### PR TITLE
MM-1084 Add automated status-domain drift guardrails

### DIFF
--- a/frontend/src/utils/executionStatusPillClasses.test.ts
+++ b/frontend/src/utils/executionStatusPillClasses.test.ts
@@ -5,6 +5,34 @@ import {
   executionStatusPillProps,
 } from './executionStatusPillClasses';
 
+const CANONICAL_WORKFLOW_STATES = [
+  'scheduled',
+  'initializing',
+  'waiting_on_dependencies',
+  'planning',
+  'awaiting_slot',
+  'executing',
+  'awaiting_external',
+  'proposals',
+  'finalizing',
+  'no_commit',
+  'completed',
+  'failed',
+  'canceled',
+] as const;
+
+const CANONICAL_STEP_STATUSES = [
+  'pending',
+  'ready',
+  'running',
+  'awaiting_external',
+  'reviewing',
+  'succeeded',
+  'failed',
+  'skipped',
+  'canceled',
+] as const;
+
 describe('executionStatusPillProps', () => {
   it('adds shimmer selector metadata for active executing and transition status pills', () => {
     expect(executionStatusPillProps('executing')).toMatchObject({
@@ -97,6 +125,18 @@ describe('executionStatusPillProps', () => {
   it('uses the no-commit teal pill class for canonical and legacy no-commit statuses', () => {
     expect(executionStatusPillProps('no_commit')).toEqual({ className: 'status status-no-commit' });
     expect(executionStatusPillProps('no_changes')).toEqual({ className: 'status status-no-commit' });
+  });
+
+  it('covers every MM-1084 canonical workflow status with a stable pill class', () => {
+    for (const status of CANONICAL_WORKFLOW_STATES) {
+      expect(executionStatusPillProps(status).className).toMatch(/^status status-/);
+    }
+  });
+
+  it('covers every MM-1084 canonical step status with a stable pill class', () => {
+    for (const status of CANONICAL_STEP_STATUSES) {
+      expect(executionStatusPillProps(status).className).toMatch(/^status status-/);
+    }
   });
 
   it('preserves MM-488 traceability for downstream verification', () => {

--- a/tests/unit/tools/test_status_domain_audit.py
+++ b/tests/unit/tools/test_status_domain_audit.py
@@ -27,7 +27,7 @@ def test_status_domain_audit_passes_current_repository() -> None:
 def test_status_domain_audit_fail_on_unknown_mode_rejects_unallowlisted_token() -> None:
     allowed_tokens = status_domain_audit.approved_status_tokens()
     findings = status_domain_audit.audit_text_for_status_tokens(
-        'payload = {"status": "surprise_new_status"}\n',
+        'workflow_status_payload = {"status": "surprise_new_status"}\n',
         path=Path("moonmind/workflows/temporal/example.py"),
         allowed_tokens=allowed_tokens,
         require_domain_path=False,
@@ -45,6 +45,67 @@ def test_status_domain_audit_fail_on_unknown_mode_rejects_unallowlisted_token() 
         )
         == []
     )
+
+
+def test_status_domain_audit_checks_common_status_key_in_domain_files() -> None:
+    findings = status_domain_audit.audit_text_for_status_tokens(
+        'workflow_status_payload = {"status": "surprise_new_status"}\n',
+        path=Path("moonmind/workflows/temporal/example.py"),
+        allowed_tokens=status_domain_audit.approved_status_tokens(),
+    )
+
+    assert [finding.code for finding in findings] == ["unknown-status-token"]
+    assert findings[0].token == "surprise_new_status"
+
+
+def test_status_domain_audit_recognizes_status_comparisons_and_cases() -> None:
+    findings = status_domain_audit.audit_text_for_status_tokens(
+        (
+            'if (workflowStatus === "surprise_new_status") {\n'
+            "  return true;\n"
+            "}\n"
+            'case "other_surprise_status":\n'
+        ),
+        path=Path("moonmind/workflows/temporal/example.ts"),
+        allowed_tokens=status_domain_audit.approved_status_tokens(),
+    )
+
+    assert [finding.token for finding in findings] == [
+        "surprise_new_status",
+        "other_surprise_status",
+    ]
+
+
+def test_status_domain_audit_allows_recursive_test_globs() -> None:
+    findings = status_domain_audit.audit_text_for_status_tokens(
+        'payload = {"status": "surprise_new_status"}\n',
+        path=Path("frontend/src/components/subfolder/example.test.ts"),
+        allowed_tokens=status_domain_audit.approved_status_tokens(),
+    )
+
+    assert findings == []
+
+
+def test_status_domain_audit_prunes_ignored_dirs_relative_to_repo_root(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "var" / "repo"
+    audited_dir = repo / "moonmind" / "workflows" / "temporal"
+    ignored_dir = repo / "var" / "moonmind" / "workflows" / "temporal"
+    audited_dir.mkdir(parents=True)
+    ignored_dir.mkdir(parents=True)
+    audited_file = audited_dir / "example.py"
+    ignored_file = ignored_dir / "ignored.py"
+    audited_file.write_text('payload = {"status": "running"}\n', encoding="utf-8")
+    ignored_file.write_text('payload = {"status": "running"}\n', encoding="utf-8")
+
+    candidates = {
+        path.relative_to(repo).as_posix()
+        for path in status_domain_audit._iter_candidate_files(repo)
+    }
+
+    assert "moonmind/workflows/temporal/example.py" in candidates
+    assert "var/moonmind/workflows/temporal/ignored.py" not in candidates
 
 
 def test_status_domain_audit_blocks_generic_global_status_vocabulary() -> None:

--- a/tests/unit/tools/test_status_domain_audit.py
+++ b/tests/unit/tools/test_status_domain_audit.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import get_args
+
+from api_service.db.models import MoonMindWorkflowState
+from moonmind.schemas.temporal_models import StepLedgerRowModel
+from tools import status_domain_audit
+
+
+def test_backend_workflow_states_match_active_visibility_doc() -> None:
+    assert {state.value for state in MoonMindWorkflowState} == (
+        status_domain_audit.canonical_workflow_states()
+    )
+
+
+def test_backend_step_ledger_statuses_match_active_step_ledger_doc() -> None:
+    status_annotation = StepLedgerRowModel.model_fields["status"].annotation
+
+    assert set(get_args(status_annotation)) == status_domain_audit.canonical_step_statuses()
+
+
+def test_status_domain_audit_passes_current_repository() -> None:
+    assert status_domain_audit.audit_repository() == []
+
+
+def test_status_domain_audit_fail_on_unknown_mode_rejects_unallowlisted_token() -> None:
+    allowed_tokens = status_domain_audit.approved_status_tokens()
+    findings = status_domain_audit.audit_text_for_status_tokens(
+        'payload = {"status": "surprise_new_status"}\n',
+        path=Path("moonmind/workflows/temporal/example.py"),
+        allowed_tokens=allowed_tokens,
+        require_domain_path=False,
+    )
+
+    assert [finding.code for finding in findings] == ["unknown-status-token"]
+    assert findings[0].token == "surprise_new_status"
+
+    assert (
+        status_domain_audit.audit_text_for_status_tokens(
+            'payload = {"status": "running"}\n',
+            path=Path("moonmind/workflows/temporal/example.py"),
+            allowed_tokens=allowed_tokens,
+            require_domain_path=False,
+        )
+        == []
+    )
+
+
+def test_status_domain_audit_blocks_generic_global_status_vocabulary() -> None:
+    findings = status_domain_audit.audit_text_for_status_tokens(
+        "GLOBAL_STATUS_VOCABULARY = {'running'}\n",
+        path=Path("moonmind/workflows/temporal/example.py"),
+        allowed_tokens=status_domain_audit.approved_status_tokens(),
+        require_domain_path=False,
+    )
+
+    assert [finding.code for finding in findings] == [
+        "generic-global-status-vocabulary"
+    ]
+
+
+def test_status_domain_audit_blocks_archived_workflow_status_authority_refs(
+    tmp_path: Path,
+) -> None:
+    docs = tmp_path / "docs" / "Workflows"
+    docs.mkdir(parents=True)
+    (docs / "WorkflowStatus.md").write_text("archived pointer\n", encoding="utf-8")
+    active = tmp_path / "docs" / "Temporal"
+    active.mkdir()
+    (active / "example.md").write_text(
+        "Use docs/Workflows/WorkflowStatus.md as source\n",
+        encoding="utf-8",
+    )
+
+    findings = status_domain_audit.audit_archived_workflow_status_refs(tmp_path)
+
+    assert [finding.code for finding in findings] == [
+        "archived-workflow-status-authority"
+    ]
+
+
+def test_status_domain_audit_preserves_mm1084_and_mm1073_traceability() -> None:
+    traceability = status_domain_audit.STATUS_DOMAIN_AUDIT_TRACEABILITY
+
+    assert traceability["jiraIssue"] == "MM-1084"
+    assert traceability["sourceIssue"] == "MM-1073"
+    assert "docs/Workflows/WorkflowStatus.md#archived-pointer-004" in traceability[
+        "canonicalClaimIds"
+    ]

--- a/tools/audit_status_tokens.py
+++ b/tools/audit_status_tokens.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python3
+"""Emit a non-destructive status-token inventory report for MM-1080."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+from dataclasses import dataclass
+import os
+from pathlib import Path
+import sys
+
+
+DEFAULT_TOKENS = (
+    "mm_state",
+    "closeStatus",
+    "temporalStatus",
+    "no_changes",
+    "awaiting_action",
+    "queued",
+    "in-progress",
+    "StepExecutionStatus",
+)
+
+DEFAULT_SCAN_ROOTS = (
+    "api_service",
+    "docs",
+    "frontend/src",
+    "moonmind",
+    "tests",
+    "tools",
+)
+
+SKIP_DIRS = {
+    ".git",
+    ".mypy_cache",
+    ".pytest_cache",
+    ".ruff_cache",
+    ".venv",
+    "__pycache__",
+    "node_modules",
+    "var",
+}
+
+TEXT_SUFFIXES = {
+    ".css",
+    ".html",
+    ".js",
+    ".json",
+    ".md",
+    ".py",
+    ".sh",
+    ".toml",
+    ".ts",
+    ".tsx",
+    ".txt",
+    ".yaml",
+    ".yml",
+}
+
+
+@dataclass(frozen=True, slots=True)
+class TokenClassification:
+    token: str
+    guessed_domain: str
+    canonicality: str
+    action: str
+
+
+TOKEN_CLASSIFICATIONS: dict[str, TokenClassification] = {
+    "mm_state": TokenClassification(
+        token="mm_state",
+        guessed_domain="workflow_lifecycle_state",
+        canonicality="canonical",
+        action="keep_canonical",
+    ),
+    "closeStatus": TokenClassification(
+        token="closeStatus",
+        guessed_domain="temporal_close_status",
+        canonicality="canonical",
+        action="keep_canonical",
+    ),
+    "temporalStatus": TokenClassification(
+        token="temporalStatus",
+        guessed_domain="temporal_status",
+        canonicality="canonical",
+        action="keep_canonical",
+    ),
+    "no_changes": TokenClassification(
+        token="no_changes",
+        guessed_domain="legacy_or_migration_status",
+        canonicality="historical",
+        action="historical_migration_only",
+    ),
+    "awaiting_action": TokenClassification(
+        token="awaiting_action",
+        guessed_domain="dashboard_compatibility_status",
+        canonicality="compatibility",
+        action="rename_domain_specific",
+    ),
+    "queued": TokenClassification(
+        token="queued",
+        guessed_domain="provider_normalized_status",
+        canonicality="boundary_canonical",
+        action="move_to_provider_boundary",
+    ),
+    "in-progress": TokenClassification(
+        token="in-progress",
+        guessed_domain="provider_native_status",
+        canonicality="non_canonical",
+        action="move_to_provider_boundary",
+    ),
+    "StepExecutionStatus": TokenClassification(
+        token="StepExecutionStatus",
+        guessed_domain="step_execution_artifact_status",
+        canonicality="canonical",
+        action="keep_canonical",
+    ),
+}
+
+REPORT_COLUMNS = (
+    "token",
+    "guessed_domain",
+    "files",
+    "canonicality",
+    "action",
+)
+
+
+def classify_token(token: str) -> TokenClassification:
+    return TOKEN_CLASSIFICATIONS.get(
+        token,
+        TokenClassification(
+            token=token,
+            guessed_domain="unknown",
+            canonicality="unknown",
+            action="delete_unused",
+        ),
+    )
+
+
+def iter_text_files(root: Path, scan_roots: tuple[str, ...]) -> list[Path]:
+    files: list[Path] = []
+    for scan_root in scan_roots:
+        base = root / scan_root
+        if not base.exists():
+            continue
+        if base.is_file():
+            if base.suffix in TEXT_SUFFIXES:
+                files.append(base)
+            continue
+        for dirpath, dirnames, filenames in os.walk(base):
+            dirnames[:] = [dirname for dirname in dirnames if dirname not in SKIP_DIRS]
+            for filename in filenames:
+                path = Path(dirpath) / filename
+                if path.suffix in TEXT_SUFFIXES:
+                    files.append(path)
+    return sorted(set(files))
+
+
+def find_token_files(
+    *,
+    root: Path,
+    scan_roots: tuple[str, ...],
+    tokens: tuple[str, ...],
+) -> dict[str, list[str]]:
+    matches = {token: [] for token in tokens}
+    for path in iter_text_files(root, scan_roots):
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError, ValueError):
+            continue
+        for token in tokens:
+            if token in text:
+                try:
+                    rel_path = path.relative_to(root).as_posix()
+                except ValueError:
+                    rel_path = path.as_posix()
+                matches[token].append(rel_path)
+    return matches
+
+
+def build_report_rows(
+    *,
+    root: Path,
+    scan_roots: tuple[str, ...],
+    tokens: tuple[str, ...],
+) -> list[dict[str, str]]:
+    token_files = find_token_files(root=root, scan_roots=scan_roots, tokens=tokens)
+    rows: list[dict[str, str]] = []
+    for token in tokens:
+        classification = classify_token(token)
+        rows.append(
+            {
+                "token": token,
+                "guessed_domain": classification.guessed_domain,
+                "files": ";".join(token_files[token]),
+                "canonicality": classification.canonicality,
+                "action": classification.action,
+            }
+        )
+    return rows
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--root",
+        default=".",
+        help="Repository root to scan. Defaults to the current directory.",
+    )
+    parser.add_argument(
+        "--token",
+        action="append",
+        dest="tokens",
+        help="Token to scan. May be repeated. Defaults to the seeded MM-1080 tokens.",
+    )
+    parser.add_argument(
+        "--scan-root",
+        action="append",
+        dest="scan_roots",
+        help="Relative path to scan. May be repeated.",
+    )
+    parser.add_argument(
+        "--fail-on-unknown",
+        action="store_true",
+        help=(
+            "Exit nonzero after writing the CSV report when a scanned token is "
+            "unknown or assigned to the unknown domain."
+        ),
+    )
+    return parser.parse_args(argv)
+
+
+def has_unknown_or_misplaced_rows(rows: list[dict[str, str]]) -> bool:
+    for row in rows:
+        has_files = bool(row.get("files"))
+        if not has_files:
+            continue
+        if row.get("guessed_domain") == "unknown":
+            return True
+        if row.get("canonicality") == "unknown":
+            return True
+    return False
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(list(argv or sys.argv[1:]))
+    root = Path(args.root).resolve()
+    tokens = tuple(args.tokens or DEFAULT_TOKENS)
+    scan_roots = tuple(args.scan_roots or DEFAULT_SCAN_ROOTS)
+    writer = csv.DictWriter(sys.stdout, fieldnames=REPORT_COLUMNS)
+    writer.writeheader()
+    rows = build_report_rows(root=root, scan_roots=scan_roots, tokens=tokens)
+    writer.writerows(rows)
+    if args.fail_on_unknown and has_unknown_or_misplaced_rows(rows):
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/status_domain_audit.py
+++ b/tools/status_domain_audit.py
@@ -1,0 +1,400 @@
+#!/usr/bin/env python3
+"""Audit MoonMind status-domain tokens.
+
+MM-1084: keep workflow, step, and projection statuses tied to their canonical
+domain documents instead of recreating a generic global status vocabulary.
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from pathlib import Path
+import re
+import sys
+from typing import Iterable
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW_STATUS_POINTER = Path("docs/Workflows/WorkflowStatus.md")
+
+WORKFLOW_STATE_DOC = Path("docs/Temporal/VisibilityAndUiQueryModel.md")
+STEP_STATUS_DOC = Path("docs/Temporal/StepLedgerAndProgressModel.md")
+
+STATUS_DOMAIN_AUDIT_TRACEABILITY = {
+    "jiraIssue": "MM-1084",
+    "sourceIssue": "MM-1073",
+    "sourceDocument": WORKFLOW_STATUS_POINTER.as_posix(),
+    "canonicalClaimIds": ["docs/Workflows/WorkflowStatus.md#archived-pointer-004"],
+    "requirements": [
+        "DESIGN-REQ-008",
+        "DESIGN-REQ-010",
+        "DESIGN-REQ-011",
+        "DESIGN-REQ-012",
+    ],
+}
+
+DOMAIN_PATH_PATTERNS = (
+    "api_service/core/",
+    "api_service/api/routers/executions.py",
+    "api_service/db/models.py",
+    "moonmind/schemas/temporal_models.py",
+    "moonmind/workflows/temporal/",
+    "frontend/src/utils/executionStatusPillClasses.ts",
+    "frontend/src/generated/openapi.ts",
+)
+
+ARCHIVED_POINTER_REFERENCE_ALLOWED_PATHS = frozenset(
+    {
+        WORKFLOW_STATUS_POINTER.as_posix(),
+        "tools/status_domain_audit.py",
+    }
+)
+
+WORKFLOW_ROLLUP_STATUSES = frozenset(
+    {
+        "queued",
+        "running",
+        "awaiting_action",
+        "waiting",
+        "completed",
+        "failed",
+        "canceled",
+    }
+)
+TEMPORAL_CLOSE_STATUSES = frozenset(
+    {"completed", "failed", "canceled", "terminated", "timed_out", "continued_as_new"}
+)
+LEGACY_NO_COMMIT_TOKENS = frozenset({"no_changes"})
+
+PROVIDER_STATUS_NORMALIZER_PATHS = (
+    "moonmind/jules/",
+    "moonmind/workflows/adapters/",
+    "tests/unit/jules/",
+    "tests/unit/workflows/adapters/",
+)
+
+ALLOWED_STATUS_TOKEN_LOCATIONS = (
+    {
+        "domain": "historical_migration",
+        "action": "allow_existing_schema_history",
+        "reason": (
+            "Migrations preserve historical database enum values and are not "
+            "active implementation authority."
+        ),
+        "path_prefixes": ("api_service/migrations/",),
+    },
+    {
+        "domain": "generated_api_fixture",
+        "action": "allow_generated_contract_snapshot",
+        "reason": (
+            "Generated OpenAPI output mirrors backend schemas; source contracts "
+            "are audited separately."
+        ),
+        "path_prefixes": ("frontend/src/generated/",),
+    },
+    {
+        "domain": "provider_normalizer",
+        "action": "allow_provider_raw_statuses_at_adapter_boundary",
+        "reason": "Provider statuses are valid inside provider and integration normalizers.",
+        "path_prefixes": PROVIDER_STATUS_NORMALIZER_PATHS,
+    },
+    {
+        "domain": "test_fixture",
+        "action": "allow_test_fixture_status_literals",
+        "reason": (
+            "Tests may contain raw tokens to prove normalization, rejection, "
+            "and compatibility behavior."
+        ),
+        "path_prefixes": (
+            "tests/",
+            "frontend/src/**/*.test.ts",
+            "frontend/src/**/*.test.tsx",
+        ),
+    },
+)
+
+STATUS_CONTEXT_RE = re.compile(
+    r"""
+    (?P<keyquote>["'`])?
+    (?P<key>
+        mm_state
+        |currentTargetState
+        |current_target_state
+        |dashboardStatus
+        |dashboard_status
+        |temporalStatus
+        |temporal_status
+        |closeStatus
+        |close_status
+        |rawState
+        |raw_state
+        |state
+        |status
+    )
+    (?P=keyquote)?
+    \s*(?:[:=]|\|)\s*
+    (?P<quote>["'`])(?P<token>[a-z][a-z0-9_-]*)(?P=quote)
+    """,
+    re.VERBOSE,
+)
+
+STRICT_STATUS_KEYS = frozenset(
+    {
+        "mm_state",
+        "currentTargetState",
+        "current_target_state",
+        "dashboardStatus",
+        "dashboard_status",
+        "temporalStatus",
+        "temporal_status",
+        "closeStatus",
+        "close_status",
+        "rawState",
+        "raw_state",
+    }
+)
+GENERIC_STATUS_SCHEMA_FILES = frozenset(
+    {
+        "api_service/db/models.py",
+        "moonmind/schemas/temporal_models.py",
+        "frontend/src/utils/executionStatusPillClasses.ts",
+        "frontend/src/generated/openapi.ts",
+    }
+)
+
+GENERIC_GLOBAL_VOCABULARY_RE = re.compile(
+    r"\b(?:GLOBAL|GENERIC|COMMON|UNIFIED)_STATUS(?:_VOCABULARY|_TOKENS|_VALUES|ES)?\b"
+)
+
+
+@dataclass(frozen=True)
+class AuditFinding:
+    path: Path
+    line_number: int
+    code: str
+    message: str
+    token: str | None = None
+
+    def render(self) -> str:
+        location = f"{self.path.as_posix()}:{self.line_number}"
+        token = f" token={self.token!r}" if self.token else ""
+        return f"{location}: {self.code}: {self.message}{token}"
+
+
+def _read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def _relative(path: Path, root: Path = REPO_ROOT) -> Path:
+    try:
+        return path.resolve().relative_to(root.resolve())
+    except ValueError:
+        return path
+
+
+def _extract_text_block_after_heading(text: str, heading: str) -> set[str]:
+    marker = text.index(heading)
+    block_start = text.index("```text", marker)
+    value_start = text.index("\n", block_start) + 1
+    value_end = text.index("```", value_start)
+    return {line.strip() for line in text[value_start:value_end].splitlines() if line.strip()}
+
+
+def canonical_workflow_states(root: Path = REPO_ROOT) -> set[str]:
+    text = _read_text(root / WORKFLOW_STATE_DOC)
+    return _extract_text_block_after_heading(text, "### 5.1 `mm_state` value set")
+
+
+def canonical_step_statuses(root: Path = REPO_ROOT) -> set[str]:
+    text = _read_text(root / STEP_STATUS_DOC)
+    status_table = re.search(
+        r"The canonical v1 step statuses are:\n\n(?P<table>\| Status \| Meaning \|.*?)(?:\n\n|$)",
+        text,
+        flags=re.DOTALL,
+    )
+    if not status_table:
+        raise RuntimeError("Could not locate canonical step status table")
+    statuses: set[str] = set()
+    for match in re.finditer(r"\| `(?P<status>[a-z][a-z0-9_-]*)` \|", status_table.group("table")):
+        statuses.add(match.group("status"))
+    if not statuses:
+        raise RuntimeError("Could not parse canonical step statuses")
+    return statuses
+
+
+def approved_status_tokens(root: Path = REPO_ROOT) -> set[str]:
+    return (
+        canonical_workflow_states(root)
+        | canonical_step_statuses(root)
+        | WORKFLOW_ROLLUP_STATUSES
+        | TEMPORAL_CLOSE_STATUSES
+        | LEGACY_NO_COMMIT_TOKENS
+    )
+
+
+def _is_domain_path(path: Path) -> bool:
+    rel = path.as_posix()
+    return any(
+        rel == pattern.rstrip("/") or rel.startswith(pattern)
+        for pattern in DOMAIN_PATH_PATTERNS
+    )
+
+
+def _is_allowlisted_path(path: Path) -> bool:
+    rel = path.as_posix()
+    for entry in ALLOWED_STATUS_TOKEN_LOCATIONS:
+        for prefix in entry["path_prefixes"]:
+            if "*" in prefix:
+                if path.match(prefix):
+                    return True
+            elif rel.startswith(prefix):
+                return True
+    return False
+
+
+def _should_audit_status_match(
+    *,
+    path: Path,
+    key: str,
+    require_domain_path: bool,
+) -> bool:
+    if not require_domain_path:
+        return True
+    if key in STRICT_STATUS_KEYS:
+        return True
+    if path.as_posix() in GENERIC_STATUS_SCHEMA_FILES:
+        return True
+    return False
+
+
+def _iter_candidate_files(root: Path) -> Iterable[Path]:
+    ignored_dirs = {
+        ".git",
+        ".mypy_cache",
+        ".pytest_cache",
+        ".ruff_cache",
+        ".venv",
+        "node_modules",
+        "artifacts",
+        "artifacts-root-owned-context",
+        "var",
+    }
+    suffixes = {".py", ".ts", ".tsx", ".js", ".jsx", ".json", ".yaml", ".yml", ".md"}
+    for path in root.rglob("*"):
+        if any(part in ignored_dirs for part in path.parts):
+            continue
+        if path.is_file() and path.suffix in suffixes:
+            yield path
+
+
+def audit_text_for_status_tokens(
+    text: str,
+    *,
+    path: Path,
+    allowed_tokens: set[str],
+    require_domain_path: bool = True,
+) -> list[AuditFinding]:
+    findings: list[AuditFinding] = []
+    rel_path = path
+    is_domain_path = _is_domain_path(rel_path)
+    is_allowlisted = _is_allowlisted_path(rel_path)
+    for line_number, line in enumerate(text.splitlines(), start=1):
+        if is_allowlisted:
+            continue
+        if GENERIC_GLOBAL_VOCABULARY_RE.search(line):
+            findings.append(
+                AuditFinding(
+                    rel_path,
+                    line_number,
+                    "generic-global-status-vocabulary",
+                    "generic status vocabularies are forbidden; keep values domain-specific",
+                )
+            )
+        if require_domain_path and not is_domain_path:
+            continue
+        for match in STATUS_CONTEXT_RE.finditer(line):
+            key = match.group("key")
+            if not _should_audit_status_match(
+                path=rel_path,
+                key=key,
+                require_domain_path=require_domain_path,
+            ):
+                continue
+            token = match.group("token")
+            if token not in allowed_tokens:
+                findings.append(
+                    AuditFinding(
+                        rel_path,
+                        line_number,
+                        "unknown-status-token",
+                        (
+                            "raw status token is not in an approved workflow, "
+                            "step, rollup, close, provider, fixture, or "
+                            "historical domain"
+                        ),
+                        token,
+                    )
+                )
+    return findings
+
+
+def audit_archived_workflow_status_refs(root: Path) -> list[AuditFinding]:
+    findings: list[AuditFinding] = []
+    needle = WORKFLOW_STATUS_POINTER.as_posix()
+    for path in _iter_candidate_files(root):
+        rel = _relative(path, root)
+        if rel.as_posix() in ARCHIVED_POINTER_REFERENCE_ALLOWED_PATHS:
+            continue
+        if rel.as_posix().startswith("tests/"):
+            continue
+        text = _read_text(path)
+        for line_number, line in enumerate(text.splitlines(), start=1):
+            if needle in line:
+                findings.append(
+                    AuditFinding(
+                        rel,
+                        line_number,
+                        "archived-workflow-status-authority",
+                        (
+                            "archived WorkflowStatus.md may not be cited as "
+                            "active implementation authority"
+                        ),
+                    )
+                )
+    return findings
+
+
+def audit_repository(root: Path = REPO_ROOT) -> list[AuditFinding]:
+    allowed_tokens = approved_status_tokens(root)
+    findings: list[AuditFinding] = []
+    for path in _iter_candidate_files(root):
+        rel = _relative(path, root)
+        findings.extend(
+            audit_text_for_status_tokens(
+                _read_text(path),
+                path=rel,
+                allowed_tokens=allowed_tokens,
+                require_domain_path=True,
+            )
+        )
+    findings.extend(audit_archived_workflow_status_refs(root))
+    return findings
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", type=Path, default=REPO_ROOT)
+    args = parser.parse_args(argv)
+
+    findings = audit_repository(args.repo_root)
+    if findings:
+        for finding in findings:
+            print(finding.render(), file=sys.stderr)
+        return 1
+    print("status domain audit passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/status_domain_audit.py
+++ b/tools/status_domain_audit.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 
 import argparse
 from dataclasses import dataclass
+import fnmatch
+import os
 from pathlib import Path
 import re
 import sys
@@ -116,26 +118,57 @@ ALLOWED_STATUS_TOKEN_LOCATIONS = (
 
 STATUS_CONTEXT_RE = re.compile(
     r"""
-    (?P<keyquote>["'`])?
-    (?P<key>
-        mm_state
-        |currentTargetState
-        |current_target_state
-        |dashboardStatus
-        |dashboard_status
-        |temporalStatus
-        |temporal_status
-        |closeStatus
-        |close_status
-        |rawState
-        |raw_state
-        |state
-        |status
+    (?<![.\w])
+    (?:
+        (?P<keyquote>["'`])
+        (?P<quoted_key>
+            mm_state
+            |currentTargetState
+            |current_target_state
+            |dashboardStatus
+            |dashboard_status
+            |temporalStatus
+            |temporal_status
+            |closeStatus
+            |close_status
+            |rawState
+            |raw_state
+            |workflowStatus
+            |workflow_status
+            |stepStatus
+            |step_status
+            |state
+            |status
+        )
+        (?P=keyquote)
+        |
+        (?P<unquoted_key>
+            mm_state
+            |currentTargetState
+            |current_target_state
+            |dashboardStatus
+            |dashboard_status
+            |temporalStatus
+            |temporal_status
+            |closeStatus
+            |close_status
+            |rawState
+            |raw_state
+            |workflowStatus
+            |workflow_status
+            |stepStatus
+            |step_status
+            |state
+            |status
+        )
     )
-    (?P=keyquote)?
-    \s*(?:[:=]|\|)\s*
+    \s*(?P<operator>:|=|={2,3}|!==?|\|)\s*
     (?P<quote>["'`])(?P<token>[a-z][a-z0-9_-]*)(?P=quote)
     """,
+    re.VERBOSE,
+)
+STATUS_CASE_RE = re.compile(
+    r"""\bcase\s+(?P<quote>["'`])(?P<token>[a-z][a-z0-9_-]*)(?P=quote)""",
     re.VERBOSE,
 )
 
@@ -152,6 +185,10 @@ STRICT_STATUS_KEYS = frozenset(
         "close_status",
         "rawState",
         "raw_state",
+        "workflowStatus",
+        "workflow_status",
+        "stepStatus",
+        "step_status",
     }
 )
 GENERIC_STATUS_SCHEMA_FILES = frozenset(
@@ -165,6 +202,13 @@ GENERIC_STATUS_SCHEMA_FILES = frozenset(
 
 GENERIC_GLOBAL_VOCABULARY_RE = re.compile(
     r"\b(?:GLOBAL|GENERIC|COMMON|UNIFIED)_STATUS(?:_VOCABULARY|_TOKENS|_VALUES|ES)?\b"
+)
+STATUS_DOMAIN_LINE_RE = re.compile(
+    (
+        r"\b(?:workflow|step|dashboard|temporal|close|raw|current_target)_status"
+        r"|mm_state|currentTargetState|dashboardStatus|temporalStatus|closeStatus|rawState\b"
+    ),
+    re.IGNORECASE,
 )
 
 
@@ -194,10 +238,23 @@ def _relative(path: Path, root: Path = REPO_ROOT) -> Path:
 
 
 def _extract_text_block_after_heading(text: str, heading: str) -> set[str]:
-    marker = text.index(heading)
-    block_start = text.index("```text", marker)
-    value_start = text.index("\n", block_start) + 1
-    value_end = text.index("```", value_start)
+    try:
+        marker = text.index(heading)
+    except ValueError as exc:
+        raise RuntimeError(f"Could not find heading {heading!r} in document") from exc
+    try:
+        block_start = text.index("```text", marker)
+    except ValueError as exc:
+        raise RuntimeError(
+            f"Could not find code block start '```text' after heading {heading!r}"
+        ) from exc
+    try:
+        value_start = text.index("\n", block_start) + 1
+        value_end = text.index("```", value_start)
+    except ValueError as exc:
+        raise RuntimeError(
+            f"Could not find code block end '```' after heading {heading!r}"
+        ) from exc
     return {line.strip() for line in text[value_start:value_end].splitlines() if line.strip()}
 
 
@@ -246,7 +303,7 @@ def _is_allowlisted_path(path: Path) -> bool:
     for entry in ALLOWED_STATUS_TOKEN_LOCATIONS:
         for prefix in entry["path_prefixes"]:
             if "*" in prefix:
-                if path.match(prefix):
+                if fnmatch.fnmatch(rel, prefix):
                     return True
             elif rel.startswith(prefix):
                 return True
@@ -257,13 +314,25 @@ def _should_audit_status_match(
     *,
     path: Path,
     key: str,
+    key_is_quoted: bool,
+    operator: str,
+    line: str,
     require_domain_path: bool,
 ) -> bool:
     if not require_domain_path:
         return True
+    is_comparison = operator in {"==", "===", "!=", "!=="}
+    if not key_is_quoted and not is_comparison:
+        return False
     if key in STRICT_STATUS_KEYS:
         return True
     if path.as_posix() in GENERIC_STATUS_SCHEMA_FILES:
+        if key == "status":
+            return bool(STATUS_DOMAIN_LINE_RE.search(line))
+        return True
+    if key == "status" and _is_domain_path(path):
+        return bool(STATUS_DOMAIN_LINE_RE.search(line))
+    if key == "state" and is_comparison and _is_domain_path(path):
         return True
     return False
 
@@ -281,11 +350,12 @@ def _iter_candidate_files(root: Path) -> Iterable[Path]:
         "var",
     }
     suffixes = {".py", ".ts", ".tsx", ".js", ".jsx", ".json", ".yaml", ".yml", ".md"}
-    for path in root.rglob("*"):
-        if any(part in ignored_dirs for part in path.parts):
-            continue
-        if path.is_file() and path.suffix in suffixes:
-            yield path
+    for dirpath, dirs, filenames in os.walk(root):
+        dirs[:] = [directory for directory in dirs if directory not in ignored_dirs]
+        for filename in filenames:
+            path = Path(dirpath) / filename
+            if path.suffix in suffixes:
+                yield path
 
 
 def audit_text_for_status_tokens(
@@ -297,11 +367,10 @@ def audit_text_for_status_tokens(
 ) -> list[AuditFinding]:
     findings: list[AuditFinding] = []
     rel_path = path
+    if _is_allowlisted_path(rel_path):
+        return []
     is_domain_path = _is_domain_path(rel_path)
-    is_allowlisted = _is_allowlisted_path(rel_path)
     for line_number, line in enumerate(text.splitlines(), start=1):
-        if is_allowlisted:
-            continue
         if GENERIC_GLOBAL_VOCABULARY_RE.search(line):
             findings.append(
                 AuditFinding(
@@ -314,13 +383,34 @@ def audit_text_for_status_tokens(
         if require_domain_path and not is_domain_path:
             continue
         for match in STATUS_CONTEXT_RE.finditer(line):
-            key = match.group("key")
+            key = match.group("quoted_key") or match.group("unquoted_key")
             if not _should_audit_status_match(
                 path=rel_path,
                 key=key,
+                key_is_quoted=bool(match.group("quoted_key")),
+                operator=match.group("operator"),
+                line=line,
                 require_domain_path=require_domain_path,
             ):
                 continue
+            token = match.group("token")
+            if key == "status" and token.startswith("mm_"):
+                continue
+            if token not in allowed_tokens:
+                findings.append(
+                    AuditFinding(
+                        rel_path,
+                        line_number,
+                        "unknown-status-token",
+                        (
+                            "raw status token is not in an approved workflow, "
+                            "step, rollup, close, provider, fixture, or "
+                            "historical domain"
+                        ),
+                        token,
+                    )
+                )
+        for match in STATUS_CASE_RE.finditer(line):
             token = match.group("token")
             if token not in allowed_tokens:
                 findings.append(

--- a/tools/test_unit.sh
+++ b/tools/test_unit.sh
@@ -152,6 +152,7 @@ fi
 
 if [[ "$RUN_PYTHON_TESTS" == "1" ]]; then
     "$PYTHON_BIN" "$SCRIPT_DIR/check_removed_capability_semantics.py" || exit 1
+    "$PYTHON_BIN" "$SCRIPT_DIR/status_domain_audit.py" || exit 1
 
     PYTEST_DURATIONS="${MOONMIND_PYTEST_DURATIONS:-25}"
     PYTEST_REPORT_ARGS=(--durations="$PYTEST_DURATIONS")


### PR DESCRIPTION
Issue: MM-1084

Summary:
- Added a repository status-domain audit that rejects unallowlisted raw status tokens and archived WorkflowStatus.md authority references.
- Added backend tests for canonical status values, fail-on-unknown behavior, explicit allowlist reasoning, and the no-global-status-vocabulary guardrail.
- Expanded frontend status pill helper tests to cover canonical workflow and step status values.
- Wired the status-domain audit into the unit test runner so the targeted required suite fails on drift.

Tests run:
- MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/tools/test_status_domain_audit.py --ui-args frontend/src/utils/executionStatusPillClasses.test.ts

Remaining risks:
- The audit is intentionally strict and may require explicit allowlist entries when legitimate new status domains are introduced.
