### PR TITLE
Handle provider quota as awaiting slot retry

### DIFF
--- a/moonmind/workflows/provider_failures.py
+++ b/moonmind/workflows/provider_failures.py
@@ -44,6 +44,7 @@ _RATE_LIMIT_MARKERS = (
     "usage limit",
     "usage_limit_reached",
     "hit your limit",
+    "hit your weekly limit",
     "hit your session limit",
     "send a request to your admin",
 )

--- a/moonmind/workflows/temporal/runtime/output_parser.py
+++ b/moonmind/workflows/temporal/runtime/output_parser.py
@@ -20,12 +20,13 @@ _GEMINI_RATE_LIMIT_MARKERS: tuple[str, ...] = (
     "retrying with backoff",
 )
 # Markers for Anthropic Claude Code CLI usage-limit messages.  The shipped CLI
-# prints variations of "You've hit your limit · resets <time>" (account
-# quota), "You've hit your session limit ..." (subscription/session quota), and
-# "You've hit your usage limit ..." (workspace/admin quota); all exit with a
-# non-zero code and otherwise look like a generic execution error.
+# prints variations of "You've hit your limit · resets <time>" (account quota),
+# "You've hit your weekly/session limit ..." (subscription quota), and "You've
+# hit your usage limit ..." (workspace/admin quota); all exit with a non-zero
+# code and otherwise look like a generic execution error.
 _CLAUDE_CODE_RATE_LIMIT_MARKERS: tuple[str, ...] = (
     "hit your limit",
+    "hit your weekly limit",
     "hit your session limit",
     "usage limit",
     "status 429",

--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -170,6 +170,9 @@ AGENT_RUN_RESILIENCY_POLICY_PATCH_ID = "agent-run-resiliency-policy-v1"
 AGENT_RUN_STRUCTURED_PROVIDER_FAILURE_PATCH_ID = (
     "agent-run-structured-provider-failure-cooldown-v1"
 )
+AGENT_RUN_PROVIDER_COOLDOWN_EXPONENTIAL_BACKOFF_PATCH_ID = (
+    "agent-run-provider-cooldown-exponential-backoff-v1"
+)
 AGENT_RUN_MANAGED_NO_PROGRESS_RECONCILIATION_PATCH_ID = (
     "agent-run-managed-no-progress-reconciliation-v1"
 )
@@ -204,6 +207,7 @@ _SLOT_WAIT_TIMEOUT_SECONDS = 120
 _SLOT_WAIT_MAX_RESETS = 3
 _DEFAULT_NO_PROGRESS_TIMEOUT_SECONDS = 1800
 _DEFAULT_MANAGED_429_RETRY_DELAY_SECONDS = 900
+_MAX_PROVIDER_COOLDOWN_BACKOFF_SECONDS = 3600
 _MANAGED_RUNTIME_STORE_ROOT = os.environ.get(
     "MOONMIND_AGENT_RUNTIME_STORE", "/work/agent_jobs"
 )
@@ -441,6 +445,7 @@ class MoonMindAgentRun:
         self._awaiting_slot_reason_override: str | None = None
         self._slot_wait_timeout_override_seconds: int | None = None
         self._skip_default_profile_pin_once: bool = False
+        self._provider_cooldown_retry_counts: dict[str, int] = {}
         self.runtime_selection_updated_event = asyncio.Event()
         self._pending_runtime_selection_update: dict[str, Any] | None = None
         self._paused: bool = False
@@ -628,6 +633,34 @@ class MoonMindAgentRun:
             if seconds >= 0:
                 return seconds
         return _DEFAULT_MANAGED_429_RETRY_DELAY_SECONDS
+
+    @staticmethod
+    def _provider_failure_supplies_retry_timing(provider_failure_event: Any) -> bool:
+        if provider_failure_event is None:
+            return False
+        retry_after_seconds = getattr(
+            provider_failure_event, "retry_after_seconds", None
+        )
+        if retry_after_seconds is not None and retry_after_seconds > 0:
+            return True
+        return bool(getattr(provider_failure_event, "reset_at", None))
+
+    def _next_provider_cooldown_seconds(
+        self,
+        *,
+        runtime_id: str,
+        profile_id: str | None,
+        base_seconds: int,
+    ) -> int:
+        seconds = max(0, int(base_seconds))
+        if seconds <= 0:
+            return seconds
+        key = str(profile_id or runtime_id or "managed").strip() or "managed"
+        prior_failures = self._provider_cooldown_retry_counts.get(key, 0)
+        self._provider_cooldown_retry_counts[key] = prior_failures + 1
+        multiplier = 2 ** min(prior_failures, 10)
+        cap = max(seconds, _MAX_PROVIDER_COOLDOWN_BACKOFF_SECONDS)
+        return min(seconds * multiplier, cap)
 
     @staticmethod
     def _profile_selector_has_constraints(selector: Any) -> bool:
@@ -3856,6 +3889,19 @@ class MoonMindAgentRun:
                                 provider_failure_event,
                                 now=workflow.now(),
                                 default_seconds=cooldown_seconds,
+                            )
+                        if (
+                            workflow.patched(
+                                AGENT_RUN_PROVIDER_COOLDOWN_EXPONENTIAL_BACKOFF_PATCH_ID
+                            )
+                            and not self._provider_failure_supplies_retry_timing(
+                                provider_failure_event
+                            )
+                        ):
+                            cooldown_seconds = self._next_provider_cooldown_seconds(
+                                runtime_id=runtime_id,
+                                profile_id=profile_id,
+                                base_seconds=cooldown_seconds,
                             )
                         waiting_reason = self._build_managed_rate_limit_waiting_reason(
                             runtime_id=runtime_id,

--- a/tests/unit/workflows/temporal/runtime/test_output_parser.py
+++ b/tests/unit/workflows/temporal/runtime/test_output_parser.py
@@ -96,6 +96,13 @@ class TestDefaultStrategyClassifyExit:
         assert status == "failed"
         assert failure == "integration_error"
 
+    def test_claude_rate_limited_weekly_variant(self) -> None:
+        s = ClaudeCodeStrategy()
+        stdout = "You've hit your weekly limit · resets 12pm (UTC)"
+        status, failure = s.classify_exit(1, stdout, "")
+        assert status == "failed"
+        assert failure == "integration_error"
+
     def test_claude_rate_limited_session_limit_variant(self) -> None:
         s = ClaudeCodeStrategy()
         stdout = "You've hit your session limit · resets 3:20am (UTC)"
@@ -247,6 +254,17 @@ class TestClaudeCodeOutputParser:
             "You've hit your session limit · resets 9:50pm (UTC)"
         ]
 
+    def test_parse_detects_weekly_limit_message(self) -> None:
+        parser = ClaudeCodeOutputParser()
+        result = parser.parse(
+            "You've hit your weekly limit · resets 12pm (UTC)\n",
+            "",
+        )
+        assert result.rate_limited
+        assert result.error_messages == [
+            "You've hit your weekly limit · resets 12pm (UTC)"
+        ]
+
     def test_parse_ignores_session_limit_prose_without_hit_phrase(self) -> None:
         parser = ClaudeCodeOutputParser()
         result = parser.parse(
@@ -279,6 +297,16 @@ class TestClaudeCodeOutputParser:
         parser = ClaudeCodeOutputParser()
         events = parser.parse_stream_chunk(
             "You've hit your session limit · resets 3:20am (UTC)\n"
+        )
+        assert len(events) == 1
+        assert events[0]["type"] == "rate_limit"
+        assert events[0]["provider"] == "claude_code"
+        assert events[0]["status_code"] == 429
+
+    def test_parse_stream_chunk_emits_weekly_limit_event(self) -> None:
+        parser = ClaudeCodeOutputParser()
+        events = parser.parse_stream_chunk(
+            "You've hit your weekly limit · resets 12pm (UTC)\n"
         )
         assert len(events) == 1
         assert events[0]["type"] == "rate_limit"
@@ -345,6 +373,25 @@ class TestStrategyClassifyResultRateLimit:
         result = s.classify_result(
             exit_code=1,
             stdout="You've hit your session limit · resets 3:20am (UTC)\n",
+            stderr="",
+        )
+        assert result.status == "failed"
+        assert result.failure_class == "integration_error"
+        assert result.provider_error_code == "429"
+        assert provider_error_requires_cooldown(
+            provider_error_code=result.provider_error_code,
+            retry_recommendation=None,
+        )
+
+    def test_claude_code_weekly_limit_emits_429_provider_error_code(self) -> None:
+        from moonmind.workflows.provider_failures import (
+            provider_error_requires_cooldown,
+        )
+
+        s = ClaudeCodeStrategy()
+        result = s.classify_result(
+            exit_code=1,
+            stdout="You've hit your weekly limit · resets 12pm (UTC)\n",
             stderr="",
         )
         assert result.status == "failed"

--- a/tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py
@@ -15,6 +15,7 @@ from moonmind.schemas.agent_runtime_models import (
     _MAX_SUMMARY_CHARS,
 )
 from moonmind.schemas.temporal_activity_models import AgentRuntimeFetchResultInput
+from moonmind.workflows.provider_failures import ProviderFailureEvent
 from moonmind.workflows.temporal.workflows import agent_run as agent_run_module
 from moonmind.workflows.temporal.workflows.agent_run import MoonMindAgentRun
 from moonmind.workflows.temporal.workflows.merge_gate import build_resolver_run_request
@@ -117,6 +118,56 @@ async def test_slot_waiting_reason_summarizes_capacity_or_cooldown() -> None:
     assert "runtime=codex_cli" in reason
     assert "provider=openai" in reason
     assert "missing_condition=capacity_or_cooldown" in reason
+
+async def test_provider_cooldown_backoff_doubles_and_caps_per_profile() -> None:
+    run = MoonMindAgentRun()
+
+    cooldowns = [
+        run._next_provider_cooldown_seconds(
+            runtime_id="claude_code",
+            profile_id="claude-anthropic",
+            base_seconds=900,
+        )
+        for _ in range(5)
+    ]
+
+    assert cooldowns == [900, 1800, 3600, 3600, 3600]
+
+async def test_provider_cooldown_backoff_tracks_profiles_independently() -> None:
+    run = MoonMindAgentRun()
+
+    first_profile = run._next_provider_cooldown_seconds(
+        runtime_id="claude_code",
+        profile_id="claude-anthropic",
+        base_seconds=300,
+    )
+    second_profile = run._next_provider_cooldown_seconds(
+        runtime_id="claude_code",
+        profile_id="claude-anthropic-backup",
+        base_seconds=300,
+    )
+    first_profile_second_failure = run._next_provider_cooldown_seconds(
+        runtime_id="claude_code",
+        profile_id="claude-anthropic",
+        base_seconds=300,
+    )
+
+    assert (first_profile, second_profile, first_profile_second_failure) == (
+        300,
+        300,
+        600,
+    )
+
+async def test_provider_cooldown_backoff_honors_structured_retry_timing() -> None:
+    assert MoonMindAgentRun._provider_failure_supplies_retry_timing(
+        ProviderFailureEvent(retry_after_seconds=120)
+    )
+    assert MoonMindAgentRun._provider_failure_supplies_retry_timing(
+        ProviderFailureEvent(reset_at="2026-07-01T12:00:00+00:00")
+    )
+    assert not MoonMindAgentRun._provider_failure_supplies_retry_timing(
+        ProviderFailureEvent(provider_error_class="rate_limit")
+    )
 
 async def test_managed_fetch_result_input_ignores_legacy_workspace_branch_for_head_branch(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit/workflows/test_provider_failures.py
+++ b/tests/unit/workflows/test_provider_failures.py
@@ -72,6 +72,7 @@ def test_provider_failure_search_markers_cover_classification_markers() -> None:
         "temporary errors",
         "try again later",
         "usage_limit_reached",
+        "hit your weekly limit",
         "http 401",
         "http 403",
         "insufficient scope",
@@ -92,6 +93,16 @@ def test_classifies_claude_code_short_limit_as_429() -> None:
 def test_classifies_claude_code_session_limit_as_429() -> None:
     result = classify_provider_failure(
         "You've hit your session limit · resets 3:20am (UTC)"
+    )
+
+    assert result is not None
+    assert result.failure_class == "integration_error"
+    assert result.provider_error_code == "429"
+    assert result.retry_recommendation == "retry_after_cooldown"
+
+def test_classifies_claude_code_weekly_limit_as_429() -> None:
+    result = classify_provider_failure(
+        "You've hit your weekly limit · resets 12pm (UTC)"
     )
 
     assert result is not None


### PR DESCRIPTION
## Summary

- classify Claude Code weekly quota messages as provider 429 failures
- return managed quota/capacity failures to awaiting_slot through profile cooldown retry
- add bounded per-profile exponential cooldown backoff while preserving structured provider retry hints

## Tests

- MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/test_provider_failures.py tests/unit/workflows/temporal/runtime/test_output_parser.py tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py