### PR TITLE
MM-1063 update presets

### DIFF
--- a/.agents/skills/moonspec-align/SKILL.md
+++ b/.agents/skills/moonspec-align/SKILL.md
@@ -14,7 +14,7 @@ Use this skill to perform an automated analyze-to-remediate workflow for an acti
 
 ## Scope
 
-This skill edits MoonSpec artifacts, not application feature code. Typical targets are:
+This skill edits MoonSpec execution artifacts, not application feature code. Typical targets are:
 
 - `spec.md`
 - `plan.md`
@@ -34,6 +34,7 @@ Do not ask the user for clarification. Resolve uncertainty by reading project co
 - Treat the user's text as optional guidance.
 - Work from the active feature directory resolved by the prerequisite script.
 - Require `spec.md`, `plan.md`, and `tasks.md`; stop with the prerequisite error if any are missing.
+- Read `AGENTS.md` when present for project principles, repo constraints, and test discipline.
 - Use absolute paths in reports.
 - Preserve user-provided source requirements and original request text exactly when they are already recorded in artifacts.
 
@@ -51,7 +52,7 @@ Parse `FEATURE_DIR` and `AVAILABLE_DOCS`, then derive:
 - `PLAN = FEATURE_DIR/plan.md`
 - `TASKS = FEATURE_DIR/tasks.md`
 - optional docs from `AVAILABLE_DOCS`
-- `CONSTITUTION = .specify/memory/constitution.md`
+- `REPO_GUIDANCE = AGENTS.md` when present
 
 If shell arguments contain single quotes, use shell-safe escaping such as `'I'\''m Groot'`, or double quotes when possible.
 
@@ -73,9 +74,9 @@ Load enough context to make edits confidently, but do not paste whole artifacts 
 Read:
 
 - `spec.md`: input/source request, user story, acceptance scenarios, edge cases, functional requirements, success criteria, key entities, assumptions, source design coverage.
-- `plan.md`: technical context, constitution checks, project structure, phase notes, complexity tracking.
+- `plan.md`: technical context, Principles Check, project structure, phase notes, complexity tracking, and requirement status.
 - `tasks.md`: phases, task IDs, dependencies, parallel markers, file paths, tests, implementation tasks.
-- `.specify/memory/constitution.md`: principles and normative `MUST`/`SHOULD` statements.
+- `AGENTS.md` when present: project principles, repo constraints, and test discipline.
 - optional docs listed by the prerequisite script when findings refer to them.
 
 Also inspect relevant repository files when needed to resolve uncertainty, especially test framework configuration, project layout, existing contracts, and naming conventions.
@@ -88,7 +89,7 @@ Build an internal model before editing:
 - User-story inventory with acceptance scenarios and edge cases.
 - Task coverage mapping from task IDs to requirements, scenarios, success criteria, and design artifacts.
 - Artifact authority order:
-  1. Constitution and explicit source design requirements.
+  1. Explicit source design requirements and relevant `AGENTS.md` principles.
   2. Original feature input preserved in `spec.md`.
   3. `spec.md` user-visible behavior and acceptance criteria.
   4. `plan.md` architecture and technical decisions.
@@ -103,7 +104,7 @@ Identify high-signal findings. Aggregate related issues instead of creating nois
 - Duplication: overlapping requirements, repeated tasks, duplicate terminology definitions.
 - Ambiguity: vague terms such as fast, scalable, secure, intuitive, robust without measurable criteria; unresolved placeholders; unclear actors or data ownership.
 - Underspecification: requirements missing objects or outcomes, success criteria without validation path, edge cases with no acceptance coverage, tasks referencing undefined components.
-- Constitution alignment: conflicts with `MUST` statements, missing mandated quality gates, unjustified complexity.
+- Principle alignment: conflicts with `AGENTS.md` `MUST` statements, missing mandated quality gates, unjustified complexity.
 - Coverage gaps: requirements or buildable success criteria with no tasks, tests absent for required behavior, contracts not represented in quickstart or tasks.
 - Inconsistency: terminology drift, entity drift, contradictory stack choices, test strategy mismatch, task ordering conflicts, implementation tasks before required tests.
 
@@ -117,7 +118,7 @@ Use this decision process:
 2. Gather available evidence from the artifacts and repository.
 3. List 2-3 plausible resolutions.
 4. Weigh pros and cons using project context:
-   - conformance to constitution and source requirements
+   - conformance to source requirements and relevant principles
    - preservation of user-visible behavior
    - implementation blast radius
    - testability
@@ -129,7 +130,7 @@ Use this decision process:
 Default choices:
 
 - If `tasks.md` conflicts with `spec.md`, update `tasks.md` unless the spec is clearly incomplete relative to the original input.
-- If `plan.md` conflicts with the constitution or explicit source design requirement, update `plan.md`.
+- If `plan.md` conflicts with an explicit source design requirement or relevant `AGENTS.md` principle, update `plan.md`.
 - If `spec.md` is ambiguous but the repo has a clear established convention, update `spec.md` with that convention as an assumption or measurable requirement.
 - If two options are equally plausible and neither is required by higher authority, choose the simpler and more reversible option.
 - If a finding cannot be remediated without inventing product scope, add a bounded assumption and a validation task instead of asking the user.
@@ -163,7 +164,7 @@ Constraints:
 
 Use a stable top-down order so reruns are predictable:
 
-1. Constitution conflicts.
+1. Principle conflicts.
 2. Source requirement and original-input preservation issues.
 3. Spec requirement, scenario, edge-case, entity, and success-criteria issues.
 4. Plan and design artifact issues.
@@ -182,7 +183,7 @@ After editing:
    - every functional requirement has task coverage
    - every buildable success criterion has task or quickstart coverage
    - test tasks cover required unit and integration behavior where applicable
-   - no constitution `MUST` conflict remains
+   - no relevant `AGENTS.md` `MUST` conflict remains
    - no unresolved placeholders remain unless explicitly intentional and explained
    - task ordering is coherent
 4. Run lightweight repository tests or formatting commands when the edits touched generated checks, test commands, or machine-readable contracts. If no relevant command exists, say so.

--- a/.agents/skills/moonspec-implement/SKILL.md
+++ b/.agents/skills/moonspec-implement/SKILL.md
@@ -31,6 +31,7 @@ Do not use this skill to split a broad design, write a spec, create a plan, or g
 - Treat the user's text as optional implementation guidance.
 - Work from the active feature directory resolved by the prerequisite script.
 - Require `spec.md`, `plan.md`, and `tasks.md`.
+- Read `AGENTS.md` when present for project principles, repo constraints, and test discipline.
 - The spec must contain exactly one independently testable user story.
 - `tasks.md` must be specific enough to execute without inventing hidden product scope.
 - Use absolute paths in reports and cite files changed or validated.
@@ -87,7 +88,7 @@ Parse `FEATURE_DIR` and `AVAILABLE_DOCS`, then derive:
 - `PLAN = FEATURE_DIR/plan.md`
 - `TASKS = FEATURE_DIR/tasks.md`
 - optional docs from `AVAILABLE_DOCS`
-- `CONSTITUTION = .specify/memory/constitution.md`
+- `REPO_GUIDANCE = AGENTS.md` when present
 
 If shell arguments contain single quotes, use shell-safe escaping such as `'I'\''m Groot'`, or double quotes when possible.
 
@@ -114,9 +115,9 @@ If any checklist has incomplete items, stop and ask whether to proceed. Continue
 Read enough context to implement without guessing:
 
 - `tasks.md`: task IDs, phases, dependencies, parallel markers, file paths, required test commands, and final verification task.
-- `plan.md`: tech stack, architecture, project structure, test tooling, integration dependencies, and constraints.
+- `plan.md`: tech stack, architecture, project structure, test tooling, integration dependencies, Principles Check, and constraints.
 - `spec.md`: preserved `**Input**`, the single story, independent test, acceptance scenarios, edge cases, functional requirements, success criteria, assumptions, and source design mappings.
-- `.specify/memory/constitution.md`: project constraints, quality gates, and TDD expectations.
+- `AGENTS.md` when present: project principles, repo constraints, quality gates, and TDD expectations.
 - `data-model.md` when present: entities, relationships, validation rules, and state transitions.
 - `contracts/` when present: public interfaces and contract or integration test obligations.
 - `research.md` when present: technical decisions and constraints.
@@ -127,8 +128,9 @@ Validate before editing code:
 
 - `spec.md` has exactly one independently testable user story.
 - Any `DESIGN-REQ-*` or `DOC-REQ-*` mappings are traceable to planned code or test work.
+- Relevant `AGENTS.md` principles and testing discipline are represented in the plan or tasks when they affect implementation.
 - `tasks.md` includes unit test tasks and integration test tasks unless the spec clearly makes one class irrelevant.
-- Implementation tasks do not introduce scope outside the story, original request, or source design constraints.
+- Implementation tasks do not introduce scope outside the story, original request, source design constraints, or relevant repo guidance.
 
 If the spec contains multiple stories, stop and tell the user to split the design with `/moonspec.breakdown` or regenerate a one-story spec with `/moonspec.specify`.
 
@@ -194,7 +196,7 @@ Rules:
 - Prefer project-local helpers and established abstractions over new patterns.
 - Keep the work scoped to the single story.
 - Do not weaken requirements, delete source design mappings, or remove the preserved original request.
-- Do not add hidden scope beyond the story, source design constraints, or explicit user guidance.
+- Do not add hidden scope beyond the story, source design constraints, relevant repo guidance, or explicit user guidance.
 - Write unit tests for domain rules, transformations, validation, edge cases, and failure modes named by the spec.
 - Write integration tests for acceptance scenarios, end-to-end workflows, contracts, persistence, external services, startup wiring, or user-facing interfaces when the design implies them.
 - Confirm new tests fail before implementing production behavior, then make them pass.
@@ -231,10 +233,11 @@ Before reporting completion:
 2. Verify production behavior matches the single story in `spec.md`.
 3. Verify the implementation remains aligned with the original feature request or declarative design preserved in `spec.md` `**Input**`.
 4. Verify every in-scope `DESIGN-REQ-*` or `DOC-REQ-*` has implementation and test evidence.
-5. Run unit tests and integration tests named in `plan.md`, `tasks.md`, `quickstart.md`, or project conventions.
-6. Run quickstart validation when present and feasible.
-7. Confirm no hidden scope or contradiction was introduced.
-8. Run the final `/moonspec.verify` task when present.
+5. Verify relevant `AGENTS.md` principles and testing discipline were not violated.
+6. Run unit tests and integration tests named in `plan.md`, `tasks.md`, `quickstart.md`, or project conventions.
+7. Run quickstart validation when present and feasible.
+8. Confirm no hidden scope or contradiction was introduced.
+9. Run the final `/moonspec.verify` task when present.
 
 If a command cannot run because of missing credentials, services, tools, or unsafe side effects, record the exact reason and the smallest next step needed.
 
@@ -299,6 +302,7 @@ If no hooks are registered or `.specify/extensions.yml` does not exist, skip sil
 - Unit tests and integration tests are both expected implementation evidence.
 - Confirm tests fail for the intended reason before production code.
 - Preserve traceability to the original request and source design mappings.
+- Preserve relevant `AGENTS.md` principles and repo constraints.
 - Mark completed tasks `[X]` only after real completion.
 - Record canonical-doc drift in the discovery ledger instead of editing `docs/` files inline.
 - Run or recommend `/moonspec.verify` as the final alignment check.

--- a/.agents/skills/moonspec-plan/SKILL.md
+++ b/.agents/skills/moonspec-plan/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: moonspec-plan
-description: Generate a MoonSpec implementation plan and design artifacts from a single-story spec. Use when the user asks to run or reproduce `/moonspec.plan`, create or update `plan.md`, produce `research.md`, `data-model.md`, `contracts/`, or `quickstart.md`, validate constitution gates, define separate unit and integration test strategies, and perform repo-aware gap analysis before `/moonspec.tasks`.
+description: Generate a MoonSpec implementation plan and design artifacts from a single-story spec. Use when the user asks to run or reproduce `/moonspec.plan`, create or update `plan.md`, produce `research.md`, `data-model.md`, `contracts/`, or `quickstart.md`, evaluate repo principles, define separate unit and integration test strategies, and perform repo-aware gap analysis before `/moonspec.tasks`.
 metadata:
   required-capabilities:
     - git
@@ -96,7 +96,7 @@ For shell arguments containing single quotes, use shell-safe escaping such as `'
 Read:
 
 - `FEATURE_SPEC`
-- `.specify/memory/constitution.md`
+- `AGENTS.md` when present, especially project principles, testing discipline, and repo constraints
 - `IMPL_PLAN`
 - Relevant implementation files, tests, contracts, fixtures, migrations, and public interfaces for the story
 
@@ -106,7 +106,7 @@ Validate before planning:
 - The story has a Summary, Goal, Independent Test, Acceptance Scenarios, Requirements, and Success Criteria.
 - Source design mappings such as `DESIGN-REQ-*` are preserved when present.
 - Source packet provenance is preserved when present: source document path, document class, viewpoint, owning surface, stable claim IDs, temporary-adapter role, and issue traceability such as `MM-933` / `MM-927`.
-- Constitution gates and `MUST` constraints are available for the plan.
+- Relevant `AGENTS.md` principles, testing discipline, and `MUST` constraints are reflected in the plan when present.
 - In-scope requirement IDs and scenario IDs can be identified for planning and traceability.
 
 ## Fill plan.md
@@ -129,9 +129,9 @@ Fill:
   - Performance goals
   - Constraints
   - Scale/scope
-- `Constitution Check`: derive gates from `.specify/memory/constitution.md`
+- `Principles Check`: derive relevant checks from `AGENTS.md` project principles, testing discipline, and repo constraints when present
 - `Project Structure`: replace placeholder trees with the actual repository layout for the feature
-- `Complexity Tracking`: fill only when constitution violations are justified
+- `Complexity Tracking`: fill only when principle conflicts or unjustified complexity must be justified
 
 Add a `## Requirement Status` section after `## Summary` with one row per in-scope item that materially affects delivery:
 
@@ -167,16 +167,16 @@ Rules:
 
 Mark technical unknowns as `NEEDS CLARIFICATION` only when they block defensible planning and cannot be resolved from the repo, spec, or conventional project patterns.
 
-## Constitution Gate
+## Principles Check
 
-Evaluate the constitution before Phase 0 research.
+Evaluate relevant `AGENTS.md` principles, testing discipline, and repo constraints before Phase 0 research.
 
 Rules:
 
-- Error on unjustified constitution violations.
-- Record justified violations in `Complexity Tracking`.
+- Error on unjustified principle conflicts.
+- Record justified conflicts in `Complexity Tracking` with the reason and mitigation.
 - Do not continue with unresolved hard gate failures.
-- Re-check the constitution after Phase 1 design artifacts are generated.
+- Re-check relevant principles after Phase 1 design artifacts are generated.
 
 ## Phase 0: Research And Repo Gap Analysis
 
@@ -188,7 +188,7 @@ Research and resolve:
 - Dependency choices and best practices
 - Integration patterns
 - Test tooling choices, with unit and integration test tools identified separately
-- Any source design or constitution constraint that affects architecture
+- Any source design or repo-principle constraint that affects architecture
 - Current repo coverage for each in-scope requirement or scenario
 
 For each in-scope item, inspect relevant code and tests, then classify it:
@@ -268,7 +268,7 @@ Report:
 - Generated artifacts
 - Unit test strategy
 - Integration test strategy
-- Constitution gate result
+- Principles check result
 - Requirement status summary by ID and count
 - Which items need code changes
 - Which items need tests only
@@ -314,6 +314,6 @@ If no hooks are registered or `.specify/extensions.yml` does not exist, skip sil
 - Existing code never removes a requirement from `spec.md`; it only changes the planned work.
 - Prefer verification tests before implementation when behavior appears to already exist, but include fallback implementation work for `implemented_unverified` items when verification fails.
 - Resolve all planning clarifications through `research.md`.
-- Error on gate failures, multiple user stories, or unresolved clarifications.
+- Error on unjustified principle conflicts, multiple user stories, or unresolved clarifications.
 - Generate design artifacts only; leave task generation to `/moonspec.tasks`.
 - `tasks.md` should consume `## Requirement Status` when deciding whether to emit implementation tasks, verification-only tasks, or no new work for already-verified items.

--- a/.agents/skills/moonspec-tasks/SKILL.md
+++ b/.agents/skills/moonspec-tasks/SKILL.md
@@ -89,7 +89,7 @@ Parse `FEATURE_DIR` and `AVAILABLE_DOCS`, then derive:
 - `PLAN = FEATURE_DIR/plan.md`
 - `TASKS = FEATURE_DIR/tasks.md`
 - optional docs from `AVAILABLE_DOCS`
-- `CONSTITUTION = .specify/memory/constitution.md`
+- `REPO_GUIDANCE = AGENTS.md` when present
 
 If shell arguments contain single quotes, use shell-safe escaping such as `'I'\''m Groot'`, or double quotes when possible.
 
@@ -99,7 +99,7 @@ Read:
 
 - `plan.md`: tech stack, libraries, project structure, unit test tooling, integration test tooling, constraints, validation commands, and any `## Requirement Status` table.
 - `spec.md`: preserved `**Input**`, `## Source Packet`, single user story, goal, independent test, acceptance scenarios, edge cases, functional requirements, success criteria, assumptions, and source design mappings such as `CLAIM-*`, `DESIGN-REQ-*` or `DOC-REQ-*`.
-- `.specify/memory/constitution.md`: project constraints and test discipline.
+- `AGENTS.md` when present: project principles, repo constraints, and test discipline.
 - `data-model.md` when present: entities, relationships, validation rules, and state transitions.
 - `contracts/` when present: public interfaces and contract or integration test obligations.
 - `research.md` when present: technical decisions that affect setup or implementation tasks.
@@ -113,7 +113,7 @@ Build a traceability inventory before writing tasks:
 - One row per meaningful edge case.
 - One row per measurable success criterion or `SC-*`.
 - One row per in-scope stable source claim ID from `## Source Packet`, such as `CLAIM-*`, `DESIGN-REQ-*` or `DOC-REQ-*`.
-- One row per constitution requirement that affects implementation or testing.
+- One row per relevant AGENTS.md principle, repo constraint, or testing-discipline requirement that affects implementation or testing.
 
 For each row, carry forward the matching `## Requirement Status` entry from `plan.md` when present. Allowed statuses are `missing`, `partial`, `implemented_unverified`, and `implemented_verified`; if a row has no status, treat it as `missing`.
 

--- a/.agents/skills/moonspec-verify/SKILL.md
+++ b/.agents/skills/moonspec-verify/SKILL.md
@@ -28,12 +28,13 @@ This skill answers:
 ## Inputs
 
 - Treat the user's text as optional verification focus.
-- Work from the active feature directory resolved by the prerequisite script unless the user provides a specific feature directory or `spec.md`.
-- Require `spec.md`, `plan.md`, `tasks.md`, and `.specify/memory/constitution.md`.
+- Work from the active feature directory resolved by the prerequisite script unless the user provides a specific feature directory, `spec.md`, or issue-brief verification inputs.
+- In MoonSpec feature-directory mode, require `spec.md`, `plan.md`, `tasks.md`, and `.specify/memory/constitution.md`.
+- In issue-brief verification mode, use the provided issue brief artifact, issue reference, acceptance criteria, and assessment artifact as the verification baseline without requiring a MoonSpec feature directory, `spec.md`, `plan.md`, or `tasks.md`.
 - Use absolute paths in reports.
 - Keep the verdict conservative when evidence is incomplete.
 
-Stop if the required artifacts cannot be located. If `spec.md` contains multiple stories, report `NO_DETERMINATION` for MoonSpec completion and recommend splitting the design with `/moonspec.breakdown` or regenerating a one-story spec.
+Stop if the required artifacts for the selected mode cannot be located. If `spec.md` contains multiple stories, report `NO_DETERMINATION` for MoonSpec completion and recommend splitting the design with `/moonspec.breakdown` or regenerating a one-story spec.
 
 ## Pre-Verify Hooks
 
@@ -72,6 +73,22 @@ Wait for the result of the hook command before proceeding to verification.
 If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently.
 
 ## Setup
+
+If the user provides issue-brief verification inputs, use issue-brief verification mode. Accept inputs expressed in prose or preset instructions such as:
+
+- issue provider, for example `jira` or `github`
+- issue reference, for example `MM-1063` or `owner/repo#123`
+- issue brief artifact path, such as `artifacts/jira-implement-brief.json`
+- assessment artifact path, such as `artifacts/jira-implement-assessment.json`
+
+In issue-brief verification mode:
+
+1. Read the issue brief artifact and assessment artifact.
+2. Use the issue summary, description, acceptance criteria, loaded preset brief, and the assessment's unmet and partially-met requirements as the verification baseline.
+3. Treat a `PARTIALLY_IMPLEMENTED` assessment as a bounded backlog: verify only the previously unmet or partially met requirements unless the issue brief explicitly requires broader validation.
+4. Treat `FULLY_IMPLEMENTED` as already verified only when no implementation step made code changes after that assessment.
+5. Inspect production code and tests directly; do not treat the assessment itself as proof that new work is complete.
+6. Do not require `spec.md`, `plan.md`, `tasks.md`, or `.specify/memory/constitution.md`.
 
 If the user provides a specific `spec.md` or feature directory, use it and derive sibling artifacts from that directory.
 
@@ -117,7 +134,7 @@ not be deleted, moved, or treated as the active selected skill snapshot.
 
 ## Load Verification Sources
 
-Read:
+In MoonSpec feature-directory mode, read:
 
 - `spec.md`: original request in `**Input**`, the single user story, independent test, acceptance scenarios or `SCN-*`, functional requirements `FR-*`, success criteria `SC-*`, edge cases, assumptions, key entities, and source design mappings such as `DESIGN-REQ-*` or `DOC-REQ-*`.
 - `plan.md`: intended architecture, project structure, test commands, test tooling, integration dependencies, and constraints. Treat as context, not proof.
@@ -128,6 +145,15 @@ Read:
 - The canonical source document named by `spec.md` `**Source Document**` when present, plus `artifacts/doc-discoveries/<feature>.json` when it exists, so source-document drift can be assessed.
 
 Do not use copied source requirement text in `spec.md` as evidence that behavior exists.
+
+In issue-brief verification mode, read:
+
+- the issue brief artifact: issue key or GitHub issue ref, title, description, acceptance criteria, loaded preset brief, constraints, and source-resolution metadata when present.
+- the assessment artifact: verdict, per-requirement statuses, unmet requirements, partially met requirements, blocking evidence, and summary.
+- changed production and test files relevant to the issue brief and assessment gaps.
+- local implementation artifacts named by the preset, such as pull request handoff artifacts or verification reports, only as process context.
+
+Do not use the issue brief, assessment, or generated handoff text as evidence that behavior exists.
 
 ## Canonical Claim Coverage
 
@@ -181,6 +207,7 @@ Build an internal inventory before inspecting code:
 - One row per constitution constraint or `CC-*`.
 - One row per in-scope `DESIGN-REQ-*` or `DOC-REQ-*`.
 - One row per stable canonical source claim in scope for the story.
+- In issue-brief verification mode, one row per acceptance criterion and one row per unmet or partially met assessment requirement.
 
 For each row, track:
 
@@ -258,6 +285,14 @@ Choose exactly one verdict:
 
 Prefer `ADDITIONAL_WORK_NEEDED` over `NO_DETERMINATION` when a concrete missing code or test gap is visible.
 
+When the verdict is `ADDITIONAL_WORK_NEEDED`, include a structured Remaining Work section that remediation steps can consume. Each item must identify:
+
+- requirement or acceptance criterion
+- gap type: `implementation`, `verification`, `documentation`, or `environment`
+- concrete remaining work
+- suggested files, commands, or evidence to inspect
+- whether the gap is recoverable in the current runtime
+
 ## Report
 
 Return a Markdown report in the response. Do not write a file unless the user explicitly asks for one.
@@ -320,6 +355,22 @@ Use this structure:
 ## Remaining Work
 
 - [Ordered, concrete code or test changes required before completion]
+
+For issue-brief verification mode, set:
+
+- **Feature**: issue reference
+- **Spec**: N/A (issue-brief verification mode)
+- **Original Request Source**: issue brief artifact path
+
+Use this structured form for each Remaining Work item:
+
+```markdown
+- Requirement: [criterion or assessment requirement]
+  Gap Type: implementation | verification | documentation | environment
+  Remaining Work: [bounded work]
+  Suggested Evidence: [files, tests, commands, or artifact refs]
+  Recoverable In Current Runtime: true | false
+```
 
 ## Decision
 

--- a/.agents/skills/moonspec-verify/SKILL.md
+++ b/.agents/skills/moonspec-verify/SKILL.md
@@ -28,13 +28,12 @@ This skill answers:
 ## Inputs
 
 - Treat the user's text as optional verification focus.
-- Work from the active feature directory resolved by the prerequisite script unless the user provides a specific feature directory, `spec.md`, or issue-brief verification inputs.
-- In MoonSpec feature-directory mode, require `spec.md`, `plan.md`, `tasks.md`, and `.specify/memory/constitution.md`.
-- In issue-brief verification mode, use the provided issue brief artifact, issue reference, acceptance criteria, and assessment artifact as the verification baseline without requiring a MoonSpec feature directory, `spec.md`, `plan.md`, or `tasks.md`.
+- Work from the active feature directory resolved by the prerequisite script unless the user provides a specific feature directory or `spec.md`.
+- Require `spec.md`, `plan.md`, `tasks.md`, and `.specify/memory/constitution.md`.
 - Use absolute paths in reports.
 - Keep the verdict conservative when evidence is incomplete.
 
-Stop if the required artifacts for the selected mode cannot be located. If `spec.md` contains multiple stories, report `NO_DETERMINATION` for MoonSpec completion and recommend splitting the design with `/moonspec.breakdown` or regenerating a one-story spec.
+Stop if the required artifacts cannot be located. If `spec.md` contains multiple stories, report `NO_DETERMINATION` for MoonSpec completion and recommend splitting the design with `/moonspec.breakdown` or regenerating a one-story spec.
 
 ## Pre-Verify Hooks
 
@@ -73,22 +72,6 @@ Wait for the result of the hook command before proceeding to verification.
 If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently.
 
 ## Setup
-
-If the user provides issue-brief verification inputs, use issue-brief verification mode. Accept inputs expressed in prose or preset instructions such as:
-
-- issue provider, for example `jira` or `github`
-- issue reference, for example `MM-1063` or `owner/repo#123`
-- issue brief artifact path, such as `artifacts/jira-implement-brief.json`
-- assessment artifact path, such as `artifacts/jira-implement-assessment.json`
-
-In issue-brief verification mode:
-
-1. Read the issue brief artifact and assessment artifact.
-2. Use the issue summary, description, acceptance criteria, loaded preset brief, and the assessment's unmet and partially-met requirements as the verification baseline.
-3. Treat a `PARTIALLY_IMPLEMENTED` assessment as a bounded backlog: verify only the previously unmet or partially met requirements unless the issue brief explicitly requires broader validation.
-4. Treat `FULLY_IMPLEMENTED` as already verified only when no implementation step made code changes after that assessment.
-5. Inspect production code and tests directly; do not treat the assessment itself as proof that new work is complete.
-6. Do not require `spec.md`, `plan.md`, `tasks.md`, or `.specify/memory/constitution.md`.
 
 If the user provides a specific `spec.md` or feature directory, use it and derive sibling artifacts from that directory.
 
@@ -134,7 +117,7 @@ not be deleted, moved, or treated as the active selected skill snapshot.
 
 ## Load Verification Sources
 
-In MoonSpec feature-directory mode, read:
+Read:
 
 - `spec.md`: original request in `**Input**`, the single user story, independent test, acceptance scenarios or `SCN-*`, functional requirements `FR-*`, success criteria `SC-*`, edge cases, assumptions, key entities, and source design mappings such as `DESIGN-REQ-*` or `DOC-REQ-*`.
 - `plan.md`: intended architecture, project structure, test commands, test tooling, integration dependencies, and constraints. Treat as context, not proof.
@@ -145,15 +128,6 @@ In MoonSpec feature-directory mode, read:
 - The canonical source document named by `spec.md` `**Source Document**` when present, plus `artifacts/doc-discoveries/<feature>.json` when it exists, so source-document drift can be assessed.
 
 Do not use copied source requirement text in `spec.md` as evidence that behavior exists.
-
-In issue-brief verification mode, read:
-
-- the issue brief artifact: issue key or GitHub issue ref, title, description, acceptance criteria, loaded preset brief, constraints, and source-resolution metadata when present.
-- the assessment artifact: verdict, per-requirement statuses, unmet requirements, partially met requirements, blocking evidence, and summary.
-- changed production and test files relevant to the issue brief and assessment gaps.
-- local implementation artifacts named by the preset, such as pull request handoff artifacts or verification reports, only as process context.
-
-Do not use the issue brief, assessment, or generated handoff text as evidence that behavior exists.
 
 ## Canonical Claim Coverage
 
@@ -207,7 +181,6 @@ Build an internal inventory before inspecting code:
 - One row per constitution constraint or `CC-*`.
 - One row per in-scope `DESIGN-REQ-*` or `DOC-REQ-*`.
 - One row per stable canonical source claim in scope for the story.
-- In issue-brief verification mode, one row per acceptance criterion and one row per unmet or partially met assessment requirement.
 
 For each row, track:
 
@@ -285,14 +258,6 @@ Choose exactly one verdict:
 
 Prefer `ADDITIONAL_WORK_NEEDED` over `NO_DETERMINATION` when a concrete missing code or test gap is visible.
 
-When the verdict is `ADDITIONAL_WORK_NEEDED`, include a structured Remaining Work section that remediation steps can consume. Each item must identify:
-
-- requirement or acceptance criterion
-- gap type: `implementation`, `verification`, `documentation`, or `environment`
-- concrete remaining work
-- suggested files, commands, or evidence to inspect
-- whether the gap is recoverable in the current runtime
-
 ## Report
 
 Return a Markdown report in the response. Do not write a file unless the user explicitly asks for one.
@@ -355,22 +320,6 @@ Use this structure:
 ## Remaining Work
 
 - [Ordered, concrete code or test changes required before completion]
-
-For issue-brief verification mode, set:
-
-- **Feature**: issue reference
-- **Spec**: N/A (issue-brief verification mode)
-- **Original Request Source**: issue brief artifact path
-
-Use this structured form for each Remaining Work item:
-
-```markdown
-- Requirement: [criterion or assessment requirement]
-  Gap Type: implementation | verification | documentation | environment
-  Remaining Work: [bounded work]
-  Suggested Evidence: [files, tests, commands, or artifact refs]
-  Recoverable In Current Runtime: true | false
-```
 
 ## Decision
 

--- a/.agents/skills/moonspec-verify/SKILL.md
+++ b/.agents/skills/moonspec-verify/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: moonspec-verify
-description: Verify a completed MoonSpec implementation against the original request, one-story `spec.md`, plan, tasks, constitution, source-design mappings, and required tests. Use when the user asks to run or reproduce `/moonspec.verify`, perform the final read-only implementation check, audit unit and integration test evidence, classify requirement coverage, or decide whether more code or test work is needed before closing a spec.
+description: Verify a completed MoonSpec implementation against the original request, one-story `spec.md`, plan, tasks, AGENTS.md repo guidance, source-design mappings, and required tests. Use when the user asks to run or reproduce `/moonspec.verify`, perform the final read-only implementation check, audit unit and integration test evidence, classify requirement coverage, or decide whether more code or test work is needed before closing a spec.
 metadata:
   required-capabilities:
     - git
@@ -21,19 +21,21 @@ This skill answers:
 - Does the implementation satisfy the original request or declarative design preserved in `spec.md`?
 - Is the single story in `spec.md` fully implemented?
 - Do unit tests and integration tests provide credible evidence?
-- Which requirements, scenarios, source design mappings, or constitution rules remain partial, missing, conflicting, or unverified?
+- Which requirements, scenarios, source design mappings, or AGENTS.md principles remain partial, missing, conflicting, or unverified?
 - Which stable canonical source claims are covered by implementation behavior, test evidence, artifact evidence, or a clear gap reason?
 - Did verified implementation evidence contradict claims in the canonical source document, indicating doc drift that reconciliation must handle?
 
 ## Inputs
 
 - Treat the user's text as optional verification focus.
-- Work from the active feature directory resolved by the prerequisite script unless the user provides a specific feature directory or `spec.md`.
-- Require `spec.md`, `plan.md`, `tasks.md`, and `.specify/memory/constitution.md`.
+- Work from the active feature directory resolved by the prerequisite script unless the user provides a specific feature directory, `spec.md`, or issue-brief verification inputs.
+- In MoonSpec feature-directory mode, require `spec.md`, `plan.md`, and `tasks.md`.
+- In issue-brief verification mode, use the provided issue brief artifact, issue reference, acceptance criteria, and assessment artifact as the verification baseline without requiring a MoonSpec feature directory, `spec.md`, `plan.md`, or `tasks.md`.
+- Read `AGENTS.md` when present for project principles, repo constraints, and test discipline.
 - Use absolute paths in reports.
 - Keep the verdict conservative when evidence is incomplete.
 
-Stop if the required artifacts cannot be located. If `spec.md` contains multiple stories, report `NO_DETERMINATION` for MoonSpec completion and recommend splitting the design with `/moonspec.breakdown` or regenerating a one-story spec.
+Stop if the required artifacts for the selected mode cannot be located. If `spec.md` contains multiple stories, report `NO_DETERMINATION` for MoonSpec completion and recommend splitting the design with `/moonspec.breakdown` or regenerating a one-story spec.
 
 ## Pre-Verify Hooks
 
@@ -73,6 +75,22 @@ If no hooks are registered or `.specify/extensions.yml` does not exist, skip sil
 
 ## Setup
 
+If the user provides issue-brief verification inputs, use issue-brief verification mode. Accept inputs expressed in prose or preset instructions such as:
+
+- issue provider, for example `jira` or `github`
+- issue reference, for example `MM-1063` or `owner/repo#123`
+- issue brief artifact path, such as `artifacts/jira-implement-brief.json`
+- assessment artifact path, such as `artifacts/jira-implement-assessment.json`
+
+In issue-brief verification mode:
+
+1. Read the issue brief artifact and assessment artifact.
+2. Use the issue summary, description, acceptance criteria, loaded preset brief, and the assessment's unmet and partially-met requirements as the verification baseline.
+3. Treat a `PARTIALLY_IMPLEMENTED` assessment as a bounded backlog: verify only the previously unmet or partially met requirements unless the issue brief explicitly requires broader validation.
+4. Treat `FULLY_IMPLEMENTED` as already verified only when no implementation step made code changes after that assessment.
+5. Inspect production code and tests directly; do not treat the assessment itself as proof that new work is complete.
+6. Do not require `spec.md`, `plan.md`, `tasks.md`, or `.specify/memory/constitution.md`.
+
 If the user provides a specific `spec.md` or feature directory, use it and derive sibling artifacts from that directory.
 
 Otherwise run the prerequisite script from the repository root:
@@ -87,14 +105,13 @@ Parse `FEATURE_DIR` and `AVAILABLE_DOCS`, then derive:
 - `PLAN = FEATURE_DIR/plan.md`
 - `TASKS = FEATURE_DIR/tasks.md`
 - optional docs from `AVAILABLE_DOCS`
-- `CONSTITUTION = .specify/memory/constitution.md`
+- `REPO_GUIDANCE = AGENTS.md` when present
 
 If shell arguments contain single quotes, use shell-safe escaping such as `'I'\''m Groot'`, or double quotes when possible.
 
 ## Workspace Projection Preflight
 
-Before running full-suite verification commands, ensure the repository view is not
-contaminated by a MoonMind active skill projection:
+Before running full-suite verification commands, ensure the repository view is not contaminated by a MoonMind active skill projection:
 
 ```bash
 test ! -L .agents/skills
@@ -103,45 +120,38 @@ test ! -e skills_active || test -L skills_active
 git status --porcelain -- .agents/skills .gemini/skills skills_active
 ```
 
-If `.agents/skills` or `.gemini/skills` is an active projection symlink, repair
-the checkout view before running full-suite evidence. Prefer restoring the
-tracked repository files or using a clean reclone/worktree. If repair is not
-possible in the current runtime, stop with verdict `BLOCKED`, include the
-diagnostic `ENVIRONMENT_CONTAMINATED_BY_SKILL_PROJECTION`, set
-`recoverableInCurrentRuntime: false`, set `recommendedNextAction: blocked`, and
-do not report `NO_DETERMINATION` merely because MoonMind's active projection
-masked tracked skill files.
+If `.agents/skills` or `.gemini/skills` is an active projection symlink, repair the checkout view before running full-suite evidence. Prefer restoring the tracked repository files or using a clean reclone/worktree. If repair is not possible in the current runtime, stop with verdict `BLOCKED`, include the diagnostic `ENVIRONMENT_CONTAMINATED_BY_SKILL_PROJECTION`, set `recoverableInCurrentRuntime: false`, set `recommendedNextAction: blocked`, and do not report `NO_DETERMINATION` merely because MoonMind's active projection masked tracked skill files.
 
-Real repo-authored `.agents/skills` directories are valid source input and must
-not be deleted, moved, or treated as the active selected skill snapshot.
+Real repo-authored `.agents/skills` directories are valid source input and must not be deleted, moved, or treated as the active selected skill snapshot.
 
 ## Load Verification Sources
 
-Read:
+In MoonSpec feature-directory mode, read:
 
 - `spec.md`: original request in `**Input**`, the single user story, independent test, acceptance scenarios or `SCN-*`, functional requirements `FR-*`, success criteria `SC-*`, edge cases, assumptions, key entities, and source design mappings such as `DESIGN-REQ-*` or `DOC-REQ-*`.
-- `plan.md`: intended architecture, project structure, test commands, test tooling, integration dependencies, and constraints. Treat as context, not proof.
+- `plan.md`: intended architecture, project structure, Principles Check, test commands, test tooling, integration dependencies, and constraints. Treat as context, not proof.
 - `tasks.md`: expected file paths, sequencing, test commands, and process completion. Treat checked tasks as process evidence only, not implementation proof.
-- `.specify/memory/constitution.md`: `MUST` constraints and quality gates.
+- `AGENTS.md` when present: project principles, repo constraints, `MUST` rules, and testing discipline.
 - `research.md`, `data-model.md`, `contracts/`, `quickstart.md`, and `checklists/` when present and relevant.
 - `specs/breakdown.md` when source design coverage or cross-spec dependencies matter.
 - The canonical source document named by `spec.md` `**Source Document**` when present, plus `artifacts/doc-discoveries/<feature>.json` when it exists, so source-document drift can be assessed.
 
 Do not use copied source requirement text in `spec.md` as evidence that behavior exists.
 
+In issue-brief verification mode, read:
+
+- the issue brief artifact: issue key or GitHub issue ref, title, description, acceptance criteria, loaded preset brief, constraints, and source-resolution metadata when present.
+- the assessment artifact: verdict, per-requirement statuses, unmet requirements, partially met requirements, blocking evidence, and summary.
+- changed production and test files relevant to the issue brief and assessment gaps.
+- local implementation artifacts named by the preset, such as pull request handoff artifacts or verification reports, only as process context.
+
+Do not use the issue brief, assessment, or generated handoff text as evidence that behavior exists.
+
 ## Canonical Claim Coverage
 
-When a canonical source document is present, report first-class Canonical Claim
-Coverage over stable canonical claims from that source while preserving the
-existing Source Document Drift section for reconciliation handoff.
+When a canonical source document is present, report first-class Canonical Claim Coverage over stable canonical claims from that source while preserving the existing Source Document Drift section for reconciliation handoff.
 
-Build the claim inventory from the canonical source document's stable claim
-headings and durable claim anchors, such as `DOC-REQ-*`, `CONTRACT-*`, `INV-*`,
-`NON-GOAL-*`, `QUALITY-*`, and `TEST-*`. Use temporary `DESIGN-REQ-*` values
-only as source-issue traceability, not as stable canonical claim IDs. Preserve
-source issue traceability or related coverage IDs when the
-canonical document provides it, but do not treat traceability prose as proof of
-behavior.
+Build the claim inventory from the canonical source document's stable claim headings and durable claim anchors, such as `DOC-REQ-*`, `CONTRACT-*`, `INV-*`, `NON-GOAL-*`, `QUALITY-*`, and `TEST-*`. Use temporary `DESIGN-REQ-*` values only as source-issue traceability, not as stable canonical claim IDs. Preserve source issue traceability or related coverage IDs when the canonical document provides it, but do not treat traceability prose as proof of behavior.
 
 For each in-scope canonical claim, classify the result with separate fields for:
 
@@ -149,8 +159,7 @@ For each in-scope canonical claim, classify the result with separate fields for:
 - Verification status: `VERIFIED`, `PARTIAL`, `MISSING`, `CONFLICT`, or `NO_DETERMINATION`.
 - Drift status: `NONE`, `POSSIBLE_DOC_DRIFT`, or `DEFINITE_DOC_DRIFT`.
 
-Each claim row must include at least one durable reference in one of these
-fields:
+Each claim row must include at least one durable reference in one of these fields:
 
 - Code evidence, such as repository file paths with line numbers or named code symbols.
 - Test evidence, such as test file paths, test names, and command results.
@@ -163,12 +172,9 @@ Classify gaps separately:
 - Verification gaps mean tests, command evidence, or inspection evidence are missing or insufficient.
 - Doc drift means verified behavior contradicts, supersedes, or reveals ambiguity in the canonical source document.
 
-Doc drift alone does not block `FULLY_IMPLEMENTED` when implementation behavior
-and required verification are correct for the agreed story scope. In that case,
-set the claim's drift status and also record the structured drift in Source Document Drift for `moonspec-doc-reconcile`.
+Doc drift alone does not block `FULLY_IMPLEMENTED` when implementation behavior and required verification are correct for the agreed story scope. In that case, set the claim's drift status and also record the structured drift in Source Document Drift for `moonspec-doc-reconcile`.
 
-Use durable evidence references instead of pasting large source, code, test,
-artifact, or log content into the report.
+Use durable evidence references instead of pasting large source, code, test, artifact, or log content into the report.
 
 ## Verification Inventory
 
@@ -178,9 +184,10 @@ Build an internal inventory before inspecting code:
 - One row per acceptance scenario or `SCN-*`.
 - One row per observable success criterion or `SC-*`.
 - One row per edge case that affects behavior.
-- One row per constitution constraint or `CC-*`.
+- One row per relevant AGENTS.md principle, repo constraint, or testing-discipline item that affects implementation or verification.
 - One row per in-scope `DESIGN-REQ-*` or `DOC-REQ-*`.
 - One row per stable canonical source claim in scope for the story.
+- In issue-brief verification mode, one row per acceptance criterion and one row per unmet or partially met assessment requirement.
 
 For each row, track:
 
@@ -212,7 +219,7 @@ Evidence rules:
 - Unit tests should cover domain rules, transformations, validation, edge cases, and failure modes.
 - Integration tests should cover acceptance scenarios, workflows, contracts, persistence, external interfaces, CLI/API/UI wiring, and other system interactions.
 - Comments, TODOs, dead code, unreferenced helpers, and documentation-only changes are non-evidence unless the requirement is explicitly documentation-only.
-- Implementation must not add hidden scope that contradicts the original request, source design, spec, or constitution.
+- Implementation must not add hidden scope that contradicts the original request, source design, spec, or relevant repo guidance.
 
 ## Run Verification Commands
 
@@ -234,16 +241,16 @@ Use these statuses:
 - `VERIFIED`: implementation and validation evidence satisfy the item.
 - `PARTIAL`: some implementation exists, but behavior, wiring, or test coverage is incomplete.
 - `MISSING`: no meaningful implementation evidence exists.
-- `CONFLICT`: implementation contradicts the spec, original request, source design, or constitution.
+- `CONFLICT`: implementation contradicts the spec, original request, source design, or relevant repo guidance.
 - `NO_DETERMINATION`: evidence is too ambiguous or unavailable to make a defensible call.
 
 Rules:
 
-- Do not mark the feature `FULLY_IMPLEMENTED` unless every in-scope `FR-*`, constitution constraint, source design requirement, and acceptance-critical behavior is `VERIFIED`.
+- Do not mark the feature `FULLY_IMPLEMENTED` unless every in-scope `FR-*`, relevant AGENTS.md principle, source design requirement, and acceptance-critical behavior is `VERIFIED`.
 - Missing required unit or integration tests is a verification failure unless the spec clearly makes that test class irrelevant.
 - Missing integration coverage for acceptance scenarios, contracts, workflows, persistence, or external boundaries is a high-severity gap.
 - Separate missing implementation from missing validation when both matter.
-- Treat violated constitution `MUST` rules as blocking failures.
+- Treat violated AGENTS.md `MUST` rules as blocking failures.
 - Treat original request misalignment as blocking even if later tasks are complete.
 - Source-document drift alone does not block `FULLY_IMPLEMENTED` when the implementation is correct per the agreed story scope; record it in the Source Document Drift section as structured input for `moonspec-doc-reconcile`. Drift becomes blocking only when it reveals the implementation itself contradicts agreed scope.
 - Canonical claim doc drift alone follows the same rule: it is non-blocking when behavior and verification are correct, but implementation gaps and verification gaps remain blocking until resolved or explicitly out of scope.
@@ -252,11 +259,19 @@ Rules:
 
 Choose exactly one verdict:
 
-- `FULLY_IMPLEMENTED`: implementation, unit tests, integration tests, source design requirements, constitution constraints, and original request alignment all verify.
+- `FULLY_IMPLEMENTED`: implementation, unit tests, integration tests, source design requirements, relevant AGENTS.md principles, and original request alignment all verify.
 - `ADDITIONAL_WORK_NEEDED`: concrete implementation or validation gaps remain.
 - `NO_DETERMINATION`: required evidence cannot be inspected or commands cannot be run enough to reach a defensible conclusion.
 
 Prefer `ADDITIONAL_WORK_NEEDED` over `NO_DETERMINATION` when a concrete missing code or test gap is visible.
+
+When the verdict is `ADDITIONAL_WORK_NEEDED`, include a structured Remaining Work section that remediation steps can consume. Each item must identify:
+
+- requirement or acceptance criterion
+- gap type: `implementation`, `verification`, `documentation`, or `environment`
+- concrete remaining work
+- suggested files, commands, or evidence to inspect
+- whether the gap is recoverable in the current runtime
 
 ## Report
 
@@ -291,11 +306,11 @@ Use this structure:
 | Scenario | Evidence | Status | Notes |
 |----------|----------|--------|-------|
 
-## Constitution And Source Design Coverage
+## Story Scope, Principles, And Source Claim Coverage
 
 | Item | Evidence | Status | Notes |
 |------|----------|--------|-------|
-| DESIGN-REQ-001 / CC-001 | [file/test/reference] | VERIFIED/PARTIAL/MISSING/CONFLICT/NO_DETERMINATION | [notes] |
+| DOC-REQ-001 / AGENTS.md principle | [file/test/reference] | VERIFIED/PARTIAL/MISSING/CONFLICT/NO_DETERMINATION | [notes] |
 
 ## Canonical Claim Coverage
 
@@ -320,6 +335,22 @@ Use this structure:
 ## Remaining Work
 
 - [Ordered, concrete code or test changes required before completion]
+
+For issue-brief verification mode, set:
+
+- **Feature**: issue reference
+- **Spec**: N/A (issue-brief verification mode)
+- **Original Request Source**: issue brief artifact path
+
+Use this structured form for each Remaining Work item:
+
+```markdown
+- Requirement: [criterion or assessment requirement]
+  Gap Type: implementation | verification | documentation | environment
+  Remaining Work: [bounded work]
+  Suggested Evidence: [files, tests, commands, or artifact refs]
+  Recoverable In Current Runtime: true | false
+```
 
 ## Decision
 
@@ -360,11 +391,11 @@ If no hooks are registered or `.specify/extensions.yml` does not exist, skip sil
 ## Key Rules
 
 - Verification is read-only except ignored disposable test artifacts.
-- The original request as preserved in `spec.md`, interpreted against the canonical source document per `docs/Workflows/MoonSpecDocumentModel.md`, is the alignment baseline. The canonical document — not the spec — remains the source of truth for desired state.
-- MoonSpec uses one story per spec.
-- `spec.md` plus `.specify/memory/constitution.md` define governing requirements.
+- `spec.md` defines the bounded one-story verification scope and preserves the original request/source packet.
+- When `spec.md` names a canonical source document, interpret the story against that document's in-scope stable claims; the canonical document remains the durable desired-state authority unless verified drift is handed off to doc reconciliation.
+- Do not require unrelated claims from a larger canonical design to verify for this story, but do not let the temporary spec silently override an in-scope canonical conflict.
+- Relevant AGENTS.md guidance defines repo principles, constraints, and test discipline for the story.
 - `plan.md` and `tasks.md` are useful context but never proof of implementation.
 - Unit tests and integration tests are both expected evidence.
-- Production code, wiring, configuration, migrations, contracts, and tests are stronger evidence than task checkboxes.
-- Do not mark the feature complete when behavior is only inferred.
-- Report concrete remaining code or test work when verification fails.
+- Prefer direct, citeable repository evidence from production code, wiring, configuration, and tests.
+- Do not mark the feature complete when required behavior is only inferred and not verified.

--- a/.specify/scripts/bash/common.sh
+++ b/.specify/scripts/bash/common.sh
@@ -21,6 +21,21 @@ get_current_branch() {
         return
     fi
 
+    local repo_root=$(get_repo_root)
+    local feature_json="$repo_root/.specify/feature.json"
+    if [[ -f "$feature_json" ]]; then
+        local feature_dir
+        feature_dir=$(
+            sed -nE \
+                's/.*"feature_directory"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/p' \
+                "$feature_json" | head -n 1
+        )
+        if [[ -n "$feature_dir" ]]; then
+            basename "$feature_dir"
+            return
+        fi
+    fi
+
     # Then check git if available
     if git rev-parse --abbrev-ref HEAD >/dev/null 2>&1; then
         git rev-parse --abbrev-ref HEAD
@@ -28,7 +43,6 @@ get_current_branch() {
     fi
 
     # For non-git repos, try to find the latest feature directory
-    local repo_root=$(get_repo_root)
     local specs_dir="$repo_root/specs"
 
     if [[ -d "$specs_dir" ]]; then
@@ -39,10 +53,14 @@ get_current_branch() {
             if [[ -d "$dir" ]]; then
                 local dirname=$(basename "$dir")
                 if [[ "$dirname" =~ ^([0-9]{3})- ]]; then
-                    local number=${BASH_REMATCH[1]}
-                    number=$((10#$number))
-                    if [[ "$number" -gt "$highest" ]]; then
-                        highest=$number
+                    local sequence=${BASH_REMATCH[1]}
+                    sequence=$((10#$sequence))
+                    if [[ "$sequence" -gt "$highest" ]]; then
+                        highest=$sequence
+                        latest_feature=$dirname
+                    fi
+                elif [[ "$dirname" =~ ^[0-9]{8}-[0-9]{6}- ]]; then
+                    if [[ "$dirname" > "$latest_feature" ]]; then
                         latest_feature=$dirname
                     fi
                 fi
@@ -73,9 +91,9 @@ check_feature_branch() {
         return 0
     fi
 
-    if [[ ! "$branch" =~ ^[0-9]{3}- ]]; then
+    if [[ ! "$branch" =~ ^[0-9]{3}- && ! "$branch" =~ ^[0-9]{8}-[0-9]{6}- ]]; then
         echo "ERROR: Not on a feature branch. Current branch: $branch" >&2
-        echo "Feature branches should be named like: 001-feature-name" >&2
+        echo "Feature branches should be named like: 001-feature-name or 20260319-143022-feature-name" >&2
         return 1
     fi
 
@@ -154,4 +172,3 @@ EOF
 
 check_file() { [[ -f "$1" ]] && echo "  ✓ $2" || echo "  ✗ $2"; }
 check_dir() { [[ -d "$1" && -n $(ls -A "$1" 2>/dev/null) ]] && echo "  ✓ $2" || echo "  ✗ $2"; }
-

--- a/.specify/templates/commands/moonspec.align.md
+++ b/.specify/templates/commands/moonspec.align.md
@@ -24,33 +24,14 @@ You **MUST** consider the user input before proceeding (if not empty).
 - For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
   - If the hook has no `condition` field, or it is null/empty, treat the hook as executable.
   - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation.
-- For each executable hook, output the following based on its `optional` flag:
-  - **Optional hook** (`optional: true`):
-    ```
-    ## Extension Hooks
-
-    **Optional Pre-Hook**: {extension}
-    Command: `/{command}`
-    Description: {description}
-
-    Prompt: {prompt}
-    To execute: `/{command}`
-    ```
-  - **Mandatory hook** (`optional: false`):
-    ```
-    ## Extension Hooks
-
-    **Automatic Pre-Hook**: {extension}
-    Executing: `/{command}`
-    EXECUTE_COMMAND: {command}
-
-    Wait for the result of the hook command before proceeding to the Goal.
-    ```
+- For executable hooks:
+  - Optional hooks: report the hook command and prompt, but do not pause for user input.
+  - Mandatory hooks: output `EXECUTE_COMMAND: {command}` and execute or delegate it according to the active hook execution environment before continuing.
 - If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently.
 
 ## Goal
 
-Identify inconsistencies, duplications, ambiguities, underspecified items, coverage gaps, and constitution conflicts across MoonSpec artifacts, then automatically implement conservative artifact improvements without asking the user for clarification.
+Identify inconsistencies, duplications, ambiguities, underspecified items, coverage gaps, and principle conflicts across MoonSpec artifacts, then automatically implement conservative artifact improvements without asking the user for clarification.
 
 This command MUST run only after `/moonspec.tasks` has successfully produced a complete `tasks.md`.
 
@@ -62,7 +43,7 @@ This command MUST run only after `/moonspec.tasks` has successfully produced a c
 
 **No application implementation**: Do **not** edit application source code, production tests, migrations, or runtime configuration unless the user explicitly asks for implementation beyond artifact alignment.
 
-**Constitution Authority**: The project constitution (`.specify/memory/constitution.md`) is **non-negotiable** within this command. Constitution conflicts are automatically CRITICAL and require adjustment of the spec, plan, design artifacts, or tasks—not dilution, reinterpretation, or silent ignoring of the principle. If a principle itself needs to change, that must occur in a separate, explicit constitution update outside `/moonspec.align`.
+**Principles authority**: `AGENTS.md`, when present, provides project principles, repo constraints, and testing discipline for this command. Principle conflicts are automatically high priority and require adjustment of the spec, plan, design artifacts, or tasks—not dilution, reinterpretation, or silent ignoring of the principle.
 
 ## Execution Steps
 
@@ -73,7 +54,7 @@ Run `{SCRIPT}` once from repo root and parse JSON for `FEATURE_DIR` and `AVAILAB
 - SPEC = FEATURE_DIR/spec.md
 - PLAN = FEATURE_DIR/plan.md
 - TASKS = FEATURE_DIR/tasks.md
-- CONSTITUTION = `.specify/memory/constitution.md`
+- REPO_GUIDANCE = AGENTS.md when present
 
 Abort with an error message if any required file is missing. Instruct the user to run the missing prerequisite command.
 
@@ -100,7 +81,7 @@ Load enough context to make edits confidently:
 - Testing strategy and tools
 - Data model and contract references
 - Phases and technical constraints
-- Constitution checks and complexity tracking
+- Principles Check and complexity tracking
 
 **From tasks.md:**
 
@@ -111,6 +92,13 @@ Load enough context to make edits confidently:
 - Unit and integration test tasks
 - Dependency and ordering notes
 
+**From AGENTS.md, when present:**
+
+- Project principles
+- Repo constraints
+- Testing discipline
+- Source-of-truth expectations
+
 **From optional docs:**
 
 - `research.md`
@@ -118,12 +106,6 @@ Load enough context to make edits confidently:
 - `contracts/`
 - `quickstart.md`
 - `checklists/` when present
-
-**From constitution:**
-
-- Principle names
-- `MUST` and `SHOULD` normative statements
-- Required quality gates
 
 Also inspect relevant repository files when needed to resolve uncertainty, especially project layout, test framework configuration, existing contracts, and naming conventions.
 
@@ -134,7 +116,7 @@ Create internal representations:
 - **Requirements inventory**: For each `FR-*`, buildable `SC-*`, acceptance scenario, edge case, and in-scope source requirement, record a stable key.
 - **Task coverage mapping**: Map each task to one or more requirements, scenarios, success criteria, source requirements, or design artifacts.
 - **Artifact authority order**:
-  1. Constitution and explicit source design requirements
+  1. Explicit source design requirements and relevant `AGENTS.md` principles
   2. Original feature input preserved in `spec.md`
   3. `spec.md` user-visible behavior and acceptance criteria
   4. `plan.md` architecture and technical decisions
@@ -146,44 +128,12 @@ Create internal representations:
 
 Identify high-signal findings. Aggregate related issues instead of creating noisy one-off findings.
 
-#### A. Duplication Detection
-
-- Identify near-duplicate requirements, scenarios, entities, design decisions, or tasks.
-- Mark lower-quality phrasing for consolidation.
-
-#### B. Ambiguity Detection
-
-- Flag vague adjectives such as fast, scalable, secure, intuitive, reliable, and robust when no measurable criterion exists.
-- Flag unresolved placeholders such as TODO, TKTK, ???, `<placeholder>`, and `[NEEDS CLARIFICATION: ...]`.
-- Flag unclear actors, data ownership, failure behavior, or validation expectations.
-
-#### C. Underspecification
-
-- Requirements with verbs but missing objects or measurable outcomes.
-- Acceptance scenarios without expected observable result.
-- Edge cases without requirement or task coverage.
-- Success criteria requiring buildable work but missing validation path.
-- Tasks referencing files, components, commands, or contracts not defined in spec or plan.
-
-#### D. Constitution Alignment
-
-- Any artifact conflicting with a constitution `MUST` principle.
-- Missing mandated sections, quality gates, unit tests, integration tests, or verification requirements.
-
-#### E. Coverage Gaps
-
-- Requirements with zero associated tasks.
-- In-scope source requirements with no mapped functional requirement or task.
-- Buildable success criteria not reflected in tasks or quickstart.
-- Required contracts not represented in tests or implementation tasks.
-
-#### F. Inconsistency
-
-- Terminology drift across artifacts.
-- Data entities referenced in plan but absent in spec or data model, or vice versa.
-- Task ordering contradictions.
-- Test-first ordering contradictions.
-- Conflicting technology, interface, persistence, or validation decisions.
+- Duplication: near-duplicate requirements, scenarios, entities, design decisions, or tasks.
+- Ambiguity: vague adjectives, unresolved placeholders, unclear actors, data ownership, failure behavior, or validation expectations.
+- Underspecification: requirements missing objects or measurable outcomes, acceptance scenarios without observable results, edge cases without coverage, or tasks referencing undefined components.
+- Principle alignment: conflicts with `AGENTS.md` `MUST` statements, missing mandated quality gates, missing unit/integration tests, or unjustified complexity.
+- Coverage gaps: requirements or source requirements with no associated tasks, buildable success criteria not reflected in tasks or quickstart, or contracts not represented in tests.
+- Inconsistency: terminology drift, entity drift, task ordering contradictions, test-first ordering contradictions, or conflicting technology/interface/persistence decisions.
 
 ### 5. Resolve Uncertainties
 
@@ -195,7 +145,7 @@ Use this decision process:
 2. Gather evidence from artifacts and repository context.
 3. Identify 2-3 plausible resolutions.
 4. Weigh pros and cons using:
-   - conformance to constitution and source requirements
+   - conformance to source requirements and relevant principles
    - preservation of user-visible behavior
    - implementation blast radius
    - testability
@@ -207,7 +157,7 @@ Use this decision process:
 Default decisions:
 
 - If `tasks.md` conflicts with `spec.md`, update `tasks.md` unless the spec is clearly incomplete relative to the original input.
-- If `plan.md` conflicts with the constitution or explicit source design requirement, update `plan.md`.
+- If `plan.md` conflicts with an explicit source design requirement or relevant `AGENTS.md` principle, update `plan.md`.
 - If `spec.md` is ambiguous but the repo has a clear established convention, update `spec.md` with that convention as an assumption or measurable requirement.
 - If two options are equally plausible and neither is required by higher authority, choose the simpler and more reversible option.
 - If a finding cannot be remediated without inventing product scope, add a bounded assumption and a validation task instead of asking the user.
@@ -216,7 +166,7 @@ Default decisions:
 
 Edit artifacts in this order:
 
-1. Constitution conflicts.
+1. Principle conflicts.
 2. Source requirement and original-input preservation issues.
 3. Spec requirement, scenario, edge-case, entity, and success-criteria issues.
 4. Plan and design artifact issues.
@@ -254,7 +204,7 @@ After editing:
    - every in-scope source requirement maps to a functional requirement and task
    - every buildable success criterion has task or quickstart coverage
    - test tasks cover required unit and integration behavior where applicable
-   - no constitution `MUST` conflict remains
+   - no relevant `AGENTS.md` `MUST` conflict remains
    - no unresolved placeholders remain unless explicitly intentional and explained
    - task ordering is coherent
 4. Run lightweight repository checks when the edits touched generated checks, test commands, or machine-readable contracts. If no relevant command exists, report that no additional command was available.
@@ -291,33 +241,16 @@ Include exact artifact paths. Mention remediation intentionally skipped because 
 - For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
   - If the hook has no `condition` field, or it is null/empty, treat the hook as executable.
   - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation.
-- For each executable hook, output the following based on its `optional` flag:
-  - **Optional hook** (`optional: true`):
-    ```
-    ## Extension Hooks
-
-    **Optional Hook**: {extension}
-    Command: `/{command}`
-    Description: {description}
-
-    Prompt: {prompt}
-    To execute: `/{command}`
-    ```
-  - **Mandatory hook** (`optional: false`):
-    ```
-    ## Extension Hooks
-
-    **Automatic Hook**: {extension}
-    Executing: `/{command}`
-    EXECUTE_COMMAND: {command}
-    ```
+- For executable hooks:
+  - Optional hooks: report the hook command and prompt.
+  - Mandatory hooks: output `EXECUTE_COMMAND: {command}` and execute or delegate it.
 - If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently.
 
 ## Operating Principles
 
 - **Automated remediation**: Apply artifact edits directly after analysis.
 - **No clarification loop**: Resolve uncertainty with project context and conservative assumptions.
-- **Authority preserving**: Never weaken constitution, source design, or original request intent to simplify downstream artifacts.
+- **Authority preserving**: Never weaken source design, original request intent, or relevant `AGENTS.md` principles to simplify downstream artifacts.
 - **Traceability**: Maintain clear mappings from source requirements to spec requirements, tasks, tests, and validation.
 - **Context efficiency**: Focus on high-signal findings and concise edit summaries.
 - **Deterministic results**: Rerunning without changes should produce stable decisions and minimal diffs.

--- a/.specify/templates/commands/moonspec.implement.md
+++ b/.specify/templates/commands/moonspec.implement.md
@@ -56,44 +56,22 @@ You **MUST** consider the user input before proceeding (if not empty).
 
 MoonSpec implements robust behavior from declarative designs through one-story specs and test-driven delivery. This command executes the current `tasks.md` for exactly one independently testable story, keeps the original request or source design traceable through implementation, treats unit and integration tests as required evidence, and finishes with `/moonspec.verify` as the final alignment check.
 
-1. Run `{SCRIPT}` from repo root and parse FEATURE_DIR and AVAILABLE_DOCS list. All paths must be absolute. For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
+1. Run `{SCRIPT}` from repo root and parse FEATURE_DIR and AVAILABLE_DOCS list. All paths must be absolute. Derive:
+   - SPEC = FEATURE_DIR/spec.md
+   - PLAN = FEATURE_DIR/plan.md
+   - TASKS = FEATURE_DIR/tasks.md
+   - REPO_GUIDANCE = AGENTS.md when present
 
 2. **Check checklists status** (if FEATURE_DIR/checklists/ exists):
-   - Scan all checklist files in the checklists/ directory
-   - For each checklist, count:
-     - Total items: All lines matching `- [ ]` or `- [X]` or `- [x]`
-     - Completed items: Lines matching `- [X]` or `- [x]`
-     - Incomplete items: Lines matching `- [ ]`
-   - Create a status table:
-
-     ```text
-     | Checklist | Total | Completed | Incomplete | Status |
-     |-----------|-------|-----------|------------|--------|
-     | ux.md     | 12    | 12        | 0          | ✓ PASS |
-     | test.md   | 8     | 5         | 3          | ✗ FAIL |
-     | security.md | 6   | 6         | 0          | ✓ PASS |
-     ```
-
-   - Calculate overall status:
-     - **PASS**: All checklists have 0 incomplete items
-     - **FAIL**: One or more checklists have incomplete items
-
-   - **If any checklist is incomplete**:
-     - Display the table with incomplete item counts
-     - **STOP** and ask: "Some checklists are incomplete. Do you want to proceed with implementation anyway? (yes/no)"
-     - Wait for user response before continuing
-     - If user says "no" or "wait" or "stop", halt execution
-     - If user says "yes" or "proceed" or "continue", proceed to step 3
-
-   - **If all checklists are complete**:
-     - Display the table showing all checklists passed
-     - Automatically proceed to step 3
+   - Scan all checklist files in the checklists/ directory.
+   - Count total, completed, and incomplete checklist items.
+   - If any checklist is incomplete, stop and ask whether to proceed. Continue only when the user explicitly says yes, proceed, or continue.
 
 3. Load and analyze the implementation context:
    - **REQUIRED**: Read tasks.md for the complete task list and execution plan
-   - **REQUIRED**: Read plan.md for tech stack, architecture, and file structure
+   - **REQUIRED**: Read plan.md for tech stack, architecture, Principles Check, constraints, and file structure
    - **REQUIRED**: Read spec.md for the single user story, acceptance scenarios, functional requirements, edge cases, success criteria, and the preserved original request in the `**Input**` field
-   - **REQUIRED**: Read `.specify/memory/constitution.md` for project constraints and TDD expectations
+   - **IF PRESENT**: Read AGENTS.md for project principles, repo constraints, and TDD expectations
    - **IF EXISTS**: Read data-model.md for entities and relationships
    - **IF EXISTS**: Read contracts/ for API specifications and integration/contract test requirements
    - **IF EXISTS**: Read research.md for technical decisions and constraints
@@ -103,122 +81,75 @@ MoonSpec implements robust behavior from declarative designs through one-story s
    - Extract source design mappings such as `DESIGN-REQ-*` or `DOC-REQ-*` so implementation and tests can be traced back to the original declarative design or feature request.
 
 4. **Project Setup Verification**:
-   - **REQUIRED**: Create/verify ignore files based on actual project setup:
-
-   **Detection & Creation Logic**:
-   - Check if the following command succeeds to determine if the repository is a git repo (create/verify .gitignore if so):
-
-     ```sh
-     git rev-parse --git-dir 2>/dev/null
-     ```
-
-   - Check if Dockerfile* exists or Docker in plan.md → create/verify .dockerignore
-   - Check if .eslintrc* exists → create/verify .eslintignore
-   - Check if eslint.config.* exists → ensure the config's `ignores` entries cover required patterns
-   - Check if .prettierrc* exists → create/verify .prettierignore
-   - Check if .npmrc or package.json exists → create/verify .npmignore (if publishing)
-   - Check if terraform files (*.tf) exist → create/verify .terraformignore
-   - Check if .helmignore needed (helm charts present) → create/verify .helmignore
-
-   **If ignore file already exists**: Verify it contains essential patterns, append missing critical patterns only
-   **If ignore file missing**: Create with full pattern set for detected technology
-
-   **Common Patterns by Technology** (from plan.md tech stack):
-   - **Node.js/JavaScript/TypeScript**: `node_modules/`, `dist/`, `build/`, `*.log`, `.env*`
-   - **Python**: `__pycache__/`, `*.pyc`, `.venv/`, `venv/`, `dist/`, `*.egg-info/`
-   - **Java**: `target/`, `*.class`, `*.jar`, `.gradle/`, `build/`
-   - **C#/.NET**: `bin/`, `obj/`, `*.user`, `*.suo`, `packages/`
-   - **Go**: `*.exe`, `*.test`, `vendor/`, `*.out`
-   - **Ruby**: `.bundle/`, `log/`, `tmp/`, `*.gem`, `vendor/bundle/`
-   - **PHP**: `vendor/`, `*.log`, `*.cache`, `*.env`
-   - **Rust**: `target/`, `debug/`, `release/`, `*.rs.bk`, `*.rlib`, `*.prof*`, `.idea/`, `*.log`, `.env*`
-   - **Kotlin**: `build/`, `out/`, `.gradle/`, `.idea/`, `*.class`, `*.jar`, `*.iml`, `*.log`, `.env*`
-   - **C++**: `build/`, `bin/`, `obj/`, `out/`, `*.o`, `*.so`, `*.a`, `*.exe`, `*.dll`, `.idea/`, `*.log`, `.env*`
-   - **C**: `build/`, `bin/`, `obj/`, `out/`, `*.o`, `*.a`, `*.so`, `*.exe`, `*.dll`, `autom4te.cache/`, `config.status`, `config.log`, `.idea/`, `*.log`, `.env*`
-   - **Swift**: `.build/`, `DerivedData/`, `*.swiftpm/`, `Packages/`
-   - **R**: `.Rproj.user/`, `.Rhistory`, `.RData`, `.Ruserdata`, `*.Rproj`, `packrat/`, `renv/`
-   - **Universal**: `.DS_Store`, `Thumbs.db`, `*.tmp`, `*.swp`, `.vscode/`, `.idea/`
-
-   **Tool-Specific Patterns**:
-   - **Docker**: `node_modules/`, `.git/`, `Dockerfile*`, `.dockerignore`, `*.log*`, `.env*`, `coverage/`
-   - **ESLint**: `node_modules/`, `dist/`, `build/`, `coverage/`, `*.min.js`
-   - **Prettier**: `node_modules/`, `dist/`, `build/`, `coverage/`, `package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`
-   - **Terraform**: `.terraform/`, `*.tfstate*`, `*.tfvars`, `.terraform.lock.hcl`
-   - **Kubernetes/k8s**: `*.secret.yaml`, `secrets/`, `.kube/`, `kubeconfig*`, `*.key`, `*.crt`
+   - Create or verify ignore files based on actual project setup.
+   - Append only missing critical patterns. Do not rewrite existing ignore files wholesale.
+   - Cover generated outputs, dependencies, local env files, logs, caches, and test artifacts for the detected stack.
 
 5. Parse tasks.md structure and extract:
-   - **Task phases**: Setup, Foundational, single-story work, Polish, Final Verification
-   - **Story scope**: The one story goal, independent test criteria, acceptance scenarios, and source design coverage owned by this spec
-   - **Test tasks**: Unit tests for domain behavior and edge cases, plus integration tests for acceptance scenarios, workflows, external interfaces, persistence, contracts, or other system interactions
-   - **Task dependencies**: Sequential vs parallel execution rules
-   - **Task details**: ID, description, file paths, parallel markers [P]
-   - **Execution flow**: TDD order, dependency requirements, and final `/moonspec.verify` task
+   - Task phases: Setup, Foundational, single-story work, Polish, Final Verification
+   - Story scope: the one story goal, independent test criteria, acceptance scenarios, and source design coverage owned by this spec
+   - Test tasks: unit tests for domain behavior and edge cases, plus integration tests for acceptance scenarios, workflows, external interfaces, persistence, contracts, or other system interactions
+   - Task dependencies: sequential vs parallel execution rules
+   - Task details: ID, description, file paths, parallel markers [P]
+   - Execution flow: TDD order, dependency requirements, and final `/moonspec.verify` task
 
 6. Execute implementation following the task plan:
-   - **Phase-by-phase execution**: Complete each phase before moving to the next
-   - **Respect dependencies**: Run sequential tasks in order, parallel tasks [P] can run together  
-   - **Follow TDD by default**: Execute unit and integration test tasks before their corresponding implementation tasks
-   - **Confirm red first**: Run each new or changed test and confirm it fails for the expected reason before writing production code for that behavior
-   - **Protect source traceability**: Keep implementation and test evidence mapped to the story, acceptance scenarios, functional requirements, and source design IDs extracted from spec.md
-   - **File-based coordination**: Tasks affecting the same files must run sequentially
-   - **Validation checkpoints**: Verify each phase completion before proceeding
+   - Complete each phase before moving to the next.
+   - Follow TDD by default: execute unit and integration test tasks before their corresponding implementation tasks.
+   - Confirm red first: run each new or changed test and confirm it fails for the expected reason before writing production code for that behavior.
+   - Protect source traceability: keep implementation and test evidence mapped to the story, acceptance scenarios, functional requirements, and source design IDs extracted from spec.md.
+   - Preserve relevant AGENTS.md principles, repo constraints, and testing discipline.
+   - Tasks affecting the same files must run sequentially.
+   - Verify each phase completion before proceeding.
 
 7. Implementation execution rules:
-   - **Setup first**: Initialize project structure, dependencies, configuration
-   - **Foundational prerequisites**: Complete shared infrastructure, fixtures, test harnesses, service containers, emulators, migrations, or configuration required before story work
-   - **Tests before code**: Write and run unit tests and integration tests before production code, confirming they fail for the intended reason
-   - **Unit coverage**: Cover domain rules, transformations, validation, edge cases, and failure modes named by the spec
-   - **Integration coverage**: Cover acceptance scenarios, end-to-end workflows, contract boundaries, persistence, external services, CLI/API/UI wiring, and other system interactions implied by the design
-   - **Core development**: Implement only the models, services, CLI commands, endpoints, UI, contracts, or workflows needed for the single story
-   - **Integration work**: Wire database connections, middleware, logging, external services, configuration, startup registration, and deployment-facing behavior required by the story
-   - **Polish and validation**: Refactor after tests pass, expand meaningful unit/integration coverage, optimize the story path, update documentation, and run final verification
+   - Setup first: initialize project structure, dependencies, configuration.
+   - Foundational prerequisites: complete shared infrastructure, fixtures, test harnesses, service containers, emulators, migrations, or configuration required before story work.
+   - Tests before code: write and run unit tests and integration tests before production code, confirming they fail for the intended reason.
+   - Unit coverage: cover domain rules, transformations, validation, edge cases, and failure modes named by the spec.
+   - Integration coverage: cover acceptance scenarios, end-to-end workflows, contract boundaries, persistence, external services, CLI/API/UI wiring, and other system interactions implied by the design.
+   - Core development: implement only the models, services, CLI commands, endpoints, UI, contracts, or workflows needed for the single story.
+   - Integration work: wire database connections, middleware, logging, external services, configuration, startup registration, and deployment-facing behavior required by the story.
+   - Polish and validation: refactor after tests pass, expand meaningful unit/integration coverage, optimize the story path, update documentation, and run final verification.
 
 8. Progress tracking and error handling:
-   - Report progress after each completed task
-   - Halt execution if any non-parallel task fails
-   - For parallel tasks [P], continue with successful tasks, report failed ones
-   - Provide clear error messages with context for debugging
-   - Suggest next steps if implementation cannot proceed
-   - **IMPORTANT** For completed tasks, make sure to mark the task off as [X] in the tasks file.
+   - Report progress after each completed task.
+   - Halt execution if any non-parallel task fails.
+   - For parallel tasks [P], continue with successful tasks and report failed ones.
+   - Provide clear error messages with context for debugging.
+   - Suggest next steps if implementation cannot proceed.
+   - For completed tasks, mark the task off as [X] in the tasks file.
 
 9. Completion validation:
-   - Verify all required tasks are completed
-   - Check that the implemented behavior matches the single story in spec.md
-   - Check that the implementation remains aligned with the original feature request or declarative design preserved in spec.md `**Input**`
-   - Check that every in-scope source design mapping such as `DESIGN-REQ-*` or `DOC-REQ-*` has implementation and test evidence
-   - Validate that unit and integration tests pass and coverage meets requirements
-   - Confirm the implementation follows the technical plan
-   - Confirm no extra hidden scope was added beyond the story or source design constraints
-   - Run `/moonspec.verify` if present as the final task; otherwise explicitly recommend it as the final MoonSpec check before considering the work complete
-   - Report final status with summary of completed work
+   - Verify all required tasks are completed.
+   - Check that the implemented behavior matches the single story in spec.md.
+   - Check that the implementation remains aligned with the original feature request or declarative design preserved in spec.md `**Input**`.
+   - Check that every in-scope source design mapping such as `DESIGN-REQ-*` or `DOC-REQ-*` has implementation and test evidence.
+   - Check that relevant AGENTS.md principles and testing discipline are not violated.
+   - Validate that unit and integration tests pass and coverage meets requirements.
+   - Confirm the implementation follows the technical plan.
+   - Confirm no extra hidden scope was added beyond the story, source design constraints, or relevant repo guidance.
+   - Run `/moonspec.verify` if present as the final task; otherwise explicitly recommend it as the final MoonSpec check before considering the work complete.
+   - Report final status with summary of completed work.
 
 Note: This command assumes a complete one-story task breakdown exists in tasks.md. If tasks are incomplete or missing, suggest running `/moonspec.tasks` first to regenerate the task list. If the source input is a broad technical or declarative design that has not yet been split into one-story specs, suggest running `/moonspec.breakdown` first.
 
 10. **Check for extension hooks**: After completion validation, check if `.specify/extensions.yml` exists in the project root.
-    - If it exists, read it and look for entries under the `hooks.after_implement` key
-    - If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+    - If it exists, read it and look for entries under the `hooks.after_implement` key.
+    - If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally.
     - Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
-    - For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
-      - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
-      - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
-    - For each executable hook, output the following based on its `optional` flag:
-      - **Optional hook** (`optional: true`):
-        ```
-        ## Extension Hooks
+    - For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions.
+    - For executable hooks:
+      - Optional hooks: report the hook command and prompt.
+      - Mandatory hooks: output `EXECUTE_COMMAND: {command}` and execute or delegate it.
+    - If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently.
 
-        **Optional Hook**: {extension}
-        Command: `/{command}`
-        Description: {description}
+## Key Rules
 
-        Prompt: {prompt}
-        To execute: `/{command}`
-        ```
-      - **Mandatory hook** (`optional: false`):
-        ```
-        ## Extension Hooks
-
-        **Automatic Hook**: {extension}
-        Executing: `/{command}`
-        EXECUTE_COMMAND: {command}
-        ```
-    - If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently
+- Implement exactly one story.
+- Keep tests before production code.
+- Unit tests and integration tests are required evidence unless the spec clearly makes one class irrelevant.
+- Preserve traceability to the original request and source design mappings.
+- Preserve relevant AGENTS.md principles and repo constraints.
+- Mark completed tasks only after the work and validation are real.
+- Run or recommend `/moonspec.verify` before considering the story complete.

--- a/.specify/templates/commands/moonspec.plan.md
+++ b/.specify/templates/commands/moonspec.plan.md
@@ -59,17 +59,17 @@ You **MUST** consider the user input before proceeding (if not empty).
 
 1. **Setup**: Run `{SCRIPT}` from repo root and parse JSON for FEATURE_SPEC, IMPL_PLAN, SPECS_DIR, BRANCH. For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
 
-2. **Load context**: Read FEATURE_SPEC and `.specify/memory/constitution.md`. Confirm FEATURE_SPEC contains exactly one user story. Load IMPL_PLAN template (already copied).
+2. **Load context**: Read FEATURE_SPEC, IMPL_PLAN template (already copied), and `AGENTS.md` when present for principles, testing discipline, and repo constraints. Confirm FEATURE_SPEC contains exactly one user story.
 
 3. **Execute plan workflow**: Follow the structure in IMPL_PLAN template to:
    - Fill Technical Context (mark unknowns as "NEEDS CLARIFICATION")
    - Identify unit testing and integration testing tools separately
-   - Fill Constitution Check section from constitution
-   - Evaluate gates (ERROR if violations unjustified)
+   - Fill Principles Check section from relevant `AGENTS.md` guidance
+   - Evaluate principle conflicts (ERROR if violations are unjustified)
    - Phase 0: Generate research.md (resolve all NEEDS CLARIFICATION)
    - Phase 1: Generate data-model.md, contracts/, quickstart.md, including test-first validation scenarios
    - Phase 1: Update agent context by running the agent script
-   - Re-evaluate Constitution Check post-design
+   - Re-evaluate Principles Check post-design
 
 4. **Stop and report**: Command ends after design planning. Report branch, IMPL_PLAN path, generated artifacts, and the unit/integration test strategy to be used by `/moonspec.tasks`.
 
@@ -154,4 +154,4 @@ You **MUST** consider the user input before proceeding (if not empty).
 ## Key rules
 
 - Use absolute paths
-- ERROR on gate failures, multiple user stories in the spec, or unresolved clarifications
+- ERROR on unjustified principle conflicts, multiple user stories in the spec, or unresolved clarifications

--- a/.specify/templates/commands/moonspec.tasks.md
+++ b/.specify/templates/commands/moonspec.tasks.md
@@ -66,9 +66,9 @@ MoonSpec tasks turn one declarative design-backed spec into an executable implem
 
 1. **Setup**: Run `{SCRIPT}` from repo root and parse FEATURE_DIR and AVAILABLE_DOCS list. All paths must be absolute. For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
 
-2. **Load design documents**: Read from FEATURE_DIR:
+2. **Load design documents**: Read from FEATURE_DIR and repo guidance:
    - **Required**: plan.md (tech stack, libraries, structure), spec.md (single user story)
-   - **Required**: `.specify/memory/constitution.md` for project constraints and test discipline
+   - **If present**: `AGENTS.md` for project principles, constraints, and test discipline
    - **Optional**: data-model.md (entities), contracts/ (interface contracts), research.md (decisions), quickstart.md (test scenarios), `specs/breakdown.md` (source design coverage context)
    - Note: Not all projects have all documents. Generate tasks based on what's available.
 
@@ -76,7 +76,7 @@ MoonSpec tasks turn one declarative design-backed spec into an executable implem
    - Load plan.md and extract tech stack, libraries, project structure, unit testing tools, and integration testing tools
    - Load spec.md and extract the preserved `**Input**`, single user story, goal, independent test, acceptance scenarios, edge cases, functional requirements, success criteria, assumptions, and source design mappings such as `DESIGN-REQ-*` or `DOC-REQ-*`
    - Confirm spec.md contains exactly one independently testable user story; if it contains multiple stories, STOP and tell the user to use `/moonspec.breakdown` for broad designs or regenerate a one-story spec with `/moonspec.specify`
-   - Build a traceability inventory covering each `FR-*`, acceptance scenario, edge case, measurable success criterion, and in-scope source design mapping
+   - Build a traceability inventory covering each `FR-*`, acceptance scenario, edge case, measurable success criterion, in-scope source design mapping, and relevant AGENTS.md principle/test-discipline requirement
    - If data-model.md exists: Extract entities needed by the story
    - If contracts/ exists: Map interface contracts to the story and to integration/contract test tasks
    - If research.md exists: Extract decisions for setup tasks
@@ -221,6 +221,11 @@ Every task MUST strictly follow this format:
    - Each source design workflow or public boundary → at least one integration test task
    - Each source design rule, invariant, or edge case → at least one unit test task where applicable
    - Explicit non-goals and constraints → guardrail tests, validation tasks, or documented scope checks when they affect implementation
+
+6. **From AGENTS.md Principles And Test Discipline**:
+   - Each relevant principle conflict → a visible mitigation or scope decision in tasks.md
+   - Each testing-discipline requirement → concrete unit, integration, or validation tasks
+   - Repo-specific docs/source-of-truth requirements → concrete documentation or reconciliation tasks when they apply
 
 ### Phase Structure
 

--- a/.specify/templates/commands/moonspec.verify.md
+++ b/.specify/templates/commands/moonspec.verify.md
@@ -1,5 +1,5 @@
 ---
-description: Verify the final implementation against the original feature request, specification, plan, tasks, and required tests.
+description: Verify the final implementation against the original feature request, specification, plan, tasks, repo guidance, and required tests.
 scripts:
   sh: .specify/scripts/bash/check-prerequisites.sh --json --require-tasks --include-tasks
 ---
@@ -52,14 +52,19 @@ You **MUST** consider the user input before proceeding (if not empty).
 
 This command is the final MoonSpec check. It verifies that the completed implementation satisfies the original feature request preserved in `spec.md`, not just the later task list.
 
-1. **Setup**: Run `{SCRIPT}` from repo root and parse FEATURE_DIR and AVAILABLE_DOCS list. All paths must be absolute. For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
+1. **Setup**: Run `{SCRIPT}` from repo root and parse FEATURE_DIR and AVAILABLE_DOCS list. All paths must be absolute. Derive:
+   - SPEC = FEATURE_DIR/spec.md
+   - PLAN = FEATURE_DIR/plan.md
+   - TASKS = FEATURE_DIR/tasks.md
+   - REPO_GUIDANCE = AGENTS.md when present
 
 2. **Load verification sources**:
-   - **Required**: `spec.md`, `plan.md`, `tasks.md`, `.specify/memory/constitution.md`
+   - **Required**: `spec.md`, `plan.md`, `tasks.md`
+   - **If present**: `AGENTS.md` for project principles, repo constraints, and test discipline
    - **If exists**: `research.md`, `data-model.md`, `contracts/`, `quickstart.md`, `checklists/`
    - Extract the original request from the `**Input**` field in `spec.md`
    - Extract the single user story, acceptance scenarios or `SCN-*`, functional requirements `FR-*`, success criteria `SC-*`, edge cases, assumptions, independent test, and source design mappings such as `DESIGN-REQ-*` or `DOC-REQ-*`
-   - Extract constitution `MUST` constraints and any explicit quality gates
+   - Extract relevant AGENTS.md `MUST` constraints and any explicit quality gates when present
    - Treat `plan.md` and `tasks.md` as intent and process context only. They can help identify expected files, commands, and sequencing, but they are never proof that behavior is implemented.
 
 3. **Build a verification inventory**:
@@ -67,7 +72,7 @@ This command is the final MoonSpec check. It verifies that the completed impleme
      - One row per `FR-*`
      - One row per acceptance scenario or `SCN-*`
      - One row per observable `SC-*`
-     - One row per constitution constraint or `CC-*`
+     - One row per relevant AGENTS.md principle, repo constraint, or testing-discipline item that affects implementation or verification
      - One row per in-scope `DESIGN-REQ-*` or `DOC-REQ-*`
    - For each row, track expected behavior, likely production code touchpoints, expected unit or integration tests, current status, evidence, and remaining gap
 
@@ -81,7 +86,7 @@ This command is the final MoonSpec check. It verifies that the completed impleme
    - Confirm integration tests exist for acceptance scenarios, external interfaces, persistence, workflows, or other system interactions
    - Confirm in-scope source design requirements have code-or-test traceability; copied requirement text in `spec.md` is not implementation evidence
    - Treat comments, TODOs, dead code, unreferenced helpers, and documentation-only changes as non-evidence unless the requirement is explicitly documentation-only
-   - Confirm implementation does not add hidden scope that contradicts the original request
+   - Confirm implementation does not add hidden scope that contradicts the original request, source design, spec, or relevant repo guidance
 
 5. **Run verification commands when available**:
    - Run unit test commands from `plan.md`, `tasks.md`, or project conventions
@@ -95,9 +100,9 @@ This command is the final MoonSpec check. It verifies that the completed impleme
      - `VERIFIED`: implementation and validation evidence satisfy the item
      - `PARTIAL`: some implementation exists, but behavior, wiring, or test coverage is incomplete
      - `MISSING`: no meaningful implementation evidence exists
-     - `CONFLICT`: implementation contradicts the spec, original request, source design, or constitution
+     - `CONFLICT`: implementation contradicts the spec, original request, source design, or relevant repo guidance
      - `NO_DETERMINATION`: the spec or repository evidence is too ambiguous to make a defensible call
-   - Do not mark the feature complete unless every in-scope `FR-*`, constitution constraint, and source design requirement is `VERIFIED`
+   - Do not mark the feature complete unless every in-scope `FR-*`, relevant AGENTS.md principle, and source design requirement is `VERIFIED`
    - Missing scenario-driven unit or integration coverage for required behavior is at least a high-severity gap
    - Separate missing implementation from missing validation when both matter
 
@@ -107,7 +112,7 @@ This command is the final MoonSpec check. It verifies that the completed impleme
    - Check whether assumptions made during specification still hold
    - Check whether integration tests cover the end-to-end behavior implied by the original request
    - Treat missing required unit or integration tests as a verification failure unless the spec explicitly makes that class irrelevant
-   - Treat violated constitution `MUST` rules as blocking failures
+   - Treat violated AGENTS.md `MUST` rules as blocking failures
 
 8. **Produce the final verification report**:
 
@@ -138,11 +143,11 @@ This command is the final MoonSpec check. It verifies that the completed impleme
    | Scenario | Evidence | Status | Notes |
    |----------|----------|--------|-------|
 
-   ## Constitution And Source Design Coverage
+   ## Story Scope, Principles, And Source Claim Coverage
 
    | Item | Evidence | Status | Notes |
    |------|----------|--------|-------|
-   | DESIGN-REQ-001 / CC-001 | [file/test/reference] | VERIFIED/PARTIAL/MISSING/CONFLICT/NO_DETERMINATION | [notes] |
+   | DOC-REQ-001 / AGENTS.md principle | [file/test/reference] | VERIFIED/PARTIAL/MISSING/CONFLICT/NO_DETERMINATION | [notes] |
 
    ## Original Request Alignment
 
@@ -158,7 +163,7 @@ This command is the final MoonSpec check. It verifies that the completed impleme
 
    ## Decision
 
-   - FULLY_IMPLEMENTED only if implementation, unit tests, integration tests, source design requirements, constitution constraints, and original request alignment all verify.
+   - FULLY_IMPLEMENTED only if implementation, unit tests, integration tests, in-scope source claims, relevant AGENTS.md principles, and original request alignment all verify.
    ```
 
 9. **Report completion**:
@@ -169,40 +174,25 @@ This command is the final MoonSpec check. It verifies that the completed impleme
 ## Post-Execution Checks
 
 **Check for extension hooks (after final verification)**:
-Check if `.specify/extensions.yml` exists in the project root.
+- Check if `.specify/extensions.yml` exists in the project root.
 - If it exists, read it and look for entries under the `hooks.after_verify` key
 - If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
 - Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
 - For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
   - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
   - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
-- For each executable hook, output the following based on its `optional` flag:
-  - **Optional hook** (`optional: true`):
-    ```
-    ## Extension Hooks
-
-    **Optional Hook**: {extension}
-    Command: `/{command}`
-    Description: {description}
-
-    Prompt: {prompt}
-    To execute: `/{command}`
-    ```
-  - **Mandatory hook** (`optional: false`):
-    ```
-    ## Extension Hooks
-
-    **Automatic Hook**: {extension}
-    Executing: `/{command}`
-    EXECUTE_COMMAND: {command}
-    ```
+- For executable hooks:
+  - Optional hooks: report the hook command and prompt.
+  - Mandatory hooks: output `EXECUTE_COMMAND: {command}` and execute or delegate it.
 - If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently
 
 ## Key Rules
 
 - Verification is read-only except for normal test artifacts.
-- The original request in `spec.md` is the source of truth for final alignment.
-- `spec.md` plus `.specify/memory/constitution.md` define the governing requirements.
+- `spec.md` defines the bounded one-story verification scope and preserves the original request/source packet.
+- When `spec.md` names a canonical source document, interpret the story against that document's in-scope stable claims; the canonical document remains the durable desired-state authority unless verified drift is handed off to doc reconciliation.
+- Do not require unrelated claims from a larger canonical design to verify for this story, but do not let the temporary spec silently override an in-scope canonical conflict.
+- Relevant AGENTS.md guidance defines repo principles, constraints, and test discipline for the story.
 - `plan.md` and `tasks.md` are useful context but never proof of implementation.
 - Unit tests and integration tests are both expected evidence.
 - Prefer direct, citeable repository evidence from production code, wiring, configuration, and tests.

--- a/.specify/templates/plan-template.md
+++ b/.specify/templates/plan-template.md
@@ -30,11 +30,11 @@
 **Constraints**: [domain-specific, e.g., <200ms p95, <100MB memory, offline-capable or NEEDS CLARIFICATION]  
 **Scale/Scope**: [domain-specific, e.g., 10k users, 1M LOC, 50 screens or NEEDS CLARIFICATION]
 
-## Constitution Check
+## Principles Check
 
 *GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
 
-[Gates determined based on constitution file]
+[Relevant principles, testing discipline, and repo constraints from AGENTS.md]
 
 ## Project Structure
 
@@ -99,7 +99,7 @@ directories captured above]
 
 ## Complexity Tracking
 
-> **Fill ONLY if Constitution Check has violations that must be justified**
+> **Fill ONLY if Principles Check has violations that must be justified**
 
 | Violation | Why Needed | Simpler Alternative Rejected Because |
 |-----------|------------|-------------------------------------|

--- a/api_service/data/presets/github-issue-breakdown-implement.yaml
+++ b/api_service/data/presets/github-issue-breakdown-implement.yaml
@@ -1,0 +1,135 @@
+slug: github-issue-breakdown-implement
+title: Breakdown and GitHub Issue Implement
+description: Break a preferred source input into stories, create GitHub issues, then create dependent GitHub Issue Implement workflow executions for each generated issue.
+scope: global
+tags:
+  - github
+  - moonspec
+  - breakdown
+  - implement
+requiredCapabilities:
+  - git
+  - gh
+annotations:
+  sourceSkill: moonspec-breakdown
+  githubIssueWorkflow: breakdown-to-dependent-implement
+  output: dependent-github-issue-implement-workflows
+  sourceReference: MM-1063
+inputs:
+  - name: feature_request
+    label: Workflow Instructions
+    type: markdown
+    required: false
+    default: ""
+  - name: source_design_path
+    label: Source Document Path
+    type: repo_path
+    required: false
+    default: ""
+  - name: github_repository
+    label: GitHub Repository
+    type: text
+    required: true
+    default: ""
+  - name: github_labels
+    label: GitHub Labels
+    type: text
+    required: false
+    default: ""
+  - name: publish_mode
+    label: Publish Mode
+    type: enum
+    required: true
+    default: pr_with_merge_automation
+    options:
+      - pr
+      - pr_with_merge_automation
+steps:
+  - title: Break down preferred source input
+    instructions: |-
+      Run moonspec-breakdown using this input preference chain:
+
+      1. If Source document path is non-empty, read that repo path and use it as the source design.
+      2. Otherwise, use Workflow instructions as the source design.
+
+      Source document path:
+      {{ inputs.source_design_path }}
+
+      Workflow instructions:
+      {{ inputs.feature_request }}
+
+      If the selected input is a readable repo path under docs/ (except docs/tmp/) or AGENTS.md, use that file as the canonical declarative document and preserve its path plus stable canonical claim IDs in every story's sourceReference.path and sourceReference.claimIds.
+      If the selected input is a non-canonical file-backed source, preserve that source path in source.path, source.referencePath, and story sourceReference.path, record sourceReference.claimIds as an empty list, and use sourceReference.coverageIds for run-local traceability.
+      If the selected input is workflow instructions without a readable path, preserve those instructions as inline source text, set source.path and source.referencePath to null, set each story's sourceReference.path to null, and set sourceReference.claimIds to an empty list.
+      The canonical declarative document is the primary source of truth; the breakdown output is a temporary derived view (see docs/Workflows/MoonSpecDocumentModel.md).
+      Classify the selected input before extracting stories. Prefer declarative sources when one is selected or resolved. If the selected input is primarily framed as steps, phases, recommendations, checklist items, status, or a roadmap, record sourceDocumentClass as imperative-input and decompose the underlying actionable desired system behavior into GitHub-ready MoonSpec stories instead of failing solely because the source is imperative. Otherwise record sourceDocumentClass as canonical-declarative or declarative-text as appropriate.
+      Record sourceDocumentClass in the breakdown output.
+      Write the coverage-checked story breakdown to the runtime-provided story breakdown paths.
+    skill:
+      id: moonspec-breakdown
+      args: {}
+      requiredCapabilities:
+        - git
+  - title: Reconcile stories with current implementation
+    instructions: |-
+      Use story-reconcile-implementation to compare the generated MoonSpec story breakdown against the current repository implementation before any GitHub issue creation occurs.
+
+      Read the runtime-provided story breakdown JSON path and rewrite that same JSON handoff with implementationStatus and jiraCreation fields for every story.
+      Mark fully implemented stories with jiraCreation.action = "skip" so no GitHub issue or downstream GitHub Issue Implement workflow execution is created for completed work.
+      For partially implemented stories, preserve the original story scope and add remainingWork so GitHub tracks only the unmet requirements.
+      Mark unverifiable stories with jiraCreation.action = "manual_review" so deterministic GitHub issue creation will not create implementation work automatically.
+      Write the reconciliation report to the runtime-provided markdown breakdown path when available.
+      Do not create GitHub issues, do not create downstream workflow executions, and do not implement code in this reconciliation step.
+    skill:
+      id: story-reconcile-implementation
+      args: {}
+      requiredCapabilities:
+        - git
+  - title: Create GitHub issues
+    instructions: |-
+      Create one GitHub issue in {{ inputs.github_repository }} for each eligible story from the reconciled MoonSpec breakdown.
+
+      Use the runtime-provided story breakdown JSON path.
+      Every GitHub issue must include the Source Document path and canonical claim IDs from the story breakdown when present; otherwise include the source title.
+      Do not create GitHub issues for stories where jiraCreation.action is skip or manual_review.
+      For stories where jiraCreation.action is create_remaining_work_issue, create the GitHub issue from the story's remainingWork while preserving the original story traceability.
+      Apply these comma-separated labels when provided: {{ inputs.github_labels }}.
+      Return the created GitHub issue numbers, URLs, source traceability, skipped stories, and blocked stories.
+    storyOutput:
+      mode: github
+      fallback: fail
+      github:
+        repository: "{{ inputs.github_repository }}"
+        labels: "{{ inputs.github_labels }}"
+        dependencyMode: none
+    skill:
+      id: story.create_github_issues
+      requiredCapabilities:
+        - gh
+      args: {}
+  - title: Create dependent GitHub Issue Implement workflow executions
+    instructions: |-
+      Create one GitHub Issue Implement workflow execution for each GitHub issue created from the trusted GitHub story output.
+
+      Use the ordered issue mappings returned by story.create_github_issues. Preserve the generated story order when creating downstream workflow executions.
+      Do not create downstream workflow executions for skipped fully implemented stories or manual-review stories that did not produce GitHub issue mappings.
+      Each downstream workflow execution must run GitHub Issue Implement on its corresponding GitHub issue and must not run implementation inline inside this breakdown run.
+      Create workflow dependencies with dependsOn so each later generated workflow execution waits for the immediately earlier generated workflow ID.
+      Preserve the original source brief in downstream workflow instructions and result traceability.
+      Report created workflow executions, skipped stories, dependency edges, partial failures, and no-downstream-workflow outcomes honestly.
+    githubOrchestration:
+      task:
+        repository: "{{ inputs.github_repository }}"
+        runtime:
+          mode: "{{ context.targetRuntime }}"
+        publish:
+          mode: "pr"
+          mergeAutomation:
+            enabled: "{{ inputs.publish_mode == 'pr_with_merge_automation' }}"
+      traceability:
+        sourceIssueKey: MM-1063
+    skill:
+      id: story.create_github_issue_implement_workflows
+      requiredCapabilities:
+        - gh
+      args: {}

--- a/api_service/data/presets/github-issue-breakdown-implement.yaml
+++ b/api_service/data/presets/github-issue-breakdown-implement.yaml
@@ -14,7 +14,6 @@ annotations:
   sourceSkill: moonspec-breakdown
   githubIssueWorkflow: breakdown-to-dependent-implement
   output: dependent-github-issue-implement-workflows
-  sourceReference: MM-1063
 inputs:
   - name: feature_request
     label: Workflow Instructions
@@ -126,8 +125,6 @@ steps:
           mode: "pr"
           mergeAutomation:
             enabled: "{{ inputs.publish_mode == 'pr_with_merge_automation' }}"
-      traceability:
-        sourceIssueKey: MM-1063
     skill:
       id: story.create_github_issue_implement_workflows
       requiredCapabilities:

--- a/api_service/data/presets/github-issue-breakdown-orchestrate.yaml
+++ b/api_service/data/presets/github-issue-breakdown-orchestrate.yaml
@@ -14,7 +14,6 @@ annotations:
   sourceSkill: moonspec-breakdown
   githubIssueWorkflow: breakdown-to-dependent-orchestrate
   output: dependent-github-issue-orchestrate-workflows
-  sourceReference: MM-1063
 inputs:
   - name: feature_request
     label: Workflow Instructions
@@ -127,8 +126,6 @@ steps:
           mode: "pr"
           mergeAutomation:
             enabled: "{{ inputs.publish_mode == 'pr_with_merge_automation' }}"
-      traceability:
-        sourceIssueKey: MM-1063
     skill:
       id: story.create_github_issue_orchestrate_workflows
       requiredCapabilities:

--- a/api_service/data/presets/github-issue-breakdown-orchestrate.yaml
+++ b/api_service/data/presets/github-issue-breakdown-orchestrate.yaml
@@ -1,0 +1,136 @@
+slug: github-issue-breakdown-orchestrate
+title: Breakdown and GitHub Issue Orchestrate
+description: Break a preferred source input into stories, create GitHub issues, then create dependent GitHub Issue Orchestrate workflow executions for each generated issue.
+scope: global
+tags:
+  - github
+  - moonspec
+  - breakdown
+  - orchestration
+requiredCapabilities:
+  - git
+  - gh
+annotations:
+  sourceSkill: moonspec-breakdown
+  githubIssueWorkflow: breakdown-to-dependent-orchestrate
+  output: dependent-github-issue-orchestrate-workflows
+  sourceReference: MM-1063
+inputs:
+  - name: feature_request
+    label: Workflow Instructions
+    type: markdown
+    required: false
+    default: ""
+  - name: source_design_path
+    label: Source Document Path
+    type: repo_path
+    required: false
+    default: ""
+  - name: github_repository
+    label: GitHub Repository
+    type: text
+    required: true
+    default: ""
+  - name: github_labels
+    label: GitHub Labels
+    type: text
+    required: false
+    default: ""
+  - name: publish_mode
+    label: Publish Mode
+    type: enum
+    required: true
+    default: pr_with_merge_automation
+    options:
+      - pr
+      - pr_with_merge_automation
+steps:
+  - title: Break down preferred source input
+    instructions: |-
+      Run moonspec-breakdown using this input preference chain:
+
+      1. If Source document path is non-empty, read that repo path and use it as the source design.
+      2. Otherwise, use Workflow instructions as the source design.
+
+      Source document path:
+      {{ inputs.source_design_path }}
+
+      Workflow instructions:
+      {{ inputs.feature_request }}
+
+      If the selected input is a readable repo path under docs/ (except docs/tmp/) or AGENTS.md, use that file as the canonical declarative document and preserve its path plus stable canonical claim IDs in every story's sourceReference.path and sourceReference.claimIds.
+      If the selected input is a non-canonical file-backed source, preserve that source path in source.path, source.referencePath, and story sourceReference.path, record sourceReference.claimIds as an empty list, and use sourceReference.coverageIds for run-local traceability.
+      If the selected input is workflow instructions without a readable path, preserve those instructions as inline source text, set source.path and source.referencePath to null, set each story's sourceReference.path to null, and set sourceReference.claimIds as an empty list.
+      The canonical declarative document is the primary source of truth; the breakdown output is a temporary derived view (see docs/Workflows/MoonSpecDocumentModel.md).
+      Classify the selected input before extracting stories. Prefer declarative sources when one is selected or resolved. If the selected input is primarily framed as steps, phases, recommendations, checklist items, status, or a roadmap, record sourceDocumentClass as imperative-input and decompose the underlying actionable desired system behavior into GitHub-ready MoonSpec stories instead of failing solely because the source is imperative. Otherwise record sourceDocumentClass as canonical-declarative or declarative-text as appropriate.
+      Record sourceDocumentClass in the breakdown output.
+      Write the coverage-checked story breakdown to the runtime-provided story breakdown paths.
+    skill:
+      id: moonspec-breakdown
+      args: {}
+      requiredCapabilities:
+        - git
+  - title: Reconcile stories with current implementation
+    instructions: |-
+      Use story-reconcile-implementation to compare the generated MoonSpec story breakdown against the current repository implementation before any GitHub issue creation occurs.
+
+      Read the runtime-provided story breakdown JSON path and rewrite that same JSON handoff with implementationStatus and jiraCreation fields for every story.
+      Mark fully implemented stories with jiraCreation.action = "skip" so no GitHub issue or downstream GitHub Issue Orchestrate workflow execution is created for completed work.
+      For partially implemented stories, preserve the original story scope and add remainingWork so GitHub tracks only the unmet requirements.
+      Mark unverifiable stories with jiraCreation.action = "manual_review" so deterministic GitHub issue creation will not create orchestration work automatically.
+      Write the reconciliation report to the runtime-provided markdown breakdown path when available.
+      Do not create GitHub issues, do not create downstream workflow executions, and do not implement code in this reconciliation step.
+    skill:
+      id: story-reconcile-implementation
+      args: {}
+      requiredCapabilities:
+        - git
+  - title: Create GitHub issues
+    instructions: |-
+      Create one GitHub issue in {{ inputs.github_repository }} for each eligible story from the reconciled MoonSpec breakdown.
+
+      Use the runtime-provided story breakdown JSON path.
+      Every GitHub issue must include the Source Document path and canonical claim IDs from the story breakdown when present; otherwise include the source title.
+      Do not create GitHub issues for stories where jiraCreation.action is skip or manual_review.
+      For stories where jiraCreation.action is create_remaining_work_issue, create the GitHub issue from the story's remainingWork while preserving the original story traceability.
+      Apply these comma-separated labels when provided: {{ inputs.github_labels }}.
+      Return the created GitHub issue numbers, URLs, source traceability, skipped stories, and blocked stories.
+    storyOutput:
+      mode: github
+      fallback: fail
+      github:
+        repository: "{{ inputs.github_repository }}"
+        labels: "{{ inputs.github_labels }}"
+        dependencyMode: none
+    skill:
+      id: story.create_github_issues
+      requiredCapabilities:
+        - gh
+      args: {}
+  - title: Create dependent GitHub Issue Orchestrate workflow executions
+    instructions: |-
+      Create one GitHub Issue Orchestrate workflow execution for each GitHub issue created from the trusted GitHub story output.
+
+      Use the ordered issue mappings returned by story.create_github_issues. Preserve the generated story order when creating downstream workflow executions.
+      Each downstream workflow execution must carry the story's sourceReference.path as its source_design_path input when present so the downstream GitHub Issue Orchestrate doc-reconciliation step knows the canonical source document. If the source path is absent because the story came from workflow instructions, preserve the source title instead of inventing a document path.
+      Do not create downstream workflow executions for skipped fully implemented stories or manual-review stories that did not produce GitHub issue mappings.
+      Each downstream workflow execution must run GitHub Issue Orchestrate on its corresponding GitHub issue and must not run implementation inline inside this breakdown run.
+      Create workflow dependencies with dependsOn so each later generated workflow execution waits for the immediately earlier generated workflow ID.
+      Preserve the original source brief in downstream workflow instructions and result traceability.
+      Report created workflow executions, skipped stories, dependency edges, partial failures, and no-downstream-workflow outcomes honestly.
+    githubOrchestration:
+      task:
+        repository: "{{ inputs.github_repository }}"
+        runtime:
+          mode: "{{ context.targetRuntime }}"
+        publish:
+          mode: "pr"
+          mergeAutomation:
+            enabled: "{{ inputs.publish_mode == 'pr_with_merge_automation' }}"
+      traceability:
+        sourceIssueKey: MM-1063
+    skill:
+      id: story.create_github_issue_orchestrate_workflows
+      requiredCapabilities:
+        - gh
+      args: {}

--- a/api_service/data/presets/github-issue-implement.yaml
+++ b/api_service/data/presets/github-issue-implement.yaml
@@ -46,7 +46,7 @@ annotations:
       github_issue:
         type: object
         title: GitHub issue
-        description: Issue that will seed the task instructions and implementation
+        description: Issue that will seed the workflow instructions and implementation
           context.
         required:
         - repository

--- a/api_service/data/presets/github-issue-orchestrate.yaml
+++ b/api_service/data/presets/github-issue-orchestrate.yaml
@@ -47,7 +47,7 @@ annotations:
       github_issue:
         type: object
         title: GitHub issue
-        description: Issue that will seed the task instructions and orchestration context.
+        description: Issue that will seed the workflow instructions and orchestration context.
         required:
         - repository
         - number
@@ -171,7 +171,7 @@ steps:
       assessmentArtifactPath: artifacts/github-issue-orchestrate-assessment.json
 - title: Classify request and resume point
   instructions: 'Use the GitHub issue preset brief for {{ inputs.github_issue.repository }}#{{
-    inputs.github_issue.number }} as the canonical Moon Spec orchestration input.
+    inputs.github_issue.number }} as the canonical MoonSpec orchestration input.
 
 
     Additional constraints:
@@ -191,12 +191,12 @@ steps:
     Classify the input as a single-story feature request, broad technical or declarative design,
     or existing feature directory.
 
-    Inspect existing Moon Spec artifacts and resume from the first incomplete stage instead
+    Inspect existing MoonSpec artifacts and resume from the first incomplete stage instead
     of regenerating valid later-stage artifacts.'
   skill:
     id: auto
     args: {}
-- title: Create or select Moon Spec
+- title: Create or select MoonSpec
   instructions: 'For a single-story GitHub issue preset brief, run moonspec-specify unless
     an active spec.md already passes the specify gate.
 
@@ -239,7 +239,7 @@ steps:
   skill:
     id: moonspec-tasks
     args: {}
-- title: Align Moon Spec artifacts
+- title: Align MoonSpec artifacts
   instructions: 'Run moonspec-align after task generation.
 
     Let moonspec-align analyze and remediate artifact drift conservatively without manual
@@ -772,9 +772,9 @@ steps:
     update so the confirmed pull request URL is available to both GitHub issue lifecycle handling
     and MoonMind publish handling. If generic managed-runtime guidance says not to push or
     create a pull request, treat this step-specific handoff instruction as the controlling
-    instruction for this step only. If the task is submitted with PR merge automation enabled,
+    instruction for this step only. If the workflow is submitted with PR merge automation enabled,
     the parent workflow must use the pull request URL produced by this step as the published
-    PR and then run merge automation against that PR. If the runtime instructions, task parameters,
+    PR and then run merge automation against that PR. If the runtime instructions, workflow parameters,
     authentication, remote configuration, branch protection, or repository permissions prevent
     committing, pushing, or creating the pull request in this step, stop before changing GitHub
     issue status to Code Review and report the exact blocker.

--- a/api_service/data/presets/issue-implement-work-pr.yaml
+++ b/api_service/data/presets/issue-implement-work-pr.yaml
@@ -104,8 +104,11 @@ steps:
     the blocking evidence from the assessment.
 
 
-    Otherwise verify that the implementation for {{ inputs.issue_provider }} issue
-    {{ inputs.issue_ref }} satisfies the loaded preset brief and acceptance criteria.
+    Otherwise run moonspec-verify in issue-brief verification mode for {{ inputs.issue_provider
+    }} issue {{ inputs.issue_ref }}. Use {{ inputs.brief_artifact_path }} as the
+    authoritative issue brief and {{ inputs.assessment_artifact_path }} as the initial
+    state assessment. Do not require a MoonSpec feature directory, spec.md, plan.md,
+    or tasks.md for this issue-brief verification mode.
 
 
     Re-read the issue preset brief and confirm every required behavior change is implemented
@@ -113,11 +116,20 @@ steps:
     brief or implied by the changed code paths.
 
 
-    If gaps remain, fix them now before proceeding to pull request creation. Do not
-    create a pull request until the implementation matches the brief and the relevant
-    tests pass.'
+    If verification returns ADDITIONAL_WORK_NEEDED, produce structured remaining
+    work with implementation gaps, verification gaps, required tests, and concrete
+    next files or commands so remediation can consume it. Fix those gaps before
+    proceeding to pull request creation.
+
+
+    If verification returns NO_DETERMINATION, BLOCKED, FAILED_UNRECOVERABLE, or
+    ENVIRONMENT_CONTAMINATED_BY_SKILL_PROJECTION, stop and report the terminal evidence.
+
+
+    Do not create a pull request until the controlling moonspec-verify verdict is
+    FULLY_IMPLEMENTED and the relevant tests pass.'
   skill:
-    id: auto
+    id: moonspec-verify
     args: {}
     requiredCapabilities:
     - git
@@ -139,7 +151,10 @@ steps:
 
 
     Otherwise create a pull request for the completed work for {{ inputs.issue_provider
-    }} issue {{ inputs.issue_ref }}.
+    }} issue {{ inputs.issue_ref }} only after the immediately preceding controlling
+    moonspec-verify verdict is FULLY_IMPLEMENTED. If the verifier reported ADDITIONAL_WORK_NEEDED,
+    NO_DETERMINATION, BLOCKED, FAILED_UNRECOVERABLE, or ENVIRONMENT_CONTAMINATED_BY_SKILL_PROJECTION,
+    stop without creating a pull request and report the verifier evidence.
 
 
     This Issue Implement handoff step is the explicit PR-publication step for this
@@ -147,12 +162,12 @@ steps:
     }} code review transition so the confirmed pull request URL is available to both
     {{ inputs.issue_provider }} and MoonMind publish handling. If generic managed-runtime
     guidance says not to push or create a pull request, treat this step-specific handoff
-    instruction as the controlling instruction for this step only. If the task is
+    instruction as the controlling instruction for this step only. If the workflow is
     submitted with PR merge automation enabled, the parent workflow must use the pull
     request URL produced by this step as the published PR and then run merge automation
     against that PR; on a successful merge the parent workflow will transition {{
     inputs.issue_provider }} issue {{ inputs.issue_ref }} to Done automatically. If
-    the runtime instructions, task parameters, authentication, remote configuration,
+    the runtime instructions, workflow parameters, authentication, remote configuration,
     branch protection, or repository permissions prevent committing, pushing, or creating
     the pull request in this step, stop before changing Jira to Review and report
     the exact blocker.

--- a/api_service/data/presets/issue-implement-work-pr.yaml
+++ b/api_service/data/presets/issue-implement-work-pr.yaml
@@ -118,8 +118,8 @@ steps:
 
     If verification returns ADDITIONAL_WORK_NEEDED, produce structured remaining
     work with implementation gaps, verification gaps, required tests, and concrete
-    next files or commands so remediation can consume it. Fix those gaps before
-    proceeding to pull request creation.
+    next files or commands so the following remediation step can consume it. Do
+    not modify source code or tests in this read-only verification step.
 
 
     If verification returns NO_DETERMINATION, BLOCKED, FAILED_UNRECOVERABLE, or
@@ -128,6 +128,63 @@ steps:
 
     Do not create a pull request until the controlling moonspec-verify verdict is
     FULLY_IMPLEMENTED and the relevant tests pass.'
+  skill:
+    id: moonspec-verify
+    args: {}
+    requiredCapabilities:
+    - git
+- title: Remediate verification gaps
+  instructions: 'Inspect the latest moonspec-verify result for {{ inputs.issue_provider
+    }} issue {{ inputs.issue_ref }} before doing any work.
+
+
+    If the latest verdict is FULLY_IMPLEMENTED, make no code changes and report
+    that remediation is skipped because verification already passed.
+
+
+    If the latest verdict is ADDITIONAL_WORK_NEEDED, treat the verification report''s
+    gaps and remaining work as the authoritative bounded implementation backlog.
+    Fix only those reported implementation or verification gaps, update or add the
+    required tests, and run the focused checks named by the verification report when
+    feasible.
+
+
+    If the latest verdict is NO_DETERMINATION, only proceed when the missing evidence
+    is recoverable in this runtime, such as by running a skipped command or inspecting
+    available files. Otherwise stop and report the exact blocker. If the latest verdict
+    is BLOCKED, FAILED_UNRECOVERABLE, or ENVIRONMENT_CONTAMINATED_BY_SKILL_PROJECTION,
+    treat it as terminal for issue implementation remediation and do not create a
+    pull request.
+
+
+    Do not broaden the issue scope, do not create a pull request, and do not change
+    {{ inputs.issue_provider }} issue status during remediation.'
+  skill:
+    id: auto
+    args: {}
+    requiredCapabilities:
+    - git
+- title: Verify remediation
+  instructions: 'Read {{ inputs.assessment_artifact_path }} and inspect the latest
+    remediation result before doing anything.
+
+
+    Run moonspec-verify in issue-brief verification mode for {{ inputs.issue_provider
+    }} issue {{ inputs.issue_ref }} after remediation, even when remediation was
+    skipped because the prior verdict was FULLY_IMPLEMENTED. Use {{ inputs.brief_artifact_path
+    }} as the authoritative issue brief and {{ inputs.assessment_artifact_path }}
+    as the initial state assessment.
+
+
+    This is the controlling verification gate for pull request creation. If the verdict
+    is ADDITIONAL_WORK_NEEDED or NO_DETERMINATION, stop and report the gaps or missing
+    evidence; do not continue to pull request creation. If the verdict is BLOCKED,
+    FAILED_UNRECOVERABLE, or ENVIRONMENT_CONTAMINATED_BY_SKILL_PROJECTION, classify
+    runtime or infrastructure causes as environment failure, stop immediately, and
+    do not create a pull request.
+
+
+    Continue to pull request creation only when this post-remediation verdict is FULLY_IMPLEMENTED.'
   skill:
     id: moonspec-verify
     args: {}
@@ -151,8 +208,8 @@ steps:
 
 
     Otherwise create a pull request for the completed work for {{ inputs.issue_provider
-    }} issue {{ inputs.issue_ref }} only after the immediately preceding controlling
-    moonspec-verify verdict is FULLY_IMPLEMENTED. If the verifier reported ADDITIONAL_WORK_NEEDED,
+    }} issue {{ inputs.issue_ref }} only after the controlling post-remediation moonspec-verify
+    verdict is FULLY_IMPLEMENTED. If the verifier reported ADDITIONAL_WORK_NEEDED,
     NO_DETERMINATION, BLOCKED, FAILED_UNRECOVERABLE, or ENVIRONMENT_CONTAMINATED_BY_SKILL_PROJECTION,
     stop without creating a pull request and report the verifier evidence.
 

--- a/api_service/data/presets/jira-breakdown-implement.yaml
+++ b/api_service/data/presets/jira-breakdown-implement.yaml
@@ -1,6 +1,6 @@
 slug: jira-breakdown-implement
 title: Breakdown and Jira Implement
-description: Break a preferred source input into stories, create Jira issues, then create dependent Jira Implement tasks for each generated issue.
+description: Break a preferred source input into stories, create Jira issues, then create dependent Jira Implement workflow executions for each generated issue.
 scope: global
 tags:
   - jira
@@ -13,7 +13,7 @@ requiredCapabilities:
 annotations:
   sourceSkill: jira-breakdown
   jiraWorkflow: breakdown-to-dependent-implement
-  output: dependent-jira-implement-tasks
+  output: dependent-jira-implement-workflows
 inputs:
   - name: feature_request
     label: Workflow Instructions
@@ -110,11 +110,11 @@ steps:
       Use story-reconcile-implementation to compare the generated MoonSpec story breakdown against the current repository implementation before any Jira issue creation occurs.
 
       Read the runtime-provided story breakdown JSON path and rewrite that same JSON handoff with implementationStatus and jiraCreation fields for every story.
-      Mark fully implemented stories with jiraCreation.action = "skip" so no Jira issue or downstream Jira Implement task is created for completed work.
+      Mark fully implemented stories with jiraCreation.action = "skip" so no Jira issue or downstream Jira Implement workflow execution is created for completed work.
       For partially implemented stories, preserve the original story scope and add remainingWork so Jira tracks only the unmet requirements.
       Mark unverifiable stories with jiraCreation.action = "manual_review" so deterministic Jira creation will not create implementation work automatically.
       Write the reconciliation report to the runtime-provided markdown breakdown path when available.
-      Do not create Jira issues, do not create implementation tasks, and do not implement code in this reconciliation step.
+      Do not create Jira issues, do not create downstream workflow executions, and do not implement code in this reconciliation step.
     skill:
       id: story-reconcile-implementation
       args: {}
@@ -147,16 +147,16 @@ steps:
       requiredCapabilities:
         - jira
       args: {}
-  - title: Create dependent Jira Implement tasks
+  - title: Create dependent Jira Implement workflow executions
     instructions: |-
-      Create one Jira Implement task for each Jira issue created from the trusted Jira story output.
+      Create one Jira Implement workflow execution for each Jira issue created from the trusted Jira story output.
 
-      Use the ordered issue mappings returned by story.create_jira_issues. Preserve the generated story order when creating downstream tasks.
-      Do not create downstream tasks for skipped fully implemented stories or manual-review stories that did not produce Jira issue mappings.
-      Each downstream task must run Jira Implement on its corresponding Jira story issue and must not run implementation inline inside this breakdown run.
-      Create task dependencies with dependsOn so each later generated task waits for the immediately earlier generated task workflow ID.
-      Preserve source Jira issue {{ inputs.source_issue_key }} and the original source brief in downstream task instructions and result traceability.
-      Report created tasks, skipped stories, dependency edges, partial failures, and no-downstream-task outcomes honestly.
+      Use the ordered issue mappings returned by story.create_jira_issues. Preserve the generated story order when creating downstream workflow executions.
+      Do not create downstream workflow executions for skipped fully implemented stories or manual-review stories that did not produce Jira issue mappings.
+      Each downstream workflow execution must run Jira Implement on its corresponding Jira story issue and must not run implementation inline inside this breakdown run.
+      Create workflow dependencies with dependsOn so each later generated workflow execution waits for the immediately earlier generated workflow ID.
+      Preserve source Jira issue {{ inputs.source_issue_key }} and the original source brief in downstream workflow instructions and result traceability.
+      Report created workflow executions, skipped stories, dependency edges, partial failures, and no-downstream-workflow outcomes honestly.
     jiraOrchestration:
       task:
         repository: "{{ context.repository }}"

--- a/api_service/data/presets/jira-breakdown-orchestrate.yaml
+++ b/api_service/data/presets/jira-breakdown-orchestrate.yaml
@@ -1,6 +1,6 @@
 slug: jira-breakdown-orchestrate
 title: Breakdown and Jira Orchestrate
-description: Break a preferred source input into stories, create Jira issues, then create dependent Jira Orchestrate tasks for each generated issue.
+description: Break a preferred source input into stories, create Jira issues, then create dependent Jira Orchestrate workflow executions for each generated issue.
 scope: global
 tags:
   - jira
@@ -13,7 +13,7 @@ requiredCapabilities:
 annotations:
   sourceSkill: jira-breakdown
   jiraWorkflow: breakdown-to-dependent-orchestrate
-  output: dependent-jira-orchestrate-tasks
+  output: dependent-jira-orchestrate-workflows
 inputs:
   - name: feature_request
     label: Workflow Instructions
@@ -110,11 +110,11 @@ steps:
       Use story-reconcile-implementation to compare the generated MoonSpec story breakdown against the current repository implementation before any Jira issue creation occurs.
 
       Read the runtime-provided story breakdown JSON path and rewrite that same JSON handoff with implementationStatus and jiraCreation fields for every story.
-      Mark fully implemented stories with jiraCreation.action = "skip" so no Jira issue or downstream Jira Orchestrate task is created for completed work.
+      Mark fully implemented stories with jiraCreation.action = "skip" so no Jira issue or downstream Jira Orchestrate workflow execution is created for completed work.
       For partially implemented stories, preserve the original story scope and add remainingWork so Jira tracks only the unmet requirements.
       Mark unverifiable stories with jiraCreation.action = "manual_review" so deterministic Jira creation will not create implementation work automatically.
       Write the reconciliation report to the runtime-provided markdown breakdown path when available.
-      Do not create Jira issues, do not create implementation tasks, and do not implement code in this reconciliation step.
+      Do not create Jira issues, do not create downstream workflow executions, and do not implement code in this reconciliation step.
     skill:
       id: story-reconcile-implementation
       args: {}
@@ -147,17 +147,17 @@ steps:
       requiredCapabilities:
         - jira
       args: {}
-  - title: Create dependent Jira Orchestrate tasks
+  - title: Create dependent Jira Orchestrate workflow executions
     instructions: |-
-      Create one Jira Orchestrate task for each Jira issue created from the trusted Jira story output.
+      Create one Jira Orchestrate workflow execution for each Jira issue created from the trusted Jira story output.
 
-      Use the ordered issue mappings returned by story.create_jira_issues. Preserve the generated story order when creating downstream tasks.
-      Each downstream task must carry the story's sourceReference.path as its source_design_path input when present so the downstream Jira Orchestrate doc-reconciliation step knows the canonical source document. If the source path is absent because the story came from a trusted Jira issue description or workflow instructions, preserve the source title and source Jira issue traceability instead of inventing a document path.
-      Do not create downstream tasks for skipped fully implemented stories or manual-review stories that did not produce Jira issue mappings.
-      Each downstream task must run Jira Orchestrate on its corresponding Jira story issue and must not run implementation inline inside this breakdown run.
-      Create task dependencies with dependsOn so each later generated task waits for the immediately earlier generated task workflow ID.
-      Preserve source Jira issue {{ inputs.source_issue_key }} and the original source brief in downstream task instructions and result traceability.
-      Report created tasks, skipped stories, dependency edges, partial failures, and no-downstream-task outcomes honestly.
+      Use the ordered issue mappings returned by story.create_jira_issues. Preserve the generated story order when creating downstream workflow executions.
+      Each downstream workflow execution must carry the story's sourceReference.path as its source_design_path input when present so the downstream Jira Orchestrate doc-reconciliation step knows the canonical source document. If the source path is absent because the story came from a trusted Jira issue description or workflow instructions, preserve the source title and source Jira issue traceability instead of inventing a document path.
+      Do not create downstream workflow executions for skipped fully implemented stories or manual-review stories that did not produce Jira issue mappings.
+      Each downstream workflow execution must run Jira Orchestrate on its corresponding Jira story issue and must not run implementation inline inside this breakdown run.
+      Create workflow dependencies with dependsOn so each later generated workflow execution waits for the immediately earlier generated workflow ID.
+      Preserve source Jira issue {{ inputs.source_issue_key }} and the original source brief in downstream workflow instructions and result traceability.
+      Report created workflow executions, skipped stories, dependency edges, partial failures, and no-downstream-workflow outcomes honestly.
     jiraOrchestration:
       task:
         repository: "{{ context.repository }}"

--- a/api_service/data/presets/jira-implement.yaml
+++ b/api_service/data/presets/jira-implement.yaml
@@ -27,7 +27,7 @@ annotations:
       jira_issue:
         type: object
         title: Jira issue
-        description: Issue that will seed the task instructions and implementation
+        description: Issue that will seed the workflow instructions and implementation
           context.
         required:
         - key
@@ -233,11 +233,11 @@ steps:
     the confirmed status.
 
 
-    Note: when this task was submitted with PR merge automation enabled and the work
-    followed the Review path, the parent workflow will transition Jira issue
+    Note: when this workflow execution was submitted with PR merge automation enabled
+    and the work followed the Review path, the parent workflow will transition Jira issue
     {{ inputs.jira_issue_key }} to Done automatically after the pull request merges.
-    This in-task step only owns the explicit Done transition for the already-implemented
-    case and the Review transition for the freshly-implemented case.'
+    This preset step only owns the explicit Done transition for the already-implemented
+    case and the Review transition for the freshly implemented case.'
   skill:
     id: jira-issue-updater
     requiredCapabilities:

--- a/api_service/data/presets/jira-orchestrate.yaml
+++ b/api_service/data/presets/jira-orchestrate.yaml
@@ -23,7 +23,7 @@ annotations:
       jira_issue:
         type: object
         title: Jira issue
-        description: Issue that will seed the task instructions and orchestration context.
+        description: Issue that will seed the workflow instructions and orchestration context.
         required:
           - key
         properties:
@@ -129,7 +129,7 @@ steps:
         issueKey: "{{ inputs.jira_issue_key }}"
   - title: Classify request and resume point
     instructions: |-
-      Use the Jira preset brief for {{ inputs.jira_issue_key }} as the canonical Moon Spec orchestration input.
+      Use the Jira preset brief for {{ inputs.jira_issue_key }} as the canonical MoonSpec orchestration input.
 
       Additional constraints:
       {{ inputs.constraints }}
@@ -139,11 +139,11 @@ steps:
       Source design path (optional): {{ inputs.source_design_path }}.
 
       Classify the input as a single-story feature request, broad technical or declarative design, or existing feature directory.
-      Inspect existing Moon Spec artifacts and resume from the first incomplete stage instead of regenerating valid later-stage artifacts.
+      Inspect existing MoonSpec artifacts and resume from the first incomplete stage instead of regenerating valid later-stage artifacts.
     skill:
       id: auto
       args: {}
-  - title: Create or select Moon Spec
+  - title: Create or select MoonSpec
     instructions: |-
       For a single-story Jira preset brief, run moonspec-specify unless an active spec.md already passes the specify gate.
       For a broad technical or declarative design, run moonspec-breakdown first, then select the recommended first generated spec unless the issue brief explicitly requires processing all specs.
@@ -173,7 +173,7 @@ steps:
     skill:
       id: moonspec-tasks
       args: {}
-  - title: Align Moon Spec artifacts
+  - title: Align MoonSpec artifacts
     instructions: |-
       Run moonspec-align after task generation.
       Let moonspec-align analyze and remediate artifact drift conservatively without manual analyze prompts, scripted user approvals, or extra Prompt A/Prompt B loops.
@@ -473,7 +473,7 @@ steps:
 
       Before committing, inspect the latest post-remediation moonspec-verify result and confirm the verdict is FULLY_IMPLEMENTED. If the latest verdict is ADDITIONAL_WORK_NEEDED, NO_DETERMINATION, BLOCKED, FAILED_UNRECOVERABLE, or ENVIRONMENT_CONTAMINATED_BY_SKILL_PROJECTION, stop without committing, pushing, creating a pull request, or changing Jira. Classify runtime or infrastructure causes as environment failure.
 
-      This Jira Orchestrate handoff step is the explicit PR-publication step for this preset. It intentionally owns pull request creation before the Jira Review transition so the confirmed pull request URL is available to both Jira and MoonMind publish handling. If generic managed-runtime guidance says not to push or create a pull request, treat this step-specific handoff instruction as the controlling instruction for this step only. If the task is submitted with PR merge automation enabled, the parent workflow must use the pull request URL produced by this step as the published PR and then run merge automation against that PR. If the runtime instructions, task parameters, authentication, remote configuration, branch protection, or repository permissions prevent committing, pushing, or creating the pull request in this step, stop before changing Jira to Review and report the exact blocker.
+      This Jira Orchestrate handoff step is the explicit PR-publication step for this preset. It intentionally owns pull request creation before the Jira Review transition so the confirmed pull request URL is available to both Jira and MoonMind publish handling. If generic managed-runtime guidance says not to push or create a pull request, treat this step-specific handoff instruction as the controlling instruction for this step only. If the workflow is submitted with PR merge automation enabled, the parent workflow must use the pull request URL produced by this step as the published PR and then run merge automation against that PR. If the runtime instructions, workflow parameters, authentication, remote configuration, branch protection, or repository permissions prevent committing, pushing, or creating the pull request in this step, stop before changing Jira to Review and report the exact blocker.
 
       First confirm the working tree contains only intentional changes for this issue and no raw credentials. Commit the work with a concise message that includes {{ inputs.jira_issue_key }}. Push the current non-protected work branch and create a non-draft pull request with the available authenticated GitHub tooling.
 

--- a/api_service/services/presets/catalog.py
+++ b/api_service/services/presets/catalog.py
@@ -78,6 +78,12 @@ _JIRA_BREAKDOWN_IMPLEMENT_SLUG = "jira-breakdown-implement"
 _JIRA_BREAKDOWN_COMPOSITE_SLUGS = frozenset(
     {_JIRA_BREAKDOWN_ORCHESTRATE_SLUG, _JIRA_BREAKDOWN_IMPLEMENT_SLUG}
 )
+_GITHUB_ISSUE_BREAKDOWN_SLUGS = frozenset(
+    {
+        "github-issue-breakdown-implement",
+        "github-issue-breakdown-orchestrate",
+    }
+)
 _JIRA_BREAKDOWN_PROJECT_DEFAULT_SLUGS = frozenset(
     {
         _JIRA_BREAKDOWN_SLUG,
@@ -90,6 +96,10 @@ _JIRA_BREAKDOWN_REPLACEABLE_PROJECT_DEFAULTS = frozenset({"TOOL", "MM"})
 _JIRA_BREAKDOWN_SOURCE_INPUTS = (
     "source_design_path",
     "source_issue_key",
+    "feature_request",
+)
+_GITHUB_ISSUE_BREAKDOWN_SOURCE_INPUTS = (
+    "source_design_path",
     "feature_request",
 )
 _SLUG_PATTERN = re.compile(r"[^a-z0-9-]+")
@@ -678,24 +688,32 @@ def _preset_step_enabled(value: Any) -> bool:
         return False
     return True
 
-def _validate_jira_breakdown_source_inputs(
+def _validate_breakdown_source_inputs(
     *,
     slug: str,
     inputs: Mapping[str, Any],
 ) -> None:
-    if slug not in _JIRA_BREAKDOWN_PROJECT_DEFAULT_SLUGS:
+    if slug in _JIRA_BREAKDOWN_PROJECT_DEFAULT_SLUGS:
+        source_inputs = _JIRA_BREAKDOWN_SOURCE_INPUTS
+        provider_label = "Jira"
+        source_message = (
+            "Provide a Source Document Path, Source Jira Issue Key, "
+            "or Workflow Instructions."
+        )
+    elif slug in _GITHUB_ISSUE_BREAKDOWN_SLUGS:
+        source_inputs = _GITHUB_ISSUE_BREAKDOWN_SOURCE_INPUTS
+        provider_label = "GitHub issue"
+        source_message = "Provide a Source Document Path or Workflow Instructions."
+    else:
         return
-    if any(str(inputs.get(name) or "").strip() for name in _JIRA_BREAKDOWN_SOURCE_INPUTS):
+    if any(str(inputs.get(name) or "").strip() for name in source_inputs):
         return
     raise PresetValidationError(
-        "Jira breakdown presets require a source input.",
+        f"{provider_label} breakdown presets require a source input.",
         errors=[
             {
                 "path": "preset.inputs",
-                "message": (
-                    "Provide a Source Document Path, Source Jira Issue Key, "
-                    "or Workflow Instructions."
-                ),
+                "message": source_message,
                 "code": "required",
                 "recoverable": True,
             }
@@ -2082,7 +2100,7 @@ class PresetCatalogService:
             submitted=submitted_inputs,
             resolved=validated_inputs,
         )
-        _validate_jira_breakdown_source_inputs(
+        _validate_breakdown_source_inputs(
             slug=template.slug,
             inputs=validated_inputs,
         )

--- a/moonmind/agents/codex_worker/worker.py
+++ b/moonmind/agents/codex_worker/worker.py
@@ -5053,7 +5053,7 @@ class CodexWorker:
             sanitized = _FULL_UUID_PATTERN.sub("job", sanitized)
         sanitized = sanitized.strip()
         if not sanitized:
-            sanitized = "MoonMind task result"
+            sanitized = "MoonMind workflow result"
         if len(sanitized) <= max_chars:
             return sanitized
         return f"{sanitized[: max_chars - 3].rstrip()}..."
@@ -5076,7 +5076,9 @@ class CodexWorker:
         if candidate:
             return cls._sanitize_pr_title(candidate, redact_uuids=False)
 
-        return cls._sanitize_pr_title(f"MoonMind task result [mm:{str(job_id)[:8]}]")
+        return cls._sanitize_pr_title(
+            f"MoonMind workflow result [mm:{str(job_id)[:8]}]"
+        )
 
     @classmethod
     def _derive_default_jira_pr_title(
@@ -6084,7 +6086,7 @@ class CodexWorker:
 
             commit_message = (
                 self._resolve_publish_text_override(publish.get("commitMessage"))
-                or f"MoonMind task result for job {job_id}"
+                or f"MoonMind workflow result for job {job_id}"
             )
             await self._run_stage_command(
                 ["git", "commit", "-m", commit_message],

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -1863,7 +1863,7 @@ def _default_registry_skill_payload(*, name: str) -> dict[str, Any]:
     if name == "story.create_jira_issues":
         return {
             "name": name,
-            "description": "Create Jira issues from Moon Spec story breakdown output.",
+            "description": "Create Jira issues from MoonSpec story breakdown output.",
             "inputs": {
                 "schema": {
                     "type": "object",
@@ -1902,7 +1902,7 @@ def _default_registry_skill_payload(*, name: str) -> dict[str, Any]:
     if name == "story.create_github_issues":
         return {
             "name": name,
-            "description": "Create GitHub issues from Moon Spec story breakdown output.",
+            "description": "Create GitHub issues from MoonSpec story breakdown output.",
             "inputs": {
                 "schema": {
                     "type": "object",
@@ -9966,7 +9966,7 @@ class TemporalAgentRuntimeActivities:
         normalized_message = (
             str(commit_message).strip()
             if isinstance(commit_message, str) and commit_message.strip()
-            else f"MoonMind task result for run {run_id}"
+            else f"MoonMind workflow result for run {run_id}"
         )
         commit_proc = await asyncio.create_subprocess_exec(
             *self._workspace_git_command(

--- a/moonmind/workflows/temporal/worker_runtime.py
+++ b/moonmind/workflows/temporal/worker_runtime.py
@@ -888,6 +888,8 @@ _AUTHORED_STEP_METADATA_KEYS = (
     "skill",
     "jiraOrchestration",
     "jira_orchestration",
+    "githubOrchestration",
+    "github_orchestration",
     "documentUpdateOrchestration",
     "document_update_orchestration",
     "storyOutput",

--- a/tests/integration/test_startup_preset_seeding.py
+++ b/tests/integration/test_startup_preset_seeding.py
@@ -355,7 +355,7 @@ async def test_startup_seeds_default_task_templates(disabled_env_keys, tmp_path)
         )
         assert verify_step["skill"]["id"] == "moonspec-verify"
         assert "issue-brief verification mode" in verify_step["instructions"]
-        assert "controlling moonspec-verify verdict is FULLY_IMPLEMENTED" in (
+        assert "controlling post-remediation moonspec-verify verdict is FULLY_IMPLEMENTED" in (
             implement_pr_step["instructions"]
         )
         assert "merge automation" in implement_pr_step["instructions"]

--- a/tests/integration/test_startup_preset_seeding.py
+++ b/tests/integration/test_startup_preset_seeding.py
@@ -346,6 +346,16 @@ async def test_startup_seeds_default_task_templates(disabled_env_keys, tmp_path)
             for step in expanded_steps
             if step["title"] == "Create pull request"
         )
+        verify_step = next(
+            step
+            for step in expanded_steps
+            if step["title"] == "Verify implementation"
+        )
+        assert verify_step["skill"]["id"] == "moonspec-verify"
+        assert "issue-brief verification mode" in verify_step["instructions"]
+        assert "controlling moonspec-verify verdict is FULLY_IMPLEMENTED" in (
+            implement_pr_step["instructions"]
+        )
         assert "merge automation" in implement_pr_step["instructions"]
         assert "Done automatically" in implement_pr_step["instructions"]
         assert "artifacts/jira-implement-pr.json" in implement_pr_step["instructions"]
@@ -433,7 +443,7 @@ async def test_startup_seeds_default_task_templates(disabled_env_keys, tmp_path)
         assert "Selected Jira board ID" not in implement_jira_step["instructions"]
         assert "boardId" not in implement_jira_step["storyOutput"]["jira"]
         assert (
-            "Create one Jira Implement task"
+            "Create one Jira Implement workflow execution"
             in implement_downstream_step["instructions"]
         )
         assert "dependsOn" in implement_downstream_step["instructions"]
@@ -443,6 +453,56 @@ async def test_startup_seeds_default_task_templates(disabled_env_keys, tmp_path)
                 "enabled": "{{ inputs.publish_mode == 'pr_with_merge_automation' }}"
             },
         }
+
+        for slug, title, downstream_skill in (
+            (
+                "github-issue-breakdown-implement",
+                "Breakdown and GitHub Issue Implement",
+                "story.create_github_issue_implement_workflows",
+            ),
+            (
+                "github-issue-breakdown-orchestrate",
+                "Breakdown and GitHub Issue Orchestrate",
+                "story.create_github_issue_orchestrate_workflows",
+            ),
+        ):
+            result = await session.execute(
+                select(Preset)
+                .where(
+                    Preset.slug == slug,
+                    Preset.scope_type == PresetScopeType.GLOBAL,
+                    Preset.scope_ref.is_(None),
+                )
+            )
+            github_breakdown_template = result.scalar_one_or_none()
+            assert github_breakdown_template is not None
+            assert github_breakdown_template.title == title
+            assert [
+                (step.get("skill") or step.get("tool"))["id"]
+                for step in github_breakdown_template.steps
+            ] == [
+                "moonspec-breakdown",
+                "story-reconcile-implementation",
+                "story.create_github_issues",
+                downstream_skill,
+            ]
+            github_create_step = github_breakdown_template.steps[2]
+            assert github_create_step["storyOutput"]["github"] == {
+                "repository": "{{ inputs.github_repository }}",
+                "labels": "{{ inputs.github_labels }}",
+                "dependencyMode": "none",
+            }
+            github_downstream_step = github_breakdown_template.steps[3]
+            assert "workflow execution" in github_downstream_step["instructions"]
+            assert "Create workflow dependencies with dependsOn" in (
+                github_downstream_step["instructions"]
+            )
+            assert github_downstream_step["githubOrchestration"]["task"]["publish"] == {
+                "mode": "pr",
+                "mergeAutomation": {
+                    "enabled": "{{ inputs.publish_mode == 'pr_with_merge_automation' }}"
+                },
+            }
 
         result = await session.execute(
             select(Preset)

--- a/tests/integration/test_startup_preset_seeding.py
+++ b/tests/integration/test_startup_preset_seeding.py
@@ -281,7 +281,7 @@ async def test_startup_seeds_default_task_templates(disabled_env_keys, tmp_path)
         assert jira_implement_steps[1] == "auto"
         assert jira_implement_steps[2] == "jira.check_blockers"
         assert jira_implement_steps[-1] == "jira-issue-updater"
-        assert len(jira_implement_steps) == 8
+        assert len(jira_implement_steps) == 10
         implement_step_titles = [step["title"] for step in expanded_steps]
         assert implement_step_titles[0] == "Load Jira preset brief"
         assert implement_step_titles[1] == "Assess existing implementation state"
@@ -289,6 +289,8 @@ async def test_startup_seeds_default_task_templates(disabled_env_keys, tmp_path)
         assert implement_step_titles[3] == "Move Jira issue to In Progress"
         assert "Implement the issue" in implement_step_titles
         assert "Verify implementation" in implement_step_titles
+        assert "Remediate verification gaps" in implement_step_titles
+        assert "Verify remediation" in implement_step_titles
         assert "Create pull request" in implement_step_titles
         assert implement_step_titles[-1] == "Finalize Jira status"
         implement_brief_step = expanded_steps[0]

--- a/tests/unit/agents/codex_worker/test_worker.py
+++ b/tests/unit/agents/codex_worker/test_worker.py
@@ -8556,7 +8556,7 @@ async def test_derive_default_pr_title_uses_short_correlation_fallback(
         resolved_steps=worker._resolve_task_steps(payload),
     )
 
-    assert title == f"MoonMind task result [mm:{str(job_id)[:8]}]"
+    assert title == f"MoonMind workflow result [mm:{str(job_id)[:8]}]"
     assert str(job_id) not in title
     assert len(title) <= 90
 

--- a/tests/unit/agents/test_moonspec_verify_skill.py
+++ b/tests/unit/agents/test_moonspec_verify_skill.py
@@ -48,3 +48,25 @@ def test_moonspec_verify_skill_reports_canonical_claim_coverage() -> None:
     assert "Doc drift alone does not block `FULLY_IMPLEMENTED`" in text
     assert "Use durable evidence references" in text
     assert "structured drift in Source Document Drift" in text
+
+
+def test_moonspec_verify_skill_supports_issue_brief_mode() -> None:
+    skill_path = (
+        Path(__file__).resolve().parents[3]
+        / ".agents"
+        / "skills"
+        / "moonspec-verify"
+        / "SKILL.md"
+    )
+
+    text = skill_path.read_text(encoding="utf-8")
+
+    assert "issue-brief verification mode" in text
+    assert "without requiring a MoonSpec feature directory" in text
+    assert "issue brief artifact path" in text
+    assert "assessment artifact path" in text
+    assert "PARTIALLY_IMPLEMENTED" in text
+    assert "unmet and partially-met requirements" in text
+    assert "Do not require `spec.md`, `plan.md`, `tasks.md`" in text
+    assert "Gap Type: implementation | verification | documentation | environment" in text
+    assert "Recoverable In Current Runtime: true | false" in text

--- a/tests/unit/api/test_github_issue_breakdown_presets.py
+++ b/tests/unit/api/test_github_issue_breakdown_presets.py
@@ -1,0 +1,157 @@
+"""Catalog-boundary tests for MM-1063 GitHub Issue breakdown composite presets."""
+
+from __future__ import annotations
+
+import shutil
+from contextlib import asynccontextmanager
+from pathlib import Path
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+from api_service.db.models import Base, Preset, PresetScopeType
+from api_service.services.presets.catalog import PresetCatalogService
+
+pytestmark = [pytest.mark.asyncio]
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_PRESET_DIR = _REPO_ROOT / "api_service" / "data" / "presets"
+
+
+@asynccontextmanager
+async def _catalog_db(tmp_path):
+    db_url = f"sqlite+aiosqlite:///{tmp_path}/github_issue_breakdown.db"
+    engine = create_async_engine(db_url, future=True)
+    async_session_maker = sessionmaker(
+        engine, class_=AsyncSession, expire_on_commit=False
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    try:
+        yield async_session_maker
+    finally:
+        await engine.dispose()
+
+
+def _seed_dir(tmp_path) -> Path:
+    seed_dir = tmp_path / "presets"
+    seed_dir.mkdir()
+    for filename in (
+        "github-issue-breakdown-implement.yaml",
+        "github-issue-breakdown-orchestrate.yaml",
+    ):
+        shutil.copy(_PRESET_DIR / filename, seed_dir / filename)
+    return seed_dir
+
+
+async def _load_preset(session, slug: str) -> Preset:
+    result = await session.execute(
+        select(Preset).where(
+            Preset.slug == slug,
+            Preset.scope_type == PresetScopeType.GLOBAL,
+            Preset.scope_ref.is_(None),
+        )
+    )
+    return result.scalar_one()
+
+
+@pytest.mark.parametrize(
+    ("slug", "title", "workflow_skill"),
+    [
+        (
+            "github-issue-breakdown-implement",
+            "Breakdown and GitHub Issue Implement",
+            "story.create_github_issue_implement_workflows",
+        ),
+        (
+            "github-issue-breakdown-orchestrate",
+            "Breakdown and GitHub Issue Orchestrate",
+            "story.create_github_issue_orchestrate_workflows",
+        ),
+    ],
+)
+async def test_github_issue_breakdown_seed_creates_issues_and_workflows(
+    tmp_path,
+    slug: str,
+    title: str,
+    workflow_skill: str,
+):
+    async with _catalog_db(tmp_path) as session_maker:
+        async with session_maker() as session:
+            service = PresetCatalogService(session)
+            await service.sync_seed_templates(seed_dir=_seed_dir(tmp_path))
+
+            template = await _load_preset(session, slug)
+
+    assert template.title == title
+    assert sorted(template.required_capabilities) == ["gh", "git"]
+    assert [item["name"] for item in template.inputs_schema] == [
+        "feature_request",
+        "source_design_path",
+        "github_repository",
+        "github_labels",
+        "publish_mode",
+    ]
+    assert [
+        (step.get("skill") or step.get("tool"))["id"]
+        for step in template.steps
+    ] == [
+        "moonspec-breakdown",
+        "story-reconcile-implementation",
+        "story.create_github_issues",
+        workflow_skill,
+    ]
+
+    create_step = template.steps[2]
+    assert create_step["storyOutput"] == {
+        "mode": "github",
+        "fallback": "fail",
+        "github": {
+            "repository": "{{ inputs.github_repository }}",
+            "labels": "{{ inputs.github_labels }}",
+            "dependencyMode": "none",
+        },
+    }
+    downstream_step = template.steps[3]
+    assert "workflow execution" in downstream_step["instructions"]
+    assert "MoonMind task" not in downstream_step["instructions"]
+    assert downstream_step["githubOrchestration"]["task"]["publish"] == {
+        "mode": "pr",
+        "mergeAutomation": {
+            "enabled": "{{ inputs.publish_mode == 'pr_with_merge_automation' }}"
+        },
+    }
+
+
+async def test_github_issue_breakdown_implement_expands_downstream_contract(tmp_path):
+    async with _catalog_db(tmp_path) as session_maker:
+        async with session_maker() as session:
+            service = PresetCatalogService(session)
+            await service.sync_seed_templates(seed_dir=_seed_dir(tmp_path))
+
+            expanded = await service.expand_template(
+                slug="github-issue-breakdown-implement",
+                scope="global",
+                scope_ref=None,
+                inputs={
+                    "feature_request": "Split MM-1063 work.",
+                    "source_design_path": "",
+                    "github_repository": "MoonLadderStudios/MoonMind",
+                    "github_labels": "MM-1063",
+                    "publish_mode": "pr",
+                },
+                context={"targetRuntime": "codex"},
+            )
+
+    steps = expanded["steps"]
+    assert steps[2]["skill"]["id"] == "story.create_github_issues"
+    assert steps[2]["storyOutput"]["github"]["repository"] == (
+        "MoonLadderStudios/MoonMind"
+    )
+    assert steps[3]["skill"]["id"] == "story.create_github_issue_implement_workflows"
+    assert steps[3]["githubOrchestration"]["task"]["repository"] == (
+        "MoonLadderStudios/MoonMind"
+    )
+    assert steps[3]["githubOrchestration"]["task"]["runtime"]["mode"] == "codex"

--- a/tests/unit/api/test_github_issue_breakdown_presets.py
+++ b/tests/unit/api/test_github_issue_breakdown_presets.py
@@ -12,7 +12,10 @@ from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
 
 from api_service.db.models import Base, Preset, PresetScopeType
-from api_service.services.presets.catalog import PresetCatalogService
+from api_service.services.presets.catalog import (
+    PresetCatalogService,
+    PresetValidationError,
+)
 
 pytestmark = [pytest.mark.asyncio]
 
@@ -87,6 +90,7 @@ async def test_github_issue_breakdown_seed_creates_issues_and_workflows(
 
     assert template.title == title
     assert sorted(template.required_capabilities) == ["gh", "git"]
+    assert "sourceReference" not in template.annotations
     assert [item["name"] for item in template.inputs_schema] == [
         "feature_request",
         "source_design_path",
@@ -117,6 +121,7 @@ async def test_github_issue_breakdown_seed_creates_issues_and_workflows(
     downstream_step = template.steps[3]
     assert "workflow execution" in downstream_step["instructions"]
     assert "MoonMind task" not in downstream_step["instructions"]
+    assert "traceability" not in downstream_step["githubOrchestration"]
     assert downstream_step["githubOrchestration"]["task"]["publish"] == {
         "mode": "pr",
         "mergeAutomation": {
@@ -155,3 +160,35 @@ async def test_github_issue_breakdown_implement_expands_downstream_contract(tmp_
         "MoonLadderStudios/MoonMind"
     )
     assert steps[3]["githubOrchestration"]["task"]["runtime"]["mode"] == "codex"
+    assert "traceability" not in steps[3]["githubOrchestration"]
+
+
+async def test_github_issue_breakdown_requires_source_input(tmp_path):
+    async with _catalog_db(tmp_path) as session_maker:
+        async with session_maker() as session:
+            service = PresetCatalogService(session)
+            await service.sync_seed_templates(seed_dir=_seed_dir(tmp_path))
+
+            with pytest.raises(PresetValidationError) as excinfo:
+                await service.expand_template(
+                    slug="github-issue-breakdown-implement",
+                    scope="global",
+                    scope_ref=None,
+                    inputs={
+                        "feature_request": "",
+                        "source_design_path": "",
+                        "github_repository": "MoonLadderStudios/MoonMind",
+                        "github_labels": "",
+                        "publish_mode": "pr",
+                    },
+                    context={"targetRuntime": "codex"},
+                )
+
+    assert excinfo.value.errors == [
+        {
+            "path": "preset.inputs",
+            "message": "Provide a Source Document Path or Workflow Instructions.",
+            "code": "required",
+            "recoverable": True,
+        }
+    ]

--- a/tests/unit/api/test_presets_service.py
+++ b/tests/unit/api/test_presets_service.py
@@ -2949,6 +2949,8 @@ async def test_seed_catalog_github_issue_implement_expands_shared_includes(tmp_p
         "Mark GitHub issue In Progress",
         "Implement the issue",
         "Verify implementation",
+        "Remediate verification gaps",
+        "Verify remediation",
         "Create pull request",
         "Finalize GitHub issue status",
     ]
@@ -2957,8 +2959,12 @@ async def test_seed_catalog_github_issue_implement_expands_shared_includes(tmp_p
     assert expanded["steps"][3]["tool"]["id"] == "github.update_issue_status"
     assert expanded["steps"][5]["skill"]["id"] == "moonspec-verify"
     assert "issue-brief verification mode" in expanded["steps"][5]["instructions"]
-    assert "controlling moonspec-verify verdict is FULLY_IMPLEMENTED" in (
-        expanded["steps"][6]["instructions"]
+    assert expanded["steps"][6]["skill"]["id"] == "auto"
+    assert "ADDITIONAL_WORK_NEEDED" in expanded["steps"][6]["instructions"]
+    assert expanded["steps"][7]["skill"]["id"] == "moonspec-verify"
+    assert "controlling verification gate" in expanded["steps"][7]["instructions"]
+    assert "controlling post-remediation moonspec-verify verdict is FULLY_IMPLEMENTED" in (
+        expanded["steps"][8]["instructions"]
     )
     assert [item["presetSlug"] for item in expanded["authoredPresets"]] == [
         "github-issue-implement",

--- a/tests/unit/api/test_presets_service.py
+++ b/tests/unit/api/test_presets_service.py
@@ -2955,6 +2955,11 @@ async def test_seed_catalog_github_issue_implement_expands_shared_includes(tmp_p
     assert expanded["steps"][0]["tool"]["id"] == "github.load_issue_preset_brief"
     assert expanded["steps"][2]["tool"]["id"] == "github.check_issue_blockers"
     assert expanded["steps"][3]["tool"]["id"] == "github.update_issue_status"
+    assert expanded["steps"][5]["skill"]["id"] == "moonspec-verify"
+    assert "issue-brief verification mode" in expanded["steps"][5]["instructions"]
+    assert "controlling moonspec-verify verdict is FULLY_IMPLEMENTED" in (
+        expanded["steps"][6]["instructions"]
+    )
     assert [item["presetSlug"] for item in expanded["authoredPresets"]] == [
         "github-issue-implement",
         "issue-implement-assessment",
@@ -3004,11 +3009,11 @@ async def test_seed_catalog_github_issue_orchestrate_expands_gated_workflow(tmp_
         "Check GitHub issue blockers before orchestration",
         "Mark GitHub issue In Progress",
         "Classify request and resume point",
-        "Create or select Moon Spec",
+        "Create or select MoonSpec",
         "Split broad designs when needed",
         "Plan selected spec",
         "Generate TDD task breakdown",
-        "Align Moon Spec artifacts",
+        "Align MoonSpec artifacts",
         "Implement the task breakdown",
         "Verify completion",
         "Remediate verification gaps 1 of 6",
@@ -3144,7 +3149,7 @@ async def test_seed_catalog_includes_jira_breakdown_orchestrate_preset(
                 "jira-breakdown"
             )
             assert template.annotations["output"] == (
-                "dependent-jira-orchestrate-tasks"
+                "dependent-jira-orchestrate-workflows"
             )
             assert [
                 (step.get("skill") or step.get("tool"))["id"]
@@ -3193,7 +3198,10 @@ async def test_seed_catalog_includes_jira_breakdown_orchestrate_preset(
             }
             downstream = expanded["steps"][4]
             assert downstream["skill"]["id"] == "story.create_jira_orchestrate_tasks"
-            assert "Create one Jira Orchestrate task" in downstream["instructions"]
+            assert (
+                "Create one Jira Orchestrate workflow execution"
+                in downstream["instructions"]
+            )
             assert "dependsOn" in downstream["instructions"]
             assert "MM-404" in downstream["instructions"]
             assert "Selected Jira board" not in expanded["steps"][3]["instructions"]

--- a/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
+++ b/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
@@ -2474,6 +2474,7 @@ def test_runtime_planner_preserves_github_orchestration_for_direct_story_tool() 
                 "publish": {"mode": "none"},
                 "steps": [
                     {
+                        "type": "skill",
                         "title": "Create dependent GitHub Issue Implement workflow executions",
                         "instructions": "Create downstream workflows.",
                         "githubOrchestration": {

--- a/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
+++ b/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
@@ -2459,6 +2459,53 @@ def test_github_story_tools_route_as_direct_story_output_tools() -> None:
     )
 
 
+def test_runtime_planner_preserves_github_orchestration_for_direct_story_tool() -> None:
+    planner = _build_runtime_planner()
+    snapshot = SimpleNamespace(
+        digest="reg:sha256:test",
+        artifact_ref="art_registry_123",
+    )
+
+    plan = planner(
+        inputs={
+            "task": {
+                "instructions": "Create GitHub issue workflows.",
+                "repository": "MoonLadderStudios/MoonMind",
+                "publish": {"mode": "none"},
+                "steps": [
+                    {
+                        "title": "Create dependent GitHub Issue Implement workflow executions",
+                        "instructions": "Create downstream workflows.",
+                        "githubOrchestration": {
+                            "task": {
+                                "repository": "MoonLadderStudios/MoonMind",
+                                "runtime": {"mode": "codex"},
+                                "publish": {
+                                    "mode": "pr",
+                                    "mergeAutomation": {"enabled": True},
+                                },
+                            }
+                        },
+                        "skill": {
+                            "id": "story.create_github_issue_implement_workflows"
+                        },
+                    }
+                ],
+            }
+        },
+        parameters={},
+        snapshot=snapshot,
+    )
+
+    assert plan["nodes"][0]["inputs"]["githubOrchestration"] == {
+        "task": {
+            "repository": "MoonLadderStudios/MoonMind",
+            "runtime": {"mode": "codex"},
+            "publish": {"mode": "pr", "mergeAutomation": {"enabled": True}},
+        }
+    }
+
+
 def test_runtime_planner_does_not_require_pr_branch_for_jira_issue_creator():
     planner = _build_runtime_planner()
     snapshot = SimpleNamespace(


### PR DESCRIPTION
Issue reference: MM-1063

Summary:
- Adds GitHub Issue breakdown composite presets for Implement and Orchestrate workflows.
- Normalizes breakdown/Jira/GitHub Issue preset copy around MoonMind workflow terminology and MoonSpec spelling.
- Updates issue implementation PR gates to use moonspec-verify issue-brief verification before PR or lifecycle transitions.
- Extends tests for preset seeding, expansion, GitHub issue breakdown workflow creation, verification mode, and terminology guardrails.

Tests run:
- MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/test_github_issue_breakdown_presets.py tests/unit/api/test_presets_service.py tests/unit/agents/test_moonspec_verify_skill.py tests/unit/agents/codex_worker/test_worker.py
- MOONMIND_FORCE_LOCAL_TESTS=1 pytest tests/integration/test_startup_preset_seeding.py -q --tb=short

Remaining risks:
- Provider-backed GitHub/Jira lifecycle behavior was not exercised with live credentials in this step.
- The broader integration suite was not run; verification focused on the MM-1063 preset and skill-boundary changes.
