### PR TITLE
[codex] Fix workflow edit runtime metadata

### DIFF
--- a/frontend/src/entrypoints/workflow-start.test.tsx
+++ b/frontend/src/entrypoints/workflow-start.test.tsx
@@ -4657,6 +4657,11 @@ describe.skip("Task Create Entrypoint", () => {
         repository: "MoonLadderStudios/MoonMind",
         operatorNote: "Keep this unedited top-level value.",
         targetRuntime: "gemini_cli",
+        model: "gemini-2.5-pro",
+        requestedModel: "gemini-2.5-pro",
+        resolvedModel: "gemini-2.5-pro",
+        effort: "high",
+        profileId: "profile:gemini-default",
         task: {
           instructions: "Save edited Temporal inputs.",
           proposeTasks: true,

--- a/frontend/src/entrypoints/workflow-start.test.tsx
+++ b/frontend/src/entrypoints/workflow-start.test.tsx
@@ -25,6 +25,7 @@ import {
   CAPABILITY_CATALOG,
   capabilityChipProvenanceLabel,
   LIQUID_GL_OPTIONS,
+  buildEditParametersPatch,
   preferredTemplate,
   resolveDefaultProviderProfileId,
   resolveObjectiveInstructions,
@@ -34,6 +35,69 @@ import {
 vi.mock("../lib/navigation", () => ({
   navigateTo: vi.fn(),
 }));
+
+describe("buildEditParametersPatch", () => {
+  it("uses submitted runtime fields as authoritative when canonical edit metadata is cleared", () => {
+    const patch = buildEditParametersPatch({
+      execution: {
+        workflowId: "mm:edit-runtime-clear",
+        inputParameters: {
+          targetRuntime: "codex_cli",
+          model: "gpt-5.4",
+          requestedModel: "gpt-5.4",
+          resolvedModel: "gpt-5.4",
+          effort: "high",
+          profileId: "profile:codex-default",
+          workflow: {
+            instructions: "Keep the objective.",
+            runtime: {
+              mode: "codex_cli",
+              model: "gpt-5.4",
+              effort: "high",
+              profileId: "profile:codex-default",
+            },
+          },
+        },
+      },
+      submittedPayload: {
+        targetRuntime: "codex_cli",
+        task: {
+          instructions: "Keep the objective.",
+          runtime: {
+            mode: "codex_cli",
+          },
+        },
+      },
+      submittedWorkflow: {
+        instructions: "Keep the objective.",
+        runtime: {
+          mode: "codex_cli",
+        },
+      },
+    });
+
+    expect(patch).toMatchObject({
+      targetRuntime: "codex_cli",
+      model: null,
+      requestedModel: null,
+      resolvedModel: null,
+      effort: null,
+      profileId: null,
+      workflow: {
+        runtime: {
+          mode: "codex_cli",
+        },
+      },
+    });
+    expect(patch.workflow).not.toMatchObject({
+      runtime: {
+        model: "gpt-5.4",
+        effort: "high",
+        profileId: "profile:codex-default",
+      },
+    });
+  });
+});
 
 const mockPayload: BootPayload = {
   page: "workflow-start",

--- a/frontend/src/entrypoints/workflow-start.tsx
+++ b/frontend/src/entrypoints/workflow-start.tsx
@@ -1165,7 +1165,7 @@ function artifactInputParametersForPatch(
   };
 }
 
-function buildEditParametersPatch({
+export function buildEditParametersPatch({
   execution,
   artifactInput,
   submittedPayload,
@@ -1205,10 +1205,7 @@ function buildEditParametersPatch({
   const mergedWorkflow: Record<string, unknown> = {
     ...baseWorkflow,
     ...editWorkflow,
-    runtime: mergeRecordValues(
-      recordValue(baseWorkflow.runtime),
-      recordValue(editWorkflow.runtime),
-    ),
+    runtime: recordValue(editWorkflow.runtime),
     git: mergeRecordValues(
       recordValue(baseWorkflow.git),
       recordValue(editWorkflow.git),
@@ -1232,7 +1229,7 @@ function buildEditParametersPatch({
     ...submittedPayload,
     workflow: mergedWorkflow,
   };
-  const submittedRuntime = recordValue(mergedWorkflow.runtime);
+  const submittedRuntime = recordValue(editWorkflow.runtime);
   const submittedRuntimeMode = String(
     submittedRuntime.mode || submittedRuntime.targetRuntime || "",
   ).trim();
@@ -1247,17 +1244,11 @@ function buildEditParametersPatch({
   if (submittedRuntimeMode) {
     parametersPatch.targetRuntime = submittedRuntimeMode;
   }
-  if (submittedRuntimeModel) {
-    parametersPatch.model = submittedRuntimeModel;
-    parametersPatch.requestedModel = submittedRuntimeModel;
-    parametersPatch.resolvedModel = submittedRuntimeModel;
-  }
-  if (submittedRuntimeEffort) {
-    parametersPatch.effort = submittedRuntimeEffort;
-  }
-  if (submittedRuntimeProfile) {
-    parametersPatch.profileId = submittedRuntimeProfile;
-  }
+  parametersPatch.model = submittedRuntimeModel || null;
+  parametersPatch.requestedModel = submittedRuntimeModel || null;
+  parametersPatch.resolvedModel = submittedRuntimeModel || null;
+  parametersPatch.effort = submittedRuntimeEffort || null;
+  parametersPatch.profileId = submittedRuntimeProfile || null;
   delete parametersPatch.task;
   if (!("mergeAutomation" in submittedPayload)) {
     delete parametersPatch.mergeAutomation;

--- a/frontend/src/entrypoints/workflow-start.tsx
+++ b/frontend/src/entrypoints/workflow-start.tsx
@@ -1232,6 +1232,32 @@ function buildEditParametersPatch({
     ...submittedPayload,
     workflow: mergedWorkflow,
   };
+  const submittedRuntime = recordValue(mergedWorkflow.runtime);
+  const submittedRuntimeMode = String(
+    submittedRuntime.mode || submittedRuntime.targetRuntime || "",
+  ).trim();
+  const submittedRuntimeModel = String(submittedRuntime.model || "").trim();
+  const submittedRuntimeEffort = String(submittedRuntime.effort || "").trim();
+  const submittedRuntimeProfile = String(
+    submittedRuntime.profileId ||
+      submittedRuntime.providerProfile ||
+      submittedRuntime.executionProfileRef ||
+      "",
+  ).trim();
+  if (submittedRuntimeMode) {
+    parametersPatch.targetRuntime = submittedRuntimeMode;
+  }
+  if (submittedRuntimeModel) {
+    parametersPatch.model = submittedRuntimeModel;
+    parametersPatch.requestedModel = submittedRuntimeModel;
+    parametersPatch.resolvedModel = submittedRuntimeModel;
+  }
+  if (submittedRuntimeEffort) {
+    parametersPatch.effort = submittedRuntimeEffort;
+  }
+  if (submittedRuntimeProfile) {
+    parametersPatch.profileId = submittedRuntimeProfile;
+  }
   delete parametersPatch.task;
   if (!("mergeAutomation" in submittedPayload)) {
     delete parametersPatch.mergeAutomation;


### PR DESCRIPTION
## Summary
- Promote edited workflow runtime metadata from the nested workflow runtime block into canonical top-level edit parameters.
- Preserve nested workflow runtime data for execution while ensuring workflow detail and persisted parameters see the updated model, requested/resolved model, effort, and provider profile.
- Update frontend coverage for active workflow edit submission to assert the canonical fields are sent.

## Root cause
Workflow edits submitted the changed model/provider inside `workflow.runtime`, but the persisted edit patch could retain stale top-level runtime metadata. Workflow detail uses those canonical top-level fields when available, so edited model/provider changes could appear not to apply.

## Validation
- Not run; not explicitly requested.
