### PR TITLE
My now supposedly unified workflows page still needs more work. It should feel more like ChatGPT.com in the sense that the sidebar is very near the le

### DIFF
--- a/frontend/src/entrypoints/dashboard.test.tsx
+++ b/frontend/src/entrypoints/dashboard.test.tsx
@@ -505,6 +505,31 @@ describe('Dashboard shared entry', () => {
     );
   });
 
+  it('lets edge-to-edge data panels beat the 112rem cap via higher specificity', async () => {
+    // The edge-to-edge `max-width: none` rule and the `.panel.panel--data-wide`
+    // 112rem cap would otherwise have equal specificity, letting the later cap
+    // win on source order and re-center wide layouts. Prefixing the `:has()`
+    // rule with `.panel` raises its specificity so the edge-to-edge intent wins.
+    expect(dashboardCss).toMatch(
+      /\.panel\.panel--data-wide:has\(\.workflow-list-data-slab\),\s*\.panel\.panel--data-wide:has\(\.workflow-workspace-shell\)\s*\{[^}]*max-width:\s*none/s,
+    );
+  });
+
+  it('places workflow sidebar dividers on list items so row radius cannot curve them', async () => {
+    // A `border-bottom` on `.workflow-workspace-sidebar-row` curves at the
+    // corners because the row carries `border-radius`. The divider lives on the
+    // `li` container instead, keeping a straight hairline and rounded hover.
+    const listItemBlock = cssRuleBlock(dashboardCss, '.workflow-workspace-sidebar-list li');
+    expect(listItemBlock).toContain('border-bottom: 1px solid rgb(var(--mm-border) / 0.4)');
+
+    const lastItemBlock = cssRuleBlock(dashboardCss, '.workflow-workspace-sidebar-list li:last-child');
+    expect(lastItemBlock).toContain('border-bottom: 0');
+
+    const rowBlock = cssRuleBlock(dashboardCss, '.workflow-workspace-sidebar-row');
+    expect(rowBlock).toContain('border-radius: 0.4rem');
+    expect(rowBlock).not.toContain('border-bottom');
+  });
+
   it('keeps checkbox label hit areas bounded to visible control text', async () => {
     const checkboxLabelBlock = cssRuleBlock(dashboardCss, 'label.checkbox');
 

--- a/frontend/src/entrypoints/workflow-detail.test.tsx
+++ b/frontend/src/entrypoints/workflow-detail.test.tsx
@@ -721,8 +721,6 @@ describe('Workflow Detail Entrypoint', () => {
     expect(pinned.getAttribute('aria-current')).toBe('page');
     expect(pinned.getAttribute('data-pinned')).toBe('true');
     expect(within(pinned).getByLabelText('executing')).toBeTruthy();
-    expect(within(pinned).getByText('scheduled-marker')).toBeTruthy();
-    expect(within(pinned).queryByText('detail-updated-marker')).toBeNull();
     expect(within(sidebar).getByRole('link', { name: /Filtered workflow/i }).getAttribute('aria-current')).toBeNull();
     expect(screen.getByRole('main', { name: 'Workflow detail' })).toBeTruthy();
     expect(await screen.findByRole('heading', { name: 'Workflow Detail' })).toBeTruthy();
@@ -1011,11 +1009,14 @@ describe('Workflow Detail Entrypoint', () => {
     );
 
     const dashboardCss = await readDashboardCss();
-    expect(dashboardCss).toMatch(/\.workflow-workspace-close-sidebar\s*\{[\s\S]*border-style:\s*dashed;/);
-    expect(dashboardCss).toMatch(/\.workflow-workspace-expand-list\s*\{[\s\S]*background:\s*rgb\(var\(--mm-accent\)/);
+    // Both controls are compact icon buttons (fixed square footprint), but only
+    // the expand-to-list control carries the accent emphasis so they stay
+    // visually distinct.
+    expect(dashboardCss).toMatch(/\.workflow-workspace-close-sidebar[\s\S]*?width:\s*2rem;/);
+    expect(dashboardCss).toMatch(/\.workflow-workspace-expand-list\s*\{[\s\S]*?background:\s*rgb\(var\(--mm-accent\)/);
   });
 
-  it('MM-1002 renders sidebar titles, repositories, runtimes, and statuses as React text', async () => {
+  it('MM-1002 renders sidebar titles and statuses as React text', async () => {
     window.history.pushState({}, 'Workspace Sidebar Text Test', '/workflows/test-123?source=temporal');
     mockDesktopViewport(true);
     mockWorkflowWorkspaceFetches({
@@ -1036,10 +1037,10 @@ describe('Workflow Detail Entrypoint', () => {
 
     renderWithClient(<WorkflowDetailEntrypoint payload={stepsPayload} />);
 
+    // The sidebar row is now just the title and a status pill; both untrusted
+    // fields must render as escaped text rather than live DOM nodes.
     const sidebar = await screen.findByRole('complementary', { name: 'Workflow navigation' });
     expect(await within(sidebar).findByText('<img src=x onerror=alert(1)>')).toBeTruthy();
-    expect(within(sidebar).getByText('<b>owner/repo</b>')).toBeTruthy();
-    expect(within(sidebar).getByText('Codex CLI')).toBeTruthy();
     expect(within(sidebar).getAllByText('<script>alert(1)</script>').length).toBeGreaterThan(0);
     expect(within(sidebar).queryByRole('img')).toBeNull();
     expect(sidebar.querySelector('script')).toBeNull();

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -94,10 +94,6 @@ function workflowWorkspaceRowId(row: WorkflowWorkspaceRow): string {
   return row.workflowId || row.taskId || '';
 }
 
-function workflowWorkspaceRowUpdatedAt(row: WorkflowWorkspaceRow): string | null | undefined {
-  return row.closedAt || row.scheduledFor || row.updatedAt || row.createdAt;
-}
-
 function workflowWorkspaceRowFromDetail(detail: ExecutionDetail): WorkflowWorkspaceRow {
   return {
     taskId: detail.taskId,
@@ -113,32 +109,6 @@ function workflowWorkspaceRowFromDetail(detail: ExecutionDetail): WorkflowWorksp
     repository: detail.repository,
     targetRuntime: detail.targetRuntime,
   };
-}
-
-const WORKFLOW_WORKSPACE_RELATIVE_TIME_UNITS: Array<[string, number]> = [
-  ['y', 31536000],
-  ['mo', 2592000],
-  ['w', 604800],
-  ['d', 86400],
-  ['h', 3600],
-  ['m', 60],
-];
-
-function formatWorkflowWorkspaceRelativeTime(iso: string | null | undefined): string {
-  if (!iso) return 'Updated time unavailable';
-  const date = new Date(iso);
-  const ms = date.getTime();
-  if (Number.isNaN(ms)) return iso;
-  const diffSeconds = Math.round((Date.now() - ms) / 1000);
-  const absSeconds = Math.abs(diffSeconds);
-  if (absSeconds < 45) return 'just now';
-  const suffix = diffSeconds >= 0 ? 'ago' : 'from now';
-  for (const [label, unitSeconds] of WORKFLOW_WORKSPACE_RELATIVE_TIME_UNITS) {
-    if (absSeconds >= unitSeconds) {
-      return `${Math.floor(absSeconds / unitSeconds)}${label} ${suffix}`;
-    }
-  }
-  return `${absSeconds}s ${suffix}`;
 }
 
 function useWorkflowWorkspaceDesktop(): boolean {
@@ -291,8 +261,6 @@ function WorkflowSidebarRow({
   const active = workflowId === activeWorkflowId;
   const status = row.rawState || row.state || row.status || 'unknown';
   const title = row.title?.trim() || workflowId || 'Untitled workflow';
-  const repository = row.repository?.trim();
-  const runtime = formatRuntimeLabel(row.targetRuntime);
   return (
     <li>
       <a
@@ -305,20 +273,46 @@ function WorkflowSidebarRow({
         <span className="workflow-workspace-sidebar-row-main">
           {pinned ? <span className="workflow-workspace-sidebar-kicker">Current workflow</span> : null}
           <span className="workflow-workspace-sidebar-title">{title}</span>
-          <span className="workflow-workspace-sidebar-meta">
-            {formatWorkflowWorkspaceRelativeTime(workflowWorkspaceRowUpdatedAt(row))}
-          </span>
-          <span className="workflow-workspace-sidebar-labels" aria-label="Workflow metadata">
-            {repository ? <span>{repository}</span> : null}
-            {runtime !== '—' ? <span>{runtime}</span> : null}
-            <span>{formatStatusLabel(status)}</span>
-          </span>
         </span>
         <ExecutionStatusPill status={status} />
       </a>
     </li>
   );
 }
+
+function WorkspaceControlIcon({ children }: { children: ReactNode }) {
+  return (
+    <svg
+      className="workflow-workspace-control-icon"
+      viewBox="0 0 24 24"
+      aria-hidden="true"
+      focusable="false"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      {children}
+    </svg>
+  );
+}
+
+const SIDEBAR_TOGGLE_ICON = (
+  <WorkspaceControlIcon>
+    <rect x="3" y="4" width="18" height="16" rx="2" />
+    <path d="M9 4v16" />
+  </WorkspaceControlIcon>
+);
+
+const EXPAND_LIST_ICON = (
+  <WorkspaceControlIcon>
+    <path d="M15 3h6v6" />
+    <path d="M9 21H3v-6" />
+    <path d="M21 3l-7 7" />
+    <path d="M3 21l7-7" />
+  </WorkspaceControlIcon>
+);
 
 function WorkflowSidebarControls({
   fullListHref,
@@ -336,15 +330,19 @@ function WorkflowSidebarControls({
         type="button"
         className="secondary workflow-workspace-close-sidebar"
         onClick={onClose}
+        aria-label="Close sidebar"
+        title="Close sidebar"
       >
-        Close sidebar
+        {SIDEBAR_TOGGLE_ICON}
       </button>
       <a
         className="button workflow-workspace-expand-list"
         href={fullListHref}
         onClick={markWorkflowListReturnFocusIntent}
+        aria-label="Expand to full list"
+        title="Expand to full list"
       >
-        Expand to full list
+        {EXPAND_LIST_ICON}
       </a>
     </div>
   );
@@ -528,8 +526,10 @@ export function WorkflowWorkspaceShell({
             setSidebarOpen(true);
             window.setTimeout(() => closeButtonRef.current?.focus(), 0);
           }}
+          aria-label="Open workflow sidebar"
+          title="Open workflow sidebar"
         >
-          Open workflow sidebar
+          {SIDEBAR_TOGGLE_ICON}
         </button>
       )}
       <main className="workflow-workspace-detail" aria-label="Workflow detail">

--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -530,12 +530,21 @@ h1 {
  * needed to constrain and center it. */
 
 .panel:has(.workflow-list-notices-deck),
-.panel:has(.workflow-list-data-slab) {
+.panel:has(.workflow-list-data-slab),
+.panel:has(.workflow-workspace-shell) {
   border: 0;
   background: transparent;
   box-shadow: none;
   padding: 0;
   min-height: 0;
+}
+
+/* Workflows table and unified workspace run edge-to-edge, reaching up to the
+ * full-width border line under the masthead instead of sitting inside a
+ * narrower centered card. */
+.panel--data-wide:has(.workflow-list-data-slab),
+.panel--data-wide:has(.workflow-workspace-shell) {
+  max-width: none;
 }
 
 .panel:has(.settings-page) {
@@ -1865,8 +1874,13 @@ tbody tr:hover {
   gap: 0;
   overflow: visible;
   padding: 0;
-  border-color: rgb(var(--mm-border) / 0.45);
-  background: rgb(var(--mm-panel) / 0.96);
+  /* Not a card: drop the rounded border, fill, and shadow inherited from
+   * `.panel--data` so the table reads as content that runs to the page edges.
+   * Row dividers (td border-bottom) and the header/footer rules keep structure. */
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
 }
 
 .queue-results-toolbar {
@@ -6789,16 +6803,18 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
 
 .workflow-workspace-shell {
   display: grid;
-  grid-template-columns: minmax(17.5rem, 21rem) minmax(0, 1fr);
+  grid-template-columns: minmax(14rem, 17rem) minmax(0, 1fr);
   align-items: start;
-  gap: 1rem;
+  column-gap: 2.25rem;
   width: 100%;
-  max-width: min(118rem, calc(100vw - 2rem));
-  margin-inline: auto;
+  max-width: none;
 }
 
+/* Collapsed: the sidebar becomes a single toggle icon in a narrow left rail so
+ * the centered detail container keeps the same width and only re-centers. */
 .workflow-workspace-shell[data-sidebar-collapsed="true"] {
-  grid-template-columns: minmax(0, 1fr);
+  grid-template-columns: auto minmax(0, 1fr);
+  column-gap: 1rem;
 }
 
 .workflow-workspace-sidebar {
@@ -6806,38 +6822,50 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
   top: 1rem;
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 0.5rem;
   max-height: calc(100vh - 2rem);
   overflow: hidden;
-  border: 1px solid var(--mm-glass-border);
-  border-radius: 0.8rem;
-  background: var(--mm-glass-fill);
-  box-shadow: var(--mm-elevation-panel);
-  border-right-color: rgb(var(--mm-border) / 0.92);
-  padding: 0.75rem;
+  /* Not a card: the sidebar is a plain left column separated from the detail by
+   * the grid gap and a single hairline divider, like ChatGPT. */
+  padding: 0 1.25rem 0 0;
+  border-right: 1px solid rgb(var(--mm-border) / 0.55);
 }
 
 .workflow-workspace-sidebar-controls {
   display: flex;
-  gap: 0.5rem;
+  gap: 0.4rem;
   align-items: center;
   justify-content: space-between;
+  padding-bottom: 0.4rem;
 }
 
-.workflow-workspace-sidebar-controls .button,
-.workflow-workspace-sidebar-controls button {
-  white-space: nowrap;
+/* The sidebar controls are compact icon buttons rather than full-text buttons. */
+.workflow-workspace-close-sidebar,
+.workflow-workspace-expand-list,
+.workflow-workspace-open-sidebar {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  padding: 0;
+  border-radius: 0.5rem;
+  flex: 0 0 auto;
 }
 
-.workflow-workspace-close-sidebar {
-  border-style: dashed;
+.workflow-workspace-control-icon {
+  width: 1.05rem;
+  height: 1.05rem;
+  flex: 0 0 auto;
 }
 
+/* The expand-to-list control keeps the accent emphasis so it stays visually
+ * distinct from the neutral collapse control. */
 .workflow-workspace-expand-list {
   background: rgb(var(--mm-accent) / 0.16);
-  border-color: rgb(var(--mm-accent) / 0.55);
-  color: rgb(var(--mm-ink));
-  font-weight: 800;
+  border-color: rgb(var(--mm-accent) / 0.45);
+  color: rgb(var(--mm-accent));
+  box-shadow: none;
 }
 
 .workflow-workspace-expand-list:hover,
@@ -6849,12 +6877,28 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
 .workflow-workspace-sidebar-list {
   display: flex;
   flex-direction: column;
-  gap: 0.45rem;
-  overflow: auto;
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
   list-style: none;
   padding: 0;
   margin: 0;
-  scrollbar-gutter: stable;
+  /* Slimmer, theme-matched scrollbar instead of the default chunky one. */
+  scrollbar-width: thin;
+  scrollbar-color: rgb(var(--mm-border) / 0.55) transparent;
+}
+
+.workflow-workspace-sidebar-list::-webkit-scrollbar {
+  width: 6px;
+}
+
+.workflow-workspace-sidebar-list::-webkit-scrollbar-thumb {
+  background: rgb(var(--mm-border) / 0.55);
+  border-radius: 999px;
+}
+
+.workflow-workspace-sidebar-list::-webkit-scrollbar-track {
+  background: transparent;
 }
 
 .workflow-workspace-sidebar-pinned-list {
@@ -6865,96 +6909,79 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
 .workflow-workspace-sidebar-row {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
-  align-items: start;
+  align-items: center;
   gap: 0.55rem;
-  min-height: 3.75rem;
-  padding: 0.62rem;
-  border: 1px solid rgb(var(--mm-border) / 0.68);
-  border-radius: 0.55rem;
-  background: rgb(var(--mm-panel) / 0.92);
+  padding: 0.5rem 0.45rem;
+  /* Rows are separated by the same hairline dividers used elsewhere, not by
+   * individual bordered cards. */
+  border: 0;
+  border-bottom: 1px solid rgb(var(--mm-border) / 0.4);
+  border-radius: 0.4rem;
+  background: transparent;
   color: rgb(var(--mm-ink));
   text-decoration: none;
   transition:
     background-color 140ms ease,
-    border-color 140ms ease,
     box-shadow 140ms ease;
 }
 
+.workflow-workspace-sidebar-list li:last-child .workflow-workspace-sidebar-row {
+  border-bottom: 0;
+}
+
 .workflow-workspace-sidebar-row-pinned {
-  border-style: dashed;
-  background: rgb(var(--mm-accent) / 0.08);
+  background: rgb(var(--mm-accent) / 0.06);
 }
 
 .workflow-workspace-sidebar-row:hover,
 .workflow-workspace-sidebar-row:focus-visible {
-  border-color: rgb(var(--mm-accent) / 0.62);
-  background: rgb(var(--mm-accent) / 0.10);
+  background: rgb(var(--mm-ink) / 0.06);
 }
 
 .workflow-workspace-sidebar-row[aria-current="page"] {
-  border-color: rgb(var(--mm-accent) / 0.78);
-  box-shadow: inset 4px 0 0 rgb(var(--mm-accent));
-  background: rgb(var(--mm-accent) / 0.14);
+  box-shadow: inset 3px 0 0 rgb(var(--mm-accent));
+  background: rgb(var(--mm-accent) / 0.12);
 }
 
 .workflow-workspace-sidebar-row-main {
   min-width: 0;
   display: flex;
   flex-direction: column;
-  gap: 0.18rem;
+  gap: 0.12rem;
 }
 
 .workflow-workspace-sidebar-kicker {
   color: rgb(var(--mm-accent));
-  font-size: 0.74rem;
-  font-weight: 800;
+  font-size: 0.7rem;
+  font-weight: 700;
   text-transform: uppercase;
+  letter-spacing: 0.02em;
 }
 
+/* The title keeps a steady list size; it must not balloon in the sidebar. */
 .workflow-workspace-sidebar-title {
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  font-weight: 700;
-}
-
-.workflow-workspace-sidebar-meta {
-  color: rgb(var(--mm-muted));
-  font-size: 0.82rem;
-}
-
-.workflow-workspace-sidebar-labels {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.25rem;
-  color: rgb(var(--mm-muted));
-  font-size: 0.76rem;
-  line-height: 1.25;
-}
-
-.workflow-workspace-sidebar-labels span {
-  max-width: 100%;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.workflow-workspace-sidebar-labels span:not(:last-child)::after {
-  content: "|";
-  margin-left: 0.25rem;
-  color: rgb(var(--mm-muted) / 0.72);
+  font-size: 0.875rem;
+  font-weight: 600;
 }
 
 .workflow-workspace-sidebar-state {
-  border: 1px dashed rgb(var(--mm-border) / 0.75);
-  border-radius: 0.55rem;
-  padding: 0.65rem;
-  background: rgb(var(--mm-panel) / 0.88);
+  padding: 0.5rem 0.45rem;
+  color: rgb(var(--mm-muted));
+  font-size: 0.85rem;
 }
 
+/* The detail is a centered, width-bounded container with a gap from the sidebar.
+ * Because its width is capped, collapsing the sidebar only re-centers it; it
+ * never grows wider. */
 .workflow-workspace-detail {
   min-width: 0;
+  width: 100%;
+  max-width: 72rem;
+  margin-inline: auto;
 }
 
 .workflow-workspace-open-sidebar {

--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -541,9 +541,11 @@ h1 {
 
 /* Workflows table and unified workspace run edge-to-edge, reaching up to the
  * full-width border line under the masthead instead of sitting inside a
- * narrower centered card. */
-.panel--data-wide:has(.workflow-list-data-slab),
-.panel--data-wide:has(.workflow-workspace-shell) {
+ * narrower centered card. The `.panel` prefix raises specificity above the
+ * later `.panel.panel--data-wide` 112rem cap so the edge-to-edge intent wins
+ * regardless of source order. */
+.panel.panel--data-wide:has(.workflow-list-data-slab),
+.panel.panel--data-wide:has(.workflow-workspace-shell) {
   max-width: none;
 }
 
@@ -6906,16 +6908,25 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
   overflow: visible;
 }
 
+/* Rows are separated by the same hairline dividers used elsewhere, not by
+ * individual bordered cards. The divider lives on the `li` container rather
+ * than on the row so the row's `border-radius` cannot curve the hairline at
+ * its corners. */
+.workflow-workspace-sidebar-list li {
+  border-bottom: 1px solid rgb(var(--mm-border) / 0.4);
+}
+
+.workflow-workspace-sidebar-list li:last-child {
+  border-bottom: 0;
+}
+
 .workflow-workspace-sidebar-row {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
   align-items: center;
   gap: 0.55rem;
   padding: 0.5rem 0.45rem;
-  /* Rows are separated by the same hairline dividers used elsewhere, not by
-   * individual bordered cards. */
   border: 0;
-  border-bottom: 1px solid rgb(var(--mm-border) / 0.4);
   border-radius: 0.4rem;
   background: transparent;
   color: rgb(var(--mm-ink));
@@ -6923,10 +6934,6 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
   transition:
     background-color 140ms ease,
     box-shadow 140ms ease;
-}
-
-.workflow-workspace-sidebar-list li:last-child .workflow-workspace-sidebar-row {
-  border-bottom: 0;
 }
 
 .workflow-workspace-sidebar-row-pinned {


### PR DESCRIPTION
My now supposedly unified workflows page still needs more work. It should feel more like ChatGPT.com in the sense that the sidebar is very near the left-edge with only a little bit of margin. Cards are not used for the sidebar or the table any longer. The table should extend to the edges up to the border line underneath the nav bar. There should just be some margin within the table. When you collapse the table to the sidebar, the data should not restructure as much as it does now. The "Codex CLI | completed" should not appear in the sidebar. The "13m ago" should not appear in the sidebar. The status pill is nice to see, so that can stay. It should still feel like the same kind of dividers as before and not be double bordered cards in the sidebar. The title should not grow larger in the sidebar. 

The close sidebar and expand to full list buttons should be icons and not full text. 

The workflow detail should appear in a container in the center of the page, so there should be a bit of a gap between the edge of the sidebard and the start of the workflow detail container. When you minimize the sidebar, the workflow detail should not grow larger.

The slider bar on the sidebar should be slightly thinner and styled to look less out of place compared to the rest of the site.