### PR TITLE
Repair MoonSpec gate contract violations and add draft-PR policy for environment-blocked verdicts

### DIFF
--- a/api_service/services/settings_catalog.py
+++ b/api_service/services/settings_catalog.py
@@ -559,6 +559,33 @@ _REGISTRY: tuple[SettingRegistryEntry, ...] = (
         order=20,
     ),
     SettingRegistryEntry(
+        key="workflow.moonspec_environment_blocked_publish_action",
+        title="MoonSpec Environment-Blocked Publish Action",
+        description=(
+            "Publication behavior when the MoonSpec verification gate stops "
+            "with an environment-class outcome: fail the run (fail closed) or "
+            "publish a draft pull request annotated as verification-incomplete."
+        ),
+        category="Workflow",
+        section="user-workspace",
+        value_type="enum",
+        ui="select",
+        scopes=("workspace",),
+        default_value="fail",
+        settings_path=("workflow", "moonspec_environment_blocked_publish_action"),
+        env_aliases=(
+            "WORKFLOW_MOONSPEC_ENVIRONMENT_BLOCKED_PUBLISH_ACTION",
+            "MOONMIND_MOONSPEC_ENVIRONMENT_BLOCKED_PUBLISH_ACTION",
+        ),
+        apply_mode="next_workflow",
+        options=(
+            ("fail", "Fail the run (fail closed)"),
+            ("draft_pr", "Publish draft PR with attention flag"),
+        ),
+        applies_to=("publishing",),
+        order=21,
+    ),
+    SettingRegistryEntry(
         key="skills.policy_mode",
         title="Skill Policy Mode",
         description="Policy used when resolving workflow skills.",

--- a/docs/Workflows/WorkflowPublishing.md
+++ b/docs/Workflows/WorkflowPublishing.md
@@ -262,12 +262,38 @@ Workflows that include MoonSpec verification gates must use the latest structure
 
 Non-retryable blocking verdicts, including `NO_DETERMINATION`, `BLOCKED`, and `FAILED_UNRECOVERABLE`, block publication without waiting for additional remediation attempts unless the workflow explicitly models the missing evidence as recoverable work inside the same bounded plan.
 
+The gate distinguishes a verifier judgment from a malformed verdict envelope:
+
+- The runtime injects the canonical output contract (allowed `verdict` and
+  `recommendedNextAction` values) into moonspec-verify instructions, and the
+  artifact-publication boundary records `contractViolations` on the structured
+  gate payload when the verifier JSON drifts from that contract.
+- A gate payload that fails contract validation is downgraded fail-closed to
+  `NO_DETERMINATION`, and the gate records a `downgradeReason` naming the
+  declared verdict and the violating field in publish context, the blocking
+  operator message, and the failure summary.
+- Before treating a contract-violating verify output as blocking, the workflow
+  re-runs the verify step a bounded number of times with corrective feedback so
+  the verifier can rewrite its structured JSON. Remediation implement cycles
+  are never spent on a malformed verdict envelope.
+
 When MoonSpec verification blocks publication, the workflow records
 `publicationBlockedBy: "moonspec_verify"` in publish context, preserves the
 latest verification report and evidence refs, writes a compact
 `failureSummary.type = "moonspec_verification_gate"` block in
 `reports/run_summary.json`, and marks downstream publication or Jira handoff
 steps skipped rather than creating a pull request with known incomplete work.
+
+Operators may opt environment-class gate outcomes into draft publication with
+`workflow.moonspec_environment_blocked_publish_action`
+(`WORKFLOW_MOONSPEC_ENVIRONMENT_BLOCKED_PUBLISH_ACTION`, default `fail`). With
+`draft_pr`, a gate stop whose outcome is environment-class — verdict `BLOCKED`,
+or `NO_DETERMINATION` produced by a degraded/malformed gate payload — publishes
+a **draft** pull request annotated with a "MoonSpec verification incomplete"
+section and the verification report ref, and the run completes with
+`attention_required: true` and a distinct summary instead of failing.
+Implementation-gap verdicts (`ADDITIONAL_WORK_NEEDED`, `FAILED_UNRECOVERABLE`)
+and verifier-declared `NO_DETERMINATION` always remain fail-closed.
 
 ### Agent Instructions
 

--- a/moonmind/config/settings.py
+++ b/moonmind/config/settings.py
@@ -768,6 +768,41 @@ class WorkflowSettings(BaseSettings):
             }
         },
     )
+    moonspec_environment_blocked_publish_action: str = Field(
+        "fail",
+        validation_alias=AliasChoices(
+            "WORKFLOW_MOONSPEC_ENVIRONMENT_BLOCKED_PUBLISH_ACTION",
+            "MOONMIND_MOONSPEC_ENVIRONMENT_BLOCKED_PUBLISH_ACTION",
+        ),
+        description=(
+            "Publication behavior when the MoonSpec verification gate stops "
+            "with an environment-class outcome (verdict BLOCKED, or "
+            "NO_DETERMINATION produced by a degraded/malformed gate payload): "
+            "'fail' fails the run fail-closed; 'draft_pr' publishes a draft "
+            "pull request annotated as verification-incomplete and completes "
+            "the run with attention_required."
+        ),
+        json_schema_extra={
+            "moonmind": {
+                "expose": True,
+                "key": "workflow.moonspec_environment_blocked_publish_action",
+                "section": "user-workspace",
+                "category": "Workflow",
+                "scopes": ["workspace"],
+                "ui": "select",
+                "type": "enum",
+                "requires_reload": False,
+                "apply_mode": "next_workflow",
+                "title": "MoonSpec Environment-Blocked Publish Action",
+                "options": [
+                    ("fail", "Fail the run (fail closed)"),
+                    ("draft_pr", "Publish draft PR with attention flag"),
+                ],
+                "applies_to": ["publishing"],
+                "order": 21,
+            }
+        },
+    )
     github_repository: Optional[str] = Field(
         "MoonLadderStudios/MoonMind",
         validation_alias=AliasChoices(

--- a/moonmind/workflows/adapters/github_service.py
+++ b/moonmind/workflows/adapters/github_service.py
@@ -885,6 +885,7 @@ class GitHubService:
         base: str,
         title: str,
         body: str,
+        draft: bool = False,
         github_token: str | None = None,
     ) -> CreatePRResult:
         """Create a GitHub pull request via REST API."""
@@ -902,6 +903,10 @@ class GitHubService:
         api_url = f"https://api.github.com/repos/{repo}/pulls"
         headers = self._github_headers(token)
         payload = {"title": title, "head": head, "base": base, "body": body}
+        if draft:
+            # Only applies to the create branch below; GitHub does not allow
+            # flipping an existing PR to draft via the PATCH metadata update.
+            payload["draft"] = True
 
         async with httpx.AsyncClient(timeout=self._timeout) as client:
             try:

--- a/moonmind/workflows/adapters/github_service.py
+++ b/moonmind/workflows/adapters/github_service.py
@@ -919,6 +919,19 @@ class GitHubService:
                 )
                 if existing_pr is not None:
                     existing_url = str(existing_pr.get("html_url") or "")
+                    if draft and not bool(existing_pr.get("draft")):
+                        return CreatePRResult(
+                            url=existing_url or None,
+                            created=False,
+                            adopted=False,
+                            summary=(
+                                "draft PR requested but an existing "
+                                "non-draft pull request already exists for "
+                                f"{head} -> {base}: "
+                                f"{existing_url or 'unknown URL'}"
+                            ),
+                            head_sha=(existing_pr.get("head") or {}).get("sha"),
+                        )
                     pr_number = existing_pr.get("number")
                     if pr_number is None:
                         return CreatePRResult(

--- a/moonmind/workflows/skills/approval_policy.py
+++ b/moonmind/workflows/skills/approval_policy.py
@@ -25,6 +25,57 @@ _RECOMMENDED_NEXT_ACTIONS = {
     "blocked",
 }
 
+_VERDICT_SYNONYMS = {
+    "PASS": "FULLY_IMPLEMENTED",
+    "FAIL": "ADDITIONAL_WORK_NEEDED",
+    "INCONCLUSIVE": "NO_DETERMINATION",
+}
+
+
+def recommended_next_actions() -> tuple[str, ...]:
+    """Canonical ``recommendedNextAction`` vocabulary for gate payloads."""
+    return tuple(sorted(_RECOMMENDED_NEXT_ACTIONS))
+
+
+def step_gate_contract_violations(payload: Mapping[str, Any]) -> list[str]:
+    """Return the contract violations that force a fail-closed downgrade.
+
+    A non-empty result means ``parse_step_gate_result`` will mark the payload
+    invalid/degraded and downgrade its verdict to ``NO_DETERMINATION``.
+    """
+    violations: list[str] = []
+    raw_verdict = str(payload.get("verdict") or "").strip()
+    if not raw_verdict:
+        violations.append(
+            "verdict is missing from the structured gate payload"
+        )
+    else:
+        normalized = raw_verdict.upper()
+        normalized = _VERDICT_SYNONYMS.get(normalized, normalized)
+        if normalized not in REVIEW_VERDICTS:
+            violations.append(
+                f"verdict {raw_verdict!r} is not one of "
+                f"{sorted(REVIEW_VERDICTS)}"
+            )
+    if bool(payload.get("invalid")):
+        violations.append("payload was flagged invalid by its producer")
+    if bool(payload.get("degraded")):
+        violations.append("payload was flagged degraded by its producer")
+    recommended_next_action = payload.get("recommendedNextAction") or payload.get(
+        "recommended_next_action"
+    )
+    recommended_text = (
+        recommended_next_action.strip()
+        if isinstance(recommended_next_action, str)
+        else None
+    )
+    if recommended_text and recommended_text not in _RECOMMENDED_NEXT_ACTIONS:
+        violations.append(
+            f"recommendedNextAction {recommended_text!r} is not one of "
+            f"{sorted(_RECOMMENDED_NEXT_ACTIONS)}"
+        )
+    return violations
+
 @dataclass(frozen=True, slots=True)
 class ReviewRequest:
     """Input envelope for the ``step.review`` activity."""
@@ -90,6 +141,7 @@ class ReviewVerdict:
     recoverable_in_current_runtime: bool = False
     invalid: bool = False
     degraded: bool = False
+    downgrade_reason: str | None = None
 
     def __post_init__(self) -> None:
         if self.verdict not in REVIEW_VERDICTS:
@@ -146,6 +198,8 @@ class ReviewVerdict:
             payload["workspacePolicyRecommendation"] = (
                 self.workspace_policy_recommendation
             )
+        if self.downgrade_reason:
+            payload["downgradeReason"] = self.downgrade_reason
         return payload
 
     def to_gate_result(self) -> "StepGateResult":
@@ -164,6 +218,7 @@ class ReviewVerdict:
             recoverable_in_current_runtime=self.recoverable_in_current_runtime,
             invalid=self.invalid,
             degraded=self.degraded,
+            downgrade_reason=self.downgrade_reason,
         )
 
 
@@ -185,6 +240,7 @@ class StepGateResult:
     recoverable_in_current_runtime: bool = False
     invalid: bool = False
     degraded: bool = False
+    downgrade_reason: str | None = None
     schema_version: str = "v1"
 
     def __post_init__(self) -> None:
@@ -254,6 +310,8 @@ class StepGateResult:
             payload["workspacePolicyRecommendation"] = (
                 self.workspace_policy_recommendation
             )
+        if self.downgrade_reason:
+            payload["downgradeReason"] = self.downgrade_reason
         return payload
 
     def to_review_verdict(self) -> ReviewVerdict:
@@ -272,6 +330,7 @@ class StepGateResult:
             recoverable_in_current_runtime=self.recoverable_in_current_runtime,
             invalid=self.invalid,
             degraded=self.degraded,
+            downgrade_reason=self.downgrade_reason,
         )
 
 def parse_review_verdict(payload: Mapping[str, Any]) -> ReviewVerdict:
@@ -281,19 +340,16 @@ def parse_review_verdict(payload: Mapping[str, Any]) -> ReviewVerdict:
 
 def parse_step_gate_result(payload: Mapping[str, Any]) -> StepGateResult:
     """Normalize activity output into the canonical gate result contract."""
-    verdict_raw = str(payload.get("verdict") or "INCONCLUSIVE").strip().upper()
-    verdict_raw = {
-        "PASS": "FULLY_IMPLEMENTED",
-        "FAIL": "ADDITIONAL_WORK_NEEDED",
-        "INCONCLUSIVE": "NO_DETERMINATION",
-    }.get(verdict_raw, verdict_raw)
+    declared_verdict = str(payload.get("verdict") or "").strip()
+    verdict_raw = (declared_verdict or "INCONCLUSIVE").upper()
+    verdict_raw = _VERDICT_SYNONYMS.get(verdict_raw, verdict_raw)
     invalid = bool(payload.get("invalid"))
     degraded = bool(payload.get("degraded"))
     if verdict_raw not in REVIEW_VERDICTS:
         verdict_raw = "NO_DETERMINATION"
         invalid = True
         degraded = True
-    elif not str(payload.get("verdict") or "").strip():
+    elif not declared_verdict:
         invalid = True
         degraded = True
 
@@ -344,12 +400,29 @@ def parse_step_gate_result(payload: Mapping[str, Any]) -> StepGateResult:
         # of raising a hard ContractValidationError from StepGateResult.
         invalid = True
         degraded = True
+    downgrade_reason: str | None = None
     if invalid or degraded:
         # An invalid/degraded gate result must not retain a passing verdict:
         # downstream branching keys on ``verdict`` alone (see run.py), so a
         # malformed/degraded result that still says FULLY_IMPLEMENTED would
         # otherwise approve publication. Downgrade the verdict and force a
         # blocking action so the gate fails closed.
+        violations = step_gate_contract_violations(payload)
+        detail = (
+            "; ".join(violations)
+            if violations
+            else "gate payload failed contract validation"
+        )
+        if verdict_raw != "NO_DETERMINATION":
+            downgrade_reason = (
+                f"declared verdict {verdict_raw} was downgraded to "
+                f"NO_DETERMINATION because the structured gate payload failed "
+                f"contract validation: {detail}"
+            )
+        else:
+            downgrade_reason = (
+                f"structured gate payload failed contract validation: {detail}"
+            )
         verdict_raw = "NO_DETERMINATION"
         recommended_next_action = "blocked"
     elif not recommended_next_action and verdict_raw == "FULLY_IMPLEMENTED":
@@ -401,6 +474,7 @@ def parse_step_gate_result(payload: Mapping[str, Any]) -> StepGateResult:
         ),
         invalid=invalid,
         degraded=degraded,
+        downgrade_reason=downgrade_reason,
     )
 
 
@@ -504,4 +578,6 @@ __all__ = [
     "build_review_prompt",
     "parse_step_gate_result",
     "parse_review_verdict",
+    "recommended_next_actions",
+    "step_gate_contract_violations",
 ]

--- a/moonmind/workflows/skills/approval_policy.py
+++ b/moonmind/workflows/skills/approval_policy.py
@@ -61,19 +61,22 @@ def step_gate_contract_violations(payload: Mapping[str, Any]) -> list[str]:
         violations.append("payload was flagged invalid by its producer")
     if bool(payload.get("degraded")):
         violations.append("payload was flagged degraded by its producer")
-    recommended_next_action = payload.get("recommendedNextAction") or payload.get(
-        "recommended_next_action"
-    )
-    recommended_text = (
-        recommended_next_action.strip()
-        if isinstance(recommended_next_action, str)
-        else None
-    )
-    if recommended_text and recommended_text not in _RECOMMENDED_NEXT_ACTIONS:
-        violations.append(
-            f"recommendedNextAction {recommended_text!r} is not one of "
-            f"{sorted(_RECOMMENDED_NEXT_ACTIONS)}"
-        )
+    recommended_next_action = payload.get("recommendedNextAction")
+    if recommended_next_action is None:
+        recommended_next_action = payload.get("recommended_next_action")
+    if recommended_next_action is not None:
+        if not isinstance(recommended_next_action, str):
+            violations.append(
+                "recommendedNextAction must be a string, got "
+                f"{type(recommended_next_action).__name__}"
+            )
+        else:
+            recommended_text = recommended_next_action.strip()
+            if recommended_text not in _RECOMMENDED_NEXT_ACTIONS:
+                violations.append(
+                    f"recommendedNextAction {recommended_text!r} is not one of "
+                    f"{sorted(_RECOMMENDED_NEXT_ACTIONS)}"
+                )
     return violations
 
 @dataclass(frozen=True, slots=True)
@@ -388,13 +391,13 @@ def parse_step_gate_result(payload: Mapping[str, Any]) -> StepGateResult:
         "blocking_evidence_refs"
     )
 
-    recommended_next_action = _optional_text(
-        payload.get("recommendedNextAction")
-        or payload.get("recommended_next_action")
-    )
-    if (
-        recommended_next_action
-        and recommended_next_action not in _RECOMMENDED_NEXT_ACTIONS
+    recommended_next_action_value = payload.get("recommendedNextAction")
+    if recommended_next_action_value is None:
+        recommended_next_action_value = payload.get("recommended_next_action")
+    recommended_next_action = _optional_text(recommended_next_action_value)
+    if recommended_next_action_value is not None and (
+        not isinstance(recommended_next_action_value, str)
+        or recommended_next_action not in _RECOMMENDED_NEXT_ACTIONS
     ):
         # Fail closed gracefully on an unrecognized recommended action instead
         # of raising a hard ContractValidationError from StepGateResult.

--- a/moonmind/workflows/temporal/activities/jules_activities.py
+++ b/moonmind/workflows/temporal/activities/jules_activities.py
@@ -389,6 +389,7 @@ async def repo_create_pr_activity(payload: dict) -> dict:
         base: str = Field(min_length=1)
         title: str = Field(min_length=1)
         body: str = Field(default="")
+        draft: bool = Field(default=False)
 
     try:
         validated = _CreatePRPayload.model_validate(payload)
@@ -410,6 +411,7 @@ async def repo_create_pr_activity(payload: dict) -> dict:
         base=validated.base,
         title=validated.title,
         body=validated.body,
+        draft=validated.draft,
     )
     return result.model_dump(by_alias=True)
 

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -184,7 +184,14 @@ from moonmind.workflows.skills.skill_registry import (
     create_registry_snapshot,
     parse_skill_registry,
 )
-from moonmind.workflows.skills.tool_plan_contracts import ToolFailure
+from moonmind.workflows.skills.approval_policy import (
+    recommended_next_actions,
+    step_gate_contract_violations,
+)
+from moonmind.workflows.skills.tool_plan_contracts import (
+    REVIEW_VERDICTS,
+    ToolFailure,
+)
 from moonmind.workflows.temporal.activity_catalog import TemporalActivityCatalog
 from moonmind.workflows.temporal.artifacts import (
     ArtifactRef,
@@ -7144,6 +7151,19 @@ class TemporalAgentRuntimeActivities:
                 )
                 return {}
             gate_payload = dict(payload)
+            contract_violations = step_gate_contract_violations(gate_payload)
+            if contract_violations:
+                # Surface violations at the boundary where the verifier JSON
+                # enters MoonMind so the workflow gate can request a bounded
+                # corrective re-verify instead of failing the run on a
+                # malformed-but-possibly-approving payload.
+                gate_payload["contractViolations"] = list(contract_violations)
+                logger.warning(
+                    "MoonSpec verify artifact violates the gate contract "
+                    "(%s): %s",
+                    verify_path,
+                    "; ".join(contract_violations),
+                )
             verify_ref = await _write_json_artifact(
                 self._artifact_service,
                 principal="system:agent_runtime",
@@ -8312,11 +8332,20 @@ class TemporalAgentRuntimeActivities:
                 break
         if not verify_artifact_path or verify_artifact_path in instructions:
             return instructions
+        verdict_values = " | ".join(f'"{value}"' for value in sorted(REVIEW_VERDICTS))
+        next_action_values = " | ".join(
+            f'"{value}"' for value in recommended_next_actions()
+        )
         block = (
             "MoonSpec verification output contract:\n"
             f"- Write the complete structured verifier JSON to `{verify_artifact_path}`.\n"
             "- The JSON must include the canonical `verdict`, `recommendedNextAction`, "
             "`recoverableInCurrentRuntime`, and `remainingWork` fields.\n"
+            f"- `verdict` must be exactly one of: {verdict_values}.\n"
+            f"- `recommendedNextAction` must be exactly one of: {next_action_values}. "
+            "Any other value (for example \"create_pull_request\") is a contract "
+            "violation that forces the publication gate to fail closed, discarding "
+            "an otherwise passing verdict.\n"
             "- Still return the Markdown MoonSpec Verification Report in the assistant response."
         )
         return instructions.rstrip() + "\n\n" + block

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -8330,15 +8330,23 @@ class TemporalAgentRuntimeActivities:
             if isinstance(value, str) and value.strip():
                 verify_artifact_path = value.strip()
                 break
-        if not verify_artifact_path or verify_artifact_path in instructions:
+        if not verify_artifact_path:
             return instructions
         verdict_values = " | ".join(f'"{value}"' for value in sorted(REVIEW_VERDICTS))
         next_action_values = " | ".join(
             f'"{value}"' for value in recommended_next_actions()
         )
+        path_hint = (
+            ""
+            if verify_artifact_path in instructions
+            else (
+                "- Write the complete structured verifier JSON to "
+                f"`{verify_artifact_path}`.\n"
+            )
+        )
         block = (
             "MoonSpec verification output contract:\n"
-            f"- Write the complete structured verifier JSON to `{verify_artifact_path}`.\n"
+            f"{path_hint}"
             "- The JSON must include the canonical `verdict`, `recommendedNextAction`, "
             "`recoverableInCurrentRuntime`, and `remainingWork` fields.\n"
             f"- `verdict` must be exactly one of: {verdict_values}.\n"

--- a/moonmind/workflows/temporal/service.py
+++ b/moonmind/workflows/temporal/service.py
@@ -1110,6 +1110,18 @@ class TemporalExecutionService:
         params = dict(initial_parameters or {})
         if failure_policy is not None:
             params.setdefault("failurePolicy", failure_policy)
+        if workflow_type_enum is TemporalWorkflowType.USER_WORKFLOW:
+            action = str(
+                getattr(
+                    settings.workflow,
+                    "moonspec_environment_blocked_publish_action",
+                    "fail",
+                )
+                or "fail"
+            ).strip().lower()
+            if action not in {"fail", "draft_pr"}:
+                action = "fail"
+            params["moonspecEnvironmentBlockedPublishAction"] = action
         task_params = dict(_workflow_payload(params))
         legacy_task_params = params.get("task")
         if isinstance(legacy_task_params, Mapping):

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -113,7 +113,9 @@ from moonmind.workflows.skills.approval_policy import (
     build_feedback_input,
     build_feedback_instruction,
     parse_step_gate_result,
+    recommended_next_actions,
 )
+from moonmind.workflows.skills.tool_plan_contracts import REVIEW_VERDICTS
 from moonmind.workflows.temporal.step_ledger import (
     TERMINAL_STEP_STATUSES,
     build_initial_step_rows,
@@ -335,6 +337,10 @@ _ALREADY_IMPLEMENTED_UNCERTAINTY_PATTERN = re.compile(
     re.IGNORECASE,
 )
 _MOONSPEC_GATE_PASSING_VERDICTS = frozenset({"FULLY_IMPLEMENTED"})
+# Bounded budget for re-running a moonspec-verify step whose structured gate
+# output violated the canonical contract (a parse problem, not a verifier
+# judgment). Remediation implement cycles cannot fix malformed JSON.
+_MOONSPEC_GATE_CONTRACT_REPAIR_MAX_ATTEMPTS = 2
 _MOONSPEC_GATE_BLOCKING_VERDICTS = frozenset(
     {
         "ADDITIONAL_WORK_NEEDED",
@@ -528,6 +534,10 @@ RUN_MOONSPEC_VERIFY_REMEDIATION_INDEX_PATCH = (
     "run-moonspec-verify-remediation-index-v1"
 )
 RUN_MOONSPEC_REMEDIATION_STEP_SKIP_PATCH = "run-moonspec-remediation-step-skip-v1"
+RUN_MOONSPEC_GATE_CONTRACT_REPAIR_PATCH = "run-moonspec-gate-contract-repair-v1"
+RUN_MOONSPEC_GATE_ENVIRONMENT_DRAFT_PUBLISH_PATCH = (
+    "run-moonspec-gate-environment-draft-publish-v1"
+)
 RUN_STEP_RETRY_OVERRIDES_PATCH = "run-step-retry-overrides-v1"
 # MM-880: compile + persist a versioned ResiliencePolicy envelope before step
 # execution begins so every step execution can be traced to the policy values
@@ -943,6 +953,7 @@ class MoonMindRunWorkflow:
         self._plan_blocked_message: Optional[str] = None
         self._moonspec_gate_verdict: Optional[str] = None
         self._moonspec_gate_reason: Optional[str] = None
+        self._moonspec_draft_publication_reason: Optional[str] = None
         self._last_diagnostics_ref: Optional[str] = None
         # Bounded, redacted structured failure diagnostic captured at the
         # failure boundary. Surfaced in reports/run_summary.json and reused by
@@ -4857,6 +4868,47 @@ class MoonMindRunWorkflow:
                     return gate_result_ref
         return None
 
+    def _moonspec_verify_contract_repair_feedback(
+        self,
+        *,
+        execution_result: Any,
+        tool_name: str,
+        node_inputs: Mapping[str, Any],
+    ) -> str | None:
+        """Corrective feedback when a verify step's gate output is malformed.
+
+        Returns text only for moonspec-verify steps whose structured gate
+        payload failed contract validation (invalid/degraded), meaning the
+        gate could not trust the verdict envelope. A ``None`` result means
+        the output is either not a verify step or contract-clean.
+        """
+        if not self._is_moonspec_verify_step(
+            tool_name=tool_name,
+            node_inputs=node_inputs,
+        ):
+            return None
+        outputs = self._get_from_result(execution_result, "outputs")
+        if not isinstance(outputs, Mapping):
+            return None
+        gate_result = self._moonspec_verify_gate_result(outputs)
+        if not (gate_result.invalid or gate_result.degraded):
+            return None
+        detail = gate_result.downgrade_reason or (
+            "the structured verifier JSON was missing or failed contract "
+            "validation"
+        )
+        verdicts = ", ".join(sorted(REVIEW_VERDICTS))
+        next_actions = ", ".join(recommended_next_actions())
+        return (
+            "MoonSpec verify gate contract repair required: "
+            f"{detail}. Rewrite the structured verifier JSON at the "
+            "instructed verify artifact path using only canonical field "
+            f"values (verdict one of: {verdicts}; recommendedNextAction one "
+            f"of: {next_actions}), re-verify against the current workspace "
+            "state, and finish with the Markdown MoonSpec Verification "
+            "Report. Do not modify implementation source in this attempt."
+        )
+
     def _record_moonspec_verify_gate(
         self,
         *,
@@ -4916,6 +4968,8 @@ class MoonMindRunWorkflow:
             "invalid": gate_result.invalid,
             "degraded": gate_result.degraded,
         }
+        if gate_result.downgrade_reason:
+            gate_context["downgradeReason"] = gate_result.downgrade_reason
         gate_result_ref = self._moonspec_verify_gate_result_ref(outputs)
         if gate_result_ref:
             gate_context["gateResultRef"] = gate_result_ref
@@ -5072,14 +5126,20 @@ class MoonMindRunWorkflow:
             return None
         gate_context = self._publish_context.get("moonSpecGate")
         diagnostics_ref = None
+        downgrade_reason = None
         if isinstance(gate_context, Mapping):
             diagnostics_ref = self._coerce_text(
                 gate_context.get("diagnosticsRef"), max_chars=400
+            )
+            downgrade_reason = self._coerce_text(
+                gate_context.get("downgradeReason"), max_chars=700
             )
         parts = [
             "MoonSpec verification did not approve publication",
             f"verdict {verdict}",
         ]
+        if downgrade_reason:
+            parts.append(downgrade_reason)
         if self._moonspec_gate_reason:
             parts.append(self._moonspec_gate_reason)
         if diagnostics_ref:
@@ -5088,6 +5148,11 @@ class MoonMindRunWorkflow:
         return f"{reason}." if reason else None
 
     def _apply_blocking_moonspec_gate_to_publish(self) -> bool:
+        if self._moonspec_draft_publication_reason is not None:
+            # Draft publication (operator policy draft_pr) supersedes the
+            # fail-closed block: the run publishes a draft PR annotated as
+            # verification-incomplete instead of blocking publication.
+            return False
         reason = self._blocking_moonspec_gate_reason()
         if not reason:
             return False
@@ -5096,6 +5161,91 @@ class MoonMindRunWorkflow:
         self._publish_reason = reason
         self._publish_context["publicationBlockedBy"] = "moonspec_verify"
         return True
+
+    @staticmethod
+    def _moonspec_environment_blocked_publish_action() -> str:
+        action = (
+            str(
+                getattr(
+                    settings.workflow,
+                    "moonspec_environment_blocked_publish_action",
+                    "fail",
+                )
+                or "fail"
+            )
+            .strip()
+            .lower()
+        )
+        return action if action in {"fail", "draft_pr"} else "fail"
+
+    def _moonspec_gate_qualifies_for_draft_publish(self) -> bool:
+        """Environment-class gate outcomes eligible for draft publication.
+
+        Qualifying outcomes are verifier-declared environment failures
+        (``BLOCKED``) and ``NO_DETERMINATION`` produced by downgrading a
+        degraded/malformed gate payload. Genuine implementation-gap verdicts
+        (``ADDITIONAL_WORK_NEEDED``, ``FAILED_UNRECOVERABLE``) never qualify.
+        """
+        verdict = self._normalize_moonspec_verify_verdict(self._moonspec_gate_verdict)
+        if verdict == "BLOCKED":
+            return True
+        if verdict != "NO_DETERMINATION":
+            return False
+        gate_context = self._publish_context.get("moonSpecGate")
+        if not isinstance(gate_context, Mapping):
+            return False
+        return bool(gate_context.get("degraded") or gate_context.get("invalid"))
+
+    def _activate_moonspec_draft_publication(self, gate_reason: str) -> str:
+        summary = (
+            "MoonSpec verification incomplete; publishing draft pull request "
+            f"for operator review. {gate_reason}"
+        )
+        self._moonspec_draft_publication_reason = gate_reason
+        self._attention_required = True
+        gate_context = self._publish_context.get("moonSpecGate")
+        if isinstance(gate_context, dict):
+            gate_context["publicationPolicy"] = (
+                "draft_pr_on_environment_blocked"
+            )
+        self._publish_context["moonSpecDraftPublication"] = {
+            "policy": "draft_pr_on_environment_blocked",
+            "reason": gate_reason,
+        }
+        return summary
+
+    def _moonspec_draft_publication_body_section(self) -> str:
+        gate_context = self._publish_context.get("moonSpecGate")
+        verdict = None
+        diagnostics_ref = None
+        if isinstance(gate_context, Mapping):
+            verdict = self._coerce_text(gate_context.get("verdict"), max_chars=80)
+            diagnostics_ref = self._coerce_text(
+                gate_context.get("diagnosticsRef"), max_chars=400
+            )
+        lines = [
+            "## MoonSpec verification incomplete",
+            "",
+            (
+                "This pull request was opened as a **draft** because MoonSpec "
+                f"verification did not approve publication (verdict "
+                f"{verdict or 'unknown'}) and the operator policy "
+                "`workflow.moonspec_environment_blocked_publish_action` is "
+                "`draft_pr`."
+            ),
+            "",
+        ]
+        reason = self._moonspec_draft_publication_reason
+        if reason:
+            lines.append(f"- Gate outcome: {reason}")
+        if diagnostics_ref:
+            lines.append(f"- Verification report: {diagnostics_ref}")
+        lines.append("")
+        lines.append(
+            "Review the verification evidence before marking this pull "
+            "request ready for review."
+        )
+        return "\n".join(lines)
 
     def _review_gate_budget_metadata(
         self,
@@ -6528,6 +6678,15 @@ class MoonMindRunWorkflow:
         terminal_state = (
             STATE_NO_COMMIT if output_status == "no_commit" else STATE_COMPLETED
         )
+        if self._moonspec_draft_publication_reason is not None:
+            # Draft publication completes the run but requires operator
+            # attention: the verification evidence is incomplete.
+            self._attention_required = True
+            output_message = (
+                "Workflow completed with a draft pull request; MoonSpec "
+                "verification is incomplete and requires operator review. "
+                f"{self._moonspec_draft_publication_reason}"
+            )
         self._close_status = CLOSE_STATUS_COMPLETED
         self._set_state(terminal_state, summary=output_message)
         await self._record_terminal_state(
@@ -7256,6 +7415,7 @@ class MoonMindRunWorkflow:
                     )
             review_retry_count = 0
             consecutive_no_progress_attempts = 0
+            moonspec_contract_repair_attempts = 0
             previous_review_feedback: str | None = None
             previous_review_issues: tuple[Mapping[str, Any], ...] = ()
             result_status: str | None = None
@@ -7892,6 +8052,42 @@ class MoonMindRunWorkflow:
                 if self._cancel_requested:
                     return
 
+                if workflow.patched(RUN_MOONSPEC_GATE_CONTRACT_REPAIR_PATCH):
+                    contract_repair_feedback = (
+                        self._moonspec_verify_contract_repair_feedback(
+                            execution_result=execution_result,
+                            tool_name=tool_name,
+                            node_inputs=node_inputs,
+                        )
+                    )
+                    if (
+                        contract_repair_feedback
+                        and moonspec_contract_repair_attempts
+                        < _MOONSPEC_GATE_CONTRACT_REPAIR_MAX_ATTEMPTS
+                    ):
+                        moonspec_contract_repair_attempts += 1
+                        self._upsert_step_check(
+                            node_id,
+                            kind="moonspec_gate_contract",
+                            status="failed",
+                            summary=self._bounded_review_summary(
+                                contract_repair_feedback,
+                                fallback=(
+                                    "MoonSpec verify output failed gate "
+                                    "contract validation"
+                                ),
+                            ),
+                            retry_count=moonspec_contract_repair_attempts,
+                            artifact_ref=None,
+                        )
+                        previous_review_feedback = contract_repair_feedback
+                        previous_review_issues = ()
+                        # The repair budget is tracked separately from the
+                        # approval-policy review budget: leave
+                        # current_review_attempt unchanged so a contract
+                        # repair never consumes review-gate attempts.
+                        continue
+
                 if not review_gate_active:
                     accepted_execution = True
                     break
@@ -8304,6 +8500,30 @@ class MoonMindRunWorkflow:
                     if blocking_gate_reason and not bool(
                         continuation_decision.get("continueLoop")
                     ):
+                        if (
+                            workflow.patched(
+                                RUN_MOONSPEC_GATE_ENVIRONMENT_DRAFT_PUBLISH_PATCH
+                            )
+                            and self._moonspec_environment_blocked_publish_action()
+                            == "draft_pr"
+                            and self._moonspec_gate_qualifies_for_draft_publish()
+                        ):
+                            draft_summary = (
+                                self._activate_moonspec_draft_publication(
+                                    blocking_gate_reason
+                                )
+                            )
+                            self._summary = draft_summary
+                            self._mark_remaining_plan_steps_skipped(
+                                ordered_nodes=ordered_nodes,
+                                completed_index=index - 1,
+                                summary=draft_summary,
+                            )
+                            self._refresh_step_readiness(
+                                updated_at=workflow.now()
+                            )
+                            self._update_memo()
+                            break
                         self._plan_blocked_message = blocking_gate_reason
                         self._publish_status = "not_required"
                         self._publish_reason = blocking_gate_reason
@@ -8565,6 +8785,12 @@ class MoonMindRunWorkflow:
                     )
                     self._publish_context["branch"] = head_branch
                     self._publish_context["baseRef"] = base_branch
+                    if self._moonspec_draft_publication_reason is not None:
+                        pr_body = (
+                            pr_body.rstrip()
+                            + "\n\n"
+                            + self._moonspec_draft_publication_body_section()
+                        )
                     create_payload = {
                         "repo": self._repo,
                         "head": head_branch,
@@ -8572,6 +8798,8 @@ class MoonMindRunWorkflow:
                         "title": pr_title,
                         "body": pr_body,
                     }
+                    if self._moonspec_draft_publication_reason is not None:
+                        create_payload["draft"] = True
                     try:
                         create_result = await workflow.execute_activity(
                             "repo.create_pr",
@@ -14662,6 +14890,11 @@ class MoonMindRunWorkflow:
         }
         if classification:
             compact["classification"] = classification
+        downgrade_reason = self._coerce_text(
+            gate_context.get("downgradeReason"), max_chars=700
+        )
+        if downgrade_reason:
+            compact["downgradeReason"] = downgrade_reason
         diagnostics_ref = self._coerce_text(
             gate_context.get("diagnosticsRef"), max_chars=400
         )

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -953,6 +953,7 @@ class MoonMindRunWorkflow:
         self._plan_blocked_message: Optional[str] = None
         self._moonspec_gate_verdict: Optional[str] = None
         self._moonspec_gate_reason: Optional[str] = None
+        self._moonspec_environment_blocked_publish_action_snapshot: str = "fail"
         self._moonspec_draft_publication_reason: Optional[str] = None
         self._last_diagnostics_ref: Optional[str] = None
         # Bounded, redacted structured failure diagnostic captured at the
@@ -4950,9 +4951,17 @@ class MoonMindRunWorkflow:
                 break
         self._moonspec_gate_verdict = verdict
         self._moonspec_gate_reason = reason
+        declared_verdict = None
+        for source in self._moonspec_verify_sources(outputs):
+            declared_verdict = self._normalize_moonspec_verify_verdict(
+                source.get("verdict")
+            )
+            if declared_verdict:
+                break
         gate_context: dict[str, Any] = {
             "logicalStepId": node_id,
             "verdict": verdict,
+            "declaredVerdict": declared_verdict,
             "confidence": gate_result.confidence,
             "validatedRefs": dict(gate_result.validated_refs or {}),
             "invalidatedRefs": list(gate_result.invalidated_refs),
@@ -5163,20 +5172,14 @@ class MoonMindRunWorkflow:
         return True
 
     @staticmethod
-    def _moonspec_environment_blocked_publish_action() -> str:
-        action = (
-            str(
-                getattr(
-                    settings.workflow,
-                    "moonspec_environment_blocked_publish_action",
-                    "fail",
-                )
-                or "fail"
-            )
-            .strip()
-            .lower()
-        )
+    def _normalize_moonspec_environment_blocked_publish_action(value: Any) -> str:
+        action = str(value or "fail").strip().lower()
         return action if action in {"fail", "draft_pr"} else "fail"
+
+    def _moonspec_environment_blocked_publish_action(self) -> str:
+        return self._normalize_moonspec_environment_blocked_publish_action(
+            self._moonspec_environment_blocked_publish_action_snapshot
+        )
 
     def _moonspec_gate_qualifies_for_draft_publish(self) -> bool:
         """Environment-class gate outcomes eligible for draft publication.
@@ -5186,6 +5189,8 @@ class MoonMindRunWorkflow:
         degraded/malformed gate payload. Genuine implementation-gap verdicts
         (``ADDITIONAL_WORK_NEEDED``, ``FAILED_UNRECOVERABLE``) never qualify.
         """
+        if not self._moonspec_gate_verdict:
+            return False
         verdict = self._normalize_moonspec_verify_verdict(self._moonspec_gate_verdict)
         if verdict == "BLOCKED":
             return True
@@ -5193,6 +5198,14 @@ class MoonMindRunWorkflow:
             return False
         gate_context = self._publish_context.get("moonSpecGate")
         if not isinstance(gate_context, Mapping):
+            return False
+        declared_verdict = self._normalize_moonspec_verify_verdict(
+            gate_context.get("declaredVerdict")
+        )
+        if declared_verdict in {
+            "ADDITIONAL_WORK_NEEDED",
+            "FAILED_UNRECOVERABLE",
+        }:
             return False
         return bool(gate_context.get("degraded") or gate_context.get("invalid"))
 
@@ -6739,6 +6752,12 @@ class MoonMindRunWorkflow:
             input_payload,
             "initialParameters",
             "initial_parameters",
+        )
+        self._moonspec_environment_blocked_publish_action_snapshot = (
+            self._normalize_moonspec_environment_blocked_publish_action(
+                parameters.get("moonspecEnvironmentBlockedPublishAction")
+                or parameters.get("moonspec_environment_blocked_publish_action")
+            )
         )
         recovery_source = self._mapping_value(parameters, "recoverySource", "recovery_source")
         self._recovery_source = (
@@ -8506,6 +8525,7 @@ class MoonMindRunWorkflow:
                             )
                             and self._moonspec_environment_blocked_publish_action()
                             == "draft_pr"
+                            and publish_mode == "pr"
                             and self._moonspec_gate_qualifies_for_draft_publish()
                         ):
                             draft_summary = (

--- a/tests/unit/services/snapshots/settings_catalog_snapshot.json
+++ b/tests/unit/services/snapshots/settings_catalog_snapshot.json
@@ -43,6 +43,13 @@
     "section": "user-workspace",
     "type": "enum"
   },
+  "workflow.moonspec_environment_blocked_publish_action": {
+    "scopes": [
+      "workspace"
+    ],
+    "section": "user-workspace",
+    "type": "enum"
+  },
   "workflow.operation_mode": {
     "scopes": [
       "workspace"

--- a/tests/unit/services/test_settings_catalog.py
+++ b/tests/unit/services/test_settings_catalog.py
@@ -3078,7 +3078,7 @@ def test_settings_registry_default_uses_catalog_key_ledger():
 
 def test_settings_registry_default_registry_passes_ledger_check():
     registry = SettingsRegistry(_REGISTRY)
-    assert len(registry.entries) == 7
+    assert len(registry.entries) == 8
 
 
 def test_settings_catalog_builder_filters_by_section():

--- a/tests/unit/workflows/adapters/test_github_service.py
+++ b/tests/unit/workflows/adapters/test_github_service.py
@@ -162,6 +162,46 @@ async def test_create_pr_adopts_existing_head_base_pr(monkeypatch):
     mock_client.post.assert_not_awaited()
 
 
+@pytest.mark.asyncio
+async def test_create_pr_draft_request_rejects_existing_non_draft_pr(monkeypatch):
+    monkeypatch.setenv("GITHUB_TOKEN", "github-token-fixture")
+
+    existing_pr = {
+        "number": 42,
+        "html_url": "https://github.com/o/r/pull/42",
+        "draft": False,
+        "head": {"ref": "feature", "sha": "abc123", "repo": {"full_name": "o/r"}},
+        "base": {"ref": "main"},
+    }
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(return_value=_mock_get_response(200, [existing_pr]))
+    mock_client.patch = AsyncMock()
+    mock_client.post = AsyncMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch(
+        "moonmind.workflows.adapters.github_service.httpx.AsyncClient",
+        return_value=mock_client,
+    ):
+        result = await GitHubService().create_pull_request(
+            repo="o/r",
+            head="feature",
+            base="main",
+            title="T",
+            body="B",
+            draft=True,
+        )
+
+    assert result.created is False
+    assert result.adopted is False
+    assert result.url == "https://github.com/o/r/pull/42"
+    assert result.head_sha == "abc123"
+    assert "existing non-draft pull request" in result.summary
+    mock_client.patch.assert_not_awaited()
+    mock_client.post.assert_not_awaited()
+
+
 def test_pull_request_head_match_fails_closed_on_missing_repo_metadata() -> None:
     svc = GitHubService()
 

--- a/tests/unit/workflows/adapters/test_github_service.py
+++ b/tests/unit/workflows/adapters/test_github_service.py
@@ -77,6 +77,38 @@ async def test_create_pr_success(monkeypatch):
     assert result.url == "https://github.com/o/r/pull/42"
     assert result.head_sha == "abc123"
     assert result.adopted is False
+    _args, kwargs = mock_client.post.call_args
+    assert "draft" not in kwargs["json"]
+
+
+@pytest.mark.asyncio
+async def test_create_pr_draft_flag_reaches_rest_payload(monkeypatch):
+    """draft=True is sent to the GitHub create endpoint."""
+    monkeypatch.setenv("GITHUB_TOKEN", "github-token-fixture")
+
+    mock_client = AsyncMock()
+    mock_client.post = AsyncMock(
+        return_value=_mock_response(
+            201,
+            {
+                "html_url": "https://github.com/o/r/pull/43",
+                "head": {"sha": "def456"},
+            },
+        )
+    )
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("moonmind.workflows.adapters.github_service.httpx.AsyncClient", return_value=mock_client):
+        svc = GitHubService()
+        result = await svc.create_pull_request(
+            repo="o/r", head="feature", base="main", title="T", body="B",
+            draft=True,
+        )
+
+    assert result.created is True
+    _args, kwargs = mock_client.post.call_args
+    assert kwargs["json"]["draft"] is True
 
 
 @pytest.mark.asyncio

--- a/tests/unit/workflows/skills/test_review_gate_contracts.py
+++ b/tests/unit/workflows/skills/test_review_gate_contracts.py
@@ -277,6 +277,22 @@ class TestParseReviewVerdict:
         assert gate.degraded is True
         assert gate.recommended_next_action == "blocked"
 
+    def test_parse_non_string_recommended_action_fails_closed(self):
+        gate = parse_step_gate_result(
+            {
+                "verdict": "FULLY_IMPLEMENTED",
+                "confidence": 0.95,
+                "recommendedNextAction": ["advance"],
+            }
+        )
+
+        assert gate.verdict == "NO_DETERMINATION"
+        assert gate.invalid is True
+        assert gate.degraded is True
+        assert gate.recommended_next_action == "blocked"
+        assert gate.downgrade_reason is not None
+        assert "recommendedNextAction must be a string" in gate.downgrade_reason
+
     @pytest.mark.parametrize("flag", ["invalid", "degraded"])
     def test_parse_passing_verdict_with_failure_flag_downgrades(self, flag):
         # A passing verdict that arrives already marked invalid/degraded must

--- a/tests/unit/workflows/skills/test_review_gate_contracts.py
+++ b/tests/unit/workflows/skills/test_review_gate_contracts.py
@@ -18,6 +18,8 @@ from moonmind.workflows.skills.approval_policy import (
     build_review_prompt,
     parse_step_gate_result,
     parse_review_verdict,
+    recommended_next_actions,
+    step_gate_contract_violations,
 )
 
 # ── ApprovalPolicyPolicy ──────────────────────────────────────────────────
@@ -286,6 +288,80 @@ class TestParseReviewVerdict:
         assert gate.verdict == "NO_DETERMINATION"
         assert gate.recommended_next_action == "blocked"
         assert getattr(gate, flag) is True
+
+    def test_downgrade_reason_names_declared_verdict_and_violation(self):
+        # Regression for approving verifier reports discarded over a
+        # non-canonical recommendedNextAction (observed: "create_pull_request"
+        # downgraded FULLY_IMPLEMENTED to an unexplained NO_DETERMINATION).
+        gate = parse_step_gate_result(
+            {
+                "verdict": "FULLY_IMPLEMENTED",
+                "confidence": "high",
+                "recommendedNextAction": "create_pull_request",
+            }
+        )
+        assert gate.verdict == "NO_DETERMINATION"
+        assert gate.downgrade_reason is not None
+        assert "FULLY_IMPLEMENTED" in gate.downgrade_reason
+        assert "create_pull_request" in gate.downgrade_reason
+        assert gate.to_payload()["downgradeReason"] == gate.downgrade_reason
+        assert (
+            gate.to_review_verdict().downgrade_reason == gate.downgrade_reason
+        )
+
+    def test_downgrade_reason_for_unrecognized_verdict(self):
+        gate = parse_step_gate_result({"verdict": "FUTURE_VERDICT"})
+        assert gate.verdict == "NO_DETERMINATION"
+        assert gate.downgrade_reason is not None
+        assert "FUTURE_VERDICT" in gate.downgrade_reason
+
+    def test_no_downgrade_reason_for_clean_payload(self):
+        gate = parse_step_gate_result(
+            {
+                "verdict": "FULLY_IMPLEMENTED",
+                "confidence": "high",
+                "recommendedNextAction": "advance",
+            }
+        )
+        assert gate.verdict == "FULLY_IMPLEMENTED"
+        assert gate.downgrade_reason is None
+        assert "downgradeReason" not in gate.to_payload()
+
+    def test_step_gate_contract_violations_clean_payload(self):
+        assert (
+            step_gate_contract_violations(
+                {
+                    "verdict": "BLOCKED",
+                    "recommendedNextAction": "blocked",
+                    "recoverableInCurrentRuntime": False,
+                }
+            )
+            == []
+        )
+
+    def test_step_gate_contract_violations_reports_each_field(self):
+        violations = step_gate_contract_violations(
+            {
+                "verdict": "SOMETHING_ELSE",
+                "recommendedNextAction": "create_pull_request",
+                "degraded": True,
+            }
+        )
+        joined = " ".join(violations)
+        assert "SOMETHING_ELSE" in joined
+        assert "create_pull_request" in joined
+        assert "degraded" in joined
+        assert step_gate_contract_violations({}) == [
+            "verdict is missing from the structured gate payload"
+        ]
+
+    def test_recommended_next_actions_vocabulary(self):
+        assert recommended_next_actions() == (
+            "advance",
+            "blocked",
+            "needs_human",
+            "reattempt_current_step",
+        )
 
     def test_parse_bad_confidence_clamped(self):
         v = parse_review_verdict({"verdict": "PASS", "confidence": 5.0})

--- a/tests/unit/workflows/temporal/test_activity_runtime.py
+++ b/tests/unit/workflows/temporal/test_activity_runtime.py
@@ -114,6 +114,13 @@ async def test_prepare_managed_codex_turn_adds_moonspec_verify_artifact_hint() -
     assert "MoonSpec verification output contract:" in prepared
     assert "var/artifacts/moonspec-verify/verify-final.json" in prepared
     assert "complete structured verifier JSON" in prepared
+    # The hint must enumerate the enforced vocabularies so the verifier agent
+    # cannot drift into non-canonical values the gate would fail closed on.
+    assert '"FULLY_IMPLEMENTED"' in prepared
+    assert '"BLOCKED"' in prepared
+    assert '"advance"' in prepared
+    assert '"reattempt_current_step"' in prepared
+    assert "create_pull_request" in prepared
 
 
 async def test_codex_skill_payload_rejects_auto_publish_mode() -> None:
@@ -4939,7 +4946,7 @@ async def test_agent_runtime_publish_artifacts_publishes_moonspec_verify_json(
                     {
                         "schemaVersion": 1,
                         "verdict": "FULLY_IMPLEMENTED",
-                        "recommendedNextAction": "publish",
+                        "recommendedNextAction": "advance",
                         "recoverableInCurrentRuntime": True,
                         "remainingWork": [],
                     }
@@ -5005,6 +5012,84 @@ async def test_agent_runtime_publish_artifacts_publishes_moonspec_verify_json(
             assert result.metadata["moonSpecVerify"]["gateResultRef"] == (
                 result.metadata["gateResultRef"]
             )
+            assert "contractViolations" not in result.metadata["moonSpecVerify"]
+
+
+async def test_agent_runtime_publish_artifacts_flags_moonspec_contract_violations(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async with temporal_db(tmp_path) as session_maker:
+        async with session_maker() as session:
+            workspace = tmp_path / "workspace"
+            verify_path = workspace / "var/artifacts/moonspec-verify/final.json"
+            verify_path.parent.mkdir(parents=True)
+            # Regression fixture mirroring the observed drift: an approving
+            # verdict paired with a non-canonical recommendedNextAction.
+            verify_path.write_text(
+                json.dumps(
+                    {
+                        "schemaVersion": "moonspec-verify.issue_brief.v1",
+                        "verdict": "FULLY_IMPLEMENTED",
+                        "recommendedNextAction": "create_pull_request",
+                        "recoverableInCurrentRuntime": True,
+                        "remainingWork": [],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            run_store = ManagedRunStore(tmp_path / "runs")
+            run_store.save(
+                ManagedRunRecord(
+                    runId="verify-run-2",
+                    agentId="codex_cli",
+                    runtimeId="codex_cli",
+                    status="completed",
+                    startedAt=datetime.now(timezone.utc),
+                    workspacePath=workspace.as_posix(),
+                )
+            )
+            service = TemporalArtifactService(
+                TemporalArtifactRepository(session),
+                store=LocalTemporalArtifactStore(tmp_path / "artifacts"),
+            )
+            activities = TemporalAgentRuntimeActivities(
+                artifact_service=service,
+                run_store=run_store,
+            )
+
+            async def _skip_notify(*_args: Any, **_kwargs: Any) -> dict[str, str]:
+                return {"status": "skipped"}
+
+            monkeypatch.setattr(
+                activities,
+                "execution_notify_completion",
+                _skip_notify,
+            )
+            monkeypatch.setattr(
+                temporal_activity,
+                "info",
+                lambda: SimpleNamespace(
+                    namespace="default",
+                    workflow_id="parent-wf:agent:verify",
+                    workflow_run_id="child-run-verify-2",
+                ),
+            )
+
+            result = await activities.agent_runtime_publish_artifacts(
+                AgentRunResult(
+                    summary="Completed.",
+                    metadata={
+                        "agentRunId": "verify-run-2",
+                        "verify_artifact_path": (
+                            "var/artifacts/moonspec-verify/final.json"
+                        ),
+                    },
+                )
+            )
+
+            violations = result.metadata["moonSpecVerify"]["contractViolations"]
+            assert any("create_pull_request" in item for item in violations)
 
 
 async def test_agent_runtime_publish_artifacts_uses_last_assistant_text_for_report_body(

--- a/tests/unit/workflows/temporal/test_activity_runtime.py
+++ b/tests/unit/workflows/temporal/test_activity_runtime.py
@@ -123,6 +123,23 @@ async def test_prepare_managed_codex_turn_adds_moonspec_verify_artifact_hint() -
     assert "create_pull_request" in prepared
 
 
+async def test_prepare_managed_codex_turn_appends_vocab_when_path_already_present() -> None:
+    path = "var/artifacts/moonspec-verify/verify-final.json"
+    prepared = TemporalAgentRuntimeActivities._prepare_managed_codex_turn_text(
+        f"Run moonspec-verify and write JSON to `{path}`.",
+        parameters={
+            "metadata": {"moonmind": {"selectedSkill": "moonspec-verify"}},
+            "verify_artifact_path": path,
+        },
+    )
+
+    assert "MoonSpec verification output contract:" in prepared
+    assert prepared.count("complete structured verifier JSON") == 0
+    assert '"FULLY_IMPLEMENTED"' in prepared
+    assert '"advance"' in prepared
+    assert "create_pull_request" in prepared
+
+
 async def test_codex_skill_payload_rejects_auto_publish_mode() -> None:
     from moonmind.agents.codex_worker.handlers import (
         CodexSkillPayload,

--- a/tests/unit/workflows/temporal/test_jules_activities.py
+++ b/tests/unit/workflows/temporal/test_jules_activities.py
@@ -506,7 +506,7 @@ async def test_repo_create_pr_activity_delegates():
         }
         
         result = await repo_create_pr_activity(payload)
-        
+
         assert result == expected_inner.model_dump(by_alias=True)
         mock_svc.create_pull_request.assert_awaited_once_with(
             repo="owner/repo",
@@ -514,6 +514,37 @@ async def test_repo_create_pr_activity_delegates():
             base="main",
             title="Title",
             body="Body",
+            draft=False,
+        )
+
+
+async def test_repo_create_pr_activity_delegates_draft_flag():
+    from moonmind.workflows.temporal.activities.jules_activities import repo_create_pr_activity
+
+    with patch("moonmind.workflows.adapters.github_service.GitHubService") as mock_svc_cls:
+        mock_svc = mock_svc_cls.return_value
+
+        from moonmind.workflows.adapters.github_service import CreatePRResult
+
+        mock_svc.create_pull_request = AsyncMock(
+            return_value=CreatePRResult(
+                url="https://github.com/abc", created=True, summary=""
+            )
+        )
+
+        await repo_create_pr_activity(
+            {
+                "repo": "owner/repo",
+                "head": "branch",
+                "base": "main",
+                "title": "Title",
+                "body": "Body",
+                "draft": True,
+            }
+        )
+
+        assert (
+            mock_svc.create_pull_request.await_args.kwargs["draft"] is True
         )
 
 

--- a/tests/unit/workflows/temporal/test_temporal_service.py
+++ b/tests/unit/workflows/temporal/test_temporal_service.py
@@ -352,6 +352,50 @@ async def test_create_execution_initializes_lifecycle_search_attributes(tmp_path
 
 
 @pytest.mark.asyncio
+async def test_create_execution_snapshots_moonspec_environment_publish_action(
+    tmp_path,
+    mock_client_adapter,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(
+        settings.workflow,
+        "moonspec_environment_blocked_publish_action",
+        "draft_pr",
+    )
+    async with temporal_db(tmp_path) as session:
+        service = TemporalExecutionService(
+            session,
+            client_adapter=mock_client_adapter,
+        )
+
+        record = await service.create_execution(
+            workflow_type="MoonMind.UserWorkflow",
+            owner_id=uuid4(),
+            title="My run",
+            input_artifact_ref=None,
+            plan_artifact_ref=None,
+            manifest_artifact_ref=None,
+            failure_policy=None,
+            initial_parameters=_valid_user_workflow_parameters(),
+            idempotency_key="create-moonspec-draft-policy",
+        )
+
+        assert (
+            record.parameters["moonspecEnvironmentBlockedPublishAction"]
+            == "draft_pr"
+        )
+        start_args = mock_client_adapter.start_workflow.await_args.kwargs[
+            "input_args"
+        ]
+        assert (
+            start_args["initial_parameters"][
+                "moonspecEnvironmentBlockedPublishAction"
+            ]
+            == "draft_pr"
+        )
+
+
+@pytest.mark.asyncio
 async def test_create_execution_writes_runtime_and_primary_skill_search_attributes(tmp_path):
     async with temporal_db(tmp_path) as session:
         service = TemporalExecutionService(session)

--- a/tests/unit/workflows/temporal/workflows/test_run_integration.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_integration.py
@@ -3143,6 +3143,22 @@ def test_moonspec_gate_draft_publish_qualification(
     )
     assert mock_run_workflow._moonspec_gate_qualifies_for_draft_publish() is True
 
+    # A degraded implementation-gap verdict is still an implementation gap,
+    # not an environment-class failure eligible for draft publication.
+    mock_run_workflow._record_moonspec_verify_gate(
+        node_id="verify-final",
+        outputs={
+            "moonSpecVerify": {
+                "verdict": "ADDITIONAL_WORK_NEEDED",
+                "recommendedNextAction": "create_pull_request",
+            }
+        },
+    )
+    assert mock_run_workflow._publish_context["moonSpecGate"][
+        "declaredVerdict"
+    ] == "ADDITIONAL_WORK_NEEDED"
+    assert mock_run_workflow._moonspec_gate_qualifies_for_draft_publish() is False
+
     # Genuine implementation gaps never qualify.
     mock_run_workflow._record_moonspec_verify_gate(
         node_id="verify-final",
@@ -3162,27 +3178,25 @@ def test_moonspec_gate_draft_publish_qualification(
     )
     assert mock_run_workflow._moonspec_gate_qualifies_for_draft_publish() is False
 
+    mock_run_workflow._moonspec_gate_verdict = None
+    assert mock_run_workflow._moonspec_gate_qualifies_for_draft_publish() is False
+
 
 def test_moonspec_environment_blocked_publish_action_defaults_to_fail(
     mock_run_workflow: MoonMindRunWorkflow,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     assert (
         mock_run_workflow._moonspec_environment_blocked_publish_action() == "fail"
     )
-    monkeypatch.setattr(
-        run_workflow_module.settings.workflow,
-        "moonspec_environment_blocked_publish_action",
-        "draft_pr",
+    mock_run_workflow._moonspec_environment_blocked_publish_action_snapshot = (
+        "draft_pr"
     )
     assert (
         mock_run_workflow._moonspec_environment_blocked_publish_action()
         == "draft_pr"
     )
-    monkeypatch.setattr(
-        run_workflow_module.settings.workflow,
-        "moonspec_environment_blocked_publish_action",
-        "unsupported_value",
+    mock_run_workflow._moonspec_environment_blocked_publish_action_snapshot = (
+        "unsupported_value"
     )
     assert (
         mock_run_workflow._moonspec_environment_blocked_publish_action() == "fail"

--- a/tests/unit/workflows/temporal/workflows/test_run_integration.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_integration.py
@@ -3041,6 +3041,222 @@ def test_moonspec_verify_gate_accepts_fully_implemented_publish(
     )
 
 
+def test_moonspec_gate_downgrade_reason_surfaces_in_blocking_message(
+    mock_run_workflow: MoonMindRunWorkflow,
+) -> None:
+    # Regression: an approving verifier report with a non-canonical
+    # recommendedNextAction must explain the downgrade instead of surfacing
+    # an unexplained NO_DETERMINATION.
+    mock_run_workflow._record_moonspec_verify_gate(
+        node_id="verify-final",
+        outputs={
+            "moonSpecVerify": {
+                "verdict": "FULLY_IMPLEMENTED",
+                "recommendedNextAction": "create_pull_request",
+                "summary": "Issue fully implemented after remediation.",
+            },
+            "diagnostics_ref": "art_verify_report",
+        },
+    )
+
+    gate_context = mock_run_workflow._publish_context["moonSpecGate"]
+    assert gate_context["verdict"] == "NO_DETERMINATION"
+    assert "create_pull_request" in gate_context["downgradeReason"]
+    assert "FULLY_IMPLEMENTED" in gate_context["downgradeReason"]
+
+    reason = mock_run_workflow._blocking_moonspec_gate_reason()
+    assert reason is not None
+    assert "FULLY_IMPLEMENTED" in reason
+    assert "create_pull_request" in reason
+    assert "art_verify_report" in reason
+
+
+def test_moonspec_contract_repair_feedback_for_degraded_verify_output(
+    mock_run_workflow: MoonMindRunWorkflow,
+) -> None:
+    execution_result = {
+        "outputs": {
+            "moonSpecVerify": {
+                "verdict": "FULLY_IMPLEMENTED",
+                "recommendedNextAction": "create_pull_request",
+            }
+        }
+    }
+
+    feedback = mock_run_workflow._moonspec_verify_contract_repair_feedback(
+        execution_result=execution_result,
+        tool_name="auto",
+        node_inputs={"selectedSkill": "moonspec-verify"},
+    )
+    assert feedback is not None
+    assert "create_pull_request" in feedback
+    assert "reattempt_current_step" in feedback
+    assert "FULLY_IMPLEMENTED" in feedback
+
+    # Contract-clean verify output requires no repair.
+    assert (
+        mock_run_workflow._moonspec_verify_contract_repair_feedback(
+            execution_result={
+                "outputs": {
+                    "moonSpecVerify": {
+                        "verdict": "FULLY_IMPLEMENTED",
+                        "recommendedNextAction": "advance",
+                    }
+                }
+            },
+            tool_name="auto",
+            node_inputs={"selectedSkill": "moonspec-verify"},
+        )
+        is None
+    )
+
+    # Non-verify steps never trigger contract repair, even with odd outputs.
+    assert (
+        mock_run_workflow._moonspec_verify_contract_repair_feedback(
+            execution_result=execution_result,
+            tool_name="auto",
+            node_inputs={"selectedSkill": "jira-issue-updater"},
+        )
+        is None
+    )
+
+
+def test_moonspec_gate_draft_publish_qualification(
+    mock_run_workflow: MoonMindRunWorkflow,
+) -> None:
+    # Verifier-declared environment failure qualifies.
+    mock_run_workflow._record_moonspec_verify_gate(
+        node_id="verify-final",
+        outputs={"verdict": "BLOCKED"},
+    )
+    assert mock_run_workflow._moonspec_gate_qualifies_for_draft_publish() is True
+
+    # Degraded downgrade to NO_DETERMINATION qualifies.
+    mock_run_workflow._record_moonspec_verify_gate(
+        node_id="verify-final",
+        outputs={
+            "moonSpecVerify": {
+                "verdict": "FULLY_IMPLEMENTED",
+                "recommendedNextAction": "create_pull_request",
+            }
+        },
+    )
+    assert mock_run_workflow._moonspec_gate_qualifies_for_draft_publish() is True
+
+    # Genuine implementation gaps never qualify.
+    mock_run_workflow._record_moonspec_verify_gate(
+        node_id="verify-final",
+        outputs={"verdict": "ADDITIONAL_WORK_NEEDED"},
+    )
+    assert mock_run_workflow._moonspec_gate_qualifies_for_draft_publish() is False
+
+    # A verifier-declared NO_DETERMINATION (clean payload) stays fail-closed.
+    mock_run_workflow._record_moonspec_verify_gate(
+        node_id="verify-final",
+        outputs={
+            "moonSpecVerify": {
+                "verdict": "NO_DETERMINATION",
+                "recommendedNextAction": "blocked",
+            }
+        },
+    )
+    assert mock_run_workflow._moonspec_gate_qualifies_for_draft_publish() is False
+
+
+def test_moonspec_environment_blocked_publish_action_defaults_to_fail(
+    mock_run_workflow: MoonMindRunWorkflow,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    assert (
+        mock_run_workflow._moonspec_environment_blocked_publish_action() == "fail"
+    )
+    monkeypatch.setattr(
+        run_workflow_module.settings.workflow,
+        "moonspec_environment_blocked_publish_action",
+        "draft_pr",
+    )
+    assert (
+        mock_run_workflow._moonspec_environment_blocked_publish_action()
+        == "draft_pr"
+    )
+    monkeypatch.setattr(
+        run_workflow_module.settings.workflow,
+        "moonspec_environment_blocked_publish_action",
+        "unsupported_value",
+    )
+    assert (
+        mock_run_workflow._moonspec_environment_blocked_publish_action() == "fail"
+    )
+
+
+def test_moonspec_draft_publication_supersedes_blocking_gate(
+    mock_run_workflow: MoonMindRunWorkflow,
+) -> None:
+    mock_run_workflow._record_moonspec_verify_gate(
+        node_id="verify-final",
+        outputs={
+            "verdict": "BLOCKED",
+            "operator_summary": "Docker validation wrapper cannot mount repo.",
+            "diagnostics_ref": "art_verify_blocked",
+        },
+    )
+    blocking_reason = mock_run_workflow._blocking_moonspec_gate_reason()
+    assert blocking_reason is not None
+
+    summary = mock_run_workflow._activate_moonspec_draft_publication(
+        blocking_reason
+    )
+    assert "draft pull request" in summary
+
+    # The fail-closed block is superseded: publication proceeds.
+    assert mock_run_workflow._apply_blocking_moonspec_gate_to_publish() is False
+    assert mock_run_workflow._plan_blocked_message is None
+
+    # Simulate the state the run loop records after native draft-PR creation.
+    mock_run_workflow._pull_request_url = "https://github.com/org/repo/pull/7"
+    mock_run_workflow._publish_status = "published"
+    status, _message, publish_failure = (
+        mock_run_workflow._determine_publish_completion(
+            parameters={"publishMode": "pr"}
+        )
+    )
+    assert publish_failure is False
+    assert status != "failed"
+
+    assert mock_run_workflow._attention_required is True
+    draft_context = mock_run_workflow._publish_context["moonSpecDraftPublication"]
+    assert draft_context["policy"] == "draft_pr_on_environment_blocked"
+    assert mock_run_workflow._publish_context["moonSpecGate"][
+        "publicationPolicy"
+    ] == "draft_pr_on_environment_blocked"
+
+    body_section = mock_run_workflow._moonspec_draft_publication_body_section()
+    assert "MoonSpec verification incomplete" in body_section
+    assert "BLOCKED" in body_section
+    assert "art_verify_blocked" in body_section
+
+
+def test_moonspec_blocking_gate_unchanged_without_draft_activation(
+    mock_run_workflow: MoonMindRunWorkflow,
+) -> None:
+    # In-flight compatibility: when the draft-publish path never activates
+    # (patch off or policy 'fail'), the gate blocks exactly as before.
+    mock_run_workflow._record_moonspec_verify_gate(
+        node_id="verify-final",
+        outputs={"verdict": "BLOCKED", "diagnostics_ref": "art_verify_blocked"},
+    )
+    assert mock_run_workflow._moonspec_draft_publication_reason is None
+    assert mock_run_workflow._apply_blocking_moonspec_gate_to_publish() is True
+    assert mock_run_workflow._publish_status == "not_required"
+    status, message, publish_failure = (
+        mock_run_workflow._determine_publish_completion(
+            parameters={"publishMode": "pr"}
+        )
+    )
+    assert publish_failure is True
+    assert "BLOCKED" in message
+
+
 def test_jira_orchestrate_external_handoff_requires_passing_moonspec_gate(
     mock_run_workflow: MoonMindRunWorkflow,
 ) -> None:


### PR DESCRIPTION
## Problem

MoonSpec verification gate failures have been discarding approved or verified work:

- Workflow `mm:d88ee5f5-a3b4-43e4-bf76-2a918f346e49` failed with an unexplained `NO_DETERMINATION` even though the verifier returned `FULLY_IMPLEMENTED` on **all five** verify attempts. Root cause: the final verify report used `recommendedNextAction: "create_pull_request"` (not in the canonical set `advance | reattempt_current_step | needs_human | blocked`), so `parse_step_gate_result` marked the payload invalid and fail-closed downgraded the approving verdict — with no explanation in the failure message.
- Workflow `mm:9c0332bb-2120-479c-ace4-7cbd7756f233` failed with `BLOCKED` because the runner environment could not execute the project's Docker validation wrapper, even though the implementation was fully verified by inspection and the work branch was already pushed.

## Changes

**1. Contract enforcement at the verify boundary (prevention)**
- `_append_moonspec_verify_artifact_hint` now enumerates the canonical `verdict` and `recommendedNextAction` vocabularies in the verifier instructions, explicitly warning that values like `create_pull_request` force the gate to fail closed.
- `agent_runtime_publish_artifacts` validates the structured verifier JSON via the new shared `step_gate_contract_violations` helper and records `contractViolations` on the gate payload and published artifact.

**2. Bounded contract repair instead of terminal failure** (`run-moonspec-gate-contract-repair-v1`)
- When a moonspec-verify step completes with a contract-violating gate payload, the workflow re-runs the verify step with corrective feedback naming the exact violations (max 2 repair attempts, tracked separately from the approval-policy review budget). Remediation implement cycles are never spent on a malformed verdict envelope.

**3. Downgrade transparency**
- `parse_step_gate_result` records `downgrade_reason` naming the declared verdict and the violating field. It flows into the gate publish context, the blocking operator message ("declared verdict FULLY_IMPLEMENTED was downgraded to NO_DETERMINATION because …"), and `failureSummary`.

**4. Draft-PR policy for environment-class gate stops** (`run-moonspec-gate-environment-draft-publish-v1`)
- New operator setting `workflow.moonspec_environment_blocked_publish_action` (`WORKFLOW_MOONSPEC_ENVIRONMENT_BLOCKED_PUBLISH_ACTION`, default **`fail`** — behavior unchanged unless opted in), registered in the settings catalog.
- With `draft_pr`, a gate stop whose outcome is environment-class — verdict `BLOCKED`, or `NO_DETERMINATION` produced by a degraded/malformed payload — publishes a **draft** pull request with a "MoonSpec verification incomplete" body section (gate outcome + verification report ref), and the run completes with `attention_required: true` and a distinct summary instead of failing.
- Implementation-gap verdicts (`ADDITIONAL_WORK_NEEDED`, `FAILED_UNRECOVERABLE`) and verifier-declared `NO_DETERMINATION` always remain fail-closed.
- `draft` flag threads through `repo.create_pr` → `GitHubService.create_pull_request` → GitHub REST payload (create branch only; adopted PRs cannot be flipped to draft via PATCH).

## Replay / in-flight safety

Both workflow behavior changes are guarded by new `workflow.patched` ids; in-flight histories replay the previous fail-closed behavior unchanged. `downgrade_reason` is an additive dataclass field; activity payload additions (`draft`, `contractViolations`) are optional with safe defaults.

## Testing

- `tests/unit/workflows/skills/test_review_gate_contracts.py` — downgrade reason content/round-trip, violation helper, vocabulary guard (44 passed)
- `tests/unit/workflows/temporal/workflows/test_run_integration.py` — downgrade reason in blocking message, contract-repair feedback (verify/clean/non-verify), draft-publish qualification matrix, draft supersedes blocking with completion success, fail-closed unchanged without activation (115 passed)
- `tests/unit/workflows/temporal/test_activity_runtime.py` — hint enumerates vocabularies; contractViolations recorded for the observed drift fixture; clean payload untouched (133 passed)
- `tests/unit/workflows/adapters/test_github_service.py` + `test_jules_activities.py` — draft flag passthrough and REST payload (73 passed)
- Settings catalog registry/snapshot/guardrails suites regenerated and green (156 passed)
- Full targeted sweep: `pytest tests/unit/workflows/skills tests/unit/workflows/temporal/workflows tests/unit/workflows/temporal/test_activity_runtime.py tests/unit/workflows/temporal/test_jules_activities.py tests/unit/workflows/adapters/test_github_service.py tests/unit/config` → **1106 passed**; `tools/check_removed_capability_semantics.py` and `tools/status_domain_audit.py` pass.

Note: `./tools/test_unit.sh` is currently blocked in this working tree by a pre-existing environment issue — the deployment stack wrote a root-owned, unreadable `deploy/state/desired-state.json` (gitignored runtime state) that `status_domain_audit.py` crashes on during its repo scan. The audit passes with that file out of the scan path, and the file does not exist in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)