### PR TITLE
The X button on the capabilities and images needs to be SMALLER. Particularly the outer border. It is too large vertically and horizontally in compari

### DIFF
--- a/frontend/src/entrypoints/dashboard-app.tsx
+++ b/frontend/src/entrypoints/dashboard-app.tsx
@@ -349,6 +349,7 @@ function DashboardNavigation({ uiInfo }: { uiInfo: DashboardUiInfo | null }) {
         >
           <NavLink
             to="/workflows"
+            end
             className={({ isActive }) => (isActive || isWorkflowDetail ? 'active' : undefined)}
           >
             <WorkflowsNavIcon className="route-nav-icon" />

--- a/frontend/src/entrypoints/dashboard.test.tsx
+++ b/frontend/src/entrypoints/dashboard.test.tsx
@@ -353,9 +353,11 @@ describe('Dashboard shared entry', () => {
     expect(await screen.findByText('Workflow start route loaded')).toBeTruthy();
     const shellPanel = document.querySelector('.panel');
     const startLink = screen.getByRole('link', { name: 'Start Workflow' });
+    const workflowsLink = screen.getByRole('link', { name: 'Workflows' });
     expect(startLink.getAttribute('aria-current')).toBe('page');
+    expect(workflowsLink.getAttribute('aria-current')).toBeNull();
 
-    fireEvent.click(screen.getByRole('link', { name: 'Workflows' }));
+    fireEvent.click(workflowsLink);
 
     expect(await screen.findByText('Workflow list route loaded')).toBeTruthy();
     expect(document.querySelector('.panel')).toBe(shellPanel);

--- a/frontend/src/entrypoints/workflow-start.test.tsx
+++ b/frontend/src/entrypoints/workflow-start.test.tsx
@@ -18293,10 +18293,10 @@ describe("Task Create MM-937 step hover containment", () => {
 
   it("keeps context chip remove buttons compact after the generic icon-button rules", () => {
     expect(dashboardCss).toMatch(
-      /\.queue-step-capability-chip\s+\.queue-step-capability-chip-remove,\s*\.queue-step-attachment-chip\s+\.queue-step-attachment-chip-remove\s*\{[^}]*width:\s*1rem;[^}]*height:\s*1rem;[^}]*box-shadow:\s*none;/s,
+      /\.queue-step-capability-chip\s+\.queue-step-capability-chip-remove,\s*\.queue-step-attachment-chip\s+\.queue-step-attachment-chip-remove\s*\{[^}]*width:\s*1rem;[^}]*height:\s*1rem;[^}]*background:\s*transparent;[^}]*border:\s*none;[^}]*padding:\s*0;[^}]*box-shadow:\s*none;/s,
     );
     expect(dashboardCss).toMatch(
-      /\.queue-step-capability-chip\s+\.queue-step-capability-chip-remove:hover,[^{]+\.queue-step-attachment-chip\s+\.queue-step-attachment-chip-remove\.is-clicked\s*\{[^}]*transform:\s*none;/s,
+      /\.queue-step-capability-chip\s+\.queue-step-capability-chip-remove:hover,[^{]+\.queue-step-attachment-chip\s+\.queue-step-attachment-chip-remove\.is-clicked\s*\{[^}]*background:\s*transparent;[^}]*border:\s*none;[^}]*box-shadow:\s*none;[^}]*transform:\s*none;[^}]*filter:\s*none;/s,
     );
   });
 

--- a/frontend/src/entrypoints/workflow-start.test.tsx
+++ b/frontend/src/entrypoints/workflow-start.test.tsx
@@ -18290,4 +18290,19 @@ describe("Task Create MM-937 step hover containment", () => {
       /\.queue-step-controls\s+\.queue-step-icon-button:last-child\s*\{[^}]*transform-origin:\s*right center;/s,
     );
   });
+
+  it("keeps context chip remove buttons compact after the generic icon-button rules", () => {
+    expect(dashboardCss).toMatch(
+      /\.queue-step-capability-chip\s+\.queue-step-capability-chip-remove,\s*\.queue-step-attachment-chip\s+\.queue-step-attachment-chip-remove\s*\{[^}]*width:\s*1rem;[^}]*height:\s*1rem;[^}]*box-shadow:\s*none;/s,
+    );
+    expect(dashboardCss).toMatch(
+      /\.queue-step-capability-chip\s+\.queue-step-capability-chip-remove:hover,[^{]+\.queue-step-attachment-chip\s+\.queue-step-attachment-chip-remove\.is-clicked\s*\{[^}]*transform:\s*none;/s,
+    );
+  });
+
+  it("keeps dependency remove buttons in a fixed right column beside wrapping text", () => {
+    expect(dashboardCss).toMatch(
+      /#queue-dependency-list\s+li\s*\{[^}]*display:\s*grid;[^}]*grid-template-columns:\s*minmax\(0,\s*1fr\)\s+auto;[^}]*align-items:\s*center;/s,
+    );
+  });
 });

--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -5084,6 +5084,13 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
   gap: 0.5rem;
 }
 
+#queue-dependency-list li {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  column-gap: 0.5rem;
+}
+
 :is(.queue-step-attachments-list, #queue-dependency-list) li > span:first-child {
   min-width: 0;
   overflow-wrap: anywhere;
@@ -6348,6 +6355,33 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
   box-shadow: none;
   transform: none;
   filter: none;
+}
+
+.queue-step-capability-chip .queue-step-capability-chip-remove,
+.queue-step-attachment-chip .queue-step-attachment-chip-remove {
+  flex: 0 0 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  height: 1rem;
+  border-radius: 999px;
+  background-image: none;
+  box-shadow: none;
+}
+
+.queue-step-capability-chip .queue-step-capability-chip-remove svg,
+.queue-step-attachment-chip .queue-step-attachment-chip-remove svg {
+  width: 0.56rem;
+  height: 0.56rem;
+  stroke-width: 2;
+}
+
+.queue-step-capability-chip .queue-step-capability-chip-remove:hover,
+.queue-step-capability-chip .queue-step-capability-chip-remove:active,
+.queue-step-capability-chip .queue-step-capability-chip-remove.is-clicked,
+.queue-step-attachment-chip .queue-step-attachment-chip-remove:hover,
+.queue-step-attachment-chip .queue-step-attachment-chip-remove:active,
+.queue-step-attachment-chip .queue-step-attachment-chip-remove.is-clicked {
+  transform: none;
 }
 
 .sr-only {

--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -6364,7 +6364,10 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
   min-width: 1rem;
   height: 1rem;
   border-radius: 999px;
+  background: transparent;
   background-image: none;
+  border: none;
+  padding: 0;
   box-shadow: none;
 }
 
@@ -6381,7 +6384,12 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
 .queue-step-attachment-chip .queue-step-attachment-chip-remove:hover,
 .queue-step-attachment-chip .queue-step-attachment-chip-remove:active,
 .queue-step-attachment-chip .queue-step-attachment-chip-remove.is-clicked {
+  background: transparent;
+  background-image: none;
+  border: none;
+  box-shadow: none;
   transform: none;
+  filter: none;
 }
 
 .sr-only {


### PR DESCRIPTION
The X button on the capabilities and images needs to be SMALLER. Particularly the outer border. It is too large vertically and horizontally in comparison to the text. This is the third time I'm asking for this change so not sure what is going on and why it's not changing. make sure that your change actually works since the last two attempts failed.

Additionally, I want the dependencies which get added to have an X that remains to the right of the dependency text without wrapping down to its own line. The dependency text should wrap early so that the X does not get pushed down to a new line. The X should remain centered vertically to the right of the dependency text.

Lastly when I select Start Workflow, I see a fat purple underline for both Workflows AND Start Workflow. It should only be under Start Workflow in this case.