### PR TITLE
[codex] Retry Codex empty assistant self-heal twice

### DIFF
--- a/moonmind/workflows/adapters/codex_session_adapter.py
+++ b/moonmind/workflows/adapters/codex_session_adapter.py
@@ -175,6 +175,7 @@ _SESSION_INTERVENTION_FIELDS = (
     "fromSessionEpoch",
     "toSessionEpoch",
 )
+_EMPTY_ASSISTANT_MAX_CLEAR_SESSION_ATTEMPTS = 2
 _JIRA_CREATED_ISSUE_KEYS_PATTERN = re.compile(
     r"\b(?:created\s+(?:jira\s+)?(?:issues?|stories?|tickets?)|"
     r"created\s+(?:issue\s+)?keys?|issue\s+keys?\s+created)\b"
@@ -757,67 +758,90 @@ class CodexSessionAdapter(ManagedAgentAdapter):
                     turn_error.type == "CodexTransientTurnError"
                     and _is_empty_assistant_turn_failure(turn_metadata)
                 ):
-                    previous_locator = current_locator
-                    reset_thread_id = _reset_thread_id_for_empty_turn(previous_locator)
-                    reset_handle = await self.clear_session(
-                        binding=binding,
-                        new_thread_id=reset_thread_id,
-                        reason="retry_after_empty_assistant_output",
-                        request_id=(
-                            f"{binding.agent_run_id}:empty-assistant-clear:"
-                            f"{previous_locator.session_epoch}:"
-                            f"{previous_locator.thread_id}"
-                        ),
-                    )
-                    current_locator = self._locator_from_state(
-                        session_state=reset_handle.session_state,
-                        runtime_epoch=reset_handle.session_state.session_epoch,
-                    )
-                    current_active_turn_id = reset_handle.session_state.active_turn_id
-                    session_interventions.append(
-                        {
-                            "action": "clear_session",
-                            "reason": "retry_after_empty_assistant_output",
-                            "fromThreadId": previous_locator.thread_id,
-                            "toThreadId": current_locator.thread_id,
-                            "fromSessionEpoch": previous_locator.session_epoch,
-                            "toSessionEpoch": current_locator.session_epoch,
-                        }
-                    )
-                    try:
-                        turn_response = await _send_current_turn()
-                    except ActivityError as retry_exc:
-                        retry_error = (
-                            retry_exc.cause
-                            if isinstance(retry_exc.cause, ApplicationError)
-                            else None
+                    prior_turn_failures: list[dict[str, Any]] = [dict(turn_metadata)]
+                    for _attempt in range(
+                        1, _EMPTY_ASSISTANT_MAX_CLEAR_SESSION_ATTEMPTS + 1
+                    ):
+                        previous_locator = current_locator
+                        reset_thread_id = _reset_thread_id_for_empty_turn(
+                            previous_locator
                         )
-                        if retry_error is None or retry_error.type not in (
-                            "CodexTransientTurnError",
-                            "CodexPermanentTurnError",
-                        ):
-                            raise
-                        retry_metadata = _turn_failure_metadata_from_activity_error(
-                            retry_error
+                        reset_handle = await self.clear_session(
+                            binding=binding,
+                            new_thread_id=reset_thread_id,
+                            reason="retry_after_empty_assistant_output",
+                            request_id=(
+                                f"{binding.agent_run_id}:empty-assistant-clear:"
+                                f"{previous_locator.session_epoch}:"
+                                f"{previous_locator.thread_id}"
+                            ),
                         )
-                        if _is_empty_assistant_turn_failure(retry_metadata):
-                            retry_metadata["selfHealExhausted"] = True
-                            retry_metadata["selfHealAction"] = "clear_session"
-                            retry_metadata["selfHealAttempts"] = 1
-                        retry_metadata["sessionInterventions"] = session_interventions
-                        retry_metadata["priorTurnFailure"] = turn_metadata
-                        publication = await self._publish_failure_artifacts(
-                            locator=current_locator,
-                            managed_run_id=binding.agent_run_id,
-                            run_id=run_id,
+                        current_locator = self._locator_from_state(
+                            session_state=reset_handle.session_state,
+                            runtime_epoch=reset_handle.session_state.session_epoch,
                         )
-                        failure_error = _publish_activity_error_result(
-                            retry_error,
-                            retry_metadata,
-                            publication,
+                        current_active_turn_id = reset_handle.session_state.active_turn_id
+                        session_interventions.append(
+                            {
+                                "action": "clear_session",
+                                "reason": "retry_after_empty_assistant_output",
+                                "fromThreadId": previous_locator.thread_id,
+                                "toThreadId": current_locator.thread_id,
+                                "fromSessionEpoch": previous_locator.session_epoch,
+                                "toSessionEpoch": current_locator.session_epoch,
+                            }
                         )
-                        failed_state_persisted = True
-                        raise failure_error from retry_exc
+                        try:
+                            turn_response = await _send_current_turn()
+                            break
+                        except ActivityError as retry_exc:
+                            retry_error = (
+                                retry_exc.cause
+                                if isinstance(retry_exc.cause, ApplicationError)
+                                else None
+                            )
+                            if retry_error is None or retry_error.type not in (
+                                "CodexTransientTurnError",
+                                "CodexPermanentTurnError",
+                            ):
+                                raise
+                            retry_metadata = _turn_failure_metadata_from_activity_error(
+                                retry_error
+                            )
+                            is_empty_retry = _is_empty_assistant_turn_failure(
+                                retry_metadata
+                            )
+                            can_retry_empty_turn = (
+                                retry_error.type == "CodexTransientTurnError"
+                                and is_empty_retry
+                                and _attempt
+                                < _EMPTY_ASSISTANT_MAX_CLEAR_SESSION_ATTEMPTS
+                            )
+                            if can_retry_empty_turn:
+                                prior_turn_failures.append(dict(retry_metadata))
+                                continue
+                            if is_empty_retry:
+                                retry_metadata["selfHealExhausted"] = True
+                                retry_metadata["selfHealAction"] = "clear_session"
+                                retry_metadata["selfHealAttempts"] = len(
+                                    session_interventions
+                                )
+                            retry_metadata["sessionInterventions"] = session_interventions
+                            retry_metadata["priorTurnFailure"] = prior_turn_failures[0]
+                            if len(prior_turn_failures) > 1:
+                                retry_metadata["priorTurnFailures"] = prior_turn_failures
+                            publication = await self._publish_failure_artifacts(
+                                locator=current_locator,
+                                managed_run_id=binding.agent_run_id,
+                                run_id=run_id,
+                            )
+                            failure_error = _publish_activity_error_result(
+                                retry_error,
+                                retry_metadata,
+                                publication,
+                            )
+                            failed_state_persisted = True
+                            raise failure_error from retry_exc
                 else:
                     publication = await self._publish_failure_artifacts(
                         locator=current_locator,

--- a/moonmind/workflows/adapters/codex_session_adapter.py
+++ b/moonmind/workflows/adapters/codex_session_adapter.py
@@ -770,6 +770,7 @@ class CodexSessionAdapter(ManagedAgentAdapter):
                             binding=binding,
                             new_thread_id=reset_thread_id,
                             reason="retry_after_empty_assistant_output",
+                            locator=previous_locator,
                             request_id=(
                                 f"{binding.agent_run_id}:empty-assistant-clear:"
                                 f"{previous_locator.session_epoch}:"
@@ -1262,8 +1263,9 @@ class CodexSessionAdapter(ManagedAgentAdapter):
         new_thread_id: str,
         reason: str | None = None,
         request_id: str | None = None,
+        locator: CodexManagedSessionLocator | None = None,
     ) -> CodexManagedSessionHandle:
-        locator = await self._current_locator(binding)
+        locator = locator or await self._current_locator(binding)
         try:
             handle = await self._clear_session_with_locator(
                 locator=locator,

--- a/tests/unit/workflows/adapters/test_codex_session_adapter.py
+++ b/tests/unit/workflows/adapters/test_codex_session_adapter.py
@@ -1988,7 +1988,9 @@ async def test_start_marks_empty_assistant_retry_exhausted(
     binding = _binding()
     workspace_path = tmp_path / "agent_jobs" / binding.agent_run_id / "repo"
     reset_thread_id = "thread-1:empty-output-reset"
+    second_reset_thread_id = "thread-1:empty-output-reset:empty-output-reset"
     send_turn_calls: list[Any] = []
+    clear_calls: list[Any] = []
     run_store = ManagedRunStore(tmp_path / "managed_runs")
 
     async def _load_snapshot(_workflow_id: str) -> CodexManagedSessionSnapshot:
@@ -2025,14 +2027,15 @@ async def test_start_marks_empty_assistant_retry_exhausted(
         )
 
     async def _clear_remote_session(request: Any) -> CodexManagedSessionHandle:
-        assert request.request_id == (
-            f"{binding.agent_run_id}:empty-assistant-clear:1:thread-1"
+        clear_calls.append(request)
+        expected_thread_id = (
+            reset_thread_id if len(clear_calls) == 1 else second_reset_thread_id
         )
         return _session_handle(
             session_id=binding.session_id,
-            session_epoch=2,
+            session_epoch=1 + len(clear_calls),
             container_id="container-1",
-            thread_id=reset_thread_id,
+            thread_id=expected_thread_id,
         )
 
     async def _publish_artifacts(
@@ -2074,12 +2077,158 @@ async def test_start_marks_empty_assistant_retry_exhausted(
     with pytest.raises(CodexSessionRunFailedError) as excinfo:
         await adapter.start(_request(binding, workspace_path=str(workspace_path)))
 
-    assert len(send_turn_calls) == 2
+    assert len(send_turn_calls) == 3
+    assert len(clear_calls) == 2
+    assert clear_calls[0].request_id == (
+        f"{binding.agent_run_id}:empty-assistant-clear:1:thread-1"
+    )
+    assert clear_calls[1].request_id == (
+        f"{binding.agent_run_id}:empty-assistant-clear:2:{reset_thread_id}"
+    )
     turn_metadata = excinfo.value.agent_run_result.metadata["turnMetadata"]
     assert turn_metadata["selfHealExhausted"] is True
     assert turn_metadata["selfHealAction"] == "clear_session"
-    assert turn_metadata["selfHealAttempts"] == 1
+    assert turn_metadata["selfHealAttempts"] == 2
     assert turn_metadata["sessionInterventions"][0]["toSessionEpoch"] == 2
+    assert turn_metadata["sessionInterventions"][1]["toSessionEpoch"] == 3
+
+
+async def test_start_recovers_after_second_empty_assistant_clear(
+    tmp_path: Path,
+) -> None:
+    binding = _binding()
+    workspace_path = tmp_path / "agent_jobs" / binding.agent_run_id / "repo"
+    reset_thread_id = "thread-1:empty-output-reset"
+    second_reset_thread_id = "thread-1:empty-output-reset:empty-output-reset"
+    send_turn_calls: list[Any] = []
+    clear_calls: list[Any] = []
+    run_store = ManagedRunStore(tmp_path / "managed_runs")
+
+    async def _load_snapshot(_workflow_id: str) -> CodexManagedSessionSnapshot:
+        return _snapshot(
+            binding=binding,
+            container_id="container-1",
+            thread_id="thread-1",
+        )
+
+    async def _session_status(_request: Any) -> CodexManagedSessionHandle:
+        return _session_handle(
+            session_id=binding.session_id,
+            session_epoch=binding.session_epoch,
+            container_id="container-1",
+            thread_id="thread-1",
+        )
+
+    async def _send_turn(request: Any) -> CodexManagedSessionTurnResponse:
+        send_turn_calls.append(request)
+        if len(send_turn_calls) < 3:
+            metadata = {
+                "reason": "codex app-server turn/completed produced no assistant output",
+                "failureClass": "transient",
+                "failureCause": "app_server_protocol_empty_turn",
+                "retryRecommendedAction": "clear_session",
+                "turnFailureEvidence": {"schemaVersion": "v1"},
+            }
+            _raise_activity_error_from_application_error(
+                ApplicationError(
+                    metadata["reason"],
+                    metadata,
+                    type="CodexTransientTurnError",
+                    non_retryable=True,
+                )
+            )
+        return _turn_response(
+            session_id=binding.session_id,
+            session_epoch=3,
+            container_id="container-1",
+            thread_id=second_reset_thread_id,
+            turn_id="turn-after-second-reset",
+            status="completed",
+            assistant_text="Recovered after second session reset.",
+        )
+
+    async def _clear_remote_session(request: Any) -> CodexManagedSessionHandle:
+        clear_calls.append(request)
+        expected_thread_id = (
+            reset_thread_id if len(clear_calls) == 1 else second_reset_thread_id
+        )
+        return _session_handle(
+            session_id=binding.session_id,
+            session_epoch=1 + len(clear_calls),
+            container_id="container-1",
+            thread_id=expected_thread_id,
+        )
+
+    async def _fetch_summary(_request: Any) -> CodexManagedSessionSummary:
+        return _summary(
+            session_id=binding.session_id,
+            session_epoch=3,
+            container_id="container-1",
+            thread_id=second_reset_thread_id,
+            last_assistant_text="Recovered after second session reset.",
+        )
+
+    async def _publish_artifacts(
+        _request: Any,
+    ) -> CodexManagedSessionArtifactsPublication:
+        return _publication(
+            session_id=binding.session_id,
+            session_epoch=3,
+            container_id="container-1",
+            thread_id=second_reset_thread_id,
+        )
+
+    adapter = CodexSessionAdapter(
+        profile_fetcher=_fake_profiles(
+            [{"profile_id": "codex-default", "credential_source": "oauth_volume"}]
+        ),
+        slot_requester=_async_noop,
+        slot_releaser=_async_noop,
+        cooldown_reporter=_async_noop,
+        workflow_id="wf-agent-run-1",
+        runtime_id="codex_cli",
+        run_store=run_store,
+        load_session_snapshot=_load_snapshot,
+        launch_session=_async_noop,
+        session_status=_session_status,
+        prepare_turn_instructions=_prepare_turn_instructions,
+        send_turn=_send_turn,
+        interrupt_turn=_async_noop,
+        clear_remote_session=_clear_remote_session,
+        terminate_remote_session=_async_noop,
+        fetch_remote_summary=_fetch_summary,
+        publish_remote_artifacts=_publish_artifacts,
+        attach_runtime_handles=_async_noop,
+        apply_session_control_action=_async_noop,
+        workspace_root=str(tmp_path / "agent_jobs"),
+        session_image_ref="ghcr.io/moonladderstudios/moonmind:latest",
+    )
+
+    handle = await adapter.start(_request(binding, workspace_path=str(workspace_path)))
+    result = await adapter.fetch_result(handle.run_id)
+
+    assert handle.status == "completed"
+    assert len(send_turn_calls) == 3
+    assert len(clear_calls) == 2
+    assert send_turn_calls[2].thread_id == second_reset_thread_id
+    assert result.metadata["turnMetadata"]["sessionInterventions"] == [
+        {
+            "action": "clear_session",
+            "reason": "retry_after_empty_assistant_output",
+            "fromThreadId": "thread-1",
+            "toThreadId": reset_thread_id,
+            "fromSessionEpoch": 1,
+            "toSessionEpoch": 2,
+        },
+        {
+            "action": "clear_session",
+            "reason": "retry_after_empty_assistant_output",
+            "fromThreadId": reset_thread_id,
+            "toThreadId": second_reset_thread_id,
+            "fromSessionEpoch": 2,
+            "toSessionEpoch": 3,
+        },
+    ]
 
 
 async def test_start_does_not_clear_session_for_codex_no_credits_failure(

--- a/tests/unit/workflows/adapters/test_codex_session_adapter.py
+++ b/tests/unit/workflows/adapters/test_codex_session_adapter.py
@@ -2028,6 +2028,10 @@ async def test_start_marks_empty_assistant_retry_exhausted(
 
     async def _clear_remote_session(request: Any) -> CodexManagedSessionHandle:
         clear_calls.append(request)
+        assert request.session_epoch == len(clear_calls)
+        assert request.thread_id == (
+            "thread-1" if len(clear_calls) == 1 else reset_thread_id
+        )
         expected_thread_id = (
             reset_thread_id if len(clear_calls) == 1 else second_reset_thread_id
         )
@@ -2149,6 +2153,10 @@ async def test_start_recovers_after_second_empty_assistant_clear(
 
     async def _clear_remote_session(request: Any) -> CodexManagedSessionHandle:
         clear_calls.append(request)
+        assert request.session_epoch == len(clear_calls)
+        assert request.thread_id == (
+            "thread-1" if len(clear_calls) == 1 else reset_thread_id
+        )
         expected_thread_id = (
             reset_thread_id if len(clear_calls) == 1 else second_reset_thread_id
         )


### PR DESCRIPTION
## Summary
- Allow the Codex session adapter to clear the session twice for consecutive app-server empty-turn failures before exhausting the run.
- Preserve prior empty-turn failure evidence and report the actual `selfHealAttempts` count.
- Add adapter unit coverage for both second-clear recovery and exhaustion after two clears.

## Root cause
Workflow `mm:77af0016-c16d-4828-a1d1-9b3fa38efaf7` failed after its dependency chain hit repeated Codex app-server `task_complete` / turn-completed events with no assistant output. The adapter classified this as transient and cleared the session once, but the second consecutive empty turn immediately exhausted the run because the self-heal budget was hardcoded to one clear-session retry.

## Impact
This keeps recovery inside the Codex session adapter boundary and avoids changing root `MoonMind.AgentRun` workflow command ordering. Future transient empty-turn incidents get one additional isolated session clear before the workflow is marked failed.

## Validation
- Not run; tests were not explicitly requested in this session.