### PR TITLE
[codex] Use ScrollText icon for workflows nav

### DIFF
--- a/frontend/src/entrypoints/dashboard-app.tsx
+++ b/frontend/src/entrypoints/dashboard-app.tsx
@@ -18,12 +18,12 @@ import {
   useNavigate,
 } from 'react-router-dom';
 import { QueryErrorResetBoundary, useQuery, useQueryClient } from '@tanstack/react-query';
+import { ScrollText } from 'lucide-react';
 import {
   MoonIcon,
   RocketIcon,
   SettingsIcon,
   SparklesIcon,
-  WorkflowIcon,
 } from 'lucide-animated';
 
 import type { BootPayload } from '../boot/parseBootPayload';
@@ -67,7 +67,7 @@ type NavIconProps = {
 };
 
 function WorkflowsNavIcon({ className }: NavIconProps) {
-  return <WorkflowIcon size={NAV_ICON_SIZE} className={className} animateOnHover aria-hidden="true" />;
+  return <ScrollText size={NAV_ICON_SIZE} className={className} aria-hidden="true" />;
 }
 
 function StartWorkflowNavIcon({ className }: NavIconProps) {


### PR DESCRIPTION
## Summary
- Replaced the Workflows nav icon with Lucide `ScrollText` from `lucide-react`.
- Removed the Workflows nav item from `lucide-animated` because the installed animated icon package does not export a ScrollText variant.

## Validation
- Verified the branch diff is limited to `frontend/src/entrypoints/dashboard-app.tsx` with 2 additions and 2 deletions.
- Not run: local UI typecheck/tests, because this environment does not have a checkout/authenticated GitHub CLI available.