### PR TITLE
[codex] Add Omnigent external checkpoint policy lane

### DIFF
--- a/docs/tmp/OmnigentCheckpointingCompatibilityPlan.md
+++ b/docs/tmp/OmnigentCheckpointingCompatibilityPlan.md
@@ -44,10 +44,13 @@ This does not make `workspace.apply_policy` restore Omnigent workspaces. Until a
 
 This also does not introduce intra-session Temporal checkpoints. The Omnigent v1 adapter still owns live-session durability and reattach semantics inside the single execute activity.
 
+This change lands the policy mapping at the `resolve_checkpoint_policy` resolution layer only. It does not yet make the lane fire for the documented Omnigent v1 shape (`agentKind=external`, `agentId=omnigent`, with provider fields under `parameters.omnigent`). The Step Execution call sites in `moonmind/workflows/temporal/workflows/run.py` pass `runtime_kind=self._target_runtime`, and `_target_runtime` is sourced only from `targetRuntime` / `runtime.mode` (see `_runtime_visibility_from_parameters`), never from the per-step `agentId`. For a v1 run that selects Omnigent via `agentId` alone, `runtime_kind` is `None`, the Omnigent branch is skipped, and capture falls back to the local `git_patch` / `worktree_archive` defaults. Activating the lane requires threading the external-agent identity into the checkpoint call sites (see follow-up below); the pure-function mapping is intentionally landed first to keep the deterministic workflow change reviewable and replay-safe.
+
 ## Follow-up work
 
-1. Teach `integration.omnigent.execute` to emit an `externalStateRef` checkpoint artifact alongside diagnostics/result artifacts.
-2. Ensure activity retry looks up the idempotency/session mapping, reconnects to the Omnigent stream, fetches a snapshot, and reconciles first-message state before waiting for terminal completion.
-3. Add an adapter-level terminal harvest step that copies changed files, current files, optional diff/patch, stream mirror, snapshots, and diagnostics into MoonMind artifacts.
-4. Split `ephemeral_workspace_ref` into provider-neutral artifact refs versus local sandbox paths, or introduce explicit fields so capture and policy-apply semantics cannot disagree.
-5. Add end-to-end coverage for Omnigent reattach, terminal harvest, patch-unavailable diagnostics, and blocked local workspace-restore attempts.
+1. Thread the per-step external-agent identity into the `resolve_checkpoint_policy` call sites in `moonmind/workflows/temporal/workflows/run.py` so the Omnigent lane actually fires for the documented v1 shape. Today those call sites pass only `self._target_runtime`, which is `None` for `agentId=omnigent` runs that do not also set `targetRuntime` / `runtime.mode`. The step's `agentId` is already recoverable per `logical_step_id` (see `_step_execution_compact_execution_refs` reading the step-ledger `tool.name`); use that signal rather than overloading runtime visibility. Treat this as a deterministic-workflow change: add workflow-boundary coverage and confirm replay/in-flight safety, and land it together with the `externalStateRef` emission in item 2 so the selected `external_state_ref` capture has real evidence to package.
+2. Teach `integration.omnigent.execute` to emit an `externalStateRef` checkpoint artifact alongside diagnostics/result artifacts.
+3. Ensure activity retry looks up the idempotency/session mapping, reconnects to the Omnigent stream, fetches a snapshot, and reconciles first-message state before waiting for terminal completion.
+4. Add an adapter-level terminal harvest step that copies changed files, current files, optional diff/patch, stream mirror, snapshots, and diagnostics into MoonMind artifacts.
+5. Split `ephemeral_workspace_ref` into provider-neutral artifact refs versus local sandbox paths, or introduce explicit fields so capture and policy-apply semantics cannot disagree.
+6. Add end-to-end coverage for Omnigent reattach, terminal harvest, patch-unavailable diagnostics, and blocked local workspace-restore attempts.

--- a/docs/tmp/OmnigentCheckpointingCompatibilityPlan.md
+++ b/docs/tmp/OmnigentCheckpointingCompatibilityPlan.md
@@ -1,0 +1,53 @@
+# Omnigent checkpointing compatibility plan
+
+Status: Draft implementation note  
+Date: 2026-06-30  
+Related: `docs/Omnigent/OmnigentAdapter.md`, `docs/Steps/StepExecutionsAndCheckpointing.md`, `moonmind/workflows/temporal/checkpoint_policy.py`
+
+## Problem
+
+MoonMind's Step Execution checkpoint model currently assumes that most checkpointable workspace state is available to the MoonMind sandbox worker. That is valid for local/sandbox-backed execution, but it does not match the v1 Omnigent adapter design:
+
+1. The Omnigent session and live workspace are provider-owned during `integration.omnigent.execute`.
+2. MoonMind remains the artifact and orchestration authority, but it should harvest Omnigent streams, snapshots, diagnostics, changed files, diffs, and terminal outputs into MoonMind artifacts at the adapter boundary.
+3. Omnigent v1 explicitly does not provide Temporal-checkpointed intra-session progress. Activity retry should reattach to the existing Omnigent session through the idempotency/session mapping instead of recreating the session or trying to restore a local sandbox worktree.
+4. The existing `resolve_checkpoint_policy(..., runtime_kind=...)` parameter was present but not used, so Omnigent-shaped executions inherited local defaults such as `git_patch` or `worktree_archive`.
+
+A second design gap remains outside this small change: `ephemeral_workspace_ref.workspaceRef` is ambiguous. The capture activity writes an artifact ref, while `workspace.apply_policy` treats `workspaceRef` as a sandbox filesystem path. That should be split or normalized before relying on ephemeral workspace refs for cross-boundary recovery.
+
+## Compatibility decision for Omnigent v1
+
+Omnigent should use the existing `external_state_ref` checkpoint kind for non-recovery-restoration Step Execution boundaries.
+
+For Omnigent runtime kinds, `resolve_checkpoint_policy` now selects:
+
+```text
+workspacePolicy = continue_from_previous_execution
+checkpointKind  = external_state_ref
+```
+
+This checkpoint lane means "reattach to or reconcile an external provider session," not "restore a MoonMind sandbox checkout." It is compatible with the Omnigent v1 adapter contract because the durable evidence lives in MoonMind artifacts and Omnigent resource IDs remain diagnostic/session correlation values.
+
+Required evidence should be compact and ref-only:
+
+| Boundary | Required evidence |
+| --- | --- |
+| `before_execution` | `externalStateRef`, `idempotencyKey`, `omnigentSessionId` |
+| `after_execution` | `externalStateRef`, `diagnosticsRef`, `omnigentSessionId` |
+| Other non-recovery Omnigent boundaries | `externalStateRef`, `omnigentSessionId` |
+
+The `externalStateRef` payload should point at MoonMind-owned artifact evidence for the adapter state, not raw Omnigent payloads. At minimum it should identify the endpoint or endpoint ref, Omnigent session id, agent id when known, first-message digest/state, reattach state, stream/snapshot artifact refs, terminal result refs, and any patch/diff capture refs or patch-unavailable diagnostic.
+
+## What this does not do
+
+This does not make `workspace.apply_policy` restore Omnigent workspaces. Until a provider-specific restore or harvest bridge exists, `workspace.apply_policy` should continue to reject incompatible `external_state_ref` policies rather than silently fabricating local state.
+
+This also does not introduce intra-session Temporal checkpoints. The Omnigent v1 adapter still owns live-session durability and reattach semantics inside the single execute activity.
+
+## Follow-up work
+
+1. Teach `integration.omnigent.execute` to emit an `externalStateRef` checkpoint artifact alongside diagnostics/result artifacts.
+2. Ensure activity retry looks up the idempotency/session mapping, reconnects to the Omnigent stream, fetches a snapshot, and reconciles first-message state before waiting for terminal completion.
+3. Add an adapter-level terminal harvest step that copies changed files, current files, optional diff/patch, stream mirror, snapshots, and diagnostics into MoonMind artifacts.
+4. Split `ephemeral_workspace_ref` into provider-neutral artifact refs versus local sandbox paths, or introduce explicit fields so capture and policy-apply semantics cannot disagree.
+5. Add end-to-end coverage for Omnigent reattach, terminal harvest, patch-unavailable diagnostics, and blocked local workspace-restore attempts.

--- a/moonmind/workflows/temporal/checkpoint_policy.py
+++ b/moonmind/workflows/temporal/checkpoint_policy.py
@@ -36,8 +36,7 @@ def _boundary_token(boundary: Any) -> str:
 def _is_omnigent_runtime(runtime_kind: str | None) -> bool:
     """Return True for Omnigent aliases without making the contract alias-heavy."""
 
-    token = str(runtime_kind or "").strip().replace("_", "-").lower()
-    return "omnigent" in token
+    return "omnigent" in str(runtime_kind or "").lower()
 
 
 def _workspace_policy_from_recovery_source(

--- a/moonmind/workflows/temporal/checkpoint_policy.py
+++ b/moonmind/workflows/temporal/checkpoint_policy.py
@@ -1,4 +1,4 @@
-"""Shared checkpoint policy selection for MM-996 failed-step recovery."""
+"""Shared checkpoint policy selection for Step Execution recovery."""
 
 from __future__ import annotations
 
@@ -15,6 +15,29 @@ class ResolvedCheckpointPolicy:
     checkpoint_kind: str
     resumable: bool
     required_evidence: tuple[str, ...]
+
+
+_OMNIGENT_EXTERNAL_STATE_BOUNDARIES = frozenset(
+    {
+        "after_prepare",
+        "before_execution",
+        "after_execution",
+        "after_gate",
+        "before_publication",
+    }
+)
+
+
+def _boundary_token(boundary: Any) -> str:
+    boundary_value = boundary.value if hasattr(boundary, "value") else boundary
+    return str(boundary_value or "").strip()
+
+
+def _is_omnigent_runtime(runtime_kind: str | None) -> bool:
+    """Return True for Omnigent aliases without making the contract alias-heavy."""
+
+    token = str(runtime_kind or "").strip().replace("_", "-").lower()
+    return "omnigent" in token
 
 
 def _workspace_policy_from_recovery_source(
@@ -37,6 +60,27 @@ def _workspace_policy_from_recovery_source(
     return "restore_pre_execution"
 
 
+def _omnigent_required_evidence(boundary_token: str) -> tuple[str, ...]:
+    if boundary_token == "before_execution":
+        return ("externalStateRef", "idempotencyKey", "omnigentSessionId")
+    if boundary_token == "after_execution":
+        return ("externalStateRef", "diagnosticsRef", "omnigentSessionId")
+    return ("externalStateRef", "omnigentSessionId")
+
+
+def _omnigent_checkpoint_policy(
+    boundary_token: str,
+) -> ResolvedCheckpointPolicy | None:
+    if boundary_token not in _OMNIGENT_EXTERNAL_STATE_BOUNDARIES:
+        return None
+    return ResolvedCheckpointPolicy(
+        workspace_policy="continue_from_previous_execution",
+        checkpoint_kind="external_state_ref",
+        resumable=True,
+        required_evidence=_omnigent_required_evidence(boundary_token),
+    )
+
+
 def resolve_checkpoint_policy(
     *,
     boundary: str,
@@ -45,9 +89,12 @@ def resolve_checkpoint_policy(
 ) -> ResolvedCheckpointPolicy:
     """Return the shared policy used for capture, manifests, and recovery apply."""
 
-    del runtime_kind
-    boundary_value = boundary.value if hasattr(boundary, "value") else boundary
-    boundary_token = str(boundary_value or "").strip()
+    boundary_token = _boundary_token(boundary)
+    if _is_omnigent_runtime(runtime_kind):
+        external_policy = _omnigent_checkpoint_policy(boundary_token)
+        if external_policy is not None:
+            return external_policy
+
     if boundary_token == "before_recovery_restoration":
         return ResolvedCheckpointPolicy(
             workspace_policy=_workspace_policy_from_recovery_source(recovery_source),

--- a/tests/unit/workflows/temporal/test_checkpoint_policy.py
+++ b/tests/unit/workflows/temporal/test_checkpoint_policy.py
@@ -2,13 +2,30 @@
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from enum import Enum
 
+from moonmind.schemas.temporal_models import StepExecutionIdentityModel
 from moonmind.workflows.temporal.checkpoint_policy import resolve_checkpoint_policy
+from moonmind.workflows.temporal.step_checkpoints import (
+    build_step_checkpoint_payload,
+    validate_step_checkpoint_payload,
+)
 
 
 class _Boundary(Enum):
     BEFORE_RECOVERY_RESTORATION = "before_recovery_restoration"
+    BEFORE_EXECUTION = "before_execution"
+    AFTER_EXECUTION = "after_execution"
+
+
+def _identity() -> StepExecutionIdentityModel:
+    return StepExecutionIdentityModel(
+        workflowId="workflow-1",
+        runId="run-1",
+        logicalStepId="checkpoint-story",
+        executionOrdinal=1,
+    )
 
 
 def test_resolve_checkpoint_policy_uses_enum_value() -> None:
@@ -23,3 +40,103 @@ def test_resolve_checkpoint_policy_uses_enum_value() -> None:
 
     assert policy.checkpoint_kind == "worktree_archive"
     assert policy.workspace_policy == "start_from_last_passed_commit"
+
+
+def test_resolve_checkpoint_policy_uses_omnigent_external_state_after_execution() -> None:
+    policy = resolve_checkpoint_policy(
+        boundary=_Boundary.AFTER_EXECUTION,
+        runtime_kind="integration.omnigent.execute",
+    )
+
+    assert policy.workspace_policy == "continue_from_previous_execution"
+    assert policy.checkpoint_kind == "external_state_ref"
+    assert policy.resumable is True
+    assert policy.required_evidence == (
+        "externalStateRef",
+        "diagnosticsRef",
+        "omnigentSessionId",
+    )
+
+
+def test_resolve_checkpoint_policy_uses_omnigent_external_state_before_execution() -> None:
+    policy = resolve_checkpoint_policy(
+        boundary=_Boundary.BEFORE_EXECUTION,
+        runtime_kind="external:omnigent",
+    )
+
+    assert policy.workspace_policy == "continue_from_previous_execution"
+    assert policy.checkpoint_kind == "external_state_ref"
+    assert policy.required_evidence == (
+        "externalStateRef",
+        "idempotencyKey",
+        "omnigentSessionId",
+    )
+
+
+def test_resolve_checkpoint_policy_keeps_local_after_execution_default() -> None:
+    policy = resolve_checkpoint_policy(
+        boundary="after_execution",
+        runtime_kind="codex_cli",
+    )
+
+    assert policy.workspace_policy == "restore_pre_execution"
+    assert policy.checkpoint_kind == "git_patch"
+    assert policy.required_evidence == ("patchRef", "manifestRef")
+
+
+def test_omnigent_runtime_does_not_override_recovery_restoration_policy() -> None:
+    policy = resolve_checkpoint_policy(
+        boundary=_Boundary.BEFORE_RECOVERY_RESTORATION,
+        runtime_kind="omnigent",
+        recovery_source={
+            "recoveryWorkspace": {
+                "workspacePolicy": "start_from_last_passed_commit",
+            }
+        },
+    )
+
+    assert policy.checkpoint_kind == "worktree_archive"
+    assert policy.workspace_policy == "start_from_last_passed_commit"
+
+
+def test_external_state_checkpoint_is_continue_only() -> None:
+    identity = _identity()
+    checkpoint = build_step_checkpoint_payload(
+        identity=identity,
+        boundary="after_execution",
+        task_input_snapshot_ref="artifact-input",
+        plan_digest="sha256:plan",
+        workspace={
+            "kind": "external_state_ref",
+            "externalStateRef": "artifact-omnigent-state",
+        },
+        step_outputs={
+            "diagnosticsRef": "artifact-diagnostics",
+            "resultRef": "artifact-result",
+        },
+        created_at=datetime(2026, 6, 30, 12, 0, tzinfo=UTC),
+    )
+
+    valid = validate_step_checkpoint_payload(
+        checkpoint,
+        expected_source=identity,
+        expected_task_input_snapshot_ref="artifact-input",
+        expected_plan_digest="sha256:plan",
+        workspace_policy="continue_from_previous_execution",
+        required_artifact_refs=[
+            "artifact-omnigent-state",
+            "artifact-diagnostics",
+            "artifact-result",
+        ],
+    )
+    rejected = validate_step_checkpoint_payload(
+        checkpoint,
+        expected_source=identity,
+        expected_task_input_snapshot_ref="artifact-input",
+        expected_plan_digest="sha256:plan",
+        workspace_policy="restore_pre_execution",
+    )
+
+    assert valid.valid is True
+    assert rejected.valid is False
+    assert rejected.failure_code == "policy_incompatible"


### PR DESCRIPTION
## Summary

- Uses `runtime_kind` in `resolve_checkpoint_policy` instead of discarding it.
- Routes Omnigent runtime boundaries to an `external_state_ref` checkpoint lane with `continue_from_previous_execution`, matching the v1 adapter model where Omnigent owns live session durability and MoonMind owns artifact evidence.
- Keeps failed-step recovery restoration on the existing local workspace policy path.
- Adds unit coverage for Omnigent policy selection and `external_state_ref` validation behavior.
- Adds `docs/tmp/OmnigentCheckpointingCompatibilityPlan.md` to capture the design decision, remaining gaps, and follow-up work.

## Why

The existing checkpoint policy was local-sandbox oriented and ignored the `runtime_kind` parameter, so Omnigent-shaped executions inherited `git_patch` or `worktree_archive` defaults even though the Omnigent adapter design treats live session state as provider-owned and reattaches through idempotency/session evidence.

## Validation

Not run in this session; changes were made through the GitHub connector without a local checkout. Suggested targeted check:

```bash
pytest tests/unit/workflows/temporal/test_checkpoint_policy.py tests/unit/workflows/temporal/test_step_checkpoints.py -q
```
