### PR TITLE
MM-1054 Complete Skill input contract normalization

### DIFF
--- a/api_service/api/routers/workflow_console.py
+++ b/api_service/api/routers/workflow_console.py
@@ -12,6 +12,7 @@ import tempfile
 import uuid
 import zipfile
 from collections.abc import Callable
+from dataclasses import dataclass
 from html import escape
 from pathlib import Path, PurePosixPath
 from typing import Literal
@@ -41,7 +42,10 @@ from api_service.api.routers.workflow_console_view_model import (
 from api_service.auth_providers import get_current_user
 from api_service.db.models import User
 from api_service.services.settings_catalog import settings_permissions_for_user
-from moonmind.capabilities.input_contracts import parse_skill_capability_input_contract
+from moonmind.capabilities.input_contracts import (
+    content_digest_for_text,
+    parse_skill_capability_input_contract,
+)
 from moonmind.config.settings import settings
 from moonmind.services.skill_resolution import (
     extract_required_capabilities_from_skill_markdown,
@@ -85,6 +89,19 @@ _MAX_SKILL_UNCOMPRESSED_BYTES = 200 * 1024 * 1024
 _MAX_SKILL_FILE_BYTES = 25 * 1024 * 1024
 _MAX_SKILL_ZIP_ENTRIES = 500
 _IMPORTED_SKILL_NAME_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+_SKILL_INPUT_CONTRACT_CACHE_MAX = 256
+
+
+@dataclass(frozen=True, slots=True)
+class _CachedSkillInputContract:
+    content_digest: str
+    contract: dict[str, object]
+
+
+_SKILL_INPUT_CONTRACT_CACHE: dict[
+    tuple[str, str, int, int],
+    _CachedSkillInputContract,
+] = {}
 
 _DASHBOARD_ROUTE_NOT_FOUND_DETAIL = {
     "code": "dashboard_route_not_found",
@@ -177,6 +194,44 @@ class DashboardUiInfoResponse(BaseModel):
         alias="settingsPermissions",
     )
     worker_pause: dict = Field(default_factory=dict, alias="workerPause")
+
+
+async def _read_file_backed_skill_input_contract(
+    *,
+    skill_id: str,
+    label: str,
+    skill_file: Path,
+    source_kind: str,
+) -> tuple[str, dict[str, object]]:
+    """Read and parse a SKILL.md contract using content evidence as cache proof."""
+
+    stat_result = await asyncio.to_thread(skill_file.stat)
+    cache_key = (
+        str(skill_file.resolve()),
+        skill_id,
+        stat_result.st_mtime_ns,
+        stat_result.st_size,
+    )
+    skill_markdown = await asyncio.to_thread(skill_file.read_text, encoding="utf-8")
+    content_digest = content_digest_for_text(skill_markdown)
+    cached = _SKILL_INPUT_CONTRACT_CACHE.get(cache_key)
+    if cached is not None and cached.content_digest == content_digest:
+        return skill_markdown, dict(cached.contract)
+
+    contract = parse_skill_capability_input_contract(
+        skill_id=skill_id,
+        label=label,
+        markdown=skill_markdown,
+        source={"kind": source_kind, "path": str(skill_file)},
+    )
+    _SKILL_INPUT_CONTRACT_CACHE[cache_key] = _CachedSkillInputContract(
+        content_digest=content_digest,
+        contract=dict(contract),
+    )
+    if len(_SKILL_INPUT_CONTRACT_CACHE) > _SKILL_INPUT_CONTRACT_CACHE_MAX:
+        oldest_key = next(iter(_SKILL_INPUT_CONTRACT_CACHE))
+        _SKILL_INPUT_CONTRACT_CACHE.pop(oldest_key, None)
+    return skill_markdown, dict(contract)
 
 class _ValidatedSkillZip(BaseModel):
     skill_name: str
@@ -928,15 +983,11 @@ async def list_dashboard_skills(
         required_capabilities: list[str] = []
         skill_file = resolve_skill_markdown_path(skill_id)
         if skill_file is not None:
-            skill_markdown = await asyncio.to_thread(
-                skill_file.read_text,
-                encoding="utf-8",
-            )
-            contract = parse_skill_capability_input_contract(
+            skill_markdown, contract = await _read_file_backed_skill_input_contract(
                 skill_id=skill_id,
                 label=skill_id,
-                markdown=skill_markdown,
-                source={"kind": "local", "path": str(skill_file)},
+                skill_file=skill_file,
+                source_kind="local",
             )
             required_capabilities = list(
                 extract_required_capabilities_from_skill_markdown(

--- a/api_service/services/agent_skills_service.py
+++ b/api_service/services/agent_skills_service.py
@@ -14,6 +14,7 @@ from api_service.db.models import (
     AgentSkillFormat,
     SkillSet,
 )
+from moonmind.capabilities.input_contracts import parse_skill_capability_input_contract
 from moonmind.services.skill_resolution import (
     extract_required_capabilities_from_skill_markdown,
     extract_required_skill_names_from_skill_markdown,
@@ -110,6 +111,12 @@ class AgentSkillsService:
             skill_name=skill_slug,
             source_label=f"deployment skill '{skill_slug}'",
         )
+        input_contract = parse_skill_capability_input_contract(
+            skill_id=skill_slug,
+            label=skill.title or skill_slug,
+            markdown=content,
+            source={"kind": "deployment"},
+        )
 
         try:
             parsed_format = AgentSkillFormat(format_str)
@@ -127,6 +134,12 @@ class AgentSkillsService:
                 "format": format_str,
                 "required_skills": list(required_skills),
                 "required_capabilities": list(required_capabilities),
+                "input_schema": input_contract.get("inputSchema", {}),
+                "ui_schema": input_contract.get("uiSchema", {}),
+                "defaults": input_contract.get("defaults", {}),
+                "input_contract_digest": input_contract.get("contractDigest"),
+                "input_schema_diagnostics": input_contract.get("diagnostics", []),
+                "content_digest": input_contract.get("contentDigest"),
             },
         )
         artifact = await self._artifact_service.write_complete(

--- a/moonmind/capabilities/input_contracts.py
+++ b/moonmind/capabilities/input_contracts.py
@@ -15,8 +15,86 @@ import yaml
 CapabilityKind = Literal["tool", "skill", "preset"]
 
 PARSER_VERSION = "capability-input-contracts:v1"
+MAX_FRONTMATTER_BYTES = 64 * 1024
+MAX_INPUT_SCHEMA_BYTES = 128 * 1024
+MAX_UI_SCHEMA_BYTES = 64 * 1024
+MAX_DEFAULTS_BYTES = 64 * 1024
+
+_SUPPORTED_SCHEMA_KEYWORDS = frozenset(
+    {
+        "$defs",
+        "$schema",
+        "additionalProperties",
+        "anyOf",
+        "default",
+        "description",
+        "enum",
+        "examples",
+        "exclusiveMaximum",
+        "exclusiveMinimum",
+        "format",
+        "items",
+        "maxItems",
+        "maxLength",
+        "maximum",
+        "minItems",
+        "minLength",
+        "minimum",
+        "oneOf",
+        "pattern",
+        "properties",
+        "required",
+        "title",
+        "type",
+    }
+)
+_DIAGNOSED_SAFE_SCHEMA_KEYWORDS = frozenset(
+    {
+        "allOf",
+        "contains",
+        "dependentRequired",
+        "dependentSchemas",
+        "if",
+        "not",
+        "patternProperties",
+        "prefixItems",
+        "then",
+        "unevaluatedProperties",
+    }
+)
+_SUPPORTED_MOONMIND_HINTS = frozenset(
+    {
+        "x-moonmind-context-default",
+        "x-moonmind-multiline",
+        "x-moonmind-provider",
+        "x-moonmind-semantic-type",
+        "x-moonmind-widget",
+    }
+)
+_SUPPORTED_WIDGETS = frozenset(
+    {
+        "checkbox",
+        "file-reference-picker",
+        "github.branch-picker",
+        "github.issue-picker",
+        "github.repository-picker",
+        "jira.issue-picker",
+        "json",
+        "markdown",
+        "model-picker",
+        "multi-select",
+        "number",
+        "provider.profile-picker",
+        "select",
+        "text",
+        "textarea",
+    }
+)
 _SECRET_LIKE_VALUE_PATTERN = re.compile(
-    r"(token=|password=|bearer\s+|ghp_|github_pat_|akia[0-9a-z]{16}|aiza|atatt|-----begin [a-z ]*private key)",
+    (
+        r"(token=|password=|bearer\s+|ghp_|github_pat_|akia[0-9a-z]{16}|"
+        r"aiza|atatt|-----begin [a-z ]*private key)"
+    ),
     re.IGNORECASE,
 )
 
@@ -49,7 +127,9 @@ def content_digest_for_text(content: str) -> str:
     return "sha256:" + hashlib.sha256(content.encode("utf-8")).hexdigest()
 
 
-def parse_skill_markdown_frontmatter(content: str) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+def parse_skill_markdown_frontmatter(
+    content: str,
+) -> tuple[dict[str, Any], list[dict[str, Any]]]:
     """Parse YAML frontmatter from a SKILL.md file with a safe loader."""
 
     if not content.startswith("---"):
@@ -60,19 +140,36 @@ def parse_skill_markdown_frontmatter(content: str) -> tuple[dict[str, Any], list
         return {}, [
             _diagnostic(
                 code="frontmatter_unclosed",
-                message="Skill frontmatter is not closed; structured metadata was ignored.",
+                message=(
+                    "Skill frontmatter is not closed; structured metadata was ignored."
+                ),
                 severity="warning",
                 path="frontmatter",
             )
         ]
     raw_frontmatter = content[3:end]
+    if len(raw_frontmatter.encode("utf-8")) > MAX_FRONTMATTER_BYTES:
+        return {}, [
+            _diagnostic(
+                code="frontmatter_too_large",
+                message=(
+                    "Skill frontmatter exceeds the supported size; structured "
+                    "metadata was ignored."
+                ),
+                severity="warning",
+                path="frontmatter",
+            )
+        ]
     try:
         parsed = yaml.safe_load(raw_frontmatter) or {}
     except yaml.YAMLError as exc:
         return {}, [
             _diagnostic(
                 code="frontmatter_yaml_invalid",
-                message="Skill frontmatter YAML could not be parsed; structured metadata was ignored.",
+                message=(
+                    "Skill frontmatter YAML could not be parsed; structured "
+                    "metadata was ignored."
+                ),
                 severity="warning",
                 path="frontmatter",
                 details={"error": str(exc)},
@@ -82,7 +179,10 @@ def parse_skill_markdown_frontmatter(content: str) -> tuple[dict[str, Any], list
         return {}, [
             _diagnostic(
                 code="frontmatter_not_object",
-                message="Skill frontmatter must be a YAML mapping; structured metadata was ignored.",
+                message=(
+                    "Skill frontmatter must be a YAML mapping; structured "
+                    "metadata was ignored."
+                ),
                 severity="warning",
                 path="frontmatter",
             )
@@ -96,13 +196,33 @@ def parse_capability_input_contract(
     """Extract schema metadata using accepted source casing."""
 
     metadata = raw_metadata or {}
+    diagnostics: list[dict[str, Any]] = []
     input_schema = _first_mapping(metadata, "inputSchema", "input_schema")
     ui_schema = _first_mapping(metadata, "uiSchema", "ui_schema")
     defaults = _first_mapping(metadata, "defaults")
+    input_schema = _bounded_mapping(
+        input_schema,
+        path="inputSchema",
+        max_bytes=MAX_INPUT_SCHEMA_BYTES,
+        diagnostics=diagnostics,
+    )
+    ui_schema = _bounded_mapping(
+        ui_schema,
+        path="uiSchema",
+        max_bytes=MAX_UI_SCHEMA_BYTES,
+        diagnostics=diagnostics,
+    )
+    defaults = _bounded_mapping(
+        defaults,
+        path="defaults",
+        max_bytes=MAX_DEFAULTS_BYTES,
+        diagnostics=diagnostics,
+    )
     return CapabilityInputContractParts(
         input_schema=_json_compatible_mapping(input_schema),
         ui_schema=_json_compatible_mapping(ui_schema),
         defaults=_json_compatible_mapping(defaults),
+        diagnostics=diagnostics,
     )
 
 
@@ -161,7 +281,8 @@ def normalize_capability_input_contract(
 
     if input_schema:
         root_type = input_schema.get("type")
-        if root_type != "object" or not isinstance(input_schema.get("properties", {}), Mapping):
+        properties = input_schema.get("properties", {})
+        if root_type != "object" or not isinstance(properties, Mapping):
             diagnostics.append(
                 _diagnostic(
                     code="input_schema_root_not_object",
@@ -174,17 +295,26 @@ def normalize_capability_input_contract(
                 )
             )
             input_schema = {}
-
-    if _contains_secret_like_value(defaults):
-        diagnostics.append(
-            _diagnostic(
-                code="defaults_secret_like_value",
-                message="Capability defaults contained a secret-like value and were omitted.",
-                severity="warning",
-                path="defaults",
+        else:
+            input_schema, schema_diagnostics = _normalize_schema_metadata(
+                input_schema,
+                path="inputSchema",
             )
+            diagnostics.extend(schema_diagnostics)
+
+    if input_schema:
+        input_schema, schema_default_diagnostics = _remove_secret_like_schema_defaults(
+            input_schema,
+            path="inputSchema",
         )
-        defaults = {}
+        diagnostics.extend(schema_default_diagnostics)
+
+    defaults, default_diagnostics = _remove_secret_like_defaults(defaults)
+    diagnostics.extend(default_diagnostics)
+
+    if ui_schema:
+        ui_schema, ui_diagnostics = _normalize_ui_schema_metadata(ui_schema)
+        diagnostics.extend(ui_diagnostics)
 
     digest_payload = {
         "parserVersion": PARSER_VERSION,
@@ -195,7 +325,11 @@ def normalize_capability_input_contract(
         "defaults": defaults,
     }
     contract_digest = "sha256:" + hashlib.sha256(
-        json.dumps(digest_payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        json.dumps(
+            digest_payload,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
     ).hexdigest()
 
     contract: dict[str, Any] = {
@@ -215,6 +349,79 @@ def normalize_capability_input_contract(
     if owner.source:
         contract["source"] = dict(owner.source)
     return contract
+
+
+def validate_capability_inputs(
+    *,
+    contract: Mapping[str, Any],
+    values: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    """Validate values against MoonMind's supported capability schema subset."""
+
+    input_schema = contract.get("inputSchema")
+    if not isinstance(input_schema, Mapping):
+        input_schema = {}
+    defaults = contract.get("defaults")
+    if not isinstance(defaults, Mapping):
+        defaults = {}
+    merged_values = {**dict(defaults), **dict(values or {})}
+    errors: list[dict[str, Any]] = []
+    properties = input_schema.get("properties")
+    if not isinstance(properties, Mapping):
+        properties = {}
+
+    required = input_schema.get("required")
+    required_names = required if isinstance(required, Sequence) else []
+    for raw_name in required_names:
+        name = str(raw_name)
+        if name not in merged_values or merged_values.get(name) in (None, ""):
+            errors.append(_validation_error(name, "required", "Field is required."))
+
+    for name, field_schema in properties.items():
+        if not isinstance(field_schema, Mapping) or name not in merged_values:
+            continue
+        value = merged_values[name]
+        if value is None:
+            continue
+        expected_type = field_schema.get("type")
+        if isinstance(expected_type, str) and not _value_matches_schema_type(
+            value,
+            expected_type,
+        ):
+            errors.append(
+                _validation_error(
+                    str(name),
+                    "type",
+                    f"Field must be a JSON Schema {expected_type} value.",
+                )
+            )
+            continue
+        allowed_values = field_schema.get("enum")
+        if isinstance(allowed_values, Sequence) and not isinstance(
+            allowed_values,
+            (str, bytes, bytearray),
+        ):
+            if value not in list(allowed_values):
+                errors.append(
+                    _validation_error(str(name), "enum", "Field value is not allowed.")
+                )
+        field_format = field_schema.get("format")
+        if isinstance(field_format, str) and isinstance(value, str):
+            if not _value_matches_format(value, field_format):
+                errors.append(
+                    _validation_error(
+                        str(name),
+                        "format",
+                        f"Field must match the {field_format} format.",
+                    )
+                )
+
+    return {
+        "values": merged_values,
+        "errors": errors,
+        "warnings": list(contract.get("diagnostics") or []),
+        "contractDigest": contract.get("contractDigest"),
+    }
 
 
 def parse_skill_capability_input_contract(
@@ -309,6 +516,280 @@ def _contains_secret_like_value(value: Any) -> bool:
     if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
         return any(_contains_secret_like_value(item) for item in value)
     return bool(_SECRET_LIKE_VALUE_PATTERN.search(str(value or "")))
+
+
+def _bounded_mapping(
+    value: Mapping[str, Any] | None,
+    *,
+    path: str,
+    max_bytes: int,
+    diagnostics: list[dict[str, Any]],
+) -> Mapping[str, Any] | None:
+    if not isinstance(value, Mapping):
+        return None
+    if _json_size_bytes(_json_compatible_mapping(value) or {}) <= max_bytes:
+        return value
+    diagnostics.append(
+        _diagnostic(
+            code="metadata_too_large",
+            message=f"Capability {path} exceeds the supported size and was omitted.",
+            severity="warning",
+            path=path,
+        )
+    )
+    return None
+
+
+def _json_size_bytes(value: Any) -> int:
+    return len(
+        json.dumps(
+            value,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    )
+
+
+def _normalize_schema_metadata(
+    schema: Mapping[str, Any],
+    *,
+    path: str,
+) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    diagnostics: list[dict[str, Any]] = []
+    normalized: dict[str, Any] = {}
+    for key, value in schema.items():
+        key_str = str(key)
+        child_path = f"{path}.{key_str}"
+        if _is_preserved_schema_key(key_str):
+            if isinstance(value, Mapping):
+                if key_str in {"properties", "$defs"}:
+                    child_properties: dict[str, Any] = {}
+                    for child_key, child_value in value.items():
+                        if isinstance(child_value, Mapping):
+                            normalized_child, child_diagnostics = (
+                                _normalize_schema_metadata(
+                                    child_value,
+                                    path=f"{child_path}.{child_key}",
+                                )
+                            )
+                            child_properties[str(child_key)] = normalized_child
+                            diagnostics.extend(child_diagnostics)
+                        else:
+                            child_properties[str(child_key)] = _json_compatible_value(
+                                child_value
+                            )
+                    normalized[key_str] = child_properties
+                else:
+                    normalized[key_str], nested = _normalize_schema_metadata(
+                        value,
+                        path=child_path,
+                    )
+                    diagnostics.extend(nested)
+            elif isinstance(value, Sequence) and not isinstance(
+                value,
+                (str, bytes, bytearray),
+            ):
+                items: list[Any] = []
+                for item in value:
+                    if isinstance(item, Mapping):
+                        normalized_item, item_diagnostics = _normalize_schema_metadata(
+                            item,
+                            path=f"{child_path}[]",
+                        )
+                        items.append(normalized_item)
+                        diagnostics.extend(item_diagnostics)
+                    else:
+                        items.append(_json_compatible_value(item))
+                normalized[key_str] = items
+            else:
+                normalized[key_str] = _json_compatible_value(value)
+        elif key_str.startswith("x-moonmind-"):
+            normalized[key_str] = _json_compatible_value(value)
+            diagnostics.append(
+                _diagnostic(
+                    code="ignored_hint",
+                    message=(
+                        f"Unsupported MoonMind input hint '{key_str}' was "
+                        "preserved as metadata only."
+                    ),
+                    severity="warning",
+                    path=child_path,
+                )
+            )
+        elif key_str in _DIAGNOSED_SAFE_SCHEMA_KEYWORDS:
+            normalized[key_str] = _json_compatible_value(value)
+            diagnostics.append(
+                _diagnostic(
+                    code="unsupported_keyword",
+                    message=(
+                        f"JSON Schema keyword '{key_str}' is preserved but not "
+                        "interpreted by generated fields."
+                    ),
+                    severity="warning",
+                    path=child_path,
+                )
+            )
+        else:
+            diagnostics.append(
+                _diagnostic(
+                    code="unsupported_keyword",
+                    message=f"Unsupported schema metadata '{key_str}' was ignored.",
+                    severity="warning",
+                    path=child_path,
+                )
+            )
+    return normalized, diagnostics
+
+
+def _is_preserved_schema_key(key: str) -> bool:
+    return key in _SUPPORTED_SCHEMA_KEYWORDS or key in _SUPPORTED_MOONMIND_HINTS
+
+
+def _remove_secret_like_schema_defaults(
+    value: Any,
+    *,
+    path: str,
+) -> tuple[Any, list[dict[str, Any]]]:
+    diagnostics: list[dict[str, Any]] = []
+    if isinstance(value, Mapping):
+        sanitized: dict[str, Any] = {}
+        for key, item in value.items():
+            child_path = f"{path}.{key}"
+            if str(key) == "default" and _contains_secret_like_value(item):
+                diagnostics.append(
+                    _diagnostic(
+                        code="defaults_secret_like_value",
+                        message=(
+                            "Capability schema default contained a secret-like "
+                            "value and was omitted."
+                        ),
+                        severity="warning",
+                        path=child_path,
+                    )
+                )
+                continue
+            sanitized_value, child_diagnostics = _remove_secret_like_schema_defaults(
+                item,
+                path=child_path,
+            )
+            sanitized[str(key)] = sanitized_value
+            diagnostics.extend(child_diagnostics)
+        return sanitized, diagnostics
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        sanitized_items: list[Any] = []
+        for index, item in enumerate(value):
+            sanitized_item, child_diagnostics = _remove_secret_like_schema_defaults(
+                item,
+                path=f"{path}[{index}]",
+            )
+            sanitized_items.append(sanitized_item)
+            diagnostics.extend(child_diagnostics)
+        return sanitized_items, diagnostics
+    return value, diagnostics
+
+
+def _remove_secret_like_defaults(
+    defaults: Mapping[str, Any],
+) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    diagnostics: list[dict[str, Any]] = []
+    sanitized: dict[str, Any] = {}
+    for key, value in defaults.items():
+        if _contains_secret_like_value(value):
+            diagnostics.append(
+                _diagnostic(
+                    code="defaults_secret_like_value",
+                    message=(
+                        "Capability defaults contained a secret-like value "
+                        "and were omitted."
+                    ),
+                    severity="warning",
+                    path=f"defaults.{key}",
+                )
+            )
+            continue
+        sanitized[str(key)] = value
+    return sanitized, diagnostics
+
+
+def _normalize_ui_schema_metadata(
+    ui_schema: Mapping[str, Any],
+) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    diagnostics: list[dict[str, Any]] = []
+    normalized = _json_compatible_mapping(ui_schema) or {}
+    for field_name, field_ui_schema in normalized.items():
+        if not isinstance(field_ui_schema, Mapping):
+            diagnostics.append(
+                _diagnostic(
+                    code="unsupported_widget",
+                    message="uiSchema field metadata must be an object.",
+                    severity="warning",
+                    path=f"uiSchema.{field_name}",
+                )
+            )
+            continue
+        widget = field_ui_schema.get("widget")
+        if isinstance(widget, str) and widget not in _SUPPORTED_WIDGETS:
+            diagnostics.append(
+                _diagnostic(
+                    code="unsupported_widget",
+                    message=(
+                        f"Unsupported widget '{widget}' will use a safe renderer "
+                        "fallback."
+                    ),
+                    severity="warning",
+                    path=f"uiSchema.{field_name}.widget",
+                )
+            )
+    return normalized, diagnostics
+
+
+def _value_matches_schema_type(value: Any, expected_type: str) -> bool:
+    if expected_type == "string":
+        return isinstance(value, str)
+    if expected_type == "boolean":
+        return isinstance(value, bool)
+    if expected_type == "integer":
+        return isinstance(value, int) and not isinstance(value, bool)
+    if expected_type == "number":
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+    if expected_type == "array":
+        return isinstance(value, Sequence) and not isinstance(
+            value,
+            (str, bytes, bytearray),
+        )
+    if expected_type == "object":
+        return isinstance(value, Mapping)
+    return True
+
+
+def _value_matches_format(value: str, field_format: str) -> bool:
+    if field_format == "email":
+        return "@" in value and "." in value.rsplit("@", 1)[-1]
+    if field_format == "uri":
+        return value.startswith(("http://", "https://"))
+    if field_format == "date":
+        try:
+            dt.date.fromisoformat(value)
+        except ValueError:
+            return False
+        return True
+    if field_format == "date-time":
+        try:
+            dt.datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            return False
+        return True
+    return True
+
+
+def _validation_error(path: str, code: str, message: str) -> dict[str, Any]:
+    return {
+        "path": path,
+        "code": code,
+        "message": message,
+        "recoverable": True,
+    }
 
 
 def _diagnostic(

--- a/moonmind/capabilities/input_contracts.py
+++ b/moonmind/capabilities/input_contracts.py
@@ -26,6 +26,7 @@ _SUPPORTED_SCHEMA_KEYWORDS = frozenset(
         "$schema",
         "additionalProperties",
         "anyOf",
+        "const",
         "default",
         "description",
         "enum",
@@ -562,7 +563,9 @@ def _normalize_schema_metadata(
         key_str = str(key)
         child_path = f"{path}.{key_str}"
         if _is_preserved_schema_key(key_str):
-            if isinstance(value, Mapping):
+            if key_str == "default":
+                normalized[key_str] = _json_compatible_value(value)
+            elif isinstance(value, Mapping):
                 if key_str in {"properties", "$defs"}:
                     child_properties: dict[str, Any] = {}
                     for child_key, child_value in value.items():

--- a/tests/unit/api/routers/test_workflow_console.py
+++ b/tests/unit/api/routers/test_workflow_console.py
@@ -19,6 +19,7 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from api_service.api.routers import workflow_console as workflow_console_router
 from api_service.main import app as main_app
 from api_service.api.routers.workflow_console import (
     _get_temporal_service,
@@ -718,6 +719,91 @@ def test_skills_api_parses_skill_input_contract(
     assert item["contentDigest"].startswith("sha256:")
     assert item["source"]["contentDigest"] == item["contentDigest"]
     assert item["diagnostics"] == []
+
+def test_skills_api_caches_file_backed_input_contract_by_content_evidence(
+    client: TestClient, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    local_root = tmp_path / "local"
+    legacy_root = tmp_path / "legacy"
+    skill_dir = legacy_root / "jira-implement"
+    skill_dir.mkdir(parents=True)
+    skill_file = skill_dir / "SKILL.md"
+    skill_file.write_text(
+        (
+            "---\n"
+            "name: Jira Implement\n"
+            "inputSchema:\n"
+            "  type: object\n"
+            "  properties:\n"
+            "    issue_key:\n"
+            "      type: string\n"
+            "---\n"
+            "# Jira Implement\n"
+        ),
+        encoding="utf-8",
+    )
+    workflow_console_router._SKILL_INPUT_CONTRACT_CACHE.clear()
+
+    monkeypatch.setattr(
+        "api_service.api.routers.workflow_console.settings.workflow.skills_local_mirror_root",
+        str(local_root),
+    )
+    monkeypatch.setattr(
+        "api_service.api.routers.workflow_console.settings.workflow.skills_legacy_mirror_root",
+        str(legacy_root),
+    )
+    monkeypatch.setattr(
+        "api_service.api.routers.workflow_console.list_available_skill_names",
+        lambda: ("jira-implement",),
+    )
+    parse_calls = 0
+    real_parse = workflow_console_router.parse_skill_capability_input_contract
+
+    def counting_parse(*args, **kwargs):
+        nonlocal parse_calls
+        parse_calls += 1
+        return real_parse(*args, **kwargs)
+
+    monkeypatch.setattr(
+        workflow_console_router,
+        "parse_skill_capability_input_contract",
+        counting_parse,
+    )
+
+    first_response = client.get("/api/workflows/skills")
+    second_response = client.get("/api/workflows/skills")
+
+    assert first_response.status_code == 200
+    assert second_response.status_code == 200
+    assert parse_calls == 1
+    assert first_response.json()["legacyItems"][0]["contractDigest"] == (
+        second_response.json()["legacyItems"][0]["contractDigest"]
+    )
+
+    skill_file.write_text(
+        (
+            "---\n"
+            "name: Jira Implement\n"
+            "inputSchema:\n"
+            "  type: object\n"
+            "  properties:\n"
+            "    issue_key:\n"
+            "      type: string\n"
+            "    repository:\n"
+            "      type: string\n"
+            "---\n"
+            "# Jira Implement\n"
+        ),
+        encoding="utf-8",
+    )
+
+    changed_response = client.get("/api/workflows/skills")
+
+    assert changed_response.status_code == 200
+    assert parse_calls == 2
+    assert "repository" in changed_response.json()["legacyItems"][0]["inputSchema"][
+        "properties"
+    ]
 
 def test_create_dashboard_skill_success(
     client: TestClient, tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/unit/api/test_agent_skills_service.py
+++ b/tests/unit/api/test_agent_skills_service.py
@@ -104,6 +104,54 @@ async def test_update_skill_content_success(tmp_path, mock_artifact_service: Asy
             mock_artifact_service.create.assert_awaited_once()
             mock_artifact_service.write_complete.assert_awaited_once()
 
+
+@pytest.mark.asyncio
+async def test_update_skill_content_persists_input_contract_metadata(
+    tmp_path, mock_artifact_service: AsyncMock
+):
+    async with template_db(tmp_path) as session_maker:
+        async with session_maker() as db_session:
+            svc = AgentSkillsService(
+                session=db_session,
+                artifact_service=mock_artifact_service,
+            )
+            await svc.create_skill(slug="issue-skill", title="Issue Skill")
+
+            await svc.update_skill_content(
+                skill_slug="issue-skill",
+                content=(
+                    "---\n"
+                    "name: Issue Skill\n"
+                    "inputSchema:\n"
+                    "  type: object\n"
+                    "  required: [issue_key]\n"
+                    "  properties:\n"
+                    "    issue_key:\n"
+                    "      type: string\n"
+                    "      title: Issue key\n"
+                    "      allOf:\n"
+                    "        - minLength: 3\n"
+                    "uiSchema:\n"
+                    "  issue_key:\n"
+                    "    widget: jira.issue-picker\n"
+                    "defaults:\n"
+                    "  issue_key: MM-1047\n"
+                    "---\n"
+                    "# Issue Skill\n"
+                ),
+            )
+
+            metadata = mock_artifact_service.create.await_args.kwargs["metadata_json"]
+            assert metadata["skill_slug"] == "issue-skill"
+            assert metadata["input_schema"]["required"] == ["issue_key"]
+            assert metadata["ui_schema"]["issue_key"]["widget"] == "jira.issue-picker"
+            assert metadata["defaults"] == {"issue_key": "MM-1047"}
+            assert metadata["input_contract_digest"].startswith("sha256:")
+            assert metadata["content_digest"].startswith("sha256:")
+            assert metadata["input_schema_diagnostics"][0]["code"] == (
+                "unsupported_keyword"
+            )
+
 @pytest.mark.asyncio
 async def test_update_skill_content_replaces_current_content(
     tmp_path, mock_artifact_service: AsyncMock

--- a/tests/unit/capabilities/test_input_contracts.py
+++ b/tests/unit/capabilities/test_input_contracts.py
@@ -181,6 +181,67 @@ def test_preset_contract_dates_are_json_compatible() -> None:
     assert contract["contractDigest"].startswith("sha256:")
 
 
+def test_one_of_const_options_are_preserved_for_renderer_choices() -> None:
+    contract = normalize_capability_input_contract(
+        owner=CapabilityInputOwner(
+            id="demo-preset",
+            kind="preset",
+            label="Demo Preset",
+        ),
+        parts=capability_contract_from_legacy_inputs(
+            inputs_schema=[],
+            annotations={
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "mode": {
+                            "title": "Mode",
+                            "oneOf": [
+                                {"const": "safe", "title": "Safe"},
+                                {"const": "fast", "title": "Fast"},
+                            ],
+                        }
+                    },
+                }
+            },
+        ),
+    )
+
+    assert contract["inputSchema"]["properties"]["mode"]["oneOf"] == [
+        {"const": "safe", "title": "Safe"},
+        {"const": "fast", "title": "Fast"},
+    ]
+    assert contract["diagnostics"] == []
+
+
+def test_schema_object_defaults_are_preserved_as_values() -> None:
+    contract = normalize_capability_input_contract(
+        owner=CapabilityInputOwner(
+            id="demo-preset",
+            kind="preset",
+            label="Demo Preset",
+        ),
+        parts=capability_contract_from_legacy_inputs(
+            inputs_schema=[],
+            annotations={
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "issue": {
+                            "type": "object",
+                            "title": "Issue",
+                            "default": {"key": "MM-1"},
+                        }
+                    },
+                }
+            },
+        ),
+    )
+
+    assert contract["inputSchema"]["properties"]["issue"]["default"] == {"key": "MM-1"}
+    assert contract["diagnostics"] == []
+
+
 def test_unsupported_safe_schema_and_widget_metadata_are_diagnosed() -> None:
     markdown = (
         "---\n"

--- a/tests/unit/capabilities/test_input_contracts.py
+++ b/tests/unit/capabilities/test_input_contracts.py
@@ -5,6 +5,7 @@ from moonmind.capabilities.input_contracts import (
     capability_contract_from_legacy_inputs,
     normalize_capability_input_contract,
     parse_skill_capability_input_contract,
+    validate_capability_inputs,
 )
 
 
@@ -178,3 +179,135 @@ def test_preset_contract_dates_are_json_compatible() -> None:
     assert contract["inputSchema"]["properties"]["due_date"]["default"] == "2026-06-30"
     assert contract["defaults"] == {"due_date": "2026-06-30"}
     assert contract["contractDigest"].startswith("sha256:")
+
+
+def test_unsupported_safe_schema_and_widget_metadata_are_diagnosed() -> None:
+    markdown = (
+        "---\n"
+        "name: Demo Skill\n"
+        "inputSchema:\n"
+        "  type: object\n"
+        "  properties:\n"
+        "    target:\n"
+        "      type: string\n"
+        "      allOf:\n"
+        "        - minLength: 3\n"
+        "      x-moonmind-unknown-hint: true\n"
+        "      customWidget: no\n"
+        "uiSchema:\n"
+        "  target:\n"
+        "    widget: deployment.secret-picker\n"
+        "---\n"
+        "# Demo\n"
+    )
+
+    contract = parse_skill_capability_input_contract(
+        skill_id="demo-skill",
+        label="Demo Skill",
+        markdown=markdown,
+    )
+
+    diagnostics = {item["code"]: item for item in contract["diagnostics"]}
+    assert contract["inputSchema"]["properties"]["target"]["allOf"] == [
+        {"minLength": 3}
+    ]
+    assert "customWidget" not in contract["inputSchema"]["properties"]["target"]
+    assert diagnostics["unsupported_keyword"]["path"].startswith("inputSchema")
+    assert diagnostics["ignored_hint"]["path"].endswith("x-moonmind-unknown-hint")
+    assert diagnostics["unsupported_widget"]["path"] == "uiSchema.target.widget"
+
+
+def test_secret_like_defaults_are_removed_from_schema_and_defaults() -> None:
+    markdown = (
+        "---\n"
+        "name: Demo Skill\n"
+        "inputSchema:\n"
+        "  type: object\n"
+        "  properties:\n"
+        "    api_token:\n"
+        "      type: string\n"
+        "      default: ghp_thisShouldNotReachTheContract\n"
+        "    branch:\n"
+        "      type: string\n"
+        "      default: main\n"
+        "defaults:\n"
+        "  api_token: password=hidden\n"
+        "  branch: main\n"
+        "---\n"
+        "# Demo\n"
+    )
+
+    contract = parse_skill_capability_input_contract(
+        skill_id="demo-skill",
+        label="Demo Skill",
+        markdown=markdown,
+    )
+
+    properties = contract["inputSchema"]["properties"]
+    assert "default" not in properties["api_token"]
+    assert properties["branch"]["default"] == "main"
+    assert contract["defaults"] == {"branch": "main"}
+    assert [
+        item["code"] for item in contract["diagnostics"]
+    ].count("defaults_secret_like_value") == 2
+
+
+def test_oversized_skill_frontmatter_is_omitted_with_diagnostic() -> None:
+    markdown = (
+        "---\n"
+        "name: Demo Skill\n"
+        "inputSchema:\n"
+        "  type: object\n"
+        "  properties:\n"
+        f"    target:\n      type: string\n      description: {'x' * 140000}\n"
+        "---\n"
+        "# Demo\n"
+    )
+
+    contract = parse_skill_capability_input_contract(
+        skill_id="demo-skill",
+        label="Demo Skill",
+        markdown=markdown,
+    )
+
+    assert contract["inputSchema"] == {}
+    assert contract["diagnostics"][0]["code"] == "frontmatter_too_large"
+    assert contract["diagnostics"][0]["path"] == "frontmatter"
+
+
+def test_validate_capability_inputs_reports_field_errors() -> None:
+    contract = normalize_capability_input_contract(
+        owner=CapabilityInputOwner(
+            id="demo-skill",
+            kind="skill",
+            label="Demo Skill",
+        ),
+        parts=capability_contract_from_legacy_inputs(
+            inputs_schema=[],
+            annotations={
+                "inputSchema": {
+                    "type": "object",
+                    "required": ["issue_key", "due_date"],
+                    "properties": {
+                        "issue_key": {"type": "string"},
+                        "priority": {"type": "string", "enum": ["low", "high"]},
+                        "due_date": {"type": "string", "format": "date"},
+                    },
+                },
+                "defaults": {"priority": "low"},
+            },
+        ),
+    )
+
+    result = validate_capability_inputs(
+        contract=contract,
+        values={"priority": "urgent", "due_date": "not-a-date"},
+    )
+
+    assert result["values"]["priority"] == "urgent"
+    assert [error["code"] for error in result["errors"]] == [
+        "required",
+        "enum",
+        "format",
+    ]
+    assert result["contractDigest"] == contract["contractDigest"]


### PR DESCRIPTION
Issue reference: MM-1054

Summary:
- Completes shared Skill/Preset capability input contract normalization with schema diagnostics, widget hint handling, size bounds, and safe default sanitization.
- Persists deployment-stored Skill contract metadata including schema, ui schema, defaults, diagnostics, content digest, and contract digest.
- Adds file-backed Skill discovery caching by content evidence and expands unit coverage for contract parsing, service persistence, and workflow-console catalog exposure.

Tests run:
- MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --python-only tests/unit/capabilities/test_input_contracts.py tests/unit/api/test_agent_skills_service.py tests/unit/api/routers/test_workflow_console.py
- python -m ruff check api_service/api/routers/workflow_console.py tests/unit/api/routers/test_workflow_console.py moonmind/capabilities/input_contracts.py api_service/services/agent_skills_service.py tests/unit/capabilities/test_input_contracts.py tests/unit/api/test_agent_skills_service.py (not run: ruff is not installed in this container)

Remaining risks:
- Broader dashboard Vitest spillover from the non-python targeted runner remains outside this change; verification record notes unrelated workflow-detail/workflow-list failures.
- No integration_ci suite was selected because this change does not touch Docker, compose, migrations, database schema, runtime infrastructure, or integration boundaries.