### PR TITLE
[codex] fix failed step recovery checkpoints

### DIFF
--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -3236,6 +3236,7 @@ def _recovery_checkpoint_ref_from_record(record) -> str | None:
     memo = dict(getattr(record, "memo", None) or {})
     search_attributes = dict(getattr(record, "search_attributes", None) or {})
     params = dict(getattr(record, "parameters", None) or {})
+    recovery_manifest = _recovery_manifest_summary_from_record(record)
     recovery_block = params.get("recoverySource")
     if not isinstance(recovery_block, Mapping):
         recovery_block = params.get("recovery_source")
@@ -3245,6 +3246,28 @@ def _recovery_checkpoint_ref_from_record(record) -> str | None:
         memo.get("recovery_checkpoint_ref"),
         memo.get("recoveryCheckpointRef"),
         search_attributes.get("mm_recovery_checkpoint_ref"),
+        recovery_manifest.get("checkpointRef"),
+        recovery_manifest.get("checkpoint_ref"),
+        _nested_recovery_manifest_text(
+            recovery_manifest,
+            "validation",
+            "checkpointRef",
+        ),
+        _nested_recovery_manifest_text(
+            recovery_manifest,
+            "validation",
+            "checkpoint_ref",
+        ),
+        _nested_recovery_manifest_text(
+            recovery_manifest,
+            "recoveryEligibility",
+            "checkpointRef",
+        ),
+        _nested_recovery_manifest_text(
+            recovery_manifest,
+            "recoveryEligibility",
+            "checkpoint_ref",
+        ),
         recovery_block.get("recoveryCheckpointRef"),
         recovery_block.get("recovery_checkpoint_ref"),
     ):
@@ -3254,16 +3277,53 @@ def _recovery_checkpoint_ref_from_record(record) -> str | None:
     return None
 
 
+def _recovery_manifest_summary_from_record(record) -> Mapping[str, Any]:
+    finish_summary = getattr(record, "finish_summary_json", None)
+    if not isinstance(finish_summary, Mapping):
+        return {}
+    recovery_manifest = finish_summary.get("recoveryManifest")
+    if not isinstance(recovery_manifest, Mapping):
+        recovery_manifest = finish_summary.get("recovery_manifest")
+    return recovery_manifest if isinstance(recovery_manifest, Mapping) else {}
+
+
+def _nested_recovery_manifest_text(
+    manifest: Mapping[str, Any],
+    block_key: str,
+    key: str,
+) -> str | None:
+    block = manifest.get(block_key)
+    if not isinstance(block, Mapping):
+        return None
+    value = block.get(key)
+    candidate = str(value or "").strip()
+    return candidate or None
+
+
+def _recovery_manifest_summary_allows_resume(record) -> bool:
+    manifest = _recovery_manifest_summary_from_record(record)
+    if not manifest:
+        return False
+    if not _coerce_bool(manifest.get("resumeAllowed"), default=False):
+        return False
+    validation_result = str(
+        manifest.get("validationResult")
+        or manifest.get("validation_result")
+        or _nested_recovery_manifest_text(manifest, "validation", "result")
+        or ""
+    ).strip().lower()
+    if validation_result != "valid":
+        return False
+    checkpoint_ref = _recovery_checkpoint_ref_from_record(record)
+    failed_step_id = _recovery_failed_step_id_from_record(record)
+    return bool(checkpoint_ref and failed_step_id)
+
+
 def _recovery_manifest_ref_from_record(record) -> str | None:
     memo = dict(getattr(record, "memo", None) or {})
     search_attributes = dict(getattr(record, "search_attributes", None) or {})
     params = dict(getattr(record, "parameters", None) or {})
-    finish_summary = dict(getattr(record, "finish_summary_json", None) or {})
-    recovery_manifest = finish_summary.get("recoveryManifest")
-    if not isinstance(recovery_manifest, Mapping):
-        recovery_manifest = finish_summary.get("recovery_manifest")
-    if not isinstance(recovery_manifest, Mapping):
-        recovery_manifest = {}
+    recovery_manifest = _recovery_manifest_summary_from_record(record)
     recovery_block = params.get("recoverySource")
     if not isinstance(recovery_block, Mapping):
         recovery_block = params.get("recovery_source")
@@ -3310,6 +3370,7 @@ def _canonical_recovery_manifest_ref(
 def _recovery_failed_step_id_from_record(record) -> str | None:
     memo = dict(getattr(record, "memo", None) or {})
     params = dict(getattr(record, "parameters", None) or {})
+    recovery_manifest = _recovery_manifest_summary_from_record(record)
     recovery_block = params.get("recoverySource")
     if not isinstance(recovery_block, Mapping):
         recovery_block = params.get("recovery_source")
@@ -3318,6 +3379,8 @@ def _recovery_failed_step_id_from_record(record) -> str | None:
     for value in (
         memo.get("resume_failed_step_id"),
         memo.get("resumeFailedStepId"),
+        recovery_manifest.get("failedLogicalStepId"),
+        recovery_manifest.get("failed_logical_step_id"),
         recovery_block.get("failedStepId"),
         recovery_block.get("failed_step_id"),
     ):
@@ -3418,6 +3481,8 @@ def _recovery_plan_identity_from_record(record) -> str | None:
         memo.get("resumePlanDigest"),
         memo.get("plan_ref"),
         memo.get("plan_digest"),
+        _coerce_artifact_ref(memo.get("plan_artifact_ref")),
+        _coerce_artifact_ref(memo.get("planArtifactRef")),
         search_attributes.get("mm_recovery_plan_ref"),
         search_attributes.get("mm_recovery_plan_digest"),
         recovery_block.get("sourcePlanRef"),
@@ -3452,6 +3517,10 @@ def _recovery_evidence_marked_stale(record) -> bool:
 def _recovery_evidence_disabled_reason(record) -> str | None:
     if _recovery_evidence_marked_stale(record):
         return "stale_recovery_evidence"
+    if _recovery_manifest_summary_allows_resume(record):
+        if not _recovery_plan_identity_from_record(record):
+            return "plan_identity_missing"
+        return None
     if not _recovery_checkpoint_ref_from_record(record):
         return "recovery_checkpoint_missing"
     if not _recovery_failed_step_id_from_record(record):

--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -3300,7 +3300,12 @@ def _nested_recovery_manifest_text(
     return candidate or None
 
 
-def _recovery_manifest_summary_allows_resume(record) -> bool:
+def _recovery_manifest_summary_allows_resume(
+    record,
+    checkpoint_ref: str | None = None,
+    failed_step_id: str | None = None,
+    manifest_ref: str | None = None,
+) -> bool:
     manifest = _recovery_manifest_summary_from_record(record)
     if not manifest:
         return False
@@ -3314,9 +3319,13 @@ def _recovery_manifest_summary_allows_resume(record) -> bool:
     ).strip().lower()
     if validation_result != "valid":
         return False
-    checkpoint_ref = _recovery_checkpoint_ref_from_record(record)
-    failed_step_id = _recovery_failed_step_id_from_record(record)
-    return bool(checkpoint_ref and failed_step_id)
+    if checkpoint_ref is None:
+        checkpoint_ref = _recovery_checkpoint_ref_from_record(record)
+    if failed_step_id is None:
+        failed_step_id = _recovery_failed_step_id_from_record(record)
+    if manifest_ref is None:
+        manifest_ref = _recovery_manifest_ref_from_record(record)
+    return bool(checkpoint_ref and failed_step_id and manifest_ref)
 
 
 def _recovery_manifest_ref_from_record(record) -> str | None:
@@ -3517,13 +3526,19 @@ def _recovery_evidence_marked_stale(record) -> bool:
 def _recovery_evidence_disabled_reason(record) -> str | None:
     if _recovery_evidence_marked_stale(record):
         return "stale_recovery_evidence"
-    if _recovery_manifest_summary_allows_resume(record):
+    checkpoint_ref = _recovery_checkpoint_ref_from_record(record)
+    failed_step_id = _recovery_failed_step_id_from_record(record)
+    if _recovery_manifest_summary_allows_resume(
+        record,
+        checkpoint_ref=checkpoint_ref,
+        failed_step_id=failed_step_id,
+    ):
         if not _recovery_plan_identity_from_record(record):
             return "plan_identity_missing"
         return None
-    if not _recovery_checkpoint_ref_from_record(record):
+    if not checkpoint_ref:
         return "recovery_checkpoint_missing"
-    if not _recovery_failed_step_id_from_record(record):
+    if not failed_step_id:
         return "failed_step_identity_missing"
     if not _recovery_completed_step_refs_from_record(record):
         return "completed_step_refs_missing"

--- a/api_service/core/sync.py
+++ b/api_service/core/sync.py
@@ -92,6 +92,27 @@ def _finish_summary_from_memo(memo: dict[str, Any]) -> dict[str, Any] | None:
         return sanitized if isinstance(sanitized, dict) else None
     return None
 
+def _artifact_ref_from_memo(memo: dict[str, Any], *keys: str) -> str | None:
+    for key in keys:
+        value = memo.get(key)
+        if isinstance(value, str):
+            candidate = value.strip()
+            if candidate:
+                return candidate
+        if isinstance(value, dict):
+            for ref_key in (
+                "artifactRef",
+                "artifact_ref",
+                "artifactId",
+                "artifact_id",
+                "id",
+                "ref",
+            ):
+                candidate = str(value.get(ref_key) or "").strip()
+                if candidate:
+                    return candidate
+    return None
+
 def _finish_outcome_code_from_summary(
     finish_summary: dict[str, Any] | None,
 ) -> str | None:
@@ -342,9 +363,24 @@ async def map_temporal_state_to_projection(
         "artifact_refs": artifact_refs,
         "finish_outcome_code": _finish_outcome_code_from_summary(finish_summary),
         "finish_summary_json": finish_summary,
-        "input_ref": memo.get("input_ref"),
-        "plan_ref": memo.get("plan_ref"),
-        "manifest_ref": memo.get("manifest_ref"),
+        "input_ref": _artifact_ref_from_memo(
+            memo,
+            "input_ref",
+            "input_artifact_ref",
+            "inputArtifactRef",
+        ),
+        "plan_ref": _artifact_ref_from_memo(
+            memo,
+            "plan_ref",
+            "plan_artifact_ref",
+            "planArtifactRef",
+        ),
+        "manifest_ref": _artifact_ref_from_memo(
+            memo,
+            "manifest_ref",
+            "manifest_artifact_ref",
+            "manifestArtifactRef",
+        ),
         "parameters": _sanitize_for_json(memo.get("parameters", {}) or {}),
         "integration_state": _sanitize_for_json(memo.get("integration_state")),
         "pending_parameters_patch": _sanitize_for_json(

--- a/api_service/core/sync.py
+++ b/api_service/core/sync.py
@@ -108,9 +108,11 @@ def _artifact_ref_from_memo(memo: dict[str, Any], *keys: str) -> str | None:
                 "id",
                 "ref",
             ):
-                candidate = str(value.get(ref_key) or "").strip()
-                if candidate:
-                    return candidate
+                ref_val = value.get(ref_key)
+                if isinstance(ref_val, str):
+                    candidate = ref_val.strip()
+                    if candidate:
+                        return candidate
     return None
 
 def _finish_outcome_code_from_summary(

--- a/moonmind/workflows/temporal/service.py
+++ b/moonmind/workflows/temporal/service.py
@@ -3091,28 +3091,6 @@ class TemporalExecutionService:
             or str(memo.get("resume_checkpoint_ref") or "").strip()
             or str(memo.get("resumeCheckpointRef") or "").strip()
         )
-        if not canonical_checkpoint_ref:
-            raise TemporalExecutionRecoveryCheckpointError(
-                "Recovery checkpoint ref is required."
-            )
-        requested_checkpoint_ref = str(recovery_checkpoint_ref or "").strip()
-        if (
-            requested_checkpoint_ref
-            and requested_checkpoint_ref != canonical_checkpoint_ref
-        ):
-            raise TemporalExecutionRecoveryCheckpointError(
-                "Recovery checkpoint ref does not match source execution."
-            )
-        checkpoint_ref = canonical_checkpoint_ref
-        source_snapshot_ref = str(
-            memo.get("task_input_snapshot_ref")
-            or memo.get("taskInputSnapshotRef")
-            or ""
-        ).strip()
-        if not source_snapshot_ref:
-            raise TemporalExecutionRecoveryCheckpointError(
-                "Original task input snapshot ref is required for failed-step recovery."
-            )
 
         if checkpoint_payload is None:
             raise TemporalExecutionRecoveryCheckpointError(
@@ -3135,6 +3113,26 @@ class TemporalExecutionService:
             raise TemporalExecutionRecoveryCheckpointError(
                 "Failed-run recovery manifest is invalid."
             ) from exc
+        manifest_checkpoint_ref = str(
+            recovery_manifest.validation.checkpoint_ref
+            or recovery_manifest.recovery_eligibility.checkpoint_ref
+            or ""
+        ).strip()
+        if not canonical_checkpoint_ref:
+            canonical_checkpoint_ref = manifest_checkpoint_ref
+        if not canonical_checkpoint_ref:
+            raise TemporalExecutionRecoveryCheckpointError(
+                "Recovery checkpoint ref is required."
+            )
+        requested_checkpoint_ref = str(recovery_checkpoint_ref or "").strip()
+        if (
+            requested_checkpoint_ref
+            and requested_checkpoint_ref != canonical_checkpoint_ref
+        ):
+            raise TemporalExecutionRecoveryCheckpointError(
+                "Recovery checkpoint ref does not match source execution."
+            )
+        checkpoint_ref = canonical_checkpoint_ref
         if not recovery_manifest.resume_allowed:
             raise TemporalExecutionRecoveryCheckpointError(
                 "Failed-run recovery manifest does not allow resume."
@@ -3147,7 +3145,7 @@ class TemporalExecutionService:
             raise TemporalExecutionRecoveryCheckpointError(
                 "Failed-run recovery manifest runId does not match source execution."
             )
-        if recovery_manifest.validation.checkpoint_ref != checkpoint_ref:
+        if manifest_checkpoint_ref != checkpoint_ref:
             raise TemporalExecutionRecoveryCheckpointError(
                 "Failed-run recovery manifest checkpoint ref does not match source execution."
             )
@@ -3164,6 +3162,16 @@ class TemporalExecutionService:
         if checkpoint.source.run_id != source_run_id:
             raise TemporalExecutionRecoveryCheckpointError(
                 "Recovery checkpoint runId does not match source execution."
+            )
+        source_snapshot_ref = str(
+            memo.get("task_input_snapshot_ref")
+            or memo.get("taskInputSnapshotRef")
+            or checkpoint.task_input_snapshot_ref
+            or ""
+        ).strip()
+        if not source_snapshot_ref:
+            raise TemporalExecutionRecoveryCheckpointError(
+                "Original task input snapshot ref is required for failed-step recovery."
             )
         if checkpoint.task_input_snapshot_ref != source_snapshot_ref:
             raise TemporalExecutionRecoveryCheckpointError(

--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -981,6 +981,20 @@ class MoonMindAgentRun:
             request=request,
             metadata=metadata,
         )
+        if request.workspace_spec:
+            workspace_spec = dict(request.workspace_spec)
+            metadata.setdefault("workspaceSpec", workspace_spec)
+            for key in (
+                "workspacePath",
+                "workspaceRootRef",
+                "workspaceRoot",
+                "baseCommit",
+                "workspaceCheckpointKind",
+                "checkpointKind",
+            ):
+                value = workspace_spec.get(key)
+                if value is not None:
+                    metadata.setdefault(key, value)
 
         agent_run_id = ""
         if request.managed_session is not None:

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -828,6 +828,37 @@ class MoonMindRunWorkflow:
             self._failure_diagnostic = diagnostic
         return diagnostic
 
+    def _record_step_execution_exception(
+        self,
+        exc: BaseException,
+        *,
+        logical_step_id: str,
+        tool_name: str,
+        source: str,
+        updated_at: datetime,
+        child_workflow_id: str | None = None,
+        diagnostics_ref: str | None = None,
+    ) -> dict[str, Any]:
+        """Record step-scoped terminal failure evidence for raised executions."""
+
+        diagnostic = self._record_failure_diagnostic(
+            exc,
+            stage=self._state,
+            step_id=logical_step_id,
+            step_title=tool_name,
+            source=source,
+            child_workflow_id=child_workflow_id,
+            diagnostics_ref=diagnostics_ref,
+        )
+        self._mark_step_terminal(
+            logical_step_id,
+            status="failed",
+            updated_at=updated_at,
+            summary=diagnostic["message"],
+            last_error=diagnostic["category"],
+        )
+        return diagnostic
+
     def _record_result_failure_diagnostic(
         self,
         *,
@@ -6691,7 +6722,24 @@ class MoonMindRunWorkflow:
                     updated_at=workflow.now(),
                     summary=self._summary,
                 )
-                self._record_step_workspace_capture_input(node_id, node_inputs)
+                capture_input_source = dict(node_inputs)
+                workflow_workspace_spec = self._mapping_value(
+                    parameters,
+                    "workspaceSpec",
+                    "workspace_spec",
+                )
+                if (
+                    isinstance(workflow_workspace_spec, Mapping)
+                    and "workspaceSpec" not in capture_input_source
+                    and "workspace_spec" not in capture_input_source
+                ):
+                    capture_input_source["workspaceSpec"] = dict(
+                        workflow_workspace_spec
+                    )
+                self._record_step_workspace_capture_input(
+                    node_id,
+                    capture_input_source,
+                )
                 current_step_execution = self._step_execution_for(node_id) or 1
                 attempt_reason = (
                     "quality_gate_failed"
@@ -7024,15 +7072,43 @@ class MoonMindRunWorkflow:
                             if step_retry_overrides_enabled
                             else None
                         )
-                        execution_result = await workflow.execute_activity(
-                            route.activity_type,
-                            execute_payload,
-                            cancellation_type=ActivityCancellationType.TRY_CANCEL,
-                            **self._execute_kwargs_for_route(
-                                route,
-                                max_attempts_override=max_attempts_override,
-                            ),
-                        )
+                        try:
+                            execution_result = await workflow.execute_activity(
+                                route.activity_type,
+                                execute_payload,
+                                cancellation_type=ActivityCancellationType.TRY_CANCEL,
+                                **self._execute_kwargs_for_route(
+                                    route,
+                                    max_attempts_override=max_attempts_override,
+                                ),
+                            )
+                        except Exception as exc:
+                            diagnostic = self._record_step_execution_exception(
+                                exc,
+                                logical_step_id=node_id,
+                                tool_name=tool_name,
+                                source="activity",
+                                updated_at=workflow.now(),
+                            )
+                            if step_execution_manifest_enabled:
+                                await self._record_step_execution_manifest(
+                                    node_id,
+                                    phase="terminal",
+                                    updated_at=workflow.now(),
+                                    reason=attempt_reason,
+                                    status="failed",
+                                    terminal_disposition="failed_unrecoverable",
+                                    summary=diagnostic.get("message"),
+                                    execution={
+                                        "kind": tool_type,
+                                        "toolName": tool_name,
+                                        "activityType": route.activity_type,
+                                    },
+                                )
+                            if failure_mode == "FAIL_FAST":
+                                raise
+                            result_status = "FAILED"
+                            break
 
                     else:
                         raise ValueError(
@@ -12081,6 +12157,29 @@ class MoonMindRunWorkflow:
             idempotency_key = f"{wf_info.workflow_id}:{node_id}:{wf_info.run_id}"
 
         workspace_spec: dict[str, Any] = {}
+        for source_label, raw_workspace_spec in (
+            ("workflow.workspaceSpec", (
+                workflow_parameters.get("workspaceSpec")
+                if isinstance(workflow_parameters, Mapping)
+                else None
+            )),
+            ("workflow.workspace_spec", (
+                workflow_parameters.get("workspace_spec")
+                if isinstance(workflow_parameters, Mapping)
+                else None
+            )),
+            ("node.runtime.workspaceSpec", runtime_block.get("workspaceSpec")),
+            ("node.runtime.workspace_spec", runtime_block.get("workspace_spec")),
+            ("node.workspaceSpec", node_inputs.get("workspaceSpec")),
+            ("node.workspace_spec", node_inputs.get("workspace_spec")),
+        ):
+            if isinstance(raw_workspace_spec, Mapping):
+                workspace_spec.update(
+                    self._json_mapping(
+                        raw_workspace_spec,
+                        path=source_label,
+                    )
+                )
         for ws_key in (
             "repository",
             "repo",

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -34,7 +34,9 @@ from api_service.api.routers.executions import (
     _hydrate_related_run_metadata,
     _merge_workflow_preserving_artifact_instructions,
     _canonical_recovery_manifest_ref,
+    _recovery_evidence_disabled_reason,
     _recovery_manifest_ref_from_record,
+    _recovery_manifest_summary_allows_resume,
     _recovery_not_available_reason,
     _reject_recovery_manifest_mismatch,
     _reuse_original_task_input_snapshot_from_source,
@@ -966,6 +968,52 @@ def test_recovery_manifest_ref_reads_finish_summary_manifest_ref() -> None:
     }
 
     assert _recovery_manifest_ref_from_record(record) == "artifact://recovery/manifest-1"
+
+
+def _valid_recovery_manifest_summary(*, include_manifest_ref: bool = True) -> dict[str, Any]:
+    manifest: dict[str, Any] = {
+        "schemaVersion": "v1",
+        "resumeAllowed": True,
+        "validationResult": "valid",
+        "failedLogicalStepId": "implement",
+        "checkpointRef": "artifact://resume-checkpoints/source/checkpoint-v1",
+    }
+    if include_manifest_ref:
+        manifest["manifestRef"] = "artifact://recovery/manifest"
+    return manifest
+
+
+def test_recovery_manifest_summary_requires_manifest_ref() -> None:
+    record = _build_execution_record(state=MoonMindWorkflowState.FAILED)
+    record.memo = {**record.memo, "plan_artifact_ref": {"artifact_id": "artifact://plan/source"}}
+
+    record.finish_summary_json = {"recoveryManifest": _valid_recovery_manifest_summary()}
+    assert _recovery_manifest_summary_allows_resume(record) is True
+
+    record.finish_summary_json = {
+        "recoveryManifest": _valid_recovery_manifest_summary(include_manifest_ref=False)
+    }
+    assert _recovery_manifest_summary_allows_resume(record) is False
+
+
+def test_recovery_evidence_disabled_when_manifest_ref_missing() -> None:
+    """A compact summary that lacks a manifest ref must not advertise resume.
+
+    Without the manifest ref the POST resume path would immediately 409 with
+    ``recovery_manifest_missing``, so the summary fast-path must stop enabling
+    resume and the record must fall back to the full-evidence checks (which it
+    cannot satisfy here), leaving resume disabled.
+    """
+    record = _build_execution_record(state=MoonMindWorkflowState.FAILED)
+    record.memo = {**record.memo, "plan_artifact_ref": {"artifact_id": "artifact://plan/source"}}
+
+    record.finish_summary_json = {"recoveryManifest": _valid_recovery_manifest_summary()}
+    assert _recovery_evidence_disabled_reason(record) is None
+
+    record.finish_summary_json = {
+        "recoveryManifest": _valid_recovery_manifest_summary(include_manifest_ref=False)
+    }
+    assert _recovery_evidence_disabled_reason(record) is not None
 
 
 def test_canonical_recovery_manifest_ref_rejects_request_override() -> None:

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -11672,7 +11672,11 @@ def test_describe_execution_exposes_temporal_workflow_editing_contract(
     _override_temporal_client(app)
     _override_user_dependencies(app, is_superuser=True)
     monkeypatch.setattr(settings.temporal_dashboard, "actions_enabled", True)
-    monkeypatch.setattr(settings.temporal_dashboard, "temporal_workflow_editing_enabled", True)
+    monkeypatch.setattr(
+        settings.temporal_dashboard,
+        "temporal_workflow_editing_enabled",
+        True,
+    )
 
     with TestClient(app) as test_client:
         response = test_client.get("/api/executions/mm:wf-1")
@@ -11749,6 +11753,51 @@ def test_describe_execution_exposes_failed_step_recovery_distinct_from_lifecycle
     )
     assert body["resume"]["failedStepId"] == "implement"
     assert body["resume"]["sourceRunId"] == "run-2"
+
+
+def test_describe_execution_enables_failed_step_recovery_from_valid_manifest_summary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app = FastAPI()
+    app.include_router(router)
+    mock_service = AsyncMock()
+    record = _build_execution_record(state=MoonMindWorkflowState.FAILED)
+    record.memo = {
+        **record.memo,
+        "plan_artifact_ref": {"artifact_id": "artifact://plan/source"},
+    }
+    record.finish_summary_json = {
+        "recoveryManifest": {
+            "schemaVersion": "v1",
+            "contentType": FAILED_RUN_RECOVERY_MANIFEST_CONTENT_TYPE,
+            "resumeAllowed": True,
+            "failedLogicalStepId": "implement",
+            "failedExecutionOrdinal": 1,
+            "validationResult": "valid",
+            "checkpointRef": "artifact://resume-checkpoints/source/checkpoint-v1",
+            "manifestRef": "artifact://recovery/manifest",
+        }
+    }
+    mock_service.describe_execution.return_value = record
+    app.dependency_overrides[_get_service] = lambda: mock_service
+    _override_temporal_client(app)
+    _override_user_dependencies(app, is_superuser=True)
+    monkeypatch.setattr(settings.temporal_dashboard, "actions_enabled", True)
+    monkeypatch.setattr(settings.temporal_dashboard, "temporal_workflow_editing_enabled", True)
+
+    with TestClient(app) as test_client:
+        response = test_client.get("/api/executions/mm:wf-1")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["actions"]["canResumeFromFailedStep"] is True
+    assert body["resume"]["available"] is True
+    assert (
+        body["resume"]["checkpointRef"]
+        == "artifact://resume-checkpoints/source/checkpoint-v1"
+    )
+    assert body["resume"]["failedStepId"] == "implement"
+    assert body["resume"]["disabledReason"] is None
 
 
 def test_describe_execution_exposes_target_attachment_and_recovery_diagnostics(
@@ -12707,6 +12756,109 @@ def test_failed_step_recovery_hydrates_checkpoint_artifact(
         == "artifact://recovery/manifest"
     )
     assert call_kwargs["recovery_checkpoint_ref"] is None
+
+
+def test_failed_step_recovery_hydrates_checkpoint_from_manifest_summary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app = FastAPI()
+    app.include_router(router)
+    mock_service = AsyncMock()
+    canonical = _build_execution_record(state=MoonMindWorkflowState.FAILED)
+    canonical.memo = {
+        **canonical.memo,
+        "task_input_snapshot_ref": "artifact://snapshot/source",
+    }
+    canonical.finish_summary_json = {
+        "recoveryManifest": {
+            "resumeAllowed": True,
+            "failedLogicalStepId": "implement",
+            "failedExecutionOrdinal": 1,
+            "validationResult": "valid",
+            "checkpointRef": "artifact://resume-checkpoints/source/checkpoint-v1",
+            "manifestRef": "artifact://recovery/manifest",
+        }
+    }
+    mock_service.describe_execution.return_value = canonical
+    mock_service.create_failed_step_recovery_execution.return_value = {
+        "accepted": True,
+        "applied": "created_resumed_execution",
+        "source": {"workflowId": canonical.workflow_id, "runId": canonical.run_id},
+        "execution": {
+            "workflowId": "mm:resumed",
+            "runId": "run-resumed",
+            "detailHref": "/workflows/mm:resumed",
+        },
+        "relationship": "Recovered from failed step",
+        "recoveryCheckpointRef": "artifact://resume-checkpoints/source/checkpoint-v1",
+    }
+    checkpoint_payload = {
+        "schemaVersion": "v1",
+        "source": {"workflowId": canonical.workflow_id, "runId": canonical.run_id},
+        "taskInputSnapshotRef": "artifact://snapshot/source",
+        "planDigest": "sha256:resume-plan",
+        "failedStep": {
+            "logicalStepId": "implement",
+            "order": 2,
+            "attempt": 1,
+        },
+        "preservedSteps": [
+            {
+                "logicalStepId": "plan",
+                "order": 1,
+                "status": "succeeded",
+                "sourceExecutionOrdinal": 1,
+                "artifacts": {"summary": "artifact://completed/plan"},
+                "stateCheckpointRef": "artifact://workspace/before-implement",
+            }
+        ],
+        "recoveryWorkspace": {
+            "checkpointRef": "artifact://resume-checkpoints/source/checkpoint-v1",
+        },
+    }
+    manifest_payload = _valid_failed_run_recovery_manifest_payload(
+        canonical,
+        checkpoint_ref="artifact://resume-checkpoints/source/checkpoint-v1",
+    )
+    artifact_service = SimpleNamespace(
+        read=AsyncMock(
+            side_effect=[
+                (SimpleNamespace(), json.dumps(manifest_payload).encode()),
+                (SimpleNamespace(), json.dumps(checkpoint_payload).encode()),
+            ]
+        )
+    )
+
+    class Session:
+        async def get(self, model, key):
+            return canonical
+
+        async def commit(self):
+            return None
+
+    app.dependency_overrides[_get_service] = lambda: mock_service
+    app.dependency_overrides[get_async_session] = lambda: Session()
+    _override_user_dependencies(app, is_superuser=True)
+    monkeypatch.setattr(
+        "api_service.api.routers.executions.get_temporal_artifact_service",
+        lambda _session: artifact_service,
+    )
+
+    with TestClient(app) as test_client:
+        response = test_client.post(
+            "/api/executions/mm:wf-1/recover-from-failed-step",
+            json={"idempotencyKey": "resume-1"},
+        )
+
+    assert response.status_code == 201
+    assert artifact_service.read.await_count == 2
+    call_kwargs = mock_service.create_failed_step_recovery_execution.await_args.kwargs
+    assert call_kwargs["checkpoint_payload"] == checkpoint_payload
+    assert call_kwargs["failed_run_recovery_manifest"] == manifest_payload
+    assert (
+        call_kwargs["failed_run_recovery_manifest_ref"]
+        == "artifact://recovery/manifest"
+    )
 
 
 def test_selected_step_recovery_pins_source_and_selected_step(

--- a/tests/unit/test_sync.py
+++ b/tests/unit/test_sync.py
@@ -147,6 +147,32 @@ def test_map_temporal_state_to_projection_extracts_finish_summary():
     assert result["finish_summary_json"] == finish_summary
 
 
+def test_map_temporal_state_to_projection_uses_plan_artifact_ref_when_plan_ref_missing():
+    start_time = datetime.now(UTC)
+    desc = Mock(spec=WorkflowExecutionDescription)
+    desc.id = "mm:plan-artifact-ref"
+    desc.run_id = "run-plan-artifact-ref"
+    desc.namespace = "moonmind"
+    desc.workflow_type = "MoonMind.UserWorkflow"
+    desc.status = WorkflowExecutionStatus.FAILED
+    desc.start_time = start_time
+    desc.execution_time = start_time
+    desc.close_time = start_time
+    desc.search_attributes = {}
+
+    async def _memo() -> dict[str, object]:
+        return {
+            "entry": "run",
+            "plan_artifact_ref": {"artifact_id": "artifact://plan/source"},
+        }
+
+    desc.memo = _memo
+
+    result = asyncio.run(map_temporal_state_to_projection(desc))
+
+    assert result["plan_ref"] == "artifact://plan/source"
+
+
 def test_map_temporal_state_to_projection_extracts_snake_case_finish_outcome():
     start_time = datetime.now(UTC)
     desc = Mock(spec=WorkflowExecutionDescription)

--- a/tests/unit/test_sync.py
+++ b/tests/unit/test_sync.py
@@ -6,6 +6,7 @@ import pytest
 from temporalio.client import WorkflowExecutionDescription, WorkflowExecutionStatus
 
 from api_service.core.sync import (
+    _artifact_ref_from_memo,
     map_temporal_state_to_projection,
     merged_memo_for_projection,
     merged_parameters_for_projection,
@@ -940,3 +941,33 @@ def test_started_at_persists_through_awaiting_slot_after_work_began():
 
     assert result["state"] == MoonMindWorkflowState.AWAITING_SLOT
     assert _as_utc(result["started_at"]) == semantic_started_at
+
+
+def test_artifact_ref_from_memo_returns_string_ref():
+    memo = {"plan_artifact_ref": {"artifact_id": "artifact://plan/source"}}
+
+    assert _artifact_ref_from_memo(memo, "plan_artifact_ref") == "artifact://plan/source"
+
+
+def test_artifact_ref_from_memo_ignores_non_string_ref_values():
+    """Nested dicts/lists under a ref key must not be stringified into an
+    invalid artifact reference; only genuine string refs are returned."""
+    memo = {
+        "plan_artifact_ref": {
+            "artifact_id": {"nested": "value"},
+            "ref": ["artifact://plan/list"],
+        }
+    }
+
+    assert _artifact_ref_from_memo(memo, "plan_artifact_ref") is None
+
+
+def test_artifact_ref_from_memo_skips_non_string_then_finds_valid_ref():
+    memo = {
+        "plan_artifact_ref": {
+            "artifactId": {"nested": "value"},
+            "id": "artifact://plan/id",
+        }
+    }
+
+    assert _artifact_ref_from_memo(memo, "plan_artifact_ref") == "artifact://plan/id"

--- a/tests/unit/tools/test_check_removed_capability_semantics.py
+++ b/tests/unit/tools/test_check_removed_capability_semantics.py
@@ -112,6 +112,15 @@ def test_guard_excludes_transient_artifacts(tmp_path: Path) -> None:
     assert check_removed_capability_semantics(tmp_path) == []
 
 
+def test_guard_excludes_local_deployment_state(tmp_path: Path) -> None:
+    desired_state = tmp_path / "deploy" / "state" / "desired-state.json"
+    desired_state.parent.mkdir(parents=True)
+    desired_state.write_text(_old_camel(), encoding="utf-8")
+
+    assert list(iter_scanned_files(tmp_path)) == []
+    assert check_removed_capability_semantics(tmp_path) == []
+
+
 def test_guard_excludes_local_skill_overlay(tmp_path: Path) -> None:
     local_skill = tmp_path / ".agents" / "skills" / "local" / "private" / "SKILL.md"
     local_skill.parent.mkdir(parents=True)

--- a/tests/unit/workflows/temporal/test_temporal_service.py
+++ b/tests/unit/workflows/temporal/test_temporal_service.py
@@ -3188,6 +3188,60 @@ async def test_failed_step_recovery_creates_linked_execution_with_source_identit
 
 
 @pytest.mark.asyncio
+async def test_failed_step_recovery_accepts_manifest_checkpoint_without_memo_ref(
+    tmp_path, mock_client_adapter
+):
+    async with temporal_db(tmp_path) as session:
+        service = TemporalExecutionService(session)
+        service._client_adapter = mock_client_adapter
+
+        created = await service.create_execution(
+            workflow_type="MoonMind.UserWorkflow",
+            owner_id=uuid4(),
+            title="recover source",
+            input_artifact_ref="artifact://input/source",
+            plan_artifact_ref="artifact://plan/source",
+            manifest_artifact_ref=None,
+            failure_policy=None,
+            initial_parameters={
+                "workflow": {"title": "recovery source", "instructions": "Original"},
+            },
+            idempotency_key=None,
+        )
+        created.state = MoonMindWorkflowState.FAILED
+        created.close_status = TemporalExecutionCloseStatus.FAILED
+        created.memo = {
+            **created.memo,
+            "task_input_snapshot_ref": "artifact://snapshot/source",
+        }
+        await session.commit()
+
+        result = await service.create_failed_step_recovery_execution(
+            created,
+            recovery_checkpoint_ref=None,
+            idempotency_key="recover-manifest-ref",
+            checkpoint_payload=_valid_recovery_checkpoint_payload(
+                workflow_id=created.workflow_id,
+                run_id=created.run_id,
+                snapshot_ref="artifact://snapshot/source",
+            ),
+            failed_run_recovery_manifest_ref="artifact://recovery/manifest",
+            failed_run_recovery_manifest=_valid_failed_run_recovery_manifest_payload(
+                workflow_id=created.workflow_id,
+                run_id=created.run_id,
+                checkpoint_ref="artifact://checkpoint/source",
+            ),
+        )
+
+        resumed = await service.describe_execution(result["execution"]["workflowId"])
+        assert result["applied"] == "created_resumed_execution"
+        assert (
+            resumed.parameters["workflow"]["resume"]["recoveryCheckpointRef"]
+            == "artifact://checkpoint/source"
+        )
+
+
+@pytest.mark.asyncio
 async def test_failed_step_recovery_accepts_legacy_checkpoint_memo_key(
     tmp_path, mock_client_adapter
 ):

--- a/tests/unit/workflows/temporal/workflows/test_agent_run_prepared_context.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_run_prepared_context.py
@@ -101,3 +101,32 @@ def test_result_metadata_preserves_parent_prepared_context_authority(monkeypatch
     ]
     assert "write-report" not in str(moonmind_metadata)
     assert "report-notes" not in str(moonmind_metadata)
+
+
+def test_result_metadata_carries_compact_workspace_capture_input(monkeypatch):
+    _configure_workflow_runtime(monkeypatch)
+    run = MoonMindAgentRun()
+    request = AgentExecutionRequest(
+        agentKind="managed",
+        agentId="codex_cli",
+        correlationId="corr-workspace",
+        idempotencyKey="idem-workspace",
+        workspaceSpec={
+            "workspacePath": "/work/agent_jobs/job-1/repo",
+            "baseCommit": "abc123",
+            "workspaceCheckpointKind": "git_patch",
+        },
+    )
+
+    result = run._enrich_result_metadata(
+        request=request,
+        result=AgentRunResult(summary="done", metadata={}),
+    )
+
+    assert result is not None
+    assert result.metadata["workspaceSpec"] == {
+        "workspacePath": "/work/agent_jobs/job-1/repo",
+        "baseCommit": "abc123",
+        "workspaceCheckpointKind": "git_patch",
+    }
+    assert result.metadata["workspacePath"] == "/work/agent_jobs/job-1/repo"

--- a/tests/unit/workflows/temporal/workflows/test_run_recover_from_failed_step.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_recover_from_failed_step.py
@@ -438,6 +438,37 @@ def test_recovery_source_accepts_checkpoint_payload_ref_workspace_evidence() -> 
     assert workflow._recovery_workspace_restored_ref == restored_ref
 
 
+def test_step_execution_exception_records_failed_step_diagnostic(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _configure_workflow_runtime(monkeypatch)
+    now = datetime.now(UTC)
+    workflow = MoonMindRunWorkflow()
+    workflow._initialize_step_ledger(
+        ordered_nodes=[{"id": "create-jira", "title": "Create Jira issues"}],
+        dependency_map={"create-jira": []},
+        updated_at=now,
+    )
+    workflow._mark_step_running("create-jira", updated_at=now, summary="Running")
+
+    diagnostic = workflow._record_step_execution_exception(
+        RuntimeError("tool activity failed"),
+        logical_step_id="create-jira",
+        tool_name="story.create_jira_issues",
+        source="activity",
+        updated_at=now,
+    )
+
+    row = workflow._step_ledger_row_for("create-jira")
+    assert row is not None
+    assert row["status"] == "failed"
+    assert row["lastError"] == diagnostic["category"]
+    assert workflow._failure_diagnostic is not None
+    assert workflow._failure_diagnostic["stepId"] == "create-jira"
+    assert workflow._failure_diagnostic["source"] == "activity"
+    assert workflow._failure_diagnostic["message"] == "tool activity failed"
+
+
 def test_preserved_outputs_are_available_to_failed_step_dependencies() -> None:
     now = datetime.now(UTC)
     workflow = _workflow_with_resume()

--- a/tools/check_removed_capability_semantics.py
+++ b/tools/check_removed_capability_semantics.py
@@ -119,6 +119,8 @@ def _is_scanned_file(path: Path, root: Path) -> bool:
         return False
     if any(part in EXCLUDED_DIR_NAMES for part in relative.parts):
         return False
+    if relative.parts[:2] == ("deploy", "state"):
+        return False
     if relative.parts[:3] == (".agents", "skills", "local"):
         return False
     return path.is_file() and path.suffix in SCANNED_SUFFIXES


### PR DESCRIPTION
## Summary

Fixes failed-step recovery evidence so checkpoint-backed resume is available when the workflow has valid recovery data, and prevents local deployment state files from breaking the static preflight scanner.

## Root Cause

Several recovery paths were not connected end to end:

- direct skill activity exceptions could escape before the step ledger was marked failed
- checkpoint capture could miss workspace metadata that already existed on the workflow or child agent result
- API and service resume gates depended on legacy memo fields even when `finishSummary.recoveryManifest` contained valid checkpoint evidence
- Temporal projection did not normalize `plan_artifact_ref` into canonical `plan_ref`, leaving the plan identity gate empty

The recurring `deploy/state/desired-state.json` permission error was a separate local-tooling problem: the MM-917 static guard scanned ignored deployment state under `deploy/state`, so root-owned local state could fail the unit wrapper before pytest started.

## Changes

- Normalize skill activity failures into step-scoped diagnostics and terminal failed step evidence.
- Propagate compact workspace checkpoint capture metadata through workflow and agent-result boundaries.
- Allow validated failed-run recovery manifest summaries to drive API resume availability and recovery submission.
- Let recovery service derive the canonical checkpoint ref from the validated recovery manifest when memo fields are absent.
- Normalize plan/input/manifest artifact refs from memo aliases during Temporal projection sync.
- Exclude local `deploy/state` files from the removed-capability semantic scanner.
- Add focused unit coverage for the workflow, API, service, agent-result metadata, sync, and scanner paths.

## Validation

- `python3 -m pytest` focused recovery regression set: 6 passed
- Recovery/API selected suite: 22 passed, 364 deselected
- Temporal service recovery subset: 15 passed, 124 deselected
- Agent result-enrichment subset: 2 passed, 20 deselected
- `python3 -m pytest tests/unit/tools/test_check_removed_capability_semantics.py -q`: 8 passed
- `./tools/test_unit.sh tests/unit/tools/test_check_removed_capability_semantics.py::test_guard_excludes_local_deployment_state`: passed, including frontend phase with 45 files and 730 tests passed, 237 skipped
- `PYTHONPYCACHEPREFIX=/tmp/moonmind_pycache python3 -m py_compile ...`: passed
- `git diff --check`: passed

`ruff` is not installed in this environment.
