### PR TITLE
[codex] document chat instruction intervention architecture

### DIFF
--- a/docs/Api/ChatInstructionsApiContract.md
+++ b/docs/Api/ChatInstructionsApiContract.md
@@ -34,8 +34,10 @@ Path parameters:
 
 Success status:
 
-- `200 OK` when a running execution accepts or rejects the instruction through workflow logic.
+- `200 OK` when a running execution accepts the instruction through workflow logic.
 - `201 Created` when the API creates a linked follow-up execution for a terminal source.
+
+Rejected instructions are not success responses. Well-formed instructions rejected by state or policy return `409 chat_instruction_rejected`; invalid request shape or domain validation returns `422 invalid_chat_instruction_request`.
 
 ## 3. Request body
 
@@ -75,7 +77,7 @@ Rules:
 
 - `message` is accepted at the API boundary and then stored as an artifact before workflow delivery.
 - The workflow-facing Update receives `messageArtifactRef`, not the full user message.
-- `instructionId` and/or `idempotencyKey` should dedupe retries.
+- `instructionId` and/or `idempotencyKey` are stable client keys and must dedupe retries.
 - `observedState` lets the workflow reject stale UI targets before applying semantic effects.
 - `policy` expresses caller/product permission for destructive changes such as active-Step cancel-and-reattempt.
 

--- a/docs/Api/ChatInstructionsApiContract.md
+++ b/docs/Api/ChatInstructionsApiContract.md
@@ -1,0 +1,181 @@
+# Chat Instructions API Contract
+
+**Status:** Design Draft  
+**Owner:** MoonMind Platform  
+**Last updated:** 2026-07-02  
+**Audience:** backend, dashboard, integrations
+
+**Implementation tracking:** Rollout tasks and implementation checklists belong under `docs/tmp/`, issues, or pull requests. This document defines the public API contract target.
+
+## 1. Purpose
+
+This document defines the `/api/executions/{workflowId}/chat-instructions` endpoint. It is the preferred API surface for user chat that is intended to steer a Temporal-backed Workflow Execution.
+
+The endpoint is deliberately separate from the generic update endpoint because chat instructions need API-owned behavior before and after the Temporal call:
+
+- authorization against the source execution,
+- chat text artifact creation,
+- policy checks,
+- running-vs-terminal state routing,
+- linked follow-up execution creation for terminal sources,
+- response normalization for the dashboard chat panel.
+
+## 2. Endpoint
+
+```http
+POST /api/executions/{workflowId}/chat-instructions
+```
+
+Path parameters:
+
+| Field | Meaning |
+| --- | --- |
+| `workflowId` | Source Workflow Execution identity and target for running-workflow chat. |
+
+Success status:
+
+- `200 OK` when a running execution accepts or rejects the instruction through workflow logic.
+- `201 Created` when the API creates a linked follow-up execution for a terminal source.
+
+## 3. Request body
+
+Representative shape:
+
+```json
+{
+  "instructionId": "client-generated-id",
+  "idempotencyKey": "optional-dedupe-key",
+  "chatThreadId": "optional-thread-id",
+  "message": "Use the Provider Profiles wording in the remaining steps.",
+  "scope": "auto",
+  "intentHint": "unknown",
+  "target": {
+    "runId": "current-run-id",
+    "logicalStepId": "optional-step-id",
+    "stepExecutionOrdinal": 1,
+    "planRevision": 2,
+    "childWorkflowId": "optional-child-id"
+  },
+  "observedState": {
+    "runId": "current-run-id-seen-by-client",
+    "logicalStepId": "active-step-seen-by-client",
+    "planRevision": 2,
+    "updatedAt": "2026-07-02T00:00:00Z"
+  },
+  "policy": {
+    "allowCancelActiveStep": false,
+    "allowVoidFutureSteps": true,
+    "allowCreateFollowupExecution": true,
+    "requireApprovalForExternalSideEffects": true
+  }
+}
+```
+
+Rules:
+
+- `message` is accepted at the API boundary and then stored as an artifact before workflow delivery.
+- The workflow-facing Update receives `messageArtifactRef`, not the full user message.
+- `instructionId` and/or `idempotencyKey` should dedupe retries.
+- `observedState` lets the workflow reject stale UI targets before applying semantic effects.
+- `policy` expresses caller/product permission for destructive changes such as active-Step cancel-and-reattempt.
+
+## 4. Running execution behavior
+
+When the source execution is non-terminal, the API sends the `SubmitChatInstruction` Update to `MoonMind.UserWorkflow`.
+
+The workflow returns a `ChatInstructionDecision` and remains authoritative for the semantic effect.
+
+Allowed decisions include:
+
+```text
+attached_to_active_step
+queued_for_safe_point
+queued_for_step
+active_step_cancel_requested
+step_reattempt_scheduled
+plan_revision_requested
+future_steps_superseded
+rejected_stale_target
+rejected_terminal
+rejected_policy
+rejected_invalid_payload
+rejected_unsupported_runtime
+```
+
+The API must not locally claim acceptance if the workflow rejects the Update.
+
+## 5. Terminal execution behavior
+
+When the source execution is terminal, the API does not send an ordinary chat mutation to the closed workflow.
+
+If policy permits follow-up creation, the API starts a linked Workflow Execution with source refs pinned in the new execution input:
+
+```json
+{
+  "chatFollowup": {
+    "sourceWorkflowId": "mm:source",
+    "sourceRunId": "source-run-id",
+    "sourcePlanRef": "artifact://plan",
+    "sourceFinishSummaryRef": "artifact://finish-summary",
+    "sourceStepLedgerRef": "artifact://optional-step-ledger-snapshot",
+    "chatInstructionRef": "artifact://instruction"
+  }
+}
+```
+
+The response decision is `created_followup_execution` and includes `followupWorkflowId`.
+
+If policy does not permit follow-up creation, the response is a typed rejection such as `rejected_terminal` or `rejected_policy`.
+
+## 6. Response body
+
+Representative running-workflow response:
+
+```json
+{
+  "accepted": true,
+  "instructionId": "client-generated-id",
+  "decision": "attached_to_active_step",
+  "workflowId": "mm:source",
+  "runId": "current-run-id",
+  "targetLogicalStepId": "implement-change",
+  "childWorkflowId": "mm:source:agent:implement-change",
+  "messageArtifactRef": "artifact://chat-instruction",
+  "newPlanRef": null,
+  "followupWorkflowId": null,
+  "warnings": []
+}
+```
+
+Representative terminal follow-up response:
+
+```json
+{
+  "accepted": true,
+  "instructionId": "client-generated-id",
+  "decision": "created_followup_execution",
+  "workflowId": "mm:source",
+  "runId": "source-run-id",
+  "messageArtifactRef": "artifact://chat-instruction",
+  "newPlanRef": null,
+  "followupWorkflowId": "mm:followup",
+  "warnings": []
+}
+```
+
+## 7. Error responses
+
+| Status | Code | Meaning |
+| --- | --- | --- |
+| `404` | `execution_not_found` | Source execution does not exist or is not visible to the caller. |
+| `409` | `chat_instruction_rejected` | Instruction is well-formed but rejected by state or policy. |
+| `422` | `invalid_chat_instruction_request` | Request shape or domain validation failed. |
+| `503` | `temporal_unavailable` | Running execution requires Temporal but Temporal is unavailable. |
+
+## 8. Relationship to other execution actions
+
+- `SubmitChatInstruction` is not a replacement for `Cancel`.
+- `SubmitChatInstruction` is not failed-step recovery.
+- `SubmitChatInstruction` is not `RequestRerun` unless a future policy explicitly maps a chat intent to a new-run flow.
+- Chat-driven terminal follow-up starts a new linked Workflow Execution and leaves the source unchanged.
+- Chat-driven future-Step changes create new plan artifacts and supersede future Step rows rather than editing old plan artifacts in place.

--- a/docs/Temporal/ChatInstructionTemporalContract.md
+++ b/docs/Temporal/ChatInstructionTemporalContract.md
@@ -25,14 +25,14 @@ Reasons:
 - the workflow must validate stale `runId`, Step, plan revision, and policy before accepting semantic effects,
 - the response must explain whether the instruction attached to active work, queued for a safe point, triggered replan, or was rejected.
 
-Internal child workflow delivery may use Signals, including the existing `operator_message` shape or a typed successor. Signals are appropriate after the parent has accepted the instruction and is notifying an active child asynchronously.
+Internal child workflow delivery uses a typed artifact-ref Signal after the parent has accepted the instruction and is notifying an active child asynchronously. The existing `operator_message` Signal remains legacy non-chat behavior because it carries raw message text in workflow history.
 
 ## 3. Update handling pattern
 
 The `SubmitChatInstruction` handler should stay lightweight:
 
 1. validate the typed request,
-2. dedupe by `instructionId`, `idempotencyKey`, or Temporal Update ID,
+2. dedupe by stable client keys (`idempotencyKey` and/or `instructionId`) when present, with Temporal Update ID only as a fallback for requests without a client key,
 3. reject stale targets before acceptance,
 4. record a compact instruction command in workflow state,
 5. wake the main workflow loop,

--- a/docs/Temporal/ChatInstructionTemporalContract.md
+++ b/docs/Temporal/ChatInstructionTemporalContract.md
@@ -1,0 +1,102 @@
+# Temporal Chat Instruction Contract
+
+**Status:** Design Draft / normative target  
+**Owner:** MoonMind Platform  
+**Last updated:** 2026-07-02  
+**Audience:** backend, workflow authors, managed-runtime, integrations
+
+**Implementation tracking:** Rollout tasks and tactical sequencing belong under `docs/tmp/`, issues, pull requests, or local-only handoffs.
+
+## 1. Purpose
+
+This document defines the Temporal-facing contract for chat instructions. It is a focused companion to `docs/Workflows/ChatInstructionIntervention.md` and should be folded into the larger Temporal architecture docs as implementation stabilizes.
+
+## 2. Primitive selection
+
+Public user chat instructions use a Temporal Update:
+
+```text
+MoonMind.UserWorkflow.SubmitChatInstruction
+```
+
+Reasons:
+
+- the caller needs synchronous accepted/rejected semantics,
+- the workflow must validate stale `runId`, Step, plan revision, and policy before accepting semantic effects,
+- the response must explain whether the instruction attached to active work, queued for a safe point, triggered replan, or was rejected.
+
+Internal child workflow delivery may use Signals, including the existing `operator_message` shape or a typed successor. Signals are appropriate after the parent has accepted the instruction and is notifying an active child asynchronously.
+
+## 3. Update handling pattern
+
+The `SubmitChatInstruction` handler should stay lightweight:
+
+1. validate the typed request,
+2. dedupe by `instructionId`, `idempotencyKey`, or Temporal Update ID,
+3. reject stale targets before acceptance,
+4. record a compact instruction command in workflow state,
+5. wake the main workflow loop,
+6. return `ChatInstructionDecision`.
+
+The handler must not perform provider calls, artifact writes, or plan generation directly. Those belong in Activities or in the main workflow loop after the command is accepted.
+
+## 4. Main-loop safe points
+
+`MoonMind.UserWorkflow` should drain accepted chat commands at safe points such as:
+
+- before selecting the next ready Step,
+- before launching a child `MoonMind.AgentRun`,
+- while paused,
+- while awaiting provider/profile slot assignment,
+- between external-provider polling cycles,
+- before final completion if a bounded completion-grace window is enabled.
+
+Conflicting mutations are serialized through the workflow-owned command queue rather than by relying on handler interleaving behavior.
+
+## 5. Continue-As-New carry-forward
+
+Continue-As-New payloads must not carry full chat text. Carry-forward state is limited to:
+
+- current plan ref and plan revision,
+- pending compact chat instruction commands,
+- processed instruction IDs needed for bounded dedupe,
+- active Step and child refs,
+- Step ledger compact state,
+- artifact refs needed to resume safely.
+
+## 6. Child workflow delivery
+
+When a chat instruction targets active agent work, the parent workflow may signal the child `MoonMind.AgentRun` with an internal typed message.
+
+Recommended internal payload concepts:
+
+```json
+{
+  "instructionId": "client-generated-id",
+  "messageArtifactRef": "artifact://chat-instruction",
+  "messageSummary": "Bounded display summary",
+  "targetLogicalStepId": "implement-change",
+  "stepExecutionOrdinal": 1,
+  "deliveryPolicy": "append_live"
+}
+```
+
+Child delivery remains best-effort unless the runtime declares stronger support. The parent decision should distinguish accepted workflow instruction from confirmed provider/runtime delivery when that distinction matters to the UI.
+
+## 7. Replan and reattempt boundaries
+
+Plan revision and active-Step reattempt are workflow orchestration effects, not Signal effects.
+
+- Plan revision should call a planning Activity such as `plan.revise_from_chat_instruction`.
+- Active-Step reattempt should request cancellation of the active child, preserve evidence, then start a new Step Execution attempt.
+- External side effects require explicit policy or approval before automatic compensation.
+
+## 8. Terminal executions
+
+Closed Workflow Executions do not accept `SubmitChatInstruction` as an ordinary mutation. The API creates linked follow-up executions for terminal sources and pins source `workflowId`, source `runId`, plan refs, finish-summary refs, optional Step ledger refs, and chat instruction refs.
+
+## 9. Visibility posture
+
+The workflow may update `mm_updated_at` on accepted chat instructions. Do not put chat text, full summaries, prompts, diffs, logs, or provider payloads into Search Attributes or Memo.
+
+A future `mm_state = replanning` value should be added only if product surfaces need a first-class list/detail state for chat-driven plan revision.

--- a/docs/Temporal/WorkflowExecutionProductModel.md
+++ b/docs/Temporal/WorkflowExecutionProductModel.md
@@ -2,13 +2,13 @@
 
 **Status:** Normative
 **Owner:** MoonMind Platform
-**Last updated:** 2026-05-21
+**Last updated:** 2026-07-02
 **Audience:** operators, integrators, backend, dashboard, workflow authors
 **Source design:** `docs/Temporal/WorkflowLanguageHardSwitchPlan.md`
 
 MoonMind work is represented as Temporal-backed Workflow Executions. MoonMind does not define a separate product entity named Task. The word Task is reserved for Temporal internals and explicitly qualified external systems. A logical Step may have one or more Step Executions; retries are low-level operations inside a Step Execution.
 
-In informal UI copy, **Workflow** may be used as shorthand for **Workflow Execution** when the context is clear. In APIs, schemas, docs, and operator contracts, use the exact term **Workflow Execution**.
+In informal UI copy, **Workflow** may be used as shorthand for **Workflow Execution** when the context is clear. In APIs, schemas, docs, and operator contracts, use the exact term **Workflow Execution**. Chat-facing product copy may use **chat** for the user message surface, but chat is an input/control surface over Workflow Executions rather than a separate execution entity.
 
 ## Canonical Model
 
@@ -21,7 +21,9 @@ In informal UI copy, **Workflow** may be used as shorthand for **Workflow Execut
 | `entry` | A short, URL-safe workflow type slug used in payloads and routing. For example, `user_workflow` identifies `MoonMind.UserWorkflow`. |
 | **Step** | A user-visible unit of work inside a Workflow Execution. A Step is not a Temporal Activity and not a Temporal Task. |
 | **Step Execution** | One semantic execution of a logical Step, scoped to the Workflow Execution, latest run, logical step, and execution ordinal. |
-| **artifacts** | Durable evidence, inputs, outputs, diagnostics, reports, logs, checkpoints, and other large content stored outside workflow history and referenced by compact artifact refs. |
+| **chat instruction** | A typed, artifact-backed user chat message intended to affect a Workflow Execution. Running executions receive it through `SubmitChatInstruction`; terminal executions may create linked follow-up executions. |
+| **chat thread** | A UI/product grouping of chat instructions and related Workflow Executions. It is not the durable execution identity unless a future `MoonMind.ChatThread` workflow is explicitly introduced. |
+| **artifacts** | Durable evidence, inputs, outputs, diagnostics, reports, logs, checkpoints, chat instruction records, and other large content stored outside workflow history and referenced by compact artifact refs. |
 | `externalRefs` | Qualified links to external systems such as Jira, GitHub, Codex, or another provider. External IDs are references, not MoonMind identity. |
 
 ## Identity Rules
@@ -29,7 +31,7 @@ In informal UI copy, **Workflow** may be used as shorthand for **Workflow Execut
 - Use `workflowId` as the stable product identity and route key.
 - Use `runId` for the current/latest Temporal run instance.
 - Do not route primary product pages by `runId`.
-- Do not make Jira, GitHub, Codex, or provider IDs part of MoonMind identity.
+- Do not make Jira, GitHub, Codex, provider IDs, chat message IDs, or chat thread IDs part of MoonMind execution identity.
 - Store external provider identifiers in `externalRefs`.
 
 Example:
@@ -57,9 +59,21 @@ Example:
 
 ## Step Model
 
-A Workflow Execution is composed from Steps. Each Step represents user-visible work in the plan or ledger. A Step may execute once, be skipped, fail, or be re-executed after recovery.
+A Workflow Execution is composed from Steps. Each Step represents user-visible work in the plan or ledger. A Step may execute once, be skipped, fail, be superseded by a chat-driven plan revision, or be re-executed after recovery or chat-driven reattempt.
 
-A Step Execution is the semantic execution of a Step. Retries of Activities, provider calls, or other idempotent operations inside the same semantic execution do not create a new Step Execution. Re-executing a Step after recovery creates a new Step Execution with a new ordinal and new evidence artifacts.
+A Step Execution is the semantic execution of a Step. Retries of Activities, provider calls, or other idempotent operations inside the same semantic execution do not create a new Step Execution. Re-executing a Step after recovery or a chat-driven cancel-and-reattempt creates a new Step Execution with a new ordinal and new evidence artifacts.
+
+## Chat Instruction Model
+
+Chat is a control and clarification surface over Workflow Executions.
+
+Rules:
+
+- A running Workflow Execution may accept chat instructions through the typed `SubmitChatInstruction` Update.
+- A terminal Workflow Execution does not mutate in response to chat; the API may create a linked follow-up execution with pinned source refs.
+- Chat instructions that alter future work create new plan artifacts and supersede future Step rows rather than editing old plan artifacts in place.
+- Raw chat text belongs in artifacts. Workflow history, Search Attributes, Memo, and Step rows carry compact refs and bounded summaries only.
+- A chat thread may group source and follow-up executions in the UI, but `workflowId` remains the execution route key.
 
 ## Allowed Uses Of Task
 
@@ -79,3 +93,5 @@ Do not use an unqualified Task label for MoonMind-owned product work.
 `MoonMind.UserWorkflow` is the user-submitted, Step-ledger-owning Workflow Execution type. Existing references to `MoonMind.UserWorkflow` identify the current live workflow implementation or historic naming, not a separate product entity named Task.
 
 `MoonMind.AgentRun` remains the durable lifecycle wrapper for one true managed or external agent execution. `MoonMind.ManifestIngest`, `MoonMind.AgentSession`, `MoonMind.ManagedSessionReconcile`, `MoonMind.ProviderProfileManager`, `MoonMind.OAuthSession`, and `MoonMind.MergeAutomation` keep their specialized workflow semantics.
+
+A future `MoonMind.ChatThread` workflow should be added only if chat threads become durable orchestration objects that need to own multi-execution lifecycle, not merely because the UI has a chat panel.

--- a/docs/UI/WorkflowChatPanel.md
+++ b/docs/UI/WorkflowChatPanel.md
@@ -1,0 +1,116 @@
+# Workflow Chat Panel
+
+**Status:** Design Draft  
+**Owner:** MoonMind Dashboard  
+**Last updated:** 2026-07-02  
+**Audience:** dashboard, backend, workflow authors
+
+**Implementation tracking:** Rollout tasks belong under `docs/tmp/`, issues, or pull requests.
+
+## 1. Purpose
+
+This document defines the dashboard contract for the workflow detail chat panel. The panel lets a user submit chat instructions that affect a running Workflow Execution or create linked follow-up work after completion.
+
+This is a UI companion to:
+
+- `docs/Workflows/ChatInstructionIntervention.md`
+- `docs/Api/ChatInstructionsApiContract.md`
+- `docs/Temporal/ChatInstructionTemporalContract.md`
+
+## 2. Product stance
+
+The chat panel is a control and clarification surface for Workflow Executions. It does not replace the Step ledger, artifacts, logs, or execution actions.
+
+The UI must render the explicit `ChatInstructionDecision` returned by the API. It must not infer acceptance from local state or optimistic UI alone.
+
+## 3. Entry points
+
+The workflow detail page may expose the chat panel when:
+
+- the caller is authorized to update or follow up on the execution,
+- the execution is running, waiting, paused, or terminal with follow-up policy enabled,
+- the backend runtime config exposes the chat instruction endpoint.
+
+The panel should be available from the main detail route:
+
+```text
+/workflows/{workflowId}
+```
+
+## 4. Send flow
+
+The panel sends:
+
+```http
+POST /api/executions/{workflowId}/chat-instructions
+```
+
+The request includes the chat message, optional target hints, the current UI-observed `runId`, active `logicalStepId`, plan revision when known, and policy flags implied by the selected UI action.
+
+The response tells the UI what happened.
+
+## 5. Decision rendering
+
+| Decision | UI behavior |
+| --- | --- |
+| `attached_to_active_step` | Show accepted state on the message and link to the active Step. |
+| `queued_for_safe_point` | Show queued state and explain that it will apply before the next safe boundary. |
+| `queued_for_step` | Show the target Step or next Step if known. |
+| `active_step_cancel_requested` | Show that current active work is being canceled before reattempt. |
+| `step_reattempt_scheduled` | Show the new Step Execution attempt once available. |
+| `plan_revision_requested` | Show replanning state and keep the Step list loading from server truth. |
+| `future_steps_superseded` | Show superseded Step badges and link to the new plan revision. |
+| `created_followup_execution` | Show a link to the follow-up Workflow Execution. |
+| `rejected_stale_target` | Ask the user to refresh or retarget because the page was stale. |
+| `rejected_terminal` | Offer follow-up creation if policy allows. |
+| `rejected_policy` | Explain the policy block and show available safe actions. |
+| `rejected_unsupported_runtime` | Explain that the active runtime cannot accept live chat instructions. |
+
+## 6. Targeting controls
+
+The first implementation may default to `scope = auto`. Advanced controls may later allow:
+
+- target active Step,
+- target a specific Step,
+- apply to future Steps,
+- create follow-up from a completed execution,
+- allow or deny active-Step cancellation,
+- allow or deny future-Step voiding.
+
+Target controls should be disabled or hidden when the backend cannot enforce the requested policy.
+
+## 7. Step ledger integration
+
+The Steps section remains the primary operator comprehension surface. The chat panel should not duplicate Step truth.
+
+When chat changes Step state, the UI should refetch or subscribe to server state and render:
+
+- instruction refs on affected Step rows,
+- new Step Execution attempts,
+- superseded future Steps,
+- plan revision refs,
+- follow-up links for terminal source executions.
+
+## 8. Terminal follow-up UI
+
+For terminal executions, the composer should make the product behavior explicit:
+
+- the source execution will remain unchanged,
+- a new linked follow-up execution may be created,
+- the follow-up will pin source workflow/run/plan/report refs,
+- the user will be taken to or shown a link to the follow-up Workflow Execution.
+
+## 9. Stale-state handling
+
+Every chat request should include the UI-observed `runId`, active Step, and plan revision when known. If the backend returns `rejected_stale_target`, the panel should refresh execution detail and Step ledger before allowing retry.
+
+## 10. Rollout flags
+
+Recommended flags:
+
+- `workflowChatPanelEnabled`
+- `workflowChatFollowupEnabled`
+- `workflowChatPlanRevisionEnabled`
+- `workflowChatCancelReattemptEnabled`
+
+Read-first behavior remains required: the UI should fetch current execution detail and Step ledger before presenting destructive chat actions.

--- a/docs/UI/WorkflowChatPanel.md
+++ b/docs/UI/WorkflowChatPanel.md
@@ -64,6 +64,7 @@ The response tells the UI what happened.
 | `rejected_stale_target` | Ask the user to refresh or retarget because the page was stale. |
 | `rejected_terminal` | Offer follow-up creation if policy allows. |
 | `rejected_policy` | Explain the policy block and show available safe actions. |
+| `rejected_invalid_payload` | Explain that the submitted instruction payload or target state is invalid. |
 | `rejected_unsupported_runtime` | Explain that the active runtime cannot accept live chat instructions. |
 
 ## 6. Targeting controls

--- a/docs/Workflows/ChatInstructionIntervention.md
+++ b/docs/Workflows/ChatInstructionIntervention.md
@@ -1,0 +1,105 @@
+# Chat Instruction Intervention
+
+**Status:** Design Draft / normative target  
+**Owner:** MoonMind Platform  
+**Last updated:** 2026-07-02  
+**Audience:** backend, workflow authors, dashboard, integrations, managed-runtime, operators
+
+**Implementation tracking:** Rollout tasks and tactical sequencing belong under `docs/tmp/`, issues, pull requests, or local-only handoffs. This document defines the durable architecture and product contract.
+
+## 1. Purpose
+
+MoonMind is adding a chat interface to active and completed Workflow Executions. This document defines how a user chat message can safely affect Temporal-managed work without turning the API, dashboard, or projection layer into a second orchestration engine.
+
+The preferred product term is **chat**. New public contracts should use names such as `chatInstruction`, `chatThread`, and `SubmitChatInstruction`.
+
+A chat message becomes a typed, artifact-backed workflow instruction. `MoonMind.UserWorkflow` decides whether it attaches to the active Step, queues for a safe point, triggers a plan revision, cancels and reattempts active work, creates a linked follow-up execution, or rejects the request.
+
+## 2. Related docs
+
+This document is the cross-cutting owner for chat instruction intervention and should be reflected by the Temporal architecture, workflow lifecycle, signal/update, type-safety, Step ledger, run-history, artifact, API, UI, and managed-runtime docs.
+
+## 3. Design principles
+
+1. **Chat is an input surface, not an orchestrator.** The dashboard and API may classify and route a chat instruction, but they must not schedule work independently of Temporal workflow state.
+2. **Public chat mutations use Updates.** The running-workflow primitive is `SubmitChatInstruction`; internal child delivery may use compact Signals such as `operator_message`.
+3. **Chat text is artifact-backed.** Workflow history, Search Attributes, Memo, and Step rows carry compact refs, summaries, hashes, and bounded metadata only.
+4. **The workflow serializes conflicting mutations.** The Update validates, dedupes, records a compact command, wakes the main loop, and returns a bounded decision. The main loop drains commands at safe points.
+5. **Closed executions are immutable.** Terminal Workflow Executions do not accept ordinary chat mutation; the API creates linked follow-up executions with pinned source refs.
+6. **Replanning creates a new plan artifact.** Chat that changes future work creates a plan revision and records superseded future Steps.
+
+## 4. Public control surface
+
+Preferred endpoint:
+
+```http
+POST /api/executions/{workflowId}/chat-instructions
+```
+
+The endpoint authenticates the caller, stores the chat message as an instruction artifact, inspects execution state, calls the `SubmitChatInstruction` Update when the execution is running, creates a linked follow-up execution when the source execution is terminal, and returns a `ChatInstructionDecision`.
+
+The generic update endpoint may also accept `updateName = SubmitChatInstruction`, but the dedicated route is preferred because it owns artifact creation, policy checks, terminal fallback, and follow-up creation.
+
+Existing `SendMessage` behavior may remain as a compatibility alias for active-Step chat addendum only. New clients should use `SubmitChatInstruction`.
+
+## 5. Boundary models
+
+New models should live in a domain schema module such as `moonmind/schemas/chat_instruction_models.py`.
+
+`ChatInstructionInput` should include `instructionId`, optional `idempotencyKey`, optional `chatThreadId`, `messageArtifactRef`, bounded `messageSummary`, `scope`, `intentHint`, a target block with `workflowId`, `runId`, `logicalStepId`, `stepExecutionOrdinal`, `planRevision`, and `childWorkflowId`, an `observedState` block for stale-target rejection, and policy flags such as `allowCancelActiveStep`, `allowVoidFutureSteps`, and `allowCreateFollowupExecution`.
+
+`ChatInstructionDecision` should include `accepted`, `instructionId`, `decision`, `workflowId`, `runId`, optional `targetLogicalStepId`, optional `childWorkflowId`, `messageArtifactRef`, optional `newPlanRef`, optional `followupWorkflowId`, and warnings.
+
+Allowed decisions include `attached_to_active_step`, `queued_for_safe_point`, `queued_for_step`, `active_step_cancel_requested`, `step_reattempt_scheduled`, `plan_revision_requested`, `future_steps_superseded`, `created_followup_execution`, `rejected_stale_target`, `rejected_terminal`, `rejected_policy`, `rejected_invalid_payload`, and `rejected_unsupported_runtime`.
+
+## 6. Runtime behavior
+
+`MoonMind.UserWorkflow` evaluates chat instructions against workflow-owned state.
+
+- If an active child supports live addendum, the instruction is attached to the active Step and forwarded internally.
+- If the active child cannot safely accept a live addendum and policy permits, the parent cancels active work and schedules a new Step Execution attempt.
+- If the instruction changes future work, the workflow requests a plan revision, writes a new immutable plan artifact, and marks old future Steps superseded.
+- If the client targets a stale `runId`, Step, or plan revision, the Update rejects the instruction before applying semantic effects.
+- If the source execution is terminal, the workflow rejects mutation and the API may create a linked follow-up execution.
+
+## 7. Plan revision and Step ledger rules
+
+Chat-driven plan changes do not edit a plan in place. The new plan artifact should record `planRevision`, `supersedesPlanRef`, `chatInstructionRef`, `replanBoundary`, preserved logical Step IDs, superseded logical Step IDs, and new logical Step IDs.
+
+The preferred target-state Step status for future work voided by chat is `superseded`. If adding a new status is too disruptive initially, represent it as `status = skipped` plus `terminalDisposition = superseded_by_chat_instruction` and refs to the chat instruction and superseding plan artifact.
+
+## 8. Terminal follow-up behavior
+
+A terminal source execution remains immutable. The API-created follow-up execution receives its own `workflowId` and `runId` and pins source `workflowId`, source `runId`, source plan refs, finish summary refs, optional Step ledger snapshot refs, and the chat instruction ref. The relationship type should be `chat_followup`.
+
+Follow-up execution is not failed-step recovery and not `RequestRerun` / Continue-As-New unless a future policy explicitly defines that behavior.
+
+## 9. Source-of-truth rules
+
+| Concern | Authoritative source | Projection role |
+| --- | --- | --- |
+| Chat text | Instruction artifact | optional preview/ref display |
+| Instruction acceptance | Workflow Update result or API follow-up creation result | cache latest decision for UI |
+| Running instruction command | `MoonMind.UserWorkflow` state/history | derived row or timeline item |
+| Active child delivery | child workflow history and runtime/provider artifacts | display delivery state |
+| Plan revision | new plan artifact + workflow state refs | display current plan revision |
+| Superseded future Steps | workflow Step ledger | optional derived step projection |
+| Follow-up relation | API-created relation plus source/target refs | related-workflows display |
+
+Projection rows must not accept chat instructions by local mutation only.
+
+## 10. Visibility, artifact, and UI posture
+
+Do not add chat text or long chat summaries to Search Attributes. `mm_updated_at` may move on accepted chat instructions. A future bounded state such as `mm_state = replanning` or a bounded pending-instruction field should be added only if list filtering requires it.
+
+Recommended content types are `application/vnd.moonmind.chat-instruction+json;version=1`, `application/vnd.moonmind.chat-instruction-decision+json;version=1`, and `application/vnd.moonmind.chat-plan-revision+json;version=1`.
+
+The workflow detail page should expose a chat panel that sends chat instructions, shows the explicit decision, displays stale-target guidance, renders superseded future Steps distinctly, and links terminal source executions to chat follow-up executions.
+
+## 11. Rollout plan
+
+1. Add typed `SubmitChatInstruction`, keep `SendMessage` as a compatibility alias, store chat text as artifacts, and forward supported active-Step messages.
+2. Add the dedicated API route and terminal follow-up execution creation.
+3. Add plan revision metadata, a replan activity, superseded Step rows, and UI rendering.
+4. Add policy-gated active child cancellation and Step reattempts.
+5. Introduce a dedicated `MoonMind.ChatThread` workflow only if the product later needs multi-execution thread orchestration as a durable entity.

--- a/docs/Workflows/ChatInstructionIntervention.md
+++ b/docs/Workflows/ChatInstructionIntervention.md
@@ -22,7 +22,7 @@ This document is the cross-cutting owner for chat instruction intervention and s
 ## 3. Design principles
 
 1. **Chat is an input surface, not an orchestrator.** The dashboard and API may classify and route a chat instruction, but they must not schedule work independently of Temporal workflow state.
-2. **Public chat mutations use Updates.** The running-workflow primitive is `SubmitChatInstruction`; internal child delivery may use compact Signals such as `operator_message`.
+2. **Public chat mutations use Updates.** The running-workflow primitive is `SubmitChatInstruction`; internal child delivery uses a typed artifact-ref Signal rather than raw chat text.
 3. **Chat text is artifact-backed.** Workflow history, Search Attributes, Memo, and Step rows carry compact refs, summaries, hashes, and bounded metadata only.
 4. **The workflow serializes conflicting mutations.** The Update validates, dedupes, records a compact command, wakes the main loop, and returns a bounded decision. The main loop drains commands at safe points.
 5. **Closed executions are immutable.** Terminal Workflow Executions do not accept ordinary chat mutation; the API creates linked follow-up executions with pinned source refs.
@@ -40,13 +40,15 @@ The endpoint authenticates the caller, stores the chat message as an instruction
 
 The generic update endpoint may also accept `updateName = SubmitChatInstruction`, but the dedicated route is preferred because it owns artifact creation, policy checks, terminal fallback, and follow-up creation.
 
-Existing `SendMessage` behavior may remain as a compatibility alias for active-Step chat addendum only. New clients should use `SubmitChatInstruction`.
+Existing `SendMessage` behavior is legacy active-Step addendum behavior, not a compatibility alias for the chat instruction contract. A cutover to `SubmitChatInstruction` must update callers and any durable workflow boundary explicitly rather than maintaining parallel public controls.
 
 ## 5. Boundary models
 
 New models should live in a domain schema module such as `moonmind/schemas/chat_instruction_models.py`.
 
-`ChatInstructionInput` should include `instructionId`, optional `idempotencyKey`, optional `chatThreadId`, `messageArtifactRef`, bounded `messageSummary`, `scope`, `intentHint`, a target block with `workflowId`, `runId`, `logicalStepId`, `stepExecutionOrdinal`, `planRevision`, and `childWorkflowId`, an `observedState` block for stale-target rejection, and policy flags such as `allowCancelActiveStep`, `allowVoidFutureSteps`, and `allowCreateFollowupExecution`.
+`ChatInstructionApiRequest` is the public API request body. It accepts `instructionId`, optional `idempotencyKey`, optional `chatThreadId`, the raw `message`, `scope`, `intentHint`, a target block with `runId`, `logicalStepId`, `stepExecutionOrdinal`, `planRevision`, and `childWorkflowId`, an `observedState` block for stale-target rejection, and policy flags such as `allowCancelActiveStep`, `allowVoidFutureSteps`, and `allowCreateFollowupExecution`.
+
+`ChatInstructionWorkflowInput` is the workflow-facing Temporal Update payload. It should include the same stable instruction, target, observed-state, and policy fields, but it receives `messageArtifactRef` and bounded `messageSummary` after the API stores the raw message as an artifact. It must not carry the full user message in workflow history.
 
 `ChatInstructionDecision` should include `accepted`, `instructionId`, `decision`, `workflowId`, `runId`, optional `targetLogicalStepId`, optional `childWorkflowId`, `messageArtifactRef`, optional `newPlanRef`, optional `followupWorkflowId`, and warnings.
 
@@ -66,7 +68,7 @@ Allowed decisions include `attached_to_active_step`, `queued_for_safe_point`, `q
 
 Chat-driven plan changes do not edit a plan in place. The new plan artifact should record `planRevision`, `supersedesPlanRef`, `chatInstructionRef`, `replanBoundary`, preserved logical Step IDs, superseded logical Step IDs, and new logical Step IDs.
 
-The preferred target-state Step status for future work voided by chat is `superseded`. If adding a new status is too disruptive initially, represent it as `status = skipped` plus `terminalDisposition = superseded_by_chat_instruction` and refs to the chat instruction and superseding plan artifact.
+Future work voided by chat remains in the operator-facing Step ledger status domain. Represent superseded future Steps as `status = skipped` plus `terminalDisposition = superseded_by_chat_instruction` and refs to the chat instruction and superseding plan artifact. Adding a new Step ledger status requires updating the canonical status matrix, schemas, API projections, and UI together.
 
 ## 8. Terminal follow-up behavior
 
@@ -95,11 +97,3 @@ Do not add chat text or long chat summaries to Search Attributes. `mm_updated_at
 Recommended content types are `application/vnd.moonmind.chat-instruction+json;version=1`, `application/vnd.moonmind.chat-instruction-decision+json;version=1`, and `application/vnd.moonmind.chat-plan-revision+json;version=1`.
 
 The workflow detail page should expose a chat panel that sends chat instructions, shows the explicit decision, displays stale-target guidance, renders superseded future Steps distinctly, and links terminal source executions to chat follow-up executions.
-
-## 11. Rollout plan
-
-1. Add typed `SubmitChatInstruction`, keep `SendMessage` as a compatibility alias, store chat text as artifacts, and forward supported active-Step messages.
-2. Add the dedicated API route and terminal follow-up execution creation.
-3. Add plan revision metadata, a replan activity, superseded Step rows, and UI rendering.
-4. Add policy-gated active child cancellation and Step reattempts.
-5. Introduce a dedicated `MoonMind.ChatThread` workflow only if the product later needs multi-execution thread orchestration as a durable entity.

--- a/docs/Workflows/WorkflowRunsApi.md
+++ b/docs/Workflows/WorkflowRunsApi.md
@@ -2,15 +2,16 @@
 
 Status: Active  
 Owners: MoonMind Engineering  
-Last Updated: 2026-04-04
+Last Updated: 2026-07-02
 
 ## 1. Purpose
 
-Define the REST API surfaces used to create, monitor, and observe MoonMind Workflow runs in the Temporal-first architecture.
+Define the REST API surfaces used to create, monitor, steer, and observe MoonMind Workflow runs in the Temporal-first architecture.
 
 MoonMind now splits this responsibility across:
 
 - **`/api/executions`** for Temporal-backed execution lifecycle operations
+- **`/api/executions/{workflowId}/chat-instructions`** for chat-based workflow steering, active-Step addenda, plan-revision requests, and terminal follow-up starts
 - **`/api/agent-runs`** for managed-run observability (logs, diagnostics, live follow)
 
 The dashboard still presents these executions as **Workflows** in the product UI, but the active lifecycle API is execution-oriented.
@@ -19,9 +20,10 @@ The public `/api/agent-runs` path comes from the `agent_runs` router's `prefix="
 
 ## 2. API Surface
 
-Workflow runs are served by two active router families:
+Workflow runs are served by three active router families:
 
 - **`/api/executions`** — Execution lifecycle for Temporal-backed work.
+- **`/api/executions/{workflowId}/chat-instructions`** — Chat instruction steering for running or terminal executions.
 - **`/api/agent-runs`** — Artifact-backed managed-run observability.
 
 ### 2.1 Execution Lifecycle (`/api/executions`)
@@ -31,7 +33,7 @@ Workflow runs are served by two active router families:
 | `POST` | `/api/executions` | Create/start a Temporal-backed execution |
 | `GET`  | `/api/executions` | List executions visible to the caller |
 | `GET`  | `/api/executions/{workflowId}` | Get execution detail |
-| `POST` | `/api/executions/{workflowId}/update` | Apply an in-place workflow update such as `UpdateInputs`, `SetTitle`, or `RequestRerun` (Continue-As-New on the same logical execution) |
+| `POST` | `/api/executions/{workflowId}/update` | Apply an in-place workflow update such as `UpdateInputs`, `SetTitle`, `RequestRerun`, or the compatibility form of `SubmitChatInstruction` |
 | `POST` | `/api/executions/{workflowId}/signal` | Send an asynchronous workflow signal such as pause, resume, or approve |
 | `POST` | `/api/executions/{workflowId}/cancel` | Cancel or terminate an execution |
 
@@ -44,6 +46,7 @@ These routes extend the main lifecycle surface for specific execution types:
 | `GET` | `/api/executions/{workflowId}/manifest-status` | Fetch manifest-run status summary |
 | `GET` | `/api/executions/{workflowId}/manifest-nodes` | Page manifest node state |
 | `GET` | `/api/executions/{workflowId}/steps` | Fetch the latest/current run step ledger |
+| `POST` | `/api/executions/{workflowId}/chat-instructions` | Submit a typed chat instruction; running executions receive a `SubmitChatInstruction` Update, terminal executions may create a linked follow-up execution |
 | `POST` | `/api/executions/{workflowId}/integration` | Register/update integration monitoring state |
 | `POST` | `/api/executions/{workflowId}/integration/poll` | Record integration poll results |
 | `POST` | `/api/executions/{workflowId}/reschedule` | Change the scheduled time of a scheduled execution |
@@ -77,8 +80,9 @@ The normal control-plane flow is:
 1. Create or list work through `/api/executions`
 2. Use `workflowId` for lifecycle actions and detail fetches
 3. Read the step ledger from `/api/executions/{workflowId}/steps`
-4. Resolve the relevant step's `agentRunId` when managed-run observability is available
-5. Use `/api/agent-runs/{agentRunId}` for logs, diagnostics, and live follow
+4. Submit user chat steering through `/api/executions/{workflowId}/chat-instructions` when the user wants to affect running or completed work
+5. Resolve the relevant step's `agentRunId` when managed-run observability is available
+6. Use `/api/agent-runs/{agentRunId}` for logs, diagnostics, and live follow
 
 ## 4. Observability Behavior
 
@@ -98,6 +102,15 @@ Failed `MoonMind.Run` executions may expose failed-step recovery when the source
 The default `recover-from-failed-step` route preserves the original task input and starts new execution at the recorded failed step. The `recover-from-selected-step` route is for intentional earlier recovery: the request must include the source `workflowId`, source `runId`, and `selectedStartStepId`. The service validates those values against the canonical source execution and checkpoint payload before creating the follow-up execution. Steps before the selected start step are preserved from checkpoint evidence; the selected step and downstream steps execute again.
 
 Recovery routes do not accept edited task instructions, attachments, runtime/model settings, dependency changes, or publish changes. Operators must use edit/rerun flows for those behaviors.
+
+## 4.2 Chat Instruction Behavior
+
+Chat instructions are not recovery and are not ordinary projection-side edits. The chat instruction route stores the chat text as an artifact, then either:
+
+- sends a typed `SubmitChatInstruction` Update to a running `MoonMind.UserWorkflow`, or
+- creates a linked `chat_followup` execution when the source execution is terminal and policy permits follow-up creation.
+
+Running-workflow decisions are returned as `ChatInstructionDecision` values such as `attached_to_active_step`, `queued_for_safe_point`, `plan_revision_requested`, `future_steps_superseded`, `created_followup_execution`, or a typed rejection. Terminal source executions remain immutable.
 
 ## 5. Request Model Posture
 
@@ -122,6 +135,7 @@ The legacy `/api/queue/jobs` lifecycle routes and `/api/queue` worker callback r
 
 ## 7. Related Documentation
 
+- [ChatInstructionIntervention.md](ChatInstructionIntervention.md) — Chat instruction steering, active-Step addendum, plan revision, and terminal follow-up design
 - [../Api/ExecutionsApiContract.md](../Api/ExecutionsApiContract.md) — Direct execution lifecycle contract
 - [WorkflowArchitecture.md](WorkflowArchitecture.md) — Overall Workflow system design
 - [../UI/WorkflowConsoleArchitecture.md](../UI/WorkflowConsoleArchitecture.md) — Workflow-oriented UI over execution APIs

--- a/docs/Workflows/WorkflowRunsApi.md
+++ b/docs/Workflows/WorkflowRunsApi.md
@@ -11,8 +11,9 @@ Define the REST API surfaces used to create, monitor, steer, and observe MoonMin
 MoonMind now splits this responsibility across:
 
 - **`/api/executions`** for Temporal-backed execution lifecycle operations
-- **`/api/executions/{workflowId}/chat-instructions`** for chat-based workflow steering, active-Step addenda, plan-revision requests, and terminal follow-up starts
 - **`/api/agent-runs`** for managed-run observability (logs, diagnostics, live follow)
+
+The planned `/api/executions/{workflowId}/chat-instructions` route is the target surface for chat-based workflow steering, active-Step addenda, plan-revision requests, and terminal follow-up starts once the router is implemented.
 
 The dashboard still presents these executions as **Workflows** in the product UI, but the active lifecycle API is execution-oriented.
 
@@ -20,10 +21,9 @@ The public `/api/agent-runs` path comes from the `agent_runs` router's `prefix="
 
 ## 2. API Surface
 
-Workflow runs are served by three active router families:
+Workflow runs are served by two active router families:
 
 - **`/api/executions`** — Execution lifecycle for Temporal-backed work.
-- **`/api/executions/{workflowId}/chat-instructions`** — Chat instruction steering for running or terminal executions.
 - **`/api/agent-runs`** — Artifact-backed managed-run observability.
 
 ### 2.1 Execution Lifecycle (`/api/executions`)
@@ -46,7 +46,6 @@ These routes extend the main lifecycle surface for specific execution types:
 | `GET` | `/api/executions/{workflowId}/manifest-status` | Fetch manifest-run status summary |
 | `GET` | `/api/executions/{workflowId}/manifest-nodes` | Page manifest node state |
 | `GET` | `/api/executions/{workflowId}/steps` | Fetch the latest/current run step ledger |
-| `POST` | `/api/executions/{workflowId}/chat-instructions` | Submit a typed chat instruction; running executions receive a `SubmitChatInstruction` Update, terminal executions may create a linked follow-up execution |
 | `POST` | `/api/executions/{workflowId}/integration` | Register/update integration monitoring state |
 | `POST` | `/api/executions/{workflowId}/integration/poll` | Record integration poll results |
 | `POST` | `/api/executions/{workflowId}/reschedule` | Change the scheduled time of a scheduled execution |
@@ -80,9 +79,8 @@ The normal control-plane flow is:
 1. Create or list work through `/api/executions`
 2. Use `workflowId` for lifecycle actions and detail fetches
 3. Read the step ledger from `/api/executions/{workflowId}/steps`
-4. Submit user chat steering through `/api/executions/{workflowId}/chat-instructions` when the user wants to affect running or completed work
-5. Resolve the relevant step's `agentRunId` when managed-run observability is available
-6. Use `/api/agent-runs/{agentRunId}` for logs, diagnostics, and live follow
+4. Resolve the relevant step's `agentRunId` when managed-run observability is available
+5. Use `/api/agent-runs/{agentRunId}` for logs, diagnostics, and live follow
 
 ## 4. Observability Behavior
 
@@ -105,12 +103,12 @@ Recovery routes do not accept edited task instructions, attachments, runtime/mod
 
 ## 4.2 Chat Instruction Behavior
 
-Chat instructions are not recovery and are not ordinary projection-side edits. The chat instruction route stores the chat text as an artifact, then either:
+Chat instructions are not recovery and are not ordinary projection-side edits. The planned chat instruction route stores the chat text as an artifact, then either:
 
 - sends a typed `SubmitChatInstruction` Update to a running `MoonMind.UserWorkflow`, or
 - creates a linked `chat_followup` execution when the source execution is terminal and policy permits follow-up creation.
 
-Running-workflow decisions are returned as `ChatInstructionDecision` values such as `attached_to_active_step`, `queued_for_safe_point`, `plan_revision_requested`, `future_steps_superseded`, `created_followup_execution`, or a typed rejection. Terminal source executions remain immutable.
+Running-workflow decisions are returned as `ChatInstructionDecision` values such as `attached_to_active_step`, `queued_for_safe_point`, `plan_revision_requested`, `future_steps_superseded`, or a typed rejection. Terminal source executions remain immutable; `created_followup_execution` belongs only to the terminal API follow-up path.
 
 ## 5. Request Model Posture
 

--- a/docs/tmp/chat-intervention-test.md
+++ b/docs/tmp/chat-intervention-test.md
@@ -1,0 +1,3 @@
+# Chat intervention docs test
+
+This temporary file verifies file writes on the chat instruction docs branch.

--- a/docs/tmp/chat-intervention-test.md
+++ b/docs/tmp/chat-intervention-test.md
@@ -1,3 +1,0 @@
-# Chat intervention docs test
-
-This temporary file verifies file writes on the chat instruction docs branch.


### PR DESCRIPTION
## Summary

- add the canonical chat instruction intervention design covering `SubmitChatInstruction`, active-Step addenda, cancel-and-reattempt, plan revision, future-Step superseding, terminal follow-up executions, and chat thread posture
- add focused API, Temporal, and UI companion contracts for the new chat instruction surface
- update the Workflow Execution product model and Workflow Runs API overview to recognize chat instructions as a control surface over Workflow Executions

## Why

MoonMind is adding more chat interface behavior around workflows. The architecture needs a durable contract for how chat can safely steer running workflows, affect a single Step, supersede future Steps, or create follow-up work after a source execution is terminal.

This keeps the API and dashboard from becoming a competing orchestration layer: running-workflow chat goes through an acknowledged Temporal Update, internal child delivery remains compact and workflow-owned, terminal source executions stay immutable, and large chat content is artifact-backed.

## User / developer impact

- introduces the preferred **chat** terminology instead of longer conversational phrasing
- defines `SubmitChatInstruction`, `ChatInstructionInput`, and `ChatInstructionDecision`
- defines the dedicated `POST /api/executions/{workflowId}/chat-instructions` route target
- gives the dashboard explicit decision states to render instead of guessing from local state

## Validation

- documentation-only change
- reviewed diff with GitHub compare: 6 doc files changed, 546 additions / 12 deletions

## Notes

The branch was created before the latest `main` commits and is currently behind `main`; this is a docs-only branch and can be updated before merge if needed.