### PR TITLE
Fix workflow detail routing and plan retry timeout

### DIFF
--- a/frontend/src/entrypoints/dashboard.test.tsx
+++ b/frontend/src/entrypoints/dashboard.test.tsx
@@ -292,6 +292,18 @@ describe('Dashboard shared entry', () => {
     expect(screen.queryByText('Dashboard configuration error')).toBeNull();
   });
 
+  it('routes percent-encoded workflow detail IDs through the shared shell', async () => {
+    const encodedPath = '/workflows/mm%3A97d44980-355c-4300-96a7-0ad166440d95';
+    window.history.replaceState({}, '', encodedPath);
+
+    renderWithClient(<DashboardApp payload={{ page: 'dashboard', apiBase: '/api' }} />);
+
+    expect(
+      await screen.findByText(`Workflow detail initial path: ${encodedPath}`),
+    ).toBeTruthy();
+    expect(screen.queryByText(/Unknown dashboard page:/i)).toBeNull();
+  });
+
   it('recovers from a failed lazy page import when the user retries (MM-960)', async () => {
     const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     try {

--- a/frontend/src/lib/dashboardRoutes.test.ts
+++ b/frontend/src/lib/dashboardRoutes.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveDashboardRoute } from './dashboardRoutes';
+
+describe('dashboard route resolution', () => {
+  it('resolves percent-encoded workflow detail IDs', () => {
+    const path = '/workflows/mm%3A97d44980-355c-4300-96a7-0ad166440d95';
+
+    expect(resolveDashboardRoute(path)).toEqual({
+      page: 'workflow-detail',
+      dataWidePanel: false,
+      currentPath: path,
+    });
+  });
+
+  it('resolves encoded workflow IDs with detail tabs', () => {
+    const path = '/workflows/mm%3A97d44980-355c-4300-96a7-0ad166440d95/steps';
+
+    expect(resolveDashboardRoute(path)?.page).toBe('workflow-detail');
+  });
+
+  it('rejects encoded slashes inside workflow IDs', () => {
+    expect(resolveDashboardRoute('/workflows/mm%2Fbad')).toBeNull();
+  });
+
+  it('resolves encoded manifest and schedule detail IDs', () => {
+    expect(resolveDashboardRoute('/manifests/default%3Aworkflow')?.page).toBe(
+      'manifests',
+    );
+    expect(resolveDashboardRoute('/schedules/nightly%3Abuild')?.page).toBe(
+      'schedules',
+    );
+  });
+});

--- a/frontend/src/lib/dashboardRoutes.test.ts
+++ b/frontend/src/lib/dashboardRoutes.test.ts
@@ -19,6 +19,21 @@ describe('dashboard route resolution', () => {
     expect(resolveDashboardRoute(path)?.page).toBe('workflow-detail');
   });
 
+  it('resolves reserved-looking workflow IDs as detail pages', () => {
+    for (const path of [
+      '/workflows/settings',
+      '/workflows/schedules',
+      '/workflows/workers',
+      '/workflows/settings/steps',
+    ]) {
+      expect(resolveDashboardRoute(path)?.page).toBe('workflow-detail');
+    }
+  });
+
+  it('keeps the new workflow route on the start page', () => {
+    expect(resolveDashboardRoute('/workflows/new')?.page).toBe('workflow-start');
+  });
+
   it('rejects encoded slashes inside workflow IDs', () => {
     expect(resolveDashboardRoute('/workflows/mm%2Fbad')).toBeNull();
   });

--- a/frontend/src/lib/dashboardRoutes.ts
+++ b/frontend/src/lib/dashboardRoutes.ts
@@ -30,9 +30,22 @@ export type DashboardUiInfo = {
   workerPause?: unknown;
 };
 
-const WORKFLOW_DETAIL_PATH = /^\/workflows\/[A-Za-z0-9][A-Za-z0-9._:{}-]{0,254}(?:\/(?:steps|artifacts|runs|debug))?$/;
-const MANIFEST_DETAIL_PATH = /^\/manifests\/[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/;
-const SCHEDULE_DETAIL_PATH = /^\/schedules\/[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/;
+const DETAIL_SEGMENT = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/;
+const WORKFLOW_ID_SEGMENT = /^[A-Za-z0-9][A-Za-z0-9._:{}-]{0,254}$/;
+const WORKFLOW_DETAIL_TABS = new Set(['steps', 'artifacts', 'runs', 'debug']);
+const RESERVED_WORKFLOW_ROUTE_SEGMENTS = new Set([
+  'manifests',
+  'new',
+  'proposals',
+  'queue',
+  'schedules',
+  'secrets',
+  'settings',
+  'skills',
+  'system',
+  'temporal',
+  'workers',
+]);
 
 function withoutTrailingSlash(pathname: string): string {
   return pathname.length > 1 && pathname.endsWith('/') ? pathname.slice(0, -1) : pathname;
@@ -41,6 +54,51 @@ function withoutTrailingSlash(pathname: string): string {
 function hasExtension(pathname: string): boolean {
   const leaf = pathname.split('/').pop() ?? '';
   return /\.[A-Za-z0-9]+$/.test(leaf);
+}
+
+function decodePathSegment(segment: string): string | null {
+  try {
+    const decoded = decodeURIComponent(segment);
+    return decoded.includes('/') ? null : decoded;
+  } catch {
+    return null;
+  }
+}
+
+function pathParts(path: string): string[] {
+  return path.split('/').slice(1);
+}
+
+function isWorkflowDetailPath(path: string): boolean {
+  const parts = pathParts(path);
+  if (parts.length !== 2 && parts.length !== 3) {
+    return false;
+  }
+  if (parts[0] !== 'workflows') {
+    return false;
+  }
+  const workflowId = decodePathSegment(parts[1]);
+  if (
+    !workflowId ||
+    !WORKFLOW_ID_SEGMENT.test(workflowId) ||
+    RESERVED_WORKFLOW_ROUTE_SEGMENTS.has(workflowId.toLowerCase())
+  ) {
+    return false;
+  }
+  if (parts.length === 2) {
+    return true;
+  }
+  const tab = decodePathSegment(parts[2]);
+  return Boolean(tab && WORKFLOW_DETAIL_TABS.has(tab));
+}
+
+function isDetailPath(path: string, prefix: 'manifests' | 'schedules'): boolean {
+  const parts = pathParts(path);
+  if (parts.length !== 2 || parts[0] !== prefix) {
+    return false;
+  }
+  const detailId = decodePathSegment(parts[1]);
+  return Boolean(detailId && DETAIL_SEGMENT.test(detailId));
 }
 
 export function resolveDashboardRoute(pathname: string): DashboardRoute | null {
@@ -54,7 +112,7 @@ export function resolveDashboardRoute(pathname: string): DashboardRoute | null {
   if (path === '/workflows/new') {
     return { page: 'workflow-start', dataWidePanel: false, currentPath: path };
   }
-  if (WORKFLOW_DETAIL_PATH.test(path) && path !== '/workflows/new') {
+  if (isWorkflowDetailPath(path) && path !== '/workflows/new') {
     return { page: 'workflow-detail', dataWidePanel: false, currentPath: path };
   }
   if (path === '/settings' || path.startsWith('/settings/')) {
@@ -63,10 +121,10 @@ export function resolveDashboardRoute(pathname: string): DashboardRoute | null {
   if (path === '/skills' || path.startsWith('/skills/')) {
     return { page: 'skills', dataWidePanel: false, currentPath: path };
   }
-  if (path === '/schedules' || SCHEDULE_DETAIL_PATH.test(path)) {
+  if (path === '/schedules' || isDetailPath(path, 'schedules')) {
     return { page: 'schedules', dataWidePanel: false, currentPath: path };
   }
-  if (path === '/manifests' || MANIFEST_DETAIL_PATH.test(path)) {
+  if (path === '/manifests' || isDetailPath(path, 'manifests')) {
     return { page: 'manifests', dataWidePanel: false, currentPath: path };
   }
   if (path === '/index-health') {

--- a/frontend/src/lib/dashboardRoutes.ts
+++ b/frontend/src/lib/dashboardRoutes.ts
@@ -33,19 +33,6 @@ export type DashboardUiInfo = {
 const DETAIL_SEGMENT = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/;
 const WORKFLOW_ID_SEGMENT = /^[A-Za-z0-9][A-Za-z0-9._:{}-]{0,254}$/;
 const WORKFLOW_DETAIL_TABS = new Set(['steps', 'artifacts', 'runs', 'debug']);
-const RESERVED_WORKFLOW_ROUTE_SEGMENTS = new Set([
-  'manifests',
-  'new',
-  'proposals',
-  'queue',
-  'schedules',
-  'secrets',
-  'settings',
-  'skills',
-  'system',
-  'temporal',
-  'workers',
-]);
 
 function withoutTrailingSlash(pathname: string): string {
   return pathname.length > 1 && pathname.endsWith('/') ? pathname.slice(0, -1) : pathname;
@@ -77,18 +64,22 @@ function isWorkflowDetailPath(path: string): boolean {
   if (parts[0] !== 'workflows') {
     return false;
   }
-  const workflowId = decodePathSegment(parts[1]);
-  if (
-    !workflowId ||
-    !WORKFLOW_ID_SEGMENT.test(workflowId) ||
-    RESERVED_WORKFLOW_ROUTE_SEGMENTS.has(workflowId.toLowerCase())
-  ) {
+  const workflowIdSegment = parts[1];
+  if (!workflowIdSegment) {
+    return false;
+  }
+  const workflowId = decodePathSegment(workflowIdSegment);
+  if (!workflowId || !WORKFLOW_ID_SEGMENT.test(workflowId)) {
     return false;
   }
   if (parts.length === 2) {
     return true;
   }
-  const tab = decodePathSegment(parts[2]);
+  const tabSegment = parts[2];
+  if (!tabSegment) {
+    return false;
+  }
+  const tab = decodePathSegment(tabSegment);
   return Boolean(tab && WORKFLOW_DETAIL_TABS.has(tab));
 }
 
@@ -97,7 +88,11 @@ function isDetailPath(path: string, prefix: 'manifests' | 'schedules'): boolean 
   if (parts.length !== 2 || parts[0] !== prefix) {
     return false;
   }
-  const detailId = decodePathSegment(parts[1]);
+  const detailIdSegment = parts[1];
+  if (!detailIdSegment) {
+    return false;
+  }
+  const detailId = decodePathSegment(detailIdSegment);
   return Boolean(detailId && DETAIL_SEGMENT.test(detailId));
 }
 

--- a/moonmind/workflows/temporal/activity_catalog.py
+++ b/moonmind/workflows/temporal/activity_catalog.py
@@ -506,7 +506,7 @@ def build_default_activity_catalog(
             capability_class="llm",
             task_queue=cfg.activity_llm_task_queue,
             fleet=LLM_FLEET,
-            timeouts=TemporalActivityTimeouts(600, 600),
+            timeouts=TemporalActivityTimeouts(300, 900),
             retries=_activity_retries(max_attempts=3, max_interval_seconds=120),
         ),
         TemporalActivityDefinition(

--- a/tests/unit/workflows/temporal/test_activity_catalog.py
+++ b/tests/unit/workflows/temporal/test_activity_catalog.py
@@ -124,6 +124,19 @@ def test_default_catalog_exposes_canonical_queues_and_fleets():
     assert "deployment_control" in fleets[DEPLOYMENT_FLEET].capabilities
     assert "docker_workload" in fleets[AGENT_RUNTIME_FLEET].capabilities
 
+def test_plan_generate_timeout_budget_allows_retry_after_attempt_timeout():
+    catalog = build_default_activity_catalog()
+
+    route = catalog.resolve_activity("plan.generate")
+
+    assert route.timeouts.start_to_close_seconds == 300
+    assert route.timeouts.schedule_to_close_seconds == 900
+    assert (
+        route.timeouts.schedule_to_close_seconds
+        > route.timeouts.start_to_close_seconds
+    )
+    assert route.retries.max_attempts == 3
+
 def test_resolve_skill_uses_capability_routing_for_mm_skill_execute():
     catalog = build_default_activity_catalog()
 


### PR DESCRIPTION
## Summary
- Decode dashboard route path segments before matching workflow, manifest, and schedule detail routes so `/workflows/mm%3A...` reaches the workflow detail page instead of the unknown-page fallback.
- Add frontend regression coverage for percent-encoded workflow detail IDs.
- Give `plan.generate` a 300s per-attempt timeout within a 900s schedule-to-close budget so its existing retry policy can recover from a stuck first attempt.

## Failure diagnosis
- `mm:97d44980-355c-4300-96a7-0ad166440d95` failed while running `plan.generate` on `mm.activity.llm`.
- Temporal scheduled the activity at `2026-06-30T01:07:27Z`, started it immediately, then timed it out exactly 600 seconds later with `ScheduleToClose timeout`.
- The catalog previously set both start-to-close and schedule-to-close to 600s, so one stuck attempt consumed the whole retry window and the configured 3 attempts could not run.

## Tests
- `npm run ui:test -- frontend/src/lib/dashboardRoutes.test.ts frontend/src/entrypoints/dashboard.test.tsx`
- `MOONMIND_DISABLE_DEFAULT_USER_DB_LOOKUP=1 MOONMIND_ALLOW_LIVE_TEMPORAL_IN_TESTS=0 .venv/bin/python -m pytest -q -p no:cacheprovider tests/unit/workflows/temporal/test_activity_catalog.py`

Note: `./tools/test_unit.sh ...` is currently blocked in this workspace before tests start because `tools/check_removed_capability_semantics.py` cannot read the local root-owned `deploy/state/desired-state.json` file.