### PR TITLE
MM-1048 Match shimmer hue to status pill

### DIFF
--- a/frontend/src/entrypoints/dashboard.test.tsx
+++ b/frontend/src/entrypoints/dashboard.test.tsx
@@ -913,32 +913,41 @@ describe('Dashboard shared entry', () => {
 
   it('defines the shared MM-488 executing shimmer modifier contract', async () => {
     expect(dashboardCss).toMatch(/--mm-executing-sweep-cycle-duration:\s*2600ms/);
-    // MM-1041: steeper band angle pairs with the flatter, more horizontal travel path.
-    expect(dashboardCss).toMatch(/--mm-executing-sweep-angle:\s*-24deg/);
+    // MM-1048: angle and vertical travel are slightly more horizontal than the
+    // previous -24deg / +/-128% treatment.
+    expect(dashboardCss).toMatch(/--mm-executing-sweep-angle:\s*-20deg/);
     expect(dashboardCss).toMatch(/--mm-executing-sweep-band-width:\s*24%/);
     expect(dashboardCss).toMatch(/--mm-executing-sweep-band-height:\s*180%/);
     expect(dashboardCss).toMatch(/--mm-executing-sweep-halo-width-multiplier:\s*10/);
     expect(dashboardCss).toMatch(/--mm-executing-sweep-core-width-multiplier:\s*9\.1667/);
     expect(dashboardCss).not.toContain('--mm-executing-sweep-halo-peak-width-multiplier');
     expect(dashboardCss).not.toContain('--mm-executing-sweep-core-peak-width-multiplier');
-    // MM-1041: vertical travel reduced (160% -> 128%) so the horizontal delta
+    // MM-1048: vertical travel is reduced to +/-120% so the horizontal delta
     // exceeds the vertical delta and the sweep travels more horizontally.
     expect(dashboardCss).toMatch(/--mm-executing-sweep-start-x:\s*135%/);
-    expect(dashboardCss).toMatch(/--mm-executing-sweep-start-y:\s*128%/);
+    expect(dashboardCss).toMatch(/--mm-executing-sweep-start-y:\s*120%/);
     expect(dashboardCss).toMatch(/--mm-executing-sweep-end-x:\s*-135%/);
-    expect(dashboardCss).toMatch(/--mm-executing-sweep-end-y:\s*-128%/);
+    expect(dashboardCss).toMatch(/--mm-executing-sweep-end-y:\s*-120%/);
     expect(dashboardCss).toMatch(/--mm-executing-sweep-layer-offset-x:\s*-12%/);
     expect(dashboardCss).toMatch(/--mm-executing-sweep-layer-offset-y:\s*-10%/);
     expect(dashboardCss).toContain('--mm-executing-letter-cycle-duration: var(--mm-executing-sweep-cycle-duration)');
     expect(dashboardCss).toContain('--mm-executing-letter-sweep-start-ratio: 0.2');
     expect(dashboardCss).toContain('--mm-executing-letter-sweep-travel-ratio: 0.18');
     expect(dashboardCss).toContain('--mm-executing-letter-sweep-direction: 1');
-    expect(dashboardCss).toContain('--mm-executing-letter-halo: rgb(var(--mm-accent-2) / 0.32)');
-    expect(dashboardCss).toContain('--mm-executing-letter-bright: color-mix(in srgb, rgb(var(--mm-accent-2)) 68%, white 32%)');
+    expect(dashboardCss).toContain('--mm-executing-letter-halo: var(--mm-status-shimmer-letter-halo)');
+    expect(dashboardCss).toContain('--mm-executing-letter-bright: var(--mm-status-shimmer-letter-bright)');
     expect(dashboardCss).toContain('--mm-executing-border-glint-outset: 1px');
     expect(dashboardCss).toContain('--mm-executing-border-glint-width: 3px');
     expect(dashboardCss).toContain('--mm-executing-border-glint-opacity: 0.95');
     expect(dashboardCss).toContain('--mm-executing-moving-light-gradient:');
+    expect(dashboardCss).toContain('--mm-status-shimmer-halo: color-mix(in srgb, currentColor 30%, transparent)');
+    expect(dashboardCss).toContain('--mm-status-shimmer-core: color-mix(in srgb, currentColor 70%, white 30%)');
+    expect(dashboardCss).toContain('--mm-status-shimmer-letter-halo: color-mix(in srgb, currentColor 32%, transparent)');
+    expect(dashboardCss).toContain('--mm-status-shimmer-letter-bright: color-mix(in srgb, currentColor 68%, white 32%)');
+    expect(dashboardCss).toContain('var(--mm-status-shimmer-halo) 50%');
+    expect(dashboardCss).toContain('var(--mm-status-shimmer-core) 50%');
+    expect(dashboardCss).not.toContain('rgb(var(--mm-accent) / var(--mm-executing-sweep-halo-opacity)) 50%');
+    expect(dashboardCss).not.toContain('rgb(var(--mm-accent-2) / var(--mm-executing-sweep-core-opacity)) 50%');
 
     const shimmerBlock = cssRuleBlocks(
       dashboardCss,

--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -51,19 +51,18 @@
   --mm-mobile-nav-active-edge: rgb(var(--mm-accent) / 0.88);
   --mm-font-sans: "IBM Plex Sans", system-ui, sans-serif;
   --mm-executing-sweep-cycle-duration: 2600ms;
-  /* MM-1041: flatter, more horizontal sweep. Steeper band angle (-24deg) keeps
-     the luminous stripe near-perpendicular to the reduced vertical travel. */
-  --mm-executing-sweep-angle: -24deg;
+  /* MM-1048: slightly more horizontal shimmer path while preserving the shared
+     compatibility token names used by existing status-pill selectors. */
+  --mm-executing-sweep-angle: -20deg;
   --mm-executing-sweep-band-width: 24%;
   --mm-executing-sweep-band-height: 180%;
   --mm-executing-sweep-halo-width-multiplier: 10;
   --mm-executing-sweep-core-width-multiplier: 9.1667;
-  /* MM-1041: horizontal travel delta (270%) now exceeds the vertical delta
-     (256%) so the sweep reads as traveling slightly more horizontally. */
+  /* MM-1048: horizontal travel delta (270%) exceeds the vertical delta (240%). */
   --mm-executing-sweep-start-x: 135%;
-  --mm-executing-sweep-start-y: 128%;
+  --mm-executing-sweep-start-y: 120%;
   --mm-executing-sweep-end-x: -135%;
-  --mm-executing-sweep-end-y: -128%;
+  --mm-executing-sweep-end-y: -120%;
   --mm-executing-sweep-layer-offset-x: -12%;
   --mm-executing-sweep-layer-offset-y: -10%;
   --mm-executing-sweep-core-opacity: 0.34;
@@ -75,19 +74,19 @@
   --mm-executing-letter-sweep-start-ratio: 0.2;
   --mm-executing-letter-sweep-travel-ratio: 0.18;
   --mm-executing-letter-sweep-direction: 1;
-  --mm-executing-letter-halo: rgb(var(--mm-accent-2) / 0.32);
-  --mm-executing-letter-bright: color-mix(in srgb, rgb(var(--mm-accent-2)) 68%, white 32%);
+  --mm-executing-letter-halo: var(--mm-status-shimmer-letter-halo);
+  --mm-executing-letter-bright: var(--mm-status-shimmer-letter-bright);
   --mm-executing-moving-light-gradient:
     linear-gradient(
       var(--mm-executing-sweep-angle),
       transparent 0 36%,
-      rgb(var(--mm-accent) / var(--mm-executing-sweep-halo-opacity)) 50%,
+      var(--mm-status-shimmer-halo) 50%,
       transparent 64%
     ),
     linear-gradient(
       var(--mm-executing-sweep-angle),
       transparent 0 44%,
-      rgb(var(--mm-accent-2) / var(--mm-executing-sweep-core-opacity)) 50%,
+      var(--mm-status-shimmer-core) 50%,
       transparent 56%
     );
   --mm-font-headline: var(--mm-font-sans);
@@ -2805,6 +2804,12 @@ tr[data-proposal-id].proposal-consuming td {
 
 .status[data-effect="shimmer-sweep"],
 .status-running.is-executing {
+  --mm-status-shimmer-halo: color-mix(in srgb, currentColor 30%, transparent);
+  --mm-status-shimmer-core: color-mix(in srgb, currentColor 70%, white 30%);
+  --mm-status-shimmer-letter-halo: color-mix(in srgb, currentColor 32%, transparent);
+  --mm-status-shimmer-letter-bright: color-mix(in srgb, currentColor 68%, white 32%);
+  --mm-executing-letter-halo: var(--mm-status-shimmer-letter-halo);
+  --mm-executing-letter-bright: var(--mm-status-shimmer-letter-bright);
   position: relative;
   overflow: hidden;
   isolation: isolate;


### PR DESCRIPTION
Issue: MM-1048

Summary:
- Updated the shared status-pill shimmer gradient to derive halo, core, and fallback letter colors from the pill's current semantic color instead of fixed executing/cyan tokens.
- Adjusted the shimmer sweep geometry from the prior -24deg / +/-128% vertical travel treatment to -20deg / +/-120% so the motion reads slightly more horizontal.
- Updated the dashboard CSS contract test expectations for the new status-derived shimmer tokens and geometry.

Tests run:
- `./tools/test_unit.sh --ui-args frontend/src/entrypoints/dashboard.test.tsx` (blocked: `/usr/local/bin/python: No module named pytest` before Vitest ran)
- `npm ci --no-fund --no-audit`
- `./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/dashboard.test.tsx` (blocked: Vitest resolved test modules to `/frontend/...`, which does not exist in this managed workspace)
- `./node_modules/.bin/vitest run --config frontend/vite.config.ts` (same `/frontend/...` module-resolution blocker for all discovered frontend test files)

Remaining risks:
- Focused Vitest verification could not complete in this container because of the local module-resolution issue above; the changed assertions are limited to the CSS contract test and should run in normal frontend CI.
