### PR TITLE
The height of each row in the workflow list should be consistent and allow for 2 lines of title text to wrap, but then get cut off at that point, what

### DIFF
--- a/frontend/src/entrypoints/dashboard.test.tsx
+++ b/frontend/src/entrypoints/dashboard.test.tsx
@@ -530,6 +530,33 @@ describe('Dashboard shared entry', () => {
     expect(rowBlock).not.toContain('border-bottom');
   });
 
+  it('keeps workflow titles clamped to two consistent lines in the list and sidebar', async () => {
+    const tableTitleBlock = cssRuleBlock(dashboardCss, '.workflow-list-row-title');
+    expect(tableTitleBlock).toContain('display: -webkit-box');
+    expect(tableTitleBlock).toContain('min-height: 2.5em');
+    expect(tableTitleBlock).toContain('max-height: 2.5em');
+    expect(tableTitleBlock).toContain('-webkit-line-clamp: 2');
+
+    const sidebarRowBlock = cssRuleBlock(dashboardCss, '.workflow-workspace-sidebar-row');
+    expect(sidebarRowBlock).toContain('min-height: 3.75rem');
+
+    const sidebarTitleBlock = cssRuleBlock(dashboardCss, '.workflow-workspace-sidebar-title');
+    expect(sidebarTitleBlock).toContain('display: -webkit-box');
+    expect(sidebarTitleBlock).toContain('min-height: 2.5em');
+    expect(sidebarTitleBlock).toContain('max-height: 2.5em');
+    expect(sidebarTitleBlock).toContain('-webkit-line-clamp: 2');
+    expect(sidebarTitleBlock).not.toContain('white-space: nowrap');
+  });
+
+  it('keeps the workflow sidebar scrollbar close to its divider', async () => {
+    const sidebarBlock = cssRuleBlock(dashboardCss, '.workflow-workspace-sidebar');
+    expect(sidebarBlock).toContain('padding: 0 0.125rem 0 0');
+
+    const sidebarListBlock = cssRuleBlock(dashboardCss, '.workflow-workspace-sidebar-list');
+    expect(sidebarListBlock).toContain('padding: 0 0.125rem 0 0');
+    expect(sidebarListBlock).toContain('scrollbar-width: thin');
+  });
+
   it('keeps checkbox label hit areas bounded to visible control text', async () => {
     const checkboxLabelBlock = cssRuleBlock(dashboardCss, 'label.checkbox');
 

--- a/frontend/src/entrypoints/dashboard.test.tsx
+++ b/frontend/src/entrypoints/dashboard.test.tsx
@@ -533,8 +533,7 @@ describe('Dashboard shared entry', () => {
   it('keeps workflow titles clamped to two consistent lines in the list and sidebar', async () => {
     const tableTitleBlock = cssRuleBlock(dashboardCss, '.workflow-list-row-title');
     expect(tableTitleBlock).toContain('display: -webkit-box');
-    expect(tableTitleBlock).toContain('min-height: 2.5em');
-    expect(tableTitleBlock).toContain('max-height: 2.5em');
+    expect(tableTitleBlock).toContain('height: 2.5em');
     expect(tableTitleBlock).toContain('-webkit-line-clamp: 2');
 
     const sidebarRowBlock = cssRuleBlock(dashboardCss, '.workflow-workspace-sidebar-row');
@@ -542,8 +541,7 @@ describe('Dashboard shared entry', () => {
 
     const sidebarTitleBlock = cssRuleBlock(dashboardCss, '.workflow-workspace-sidebar-title');
     expect(sidebarTitleBlock).toContain('display: -webkit-box');
-    expect(sidebarTitleBlock).toContain('min-height: 2.5em');
-    expect(sidebarTitleBlock).toContain('max-height: 2.5em');
+    expect(sidebarTitleBlock).toContain('height: 2.5em');
     expect(sidebarTitleBlock).toContain('-webkit-line-clamp: 2');
     expect(sidebarTitleBlock).not.toContain('white-space: nowrap');
   });

--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -2250,8 +2250,7 @@ tbody tr:hover {
 
 .workflow-list-row-title {
   display: -webkit-box;
-  min-height: 2.5em;
-  max-height: 2.5em;
+  height: 2.5em;
   overflow: hidden;
   color: inherit;
   font-weight: 600;
@@ -6966,8 +6965,7 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
 .workflow-workspace-sidebar-title {
   display: -webkit-box;
   min-width: 0;
-  min-height: 2.5em;
-  max-height: 2.5em;
+  height: 2.5em;
   overflow: hidden;
   font-size: 0.875rem;
   font-weight: 600;

--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -2249,11 +2249,17 @@ tbody tr:hover {
 }
 
 .workflow-list-row-title {
-  display: block;
-  font-weight: 600;
+  display: -webkit-box;
+  min-height: 2.5em;
+  max-height: 2.5em;
+  overflow: hidden;
   color: inherit;
-  text-decoration: none;
+  font-weight: 600;
+  line-height: 1.25;
   overflow-wrap: anywhere;
+  text-decoration: none;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
 }
 
 .workflow-list-row-title:hover {
@@ -6819,7 +6825,7 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
   overflow: hidden;
   /* Not a card: the sidebar is a plain left column separated from the detail by
    * the grid gap and a single hairline divider, like ChatGPT. */
-  padding: 0 1.25rem 0 0;
+  padding: 0 0.125rem 0 0;
   border-right: 1px solid rgb(var(--mm-border) / 0.55);
 }
 
@@ -6873,7 +6879,7 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
   min-height: 0;
   overflow-y: auto;
   list-style: none;
-  padding: 0;
+  padding: 0 0.125rem 0 0;
   margin: 0;
   /* Slimmer, theme-matched scrollbar instead of the default chunky one. */
   scrollbar-width: thin;
@@ -6914,6 +6920,7 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
   align-items: center;
+  min-height: 3.75rem;
   gap: 0.55rem;
   padding: 0.5rem 0.45rem;
   border: 0;
@@ -6957,12 +6964,17 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
 
 /* The title keeps a steady list size; it must not balloon in the sidebar. */
 .workflow-workspace-sidebar-title {
+  display: -webkit-box;
   min-width: 0;
+  min-height: 2.5em;
+  max-height: 2.5em;
   overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
   font-size: 0.875rem;
   font-weight: 600;
+  line-height: 1.25;
+  overflow-wrap: anywhere;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
 }
 
 .workflow-workspace-sidebar-state {


### PR DESCRIPTION
The height of each row in the workflow list should be consistent and allow for 2 lines of title text to wrap, but then get cut off at that point, whatever it is based on the resolution of the screen. When we transition to the sidebar, the height of each of these title rows should remain consistent and not change.

Additionally, the sidebar scroll bar should be closer to the vertical line next to it and only have a tiny gap. See the ChatGPT screenshot attached for an example of the approximate spacing the sidebar scroll bar should use.