### PR TITLE
Move moonspec github submodule out of the vendor directory and into the root directory. Adjust all references to it in the project to make sure it wor

### DIFF
--- a/.agents/skills/moonspec-align/SKILL.md
+++ b/.agents/skills/moonspec-align/SKILL.md
@@ -5,7 +5,7 @@ metadata:
   required-capabilities:
     - git
 ---
-<!-- Generated from vendor/moonspec/bundle/skills/moonspec-align/SKILL.md; edit MoonSpec repo instead. -->
+<!-- Generated from moonspec/bundle/skills/moonspec-align/SKILL.md; edit MoonSpec repo instead. -->
 
 
 # MoonSpec Align

--- a/.agents/skills/moonspec-align/agents/openai.yaml
+++ b/.agents/skills/moonspec-align/agents/openai.yaml
@@ -1,4 +1,4 @@
-# Generated from vendor/moonspec/bundle/skills/moonspec-align/agents/openai.yaml; edit MoonSpec repo instead.
+# Generated from moonspec/bundle/skills/moonspec-align/agents/openai.yaml; edit MoonSpec repo instead.
 interface:
   display_name: "MoonSpec Align"
   short_description: "Analyze and remediate MoonSpec artifact drift."

--- a/.agents/skills/moonspec-breakdown/SKILL.md
+++ b/.agents/skills/moonspec-breakdown/SKILL.md
@@ -5,7 +5,7 @@ metadata:
   required-capabilities:
     - git
 ---
-<!-- Generated from vendor/moonspec/bundle/skills/moonspec-breakdown/SKILL.md; edit MoonSpec repo instead. -->
+<!-- Generated from moonspec/bundle/skills/moonspec-breakdown/SKILL.md; edit MoonSpec repo instead. -->
 
 
 # MoonSpec Breakdown

--- a/.agents/skills/moonspec-breakdown/agents/openai.yaml
+++ b/.agents/skills/moonspec-breakdown/agents/openai.yaml
@@ -1,4 +1,4 @@
-# Generated from vendor/moonspec/bundle/skills/moonspec-breakdown/agents/openai.yaml; edit MoonSpec repo instead.
+# Generated from moonspec/bundle/skills/moonspec-breakdown/agents/openai.yaml; edit MoonSpec repo instead.
 interface:
   display_name: "MoonSpec Breakdown"
   short_description: "Split designs into coverage-checked one-story specs."

--- a/.agents/skills/moonspec-doc-reconcile/SKILL.md
+++ b/.agents/skills/moonspec-doc-reconcile/SKILL.md
@@ -5,7 +5,7 @@ metadata:
   required-capabilities:
     - git
 ---
-<!-- Generated from vendor/moonspec/bundle/skills/moonspec-doc-reconcile/SKILL.md; edit MoonSpec repo instead. -->
+<!-- Generated from moonspec/bundle/skills/moonspec-doc-reconcile/SKILL.md; edit MoonSpec repo instead. -->
 
 
 # MoonSpec Doc Reconcile

--- a/.agents/skills/moonspec-doc-reconcile/agents/openai.yaml
+++ b/.agents/skills/moonspec-doc-reconcile/agents/openai.yaml
@@ -1,4 +1,4 @@
-# Generated from vendor/moonspec/bundle/skills/moonspec-doc-reconcile/agents/openai.yaml; edit MoonSpec repo instead.
+# Generated from moonspec/bundle/skills/moonspec-doc-reconcile/agents/openai.yaml; edit MoonSpec repo instead.
 interface:
   display_name: "MoonSpec Doc Reconcile"
   short_description: "Reconcile canonical docs after verified MoonSpec implementation."

--- a/.agents/skills/moonspec-implement/SKILL.md
+++ b/.agents/skills/moonspec-implement/SKILL.md
@@ -5,7 +5,7 @@ metadata:
   required-capabilities:
     - git
 ---
-<!-- Generated from vendor/moonspec/bundle/skills/moonspec-implement/SKILL.md; edit MoonSpec repo instead. -->
+<!-- Generated from moonspec/bundle/skills/moonspec-implement/SKILL.md; edit MoonSpec repo instead. -->
 
 
 # MoonSpec Implement

--- a/.agents/skills/moonspec-implement/agents/openai.yaml
+++ b/.agents/skills/moonspec-implement/agents/openai.yaml
@@ -1,4 +1,4 @@
-# Generated from vendor/moonspec/bundle/skills/moonspec-implement/agents/openai.yaml; edit MoonSpec repo instead.
+# Generated from moonspec/bundle/skills/moonspec-implement/agents/openai.yaml; edit MoonSpec repo instead.
 interface:
   display_name: "MoonSpec Implement"
   short_description: "Implement a one-story MoonSpec task breakdown with TDD."

--- a/.agents/skills/moonspec-orchestrate/SKILL.md
+++ b/.agents/skills/moonspec-orchestrate/SKILL.md
@@ -5,7 +5,7 @@ metadata:
   required-capabilities:
     - git
 ---
-<!-- Generated from vendor/moonspec/bundle/skills/moonspec-orchestrate/SKILL.md; edit MoonSpec repo instead. -->
+<!-- Generated from moonspec/bundle/skills/moonspec-orchestrate/SKILL.md; edit MoonSpec repo instead. -->
 
 
 # MoonSpec Orchestrate

--- a/.agents/skills/moonspec-orchestrate/agents/openai.yaml
+++ b/.agents/skills/moonspec-orchestrate/agents/openai.yaml
@@ -1,4 +1,4 @@
-# Generated from vendor/moonspec/bundle/skills/moonspec-orchestrate/agents/openai.yaml; edit MoonSpec repo instead.
+# Generated from moonspec/bundle/skills/moonspec-orchestrate/agents/openai.yaml; edit MoonSpec repo instead.
 interface:
   display_name: "MoonSpec Orchestrate"
   short_description: "Run the MoonSpec lifecycle end to end"

--- a/.agents/skills/moonspec-plan/SKILL.md
+++ b/.agents/skills/moonspec-plan/SKILL.md
@@ -5,7 +5,7 @@ metadata:
   required-capabilities:
     - git
 ---
-<!-- Generated from vendor/moonspec/bundle/skills/moonspec-plan/SKILL.md; edit MoonSpec repo instead. -->
+<!-- Generated from moonspec/bundle/skills/moonspec-plan/SKILL.md; edit MoonSpec repo instead. -->
 
 
 # MoonSpec Plan

--- a/.agents/skills/moonspec-plan/agents/openai.yaml
+++ b/.agents/skills/moonspec-plan/agents/openai.yaml
@@ -1,4 +1,4 @@
-# Generated from vendor/moonspec/bundle/skills/moonspec-plan/agents/openai.yaml; edit MoonSpec repo instead.
+# Generated from moonspec/bundle/skills/moonspec-plan/agents/openai.yaml; edit MoonSpec repo instead.
 interface:
   display_name: "MoonSpec Plan"
   short_description: "Create implementation plans and design artifacts."

--- a/.agents/skills/moonspec-specify/SKILL.md
+++ b/.agents/skills/moonspec-specify/SKILL.md
@@ -5,7 +5,7 @@ metadata:
   required-capabilities:
     - git
 ---
-<!-- Generated from vendor/moonspec/bundle/skills/moonspec-specify/SKILL.md; edit MoonSpec repo instead. -->
+<!-- Generated from moonspec/bundle/skills/moonspec-specify/SKILL.md; edit MoonSpec repo instead. -->
 
 
 # MoonSpec Specify

--- a/.agents/skills/moonspec-specify/agents/openai.yaml
+++ b/.agents/skills/moonspec-specify/agents/openai.yaml
@@ -1,4 +1,4 @@
-# Generated from vendor/moonspec/bundle/skills/moonspec-specify/agents/openai.yaml; edit MoonSpec repo instead.
+# Generated from moonspec/bundle/skills/moonspec-specify/agents/openai.yaml; edit MoonSpec repo instead.
 interface:
   display_name: "MoonSpec Specify"
   short_description: "Create MoonSpec specs from requests or designs."

--- a/.agents/skills/moonspec-tasks/SKILL.md
+++ b/.agents/skills/moonspec-tasks/SKILL.md
@@ -5,7 +5,7 @@ metadata:
   required-capabilities:
     - git
 ---
-<!-- Generated from vendor/moonspec/bundle/skills/moonspec-tasks/SKILL.md; edit MoonSpec repo instead. -->
+<!-- Generated from moonspec/bundle/skills/moonspec-tasks/SKILL.md; edit MoonSpec repo instead. -->
 
 
 # MoonSpec Tasks

--- a/.agents/skills/moonspec-tasks/agents/openai.yaml
+++ b/.agents/skills/moonspec-tasks/agents/openai.yaml
@@ -1,4 +1,4 @@
-# Generated from vendor/moonspec/bundle/skills/moonspec-tasks/agents/openai.yaml; edit MoonSpec repo instead.
+# Generated from moonspec/bundle/skills/moonspec-tasks/agents/openai.yaml; edit MoonSpec repo instead.
 interface:
   display_name: "MoonSpec Tasks"
   short_description: "Generate a one-story TDD task breakdown"

--- a/.agents/skills/moonspec-verify/SKILL.md
+++ b/.agents/skills/moonspec-verify/SKILL.md
@@ -5,7 +5,7 @@ metadata:
   required-capabilities:
     - git
 ---
-<!-- Generated from vendor/moonspec/bundle/skills/moonspec-verify/SKILL.md; edit MoonSpec repo instead. -->
+<!-- Generated from moonspec/bundle/skills/moonspec-verify/SKILL.md; edit MoonSpec repo instead. -->
 
 
 # MoonSpec Verify

--- a/.agents/skills/moonspec-verify/agents/openai.yaml
+++ b/.agents/skills/moonspec-verify/agents/openai.yaml
@@ -1,4 +1,4 @@
-# Generated from vendor/moonspec/bundle/skills/moonspec-verify/agents/openai.yaml; edit MoonSpec repo instead.
+# Generated from moonspec/bundle/skills/moonspec-verify/agents/openai.yaml; edit MoonSpec repo instead.
 interface:
   display_name: "MoonSpec Verify"
   short_description: "Verify final MoonSpec implementation evidence"

--- a/.gemini/commands/moonspec.align.toml
+++ b/.gemini/commands/moonspec.align.toml
@@ -1,4 +1,4 @@
-# Generated from vendor/moonspec/bundle/commands/gemini/moonspec.align.toml; edit MoonSpec repo instead.
+# Generated from moonspec/bundle/commands/gemini/moonspec.align.toml; edit MoonSpec repo instead.
 description = "Analyze and remediate MoonSpec artifact drift."
 
 prompt = """

--- a/.gemini/commands/moonspec.breakdown.toml
+++ b/.gemini/commands/moonspec.breakdown.toml
@@ -1,4 +1,4 @@
-# Generated from vendor/moonspec/bundle/commands/gemini/moonspec.breakdown.toml; edit MoonSpec repo instead.
+# Generated from moonspec/bundle/commands/gemini/moonspec.breakdown.toml; edit MoonSpec repo instead.
 description = "Split a broad design into coverage-checked one-story MoonSpec candidates."
 
 prompt = """

--- a/.gemini/commands/moonspec.doc-reconcile.toml
+++ b/.gemini/commands/moonspec.doc-reconcile.toml
@@ -1,4 +1,4 @@
-# Generated from vendor/moonspec/bundle/commands/gemini/moonspec.doc-reconcile.toml; edit MoonSpec repo instead.
+# Generated from moonspec/bundle/commands/gemini/moonspec.doc-reconcile.toml; edit MoonSpec repo instead.
 description = "Reconcile canonical docs after verified MoonSpec implementation."
 
 prompt = """

--- a/.gemini/commands/moonspec.implement.toml
+++ b/.gemini/commands/moonspec.implement.toml
@@ -1,4 +1,4 @@
-# Generated from vendor/moonspec/bundle/commands/gemini/moonspec.implement.toml; edit MoonSpec repo instead.
+# Generated from moonspec/bundle/commands/gemini/moonspec.implement.toml; edit MoonSpec repo instead.
 description = "Implement a one-story MoonSpec task breakdown with TDD."
 
 prompt = """

--- a/.gemini/commands/moonspec.orchestrate.toml
+++ b/.gemini/commands/moonspec.orchestrate.toml
@@ -1,4 +1,4 @@
-# Generated from vendor/moonspec/bundle/commands/gemini/moonspec.orchestrate.toml; edit MoonSpec repo instead.
+# Generated from moonspec/bundle/commands/gemini/moonspec.orchestrate.toml; edit MoonSpec repo instead.
 description = "Run the MoonSpec lifecycle end to end for one story."
 
 prompt = """

--- a/.gemini/commands/moonspec.plan.toml
+++ b/.gemini/commands/moonspec.plan.toml
@@ -1,4 +1,4 @@
-# Generated from vendor/moonspec/bundle/commands/gemini/moonspec.plan.toml; edit MoonSpec repo instead.
+# Generated from moonspec/bundle/commands/gemini/moonspec.plan.toml; edit MoonSpec repo instead.
 description = "Create MoonSpec implementation planning artifacts."
 
 prompt = """

--- a/.gemini/commands/moonspec.specify.toml
+++ b/.gemini/commands/moonspec.specify.toml
@@ -1,4 +1,4 @@
-# Generated from vendor/moonspec/bundle/commands/gemini/moonspec.specify.toml; edit MoonSpec repo instead.
+# Generated from moonspec/bundle/commands/gemini/moonspec.specify.toml; edit MoonSpec repo instead.
 description = "Create or update a one-story MoonSpec specification."
 
 prompt = """

--- a/.gemini/commands/moonspec.tasks.toml
+++ b/.gemini/commands/moonspec.tasks.toml
@@ -1,4 +1,4 @@
-# Generated from vendor/moonspec/bundle/commands/gemini/moonspec.tasks.toml; edit MoonSpec repo instead.
+# Generated from moonspec/bundle/commands/gemini/moonspec.tasks.toml; edit MoonSpec repo instead.
 description = "Generate a TDD-first MoonSpec task breakdown."
 
 prompt = """

--- a/.gemini/commands/moonspec.verify.toml
+++ b/.gemini/commands/moonspec.verify.toml
@@ -1,4 +1,4 @@
-# Generated from vendor/moonspec/bundle/commands/gemini/moonspec.verify.toml; edit MoonSpec repo instead.
+# Generated from moonspec/bundle/commands/gemini/moonspec.verify.toml; edit MoonSpec repo instead.
 description = "Verify a completed MoonSpec implementation."
 
 prompt = """

--- a/.github/workflows/pytest-unit-tests.yml
+++ b/.github/workflows/pytest-unit-tests.yml
@@ -162,7 +162,7 @@ jobs:
         run: |
           set -euo pipefail
           python -m pip install --upgrade pip PyYAML
-          test -f vendor/moonspec/bundle/moonspec.bundle.yaml
+          test -f moonspec/bundle/moonspec.bundle.yaml
           python3 tools/sync_moonspec_submodule.py --check
 
   api-component:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,8 +1,8 @@
 [submodule "open-webui"]
 	path = open-webui
 	url = https://github.com/open-webui/open-webui.git
-[submodule "vendor/moonspec"]
-	path = vendor/moonspec
+[submodule "moonspec"]
+	path = moonspec
 	url = https://github.com/MoonLadderStudios/MoonSpec.git
 [submodule "omnigent"]
 	path = omnigent

--- a/.specify/scripts/bash/check-prerequisites.sh
+++ b/.specify/scripts/bash/check-prerequisites.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Generated from vendor/moonspec/bundle/scripts/bash/check-prerequisites.sh; edit MoonSpec repo instead.
+# Generated from moonspec/bundle/scripts/bash/check-prerequisites.sh; edit MoonSpec repo instead.
 
 # Consolidated prerequisite checking script
 #

--- a/.specify/scripts/bash/common.sh
+++ b/.specify/scripts/bash/common.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Generated from vendor/moonspec/bundle/scripts/bash/common.sh; edit MoonSpec repo instead.
+# Generated from moonspec/bundle/scripts/bash/common.sh; edit MoonSpec repo instead.
 # Common functions and variables for all scripts
 
 # Get repository root, with fallback for non-git repositories

--- a/.specify/scripts/bash/create-new-feature.sh
+++ b/.specify/scripts/bash/create-new-feature.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Generated from vendor/moonspec/bundle/scripts/bash/create-new-feature.sh; edit MoonSpec repo instead.
+# Generated from moonspec/bundle/scripts/bash/create-new-feature.sh; edit MoonSpec repo instead.
 
 set -e
 

--- a/.specify/scripts/bash/setup-plan.sh
+++ b/.specify/scripts/bash/setup-plan.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Generated from vendor/moonspec/bundle/scripts/bash/setup-plan.sh; edit MoonSpec repo instead.
+# Generated from moonspec/bundle/scripts/bash/setup-plan.sh; edit MoonSpec repo instead.
 
 set -e
 

--- a/.specify/scripts/bash/update-agent-context.sh
+++ b/.specify/scripts/bash/update-agent-context.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Generated from vendor/moonspec/bundle/scripts/bash/update-agent-context.sh; edit MoonSpec repo instead.
+# Generated from moonspec/bundle/scripts/bash/update-agent-context.sh; edit MoonSpec repo instead.
 
 # Update agent context files with information from plan.md
 #

--- a/.specify/scripts/bash/validate-implementation-scope.sh
+++ b/.specify/scripts/bash/validate-implementation-scope.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Generated from vendor/moonspec/bundle/scripts/bash/validate-implementation-scope.sh; edit MoonSpec repo instead.
+# Generated from moonspec/bundle/scripts/bash/validate-implementation-scope.sh; edit MoonSpec repo instead.
 
 set -euo pipefail
 

--- a/.specify/templates/agent-file-template.md
+++ b/.specify/templates/agent-file-template.md
@@ -1,4 +1,4 @@
-<!-- Generated from vendor/moonspec/bundle/templates/agent-file-template.md; edit MoonSpec repo instead. -->
+<!-- Generated from moonspec/bundle/templates/agent-file-template.md; edit MoonSpec repo instead. -->
 
 # [PROJECT NAME] Development Guidelines
 

--- a/.specify/templates/checklist-template.md
+++ b/.specify/templates/checklist-template.md
@@ -1,4 +1,4 @@
-<!-- Generated from vendor/moonspec/bundle/templates/checklist-template.md; edit MoonSpec repo instead. -->
+<!-- Generated from moonspec/bundle/templates/checklist-template.md; edit MoonSpec repo instead. -->
 
 # [CHECKLIST TYPE] Checklist: [FEATURE NAME]
 

--- a/.specify/templates/commands/moonspec.align.md
+++ b/.specify/templates/commands/moonspec.align.md
@@ -3,7 +3,7 @@ description: Analyze and automatically remediate MoonSpec artifact drift across 
 scripts:
   sh: .specify/scripts/bash/check-prerequisites.sh --json --require-tasks --include-tasks
 ---
-<!-- Generated from vendor/moonspec/bundle/commands/markdown/moonspec.align.md; edit MoonSpec repo instead. -->
+<!-- Generated from moonspec/bundle/commands/markdown/moonspec.align.md; edit MoonSpec repo instead. -->
 
 
 ## User Input

--- a/.specify/templates/commands/moonspec.breakdown.md
+++ b/.specify/templates/commands/moonspec.breakdown.md
@@ -5,7 +5,7 @@ handoffs:
     agent: moonspec.plan
     prompt: Create an implementation plan for the highest-priority generated spec.
 ---
-<!-- Generated from vendor/moonspec/bundle/commands/markdown/moonspec.breakdown.md; edit MoonSpec repo instead. -->
+<!-- Generated from moonspec/bundle/commands/markdown/moonspec.breakdown.md; edit MoonSpec repo instead. -->
 
 
 ## User Input

--- a/.specify/templates/commands/moonspec.doc-reconcile.md
+++ b/.specify/templates/commands/moonspec.doc-reconcile.md
@@ -1,7 +1,7 @@
 ---
 description: Reconcile canonical docs after a verified MoonSpec implementation.
 ---
-<!-- Generated from vendor/moonspec/bundle/commands/markdown/moonspec.doc-reconcile.md; edit MoonSpec repo instead. -->
+<!-- Generated from moonspec/bundle/commands/markdown/moonspec.doc-reconcile.md; edit MoonSpec repo instead. -->
 
 
 ## User Input

--- a/.specify/templates/commands/moonspec.implement.md
+++ b/.specify/templates/commands/moonspec.implement.md
@@ -7,7 +7,7 @@ handoffs:
 scripts:
   sh: .specify/scripts/bash/check-prerequisites.sh --json --require-tasks --include-tasks
 ---
-<!-- Generated from vendor/moonspec/bundle/commands/markdown/moonspec.implement.md; edit MoonSpec repo instead. -->
+<!-- Generated from moonspec/bundle/commands/markdown/moonspec.implement.md; edit MoonSpec repo instead. -->
 
 
 ## User Input

--- a/.specify/templates/commands/moonspec.orchestrate.md
+++ b/.specify/templates/commands/moonspec.orchestrate.md
@@ -1,7 +1,7 @@
 ---
 description: Run the full MoonSpec lifecycle for one preselected story.
 ---
-<!-- Generated from vendor/moonspec/bundle/commands/markdown/moonspec.orchestrate.md; edit MoonSpec repo instead. -->
+<!-- Generated from moonspec/bundle/commands/markdown/moonspec.orchestrate.md; edit MoonSpec repo instead. -->
 
 
 ## User Input

--- a/.specify/templates/commands/moonspec.plan.md
+++ b/.specify/templates/commands/moonspec.plan.md
@@ -10,7 +10,7 @@ scripts:
 agent_scripts:
   sh: .specify/scripts/bash/update-agent-context.sh __AGENT__
 ---
-<!-- Generated from vendor/moonspec/bundle/commands/markdown/moonspec.plan.md; edit MoonSpec repo instead. -->
+<!-- Generated from moonspec/bundle/commands/markdown/moonspec.plan.md; edit MoonSpec repo instead. -->
 
 
 ## User Input

--- a/.specify/templates/commands/moonspec.specify.md
+++ b/.specify/templates/commands/moonspec.specify.md
@@ -5,7 +5,7 @@ handoffs:
     agent: moonspec.plan
     prompt: Create a plan for the spec. I am building with...
 ---
-<!-- Generated from vendor/moonspec/bundle/commands/markdown/moonspec.specify.md; edit MoonSpec repo instead. -->
+<!-- Generated from moonspec/bundle/commands/markdown/moonspec.specify.md; edit MoonSpec repo instead. -->
 
 
 ## User Input

--- a/.specify/templates/commands/moonspec.tasks.md
+++ b/.specify/templates/commands/moonspec.tasks.md
@@ -15,7 +15,7 @@ handoffs:
 scripts:
   sh: .specify/scripts/bash/check-prerequisites.sh --json
 ---
-<!-- Generated from vendor/moonspec/bundle/commands/markdown/moonspec.tasks.md; edit MoonSpec repo instead. -->
+<!-- Generated from moonspec/bundle/commands/markdown/moonspec.tasks.md; edit MoonSpec repo instead. -->
 
 
 ## User Input

--- a/.specify/templates/commands/moonspec.verify.md
+++ b/.specify/templates/commands/moonspec.verify.md
@@ -3,7 +3,7 @@ description: Verify the final implementation against the original feature reques
 scripts:
   sh: .specify/scripts/bash/check-prerequisites.sh --json --require-tasks --include-tasks
 ---
-<!-- Generated from vendor/moonspec/bundle/commands/markdown/moonspec.verify.md; edit MoonSpec repo instead. -->
+<!-- Generated from moonspec/bundle/commands/markdown/moonspec.verify.md; edit MoonSpec repo instead. -->
 
 
 ## User Input

--- a/.specify/templates/plan-template.md
+++ b/.specify/templates/plan-template.md
@@ -1,4 +1,4 @@
-<!-- Generated from vendor/moonspec/bundle/templates/plan-template.md; edit MoonSpec repo instead. -->
+<!-- Generated from moonspec/bundle/templates/plan-template.md; edit MoonSpec repo instead. -->
 
 # Implementation Plan: [FEATURE]
 

--- a/.specify/templates/spec-template.md
+++ b/.specify/templates/spec-template.md
@@ -1,4 +1,4 @@
-<!-- Generated from vendor/moonspec/bundle/templates/spec-template.md; edit MoonSpec repo instead. -->
+<!-- Generated from moonspec/bundle/templates/spec-template.md; edit MoonSpec repo instead. -->
 
 # Feature Specification: [FEATURE NAME]
 

--- a/.specify/templates/tasks-template.md
+++ b/.specify/templates/tasks-template.md
@@ -1,7 +1,7 @@
 ---
 description: "Task list template for single-story MoonSpec implementation"
 ---
-<!-- Generated from vendor/moonspec/bundle/templates/tasks-template.md; edit MoonSpec repo instead. -->
+<!-- Generated from moonspec/bundle/templates/tasks-template.md; edit MoonSpec repo instead. -->
 
 
 # Tasks: [FEATURE NAME]

--- a/api_service/data/presets/moonspec-orchestrate.yaml
+++ b/api_service/data/presets/moonspec-orchestrate.yaml
@@ -1,4 +1,4 @@
-# Generated from vendor/moonspec/bundle/presets/moonspec-orchestrate.yaml; edit MoonSpec repo instead.
+# Generated from moonspec/bundle/presets/moonspec-orchestrate.yaml; edit MoonSpec repo instead.
 slug: moonspec-orchestrate
 title: MoonSpec Orchestrate
 description: Run the full MoonSpec lifecycle from a preselected single-story request or active feature context through specification, planning, alignment, implementation, and verification.

--- a/docs/Workflows/MoonSpecBundleIntegration.md
+++ b/docs/Workflows/MoonSpecBundleIntegration.md
@@ -1,6 +1,6 @@
 # MoonSpec Bundle Integration
 
-MoonSpec workflow assets are sourced from the `vendor/moonspec` git submodule.
+MoonSpec workflow assets are sourced from the root-level `moonspec` git submodule.
 MoonMind keeps the current runtime paths stable by projecting the pinned bundle
 revision into the paths the application already reads.
 
@@ -9,14 +9,14 @@ revision into the paths the application already reads.
 Edit MoonSpec workflow behavior in the MoonSpec repository, not in projected
 MoonMind files. The projected paths are generated from:
 
-- `vendor/moonspec/bundle/skills/` to `.agents/skills/`
-- `vendor/moonspec/bundle/templates/` to `.specify/templates/`
-- `vendor/moonspec/bundle/scripts/bash/` to `.specify/scripts/bash/`
-- `vendor/moonspec/bundle/presets/moonspec-orchestrate.yaml` to
+- `moonspec/bundle/skills/` to `.agents/skills/`
+- `moonspec/bundle/templates/` to `.specify/templates/`
+- `moonspec/bundle/scripts/bash/` to `.specify/scripts/bash/`
+- `moonspec/bundle/presets/moonspec-orchestrate.yaml` to
   `api_service/data/presets/moonspec-orchestrate.yaml`
-- `vendor/moonspec/bundle/docs/MoonSpecDocumentModel.md` to
+- `moonspec/bundle/docs/MoonSpecDocumentModel.md` to
   `docs/Workflows/MoonSpecDocumentModel.md`
-- `vendor/moonspec/bundle/commands/gemini/` to `.gemini/commands/`
+- `moonspec/bundle/commands/gemini/` to `.gemini/commands/`
 
 MoonMind owns the submodule pointer, projection script, runtime preset seeding,
 workflow scheduling, database/API/UI behavior, and MoonMind-specific tests.
@@ -29,7 +29,7 @@ After cloning MoonMind, initialize submodules:
 git submodule update --init --recursive
 ```
 
-CI checks out submodules and verifies that `vendor/moonspec/bundle/moonspec.bundle.yaml`
+CI checks out submodules and verifies that `moonspec/bundle/moonspec.bundle.yaml`
 exists.
 
 ## Projection
@@ -53,7 +53,7 @@ submodule revision.
 ## Bumping MoonSpec
 
 1. Update the MoonSpec repository and merge the upstream MoonSpec PR.
-2. In MoonMind, update `vendor/moonspec` to the desired MoonSpec commit.
+2. In MoonMind, update `moonspec` to the desired MoonSpec commit.
 3. Run `python3 tools/sync_moonspec_submodule.py --write`.
 4. Run `python3 tools/sync_moonspec_submodule.py --check`.
 5. Run the targeted MoonMind tests for projection, preset seeding, scheduling,

--- a/docs/Workflows/MoonSpecDocumentModel.md
+++ b/docs/Workflows/MoonSpecDocumentModel.md
@@ -1,4 +1,4 @@
-<!-- Generated from vendor/moonspec/bundle/docs/MoonSpecDocumentModel.md; edit MoonSpec repo instead. -->
+<!-- Generated from moonspec/bundle/docs/MoonSpecDocumentModel.md; edit MoonSpec repo instead. -->
 
 # MoonSpec Document Model
 

--- a/tests/unit/tools/test_sync_moonspec_submodule.py
+++ b/tests/unit/tools/test_sync_moonspec_submodule.py
@@ -48,7 +48,7 @@ def test_markdown_header_preserves_skill_front_matter() -> None:
 
     assert result.startswith("---\nname: moonspec-test\n---\n")
     assert (
-        "Generated from vendor/moonspec/bundle/skills/moonspec-test/SKILL.md"
+        "Generated from moonspec/bundle/skills/moonspec-test/SKILL.md"
         in result
     )
 

--- a/tools/sync_moonspec_submodule.py
+++ b/tools/sync_moonspec_submodule.py
@@ -12,7 +12,7 @@ from typing import Any
 import yaml
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
-DEFAULT_SOURCE = REPO_ROOT / "vendor" / "moonspec"
+DEFAULT_SOURCE = REPO_ROOT / "moonspec"
 LOCAL_UNEXPECTED = (
     ".specify/templates/constitution-template.md",
     ".specify/templates/commands/align.md",
@@ -110,7 +110,7 @@ def _planned_files(
 
 def _header_for(path: Path, source_rel: Path) -> str:
     marker = (
-        f"Generated from vendor/moonspec/bundle/{source_rel.as_posix()}; "
+        f"Generated from moonspec/bundle/{source_rel.as_posix()}; "
         "edit MoonSpec repo instead."
     )
     if path.suffix == ".md":


### PR DESCRIPTION
Move moonspec github submodule out of the vendor directory and into the root directory. Adjust all references to it in the project to make sure it works from its new home properly.