### PR TITLE
The workflow detail page feels slightly too wide for a container and I don't need the "Back to workflows" link at the top since there are a bunch of o

### DIFF
--- a/frontend/src/entrypoints/workflow-detail.test.tsx
+++ b/frontend/src/entrypoints/workflow-detail.test.tsx
@@ -1082,7 +1082,7 @@ describe('Workflow Detail Entrypoint', () => {
       /@media \(prefers-reduced-motion:\s*reduce\)\s*\{[\s\S]*\.workflow-workspace-shell,[\s\S]*\.workflow-workspace-detail[\s\S]*transition:\s*none !important;[\s\S]*animation:\s*none !important;[\s\S]*transform:\s*none !important;/,
     );
     expect(dashboardCss).toMatch(
-      /\.workflow-workspace-detail\s*\{[\s\S]*max-width:\s*66rem;/,
+      /\.workflow-workspace-detail\s*\{[^}]*max-width:\s*66rem;/,
     );
   });
 

--- a/frontend/src/entrypoints/workflow-detail.test.tsx
+++ b/frontend/src/entrypoints/workflow-detail.test.tsx
@@ -1081,6 +1081,9 @@ describe('Workflow Detail Entrypoint', () => {
     expect(dashboardCss).toMatch(
       /@media \(prefers-reduced-motion:\s*reduce\)\s*\{[\s\S]*\.workflow-workspace-shell,[\s\S]*\.workflow-workspace-detail[\s\S]*transition:\s*none !important;[\s\S]*animation:\s*none !important;[\s\S]*transform:\s*none !important;/,
     );
+    expect(dashboardCss).toMatch(
+      /\.workflow-workspace-detail\s*\{[\s\S]*max-width:\s*66rem;/,
+    );
   });
 
   it('MM-997 keeps workflow detail standalone when the workflow list is disabled', async () => {
@@ -1189,7 +1192,7 @@ describe('Workflow Detail Entrypoint', () => {
     );
 
     expect(await screen.findByRole('heading', { name: 'Workflow Detail' })).toBeTruthy();
-    expect(screen.getByRole('link', { name: 'Back to workflows' }).getAttribute('href')).toBe('/workflows');
+    expect(screen.queryByRole('link', { name: 'Back to workflows' })).toBeNull();
     expect(screen.queryByRole('complementary', { name: 'Workflow navigation' })).toBeNull();
     expect(screen.queryByRole('button', { name: 'Close sidebar' })).toBeNull();
     expect(screen.queryByRole('button', { name: 'Open workflow sidebar' })).toBeNull();

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -6933,14 +6933,6 @@ export function WorkflowDetailPage({ payload }: { payload: BootPayload }) {
     <div className="stack workflow-detail-page">
       <div className="toolbar">
         <div>
-          <a
-            className="breadcrumb-link"
-            href="/workflows"
-            data-jira-issue="MM-1001"
-            data-source-issue="MM-975"
-          >
-            Back to workflows
-          </a>
           <h2 className="page-title">Workflow Detail</h2>
           <div className="toolbar-identity-row">
             <p className="page-meta">Workflow {taskId || '—'}</p>

--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -6987,7 +6987,7 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
 .workflow-workspace-detail {
   min-width: 0;
   width: 100%;
-  max-width: 72rem;
+  max-width: 66rem;
   margin-inline: auto;
 }
 


### PR DESCRIPTION
The workflow detail page feels slightly too wide for a container and I don't need the "Back to workflows" link at the top since there are a bunch of other ways to achieve this result already present on screen.