### PR TITLE
MM-1067 Add GitHub Issue Orchestrate preset

### DIFF
--- a/api_service/data/presets/github-issue-orchestrate.yaml
+++ b/api_service/data/presets/github-issue-orchestrate.yaml
@@ -1,0 +1,858 @@
+slug: github-issue-orchestrate
+title: GitHub Issue Orchestrate
+description: Move a GitHub issue through the full MoonSpec lifecycle by using its trusted
+  issue brief as orchestration input, creating a PR, and updating GitHub issue status.
+scope: global
+tags:
+- github
+- moonspec
+- orchestration
+- pull-request
+requiredCapabilities:
+- git
+- gh
+annotations:
+  sourceSkill: moonspec-orchestrate
+  githubIssueWorkflow: implementation-to-code-review
+  output: pull-request
+  issueInput:
+    provider: github
+    objectInput: github_issue
+    refInput: github_issue_ref
+    refTemplate: '{{ repository }}#{{ number }}'
+  githubIssueUpdate:
+    inProgress:
+      comment: true
+      labelsToAdd:
+      - 'status: in-progress'
+      labelsToRemove:
+      - 'status: todo'
+    codeReview:
+      commentPullRequestUrl: true
+      labelsToAdd:
+      - 'status: code-review'
+      labelsToRemove:
+      - 'status: in-progress'
+    done:
+      closeIssue: true
+      labelsToAdd:
+      - 'status: done'
+      labelsToRemove:
+      - 'status: code-review'
+  inputSchema:
+    type: object
+    required:
+    - github_issue
+    properties:
+      github_issue:
+        type: object
+        title: GitHub issue
+        description: Issue that will seed the task instructions and orchestration context.
+        required:
+        - repository
+        - number
+        properties:
+          repository:
+            type: string
+            title: Repository
+          number:
+            type: integer
+            title: Issue number
+          title:
+            type: string
+          body:
+            type: string
+          url:
+            type: string
+            format: uri
+          state:
+            type: string
+          labels:
+            type: array
+            items:
+              type: string
+  uiSchema:
+    github_issue:
+      widget: github.issue-picker
+      dataSource: github.issues
+      searchPlaceholder: Search GitHub issues
+      allowManualIssueEntry: true
+  defaults: {}
+  jiraIssue: MM-1067
+  sourceReference: MM-1063
+inputs:
+- name: github_issue_ref
+  label: GitHub Issue Reference
+  type: text
+  required: false
+  default: ''
+- name: source_design_path
+  label: Source Design Path
+  type: text
+  required: false
+  default: ''
+- name: constraints
+  label: Constraints
+  type: textarea
+  required: false
+  default: ''
+steps:
+- title: Load GitHub issue brief
+  type: tool
+  instructions: 'Fetch GitHub issue {{ inputs.github_issue.repository }}#{{ inputs.github_issue.number
+    }} through the deterministic trusted GitHub tool surface.
+
+
+    Build the canonical MoonSpec orchestration input from the issue title, body, labels, state,
+    URL, and any acceptance criteria in the issue body. Preserve the repository and issue
+    number in the brief so downstream spec artifacts and the pull request can reference {{
+    inputs.github_issue.repository }}#{{ inputs.github_issue.number }}.'
+  tool:
+    id: github.load_issue_preset_brief
+    requiredCapabilities:
+    - gh
+    inputs:
+      repository: '{{ inputs.github_issue.repository }}'
+      issueNumber: '{{ inputs.github_issue.number }}'
+- kind: include
+  slug: issue-implement-assessment
+  alias: assess
+  scope: global
+  inputMapping:
+    issue_provider: github
+    issue_ref: '{{ inputs.github_issue.repository }}#{{ inputs.github_issue.number }}'
+    issue_url: '{{ inputs.github_issue.url | default('''') }}'
+    brief_artifact_path: artifacts/github-issue-orchestrate-brief.json
+    assessment_artifact_path: artifacts/github-issue-orchestrate-assessment.json
+- title: Check GitHub issue blockers before orchestration
+  type: tool
+  instructions: 'Read artifacts/github-issue-orchestrate-assessment.json (or the recorded
+    verdict from the assess step) before applying blocker results.
+
+
+    Check GitHub issue {{ inputs.github_issue.repository }}#{{ inputs.github_issue.number
+    }} through the deterministic trusted GitHub blocker preflight before any MoonSpec orchestration
+    work starts. For this first version, treat explicit blocking labels or a known blocker
+    section in the issue body as blocker evidence.
+
+
+    If the recorded verdict is FULLY_IMPLEMENTED, report blocker findings for the record but
+    do not stop finalization. Otherwise, if unresolved blockers are detected or blocker evidence
+    cannot be evaluated from trusted GitHub data, stop orchestration and report the blocker
+    details. Do not use raw GitHub credentials, web scraping, or prompt text alone to decide
+    blocker state.'
+  tool:
+    id: github.check_issue_blockers
+    requiredCapabilities:
+    - gh
+    inputs:
+      repository: '{{ inputs.github_issue.repository }}'
+      issueNumber: '{{ inputs.github_issue.number }}'
+- title: Mark GitHub issue In Progress
+  type: tool
+  instructions: 'Read artifacts/github-issue-orchestrate-assessment.json (or the recorded
+    verdict from the assess step) before changing GitHub.
+
+
+    If the recorded verdict is FULLY_IMPLEMENTED, skip the In Progress update because the
+    issue is already implemented. If the recorded verdict is BLOCKED, stop without changing
+    GitHub. Otherwise mark GitHub issue {{ inputs.github_issue.repository }}#{{ inputs.github_issue.number
+    }} as In Progress using the configured GitHub issue update strategy.'
+  tool:
+    id: github.update_issue_status
+    requiredCapabilities:
+    - gh
+    inputs:
+      repository: '{{ inputs.github_issue.repository }}'
+      issueNumber: '{{ inputs.github_issue.number }}'
+      targetStatus: In Progress
+      mode: start
+- title: Classify request and resume point
+  instructions: 'Use the GitHub issue preset brief for {{ inputs.github_issue.repository }}#{{
+    inputs.github_issue.number }} as the canonical Moon Spec orchestration input.
+
+
+    Additional constraints:
+
+    {{ inputs.constraints }}
+
+
+    GitHub Issue Orchestrate always runs as a runtime implementation workflow. If artifacts/github-issue-orchestrate-assessment.json
+    records FULLY_IMPLEMENTED, skip MoonSpec artifact generation and implementation work and
+    preserve that no-code-change result for final GitHub status update.
+
+    If the brief points at an implementation document, treat it as runtime source requirements.
+
+    Source design path (optional): {{ inputs.source_design_path }}.
+
+
+    Classify the input as a single-story feature request, broad technical or declarative design,
+    or existing feature directory.
+
+    Inspect existing Moon Spec artifacts and resume from the first incomplete stage instead
+    of regenerating valid later-stage artifacts.'
+  skill:
+    id: auto
+    args: {}
+- title: Create or select Moon Spec
+  instructions: 'For a single-story GitHub issue preset brief, run moonspec-specify unless
+    an active spec.md already passes the specify gate.
+
+    For a broad technical or declarative design, run moonspec-breakdown first, then select
+    the recommended first generated spec unless the issue brief explicitly requires processing
+    all specs.
+
+    Preserve GitHub issue {{ inputs.github_issue.repository }}#{{ inputs.github_issue.number
+    }} and the original preset brief in spec.md so final verification can compare against
+    them.'
+  skill:
+    id: moonspec-specify
+    args: {}
+- title: Split broad designs when needed
+  instructions: 'Run moonspec-breakdown only when the GitHub issue preset brief is a broad
+    technical or declarative design with multiple independently testable stories.
+
+    Keep each generated spec isolated and process specs in dependency order when multiple
+    specs are required by {{ inputs.github_issue.repository }}#{{ inputs.github_issue.number
+    }}.'
+  skill:
+    id: auto
+    args: {}
+- title: Plan selected spec
+  instructions: 'Run moonspec-plan when plan.md or required design artifacts are missing or
+    stale.
+
+    Verify that plan.md, research.md, quickstart.md, and any required data model or contracts
+    exist before continuing.
+
+    Keep unit and integration test strategies explicit.'
+  skill:
+    id: moonspec-plan
+    args: {}
+- title: Generate TDD task breakdown
+  instructions: 'Run moonspec-tasks when tasks.md is missing or upstream artifacts changed.
+
+    Verify tasks.md covers exactly one story and includes red-first unit tests, integration
+    tests, implementation tasks, story validation, and final /moonspec-verify work.'
+  skill:
+    id: moonspec-tasks
+    args: {}
+- title: Align Moon Spec artifacts
+  instructions: 'Run moonspec-align after task generation.
+
+    Let moonspec-align analyze and remediate artifact drift conservatively without manual
+    analyze prompts, scripted user approvals, or extra Prompt A/Prompt B loops.
+
+    If alignment changes spec.md, plan.md, design artifacts, or tasks.md, re-check the downstream
+    gates and regenerate only artifacts that are now stale.'
+  skill:
+    id: moonspec-align
+    args: {}
+- title: Implement the task breakdown
+  instructions: '/clear
+
+
+    Read artifacts/github-issue-orchestrate-assessment.json before doing any work. If it records
+    FULLY_IMPLEMENTED, make no code changes and report implementation as already satisfied.
+    Otherwise run moonspec-implement when implementation work remains.
+
+    Require TDD evidence: unit and integration tests are written and confirmed failing before
+    production code.
+
+    Mark completed tasks [X] in tasks.md and preserve the selected story scope.'
+  skill:
+    id: moonspec-implement
+    args: {}
+    requiredCapabilities:
+    - git
+- title: Verify completion
+  instructions: '/clear
+
+
+    Read artifacts/github-issue-orchestrate-assessment.json before doing anything. If it records
+    FULLY_IMPLEMENTED and no MoonSpec implementation work ran, report verification as already
+    satisfied by the initial assessment and skip rerunning verification. Otherwise run moonspec-verify
+    as the final read-only gate unless an up-to-date verification report already covers the
+    current code and artifacts.
+
+    If the verdict is ADDITIONAL_WORK_NEEDED, preserve the report as the mandatory remediation
+    input for the next step.
+
+    If the verdict is NO_DETERMINATION, stop and report the missing evidence, commands, or
+    context. If the verdict is BLOCKED, FAILED_UNRECOVERABLE, or ENVIRONMENT_CONTAMINATED_BY_SKILL_PROJECTION,
+    classify it as an environment or setup failure when the verifier identifies missing runtime
+    infrastructure, stop immediately, skip all remediation attempts, and do not create a pull
+    request.
+
+    Do not create a pull request from this step. Pull request creation is allowed only after
+    the post-remediation verification step reports FULLY_IMPLEMENTED.'
+  skill:
+    id: moonspec-verify
+    args: {}
+- title: Remediate verification gaps 1 of 6
+  annotations:
+    jiraOrchestrateRole: moonspec-remediation
+    moonSpecRemediationAttempt: 1
+    moonSpecRemediationMaxAttempts: 6
+  instructions: '/clear
+
+
+    Inspect the latest moonspec-verify result for {{ inputs.github_issue.repository }}#{{
+    inputs.github_issue.number }} before doing any work. This is remediation attempt 1 of
+    6.
+
+
+    If the latest verdict is FULLY_IMPLEMENTED, make no code changes and report that remediation
+    is skipped because verification already passed.
+
+
+    If the latest verdict is ADDITIONAL_WORK_NEEDED, treat the verification report''s gaps
+    and remaining work as the authoritative bounded implementation backlog. Run moonspec-implement
+    to fix the reported implementation or validation gaps, update tasks.md only for work actually
+    completed, and run the focused unit or integration checks named by the verification report
+    when feasible.
+
+
+    If the latest verdict is NO_DETERMINATION, only proceed when the missing evidence is recoverable
+    in this runtime, such as by running a skipped command or inspecting available files. Otherwise
+    stop and report the exact blocker. If the latest verdict is BLOCKED, FAILED_UNRECOVERABLE,
+    or ENVIRONMENT_CONTAMINATED_BY_SKILL_PROJECTION, treat it as terminal for GitHub Issue
+    Orchestrate remediation, classify runtime or infrastructure causes as environment failure,
+    skip every remaining remediation attempt, and do not create a pull request.
+
+
+    Do not broaden the selected story scope, do not create a pull request, and do not update
+    GitHub issue status during remediation.'
+  skill:
+    id: moonspec-implement
+    args: {}
+    requiredCapabilities:
+    - git
+- title: Verify remediation 1 of 6
+  annotations:
+    jiraOrchestrateRole: moonspec-verification-gate
+    moonSpecRemediationAttempt: 1
+    moonSpecRemediationMaxAttempts: 6
+    moonSpecFinalRemediationGate: false
+  instructions: '/clear
+
+
+    Run moonspec-verify after remediation attempt 1, even when remediation was skipped because
+    the prior verdict was FULLY_IMPLEMENTED.
+
+
+    If the verdict is ADDITIONAL_WORK_NEEDED and another remediation attempt remains, preserve
+    the verification report as the mandatory input for the next remediation attempt.
+
+    If the verdict is NO_DETERMINATION, stop and report the missing evidence, commands, or
+    context unless the missing evidence is recoverable in the current runtime by the next
+    remediation attempt. If the verdict is BLOCKED, FAILED_UNRECOVERABLE, or ENVIRONMENT_CONTAMINATED_BY_SKILL_PROJECTION,
+    treat it as terminal, classify runtime or infrastructure causes as environment failure,
+    skip every remaining remediation attempt, and do not create a pull request.
+
+
+    Continue toward pull request creation only when the latest post-remediation verdict is
+    FULLY_IMPLEMENTED.'
+  skill:
+    id: moonspec-verify
+    args: {}
+- title: Remediate verification gaps 2 of 6
+  annotations:
+    jiraOrchestrateRole: moonspec-remediation
+    moonSpecRemediationAttempt: 2
+    moonSpecRemediationMaxAttempts: 6
+  instructions: '/clear
+
+
+    Inspect the latest moonspec-verify result for {{ inputs.github_issue.repository }}#{{
+    inputs.github_issue.number }} before doing any work. This is remediation attempt 2 of
+    6.
+
+
+    If the latest verdict is FULLY_IMPLEMENTED, make no code changes and report that remediation
+    is skipped because verification already passed.
+
+
+    If the latest verdict is ADDITIONAL_WORK_NEEDED, treat the verification report''s gaps
+    and remaining work as the authoritative bounded implementation backlog. Run moonspec-implement
+    to fix the reported implementation or validation gaps, update tasks.md only for work actually
+    completed, and run the focused unit or integration checks named by the verification report
+    when feasible.
+
+
+    If the latest verdict is NO_DETERMINATION, only proceed when the missing evidence is recoverable
+    in this runtime, such as by running a skipped command or inspecting available files. Otherwise
+    stop and report the exact blocker. If the latest verdict is BLOCKED, FAILED_UNRECOVERABLE,
+    or ENVIRONMENT_CONTAMINATED_BY_SKILL_PROJECTION, treat it as terminal for GitHub Issue
+    Orchestrate remediation, classify runtime or infrastructure causes as environment failure,
+    skip every remaining remediation attempt, and do not create a pull request.
+
+
+    Do not broaden the selected story scope, do not create a pull request, and do not update
+    GitHub issue status during remediation.'
+  skill:
+    id: moonspec-implement
+    args: {}
+    requiredCapabilities:
+    - git
+- title: Verify remediation 2 of 6
+  annotations:
+    jiraOrchestrateRole: moonspec-verification-gate
+    moonSpecRemediationAttempt: 2
+    moonSpecRemediationMaxAttempts: 6
+    moonSpecFinalRemediationGate: false
+  instructions: '/clear
+
+
+    Run moonspec-verify after remediation attempt 2, even when remediation was skipped because
+    the prior verdict was FULLY_IMPLEMENTED.
+
+
+    If the verdict is ADDITIONAL_WORK_NEEDED and another remediation attempt remains, preserve
+    the verification report as the mandatory input for the next remediation attempt.
+
+    If the verdict is NO_DETERMINATION, stop and report the missing evidence, commands, or
+    context unless the missing evidence is recoverable in the current runtime by the next
+    remediation attempt. If the verdict is BLOCKED, FAILED_UNRECOVERABLE, or ENVIRONMENT_CONTAMINATED_BY_SKILL_PROJECTION,
+    treat it as terminal, classify runtime or infrastructure causes as environment failure,
+    skip every remaining remediation attempt, and do not create a pull request.
+
+
+    Continue toward pull request creation only when the latest post-remediation verdict is
+    FULLY_IMPLEMENTED.'
+  skill:
+    id: moonspec-verify
+    args: {}
+- title: Remediate verification gaps 3 of 6
+  annotations:
+    jiraOrchestrateRole: moonspec-remediation
+    moonSpecRemediationAttempt: 3
+    moonSpecRemediationMaxAttempts: 6
+  instructions: '/clear
+
+
+    Inspect the latest moonspec-verify result for {{ inputs.github_issue.repository }}#{{
+    inputs.github_issue.number }} before doing any work. This is remediation attempt 3 of
+    6.
+
+
+    If the latest verdict is FULLY_IMPLEMENTED, make no code changes and report that remediation
+    is skipped because verification already passed.
+
+
+    If the latest verdict is ADDITIONAL_WORK_NEEDED, treat the verification report''s gaps
+    and remaining work as the authoritative bounded implementation backlog. Run moonspec-implement
+    to fix the reported implementation or validation gaps, update tasks.md only for work actually
+    completed, and run the focused unit or integration checks named by the verification report
+    when feasible.
+
+
+    If the latest verdict is NO_DETERMINATION, only proceed when the missing evidence is recoverable
+    in this runtime, such as by running a skipped command or inspecting available files. Otherwise
+    stop and report the exact blocker. If the latest verdict is BLOCKED, FAILED_UNRECOVERABLE,
+    or ENVIRONMENT_CONTAMINATED_BY_SKILL_PROJECTION, treat it as terminal for GitHub Issue
+    Orchestrate remediation, classify runtime or infrastructure causes as environment failure,
+    skip every remaining remediation attempt, and do not create a pull request.
+
+
+    Do not broaden the selected story scope, do not create a pull request, and do not update
+    GitHub issue status during remediation.'
+  skill:
+    id: moonspec-implement
+    args: {}
+    requiredCapabilities:
+    - git
+- title: Verify remediation 3 of 6
+  annotations:
+    jiraOrchestrateRole: moonspec-verification-gate
+    moonSpecRemediationAttempt: 3
+    moonSpecRemediationMaxAttempts: 6
+    moonSpecFinalRemediationGate: false
+  instructions: '/clear
+
+
+    Run moonspec-verify after remediation attempt 3, even when remediation was skipped because
+    the prior verdict was FULLY_IMPLEMENTED.
+
+
+    If the verdict is ADDITIONAL_WORK_NEEDED and another remediation attempt remains, preserve
+    the verification report as the mandatory input for the next remediation attempt.
+
+    If the verdict is NO_DETERMINATION, stop and report the missing evidence, commands, or
+    context unless the missing evidence is recoverable in the current runtime by the next
+    remediation attempt. If the verdict is BLOCKED, FAILED_UNRECOVERABLE, or ENVIRONMENT_CONTAMINATED_BY_SKILL_PROJECTION,
+    treat it as terminal, classify runtime or infrastructure causes as environment failure,
+    skip every remaining remediation attempt, and do not create a pull request.
+
+
+    Continue toward pull request creation only when the latest post-remediation verdict is
+    FULLY_IMPLEMENTED.'
+  skill:
+    id: moonspec-verify
+    args: {}
+- title: Remediate verification gaps 4 of 6
+  annotations:
+    jiraOrchestrateRole: moonspec-remediation
+    moonSpecRemediationAttempt: 4
+    moonSpecRemediationMaxAttempts: 6
+  instructions: '/clear
+
+
+    Inspect the latest moonspec-verify result for {{ inputs.github_issue.repository }}#{{
+    inputs.github_issue.number }} before doing any work. This is remediation attempt 4 of
+    6.
+
+
+    If the latest verdict is FULLY_IMPLEMENTED, make no code changes and report that remediation
+    is skipped because verification already passed.
+
+
+    If the latest verdict is ADDITIONAL_WORK_NEEDED, treat the verification report''s gaps
+    and remaining work as the authoritative bounded implementation backlog. Run moonspec-implement
+    to fix the reported implementation or validation gaps, update tasks.md only for work actually
+    completed, and run the focused unit or integration checks named by the verification report
+    when feasible.
+
+
+    If the latest verdict is NO_DETERMINATION, only proceed when the missing evidence is recoverable
+    in this runtime, such as by running a skipped command or inspecting available files. Otherwise
+    stop and report the exact blocker. If the latest verdict is BLOCKED, FAILED_UNRECOVERABLE,
+    or ENVIRONMENT_CONTAMINATED_BY_SKILL_PROJECTION, treat it as terminal for GitHub Issue
+    Orchestrate remediation, classify runtime or infrastructure causes as environment failure,
+    skip every remaining remediation attempt, and do not create a pull request.
+
+
+    Do not broaden the selected story scope, do not create a pull request, and do not update
+    GitHub issue status during remediation.'
+  skill:
+    id: moonspec-implement
+    args: {}
+    requiredCapabilities:
+    - git
+- title: Verify remediation 4 of 6
+  annotations:
+    jiraOrchestrateRole: moonspec-verification-gate
+    moonSpecRemediationAttempt: 4
+    moonSpecRemediationMaxAttempts: 6
+    moonSpecFinalRemediationGate: false
+  instructions: '/clear
+
+
+    Run moonspec-verify after remediation attempt 4, even when remediation was skipped because
+    the prior verdict was FULLY_IMPLEMENTED.
+
+
+    If the verdict is ADDITIONAL_WORK_NEEDED and another remediation attempt remains, preserve
+    the verification report as the mandatory input for the next remediation attempt.
+
+    If the verdict is NO_DETERMINATION, stop and report the missing evidence, commands, or
+    context unless the missing evidence is recoverable in the current runtime by the next
+    remediation attempt. If the verdict is BLOCKED, FAILED_UNRECOVERABLE, or ENVIRONMENT_CONTAMINATED_BY_SKILL_PROJECTION,
+    treat it as terminal, classify runtime or infrastructure causes as environment failure,
+    skip every remaining remediation attempt, and do not create a pull request.
+
+
+    Continue toward pull request creation only when the latest post-remediation verdict is
+    FULLY_IMPLEMENTED.'
+  skill:
+    id: moonspec-verify
+    args: {}
+- title: Remediate verification gaps 5 of 6
+  annotations:
+    jiraOrchestrateRole: moonspec-remediation
+    moonSpecRemediationAttempt: 5
+    moonSpecRemediationMaxAttempts: 6
+  instructions: '/clear
+
+
+    Inspect the latest moonspec-verify result for {{ inputs.github_issue.repository }}#{{
+    inputs.github_issue.number }} before doing any work. This is remediation attempt 5 of
+    6.
+
+
+    If the latest verdict is FULLY_IMPLEMENTED, make no code changes and report that remediation
+    is skipped because verification already passed.
+
+
+    If the latest verdict is ADDITIONAL_WORK_NEEDED, treat the verification report''s gaps
+    and remaining work as the authoritative bounded implementation backlog. Run moonspec-implement
+    to fix the reported implementation or validation gaps, update tasks.md only for work actually
+    completed, and run the focused unit or integration checks named by the verification report
+    when feasible.
+
+
+    If the latest verdict is NO_DETERMINATION, only proceed when the missing evidence is recoverable
+    in this runtime, such as by running a skipped command or inspecting available files. Otherwise
+    stop and report the exact blocker. If the latest verdict is BLOCKED, FAILED_UNRECOVERABLE,
+    or ENVIRONMENT_CONTAMINATED_BY_SKILL_PROJECTION, treat it as terminal for GitHub Issue
+    Orchestrate remediation, classify runtime or infrastructure causes as environment failure,
+    skip every remaining remediation attempt, and do not create a pull request.
+
+
+    Do not broaden the selected story scope, do not create a pull request, and do not update
+    GitHub issue status during remediation.'
+  skill:
+    id: moonspec-implement
+    args: {}
+    requiredCapabilities:
+    - git
+- title: Verify remediation 5 of 6
+  annotations:
+    jiraOrchestrateRole: moonspec-verification-gate
+    moonSpecRemediationAttempt: 5
+    moonSpecRemediationMaxAttempts: 6
+    moonSpecFinalRemediationGate: false
+  instructions: '/clear
+
+
+    Run moonspec-verify after remediation attempt 5, even when remediation was skipped because
+    the prior verdict was FULLY_IMPLEMENTED.
+
+
+    If the verdict is ADDITIONAL_WORK_NEEDED and another remediation attempt remains, preserve
+    the verification report as the mandatory input for the next remediation attempt.
+
+    If the verdict is NO_DETERMINATION, stop and report the missing evidence, commands, or
+    context unless the missing evidence is recoverable in the current runtime by the next
+    remediation attempt. If the verdict is BLOCKED, FAILED_UNRECOVERABLE, or ENVIRONMENT_CONTAMINATED_BY_SKILL_PROJECTION,
+    treat it as terminal, classify runtime or infrastructure causes as environment failure,
+    skip every remaining remediation attempt, and do not create a pull request.
+
+
+    Continue toward pull request creation only when the latest post-remediation verdict is
+    FULLY_IMPLEMENTED.'
+  skill:
+    id: moonspec-verify
+    args: {}
+- title: Remediate verification gaps 6 of 6
+  annotations:
+    jiraOrchestrateRole: moonspec-remediation
+    moonSpecRemediationAttempt: 6
+    moonSpecRemediationMaxAttempts: 6
+  instructions: '/clear
+
+
+    Inspect the latest moonspec-verify result for {{ inputs.github_issue.repository }}#{{
+    inputs.github_issue.number }} before doing any work. This is remediation attempt 6 of
+    6.
+
+
+    If the latest verdict is FULLY_IMPLEMENTED, make no code changes and report that remediation
+    is skipped because verification already passed.
+
+
+    If the latest verdict is ADDITIONAL_WORK_NEEDED, treat the verification report''s gaps
+    and remaining work as the authoritative bounded implementation backlog. Run moonspec-implement
+    to fix the reported implementation or validation gaps, update tasks.md only for work actually
+    completed, and run the focused unit or integration checks named by the verification report
+    when feasible.
+
+
+    If the latest verdict is NO_DETERMINATION, only proceed when the missing evidence is recoverable
+    in this runtime, such as by running a skipped command or inspecting available files. Otherwise
+    stop and report the exact blocker. If the latest verdict is BLOCKED, FAILED_UNRECOVERABLE,
+    or ENVIRONMENT_CONTAMINATED_BY_SKILL_PROJECTION, treat it as terminal for GitHub Issue
+    Orchestrate remediation, classify runtime or infrastructure causes as environment failure,
+    skip every remaining remediation attempt, and do not create a pull request.
+
+
+    Do not broaden the selected story scope, do not create a pull request, and do not update
+    GitHub issue status during remediation.'
+  skill:
+    id: moonspec-implement
+    args: {}
+    requiredCapabilities:
+    - git
+- title: Verify remediation 6 of 6
+  annotations:
+    jiraOrchestrateRole: moonspec-verification-gate
+    moonSpecRemediationAttempt: 6
+    moonSpecRemediationMaxAttempts: 6
+    moonSpecFinalRemediationGate: true
+  instructions: '/clear
+
+
+    Run moonspec-verify after remediation attempt 6, even when remediation was skipped because
+    the prior verdict was FULLY_IMPLEMENTED.
+
+
+    This is the controlling verification gate for GitHub Issue Orchestrate publication. If
+    the verdict is ADDITIONAL_WORK_NEEDED or NO_DETERMINATION, the remediation budget is exhausted:
+    stop the orchestration, report the gaps or missing evidence, and do not continue to pull
+    request creation. If the verdict is BLOCKED, FAILED_UNRECOVERABLE, or ENVIRONMENT_CONTAMINATED_BY_SKILL_PROJECTION,
+    classify runtime or infrastructure causes as environment failure, stop immediately, and
+    do not create a pull request.
+
+
+    Continue to pull request creation only when this post-remediation verdict is FULLY_IMPLEMENTED.'
+  skill:
+    id: moonspec-verify
+    args: {}
+- title: Reconcile declarative docs
+  annotations:
+    jiraOrchestrateRole: doc-reconciliation
+  instructions: '/clear
+
+
+    Run moonspec-doc-reconcile for {{ inputs.github_issue.repository }}#{{ inputs.github_issue.number
+    }} only when the controlling post-remediation verdict is FULLY_IMPLEMENTED. If artifacts/github-issue-orchestrate-assessment.json
+    records FULLY_IMPLEMENTED and no MoonSpec verification gate ran, skip doc reconciliation
+    because there is no new implementation discovery to reconcile. If the latest verdict is
+    not FULLY_IMPLEMENTED, make no changes and report that doc reconciliation is skipped because
+    publication is already blocked.
+
+
+    Use the canonical source document recorded in spec.md (Source Document){% if inputs.source_design_path
+    %} or the provided source design path {{ inputs.source_design_path }}{% endif %} as the
+    starting authority candidate. Reconcile by authority scope, not original-source convenience:
+    apply docs/Workflows/MoonSpecDocumentModel.md plus the docs/DocumentationArchitecture.md
+    authority ladder and module-owned contract policy to identify the canonical document that
+    owns each affected claim. The owning canonical doc may be different from the original
+    source doc. If no canonical source candidate under docs/ exists, write the structured
+    no_update_required outcome and continue.
+
+
+    Consume the latest moonspec-verify report, including its Source Document Drift section,
+    plus artifacts/doc-discoveries/<feature>.json when present. Apply the moonspec-doc-reconcile
+    update gate strictly: edit canonical docs only for definite, evidence-backed discoveries
+    showing the document is functionally wrong, internally inconsistent, or correctly diverged
+    from for verified best-practice reasons. Otherwise report no_update_required; a no-op
+    outcome is a correct result.
+
+
+    If a required update conflicts with the constitution, README, Document Model, Documentation
+    Architecture Standard, module-owned contract policy, or architecture direction, or if
+    ownership is ambiguous between multiple canonical documents, do not edit the document;
+    create the GitHub follow-up issue per the skill and continue. Escalation does not block
+    pull request creation.
+
+
+    Write the structured outcome to artifacts/github-issue-orchestrate-doc-reconcile.json
+    with keys action, docPaths, updated, noUpdateRequired, escalated, gateRationale, evidence,
+    and githubIssue when escalated. Every updated/noUpdateRequired/escalated item must include
+    a reason. Do not commit, push, or create a pull request from this step; any canonical
+    doc edits remain in the working tree so the pull request step publishes them together
+    with the implementation.'
+  skill:
+    id: moonspec-doc-reconcile
+    args: {}
+    requiredCapabilities:
+    - git
+- title: Create pull request
+  annotations:
+    jiraOrchestrateRole: pull-request-handoff
+  instructions: '/clear
+
+
+    Read artifacts/github-issue-orchestrate-assessment.json (or the recorded verdict from
+    the assess step) before doing anything.
+
+
+    If the recorded verdict is FULLY_IMPLEMENTED and no MoonSpec implementation work ran,
+    skip pull request creation entirely and report it as skipped because there is nothing
+    new to publish. Do not write artifacts/github-issue-orchestrate-pr.json in this case.
+    The final step will apply the configured Done strategy.
+
+
+    Otherwise create a pull request for the completed work for GitHub issue {{ inputs.github_issue.repository
+    }}#{{ inputs.github_issue.number }}.
+
+
+    Before committing, inspect the latest post-remediation moonspec-verify result and confirm
+    the verdict is FULLY_IMPLEMENTED. If the latest verdict is ADDITIONAL_WORK_NEEDED, NO_DETERMINATION,
+    BLOCKED, FAILED_UNRECOVERABLE, or ENVIRONMENT_CONTAMINATED_BY_SKILL_PROJECTION, stop without
+    committing, pushing, creating a pull request, or changing GitHub issue status. Classify
+    runtime or infrastructure causes as environment failure.
+
+
+    This GitHub Issue Orchestrate handoff step is the explicit PR-publication step for this
+    preset. It intentionally owns pull request creation before the GitHub Code Review status
+    update so the confirmed pull request URL is available to both GitHub issue lifecycle handling
+    and MoonMind publish handling. If generic managed-runtime guidance says not to push or
+    create a pull request, treat this step-specific handoff instruction as the controlling
+    instruction for this step only. If the task is submitted with PR merge automation enabled,
+    the parent workflow must use the pull request URL produced by this step as the published
+    PR and then run merge automation against that PR. If the runtime instructions, task parameters,
+    authentication, remote configuration, branch protection, or repository permissions prevent
+    committing, pushing, or creating the pull request in this step, stop before changing GitHub
+    issue status to Code Review and report the exact blocker.
+
+
+    First confirm the working tree contains only intentional changes for {{ inputs.github_issue.repository
+    }}#{{ inputs.github_issue.number }} and no raw credentials. Commit the work with a concise
+    message that includes {{ inputs.github_issue.repository }}#{{ inputs.github_issue.number
+    }}. Push the current non-protected work branch and create a non-draft pull request with
+    the available authenticated GitHub tooling.
+
+
+    The pull request must be ready for review, not a draft. Do not pass draft flags when creating
+    it. If the available tool or repository default creates a draft pull request, immediately
+    mark it ready for review and verify the final pull request isDraft value is false before
+    continuing.
+
+
+    The pull request title must include {{ inputs.github_issue.repository }}#{{ inputs.github_issue.number
+    }}. The pull request body must include:
+
+    - the GitHub issue reference
+
+    - the active MoonSpec feature path
+
+    - verification verdict
+
+    - tests run
+
+    - remaining risks
+
+    - the doc reconciliation outcome from artifacts/github-issue-orchestrate-doc-reconcile.json
+    when present: updated canonical doc paths, the no-update rationale, or the escalation
+    issue reference
+
+    - a Documentation Conformance section listing canonical sources, temporary artifacts consulted,
+    claim coverage, and reconciliation outcomes
+
+
+    Canonical doc edits produced by the doc reconciliation step are intentional changes for
+    this issue and must be committed in the same pull request.
+
+
+    After creation and non-draft verification, record the confirmed pull request URL in the
+    step result and in a local handoff artifact at artifacts/github-issue-orchestrate-pr.json
+    with keys issue_provider, issue_ref, repository, issue_number, and pull_request_url. Do
+    not continue unless the pull_request_url is a GitHub pull request URL for the current
+    work branch and the pull request is confirmed non-draft.'
+  skill:
+    id: auto
+    args: {}
+    requiredCapabilities:
+    - git
+- title: Finalize GitHub issue status
+  type: tool
+  annotations:
+    jiraOrchestrateRole: code-review-handoff
+  instructions: 'Read artifacts/github-issue-orchestrate-assessment.json (or the recorded
+    verdict from the assess step) before changing GitHub.
+
+
+    If the recorded verdict is BLOCKED, stop without changing GitHub and report the blocking
+    evidence. If the recorded verdict is FULLY_IMPLEMENTED and no code changes were made,
+    apply the configured Done strategy.
+
+
+    Otherwise read artifacts/github-issue-orchestrate-pr.json, verify it contains a pull_request_url
+    for {{ inputs.github_issue.repository }}#{{ inputs.github_issue.number }}, and apply the
+    configured Code Review strategy with the pull request URL. Before using the trusted GitHub
+    update tool, confirm the latest post-remediation moonspec-verify verdict is FULLY_IMPLEMENTED;
+    terminal verifier outcomes such as ADDITIONAL_WORK_NEEDED, NO_DETERMINATION, BLOCKED,
+    FAILED_UNRECOVERABLE, or ENVIRONMENT_CONTAMINATED_BY_SKILL_PROJECTION must stop before
+    this status update. Do not assume a single organization workflow; use the configured label/comment/close
+    strategy exposed by the trusted GitHub update tool.'
+  tool:
+    id: github.update_issue_status
+    requiredCapabilities:
+    - gh
+    inputs:
+      repository: '{{ inputs.github_issue.repository }}'
+      issueNumber: '{{ inputs.github_issue.number }}'
+      mode: finalize_after_pr_or_done
+      pullRequestArtifactPath: artifacts/github-issue-orchestrate-pr.json

--- a/api_service/data/presets/github-issue-orchestrate.yaml
+++ b/api_service/data/presets/github-issue-orchestrate.yaml
@@ -114,6 +114,7 @@ steps:
     inputs:
       repository: '{{ inputs.github_issue.repository }}'
       issueNumber: '{{ inputs.github_issue.number }}'
+      artifactPath: artifacts/github-issue-orchestrate-brief.json
 - kind: include
   slug: issue-implement-assessment
   alias: assess
@@ -167,6 +168,7 @@ steps:
       issueNumber: '{{ inputs.github_issue.number }}'
       targetStatus: In Progress
       mode: start
+      assessmentArtifactPath: artifacts/github-issue-orchestrate-assessment.json
 - title: Classify request and resume point
   instructions: 'Use the GitHub issue preset brief for {{ inputs.github_issue.repository }}#{{
     inputs.github_issue.number }} as the canonical Moon Spec orchestration input.

--- a/moonmind/workflows/temporal/story_output_tools.py
+++ b/moonmind/workflows/temporal/story_output_tools.py
@@ -3096,13 +3096,20 @@ async def load_github_issue_preset_brief(
     if labels:
         brief_parts.append("Labels: " + ", ".join(str(label) for label in labels))
     preset_brief = "\n\n".join(part for part in brief_parts if part)
+    artifact_path = _first_string(
+        inputs.get("artifactPath"),
+        inputs.get("artifact_path"),
+        inputs.get("briefArtifactPath"),
+        inputs.get("brief_artifact_path"),
+        "artifacts/github-issue-implement-brief.json",
+    )
     return ToolResult(
         status="COMPLETED",
         outputs={
             "trustedSource": "moonmind.github.get_issue",
             "issue": issue,
             "presetBrief": preset_brief,
-            "artifactPath": "artifacts/github-issue-implement-brief.json",
+            "artifactPath": artifact_path,
             "summary": f"Loaded GitHub issue preset brief for {issue_ref} from trusted GitHub data.",
         },
     )
@@ -3219,6 +3226,54 @@ def _pull_request_url_from_artifact_path(
     return ""
 
 
+def _local_json_artifact_from_path(
+    *,
+    artifact_path: str,
+    inputs: Mapping[str, Any],
+    context: Mapping[str, Any] | None,
+) -> dict[str, Any] | None:
+    raw_path = Path(artifact_path).expanduser()
+    candidate_paths: list[Path] = []
+    if raw_path.is_absolute():
+        candidate_paths.append(raw_path.resolve())
+    else:
+        for root in _repo_root_candidates(inputs, context):
+            candidate = (root / raw_path).resolve()
+            if candidate.is_relative_to(root):
+                candidate_paths.append(candidate)
+    for candidate in candidate_paths:
+        if not candidate.exists() or not candidate.is_file():
+            continue
+        try:
+            payload = json.loads(candidate.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if isinstance(payload, Mapping):
+            return dict(payload)
+    return None
+
+
+def _assessment_verdict_from_artifact(
+    inputs: Mapping[str, Any],
+    context: Mapping[str, Any] | None,
+) -> tuple[str, bool]:
+    artifact_path = _string(
+        inputs.get("assessmentArtifactPath")
+        or inputs.get("assessment_artifact_path")
+    )
+    if not artifact_path:
+        return "", True
+    payload = _local_json_artifact_from_path(
+        artifact_path=artifact_path,
+        inputs=inputs,
+        context=context,
+    )
+    if payload is None:
+        return "", False
+    verdict = _string(payload.get("verdict")).upper()
+    return verdict, True
+
+
 def _github_status_pull_request_url(
     inputs: Mapping[str, Any],
     context: Mapping[str, Any] | None,
@@ -3238,13 +3293,49 @@ async def update_github_issue_status(
 ) -> ToolResult:
     repository, issue_number = _github_issue_inputs(inputs)
     mode = _github_status_mode(inputs)
+    assessment_verdict, assessment_available = _assessment_verdict_from_artifact(
+        inputs,
+        _context,
+    )
+    issue_ref = f"{repository}#{issue_number}"
+    if mode in {"start", "in_progress"} and (
+        inputs.get("assessmentArtifactPath") or inputs.get("assessment_artifact_path")
+    ):
+        if not assessment_available:
+            return ToolResult(
+                status="FAILED",
+                outputs={
+                    "issueRef": issue_ref,
+                    "decision": "blocked",
+                    "summary": "GitHub issue status update requires an assessment artifact, but it was unavailable.",
+                },
+            )
+        if assessment_verdict == "FULLY_IMPLEMENTED":
+            return ToolResult(
+                status="COMPLETED",
+                outputs={
+                    "issueRef": issue_ref,
+                    "decision": "skipped",
+                    "assessmentVerdict": assessment_verdict,
+                    "summary": f"Skipped GitHub issue In Progress update for {issue_ref} because assessment verdict is FULLY_IMPLEMENTED.",
+                },
+            )
+        if assessment_verdict == "BLOCKED":
+            return ToolResult(
+                status="FAILED",
+                outputs={
+                    "issueRef": issue_ref,
+                    "decision": "blocked",
+                    "assessmentVerdict": assessment_verdict,
+                    "summary": f"Skipped GitHub issue In Progress update for {issue_ref} because assessment verdict is BLOCKED.",
+                },
+            )
     pull_request_url = _github_status_pull_request_url(inputs, _context)
     if mode == "finalize_after_pr_or_done":
         mode = "code_review" if pull_request_url else "done"
     actions = _GITHUB_STATUS_ACTIONS.get(mode, {})
     service = github_service_factory()
     token, resolution_error = await service.resolve_github_token(repo=repository)
-    issue_ref = f"{repository}#{issue_number}"
     if not token:
         return ToolResult(status="FAILED", outputs={"issueRef": issue_ref, "summary": resolution_error or "GitHub issue update is unavailable."})
     headers = service._github_headers(token)

--- a/tests/unit/api/test_github_issue_orchestrate_preset.py
+++ b/tests/unit/api/test_github_issue_orchestrate_preset.py
@@ -110,6 +110,9 @@ async def test_github_issue_orchestrate_seed_exposes_issue_picker_and_tools(tmp_
         "github.update_issue_status",
     ]
     assert template.steps[1]["slug"] == "issue-implement-assessment"
+    assert template.steps[0]["tool"]["inputs"]["artifactPath"] == (
+        "artifacts/github-issue-orchestrate-brief.json"
+    )
     assert template.steps[1]["inputMapping"] == {
         "issue_provider": "github",
         "issue_ref": "{{ inputs.github_issue.repository }}#{{ inputs.github_issue.number }}",
@@ -117,6 +120,9 @@ async def test_github_issue_orchestrate_seed_exposes_issue_picker_and_tools(tmp_
         "brief_artifact_path": "artifacts/github-issue-orchestrate-brief.json",
         "assessment_artifact_path": "artifacts/github-issue-orchestrate-assessment.json",
     }
+    assert template.steps[3]["tool"]["inputs"]["assessmentArtifactPath"] == (
+        "artifacts/github-issue-orchestrate-assessment.json"
+    )
 
 
 async def test_github_issue_orchestrate_expands_required_order_and_gates(tmp_path):
@@ -154,6 +160,7 @@ async def test_github_issue_orchestrate_expands_required_order_and_gates(tmp_pat
     assert steps[0]["tool"]["inputs"] == {
         "repository": "MoonLadderStudios/MoonMind",
         "issueNumber": "1063",
+        "artifactPath": "artifacts/github-issue-orchestrate-brief.json",
     }
     assert steps[1]["skill"]["id"] == "auto"
     assert "artifacts/github-issue-orchestrate-assessment.json" in steps[1][
@@ -172,6 +179,7 @@ async def test_github_issue_orchestrate_expands_required_order_and_gates(tmp_pat
             "issueNumber": "1063",
             "targetStatus": "In Progress",
             "mode": "start",
+            "assessmentArtifactPath": "artifacts/github-issue-orchestrate-assessment.json",
         },
     }
 

--- a/tests/unit/api/test_github_issue_orchestrate_preset.py
+++ b/tests/unit/api/test_github_issue_orchestrate_preset.py
@@ -1,0 +1,230 @@
+"""Catalog-boundary tests for the MM-1067 ``github-issue-orchestrate`` seed preset."""
+
+from __future__ import annotations
+
+import shutil
+from contextlib import asynccontextmanager
+from pathlib import Path
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+from api_service.db.models import Base, Preset, PresetScopeType
+from api_service.services.presets.catalog import PresetCatalogService
+
+pytestmark = [pytest.mark.asyncio]
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_PRESET_DIR = _REPO_ROOT / "api_service" / "data" / "presets"
+
+
+@asynccontextmanager
+async def _catalog_db(tmp_path):
+    db_url = f"sqlite+aiosqlite:///{tmp_path}/github_issue_orchestrate.db"
+    engine = create_async_engine(db_url, future=True)
+    async_session_maker = sessionmaker(
+        engine, class_=AsyncSession, expire_on_commit=False
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    try:
+        yield async_session_maker
+    finally:
+        await engine.dispose()
+
+
+def _seed_dir(tmp_path) -> Path:
+    seed_dir = tmp_path / "presets"
+    seed_dir.mkdir()
+    for filename in (
+        "github-issue-orchestrate.yaml",
+        "issue-implement-assessment.yaml",
+    ):
+        shutil.copy(_PRESET_DIR / filename, seed_dir / filename)
+    return seed_dir
+
+
+async def _load_preset(session) -> Preset:
+    result = await session.execute(
+        select(Preset).where(
+            Preset.slug == "github-issue-orchestrate",
+            Preset.scope_type == PresetScopeType.GLOBAL,
+            Preset.scope_ref.is_(None),
+        )
+    )
+    return result.scalar_one()
+
+
+async def test_github_issue_orchestrate_seed_exposes_issue_picker_and_tools(tmp_path):
+    async with _catalog_db(tmp_path) as session_maker:
+        async with session_maker() as session:
+            service = PresetCatalogService(session)
+            await service.sync_seed_templates(seed_dir=_seed_dir(tmp_path))
+
+            template = await _load_preset(session)
+            annotations = template.annotations or {}
+
+    assert template.title == "GitHub Issue Orchestrate"
+    assert template.scope_type is PresetScopeType.GLOBAL
+    assert sorted(template.required_capabilities) == ["gh", "git"]
+
+    assert annotations["jiraIssue"] == "MM-1067"
+    assert annotations["sourceReference"] == "MM-1063"
+    assert annotations["issueInput"] == {
+        "provider": "github",
+        "objectInput": "github_issue",
+        "refInput": "github_issue_ref",
+        "refTemplate": "{{ repository }}#{{ number }}",
+    }
+    assert annotations["inputSchema"]["required"] == ["github_issue"]
+    github_issue = annotations["inputSchema"]["properties"]["github_issue"]
+    assert github_issue["required"] == ["repository", "number"]
+    assert annotations["uiSchema"]["github_issue"] == {
+        "widget": "github.issue-picker",
+        "dataSource": "github.issues",
+        "searchPlaceholder": "Search GitHub issues",
+        "allowManualIssueEntry": True,
+    }
+    assert annotations["githubIssueUpdate"]["inProgress"]["labelsToAdd"] == [
+        "status: in-progress"
+    ]
+    assert annotations["githubIssueUpdate"]["codeReview"][
+        "commentPullRequestUrl"
+    ] is True
+
+    assert [step.get("kind", "step") for step in template.steps[:4]] == [
+        "step",
+        "include",
+        "step",
+        "step",
+    ]
+    assert [
+        (step.get("tool") or step.get("skill") or {}).get("id")
+        for step in template.steps[:4]
+    ] == [
+        "github.load_issue_preset_brief",
+        None,
+        "github.check_issue_blockers",
+        "github.update_issue_status",
+    ]
+    assert template.steps[1]["slug"] == "issue-implement-assessment"
+    assert template.steps[1]["inputMapping"] == {
+        "issue_provider": "github",
+        "issue_ref": "{{ inputs.github_issue.repository }}#{{ inputs.github_issue.number }}",
+        "issue_url": "{{ inputs.github_issue.url | default('') }}",
+        "brief_artifact_path": "artifacts/github-issue-orchestrate-brief.json",
+        "assessment_artifact_path": "artifacts/github-issue-orchestrate-assessment.json",
+    }
+
+
+async def test_github_issue_orchestrate_expands_required_order_and_gates(tmp_path):
+    async with _catalog_db(tmp_path) as session_maker:
+        async with session_maker() as session:
+            service = PresetCatalogService(session)
+            await service.sync_seed_templates(seed_dir=_seed_dir(tmp_path))
+
+            expanded = await service.expand_template(
+                slug="github-issue-orchestrate",
+                scope="global",
+                scope_ref=None,
+                inputs={
+                    "github_issue": {
+                        "repository": "MoonLadderStudios/MoonMind",
+                        "number": 1063,
+                        "url": "https://github.com/MoonLadderStudios/MoonMind/issues/1063",
+                    },
+                    "github_issue_ref": "MoonLadderStudios/MoonMind#1063",
+                    "source_design_path": "",
+                    "constraints": "Preserve MM-1063 traceability.",
+                },
+                context={},
+            )
+
+    steps = expanded["steps"]
+    assert len(steps) == 27
+    assert [step["title"] for step in steps[:4]] == [
+        "Load GitHub issue brief",
+        "Assess existing implementation state",
+        "Check GitHub issue blockers before orchestration",
+        "Mark GitHub issue In Progress",
+    ]
+    assert steps[0]["tool"]["id"] == "github.load_issue_preset_brief"
+    assert steps[0]["tool"]["inputs"] == {
+        "repository": "MoonLadderStudios/MoonMind",
+        "issueNumber": "1063",
+    }
+    assert steps[1]["skill"]["id"] == "auto"
+    assert "artifacts/github-issue-orchestrate-assessment.json" in steps[1][
+        "instructions"
+    ]
+    assert "FULLY_IMPLEMENTED" in steps[1]["instructions"]
+    assert steps[2]["tool"]["id"] == "github.check_issue_blockers"
+    assert "deterministic trusted GitHub blocker preflight" in steps[2][
+        "instructions"
+    ]
+    assert steps[3]["tool"] == {
+        "id": "github.update_issue_status",
+        "requiredCapabilities": ["gh"],
+        "inputs": {
+            "repository": "MoonLadderStudios/MoonMind",
+            "issueNumber": "1063",
+            "targetStatus": "In Progress",
+            "mode": "start",
+        },
+    }
+
+    assert [steps[index]["skill"]["id"] for index in range(4, 11)] == [
+        "auto",
+        "moonspec-specify",
+        "auto",
+        "moonspec-plan",
+        "moonspec-tasks",
+        "moonspec-align",
+        "moonspec-implement",
+    ]
+    assert "Preserve MM-1063 traceability." in steps[4]["instructions"]
+    assert "FULLY_IMPLEMENTED" in steps[4]["instructions"]
+    assert "make no code changes" in steps[10]["instructions"]
+    assert steps[11]["skill"]["id"] == "moonspec-verify"
+
+    assert steps[12]["title"] == "Remediate verification gaps 1 of 6"
+    assert steps[12]["annotations"]["jiraOrchestrateRole"] == "moonspec-remediation"
+    assert "ADDITIONAL_WORK_NEEDED" in steps[12]["instructions"]
+    assert steps[23]["title"] == "Verify remediation 6 of 6"
+    assert steps[23]["annotations"]["moonSpecFinalRemediationGate"] is True
+    assert "controlling verification gate" in steps[23]["instructions"]
+
+    assert steps[24]["title"] == "Reconcile declarative docs"
+    assert steps[24]["annotations"] == {"jiraOrchestrateRole": "doc-reconciliation"}
+    assert steps[24]["skill"]["id"] == "moonspec-doc-reconcile"
+    assert "FULLY_IMPLEMENTED" in steps[24]["instructions"]
+    assert "skip doc reconciliation" in steps[24]["instructions"]
+    assert "artifacts/github-issue-orchestrate-doc-reconcile.json" in steps[24][
+        "instructions"
+    ]
+
+    assert steps[25]["title"] == "Create pull request"
+    assert steps[25]["annotations"] == {"jiraOrchestrateRole": "pull-request-handoff"}
+    assert "skip pull request creation entirely" in steps[25]["instructions"]
+    assert "post-remediation moonspec-verify" in steps[25]["instructions"]
+    assert "terminal verifier outcomes" not in steps[25]["instructions"].lower()
+    assert "ADDITIONAL_WORK_NEEDED" in steps[25]["instructions"]
+    assert "artifacts/github-issue-orchestrate-pr.json" in steps[25]["instructions"]
+
+    assert steps[26]["title"] == "Finalize GitHub issue status"
+    assert steps[26]["annotations"] == {"jiraOrchestrateRole": "code-review-handoff"}
+    assert steps[26]["tool"] == {
+        "id": "github.update_issue_status",
+        "requiredCapabilities": ["gh"],
+        "inputs": {
+            "repository": "MoonLadderStudios/MoonMind",
+            "issueNumber": "1063",
+            "mode": "finalize_after_pr_or_done",
+            "pullRequestArtifactPath": "artifacts/github-issue-orchestrate-pr.json",
+        },
+    }
+    assert "apply the configured Done strategy" in steps[26]["instructions"]
+    assert "terminal verifier outcomes" in steps[26]["instructions"]
+    assert "Code Review strategy" in steps[26]["instructions"]

--- a/tests/unit/api/test_presets_service.py
+++ b/tests/unit/api/test_presets_service.py
@@ -3031,9 +3031,17 @@ async def test_seed_catalog_github_issue_orchestrate_expands_gated_workflow(tmp_
     assert expanded["steps"][0]["tool"]["inputs"] == {
         "repository": "MoonLadderStudios/MoonMind",
         "issueNumber": "1067",
+        "artifactPath": "artifacts/github-issue-orchestrate-brief.json",
     }
     assert expanded["steps"][2]["tool"]["id"] == "github.check_issue_blockers"
     assert expanded["steps"][3]["tool"]["id"] == "github.update_issue_status"
+    assert expanded["steps"][3]["tool"]["inputs"] == {
+        "repository": "MoonLadderStudios/MoonMind",
+        "issueNumber": "1067",
+        "targetStatus": "In Progress",
+        "mode": "start",
+        "assessmentArtifactPath": "artifacts/github-issue-orchestrate-assessment.json",
+    }
     assert expanded["steps"][26]["tool"]["id"] == "github.update_issue_status"
     assert expanded["steps"][26]["tool"]["inputs"] == {
         "repository": "MoonLadderStudios/MoonMind",

--- a/tests/unit/api/test_presets_service.py
+++ b/tests/unit/api/test_presets_service.py
@@ -2964,6 +2964,143 @@ async def test_seed_catalog_github_issue_implement_expands_shared_includes(tmp_p
         "MoonLadderStudios/MoonMind#123"
     )
 
+
+async def test_seed_catalog_github_issue_orchestrate_expands_gated_workflow(tmp_path):
+    seed_dir = (
+        Path(__file__).resolve().parents[3]
+        / "api_service"
+        / "data"
+        / "presets"
+    )
+
+    async with template_db(tmp_path) as session_maker:
+        async with session_maker() as session:
+            service = PresetCatalogService(session)
+            await service.sync_seed_templates(seed_dir=seed_dir)
+
+            template = await service._get_template_for_scope(
+                slug="github-issue-orchestrate",
+                scope=PresetScopeType.GLOBAL,
+                scope_ref=None,
+            )
+            expanded = await service.expand_template(
+                slug="github-issue-orchestrate",
+                scope="global",
+                scope_ref=None,
+                inputs={
+                    "github_issue": {
+                        "repository": "MoonLadderStudios/MoonMind",
+                        "number": 1067,
+                        "url": "https://github.com/MoonLadderStudios/MoonMind/issues/1067",
+                    },
+                    "constraints": "Keep preset scope bounded.",
+                },
+                context={},
+            )
+
+    assert [step["title"] for step in expanded["steps"]] == [
+        "Load GitHub issue brief",
+        "Assess existing implementation state",
+        "Check GitHub issue blockers before orchestration",
+        "Mark GitHub issue In Progress",
+        "Classify request and resume point",
+        "Create or select Moon Spec",
+        "Split broad designs when needed",
+        "Plan selected spec",
+        "Generate TDD task breakdown",
+        "Align Moon Spec artifacts",
+        "Implement the task breakdown",
+        "Verify completion",
+        "Remediate verification gaps 1 of 6",
+        "Verify remediation 1 of 6",
+        "Remediate verification gaps 2 of 6",
+        "Verify remediation 2 of 6",
+        "Remediate verification gaps 3 of 6",
+        "Verify remediation 3 of 6",
+        "Remediate verification gaps 4 of 6",
+        "Verify remediation 4 of 6",
+        "Remediate verification gaps 5 of 6",
+        "Verify remediation 5 of 6",
+        "Remediate verification gaps 6 of 6",
+        "Verify remediation 6 of 6",
+        "Reconcile declarative docs",
+        "Create pull request",
+        "Finalize GitHub issue status",
+    ]
+    assert expanded["steps"][0]["tool"]["id"] == "github.load_issue_preset_brief"
+    assert expanded["steps"][0]["tool"]["inputs"] == {
+        "repository": "MoonLadderStudios/MoonMind",
+        "issueNumber": "1067",
+    }
+    assert expanded["steps"][2]["tool"]["id"] == "github.check_issue_blockers"
+    assert expanded["steps"][3]["tool"]["id"] == "github.update_issue_status"
+    assert expanded["steps"][26]["tool"]["id"] == "github.update_issue_status"
+    assert expanded["steps"][26]["tool"]["inputs"] == {
+        "repository": "MoonLadderStudios/MoonMind",
+        "issueNumber": "1067",
+        "mode": "finalize_after_pr_or_done",
+        "pullRequestArtifactPath": "artifacts/github-issue-orchestrate-pr.json",
+    }
+    assert expanded["steps"][11]["skill"]["id"] == "moonspec-verify"
+    assert expanded["steps"][23]["annotations"] == {
+        "jiraOrchestrateRole": "moonspec-verification-gate",
+        "moonSpecRemediationAttempt": 6,
+        "moonSpecRemediationMaxAttempts": 6,
+        "moonSpecFinalRemediationGate": True,
+    }
+    assert expanded["steps"][24]["annotations"] == {
+        "jiraOrchestrateRole": "doc-reconciliation"
+    }
+    assert expanded["steps"][25]["annotations"] == {
+        "jiraOrchestrateRole": "pull-request-handoff"
+    }
+    assert expanded["steps"][26]["annotations"] == {
+        "jiraOrchestrateRole": "code-review-handoff"
+    }
+    assert "ADDITIONAL_WORK_NEEDED or NO_DETERMINATION" in expanded["steps"][23][
+        "instructions"
+    ]
+    assert "do not continue to pull request creation" in expanded["steps"][23][
+        "instructions"
+    ]
+    assert "only when the controlling post-remediation verdict is FULLY_IMPLEMENTED" in expanded[
+        "steps"
+    ][24]["instructions"]
+    assert "If the latest verdict is not FULLY_IMPLEMENTED" in expanded["steps"][24][
+        "instructions"
+    ]
+    assert "stop without committing, pushing, creating a pull request" in expanded["steps"][
+        25
+    ]["instructions"]
+    assert "terminal verifier outcomes" in expanded["steps"][26]["instructions"]
+    assert "must stop before this status update" in expanded["steps"][26][
+        "instructions"
+    ]
+    assert "FULLY_IMPLEMENTED and no MoonSpec implementation work ran" in expanded[
+        "steps"
+    ][11]["instructions"]
+    assert "skip doc reconciliation" in expanded["steps"][24]["instructions"]
+    assert "skip pull request creation entirely" in expanded["steps"][25][
+        "instructions"
+    ]
+    assert "apply the configured Done strategy" in expanded["steps"][26][
+        "instructions"
+    ]
+    assert [item["presetSlug"] for item in expanded["authoredPresets"]] == [
+        "github-issue-orchestrate",
+        "issue-implement-assessment",
+    ]
+    assert template.annotations["uiSchema"]["github_issue"] == {
+        "widget": "github.issue-picker",
+        "dataSource": "github.issues",
+        "searchPlaceholder": "Search GitHub issues",
+        "allowManualIssueEntry": True,
+    }
+    assert expanded["appliedTemplate"]["inputs"]["github_issue_ref"] == (
+        "MoonLadderStudios/MoonMind#1067"
+    )
+
+
 async def test_seed_catalog_includes_jira_breakdown_orchestrate_preset(
     tmp_path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit/workflows/temporal/test_story_output_tools.py
+++ b/tests/unit/workflows/temporal/test_story_output_tools.py
@@ -13,7 +13,9 @@ from moonmind.workflows.temporal.story_output_tools import (
     create_jira_issues_from_stories,
     create_jira_orchestrate_tasks_from_issue_mappings,
     discover_documents,
+    load_github_issue_preset_brief,
     load_jira_preset_brief,
+    update_github_issue_status,
 )
 
 class _FakeJiraService:
@@ -98,6 +100,146 @@ class _FakeExecutionCreator:
             "runId": f"run-{index}",
             "title": kwargs.get("title"),
         }
+
+
+class _FakeGitHubService:
+    def __init__(self) -> None:
+        self.token_requests: list[str] = []
+
+    async def resolve_github_token(self, *, repo: str):
+        self.token_requests.append(repo)
+        return "ghs-test", None
+
+    def _github_headers(self, token: str) -> dict[str, str]:
+        return {"Authorization": f"Bearer {token}"}
+
+    def _github_permission_summary(self, response) -> str:
+        return f"github status {response.status_code}"
+
+
+class _FakeHttpResponse:
+    def __init__(self, payload: dict[str, Any], status_code: int = 200) -> None:
+        self._payload = payload
+        self.status_code = status_code
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> dict[str, Any]:
+        return self._payload
+
+
+class _FakeHttpClient:
+    def __init__(self, *args, **kwargs) -> None:
+        self.requests: list[tuple[str, str, Any]] = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        return None
+
+    async def get(self, url: str, **kwargs):
+        self.requests.append(("GET", url, kwargs))
+        return _FakeHttpResponse(
+            {
+                "number": 1067,
+                "title": "Add GitHub Issue Orchestrate preset",
+                "body": "Build the preset.",
+                "html_url": "https://github.com/MoonLadderStudios/MoonMind/issues/1067",
+                "state": "open",
+                "labels": [{"name": "moonspec"}],
+            }
+        )
+
+    async def patch(self, url: str, **kwargs):
+        self.requests.append(("PATCH", url, kwargs))
+        return _FakeHttpResponse(
+            {
+                "number": 1067,
+                "title": "Add GitHub Issue Orchestrate preset",
+                "body": "Build the preset.",
+                "html_url": "https://github.com/MoonLadderStudios/MoonMind/issues/1067",
+                "state": "open",
+                "labels": [{"name": "status: in-progress"}],
+            }
+        )
+
+    async def post(self, url: str, **kwargs):
+        self.requests.append(("POST", url, kwargs))
+        return _FakeHttpResponse({"id": 1})
+
+
+@pytest.mark.asyncio
+async def test_load_github_issue_preset_brief_uses_requested_artifact_path(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(story_tools.httpx, "AsyncClient", _FakeHttpClient)
+    service = _FakeGitHubService()
+
+    result = await load_github_issue_preset_brief(
+        {
+            "repository": "MoonLadderStudios/MoonMind",
+            "issueNumber": 1067,
+            "artifactPath": "artifacts/github-issue-orchestrate-brief.json",
+        },
+        github_service_factory=lambda: service,
+    )
+
+    assert result.status == "COMPLETED"
+    assert result.outputs["artifactPath"] == (
+        "artifacts/github-issue-orchestrate-brief.json"
+    )
+    assert result.outputs["issue"]["number"] == 1067
+    assert service.token_requests == ["MoonLadderStudios/MoonMind"]
+
+
+@pytest.mark.asyncio
+async def test_update_github_issue_status_skips_start_for_fully_implemented_assessment(
+    tmp_path,
+):
+    assessment = tmp_path / "assessment.json"
+    assessment.write_text('{"verdict": "FULLY_IMPLEMENTED"}', encoding="utf-8")
+    service = _FakeGitHubService()
+
+    result = await update_github_issue_status(
+        {
+            "repository": "MoonLadderStudios/MoonMind",
+            "issueNumber": 1067,
+            "mode": "start",
+            "assessmentArtifactPath": str(assessment),
+        },
+        github_service_factory=lambda: service,
+    )
+
+    assert result.status == "COMPLETED"
+    assert result.outputs["decision"] == "skipped"
+    assert result.outputs["assessmentVerdict"] == "FULLY_IMPLEMENTED"
+    assert service.token_requests == []
+
+
+@pytest.mark.asyncio
+async def test_update_github_issue_status_blocks_start_for_blocked_assessment(
+    tmp_path,
+):
+    assessment = tmp_path / "assessment.json"
+    assessment.write_text('{"verdict": "BLOCKED"}', encoding="utf-8")
+    service = _FakeGitHubService()
+
+    result = await update_github_issue_status(
+        {
+            "repository": "MoonLadderStudios/MoonMind",
+            "issueNumber": 1067,
+            "targetStatus": "In Progress",
+            "assessmentArtifactPath": str(assessment),
+        },
+        github_service_factory=lambda: service,
+    )
+
+    assert result.status == "FAILED"
+    assert result.outputs["decision"] == "blocked"
+    assert result.outputs["assessmentVerdict"] == "BLOCKED"
+    assert service.token_requests == []
 
 @pytest.mark.asyncio
 async def test_create_jira_issues_from_inline_story_breakdown():


### PR DESCRIPTION
Issue: MM-1067

Summary:
- Added the `github-issue-orchestrate` preset with GitHub issue picker/manual fallback inputs and trusted GitHub issue brief, blocker, and status update steps.
- Mirrored the Jira orchestrate verification, remediation, doc reconciliation, PR publication, and final status update flow with verifier-gated terminal outcomes.
- Added catalog-boundary and seed catalog tests for the new preset expansion and no-code-change handoff behavior.

Tests run:
- `./tools/test_unit.sh tests/unit/api/test_github_issue_orchestrate_preset.py tests/unit/api/test_presets_service.py`

Remaining risks:
- Full end-to-end preset execution was not run in this publication step; coverage is at the preset catalog/unit boundary.
