### PR TITLE
MM-1060 degrade Temporal execution list counts

### DIFF
--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -9428,6 +9428,22 @@ async def list_executions(
                             getattr(record_obj, "started_at", None) or datetime.now(UTC)
                         )
                     execution = _serialize_execution_list_item(record_obj)
+                    if (
+                        _execution_uses_live_workflow_queries(execution)
+                        and (
+                            _request_has_progress_filters(request)
+                            or sort in {"progress", "progressPct"}
+                        )
+                    ):
+                        progress, queried_run_id = await _load_execution_progress(
+                            temporal_client=temporal_client,
+                            workflow_id=wf.id,
+                        )
+                        update: dict[str, object] = {"progress": progress}
+                        if queried_run_id:
+                            update["run_id"] = queried_run_id
+                            update["temporal_run_id"] = queried_run_id
+                        execution = execution.model_copy(update=update)
                     items.append(execution)
 
                 if _request_has_progress_filters(request):

--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -247,6 +247,7 @@ _EXECUTION_FACET_ATTRS = {
 _OPTIONAL_TEMPORAL_SEARCH_ATTRIBUTES = {
     "mm_target_runtime": IndexedValueType.INDEXED_VALUE_TYPE_KEYWORD_LIST,
     "mm_target_skill": IndexedValueType.INDEXED_VALUE_TYPE_KEYWORD_LIST,
+    "mm_title": IndexedValueType.INDEXED_VALUE_TYPE_KEYWORD_LIST,
 }
 _UNSORTABLE_TEMPORAL_SEARCH_ATTRIBUTES = frozenset(
     {
@@ -264,6 +265,7 @@ _EXECUTION_FILTER_ATTR_BY_ALIAS = {
     "targetRuntimeNotIn": "mm_target_runtime",
     "targetSkillIn": "mm_target_skill",
     "targetSkillNotIn": "mm_target_skill",
+    "titleContains": "mm_title",
 }
 _EXECUTION_FACET_FILTER_ALIASES = {
     "status": frozenset({"state", "stateIn", "stateNotIn"}),
@@ -1349,7 +1351,7 @@ def _build_temporal_execution_query(
             request.query_params.get("workflowIdContains"),
             alias="workflowIdContains",
         )
-    if not excluded("titleContains"):
+    if attr_available("mm_title") and not excluded("titleContains"):
         _append_word_match_temporal_filter(
             query_parts,
             "mm_title",
@@ -9314,10 +9316,10 @@ async def list_executions(
                 return ExecutionListResponse(
                     items=[],
                     nextPageToken=None,
-                    count=0,
-                    countMode="exact",
+                    count=None,
+                    countMode="estimated_or_unknown",
                     staleState=False,
-                    degradedCount=False,
+                    degradedCount=True,
                     refreshedAt=datetime.now(UTC),
                 )
             count_query, list_query = _build_temporal_execution_query(
@@ -9359,14 +9361,30 @@ async def list_executions(
             import base64
             token_bytes = base64.b64decode(next_page_token) if next_page_token else None
 
-            count_info = await client.count_workflows(query=count_query)
-
             iterator = client.list_workflows(
                 query=list_query,
                 page_size=page_size,
                 next_page_token=token_bytes,
             )
             await iterator.fetch_next_page()
+
+            count_value: int | None = None
+            count_mode = "exact"
+            degraded_count = False
+            try:
+                count_info = await asyncio.wait_for(
+                    client.count_workflows(query=count_query),
+                    timeout=settings.temporal_dashboard.list_count_timeout_seconds,
+                )
+                count_value = count_info.count
+            except Exception as exc:
+                count_mode = "estimated_or_unknown"
+                degraded_count = True
+                logger.warning(
+                    "Temporal execution list count degraded for query_present=%s: %s",
+                    bool(count_query),
+                    exc,
+                )
 
             page = iterator.current_page or []
             canonical_map: dict[str, TemporalExecutionCanonicalRecord] = {}
@@ -9410,16 +9428,6 @@ async def list_executions(
                             getattr(record_obj, "started_at", None) or datetime.now(UTC)
                         )
                     execution = _serialize_execution_list_item(record_obj)
-                    if _execution_uses_live_workflow_queries(execution):
-                        progress, queried_run_id = await _load_execution_progress(
-                            temporal_client=temporal_client,
-                            workflow_id=wf.id,
-                        )
-                        update: dict[str, object] = {"progress": progress}
-                        if queried_run_id:
-                            update["run_id"] = queried_run_id
-                            update["temporal_run_id"] = queried_run_id
-                        execution = execution.model_copy(update=update)
                     items.append(execution)
 
                 if _request_has_progress_filters(request):
@@ -9461,9 +9469,9 @@ async def list_executions(
             return ExecutionListResponse(
                 items=items,
                 next_page_token=new_token_str,
-                count=count_info.count,
-                count_mode="exact",
-                degraded_count=False,
+                count=count_value,
+                count_mode=count_mode,
+                degraded_count=degraded_count,
                 refreshed_at=datetime.now(UTC),
             )
         except TemporalExecutionValidationError as exc:

--- a/docs/Api/ExecutionsApiContract.md
+++ b/docs/Api/ExecutionsApiContract.md
@@ -313,8 +313,12 @@ Current staging note:
 | `nextPageToken` | string or `null` | no | Opaque pagination token |
 | `count` | integer or `null` | no | Count for the filtered query |
 | `countMode` | `exact \| estimated_or_unknown` | yes | Count confidence |
+| `degradedCount` | boolean | yes | `true` when an exact count was unavailable |
 
-Current implementation always returns `countMode = "exact"`.
+Temporal-backed list reads return `countMode = "exact"` only when the page read
+and the bounded count query both succeed. If the page read succeeds but the
+count query fails or times out, the response keeps the rows and returns
+`count = null`, `countMode = "estimated_or_unknown"`, and `degradedCount = true`.
 
 ---
 
@@ -476,10 +480,9 @@ Meaningfully newer `updatedAt` values still sort first. Small updated-time diffe
 
 The list response includes:
 
-- `count`: current filtered total,
-- `countMode`: currently always `exact`.
-
-Future implementations may return `estimated_or_unknown` if count behavior changes.
+- `count`: current filtered total when known,
+- `countMode`: `exact` or `estimated_or_unknown`,
+- `degradedCount`: whether exact count enrichment failed.
 
 Client rule:
 
@@ -995,9 +998,11 @@ The current router returns:
 
 - projection-backed pagination tokens,
 - projection-backed exact counts,
-- `countMode = "exact"`.
+- Temporal-backed rows when `source=temporal`, with exact counts treated as
+  bounded best-effort enrichment.
 
-That behavior is honest for the current adapter implementation, but it should not be mistaken for a promise that all future Temporal-backed list implementations can always provide canonical exact counts.
+Temporal-backed list reads preserve rows when count enrichment fails; only the
+page fetch itself is a page-load prerequisite.
 
 ### 17.4 Known cleanup candidates
 

--- a/moonmind/config/settings.py
+++ b/moonmind/config/settings.py
@@ -302,6 +302,11 @@ class TemporalDashboardSettings(BaseSettings):
         validation_alias=AliasChoices("TEMPORAL_DASHBOARD_LIVE_QUERY_TIMEOUT_SECONDS"),
         gt=0,
     )
+    list_count_timeout_seconds: float = Field(
+        1.0,
+        validation_alias=AliasChoices("TEMPORAL_DASHBOARD_LIST_COUNT_TIMEOUT_SECONDS"),
+        gt=0,
+    )
     list_endpoint: str = Field(
         "/api/executions",
         validation_alias=AliasChoices("TEMPORAL_DASHBOARD_LIST_ENDPOINT"),

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -2429,6 +2429,97 @@ def test_list_executions_source_temporal_does_not_hydrate_live_progress() -> Non
     temporal_client.get_workflow_handle.assert_not_called()
 
 
+def test_list_executions_source_temporal_hydrates_live_progress_for_filters() -> None:
+    app = FastAPI()
+    app.include_router(router)
+    mock_service = AsyncMock()
+    app.dependency_overrides[_get_service] = lambda: mock_service
+
+    class _EmptyCanonicalResult:
+        def scalars(self) -> "_EmptyCanonicalResult":
+            return self
+
+        def all(self) -> list[TemporalExecutionCanonicalRecord]:
+            return []
+
+    class _Session:
+        async def execute(self, _stmt: object) -> _EmptyCanonicalResult:
+            return _EmptyCanonicalResult()
+
+    app.dependency_overrides[get_async_session] = lambda: _Session()
+    _override_user_dependencies(app, is_superuser=True)
+
+    async def _memo():
+        return {
+            "title": "Live workflow",
+            "summary": "Running tests.",
+        }
+
+    workflow = SimpleNamespace(
+        id="mm:wf-live",
+        run_id="run-temporal",
+        namespace="default",
+        workflow_type="MoonMind.UserWorkflow",
+        status="RUNNING",
+        start_time=datetime(2026, 4, 4, 18, 0, tzinfo=UTC),
+        close_time=None,
+        execution_time=None,
+        search_attributes={
+            "mm_state": "executing",
+            "mm_owner_id": "system",
+            "mm_owner_type": "system",
+            "mm_entry": "run",
+        },
+        memo=_memo,
+    )
+
+    class _WorkflowIterator:
+        current_page = [workflow]
+        next_page_token: bytes | None = None
+
+        async def fetch_next_page(self) -> None:
+            return None
+
+    temporal_client = _override_query_client(
+        app,
+        progress={
+            "total": 3,
+            "pending": 0,
+            "ready": 0,
+            "running": 1,
+            "awaitingExternal": 0,
+            "reviewing": 0,
+            "succeeded": 2,
+            "failed": 0,
+            "skipped": 0,
+            "canceled": 0,
+            "currentStepTitle": "Run tests",
+            "updatedAt": "2026-04-04T18:11:15Z",
+            "runId": "run-live",
+        },
+    )
+    temporal_client.count_workflows = AsyncMock(return_value=SimpleNamespace(count=1))
+    temporal_client.list_workflows = Mock(return_value=_WorkflowIterator())
+
+    with TestClient(app) as test_client:
+        response = test_client.get(
+            "/api/executions",
+            params={
+                "source": "temporal",
+                "ownerType": "system",
+                "progressPctFrom": "50",
+                "progressStepTitleContains": "tests",
+            },
+        )
+
+    assert response.status_code == 200
+    items = response.json()["items"]
+    assert [item["workflowId"] for item in items] == ["mm:wf-live"]
+    assert items[0]["runId"] == "run-live"
+    assert items[0]["progress"]["currentStepTitle"] == "Run tests"
+    temporal_client.get_workflow_handle.assert_called_once_with("mm:wf-live")
+
+
 def test_execution_facets_exclude_requested_facet_filter_and_keep_workflow_scope() -> None:
     app = FastAPI()
     app.include_router(router)

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -1184,6 +1184,80 @@ def test_list_executions_temporal_query_includes_target_runtime_filter() -> None
         == temporal_client.count_workflows.await_args.kwargs["query"]
     )
 
+def test_list_executions_source_temporal_degrades_count_failure() -> None:
+    app = FastAPI()
+    app.include_router(router)
+    mock_service = AsyncMock()
+    app.dependency_overrides[_get_service] = lambda: mock_service
+
+    class _EmptyCanonicalResult:
+        def scalars(self) -> "_EmptyCanonicalResult":
+            return self
+
+        def all(self) -> list[TemporalExecutionCanonicalRecord]:
+            return []
+
+    class _Session:
+        async def execute(self, _stmt: object) -> _EmptyCanonicalResult:
+            return _EmptyCanonicalResult()
+
+    app.dependency_overrides[get_async_session] = lambda: _Session()
+    _override_user_dependencies(app, is_superuser=True)
+
+    async def _memo():
+        return {"title": "Count degraded"}
+
+    workflow = SimpleNamespace(
+        id="mm:wf-count-degraded",
+        run_id="run-temporal",
+        namespace="default",
+        workflow_type="MoonMind.UserWorkflow",
+        status="RUNNING",
+        start_time=datetime(2026, 4, 4, 18, 0, tzinfo=UTC),
+        close_time=None,
+        execution_time=None,
+        search_attributes={
+            "mm_state": "executing",
+            "mm_owner_id": "system",
+            "mm_owner_type": "system",
+            "mm_entry": "run",
+        },
+        memo=_memo,
+    )
+
+    class _WorkflowIterator:
+        current_page = [workflow]
+        next_page_token: bytes | None = None
+
+        async def fetch_next_page(self) -> None:
+            return None
+
+    temporal_client = SimpleNamespace(
+        operator_service=SimpleNamespace(
+            list_search_attributes=AsyncMock(
+                return_value=SimpleNamespace(custom_attributes={})
+            )
+        ),
+        count_workflows=AsyncMock(side_effect=RuntimeError("count unavailable")),
+        list_workflows=Mock(return_value=_WorkflowIterator()),
+    )
+    app.dependency_overrides[get_temporal_client] = lambda: temporal_client
+
+    with TestClient(app) as test_client:
+        response = test_client.get(
+            "/api/executions",
+            params={"source": "temporal", "ownerType": "system"},
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert [item["workflowId"] for item in body["items"]] == ["mm:wf-count-degraded"]
+    assert body["count"] is None
+    assert body["countMode"] == "estimated_or_unknown"
+    assert body["degradedCount"] is True
+    temporal_client.list_workflows.assert_called_once()
+    temporal_client.count_workflows.assert_awaited_once()
+
 def test_list_executions_temporal_query_includes_canonical_state_filters() -> None:
     app = FastAPI()
     app.include_router(router)
@@ -1536,7 +1610,11 @@ def test_list_executions_temporal_runtime_skill_filters_degrade_when_unregistere
         )
 
     assert response.status_code == 200
-    assert response.json()["items"] == []
+    body = response.json()
+    assert body["items"] == []
+    assert body["count"] is None
+    assert body["countMode"] == "estimated_or_unknown"
+    assert body["degradedCount"] is True
     temporal_client.count_workflows.assert_not_called()
     temporal_client.list_workflows.assert_not_called()
 
@@ -1683,6 +1761,15 @@ def test_list_executions_temporal_query_includes_canonical_date_bounds() -> None
             return None
 
     temporal_client = SimpleNamespace(
+        operator_service=SimpleNamespace(
+            list_search_attributes=AsyncMock(
+                return_value=SimpleNamespace(
+                    custom_attributes={
+                        "mm_title": SimpleNamespace(type=_TARGET_SEARCH_ATTRIBUTE_TYPE),
+                    }
+                )
+            )
+        ),
         count_workflows=AsyncMock(return_value=SimpleNamespace(count=0)),
         list_workflows=Mock(return_value=_WorkflowIterator()),
     )
@@ -1746,6 +1833,15 @@ def test_list_executions_temporal_query_includes_blank_date_filter_semantics() -
             return None
 
     temporal_client = SimpleNamespace(
+        operator_service=SimpleNamespace(
+            list_search_attributes=AsyncMock(
+                return_value=SimpleNamespace(
+                    custom_attributes={
+                        "mm_title": SimpleNamespace(type=_TARGET_SEARCH_ATTRIBUTE_TYPE),
+                    }
+                )
+            )
+        ),
         count_workflows=AsyncMock(return_value=SimpleNamespace(count=0)),
         list_workflows=Mock(return_value=_WorkflowIterator()),
     )
@@ -1782,6 +1878,15 @@ def test_list_executions_temporal_query_supports_sort_and_text_filters() -> None
             return None
 
     temporal_client = SimpleNamespace(
+        operator_service=SimpleNamespace(
+            list_search_attributes=AsyncMock(
+                return_value=SimpleNamespace(
+                    custom_attributes={
+                        "mm_title": SimpleNamespace(type=_TARGET_SEARCH_ATTRIBUTE_TYPE),
+                    }
+                )
+            )
+        ),
         count_workflows=AsyncMock(return_value=SimpleNamespace(count=0)),
         list_workflows=Mock(return_value=_WorkflowIterator()),
     )
@@ -1873,6 +1978,15 @@ def test_list_executions_temporal_query_title_filter_ands_word_tokens() -> None:
             return None
 
     temporal_client = SimpleNamespace(
+        operator_service=SimpleNamespace(
+            list_search_attributes=AsyncMock(
+                return_value=SimpleNamespace(
+                    custom_attributes={
+                        "mm_title": SimpleNamespace(type=_TARGET_SEARCH_ATTRIBUTE_TYPE),
+                    }
+                )
+            )
+        ),
         count_workflows=AsyncMock(return_value=SimpleNamespace(count=0)),
         list_workflows=Mock(return_value=_WorkflowIterator()),
     )
@@ -1900,7 +2014,19 @@ def test_list_executions_temporal_query_rejects_title_filter_without_tokens() ->
     mock_service = AsyncMock()
     app.dependency_overrides[_get_service] = lambda: mock_service
     _override_user_dependencies(app, is_superuser=True)
-    temporal_client = SimpleNamespace(count_workflows=AsyncMock(), list_workflows=Mock())
+    temporal_client = SimpleNamespace(
+        operator_service=SimpleNamespace(
+            list_search_attributes=AsyncMock(
+                return_value=SimpleNamespace(
+                    custom_attributes={
+                        "mm_title": SimpleNamespace(type=_TARGET_SEARCH_ATTRIBUTE_TYPE),
+                    }
+                )
+            )
+        ),
+        count_workflows=AsyncMock(),
+        list_workflows=Mock(),
+    )
     app.dependency_overrides[get_temporal_client] = lambda: temporal_client
 
     with TestClient(app) as test_client:
@@ -2217,7 +2343,7 @@ def test_list_executions_source_temporal_filters_and_sorts_progress_from_bounded
     assert "ORDER BY" not in list_query
 
 
-def test_list_executions_source_temporal_hydrates_live_progress() -> None:
+def test_list_executions_source_temporal_does_not_hydrate_live_progress() -> None:
     app = FastAPI()
     app.include_router(router)
     mock_service = AsyncMock()
@@ -2298,10 +2424,9 @@ def test_list_executions_source_temporal_hydrates_live_progress() -> None:
     assert response.status_code == 200
     item = response.json()["items"][0]
     assert item["workflowId"] == "mm:wf-live"
-    assert item["runId"] == "run-live"
-    assert item["progress"]["succeeded"] == 2
-    assert item["progress"]["currentStepTitle"] == "Run tests"
-    temporal_client.get_workflow_handle.assert_called_once_with("mm:wf-live")
+    assert item["runId"] == "run-temporal"
+    assert item["progress"] is None
+    temporal_client.get_workflow_handle.assert_not_called()
 
 
 def test_execution_facets_exclude_requested_facet_filter_and_keep_workflow_scope() -> None:


### PR DESCRIPTION
Issue: MM-1060

Summary:
- Degrades Temporal-backed execution list count failures independently from page fetching.
- Returns rows with count=null, countMode="estimated_or_unknown", and degradedCount=true when count_workflows fails or times out.
- Adds a configurable count timeout and updates the API contract documentation.
- Adds unit coverage for degraded count behavior and related Temporal query handling.

Tests run:
- ./tools/test_unit.sh --python-only tests/unit/api/routers/test_executions.py -q
- ./tools/test_unit.sh --python-only tests/unit/workflows/temporal/test_client_schedules.py tests/unit/workflows/temporal/workflows/test_run_step_ledger.py -q
- ./tools/test_unit.sh --python-only tests/unit/workflows/temporal/test_run_artifacts.py tests/unit/workflows/temporal/test_temporal_service.py -q
- ./tools/test_integration.sh tests/integration/temporal/test_namespace_retention.py (ran hermetic integration_ci suite: 383 passed, 1 skipped, 87 deselected)

Remaining risks:
- The prior assessment was PARTIALLY_IMPLEMENTED; this PR addresses the remaining list count degradation gap identified in the follow-up implementation evidence.
- Broader MM-1060 facets/capability posture should still be reviewed against the full acceptance criteria during PR review.
