### PR TITLE
Fix MoonSpec verify gate determination

### DIFF
--- a/api_service/data/presets/github-issue-orchestrate.yaml
+++ b/api_service/data/presets/github-issue-orchestrate.yaml
@@ -290,7 +290,8 @@ steps:
     the post-remediation verification step reports FULLY_IMPLEMENTED.'
   skill:
     id: moonspec-verify
-    args: {}
+    args:
+      verify_artifact_path: var/artifacts/moonspec-verify/github-issue-orchestrate.json
 - title: Remediate verification gaps 1 of 6
   annotations:
     jiraOrchestrateRole: moonspec-remediation
@@ -357,7 +358,8 @@ steps:
     FULLY_IMPLEMENTED.'
   skill:
     id: moonspec-verify
-    args: {}
+    args:
+      verify_artifact_path: var/artifacts/moonspec-verify/github-issue-orchestrate.json
 - title: Remediate verification gaps 2 of 6
   annotations:
     jiraOrchestrateRole: moonspec-remediation
@@ -424,7 +426,8 @@ steps:
     FULLY_IMPLEMENTED.'
   skill:
     id: moonspec-verify
-    args: {}
+    args:
+      verify_artifact_path: var/artifacts/moonspec-verify/github-issue-orchestrate.json
 - title: Remediate verification gaps 3 of 6
   annotations:
     jiraOrchestrateRole: moonspec-remediation
@@ -491,7 +494,8 @@ steps:
     FULLY_IMPLEMENTED.'
   skill:
     id: moonspec-verify
-    args: {}
+    args:
+      verify_artifact_path: var/artifacts/moonspec-verify/github-issue-orchestrate.json
 - title: Remediate verification gaps 4 of 6
   annotations:
     jiraOrchestrateRole: moonspec-remediation
@@ -558,7 +562,8 @@ steps:
     FULLY_IMPLEMENTED.'
   skill:
     id: moonspec-verify
-    args: {}
+    args:
+      verify_artifact_path: var/artifacts/moonspec-verify/github-issue-orchestrate.json
 - title: Remediate verification gaps 5 of 6
   annotations:
     jiraOrchestrateRole: moonspec-remediation
@@ -625,7 +630,8 @@ steps:
     FULLY_IMPLEMENTED.'
   skill:
     id: moonspec-verify
-    args: {}
+    args:
+      verify_artifact_path: var/artifacts/moonspec-verify/github-issue-orchestrate.json
 - title: Remediate verification gaps 6 of 6
   annotations:
     jiraOrchestrateRole: moonspec-remediation
@@ -689,7 +695,8 @@ steps:
     Continue to pull request creation only when this post-remediation verdict is FULLY_IMPLEMENTED.'
   skill:
     id: moonspec-verify
-    args: {}
+    args:
+      verify_artifact_path: var/artifacts/moonspec-verify/github-issue-orchestrate.json
 - title: Reconcile declarative docs
   annotations:
     jiraOrchestrateRole: doc-reconciliation

--- a/api_service/data/presets/jira-orchestrate.yaml
+++ b/api_service/data/presets/jira-orchestrate.yaml
@@ -203,7 +203,8 @@ steps:
       Do not create a pull request from this step. Pull request creation is allowed only after the post-remediation verification step reports FULLY_IMPLEMENTED.
     skill:
       id: moonspec-verify
-      args: {}
+      args:
+        verify_artifact_path: var/artifacts/moonspec-verify/jira-orchestrate.json
   - title: Remediate verification gaps 1 of 6
     annotations:
       jiraOrchestrateRole: moonspec-remediation
@@ -243,7 +244,8 @@ steps:
       Continue toward pull request creation only when the latest post-remediation verdict is FULLY_IMPLEMENTED.
     skill:
       id: moonspec-verify
-      args: {}
+      args:
+        verify_artifact_path: var/artifacts/moonspec-verify/jira-orchestrate.json
   - title: Remediate verification gaps 2 of 6
     annotations:
       jiraOrchestrateRole: moonspec-remediation
@@ -283,7 +285,8 @@ steps:
       Continue toward pull request creation only when the latest post-remediation verdict is FULLY_IMPLEMENTED.
     skill:
       id: moonspec-verify
-      args: {}
+      args:
+        verify_artifact_path: var/artifacts/moonspec-verify/jira-orchestrate.json
   - title: Remediate verification gaps 3 of 6
     annotations:
       jiraOrchestrateRole: moonspec-remediation
@@ -323,7 +326,8 @@ steps:
       Continue toward pull request creation only when the latest post-remediation verdict is FULLY_IMPLEMENTED.
     skill:
       id: moonspec-verify
-      args: {}
+      args:
+        verify_artifact_path: var/artifacts/moonspec-verify/jira-orchestrate.json
   - title: Remediate verification gaps 4 of 6
     annotations:
       jiraOrchestrateRole: moonspec-remediation
@@ -363,7 +367,8 @@ steps:
       Continue toward pull request creation only when the latest post-remediation verdict is FULLY_IMPLEMENTED.
     skill:
       id: moonspec-verify
-      args: {}
+      args:
+        verify_artifact_path: var/artifacts/moonspec-verify/jira-orchestrate.json
   - title: Remediate verification gaps 5 of 6
     annotations:
       jiraOrchestrateRole: moonspec-remediation
@@ -403,7 +408,8 @@ steps:
       Continue toward pull request creation only when the latest post-remediation verdict is FULLY_IMPLEMENTED.
     skill:
       id: moonspec-verify
-      args: {}
+      args:
+        verify_artifact_path: var/artifacts/moonspec-verify/jira-orchestrate.json
   - title: Remediate verification gaps 6 of 6
     annotations:
       jiraOrchestrateRole: moonspec-remediation
@@ -442,7 +448,8 @@ steps:
       Continue to pull request creation only when this post-remediation verdict is FULLY_IMPLEMENTED.
     skill:
       id: moonspec-verify
-      args: {}
+      args:
+        verify_artifact_path: var/artifacts/moonspec-verify/jira-orchestrate.json
   - title: Reconcile declarative docs
     annotations:
       jiraOrchestrateRole: doc-reconciliation

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -7960,6 +7960,10 @@ class TemporalAgentRuntimeActivities:
             parameters=parameters,
             skill_materialization_metadata=skill_materialization_metadata,
         )
+        prepared = cls._append_moonspec_verify_artifact_hint(
+            prepared,
+            parameters=parameters,
+        )
         prepared = cls._append_skills_on_demand_notice(
             prepared,
             parameters=parameters,
@@ -8168,6 +8172,37 @@ class TemporalAgentRuntimeActivities:
         if not on_demand_instruction or on_demand_instruction in instructions:
             return instructions
         return instructions.rstrip() + "\n\n" + on_demand_instruction
+
+    @staticmethod
+    def _append_moonspec_verify_artifact_hint(
+        instructions: str,
+        *,
+        parameters: Mapping[str, Any] | None,
+    ) -> str:
+        params = parameters if isinstance(parameters, Mapping) else {}
+        if selected_agent_skill(params) != "moonspec-verify":
+            return instructions
+        verify_artifact_path = ""
+        for key in (
+            "verify_artifact_path",
+            "verifyArtifactPath",
+            "verification_artifact_path",
+            "verificationArtifactPath",
+        ):
+            value = params.get(key)
+            if isinstance(value, str) and value.strip():
+                verify_artifact_path = value.strip()
+                break
+        if not verify_artifact_path or verify_artifact_path in instructions:
+            return instructions
+        block = (
+            "MoonSpec verification output contract:\n"
+            f"- Write the complete structured verifier JSON to `{verify_artifact_path}`.\n"
+            "- The JSON must include the canonical `verdict`, `recommendedNextAction`, "
+            "`recoverableInCurrentRuntime`, and `remainingWork` fields.\n"
+            "- Still return the Markdown MoonSpec Verification Report in the assistant response."
+        )
+        return instructions.rstrip() + "\n\n" + block
 
     @staticmethod
     def _append_managed_step_boundary(instructions: str) -> str:

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -7061,6 +7061,124 @@ class TemporalAgentRuntimeActivities:
             published["storyOutput"] = story_output
             return published
 
+        def _workspace_moonspec_verify_path_candidates(
+            workspace: Path,
+            raw_path: str,
+        ) -> list[Path]:
+            if not raw_path:
+                return []
+            candidate = Path(raw_path)
+            candidates: list[Path] = []
+            if not candidate.is_absolute():
+                candidates.append(workspace / candidate)
+                if candidate.parts and candidate.parts[0] == "artifacts":
+                    candidates.append(workspace.parent / candidate)
+            else:
+                candidates.append(candidate)
+
+            resolved_candidates: list[Path] = []
+            job_artifact_root = (workspace.parent / "artifacts").resolve()
+            for path in candidates:
+                resolved = path.expanduser().resolve()
+                allowed = resolved.is_relative_to(workspace) or resolved.is_relative_to(
+                    job_artifact_root
+                )
+                if not allowed:
+                    logger.warning(
+                        "Skipping MoonSpec verify artifact publication outside "
+                        "workspace or job artifact root: %s",
+                        raw_path,
+                    )
+                    continue
+                if resolved not in resolved_candidates:
+                    resolved_candidates.append(resolved)
+            return resolved_candidates
+
+        def _workspace_moonspec_verify_path(
+            workspace: Path,
+            raw_path: str,
+        ) -> Path | None:
+            candidates = _workspace_moonspec_verify_path_candidates(
+                workspace,
+                raw_path,
+            )
+            for candidate in candidates:
+                if candidate.is_file():
+                    return candidate
+            if candidates:
+                logger.warning(
+                    "MoonSpec verify artifact file was not found for publication: %s",
+                    raw_path,
+                )
+            return None
+
+        async def _publish_moonspec_verify_artifact() -> dict[str, Any]:
+            verify_path = _metadata_text(
+                "verify_artifact_path",
+                "verifyArtifactPath",
+                "verification_artifact_path",
+                "verificationArtifactPath",
+            )
+            if not verify_path:
+                return {}
+            agent_run_id = _metadata_text("agentRunId", "agent_run_id")
+            if not agent_run_id or self._run_store is None:
+                return {}
+            record = self._run_store.load(agent_run_id)
+            if record is None:
+                logger.warning(
+                    "Skipping MoonSpec verify artifact publication: run record not "
+                    "found for %s",
+                    agent_run_id,
+                )
+                return {}
+            workspace_path = str(getattr(record, "workspace_path", "") or "").strip()
+            if not workspace_path:
+                return {}
+            workspace = Path(workspace_path).expanduser().resolve()
+            path = _workspace_moonspec_verify_path(workspace, verify_path)
+            if path is None:
+                return {}
+            try:
+                payload = json.loads(path.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                logger.warning(
+                    "MoonSpec verify artifact could not be read as JSON: %s",
+                    verify_path,
+                    exc_info=True,
+                )
+                return {}
+            if not isinstance(payload, Mapping):
+                logger.warning(
+                    "MoonSpec verify artifact payload must be a JSON object: %s",
+                    verify_path,
+                )
+                return {}
+            gate_payload = dict(payload)
+            verify_ref = await _write_json_artifact(
+                self._artifact_service,
+                principal="system:agent_runtime",
+                payload=gate_payload,
+                execution_ref=_execution_ref("output.moonspec_verify"),
+                metadata_json={
+                    "name": "moonspec-verify-result.json",
+                    "path": verify_path,
+                    "producer": "activity:agent_runtime.publish_artifacts",
+                    "labels": [
+                        "agent_runtime",
+                        "output.moonspec_verify",
+                        "moonspec_verify",
+                    ],
+                    **step_artifact_metadata,
+                },
+            )
+            gate_payload["gateResultRef"] = verify_ref.artifact_id
+            return {
+                "moonSpecVerify": gate_payload,
+                "gateResultRef": verify_ref.artifact_id,
+                "moonSpecVerifyArtifactRef": verify_ref.artifact_id,
+            }
+
         result_summary = result_dict.get("summary") or result_dict.get("raw", "")
         operator_summary = self._sanitize_operator_summary(
             _metadata_text("operator_summary", "operatorSummary")
@@ -7176,6 +7294,16 @@ class TemporalAgentRuntimeActivities:
                     enriched_metadata_for_result["storyOutput"] = dict(
                         story_output_ref_payload
                     )
+                result_dict["metadata"] = enriched_metadata_for_result
+            moonspec_verify_refs = await _publish_moonspec_verify_artifact()
+            if moonspec_verify_refs:
+                published_refs.update(moonspec_verify_refs)
+                enriched_metadata_for_result = (
+                    dict(result_dict.get("metadata") or {})
+                    if isinstance(result_dict.get("metadata"), Mapping)
+                    else {}
+                )
+                enriched_metadata_for_result.update(moonspec_verify_refs)
                 result_dict["metadata"] = enriched_metadata_for_result
             summary_ref = await _write_json_artifact(
                 self._artifact_service,

--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -1077,6 +1077,26 @@ class MoonMindAgentRun:
         request_params = (
             request.parameters if isinstance(request.parameters, Mapping) else {}
         )
+        selected_skill = _request_selected_skill(request)
+        if selected_skill:
+            moonmind_payload = (
+                metadata.get("moonmind")
+                if isinstance(metadata.get("moonmind"), dict)
+                else {}
+            )
+            moonmind_payload.setdefault("selectedSkill", selected_skill)
+            metadata["moonmind"] = moonmind_payload
+        if str(selected_skill or "").strip().lower() == "moonspec-verify":
+            for key in (
+                "verify_artifact_path",
+                "verifyArtifactPath",
+                "verification_artifact_path",
+                "verificationArtifactPath",
+            ):
+                value = request_params.get(key)
+                if isinstance(value, str) and value.strip():
+                    metadata["verify_artifact_path"] = value.strip()
+                    break
         request_metadata = request_params.get("metadata")
         request_moonmind = (
             request_metadata.get("moonmind")

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -348,17 +348,6 @@ _MOONSPEC_GATE_VERDICT_TEXT_PATTERN = re.compile(
     r")\b",
     re.IGNORECASE,
 )
-_MOONSPEC_VERIFY_REPORT_VERDICT_PATTERN = re.compile(
-    r"(?im)^\s*\*\*Verdict\*\*\s*:\s*`?("
-    r"FULLY_IMPLEMENTED|"
-    r"ADDITIONAL_WORK_NEEDED|"
-    r"NO_DETERMINATION|"
-    r"ENVIRONMENT_CONTAMINATED_BY_SKILL_PROJECTION|"
-    r"FAILED_UNRECOVERABLE|"
-    r"BLOCKED"
-    r")`?\b"
-)
-
 class RunWorkflowInput(TypedDict, total=False):
     """Input payload for the MoonMind.UserWorkflow workflow."""
 
@@ -4381,18 +4370,6 @@ class MoonMindRunWorkflow:
                         return text
         return None
 
-    def _extract_moonspec_verify_report_verdict(
-        self,
-        outputs: Mapping[str, Any],
-    ) -> str | None:
-        report_text = self._moonspec_verify_report_text(outputs)
-        if not report_text:
-            return None
-        match = _MOONSPEC_VERIFY_REPORT_VERDICT_PATTERN.search(report_text[:4000])
-        if not match:
-            return None
-        return self._normalize_moonspec_verify_verdict(match.group(1))
-
     def _moonspec_verify_gate_result(
         self,
         outputs: Mapping[str, Any],
@@ -4412,10 +4389,6 @@ class MoonMindRunWorkflow:
                     payload = dict(source)
                     payload["verdict"] = source.get(key)
                     return parse_step_gate_result(payload)
-
-        report_verdict = self._extract_moonspec_verify_report_verdict(outputs)
-        if report_verdict:
-            return parse_step_gate_result({"verdict": report_verdict})
 
         return parse_step_gate_result({})
 
@@ -4445,10 +4418,10 @@ class MoonMindRunWorkflow:
     ) -> None:
         gate_result = self._moonspec_verify_gate_result(outputs)
         verdict = gate_result.verdict
-        report_verdict = self._extract_moonspec_verify_report_verdict(outputs)
         reason = (
-            f"MoonSpec verification report verdict: {report_verdict}"
-            if report_verdict
+            "MoonSpec verification report was present but structured gate output "
+            "was missing."
+            if gate_result.degraded and self._moonspec_verify_report_text(outputs)
             else None
         )
         if reason is None:
@@ -12306,10 +12279,9 @@ class MoonMindRunWorkflow:
                     break
             if verify_artifact_path:
                 break
-        parameters.setdefault(
-            "verify_artifact_path",
+        parameters["verify_artifact_path"] = (
             verify_artifact_path
-            or self._default_moonspec_verify_artifact_path(node_id),
+            or self._default_moonspec_verify_artifact_path(node_id)
         )
 
     def _build_agent_execution_request(
@@ -13153,8 +13125,9 @@ class MoonMindRunWorkflow:
             outputs["providerErrorCode"] = provider_error_code
         if retry_recommendation:
             outputs["retryRecommendation"] = retry_recommendation
-        for key, value in metadata.items():
-            outputs.setdefault(key, value)
+        if isinstance(metadata, Mapping):
+            for key, value in metadata.items():
+                outputs.setdefault(key, value)
 
         return {
             "status": status,

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -348,6 +348,16 @@ _MOONSPEC_GATE_VERDICT_TEXT_PATTERN = re.compile(
     r")\b",
     re.IGNORECASE,
 )
+_MOONSPEC_VERIFY_REPORT_VERDICT_PATTERN = re.compile(
+    r"(?im)^\s*\*\*Verdict\*\*\s*:\s*`?("
+    r"FULLY_IMPLEMENTED|"
+    r"ADDITIONAL_WORK_NEEDED|"
+    r"NO_DETERMINATION|"
+    r"ENVIRONMENT_CONTAMINATED_BY_SKILL_PROJECTION|"
+    r"FAILED_UNRECOVERABLE|"
+    r"BLOCKED"
+    r")`?\b"
+)
 
 class RunWorkflowInput(TypedDict, total=False):
     """Input payload for the MoonMind.UserWorkflow workflow."""
@@ -4333,6 +4343,56 @@ class MoonMindRunWorkflow:
             return None
         return self._normalize_moonspec_verify_verdict(match.group(1))
 
+    def _moonspec_verify_report_text(
+        self,
+        outputs: Mapping[str, Any],
+    ) -> str | None:
+        for source in self._moonspec_verify_sources(outputs):
+            for key in (
+                "moonSpecVerifyReport",
+                "moonspecVerifyReport",
+                "verificationReport",
+                "verification_report",
+                "lastAssistantText",
+                "assistantText",
+                "summary",
+                "message",
+            ):
+                value = source.get(key)
+                if not isinstance(value, str):
+                    continue
+                text = value.strip()
+                if (
+                    "# MoonSpec Verification Report" in text
+                    and "**Verdict**" in text
+                ):
+                    return text
+            turn_metadata = source.get("turnMetadata")
+            if isinstance(turn_metadata, Mapping):
+                for key in ("assistantText", "lastAssistantText"):
+                    value = turn_metadata.get(key)
+                    if not isinstance(value, str):
+                        continue
+                    text = value.strip()
+                    if (
+                        "# MoonSpec Verification Report" in text
+                        and "**Verdict**" in text
+                    ):
+                        return text
+        return None
+
+    def _extract_moonspec_verify_report_verdict(
+        self,
+        outputs: Mapping[str, Any],
+    ) -> str | None:
+        report_text = self._moonspec_verify_report_text(outputs)
+        if not report_text:
+            return None
+        match = _MOONSPEC_VERIFY_REPORT_VERDICT_PATTERN.search(report_text[:4000])
+        if not match:
+            return None
+        return self._normalize_moonspec_verify_verdict(match.group(1))
+
     def _moonspec_verify_gate_result(
         self,
         outputs: Mapping[str, Any],
@@ -4352,6 +4412,10 @@ class MoonMindRunWorkflow:
                     payload = dict(source)
                     payload["verdict"] = source.get(key)
                     return parse_step_gate_result(payload)
+
+        report_verdict = self._extract_moonspec_verify_report_verdict(outputs)
+        if report_verdict:
+            return parse_step_gate_result({"verdict": report_verdict})
 
         return parse_step_gate_result({})
 
@@ -4381,19 +4445,25 @@ class MoonMindRunWorkflow:
     ) -> None:
         gate_result = self._moonspec_verify_gate_result(outputs)
         verdict = gate_result.verdict
-        reason = None
-        for source in self._moonspec_verify_sources(outputs):
-            reason = self._sanitize_operator_summary(
-                self._coerce_text(
-                    source.get("operator_summary")
-                    or source.get("operatorSummary")
-                    or source.get("summary")
-                    or source.get("message"),
-                    max_chars=700,
+        report_verdict = self._extract_moonspec_verify_report_verdict(outputs)
+        reason = (
+            f"MoonSpec verification report verdict: {report_verdict}"
+            if report_verdict
+            else None
+        )
+        if reason is None:
+            for source in self._moonspec_verify_sources(outputs):
+                reason = self._sanitize_operator_summary(
+                    self._coerce_text(
+                        source.get("operator_summary")
+                        or source.get("operatorSummary")
+                        or source.get("summary")
+                        or source.get("message"),
+                        max_chars=700,
+                    )
                 )
-            )
-            if reason:
-                break
+                if reason:
+                    break
         diagnostics_ref = None
         for source in self._moonspec_verify_sources(outputs):
             diagnostics_ref = self._coerce_text(
@@ -12206,6 +12276,42 @@ class MoonMindRunWorkflow:
             payload.pop(key, None)
         return payload
 
+    @staticmethod
+    def _default_moonspec_verify_artifact_path(node_id: str) -> str:
+        safe_node_id = re.sub(r"[^A-Za-z0-9_.-]+", "-", str(node_id or "")).strip("-")
+        if not safe_node_id:
+            safe_node_id = "verify"
+        return f"var/artifacts/moonspec-verify/{safe_node_id}.json"
+
+    def _ensure_moonspec_verify_parameters(
+        self,
+        *,
+        parameters: dict[str, Any],
+        node_inputs: Mapping[str, Any],
+        node_id: str,
+    ) -> None:
+        nested_inputs = node_inputs.get("inputs")
+        skill_inputs = nested_inputs if isinstance(nested_inputs, Mapping) else {}
+        verify_artifact_path = None
+        for source in (parameters, node_inputs, skill_inputs):
+            for key in (
+                "verify_artifact_path",
+                "verifyArtifactPath",
+                "verification_artifact_path",
+                "verificationArtifactPath",
+            ):
+                value = source.get(key)
+                if isinstance(value, str) and value.strip():
+                    verify_artifact_path = value.strip()
+                    break
+            if verify_artifact_path:
+                break
+        parameters.setdefault(
+            "verify_artifact_path",
+            verify_artifact_path
+            or self._default_moonspec_verify_artifact_path(node_id),
+        )
+
     def _build_agent_execution_request(
         self,
         *,
@@ -12416,6 +12522,12 @@ class MoonMindRunWorkflow:
             if compact_skill_payload:
                 compact_skill_payload.setdefault("name", selected_skill)
                 parameters["skill"] = dict(compact_skill_payload)
+            if selected_skill.lower() == "moonspec-verify":
+                self._ensure_moonspec_verify_parameters(
+                    parameters=parameters,
+                    node_inputs=node_inputs,
+                    node_id=node_id,
+                )
         bundle_payload: dict[str, Any] = {}
         for bundle_key in (
             "bundleId",
@@ -13041,7 +13153,8 @@ class MoonMindRunWorkflow:
             outputs["providerErrorCode"] = provider_error_code
         if retry_recommendation:
             outputs["retryRecommendation"] = retry_recommendation
-        outputs.update(metadata)
+        for key, value in metadata.items():
+            outputs.setdefault(key, value)
 
         return {
             "status": status,

--- a/tests/integration/test_startup_preset_seeding.py
+++ b/tests/integration/test_startup_preset_seeding.py
@@ -168,6 +168,9 @@ async def test_startup_seeds_default_task_templates(disabled_env_keys, tmp_path)
             if step["title"] == "Verify remediation 6 of 6"
         )
         assert remediation_verify_step["skill"]["id"] == "moonspec-verify"
+        assert remediation_verify_step["skill"]["args"]["verify_artifact_path"] == (
+            "var/artifacts/moonspec-verify/jira-orchestrate.json"
+        )
         assert "controlling verification gate" in remediation_verify_step["instructions"]
         doc_reconcile_step = next(
             step

--- a/tests/unit/api/test_presets_service.py
+++ b/tests/unit/api/test_presets_service.py
@@ -3092,12 +3092,18 @@ async def test_seed_catalog_github_issue_orchestrate_expands_gated_workflow(tmp_
         "pullRequestArtifactPath": "artifacts/github-issue-orchestrate-pr.json",
     }
     assert expanded["steps"][11]["skill"]["id"] == "moonspec-verify"
+    assert expanded["steps"][11]["skill"]["args"]["verify_artifact_path"] == (
+        "var/artifacts/moonspec-verify/github-issue-orchestrate.json"
+    )
     assert expanded["steps"][23]["annotations"] == {
         "jiraOrchestrateRole": "moonspec-verification-gate",
         "moonSpecRemediationAttempt": 6,
         "moonSpecRemediationMaxAttempts": 6,
         "moonSpecFinalRemediationGate": True,
     }
+    assert expanded["steps"][23]["skill"]["args"]["verify_artifact_path"] == (
+        "var/artifacts/moonspec-verify/github-issue-orchestrate.json"
+    )
     assert expanded["steps"][24]["annotations"] == {
         "jiraOrchestrateRole": "doc-reconciliation"
     }

--- a/tests/unit/workflows/temporal/test_activity_runtime.py
+++ b/tests/unit/workflows/temporal/test_activity_runtime.py
@@ -101,6 +101,20 @@ PENTEST_RUNNER_IMAGE = "ghcr.io/moonladderstudios/moonmind-pentestgpt:1.0"
 pytestmark = [pytest.mark.asyncio]
 
 
+async def test_prepare_managed_codex_turn_adds_moonspec_verify_artifact_hint() -> None:
+    prepared = TemporalAgentRuntimeActivities._prepare_managed_codex_turn_text(
+        "Run moonspec-verify.",
+        parameters={
+            "metadata": {"moonmind": {"selectedSkill": "moonspec-verify"}},
+            "verify_artifact_path": "var/artifacts/moonspec-verify/verify-final.json",
+        },
+    )
+
+    assert "MoonSpec verification output contract:" in prepared
+    assert "var/artifacts/moonspec-verify/verify-final.json" in prepared
+    assert "complete structured verifier JSON" in prepared
+
+
 async def test_checkpoint_activity_runtime_bindings_are_registered() -> None:
     catalog = TemporalActivityCatalog(
         activities=(

--- a/tests/unit/workflows/temporal/test_activity_runtime.py
+++ b/tests/unit/workflows/temporal/test_activity_runtime.py
@@ -26,7 +26,7 @@ from moonmind.integrations.pentest.models import (
     PENTEST_CLAUDE_OAUTH_RUNNER_PROFILE_ID,
 )
 from moonmind.jules.runtime import JULES_RUNTIME_DISABLED_MESSAGE
-from moonmind.schemas.agent_runtime_models import AgentRunResult
+from moonmind.schemas.agent_runtime_models import AgentRunResult, ManagedRunRecord
 from moonmind.schemas.jules_models import JulesTaskResponse
 from moonmind.schemas.workload_models import (
     ValidatedWorkloadRequest,
@@ -94,6 +94,7 @@ from moonmind.workflows.temporal.artifacts import (
     build_artifact_ref,
 )
 from moonmind.workflows.temporal.report_artifacts import validate_report_bundle_result
+from moonmind.workflows.temporal.runtime.store import ManagedRunStore
 from moonmind.workloads.registry import RunnerProfileRegistry
 
 PENTEST_RUNNER_IMAGE = "ghcr.io/moonladderstudios/moonmind-pentestgpt:1.0"
@@ -4893,7 +4894,6 @@ async def test_agent_runtime_publish_artifacts_publishes_explicit_report_bundle(
                 link_type="report.primary",
                 latest_only=True,
             )
-
             assert len(reports) == 1
             assert reports[0].metadata_json["report_type"] == "integration_test_report"
             assert reports[0].metadata_json["report_scope"] == "final"
@@ -4905,6 +4905,89 @@ async def test_agent_runtime_publish_artifacts_publishes_explicit_report_bundle(
             )
             body = path.read_bytes()
             assert body.decode("utf-8") == "# Integration test report\n\nAll tests passed.\n"
+
+
+async def test_agent_runtime_publish_artifacts_publishes_moonspec_verify_json(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async with temporal_db(tmp_path) as session_maker:
+        async with session_maker() as session:
+            workspace = tmp_path / "workspace"
+            verify_path = workspace / "var/artifacts/moonspec-verify/final.json"
+            verify_path.parent.mkdir(parents=True)
+            verify_path.write_text(
+                json.dumps(
+                    {
+                        "schemaVersion": 1,
+                        "verdict": "FULLY_IMPLEMENTED",
+                        "recommendedNextAction": "publish",
+                        "recoverableInCurrentRuntime": True,
+                        "remainingWork": [],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            run_store = ManagedRunStore(tmp_path / "runs")
+            run_store.save(
+                ManagedRunRecord(
+                    runId="verify-run-1",
+                    agentId="codex_cli",
+                    runtimeId="codex_cli",
+                    status="completed",
+                    startedAt=datetime.now(timezone.utc),
+                    workspacePath=workspace.as_posix(),
+                )
+            )
+            service = TemporalArtifactService(
+                TemporalArtifactRepository(session),
+                store=LocalTemporalArtifactStore(tmp_path / "artifacts"),
+            )
+            activities = TemporalAgentRuntimeActivities(
+                artifact_service=service,
+                run_store=run_store,
+            )
+
+            async def _skip_notify(*_args: Any, **_kwargs: Any) -> dict[str, str]:
+                return {"status": "skipped"}
+
+            monkeypatch.setattr(
+                activities,
+                "execution_notify_completion",
+                _skip_notify,
+            )
+            monkeypatch.setattr(
+                temporal_activity,
+                "info",
+                lambda: SimpleNamespace(
+                    namespace="default",
+                    workflow_id="parent-wf:agent:verify",
+                    workflow_run_id="child-run-verify",
+                ),
+            )
+
+            result = await activities.agent_runtime_publish_artifacts(
+                AgentRunResult(
+                    summary="Completed.",
+                    metadata={
+                        "agentRunId": "verify-run-1",
+                        "verify_artifact_path": (
+                            "var/artifacts/moonspec-verify/final.json"
+                        ),
+                    },
+                )
+            )
+
+            assert isinstance(result, AgentRunResult)
+            assert result.metadata["gateResultRef"].startswith("art_")
+            assert result.metadata["moonSpecVerifyArtifactRef"] == (
+                result.metadata["gateResultRef"]
+            )
+            assert result.metadata["moonSpecVerify"]["verdict"] == "FULLY_IMPLEMENTED"
+            assert result.metadata["moonSpecVerify"]["gateResultRef"] == (
+                result.metadata["gateResultRef"]
+            )
+
 
 async def test_agent_runtime_publish_artifacts_uses_last_assistant_text_for_report_body(
     tmp_path: Path,

--- a/tests/unit/workflows/temporal/test_run_artifacts.py
+++ b/tests/unit/workflows/temporal/test_run_artifacts.py
@@ -5858,3 +5858,26 @@ def test_moonspec_verify_gate_result_fails_closed_without_verdict() -> None:
     assert gate.verdict == "NO_DETERMINATION"
     assert gate.invalid is True
     assert gate.degraded is True
+
+
+def test_agent_run_result_mapping_preserves_canonical_diagnostics_ref() -> None:
+    workflow = MoonMindRunWorkflow()
+
+    mapped = workflow._map_agent_run_result(
+        {
+            "summary": "Completed with status completed",
+            "diagnosticsRef": "art_verify_report",
+            "metadata": {
+                "diagnosticsRef": "sess:mm-example:codex_cli/diagnostics.json",
+                "lastAssistantText": "# MoonSpec Verification Report\n\n**Verdict**: `FULLY_IMPLEMENTED`",
+            },
+            "outputRefs": [],
+        }
+    )
+
+    outputs = mapped["outputs"]
+    assert outputs["diagnosticsRef"] == "art_verify_report"
+    assert (
+        outputs["lastAssistantText"]
+        == "# MoonSpec Verification Report\n\n**Verdict**: `FULLY_IMPLEMENTED`"
+    )

--- a/tests/unit/workflows/temporal/test_run_artifacts.py
+++ b/tests/unit/workflows/temporal/test_run_artifacts.py
@@ -5881,3 +5881,20 @@ def test_agent_run_result_mapping_preserves_canonical_diagnostics_ref() -> None:
         outputs["lastAssistantText"]
         == "# MoonSpec Verification Report\n\n**Verdict**: `FULLY_IMPLEMENTED`"
     )
+
+
+def test_agent_run_result_mapping_ignores_malformed_metadata() -> None:
+    workflow = MoonMindRunWorkflow()
+
+    mapped = workflow._map_agent_run_result(
+        {
+            "summary": "Completed with status completed",
+            "diagnosticsRef": "art_verify_report",
+            "metadata": ["not", "a", "mapping"],
+            "outputRefs": [],
+        }
+    )
+
+    outputs = mapped["outputs"]
+    assert outputs["diagnosticsRef"] == "art_verify_report"
+    assert outputs["summary"] == "Completed with status completed"

--- a/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
+++ b/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
@@ -2072,10 +2072,17 @@ async def test_child_jira_orchestrate_run_expands_seeded_template_steps(tmp_path
     assert "MM-501" in task["steps"][0]["instructions"]
     assert task["steps"][7]["skill"]["id"] == "moonspec-tasks"
     assert task["steps"][9]["skill"]["id"] == "moonspec-implement"
+    assert task["steps"][10]["skill"]["id"] == "moonspec-verify"
+    assert task["steps"][10]["skill"]["args"]["verify_artifact_path"] == (
+        "var/artifacts/moonspec-verify/jira-orchestrate.json"
+    )
     assert task["steps"][11]["title"] == "Remediate verification gaps 1 of 6"
     assert task["steps"][11]["skill"]["id"] == "moonspec-implement"
     assert task["steps"][22]["title"] == "Verify remediation 6 of 6"
     assert task["steps"][22]["skill"]["id"] == "moonspec-verify"
+    assert task["steps"][22]["skill"]["args"]["verify_artifact_path"] == (
+        "var/artifacts/moonspec-verify/jira-orchestrate.json"
+    )
     assert task["steps"][23]["title"] == "Reconcile declarative docs"
     assert task["steps"][23]["skill"]["id"] == "moonspec-doc-reconcile"
     assert task["steps"][24]["title"] == "Create pull request"

--- a/tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py
@@ -380,6 +380,31 @@ async def test_managed_session_result_enrichment_carries_story_output_paths(
         "artifacts/story-breakdowns/demo/stories.md"
     )
 
+
+async def test_managed_session_result_enrichment_carries_moonspec_verify_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _configure_workflow_runtime(monkeypatch)
+    run = MoonMindAgentRun()
+    request = _managed_session_request(
+        parameters={
+            "metadata": {"moonmind": {"selectedSkill": "moonspec-verify"}},
+            "verify_artifact_path": "var/artifacts/moonspec-verify/final.json",
+        },
+    )
+
+    result = run._enrich_result_metadata(
+        request=request,
+        result=AgentRunResult(summary="done", metadata={}),
+    )
+
+    assert result is not None
+    assert result.metadata["verify_artifact_path"] == (
+        "var/artifacts/moonspec-verify/final.json"
+    )
+    assert result.metadata["moonmind"]["selectedSkill"] == "moonspec-verify"
+
+
 async def test_agent_run_uses_codex_session_adapter_for_managed_codex_session(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/workflows/temporal/workflows/test_run_integration.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_integration.py
@@ -2499,6 +2499,59 @@ def test_moonspec_verify_text_verdict_parser_is_not_a_branch_boundary(
     )
 
 
+def test_moonspec_verify_gate_accepts_report_shaped_markdown(
+    mock_run_workflow: MoonMindRunWorkflow,
+) -> None:
+    mock_run_workflow._record_moonspec_verify_gate(
+        node_id="verify-final",
+        outputs={
+            "lastAssistantText": (
+                "# MoonSpec Verification Report\n\n"
+                "**Feature**: MM-1099\n"
+                "**Verdict**: `FULLY_IMPLEMENTED`\n"
+                "**Confidence**: HIGH\n"
+            ),
+            "operator_summary": "stale session text from an earlier step",
+            "diagnosticsRef": "art_verify_report",
+        },
+    )
+
+    gate_context = mock_run_workflow._publish_context["moonSpecGate"]
+    assert gate_context["verdict"] == "FULLY_IMPLEMENTED"
+    assert gate_context["summary"] == (
+        "MoonSpec verification report verdict: FULLY_IMPLEMENTED"
+    )
+    assert gate_context["diagnosticsRef"] == "art_verify_report"
+    assert gate_context["invalid"] is False
+    assert gate_context["degraded"] is False
+    assert mock_run_workflow._apply_blocking_moonspec_gate_to_publish() is False
+
+
+def test_moonspec_verify_gate_report_fallback_ignores_stale_operator_summary(
+    mock_run_workflow: MoonMindRunWorkflow,
+) -> None:
+    mock_run_workflow._record_moonspec_verify_gate(
+        node_id="verify-final",
+        outputs={
+            "lastAssistantText": (
+                "# MoonSpec Verification Report\n\n"
+                "**Feature**: MM-1099\n"
+                "**Verdict**: ADDITIONAL_WORK_NEEDED\n"
+                "**Confidence**: MEDIUM\n"
+            ),
+            "operator_summary": "stale Jira updater transcript",
+            "diagnosticsRef": "art_verify_report",
+        },
+    )
+
+    assert mock_run_workflow._apply_blocking_moonspec_gate_to_publish() is True
+    blocked_message = mock_run_workflow._plan_blocked_message or ""
+    assert "ADDITIONAL_WORK_NEEDED" in blocked_message
+    assert "MoonSpec verification report verdict" in blocked_message
+    assert "stale Jira updater transcript" not in blocked_message
+    assert "art_verify_report" in blocked_message
+
+
 def test_moonspec_verify_gate_records_nested_summary_and_report(
     mock_run_workflow: MoonMindRunWorkflow,
 ) -> None:
@@ -2545,6 +2598,37 @@ def test_moonspec_verify_gate_fails_closed_for_verdict_looking_prose_output(
     assert gate_context["diagnosticsRef"] == "art_verify_prose_only"
     assert mock_run_workflow._apply_blocking_moonspec_gate_to_publish() is True
     assert "NO_DETERMINATION" in (mock_run_workflow._plan_blocked_message or "")
+
+
+def test_moonspec_verify_default_artifact_path_is_added_to_parameters(
+    mock_run_workflow: MoonMindRunWorkflow,
+) -> None:
+    parameters: dict[str, Any] = {}
+
+    mock_run_workflow._ensure_moonspec_verify_parameters(
+        parameters=parameters,
+        node_inputs={"inputs": {}},
+        node_id="tpl:jira-orchestrate:11:e7cc7ca9",
+    )
+
+    assert parameters["verify_artifact_path"] == (
+        "var/artifacts/moonspec-verify/"
+        "tpl-jira-orchestrate-11-e7cc7ca9.json"
+    )
+
+
+def test_moonspec_verify_artifact_path_uses_nested_skill_args(
+    mock_run_workflow: MoonMindRunWorkflow,
+) -> None:
+    parameters: dict[str, Any] = {}
+
+    mock_run_workflow._ensure_moonspec_verify_parameters(
+        parameters=parameters,
+        node_inputs={"inputs": {"verifyArtifactPath": "var/artifacts/custom.json"}},
+        node_id="verify-final",
+    )
+
+    assert parameters["verify_artifact_path"] == "var/artifacts/custom.json"
 
 
 def test_moonspec_verify_blocked_attempt_one_stops_with_remaining_budget(

--- a/tests/unit/workflows/temporal/workflows/test_run_integration.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_integration.py
@@ -2499,7 +2499,7 @@ def test_moonspec_verify_text_verdict_parser_is_not_a_branch_boundary(
     )
 
 
-def test_moonspec_verify_gate_accepts_report_shaped_markdown(
+def test_moonspec_verify_gate_degrades_report_only_markdown(
     mock_run_workflow: MoonMindRunWorkflow,
 ) -> None:
     mock_run_workflow._record_moonspec_verify_gate(
@@ -2517,17 +2517,18 @@ def test_moonspec_verify_gate_accepts_report_shaped_markdown(
     )
 
     gate_context = mock_run_workflow._publish_context["moonSpecGate"]
-    assert gate_context["verdict"] == "FULLY_IMPLEMENTED"
+    assert gate_context["verdict"] == "NO_DETERMINATION"
     assert gate_context["summary"] == (
-        "MoonSpec verification report verdict: FULLY_IMPLEMENTED"
+        "MoonSpec verification report was present but structured gate output "
+        "was missing."
     )
     assert gate_context["diagnosticsRef"] == "art_verify_report"
-    assert gate_context["invalid"] is False
-    assert gate_context["degraded"] is False
-    assert mock_run_workflow._apply_blocking_moonspec_gate_to_publish() is False
+    assert gate_context["invalid"] is True
+    assert gate_context["degraded"] is True
+    assert mock_run_workflow._apply_blocking_moonspec_gate_to_publish() is True
 
 
-def test_moonspec_verify_gate_report_fallback_ignores_stale_operator_summary(
+def test_moonspec_verify_gate_report_only_markdown_ignores_stale_operator_summary(
     mock_run_workflow: MoonMindRunWorkflow,
 ) -> None:
     mock_run_workflow._record_moonspec_verify_gate(
@@ -2546,8 +2547,8 @@ def test_moonspec_verify_gate_report_fallback_ignores_stale_operator_summary(
 
     assert mock_run_workflow._apply_blocking_moonspec_gate_to_publish() is True
     blocked_message = mock_run_workflow._plan_blocked_message or ""
-    assert "ADDITIONAL_WORK_NEEDED" in blocked_message
-    assert "MoonSpec verification report verdict" in blocked_message
+    assert "NO_DETERMINATION" in blocked_message
+    assert "structured gate output was missing" in blocked_message
     assert "stale Jira updater transcript" not in blocked_message
     assert "art_verify_report" in blocked_message
 
@@ -2603,7 +2604,7 @@ def test_moonspec_verify_gate_fails_closed_for_verdict_looking_prose_output(
 def test_moonspec_verify_default_artifact_path_is_added_to_parameters(
     mock_run_workflow: MoonMindRunWorkflow,
 ) -> None:
-    parameters: dict[str, Any] = {}
+    parameters: dict[str, Any] = {"verify_artifact_path": ""}
 
     mock_run_workflow._ensure_moonspec_verify_parameters(
         parameters=parameters,


### PR DESCRIPTION
## Summary
- pass a `verify_artifact_path` into Jira and GitHub issue MoonSpec verification steps and add a runtime default for generated verify nodes
- append the MoonSpec verifier output contract to managed Codex turns so the verifier writes structured JSON while still returning the Markdown report
- accept only report-shaped MoonSpec verifier Markdown as a narrow fallback when structured JSON is missing, avoiding false `NO_DETERMINATION` failures for reports that clearly say `FULLY_IMPLEMENTED`
- preserve canonical artifact refs over stale metadata refs so diagnostics point at readable artifacts

## Investigation notes
- `moonspec` is initialized at `4dc84d137b534e14258a63e997df9ccc9ac03edb`, the pinned `origin/mm-1071-issue-brief-verification` commit.
- `python3 tools/sync_moonspec_submodule.py --check` reports the MoonSpec projection is current.
- `.agents/skills/moonspec-*` are projected directories, not symlinks. That matches the canonical docs: tracked repo skills are projected from `moonspec/bundle/skills`; symlink mapping applies to run-scoped active snapshots, not the publishable checkout.
- Example workflow `mm:d77f8e18-4825-4719-894b-9bc4c5f1f445` produced a Markdown MoonSpec Verification Report with `FULLY_IMPLEMENTED`, but the parent gate had no structured verifier artifact and therefore degraded to `NO_DETERMINATION`.

## Tests
- `PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -m pytest -q tests/unit/workflows/temporal/workflows/test_run_integration.py -k moonspec_verify --tb=short`
- `PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -m pytest -q tests/unit/workflows/temporal/test_run_artifacts.py::test_agent_run_result_mapping_preserves_canonical_diagnostics_ref tests/unit/workflows/temporal/test_activity_runtime.py::test_prepare_managed_codex_turn_adds_moonspec_verify_artifact_hint tests/unit/workflows/temporal/test_temporal_worker_runtime.py::test_child_jira_orchestrate_run_expands_seeded_template_steps tests/unit/api/test_presets_service.py::test_seed_catalog_github_issue_orchestrate_expands_gated_workflow tests/integration/test_startup_preset_seeding.py::test_startup_seeds_default_task_templates --tb=short`
- `PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -m pytest -q tests/unit/agents/test_moonspec_verify_skill.py tests/unit/tools/test_sync_moonspec_submodule.py --tb=short`
- `PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -m pytest -q tests/unit/workflows/temporal/test_run_artifacts.py -k 'moonspec_verify_gate_result or agent_run_result_mapping_preserves_canonical_diagnostics_ref' --tb=short`
- `python3 tools/sync_moonspec_submodule.py --check`

Note: the normal `./tools/test_unit.sh` wrapper is blocked in this checkout by root-owned local state/pycache files (`deploy/state/desired-state.json` and pytest cache paths), so the focused tests were run directly through the repo virtualenv with bytecode writes disabled.
