### PR TITLE
MM-1066 Remove Jira Board from breakdown presets

### DIFF
--- a/api_service/data/presets/jira-breakdown-implement.yaml
+++ b/api_service/data/presets/jira-breakdown-implement.yaml
@@ -1,5 +1,5 @@
 slug: jira-breakdown-implement
-title: Jira Breakdown and Implement
+title: Breakdown and Jira Implement
 description: Break a preferred source input into stories, create Jira issues, then create dependent Jira Implement tasks for each generated issue.
 scope: global
 tags:

--- a/api_service/data/presets/jira-breakdown-orchestrate.yaml
+++ b/api_service/data/presets/jira-breakdown-orchestrate.yaml
@@ -1,5 +1,5 @@
 slug: jira-breakdown-orchestrate
-title: Jira Breakdown and Orchestrate
+title: Breakdown and Jira Orchestrate
 description: Break a preferred source input into stories, create Jira issues, then create dependent Jira Orchestrate tasks for each generated issue.
 scope: global
 tags:
@@ -35,11 +35,6 @@ inputs:
     type: text
     required: true
     default: Story
-  - name: jira_board_id
-    label: Jira Board
-    type: jira_board
-    required: false
-    default: ""
   - name: jira_dependency_mode
     label: Jira Dependency Mode
     type: enum
@@ -135,7 +130,6 @@ steps:
       For stories where jiraCreation.action is create_remaining_work_issue, create the Jira issue from the story's remainingWork while preserving the original story traceability.
       {% if inputs.source_issue_key %}Source Jira issue key: {{ inputs.source_issue_key }}.{% endif %}
       {% if inputs.source_issue_key and inputs.jira_issue_type | lower in ["sub-task", "subtask", "sub task"] %}Create each generated Jira issue as a sub-task of {{ inputs.source_issue_key }}.{% endif %}
-      {% if inputs.jira_board_id %}Selected Jira board ID: {{ inputs.jira_board_id }}.{% endif %}
       Dependency mode: {{ inputs.jira_dependency_mode }}.
       If dependency mode is linear_blocker_chain, create an ordered blocker chain so each later story is blocked by the immediately preceding story.
       If dependency mode is none, create the Jira issues without dependency links.
@@ -146,7 +140,6 @@ steps:
       jira:
         projectKey: "{{ inputs.jira_project_key }}"
         issueTypeName: "{{ inputs.jira_issue_type }}"
-        boardId: "{{ inputs.jira_board_id }}"
         sourceIssueKey: "{{ inputs.source_issue_key }}"
         dependencyMode: "{{ inputs.jira_dependency_mode }}"
     skill:

--- a/api_service/data/presets/jira-breakdown.yaml
+++ b/api_service/data/presets/jira-breakdown.yaml
@@ -1,5 +1,5 @@
 slug: jira-breakdown
-title: Jira Breakdown
+title: Breakdown and Jira Create
 description: Break a preferred source input into MoonSpec story candidates, then create Jira Story issues from the generated breakdown.
 scope: global
 tags:
@@ -39,11 +39,6 @@ inputs:
     type: text
     required: true
     default: Story
-  - name: jira_board_id
-    label: Jira Board
-    type: jira_board
-    required: false
-    default: ""
   - name: jira_dependency_mode
     label: Jira Dependency Mode
     type: enum
@@ -108,7 +103,6 @@ steps:
       Use the runtime-provided story breakdown JSON path.
       Every Jira issue must include the Source Document path and canonical claim IDs from the story breakdown when present; otherwise include the source title and Source Jira issue key when present.
       {% if inputs.source_issue_key %}Source Jira issue key: {{ inputs.source_issue_key }}.{% endif %}
-      {% if inputs.jira_board_id %}Selected Jira board ID: {{ inputs.jira_board_id }}.{% endif %}
       Dependency mode: {{ inputs.jira_dependency_mode }}.
       If dependency mode is linear_blocker_chain, create an ordered blocker chain so each later story is blocked by the immediately preceding story.
       If dependency mode is none, create the Jira issues without dependency links.
@@ -118,7 +112,6 @@ steps:
       jira:
         projectKey: "{{ inputs.jira_project_key }}"
         issueTypeName: "{{ inputs.jira_issue_type }}"
-        boardId: "{{ inputs.jira_board_id }}"
         dependencyMode: "{{ inputs.jira_dependency_mode }}"
     skill:
       id: story.create_jira_issues

--- a/moonmind/workflows/executions/preset_goal_scheduler.py
+++ b/moonmind/workflows/executions/preset_goal_scheduler.py
@@ -164,7 +164,6 @@ def schedule_preset_from_goal(goal: str) -> GoalPresetSchedule | None:
                 "feature_request": normalized_goal,
                 "jira_project_key": _jira_project_key(normalized_goal),
                 "jira_issue_type": "Story",
-                "jira_board_id": "",
                 "jira_dependency_mode": "linear_blocker_chain",
                 "publish_mode": "pr_with_merge_automation",
                 "source_issue_key": "",

--- a/tests/integration/test_startup_preset_seeding.py
+++ b/tests/integration/test_startup_preset_seeding.py
@@ -88,6 +88,10 @@ async def test_startup_seeds_default_task_templates(disabled_env_keys, tmp_path)
         )
         jira_template = result.scalar_one_or_none()
         assert jira_template is not None
+        assert jira_template.title == "Breakdown and Jira Create"
+        assert "jira_board_id" not in {
+            item["name"] for item in jira_template.inputs_schema
+        }
         assert [
             (step.get("skill") or step.get("tool"))["id"]
             for step in jira_template.steps
@@ -96,6 +100,9 @@ async def test_startup_seeds_default_task_templates(disabled_env_keys, tmp_path)
             "moonspec-breakdown",
             "story.create_jira_issues",
         ]
+        jira_create_step = jira_template.steps[2]
+        assert "Selected Jira board" not in jira_create_step["instructions"]
+        assert "boardId" not in jira_create_step["storyOutput"]["jira"]
 
         result = await session.execute(
             select(Preset)
@@ -364,6 +371,10 @@ async def test_startup_seeds_default_task_templates(disabled_env_keys, tmp_path)
         )
         composite_template = result.scalar_one_or_none()
         assert composite_template is not None
+        assert composite_template.title == "Breakdown and Jira Orchestrate"
+        assert "jira_board_id" not in {
+            item["name"] for item in composite_template.inputs_schema
+        }
         assert [
             (step.get("skill") or step.get("tool"))["id"]
             for step in composite_template.steps
@@ -376,6 +387,9 @@ async def test_startup_seeds_default_task_templates(disabled_env_keys, tmp_path)
         ]
         reconcile_step = composite_template.steps[2]
         assert "fully implemented stories" in reconcile_step["instructions"]
+        composite_jira_step = composite_template.steps[3]
+        assert "Selected Jira board" not in composite_jira_step["instructions"]
+        assert "boardId" not in composite_jira_step["storyOutput"]["jira"]
         downstream_step = composite_template.steps[4]
         assert "trusted Jira story output" in downstream_step["instructions"]
         assert "dependsOn" in downstream_step["instructions"]
@@ -398,6 +412,7 @@ async def test_startup_seeds_default_task_templates(disabled_env_keys, tmp_path)
         )
         implement_composite_template = result.scalar_one_or_none()
         assert implement_composite_template is not None
+        assert implement_composite_template.title == "Breakdown and Jira Implement"
         assert "jira_board_id" not in {
             item["name"] for item in implement_composite_template.inputs_schema
         }

--- a/tests/unit/api/test_presets_service.py
+++ b/tests/unit/api/test_presets_service.py
@@ -2043,7 +2043,10 @@ async def test_seed_catalog_includes_jira_breakdown_preset(
                 scope=PresetScopeType.GLOBAL,
                 scope_ref=None,
             )
-            assert template.title == "Jira Breakdown"
+            assert template.title == "Breakdown and Jira Create"
+            assert "jira_board_id" not in {
+                item["name"] for item in template.inputs_schema
+            }
             assert [
                 (step.get("skill") or step.get("tool"))["id"]
                 for step in template.steps
@@ -2079,10 +2082,10 @@ async def test_seed_catalog_includes_jira_breakdown_preset(
                 "jira": {
                     "projectKey": "MM",
                     "issueTypeName": "Story",
-                    "boardId": "",
                     "dependencyMode": "linear_blocker_chain",
                 },
             }
+            assert "Selected Jira board" not in expanded["steps"][1]["instructions"]
             assert expanded["appliedTemplate"]["inputs"]["jira_dependency_mode"] == (
                 "linear_blocker_chain"
             )
@@ -2433,7 +2436,6 @@ async def test_jira_breakdown_uses_single_allowed_project_as_runtime_default(
             assert expanded["steps"][1]["storyOutput"]["jira"] == {
                 "projectKey": "MM",
                 "issueTypeName": "Story",
-                "boardId": "",
                 "dependencyMode": "none",
             }
             assert expanded["appliedTemplate"]["inputs"]["jira_project_key"] == "MM"
@@ -2505,7 +2507,6 @@ async def test_jira_breakdown_orchestrate_uses_repository_policy_defaults(
                 "jira": {
                     "projectKey": "GAME",
                     "issueTypeName": "Story",
-                    "boardId": "",
                     "sourceIssueKey": "GAME-404",
                     "dependencyMode": "linear_blocker_chain",
                 },
@@ -2564,7 +2565,6 @@ async def test_jira_breakdown_replaces_legacy_placeholder_with_single_allowed_pr
             assert expanded["steps"][1]["storyOutput"]["jira"] == {
                 "projectKey": "MM",
                 "issueTypeName": "Story",
-                "boardId": "",
                 "dependencyMode": "none",
             }
             assert expanded["appliedTemplate"]["inputs"]["jira_project_key"] == "MM"
@@ -2991,7 +2991,10 @@ async def test_seed_catalog_includes_jira_breakdown_orchestrate_preset(
                 scope=PresetScopeType.GLOBAL,
                 scope_ref=None,
             )
-            assert template.title == "Jira Breakdown and Orchestrate"
+            assert template.title == "Breakdown and Jira Orchestrate"
+            assert "jira_board_id" not in {
+                item["name"] for item in template.inputs_schema
+            }
             assert template.annotations["sourceSkill"] == (
                 "jira-breakdown"
             )
@@ -3017,7 +3020,6 @@ async def test_seed_catalog_includes_jira_breakdown_orchestrate_preset(
                     "feature_request": "docs/Designs/RuntimeTypes.md",
                     "jira_project_key": "MM",
                     "jira_issue_type": "Story",
-                    "jira_board_id": "84",
                     "jira_dependency_mode": "linear_blocker_chain",
                     "publish_mode": "pr_with_merge_automation",
                     "source_issue_key": "MM-404",
@@ -3041,7 +3043,6 @@ async def test_seed_catalog_includes_jira_breakdown_orchestrate_preset(
             assert expanded["steps"][3]["storyOutput"]["jira"] == {
                 "projectKey": "MM",
                 "issueTypeName": "Story",
-                "boardId": "84",
                 "sourceIssueKey": "MM-404",
                 "dependencyMode": "linear_blocker_chain",
             }
@@ -3050,7 +3051,7 @@ async def test_seed_catalog_includes_jira_breakdown_orchestrate_preset(
             assert "Create one Jira Orchestrate task" in downstream["instructions"]
             assert "dependsOn" in downstream["instructions"]
             assert "MM-404" in downstream["instructions"]
-            assert "Selected Jira board ID: 84" in expanded["steps"][3]["instructions"]
+            assert "Selected Jira board" not in expanded["steps"][3]["instructions"]
             assert downstream["jiraOrchestration"]["task"] == {
                 "repository": "MoonLadderStudios/MoonMind",
                 "runtime": {"mode": "codex_cli"},
@@ -3107,7 +3108,6 @@ async def test_jira_breakdown_orchestrate_can_create_source_subtasks(
             assert jira_step["storyOutput"]["jira"] == {
                 "projectKey": "MM",
                 "issueTypeName": "Sub-task",
-                "boardId": "",
                 "sourceIssueKey": "MM-404",
                 "dependencyMode": "linear_blocker_chain",
             }
@@ -3149,6 +3149,7 @@ async def test_seed_catalog_includes_jira_breakdown_implement_preset(tmp_path):
                 scope_ref=None,
             )
 
+    assert template["title"] == "Breakdown and Jira Implement"
     assert "jira_board_id" not in {item["name"] for item in template["inputs"]}
     assert len(expanded["steps"]) == 5
     assert expanded["steps"][0]["tool"]["id"] == "jira.load_preset_brief"

--- a/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
+++ b/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
@@ -505,7 +505,6 @@ async def test_child_jira_breakdown_implement_expands_workflow_runtime_context(
                             "feature_request": "docs/Designs/RuntimeTypes.md",
                             "jira_project_key": "MM",
                             "jira_issue_type": "Story",
-                            "jira_board_id": "",
                             "jira_dependency_mode": "linear_blocker_chain",
                             "publish_mode": "pr_with_merge_automation",
                             "source_issue_key": "MM-404",
@@ -1434,7 +1433,7 @@ def test_runtime_planner_shares_story_breakdown_path_for_jira_breakdown_preset()
     plan = planner(
         inputs={
             "task": {
-                "title": "Jira Breakdown",
+                "title": "Breakdown and Jira Create",
                 "instructions": "Break down docs/Design.md into Jira stories.",
                 "runtime": {"mode": "codex_cli"},
                 "publish": {"mode": "pr"},
@@ -1476,7 +1475,9 @@ def test_runtime_planner_shares_story_breakdown_path_for_jira_breakdown_preset()
         breakdown["inputs"]["storyOutput"]["requiresStoryBreakdownArtifactRef"]
         is True
     )
-    assert breakdown["inputs"]["targetBranch"].startswith("jira-breakdown-")
+    assert breakdown["inputs"]["targetBranch"].startswith(
+        "breakdown-and-jira-create-"
+    )
     assert (
         jira["inputs"]["storyBreakdownPath"]
         == breakdown["inputs"]["storyBreakdownPath"]
@@ -1505,7 +1506,7 @@ def test_runtime_planner_preserves_step_story_output_without_task_story_output()
     plan = planner(
         inputs={
             "task": {
-                "title": "Jira Breakdown",
+                "title": "Breakdown and Jira Create",
                 "instructions": "Create Jira stories from a step-local config.",
                 "runtime": {"mode": "codex_cli"},
                 "publish": {"mode": "none"},
@@ -1660,7 +1661,7 @@ def test_runtime_planner_routes_jira_orchestrate_task_creator_as_skill_step():
     plan = planner(
         inputs={
             "task": {
-                "title": "Jira Breakdown and Orchestrate",
+                "title": "Breakdown and Jira Orchestrate",
                 "instructions": "Break down docs/Design.md into Jira stories.",
                 "runtime": {"mode": "codex_cli"},
                 "publish": {"mode": "none"},
@@ -1752,7 +1753,7 @@ def test_runtime_planner_routes_jira_implement_task_creator_as_skill_step():
     plan = planner(
         inputs={
             "task": {
-                "title": "Jira Breakdown and Implement",
+                "title": "Breakdown and Jira Implement",
                 "instructions": "Break down docs/Design.md into Jira stories.",
                 "runtime": {"mode": "codex_cli"},
                 "publish": {"mode": "none"},
@@ -1943,7 +1944,6 @@ def test_runtime_planner_dedupes_repeated_identical_preset_steps():
             "jira": {
                 "projectKey": "MM",
                 "issueTypeName": "Story",
-                "boardId": "15",
                 "dependencyMode": "linear_blocker_chain",
             },
         },
@@ -2403,7 +2403,7 @@ def test_runtime_planner_uses_branch_handoff_for_jira_output_when_task_publish_n
     plan = planner(
         inputs={
             "task": {
-                "title": "Jira Breakdown",
+                "title": "Breakdown and Jira Create",
                 "instructions": "Break down docs/Design.md into Jira stories.",
                 "runtime": {"mode": "codex_cli"},
                 "publish": {"mode": "none"},
@@ -2438,7 +2438,9 @@ def test_runtime_planner_uses_branch_handoff_for_jira_output_when_task_publish_n
 
     assert breakdown["inputs"]["storyOutput"]["mode"] == "jira"
     assert breakdown["inputs"]["publishMode"] == "branch"
-    assert breakdown["inputs"]["targetBranch"].startswith("jira-breakdown-")
+    assert breakdown["inputs"]["targetBranch"].startswith(
+        "breakdown-and-jira-create-"
+    )
     assert "commit your work" in breakdown["inputs"]["instructions"]
     assert jira["inputs"]["publishMode"] == "none"
     assert jira["inputs"]["storyOutput"]["mode"] == "jira"


### PR DESCRIPTION
Issue: MM-1066

Summary:
- Renamed the Jira breakdown presets to Breakdown and Jira Create, Breakdown and Jira Implement, and Breakdown and Jira Orchestrate.
- Removed Jira Board inputs, Selected Jira board copy, and storyOutput.jira.boardId from Jira breakdown create/orchestrate flows.
- Updated preset seeding and runtime planning tests to assert projectKey/issueTypeName-only Jira story output.

Tests run:
- MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/test_presets_service.py tests/unit/workflows/temporal/test_temporal_worker_runtime.py
- MOONMIND_FORCE_LOCAL_TESTS=1 python -m pytest tests/integration/test_startup_preset_seeding.py -q --tb=short

Remaining risks:
- Did not run the full compose-backed integration_ci suite; verification was focused on the changed preset seeding and runtime planning paths.
