### PR TITLE
MM-1090 Complete checkpoint branch git isolation and binding behavior

### DIFF
--- a/api_service/db/models.py
+++ b/api_service/db/models.py
@@ -253,6 +253,7 @@ class RecurringWorkflowDefinition(Base):
         server_default=func.now(),
         onupdate=func.now(),
     )
+
     runs: Mapped[list["RecurringWorkflowRun"]] = relationship(
         "RecurringWorkflowRun",
         back_populates="definition",
@@ -407,6 +408,257 @@ class OmnigentExternalRun(Base):
         onupdate=func.now(),
     )
 
+
+class WorkflowCheckpointBranch(Base):
+    """Product-level checkpoint branch persisted separately from git refs."""
+
+    __tablename__ = "workflow_checkpoint_branches"
+    __table_args__ = (
+        Index("ix_checkpoint_branches_workflow", "workflow_id"),
+        Index("ix_checkpoint_branches_checkpoint", "source_checkpoint_ref"),
+        Index("ix_checkpoint_branches_state", "state"),
+    )
+
+    branch_id: Mapped[str] = mapped_column(String(255), primary_key=True)
+    workflow_id: Mapped[str] = mapped_column(String(255), nullable=False)
+    root_workflow_id: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    source_run_id: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    logical_step_id: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    source_execution_ordinal: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
+    source_checkpoint_boundary: Mapped[str] = mapped_column(String(64), nullable=False)
+    source_checkpoint_ref: Mapped[str] = mapped_column(String(1024), nullable=False)
+    source_checkpoint_digest: Mapped[Optional[str]] = mapped_column(String(128), nullable=True)
+    parent_branch_id: Mapped[Optional[str]] = mapped_column(
+        String(255),
+        ForeignKey("workflow_checkpoint_branches.branch_id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    parent_turn_id: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    label: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    state: Mapped[str] = mapped_column(
+        String(64), nullable=False, default="created", server_default="created"
+    )
+    branch_kind: Mapped[str] = mapped_column(
+        String(64), nullable=False, default="checkpoint", server_default="checkpoint"
+    )
+    workspace_policy: Mapped[str] = mapped_column(String(64), nullable=False)
+    runtime_context_policy: Mapped[Optional[str]] = mapped_column(String(64), nullable=True)
+    git_repository: Mapped[Optional[str]] = mapped_column(String(512), nullable=True)
+    git_base_branch: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    git_base_commit: Mapped[Optional[str]] = mapped_column(String(128), nullable=True)
+    git_work_branch: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    current_head_step_execution_id: Mapped[Optional[str]] = mapped_column(
+        String(255), nullable=True
+    )
+    current_head_checkpoint_ref: Mapped[Optional[str]] = mapped_column(
+        String(1024), nullable=True
+    )
+    current_head_commit: Mapped[Optional[str]] = mapped_column(String(128), nullable=True)
+    pull_request_url: Mapped[Optional[str]] = mapped_column(String(1024), nullable=True)
+    artifact_refs: Mapped[dict[str, Any]] = mapped_column(
+        mutable_json_dict(), nullable=False, default=dict
+    )
+    diagnostics: Mapped[dict[str, Any]] = mapped_column(
+        mutable_json_dict(), nullable=False, default=dict
+    )
+    promoted_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True))
+    archived_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True))
+    created_by: Mapped[Optional[UUID]] = mapped_column(
+        Uuid, ForeignKey("user.id", ondelete="SET NULL"), nullable=True
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
+    )
+
+    turns: Mapped[list["WorkflowCheckpointBranchTurn"]] = relationship(
+        "WorkflowCheckpointBranchTurn",
+        back_populates="branch",
+        cascade="all, delete-orphan",
+        foreign_keys=lambda: [WorkflowCheckpointBranchTurn.branch_id],
+        order_by="WorkflowCheckpointBranchTurn.created_at",
+    )
+    git_binding: Mapped[Optional["WorkflowCheckpointBranchGitBinding"]] = relationship(
+        "WorkflowCheckpointBranchGitBinding",
+        back_populates="branch",
+        cascade="all, delete-orphan",
+        uselist=False,
+    )
+    artifacts: Mapped[list["WorkflowCheckpointBranchArtifact"]] = relationship(
+        "WorkflowCheckpointBranchArtifact",
+        back_populates="branch",
+        cascade="all, delete-orphan",
+        order_by="WorkflowCheckpointBranchArtifact.created_at",
+    )
+
+
+class WorkflowCheckpointBranchTurn(Base):
+    """Immutable instruction-bearing turn for a checkpoint branch."""
+
+    __tablename__ = "workflow_checkpoint_branch_turns"
+    __table_args__ = (
+        UniqueConstraint(
+            "idempotency_key", name="uq_checkpoint_branch_turn_idempotency_key"
+        ),
+        Index("ix_checkpoint_branch_turns_branch", "branch_id"),
+        Index("ix_checkpoint_branch_turns_status", "status"),
+    )
+
+    branch_turn_id: Mapped[str] = mapped_column(String(255), primary_key=True)
+    branch_id: Mapped[str] = mapped_column(
+        String(255),
+        ForeignKey("workflow_checkpoint_branches.branch_id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    parent_turn_id: Mapped[Optional[str]] = mapped_column(
+        String(255),
+        ForeignKey(
+            "workflow_checkpoint_branch_turns.branch_turn_id",
+            ondelete="SET NULL",
+        ),
+        nullable=True,
+    )
+    source_checkpoint_ref: Mapped[str] = mapped_column(String(1024), nullable=False)
+    source_checkpoint_digest: Mapped[Optional[str]] = mapped_column(String(128), nullable=True)
+    instruction_ref: Mapped[str] = mapped_column(String(1024), nullable=False)
+    instruction_digest: Mapped[str] = mapped_column(String(128), nullable=False)
+    context_bundle_ref: Mapped[Optional[str]] = mapped_column(String(1024), nullable=True)
+    workspace_policy: Mapped[str] = mapped_column(String(64), nullable=False)
+    git_work_branch: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    workspace_restore_ref: Mapped[Optional[str]] = mapped_column(String(1024), nullable=True)
+    git_binding_ref: Mapped[Optional[str]] = mapped_column(String(1024), nullable=True)
+    step_execution_manifest_ref: Mapped[Optional[str]] = mapped_column(
+        String(1024), nullable=True
+    )
+    created_step_execution_id: Mapped[Optional[str]] = mapped_column(
+        String(255), nullable=True
+    )
+    runtime_agent_run_id: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    provider_session_id: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    idempotency_key: Mapped[str] = mapped_column(String(512), nullable=False)
+    status: Mapped[str] = mapped_column(
+        String(64), nullable=False, default="preparing", server_default="preparing"
+    )
+    diagnostics: Mapped[dict[str, Any]] = mapped_column(
+        mutable_json_dict(), nullable=False, default=dict
+    )
+    started_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True))
+    completed_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True))
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
+    )
+
+    branch: Mapped[WorkflowCheckpointBranch] = relationship(
+        "WorkflowCheckpointBranch",
+        back_populates="turns",
+        foreign_keys=[branch_id],
+    )
+
+
+class WorkflowCheckpointBranchGitBinding(Base):
+    """Git/worktree/provider workspace binding for one product checkpoint branch."""
+
+    __tablename__ = "workflow_checkpoint_branch_git_bindings"
+    __table_args__ = (
+        UniqueConstraint(
+            "repository",
+            "work_branch",
+            name="uq_checkpoint_branch_git_binding_work_branch",
+        ),
+        Index("ix_checkpoint_branch_git_bindings_repository", "repository"),
+    )
+
+    branch_id: Mapped[str] = mapped_column(
+        String(255),
+        ForeignKey("workflow_checkpoint_branches.branch_id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    repository: Mapped[str] = mapped_column(String(512), nullable=False)
+    base_branch: Mapped[str] = mapped_column(String(255), nullable=False)
+    base_commit: Mapped[Optional[str]] = mapped_column(String(128), nullable=True)
+    work_branch: Mapped[str] = mapped_column(String(255), nullable=False)
+    worktree_ref: Mapped[Optional[str]] = mapped_column(String(1024), nullable=True)
+    provider_workspace_ref: Mapped[Optional[str]] = mapped_column(
+        String(1024), nullable=True
+    )
+    head_commit: Mapped[Optional[str]] = mapped_column(String(128), nullable=True)
+    patch_ref: Mapped[Optional[str]] = mapped_column(String(1024), nullable=True)
+    pull_request_url: Mapped[Optional[str]] = mapped_column(String(1024), nullable=True)
+    workspace_policy: Mapped[str] = mapped_column(String(64), nullable=False)
+    creation_mode: Mapped[str] = mapped_column(String(64), nullable=False)
+    publish_status: Mapped[str] = mapped_column(
+        String(64),
+        nullable=False,
+        default="not_published",
+        server_default="not_published",
+    )
+    binding_metadata: Mapped[dict[str, Any]] = mapped_column(
+        mutable_json_dict(), nullable=False, default=dict
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
+    )
+
+    branch: Mapped[WorkflowCheckpointBranch] = relationship(
+        "WorkflowCheckpointBranch", back_populates="git_binding"
+    )
+
+
+class WorkflowCheckpointBranchArtifact(Base):
+    """Artifact refs attached to checkpoint branch or branch-turn evidence."""
+
+    __tablename__ = "workflow_checkpoint_branch_artifacts"
+    __table_args__ = (
+        UniqueConstraint(
+            "branch_id",
+            "branch_turn_id",
+            "artifact_kind",
+            name="uq_checkpoint_branch_artifact_kind",
+        ),
+        Index("ix_checkpoint_branch_artifacts_branch", "branch_id"),
+    )
+
+    id: Mapped[UUID] = mapped_column(Uuid, primary_key=True, default=uuid4)
+    branch_id: Mapped[str] = mapped_column(
+        String(255),
+        ForeignKey("workflow_checkpoint_branches.branch_id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    branch_turn_id: Mapped[Optional[str]] = mapped_column(
+        String(255),
+        ForeignKey("workflow_checkpoint_branch_turns.branch_turn_id", ondelete="CASCADE"),
+        nullable=True,
+    )
+    artifact_kind: Mapped[str] = mapped_column(String(128), nullable=False)
+    artifact_ref: Mapped[str] = mapped_column(String(1024), nullable=False)
+    content_type: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    digest: Mapped[Optional[str]] = mapped_column(String(128), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+
+    branch: Mapped[WorkflowCheckpointBranch] = relationship(
+        "WorkflowCheckpointBranch", back_populates="artifacts"
+    )
+
+
 __all__ = [
     "Base",
     "User",
@@ -419,6 +671,10 @@ __all__ = [
     "RecurringWorkflowScheduleType",
     "RecurringWorkflowScopeType",
     "OmnigentExternalRun",
+    "WorkflowCheckpointBranch",
+    "WorkflowCheckpointBranchTurn",
+    "WorkflowCheckpointBranchGitBinding",
+    "WorkflowCheckpointBranchArtifact",
     "TemporalWorkflowType",
     "MoonMindWorkflowState",
     "TemporalExecutionCloseStatus",

--- a/api_service/migrations/versions/333_mm1090_checkpoint_branch_git_bindings.py
+++ b/api_service/migrations/versions/333_mm1090_checkpoint_branch_git_bindings.py
@@ -1,0 +1,275 @@
+"""Add checkpoint branch git binding records for MM-1090.
+
+Revision ID: 333_mm1090_checkpoint_branch_git_bindings
+Revises: 332_mm1024_no_commit_status
+Create Date: 2026-07-02
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = "333_mm1090_checkpoint_branch_git_bindings"
+down_revision: Union[str, None] = "332_mm1024_no_commit_status"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "workflow_checkpoint_branches",
+        sa.Column("branch_id", sa.String(length=255), primary_key=True),
+        sa.Column("workflow_id", sa.String(length=255), nullable=False),
+        sa.Column("root_workflow_id", sa.String(length=255), nullable=True),
+        sa.Column("source_run_id", sa.String(length=255), nullable=True),
+        sa.Column("logical_step_id", sa.String(length=255), nullable=True),
+        sa.Column("source_execution_ordinal", sa.Integer(), nullable=True),
+        sa.Column("source_checkpoint_boundary", sa.String(length=64), nullable=False),
+        sa.Column("source_checkpoint_ref", sa.String(length=1024), nullable=False),
+        sa.Column("source_checkpoint_digest", sa.String(length=128), nullable=True),
+        sa.Column("parent_branch_id", sa.String(length=255), nullable=True),
+        sa.Column("parent_turn_id", sa.String(length=255), nullable=True),
+        sa.Column("label", sa.String(length=255), nullable=True),
+        sa.Column("state", sa.String(length=64), nullable=False, server_default="created"),
+        sa.Column(
+            "branch_kind",
+            sa.String(length=64),
+            nullable=False,
+            server_default="checkpoint",
+        ),
+        sa.Column("workspace_policy", sa.String(length=64), nullable=False),
+        sa.Column("runtime_context_policy", sa.String(length=64), nullable=True),
+        sa.Column("git_repository", sa.String(length=512), nullable=True),
+        sa.Column("git_base_branch", sa.String(length=255), nullable=True),
+        sa.Column("git_base_commit", sa.String(length=128), nullable=True),
+        sa.Column("git_work_branch", sa.String(length=255), nullable=True),
+        sa.Column("current_head_step_execution_id", sa.String(length=255), nullable=True),
+        sa.Column("current_head_checkpoint_ref", sa.String(length=1024), nullable=True),
+        sa.Column("current_head_commit", sa.String(length=128), nullable=True),
+        sa.Column("pull_request_url", sa.String(length=1024), nullable=True),
+        sa.Column("artifact_refs", sa.JSON(), nullable=False, server_default=sa.text("'{}'")),
+        sa.Column("diagnostics", sa.JSON(), nullable=False, server_default=sa.text("'{}'")),
+        sa.Column("promoted_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("archived_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("created_by", sa.Uuid(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.ForeignKeyConstraint(["created_by"], ["user.id"], ondelete="SET NULL"),
+        sa.ForeignKeyConstraint(
+            ["parent_branch_id"],
+            ["workflow_checkpoint_branches.branch_id"],
+            ondelete="SET NULL",
+        ),
+    )
+    op.create_index(
+        "ix_checkpoint_branches_workflow",
+        "workflow_checkpoint_branches",
+        ["workflow_id"],
+    )
+    op.create_index(
+        "ix_checkpoint_branches_checkpoint",
+        "workflow_checkpoint_branches",
+        ["source_checkpoint_ref"],
+    )
+    op.create_index(
+        "ix_checkpoint_branches_state",
+        "workflow_checkpoint_branches",
+        ["state"],
+    )
+
+    op.create_table(
+        "workflow_checkpoint_branch_turns",
+        sa.Column("branch_turn_id", sa.String(length=255), primary_key=True),
+        sa.Column("branch_id", sa.String(length=255), nullable=False),
+        sa.Column("parent_turn_id", sa.String(length=255), nullable=True),
+        sa.Column("source_checkpoint_ref", sa.String(length=1024), nullable=False),
+        sa.Column("source_checkpoint_digest", sa.String(length=128), nullable=True),
+        sa.Column("instruction_ref", sa.String(length=1024), nullable=False),
+        sa.Column("instruction_digest", sa.String(length=128), nullable=False),
+        sa.Column("context_bundle_ref", sa.String(length=1024), nullable=True),
+        sa.Column("workspace_policy", sa.String(length=64), nullable=False),
+        sa.Column("git_work_branch", sa.String(length=255), nullable=True),
+        sa.Column("workspace_restore_ref", sa.String(length=1024), nullable=True),
+        sa.Column("git_binding_ref", sa.String(length=1024), nullable=True),
+        sa.Column("step_execution_manifest_ref", sa.String(length=1024), nullable=True),
+        sa.Column("created_step_execution_id", sa.String(length=255), nullable=True),
+        sa.Column("runtime_agent_run_id", sa.String(length=255), nullable=True),
+        sa.Column("provider_session_id", sa.String(length=255), nullable=True),
+        sa.Column("idempotency_key", sa.String(length=512), nullable=False),
+        sa.Column("status", sa.String(length=64), nullable=False, server_default="preparing"),
+        sa.Column("diagnostics", sa.JSON(), nullable=False, server_default=sa.text("'{}'")),
+        sa.Column("started_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.ForeignKeyConstraint(
+            ["branch_id"],
+            ["workflow_checkpoint_branches.branch_id"],
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["parent_turn_id"],
+            ["workflow_checkpoint_branch_turns.branch_turn_id"],
+            ondelete="SET NULL",
+        ),
+        sa.UniqueConstraint(
+            "idempotency_key", name="uq_checkpoint_branch_turn_idempotency_key"
+        ),
+    )
+    op.create_index(
+        "ix_checkpoint_branch_turns_branch",
+        "workflow_checkpoint_branch_turns",
+        ["branch_id"],
+    )
+    op.create_index(
+        "ix_checkpoint_branch_turns_status",
+        "workflow_checkpoint_branch_turns",
+        ["status"],
+    )
+
+    op.create_table(
+        "workflow_checkpoint_branch_git_bindings",
+        sa.Column("branch_id", sa.String(length=255), primary_key=True),
+        sa.Column("repository", sa.String(length=512), nullable=False),
+        sa.Column("base_branch", sa.String(length=255), nullable=False),
+        sa.Column("base_commit", sa.String(length=128), nullable=True),
+        sa.Column("work_branch", sa.String(length=255), nullable=False),
+        sa.Column("worktree_ref", sa.String(length=1024), nullable=True),
+        sa.Column("provider_workspace_ref", sa.String(length=1024), nullable=True),
+        sa.Column("head_commit", sa.String(length=128), nullable=True),
+        sa.Column("patch_ref", sa.String(length=1024), nullable=True),
+        sa.Column("pull_request_url", sa.String(length=1024), nullable=True),
+        sa.Column("workspace_policy", sa.String(length=64), nullable=False),
+        sa.Column("creation_mode", sa.String(length=64), nullable=False),
+        sa.Column(
+            "publish_status",
+            sa.String(length=64),
+            nullable=False,
+            server_default="not_published",
+        ),
+        sa.Column("binding_metadata", sa.JSON(), nullable=False, server_default=sa.text("'{}'")),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.ForeignKeyConstraint(
+            ["branch_id"],
+            ["workflow_checkpoint_branches.branch_id"],
+            ondelete="CASCADE",
+        ),
+        sa.UniqueConstraint(
+            "repository",
+            "work_branch",
+            name="uq_checkpoint_branch_git_binding_work_branch",
+        ),
+    )
+    op.create_index(
+        "ix_checkpoint_branch_git_bindings_repository",
+        "workflow_checkpoint_branch_git_bindings",
+        ["repository"],
+    )
+
+    op.create_table(
+        "workflow_checkpoint_branch_artifacts",
+        sa.Column("id", sa.Uuid(), primary_key=True),
+        sa.Column("branch_id", sa.String(length=255), nullable=False),
+        sa.Column("branch_turn_id", sa.String(length=255), nullable=True),
+        sa.Column("artifact_kind", sa.String(length=128), nullable=False),
+        sa.Column("artifact_ref", sa.String(length=1024), nullable=False),
+        sa.Column("content_type", sa.String(length=255), nullable=True),
+        sa.Column("digest", sa.String(length=128), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.ForeignKeyConstraint(
+            ["branch_id"],
+            ["workflow_checkpoint_branches.branch_id"],
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["branch_turn_id"],
+            ["workflow_checkpoint_branch_turns.branch_turn_id"],
+            ondelete="CASCADE",
+        ),
+        sa.UniqueConstraint(
+            "branch_id",
+            "branch_turn_id",
+            "artifact_kind",
+            name="uq_checkpoint_branch_artifact_kind",
+        ),
+    )
+    op.create_index(
+        "ix_checkpoint_branch_artifacts_branch",
+        "workflow_checkpoint_branch_artifacts",
+        ["branch_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_checkpoint_branch_artifacts_branch",
+        table_name="workflow_checkpoint_branch_artifacts",
+    )
+    op.drop_table("workflow_checkpoint_branch_artifacts")
+    op.drop_index(
+        "ix_checkpoint_branch_git_bindings_repository",
+        table_name="workflow_checkpoint_branch_git_bindings",
+    )
+    op.drop_table("workflow_checkpoint_branch_git_bindings")
+    op.drop_index(
+        "ix_checkpoint_branch_turns_status",
+        table_name="workflow_checkpoint_branch_turns",
+    )
+    op.drop_index(
+        "ix_checkpoint_branch_turns_branch",
+        table_name="workflow_checkpoint_branch_turns",
+    )
+    op.drop_table("workflow_checkpoint_branch_turns")
+    op.drop_index(
+        "ix_checkpoint_branches_state",
+        table_name="workflow_checkpoint_branches",
+    )
+    op.drop_index(
+        "ix_checkpoint_branches_checkpoint",
+        table_name="workflow_checkpoint_branches",
+    )
+    op.drop_index(
+        "ix_checkpoint_branches_workflow",
+        table_name="workflow_checkpoint_branches",
+    )
+    op.drop_table("workflow_checkpoint_branches")

--- a/api_service/migrations/versions/333_mm1090_cp_bindings.py
+++ b/api_service/migrations/versions/333_mm1090_cp_bindings.py
@@ -1,6 +1,6 @@
 """Add checkpoint branch git binding records for MM-1090.
 
-Revision ID: 333_mm1090_checkpoint_branch_git_bindings
+Revision ID: 333_mm1090_cp_bindings
 Revises: 332_mm1024_no_commit_status
 Create Date: 2026-07-02
 """
@@ -13,7 +13,7 @@ import sqlalchemy as sa
 from alembic import op
 
 
-revision: str = "333_mm1090_checkpoint_branch_git_bindings"
+revision: str = "333_mm1090_cp_bindings"
 down_revision: Union[str, None] = "332_mm1024_no_commit_status"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None

--- a/api_service/services/checkpoint_branches.py
+++ b/api_service/services/checkpoint_branches.py
@@ -12,7 +12,7 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any
 
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from api_service.db.models import (
@@ -24,6 +24,8 @@ from api_service.db.models import (
 from moonmind.workflows.checkpoint_branches import (
     CHECKPOINT_BRANCH_GIT_BINDING_CONTENT_TYPE,
     CHECKPOINT_BRANCH_WORKSPACE_RESTORE_CONTENT_TYPE,
+    CheckpointBranchGitBindingError,
+    CheckpointBranchGitBindingInput,
     CheckpointBranchGitBindingResult,
     prepare_checkpoint_branch_git_binding,
 )
@@ -70,9 +72,16 @@ async def prepare_checkpoint_branch_workspace(
 ) -> CheckpointBranchWorkspacePreparation:
     """Validate, emit artifacts, and persist a checkpoint branch git binding."""
 
+    try:
+        validated_input = CheckpointBranchGitBindingInput.model_validate(binding_input)
+    except ValueError as exc:
+        raise CheckpointBranchGitBindingError(
+            "invalid_binding", f"checkpoint branch git binding input invalid: {exc}"
+        ) from exc
+
     existing_bindings = await _existing_bindings_by_work_branch(
         session=session,
-        repository=str(binding_input.get("repository") or "").strip(),
+        repository=validated_input.repository,
     )
     prepared = prepare_checkpoint_branch_git_binding(
         binding_input,
@@ -132,7 +141,8 @@ async def _existing_bindings_by_work_branch(
         return {}
     result = await session.execute(
         select(WorkflowCheckpointBranchGitBinding).where(
-            WorkflowCheckpointBranchGitBinding.repository == repository
+            func.lower(WorkflowCheckpointBranchGitBinding.repository)
+            == repository.lower()
         )
     )
     bindings: dict[str, dict[str, str]] = {}
@@ -188,7 +198,7 @@ async def _persist_prepared_checkpoint_branch(
             source_checkpoint_digest=binding.source_checkpoint_digest,
             parent_branch_id=parent_branch_id,
             parent_turn_id=parent_turn_id,
-            label=None,
+            label=binding.label,
             state="preparing",
             workspace_policy=str(binding.workspace_policy),
             runtime_context_policy=runtime_context_policy,
@@ -205,6 +215,7 @@ async def _persist_prepared_checkpoint_branch(
         branch.workspace_policy = str(binding.workspace_policy)
         branch.runtime_context_policy = runtime_context_policy
         branch.logical_step_id = binding.logical_step_id
+        branch.label = binding.label
         branch.git_repository = binding.repository
         branch.git_base_branch = binding.base_branch
         branch.git_base_commit = binding.base_commit
@@ -318,18 +329,28 @@ async def _persist_branch_turn(
         )
         session.add(turn)
         return
-    turn.parent_turn_id = parent_turn_id
-    turn.source_checkpoint_ref = binding.source_checkpoint_ref
-    turn.source_checkpoint_digest = binding.source_checkpoint_digest
-    turn.instruction_ref = instruction_ref
-    turn.instruction_digest = instruction_digest
-    turn.idempotency_key = binding.idempotency_key
-    turn.workspace_policy = str(binding.workspace_policy)
-    turn.git_work_branch = binding.work_branch
+    expected = {
+        "branch_id": binding.product_branch_id,
+        "parent_turn_id": parent_turn_id,
+        "source_checkpoint_ref": binding.source_checkpoint_ref,
+        "source_checkpoint_digest": binding.source_checkpoint_digest,
+        "instruction_ref": instruction_ref,
+        "instruction_digest": instruction_digest,
+        "idempotency_key": binding.idempotency_key,
+        "workspace_policy": str(binding.workspace_policy),
+        "git_work_branch": binding.work_branch,
+        "step_execution_manifest_ref": step_execution_manifest_ref,
+        "created_step_execution_id": created_step_execution_id,
+    }
+    for field_name, expected_value in expected.items():
+        if getattr(turn, field_name) != expected_value:
+            raise CheckpointBranchGitBindingError(
+                "invalid_binding",
+                f"existing branch turn {binding.branch_turn_id!r} has "
+                f"different {field_name}",
+            )
     turn.workspace_restore_ref = workspace_restore_ref
     turn.git_binding_ref = git_binding_ref
-    turn.step_execution_manifest_ref = step_execution_manifest_ref
-    turn.created_step_execution_id = created_step_execution_id
     turn.status = "preparing"
     turn.diagnostics = {**(turn.diagnostics or {}), **diagnostics}
 

--- a/api_service/services/checkpoint_branches.py
+++ b/api_service/services/checkpoint_branches.py
@@ -1,0 +1,369 @@
+"""Checkpoint branch launch preparation service for MM-1090.
+
+The service keeps repository-mutating checkpoint branch preparation at an
+activity/service boundary: it validates git isolation, emits launch evidence,
+and persists the product-branch-to-git-branch binding before agent work starts.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable, Mapping
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from api_service.db.models import (
+    WorkflowCheckpointBranch,
+    WorkflowCheckpointBranchArtifact,
+    WorkflowCheckpointBranchGitBinding,
+    WorkflowCheckpointBranchTurn,
+)
+from moonmind.workflows.checkpoint_branches import (
+    CHECKPOINT_BRANCH_GIT_BINDING_CONTENT_TYPE,
+    CHECKPOINT_BRANCH_WORKSPACE_RESTORE_CONTENT_TYPE,
+    CheckpointBranchGitBindingResult,
+    prepare_checkpoint_branch_git_binding,
+)
+
+CheckpointBranchArtifactWriter = Callable[
+    [str, Mapping[str, Any], str], Awaitable[tuple[str, str | None]]
+]
+
+
+@dataclass(frozen=True)
+class CheckpointBranchWorkspacePreparation:
+    """Persisted checkpoint branch launch evidence."""
+
+    branch_id: str
+    branch_turn_id: str | None
+    git_work_branch: str
+    workspace_policy: str
+    workspace_restore_ref: str
+    git_binding_ref: str
+    workspace_restore_digest: str | None
+    git_binding_digest: str | None
+    binding: CheckpointBranchGitBindingResult
+
+
+async def prepare_checkpoint_branch_workspace(
+    *,
+    session: AsyncSession,
+    binding_input: Mapping[str, Any],
+    known_refs: set[str] | frozenset[str],
+    current_ref: str | None,
+    instruction_ref: str,
+    instruction_digest: str,
+    artifact_writer: CheckpointBranchArtifactWriter,
+    source_checkpoint_boundary: str = "after_execution",
+    root_workflow_id: str | None = None,
+    source_run_id: str | None = None,
+    source_execution_ordinal: int | None = None,
+    parent_branch_id: str | None = None,
+    parent_turn_id: str | None = None,
+    runtime_context_policy: str | None = None,
+    step_execution_manifest_ref: str | None = None,
+    created_step_execution_id: str | None = None,
+    created_at: datetime | None = None,
+) -> CheckpointBranchWorkspacePreparation:
+    """Validate, emit artifacts, and persist a checkpoint branch git binding."""
+
+    existing_bindings = await _existing_bindings_by_work_branch(
+        session=session,
+        repository=str(binding_input.get("repository") or "").strip(),
+    )
+    prepared = prepare_checkpoint_branch_git_binding(
+        binding_input,
+        known_refs=known_refs,
+        existing_bindings_by_work_branch=existing_bindings,
+        current_ref=current_ref,
+        created_at=created_at or datetime.now(UTC),
+    )
+    workspace_restore_ref, workspace_restore_digest = await artifact_writer(
+        "runtime.branch.workspace_restore.json",
+        prepared.workspace_restore_payload,
+        CHECKPOINT_BRANCH_WORKSPACE_RESTORE_CONTENT_TYPE,
+    )
+    git_binding_ref, git_binding_digest = await artifact_writer(
+        "runtime.branch.git_binding.json",
+        prepared.git_binding_payload,
+        CHECKPOINT_BRANCH_GIT_BINDING_CONTENT_TYPE,
+    )
+
+    await _persist_prepared_checkpoint_branch(
+        session=session,
+        prepared=prepared,
+        workspace_restore_ref=workspace_restore_ref,
+        workspace_restore_digest=workspace_restore_digest,
+        git_binding_ref=git_binding_ref,
+        git_binding_digest=git_binding_digest,
+        instruction_ref=instruction_ref,
+        instruction_digest=instruction_digest,
+        source_checkpoint_boundary=source_checkpoint_boundary,
+        root_workflow_id=root_workflow_id,
+        source_run_id=source_run_id,
+        source_execution_ordinal=source_execution_ordinal,
+        parent_branch_id=parent_branch_id,
+        parent_turn_id=parent_turn_id,
+        runtime_context_policy=runtime_context_policy,
+        step_execution_manifest_ref=step_execution_manifest_ref,
+        created_step_execution_id=created_step_execution_id,
+    )
+
+    return CheckpointBranchWorkspacePreparation(
+        branch_id=prepared.binding.product_branch_id,
+        branch_turn_id=prepared.binding.branch_turn_id,
+        git_work_branch=prepared.binding.work_branch,
+        workspace_policy=str(prepared.binding.workspace_policy),
+        workspace_restore_ref=workspace_restore_ref,
+        git_binding_ref=git_binding_ref,
+        workspace_restore_digest=workspace_restore_digest,
+        git_binding_digest=git_binding_digest,
+        binding=prepared,
+    )
+
+
+async def _existing_bindings_by_work_branch(
+    *, session: AsyncSession, repository: str
+) -> dict[str, dict[str, str]]:
+    if not repository:
+        return {}
+    result = await session.execute(
+        select(WorkflowCheckpointBranchGitBinding).where(
+            WorkflowCheckpointBranchGitBinding.repository == repository
+        )
+    )
+    bindings: dict[str, dict[str, str]] = {}
+    for binding in result.scalars():
+        bindings[binding.work_branch] = {
+            "productBranchId": binding.branch_id,
+            "repository": binding.repository,
+        }
+    return bindings
+
+
+async def _persist_prepared_checkpoint_branch(
+    *,
+    session: AsyncSession,
+    prepared: CheckpointBranchGitBindingResult,
+    workspace_restore_ref: str,
+    workspace_restore_digest: str | None,
+    git_binding_ref: str,
+    git_binding_digest: str | None,
+    instruction_ref: str,
+    instruction_digest: str,
+    source_checkpoint_boundary: str,
+    root_workflow_id: str | None,
+    source_run_id: str | None,
+    source_execution_ordinal: int | None,
+    parent_branch_id: str | None,
+    parent_turn_id: str | None,
+    runtime_context_policy: str | None,
+    step_execution_manifest_ref: str | None,
+    created_step_execution_id: str | None,
+) -> None:
+    binding = prepared.binding
+    branch = await session.get(WorkflowCheckpointBranch, binding.product_branch_id)
+    artifact_refs = {
+        "workspace_restore": workspace_restore_ref,
+        "git_binding": git_binding_ref,
+    }
+    if step_execution_manifest_ref:
+        artifact_refs["step_execution_manifest"] = step_execution_manifest_ref
+    diagnostics = dict(prepared.diagnostics)
+    diagnostics["workspaceRestoreRef"] = workspace_restore_ref
+    diagnostics["gitBindingRef"] = git_binding_ref
+    if branch is None:
+        branch = WorkflowCheckpointBranch(
+            branch_id=binding.product_branch_id,
+            workflow_id=str(prepared.diagnostics["workflowId"]),
+            root_workflow_id=root_workflow_id,
+            source_run_id=source_run_id,
+            logical_step_id=binding.logical_step_id,
+            source_execution_ordinal=source_execution_ordinal,
+            source_checkpoint_boundary=source_checkpoint_boundary,
+            source_checkpoint_ref=binding.source_checkpoint_ref,
+            source_checkpoint_digest=binding.source_checkpoint_digest,
+            parent_branch_id=parent_branch_id,
+            parent_turn_id=parent_turn_id,
+            label=None,
+            state="preparing",
+            workspace_policy=str(binding.workspace_policy),
+            runtime_context_policy=runtime_context_policy,
+            git_repository=binding.repository,
+            git_base_branch=binding.base_branch,
+            git_base_commit=binding.base_commit,
+            git_work_branch=binding.work_branch,
+            artifact_refs=artifact_refs,
+            diagnostics=diagnostics,
+        )
+        session.add(branch)
+    else:
+        branch.state = "preparing"
+        branch.workspace_policy = str(binding.workspace_policy)
+        branch.runtime_context_policy = runtime_context_policy
+        branch.logical_step_id = binding.logical_step_id
+        branch.git_repository = binding.repository
+        branch.git_base_branch = binding.base_branch
+        branch.git_base_commit = binding.base_commit
+        branch.git_work_branch = binding.work_branch
+        branch.artifact_refs = {**(branch.artifact_refs or {}), **artifact_refs}
+        branch.diagnostics = {**(branch.diagnostics or {}), **diagnostics}
+
+    git_binding = await session.get(
+        WorkflowCheckpointBranchGitBinding, binding.product_branch_id
+    )
+    binding_metadata = {
+        "binding": prepared.git_binding_payload,
+        "workspaceRestoreArtifact": workspace_restore_ref,
+        "gitBindingArtifact": git_binding_ref,
+    }
+    if git_binding is None:
+        git_binding = WorkflowCheckpointBranchGitBinding(
+            branch_id=binding.product_branch_id,
+            repository=binding.repository,
+            base_branch=binding.base_branch,
+            base_commit=binding.base_commit,
+            work_branch=binding.work_branch,
+            worktree_ref=binding.worktree_ref,
+            provider_workspace_ref=binding.provider_workspace_ref,
+            workspace_policy=str(binding.workspace_policy),
+            creation_mode=str(binding.creation_mode),
+            publish_status=binding.publish_status,
+            binding_metadata=binding_metadata,
+        )
+        session.add(git_binding)
+    else:
+        git_binding.repository = binding.repository
+        git_binding.base_branch = binding.base_branch
+        git_binding.base_commit = binding.base_commit
+        git_binding.work_branch = binding.work_branch
+        git_binding.worktree_ref = binding.worktree_ref
+        git_binding.provider_workspace_ref = binding.provider_workspace_ref
+        git_binding.workspace_policy = str(binding.workspace_policy)
+        git_binding.creation_mode = str(binding.creation_mode)
+        git_binding.binding_metadata = binding_metadata
+
+    if binding.branch_turn_id:
+        await _persist_branch_turn(
+            session=session,
+            prepared=prepared,
+            workspace_restore_ref=workspace_restore_ref,
+            git_binding_ref=git_binding_ref,
+            instruction_ref=instruction_ref,
+            instruction_digest=instruction_digest,
+            parent_turn_id=parent_turn_id,
+            step_execution_manifest_ref=step_execution_manifest_ref,
+            created_step_execution_id=created_step_execution_id,
+        )
+
+    await _upsert_artifact_ref(
+        session=session,
+        branch_id=binding.product_branch_id,
+        branch_turn_id=binding.branch_turn_id,
+        artifact_kind="runtime.branch.workspace_restore.json",
+        artifact_ref=workspace_restore_ref,
+        content_type=CHECKPOINT_BRANCH_WORKSPACE_RESTORE_CONTENT_TYPE,
+        digest=workspace_restore_digest,
+    )
+    await _upsert_artifact_ref(
+        session=session,
+        branch_id=binding.product_branch_id,
+        branch_turn_id=binding.branch_turn_id,
+        artifact_kind="runtime.branch.git_binding.json",
+        artifact_ref=git_binding_ref,
+        content_type=CHECKPOINT_BRANCH_GIT_BINDING_CONTENT_TYPE,
+        digest=git_binding_digest,
+    )
+    await session.flush()
+
+
+async def _persist_branch_turn(
+    *,
+    session: AsyncSession,
+    prepared: CheckpointBranchGitBindingResult,
+    workspace_restore_ref: str,
+    git_binding_ref: str,
+    instruction_ref: str,
+    instruction_digest: str,
+    parent_turn_id: str | None,
+    step_execution_manifest_ref: str | None,
+    created_step_execution_id: str | None,
+) -> None:
+    binding = prepared.binding
+    assert binding.branch_turn_id is not None
+    turn = await session.get(WorkflowCheckpointBranchTurn, binding.branch_turn_id)
+    diagnostics = dict(prepared.branch_turn_metadata or {})
+    diagnostics["gitBinding"] = prepared.diagnostics["gitBinding"]
+    if turn is None:
+        turn = WorkflowCheckpointBranchTurn(
+            branch_turn_id=binding.branch_turn_id,
+            branch_id=binding.product_branch_id,
+            parent_turn_id=parent_turn_id,
+            source_checkpoint_ref=binding.source_checkpoint_ref,
+            source_checkpoint_digest=binding.source_checkpoint_digest,
+            instruction_ref=instruction_ref,
+            instruction_digest=instruction_digest,
+            workspace_policy=str(binding.workspace_policy),
+            git_work_branch=binding.work_branch,
+            workspace_restore_ref=workspace_restore_ref,
+            git_binding_ref=git_binding_ref,
+            step_execution_manifest_ref=step_execution_manifest_ref,
+            created_step_execution_id=created_step_execution_id,
+            idempotency_key=binding.idempotency_key,
+            status="preparing",
+            diagnostics=diagnostics,
+        )
+        session.add(turn)
+        return
+    turn.parent_turn_id = parent_turn_id
+    turn.source_checkpoint_ref = binding.source_checkpoint_ref
+    turn.source_checkpoint_digest = binding.source_checkpoint_digest
+    turn.instruction_ref = instruction_ref
+    turn.instruction_digest = instruction_digest
+    turn.idempotency_key = binding.idempotency_key
+    turn.workspace_policy = str(binding.workspace_policy)
+    turn.git_work_branch = binding.work_branch
+    turn.workspace_restore_ref = workspace_restore_ref
+    turn.git_binding_ref = git_binding_ref
+    turn.step_execution_manifest_ref = step_execution_manifest_ref
+    turn.created_step_execution_id = created_step_execution_id
+    turn.status = "preparing"
+    turn.diagnostics = {**(turn.diagnostics or {}), **diagnostics}
+
+
+async def _upsert_artifact_ref(
+    *,
+    session: AsyncSession,
+    branch_id: str,
+    branch_turn_id: str | None,
+    artifact_kind: str,
+    artifact_ref: str,
+    content_type: str,
+    digest: str | None,
+) -> None:
+    result = await session.execute(
+        select(WorkflowCheckpointBranchArtifact).where(
+            WorkflowCheckpointBranchArtifact.branch_id == branch_id,
+            WorkflowCheckpointBranchArtifact.branch_turn_id == branch_turn_id,
+            WorkflowCheckpointBranchArtifact.artifact_kind == artifact_kind,
+        )
+    )
+    artifact = result.scalar_one_or_none()
+    if artifact is None:
+        session.add(
+            WorkflowCheckpointBranchArtifact(
+                branch_id=branch_id,
+                branch_turn_id=branch_turn_id,
+                artifact_kind=artifact_kind,
+                artifact_ref=artifact_ref,
+                content_type=content_type,
+                digest=digest,
+            )
+        )
+        return
+    artifact.artifact_ref = artifact_ref
+    artifact.content_type = content_type
+    artifact.digest = digest

--- a/moonmind/workflows/checkpoint_branches.py
+++ b/moonmind/workflows/checkpoint_branches.py
@@ -41,6 +41,8 @@ CheckpointBranchBindingFailureCode = Literal[
     "workspace_policy_incompatible",
     "invalid_binding",
 ]
+MAX_GIT_BRANCH_LENGTH = 255
+_GENERATED_BRANCH_COMPONENT_LENGTH = 40
 
 _PROTECTED_REFS = frozenset(
     {
@@ -68,7 +70,7 @@ class CheckpointBranchGitBindingInput(BaseModel):
     product_branch_id: str = Field(
         ..., alias="productBranchId", min_length=1, max_length=255
     )
-    branch_turn_id: str | None = Field(None, alias="branchTurnId", max_length=255)
+    branch_turn_id: str = Field(..., alias="branchTurnId", min_length=1, max_length=255)
     source_checkpoint_ref: str = Field(
         ..., alias="sourceCheckpointRef", min_length=1, max_length=1024
     )
@@ -85,9 +87,7 @@ class CheckpointBranchGitBindingInput(BaseModel):
     idempotency_key: str = Field(
         ..., alias="idempotencyKey", min_length=1, max_length=512
     )
-    requested_work_branch: str | None = Field(
-        None, alias="requestedWorkBranch", max_length=255
-    )
+    requested_work_branch: str | None = Field(None, alias="requestedWorkBranch")
     worktree_ref: str | None = Field(None, alias="worktreeRef", max_length=1024)
     provider_workspace_ref: str | None = Field(
         None, alias="providerWorkspaceRef", max_length=1024
@@ -124,8 +124,9 @@ class CheckpointBranchGitBindingModel(BaseModel):
     model_config = ConfigDict(populate_by_name=True, extra="forbid")
 
     product_branch_id: str = Field(..., alias="productBranchId")
-    branch_turn_id: str | None = Field(None, alias="branchTurnId")
+    branch_turn_id: str = Field(..., alias="branchTurnId")
     logical_step_id: str | None = Field(None, alias="logicalStepId")
+    label: str | None = None
     idempotency_key: str = Field(..., alias="idempotencyKey")
     repository: str
     base_branch: str = Field(..., alias="baseBranch")
@@ -175,8 +176,12 @@ def generate_checkpoint_branch_name(
 ) -> str:
     """Generate a deterministic sanitized checkpoint branch work ref."""
 
-    workflow_slug = sanitize_branch_component(workflow_id)
-    step_slug = sanitize_branch_component(logical_step_id or "workflow")
+    workflow_slug = sanitize_branch_component(workflow_id)[
+        :_GENERATED_BRANCH_COMPONENT_LENGTH
+    ]
+    step_slug = sanitize_branch_component(logical_step_id or "workflow")[
+        :_GENERATED_BRANCH_COMPONENT_LENGTH
+    ]
     checkpoint_source = f"{checkpoint_ref}:{idempotency_key}"
     checkpoint_short = hashlib.sha256(
         checkpoint_source.encode("utf-8")
@@ -207,7 +212,8 @@ def prepare_checkpoint_branch_git_binding(
         ) from exc
 
     _validate_ref_is_not_detached(current_ref)
-    _validate_base_ref(model.base_branch, known_refs)
+    normalized_known_refs = {_normalize_ref(ref) for ref in known_refs}
+    _validate_base_ref(model.base_branch, normalized_known_refs)
     work_branch = model.requested_work_branch or generate_checkpoint_branch_name(
         workflow_id=model.workflow_id,
         logical_step_id=model.logical_step_id,
@@ -222,6 +228,7 @@ def prepare_checkpoint_branch_git_binding(
         model=model,
         work_branch=work_branch,
         existing_bindings_by_work_branch=existing_bindings_by_work_branch or {},
+        normalized_known_refs=normalized_known_refs,
     )
 
     now = created_at or datetime.now(UTC)
@@ -229,6 +236,7 @@ def prepare_checkpoint_branch_git_binding(
         productBranchId=model.product_branch_id,
         branchTurnId=model.branch_turn_id,
         logicalStepId=model.logical_step_id,
+        label=model.label,
         idempotencyKey=model.idempotency_key,
         repository=model.repository,
         baseBranch=model.base_branch,
@@ -250,14 +258,12 @@ def prepare_checkpoint_branch_git_binding(
         "workspaceMode": model.creation_mode,
         "gitBinding": binding_payload,
     }
-    turn_metadata = None
-    if model.branch_turn_id:
-        turn_metadata = {
-            "branchId": model.product_branch_id,
-            "branchTurnId": model.branch_turn_id,
-            "workspacePolicy": model.workspace_policy,
-            "gitWorkBranch": work_branch,
-        }
+    turn_metadata = {
+        "branchId": model.product_branch_id,
+        "branchTurnId": model.branch_turn_id,
+        "workspacePolicy": model.workspace_policy,
+        "gitWorkBranch": work_branch,
+    }
     workspace_restore = {
         "contentType": CHECKPOINT_BRANCH_WORKSPACE_RESTORE_CONTENT_TYPE,
         "workflowId": model.workflow_id,
@@ -330,17 +336,13 @@ def _validate_ref_is_not_detached(current_ref: str | None) -> None:
         )
 
 
-def _validate_base_ref(base_branch: str, known_refs: set[str] | frozenset[str]) -> None:
+def _validate_base_ref(base_branch: str, normalized_known_refs: set[str]) -> None:
     normalized = _normalize_ref(base_branch)
-    if normalized in _PROTECTED_REFS:
-        raise CheckpointBranchGitBindingError(
-            "protected_branch_ref", f"base ref {base_branch!r} is protected"
-        )
     if _HEX_COMMIT_RE.fullmatch(base_branch):
         raise CheckpointBranchGitBindingError(
             "detached_head", "base ref must be a named branch, not a detached commit"
         )
-    if not known_refs or base_branch not in known_refs:
+    if not normalized_known_refs or normalized not in normalized_known_refs:
         raise CheckpointBranchGitBindingError(
             "unknown_ref", f"base ref {base_branch!r} is not a known repository ref"
         )
@@ -348,21 +350,31 @@ def _validate_base_ref(base_branch: str, known_refs: set[str] | frozenset[str]) 
 
 def _validate_work_branch(work_branch: str) -> None:
     normalized = _normalize_ref(work_branch)
+    branch_parts = work_branch.split("/")
+    if len(work_branch) > MAX_GIT_BRANCH_LENGTH:
+        raise CheckpointBranchGitBindingError(
+            "protected_branch_ref",
+            f"work branch {work_branch!r} exceeds maximum length of 255 characters",
+        )
     if (
         normalized in _PROTECTED_REFS
         or work_branch.startswith("refs/")
         or work_branch.startswith("/")
         or work_branch.endswith("/")
+        or work_branch.endswith(".")
         or work_branch.endswith(".lock")
+        or any(part.startswith(".") for part in branch_parts)
+        or any(part.endswith(".lock") for part in branch_parts)
     ):
         raise CheckpointBranchGitBindingError(
             "protected_branch_ref", f"work branch {work_branch!r} is not allowed"
         )
-    branch_parts = work_branch.split("/")
     if (
         work_branch.strip() != work_branch
         or "//" in work_branch
         or ".." in work_branch
+        or "@{" in work_branch
+        or "\\" in work_branch
         or any(part != sanitize_branch_component(part) for part in branch_parts)
     ):
         raise CheckpointBranchGitBindingError(
@@ -389,23 +401,28 @@ def _validate_collision(
     model: CheckpointBranchGitBindingInput,
     work_branch: str,
     existing_bindings_by_work_branch: Mapping[str, Mapping[str, Any]],
+    normalized_known_refs: set[str],
 ) -> None:
     existing = existing_bindings_by_work_branch.get(work_branch)
-    if not existing:
-        return
-    existing_branch_id = str(
-        existing.get("productBranchId") or existing.get("branch_id") or ""
-    ).strip()
-    existing_repository = str(existing.get("repository") or "").strip()
-    if (
-        existing_branch_id == model.product_branch_id
-        and existing_repository == model.repository
-    ):
-        return
-    raise CheckpointBranchGitBindingError(
-        "git_branch_collision",
-        "existing work branch belongs to a different checkpoint branch binding",
-    )
+    if existing:
+        existing_branch_id = str(
+            existing.get("productBranchId") or existing.get("branch_id") or ""
+        ).strip()
+        existing_repository = str(existing.get("repository") or "").strip()
+        if (
+            existing_branch_id == model.product_branch_id
+            and existing_repository.lower() == model.repository.lower()
+        ):
+            return
+        raise CheckpointBranchGitBindingError(
+            "git_branch_collision",
+            "existing work branch belongs to a different checkpoint branch binding",
+        )
+    if _normalize_ref(work_branch) in normalized_known_refs:
+        raise CheckpointBranchGitBindingError(
+            "git_branch_collision",
+            f"work branch {work_branch!r} already exists as a repository ref",
+        )
 
 
 def _normalize_ref(ref: str) -> str:

--- a/moonmind/workflows/checkpoint_branches.py
+++ b/moonmind/workflows/checkpoint_branches.py
@@ -125,6 +125,8 @@ class CheckpointBranchGitBindingModel(BaseModel):
 
     product_branch_id: str = Field(..., alias="productBranchId")
     branch_turn_id: str | None = Field(None, alias="branchTurnId")
+    logical_step_id: str | None = Field(None, alias="logicalStepId")
+    idempotency_key: str = Field(..., alias="idempotencyKey")
     repository: str
     base_branch: str = Field(..., alias="baseBranch")
     base_commit: str | None = Field(None, alias="baseCommit")
@@ -226,6 +228,8 @@ def prepare_checkpoint_branch_git_binding(
     binding = CheckpointBranchGitBindingModel(
         productBranchId=model.product_branch_id,
         branchTurnId=model.branch_turn_id,
+        logicalStepId=model.logical_step_id,
+        idempotencyKey=model.idempotency_key,
         repository=model.repository,
         baseBranch=model.base_branch,
         baseCommit=model.base_commit,
@@ -259,6 +263,7 @@ def prepare_checkpoint_branch_git_binding(
         "workflowId": model.workflow_id,
         "productBranchId": model.product_branch_id,
         "branchTurnId": model.branch_turn_id,
+        "logicalStepId": model.logical_step_id,
         "sourceCheckpointRef": model.source_checkpoint_ref,
         "sourceCheckpointDigest": model.source_checkpoint_digest,
         "workspacePolicy": model.workspace_policy,
@@ -279,6 +284,7 @@ def prepare_checkpoint_branch_git_binding(
         "workflowId": model.workflow_id,
         "productBranchId": model.product_branch_id,
         "branchTurnId": model.branch_turn_id,
+        "logicalStepId": model.logical_step_id,
         "workspacePolicy": model.workspace_policy,
         "creationMode": model.creation_mode,
         "gitBinding": {
@@ -373,7 +379,8 @@ def _validate_workspace_isolation(
     if not isolated:
         raise CheckpointBranchGitBindingError(
             "workspace_policy_incompatible",
-            "repository-mutating checkpoint branches require git/worktree/provider isolation",
+            "repository-mutating checkpoint branches require "
+            "git/worktree/provider isolation",
         )
 
 

--- a/moonmind/workflows/checkpoint_branches.py
+++ b/moonmind/workflows/checkpoint_branches.py
@@ -1,0 +1,405 @@
+"""Checkpoint Branch git binding helpers for MM-1090.
+
+These helpers stay outside Temporal workflow code so launch activities and API
+services can validate workspace/git isolation before starting repository-
+mutating branch work.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
+
+from moonmind.schemas.temporal_models import WorkspacePolicy
+from moonmind.workflows.automation.workspace import sanitize_branch_component
+
+CHECKPOINT_BRANCH_WORKSPACE_RESTORE_CONTENT_TYPE = (
+    "application/vnd.moonmind.checkpoint-branch.workspace-restore+json;version=1"
+)
+CHECKPOINT_BRANCH_GIT_BINDING_CONTENT_TYPE = (
+    "application/vnd.moonmind.checkpoint-branch.git-binding+json;version=1"
+)
+
+CheckpointBranchCreationMode = Literal[
+    "from_checkpoint_worktree",
+    "from_checkpoint_patch",
+    "from_last_accepted_commit",
+    "fresh_from_source_branch",
+    "external_provider_state",
+]
+CheckpointBranchBindingFailureCode = Literal[
+    "detached_head",
+    "git_branch_collision",
+    "protected_branch_ref",
+    "unknown_ref",
+    "workspace_policy_incompatible",
+    "invalid_binding",
+]
+
+_PROTECTED_REFS = frozenset(
+    {
+        "",
+        "head",
+        "main",
+        "master",
+        "trunk",
+        "develop",
+        "development",
+        "release",
+        "stable",
+        "production",
+    }
+)
+_HEX_COMMIT_RE = re.compile(r"^[0-9a-f]{7,40}$", re.IGNORECASE)
+
+
+class CheckpointBranchGitBindingInput(BaseModel):
+    """Validated input for preparing one checkpoint branch git binding."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    workflow_id: str = Field(..., alias="workflowId", min_length=1, max_length=255)
+    product_branch_id: str = Field(
+        ..., alias="productBranchId", min_length=1, max_length=255
+    )
+    branch_turn_id: str | None = Field(None, alias="branchTurnId", max_length=255)
+    source_checkpoint_ref: str = Field(
+        ..., alias="sourceCheckpointRef", min_length=1, max_length=1024
+    )
+    source_checkpoint_digest: str | None = Field(
+        None, alias="sourceCheckpointDigest", max_length=128
+    )
+    logical_step_id: str | None = Field(None, alias="logicalStepId", max_length=255)
+    label: str | None = Field(None, max_length=255)
+    repository: str = Field(..., min_length=1, max_length=512)
+    base_branch: str = Field(..., alias="baseBranch", min_length=1, max_length=255)
+    base_commit: str | None = Field(None, alias="baseCommit", max_length=128)
+    workspace_policy: WorkspacePolicy = Field(..., alias="workspacePolicy")
+    creation_mode: CheckpointBranchCreationMode = Field(..., alias="creationMode")
+    idempotency_key: str = Field(
+        ..., alias="idempotencyKey", min_length=1, max_length=512
+    )
+    requested_work_branch: str | None = Field(
+        None, alias="requestedWorkBranch", max_length=255
+    )
+    worktree_ref: str | None = Field(None, alias="worktreeRef", max_length=1024)
+    provider_workspace_ref: str | None = Field(
+        None, alias="providerWorkspaceRef", max_length=1024
+    )
+
+    @field_validator(
+        "workflow_id",
+        "product_branch_id",
+        "branch_turn_id",
+        "source_checkpoint_ref",
+        "source_checkpoint_digest",
+        "logical_step_id",
+        "label",
+        "repository",
+        "base_branch",
+        "base_commit",
+        "idempotency_key",
+        "requested_work_branch",
+        "worktree_ref",
+        "provider_workspace_ref",
+        mode="before",
+    )
+    @classmethod
+    def _strip_text(cls, value: Any) -> str | None:
+        if value is None:
+            return None
+        candidate = str(value).strip()
+        return candidate or None
+
+
+class CheckpointBranchGitBindingModel(BaseModel):
+    """Compact binding record separating product branch id from git work branch."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    product_branch_id: str = Field(..., alias="productBranchId")
+    branch_turn_id: str | None = Field(None, alias="branchTurnId")
+    repository: str
+    base_branch: str = Field(..., alias="baseBranch")
+    base_commit: str | None = Field(None, alias="baseCommit")
+    work_branch: str = Field(..., alias="workBranch")
+    worktree_ref: str | None = Field(None, alias="worktreeRef")
+    provider_workspace_ref: str | None = Field(None, alias="providerWorkspaceRef")
+    workspace_policy: WorkspacePolicy = Field(..., alias="workspacePolicy")
+    creation_mode: CheckpointBranchCreationMode = Field(..., alias="creationMode")
+    source_checkpoint_ref: str = Field(..., alias="sourceCheckpointRef")
+    source_checkpoint_digest: str | None = Field(
+        None, alias="sourceCheckpointDigest"
+    )
+    publish_status: str = Field("not_published", alias="publishStatus")
+    created_at: datetime = Field(..., alias="createdAt")
+
+
+@dataclass(frozen=True)
+class CheckpointBranchGitBindingResult:
+    """Prepared binding and branch-level evidence payloads."""
+
+    binding: CheckpointBranchGitBindingModel
+    workspace_restore_payload: dict[str, Any]
+    git_binding_payload: dict[str, Any]
+    branch_metadata: dict[str, Any]
+    branch_turn_metadata: dict[str, Any] | None
+    step_execution_manifest_branch: dict[str, Any]
+    diagnostics: dict[str, Any]
+
+
+class CheckpointBranchGitBindingError(ValueError):
+    """Fail-closed checkpoint branch binding validation error."""
+
+    def __init__(self, failure_code: CheckpointBranchBindingFailureCode, message: str):
+        super().__init__(message)
+        self.failure_code = failure_code
+
+
+def generate_checkpoint_branch_name(
+    *,
+    workflow_id: str,
+    logical_step_id: str | None,
+    checkpoint_ref: str,
+    product_branch_id: str,
+    label: str | None,
+    idempotency_key: str,
+) -> str:
+    """Generate a deterministic sanitized checkpoint branch work ref."""
+
+    workflow_slug = sanitize_branch_component(workflow_id)
+    step_slug = sanitize_branch_component(logical_step_id or "workflow")
+    checkpoint_source = f"{checkpoint_ref}:{idempotency_key}"
+    checkpoint_short = hashlib.sha256(
+        checkpoint_source.encode("utf-8")
+    ).hexdigest()[:8]
+    branch_slug = sanitize_branch_component(product_branch_id)[:16]
+    label_slug = sanitize_branch_component(label or idempotency_key)[:48]
+    return (
+        f"mm/{workflow_slug}/{step_slug}/cp-{checkpoint_short}/"
+        f"{branch_slug}-{label_slug}"
+    )
+
+
+def prepare_checkpoint_branch_git_binding(
+    raw_input: Mapping[str, Any],
+    *,
+    known_refs: set[str] | frozenset[str],
+    existing_bindings_by_work_branch: Mapping[str, Mapping[str, Any]] | None = None,
+    current_ref: str | None = None,
+    created_at: datetime | None = None,
+) -> CheckpointBranchGitBindingResult:
+    """Validate and build binding/artifact payloads for checkpoint branch launch."""
+
+    try:
+        model = CheckpointBranchGitBindingInput.model_validate(raw_input)
+    except ValidationError as exc:
+        raise CheckpointBranchGitBindingError(
+            "invalid_binding", f"checkpoint branch git binding input invalid: {exc}"
+        ) from exc
+
+    _validate_ref_is_not_detached(current_ref)
+    _validate_base_ref(model.base_branch, known_refs)
+    work_branch = model.requested_work_branch or generate_checkpoint_branch_name(
+        workflow_id=model.workflow_id,
+        logical_step_id=model.logical_step_id,
+        checkpoint_ref=model.source_checkpoint_ref,
+        product_branch_id=model.product_branch_id,
+        label=model.label,
+        idempotency_key=model.idempotency_key,
+    )
+    _validate_work_branch(work_branch)
+    _validate_workspace_isolation(model, work_branch)
+    _validate_collision(
+        model=model,
+        work_branch=work_branch,
+        existing_bindings_by_work_branch=existing_bindings_by_work_branch or {},
+    )
+
+    now = created_at or datetime.now(UTC)
+    binding = CheckpointBranchGitBindingModel(
+        productBranchId=model.product_branch_id,
+        branchTurnId=model.branch_turn_id,
+        repository=model.repository,
+        baseBranch=model.base_branch,
+        baseCommit=model.base_commit,
+        workBranch=work_branch,
+        worktreeRef=model.worktree_ref,
+        providerWorkspaceRef=model.provider_workspace_ref,
+        workspacePolicy=model.workspace_policy,
+        creationMode=model.creation_mode,
+        sourceCheckpointRef=model.source_checkpoint_ref,
+        sourceCheckpointDigest=model.source_checkpoint_digest,
+        createdAt=now,
+    )
+    binding_payload = binding.model_dump(by_alias=True, mode="json")
+    branch_metadata = {
+        "branchId": model.product_branch_id,
+        "gitWorkBranch": work_branch,
+        "workspacePolicy": model.workspace_policy,
+        "workspaceMode": model.creation_mode,
+        "gitBinding": binding_payload,
+    }
+    turn_metadata = None
+    if model.branch_turn_id:
+        turn_metadata = {
+            "branchId": model.product_branch_id,
+            "branchTurnId": model.branch_turn_id,
+            "workspacePolicy": model.workspace_policy,
+            "gitWorkBranch": work_branch,
+        }
+    workspace_restore = {
+        "contentType": CHECKPOINT_BRANCH_WORKSPACE_RESTORE_CONTENT_TYPE,
+        "workflowId": model.workflow_id,
+        "productBranchId": model.product_branch_id,
+        "branchTurnId": model.branch_turn_id,
+        "sourceCheckpointRef": model.source_checkpoint_ref,
+        "sourceCheckpointDigest": model.source_checkpoint_digest,
+        "workspacePolicy": model.workspace_policy,
+        "creationMode": model.creation_mode,
+        "repository": model.repository,
+        "baseBranch": model.base_branch,
+        "baseCommit": model.base_commit,
+        "workBranch": work_branch,
+        "worktreeRef": model.worktree_ref,
+        "providerWorkspaceRef": model.provider_workspace_ref,
+        "createdAt": now.isoformat(),
+    }
+    git_binding = {
+        "contentType": CHECKPOINT_BRANCH_GIT_BINDING_CONTENT_TYPE,
+        **binding_payload,
+    }
+    diagnostics = {
+        "workflowId": model.workflow_id,
+        "productBranchId": model.product_branch_id,
+        "branchTurnId": model.branch_turn_id,
+        "workspacePolicy": model.workspace_policy,
+        "creationMode": model.creation_mode,
+        "gitBinding": {
+            "repository": model.repository,
+            "baseBranch": model.base_branch,
+            "baseCommit": model.base_commit,
+            "workBranch": work_branch,
+            "worktreeRef": model.worktree_ref,
+            "providerWorkspaceRef": model.provider_workspace_ref,
+        },
+        "evidence": {
+            "workspaceRestoreArtifact": "runtime.branch.workspace_restore.json",
+            "gitBindingArtifact": "runtime.branch.git_binding.json",
+        },
+    }
+    manifest_branch = {
+        "branchId": model.product_branch_id,
+        "branchTurnId": model.branch_turn_id,
+        "rootCheckpointRef": model.source_checkpoint_ref,
+        "workspacePolicy": model.workspace_policy,
+        "gitWorkBranch": work_branch,
+        "gitBindingArtifact": "runtime.branch.git_binding.json",
+        "workspaceRestoreArtifact": "runtime.branch.workspace_restore.json",
+    }
+    return CheckpointBranchGitBindingResult(
+        binding=binding,
+        workspace_restore_payload=workspace_restore,
+        git_binding_payload=git_binding,
+        branch_metadata=branch_metadata,
+        branch_turn_metadata=turn_metadata,
+        step_execution_manifest_branch=manifest_branch,
+        diagnostics=diagnostics,
+    )
+
+
+def _validate_ref_is_not_detached(current_ref: str | None) -> None:
+    if current_ref is None:
+        return
+    ref = current_ref.strip()
+    if not ref or ref.upper() == "HEAD" or _HEX_COMMIT_RE.fullmatch(ref):
+        raise CheckpointBranchGitBindingError(
+            "detached_head", "checkpoint branch launch requires an attached git ref"
+        )
+
+
+def _validate_base_ref(base_branch: str, known_refs: set[str] | frozenset[str]) -> None:
+    normalized = _normalize_ref(base_branch)
+    if normalized in _PROTECTED_REFS:
+        raise CheckpointBranchGitBindingError(
+            "protected_branch_ref", f"base ref {base_branch!r} is protected"
+        )
+    if _HEX_COMMIT_RE.fullmatch(base_branch):
+        raise CheckpointBranchGitBindingError(
+            "detached_head", "base ref must be a named branch, not a detached commit"
+        )
+    if not known_refs or base_branch not in known_refs:
+        raise CheckpointBranchGitBindingError(
+            "unknown_ref", f"base ref {base_branch!r} is not a known repository ref"
+        )
+
+
+def _validate_work_branch(work_branch: str) -> None:
+    normalized = _normalize_ref(work_branch)
+    if (
+        normalized in _PROTECTED_REFS
+        or work_branch.startswith("refs/")
+        or work_branch.startswith("/")
+        or work_branch.endswith("/")
+        or work_branch.endswith(".lock")
+    ):
+        raise CheckpointBranchGitBindingError(
+            "protected_branch_ref", f"work branch {work_branch!r} is not allowed"
+        )
+    branch_parts = work_branch.split("/")
+    if (
+        work_branch.strip() != work_branch
+        or "//" in work_branch
+        or ".." in work_branch
+        or any(part != sanitize_branch_component(part) for part in branch_parts)
+    ):
+        raise CheckpointBranchGitBindingError(
+            "protected_branch_ref", f"work branch {work_branch!r} is not sanitized"
+        )
+
+
+def _validate_workspace_isolation(
+    model: CheckpointBranchGitBindingInput, work_branch: str
+) -> None:
+    isolated = bool(work_branch) or bool(model.worktree_ref) or bool(
+        model.provider_workspace_ref
+    )
+    if not isolated:
+        raise CheckpointBranchGitBindingError(
+            "workspace_policy_incompatible",
+            "repository-mutating checkpoint branches require git/worktree/provider isolation",
+        )
+
+
+def _validate_collision(
+    *,
+    model: CheckpointBranchGitBindingInput,
+    work_branch: str,
+    existing_bindings_by_work_branch: Mapping[str, Mapping[str, Any]],
+) -> None:
+    existing = existing_bindings_by_work_branch.get(work_branch)
+    if not existing:
+        return
+    existing_branch_id = str(
+        existing.get("productBranchId") or existing.get("branch_id") or ""
+    ).strip()
+    existing_repository = str(existing.get("repository") or "").strip()
+    if (
+        existing_branch_id == model.product_branch_id
+        and existing_repository == model.repository
+    ):
+        return
+    raise CheckpointBranchGitBindingError(
+        "git_branch_collision",
+        "existing work branch belongs to a different checkpoint branch binding",
+    )
+
+
+def _normalize_ref(ref: str) -> str:
+    return ref.strip().removeprefix("refs/heads/").lower()

--- a/tests/unit/api/db/test_models.py
+++ b/tests/unit/api/db/test_models.py
@@ -2,7 +2,14 @@ from fastapi_users.db import SQLAlchemyBaseUserTable
 from sqlalchemy import inspect
 from sqlalchemy.orm import DeclarativeBase
 
-from api_service.db.models import Base, User
+from api_service.db.models import (
+    Base,
+    User,
+    WorkflowCheckpointBranch,
+    WorkflowCheckpointBranchArtifact,
+    WorkflowCheckpointBranchGitBinding,
+    WorkflowCheckpointBranchTurn,
+)
 
 def test_user_model_inheritance():
     """Test that the User model inherits from SQLAlchemyBaseUserTable and Base."""
@@ -50,3 +57,42 @@ def test_user_model_columns():
 def test_base_model_inheritance():
     """Test that the Base model inherits from DeclarativeBase."""
     assert issubclass(Base, DeclarativeBase)
+
+
+def test_checkpoint_branch_persistence_models_expose_binding_columns():
+    """MM-1090 requires product branch and git work branch to be persisted separately."""
+
+    branch_columns = set(inspect(WorkflowCheckpointBranch).columns.keys())
+    turn_columns = set(inspect(WorkflowCheckpointBranchTurn).columns.keys())
+    binding_columns = set(inspect(WorkflowCheckpointBranchGitBinding).columns.keys())
+    artifact_columns = set(inspect(WorkflowCheckpointBranchArtifact).columns.keys())
+
+    assert {"branch_id", "workspace_policy", "git_work_branch"} <= branch_columns
+    assert {
+        "branch_turn_id",
+        "branch_id",
+        "workspace_policy",
+        "git_work_branch",
+        "workspace_restore_ref",
+        "git_binding_ref",
+        "step_execution_manifest_ref",
+    } <= turn_columns
+    assert {
+        "branch_id",
+        "repository",
+        "base_branch",
+        "base_commit",
+        "work_branch",
+        "worktree_ref",
+        "provider_workspace_ref",
+        "workspace_policy",
+        "creation_mode",
+        "binding_metadata",
+    } <= binding_columns
+    assert {
+        "branch_id",
+        "branch_turn_id",
+        "artifact_kind",
+        "artifact_ref",
+        "content_type",
+    } <= artifact_columns

--- a/tests/unit/services/test_checkpoint_branches_service.py
+++ b/tests/unit/services/test_checkpoint_branches_service.py
@@ -1,0 +1,231 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+from api_service.db.models import (
+    Base,
+    WorkflowCheckpointBranch,
+    WorkflowCheckpointBranchArtifact,
+    WorkflowCheckpointBranchGitBinding,
+    WorkflowCheckpointBranchTurn,
+)
+from api_service.services.checkpoint_branches import (
+    prepare_checkpoint_branch_workspace,
+)
+from moonmind.workflows.checkpoint_branches import CheckpointBranchGitBindingError
+
+pytestmark = [pytest.mark.asyncio]
+
+
+def _binding_input(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "workflowId": "MM-1087 Workflow",
+        "productBranchId": "cbr_MM-1090",
+        "branchTurnId": "cbt_MM-1090_1",
+        "sourceCheckpointRef": "artifact://checkpoint/root",
+        "sourceCheckpointDigest": "sha256:checkpoint",
+        "logicalStepId": "Implement MM-1090",
+        "label": "Fix Git Isolation",
+        "repository": "MoonLadderStudios/MoonMind",
+        "baseBranch": "feature/mm-1087-source",
+        "baseCommit": "abc1234",
+        "workspacePolicy": "apply_previous_execution_diff_to_clean_baseline",
+        "creationMode": "from_checkpoint_patch",
+        "idempotencyKey": "MM-1090:MM-1087:checkpoint",
+        "requestedWorkBranch": (
+            "mm/mm-1087-workflow/implement-mm-1090/cp-12345678/"
+            "cbr-mm-1090-fix-git-isolation"
+        ),
+    }
+    payload.update(overrides)
+    return payload
+
+
+@pytest_asyncio.fixture()
+async def session(tmp_path) -> AsyncSession:
+    engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path}/checkpoint.db")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    async_session_maker = sessionmaker(
+        engine,
+        class_=AsyncSession,
+        expire_on_commit=False,
+    )
+    async with async_session_maker() as db_session:
+        yield db_session
+    await engine.dispose()
+
+
+async def test_prepare_checkpoint_branch_workspace_persists_binding_and_artifacts(
+    session: AsyncSession,
+) -> None:
+    emitted: list[tuple[str, Mapping[str, Any], str]] = []
+
+    async def write_artifact(
+        artifact_kind: str,
+        payload: Mapping[str, Any],
+        content_type: str,
+    ) -> tuple[str, str]:
+        emitted.append((artifact_kind, payload, content_type))
+        return f"artifact://MM-1090/{artifact_kind}", f"sha256:{artifact_kind}"
+
+    result = await prepare_checkpoint_branch_workspace(
+        session=session,
+        binding_input=_binding_input(),
+        known_refs={"feature/mm-1087-source"},
+        current_ref="feature/mm-1087-source",
+        instruction_ref="artifact://MM-1090/input.branch_turn.instructions.md",
+        instruction_digest="sha256:instructions",
+        artifact_writer=write_artifact,
+        root_workflow_id="MM-1087",
+        source_run_id="run-MM-1087",
+        source_execution_ordinal=1,
+        step_execution_manifest_ref=(
+            "artifact://MM-1090/output.branch_turn.step_execution_manifest.json"
+        ),
+        created_step_execution_id="step-MM-1090",
+    )
+    await session.commit()
+
+    assert result.branch_id == "cbr_MM-1090"
+    assert result.branch_turn_id == "cbt_MM-1090_1"
+    assert result.git_work_branch.startswith("mm/mm-1087-workflow/")
+    assert [item[0] for item in emitted] == [
+        "runtime.branch.workspace_restore.json",
+        "runtime.branch.git_binding.json",
+    ]
+    assert emitted[0][1]["productBranchId"] == "cbr_MM-1090"
+    assert emitted[1][1]["productBranchId"] == "cbr_MM-1090"
+    assert emitted[0][1]["workspacePolicy"] == (
+        "apply_previous_execution_diff_to_clean_baseline"
+    )
+
+    branch = await session.get(WorkflowCheckpointBranch, "cbr_MM-1090")
+    assert branch is not None
+    assert branch.logical_step_id == "Implement MM-1090"
+    assert branch.workspace_policy == "apply_previous_execution_diff_to_clean_baseline"
+    assert branch.git_work_branch == result.git_work_branch
+    assert branch.artifact_refs["workspace_restore"] == result.workspace_restore_ref
+    assert branch.artifact_refs["git_binding"] == result.git_binding_ref
+    assert branch.diagnostics["workspacePolicy"] == branch.workspace_policy
+
+    turn = await session.get(WorkflowCheckpointBranchTurn, "cbt_MM-1090_1")
+    assert turn is not None
+    assert turn.branch_id == "cbr_MM-1090"
+    assert turn.workspace_policy == branch.workspace_policy
+    assert turn.git_work_branch == result.git_work_branch
+    assert turn.workspace_restore_ref == result.workspace_restore_ref
+    assert turn.git_binding_ref == result.git_binding_ref
+    assert turn.step_execution_manifest_ref == (
+        "artifact://MM-1090/output.branch_turn.step_execution_manifest.json"
+    )
+
+    binding = await session.get(WorkflowCheckpointBranchGitBinding, "cbr_MM-1090")
+    assert binding is not None
+    assert binding.work_branch == result.git_work_branch
+    assert binding.branch_id != binding.work_branch
+    assert binding.binding_metadata["gitBindingArtifact"] == result.git_binding_ref
+
+    artifacts = (
+        await session.execute(select(WorkflowCheckpointBranchArtifact))
+    ).scalars().all()
+    assert {artifact.artifact_kind for artifact in artifacts} == {
+        "runtime.branch.workspace_restore.json",
+        "runtime.branch.git_binding.json",
+    }
+
+
+async def test_prepare_checkpoint_branch_workspace_reuses_matching_binding(
+    session: AsyncSession,
+) -> None:
+    emitted_count = 0
+
+    async def write_artifact(
+        artifact_kind: str,
+        payload: Mapping[str, Any],
+        content_type: str,
+    ) -> tuple[str, None]:
+        nonlocal emitted_count
+        emitted_count += 1
+        return f"artifact://MM-1090/{emitted_count}/{artifact_kind}", None
+
+    kwargs = {
+        "session": session,
+        "binding_input": _binding_input(),
+        "known_refs": {"feature/mm-1087-source"},
+        "current_ref": "feature/mm-1087-source",
+        "instruction_ref": "artifact://MM-1090/input.branch_turn.instructions.md",
+        "instruction_digest": "sha256:instructions",
+        "artifact_writer": write_artifact,
+    }
+
+    first = await prepare_checkpoint_branch_workspace(**kwargs)
+    second = await prepare_checkpoint_branch_workspace(**kwargs)
+
+    assert second.git_work_branch == first.git_work_branch
+    assert emitted_count == 4
+    artifacts = (
+        await session.execute(select(WorkflowCheckpointBranchArtifact))
+    ).scalars().all()
+    assert len(artifacts) == 2
+
+
+async def test_prepare_checkpoint_branch_workspace_rejects_mismatched_collision(
+    session: AsyncSession,
+) -> None:
+    session.add(
+        WorkflowCheckpointBranch(
+            branch_id="cbr_other",
+            workflow_id="MM-1087",
+            source_checkpoint_boundary="after_execution",
+            source_checkpoint_ref="artifact://checkpoint/other",
+            workspace_policy="apply_previous_execution_diff_to_clean_baseline",
+            git_repository="MoonLadderStudios/MoonMind",
+            git_base_branch="feature/mm-1087-source",
+            git_work_branch=(
+                "mm/mm-1087-workflow/implement-mm-1090/cp-12345678/"
+                "cbr-mm-1090-fix-git-isolation"
+            ),
+        )
+    )
+    session.add(
+        WorkflowCheckpointBranchGitBinding(
+            branch_id="cbr_other",
+            repository="MoonLadderStudios/MoonMind",
+            base_branch="feature/mm-1087-source",
+            work_branch=(
+                "mm/mm-1087-workflow/implement-mm-1090/cp-12345678/"
+                "cbr-mm-1090-fix-git-isolation"
+            ),
+            workspace_policy="apply_previous_execution_diff_to_clean_baseline",
+            creation_mode="from_checkpoint_patch",
+        )
+    )
+    await session.flush()
+
+    async def write_artifact(
+        artifact_kind: str,
+        payload: Mapping[str, Any],
+        content_type: str,
+    ) -> tuple[str, None]:
+        raise AssertionError("collision must fail before artifact emission")
+
+    with pytest.raises(CheckpointBranchGitBindingError) as exc_info:
+        await prepare_checkpoint_branch_workspace(
+            session=session,
+            binding_input=_binding_input(),
+            known_refs={"feature/mm-1087-source"},
+            current_ref="feature/mm-1087-source",
+            instruction_ref="artifact://MM-1090/input.branch_turn.instructions.md",
+            instruction_digest="sha256:instructions",
+            artifact_writer=write_artifact,
+        )
+
+    assert exc_info.value.failure_code == "git_branch_collision"

--- a/tests/unit/services/test_checkpoint_branches_service.py
+++ b/tests/unit/services/test_checkpoint_branches_service.py
@@ -17,6 +17,7 @@ from api_service.db.models import (
     WorkflowCheckpointBranchTurn,
 )
 from api_service.services.checkpoint_branches import (
+    _existing_bindings_by_work_branch,
     prepare_checkpoint_branch_workspace,
 )
 from moonmind.workflows.checkpoint_branches import CheckpointBranchGitBindingError
@@ -110,6 +111,7 @@ async def test_prepare_checkpoint_branch_workspace_persists_binding_and_artifact
     branch = await session.get(WorkflowCheckpointBranch, "cbr_MM-1090")
     assert branch is not None
     assert branch.logical_step_id == "Implement MM-1090"
+    assert branch.label == "Fix Git Isolation"
     assert branch.workspace_policy == "apply_previous_execution_diff_to_clean_baseline"
     assert branch.git_work_branch == result.git_work_branch
     assert branch.artifact_refs["workspace_restore"] == result.workspace_restore_ref
@@ -175,6 +177,105 @@ async def test_prepare_checkpoint_branch_workspace_reuses_matching_binding(
         await session.execute(select(WorkflowCheckpointBranchArtifact))
     ).scalars().all()
     assert len(artifacts) == 2
+
+
+async def test_prepare_checkpoint_branch_workspace_validates_input_before_query(
+    session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fail_query(*args: object, **kwargs: object) -> dict[str, dict[str, str]]:
+        raise AssertionError("input validation must run before database lookup")
+
+    monkeypatch.setattr(
+        "api_service.services.checkpoint_branches._existing_bindings_by_work_branch",
+        fail_query,
+    )
+
+    async def write_artifact(
+        artifact_kind: str,
+        payload: Mapping[str, Any],
+        content_type: str,
+    ) -> tuple[str, None]:
+        raise AssertionError("invalid input must fail before artifact emission")
+
+    with pytest.raises(CheckpointBranchGitBindingError) as exc_info:
+        await prepare_checkpoint_branch_workspace(
+            session=session,
+            binding_input={**_binding_input(), "repository": None},
+            known_refs={"feature/mm-1087-source"},
+            current_ref="feature/mm-1087-source",
+            instruction_ref="artifact://MM-1090/input.branch_turn.instructions.md",
+            instruction_digest="sha256:instructions",
+            artifact_writer=write_artifact,
+        )
+
+    assert exc_info.value.failure_code == "invalid_binding"
+
+
+async def test_existing_bindings_match_repository_case_insensitively(
+    session: AsyncSession,
+) -> None:
+    session.add(
+        WorkflowCheckpointBranch(
+            branch_id="cbr_MM-1090",
+            workflow_id="MM-1087",
+            source_checkpoint_boundary="after_execution",
+            source_checkpoint_ref="artifact://checkpoint/root",
+            workspace_policy="apply_previous_execution_diff_to_clean_baseline",
+        )
+    )
+    session.add(
+        WorkflowCheckpointBranchGitBinding(
+            branch_id="cbr_MM-1090",
+            repository="MoonLadderStudios/MoonMind",
+            base_branch="feature/mm-1087-source",
+            work_branch="mm/mm-1087/implement/cp-12345678/cbr-mm-1090",
+            workspace_policy="apply_previous_execution_diff_to_clean_baseline",
+            creation_mode="from_checkpoint_patch",
+        )
+    )
+    await session.flush()
+
+    bindings = await _existing_bindings_by_work_branch(
+        session=session,
+        repository="moonladderstudios/moonmind",
+    )
+
+    assert "mm/mm-1087/implement/cp-12345678/cbr-mm-1090" in bindings
+
+
+async def test_prepare_checkpoint_branch_workspace_rejects_mismatched_turn_reuse(
+    session: AsyncSession,
+) -> None:
+    async def write_artifact(
+        artifact_kind: str,
+        payload: Mapping[str, Any],
+        content_type: str,
+    ) -> tuple[str, None]:
+        return f"artifact://MM-1090/{artifact_kind}", None
+
+    await prepare_checkpoint_branch_workspace(
+        session=session,
+        binding_input=_binding_input(),
+        known_refs={"feature/mm-1087-source"},
+        current_ref="feature/mm-1087-source",
+        instruction_ref="artifact://MM-1090/input.branch_turn.instructions.md",
+        instruction_digest="sha256:instructions",
+        artifact_writer=write_artifact,
+    )
+
+    with pytest.raises(CheckpointBranchGitBindingError) as exc_info:
+        await prepare_checkpoint_branch_workspace(
+            session=session,
+            binding_input=_binding_input(idempotencyKey="MM-1090:different"),
+            known_refs={"feature/mm-1087-source"},
+            current_ref="feature/mm-1087-source",
+            instruction_ref="artifact://MM-1090/input.branch_turn.instructions.md",
+            instruction_digest="sha256:instructions",
+            artifact_writer=write_artifact,
+        )
+
+    assert exc_info.value.failure_code == "invalid_binding"
 
 
 async def test_prepare_checkpoint_branch_workspace_rejects_mismatched_collision(

--- a/tests/unit/workflows/test_checkpoint_branches.py
+++ b/tests/unit/workflows/test_checkpoint_branches.py
@@ -58,6 +58,22 @@ def test_generated_checkpoint_branch_name_is_deterministic_and_sanitized() -> No
     assert "!" not in first
 
 
+def test_generated_checkpoint_branch_name_caps_long_components() -> None:
+    branch = generate_checkpoint_branch_name(
+        workflow_id="workflow-" + ("x" * 255),
+        logical_step_id="step-" + ("y" * 255),
+        checkpoint_ref="artifact://checkpoint/root",
+        product_branch_id="cbr_MM-1090",
+        label="Fix Git Isolation!",
+        idempotency_key="MM-1090:MM-1087:checkpoint",
+    )
+
+    parts = branch.split("/")
+    assert len(branch) <= 255
+    assert len(parts[1]) == 40
+    assert len(parts[2]) == 40
+
+
 def test_prepare_binding_separates_product_branch_from_git_work_branch() -> None:
     created_at = datetime(2026, 7, 2, 12, 0, tzinfo=UTC)
 
@@ -81,6 +97,16 @@ def test_prepare_binding_separates_product_branch_from_git_work_branch() -> None
         == binding["workspacePolicy"]
     )
     assert result.diagnostics["workspacePolicy"] == binding["workspacePolicy"]
+
+
+def test_prepare_binding_accepts_normalized_protected_base_ref() -> None:
+    result = prepare_checkpoint_branch_git_binding(
+        _binding_input(baseBranch="main"),
+        known_refs={"refs/heads/main"},
+        current_ref="main",
+    )
+
+    assert result.binding.base_branch == "main"
 
 
 def test_prepare_binding_emits_workspace_restore_and_git_binding_artifacts() -> None:
@@ -134,7 +160,31 @@ def test_prepare_binding_emits_workspace_restore_and_git_binding_artifacts() -> 
             "feature/mm-1087-source",
             "protected_branch_ref",
         ),
-        ({"baseBranch": "main"}, {"main"}, "main", "protected_branch_ref"),
+        (
+            {"requestedWorkBranch": ".foo/bar"},
+            {"feature/mm-1087-source"},
+            "feature/mm-1087-source",
+            "protected_branch_ref",
+        ),
+        (
+            {"requestedWorkBranch": "mm/foo.lock/bar"},
+            {"feature/mm-1087-source"},
+            "feature/mm-1087-source",
+            "protected_branch_ref",
+        ),
+        (
+            {"requestedWorkBranch": "mm/foo."},
+            {"feature/mm-1087-source"},
+            "feature/mm-1087-source",
+            "protected_branch_ref",
+        ),
+        (
+            {"requestedWorkBranch": "mm/" + ("x" * 253)},
+            {"feature/mm-1087-source"},
+            "feature/mm-1087-source",
+            "protected_branch_ref",
+        ),
+        ({"branchTurnId": None}, {"feature/mm-1087-source"}, "main", "invalid_binding"),
     ],
 )
 def test_prepare_binding_fails_closed_for_unsafe_refs(
@@ -163,12 +213,23 @@ def test_prepare_binding_reuses_matching_collision_idempotently() -> None:
         existing_bindings_by_work_branch={
             work_branch: {
                 "productBranchId": "cbr_MM-1090",
-                "repository": "MoonLadderStudios/MoonMind",
+                "repository": "moonladderstudios/moonmind",
             }
         },
     )
 
     assert result.binding.work_branch == work_branch
+
+
+def test_prepare_binding_rejects_work_branch_that_already_exists_as_repo_ref() -> None:
+    with pytest.raises(CheckpointBranchGitBindingError) as exc_info:
+        prepare_checkpoint_branch_git_binding(
+            _binding_input(requestedWorkBranch="feature/existing-work"),
+            known_refs={"feature/mm-1087-source", "refs/heads/feature/existing-work"},
+            current_ref="feature/mm-1087-source",
+        )
+
+    assert exc_info.value.failure_code == "git_branch_collision"
 
 
 def test_prepare_binding_rejects_mismatched_collision() -> None:

--- a/tests/unit/workflows/test_checkpoint_branches.py
+++ b/tests/unit/workflows/test_checkpoint_branches.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from moonmind.workflows.checkpoint_branches import (
+    CHECKPOINT_BRANCH_GIT_BINDING_CONTENT_TYPE,
+    CHECKPOINT_BRANCH_WORKSPACE_RESTORE_CONTENT_TYPE,
+    CheckpointBranchGitBindingError,
+    generate_checkpoint_branch_name,
+    prepare_checkpoint_branch_git_binding,
+)
+
+
+def _binding_input(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "workflowId": "MM-1087 Workflow",
+        "productBranchId": "cbr_MM-1090",
+        "branchTurnId": "cbt_1",
+        "sourceCheckpointRef": "artifact://checkpoint/root",
+        "sourceCheckpointDigest": "sha256:checkpoint",
+        "logicalStepId": "Implement MM-1090",
+        "label": "Fix Git Isolation!",
+        "repository": "MoonLadderStudios/MoonMind",
+        "baseBranch": "feature/mm-1087-source",
+        "baseCommit": "abc1234",
+        "workspacePolicy": "apply_previous_execution_diff_to_clean_baseline",
+        "creationMode": "from_checkpoint_patch",
+        "idempotencyKey": "MM-1090:MM-1087:checkpoint",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_generated_checkpoint_branch_name_is_deterministic_and_sanitized() -> None:
+    first = generate_checkpoint_branch_name(
+        workflow_id="MM-1087 Workflow",
+        logical_step_id="Implement MM-1090",
+        checkpoint_ref="artifact://checkpoint/root",
+        product_branch_id="cbr_MM-1090",
+        label="Fix Git Isolation!",
+        idempotency_key="MM-1090:MM-1087:checkpoint",
+    )
+    second = generate_checkpoint_branch_name(
+        workflow_id="MM-1087 Workflow",
+        logical_step_id="Implement MM-1090",
+        checkpoint_ref="artifact://checkpoint/root",
+        product_branch_id="cbr_MM-1090",
+        label="Fix Git Isolation!",
+        idempotency_key="MM-1090:MM-1087:checkpoint",
+    )
+
+    assert first == second
+    assert first.startswith("mm/mm-1087-workflow/implement-mm-1090/cp-")
+    assert first.endswith("/cbr_mm-1090-fix-git-isolation")
+    assert " " not in first
+    assert "!" not in first
+
+
+def test_prepare_binding_separates_product_branch_from_git_work_branch() -> None:
+    created_at = datetime(2026, 7, 2, 12, 0, tzinfo=UTC)
+
+    result = prepare_checkpoint_branch_git_binding(
+        _binding_input(),
+        known_refs={"feature/mm-1087-source"},
+        current_ref="feature/mm-1087-source",
+        created_at=created_at,
+    )
+
+    binding = result.binding.model_dump(by_alias=True, mode="json")
+    assert binding["productBranchId"] == "cbr_MM-1090"
+    assert binding["workBranch"].startswith("mm/mm-1087-workflow/")
+    assert binding["workBranch"] != binding["productBranchId"]
+    assert binding["workspacePolicy"] == "apply_previous_execution_diff_to_clean_baseline"
+    assert result.branch_metadata["workspacePolicy"] == binding["workspacePolicy"]
+    assert result.branch_turn_metadata is not None
+    assert result.branch_turn_metadata["workspacePolicy"] == binding["workspacePolicy"]
+    assert (
+        result.step_execution_manifest_branch["workspacePolicy"]
+        == binding["workspacePolicy"]
+    )
+    assert result.diagnostics["workspacePolicy"] == binding["workspacePolicy"]
+
+
+def test_prepare_binding_emits_workspace_restore_and_git_binding_artifacts() -> None:
+    result = prepare_checkpoint_branch_git_binding(
+        _binding_input(),
+        known_refs={"feature/mm-1087-source"},
+        current_ref="feature/mm-1087-source",
+        created_at=datetime(2026, 7, 2, 12, 0, tzinfo=UTC),
+    )
+
+    assert (
+        result.workspace_restore_payload["contentType"]
+        == CHECKPOINT_BRANCH_WORKSPACE_RESTORE_CONTENT_TYPE
+    )
+    assert (
+        result.git_binding_payload["contentType"]
+        == CHECKPOINT_BRANCH_GIT_BINDING_CONTENT_TYPE
+    )
+    assert result.workspace_restore_payload["productBranchId"] == "cbr_MM-1090"
+    assert result.git_binding_payload["productBranchId"] == "cbr_MM-1090"
+    assert (
+        result.diagnostics["evidence"]["workspaceRestoreArtifact"]
+        == "runtime.branch.workspace_restore.json"
+    )
+    assert (
+        result.diagnostics["evidence"]["gitBindingArtifact"]
+        == "runtime.branch.git_binding.json"
+    )
+
+
+@pytest.mark.parametrize(
+    ("overrides", "known_refs", "current_ref", "failure_code"),
+    [
+        (
+            {"requestedWorkBranch": "main"},
+            {"feature/mm-1087-source"},
+            "feature/mm-1087-source",
+            "protected_branch_ref",
+        ),
+        ({}, {"feature/mm-1087-source"}, "HEAD", "detached_head"),
+        (
+            {"baseBranch": "missing"},
+            {"feature/mm-1087-source"},
+            "feature/mm-1087-source",
+            "unknown_ref",
+        ),
+        ({}, set(), "feature/mm-1087-source", "unknown_ref"),
+        (
+            {"requestedWorkBranch": "mm/MM 1087/not-sanitized"},
+            {"feature/mm-1087-source"},
+            "feature/mm-1087-source",
+            "protected_branch_ref",
+        ),
+        ({"baseBranch": "main"}, {"main"}, "main", "protected_branch_ref"),
+    ],
+)
+def test_prepare_binding_fails_closed_for_unsafe_refs(
+    overrides: dict[str, object],
+    known_refs: set[str],
+    current_ref: str,
+    failure_code: str,
+) -> None:
+    with pytest.raises(CheckpointBranchGitBindingError) as exc_info:
+        prepare_checkpoint_branch_git_binding(
+            _binding_input(**overrides),
+            known_refs=known_refs,
+            current_ref=current_ref,
+        )
+
+    assert exc_info.value.failure_code == failure_code
+
+
+def test_prepare_binding_reuses_matching_collision_idempotently() -> None:
+    work_branch = "mm/mm-1087/implement/cp-12345678/cbr-mm-1090"
+
+    result = prepare_checkpoint_branch_git_binding(
+        _binding_input(requestedWorkBranch=work_branch),
+        known_refs={"feature/mm-1087-source"},
+        current_ref="feature/mm-1087-source",
+        existing_bindings_by_work_branch={
+            work_branch: {
+                "productBranchId": "cbr_MM-1090",
+                "repository": "MoonLadderStudios/MoonMind",
+            }
+        },
+    )
+
+    assert result.binding.work_branch == work_branch
+
+
+def test_prepare_binding_rejects_mismatched_collision() -> None:
+    work_branch = "mm/mm-1087/implement/cp-12345678/cbr-mm-1090"
+
+    with pytest.raises(CheckpointBranchGitBindingError) as exc_info:
+        prepare_checkpoint_branch_git_binding(
+            _binding_input(requestedWorkBranch=work_branch),
+            known_refs={"feature/mm-1087-source"},
+            current_ref="feature/mm-1087-source",
+            existing_bindings_by_work_branch={
+                work_branch: {
+                    "productBranchId": "cbr_other",
+                    "repository": "MoonLadderStudios/MoonMind",
+                }
+            },
+        )
+
+    assert exc_info.value.failure_code == "git_branch_collision"


### PR DESCRIPTION
Issue: MM-1090

Summary:
- Adds checkpoint branch git binding persistence models and migration.
- Adds checkpoint branch workspace preparation service logic with deterministic sanitized branch naming, protected-ref validation, collision checks, and workspace policy evidence.
- Emits workspace_restore and git_binding artifact payloads and records diagnostics/manifest metadata.
- Adds targeted workflow, service, and DB model tests for binding records, artifacts, and fail-closed safety cases.

Tests run:
- ./tools/test_unit.sh tests/unit/workflows/test_checkpoint_branches.py tests/unit/services/test_checkpoint_branches_service.py tests/unit/api/db/test_models.py
- ./tools/test_integration.sh

Remaining risks:
- Local Git metadata in this managed workspace has root-owned reflog/index files from an earlier step, so local remote-tracking refs could not be refreshed after push; the GitHub remote branch and PR state are authoritative.
