### PR TITLE
Adjust recurring schedule list border and create action

### DIFF
--- a/frontend/src/entrypoints/schedules.test.tsx
+++ b/frontend/src/entrypoints/schedules.test.tsx
@@ -233,7 +233,7 @@ describe("SchedulesPage", () => {
     renderWithClient(<SchedulesPage payload={mockPayload} />);
 
     const createLink = await screen.findByRole("link", {
-      name: "Create from workflow page",
+      name: "Create recurring schedule",
     });
     expect(createLink.getAttribute("href")).toBe(
       "/workflows/new?scheduleMode=recurring",

--- a/frontend/src/entrypoints/schedules.tsx
+++ b/frontend/src/entrypoints/schedules.tsx
@@ -1217,8 +1217,12 @@ export function SchedulesPage({ payload }: { payload: BootPayload }) {
           <button type="button" className="secondary" onClick={() => void refetch()} disabled={isFetching}>
             {isFetching ? 'Refreshing' : 'Refresh'}
           </button>
-          <a href="/workflows/new?scheduleMode=recurring" className="button">
-            Create from workflow page
+          <a
+            href="/workflows/new?scheduleMode=recurring"
+            className="button queue-step-icon-button"
+            aria-label="Create recurring schedule"
+          >
+            +
           </a>
         </div>
       </header>
@@ -1242,7 +1246,7 @@ export function SchedulesPage({ payload }: { payload: BootPayload }) {
         </div>
       </section>
 
-      <section className="panel--data schedules-table-panel" aria-label="Recurring schedule list">
+      <section className="schedules-table-panel" aria-label="Recurring schedule list">
         <DataTable
             data={schedules}
             isLoading={isLoading}

--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -567,6 +567,14 @@ h1 {
   min-height: 0;
 }
 
+.panel:has(.schedules-page) {
+  border: 0;
+  background: transparent;
+  box-shadow: none;
+  padding: 0;
+  min-height: 0;
+}
+
 .panel.panel--data-wide {
   max-width: min(112rem, calc(100vw - 2rem));
 }


### PR DESCRIPTION
## Summary
- Remove the outer dashboard panel wrapper around the recurring schedules list route so only the table’s own border remains.
- Keep the DataTable border visible on the recurring schedules table and remove redundant nesting borders.
- Change the recurring schedules create action to an icon-only `+` control (no visible text).
- Keep the create action linking to `/workflows/new?scheduleMode=recurring`.
- Update the schedules page test to assert the new accessible button label.

## Testing
- Updated the list container to remove the extra `panel` wrapper via CSS: `frontend/src/styles/dashboard.css`.
- Updated recurring schedules page markup in `frontend/src/entrypoints/schedules.tsx`.
- Updated the corresponding list-page test in `frontend/src/entrypoints/schedules.test.tsx`.

## Notes
Frontend test execution in this environment was not conclusive due existing dependency/runtime constraints outside this change; no functional scope changes beyond the files above.
