### PR TITLE
MM-1033 Floating toast notifications for workflow row actions

### DIFF
--- a/frontend/src/boot/mountPage.tsx
+++ b/frontend/src/boot/mountPage.tsx
@@ -4,6 +4,7 @@ import { QueryClientProvider } from '@tanstack/react-query';
 import { parseBootPayload } from './parseBootPayload';
 import { createDashboardQueryClient } from './queryClient';
 import { DashboardErrorState } from '../components/DashboardErrorState';
+import { DashboardToastProvider } from '../components/dashboard/DashboardToast';
 import '@fontsource/ibm-plex-sans/latin-400.css';
 import '@fontsource/ibm-plex-sans/latin-500.css';
 import '@fontsource/ibm-plex-sans/latin-600.css';
@@ -31,7 +32,9 @@ export function mountPage(App: React.ComponentType<{ payload: ReturnType<typeof 
     createRoot(rootElement).render(
       <StrictMode>
         <QueryClientProvider client={queryClient}>
-          <App payload={payload} />
+          <DashboardToastProvider>
+            <App payload={payload} />
+          </DashboardToastProvider>
         </QueryClientProvider>
       </StrictMode>
     );

--- a/frontend/src/components/WorkflowRowActionsMenu.test.tsx
+++ b/frontend/src/components/WorkflowRowActionsMenu.test.tsx
@@ -218,6 +218,46 @@ describe('WorkflowRowActionsMenu', () => {
     expect(action.getAttribute('href')).toBe('/workflows/wf-123?source=temporal');
   });
 
+  it('links rerun success to the returned execution when a separate workflow is created', async () => {
+    fetchSpy.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === '/api/executions/wf-123?source=temporal') {
+        return Promise.resolve({
+          ok: true,
+          json: async () => detailResponse,
+        } as Response);
+      }
+      if (url === '/api/executions/wf-123/update') {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            execution: {
+              workflowId: 'mm:rerun-created',
+              redirectPath: '/workflows/mm:rerun-created?source=temporal',
+            },
+          }),
+        } as Response);
+      }
+      return Promise.resolve({ ok: true, json: async () => ({}) } as Response);
+    });
+
+    renderWithClient(
+      <WorkflowRowActionsMenu
+        workflowId="wf-123"
+        apiBase="/api"
+        actionsEnabled
+        taskEditingEnabled
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Actions' }));
+    await waitForActionAvailability();
+    fireEvent.click(await screen.findByRole('menuitem', { name: 'Rerun' }));
+
+    const toast = await screen.findByRole('status');
+    const action = within(toast).getByRole('link', { name: 'View workflow' });
+    expect(action.getAttribute('href')).toBe('/workflows/mm:rerun-created?source=temporal');
+  });
+
   it('dismisses rerun success toasts manually', async () => {
     renderWithClient(
       <WorkflowRowActionsMenu
@@ -273,6 +313,39 @@ describe('WorkflowRowActionsMenu', () => {
     const toast = within(viewport).getByRole('alert');
     expect(within(toast).getByText('Workflow action failed')).toBeTruthy();
     expect(within(toast).getByText('Workflow no longer accepts rerun requests.')).toBeTruthy();
+  });
+
+  it('shows non-Error mutation failures without crashing the error toast', async () => {
+    fetchSpy.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === '/api/executions/wf-123?source=temporal') {
+        return Promise.resolve({
+          ok: true,
+          json: async () => detailResponse,
+        } as Response);
+      }
+      if (url === '/api/executions/wf-123/update') {
+        return Promise.reject({ message: '  Custom action failure.  ' });
+      }
+      return Promise.resolve({ ok: true, json: async () => ({}) } as Response);
+    });
+
+    renderWithClient(
+      <WorkflowRowActionsMenu
+        workflowId="wf-123"
+        apiBase="/api"
+        actionsEnabled
+        taskEditingEnabled
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Actions' }));
+    await waitForActionAvailability();
+    fireEvent.click(await screen.findByRole('menuitem', { name: 'Rerun' }));
+
+    const viewport = await screen.findByLabelText('Dashboard notifications');
+    const toast = within(viewport).getByRole('alert');
+    expect(within(toast).getByText('Workflow action failed')).toBeTruthy();
+    expect(within(toast).getByText('Custom action failure.')).toBeTruthy();
   });
 
   it('posts a graceful cancel request directly from the row menu', async () => {

--- a/frontend/src/components/WorkflowRowActionsMenu.test.tsx
+++ b/frontend/src/components/WorkflowRowActionsMenu.test.tsx
@@ -1,5 +1,5 @@
-import { beforeEach, describe, expect, it, vi, type MockInstance } from 'vitest';
-import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi, type MockInstance } from 'vitest';
+import { fireEvent, screen, waitFor, within } from '@testing-library/react';
 
 import { renderWithClient } from '../utils/test-utils';
 import { WorkflowRowActionsMenu } from './WorkflowRowActionsMenu';
@@ -20,6 +20,7 @@ describe('WorkflowRowActionsMenu', () => {
   };
 
   beforeEach(() => {
+    vi.useRealTimers();
     window.history.pushState({}, 'Workflows', '/workflows?source=temporal');
     fetchSpy = vi.spyOn(window, 'fetch').mockImplementation((input: RequestInfo | URL) => {
       const url = String(input);
@@ -31,6 +32,10 @@ describe('WorkflowRowActionsMenu', () => {
       }
       return Promise.resolve({ ok: true, json: async () => ({}) } as Response);
     });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   const renderMenu = () =>
@@ -178,7 +183,7 @@ describe('WorkflowRowActionsMenu', () => {
   });
 
   it('requests a rerun from the row menu without navigating away from the workflow list', async () => {
-    renderWithClient(
+    const { container } = renderWithClient(
       <WorkflowRowActionsMenu
         workflowId="wf-123"
         apiBase="/api"
@@ -204,10 +209,70 @@ describe('WorkflowRowActionsMenu', () => {
     expect(window.location.pathname).toBe('/workflows');
     expect(window.location.search).toBe('?source=temporal');
     expect(
-      await screen.findByText('Rerun was requested and the latest execution view is ready.'),
-    ).toBeTruthy();
-    expect(screen.getByRole('status').className).toContain('notice');
-    expect(screen.getByRole('status').className).toContain('ok');
+      within(container).queryByText('Rerun was requested and the latest execution view is ready.'),
+    ).toBeNull();
+    const toast = await screen.findByRole('status');
+    expect(within(toast).getByText('Rerun requested')).toBeTruthy();
+    expect(within(toast).getByText('Example workflow has been queued.')).toBeTruthy();
+    const action = within(toast).getByRole('link', { name: 'View workflow' });
+    expect(action.getAttribute('href')).toBe('/workflows/wf-123?source=temporal');
+  });
+
+  it('dismisses rerun success toasts manually', async () => {
+    renderWithClient(
+      <WorkflowRowActionsMenu
+        workflowId="wf-123"
+        apiBase="/api"
+        actionsEnabled
+        taskEditingEnabled
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Actions' }));
+    await waitForActionAvailability();
+    fireEvent.click(await screen.findByRole('menuitem', { name: 'Rerun' }));
+
+    const toast = await screen.findByRole('status');
+    fireEvent.click(within(toast).getByRole('button', { name: 'Dismiss Rerun requested' }));
+    await waitFor(() => {
+      expect(screen.queryByRole('status')).toBeNull();
+    });
+  });
+
+  it('shows rerun request failures in an accessible toast', async () => {
+    fetchSpy.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === '/api/executions/wf-123?source=temporal') {
+        return Promise.resolve({
+          ok: true,
+          json: async () => detailResponse,
+        } as Response);
+      }
+      if (url === '/api/executions/wf-123/update') {
+        return Promise.resolve({
+          ok: false,
+          statusText: 'Conflict',
+          text: async () => JSON.stringify({ detail: 'Workflow no longer accepts rerun requests.' }),
+        } as Response);
+      }
+      return Promise.resolve({ ok: true, json: async () => ({}) } as Response);
+    });
+
+    renderWithClient(
+      <WorkflowRowActionsMenu
+        workflowId="wf-123"
+        apiBase="/api"
+        actionsEnabled
+        taskEditingEnabled
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Actions' }));
+    await waitForActionAvailability();
+    fireEvent.click(await screen.findByRole('menuitem', { name: 'Rerun' }));
+
+    const viewport = await screen.findByLabelText('Dashboard notifications');
+    const toast = within(viewport).getByRole('alert');
+    expect(within(toast).getByText('Workflow action failed')).toBeTruthy();
+    expect(within(toast).getByText('Workflow no longer accepts rerun requests.')).toBeTruthy();
   });
 
   it('posts a graceful cancel request directly from the row menu', async () => {

--- a/frontend/src/components/WorkflowRowActionsMenu.tsx
+++ b/frontend/src/components/WorkflowRowActionsMenu.tsx
@@ -77,6 +77,7 @@ const KEBAB_ICON = (
 );
 
 const ACTION_AVAILABILITY_PENDING_REASON = 'Checking availability…';
+const DEFAULT_WORKFLOW_ACTION_ERROR = 'The workflow action could not be completed.';
 
 const PENDING_WORKFLOW_ACTION_CAPABILITIES = {
   canSetTitle: true,
@@ -93,9 +94,21 @@ const PENDING_WORKFLOW_ACTION_CAPABILITIES = {
   canBypassDependencies: true,
 } satisfies RowActionsExecution['actions'];
 
-function readableWorkflowActionError(error: Error): string {
-  const message = error.message.trim();
-  if (!message) return 'The workflow action could not be completed.';
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function readableWorkflowActionError(error: unknown): string {
+  const rawMessage =
+    error instanceof Error
+      ? error.message
+      : typeof error === 'string'
+        ? error
+        : isRecord(error) && typeof error.message === 'string'
+          ? error.message
+          : '';
+  const message = rawMessage.trim();
+  if (!message) return DEFAULT_WORKFLOW_ACTION_ERROR;
   try {
     const parsed = JSON.parse(message) as { detail?: unknown; message?: unknown };
     const parsedMessage =
@@ -109,6 +122,21 @@ function readableWorkflowActionError(error: Error): string {
     // Plain text API errors are already user-readable enough for this surface.
   }
   return message.replace(/\s+/g, ' ').slice(0, 240);
+}
+
+function workflowActionResultHref(result: unknown, fallbackHref: string): string {
+  const execution = isRecord(result) && isRecord(result.execution) ? result.execution : null;
+  const redirectPath =
+    execution && typeof execution.redirectPath === 'string' ? execution.redirectPath.trim() : '';
+  if (redirectPath) return redirectPath;
+
+  const resultWorkflowId =
+    execution && typeof execution.workflowId === 'string' ? execution.workflowId.trim() : '';
+  if (resultWorkflowId) {
+    return workflowDetailHref(resultWorkflowId, new URLSearchParams(window.location.search));
+  }
+
+  return fallbackHref;
 }
 
 export type WorkflowRowActionsMenuProps = {
@@ -161,7 +189,7 @@ export function WorkflowRowActionsMenu({
   }, [queryClient, workflowId]);
 
   const onMutationError = useCallback(
-    (error: Error) => {
+    (error: unknown) => {
       const message = readableWorkflowActionError(error);
       setActionError(message);
       toast.error({
@@ -367,13 +395,13 @@ export function WorkflowRowActionsMenu({
           updateMutation.mutate(
             { updateName: 'RequestRerun' },
             {
-              onSuccess: () => {
+              onSuccess: (result) => {
                 toast.success({
                   title: 'Rerun requested',
                   message: `${workflowSubject} has been queued.`,
                   action: {
                     label: 'View workflow',
-                    href: detailHref,
+                    href: workflowActionResultHref(result, detailHref),
                   },
                 });
               },

--- a/frontend/src/components/WorkflowRowActionsMenu.tsx
+++ b/frontend/src/components/WorkflowRowActionsMenu.tsx
@@ -3,7 +3,9 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { z } from 'zod';
 
 import { DashboardActionDialog } from './DashboardActionDialog';
+import { useDashboardToast } from './dashboard/DashboardToast';
 import { formatStatusLabel } from '../utils/formatters';
+import { workflowDetailHref } from '../lib/workflowListContext';
 import {
   taskCompareHref,
   taskEditForRerunHref,
@@ -91,6 +93,24 @@ const PENDING_WORKFLOW_ACTION_CAPABILITIES = {
   canBypassDependencies: true,
 } satisfies RowActionsExecution['actions'];
 
+function readableWorkflowActionError(error: Error): string {
+  const message = error.message.trim();
+  if (!message) return 'The workflow action could not be completed.';
+  try {
+    const parsed = JSON.parse(message) as { detail?: unknown; message?: unknown };
+    const parsedMessage =
+      typeof parsed.detail === 'string'
+        ? parsed.detail
+        : typeof parsed.message === 'string'
+          ? parsed.message
+          : null;
+    if (parsedMessage?.trim()) return parsedMessage.trim();
+  } catch {
+    // Plain text API errors are already user-readable enough for this surface.
+  }
+  return message.replace(/\s+/g, ' ').slice(0, 240);
+}
+
 export type WorkflowRowActionsMenuProps = {
   workflowId: string;
   apiBase: string;
@@ -111,6 +131,7 @@ export function WorkflowRowActionsMenu({
   taskEditingEnabled,
 }: WorkflowRowActionsMenuProps) {
   const queryClient = useQueryClient();
+  const toast = useDashboardToast();
   const [hasOpened, setHasOpened] = useState(false);
   const [actionError, setActionError] = useState<string | null>(null);
   const [actionNotice, setActionNotice] = useState<string | null>(null);
@@ -140,9 +161,17 @@ export function WorkflowRowActionsMenu({
     void queryClient.invalidateQueries({ queryKey: ['workflow-list'] });
   }, [queryClient, workflowId]);
 
-  const onMutationError = useCallback((error: Error) => {
-    setActionError(error.message);
-  }, []);
+  const onMutationError = useCallback(
+    (error: Error) => {
+      const message = readableWorkflowActionError(error);
+      setActionError(message);
+      toast.error({
+        title: 'Workflow action failed',
+        message,
+      });
+    },
+    [toast],
+  );
 
   const updateMutation = useMutation({
     mutationFn: async (body: Record<string, unknown>) => {
@@ -289,6 +318,8 @@ export function WorkflowRowActionsMenu({
   const rerunUnavailableReason = actions?.disabledReasons?.canRerun || null;
   const canCreateRemediation = Boolean(execution && isRemediationEligibleTarget(execution));
   const actionAvailabilityPending = actionsEnabled && !actions && !detailQuery.isError;
+  const workflowSubject = execution?.title?.trim() || workflowId;
+  const detailHref = workflowDetailHref(workflowId, new URLSearchParams(window.location.search));
   const disabledReason = useCallback(
     (key: string): string | null => {
       if (actionAvailabilityPending) return ACTION_AVAILABILITY_PENDING_REASON;
@@ -333,13 +364,19 @@ export function WorkflowRowActionsMenu({
         onCompareRun: () => {},
         onRerun: () => {
           setActionError(null);
-          setActionNotice(null);
           if (busy || !workflowId) return;
           updateMutation.mutate(
             { updateName: 'RequestRerun' },
             {
               onSuccess: () => {
-                setActionNotice('Rerun was requested and the latest execution view is ready.');
+                toast.success({
+                  title: 'Rerun requested',
+                  message: `${workflowSubject} has been queued.`,
+                  action: {
+                    label: 'View workflow',
+                    href: detailHref,
+                  },
+                });
               },
             },
           );
@@ -409,6 +446,7 @@ export function WorkflowRowActionsMenu({
     compareHref,
     createRemediationMutation,
     disabledReason,
+    detailHref,
     editHref,
     editTaskUnavailableReason,
     execution,
@@ -416,8 +454,10 @@ export function WorkflowRowActionsMenu({
     rerunUnavailableReason,
     signalMutation,
     taskEditingEnabled,
+    toast,
     updateMutation,
     workflowId,
+    workflowSubject,
   ]);
 
   const emptyMessage = detailQuery.isLoading
@@ -425,7 +465,7 @@ export function WorkflowRowActionsMenu({
     : detailQuery.isError
       ? 'Unable to load workflow actions.'
       : 'No workflow actions are currently available.';
-  const subject = execution?.title?.trim() || workflowId;
+  const subject = workflowSubject;
   const closeDialog = () => {
     setActiveDialog(null);
     setActionError(null);

--- a/frontend/src/components/WorkflowRowActionsMenu.tsx
+++ b/frontend/src/components/WorkflowRowActionsMenu.tsx
@@ -134,7 +134,6 @@ export function WorkflowRowActionsMenu({
   const toast = useDashboardToast();
   const [hasOpened, setHasOpened] = useState(false);
   const [actionError, setActionError] = useState<string | null>(null);
-  const [actionNotice, setActionNotice] = useState<string | null>(null);
   const [activeDialog, setActiveDialog] = useState<RowActionDialogKind | null>(null);
 
   const detailQuery = useQuery({
@@ -416,7 +415,6 @@ export function WorkflowRowActionsMenu({
         },
         onBypassDependencies: () => {
           setActionError(null);
-          setActionNotice(null);
           signalMutation.mutate(
             {
               signalName: 'BypassDependencies',
@@ -424,7 +422,14 @@ export function WorkflowRowActionsMenu({
             },
             {
               onSuccess: () => {
-                setActionNotice('Dependency wait bypass was requested.');
+                toast.success({
+                  title: 'Dependency wait bypass requested',
+                  message: `${workflowSubject} will continue without waiting on dependencies.`,
+                  action: {
+                    label: 'View workflow',
+                    href: detailHref,
+                  },
+                });
               },
             },
           );
@@ -535,11 +540,6 @@ export function WorkflowRowActionsMenu({
       {actionError ? (
         <p className="workflow-row-actions-error" role="alert">
           {actionError}
-        </p>
-      ) : null}
-      {actionNotice ? (
-        <p className="notice ok" role="status">
-          {actionNotice}
         </p>
       ) : null}
     </div>

--- a/frontend/src/components/dashboard/DashboardToast.test.tsx
+++ b/frontend/src/components/dashboard/DashboardToast.test.tsx
@@ -1,0 +1,88 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+
+import { DashboardToastProvider, useDashboardToast } from './DashboardToast';
+
+function ToastHarness() {
+  const toast = useDashboardToast();
+  return (
+    <button
+      type="button"
+      onClick={() => {
+        toast.success({
+          title: 'Rerun requested',
+          message: 'Example workflow has been queued.',
+          action: { label: 'View workflow', href: '/workflows/wf-123?source=temporal' },
+          durationMs: 1000,
+        });
+      }}
+    >
+      Show toast
+    </button>
+  );
+}
+
+function renderToastHarness() {
+  render(
+    <DashboardToastProvider>
+      <ToastHarness />
+    </DashboardToastProvider>,
+  );
+  fireEvent.click(screen.getByRole('button', { name: 'Show toast' }));
+}
+
+describe('DashboardToast (MM-1033)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('auto-dismisses success toasts after their duration', () => {
+    renderToastHarness();
+    expect(screen.getByRole('status')).toBeTruthy();
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    expect(screen.queryByRole('status')).toBeNull();
+  });
+
+  it('pauses auto-dismiss while hovered', () => {
+    renderToastHarness();
+    const toast = screen.getByRole('status');
+
+    fireEvent.mouseEnter(toast);
+    act(() => {
+      vi.advanceTimersByTime(1500);
+    });
+    expect(screen.getByRole('status')).toBeTruthy();
+
+    fireEvent.mouseLeave(toast);
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(screen.queryByRole('status')).toBeNull();
+  });
+
+  it('pauses auto-dismiss while focused', () => {
+    renderToastHarness();
+    const closeButton = screen.getByRole('button', { name: 'Dismiss Rerun requested' });
+
+    fireEvent.focus(closeButton);
+    act(() => {
+      vi.advanceTimersByTime(1500);
+    });
+    expect(screen.getByRole('status')).toBeTruthy();
+
+    fireEvent.blur(closeButton);
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(screen.queryByRole('status')).toBeNull();
+  });
+});
+

--- a/frontend/src/components/dashboard/DashboardToast.test.tsx
+++ b/frontend/src/components/dashboard/DashboardToast.test.tsx
@@ -85,4 +85,3 @@ describe('DashboardToast (MM-1033)', () => {
     expect(screen.queryByRole('status')).toBeNull();
   });
 });
-

--- a/frontend/src/components/dashboard/DashboardToast.test.tsx
+++ b/frontend/src/components/dashboard/DashboardToast.test.tsx
@@ -68,6 +68,37 @@ describe('DashboardToast (MM-1033)', () => {
     expect(screen.queryByRole('status')).toBeNull();
   });
 
+  it('does not subtract remaining duration twice while already paused', () => {
+    renderToastHarness();
+    const toast = screen.getByRole('status');
+    const closeButton = screen.getByRole('button', { name: 'Dismiss Rerun requested' });
+
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+    fireEvent.mouseEnter(toast);
+    act(() => {
+      vi.advanceTimersByTime(600);
+    });
+    fireEvent.focus(closeButton);
+    act(() => {
+      vi.advanceTimersByTime(600);
+    });
+    expect(screen.getByRole('status')).toBeTruthy();
+
+    fireEvent.mouseLeave(toast);
+    fireEvent.blur(closeButton);
+    act(() => {
+      vi.advanceTimersByTime(699);
+    });
+    expect(screen.getByRole('status')).toBeTruthy();
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(screen.queryByRole('status')).toBeNull();
+  });
+
   it('pauses auto-dismiss while focused', () => {
     renderToastHarness();
     const closeButton = screen.getByRole('button', { name: 'Dismiss Rerun requested' });

--- a/frontend/src/components/dashboard/DashboardToast.tsx
+++ b/frontend/src/components/dashboard/DashboardToast.tsx
@@ -1,0 +1,188 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react';
+import { CheckCircle2, X, XCircle } from 'lucide-react';
+
+export type DashboardToastVariant = 'success' | 'error' | 'info';
+
+export type DashboardToastAction = {
+  label: string;
+  href: string;
+};
+
+export type DashboardToastOptions = {
+  title: string;
+  message?: string;
+  action?: DashboardToastAction;
+  durationMs?: number | null;
+};
+
+type DashboardToastItem = DashboardToastOptions & {
+  id: string;
+  variant: DashboardToastVariant;
+};
+
+type DashboardToastContextValue = {
+  success: (options: DashboardToastOptions) => string;
+  error: (options: DashboardToastOptions) => string;
+  info: (options: DashboardToastOptions) => string;
+  dismiss: (id: string) => void;
+};
+
+const DashboardToastContext = createContext<DashboardToastContextValue | null>(null);
+const SUCCESS_TOAST_DURATION_MS = 5000;
+let toastIdSequence = 0;
+
+function createToastId(): string {
+  toastIdSequence += 1;
+  return `dashboard-toast-${toastIdSequence}`;
+}
+
+export function DashboardToastProvider({ children }: { children: ReactNode }) {
+  const [toasts, setToasts] = useState<DashboardToastItem[]>([]);
+
+  const dismiss = useCallback((id: string) => {
+    setToasts((current) => current.filter((toast) => toast.id !== id));
+  }, []);
+
+  const addToast = useCallback((variant: DashboardToastVariant, options: DashboardToastOptions) => {
+    const id = createToastId();
+    const durationMs =
+      options.durationMs === undefined
+        ? variant === 'success' || variant === 'info'
+          ? SUCCESS_TOAST_DURATION_MS
+          : null
+        : options.durationMs;
+    setToasts((current) => [
+      ...current,
+      {
+        ...options,
+        durationMs,
+        id,
+        variant,
+      },
+    ]);
+    return id;
+  }, []);
+
+  const value = useMemo<DashboardToastContextValue>(
+    () => ({
+      success: (options) => addToast('success', options),
+      error: (options) => addToast('error', options),
+      info: (options) => addToast('info', options),
+      dismiss,
+    }),
+    [addToast, dismiss],
+  );
+
+  return (
+    <DashboardToastContext.Provider value={value}>
+      {children}
+      <DashboardToastViewport toasts={toasts} onDismiss={dismiss} />
+    </DashboardToastContext.Provider>
+  );
+}
+
+export function useDashboardToast(): DashboardToastContextValue {
+  const context = useContext(DashboardToastContext);
+  if (!context) {
+    throw new Error('useDashboardToast must be used within DashboardToastProvider');
+  }
+  return context;
+}
+
+function DashboardToastViewport({
+  toasts,
+  onDismiss,
+}: {
+  toasts: DashboardToastItem[];
+  onDismiss: (id: string) => void;
+}) {
+  if (toasts.length === 0) return null;
+  return (
+    <div className="dashboard-toast-viewport" aria-label="Dashboard notifications">
+      {toasts.map((toast) => (
+        <DashboardToast key={toast.id} toast={toast} onDismiss={onDismiss} />
+      ))}
+    </div>
+  );
+}
+
+function DashboardToast({
+  toast,
+  onDismiss,
+}: {
+  toast: DashboardToastItem;
+  onDismiss: (id: string) => void;
+}) {
+  const [isPaused, setIsPaused] = useState(false);
+  const remainingMs = useRef(toast.durationMs ?? null);
+  const startedAt = useRef<number | null>(null);
+  const timer = useRef<number | null>(null);
+  const isError = toast.variant === 'error';
+
+  const clearTimer = useCallback(() => {
+    if (timer.current !== null) {
+      window.clearTimeout(timer.current);
+      timer.current = null;
+    }
+  }, []);
+
+  useEffect(() => {
+    if (remainingMs.current === null || isPaused) return clearTimer;
+    startedAt.current = Date.now();
+    timer.current = window.setTimeout(() => {
+      onDismiss(toast.id);
+    }, remainingMs.current);
+    return clearTimer;
+  }, [clearTimer, isPaused, onDismiss, toast.id]);
+
+  const pause = () => {
+    if (remainingMs.current !== null && startedAt.current !== null) {
+      remainingMs.current = Math.max(0, remainingMs.current - (Date.now() - startedAt.current));
+    }
+    setIsPaused(true);
+  };
+  const resume = () => setIsPaused(false);
+
+  return (
+    <section
+      className={`dashboard-toast dashboard-toast--${toast.variant}`}
+      role={isError ? 'alert' : 'status'}
+      aria-live={isError ? 'assertive' : 'polite'}
+      onMouseEnter={pause}
+      onMouseLeave={resume}
+      onFocus={pause}
+      onBlur={resume}
+    >
+      <div className="dashboard-toast__icon" aria-hidden="true">
+        {isError ? <XCircle size={18} /> : <CheckCircle2 size={18} />}
+      </div>
+      <div className="dashboard-toast__content">
+        <p className="dashboard-toast__title">{toast.title}</p>
+        {toast.message ? <p className="dashboard-toast__message">{toast.message}</p> : null}
+        {toast.action ? (
+          <a className="dashboard-toast__action" href={toast.action.href}>
+            {toast.action.label}
+          </a>
+        ) : null}
+      </div>
+      <button
+        type="button"
+        className="dashboard-toast__close"
+        aria-label={`Dismiss ${toast.title}`}
+        onClick={() => onDismiss(toast.id)}
+      >
+        <X size={16} aria-hidden="true" />
+      </button>
+    </section>
+  );
+}
+

--- a/frontend/src/components/dashboard/DashboardToast.tsx
+++ b/frontend/src/components/dashboard/DashboardToast.tsx
@@ -89,7 +89,6 @@ export function DashboardToastProvider({ children }: { children: ReactNode }) {
     </DashboardToastContext.Provider>
   );
 }
-
 export function useDashboardToast(): DashboardToastContextValue {
   const context = useContext(DashboardToastContext);
   if (!context) {
@@ -185,4 +184,3 @@ function DashboardToast({
     </section>
   );
 }
-

--- a/frontend/src/components/dashboard/DashboardToast.tsx
+++ b/frontend/src/components/dashboard/DashboardToast.tsx
@@ -122,6 +122,7 @@ function DashboardToast({
   onDismiss: (id: string) => void;
 }) {
   const [isPaused, setIsPaused] = useState(false);
+  const isPausedRef = useRef(false);
   const remainingMs = useRef(toast.durationMs ?? null);
   const startedAt = useRef<number | null>(null);
   const timer = useRef<number | null>(null);
@@ -144,12 +145,17 @@ function DashboardToast({
   }, [clearTimer, isPaused, onDismiss, toast.id]);
 
   const pause = () => {
+    if (isPausedRef.current) return;
+    isPausedRef.current = true;
     if (remainingMs.current !== null && startedAt.current !== null) {
       remainingMs.current = Math.max(0, remainingMs.current - (Date.now() - startedAt.current));
     }
     setIsPaused(true);
   };
-  const resume = () => setIsPaused(false);
+  const resume = () => {
+    isPausedRef.current = false;
+    setIsPaused(false);
+  };
 
   return (
     <section

--- a/frontend/src/components/dashboard/index.ts
+++ b/frontend/src/components/dashboard/index.ts
@@ -10,5 +10,11 @@ export type {
 } from './DashboardNotice';
 export { DashboardErrorDetails } from './DashboardErrorDetails';
 export type { DashboardErrorDetailsProps } from './DashboardErrorDetails';
+export { DashboardToastProvider, useDashboardToast } from './DashboardToast';
+export type {
+  DashboardToastAction,
+  DashboardToastOptions,
+  DashboardToastVariant,
+} from './DashboardToast';
 export { LogPanel } from './LogPanel';
 export type { LogPanelProps } from './LogPanel';

--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -7829,6 +7829,141 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
   color: rgb(var(--mm-danger));
 }
 
+/* DashboardToast ----------------------------------------------------------- */
+
+.dashboard-toast-viewport {
+  position: fixed;
+  z-index: 1000;
+  right: max(1rem, env(safe-area-inset-right));
+  bottom: max(1rem, env(safe-area-inset-bottom));
+  display: flex;
+  width: min(24rem, calc(100vw - 2rem));
+  max-height: calc(100vh - 2rem);
+  flex-direction: column;
+  gap: 0.75rem;
+  pointer-events: none;
+}
+
+.dashboard-toast {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  gap: 0.7rem;
+  align-items: start;
+  border-radius: 0.5rem;
+  border: 1px solid rgb(var(--mm-border) / 0.82);
+  background: rgb(var(--mm-panel) / 0.97);
+  color: rgb(var(--mm-ink));
+  box-shadow: 0 20px 42px -28px rgb(var(--mm-ink) / 0.72);
+  padding: 0.82rem;
+  pointer-events: auto;
+  animation: dashboard-toast-enter 160ms ease-out;
+}
+
+.dashboard-toast--success {
+  border-color: rgb(var(--mm-ok) / 0.58);
+}
+
+.dashboard-toast--error {
+  border-color: rgb(var(--mm-danger) / 0.58);
+}
+
+.dashboard-toast__icon {
+  display: inline-flex;
+  color: rgb(var(--mm-accent));
+  padding-top: 0.12rem;
+}
+
+.dashboard-toast--success .dashboard-toast__icon {
+  color: rgb(var(--mm-ok));
+}
+
+.dashboard-toast--error .dashboard-toast__icon {
+  color: rgb(var(--mm-danger));
+}
+
+.dashboard-toast__content {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 0.38rem;
+}
+
+.dashboard-toast__title,
+.dashboard-toast__message {
+  margin: 0;
+}
+
+.dashboard-toast__title {
+  font-weight: 700;
+  line-height: 1.25;
+}
+
+.dashboard-toast__message {
+  color: rgb(var(--mm-ink) / 0.76);
+  font-size: 0.88rem;
+  line-height: 1.4;
+  overflow-wrap: anywhere;
+}
+
+.dashboard-toast__action {
+  width: fit-content;
+  color: rgb(var(--mm-accent));
+  font-size: 0.88rem;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.dashboard-toast__action:hover,
+.dashboard-toast__action:focus-visible {
+  text-decoration: underline;
+}
+
+.dashboard-toast__close {
+  display: inline-flex;
+  width: 1.75rem;
+  height: 1.75rem;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid transparent;
+  border-radius: 0.45rem;
+  background: transparent;
+  color: rgb(var(--mm-ink) / 0.68);
+  cursor: pointer;
+}
+
+.dashboard-toast__close:hover,
+.dashboard-toast__close:focus-visible {
+  border-color: rgb(var(--mm-border) / 0.82);
+  background: rgb(var(--mm-ink) / 0.06);
+  color: rgb(var(--mm-ink));
+}
+
+@keyframes dashboard-toast-enter {
+  from {
+    opacity: 0;
+    transform: translateY(0.35rem);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (max-width: 640px) {
+  .dashboard-toast-viewport {
+    right: max(0.75rem, env(safe-area-inset-right));
+    left: max(0.75rem, env(safe-area-inset-left));
+    bottom: max(0.75rem, env(safe-area-inset-bottom));
+    width: auto;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .dashboard-toast {
+    animation: none;
+  }
+}
+
 /* DashboardErrorDetails ---------------------------------------------------- */
 
 .dashboard-error-details {

--- a/frontend/src/utils/test-utils.tsx
+++ b/frontend/src/utils/test-utils.tsx
@@ -1,6 +1,7 @@
 import { ReactElement } from 'react';
 import { render, RenderOptions } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { DashboardToastProvider } from '../components/dashboard/DashboardToast';
 
 const createTestQueryClient = () => new QueryClient({
   defaultOptions: {
@@ -16,14 +17,18 @@ export function renderWithClient(
 ) {
   const testQueryClient = createTestQueryClient();
   const { rerender, ...result } = render(
-    <QueryClientProvider client={testQueryClient}>{ui}</QueryClientProvider>,
+    <QueryClientProvider client={testQueryClient}>
+      <DashboardToastProvider>{ui}</DashboardToastProvider>
+    </QueryClientProvider>,
     options
   );
   return {
     ...result,
     rerender: (rerenderUi: ReactElement) =>
       rerender(
-        <QueryClientProvider client={testQueryClient}>{rerenderUi}</QueryClientProvider>
+        <QueryClientProvider client={testQueryClient}>
+          <DashboardToastProvider>{rerenderUi}</DashboardToastProvider>
+        </QueryClientProvider>
       ),
   };
 }


### PR DESCRIPTION
Issue reference: MM-1033

Summary:
- Adds a reusable dashboard toast provider, viewport, and toast component mounted at dashboard boot.
- Routes workflow row rerun success feedback to a floating toast with workflow context and a View workflow action.
- Surfaces workflow action failures through an accessible error toast while preserving accessible inline dialog/action errors.
- Updates workflow row action and toast tests for rerun toast behavior, dismissal, old inline notice removal, and error feedback.

Tests run:
- git diff --check
- Secret-pattern scan over branch diff
- ./tools/test_unit.sh --ui-args frontend/src/components/dashboard/DashboardToast.test.tsx frontend/src/components/WorkflowRowActionsMenu.test.tsx (blocked: container lacks pytest)
- npm run ui:test -- frontend/src/components/dashboard/DashboardToast.test.tsx frontend/src/components/WorkflowRowActionsMenu.test.tsx (blocked: npm shim could not find vitest before install)
- npm ci --no-fund --no-audit
- ./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/components/dashboard/DashboardToast.test.tsx frontend/src/components/WorkflowRowActionsMenu.test.tsx (blocked: Vitest resolved imports under /frontend/...)
- ./node_modules/.bin/vitest run --config /work/agent_jobs/mm:c53b3e6c-7f2f-46d1-89e9-3b55e8db6bb4/repo/frontend/vite.config.ts frontend/src/components/dashboard/DashboardToast.test.tsx frontend/src/components/WorkflowRowActionsMenu.test.tsx (blocked: same /frontend/... module resolution issue)

Remaining risks:
- Targeted Vitest tests could not complete in this managed workspace because test module paths resolve to /frontend/... despite the files existing under the repository root.
- Error toasts are long-lived by default and still paired with existing inline accessible error text for row action failures.
