### PR TITLE
MM-1068 Create GitHub issue story-output tools

### DIFF
--- a/docs/Workflows/SkillAndPlanContracts.md
+++ b/docs/Workflows/SkillAndPlanContracts.md
@@ -577,6 +577,23 @@ and `"false"` for callers that produce typed or form encoded payloads.
 
 If Jira output succeeds, workflow PR output is skipped because Jira is the requested output. If Jira output cannot run or fails and fallback is enabled, the tool returns fallback metadata pointing to the existing `artifacts/story-breakdowns/...` handoff so normal branch/PR publishing can expose that docs output.
 
+`story.create_github_issues` uses the same runtime story breakdown inputs and
+reconciliation semantics as `story.create_jira_issues`, but creates GitHub
+issues through the trusted GitHub integration. It preserves source
+path/title/section/claim/source issue traceability in each GitHub issue body and
+returns stable `github.issueMappings` for downstream workflow creation. GitHub
+issue dependency output is conservative: the tool reports
+`dependencyMode = "none"` and `dependencyCount = 0` unless a trusted GitHub API
+operation has actually established a dependency relationship.
+
+`story.create_github_issue_implement_workflows` and
+`story.create_github_issue_orchestrate_workflows` consume the GitHub issue
+mappings and create downstream MoonMind workflow executions using the
+`github-issue-implement` and `github-issue-orchestrate` presets. Their output is
+reported under `githubWorkflowOrchestration` and uses workflow terminology such
+as `createdWorkflowCount`, `dependencyMode`, and `dependencyCount`; dependency
+counts refer to MoonMind workflow dependencies, not GitHub issue dependencies.
+
 ---
 
 ## 6) Plan contract

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -1899,6 +1899,86 @@ def _default_registry_skill_payload(*, name: str) -> dict[str, Any]:
             },
         }
 
+    if name == "story.create_github_issues":
+        return {
+            "name": name,
+            "description": "Create GitHub issues from Moon Spec story breakdown output.",
+            "inputs": {
+                "schema": {
+                    "type": "object",
+                    "properties": {
+                        "stories": {"type": "array"},
+                        "storyOutput": {"type": "object"},
+                        "storyBreakdownPath": {"type": "string"},
+                        "storyBreakdownJson": {"type": "string"},
+                        "repository": {"type": "string"},
+                        "targetBranch": {"type": "string"},
+                        "branch": {"type": "string"},
+                    },
+                    "additionalProperties": True,
+                }
+            },
+            "outputs": {
+                "schema": {
+                    "type": "object",
+                    "additionalProperties": True,
+                }
+            },
+            "executor": {
+                "activity_type": "mm.tool.execute",
+                "selector": {"mode": "by_capability"},
+            },
+            "requirements": {"capabilities": ["integration:github"]},
+            "policies": {
+                "timeouts": {
+                    "start_to_close_seconds": 300,
+                    "schedule_to_close_seconds": 600,
+                },
+                "retries": {"max_attempts": 1},
+            },
+        }
+
+    if name in {
+        "story.create_github_issue_implement_workflows",
+        "story.create_github_issue_orchestrate_workflows",
+    }:
+        return {
+            "name": name,
+            "description": (
+                "Create downstream MoonMind workflows from GitHub issue mappings."
+            ),
+            "inputs": {
+                "schema": {
+                    "type": "object",
+                    "properties": {
+                        "github": {"type": "object"},
+                        "issueMappings": {"type": "array"},
+                        "githubOrchestration": {"type": "object"},
+                        "traceability": {"type": "object"},
+                    },
+                    "additionalProperties": True,
+                }
+            },
+            "outputs": {
+                "schema": {
+                    "type": "object",
+                    "additionalProperties": True,
+                }
+            },
+            "executor": {
+                "activity_type": "mm.tool.execute",
+                "selector": {"mode": "by_capability"},
+            },
+            "requirements": {"capabilities": ["integration:github"]},
+            "policies": {
+                "timeouts": {
+                    "start_to_close_seconds": 300,
+                    "schedule_to_close_seconds": 600,
+                },
+                "retries": {"max_attempts": 1},
+            },
+        }
+
     description = (
         "Execute generic runtime CLI instructions."
         if name == _AUTO_SKILL_SENTINEL

--- a/moonmind/workflows/temporal/story_output_tools.py
+++ b/moonmind/workflows/temporal/story_output_tools.py
@@ -29,6 +29,13 @@ from moonmind.workflows.skills.tool_plan_contracts import ToolResult
 JIRA_CREATE_ISSUES_TOOL_NAME = "story.create_jira_issues"
 JIRA_ORCHESTRATE_TASKS_TOOL_NAME = "story.create_jira_orchestrate_tasks"
 JIRA_IMPLEMENT_TASKS_TOOL_NAME = "story.create_jira_implement_tasks"
+GITHUB_CREATE_ISSUES_TOOL_NAME = "story.create_github_issues"
+GITHUB_ORCHESTRATE_WORKFLOWS_TOOL_NAME = (
+    "story.create_github_issue_orchestrate_workflows"
+)
+GITHUB_IMPLEMENT_WORKFLOWS_TOOL_NAME = (
+    "story.create_github_issue_implement_workflows"
+)
 JIRA_CHECK_BLOCKERS_TOOL_NAME = "jira.check_blockers"
 JIRA_LOAD_PRESET_BRIEF_TOOL_NAME = "jira.load_preset_brief"
 GITHUB_LOAD_ISSUE_PRESET_BRIEF_TOOL_NAME = "github.load_issue_preset_brief"
@@ -39,6 +46,13 @@ JIRA_STORY_TOOL_NAMES = frozenset(
         JIRA_CREATE_ISSUES_TOOL_NAME,
         JIRA_ORCHESTRATE_TASKS_TOOL_NAME,
         JIRA_IMPLEMENT_TASKS_TOOL_NAME,
+    }
+)
+GITHUB_STORY_TOOL_NAMES = frozenset(
+    {
+        GITHUB_CREATE_ISSUES_TOOL_NAME,
+        GITHUB_ORCHESTRATE_WORKFLOWS_TOOL_NAME,
+        GITHUB_IMPLEMENT_WORKFLOWS_TOOL_NAME,
     }
 )
 _SOURCE_DOCUMENT_PATH_RE = re.compile(
@@ -57,6 +71,18 @@ _DOWNSTREAM_PRESETS: dict[str, dict[str, str]] = {
         "slug": "jira-implement",
         "label": "Jira Implement",
         "idempotencyPrefix": "jira-implement",
+    },
+}
+_GITHUB_DOWNSTREAM_PRESETS: dict[str, dict[str, str]] = {
+    _DOWNSTREAM_PRESET_ORCHESTRATE: {
+        "slug": "github-issue-orchestrate",
+        "label": "GitHub Issue Orchestrate",
+        "idempotencyPrefix": "github-issue-orchestrate",
+    },
+    _DOWNSTREAM_PRESET_IMPLEMENT: {
+        "slug": "github-issue-implement",
+        "label": "GitHub Issue Implement",
+        "idempotencyPrefix": "github-issue-implement",
     },
 }
 JIRA_DESCRIPTION_MAX_CHARS = 32767
@@ -1614,6 +1640,449 @@ async def create_jira_implement_tasks_from_issue_mappings(
     )
 
 
+def _github_issue_mappings_from_inputs(
+    inputs: Mapping[str, Any],
+    *,
+    context: Mapping[str, Any] | None = None,
+) -> list[dict[str, Any]]:
+    github_payload = _mapping(inputs.get("github"))
+    input_previous_outputs = _mapping(
+        inputs.get("previousOutputs") or inputs.get("previous_outputs")
+    )
+    context_previous_outputs = _mapping(
+        (context or {}).get("previousOutputs")
+        or (context or {}).get("previous_outputs")
+    )
+    input_previous_github_payload = _mapping(input_previous_outputs.get("github"))
+    context_previous_github_payload = _mapping(context_previous_outputs.get("github"))
+    candidates = (
+        github_payload.get("issueMappings")
+        or github_payload.get("issue_mappings")
+        or inputs.get("issueMappings")
+        or inputs.get("issue_mappings")
+        or github_payload.get("createdIssues")
+        or inputs.get("createdIssues")
+        or input_previous_github_payload.get("issueMappings")
+        or input_previous_github_payload.get("issue_mappings")
+        or input_previous_github_payload.get("createdIssues")
+        or input_previous_outputs.get("issueMappings")
+        or input_previous_outputs.get("issue_mappings")
+        or input_previous_outputs.get("createdIssues")
+        or context_previous_github_payload.get("issueMappings")
+        or context_previous_github_payload.get("issue_mappings")
+        or context_previous_github_payload.get("createdIssues")
+        or context_previous_outputs.get("issueMappings")
+        or context_previous_outputs.get("issue_mappings")
+        or context_previous_outputs.get("createdIssues")
+        or []
+    )
+    mappings = [dict(item) for item in _list(candidates) if isinstance(item, Mapping)]
+
+    def sort_key(item: Mapping[str, Any]) -> tuple[int, str]:
+        raw_index = item.get("storyIndex") or item.get("story_index") or 0
+        try:
+            index = int(raw_index)
+        except (TypeError, ValueError):
+            index = 0
+        return index, _string(item.get("storyId") or item.get("story_id"))
+
+    return sorted(mappings, key=sort_key)
+
+
+def _github_issue_input_from_mapping(
+    *,
+    mapping: Mapping[str, Any],
+    repository: str,
+    issue_number: str,
+    summary: str,
+) -> dict[str, Any]:
+    nested_issue = _mapping(
+        mapping.get("githubIssue")
+        or mapping.get("github_issue")
+        or mapping.get("issue")
+    )
+    resolved_repository = _first_string(
+        repository,
+        nested_issue.get("repository"),
+        nested_issue.get("repo"),
+        mapping.get("repository"),
+        mapping.get("repo"),
+    )
+    resolved_number = _first_string(
+        issue_number,
+        nested_issue.get("number"),
+        nested_issue.get("issueNumber"),
+        nested_issue.get("issue_number"),
+        mapping.get("number"),
+        mapping.get("issueNumber"),
+        mapping.get("issue_number"),
+    )
+    issue: dict[str, Any] = {
+        "repository": resolved_repository,
+        "number": int(resolved_number) if resolved_number.isdigit() else resolved_number,
+    }
+    resolved_title = _first_string(
+        summary,
+        nested_issue.get("title"),
+        nested_issue.get("summary"),
+        mapping.get("title"),
+        mapping.get("summary"),
+    )
+    if resolved_title:
+        issue["title"] = resolved_title
+    url = _first_string(
+        mapping.get("issueUrl"),
+        mapping.get("issue_url"),
+        mapping.get("url"),
+        mapping.get("html_url"),
+        nested_issue.get("url"),
+        nested_issue.get("html_url"),
+    )
+    if url:
+        issue["url"] = url
+    return issue
+
+
+def _github_downstream_workflow_payload(
+    *,
+    mapping: Mapping[str, Any],
+    task_payload: Mapping[str, Any],
+    traceability: Mapping[str, Any],
+    depends_on: list[str],
+    source_issue_key: str,
+    target_preset: str,
+) -> tuple[str, dict[str, Any]]:
+    preset = _GITHUB_DOWNSTREAM_PRESETS[target_preset]
+    preset_label = preset["label"]
+    preset_slug = preset["slug"]
+    repository = _string(
+        mapping.get("repository")
+        or mapping.get("repo")
+        or task_payload.get("repository")
+        or task_payload.get("repo")
+    )
+    issue_number = _string(
+        mapping.get("issueNumber")
+        or mapping.get("issue_number")
+        or mapping.get("number")
+    )
+    story_id = _string(mapping.get("storyId") or mapping.get("story_id"))
+    summary = _string(mapping.get("summary")) or (
+        f"{repository}#{issue_number}" if repository and issue_number else issue_number
+    )
+    source_brief_ref = _string(
+        traceability.get("sourceBriefRef") or traceability.get("source_brief_ref")
+    )
+    source_design_path = _string(
+        mapping.get("sourceDesignPath") or mapping.get("source_design_path")
+    )
+    source_claim_ids = [
+        _string(item)
+        for item in _list(
+            mapping.get("sourceClaimIds") or mapping.get("source_claim_ids")
+        )
+        if _string(item)
+    ]
+    github_issue_ref = (
+        f"{repository}#{issue_number}" if repository and issue_number else "unknown"
+    )
+    claim_line = (
+        "Source canonical claim IDs: "
+        + (", ".join(source_claim_ids) if source_claim_ids else "not provided")
+        + ".\n"
+    )
+    instructions = (
+        f"Run {preset_label} for {github_issue_ref}.\n\n"
+        f"Source story: {story_id or summary}.\n"
+        f"Source summary: {summary}.\n"
+        f"Source issue: {source_issue_key or 'unknown'}.\n"
+        f"Source design document: {source_design_path or 'not provided'}.\n"
+        f"{claim_line}"
+        f"Original brief reference: {source_brief_ref or 'not provided'}.\n\n"
+        f"Use the existing {preset_label} workflow for this GitHub issue. "
+        "Do not run implementation inline inside the breakdown task."
+    )
+    runtime = _mapping(task_payload.get("runtime"))
+    publish = _mapping(task_payload.get("publish"))
+    github_issue_input = _github_issue_input_from_mapping(
+        mapping=mapping,
+        repository=repository,
+        issue_number=issue_number,
+        summary=summary,
+    )
+    task: dict[str, Any] = {
+        "title": f"Run {preset_label} for {github_issue_ref}: {summary}",
+        "instructions": instructions,
+        "inputs": {
+            "github_issue": github_issue_input,
+            "github_issue_ref": github_issue_ref,
+            "source_design_path": source_design_path,
+            "source_claim_ids": source_claim_ids,
+            "constraints": (
+                f"Preserve source issue {source_issue_key} traceability."
+                if source_issue_key
+                else ""
+            ),
+        },
+        "taskTemplate": {
+            "slug": preset_slug,
+        },
+    }
+    if runtime:
+        task["runtime"] = runtime
+    if publish:
+        task["publish"] = publish
+    if repository:
+        task["repository"] = repository
+    if depends_on:
+        task["dependsOn"] = list(depends_on)
+    return task["title"], task
+
+
+async def _create_github_downstream_workflows_from_issue_mappings(
+    inputs: Mapping[str, Any],
+    _context: Mapping[str, Any] | None = None,
+    *,
+    execution_creator: ExecutionCreator | None = None,
+    target_preset: str,
+) -> ToolResult:
+    """Create dependent downstream GitHub issue workflows from ordered mappings."""
+
+    preset = _GITHUB_DOWNSTREAM_PRESETS[target_preset]
+    preset_label = preset["label"]
+    preset_idempotency_prefix = preset["idempotencyPrefix"]
+
+    if execution_creator is None:
+        raise ValueError(
+            f"execution_creator is required for {preset_label} workflow creation."
+        )
+
+    context = _context or {}
+    issue_mappings = _github_issue_mappings_from_inputs(inputs, context=context)
+    orchestration_payload = _mapping(
+        inputs.get("githubOrchestration") or inputs.get("github_orchestration")
+    )
+    task_payload = _mapping(orchestration_payload.get("task") or inputs.get("task"))
+    traceability = _mapping(
+        orchestration_payload.get("traceability") or inputs.get("traceability")
+    )
+    source_issue_key = _source_issue_key(inputs=inputs, traceability=traceability)
+    source_brief_ref = _string(
+        traceability.get("sourceBriefRef") or traceability.get("source_brief_ref")
+    )
+    repository = _string(task_payload.get("repository") or task_payload.get("repo"))
+    owner_id = (
+        _string(task_payload.get("ownerId") or task_payload.get("owner_id"))
+        or _string(inputs.get("ownerId") or inputs.get("owner_id"))
+        or _string(context.get("ownerId") or context.get("owner_id"))
+        or None
+    )
+    owner_type = (
+        _string(task_payload.get("ownerType") or task_payload.get("owner_type"))
+        or _string(inputs.get("ownerType") or inputs.get("owner_type"))
+        or _string(context.get("ownerType") or context.get("owner_type"))
+        or None
+    )
+
+    workflows: list[dict[str, Any]] = []
+    dependencies: list[dict[str, Any]] = []
+    failures: list[dict[str, Any]] = []
+    skipped_stories: list[dict[str, Any]] = []
+    previous_workflow_id = ""
+
+    for index, mapping in enumerate(issue_mappings, start=1):
+        story_id = (
+            _string(mapping.get("storyId") or mapping.get("story_id"))
+            or f"STORY-{index:03d}"
+        )
+        story_index = mapping.get("storyIndex") or mapping.get("story_index") or index
+        issue_number = _string(
+            mapping.get("issueNumber")
+            or mapping.get("issue_number")
+            or mapping.get("number")
+        )
+        mapping_repository = _string(
+            mapping.get("repository") or mapping.get("repo") or repository
+        )
+        summary = _string(mapping.get("summary"))
+        base_result = {
+            "storyId": story_id,
+            "storyIndex": story_index,
+            "repository": mapping_repository,
+            "githubIssueNumber": issue_number,
+        }
+        if not mapping_repository or not issue_number:
+            failures.append(
+                {
+                    **base_result,
+                    "errorCode": "missing_github_issue_ref",
+                    "message": (
+                        f"{preset_label} workflow creation requires repository "
+                        "and issueNumber."
+                    ),
+                }
+            )
+            skipped_stories.append({**base_result, "summary": summary})
+            continue
+
+        depends_on = [previous_workflow_id] if previous_workflow_id else []
+        title, task = _github_downstream_workflow_payload(
+            mapping={**dict(mapping), "repository": mapping_repository},
+            task_payload=task_payload,
+            traceability=traceability,
+            depends_on=depends_on,
+            source_issue_key=source_issue_key,
+            target_preset=target_preset,
+        )
+        idempotency_key = _stable_idempotency_key(
+            source_issue_key=source_issue_key,
+            story_id=story_id,
+            issue_key=f"{mapping_repository}#{issue_number}",
+            prefix=preset_idempotency_prefix,
+        )
+        try:
+            created = execution_creator(
+                workflow_type="MoonMind.UserWorkflow",
+                owner_id=owner_id,
+                owner_type=owner_type,
+                title=title,
+                input_artifact_ref=None,
+                plan_artifact_ref=None,
+                manifest_artifact_ref=None,
+                failure_policy=None,
+                initial_parameters={
+                    "requestType": "workflow",
+                    "repository": mapping_repository,
+                    "targetRuntime": _string(_mapping(task.get("runtime")).get("mode")) or None,
+                    "publishMode": _string(_mapping(task.get("publish")).get("mode")) or None,
+                    "workflow": task,
+                    "traceability": {
+                        "sourceIssueKey": source_issue_key,
+                        "sourceBriefRef": source_brief_ref,
+                    },
+                },
+                idempotency_key=idempotency_key,
+                repository=mapping_repository,
+                integration="github",
+                summary=f"{preset_label} workflow for {mapping_repository}#{issue_number}.",
+            )
+            if inspect.isawaitable(created):
+                created = await created  # type: ignore[assignment]
+        except Exception as exc:
+            failures.append(
+                {
+                    **base_result,
+                    "errorCode": "workflow_creation_failed",
+                    "message": str(exc) or "Downstream workflow creation failed.",
+                    "dependsOn": depends_on,
+                }
+            )
+            remaining = issue_mappings[index:]
+            for skipped in remaining:
+                skipped_stories.append(
+                    {
+                        "storyId": _string(skipped.get("storyId") or skipped.get("story_id")),
+                        "storyIndex": skipped.get("storyIndex") or skipped.get("story_index"),
+                        "repository": _string(skipped.get("repository") or skipped.get("repo")),
+                        "githubIssueNumber": _string(
+                            skipped.get("issueNumber")
+                            or skipped.get("issue_number")
+                            or skipped.get("number")
+                        ),
+                        "errorCode": "dependency_not_created",
+                        "message": "Earlier downstream workflow creation failed.",
+                    }
+                )
+            break
+
+        created_mapping = dict(created)
+        workflow_id = _string(
+            created_mapping.get("workflowId") or created_mapping.get("workflow_id")
+        )
+        workflow_result = {
+            **base_result,
+            "workflowId": workflow_id,
+            "runId": _string(created_mapping.get("runId") or created_mapping.get("run_id")),
+            "title": _string(created_mapping.get("title")) or title,
+            "created": not bool(created_mapping.get("existing")),
+            "existing": bool(created_mapping.get("existing")),
+            "dependsOn": depends_on,
+            "idempotencyKey": idempotency_key,
+        }
+        workflows.append(workflow_result)
+        if depends_on:
+            dependencies.append(
+                {
+                    "fromWorkflowId": depends_on[0],
+                    "toWorkflowId": workflow_id,
+                    "fromStoryId": workflows[-2]["storyId"] if len(workflows) > 1 else "",
+                    "toStoryId": story_id,
+                    "status": "created",
+                }
+            )
+        previous_workflow_id = workflow_id
+
+    if not issue_mappings:
+        status = "no_downstream_workflows"
+    elif failures or skipped_stories:
+        status = "partial" if workflows else "no_downstream_workflows"
+    else:
+        status = "completed"
+
+    return ToolResult(
+        status="COMPLETED",
+        outputs={
+            "githubWorkflowOrchestration": {
+                "status": status,
+                "storyCount": len(issue_mappings),
+                "createdWorkflowCount": len(workflows),
+                "dependencyMode": "workflow_linear_chain" if dependencies else "none",
+                "dependencyCount": len(dependencies),
+                "workflows": workflows,
+                "dependencies": dependencies,
+                "skippedStories": skipped_stories,
+                "failures": failures,
+                "traceability": {
+                    "sourceIssueKey": source_issue_key,
+                    "sourceBriefRef": source_brief_ref,
+                },
+            }
+        },
+    )
+
+
+async def create_github_issue_orchestrate_workflows_from_issue_mappings(
+    inputs: Mapping[str, Any],
+    _context: Mapping[str, Any] | None = None,
+    *,
+    execution_creator: ExecutionCreator | None = None,
+) -> ToolResult:
+    """Create dependent GitHub Issue Orchestrate workflows from issue mappings."""
+
+    return await _create_github_downstream_workflows_from_issue_mappings(
+        inputs,
+        _context,
+        execution_creator=execution_creator,
+        target_preset=_DOWNSTREAM_PRESET_ORCHESTRATE,
+    )
+
+
+async def create_github_issue_implement_workflows_from_issue_mappings(
+    inputs: Mapping[str, Any],
+    _context: Mapping[str, Any] | None = None,
+    *,
+    execution_creator: ExecutionCreator | None = None,
+) -> ToolResult:
+    """Create dependent GitHub Issue Implement workflows from issue mappings."""
+
+    return await _create_github_downstream_workflows_from_issue_mappings(
+        inputs,
+        _context,
+        execution_creator=execution_creator,
+        target_preset=_DOWNSTREAM_PRESET_IMPLEMENT,
+    )
+
+
 def _dependency_mode(
     *,
     inputs: Mapping[str, Any],
@@ -2522,6 +2991,379 @@ async def create_jira_issues_from_stories(
             },
         },
     )
+
+def _github_story_output_payload(
+    inputs: Mapping[str, Any],
+) -> dict[str, Any]:
+    return _mapping(inputs.get("github") or inputs.get("storyOutput") or inputs.get("story_output"))
+
+
+def _github_repository_from_inputs(inputs: Mapping[str, Any]) -> str:
+    github_payload = _github_story_output_payload(inputs)
+    return _string(
+        inputs.get("repository")
+        or inputs.get("repo")
+        or github_payload.get("repository")
+        or github_payload.get("repo")
+    )
+
+
+def _github_labels(
+    *,
+    story: Mapping[str, Any],
+    github_payload: Mapping[str, Any],
+    marker_label: str,
+) -> list[str]:
+    labels: list[str] = []
+    for source in (github_payload, story):
+        for item in _list(source.get("labels")):
+            label = _string(item.get("name") if isinstance(item, Mapping) else item)
+            if label:
+                labels.append(label)
+    if marker_label:
+        labels.append(marker_label)
+    return list(dict.fromkeys(labels))
+
+
+def _github_issue_mapping(
+    *,
+    story: Mapping[str, Any],
+    issue: Mapping[str, Any],
+    repository: str,
+    index: int,
+    summary: str,
+    fallback_source_path: str,
+) -> dict[str, Any]:
+    reference = _story_source_reference(story, fallback_path=fallback_source_path)
+    number = _string(
+        issue.get("number")
+        or issue.get("issueNumber")
+        or issue.get("issue_number")
+        or issue.get("externalKey")
+        or issue.get("external_key")
+    )
+    url = _string(
+        issue.get("html_url")
+        or issue.get("issueUrl")
+        or issue.get("issue_url")
+        or issue.get("externalUrl")
+        or issue.get("external_url")
+        or issue.get("url")
+    )
+    mapping = {
+        "storyId": _story_id(story, index=index),
+        "storyIndex": index,
+        "summary": summary,
+        "repository": repository,
+        "issueNumber": number,
+        "issueUrl": url,
+        "sourceDesignPath": _string(reference.get("path")),
+        "sourceTitle": _string(reference.get("title")),
+        "sourceClaimIds": _story_source_claim_ids(reference),
+        "sourceSections": [
+            _string(item) for item in _list(reference.get("sections")) if _string(item)
+        ],
+        "sourceIssueKey": _string(
+            reference.get("sourceIssueKey") or reference.get("source_issue_key")
+        ),
+    }
+    coverage_ids = [
+        _string(item)
+        for item in _list(reference.get("coverageIds") or reference.get("coverage_ids"))
+        if _string(item)
+    ]
+    if coverage_ids:
+        mapping["coverageIds"] = coverage_ids
+    return mapping
+
+
+def _github_noop_result(
+    *,
+    original_story_count: int,
+    skipped_stories: Sequence[Mapping[str, Any]] = (),
+    blocked_stories: Sequence[Mapping[str, Any]] = (),
+    partial_stories_adjusted: Sequence[Mapping[str, Any]] = (),
+    story_breakdown_artifact_ref: str = "",
+    story_breakdown_path: str = "",
+) -> ToolResult:
+    story_output: dict[str, Any] = {
+        "mode": "github",
+        "status": "github_noop",
+        "storyCount": original_story_count,
+        "eligibleStoryCount": 0,
+        "createdCount": 0,
+        "dependencyMode": "none",
+        "dependencyCount": 0,
+        "skippedStories": [dict(story) for story in skipped_stories],
+        "blockedStories": [dict(story) for story in blocked_stories],
+        "partialStoriesAdjusted": [dict(story) for story in partial_stories_adjusted],
+    }
+    if story_breakdown_artifact_ref:
+        story_output["storyBreakdownArtifactRef"] = story_breakdown_artifact_ref
+    if story_breakdown_path:
+        story_output["storyBreakdownPath"] = story_breakdown_path
+    return ToolResult(
+        status="COMPLETED",
+        outputs={
+            "storyOutput": story_output,
+            "github": {
+                "createdCount": 0,
+                "createdIssues": [],
+                "dependencyMode": "none",
+                "dependencyCount": 0,
+                "issueMappings": [],
+                "skippedStories": story_output["skippedStories"],
+                "blockedStories": story_output["blockedStories"],
+                "partialStoriesAdjusted": story_output["partialStoriesAdjusted"],
+            },
+        },
+    )
+
+
+async def create_github_issues_from_stories(
+    inputs: Mapping[str, Any],
+    _context: Mapping[str, Any] | None = None,
+    *,
+    github_service_factory: Callable[[], GitHubService] = GitHubService,
+    story_fetcher: StoryFetcher = _default_github_story_fetcher,
+    artifact_reader: ArtifactReader | None = None,
+) -> ToolResult:
+    """Create one GitHub issue per reconciled story candidate."""
+
+    previous_outputs = _mapping(
+        (_context or {}).get("previousOutputs")
+        or (_context or {}).get("previous_outputs")
+        or inputs.get("previousOutputs")
+        or inputs.get("previous_outputs")
+    )
+    story_output = _mapping(inputs.get("storyOutput") or inputs.get("story_output"))
+    previous_story_output = _mapping(
+        previous_outputs.get("storyOutput") or previous_outputs.get("story_output")
+    )
+    github_payload = _mapping(story_output.get("github") or inputs.get("github"))
+    repository = _github_repository_from_inputs(
+        {**dict(inputs), "github": {**github_payload, **_mapping(inputs.get("github"))}}
+    )
+    if not repository:
+        raise ValueError("repository is required for GitHub story issue creation.")
+
+    dependency_mode = _string(
+        github_payload.get("dependencyMode")
+        or github_payload.get("dependency_mode")
+        or story_output.get("dependencyMode")
+        or story_output.get("dependency_mode")
+        or inputs.get("dependencyMode")
+        or inputs.get("dependency_mode")
+        or "none"
+    ).lower()
+    if dependency_mode != "none":
+        raise ValueError(
+            "GitHub story issue creation supports dependencyMode 'none' only; "
+            "GitHub issue dependencies are not claimed without a trusted API result."
+        )
+
+    raw_story_payload = (
+        inputs.get("stories")
+        or inputs.get("storyBreakdown")
+        or inputs.get("story_breakdown")
+        or inputs.get("storyBreakdownJson")
+        or previous_outputs.get("stories")
+        or previous_outputs.get("storyBreakdown")
+        or previous_outputs.get("story_breakdown")
+        or previous_outputs.get("storyBreakdownJson")
+        or previous_story_output.get("stories")
+        or previous_story_output.get("storyBreakdown")
+        or previous_story_output.get("story_breakdown")
+        or previous_story_output.get("storyBreakdownJson")
+    )
+    parsed_story_payload = _parse_story_breakdown_payload(raw_story_payload)
+    breakdown_source_path = _breakdown_source_path(parsed_story_payload)
+    breakdown_source_document_class = _breakdown_source_document_class(
+        parsed_story_payload
+    )
+    stories = _coerce_story_payload(parsed_story_payload)
+    artifact_ref_was_read = False
+    artifact_payload_had_explicit_empty_stories = False
+    artifact_payload_failure_reason = ""
+    artifact_ref = ""
+    if not stories:
+        artifact_ref = _string(
+            inputs.get("storyBreakdownArtifactRef")
+            or inputs.get("story_breakdown_artifact_ref")
+            or story_output.get("storyBreakdownArtifactRef")
+            or story_output.get("story_breakdown_artifact_ref")
+            or previous_outputs.get("storyBreakdownArtifactRef")
+            or previous_outputs.get("story_breakdown_artifact_ref")
+            or previous_story_output.get("storyBreakdownArtifactRef")
+            or previous_story_output.get("story_breakdown_artifact_ref")
+        )
+        if artifact_ref:
+            if artifact_reader is None:
+                raise ValueError(
+                    "storyBreakdownArtifactRef was provided, but this worker "
+                    "has no artifact reader configured."
+                )
+            artifact_payload = artifact_reader(artifact_ref)
+            if inspect.isawaitable(artifact_payload):
+                artifact_payload = await artifact_payload  # type: ignore[assignment]
+            parsed_payload = _parse_story_breakdown_payload(artifact_payload)
+            breakdown_source_path = _breakdown_source_path(parsed_payload)
+            breakdown_source_document_class = _breakdown_source_document_class(
+                parsed_payload
+            )
+            artifact_payload_failure_reason = _story_breakdown_failure_reason(
+                parsed_payload
+            )
+            stories = _coerce_story_payload(parsed_payload)
+            artifact_ref_was_read = True
+            artifact_payload_had_explicit_empty_stories = (
+                _has_explicit_empty_story_list(parsed_payload)
+            )
+    if not stories and artifact_ref_was_read and artifact_payload_failure_reason:
+        raise ValueError(artifact_payload_failure_reason)
+    if (
+        not stories
+        and artifact_ref_was_read
+        and artifact_payload_had_explicit_empty_stories
+    ):
+        return _github_noop_result(
+            original_story_count=0,
+            story_breakdown_artifact_ref=artifact_ref,
+            story_breakdown_path=_string(
+                inputs.get("storyBreakdownPath")
+                or story_output.get("storyBreakdownPath")
+                or previous_outputs.get("storyBreakdownPath")
+                or previous_story_output.get("storyBreakdownPath")
+            ),
+        )
+    if not stories:
+        repo = _string(inputs.get("repository") or inputs.get("repo"))
+        ref = _string(
+            inputs.get("targetBranch")
+            or inputs.get("branch")
+            or inputs.get("startingBranch")
+        )
+        path = _string(
+            inputs.get("storyBreakdownPath")
+            or story_output.get("storyBreakdownPath")
+            or previous_outputs.get("storyBreakdownPath")
+            or previous_story_output.get("storyBreakdownPath")
+        )
+        if repo and ref and path:
+            fetched = story_fetcher(repo, ref, path)
+            if inspect.isawaitable(fetched):
+                fetched = await fetched  # type: ignore[assignment]
+            fetched_payload = _parse_story_breakdown_payload(fetched)
+            breakdown_source_path = _breakdown_source_path(fetched_payload)
+            breakdown_source_document_class = _breakdown_source_document_class(
+                fetched_payload
+            )
+            stories = _coerce_story_payload(fetched_payload)
+    if not stories:
+        raise ValueError("No stories were available for GitHub issue creation.")
+
+    original_story_count = len(stories)
+    (
+        stories,
+        skipped_stories,
+        blocked_stories,
+        partial_stories_adjusted,
+    ) = _reconcile_stories_for_jira_creation(stories)
+    if not stories:
+        return _github_noop_result(
+            original_story_count=original_story_count,
+            skipped_stories=skipped_stories,
+            blocked_stories=blocked_stories,
+            partial_stories_adjusted=partial_stories_adjusted,
+        )
+
+    missing_claim_ids = _missing_source_claim_story_ids(
+        stories,
+        fallback_path=breakdown_source_path,
+        source_document_class=breakdown_source_document_class,
+    )
+    if missing_claim_ids:
+        raise ValueError(
+            "GitHub story creation requires sourceReference.claimIds for every "
+            "canonical declarative story with sourceReference.path or breakdown "
+            "source.referencePath. Missing: "
+            + ", ".join(missing_claim_ids)
+        )
+
+    service = github_service_factory()
+    marker_label = _workflow_marker_label(inputs=inputs, context=_context)
+    created: list[dict[str, Any]] = []
+    issue_mappings: list[dict[str, Any]] = []
+    for index, story in enumerate(stories, start=1):
+        summary = _story_summary(story, index=index)
+        result = await service.create_issue(
+            repo=repository,
+            title=summary,
+            body=_story_description_with_source(
+                story,
+                fallback_source_path=breakdown_source_path,
+            ),
+            labels=_github_labels(
+                story=story,
+                github_payload=github_payload,
+                marker_label=marker_label,
+            ),
+            github_token=_string(github_payload.get("token") or github_payload.get("githubToken")),
+        )
+        issue_result = (
+            result.model_dump(by_alias=True)
+            if hasattr(result, "model_dump")
+            else dict(result)
+        )
+        if not bool(issue_result.get("created")):
+            raise ValueError(
+                _string(issue_result.get("summary"))
+                or "GitHub issue creation failed."
+            )
+        created.append(issue_result)
+        issue_mappings.append(
+            _github_issue_mapping(
+                story=story,
+                issue=issue_result,
+                repository=repository,
+                index=index,
+                summary=summary,
+                fallback_source_path=breakdown_source_path,
+            )
+        )
+
+    partial = bool(blocked_stories)
+    story_status = "github_partial" if partial else "github_created"
+    return ToolResult(
+        status="COMPLETED",
+        outputs={
+            "storyOutput": {
+                "mode": "github",
+                "status": story_status,
+                "storyCount": original_story_count,
+                "eligibleStoryCount": len(stories),
+                "createdCount": len(created),
+                "dependencyMode": "none",
+                "dependencyCount": 0,
+                "skippedStories": skipped_stories,
+                "blockedStories": blocked_stories,
+                "partialStoriesAdjusted": partial_stories_adjusted,
+            },
+            "github": {
+                "repository": repository,
+                "createdCount": len(created),
+                "createdIssues": created,
+                "dependencyMode": "none",
+                "dependencyCount": 0,
+                "issueMappings": issue_mappings,
+                "skippedStories": skipped_stories,
+                "blockedStories": blocked_stories,
+                "partialStoriesAdjusted": partial_stories_adjusted,
+                **({"partial": True} if partial else {}),
+            },
+        },
+    )
+
 
 def _blocker_preflight_target_issue_key(inputs: Mapping[str, Any]) -> str:
     nested = _mapping(
@@ -3799,6 +4641,51 @@ def register_story_output_tool_handlers(
         handler=_create_jira_implement_tasks,
     )
 
+    async def _create_github_issues(
+        inputs: Mapping[str, Any],
+        context: Mapping[str, Any] | None = None,
+    ) -> ToolResult:
+        return await create_github_issues_from_stories(
+            inputs,
+            context,
+            artifact_reader=artifact_reader,
+        )
+
+    dispatcher.register_skill(
+        skill_name=GITHUB_CREATE_ISSUES_TOOL_NAME,
+        handler=_create_github_issues,
+    )
+
+    async def _create_github_issue_orchestrate_workflows(
+        inputs: Mapping[str, Any],
+        context: Mapping[str, Any] | None = None,
+    ) -> ToolResult:
+        return await create_github_issue_orchestrate_workflows_from_issue_mappings(
+            inputs,
+            context,
+            execution_creator=execution_creator,
+        )
+
+    dispatcher.register_skill(
+        skill_name=GITHUB_ORCHESTRATE_WORKFLOWS_TOOL_NAME,
+        handler=_create_github_issue_orchestrate_workflows,
+    )
+
+    async def _create_github_issue_implement_workflows(
+        inputs: Mapping[str, Any],
+        context: Mapping[str, Any] | None = None,
+    ) -> ToolResult:
+        return await create_github_issue_implement_workflows_from_issue_mappings(
+            inputs,
+            context,
+            execution_creator=execution_creator,
+        )
+
+    dispatcher.register_skill(
+        skill_name=GITHUB_IMPLEMENT_WORKFLOWS_TOOL_NAME,
+        handler=_create_github_issue_implement_workflows,
+    )
+
     async def _check_jira_blockers(
         inputs: Mapping[str, Any],
         context: Mapping[str, Any] | None = None,
@@ -3881,6 +4768,9 @@ def register_story_output_tool_handlers(
     )
 
 __all__ = [
+    "GITHUB_CREATE_ISSUES_TOOL_NAME",
+    "GITHUB_IMPLEMENT_WORKFLOWS_TOOL_NAME",
+    "GITHUB_ORCHESTRATE_WORKFLOWS_TOOL_NAME",
     "JIRA_CHECK_BLOCKERS_TOOL_NAME",
     "JIRA_CREATE_ISSUES_TOOL_NAME",
     "JIRA_IMPLEMENT_TASKS_TOOL_NAME",
@@ -3888,9 +4778,13 @@ __all__ = [
     "GITHUB_LOAD_ISSUE_PRESET_BRIEF_TOOL_NAME",
     "GITHUB_CHECK_ISSUE_BLOCKERS_TOOL_NAME",
     "GITHUB_UPDATE_ISSUE_STATUS_TOOL_NAME",
+    "GITHUB_STORY_TOOL_NAMES",
     "JIRA_ORCHESTRATE_TASKS_TOOL_NAME",
     "JIRA_STORY_TOOL_NAMES",
     "check_jira_blockers",
+    "create_github_issue_implement_workflows_from_issue_mappings",
+    "create_github_issue_orchestrate_workflows_from_issue_mappings",
+    "create_github_issues_from_stories",
     "create_jira_issues_from_stories",
     "create_jira_orchestrate_tasks_from_issue_mappings",
     "create_jira_implement_tasks_from_issue_mappings",

--- a/moonmind/workflows/temporal/story_output_tools.py
+++ b/moonmind/workflows/temporal/story_output_tools.py
@@ -3308,7 +3308,7 @@ async def create_github_issues_from_stories(
                 github_payload=github_payload,
                 marker_label=marker_label,
             ),
-            github_token=_string(github_payload.get("token") or github_payload.get("githubToken")),
+            github_token=None,
         )
         issue_result = (
             result.model_dump(by_alias=True)

--- a/moonmind/workflows/temporal/worker_runtime.py
+++ b/moonmind/workflows/temporal/worker_runtime.py
@@ -140,6 +140,7 @@ from moonmind.workflows.temporal.runtime.paths import managed_runtime_artifact_r
 from moonmind.workflows.temporal.runtime.supervisor import ManagedRunSupervisor
 from moonmind.workflows.temporal.story_output_tools import (
     DOCUMENT_UPDATE_TASKS_TOOL_NAME,
+    GITHUB_STORY_TOOL_NAMES,
     JIRA_STORY_TOOL_NAMES,
     register_story_output_tool_handlers,
 )
@@ -866,6 +867,7 @@ _JIRA_AGENT_SKILLS = JIRA_AGENT_SKILLS
 _STORY_OUTPUT_TASK_TOOLS = frozenset(
     {
         *JIRA_STORY_TOOL_NAMES,
+        *GITHUB_STORY_TOOL_NAMES,
         DOCUMENT_UPDATE_TASKS_TOOL_NAME,
     }
 )

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -7782,9 +7782,10 @@ class MoonMindRunWorkflow:
                         require_pull_request_url = False
                         self._publish_status = "published"
                         self._publish_reason = (
-                            "Jira issue output succeeded; no PR output required"
+                            f"{story_output_mode.title()} issue output succeeded; "
+                            "no PR output required"
                         )
-                        self._publish_context["storyOutputMode"] = "jira"
+                        self._publish_context["storyOutputMode"] = story_output_mode
             if require_pull_request_url and pull_request_url is None:
                 pull_request_url = self._extract_pull_request_url(execution_result)
 
@@ -10116,11 +10117,19 @@ class MoonMindRunWorkflow:
 
     @staticmethod
     def _is_successful_jira_story_output(*, mode: str, status: str) -> bool:
-        return mode == "jira" and status in {
-            "jira_created",
-            "jira_partial",
-            "jira_noop",
-        }
+        if mode == "jira":
+            return status in {
+                "jira_created",
+                "jira_partial",
+                "jira_noop",
+            }
+        if mode == "github":
+            return status in {
+                "github_created",
+                "github_partial",
+                "github_noop",
+            }
+        return False
 
     @staticmethod
     def _trusted_jira_output_summary(outputs: Mapping[str, Any]) -> str | None:

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -10144,9 +10144,35 @@ class MoonMindRunWorkflow:
                     parts.append(f"dependencyMode={dependency_mode}")
                 return "; ".join(parts) + "."
             reason = str(story_output.get("reason") or "").strip()
-            if status:
+            if status and (status.startswith("jira_") or status == "fallback"):
                 suffix = f": {reason}" if reason else ""
                 return f"Jira story output finished with status {status}{suffix}."
+
+        if isinstance(story_output, Mapping):
+            status = str(story_output.get("status") or "").strip()
+            created_count = story_output.get("createdCount")
+            story_count = story_output.get("storyCount")
+            eligible_count = story_output.get("eligibleStoryCount")
+            dependency_mode = str(story_output.get("dependencyMode") or "").strip()
+            dependency_count = story_output.get("dependencyCount")
+            if status in {"github_created", "github_partial", "github_noop"}:
+                verb = "Created" if status != "github_noop" else "Created no"
+                parts = [f"{verb} GitHub issues"]
+                if isinstance(created_count, int):
+                    parts.append(f"created={created_count}")
+                if isinstance(eligible_count, int):
+                    parts.append(f"eligible={eligible_count}")
+                if isinstance(story_count, int):
+                    parts.append(f"stories={story_count}")
+                if dependency_mode:
+                    parts.append(f"dependencyMode={dependency_mode}")
+                if isinstance(dependency_count, int):
+                    parts.append(f"dependencyCount={dependency_count}")
+                return "; ".join(parts) + "."
+            reason = str(story_output.get("reason") or "").strip()
+            if status and status.startswith("github_"):
+                suffix = f": {reason}" if reason else ""
+                return f"GitHub story output finished with status {status}{suffix}."
 
         orchestration = outputs.get("jiraOrchestration") or outputs.get(
             "jira_orchestration"
@@ -10177,6 +10203,36 @@ class MoonMindRunWorkflow:
             if status:
                 suffix = f" ({'; '.join(parts)})" if parts else ""
                 return f"Jira downstream task creation {status}{suffix}."
+
+        github_orchestration = outputs.get("githubWorkflowOrchestration") or outputs.get(
+            "github_workflow_orchestration"
+        )
+        if isinstance(github_orchestration, Mapping):
+            status = str(github_orchestration.get("status") or "").strip()
+            created_count = github_orchestration.get("createdWorkflowCount")
+            story_count = github_orchestration.get("storyCount")
+            dependency_count = github_orchestration.get("dependencyCount")
+            parts = []
+            if isinstance(created_count, int):
+                parts.append(f"createdWorkflows={created_count}")
+            if isinstance(story_count, int):
+                parts.append(f"stories={story_count}")
+            if isinstance(dependency_count, int):
+                parts.append(f"workflowDependencies={dependency_count}")
+            failures = github_orchestration.get("failures")
+            if isinstance(failures, list) and failures:
+                first_failure = failures[0] if isinstance(failures[0], Mapping) else {}
+                message = str(first_failure.get("message") or "").strip()
+                error_code = str(first_failure.get("errorCode") or "").strip()
+                if error_code or message:
+                    message = message.rstrip(".")
+                    parts.append(
+                        "firstFailure="
+                        + ": ".join(part for part in (error_code, message) if part)
+                    )
+            if status:
+                suffix = f" ({'; '.join(parts)})" if parts else ""
+                return f"GitHub downstream workflow creation {status}{suffix}."
         return None
 
     def _record_execution_context(self, *, node_id: str, execution_result: Any) -> None:

--- a/tests/unit/workflows/temporal/test_run_artifacts.py
+++ b/tests/unit/workflows/temporal/test_run_artifacts.py
@@ -4447,11 +4447,31 @@ def test_publish_completion_requires_pr_url_for_pr_publish_mode() -> None:
     assert reason == "publishMode 'pr' requested but no PR was created"
     assert failed is True
 
-@pytest.mark.parametrize("story_status", ["jira_created", "jira_partial"])
-def test_jira_story_output_status_satisfies_pr_publish(story_status: str) -> None:
+@pytest.mark.parametrize(
+    ("mode", "story_status"),
+    [
+        ("jira", "jira_created"),
+        ("jira", "jira_partial"),
+        ("github", "github_created"),
+        ("github", "github_partial"),
+        ("github", "github_noop"),
+    ],
+)
+def test_story_output_status_satisfies_pr_publish(mode: str, story_status: str) -> None:
     assert MoonMindRunWorkflow._is_successful_jira_story_output(
-        mode="jira",
+        mode=mode,
         status=story_status,
+    )
+
+
+def test_story_output_status_rejects_cross_mode_status() -> None:
+    assert not MoonMindRunWorkflow._is_successful_jira_story_output(
+        mode="jira",
+        status="github_created",
+    )
+    assert not MoonMindRunWorkflow._is_successful_jira_story_output(
+        mode="github",
+        status="jira_created",
     )
 
 

--- a/tests/unit/workflows/temporal/test_story_output_tools.py
+++ b/tests/unit/workflows/temporal/test_story_output_tools.py
@@ -9,6 +9,9 @@ from moonmind.workflows.temporal import story_output_tools as story_tools
 from moonmind.workflows.temporal.story_output_tools import (
     check_jira_blockers,
     create_document_update_tasks_from_paths,
+    create_github_issue_implement_workflows_from_issue_mappings,
+    create_github_issue_orchestrate_workflows_from_issue_mappings,
+    create_github_issues_from_stories,
     create_jira_implement_tasks_from_issue_mappings,
     create_jira_issues_from_stories,
     create_jira_orchestrate_tasks_from_issue_mappings,
@@ -102,13 +105,48 @@ class _FakeExecutionCreator:
         }
 
 
+class _RecordingDispatcher:
+    def __init__(self) -> None:
+        self.skills: dict[str, Any] = {}
+
+    def register_skill(self, *, skill_name: str, handler: Any) -> None:
+        self.skills[skill_name] = handler
+
+
 class _FakeGitHubService:
     def __init__(self) -> None:
         self.token_requests: list[str] = []
+        self.create_issue_requests: list[dict[str, Any]] = []
 
     async def resolve_github_token(self, *, repo: str):
         self.token_requests.append(repo)
         return "ghs-test", None
+
+    async def create_issue(
+        self,
+        *,
+        repo: str,
+        title: str,
+        body: str,
+        labels: list[str] | None = None,
+        github_token: str | None = None,
+    ):
+        self.create_issue_requests.append(
+            {
+                "repo": repo,
+                "title": title,
+                "body": body,
+                "labels": labels or [],
+                "github_token": github_token,
+            }
+        )
+        issue_number = len(self.create_issue_requests)
+        return {
+            "externalKey": str(issue_number),
+            "externalUrl": f"https://github.com/{repo}/issues/{issue_number}",
+            "created": True,
+            "summary": f"GitHub issue created: https://github.com/{repo}/issues/{issue_number}",
+        }
 
     def _github_headers(self, token: str) -> dict[str, str]:
         return {"Authorization": f"Bearer {token}"}
@@ -442,6 +480,242 @@ async def test_create_jira_issues_drops_original_criteria_when_partial_remaining
     assert "Implement only the missing behavior." in request.description
     assert "Acceptance Criteria\nOriginal completed criterion." not in request.description
     assert "Requirements\nOriginal completed requirement." not in request.description
+
+
+@pytest.mark.asyncio
+async def test_create_github_issues_from_reconciled_story_breakdown():
+    service = _FakeGitHubService()
+
+    result = await create_github_issues_from_stories(
+        {
+            "repository": "MoonLadderStudios/MoonMind",
+            "workflowId": "mm-1068-run",
+            "github": {"labels": ["moonmind", "MM-1068"]},
+            "stories": {
+                "source": {
+                    "referencePath": "docs/Workflows/SkillAndPlanContracts.md",
+                    "sourceDocumentClass": "canonical-declarative",
+                },
+                "stories": [
+                    {
+                        "id": "STORY-001",
+                        "summary": "Create GitHub issue story output",
+                        "description": "As a breakdown workflow, create GitHub issues.",
+                        "acceptanceCriteria": ["One issue is created."],
+                        "sourceReference": {
+                            "path": "docs/Workflows/SkillAndPlanContracts.md",
+                            "title": "MM-1063: Update Presets",
+                            "sections": [
+                                "Add GitHub Issue creation from MoonSpec breakdowns"
+                            ],
+                            "claimIds": ["DESIGN-REQ-007"],
+                            "coverageIds": ["DESIGN-REQ-014"],
+                            "sourceIssueKey": "MM-1063",
+                        },
+                    },
+                    {
+                        "id": "STORY-002",
+                        "summary": "Already implemented",
+                        "implementationStatus": "fully_implemented",
+                        "jiraCreation": {"action": "skip"},
+                    },
+                    {
+                        "id": "STORY-003",
+                        "summary": "Unverifiable story",
+                        "implementationStatus": "unverifiable",
+                        "jiraCreation": {"action": "manual_review"},
+                    },
+                ],
+            },
+        },
+        github_service_factory=lambda: service,
+    )
+
+    assert result.status == "COMPLETED"
+    assert result.outputs["storyOutput"]["status"] == "github_partial"
+    assert result.outputs["storyOutput"]["storyCount"] == 3
+    assert result.outputs["storyOutput"]["eligibleStoryCount"] == 1
+    assert result.outputs["storyOutput"]["createdCount"] == 1
+    assert result.outputs["storyOutput"]["dependencyMode"] == "none"
+    assert result.outputs["storyOutput"]["dependencyCount"] == 0
+    assert result.outputs["storyOutput"]["skippedStories"][0]["storyId"] == "STORY-002"
+    assert result.outputs["storyOutput"]["blockedStories"][0]["storyId"] == "STORY-003"
+    assert result.outputs["github"]["issueMappings"] == [
+        {
+            "storyId": "STORY-001",
+            "storyIndex": 1,
+            "summary": "Create GitHub issue story output",
+            "repository": "MoonLadderStudios/MoonMind",
+            "issueNumber": "1",
+            "issueUrl": "https://github.com/MoonLadderStudios/MoonMind/issues/1",
+            "sourceDesignPath": "docs/Workflows/SkillAndPlanContracts.md",
+            "sourceTitle": "MM-1063: Update Presets",
+            "sourceClaimIds": ["DESIGN-REQ-007"],
+            "sourceSections": [
+                "Add GitHub Issue creation from MoonSpec breakdowns"
+            ],
+            "sourceIssueKey": "MM-1063",
+            "coverageIds": ["DESIGN-REQ-014"],
+        }
+    ]
+
+    request = service.create_issue_requests[0]
+    assert request["repo"] == "MoonLadderStudios/MoonMind"
+    assert request["title"] == "Create GitHub issue story output"
+    assert request["labels"] == [
+        "moonmind",
+        "MM-1068",
+        "moonmind-workflow-mm-1068-run",
+    ]
+    assert "Source Document: docs/Workflows/SkillAndPlanContracts.md" in request["body"]
+    assert "Source Title: MM-1063: Update Presets" in request["body"]
+    assert "Source Sections:" in request["body"]
+    assert "DESIGN-REQ-007" in request["body"]
+    assert "DESIGN-REQ-014" in request["body"]
+    assert "One issue is created." in request["body"]
+
+
+@pytest.mark.asyncio
+async def test_create_github_issues_narrows_partial_story_to_remaining_work():
+    service = _FakeGitHubService()
+
+    result = await create_github_issues_from_stories(
+        {
+            "repository": "MoonLadderStudios/MoonMind",
+            "stories": [
+                {
+                    "id": "STORY-001",
+                    "summary": "Original broad GitHub story",
+                    "description": "Original work.",
+                    "implementationStatus": "partially_implemented",
+                    "implementedEvidence": [
+                        {"requirement": "DESIGN-REQ-007", "evidence": "Tool exists."}
+                    ],
+                    "remainingWork": {
+                        "summary": "Complete GitHub workflow mapping",
+                        "description": "Add workflow creation outputs.",
+                        "acceptanceCriteria": ["Workflow mappings are returned."],
+                    },
+                }
+            ],
+        },
+        github_service_factory=lambda: service,
+    )
+
+    assert result.status == "COMPLETED"
+    assert result.outputs["storyOutput"]["status"] == "github_created"
+    assert result.outputs["storyOutput"]["partialStoriesAdjusted"][0]["storyId"] == (
+        "STORY-001"
+    )
+    request = service.create_issue_requests[0]
+    assert request["title"] == "Complete GitHub workflow mapping"
+    assert "Add workflow creation outputs." in request["body"]
+    assert "Already Implemented Evidence" in request["body"]
+    assert "Tool exists." in request["body"]
+    assert "Original Story Scope" in request["body"]
+    assert "Workflow mappings are returned." in request["body"]
+
+
+@pytest.mark.asyncio
+async def test_create_github_issue_workflows_from_issue_mappings():
+    creator = _FakeExecutionCreator()
+
+    result = await create_github_issue_implement_workflows_from_issue_mappings(
+        {
+            "github": {
+                "issueMappings": [
+                    {
+                        "storyId": "STORY-001",
+                        "storyIndex": 1,
+                        "summary": "First story",
+                        "repository": "MoonLadderStudios/MoonMind",
+                        "issueNumber": "11",
+                        "sourceDesignPath": "docs/Workflows/SkillAndPlanContracts.md",
+                        "sourceClaimIds": ["DESIGN-REQ-007"],
+                    },
+                    {
+                        "storyId": "STORY-002",
+                        "storyIndex": 2,
+                        "summary": "Second story",
+                        "repository": "MoonLadderStudios/MoonMind",
+                        "issueNumber": "12",
+                    },
+                ]
+            },
+            "githubOrchestration": {
+                "traceability": {
+                    "sourceIssueKey": "MM-1063",
+                    "sourceBriefRef": "MM-1068",
+                },
+                "task": {
+                    "runtime": {"mode": "codex"},
+                    "publish": {"mode": "pr"},
+                },
+            },
+        },
+        execution_creator=creator,
+    )
+
+    orchestration = result.outputs["githubWorkflowOrchestration"]
+    assert orchestration["status"] == "completed"
+    assert orchestration["storyCount"] == 2
+    assert orchestration["createdWorkflowCount"] == 2
+    assert orchestration["dependencyMode"] == "workflow_linear_chain"
+    assert orchestration["dependencyCount"] == 1
+    assert orchestration["workflows"][0]["githubIssueNumber"] == "11"
+    assert orchestration["workflows"][1]["dependsOn"] == ["mm:story-1"]
+
+    first_request = creator.requests[0]
+    assert first_request["integration"] == "github"
+    assert first_request["idempotency_key"].startswith(
+        "github-issue-implement:MM-1063:STORY-001:"
+    )
+    workflow = first_request["initial_parameters"]["workflow"]
+    assert workflow["taskTemplate"]["slug"] == "github-issue-implement"
+    assert workflow["inputs"]["github_issue"] == {
+        "repository": "MoonLadderStudios/MoonMind",
+        "number": 11,
+        "title": "First story",
+    }
+    assert workflow["inputs"]["github_issue_ref"] == "MoonLadderStudios/MoonMind#11"
+    assert "Source issue: MM-1063." in workflow["instructions"]
+    assert "Source canonical claim IDs: DESIGN-REQ-007." in workflow["instructions"]
+
+
+@pytest.mark.asyncio
+async def test_create_github_issue_orchestrate_workflows_uses_orchestrate_preset():
+    creator = _FakeExecutionCreator()
+
+    result = await create_github_issue_orchestrate_workflows_from_issue_mappings(
+        {
+            "issueMappings": [
+                {
+                    "storyId": "STORY-001",
+                    "storyIndex": 1,
+                    "summary": "Orchestrate story",
+                    "repository": "MoonLadderStudios/MoonMind",
+                    "issueNumber": "21",
+                }
+            ],
+            "traceability": {"sourceIssueKey": "MM-1063"},
+        },
+        execution_creator=creator,
+    )
+
+    assert result.outputs["githubWorkflowOrchestration"]["createdWorkflowCount"] == 1
+    workflow = creator.requests[0]["initial_parameters"]["workflow"]
+    assert workflow["taskTemplate"]["slug"] == "github-issue-orchestrate"
+    assert workflow["inputs"]["github_issue_ref"] == "MoonLadderStudios/MoonMind#21"
+
+
+def test_register_story_output_tool_handlers_includes_github_story_tools():
+    dispatcher = _RecordingDispatcher()
+
+    story_tools.register_story_output_tool_handlers(dispatcher)
+
+    assert "story.create_github_issues" in dispatcher.skills
+    assert "story.create_github_issue_implement_workflows" in dispatcher.skills
+    assert "story.create_github_issue_orchestrate_workflows" in dispatcher.skills
 
 @pytest.mark.asyncio
 async def test_load_jira_preset_brief_uses_trusted_jira_issue_payload():

--- a/tests/unit/workflows/temporal/test_story_output_tools.py
+++ b/tests/unit/workflows/temporal/test_story_output_tools.py
@@ -490,7 +490,11 @@ async def test_create_github_issues_from_reconciled_story_breakdown():
         {
             "repository": "MoonLadderStudios/MoonMind",
             "workflowId": "mm-1068-run",
-            "github": {"labels": ["moonmind", "MM-1068"]},
+            "github": {
+                "labels": ["moonmind", "MM-1068"],
+                "token": "workflow-payload-token",
+                "githubToken": "workflow-payload-token-alias",
+            },
             "stories": {
                 "source": {
                     "referencePath": "docs/Workflows/SkillAndPlanContracts.md",
@@ -573,6 +577,7 @@ async def test_create_github_issues_from_reconciled_story_breakdown():
     assert "DESIGN-REQ-007" in request["body"]
     assert "DESIGN-REQ-014" in request["body"]
     assert "One issue is created." in request["body"]
+    assert request["github_token"] is None
 
 
 @pytest.mark.asyncio

--- a/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
+++ b/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
@@ -2446,6 +2446,19 @@ def test_runtime_planner_uses_branch_handoff_for_jira_output_when_task_publish_n
     assert jira["inputs"]["storyOutput"]["mode"] == "jira"
     assert jira["inputs"]["targetBranch"] == breakdown["inputs"]["targetBranch"]
 
+
+def test_github_story_tools_route_as_direct_story_output_tools() -> None:
+    assert "story.create_github_issues" in worker_runtime._STORY_OUTPUT_TASK_TOOLS
+    assert (
+        "story.create_github_issue_orchestrate_workflows"
+        in worker_runtime._STORY_OUTPUT_TASK_TOOLS
+    )
+    assert (
+        "story.create_github_issue_implement_workflows"
+        in worker_runtime._STORY_OUTPUT_TASK_TOOLS
+    )
+
+
 def test_runtime_planner_does_not_require_pr_branch_for_jira_issue_creator():
     planner = _build_runtime_planner()
     snapshot = SimpleNamespace(

--- a/tests/unit/workflows/temporal/workflows/test_run_integration.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_integration.py
@@ -2321,6 +2321,40 @@ def test_trusted_jira_output_summary_omits_empty_reason_suffix() -> None:
     assert summary == "Jira story output finished with status jira_blocked."
 
 
+def test_trusted_output_summary_uses_github_workflow_terminology() -> None:
+    issue_summary = MoonMindRunWorkflow._trusted_jira_output_summary(
+        {
+            "storyOutput": {
+                "status": "github_created",
+                "createdCount": 2,
+                "eligibleStoryCount": 2,
+                "storyCount": 3,
+                "dependencyMode": "none",
+                "dependencyCount": 0,
+            }
+        }
+    )
+    workflow_summary = MoonMindRunWorkflow._trusted_jira_output_summary(
+        {
+            "githubWorkflowOrchestration": {
+                "status": "completed",
+                "createdWorkflowCount": 2,
+                "storyCount": 2,
+                "dependencyCount": 1,
+            }
+        }
+    )
+
+    assert issue_summary == (
+        "Created GitHub issues; created=2; eligible=2; stories=3; "
+        "dependencyMode=none; dependencyCount=0."
+    )
+    assert workflow_summary == (
+        "GitHub downstream workflow creation completed "
+        "(createdWorkflows=2; stories=2; workflowDependencies=1)."
+    )
+
+
 def test_record_execution_context_scrubs_operator_summary_and_ignores_negative_commit_count(
     mock_run_workflow: MoonMindRunWorkflow,
 ) -> None:


### PR DESCRIPTION
## Issue
MM-1068: Create GitHub issue story-output tools

## Summary
- Registered `story.create_github_issues`, `story.create_github_issue_implement_workflows`, and `story.create_github_issue_orchestrate_workflows` story-output tools.
- Added GitHub issue creation from reconciled runtime story breakdown JSON with source path, title, claim, and source issue traceability preserved in issue bodies.
- Added downstream GitHub Issue Implement and GitHub Issue Orchestrate workflow execution creation from stable issue mappings, with conservative dependency metadata and workflow-focused outputs.
- Updated workflow runtime integration, documentation, and unit coverage for the new story-output tool contracts.

## Tests run
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_story_output_tools.py tests/unit/workflows/temporal/workflows/test_run_integration.py`

## Remaining risks
- External GitHub issue creation and downstream workflow execution depend on authenticated runtime configuration and trusted API responses in the target environment.
