### PR TITLE
MM-1107 Animate nav icons from whole item hover

### DIFF
--- a/frontend/src/entrypoints/dashboard-app.tsx
+++ b/frontend/src/entrypoints/dashboard-app.tsx
@@ -3,8 +3,10 @@ import {
   lazy,
   useEffect,
   useMemo,
+  useRef,
   useState,
   type ComponentType,
+  type Ref,
   type ReactNode,
 } from 'react';
 import {
@@ -21,9 +23,13 @@ import { QueryErrorResetBoundary, useQuery, useQueryClient } from '@tanstack/rea
 import { ScrollText } from 'lucide-react';
 import {
   MoonIcon,
+  type MoonIconHandle,
   RocketIcon,
+  type RocketIconHandle,
   SettingsIcon,
+  type SettingsIconHandle,
   SparklesIcon,
+  type SparklesIconHandle,
 } from 'lucide-animated';
 
 import type { BootPayload } from '../boot/parseBootPayload';
@@ -66,24 +72,102 @@ type NavIconProps = {
   className?: string | undefined;
 };
 
+type AnimatedNavIconHandle =
+  | MoonIconHandle
+  | RocketIconHandle
+  | SettingsIconHandle
+  | SparklesIconHandle;
+
+type AnimatedNavIconProps = NavIconProps & {
+  iconRef?: Ref<AnimatedNavIconHandle> | undefined;
+};
+
 function WorkflowsNavIcon({ className }: NavIconProps) {
   return <ScrollText size={NAV_ICON_SIZE} className={className} aria-hidden="true" />;
 }
 
-function StartWorkflowNavIcon({ className }: NavIconProps) {
-  return <RocketIcon size={NAV_ICON_SIZE} className={className} animateOnHover aria-hidden="true" />;
+function StartWorkflowNavIcon({ className, iconRef }: AnimatedNavIconProps) {
+  return (
+    <RocketIcon
+      ref={iconRef as Ref<RocketIconHandle>}
+      size={NAV_ICON_SIZE}
+      className={className}
+      animateOnHover={false}
+      aria-hidden="true"
+    />
+  );
 }
 
-function SchedulesNavIcon({ className }: NavIconProps) {
-  return <MoonIcon size={NAV_ICON_SIZE} className={className} animateOnHover aria-hidden="true" />;
+function SchedulesNavIcon({ className, iconRef }: AnimatedNavIconProps) {
+  return (
+    <MoonIcon
+      ref={iconRef as Ref<MoonIconHandle>}
+      size={NAV_ICON_SIZE}
+      className={className}
+      animateOnHover={false}
+      aria-hidden="true"
+    />
+  );
 }
 
-function SkillsNavIcon({ className }: NavIconProps) {
-  return <SparklesIcon size={NAV_ICON_SIZE} className={className} animateOnHover aria-hidden="true" />;
+function SkillsNavIcon({ className, iconRef }: AnimatedNavIconProps) {
+  return (
+    <SparklesIcon
+      ref={iconRef as Ref<SparklesIconHandle>}
+      size={NAV_ICON_SIZE}
+      className={className}
+      animateOnHover={false}
+      aria-hidden="true"
+    />
+  );
 }
 
-function SettingsNavIcon({ className }: NavIconProps) {
-  return <SettingsIcon size={NAV_ICON_SIZE} className={className} animateOnHover aria-hidden="true" />;
+function SettingsNavIcon({ className, iconRef }: AnimatedNavIconProps) {
+  return (
+    <SettingsIcon
+      ref={iconRef as Ref<SettingsIconHandle>}
+      size={NAV_ICON_SIZE}
+      className={className}
+      animateOnHover={false}
+      aria-hidden="true"
+    />
+  );
+}
+
+function AnimatedRouteNavLink({
+  to,
+  children,
+  icon,
+  className,
+}: {
+  to: string;
+  children: ReactNode;
+  icon: ComponentType<AnimatedNavIconProps>;
+  className: ({ isActive }: { isActive: boolean }) => string | undefined;
+}) {
+  const Icon = icon;
+  const iconRef = useRef<AnimatedNavIconHandle | null>(null);
+  const ref = iconRef as Ref<AnimatedNavIconHandle>;
+  const startAnimation = () => {
+    iconRef.current?.startAnimation();
+  };
+  const stopAnimation = () => {
+    iconRef.current?.stopAnimation();
+  };
+
+  return (
+    <NavLink
+      to={to}
+      className={className}
+      onMouseEnter={startAnimation}
+      onMouseLeave={stopAnimation}
+      onFocus={startAnimation}
+      onBlur={stopAnimation}
+    >
+      <Icon className="route-nav-icon" iconRef={ref} />
+      {children}
+    </NavLink>
+  );
 }
 
 function isSupportedPage(page: string): page is DashboardPage {
@@ -305,22 +389,34 @@ function DashboardNavigation({ uiInfo }: { uiInfo: DashboardUiInfo | null }) {
             <WorkflowsNavIcon className="route-nav-icon" />
             Workflows
           </NavLink>
-          <NavLink to="/workflows/new" className={({ isActive }) => (isActive ? 'active' : undefined)}>
-            <StartWorkflowNavIcon className="route-nav-icon" />
+          <AnimatedRouteNavLink
+            to="/workflows/new"
+            icon={StartWorkflowNavIcon}
+            className={({ isActive }) => (isActive ? 'active' : undefined)}
+          >
             Create
-          </NavLink>
-          <NavLink to="/schedules" className={({ isActive }) => (isActive ? 'active' : undefined)}>
-            <SchedulesNavIcon className="route-nav-icon" />
+          </AnimatedRouteNavLink>
+          <AnimatedRouteNavLink
+            to="/schedules"
+            icon={SchedulesNavIcon}
+            className={({ isActive }) => (isActive ? 'active' : undefined)}
+          >
             Schedules
-          </NavLink>
-          <NavLink to="/skills" className={({ isActive }) => (isActive ? 'active' : undefined)}>
-            <SkillsNavIcon className="route-nav-icon" />
+          </AnimatedRouteNavLink>
+          <AnimatedRouteNavLink
+            to="/skills"
+            icon={SkillsNavIcon}
+            className={({ isActive }) => (isActive ? 'active' : undefined)}
+          >
             Skills
-          </NavLink>
-          <NavLink to="/settings" className={({ isActive }) => (isActive ? 'active' : undefined)}>
-            <SettingsNavIcon className="route-nav-icon" />
+          </AnimatedRouteNavLink>
+          <AnimatedRouteNavLink
+            to="/settings"
+            icon={SettingsNavIcon}
+            className={({ isActive }) => (isActive ? 'active' : undefined)}
+          >
             Settings
-          </NavLink>
+          </AnimatedRouteNavLink>
         </nav>
       </div>
 

--- a/frontend/src/entrypoints/dashboard-app.tsx
+++ b/frontend/src/entrypoints/dashboard-app.tsx
@@ -146,8 +146,7 @@ function AnimatedRouteNavLink({
   className: ({ isActive }: { isActive: boolean }) => string | undefined;
 }) {
   const Icon = icon;
-  const iconRef = useRef<AnimatedNavIconHandle | null>(null);
-  const ref = iconRef as Ref<AnimatedNavIconHandle>;
+  const iconRef = useRef<AnimatedNavIconHandle>(null);
   const startAnimation = () => {
     iconRef.current?.startAnimation();
   };
@@ -164,7 +163,7 @@ function AnimatedRouteNavLink({
       onFocus={startAnimation}
       onBlur={stopAnimation}
     >
-      <Icon className="route-nav-icon" iconRef={ref} />
+      <Icon className="route-nav-icon" iconRef={iconRef} />
       {children}
     </NavLink>
   );

--- a/frontend/src/entrypoints/dashboard.test.tsx
+++ b/frontend/src/entrypoints/dashboard.test.tsx
@@ -16,6 +16,17 @@ import { fireEvent, renderWithClient, screen, waitFor } from '../utils/test-util
 import { DashboardApp } from './dashboard-app';
 import { navigateTo } from '../lib/navigation';
 
+const animatedNavIconMocks = vi.hoisted(() => ({
+  moonStart: vi.fn(),
+  moonStop: vi.fn(),
+  rocketStart: vi.fn(),
+  rocketStop: vi.fn(),
+  settingsStart: vi.fn(),
+  settingsStop: vi.fn(),
+  sparklesStart: vi.fn(),
+  sparklesStop: vi.fn(),
+}));
+
 function normalizeCssSelector(selector: string): string {
   return selector
     .replace(/\s*\{\s*$/, '')
@@ -104,6 +115,59 @@ vi.mock('@xterm/addon-fit', () => ({
     fit() {}
   },
 }));
+
+vi.mock('lucide-animated', async () => {
+  const React = await vi.importActual<typeof import('react')>('react');
+  type AnimatedIconProps = {
+    'aria-hidden'?: boolean | 'true' | 'false';
+    animateOnHover?: boolean;
+    className?: string;
+    size?: number;
+  };
+
+  function createAnimatedIcon(
+    testId: string,
+    startAnimation: () => void,
+    stopAnimation: () => void,
+  ) {
+    return React.forwardRef<unknown, AnimatedIconProps>((props, ref) => {
+      React.useImperativeHandle(ref, () => ({
+        startAnimation,
+        stopAnimation,
+      }));
+      return React.createElement('svg', {
+        'aria-hidden': props['aria-hidden'],
+        className: props.className,
+        'data-animate-on-hover': String(props.animateOnHover),
+        'data-size': props.size,
+        'data-testid': testId,
+      });
+    });
+  }
+
+  return {
+    MoonIcon: createAnimatedIcon(
+      'animated-nav-icon-schedules',
+      animatedNavIconMocks.moonStart,
+      animatedNavIconMocks.moonStop,
+    ),
+    RocketIcon: createAnimatedIcon(
+      'animated-nav-icon-create',
+      animatedNavIconMocks.rocketStart,
+      animatedNavIconMocks.rocketStop,
+    ),
+    SettingsIcon: createAnimatedIcon(
+      'animated-nav-icon-settings',
+      animatedNavIconMocks.settingsStart,
+      animatedNavIconMocks.settingsStop,
+    ),
+    SparklesIcon: createAnimatedIcon(
+      'animated-nav-icon-skills',
+      animatedNavIconMocks.sparklesStart,
+      animatedNavIconMocks.sparklesStop,
+    ),
+  };
+});
 
 // MM-960: simulate a transient dynamic-import (chunk-load) failure for one page
 // so we can assert the route boundary's Retry recreates the lazy import instead
@@ -223,6 +287,7 @@ describe('Dashboard shared entry', () => {
   });
 
   beforeEach(() => {
+    Object.values(animatedNavIconMocks).forEach((mock) => mock.mockClear());
     fetchSpy = vi.spyOn(window, 'fetch').mockImplementation((input: RequestInfo | URL) => {
       const url = String(input);
       if (url === '/api/ui/info') {
@@ -257,6 +322,35 @@ describe('Dashboard shared entry', () => {
     window.WebSocket = originalWebSocket;
     document.querySelectorAll('[data-nav]').forEach((node) => node.remove());
     window.history.replaceState({}, '', '/');
+  });
+
+  it('MM-1107 animates lucide nav icons from the whole route link hover', async () => {
+    window.history.replaceState({}, '', '/workflows');
+    renderWithClient(<DashboardApp payload={{ page: 'dashboard', apiBase: '/api' }} />);
+
+    await screen.findByText('Workflow list route loaded', {}, { timeout: 10000 });
+
+    const workflowsLink = screen.getByRole('link', { name: 'Workflows' });
+    expect(workflowsLink.querySelector('[data-testid^="animated-nav-icon-"]')).toBeNull();
+
+    const createLink = screen.getByRole('link', { name: 'Create' });
+    const createIcon = screen.getByTestId('animated-nav-icon-create');
+    expect(createIcon.getAttribute('data-animate-on-hover')).toBe('false');
+
+    fireEvent.mouseEnter(createLink);
+    expect(animatedNavIconMocks.rocketStart).toHaveBeenCalledTimes(1);
+
+    fireEvent.mouseLeave(createLink);
+    expect(animatedNavIconMocks.rocketStop).toHaveBeenCalledTimes(1);
+
+    fireEvent.mouseEnter(screen.getByRole('link', { name: 'Schedules' }));
+    expect(animatedNavIconMocks.moonStart).toHaveBeenCalledTimes(1);
+
+    fireEvent.mouseEnter(screen.getByRole('link', { name: 'Skills' }));
+    expect(animatedNavIconMocks.sparklesStart).toHaveBeenCalledTimes(1);
+
+    fireEvent.mouseEnter(screen.getByRole('link', { name: 'Settings' }));
+    expect(animatedNavIconMocks.settingsStart).toHaveBeenCalledTimes(1);
   });
 
   it('renders dashboard alerts and lazy-loads the requested page component', async () => {


### PR DESCRIPTION
## Summary
- Updates animated dashboard nav icons so the enclosing nav link starts and stops animation on hover and focus.
- Leaves the Workflows ScrollText icon non-animated as allowed.
- Adds focused dashboard UI coverage for MM-1107.

## Verification
- Existing structured verifier artifact: FULLY_IMPLEMENTED at /work/agent_jobs/mm:01ba120a-504d-4bcd-afa7-f20f1ed532da/artifacts/jira-implement-verify.json
- Focused frontend unit: PASS via ./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/dashboard.test.tsx
- Unit wrapper noted environment prerequisite failure: python module pytest missing in this runtime
