### PR TITLE
When you click expand to full list from the workflow detail view, I want it to expand the workflows table without there being a feeling that it's adju

### DIFF
--- a/frontend/src/entrypoints/workflow-list.test.tsx
+++ b/frontend/src/entrypoints/workflow-list.test.tsx
@@ -1783,14 +1783,7 @@ describe('Workflows Entrypoint', () => {
       'Workspace return focus',
       '/workflows?stateIn=completed&limit=50&returnFromWorkflowDetail=1',
     );
-    const focusOptions: Array<FocusOptions | undefined> = [];
-    const originalFocus = HTMLElement.prototype.focus;
-    const focusSpy = vi
-      .spyOn(HTMLElement.prototype, 'focus')
-      .mockImplementation(function focusWithOptions(options?: FocusOptions) {
-        focusOptions.push(options);
-        originalFocus.call(this);
-      });
+    const focusSpy = vi.spyOn(HTMLElement.prototype, 'focus');
 
     renderWithClient(<WorkflowListPage payload={mockPayload} />);
 
@@ -1798,7 +1791,7 @@ describe('Workflows Entrypoint', () => {
     const listRegion = screen.getByRole('region', { name: 'Workflow list' });
     await waitFor(() => expect(document.activeElement).toBe(listRegion));
     expect(listRegion.getAttribute('tabindex')).toBe('-1');
-    expect(focusOptions).toContainEqual({ preventScroll: true });
+    expect(focusSpy).toHaveBeenCalledWith({ preventScroll: true });
     focusSpy.mockRestore();
   });
 

--- a/frontend/src/entrypoints/workflow-list.test.tsx
+++ b/frontend/src/entrypoints/workflow-list.test.tsx
@@ -1783,6 +1783,14 @@ describe('Workflows Entrypoint', () => {
       'Workspace return focus',
       '/workflows?stateIn=completed&limit=50&returnFromWorkflowDetail=1',
     );
+    const focusOptions: Array<FocusOptions | undefined> = [];
+    const originalFocus = HTMLElement.prototype.focus;
+    const focusSpy = vi
+      .spyOn(HTMLElement.prototype, 'focus')
+      .mockImplementation(function focusWithOptions(options?: FocusOptions) {
+        focusOptions.push(options);
+        originalFocus.call(this);
+      });
 
     renderWithClient(<WorkflowListPage payload={mockPayload} />);
 
@@ -1790,6 +1798,8 @@ describe('Workflows Entrypoint', () => {
     const listRegion = screen.getByRole('region', { name: 'Workflow list' });
     await waitFor(() => expect(document.activeElement).toBe(listRegion));
     expect(listRegion.getAttribute('tabindex')).toBe('-1');
+    expect(focusOptions).toContainEqual({ preventScroll: true });
+    focusSpy.mockRestore();
   });
 
   it('MM-1008 does not make the workflow list region focusable on normal list visits', async () => {

--- a/frontend/src/entrypoints/workflow-list.tsx
+++ b/frontend/src/entrypoints/workflow-list.tsx
@@ -1241,7 +1241,7 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
     if (!focusListOnWorkspaceReturn || didFocusWorkspaceReturnRef.current) return;
     didFocusWorkspaceReturnRef.current = true;
     const frame = window.requestAnimationFrame(() => {
-      workflowListRegionRef.current?.focus();
+      workflowListRegionRef.current?.focus({ preventScroll: true });
     });
     return () => window.cancelAnimationFrame(frame);
   }, [focusListOnWorkspaceReturn]);


### PR DESCRIPTION
When you click expand to full list from the workflow detail view, I want it to expand the workflows table without there being a feeling that it's adjusting the vertical placement of the sidebar. The title rows should stay in their exact same vertical placement on screen. So, when it jumps to having the workflow column labels as the top of the screen automatically instead of seeing the nav bar, this feels wrong and needs to be fixed.