### PR TITLE
[codex] Remove workflow live update footer text

### DIFF
--- a/frontend/src/components/PageSizeSelector.tsx
+++ b/frontend/src/components/PageSizeSelector.tsx
@@ -1,7 +1,21 @@
-import { JSX } from 'react';
+import { JSX, useLayoutEffect, useRef } from 'react';
 
 export const PAGE_SIZE_OPTIONS = [20, 25, 50, 100] as const;
 export const DEFAULT_PAGE_SIZE = 50;
+
+const WORKFLOW_LIVE_UPDATES_ENABLED_PREFIX = 'Live updates enabled. Polling every ';
+
+function suppressWorkflowLiveUpdatesEnabledFooterText(root: HTMLElement | null): void {
+  const footer = root?.closest('.workflow-list-results-footer');
+  const liveStatus = footer?.querySelector<HTMLElement>('.workflow-list-footer-live > .small:first-child');
+  if (!liveStatus) return;
+  if (!liveStatus.textContent?.startsWith(WORKFLOW_LIVE_UPDATES_ENABLED_PREFIX)) {
+    liveStatus.removeAttribute('aria-hidden');
+    return;
+  }
+  liveStatus.textContent = '';
+  liveStatus.setAttribute('aria-hidden', 'true');
+}
 
 export function parsePageSize(raw: string | null): number {
   const parsed = Number(raw || DEFAULT_PAGE_SIZE);
@@ -17,8 +31,14 @@ interface PageSizeSelectorProps {
 }
 
 export function PageSizeSelector({ pageSize, onPageSizeChange, disabled }: PageSizeSelectorProps): JSX.Element {
+  const labelRef = useRef<HTMLLabelElement | null>(null);
+
+  useLayoutEffect(() => {
+    suppressWorkflowLiveUpdatesEnabledFooterText(labelRef.current);
+  });
+
   return (
-    <label className="queue-page-size-selector">
+    <label ref={labelRef} className="queue-page-size-selector">
       Show
       <select
         value={pageSize}


### PR DESCRIPTION
## Summary
- Removes the enabled live-update polling sentence from the bottom workflow-list footer.
- Keeps pagination, the current-page sort notice, and the View options live-update control intact.

## Verification
- Fetched `frontend/src/components/PageSizeSelector.tsx` from the branch and confirmed the footer suppression logic is present.
- Compared `codex/remove-workflow-live-footer-status` against `main`; the branch is ahead by 1 commit and only changes `frontend/src/components/PageSizeSelector.tsx`.

Note: I could not run the frontend test suite in this environment because the repository is only accessible through the GitHub connector here.