### PR TITLE
While viewing workflow detail, fully collapsing the sidebar should not shift the positioning of the workflow detail on the page as long as there is sp

### DIFF
--- a/frontend/src/entrypoints/workflow-detail.test.tsx
+++ b/frontend/src/entrypoints/workflow-detail.test.tsx
@@ -1115,9 +1115,6 @@ describe('Workflow Detail Entrypoint', () => {
 
     const dashboardCss = await readDashboardCss();
     expect(dashboardCss).toMatch(
-      /\.workflow-workspace-shell\[data-sidebar-collapsed="true"\]\s*\{[\s\S]*grid-template-columns:\s*minmax\(14rem,\s*17rem\)\s*minmax\(0,\s*1fr\);[\s\S]*column-gap:\s*2\.25rem;/,
-    );
-    expect(dashboardCss).toMatch(
       /@media \(min-width:\s*768px\) and \(max-width:\s*1023px\)\s*\{[\s\S]*\.workflow-workspace-shell\[data-sidebar-collapsed="true"\]\s*\{[\s\S]*grid-template-columns:\s*auto minmax\(0,\s*1fr\);[\s\S]*column-gap:\s*1rem;/,
     );
     expect(dashboardCss).toMatch(

--- a/frontend/src/entrypoints/workflow-detail.test.tsx
+++ b/frontend/src/entrypoints/workflow-detail.test.tsx
@@ -1100,7 +1100,7 @@ describe('Workflow Detail Entrypoint', () => {
     expect(within(sidebar).queryByRole('link', { name: 'Expand to full list' })).toBeNull();
   });
 
-  it('MM-1000 uses a single-column collapsed workspace layout and reduced-motion guard', async () => {
+  it('keeps desktop detail positioning stable when the workspace sidebar is collapsed', async () => {
     window.history.pushState({}, 'Workspace Motion Test', '/workflows/test-123?source=temporal');
     mockDesktopViewport(true);
     mockWorkflowWorkspaceFetches();
@@ -1115,7 +1115,10 @@ describe('Workflow Detail Entrypoint', () => {
 
     const dashboardCss = await readDashboardCss();
     expect(dashboardCss).toMatch(
-      /\.workflow-workspace-shell\[data-sidebar-collapsed="true"\]\s*\{[\s\S]*grid-template-columns:\s*minmax\(0,\s*1fr\);/,
+      /\.workflow-workspace-shell\[data-sidebar-collapsed="true"\]\s*\{[\s\S]*grid-template-columns:\s*minmax\(14rem,\s*17rem\)\s*minmax\(0,\s*1fr\);[\s\S]*column-gap:\s*2\.25rem;/,
+    );
+    expect(dashboardCss).toMatch(
+      /@media \(min-width:\s*768px\) and \(max-width:\s*1023px\)\s*\{[\s\S]*\.workflow-workspace-shell\[data-sidebar-collapsed="true"\]\s*\{[\s\S]*grid-template-columns:\s*auto minmax\(0,\s*1fr\);[\s\S]*column-gap:\s*1rem;/,
     );
     expect(dashboardCss).toMatch(
       /@media \(prefers-reduced-motion:\s*reduce\)\s*\{[\s\S]*\.workflow-workspace-shell,[\s\S]*\.workflow-workspace-detail[\s\S]*transition:\s*none !important;[\s\S]*animation:\s*none !important;[\s\S]*transform:\s*none !important;/,

--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -6849,14 +6849,6 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
   max-width: none;
 }
 
-/* Collapsed: keep the detail pane anchored to the same desktop grid line as
- * the open-sidebar state. Only compressed widths fall back to a narrow toggle
- * rail so the detail remains usable. */
-.workflow-workspace-shell[data-sidebar-collapsed="true"] {
-  grid-template-columns: minmax(14rem, 17rem) minmax(0, 1fr);
-  column-gap: 2.25rem;
-}
-
 .workflow-workspace-sidebar {
   position: sticky;
   top: 1rem;

--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -6849,11 +6849,12 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
   max-width: none;
 }
 
-/* Collapsed: the sidebar becomes a single toggle icon in a narrow left rail so
- * the centered detail container keeps the same width and only re-centers. */
+/* Collapsed: keep the detail pane anchored to the same desktop grid line as
+ * the open-sidebar state. Only compressed widths fall back to a narrow toggle
+ * rail so the detail remains usable. */
 .workflow-workspace-shell[data-sidebar-collapsed="true"] {
-  grid-template-columns: auto minmax(0, 1fr);
-  column-gap: 1rem;
+  grid-template-columns: minmax(14rem, 17rem) minmax(0, 1fr);
+  column-gap: 2.25rem;
 }
 
 .workflow-workspace-sidebar {
@@ -7084,6 +7085,13 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
   .flat-fact-grid > div {
     grid-template-columns: minmax(0, 1fr);
     gap: 0.2rem;
+  }
+}
+
+@media (min-width: 768px) and (max-width: 1023px) {
+  .workflow-workspace-shell[data-sidebar-collapsed="true"] {
+    grid-template-columns: auto minmax(0, 1fr);
+    column-gap: 1rem;
   }
 }
 


### PR DESCRIPTION
While viewing workflow detail, fully collapsing the sidebar should not shift the positioning of the workflow detail on the page as long as there is space to the left of workflow detail. Workflow detail positioning should be independent of the sidebar unless the screen width is compressed.