### PR TITLE
Fix toast close icon, sidebar row height, and workflow list striping

### DIFF
--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -1867,8 +1867,8 @@ tbody tr:hover {
   background: rgb(var(--mm-accent) / 0.18);
 }
 
-.dark .workflow-list-data-slab tbody tr:nth-child(2n),
-.workflow-list-data-slab tbody tr:nth-child(2n) {
+.dark .workflow-list-data-slab tbody tr:nth-child(2n):not(:hover),
+.workflow-list-data-slab tbody tr:nth-child(2n):not(:hover) {
   background: transparent;
 }
 
@@ -6953,7 +6953,7 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
   align-items: center;
-  min-height: 0;
+  min-height: 3.75rem;
   padding: 0.58rem 0.55rem;
   gap: 0.55rem;
   border: 0;
@@ -7960,10 +7960,19 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
 }
 
 .dashboard-toast__close:hover,
-.dashboard-toast__close:focus-visible {
+.dashboard-toast__close:focus-visible,
+.dashboard-toast__close:active {
+  transform: none;
+  filter: none;
+  box-shadow: none;
+  background-image: none;
   border-color: rgb(var(--mm-border) / 0.82);
   background: rgb(var(--mm-ink) / 0.06);
   color: rgb(var(--mm-ink));
+}
+
+.dashboard-toast__close:active {
+  background: rgb(var(--mm-ink) / 0.12);
 }
 
 @keyframes dashboard-toast-enter {

--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -1867,6 +1867,11 @@ tbody tr:hover {
   background: rgb(var(--mm-accent) / 0.18);
 }
 
+.dark .workflow-list-data-slab tbody tr:nth-child(2n),
+.workflow-list-data-slab tbody tr:nth-child(2n) {
+  background: transparent;
+}
+
 .queue-layouts {
   display: grid;
   gap: 1rem;
@@ -6948,9 +6953,9 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
   align-items: center;
-  min-height: 3.75rem;
+  min-height: 0;
+  padding: 0.58rem 0.55rem;
   gap: 0.55rem;
-  padding: 0.5rem 0.45rem;
   border: 0;
   border-radius: 0.4rem;
   background: transparent;
@@ -7935,13 +7940,23 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
   display: inline-flex;
   width: 1.75rem;
   height: 1.75rem;
+  padding: 0;
   align-items: center;
   justify-content: center;
   border: 1px solid transparent;
   border-radius: 0.45rem;
   background: transparent;
   color: rgb(var(--mm-ink) / 0.68);
+  line-height: 1;
+  box-shadow: none;
   cursor: pointer;
+}
+
+.dashboard-toast__close svg {
+  width: 0.95rem;
+  height: 0.95rem;
+  stroke: currentColor;
+  stroke-width: 2;
 }
 
 .dashboard-toast__close:hover,


### PR DESCRIPTION
## Summary
- Make floating toast close button render as an actual X icon by resetting inherited button defaults for size/spacing/shadow and explicit icon sizing.
- Remove alternating row striping from the workflow list () within the workflow list table slab.
- Align workflow workspace sidebar row height with workflow list rows by removing forced minimum height and matching table-like row padding.

## Testing
- ./tools/test_unit.sh --dashboard-only --ui-args frontend/src/components/dashboard/DashboardToast.test.tsx frontend/src/entrypoints/workflow-list.test.tsx
