### PR TITLE
MM-1057 Add backend Skill input validation and runtime handoff evidence

### DIFF
--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -6298,14 +6298,10 @@ def _normalize_task_steps(task_payload: dict[str, Any]) -> list[dict[str, Any]]:
                         raw_args = selected_skill.get("inputs")
                     if isinstance(raw_args, dict):
                         normalized_skill["args"] = dict(raw_args)
-                    for evidence_key in (
-                        "contentRef",
-                        "contentDigest",
-                        "inputContractDigest",
-                    ):
-                        evidence_value = selected_skill.get(evidence_key)
-                        if isinstance(evidence_value, str) and evidence_value.strip():
-                            normalized_skill[evidence_key] = evidence_value.strip()
+                    _copy_skill_contract_metadata(
+                        source=selected_skill,
+                        target=normalized_skill,
+                    )
                     raw_caps = selected_skill.get("requiredCapabilities")
                     if raw_caps is not None:
                         normalized_caps = _coerce_string_list(
@@ -6340,6 +6336,24 @@ def _normalize_task_steps(task_payload: dict[str, Any]) -> list[dict[str, Any]]:
 
     task_payload["steps"] = normalized_steps
     return normalized_steps
+
+def _copy_skill_contract_metadata(
+    *,
+    source: Mapping[str, Any],
+    target: dict[str, Any],
+) -> None:
+    for metadata_key in ("inputSchema", "uiSchema", "defaults"):
+        metadata_value = source.get(metadata_key)
+        if isinstance(metadata_value, Mapping):
+            target[metadata_key] = dict(metadata_value)
+    for evidence_key in (
+        "contentRef",
+        "contentDigest",
+        "inputContractDigest",
+    ):
+        evidence_value = source.get(evidence_key)
+        if isinstance(evidence_value, str) and evidence_value.strip():
+            target[evidence_key] = evidence_value.strip()
 
 async def _resolve_step_runtime_selections(
     *,
@@ -6900,6 +6914,7 @@ def _normalize_task_tool(task_payload: dict[str, Any]) -> dict[str, Any] | None:
         inline_inputs = selected_payload.get("args")
     if isinstance(inline_inputs, dict) and inline_inputs:
         normalized["inputs"] = dict(inline_inputs)
+    _copy_skill_contract_metadata(source=selected_payload, target=normalized)
     return normalized
 
 _PENTEST_TOOL_NAME = "security.pentest.run"

--- a/frontend/src/entrypoints/workflow-start.test.tsx
+++ b/frontend/src/entrypoints/workflow-start.test.tsx
@@ -16205,14 +16205,14 @@ describe("Task Create schema-driven capability inputs", () => {
       payload: {
         task: {
           tool?: { inputs?: Record<string, unknown> };
-          skill?: { args?: Record<string, unknown> };
+          skill?: { inputs?: Record<string, unknown> };
         };
       };
     };
     expect(request.payload.task.tool?.inputs).toMatchObject({
       repository: "MoonLadderStudios/SchemaRepo",
     });
-    expect(request.payload.task.skill?.args).toMatchObject({
+    expect(request.payload.task.skill?.inputs).toMatchObject({
       repository: "MoonLadderStudios/SchemaRepo",
     });
   });
@@ -16666,7 +16666,7 @@ describe("Task Create governed Tool authoring", () => {
     });
     expect(request.payload.task.skill).toEqual({
       id: "moonspec-orchestrate",
-      args: {
+      inputs: {
         issueKey: "MM-577",
         mode: "runtime",
       },

--- a/frontend/src/entrypoints/workflow-start.tsx
+++ b/frontend/src/entrypoints/workflow-start.tsx
@@ -608,6 +608,9 @@ interface SkillCapabilityDetail {
   inputSchema?: Record<string, unknown>;
   uiSchema?: Record<string, unknown>;
   defaults?: Record<string, unknown>;
+  contractDigest?: string | null;
+  contentDigest?: string | null;
+  contentRef?: string | null;
   requiredCapabilities?: string[];
 }
 
@@ -3381,6 +3384,24 @@ function schemaSkillInputs(
   return {
     values,
     errors: validateSchemaCapabilityValues(detail, values),
+  };
+}
+
+function skillInputContractPayload(
+  detail: SkillCapabilityDetail | null | undefined,
+): Record<string, unknown> {
+  if (!detail) {
+    return {};
+  }
+  return {
+    ...(detail.inputSchema ? { inputSchema: detail.inputSchema } : {}),
+    ...(detail.uiSchema ? { uiSchema: detail.uiSchema } : {}),
+    ...(detail.defaults ? { defaults: detail.defaults } : {}),
+    ...(detail.contractDigest
+      ? { inputContractDigest: detail.contractDigest }
+      : {}),
+    ...(detail.contentDigest ? { contentDigest: detail.contentDigest } : {}),
+    ...(detail.contentRef ? { contentRef: detail.contentRef } : {}),
   };
 }
 
@@ -8997,13 +9018,15 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
       ...(Object.keys(primarySkillArgs).length > 0
         ? { inputs: primarySkillArgs }
         : {}),
+      ...skillInputContractPayload(primarySkillDetail),
       ...(taskSkillRequiredCapabilities.length > 0
         ? { requiredCapabilities: taskSkillRequiredCapabilities }
         : {}),
     };
     const primaryStepSkill = {
       id: primarySkillId,
-      args: primarySkillArgs,
+      inputs: primarySkillArgs,
+      ...skillInputContractPayload(primarySkillDetail),
       ...(taskSkillRequiredCapabilities.length > 0
         ? { requiredCapabilities: taskSkillRequiredCapabilities }
         : {}),
@@ -9017,6 +9040,7 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
       sourceIndex: number;
       step: StepState;
       skillId: string;
+      skillDetail: SkillCapabilityDetail | null;
       skillArgsRaw: string;
       skillArgs: Record<string, unknown>;
       skillCaps: string[];
@@ -9158,6 +9182,7 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
         sourceIndex: index,
         step,
         skillId: stepSkillId,
+        skillDetail: stepSkillDetail,
         skillArgsRaw: stepSkillArgsRaw,
         skillArgs: stepSkillArgs,
         skillCaps: stepSkillCaps,
@@ -9392,6 +9417,7 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
       sourceIndex,
       step,
       skillId: stepSkillId,
+      skillDetail: stepSkillDetail,
       skillArgsRaw: stepSkillArgsRaw,
       skillArgs: stepSkillArgs,
       skillCaps: stepSkillCaps,
@@ -9442,13 +9468,15 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
           type: "skill",
           name: stepSkillId || primarySkillId,
           inputs: stepSkillArgs,
+          ...skillInputContractPayload(stepSkillDetail || primarySkillDetail),
           ...(stepSkillCaps.length > 0
             ? { requiredCapabilities: stepSkillCaps }
             : {}),
         };
         stepPayload.skill = {
           id: stepSkillId || primarySkillId,
-          args: stepSkillArgs,
+          inputs: stepSkillArgs,
+          ...skillInputContractPayload(stepSkillDetail || primarySkillDetail),
           ...(stepSkillCaps.length > 0
             ? { requiredCapabilities: stepSkillCaps }
             : {}),

--- a/moonmind/capabilities/input_contracts.py
+++ b/moonmind/capabilities/input_contracts.py
@@ -9,6 +9,7 @@ import re
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from typing import Any, Literal
+from urllib.parse import urlparse
 
 import yaml
 
@@ -19,6 +20,34 @@ _SECRET_LIKE_VALUE_PATTERN = re.compile(
     r"(token=|password=|bearer\s+|ghp_|github_pat_|akia[0-9a-z]{16}|aiza|atatt|-----begin [a-z ]*private key)",
     re.IGNORECASE,
 )
+_REGISTERED_WIDGETS = {
+    "text",
+    "textarea",
+    "markdown",
+    "number",
+    "checkbox",
+    "select",
+    "multi-select",
+    "json",
+    "jira.issue-picker",
+    "github.issue-picker",
+    "github.repository-picker",
+    "github.branch-picker",
+    "provider.profile-picker",
+    "model-picker",
+    "file-reference-picker",
+}
+_CODE_LIKE_SCHEMA_KEYS = {
+    "script",
+    "scripts",
+    "function",
+    "functions",
+    "eval",
+    "expression",
+    "x-code",
+    "x-moonmind-code",
+    "x-moonmind-transform",
+}
 
 
 @dataclass(frozen=True, slots=True)
@@ -155,7 +184,9 @@ def normalize_capability_input_contract(
     """Return a camelCase renderer-facing capability input contract."""
 
     diagnostics = [dict(item) for item in parts.diagnostics]
-    input_schema = _json_compatible_mapping(parts.input_schema) or {}
+    input_schema = _sanitize_schema_descriptions(
+        _json_compatible_mapping(parts.input_schema) or {}
+    )
     ui_schema = _json_compatible_mapping(parts.ui_schema) or {}
     defaults = _json_compatible_mapping(parts.defaults) or {}
 
@@ -185,6 +216,8 @@ def normalize_capability_input_contract(
             )
         )
         defaults = {}
+    diagnostics.extend(_schema_trust_diagnostics(input_schema))
+    diagnostics.extend(_ui_schema_widget_diagnostics(ui_schema))
 
     digest_payload = {
         "parserVersion": PARSER_VERSION,
@@ -209,12 +242,95 @@ def normalize_capability_input_contract(
         "diagnostics": diagnostics,
     }
     if owner.description:
-        contract["description"] = owner.description
+        contract["description"] = _sanitize_markdown_description(owner.description)
     if owner.content_digest:
         contract["contentDigest"] = owner.content_digest
     if owner.source:
         contract["source"] = dict(owner.source)
     return contract
+
+
+def validate_capability_inputs(
+    *,
+    contract: Mapping[str, Any],
+    values: Mapping[str, Any] | None,
+    workflow_context: Mapping[str, Any] | None = None,
+    path_prefix: str = "inputs",
+) -> dict[str, Any]:
+    """Validate capability values against inputSchema and safe backend defaults."""
+
+    input_schema = _json_compatible_mapping(
+        contract.get("inputSchema") if isinstance(contract, Mapping) else None
+    ) or {}
+    defaults = _json_compatible_mapping(
+        contract.get("defaults") if isinstance(contract, Mapping) else None
+    ) or {}
+    submitted = _json_compatible_mapping(values) or {}
+    context = workflow_context or {}
+    errors: list[dict[str, Any]] = []
+    warnings: list[dict[str, Any]] = []
+
+    if _contains_secret_like_value(defaults):
+        warnings.append(
+            _validation_issue(
+                path=f"{path_prefix}.defaults",
+                message="Capability defaults contained a secret-like value and were ignored.",
+                code="secret_like_default",
+            )
+        )
+        defaults = {}
+
+    schema_warnings = _schema_trust_diagnostics(input_schema)
+    for warning in schema_warnings:
+        warnings.append(
+            _validation_issue(
+                path=_join_path(
+                    path_prefix,
+                    _schema_path_to_input_path(warning.get("path")),
+                ),
+                message=str(warning.get("message") or "Schema metadata was ignored."),
+                code=str(warning.get("code") or "schema_metadata_ignored"),
+            )
+        )
+
+    ui_schema = _json_compatible_mapping(contract.get("uiSchema")) or {}
+    for warning in _ui_schema_widget_diagnostics(ui_schema):
+        warnings.append(
+            _validation_issue(
+                path=_join_path(
+                    path_prefix,
+                    _schema_path_to_input_path(warning.get("path")),
+                ),
+                message=str(warning.get("message") or "Unsupported widget was ignored."),
+                code=str(warning.get("code") or "unsupported_widget"),
+            )
+        )
+
+    effective = _apply_backend_defaults(
+        schema=input_schema,
+        submitted=submitted,
+        defaults=defaults,
+        workflow_context=context,
+    )
+    _validate_schema_value(
+        schema=input_schema or {"type": "object", "properties": {}},
+        value=effective,
+        path=path_prefix,
+        errors=errors,
+    )
+
+    source = contract.get("source")
+    source_content_ref = (
+        source.get("contentRef") if isinstance(source, Mapping) else None
+    )
+    return {
+        "values": effective,
+        "errors": errors,
+        "warnings": warnings,
+        "contractDigest": contract.get("contractDigest"),
+        "contentDigest": contract.get("contentDigest"),
+        "contentRef": contract.get("contentRef") or source_content_ref,
+    }
 
 
 def parse_skill_capability_input_contract(
@@ -291,6 +407,236 @@ def _json_compatible_value(value: Any) -> Any:
     if isinstance(value, (dt.date, dt.datetime, dt.time)):
         return value.isoformat()
     return value
+
+
+def _sanitize_schema_descriptions(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        sanitized: dict[str, Any] = {}
+        for key, item in value.items():
+            if key in {"description", "markdownDescription"} and isinstance(item, str):
+                sanitized[str(key)] = _sanitize_markdown_description(item)
+            else:
+                sanitized[str(key)] = _sanitize_schema_descriptions(item)
+        return sanitized
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return [_sanitize_schema_descriptions(item) for item in value]
+    return value
+
+
+def _sanitize_markdown_description(value: str) -> str:
+    stripped = re.sub(r"<[^>]*>", "", value)
+    stripped = re.sub(r"(?i)javascript\s*:", "", stripped)
+    return stripped.strip()
+
+
+def _schema_trust_diagnostics(
+    schema: Any,
+    path: str = "inputSchema",
+) -> list[dict[str, Any]]:
+    diagnostics: list[dict[str, Any]] = []
+    if isinstance(schema, Mapping):
+        ref = schema.get("$ref")
+        if isinstance(ref, str) and urlparse(ref).scheme in {"http", "https"}:
+            diagnostics.append(
+                _diagnostic(
+                    code="remote_ref_ignored",
+                    message="Remote schema references are not fetched during validation.",
+                    severity="warning",
+                    path=f"{path}.$ref",
+                )
+            )
+        for key, item in schema.items():
+            key_text = str(key)
+            if key_text.lower() in _CODE_LIKE_SCHEMA_KEYS:
+                diagnostics.append(
+                    _diagnostic(
+                        code="schema_code_ignored",
+                        message="Schema-provided code or expressions are ignored.",
+                        severity="warning",
+                        path=f"{path}.{key_text}",
+                    )
+                )
+            diagnostics.extend(_schema_trust_diagnostics(item, f"{path}.{key_text}"))
+    elif isinstance(schema, Sequence) and not isinstance(schema, (str, bytes, bytearray)):
+        for index, item in enumerate(schema):
+            diagnostics.extend(_schema_trust_diagnostics(item, f"{path}[{index}]"))
+    return diagnostics
+
+
+def _ui_schema_widget_diagnostics(
+    ui_schema: Mapping[str, Any],
+) -> list[dict[str, Any]]:
+    diagnostics: list[dict[str, Any]] = []
+    for field_name, field_ui in ui_schema.items():
+        if not isinstance(field_ui, Mapping):
+            continue
+        widget = field_ui.get("widget")
+        if widget is None:
+            continue
+        widget_name = str(widget).strip()
+        if widget_name and widget_name not in _REGISTERED_WIDGETS:
+            diagnostics.append(
+                _diagnostic(
+                    code="unsupported_widget",
+                    message=f"Unsupported widget '{widget_name}' was ignored.",
+                    severity="warning",
+                    path=f"uiSchema.{field_name}.widget",
+                )
+            )
+    return diagnostics
+
+
+def _apply_backend_defaults(
+    *,
+    schema: Mapping[str, Any],
+    submitted: Mapping[str, Any],
+    defaults: Mapping[str, Any],
+    workflow_context: Mapping[str, Any],
+) -> dict[str, Any]:
+    properties = schema.get("properties")
+    if not isinstance(properties, Mapping):
+        return dict(submitted)
+    effective = dict(submitted)
+    for name, raw_field_schema in properties.items():
+        field_name = str(name)
+        if field_name in effective and effective[field_name] not in (None, ""):
+            continue
+        field_schema = raw_field_schema if isinstance(raw_field_schema, Mapping) else {}
+        context_key = field_schema.get("x-moonmind-context-default")
+        if isinstance(context_key, str) and context_key:
+            context_value = workflow_context.get(context_key)
+            if context_value not in (None, ""):
+                effective[field_name] = _json_compatible_value(context_value)
+                continue
+        if field_name in defaults and defaults[field_name] not in (None, ""):
+            effective[field_name] = defaults[field_name]
+            continue
+        if "default" in field_schema and field_schema.get("default") not in (None, ""):
+            effective[field_name] = _json_compatible_value(field_schema.get("default"))
+    return effective
+
+
+def _validate_schema_value(
+    *,
+    schema: Mapping[str, Any],
+    value: Any,
+    path: str,
+    errors: list[dict[str, Any]],
+) -> None:
+    schema_type = schema.get("type")
+    if schema_type == "object" or isinstance(schema.get("properties"), Mapping):
+        if not isinstance(value, Mapping):
+            errors.append(
+                _validation_issue(
+                    path=path,
+                    message="Value must be an object.",
+                    code="type",
+                )
+            )
+            return
+        required = (
+            schema.get("required") if isinstance(schema.get("required"), list) else []
+        )
+        for required_name in required:
+            key = str(required_name)
+            if key not in value or value.get(key) in (None, ""):
+                errors.append(
+                    _validation_issue(
+                        path=f"{path}.{key}",
+                        message=f"{key} is required.",
+                        code="required",
+                    )
+                )
+        properties = schema.get("properties")
+        if isinstance(properties, Mapping):
+            for key, field_schema in properties.items():
+                if key not in value:
+                    continue
+                if isinstance(field_schema, Mapping):
+                    _validate_schema_value(
+                        schema=field_schema,
+                        value=value.get(key),
+                        path=f"{path}.{key}",
+                        errors=errors,
+                    )
+        return
+    if schema_type == "string" and not isinstance(value, str):
+        errors.append(
+            _validation_issue(path=path, message="Value must be a string.", code="type")
+        )
+    elif schema_type == "integer" and not (
+        isinstance(value, int) and not isinstance(value, bool)
+    ):
+        errors.append(
+            _validation_issue(
+                path=path,
+                message="Value must be an integer.",
+                code="type",
+            )
+        )
+    elif schema_type == "number" and not (
+        isinstance(value, (int, float)) and not isinstance(value, bool)
+    ):
+        errors.append(
+            _validation_issue(path=path, message="Value must be a number.", code="type")
+        )
+    elif schema_type == "boolean" and not isinstance(value, bool):
+        errors.append(
+            _validation_issue(
+                path=path,
+                message="Value must be a boolean.",
+                code="type",
+            )
+        )
+    elif schema_type == "array" and not isinstance(value, list):
+        errors.append(
+            _validation_issue(path=path, message="Value must be an array.", code="type")
+        )
+
+    enum = schema.get("enum")
+    if isinstance(enum, list) and value not in enum:
+        errors.append(
+            _validation_issue(
+                path=path,
+                message="Value must be one of the allowed options.",
+                code="enum",
+            )
+        )
+    fmt = str(schema.get("format") or "").strip()
+    if fmt == "uri" and isinstance(value, str) and not urlparse(value).scheme:
+        errors.append(
+            _validation_issue(path=path, message="Value must be a URI.", code="format")
+        )
+    if fmt == "email" and isinstance(value, str) and "@" not in value:
+        errors.append(
+            _validation_issue(
+                path=path,
+                message="Value must be an email address.",
+                code="format",
+            )
+        )
+
+
+def _schema_path_to_input_path(path: Any) -> str:
+    text = str(path or "")
+    text = text.replace("inputSchema.properties.", "")
+    text = text.replace("uiSchema.", "")
+    text = text.replace(".widget", "")
+    return text
+
+
+def _join_path(prefix: str, suffix: str) -> str:
+    suffix = suffix.strip(".")
+    return f"{prefix}.{suffix}" if suffix else prefix
+
+
+def _validation_issue(*, path: str, message: str, code: str) -> dict[str, Any]:
+    return {
+        "path": path,
+        "message": message,
+        "code": code,
+        "recoverable": True,
+    }
 
 
 def _first_mapping(metadata: Mapping[str, Any], *keys: str) -> dict[str, Any] | None:

--- a/moonmind/capabilities/input_contracts.py
+++ b/moonmind/capabilities/input_contracts.py
@@ -826,7 +826,11 @@ def _validate_schema_value(
                     )
         additional_properties = schema.get("additionalProperties")
         if additional_properties is False:
-            allowed = {str(key) for key in properties}
+            allowed = (
+                {str(key) for key in properties}
+                if isinstance(properties, Mapping)
+                else set()
+            )
             for key in value:
                 if str(key) not in allowed:
                     errors.append(

--- a/moonmind/capabilities/input_contracts.py
+++ b/moonmind/capabilities/input_contracts.py
@@ -318,6 +318,13 @@ def validate_capability_inputs(
         path=path_prefix,
         errors=errors,
     )
+    _validate_integration_references(
+        schema=input_schema,
+        ui_schema=ui_schema,
+        value=effective,
+        path=path_prefix,
+        errors=errors,
+    )
 
     source = contract.get("source")
     source_content_ref = (
@@ -559,11 +566,25 @@ def _validate_schema_value(
                         path=f"{path}.{key}",
                         errors=errors,
                     )
+        additional_properties = schema.get("additionalProperties")
+        if additional_properties is False:
+            allowed = {str(key) for key in properties}
+            for key in value:
+                if str(key) not in allowed:
+                    errors.append(
+                        _validation_issue(
+                            path=f"{path}.{key}",
+                            message="Additional properties are not allowed.",
+                            code="additionalProperties",
+                        )
+                    )
         return
+
     if schema_type == "string" and not isinstance(value, str):
         errors.append(
             _validation_issue(path=path, message="Value must be a string.", code="type")
         )
+        return
     elif schema_type == "integer" and not (
         isinstance(value, int) and not isinstance(value, bool)
     ):
@@ -574,12 +595,14 @@ def _validate_schema_value(
                 code="type",
             )
         )
+        return
     elif schema_type == "number" and not (
         isinstance(value, (int, float)) and not isinstance(value, bool)
     ):
         errors.append(
             _validation_issue(path=path, message="Value must be a number.", code="type")
         )
+        return
     elif schema_type == "boolean" and not isinstance(value, bool):
         errors.append(
             _validation_issue(
@@ -588,10 +611,12 @@ def _validate_schema_value(
                 code="type",
             )
         )
+        return
     elif schema_type == "array" and not isinstance(value, list):
         errors.append(
             _validation_issue(path=path, message="Value must be an array.", code="type")
         )
+        return
 
     enum = schema.get("enum")
     if isinstance(enum, list) and value not in enum:
@@ -602,6 +627,98 @@ def _validate_schema_value(
                 code="enum",
             )
         )
+    if schema_type == "string" and isinstance(value, str):
+        min_length = schema.get("minLength")
+        if isinstance(min_length, int) and len(value) < min_length:
+            errors.append(
+                _validation_issue(
+                    path=path,
+                    message=f"Value must be at least {min_length} characters.",
+                    code="minLength",
+                )
+            )
+        max_length = schema.get("maxLength")
+        if isinstance(max_length, int) and len(value) > max_length:
+            errors.append(
+                _validation_issue(
+                    path=path,
+                    message=f"Value must be at most {max_length} characters.",
+                    code="maxLength",
+                )
+            )
+        pattern = schema.get("pattern")
+        if isinstance(pattern, str):
+            try:
+                matches = re.search(pattern, value) is not None
+            except re.error:
+                matches = True
+            if not matches:
+                errors.append(
+                    _validation_issue(
+                        path=path,
+                        message="Value must match the required pattern.",
+                        code="pattern",
+                    )
+                )
+    if schema_type in {"integer", "number"} and isinstance(value, (int, float)):
+        minimum = schema.get("minimum")
+        if isinstance(minimum, (int, float)) and value < minimum:
+            errors.append(
+                _validation_issue(
+                    path=path,
+                    message=f"Value must be greater than or equal to {minimum}.",
+                    code="minimum",
+                )
+            )
+        maximum = schema.get("maximum")
+        if isinstance(maximum, (int, float)) and value > maximum:
+            errors.append(
+                _validation_issue(
+                    path=path,
+                    message=f"Value must be less than or equal to {maximum}.",
+                    code="maximum",
+                )
+            )
+    if schema_type == "array" and isinstance(value, list):
+        min_items = schema.get("minItems")
+        if isinstance(min_items, int) and len(value) < min_items:
+            errors.append(
+                _validation_issue(
+                    path=path,
+                    message=f"Value must contain at least {min_items} items.",
+                    code="minItems",
+                )
+            )
+        max_items = schema.get("maxItems")
+        if isinstance(max_items, int) and len(value) > max_items:
+            errors.append(
+                _validation_issue(
+                    path=path,
+                    message=f"Value must contain at most {max_items} items.",
+                    code="maxItems",
+                )
+            )
+        if schema.get("uniqueItems") is True:
+            encoded_items = [
+                json.dumps(item, sort_keys=True, default=str) for item in value
+            ]
+            if len(set(encoded_items)) != len(encoded_items):
+                errors.append(
+                    _validation_issue(
+                        path=path,
+                        message="Array items must be unique.",
+                        code="uniqueItems",
+                    )
+                )
+        item_schema = schema.get("items")
+        if isinstance(item_schema, Mapping):
+            for index, item in enumerate(value):
+                _validate_schema_value(
+                    schema=item_schema,
+                    value=item,
+                    path=f"{path}[{index}]",
+                    errors=errors,
+                )
     fmt = str(schema.get("format") or "").strip()
     if fmt == "uri" and isinstance(value, str) and not urlparse(value).scheme:
         errors.append(
@@ -615,6 +732,88 @@ def _validate_schema_value(
                 code="format",
             )
         )
+
+
+def _validate_integration_references(
+    *,
+    schema: Mapping[str, Any],
+    ui_schema: Mapping[str, Any],
+    value: Mapping[str, Any],
+    path: str,
+    errors: list[dict[str, Any]],
+) -> None:
+    properties = schema.get("properties")
+    if not isinstance(properties, Mapping):
+        return
+    for field_name, field_schema in properties.items():
+        name = str(field_name)
+        if name not in value or not isinstance(field_schema, Mapping):
+            continue
+        field_ui_schema = ui_schema.get(name)
+        widget = (
+            field_ui_schema.get("widget")
+            if isinstance(field_ui_schema, Mapping)
+            else None
+        )
+        semantic_type = field_schema.get("x-moonmind-semantic-type")
+        field_value = value.get(name)
+        field_path = f"{path}.{name}"
+        if (
+            widget in {"jira.issue-picker", "github.issue-picker"}
+            or semantic_type == "issue-reference"
+        ):
+            _validate_issue_reference(field_value, field_path, errors)
+        elif widget == "github.repository-picker" or semantic_type == "repository":
+            _validate_repository_reference(field_value, field_path, errors)
+        elif widget == "github.branch-picker" or semantic_type == "branch":
+            if not isinstance(field_value, str) or not field_value.strip():
+                errors.append(
+                    _validation_issue(
+                        path=field_path,
+                        message="Branch reference must be a non-empty string.",
+                        code="reference",
+                    )
+                )
+
+
+def _validate_issue_reference(
+    value: Any,
+    path: str,
+    errors: list[dict[str, Any]],
+) -> None:
+    if isinstance(value, str):
+        if value.strip():
+            return
+    elif isinstance(value, Mapping):
+        key = str(
+            value.get("key") or value.get("id") or value.get("url") or ""
+        ).strip()
+        number = value.get("number")
+        if key or (isinstance(number, int) and not isinstance(number, bool)):
+            return
+    errors.append(
+        _validation_issue(
+            path=path,
+            message="Issue reference must include a key, URL, or numeric issue number.",
+            code="reference",
+        )
+    )
+
+
+def _validate_repository_reference(
+    value: Any,
+    path: str,
+    errors: list[dict[str, Any]],
+) -> None:
+    if isinstance(value, str) and re.fullmatch(r"[^/\s]+/[^/\s]+", value.strip()):
+        return
+    errors.append(
+        _validation_issue(
+            path=path,
+            message="Repository reference must use owner/name format.",
+            code="reference",
+        )
+    )
 
 
 def _schema_path_to_input_path(path: Any) -> str:

--- a/moonmind/workflows/temporal/worker_runtime.py
+++ b/moonmind/workflows/temporal/worker_runtime.py
@@ -42,6 +42,7 @@ from api_service.db.models import (
     TemporalExecutionOwnerType,
     TemporalExecutionRecord,
 )
+from moonmind.capabilities.input_contracts import validate_capability_inputs
 from moonmind.config.logging import configure_logging, default_log_fields_from_env
 from moonmind.config.settings import settings
 from moonmind.workflows.skills.deployment_execution import (
@@ -1081,6 +1082,65 @@ def _selected_step_tool_inputs(step_entry: Mapping[str, Any]) -> dict[str, Any]:
     )
 
 
+def _validated_step_skill_inputs(
+    *,
+    step_entry: Mapping[str, Any],
+    step_index: int,
+    raw_inputs: Mapping[str, Any],
+    workflow_context: Mapping[str, Any],
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    skill_payload = _coerce_mapping(step_entry.get("skill")) or _coerce_mapping(
+        step_entry.get("tool")
+    )
+    return _validated_skill_payload_inputs(
+        skill_payload=skill_payload,
+        raw_inputs=raw_inputs,
+        workflow_context=workflow_context,
+        path_prefix=f"steps[{step_index}].skill.inputs",
+    )
+
+
+def _validated_skill_payload_inputs(
+    *,
+    skill_payload: Mapping[str, Any],
+    raw_inputs: Mapping[str, Any],
+    workflow_context: Mapping[str, Any],
+    path_prefix: str,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    input_schema = _coerce_mapping(skill_payload.get("inputSchema"))
+    if not input_schema:
+        return dict(raw_inputs), {}
+    contract = {
+        "inputSchema": input_schema,
+        "uiSchema": _coerce_mapping(skill_payload.get("uiSchema")),
+        "defaults": _coerce_mapping(skill_payload.get("defaults")),
+        "contractDigest": skill_payload.get("inputContractDigest")
+        or skill_payload.get("contractDigest"),
+        "contentDigest": skill_payload.get("contentDigest"),
+        "contentRef": skill_payload.get("contentRef"),
+    }
+    result = validate_capability_inputs(
+        contract=contract,
+        values=raw_inputs,
+        workflow_context=workflow_context,
+        path_prefix=path_prefix,
+    )
+    errors = result.get("errors") if isinstance(result, Mapping) else []
+    if errors:
+        raise RuntimeError(json.dumps({"skillInputErrors": errors}, sort_keys=True))
+    evidence = {
+        key: value
+        for key, value in {
+            "inputContractDigest": result.get("contractDigest"),
+            "contentDigest": result.get("contentDigest"),
+            "contentRef": result.get("contentRef"),
+            "skillInputWarnings": result.get("warnings"),
+        }.items()
+        if value
+    }
+    return _coerce_mapping(result.get("values")), evidence
+
+
 def _merge_story_output_inputs(
     existing: Mapping[str, Any] | None,
     override: Any,
@@ -1331,6 +1391,20 @@ def _build_runtime_planner():
                 selected_skill_payload.get("inputs")
                 or selected_skill_payload.get("args")
             )
+        selected_skill_evidence: dict[str, Any] = {}
+        if selected_skill_payload:
+            selected_skill_inputs, selected_skill_evidence = (
+                _validated_skill_payload_inputs(
+                    skill_payload=selected_skill_payload,
+                    raw_inputs=selected_skill_inputs,
+                    workflow_context={
+                        **parameter_payload,
+                        **_coerce_mapping(parameter_payload.get("context")),
+                        **git_payload,
+                    },
+                    path_prefix="steps[0].skill.inputs",
+                )
+            )
 
         # --- Resolve instructions ---
         instructions = (
@@ -1430,6 +1504,9 @@ def _build_runtime_planner():
             "instructions": instructions,
             "runtime": runtime_node,
         }
+        if selected_skill_inputs:
+            node_inputs["inputs"] = dict(selected_skill_inputs)
+        node_inputs.update(selected_skill_evidence)
 
         step_count = task_payload.get("stepCount") or parameter_payload.get("stepCount")
         if step_count is not None:
@@ -1784,6 +1861,18 @@ def _build_runtime_planner():
                     step_entry,
                     include_type=is_agent_runtime_step or "source" in step_entry,
                 )
+                step_skill_evidence: dict[str, Any] = {}
+                if is_agent_runtime_step:
+                    step_tool_inputs, step_skill_evidence = _validated_step_skill_inputs(
+                        step_entry=step_entry,
+                        step_index=idx,
+                        raw_inputs=step_tool_inputs,
+                        workflow_context={
+                            **parameter_payload,
+                            **_coerce_mapping(parameter_payload.get("context")),
+                            **git_payload,
+                        },
+                    )
                 step_extra_inputs = {
                     k: v
                     for k, v in step_entry.items()
@@ -1823,6 +1912,9 @@ def _build_runtime_planner():
                         }
                     for key, value in step_tool_inputs.items():
                         step_node_inputs.setdefault(key, value)
+                    if step_tool_inputs:
+                        step_node_inputs["inputs"] = dict(step_tool_inputs)
+                    step_node_inputs.update(step_skill_evidence)
                 else:
                     step_node_inputs = (
                         _direct_story_tool_context_inputs(node_inputs)

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -40,6 +40,7 @@ from api_service.api.routers.executions import (
     _reuse_original_task_input_snapshot_from_source,
     _workflow_input_snapshot_descriptor_from_record,
     _normalize_task_steps,
+    _normalize_task_tool,
     _resolve_step_runtime_selections,
     _step_execution_detail_payload,
     _detect_optional_temporal_search_attributes,
@@ -367,6 +368,77 @@ def test_mm842_task_steps_accept_ordered_steps_without_graph_metadata() -> None:
     assert all("dependsOn" not in step for step in steps)
     assert all("depends_on" not in step for step in steps)
     assert all("dependencies" not in step for step in steps)
+
+
+def test_task_skill_normalization_preserves_input_contract_metadata() -> None:
+    task_payload = {
+        "steps": [
+            {
+                "id": "validate",
+                "skill": {
+                    "id": "schema.skill",
+                    "inputs": {"repository": "MoonLadderStudios/MoonMind"},
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {"repository": {"type": "string"}},
+                    },
+                    "uiSchema": {
+                        "repository": {"widget": "github.repository-picker"},
+                    },
+                    "defaults": {"branch": "main"},
+                    "inputContractDigest": "sha256:contract",
+                    "contentDigest": "sha256:content",
+                    "contentRef": "artifact:skill-contract",
+                },
+            }
+        ]
+    }
+
+    steps = _normalize_task_steps(task_payload)
+
+    skill = steps[0]["skill"]
+    assert skill["args"] == {"repository": "MoonLadderStudios/MoonMind"}
+    assert skill["inputSchema"]["properties"]["repository"]["type"] == "string"
+    assert skill["uiSchema"]["repository"]["widget"] == "github.repository-picker"
+    assert skill["defaults"] == {"branch": "main"}
+    assert skill["inputContractDigest"] == "sha256:contract"
+    assert skill["contentDigest"] == "sha256:content"
+    assert skill["contentRef"] == "artifact:skill-contract"
+
+
+def test_task_tool_normalization_preserves_skill_input_contract_metadata() -> None:
+    normalized = _normalize_task_tool(
+        {
+            "skill": {
+                "id": "schema.skill",
+                "inputs": {"issue": "MM-1057"},
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {"issue": {"type": "string"}},
+                },
+                "uiSchema": {"issue": {"widget": "jira.issue-picker"}},
+                "defaults": {"repository": "MoonLadderStudios/MoonMind"},
+                "inputContractDigest": "sha256:contract",
+                "contentDigest": "sha256:content",
+                "contentRef": "artifact:skill-contract",
+            },
+        }
+    )
+
+    assert normalized == {
+        "type": "skill",
+        "name": "schema.skill",
+        "inputs": {"issue": "MM-1057"},
+        "inputSchema": {
+            "type": "object",
+            "properties": {"issue": {"type": "string"}},
+        },
+        "uiSchema": {"issue": {"widget": "jira.issue-picker"}},
+        "defaults": {"repository": "MoonLadderStudios/MoonMind"},
+        "inputContractDigest": "sha256:contract",
+        "contentDigest": "sha256:content",
+        "contentRef": "artifact:skill-contract",
+    }
 
 
 @pytest.mark.parametrize("field_name", ["dependsOn", "depends_on", "dependencies"])

--- a/tests/unit/capabilities/test_input_contracts.py
+++ b/tests/unit/capabilities/test_input_contracts.py
@@ -270,3 +270,103 @@ def test_validate_capability_inputs_ignores_secret_defaults_and_remote_code_meta
     assert "schema_code_ignored" in warning_codes
     assert "unsupported_widget" in warning_codes
     assert "token" not in result["values"]
+
+
+def test_validate_capability_inputs_applies_json_schema_constraints() -> None:
+    contract = normalize_capability_input_contract(
+        owner=CapabilityInputOwner(id="demo", kind="skill", label="Demo"),
+        parts=capability_contract_from_legacy_inputs(
+            inputs_schema=[],
+            annotations={
+                "inputSchema": {
+                    "type": "object",
+                    "additionalProperties": False,
+                    "required": ["title"],
+                    "properties": {
+                        "title": {
+                            "type": "string",
+                            "minLength": 3,
+                            "pattern": "^MM-",
+                        },
+                        "priority": {"type": "integer", "minimum": 1, "maximum": 5},
+                        "labels": {
+                            "type": "array",
+                            "minItems": 1,
+                            "uniqueItems": True,
+                            "items": {"type": "string", "enum": ["bug", "docs"]},
+                        },
+                    },
+                }
+            },
+        ),
+    )
+
+    result = validate_capability_inputs(
+        contract=contract,
+        values={
+            "title": "no",
+            "priority": 10,
+            "labels": ["bug", "bug", "other"],
+            "extra": True,
+        },
+        path_prefix="steps[2].skill.inputs",
+    )
+
+    errors_by_code = {error["code"]: error["path"] for error in result["errors"]}
+    assert errors_by_code["additionalProperties"] == "steps[2].skill.inputs.extra"
+    assert errors_by_code["minLength"] == "steps[2].skill.inputs.title"
+    assert errors_by_code["pattern"] == "steps[2].skill.inputs.title"
+    assert errors_by_code["maximum"] == "steps[2].skill.inputs.priority"
+    assert errors_by_code["uniqueItems"] == "steps[2].skill.inputs.labels"
+    assert "steps[2].skill.inputs.labels[2]" in [
+        error["path"] for error in result["errors"] if error["code"] == "enum"
+    ]
+
+
+def test_validate_capability_inputs_checks_registered_reference_fields() -> None:
+    contract = normalize_capability_input_contract(
+        owner=CapabilityInputOwner(id="demo", kind="skill", label="Demo"),
+        parts=capability_contract_from_legacy_inputs(
+            inputs_schema=[],
+            annotations={
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "issue": {
+                            "type": "object",
+                            "x-moonmind-semantic-type": "issue-reference",
+                        },
+                        "repository": {
+                            "type": "string",
+                            "x-moonmind-semantic-type": "repository",
+                        },
+                        "branch": {
+                            "type": "string",
+                            "x-moonmind-semantic-type": "branch",
+                        },
+                    },
+                },
+                "uiSchema": {
+                    "issue": {"widget": "jira.issue-picker"},
+                    "repository": {"widget": "github.repository-picker"},
+                    "branch": {"widget": "github.branch-picker"},
+                },
+            },
+        ),
+    )
+
+    result = validate_capability_inputs(
+        contract=contract,
+        values={"issue": {}, "repository": "MoonMind", "branch": ""},
+        path_prefix="steps[3].skill.inputs",
+    )
+
+    assert [
+        (error["path"], error["code"])
+        for error in result["errors"]
+        if error["code"] == "reference"
+    ] == [
+        ("steps[3].skill.inputs.issue", "reference"),
+        ("steps[3].skill.inputs.repository", "reference"),
+        ("steps[3].skill.inputs.branch", "reference"),
+    ]

--- a/tests/unit/capabilities/test_input_contracts.py
+++ b/tests/unit/capabilities/test_input_contracts.py
@@ -5,6 +5,7 @@ from moonmind.capabilities.input_contracts import (
     capability_contract_from_legacy_inputs,
     normalize_capability_input_contract,
     parse_skill_capability_input_contract,
+    validate_capability_inputs,
 )
 
 
@@ -178,3 +179,94 @@ def test_preset_contract_dates_are_json_compatible() -> None:
     assert contract["inputSchema"]["properties"]["due_date"]["default"] == "2026-06-30"
     assert contract["defaults"] == {"due_date": "2026-06-30"}
     assert contract["contractDigest"].startswith("sha256:")
+
+
+def test_validate_capability_inputs_uses_input_schema_defaults_and_field_paths() -> None:
+    contract = normalize_capability_input_contract(
+        owner=CapabilityInputOwner(
+            id="demo-skill",
+            kind="skill",
+            label="Demo Skill",
+            content_digest="sha256:content",
+        ),
+        parts=capability_contract_from_legacy_inputs(
+            inputs_schema=[],
+            annotations={
+                "inputSchema": {
+                    "type": "object",
+                    "required": ["repository", "issue"],
+                    "properties": {
+                        "repository": {
+                            "type": "string",
+                            "x-moonmind-context-default": "repository",
+                        },
+                        "issue": {"type": "integer"},
+                        "branch": {"type": "string", "default": "schema-main"},
+                    },
+                },
+                "uiSchema": {"issue": {"widget": "jira.issue-picker"}},
+                "defaults": {"branch": "default-main"},
+            },
+        ),
+    )
+
+    result = validate_capability_inputs(
+        contract=contract,
+        values={"issue": "MM-1057"},
+        workflow_context={"repository": "MoonLadderStudios/MoonMind"},
+        path_prefix="steps[0].skill.inputs",
+    )
+
+    assert result["values"]["repository"] == "MoonLadderStudios/MoonMind"
+    assert result["values"]["branch"] == "default-main"
+    assert result["errors"] == [
+        {
+            "path": "steps[0].skill.inputs.issue",
+            "message": "Value must be an integer.",
+            "code": "type",
+            "recoverable": True,
+        }
+    ]
+    assert result["contractDigest"] == contract["contractDigest"]
+    assert result["contentDigest"] == "sha256:content"
+
+
+def test_validate_capability_inputs_ignores_secret_defaults_and_remote_code_metadata() -> None:
+    contract = {
+        "inputSchema": {
+            "type": "object",
+            "$ref": "https://example.invalid/schema.json",
+            "x-code": "return secret",
+            "properties": {
+                "token": {"type": "string"},
+                "target": {
+                    "type": "string",
+                    "description": "<script>alert(1)</script>Target",
+                },
+            },
+        },
+        "uiSchema": {"target": {"widget": "remote.widget"}},
+        "defaults": {"token": "ghp_not_a_real_token"},
+        "contractDigest": "sha256:contract",
+    }
+
+    normalized = normalize_capability_input_contract(
+        owner=CapabilityInputOwner(id="demo", kind="skill", label="Demo"),
+        parts=capability_contract_from_legacy_inputs(
+            inputs_schema=[],
+            annotations=contract,
+        ),
+    )
+    result = validate_capability_inputs(
+        contract=normalized,
+        values={"target": "MM-1057"},
+        path_prefix="steps[1].skill.inputs",
+    )
+
+    assert normalized["defaults"] == {}
+    assert normalized["inputSchema"]["properties"]["target"]["description"] == "alert(1)Target"
+    warning_codes = {warning["code"] for warning in result["warnings"]}
+    assert "remote_ref_ignored" in warning_codes
+    assert "schema_code_ignored" in warning_codes
+    assert "unsupported_widget" in warning_codes
+    assert "token" not in result["values"]

--- a/tests/unit/capabilities/test_input_contracts.py
+++ b/tests/unit/capabilities/test_input_contracts.py
@@ -591,3 +591,37 @@ def test_validate_capability_inputs_checks_registered_reference_fields() -> None
         ("steps[3].skill.inputs.repository", "reference"),
         ("steps[3].skill.inputs.branch", "reference"),
     ]
+
+
+def test_validate_capability_inputs_handles_object_without_properties() -> None:
+    contract = normalize_capability_input_contract(
+        owner=CapabilityInputOwner(id="demo", kind="skill", label="Demo"),
+        parts=capability_contract_from_legacy_inputs(
+            inputs_schema=[],
+            annotations={
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "emptyObject": {
+                            "type": "object",
+                            "additionalProperties": False,
+                        }
+                    },
+                }
+            },
+        ),
+    )
+
+    result = validate_capability_inputs(
+        contract=contract,
+        values={"emptyObject": {"unexpected": True}},
+    )
+
+    assert result["errors"] == [
+        {
+            "path": "inputs.emptyObject.unexpected",
+            "message": "Additional properties are not allowed.",
+            "code": "additionalProperties",
+            "recoverable": True,
+        }
+    ]

--- a/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
+++ b/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
@@ -625,6 +625,148 @@ def test_runtime_planner_maps_explicit_skill_step_with_provenance_to_agent_runti
     }
 
 
+def test_runtime_planner_validates_skill_step_contract_and_carries_evidence():
+    planner = _build_runtime_planner()
+    snapshot = SimpleNamespace(
+        digest="reg:sha256:test",
+        artifact_ref="art_registry_123",
+    )
+
+    plan = planner(
+        inputs={
+            "task": {
+                "instructions": "Run explicit skill step.",
+                "runtime": {"mode": "codex_cli"},
+                "steps": [
+                    {
+                        "id": "implement-mm-1057",
+                        "type": "skill",
+                        "instructions": "Implement MM-1057.",
+                        "skill": {
+                            "id": "jira-implement",
+                            "inputs": {"issueKey": "MM-1057"},
+                            "inputSchema": {
+                                "type": "object",
+                                "required": ["issueKey", "repository"],
+                                "properties": {
+                                    "issueKey": {"type": "string"},
+                                    "repository": {
+                                        "type": "string",
+                                        "x-moonmind-context-default": "repository",
+                                    },
+                                },
+                            },
+                            "inputContractDigest": "sha256:contract",
+                            "contentDigest": "sha256:content",
+                            "contentRef": "artifact:skill",
+                        },
+                    }
+                ],
+            }
+        },
+        parameters={"repository": "MoonLadderStudios/MoonMind"},
+        snapshot=snapshot,
+    )
+
+    node_inputs = plan["nodes"][0]["inputs"]
+    assert node_inputs["inputs"] == {
+        "issueKey": "MM-1057",
+        "repository": "MoonLadderStudios/MoonMind",
+    }
+    assert node_inputs["issueKey"] == "MM-1057"
+    assert node_inputs["repository"] == "MoonLadderStudios/MoonMind"
+    assert node_inputs["inputContractDigest"] == "sha256:contract"
+    assert node_inputs["contentDigest"] == "sha256:content"
+    assert node_inputs["contentRef"] == "artifact:skill"
+
+
+def test_runtime_planner_validates_primary_skill_contract_and_carries_evidence():
+    planner = _build_runtime_planner()
+    snapshot = SimpleNamespace(
+        digest="reg:sha256:test",
+        artifact_ref="art_registry_123",
+    )
+
+    plan = planner(
+        inputs={
+            "task": {
+                "instructions": "Implement MM-1057.",
+                "runtime": {"mode": "codex_cli"},
+                "skill": {
+                    "id": "jira-implement",
+                    "inputs": {"issueKey": "MM-1057"},
+                    "inputSchema": {
+                        "type": "object",
+                        "required": ["issueKey", "repository"],
+                        "properties": {
+                            "issueKey": {"type": "string"},
+                            "repository": {
+                                "type": "string",
+                                "x-moonmind-context-default": "repository",
+                            },
+                        },
+                    },
+                    "inputContractDigest": "sha256:contract",
+                    "contentDigest": "sha256:content",
+                    "contentRef": "artifact:skill",
+                },
+            }
+        },
+        parameters={"repository": "MoonLadderStudios/MoonMind"},
+        snapshot=snapshot,
+    )
+
+    node_inputs = plan["nodes"][0]["inputs"]
+    assert node_inputs["inputs"] == {
+        "issueKey": "MM-1057",
+        "repository": "MoonLadderStudios/MoonMind",
+    }
+    assert node_inputs["inputContractDigest"] == "sha256:contract"
+    assert node_inputs["contentDigest"] == "sha256:content"
+    assert node_inputs["contentRef"] == "artifact:skill"
+
+
+def test_runtime_planner_reports_field_addressable_skill_input_errors():
+    planner = _build_runtime_planner()
+    snapshot = SimpleNamespace(
+        digest="reg:sha256:test",
+        artifact_ref="art_registry_123",
+    )
+
+    with pytest.raises(RuntimeError) as excinfo:
+        planner(
+            inputs={
+                "task": {
+                    "instructions": "Run explicit skill step.",
+                    "runtime": {"mode": "codex_cli"},
+                    "steps": [
+                        {
+                            "id": "implement-mm-1057",
+                            "type": "skill",
+                            "instructions": "Implement MM-1057.",
+                            "skill": {
+                                "id": "jira-implement",
+                                "inputs": {},
+                                "inputSchema": {
+                                    "type": "object",
+                                    "required": ["issueKey"],
+                                    "properties": {
+                                        "issueKey": {"type": "string"},
+                                    },
+                                },
+                            },
+                        }
+                    ],
+                }
+            },
+            parameters={},
+            snapshot=snapshot,
+        )
+
+    assert "steps[0].skill.inputs.issueKey" in str(excinfo.value)
+    assert "required" in str(excinfo.value)
+
+
 def test_runtime_planner_orders_flattened_tool_and_skill_steps_with_provenance():
     planner = _build_runtime_planner()
     snapshot = SimpleNamespace(


### PR DESCRIPTION
Issue reference: MM-1057

Summary:
- Added backend Skill input validation/defaulting against normalized `inputSchema`, including field-addressable errors and warnings.
- Added trust-boundary diagnostics for remote schema refs, schema-provided code hooks, unsupported widgets, secret-like defaults, and sanitized markdown descriptions.
- Passed compact validated Skill input values plus content and input contract evidence through workflow start/runtime handoff paths.
- Updated focused backend/runtime and workflow-start UI tests for the new validation and handoff behavior.

Tests run:
- `./tools/test_unit.sh tests/unit/capabilities/test_input_contracts.py tests/unit/workflows/temporal/test_temporal_worker_runtime.py` passed: 115 passed.
- `./tools/test_unit.sh --ui-args frontend/src/entrypoints/workflow-start.test.tsx` passed UI suite: 43 files passed, 705 passed, 237 skipped.
- Broad `./tools/test_unit.sh --ui-args frontend/src/entrypoints/workflow-start.test.tsx` invocation also ran the Python unit suite and failed in unrelated `tests/unit/tools/test_sync_moonspec_submodule.py` because `vendor/moonspec/bundle/moonspec.bundle.yaml` is missing in this workspace.

Remaining risks:
- Full Python unit suite could not be green in this workspace until the MoonSpec vendor bundle is present.
- This implements backend validation/defaulting and compact evidence handoff, but provider-specific reference validators remain limited to the registered semantic/widget checks covered here.
