### PR TITLE
[codex] Fix publish staging for pre-staged deletes

### DIFF
--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -9320,6 +9320,16 @@ class TemporalAgentRuntimeActivities:
     @staticmethod
     def _parse_git_status_records(status_output: bytes) -> tuple[tuple[str, str], ...]:
         """Extract ``(status, path)`` records from `git status --porcelain=v1 -z`."""
+        entries = TemporalAgentRuntimeActivities._parse_git_status_record_entries(
+            status_output
+        )
+        return tuple((status, path) for status, path, _is_source_path in entries)
+
+    @staticmethod
+    def _parse_git_status_record_entries(
+        status_output: bytes,
+    ) -> tuple[tuple[str, str, bool], ...]:
+        """Extract Git status records and mark rename/copy source paths."""
 
         def _decode_path(path_bytes: bytes) -> str:
             return os.fsdecode(path_bytes)
@@ -9329,7 +9339,7 @@ class TemporalAgentRuntimeActivities:
             return ()
 
         entries = raw_output.split(b"\0")
-        records: list[tuple[str, str]] = []
+        records: list[tuple[str, str, bool]] = []
         index = 0
         while index < len(entries):
             record = entries[index]
@@ -9343,7 +9353,7 @@ class TemporalAgentRuntimeActivities:
             path_bytes = record[3:]
             if not path_bytes:
                 raise ValueError(f"missing path in git status record: {record!r}")
-            records.append((status, _decode_path(path_bytes)))
+            records.append((status, _decode_path(path_bytes), False))
 
             if "R" in status or "C" in status:
                 index += 1
@@ -9356,14 +9366,21 @@ class TemporalAgentRuntimeActivities:
                     raise ValueError(
                         f"missing original path for git rename/copy record: {record!r}"
                     )
-                records.append((status, _decode_path(original_path_bytes)))
+                records.append((status, _decode_path(original_path_bytes), True))
 
             index += 1
 
-        deduped: dict[str, tuple[str, str]] = {}
-        for status, path in records:
-            deduped.setdefault(path, (status, path))
+        deduped: dict[str, tuple[str, str, bool]] = {}
+        for status, path, is_source_path in records:
+            deduped.setdefault(path, (status, path, is_source_path))
         return tuple(deduped.values())
+
+    @staticmethod
+    def _git_status_needs_worktree_stage(status: str) -> bool:
+        """Return True when a porcelain status has unstaged worktree changes."""
+        if len(status) != 2 or status in {"??", "!!"}:
+            return False
+        return status[1] != " "
 
     @staticmethod
     def _should_exclude_publish_path(
@@ -9886,7 +9903,11 @@ class TemporalAgentRuntimeActivities:
             workspace_path = Path(workspace).expanduser().resolve()
             tracked_paths: list[str] = []
             untracked_paths: list[str] = []
-            for status, path in self._parse_git_status_records(status_stdout):
+            for (
+                status,
+                path,
+                is_source_path,
+            ) in self._parse_git_status_record_entries(status_stdout):
                 if self._should_exclude_publish_path(
                     path,
                     workspace=workspace_path,
@@ -9894,15 +9915,17 @@ class TemporalAgentRuntimeActivities:
                     continue
                 if status == "??":
                     untracked_paths.append(path)
-                elif status != "!!":
+                elif (
+                    status != "!!"
+                    and not is_source_path
+                    and self._git_status_needs_worktree_stage(status)
+                ):
                     tracked_paths.append(path)
         except ValueError as exc:
             return {
                 "push_status": "failed",
                 "push_error": f"could not parse workspace changes: {exc}",
             }
-        if not tracked_paths and not untracked_paths:
-            return {}
 
         async def _stage_paths(
             *,
@@ -9960,7 +9983,17 @@ class TemporalAgentRuntimeActivities:
                 "push_error": f"could not inspect staged workspace changes: {detail}",
             }
 
-        if not staged_stdout.decode("utf-8", errors="replace").strip():
+        staged_paths = [
+            path.strip()
+            for path in staged_stdout.decode("utf-8", errors="replace").splitlines()
+            if path.strip()
+        ]
+        publishable_staged_paths = [
+            path
+            for path in staged_paths
+            if not self._should_exclude_publish_path(path, workspace=workspace_path)
+        ]
+        if not publishable_staged_paths:
             return {}
 
         normalized_message = (

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -10003,7 +10003,12 @@ class TemporalAgentRuntimeActivities:
         )
         commit_proc = await asyncio.create_subprocess_exec(
             *self._workspace_git_command(
-                workspace, "commit", "-m", normalized_message,
+                workspace,
+                "commit",
+                "-m",
+                normalized_message,
+                "--",
+                *publishable_staged_paths,
             ),
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,

--- a/tests/unit/services/temporal/test_fetch_result_push.py
+++ b/tests/unit/services/temporal/test_fetch_result_push.py
@@ -1422,6 +1422,81 @@ class TestPushWorkspaceBranch:
         ]
 
     @pytest.mark.asyncio
+    async def test_push_commits_already_staged_add_delete_without_restaging(self):
+        """Already-staged add/delete changes should commit without pathspec failures."""
+        store = _make_mock_store()
+        activities = TemporalAgentRuntimeActivities(run_store=store)
+        call_count = 0
+        recorded_calls: list[tuple[object, ...]] = []
+
+        async def _mock_exec(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            recorded_calls.append(args)
+            proc = AsyncMock()
+            if call_count == 1:  # rev-parse
+                proc.communicate = AsyncMock(return_value=(b"auto-staged123\n", b""))
+                proc.returncode = 0
+            elif call_count == 2:  # status --porcelain
+                proc.communicate = AsyncMock(
+                    return_value=(
+                        b"A  tests/unit/tools/test_link_moonspec_submodule.py\0"
+                        b"D  tests/unit/tools/test_sync_moonspec_submodule.py\0",
+                        b"",
+                    )
+                )
+                proc.returncode = 0
+            elif call_count == 3:  # staged diff check
+                proc.communicate = AsyncMock(
+                    return_value=(
+                        b"tests/unit/tools/test_link_moonspec_submodule.py\n"
+                        b"tests/unit/tools/test_sync_moonspec_submodule.py\n",
+                        b"",
+                    )
+                )
+                proc.returncode = 0
+            elif call_count == 4:  # commit
+                proc.communicate = AsyncMock(
+                    return_value=(b"[auto-staged123 abc123] msg\n", b"")
+                )
+                proc.returncode = 0
+            elif call_count == 5:  # remote default branch
+                proc.communicate = AsyncMock(return_value=(b"origin/main\n", b""))
+                proc.returncode = 0
+            elif call_count == 6:  # remote branch sha before push
+                proc.communicate = AsyncMock(return_value=(b"staged-remote-sha\n", b""))
+                proc.returncode = 0
+            elif call_count == 7:  # push
+                proc.communicate = AsyncMock(return_value=(b"", b""))
+                proc.returncode = 0
+            elif call_count == 8:  # rev-parse HEAD
+                proc.communicate = AsyncMock(return_value=(b"staged-head-sha\n", b""))
+                proc.returncode = 0
+            else:  # rev-list --count
+                proc.communicate = AsyncMock(return_value=(b"1\n", b""))
+                proc.returncode = 0
+            return proc
+
+        with patch("asyncio.create_subprocess_exec", side_effect=_mock_exec):
+            result = await activities._push_workspace_branch(
+                "run-1",
+                commit_message="Ship staged workspace",
+            )
+
+        assert result["push_status"] == "pushed"
+        assert result["push_branch"] == "auto-staged123"
+        assert result["push_commit_count"] == 1
+        assert result["push_head_sha"] == "staged-head-sha"
+        assert result["push_commit_message"] == "Ship staged workspace"
+        assert all("add" not in call for call in recorded_calls)
+        commit_call = next(call for call in recorded_calls if "commit" in call)
+        assert list(commit_call[-3:]) == [
+            "commit",
+            "-m",
+            "Ship staged workspace",
+        ]
+
+    @pytest.mark.asyncio
     async def test_push_dirty_workspace_commit_failure_returns_failed(self):
         """Commit failures surface as publish failures instead of false no-ops."""
         store = _make_mock_store()

--- a/tests/unit/services/temporal/test_fetch_result_push.py
+++ b/tests/unit/services/temporal/test_fetch_result_push.py
@@ -1356,7 +1356,13 @@ class TestPushWorkspaceBranch:
             "tests/new_test.py",
         ]
         commit_call = next(call for call in recorded_calls if "commit" in call)
-        assert list(commit_call[-3:]) == ["commit", "-m", "Ship dirty workspace"]
+        assert list(commit_call[-5:]) == [
+            "-m",
+            "Ship dirty workspace",
+            "--",
+            "api_service/main.py",
+            "tests/new_test.py",
+        ]
 
     @pytest.mark.asyncio
     async def test_push_stages_tracked_artifact_under_ignored_parent_with_update(self):
@@ -1490,10 +1496,12 @@ class TestPushWorkspaceBranch:
         assert result["push_commit_message"] == "Ship staged workspace"
         assert all("add" not in call for call in recorded_calls)
         commit_call = next(call for call in recorded_calls if "commit" in call)
-        assert list(commit_call[-3:]) == [
-            "commit",
+        assert list(commit_call[-5:]) == [
             "-m",
             "Ship staged workspace",
+            "--",
+            "tests/unit/tools/test_link_moonspec_submodule.py",
+            "tests/unit/tools/test_sync_moonspec_submodule.py",
         ]
 
     @pytest.mark.asyncio

--- a/tests/unit/workflows/temporal/test_agent_runtime_activities.py
+++ b/tests/unit/workflows/temporal/test_agent_runtime_activities.py
@@ -5087,13 +5087,23 @@ async def test_commit_workspace_changes_filters_skill_projection_from_string_wor
     projection.symlink_to(backing, target_is_directory=True)
     activities = TemporalAgentRuntimeActivities()
     recorded_calls: list[tuple[object, ...]] = []
+    call_count = 0
 
     async def _mock_exec(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
         recorded_calls.append(args)
         proc = AsyncMock()
-        proc.communicate = AsyncMock(
-            return_value=(b" D .agents/skills/pr-resolver/SKILL.md\0", b"")
-        )
+        if call_count == 1:
+            proc.communicate = AsyncMock(
+                return_value=(b" D .agents/skills/pr-resolver/SKILL.md\0", b"")
+            )
+        elif call_count == 2:
+            proc.communicate = AsyncMock(
+                return_value=(b".agents/skills/pr-resolver/SKILL.md\n", b"")
+            )
+        else:
+            raise AssertionError(f"Unexpected subprocess call #{call_count}: {args!r}")
         proc.returncode = 0
         return proc
 
@@ -5107,7 +5117,63 @@ async def test_commit_workspace_changes_filters_skill_projection_from_string_wor
         )
 
     assert result == {}
-    assert len(recorded_calls) == 1
+    assert len(recorded_calls) == 2
+
+
+async def test_commit_workspace_changes_commits_only_publishable_staged_paths(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "repo"
+    workspace.mkdir()
+    activities = TemporalAgentRuntimeActivities()
+    recorded_calls: list[tuple[object, ...]] = []
+    call_count = 0
+
+    async def _mock_exec(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        recorded_calls.append(args)
+        proc = AsyncMock()
+        if call_count == 1:
+            proc.communicate = AsyncMock(
+                return_value=(b"D  publishable.txt\0D  CLAUDE.md\0", b"")
+            )
+        elif call_count == 2:
+            proc.communicate = AsyncMock(
+                return_value=(b"publishable.txt\nCLAUDE.md\n", b"")
+            )
+        elif call_count == 3:
+            proc.communicate = AsyncMock(return_value=(b"[main abc123] commit\n", b""))
+        else:
+            raise AssertionError(f"Unexpected subprocess call #{call_count}: {args!r}")
+        proc.returncode = 0
+        return proc
+
+    with pytest.MonkeyPatch.context() as patcher:
+        patcher.setattr(asyncio, "create_subprocess_exec", _mock_exec)
+        result = await activities._commit_workspace_changes_if_needed(
+            str(workspace),
+            run_id="run-1",
+            env={},
+            commit_message="publish result",
+        )
+
+    assert result == {"push_commit_message": "publish result"}
+    assert recorded_calls[0][-4:] == (
+        "status",
+        "--porcelain=v1",
+        "-z",
+        "--untracked-files=all",
+    )
+    assert recorded_calls[1][-3:] == ("diff", "--cached", "--name-only")
+    assert recorded_calls[2][-5:] == (
+        "commit",
+        "-m",
+        "publish result",
+        "--",
+        "publishable.txt",
+    )
+    assert "CLAUDE.md" not in recorded_calls[2]
 
 
 async def test_publish_path_filter_allows_checked_in_skill_directory(


### PR DESCRIPTION
## Summary

Fixes MoonMind publish finalization when an agent leaves changes already staged, including staged deletes. The failed workflow `mm:e07c5111-1283-4545-ad60-033d63d633b3` accepted its implementation step, then failed finalization because publish tried to run `git add -u` on an already-staged deleted path and Git returned a pathspec error.

## Root Cause

`_commit_workspace_changes_if_needed` treated every non-untracked porcelain status path as needing restage. For index-only changes such as `D  tests/unit/tools/test_sync_moonspec_submodule.py`, the path is already staged and absent from the worktree/index, so `git add -u -- <deleted-path>` can fail even though the staged deletion is ready to commit.

## Changes

- Parse porcelain status records with rename/copy source-path metadata for publish staging.
- Stage only worktree-side changes and untracked files.
- Commit already-staged publishable changes by checking the cached diff instead of returning early.
- Add a regression test for already-staged add/delete changes so publish commits without restaging deleted paths.

## Validation

- `git diff --check`
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/services/temporal/test_fetch_result_push.py`
  - Python target: `73 passed`
  - Frontend wrapper suite: `46 passed`, `745 passed`, `237 skipped`