### PR TITLE
[codex] Handle redacted Docker sidecar conflicts

### DIFF
--- a/moonmind/workflows/temporal/runtime/managed_session_controller.py
+++ b/moonmind/workflows/temporal/runtime/managed_session_controller.py
@@ -678,14 +678,18 @@ class DockerCodexManagedSessionController:
     def _docker_name_conflict(exc: RuntimeError, container_name: str) -> bool:
         detail = str(exc).lower()
         name = str(container_name or "").strip().lower()
-        if not name:
-            return False
-        return (
+        has_name_conflict = (
             "conflict" in detail
             and "container name" in detail
             and "already in use" in detail
-            and name in detail
         )
+        if not has_name_conflict:
+            return False
+        if not name:
+            return False
+        if name in detail:
+            return True
+        return "[redacted]" in detail
 
     async def _cleanup_docker_sidecar_resources(
         self,

--- a/tests/unit/services/temporal/runtime/test_managed_session_controller.py
+++ b/tests/unit/services/temporal/runtime/test_managed_session_controller.py
@@ -571,6 +571,7 @@ async def test_launch_session_recreates_sidecar_after_name_conflict(
     commands: list[tuple[str, ...]] = []
     sidecar_run_attempts = 0
     sidecar_name = "moonmind-session-sess-1-docker"
+    redacted_sidecar_name = "moonmind-session-sess-[REDACTED]-docker"
 
     async def _fake_runner(
         command: tuple[str, ...],
@@ -596,7 +597,8 @@ async def test_launch_session_recreates_sidecar_after_name_conflict(
                         125,
                         "",
                         'docker: Error response from daemon: Conflict. '
-                        f'The container name "/{sidecar_name}" is already in use '
+                        f'The container name "/{redacted_sidecar_name}" '
+                        "is already in use "
                         'by container "old-sidecar". You have to remove '
                         "(or rename) that container to be able to reuse that name.",
                     )


### PR DESCRIPTION
## Summary
- Fix managed-session Docker sidecar conflict detection when the Docker error message has the session-derived container name partially redacted.
- Keep the existing cleanup-and-retry path for stale sidecars left behind by a cancelled launch attempt.
- Update the managed-session controller regression to cover the redacted conflict message shape observed in workflow mm:c952bebd-8ee2-4492-8fcb-f75e63088919.

## Root Cause
Workflow mm:c952bebd-8ee2-4492-8fcb-f75e63088919 failed while launching its Codex Docker sidecar. The first launch attempt was cancelled while the sidecar container was in flight, leaving the sidecar name reserved. The retry received Docker code 125 for “container name already in use”, but MoonMind checked for the full container name after error redaction had replaced part of the session ID, so the stale sidecar cleanup retry was skipped.

## Validation
- MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/services/temporal/runtime/test_managed_session_controller.py
