### PR TITLE
When initially loading or when I have no workflows yet, I see a view similar to the screenshot. I do not want to see these filters and view options on

### DIFF
--- a/frontend/src/entrypoints/dashboard.test.tsx
+++ b/frontend/src/entrypoints/dashboard.test.tsx
@@ -728,6 +728,10 @@ describe('Dashboard shared entry', () => {
       dashboardCss,
       isMobileWorkflowRule('.workflow-list-data-slab .workflow-list-results-footer'),
     );
+    const mobileViewOptionsPopoverBlock = cssRuleBlockMatching(
+      dashboardCss,
+      isMobileWorkflowRule('.workflow-list-view-options-popover'),
+    );
 
     expect(mobileSlabBlock).toContain('border: 0');
     expect(mobileSlabBlock).toContain('border-radius: 0');
@@ -741,6 +745,10 @@ describe('Dashboard shared entry', () => {
     expect(mobileFooterBlock).toContain('border-top: 0');
     expect(mobileFooterBlock).toContain('padding-left: 0');
     expect(mobileFooterBlock).toContain('padding-right: 0');
+
+    expect(mobileViewOptionsPopoverBlock).toContain('right: auto');
+    expect(mobileViewOptionsPopoverBlock).toContain('left: 0');
+    expect(mobileViewOptionsPopoverBlock).toContain('max-width: calc(100vw - 2rem)');
 
     // Individual cards must keep their standalone card styling.
     const cardBlock = cssRuleBlock(dashboardCss, '.queue-card');

--- a/frontend/src/entrypoints/workflow-list.test.tsx
+++ b/frontend/src/entrypoints/workflow-list.test.tsx
@@ -2435,6 +2435,48 @@ describe('Workflows Entrypoint', () => {
     }
   });
 
+  it('keeps mobile Filters and View options controls hidden on desktop empty states', async () => {
+    const actionsPayload: BootPayload = {
+      page: 'workflow-list',
+      apiBase: '/api',
+      initialData: {
+        dashboardConfig: {
+          features: { temporalDashboard: { listEnabled: true, actionsEnabled: true } },
+        },
+      },
+    };
+    fetchSpy.mockResolvedValue({
+      ok: true,
+      json: async () => ({ items: [], count: 0 }),
+    } as Response);
+
+    vi.stubGlobal(
+      'matchMedia',
+      (query: string) => ({
+        matches: true,
+        media: query,
+        onchange: null,
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        addListener: () => {},
+        removeListener: () => {},
+        dispatchEvent: () => false,
+      }),
+    );
+
+    try {
+      renderWithClient(<WorkflowListPage payload={actionsPayload} />);
+      expect(await screen.findByText('No workflows found for the current filters.')).toBeTruthy();
+
+      expect(document.querySelector('.workflow-list-results-header')).toBeNull();
+      expect(screen.queryByRole('button', { name: 'Filters' })).toBeNull();
+      expect(screen.queryByRole('button', { name: 'View options' })).toBeNull();
+      expect(screen.queryByRole('button', { name: 'Advanced filters' })).toBeNull();
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
   it('keeps a desktop entry point to the advanced filters drawer after dropping the Filters row', async () => {
     const actionsPayload: BootPayload = {
       page: 'workflow-list',

--- a/frontend/src/entrypoints/workflow-list.test.tsx
+++ b/frontend/src/entrypoints/workflow-list.test.tsx
@@ -2435,7 +2435,7 @@ describe('Workflows Entrypoint', () => {
     }
   });
 
-  it('keeps mobile Filters and View options controls hidden on desktop empty states', async () => {
+  it('keeps filter and view controls reachable on desktop filtered empty states', async () => {
     const actionsPayload: BootPayload = {
       page: 'workflow-list',
       apiBase: '/api',
@@ -2449,6 +2449,7 @@ describe('Workflows Entrypoint', () => {
       ok: true,
       json: async () => ({ items: [], count: 0 }),
     } as Response);
+    window.history.pushState({}, 'Filtered workflows', '/workflows?stateIn=completed');
 
     vi.stubGlobal(
       'matchMedia',
@@ -2468,10 +2469,51 @@ describe('Workflows Entrypoint', () => {
       renderWithClient(<WorkflowListPage payload={actionsPayload} />);
       expect(await screen.findByText('No workflows found for the current filters.')).toBeTruthy();
 
-      expect(document.querySelector('.workflow-list-results-header')).toBeNull();
-      expect(screen.queryByRole('button', { name: 'Filters' })).toBeNull();
-      expect(screen.queryByRole('button', { name: 'View options' })).toBeNull();
+      expect(document.querySelector('.workflow-list-results-header')).toBeTruthy();
+      expect(screen.getByRole('button', { name: 'Filters' })).toBeTruthy();
+      expect(screen.getByRole('button', { name: 'View options' })).toBeTruthy();
       expect(screen.queryByRole('button', { name: 'Advanced filters' })).toBeNull();
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it('keeps desktop header controls when actions are disabled', async () => {
+    const actionsDisabledPayload: BootPayload = {
+      page: 'workflow-list',
+      apiBase: '/api',
+      initialData: {
+        dashboardConfig: {
+          features: { temporalDashboard: { listEnabled: true, actionsEnabled: false } },
+        },
+      },
+    };
+
+    vi.stubGlobal(
+      'matchMedia',
+      (query: string) => ({
+        matches: true,
+        media: query,
+        onchange: null,
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        addListener: () => {},
+        removeListener: () => {},
+        dispatchEvent: () => false,
+      }),
+    );
+
+    try {
+      renderWithClient(<WorkflowListPage payload={actionsDisabledPayload} />);
+      await screen.findAllByText('Example task');
+
+      expect(screen.queryByRole('columnheader', { name: 'Actions' })).toBeNull();
+      expect(screen.getByRole('button', { name: 'Filters' })).toBeTruthy();
+      const viewOptions = screen.getByRole('button', { name: 'View options' });
+      expect(viewOptions.closest('th')).toBeNull();
+
+      fireEvent.click(viewOptions);
+      expect(screen.getByRole('radio', { name: 'Compact' })).toBeTruthy();
     } finally {
       vi.unstubAllGlobals();
     }

--- a/frontend/src/entrypoints/workflow-list.tsx
+++ b/frontend/src/entrypoints/workflow-list.tsx
@@ -2172,13 +2172,12 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
   // Desktop promotes the per-column filter buttons and an Actions-header "View
   // options" icon, dropping the results header row. The icon lives inside the
   // rendered table header, so it can only host "View options" when the table is
-  // actually on screen. The labelled control falls back to the results header
-  // otherwise — on mobile, when there is no Actions column, and on the
-  // loading/error/empty states where the table (and its column filters) are
-  // replaced by a message and the Filters trigger is the only filter affordance.
+  // actually on screen. The labelled control falls back to the results header on
+  // mobile only; desktop empty/loading states intentionally avoid showing the
+  // mobile Filters and View options row.
   const tableHasRows = !isLoading && !isError && sortedItems.length > 0;
   const showViewOptionsIcon = isDesktop && actionsEnabled && tableHasRows;
-  const showResultsHeader = !showViewOptionsIcon;
+  const showResultsHeader = !isDesktop && !showViewOptionsIcon;
 
   return (
     <div className="stack">

--- a/frontend/src/entrypoints/workflow-list.tsx
+++ b/frontend/src/entrypoints/workflow-list.tsx
@@ -2170,14 +2170,13 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
   );
 
   // Desktop promotes the per-column filter buttons and an Actions-header "View
-  // options" icon, dropping the results header row. The icon lives inside the
-  // rendered table header, so it can only host "View options" when the table is
-  // actually on screen. The labelled control falls back to the results header on
-  // mobile only; desktop empty/loading states intentionally avoid showing the
-  // mobile Filters and View options row.
+  // options" icon when that header is available. Keep the labelled header
+  // controls as a fallback for active-filter empty/loading states and for
+  // desktop tables without the Actions column.
   const tableHasRows = !isLoading && !isError && sortedItems.length > 0;
   const showViewOptionsIcon = isDesktop && actionsEnabled && tableHasRows;
-  const showResultsHeader = !isDesktop && !showViewOptionsIcon;
+  const showResultsHeader =
+    !isDesktop || (!showViewOptionsIcon && (hasActiveFilters || (tableHasRows && !actionsEnabled)));
 
   return (
     <div className="stack">

--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -2624,14 +2624,28 @@ tr[data-proposal-id].proposal-consuming td {
 }
 
 @media (max-width: 767px) {
+  .workflow-list-results-header {
+    align-items: center;
+    justify-content: flex-start;
+    flex-wrap: nowrap;
+    gap: 0.5rem;
+  }
+
   .workflow-list-filter-bar {
-    align-items: stretch;
-    width: 100%;
+    flex: 0 1 auto;
+    align-items: center;
+    width: auto;
   }
 
   .workflow-list-filter-trigger {
     justify-content: center;
-    width: 100%;
+    width: auto;
+    white-space: nowrap;
+  }
+
+  .workflow-list-view-options {
+    flex: 0 0 auto;
+    margin-left: 0;
   }
 
   .queue-results-toolbar,

--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -2625,10 +2625,14 @@ tr[data-proposal-id].proposal-consuming td {
 
 @media (max-width: 767px) {
   .workflow-list-results-header {
+    display: flex;
     align-items: center;
     justify-content: flex-start;
     flex-wrap: nowrap;
     gap: 0.5rem;
+    padding: 0 0 0.75rem;
+    border-bottom: 0;
+    background: transparent;
   }
 
   .workflow-list-filter-bar {
@@ -2646,6 +2650,12 @@ tr[data-proposal-id].proposal-consuming td {
   .workflow-list-view-options {
     flex: 0 0 auto;
     margin-left: 0;
+  }
+
+  .workflow-list-view-options-popover {
+    right: auto;
+    left: 0;
+    max-width: calc(100vw - 2rem);
   }
 
   .queue-results-toolbar,
@@ -2682,13 +2692,6 @@ tr[data-proposal-id].proposal-consuming td {
     background: transparent;
     box-shadow: none;
     padding: 0;
-  }
-
-  .workflow-list-results-header {
-    display: flex;
-    padding: 0 0 0.75rem;
-    border-bottom: 0;
-    background: transparent;
   }
 
   .workflow-list-data-slab .workflow-list-results-footer {


### PR DESCRIPTION
When initially loading or when I have no workflows yet, I see a view similar to the screenshot. I do not want to see these filters and view options on desktop. I believe these were for mobile only.

However, on mobile, I would prefer for the filters button and view options button to be side to side and not one on top of the other. Right now the Filters button spands the whole screen width on mobile, so it needs to be constrained.