### PR TITLE
The status icons next to the steps in Workflow Details got sized incorrectly and are now way too small. Fix them so they mostly fill the circle.

### DIFF
--- a/frontend/src/entrypoints/dashboard.test.tsx
+++ b/frontend/src/entrypoints/dashboard.test.tsx
@@ -575,6 +575,18 @@ describe('Dashboard shared entry', () => {
     expect(svgBlock).toContain('height: 0.8125rem');
   });
 
+  it('keeps workflow detail step timeline icons large inside their status circles', async () => {
+    const iconBlock = cssRuleBlock(dashboardCss, '.step-tl-icon');
+    expect(iconBlock).toContain('width: 1.35rem');
+    expect(iconBlock).toContain('height: 1.35rem');
+    expect(iconBlock).toContain('border-radius: 50%');
+
+    const svgBlock = cssRuleBlock(dashboardCss, '.step-tl-icon svg');
+    expect(svgBlock).toContain('width: 1.05rem');
+    expect(svgBlock).toContain('height: 1.05rem');
+    expect(svgBlock).toContain('stroke-width: 2.4');
+  });
+
   it('keeps checkbox label hit areas bounded to visible control text', async () => {
     const checkboxLabelBlock = cssRuleBlock(dashboardCss, 'label.checkbox');
 

--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -3921,8 +3921,8 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
 }
 
 .step-tl-icon svg {
-  width: 0.78rem;
-  height: 0.78rem;
+  width: 1.05rem;
+  height: 1.05rem;
   stroke-width: 2.4;
 }
 


### PR DESCRIPTION
The status icons next to the steps in Workflow Details got sized incorrectly and are now way too small. Fix them so they mostly fill the circle.