### PR TITLE
MM-1053 Enforce Skill schema trust boundaries

### DIFF
--- a/api_service/services/agent_skills_service.py
+++ b/api_service/services/agent_skills_service.py
@@ -14,6 +14,10 @@ from api_service.db.models import (
     AgentSkillFormat,
     SkillSet,
 )
+from moonmind.capabilities.input_contracts import (
+    CapabilityInputContractError,
+    parse_skill_capability_input_contract,
+)
 from moonmind.services.skill_resolution import (
     extract_required_capabilities_from_skill_markdown,
     extract_required_skill_names_from_skill_markdown,
@@ -110,6 +114,18 @@ class AgentSkillsService:
             skill_name=skill_slug,
             source_label=f"deployment skill '{skill_slug}'",
         )
+        try:
+            input_contract = parse_skill_capability_input_contract(
+                skill_id=skill_slug,
+                label=skill.title or skill_slug,
+                markdown=content,
+                source={"kind": "deployment"},
+                strict=True,
+            )
+        except CapabilityInputContractError as exc:
+            raise ValueError(
+                f"Invalid Skill input schema for '{skill_slug}': {exc}"
+            ) from exc
 
         try:
             parsed_format = AgentSkillFormat(format_str)
@@ -127,6 +143,13 @@ class AgentSkillsService:
                 "format": format_str,
                 "required_skills": list(required_skills),
                 "required_capabilities": list(required_capabilities),
+                "source_issue": "MM-1047",
+                "implementation_issue": "MM-1053",
+                "input_schema": input_contract.get("inputSchema", {}),
+                "ui_schema": input_contract.get("uiSchema", {}),
+                "defaults": input_contract.get("defaults", {}),
+                "input_contract_digest": input_contract.get("contractDigest"),
+                "input_schema_diagnostics": input_contract.get("diagnostics", []),
             },
         )
         artifact = await self._artifact_service.write_complete(

--- a/frontend/src/entrypoints/workflow-start.test.tsx
+++ b/frontend/src/entrypoints/workflow-start.test.tsx
@@ -15573,6 +15573,7 @@ describe("Task Create schema-driven capability inputs", () => {
           legacyItems: [
             {
               id: "schema.skill",
+              contractDigest: "sha256:current-skill-contract",
               inputSchema: {
                 type: "object",
                 required: ["repository"],
@@ -16205,7 +16206,10 @@ describe("Task Create schema-driven capability inputs", () => {
       payload: {
         task: {
           tool?: { inputs?: Record<string, unknown> };
-          skill?: { args?: Record<string, unknown> };
+          skill?: {
+            args?: Record<string, unknown>;
+            inputContractDigest?: string;
+          };
         };
       };
     };
@@ -16215,6 +16219,9 @@ describe("Task Create schema-driven capability inputs", () => {
     expect(request.payload.task.skill?.args).toMatchObject({
       repository: "MoonLadderStudios/SchemaRepo",
     });
+    expect(request.payload.task.skill?.inputContractDigest).toBe(
+      "sha256:current-skill-contract",
+    );
   });
 
   it("keeps cleared optional numeric schema inputs unset", async () => {

--- a/frontend/src/entrypoints/workflow-start.tsx
+++ b/frontend/src/entrypoints/workflow-start.tsx
@@ -608,6 +608,7 @@ interface SkillCapabilityDetail {
   inputSchema?: Record<string, unknown>;
   uiSchema?: Record<string, unknown>;
   defaults?: Record<string, unknown>;
+  contractDigest?: string;
   requiredCapabilities?: string[];
 }
 
@@ -771,6 +772,7 @@ interface StepState {
   pentestScopeDraft: PentestScopeDraftState;
   skillId: string;
   skillArgs: string;
+  skillInputContractDigest: string;
   // MM-936: explicit, user-authored required capabilities for this step. The
   // chip selector treats this as the only removable capability source; derived
   // capabilities (skill/tool/preset/runtime/publish) are computed for display.
@@ -1551,6 +1553,7 @@ function createStepStateEntry(
     pentestScopeDraft: createPentestScopeDraftState(),
     skillId: "",
     skillArgs: "",
+    skillInputContractDigest: "",
     explicitRequiredCapabilities: [],
     runtimeMode: "",
     runtimeModel: "",
@@ -1854,6 +1857,8 @@ function createStepStateEntriesFromTemporalDraft(
           : "",
       skillArgs:
         step.stepType === "skill" ? stringifySkillArgs(step.skillArgs) : "",
+      skillInputContractDigest:
+        step.stepType === "skill" ? step.skillInputContractDigest : "",
       explicitRequiredCapabilities: mergeCapabilities(
         step.skillRequiredCapabilities,
       ),
@@ -3389,6 +3394,15 @@ function mergeSkillArgsWithSchemaInputs(
   schemaInputs: Record<string, unknown>,
 ): Record<string, unknown> {
   return { ...skillArgs, ...schemaInputs };
+}
+
+function skillContractDigestMismatch(
+  savedDigest: string,
+  detail: Pick<SkillCapabilityDetail, "contractDigest"> | null | undefined,
+): boolean {
+  const saved = savedDigest.trim();
+  const current = String(detail?.contractDigest || "").trim();
+  return Boolean(saved && current && saved !== current);
 }
 
 function schemaToolInputs(
@@ -8910,6 +8924,13 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
           primaryStep?.explicitRequiredCapabilities,
         )
       : [];
+    const primaryInputContractDigest = primaryStepIsSkill
+      ? String(
+          primarySkillDetail?.contractDigest ||
+            primaryStep?.skillInputContractDigest ||
+            "",
+        ).trim()
+      : "";
     const primarySchemaInputs = primaryStep
       ? schemaSkillInputs(primarySkillDetail, primaryStep.presetInputValues)
       : { values: {}, errors: {} };
@@ -8997,6 +9018,9 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
       ...(Object.keys(primarySkillArgs).length > 0
         ? { inputs: primarySkillArgs }
         : {}),
+      ...(primaryInputContractDigest
+        ? { inputContractDigest: primaryInputContractDigest }
+        : {}),
       ...(taskSkillRequiredCapabilities.length > 0
         ? { requiredCapabilities: taskSkillRequiredCapabilities }
         : {}),
@@ -9004,6 +9028,9 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
     const primaryStepSkill = {
       id: primarySkillId,
       args: primarySkillArgs,
+      ...(primaryInputContractDigest
+        ? { inputContractDigest: primaryInputContractDigest }
+        : {}),
       ...(taskSkillRequiredCapabilities.length > 0
         ? { requiredCapabilities: taskSkillRequiredCapabilities }
         : {}),
@@ -9011,6 +9038,7 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
     const primaryStepHasSkillOverride =
       hasExplicitSkillSelection(primarySkillId) ||
       Object.keys(primarySkillArgs).length > 0 ||
+      Boolean(primaryInputContractDigest) ||
       taskSkillRequiredCapabilities.length > 0;
 
     const parsedAdditionalStepInputs: Array<{
@@ -9022,6 +9050,7 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
       skillCaps: string[];
       toolCaps: string[];
       toolInputs: Record<string, unknown>;
+      inputContractDigest: string;
       hasStepContent: boolean;
     }> = [];
     for (let index = 1; index < submissionSteps.length; index += 1) {
@@ -9051,6 +9080,13 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
             step.explicitRequiredCapabilities,
           )
         : [];
+      const stepInputContractDigest = stepIsSkill
+        ? String(
+            stepSkillDetail?.contractDigest ||
+              step.skillInputContractDigest ||
+              "",
+          ).trim()
+        : "";
       const stepToolDefinition =
         stepIsTool
           ? (trustedToolsQuery.data || []).find(
@@ -9163,6 +9199,7 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
         skillCaps: stepSkillCaps,
         toolCaps: stepToolCaps,
         toolInputs: stepToolInputs,
+        inputContractDigest: stepInputContractDigest,
         hasStepContent,
       });
     }
@@ -9397,6 +9434,7 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
       skillCaps: stepSkillCaps,
       toolCaps: stepToolCaps,
       toolInputs: stepToolInputs,
+      inputContractDigest: stepInputContractDigest,
       hasStepContent: hasPreUploadStepContent,
     } of parsedAdditionalStepInputs) {
       const uploadedStepAttachmentsForStep =
@@ -9442,6 +9480,9 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
           type: "skill",
           name: stepSkillId || primarySkillId,
           inputs: stepSkillArgs,
+          ...(stepInputContractDigest
+            ? { inputContractDigest: stepInputContractDigest }
+            : {}),
           ...(stepSkillCaps.length > 0
             ? { requiredCapabilities: stepSkillCaps }
             : {}),
@@ -9449,6 +9490,9 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
         stepPayload.skill = {
           id: stepSkillId || primarySkillId,
           args: stepSkillArgs,
+          ...(stepInputContractDigest
+            ? { inputContractDigest: stepInputContractDigest }
+            : {}),
           ...(stepSkillCaps.length > 0
             ? { requiredCapabilities: stepSkillCaps }
             : {}),
@@ -10494,6 +10538,10 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
               )
                 ? Object.entries(schemaProperties(selectedSkillDetail?.inputSchema))
                 : [];
+              const selectedSkillContractChanged = skillContractDigestMismatch(
+                step.skillInputContractDigest,
+                selectedSkillDetail,
+              );
               const toolSearchText = toolSearchTextByStep[step.localId] || "";
               const trustedToolDefinitions = trustedToolsQuery.data || [];
               const toolChoiceGroups = groupedToolChoices(
@@ -11243,6 +11291,7 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
                           onChange={(nextValue) =>
                             updateStep(step.localId, {
                               skillId: nextValue,
+                              skillInputContractDigest: "",
                             })
                           }
                         />
@@ -11274,20 +11323,27 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
                         </label>
                       ) : null}
                       {selectedSkillDetail ? (
-                        <SchemaCapabilityFields
-                          fields={visibleSkillSchemaFields}
-                          detail={selectedSkillDetail}
-                          values={step.presetInputValues}
-                          errors={step.presetInputErrors}
-                          disabled={false}
-                          onChange={(name, value) =>
-                            updateStepPresetInputValue(
-                              step.localId,
-                              { name },
-                              value,
-                            )
-                          }
-                        />
+                        <>
+                          {selectedSkillContractChanged ? (
+                            <p className="notice small" role="status">
+                              Skill input contract changed. Existing draft values are preserved and will be revalidated before submit.
+                            </p>
+                          ) : null}
+                          <SchemaCapabilityFields
+                            fields={visibleSkillSchemaFields}
+                            detail={selectedSkillDetail}
+                            values={step.presetInputValues}
+                            errors={step.presetInputErrors}
+                            disabled={false}
+                            onChange={(name, value) =>
+                              updateStepPresetInputValue(
+                                step.localId,
+                                { name },
+                                value,
+                              )
+                            }
+                          />
+                        </>
                       ) : null}
                     </div>
                   ) : null}

--- a/frontend/src/entrypoints/workflow-start.tsx
+++ b/frontend/src/entrypoints/workflow-start.tsx
@@ -5880,6 +5880,7 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
           ...(item.inputSchema ? { inputSchema: item.inputSchema } : {}),
           ...(item.uiSchema ? { uiSchema: item.uiSchema } : {}),
           ...(item.defaults ? { defaults: item.defaults } : {}),
+          ...(item.contractDigest ? { contractDigest: item.contractDigest } : {}),
           ...(Array.isArray(item.requiredCapabilities)
             ? {
                 requiredCapabilities: item.requiredCapabilities

--- a/frontend/src/lib/temporalTaskEditing.test.ts
+++ b/frontend/src/lib/temporalTaskEditing.test.ts
@@ -342,4 +342,34 @@ describe("buildTemporalSubmissionDraftFromExecution runtime command metadata", (
     ]);
     expect(draft.appliedTemplates[0]?.slug).toBe("jira-implement");
   });
+
+  it("preserves Skill input contract digests from saved drafts", () => {
+    const draft = buildTemporalSubmissionDraftFromExecution({
+      workflowId: "mm:skill-contract-digest",
+      workflowType: "MoonMind.UserWorkflow",
+      inputParameters: {
+        task: {
+          instructions: "Edit a saved Skill draft.",
+          steps: [
+            {
+              type: "skill",
+              instructions: "Use the saved structured values.",
+              skill: {
+                id: "schema.skill",
+                inputContractDigest: "sha256:saved-contract",
+                args: { repository: "MoonLadderStudios/MoonMind" },
+              },
+            },
+          ],
+        },
+      },
+    });
+
+    expect(draft.steps[0]?.skillInputContractDigest).toBe(
+      "sha256:saved-contract",
+    );
+    expect(draft.steps[0]?.skillArgs).toEqual({
+      repository: "MoonLadderStudios/MoonMind",
+    });
+  });
 });

--- a/frontend/src/lib/temporalTaskEditing.test.ts
+++ b/frontend/src/lib/temporalTaskEditing.test.ts
@@ -348,7 +348,7 @@ describe("buildTemporalSubmissionDraftFromExecution runtime command metadata", (
       workflowId: "mm:skill-contract-digest",
       workflowType: "MoonMind.UserWorkflow",
       inputParameters: {
-        task: {
+        workflow: {
           instructions: "Edit a saved Skill draft.",
           steps: [
             {

--- a/frontend/src/lib/temporalTaskEditing.ts
+++ b/frontend/src/lib/temporalTaskEditing.ts
@@ -133,6 +133,7 @@ export type TemporalSubmissionDraft = {
     preset?: TemporalSubmissionDraftPresetPayload;
     skillId: string;
     skillArgs: Record<string, unknown>;
+    skillInputContractDigest: string;
     skillRequiredCapabilities: string[];
     templateStepId: string;
     templateInstructions: string;
@@ -539,6 +540,10 @@ function draftStepFrom(value: unknown): TemporalSubmissionDraft['steps'][number]
     ...(Object.keys(preset).length > 0 ? { preset } : {}),
     skillId: stringValue(tool.name, tool.id, skill.id, skill.name),
     skillArgs: firstObjectValue(tool.inputs, tool.args, skill.inputs, skill.args),
+    skillInputContractDigest: stringValue(
+      tool.inputContractDigest,
+      skill.inputContractDigest,
+    ),
     skillRequiredCapabilities: stringArrayValue(
       tool.requiredCapabilities,
       skill.requiredCapabilities,

--- a/moonmind/capabilities/input_contracts.py
+++ b/moonmind/capabilities/input_contracts.py
@@ -82,6 +82,10 @@ _UNSUPPORTED_SCHEMA_KEYWORDS = frozenset(
         "unevaluatedproperties",
     }
 )
+_DESCRIPTION_SCRIPT_BLOCK_RE = re.compile(
+    r"<(script|style)\b[^>]*>.*?</\1>",
+    re.IGNORECASE | re.DOTALL,
+)
 _DESCRIPTION_MARKDOWN_RE = re.compile(
     r"(<[^>]+>|!\[[^\]]*]\([^)]+\)|\[[^\]]+]\((?:javascript:|data:)[^)]+\))",
     re.IGNORECASE,
@@ -546,6 +550,10 @@ def _sanitize_schema_metadata(
             )
             diagnostics.append(diagnostic)
             if strict:
+                _record_contract_event(
+                    "skill_input_schema_strict_policy_rejection",
+                    code=diagnostic["code"],
+                )
                 raise CapabilityInputContractError(diagnostic["message"])
             continue
         if key_lower in _EXECUTABLE_METADATA_KEYS:
@@ -577,6 +585,10 @@ def _sanitize_schema_metadata(
             )
             diagnostics.append(diagnostic)
             if strict:
+                _record_contract_event(
+                    "skill_input_schema_strict_policy_rejection",
+                    code=diagnostic["code"],
+                )
                 raise CapabilityInputContractError(diagnostic["message"])
             continue
         if key_text == "x-moonmind-widget":
@@ -703,7 +715,8 @@ def _sanitize_description(
                 path=path,
             )
         )
-    sanitized = _DESCRIPTION_MARKDOWN_RE.sub("", value).strip()
+    sanitized = _DESCRIPTION_SCRIPT_BLOCK_RE.sub("", value)
+    sanitized = _DESCRIPTION_MARKDOWN_RE.sub("", sanitized).strip()
     if sanitized != value.strip():
         diagnostics.append(
             _diagnostic(

--- a/moonmind/capabilities/input_contracts.py
+++ b/moonmind/capabilities/input_contracts.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import datetime as dt
 import hashlib
 import json
+import logging
 import re
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
@@ -15,10 +16,81 @@ import yaml
 CapabilityKind = Literal["tool", "skill", "preset"]
 
 PARSER_VERSION = "capability-input-contracts:v1"
+MAX_FRONTMATTER_BYTES = 64 * 1024
+MAX_INPUT_SCHEMA_BYTES = 128 * 1024
+MAX_UI_SCHEMA_BYTES = 64 * 1024
+MAX_DEFAULTS_BYTES = 32 * 1024
+MAX_DESCRIPTION_BYTES = 8 * 1024
+REGISTERED_WIDGETS = frozenset(
+    {
+        "text",
+        "textarea",
+        "markdown",
+        "number",
+        "checkbox",
+        "select",
+        "multi-select",
+        "json",
+        "jira.issue-picker",
+        "github.issue-picker",
+        "github.repository-picker",
+        "github.branch-picker",
+        "provider.profile-picker",
+        "model-picker",
+        "file-reference-picker",
+    }
+)
 _SECRET_LIKE_VALUE_PATTERN = re.compile(
     r"(token=|password=|bearer\s+|ghp_|github_pat_|akia[0-9a-z]{16}|aiza|atatt|-----begin [a-z ]*private key)",
     re.IGNORECASE,
 )
+_EXECUTABLE_METADATA_KEYS = frozenset(
+    {
+        "$dynamicref",
+        "component",
+        "components",
+        "dangerouslysetinnerhtml",
+        "eval",
+        "expression",
+        "function",
+        "import",
+        "onchange",
+        "onclick",
+        "onload",
+        "remotecomponent",
+        "script",
+        "srcdoc",
+    }
+)
+_UNSUPPORTED_SCHEMA_KEYWORDS = frozenset(
+    {
+        "$defs",
+        "$id",
+        "$schema",
+        "$vocabulary",
+        "contentencoding",
+        "contentmediatype",
+        "contentschema",
+        "dependentrequired",
+        "dependentschemas",
+        "if",
+        "then",
+        "else",
+        "patternproperties",
+        "propertynames",
+        "unevaluateditems",
+        "unevaluatedproperties",
+    }
+)
+_DESCRIPTION_MARKDOWN_RE = re.compile(
+    r"(<[^>]+>|!\[[^\]]*]\([^)]+\)|\[[^\]]+]\((?:javascript:|data:)[^)]+\))",
+    re.IGNORECASE,
+)
+logger = logging.getLogger(__name__)
+
+
+class CapabilityInputContractError(ValueError):
+    """Raised when strict contract policy rejects untrusted metadata."""
 
 
 @dataclass(frozen=True, slots=True)
@@ -49,49 +121,94 @@ def content_digest_for_text(content: str) -> str:
     return "sha256:" + hashlib.sha256(content.encode("utf-8")).hexdigest()
 
 
-def parse_skill_markdown_frontmatter(content: str) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+def parse_skill_markdown_frontmatter(
+    content: str,
+    *,
+    strict: bool = False,
+) -> tuple[dict[str, Any], list[dict[str, Any]]]:
     """Parse YAML frontmatter from a SKILL.md file with a safe loader."""
 
     if not content.startswith("---"):
+        _record_contract_event("skill_input_schema_omitted", source_kind="unknown")
         return {}, []
     marker = "\n---"
     end = content.find(marker, 3)
     if end < 0:
-        return {}, [
-            _diagnostic(
-                code="frontmatter_unclosed",
-                message="Skill frontmatter is not closed; structured metadata was ignored.",
-                severity="warning",
-                path="frontmatter",
+        diagnostic = _diagnostic(
+            code="frontmatter_unclosed",
+            message="Skill frontmatter is not closed; structured metadata was ignored.",
+            severity="error" if strict else "warning",
+            path="frontmatter",
+            recoverable=not strict,
+        )
+        if strict:
+            _record_contract_event(
+                "skill_input_schema_strict_policy_rejection",
+                code=diagnostic["code"],
             )
-        ]
+            raise CapabilityInputContractError(diagnostic["message"])
+        return {}, [diagnostic]
     raw_frontmatter = content[3:end]
+    if len(raw_frontmatter.encode("utf-8")) > MAX_FRONTMATTER_BYTES:
+        diagnostic = _diagnostic(
+            code="frontmatter_size_limit",
+            message="Skill frontmatter exceeds the supported metadata size limit.",
+            severity="error" if strict else "warning",
+            path="frontmatter",
+            recoverable=not strict,
+        )
+        if strict:
+            _record_contract_event(
+                "skill_input_schema_strict_policy_rejection",
+                code=diagnostic["code"],
+            )
+            raise CapabilityInputContractError(diagnostic["message"])
+        return {}, [diagnostic]
     try:
         parsed = yaml.safe_load(raw_frontmatter) or {}
     except yaml.YAMLError as exc:
-        return {}, [
-            _diagnostic(
-                code="frontmatter_yaml_invalid",
-                message="Skill frontmatter YAML could not be parsed; structured metadata was ignored.",
-                severity="warning",
-                path="frontmatter",
-                details={"error": str(exc)},
+        diagnostic = _diagnostic(
+            code="frontmatter_yaml_invalid",
+            message="Skill frontmatter YAML could not be parsed; structured metadata was ignored.",
+            severity="error" if strict else "warning",
+            path="frontmatter",
+            details={"errorType": type(exc).__name__},
+            recoverable=not strict,
+        )
+        if strict:
+            _record_contract_event(
+                "skill_input_schema_strict_policy_rejection",
+                code=diagnostic["code"],
             )
+            raise CapabilityInputContractError(diagnostic["message"]) from exc
+        return {}, [
+            diagnostic
         ]
     if not isinstance(parsed, Mapping):
-        return {}, [
-            _diagnostic(
-                code="frontmatter_not_object",
-                message="Skill frontmatter must be a YAML mapping; structured metadata was ignored.",
-                severity="warning",
-                path="frontmatter",
+        diagnostic = _diagnostic(
+            code="frontmatter_not_object",
+            message=(
+                "Skill frontmatter must be a YAML mapping; structured metadata "
+                "was ignored."
+            ),
+            severity="error" if strict else "warning",
+            path="frontmatter",
+            recoverable=not strict,
+        )
+        if strict:
+            _record_contract_event(
+                "skill_input_schema_strict_policy_rejection",
+                code=diagnostic["code"],
             )
-        ]
+            raise CapabilityInputContractError(diagnostic["message"])
+        return {}, [diagnostic]
     return dict(parsed), []
 
 
 def parse_capability_input_contract(
     raw_metadata: Mapping[str, Any] | None,
+    *,
+    strict: bool = False,
 ) -> CapabilityInputContractParts:
     """Extract schema metadata using accepted source casing."""
 
@@ -99,11 +216,12 @@ def parse_capability_input_contract(
     input_schema = _first_mapping(metadata, "inputSchema", "input_schema")
     ui_schema = _first_mapping(metadata, "uiSchema", "ui_schema")
     defaults = _first_mapping(metadata, "defaults")
-    return CapabilityInputContractParts(
+    parts = CapabilityInputContractParts(
         input_schema=_json_compatible_mapping(input_schema),
         ui_schema=_json_compatible_mapping(ui_schema),
         defaults=_json_compatible_mapping(defaults),
     )
+    return _enforce_contract_size_limits(parts, strict=strict)
 
 
 def capability_contract_from_legacy_inputs(
@@ -151,40 +269,60 @@ def normalize_capability_input_contract(
     *,
     owner: CapabilityInputOwner,
     parts: CapabilityInputContractParts,
+    strict: bool = False,
 ) -> dict[str, Any]:
     """Return a camelCase renderer-facing capability input contract."""
 
     diagnostics = [dict(item) for item in parts.diagnostics]
-    input_schema = _json_compatible_mapping(parts.input_schema) or {}
-    ui_schema = _json_compatible_mapping(parts.ui_schema) or {}
-    defaults = _json_compatible_mapping(parts.defaults) or {}
+    bounded_parts = _enforce_contract_size_limits(parts, strict=strict)
+    diagnostics = [dict(item) for item in bounded_parts.diagnostics]
+    input_schema = _json_compatible_mapping(bounded_parts.input_schema) or {}
+    ui_schema = _json_compatible_mapping(bounded_parts.ui_schema) or {}
+    defaults = _json_compatible_mapping(bounded_parts.defaults) or {}
 
     if input_schema:
+        input_schema = _sanitize_schema_metadata(input_schema, diagnostics, strict=strict)
         root_type = input_schema.get("type")
         if root_type != "object" or not isinstance(input_schema.get("properties", {}), Mapping):
-            diagnostics.append(
-                _diagnostic(
-                    code="input_schema_root_not_object",
-                    message=(
-                        "Capability inputSchema must be a root object schema; "
-                        "generated fields were omitted."
-                    ),
-                    severity="warning",
-                    path="inputSchema",
-                )
+            diagnostic = _diagnostic(
+                code="input_schema_root_not_object",
+                message=(
+                    "Capability inputSchema must be a root object schema; "
+                    "generated fields were omitted."
+                ),
+                severity="error" if strict else "warning",
+                path="inputSchema",
+                recoverable=not strict,
             )
+            diagnostics.append(diagnostic)
+            if strict:
+                _record_contract_event("skill_input_schema_strict_policy_rejection", owner_kind=owner.kind, source_kind=_source_kind(owner), code=diagnostic["code"])
+                raise CapabilityInputContractError(diagnostic["message"])
             input_schema = {}
+        else:
+            properties = input_schema.get("properties", {})
+            if isinstance(properties, Mapping):
+                _record_contract_event(
+                    "skill_input_schema_generated_field_count",
+                    owner_kind=owner.kind,
+                    source_kind=_source_kind(owner),
+                    field_count=len(properties),
+                )
 
     if _contains_secret_like_value(defaults):
-        diagnostics.append(
-            _diagnostic(
-                code="defaults_secret_like_value",
-                message="Capability defaults contained a secret-like value and were omitted.",
-                severity="warning",
-                path="defaults",
-            )
+        diagnostic = _diagnostic(
+            code="defaults_secret_like_value",
+            message="Capability defaults contained a secret-like value and were omitted.",
+            severity="error" if strict else "warning",
+            path="defaults",
+            recoverable=not strict,
         )
+        diagnostics.append(diagnostic)
+        if strict:
+            _record_contract_event("skill_input_schema_strict_policy_rejection", owner_kind=owner.kind, source_kind=_source_kind(owner), code=diagnostic["code"])
+            raise CapabilityInputContractError(diagnostic["message"])
         defaults = {}
+    ui_schema = _sanitize_ui_schema(ui_schema, diagnostics, strict=strict, owner=owner)
 
     digest_payload = {
         "parserVersion": PARSER_VERSION,
@@ -214,6 +352,13 @@ def normalize_capability_input_contract(
         contract["contentDigest"] = owner.content_digest
     if owner.source:
         contract["source"] = dict(owner.source)
+    _record_contract_event(
+        "skill_input_schema_parse_result",
+        owner_kind=owner.kind,
+        source_kind=_source_kind(owner),
+        status="success" if input_schema else "omitted",
+        diagnostic_codes=sorted({str(item.get("code", "")) for item in diagnostics if item.get("code")}),
+    )
     return contract
 
 
@@ -223,17 +368,19 @@ def parse_skill_capability_input_contract(
     label: str,
     markdown: str,
     source: Mapping[str, Any] | None = None,
+    strict: bool = False,
 ) -> dict[str, Any]:
     """Parse SKILL.md frontmatter into a normalized kind=skill contract."""
 
-    frontmatter, diagnostics = parse_skill_markdown_frontmatter(markdown)
-    description = str(frontmatter.get("description") or "").strip() or None
-    parts = parse_capability_input_contract(frontmatter)
+    frontmatter, diagnostics = parse_skill_markdown_frontmatter(markdown, strict=strict)
+    raw_description = str(frontmatter.get("description") or "").strip()
+    description, description_diagnostics = _sanitize_description(raw_description)
+    parts = parse_capability_input_contract(frontmatter, strict=strict)
     parts = CapabilityInputContractParts(
         input_schema=parts.input_schema,
         ui_schema=parts.ui_schema,
         defaults=parts.defaults,
-        diagnostics=[*diagnostics, *parts.diagnostics],
+        diagnostics=[*diagnostics, *description_diagnostics, *parts.diagnostics],
     )
     content_digest = content_digest_for_text(markdown)
     return normalize_capability_input_contract(
@@ -249,6 +396,7 @@ def parse_skill_capability_input_contract(
             },
         ),
         parts=parts,
+        strict=strict,
     )
 
 
@@ -318,13 +466,270 @@ def _diagnostic(
     severity: str,
     path: str,
     details: Mapping[str, Any] | None = None,
+    recoverable: bool = True,
 ) -> dict[str, Any]:
     diagnostic: dict[str, Any] = {
         "code": code,
         "message": message,
         "severity": severity,
         "path": path,
+        "recoverable": recoverable,
     }
     if details:
         diagnostic["details"] = dict(details)
     return diagnostic
+
+
+def _enforce_contract_size_limits(
+    parts: CapabilityInputContractParts,
+    *,
+    strict: bool,
+) -> CapabilityInputContractParts:
+    diagnostics = [dict(item) for item in parts.diagnostics]
+    values: dict[str, Mapping[str, Any] | None] = {
+        "input_schema": parts.input_schema,
+        "ui_schema": parts.ui_schema,
+        "defaults": parts.defaults,
+    }
+    limits = {
+        "input_schema": MAX_INPUT_SCHEMA_BYTES,
+        "ui_schema": MAX_UI_SCHEMA_BYTES,
+        "defaults": MAX_DEFAULTS_BYTES,
+    }
+    for field_name, limit in limits.items():
+        value = values[field_name]
+        if value is None:
+            continue
+        size = len(json.dumps(_json_compatible_mapping(value) or {}, sort_keys=True).encode("utf-8"))
+        if size <= limit:
+            continue
+        api_path = {"input_schema": "inputSchema", "ui_schema": "uiSchema", "defaults": "defaults"}[field_name]
+        diagnostic = _diagnostic(
+            code=f"{field_name}_size_limit",
+            message=f"Capability {api_path} exceeds the supported size limit.",
+            severity="error" if strict else "warning",
+            path=api_path,
+            recoverable=not strict,
+        )
+        diagnostics.append(diagnostic)
+        if strict:
+            _record_contract_event("skill_input_schema_strict_policy_rejection", code=diagnostic["code"])
+            raise CapabilityInputContractError(diagnostic["message"])
+        values[field_name] = None
+    return CapabilityInputContractParts(
+        input_schema=values["input_schema"],
+        ui_schema=values["ui_schema"],
+        defaults=values["defaults"],
+        diagnostics=diagnostics,
+    )
+
+
+def _sanitize_schema_metadata(
+    schema: dict[str, Any],
+    diagnostics: list[dict[str, Any]],
+    *,
+    strict: bool,
+    path: str = "inputSchema",
+) -> dict[str, Any]:
+    sanitized: dict[str, Any] = {}
+    for key, value in schema.items():
+        key_text = str(key)
+        key_lower = key_text.lower()
+        current_path = f"{path}.{key_text}"
+        if key_text == "$ref" and _is_remote_ref(value):
+            diagnostic = _diagnostic(
+                code="remote_ref_disabled",
+                message="Remote schema references are disabled for Skill input schemas.",
+                severity="error" if strict else "warning",
+                path=current_path,
+                recoverable=not strict,
+            )
+            diagnostics.append(diagnostic)
+            if strict:
+                raise CapabilityInputContractError(diagnostic["message"])
+            continue
+        if key_lower in _EXECUTABLE_METADATA_KEYS:
+            diagnostics.append(
+                _diagnostic(
+                    code="executable_metadata_ignored",
+                    message="Executable schema metadata was ignored.",
+                    severity="warning",
+                    path=current_path,
+                )
+            )
+            continue
+        if key_lower in _UNSUPPORTED_SCHEMA_KEYWORDS:
+            diagnostics.append(
+                _diagnostic(
+                    code="unsupported_keyword",
+                    message="Unsupported JSON Schema keyword was preserved as inert metadata.",
+                    severity="info",
+                    path=current_path,
+                )
+            )
+        if key_text == "default" and _contains_secret_like_value(value):
+            diagnostic = _diagnostic(
+                code="secret_like_default",
+                message="Secret-like schema default was ignored.",
+                severity="error" if strict else "warning",
+                path=current_path,
+                recoverable=not strict,
+            )
+            diagnostics.append(diagnostic)
+            if strict:
+                raise CapabilityInputContractError(diagnostic["message"])
+            continue
+        if key_text == "x-moonmind-widget":
+            widget = str(value or "").strip()
+            if widget and widget not in REGISTERED_WIDGETS:
+                diagnostics.extend(
+                    [
+                        _diagnostic(
+                            code="unsupported_widget",
+                            message=(
+                                "Unsupported widget metadata was ignored; the "
+                                "renderer will use a safe fallback."
+                            ),
+                            severity="warning",
+                            path=current_path,
+                        ),
+                        _diagnostic(
+                            code="fallback_renderer",
+                            message="A safe fallback renderer will be used.",
+                            severity="info",
+                            path=path,
+                        ),
+                    ]
+                )
+                continue
+        if key_text.startswith("x-") and not key_text.startswith("x-moonmind-"):
+            diagnostics.append(
+                _diagnostic(
+                    code="ignored_hint",
+                    message="Unknown non-namespaced schema hint was ignored.",
+                    severity="warning",
+                    path=current_path,
+                )
+            )
+            continue
+        if key_text == "description" and isinstance(value, str):
+            description, description_diagnostics = _sanitize_description(value, path=current_path)
+            diagnostics.extend(description_diagnostics)
+            sanitized[key_text] = description
+            continue
+        if isinstance(value, Mapping):
+            sanitized[key_text] = _sanitize_schema_metadata(dict(value), diagnostics, strict=strict, path=current_path)
+            continue
+        if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+            sanitized[key_text] = [
+                _sanitize_schema_metadata(dict(item), diagnostics, strict=strict, path=f"{current_path}[{index}]")
+                if isinstance(item, Mapping)
+                else item
+                for index, item in enumerate(value)
+            ]
+            continue
+        sanitized[key_text] = value
+    return sanitized
+
+
+def _sanitize_ui_schema(
+    ui_schema: dict[str, Any],
+    diagnostics: list[dict[str, Any]],
+    *,
+    strict: bool,
+    owner: CapabilityInputOwner,
+) -> dict[str, Any]:
+    sanitized: dict[str, Any] = {}
+    for field_name, raw_field in ui_schema.items():
+        if not isinstance(raw_field, Mapping):
+            continue
+        field_ui: dict[str, Any] = {}
+        for key, value in raw_field.items():
+            key_text = str(key)
+            key_lower = key_text.lower()
+            path = f"uiSchema.{field_name}.{key_text}"
+            if key_lower in _EXECUTABLE_METADATA_KEYS or _is_remote_ref(value):
+                diagnostics.append(
+                    _diagnostic(
+                        code="executable_metadata_ignored",
+                        message="Executable or remote UI metadata was ignored.",
+                        severity="warning",
+                        path=path,
+                    )
+                )
+                continue
+            if key_text == "widget":
+                widget = str(value or "").strip()
+                if widget and widget not in REGISTERED_WIDGETS:
+                    diagnostics.append(
+                        _diagnostic(
+                            code="unsupported_widget",
+                            message="Unsupported widget metadata was ignored; the renderer will use a safe fallback.",
+                            severity="warning",
+                            path=path,
+                        )
+                    )
+                    diagnostics.append(
+                        _diagnostic(
+                            code="fallback_renderer",
+                            message="A safe fallback renderer will be used.",
+                            severity="info",
+                            path=f"uiSchema.{field_name}",
+                        )
+                    )
+                    _record_contract_event("skill_input_schema_unsupported_widget", owner_kind=owner.kind, source_kind=_source_kind(owner))
+                    continue
+            field_ui[key_text] = _json_compatible_value(value)
+        sanitized[str(field_name)] = field_ui
+    return sanitized
+
+
+def _sanitize_description(
+    value: str,
+    *,
+    path: str = "description",
+) -> tuple[str | None, list[dict[str, Any]]]:
+    if not value:
+        return None, []
+    diagnostics: list[dict[str, Any]] = []
+    encoded = value.encode("utf-8")
+    if len(encoded) > MAX_DESCRIPTION_BYTES:
+        value = encoded[:MAX_DESCRIPTION_BYTES].decode("utf-8", errors="ignore")
+        diagnostics.append(
+            _diagnostic(
+                code="description_size_limit",
+                message="Capability description exceeded the supported size limit and was truncated.",
+                severity="warning",
+                path=path,
+            )
+        )
+    sanitized = _DESCRIPTION_MARKDOWN_RE.sub("", value).strip()
+    if sanitized != value.strip():
+        diagnostics.append(
+            _diagnostic(
+                code="unsafe_markdown_ignored",
+                message="Unsafe markdown or HTML in a capability description was ignored.",
+                severity="warning",
+                path=path,
+            )
+        )
+    return sanitized or None, diagnostics
+
+
+def _is_remote_ref(value: Any) -> bool:
+    text = str(value or "").strip().lower()
+    return text.startswith(("http://", "https://", "javascript:", "data:"))
+
+
+def _source_kind(owner: CapabilityInputOwner) -> str:
+    source = owner.source or {}
+    return str(source.get("kind") or source.get("source_kind") or "unknown")
+
+
+def _record_contract_event(event: str, **attributes: Any) -> None:
+    safe_attributes = {
+        key: value
+        for key, value in attributes.items()
+        if value is not None and key not in {"default", "defaults", "input", "inputs", "value", "values"}
+    }
+    logger.info("capability_input_contract.%s", event, extra={"event": event, "attributes": safe_attributes})

--- a/tests/unit/api/test_agent_skills_service.py
+++ b/tests/unit/api/test_agent_skills_service.py
@@ -105,6 +105,99 @@ async def test_update_skill_content_success(tmp_path, mock_artifact_service: Asy
             mock_artifact_service.write_complete.assert_awaited_once()
 
 @pytest.mark.asyncio
+async def test_update_skill_content_persists_input_contract_metadata(
+    tmp_path, mock_artifact_service: AsyncMock
+):
+    async with template_db(tmp_path) as session_maker:
+        async with session_maker() as db_session:
+            svc = AgentSkillsService(session=db_session, artifact_service=mock_artifact_service)
+            await svc.create_skill(slug="docs-skill", title="Docs")
+
+            await svc.update_skill_content(
+                skill_slug="docs-skill",
+                content=(
+                    "---\n"
+                    "name: docs-skill\n"
+                    "description: Collect an issue.\n"
+                    "inputSchema:\n"
+                    "  type: object\n"
+                    "  required: [issue]\n"
+                    "  properties:\n"
+                    "    issue:\n"
+                    "      type: string\n"
+                    "uiSchema:\n"
+                    "  issue:\n"
+                    "    widget: text\n"
+                    "defaults:\n"
+                    "  issue: MM-1047\n"
+                    "---\n"
+                    "# Docs\n"
+                ),
+            )
+
+            metadata = mock_artifact_service.create.await_args.kwargs["metadata_json"]
+            assert metadata["implementation_issue"] == "MM-1053"
+            assert metadata["source_issue"] == "MM-1047"
+            assert metadata["input_schema"]["required"] == ["issue"]
+            assert metadata["ui_schema"] == {"issue": {"widget": "text"}}
+            assert metadata["defaults"] == {"issue": "MM-1047"}
+            assert metadata["input_contract_digest"].startswith("sha256:")
+            assert metadata["input_schema_diagnostics"] == []
+
+@pytest.mark.asyncio
+async def test_update_skill_content_rejects_secret_like_defaults_before_artifact_create(
+    tmp_path, mock_artifact_service: AsyncMock
+):
+    async with template_db(tmp_path) as session_maker:
+        async with session_maker() as db_session:
+            svc = AgentSkillsService(session=db_session, artifact_service=mock_artifact_service)
+            await svc.create_skill(slug="docs-skill", title="Docs")
+
+            with pytest.raises(ValueError, match="Invalid Skill input schema"):
+                await svc.update_skill_content(
+                    skill_slug="docs-skill",
+                    content=(
+                        "---\n"
+                        "name: docs-skill\n"
+                        "inputSchema:\n"
+                        "  type: object\n"
+                        "  properties:\n"
+                        "    token:\n"
+                        "      type: string\n"
+                        "defaults:\n"
+                        "  token: token=raw-secret\n"
+                        "---\n"
+                        "# Docs\n"
+                    ),
+                )
+
+            mock_artifact_service.create.assert_not_awaited()
+            mock_artifact_service.write_complete.assert_not_awaited()
+
+@pytest.mark.asyncio
+async def test_update_skill_content_rejects_malformed_frontmatter_before_artifact_create(
+    tmp_path, mock_artifact_service: AsyncMock
+):
+    async with template_db(tmp_path) as session_maker:
+        async with session_maker() as db_session:
+            svc = AgentSkillsService(session=db_session, artifact_service=mock_artifact_service)
+            await svc.create_skill(slug="docs-skill", title="Docs")
+
+            with pytest.raises(ValueError, match="invalid YAML frontmatter|frontmatter"):
+                await svc.update_skill_content(
+                    skill_slug="docs-skill",
+                    content=(
+                        "---\n"
+                        "name: [unterminated\n"
+                        "---\n"
+                        "# Docs\n"
+                    ),
+                )
+
+            mock_artifact_service.create.assert_not_awaited()
+            mock_artifact_service.write_complete.assert_not_awaited()
+
+@pytest.mark.asyncio
 async def test_update_skill_content_replaces_current_content(
     tmp_path, mock_artifact_service: AsyncMock
 ):

--- a/tests/unit/capabilities/test_input_contracts.py
+++ b/tests/unit/capabilities/test_input_contracts.py
@@ -278,6 +278,37 @@ def test_skill_contract_omits_secret_like_schema_default() -> None:
     }
 
 
+def test_strict_contract_records_remote_ref_rejection(caplog: pytest.LogCaptureFixture) -> None:
+    markdown = (
+        "---\n"
+        "name: Demo Skill\n"
+        "inputSchema:\n"
+        "  type: object\n"
+        "  properties:\n"
+        "    target:\n"
+        "      type: string\n"
+        "      $ref: https://example.invalid/schema.json\n"
+        "---\n"
+        "# Demo\n"
+    )
+
+    caplog.set_level("INFO", logger="moonmind.capabilities.input_contracts")
+
+    with pytest.raises(CapabilityInputContractError, match="Remote schema references"):
+        parse_skill_capability_input_contract(
+            skill_id="demo-skill",
+            label="Demo Skill",
+            markdown=markdown,
+            strict=True,
+        )
+
+    assert any(
+        getattr(record, "event", None) == "skill_input_schema_strict_policy_rejection"
+        and getattr(record, "attributes", None) == {"code": "remote_ref_disabled"}
+        for record in caplog.records
+    )
+
+
 def test_strict_contract_rejects_schema_size_limit() -> None:
     huge_description = "a" * (128 * 1024)
 

--- a/tests/unit/capabilities/test_input_contracts.py
+++ b/tests/unit/capabilities/test_input_contracts.py
@@ -1,7 +1,10 @@
 import datetime as dt
+import pytest
 
 from moonmind.capabilities.input_contracts import (
+    CapabilityInputContractError,
     CapabilityInputOwner,
+    CapabilityInputContractParts,
     capability_contract_from_legacy_inputs,
     normalize_capability_input_contract,
     parse_skill_capability_input_contract,
@@ -178,3 +181,123 @@ def test_preset_contract_dates_are_json_compatible() -> None:
     assert contract["inputSchema"]["properties"]["due_date"]["default"] == "2026-06-30"
     assert contract["defaults"] == {"due_date": "2026-06-30"}
     assert contract["contractDigest"].startswith("sha256:")
+
+
+def test_lenient_skill_contract_blocks_remote_refs_and_executable_metadata() -> None:
+    markdown = (
+        "---\n"
+        "name: Demo Skill\n"
+        "description: '<script>alert(1)</script>Safe text'\n"
+        "inputSchema:\n"
+        "  type: object\n"
+        "  properties:\n"
+        "    target:\n"
+        "      type: string\n"
+        "      $ref: https://example.invalid/schema.json\n"
+        "      onClick: steal()\n"
+        "      x-moonmind-widget: remote.component\n"
+        "      x-foreign-widget: unsafe\n"
+        "      description: '[bad](javascript:unsafe)Safe description'\n"
+        "uiSchema:\n"
+        "  target:\n"
+        "    widget: https://example.invalid/widget.js\n"
+        "    component: RemoteComponent\n"
+        "---\n"
+        "# Demo\n"
+    )
+
+    contract = parse_skill_capability_input_contract(
+        skill_id="demo-skill",
+        label="Demo Skill",
+        markdown=markdown,
+    )
+
+    target = contract["inputSchema"]["properties"]["target"]
+    assert "$ref" not in target
+    assert "onClick" not in target
+    assert "x-foreign-widget" not in target
+    assert contract["uiSchema"]["target"] == {}
+    assert contract["description"] == "Safe text"
+    assert target["description"] == "Safe description"
+    diagnostic_codes = {item["code"] for item in contract["diagnostics"]}
+    assert "remote_ref_disabled" in diagnostic_codes
+    assert "executable_metadata_ignored" in diagnostic_codes
+    assert "ignored_hint" in diagnostic_codes
+    assert "fallback_renderer" in diagnostic_codes
+    assert "unsafe_markdown_ignored" in diagnostic_codes
+
+
+def test_strict_skill_contract_rejects_secret_like_defaults() -> None:
+    markdown = (
+        "---\n"
+        "name: Demo Skill\n"
+        "inputSchema:\n"
+        "  type: object\n"
+        "  properties:\n"
+        "    token:\n"
+        "      type: string\n"
+        "defaults:\n"
+        "  token: ghp_1234567890abcdef\n"
+        "---\n"
+        "# Demo\n"
+    )
+
+    with pytest.raises(CapabilityInputContractError, match="secret-like value"):
+        parse_skill_capability_input_contract(
+            skill_id="demo-skill",
+            label="Demo Skill",
+            markdown=markdown,
+            strict=True,
+        )
+
+
+def test_skill_contract_omits_secret_like_schema_default() -> None:
+    markdown = (
+        "---\n"
+        "name: Demo Skill\n"
+        "inputSchema:\n"
+        "  type: object\n"
+        "  properties:\n"
+        "    token:\n"
+        "      type: string\n"
+        "      default: password=raw-secret\n"
+        "---\n"
+        "# Demo\n"
+    )
+
+    contract = parse_skill_capability_input_contract(
+        skill_id="demo-skill",
+        label="Demo Skill",
+        markdown=markdown,
+    )
+
+    token_schema = contract["inputSchema"]["properties"]["token"]
+    assert "default" not in token_schema
+    assert {item["code"] for item in contract["diagnostics"]} >= {
+        "secret_like_default",
+    }
+
+
+def test_strict_contract_rejects_schema_size_limit() -> None:
+    huge_description = "a" * (128 * 1024)
+
+    with pytest.raises(CapabilityInputContractError, match="inputSchema exceeds"):
+        normalize_capability_input_contract(
+            owner=CapabilityInputOwner(
+                id="demo-skill",
+                kind="skill",
+                label="Demo Skill",
+            ),
+            parts=CapabilityInputContractParts(
+                input_schema={
+                    "type": "object",
+                    "properties": {
+                        "target": {
+                            "type": "string",
+                            "description": huge_description,
+                        }
+                    },
+                },
+            ),
+            strict=True,
+        )


### PR DESCRIPTION
Issue reference: MM-1053

Summary:
- Adds hardened Skill input contract parsing with size limits, safe YAML/frontmatter handling, schema/default diagnostics, secret-like default rejection/omission, remote ref and executable metadata blocking, unsupported keyword/widget reporting, schema digest generation, and sanitized descriptions.
- Persists validated input contract metadata during managed Skill save flows and rejects strict-policy schema failures before artifact creation.
- Adds frontend stale input contract digest detection, stale notice behavior, validation/fallback observability events, and coverage for preserving draft values across contract changes.

Tests run:
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/capabilities/test_input_contracts.py tests/unit/api/test_agent_skills_service.py --ui-args frontend/src/entrypoints/workflow-start.test.tsx frontend/src/lib/temporalTaskEditing.test.ts`

Remaining risks:
- No compose-backed integration suite was run because this PR touches Skill contract parsing and workflow-start UI behavior, not Docker, migrations, database schema, or runtime infrastructure.
