### PR TITLE
Fix checkpoint branch turn evidence launch

### DIFF
--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -8477,7 +8477,7 @@ export interface components {
         };
         /**
          * StepExecutionBranchMetadataModel
-         * @description Optional Step Execution manifest lineage for checkpoint branch turns.
+         * @description Optional Checkpoint Branch lineage attached to a Step Execution manifest.
          */
         StepExecutionBranchMetadataModel: {
             /** Branchid */
@@ -8490,6 +8490,8 @@ export interface components {
             sourceStateKind?: string | null;
             /** Sourcestateref */
             sourceStateRef?: string | null;
+            /** Sourcestatedigest */
+            sourceStateDigest?: string | null;
             /** Parentbranchid */
             parentBranchId?: string | null;
             /** Parentturnid */
@@ -8519,7 +8521,7 @@ export interface components {
             lineage?: components["schemas"]["StepExecutionLineageModel"] | null;
             branch?: components["schemas"]["StepExecutionBranchMetadataModel"] | null;
             /** Reason */
-            reason?: ("initial_execution" | "quality_gate_failed" | "tests_failed" | "runtime_recovered" | "recover_from_failed_step" | "remediation_context" | "operator_requested" | "dependency_invalidated" | "policy_revalidation" | "checkpoint_branch") | null;
+            reason?: ("initial_execution" | "quality_gate_failed" | "tests_failed" | "runtime_recovered" | "recover_from_failed_step" | "checkpoint_branch" | "remediation_context" | "operator_requested" | "dependency_invalidated" | "policy_revalidation") | null;
             /** Status */
             status?: ("pending" | "preparing" | "executing" | "running" | "checking" | "completed" | "succeeded" | "failed" | "blocked" | "canceled" | "superseded") | null;
             /** Terminaldisposition */
@@ -8644,7 +8646,7 @@ export interface components {
             lineage?: components["schemas"]["StepExecutionLineageModel"] | null;
             branch?: components["schemas"]["StepExecutionBranchMetadataModel"] | null;
             /** Reason */
-            reason?: ("initial_execution" | "quality_gate_failed" | "tests_failed" | "runtime_recovered" | "recover_from_failed_step" | "remediation_context" | "operator_requested" | "dependency_invalidated" | "policy_revalidation" | "checkpoint_branch") | null;
+            reason?: ("initial_execution" | "quality_gate_failed" | "tests_failed" | "runtime_recovered" | "recover_from_failed_step" | "checkpoint_branch" | "remediation_context" | "operator_requested" | "dependency_invalidated" | "policy_revalidation") | null;
             /** Status */
             status?: ("pending" | "preparing" | "executing" | "running" | "checking" | "completed" | "succeeded" | "failed" | "blocked" | "canceled" | "superseded") | null;
             /** Terminaldisposition */

--- a/moonmind/schemas/checkpoint_branch_models.py
+++ b/moonmind/schemas/checkpoint_branch_models.py
@@ -226,6 +226,9 @@ class StepExecutionBranchMetadataModel(BaseModel):
     )
     source_state_kind: str | None = Field(None, alias="sourceStateKind", min_length=1)
     source_state_ref: str | None = Field(None, alias="sourceStateRef", min_length=1)
+    source_state_digest: str | None = Field(
+        None, alias="sourceStateDigest", min_length=1
+    )
     parent_branch_id: str | None = Field(None, alias="parentBranchId", min_length=1)
     parent_turn_id: str | None = Field(None, alias="parentTurnId", min_length=1)
     git_work_branch: str | None = Field(None, alias="gitWorkBranch", min_length=1)

--- a/moonmind/schemas/temporal_models.py
+++ b/moonmind/schemas/temporal_models.py
@@ -345,7 +345,12 @@ class StepEvidenceSummaryModel(BaseModel):
     diagnostic_refs: list[EnvironmentDiagnosticReferenceModel] = Field(
         default_factory=list, alias="diagnosticRefs"
     )
-StepExecutionSemanticOperation = Literal["retry", "reexecute", "recover"]
+StepExecutionSemanticOperation = Literal[
+    "retry",
+    "reexecute",
+    "recover",
+    "checkpoint_branch",
+]
 StepExecutionCheckpointBoundary = Literal[
     "after_prepare",
     "before_execution",
@@ -763,6 +768,35 @@ class StepExecutionSummaryRefModel(BaseModel):
         None, alias="terminalDisposition"
     )
     summary: str | None = Field(None, alias="summary", max_length=1000)
+
+
+class StepExecutionBranchMetadataModel(BaseModel):
+    """Optional Checkpoint Branch lineage attached to a Step Execution manifest."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    branch_id: str = Field(..., alias="branchId", min_length=1)
+    branch_turn_id: str = Field(..., alias="branchTurnId", min_length=1)
+    root_checkpoint_ref: str = Field(..., alias="rootCheckpointRef", min_length=1)
+    parent_branch_id: str | None = Field(None, alias="parentBranchId")
+    parent_turn_id: str | None = Field(None, alias="parentTurnId")
+    git_work_branch: str | None = Field(None, alias="gitWorkBranch")
+
+    @field_validator(
+        "branch_id",
+        "branch_turn_id",
+        "root_checkpoint_ref",
+        "parent_branch_id",
+        "parent_turn_id",
+        "git_work_branch",
+        mode="before",
+    )
+    @classmethod
+    def _strip_optional_text(cls, value: Any) -> str | None:
+        if value is None:
+            return None
+        candidate = str(value).strip()
+        return candidate or None
 
 
 class StepExecutionManifestModel(BaseModel):

--- a/moonmind/schemas/temporal_models.py
+++ b/moonmind/schemas/temporal_models.py
@@ -777,7 +777,14 @@ class StepExecutionBranchMetadataModel(BaseModel):
 
     branch_id: str = Field(..., alias="branchId", min_length=1)
     branch_turn_id: str = Field(..., alias="branchTurnId", min_length=1)
-    root_checkpoint_ref: str = Field(..., alias="rootCheckpointRef", min_length=1)
+    root_checkpoint_ref: str | None = Field(
+        None, alias="rootCheckpointRef", min_length=1
+    )
+    source_state_kind: str | None = Field(None, alias="sourceStateKind", min_length=1)
+    source_state_ref: str | None = Field(None, alias="sourceStateRef", min_length=1)
+    source_state_digest: str | None = Field(
+        None, alias="sourceStateDigest", min_length=1
+    )
     parent_branch_id: str | None = Field(None, alias="parentBranchId")
     parent_turn_id: str | None = Field(None, alias="parentTurnId")
     git_work_branch: str | None = Field(None, alias="gitWorkBranch")
@@ -786,6 +793,9 @@ class StepExecutionBranchMetadataModel(BaseModel):
         "branch_id",
         "branch_turn_id",
         "root_checkpoint_ref",
+        "source_state_kind",
+        "source_state_ref",
+        "source_state_digest",
         "parent_branch_id",
         "parent_turn_id",
         "git_work_branch",
@@ -797,6 +807,18 @@ class StepExecutionBranchMetadataModel(BaseModel):
             return None
         candidate = str(value).strip()
         return candidate or None
+
+    @model_validator(mode="after")
+    def _requires_checkpoint_or_typed_state(
+        self,
+    ) -> "StepExecutionBranchMetadataModel":
+        if self.root_checkpoint_ref:
+            return self
+        if self.source_state_kind and self.source_state_ref:
+            return self
+        raise ValueError(
+            "branch manifest metadata requires rootCheckpointRef or typed sourceStateRef"
+        )
 
 
 class StepExecutionManifestModel(BaseModel):

--- a/moonmind/statuses/step_execution.py
+++ b/moonmind/statuses/step_execution.py
@@ -44,6 +44,7 @@ StepExecutionReason = Literal[
     "tests_failed",
     "runtime_recovered",
     "recover_from_failed_step",
+    "checkpoint_branch",
     "remediation_context",
     "operator_requested",
     "dependency_invalidated",

--- a/moonmind/workflows/executions/prepared_context.py
+++ b/moonmind/workflows/executions/prepared_context.py
@@ -635,12 +635,17 @@ def build_branch_turn_context_bundle(
     parent_turn_id: str | None = None,
     label: str | None = None,
     git_work_branch: str | None = None,
+    prepared_context: StepPreparedContext | None = None,
     workspace_baseline: Mapping[str, Any] | None = None,
     prior_evidence_refs: Sequence[Any] | None = None,
     bounded_summaries: Sequence[Any] | None = None,
     branch_comparison_refs: Sequence[Any] | None = None,
     runtime_selection: Mapping[str, Any] | None = None,
     policy_refs: Mapping[str, Any] | None = None,
+    retrieval: Mapping[str, Any] | None = None,
+    memory_proposals: Sequence[Mapping[str, Any]] | None = None,
+    memory_context: Mapping[str, Any] | None = None,
+    fix_patterns: Sequence[Mapping[str, Any]] | None = None,
     builder_version: str = BRANCH_TURN_CONTEXT_BUILDER_VERSION,
 ) -> ExecutionContextBundle:
     """Build the immutable context bundle for one Checkpoint Branch turn.
@@ -706,6 +711,7 @@ def build_branch_turn_context_bundle(
         task_input_snapshot_ref=task_input_snapshot_ref,
         plan_ref=plan_ref,
         plan_digest=plan_digest,
+        prepared_context=prepared_context,
         workspace_policy=workspace_policy,
         runtime_context_policy=runtime_context_policy,
         workspace_baseline=workspace_baseline,
@@ -715,6 +721,10 @@ def build_branch_turn_context_bundle(
         branch_comparison_refs=branch_comparison_refs,
         runtime_selection=runtime_selection,
         policy_refs=policy_refs,
+        retrieval=retrieval,
+        memory_proposals=memory_proposals,
+        memory_context=memory_context,
+        fix_patterns=fix_patterns,
         builder_version=builder_version,
     )
 

--- a/moonmind/workflows/executions/prepared_context.py
+++ b/moonmind/workflows/executions/prepared_context.py
@@ -17,6 +17,12 @@ from moonmind.memory.procedural import fix_patterns_to_memory_proposals
 
 TargetKind = Literal["objective", "step"]
 RetrievalStatus = Literal["captured", "skipped", "unavailable"]
+BranchRuntimeContextPolicy = Literal[
+    "fresh_agent_run",
+    "reuse_session_new_epoch",
+    "reuse_session_same_epoch",
+    "external_provider_continuation",
+]
 MemoryProposalState = Literal[
     "proposed",
     "accepted_for_run_context",
@@ -25,6 +31,26 @@ MemoryProposalState = Literal[
     "superseded",
 ]
 EXECUTION_CONTEXT_BUILDER_VERSION = "execution-context-builder-v1"
+BRANCH_TURN_CONTEXT_BUILDER_VERSION = "branch-turn-context-builder-v1"
+MM_1089_TRACEABILITY = "MM-1089"
+MINIMUM_BRANCH_ARTIFACT_NAMES: tuple[str, ...] = (
+    "input.branch.root_checkpoint.json",
+    "input.branch.initial_instructions.md",
+    "runtime.branch.context_bundle.json",
+    "runtime.branch.workspace_restore.json",
+    "runtime.branch.git_binding.json",
+    "output.branch.summary.json",
+    "output.branch.latest_head.json",
+)
+MINIMUM_BRANCH_TURN_ARTIFACT_NAMES: tuple[str, ...] = (
+    "input.branch_turn.instructions.md",
+    "runtime.branch_turn.context_bundle.json",
+    "runtime.branch_turn.agent_request.json",
+    "runtime.branch_turn.agent_result.json",
+    "output.branch_turn.step_execution_manifest.json",
+    "output.branch_turn.checkpoint.json",
+    "output.branch_turn.diagnostics.json",
+)
 
 _EFFORT_COST_UNITS = {
     "minimal": 1,
@@ -245,6 +271,12 @@ class ExecutionContextBundle(BaseModel):
     logical_step_id: str = Field(alias="logicalStepId")
     execution_ordinal: int = Field(alias="executionOrdinal")
     reason: str = "initial_execution"
+    branch: dict[str, Any] | None = Field(default=None, alias="branch")
+    instruction_refs: list[str] = Field(default_factory=list, alias="instructionRefs")
+    instruction_digests: dict[str, str] = Field(
+        default_factory=dict,
+        alias="instructionDigests",
+    )
     prepared_input_refs: list[str] = Field(
         default_factory=list,
         alias="preparedInputRefs",
@@ -256,6 +288,10 @@ class ExecutionContextBundle(BaseModel):
     plan_ref: str | None = Field(default=None, alias="planRef")
     plan_digest: str | None = Field(default=None, alias="planDigest")
     workspace_policy: str | None = Field(default=None, alias="workspacePolicy")
+    runtime_context_policy: BranchRuntimeContextPolicy | None = Field(
+        default=None,
+        alias="runtimeContextPolicy",
+    )
     workspace_baseline: dict[str, Any] = Field(
         default_factory=dict,
         alias="workspaceBaseline",
@@ -267,6 +303,14 @@ class ExecutionContextBundle(BaseModel):
     prior_evidence_refs: list[str] = Field(
         default_factory=list,
         alias="priorEvidenceRefs",
+    )
+    bounded_summaries: list[str] = Field(
+        default_factory=list,
+        alias="boundedSummaries",
+    )
+    branch_comparison_refs: list[str] = Field(
+        default_factory=list,
+        alias="branchComparisonRefs",
     )
     retrieval_manifest_ref: str | None = Field(
         default=None,
@@ -321,10 +365,16 @@ class ExecutionContextBundle(BaseModel):
                 "taskInputSnapshotRef": self.task_input_snapshot_ref,
                 "planRef": self.plan_ref,
                 "planDigest": self.plan_digest,
+                "branch": self.branch,
+                "instructionRefs": list(self.instruction_refs),
+                "instructionDigests": dict(self.instruction_digests),
                 "workspacePolicy": self.workspace_policy,
+                "runtimeContextPolicy": self.runtime_context_policy,
                 "workspaceBaseline": self.workspace_baseline,
                 "checkpointRefs": self.checkpoint_refs,
                 "priorEvidenceRefs": list(self.prior_evidence_refs),
+                "boundedSummaries": list(self.bounded_summaries),
+                "branchComparisonRefs": list(self.branch_comparison_refs),
                 "retrievalManifestRef": self.retrieval_manifest_ref,
                 "memoryManifestRef": self.memory_manifest_ref,
                 "memoryContextRef": self.memory_context_ref,
@@ -461,14 +511,20 @@ def build_execution_context_bundle(
     logical_step_id: str,
     execution_ordinal: int | None = None,
     reason: str = "initial_execution",
+    branch: Mapping[str, Any] | None = None,
+    instruction_refs: Sequence[Any] | None = None,
+    instruction_digests: Mapping[str, Any] | None = None,
     task_input_snapshot_ref: str | None = None,
     plan_ref: str | None = None,
     plan_digest: str | None = None,
     prepared_context: StepPreparedContext | None = None,
     workspace_policy: str | None = None,
+    runtime_context_policy: BranchRuntimeContextPolicy | None = None,
     workspace_baseline: Mapping[str, Any] | None = None,
     checkpoint_refs: Mapping[str, Any] | None = None,
     prior_evidence_refs: Sequence[Any] | None = None,
+    bounded_summaries: Sequence[Any] | None = None,
+    branch_comparison_refs: Sequence[Any] | None = None,
     runtime_selection: Mapping[str, Any] | None = None,
     quality_gate_profile: str | None = None,
     policy_refs: Mapping[str, Any] | None = None,
@@ -519,14 +575,20 @@ def build_execution_context_bundle(
         "logicalStepId": logical_step_id,
         "executionOrdinal": execution_ordinal or 1,
         "reason": reason,
+        "branch": _optional_mapping(branch),
+        "instructionRefs": _clean_existing_refs(instruction_refs),
+        "instructionDigests": _compact_mapping(instruction_digests),
         "taskInputSnapshotRef": _optional_text(task_input_snapshot_ref),
         "planRef": _optional_text(plan_ref),
         "planDigest": _optional_text(plan_digest),
         "preparedInputRefs": list(prepared_input_refs),
         "workspacePolicy": _optional_text(workspace_policy),
+        "runtimeContextPolicy": runtime_context_policy,
         "workspaceBaseline": _compact_mapping(workspace_baseline),
         "checkpointRefs": _compact_mapping(checkpoint_refs),
         "priorEvidenceRefs": _clean_existing_refs(prior_evidence_refs),
+        "boundedSummaries": _bounded_summaries(bounded_summaries),
+        "branchComparisonRefs": _clean_existing_refs(branch_comparison_refs),
         "retrievalManifestRef": retrieval_manifest_ref,
         "memoryManifestRef": memory_manifest_ref,
         "memoryContextRef": memory_context_ref,
@@ -549,6 +611,175 @@ def build_execution_context_bundle(
         "contextBundleDigest": digest,
     }
     return ExecutionContextBundle.model_validate(payload)
+
+
+def build_branch_turn_context_bundle(
+    *,
+    workflow_id: str,
+    run_id: str,
+    logical_step_id: str,
+    execution_ordinal: int,
+    branch_id: str,
+    branch_turn_id: str,
+    source_checkpoint: Mapping[str, Any],
+    instruction_artifact_ref: str,
+    instruction_digest: str,
+    runtime_context_policy: BranchRuntimeContextPolicy,
+    workspace_policy: str,
+    task_input_snapshot_ref: str | None = None,
+    plan_ref: str | None = None,
+    plan_digest: str | None = None,
+    initial_instruction_ref: str | None = None,
+    initial_instruction_digest: str | None = None,
+    parent_branch_id: str | None = None,
+    parent_turn_id: str | None = None,
+    label: str | None = None,
+    git_work_branch: str | None = None,
+    workspace_baseline: Mapping[str, Any] | None = None,
+    prior_evidence_refs: Sequence[Any] | None = None,
+    bounded_summaries: Sequence[Any] | None = None,
+    branch_comparison_refs: Sequence[Any] | None = None,
+    runtime_selection: Mapping[str, Any] | None = None,
+    policy_refs: Mapping[str, Any] | None = None,
+    builder_version: str = BRANCH_TURN_CONTEXT_BUILDER_VERSION,
+) -> ExecutionContextBundle:
+    """Build the immutable context bundle for one Checkpoint Branch turn.
+
+    This is the MM-1089 branch-turn launch contract: it requires a new Step
+    Execution identity, pinned source checkpoint identity, declared workspace
+    and runtime policies, and artifact-backed instructions with a digest.
+    """
+
+    checkpoint = _branch_source_checkpoint(source_checkpoint)
+    turn_ref = _required_artifact_ref(
+        instruction_artifact_ref,
+        field_name="instruction_artifact_ref",
+    )
+    turn_digest = _required_digest(
+        instruction_digest,
+        field_name="instruction_digest",
+    )
+    instruction_refs = [turn_ref]
+    instruction_digests = {turn_ref: turn_digest}
+    if initial_instruction_ref is not None:
+        initial_ref = _required_artifact_ref(
+            initial_instruction_ref,
+            field_name="initial_instruction_ref",
+        )
+        instruction_refs.insert(0, initial_ref)
+        if initial_instruction_digest is None:
+            raise ValueError(
+                "initial_instruction_digest is required with initial_instruction_ref"
+            )
+        instruction_digests[initial_ref] = _required_digest(
+            initial_instruction_digest,
+            field_name="initial_instruction_digest",
+        )
+
+    branch = {
+        "branchId": _required_text(branch_id, field_name="branch_id"),
+        "branchTurnId": _required_text(branch_turn_id, field_name="branch_turn_id"),
+        "label": _optional_text(label),
+        "sourceCheckpoint": checkpoint,
+        "sourceCheckpointRef": checkpoint["checkpointRef"],
+        "sourceCheckpointDigest": checkpoint.get("checkpointDigest"),
+        "rootCheckpointRef": checkpoint["checkpointRef"],
+        "parentBranchId": _optional_text(parent_branch_id),
+        "parentTurnId": _optional_text(parent_turn_id),
+        "gitWorkBranch": _optional_text(git_work_branch),
+        "traceability": MM_1089_TRACEABILITY,
+    }
+    checkpoint_refs = {
+        "source": checkpoint["checkpointRef"],
+        "sourceCheckpoint": checkpoint,
+    }
+
+    return build_execution_context_bundle(
+        workflow_id=workflow_id,
+        run_id=run_id,
+        logical_step_id=logical_step_id,
+        execution_ordinal=execution_ordinal,
+        reason="checkpoint_branch",
+        branch=branch,
+        instruction_refs=instruction_refs,
+        instruction_digests=instruction_digests,
+        task_input_snapshot_ref=task_input_snapshot_ref,
+        plan_ref=plan_ref,
+        plan_digest=plan_digest,
+        workspace_policy=workspace_policy,
+        runtime_context_policy=runtime_context_policy,
+        workspace_baseline=workspace_baseline,
+        checkpoint_refs=checkpoint_refs,
+        prior_evidence_refs=prior_evidence_refs,
+        bounded_summaries=bounded_summaries,
+        branch_comparison_refs=branch_comparison_refs,
+        runtime_selection=runtime_selection,
+        policy_refs=policy_refs,
+        builder_version=builder_version,
+    )
+
+
+def branch_turn_step_execution_manifest_projection(
+    bundle: ExecutionContextBundle,
+) -> dict[str, Any]:
+    """Return branch metadata for a Step Execution manifest extension."""
+
+    branch = dict(bundle.branch or {})
+    return {
+        "branch": {
+            "branchId": branch.get("branchId"),
+            "branchTurnId": branch.get("branchTurnId"),
+            "rootCheckpointRef": branch.get("rootCheckpointRef"),
+            "parentBranchId": branch.get("parentBranchId"),
+            "parentTurnId": branch.get("parentTurnId"),
+            "gitWorkBranch": branch.get("gitWorkBranch"),
+        }
+    }
+
+
+def build_branch_turn_artifact_manifest(
+    *,
+    branch_id: str,
+    branch_turn_id: str,
+    context_bundle: ExecutionContextBundle,
+) -> dict[str, Any]:
+    """Build the minimum named artifact plan for a branch and branch turn."""
+
+    branch_text = _safe_segment(_required_text(branch_id, field_name="branch_id"))
+    turn_text = _safe_segment(
+        _required_text(branch_turn_id, field_name="branch_turn_id")
+    )
+    artifacts: list[dict[str, Any]] = []
+    for name in MINIMUM_BRANCH_ARTIFACT_NAMES:
+        artifacts.append(
+            {
+                "name": name,
+                "artifactRef": f"artifact://checkpoint-branches/{branch_text}/{name}",
+                "scope": "branch",
+            }
+        )
+    for name in MINIMUM_BRANCH_TURN_ARTIFACT_NAMES:
+        artifacts.append(
+            {
+                "name": name,
+                "artifactRef": (
+                    "artifact://checkpoint-branches/"
+                    f"{branch_text}/turns/{turn_text}/{name}"
+                ),
+                "scope": "branch_turn",
+            }
+        )
+    payload = {
+        "schemaVersion": "v1",
+        "traceability": MM_1089_TRACEABILITY,
+        "branchId": branch_id,
+        "branchTurnId": branch_turn_id,
+        "contextBundleRef": context_bundle.context_bundle_ref,
+        "contextBundleDigest": context_bundle.context_bundle_digest,
+        "artifacts": artifacts,
+    }
+    payload["artifactManifestDigest"] = _digest_payload(payload)
+    return payload
 
 
 def _build_cost_policy(runtime_selection: Mapping[str, Any]) -> dict[str, Any]:
@@ -710,6 +941,48 @@ def _clean_existing_refs(existing_refs: Sequence[Any] | None) -> list[str]:
         if isinstance(ref, str) and ref.strip():
             refs.append(ref.strip())
     return refs
+
+
+def _branch_source_checkpoint(source_checkpoint: Mapping[str, Any]) -> dict[str, Any]:
+    if not isinstance(source_checkpoint, Mapping):
+        raise ValueError("source_checkpoint must be a mapping")
+    _reject_unsafe_values(source_checkpoint, path="branch.sourceCheckpoint")
+    payload = {
+        "workflowId": _required_text(
+            source_checkpoint.get("workflowId") or source_checkpoint.get("workflow_id"),
+            field_name="source_checkpoint.workflowId",
+        ),
+        "runId": _required_text(
+            source_checkpoint.get("runId") or source_checkpoint.get("run_id"),
+            field_name="source_checkpoint.runId",
+        ),
+        "logicalStepId": _optional_text(
+            source_checkpoint.get("logicalStepId")
+            or source_checkpoint.get("logical_step_id")
+        ),
+        "sourceExecutionOrdinal": _optional_int(
+            source_checkpoint.get("sourceExecutionOrdinal")
+            or source_checkpoint.get("source_execution_ordinal")
+            or source_checkpoint.get("executionOrdinal")
+            or source_checkpoint.get("execution_ordinal")
+        ),
+        "checkpointBoundary": _required_text(
+            source_checkpoint.get("checkpointBoundary")
+            or source_checkpoint.get("checkpoint_boundary"),
+            field_name="source_checkpoint.checkpointBoundary",
+        ),
+        "checkpointRef": _required_artifact_ref(
+            source_checkpoint.get("checkpointRef")
+            or source_checkpoint.get("checkpoint_ref"),
+            field_name="source_checkpoint.checkpointRef",
+        ),
+        "checkpointDigest": _optional_digest(
+            source_checkpoint.get("checkpointDigest")
+            or source_checkpoint.get("checkpoint_digest")
+        ),
+    }
+    _reject_unsafe_values(payload, path="branch.sourceCheckpoint")
+    return {key: value for key, value in payload.items() if value is not None}
 
 
 def build_recovery_prepared_artifact_refs(
@@ -982,6 +1255,35 @@ def _optional_text(value: Any) -> str | None:
         return None
     candidate = str(value).strip()
     return candidate or None
+
+
+def _required_text(value: Any, *, field_name: str) -> str:
+    candidate = _optional_text(value)
+    if candidate is None:
+        raise ValueError(f"{field_name} must be a non-empty string")
+    _reject_unsafe_values(candidate, path=field_name)
+    return candidate
+
+
+def _required_artifact_ref(value: Any, *, field_name: str) -> str:
+    candidate = _required_text(value, field_name=field_name)
+    if not candidate.startswith("artifact://"):
+        raise ValueError(f"{field_name} must be an artifact ref")
+    return candidate
+
+
+def _required_digest(value: Any, *, field_name: str) -> str:
+    candidate = _required_text(value, field_name=field_name)
+    if not candidate.startswith("sha256:"):
+        raise ValueError(f"{field_name} must be a sha256 digest")
+    return candidate
+
+
+def _optional_digest(value: Any) -> str | None:
+    candidate = _optional_text(value)
+    if candidate is None:
+        return None
+    return _required_digest(candidate, field_name="checkpointDigest")
 
 
 def _optional_int(value: Any) -> int | None:

--- a/moonmind/workflows/executions/prepared_context.py
+++ b/moonmind/workflows/executions/prepared_context.py
@@ -107,6 +107,7 @@ _UNSAFE_PROVIDER_PAYLOAD_KEYS = {
     "tool_calls",
 }
 _SAFE_SEGMENT_RE = re.compile(r"[^A-Za-z0-9._:-]+")
+_COMPACT_ARTIFACT_ID_RE = re.compile(r"^art_[A-Za-z0-9][A-Za-z0-9_.:-]*$")
 
 
 class PreparedInputEntry(BaseModel):
@@ -655,7 +656,7 @@ def build_branch_turn_context_bundle(
     and runtime policies, and artifact-backed instructions with a digest.
     """
 
-    checkpoint = _branch_source_checkpoint(source_checkpoint)
+    source = _branch_source_evidence(source_checkpoint)
     turn_ref = _required_artifact_ref(
         instruction_artifact_ref,
         field_name="instruction_artifact_ref",
@@ -685,19 +686,29 @@ def build_branch_turn_context_bundle(
         "branchId": _required_text(branch_id, field_name="branch_id"),
         "branchTurnId": _required_text(branch_turn_id, field_name="branch_turn_id"),
         "label": _optional_text(label),
-        "sourceCheckpoint": checkpoint,
-        "sourceCheckpointRef": checkpoint["checkpointRef"],
-        "sourceCheckpointDigest": checkpoint.get("checkpointDigest"),
-        "rootCheckpointRef": checkpoint["checkpointRef"],
+        "sourceCheckpoint": source if source.get("checkpointRef") else None,
+        "sourceCheckpointRef": source.get("checkpointRef"),
+        "sourceCheckpointDigest": source.get("checkpointDigest"),
+        "rootCheckpointRef": source.get("checkpointRef"),
+        "sourceStateKind": source.get("sourceStateKind"),
+        "sourceStateRef": source.get("sourceStateRef"),
+        "sourceStateDigest": source.get("sourceStateDigest"),
         "parentBranchId": _optional_text(parent_branch_id),
         "parentTurnId": _optional_text(parent_turn_id),
         "gitWorkBranch": _optional_text(git_work_branch),
         "traceability": MM_1089_TRACEABILITY,
     }
-    checkpoint_refs = {
-        "source": checkpoint["checkpointRef"],
-        "sourceCheckpoint": checkpoint,
-    }
+    branch = {key: value for key, value in branch.items() if value is not None}
+    checkpoint_refs = {}
+    if source.get("checkpointRef"):
+        checkpoint_refs["source"] = source["checkpointRef"]
+        checkpoint_refs["sourceCheckpoint"] = source
+    elif source.get("sourceStateRef"):
+        checkpoint_refs["sourceState"] = {
+            key: source[key]
+            for key in ("sourceStateKind", "sourceStateRef", "sourceStateDigest")
+            if source.get(key) is not None
+        }
 
     return build_execution_context_bundle(
         workflow_id=workflow_id,
@@ -735,14 +746,20 @@ def branch_turn_step_execution_manifest_projection(
     """Return branch metadata for a Step Execution manifest extension."""
 
     branch = dict(bundle.branch or {})
+    branch_metadata = {
+        "branchId": branch.get("branchId"),
+        "branchTurnId": branch.get("branchTurnId"),
+        "rootCheckpointRef": branch.get("rootCheckpointRef"),
+        "sourceStateKind": branch.get("sourceStateKind"),
+        "sourceStateRef": branch.get("sourceStateRef"),
+        "sourceStateDigest": branch.get("sourceStateDigest"),
+        "parentBranchId": branch.get("parentBranchId"),
+        "parentTurnId": branch.get("parentTurnId"),
+        "gitWorkBranch": branch.get("gitWorkBranch"),
+    }
     return {
         "branch": {
-            "branchId": branch.get("branchId"),
-            "branchTurnId": branch.get("branchTurnId"),
-            "rootCheckpointRef": branch.get("rootCheckpointRef"),
-            "parentBranchId": branch.get("parentBranchId"),
-            "parentTurnId": branch.get("parentTurnId"),
-            "gitWorkBranch": branch.get("gitWorkBranch"),
+            key: value for key, value in branch_metadata.items() if value is not None
         }
     }
 
@@ -752,6 +769,7 @@ def build_branch_turn_artifact_manifest(
     branch_id: str,
     branch_turn_id: str,
     context_bundle: ExecutionContextBundle,
+    artifact_refs: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Build the minimum named artifact plan for a branch and branch turn."""
 
@@ -759,25 +777,34 @@ def build_branch_turn_artifact_manifest(
     turn_text = _safe_segment(
         _required_text(branch_turn_id, field_name="branch_turn_id")
     )
+    actual_refs = {
+        str(name): str(ref).strip()
+        for name, ref in dict(artifact_refs or {}).items()
+        if str(name).strip() and str(ref).strip()
+    }
     artifacts: list[dict[str, Any]] = []
     for name in MINIMUM_BRANCH_ARTIFACT_NAMES:
+        planned_ref = f"artifact://checkpoint-branches/{branch_text}/{name}"
         artifacts.append(
-            {
-                "name": name,
-                "artifactRef": f"artifact://checkpoint-branches/{branch_text}/{name}",
-                "scope": "branch",
-            }
+            _branch_artifact_manifest_entry(
+                name=name,
+                scope="branch",
+                planned_ref=planned_ref,
+                actual_ref=actual_refs.get(name),
+            )
         )
     for name in MINIMUM_BRANCH_TURN_ARTIFACT_NAMES:
+        planned_ref = (
+            "artifact://checkpoint-branches/"
+            f"{branch_text}/turns/{turn_text}/{name}"
+        )
         artifacts.append(
-            {
-                "name": name,
-                "artifactRef": (
-                    "artifact://checkpoint-branches/"
-                    f"{branch_text}/turns/{turn_text}/{name}"
-                ),
-                "scope": "branch_turn",
-            }
+            _branch_artifact_manifest_entry(
+                name=name,
+                scope="branch_turn",
+                planned_ref=planned_ref,
+                actual_ref=actual_refs.get(name),
+            )
         )
     payload = {
         "schemaVersion": "v1",
@@ -790,6 +817,26 @@ def build_branch_turn_artifact_manifest(
     }
     payload["artifactManifestDigest"] = _digest_payload(payload)
     return payload
+
+
+def _branch_artifact_manifest_entry(
+    *,
+    name: str,
+    scope: str,
+    planned_ref: str,
+    actual_ref: str | None,
+) -> dict[str, Any]:
+    entry = {
+        "name": name,
+        "scope": scope,
+        "plannedArtifactRef": planned_ref,
+    }
+    if actual_ref:
+        entry["artifactRef"] = actual_ref
+        entry["artifactRefStatus"] = "persisted"
+    else:
+        entry["artifactRefStatus"] = "planned"
+    return entry
 
 
 def _build_cost_policy(runtime_selection: Mapping[str, Any]) -> dict[str, Any]:
@@ -953,10 +1000,19 @@ def _clean_existing_refs(existing_refs: Sequence[Any] | None) -> list[str]:
     return refs
 
 
-def _branch_source_checkpoint(source_checkpoint: Mapping[str, Any]) -> dict[str, Any]:
+def _branch_source_evidence(source_checkpoint: Mapping[str, Any]) -> dict[str, Any]:
     if not isinstance(source_checkpoint, Mapping):
         raise ValueError("source_checkpoint must be a mapping")
     _reject_unsafe_values(source_checkpoint, path="branch.sourceCheckpoint")
+    checkpoint_ref = source_checkpoint.get("checkpointRef") or source_checkpoint.get(
+        "checkpoint_ref"
+    )
+    source_state_kind = source_checkpoint.get(
+        "sourceStateKind"
+    ) or source_checkpoint.get("source_state_kind")
+    source_state_ref = source_checkpoint.get("sourceStateRef") or source_checkpoint.get(
+        "source_state_ref"
+    )
     payload = {
         "workflowId": _required_text(
             source_checkpoint.get("workflowId") or source_checkpoint.get("workflow_id"),
@@ -976,21 +1032,35 @@ def _branch_source_checkpoint(source_checkpoint: Mapping[str, Any]) -> dict[str,
             or source_checkpoint.get("executionOrdinal")
             or source_checkpoint.get("execution_ordinal")
         ),
-        "checkpointBoundary": _required_text(
+        "checkpointBoundary": _optional_text(
             source_checkpoint.get("checkpointBoundary")
-            or source_checkpoint.get("checkpoint_boundary"),
-            field_name="source_checkpoint.checkpointBoundary",
+            or source_checkpoint.get("checkpoint_boundary")
         ),
-        "checkpointRef": _required_artifact_ref(
-            source_checkpoint.get("checkpointRef")
-            or source_checkpoint.get("checkpoint_ref"),
+        "checkpointRef": _optional_artifact_ref(
+            checkpoint_ref,
             field_name="source_checkpoint.checkpointRef",
         ),
         "checkpointDigest": _optional_digest(
             source_checkpoint.get("checkpointDigest")
             or source_checkpoint.get("checkpoint_digest")
         ),
+        "sourceStateKind": _optional_text(source_state_kind),
+        "sourceStateRef": _optional_text(source_state_ref),
+        "sourceStateDigest": _optional_digest(
+            source_checkpoint.get("sourceStateDigest")
+            or source_checkpoint.get("source_state_digest")
+        ),
     }
+    if payload["checkpointRef"] and not payload["checkpointBoundary"]:
+        raise ValueError(
+            "source_checkpoint.checkpointBoundary is required with checkpointRef"
+        )
+    if not payload["checkpointRef"] and not (
+        payload["sourceStateKind"] and payload["sourceStateRef"]
+    ):
+        raise ValueError(
+            "source_checkpoint requires checkpointRef or typed sourceStateRef"
+        )
     _reject_unsafe_values(payload, path="branch.sourceCheckpoint")
     return {key: value for key, value in payload.items() if value is not None}
 
@@ -1276,9 +1346,21 @@ def _required_text(value: Any, *, field_name: str) -> str:
 
 
 def _required_artifact_ref(value: Any, *, field_name: str) -> str:
+    candidate = _optional_artifact_ref(value, field_name=field_name)
+    if candidate is None:
+        raise ValueError(f"{field_name} must be a non-empty string")
+    return candidate
+
+
+def _optional_artifact_ref(value: Any, *, field_name: str) -> str | None:
+    if value is None:
+        return None
     candidate = _required_text(value, field_name=field_name)
-    if not candidate.startswith("artifact://"):
-        raise ValueError(f"{field_name} must be an artifact ref")
+    if not (
+        candidate.startswith("artifact://")
+        or _COMPACT_ARTIFACT_ID_RE.fullmatch(candidate)
+    ):
+        raise ValueError(f"{field_name} must be an artifact ref or artifact id")
     return candidate
 
 

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -54,6 +54,9 @@ with workflow.unsafe.imports_passed_through():
     from moonmind.workflows.executions.routing import _coerce_bool
     from moonmind.workflows.executions.prepared_context import (
         ExecutionContextBundle,
+        branch_turn_step_execution_manifest_projection,
+        build_branch_turn_artifact_manifest,
+        build_branch_turn_context_bundle,
         build_durable_retrieval_manifest_artifact,
         build_execution_context_bundle,
         build_prepared_input_manifest,
@@ -511,6 +514,7 @@ RUN_EMIT_EPHEMERAL_STEP_CHECKPOINTS_PATCH = (
     "run-emit-ephemeral-step-checkpoints-v1"
 )
 RUN_STEP_EXECUTION_NAMING_PATCH = "run-step-execution-naming-v1"
+RUN_CHECKPOINT_BRANCH_TURN_CONTEXT_PATCH = "run-checkpoint-branch-turn-context-v1"
 RUN_ALREADY_IMPLEMENTED_JIRA_COMPLETION_PATCH = (
     "run-already-implemented-jira-completion-v1"
 )
@@ -1024,6 +1028,12 @@ class MoonMindRunWorkflow:
         self._step_execution_retrieval_manifest_artifacts: dict[
             tuple[str, int], dict[str, Any]
         ] = {}
+        self._step_execution_branch_projections: dict[
+            tuple[str, int], dict[str, Any]
+        ] = {}
+        self._step_execution_branch_artifact_manifests: dict[
+            tuple[str, int], dict[str, Any]
+        ] = {}
         # Side-effect records observed per logical step across attempts, keyed by
         # logical step id. Used to detect already-occurred non-idempotent
         # external effects when a reattempt starts (Section 11, rules 3-4).
@@ -1315,6 +1325,11 @@ class MoonMindRunWorkflow:
             logicalStepId=logical_step_id,
             executionOrdinal=attempt,
         )
+        branch_metadata = self._step_execution_branch_metadata(
+            logical_step_id,
+            attempt=attempt,
+        )
+        manifest_reason = "checkpoint_branch" if branch_metadata else reason
         step_execution_id = build_step_execution_id(identity)
         idempotency_key = build_step_execution_idempotency_key(identity, "manifest")
         source_execution_ordinal = self._step_execution_source_identity(
@@ -1323,7 +1338,7 @@ class MoonMindRunWorkflow:
         )
         lineage = self._step_execution_lineage(
             logical_step_id,
-            reason=reason,
+            reason=manifest_reason,
             source_execution_ordinal=source_execution_ordinal,
         )
         workspace = self._step_execution_workspace(
@@ -1335,6 +1350,11 @@ class MoonMindRunWorkflow:
             **self._step_execution_compact_execution_refs(logical_step_id),
             **(execution or {}),
         }
+        if branch_metadata:
+            execution_payload.setdefault(
+                "checkpointBranchTurn",
+                dict(branch_metadata),
+            )
         # MM-880: stamp the versioned ResiliencePolicy reference governing this
         # step so it can be traced to the exact policy values that applied.
         # Steps whose resolved provider profile differs from the run-level one
@@ -1441,6 +1461,20 @@ class MoonMindRunWorkflow:
                 logical_step_id,
                 attempt=identity.execution_ordinal,
             )
+            branch_artifact_manifest_ref = (
+                await self._persist_step_execution_branch_artifact_manifest(
+                    logical_step_id,
+                    attempt=identity.execution_ordinal,
+                )
+            )
+            if branch_artifact_manifest_ref and branch_metadata:
+                checkpoint_branch_turn = dict(
+                    execution_payload.get("checkpointBranchTurn") or {}
+                )
+                checkpoint_branch_turn["artifactManifestRef"] = (
+                    branch_artifact_manifest_ref
+                )
+                execution_payload["checkpointBranchTurn"] = checkpoint_branch_turn
 
         manifest = StepExecutionManifestModel(
             stepExecutionId=step_execution_id,
@@ -1449,7 +1483,8 @@ class MoonMindRunWorkflow:
             logicalStepId=identity.logical_step_id,
             executionOrdinal=identity.execution_ordinal,
             lineage=dict(lineage) if lineage is not None else None,
-            reason=reason,
+            branch=dict(branch_metadata) if branch_metadata else None,
+            reason=manifest_reason,
             status=resolved_status,
             terminalDisposition=resolved_terminal_disposition,
             startedAt=self._step_execution_started_at(logical_step_id) or updated_at,
@@ -1458,7 +1493,7 @@ class MoonMindRunWorkflow:
             context=self._step_execution_manifest_context_projection(
                 logical_step_id,
                 attempt=identity.execution_ordinal,
-                reason=reason,
+                reason=manifest_reason,
                 execution=execution_payload,
             ),
             workspace=workspace_payload,
@@ -1540,6 +1575,65 @@ class MoonMindRunWorkflow:
         if isinstance(cached_context, Mapping):
             updated_context = dict(cached_context)
             updated_context["retrievalManifestRef"] = manifest_ref
+            self._step_execution_context_projections[cache_key] = updated_context
+        return manifest_ref
+
+    async def _persist_step_execution_branch_artifact_manifest(
+        self,
+        logical_step_id: str,
+        *,
+        attempt: int,
+    ) -> str | None:
+        cache_key = (logical_step_id, attempt)
+        branch_artifact_manifest = self._step_execution_branch_artifact_manifests.get(
+            cache_key
+        )
+        if not isinstance(branch_artifact_manifest, Mapping):
+            return None
+        existing_ref = branch_artifact_manifest.get("persistedArtifactRef")
+        if isinstance(existing_ref, str) and existing_ref.strip():
+            return existing_ref
+
+        payload = {
+            key: value
+            for key, value in dict(branch_artifact_manifest).items()
+            if key != "persistedArtifactRef"
+        }
+        branch_id = self._coerce_text(payload.get("branchId"), max_chars=200)
+        branch_turn_id = self._coerce_text(payload.get("branchTurnId"), max_chars=200)
+        if not branch_id or not branch_turn_id:
+            raise ValueError(
+                "checkpoint branch artifact manifest requires branchId and branchTurnId"
+            )
+        manifest_ref = await self._write_json_artifact(
+            name=(
+                "reports/checkpoint_branches/"
+                f"{self._artifact_slug(branch_id)}/turns/"
+                f"{self._artifact_slug(branch_turn_id)}/artifact_manifest.json"
+            ),
+            payload=payload,
+            content_type="application/json",
+            metadata_json={
+                "artifact_kind": "checkpoint_branch_turn_artifact_manifest",
+                "traceability": str(payload.get("traceability") or "MM-1089"),
+                "branchId": branch_id,
+                "branchTurnId": branch_turn_id,
+                "logicalStepId": logical_step_id,
+                "attempt": attempt,
+            },
+        )
+        persisted_artifact = dict(branch_artifact_manifest)
+        persisted_artifact["persistedArtifactRef"] = manifest_ref
+        self._step_execution_branch_artifact_manifests[cache_key] = persisted_artifact
+
+        cached_context = self._step_execution_context_projections.get(cache_key)
+        if isinstance(cached_context, Mapping):
+            updated_context = dict(cached_context)
+            updated_context["branchArtifactManifestRef"] = manifest_ref
+            branch_context = dict(updated_context.get("branch") or {})
+            if branch_context:
+                branch_context["artifactManifestRef"] = manifest_ref
+                updated_context["branch"] = branch_context
             self._step_execution_context_projections[cache_key] = updated_context
         return manifest_ref
 
@@ -3486,6 +3580,235 @@ class MoonMindRunWorkflow:
             "quality_gate_profile": "repo-default",
             "policy_refs": dict(policy_refs or {}),
         }
+
+    def _checkpoint_branch_turn_payload(
+        self,
+        *,
+        node_inputs: Mapping[str, Any],
+        runtime_block: Mapping[str, Any],
+        metadata_payload: Mapping[str, Any],
+    ) -> dict[str, Any] | None:
+        """Return explicit checkpoint-branch turn metadata for a runtime node."""
+
+        for path, source in (
+            ("node.runtime", runtime_block),
+            ("node.inputs", node_inputs),
+            ("node.metadata", metadata_payload),
+        ):
+            payload = self._checkpoint_branch_turn_payload_from_source(
+                source,
+                path=path,
+            )
+            if payload is not None:
+                return payload
+        return None
+
+    def _checkpoint_branch_turn_payload_from_source(
+        self,
+        source: Mapping[str, Any],
+        *,
+        path: str,
+    ) -> dict[str, Any] | None:
+        for key in (
+            "checkpointBranchTurn",
+            "checkpoint_branch_turn",
+            "branchTurn",
+            "branch_turn",
+        ):
+            value = source.get(key)
+            if value is None:
+                continue
+            if not isinstance(value, Mapping):
+                raise ValueError(f"{path}.{key} must be an object when provided")
+            return self._json_mapping(value, path=f"{path}.{key}")
+
+        moonmind_payload = source.get("moonmind")
+        if isinstance(moonmind_payload, Mapping):
+            nested = self._checkpoint_branch_turn_payload_from_source(
+                moonmind_payload,
+                path=f"{path}.moonmind",
+            )
+            if nested is not None:
+                return nested
+
+        branch_id_present = any(key in source for key in ("branchId", "branch_id"))
+        branch_turn_present = any(
+            key in source for key in ("branchTurnId", "branch_turn_id")
+        )
+        if branch_id_present and branch_turn_present:
+            return self._json_mapping(source, path=path)
+        return None
+
+    def _checkpoint_branch_turn_text(
+        self,
+        payload: Mapping[str, Any],
+        *keys: str,
+    ) -> str | None:
+        for key in keys:
+            value = payload.get(key)
+            if value is None:
+                continue
+            if not isinstance(value, str):
+                raise ValueError(f"checkpoint branch turn {key} must be a string")
+            normalized = value.strip()
+            if normalized:
+                return normalized
+        return None
+
+    def _checkpoint_branch_turn_instruction_ref(
+        self,
+        payload: Mapping[str, Any],
+        *,
+        node_inputs: Mapping[str, Any],
+    ) -> str | None:
+        explicit_ref = self._checkpoint_branch_turn_text(
+            payload,
+            "instructionArtifactRef",
+            "instruction_artifact_ref",
+            "instructionRef",
+            "instruction_ref",
+            "instructionsArtifactRef",
+            "instructions_artifact_ref",
+        )
+        if explicit_ref:
+            return explicit_ref
+        for key in ("instructionRef", "instruction_ref", "instructions"):
+            value = node_inputs.get(key)
+            if isinstance(value, str) and value.strip().startswith("artifact://"):
+                return value.strip()
+        return None
+
+    def _checkpoint_branch_turn_source_checkpoint(
+        self,
+        payload: Mapping[str, Any],
+        *,
+        node_id: str,
+        wf_info: Any,
+        context_workspace: Mapping[str, Any],
+    ) -> dict[str, Any]:
+        raw_source = payload.get("sourceCheckpoint") or payload.get(
+            "source_checkpoint"
+        )
+        if raw_source is None:
+            source: dict[str, Any] = {}
+        elif isinstance(raw_source, Mapping):
+            source = self._json_mapping(
+                raw_source,
+                path="checkpointBranchTurn.sourceCheckpoint",
+            )
+        else:
+            raise ValueError(
+                "checkpoint branch turn sourceCheckpoint must be an object"
+            )
+
+        for source_key, payload_keys in (
+            ("workflowId", ("sourceWorkflowId", "source_workflow_id", "workflowId")),
+            ("runId", ("sourceRunId", "source_run_id", "runId")),
+            (
+                "logicalStepId",
+                (
+                    "sourceLogicalStepId",
+                    "source_logical_step_id",
+                    "logicalStepId",
+                ),
+            ),
+            (
+                "sourceExecutionOrdinal",
+                (
+                    "sourceExecutionOrdinal",
+                    "source_execution_ordinal",
+                    "executionOrdinal",
+                    "execution_ordinal",
+                ),
+            ),
+            (
+                "checkpointBoundary",
+                (
+                    "sourceCheckpointBoundary",
+                    "source_checkpoint_boundary",
+                    "checkpointBoundary",
+                    "checkpoint_boundary",
+                ),
+            ),
+            (
+                "checkpointRef",
+                (
+                    "sourceCheckpointRef",
+                    "source_checkpoint_ref",
+                    "checkpointRef",
+                    "checkpoint_ref",
+                ),
+            ),
+            (
+                "checkpointDigest",
+                (
+                    "sourceCheckpointDigest",
+                    "source_checkpoint_digest",
+                    "checkpointDigest",
+                    "checkpoint_digest",
+                ),
+            ),
+        ):
+            if source.get(source_key) is not None:
+                continue
+            for payload_key in payload_keys:
+                value = payload.get(payload_key)
+                if value is not None:
+                    source[source_key] = value
+                    break
+
+        source.setdefault("workflowId", wf_info.workflow_id)
+        source.setdefault("runId", wf_info.run_id)
+        source.setdefault("logicalStepId", node_id)
+        source.setdefault("checkpointBoundary", "after_execution")
+        if source.get("checkpointRef") is None:
+            checkpoint_ref = (
+                context_workspace.get("checkpointRef")
+                or context_workspace.get("stateCheckpointRef")
+                or context_workspace.get("checkpointBeforeRef")
+            )
+            if checkpoint_ref is not None:
+                source["checkpointRef"] = checkpoint_ref
+        if source.get("checkpointDigest") is None:
+            checkpoint_digest = (
+                context_workspace.get("checkpointDigest")
+                or context_workspace.get("stateCheckpointDigest")
+                or context_workspace.get("checkpointBeforeDigest")
+            )
+            if checkpoint_digest is not None:
+                source["checkpointDigest"] = checkpoint_digest
+        return source
+
+    def _checkpoint_branch_turn_workspace_policy(
+        self,
+        payload: Mapping[str, Any],
+        *,
+        context_kwargs: Mapping[str, Any],
+    ) -> str:
+        return (
+            self._checkpoint_branch_turn_text(
+                payload,
+                "workspacePolicy",
+                "workspace_policy",
+            )
+            or str(context_kwargs.get("workspace_policy") or "")
+            or "fresh_branch_from_source"
+        )
+
+    def _step_execution_branch_metadata(
+        self,
+        logical_step_id: str,
+        *,
+        attempt: int,
+    ) -> dict[str, Any] | None:
+        if not self._workflow_patch_enabled(RUN_CHECKPOINT_BRANCH_TURN_CONTEXT_PATCH):
+            return None
+        branch_metadata = self._step_execution_branch_projections.get(
+            (logical_step_id, attempt)
+        )
+        if not isinstance(branch_metadata, Mapping):
+            return None
+        return dict(branch_metadata)
 
     def _step_execution_manifest_context_projection(
         self,
@@ -12528,6 +12851,11 @@ class MoonMindRunWorkflow:
         }
         if execution_profile_ref:
             context_policy_refs["executionProfileRef"] = execution_profile_ref
+        runtime_context_policy = (
+            "fresh_agent_run"
+            if agent_kind == "managed"
+            else "external_provider_continuation"
+        )
         retrieval_context = None
         retrieval_manifest_artifact = None
         memory_proposals = None
@@ -12577,24 +12905,157 @@ class MoonMindRunWorkflow:
                     for pattern in raw_fix_patterns
                     if isinstance(pattern, Mapping)
                 ]
-        attempt_context = build_execution_context_bundle(
-            workflow_id=wf_info.workflow_id,
-            run_id=wf_info.run_id,
-            logical_step_id=node_id,
-            execution_ordinal=execution_ordinal,
-            prepared_context=prepared_context,
-            **self._step_execution_context_kwargs(
-                node_id,
-                attempt=execution_ordinal,
-                workspace=context_workspace,
-                policy_refs=context_policy_refs,
-            ),
-            runtime_selection=runtime_selection,
-            retrieval=retrieval_context,
-            memory_proposals=memory_proposals,
-            memory_context=memory_context,
-            fix_patterns=fix_patterns,
+        context_kwargs = self._step_execution_context_kwargs(
+            node_id,
+            attempt=execution_ordinal,
+            workspace=context_workspace,
+            policy_refs=context_policy_refs,
         )
+        branch_turn_payload = None
+        branch_projection = None
+        branch_artifact_manifest = None
+        metadata_payload_for_branch = (
+            parameters.get("metadata")
+            if isinstance(parameters.get("metadata"), dict)
+            else {}
+        )
+        candidate_branch_turn_payload = self._checkpoint_branch_turn_payload(
+            node_inputs=node_inputs,
+            runtime_block=runtime_block,
+            metadata_payload=metadata_payload_for_branch,
+        )
+        if candidate_branch_turn_payload is not None and self._workflow_patch_enabled(
+            RUN_CHECKPOINT_BRANCH_TURN_CONTEXT_PATCH
+        ):
+            branch_turn_payload = candidate_branch_turn_payload
+        if branch_turn_payload is not None:
+            source_checkpoint = self._checkpoint_branch_turn_source_checkpoint(
+                branch_turn_payload,
+                node_id=node_id,
+                wf_info=wf_info,
+                context_workspace=context_workspace,
+            )
+            branch_id = self._checkpoint_branch_turn_text(
+                branch_turn_payload,
+                "branchId",
+                "branch_id",
+            )
+            branch_turn_id = self._checkpoint_branch_turn_text(
+                branch_turn_payload,
+                "branchTurnId",
+                "branch_turn_id",
+            )
+            instruction_ref = self._checkpoint_branch_turn_instruction_ref(
+                branch_turn_payload,
+                node_inputs=node_inputs,
+            )
+            instruction_digest = self._checkpoint_branch_turn_text(
+                branch_turn_payload,
+                "instructionDigest",
+                "instruction_digest",
+                "instructionArtifactDigest",
+                "instruction_artifact_digest",
+            )
+            runtime_policy = (
+                self._checkpoint_branch_turn_text(
+                    branch_turn_payload,
+                    "runtimeContextPolicy",
+                    "runtime_context_policy",
+                )
+                or runtime_context_policy
+            )
+            attempt_context = build_branch_turn_context_bundle(
+                workflow_id=wf_info.workflow_id,
+                run_id=wf_info.run_id,
+                logical_step_id=node_id,
+                execution_ordinal=execution_ordinal,
+                branch_id=branch_id or "",
+                branch_turn_id=branch_turn_id or "",
+                source_checkpoint=source_checkpoint,
+                instruction_artifact_ref=instruction_ref or "",
+                instruction_digest=instruction_digest or "",
+                runtime_context_policy=runtime_policy,
+                workspace_policy=self._checkpoint_branch_turn_workspace_policy(
+                    branch_turn_payload,
+                    context_kwargs=context_kwargs,
+                ),
+                task_input_snapshot_ref=context_kwargs.get("task_input_snapshot_ref"),
+                plan_ref=context_kwargs.get("plan_ref"),
+                plan_digest=context_kwargs.get("plan_digest"),
+                initial_instruction_ref=self._checkpoint_branch_turn_text(
+                    branch_turn_payload,
+                    "initialInstructionRef",
+                    "initial_instruction_ref",
+                    "initialInstructionArtifactRef",
+                    "initial_instruction_artifact_ref",
+                ),
+                initial_instruction_digest=self._checkpoint_branch_turn_text(
+                    branch_turn_payload,
+                    "initialInstructionDigest",
+                    "initial_instruction_digest",
+                    "initialInstructionArtifactDigest",
+                    "initial_instruction_artifact_digest",
+                ),
+                parent_branch_id=self._checkpoint_branch_turn_text(
+                    branch_turn_payload,
+                    "parentBranchId",
+                    "parent_branch_id",
+                ),
+                parent_turn_id=self._checkpoint_branch_turn_text(
+                    branch_turn_payload,
+                    "parentTurnId",
+                    "parent_turn_id",
+                ),
+                label=self._checkpoint_branch_turn_text(
+                    branch_turn_payload,
+                    "label",
+                ),
+                git_work_branch=self._checkpoint_branch_turn_text(
+                    branch_turn_payload,
+                    "gitWorkBranch",
+                    "git_work_branch",
+                ),
+                prepared_context=prepared_context,
+                workspace_baseline=context_kwargs.get("workspace_baseline"),
+                prior_evidence_refs=context_kwargs.get("prior_evidence_refs"),
+                bounded_summaries=context_kwargs.get("bounded_summaries"),
+                branch_comparison_refs=context_kwargs.get("branch_comparison_refs"),
+                runtime_selection=runtime_selection,
+                policy_refs=context_kwargs.get("policy_refs"),
+                retrieval=retrieval_context,
+                memory_proposals=memory_proposals,
+                memory_context=memory_context,
+                fix_patterns=fix_patterns,
+            )
+            branch_projection = branch_turn_step_execution_manifest_projection(
+                attempt_context
+            ).get("branch")
+            if isinstance(branch_projection, Mapping):
+                self._step_execution_branch_projections[
+                    (node_id, execution_ordinal)
+                ] = dict(branch_projection)
+            branch_artifact_manifest = build_branch_turn_artifact_manifest(
+                branch_id=branch_id or "",
+                branch_turn_id=branch_turn_id or "",
+                context_bundle=attempt_context,
+            )
+            self._step_execution_branch_artifact_manifests[
+                (node_id, execution_ordinal)
+            ] = dict(branch_artifact_manifest)
+        else:
+            attempt_context = build_execution_context_bundle(
+                workflow_id=wf_info.workflow_id,
+                run_id=wf_info.run_id,
+                logical_step_id=node_id,
+                execution_ordinal=execution_ordinal,
+                prepared_context=prepared_context,
+                **context_kwargs,
+                runtime_selection=runtime_selection,
+                retrieval=retrieval_context,
+                memory_proposals=memory_proposals,
+                memory_context=memory_context,
+                fix_patterns=fix_patterns,
+            )
         metadata_payload = (
             parameters.get("metadata")
             if isinstance(parameters.get("metadata"), dict)
@@ -12612,6 +13073,34 @@ class MoonMindRunWorkflow:
         moonmind_payload["stepExecutionManifestProjection"] = (
             attempt_context.to_manifest_projection()
         )
+        if isinstance(branch_projection, Mapping) and isinstance(
+            branch_artifact_manifest,
+            Mapping,
+        ):
+            branch_context = dict(attempt_context.branch or {})
+            checkpoint_branch_turn = {
+                "branchId": branch_context.get("branchId"),
+                "branchTurnId": branch_context.get("branchTurnId"),
+                "sourceCheckpointRef": branch_context.get("sourceCheckpointRef"),
+                "sourceCheckpointDigest": branch_context.get(
+                    "sourceCheckpointDigest"
+                ),
+                "rootCheckpointRef": branch_context.get("rootCheckpointRef"),
+                "contextBundleRef": attempt_context.context_bundle_ref,
+                "contextBundleDigest": attempt_context.context_bundle_digest,
+                "builderVersion": attempt_context.builder_version,
+                "artifactManifestDigest": branch_artifact_manifest.get(
+                    "artifactManifestDigest"
+                ),
+            }
+            moonmind_payload["checkpointBranchTurn"] = {
+                key: value
+                for key, value in checkpoint_branch_turn.items()
+                if value is not None
+            }
+            moonmind_payload["checkpointBranchTurnArtifactManifest"] = dict(
+                branch_artifact_manifest
+            )
         if retrieval_manifest_artifact is not None:
             moonmind_payload["retrievalManifestArtifact"] = retrieval_manifest_artifact
             self._step_execution_retrieval_manifest_artifacts[
@@ -12635,11 +13124,6 @@ class MoonMindRunWorkflow:
             logicalStepId=node_id,
             executionOrdinal=step_execution or 1,
         )
-        runtime_context_policy = (
-            "fresh_agent_run"
-            if agent_kind == "managed"
-            else "external_provider_continuation"
-        )
         step_execution_payload: dict[str, Any] = {
             "schemaVersion": "v1",
             "workflowId": wf_info.workflow_id,
@@ -12647,8 +13131,10 @@ class MoonMindRunWorkflow:
             "logicalStepId": node_id,
             "executionOrdinal": step_execution_identity.execution_ordinal,
             "stepExecutionId": build_step_execution_id(step_execution_identity),
-            "reason": attempt_reason,
-            "runtimeContextPolicy": runtime_context_policy,
+            "reason": "checkpoint_branch" if branch_projection else attempt_reason,
+            "runtimeContextPolicy": (
+                attempt_context.runtime_context_policy or runtime_context_policy
+            ),
             "contextBundleRef": attempt_context.context_bundle_ref,
             "contextBundleDigest": attempt_context.context_bundle_digest,
             "preparedInputRefs": list(attempt_context.prepared_input_refs),
@@ -12722,17 +13208,28 @@ class MoonMindRunWorkflow:
         retrieval_artifact = self._step_execution_retrieval_manifest_artifacts.get(
             (logical_step_id, attempt)
         )
-        if not isinstance(retrieval_artifact, Mapping):
-            return request
-        persisted_ref = retrieval_artifact.get("persistedArtifactRef")
-        if not isinstance(persisted_ref, str) or not persisted_ref.strip():
+        branch_artifact_manifest = self._step_execution_branch_artifact_manifests.get(
+            (logical_step_id, attempt)
+        )
+        if not isinstance(retrieval_artifact, Mapping) and not isinstance(
+            branch_artifact_manifest,
+            Mapping,
+        ):
             return request
 
         update_payload: dict[str, Any] = {}
         metadata = dict(request.parameters.get("metadata") or {})
         moonmind_metadata = dict(metadata.get("moonmind") or {})
+        if isinstance(retrieval_artifact, Mapping):
+            persisted_ref = retrieval_artifact.get("persistedArtifactRef")
+        else:
+            persisted_ref = None
         execution_context = dict(moonmind_metadata.get("executionContext") or {})
-        if execution_context:
+        if (
+            isinstance(persisted_ref, str)
+            and persisted_ref.strip()
+            and execution_context
+        ):
             # ``retrievalManifestRef`` is part of the context-bundle digest, so
             # rebuild through the model to recompute ``contextBundleRef`` /
             # ``contextBundleDigest`` instead of swapping the ref in place and
@@ -12747,17 +13244,50 @@ class MoonMindRunWorkflow:
             moonmind_metadata["stepExecutionManifestProjection"] = (
                 rebuilt_context.to_manifest_projection()
             )
-        retrieval_manifest_artifact = dict(
-            moonmind_metadata.get("retrievalManifestArtifact") or {}
-        )
-        retrieval_manifest_artifact["persistedArtifactRef"] = persisted_ref
-        moonmind_metadata["retrievalManifestArtifact"] = retrieval_manifest_artifact
+            retrieval_manifest_artifact = dict(
+                moonmind_metadata.get("retrievalManifestArtifact") or {}
+            )
+            retrieval_manifest_artifact["persistedArtifactRef"] = persisted_ref
+            moonmind_metadata["retrievalManifestArtifact"] = retrieval_manifest_artifact
+        branch_artifact_ref = None
+        if isinstance(branch_artifact_manifest, Mapping):
+            candidate_ref = branch_artifact_manifest.get("persistedArtifactRef")
+            if isinstance(candidate_ref, str) and candidate_ref.strip():
+                branch_artifact_ref = candidate_ref.strip()
+        if branch_artifact_ref:
+            branch_turn = dict(moonmind_metadata.get("checkpointBranchTurn") or {})
+            branch_turn["artifactManifestRef"] = branch_artifact_ref
+            moonmind_metadata["checkpointBranchTurn"] = branch_turn
+            branch_manifest_payload = dict(
+                moonmind_metadata.get("checkpointBranchTurnArtifactManifest")
+                or branch_artifact_manifest
+            )
+            branch_manifest_payload["persistedArtifactRef"] = branch_artifact_ref
+            moonmind_metadata["checkpointBranchTurnArtifactManifest"] = (
+                branch_manifest_payload
+            )
+            projection = dict(
+                moonmind_metadata.get("stepExecutionManifestProjection") or {}
+            )
+            projection_context = dict(projection.get("context") or {})
+            if projection_context:
+                projection_branch = dict(projection_context.get("branch") or {})
+                if projection_branch:
+                    projection_branch["artifactManifestRef"] = branch_artifact_ref
+                    projection_context["branch"] = projection_branch
+                projection_context["branchArtifactManifestRef"] = branch_artifact_ref
+                projection["context"] = projection_context
+                moonmind_metadata["stepExecutionManifestProjection"] = projection
         metadata["moonmind"] = moonmind_metadata
         parameters = dict(request.parameters)
         parameters["metadata"] = metadata
         update_payload["parameters"] = parameters
 
-        if request.step_execution is not None:
+        if (
+            request.step_execution is not None
+            and isinstance(persisted_ref, str)
+            and persisted_ref.strip()
+        ):
             update_payload["step_execution"] = request.step_execution.model_copy(
                 update={"retrieval_manifest_ref": persisted_ref}
             )
@@ -12868,6 +13398,15 @@ class MoonMindRunWorkflow:
         }
         normalized_agent_id = _normalize_agent_runtime_id(agent_id)
         return runtime_mapping.get(normalized_agent_id, normalized_agent_id)
+
+    @staticmethod
+    def _workflow_patch_enabled(patch_id: str) -> bool:
+        try:
+            return bool(workflow.patched(patch_id))
+        except Exception as exc:
+            if exc.__class__.__name__ == "_NotInWorkflowEventLoopError":
+                return False
+            raise
 
     @staticmethod
     def _workflow_is_replaying() -> bool:

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -3780,9 +3780,7 @@ class MoonMindRunWorkflow:
                     source[source_key] = value
                     break
 
-        source.setdefault("workflowId", wf_info.workflow_id)
-        source.setdefault("runId", wf_info.run_id)
-        source.setdefault("logicalStepId", node_id)
+        explicit_checkpoint_ref = source.get("checkpointRef") is not None
         source.setdefault("checkpointBoundary", "after_execution")
         workspace = context_workspace if isinstance(context_workspace, Mapping) else {}
         if source.get("checkpointRef") is None:
@@ -3803,6 +3801,10 @@ class MoonMindRunWorkflow:
             )
             if checkpoint_digest is not None:
                 source["checkpointDigest"] = checkpoint_digest
+        if source.get("checkpointRef") is not None and not explicit_checkpoint_ref:
+            source.setdefault("workflowId", wf_info.workflow_id)
+            source.setdefault("runId", wf_info.run_id)
+            source.setdefault("logicalStepId", node_id)
         return source
 
     def _checkpoint_branch_turn_workspace_policy(
@@ -7293,10 +7295,12 @@ class MoonMindRunWorkflow:
                                     if review_gate_active
                                     else None,
                                 )
-                                request = self._request_with_persisted_retrieval_ref(
-                                    request,
-                                    logical_step_id=node_id,
-                                    attempt=current_step_execution,
+                                request = (
+                                    await self._request_with_persisted_retrieval_ref(
+                                        request,
+                                        logical_step_id=node_id,
+                                        attempt=current_step_execution,
+                                    )
                                 )
                             slot_continuity_enabled = workflow.patched(
                                 RUN_SLOT_CONTINUITY_PATCH
@@ -13257,7 +13261,7 @@ class MoonMindRunWorkflow:
             profile_selector=profile_selector,
         )
 
-    def _request_with_persisted_retrieval_ref(
+    async def _request_with_persisted_retrieval_ref(
         self,
         request: AgentExecutionRequest,
         *,
@@ -13358,10 +13362,28 @@ class MoonMindRunWorkflow:
                 branch_manifest_payload["contextBundleDigest"] = (
                     current_context_bundle.context_bundle_digest
                 )
+            previous_branch_payload = {
+                key: value
+                for key, value in dict(branch_artifact_manifest).items()
+                if key != "persistedArtifactRef"
+            }
+            if branch_manifest_payload != previous_branch_payload:
+                self._step_execution_branch_artifact_manifests[
+                    (logical_step_id, attempt)
+                ] = dict(branch_manifest_payload)
+                persisted_branch_ref = (
+                    await self._persist_step_execution_branch_artifact_manifest(
+                        logical_step_id,
+                        attempt=attempt,
+                    )
+                )
+                if persisted_branch_ref:
+                    branch_artifact_ref = persisted_branch_ref
             branch_manifest_payload["persistedArtifactRef"] = branch_artifact_ref
             branch_turn["artifactManifestDigest"] = branch_manifest_payload.get(
                 "artifactManifestDigest"
             )
+            branch_turn["artifactManifestRef"] = branch_artifact_ref
             moonmind_metadata["checkpointBranchTurn"] = branch_turn
             moonmind_metadata["checkpointBranchTurnArtifactManifest"] = (
                 branch_manifest_payload

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -3609,6 +3609,8 @@ class MoonMindRunWorkflow:
         *,
         path: str,
     ) -> dict[str, Any] | None:
+        if not isinstance(source, Mapping):
+            return None
         for key in (
             "checkpointBranchTurn",
             "checkpoint_branch_turn",
@@ -3748,6 +3750,27 @@ class MoonMindRunWorkflow:
                     "checkpoint_digest",
                 ),
             ),
+            (
+                "sourceStateKind",
+                (
+                    "sourceStateKind",
+                    "source_state_kind",
+                ),
+            ),
+            (
+                "sourceStateRef",
+                (
+                    "sourceStateRef",
+                    "source_state_ref",
+                ),
+            ),
+            (
+                "sourceStateDigest",
+                (
+                    "sourceStateDigest",
+                    "source_state_digest",
+                ),
+            ),
         ):
             if source.get(source_key) is not None:
                 continue
@@ -3761,19 +3784,22 @@ class MoonMindRunWorkflow:
         source.setdefault("runId", wf_info.run_id)
         source.setdefault("logicalStepId", node_id)
         source.setdefault("checkpointBoundary", "after_execution")
+        workspace = context_workspace if isinstance(context_workspace, Mapping) else {}
         if source.get("checkpointRef") is None:
             checkpoint_ref = (
-                context_workspace.get("checkpointRef")
-                or context_workspace.get("stateCheckpointRef")
-                or context_workspace.get("checkpointBeforeRef")
+                workspace.get("checkpointAfterRef")
+                or workspace.get("checkpointRef")
+                or workspace.get("stateCheckpointRef")
+                or workspace.get("checkpointBeforeRef")
             )
             if checkpoint_ref is not None:
                 source["checkpointRef"] = checkpoint_ref
         if source.get("checkpointDigest") is None:
             checkpoint_digest = (
-                context_workspace.get("checkpointDigest")
-                or context_workspace.get("stateCheckpointDigest")
-                or context_workspace.get("checkpointBeforeDigest")
+                workspace.get("checkpointAfterDigest")
+                or workspace.get("checkpointDigest")
+                or workspace.get("stateCheckpointDigest")
+                or workspace.get("checkpointBeforeDigest")
             )
             if checkpoint_digest is not None:
                 source["checkpointDigest"] = checkpoint_digest
@@ -9541,6 +9567,12 @@ class MoonMindRunWorkflow:
     ) -> None:
         if not workflow.patched(RUN_WORKFLOW_SCOPED_SESSION_CLEAR_BETWEEN_STEPS_PATCH):
             return
+        if (
+            request.step_execution is not None
+            and request.step_execution.runtime_context_policy
+            == "reuse_session_same_epoch"
+        ):
+            return
         execution_ordinal = self._step_execution_for(logical_step_id) or 1
         # New histories dedupe by Step Execution identity (logical step +
         # attempt ordinal). Histories that predate this patch keep the old
@@ -12914,6 +12946,7 @@ class MoonMindRunWorkflow:
         branch_turn_payload = None
         branch_projection = None
         branch_artifact_manifest = None
+        branch_instruction_ref = None
         metadata_payload_for_branch = (
             parameters.get("metadata")
             if isinstance(parameters.get("metadata"), dict)
@@ -12949,6 +12982,7 @@ class MoonMindRunWorkflow:
                 branch_turn_payload,
                 node_inputs=node_inputs,
             )
+            branch_instruction_ref = instruction_ref
             instruction_digest = self._checkpoint_branch_turn_text(
                 branch_turn_payload,
                 "instructionDigest",
@@ -13034,10 +13068,30 @@ class MoonMindRunWorkflow:
                 self._step_execution_branch_projections[
                     (node_id, execution_ordinal)
                 ] = dict(branch_projection)
+            artifact_refs: dict[str, str] = {}
+            source_ref = (
+                attempt_context.branch.get("rootCheckpointRef")
+                if attempt_context.branch
+                else None
+            )
+            if source_ref:
+                artifact_refs["input.branch.root_checkpoint.json"] = str(source_ref)
+            initial_ref = self._checkpoint_branch_turn_text(
+                branch_turn_payload,
+                "initialInstructionRef",
+                "initial_instruction_ref",
+                "initialInstructionArtifactRef",
+                "initial_instruction_artifact_ref",
+            )
+            if initial_ref:
+                artifact_refs["input.branch.initial_instructions.md"] = initial_ref
+            if instruction_ref:
+                artifact_refs["input.branch_turn.instructions.md"] = instruction_ref
             branch_artifact_manifest = build_branch_turn_artifact_manifest(
                 branch_id=branch_id or "",
                 branch_turn_id=branch_turn_id or "",
                 context_bundle=attempt_context,
+                artifact_refs=artifact_refs,
             )
             self._step_execution_branch_artifact_manifests[
                 (node_id, execution_ordinal)
@@ -13176,14 +13230,19 @@ class MoonMindRunWorkflow:
             node_inputs.get("runtimeCommand") or node_inputs.get("runtime_command")
         )
 
+        request_instruction_ref = (
+            branch_instruction_ref
+            or node_inputs.get("instructions")
+            or node_inputs.get("instructionRef")
+        )
+
         return AgentExecutionRequest(
             agent_kind=agent_kind,
             agent_id=agent_id,
             execution_profile_ref=execution_profile_ref,
             correlation_id=correlation_id,
             idempotency_key=idempotency_key,
-            instruction_ref=node_inputs.get("instructions")
-            or node_inputs.get("instructionRef"),
+            instruction_ref=request_instruction_ref,
             runtime_command=runtime_command_payload,
             step_execution=step_execution_payload,
             resolved_skillset_ref=resolved_skillset_ref,
@@ -13225,6 +13284,7 @@ class MoonMindRunWorkflow:
         else:
             persisted_ref = None
         execution_context = dict(moonmind_metadata.get("executionContext") or {})
+        current_context_bundle = None
         if (
             isinstance(persisted_ref, str)
             and persisted_ref.strip()
@@ -13244,28 +13304,71 @@ class MoonMindRunWorkflow:
             moonmind_metadata["stepExecutionManifestProjection"] = (
                 rebuilt_context.to_manifest_projection()
             )
+            current_context_bundle = rebuilt_context
             retrieval_manifest_artifact = dict(
                 moonmind_metadata.get("retrievalManifestArtifact") or {}
             )
             retrieval_manifest_artifact["persistedArtifactRef"] = persisted_ref
             moonmind_metadata["retrievalManifestArtifact"] = retrieval_manifest_artifact
+        elif execution_context:
+            current_context_bundle = ExecutionContextBundle.model_validate(
+                execution_context
+            )
         branch_artifact_ref = None
         if isinstance(branch_artifact_manifest, Mapping):
             candidate_ref = branch_artifact_manifest.get("persistedArtifactRef")
             if isinstance(candidate_ref, str) and candidate_ref.strip():
                 branch_artifact_ref = candidate_ref.strip()
-        if branch_artifact_ref:
+        if branch_artifact_ref and current_context_bundle is not None:
             branch_turn = dict(moonmind_metadata.get("checkpointBranchTurn") or {})
+            branch_turn["contextBundleRef"] = current_context_bundle.context_bundle_ref
+            branch_turn["contextBundleDigest"] = (
+                current_context_bundle.context_bundle_digest
+            )
             branch_turn["artifactManifestRef"] = branch_artifact_ref
-            moonmind_metadata["checkpointBranchTurn"] = branch_turn
-            branch_manifest_payload = dict(
+            existing_branch_manifest = dict(
                 moonmind_metadata.get("checkpointBranchTurnArtifactManifest")
                 or branch_artifact_manifest
             )
+            actual_refs = {
+                str(entry.get("name")): str(entry.get("artifactRef"))
+                for entry in existing_branch_manifest.get("artifacts", ())
+                if isinstance(entry, Mapping)
+                and str(entry.get("name") or "").strip()
+                and str(entry.get("artifactRef") or "").strip()
+            }
+            branch_id = branch_turn.get("branchId") or existing_branch_manifest.get(
+                "branchId"
+            )
+            branch_turn_id = branch_turn.get(
+                "branchTurnId"
+            ) or existing_branch_manifest.get("branchTurnId")
+            if branch_id and branch_turn_id:
+                branch_manifest_payload = build_branch_turn_artifact_manifest(
+                    branch_id=str(branch_id),
+                    branch_turn_id=str(branch_turn_id),
+                    context_bundle=current_context_bundle,
+                    artifact_refs=actual_refs,
+                )
+            else:
+                branch_manifest_payload = existing_branch_manifest
+                branch_manifest_payload["contextBundleRef"] = (
+                    current_context_bundle.context_bundle_ref
+                )
+                branch_manifest_payload["contextBundleDigest"] = (
+                    current_context_bundle.context_bundle_digest
+                )
             branch_manifest_payload["persistedArtifactRef"] = branch_artifact_ref
+            branch_turn["artifactManifestDigest"] = branch_manifest_payload.get(
+                "artifactManifestDigest"
+            )
+            moonmind_metadata["checkpointBranchTurn"] = branch_turn
             moonmind_metadata["checkpointBranchTurnArtifactManifest"] = (
                 branch_manifest_payload
             )
+            self._step_execution_branch_artifact_manifests[
+                (logical_step_id, attempt)
+            ] = dict(branch_manifest_payload)
             projection = dict(
                 moonmind_metadata.get("stepExecutionManifestProjection") or {}
             )

--- a/tests/unit/services/test_checkpoint_branch_service.py
+++ b/tests/unit/services/test_checkpoint_branch_service.py
@@ -116,13 +116,17 @@ def test_branch_manifest_metadata_is_optional_step_execution_lineage() -> None:
         }
     )
 
-    assert manifest.branch == StepExecutionBranchMetadataModel(
+    assert manifest.branch is not None
+    expected_branch = StepExecutionBranchMetadataModel(
         branchId="cbr-1",
         branchTurnId="cbt-1",
         rootCheckpointRef="artifact://checkpoint/after",
         parentBranchId="cbr-parent",
         parentTurnId="cbt-parent",
         gitWorkBranch="mm/wf-1/implement/cbr-1-focused-fix",
+    )
+    assert manifest.branch.model_dump(by_alias=True) == expected_branch.model_dump(
+        by_alias=True
     )
     assert manifest.model_dump(by_alias=True)["branch"]["branchId"] == "cbr-1"
 

--- a/tests/unit/workflows/executions/test_prepared_context.py
+++ b/tests/unit/workflows/executions/test_prepared_context.py
@@ -570,8 +570,6 @@ def test_mm_1089_branch_turn_context_records_immutable_launch_evidence() -> None
             "branchId": "cbr_01",
             "branchTurnId": "cbt_01",
             "rootCheckpointRef": "artifact://checkpoints/after-execution",
-            "parentBranchId": None,
-            "parentTurnId": None,
             "gitWorkBranch": "mm/workflow-1/implement-story/cbr-01",
         }
     }
@@ -611,6 +609,94 @@ def test_mm_1089_branch_turn_artifact_manifest_names_minimum_evidence() -> None:
     assert manifest["traceability"] == "MM-1089"
     assert manifest["contextBundleRef"] == bundle.context_bundle_ref
     assert manifest["artifactManifestDigest"].startswith("sha256:")
+    instruction_entry = next(
+        artifact
+        for artifact in manifest["artifacts"]
+        if artifact["name"] == "input.branch_turn.instructions.md"
+    )
+    assert instruction_entry["artifactRefStatus"] == "planned"
+    assert "artifactRef" not in instruction_entry
+
+
+def test_mm_1089_branch_turn_artifact_manifest_uses_real_refs_when_available() -> None:
+    bundle = build_branch_turn_context_bundle(
+        workflow_id="workflow-1",
+        run_id="run-branch-turn-1",
+        logical_step_id="implement-story",
+        execution_ordinal=3,
+        branch_id="cbr_01",
+        branch_turn_id="cbt_01",
+        source_checkpoint={
+            "workflowId": "workflow-1",
+            "runId": "run-source",
+            "checkpointBoundary": "after_execution",
+            "checkpointRef": "art_checkpoint",
+        },
+        instruction_artifact_ref="art_instruction",
+        instruction_digest="sha256:turn",
+        runtime_context_policy="reuse_session_new_epoch",
+        workspace_policy="continue_from_previous_execution",
+    )
+
+    manifest = build_branch_turn_artifact_manifest(
+        branch_id="cbr_01",
+        branch_turn_id="cbt_01",
+        context_bundle=bundle,
+        artifact_refs={
+            "input.branch.root_checkpoint.json": "art_checkpoint",
+            "input.branch_turn.instructions.md": "art_instruction",
+        },
+    )
+
+    by_name = {artifact["name"]: artifact for artifact in manifest["artifacts"]}
+    assert by_name["input.branch.root_checkpoint.json"]["artifactRef"] == (
+        "art_checkpoint"
+    )
+    assert by_name["input.branch.root_checkpoint.json"]["artifactRefStatus"] == (
+        "persisted"
+    )
+    assert by_name["input.branch_turn.instructions.md"]["artifactRef"] == (
+        "art_instruction"
+    )
+    assert by_name["runtime.branch_turn.agent_result.json"][
+        "artifactRefStatus"
+    ] == "planned"
+
+
+def test_mm_1089_branch_turn_context_accepts_typed_source_state() -> None:
+    bundle = build_branch_turn_context_bundle(
+        workflow_id="workflow-1",
+        run_id="run-branch-turn-1",
+        logical_step_id="implement-story",
+        execution_ordinal=3,
+        branch_id="cbr_01",
+        branch_turn_id="cbt_01",
+        source_checkpoint={
+            "workflowId": "workflow-1",
+            "runId": "run-source",
+            "sourceStateKind": "provider_session",
+            "sourceStateRef": "provider://session/1",
+            "sourceStateDigest": "sha256:provider-state",
+        },
+        instruction_artifact_ref="art_instruction",
+        instruction_digest="sha256:turn",
+        runtime_context_policy="external_provider_continuation",
+        workspace_policy="continue_from_previous_execution",
+    )
+
+    branch = bundle.model_dump(by_alias=True, exclude_none=True)["branch"]
+    assert branch["sourceStateKind"] == "provider_session"
+    assert branch["sourceStateRef"] == "provider://session/1"
+    assert "rootCheckpointRef" not in branch
+    assert branch_turn_step_execution_manifest_projection(bundle) == {
+        "branch": {
+            "branchId": "cbr_01",
+            "branchTurnId": "cbt_01",
+            "sourceStateKind": "provider_session",
+            "sourceStateRef": "provider://session/1",
+            "sourceStateDigest": "sha256:provider-state",
+        }
+    }
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/workflows/executions/test_prepared_context.py
+++ b/tests/unit/workflows/executions/test_prepared_context.py
@@ -9,9 +9,14 @@ from moonmind.memory.procedural import (
     extract_error_signature,
 )
 from moonmind.workflows.executions.prepared_context import (
+    MINIMUM_BRANCH_ARTIFACT_NAMES,
+    MINIMUM_BRANCH_TURN_ARTIFACT_NAMES,
     PreparedContextFailure,
     PreparedInputEntry,
     PreparedInputManifest,
+    branch_turn_step_execution_manifest_projection,
+    build_branch_turn_artifact_manifest,
+    build_branch_turn_context_bundle,
     build_durable_retrieval_manifest_artifact,
     build_execution_context_bundle,
     build_memory_manifest,
@@ -496,6 +501,173 @@ def test_execution_context_records_required_attempt_contract_fields() -> None:
     assert projection["context"]["priorEvidenceRefs"] == [
         "artifact://attempt-1-manifest"
     ]
+
+
+def test_mm_1089_branch_turn_context_records_immutable_launch_evidence() -> None:
+    bundle = build_branch_turn_context_bundle(
+        workflow_id="workflow-1",
+        run_id="run-branch-turn-1",
+        logical_step_id="implement-story",
+        execution_ordinal=3,
+        branch_id="cbr_01",
+        branch_turn_id="cbt_01",
+        source_checkpoint={
+            "workflowId": "workflow-1",
+            "runId": "run-source",
+            "logicalStepId": "implement-story",
+            "sourceExecutionOrdinal": 2,
+            "checkpointBoundary": "after_execution",
+            "checkpointRef": "artifact://checkpoints/after-execution",
+            "checkpointDigest": "sha256:checkpoint",
+        },
+        initial_instruction_ref="artifact://branch/initial-instructions",
+        initial_instruction_digest="sha256:initial",
+        instruction_artifact_ref="artifact://branch-turn/instructions",
+        instruction_digest="sha256:turn",
+        runtime_context_policy="fresh_agent_run",
+        workspace_policy="apply_previous_execution_diff_to_clean_baseline",
+        workspace_baseline={"kind": "git_patch", "patchRef": "artifact://patch"},
+        prior_evidence_refs=["artifact://attempt-2-manifest"],
+        bounded_summaries=["Previous attempt failed the unit gate."],
+        runtime_selection={"runtimeId": "codex_cli", "model": "gpt-5"},
+        policy_refs={"workspacePolicyRef": "artifact://policies/workspace"},
+        git_work_branch="mm/workflow-1/implement-story/cbr-01",
+    )
+
+    dumped = bundle.model_dump(by_alias=True, exclude_none=True)
+
+    assert dumped["reason"] == "checkpoint_branch"
+    assert dumped["executionOrdinal"] == 3
+    assert dumped["branch"]["branchId"] == "cbr_01"
+    assert dumped["branch"]["branchTurnId"] == "cbt_01"
+    assert dumped["branch"]["sourceCheckpoint"]["checkpointRef"] == (
+        "artifact://checkpoints/after-execution"
+    )
+    assert dumped["branch"]["traceability"] == "MM-1089"
+    assert dumped["instructionRefs"] == [
+        "artifact://branch/initial-instructions",
+        "artifact://branch-turn/instructions",
+    ]
+    assert dumped["instructionDigests"] == {
+        "artifact://branch/initial-instructions": "sha256:initial",
+        "artifact://branch-turn/instructions": "sha256:turn",
+    }
+    assert dumped["workspacePolicy"] == (
+        "apply_previous_execution_diff_to_clean_baseline"
+    )
+    assert dumped["runtimeContextPolicy"] == "fresh_agent_run"
+    assert dumped["checkpointRefs"]["source"] == (
+        "artifact://checkpoints/after-execution"
+    )
+    assert bundle.context_bundle_ref == (
+        f"execution-context-bundle://{bundle.context_bundle_digest}"
+    )
+    projection = bundle.to_manifest_projection()["context"]
+    assert projection["branch"]["branchTurnId"] == "cbt_01"
+    assert projection["runtimeContextPolicy"] == "fresh_agent_run"
+    assert branch_turn_step_execution_manifest_projection(bundle) == {
+        "branch": {
+            "branchId": "cbr_01",
+            "branchTurnId": "cbt_01",
+            "rootCheckpointRef": "artifact://checkpoints/after-execution",
+            "parentBranchId": None,
+            "parentTurnId": None,
+            "gitWorkBranch": "mm/workflow-1/implement-story/cbr-01",
+        }
+    }
+
+
+def test_mm_1089_branch_turn_artifact_manifest_names_minimum_evidence() -> None:
+    bundle = build_branch_turn_context_bundle(
+        workflow_id="workflow-1",
+        run_id="run-branch-turn-1",
+        logical_step_id="implement-story",
+        execution_ordinal=3,
+        branch_id="cbr_01",
+        branch_turn_id="cbt_01",
+        source_checkpoint={
+            "workflowId": "workflow-1",
+            "runId": "run-source",
+            "checkpointBoundary": "after_execution",
+            "checkpointRef": "artifact://checkpoints/after-execution",
+        },
+        instruction_artifact_ref="artifact://branch-turn/instructions",
+        instruction_digest="sha256:turn",
+        runtime_context_policy="reuse_session_new_epoch",
+        workspace_policy="continue_from_previous_execution",
+    )
+
+    manifest = build_branch_turn_artifact_manifest(
+        branch_id="cbr_01",
+        branch_turn_id="cbt_01",
+        context_bundle=bundle,
+    )
+
+    names = [artifact["name"] for artifact in manifest["artifacts"]]
+    assert names == [
+        *MINIMUM_BRANCH_ARTIFACT_NAMES,
+        *MINIMUM_BRANCH_TURN_ARTIFACT_NAMES,
+    ]
+    assert manifest["traceability"] == "MM-1089"
+    assert manifest["contextBundleRef"] == bundle.context_bundle_ref
+    assert manifest["artifactManifestDigest"].startswith("sha256:")
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "match"),
+    [
+        (
+            {"instruction_artifact_ref": "inline instruction text"},
+            "instruction_artifact_ref must be an artifact ref",
+        ),
+        (
+            {"instruction_digest": "not-a-digest"},
+            "instruction_digest must be a sha256 digest",
+        ),
+        (
+            {"source_checkpoint": {"checkpointRef": "artifact://checkpoint"}},
+            "source_checkpoint.workflowId",
+        ),
+        (
+            {
+                "source_checkpoint": {
+                    "workflowId": "workflow-1",
+                    "runId": "run-source",
+                    "checkpointBoundary": "after_execution",
+                    "checkpointRef": "artifact://checkpoint",
+                    "providerPayload": {"messages": ["raw"]},
+                }
+            },
+            "provider payload",
+        ),
+    ],
+)
+def test_mm_1089_branch_turn_context_rejects_unsafe_or_incomplete_inputs(
+    kwargs: dict[str, object],
+    match: str,
+) -> None:
+    base = {
+        "workflow_id": "workflow-1",
+        "run_id": "run-branch-turn-1",
+        "logical_step_id": "implement-story",
+        "execution_ordinal": 3,
+        "branch_id": "cbr_01",
+        "branch_turn_id": "cbt_01",
+        "source_checkpoint": {
+            "workflowId": "workflow-1",
+            "runId": "run-source",
+            "checkpointBoundary": "after_execution",
+            "checkpointRef": "artifact://checkpoints/after-execution",
+        },
+        "instruction_artifact_ref": "artifact://branch-turn/instructions",
+        "instruction_digest": "sha256:turn",
+        "runtime_context_policy": "fresh_agent_run",
+        "workspace_policy": "continue_from_previous_execution",
+    }
+    base.update(kwargs)
+
+    with pytest.raises(ValueError, match=match):
+        build_branch_turn_context_bundle(**base)
 
 
 def test_with_retrieval_manifest_ref_recomputes_digest() -> None:

--- a/tests/unit/workflows/temporal/test_step_execution_manifest.py
+++ b/tests/unit/workflows/temporal/test_step_execution_manifest.py
@@ -110,6 +110,52 @@ def test_step_execution_manifest_accepts_canonical_payload_and_content_type() ->
     assert manifest.model_dump(by_alias=True)["terminalDisposition"] == "accepted"
 
 
+def test_mm_1089_step_execution_manifest_accepts_checkpoint_branch_metadata() -> None:
+    manifest = StepExecutionManifestModel.model_validate(
+        {
+            **_identity(),
+            "schemaVersion": "v1",
+            "stepExecutionId": "workflow-1:run-1:implement-story:execution:2",
+            "executionScope": "run",
+            "reason": "checkpoint_branch",
+            "status": "running",
+            "terminalDisposition": None,
+            "branch": {
+                "branchId": "cbr_01",
+                "branchTurnId": "cbt_01",
+                "rootCheckpointRef": "artifact://checkpoints/after-execution",
+                "parentBranchId": None,
+                "parentTurnId": None,
+                "gitWorkBranch": "mm/workflow-1/implement-story/cbr-01",
+            },
+            "input": {"taskInputSnapshotRef": "artifact://task-input"},
+            "context": {"contextBundleRef": "execution-context-bundle://sha256:ctx"},
+            "workspace": {
+                "policy": "continue_from_previous_execution",
+                "runtimeContextPolicy": "fresh_agent_run",
+            },
+            "execution": {"kind": "agent_run"},
+            "outputs": {},
+            "checks": [],
+            "sideEffects": {},
+            "dependencyEffects": {"invalidatedLogicalStepIds": []},
+            "budget": {},
+        }
+    )
+
+    dumped = manifest.model_dump(by_alias=True)
+
+    assert dumped["reason"] == "checkpoint_branch"
+    assert dumped["branch"] == {
+        "branchId": "cbr_01",
+        "branchTurnId": "cbt_01",
+        "rootCheckpointRef": "artifact://checkpoints/after-execution",
+        "parentBranchId": None,
+        "parentTurnId": None,
+        "gitWorkBranch": "mm/workflow-1/implement-story/cbr-01",
+    }
+
+
 def test_step_execution_manifest_boundary_accepts_previous_compact_payload_shape() -> (
     None
 ):
@@ -396,13 +442,19 @@ def test_step_execution_boundary_result_is_compact_and_typed() -> None:
     assert "payload" not in serialized
 
 
-def test_step_execution_semantic_operation_keeps_retry_reexecute_recovery_distinct() -> None:
+def test_mm_1089_step_execution_semantic_operation_keeps_branch_turn_distinct() -> None:
     retry = StepExecutionSemanticOperationModel.model_validate({"kind": "retry"})
-    reexecute = StepExecutionSemanticOperationModel.model_validate({"kind": "reexecute"})
+    reexecute = StepExecutionSemanticOperationModel.model_validate(
+        {"kind": "reexecute"}
+    )
     recover = StepExecutionSemanticOperationModel.model_validate({"kind": "recover"})
+    branch = StepExecutionSemanticOperationModel.model_validate(
+        {"kind": "checkpoint_branch"}
+    )
 
-    assert {retry.kind, reexecute.kind, recover.kind} == {
+    assert {retry.kind, reexecute.kind, recover.kind, branch.kind} == {
         "retry",
         "reexecute",
         "recover",
+        "checkpoint_branch",
     }

--- a/tests/unit/workflows/temporal/test_step_execution_manifest.py
+++ b/tests/unit/workflows/temporal/test_step_execution_manifest.py
@@ -150,10 +150,46 @@ def test_mm_1089_step_execution_manifest_accepts_checkpoint_branch_metadata() ->
         "branchId": "cbr_01",
         "branchTurnId": "cbt_01",
         "rootCheckpointRef": "artifact://checkpoints/after-execution",
+        "sourceStateKind": None,
+        "sourceStateRef": None,
+        "sourceStateDigest": None,
         "parentBranchId": None,
         "parentTurnId": None,
         "gitWorkBranch": "mm/workflow-1/implement-story/cbr-01",
     }
+
+
+def test_mm_1089_step_execution_manifest_accepts_typed_branch_source_state() -> None:
+    manifest = StepExecutionManifestModel.model_validate(
+        {
+            **_identity(),
+            "schemaVersion": "v1",
+            "stepExecutionId": "workflow-1:run-1:implement-story:execution:2",
+            "executionScope": "run",
+            "reason": "checkpoint_branch",
+            "status": "running",
+            "branch": {
+                "branchId": "cbr_01",
+                "branchTurnId": "cbt_01",
+                "sourceStateKind": "provider_session",
+                "sourceStateRef": "provider://session/1",
+            },
+            "input": {},
+            "context": {},
+            "workspace": {},
+            "execution": {},
+            "outputs": {},
+            "checks": [],
+            "sideEffects": {},
+            "dependencyEffects": {},
+            "budget": {},
+        }
+    )
+
+    assert manifest.branch is not None
+    assert manifest.branch.root_checkpoint_ref is None
+    assert manifest.branch.source_state_kind == "provider_session"
+    assert manifest.branch.source_state_ref == "provider://session/1"
 
 
 def test_step_execution_manifest_boundary_accepts_previous_compact_payload_shape() -> (

--- a/tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py
@@ -1001,7 +1001,6 @@ class TestBuildAgentExecutionRequest(unittest.TestCase):
                             "moonmind": {"checkpointBranchTurn": branch_turn}
                         },
                     },
-                    "instructionRef": "artifact://instructions/turn-1",
                 },
                 node_id="branch-implement",
                 tool_name="codex_cli",
@@ -1010,6 +1009,7 @@ class TestBuildAgentExecutionRequest(unittest.TestCase):
 
         assert request.step_execution is not None
         self.assertEqual(request.step_execution.reason, "checkpoint_branch")
+        self.assertEqual(request.instruction_ref, "artifact://instructions/turn-1")
         moonmind_metadata = request.parameters["metadata"]["moonmind"]
         execution_context = moonmind_metadata["executionContext"]
         self.assertEqual(execution_context["reason"], "checkpoint_branch")

--- a/tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py
@@ -23,6 +23,7 @@ from moonmind.schemas.agent_skill_models import (
     ResolvedSkillSet,
 )
 from moonmind.workflows.temporal.workflows.run import (
+    RUN_CHECKPOINT_BRANCH_TURN_CONTEXT_PATCH,
     RUN_JSON_ARTIFACT_WRITE_COMPLETE_PATCH,
     RUN_SLOT_CONTINUITY_PATCH,
     RUN_STEP_EXECUTION_NAMING_PATCH,
@@ -959,6 +960,96 @@ class TestBuildAgentExecutionRequest(unittest.TestCase):
         self.assertEqual(
             step_execution.skill_source_policy["checkedInSkillMutation"],
             "prohibited",
+        )
+
+    def test_build_agent_execution_request_launches_checkpoint_branch_turn_context(self) -> None:
+        from unittest.mock import patch
+
+        wf = MoonMindRunWorkflow()
+
+        class MockInfo:
+            namespace = "default"
+            workflow_id = "test-wf-id"
+            run_id = "test-run-id"
+
+        branch_turn = {
+            "branchId": "branch-1",
+            "branchTurnId": "turn-1",
+            "sourceCheckpointRef": "artifact://checkpoint/source",
+            "sourceCheckpointDigest": "sha256:" + "a" * 64,
+            "instructionArtifactRef": "artifact://instructions/turn-1",
+            "instructionDigest": "sha256:" + "b" * 64,
+            "workspacePolicy": "fresh_branch_from_source",
+            "runtimeContextPolicy": "fresh_agent_run",
+            "gitWorkBranch": "mm/branch-1",
+        }
+
+        with patch(
+            "moonmind.workflows.temporal.workflows.run.workflow.info",
+            return_value=MockInfo(),
+        ), patch(
+            "moonmind.workflows.temporal.workflows.run.workflow.patched",
+            side_effect=lambda patch_id: (
+                patch_id == RUN_CHECKPOINT_BRANCH_TURN_CONTEXT_PATCH
+            ),
+        ):
+            request = wf._build_agent_execution_request(
+                node_inputs={
+                    "runtime": {
+                        "mode": "codex_cli",
+                        "metadata": {
+                            "moonmind": {"checkpointBranchTurn": branch_turn}
+                        },
+                    },
+                    "instructionRef": "artifact://instructions/turn-1",
+                },
+                node_id="branch-implement",
+                tool_name="codex_cli",
+                attempt_reason="runtime_recovered",
+            )
+
+        assert request.step_execution is not None
+        self.assertEqual(request.step_execution.reason, "checkpoint_branch")
+        moonmind_metadata = request.parameters["metadata"]["moonmind"]
+        execution_context = moonmind_metadata["executionContext"]
+        self.assertEqual(execution_context["reason"], "checkpoint_branch")
+        self.assertEqual(
+            execution_context["builderVersion"],
+            "branch-turn-context-builder-v1",
+        )
+        self.assertEqual(execution_context["branch"]["branchId"], "branch-1")
+        self.assertEqual(execution_context["branch"]["branchTurnId"], "turn-1")
+        self.assertEqual(
+            execution_context["instructionRefs"],
+            ["artifact://instructions/turn-1"],
+        )
+        self.assertEqual(
+            moonmind_metadata["checkpointBranchTurn"]["artifactManifestDigest"],
+            moonmind_metadata["checkpointBranchTurnArtifactManifest"][
+                "artifactManifestDigest"
+            ],
+        )
+        artifact_names = {
+            artifact["name"]
+            for artifact in moonmind_metadata["checkpointBranchTurnArtifactManifest"][
+                "artifacts"
+            ]
+        }
+        self.assertIn(
+            "output.branch_turn.step_execution_manifest.json",
+            artifact_names,
+        )
+        self.assertEqual(
+            moonmind_metadata["stepExecutionManifestProjection"]["context"][
+                "branch"
+            ]["branchId"],
+            "branch-1",
+        )
+        self.assertEqual(
+            wf._step_execution_branch_projections[("branch-implement", 1)][
+                "branchTurnId"
+            ],
+            "turn-1",
         )
 
     def test_managed_reattempt_records_session_reset_launch_evidence(self) -> None:

--- a/tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py
@@ -975,6 +975,9 @@ class TestBuildAgentExecutionRequest(unittest.TestCase):
         branch_turn = {
             "branchId": "branch-1",
             "branchTurnId": "turn-1",
+            "sourceWorkflowId": "source-wf",
+            "sourceRunId": "source-run",
+            "sourceLogicalStepId": "source-step",
             "sourceCheckpointRef": "artifact://checkpoint/source",
             "sourceCheckpointDigest": "sha256:" + "a" * 64,
             "instructionArtifactRef": "artifact://instructions/turn-1",
@@ -1051,6 +1054,50 @@ class TestBuildAgentExecutionRequest(unittest.TestCase):
             ],
             "turn-1",
         )
+
+    def test_checkpoint_branch_turn_requires_source_identity_for_explicit_checkpoint_ref(
+        self,
+    ) -> None:
+        wf = MoonMindRunWorkflow()
+
+        class MockInfo:
+            namespace = "default"
+            workflow_id = "test-wf-id"
+            run_id = "test-run-id"
+
+        branch_turn = {
+            "branchId": "branch-1",
+            "branchTurnId": "turn-1",
+            "sourceCheckpointRef": "artifact://checkpoint/source",
+            "sourceCheckpointDigest": "sha256:" + "a" * 64,
+            "instructionArtifactRef": "artifact://instructions/turn-1",
+            "instructionDigest": "sha256:" + "b" * 64,
+            "workspacePolicy": "fresh_branch_from_source",
+            "runtimeContextPolicy": "fresh_agent_run",
+        }
+
+        with patch(
+            "moonmind.workflows.temporal.workflows.run.workflow.info",
+            return_value=MockInfo(),
+        ), patch(
+            "moonmind.workflows.temporal.workflows.run.workflow.patched",
+            side_effect=lambda patch_id: (
+                patch_id == RUN_CHECKPOINT_BRANCH_TURN_CONTEXT_PATCH
+            ),
+        ), pytest.raises(ValueError, match="source_checkpoint.workflowId"):
+            wf._build_agent_execution_request(
+                node_inputs={
+                    "runtime": {
+                        "mode": "codex_cli",
+                        "metadata": {
+                            "moonmind": {"checkpointBranchTurn": branch_turn}
+                        },
+                    },
+                },
+                node_id="branch-implement",
+                tool_name="codex_cli",
+                attempt_reason="runtime_recovered",
+            )
 
     def test_managed_reattempt_records_session_reset_launch_evidence(self) -> None:
         from unittest.mock import patch

--- a/tests/unit/workflows/temporal/workflows/test_run_codex_sessions.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_codex_sessions.py
@@ -50,12 +50,82 @@ def _managed_request(agent_id: str = "codex") -> AgentExecutionRequest:
         executionProfileRef="codex-default",
     )
 
+
+def _managed_step_request(
+    agent_id: str = "codex",
+    *,
+    runtime_context_policy: str = "fresh_agent_run",
+) -> AgentExecutionRequest:
+    return AgentExecutionRequest(
+        agentKind="managed",
+        agentId=agent_id,
+        correlationId="corr-1",
+        idempotencyKey="idem-1",
+        executionProfileRef="codex-default",
+        stepExecution={
+            "schemaVersion": "v1",
+            "workflowId": "wf-run-1",
+            "runId": "run-1",
+            "logicalStepId": "step-2",
+            "executionOrdinal": 1,
+            "stepExecutionId": "wf-run-1:run-1:step-2:execution:1",
+            "reason": "checkpoint_branch",
+            "runtimeContextPolicy": runtime_context_policy,
+        },
+    )
+
+
 def _use_external_handle(monkeypatch: pytest.MonkeyPatch, handle: Any) -> None:
     monkeypatch.setattr(
         run_module.workflow,
         "get_external_workflow_handle",
         lambda _workflow_id, run_id=None: handle,
     )
+
+
+@pytest.mark.asyncio
+async def test_run_preserves_workflow_scoped_session_for_same_epoch_branch_turn(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workflow = MoonMindRunWorkflow()
+    _configure_workflow_runtime(monkeypatch)
+    monkeypatch.setattr(
+        run_module.workflow,
+        "patched",
+        lambda patch_id: patch_id
+        in {
+            RUN_WORKFLOW_SCOPED_SESSION_CLEAR_BETWEEN_STEPS_PATCH,
+            RUN_WORKFLOW_SCOPED_SESSION_CLEAR_PER_EXECUTION_PATCH,
+            RUN_WORKFLOW_SCOPED_SESSION_CLEAR_ACTIVITY_SIGNAL_PATCH,
+        },
+    )
+
+    async def fake_execute_activity(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+        raise AssertionError("same-epoch branch turns must not clear the session")
+
+    monkeypatch.setattr(run_module.workflow, "execute_activity", fake_execute_activity)
+    workflow._codex_session_binding = CodexManagedSessionBinding(
+        workflowId="wf-run-1:session:codex_cli",
+        agentRunId="wf-run-1",
+        sessionId="sess:wf-run-1:codex_cli",
+        sessionEpoch=1,
+        runtimeId="codex_cli",
+        executionProfileRef="codex-default",
+    )
+    workflow._step_ledger_rows = [{"logicalStepId": "step-2", "attempt": 1}]
+
+    await workflow._maybe_clear_workflow_scoped_session_before_step(
+        request=_managed_step_request(
+            "codex",
+            runtime_context_policy="reuse_session_same_epoch",
+        ),
+        logical_step_id="step-2",
+    )
+
+    assert workflow._codex_session_cleared_before_step_attempts == set()
+    assert workflow._codex_session_binding is not None
+    assert workflow._codex_session_binding.session_epoch == 1
+
 
 @pytest.mark.asyncio
 async def test_run_defers_workflow_scoped_codex_session_until_slot_when_unbound(

--- a/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
@@ -703,6 +703,9 @@ async def test_checkpoint_branch_turn_manifest_persists_branch_artifact_manifest
     branch_turn = {
         "branchId": "branch-1",
         "branchTurnId": "turn-1",
+        "sourceWorkflowId": "source-wf",
+        "sourceRunId": "source-run",
+        "sourceLogicalStepId": "source-step",
         "sourceCheckpointRef": "artifact://checkpoint/source",
         "sourceCheckpointDigest": "sha256:" + "a" * 64,
         "instructionArtifactRef": "artifact://instructions/turn-1",
@@ -766,7 +769,7 @@ async def test_checkpoint_branch_turn_manifest_persists_branch_artifact_manifest
         "artifactManifestRef"
     ] == "artifact-write-1"
 
-    refreshed_request = workflow._request_with_persisted_retrieval_ref(
+    refreshed_request = await workflow._request_with_persisted_retrieval_ref(
         request,
         logical_step_id="branch-implement",
         attempt=1,
@@ -780,7 +783,8 @@ async def test_checkpoint_branch_turn_manifest_persists_branch_artifact_manifest
     ] == "artifact-write-1"
 
 
-def test_checkpoint_branch_turn_refresh_keeps_retrieval_context_refs_in_sync(
+@pytest.mark.asyncio
+async def test_checkpoint_branch_turn_refresh_repersists_rebuilt_branch_manifest(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     _configure_workflow_runtime(monkeypatch)
@@ -790,9 +794,31 @@ def test_checkpoint_branch_turn_refresh_keeps_retrieval_context_refs_in_sync(
         lambda patch_id: patch_id == run_module.RUN_CHECKPOINT_BRANCH_TURN_CONTEXT_PATCH,
     )
     workflow = MoonMindRunWorkflow()
+    writes: list[dict[str, Any]] = []
+
+    async def fake_write_json_artifact(
+        name: str,
+        payload: dict[str, Any],
+        content_type: str = "application/json",
+        metadata_json: dict[str, Any] | None = None,
+    ) -> str:
+        writes.append(
+            {
+                "name": name,
+                "payload": payload,
+                "content_type": content_type,
+                "metadata_json": metadata_json,
+            }
+        )
+        return f"art_branch_manifest_rebuilt_{len(writes)}"
+
+    monkeypatch.setattr(workflow, "_write_json_artifact", fake_write_json_artifact)
     branch_turn = {
         "branchId": "branch-1",
         "branchTurnId": "turn-1",
+        "sourceWorkflowId": "source-wf",
+        "sourceRunId": "source-run",
+        "sourceLogicalStepId": "source-step",
         "sourceCheckpointRef": "artifact://checkpoint/source",
         "sourceCheckpointDigest": "sha256:" + "a" * 64,
         "instructionArtifactRef": "artifact://instructions/turn-1",
@@ -826,7 +852,7 @@ def test_checkpoint_branch_turn_refresh_keeps_retrieval_context_refs_in_sync(
         ("branch-implement", 1)
     ]["persistedArtifactRef"] = "art_branch_manifest"
 
-    refreshed = workflow._request_with_persisted_retrieval_ref(
+    refreshed = await workflow._request_with_persisted_retrieval_ref(
         request,
         logical_step_id="branch-implement",
         attempt=1,
@@ -851,6 +877,16 @@ def test_checkpoint_branch_turn_refresh_keeps_retrieval_context_refs_in_sync(
     ]
     assert branch_turn_metadata["artifactManifestDigest"] == artifact_manifest[
         "artifactManifestDigest"
+    ]
+    assert branch_turn_metadata["artifactManifestRef"] == (
+        "art_branch_manifest_rebuilt_1"
+    )
+    assert artifact_manifest["persistedArtifactRef"] == "art_branch_manifest_rebuilt_1"
+    assert writes[0]["name"] == (
+        "reports/checkpoint_branches/branch-1/turns/turn-1/artifact_manifest.json"
+    )
+    assert writes[0]["payload"]["contextBundleRef"] == execution_context[
+        "contextBundleRef"
     ]
 
 

--- a/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
@@ -780,6 +780,80 @@ async def test_checkpoint_branch_turn_manifest_persists_branch_artifact_manifest
     ] == "artifact-write-1"
 
 
+def test_checkpoint_branch_turn_refresh_keeps_retrieval_context_refs_in_sync(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _configure_workflow_runtime(monkeypatch)
+    monkeypatch.setattr(
+        run_module.workflow,
+        "patched",
+        lambda patch_id: patch_id == run_module.RUN_CHECKPOINT_BRANCH_TURN_CONTEXT_PATCH,
+    )
+    workflow = MoonMindRunWorkflow()
+    branch_turn = {
+        "branchId": "branch-1",
+        "branchTurnId": "turn-1",
+        "sourceCheckpointRef": "artifact://checkpoint/source",
+        "sourceCheckpointDigest": "sha256:" + "a" * 64,
+        "instructionArtifactRef": "artifact://instructions/turn-1",
+        "instructionDigest": "sha256:" + "b" * 64,
+        "workspacePolicy": "fresh_branch_from_source",
+        "runtimeContextPolicy": "fresh_agent_run",
+    }
+    request = workflow._build_agent_execution_request(
+        node_inputs={
+            "runtime": {
+                "mode": "codex_cli",
+                "metadata": {"moonmind": {"checkpointBranchTurn": branch_turn}},
+            }
+        },
+        node_id="branch-implement",
+        tool_name="codex_cli",
+        workflow_parameters={
+            "task": {
+                "retrieval": {
+                    "query": "branch context",
+                    "returnedRefs": ["artifact://doc"],
+                },
+                "steps": [{"id": "branch-implement"}],
+            }
+        },
+    )
+    workflow._step_execution_retrieval_manifest_artifacts[
+        ("branch-implement", 1)
+    ]["persistedArtifactRef"] = "art_retrieval"
+    workflow._step_execution_branch_artifact_manifests[
+        ("branch-implement", 1)
+    ]["persistedArtifactRef"] = "art_branch_manifest"
+
+    refreshed = workflow._request_with_persisted_retrieval_ref(
+        request,
+        logical_step_id="branch-implement",
+        attempt=1,
+    )
+
+    moonmind_metadata = refreshed.parameters["metadata"]["moonmind"]
+    execution_context = moonmind_metadata["executionContext"]
+    branch_turn_metadata = moonmind_metadata["checkpointBranchTurn"]
+    artifact_manifest = moonmind_metadata["checkpointBranchTurnArtifactManifest"]
+    assert execution_context["retrievalManifestRef"] == "art_retrieval"
+    assert branch_turn_metadata["contextBundleRef"] == execution_context[
+        "contextBundleRef"
+    ]
+    assert branch_turn_metadata["contextBundleDigest"] == execution_context[
+        "contextBundleDigest"
+    ]
+    assert artifact_manifest["contextBundleRef"] == execution_context[
+        "contextBundleRef"
+    ]
+    assert artifact_manifest["contextBundleDigest"] == execution_context[
+        "contextBundleDigest"
+    ]
+    assert branch_turn_metadata["artifactManifestDigest"] == artifact_manifest[
+        "artifactManifestDigest"
+    ]
+
+
 @pytest.mark.asyncio
 async def test_retrieval_manifest_persistence_writes_status_artifacts(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
@@ -650,6 +650,137 @@ async def test_start_manifest_uses_launch_context_projection_refs(
 
 
 @pytest.mark.asyncio
+async def test_checkpoint_branch_turn_manifest_persists_branch_artifact_manifest(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _configure_workflow_runtime(monkeypatch)
+    monkeypatch.setattr(
+        run_module.workflow,
+        "patched",
+        lambda patch_id: patch_id
+        in {
+            run_module.RUN_CANONICAL_STEP_STATUS_VOCAB_PATCH,
+            run_module.RUN_CHECKPOINT_BRANCH_TURN_CONTEXT_PATCH,
+        },
+    )
+    workflow = MoonMindRunWorkflow()
+    writes: list[dict[str, Any]] = []
+
+    async def fake_write_json_artifact(
+        name: str,
+        payload: dict[str, Any],
+        content_type: str = "application/json",
+        metadata_json: dict[str, Any] | None = None,
+    ) -> str:
+        writes.append(
+            {
+                "name": name,
+                "payload": payload,
+                "content_type": content_type,
+                "metadata_json": metadata_json,
+            }
+        )
+        return f"artifact-write-{len(writes)}"
+
+    monkeypatch.setattr(workflow, "_write_json_artifact", fake_write_json_artifact)
+    now = datetime(2026, 4, 7, 12, 0, tzinfo=UTC)
+    workflow._initialize_step_ledger(
+        ordered_nodes=[
+            {
+                "id": "branch-implement",
+                "tool": {"type": "agent_runtime", "name": "codex_cli"},
+                "inputs": {"title": "Implement on checkpoint branch"},
+            }
+        ],
+        dependency_map={"branch-implement": []},
+        updated_at=now,
+    )
+    workflow._mark_step_running(
+        "branch-implement",
+        updated_at=now,
+        summary="Launching branch turn",
+    )
+    branch_turn = {
+        "branchId": "branch-1",
+        "branchTurnId": "turn-1",
+        "sourceCheckpointRef": "artifact://checkpoint/source",
+        "sourceCheckpointDigest": "sha256:" + "a" * 64,
+        "instructionArtifactRef": "artifact://instructions/turn-1",
+        "instructionDigest": "sha256:" + "b" * 64,
+        "workspacePolicy": "fresh_branch_from_source",
+        "runtimeContextPolicy": "fresh_agent_run",
+        "gitWorkBranch": "mm/branch-1",
+    }
+    request = workflow._build_agent_execution_request(
+        node_inputs={
+            "runtime": {
+                "mode": "codex_cli",
+                "metadata": {"moonmind": {"checkpointBranchTurn": branch_turn}},
+            },
+            "instructionRef": "artifact://instructions/turn-1",
+        },
+        node_id="branch-implement",
+        tool_name="codex_cli",
+        workflow_parameters={"task": {"steps": [{"id": "branch-implement"}]}},
+    )
+
+    await workflow._record_step_execution_manifest(
+        "branch-implement",
+        phase="start",
+        updated_at=now,
+        reason="initial_execution",
+    )
+
+    assert writes[0]["name"] == (
+        "reports/checkpoint_branches/branch-1/turns/turn-1/artifact_manifest.json"
+    )
+    assert writes[0]["metadata_json"]["artifact_kind"] == (
+        "checkpoint_branch_turn_artifact_manifest"
+    )
+    assert {
+        artifact["name"] for artifact in writes[0]["payload"]["artifacts"]
+    } >= {
+        "input.branch_turn.instructions.md",
+        "runtime.branch_turn.agent_request.json",
+        "output.branch_turn.step_execution_manifest.json",
+        "output.branch_turn.diagnostics.json",
+    }
+    assert writes[1]["name"] == (
+        "reports/step_executions/branch-implement_attempt_1.json"
+    )
+    manifest_payload = writes[1]["payload"]
+    assert manifest_payload["reason"] == "checkpoint_branch"
+    assert manifest_payload["branch"] == {
+        "branchId": "branch-1",
+        "branchTurnId": "turn-1",
+        "rootCheckpointRef": "artifact://checkpoint/source",
+        "gitWorkBranch": "mm/branch-1",
+    }
+    assert manifest_payload["context"]["builderVersion"] == (
+        "branch-turn-context-builder-v1"
+    )
+    assert manifest_payload["context"]["branchArtifactManifestRef"] == (
+        "artifact-write-1"
+    )
+    assert manifest_payload["execution"]["checkpointBranchTurn"][
+        "artifactManifestRef"
+    ] == "artifact-write-1"
+
+    refreshed_request = workflow._request_with_persisted_retrieval_ref(
+        request,
+        logical_step_id="branch-implement",
+        attempt=1,
+    )
+    refreshed_metadata = refreshed_request.parameters["metadata"]["moonmind"]
+    assert refreshed_metadata["checkpointBranchTurn"]["artifactManifestRef"] == (
+        "artifact-write-1"
+    )
+    assert refreshed_metadata["stepExecutionManifestProjection"]["context"][
+        "branchArtifactManifestRef"
+    ] == "artifact-write-1"
+
+
+@pytest.mark.asyncio
 async def test_retrieval_manifest_persistence_writes_status_artifacts(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/workflows/temporal/workflows/test_run_target_aware_inputs.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_target_aware_inputs.py
@@ -232,7 +232,8 @@ def test_run_request_records_durable_retrieval_manifest_artifact_metadata() -> N
     )
 
 
-def test_run_request_refreshes_runtime_metadata_after_retrieval_persistence() -> None:
+@pytest.mark.asyncio
+async def test_run_request_refreshes_runtime_metadata_after_retrieval_persistence() -> None:
     wf = MoonMindRunWorkflow()
     task_payload = {
         **_task_payload(),
@@ -259,7 +260,7 @@ def test_run_request_refreshes_runtime_metadata_after_retrieval_persistence() ->
         ("collect-evidence", 1)
     ]
     cached_artifact["persistedArtifactRef"] = "art_retrieval_1"
-    refreshed = wf._request_with_persisted_retrieval_ref(
+    refreshed = await wf._request_with_persisted_retrieval_ref(
         request,
         logical_step_id="collect-evidence",
         attempt=1,


### PR DESCRIPTION
## Summary
- Diagnosed workflow `mm:e1c818cb-ffe5-4a5d-9f77-0968eaf06c06` as a MoonSpec verification failure: the MM-1089 schema/helper scaffold existed, but the actual agent launch path still emitted generic Step Execution evidence.
- Wire explicit `checkpointBranchTurn` metadata into runtime launch context, `checkpoint_branch` Step Execution reason, top-level manifest branch metadata, and a persisted branch-turn artifact manifest.
- Preserve prepared input, retrieval, and memory refs when building branch-turn context bundles, and add workflow-boundary unit coverage for launch metadata and manifest persistence.

## Testing
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py tests/unit/workflows/temporal/workflows/test_run_step_ledger.py tests/unit/workflows/executions/test_prepared_context.py tests/unit/workflows/temporal/test_step_execution_manifest.py`
  - Python: 194 passed, 2 subtests passed
  - Frontend wrapper: 51 files passed; 762 passed, 237 skipped
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/services/test_checkpoint_branch_service.py`
  - Python: 9 passed
  - Frontend wrapper: 51 files passed; 762 passed, 237 skipped
