### PR TITLE
MM-1064 add sidebar status icons

### DIFF
--- a/frontend/src/entrypoints/dashboard.test.tsx
+++ b/frontend/src/entrypoints/dashboard.test.tsx
@@ -557,6 +557,8 @@ describe('Dashboard shared entry', () => {
 
   it('MM-1064 keeps workflow sidebar status icons compact inside status-colored containers', async () => {
     const iconBlock = cssRuleBlock(dashboardCss, '.workflow-workspace-sidebar-status-icon');
+    expect(iconBlock).toContain('display: inline-flex');
+    expect(iconBlock).toContain('align-items: center');
     expect(iconBlock).toContain('width: 1.375rem');
     expect(iconBlock).toContain('height: 1.375rem');
     expect(iconBlock).toContain('min-width: 1.375rem');

--- a/frontend/src/entrypoints/dashboard.test.tsx
+++ b/frontend/src/entrypoints/dashboard.test.tsx
@@ -555,6 +555,19 @@ describe('Dashboard shared entry', () => {
     expect(sidebarListBlock).toContain('scrollbar-width: thin');
   });
 
+  it('MM-1064 keeps workflow sidebar status icons compact inside status-colored containers', async () => {
+    const iconBlock = cssRuleBlock(dashboardCss, '.workflow-workspace-sidebar-status-icon');
+    expect(iconBlock).toContain('width: 1.375rem');
+    expect(iconBlock).toContain('height: 1.375rem');
+    expect(iconBlock).toContain('min-width: 1.375rem');
+    expect(iconBlock).toContain('border-radius: 0.375rem');
+    expect(iconBlock).toContain('justify-content: center');
+
+    const svgBlock = cssRuleBlock(dashboardCss, '.workflow-workspace-sidebar-status-icon svg');
+    expect(svgBlock).toContain('width: 0.8125rem');
+    expect(svgBlock).toContain('height: 0.8125rem');
+  });
+
   it('keeps checkbox label hit areas bounded to visible control text', async () => {
     const checkboxLabelBlock = cssRuleBlock(dashboardCss, 'label.checkbox');
 

--- a/frontend/src/entrypoints/workflow-detail.test.tsx
+++ b/frontend/src/entrypoints/workflow-detail.test.tsx
@@ -772,11 +772,11 @@ describe('Workflow Detail Entrypoint', () => {
       ['External wait workflow', 'Status: awaiting external', 'status-awaiting-external', 'lucide-hand'],
       ['Finalizing workflow', 'Status: finalizing', 'status-finalizing', 'lucide-package-check'],
       ['No commit workflow', 'Status: No commit', 'status-no-commit', 'lucide-check'],
-      ['No changes workflow', 'Status: no changes', 'status-no-commit', 'lucide-check'],
+      ['No changes workflow', 'Status: No commit', 'status-no-commit', 'lucide-check'],
       ['Completed workflow', 'Status: completed', 'status-completed', 'lucide-check'],
       ['Failed workflow', 'Status: failed', 'status-failed', 'lucide-x'],
       ['Canceled workflow', 'Status: canceled', 'status-canceled', 'lucide-ban'],
-      ['Unknown prototype workflow', 'Status: constructor', 'status-running', 'lucide-play'],
+      ['Unknown prototype workflow', 'Status: constructor', 'status-neutral', 'lucide-play'],
     ] as const;
 
     for (const [title, ariaLabel, statusClass, iconClass] of expectedIcons) {

--- a/frontend/src/entrypoints/workflow-detail.test.tsx
+++ b/frontend/src/entrypoints/workflow-detail.test.tsx
@@ -720,10 +720,68 @@ describe('Workflow Detail Entrypoint', () => {
     const pinned = within(pinnedGroup).getByRole('link', { name: /MM-999 selected workflow outside filters/i });
     expect(pinned.getAttribute('aria-current')).toBe('page');
     expect(pinned.getAttribute('data-pinned')).toBe('true');
-    expect(within(pinned).getByLabelText('executing')).toBeTruthy();
+    expect(within(pinned).getByLabelText('Status: executing')).toBeTruthy();
     expect(within(sidebar).getByRole('link', { name: /Filtered workflow/i }).getAttribute('aria-current')).toBeNull();
     expect(screen.getByRole('main', { name: 'Workflow detail' })).toBeTruthy();
     expect(await screen.findByRole('heading', { name: 'Workflow Detail' })).toBeTruthy();
+  });
+
+  it('MM-1064 renders compact sidebar status icons for canonical lifecycle states', async () => {
+    window.history.pushState({}, 'Workspace Sidebar Icons Test', '/workflows/test-123?source=temporal');
+    mockDesktopViewport(true);
+    mockWorkflowWorkspaceFetches({
+      rows: [
+        ['scheduled', 'Scheduled workflow'],
+        ['initializing', 'Initializing workflow'],
+        ['waiting_on_dependencies', 'Dependency wait workflow'],
+        ['planning', 'Planning workflow'],
+        ['awaiting_slot', 'Slot wait workflow'],
+        ['executing', 'Executing workflow'],
+        ['proposals', 'Proposals workflow'],
+        ['awaiting_external', 'External wait workflow'],
+        ['finalizing', 'Finalizing workflow'],
+        ['completed', 'Completed workflow'],
+        ['failed', 'Failed workflow'],
+        ['canceled', 'Canceled workflow'],
+      ].map(([rawState, title]) => ({
+        workflowId: `test-${rawState}`,
+        taskId: `test-${rawState}`,
+        source: 'temporal',
+        title,
+        status: rawState,
+        state: rawState,
+        rawState,
+        createdAt: '2026-04-09T00:00:00Z',
+      })),
+    });
+
+    renderWithClient(<WorkflowDetailEntrypoint payload={stepsPayload} />);
+
+    const sidebar = await screen.findByRole('complementary', { name: 'Workflow navigation' });
+    const expectedIcons = [
+      ['Scheduled workflow', 'Status: scheduled', 'status-scheduled', 'lucide-calendar-clock'],
+      ['Initializing workflow', 'Status: initializing', 'status-initializing', 'lucide-power'],
+      ['Dependency wait workflow', 'Status: AWAITING DEP', 'status-awaiting-dependencies', 'lucide-git-branch'],
+      ['Planning workflow', 'Status: planning', 'status-planning', 'lucide-map'],
+      ['Slot wait workflow', 'Status: AWAITING SLOT', 'status-awaiting-slot', 'lucide-hourglass'],
+      ['Executing workflow', 'Status: executing', 'status-running', 'lucide-play'],
+      ['Proposals workflow', 'Status: proposals', 'status-running', 'lucide-lightbulb'],
+      ['External wait workflow', 'Status: awaiting external', 'status-awaiting-external', 'lucide-hand'],
+      ['Finalizing workflow', 'Status: finalizing', 'status-finalizing', 'lucide-package-check'],
+      ['Completed workflow', 'Status: completed', 'status-completed', 'lucide-check'],
+      ['Failed workflow', 'Status: failed', 'status-failed', 'lucide-x'],
+      ['Canceled workflow', 'Status: canceled', 'status-canceled', 'lucide-ban'],
+    ] as const;
+
+    for (const [title, ariaLabel, statusClass, iconClass] of expectedIcons) {
+      const row = await within(sidebar).findByRole('link', { name: new RegExp(title, 'i') });
+      const iconContainer = within(row).getByLabelText(ariaLabel);
+      expect(iconContainer.classList.contains('workflow-workspace-sidebar-status-icon')).toBe(true);
+      expect(iconContainer.classList.contains(statusClass)).toBe(true);
+      expect(iconContainer.getAttribute('data-effect')).toBeNull();
+      expect(iconContainer.querySelector(`svg.${iconClass}`)).toBeTruthy();
+      expect(within(row).queryByText(ariaLabel.replace('Status: ', ''))).toBeNull();
+    }
   });
 
   it('MM-999 does not show a pinned current row when the selected workflow is in the normal sidebar list', async () => {
@@ -1037,11 +1095,12 @@ describe('Workflow Detail Entrypoint', () => {
 
     renderWithClient(<WorkflowDetailEntrypoint payload={stepsPayload} />);
 
-    // The sidebar row is now just the title and a status pill; both untrusted
-    // fields must render as escaped text rather than live DOM nodes.
+    // The sidebar row is now just the title and a status icon; untrusted fields
+    // must not become live DOM nodes.
     const sidebar = await screen.findByRole('complementary', { name: 'Workflow navigation' });
     expect(await within(sidebar).findByText('<img src=x onerror=alert(1)>')).toBeTruthy();
-    expect(within(sidebar).getAllByText('<script>alert(1)</script>').length).toBeGreaterThan(0);
+    const statusIcon = within(sidebar).getByLabelText('Status: <script>alert(1)</script>');
+    expect(statusIcon.getAttribute('title')).toBe('<script>alert(1)</script>');
     expect(within(sidebar).queryByRole('img')).toBeNull();
     expect(sidebar.querySelector('script')).toBeNull();
   });

--- a/frontend/src/entrypoints/workflow-detail.test.tsx
+++ b/frontend/src/entrypoints/workflow-detail.test.tsx
@@ -740,9 +740,12 @@ describe('Workflow Detail Entrypoint', () => {
         ['proposals', 'Proposals workflow'],
         ['awaiting_external', 'External wait workflow'],
         ['finalizing', 'Finalizing workflow'],
+        ['no_commit', 'No commit workflow'],
+        ['no_changes', 'No changes workflow'],
         ['completed', 'Completed workflow'],
         ['failed', 'Failed workflow'],
         ['canceled', 'Canceled workflow'],
+        ['constructor', 'Unknown prototype workflow'],
       ].map(([rawState, title]) => ({
         workflowId: `test-${rawState}`,
         taskId: `test-${rawState}`,
@@ -768,9 +771,12 @@ describe('Workflow Detail Entrypoint', () => {
       ['Proposals workflow', 'Status: proposals', 'status-running', 'lucide-lightbulb'],
       ['External wait workflow', 'Status: awaiting external', 'status-awaiting-external', 'lucide-hand'],
       ['Finalizing workflow', 'Status: finalizing', 'status-finalizing', 'lucide-package-check'],
+      ['No commit workflow', 'Status: No commit', 'status-no-commit', 'lucide-check'],
+      ['No changes workflow', 'Status: no changes', 'status-no-commit', 'lucide-check'],
       ['Completed workflow', 'Status: completed', 'status-completed', 'lucide-check'],
       ['Failed workflow', 'Status: failed', 'status-failed', 'lucide-x'],
       ['Canceled workflow', 'Status: canceled', 'status-canceled', 'lucide-ban'],
+      ['Unknown prototype workflow', 'Status: constructor', 'status-running', 'lucide-play'],
     ] as const;
 
     for (const [title, ariaLabel, statusClass, iconClass] of expectedIcons) {

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -271,6 +271,8 @@ const WORKFLOW_STATUS_ICONS = {
   proposals: Lightbulb,
   awaiting_external: Hand,
   finalizing: PackageCheck,
+  no_commit: Check,
+  no_changes: Check,
   completed: Check,
   failed: X,
   canceled: Ban,
@@ -284,7 +286,7 @@ function workflowStatusIconKey(status: string | null | undefined): WorkflowStatu
     .trim()
     .replace(/\s+/g, '_');
 
-  if (key in WORKFLOW_STATUS_ICONS) {
+  if (Object.prototype.hasOwnProperty.call(WORKFLOW_STATUS_ICONS, key)) {
     return key as WorkflowStatusIconKey;
   }
   if (key === 'succeeded') return 'completed';

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -1,6 +1,21 @@
 import { useEffect, useMemo, useRef, useState, type CSSProperties, type ReactNode, type RefObject } from 'react';
 import { useMutation, useQuery, useQueryClient, type UseQueryResult } from '@tanstack/react-query';
 import Anser from 'anser';
+import {
+  Ban,
+  CalendarClock,
+  Check,
+  GitBranch,
+  Hand,
+  Hourglass,
+  Lightbulb,
+  Map as MapIcon,
+  PackageCheck,
+  Play,
+  Power,
+  X,
+  type LucideIcon,
+} from 'lucide-react';
 import { Virtuoso } from 'react-virtuoso';
 import { z } from 'zod';
 import { BootPayload } from '../boot/parseBootPayload';
@@ -246,6 +261,56 @@ function workflowWorkspaceListQuery(search: URLSearchParams): string {
   return params.toString();
 }
 
+const WORKFLOW_STATUS_ICONS = {
+  scheduled: CalendarClock,
+  initializing: Power,
+  waiting_on_dependencies: GitBranch,
+  planning: MapIcon,
+  awaiting_slot: Hourglass,
+  executing: Play,
+  proposals: Lightbulb,
+  awaiting_external: Hand,
+  finalizing: PackageCheck,
+  completed: Check,
+  failed: X,
+  canceled: Ban,
+} as const satisfies Record<string, LucideIcon>;
+
+type WorkflowStatusIconKey = keyof typeof WORKFLOW_STATUS_ICONS;
+
+function workflowStatusIconKey(status: string | null | undefined): WorkflowStatusIconKey {
+  const key = String(status || '')
+    .toLowerCase()
+    .trim()
+    .replace(/\s+/g, '_');
+
+  if (key in WORKFLOW_STATUS_ICONS) {
+    return key as WorkflowStatusIconKey;
+  }
+  if (key === 'succeeded') return 'completed';
+  if (key === 'running') return 'executing';
+  if (key === 'awaiting_action') return 'awaiting_external';
+  return 'executing';
+}
+
+function WorkflowSidebarStatusIcon({ status }: { status: string | null | undefined }) {
+  const label = formatStatusLabel(status);
+  const Icon = WORKFLOW_STATUS_ICONS[workflowStatusIconKey(status)];
+  const pillProps = executionStatusPillProps(status, { enableMotion: false });
+
+  return (
+    <span
+      {...pillProps}
+      className={`${pillProps.className} workflow-workspace-sidebar-status-icon`}
+      aria-label={`Status: ${label}`}
+      title={label}
+      data-testid="workflow-workspace-sidebar-status-icon"
+    >
+      <Icon aria-hidden="true" focusable="false" />
+    </span>
+  );
+}
+
 function WorkflowSidebarRow({
   row,
   activeWorkflowId,
@@ -274,7 +339,7 @@ function WorkflowSidebarRow({
           {pinned ? <span className="workflow-workspace-sidebar-kicker">Current workflow</span> : null}
           <span className="workflow-workspace-sidebar-title">{title}</span>
         </span>
-        <ExecutionStatusPill status={status} />
+        <WorkflowSidebarStatusIcon status={status} />
       </a>
     </li>
   );

--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -6946,6 +6946,21 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
   background: rgb(var(--mm-accent) / 0.12);
 }
 
+.workflow-workspace-sidebar-status-icon {
+  width: 1.375rem;
+  height: 1.375rem;
+  min-width: 1.375rem;
+  padding: 0;
+  justify-content: center;
+  border-radius: 0.375rem;
+}
+
+.workflow-workspace-sidebar-status-icon svg {
+  width: 0.8125rem;
+  height: 0.8125rem;
+  stroke-width: 2.4;
+}
+
 .workflow-workspace-sidebar-row-main {
   min-width: 0;
   display: flex;

--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -6947,6 +6947,8 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
 }
 
 .workflow-workspace-sidebar-status-icon {
+  display: inline-flex;
+  align-items: center;
   width: 1.375rem;
   height: 1.375rem;
   min-width: 1.375rem;

--- a/frontend/src/utils/formatters.test.ts
+++ b/frontend/src/utils/formatters.test.ts
@@ -17,6 +17,7 @@ describe('formatStatusLabel', () => {
   it('replaces status underscores with spaces without changing raw filter values', () => {
     expect(formatStatusLabel('awaiting_external')).toBe('awaiting external');
     expect(formatStatusLabel('validating_token')).toBe('validating token');
+    expect(formatStatusLabel('constructor')).toBe('constructor');
     expect(formatStatusLabel(null)).toBe('—');
   });
 });

--- a/frontend/src/utils/formatters.ts
+++ b/frontend/src/utils/formatters.ts
@@ -23,7 +23,10 @@ export function formatStatusLabel(status: string | null | undefined, fallback = 
   const raw = String(status || fallback).trim();
   if (!raw) return fallback;
   const key = raw.toLowerCase().replace(/[\s_]+/g, '_');
-  return STATUS_DISPLAY_NAMES[key] || raw.replace(/_/g, ' ').replace(/\s+/g, ' ');
+  if (Object.prototype.hasOwnProperty.call(STATUS_DISPLAY_NAMES, key)) {
+    return STATUS_DISPLAY_NAMES[key]!;
+  }
+  return raw.replace(/_/g, ' ').replace(/\s+/g, ' ');
 }
 
 const RUNTIME_DISPLAY_NAMES: Record<string, string> = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@xterm/xterm": "^6.0.0",
         "anser": "^2.3.5",
         "html2canvas": "^1.4.1",
+        "lucide-react": "^1.22.0",
         "marked": "^17.0.5",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
@@ -3113,6 +3114,15 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.22.0.tgz",
+      "integrity": "sha512-c9o3l0PiNcgOQDW4F31BEYHudE7kgxVt3o30qMl36ZPwTxXlGB4QnLilhERvVM4uh/pl5MDyY1/gzZSYcHDtBg==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/lz-string": {

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "@xterm/xterm": "^6.0.0",
     "anser": "^2.3.5",
     "html2canvas": "^1.4.1",
+    "lucide-react": "^1.22.0",
     "marked": "^17.0.5",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",


### PR DESCRIPTION
Issue reference: MM-1064 (https://moonladder.atlassian.net/browse/MM-1064)

Summary:
- Replaces workflow workspace sidebar status pills with compact lucide-react status icons.
- Covers all canonical MoonMind lifecycle states while preserving existing status color and border classes on the icon container.
- Adds focused tests for canonical icon rendering and compact CSS sizing.

Tests run:
- `./tools/test_unit.sh --ui-args frontend/src/entrypoints/workflow-detail.test.tsx frontend/src/entrypoints/dashboard.test.tsx` (failed: container missing pytest before UI tests could run)
- `npm run ui:test -- frontend/src/entrypoints/workflow-detail.test.tsx frontend/src/entrypoints/dashboard.test.tsx` (failed: npm script could not resolve vitest in this managed workspace)
- `./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/workflow-detail.test.tsx frontend/src/entrypoints/dashboard.test.tsx` (failed in managed workspace due colon path resolving test modules as `/frontend/...`)
- Temporary clone under `/tmp` with `npm ci --no-fund --no-audit`, then `./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/workflow-detail.test.tsx frontend/src/entrypoints/dashboard.test.tsx` (passed: 219 tests)

Remaining risks:
- Direct Vitest execution from the managed workspace path fails because the job directory contains a colon; verification passed from an equivalent temporary clone without that path issue.
