### PR TITLE
MM-1049 Normalize Skill capability input contracts

### DIFF
--- a/api_service/api/routers/workflow_console.py
+++ b/api_service/api/routers/workflow_console.py
@@ -41,6 +41,7 @@ from api_service.api.routers.workflow_console_view_model import (
 from api_service.auth_providers import get_current_user
 from api_service.db.models import User
 from api_service.services.settings_catalog import settings_permissions_for_user
+from moonmind.capabilities.input_contracts import parse_skill_capability_input_contract
 from moonmind.config.settings import settings
 from moonmind.services.skill_resolution import (
     extract_required_capabilities_from_skill_markdown,
@@ -105,6 +106,16 @@ class DashboardSkillOption(BaseModel):
     """Serializable skill option exposed to dashboard clients."""
 
     id: str = Field(description="Skill identifier")
+    kind: Literal["skill"] = "skill"
+    label: str | None = None
+    description: str | None = None
+    input_schema: dict[str, object] = Field(default_factory=dict, alias="inputSchema")
+    ui_schema: dict[str, object] = Field(default_factory=dict, alias="uiSchema")
+    defaults: dict[str, object] = Field(default_factory=dict)
+    contract_digest: str | None = Field(None, alias="contractDigest")
+    content_digest: str | None = Field(None, alias="contentDigest")
+    source: dict[str, object] | None = None
+    diagnostics: list[dict[str, object]] = Field(default_factory=list)
     required_capabilities: list[str] = Field(
         default_factory=list,
         alias="requiredCapabilities",
@@ -921,6 +932,12 @@ async def list_dashboard_skills(
                 skill_file.read_text,
                 encoding="utf-8",
             )
+            contract = parse_skill_capability_input_contract(
+                skill_id=skill_id,
+                label=skill_id,
+                markdown=skill_markdown,
+                source={"kind": "local", "path": str(skill_file)},
+            )
             required_capabilities = list(
                 extract_required_capabilities_from_skill_markdown(
                     skill_markdown,
@@ -930,8 +947,38 @@ async def list_dashboard_skills(
             )
             if include_content:
                 markdown_content = skill_markdown
+        else:
+            contract = parse_skill_capability_input_contract(
+                skill_id=skill_id,
+                label=skill_id,
+                markdown="",
+                source={"kind": "configured"},
+            )
         return DashboardSkillOption(
             id=skill_id,
+            label=str(contract.get("label") or skill_id),
+            description=contract.get("description")
+            if isinstance(contract.get("description"), str)
+            else None,
+            inputSchema=contract.get("inputSchema")
+            if isinstance(contract.get("inputSchema"), dict)
+            else {},
+            uiSchema=contract.get("uiSchema")
+            if isinstance(contract.get("uiSchema"), dict)
+            else {},
+            defaults=contract.get("defaults")
+            if isinstance(contract.get("defaults"), dict)
+            else {},
+            contractDigest=contract.get("contractDigest")
+            if isinstance(contract.get("contractDigest"), str)
+            else None,
+            contentDigest=contract.get("contentDigest")
+            if isinstance(contract.get("contentDigest"), str)
+            else None,
+            source=contract.get("source") if isinstance(contract.get("source"), dict) else None,
+            diagnostics=contract.get("diagnostics")
+            if isinstance(contract.get("diagnostics"), list)
+            else [],
             requiredCapabilities=required_capabilities,
             markdown=markdown_content,
         )

--- a/api_service/services/presets/catalog.py
+++ b/api_service/services/presets/catalog.py
@@ -33,6 +33,11 @@ from api_service.db.models import (
     PresetReleaseStatus,
     PresetScopeType,
 )
+from moonmind.capabilities.input_contracts import (
+    CapabilityInputOwner,
+    capability_contract_from_legacy_inputs,
+    normalize_capability_input_contract,
+)
 from moonmind.config.settings import settings
 
 _FORBIDDEN_STEP_KEYS = frozenset(
@@ -1042,70 +1047,30 @@ def _contains_secret_like_value(value: Any) -> bool:
         return any(_contains_secret_like_value(item) for item in value)
     return bool(_SECRET_LIKE_VALUE_PATTERN.search(str(value or "")))
 
-def _legacy_input_to_json_schema(definition: Mapping[str, Any]) -> dict[str, Any]:
-    explicit_schema = definition.get("schema")
-    if isinstance(explicit_schema, Mapping):
-        return dict(explicit_schema)
-
-    input_type = str(definition.get("type") or "text").strip().lower()
-    title = str(definition.get("label") or definition.get("name") or "").strip()
-    schema: dict[str, Any]
-    if input_type == "boolean":
-        schema = {"type": "boolean"}
-    elif input_type == "enum":
-        schema = {
-            "type": "string",
-            "enum": [str(item) for item in definition.get("options") or []],
-        }
-    else:
-        schema = {"type": "string"}
-    if title:
-        schema["title"] = title
-    placeholder = str(definition.get("placeholder") or "").strip()
-    if placeholder:
-        schema["description"] = placeholder
-    return schema
-
 def _capability_contract_from_inputs(
     *,
     inputs_schema: list[dict[str, Any]],
     annotations: Mapping[str, Any] | None,
+    slug: str,
+    title: str,
+    description: str | None,
+    preset_digest: str | None,
 ) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any]]:
-    annotations = annotations or {}
-    annotated_schema = annotations.get("inputSchema") or annotations.get("input_schema")
-    annotated_ui_schema = annotations.get("uiSchema") or annotations.get("ui_schema")
-    annotated_defaults = annotations.get("defaults")
-    if isinstance(annotated_schema, Mapping):
-        return (
-            dict(annotated_schema),
-            dict(annotated_ui_schema) if isinstance(annotated_ui_schema, Mapping) else {},
-            dict(annotated_defaults) if isinstance(annotated_defaults, Mapping) else {},
-        )
-
-    properties: dict[str, Any] = {}
-    required: list[str] = []
-    ui_schema: dict[str, Any] = {}
-    defaults: dict[str, Any] = {}
-    for definition in inputs_schema:
-        name = str(definition.get("name") or "").strip()
-        if not name:
-            continue
-        properties[name] = _legacy_input_to_json_schema(definition)
-        if bool(definition.get("required", False)):
-            required.append(name)
-        default = definition.get("default")
-        if default not in (None, ""):
-            defaults[name] = default
-        field_ui_schema = definition.get("uiSchema") or definition.get("ui_schema")
-        if isinstance(field_ui_schema, Mapping):
-            ui_schema[name] = dict(field_ui_schema)
-    schema: dict[str, Any] = {
-        "type": "object",
-        "properties": properties,
-    }
-    if required:
-        schema["required"] = required
-    return schema, ui_schema, defaults
+    parts = capability_contract_from_legacy_inputs(
+        inputs_schema=inputs_schema,
+        annotations=annotations,
+    )
+    contract = normalize_capability_input_contract(
+        owner=CapabilityInputOwner(
+            id=slug,
+            kind="preset",
+            label=title,
+            description=description,
+            content_digest=preset_digest,
+        ),
+        parts=parts,
+    )
+    return contract["inputSchema"], contract["uiSchema"], contract["defaults"]
 
 def _schema_contract_input_definitions(
     *,
@@ -1186,9 +1151,14 @@ def _serialize_template(
     recent_applied_at: datetime | None,
     include_detail: bool,
 ) -> dict[str, Any]:
+    preset_digest = _preset_digest(template)
     input_schema, ui_schema, defaults = _capability_contract_from_inputs(
         inputs_schema=template.inputs_schema or [],
         annotations=template.annotations or {},
+        slug=template.slug,
+        title=template.title,
+        description=template.description,
+        preset_digest=preset_digest,
     )
     serialized = {
         "slug": template.slug,
@@ -1208,7 +1178,7 @@ def _serialize_template(
             list(template.required_capabilities or [])
         ),
         "releaseStatus": template.release_status.value,
-        "presetDigest": _preset_digest(template),
+        "presetDigest": preset_digest,
         "isFavorite": is_favorite,
         "recentAppliedAt": (
             recent_applied_at.astimezone(UTC).isoformat() if recent_applied_at else None

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -4279,6 +4279,40 @@ export interface components {
              */
             id: string;
             /**
+             * Kind
+             * @default skill
+             * @constant
+             */
+            kind: "skill";
+            /** Label */
+            label?: string | null;
+            /** Description */
+            description?: string | null;
+            /** Inputschema */
+            inputSchema?: {
+                [key: string]: unknown;
+            };
+            /** Uischema */
+            uiSchema?: {
+                [key: string]: unknown;
+            };
+            /** Defaults */
+            defaults?: {
+                [key: string]: unknown;
+            };
+            /** Contractdigest */
+            contractDigest?: string | null;
+            /** Contentdigest */
+            contentDigest?: string | null;
+            /** Source */
+            source?: {
+                [key: string]: unknown;
+            } | null;
+            /** Diagnostics */
+            diagnostics?: {
+                [key: string]: unknown;
+            }[];
+            /**
              * Requiredcapabilities
              * @description Default required capabilities declared by Skill metadata
              */

--- a/moonmind/capabilities/__init__.py
+++ b/moonmind/capabilities/__init__.py
@@ -1,2 +1,1 @@
 """Shared capability contract helpers."""
-

--- a/moonmind/capabilities/__init__.py
+++ b/moonmind/capabilities/__init__.py
@@ -1,0 +1,2 @@
+"""Shared capability contract helpers."""
+

--- a/moonmind/capabilities/input_contracts.py
+++ b/moonmind/capabilities/input_contracts.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import datetime as dt
 import hashlib
 import json
 import re
@@ -99,9 +100,9 @@ def parse_capability_input_contract(
     ui_schema = _first_mapping(metadata, "uiSchema", "ui_schema")
     defaults = _first_mapping(metadata, "defaults")
     return CapabilityInputContractParts(
-        input_schema=input_schema,
-        ui_schema=ui_schema,
-        defaults=defaults,
+        input_schema=_json_compatible_mapping(input_schema),
+        ui_schema=_json_compatible_mapping(ui_schema),
+        defaults=_json_compatible_mapping(defaults),
     )
 
 
@@ -154,9 +155,9 @@ def normalize_capability_input_contract(
     """Return a camelCase renderer-facing capability input contract."""
 
     diagnostics = [dict(item) for item in parts.diagnostics]
-    input_schema = dict(parts.input_schema) if isinstance(parts.input_schema, Mapping) else {}
-    ui_schema = dict(parts.ui_schema) if isinstance(parts.ui_schema, Mapping) else {}
-    defaults = dict(parts.defaults) if isinstance(parts.defaults, Mapping) else {}
+    input_schema = _json_compatible_mapping(parts.input_schema) or {}
+    ui_schema = _json_compatible_mapping(parts.ui_schema) or {}
+    defaults = _json_compatible_mapping(parts.defaults) or {}
 
     if input_schema:
         root_type = input_schema.get("type")
@@ -273,6 +274,23 @@ def _legacy_input_to_json_schema(definition: Mapping[str, Any]) -> dict[str, Any
     if placeholder:
         schema["description"] = placeholder
     return schema
+
+
+
+def _json_compatible_mapping(value: Mapping[str, Any] | None) -> dict[str, Any] | None:
+    if not isinstance(value, Mapping):
+        return None
+    return {str(key): _json_compatible_value(item) for key, item in value.items()}
+
+
+def _json_compatible_value(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return {str(key): _json_compatible_value(item) for key, item in value.items()}
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return [_json_compatible_value(item) for item in value]
+    if isinstance(value, (dt.date, dt.datetime, dt.time)):
+        return value.isoformat()
+    return value
 
 
 def _first_mapping(metadata: Mapping[str, Any], *keys: str) -> dict[str, Any] | None:

--- a/moonmind/capabilities/input_contracts.py
+++ b/moonmind/capabilities/input_contracts.py
@@ -310,4 +310,3 @@ def _diagnostic(
     if details:
         diagnostic["details"] = dict(details)
     return diagnostic
-

--- a/moonmind/capabilities/input_contracts.py
+++ b/moonmind/capabilities/input_contracts.py
@@ -1,0 +1,313 @@
+"""Normalize renderer-facing input contracts for MoonMind capabilities."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+import yaml
+
+CapabilityKind = Literal["tool", "skill", "preset"]
+
+PARSER_VERSION = "capability-input-contracts:v1"
+_SECRET_LIKE_VALUE_PATTERN = re.compile(
+    r"(token=|password=|bearer\s+|ghp_|github_pat_|akia[0-9a-z]{16}|aiza|atatt|-----begin [a-z ]*private key)",
+    re.IGNORECASE,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class CapabilityInputOwner:
+    """Identity and provenance for a capability input contract."""
+
+    id: str
+    kind: CapabilityKind
+    label: str
+    description: str | None = None
+    content_digest: str | None = None
+    source: Mapping[str, Any] | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class CapabilityInputContractParts:
+    """Raw schema metadata before owner fields and digests are attached."""
+
+    input_schema: Mapping[str, Any] | None = None
+    ui_schema: Mapping[str, Any] | None = None
+    defaults: Mapping[str, Any] | None = None
+    diagnostics: list[dict[str, Any]] = field(default_factory=list)
+
+
+def content_digest_for_text(content: str) -> str:
+    """Return a deterministic content digest for text."""
+
+    return "sha256:" + hashlib.sha256(content.encode("utf-8")).hexdigest()
+
+
+def parse_skill_markdown_frontmatter(content: str) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    """Parse YAML frontmatter from a SKILL.md file with a safe loader."""
+
+    if not content.startswith("---"):
+        return {}, []
+    marker = "\n---"
+    end = content.find(marker, 3)
+    if end < 0:
+        return {}, [
+            _diagnostic(
+                code="frontmatter_unclosed",
+                message="Skill frontmatter is not closed; structured metadata was ignored.",
+                severity="warning",
+                path="frontmatter",
+            )
+        ]
+    raw_frontmatter = content[3:end]
+    try:
+        parsed = yaml.safe_load(raw_frontmatter) or {}
+    except yaml.YAMLError as exc:
+        return {}, [
+            _diagnostic(
+                code="frontmatter_yaml_invalid",
+                message="Skill frontmatter YAML could not be parsed; structured metadata was ignored.",
+                severity="warning",
+                path="frontmatter",
+                details={"error": str(exc)},
+            )
+        ]
+    if not isinstance(parsed, Mapping):
+        return {}, [
+            _diagnostic(
+                code="frontmatter_not_object",
+                message="Skill frontmatter must be a YAML mapping; structured metadata was ignored.",
+                severity="warning",
+                path="frontmatter",
+            )
+        ]
+    return dict(parsed), []
+
+
+def parse_capability_input_contract(
+    raw_metadata: Mapping[str, Any] | None,
+) -> CapabilityInputContractParts:
+    """Extract schema metadata using accepted source casing."""
+
+    metadata = raw_metadata or {}
+    input_schema = _first_mapping(metadata, "inputSchema", "input_schema")
+    ui_schema = _first_mapping(metadata, "uiSchema", "ui_schema")
+    defaults = _first_mapping(metadata, "defaults")
+    return CapabilityInputContractParts(
+        input_schema=input_schema,
+        ui_schema=ui_schema,
+        defaults=defaults,
+    )
+
+
+def capability_contract_from_legacy_inputs(
+    *,
+    inputs_schema: Sequence[Mapping[str, Any]],
+    annotations: Mapping[str, Any] | None,
+) -> CapabilityInputContractParts:
+    """Build contract parts from preset annotations or legacy input rows."""
+
+    parts = parse_capability_input_contract(annotations)
+    if isinstance(parts.input_schema, Mapping):
+        return parts
+
+    properties: dict[str, Any] = {}
+    required: list[str] = []
+    ui_schema: dict[str, Any] = {}
+    defaults: dict[str, Any] = {}
+    for definition in inputs_schema:
+        name = str(definition.get("name") or "").strip()
+        if not name:
+            continue
+        properties[name] = _legacy_input_to_json_schema(definition)
+        if bool(definition.get("required", False)):
+            required.append(name)
+        default = definition.get("default")
+        if default not in (None, ""):
+            defaults[name] = default
+        field_ui_schema = definition.get("uiSchema") or definition.get("ui_schema")
+        if isinstance(field_ui_schema, Mapping):
+            ui_schema[name] = dict(field_ui_schema)
+    schema: dict[str, Any] = {
+        "type": "object",
+        "properties": properties,
+    }
+    if required:
+        schema["required"] = required
+    return CapabilityInputContractParts(
+        input_schema=schema,
+        ui_schema=ui_schema,
+        defaults=defaults,
+    )
+
+
+def normalize_capability_input_contract(
+    *,
+    owner: CapabilityInputOwner,
+    parts: CapabilityInputContractParts,
+) -> dict[str, Any]:
+    """Return a camelCase renderer-facing capability input contract."""
+
+    diagnostics = [dict(item) for item in parts.diagnostics]
+    input_schema = dict(parts.input_schema) if isinstance(parts.input_schema, Mapping) else {}
+    ui_schema = dict(parts.ui_schema) if isinstance(parts.ui_schema, Mapping) else {}
+    defaults = dict(parts.defaults) if isinstance(parts.defaults, Mapping) else {}
+
+    if input_schema:
+        root_type = input_schema.get("type")
+        if root_type != "object" or not isinstance(input_schema.get("properties", {}), Mapping):
+            diagnostics.append(
+                _diagnostic(
+                    code="input_schema_root_not_object",
+                    message=(
+                        "Capability inputSchema must be a root object schema; "
+                        "generated fields were omitted."
+                    ),
+                    severity="warning",
+                    path="inputSchema",
+                )
+            )
+            input_schema = {}
+
+    if _contains_secret_like_value(defaults):
+        diagnostics.append(
+            _diagnostic(
+                code="defaults_secret_like_value",
+                message="Capability defaults contained a secret-like value and were omitted.",
+                severity="warning",
+                path="defaults",
+            )
+        )
+        defaults = {}
+
+    digest_payload = {
+        "parserVersion": PARSER_VERSION,
+        "owner": {"id": owner.id, "kind": owner.kind},
+        "contentDigest": owner.content_digest,
+        "inputSchema": input_schema,
+        "uiSchema": ui_schema,
+        "defaults": defaults,
+    }
+    contract_digest = "sha256:" + hashlib.sha256(
+        json.dumps(digest_payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+
+    contract: dict[str, Any] = {
+        "id": owner.id,
+        "kind": owner.kind,
+        "label": owner.label,
+        "inputSchema": input_schema,
+        "uiSchema": ui_schema,
+        "defaults": defaults,
+        "contractDigest": contract_digest,
+        "diagnostics": diagnostics,
+    }
+    if owner.description:
+        contract["description"] = owner.description
+    if owner.content_digest:
+        contract["contentDigest"] = owner.content_digest
+    if owner.source:
+        contract["source"] = dict(owner.source)
+    return contract
+
+
+def parse_skill_capability_input_contract(
+    *,
+    skill_id: str,
+    label: str,
+    markdown: str,
+    source: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Parse SKILL.md frontmatter into a normalized kind=skill contract."""
+
+    frontmatter, diagnostics = parse_skill_markdown_frontmatter(markdown)
+    description = str(frontmatter.get("description") or "").strip() or None
+    parts = parse_capability_input_contract(frontmatter)
+    parts = CapabilityInputContractParts(
+        input_schema=parts.input_schema,
+        ui_schema=parts.ui_schema,
+        defaults=parts.defaults,
+        diagnostics=[*diagnostics, *parts.diagnostics],
+    )
+    content_digest = content_digest_for_text(markdown)
+    return normalize_capability_input_contract(
+        owner=CapabilityInputOwner(
+            id=skill_id,
+            kind="skill",
+            label=str(frontmatter.get("name") or label or skill_id).strip() or skill_id,
+            description=description,
+            content_digest=content_digest,
+            source={
+                **dict(source or {}),
+                "contentDigest": content_digest,
+            },
+        ),
+        parts=parts,
+    )
+
+
+def _legacy_input_to_json_schema(definition: Mapping[str, Any]) -> dict[str, Any]:
+    explicit_schema = definition.get("schema")
+    if isinstance(explicit_schema, Mapping):
+        return dict(explicit_schema)
+
+    input_type = str(definition.get("type") or "text").strip().lower()
+    title = str(definition.get("label") or definition.get("name") or "").strip()
+    if input_type == "boolean":
+        schema: dict[str, Any] = {"type": "boolean"}
+    elif input_type == "enum":
+        schema = {
+            "type": "string",
+            "enum": [str(item) for item in definition.get("options") or []],
+        }
+    else:
+        schema = {"type": "string"}
+    if title:
+        schema["title"] = title
+    placeholder = str(definition.get("placeholder") or "").strip()
+    if placeholder:
+        schema["description"] = placeholder
+    return schema
+
+
+def _first_mapping(metadata: Mapping[str, Any], *keys: str) -> dict[str, Any] | None:
+    for key in keys:
+        value = metadata.get(key)
+        if isinstance(value, Mapping):
+            return dict(value)
+    return None
+
+
+def _contains_secret_like_value(value: Any) -> bool:
+    if value is None:
+        return False
+    if isinstance(value, Mapping):
+        return any(_contains_secret_like_value(item) for item in value.values())
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return any(_contains_secret_like_value(item) for item in value)
+    return bool(_SECRET_LIKE_VALUE_PATTERN.search(str(value or "")))
+
+
+def _diagnostic(
+    *,
+    code: str,
+    message: str,
+    severity: str,
+    path: str,
+    details: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    diagnostic: dict[str, Any] = {
+        "code": code,
+        "message": message,
+        "severity": severity,
+        "path": path,
+    }
+    if details:
+        diagnostic["details"] = dict(details)
+    return diagnostic
+

--- a/tests/unit/api/routers/test_workflow_console.py
+++ b/tests/unit/api/routers/test_workflow_console.py
@@ -601,15 +601,19 @@ def test_skills_api_returns_available_skill_ids(
     response = client.get("/api/workflows/skills")
 
     assert response.status_code == 200
-    assert response.json() == {
-        "items": {
-            "worker": ["speckit", "speckit-orchestrate"],
-        },
-        "legacyItems": [
-            {"id": "speckit", "requiredCapabilities": [], "markdown": None},
-            {"id": "speckit-orchestrate", "requiredCapabilities": [], "markdown": None},
-        ],
-    }
+    payload = response.json()
+    assert payload["items"] == {"worker": ["speckit", "speckit-orchestrate"]}
+    assert [item["id"] for item in payload["legacyItems"]] == [
+        "speckit",
+        "speckit-orchestrate",
+    ]
+    assert payload["legacyItems"][0]["kind"] == "skill"
+    assert payload["legacyItems"][0]["inputSchema"] == {}
+    assert payload["legacyItems"][0]["uiSchema"] == {}
+    assert payload["legacyItems"][0]["defaults"] == {}
+    assert payload["legacyItems"][0]["requiredCapabilities"] == []
+    assert payload["legacyItems"][0]["markdown"] is None
+    assert payload["legacyItems"][0]["contractDigest"].startswith("sha256:")
 
 def test_skills_api_include_content_reads_legacy_skill_markdown(
     client: TestClient, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -645,13 +649,75 @@ def test_skills_api_include_content_reads_legacy_skill_markdown(
     response = client.get("/api/workflows/skills?includeContent=true")
 
     assert response.status_code == 200
-    assert response.json()["legacyItems"] == [
-        {
-            "id": "speckit-orchestrate",
-            "requiredCapabilities": ["git"],
-            "markdown": skill_markdown,
-        },
-    ]
+    item = response.json()["legacyItems"][0]
+    assert item["id"] == "speckit-orchestrate"
+    assert item["kind"] == "skill"
+    assert item["requiredCapabilities"] == ["git"]
+    assert item["markdown"] == skill_markdown
+    assert item["inputSchema"] == {}
+    assert item["uiSchema"] == {}
+    assert item["defaults"] == {}
+    assert item["contentDigest"].startswith("sha256:")
+    assert item["source"]["kind"] == "local"
+
+
+def test_skills_api_parses_skill_input_contract(
+    client: TestClient, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    local_root = tmp_path / "local"
+    legacy_root = tmp_path / "legacy"
+    skill_dir = legacy_root / "jira-implement"
+    skill_dir.mkdir(parents=True)
+    skill_markdown = (
+        "---\n"
+        "name: Jira Implement\n"
+        "description: Implement a Jira issue.\n"
+        "input_schema:\n"
+        "  type: object\n"
+        "  required:\n"
+        "    - issue_key\n"
+        "  properties:\n"
+        "    issue_key:\n"
+        "      type: string\n"
+        "      title: Issue key\n"
+        "ui_schema:\n"
+        "  issue_key:\n"
+        "    widget: jira.issue-picker\n"
+        "defaults:\n"
+        "  issue_key: MM-1047\n"
+        "---\n"
+        "# Jira Implement\n"
+    )
+    (skill_dir / "SKILL.md").write_text(skill_markdown, encoding="utf-8")
+
+    monkeypatch.setattr(
+        "api_service.api.routers.workflow_console.settings.workflow.skills_local_mirror_root",
+        str(local_root),
+    )
+    monkeypatch.setattr(
+        "api_service.api.routers.workflow_console.settings.workflow.skills_legacy_mirror_root",
+        str(legacy_root),
+    )
+    monkeypatch.setattr(
+        "api_service.api.routers.workflow_console.list_available_skill_names",
+        lambda: ("jira-implement",),
+    )
+
+    response = client.get("/api/workflows/skills")
+
+    assert response.status_code == 200
+    item = response.json()["legacyItems"][0]
+    assert item["id"] == "jira-implement"
+    assert item["kind"] == "skill"
+    assert item["label"] == "Jira Implement"
+    assert item["description"] == "Implement a Jira issue."
+    assert item["inputSchema"]["required"] == ["issue_key"]
+    assert item["uiSchema"]["issue_key"]["widget"] == "jira.issue-picker"
+    assert item["defaults"] == {"issue_key": "MM-1047"}
+    assert item["contractDigest"].startswith("sha256:")
+    assert item["contentDigest"].startswith("sha256:")
+    assert item["source"]["contentDigest"] == item["contentDigest"]
+    assert item["diagnostics"] == []
 
 def test_create_dashboard_skill_success(
     client: TestClient, tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/unit/capabilities/test_input_contracts.py
+++ b/tests/unit/capabilities/test_input_contracts.py
@@ -1,3 +1,5 @@
+import datetime as dt
+
 from moonmind.capabilities.input_contracts import (
     CapabilityInputOwner,
     capability_contract_from_legacy_inputs,
@@ -65,6 +67,33 @@ def test_non_object_skill_schema_is_diagnosed_without_invalidating_skill() -> No
     assert contract["diagnostics"][0]["code"] == "input_schema_root_not_object"
 
 
+def test_skill_frontmatter_yaml_dates_are_json_compatible() -> None:
+    markdown = (
+        "---\n"
+        "name: Demo Skill\n"
+        "inputSchema:\n"
+        "  type: object\n"
+        "  properties:\n"
+        "    due_date:\n"
+        "      type: string\n"
+        "      default: 2026-06-30\n"
+        "defaults:\n"
+        "  due_date: 2026-06-30\n"
+        "---\n"
+        "# Demo\n"
+    )
+
+    contract = parse_skill_capability_input_contract(
+        skill_id="demo-skill",
+        label="Demo Skill",
+        markdown=markdown,
+    )
+
+    assert contract["inputSchema"]["properties"]["due_date"]["default"] == "2026-06-30"
+    assert contract["defaults"] == {"due_date": "2026-06-30"}
+    assert contract["contractDigest"].startswith("sha256:")
+
+
 def test_equivalent_skill_and_preset_schemas_share_renderer_fields() -> None:
     schema = {
         "type": "object",
@@ -120,3 +149,32 @@ def test_equivalent_skill_and_preset_schemas_share_renderer_fields() -> None:
 
     for field in ("inputSchema", "uiSchema", "defaults"):
         assert skill[field] == preset[field]
+
+
+def test_preset_contract_dates_are_json_compatible() -> None:
+    contract = normalize_capability_input_contract(
+        owner=CapabilityInputOwner(
+            id="demo-preset",
+            kind="preset",
+            label="Demo Preset",
+        ),
+        parts=capability_contract_from_legacy_inputs(
+            inputs_schema=[],
+            annotations={
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "due_date": {
+                            "type": "string",
+                            "default": dt.date(2026, 6, 30),
+                        }
+                    },
+                },
+                "defaults": {"due_date": dt.date(2026, 6, 30)},
+            },
+        ),
+    )
+
+    assert contract["inputSchema"]["properties"]["due_date"]["default"] == "2026-06-30"
+    assert contract["defaults"] == {"due_date": "2026-06-30"}
+    assert contract["contractDigest"].startswith("sha256:")

--- a/tests/unit/capabilities/test_input_contracts.py
+++ b/tests/unit/capabilities/test_input_contracts.py
@@ -1,0 +1,122 @@
+from moonmind.capabilities.input_contracts import (
+    CapabilityInputOwner,
+    capability_contract_from_legacy_inputs,
+    normalize_capability_input_contract,
+    parse_skill_capability_input_contract,
+)
+
+
+def test_skill_frontmatter_snake_case_normalizes_to_camel_case_contract() -> None:
+    markdown = (
+        "---\n"
+        "name: Demo Skill\n"
+        "description: Collect a target.\n"
+        "input_schema:\n"
+        "  type: object\n"
+        "  required:\n"
+        "    - target\n"
+        "  properties:\n"
+        "    target:\n"
+        "      type: string\n"
+        "      title: Target\n"
+        "ui_schema:\n"
+        "  target:\n"
+        "    widget: textarea\n"
+        "defaults:\n"
+        "  target: MM-1047\n"
+        "---\n"
+        "# Demo\n"
+    )
+
+    contract = parse_skill_capability_input_contract(
+        skill_id="demo-skill",
+        label="Demo Skill",
+        markdown=markdown,
+        source={"kind": "test"},
+    )
+
+    assert contract["kind"] == "skill"
+    assert contract["inputSchema"]["required"] == ["target"]
+    assert contract["uiSchema"] == {"target": {"widget": "textarea"}}
+    assert contract["defaults"] == {"target": "MM-1047"}
+    assert contract["contractDigest"].startswith("sha256:")
+    assert contract["contentDigest"].startswith("sha256:")
+    assert contract["diagnostics"] == []
+
+
+def test_non_object_skill_schema_is_diagnosed_without_invalidating_skill() -> None:
+    markdown = (
+        "---\n"
+        "name: Demo Skill\n"
+        "inputSchema:\n"
+        "  type: string\n"
+        "---\n"
+        "# Demo\n"
+    )
+
+    contract = parse_skill_capability_input_contract(
+        skill_id="demo-skill",
+        label="Demo Skill",
+        markdown=markdown,
+    )
+
+    assert contract["kind"] == "skill"
+    assert contract["inputSchema"] == {}
+    assert contract["diagnostics"][0]["code"] == "input_schema_root_not_object"
+
+
+def test_equivalent_skill_and_preset_schemas_share_renderer_fields() -> None:
+    schema = {
+        "type": "object",
+        "required": ["target"],
+        "properties": {
+            "target": {
+                "type": "string",
+                "title": "Target",
+                "x-moonmind-context-default": "issue",
+            }
+        },
+    }
+    ui_schema = {"target": {"widget": "jira.issue-picker"}}
+    defaults = {"target": "MM-1047"}
+    skill = parse_skill_capability_input_contract(
+        skill_id="demo-skill",
+        label="Demo Skill",
+        markdown=(
+            "---\n"
+            "name: Demo Skill\n"
+            "inputSchema:\n"
+            "  type: object\n"
+            "  required: [target]\n"
+            "  properties:\n"
+            "    target:\n"
+            "      type: string\n"
+            "      title: Target\n"
+            "      x-moonmind-context-default: issue\n"
+            "uiSchema:\n"
+            "  target:\n"
+            "    widget: jira.issue-picker\n"
+            "defaults:\n"
+            "  target: MM-1047\n"
+            "---\n"
+            "# Demo\n"
+        ),
+    )
+    preset = normalize_capability_input_contract(
+        owner=CapabilityInputOwner(
+            id="demo-preset",
+            kind="preset",
+            label="Demo Preset",
+        ),
+        parts=capability_contract_from_legacy_inputs(
+            inputs_schema=[],
+            annotations={
+                "inputSchema": schema,
+                "uiSchema": ui_schema,
+                "defaults": defaults,
+            },
+        ),
+    )
+
+    for field in ("inputSchema", "uiSchema", "defaults"):
+        assert skill[field] == preset[field]


### PR DESCRIPTION
Issue reference: MM-1049

Summary:
- Added a shared capability input contract parser/normalizer for preset and Skill schema metadata.
- Normalized Skill frontmatter `inputSchema`/`input_schema`, `uiSchema`/`ui_schema`, defaults, source evidence, digests, and diagnostics into camelCase API fields.
- Updated workflow console Skill catalog responses and preset catalog normalization to use the shared contract path.
- Added unit coverage for Skill/Preset renderer-facing equivalence, non-object schema diagnostics, schema-less Skills, and alternate source casing.

Tests run:
- `git diff --check origin/main..HEAD && git diff --check`
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/capabilities/test_input_contracts.py tests/unit/api/routers/test_workflow_console.py -q` passed: 58 Python tests; dashboard Vitest suite 43 files, 705 tests passed, 237 skipped.

Remaining risks:
- Hermetic integration tests were not run because this change does not touch Docker, compose, database migrations, Temporal workflow/activity signatures, runtime infrastructure, or an integration_ci-selected boundary.
