### PR TITLE
Fix batch-workflows repository inheritance defaults

### DIFF
--- a/.agents/skills/batch-workflows/bin/batch_workflows.py
+++ b/.agents/skills/batch-workflows/bin/batch_workflows.py
@@ -167,7 +167,10 @@ def child_goal_for_target(
             if isinstance(target.get("githubIssue"), dict)
             else {}
         )
-        repository = _text(issue.get("repository")) or _text(target.get("repository"))
+        repository = (
+            _normalize_repo(issue.get("repository"))
+            or _normalize_repo(target.get("repository"))
+        )
         number = issue.get("number")
         ref = _text(target.get("ref"))
         if repository and number is not None:
@@ -209,7 +212,7 @@ def bind_child_inputs(
             "jira_issue": dict(issue) if issue else {"key": key},
             "jira_issue_key": key,
             "repository": (
-                _text(target.get("repository")) or normalized_fallback or ""
+                _normalize_repo(target.get("repository")) or normalized_fallback or ""
             ),
             "verification_mode": "auto",
             "update_status": False,
@@ -244,15 +247,19 @@ def bind_child_inputs(
             else {}
         )
         repository = (
-            _text(issue.get("repository"))
-            or _text(target.get("repository"))
+            _normalize_repo(issue.get("repository"))
+            or _normalize_repo(target.get("repository"))
             or normalized_fallback
         )
         number = issue.get("number")
         if not repository or number is None:
             return None
+        resolved_issue = dict(issue)
+        if not _text(resolved_issue.get("repository")):
+            resolved_issue["repository"] = repository
+
         inputs = {
-            "github_issue": dict(issue),
+            "github_issue": resolved_issue,
             "github_issue_ref": f"{repository}#{number}",
             "constraints": shared or "",
         }
@@ -306,7 +313,7 @@ def build_child_request(
     provider = str(target.get("provider") or "").strip().lower()
     ref = _text(target.get("ref")) or ""
     repository = (
-        _text(target.get("repository"))
+        _normalize_repo(target.get("repository"))
         or _normalize_repo(target.get("batch_repository"))
         or _normalize_repo(default_repository)
     )

--- a/.agents/skills/batch-workflows/bin/batch_workflows.py
+++ b/.agents/skills/batch-workflows/bin/batch_workflows.py
@@ -84,6 +84,15 @@ def _normalize_publish_mode(value: str | None) -> str:
     return candidate
 
 
+def _normalize_repo(value: Any) -> str | None:
+    candidate = str(value or "").strip()
+    if not candidate:
+        return None
+    if candidate.endswith(".git"):
+        candidate = candidate[:-4]
+    return candidate or None
+
+
 def parse_run_ref(value: str | None) -> tuple[str, str]:
     candidate = str(value or "").strip()
     if ":" not in candidate:
@@ -170,7 +179,11 @@ def child_goal_for_target(
 
 
 def bind_child_inputs(
-    target: dict[str, Any], target_kind: str, target_slug: str, constraints: str
+    target: dict[str, Any],
+    target_kind: str,
+    target_slug: str,
+    constraints: str,
+    fallback_repository: str | None = None,
 ) -> dict[str, Any] | None:
     """Apply the default issue bindings for the selected child target.
 
@@ -179,6 +192,7 @@ def bind_child_inputs(
     """
 
     provider = str(target.get("provider") or "").strip().lower()
+    normalized_fallback = _normalize_repo(fallback_repository)
     shared = _text(constraints)
     if (
         target_kind == "skill"
@@ -194,7 +208,9 @@ def bind_child_inputs(
         inputs: dict[str, Any] = {
             "jira_issue": dict(issue) if issue else {"key": key},
             "jira_issue_key": key,
-            "repository": _text(target.get("repository")) or "",
+            "repository": (
+                _text(target.get("repository")) or normalized_fallback or ""
+            ),
             "verification_mode": "auto",
             "update_status": False,
             "constraints": shared or "",
@@ -227,7 +243,11 @@ def bind_child_inputs(
             if isinstance(target.get("githubIssue"), dict)
             else {}
         )
-        repository = _text(issue.get("repository")) or _text(target.get("repository"))
+        repository = (
+            _text(issue.get("repository"))
+            or _text(target.get("repository"))
+            or normalized_fallback
+        )
         number = issue.get("number")
         if not repository or number is None:
             return None
@@ -276,6 +296,7 @@ def build_child_request(
     runtime: RuntimeSelection,
     batch_scope: str | None = None,
     inherit_runtime_from_caller: bool = False,
+    default_repository: str | None = None,
 ) -> dict[str, Any] | None:
     """Build a single ``POST /api/executions`` request for one resolved target.
 
@@ -284,7 +305,11 @@ def build_child_request(
 
     provider = str(target.get("provider") or "").strip().lower()
     ref = _text(target.get("ref")) or ""
-    repository = _text(target.get("repository"))
+    repository = (
+        _text(target.get("repository"))
+        or _normalize_repo(target.get("batch_repository"))
+        or _normalize_repo(default_repository)
+    )
     if not ref:
         return None
 
@@ -294,6 +319,7 @@ def build_child_request(
         config.target_kind,
         config.target_slug,
         config.constraints,
+        fallback_repository=repository,
     )
     if goal is None or inputs is None:
         return None
@@ -381,6 +407,7 @@ def build_child_requests(
     max_workflows: int,
     batch_scope: str | None = None,
     inherit_runtime_from_caller: bool = False,
+    default_repository: str | None = None,
 ) -> tuple[list[ChildSubmission], list[SkippedTarget]]:
     """Build child requests, capped at ``max_workflows`` resolved targets."""
 
@@ -406,6 +433,7 @@ def build_child_requests(
             runtime=runtime,
             batch_scope=batch_scope,
             inherit_runtime_from_caller=inherit_runtime_from_caller,
+            default_repository=default_repository,
         )
         if request is None:
             skipped.append(SkippedTarget(ref=ref, reason="unsupported_target"))
@@ -492,6 +520,27 @@ def _load_parent_runtime_selection(
                 or runtime_node.get("profileId")
             ),
         )
+    return None
+
+
+def _load_parent_repository(task_context_path: str | None = None) -> str | None:
+    seen: set[str] = set()
+    for candidate in _task_context_candidates(task_context_path):
+        identity = str(candidate.expanduser())
+        if identity in seen:
+            continue
+        seen.add(identity)
+        if not candidate.exists() or not candidate.is_file():
+            continue
+        try:
+            payload = json.loads(candidate.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if not isinstance(payload, dict):
+            continue
+        normalized = _normalize_repo(payload.get("repository"))
+        if normalized:
+            return normalized
     return None
 
 
@@ -718,6 +767,7 @@ async def main(argv: list[str] | None = None) -> int:
     targets = _read_targets(targets_path)
     constraints = _read_constraints(args)
     runtime = _resolve_runtime_selection(args.task_context_path)
+    batch_repository = _load_parent_repository(args.task_context_path)
     batch_scope = _parent_run_scope(args.task_context_path)
     inherit_from_caller = _task_workflow_id_from_env() is not None
     target_kind, target_slug = parse_run_ref(args.run_ref)
@@ -736,6 +786,7 @@ async def main(argv: list[str] | None = None) -> int:
         max_workflows=args.max_workflows,
         batch_scope=batch_scope,
         inherit_runtime_from_caller=inherit_from_caller,
+        default_repository=batch_repository,
     )
     created, errors = await _submit_jobs(submissions)
 

--- a/api_service/services/presets/catalog.py
+++ b/api_service/services/presets/catalog.py
@@ -998,6 +998,18 @@ def _apply_contextual_input_overrides(
         submitted=dict(submitted),
     )
 
+    if slug == _BATCH_WORKFLOWS_SLUG:
+        repository = _repository_from_context(context)
+        schema_defaults = _input_schema_defaults_by_name(inputs_schema)
+        submitted_repository = str(adjusted.get("repository") or "").strip()
+        schema_repository = str(schema_defaults.get("repository", "")).strip()
+        if (
+            repository
+            and (not submitted_repository or submitted_repository == schema_repository)
+        ):
+            adjusted["repository"] = repository
+        return adjusted
+
     if slug not in _JIRA_BREAKDOWN_PROJECT_DEFAULT_SLUGS:
         return adjusted
 

--- a/tests/unit/api/test_batch_workflows_preset.py
+++ b/tests/unit/api/test_batch_workflows_preset.py
@@ -238,6 +238,35 @@ async def test_batch_workflows_expands_orchestration_step(tmp_path):
             assert "jira" not in expanded["capabilities"]
 
 
+async def test_batch_workflows_expands_repository_from_context_when_not_provided(tmp_path):
+    async with _catalog_db(tmp_path) as session_maker:
+        async with session_maker() as session:
+            service = PresetCatalogService(session)
+            await service.sync_seed_templates(seed_dir=_seed_dir(tmp_path))
+
+            expanded = await service.expand_template(
+                slug="batch-workflows",
+                scope="global",
+                scope_ref=None,
+                inputs={
+                    "jira_project_key": "MM",
+                    "jira_status": "In Progress",
+                    "run_ref": "skill:jira-verify",
+                    "publish_mode": "none",
+                    "constraints": "Be careful",
+                    "additional_jql": "assignee = currentUser()",
+                    "max_workflows": "10",
+                },
+                context={"repository": "MoonLadderStudios/MoonMind"},
+            )
+
+            orchestration = expanded["steps"][0]["batchOrchestration"]
+            assert (
+                orchestration["source"]["jiraStatus"]["repository"]
+                == "MoonLadderStudios/MoonMind"
+            )
+
+
 async def test_batch_workflows_ignores_removed_target_preset_version_input(tmp_path):
     async with _catalog_db(tmp_path) as session_maker:
         async with session_maker() as session:

--- a/tests/unit/test_batch_workflows.py
+++ b/tests/unit/test_batch_workflows.py
@@ -102,6 +102,21 @@ def test_bind_child_inputs_jira_verify_auto_binds_issue_object_and_key():
     assert inputs["constraints"] == "Be careful"
 
 
+def test_bind_child_inputs_jira_verify_uses_fallback_repository_when_missing():
+    module = _load_module()
+    no_repo_target = dict(_JIRA_TARGET)
+    no_repo_target.pop("repository", None)
+    inputs = module["bind_child_inputs"](
+        no_repo_target,
+        "skill",
+        "jira-verify",
+        "Be careful",
+        fallback_repository="MoonLadderStudios/Tactics",
+    )
+    assert inputs is not None
+    assert inputs["repository"] == "MoonLadderStudios/Tactics"
+
+
 def test_bind_child_inputs_jira_implement_preset_auto_binds_issue_object_and_key():
     module = _load_module()
     inputs = module["bind_child_inputs"](
@@ -168,6 +183,19 @@ def test_child_goal_routes_to_selected_run_capability():
     assert github_goal is not None
 
 
+def test_load_parent_repository_reads_task_context(tmp_path):
+    module = _load_module()
+    load_parent_repository = module["_load_parent_repository"]
+
+    task_context = tmp_path / "task_context.json"
+    task_context.write_text('{"repository":"MoonLadderStudios/Tactics"}', encoding="utf-8")
+
+    assert (
+        load_parent_repository(str(task_context))
+        == "MoonLadderStudios/Tactics"
+    )
+
+
 def test_build_child_request_sets_runtime_inheritance_publish_and_idempotency():
     module = _load_module()
     runtime = module["RuntimeSelection"](
@@ -207,6 +235,23 @@ def test_build_child_request_sets_runtime_inheritance_publish_and_idempotency():
     key = payload["idempotencyKey"]
     assert key.startswith("batch-workflows:jira:THOR-123:sha256:")
     assert len(key) <= module["IDEMPOTENCY_KEY_MAX_LENGTH"]
+
+
+def test_build_child_request_uses_default_repository_when_target_missing():
+    module = _load_module()
+    target = dict(_JIRA_TARGET)
+    target.pop("repository", None)
+    request = module["build_child_request"](
+        target,
+        config=_jira_config(module),
+        runtime=module["RuntimeSelection"](mode="codex_cli"),
+        batch_scope="run-1",
+        inherit_runtime_from_caller=True,
+        default_repository="MoonLadderStudios/Alternate",
+    )
+    assert request is not None
+    assert request["payload"]["repository"] == "MoonLadderStudios/Alternate"
+    assert request["payload"]["task"]["inputs"]["repository"] == "MoonLadderStudios/Alternate"
 
 
 def test_idempotency_key_includes_target_kind_and_slug():


### PR DESCRIPTION
Preserve selected repository for batch-workflows by defaulting batch inputs and child queue submissions from parent context. Adds unit test coverage for preset expansion and helper request construction.