### PR TITLE
While viewing workflow detail, fully collapsing the sidebar should not shift the positioning of the workflow detail on the page as long as there is sp

### DIFF
--- a/frontend/src/entrypoints/workflow-detail.test.tsx
+++ b/frontend/src/entrypoints/workflow-detail.test.tsx
@@ -1117,8 +1117,8 @@ describe('Workflow Detail Entrypoint', () => {
     expect(dashboardCss).toMatch(
       /\.workflow-workspace-shell\s*\{[^}]*grid-template-columns:\s*minmax\(14rem,\s*17rem\) minmax\(0,\s*1fr\);/,
     );
-    expect(dashboardCss).not.toMatch(
-      /\.workflow-workspace-shell\[data-sidebar-collapsed="true"\]\s*\{[^}]*grid-template-columns:/,
+    expect(dashboardCss).toMatch(
+      /@media \(min-width:\s*768px\) and \(max-width:\s*85rem\)\s*\{[\s\S]*\.workflow-workspace-shell\[data-sidebar-collapsed="true"\]\s*\{[\s\S]*grid-template-columns:\s*auto minmax\(0,\s*1fr\);[\s\S]*column-gap:\s*1rem;/,
     );
     expect(dashboardCss).toMatch(
       /@media \(prefers-reduced-motion:\s*reduce\)\s*\{[\s\S]*\.workflow-workspace-shell,[\s\S]*\.workflow-workspace-detail[\s\S]*transition:\s*none !important;[\s\S]*animation:\s*none !important;[\s\S]*transform:\s*none !important;/,

--- a/frontend/src/entrypoints/workflow-detail.test.tsx
+++ b/frontend/src/entrypoints/workflow-detail.test.tsx
@@ -1115,7 +1115,10 @@ describe('Workflow Detail Entrypoint', () => {
 
     const dashboardCss = await readDashboardCss();
     expect(dashboardCss).toMatch(
-      /@media \(min-width:\s*768px\) and \(max-width:\s*1023px\)\s*\{[\s\S]*\.workflow-workspace-shell\[data-sidebar-collapsed="true"\]\s*\{[\s\S]*grid-template-columns:\s*auto minmax\(0,\s*1fr\);[\s\S]*column-gap:\s*1rem;/,
+      /\.workflow-workspace-shell\s*\{[^}]*grid-template-columns:\s*minmax\(14rem,\s*17rem\) minmax\(0,\s*1fr\);/,
+    );
+    expect(dashboardCss).not.toMatch(
+      /\.workflow-workspace-shell\[data-sidebar-collapsed="true"\]\s*\{[^}]*grid-template-columns:/,
     );
     expect(dashboardCss).toMatch(
       /@media \(prefers-reduced-motion:\s*reduce\)\s*\{[\s\S]*\.workflow-workspace-shell,[\s\S]*\.workflow-workspace-detail[\s\S]*transition:\s*none !important;[\s\S]*animation:\s*none !important;[\s\S]*transform:\s*none !important;/,

--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -7016,7 +7016,7 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
 
 /* The detail is a centered, width-bounded container in a stable grid column.
  * Sidebar collapse hides the navigation in its reserved left column, so the
- * detail only reflows when the viewport reaches the compressed mobile layout. */
+ * detail only reflows when the viewport is compressed below 85rem. */
 .workflow-workspace-detail {
   min-width: 0;
   width: 100%;
@@ -7028,6 +7028,13 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
   justify-self: start;
   align-self: start;
   margin-bottom: 0.75rem;
+}
+
+@media (min-width: 768px) and (max-width: 85rem) {
+  .workflow-workspace-shell[data-sidebar-collapsed="true"] {
+    grid-template-columns: auto minmax(0, 1fr);
+    column-gap: 1rem;
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -7014,9 +7014,9 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
   font-size: 0.85rem;
 }
 
-/* The detail is a centered, width-bounded container with a gap from the sidebar.
- * Because its width is capped, collapsing the sidebar only re-centers it; it
- * never grows wider. */
+/* The detail is a centered, width-bounded container in a stable grid column.
+ * Sidebar collapse hides the navigation in its reserved left column, so the
+ * detail only reflows when the viewport reaches the compressed mobile layout. */
 .workflow-workspace-detail {
   min-width: 0;
   width: 100%;
@@ -7074,13 +7074,6 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
   .flat-fact-grid > div {
     grid-template-columns: minmax(0, 1fr);
     gap: 0.2rem;
-  }
-}
-
-@media (min-width: 768px) and (max-width: 1023px) {
-  .workflow-workspace-shell[data-sidebar-collapsed="true"] {
-    grid-template-columns: auto minmax(0, 1fr);
-    column-gap: 1rem;
   }
 }
 


### PR DESCRIPTION
While viewing workflow detail, fully collapsing the sidebar should not shift the positioning of the workflow detail on the page as long as there is space to the left of workflow detail. Workflow detail positioning should be independent of the sidebar unless the screen width is compressed.