### PR TITLE
[codex] Rename workflow start nav to Create

### DIFF
--- a/frontend/src/entrypoints/dashboard-app.tsx
+++ b/frontend/src/entrypoints/dashboard-app.tsx
@@ -18,7 +18,7 @@ import {
   useNavigate,
 } from 'react-router-dom';
 import { QueryErrorResetBoundary, useQuery, useQueryClient } from '@tanstack/react-query';
-import { ScrollText } from 'lucide-react';
+import { Rocket, ScrollText } from 'lucide-react';
 
 import type { BootPayload } from '../boot/parseBootPayload';
 import { validatePageBoot } from '../boot/pageBootSchemas';
@@ -81,13 +81,7 @@ function WorkflowsNavIcon({ className }: NavIconProps) {
 }
 
 function StartWorkflowNavIcon({ className }: NavIconProps) {
-  return (
-    <NavIcon className={className}>
-      <path d="M12 5v14" />
-      <path d="M5 12h14" />
-      <circle cx="12" cy="12" r="8" />
-    </NavIcon>
-  );
+  return <Rocket className={className} aria-hidden="true" focusable="false" />;
 }
 
 function SchedulesNavIcon({ className }: NavIconProps) {
@@ -349,7 +343,7 @@ function DashboardNavigation({ uiInfo }: { uiInfo: DashboardUiInfo | null }) {
           </NavLink>
           <NavLink to="/workflows/new" className={({ isActive }) => (isActive ? 'active' : undefined)}>
             <StartWorkflowNavIcon className="route-nav-icon" />
-            Start Workflow
+            Create
           </NavLink>
           <NavLink to="/schedules" className={({ isActive }) => (isActive ? 'active' : undefined)}>
             <SchedulesNavIcon className="route-nav-icon" />

--- a/frontend/src/entrypoints/dashboard.test.tsx
+++ b/frontend/src/entrypoints/dashboard.test.tsx
@@ -352,7 +352,7 @@ describe('Dashboard shared entry', () => {
 
     expect(await screen.findByText('Workflow start route loaded')).toBeTruthy();
     const shellPanel = document.querySelector('.panel');
-    const startLink = screen.getByRole('link', { name: 'Start Workflow' });
+    const startLink = screen.getByRole('link', { name: 'Create' });
     const workflowsLink = screen.getByRole('link', { name: 'Workflows' });
     expect(startLink.getAttribute('aria-current')).toBe('page');
     expect(workflowsLink.getAttribute('aria-current')).toBeNull();


### PR DESCRIPTION
## Summary
- Rename the workflow start nav label from `Start Workflow` to `Create`.
- Replace the custom start-workflow nav icon with the Lucide `Rocket` icon.

## Validation
- Compared `codex/rename-start-workflow-create` against `main` and confirmed the branch is one commit ahead with a single dashboard entrypoint file changed.
- Not run: no local checkout/dependencies available in this connector-only environment.