### PR TITLE
Batch Workflow preset should change the parent workflow publish mode to None automatically (as some skills do). The setting for the child workflows sh

### DIFF
--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -7074,6 +7074,13 @@ async def _expand_goal_preset_for_workflow_submission(
     task_payload.setdefault("instructions", schedule.goal)
     task_payload["inputs"] = template_inputs
     task_payload["steps"] = list(expanded_steps)
+    expanded_publish = (
+        expanded.get("publish") if isinstance(expanded, Mapping) else None
+    )
+    if isinstance(expanded_publish, Mapping) and not isinstance(
+        task_payload.get("publish"), Mapping
+    ):
+        task_payload["publish"] = dict(expanded_publish)
     _apply_goal_schedule_metadata(
         task_payload=task_payload,
         schedule=schedule,

--- a/api_service/data/presets/batch-workflows.yaml
+++ b/api_service/data/presets/batch-workflows.yaml
@@ -214,3 +214,5 @@ steps:
     - git
     - gh
     args: {}
+  publish:
+    mode: none

--- a/api_service/data/presets/batch-workflows.yaml
+++ b/api_service/data/presets/batch-workflows.yaml
@@ -16,6 +16,8 @@ annotations:
   sourceSkill: batch-workflows
   output: child-workflows
   runtimeInheritance: caller
+  workflowPublish:
+    mode: none
   orchestration:
     kind: batch-workflows
     runtimeInheritance: caller
@@ -214,5 +216,3 @@ steps:
     - git
     - gh
     args: {}
-  publish:
-    mode: none

--- a/api_service/services/presets/catalog.py
+++ b/api_service/services/presets/catalog.py
@@ -51,7 +51,6 @@ _FORBIDDEN_STEP_KEYS = frozenset(
         "repository",
         "repo",
         "git",
-        "publish",
         "container",
         "command",
         "cmd",
@@ -132,6 +131,7 @@ _STEP_RESERVED_KEYS = frozenset(
         "skill",
         "skills",
         "preset",
+        "publish",
         "annotations",
     }
 )
@@ -1744,6 +1744,13 @@ class PresetCatalogService:
                         f"Step {index} annotations must be an object when provided."
                     )
                 step_payload["annotations"] = dict(annotations)
+            publish = raw_step.get("publish")
+            if publish is not None:
+                if not isinstance(publish, dict):
+                    raise PresetValidationError(
+                        f"Step {index} publish must be an object when provided."
+                    )
+                step_payload["publish"] = dict(publish)
             step_payload.update(
                 {
                     str(key).strip(): value
@@ -2013,6 +2020,14 @@ class PresetCatalogService:
                         f"{_format_include_path(path)}."
                     )
                 step_payload["annotations"] = dict(annotations)
+            publish = rendered.get("publish")
+            if publish is not None:
+                if not isinstance(publish, dict):
+                    raise PresetValidationError(
+                        f"Expanded step publish must be an object at "
+                        f"{_format_include_path(path)}."
+                    )
+                step_payload["publish"] = dict(publish)
             if step_type == _STEP_TYPE_TOOL:
                 if rendered.get("skill") is not None:
                     raise PresetValidationError(

--- a/api_service/services/presets/catalog.py
+++ b/api_service/services/presets/catalog.py
@@ -51,6 +51,7 @@ _FORBIDDEN_STEP_KEYS = frozenset(
         "repository",
         "repo",
         "git",
+        "publish",
         "container",
         "command",
         "cmd",
@@ -131,7 +132,6 @@ _STEP_RESERVED_KEYS = frozenset(
         "skill",
         "skills",
         "preset",
-        "publish",
         "annotations",
     }
 )
@@ -1744,13 +1744,6 @@ class PresetCatalogService:
                         f"Step {index} annotations must be an object when provided."
                     )
                 step_payload["annotations"] = dict(annotations)
-            publish = raw_step.get("publish")
-            if publish is not None:
-                if not isinstance(publish, dict):
-                    raise PresetValidationError(
-                        f"Step {index} publish must be an object when provided."
-                    )
-                step_payload["publish"] = dict(publish)
             step_payload.update(
                 {
                     str(key).strip(): value
@@ -2020,14 +2013,6 @@ class PresetCatalogService:
                         f"{_format_include_path(path)}."
                     )
                 step_payload["annotations"] = dict(annotations)
-            publish = rendered.get("publish")
-            if publish is not None:
-                if not isinstance(publish, dict):
-                    raise PresetValidationError(
-                        f"Expanded step publish must be an object at "
-                        f"{_format_include_path(path)}."
-                    )
-                step_payload["publish"] = dict(publish)
             if step_type == _STEP_TYPE_TOOL:
                 if rendered.get("skill") is not None:
                     raise PresetValidationError(
@@ -2180,6 +2165,12 @@ class PresetCatalogService:
                 for cap in _extract_step_capabilities(step)
             ]
         )
+        workflow_publish = (template.annotations or {}).get("workflowPublish")
+        if workflow_publish is not None and not isinstance(workflow_publish, Mapping):
+            raise PresetValidationError(
+                "Template workflowPublish annotation must be an object."
+            )
+
         if template.release_status is PresetReleaseStatus.INACTIVE:
             warnings.append("Template is marked inactive.")
 
@@ -2199,7 +2190,7 @@ class PresetCatalogService:
             },
         )
         _METRICS.increment("expand")
-        return {
+        expanded_payload = {
             "steps": resolved_steps,
             "composition": composition,
             "authoredPresets": authored_presets,
@@ -2215,6 +2206,9 @@ class PresetCatalogService:
             "capabilities": template_caps,
             "warnings": warnings,
         }
+        if isinstance(workflow_publish, Mapping):
+            expanded_payload["publish"] = dict(workflow_publish)
+        return expanded_payload
 
     def _resolve_inputs(
         self,

--- a/tests/integration/test_startup_preset_seeding.py
+++ b/tests/integration/test_startup_preset_seeding.py
@@ -609,6 +609,7 @@ async def test_startup_seeds_default_task_templates(disabled_env_keys, tmp_path)
         assert batch_template is not None
         batch_annotations = batch_template.annotations or {}
         assert batch_annotations["runtimeInheritance"] == "caller"
+        assert batch_annotations["workflowPublish"] == {"mode": "none"}
         batch_schema = batch_annotations["inputSchema"]
         assert batch_schema["required"] == [
             "jira_project_key",
@@ -636,7 +637,7 @@ async def test_startup_seeds_default_task_templates(disabled_env_keys, tmp_path)
         batch_steps = batch_template.steps
         assert len(batch_steps) == 1
         assert batch_steps[0]["skill"]["id"] == "batch-workflows"
-        assert batch_steps[0]["publish"] == {"mode": "none"}
+        assert "publish" not in batch_steps[0]
         assert batch_steps[0]["batchOrchestration"]["runtime"]["inherit"] == "caller"
         assert batch_steps[0]["batchOrchestration"]["source"]["kind"] == "jira_status"
         assert (

--- a/tests/integration/test_startup_preset_seeding.py
+++ b/tests/integration/test_startup_preset_seeding.py
@@ -636,6 +636,7 @@ async def test_startup_seeds_default_task_templates(disabled_env_keys, tmp_path)
         batch_steps = batch_template.steps
         assert len(batch_steps) == 1
         assert batch_steps[0]["skill"]["id"] == "batch-workflows"
+        assert batch_steps[0]["publish"] == {"mode": "none"}
         assert batch_steps[0]["batchOrchestration"]["runtime"]["inherit"] == "caller"
         assert batch_steps[0]["batchOrchestration"]["source"]["kind"] == "jira_status"
         assert (

--- a/tests/unit/api/test_batch_workflows_preset.py
+++ b/tests/unit/api/test_batch_workflows_preset.py
@@ -158,8 +158,9 @@ async def test_batch_workflows_seed_validates_and_exposes_batch_contract(tmp_pat
                 == "{{ target.githubIssue.repository }}#{{ target.githubIssue.number }}"
             )
 
-            # Runtime inheritance directive.
+            # Workflow-level directives.
             assert annotations["runtimeInheritance"] == "caller"
+            assert annotations["workflowPublish"] == {"mode": "none"}
 
             exposed_inputs = {item["name"] for item in template.inputs_schema}
             assert exposed_inputs == set(schema["properties"])
@@ -204,6 +205,8 @@ async def test_batch_workflows_expands_orchestration_step(tmp_path):
             assert len(steps) == 1
             step = steps[0]
             assert step["skill"]["id"] == "batch-workflows"
+            assert "publish" not in step
+            assert expanded["publish"] == {"mode": "none"}
 
             orchestration = step["batchOrchestration"]
             assert orchestration["source"]["kind"] == "jira_status"


### PR DESCRIPTION
Batch Workflow preset should change the parent workflow publish mode to None automatically (as some skills do). The setting for the child workflows should still be customizable through the input as it is now.