### PR TITLE
The X button on the capabilities and images needs to be SMALLER. Particularly the outer border. It is too large vertically and horizontally in compari

### DIFF
--- a/frontend/src/entrypoints/dashboard-app.tsx
+++ b/frontend/src/entrypoints/dashboard-app.tsx
@@ -306,8 +306,7 @@ function DashboardLiveUpdateProvider({
 function DashboardNavigation({ uiInfo }: { uiInfo: DashboardUiInfo | null }) {
   const [open, setOpen] = useState(false);
   const location = useLocation();
-  const isWorkflowStart =
-    location.pathname === '/workflows/new' || location.pathname.startsWith('/workflows/new/');
+  const isWorkflowStart = location.pathname.replace(/\/$/, '') === '/workflows/new';
   const isWorkflowDetail = location.pathname.startsWith('/workflows/') && !isWorkflowStart;
   const buildId = typeof uiInfo?.buildId === 'string' && uiInfo.buildId.trim() ? uiInfo.buildId : null;
 

--- a/frontend/src/entrypoints/dashboard-app.tsx
+++ b/frontend/src/entrypoints/dashboard-app.tsx
@@ -306,8 +306,9 @@ function DashboardLiveUpdateProvider({
 function DashboardNavigation({ uiInfo }: { uiInfo: DashboardUiInfo | null }) {
   const [open, setOpen] = useState(false);
   const location = useLocation();
-  const isWorkflowDetail =
-    location.pathname.startsWith('/workflows/') && location.pathname !== '/workflows/new';
+  const isWorkflowStart =
+    location.pathname === '/workflows/new' || location.pathname.startsWith('/workflows/new/');
+  const isWorkflowDetail = location.pathname.startsWith('/workflows/') && !isWorkflowStart;
   const buildId = typeof uiInfo?.buildId === 'string' && uiInfo.buildId.trim() ? uiInfo.buildId : null;
 
   useEffect(() => {

--- a/frontend/src/entrypoints/dashboard.test.tsx
+++ b/frontend/src/entrypoints/dashboard.test.tsx
@@ -356,6 +356,8 @@ describe('Dashboard shared entry', () => {
     const workflowsLink = screen.getByRole('link', { name: 'Workflows' });
     expect(startLink.getAttribute('aria-current')).toBe('page');
     expect(workflowsLink.getAttribute('aria-current')).toBeNull();
+    expect(startLink.classList.contains('active')).toBe(true);
+    expect(workflowsLink.classList.contains('active')).toBe(false);
 
     fireEvent.click(workflowsLink);
 
@@ -363,6 +365,7 @@ describe('Dashboard shared entry', () => {
     expect(document.querySelector('.panel')).toBe(shellPanel);
     expect(window.location.pathname).toBe('/workflows');
     expect(screen.getByRole('link', { name: 'Workflows' }).getAttribute('aria-current')).toBe('page');
+    expect(screen.getByRole('link', { name: 'Workflows' }).classList.contains('active')).toBe(true);
   });
 
   it('waits for UI info before mounting the workflow start route', async () => {

--- a/frontend/src/entrypoints/workflow-start.test.tsx
+++ b/frontend/src/entrypoints/workflow-start.test.tsx
@@ -18305,7 +18305,7 @@ describe("Task Create MM-937 step hover containment", () => {
 
   it("keeps dependency remove buttons in a fixed right column beside wrapping text", () => {
     expect(dashboardCss).toMatch(
-      /#queue-dependency-list\s+li\s*\{[^}]*display:\s*grid;[^}]*grid-template-columns:\s*minmax\(0,\s*1fr\)\s+auto;[^}]*align-items:\s*center;[^}]*flex-wrap:\s*nowrap;/s,
+      /#queue-dependency-list\s+li\s*\{[^}]*display:\s*grid;[^}]*grid-template-columns:\s*minmax\(0,\s*1fr\)\s+auto;[^}]*align-items:\s*center;/s,
     );
     expect(dashboardCss).toMatch(
       /#queue-dependency-list\s+li\s*>\s*span:first-child\s*\{[^}]*display:\s*block;[^}]*grid-column:\s*1;[^}]*grid-row:\s*1;/s,

--- a/frontend/src/entrypoints/workflow-start.test.tsx
+++ b/frontend/src/entrypoints/workflow-start.test.tsx
@@ -18293,7 +18293,10 @@ describe("Task Create MM-937 step hover containment", () => {
 
   it("keeps context chip remove buttons compact after the generic icon-button rules", () => {
     expect(dashboardCss).toMatch(
-      /\.queue-step-capability-chip\s+\.queue-step-capability-chip-remove,\s*\.queue-step-attachment-chip\s+\.queue-step-attachment-chip-remove\s*\{[^}]*width:\s*1rem;[^}]*height:\s*1rem;[^}]*background:\s*transparent;[^}]*border:\s*none;[^}]*padding:\s*0;[^}]*box-shadow:\s*none;/s,
+      /\.queue-step-capability-chip\s+\.queue-step-capability-chip-remove,\s*\.queue-step-attachment-chip\s+\.queue-step-attachment-chip-remove\s*\{[^}]*width:\s*0\.78rem;[^}]*height:\s*0\.78rem;[^}]*background:\s*transparent;[^}]*border:\s*none;[^}]*padding:\s*0;[^}]*box-shadow:\s*none;/s,
+    );
+    expect(dashboardCss).toMatch(
+      /\.queue-step-capability-chip\s+\.queue-step-capability-chip-remove\s+svg,\s*\.queue-step-attachment-chip\s+\.queue-step-attachment-chip-remove\s+svg\s*\{[^}]*width:\s*0\.46rem;[^}]*height:\s*0\.46rem;/s,
     );
     expect(dashboardCss).toMatch(
       /\.queue-step-capability-chip\s+\.queue-step-capability-chip-remove:hover,[^{]+\.queue-step-attachment-chip\s+\.queue-step-attachment-chip-remove\.is-clicked\s*\{[^}]*background:\s*transparent;[^}]*border:\s*none;[^}]*box-shadow:\s*none;[^}]*transform:\s*none;[^}]*filter:\s*none;/s,
@@ -18302,7 +18305,13 @@ describe("Task Create MM-937 step hover containment", () => {
 
   it("keeps dependency remove buttons in a fixed right column beside wrapping text", () => {
     expect(dashboardCss).toMatch(
-      /#queue-dependency-list\s+li\s*\{[^}]*display:\s*grid;[^}]*grid-template-columns:\s*minmax\(0,\s*1fr\)\s+auto;[^}]*align-items:\s*center;/s,
+      /#queue-dependency-list\s+li\s*\{[^}]*display:\s*grid;[^}]*grid-template-columns:\s*minmax\(0,\s*1fr\)\s+auto;[^}]*align-items:\s*center;[^}]*flex-wrap:\s*nowrap;/s,
+    );
+    expect(dashboardCss).toMatch(
+      /#queue-dependency-list\s+li\s*>\s*span:first-child\s*\{[^}]*display:\s*block;[^}]*grid-column:\s*1;[^}]*grid-row:\s*1;/s,
+    );
+    expect(dashboardCss).toMatch(
+      /#queue-dependency-list\s+\.queue-step-icon-button\s*\{[^}]*grid-column:\s*2;[^}]*grid-row:\s*1;[^}]*align-self:\s*center;[^}]*justify-self:\s*end;/s,
     );
   });
 });

--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -5086,7 +5086,6 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
   grid-template-columns: minmax(0, 1fr) auto;
   align-items: center;
   column-gap: 0.5rem;
-  flex-wrap: nowrap;
 }
 
 :is(.queue-step-attachments-list, #queue-dependency-list) li > span:first-child {

--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -5086,11 +5086,25 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
   grid-template-columns: minmax(0, 1fr) auto;
   align-items: center;
   column-gap: 0.5rem;
+  flex-wrap: nowrap;
 }
 
 :is(.queue-step-attachments-list, #queue-dependency-list) li > span:first-child {
   min-width: 0;
   overflow-wrap: anywhere;
+}
+
+#queue-dependency-list li > span:first-child {
+  display: block;
+  grid-column: 1;
+  grid-row: 1;
+}
+
+#queue-dependency-list .queue-step-icon-button {
+  grid-column: 2;
+  grid-row: 1;
+  align-self: center;
+  justify-self: end;
 }
 
 :is(.queue-step-attachments-list, #queue-dependency-list) .queue-step-icon-button {
@@ -6356,10 +6370,10 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
 
 .queue-step-capability-chip .queue-step-capability-chip-remove,
 .queue-step-attachment-chip .queue-step-attachment-chip-remove {
-  flex: 0 0 1rem;
-  width: 1rem;
-  min-width: 1rem;
-  height: 1rem;
+  flex: 0 0 0.78rem;
+  width: 0.78rem;
+  min-width: 0.78rem;
+  height: 0.78rem;
   border-radius: 999px;
   background: transparent;
   background-image: none;
@@ -6370,8 +6384,8 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
 
 .queue-step-capability-chip .queue-step-capability-chip-remove svg,
 .queue-step-attachment-chip .queue-step-attachment-chip-remove svg {
-  width: 0.56rem;
-  height: 0.56rem;
+  width: 0.46rem;
+  height: 0.46rem;
   stroke-width: 2;
 }
 


### PR DESCRIPTION
The X button on the capabilities and images needs to be SMALLER. Particularly the outer border. It is too large vertically and horizontally in comparison to the text. This is the third time I'm asking for this change so not sure what is going on and why it's not changing. make sure that your change actually works since the last two attempts failed.

Additionally, I want the dependencies which get added to have an X that remains to the right of the dependency text without wrapping down to its own line. The dependency text should wrap early so that the X does not get pushed down to a new line. The X should remain centered vertically to the right of the dependency text.

Lastly when I select Start Workflow, I see a fat purple underline for both Workflows AND Start Workflow. It should only be under Start Workflow in this case.