### PR TITLE
Make the no commit status pill gray instead of teal and update the related docs accordingly as well.

### DIFF
--- a/docs/UI/WorkflowStatusColorSemantics.md
+++ b/docs/UI/WorkflowStatusColorSemantics.md
@@ -100,7 +100,7 @@ Rationale: `awaiting_slot` represents a workflow that is waiting for capacity, n
 | `waiting_on_dependencies` | Awaiting dep | Blocked yellow | `#92400E` | `#FACC15` | Furthest non-terminal distance from active execution; blocked on prerequisite workflow state and kept legible against purple dashboard backgrounds. |
 | `awaiting_external` | Awaiting external | Blocked yellow | `#92400E` | `#FACC15` | Furthest non-terminal distance from active execution; waiting on an external system, provider, or human and kept legible against purple dashboard backgrounds. |
 | `finalizing` | Finalizing | Finalization slate | `#64748B` | `#64748B` | Wrap-up, recording, publish summary, and terminalization work. |
-| `no_commit` | No commit | No-commit teal | `#159376` | `#1A997B` | Successful or side-effectful completion with no repository commit/publish artifact. |
+| `no_commit` | No commit | No-commit gray | Muted gray token | Muted gray token | Successful or side-effectful completion with no repository commit/publish artifact. |
 
 ---
 
@@ -113,9 +113,9 @@ Terminal outcomes should remain visually stable and easy to scan:
 - `completed` is green.
 - `failed` is red.
 - `canceled` is orange.
-- `no_commit` is teal and success-adjacent, not green.
+- `no_commit` is neutral gray, not green or teal.
 
-`no_commit` must not be colored green because that would hide the fact that a publish-mode workflow did not produce a commit or PR. It must not be colored red, orange, purple, or yellow because the outcome is not a failure or blocker when the workflow correctly determined no commit was required.
+`no_commit` must not be colored green or teal because that would hide the fact that a publish-mode workflow did not produce a commit or PR. It must not be colored red, orange, purple, or yellow because the outcome is not a failure or blocker when the workflow correctly determined no commit was required. Neutral gray keeps the terminal state distinct without implying a successful commit-producing outcome.
 
 ### 5.2 Active execution
 

--- a/docs/UI/WorkflowStatusColorSemantics.md
+++ b/docs/UI/WorkflowStatusColorSemantics.md
@@ -100,7 +100,7 @@ Rationale: `awaiting_slot` represents a workflow that is waiting for capacity, n
 | `waiting_on_dependencies` | Awaiting dep | Blocked yellow | `#92400E` | `#FACC15` | Furthest non-terminal distance from active execution; blocked on prerequisite workflow state and kept legible against purple dashboard backgrounds. |
 | `awaiting_external` | Awaiting external | Blocked yellow | `#92400E` | `#FACC15` | Furthest non-terminal distance from active execution; waiting on an external system, provider, or human and kept legible against purple dashboard backgrounds. |
 | `finalizing` | Finalizing | Finalization slate | `#64748B` | `#64748B` | Wrap-up, recording, publish summary, and terminalization work. |
-| `no_commit` | No commit | No-commit gray | Muted gray token | Muted gray token | Successful or side-effectful completion with no repository commit/publish artifact. |
+| `no_commit` | No commit | No-commit gray | `#5F667A` | `#AEAACC` | Successful or side-effectful completion with no repository commit/publish artifact. |
 
 ---
 

--- a/docs/Workflows/NoCommitStatus.md
+++ b/docs/Workflows/NoCommitStatus.md
@@ -31,7 +31,7 @@ Use **No Commit** for that outcome.
 
 | Layer | Canonical value | Meaning |
 | --- | --- | --- |
-| Exact lifecycle state | `no_commit` | Terminal, success-adjacent state: workflow completed without creating a repository commit. |
+| Exact lifecycle state | `no_commit` | Terminal completed-without-commit state: workflow completed without creating a repository commit. |
 | Finish outcome code | `NO_COMMIT` | Structured finish-summary outcome for the same condition. |
 | Publish status | `skipped` | Publish stage intentionally skipped branch/PR creation because no commit was needed. |
 | Publish reason code | `no_commit` | Stable machine-readable publish reason. |

--- a/frontend/src/entrypoints/dashboard.test.tsx
+++ b/frontend/src/entrypoints/dashboard.test.tsx
@@ -1027,7 +1027,7 @@ describe('Dashboard shared entry', () => {
     expect(cssRuleBlock(dashboardCss, '.status-canceled')).toContain(
       'color: rgb(var(--mm-status-canceled, 249 115 22))',
     );
-    expect(cssRuleBlock(dashboardCss, '.status-no-commit')).toContain('color: #159376');
+    expect(cssRuleBlock(dashboardCss, '.status-no-commit')).toContain('color: rgb(var(--mm-muted))');
     expect(cssRuleBlock(dashboardCss, '.status-running, .status-running.is-executing')).toContain(
       'color: rgb(var(--mm-accent-2))',
     );

--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -2800,9 +2800,9 @@ tr[data-proposal-id].proposal-consuming td {
 }
 
 .status-no-commit {
-  color: #159376;
-  background: rgb(21 147 118 / 0.14);
-  border-color: rgb(26 153 123 / 0.62);
+  color: rgb(var(--mm-muted));
+  background: rgb(var(--mm-muted) / 0.12);
+  border-color: rgb(var(--mm-border) / 0.75);
 }
 
 .status-failed {


### PR DESCRIPTION
Make the no commit status pill gray instead of teal and update the related docs accordingly as well.