### PR TITLE
MM-1059 Complete Omnigent adapter harvest coverage

### DIFF
--- a/moonmind/omnigent/execute.py
+++ b/moonmind/omnigent/execute.py
@@ -1,4 +1,4 @@
-"""Run one Omnigent streaming-gateway execution for MM-1030."""
+"""Run one Omnigent streaming-gateway execution for MM-1059."""
 
 from __future__ import annotations
 
@@ -653,6 +653,42 @@ async def _cancel_omnigent_session(
             await client.stop_session(session_id)
 
 
+async def _capture_cancelled_omnigent_session(
+    *,
+    client: OmnigentHttpClient,
+    artifact_gateway: OmnigentArtifactGateway,
+    request: AgentExecutionRequest,
+    session_id: str,
+    agent_id: str | None,
+    initial_snapshot: dict[str, Any] | None,
+    first_message_request: dict[str, Any] | None,
+    first_message_response: dict[str, Any] | None,
+    raw_events: list[dict[str, Any]],
+    normalized_events: list[dict[str, Any]],
+) -> None:
+    with suppress(Exception):
+        final_snapshot = await client.get_session(session_id)
+        await _build_capture_bundle(
+            client=client,
+            artifact_gateway=artifact_gateway,
+            request=request,
+            session_id=session_id,
+            agent_id=agent_id,
+            initial_snapshot=initial_snapshot,
+            final_snapshot=final_snapshot or {"status": "canceled"},
+            first_message_request=first_message_request,
+            first_message_response=first_message_response,
+            raw_events=raw_events,
+            normalized_events=normalized_events,
+            terminal_status="canceled",
+            diagnostics={
+                "cancelled": True,
+                "failureClass": "system_error",
+            },
+            harvest_resources=True,
+        )
+
+
 async def _harvest_changed_files(
     *,
     client: OmnigentHttpClient,
@@ -661,7 +697,7 @@ async def _harvest_changed_files(
     session_id: str,
     manifest: dict[str, Any],
     refs: dict[str, str],
-) -> None:
+) -> list[dict[str, Any]]:
     try:
         changed = await client.list_changed_files(session_id)
     except Exception as exc:
@@ -669,7 +705,7 @@ async def _harvest_changed_files(
             exc,
             fallback="changed files unavailable",
         )
-        return
+        return []
     index_ref = await _capture_artifact_json(
         artifact_gateway,
         request,
@@ -714,6 +750,111 @@ async def _harvest_changed_files(
         harvested.append({"path": path, "artifactRef": ref})
     manifest["changedFiles"] = harvested
     manifest.setdefault("patchUnavailable", True)
+    return file_items
+
+
+async def _harvest_workspace_files(
+    *,
+    client: OmnigentHttpClient,
+    artifact_gateway: OmnigentArtifactGateway,
+    request: AgentExecutionRequest,
+    session_id: str,
+    manifest: dict[str, Any],
+    refs: dict[str, str],
+) -> None:
+    try:
+        files = await client.list_workspace_files(session_id)
+    except Exception as exc:
+        manifest["workspaceFilesUnavailable"] = _compact_summary(
+            exc,
+            fallback="workspace files unavailable",
+        )
+        return
+    index_ref = await _capture_artifact_json(
+        artifact_gateway,
+        request,
+        refs,
+        key="workspaceFilesIndexRef",
+        name="output.omnigent.workspace_files.index.json",
+        payload=files,
+        link_type="output.omnigent.workspace_files.index",
+    )
+    manifest["workspaceFilesIndexRef"] = index_ref
+    harvested: list[dict[str, Any]] = []
+    for item in _resource_items(files)[:_MAX_OMNIGENT_HARVEST_ITEMS]:
+        path = _resource_path(item)
+        if not path:
+            continue
+        if str(item.get("type") or item.get("kind") or "").strip().lower() in {
+            "dir",
+            "directory",
+            "folder",
+        }:
+            harvested.append({"path": path, "skipped": "directory"})
+            continue
+        try:
+            content = await client.get_workspace_file(session_id, path)
+        except Exception as exc:
+            harvested.append(
+                {
+                    "path": path,
+                    "unavailable": _compact_summary(
+                        exc,
+                        fallback="workspace file content unavailable",
+                    ),
+                }
+            )
+            continue
+        ref = await artifact_gateway.write_bytes(
+            request=request,
+            name=f"output.omnigent.workspace_files/{path}",
+            payload=content,
+            link_type="output.omnigent.workspace_file",
+        )
+        harvested.append({"path": path, "artifactRef": ref})
+    manifest["workspaceFiles"] = harvested
+
+
+async def _harvest_workspace_diffs(
+    *,
+    client: OmnigentHttpClient,
+    artifact_gateway: OmnigentArtifactGateway,
+    request: AgentExecutionRequest,
+    session_id: str,
+    changed_items: list[dict[str, Any]],
+    manifest: dict[str, Any],
+    refs: dict[str, str],
+) -> None:
+    paths = [
+        path
+        for path in (_resource_path(item) for item in changed_items)
+        if path
+    ][:_MAX_OMNIGENT_HARVEST_ITEMS]
+    if not paths:
+        manifest["workspaceDiffs"] = []
+        manifest["patchUnavailable"] = True
+        return
+    harvested: list[dict[str, Any]] = []
+    for path in paths:
+        try:
+            diff = await client.get_workspace_diff(session_id, path)
+        except Exception as exc:
+            manifest["workspaceDiffsUnavailable"] = _compact_summary(
+                exc,
+                fallback="workspace diff capability unavailable",
+            )
+            manifest["patchUnavailable"] = True
+            return
+        ref = await artifact_gateway.write_bytes(
+            request=request,
+            name=f"output.omnigent.workspace_diffs/{path}.diff",
+            payload=diff,
+            link_type="output.omnigent.workspace_diff",
+            content_type="text/x-diff",
+        )
+        harvested.append({"path": path, "artifactRef": ref})
+    manifest["workspaceDiffs"] = harvested
+    manifest["patchUnavailable"] = not bool(harvested)
 
 
 async def _harvest_session_files(
@@ -799,6 +940,17 @@ def _resource_items(payload: dict[str, Any]) -> list[dict[str, Any]]:
             if nested:
                 return nested
     return []
+
+
+def _resource_path(item: dict[str, Any]) -> str:
+    return str(
+        item.get("path")
+        or item.get("file_path")
+        or item.get("filePath")
+        or item.get("relativePath")
+        or item.get("name")
+        or ""
+    ).strip().strip("/")
 
 
 def _child_session_ids(
@@ -965,11 +1117,28 @@ async def _build_capture_bundle(
                 )
         manifest["childSessionEvidence"] = child_snapshots
     if harvest_resources and client is not None and session_id:
-        await _harvest_changed_files(
+        changed_items = await _harvest_changed_files(
             client=client,
             artifact_gateway=artifact_gateway,
             request=request,
             session_id=session_id,
+            manifest=manifest,
+            refs=refs,
+        )
+        await _harvest_workspace_files(
+            client=client,
+            artifact_gateway=artifact_gateway,
+            request=request,
+            session_id=session_id,
+            manifest=manifest,
+            refs=refs,
+        )
+        await _harvest_workspace_diffs(
+            client=client,
+            artifact_gateway=artifact_gateway,
+            request=request,
+            session_id=session_id,
+            changed_items=changed_items,
             manifest=manifest,
             refs=refs,
         )
@@ -1017,6 +1186,7 @@ async def _build_capture_bundle(
         "firstMessageResponseRef",
         "initialSnapshotRef",
         "changedFilesIndexRef",
+        "workspaceFilesIndexRef",
         "sessionFilesIndexRef",
         "childSessionsRef",
     ):
@@ -1074,8 +1244,12 @@ async def run_omnigent_execution(
     raw_events: list[dict[str, Any]] = []
     normalized_events: list[dict[str, Any]] = []
     target_agent_id: str | None = None
+    delete_after_harvest = False
     try:
         selection = build_omnigent_selection(request)
+        delete_after_harvest = bool(
+            selection.capture.get("deleteOmnigentSessionAfterHarvest", False)
+        )
         async with httpx.AsyncClient() as httpx_client:
             client = OmnigentHttpClient(
                 base_url=resolved_server_url(),
@@ -1106,7 +1280,7 @@ async def run_omnigent_execution(
             session_payload["idempotency_key"] = request.idempotency_key
             labels = session_payload.setdefault("labels", {})
             if isinstance(labels, dict):
-                labels.setdefault("moonmind.issue", "MM-1030")
+                labels.setdefault("moonmind.issue", "MM-1059")
 
             durable_row = None
             if run_store is not None:
@@ -1414,6 +1588,21 @@ async def run_omnigent_execution(
         await _cancel_task(stream_task)
         if client is not None and session_id:
             await _cancel_omnigent_session(client, session_id)
+            await _capture_cancelled_omnigent_session(
+                client=client,
+                artifact_gateway=artifact_gateway,
+                request=request,
+                session_id=session_id,
+                agent_id=target_agent_id,
+                initial_snapshot=initial_snapshot,
+                first_message_request=first_message,
+                first_message_response=first_message_response,
+                raw_events=raw_events,
+                normalized_events=normalized_events,
+            )
+            if delete_after_harvest:
+                with suppress(Exception):
+                    await client.delete_session(session_id)
         raise
     except (
         OmnigentArtifactError,

--- a/moonmind/omnigent/execute.py
+++ b/moonmind/omnigent/execute.py
@@ -665,6 +665,7 @@ async def _capture_cancelled_omnigent_session(
     first_message_response: dict[str, Any] | None,
     raw_events: list[dict[str, Any]],
     normalized_events: list[dict[str, Any]],
+    capture_policy: dict[str, Any] | None,
 ) -> None:
     with suppress(Exception):
         final_snapshot = await client.get_session(session_id)
@@ -686,6 +687,7 @@ async def _capture_cancelled_omnigent_session(
                 "failureClass": "system_error",
             },
             harvest_resources=True,
+            capture_policy=capture_policy,
         )
 
 
@@ -1002,6 +1004,7 @@ async def _build_capture_bundle(
     terminal_status: str,
     diagnostics: dict[str, Any],
     harvest_resources: bool,
+    capture_policy: dict[str, Any] | None = None,
 ) -> OmnigentCaptureBundle:
     refs: dict[str, str] = {}
     if first_message_request is not None:
@@ -1117,22 +1120,25 @@ async def _build_capture_bundle(
                 )
         manifest["childSessionEvidence"] = child_snapshots
     if harvest_resources and client is not None and session_id:
-        changed_items = await _harvest_changed_files(
-            client=client,
-            artifact_gateway=artifact_gateway,
-            request=request,
-            session_id=session_id,
-            manifest=manifest,
-            refs=refs,
-        )
-        await _harvest_workspace_files(
-            client=client,
-            artifact_gateway=artifact_gateway,
-            request=request,
-            session_id=session_id,
-            manifest=manifest,
-            refs=refs,
-        )
+        changed_items: list[dict[str, Any]] = []
+        if _capture_enabled(capture_policy, "changedFiles"):
+            changed_items = await _harvest_changed_files(
+                client=client,
+                artifact_gateway=artifact_gateway,
+                request=request,
+                session_id=session_id,
+                manifest=manifest,
+                refs=refs,
+            )
+        if _capture_enabled(capture_policy, "workspaceFiles"):
+            await _harvest_workspace_files(
+                client=client,
+                artifact_gateway=artifact_gateway,
+                request=request,
+                session_id=session_id,
+                manifest=manifest,
+                refs=refs,
+            )
         await _harvest_workspace_diffs(
             client=client,
             artifact_gateway=artifact_gateway,
@@ -1142,14 +1148,15 @@ async def _build_capture_bundle(
             manifest=manifest,
             refs=refs,
         )
-        await _harvest_session_files(
-            client=client,
-            artifact_gateway=artifact_gateway,
-            request=request,
-            session_id=session_id,
-            manifest=manifest,
-            refs=refs,
-        )
+        if _capture_enabled(capture_policy, "sessionFiles"):
+            await _harvest_session_files(
+                client=client,
+                artifact_gateway=artifact_gateway,
+                request=request,
+                session_id=session_id,
+                manifest=manifest,
+                refs=refs,
+            )
     diagnostics_payload = {
         "provider": "omnigent",
         "omnigentSessionId": session_id,
@@ -1208,6 +1215,12 @@ def _jsonl(events: list[dict[str, Any]]) -> str:
     )
 
 
+def _capture_enabled(capture_policy: dict[str, Any] | None, key: str) -> bool:
+    if capture_policy is None:
+        return True
+    return bool(capture_policy.get(key, True))
+
+
 async def _cancel_task(task: asyncio.Task[Any] | None) -> None:
     if task is None or task.done():
         return
@@ -1245,8 +1258,10 @@ async def run_omnigent_execution(
     normalized_events: list[dict[str, Any]] = []
     target_agent_id: str | None = None
     delete_after_harvest = False
+    capture_policy: dict[str, Any] | None = None
     try:
         selection = build_omnigent_selection(request)
+        capture_policy = selection.capture
         delete_after_harvest = bool(
             selection.capture.get("deleteOmnigentSessionAfterHarvest", False)
         )
@@ -1563,6 +1578,7 @@ async def run_omnigent_execution(
                 terminal_status=terminal_status,
                 diagnostics={"failureClass": _failure_class_for(terminal_status)},
                 harvest_resources=True,
+                capture_policy=capture_policy,
             )
             if run_store is not None:
                 await run_store.mark_terminal(
@@ -1587,22 +1603,29 @@ async def run_omnigent_execution(
         await _cancel_task(heartbeat_task)
         await _cancel_task(stream_task)
         if client is not None and session_id:
-            await _cancel_omnigent_session(client, session_id)
-            await _capture_cancelled_omnigent_session(
-                client=client,
-                artifact_gateway=artifact_gateway,
-                request=request,
-                session_id=session_id,
-                agent_id=target_agent_id,
-                initial_snapshot=initial_snapshot,
-                first_message_request=first_message,
-                first_message_response=first_message_response,
-                raw_events=raw_events,
-                normalized_events=normalized_events,
-            )
-            if delete_after_harvest:
-                with suppress(Exception):
-                    await client.delete_session(session_id)
+            async with httpx.AsyncClient() as cleanup_httpx_client:
+                cleanup_client = OmnigentHttpClient(
+                    base_url=resolved_server_url(),
+                    api_token=resolved_api_token(),
+                    client=cleanup_httpx_client,
+                )
+                await _cancel_omnigent_session(cleanup_client, session_id)
+                await _capture_cancelled_omnigent_session(
+                    client=cleanup_client,
+                    artifact_gateway=artifact_gateway,
+                    request=request,
+                    session_id=session_id,
+                    agent_id=target_agent_id,
+                    initial_snapshot=initial_snapshot,
+                    first_message_request=first_message,
+                    first_message_response=first_message_response,
+                    raw_events=raw_events,
+                    normalized_events=normalized_events,
+                    capture_policy=capture_policy,
+                )
+                if delete_after_harvest:
+                    with suppress(Exception):
+                        await cleanup_client.delete_session(session_id)
         raise
     except (
         OmnigentArtifactError,

--- a/moonmind/workflows/adapters/omnigent_client.py
+++ b/moonmind/workflows/adapters/omnigent_client.py
@@ -188,11 +188,26 @@ class OmnigentHttpClient:
             "/resources/environments/default/changes",
         )
 
+    async def list_workspace_files(self, session_id: str) -> dict[str, Any]:
+        return await self._request(
+            "GET",
+            f"/v1/sessions/{quote(session_id, safe='')}"
+            "/resources/environments/default/filesystem",
+        )
+
     async def get_workspace_file(self, session_id: str, path: str) -> bytes:
         return await self._request_bytes(
             "GET",
             f"/v1/sessions/{quote(session_id, safe='')}"
             "/resources/environments/default/filesystem/"
+            f"{quote(path, safe='')}",
+        )
+
+    async def get_workspace_diff(self, session_id: str, path: str) -> bytes:
+        return await self._request_bytes(
+            "GET",
+            f"/v1/sessions/{quote(session_id, safe='')}"
+            "/resources/environments/default/diff/"
             f"{quote(path, safe='')}",
         )
 

--- a/tests/integration/omnigent/test_execute_fake_server.py
+++ b/tests/integration/omnigent/test_execute_fake_server.py
@@ -1,0 +1,213 @@
+"""MM-1059 fake Omnigent server coverage for streaming-gateway execution."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+
+import pytest
+import pytest_asyncio
+from aiohttp import web
+
+from moonmind.omnigent.execute import (
+    LocalOmnigentArtifactGateway,
+    run_omnigent_execution,
+)
+from moonmind.schemas.agent_runtime_models import AgentExecutionRequest
+
+pytestmark = [pytest.mark.asyncio, pytest.mark.integration, pytest.mark.integration_ci]
+
+
+class FakeOmnigentServer:
+    def __init__(self, *, supports_diff: bool) -> None:
+        self.supports_diff = supports_diff
+        self.session_ids: list[str] = []
+        self.events: list[dict[str, Any]] = []
+        self.first_message_posted = asyncio.Event()
+
+    def app(self) -> web.Application:
+        app = web.Application()
+        app.router.add_get("/api/agents", self.list_agents)
+        app.router.add_post("/v1/sessions", self.create_session)
+        app.router.add_get("/v1/sessions/{session_id}", self.get_session)
+        app.router.add_post("/v1/sessions/{session_id}/events", self.post_event)
+        app.router.add_get("/v1/sessions/{session_id}/stream", self.stream)
+        app.router.add_get(
+            "/v1/sessions/{session_id}/resources/environments/default/changes",
+            self.list_changed_files,
+        )
+        app.router.add_get(
+            "/v1/sessions/{session_id}/resources/environments/default/filesystem",
+            self.list_workspace_files,
+        )
+        app.router.add_get(
+            "/v1/sessions/{session_id}/resources/environments/default/"
+            "filesystem/{path:.+}",
+            self.get_workspace_file,
+        )
+        app.router.add_get(
+            "/v1/sessions/{session_id}/resources/environments/default/"
+            "diff/{path:.+}",
+            self.get_workspace_diff,
+        )
+        app.router.add_get(
+            "/v1/sessions/{session_id}/resources/files",
+            self.list_session_files,
+        )
+        app.router.add_get(
+            "/v1/sessions/{session_id}/resources/files/{file_id}/content",
+            self.get_session_file_content,
+        )
+        return app
+
+    async def list_agents(self, _request: web.Request) -> web.Response:
+        return web.json_response({"agents": [{"id": "agent-1", "name": "codex"}]})
+
+    async def create_session(self, request: web.Request) -> web.Response:
+        payload = await request.json()
+        assert payload["agent_id"] == "agent-1"
+        assert payload["workspace"] == "https://github.com/org/repo#main"
+        assert payload["labels"]["moonmind.issue"] == "MM-1059"
+        session_id = f"session-{len(self.session_ids) + 1}"
+        self.session_ids.append(session_id)
+        return web.json_response({"id": session_id})
+
+    async def get_session(self, request: web.Request) -> web.Response:
+        return web.json_response(
+            {
+                "id": request.match_info["session_id"],
+                "status": (
+                    "completed" if self.first_message_posted.is_set() else "running"
+                ),
+                "summary": "fake Omnigent completed",
+                "githubPrUrl": "https://github.example/org/repo/pull/42",
+            }
+        )
+
+    async def post_event(self, request: web.Request) -> web.Response:
+        payload = await request.json()
+        self.events.append(payload)
+        self.first_message_posted.set()
+        return web.json_response({"pending_id": "pending-1"})
+
+    async def stream(self, _request: web.Request) -> web.StreamResponse:
+        await self.first_message_posted.wait()
+        response = web.StreamResponse(
+            status=200,
+            headers={"Content-Type": "text/event-stream"},
+        )
+        await response.prepare(_request)
+        await response.write(b'data: {"session":{"status":"running"}}\n\n')
+        await response.write(b'data: {"type":"response.completed"}\n\n')
+        await response.write_eof()
+        return response
+
+    async def list_changed_files(self, _request: web.Request) -> web.Response:
+        return web.json_response({"items": [{"path": "src/app.py"}]})
+
+    async def list_workspace_files(self, _request: web.Request) -> web.Response:
+        return web.json_response(
+            {
+                "items": [
+                    {"path": "README.md", "type": "file"},
+                    {"path": "src/app.py", "type": "file"},
+                    {"path": "src", "type": "directory"},
+                ]
+            }
+        )
+
+    async def get_workspace_file(self, request: web.Request) -> web.Response:
+        path = request.match_info["path"]
+        body = {
+            "README.md": b"# Fake repo\n",
+            "src/app.py": b"print('fake')\n",
+        }[path]
+        return web.Response(body=body, content_type="text/plain")
+
+    async def get_workspace_diff(self, request: web.Request) -> web.Response:
+        if not self.supports_diff:
+            return web.json_response({"error": "diff unavailable"}, status=404)
+        path = request.match_info["path"]
+        return web.Response(
+            body=f"diff --git a/{path} b/{path}\n".encode("utf-8"),
+            content_type="text/x-diff",
+        )
+
+    async def list_session_files(self, _request: web.Request) -> web.Response:
+        return web.json_response(
+            {"items": [{"id": "file-1", "filename": "session.log"}]}
+        )
+
+    async def get_session_file_content(self, _request: web.Request) -> web.Response:
+        return web.Response(body=b"session file evidence\n", content_type="text/plain")
+
+
+@pytest_asyncio.fixture
+async def fake_omnigent_server(request: pytest.FixtureRequest):
+    server = FakeOmnigentServer(supports_diff=bool(request.param))
+    runner = web.AppRunner(server.app())
+    await runner.setup()
+    site = web.TCPSite(runner, "127.0.0.1", 0)
+    await site.start()
+    sockets = site._server.sockets if site._server is not None else []
+    assert sockets
+    host, port = sockets[0].getsockname()[:2]
+    try:
+        yield server, f"http://{host}:{port}"
+    finally:
+        await runner.cleanup()
+
+
+@pytest.mark.parametrize("fake_omnigent_server", [True, False], indirect=True)
+async def test_omnigent_execute_harvests_resources_with_fake_server(
+    fake_omnigent_server,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    server, server_url = fake_omnigent_server
+    monkeypatch.setenv("OMNIGENT_ENABLED", "1")
+    monkeypatch.setenv("OMNIGENT_SERVER_URL", server_url)
+
+    result = await run_omnigent_execution(
+        AgentExecutionRequest(
+            agentKind="external",
+            agentId="omnigent",
+            correlationId="corr-1",
+            idempotencyKey="idem-1",
+            workspaceSpec={
+                "repository": "https://github.com/org/repo",
+                "branch": "main",
+            },
+            parameters={
+                "omnigent": {
+                    "agent": {"agentName": "codex"},
+                    "session": {"hostType": "managed"},
+                    "prompt": {"text": "Implement MM-1059 fake-server scenario"},
+                }
+            },
+        ),
+        artifact_gateway=LocalOmnigentArtifactGateway(root=tmp_path),
+    )
+
+    assert result.failure_class is None
+    assert result.summary == "fake Omnigent completed"
+    assert result.metadata["workspaceFilesIndexRef"].startswith("artifact://omnigent/")
+    assert result.metadata["sessionFilesIndexRef"].startswith("artifact://omnigent/")
+    assert result.metadata["githubPrUrl"] == "https://github.example/org/repo/pull/42"
+    assert len(server.session_ids) == 1
+    assert len(server.events) == 1
+
+    manifest = json.loads(
+        (tmp_path / "corr-1" / "output.omnigent.capture_manifest.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert manifest["workspaceFiles"][0]["path"] == "README.md"
+    assert manifest["sessionFiles"][0]["filename"] == "session.log"
+    if server.supports_diff:
+        assert manifest["patchUnavailable"] is False
+        assert manifest["workspaceDiffs"][0]["path"] == "src/app.py"
+    else:
+        assert manifest["patchUnavailable"] is True
+        assert "workspaceDiffsUnavailable" in manifest

--- a/tests/unit/omnigent/test_execute.py
+++ b/tests/unit/omnigent/test_execute.py
@@ -192,7 +192,7 @@ async def test_run_omnigent_execution_waits_for_terminal_result(monkeypatch) -> 
 
         async def create_session(self, payload: dict[str, object]) -> dict[str, object]:
             assert payload["agent_id"] == "agent-1"
-            assert payload["labels"]["moonmind.issue"] == "MM-1030"
+            assert payload["labels"]["moonmind.issue"] == "MM-1059"
             return {"id": "session-1"}
 
         async def post_event(
@@ -366,7 +366,7 @@ async def test_run_omnigent_execution_uses_nested_session_parameters(
             "labels": {
                 "moonmind.correlation_id": "corr-1",
                 "moonmind.idempotency_key": "idem-1",
-                "moonmind.issue": "MM-1030",
+                "moonmind.issue": "MM-1059",
             },
             "host_type": "external",
             "workspace": "/workspace/repo",
@@ -507,8 +507,9 @@ async def test_run_omnigent_execution_preserves_session_after_transport_error(
 
 
 @pytest.mark.asyncio
-async def test_run_omnigent_execution_interrupts_and_stops_on_cancellation(
+async def test_run_omnigent_execution_harvests_before_delete_on_cancellation(
     monkeypatch,
+    tmp_path,
 ) -> None:
     calls: list[tuple[str, object]] = []
 
@@ -547,6 +548,35 @@ async def test_run_omnigent_execution_interrupts_and_stops_on_cancellation(
             calls.append(("stop_session", session_id))
             return {}
 
+        async def list_changed_files(self, session_id: str) -> dict[str, object]:
+            calls.append(("list_changed_files", session_id))
+            return {"items": [{"path": "src/app.py"}]}
+
+        async def list_workspace_files(self, session_id: str) -> dict[str, object]:
+            calls.append(("list_workspace_files", session_id))
+            return {"items": [{"path": "src/app.py", "type": "file"}]}
+
+        async def get_workspace_file(self, session_id: str, path: str) -> bytes:
+            calls.append(("get_workspace_file", path))
+            return b"print('cancelled')\n"
+
+        async def get_workspace_diff(self, session_id: str, path: str) -> bytes:
+            calls.append(("get_workspace_diff", path))
+            return b"diff --git a/src/app.py b/src/app.py\n"
+
+        async def list_session_files(self, session_id: str) -> dict[str, object]:
+            calls.append(("list_session_files", session_id))
+            return {"items": []}
+
+        async def delete_session(
+            self,
+            session_id: str,
+            *,
+            delete_branch: bool = False,
+        ) -> dict[str, object]:
+            calls.append(("delete_session", session_id))
+            return {}
+
     async def cancel_immediately(_delay: float) -> None:
         raise asyncio.CancelledError()
 
@@ -567,13 +597,24 @@ async def test_run_omnigent_execution_interrupts_and_stops_on_cancellation(
                         "agent": {"agentName": "codex-native-ui"},
                         "session": {"allowEmptyWorkspace": True},
                         "prompt": {"text": "Do the task"},
+                        "capture": {"deleteOmnigentSessionAfterHarvest": True},
                     },
                 },
-            )
+            ),
+            artifact_gateway=LocalOmnigentArtifactGateway(root=tmp_path),
         )
 
     assert ("interrupt", "session-1") in calls
     assert ("stop_session", "session-1") in calls
+    assert ("list_changed_files", "session-1") in calls
+    assert ("delete_session", "session-1") in calls
+    assert calls.index(("list_changed_files", "session-1")) < calls.index(
+        ("delete_session", "session-1")
+    )
+    manifest_path = tmp_path / "corr-1" / "output.omnigent.capture_manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert manifest["terminalStatus"] == "canceled"
+    assert manifest["patchUnavailable"] is False
 
 
 @pytest.mark.asyncio
@@ -1151,8 +1192,22 @@ async def test_run_omnigent_execution_harvests_changed_and_session_files(
             return {"items": [{"path": "src/app.py"}]}
 
         async def get_workspace_file(self, session_id: str, path: str) -> bytes:
+            return {
+                "README.md": b"# Project\n",
+                "src/app.py": b"print('changed')\n",
+            }[path]
+
+        async def list_workspace_files(self, session_id: str) -> dict[str, object]:
+            return {
+                "items": [
+                    {"path": "README.md", "type": "file"},
+                    {"path": "src", "type": "directory"},
+                ]
+            }
+
+        async def get_workspace_diff(self, session_id: str, path: str) -> bytes:
             assert path == "src/app.py"
-            return b"print('changed')\n"
+            return b"diff --git a/src/app.py b/src/app.py\n"
 
         async def list_session_files(self, session_id: str) -> dict[str, object]:
             return {"items": [{"id": "file-1", "filename": "session.log"}]}
@@ -1184,8 +1239,14 @@ async def test_run_omnigent_execution_harvests_changed_and_session_files(
 
     assert result.failure_class is None
     assert result.metadata["changedFilesIndexRef"].startswith("artifact://omnigent/")
+    assert result.metadata["workspaceFilesIndexRef"].startswith("artifact://omnigent/")
     assert result.metadata["sessionFilesIndexRef"].startswith("artifact://omnigent/")
     assert result.metadata["githubPrUrl"] == "https://github.example/org/repo/pull/1"
+    manifest_path = tmp_path / "corr-1" / "output.omnigent.capture_manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert manifest["workspaceFiles"][0]["path"] == "README.md"
+    assert manifest["workspaceDiffs"][0]["path"] == "src/app.py"
+    assert manifest["patchUnavailable"] is False
 
 
 @pytest.mark.asyncio
@@ -1335,4 +1396,5 @@ async def test_run_omnigent_execution_records_missing_resource_harvest_and_child
     assert manifest["childSessions"] == 1
     assert manifest["childSessionEvidence"][0]["childSessionId"] == "child-1"
     assert "changedFilesUnavailable" in manifest
+    assert "workspaceFilesUnavailable" in manifest
     assert "sessionFilesUnavailable" in manifest

--- a/tests/unit/omnigent/test_execute.py
+++ b/tests/unit/omnigent/test_execute.py
@@ -512,10 +512,13 @@ async def test_run_omnigent_execution_harvests_before_delete_on_cancellation(
     tmp_path,
 ) -> None:
     calls: list[tuple[str, object]] = []
+    httpx_clients: list[object] = []
+    cleanup_harvest_client_ids: list[int] = []
 
     class FakeClient:
-        def __init__(self, **_: object) -> None:
-            pass
+        def __init__(self, **kwargs: object) -> None:
+            self.httpx_client = kwargs["client"]
+            httpx_clients.append(self.httpx_client)
 
         async def list_agents(self) -> dict[str, object]:
             return {"items": [{"id": "agent-1", "name": "codex-native-ui"}]}
@@ -550,6 +553,7 @@ async def test_run_omnigent_execution_harvests_before_delete_on_cancellation(
 
         async def list_changed_files(self, session_id: str) -> dict[str, object]:
             calls.append(("list_changed_files", session_id))
+            cleanup_harvest_client_ids.append(id(self.httpx_client))
             return {"items": [{"path": "src/app.py"}]}
 
         async def list_workspace_files(self, session_id: str) -> dict[str, object]:
@@ -608,6 +612,8 @@ async def test_run_omnigent_execution_harvests_before_delete_on_cancellation(
     assert ("stop_session", "session-1") in calls
     assert ("list_changed_files", "session-1") in calls
     assert ("delete_session", "session-1") in calls
+    assert len(httpx_clients) == 2
+    assert cleanup_harvest_client_ids == [id(httpx_clients[1])]
     assert calls.index(("list_changed_files", "session-1")) < calls.index(
         ("delete_session", "session-1")
     )
@@ -1247,6 +1253,83 @@ async def test_run_omnigent_execution_harvests_changed_and_session_files(
     assert manifest["workspaceFiles"][0]["path"] == "README.md"
     assert manifest["workspaceDiffs"][0]["path"] == "src/app.py"
     assert manifest["patchUnavailable"] is False
+
+
+@pytest.mark.asyncio
+async def test_run_omnigent_execution_honors_workspace_files_capture_opt_out(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    class FakeClient:
+        def __init__(self, **_: object) -> None:
+            pass
+
+        async def list_agents(self) -> dict[str, object]:
+            return {"items": [{"id": "agent-1", "name": "codex-native-ui"}]}
+
+        async def create_session(self, payload: dict[str, object]) -> dict[str, object]:
+            return {"id": "session-1"}
+
+        async def post_event(
+            self,
+            session_id: str,
+            payload: dict[str, object],
+        ) -> dict[str, object]:
+            return {"pending_id": "pending-1"}
+
+        async def stream_events(self, session_id: str):
+            yield {"type": "response.completed"}
+
+        async def get_session(self, session_id: str) -> dict[str, object]:
+            return {"status": "completed", "summary": "done"}
+
+        async def list_changed_files(self, session_id: str) -> dict[str, object]:
+            return {"items": [{"path": "src/app.py"}]}
+
+        async def get_workspace_file(self, session_id: str, path: str) -> bytes:
+            assert path == "src/app.py"
+            return b"print('changed')\n"
+
+        async def list_workspace_files(self, session_id: str) -> dict[str, object]:
+            raise AssertionError("workspaceFiles=false must skip workspace file harvest")
+
+        async def get_workspace_diff(self, session_id: str, path: str) -> bytes:
+            assert path == "src/app.py"
+            return b"diff --git a/src/app.py b/src/app.py\n"
+
+        async def list_session_files(self, session_id: str) -> dict[str, object]:
+            return {"items": []}
+
+    monkeypatch.setenv("OMNIGENT_ENABLED", "true")
+    monkeypatch.setenv("OMNIGENT_SERVER_URL", "https://omnigent.test")
+    monkeypatch.setattr("moonmind.omnigent.execute.OmnigentHttpClient", FakeClient)
+
+    result = await run_omnigent_execution(
+        AgentExecutionRequest(
+            agentKind="external",
+            agentId="omnigent",
+            correlationId="corr-1",
+            idempotencyKey="idem-1",
+            parameters={
+                "omnigent": {
+                    "agent": {"agentName": "codex-native-ui"},
+                    "session": {"allowEmptyWorkspace": True},
+                    "prompt": {"text": "Do the task"},
+                    "capture": {"workspaceFiles": False},
+                },
+            },
+        ),
+        artifact_gateway=LocalOmnigentArtifactGateway(root=tmp_path),
+    )
+
+    assert result.failure_class is None
+    assert "workspaceFilesIndexRef" not in result.metadata
+    manifest_path = tmp_path / "corr-1" / "output.omnigent.capture_manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert "workspaceFilesIndexRef" not in manifest
+    assert "workspaceFiles" not in manifest
+    assert manifest["changedFiles"][0]["path"] == "src/app.py"
+    assert manifest["workspaceDiffs"][0]["path"] == "src/app.py"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/workflows/adapters/test_omnigent_client.py
+++ b/tests/unit/workflows/adapters/test_omnigent_client.py
@@ -14,14 +14,18 @@ from moonmind.workflows.adapters.omnigent_client import (
 
 @pytest.mark.asyncio
 async def test_omnigent_client_exposes_confirmed_operations() -> None:
-    assert not hasattr(OmnigentHttpClient, "get_workspace_diff")
-
     async def handler(request: httpx.Request) -> httpx.Response:
         if request.method == "GET" and request.url.path == "/api/agents":
             return httpx.Response(
                 200,
                 json={"agents": [{"id": "ag_1", "name": "codex"}]},
             )
+        if request.method == "GET" and request.url.path.endswith("/diff/src/app.py"):
+            return httpx.Response(200, content=b"diff --git a/src/app.py b/src/app.py\n")
+        if request.method == "GET" and request.url.path.endswith(
+            "/filesystem/src/app.py"
+        ):
+            return httpx.Response(200, content=b"print('ok')\n")
         if request.method == "DELETE":
             assert request.url.path == "/v1/sessions/sess_1"
             assert request.url.query == b"delete_branch=false"
@@ -48,6 +52,12 @@ async def test_omnigent_client_exposes_confirmed_operations() -> None:
         {"answer": "yes"},
     ) == {"ok": True}
     assert await client.list_changed_files("sess_1") == {"ok": True}
+    assert await client.list_workspace_files("sess_1") == {"ok": True}
+    assert await client.get_workspace_file("sess_1", "src/app.py") == b"print('ok')\n"
+    assert await client.get_workspace_diff(
+        "sess_1",
+        "src/app.py",
+    ) == b"diff --git a/src/app.py b/src/app.py\n"
     assert await client.list_session_files("sess_1") == {"ok": True}
     assert await client.interrupt("sess_1") == {"ok": True}
     assert await client.stop_session("sess_1") == {"ok": True}


### PR DESCRIPTION
Issue reference: MM-1059

Summary:
- Adds Omnigent workspace file harvesting and artifact refs alongside changed/session file capture.
- Adds workspace diff capability probing with graceful patch-unavailable diagnostics when diffs are unavailable.
- Harvests cancellation evidence before optional session deletion and expands fake-server/client coverage.

Tests run:
- MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/omnigent/test_execute.py tests/unit/workflows/adapters/test_omnigent_client.py
- MOONMIND_FORCE_LOCAL_TESTS=1 pytest tests/integration/omnigent/test_execute_fake_server.py -q --tb=short

Remaining risks:
- Live disposable Omnigent server smoke coverage was not run in this environment.
- Fake-server scenarios cover the newly added harvest paths, but not every long-running stream disconnect/reconnect variant from the broader acceptance text.