### PR TITLE
[codex] Fix managed session launch retries

### DIFF
--- a/moonmind/workflows/temporal/activity_catalog.py
+++ b/moonmind/workflows/temporal/activity_catalog.py
@@ -970,8 +970,9 @@ def build_default_activity_catalog(
             capability_class="agent_runtime",
             task_queue=cfg.activity_agent_runtime_task_queue,
             fleet=AGENT_RUNTIME_FLEET,
-            timeouts=TemporalActivityTimeouts(60, 240, heartbeat_timeout_seconds=30),
+            timeouts=TemporalActivityTimeouts(300, 1200, heartbeat_timeout_seconds=120),
             retries=_activity_retries(max_attempts=3, max_interval_seconds=120),
+            heartbeat_required=True,
         ),
         TemporalActivityDefinition(
             activity_type="agent_runtime.load_session_snapshot",

--- a/moonmind/workflows/temporal/runtime/managed_session_controller.py
+++ b/moonmind/workflows/temporal/runtime/managed_session_controller.py
@@ -2914,7 +2914,7 @@ class DockerCodexManagedSessionController:
                     network_name=unrestricted_proxy_network,
                 )
         except asyncio.CancelledError:
-            await _cleanup_failed_launch(container_id or container_name)
+            await asyncio.shield(_cleanup_failed_launch(container_id or container_name))
             raise
         except Exception:
             await _cleanup_failed_launch(container_id or container_name)
@@ -2993,7 +2993,7 @@ class DockerCodexManagedSessionController:
                 extra_env={"MOONMIND_SESSION_CONTAINER_ID": container_id},
             )
         except asyncio.CancelledError:
-            await _cleanup_failed_launch(container_id)
+            await asyncio.shield(_cleanup_failed_launch(container_id))
             raise
         except Exception:
             await _cleanup_failed_launch(container_id)

--- a/moonmind/workflows/temporal/runtime/managed_session_controller.py
+++ b/moonmind/workflows/temporal/runtime/managed_session_controller.py
@@ -648,6 +648,45 @@ class DockerCodexManagedSessionController:
                 raise
             return False
 
+    async def _create_docker_sidecar_volumes(
+        self,
+        *,
+        session_id: str,
+        session_epoch: int,
+        agent_run_id: str,
+    ) -> None:
+        await self._create_volume(
+            self._sidecar_socket_volume_name(session_id),
+            labels=self._sidecar_volume_labels(
+                session_id=session_id,
+                role="docker-socket",
+                agent_run_id=agent_run_id,
+                session_epoch=session_epoch,
+            ),
+        )
+        await self._create_volume(
+            self._sidecar_graph_volume_name(session_id),
+            labels=self._sidecar_volume_labels(
+                session_id=session_id,
+                role="docker-graph",
+                agent_run_id=agent_run_id,
+                session_epoch=session_epoch,
+            ),
+        )
+
+    @staticmethod
+    def _docker_name_conflict(exc: RuntimeError, container_name: str) -> bool:
+        detail = str(exc).lower()
+        name = str(container_name or "").strip().lower()
+        if not name:
+            return False
+        return (
+            "conflict" in detail
+            and "container name" in detail
+            and "already in use" in detail
+            and name in detail
+        )
+
     async def _cleanup_docker_sidecar_resources(
         self,
         session_id: str,
@@ -687,24 +726,6 @@ class DockerCodexManagedSessionController:
         sidecar_name = self._sidecar_container_name(session_id)
         socket_volume = self._sidecar_socket_volume_name(session_id)
         graph_volume = self._sidecar_graph_volume_name(session_id)
-        await self._create_volume(
-            socket_volume,
-            labels=self._sidecar_volume_labels(
-                session_id=session_id,
-                role="docker-socket",
-                agent_run_id=agent_run_id,
-                session_epoch=session_epoch,
-            ),
-        )
-        await self._create_volume(
-            graph_volume,
-            labels=self._sidecar_volume_labels(
-                session_id=session_id,
-                role="docker-graph",
-                agent_run_id=agent_run_id,
-                session_epoch=session_epoch,
-            ),
-        )
         command = [
             self._docker_binary,
             "run",
@@ -742,7 +763,25 @@ class DockerCodexManagedSessionController:
                 f"--group={_MANAGED_SESSION_CONTAINER_GID}",
             ]
         )
-        stdout, _stderr = await self._run(command)
+        for attempt in range(2):
+            await self._create_docker_sidecar_volumes(
+                session_id=session_id,
+                session_epoch=session_epoch,
+                agent_run_id=agent_run_id,
+            )
+            try:
+                stdout, _stderr = await self._run(command)
+                break
+            except RuntimeError as exc:
+                if attempt == 0 and self._docker_name_conflict(exc, sidecar_name):
+                    await self._cleanup_docker_sidecar_resources(
+                        session_id,
+                        ignore_failure=True,
+                    )
+                    continue
+                raise
+        else:  # pragma: no cover - loop always exits by break or raise.
+            raise RuntimeError("docker sidecar run did not start")
         sidecar_id = stdout.strip()
         if not sidecar_id:
             raise RuntimeError("docker sidecar run returned a blank container id")
@@ -2829,31 +2868,13 @@ class DockerCodexManagedSessionController:
             ]
         )
         container_id = ""
-        try:
-            if docker_activate_at_launch:
-                await self._launch_docker_sidecar(
-                    session_id=request.session_id,
-                    session_epoch=request.session_epoch,
-                    agent_run_id=request.agent_run_id,
-                    docker_network=docker_network,
+
+        async def _cleanup_failed_launch(container_identifier: str) -> None:
+            if container_identifier:
+                await self._remove_container(
+                    container_identifier,
+                    ignore_failure=True,
                 )
-            stdout, _stderr = await self._run(
-                run_command,
-                extra_env=container_secret_environment or None,
-            )
-            container_id = stdout.strip()
-            if not container_id:
-                raise RuntimeError("docker run returned a blank container id")
-            if unrestricted_proxy_network:
-                await self._connect_container_network(
-                    container_id=container_id,
-                    network_name=unrestricted_proxy_network,
-                )
-        except Exception:
-            await self._remove_container(
-                container_id or container_name,
-                ignore_failure=True,
-            )
             if docker_sidecar_enabled:
                 await self._cleanup_docker_sidecar_resources(
                     request.session_id,
@@ -2862,6 +2883,41 @@ class DockerCodexManagedSessionController:
                 self._cleanup_session_docker_config(request.session_workspace_path)
             if github_broker_started:
                 await self._github_auth_brokers.stop(request.session_id)
+
+        try:
+            if docker_activate_at_launch:
+                await self._launch_docker_sidecar(
+                    session_id=request.session_id,
+                    session_epoch=request.session_epoch,
+                    agent_run_id=request.agent_run_id,
+                    docker_network=docker_network,
+                )
+            try:
+                stdout, _stderr = await self._run(
+                    run_command,
+                    extra_env=container_secret_environment or None,
+                )
+            except RuntimeError as exc:
+                if not self._docker_name_conflict(exc, container_name):
+                    raise
+                await self._remove_container(container_name, ignore_failure=True)
+                stdout, _stderr = await self._run(
+                    run_command,
+                    extra_env=container_secret_environment or None,
+                )
+            container_id = stdout.strip()
+            if not container_id:
+                raise RuntimeError("docker run returned a blank container id")
+            if unrestricted_proxy_network:
+                await self._connect_container_network(
+                    container_id=container_id,
+                    network_name=unrestricted_proxy_network,
+                )
+        except asyncio.CancelledError:
+            await _cleanup_failed_launch(container_id or container_name)
+            raise
+        except Exception:
+            await _cleanup_failed_launch(container_id or container_name)
             raise
         try:
             await self._wait_ready(container_id=container_id)
@@ -2936,16 +2992,11 @@ class DockerCodexManagedSessionController:
                 payload=container_payload,
                 extra_env={"MOONMIND_SESSION_CONTAINER_ID": container_id},
             )
+        except asyncio.CancelledError:
+            await _cleanup_failed_launch(container_id)
+            raise
         except Exception:
-            await self._remove_container(container_id, ignore_failure=True)
-            if docker_sidecar_enabled:
-                await self._cleanup_docker_sidecar_resources(
-                    request.session_id,
-                    ignore_failure=True,
-                )
-                self._cleanup_session_docker_config(request.session_workspace_path)
-            if github_broker_started:
-                await self._github_auth_brokers.stop(request.session_id)
+            await _cleanup_failed_launch(container_id)
             raise
         handle = self._with_runtime_family(
             CodexManagedSessionHandle.model_validate(payload),

--- a/tests/unit/services/temporal/runtime/test_managed_session_controller.py
+++ b/tests/unit/services/temporal/runtime/test_managed_session_controller.py
@@ -547,6 +547,174 @@ async def test_mm866_docker_enabled_session_launches_agent_with_sidecar(
     )
 
 @pytest.mark.asyncio
+async def test_launch_session_recreates_sidecar_after_name_conflict(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.delenv("MOONMIND_MANAGED_SESSION_DOCKER_NETWORK", raising=False)
+    monkeypatch.delenv("MOONMIND_DOCKER_NETWORK", raising=False)
+    workspace_root = tmp_path / "agent_jobs"
+    request = LaunchCodexManagedSessionRequest(
+        agentRunId="task-1",
+        sessionId="sess-1",
+        threadId="logical-thread-1",
+        workspacePath=str(workspace_root / "task-1" / "repo"),
+        sessionWorkspacePath=str(workspace_root / "task-1" / "session"),
+        artifactSpoolPath=str(workspace_root / "task-1" / "artifacts"),
+        codexHomePath="/home/app/.codex",
+        imageRef="ghcr.io/moonladderstudios/moonmind:latest",
+        environment={
+            "MOONMIND_URL": "http://api:8000",
+            "MOONMIND_WORKFLOW_DOCKER_MODE": "profiles",
+        },
+    )
+    commands: list[tuple[str, ...]] = []
+    sidecar_run_attempts = 0
+    sidecar_name = "moonmind-session-sess-1-docker"
+
+    async def _fake_runner(
+        command: tuple[str, ...],
+        *,
+        input_text: str | None = None,
+        env: dict[str, str] | None = None,
+    ) -> tuple[int, str, str]:
+        nonlocal sidecar_run_attempts
+        del input_text, env
+        commands.append(command)
+        if command[:3] == ("docker", "rm", "-f"):
+            return 0, "", ""
+        if command[:4] == ("docker", "volume", "rm", "-f"):
+            return 0, "", ""
+        if command[:3] == ("docker", "volume", "create"):
+            return 0, command[-1] + "\n", ""
+        if command[:2] == ("docker", "run"):
+            name = command[command.index("--name") + 1]
+            if name == sidecar_name:
+                sidecar_run_attempts += 1
+                if sidecar_run_attempts == 1:
+                    return (
+                        125,
+                        "",
+                        'docker: Error response from daemon: Conflict. '
+                        f'The container name "/{sidecar_name}" is already in use '
+                        'by container "old-sidecar". You have to remove '
+                        "(or rename) that container to be able to reuse that name.",
+                    )
+                return 0, "sidecar-ctr\n", ""
+            if name.endswith("-agent"):
+                return 0, "agent-ctr\n", ""
+        if command[:3] == ("docker", "exec", "-e") and "docker" in command:
+            return 0, '"27.0.0"\n', ""
+        if "ready" in command:
+            return 0, '{"ready": true}\n', ""
+        if "launch_session" in command:
+            payload = {
+                "sessionState": {
+                    "sessionId": request.session_id,
+                    "sessionEpoch": 1,
+                    "containerId": "agent-ctr",
+                    "threadId": request.thread_id,
+                },
+                "status": "ready",
+                "imageRef": request.image_ref,
+                "controlUrl": "docker-exec://moonmind-session-sess-1-agent",
+            }
+            return 0, json.dumps(payload), ""
+        raise AssertionError(f"unexpected command: {command}")
+
+    controller = DockerCodexManagedSessionController(
+        workspace_volume_name="agent_workspaces",
+        codex_volume_name="codex_auth_volume",
+        workspace_root=str(workspace_root),
+        command_runner=_fake_runner,
+        ready_poll_interval_seconds=0,
+    )
+
+    handle = await controller.launch_session(request)
+
+    assert handle.status == "ready"
+    assert sidecar_run_attempts == 2
+    assert commands.count(("docker", "rm", "-f", sidecar_name)) >= 2
+
+@pytest.mark.asyncio
+async def test_launch_session_cleans_up_sidecar_when_cancelled(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.delenv("MOONMIND_MANAGED_SESSION_DOCKER_NETWORK", raising=False)
+    monkeypatch.delenv("MOONMIND_DOCKER_NETWORK", raising=False)
+    workspace_root = tmp_path / "agent_jobs"
+    request = LaunchCodexManagedSessionRequest(
+        agentRunId="task-1",
+        sessionId="sess-1",
+        threadId="logical-thread-1",
+        workspacePath=str(workspace_root / "task-1" / "repo"),
+        sessionWorkspacePath=str(workspace_root / "task-1" / "session"),
+        artifactSpoolPath=str(workspace_root / "task-1" / "artifacts"),
+        codexHomePath="/home/app/.codex",
+        imageRef="ghcr.io/moonladderstudios/moonmind:latest",
+        environment={
+            "MOONMIND_URL": "http://api:8000",
+            "MOONMIND_WORKFLOW_DOCKER_MODE": "profiles",
+        },
+    )
+    commands: list[tuple[str, ...]] = []
+    sidecar_name = "moonmind-session-sess-1-docker"
+    agent_name = "moonmind-session-sess-1-agent"
+
+    async def _fake_runner(
+        command: tuple[str, ...],
+        *,
+        input_text: str | None = None,
+        env: dict[str, str] | None = None,
+    ) -> tuple[int, str, str]:
+        del input_text, env
+        commands.append(command)
+        if command[:3] == ("docker", "rm", "-f"):
+            return 0, "", ""
+        if command[:4] == ("docker", "volume", "rm", "-f"):
+            return 0, "", ""
+        if command[:3] == ("docker", "volume", "create"):
+            return 0, command[-1] + "\n", ""
+        if command[:2] == ("docker", "run"):
+            name = command[command.index("--name") + 1]
+            if name == sidecar_name:
+                return 0, "sidecar-ctr\n", ""
+            if name == agent_name:
+                raise asyncio.CancelledError()
+        if command[:3] == ("docker", "exec", "-e") and "docker" in command:
+            return 0, '"27.0.0"\n', ""
+        raise AssertionError(f"unexpected command: {command}")
+
+    controller = DockerCodexManagedSessionController(
+        workspace_volume_name="agent_workspaces",
+        codex_volume_name="codex_auth_volume",
+        workspace_root=str(workspace_root),
+        command_runner=_fake_runner,
+        ready_poll_interval_seconds=0,
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        await controller.launch_session(request)
+
+    assert commands.count(("docker", "rm", "-f", agent_name)) >= 1
+    assert commands.count(("docker", "rm", "-f", sidecar_name)) >= 2
+    assert (
+        "docker",
+        "volume",
+        "rm",
+        "-f",
+        "moonmind-session-sess-1-docker-socket",
+    ) in commands
+    assert (
+        "docker",
+        "volume",
+        "rm",
+        "-f",
+        "moonmind-session-sess-1-docker-graph",
+    ) in commands
+
+@pytest.mark.asyncio
 async def test_mm866_explicit_docker_denial_does_not_inherit_unrestricted_proxy(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/unit/workflows/temporal/test_activity_catalog.py
+++ b/tests/unit/workflows/temporal/test_activity_catalog.py
@@ -137,6 +137,17 @@ def test_plan_generate_timeout_budget_allows_retry_after_attempt_timeout():
     )
     assert route.retries.max_attempts == 3
 
+def test_launch_session_timeout_budget_covers_cold_sidecar_startup():
+    catalog = build_default_activity_catalog()
+
+    route = catalog.resolve_activity("agent_runtime.launch_session")
+
+    assert route.timeouts.start_to_close_seconds == 300
+    assert route.timeouts.schedule_to_close_seconds == 1200
+    assert route.timeouts.heartbeat_timeout_seconds == 120
+    assert route.heartbeat_required is True
+    assert route.retries.max_attempts == 3
+
 def test_resolve_skill_uses_capability_routing_for_mm_skill_execute():
     catalog = build_default_activity_catalog()
 


### PR DESCRIPTION
## Summary

Fixes managed Codex session launch failures caused by retry-poisoned Docker sidecar resources and an undersized launch activity timeout budget.

## Root Cause

`agent_runtime.launch_session` could retry after a partially completed launch while reusing deterministic Docker container names. If a previous attempt left the session sidecar behind, the next `docker run --name ...-docker` failed with a container-name conflict. A separate launch failure mode came from the activity timeout budget being too short for cold sidecar startup, agent container readiness, Docker capability probing, and app-server launch after slot contention.

## Changes

- Recreate sidecar socket/graph volumes through a shared helper.
- Detect same-session Docker name conflicts, clean up the stale sidecar resources, and retry once.
- Clean up agent containers, sidecars, sidecar volumes, Docker config, and GitHub auth broker state when launch is cancelled mid-flight.
- Increase `agent_runtime.launch_session` to a 300s StartToClose, 1200s ScheduleToClose, and 120s heartbeat timeout with heartbeat required.
- Add regression coverage for sidecar name conflicts, cancellation cleanup, and the launch timeout policy.

## Validation

- `MOONMIND_FORCE_LOCAL_TESTS=1 .venv/bin/python -m pytest -q -p no:cacheprovider tests/unit/services/temporal/runtime/test_managed_session_controller.py`
- `MOONMIND_FORCE_LOCAL_TESTS=1 .venv/bin/python -m pytest -q -p no:cacheprovider tests/unit/services/temporal/runtime/test_managed_session_controller.py -k 'launch_session or mm866 or sidecar' tests/unit/workflows/temporal/test_activity_catalog.py`
- `.venv/bin/python -m py_compile moonmind/workflows/temporal/runtime/managed_session_controller.py moonmind/workflows/temporal/activity_catalog.py tests/unit/services/temporal/runtime/test_managed_session_controller.py tests/unit/workflows/temporal/test_activity_catalog.py`

`./tools/test_unit.sh ...` is currently blocked locally before pytest by a root-owned unreadable `deploy/state/desired-state.json` file in the checkout.