### PR TITLE
MM-1080 Complete status-domain matrix and audit inventory

### DIFF
--- a/docs/Temporal/StatusDomainMatrix.md
+++ b/docs/Temporal/StatusDomainMatrix.md
@@ -1,0 +1,64 @@
+# Status Domain Matrix
+
+Status: Normative
+Owners: MoonMind Platform
+Last updated: 2026-07-01
+Source issue: MM-1080; preserves MM-1073 traceability
+
+This document is the canonical cross-domain matrix for MoonMind status tokens. It names the owner, value set, storage/API surface, and conversion boundary for each status domain so downstream cleanup can make domain-specific changes without treating similarly named tokens as interchangeable.
+
+Archived `docs/Workflows/WorkflowStatus.md` remains only an archival pointer. Do not use it as the source for new status decisions.
+
+## Domain Matrix
+
+| Domain | Owner | Canonical value set | Storage/API surface | Conversion notes |
+| --- | --- | --- | --- | --- |
+| Workflow lifecycle state | MoonMind workflow lifecycle logic | `scheduled`, `initializing`, `waiting_on_dependencies`, `planning`, `awaiting_slot`, `executing`, `awaiting_external`, `proposals`, `finalizing`, `no_commit`, `completed`, `failed`, `canceled` | Temporal Search Attribute `mm_state`; API `state`; projection `TemporalExecutionRecord.state`; enum `MoonMindWorkflowState` | This is the exact domain state for workflow filtering. It must align with terminal `closeStatus`; compatibility dashboard groups must not redefine it. |
+| Temporal close status | Temporal lifecycle projection and MoonMind invariant checks | `completed`, `failed`, `canceled`, `terminated`, `timed_out`, `continued_as_new` | API `closeStatus`; projection `TemporalExecutionRecord.close_status`; enum `TemporalExecutionCloseStatus` | Raw Temporal close concepts are terminal-only. `terminated` and `timed_out` map to API `temporalStatus=failed`; `continued_as_new` is not exposed as a distinct `temporalStatus` in the current API shape. |
+| `temporalStatus` | Executions API adapter | `running`, `completed`, `failed`, `canceled` | API JSON field `temporalStatus`; schema `ExecutionModel.temporalStatus` | Derived from `closeStatus`: `null -> running`, `completed -> completed`, `canceled -> canceled`, and failure-like close statuses -> `failed`. It is a simplified client-facing lifecycle value, not a workflow-owned state machine. |
+| Step ledger status | `MoonMind.UserWorkflow` step ledger and dashboard | `pending`, `ready`, `running`, `awaiting_external`, `reviewing`, `succeeded`, `failed`, `skipped`, `canceled` | Workflow query such as `GetStepLedger`; API step rows `status`; docs/Temporal/StepLedgerAndProgressModel.md | This domain describes operator-facing plan-step progress. It is not interchangeable with workflow lifecycle state or provider normalized status. |
+| Step execution artifact status | Step-execution artifact manifest contract | `pending`, `preparing`, `running`, `checking`, `succeeded`, `failed`, `blocked`, `canceled`, `superseded` | Step execution artifact content type `application/vnd.moonmind.step-execution+json;version=1`; schemas `moonmind.schemas.step_execution_models.StepExecutionStatus` and `moonmind.schemas.temporal_models.StepExecutionStatus` | This domain describes durable step-execution evidence artifacts. Convert to step ledger status only at an explicit workflow/API projection boundary. |
+| Provider normalized status | External provider adapters | Portable base: `queued`, `running`, `completed`, `failed`, `canceled`, `unknown`; provider extensions must be adapter-owned, such as Jules `awaiting_feedback` | Adapter result field `normalizedStatus` / internal `normalized_status`; provider monitoring payloads and artifacts | Provider-native tokens such as `in-progress` belong at provider boundaries and are normalized by the adapter. Do not promote provider-native spelling into workflow lifecycle or step ledger domains. |
+
+## Audit Actions
+
+The non-destructive status-token audit uses these action values:
+
+| Action | Meaning |
+| --- | --- |
+| `keep_canonical` | Token is already canonical for its guessed domain and should remain in that domain. |
+| `move_to_provider_boundary` | Token belongs to provider adapter normalization or provider evidence, not core workflow or step status. |
+| `move_to_legacy_alias_map` | Token should be isolated in an explicit compatibility or legacy alias map when compatibility is required. |
+| `rename_domain_specific` | Token is meaningful but too generic or cross-domain; rename or qualify it to the owning domain before behavior changes. |
+| `delete_unused` | Token appears unused or stale after evidence review and can be removed in a later destructive cleanup story. |
+| `historical_migration_only` | Token is valid only in migrations, archived evidence, or historical compatibility notes. |
+
+## Formatting Standard
+
+Machine values use lowercase snake_case, for example `awaiting_external` and `no_commit`.
+
+Enum member names use UPPER_SNAKE_CASE, for example `AWAITING_EXTERNAL` and `NO_COMMIT`.
+
+External JSON fields use camelCase, for example `temporalStatus`, `closeStatus`, and `normalizedStatus`.
+
+Finish outcome codes use UPPER_SNAKE_CASE when represented as symbolic outcome codes.
+
+UI labels use human-readable sentence or title case, for example `Awaiting external` or `No commit`.
+
+CSS classes use kebab-case, for example `status-awaiting-external` and `status-no-commit`.
+
+## Non-Destructive Audit Command
+
+Run the inventory in report mode:
+
+```bash
+python tools/audit_status_tokens.py
+```
+
+The report emits these columns:
+
+```text
+token,guessed_domain,files,canonicality,action
+```
+
+The audit is intentionally non-destructive for MM-1080. It categorizes repository evidence so later cleanup can be reviewed separately.

--- a/docs/Workflows/WorkflowStatus.md
+++ b/docs/Workflows/WorkflowStatus.md
@@ -8,6 +8,7 @@ This file is no longer the canonical source for MoonMind Workflow status design.
 
 Use these docs instead:
 
+- `docs/Temporal/StatusDomainMatrix.md` for the canonical cross-domain status matrix, token ownership, formatting rules, and non-destructive audit action vocabulary
 - `docs/Temporal/VisibilityAndUiQueryModel.md` for execution-level `mm_state`, dashboard-status mapping, Memo/Search Attribute rules, and `mm_updated_at`
 - `docs/Temporal/WorkflowExecutionProductModel.md` for the canonical Workflow Execution product model
 - `docs/Temporal/StepLedgerAndProgressModel.md` for step-level statuses, attempts, checks, and latest-run rules

--- a/tests/unit/tools/test_audit_status_tokens.py
+++ b/tests/unit/tools/test_audit_status_tokens.py
@@ -71,6 +71,44 @@ def test_report_emits_required_columns_and_file_matches(tmp_path: Path) -> None:
     assert by_token["in-progress"]["files"] == "moonmind/provider.py"
 
 
+def test_default_scan_roots_include_frontend_sources() -> None:
+    assert "frontend/src" in audit_status_tokens.DEFAULT_SCAN_ROOTS
+
+
+def test_iter_text_files_skips_pruned_directories(tmp_path: Path) -> None:
+    docs = tmp_path / "docs"
+    skipped = docs / "node_modules" / "package"
+    docs.mkdir()
+    skipped.mkdir(parents=True)
+    included = docs / "status.md"
+    excluded = skipped / "status.md"
+    included.write_text("mm_state\n", encoding="utf-8")
+    excluded.write_text("queued\n", encoding="utf-8")
+
+    files = audit_status_tokens.iter_text_files(tmp_path, ("docs",))
+
+    assert files == [included]
+
+
+def test_find_token_files_handles_unreadable_and_external_paths(tmp_path: Path) -> None:
+    docs = tmp_path / "docs"
+    external = tmp_path.parent / f"{tmp_path.name}-external"
+    docs.mkdir()
+    external.mkdir()
+    (docs / "status.md").write_text("mm_state\n", encoding="utf-8")
+    (external / "status.md").write_text("queued\n", encoding="utf-8")
+    (docs / "missing.py").symlink_to(docs / "does-not-exist.py")
+
+    matches = audit_status_tokens.find_token_files(
+        root=tmp_path,
+        scan_roots=("docs", str(external)),
+        tokens=("mm_state", "queued"),
+    )
+
+    assert matches["mm_state"] == ["docs/status.md"]
+    assert matches["queued"] == [(external / "status.md").as_posix()]
+
+
 def test_csv_report_is_parseable(tmp_path: Path, capsys) -> None:
     docs = tmp_path / "docs"
     docs.mkdir()

--- a/tests/unit/tools/test_audit_status_tokens.py
+++ b/tests/unit/tools/test_audit_status_tokens.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import csv
+import importlib.util
+from pathlib import Path
+import sys
+
+
+_MODULE_PATH = (
+    Path(__file__).resolve().parents[3] / "tools" / "audit_status_tokens.py"
+)
+_SPEC = importlib.util.spec_from_file_location("audit_status_tokens", _MODULE_PATH)
+assert _SPEC is not None
+assert _SPEC.loader is not None
+audit_status_tokens = importlib.util.module_from_spec(_SPEC)
+sys.modules["audit_status_tokens"] = audit_status_tokens
+_SPEC.loader.exec_module(audit_status_tokens)
+
+
+def test_seeded_tokens_have_required_domains_and_actions() -> None:
+    expected = {
+        "mm_state": ("workflow_lifecycle_state", "keep_canonical"),
+        "closeStatus": ("temporal_close_status", "keep_canonical"),
+        "temporalStatus": ("temporal_status", "keep_canonical"),
+        "no_changes": ("legacy_or_migration_status", "historical_migration_only"),
+        "awaiting_action": (
+            "dashboard_compatibility_status",
+            "rename_domain_specific",
+        ),
+        "queued": ("provider_normalized_status", "move_to_provider_boundary"),
+        "in-progress": ("provider_native_status", "move_to_provider_boundary"),
+        "StepExecutionStatus": ("step_execution_artifact_status", "keep_canonical"),
+    }
+
+    for token, (domain, action) in expected.items():
+        classification = audit_status_tokens.classify_token(token)
+        assert classification.guessed_domain == domain
+        assert classification.action == action
+
+
+def test_report_emits_required_columns_and_file_matches(tmp_path: Path) -> None:
+    docs = tmp_path / "docs"
+    code = tmp_path / "moonmind"
+    docs.mkdir()
+    code.mkdir()
+    (docs / "status.md").write_text(
+        "The API exposes temporalStatus and closeStatus.\n", encoding="utf-8"
+    )
+    (code / "provider.py").write_text(
+        "provider_status = 'in-progress'\nnormalized_status = 'queued'\n",
+        encoding="utf-8",
+    )
+
+    rows = audit_status_tokens.build_report_rows(
+        root=tmp_path,
+        scan_roots=("docs", "moonmind"),
+        tokens=("temporalStatus", "closeStatus", "queued", "in-progress"),
+    )
+
+    assert set(rows[0]) == {
+        "token",
+        "guessed_domain",
+        "files",
+        "canonicality",
+        "action",
+    }
+    by_token = {row["token"]: row for row in rows}
+    assert by_token["temporalStatus"]["files"] == "docs/status.md"
+    assert by_token["closeStatus"]["files"] == "docs/status.md"
+    assert by_token["queued"]["files"] == "moonmind/provider.py"
+    assert by_token["in-progress"]["files"] == "moonmind/provider.py"
+
+
+def test_csv_report_is_parseable(tmp_path: Path, capsys) -> None:
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    (docs / "status.md").write_text("mm_state\n", encoding="utf-8")
+
+    exit_code = audit_status_tokens.main(
+        ["--root", str(tmp_path), "--scan-root", "docs", "--token", "mm_state"]
+    )
+
+    assert exit_code == 0
+    parsed = list(csv.DictReader(capsys.readouterr().out.splitlines()))
+    assert parsed == [
+        {
+            "token": "mm_state",
+            "guessed_domain": "workflow_lifecycle_state",
+            "files": "docs/status.md",
+            "canonicality": "canonical",
+            "action": "keep_canonical",
+        }
+    ]

--- a/tools/audit_status_tokens.py
+++ b/tools/audit_status_tokens.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+"""Emit a non-destructive status-token inventory report for MM-1080."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+from dataclasses import dataclass
+from pathlib import Path
+import sys
+
+
+DEFAULT_TOKENS = (
+    "mm_state",
+    "closeStatus",
+    "temporalStatus",
+    "no_changes",
+    "awaiting_action",
+    "queued",
+    "in-progress",
+    "StepExecutionStatus",
+)
+
+DEFAULT_SCAN_ROOTS = (
+    "api_service",
+    "docs",
+    "moonmind",
+    "tests",
+    "tools",
+)
+
+SKIP_DIRS = {
+    ".git",
+    ".mypy_cache",
+    ".pytest_cache",
+    ".ruff_cache",
+    ".venv",
+    "__pycache__",
+    "node_modules",
+    "var",
+}
+
+TEXT_SUFFIXES = {
+    ".css",
+    ".html",
+    ".js",
+    ".json",
+    ".md",
+    ".py",
+    ".sh",
+    ".toml",
+    ".ts",
+    ".tsx",
+    ".txt",
+    ".yaml",
+    ".yml",
+}
+
+
+@dataclass(frozen=True, slots=True)
+class TokenClassification:
+    token: str
+    guessed_domain: str
+    canonicality: str
+    action: str
+
+
+TOKEN_CLASSIFICATIONS: dict[str, TokenClassification] = {
+    "mm_state": TokenClassification(
+        token="mm_state",
+        guessed_domain="workflow_lifecycle_state",
+        canonicality="canonical",
+        action="keep_canonical",
+    ),
+    "closeStatus": TokenClassification(
+        token="closeStatus",
+        guessed_domain="temporal_close_status",
+        canonicality="canonical",
+        action="keep_canonical",
+    ),
+    "temporalStatus": TokenClassification(
+        token="temporalStatus",
+        guessed_domain="temporal_status",
+        canonicality="canonical",
+        action="keep_canonical",
+    ),
+    "no_changes": TokenClassification(
+        token="no_changes",
+        guessed_domain="legacy_or_migration_status",
+        canonicality="historical",
+        action="historical_migration_only",
+    ),
+    "awaiting_action": TokenClassification(
+        token="awaiting_action",
+        guessed_domain="dashboard_compatibility_status",
+        canonicality="compatibility",
+        action="rename_domain_specific",
+    ),
+    "queued": TokenClassification(
+        token="queued",
+        guessed_domain="provider_normalized_status",
+        canonicality="boundary_canonical",
+        action="move_to_provider_boundary",
+    ),
+    "in-progress": TokenClassification(
+        token="in-progress",
+        guessed_domain="provider_native_status",
+        canonicality="non_canonical",
+        action="move_to_provider_boundary",
+    ),
+    "StepExecutionStatus": TokenClassification(
+        token="StepExecutionStatus",
+        guessed_domain="step_execution_artifact_status",
+        canonicality="canonical",
+        action="keep_canonical",
+    ),
+}
+
+REPORT_COLUMNS = (
+    "token",
+    "guessed_domain",
+    "files",
+    "canonicality",
+    "action",
+)
+
+
+def classify_token(token: str) -> TokenClassification:
+    return TOKEN_CLASSIFICATIONS.get(
+        token,
+        TokenClassification(
+            token=token,
+            guessed_domain="unknown",
+            canonicality="unknown",
+            action="delete_unused",
+        ),
+    )
+
+
+def iter_text_files(root: Path, scan_roots: tuple[str, ...]) -> list[Path]:
+    files: list[Path] = []
+    for scan_root in scan_roots:
+        base = root / scan_root
+        if not base.exists():
+            continue
+        if base.is_file():
+            candidates = [base]
+        else:
+            candidates = [
+                path
+                for path in base.rglob("*")
+                if path.is_file()
+                and not any(part in SKIP_DIRS for part in path.relative_to(root).parts)
+            ]
+        for path in candidates:
+            if path.suffix in TEXT_SUFFIXES:
+                files.append(path)
+    return sorted(set(files))
+
+
+def find_token_files(
+    *,
+    root: Path,
+    scan_roots: tuple[str, ...],
+    tokens: tuple[str, ...],
+) -> dict[str, list[str]]:
+    matches = {token: [] for token in tokens}
+    for path in iter_text_files(root, scan_roots):
+        try:
+            text = path.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            continue
+        for token in tokens:
+            if token in text:
+                matches[token].append(path.relative_to(root).as_posix())
+    return matches
+
+
+def build_report_rows(
+    *,
+    root: Path,
+    scan_roots: tuple[str, ...],
+    tokens: tuple[str, ...],
+) -> list[dict[str, str]]:
+    token_files = find_token_files(root=root, scan_roots=scan_roots, tokens=tokens)
+    rows: list[dict[str, str]] = []
+    for token in tokens:
+        classification = classify_token(token)
+        rows.append(
+            {
+                "token": token,
+                "guessed_domain": classification.guessed_domain,
+                "files": ";".join(token_files[token]),
+                "canonicality": classification.canonicality,
+                "action": classification.action,
+            }
+        )
+    return rows
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--root",
+        default=".",
+        help="Repository root to scan. Defaults to the current directory.",
+    )
+    parser.add_argument(
+        "--token",
+        action="append",
+        dest="tokens",
+        help="Token to scan. May be repeated. Defaults to the seeded MM-1080 tokens.",
+    )
+    parser.add_argument(
+        "--scan-root",
+        action="append",
+        dest="scan_roots",
+        help="Relative path to scan. May be repeated.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(list(argv or sys.argv[1:]))
+    root = Path(args.root).resolve()
+    tokens = tuple(args.tokens or DEFAULT_TOKENS)
+    scan_roots = tuple(args.scan_roots or DEFAULT_SCAN_ROOTS)
+    writer = csv.DictWriter(sys.stdout, fieldnames=REPORT_COLUMNS)
+    writer.writeheader()
+    writer.writerows(build_report_rows(root=root, scan_roots=scan_roots, tokens=tokens))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/audit_status_tokens.py
+++ b/tools/audit_status_tokens.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import csv
 from dataclasses import dataclass
+import os
 from pathlib import Path
 import sys
 
@@ -24,6 +25,7 @@ DEFAULT_TOKENS = (
 DEFAULT_SCAN_ROOTS = (
     "api_service",
     "docs",
+    "frontend/src",
     "moonmind",
     "tests",
     "tools",
@@ -144,17 +146,15 @@ def iter_text_files(root: Path, scan_roots: tuple[str, ...]) -> list[Path]:
         if not base.exists():
             continue
         if base.is_file():
-            candidates = [base]
-        else:
-            candidates = [
-                path
-                for path in base.rglob("*")
-                if path.is_file()
-                and not any(part in SKIP_DIRS for part in path.relative_to(root).parts)
-            ]
-        for path in candidates:
-            if path.suffix in TEXT_SUFFIXES:
-                files.append(path)
+            if base.suffix in TEXT_SUFFIXES:
+                files.append(base)
+            continue
+        for dirpath, dirnames, filenames in os.walk(base):
+            dirnames[:] = [dirname for dirname in dirnames if dirname not in SKIP_DIRS]
+            for filename in filenames:
+                path = Path(dirpath) / filename
+                if path.suffix in TEXT_SUFFIXES:
+                    files.append(path)
     return sorted(set(files))
 
 
@@ -168,11 +168,15 @@ def find_token_files(
     for path in iter_text_files(root, scan_roots):
         try:
             text = path.read_text(encoding="utf-8")
-        except UnicodeDecodeError:
+        except (OSError, UnicodeDecodeError, ValueError):
             continue
         for token in tokens:
             if token in text:
-                matches[token].append(path.relative_to(root).as_posix())
+                try:
+                    rel_path = path.relative_to(root).as_posix()
+                except ValueError:
+                    rel_path = path.as_posix()
+                matches[token].append(rel_path)
     return matches
 
 


### PR DESCRIPTION
Issue reference: MM-1080

Summary:
- Added docs/Temporal/StatusDomainMatrix.md as the canonical status-domain matrix for workflow lifecycle, Temporal close status, temporalStatus, step ledger, step execution artifact, and provider normalized status domains.
- Added a non-destructive tools/audit_status_tokens.py inventory command that emits token, guessed_domain, files, canonicality, and action columns.
- Added targeted unit coverage for seeded token categorization and linked the archived WorkflowStatus.md pointer to the new canonical matrix.

Tests run:
- ./tools/test_unit.sh tests/unit/tools/test_audit_status_tokens.py
- python tools/audit_status_tokens.py --token mm_state --token closeStatus --token temporalStatus --token no_changes --token awaiting_action --token queued --token in-progress --token StepExecutionStatus

Remaining risks:
- The audit command is intentionally heuristic and non-destructive; downstream cleanup still needs human review before changing status tokens.