### PR TITLE
MM-1076 Activate Omnigent checkpoint routing

### DIFF
--- a/moonmind/workflows/temporal/checkpoint_policy.py
+++ b/moonmind/workflows/temporal/checkpoint_policy.py
@@ -85,11 +85,13 @@ def resolve_checkpoint_policy(
     boundary: str,
     recovery_source: Mapping[str, Any] | None = None,
     runtime_kind: str | None = None,
+    external_agent_id: str | None = None,
 ) -> ResolvedCheckpointPolicy:
     """Return the shared policy used for capture, manifests, and recovery apply."""
 
     boundary_token = _boundary_token(boundary)
-    if _is_omnigent_runtime(runtime_kind):
+    is_omnigent_external_agent = str(external_agent_id or "").strip() == "omnigent"
+    if is_omnigent_external_agent or _is_omnigent_runtime(runtime_kind):
         external_policy = _omnigent_checkpoint_policy(boundary_token)
         if external_policy is not None:
             return external_policy

--- a/moonmind/workflows/temporal/checkpoint_policy.py
+++ b/moonmind/workflows/temporal/checkpoint_policy.py
@@ -90,7 +90,9 @@ def resolve_checkpoint_policy(
     """Return the shared policy used for capture, manifests, and recovery apply."""
 
     boundary_token = _boundary_token(boundary)
-    is_omnigent_external_agent = str(external_agent_id or "").strip() == "omnigent"
+    is_omnigent_external_agent = (
+        str(external_agent_id or "").strip().lower() == "omnigent"
+    )
     if is_omnigent_external_agent or _is_omnigent_runtime(runtime_kind):
         external_policy = _omnigent_checkpoint_policy(boundary_token)
         if external_policy is not None:

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -1013,6 +1013,7 @@ class MoonMindRunWorkflow:
         self._previous_step_checkpoint_refs: dict[str, str] = {}
         self._step_checkpoint_refs_by_boundary: dict[str, dict[str, str]] = {}
         self._step_workspace_capture_inputs: dict[str, dict[str, Any]] = {}
+        self._step_external_agent_ids: dict[str, str] = {}
         self._step_execution_launch_blocks: set[str] = set()
         self._step_dependency_effects: dict[str, dict[str, Any]] = {}
         self._step_terminal_dispositions: dict[str, str] = {}
@@ -3949,6 +3950,15 @@ class MoonMindRunWorkflow:
         logical_step_id: str,
         outputs: Mapping[str, Any],
     ) -> None:
+        raw_agent_kind = outputs.get("agentKind") or outputs.get("agent_kind")
+        raw_agent_id = outputs.get("agentId") or outputs.get("agent_id")
+        if str(raw_agent_kind or "").strip() == "external" and isinstance(
+            raw_agent_id, str
+        ):
+            external_agent_id = raw_agent_id.strip()
+            if external_agent_id:
+                self._step_external_agent_ids[logical_step_id] = external_agent_id
+
         candidates: list[Mapping[str, Any]] = [outputs]
         workspace_spec = outputs.get("workspaceSpec") or outputs.get("workspace_spec")
         if isinstance(workspace_spec, Mapping):
@@ -4007,10 +4017,11 @@ class MoonMindRunWorkflow:
             )
             if checkpoint_kind:
                 capture_input["kind"] = checkpoint_kind
-            elif base_commit:
-                capture_input["kind"] = "git_patch"
-            else:
-                capture_input["kind"] = "worktree_archive"
+            elif self._step_external_agent_ids.get(logical_step_id) != "omnigent":
+                if base_commit:
+                    capture_input["kind"] = "git_patch"
+                else:
+                    capture_input["kind"] = "worktree_archive"
             break
 
         if capture_input:
@@ -4039,6 +4050,7 @@ class MoonMindRunWorkflow:
             if isinstance(self._recovery_source, Mapping)
             else None,
             runtime_kind=self._target_runtime,
+            external_agent_id=self._step_external_agent_ids.get(logical_step_id),
         )
         payload = {
             "identity": identity.model_dump(by_alias=True, mode="json"),
@@ -12857,8 +12869,10 @@ class MoonMindRunWorkflow:
         )
         return str(
             runtime_block.get("mode")
+            or runtime_block.get("agentId")
             or runtime_block.get("agent_id")
             or node_inputs.get("targetRuntime")
+            or node_inputs.get("agentId")
             or fallback_name
             or ""
         ).strip()

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -3952,12 +3952,17 @@ class MoonMindRunWorkflow:
     ) -> None:
         raw_agent_kind = outputs.get("agentKind") or outputs.get("agent_kind")
         raw_agent_id = outputs.get("agentId") or outputs.get("agent_id")
-        if str(raw_agent_kind or "").strip() == "external" and isinstance(
-            raw_agent_id, str
-        ):
-            external_agent_id = raw_agent_id.strip()
-            if external_agent_id:
-                self._step_external_agent_ids[logical_step_id] = external_agent_id
+        agent_kind = str(raw_agent_kind or "").strip().lower()
+        agent_id = str(raw_agent_id or "").strip()
+        if not agent_id:
+            agent_id = self._agent_id_from_runtime_inputs(
+                node_inputs=outputs,
+                fallback_name=None,
+            )
+            if agent_id:
+                agent_kind = self._agent_kind_for_id(agent_id)
+        if agent_kind == "external" and agent_id:
+            self._step_external_agent_ids[logical_step_id] = agent_id.lower()
 
         candidates: list[Mapping[str, Any]] = [outputs]
         workspace_spec = outputs.get("workspaceSpec") or outputs.get("workspace_spec")

--- a/tests/unit/workflows/temporal/test_checkpoint_policy.py
+++ b/tests/unit/workflows/temporal/test_checkpoint_policy.py
@@ -77,7 +77,7 @@ def test_resolve_checkpoint_policy_uses_exact_external_agent_identity() -> None:
     policy = resolve_checkpoint_policy(
         boundary=_Boundary.BEFORE_EXECUTION,
         runtime_kind="external",
-        external_agent_id="omnigent",
+        external_agent_id="Omnigent",
     )
     control = resolve_checkpoint_policy(
         boundary=_Boundary.BEFORE_EXECUTION,

--- a/tests/unit/workflows/temporal/test_checkpoint_policy.py
+++ b/tests/unit/workflows/temporal/test_checkpoint_policy.py
@@ -73,6 +73,24 @@ def test_resolve_checkpoint_policy_uses_omnigent_external_state_before_execution
     )
 
 
+def test_resolve_checkpoint_policy_uses_exact_external_agent_identity() -> None:
+    policy = resolve_checkpoint_policy(
+        boundary=_Boundary.BEFORE_EXECUTION,
+        runtime_kind="external",
+        external_agent_id="omnigent",
+    )
+    control = resolve_checkpoint_policy(
+        boundary=_Boundary.BEFORE_EXECUTION,
+        runtime_kind="external",
+        external_agent_id="jules",
+    )
+
+    assert policy.workspace_policy == "continue_from_previous_execution"
+    assert policy.checkpoint_kind == "external_state_ref"
+    assert control.workspace_policy == "restore_pre_execution"
+    assert control.checkpoint_kind == "worktree_archive"
+
+
 def test_resolve_checkpoint_policy_keeps_local_after_execution_default() -> None:
     policy = resolve_checkpoint_policy(
         boundary="after_execution",

--- a/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
@@ -2563,6 +2563,181 @@ async def test_run_records_pre_execution_checkpoint_from_node_workspace_inputs(
 
 
 @pytest.mark.asyncio
+async def test_run_uses_external_omnigent_identity_for_checkpoint_capture(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _configure_workflow_runtime(monkeypatch)
+    monkeypatch.setattr(
+        run_module.workflow,
+        "patched",
+        lambda patch_id: patch_id == run_module.RUN_CANONICAL_STEP_CHECKPOINTS_PATCH,
+    )
+    workflow = MoonMindRunWorkflow()
+    now = datetime(2026, 6, 13, 12, 0, tzinfo=UTC)
+    node_inputs = {
+        "agentKind": "external",
+        "agentId": "omnigent",
+        "workspaceRoot": "/work/agent_jobs/run-1/repo",
+        "baseCommit": "abc123",
+    }
+    captured: list[dict[str, Any]] = []
+
+    workflow._initialize_step_ledger(
+        ordered_nodes=[{"id": "implement", "inputs": node_inputs}],
+        dependency_map={"implement": []},
+        updated_at=now,
+    )
+    workflow._mark_step_running(
+        "implement",
+        updated_at=now,
+        summary="Implementing",
+    )
+    request = workflow._build_agent_execution_request(
+        node_inputs=dict(node_inputs),
+        node_id="implement",
+        tool_name="external",
+        step_execution=1,
+    )
+    workflow._record_step_workspace_capture_input("implement", node_inputs)
+
+    async def fake_execute_activity(
+        activity: str,
+        payload: dict[str, Any],
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        captured.append({"activity": activity, "payload": payload, "kwargs": kwargs})
+        if activity == "workspace.capture_checkpoint":
+            assert payload["kind"] == "external_state_ref"
+            return {
+                "status": "captured",
+                "workspace": {
+                    "kind": "external_state_ref",
+                    "externalStateRef": "artifact://omnigent/state",
+                    "createdAt": "2026-06-13T12:00:00+00:00",
+                },
+                "diagnosticRefs": ["artifact://omnigent/manifest"],
+            }
+        assert activity == "step_checkpoint.create"
+        return _checkpoint_create_result(payload)
+
+    monkeypatch.setattr(run_module.workflow, "execute_activity", fake_execute_activity)
+
+    result = await workflow._record_canonical_step_checkpoint(
+        "implement",
+        boundary="before_execution",
+        updated_at=now,
+    )
+
+    assert request.agent_kind == "external"
+    assert request.agent_id == "omnigent"
+    assert request.step_execution is not None
+    assert request.step_execution.runtime_selection == {
+        "runtimeId": "omnigent",
+        "agentKind": "external",
+    }
+    assert result == "artifact://checkpoint/before_execution"
+    assert [(call["activity"], call["payload"]["boundary"]) for call in captured] == [
+        ("workspace.capture_checkpoint", "before_execution"),
+        ("step_checkpoint.create", "before_execution"),
+    ]
+    assert captured[0]["payload"]["kind"] == "external_state_ref"
+    assert captured[1]["payload"]["workspace"]["kind"] == "external_state_ref"
+    assert "patchRef" not in captured[1]["payload"]["workspace"]
+    assert "archiveRef" not in captured[1]["payload"]["workspace"]
+
+
+@pytest.mark.asyncio
+async def test_run_keeps_non_omnigent_and_legacy_checkpoint_capture_defaults(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _configure_workflow_runtime(monkeypatch)
+    monkeypatch.setattr(
+        run_module.workflow,
+        "patched",
+        lambda patch_id: patch_id == run_module.RUN_CANONICAL_STEP_CHECKPOINTS_PATCH,
+    )
+    workflow = MoonMindRunWorkflow()
+    now = datetime(2026, 6, 13, 12, 0, tzinfo=UTC)
+    captured: list[dict[str, Any]] = []
+
+    workflow._initialize_step_ledger(
+        ordered_nodes=[
+            {"id": "external-control", "inputs": {"title": "External control"}},
+            {"id": "legacy", "inputs": {"title": "Legacy shape"}},
+        ],
+        dependency_map={"external-control": [], "legacy": []},
+        updated_at=now,
+    )
+    for logical_step_id in ("external-control", "legacy"):
+        workflow._mark_step_running(
+            logical_step_id,
+            updated_at=now,
+            summary="Implementing",
+        )
+    workflow._record_step_workspace_capture_input(
+        "external-control",
+        {
+            "agentKind": "external",
+            "agentId": "jules",
+            "workspaceRoot": "/work/agent_jobs/run-1/repo",
+            "baseCommit": "abc123",
+        },
+    )
+    workflow._record_step_workspace_capture_input(
+        "legacy",
+        {
+            "workspaceRoot": "/work/agent_jobs/run-1/repo",
+            "baseCommit": "abc123",
+        },
+    )
+
+    async def fake_execute_activity(
+        activity: str,
+        payload: dict[str, Any],
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        captured.append({"activity": activity, "payload": payload, "kwargs": kwargs})
+        if activity == "workspace.capture_checkpoint":
+            return {
+                "status": "captured",
+                "workspace": {
+                    "kind": payload["kind"],
+                    "baseCommit": payload["baseCommit"],
+                    "patchRef": f"artifact://patch/{payload['identity']['logicalStepId']}",
+                    "manifestRef": (
+                        f"artifact://patch-manifest/{payload['identity']['logicalStepId']}"
+                    ),
+                    "createdAt": "2026-06-13T12:00:00+00:00",
+                },
+                "diagnosticRefs": [
+                    f"artifact://patch-manifest/{payload['identity']['logicalStepId']}"
+                ],
+            }
+        assert activity == "step_checkpoint.create"
+        return _checkpoint_create_result(payload)
+
+    monkeypatch.setattr(run_module.workflow, "execute_activity", fake_execute_activity)
+
+    await workflow._record_canonical_step_checkpoint(
+        "external-control",
+        boundary="before_execution",
+        updated_at=now,
+    )
+    await workflow._record_canonical_step_checkpoint(
+        "legacy",
+        boundary="before_execution",
+        updated_at=now,
+    )
+
+    capture_kinds = [
+        call["payload"]["kind"]
+        for call in captured
+        if call["activity"] == "workspace.capture_checkpoint"
+    ]
+    assert capture_kinds == ["git_patch", "git_patch"]
+
+
+@pytest.mark.asyncio
 async def test_run_skips_no_capture_ephemeral_checkpoint_for_pre_emit_histories(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
@@ -2575,8 +2575,8 @@ async def test_run_uses_external_omnigent_identity_for_checkpoint_capture(
     workflow = MoonMindRunWorkflow()
     now = datetime(2026, 6, 13, 12, 0, tzinfo=UTC)
     node_inputs = {
-        "agentKind": "external",
-        "agentId": "omnigent",
+        "agentKind": "External",
+        "agentId": "Omnigent",
         "workspaceRoot": "/work/agent_jobs/run-1/repo",
         "baseCommit": "abc123",
     }
@@ -2629,10 +2629,11 @@ async def test_run_uses_external_omnigent_identity_for_checkpoint_capture(
     )
 
     assert request.agent_kind == "external"
-    assert request.agent_id == "omnigent"
+    assert request.agent_id == "Omnigent"
+    assert workflow._step_external_agent_ids["implement"] == "omnigent"
     assert request.step_execution is not None
     assert request.step_execution.runtime_selection == {
-        "runtimeId": "omnigent",
+        "runtimeId": "Omnigent",
         "agentKind": "external",
     }
     assert result == "artifact://checkpoint/before_execution"
@@ -2644,6 +2645,25 @@ async def test_run_uses_external_omnigent_identity_for_checkpoint_capture(
     assert captured[1]["payload"]["workspace"]["kind"] == "external_state_ref"
     assert "patchRef" not in captured[1]["payload"]["workspace"]
     assert "archiveRef" not in captured[1]["payload"]["workspace"]
+
+
+def test_run_derives_external_omnigent_identity_from_runtime_selection() -> None:
+    workflow = MoonMindRunWorkflow()
+
+    workflow._record_step_workspace_capture_input(
+        "implement",
+        {
+            "runtime": {"mode": "Omnigent"},
+            "workspaceRoot": "/work/agent_jobs/run-1/repo",
+            "baseCommit": "abc123",
+        },
+    )
+
+    assert workflow._step_external_agent_ids["implement"] == "omnigent"
+    assert workflow._step_workspace_capture_inputs["implement"] == {
+        "workspacePath": "/work/agent_jobs/run-1/repo",
+        "baseCommit": "abc123",
+    }
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Issue reference: MM-1076

Summary:
- Threads the external step agent identity into Temporal checkpoint policy resolution so `agentKind=external` and `agentId=omnigent` resolve non-recovery checkpoint boundaries to `external_state_ref`.
- Ensures Omnigent v1 before/after execution capture uses external provider state evidence instead of local git patch or worktree archive defaults.
- Adds workflow/activity-boundary coverage for the real external-agent invocation shape, including an Omnigent case and a non-Omnigent control, plus checkpoint policy regression coverage.

Tests run:
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_checkpoint_policy.py tests/unit/workflows/temporal/workflows/test_run_step_ledger.py` (Python phase: 65 passed; runner later failed in existing frontend test `frontend/src/entrypoints/workflow-detail.test.tsx > expands a bound step into grouped step details and lazily attaches row-scoped observability`, unable to find `step scoped log line`.)

Remaining risks:
- The unit runner's frontend phase has an unrelated workflow-detail failure that was not changed by this backend checkpoint branch.
- In-flight safety depends on unchanged persisted payload shapes; the change derives checkpoint selection from existing step runtime metadata rather than adding or rewriting stored workflow payload fields.
