### PR TITLE
[codex] Normalize managed runtime clone branch refs

### DIFF
--- a/frontend/src/entrypoints/workflow-detail.test.tsx
+++ b/frontend/src/entrypoints/workflow-detail.test.tsx
@@ -16,6 +16,7 @@ import {
   taskEditForRerunHref,
   taskEditHref,
 } from '../lib/temporalTaskEditing';
+import { WORKFLOW_LIST_RETURN_FOCUS_INTENT_KEY } from '../lib/workflowListContext';
 import { navigateTo } from '../lib/navigation';
 import { BootPayload } from '../boot/parseBootPayload';
 import { MockInstance } from 'vitest';
@@ -816,7 +817,9 @@ describe('Workflow Detail Entrypoint', () => {
     const pinned = within(pinnedGroup).getByRole('link', { name: /MM-997 selected workflow/i });
     expect(pinned.getAttribute('aria-current')).toBe('page');
     expect(pinned.getAttribute('data-pinned')).toBe('true');
-    expect(within(sidebar).queryByRole('link', { name: 'Expand to full list' })).toBeNull();
+    expect(within(sidebar).getByRole('link', { name: 'Expand to full list' }).getAttribute('href')).toBe(
+      '/workflows?stateIn=failed&returnFromWorkflowDetail=1',
+    );
     expect(await screen.findByRole('heading', { name: 'Workflow Detail' })).toBeTruthy();
     expect(lastFetchUrl(fetchSpy, '/api/executions?')).toBe('/api/executions?source=temporal&stateIn=failed&pageSize=25');
   });
@@ -912,7 +915,11 @@ describe('Workflow Detail Entrypoint', () => {
     expect(anotherWorkflow.getAttribute('href')).toBe(
       '/workflows/test-456?source=temporal&limit=10&nextPageToken=page-2&repoContains=moon%2Frepo&integration=jira',
     );
-    expect(within(sidebar).queryByRole('link', { name: 'Expand to full list' })).toBeNull();
+    const expandLink = within(sidebar).getByRole('link', { name: 'Expand to full list' });
+    expect(expandLink.getAttribute('href')).toBe(
+      '/workflows?limit=10&repoContains=moon%2Frepo&integration=jira&returnFromWorkflowDetail=1',
+    );
+    expect(expandLink.getAttribute('href')).not.toContain('token=');
     expect(lastFetchUrl(fetchSpy, '/api/executions?')).not.toContain('selectedWorkflowId=');
     expect(lastFetchUrl(fetchSpy, '/api/executions?')).not.toContain('sort=');
     expect(lastFetchUrl(fetchSpy, '/api/executions?')).not.toContain('token=');
@@ -1022,7 +1029,7 @@ describe('Workflow Detail Entrypoint', () => {
     expect(screen.queryByRole('complementary', { name: 'Workflow navigation' })).toBeNull();
   });
 
-  it('MM-1000 keeps the workspace sidebar free of full-list navigation', async () => {
+  it('MM-1000 expands to the full list with preserved context and focusable list target', async () => {
     window.history.pushState(
       {},
       'Workspace Expand Test',
@@ -1034,7 +1041,17 @@ describe('Workflow Detail Entrypoint', () => {
     renderWithClient(<WorkflowDetailEntrypoint payload={stepsPayload} />);
 
     const sidebar = await screen.findByRole('complementary', { name: 'Workflow navigation' });
-    expect(within(sidebar).queryByRole('link', { name: 'Expand to full list' })).toBeNull();
+    const expand = within(sidebar).getByRole('link', { name: 'Expand to full list' });
+    expect(expand.getAttribute('href')).toBe(
+      '/workflows?stateIn=completed&repoContains=moon%2Frepo&limit=10&returnFromWorkflowDetail=1',
+    );
+    expect(expand.getAttribute('href')).not.toContain('source=');
+    expect(expand.getAttribute('href')).not.toContain('nextPageToken=');
+    expect(expand.getAttribute('href')).not.toContain('sort=');
+    expect(expand.getAttribute('href')).not.toContain('selectedWorkflowId=');
+    expect(expand.getAttribute('href')).not.toContain('unsafe=');
+    expect(expand.getAttribute('class') || '').toContain('button');
+    expect(expand.getAttribute('class') || '').toContain('workflow-workspace-expand-list');
     expect(within(sidebar).getByRole('button', { name: 'Close sidebar' }).getAttribute('class') || '').toContain(
       'workflow-workspace-close-sidebar',
     );
@@ -1051,11 +1068,13 @@ describe('Workflow Detail Entrypoint', () => {
     expect(within(sidebar).getByRole('button', { name: 'Close sidebar' }).getAttribute('class') || '').toContain(
       'workflow-workspace-close-sidebar',
     );
-    expect(within(sidebar).queryByRole('link', { name: 'Expand to full list' })).toBeNull();
+    expect(within(sidebar).getByRole('link', { name: 'Expand to full list' }).getAttribute('class') || '').toContain(
+      'workflow-workspace-expand-list',
+    );
 
     const dashboardCss = await readDashboardCss();
     expect(dashboardCss).toMatch(/\.workflow-workspace-close-sidebar[\s\S]*?width:\s*2rem;/);
-    expect(dashboardCss).not.toMatch(/\.workflow-workspace-expand-list/);
+    expect(dashboardCss).toMatch(/\.workflow-workspace-expand-list\s*\{[\s\S]*?background:\s*rgb\(var\(--mm-accent\)/);
   });
 
   it('MM-1002 renders sidebar titles and statuses as React text', async () => {
@@ -1089,7 +1108,7 @@ describe('Workflow Detail Entrypoint', () => {
     expect(sidebar.querySelector('script')).toBeNull();
   });
 
-  it('MM-1005 does not render full-list navigation from the desktop workspace when no list context exists', async () => {
+  it('MM-1005 expands to the plain workflow list from the desktop workspace when no list context exists', async () => {
     window.history.pushState({}, 'Workspace Plain Expand Test', '/workflows/test-123?source=temporal');
     mockDesktopViewport(true);
     mockWorkflowWorkspaceFetches();
@@ -1097,7 +1116,11 @@ describe('Workflow Detail Entrypoint', () => {
     renderWithClient(<WorkflowDetailEntrypoint payload={stepsPayload} />);
 
     const sidebar = await screen.findByRole('complementary', { name: 'Workflow navigation' });
-    expect(within(sidebar).queryByRole('link', { name: 'Expand to full list' })).toBeNull();
+    const expandLink = within(sidebar).getByRole('link', { name: 'Expand to full list' });
+    expect(expandLink.getAttribute('href')).toBe('/workflows');
+
+    fireEvent.click(expandLink);
+    expect(window.sessionStorage.getItem(WORKFLOW_LIST_RETURN_FOCUS_INTENT_KEY)).toBe('1');
   });
 
   it('keeps desktop detail positioning stable when the workspace sidebar is collapsed', async () => {

--- a/frontend/src/entrypoints/workflow-detail.test.tsx
+++ b/frontend/src/entrypoints/workflow-detail.test.tsx
@@ -763,7 +763,7 @@ describe('Workflow Detail Entrypoint', () => {
     const expectedIcons = [
       ['Scheduled workflow', 'Status: scheduled', 'status-scheduled', 'lucide-calendar-clock'],
       ['Initializing workflow', 'Status: initializing', 'status-initializing', 'lucide-power'],
-      ['Dependency wait workflow', 'Status: AWAITING DEP', 'status-awaiting-dependencies', 'lucide-git-branch'],
+      ['Dependency wait workflow', 'Status: AWAITING DEP', 'status-awaiting-dependencies', 'lucide-link'],
       ['Planning workflow', 'Status: planning', 'status-planning', 'lucide-map'],
       ['Slot wait workflow', 'Status: AWAITING SLOT', 'status-awaiting-slot', 'lucide-hourglass'],
       ['Executing workflow', 'Status: executing', 'status-running', 'lucide-play'],

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -5,7 +5,7 @@ import {
   Ban,
   CalendarClock,
   Check,
-  GitBranch,
+  Link,
   Hand,
   Hourglass,
   Lightbulb,
@@ -262,7 +262,7 @@ function workflowWorkspaceListQuery(search: URLSearchParams): string {
 const WORKFLOW_STATUS_ICONS = {
   scheduled: CalendarClock,
   initializing: Power,
-  waiting_on_dependencies: GitBranch,
+  waiting_on_dependencies: Link,
   planning: MapIcon,
   awaiting_slot: Hourglass,
   executing: Play,

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -373,22 +373,11 @@ const SIDEBAR_TOGGLE_ICON = (
   </WorkspaceControlIcon>
 );
 
-const EXPAND_LIST_ICON = (
-  <WorkspaceControlIcon>
-    <path d="M15 3h6v6" />
-    <path d="M9 21H3v-6" />
-    <path d="M21 3l-7 7" />
-    <path d="M3 21l7-7" />
-  </WorkspaceControlIcon>
-);
-
 function WorkflowSidebarControls({
-  fullListHref,
   closeButtonRef,
   onClose,
   search,
 }: {
-  fullListHref: string;
   closeButtonRef: RefObject<HTMLButtonElement | null>;
   onClose: () => void;
   search: URLSearchParams;
@@ -414,15 +403,6 @@ function WorkflowSidebarControls({
       >
         {SIDEBAR_TOGGLE_ICON}
       </button>
-      <a
-        className="button workflow-workspace-expand-list"
-        href={fullListHref}
-        onClick={markWorkflowListReturnFocusIntent}
-        aria-label="Expand to full list"
-        title="Expand to full list"
-      >
-        {EXPAND_LIST_ICON}
-      </a>
     </div>
   );
 }
@@ -475,7 +455,6 @@ function WorkflowSidebar({
   workflowsQuery: UseQueryResult<z.infer<typeof WorkflowWorkspaceListResponseSchema>, Error>;
   filteredRows: WorkflowWorkspaceRow[];
   pinnedCurrentRow: WorkflowWorkspaceRow | null;
-  fullListHref: string;
   search: URLSearchParams;
   closeButtonRef: RefObject<HTMLButtonElement | null>;
   onClose: () => void;
@@ -483,7 +462,6 @@ function WorkflowSidebar({
   return (
     <aside className="workflow-workspace-sidebar" aria-label="Workflow navigation">
       <WorkflowSidebarControls
-        fullListHref={fullListHref}
         closeButtonRef={closeButtonRef}
         onClose={onClose}
         search={search}
@@ -571,7 +549,6 @@ export function WorkflowWorkspaceShell({
   const pinnedCurrentRow = selectedWorkflowQuery.data && !activeInList
     ? workflowWorkspaceRowFromDetail(selectedWorkflowQuery.data)
     : null;
-  const fullListHref = workflowListHrefFromContext(search, { markDetailReturn: true });
 
   return (
     <div
@@ -586,7 +563,6 @@ export function WorkflowWorkspaceShell({
           workflowsQuery={workflowsQuery}
           filteredRows={filteredRows}
           pinnedCurrentRow={pinnedCurrentRow}
-          fullListHref={fullListHref}
           search={search}
           closeButtonRef={closeButtonRef}
           onClose={() => {

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -36,8 +36,10 @@ import {
   taskEditHref,
 } from '../lib/temporalTaskEditing';
 import {
+  markWorkflowListReturnFocusIntent,
   workflowDetailHref,
   workflowListContextParams,
+  workflowListHrefFromContext,
 } from '../lib/workflowListContext';
 import { WorkflowActionsMenu } from '../components/WorkflowActionsMenu';
 import {
@@ -370,10 +372,21 @@ const SIDEBAR_TOGGLE_ICON = (
   </WorkspaceControlIcon>
 );
 
+const EXPAND_LIST_ICON = (
+  <WorkspaceControlIcon>
+    <path d="M15 3h6v6" />
+    <path d="M9 21H3v-6" />
+    <path d="M21 3l-7 7" />
+    <path d="M3 21l7-7" />
+  </WorkspaceControlIcon>
+);
+
 function WorkflowSidebarControls({
+  fullListHref,
   closeButtonRef,
   onClose,
 }: {
+  fullListHref: string;
   closeButtonRef: RefObject<HTMLButtonElement | null>;
   onClose: () => void;
 }) {
@@ -389,6 +402,15 @@ function WorkflowSidebarControls({
       >
         {SIDEBAR_TOGGLE_ICON}
       </button>
+      <a
+        className="button workflow-workspace-expand-list"
+        href={fullListHref}
+        onClick={markWorkflowListReturnFocusIntent}
+        aria-label="Expand to full list"
+        title="Expand to full list"
+      >
+        {EXPAND_LIST_ICON}
+      </a>
     </div>
   );
 }
@@ -441,6 +463,7 @@ function WorkflowSidebar({
   workflowsQuery: UseQueryResult<z.infer<typeof WorkflowWorkspaceListResponseSchema>, Error>;
   filteredRows: WorkflowWorkspaceRow[];
   pinnedCurrentRow: WorkflowWorkspaceRow | null;
+  fullListHref: string;
   search: URLSearchParams;
   closeButtonRef: RefObject<HTMLButtonElement | null>;
   onClose: () => void;
@@ -448,6 +471,7 @@ function WorkflowSidebar({
   return (
     <aside className="workflow-workspace-sidebar" aria-label="Workflow navigation">
       <WorkflowSidebarControls
+        fullListHref={fullListHref}
         closeButtonRef={closeButtonRef}
         onClose={onClose}
       />
@@ -534,6 +558,7 @@ export function WorkflowWorkspaceShell({
   const pinnedCurrentRow = selectedWorkflowQuery.data && !activeInList
     ? workflowWorkspaceRowFromDetail(selectedWorkflowQuery.data)
     : null;
+  const fullListHref = workflowListHrefFromContext(search, { markDetailReturn: true });
 
   return (
     <div
@@ -548,6 +573,7 @@ export function WorkflowWorkspaceShell({
           workflowsQuery={workflowsQuery}
           filteredRows={filteredRows}
           pinnedCurrentRow={pinnedCurrentRow}
+          fullListHref={fullListHref}
           search={search}
           closeButtonRef={closeButtonRef}
           onClose={() => {

--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -6883,6 +6883,7 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
 
 /* The sidebar controls are compact icon buttons rather than full-text buttons. */
 .workflow-workspace-close-sidebar,
+.workflow-workspace-expand-list,
 .workflow-workspace-open-sidebar {
   display: inline-flex;
   align-items: center;
@@ -6898,6 +6899,21 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
   width: 1.05rem;
   height: 1.05rem;
   flex: 0 0 auto;
+}
+
+/* The expand-to-list control keeps the accent emphasis so it stays visually
+ * distinct from the neutral collapse control. */
+.workflow-workspace-expand-list {
+  background: rgb(var(--mm-accent) / 0.16);
+  border-color: rgb(var(--mm-accent) / 0.45);
+  color: rgb(var(--mm-accent));
+  box-shadow: none;
+}
+
+.workflow-workspace-expand-list:hover,
+.workflow-workspace-expand-list:focus-visible {
+  background: rgb(var(--mm-accent) / 0.24);
+  border-color: rgb(var(--mm-accent) / 0.82);
 }
 
 .workflow-workspace-sidebar-list {

--- a/moonmind/workflows/temporal/runtime/launcher.py
+++ b/moonmind/workflows/temporal/runtime/launcher.py
@@ -533,6 +533,17 @@ class ManagedRuntimeLauncher:
             "Unsupported workspaceSpec.repository format; expected owner/repo, URL, or local path"
         )
 
+    @staticmethod
+    def _normalize_clone_branch(branch: str) -> str:
+        normalized = str(branch or "").strip()
+        if normalized.startswith("refs/remotes/origin/"):
+            return normalized.removeprefix("refs/remotes/origin/")
+        if normalized.startswith("refs/heads/"):
+            return normalized.removeprefix("refs/heads/")
+        if normalized.startswith("origin/"):
+            return normalized.removeprefix("origin/")
+        return normalized
+
     async def _run_command(
         self,
         *cmd: str,
@@ -644,11 +655,12 @@ class ManagedRuntimeLauncher:
             or workspace_spec.get("branch")
             or ""
         ).strip()
+        clone_branch = self._normalize_clone_branch(branch)
         command_env = git_env if self._source_uses_github_https(source) else None
 
         clone_cmd = ["git", "clone"]
-        if branch:
-            clone_cmd.extend(["--branch", branch, "--single-branch"])
+        if clone_branch:
+            clone_cmd.extend(["--branch", clone_branch, "--single-branch"])
         clone_cmd.extend([source, str(repo_path)])
         await self._run_checked_command(
             *clone_cmd,

--- a/moonmind/workflows/temporal/runtime/launcher.py
+++ b/moonmind/workflows/temporal/runtime/launcher.py
@@ -536,12 +536,16 @@ class ManagedRuntimeLauncher:
     @staticmethod
     def _normalize_clone_branch(branch: str) -> str:
         normalized = str(branch or "").strip()
-        if normalized.startswith("refs/remotes/origin/"):
-            return normalized.removeprefix("refs/remotes/origin/")
-        if normalized.startswith("refs/heads/"):
-            return normalized.removeprefix("refs/heads/")
-        if normalized.startswith("origin/"):
-            return normalized.removeprefix("origin/")
+        while True:
+            prior = normalized
+            if normalized.startswith("refs/remotes/origin/"):
+                normalized = normalized.removeprefix("refs/remotes/origin/")
+            if normalized.startswith("refs/heads/"):
+                normalized = normalized.removeprefix("refs/heads/")
+            if normalized.startswith("origin/"):
+                normalized = normalized.removeprefix("origin/")
+            if prior == normalized:
+                break
         return normalized
 
     async def _run_command(

--- a/moonmind/workflows/temporal/runtime/managed_session_controller.py
+++ b/moonmind/workflows/temporal/runtime/managed_session_controller.py
@@ -1922,6 +1922,7 @@ class DockerCodexManagedSessionController:
             or request.workspace_spec.get("branch")
             or ""
         ).strip()
+        branch = ManagedRuntimeLauncher._normalize_clone_branch(branch)
 
         clone_command = ["git", "clone"]
         if branch:

--- a/tests/unit/services/temporal/runtime/test_launcher.py
+++ b/tests/unit/services/temporal/runtime/test_launcher.py
@@ -124,6 +124,14 @@ def test_normalize_clone_branch_strips_remote_tracking_refs():
         ManagedRuntimeLauncher._normalize_clone_branch("refs/remotes/origin/main")
         == "main"
     )
+    assert (
+        ManagedRuntimeLauncher._normalize_clone_branch("refs/remotes/origin/origin/main")
+        == "main"
+    )
+    assert (
+        ManagedRuntimeLauncher._normalize_clone_branch("refs/heads/origin/main")
+        == "main"
+    )
     assert ManagedRuntimeLauncher._normalize_clone_branch("refs/heads/main") == "main"
     assert (
         ManagedRuntimeLauncher._normalize_clone_branch("feature/origin/main")

--- a/tests/unit/services/temporal/runtime/test_launcher.py
+++ b/tests/unit/services/temporal/runtime/test_launcher.py
@@ -118,6 +118,18 @@ def test_build_command_gemini_cli():
     assert "--effort" not in cmd
     assert "Fix the bug" in cmd
 
+def test_normalize_clone_branch_strips_remote_tracking_refs():
+    assert ManagedRuntimeLauncher._normalize_clone_branch("origin/main") == "main"
+    assert (
+        ManagedRuntimeLauncher._normalize_clone_branch("refs/remotes/origin/main")
+        == "main"
+    )
+    assert ManagedRuntimeLauncher._normalize_clone_branch("refs/heads/main") == "main"
+    assert (
+        ManagedRuntimeLauncher._normalize_clone_branch("feature/origin/main")
+        == "feature/origin/main"
+    )
+
 def test_apply_runtime_command_rendering_raises_before_launch_on_failure():
     store = ManagedRunStore("/tmp/test-store")
     launcher = ManagedRuntimeLauncher(store)

--- a/tests/unit/services/temporal/runtime/test_managed_session_controller.py
+++ b/tests/unit/services/temporal/runtime/test_managed_session_controller.py
@@ -1539,7 +1539,7 @@ async def test_controller_launch_clones_workspace_before_starting_container(
         imageRef="ghcr.io/moonladderstudios/moonmind:latest",
         workspaceSpec={
             "repository": "MoonLadderStudios/MoonMind",
-            "startingBranch": "dependabot/pip/requests-2.33.1",
+            "startingBranch": "origin/dependabot/pip/requests-2.33.1",
             "targetBranch": "codex/session-fix",
         },
     )
@@ -1637,7 +1637,13 @@ async def test_controller_launch_clones_workspace_before_starting_container(
 
     await controller.launch_session(request)
 
-    assert commands[0][:2] == ("git", "clone")
+    assert commands[0][:5] == (
+        "git",
+        "clone",
+        "--branch",
+        "dependabot/pip/requests-2.33.1",
+        "--single-branch",
+    )
     assert (
         "https://github.com/MoonLadderStudios/MoonMind.git" in commands[0]
     )


### PR DESCRIPTION
## What changed
- Normalize clone-time branch refs before building managed runtime `git clone --branch` commands.
- Strip `origin/`, `refs/remotes/origin/`, and `refs/heads/` when those values are supplied as `startingBranch` or `branch` for clone setup.
- Add regression coverage for the normalization helper and the Docker managed session controller clone command.

## Why
The failing workflows passed `origin/main` as the starting branch into managed session workspace setup. `git clone --branch origin/main --single-branch ...` asks GitHub for a branch literally named `origin/main`, so Git failed with `Remote branch origin/main not found`.

The clone operation needs the remote branch name, `main`, while later comparison and publish paths may still use remote-tracking refs like `origin/main` where appropriate.

## Validation
- Not run locally; this change was made without executing tests because this session's validation policy requires explicit permission before running checks.
