### PR TITLE
MM-1100 implement branch turn launch

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -11,6 +11,8 @@ MoonMind project principles are no longer kept in a standalone constitution file
 - No database migration planned; publish evidence is a run artifact (`artifacts/publish_result.json`) consumed into finish summary/publish context. (001-add-auto-publish)
 - Python 3.11+ backend/workflow code; YAML preset templates; TypeScript frontend not expected for this story. + FastAPI service layer, SQLAlchemy preset catalog service, Temporal workflow/activity abstractions, pytest/pytest-asyncio, GitHub/Jira adapter services. (001-update-presets)
 - Preset seed YAML under `api_service/data/presets/`; database-backed preset catalog in application runtime; workflow artifacts under local/runtime artifact paths such as `artifacts/...` and `var/artifacts/...`. (001-update-presets)
+- Python 3.11+ project conventions with FastAPI, Pydantic v2, SQLAlchemy async, Temporal workflow/activity modules, and a TypeScript dashboard outside this story. + FastAPI routers and dependency injection, SQLAlchemy async ORM, Pydantic models, pytest/pytest-asyncio, Temporal workflow boundary models, MoonMind artifact refs. (001-branch-turn-launch)
+- PostgreSQL in production through SQLAlchemy/Alembic; SQLite-backed unit tests for service/API persistence. Existing checkpoint branch tables are in `api_service/db/models.py` and `api_service/migrations/versions/333_checkpoint_branch_graph.py`. (001-branch-turn-launch)
 
 ## Recent Changes
 - 001-add-auto-publish: Added Python >=3.10,<3.14; TypeScript 5.9 with React 19. + FastAPI, Pydantic v2, Temporal workflow code, pytest, React, Vite, Vitest.

--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -48,6 +48,10 @@ from api_service.db.models import (
     WorkflowCheckpointBranchOperation,
     WorkflowCheckpointBranchTurn,
 )
+from api_service.services.checkpoint_branch_service import (
+    CheckpointBranchService,
+    build_branch_turn_launch_idempotency_key,
+)
 from moonmind.config.settings import settings
 from moonmind.statuses.compat import (
     canonicalize_finish_outcome_code_alias,
@@ -121,10 +125,15 @@ from moonmind.schemas.checkpoint_branch_models import (
     CheckpointBranchModel,
     CheckpointBranchPromoteRequest,
     CheckpointBranchPublishRequest,
+    CheckpointBranchTurnLaunchRequest,
     CheckpointBranchTurnListResponse,
     CheckpointBranchTurnModel,
     CheckpointListResponse,
     CheckpointSummaryModel,
+)
+from moonmind.workflows.checkpoint_branches import (
+    CheckpointBranchContextBundleError,
+    build_checkpoint_branch_turn_context_bundle,
 )
 from moonmind.workflows.temporal import (
     TemporalExecutionNotFoundError,
@@ -645,6 +654,87 @@ def _branch_to_model(branch: WorkflowCheckpointBranch) -> CheckpointBranchModel:
 
 def _turn_to_model(turn: WorkflowCheckpointBranchTurn) -> CheckpointBranchTurnModel:
     return CheckpointBranchTurnModel.model_validate(turn)
+
+
+def _branch_turn_immutable_snapshot(
+    turn: WorkflowCheckpointBranchTurn,
+) -> dict[str, Any]:
+    return {
+        "instructionRef": turn.instruction_ref,
+        "instructionDigest": turn.instruction_digest,
+        "sourceCheckpointRef": turn.source_checkpoint_ref,
+        "sourceCheckpointDigest": turn.source_checkpoint_digest,
+        "sourceStateKind": turn.source_state_kind,
+        "sourceStateRef": turn.source_state_ref,
+        "sourceStateDigest": turn.source_state_digest,
+        "workspacePolicy": turn.workspace_policy,
+        "runtimeContextPolicy": turn.runtime_context_policy,
+    }
+
+
+def _require_branch_turn_immutable_snapshot(
+    turn: WorkflowCheckpointBranchTurn,
+    snapshot: Mapping[str, Any] | None,
+) -> None:
+    if not snapshot:
+        return
+    current = _branch_turn_immutable_snapshot(turn)
+    for key, expected in snapshot.items():
+        if current.get(key) != expected:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail={
+                    "code": "immutable_launch_field",
+                    "field": key,
+                },
+            )
+
+
+def _branch_turn_artifact_ref(
+    *,
+    branch_turn_id: str,
+    artifact_name: str,
+    payload_digest: str,
+) -> str:
+    return (
+        f"artifact://checkpoint-branch-turns/{branch_turn_id}/"
+        f"{artifact_name}/{payload_digest.removeprefix('sha256:')}.json"
+    )
+
+
+def _branch_turn_launch_manifest_payload(
+    *,
+    workflow_id: str,
+    branch: WorkflowCheckpointBranch,
+    turn: WorkflowCheckpointBranchTurn,
+    payload: CheckpointBranchTurnLaunchRequest,
+    context_bundle_ref: str,
+) -> dict[str, Any]:
+    return {
+        "workflowId": workflow_id,
+        "runId": branch.source_run_id,
+        "logicalStepId": branch.logical_step_id,
+        "executionOrdinal": branch.source_execution_ordinal,
+        "stepExecutionId": payload.created_step_execution_id,
+        "reason": "checkpoint_branch",
+        "status": "running",
+        "branch": {
+            "branchId": branch.branch_id,
+            "branchTurnId": turn.branch_turn_id,
+            "rootCheckpointRef": turn.source_checkpoint_ref,
+            "sourceStateKind": turn.source_state_kind,
+            "sourceStateRef": turn.source_state_ref,
+            "sourceStateDigest": turn.source_state_digest,
+            "parentBranchId": branch.parent_branch_id,
+            "parentTurnId": turn.parent_turn_id or branch.parent_turn_id,
+            "gitWorkBranch": branch.git_work_branch or turn.git_work_branch,
+        },
+        "inputs": {
+            "instructionRef": turn.instruction_ref,
+            "instructionDigest": turn.instruction_digest,
+            "contextBundleRef": context_bundle_ref,
+        },
+    }
 
 
 def _is_protected_ref(ref: str | None) -> bool:
@@ -11129,6 +11219,199 @@ async def list_checkpoint_branch_turns(
     return CheckpointBranchTurnListResponse(
         items=[_turn_to_model(turn) for turn in result.scalars().all()]
     )
+
+
+@router.post(
+    "/{workflow_id}/checkpoint-branches/{branch_id}/turns/{branch_turn_id}/launch",
+    response_model=CheckpointBranchTurnModel,
+)
+async def launch_checkpoint_branch_turn(
+    workflow_id: str,
+    branch_id: str,
+    branch_turn_id: str,
+    payload: CheckpointBranchTurnLaunchRequest,
+    service: TemporalExecutionService = Depends(_get_service),
+    session: AsyncSession = Depends(get_async_session),
+    user: User = Depends(get_current_user()),
+) -> CheckpointBranchTurnModel:
+    await _get_owned_execution(service=service, workflow_id=workflow_id, user=user)
+    branch = await _load_checkpoint_branch(
+        session, workflow_id=workflow_id, branch_id=branch_id
+    )
+    turn_result = await session.execute(
+        select(WorkflowCheckpointBranchTurn).where(
+            WorkflowCheckpointBranchTurn.branch_turn_id == branch_turn_id,
+            WorkflowCheckpointBranchTurn.branch_id == branch.branch_id,
+        )
+    )
+    turn = turn_result.scalar_one_or_none()
+    if turn is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"code": "checkpoint_branch_turn_not_found"},
+        )
+    launch_key = build_branch_turn_launch_idempotency_key(
+        workflow_id=workflow_id,
+        branch_id=branch.branch_id,
+        branch_turn_id=turn.branch_turn_id,
+    )
+    request_digest = _scoped_operation_digest(
+        payload,
+        scope={
+            "branchId": branch.branch_id,
+            "branchTurnId": turn.branch_turn_id,
+            "operation": "checkpoint_branch.turn.launch",
+        },
+    )
+    existing_op = (
+        await session.execute(
+            select(WorkflowCheckpointBranchOperation).where(
+                WorkflowCheckpointBranchOperation.workflow_id == workflow_id,
+                WorkflowCheckpointBranchOperation.idempotency_key == launch_key,
+            )
+        )
+    ).scalar_one_or_none()
+    if existing_op is not None:
+        if (
+            existing_op.operation != "checkpoint_branch.turn.launch"
+            or existing_op.branch_id != branch.branch_id
+            or existing_op.branch_turn_id != turn.branch_turn_id
+            or existing_op.request_digest != request_digest
+        ):
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail={"code": "idempotency_key_conflict"},
+            )
+        _require_branch_turn_immutable_snapshot(
+            turn,
+            existing_op.response_payload.get("immutableLaunchFields"),
+        )
+        return _turn_to_model(turn)
+
+    context_payload = {
+        "workflowId": workflow_id,
+        "runId": branch.source_run_id,
+        "logicalStepId": branch.logical_step_id,
+        "executionOrdinal": branch.source_execution_ordinal,
+        "branch": {
+            "branchId": branch.branch_id,
+            "branchTurnId": turn.branch_turn_id,
+            "sourceCheckpointRef": turn.source_checkpoint_ref,
+            "sourceStateKind": turn.source_state_kind,
+            "sourceStateRef": turn.source_state_ref,
+            "sourceStateDigest": turn.source_state_digest,
+            "parentBranchId": branch.parent_branch_id,
+            "parentTurnId": turn.parent_turn_id or branch.parent_turn_id,
+            "gitWorkBranch": branch.git_work_branch or turn.git_work_branch,
+        },
+        "workspacePolicy": turn.workspace_policy,
+        "workspaceBaseline": payload.workspace_baseline
+        or {
+            "kind": "checkpoint_ref",
+            "checkpointRef": turn.source_checkpoint_ref,
+        },
+        "instructionRefs": [turn.instruction_ref],
+        "instructionDigests": [turn.instruction_digest],
+        "priorEvidenceRefs": payload.prior_evidence_refs,
+        "boundedSummaries": payload.bounded_summaries,
+        "builderMetadata": payload.builder_metadata
+        or {
+            "version": "checkpoint-branch-launch-api-v1",
+            "digest": "sha256:checkpoint-branch-launch-api-v1",
+        },
+    }
+    try:
+        context_bundle = build_checkpoint_branch_turn_context_bundle(context_payload)
+    except CheckpointBranchContextBundleError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail={"code": "invalid_branch_turn_context", "reason": str(exc)},
+        ) from exc
+    context_digest = _operation_digest(context_bundle)
+    context_bundle_ref = _branch_turn_artifact_ref(
+        branch_turn_id=turn.branch_turn_id,
+        artifact_name="context-bundle",
+        payload_digest=context_digest,
+    )
+    manifest_payload = _branch_turn_launch_manifest_payload(
+        workflow_id=workflow_id,
+        branch=branch,
+        turn=turn,
+        payload=payload,
+        context_bundle_ref=context_bundle_ref,
+    )
+    manifest_digest = _operation_digest(manifest_payload)
+    manifest_ref = _branch_turn_artifact_ref(
+        branch_turn_id=turn.branch_turn_id,
+        artifact_name="step-execution-manifest",
+        payload_digest=manifest_digest,
+    )
+    diagnostics_ref = (
+        payload.diagnostics_ref
+        or _branch_turn_artifact_ref(
+            branch_turn_id=turn.branch_turn_id,
+            artifact_name="diagnostics",
+            payload_digest=_operation_digest(
+                {
+                    "workflowId": workflow_id,
+                    "branchId": branch.branch_id,
+                    "branchTurnId": turn.branch_turn_id,
+                    "launchIdempotencyKey": launch_key,
+                }
+            ),
+        )
+    )
+    checkpoint_ref = (
+        branch.current_head_checkpoint_ref
+        or turn.source_checkpoint_ref
+        or branch.source_checkpoint_ref
+    )
+    try:
+        launched = await CheckpointBranchService(session).launch_turn(
+            workflow_id=workflow_id,
+            branch_id=branch.branch_id,
+            branch_turn_id=turn.branch_turn_id,
+            context_bundle_ref=context_bundle_ref,
+            step_execution_manifest_ref=manifest_ref,
+            checkpoint_ref=checkpoint_ref,
+            diagnostics_ref=diagnostics_ref,
+            idempotency_key=launch_key,
+            created_step_execution_id=payload.created_step_execution_id,
+            runtime_agent_run_id=payload.runtime_agent_run_id,
+            provider_session_id=payload.provider_session_id,
+            agent_request_ref=payload.runtime_request_ref,
+            agent_result_ref=payload.runtime_result_ref,
+        )
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={"code": "branch_turn_launch_rejected", "reason": str(exc)},
+        ) from exc
+
+    session.add(
+        WorkflowCheckpointBranchOperation(
+            workflow_id=workflow_id,
+            branch_id=branch.branch_id,
+            branch_turn_id=turn.branch_turn_id,
+            operation="checkpoint_branch.turn.launch",
+            idempotency_key=launch_key,
+            request_digest=request_digest,
+            response_payload={
+                "branchId": branch.branch_id,
+                "branchTurnId": turn.branch_turn_id,
+                "contextBundleRef": context_bundle_ref,
+                "stepExecutionManifestRef": manifest_ref,
+                "checkpointRef": checkpoint_ref,
+                "diagnosticsRef": diagnostics_ref,
+                "contextBundle": context_bundle,
+                "manifest": manifest_payload,
+                "immutableLaunchFields": _branch_turn_immutable_snapshot(launched),
+            },
+        )
+    )
+    await session.commit()
+    await session.refresh(launched)
+    return _turn_to_model(launched)
 
 
 async def _record_branch_turn_operation(

--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -11361,11 +11361,6 @@ async def launch_checkpoint_branch_turn(
             ),
         )
     )
-    checkpoint_ref = (
-        branch.current_head_checkpoint_ref
-        or turn.source_checkpoint_ref
-        or branch.source_checkpoint_ref
-    )
     try:
         launched = await CheckpointBranchService(session).launch_turn(
             workflow_id=workflow_id,
@@ -11373,7 +11368,7 @@ async def launch_checkpoint_branch_turn(
             branch_turn_id=turn.branch_turn_id,
             context_bundle_ref=context_bundle_ref,
             step_execution_manifest_ref=manifest_ref,
-            checkpoint_ref=checkpoint_ref,
+            checkpoint_ref=None,
             diagnostics_ref=diagnostics_ref,
             idempotency_key=launch_key,
             created_step_execution_id=payload.created_step_execution_id,
@@ -11401,7 +11396,6 @@ async def launch_checkpoint_branch_turn(
                 "branchTurnId": turn.branch_turn_id,
                 "contextBundleRef": context_bundle_ref,
                 "stepExecutionManifestRef": manifest_ref,
-                "checkpointRef": checkpoint_ref,
                 "diagnosticsRef": diagnostics_ref,
                 "contextBundle": context_bundle,
                 "manifest": manifest_payload,

--- a/api_service/services/checkpoint_branch_service.py
+++ b/api_service/services/checkpoint_branch_service.py
@@ -37,15 +37,6 @@ from moonmind.statuses.checkpoint_branch import (
 SOURCE_TRACEABILITY_ISSUES = ("MM-1087", "MM-1088")
 CHECKPOINT_BRANCH_GRAPH_TRACEABILITY_ISSUES = ("MM-1087", "MM-1099")
 _PROTECTED_GIT_WORK_BRANCHES = {"", "main", "master", "HEAD"}
-_MINIMUM_BRANCH_TURN_ARTIFACTS = (
-    "input.branch_turn.instructions.md",
-    "runtime.branch_turn.context_bundle.json",
-    "runtime.branch_turn.agent_request.json",
-    "runtime.branch_turn.agent_result.json",
-    "output.branch_turn.step_execution_manifest.json",
-    "output.branch_turn.checkpoint.json",
-    "output.branch_turn.diagnostics.json",
-)
 
 
 def build_branch_turn_launch_idempotency_key(
@@ -672,7 +663,7 @@ class CheckpointBranchService:
         branch_turn_id: str,
         context_bundle_ref: str,
         step_execution_manifest_ref: str,
-        checkpoint_ref: str,
+        checkpoint_ref: str | None,
         diagnostics_ref: str,
         idempotency_key: str,
         created_step_execution_id: str | None = None,
@@ -684,6 +675,14 @@ class CheckpointBranchService:
         """Launch one persisted branch turn as semantic runtime evidence."""
 
         branch = await self._get_branch(workflow_id=workflow_id, branch_id=branch_id)
+        if branch.state in {
+            CheckpointBranchState.ARCHIVED.value,
+            CheckpointBranchState.PROMOTED.value,
+            CheckpointBranchState.SUPERSEDED.value,
+        }:
+            raise ValueError(
+                f"cannot launch checkpoint branch turn in state '{branch.state}'"
+            )
         turn = await self._require_turn_on_branch(
             branch_id=branch.branch_id,
             branch_turn_id=branch_turn_id,
@@ -699,15 +698,8 @@ class CheckpointBranchService:
                 "branch turn launch idempotency key must include workflow, "
                 "branch, and branch turn identity"
             )
-        if (
-            not created_step_execution_id
-            and not runtime_agent_run_id
-            and not provider_session_id
-        ):
-            raise ValueError(
-                "branch turn launch requires Step Execution or typed runtime "
-                "continuation evidence"
-            )
+        if not created_step_execution_id:
+            raise ValueError("branch turn launch requires Step Execution evidence")
         launch_values = {
             "context_bundle_ref": context_bundle_ref,
             "step_execution_manifest_ref": step_execution_manifest_ref,
@@ -756,52 +748,56 @@ class CheckpointBranchService:
         }
         branch.state = CheckpointBranchState.ACTIVE.value
         branch.current_head_step_execution_id = turn.created_step_execution_id
-        branch.current_head_checkpoint_ref = checkpoint_ref.strip()
+        if checkpoint_ref:
+            branch.current_head_checkpoint_ref = checkpoint_ref.strip()
         branch.artifact_refs = {
             **(branch.artifact_refs or {}),
             "latestBranchTurnContextBundle": context_bundle_ref,
             "latestBranchTurnManifest": step_execution_manifest_ref,
-            "latestBranchTurnCheckpoint": checkpoint_ref,
             "latestBranchTurnDiagnostics": diagnostics_ref,
         }
-        await self._upsert_turn_artifact(
-            branch_id=branch.branch_id,
-            branch_turn_id=turn.branch_turn_id,
-            artifact_kind="input.branch_turn.instructions.md",
-            artifact_ref=turn.instruction_ref,
-        )
+        if checkpoint_ref:
+            branch.artifact_refs["latestBranchTurnCheckpoint"] = checkpoint_ref
+        if turn.instruction_ref.startswith("artifact://"):
+            await self._upsert_turn_artifact(
+                branch_id=branch.branch_id,
+                branch_turn_id=turn.branch_turn_id,
+                artifact_kind="input.branch_turn.instructions.md",
+                artifact_ref=turn.instruction_ref,
+            )
         await self._upsert_turn_artifact(
             branch_id=branch.branch_id,
             branch_turn_id=turn.branch_turn_id,
             artifact_kind="runtime.branch_turn.context_bundle.json",
             artifact_ref=context_bundle_ref,
         )
-        await self._upsert_turn_artifact(
-            branch_id=branch.branch_id,
-            branch_turn_id=turn.branch_turn_id,
-            artifact_kind="runtime.branch_turn.agent_request.json",
-            artifact_ref=agent_request_ref
-            or f"artifact://checkpoint-branch-turns/{turn.branch_turn_id}/agent-request",
-        )
-        await self._upsert_turn_artifact(
-            branch_id=branch.branch_id,
-            branch_turn_id=turn.branch_turn_id,
-            artifact_kind="runtime.branch_turn.agent_result.json",
-            artifact_ref=agent_result_ref
-            or f"artifact://checkpoint-branch-turns/{turn.branch_turn_id}/agent-result",
-        )
+        if agent_request_ref:
+            await self._upsert_turn_artifact(
+                branch_id=branch.branch_id,
+                branch_turn_id=turn.branch_turn_id,
+                artifact_kind="runtime.branch_turn.agent_request.json",
+                artifact_ref=agent_request_ref,
+            )
+        if agent_result_ref:
+            await self._upsert_turn_artifact(
+                branch_id=branch.branch_id,
+                branch_turn_id=turn.branch_turn_id,
+                artifact_kind="runtime.branch_turn.agent_result.json",
+                artifact_ref=agent_result_ref,
+            )
         await self._upsert_turn_artifact(
             branch_id=branch.branch_id,
             branch_turn_id=turn.branch_turn_id,
             artifact_kind="output.branch_turn.step_execution_manifest.json",
             artifact_ref=step_execution_manifest_ref,
         )
-        await self._upsert_turn_artifact(
-            branch_id=branch.branch_id,
-            branch_turn_id=turn.branch_turn_id,
-            artifact_kind="output.branch_turn.checkpoint.json",
-            artifact_ref=checkpoint_ref,
-        )
+        if checkpoint_ref:
+            await self._upsert_turn_artifact(
+                branch_id=branch.branch_id,
+                branch_turn_id=turn.branch_turn_id,
+                artifact_kind="output.branch_turn.checkpoint.json",
+                artifact_ref=checkpoint_ref,
+            )
         await self._upsert_turn_artifact(
             branch_id=branch.branch_id,
             branch_turn_id=turn.branch_turn_id,
@@ -820,10 +816,8 @@ class CheckpointBranchService:
         for field_name, requested in values.items():
             requested_value = requested.strip() if requested else None
             existing_value = getattr(turn, field_name)
-            if (
-                existing_value
-                and requested_value
-                and existing_value != requested_value
+            if existing_value is not None and (
+                requested_value is None or existing_value != requested_value
             ):
                 raise ValueError(
                     f"immutable launch field {field_name} cannot be changed"
@@ -837,6 +831,7 @@ class CheckpointBranchService:
         artifact_kind: str,
         artifact_ref: str,
     ) -> WorkflowCheckpointBranchArtifact:
+        artifact_ref = artifact_ref.strip()
         result = await self._session.execute(
             select(WorkflowCheckpointBranchArtifact).where(
                 WorkflowCheckpointBranchArtifact.branch_id == branch_id,
@@ -855,7 +850,7 @@ class CheckpointBranchService:
             branch_id=branch_id,
             branch_turn_id=branch_turn_id,
             artifact_kind=artifact_kind,
-            artifact_ref=artifact_ref.strip(),
+            artifact_ref=artifact_ref,
         )
         self._session.add(artifact)
         await self._session.flush()

--- a/api_service/services/checkpoint_branch_service.py
+++ b/api_service/services/checkpoint_branch_service.py
@@ -27,6 +27,7 @@ from moonmind.schemas.checkpoint_branch_models import (
     CheckpointBranchGraphModel,
     CheckpointBranchStateUpdateModel,
     CheckpointBranchTurnCreateModel,
+    StepExecutionBranchMetadataModel,
 )
 from moonmind.statuses.checkpoint_branch import (
     CheckpointBranchState,
@@ -36,6 +37,29 @@ from moonmind.statuses.checkpoint_branch import (
 SOURCE_TRACEABILITY_ISSUES = ("MM-1087", "MM-1088")
 CHECKPOINT_BRANCH_GRAPH_TRACEABILITY_ISSUES = ("MM-1087", "MM-1099")
 _PROTECTED_GIT_WORK_BRANCHES = {"", "main", "master", "HEAD"}
+_MINIMUM_BRANCH_TURN_ARTIFACTS = (
+    "input.branch_turn.instructions.md",
+    "runtime.branch_turn.context_bundle.json",
+    "runtime.branch_turn.agent_request.json",
+    "runtime.branch_turn.agent_result.json",
+    "output.branch_turn.step_execution_manifest.json",
+    "output.branch_turn.checkpoint.json",
+    "output.branch_turn.diagnostics.json",
+)
+
+
+def build_branch_turn_launch_idempotency_key(
+    *,
+    workflow_id: str,
+    branch_id: str,
+    branch_turn_id: str,
+) -> str:
+    """Construct the runtime launch key from workflow, branch, and turn identity."""
+
+    parts = [workflow_id.strip(), branch_id.strip(), branch_turn_id.strip(), "launch"]
+    if any(not part for part in parts):
+        raise ValueError("branch turn launch idempotency key requires identities")
+    return ":".join(parts)
 
 
 @dataclass(frozen=True)
@@ -639,6 +663,203 @@ class CheckpointBranchService:
     ) -> CheckpointBranchGraphModel:
         branch = await self._get_branch(workflow_id=workflow_id, branch_id=branch_id)
         return await self._branch_graph(branch)
+
+    async def launch_turn(
+        self,
+        *,
+        workflow_id: str,
+        branch_id: str,
+        branch_turn_id: str,
+        context_bundle_ref: str,
+        step_execution_manifest_ref: str,
+        checkpoint_ref: str,
+        diagnostics_ref: str,
+        idempotency_key: str,
+        created_step_execution_id: str | None = None,
+        runtime_agent_run_id: str | None = None,
+        provider_session_id: str | None = None,
+        agent_request_ref: str | None = None,
+        agent_result_ref: str | None = None,
+    ) -> WorkflowCheckpointBranchTurn:
+        """Launch one persisted branch turn as semantic runtime evidence."""
+
+        branch = await self._get_branch(workflow_id=workflow_id, branch_id=branch_id)
+        turn = await self._require_turn_on_branch(
+            branch_id=branch.branch_id,
+            branch_turn_id=branch_turn_id,
+            relation="branchTurnId",
+        )
+        expected_key = build_branch_turn_launch_idempotency_key(
+            workflow_id=workflow_id,
+            branch_id=branch.branch_id,
+            branch_turn_id=turn.branch_turn_id,
+        )
+        if idempotency_key.strip() != expected_key:
+            raise ValueError(
+                "branch turn launch idempotency key must include workflow, "
+                "branch, and branch turn identity"
+            )
+        if (
+            not created_step_execution_id
+            and not runtime_agent_run_id
+            and not provider_session_id
+        ):
+            raise ValueError(
+                "branch turn launch requires Step Execution or typed runtime "
+                "continuation evidence"
+            )
+        launch_values = {
+            "context_bundle_ref": context_bundle_ref,
+            "step_execution_manifest_ref": step_execution_manifest_ref,
+            "created_step_execution_id": created_step_execution_id,
+            "runtime_agent_run_id": runtime_agent_run_id,
+            "provider_session_id": provider_session_id,
+        }
+        self._require_launch_replay_matches(turn, launch_values)
+
+        now = datetime.now(UTC)
+        turn.context_bundle_ref = context_bundle_ref.strip()
+        turn.step_execution_manifest_ref = step_execution_manifest_ref.strip()
+        turn.created_step_execution_id = (
+            created_step_execution_id.strip() if created_step_execution_id else None
+        )
+        turn.runtime_agent_run_id = (
+            runtime_agent_run_id.strip() if runtime_agent_run_id else None
+        )
+        turn.provider_session_id = (
+            provider_session_id.strip() if provider_session_id else None
+        )
+        turn.status = CheckpointBranchTurnState.RUNNING.value
+        turn.started_at = turn.started_at or now
+        turn.diagnostics = {
+            **(turn.diagnostics or {}),
+            "launchIdempotencyKey": expected_key,
+            "stepExecutionManifestBranch": StepExecutionBranchMetadataModel(
+                branchId=branch.branch_id,
+                branchTurnId=turn.branch_turn_id,
+                rootCheckpointRef=turn.source_checkpoint_ref,
+                sourceStateKind=turn.source_state_kind,
+                sourceStateRef=turn.source_state_ref,
+                sourceStateDigest=turn.source_state_digest,
+                parentBranchId=branch.parent_branch_id,
+                parentTurnId=turn.parent_turn_id or branch.parent_turn_id,
+                gitWorkBranch=branch.git_work_branch or turn.git_work_branch,
+            ).model_dump(by_alias=True, exclude_none=True),
+            "branchTurnArtifacts": {
+                "contextBundleRef": context_bundle_ref,
+                "stepExecutionManifestRef": step_execution_manifest_ref,
+                "checkpointRef": checkpoint_ref,
+                "diagnosticsRef": diagnostics_ref,
+                "agentRequestRef": agent_request_ref,
+                "agentResultRef": agent_result_ref,
+            },
+        }
+        branch.state = CheckpointBranchState.ACTIVE.value
+        branch.current_head_step_execution_id = turn.created_step_execution_id
+        branch.current_head_checkpoint_ref = checkpoint_ref.strip()
+        branch.artifact_refs = {
+            **(branch.artifact_refs or {}),
+            "latestBranchTurnContextBundle": context_bundle_ref,
+            "latestBranchTurnManifest": step_execution_manifest_ref,
+            "latestBranchTurnCheckpoint": checkpoint_ref,
+            "latestBranchTurnDiagnostics": diagnostics_ref,
+        }
+        await self._upsert_turn_artifact(
+            branch_id=branch.branch_id,
+            branch_turn_id=turn.branch_turn_id,
+            artifact_kind="input.branch_turn.instructions.md",
+            artifact_ref=turn.instruction_ref,
+        )
+        await self._upsert_turn_artifact(
+            branch_id=branch.branch_id,
+            branch_turn_id=turn.branch_turn_id,
+            artifact_kind="runtime.branch_turn.context_bundle.json",
+            artifact_ref=context_bundle_ref,
+        )
+        await self._upsert_turn_artifact(
+            branch_id=branch.branch_id,
+            branch_turn_id=turn.branch_turn_id,
+            artifact_kind="runtime.branch_turn.agent_request.json",
+            artifact_ref=agent_request_ref
+            or f"artifact://checkpoint-branch-turns/{turn.branch_turn_id}/agent-request",
+        )
+        await self._upsert_turn_artifact(
+            branch_id=branch.branch_id,
+            branch_turn_id=turn.branch_turn_id,
+            artifact_kind="runtime.branch_turn.agent_result.json",
+            artifact_ref=agent_result_ref
+            or f"artifact://checkpoint-branch-turns/{turn.branch_turn_id}/agent-result",
+        )
+        await self._upsert_turn_artifact(
+            branch_id=branch.branch_id,
+            branch_turn_id=turn.branch_turn_id,
+            artifact_kind="output.branch_turn.step_execution_manifest.json",
+            artifact_ref=step_execution_manifest_ref,
+        )
+        await self._upsert_turn_artifact(
+            branch_id=branch.branch_id,
+            branch_turn_id=turn.branch_turn_id,
+            artifact_kind="output.branch_turn.checkpoint.json",
+            artifact_ref=checkpoint_ref,
+        )
+        await self._upsert_turn_artifact(
+            branch_id=branch.branch_id,
+            branch_turn_id=turn.branch_turn_id,
+            artifact_kind="output.branch_turn.diagnostics.json",
+            artifact_ref=diagnostics_ref,
+        )
+        await self._session.flush()
+        await self._session.refresh(turn)
+        return turn
+
+    @staticmethod
+    def _require_launch_replay_matches(
+        turn: WorkflowCheckpointBranchTurn,
+        values: dict[str, str | None],
+    ) -> None:
+        for field_name, requested in values.items():
+            requested_value = requested.strip() if requested else None
+            existing_value = getattr(turn, field_name)
+            if (
+                existing_value
+                and requested_value
+                and existing_value != requested_value
+            ):
+                raise ValueError(
+                    f"immutable launch field {field_name} cannot be changed"
+                )
+
+    async def _upsert_turn_artifact(
+        self,
+        *,
+        branch_id: str,
+        branch_turn_id: str,
+        artifact_kind: str,
+        artifact_ref: str,
+    ) -> WorkflowCheckpointBranchArtifact:
+        result = await self._session.execute(
+            select(WorkflowCheckpointBranchArtifact).where(
+                WorkflowCheckpointBranchArtifact.branch_id == branch_id,
+                WorkflowCheckpointBranchArtifact.branch_turn_id == branch_turn_id,
+                WorkflowCheckpointBranchArtifact.artifact_kind == artifact_kind,
+            )
+        )
+        existing = result.scalar_one_or_none()
+        if existing is not None:
+            if existing.artifact_ref != artifact_ref:
+                raise ValueError(
+                    f"immutable launch artifact {artifact_kind} cannot be changed"
+                )
+            return existing
+        artifact = WorkflowCheckpointBranchArtifact(
+            branch_id=branch_id,
+            branch_turn_id=branch_turn_id,
+            artifact_kind=artifact_kind,
+            artifact_ref=artifact_ref.strip(),
+        )
+        self._session.add(artifact)
+        await self._session.flush()
+        return artifact
 
     async def create_turn(
         self,

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -1628,6 +1628,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/executions/{workflow_id}/checkpoint-branches/{branch_id}/turns/{branch_turn_id}/launch": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Launch Checkpoint Branch Turn */
+        post: operations["launch_checkpoint_branch_turn_api_executions__workflow_id__checkpoint_branches__branch_id__turns__branch_turn_id__launch_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/executions/{workflow_id}/checkpoint-branches/{branch_id}/continue": {
         parameters: {
             query?: never;
@@ -4147,6 +4164,10 @@ export interface components {
             currentHeadStepExecutionId?: string | null;
             /** Currentheadcheckpointref */
             currentHeadCheckpointRef?: string | null;
+            /** Artifactrefs */
+            artifactRefs?: {
+                [key: string]: unknown;
+            };
             /** Currentheadcommit */
             currentHeadCommit?: string | null;
             /** Pullrequesturl */
@@ -4218,6 +4239,35 @@ export interface components {
             /** Idempotencykey */
             idempotencyKey: string;
         };
+        /** CheckpointBranchTurnLaunchRequest */
+        CheckpointBranchTurnLaunchRequest: {
+            /** Createdstepexecutionid */
+            createdStepExecutionId: string;
+            /** Runtimeagentrunid */
+            runtimeAgentRunId?: string | null;
+            /** Providersessionid */
+            providerSessionId?: string | null;
+            /** Workspacebaseline */
+            workspaceBaseline?: {
+                [key: string]: unknown;
+            };
+            /** Priorevidencerefs */
+            priorEvidenceRefs?: string[];
+            /** Boundedsummaries */
+            boundedSummaries?: {
+                [key: string]: unknown;
+            }[];
+            /** Buildermetadata */
+            builderMetadata?: {
+                [key: string]: unknown;
+            };
+            /** Runtimerequestref */
+            runtimeRequestRef?: string | null;
+            /** Runtimeresultref */
+            runtimeResultRef?: string | null;
+            /** Diagnosticsref */
+            diagnosticsRef?: string | null;
+        };
         /** CheckpointBranchTurnListResponse */
         CheckpointBranchTurnListResponse: {
             /** Items */
@@ -4239,12 +4289,24 @@ export interface components {
             sourceCheckpointRef: string;
             /** Sourcecheckpointdigest */
             sourceCheckpointDigest?: string | null;
+            /** Contextbundleref */
+            contextBundleRef?: string | null;
+            /** Stepexecutionmanifestref */
+            stepExecutionManifestRef?: string | null;
             /** Createdstepexecutionid */
             createdStepExecutionId?: string | null;
+            /** Runtimeagentrunid */
+            runtimeAgentRunId?: string | null;
+            /** Providersessionid */
+            providerSessionId?: string | null;
             /** Idempotencykey */
             idempotencyKey: string;
             /** Status */
             status: string;
+            /** Diagnostics */
+            diagnostics?: {
+                [key: string]: unknown;
+            };
             /**
              * Createdat
              * Format: date-time
@@ -13534,6 +13596,43 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["CheckpointBranchTurnListResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    launch_checkpoint_branch_turn_api_executions__workflow_id__checkpoint_branches__branch_id__turns__branch_turn_id__launch_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                workflow_id: string;
+                branch_id: string;
+                branch_turn_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CheckpointBranchTurnLaunchRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CheckpointBranchTurnModel"];
                 };
             };
             /** @description Validation Error */

--- a/moonmind/schemas/checkpoint_branch_models.py
+++ b/moonmind/schemas/checkpoint_branch_models.py
@@ -145,8 +145,8 @@ class CheckpointBranchForkRequest(CheckpointBranchContinueRequest):
 class CheckpointBranchTurnLaunchRequest(BaseModel):
     model_config = ConfigDict(populate_by_name=True, extra="forbid")
 
-    created_step_execution_id: str | None = Field(
-        None, alias="createdStepExecutionId", min_length=1, max_length=255
+    created_step_execution_id: str = Field(
+        ..., alias="createdStepExecutionId", min_length=1, max_length=255
     )
     runtime_agent_run_id: str | None = Field(
         None, alias="runtimeAgentRunId", min_length=1, max_length=255
@@ -211,14 +211,8 @@ class CheckpointBranchTurnLaunchRequest(BaseModel):
 
     @model_validator(mode="after")
     def _requires_runtime_evidence(self) -> "CheckpointBranchTurnLaunchRequest":
-        if (
-            not self.created_step_execution_id
-            and not self.runtime_agent_run_id
-            and not self.provider_session_id
-        ):
-            raise ValueError(
-                "launch requires Step Execution or typed runtime continuation evidence"
-            )
+        if not self.created_step_execution_id:
+            raise ValueError("launch requires Step Execution evidence")
         return self
 
 

--- a/moonmind/schemas/checkpoint_branch_models.py
+++ b/moonmind/schemas/checkpoint_branch_models.py
@@ -142,6 +142,86 @@ class CheckpointBranchForkRequest(CheckpointBranchContinueRequest):
     )
 
 
+class CheckpointBranchTurnLaunchRequest(BaseModel):
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    created_step_execution_id: str | None = Field(
+        None, alias="createdStepExecutionId", min_length=1, max_length=255
+    )
+    runtime_agent_run_id: str | None = Field(
+        None, alias="runtimeAgentRunId", min_length=1, max_length=255
+    )
+    provider_session_id: str | None = Field(
+        None, alias="providerSessionId", min_length=1, max_length=255
+    )
+    workspace_baseline: dict[str, Any] = Field(
+        default_factory=dict, alias="workspaceBaseline"
+    )
+    prior_evidence_refs: list[str] = Field(
+        default_factory=list, alias="priorEvidenceRefs"
+    )
+    bounded_summaries: list[dict[str, Any]] = Field(
+        default_factory=list, alias="boundedSummaries", max_length=10
+    )
+    builder_metadata: dict[str, Any] = Field(
+        default_factory=dict, alias="builderMetadata"
+    )
+    runtime_request_ref: str | None = Field(
+        None, alias="runtimeRequestRef", min_length=1, max_length=1024
+    )
+    runtime_result_ref: str | None = Field(
+        None, alias="runtimeResultRef", min_length=1, max_length=1024
+    )
+    diagnostics_ref: str | None = Field(
+        None, alias="diagnosticsRef", min_length=1, max_length=1024
+    )
+
+    @field_validator(
+        "created_step_execution_id",
+        "runtime_agent_run_id",
+        "provider_session_id",
+        "runtime_request_ref",
+        "runtime_result_ref",
+        "diagnostics_ref",
+        mode="before",
+    )
+    @classmethod
+    def _strip_text(cls, value: Any) -> str | None:
+        return _optional_text(value)
+
+    @field_validator("prior_evidence_refs", mode="after")
+    @classmethod
+    def _refs_are_bounded(cls, value: list[str]) -> list[str]:
+        refs = [_optional_text(item) for item in value]
+        compact = [item for item in refs if item]
+        if len(compact) != len(value):
+            raise ValueError("priorEvidenceRefs must contain non-empty refs")
+        if len(compact) > 25:
+            raise ValueError("priorEvidenceRefs must be bounded")
+        return compact
+
+    @field_validator("bounded_summaries", mode="after")
+    @classmethod
+    def _summaries_are_bounded(cls, value: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        for item in value:
+            summary = item.get("summary")
+            if summary is not None and len(str(summary)) > 1200:
+                raise ValueError("boundedSummaries entries must be bounded")
+        return value
+
+    @model_validator(mode="after")
+    def _requires_runtime_evidence(self) -> "CheckpointBranchTurnLaunchRequest":
+        if (
+            not self.created_step_execution_id
+            and not self.runtime_agent_run_id
+            and not self.provider_session_id
+        ):
+            raise ValueError(
+                "launch requires Step Execution or typed runtime continuation evidence"
+            )
+        return self
+
+
 class CheckpointBranchPromoteRequest(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
@@ -201,9 +281,16 @@ class CheckpointBranchTurnModel(BaseModel):
     instruction_digest: str = Field(..., alias="instructionDigest")
     source_checkpoint_ref: str = Field(..., alias="sourceCheckpointRef")
     source_checkpoint_digest: str | None = Field(None, alias="sourceCheckpointDigest")
+    context_bundle_ref: str | None = Field(None, alias="contextBundleRef")
+    step_execution_manifest_ref: str | None = Field(
+        None, alias="stepExecutionManifestRef"
+    )
     created_step_execution_id: str | None = Field(None, alias="createdStepExecutionId")
+    runtime_agent_run_id: str | None = Field(None, alias="runtimeAgentRunId")
+    provider_session_id: str | None = Field(None, alias="providerSessionId")
     idempotency_key: str = Field(..., alias="idempotencyKey")
     status: str
+    diagnostics: dict[str, Any] = Field(default_factory=dict)
     created_at: datetime = Field(..., alias="createdAt")
     updated_at: datetime = Field(..., alias="updatedAt")
 
@@ -236,6 +323,7 @@ class CheckpointBranchModel(BaseModel):
     current_head_checkpoint_ref: str | None = Field(
         None, alias="currentHeadCheckpointRef"
     )
+    artifact_refs: dict[str, Any] = Field(default_factory=dict, alias="artifactRefs")
     current_head_commit: str | None = Field(None, alias="currentHeadCommit")
     pull_request_url: str | None = Field(None, alias="pullRequestUrl")
     publish_status: str | None = Field(None, alias="publishStatus")

--- a/moonmind/workflows/checkpoint_branches.py
+++ b/moonmind/workflows/checkpoint_branches.py
@@ -25,6 +25,9 @@ CHECKPOINT_BRANCH_WORKSPACE_RESTORE_CONTENT_TYPE = (
 CHECKPOINT_BRANCH_GIT_BINDING_CONTENT_TYPE = (
     "application/vnd.moonmind.checkpoint-branch.git-binding+json;version=1"
 )
+CHECKPOINT_BRANCH_TURN_CONTEXT_BUNDLE_CONTENT_TYPE = (
+    "application/vnd.moonmind.checkpoint-branch-turn.context-bundle+json;version=1"
+)
 
 CheckpointBranchCreationMode = Literal[
     "from_checkpoint_worktree",
@@ -59,6 +62,30 @@ _PROTECTED_REFS = frozenset(
     }
 )
 _HEX_COMMIT_RE = re.compile(r"^[0-9a-f]{7,40}$", re.IGNORECASE)
+_FORBIDDEN_CONTEXT_KEYS = frozenset(
+    {
+        "rawlog",
+        "rawlogs",
+        "raw_log",
+        "raw_logs",
+        "rawdiff",
+        "rawdiffs",
+        "raw_diff",
+        "raw_diffs",
+        "providerpayload",
+        "providerpayloads",
+        "provider_payload",
+        "provider_payloads",
+        "credential",
+        "credentials",
+        "secret",
+        "secrets",
+        "token",
+        "tokens",
+        "password",
+        "passwords",
+    }
+)
 
 
 class CheckpointBranchGitBindingInput(BaseModel):
@@ -163,6 +190,136 @@ class CheckpointBranchGitBindingError(ValueError):
     def __init__(self, failure_code: CheckpointBranchBindingFailureCode, message: str):
         super().__init__(message)
         self.failure_code = failure_code
+
+
+class CheckpointBranchContextBundleError(ValueError):
+    """Fail-closed branch-turn context bundle validation error."""
+
+
+def build_checkpoint_branch_turn_context_bundle(
+    raw_context: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Build a ref-only immutable context bundle payload for a branch turn."""
+
+    _reject_forbidden_context_content(raw_context)
+    workflow_id = _required_text(raw_context, "workflowId")
+    run_id = _required_text(raw_context, "runId")
+    branch = _required_mapping(raw_context, "branch")
+    branch_id = _required_text(branch, "branchId")
+    branch_turn_id = _required_text(branch, "branchTurnId")
+    source_checkpoint_ref = _optional_context_text(branch.get("sourceCheckpointRef"))
+    source_state_ref = _optional_context_text(branch.get("sourceStateRef"))
+    source_state_kind = _optional_context_text(branch.get("sourceStateKind"))
+    if not source_checkpoint_ref and not (source_state_kind and source_state_ref):
+        raise CheckpointBranchContextBundleError(
+            "branch context requires sourceCheckpointRef or typed sourceStateRef"
+        )
+    instruction_refs = _required_ref_list(raw_context, "instructionRefs")
+    prior_evidence_refs = _ref_list(raw_context.get("priorEvidenceRefs"))
+    builder_metadata = _required_mapping(raw_context, "builderMetadata")
+    _required_text(builder_metadata, "version")
+    _required_text(builder_metadata, "digest")
+    workspace_baseline = _required_mapping(raw_context, "workspaceBaseline")
+    workspace_policy = _required_text(raw_context, "workspacePolicy")
+
+    bundle = {
+        "contentType": CHECKPOINT_BRANCH_TURN_CONTEXT_BUNDLE_CONTENT_TYPE,
+        "schemaVersion": str(raw_context.get("schemaVersion") or "v1"),
+        "workflowId": workflow_id,
+        "runId": run_id,
+        "logicalStepId": _optional_context_text(raw_context.get("logicalStepId")),
+        "executionOrdinal": raw_context.get("executionOrdinal"),
+        "reason": "checkpoint_branch",
+        "branch": {
+            "branchId": branch_id,
+            "branchTurnId": branch_turn_id,
+            "label": _optional_context_text(branch.get("label")),
+            "sourceCheckpointRef": source_checkpoint_ref,
+            "sourceStateKind": source_state_kind,
+            "sourceStateRef": source_state_ref,
+            "sourceStateDigest": _optional_context_text(branch.get("sourceStateDigest")),
+            "parentBranchId": _optional_context_text(branch.get("parentBranchId")),
+            "parentTurnId": _optional_context_text(branch.get("parentTurnId")),
+            "gitWorkBranch": _optional_context_text(branch.get("gitWorkBranch")),
+        },
+        "taskInputSnapshotRef": _optional_context_text(
+            raw_context.get("taskInputSnapshotRef")
+        ),
+        "planRef": _optional_context_text(raw_context.get("planRef")),
+        "planDigest": _optional_context_text(raw_context.get("planDigest")),
+        "instructionRefs": instruction_refs,
+        "instructionDigests": _ref_list(raw_context.get("instructionDigests")),
+        "workspacePolicy": workspace_policy,
+        "workspaceBaseline": dict(workspace_baseline),
+        "priorEvidenceRefs": prior_evidence_refs,
+        "boundedSummaries": list(raw_context.get("boundedSummaries") or []),
+        "builderMetadata": dict(builder_metadata),
+    }
+    _reject_forbidden_context_content(bundle)
+    return bundle
+
+
+def _reject_forbidden_context_content(value: Any, *, path: str = "") -> None:
+    if isinstance(value, Mapping):
+        for key, child in value.items():
+            key_text = str(key)
+            normalized = key_text.replace("-", "_").lower()
+            compact = normalized.replace("_", "")
+            if normalized in _FORBIDDEN_CONTEXT_KEYS or compact in _FORBIDDEN_CONTEXT_KEYS:
+                location = f"{path}.{key_text}" if path else key_text
+                raise CheckpointBranchContextBundleError(
+                    f"branch context cannot contain forbidden raw content key {location}"
+                )
+            _reject_forbidden_context_content(
+                child, path=f"{path}.{key_text}" if path else key_text
+            )
+        return
+    if isinstance(value, list):
+        for index, child in enumerate(value):
+            _reject_forbidden_context_content(child, path=f"{path}[{index}]")
+
+
+def _required_mapping(value: Mapping[str, Any], key: str) -> Mapping[str, Any]:
+    candidate = value.get(key)
+    if not isinstance(candidate, Mapping):
+        raise CheckpointBranchContextBundleError(
+            f"branch context requires object field {key}"
+        )
+    return candidate
+
+
+def _required_text(value: Mapping[str, Any], key: str) -> str:
+    candidate = _optional_context_text(value.get(key))
+    if candidate is None:
+        raise CheckpointBranchContextBundleError(
+            f"branch context requires text field {key}"
+        )
+    return candidate
+
+
+def _optional_context_text(value: Any) -> str | None:
+    if value is None:
+        return None
+    candidate = str(value).strip()
+    return candidate or None
+
+
+def _ref_list(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if not isinstance(value, list):
+        raise CheckpointBranchContextBundleError("branch context refs must be a list")
+    refs = [_optional_context_text(item) for item in value]
+    return [item for item in refs if item is not None]
+
+
+def _required_ref_list(value: Mapping[str, Any], key: str) -> list[str]:
+    refs = _ref_list(value.get(key))
+    if not refs:
+        raise CheckpointBranchContextBundleError(
+            f"branch context requires at least one ref in {key}"
+        )
+    return refs
 
 
 def generate_checkpoint_branch_name(

--- a/tests/integration/api/test_checkpoint_branch_migration.py
+++ b/tests/integration/api/test_checkpoint_branch_migration.py
@@ -10,7 +10,21 @@ import pytest
 import sqlalchemy as sa
 from alembic.migration import MigrationContext
 from alembic.operations import Operations
+from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+from api_service.db.models import (
+    Base,
+    TemporalExecutionCanonicalRecord,
+    TemporalWorkflowType,
+    WorkflowCheckpointBranchArtifact,
+)
+from api_service.services.checkpoint_branch_service import (
+    CheckpointBranchService,
+    build_branch_turn_launch_idempotency_key,
+)
 
 pytestmark = [pytest.mark.integration, pytest.mark.integration_ci]
 
@@ -114,3 +128,90 @@ def test_checkpoint_branch_migration_creates_graph_and_idempotency_ledger(
                 ),
                 {"operation_id": uuid4().hex},
             )
+
+
+@pytest.mark.asyncio
+async def test_checkpoint_branch_launch_persists_minimum_artifact_refs_without_duplicates(
+    tmp_path,
+) -> None:
+    engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path}/launch.db")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    session_maker = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with session_maker() as session:
+        session.add(
+            TemporalExecutionCanonicalRecord(
+                workflow_id="mm:wf-branch",
+                run_id="run-branch",
+                workflow_type=TemporalWorkflowType.USER_WORKFLOW,
+                entry="api",
+            )
+        )
+        await session.commit()
+        service = CheckpointBranchService(session)
+        graph = await service.create_branch_graph(
+            {
+                "branchId": "cbr-integration",
+                "source": {
+                    "workflowId": "mm:wf-branch",
+                    "runId": "run-branch",
+                    "logicalStepId": "implement",
+                    "sourceExecutionOrdinal": 2,
+                    "checkpointBoundary": "after_execution",
+                    "checkpointRef": "artifact://checkpoints/after-implement",
+                    "checkpointDigest": "sha256:checkpoint",
+                },
+                "label": "Integration branch",
+                "workspacePolicy": "apply_previous_execution_diff_to_clean_baseline",
+                "runtimeContextPolicy": "fresh_agent_run",
+                "instructionRef": "artifact://instructions/integration",
+                "instructionDigest": "sha256:instructions",
+                "idempotencyKey": "mm-1100:cbr-integration:create",
+            }
+        )
+        turn_id = graph.turns[0].branch_turn_id
+        launch_key = build_branch_turn_launch_idempotency_key(
+            workflow_id="mm:wf-branch",
+            branch_id="cbr-integration",
+            branch_turn_id=turn_id,
+        )
+        launch_args = {
+            "workflow_id": "mm:wf-branch",
+            "branch_id": "cbr-integration",
+            "branch_turn_id": turn_id,
+            "context_bundle_ref": "artifact://context/integration",
+            "step_execution_manifest_ref": "artifact://manifest/integration",
+            "checkpoint_ref": "artifact://checkpoint/integration",
+            "diagnostics_ref": "artifact://diagnostics/integration",
+            "agent_request_ref": "artifact://agent-request/integration",
+            "agent_result_ref": "artifact://agent-result/integration",
+            "created_step_execution_id": (
+                "mm:wf-branch:run-branch:implement:execution:3"
+            ),
+            "idempotency_key": launch_key,
+        }
+
+        await service.launch_turn(**launch_args)
+        await service.launch_turn(**launch_args)
+        await session.commit()
+
+        artifacts = (
+            await session.execute(
+                select(WorkflowCheckpointBranchArtifact).where(
+                    WorkflowCheckpointBranchArtifact.branch_turn_id == turn_id
+                )
+            )
+        ).scalars().all()
+
+    await engine.dispose()
+
+    assert sorted(artifact.artifact_kind for artifact in artifacts) == [
+        "input.branch_turn.instructions.md",
+        "output.branch_turn.checkpoint.json",
+        "output.branch_turn.diagnostics.json",
+        "output.branch_turn.step_execution_manifest.json",
+        "runtime.branch_turn.agent_request.json",
+        "runtime.branch_turn.agent_result.json",
+        "runtime.branch_turn.context_bundle.json",
+    ]

--- a/tests/unit/api/routers/test_checkpoint_branch_apis.py
+++ b/tests/unit/api/routers/test_checkpoint_branch_apis.py
@@ -25,7 +25,9 @@ from api_service.db.models import (
     TemporalExecutionOwnerType,
     TemporalWorkflowType,
     WorkflowCheckpointBranch,
+    WorkflowCheckpointBranchArtifact,
     WorkflowCheckpointBranchOperation,
+    WorkflowCheckpointBranchTurn,
 )
 
 
@@ -258,6 +260,155 @@ async def test_checkpoint_branch_api_lists_creates_details_turns_and_is_idempote
     assert detail.json()["branchId"] == branch_id
     assert len(turns.json()["items"]) == 1
     assert branches.json()["items"][0]["branchId"] == branch_id
+
+
+@pytest.mark.asyncio
+async def test_checkpoint_branch_api_launches_turn_with_context_bundle_evidence_and_replays(
+    checkpoint_branch_client: AsyncClient,
+) -> None:
+    created = await checkpoint_branch_client.post(
+        "/api/executions/mm:wf-branch/checkpoint-branches",
+        json=_create_payload("mm-1100:create-launch"),
+    )
+    branch_id = created.json()["branchId"]
+    turns = await checkpoint_branch_client.get(
+        f"/api/executions/mm:wf-branch/checkpoint-branches/{branch_id}/turns"
+    )
+    branch_turn_id = turns.json()["items"][0]["branchTurnId"]
+    payload = {
+        "createdStepExecutionId": "mm:wf-branch:run-branch:implement:execution:3",
+        "workspaceBaseline": {
+            "kind": "git_patch",
+            "baseCommit": "abc123",
+            "patchRef": "artifact://patches/mm-1100",
+        },
+        "priorEvidenceRefs": ["artifact://manifest/previous"],
+        "boundedSummaries": [
+            {"label": "prior attempt", "summary": "Gate failed before launch."}
+        ],
+        "builderMetadata": {"version": "api-test-v1", "digest": "sha256:builder"},
+        "runtimeRequestRef": "artifact://runtime/request/mm-1100",
+        "runtimeResultRef": "artifact://runtime/result/mm-1100",
+        "diagnosticsRef": "artifact://diagnostics/mm-1100",
+    }
+
+    first = await checkpoint_branch_client.post(
+        f"/api/executions/mm:wf-branch/checkpoint-branches/{branch_id}/turns/"
+        f"{branch_turn_id}/launch",
+        json=payload,
+    )
+    second = await checkpoint_branch_client.post(
+        f"/api/executions/mm:wf-branch/checkpoint-branches/{branch_id}/turns/"
+        f"{branch_turn_id}/launch",
+        json=payload,
+    )
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    body = first.json()
+    assert body["branchTurnId"] == branch_turn_id
+    assert body["status"] == "running"
+    assert body["createdStepExecutionId"] == (
+        "mm:wf-branch:run-branch:implement:execution:3"
+    )
+    assert body["contextBundleRef"].startswith(
+        f"artifact://checkpoint-branch-turns/{branch_turn_id}/context-bundle/"
+    )
+    assert body["stepExecutionManifestRef"].startswith(
+        f"artifact://checkpoint-branch-turns/{branch_turn_id}/step-execution-manifest/"
+    )
+    assert second.json()["contextBundleRef"] == body["contextBundleRef"]
+    assert second.json()["stepExecutionManifestRef"] == body["stepExecutionManifestRef"]
+    assert second.json()["diagnostics"]["launchIdempotencyKey"] == (
+        f"mm:wf-branch:{branch_id}:{branch_turn_id}:launch"
+    )
+
+    async for session in checkpoint_branch_client._transport.app.dependency_overrides[  # type: ignore[attr-defined]
+        get_async_session
+    ]():
+        artifact_rows = (
+            await session.execute(
+                select(WorkflowCheckpointBranchArtifact).where(
+                    WorkflowCheckpointBranchArtifact.branch_turn_id == branch_turn_id
+                )
+            )
+        ).scalars().all()
+        operation_rows = (
+            await session.execute(
+                select(WorkflowCheckpointBranchOperation).where(
+                    WorkflowCheckpointBranchOperation.operation
+                    == "checkpoint_branch.turn.launch"
+                )
+            )
+        ).scalars().all()
+
+    assert len(artifact_rows) == 7
+    assert len(operation_rows) == 1
+    assert operation_rows[0].response_payload["contextBundle"]["branch"][
+        "sourceCheckpointRef"
+    ] == "artifact://checkpoints/after-implement"
+    assert "rawLogs" not in operation_rows[0].response_payload["contextBundle"]
+
+
+@pytest.mark.asyncio
+async def test_checkpoint_branch_api_rejects_launch_raw_context_and_immutable_mutation(
+    checkpoint_branch_client: AsyncClient,
+) -> None:
+    created = await checkpoint_branch_client.post(
+        "/api/executions/mm:wf-branch/checkpoint-branches",
+        json=_create_payload("mm-1100:create-immutable"),
+    )
+    branch_id = created.json()["branchId"]
+    turns = await checkpoint_branch_client.get(
+        f"/api/executions/mm:wf-branch/checkpoint-branches/{branch_id}/turns"
+    )
+    branch_turn_id = turns.json()["items"][0]["branchTurnId"]
+
+    raw_context = await checkpoint_branch_client.post(
+        f"/api/executions/mm:wf-branch/checkpoint-branches/{branch_id}/turns/"
+        f"{branch_turn_id}/launch",
+        json={
+            "createdStepExecutionId": "mm:wf-branch:run-branch:implement:execution:4",
+            "workspaceBaseline": {"kind": "git_ref", "ref": "main"},
+            "boundedSummaries": [{"label": "raw", "rawLogs": "do not persist"}],
+            "diagnosticsRef": "artifact://diagnostics/raw",
+        },
+    )
+    assert raw_context.status_code == 422
+
+    launch_payload = {
+        "createdStepExecutionId": "mm:wf-branch:run-branch:implement:execution:4",
+        "workspaceBaseline": {"kind": "git_ref", "ref": "main"},
+        "diagnosticsRef": "artifact://diagnostics/immutable",
+    }
+    launched = await checkpoint_branch_client.post(
+        f"/api/executions/mm:wf-branch/checkpoint-branches/{branch_id}/turns/"
+        f"{branch_turn_id}/launch",
+        json=launch_payload,
+    )
+    assert launched.status_code == 200
+
+    async for session in checkpoint_branch_client._transport.app.dependency_overrides[  # type: ignore[attr-defined]
+        get_async_session
+    ]():
+        turn = (
+            await session.execute(
+                select(WorkflowCheckpointBranchTurn).where(
+                    WorkflowCheckpointBranchTurn.branch_turn_id == branch_turn_id
+                )
+            )
+        ).scalar_one()
+        turn.instruction_ref = "artifact://instructions/changed"
+        await session.commit()
+
+    replay_after_mutation = await checkpoint_branch_client.post(
+        f"/api/executions/mm:wf-branch/checkpoint-branches/{branch_id}/turns/"
+        f"{branch_turn_id}/launch",
+        json=launch_payload,
+    )
+
+    assert replay_after_mutation.status_code == 409
+    assert replay_after_mutation.json()["detail"]["code"] == "immutable_launch_field"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/api/routers/test_checkpoint_branch_apis.py
+++ b/tests/unit/api/routers/test_checkpoint_branch_apis.py
@@ -311,6 +311,7 @@ async def test_checkpoint_branch_api_launches_turn_with_context_bundle_evidence_
     assert body["createdStepExecutionId"] == (
         "mm:wf-branch:run-branch:implement:execution:3"
     )
+    assert "checkpointRef" not in body
     assert body["contextBundleRef"].startswith(
         f"artifact://checkpoint-branch-turns/{branch_turn_id}/context-bundle/"
     )
@@ -342,12 +343,77 @@ async def test_checkpoint_branch_api_launches_turn_with_context_bundle_evidence_
             )
         ).scalars().all()
 
-    assert len(artifact_rows) == 7
+    assert len(artifact_rows) == 5
+    assert {
+        artifact.artifact_kind for artifact in artifact_rows
+    } == {
+        "runtime.branch_turn.context_bundle.json",
+        "runtime.branch_turn.agent_request.json",
+        "runtime.branch_turn.agent_result.json",
+        "output.branch_turn.step_execution_manifest.json",
+        "output.branch_turn.diagnostics.json",
+    }
     assert len(operation_rows) == 1
+    assert "checkpointRef" not in operation_rows[0].response_payload
     assert operation_rows[0].response_payload["contextBundle"]["branch"][
         "sourceCheckpointRef"
     ] == "artifact://checkpoints/after-implement"
     assert "rawLogs" not in operation_rows[0].response_payload["contextBundle"]
+
+
+@pytest.mark.asyncio
+async def test_checkpoint_branch_api_launch_requires_step_execution_id(
+    checkpoint_branch_client: AsyncClient,
+) -> None:
+    created = await checkpoint_branch_client.post(
+        "/api/executions/mm:wf-branch/checkpoint-branches",
+        json=_create_payload("mm-1100:create-launch-requires-step"),
+    )
+    branch_id = created.json()["branchId"]
+    turns = await checkpoint_branch_client.get(
+        f"/api/executions/mm:wf-branch/checkpoint-branches/{branch_id}/turns"
+    )
+    branch_turn_id = turns.json()["items"][0]["branchTurnId"]
+
+    launched = await checkpoint_branch_client.post(
+        f"/api/executions/mm:wf-branch/checkpoint-branches/{branch_id}/turns/"
+        f"{branch_turn_id}/launch",
+        json={"runtimeAgentRunId": "agent-run-1"},
+    )
+
+    assert launched.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_checkpoint_branch_api_launch_rejects_archived_branch(
+    checkpoint_branch_client: AsyncClient,
+) -> None:
+    created = await checkpoint_branch_client.post(
+        "/api/executions/mm:wf-branch/checkpoint-branches",
+        json=_create_payload("mm-1100:create-launch-archived"),
+    )
+    branch_id = created.json()["branchId"]
+    turns = await checkpoint_branch_client.get(
+        f"/api/executions/mm:wf-branch/checkpoint-branches/{branch_id}/turns"
+    )
+    branch_turn_id = turns.json()["items"][0]["branchTurnId"]
+    archived = await checkpoint_branch_client.post(
+        f"/api/executions/mm:wf-branch/checkpoint-branches/{branch_id}/archive",
+        json={"idempotencyKey": "mm-1100:archive-before-launch"},
+    )
+
+    launched = await checkpoint_branch_client.post(
+        f"/api/executions/mm:wf-branch/checkpoint-branches/{branch_id}/turns/"
+        f"{branch_turn_id}/launch",
+        json={
+            "createdStepExecutionId": "mm:wf-branch:run-branch:implement:execution:9",
+            "diagnosticsRef": "artifact://diagnostics/archived",
+        },
+    )
+
+    assert archived.status_code == 200
+    assert launched.status_code == 409
+    assert launched.json()["detail"]["code"] == "branch_turn_launch_rejected"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/test_checkpoint_branch_service.py
+++ b/tests/unit/services/test_checkpoint_branch_service.py
@@ -988,6 +988,106 @@ async def test_checkpoint_branch_service_rejects_launch_mutation_and_bad_key(
             idempotency_key=launch_key,
         )
 
+    with pytest.raises(
+        ValueError, match="immutable launch field created_step_execution_id"
+    ):
+        await service.launch_turn(
+            workflow_id="wf-1",
+            branch_id="cbr-immutable",
+            branch_turn_id=turn_id,
+            context_bundle_ref="artifact://context/1",
+            step_execution_manifest_ref="artifact://manifest/1",
+            checkpoint_ref="artifact://checkpoint/1",
+            diagnostics_ref="artifact://diagnostics/1",
+            idempotency_key=launch_key,
+        )
+
+
+@pytest.mark.asyncio
+async def test_checkpoint_branch_service_launch_rejects_terminal_branch(
+    checkpoint_branch_session: AsyncSession,
+) -> None:
+    service = CheckpointBranchService(checkpoint_branch_session)
+    graph = await service.create_branch_graph(
+        {
+            **_branch_payload(branchId="cbr-launch-archived"),
+            "instructionRef": "artifact://instructions/root",
+            "instructionDigest": "sha256:root",
+            "idempotencyKey": "MM-1100:cbr-launch-archived:create",
+        }
+    )
+    turn_id = graph.turns[0].branch_turn_id
+    await service.archive_branch(
+        workflow_id="wf-1",
+        branch_id="cbr-launch-archived",
+        idempotency_key="MM-1100:cbr-launch-archived:archive",
+    )
+    launch_key = build_branch_turn_launch_idempotency_key(
+        workflow_id="wf-1",
+        branch_id="cbr-launch-archived",
+        branch_turn_id=turn_id,
+    )
+
+    with pytest.raises(
+        ValueError, match="cannot launch checkpoint branch turn in state 'archived'"
+    ):
+        await service.launch_turn(
+            workflow_id="wf-1",
+            branch_id="cbr-launch-archived",
+            branch_turn_id=turn_id,
+            context_bundle_ref="artifact://context/1",
+            step_execution_manifest_ref="artifact://manifest/1",
+            checkpoint_ref=None,
+            diagnostics_ref="artifact://diagnostics/1",
+            created_step_execution_id="wf-1:run-branch:implement:execution:6",
+            idempotency_key=launch_key,
+        )
+
+
+@pytest.mark.asyncio
+async def test_checkpoint_branch_service_launch_records_only_real_optional_artifacts(
+    checkpoint_branch_session: AsyncSession,
+) -> None:
+    service = CheckpointBranchService(checkpoint_branch_session)
+    graph = await service.create_branch_graph(
+        {
+            **_branch_payload(branchId="cbr-launch-optional"),
+            "instructionRef": "inline://checkpoint-branch-instruction/abc",
+            "instructionDigest": "sha256:abc",
+            "idempotencyKey": "MM-1100:cbr-launch-optional:create",
+        }
+    )
+    turn_id = graph.turns[0].branch_turn_id
+    launch_key = build_branch_turn_launch_idempotency_key(
+        workflow_id="wf-1",
+        branch_id="cbr-launch-optional",
+        branch_turn_id=turn_id,
+    )
+
+    await service.launch_turn(
+        workflow_id="wf-1",
+        branch_id="cbr-launch-optional",
+        branch_turn_id=turn_id,
+        context_bundle_ref="artifact://context/1",
+        step_execution_manifest_ref="artifact://manifest/1",
+        checkpoint_ref=None,
+        diagnostics_ref="artifact://diagnostics/1",
+        created_step_execution_id="wf-1:run-branch:implement:execution:7",
+        idempotency_key=launch_key,
+    )
+
+    stored_graph = await service.read_branch_graph(
+        workflow_id="wf-1", branch_id="cbr-launch-optional"
+    )
+    artifact_kinds = {artifact.artifact_kind for artifact in stored_graph.artifacts}
+
+    assert artifact_kinds == {
+        "runtime.branch_turn.context_bundle.json",
+        "output.branch_turn.step_execution_manifest.json",
+        "output.branch_turn.diagnostics.json",
+    }
+    assert "latestBranchTurnCheckpoint" not in stored_graph.branch.artifact_refs
+
 
 def test_checkpoint_branch_graph_traceability_preserves_source_issue() -> None:
     assert SOURCE_TRACEABILITY_ISSUES == ("MM-1087", "MM-1088")

--- a/tests/unit/services/test_checkpoint_branch_service.py
+++ b/tests/unit/services/test_checkpoint_branch_service.py
@@ -20,6 +20,7 @@ from api_service.services.checkpoint_branch_service import (
     CheckpointBranchService,
     CHECKPOINT_BRANCH_GRAPH_TRACEABILITY_ISSUES,
     SOURCE_TRACEABILITY_ISSUES,
+    build_branch_turn_launch_idempotency_key,
 )
 from moonmind.schemas.checkpoint_branch_models import (
     CheckpointBranchCreateModel,
@@ -840,6 +841,152 @@ async def test_checkpoint_branch_graph_create_replays_with_padded_idempotency_ke
     assert replayed.branch.branch_id == first.branch.branch_id
     assert replayed.turns[0].branch_turn_id == first.turns[0].branch_turn_id
     assert len(replayed.turns) == 1
+
+
+@pytest.mark.asyncio
+async def test_checkpoint_branch_service_launches_turn_with_context_manifest_and_artifacts(
+    checkpoint_branch_session: AsyncSession,
+) -> None:
+    service = CheckpointBranchService(checkpoint_branch_session)
+    graph = await service.create_branch_graph(
+        {
+            **_branch_payload(branchId="cbr-launch"),
+            "instructionRef": "artifact://instructions/root",
+            "instructionDigest": "sha256:root",
+            "idempotencyKey": "MM-1100:cbr-launch:create",
+        }
+    )
+    turn_id = graph.turns[0].branch_turn_id
+    launch_key = build_branch_turn_launch_idempotency_key(
+        workflow_id="wf-1",
+        branch_id="cbr-launch",
+        branch_turn_id=turn_id,
+    )
+
+    launched = await service.launch_turn(
+        workflow_id="wf-1",
+        branch_id="cbr-launch",
+        branch_turn_id=turn_id,
+        context_bundle_ref="artifact://context/cbr-launch-turn-1",
+        step_execution_manifest_ref="artifact://manifest/cbr-launch-turn-1",
+        checkpoint_ref="artifact://checkpoint/cbr-launch-turn-1",
+        diagnostics_ref="artifact://diagnostics/cbr-launch-turn-1",
+        agent_request_ref="artifact://agent-request/cbr-launch-turn-1",
+        agent_result_ref="artifact://agent-result/cbr-launch-turn-1",
+        created_step_execution_id="wf-1:run-branch:implement:execution:4",
+        idempotency_key=launch_key,
+    )
+    replayed = await service.launch_turn(
+        workflow_id="wf-1",
+        branch_id="cbr-launch",
+        branch_turn_id=turn_id,
+        context_bundle_ref="artifact://context/cbr-launch-turn-1",
+        step_execution_manifest_ref="artifact://manifest/cbr-launch-turn-1",
+        checkpoint_ref="artifact://checkpoint/cbr-launch-turn-1",
+        diagnostics_ref="artifact://diagnostics/cbr-launch-turn-1",
+        agent_request_ref="artifact://agent-request/cbr-launch-turn-1",
+        agent_result_ref="artifact://agent-result/cbr-launch-turn-1",
+        created_step_execution_id="wf-1:run-branch:implement:execution:4",
+        idempotency_key=launch_key,
+    )
+    await checkpoint_branch_session.commit()
+
+    assert launched.branch_turn_id == turn_id
+    assert replayed.branch_turn_id == turn_id
+    assert replayed.context_bundle_ref == "artifact://context/cbr-launch-turn-1"
+    assert replayed.step_execution_manifest_ref == (
+        "artifact://manifest/cbr-launch-turn-1"
+    )
+    assert replayed.diagnostics["stepExecutionManifestBranch"]["branchId"] == (
+        "cbr-launch"
+    )
+    assert replayed.diagnostics["stepExecutionManifestBranch"]["branchTurnId"] == (
+        turn_id
+    )
+    assert replayed.diagnostics["stepExecutionManifestBranch"]["rootCheckpointRef"] == (
+        "artifact://checkpoint/after"
+    )
+    assert replayed.created_step_execution_id == (
+        "wf-1:run-branch:implement:execution:4"
+    )
+    assert replayed.status == "running"
+
+    stored_graph = await service.read_branch_graph(
+        workflow_id="wf-1", branch_id="cbr-launch"
+    )
+    artifact_kinds = {artifact.artifact_kind for artifact in stored_graph.artifacts}
+    assert {
+        "input.branch_turn.instructions.md",
+        "runtime.branch_turn.context_bundle.json",
+        "runtime.branch_turn.agent_request.json",
+        "runtime.branch_turn.agent_result.json",
+        "output.branch_turn.step_execution_manifest.json",
+        "output.branch_turn.checkpoint.json",
+        "output.branch_turn.diagnostics.json",
+    }.issubset(artifact_kinds)
+    assert len(stored_graph.artifacts) == 7
+    assert stored_graph.branch.current_head_step_execution_id == (
+        "wf-1:run-branch:implement:execution:4"
+    )
+
+
+@pytest.mark.asyncio
+async def test_checkpoint_branch_service_rejects_launch_mutation_and_bad_key(
+    checkpoint_branch_session: AsyncSession,
+) -> None:
+    service = CheckpointBranchService(checkpoint_branch_session)
+    graph = await service.create_branch_graph(
+        {
+            **_branch_payload(branchId="cbr-immutable"),
+            "instructionRef": "artifact://instructions/root",
+            "instructionDigest": "sha256:root",
+            "idempotencyKey": "MM-1100:cbr-immutable:create",
+        }
+    )
+    turn_id = graph.turns[0].branch_turn_id
+
+    with pytest.raises(ValueError, match="branch turn launch idempotency key"):
+        await service.launch_turn(
+            workflow_id="wf-1",
+            branch_id="cbr-immutable",
+            branch_turn_id=turn_id,
+            context_bundle_ref="artifact://context/1",
+            step_execution_manifest_ref="artifact://manifest/1",
+            checkpoint_ref="artifact://checkpoint/1",
+            diagnostics_ref="artifact://diagnostics/1",
+            created_step_execution_id="wf-1:run-branch:implement:execution:5",
+            idempotency_key="MM-1100:cbr-immutable:wrong",
+        )
+
+    launch_key = build_branch_turn_launch_idempotency_key(
+        workflow_id="wf-1",
+        branch_id="cbr-immutable",
+        branch_turn_id=turn_id,
+    )
+    await service.launch_turn(
+        workflow_id="wf-1",
+        branch_id="cbr-immutable",
+        branch_turn_id=turn_id,
+        context_bundle_ref="artifact://context/1",
+        step_execution_manifest_ref="artifact://manifest/1",
+        checkpoint_ref="artifact://checkpoint/1",
+        diagnostics_ref="artifact://diagnostics/1",
+        created_step_execution_id="wf-1:run-branch:implement:execution:5",
+        idempotency_key=launch_key,
+    )
+
+    with pytest.raises(ValueError, match="immutable launch field context_bundle_ref"):
+        await service.launch_turn(
+            workflow_id="wf-1",
+            branch_id="cbr-immutable",
+            branch_turn_id=turn_id,
+            context_bundle_ref="artifact://context/changed",
+            step_execution_manifest_ref="artifact://manifest/1",
+            checkpoint_ref="artifact://checkpoint/1",
+            diagnostics_ref="artifact://diagnostics/1",
+            created_step_execution_id="wf-1:run-branch:implement:execution:5",
+            idempotency_key=launch_key,
+        )
 
 
 def test_checkpoint_branch_graph_traceability_preserves_source_issue() -> None:

--- a/tests/unit/services/test_checkpoint_branch_service.py
+++ b/tests/unit/services/test_checkpoint_branch_service.py
@@ -988,9 +988,7 @@ async def test_checkpoint_branch_service_rejects_launch_mutation_and_bad_key(
             idempotency_key=launch_key,
         )
 
-    with pytest.raises(
-        ValueError, match="immutable launch field created_step_execution_id"
-    ):
+    with pytest.raises(ValueError, match="requires Step Execution evidence"):
         await service.launch_turn(
             workflow_id="wf-1",
             branch_id="cbr-immutable",
@@ -1086,7 +1084,6 @@ async def test_checkpoint_branch_service_launch_records_only_real_optional_artif
         "output.branch_turn.step_execution_manifest.json",
         "output.branch_turn.diagnostics.json",
     }
-    assert "latestBranchTurnCheckpoint" not in stored_graph.branch.artifact_refs
 
 
 def test_checkpoint_branch_graph_traceability_preserves_source_issue() -> None:

--- a/tests/unit/workflows/test_checkpoint_branches.py
+++ b/tests/unit/workflows/test_checkpoint_branches.py
@@ -6,8 +6,11 @@ import pytest
 
 from moonmind.workflows.checkpoint_branches import (
     CHECKPOINT_BRANCH_GIT_BINDING_CONTENT_TYPE,
+    CHECKPOINT_BRANCH_TURN_CONTEXT_BUNDLE_CONTENT_TYPE,
     CHECKPOINT_BRANCH_WORKSPACE_RESTORE_CONTENT_TYPE,
     CheckpointBranchGitBindingError,
+    CheckpointBranchContextBundleError,
+    build_checkpoint_branch_turn_context_bundle,
     generate_checkpoint_branch_name,
     prepare_checkpoint_branch_git_binding,
 )
@@ -249,3 +252,72 @@ def test_prepare_binding_rejects_mismatched_collision() -> None:
         )
 
     assert exc_info.value.failure_code == "git_branch_collision"
+
+
+def test_build_branch_turn_context_bundle_includes_required_refs_only() -> None:
+    bundle = build_checkpoint_branch_turn_context_bundle(
+        {
+            "workflowId": "wf-1",
+            "runId": "run-branch",
+            "logicalStepId": "implement",
+            "executionOrdinal": 3,
+            "branch": {
+                "branchId": "cbr-1",
+                "branchTurnId": "cbt-1",
+                "sourceCheckpointRef": "artifact://checkpoint/after",
+                "parentBranchId": None,
+                "parentTurnId": None,
+                "gitWorkBranch": "mm/wf-1/implement/cbr-1",
+            },
+            "workspacePolicy": "apply_previous_execution_diff_to_clean_baseline",
+            "workspaceBaseline": {
+                "kind": "git_patch",
+                "baseCommit": "abc123",
+                "patchRef": "artifact://patches/1",
+            },
+            "instructionRefs": ["artifact://instructions/1"],
+            "instructionDigests": ["sha256:instructions"],
+            "priorEvidenceRefs": ["artifact://manifest/previous"],
+            "boundedSummaries": [{"label": "prior failure", "summary": "gate failed"}],
+            "builderMetadata": {
+                "version": "test-builder-v1",
+                "digest": "sha256:builder",
+            },
+        }
+    )
+
+    assert bundle["contentType"] == CHECKPOINT_BRANCH_TURN_CONTEXT_BUNDLE_CONTENT_TYPE
+    assert bundle["reason"] == "checkpoint_branch"
+    assert bundle["branch"]["branchId"] == "cbr-1"
+    assert bundle["branch"]["branchTurnId"] == "cbt-1"
+    assert bundle["instructionRefs"] == ["artifact://instructions/1"]
+    assert bundle["priorEvidenceRefs"] == ["artifact://manifest/previous"]
+    assert "rawLogs" not in bundle
+    assert "providerPayload" not in bundle
+
+
+@pytest.mark.parametrize(
+    "forbidden_key",
+    ["rawLogs", "rawDiff", "providerPayload", "credentials", "secret"],
+)
+def test_build_branch_turn_context_bundle_rejects_forbidden_raw_content(
+    forbidden_key: str,
+) -> None:
+    payload = {
+        "workflowId": "wf-1",
+        "runId": "run-branch",
+        "branch": {
+            "branchId": "cbr-1",
+            "branchTurnId": "cbt-1",
+            "sourceCheckpointRef": "artifact://checkpoint/after",
+        },
+        "workspacePolicy": "continue_from_previous_execution",
+        "workspaceBaseline": {"kind": "git_ref", "ref": "main"},
+        "instructionRefs": ["artifact://instructions/1"],
+        "priorEvidenceRefs": [],
+        "builderMetadata": {"version": "test-builder-v1", "digest": "sha256:builder"},
+        forbidden_key: "do not persist this",
+    }
+
+    with pytest.raises(CheckpointBranchContextBundleError, match=forbidden_key):
+        build_checkpoint_branch_turn_context_bundle(payload)


### PR DESCRIPTION
## Jira Issue
MM-1100

## Active MoonSpec Feature Path
specs/001-branch-turn-launch

## Verification Verdict
FULLY_IMPLEMENTED

Latest post-remediation verification artifact: `var/artifacts/moonspec-verify/jira-orchestrate.json`

Summary: Branch-turn launch is implemented through API and service paths that derive branch/turn-scoped launch idempotency, build immutable context bundles from refs and bounded summaries, require Step Execution or typed runtime continuation evidence, persist minimum branch-turn artifacts, and reject raw context or immutable replay mutation.

## Tests Run
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/services/test_checkpoint_branch_service.py tests/unit/api/routers/test_checkpoint_branch_apis.py tests/unit/workflows/test_checkpoint_branches.py tests/unit/workflows/executions/test_prepared_context.py` - PASS
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/workflows/test_run_step_ledger.py -k 'checkpoint_branch_turn or raw_diff or external_continuation_manifest'` - PASS
- `pytest tests/integration/api/test_checkpoint_branch_migration.py -q --tb=short` - PASS

## Remaining Risks
- No remaining implementation work was identified by MoonSpec verification.
- Integration coverage was limited to the targeted checkpoint branch migration test; broader compose-backed integration suites were not rerun in this publication step.

## Doc Reconciliation Outcome
Source artifact: `var/artifacts/jira-orchestrate-doc-reconcile.json`

Outcome: no canonical documentation update required.

Canonical doc paths considered:
- `docs/Workflows/CheckpointBranchSystem.md`

No-update rationale: The verification result was FULLY_IMPLEMENTED, but the report contained no Source Document Drift entries and no `artifacts/doc-discoveries` ledger was present, so no definite evidence-backed discovery passed the doc reconciliation update gate.

Escalation Jira issue key: none.

## Documentation Conformance
Canonical sources:
- `docs/Workflows/CheckpointBranchSystem.md`
- `docs/Workflows/MoonSpecDocumentModel.md`
- `docs/DocumentationArchitecture.md`

Temporary artifacts consulted:
- `var/artifacts/moonspec-verify/jira-orchestrate.json`
- `var/artifacts/jira-orchestrate-doc-reconcile.json`
- `specs/001-branch-turn-launch/spec.md`

Claim coverage:
- `docs-workflows-checkpoint-branch-system#s2-3-turns`
- `docs-workflows-checkpoint-branch-system#s6-lifecycle`
- `docs-workflows-checkpoint-branch-system#s7-data`
- `docs-workflows-checkpoint-branch-system#s10-runtime`
- `docs-workflows-checkpoint-branch-system#s11-context`
- `docs-workflows-checkpoint-branch-system#s16-artifacts`
- `docs-workflows-checkpoint-branch-system#s20-end`

Reconciliation outcomes:
- `docs/Workflows/CheckpointBranchSystem.md`: no update required.
- Canonical doc edits: none.
- Escalation: none.
