### PR TITLE
[codex] fix step skill inheritance

### DIFF
--- a/frontend/src/entrypoints/workflow-start.test.tsx
+++ b/frontend/src/entrypoints/workflow-start.test.tsx
@@ -13633,6 +13633,58 @@ describe("Task Create MM-641 authoring validation", () => {
     expect(request.maxAttempts).toBe(3);
   });
 
+  it("does not serialize the primary Skill onto blank added steps", async () => {
+    renderWithClient(<WorkflowStartPage payload={withAttachmentPolicy()} />);
+
+    const primaryStep = (await screen.findByText("Step 1")).closest("section");
+    expect(primaryStep).not.toBeNull();
+    const primary = primaryStep as HTMLElement;
+    fireEvent.change(within(primary).getByLabelText("Instructions"), {
+      target: { value: "Break down docs/Design.md." },
+    });
+    fireEvent.change(within(primary).getByLabelText("Skill (optional)"), {
+      target: { value: "moonspec-orchestrate" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Add Step" }));
+    const secondStep = (await screen.findByText("Step 2")).closest("section");
+    expect(secondStep).not.toBeNull();
+    const second = secondStep as HTMLElement;
+    const secondSkillInput = within(second).getByLabelText(
+      "Skill (optional)",
+    ) as HTMLInputElement;
+    expect(secondSkillInput.placeholder).toBe("optional Skill name");
+    expect(
+      within(second).getByText(
+        "Leave skill blank to run this step without a selected Skill.",
+      ),
+    ).toBeTruthy();
+    fireEvent.change(within(second).getByLabelText("Instructions"), {
+      target: { value: "Create GitHub issues from the breakdown." },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Start Workflow" }));
+
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledWith(
+        "/api/executions",
+        expect.objectContaining({ method: "POST" }),
+      );
+    });
+
+    const request = latestCreateRequest() as {
+      payload?: { task?: { steps?: Array<Record<string, unknown>> } };
+    };
+    const steps = request.payload?.task?.steps || [];
+    expect(steps[0]?.skill).toMatchObject({ id: "moonspec-orchestrate" });
+    expect(steps[1]).toMatchObject({
+      instructions: "Create GitHub issues from the breakdown.",
+    });
+    expect(steps[1]?.skill).toBeUndefined();
+    expect(steps[1]?.tool).toBeUndefined();
+    expect(steps[1]?.type).toBeUndefined();
+  });
+
   it("blocks invalid MM-641 authoring drafts before creating executions", async () => {
     renderWithClient(<WorkflowStartPage payload={withAttachmentPolicy()} />);
 

--- a/frontend/src/entrypoints/workflow-start.tsx
+++ b/frontend/src/entrypoints/workflow-start.tsx
@@ -9739,22 +9739,24 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
           stepPayload.tool = toolPayload;
         }
       } else if (stepSkillId || stepSkillArgsRaw || stepSkillCaps.length > 0) {
+        const effectiveStepSkillId = stepSkillId || "auto";
+        const effectiveStepSkillDetail = stepSkillId ? stepSkillDetail : null;
         stepPayload.tool = {
           type: "skill",
-          name: stepSkillId || primarySkillId,
+          name: effectiveStepSkillId,
           inputs: stepSkillArgs,
-          ...skillInputContractPayload(stepSkillDetail || primarySkillDetail),
+          ...skillInputContractPayload(effectiveStepSkillDetail),
           ...(stepSkillCaps.length > 0
             ? { requiredCapabilities: stepSkillCaps }
             : {}),
         };
         stepPayload.skill = skillPayloadWithInputs({
-          skillId: stepSkillId || primarySkillId,
+          skillId: effectiveStepSkillId,
           inputs: stepSkillArgs,
           savedInputContractDigest: stepSkillInputContractDigest,
           currentInputContractDigest: stepCurrentSkillInputContractDigest,
           requiredCapabilities: stepSkillCaps,
-          detail: stepSkillDetail || primarySkillDetail,
+          detail: effectiveStepSkillDetail,
         });
         stepSkillRequiredCapabilities.push(...stepSkillCaps);
       }
@@ -11550,7 +11552,7 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
                           placeholder={
                             isPrimaryStep
                               ? "auto (default), moonspec-orchestrate, ..."
-                              : "inherit primary step skill"
+                              : "optional Skill name"
                           }
                           onChange={(nextValue) =>
                             updateStep(step.localId, {
@@ -11564,7 +11566,7 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
                         />
                         {isPrimaryStep ? null : (
                           <span className="small">
-                            Leave skill blank to inherit primary step defaults.
+                            Leave skill blank to run this step without a selected Skill.
                           </span>
                         )}
                       </div>

--- a/moonmind/workflows/temporal/worker_runtime.py
+++ b/moonmind/workflows/temporal/worker_runtime.py
@@ -1082,6 +1082,10 @@ def _selected_step_tool_name(step_entry: Mapping[str, Any]) -> str:
     return str(step_tool.get("name") or step_tool.get("id") or "").strip()
 
 
+def _has_explicit_step_skill_name(tool_name: str) -> bool:
+    return tool_name.strip().lower() not in {"", "auto"}
+
+
 def _selected_step_tool_inputs(step_entry: Mapping[str, Any]) -> dict[str, Any]:
     step_tool = _coerce_mapping(step_entry.get("tool")) or _coerce_mapping(
         step_entry.get("skill")
@@ -1251,7 +1255,7 @@ def _task_uses_only_jira_agent_skill(
             for step in raw_steps
         ]
         return bool(effective_step_tool_names) and all(
-            name
+            _has_explicit_step_skill_name(name)
             and (
                 _jira_agent_skill_selected(name)
                 or _story_output_task_tool_selected(name)
@@ -1887,6 +1891,9 @@ def _build_runtime_planner():
 
                 # Per-step tool/skill override
                 step_tool_name = _selected_step_tool_name(step_entry)
+                has_explicit_step_skill = _has_explicit_step_skill_name(
+                    step_tool_name
+                )
                 tool_type = _selected_step_tool_type(step_entry)
                 is_agent_runtime_step = tool_type == "agent_runtime"
                 step_metadata_inputs = _authored_step_metadata_inputs(
@@ -1927,7 +1934,7 @@ def _build_runtime_planner():
                         **step_extra_inputs,
                         "instructions": step_instructions,
                     }
-                    if not step_tool_name:
+                    if not has_explicit_step_skill:
                         _drop_inherited_skill_context(step_node_inputs)
                     step_node_inputs.update(step_metadata_inputs)
                     if base_runtime_payload or step_runtime_payload:
@@ -1981,9 +1988,11 @@ def _build_runtime_planner():
                     step_tool_name.lower() in _STORY_OUTPUT_TASK_TOOLS
                 )
                 effective_step_skill_name = (
-                    step_tool_name if is_agent_runtime_step else ""
+                    step_tool_name
+                    if is_agent_runtime_step and has_explicit_step_skill
+                    else ""
                 )
-                if step_tool_name and is_agent_runtime_step:
+                if is_agent_runtime_step and has_explicit_step_skill:
                     step_node_inputs["selectedSkill"] = step_tool_name
                     if (
                         _jira_agent_skill_selected(step_tool_name)

--- a/moonmind/workflows/temporal/worker_runtime.py
+++ b/moonmind/workflows/temporal/worker_runtime.py
@@ -891,6 +891,15 @@ _AUTHORED_STEP_METADATA_KEYS = (
     "storyOutput",
     "story_output",
 )
+_INHERITED_SKILL_CONTEXT_KEYS = (
+    "selectedSkill",
+    "skill",
+    "inputs",
+    "inputContractDigest",
+    "contentDigest",
+    "contentRef",
+    "skillInputWarnings",
+)
 
 def _normalize_required_capability_tokens(value: Any) -> list[str]:
     if not isinstance(value, list):
@@ -1167,6 +1176,11 @@ def _authored_step_metadata_inputs(
     return metadata
 
 
+def _drop_inherited_skill_context(inputs: dict[str, Any]) -> None:
+    for key in _INHERITED_SKILL_CONTEXT_KEYS:
+        inputs.pop(key, None)
+
+
 def _direct_story_tool_context_inputs(
     node_inputs: Mapping[str, Any],
 ) -> dict[str, Any]:
@@ -1233,12 +1247,15 @@ def _task_uses_only_jira_agent_skill(
         if not all(isinstance(step, Mapping) for step in raw_steps):
             return False
         effective_step_tool_names = [
-            (_selected_step_tool_name(step) or selected_skill_name).lower()
+            _selected_step_tool_name(step).lower()
             for step in raw_steps
         ]
         return bool(effective_step_tool_names) and all(
-            _jira_agent_skill_selected(name)
-            or _story_output_task_tool_selected(name)
+            name
+            and (
+                _jira_agent_skill_selected(name)
+                or _story_output_task_tool_selected(name)
+            )
             for name in effective_step_tool_names
         )
     return _jira_agent_skill_selected(
@@ -1910,6 +1927,8 @@ def _build_runtime_planner():
                         **step_extra_inputs,
                         "instructions": step_instructions,
                     }
+                    if not step_tool_name:
+                        _drop_inherited_skill_context(step_node_inputs)
                     step_node_inputs.update(step_metadata_inputs)
                     if base_runtime_payload or step_runtime_payload:
                         step_node_inputs["runtime"] = {
@@ -1962,9 +1981,7 @@ def _build_runtime_planner():
                     step_tool_name.lower() in _STORY_OUTPUT_TASK_TOOLS
                 )
                 effective_step_skill_name = (
-                    step_tool_name or selected_skill_name
-                    if is_agent_runtime_step
-                    else ""
+                    step_tool_name if is_agent_runtime_step else ""
                 )
                 if step_tool_name and is_agent_runtime_step:
                     step_node_inputs["selectedSkill"] = step_tool_name

--- a/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
+++ b/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
@@ -2594,7 +2594,14 @@ def test_runtime_planner_does_not_inherit_top_level_skill_for_blank_multi_step_e
                 "publish": {"mode": "pr"},
                 "steps": [
                     {"id": "one", "instructions": "Create the first Jira story."},
-                    {"id": "two", "instructions": "Create the second Jira story."},
+                    {
+                        "id": "two",
+                        "instructions": "Run a generic follow-up.",
+                        "skill": {
+                            "id": "auto",
+                            "inputs": {"scope": "generic"},
+                        },
+                    },
                 ],
             }
         },
@@ -2603,16 +2610,26 @@ def test_runtime_planner_does_not_inherit_top_level_skill_for_blank_multi_step_e
     )
 
     assert len(plan["nodes"]) == 2
-    for node in plan["nodes"]:
+    blank_step = plan["nodes"][0]
+    auto_step = plan["nodes"][1]
+    for node in (blank_step, auto_step):
         assert node["tool"]["type"] == "agent_runtime"
         assert "selectedSkill" not in node["inputs"]
-        assert "skill" not in node["inputs"]
-        assert "inputs" not in node["inputs"]
         assert node["inputs"]["publishMode"] == "pr"
         assert "targetBranch" in node["inputs"]
+        assert "inputContractDigest" not in node["inputs"]
+        assert "contentDigest" not in node["inputs"]
+        assert "contentRef" not in node["inputs"]
         assert not node["inputs"]["instructions"].startswith(
             "Use $jira-issue-creator."
         )
+    assert "skill" not in blank_step["inputs"]
+    assert "inputs" not in blank_step["inputs"]
+    assert auto_step["inputs"]["skill"] == {
+        "id": "auto",
+        "inputs": {"scope": "generic"},
+    }
+    assert auto_step["inputs"]["inputs"] == {"scope": "generic"}
 
 def test_runtime_planner_single_step_tool_does_not_override_top_level_publish_scope():
     planner = _build_runtime_planner()

--- a/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
+++ b/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
@@ -2568,7 +2568,7 @@ def test_runtime_planner_does_not_require_pr_branch_for_jira_pr_verify():
     assert "targetBranch" not in node["inputs"]
     assert "commit your work" not in node["inputs"]["instructions"]
 
-def test_runtime_planner_inherits_top_level_jira_skill_for_multi_step_publish():
+def test_runtime_planner_does_not_inherit_top_level_skill_for_blank_multi_step_entries():
     planner = _build_runtime_planner()
     snapshot = SimpleNamespace(
         digest="reg:sha256:test",
@@ -2578,7 +2578,18 @@ def test_runtime_planner_inherits_top_level_jira_skill_for_multi_step_publish():
     plan = planner(
         inputs={
             "task": {
-                "tool": {"type": "skill", "name": "jira-issue-creator"},
+                "tool": {
+                    "type": "skill",
+                    "name": "jira-issue-creator",
+                    "inputs": {"repository": "MoonLadderStudios/MoonMind"},
+                },
+                "skill": {
+                    "name": "jira-issue-creator",
+                    "inputs": {"repository": "MoonLadderStudios/MoonMind"},
+                    "inputContractDigest": "sha256:contract",
+                    "contentDigest": "sha256:content",
+                    "contentRef": "artifact:skill",
+                },
                 "runtime": {"mode": "codex_cli"},
                 "publish": {"mode": "pr"},
                 "steps": [
@@ -2594,10 +2605,14 @@ def test_runtime_planner_inherits_top_level_jira_skill_for_multi_step_publish():
     assert len(plan["nodes"]) == 2
     for node in plan["nodes"]:
         assert node["tool"]["type"] == "agent_runtime"
-        assert node["inputs"]["selectedSkill"] == "jira-issue-creator"
-        assert node["inputs"]["publishMode"] == "none"
-        assert "targetBranch" not in node["inputs"]
-        assert node["inputs"]["instructions"].startswith("Use $jira-issue-creator.")
+        assert "selectedSkill" not in node["inputs"]
+        assert "skill" not in node["inputs"]
+        assert "inputs" not in node["inputs"]
+        assert node["inputs"]["publishMode"] == "pr"
+        assert "targetBranch" in node["inputs"]
+        assert not node["inputs"]["instructions"].startswith(
+            "Use $jira-issue-creator."
+        )
 
 def test_runtime_planner_single_step_tool_does_not_override_top_level_publish_scope():
     planner = _build_runtime_planner()


### PR DESCRIPTION
## Summary

- stop added workflow steps from inheriting the primary step skill when their Skill field is blank
- keep per-step skill args/capabilities explicit by using `auto` instead of the primary skill when no step skill is selected
- update runtime planning so blank multi-step entries drop inherited selected-skill context and keep publish handling generic
- update create-page copy to make blank added steps clearly unbound to a selected Skill

## Root Cause

Manual added steps could be authored with a blank Skill field, but the frontend and runtime planner both had fallbacks that reused the primary step skill. That allowed later steps to execute under the first step's instruction bundle even when the user had not selected that skill per step.

## Validation

- `npm run ui:test -- frontend/src/entrypoints/workflow-start.test.tsx -t "does not serialize the primary Skill onto blank added steps"`
- `./tools/test_unit.sh tests/unit/workflows/temporal/test_temporal_worker_runtime.py`
- repo test wrapper frontend suite: 45 files passed, 726 tests passed, 237 skipped
