### PR TITLE
[codex] Rename repository labels to Repo

### DIFF
--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -1981,7 +1981,7 @@ function ProposalDeliveryCard({ outcome, index }: { outcome: Record<string, unkn
         {created === true ? <Fact label="Dedup">Created new issue</Fact> : null}
         {duplicateSource ? <Fact label="Dedup Source">{duplicateSource}</Fact> : null}
         {proposalFieldText(taskPreview, 'repository') ? (
-          <Fact label="Repository">
+          <Fact label="Repo">
             <code className="text-xs break-all">{proposalFieldText(taskPreview, 'repository')}</code>
           </Fact>
         ) : null}
@@ -7268,7 +7268,7 @@ export function WorkflowDetailPage({ payload }: { payload: BootPayload }) {
 
               <FactGroup title="Git & Publish">
                 {execution.repository ? (
-                  <Fact label="Repository">
+                  <Fact label="Repo">
                     <RepositoryFact repository={execution.repository} />
                   </Fact>
                 ) : null}

--- a/frontend/src/entrypoints/workflow-list.test.tsx
+++ b/frontend/src/entrypoints/workflow-list.test.tsx
@@ -1393,7 +1393,7 @@ describe('Workflows Entrypoint', () => {
     );
     await screen.findAllByText('Example task');
 
-    fireEvent.click(screen.getByRole('button', { name: /Repository filter: owner\/repo/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Repo filter: owner\/repo/i }));
     fireEvent.change(screen.getByLabelText('Repository filter value'), {
       target: { value: 'owner/repo ' },
     });
@@ -2098,7 +2098,7 @@ describe('Workflows Entrypoint', () => {
       expect(activeFilterText).toContain('Codex CLI');
     });
 
-    fireEvent.click(screen.getByRole('button', { name: 'Repository filter: owner/repo' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Repo filter: owner/repo' }));
     expect(screen.getByRole('dialog', { name: 'Advanced filters' })).toBeTruthy();
     await waitFor(() => {
       expect(lastExecutionListUrl()).toBe(
@@ -2745,25 +2745,25 @@ describe('Workflows Entrypoint — dashboard preferences (MM-964)', () => {
 
     // Repository column is visible by default.
     expect(
-      screen.getByRole('button', { name: /Repository\. .*sort/i }),
+      screen.getByRole('button', { name: /Repo\. .*sort/i }),
     ).toBeTruthy();
 
     // The repository value is present in the desktop table before hiding.
     expect(document.querySelector('table')?.textContent).toContain('octo/widgets');
 
     openViewOptions();
-    fireEvent.click(screen.getByRole('checkbox', { name: 'Repository' }));
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Repo' }));
 
     // Header and cell for the repository column are removed from the table.
     // (The responsive mobile card layout is a separate surface and is out of
     // scope for the column-visibility preference.)
-    expect(screen.queryByRole('button', { name: /Repository\. .*sort/i })).toBeNull();
+    expect(screen.queryByRole('button', { name: /Repo\. .*sort/i })).toBeNull();
     expect(document.querySelector('table')?.textContent).not.toContain('octo/widgets');
 
     view.unmount();
     renderWithClient(<WorkflowListPage payload={mockPayload} />);
     await screen.findAllByText('Example task');
-    expect(screen.queryByRole('button', { name: /Repository\. .*sort/i })).toBeNull();
+    expect(screen.queryByRole('button', { name: /Repo\. .*sort/i })).toBeNull();
   });
 
   it('resets density and column preferences back to defaults', async () => {
@@ -2772,7 +2772,7 @@ describe('Workflows Entrypoint — dashboard preferences (MM-964)', () => {
 
     openViewOptions();
     fireEvent.click(screen.getByRole('radio', { name: 'Compact' }));
-    fireEvent.click(screen.getByRole('checkbox', { name: 'Repository' }));
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Repo' }));
     expect(document.querySelector('.queue-table-wrapper')?.getAttribute('data-density')).toBe(
       'compact',
     );
@@ -2782,7 +2782,7 @@ describe('Workflows Entrypoint — dashboard preferences (MM-964)', () => {
     expect(document.querySelector('.queue-table-wrapper')?.getAttribute('data-density')).toBe(
       'comfortable',
     );
-    expect(screen.getByRole('button', { name: /Repository\. .*sort/i })).toBeTruthy();
+    expect(screen.getByRole('button', { name: /Repo\. .*sort/i })).toBeTruthy();
     expect(window.localStorage.getItem('moonmind.dashboard.preferences')).toBeNull();
   });
 

--- a/frontend/src/entrypoints/workflow-list.tsx
+++ b/frontend/src/entrypoints/workflow-list.tsx
@@ -117,7 +117,7 @@ const TABLE_COLUMNS: TableColumnDef[] = [
   { field: 'title', label: 'Workflow', sortable: true, colClassName: 'queue-table-column-workflow' },
   { field: 'status', label: 'Status', sortable: true, colClassName: 'queue-table-column-status' },
   { field: 'progress', label: 'Progress', sortable: true, colClassName: 'queue-table-column-progress' },
-  { field: 'repository', label: 'Repository', sortable: true, colClassName: 'queue-table-column-repository' },
+  { field: 'repository', label: 'Repo', sortable: true, colClassName: 'queue-table-column-repository' },
   { field: 'targetRuntime', label: 'Runtime', sortable: true, colClassName: 'queue-table-column-runtime' },
   { field: 'updatedAt', label: 'Updated', sortable: true, colClassName: 'queue-table-column-date' },
 ];
@@ -137,7 +137,7 @@ const FILTER_FIELDS = [
   ['title', 'Title'],
   ['status', 'Status'],
   ['progress', 'Progress'],
-  ['repository', 'Repository'],
+  ['repository', 'Repo'],
   ['targetRuntime', 'Runtime'],
   ['targetSkill', 'Skill'],
   ['updatedAt', 'Updated'],
@@ -168,7 +168,7 @@ const DRAWER_FILTER_FIELDS: Array<[FilterField, string]> = [
   ['title', 'Title'],
   ['status', 'Status'],
   ['progress', 'Progress'],
-  ['repository', 'Repository'],
+  ['repository', 'Repo'],
   ['targetRuntime', 'Runtime'],
   ['targetSkill', 'Skill'],
   ['updatedAt', 'Updated'],
@@ -2637,7 +2637,7 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
                         <dd>{formatRuntimeLabel(row.targetRuntime)}</dd>
                       </div>
                       <div>
-                        <dt>Repository</dt>
+                        <dt>Repo</dt>
                         <dd>{row.repository || '—'}</dd>
                       </div>
                       <div>


### PR DESCRIPTION
## Summary
- Renamed workflow list column/filter UI labels from `Repository` to `Repo` in the desktop table, filter drawer, and mobile card details.
- Renamed workflow detail repository fact labels from `Repository` to `Repo`.
- Updated related UI tests to match the new label text.

## Why
This is a terminology alignment change requested for consistency across the workflows list and detail views.

## Validation
- Ran focused frontend tests:
  - `npm run ui:test -- frontend/src/entrypoints/workflow-list.test.tsx frontend/src/entrypoints/workflow-detail.test.tsx`
  - Result: **2 files, 242 tests passed**.
