### PR TITLE
[codex] clarify Omnigent adapter and Temporal Search Attribute posture

### DIFF
--- a/docs/Omnigent/OmnigentAdapter.md
+++ b/docs/Omnigent/OmnigentAdapter.md
@@ -2,7 +2,7 @@
 
 Status: Proposed design
 Owners: MoonMind Platform
-Last updated: 2026-06-27
+Last updated: 2026-06-30
 
 **Implementation tracking:** rollout notes, spikes, and temporary handoffs should live under `docs/tmp/` or gitignored local-only artifacts, not as mutable checklists in this canonical design document.
 
@@ -14,14 +14,18 @@ Last updated: 2026-06-27
 - `docs/Temporal/WorkflowArtifactSystemDesign.md`
 - `docs/Temporal/ActivityCatalogAndWorkerTopology.md`
 - `docs/Temporal/ErrorTaxonomy.md`
+- `docs/Temporal/VisibilityAndUiQueryModel.md`
 - `docs/MoonMindArchitecture.md`
 - Omnigent upstream API reference: `omnigent/server/API.md` in `omnigent-ai/omnigent`
+- Omnigent upstream session schema: `omnigent/server/schemas.py` in `omnigent-ai/omnigent`
 
 ---
 
 ## 1. Purpose
 
-This document defines a declarative design for integrating **Omnigent** as an execution substrate inside MoonMind.
+This document defines the architecture for integrating **Omnigent** as an execution substrate inside MoonMind.
+
+Omnigent is a meta-harness and session server over coding and agent harnesses such as Claude Code, Codex, Cursor, OpenCode, Hermes, Pi, and custom YAML agents. Its primary runtime unit is a **session/conversation** with live streams, resources, files, host/runner binding, and optional managed sandboxes.
 
 In the target topology, MoonMind does not launch Claude Code, Codex CLI, or other Omnigent-supported harnesses directly. Instead:
 
@@ -30,7 +34,7 @@ MoonMind Temporal Workflow / AgentRun
   -> MoonMind Omnigent adapter
       -> Omnigent server API
           -> Omnigent session
-              -> omnigent-host container / sandbox / runner
+              -> Omnigent host / sandbox / runner
                   -> Claude Code, Codex, Polly, or another Omnigent harness/agent
 ```
 
@@ -42,13 +46,18 @@ The adapter must preserve MoonMind's core architecture:
 - Provider-specific details stay at the adapter/activity boundary.
 - Workflow code receives only canonical MoonMind runtime contracts.
 
+This document is intentionally written with two goals in mind:
+
+1. **Minimal goal:** support a robust v1 `OmnigentAdapter` without destabilizing MoonMind's Temporal execution model.
+2. **Stretch goal:** keep future decisions compatible with a less painful merger or deeper integration between Omnigent Server and the MoonMind API.
+
 ---
 
-## 2. Decision summary
+## 2. Architectural decision summary
 
 ### 2.1 Treat Omnigent as an external provider in v1
 
-The v1 adapter should use the **external-agent adapter pattern**, not the managed-runtime adapter pattern.
+The v1 adapter uses the **external-agent adapter pattern**, not the managed-runtime adapter pattern.
 
 Reasoning:
 
@@ -57,24 +66,35 @@ Reasoning:
 - MoonMind is delegating a run to an Omnigent server, which then provisions or uses an Omnigent host/runner.
 - Omnigent's primary unit is a long-running session/conversation, not a MoonMind-managed runtime process.
 
-Therefore the v1 provider must register as a single canonical provider identity:
+Therefore the v1 provider registers as a single canonical provider identity:
 
 ```text
 agentKind = external
 agentId   = omnigent
 ```
 
-Runtime selection, session mode, harness choice, Claude-vs-Codex choice, and built-in Omnigent agent selection must be declared in `parameters.omnigent`, not by changing the top-level MoonMind `agentId`.
+Runtime selection, session mode, harness choice, Claude-vs-Codex choice, built-in Omnigent agent selection, model overrides, reasoning effort, and capture policy live under `parameters.omnigent`, not by changing the top-level MoonMind `agentId`.
+
+Do **not** register provider-specific top-level aliases such as:
+
+```text
+omnigent_session
+omnigent_claude
+omnigent_codex
+omnigent_polly
+```
+
+Those values would split routing, policy, metrics, tests, and provider identity.
 
 ### 2.2 Use streaming-gateway execution first
 
-The recommended v1 activity shape is:
+The v1 activity shape is:
 
 ```text
 integration.omnigent.execute
 ```
 
-This mirrors the existing streaming-gateway external-provider pattern. The activity performs the entire Omnigent session execution and returns a terminal canonical `AgentRunResult`, or raises an activity error. It does not return non-terminal provider states in v1.
+This mirrors the existing streaming-gateway external-provider pattern. The activity performs the entire Omnigent session execution and returns a terminal canonical `AgentRunResult`, or raises an activity error. It does **not** return non-terminal provider states in v1.
 
 The polling/session lifecycle may be added later as v2:
 
@@ -83,27 +103,67 @@ integration.omnigent.start
 integration.omnigent.status
 integration.omnigent.fetch_result
 integration.omnigent.cancel
-integration.omnigent.send_message       # optional extension
-integration.omnigent.harvest_session    # optional extension
+integration.omnigent.send_message
+integration.omnigent.harvest_session
 ```
 
 ### 2.3 MoonMind remains the artifact authority
 
-Omnigent's files panel and session resources are observable surfaces, not the authoritative MoonMind artifact system.
+Omnigent's files panel, session resources, snapshots, and stream surfaces are observable provider resources, not the authoritative MoonMind artifact system.
 
-The adapter must copy observable Omnigent inputs, outputs, streams, snapshots, changed-file manifests, current file contents, and session file resources into MoonMind artifacts and return compact refs in `AgentRunResult`.
+The adapter must copy observable Omnigent inputs, outputs, streams, snapshots, changed-file manifests, current file contents, optional diff content, session file resources, and diagnostics into MoonMind artifacts and return compact refs in `AgentRunResult`.
+
+Omnigent resource URLs, session ids, file ids, and runner ids may appear in diagnostics metadata and provider-specific mapping tables, but they must not replace MoonMind `ArtifactRef`s in workflow evidence.
 
 ### 2.4 Durability boundary in v1
 
-The streaming-gateway model runs the entire Omnigent session inside a single `integration.omnigent.execute` activity. Temporal's durability is at the activity boundary, so v1 does **not** provide Temporal-checkpointed progress *within* a run: if the MoonMind worker dies mid-session, Temporal retries the activity from the top.
+The streaming-gateway model runs the entire Omnigent session inside one `integration.omnigent.execute` activity. Temporal's durability is at the activity boundary, so v1 does **not** provide Temporal-checkpointed progress within a single Omnigent turn.
 
-The honest v1 guarantee is therefore:
+The honest v1 guarantee is:
 
 - **Omnigent owns live-execution durability.** The Omnigent session and its runner-side workspace survive MoonMind worker death when the Omnigent server/host keeps them alive.
-- **Temporal durably records delegation and result.** Temporal durably remembers that the run was delegated to Omnigent and what the final canonical result was, and re-attaches on retry (§9.5, §10, §12.5).
+- **Temporal durably records delegation and result.** Temporal remembers that the run was delegated to Omnigent and records the final canonical result.
 - **Retry re-attaches, it does not recreate.** A retry reconnects to the existing Omnigent session rather than provisioning a second host or reposting the first message.
 
-Out of scope for v1: durable checkpointing of intra-run progress, status-bearing streaming results consumed by `MoonMind.AgentRun`, and Omnigent session continuity across MoonMind steps (a v2 concern — §21). "MoonMind with or without Temporal" is a separate architectural track, not part of this adapter contract.
+Out of scope for v1:
+
+- durable Temporal checkpointing of intra-session Omnigent progress;
+- status-bearing streaming results consumed by `MoonMind.AgentRun`;
+- long-lived Omnigent session reuse across multiple MoonMind steps;
+- making Omnigent a second MoonMind workflow engine;
+- merging MoonMind API and Omnigent Server persistence.
+
+### 2.5 Future merger posture
+
+A future MoonMind API / Omnigent Server merger should be prepared through **interface alignment**, not premature state-model fusion.
+
+Convergence-friendly boundaries:
+
+```text
+MoonMind Workflow / AgentRun / ArtifactRef
+  <-> Omnigent Session / Agent / Stream / Resources
+```
+
+Avoid designs that assume either system must subsume the other's state model. In particular:
+
+- Do not make Omnigent session ids be MoonMind workflow ids.
+- Do not force Omnigent sessions into MoonMind's Temporal lifecycle states.
+- Do not expose raw Omnigent session statuses as MoonMind workflow states.
+- Do not store Omnigent runtime credentials in MoonMind workflow payloads.
+- Do not make Omnigent's artifact store authoritative for MoonMind evidence.
+- Do not add Omnigent-specific Temporal Search Attributes unless a generic cross-provider dimension truly needs indexing.
+
+Prefer stable cross-references:
+
+```text
+MoonMind workflow id
+MoonMind agent run id
+MoonMind step execution id
+Omnigent endpoint ref
+Omnigent session id
+Omnigent agent id/name
+MoonMind artifact refs for copied evidence
+```
 
 ---
 
@@ -111,36 +171,21 @@ Out of scope for v1: durable checkpointing of intra-run progress, status-bearing
 
 | MoonMind concept | Omnigent analogue | Adapter rule |
 |---|---|---|
-| Workflow Execution | No direct equivalent | MoonMind remains orchestration envelope. |
-| `MoonMind.AgentRun` | Omnigent session execution | One AgentRun may own one Omnigent session. |
+| Workflow Execution | No direct equivalent | MoonMind remains the orchestration envelope. |
+| `MoonMind.AgentRun` | Omnigent session execution | One AgentRun may own one Omnigent session in v1. |
 | Workflow step | Session message/turn or whole session | v1 maps one step to one execute activity. |
-| Managed runtime profile | Omnigent server/agent/session target | Use endpoint/agent selectors, not raw credentials. |
+| Managed runtime profile | Omnigent endpoint/agent/session target | Use endpoint/agent selectors, not raw credentials. |
 | ArtifactRef | Omnigent snapshot/resource/file data copied into MoonMind | Never return Omnigent raw resources as top-level result. |
 | Cancel workflow/step | `interrupt`, then `stop_session` | Do not delete before harvesting artifacts. |
 | Result | Final snapshot + transcript + resource harvest | Return `AgentRunResult` with artifact refs. |
+| Intervention/approval | Omnigent elicitation resolution | Normalize to MoonMind intervention semantics; do not leak raw provider state. |
+| Session stream | Live-tail SSE | Mirror into MoonMind artifacts; do not rely on stream replay. |
 
 ---
 
-## 4. Non-goals
+## 4. Provider identity and registration
 
-The v1 adapter does not attempt to:
-
-- replace MoonMind's direct Claude Code or Codex managed runtimes;
-- expose Omnigent as a second workflow engine;
-- store raw Omnigent server credentials in workflow payloads;
-- make Omnigent's internal `ArtifactStore` the MoonMind artifact system;
-- automatically capture native runtime private state not exposed by Omnigent APIs;
-- guarantee perfect replay of transient Omnigent SSE events after the stream is disconnected;
-- implement multi-step, long-lived Omnigent session reuse across MoonMind steps in v1;
-- introduce provider-specific top-level MoonMind agent-id aliases such as `omnigent_session`, `omnigent_claude`, or `omnigent_codex`;
-- assume Omnigent exposes a stable public diff endpoint when the upstream OpenAPI does not advertise one;
-- return non-terminal states from `integration.omnigent.execute` unless `MoonMind.AgentRun` is changed to consume status-bearing streaming results.
-
----
-
-## 5. Provider identity and registration
-
-### 5.1 Runtime gate
+### 4.1 Runtime gate
 
 Add a small runtime gate:
 
@@ -168,7 +213,7 @@ OMNIGENT_STREAM_HEARTBEAT_TIMEOUT_SECONDS=120
 
 Security rule: `OMNIGENT_API_TOKEN` is resolved only at the activity boundary. It must not appear in Temporal workflow payloads, request metadata, artifacts, logs, or diagnostics.
 
-### 5.2 External registry
+### 4.2 External registry
 
 Register the adapter only when the runtime gate is enabled.
 
@@ -177,17 +222,6 @@ Canonical registration:
 ```text
 omnigent
 ```
-
-Do not register a second top-level `agentId` for the same provider. In particular, do not register:
-
-```text
-omnigent_session
-omnigent_claude
-omnigent_codex
-omnigent_polly
-```
-
-Those values would split routing, policy, metrics, tests, and provider identity. Session mode, runtime selection, built-in agent choice, and harness overrides belong under `parameters.omnigent`.
 
 The top-level `AgentExecutionRequest` remains:
 
@@ -198,15 +232,11 @@ The top-level `AgentExecutionRequest` remains:
 }
 ```
 
----
-
-## 6. Adapter classification
-
-### 6.1 Base class
+### 4.3 Base class
 
 The provider adapter should extend `BaseExternalAgentAdapter`.
 
-The class exists primarily for registry/capability declaration in v1. The actual execution should happen in `integration.omnigent.execute`, following the streaming-gateway model.
+The class exists primarily for registry/capability declaration in v1. The actual execution happens in `integration.omnigent.execute`, following the streaming-gateway model.
 
 ```text
 moonmind/workflows/adapters/omnigent_agent_adapter.py
@@ -236,13 +266,7 @@ do_cancel       -> unused, raise RuntimeError
 
 Cancellation for v1 is handled by cancellation of the execute activity, which then sends Omnigent `interrupt` / `stop_session` best-effort signals.
 
-These capability values match the only existing streaming-gateway provider, OpenClaw:
-
-- `supportsCancel=False` — in streaming mode, cancellation is delivered by Temporal activity cancellation, not a `do_cancel` hook.
-- `defaultPollHintSeconds=15` — unused in streaming mode, but kept equal to the other providers rather than introducing a bespoke value.
-- `executionStyle` uses the canonical serialized alias used by other external-provider snippets.
-
-### 6.2 Why not `ManagedAgentAdapter`
+### 4.4 Why not `ManagedAgentAdapter`
 
 `ManagedAgentAdapter` is reserved for MoonMind-owned managed runtimes where MoonMind resolves provider profiles, obtains profile leases, shapes credentials/env/files, and launches runtime activities.
 
@@ -250,13 +274,13 @@ The Omnigent topology delegates those responsibilities to Omnigent server and `o
 
 A future v2 may add an `OmnigentManagedBridgeAdapter` only if MoonMind directly provisions Omnigent hosts and controls their lifecycle as MoonMind managed workloads.
 
-Host packaging — whether `omnigent-host` runs containers via docker-in-docker, and whether MoonMind co-locates the Omnigent server/host in its own compose — is a compose/host-image concern tracked outside this adapter contract. If MoonMind ends up provisioning and controlling the host lifecycle, the ownership boundary shifts toward "managed," which is exactly the trigger for the reserved `OmnigentManagedBridgeAdapter`.
+Host packaging — whether `omnigent-host` runs containers via docker-in-docker, and whether MoonMind co-locates the Omnigent server/host in its own compose — is a compose/host-image concern tracked outside this adapter contract.
 
 ---
 
-## 7. Declarative request contract
+## 5. Declarative request contract
 
-### 7.1 Top-level request
+### 5.1 Top-level request
 
 The adapter consumes the existing canonical `AgentExecutionRequest`.
 
@@ -276,7 +300,7 @@ Required fields:
 }
 ```
 
-### 7.2 Omnigent target block
+### 5.2 Omnigent target block
 
 All Omnigent-specific execution selection lives under `parameters.omnigent`.
 
@@ -317,9 +341,10 @@ All Omnigent-specific execution selection lives under `parameters.omnigent`.
         "snapshots": true,
         "changedFiles": true,
         "workspaceFiles": true,
+        "workspaceDiffs": "capability_probe",
         "sessionFiles": true,
         "githubPr": true,
-        "patchSource": "github_pr_or_host_helper",
+        "patchSource": "omnigent_diff_or_github_pr_or_host_helper",
         "deleteOmnigentSessionAfterHarvest": false
       }
     }
@@ -327,7 +352,7 @@ All Omnigent-specific execution selection lives under `parameters.omnigent`.
 }
 ```
 
-### 7.3 Field meanings
+### 5.3 Field meanings
 
 | Field | Meaning | Notes |
 |---|---|---|
@@ -339,27 +364,43 @@ All Omnigent-specific execution selection lives under `parameters.omnigent`.
 | `session.hostType` | `managed` or `external` | `managed` means Omnigent provisions host/sandbox. |
 | `session.hostId` | Omnigent external host id | Must be absent/null for `managed`; required for external-host launch flows that need a host-bound runner. |
 | `session.workspace` | Omnigent workspace selector | For managed sessions, optional git repository URL with optional `#branch`; for external hosts, absolute path on that host. |
-| `workspaceContext` | Additional prompt/artifact metadata | May mirror repository context, but it is not a checkout mechanism; repo work must use `session.workspace` for managed sessions. |
+| `workspaceContext` | Additional prompt/artifact metadata | May mirror repository context, but it is not a checkout mechanism. |
 | `session.terminalLaunchArgs` | Native Claude/Codex launch flags | Must be bounded and non-secret. |
 | `prompt.text` | Inline prompt | Prefer artifact-backed prompt for large inputs. |
 | `prompt.instructionRef` | MoonMind artifact ref with prompt/instructions | Activity reads artifact and posts text. |
 | `prompt.includeIdempotencyMarker` | Whether to include a compact non-secret retry marker in the first message | Defaults to true for retry reconciliation. |
-| `capture.patchSource` | Where patch artifacts may come from | `github_pr_or_host_helper` in v1; do not call an undocumented Omnigent diff route. |
+| `capture.patchSource` | Where patch artifacts may come from | Capability-probed Omnigent diff, GitHub PR harvesting, or host helper. |
 | `capture.*` | Artifact capture policy | Controls MoonMind harvesting, not Omnigent storage. |
 
-### 7.4 Managed vs external session validation
+### 5.4 Managed vs external session validation
 
 The adapter must validate the session target before calling Omnigent.
 
 Rules:
 
-- For `hostType="managed"`, omit `host_id` but preserve a repository checkout by sending `workspace` when it is a git repository URL, optionally with `#<branch>`.
-- For `hostType="managed"`, `session.hostId` must be null or absent. `session.workspace` must be either null or a git repository URL. Local/absolute host paths are invalid because the sandbox does not exist before Omnigent provisions it.
+- For `hostType="managed"`, omit `hostId`.
+- For `hostType="managed"`, `session.workspace` may be omitted or set to a git repository URL, optionally with `#<branch>`.
+- For `hostType="managed"`, local/absolute host paths are invalid because the sandbox does not exist before Omnigent provisions it.
 - For managed repository tasks, `workspaceSpec.repository`, `workspaceContext.repository`, or equivalent workflow repository input must be normalized into `session.workspace` before session creation. Keeping it only as prompt/artifact context creates an empty sandbox and is not sufficient for code-editing tasks.
 - If `hostType="managed"` and no repository URL is available, Omnigent creates an empty server workspace. The adapter should allow that only for non-repository tasks or when the request explicitly opts into an empty workspace.
-- For `hostType="external"`, `hostId` and `workspace` are allowed and `workspace` must be an absolute path on that external Omnigent host. Repository URLs belong to managed session creation, not external-host launch.
+- For `hostType="external"`, `hostId` and `workspace` are allowed, and `workspace` must be an absolute path on that external Omnigent host.
+- For `hostType="external"`, repository URLs are invalid; repository URLs belong to managed session creation.
 
-### 7.5 Target resolution order
+### 5.5 Upstream compatibility note: managed `workspace`
+
+As of the 2026-06-30 upstream review, current Omnigent schema behavior allows `host_type="managed"` with a repository-URL `workspace`, and rejects `host_id` for managed sessions. Some upstream prose may still describe an older managed-session rule where `workspace` must not be set. MoonMind's adapter should follow the current schema/implementation contract:
+
+```text
+managed + workspace=https://github.com/org/repo#branch  -> valid
+managed + workspace=/local/path                         -> invalid
+managed + host_id=host_...                              -> invalid
+external + workspace=/absolute/path                     -> valid
+external + workspace=https://github.com/org/repo        -> invalid
+```
+
+If upstream changes again, update this document before changing adapter behavior.
+
+### 5.6 Target resolution order
 
 The activity resolves the Omnigent agent target in this order:
 
@@ -371,7 +412,7 @@ The activity resolves the Omnigent agent target in this order:
 
 ---
 
-## 8. Omnigent client
+## 6. Omnigent client
 
 Create a thin transport client:
 
@@ -394,14 +435,16 @@ Required operations:
 | `stream_events` | `GET /v1/sessions/{session_id}/stream` |
 | `resolve_elicitation` | `POST /v1/sessions/{id}/elicitations/{eid}/resolve` |
 | `list_changed_files` | `GET /v1/sessions/{id}/resources/environments/default/changes` |
+| `list_workspace_files` | `GET /v1/sessions/{id}/resources/environments/default/filesystem` |
 | `get_workspace_file` | `GET /v1/sessions/{id}/resources/environments/default/filesystem/{path}` |
+| `get_workspace_diff` | Optional/capability-probed `GET /v1/sessions/{id}/resources/environments/default/diff/{path}` |
 | `list_session_files` | `GET /v1/sessions/{id}/resources/files` |
 | `get_session_file_content` | `GET /v1/sessions/{id}/resources/files/{file_id}/content` |
 | `interrupt` | `POST /v1/sessions/{id}/events` with `type=interrupt` |
 | `stop_session` | `POST /v1/sessions/{id}/events` with `type=stop_session` |
 | `delete_session` | `DELETE /v1/sessions/{id}` |
 
-There is intentionally no required `get_workspace_diff` method in v1. The upstream OpenAPI-confirmed resource surface is changes plus filesystem file content; patch artifacts must come from GitHub PR harvesting, a host-side helper, or a future Omnigent capability probe.
+`get_workspace_diff` is **optional** in v1. The adapter should capability-probe it and degrade if it is unavailable. It must not be the only path to produce a patch artifact.
 
 Transport rules:
 
@@ -414,9 +457,9 @@ Transport rules:
 
 ---
 
-## 9. Execute activity lifecycle
+## 7. Execute activity lifecycle
 
-### 9.1 Activity name
+### 7.1 Activity name
 
 ```text
 integration.omnigent.execute
@@ -434,7 +477,7 @@ Output:
 AgentRunResult
 ```
 
-### 9.2 Lifecycle flow
+### 7.2 Lifecycle flow
 
 ```text
 1. Validate AgentExecutionRequest.
@@ -454,7 +497,7 @@ AgentRunResult
 15. Return canonical terminal AgentRunResult, or raise activity error on unrecoverable adapter ambiguity.
 ```
 
-### 9.3 Session creation
+### 7.3 Session creation
 
 The activity creates an Omnigent session using JSON session creation.
 
@@ -478,8 +521,6 @@ Representative managed repository-session payload:
 }
 ```
 
-For `hostType=managed`, Omnigent server provisions the host. When `workspace` is a git repository URL, the server clones it inside the sandbox and stores the cloned directory as the session workspace. When `workspace` is omitted/null, Omnigent creates an empty server workspace. The adapter must not send `host_id` for managed session creation, and must not send local host paths as managed `workspace` values.
-
 Representative external-host payload:
 
 ```json
@@ -501,7 +542,7 @@ Representative external-host payload:
 }
 ```
 
-### 9.4 First message construction
+### 7.4 First message construction
 
 The message text is assembled from:
 
@@ -509,7 +550,7 @@ The message text is assembled from:
 2. `parameters.omnigent.prompt.instructionRef`, if present.
 3. `AgentExecutionRequest.instructionRef`, if present.
 4. `parameters.description`, if present.
-5. a generated prompt from title, workspace spec, workspace context, and input refs.
+5. A generated prompt from title, workspace spec, workspace context, and input refs.
 
 Large prompt bodies should be artifact-backed and read at the activity boundary.
 
@@ -530,50 +571,9 @@ MoonMind-Omnigent-Run:
 
 The marker is intentionally non-secret and exists to support retry reconciliation against Omnigent snapshots, pending inputs, and transcripts if a Temporal activity retry occurs after the first POST reached Omnigent.
 
-### 9.5 First message idempotency
-
-The first message must be durable-idempotent across Temporal activity retries.
-
-The adapter must not unconditionally post the first message when reusing an existing Omnigent session for the same `idempotencyKey`.
-
-Required durable states:
-
-```text
-not_prepared -> prepared -> posting -> posted -> terminal
-```
-
-Rules:
-
-1. `prepared` records the canonical message digest before any HTTP POST.
-2. `posting` is persisted immediately before the `POST /events` call.
-3. `posted` is persisted immediately after Omnigent returns a successful response.
-4. If Omnigent returns a native-terminal `pending_id`, store it.
-5. If a retry finds `posted`, it must skip the first POST.
-6. If a retry finds `posting`, it must reconcile before deciding whether to repost.
-7. Reconciliation checks Omnigent snapshot `items`, native `pending_inputs`, and any captured `session.input.consumed` events for the stored digest or idempotency marker.
-8. If reconciliation finds the first message, mark it `posted` and skip posting.
-9. If reconciliation cannot prove absence, do not blindly repost and do not return a non-terminal state from `integration.omnigent.execute`. In v1, fail closed by raising a retryable activity error while the reconciliation grace period remains, then a non-retryable `integration_error` once retry/reconciliation policy is exhausted. If the implementation chooses to return instead of throwing at exhaustion, the returned `AgentRunResult` must be terminal with `failureClass=integration_error`.
-10. If the same `idempotencyKey` is reused with a different first-message digest, fail fast and require an explicit operator reset.
-
-V1 deliberately avoids returning `status=intervention_requested` from the streaming execute activity because the current streaming-gateway workflow path treats any returned result as completed. Supporting a status-bearing streaming result requires a `MoonMind.AgentRun` workflow change and belongs to v2.
-
-Representative event:
-
-```json
-{
-  "type": "message",
-  "data": {
-    "role": "user",
-    "content": [
-      {"type": "input_text", "text": "..."}
-    ]
-  }
-}
-```
-
 ---
 
-## 10. Idempotency and run mapping
+## 8. Idempotency and run mapping
 
 The adapter must persist an idempotency mapping outside the Activity attempt.
 
@@ -607,27 +607,32 @@ omnigent_external_runs
   result_ref text null
 ```
 
+Required first-message states:
+
+```text
+not_prepared -> prepared -> posting -> posted -> terminal
+```
+
 Rules:
 
-- If a record exists for `idempotencyKey`, reuse its Omnigent session.
-- If session creation succeeds, persist the `session_id` before preparing or posting the first message.
-- If first-message state is `posted`, skip the first message and continue stream/snapshot reconciliation.
-- If first-message state is `posting`, reconcile against Omnigent snapshot/pending inputs/transcript before deciding whether any retry may post.
-- Never create a second Omnigent session for the same idempotency key unless an operator explicitly resets the mapping.
-- Never post a second first message for the same idempotency key and digest unless reconciliation has positively proved the prior POST did not reach Omnigent.
-- Store only non-secret endpoint refs, not raw tokens or headers.
+1. If a record exists for `idempotencyKey`, reuse its Omnigent session.
+2. If session creation succeeds, persist the `session_id` before preparing or posting the first message.
+3. `prepared` records the canonical message digest before any HTTP POST.
+4. `posting` is persisted immediately before the `POST /events` call.
+5. `posted` is persisted immediately after Omnigent returns a successful response.
+6. If Omnigent returns a native-terminal `pending_id`, store it.
+7. If a retry finds `posted`, it must skip the first POST.
+8. If a retry finds `posting`, it must reconcile before deciding whether to repost.
+9. Reconciliation checks Omnigent snapshot `items`, native `pending_inputs`, and any captured `session.input.consumed` events for the stored digest or idempotency marker.
+10. If reconciliation finds the first message, mark it `posted` and skip posting.
+11. If reconciliation cannot prove absence, do not blindly repost. In v1, fail closed by raising a retryable activity error while the reconciliation grace period remains, then a non-retryable `integration_error` once policy is exhausted.
+12. If the same `idempotencyKey` is reused with a different first-message digest, fail fast and require an explicit operator reset.
 
-### 10.1 Shared external-session table decision
-
-Do not introduce a generic `externalSession` table in v1.
-
-Omnigent has session-specific concerns — first-message state, pending ids, SSE artifact refs, session resource harvest state, and possible child sessions — that do not yet generalize cleanly across Jules, Codex Cloud, and OpenClaw. Keep the v1 durable mapping provider-specific as `omnigent_external_runs`.
-
-Promotion to a shared table becomes appropriate when at least one additional provider needs durable re-attach/session mapping with comparable fields.
+Do not introduce a generic `externalSession` table in v1. Omnigent has session-specific concerns — first-message state, pending ids, SSE artifact refs, session resource harvest state, and possible child sessions — that do not yet generalize cleanly across Jules, Codex Cloud, and OpenClaw. Promotion to a shared table becomes appropriate only when at least one additional provider needs durable reattach/session mapping with comparable fields.
 
 ---
 
-## 11. State normalization
+## 9. State normalization
 
 Map Omnigent observations into canonical MoonMind states.
 
@@ -651,15 +656,15 @@ Unsupported or unknown provider states must be treated as adapter contract error
 
 ---
 
-## 12. Stream and snapshot capture
+## 10. Stream and snapshot capture
 
-### 12.1 Capture principle
+### 10.1 Capture principle
 
 Omnigent's stream is a live tail. It is not a replay log. Therefore the execute activity must open the stream before posting the first message whenever possible.
 
 On retry, opening the stream before reconciliation is still preferred, but the first-message idempotency rules take precedence. A retry must never post the first message merely because it has successfully reattached to the stream.
 
-### 12.2 Required artifacts
+### 10.2 Required artifacts
 
 Minimum stream/snapshot artifacts:
 
@@ -676,7 +681,7 @@ output.omnigent.transcript.jsonl
 output.omnigent.final_response.md
 ```
 
-### 12.3 Normalized SSE event shape
+### 10.3 Normalized SSE event shape
 
 ```json
 {
@@ -695,7 +700,7 @@ output.omnigent.final_response.md
 }
 ```
 
-### 12.4 Snapshot rule
+### 10.4 Snapshot and reconnect rule
 
 Fetch snapshots at least twice:
 
@@ -704,28 +709,40 @@ Fetch snapshots at least twice:
 
 Optional periodic snapshots may be captured for long runs.
 
-### 12.5 Heartbeating, worker death, and re-attach
+Omnigent reconnect semantics are:
 
-Because the whole session runs inside one activity, MoonMind worker death is only detected through Temporal's activity heartbeat — the same mechanism the OpenClaw streaming activity relies on.
+```text
+open stream first
+fetch snapshot second
+dedupe items between snapshot and stream by stable item id
+```
 
-- **Heartbeat on progress.** The activity heartbeats on each captured SSE frame, or at least on each snapshot / periodic interval, carrying a compact progress token rather than raw payloads.
-- **`heartbeat_timeout` must be much smaller than `start_to_close_timeout`.** A long session needs a large start-to-close timeout; without a much smaller heartbeat timeout, worker death surfaces only at start-to-close. Size the heartbeat timeout from `OMNIGENT_STREAM_HEARTBEAT_TIMEOUT_SECONDS` and mark the activity heartbeat-required in the activity catalog.
-- **Retry re-attaches, it never recreates.** On retry the activity looks up `omnigent_session_id`, reconnects the SSE stream to that session, fetches a fresh snapshot, applies first-message idempotency, and resumes waiting for terminal state.
+MoonMind should persist its own mirrored stream/snapshot artifacts; it must not depend on Omnigent SSE replay for correctness.
+
+### 10.5 Heartbeating, worker death, and reattach
+
+Because the whole session runs inside one activity, MoonMind worker death is detected through Temporal activity heartbeat.
+
+- Heartbeat on each captured SSE frame, or at least each snapshot / periodic interval.
+- Heartbeat payloads must be compact progress tokens, not raw provider payloads.
+- `heartbeat_timeout` must be much smaller than `start_to_close_timeout`.
+- On retry, the activity looks up `omnigent_session_id`, reconnects the SSE stream to that session, fetches a fresh snapshot, applies first-message idempotency, and resumes waiting for terminal state.
 
 ---
 
-## 13. Artifact harvesting
+## 11. Artifact harvesting
 
-### 13.1 Principle
+### 11.1 Principle
 
 MoonMind must copy Omnigent-observable resources into MoonMind artifacts. Omnigent resource URLs, session ids, or file ids may be stored in metadata, but they are not substitutes for MoonMind `ArtifactRef`s.
 
-### 13.2 Workspace files
+### 11.2 Workspace files and patch sources
 
-At terminal state, harvest the upstream-confirmed resource surfaces:
+At terminal state, harvest the upstream resource surfaces when available:
 
 ```text
 GET /v1/sessions/{id}/resources/environments/default/changes
+GET /v1/sessions/{id}/resources/environments/default/filesystem
 GET /v1/sessions/{id}/resources/environments/default/filesystem/{path}
 ```
 
@@ -737,19 +754,33 @@ output.workspace.files/<path>.current
 output.workspace.manifest.json
 ```
 
-The adapter must not assume a public Omnigent diff endpoint exists. If a patch artifact is required, produce it from one of these sources:
+If upstream exposes the capability, optionally harvest:
+
+```text
+GET /v1/sessions/{id}/resources/environments/default/diff/{path}
+```
+
+Store:
+
+```text
+output.workspace.diffs/<path>.before
+output.workspace.diffs/<path>.after
+output.workspace.patch_from_omnigent_diff.patch
+```
+
+`get_workspace_diff` must be capability-probed. If unavailable, patch artifacts come from one of these sources:
 
 1. GitHub PR diff after PR creation;
 2. host-side helper output, such as `git diff` captured inside the Omnigent host;
 3. a future Omnigent diff capability discovered explicitly at runtime.
 
-When none of those sources is available, store a diagnostic artifact instead of failing the whole run solely because `capture.patchSource` could not produce a patch:
+When none of those sources is available, store a diagnostic artifact instead of failing the whole run solely because patch capture could not produce a patch:
 
 ```text
 output.workspace.patch_unavailable.json
 ```
 
-### 13.3 Session file resources
+### 11.3 Session file resources
 
 If Omnigent session files exist, harvest:
 
@@ -766,9 +797,9 @@ output.omnigent.session_files/<file_id>/<filename>
 output.omnigent.session_files/<file_id>/metadata.json
 ```
 
-### 13.4 GitHub and PR artifacts
+### 11.4 GitHub and PR artifacts
 
-If the run creates a PR or emits a PR URL:
+If the run creates a PR or emits a PR URL, harvest:
 
 ```text
 output.github.pr.metadata.json
@@ -779,7 +810,7 @@ output.github.pr.comments.json
 
 PR harvesting may be implemented by a follow-up GitHub post-processor activity. The Omnigent adapter should at minimum detect and persist PR URLs from transcript, final snapshot, and metadata.
 
-### 13.5 Diagnostics artifact
+### 11.5 Diagnostics artifact
 
 Always produce a diagnostics artifact, even for successful runs.
 
@@ -808,7 +839,7 @@ Suggested contents:
     "changedFiles": 4,
     "sessionFiles": 0,
     "childSessions": 0,
-    "patchSource": "github_pr_or_host_helper",
+    "patchSource": "omnigent_diff_or_github_pr_or_host_helper",
     "patchProduced": false
   }
 }
@@ -816,7 +847,7 @@ Suggested contents:
 
 ---
 
-## 14. Child sessions
+## 12. Child sessions
 
 If Omnigent emits child-session creation events, the adapter must record them and may recursively capture their snapshots/resources.
 
@@ -834,9 +865,9 @@ Future behavior:
 
 ---
 
-## 15. Cancellation and cleanup
+## 13. Cancellation and cleanup
 
-### 15.1 Soft cancel
+### 13.1 Soft cancel
 
 On Temporal activity cancellation or MoonMind AgentRun cancellation:
 
@@ -847,7 +878,7 @@ On Temporal activity cancellation or MoonMind AgentRun cancellation:
 }
 ```
 
-### 15.2 Hard stop
+### 13.2 Hard stop
 
 If the session remains active after a short grace period:
 
@@ -858,7 +889,7 @@ If the session remains active after a short grace period:
 }
 ```
 
-### 15.3 Delete policy
+### 13.3 Delete policy
 
 Do not delete the Omnigent session before artifact harvest.
 
@@ -882,14 +913,14 @@ DELETE /v1/sessions/{session_id}?delete_branch=false
 
 ---
 
-## 16. Security and secret handling
+## 14. Security, auth, and secret handling
 
 Rules:
 
 1. Omnigent server URL may be stored as an endpoint ref in workflow payloads.
 2. Omnigent API tokens must be activity-side secrets only.
 3. MoonMind must redact auth headers, cookies, tokens, and secret-looking fields before artifact storage.
-4. Use the existing MoonMind redaction helpers, including `SecretRedactor` and `redact_sensitive_text`, rather than inventing a separate Omnigent-only redactor.
+4. Use existing MoonMind redaction helpers, including `SecretRedactor` and `redact_sensitive_text`, rather than inventing a separate Omnigent-only redactor.
 5. Omnigent session labels must not include secrets.
 6. `parameters.omnigent` must not include raw credentials.
 7. Runtime credentials for Claude/Codex remain Omnigent server/host configuration concerns in this topology.
@@ -897,33 +928,46 @@ Rules:
 9. Host-side capture helpers, if added later, must authenticate to MoonMind artifact APIs using scoped, short-lived credentials.
 10. First-message idempotency markers may include correlation ids and digests, but must not include raw prompts from private artifacts beyond the actual prompt body that is already being sent to Omnigent.
 
+### 14.1 Auth topology warning
+
+Omnigent has two auth surfaces:
+
+```text
+MoonMind adapter -> Omnigent HTTP/SSE API
+Omnigent host/runner/sandbox -> Omnigent runner tunnel
+```
+
+The adapter can authenticate its own HTTP/SSE calls, but that does not automatically prove that Omnigent managed sandboxes can dial back to the Omnigent server. Upstream Omnigent deploys support auth modes such as accounts, OIDC, header-auth, and single-user/local auth. Managed sandbox runner dial-back may require Omnigent server auth configuration that can supply or accept runner identity, especially in deployed multi-user environments.
+
+The adapter should therefore surface managed-host launch failures as `integration_error`/`system_error` diagnostics rather than treating them as MoonMind credential failures.
+
 ---
 
-## 17. Error classification
+## 15. Error classification
 
 | Failure | MoonMind failure class | Notes |
 |---|---|---|
 | Omnigent server unreachable before session create | `integration_error` | Retryable if transport policy allows. |
-| Omnigent server returns `429` / rate limited | `integration_error` | Classify as rate-limited; honor `Retry-After` and use bounded retry, not immediate retry. |
-| Authentication failure to Omnigent | `integration_error` | Non-retryable until config fixed. |
+| Omnigent server returns `429` / rate limited | `integration_error` | Classify as rate-limited; honor `Retry-After` and use bounded retry. |
+| Authentication failure to Omnigent API | `integration_error` | Non-retryable until config fixed. |
 | Unknown Omnigent agent name | `user_error` | Bad request/target selection. |
-| Invalid managed-session create fields | `user_error` | Example: `hostType=managed` with `host_id`, or managed `workspace` set to a local path rather than a repository URL. |
-| Managed repo task without managed repository URL | `user_error` | Repository edit tasks must provide a managed `session.workspace` repository URL or explicitly opt into an empty workspace. |
+| Invalid managed-session create fields | `user_error` | Example: managed `hostId`, managed local path workspace, or external repository URL workspace. |
+| Managed repo task without managed repository URL | `user_error` | Repository edit tasks must provide a managed repo URL or explicitly opt into an empty workspace. |
 | Session create 4xx | `user_error` or `integration_error` | Depends on validation vs auth/config. |
-| Managed host provisioning failure | `system_error` or `integration_error` | Preserve Omnigent error body in diagnostics. |
+| Managed host provisioning failure | `system_error` or `integration_error` | Preserve Omnigent error body in diagnostics after redaction. |
 | Runtime/harness not configured | `integration_error` | Omnigent host/provider config issue. |
 | Agent returns failed response | `execution_error` | Runtime attempted work and failed. |
 | Activity timeout | `system_error` or `execution_error` | Depends on timeout policy. |
 | Artifact harvest partial failure | completed with diagnostics or `system_error` | Policy-controlled. |
 | Unknown Omnigent stream event schema | `integration_error` | Contract drift. |
 | Idempotency key reused with different first-message digest | `user_error` | Caller attempted conflicting replay. |
-| Retry cannot prove whether first message was accepted | `integration_error` | V1 streaming execute must fail/throw or return a terminal result with this valid `FailureClass`; it must not return non-terminal `intervention_requested`. |
+| Retry cannot prove whether first message was accepted | `integration_error` | V1 streaming execute must fail/throw or return a terminal result with this failure class; it must not return non-terminal `intervention_requested`. |
 
 ---
 
-## 18. Canonical result contract
+## 16. Canonical result contract
 
-The execute activity must return a compact `AgentRunResult`.
+The execute activity returns a compact `AgentRunResult`.
 
 Example:
 
@@ -952,15 +996,13 @@ Example:
 }
 ```
 
-Provider-native payloads must not be returned as top-level fields. In the v1 streaming-gateway path, returned results are terminal; non-terminal state reporting requires a future workflow contract change.
+Provider-native payloads must not be returned as top-level fields. In the v1 streaming-gateway path, returned results are terminal. Non-terminal state reporting requires a future workflow contract change.
 
 ---
 
-## 19. Observability surfaces
+## 17. Observability surfaces
 
 The adapter should produce enough data to power existing MoonMind AgentRun observability endpoints.
-
-Suggested mapping:
 
 | MoonMind observability surface | Canonical `link_type` | Omnigent-backed source |
 |---|---|---|
@@ -976,7 +1018,49 @@ Host-side stdout/stderr capture is explicitly out of scope for v1 unless a MoonM
 
 ---
 
-## 20. v1 adapter and registry sketch
+## 18. Temporal Visibility and Search Attribute posture
+
+Do not add Omnigent-specific Temporal Search Attributes in v1.
+
+Do **not** add:
+
+```text
+mm_omnigent_session_id
+mm_omnigent_agent_id
+mm_omnigent_host_type
+mm_omnigent_harness
+mm_external_session_id
+```
+
+Prefer existing generic dimensions:
+
+```text
+mm_owner_id
+mm_owner_type
+mm_state
+mm_entry
+mm_repo
+mm_integration
+mm_target_runtime
+mm_target_skill
+mm_scheduled_for
+```
+
+Omnigent-specific values belong in:
+
+```text
+AgentRunResult.metadata
+diagnostics artifacts
+omnigent_external_runs mapping table
+artifact links
+step/run evidence
+```
+
+This keeps the Temporal custom Search Attribute budget provider-neutral and leaves a future merger path open without making Temporal Visibility an Omnigent session browser.
+
+---
+
+## 19. v1 adapter and registry sketch
 
 ```python
 # moonmind/workflows/adapters/omnigent_agent_adapter.py
@@ -1033,7 +1117,7 @@ if gate.enabled:
 
 ---
 
-## 21. v2 polling/session mode
+## 20. v2 polling/session mode
 
 A future polling/session adapter can support multi-step continuation against one Omnigent session.
 
@@ -1068,7 +1152,7 @@ Additional requirements:
 
 ---
 
-## 22. Host-side capture helper
+## 21. Host-side capture helper
 
 API-only capture is enough for v1. A host-side helper should be added only when MoonMind needs artifacts not exposed by Omnigent APIs.
 
@@ -1093,9 +1177,9 @@ This helper must write to MoonMind's artifact API or artifact worker surface, no
 
 ---
 
-## 23. Testing strategy
+## 22. Testing strategy
 
-### 23.1 Unit tests
+### 22.1 Unit tests
 
 - target block validation;
 - managed-session rejection of caller-provided `hostId`;
@@ -1117,9 +1201,9 @@ This helper must write to MoonMind's artifact API or artifact worker surface, no
 - `posting` state reconciliation behavior;
 - ambiguous `posting` state fails/throws instead of returning non-terminal success;
 - digest mismatch fail-fast behavior;
-- no required `get_workspace_diff` transport call in v1.
+- optional `get_workspace_diff` capability probe and fallback.
 
-### 23.2 Adapter contract tests
+### 22.2 Adapter contract tests
 
 - provider registers only when enabled;
 - `agentKind=external` is required;
@@ -1129,7 +1213,7 @@ This helper must write to MoonMind's artifact API or artifact worker surface, no
 - streaming capability is declared;
 - polling hooks fail loudly in v1.
 
-### 23.3 Integration tests with fake Omnigent server
+### 22.3 Integration tests with fake Omnigent server
 
 The fake server should support:
 
@@ -1138,7 +1222,7 @@ The fake server should support:
 - `/v1/sessions/{id}` snapshot;
 - `/v1/sessions/{id}/events`;
 - `/v1/sessions/{id}/stream` SSE;
-- resource endpoints for changes, filesystem content, and session files.
+- resource endpoints for changes, filesystem content, optional diff content, and session files.
 
 Scenarios:
 
@@ -1151,17 +1235,18 @@ Scenarios:
 7. external session create may include `host_id` and absolute-path `workspace`;
 8. stream disconnect and snapshot reconciliation;
 9. elicitation request and approval;
-10. changed files and current-file harvest without a diff endpoint;
-11. patch unavailable diagnostic when no GitHub PR/host helper/future diff capability exists;
-12. child session event capture;
-13. cancellation before completion;
-14. idempotent retry after session create but before first message;
-15. idempotent retry after first message response but before terminal result;
-16. crash-window retry with `posting` state and snapshot reconciliation;
-17. ambiguous `posting` reconciliation fails closed rather than returning `intervention_requested` from execute;
-18. conflicting first-message digest under the same idempotency key.
+10. changed files and current-file harvest;
+11. optional diff harvest when supported;
+12. patch unavailable diagnostic when no Omnigent diff/GitHub PR/host helper exists;
+13. child session event capture;
+14. cancellation before completion;
+15. idempotent retry after session create but before first message;
+16. idempotent retry after first message response but before terminal result;
+17. crash-window retry with `posting` state and snapshot reconciliation;
+18. ambiguous `posting` reconciliation fails closed rather than returning `intervention_requested` from execute;
+19. conflicting first-message digest under the same idempotency key.
 
-### 23.4 Live smoke tests
+### 22.4 Live smoke tests
 
 Run against a real Omnigent server with a disposable repository and a sandbox host. Validate:
 
@@ -1173,43 +1258,48 @@ Run against a real Omnigent server with a disposable repository and a sandbox ho
 - stream capture;
 - final snapshot capture;
 - changed-file harvest;
+- optional diff harvest if available;
 - optional PR detection;
 - activity retry does not duplicate the first prompt.
 
 ---
 
-## 24. Implementation sequencing
+## 23. Implementation sequencing
 
-This canonical doc describes desired state. Detailed rollout tasks and temporary execution checklists should live under `docs/tmp/` or local-only handoff artifacts.
-
-The stable implementation milestones are:
+Stable implementation milestones:
 
 1. Runtime gate, typed target models, fake Omnigent client, and adapter registration.
-2. `integration.omnigent.execute` with stream/snapshot capture and first-message idempotency.
-3. Resource harvesting for changed-file manifests, current file contents, and session files.
-4. GitHub PR post-processing for durable patch artifacts when PRs are produced.
-5. Optional polling/session reuse and host-side capture helper.
+2. `omnigent_external_runs` mapping and first-message idempotency.
+3. `integration.omnigent.execute` with stream/snapshot capture.
+4. Resource harvesting for changed-file manifests, current file contents, optional diffs, and session files.
+5. GitHub PR post-processing for durable patch artifacts when PRs are produced.
+6. Optional polling/session reuse and host-side capture helper.
 
 ---
 
-## 25. Open questions
+## 24. Open questions
 
 1. Should Omnigent endpoint selection be global config only, or should MoonMind support named endpoint refs per tenant/project?
 2. Should v1 require `hostType=managed`, or should external-host sessions be allowed immediately?
 3. Should the adapter delete Omnigent sessions after successful harvest in CI-style workflows?
 4. Should MoonMind patch Omnigent to emit webhooks or artifact callbacks instead of relying on SSE capture?
 5. How should clear/context-reset semantics map onto MoonMind step epochs in v2?
-6. *(Resolved — see §10.1.)* A shared `externalSession` table is not introduced in v1; `omnigent_external_runs` stays dedicated, and promotion to a shared table is deferred until a second provider needs durable session mapping.
-7. *(Resolved — fail closed.)* Ambiguous `posting` retries do not return a non-terminal state from the streaming execute activity. They raise/retry while the reconciliation grace period remains, then fail with `failureClass=integration_error` or an equivalent non-retryable integration error once exhausted.
-8. Should MoonMind require a host-side helper for first-class patch artifacts, or is GitHub PR post-processing sufficient for v1?
-9. Should empty managed workspaces require an explicit `allowEmptyWorkspace` flag, or is absence of `workspaceSpec.repository` sufficient?
+6. Which Omnigent auth modes should be considered supported for server-managed sandboxes in MoonMind deployments?
+7. Should optional Omnigent diff capture become required once upstream documents it as stable?
 
 ---
 
-## 26. Design invariant
+## 25. Non-goals
 
-The core invariant is:
+The v1 adapter does not attempt to:
 
-> Omnigent may own live execution, but MoonMind owns durable orchestration and durable evidence.
-
-Therefore every Omnigent-backed AgentRun must end with a canonical MoonMind result whose important inputs, outputs, diagnostics, and observable runtime traces are represented as MoonMind artifact refs, not as transient Omnigent session state.
+- replace MoonMind's direct Claude Code or Codex managed runtimes;
+- expose Omnigent as a second workflow engine;
+- store raw Omnigent server credentials in workflow payloads;
+- make Omnigent's internal `ArtifactStore` the MoonMind artifact system;
+- automatically capture native runtime private state not exposed by Omnigent APIs;
+- guarantee perfect replay of transient Omnigent SSE events after the stream is disconnected;
+- implement multi-step, long-lived Omnigent session reuse across MoonMind steps in v1;
+- introduce provider-specific top-level MoonMind agent-id aliases such as `omnigent_session`, `omnigent_claude`, or `omnigent_codex`;
+- require a diff endpoint when upstream capability probing says it is unavailable;
+- return non-terminal states from `integration.omnigent.execute` unless `MoonMind.AgentRun` is changed to consume status-bearing streaming results.

--- a/docs/Temporal/VisibilityAndUiQueryModel.md
+++ b/docs/Temporal/VisibilityAndUiQueryModel.md
@@ -1,353 +1,199 @@
-# Visibility and UI Query Model
+# Temporal Visibility and UI Query Model
 
-**Implementation tracking:** Rollout and backlog notes live under `docs/tmp/` or in gitignored local-only handoffs (for example `artifacts/`), not as migration checklists in canonical `docs/`.
+Status: Active design guidance
+Owners: MoonMind Platform
+Last updated: 2026-06-30
 
-**Status:** Draft 
-**Owner:** MoonMind Platform 
-**Last updated:** 2026-04-04 
-**Audience:** backend, dashboard, API, workflow authors
+This document defines MoonMind's Temporal Visibility query model and the custom Search Attribute budget we use for workflow-list, dashboard, and operational views.
 
----
-
-## 1. Purpose
-
-Define the canonical **Visibility-backed query model** for **Temporal-managed executions** in MoonMind.
-
-This document turns the higher-level decisions in the architecture and lifecycle docs into an implementation-facing contract for:
-
-- required **Search Attributes**
-- allowed **list/detail filters**
-- **Memo** fields used by UI projections
-- default **sorting** and **recency** behavior
-- **pagination token** and **count** semantics
-- mapping from Temporal execution data into the **workflow console UI**
-- exact vs compatibility status presentation rules
-- waiting and attention metadata for blocked executions
-
-This document is intentionally the bridge between:
-
-- the target rule that **Temporal Visibility** is the source of truth for Temporal-managed list/query/count, and
-- the current implementation reality that MoonMind serves `/workflows/*` console surfaces and execution-oriented `/api/executions` APIs
+It is intentionally provider-neutral. External integrations such as Omnigent, Jules, Codex Cloud, OpenClaw, or future execution substrates must not add provider-specific indexed fields unless the dimension is promoted to a generic MoonMind query concept first.
 
 ---
 
-## 2. Related docs
+## 1. Goals
 
-- `docs/Temporal/TemporalArchitecture.md`
-- `docs/Temporal/WorkflowTypeCatalogAndLifecycle.md`
-- `docs/Temporal/ManagedAndExternalAgentExecutionModel.md`
-- `docs/Temporal/WorkflowArtifactSystemDesign.md`
-- `docs/UI/WorkflowConsoleArchitecture.md`
+Temporal Visibility is used for bounded, operationally important workflow queries:
 
-This document narrows several open items from those docs so frontend and backend work can proceed without inventing ad hoc query behavior.
+- list the current user's workflow executions;
+- filter by owner, entry type, status, repository, integration, schedule, runtime, and skill when supported;
+- sort by stable built-in or registered indexed fields;
+- compute facets and metrics where exact counts are operationally safe;
+- recover gracefully when optional Search Attributes are absent during migration.
 
----
-
-## 3. Scope and non-goals
-
-## 3.1 In scope
-
-- Search Attribute registry for Temporal-managed executions
-- Memo registry for list/detail presentation
-- canonical list/detail field model for Temporal-backed rows
-- allowed filters, sort order, recency rules, pagination, and counts
-- mapping into the dashboard workflow grouping semantics
-- rules for adapter APIs and unified workflow surfaces
-
-## 3.2 Out of scope
-
-- event-history rendering or Temporal Web UI parity
-- artifact storage, upload, or ACL design
-- worker topology and task queue routing
-- full dashboard route redesign
-- raw Temporal server query syntax details
+Temporal Visibility is **not** the source of truth for full workflow details, step ledgers, artifacts, prompts, raw logs, provider-native metadata, or external session internals.
 
 ---
 
-## 4. Current implementation reality and target contract
+## 2. Query ownership boundaries
 
-## 4.1 Current implementation reality
-
-MoonMind already has a Temporal execution adapter surface, including endpoints such as:
-
-- `POST /api/executions`
-- `GET /api/executions`
-- `GET /api/executions/{workflowId}`
-- `POST /api/executions/{workflowId}/update`
-- `POST /api/executions/{workflowId}/signal`
-- `POST /api/executions/{workflowId}/cancel`
-
-During migration, some of that surface may still be backed by:
-
-- `TemporalExecutionService`
-- app DB projection rows
-- adapter/cache/reconciliation layers
-
-Current list behavior may already resemble the target shape, but the projection layer is not the semantic owner of query behavior.
-
-## 4.2 Target contract
-
-For **Temporal-managed work**, **Temporal Visibility** is the source of truth for:
-
-- list
-- filter/query
-- pagination
-- count semantics
-
-The app DB projection may continue to exist during migration, but it is an **adapter/cache/reconciliation layer**, not the owner of canonical query semantics.
-
-Contractually:
-
-1. any adapter API for Temporal-backed list/detail data must preserve **Visibility semantics**
-2. unified `/workflows/*` surfaces may reshape Temporal rows into workflow-product payloads, but they must **not invent conflicting state, sort, or pagination rules**
-3. if a projection disagrees with Temporal-backed canonical fields, **Temporal wins**
-4. provider-specific payloads and runtime-native details must not become ad hoc list/query semantics outside the canonical field model
+| Concern | Owner | Query surface |
+|---|---|---|
+| Workflow orchestration | Temporal | Workflow ids, run ids, status, visibility queries |
+| MoonMind workflow lifecycle | MoonMind workflow code | `mm_state`, `mm_updated_at`, `mm_started_at` |
+| User/security scoping | MoonMind API/workflow start path | `mm_owner_type`, `mm_owner_id` |
+| Workflow list grouping | MoonMind API/workflow start path | `mm_entry`, `WorkflowType` |
+| Repository/integration filters | MoonMind API/workflow start path | `mm_repo`, `mm_integration` |
+| Runtime/skill facets | MoonMind API/workflow start path and workflow lifecycle repair | `mm_target_runtime`, `mm_target_skill` |
+| Schedules/deferred starts | MoonMind API/Temporal start path | `mm_scheduled_for` |
+| Full evidence | MoonMind artifacts | Artifact refs, not Search Attributes |
+| Provider-native session metadata | Provider adapter / diagnostics | Mapping tables and artifacts, not Search Attributes |
 
 ---
 
-## 5. Canonical query entity model
+## 3. Search Attribute naming rules
 
-## 5.1 Canonical entity
+All MoonMind-owned Search Attributes follow these rules:
 
-The primary durable query entity for Temporal-managed work is a **Workflow Execution**.
-
-Some legacy API fields still carry `task` naming (they rename in the hard switch), but those rows map to Workflow Executions when the runtime is Temporal-backed.
-
-## 5.2 Canonical identifiers
-
-- `workflowId`: durable canonical identifier for Temporal-managed work
-- `runId`: current/latest Temporal run instance identifier; detail/debug oriented
-- `taskId`: legacy alias still present on some payloads (renames in the hard switch)
-
-Rules:
-
-- `workflowId` is the stable identity used for links, cache keys, and adapter lookups
-- `runId` must not replace `workflowId` as the primary product handle
-- detail pages may show `runId`, but only as run/debug metadata
-
-## 5.2.1 Compatibility identifier bridge
-
-For any Temporal-backed row exposed through a workflow product surface:
-
-- `taskId` **must equal** `workflowId`
-- APIs may return both `taskId` and `workflowId` during migration
-- compatibility adapters must not mint a second opaque identifier for the same Temporal execution
-- `runId` must never be used as the route identifier for workflow detail pages
-
-This keeps the workflow UI stable without introducing another alias table or migration dependency.
-
-## 5.3 Canonical list row fields
-
-A Temporal-backed list row should be expressible with the following stable fields:
-
-- `workflowId`
-- `taskId?`
-- `workflowType`
-- `entry`
-- `state`
-- `temporalStatus`
-- `title`
-- `summary`
-- `ownerType`
-- `ownerId`
-- `updatedAt`
-- `startedAt`
-- `closedAt?`
-- `waitingReason?`
-- `attentionRequired?`
-- `dashboardStatus`
-
-Optional bounded fields when available:
-
-- `repo?`
-- `integration?`
-
-Rules:
-
-- `state` is the exact `mm_state` value
-- `dashboardStatus` is a compatibility grouping only
-- list fields should not require artifact hydration to render a normal row
-- provider-native raw payloads should not become top-level list fields
-
-## 5.4 Canonical detail fields
-
-A Temporal-backed detail model may additionally include:
-
-- `runId`
-- `closeStatus`
-- `artifactRefs[]`
-- `progress`
-- `stepsHref`
-- `waitingReason?`
-- `attentionRequired?`
-- `searchAttributes`
-- `memo`
-- optional debug or reconciliation metadata
-- optional live query-derived fields such as active child state or current execution phase
-
-Detail views should show the exact Temporal-facing state (`state`, `temporalStatus`, `closeStatus`) even when list pages group them into broader workflow status groups.
+- prefix with `mm_` unless the attribute belongs to a non-MoonMind operational workflow family that predates this convention;
+- use lowercase snake_case for new MoonMind workflow attributes;
+- store bounded values only;
+- store no secrets;
+- store no large free text;
+- store no raw prompts, transcripts, stack traces, logs, or provider error bodies;
+- store no step-ledger rows or attempt history;
+- store no display-only user prose;
+- add documentation here before adding a new Search Attribute to bootstrap.
 
 ---
 
-## 6. Search Attribute registry
+## 4. Current registered custom Search Attributes
 
-## 6.1 Naming rules
+MoonMind currently registers 20 custom Search Attributes in the Temporal namespace bootstrap. Exactly 10 are `Keyword`, which is the important SQL Visibility keyword ceiling guarded by integration tests.
 
-All MoonMind-owned Search Attributes for this query model follow these rules:
+### 4.1 Keyword attributes — current 10-slot budget
 
-- prefix `mm_`
-- lowercase snake_case
-- bounded values only
-- no secrets
-- no large free text
-- no step-ledger rows or attempt history
-- no display-only user prose
+| Name | Type | Owner | Keep? | Purpose |
+|---|---:|---|---|---|
+| `mm_entry` | Keyword | API/workflow start path | Keep | Execution category for UI/query surfaces. |
+| `mm_owner_id` | Keyword | API/workflow start path | Keep | Principal identifier for user/security scoping. |
+| `mm_owner_type` | Keyword | API/workflow start path | Keep | `user`, `system`, or `service` owner class. |
+| `mm_state` | Keyword | Workflow lifecycle logic | Keep | Exact MoonMind lifecycle state. |
+| `mm_repo` | Keyword | API/workflow start path | Keep if repo filtering remains core | Stable bounded repo identifier. |
+| `mm_integration` | Keyword | API/workflow start path | Conditional keep | Integration-centric workflow filter/facet. |
+| `AgentRunId` | Keyword | Managed session workflows | Re-evaluate | Operational managed-session correlation. |
+| `RuntimeId` | Keyword | Managed session workflows | Re-evaluate | Managed-session runtime id; overlaps conceptually with generic runtime dimensions. |
+| `SessionId` | Keyword | Managed session workflows | Conditional keep | Direct Temporal lookup/correlation for managed sessions. |
+| `SessionStatus` | Keyword | Managed session / operational workflows | Strongest managed-session keep | Managed-session and cleanup/reconcile operational status. |
 
-## 6.2 Required Search Attributes
+### 4.2 Non-Keyword attributes
+
+| Name | Type | Owner | Purpose |
+|---|---:|---|---|
+| `mm_updated_at` | Datetime | Workflow lifecycle logic | Canonical user-visible recency/update time. |
+| `mm_started_at` | Datetime | Workflow lifecycle logic | Semantic “real work began” timestamp distinct from Temporal start time. |
+| `mm_scheduled_for` | Datetime | API/start path | Expected/deferred start time. |
+| `mm_target_runtime` | KeywordList | API/workflow start path; workflow repair | One-item list containing canonical runtime id for filtering/facets. |
+| `mm_target_skill` | KeywordList | API/workflow start path; workflow repair | One-item list containing primary skill id/slug/name for filtering/facets. |
+| `mm_title` | KeywordList | Workflow start/lifecycle logic | Tokenized title word search. Must be materialized before relying on title search. |
+| `mm_has_dependencies` | Bool | Dependency lifecycle | Dependency presence signal. Re-evaluate if unused by production queries. |
+| `mm_dependency_count` | Int | Dependency lifecycle | Bounded dependency count. Re-evaluate if unused by production queries. |
+| `SessionEpoch` | Int | Managed session workflows | Managed-session clear/reset/epoch correlation. |
+| `IsDegraded` | Bool | Managed session / operational workflows | Operational degraded marker. |
+
+---
+
+## 5. Required workflow-list attributes
+
+These are required for the primary Temporal-backed workflow list.
 
 | Name | Type | Required | Lifecycle owner | Update rule | Notes |
-| --- | --- | --- | --- | --- | --- |
-| `mm_owner_type` | keyword | Yes | API/workflow start path | Set at start; immutable in v1 | `user`, `system`, or `service` |
-| `mm_owner_id` | keyword | Yes | API/workflow start path | Set at start; immutable in v1 | Principal identifier |
-| `mm_state` | keyword | Yes | Workflow lifecycle logic | Update on every domain-state transition | Exact MoonMind lifecycle state |
-| `mm_updated_at` | datetime | Yes | Workflow lifecycle logic | Update on meaningful user-visible mutation | Default recency/sort key |
-| `mm_entry` | keyword | Yes | Workflow start path | Set at start; immutable | Execution category for UI/query surfaces |
+|---|---:|---:|---|---|---|
+| `mm_owner_type` | Keyword | Yes | API/workflow start path | Set at start; immutable in v1 | `user`, `system`, or `service`. |
+| `mm_owner_id` | Keyword | Yes | API/workflow start path | Set at start; immutable in v1 | Principal identifier. |
+| `mm_state` | Keyword | Yes | Workflow lifecycle logic | Update on every domain-state transition | Exact MoonMind lifecycle state. |
+| `mm_updated_at` | Datetime | Yes | Workflow lifecycle logic | Update on meaningful user-visible mutation | Default recency/sort key. |
+| `mm_entry` | Keyword | Yes | Workflow start path | Set at start; immutable | Execution category for UI/query surfaces. |
 
-## 6.3 Optional Search Attributes
+### 5.1 `mm_state` value set
+
+Allowed values for v1:
+
+```text
+scheduled
+initializing
+waiting_on_dependencies
+planning
+awaiting_slot
+executing
+awaiting_external
+proposals
+finalizing
+no_commit
+completed
+failed
+canceled
+```
+
+Rules:
+
+- `mm_state` must be set immediately on workflow start.
+- Terminal mapping must remain consistent with MoonMind `closeStatus`:
+  - `no_commit` / `completed` -> `completed`
+  - `failed` / `terminated` / `timed_out` -> `failed`
+  - `canceled` -> `canceled`
+- Graceful workflow cancellation is represented by workflow-owned terminal `mm_state=canceled` / `closeStatus=canceled` even when raw Temporal `ExecutionStatus` is `Completed` because the workflow finalized and returned normally.
+
+### 5.2 `mm_owner_type` value set
+
+Allowed values for v1:
+
+```text
+user
+system
+service
+```
+
+Rules:
+
+- `mm_owner_type` and `mm_owner_id` must always be populated together.
+- `unknown` is not an allowed owner type.
+- Standard end-user views should only show executions where `mm_owner_type = user` and `mm_owner_id` matches the authenticated principal unless a product surface explicitly says otherwise.
+
+### 5.3 `mm_entry` value set
+
+Allowed values for v1:
+
+```text
+user_workflow
+manifest
+provider_profile
+```
+
+Rules:
+
+- `mm_entry` is required.
+- `mm_entry` should not be inferred by parsing raw workflow type strings in UI code.
+- Compatibility surfaces may collapse multiple `entry` values into one broader product grouping, but the exact value must remain queryable.
+
+---
+
+## 6. Optional workflow-list attributes
 
 | Name | Type | Required | When to set | Notes |
-| --- | --- | --- | --- | --- |
-| `mm_repo` | keyword | No | Repo-scoped executions when filtering is needed | Stable bounded repo identifier |
-| `mm_integration` | keyword | No | Integration-centric execution where filtering is useful | Examples: `jules`, `github`, `openclaw` |
-| `mm_target_runtime` | keyword_list | No | Workflow start path when the canonical runtime is known; workflow lifecycle logic if it resolves later | One-item list containing the canonical runtime ID such as `codex_cli`, `claude_code`, `gemini_cli`, `codex_cloud`, or `jules`; never a display label, model, profile name, prompt, or free text |
-| `mm_target_skill` | keyword_list | No | Workflow start path when the primary skill is known; workflow lifecycle logic if it resolves later | One-item list containing the singular primary skill slug/name/id used by `targetSkill`; future multi-skill faceting requires a separate explicitly documented attribute |
-| `mm_scheduled_for` | datetime | No | Delayed start / schedule-backed execution | Queryable expected start time |
+|---|---:|---:|---|---|
+| `mm_repo` | Keyword | No | Repo-scoped executions when filtering is needed | Stable bounded repo identifier. |
+| `mm_integration` | Keyword | No | Integration-centric execution where filtering is useful | Examples: `jules`, `github`, `openclaw`, `omnigent`. |
+| `mm_target_runtime` | KeywordList | No | Workflow start path when canonical runtime is known; workflow lifecycle logic if it resolves later | One-item list containing canonical runtime ID such as `codex_cli`, `claude_code`, `gemini_cli`, `codex_cloud`, `jules`, or a generic provider-backed runtime id. Never a display label, model, profile name, prompt, or free text. |
+| `mm_target_skill` | KeywordList | No | Workflow start path when primary skill is known; workflow lifecycle logic if it resolves later | One-item list containing singular primary skill slug/name/id used by `targetSkill`; future multi-skill faceting requires a separate explicitly documented attribute. |
+| `mm_scheduled_for` | Datetime | No | Delayed start / schedule-backed execution | Queryable expected start time. |
+| `mm_title` | KeywordList | No | Workflow start/lifecycle title materialization | Tokenized title word search. Verify materialization before relying on this filter. |
 
-Runtime and skill Search Attributes are optional during migration. The API must
-confirm that `mm_target_runtime` and `mm_target_skill` are registered as
-`KeywordList` before issuing Temporal Visibility queries that reference them. When
-they are unavailable, runtime/skill filters are not authoritative and facets
-return degraded metadata rather than failing the list page.
+Runtime and skill Search Attributes are optional during migration. The API must confirm that `mm_target_runtime` and `mm_target_skill` are registered as `KeywordList` before issuing Temporal Visibility queries that reference them. When they are unavailable, runtime/skill filters are not authoritative and facets return degraded metadata rather than failing the list page.
 
-Runtime/skill filters use Temporal KeywordList membership queries
-(`mm_target_runtime = "codex_cli"`). They are not sortable through Temporal
-Visibility because SQL Visibility rejects `ORDER BY` for KeywordList fields.
+Runtime/skill filters use Temporal KeywordList membership queries:
 
-Blank or unknown runtime/skill values are omitted, not written as empty strings
-or placeholders. Existing executions that cannot be updated in Temporal
-Visibility remain blank/unknown for these dimensions; historical facet counts
-must not be faked from projection-only display values. Open executions may
-repair these attributes from canonical parameters or workflow-owned metadata
-when they next perform a bounded lifecycle Search Attribute update.
+```text
+mm_target_runtime = "codex_cli"
+mm_target_skill = "jira-implement"
+```
 
-## 6.4 Deferred Search Attributes
+They are not sortable through Temporal Visibility because SQL Visibility rejects `ORDER BY` for KeywordList fields.
 
-These are intentionally **not** required in v1:
-
-- `mm_stage`
-- `mm_error_category`
-- free-text search attributes
-- unbounded tag arrays
-- child-workflow/activity-level indexing fields
-
-If one becomes necessary, update this document first rather than adding it ad hoc in code.
-
-## 6.5 Required value sets
-
-### `mm_state`
-
-Allowed values for v1:
-
-- `scheduled`
-- `initializing`
-- `waiting_on_dependencies`
-- `planning`
-- `awaiting_slot`
-- `executing`
-- `awaiting_external`
-- `proposals`
-- `finalizing`
-- `no_commit`
-- `completed`
-- `failed`
-- `canceled`
-
-Rules:
-
-- `mm_state` must be set immediately on workflow start
-- terminal mapping must remain consistent with MoonMind `closeStatus`:
- - no_commit / completed → `completed`
- - failed / terminated / timed out → `failed`
- - canceled → `canceled`
-- graceful workflow cancellation is represented by workflow-owned terminal
-  `mm_state=canceled` / `closeStatus=canceled` even when the raw Temporal
-  `ExecutionStatus` is `Completed` because the workflow finalized and returned
-  normally
-
-### `mm_owner_type`
-
-Allowed values for v1:
-
-- `user`
-- `system`
-- `service`
-
-Rules:
-
-- `mm_owner_type` and `mm_owner_id` must always be populated together
-- `unknown` is not an allowed target-state value
-- standard end-user views should only show executions where `mm_owner_type = user` and `mm_owner_id` matches the authenticated principal, unless a product surface explicitly says otherwise
-
-### `mm_entry`
-
-Allowed values for v1 (currently normalized by the executions API):
-
-- `run`
-- `manifest`
-- `provider_profile`
-
-*(Note: additional workflow types like `agent_run` and `oauth_session` are planned or used internally but are not currently normalized for top-level list filtering by the primary executions API.)*
-
-Rules:
-
-- `mm_entry` is required
-- `mm_entry` should not be inferred by parsing raw workflow type strings in UI code
-- compatibility surfaces may collapse multiple `entry` values into one broader product grouping, but the exact value must remain queryable
+Blank or unknown runtime/skill values are omitted, not written as empty strings or placeholders. Existing executions that cannot be updated in Temporal Visibility remain blank/unknown for these dimensions; historical facet counts must not be faked from projection-only display values. Open executions may repair these attributes from canonical parameters or workflow-owned metadata when they next perform a bounded lifecycle Search Attribute update.
 
 ---
 
-## 7. Memo registry
-
-## 7.1 Required Memo fields
-
-| Field | Required | Purpose | Rules |
-| --- | --- | --- | --- |
-| `title` | Yes | Human-readable execution title | small, display-safe, mutable |
-| `summary` | Yes | Compact current summary for list/detail surfaces | small, display-safe, mutable |
-
-## 7.2 Optional Memo fields
-
-| Field | Required | Purpose | Rules |
-| --- | --- | --- | --- |
-| `input_ref` | No | Safe reference to input artifact | reference only |
-| `manifest_ref` | No | Safe reference for manifest-driven workflows | reference only |
-| `error_category` | No | Debug/detail classification for failures | display/debug only |
-| `entry_label` | No | Optional human-friendly display label | small, bounded |
-| `progress_hint` | No | Compact execution-level progress hint when useful | small, bounded, never a step ledger |
-
-## 7.3 Memo rules
-
-- keep Memo small and human-readable
-- never store secrets, full prompts, manifests, or large payloads in Memo
-- never store step-ledger rows, attempts, `checks[]`, or long error bodies in Memo
-- Memo is for **display metadata**, not filtering
-- list views should rely on `title` and `summary`, not raw artifact payloads
-
----
-
-## 8. Allowed filters and query model
-
-## 8.1 Exact filters for Temporal-backed queries
+## 7. Exact filters for Temporal-backed queries
 
 Allowed exact-match filters for Temporal-managed list queries:
 
@@ -358,373 +204,244 @@ Allowed exact-match filters for Temporal-managed list queries:
 - `entry`
 - `repo`
 - `integration`
+- `targetRuntime` when `mm_target_runtime` is registered as `KeywordList`
+- `targetRuntimeIn` / `targetRuntimeNotIn` when `mm_target_runtime` is registered as `KeywordList`
+- `targetSkillIn` / `targetSkillNotIn` when `mm_target_skill` is registered as `KeywordList`
 
-## 8.2 Filter priorities
+### 7.1 Filter priorities
 
-### Required now
+Required now:
 
 - `workflowType`
 - `ownerId`
-- `state`
-
-### Required next
-
-- `entry`
 - `ownerType`
+- `state`
+- `entry`
 
-### Optional later
+Required when product surface uses it:
 
 - `repo`
 - `integration`
+- `targetRuntime`
+- `targetSkill`
 
-These should ship only when a real UI/API consumer needs them.
-
-## 8.3 Not in v1
-
-The following are intentionally out of scope for v1 query behavior:
-
-- free-text search
-- fuzzy title search
-- arbitrary multi-field OR composition
-- arbitrary date-range filtering
-- child-workflow filtering
-- activity-level filtering
-
-## 8.4 Ownership scoping rules
-
-Ownership is not just a filter; it is part of authorization.
-
-Rules:
-
-- standard users are implicitly scoped to their own executions
-- standard users must not see `system` or `service` executions on user-facing workflow pages unless the product explicitly supports that
-- non-admin callers must not query another user’s executions
-- admin/operator callers may filter by `ownerType`, `ownerId`, or omit them
-
-The UI should not offer arbitrary owner-picking to ordinary end users.
+Do not add a new Search Attribute merely because a display field exists. A field should consume Search Attribute budget only when MoonMind needs server-side filtering, sorting, faceting, metrics, or operational lookup.
 
 ---
 
-## 9. Sorting, recency, and stable ordering
+## 8. Sort fields
 
-## 9.1 Default ordering
+Supported Temporal-backed sort fields must use built-in fields or registered sortable Search Attributes.
 
-The canonical default order for Temporal-managed list rows is:
+Sortable examples:
 
-1. `mm_updated_at DESC`
-2. `workflowId DESC` as deterministic tie-breaker
-
-This must remain true whether the backing implementation comes directly from Temporal Visibility or from a temporary adapter/projection layer.
-
-## 9.2 No queue semantics
-
-Temporal-backed lists must not imply:
-
-- FIFO queue ordering
-- worker queue position
-- queue depth semantics
-- “next to run” promises
-
-Task queues are plumbing, not a user-visible ordering model.
-
-## 9.3 What moves `mm_updated_at`
-
-`mm_updated_at` should move on **meaningful user-visible mutations**, including:
-
-- domain-state transitions
-- accepted updates
-- signal handling that changes visible workflow state
-- pause/resume/cancel/rerun actions
-- terminal success/failure transitions
-- bounded progress checkpoints that materially affect UI recency
-- step-ready, step-started, step-reviewing, step-succeeded, step-failed, step-skipped, and step-canceled transitions
-- title/summary changes that materially alter visible list/detail presentation
-
-`mm_updated_at` should **not** move on every:
-
-- heartbeat
-- log line
-- low-level retry
-- internal polling tick
-- low-level retry/backoff detail inside one step execution
-
-Implementation guidance:
-
-- progress updates must be bounded and meaningful before they affect `mm_updated_at`
-- telemetry spam must not churn ordering
-
----
-
-## 10. Compatibility status mapping for the dashboard
-
-The current dashboard uses broad normalized workflow statuses such as:
-
-- `queued`
-- `running`
-- `awaiting_action`
-- `waiting`
-- `completed`
-- `failed`
-- `canceled`
-
-Temporal-backed rows should preserve exact Temporal/MoonMind state **and** provide a compatibility grouping.
-
-## 10.1 Exact vs compatibility fields
-
-- **Exact fields:** `state`, `temporalStatus`, `closeStatus`
-- **Compatibility field:** `dashboardStatus`
-
-## 10.2 v1 mapping
-
-| Exact Temporal-backed state | Compatibility dashboard status | Notes |
-| --- | --- | --- |
-| `scheduled` | `queued` | waiting for deferred start |
-| `initializing` | `queued` | not yet materially executing user work |
-| `waiting_on_dependencies` | `waiting` | blocked on prerequisite work |
-| `planning` | `running` | active pre-execution work |
-| `awaiting_slot` | `queued` | waiting for a bounded runtime resource |
-| `executing` | `running` | active execution |
-| `awaiting_external` | `awaiting_action` | compatibility grouping only |
-| `proposals` | `running` | still active, post-execution proposal phase |
-| `finalizing` | `running` | still in-flight |
-| `no_commit` | `completed` | terminal completion without a repository commit |
-| `completed` | `completed` | terminal success |
-| `failed` | `failed` | terminal failure |
-| `canceled` | `canceled` | terminal cancellation |
-
-## 10.3 Important note on `awaiting_external`
-
-`awaiting_external` does **not** always mean the current user must take action.
-
-For compatibility surfaces it maps to `awaiting_action` because that is the nearest existing grouped status, but exact detail views must still show `awaiting_external`.
-
-That distinction matters because the actual cause may be:
-
-- approval required
-- provider callback wait
-- provider completion wait
-- operator pause
-- retry backoff
-- other non-user-blocking external wait
-
-## 10.4 Required waiting metadata
-
-To avoid misleading users, Temporal-backed rows in blocked states should expose:
-
-- `waitingReason`
-- `attentionRequired`
-
-### Allowed `waitingReason` values for v1
-
-- `approval_required`
-- `external_callback`
-- `external_completion`
-- `operator_paused`
-- `retry_backoff`
-- `dependency_wait`
-- `provider_profile_slot`
-- `unknown_external`
-
-Rules:
-
-- `waitingReason` should be set whenever the execution is in a blocked or waiting state where the reason is knowable
-- `attentionRequired = true` only when progress is blocked on human/operator action exposed by the current product surface
-- compatibility dashboards may continue using broad grouped statuses, but they must not imply user action is required when `attentionRequired = false`
-
----
-
-## 11. Pagination and count strategy
-
-## 11.1 Pagination inputs
-
-Temporal-backed list APIs use:
-
-- `pageSize`
-- `nextPageToken`
-
-Rules:
-
-- `nextPageToken` is opaque
-- clients must only echo it back to the same endpoint with the same query scope
-- changing filters invalidates the token
-
-## 11.2 Current adapter behavior
-
-Current implementations may still use opaque encoded offsets internally.
-
-That is an implementation detail, not a client contract.
-
-## 11.3 Target behavior
-
-When list/query/count is fully backed by Temporal Visibility, the API should pass through Temporal-backed pagination semantics without forcing the UI to know Temporal internals.
-
-## 11.4 Count behavior
-
-List responses may include:
-
-- `count`
-- `countMode`
-
-Allowed `countMode` values:
-
-- `exact`
-- `estimated_or_unknown`
-
-Target rule:
-
-- return exact count when operationally acceptable
-- otherwise return `estimated_or_unknown` or omit `count`
-
-## 11.5 Freshness and degraded-read behavior
-
-In an eventually consistent system:
-
-- the response from a successful update/signal/cancel/rerun action is the authoritative immediate view for that execution
-- list pages should patch the acted-on row from that action response when possible, then background-refetch the active query
-- clients must not infer that unrelated rows were refreshed
-- when `countMode != exact`, the UI must not present a precise total as authoritative
-- when `count` is omitted, pagination should rely on rows plus `nextPageToken`, not synthetic totals
-- operator-facing surfaces should expose a refresh timestamp or equivalent stale-state indicator
-
----
-
-## 12. Canonical adapter projection for UI consumers
-
-## 12.1 Preferred top-level fields
-
-When an adapter API exposes Temporal-backed data to UI consumers, it should promote these values to stable top-level fields:
-
-- `workflowId`
-- `runId`
-- `taskId`
-- `workflowType`
-- `entry`
-- `ownerType`
-- `ownerId`
-- `state`
-- `temporalStatus`
-- `closeStatus`
-- `title`
-- `summary`
-- `waitingReason`
-- `attentionRequired`
-- `updatedAt`
-- `startedAt`
-- `closedAt`
-- `dashboardStatus`
-
-Optional bounded top-level fields when available:
-
-- `repo`
-- `integration`
-
-## 12.2 Raw blobs still allowed
-
-Raw `searchAttributes` and `memo` objects may still be returned for:
-
-- debugging
-- admin/operator views
-- migration parity checks
-- adapter inspection
-
-But those raw maps are not the preferred long-term UI contract.
-
-## 12.3 Artifact references
-
-`artifactRefs[]` belongs on detail responses and on list responses only when the payload remains small and useful.
-
-List views should not require artifact hydration to render basic execution rows.
-
----
-
-## 13. UI integration requirements
-
-The dashboard runtime config and route shell should treat `temporal` as the primary execution source for Temporal-backed rows.
-
-The dashboard should use:
-
-- Temporal-backed list/detail endpoints
-- `workflowId` as the durable handle
-- `taskId == workflowId` on compatibility surfaces
-- `runId` only as run/debug metadata
-- exact state plus compatibility grouping
-- waiting metadata (`waitingReason`, `attentionRequired`)
-- Temporal action handlers for update, signal, cancel, and rerun semantics
-
-Higher-level product actions may still be composed from those primitives.
-
----
-
-## 14. Projection rules and source of truth
-
-## 14.1 Projection discipline
-
-Any app DB projection or adapter cache that mirrors Temporal-managed executions must mirror these canonical fields faithfully:
-
-- `workflowId`
-- `runId`
-- `workflowType`
-- `mm_owner_type`
-- `mm_owner_id`
+- `WorkflowId`
+- `StartTime`
+- `CloseTime`
 - `mm_state`
-- `mm_updated_at`
-- `mm_entry`
-- Memo `title`
-- Memo `summary`
+- `mm_repo`
+- `mm_integration`
+- `mm_scheduled_for`
+- `mm_updated_at` when used by supported query path
 
-## 14.2 What a projection may add
+Not sortable through Temporal Visibility:
 
-A projection may add helper fields for:
+- `mm_target_runtime`
+- `mm_target_skill`
+- `mm_title`
+- any KeywordList field
+- progress derived from step ledger or workflow queries
 
-- authorization
-- joins
-- migration telemetry
-- dashboard performance
-- reconciliation status
-
-It may not redefine the meaning of canonical Visibility-backed fields.
-
-## 14.3 Drift rule
-
-If a projection and Temporal-backed canonical metadata drift, the system should repair the projection rather than redefining the query contract around projection drift.
+KeywordList filters may be authoritative while sort remains current-page/projection-only.
 
 ---
 
-## 15. Target contract vs implementation
+## 9. Count and facet degradation
 
-This document specifies the **desired** Visibility, Memo, adapter list/detail, and UI query contract.
+List row retrieval is the primary payload. Counts and facets are enrichments.
 
-Current implementation gaps, Visibility-native query work, and items to retire after substrate cutover belong in:
+If `list_workflows` succeeds and `count_workflows` fails or times out, the API should return rows with:
 
-- `docs/Temporal/VisibilityAndUiQueryModel.md`
+```json
+{
+  "count": null,
+  "countMode": "estimated_or_unknown",
+  "degradedCount": true
+}
+```
 
-This document should remain the normative semantics source rather than a live gap tracker.
+If an optional facet Search Attribute is unavailable, the facet endpoint should return degraded metadata, not 503:
 
----
+```json
+{
+  "items": [],
+  "countMode": "estimated_or_unknown",
+  "source": "current_page_fallback"
+}
+```
 
-## 16. Acceptance criteria
-
-This document is operationally done when:
-
-1. Search Attribute names, types, and required/optional status are fixed
-2. Memo fields for list/detail presentation are fixed
-3. default ordering and `mm_updated_at` mutation rules are fixed
-4. compatibility status mapping is fixed
-5. pagination token rules and count semantics are fixed
-6. adapter/projection layers are explicitly bound to these semantics
-7. the identifier bridge is fixed (`taskId == workflowId` for Temporal-backed rows)
-8. owner semantics are fixed (`mm_owner_type` + `mm_owner_id`)
-9. step-ledger truth is explicitly kept out of Visibility and Memo
-9. waiting metadata is fixed (`waitingReason` + `attentionRequired`)
-10. `mm_entry` values are fixed and cover the current workflow catalog
-11. the UI path for Temporal-backed rows is implemented as a first-class source
+A missing optional Search Attribute is not the same as an exact zero-result query. Avoid returning `countMode="exact"` for a result that was produced by skipping unavailable authoritative filters.
 
 ---
 
-## 17. Open follow-ups
+## 10. Provider-neutral indexing rules
 
-1. Add `entry` and `ownerType` filters to public adapter APIs if not already present
-2. Add top-level `taskId`, `ownerType`, `waitingReason`, and `attentionRequired` fields wherever adapter payloads still lack them
-3. Decide when `mm_repo` and `mm_integration` become required for specific workflow families
-4. Decide whether `/api/executions` remains a migration adapter surface or evolves into a stable public API after the legacy task-named fields retire
-5. Decide whether any additional `mm_entry` values are needed beyond the current workflow catalog
+External providers and runtime substrates must not add provider-specific Search Attributes by default.
+
+Do not add provider-specific attributes such as:
+
+```text
+mm_omnigent_session_id
+mm_omnigent_agent_id
+mm_omnigent_host_type
+mm_omnigent_harness
+mm_jules_session_id
+mm_codex_cloud_thread_id
+mm_external_provider_run_id
+```
+
+Use generic dimensions when they serve a cross-provider product query:
+
+```text
+mm_integration
+mm_target_runtime
+mm_target_skill
+mm_repo
+mm_state
+mm_owner_id
+mm_owner_type
+mm_entry
+```
+
+Provider-native details belong in:
+
+- provider-specific durable mapping tables;
+- `AgentRunResult.metadata`;
+- diagnostics artifacts;
+- artifact links;
+- step/run evidence;
+- local projection database columns if needed for non-Temporal API reads.
+
+### 10.1 Omnigent-specific posture
+
+Omnigent integration must not make Temporal Visibility an Omnigent session browser.
+
+Use:
+
+```text
+mm_integration = "omnigent"        # only if integration-level filtering/faceting is needed
+mm_target_runtime = ["omnigent"]   # or another canonical provider-backed runtime id, if product uses runtime filtering
+mm_target_skill = ["<primary skill>"]
+```
+
+Store Omnigent-native fields outside Temporal Search Attributes:
+
+```text
+omnigent_session_id
+omnigent_agent_id
+omnigent_agent_name
+omnigent_host_type
+omnigent_endpoint_ref
+first_message_state
+first_message_digest
+sse_events_ref
+final_snapshot_ref
+```
+
+Preferred locations:
+
+```text
+omnigent_external_runs
+AgentRunResult.metadata
+diagnostics artifacts
+capture manifests
+step/run evidence links
+```
+
+This keeps the custom Search Attribute budget useful for MoonMind-wide workflow queries and leaves a future MoonMind API / Omnigent Server merger path open without coupling Temporal Visibility to Omnigent's internal session model.
+
+---
+
+## 11. Deferred Search Attributes
+
+These are intentionally **not** required in v1:
+
+- `mm_stage`
+- `mm_error_category`
+- `mm_external_session_id`
+- `mm_external_provider_run_id`
+- provider-specific session ids
+- child-workflow/activity-level indexing fields
+- free-text search attributes
+- unbounded tag arrays
+- multi-skill global facet arrays
+
+If one becomes necessary, update this document first rather than adding it ad hoc in code.
+
+---
+
+## 12. Memo registry
+
+### 12.1 Required Memo fields
+
+| Field | Required | Purpose | Rules |
+|---|---:|---|---|
+| `title` | Yes | Human-readable execution title | Small, display-safe, mutable. |
+| `summary` | Yes | Compact current summary for list/detail surfaces | Small, display-safe, mutable. |
+
+### 12.2 Optional Memo fields
+
+| Field | Required | Purpose | Rules |
+|---|---:|---|---|
+| `input_ref` | No | Safe reference to input artifact | Reference only. |
+| `manifest_ref` | No | Safe reference for manifest-driven workflows | Reference only. |
+| `error_category` | No | Debug/detail classification for failures | Display/debug only. |
+| `entry_label` | No | Optional human-friendly display label | Small, bounded. |
+| `progress_hint` | No | Compact execution-level progress hint when useful | Small, bounded, never a step ledger. |
+
+Memo rules:
+
+- keep Memo small and human-readable;
+- never store secrets, full prompts, manifests, or large payloads in Memo;
+- never store step-ledger rows, attempts, `checks[]`, or long error bodies in Memo;
+- Memo is for display metadata, not filtering;
+- list views should rely on `title` and `summary`, not raw artifact payloads.
+
+---
+
+## 13. Operational review checklist for new Search Attributes
+
+Before adding a new Search Attribute, answer these questions in the PR description:
+
+1. Which user or operator query requires server-side Temporal filtering/faceting/sorting?
+2. Is the dimension generic across providers, or provider-specific?
+3. Can the value be bounded and secret-free?
+4. Is the type correct for intended queries?
+5. Does it consume one of the 10 `Keyword` slots?
+6. If it consumes a `Keyword` slot, which current Keyword becomes less important?
+7. Can the same need be met by projection DB, artifact metadata, or provider mapping table instead?
+8. Is the value set documented here?
+9. Is bootstrap idempotent and type-safe?
+10. Are missing/unregistered-attribute states handled without taking down the Workflows list?
+
+---
+
+## 14. Recommended next cleanup
+
+The current registry is serviceable, but the managed-session Keyword fields should be periodically reviewed:
+
+```text
+AgentRunId
+RuntimeId
+SessionId
+SessionStatus
+```
+
+Recommended stance:
+
+- Keep `SessionStatus` if managed-session operations rely on Temporal Web/Visibility.
+- Keep `SessionId` only if direct Temporal lookup by session id is operationally common.
+- Re-evaluate `AgentRunId` and `RuntimeId` because app DB/store lookups and generic runtime dimensions may cover those use cases without consuming Keyword slots.
+- Re-evaluate `mm_has_dependencies` and `mm_dependency_count` if no production query uses them.
+
+Do not replace these with provider-specific fields. Free slots should be reserved for future generic MoonMind workflow dimensions.


### PR DESCRIPTION
## Summary

- Reworks `docs/Omnigent/OmnigentAdapter.md` with the latest Omnigent research folded into the canonical adapter design.
- Clarifies that v1 treats Omnigent as a single external provider identity (`agentId=omnigent`) and preserves MoonMind/Temporal/artifact boundaries.
- Documents upstream compatibility notes for managed repository workspaces, optional/capability-probed diff harvest, Omnigent auth topology, and future MoonMind API / Omnigent Server merger posture.
- Updates `docs/Temporal/VisibilityAndUiQueryModel.md` to make the current custom Search Attribute registry and 10-Keyword budget explicit.
- Adds provider-neutral indexing rules, including guidance that Omnigent-native session details belong in mapping tables, result metadata, diagnostics, and artifacts rather than Temporal Search Attributes.

## Why

We want future MoonMind workflow, visibility, and runtime decisions to be made with explicit awareness of the minimal OmnigentAdapter goal and the stretch goal of a less painful future MoonMind API / Omnigent Server convergence.

The main architectural constraints captured here are:

- MoonMind should integrate with Omnigent at the session/resource/artifact boundary, not the process/container boundary in v1.
- MoonMind artifacts remain authoritative evidence.
- Omnigent SSE is live-tail observation, not durable replay.
- The adapter needs durable first-message/session idempotency before any serious v1 implementation.
- Temporal Search Attributes should remain generic and provider-neutral.

## Validation

- Used the GitHub connector to compare the branch against `main`; the diff is docs-only:
  - `docs/Omnigent/OmnigentAdapter.md`
  - `docs/Temporal/VisibilityAndUiQueryModel.md`
- No code/test execution was run because the changes are documentation-only and the local environment does not have `gh` or repository checkout access.