### PR TITLE
MM-1061 Finish unified workflows page

### DIFF
--- a/frontend/src/entrypoints/dashboard-app.tsx
+++ b/frontend/src/entrypoints/dashboard-app.tsx
@@ -43,6 +43,7 @@ const PAGE_IMPORTS = {
   settings: () => import('./settings'),
   skills: () => import('./skills'),
   'workflow-start': () => import('./workflow-start'),
+  'workflows-workspace': () => import('./workflows-workspace'),
   'workflow-detail': () => import('./workflow-detail'),
   'workflows-home': () => import('./workflows-home'),
   'workflow-list': () => import('./workflow-list'),
@@ -454,7 +455,9 @@ function RoutedDashboardPage({
 
   const routedPayload = payloadForDashboardRoute(payload, route, uiInfo);
   const layout = readSharedLayout(routedPayload);
-  const routeKey = `${route.page}:${route.currentPath}${location.search}${location.hash}`;
+  const routeKey = route.page === 'workflows-workspace'
+    ? 'workflows-workspace'
+    : `${route.page}:${route.currentPath}${location.search}${location.hash}`;
 
   return (
     <AppShell dataWidePanel={layout.dataWidePanel === true} uiInfo={uiInfo}>

--- a/frontend/src/entrypoints/dashboard.test.tsx
+++ b/frontend/src/entrypoints/dashboard.test.tsx
@@ -122,6 +122,25 @@ vi.mock('./workflow-list', () => ({
   default: () => <div>Workflow list route loaded</div>,
 }));
 
+vi.mock('./workflows-workspace', () => ({
+  default: () => {
+    const isDetailRoute =
+      window.location.pathname.startsWith('/workflows/') && window.location.pathname !== '/workflows/new';
+    return (
+      <div data-testid="workflows-workspace-route">
+        <a href="/workflows/mm%3A97d44980-355c-4300-96a7-0ad166440d95?source=temporal">
+          Mock workflow title
+        </a>
+        {isDetailRoute ? (
+          <div>Workflow detail route loaded: {window.location.pathname}</div>
+        ) : (
+          <div>Workflow list route loaded</div>
+        )}
+      </div>
+    );
+  },
+}));
+
 const workflowDetailMock = vi.hoisted(() => ({
   initialPathByNode: new WeakMap<HTMLElement, string>(),
 }));
@@ -299,9 +318,10 @@ describe('Dashboard shared entry', () => {
     renderWithClient(<DashboardApp payload={{ page: 'dashboard', apiBase: '/api' }} />);
 
     expect(
-      await screen.findByText(`Workflow detail initial path: ${encodedPath}`),
+      await screen.findByText(`Workflow detail route loaded: ${encodedPath}`),
     ).toBeTruthy();
     expect(screen.queryByText(/Unknown dashboard page:/i)).toBeNull();
+    expect(document.querySelector('.panel--data-wide')).toBeTruthy();
   });
 
   it('recovers from a failed lazy page import when the user retries (MM-960)', async () => {
@@ -388,6 +408,25 @@ describe('Dashboard shared entry', () => {
     expect(window.location.search).toBe('?source=temporal');
   });
 
+  it('MM-1061 keeps the workflows workspace parent mounted across list-to-detail SPA navigation', async () => {
+    window.history.replaceState({}, '', '/workflows?source=temporal');
+    renderWithClient(<DashboardApp payload={{ page: 'dashboard', apiBase: '/api' }} />);
+
+    expect(await screen.findByText('Workflow list route loaded')).toBeTruthy();
+    const workspace = screen.getByTestId('workflows-workspace-route');
+
+    fireEvent.click(screen.getByRole('link', { name: 'Mock workflow title' }));
+
+    expect(
+      await screen.findByText(
+        'Workflow detail route loaded: /workflows/mm%3A97d44980-355c-4300-96a7-0ad166440d95',
+      ),
+    ).toBeTruthy();
+    expect(screen.getByTestId('workflows-workspace-route')).toBe(workspace);
+    expect(window.location.pathname).toBe('/workflows/mm%3A97d44980-355c-4300-96a7-0ad166440d95');
+    expect(window.location.search).toBe('?source=temporal');
+  });
+
   it('MM-1029 loads Settings permissions during SPA navigation', async () => {
     fetchSpy.mockImplementation((input: RequestInfo | URL) => {
       const url = String(input);
@@ -422,17 +461,17 @@ describe('Dashboard shared entry', () => {
     );
   });
 
-  it('MM-1029 remounts same-component route pages on SPA navigation', async () => {
+  it('MM-1061 updates workflow detail routes inside the shared workspace component', async () => {
     window.history.replaceState({}, '', '/workflows/first/debug');
 
     renderWithClient(<DashboardApp payload={{ page: 'dashboard', apiBase: '/api' }} />);
 
-    expect(await screen.findByText('Workflow detail initial path: /workflows/first/debug')).toBeTruthy();
+    expect(await screen.findByText('Workflow detail route loaded: /workflows/first/debug')).toBeTruthy();
 
     navigateTo('/workflows/second');
 
-    expect(await screen.findByText('Workflow detail initial path: /workflows/second')).toBeTruthy();
-    expect(screen.queryByText('Workflow detail initial path: /workflows/first/debug')).toBeNull();
+    expect(await screen.findByText('Workflow detail route loaded: /workflows/second')).toBeTruthy();
+    expect(screen.queryByText('Workflow detail route loaded: /workflows/first/debug')).toBeNull();
   });
 
   it('does not render operational metrics on the workflows home dashboard', async () => {

--- a/frontend/src/entrypoints/workflow-detail.test.tsx
+++ b/frontend/src/entrypoints/workflow-detail.test.tsx
@@ -1198,6 +1198,24 @@ describe('Workflow Detail Entrypoint', () => {
     expect(lastFetchUrl(fetchSpy, '/api/executions?')).toBeUndefined();
   });
 
+  it('syncs the active detail tab when the workflow URL changes under a stable parent', async () => {
+    window.history.pushState({}, 'Detail Tab Sync Test', '/workflows/test-123/steps?source=temporal');
+    mockWorkflowDetailSubrouteFetch();
+
+    const rendered = renderWithClient(<WorkflowDetailPage payload={stepsPayload} />);
+
+    expect(await screen.findByRole('heading', { name: 'Workflow Steps' })).toBeTruthy();
+    expect(screen.getByRole('link', { name: 'Steps' }).getAttribute('aria-current')).toBe('page');
+
+    window.history.pushState({}, 'Detail Tab Sync Test', '/workflows/test-123?source=temporal');
+    rendered.rerender(<WorkflowDetailPage payload={stepsPayload} />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('link', { name: 'Overview' }).getAttribute('aria-current')).toBe('page');
+    });
+    expect(screen.getByRole('link', { name: 'Steps' }).getAttribute('aria-current')).not.toBe('page');
+  });
+
   it('MM-801 renders Overview as a concise summary with stable segmented tabs', async () => {
     window.history.pushState({}, 'Overview Test', '/workflows/test-123?source=temporal');
     mockWorkflowDetailSubrouteFetch();

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -240,8 +240,14 @@ function workflowDetailSubrouteHref(
   return `/workflows/${encodeURIComponent(workflowId)}${suffix}${query ? `?${query}` : ''}`;
 }
 
-function useWorkflowDetailSubroute(): [WorkflowDetailSubroute, (next: WorkflowDetailSubroute, href: string) => void] {
-  const [subroute, setSubroute] = useState(() => workflowDetailSubrouteFromPath(window.location.pathname));
+function useWorkflowDetailSubroute(
+  pathname: string,
+): [WorkflowDetailSubroute, (next: WorkflowDetailSubroute, href: string) => void] {
+  const [subroute, setSubroute] = useState(() => workflowDetailSubrouteFromPath(pathname));
+
+  useEffect(() => {
+    setSubroute(workflowDetailSubrouteFromPath(pathname));
+  }, [pathname]);
 
   useEffect(() => {
     const onPopState = () => {
@@ -6149,18 +6155,20 @@ export function WorkflowDetailPage({ payload }: { payload: BootPayload }) {
   const structuredHistoryEnabled = shouldUseStructuredHistory(cfg);
   const isDesktop = useWorkflowWorkspaceDesktop();
 
-  const workflowIdMatch = window.location.pathname.match(
+  const currentPathname = window.location.pathname;
+  const currentSearch = window.location.search;
+  const workflowIdMatch = currentPathname.match(
     /^\/workflows\/([^/]+)(?:\/(?:steps|artifacts|runs|debug))?$/,
   );
   const taskId = decodeTaskPathSegment(workflowIdMatch ? workflowIdMatch[1] : null);
   const encodedTaskId = taskId ? encodeURIComponent(taskId) : null;
-  const search = useMemo(() => new URLSearchParams(window.location.search), []);
+  const search = useMemo(() => new URLSearchParams(currentSearch), [currentSearch]);
   const expandToFullListHref = useMemo(
     () => workflowListHrefFromContext(search, { markDetailReturn: true }),
     [search],
   );
   const showExpandToFullList = isDesktop || expandToFullListHref !== '/workflows';
-  const [detailSubroute, setDetailSubroute] = useWorkflowDetailSubroute();
+  const [detailSubroute, setDetailSubroute] = useWorkflowDetailSubroute(currentPathname);
   const sourceTemporal = search.get('source') === 'temporal';
 
   const [actionError, setActionError] = useState<string | null>(null);

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -433,7 +433,7 @@ function WorkflowSidebar({
   );
 }
 
-function WorkflowWorkspaceShell({
+export function WorkflowWorkspaceShell({
   payload,
   workflowId,
   search,

--- a/frontend/src/entrypoints/workflows-workspace.test.tsx
+++ b/frontend/src/entrypoints/workflows-workspace.test.tsx
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { BrowserRouter } from 'react-router-dom';
+
+import type { BootPayload } from '../boot/parseBootPayload';
+import { renderWithClient, screen } from '../utils/test-utils';
+import { WorkflowsWorkspacePage } from './workflows-workspace';
+
+vi.mock('./workflow-list', () => ({
+  default: () => <div data-testid="workflow-list-page">Workflow list</div>,
+}));
+
+vi.mock('./workflow-detail', () => ({
+  default: () => <div data-testid="workflow-detail-entrypoint">Workflow detail entrypoint</div>,
+  WorkflowWorkspaceShell: () => <div data-testid="workflow-workspace-shell">Workflow workspace shell</div>,
+}));
+
+function mockDesktopViewport(matches: boolean) {
+  Object.defineProperty(window, 'matchMedia', {
+    configurable: true,
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches,
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+}
+
+function renderWorkspace(payload: BootPayload) {
+  return renderWithClient(
+    <BrowserRouter>
+      <WorkflowsWorkspacePage payload={payload} />
+    </BrowserRouter>,
+  );
+}
+
+describe('WorkflowsWorkspacePage', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    mockDesktopViewport(true);
+    window.history.pushState({}, 'Workspace Test', '/workflows/test-123?source=temporal');
+  });
+
+  it.each([
+    { listEnabled: false, workspaceShellEnabled: true },
+    { listEnabled: true, workspaceShellEnabled: false },
+  ])('honors disabled desktop workspace shell flags %#', (temporalDashboard) => {
+    renderWorkspace({
+      page: 'dashboard',
+      apiBase: '/api',
+      initialData: {
+        dashboardConfig: {
+          features: { temporalDashboard },
+        },
+      },
+    });
+
+    expect(screen.getByTestId('workflow-detail-entrypoint')).toBeTruthy();
+    expect(screen.queryByTestId('workflow-workspace-shell')).toBeNull();
+  });
+
+  it('mounts the desktop workspace shell when runtime flags allow it', () => {
+    renderWorkspace({ page: 'dashboard', apiBase: '/api' });
+
+    expect(screen.getByTestId('workflow-workspace-shell')).toBeTruthy();
+    expect(screen.queryByTestId('workflow-detail-entrypoint')).toBeNull();
+  });
+});

--- a/frontend/src/entrypoints/workflows-workspace.tsx
+++ b/frontend/src/entrypoints/workflows-workspace.tsx
@@ -42,11 +42,31 @@ function decodeWorkflowIdFromPath(pathname: string): string | null {
   }
 }
 
+type WorkflowsWorkspaceDashboardConfig = {
+  features?: {
+    temporalDashboard?: {
+      listEnabled?: boolean;
+      workspaceShellEnabled?: boolean;
+    };
+  };
+};
+
+function readWorkflowsWorkspaceDashboardConfig(
+  payload: BootPayload,
+): WorkflowsWorkspaceDashboardConfig | undefined {
+  const raw = payload.initialData as { dashboardConfig?: WorkflowsWorkspaceDashboardConfig } | undefined;
+  return raw?.dashboardConfig;
+}
+
 export function WorkflowsWorkspacePage({ payload }: { payload: BootPayload }) {
   const location = useLocation();
   const workflowId = decodeWorkflowIdFromPath(location.pathname);
   const search = useMemo(() => new URLSearchParams(location.search), [location.search]);
   const isDesktop = useIsDesktop();
+  const cfg = readWorkflowsWorkspaceDashboardConfig(payload);
+  const temporalDashboard = cfg?.features?.temporalDashboard;
+  const workspaceShellEnabled = temporalDashboard?.workspaceShellEnabled !== false;
+  const listEnabled = temporalDashboard?.listEnabled !== false;
 
   if (!workflowId) {
     return (
@@ -56,7 +76,7 @@ export function WorkflowsWorkspacePage({ payload }: { payload: BootPayload }) {
     );
   }
 
-  if (!isDesktop) {
+  if (!isDesktop || !workspaceShellEnabled || !listEnabled) {
     return <WorkflowDetailEntrypoint payload={payload} />;
   }
 

--- a/frontend/src/entrypoints/workflows-workspace.tsx
+++ b/frontend/src/entrypoints/workflows-workspace.tsx
@@ -1,0 +1,74 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useLocation } from 'react-router-dom';
+
+import type { BootPayload } from '../boot/parseBootPayload';
+import WorkflowListPage from './workflow-list';
+import WorkflowDetailEntrypoint, { WorkflowWorkspaceShell } from './workflow-detail';
+
+const DESKTOP_MEDIA_QUERY = '(min-width: 768px)';
+
+function useIsDesktop(): boolean {
+  const [isDesktop, setIsDesktop] = useState(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+      return true;
+    }
+    return window.matchMedia(DESKTOP_MEDIA_QUERY).matches;
+  });
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+      return undefined;
+    }
+    const query = window.matchMedia(DESKTOP_MEDIA_QUERY);
+    const update = () => setIsDesktop(query.matches);
+    update();
+    query.addEventListener?.('change', update);
+    return () => query.removeEventListener?.('change', update);
+  }, []);
+
+  return isDesktop;
+}
+
+function decodeWorkflowIdFromPath(pathname: string): string | null {
+  const match = pathname.match(/^\/workflows\/([^/]+)(?:\/(?:steps|artifacts|runs|debug))?\/?$/);
+  if (!match?.[1]) {
+    return null;
+  }
+  try {
+    const decoded = decodeURIComponent(match[1]);
+    return decoded.includes('/') ? null : decoded;
+  } catch {
+    return null;
+  }
+}
+
+export function WorkflowsWorkspacePage({ payload }: { payload: BootPayload }) {
+  const location = useLocation();
+  const workflowId = decodeWorkflowIdFromPath(location.pathname);
+  const search = useMemo(() => new URLSearchParams(location.search), [location.search]);
+  const isDesktop = useIsDesktop();
+
+  if (!workflowId) {
+    return (
+      <section className="workflows-workspace-page" aria-label="Workflows workspace" data-jira-issue="MM-1061">
+        <WorkflowListPage payload={payload} />
+      </section>
+    );
+  }
+
+  if (!isDesktop) {
+    return <WorkflowDetailEntrypoint payload={payload} />;
+  }
+
+  return (
+    <section
+      className="workflows-workspace-page workflows-workspace-page--selected"
+      aria-label="Workflows workspace"
+      data-jira-issue="MM-1061"
+    >
+      <WorkflowWorkspaceShell payload={payload} workflowId={workflowId} search={search} />
+    </section>
+  );
+}
+
+export default WorkflowsWorkspacePage;

--- a/frontend/src/lib/dashboardRoutes.test.ts
+++ b/frontend/src/lib/dashboardRoutes.test.ts
@@ -7,8 +7,8 @@ describe('dashboard route resolution', () => {
     const path = '/workflows/mm%3A97d44980-355c-4300-96a7-0ad166440d95';
 
     expect(resolveDashboardRoute(path)).toEqual({
-      page: 'workflow-detail',
-      dataWidePanel: false,
+      page: 'workflows-workspace',
+      dataWidePanel: true,
       currentPath: path,
     });
   });
@@ -16,7 +16,7 @@ describe('dashboard route resolution', () => {
   it('resolves encoded workflow IDs with detail tabs', () => {
     const path = '/workflows/mm%3A97d44980-355c-4300-96a7-0ad166440d95/steps';
 
-    expect(resolveDashboardRoute(path)?.page).toBe('workflow-detail');
+    expect(resolveDashboardRoute(path)?.page).toBe('workflows-workspace');
   });
 
   it('resolves reserved-looking workflow IDs as detail pages', () => {
@@ -26,7 +26,7 @@ describe('dashboard route resolution', () => {
       '/workflows/workers',
       '/workflows/settings/steps',
     ]) {
-      expect(resolveDashboardRoute(path)?.page).toBe('workflow-detail');
+      expect(resolveDashboardRoute(path)?.page).toBe('workflows-workspace');
     }
   });
 

--- a/frontend/src/lib/dashboardRoutes.ts
+++ b/frontend/src/lib/dashboardRoutes.ts
@@ -8,6 +8,7 @@ export type DashboardPage =
   | 'settings'
   | 'skills'
   | 'workflow-start'
+  | 'workflows-workspace'
   | 'workflow-detail'
   | 'workflows-home'
   | 'workflow-list';
@@ -102,13 +103,13 @@ export function resolveDashboardRoute(pathname: string): DashboardRoute | null {
     return null;
   }
   if (path === '/workflows') {
-    return { page: 'workflow-list', dataWidePanel: true, currentPath: path };
+    return { page: 'workflows-workspace', dataWidePanel: true, currentPath: path };
   }
   if (path === '/workflows/new') {
     return { page: 'workflow-start', dataWidePanel: false, currentPath: path };
   }
   if (isWorkflowDetailPath(path) && path !== '/workflows/new') {
-    return { page: 'workflow-detail', dataWidePanel: false, currentPath: path };
+    return { page: 'workflows-workspace', dataWidePanel: true, currentPath: path };
   }
   if (path === '/settings' || path.startsWith('/settings/')) {
     return { page: 'settings', dataWidePanel: true, currentPath: path };


### PR DESCRIPTION
Issue reference: MM-1061

Summary:
- Routes /workflows and workflow detail subroutes through a shared workflows workspace entrypoint.
- Keeps the workflows workspace component mounted across desktop list-to-detail SPA navigation while preserving canonical workflow URLs.
- Reuses the existing workflow list page and workflow detail workspace shell, with mobile detail routes continuing to use the standalone detail entrypoint.
- Adds dashboard routing tests for the shared workspace route and list-to-detail navigation behavior.

Tests run:
- MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --dashboard-only --ui-args frontend/src/entrypoints/dashboard.test.tsx frontend/src/lib/dashboardRoutes.test.ts

Remaining risks:
- No manual browser or screenshot pass was run in this publication step.
- Broader frontend suite was not run; verification was targeted to the changed dashboard routing/workspace tests.