### PR TITLE
MM-1062 Simplify Batch Workflow

### DIFF
--- a/.agents/skills/batch-workflows/SKILL.md
+++ b/.agents/skills/batch-workflows/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: batch-workflows
-description: Resolve Jira board-column or GitHub repository issue targets and enqueue one child MoonMind workflow per target using a selected child preset, inherited runtime, and a shared publish policy.
+description: Resolve Jira issues by project/status and enqueue one child MoonMind workflow per target using a selected run capability, inherited runtime, and a shared advanced publish policy.
 metadata:
   required-capabilities:
     - git
@@ -12,70 +12,55 @@ metadata:
 
 ## Purpose
 
-Resolve a set of issue-like targets, then queue one child MoonMind workflow per
-target running a selected child preset (for example `jira-implement` or
-`github-issue-implement`). Every child inherits the parent runtime
+Resolve a Jira status cohort, then queue one child MoonMind workflow per target
+running a selected child capability such as `skill:jira-verify` or
+`preset:jira-implement`. Every child inherits the parent runtime
 (`runtimeInheritance="caller"`) and a single shared publish policy. The parent
 records a summary artifact that links every queued child workflow.
 
-This replaces one-off prompts like "Queue a Jira Implement preset for every issue
-in the In Progress column of the THOR board" with a single batch run.
+This replaces one-off prompts like "Queue Jira Verify for every MM issue in In
+Progress" with a single batch run.
 
 ## Inputs (preset inputs / skill args)
 
-- `source_kind` (string, required): `jira_board_column` or `github_repo_issues`.
-- Jira board-column source: `jira_board_id`, `jira_column`, optional
-  `jira_label_filter`, `jira_issue_type_filter`, `jira_assignee_filter`, and
-  `repository` (target repo for implementation children; defaults to the parent
-  workflow repository when available).
-- GitHub repo issues source: `github_repository`, `github_issue_state`
-  (default `open`), optional `github_label_filter`, `github_assignee_filter`,
-  `github_milestone_filter`, `github_search_query`.
-- `target_preset_slug` / `target_preset_scope`
-  (default `global`) / `target_preset_scope_ref`: the child preset to run per
-  target. Known issue presets (`jira-implement`, `github-issue-implement`) are
-  auto-bound; other presets must be mapped explicitly.
-- `constraints` (string, optional): shared input copied to every child.
-- `publish_mode` (string, required): `none`, `branch`, or `pr`.
+- `jira_project_key` (string, required): Jira project key, for example `MM`.
+- `jira_status` (string, required): Jira status name, for example `In Progress`.
+- `run_ref` (string, required): child capability to run per target. Default
+  `skill:jira-verify`. Supported values are `skill:jira-verify`,
+  `preset:jira-implement`, and the helper also supports
+  `preset:github-issue-implement` for non-default GitHub target files.
 - `max_workflows` (number, optional): hard cap on queued children. Default `25`.
-- `sort` (string, optional): target ordering.
+- `constraints` (string, optional): shared input copied to every child.
+- `additional_jql` (string, optional): advanced JQL AND-clause appended to the
+  project/status query.
+- `repository` (string, optional): repository override when workflow context
+  cannot infer it.
+- `publish_mode` (string, optional): advanced child publish override, `none`,
+  `branch`, or `pr`. Default `none`.
 
 ## Workflow
 
-1. **Resolve targets** into the canonical resolved-target shape and write them to
-   `artifacts/batch-workflows-targets.json`, then preview the list before queueing.
-   - `jira_board_column`: use the deterministic trusted Jira tool surface to list
-     the issues in the selected column of the selected board, apply the optional
-     label/issue-type/assignee filters, sort, and cap at `max_workflows`. Each
-     target is:
+1. **Resolve Jira targets** into the canonical resolved-target shape and write
+   them to `artifacts/batch-workflows-targets.json`, then preview the list before
+   queueing. Use the trusted Jira tool surface to search:
 
-     ```json
-     {
-       "provider": "jira",
-       "ref": "THOR-123",
-       "jiraIssue": {"key": "THOR-123", "summary": "...", "description": "...",
-                      "url": "...", "status": "In Progress", "assignee": "..."},
-       "repository": "MoonLadderStudios/MoonMind"
-     }
-     ```
+   ```text
+   project = "<jira_project_key>" AND status = "<jira_status>"
+   ```
 
-   - `github_repo_issues`: use the trusted GitHub tool surface (`gh issue list`)
-     on the selected repository with the chosen state and optional
-     label/assignee/milestone/search filters, sort, and cap at `max_workflows`.
-     Each target is:
+   Append `additional_jql` only when provided. Each target is:
 
-     ```json
-     {
-       "provider": "github",
-       "ref": "MoonLadderStudios/MoonMind#123",
-       "githubIssue": {"repository": "MoonLadderStudios/MoonMind", "number": 123,
-                        "title": "...", "body": "...", "url": "...",
-                        "state": "open", "labels": ["..."]},
-       "repository": "MoonLadderStudios/MoonMind"
-     }
-     ```
+   ```json
+   {
+     "provider": "jira",
+     "ref": "MM-123",
+     "jiraIssue": {"key": "MM-123", "summary": "...", "description": "...",
+                    "url": "...", "status": "In Progress", "assignee": "..."},
+     "repository": "MoonLadderStudios/MoonMind"
+   }
+   ```
 
-   Never use raw Jira/GitHub credentials, web scraping, or guessed issue content to
+   Never use raw Jira credentials, web scraping, or guessed issue content to
    build the target list.
 
 2. **Queue child workflows** by running the helper:
@@ -83,26 +68,28 @@ in the In Progress column of the THOR board" with a single batch run.
    ```bash
    python3 .agents/skills/batch-workflows/bin/batch_workflows.py \
      --targets artifacts/batch-workflows-targets.json \
-     --target-preset-slug <slug> \
-     --target-preset-scope <global|personal> \
-     --target-preset-scope-ref <scope-ref-or-empty> \
+     --run-ref <skill:jira-verify|preset:jira-implement> \
      --publish-mode <none|branch|pr> \
      --constraints-file <optional path to shared constraints> \
      --max-workflows <cap>
    ```
 
    For each resolved target the helper:
-   - Auto-binds the issue target into the child preset's issue input
-     (`jira_issue` + `jira_issue_key` for `jira-implement`; `github_issue` +
-     `github_issue_ref` for `github-issue-implement`) and copies the shared
-     `constraints` into every child.
+   - Auto-binds Jira issues into `skill:jira-verify` inputs (`jira_issue`,
+     `jira_issue_key`, `repository`, `verification_mode`, `update_status`, and
+     `constraints`).
+   - Auto-binds Jira issues into `preset:jira-implement` inputs
+     (`jira_issue`, `jira_issue_key`, and `constraints`).
+   - Auto-binds GitHub issue targets into `preset:github-issue-implement` inputs
+     when a non-default GitHub target file is provided.
    - Stamps `runtimeInheritance="caller"` plus a fallback copy of the parent's
      effective runtime (mode/model/effort/provider profile) so children reuse the
      caller runtime even on deployments that do not honour the inheritance
      contract.
    - Applies the chosen `publish.mode` once to every child.
-   - Assigns a stable idempotency key per `(batch scope, target ref)` so rerunning
-     the same batch does not create duplicate child workflows.
+   - Assigns a stable idempotency key per `(batch scope, provider, target kind,
+     target slug, target ref)` so rerunning the same batch does not create
+     duplicate child workflows.
    - Submits via the internal Temporal execution API (`POST /api/executions`);
      `MOONMIND_URL` must point at the MoonMind API from the managed session.
 
@@ -114,8 +101,8 @@ in the In Progress column of the THOR board" with a single batch run.
 
 - Require `MOONMIND_URL` to reach the MoonMind API; the legacy direct-DB queue is
   not supported.
-- Never re-select provider/model/effort in the batch form — children inherit the
+- Never re-select provider/model/effort in the batch form; children inherit the
   caller runtime.
 - Cap the resolved list at `max_workflows`.
-- Targets whose selected preset is not auto-bindable and has no explicit mapping
-  are skipped with a clear `unsupported_preset` reason rather than queued blindly.
+- Targets whose selected run capability is not auto-bindable are skipped with a
+  clear `unsupported_target` reason rather than queued blindly.

--- a/.agents/skills/batch-workflows/bin/batch_workflows.py
+++ b/.agents/skills/batch-workflows/bin/batch_workflows.py
@@ -102,8 +102,12 @@ def run_ref_for_config(config: TargetConfig) -> str:
     return f"{config.target_kind}:{config.target_slug}"
 
 
-def _required_capabilities_for(provider: str) -> list[str]:
+def _required_capabilities_for(
+    provider: str, target_kind: str | None = None, target_slug: str | None = None
+) -> list[str]:
     base = ["git"]
+    if provider == "jira" and target_kind == "skill" and target_slug == "jira-verify":
+        return base + ["jira"]
     if provider == "jira":
         base += ["jira", "gh"]
     elif provider == "github":
@@ -296,7 +300,9 @@ def build_child_request(
 
     publish_mode = _normalize_publish_mode(config.publish_mode)
     required_capabilities = config.required_capabilities or _required_capabilities_for(
-        provider
+        provider,
+        config.target_kind,
+        config.target_slug,
     )
 
     task_payload: dict[str, Any] = {
@@ -381,9 +387,10 @@ def build_child_requests(
     submissions: list[ChildSubmission] = []
     skipped: list[SkippedTarget] = []
 
-    capped = targets[: max(0, int(max_workflows))] if max_workflows else targets
-    if max_workflows and len(targets) > max_workflows:
-        for overflow in targets[max_workflows:]:
+    limit = max(0, int(max_workflows))
+    capped = targets[:limit]
+    if len(targets) > limit:
+        for overflow in targets[limit:]:
             skipped.append(
                 SkippedTarget(
                     ref=str(overflow.get("ref") or "(unknown)"),

--- a/.agents/skills/batch-workflows/bin/batch_workflows.py
+++ b/.agents/skills/batch-workflows/bin/batch_workflows.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 """Queue one child MoonMind workflow per resolved issue target.
 
-The agent resolves Jira board-column or GitHub repository issue targets into the
-canonical resolved-target shape (see SKILL.md) and writes them to a JSON file.
-This helper reads that file plus the selected child preset / publish policy and
+The agent resolves Jira status or other issue targets into the canonical
+resolved-target shape (see SKILL.md) and writes them to a JSON file. This helper
+reads that file plus the selected child run capability / publish policy and
 submits one child execution per target through the internal Temporal execution
 API. Every child inherits the parent runtime via ``runtimeInheritance="caller"``
 (with a fallback copy of the effective runtime fields) and shares a single
@@ -39,11 +39,6 @@ logger = logging.getLogger(__name__)
 API_EXECUTIONS_ENDPOINT = "/api/executions"
 IDEMPOTENCY_KEY_MAX_LENGTH = 128
 
-# Presets whose issue input the batch form auto-binds. The resolved target is
-# mapped into these presets' issue inputs and the server goal scheduler expands
-# the matching preset from the queued child goal.
-AUTO_BINDABLE_PRESETS = frozenset({"jira-implement", "github-issue-implement"})
-
 
 @dataclass
 class ChildSubmission:
@@ -68,9 +63,8 @@ class RuntimeSelection:
 
 @dataclass
 class TargetConfig:
-    preset_slug: str
-    preset_scope: str = "global"
-    preset_scope_ref: str | None = None
+    target_kind: str
+    target_slug: str
     publish_mode: str = "pr"
     constraints: str = ""
     required_capabilities: list[str] = field(default_factory=list)
@@ -90,6 +84,24 @@ def _normalize_publish_mode(value: str | None) -> str:
     return candidate
 
 
+def parse_run_ref(value: str | None) -> tuple[str, str]:
+    candidate = str(value or "").strip()
+    if ":" not in candidate:
+        raise ValueError(
+            "run ref must use '<kind>:<slug>', for example skill:jira-verify"
+        )
+    kind, slug = candidate.split(":", 1)
+    kind = kind.strip().lower()
+    slug = slug.strip()
+    if kind not in {"skill", "preset"} or not slug:
+        raise ValueError("run ref must target skill:<name> or preset:<slug>")
+    return kind, slug
+
+
+def run_ref_for_config(config: TargetConfig) -> str:
+    return f"{config.target_kind}:{config.target_slug}"
+
+
 def _required_capabilities_for(provider: str) -> list[str]:
     base = ["git"]
     if provider == "jira":
@@ -99,14 +111,32 @@ def _required_capabilities_for(provider: str) -> list[str]:
     return base
 
 
-def child_goal_for_target(target: dict[str, Any], preset_slug: str) -> str | None:
-    """Return the goal text that routes the server scheduler to ``preset_slug``.
+def child_goal_for_target(
+    target: dict[str, Any], target_kind: str, target_slug: str
+) -> str | None:
+    """Return the goal text for the selected child run target.
 
-    Returns ``None`` when the target cannot be auto-bound to the selected preset.
+    Returns ``None`` when the target cannot be auto-bound to the selected target.
     """
 
     provider = str(target.get("provider") or "").strip().lower()
-    if preset_slug == "jira-implement" and provider == "jira":
+    if (
+        target_kind == "skill"
+        and target_slug == "jira-verify"
+        and provider == "jira"
+    ):
+        issue = (
+            target.get("jiraIssue") if isinstance(target.get("jiraIssue"), dict) else {}
+        )
+        key = _text(issue.get("key")) or _text(target.get("ref"))
+        if key:
+            return f"Verify Jira issue {key}."
+        return None
+    if (
+        target_kind == "preset"
+        and target_slug == "jira-implement"
+        and provider == "jira"
+    ):
         issue = (
             target.get("jiraIssue") if isinstance(target.get("jiraIssue"), dict) else {}
         )
@@ -114,7 +144,11 @@ def child_goal_for_target(target: dict[str, Any], preset_slug: str) -> str | Non
         if key:
             return f"Implement Jira issue {key}."
         return None
-    if preset_slug == "github-issue-implement" and provider == "github":
+    if (
+        target_kind == "preset"
+        and target_slug == "github-issue-implement"
+        and provider == "github"
+    ):
         issue = (
             target.get("githubIssue")
             if isinstance(target.get("githubIssue"), dict)
@@ -132,17 +166,41 @@ def child_goal_for_target(target: dict[str, Any], preset_slug: str) -> str | Non
 
 
 def bind_child_inputs(
-    target: dict[str, Any], preset_slug: str, constraints: str
+    target: dict[str, Any], target_kind: str, target_slug: str, constraints: str
 ) -> dict[str, Any] | None:
-    """Apply the default issue bindings for the selected child preset.
+    """Apply the default issue bindings for the selected child target.
 
     Mirrors the ``annotations.bindings`` declared by the ``batch-workflows``
-    preset. Returns ``None`` when the preset is not auto-bindable for the target.
+    preset. Returns ``None`` when the target is not auto-bindable.
     """
 
     provider = str(target.get("provider") or "").strip().lower()
     shared = _text(constraints)
-    if preset_slug == "jira-implement" and provider == "jira":
+    if (
+        target_kind == "skill"
+        and target_slug == "jira-verify"
+        and provider == "jira"
+    ):
+        issue = (
+            target.get("jiraIssue") if isinstance(target.get("jiraIssue"), dict) else {}
+        )
+        key = _text(issue.get("key")) or _text(target.get("ref"))
+        if not key:
+            return None
+        inputs: dict[str, Any] = {
+            "jira_issue": dict(issue) if issue else {"key": key},
+            "jira_issue_key": key,
+            "repository": _text(target.get("repository")) or "",
+            "verification_mode": "auto",
+            "update_status": False,
+            "constraints": shared or "",
+        }
+        return inputs
+    if (
+        target_kind == "preset"
+        and target_slug == "jira-implement"
+        and provider == "jira"
+    ):
         issue = (
             target.get("jiraIssue") if isinstance(target.get("jiraIssue"), dict) else {}
         )
@@ -155,7 +213,11 @@ def bind_child_inputs(
             "constraints": shared or "",
         }
         return inputs
-    if preset_slug == "github-issue-implement" and provider == "github":
+    if (
+        target_kind == "preset"
+        and target_slug == "github-issue-implement"
+        and provider == "github"
+    ):
         issue = (
             target.get("githubIssue")
             if isinstance(target.get("githubIssue"), dict)
@@ -175,7 +237,12 @@ def bind_child_inputs(
 
 
 def _child_idempotency_key(
-    *, batch_scope: str | None, provider: str, ref: str, preset_slug: str
+    *,
+    batch_scope: str | None,
+    provider: str,
+    ref: str,
+    target_kind: str,
+    target_slug: str,
 ) -> str | None:
     scope = _text(batch_scope)
     if not scope:
@@ -184,7 +251,8 @@ def _child_idempotency_key(
         "scope": scope,
         "provider": provider,
         "ref": ref,
-        "preset": preset_slug,
+        "targetKind": target_kind,
+        "targetSlug": target_slug,
     }
     canonical = json.dumps(components, sort_keys=True, separators=(",", ":"))
     digest = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
@@ -207,7 +275,7 @@ def build_child_request(
 ) -> dict[str, Any] | None:
     """Build a single ``POST /api/executions`` request for one resolved target.
 
-    Returns ``None`` when the target cannot be auto-bound to the selected preset.
+    Returns ``None`` when the target cannot be auto-bound to the selected target.
     """
 
     provider = str(target.get("provider") or "").strip().lower()
@@ -216,8 +284,13 @@ def build_child_request(
     if not ref:
         return None
 
-    goal = child_goal_for_target(target, config.preset_slug)
-    inputs = bind_child_inputs(target, config.preset_slug, config.constraints)
+    goal = child_goal_for_target(target, config.target_kind, config.target_slug)
+    inputs = bind_child_inputs(
+        target,
+        config.target_kind,
+        config.target_slug,
+        config.constraints,
+    )
     if goal is None or inputs is None:
         return None
 
@@ -231,22 +304,22 @@ def build_child_request(
         "instructions": goal,
         "inputs": inputs,
         "publish": {"mode": publish_mode},
-        # Author the child with the selected preset via ``taskTemplate`` so the
-        # execution API expands the exact slug/scope/scopeRef (see
-        # expand_preset_for_child_run). Without this the child is goal-only and
-        # the server goal scheduler silently substitutes a global preset,
-        # dropping any personal scope or scopeRef. ``batchTargetPreset`` has no
-        # readers, so it is not emitted.
-        "taskTemplate": {
-            "slug": config.preset_slug,
-            "scope": config.preset_scope,
-            **(
-                {"scopeRef": config.preset_scope_ref}
-                if _text(config.preset_scope_ref)
-                else {}
-            ),
-        },
     }
+    if config.target_kind == "skill":
+        task_payload["tool"] = {
+            "type": "skill",
+            "name": config.target_slug,
+        }
+    elif config.target_kind == "preset":
+        # Author the child with the selected preset via ``taskTemplate`` so the
+        # execution API expands the exact global preset instead of relying on
+        # goal-only scheduler inference.
+        task_payload["taskTemplate"] = {
+            "slug": config.target_slug,
+            "scope": "global",
+        }
+    else:
+        return None
 
     payload_dict: dict[str, Any] = {
         "requiredCapabilities": required_capabilities,
@@ -280,7 +353,8 @@ def build_child_request(
         batch_scope=batch_scope,
         provider=provider,
         ref=ref,
-        preset_slug=config.preset_slug,
+        target_kind=config.target_kind,
+        target_slug=config.target_slug,
     )
     if idempotency_key:
         payload_dict["idempotencyKey"] = idempotency_key
@@ -319,9 +393,6 @@ def build_child_requests(
 
     for target in capped:
         ref = str(target.get("ref") or "(unknown)")
-        if config.preset_slug not in AUTO_BINDABLE_PRESETS:
-            skipped.append(SkippedTarget(ref=ref, reason="unsupported_preset"))
-            continue
         request = build_child_request(
             target,
             config=config,
@@ -330,7 +401,7 @@ def build_child_requests(
             inherit_runtime_from_caller=inherit_runtime_from_caller,
         )
         if request is None:
-            skipped.append(SkippedTarget(ref=ref, reason="unbindable_target"))
+            skipped.append(SkippedTarget(ref=ref, reason="unsupported_target"))
             continue
         submissions.append(
             ChildSubmission(
@@ -622,9 +693,7 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument(
         "--targets", required=True, help="Path to resolved targets JSON."
     )
-    parser.add_argument("--target-preset-slug", required=True)
-    parser.add_argument("--target-preset-scope", default="global")
-    parser.add_argument("--target-preset-scope-ref", default=None)
+    parser.add_argument("--run-ref", required=True)
     parser.add_argument("--publish-mode", default="pr")
     parser.add_argument("--constraints", default=None)
     parser.add_argument("--constraints-file", default=None)
@@ -644,11 +713,11 @@ async def main(argv: list[str] | None = None) -> int:
     runtime = _resolve_runtime_selection(args.task_context_path)
     batch_scope = _parent_run_scope(args.task_context_path)
     inherit_from_caller = _task_workflow_id_from_env() is not None
+    target_kind, target_slug = parse_run_ref(args.run_ref)
 
     config = TargetConfig(
-        preset_slug=str(args.target_preset_slug).strip(),
-        preset_scope=str(args.target_preset_scope or "global").strip() or "global",
-        preset_scope_ref=_text(args.target_preset_scope_ref),
+        target_kind=target_kind,
+        target_slug=target_slug,
         publish_mode=_normalize_publish_mode(args.publish_mode),
         constraints=constraints,
     )
@@ -666,10 +735,9 @@ async def main(argv: list[str] | None = None) -> int:
     payload = {
         "timestamp": datetime.now(UTC).isoformat(),
         "actor": os.getenv("GITHUB_ACTOR") or os.getenv("USER") or "unknown",
-        "targetPreset": {
-            "slug": config.preset_slug,
-            "scope": config.preset_scope,
-            "scopeRef": config.preset_scope_ref,
+        "target": {
+            "kind": config.target_kind,
+            "slug": config.target_slug,
         },
         "publishMode": config.publish_mode,
         "runtime": {
@@ -707,7 +775,7 @@ async def main(argv: list[str] | None = None) -> int:
     print(json.dumps(payload, indent=2))
     print(
         f"queued={payload['created']} skipped={len(skipped)} errors={len(errors)} "
-        f"preset={config.preset_slug}"
+        f"target={run_ref_for_config(config)}"
     )
     return 1 if errors else 0
 

--- a/.agents/skills/jira-verify/SKILL.md
+++ b/.agents/skills/jira-verify/SKILL.md
@@ -12,6 +12,42 @@ metadata:
   required-capabilities:
     - jira
     - git
+inputSchema:
+  type: object
+  required:
+    - jira_issue_key
+  properties:
+    jira_issue_key:
+      type: string
+      title: Jira issue
+      x-moonmind-semantic-type: issue-reference
+      x-moonmind-provider: jira
+    repository:
+      type: string
+      title: Repository
+      x-moonmind-context-default: repository
+    verification_mode:
+      type: string
+      title: Verification mode
+      enum:
+        - auto
+        - branch
+        - main
+      default: auto
+    update_status:
+      type: boolean
+      title: Update Jira status on PASS
+      default: false
+    constraints:
+      type: string
+      title: Extra verification instructions
+      x-moonmind-multiline: true
+uiSchema:
+  constraints:
+    widget: textarea
+defaults:
+  verification_mode: auto
+  update_status: false
 ---
 
 # Jira Verify

--- a/api_service/data/presets/batch-workflows.yaml
+++ b/api_service/data/presets/batch-workflows.yaml
@@ -1,15 +1,14 @@
 slug: batch-workflows
 title: Batch Workflows
-description: Resolve a set of Jira board-column or GitHub repository issue targets,
-  then queue one child MoonMind workflow per target using a selected child preset,
-  inherited runtime/provider/model settings, and a shared publish policy. The parent
-  records a summary artifact that links every queued child workflow.
+description: Resolve Jira issues by project and status, then queue one child
+  MoonMind workflow per issue using a selected run capability, inherited runtime
+  settings, and a shared advanced publish policy. The parent records a summary
+  artifact that links every queued child workflow.
 scope: global
 tags:
 - batch
 - orchestration
 - jira
-- github
 requiredCapabilities:
 - git
 - gh
@@ -23,337 +22,181 @@ annotations:
     summaryArtifact: artifacts/batch-workflows-result.json
     targetListArtifact: artifacts/batch-workflows-targets.json
   bindings:
-    jira-implement:
+    skill:jira-verify:
+      jira_issue: '{{ target.jiraIssue }}'
+      jira_issue_key: '{{ target.jiraIssue.key }}'
+      repository: '{{ target.repository }}'
+      constraints: '{{ shared.constraints }}'
+    preset:jira-implement:
       jira_issue: '{{ target.jiraIssue }}'
       jira_issue_key: '{{ target.jiraIssue.key }}'
       constraints: '{{ shared.constraints }}'
-    github-issue-implement:
+    preset:github-issue-implement:
       github_issue: '{{ target.githubIssue }}'
       github_issue_ref: '{{ target.githubIssue.repository }}#{{ target.githubIssue.number }}'
       constraints: '{{ shared.constraints }}'
   inputSchema:
     type: object
     required:
-    - source_kind
-    - target_preset_slug
-    - publish_mode
+    - jira_project_key
+    - jira_status
+    - run_ref
     properties:
-      source_kind:
+      jira_project_key:
         type: string
-        title: Batch source
-        description: Top-level discriminator that selects what the batch iterates over.
+        title: Jira project
+        description: Jira project key to query, for example MM.
+      jira_status:
+        type: string
+        title: Status
+        description: Jira status name to batch, for example In Progress.
+      run_ref:
+        type: string
+        title: Run
+        description: Child capability to run for each resolved issue.
         enum:
-        - jira_board_column
-        - github_repo_issues
-      jira_board_id:
+        - skill:jira-verify
+        - preset:jira-implement
+      max_workflows:
         type: string
-        title: Jira board
-      jira_column:
-        type: string
-        title: Column
-      jira_label_filter:
-        type: string
-        title: Tag / label filter
-      jira_issue_type_filter:
-        type: string
-        title: Issue type filter
-      jira_assignee_filter:
-        type: string
-        title: Assignee filter
-      repository:
-        type: string
-        title: Repository
-        description: Target repository for implementation child workflows. Defaults
-          to the parent workflow repository when available.
-      github_repository:
-        type: string
-        title: GitHub repository
-      github_issue_state:
-        type: string
-        title: Issue state
-        enum:
-        - open
-        - closed
-        - all
-      github_label_filter:
-        type: string
-        title: Label filter
-      github_assignee_filter:
-        type: string
-        title: Assignee filter
-      github_milestone_filter:
-        type: string
-        title: Milestone filter
-      github_search_query:
-        type: string
-        title: Search query
-      target_preset_slug:
-        type: string
-        title: Run this preset for each item
-      target_preset_scope:
-        type: string
-        title: Target preset scope
-        enum:
-        - global
-        - personal
-      target_preset_scope_ref:
-        type: string
-        title: Target preset scope reference
+        title: Max workflows
       constraints:
         type: string
-        title: Constraints
+        title: Extra instructions / constraints
+      additional_jql:
+        type: string
+        title: Additional JQL filter
+        description: Optional AND-clause appended to the project/status query.
+      repository:
+        type: string
+        title: Repository override
+        description: Target repository when it cannot be inferred from context.
       publish_mode:
         type: string
-        title: Publish mode
+        title: Publish override
         enum:
         - none
         - branch
         - pr
-      max_workflows:
-        type: string
-        title: Max workflows
-      sort:
-        type: string
-        title: Sort
-        enum:
-        - rank
-        - updated_desc
-        - priority_desc
   uiSchema:
-    source_kind:
-      widget: discriminator
-      discriminates:
-        jira_board_column:
-        - jira_board_id
-        - jira_column
-        - jira_label_filter
-        - jira_issue_type_filter
-        - jira_assignee_filter
-        - repository
-        github_repo_issues:
-        - github_repository
-        - github_issue_state
-        - github_label_filter
-        - github_assignee_filter
-        - github_milestone_filter
-        - github_search_query
-    jira_board_id:
-      widget: jira.board-picker
-    jira_column:
-      widget: jira.board-column-picker
-      dependsOn: jira_board_id
-      allowManualEntryOnApiFailure: true
+    run_ref:
+      widget: select
+    constraints:
+      widget: textarea
+      advanced: true
+    additional_jql:
+      widget: textarea
+      advanced: true
     repository:
-      widget: github.repo-picker
-    github_repository:
-      widget: github.repo-picker
-    target_preset_slug:
-      widget: preset.selector
-      highlightCompatible:
-      - jira-implement
-      - github-issue-implement
+      advanced: true
     publish_mode:
-      widget: publish.mode-picker
+      widget: select
+      advanced: true
   defaults:
-    source_kind: jira_board_column
-    github_issue_state: open
-    target_preset_slug: jira-implement
-    target_preset_scope: global
-    publish_mode: pr
+    run_ref: skill:jira-verify
     max_workflows: '25'
-    sort: rank
+    publish_mode: none
 inputs:
-- name: source_kind
-  label: Batch source
-  type: enum
-  required: true
-  default: jira_board_column
-  options:
-  - jira_board_column
-  - github_repo_issues
-- name: jira_board_id
-  label: Jira Board
-  type: jira_board
-  required: false
-  default: ''
-- name: jira_column
-  label: Column
-  type: text
-  required: false
-  default: ''
-- name: jira_label_filter
-  label: Tag / Label Filter
-  type: text
-  required: false
-  default: ''
-- name: jira_issue_type_filter
-  label: Issue Type Filter
-  type: text
-  required: false
-  default: ''
-- name: jira_assignee_filter
-  label: Assignee Filter
-  type: text
-  required: false
-  default: ''
-- name: repository
-  label: Repository
-  type: text
-  required: false
-  default: ''
-- name: github_repository
-  label: GitHub Repository
-  type: text
-  required: false
-  default: ''
-- name: github_issue_state
-  label: GitHub Issue State
-  type: enum
-  required: false
-  default: open
-  options:
-  - open
-  - closed
-  - all
-- name: github_label_filter
-  label: GitHub Label Filter
-  type: text
-  required: false
-  default: ''
-- name: github_assignee_filter
-  label: GitHub Assignee Filter
-  type: text
-  required: false
-  default: ''
-- name: github_milestone_filter
-  label: GitHub Milestone Filter
-  type: text
-  required: false
-  default: ''
-- name: github_search_query
-  label: GitHub Search Query
-  type: text
-  required: false
-  default: ''
-- name: target_preset_slug
-  label: Run This Preset For Each Item
+- name: jira_project_key
+  label: Jira Project
   type: text
   required: true
-  default: jira-implement
-- name: target_preset_scope
-  label: Target Preset Scope
-  type: enum
-  required: false
-  default: global
-  options:
-  - global
-  - personal
-- name: target_preset_scope_ref
-  label: Target Preset Scope Reference
+  default: ''
+- name: jira_status
+  label: Status
   type: text
-  required: false
+  required: true
   default: ''
-- name: constraints
-  label: Constraints
-  type: textarea
-  required: false
-  default: ''
-- name: publish_mode
-  label: Publish Mode
+- name: run_ref
+  label: Run
   type: enum
   required: true
-  default: pr
+  default: skill:jira-verify
   options:
-  - none
-  - branch
-  - pr
+  - skill:jira-verify
+  - preset:jira-implement
 - name: max_workflows
   label: Max Workflows
   type: text
   required: false
   default: '25'
-- name: sort
-  label: Sort
+- name: constraints
+  label: Extra Instructions / Constraints
+  type: textarea
+  required: false
+  default: ''
+- name: additional_jql
+  label: Additional JQL Filter
+  type: textarea
+  required: false
+  default: ''
+- name: repository
+  label: Repository Override
+  type: text
+  required: false
+  default: ''
+- name: publish_mode
+  label: Publish Override
   type: enum
   required: false
-  default: rank
+  default: none
   options:
-  - rank
-  - updated_desc
-  - priority_desc
+  - none
+  - branch
+  - pr
 steps:
-- title: Resolve targets and queue child workflows
+- title: Resolve Jira targets and queue child workflows
   annotations:
     batchWorkflowsRole: resolve-and-queue
   instructions: |-
-    Resolve a set of issue-like targets and queue one child MoonMind workflow per
+    Resolve Jira issues by project/status and queue one child MoonMind workflow per
     target. Do not re-select provider/model/effort: every child inherits the parent
     runtime via runtimeInheritance="caller".
 
-    Step 1 — Resolve targets into the canonical resolved-target shape.
-    If source_kind is "jira_board_column", use the deterministic trusted Jira tool
-    surface to list the issues in column "{{ inputs.jira_column }}" of board
-    "{{ inputs.jira_board_id }}". Apply the optional label, issue-type, and assignee
-    filters. Resolve each issue to:
+    Step 1 - Resolve targets into the canonical resolved-target shape. Use the
+    deterministic trusted Jira tool surface to search:
+    project = "{{ inputs.jira_project_key }}" AND status = "{{ inputs.jira_status }}"
+    Append this optional additional JQL filter only when it is non-empty:
+    {{ inputs.additional_jql }}
+    Resolve each issue to:
     {"provider": "jira", "ref": "<KEY>", "jiraIssue": {"key", "summary", "description",
     "url", "status", "assignee"}, "repository": "<owner/repo>"}.
-    If source_kind is "github_repo_issues", use the trusted GitHub tool surface
-    (gh issue list) on repository "{{ inputs.github_repository }}" with state
-    "{{ inputs.github_issue_state }}" and the optional label, assignee, milestone,
-    and search-query filters. Resolve each issue to:
-    {"provider": "github", "ref": "<owner/repo>#<number>", "githubIssue": {"repository",
-    "number", "title", "body", "url", "state", "labels"}, "repository": "<owner/repo>"}.
-    Apply the requested sort and cap the resolved list at {{ inputs.max_workflows }}
-    targets. Write the resolved target list to artifacts/batch-workflows-targets.json
-    and present it as a preview before queueing anything. Do not use raw Jira/GitHub
-    credentials, web scraping, or guessed issue content to build targets.
+    Use "{{ inputs.repository }}" as the repository override when it is non-empty;
+    otherwise infer the repository from workflow context when available. Cap the
+    resolved list at {{ inputs.max_workflows }} targets. Write the resolved target
+    list to artifacts/batch-workflows-targets.json and present it as a preview
+    before queueing anything. Do not use raw Jira credentials, web scraping, or
+    guessed issue content to build targets.
 
-    Step 2 — Queue one child workflow per resolved target running preset
-    "{{ inputs.target_preset_slug }}".
-    Auto-bind the resolved issue target into the child preset's issue input
-    (jira_issue/jira_issue_key for jira-implement, github_issue/github_issue_ref for
-    github-issue-implement) and copy the shared constraints into every child. Apply
-    publish mode "{{ inputs.publish_mode }}" once to every child. Run the helper
-    as a single command (the trailing backslashes join the line-continued
-    arguments; without them the shell would terminate the command after the
-    script name and parse the remaining flags as separate commands):
+    Step 2 - Queue one child workflow per resolved target running
+    "{{ inputs.run_ref }}". Auto-bind the resolved issue target into the child
+    capability's issue input and copy the shared constraints into every child.
+    Apply publish override "{{ inputs.publish_mode }}" once to every child. Run the
+    helper as a single command:
     python3 .agents/skills/batch-workflows/bin/batch_workflows.py \
     --targets artifacts/batch-workflows-targets.json \
-    --target-preset-slug "{{ inputs.target_preset_slug }}" \
-    --target-preset-scope "{{ inputs.target_preset_scope }}" \
-    --target-preset-scope-ref "{{ inputs.target_preset_scope_ref }}" \
+    --run-ref "{{ inputs.run_ref }}" \
     --publish-mode "{{ inputs.publish_mode }}" \
     --max-workflows "{{ inputs.max_workflows }}" \
     --constraints "{{ inputs.constraints }}"
     The helper stamps runtimeInheritance="caller" plus a fallback copy of the parent
-    runtime on each child and assigns a stable idempotency key so reruns do not
-    duplicate child workflows.
+    runtime on each child and assigns a stable idempotency key per target kind,
+    target slug, and resolved issue so reruns do not duplicate child workflows.
 
-    Step 3 — Record the summary. The helper writes artifacts/batch-workflows-result.json
+    Step 3 - Record the summary. The helper writes artifacts/batch-workflows-result.json
     linking every queued child workflow id together with the resolved targets, skips,
     and errors. Report the queued/skipped/error counts honestly and link the child
     workflows in the run summary.
   batchOrchestration:
     source:
-      kind: '{{ inputs.source_kind }}'
-      jiraBoardColumn:
-        boardId: '{{ inputs.jira_board_id }}'
-        column: '{{ inputs.jira_column }}'
-        labelFilter: '{{ inputs.jira_label_filter }}'
-        issueTypeFilter: '{{ inputs.jira_issue_type_filter }}'
-        assigneeFilter: '{{ inputs.jira_assignee_filter }}'
+      kind: jira_status
+      jiraStatus:
+        projectKey: '{{ inputs.jira_project_key }}'
+        status: '{{ inputs.jira_status }}'
+        additionalJql: '{{ inputs.additional_jql }}'
         repository: '{{ inputs.repository }}'
-      githubRepoIssues:
-        repository: '{{ inputs.github_repository }}'
-        state: '{{ inputs.github_issue_state }}'
-        labelFilter: '{{ inputs.github_label_filter }}'
-        assigneeFilter: '{{ inputs.github_assignee_filter }}'
-        milestoneFilter: '{{ inputs.github_milestone_filter }}'
-        searchQuery: '{{ inputs.github_search_query }}'
-    targetPreset:
-      slug: '{{ inputs.target_preset_slug }}'
-      scope: '{{ inputs.target_preset_scope }}'
-      scopeRef: '{{ inputs.target_preset_scope_ref }}'
+    target:
+      runRef: '{{ inputs.run_ref }}'
     sharedInputs:
       constraints: '{{ inputs.constraints }}'
     publish:
@@ -361,7 +204,6 @@ steps:
     runtime:
       inherit: caller
     maxWorkflows: '{{ inputs.max_workflows }}'
-    sort: '{{ inputs.sort }}'
     summaryArtifact: artifacts/batch-workflows-result.json
     targetListArtifact: artifacts/batch-workflows-targets.json
   skill:

--- a/tests/integration/test_startup_preset_seeding.py
+++ b/tests/integration/test_startup_preset_seeding.py
@@ -506,26 +506,42 @@ async def test_startup_seeds_default_task_templates(disabled_env_keys, tmp_path)
         assert batch_template is not None
         batch_annotations = batch_template.annotations or {}
         assert batch_annotations["runtimeInheritance"] == "caller"
-        assert batch_annotations["inputSchema"]["properties"]["source_kind"][
-            "enum"
-        ] == ["jira_board_column", "github_repo_issues"]
-        assert (
-            "target_preset_version"
-            not in batch_annotations["inputSchema"]["properties"]
-        )
-        assert batch_annotations["bindings"]["jira-implement"]["jira_issue_key"] == (
-            "{{ target.jiraIssue.key }}"
-        )
-        assert batch_annotations["bindings"]["github-issue-implement"][
+        batch_schema = batch_annotations["inputSchema"]
+        assert batch_schema["required"] == [
+            "jira_project_key",
+            "jira_status",
+            "run_ref",
+        ]
+        assert batch_schema["properties"]["run_ref"]["enum"] == [
+            "skill:jira-verify",
+            "preset:jira-implement",
+        ]
+        assert "source_kind" not in batch_schema["properties"]
+        assert "target_preset_slug" not in batch_schema["properties"]
+        assert "target_preset_version" not in batch_schema["properties"]
+        assert batch_annotations["uiSchema"]["run_ref"]["widget"] == "select"
+        assert batch_annotations["uiSchema"]["constraints"]["widget"] == "textarea"
+        assert batch_annotations["bindings"]["skill:jira-verify"][
+            "jira_issue_key"
+        ] == "{{ target.jiraIssue.key }}"
+        assert batch_annotations["bindings"]["preset:jira-implement"][
+            "jira_issue_key"
+        ] == "{{ target.jiraIssue.key }}"
+        assert batch_annotations["bindings"]["preset:github-issue-implement"][
             "github_issue_ref"
         ] == "{{ target.githubIssue.repository }}#{{ target.githubIssue.number }}"
         batch_steps = batch_template.steps
         assert len(batch_steps) == 1
         assert batch_steps[0]["skill"]["id"] == "batch-workflows"
         assert batch_steps[0]["batchOrchestration"]["runtime"]["inherit"] == "caller"
+        assert batch_steps[0]["batchOrchestration"]["source"]["kind"] == "jira_status"
         assert (
             batch_steps[0]["batchOrchestration"]["publish"]["mode"]
             == "{{ inputs.publish_mode }}"
+        )
+        assert (
+            batch_steps[0]["batchOrchestration"]["target"]["runRef"]
+            == "{{ inputs.run_ref }}"
         )
 
 @pytest.mark.asyncio

--- a/tests/unit/api/test_batch_workflows_preset.py
+++ b/tests/unit/api/test_batch_workflows_preset.py
@@ -1,9 +1,9 @@
-"""Catalog-boundary tests for the MM-885 ``batch-workflows`` seed preset.
+"""Catalog-boundary tests for the MM-1062 ``batch-workflows`` seed preset.
 
 These exercise the real preset validation + expansion path (the adapter boundary
 for presets): the seed YAML must validate, expose the documented batch contract
-(source discriminator, both source field sets, target-preset selector, default
-issue bindings, runtimeInheritance=caller, and a single shared publish policy),
+(Jira project/status source, run capability selector, default issue bindings,
+runtimeInheritance=caller, and a shared advanced publish policy),
 and expand into an orchestration step that queues child workflows.
 """
 
@@ -76,86 +76,92 @@ async def test_batch_workflows_seed_validates_and_exposes_batch_contract(tmp_pat
             assert template.title == "Batch Workflows"
             assert template.scope_type is PresetScopeType.GLOBAL
 
-            # Source discriminator with both options.
             schema = annotations["inputSchema"]
-            assert schema["properties"]["source_kind"]["enum"] == [
-                "jira_board_column",
-                "github_repo_issues",
+            assert schema["required"] == [
+                "jira_project_key",
+                "jira_status",
+                "run_ref",
             ]
-            assert "source_kind" in schema["required"]
-
-            # Jira board-column source field set.
             for name in (
+                "jira_project_key",
+                "jira_status",
+                "run_ref",
+                "max_workflows",
+                "constraints",
+                "additional_jql",
+                "repository",
+                "publish_mode",
+            ):
+                assert name in schema["properties"]
+            removed = {
+                "source_kind",
                 "jira_board_id",
                 "jira_column",
-                "jira_label_filter",
-                "jira_issue_type_filter",
-                "jira_assignee_filter",
-            ):
-                assert name in schema["properties"]
-            # GitHub repo issues source field set.
-            for name in (
                 "github_repository",
-                "github_issue_state",
-                "github_label_filter",
-                "github_assignee_filter",
-                "github_milestone_filter",
-                "github_search_query",
-            ):
-                assert name in schema["properties"]
-
-            # Target preset selector (slug/scope/scopeRef).
-            for name in (
                 "target_preset_slug",
                 "target_preset_scope",
                 "target_preset_scope_ref",
-            ):
-                assert name in schema["properties"]
-            assert "target_preset_version" not in schema["properties"]
-            assert "target_preset_version" not in schema["required"]
+                "sort",
+            }
+            assert removed.isdisjoint(schema["properties"])
+            assert schema["properties"]["run_ref"]["enum"] == [
+                "skill:jira-verify",
+                "preset:jira-implement",
+            ]
 
-            # Single shared publish policy normalized around none/branch/pr.
             assert schema["properties"]["publish_mode"]["enum"] == [
                 "none",
                 "branch",
                 "pr",
             ]
 
-            # Cascading board -> column discriminator wiring in the UI schema.
+            # UI schema uses only registered widgets or advanced flags.
             ui_schema = annotations["uiSchema"]
-            assert ui_schema["source_kind"]["widget"] == "discriminator"
-            assert ui_schema["jira_column"]["dependsOn"] == "jira_board_id"
-            assert ui_schema["target_preset_slug"]["highlightCompatible"] == [
-                "jira-implement",
-                "github-issue-implement",
-            ]
+            assert ui_schema["run_ref"]["widget"] == "select"
+            assert ui_schema["constraints"] == {"widget": "textarea", "advanced": True}
+            assert ui_schema["additional_jql"] == {
+                "widget": "textarea",
+                "advanced": True,
+            }
+            assert ui_schema["repository"]["advanced"] is True
+            assert ui_schema["publish_mode"] == {"widget": "select", "advanced": True}
 
             # Default issue bindings for the known issue presets.
             bindings = annotations["bindings"]
-            assert bindings["jira-implement"]["jira_issue"] == "{{ target.jiraIssue }}"
             assert (
-                bindings["jira-implement"]["jira_issue_key"]
+                bindings["skill:jira-verify"]["jira_issue"]
+                == "{{ target.jiraIssue }}"
+            )
+            assert (
+                bindings["skill:jira-verify"]["jira_issue_key"]
                 == "{{ target.jiraIssue.key }}"
             )
             assert (
-                bindings["github-issue-implement"]["github_issue"]
+                bindings["skill:jira-verify"]["repository"]
+                == "{{ target.repository }}"
+            )
+            assert (
+                bindings["preset:jira-implement"]["jira_issue"]
+                == "{{ target.jiraIssue }}"
+            )
+            assert (
+                bindings["preset:jira-implement"]["jira_issue_key"]
+                == "{{ target.jiraIssue.key }}"
+            )
+            assert (
+                bindings["preset:github-issue-implement"]["github_issue"]
                 == "{{ target.githubIssue }}"
             )
             assert (
-                bindings["github-issue-implement"]["github_issue_ref"]
+                bindings["preset:github-issue-implement"]["github_issue_ref"]
                 == "{{ target.githubIssue.repository }}#{{ target.githubIssue.number }}"
             )
 
             # Runtime inheritance directive.
             assert annotations["runtimeInheritance"] == "caller"
 
-            # The board input keeps the existing jira_board input type.
-            board_input = next(
-                item
-                for item in template.inputs_schema
-                if item["name"] == "jira_board_id"
-            )
-            assert board_input["type"] == "jira_board"
+            exposed_inputs = {item["name"] for item in template.inputs_schema}
+            assert exposed_inputs == set(schema["properties"])
 
             # Orchestration step references the batch-workflows skill.
             assert len(template.steps) == 1
@@ -182,12 +188,13 @@ async def test_batch_workflows_expands_orchestration_step(tmp_path):
                 scope="global",
                 scope_ref=None,
                 inputs={
-                    "source_kind": "jira_board_column",
-                    "jira_board_id": "42",
-                    "jira_column": "In Progress",
-                    "target_preset_slug": "jira-implement",
-                    "publish_mode": "pr",
+                    "jira_project_key": "MM",
+                    "jira_status": "In Progress",
+                    "run_ref": "skill:jira-verify",
+                    "publish_mode": "none",
                     "constraints": "Be careful",
+                    "additional_jql": "assignee = currentUser()",
+                    "repository": "MoonLadderStudios/MoonMind",
                     "max_workflows": "10",
                 },
             )
@@ -198,12 +205,19 @@ async def test_batch_workflows_expands_orchestration_step(tmp_path):
             assert step["skill"]["id"] == "batch-workflows"
 
             orchestration = step["batchOrchestration"]
-            assert orchestration["source"]["kind"] == "jira_board_column"
-            assert orchestration["source"]["jiraBoardColumn"]["boardId"] == "42"
-            assert orchestration["source"]["jiraBoardColumn"]["column"] == "In Progress"
-            assert orchestration["targetPreset"]["slug"] == "jira-implement"
-            assert "version" not in orchestration["targetPreset"]
-            assert orchestration["publish"]["mode"] == "pr"
+            assert orchestration["source"]["kind"] == "jira_status"
+            assert orchestration["source"]["jiraStatus"]["projectKey"] == "MM"
+            assert orchestration["source"]["jiraStatus"]["status"] == "In Progress"
+            assert (
+                orchestration["source"]["jiraStatus"]["additionalJql"]
+                == "assignee = currentUser()"
+            )
+            assert (
+                orchestration["source"]["jiraStatus"]["repository"]
+                == "MoonLadderStudios/MoonMind"
+            )
+            assert orchestration["target"]["runRef"] == "skill:jira-verify"
+            assert orchestration["publish"]["mode"] == "none"
             # Every child inherits the caller runtime.
             assert orchestration["runtime"]["inherit"] == "caller"
             assert orchestration["maxWorkflows"] == "10"
@@ -235,16 +249,14 @@ async def test_batch_workflows_ignores_removed_target_preset_version_input(tmp_p
                 scope="global",
                 scope_ref=None,
                 inputs={
-                    "source_kind": "jira_board_column",
-                    "jira_board_id": "42",
-                    "jira_column": "In Progress",
-                    "target_preset_slug": "jira-implement",
+                    "jira_project_key": "MM",
+                    "jira_status": "In Progress",
+                    "run_ref": "preset:jira-implement",
                     "target_preset_version": "1.1.0",
-                    "publish_mode": "pr",
+                    "publish_mode": "branch",
                 },
             )
 
     orchestration = expanded["steps"][0]["batchOrchestration"]
-    assert orchestration["targetPreset"]["slug"] == "jira-implement"
-    assert orchestration["targetPreset"]["scope"] == "global"
-    assert "version" not in orchestration["targetPreset"]
+    assert orchestration["target"]["runRef"] == "preset:jira-implement"
+    assert "targetPreset" not in orchestration

--- a/tests/unit/capabilities/test_input_contracts.py
+++ b/tests/unit/capabilities/test_input_contracts.py
@@ -1,4 +1,5 @@
 import datetime as dt
+from pathlib import Path
 
 import pytest
 
@@ -11,6 +12,32 @@ from moonmind.capabilities.input_contracts import (
     parse_skill_capability_input_contract,
     validate_capability_inputs,
 )
+
+
+def test_jira_verify_skill_exposes_batch_bindable_input_contract() -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    markdown = (
+        repo_root / ".agents" / "skills" / "jira-verify" / "SKILL.md"
+    ).read_text(encoding="utf-8")
+
+    contract = parse_skill_capability_input_contract(
+        skill_id="jira-verify",
+        label="Jira Verify",
+        markdown=markdown,
+    )
+
+    assert contract["inputSchema"]["required"] == ["jira_issue_key"]
+    properties = contract["inputSchema"]["properties"]
+    assert properties["jira_issue_key"]["x-moonmind-provider"] == "jira"
+    assert properties["repository"]["x-moonmind-context-default"] == "repository"
+    assert properties["verification_mode"]["enum"] == ["auto", "branch", "main"]
+    assert properties["update_status"]["default"] is False
+    assert contract["uiSchema"]["constraints"]["widget"] == "textarea"
+    assert contract["defaults"] == {
+        "verification_mode": "auto",
+        "update_status": False,
+    }
+    assert contract["diagnostics"] == []
 
 
 def test_skill_frontmatter_snake_case_normalizes_to_camel_case_contract() -> None:

--- a/tests/unit/test_batch_workflows.py
+++ b/tests/unit/test_batch_workflows.py
@@ -198,6 +198,7 @@ def test_build_child_request_sets_runtime_inheritance_publish_and_idempotency():
     assert payload["task"]["publish"] == {"mode": "none"}
     assert payload["repository"] == "MoonLadderStudios/MoonMind"
     assert payload["task"]["inputs"]["jira_issue_key"] == "THOR-123"
+    assert payload["requiredCapabilities"] == ["git", "jira"]
     # The selected skill is authored as a direct skill task.
     assert payload["task"]["tool"] == {"type": "skill", "name": "jira-verify"}
     assert "taskTemplate" not in payload["task"]
@@ -307,6 +308,44 @@ def test_build_child_requests_caps_at_max_workflows():
     assert len(submissions) == 2
     overflow = [item for item in skipped if item.reason == "max_workflows_exceeded"]
     assert len(overflow) == 3
+
+
+def test_build_child_requests_zero_max_workflows_skips_all_targets():
+    module = _load_module()
+    targets = [
+        {**_JIRA_TARGET, "ref": f"THOR-{n}", "jiraIssue": {"key": f"THOR-{n}"}}
+        for n in range(3)
+    ]
+    submissions, skipped = module["build_child_requests"](
+        targets,
+        config=_jira_config(module),
+        runtime=module["RuntimeSelection"](mode="codex_cli"),
+        max_workflows=0,
+        batch_scope="run-1",
+        inherit_runtime_from_caller=True,
+    )
+    assert submissions == []
+    assert [item.ref for item in skipped] == ["THOR-0", "THOR-1", "THOR-2"]
+    assert {item.reason for item in skipped} == {"max_workflows_exceeded"}
+
+
+def test_build_child_requests_negative_max_workflows_skips_all_targets():
+    module = _load_module()
+    targets = [
+        {**_JIRA_TARGET, "ref": f"THOR-{n}", "jiraIssue": {"key": f"THOR-{n}"}}
+        for n in range(3)
+    ]
+    submissions, skipped = module["build_child_requests"](
+        targets,
+        config=_jira_config(module),
+        runtime=module["RuntimeSelection"](mode="codex_cli"),
+        max_workflows=-2,
+        batch_scope="run-1",
+        inherit_runtime_from_caller=True,
+    )
+    assert submissions == []
+    assert [item.ref for item in skipped] == ["THOR-0", "THOR-1", "THOR-2"]
+    assert {item.reason for item in skipped} == {"max_workflows_exceeded"}
 
 
 def test_build_child_requests_skips_unsupported_target():

--- a/tests/unit/test_batch_workflows.py
+++ b/tests/unit/test_batch_workflows.py
@@ -1,9 +1,8 @@
-"""Unit tests for the batch-workflows fan-out helper (MM-885).
+"""Unit tests for the batch-workflows fan-out helper (MM-1062).
 
 Covers the deterministic per-target child-request construction: issue bindings,
 runtime inheritance, shared publish policy, idempotency, the max-workflows cap,
-and unsupported-preset skips. The goal text is validated against the real
-server-side goal scheduler so a queued child expands the intended child preset.
+and unsupported-target skips.
 """
 
 from __future__ import annotations
@@ -18,9 +17,6 @@ from moonmind.workflows.executions.execution_contract import (
     WorkflowContractError,
     is_self_managed_publish_skill,
     resolve_publish_mode_for_skill,
-)
-from moonmind.workflows.executions.preset_goal_scheduler import (
-    schedule_preset_from_goal,
 )
 
 
@@ -70,9 +66,9 @@ _GITHUB_TARGET: dict[str, Any] = {
 
 def _jira_config(module, **overrides):
     defaults = dict(
-        preset_slug="jira-implement",
-        preset_scope="global",
-        publish_mode="pr",
+        target_kind="skill",
+        target_slug="jira-verify",
+        publish_mode="none",
         constraints="Be careful",
     )
     defaults.update(overrides)
@@ -81,8 +77,8 @@ def _jira_config(module, **overrides):
 
 def _github_config(module, **overrides):
     defaults = dict(
-        preset_slug="github-issue-implement",
-        preset_scope="global",
+        target_kind="preset",
+        target_slug="github-issue-implement",
         publish_mode="branch",
         constraints="",
     )
@@ -90,17 +86,44 @@ def _github_config(module, **overrides):
     return module["TargetConfig"](**defaults)
 
 
-def test_bind_child_inputs_jira_auto_binds_issue_object_and_key():
+def test_bind_child_inputs_jira_verify_auto_binds_issue_object_and_key():
     module = _load_module()
-    inputs = module["bind_child_inputs"](_JIRA_TARGET, "jira-implement", "Be careful")
+    inputs = module["bind_child_inputs"](
+        _JIRA_TARGET,
+        "skill",
+        "jira-verify",
+        "Be careful",
+    )
+    assert inputs["jira_issue"]["key"] == "THOR-123"
+    assert inputs["jira_issue_key"] == "THOR-123"
+    assert inputs["repository"] == "MoonLadderStudios/MoonMind"
+    assert inputs["verification_mode"] == "auto"
+    assert inputs["update_status"] is False
+    assert inputs["constraints"] == "Be careful"
+
+
+def test_bind_child_inputs_jira_implement_preset_auto_binds_issue_object_and_key():
+    module = _load_module()
+    inputs = module["bind_child_inputs"](
+        _JIRA_TARGET,
+        "preset",
+        "jira-implement",
+        "Be careful",
+    )
     assert inputs["jira_issue"]["key"] == "THOR-123"
     assert inputs["jira_issue_key"] == "THOR-123"
     assert inputs["constraints"] == "Be careful"
+    assert "verification_mode" not in inputs
 
 
 def test_bind_child_inputs_github_auto_binds_issue_object_and_ref():
     module = _load_module()
-    inputs = module["bind_child_inputs"](_GITHUB_TARGET, "github-issue-implement", "")
+    inputs = module["bind_child_inputs"](
+        _GITHUB_TARGET,
+        "preset",
+        "github-issue-implement",
+        "",
+    )
     assert inputs["github_issue"]["number"] == 42
     assert inputs["github_issue_ref"] == "MoonLadderStudios/MoonMind#42"
     assert inputs["constraints"] == ""
@@ -108,23 +131,41 @@ def test_bind_child_inputs_github_auto_binds_issue_object_and_ref():
 
 def test_bind_child_inputs_returns_none_for_provider_mismatch():
     module = _load_module()
-    assert module["bind_child_inputs"](_GITHUB_TARGET, "jira-implement", "") is None
     assert (
-        module["bind_child_inputs"](_JIRA_TARGET, "github-issue-implement", "") is None
+        module["bind_child_inputs"](_GITHUB_TARGET, "skill", "jira-verify", "")
+        is None
+    )
+    assert (
+        module["bind_child_inputs"](
+            _JIRA_TARGET,
+            "preset",
+            "github-issue-implement",
+            "",
+        )
+        is None
     )
 
 
-def test_child_goal_routes_to_selected_preset_via_scheduler():
+def test_child_goal_routes_to_selected_run_capability():
     module = _load_module()
-    jira_goal = module["child_goal_for_target"](_JIRA_TARGET, "jira-implement")
-    github_goal = module["child_goal_for_target"](
-        _GITHUB_TARGET, "github-issue-implement"
+    verify_goal = module["child_goal_for_target"](
+        _JIRA_TARGET,
+        "skill",
+        "jira-verify",
     )
+    jira_goal = module["child_goal_for_target"](
+        _JIRA_TARGET,
+        "preset",
+        "jira-implement",
+    )
+    github_goal = module["child_goal_for_target"](
+        _GITHUB_TARGET,
+        "preset",
+        "github-issue-implement",
+    )
+    assert verify_goal == "Verify Jira issue THOR-123."
     assert jira_goal is not None
     assert github_goal is not None
-    # The queued child goal must expand the intended preset server-side.
-    assert schedule_preset_from_goal(jira_goal).slug == "jira-implement"
-    assert schedule_preset_from_goal(github_goal).slug == "github-issue-implement"
 
 
 def test_build_child_request_sets_runtime_inheritance_publish_and_idempotency():
@@ -154,14 +195,12 @@ def test_build_child_request_sets_runtime_inheritance_publish_and_idempotency():
         "executionProfileRef": "profile-1",
     }
     # Shared publish policy + repository + bound issue inputs.
-    assert payload["task"]["publish"] == {"mode": "pr"}
+    assert payload["task"]["publish"] == {"mode": "none"}
     assert payload["repository"] == "MoonLadderStudios/MoonMind"
     assert payload["task"]["inputs"]["jira_issue_key"] == "THOR-123"
-    # The selected preset is authored as the child taskTemplate (read by the
-    # execution API), not inert batchTargetPreset metadata.
-    assert payload["task"]["taskTemplate"]["slug"] == "jira-implement"
-    assert payload["task"]["taskTemplate"]["scope"] == "global"
-    assert "version" not in payload["task"]["taskTemplate"]
+    # The selected skill is authored as a direct skill task.
+    assert payload["task"]["tool"] == {"type": "skill", "name": "jira-verify"}
+    assert "taskTemplate" not in payload["task"]
     assert "batchTargetPreset" not in payload["task"]
     # Stable, length-bounded idempotency key.
     key = payload["idempotencyKey"]
@@ -169,17 +208,36 @@ def test_build_child_request_sets_runtime_inheritance_publish_and_idempotency():
     assert len(key) <= module["IDEMPOTENCY_KEY_MAX_LENGTH"]
 
 
-def test_build_child_request_authors_selected_preset_scope_and_ref():
-    # Personal scope / scopeRef must be carried into the child taskTemplate so
-    # the execution API expands the exact selected preset instead of the goal
-    # scheduler's global default.
+def test_idempotency_key_includes_target_kind_and_slug():
+    module = _load_module()
+    skill_key = module["_child_idempotency_key"](
+        batch_scope="run-1",
+        provider="jira",
+        ref="THOR-123",
+        target_kind="skill",
+        target_slug="jira-verify",
+    )
+    preset_key = module["_child_idempotency_key"](
+        batch_scope="run-1",
+        provider="jira",
+        ref="THOR-123",
+        target_kind="preset",
+        target_slug="jira-implement",
+    )
+
+    assert skill_key != preset_key
+    assert skill_key.startswith("batch-workflows:jira:THOR-123:sha256:")
+    assert preset_key.startswith("batch-workflows:jira:THOR-123:sha256:")
+
+
+def test_build_child_request_authors_selected_preset_as_global_template():
     module = _load_module()
     request = module["build_child_request"](
         _JIRA_TARGET,
         config=_jira_config(
             module,
-            preset_scope="personal",
-            preset_scope_ref="user-123",
+            target_kind="preset",
+            target_slug="jira-implement",
         ),
         runtime=module["RuntimeSelection"](mode="codex_cli"),
         batch_scope="run-1",
@@ -187,25 +245,13 @@ def test_build_child_request_authors_selected_preset_scope_and_ref():
     )
     template = request["payload"]["task"]["taskTemplate"]
     assert template["slug"] == "jira-implement"
-    assert template["scope"] == "personal"
-    assert template["scopeRef"] == "user-123"
+    assert template["scope"] == "global"
     assert "version" not in template
+    assert "scopeRef" not in template
     assert "batchTargetPreset" not in request["payload"]["task"]
 
 
-def test_build_child_request_omits_scope_ref_when_blank():
-    module = _load_module()
-    request = module["build_child_request"](
-        _JIRA_TARGET,
-        config=_jira_config(module, preset_scope_ref=None),
-        runtime=module["RuntimeSelection"](mode="codex_cli"),
-        batch_scope="run-1",
-        inherit_runtime_from_caller=True,
-    )
-    assert "scopeRef" not in request["payload"]["task"]["taskTemplate"]
-
-
-def test_parse_args_accepts_slug_scope_without_preset_version(tmp_path):
+def test_parse_args_accepts_run_ref_without_preset_version(tmp_path):
     module = _load_module()
     targets = tmp_path / "targets.json"
     targets.write_text("[]", encoding="utf-8")
@@ -214,10 +260,8 @@ def test_parse_args_accepts_slug_scope_without_preset_version(tmp_path):
         [
             "--targets",
             str(targets),
-            "--target-preset-slug",
-            "jira-implement",
-            "--target-preset-scope",
-            "global",
+            "--run-ref",
+            "skill:jira-verify",
             "--publish-mode",
             "pr",
             "--max-workflows",
@@ -225,7 +269,7 @@ def test_parse_args_accepts_slug_scope_without_preset_version(tmp_path):
         ]
     )
 
-    assert args.target_preset_slug == "jira-implement"
+    assert args.run_ref == "skill:jira-verify"
     assert not hasattr(args, "target_preset_version")
 
 
@@ -265,18 +309,22 @@ def test_build_child_requests_caps_at_max_workflows():
     assert len(overflow) == 3
 
 
-def test_build_child_requests_skips_unsupported_preset():
+def test_build_child_requests_skips_unsupported_target():
     module = _load_module()
     submissions, skipped = module["build_child_requests"](
         [_JIRA_TARGET],
-        config=_jira_config(module, preset_slug="some-custom-preset"),
+        config=_jira_config(
+            module,
+            target_kind="skill",
+            target_slug="some-custom-skill",
+        ),
         runtime=module["RuntimeSelection"](mode="codex_cli"),
         max_workflows=25,
         batch_scope="run-1",
         inherit_runtime_from_caller=True,
     )
     assert submissions == []
-    assert skipped[0].reason == "unsupported_preset"
+    assert skipped[0].reason == "unsupported_target"
 
 
 def test_normalize_publish_mode_falls_back_to_pr():


### PR DESCRIPTION
## Issue
MM-1062: Simplify Batch Workflow

## Summary
- Simplifies the batch-workflows preset into the Jira project/status default path with `skill:jira-verify` as the default run capability.
- Replaces unsupported widget hints with registered widgets or advanced metadata and removes the old board-column/GitHub-heavy default fields.
- Generalizes the batch helper from preset-only binding to run refs for `skill:jira-verify`, `preset:jira-implement`, and `preset:github-issue-implement` while preserving runtime inheritance, max-workflow caps, result artifacts, and unsupported-target skips.
- Adds structured input metadata for the `jira-verify` skill and updates the affected unit/startup tests.

## Tests run
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --python-only tests/unit/test_batch_workflows.py tests/unit/api/test_batch_workflows_preset.py` -> 17 passed
- `python -m pytest -q tests/integration/test_startup_preset_seeding.py --tb=short` -> 2 passed, 1 warning
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --python-only tests/unit/capabilities/test_input_contracts.py` -> 21 passed

## Remaining risks
- The Jira status target resolution still depends on the trusted Jira tool path at runtime; this PR validates contract generation and child request construction locally.
- Existing in-flight batches using the previous internal preset shape should not be resumed against the new pre-release contract without a controlled rerun.
