### PR TITLE
MM-1056 Render Skill input schemas on Create page

### DIFF
--- a/frontend/src/entrypoints/workflow-start.test.tsx
+++ b/frontend/src/entrypoints/workflow-start.test.tsx
@@ -5427,7 +5427,7 @@ describe.skip("Task Create Entrypoint", () => {
     });
     expect(request.payload.task.skill).toEqual({
       id: "moonspec-orchestrate",
-      args: {
+      inputs: {
         issueKey: "MM-564",
         mode: "runtime",
       },
@@ -10705,7 +10705,7 @@ describe.skip("Task Create Entrypoint", () => {
     });
     expect(savedStep?.skill).toEqual({
       id: "auto",
-      args: { mode: "advanced" },
+      inputs: { mode: "advanced" },
       requiredCapabilities: ["docker"],
     });
 
@@ -15577,14 +15577,78 @@ describe("Task Create schema-driven capability inputs", () => {
                 type: "object",
                 required: ["repository"],
                 properties: {
-                  repository: { type: "string", title: "Repository name" },
+                  repository: {
+                    type: "string",
+                    title: "Repository name",
+                    "x-moonmind-widget": "repository",
+                  },
+                  branch: {
+                    type: "string",
+                    title: "Branch",
+                    "x-moonmind-widget": "branch",
+                  },
+                  notes: {
+                    type: "string",
+                    title: "Notes",
+                    "x-moonmind-widget": "textarea",
+                  },
+                  markdown: {
+                    type: "string",
+                    title: "Markdown",
+                    "x-moonmind-widget": "markdown",
+                  },
                   effort: { type: "number", title: "Effort" },
+                  enabled: { type: "boolean", title: "Enabled" },
+                  priority: {
+                    type: "string",
+                    title: "Priority",
+                    enum: ["low", "high"],
+                  },
+                  labels: {
+                    type: "array",
+                    title: "Labels",
+                    items: {
+                      type: "string",
+                      enum: ["frontend", "backend"],
+                    },
+                  },
+                  homepage: {
+                    type: "string",
+                    format: "uri",
+                    title: "Homepage",
+                  },
+                  email: {
+                    type: "string",
+                    format: "email",
+                    title: "Email",
+                  },
+                  due: {
+                    type: "string",
+                    format: "date",
+                    title: "Due",
+                  },
+                  starts_at: {
+                    type: "string",
+                    format: "date-time",
+                    title: "Starts at",
+                  },
+                  metadata: { type: "object", title: "Metadata" },
+                  unsupported_widget: {
+                    type: "string",
+                    title: "Unsupported widget",
+                    "x-moonmind-widget": "external.lookup",
+                  },
                 },
               },
               uiSchema: {},
               defaults: {
                 repository: "MoonLadderStudios/MoonMind",
+                branch: "main",
                 effort: 2,
+                enabled: true,
+                priority: "high",
+                labels: ["frontend"],
+                metadata: { source: "skill" },
               },
             },
           ],
@@ -16180,6 +16244,62 @@ describe("Task Create schema-driven capability inputs", () => {
     });
 
     expect(await within(step).findByLabelText("Repository name")).toBeTruthy();
+    expect(within(step).getByLabelText("Branch")).toBeTruthy();
+    expect(within(step).getByLabelText("Notes").tagName).toBe("TEXTAREA");
+    expect(within(step).getByLabelText("Markdown").tagName).toBe("TEXTAREA");
+    expect((within(step).getByLabelText("Effort") as HTMLInputElement).type).toBe("number");
+    expect(within(step).getByLabelText("Enabled")).toBeTruthy();
+    expect(within(step).getByLabelText("Priority")).toBeTruthy();
+    expect((within(step).getByLabelText("Labels") as HTMLSelectElement).multiple).toBe(true);
+    expect((within(step).getByLabelText("Homepage") as HTMLInputElement).type).toBe("url");
+    expect((within(step).getByLabelText("Email") as HTMLInputElement).type).toBe("email");
+    expect((within(step).getByLabelText("Due") as HTMLInputElement).type).toBe("date");
+    expect((within(step).getByLabelText("Starts at") as HTMLInputElement).type).toBe("datetime-local");
+    expect(within(step).getByLabelText("Metadata").tagName).toBe("TEXTAREA");
+    expect(within(step).getByText("Unsupported field widget.")).toBeTruthy();
+  });
+
+  it("preserves MM-1056 Skill fallback values under step.skill.inputs for MM-1047 traceability", async () => {
+    renderWithClient(<WorkflowStartPage payload={mockPayload} />);
+    const step = (await screen.findByText("Step 1")).closest("section") as HTMLElement;
+    selectStepType(step, "Skill");
+    fireEvent.change(within(step).getByLabelText("Skill (optional)"), {
+      target: { value: "schema.skill" },
+    });
+
+    fireEvent.change(await within(step).findByLabelText("Repository name"), {
+      target: { value: "MoonLadderStudios/MoonMind" },
+    });
+    fireEvent.change(within(step).getByLabelText("Branch"), {
+      target: { value: "feature/mm-1056" },
+    });
+    fireEvent.change(within(step).getByLabelText("Unsupported widget"), {
+      target: { value: "manual fallback survives" },
+    });
+    fireEvent.change(within(step).getByLabelText("Metadata"), {
+      target: { value: '{"sourceIssue":"MM-1047"}' },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Start Workflow" }));
+
+    await waitFor(() => {
+      expect(
+        fetchSpy.mock.calls.some(([url]) => String(url) === "/api/executions"),
+      ).toBe(true);
+    });
+    const request = latestSchemaCreateRequest() as {
+      payload: {
+        task: {
+          skill?: { inputs?: Record<string, unknown>; args?: Record<string, unknown> };
+        };
+      };
+    };
+    expect(request.payload.task.skill?.inputs).toMatchObject({
+      repository: "MoonLadderStudios/MoonMind",
+      branch: "feature/mm-1056",
+      unsupported_widget: "manual fallback survives",
+      metadata: { sourceIssue: "MM-1047" },
+    });
+    expect(request.payload.task.skill?.args).toBeUndefined();
   });
 
   it("submits direct skill schema inputs in the skill payload", async () => {
@@ -16205,16 +16325,17 @@ describe("Task Create schema-driven capability inputs", () => {
       payload: {
         task: {
           tool?: { inputs?: Record<string, unknown> };
-          skill?: { args?: Record<string, unknown> };
+          skill?: { inputs?: Record<string, unknown>; args?: Record<string, unknown> };
         };
       };
     };
     expect(request.payload.task.tool?.inputs).toMatchObject({
       repository: "MoonLadderStudios/SchemaRepo",
     });
-    expect(request.payload.task.skill?.args).toMatchObject({
+    expect(request.payload.task.skill?.inputs).toMatchObject({
       repository: "MoonLadderStudios/SchemaRepo",
     });
+    expect(request.payload.task.skill?.args).toBeUndefined();
   });
 
   it("keeps cleared optional numeric schema inputs unset", async () => {
@@ -16666,7 +16787,7 @@ describe("Task Create governed Tool authoring", () => {
     });
     expect(request.payload.task.skill).toEqual({
       id: "moonspec-orchestrate",
-      args: {
+      inputs: {
         issueKey: "MM-577",
         mode: "runtime",
       },

--- a/frontend/src/entrypoints/workflow-start.test.tsx
+++ b/frontend/src/entrypoints/workflow-start.test.tsx
@@ -15569,7 +15569,7 @@ describe("Task Create schema-driven capability inputs", () => {
       return Promise.resolve({
         ok: true,
         json: async () => ({
-          items: { worker: ["schema.skill"] },
+          items: { worker: ["schema.skill", "schema.other"] },
           legacyItems: [
             {
               id: "schema.skill",
@@ -15649,6 +15649,30 @@ describe("Task Create schema-driven capability inputs", () => {
                 priority: "high",
                 labels: ["frontend"],
                 metadata: { source: "skill" },
+              },
+            },
+            {
+              id: "schema.other",
+              inputSchema: {
+                type: "object",
+                required: ["repository"],
+                properties: {
+                  repository: {
+                    type: "string",
+                    title: "Repository name",
+                    "x-moonmind-widget": "repository",
+                  },
+                  branch: {
+                    type: "string",
+                    title: "Branch",
+                    "x-moonmind-widget": "branch",
+                  },
+                },
+              },
+              uiSchema: {},
+              defaults: {
+                repository: "MoonLadderStudios/Other",
+                branch: "develop",
               },
             },
           ],
@@ -16026,6 +16050,12 @@ describe("Task Create schema-driven capability inputs", () => {
         json: async () => ({ workflowId: "mm:schema-create" }),
       } as Response);
     }
+    if (url === "/api/presets/save-from-workflow") {
+      return Promise.resolve({
+        ok: true,
+        json: async () => ({ title: "Schema Skill Preset" }),
+      } as Response);
+    }
     return Promise.resolve({
       ok: false,
       status: 404,
@@ -16336,6 +16366,107 @@ describe("Task Create schema-driven capability inputs", () => {
       repository: "MoonLadderStudios/SchemaRepo",
     });
     expect(request.payload.task.skill?.args).toBeUndefined();
+  });
+
+  it("saves direct skill schema inputs in preset payloads", async () => {
+    renderWithClient(<WorkflowStartPage payload={mockPayload} />);
+    const step = (await screen.findByText("Step 1")).closest("section") as HTMLElement;
+    selectStepType(step, "Skill");
+    fireEvent.change(within(step).getByLabelText("Instructions"), {
+      target: { value: "Save schema-backed skill inputs." },
+    });
+    fireEvent.change(within(step).getByLabelText("Skill (optional)"), {
+      target: { value: "schema.skill" },
+    });
+
+    fireEvent.change(await within(step).findByLabelText("Repository name"), {
+      target: { value: "MoonLadderStudios/SavedSchemaRepo" },
+    });
+    fireEvent.change(within(step).getByLabelText("Branch"), {
+      target: { value: "feature/saved-schema" },
+    });
+
+    const presetsSection = await screen.findByLabelText("Preset Management");
+    fireEvent.click(
+      within(presetsSection).getByRole("button", { name: "Save preset" }),
+    );
+    const dialog = await screen.findByRole("dialog", { name: "Save preset" });
+    fireEvent.change(within(dialog).getByLabelText("Preset Name"), {
+      target: { value: "Schema Skill Preset" },
+    });
+    fireEvent.click(
+      within(dialog).getByRole("button", { name: "Confirm save preset" }),
+    );
+
+    await waitFor(() => {
+      const saveCall = fetchSpy.mock.calls.find(
+        ([url, init]) =>
+          String(url) === "/api/presets/save-from-workflow" &&
+          init?.method === "POST",
+      );
+      expect(saveCall).toBeTruthy();
+      const body = JSON.parse(String(saveCall?.[1]?.body || "{}")) as {
+        steps: Array<{
+          skill?: { inputs?: Record<string, unknown> };
+          tool?: { inputs?: Record<string, unknown> };
+        }>;
+      };
+      expect(body.steps[0]?.tool?.inputs).toMatchObject({
+        repository: "MoonLadderStudios/SavedSchemaRepo",
+        branch: "feature/saved-schema",
+      });
+      expect(body.steps[0]?.skill?.inputs).toMatchObject({
+        repository: "MoonLadderStudios/SavedSchemaRepo",
+        branch: "feature/saved-schema",
+      });
+    });
+  });
+
+  it("clears direct skill schema values when switching skills", async () => {
+    renderWithClient(<WorkflowStartPage payload={mockPayload} />);
+    const step = (await screen.findByText("Step 1")).closest("section") as HTMLElement;
+    selectStepType(step, "Skill");
+    fireEvent.change(within(step).getByLabelText("Skill (optional)"), {
+      target: { value: "schema.skill" },
+    });
+
+    fireEvent.change(await within(step).findByLabelText("Repository name"), {
+      target: { value: "MoonLadderStudios/StaleRepo" },
+    });
+    fireEvent.change(within(step).getByLabelText("Skill (optional)"), {
+      target: { value: "schema.other" },
+    });
+
+    await waitFor(() => {
+      expect(
+        (within(step).getByLabelText("Repository name") as HTMLInputElement)
+          .value,
+      ).toBe("MoonLadderStudios/Other");
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Start Workflow" }));
+
+    await waitFor(() => {
+      expect(
+        fetchSpy.mock.calls.some(([url]) => String(url) === "/api/executions"),
+      ).toBe(true);
+    });
+    const request = latestSchemaCreateRequest() as {
+      payload: {
+        task: {
+          skill?: { inputs?: Record<string, unknown> };
+          tool?: { inputs?: Record<string, unknown> };
+        };
+      };
+    };
+    expect(request.payload.task.tool?.inputs).toMatchObject({
+      repository: "MoonLadderStudios/Other",
+      branch: "develop",
+    });
+    expect(request.payload.task.skill?.inputs).toMatchObject({
+      repository: "MoonLadderStudios/Other",
+      branch: "develop",
+    });
   });
 
   it("keeps cleared optional numeric schema inputs unset", async () => {

--- a/frontend/src/entrypoints/workflow-start.tsx
+++ b/frontend/src/entrypoints/workflow-start.tsx
@@ -3064,7 +3064,15 @@ function schemaChoiceOptions(schema: Record<string, unknown>): Array<{
 
 function textInputTypeForSchema(schema: Record<string, unknown>): string {
   const format = String(schema.format || "").trim().toLowerCase();
-  if (format === "email" || format === "uri" || format === "url" || format === "date") {
+  if (format === "date-time") {
+    return "datetime-local";
+  }
+  if (
+    format === "email" ||
+    format === "uri" ||
+    format === "url" ||
+    format === "date"
+  ) {
     return format === "uri" ? "url" : format;
   }
   if (schema.type === "number" || schema.type === "integer") {
@@ -3109,15 +3117,23 @@ function unsupportedCapabilityWidget(
   const supported = new Set([
     "array",
     "boolean",
+    "branch",
     "date",
+    "date-time",
     "email",
     "integer",
     "github.issue-picker",
     "jira.issue-picker",
+    "markdown",
     "number",
     "object",
+    "repository",
+    "repository-picker",
+    "repo",
+    "repo-picker",
     "string",
     "text",
+    "textarea",
     "uri",
     "url",
   ]);
@@ -3177,6 +3193,13 @@ function capabilityInputTextValue(
     return String(record.key || "");
   }
   return value === undefined || value === null ? "" : String(value);
+}
+
+function capabilityInputStringArrayValue(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.map((item) => String(item)).filter(Boolean);
 }
 
 function normalizeGitHubIssueInput(
@@ -3323,6 +3346,21 @@ function validateSchemaCapabilityValues(
     if (value === undefined || value === null || value === "") {
       continue;
     }
+    if (fieldSchema.type === "array") {
+      if (!Array.isArray(value)) {
+        errors[name] = `${capabilityFieldLabel(name, fieldSchema)} must be a JSON array.`;
+        continue;
+      }
+      const itemSchema = recordValue(fieldSchema.items);
+      if (Array.isArray(itemSchema.enum)) {
+        const allowed = new Set(itemSchema.enum.map((item) => String(item)));
+        const invalid = value.some((item) => !allowed.has(String(item)));
+        if (invalid) {
+          errors[name] = `${capabilityFieldLabel(name, fieldSchema)} must use available options.`;
+          continue;
+        }
+      }
+    }
     if (Array.isArray(fieldSchema.enum)) {
       const allowed = new Set(fieldSchema.enum.map((item) => String(item)));
       if (!allowed.has(String(value))) {
@@ -3389,6 +3427,20 @@ function mergeSkillArgsWithSchemaInputs(
   schemaInputs: Record<string, unknown>,
 ): Record<string, unknown> {
   return { ...skillArgs, ...schemaInputs };
+}
+
+function skillPayloadWithInputs(
+  skillId: string,
+  inputs: Record<string, unknown>,
+  requiredCapabilities: string[] = [],
+): PresetStepSkill {
+  return {
+    id: skillId,
+    inputs,
+    ...(requiredCapabilities.length > 0
+      ? { requiredCapabilities }
+      : {}),
+  };
 }
 
 function schemaToolInputs(
@@ -3755,6 +3807,8 @@ function SchemaCapabilityFields({
   values,
   errors,
   disabled,
+  repositoryOptions,
+  branchOptions,
   onChange,
 }: {
   fields: Array<[string, unknown]>;
@@ -3762,6 +3816,8 @@ function SchemaCapabilityFields({
   values: Record<string, unknown>;
   errors: Record<string, string>;
   disabled: boolean;
+  repositoryOptions: RepositoryOption[];
+  branchOptions: BranchOption[];
   onChange: (name: string, value: unknown) => void;
 }): ReactElement | null {
   if (fields.length === 0) {
@@ -3787,11 +3843,12 @@ function SchemaCapabilityFields({
                 id={inputId}
                 type="text"
                 value={capabilityInputTextValue(values, detail.defaults, name)}
-                disabled
-                aria-invalid
-                onChange={() => undefined}
+                disabled={disabled}
+                aria-invalid={Boolean(error)}
+                onChange={(event) => onChange(name, event.target.value)}
               />
               <span className="notice small">Unsupported field widget.</span>
+              {error ? <span className="notice small">{error}</span> : null}
             </label>
           );
         }
@@ -3851,6 +3908,54 @@ function SchemaCapabilityFields({
             </label>
           );
         }
+        const itemSchema = recordValue(fieldSchema.items);
+        if (
+          fieldSchema.type === "array" &&
+          (Array.isArray(itemSchema.enum) || schemaChoiceOptions(itemSchema).length > 0)
+        ) {
+          const itemChoices = schemaChoiceOptions(itemSchema);
+          const itemEnumOptions = Array.isArray(itemSchema.enum)
+            ? itemSchema.enum
+            : [];
+          const itemOptions: Array<{ label: string; value: unknown }> =
+            itemChoices.length > 0
+              ? itemChoices
+              : itemEnumOptions.map((option: unknown) => ({
+                  label: String(option),
+                  value: option,
+                }));
+          const selectedValues = capabilityInputStringArrayValue(value);
+          return (
+            <label key={name} htmlFor={inputId}>
+              {label}
+              <select
+                id={inputId}
+                multiple
+                value={selectedValues}
+                disabled={disabled}
+                aria-invalid={Boolean(error)}
+                onChange={(event) => {
+                  const selected = Array.from(event.currentTarget.selectedOptions)
+                    .map((option) => {
+                      const matched = itemOptions.find(
+                        (item) => String(item.value) === option.value,
+                      );
+                      return matched?.value ?? option.value;
+                    });
+                  onChange(name, selected);
+                }}
+              >
+                {itemOptions.map((option) => (
+                  <option key={String(option.value)} value={String(option.value)}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+              {description ? <span className="small">{description}</span> : null}
+              {error ? <span className="notice small">{error}</span> : null}
+            </label>
+          );
+        }
         if (Array.isArray(fieldSchema.enum) || choices.length > 0) {
           const enumOptions = Array.isArray(fieldSchema.enum)
             ? fieldSchema.enum
@@ -3888,6 +3993,22 @@ function SchemaCapabilityFields({
             </label>
           );
         }
+        if (widget === "textarea" || widget === "markdown") {
+          return (
+            <label key={name} htmlFor={inputId}>
+              {label}
+              <textarea
+                id={inputId}
+                value={capabilityInputTextValue(values, detail.defaults, name)}
+                disabled={disabled}
+                aria-invalid={Boolean(error)}
+                onChange={(event) => onChange(name, event.target.value)}
+              />
+              {description ? <span className="small">{description}</span> : null}
+              {error ? <span className="notice small">{error}</span> : null}
+            </label>
+          );
+        }
         if (fieldSchema.type === "array" || fieldSchema.type === "object") {
           return (
             <label key={name} htmlFor={inputId}>
@@ -3913,6 +4034,15 @@ function SchemaCapabilityFields({
             <input
               id={inputId}
               type={inputType}
+              list={
+                widget === "repository" ||
+                widget === "repository-picker" ||
+                widget === "repo" ||
+                widget === "repo-picker" ||
+                widget === "branch"
+                  ? `${inputId}-options`
+                  : undefined
+              }
               value={capabilityInputTextValue(values, detail.defaults, name)}
               disabled={disabled}
               aria-invalid={Boolean(error)}
@@ -3927,6 +4057,27 @@ function SchemaCapabilityFields({
                 )
               }
             />
+            {widget === "repository" ||
+            widget === "repository-picker" ||
+            widget === "repo" ||
+            widget === "repo-picker" ? (
+              <datalist id={`${inputId}-options`}>
+                {repositoryOptions.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </datalist>
+            ) : null}
+            {widget === "branch" ? (
+              <datalist id={`${inputId}-options`}>
+                {branchOptions.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </datalist>
+            ) : null}
             {description ? <span className="small">{description}</span> : null}
             {error ? <span className="notice small">{error}</span> : null}
           </label>
@@ -8299,11 +8450,11 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
           ...(caps.length > 0 ? { requiredCapabilities: caps } : {}),
         };
         blueprint.tool = normalizedTool;
-        blueprint.skill = {
-          id: normalizedTool.name,
-          args: skillArgs,
-          ...(caps.length > 0 ? { requiredCapabilities: caps } : {}),
-        };
+        blueprint.skill = skillPayloadWithInputs(
+          normalizedTool.name,
+          skillArgs,
+          caps,
+        );
       }
       presetSteps.push(blueprint);
     }
@@ -9001,13 +9152,11 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
         ? { requiredCapabilities: taskSkillRequiredCapabilities }
         : {}),
     };
-    const primaryStepSkill = {
-      id: primarySkillId,
-      args: primarySkillArgs,
-      ...(taskSkillRequiredCapabilities.length > 0
-        ? { requiredCapabilities: taskSkillRequiredCapabilities }
-        : {}),
-    };
+    const primaryStepSkill = skillPayloadWithInputs(
+      primarySkillId,
+      primarySkillArgs,
+      taskSkillRequiredCapabilities,
+    );
     const primaryStepHasSkillOverride =
       hasExplicitSkillSelection(primarySkillId) ||
       Object.keys(primarySkillArgs).length > 0 ||
@@ -9446,13 +9595,11 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
             ? { requiredCapabilities: stepSkillCaps }
             : {}),
         };
-        stepPayload.skill = {
-          id: stepSkillId || primarySkillId,
-          args: stepSkillArgs,
-          ...(stepSkillCaps.length > 0
-            ? { requiredCapabilities: stepSkillCaps }
-            : {}),
-        };
+        stepPayload.skill = skillPayloadWithInputs(
+          stepSkillId || primarySkillId,
+          stepSkillArgs,
+          stepSkillCaps,
+        );
         stepSkillRequiredCapabilities.push(...stepSkillCaps);
       }
       additionalSteps.push({ sourceIndex, payload: stepPayload });
@@ -10827,6 +10974,8 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
                             values={step.toolInputValues}
                             errors={step.toolInputErrors}
                             disabled={false}
+                            repositoryOptions={repositoryOptions}
+                            branchOptions={branchOptions}
                             onChange={(name, value) =>
                               updateToolInputValue(step.localId, name, value)
                             }
@@ -11122,6 +11271,8 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
                                 values={step.toolInputValues}
                                 errors={step.toolInputErrors}
                                 disabled={false}
+                                repositoryOptions={repositoryOptions}
+                                branchOptions={branchOptions}
                                 onChange={(name, value) =>
                                   updateToolInputValue(step.localId, name, value)
                                 }
@@ -11280,6 +11431,8 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
                           values={step.presetInputValues}
                           errors={step.presetInputErrors}
                           disabled={false}
+                          repositoryOptions={repositoryOptions}
+                          branchOptions={branchOptions}
                           onChange={(name, value) =>
                             updateStepPresetInputValue(
                               step.localId,
@@ -11516,6 +11669,8 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
                           values={step.presetInputValues}
                           errors={step.presetInputErrors}
                           disabled={isApplyingPreset}
+                          repositoryOptions={repositoryOptions}
+                          branchOptions={branchOptions}
                           onChange={(name, value) =>
                             updateStepPresetInputValue(
                               step.localId,

--- a/frontend/src/entrypoints/workflow-start.tsx
+++ b/frontend/src/entrypoints/workflow-start.tsx
@@ -3841,6 +3841,7 @@ function SchemaCapabilityFields({
               {label}
               <input
                 id={inputId}
+                aria-label={label}
                 type="text"
                 value={capabilityInputTextValue(values, detail.defaults, name)}
                 disabled={disabled}
@@ -3864,6 +3865,7 @@ function SchemaCapabilityFields({
               {label}
               <input
                 id={inputId}
+                aria-label={label}
                 type="text"
                 value={issuePickerTextValue(value, provider)}
                 placeholder={placeholder}
@@ -3897,6 +3899,7 @@ function SchemaCapabilityFields({
               {label}
               <input
                 id={inputId}
+                aria-label={label}
                 type="checkbox"
                 checked={Boolean(value)}
                 disabled={disabled}
@@ -3930,6 +3933,7 @@ function SchemaCapabilityFields({
               {label}
               <select
                 id={inputId}
+                aria-label={label}
                 multiple
                 value={selectedValues}
                 disabled={disabled}
@@ -3972,6 +3976,7 @@ function SchemaCapabilityFields({
               {label}
               <select
                 id={inputId}
+                aria-label={label}
                 value={capabilityInputTextValue(values, detail.defaults, name)}
                 disabled={disabled}
                 aria-invalid={Boolean(error)}
@@ -3999,6 +4004,7 @@ function SchemaCapabilityFields({
               {label}
               <textarea
                 id={inputId}
+                aria-label={label}
                 value={capabilityInputTextValue(values, detail.defaults, name)}
                 disabled={disabled}
                 aria-invalid={Boolean(error)}
@@ -4015,6 +4021,7 @@ function SchemaCapabilityFields({
               {label}
               <textarea
                 id={inputId}
+                aria-label={label}
                 value={complexCapabilityTextValue(value)}
                 disabled={disabled}
                 aria-invalid={Boolean(error)}
@@ -4033,6 +4040,7 @@ function SchemaCapabilityFields({
             {label}
             <input
               id={inputId}
+              aria-label={label}
               type={inputType}
               list={
                 widget === "repository" ||
@@ -4063,18 +4071,22 @@ function SchemaCapabilityFields({
             widget === "repo-picker" ? (
               <datalist id={`${inputId}-options`}>
                 {repositoryOptions.map((option) => (
-                  <option key={option.value} value={option.value}>
-                    {option.label}
-                  </option>
+                  <option
+                    key={option.value}
+                    value={option.value}
+                    label={option.label}
+                  />
                 ))}
               </datalist>
             ) : null}
             {widget === "branch" ? (
               <datalist id={`${inputId}-options`}>
                 {branchOptions.map((option) => (
-                  <option key={option.value} value={option.value}>
-                    {option.label}
-                  </option>
+                  <option
+                    key={option.value}
+                    value={option.value}
+                    label={option.label}
+                  />
                 ))}
               </datalist>
             ) : null}

--- a/frontend/src/entrypoints/workflow-start.tsx
+++ b/frontend/src/entrypoints/workflow-start.tsx
@@ -7386,9 +7386,13 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
         }
         if (
           Object.prototype.hasOwnProperty.call(updates, "skillId") &&
-          !showAdvancedStepOptions
+          updates.skillId !== step.skillId
         ) {
-          nextStep.skillArgs = "";
+          nextStep.presetInputValues = {};
+          nextStep.presetInputErrors = {};
+          if (!showAdvancedStepOptions) {
+            nextStep.skillArgs = "";
+          }
         }
         if (Object.prototype.hasOwnProperty.call(updates, "toolInputValues")) {
           nextStep.toolInputs = serializeToolInputValues(nextStep.toolInputValues);
@@ -8435,7 +8439,29 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
       // chip selector, so they persist into presets regardless of Advanced mode.
       const caps = step.explicitRequiredCapabilities;
       const skillArgsRaw = showAdvancedStepOptions ? step.skillArgs.trim() : "";
-      if (skillId || skillArgsRaw || caps.length > 0) {
+      const skillDetail = skillId
+        ? skillsQuery.data?.detailsById[skillId] || null
+        : null;
+      const structuredSkillInputs = schemaSkillInputs(
+        skillDetail,
+        step.presetInputValues,
+      );
+      if (Object.keys(structuredSkillInputs.errors).length > 0) {
+        updateStep(step.localId, {
+          presetInputErrors: structuredSkillInputs.errors,
+        });
+        setTemplateMessage(
+          Object.values(structuredSkillInputs.errors)[0] ||
+            `Complete required Skill input fields before saving Step ${index + 1}.`,
+        );
+        return false;
+      }
+      if (
+        skillId ||
+        skillArgsRaw ||
+        Object.keys(structuredSkillInputs.values).length > 0 ||
+        caps.length > 0
+      ) {
         let skillArgs: Record<string, unknown> = {};
         if (skillArgsRaw) {
           try {
@@ -8455,6 +8481,10 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
             return false;
           }
         }
+        skillArgs = mergeSkillArgsWithSchemaInputs(
+          skillArgs,
+          structuredSkillInputs.values,
+        );
         const normalizedTool = {
           type: "skill",
           name: skillId || "auto",


### PR DESCRIPTION
Issue reference: MM-1056

Summary:
- Extends the shared Create page schema renderer used by presets so selected Skill input schemas cover textarea/markdown, multi-select arrays, date-time, repository, branch, and unsupported-widget fallback paths.
- Persists structured Skill values under step.skill.inputs instead of skill.args for direct and generated Skill steps.
- Adds frontend regression coverage for MM-1056 field rendering and fallback value preservation.

Tests run:
- ./tools/test_unit.sh --dashboard-only --ui-args frontend/src/entrypoints/workflow-start.test.tsx frontend/src/lib/temporalTaskEditing.test.ts (passed: 85 passed, 237 skipped)
- ./node_modules/.bin/tsc --noEmit -p frontend/tsconfig.json (passed)
- ./node_modules/.bin/vite build --config frontend/vite.config.ts (passed)
- git diff --check (passed)

Remaining risks:
- The change is focused on the frontend Create page payload and rendering behavior; backend Skill contract exposure was already present.
- Full unit runner was not used because this managed container lacks pytest; the dashboard-only focused frontend runner was used for the affected UI files.