### PR TITLE
Make AWAITING DEP and all the statuses that currently use the same color as AWAITING DEP some shade of yellow instead of purple. Purple is too hard to

### DIFF
--- a/docs/UI/WorkflowStatusColorSemantics.md
+++ b/docs/UI/WorkflowStatusColorSemantics.md
@@ -37,7 +37,7 @@ executing
   -> waiting_on_dependencies / awaiting_external
 ```
 
-The closer a state is to active execution, the closer its hue should sit to the existing executing hue. The furthest waiting states should stay away from red-adjacent colors so they do not read as failure.
+The closer a state is to active execution, the closer its hue should sit to the existing executing hue. The furthest waiting states should stay away from red-adjacent colors so they do not read as failure. They use yellow instead of purple so the pills stay legible against MoonMind's purple-forward dashboard surfaces.
 
 When a status pill has shimmer motion, that shimmer must reinforce the same semantic hue as the pill. Shimmer is not a license to reuse the executing hue for every active-looking status.
 
@@ -53,7 +53,7 @@ These states keep their existing dashboard token values. Do not change their hue
 | `failed` | `--mm-danger` | `#F43F5E` | `#FB7185` | Terminal failure stays red. |
 | `executing` | `--mm-accent-2` | `#22D3EE` | `#7DF9FF` | Active execution stays the existing live/executing color. |
 
-`executing` is the only state in this palette that may continue using the existing cyan-like live accent. Do not introduce additional amber or cyan status assignments for the other states in this model.
+`executing` is the only state in this palette that may continue using the existing cyan-like live accent. Do not introduce additional cyan status assignments for the other states in this model. Yellow is reserved for dependency and external waiting states that need higher contrast on purple dashboard backgrounds.
 
 ---
 
@@ -71,8 +71,8 @@ Current interpretation:
 | `planning` | No by current lifecycle semantics | Use near-execution blue. |
 | `scheduled` | No | Use pre-execution waiting indigo. |
 | `awaiting_slot` | No; blocked before slot assignment | Use pre-execution waiting indigo. |
-| `waiting_on_dependencies` | No | Use furthest-from-execution purple. |
-| `awaiting_external` | No by default; waiting outside immediate execution | Use furthest-from-execution purple. |
+| `waiting_on_dependencies` | No | Use furthest-from-execution yellow. |
+| `awaiting_external` | No by default; waiting outside immediate execution | Use furthest-from-execution yellow. |
 | `finalizing` | No by normal provider-slot lifecycle; cleanup/final record work after execution | Use finalization color. |
 | `no_commit` | No; terminal completed-without-commit outcome | Use no-commit color. |
 
@@ -93,8 +93,8 @@ Rationale: `awaiting_slot` represents a workflow that is waiting for capacity, n
 | `planning` | Planning | Near-execution blue | `#2563EB` | `#2563EB` | Active planning/preparation and conceptually near execution. |
 | `scheduled` | Scheduled | Pre-execution indigo | `#6366F1` | `#6366F1` | Deferred or future work; farther from execution than setup/planning. |
 | `awaiting_slot` | Awaiting slot | Pre-execution indigo | `#6366F1` | `#6366F1` | Waiting before execution capacity is acquired; same distance family as scheduled. |
-| `waiting_on_dependencies` | Awaiting dep | Blocked purple | `#8248F6` | `#8248F6` | Furthest non-terminal distance from active execution; blocked on prerequisite workflow state. |
-| `awaiting_external` | Awaiting external | Blocked purple | `#8248F6` | `#8248F6` | Furthest non-terminal distance from active execution; waiting on an external system, provider, or human. |
+| `waiting_on_dependencies` | Awaiting dep | Blocked yellow | `#FACC15` | `#FACC15` | Furthest non-terminal distance from active execution; blocked on prerequisite workflow state and kept legible against purple dashboard backgrounds. |
+| `awaiting_external` | Awaiting external | Blocked yellow | `#FACC15` | `#FACC15` | Furthest non-terminal distance from active execution; waiting on an external system, provider, or human and kept legible against purple dashboard backgrounds. |
 | `finalizing` | Finalizing | Finalization slate | `#64748B` | `#64748B` | Wrap-up, recording, publish summary, and terminalization work. |
 | `no_commit` | No commit | No-commit teal | `#159376` | `#1A997B` | Successful or side-effectful completion with no repository commit/publish artifact. |
 
@@ -111,7 +111,7 @@ Terminal outcomes should remain visually stable and easy to scan:
 - `canceled` is orange.
 - `no_commit` is teal and success-adjacent, not green.
 
-`no_commit` must not be colored green because that would hide the fact that a publish-mode workflow did not produce a commit or PR. It must not be colored red, orange, or purple because the outcome is not a failure or blocker when the workflow correctly determined no commit was required.
+`no_commit` must not be colored green because that would hide the fact that a publish-mode workflow did not produce a commit or PR. It must not be colored red, orange, purple, or yellow because the outcome is not a failure or blocker when the workflow correctly determined no commit was required.
 
 ### 5.2 Active execution
 
@@ -123,7 +123,7 @@ Terminal outcomes should remain visually stable and easy to scan:
 
 `scheduled` and `awaiting_slot` intentionally share indigo because both are pre-execution waiting states. Work has not begun, but the workflow is still expected to progress once time or capacity becomes available.
 
-`waiting_on_dependencies` and `awaiting_external` intentionally share purple because they are the furthest non-terminal states from active execution. They are blocked outside the current execution loop and may remain stuck until a dependency, provider, human, or external system changes state. Purple keeps these states distinct without making them feel like red failure states.
+`waiting_on_dependencies` and `awaiting_external` intentionally share yellow because they are the furthest non-terminal states from active execution. The compatibility `waiting` pill uses the same yellow group. These states are blocked outside the current execution loop and may remain stuck until a dependency, provider, human, or external system changes state. Yellow keeps these states distinct without making them feel like red failure states, and it remains readable on purple dashboard backgrounds.
 
 `finalizing` uses slate because it is neither active execution nor terminal success/failure. It should feel calm and transitional.
 
@@ -159,4 +159,4 @@ The shimmer sweep angle should remain subtle. A small horizontal-bias refinement
 5. Keep shimmer implemented as one shared effect: one selector contract, one moving light field, one keyframe path, and status-derived hue inputs. Avoid duplicated per-status shimmer implementations.
 6. If the implementation keeps compatibility classes such as `status-running` or `status-queued`, those classes are grouping helpers only. Exact `mm_state` should win for final pill color.
 7. Status filters should show the same pill colors used by table rows and detail headers.
-8. Do not introduce amber or cyan for new status assignments. The existing executing color is grandfathered because it is the current `executing` hue.
+8. Do not introduce cyan for new status assignments. The existing executing color is grandfathered because it is the current `executing` hue; yellow is reserved for the shared waiting/dependency/external-wait group.

--- a/frontend/src/entrypoints/dashboard.test.tsx
+++ b/frontend/src/entrypoints/dashboard.test.tsx
@@ -1007,10 +1007,12 @@ describe('Dashboard shared entry', () => {
 
     const waitBlock = cssRuleBlocks(
       dashboardCss,
-      '.status-waiting, .status-awaiting-dependencies, .status-awaiting-external',
+      '.status-awaiting_action, .status-waiting, .status-awaiting-dependencies, .status-awaiting-external',
     ).join('\n');
-    expect(waitBlock).toContain('color: rgb(var(--mm-status-waiting, 250 204 21))');
-    expect(waitBlock).toContain('rgb(var(--mm-status-waiting, 250 204 21) / 0.14)');
+    expect(dashboardCss).toContain('--mm-status-waiting: 161 98 7');
+    expect(dashboardCss).toContain('--mm-status-waiting: 250 204 21');
+    expect(waitBlock).toContain('color: rgb(var(--mm-status-waiting))');
+    expect(waitBlock).toContain('rgb(var(--mm-status-waiting) / 0.14)');
 
     const setupBlock = cssRuleBlocks(dashboardCss, '.status-initializing, .status-planning').join('\n');
     expect(setupBlock).toContain('color: rgb(var(--mm-status-setup, 37 99 235))');

--- a/frontend/src/entrypoints/dashboard.test.tsx
+++ b/frontend/src/entrypoints/dashboard.test.tsx
@@ -1009,8 +1009,8 @@ describe('Dashboard shared entry', () => {
       dashboardCss,
       '.status-waiting, .status-awaiting-dependencies, .status-awaiting-external',
     ).join('\n');
-    expect(waitBlock).toContain('color: rgb(var(--mm-status-waiting, 130 72 246))');
-    expect(waitBlock).toContain('rgb(var(--mm-status-waiting, 130 72 246) / 0.14)');
+    expect(waitBlock).toContain('color: rgb(var(--mm-status-waiting, 250 204 21))');
+    expect(waitBlock).toContain('rgb(var(--mm-status-waiting, 250 204 21) / 0.14)');
 
     const setupBlock = cssRuleBlocks(dashboardCss, '.status-initializing, .status-planning').join('\n');
     expect(setupBlock).toContain('color: rgb(var(--mm-status-setup, 37 99 235))');

--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -2764,9 +2764,9 @@ tr[data-proposal-id].proposal-consuming td {
 .status-waiting,
 .status-awaiting-dependencies,
 .status-awaiting-external {
-  color: rgb(var(--mm-status-waiting, 130 72 246));
-  background: rgb(var(--mm-status-waiting, 130 72 246) / 0.14);
-  border-color: rgb(var(--mm-status-waiting, 130 72 246) / 0.62);
+  color: rgb(var(--mm-status-waiting, 250 204 21));
+  background: rgb(var(--mm-status-waiting, 250 204 21) / 0.14);
+  border-color: rgb(var(--mm-status-waiting, 250 204 21) / 0.62);
 }
 
 .status-initializing,

--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -15,6 +15,7 @@
   --mm-accent-warm: 244 114 182;
   --mm-ok: 34 197 94;
   --mm-warn: 245 158 11;
+  --mm-status-waiting: 161 98 7;
   --mm-danger: 244 63 94;
   --mm-action-primary: 21 147 118;
   --mm-shadow: 0 18px 32px -26px rgb(10 8 30 / 0.55);
@@ -106,6 +107,7 @@
   --mm-accent-warm: 249 115 22;
   --mm-ok: 74 222 128;
   --mm-warn: 251 191 36;
+  --mm-status-waiting: 250 204 21;
   --mm-danger: 251 113 133;
   --mm-action-primary: 26 153 123;
   --mm-shadow: 0 24px 52px -34px rgb(0 0 0 / 0.88);
@@ -2755,18 +2757,13 @@ tr[data-proposal-id].proposal-consuming td {
   border-color: rgb(var(--mm-status-queued, 99 102 241) / 0.62);
 }
 
-.status-awaiting_action {
-  color: rgb(var(--mm-accent));
-  background: rgb(var(--mm-accent) / 0.14);
-  border-color: rgb(var(--mm-accent) / 0.55);
-}
-
+.status-awaiting_action,
 .status-waiting,
 .status-awaiting-dependencies,
 .status-awaiting-external {
-  color: rgb(var(--mm-status-waiting, 250 204 21));
-  background: rgb(var(--mm-status-waiting, 250 204 21) / 0.14);
-  border-color: rgb(var(--mm-status-waiting, 250 204 21) / 0.62);
+  color: rgb(var(--mm-status-waiting));
+  background: rgb(var(--mm-status-waiting) / 0.14);
+  border-color: rgb(var(--mm-status-waiting) / 0.62);
 }
 
 .status-initializing,


### PR DESCRIPTION
Make AWAITING DEP and all the statuses that currently use the same color as AWAITING DEP some shade of yellow instead of purple. Purple is too hard to read on top of a purple background. Update the color doc and implementation.