### PR TITLE
Harden auto publish evidence handling

### DIFF
--- a/.agents/skills/_shared/publish_evidence.py
+++ b/.agents/skills/_shared/publish_evidence.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -15,10 +16,21 @@ SCHEMA_VERSION = "moonmind.publish.auto.v1"
 DEFAULT_ARTIFACTS_DIR = Path("artifacts")
 DEFAULT_RESULT_PATH = DEFAULT_ARTIFACTS_DIR / "publish_result.json"
 DEFAULT_PR_RESOLVER_SNAPSHOT_PATH = Path("var/pr_resolver/snapshot.json")
+SECRET_LIKE_RE = re.compile(
+    r"(ghp_[A-Za-z0-9_]+|github_pat_[A-Za-z0-9_]+|"
+    r"(?i:token|password)=\S+)"
+)
 
 
 class PublishEvidenceError(RuntimeError):
     """Raised when canonical publish evidence cannot be proven."""
+
+
+def _redact_diagnostic_text(value: object) -> str:
+    text = str(value or "").strip()
+    if not text:
+        return ""
+    return SECRET_LIKE_RE.sub("[redacted]", text)[:1000]
 
 
 def _run_text(cmd: list[str], *, timeout: int = 60) -> str:
@@ -33,7 +45,9 @@ def _run_text(cmd: list[str], *, timeout: int = 60) -> str:
     except (OSError, subprocess.TimeoutExpired) as exc:
         raise PublishEvidenceError(f"command unavailable: {cmd[0]}") from exc
     if result.returncode != 0:
-        raise PublishEvidenceError(f"command failed: {' '.join(cmd[:3])}")
+        stderr_msg = _redact_diagnostic_text(result.stderr)
+        suffix = f": {stderr_msg}" if stderr_msg else ""
+        raise PublishEvidenceError(f"command failed: {' '.join(cmd[:3])}{suffix}")
     return (result.stdout or "").strip()
 
 
@@ -171,13 +185,14 @@ def _verify_exact_remote_head(branch: str) -> tuple[str, str, list[str]]:
 
 
 def _verify_pr_merged(pr_url: str) -> tuple[dict[str, Any], list[str]]:
-    if not pr_url:
+    selector = _text(pr_url)
+    if not selector:
         raise PublishEvidenceError("prUrl is required for merged publish evidence")
     command = [
         "gh",
         "pr",
         "view",
-        pr_url,
+        selector,
         "--json",
         "state,mergedAt,mergeCommit,url,headRefName,headRefOid",
     ]
@@ -209,9 +224,16 @@ def _evidence_payload(
 ) -> dict[str, Any]:
     if not _text(skill_id):
         raise PublishEvidenceError("skill-id is required")
-    if not _text(repository):
+    is_terminal_failure = status in {"blocked", "failed"}
+    repository_value = _text(repository)
+    branch_value = _text(branch)
+    if not repository_value and is_terminal_failure:
+        repository_value = "unknown/unknown"
+    if not branch_value and is_terminal_failure:
+        branch_value = "unknown"
+    if not repository_value:
         raise PublishEvidenceError("repo is required")
-    if not _text(branch):
+    if not branch_value:
         raise PublishEvidenceError("branch is required")
     return {
         "schemaVersion": SCHEMA_VERSION,
@@ -220,8 +242,8 @@ def _evidence_payload(
         "skillId": skill_id,
         "status": status,
         "action": action,
-        "repository": repository,
-        "branch": branch,
+        "repository": repository_value,
+        "branch": branch_value,
         "localHead": local_head or None,
         "remoteBranchHead": remote_branch_head or None,
         "remoteVerified": bool(remote_verified),
@@ -431,6 +453,42 @@ def _resolver_pr_url(result: Mapping[str, Any], snapshot: Mapping[str, Any]) -> 
     )
 
 
+def _resolver_pr_selector(result: Mapping[str, Any], snapshot: Mapping[str, Any]) -> str:
+    final = _result_final(result)
+    pr = _snapshot_pr(snapshot)
+    return _first_text(
+        result.get("pr"),
+        result.get("pr_number"),
+        result.get("prNumber"),
+        result.get("pr_selector"),
+        result.get("prSelector"),
+        final.get("pr"),
+        final.get("pr_number"),
+        final.get("prNumber"),
+        final.get("pr_selector"),
+        final.get("prSelector"),
+        pr.get("number"),
+        _resolver_pr_url(result, snapshot),
+    )
+
+
+def _resolve_verified_merged_pr_url(
+    result: Mapping[str, Any],
+    snapshot: Mapping[str, Any],
+) -> str:
+    pr_url = _resolver_pr_url(result, snapshot)
+    if pr_url:
+        return pr_url
+    selector = _resolver_pr_selector(result, snapshot)
+    if not selector:
+        return ""
+    try:
+        payload, _commands = _verify_pr_merged(selector)
+    except PublishEvidenceError:
+        return ""
+    return _text(payload.get("url"))
+
+
 def _resolver_repo(result: Mapping[str, Any], snapshot: Mapping[str, Any]) -> str:
     final = _result_final(result)
     pr_url = _resolver_pr_url(result, snapshot)
@@ -509,6 +567,7 @@ def from_pr_resolver_result(
     pr_url = _resolver_pr_url(result, snapshot)
 
     if disposition in {"merged", "already_merged"} or status == "merged":
+        pr_url = _resolve_verified_merged_pr_url(result, snapshot)
         if not pr_url:
             return write_blocked(
                 skill_id="pr-resolver",
@@ -533,6 +592,21 @@ def from_pr_resolver_result(
                 reason="remote_merge_verification_unavailable",
                 artifacts_dir=artifacts_dir,
             )
+
+    if disposition == "reenter_gate" and status in {
+        "blocked",
+        "attempts_exhausted",
+        "failed",
+    }:
+        return write_blocked(
+            skill_id="pr-resolver",
+            repo=repo,
+            branch=branch,
+            reason=reason
+            if reason != "unknown"
+            else f"unresolved_pr_resolver_state:{status}",
+            artifacts_dir=artifacts_dir,
+        )
 
     if disposition == "reenter_gate":
         try:

--- a/.agents/skills/_shared/publish_evidence.py
+++ b/.agents/skills/_shared/publish_evidence.py
@@ -1,0 +1,718 @@
+#!/usr/bin/env python3
+"""Write canonical MoonMind auto-publish evidence from portable skill tooling."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Mapping
+from urllib.parse import urlparse
+
+SCHEMA_VERSION = "moonmind.publish.auto.v1"
+DEFAULT_ARTIFACTS_DIR = Path("artifacts")
+DEFAULT_RESULT_PATH = DEFAULT_ARTIFACTS_DIR / "publish_result.json"
+DEFAULT_PR_RESOLVER_SNAPSHOT_PATH = Path("var/pr_resolver/snapshot.json")
+
+
+class PublishEvidenceError(RuntimeError):
+    """Raised when canonical publish evidence cannot be proven."""
+
+
+def _run_text(cmd: list[str], *, timeout: int = 60) -> str:
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=timeout,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise PublishEvidenceError(f"command unavailable: {cmd[0]}") from exc
+    if result.returncode != 0:
+        raise PublishEvidenceError(f"command failed: {' '.join(cmd[:3])}")
+    return (result.stdout or "").strip()
+
+
+def _run_json(cmd: list[str], *, timeout: int = 60) -> dict[str, Any]:
+    output = _run_text(cmd, timeout=timeout)
+    try:
+        payload = json.loads(output or "{}")
+    except json.JSONDecodeError as exc:
+        raise PublishEvidenceError(
+            f"command returned invalid JSON: {' '.join(cmd[:3])}"
+        ) from exc
+    if not isinstance(payload, dict):
+        raise PublishEvidenceError(
+            f"command returned non-object JSON: {' '.join(cmd[:3])}"
+        )
+    return payload
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise PublishEvidenceError(f"JSON artifact not found: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise PublishEvidenceError(f"JSON artifact is invalid: {path}") from exc
+    if not isinstance(payload, dict):
+        raise PublishEvidenceError(f"JSON artifact must be an object: {path}")
+    return payload
+
+
+def _read_json_optional(path: Path) -> dict[str, Any]:
+    try:
+        return _read_json(path)
+    except PublishEvidenceError:
+        return {}
+
+
+def _text(value: object) -> str:
+    return str(value or "").strip()
+
+
+def _first_text(*values: object) -> str:
+    for value in values:
+        text = _text(value)
+        if text:
+            return text
+    return ""
+
+
+def _nested_mapping(payload: Mapping[str, Any], *keys: str) -> dict[str, Any]:
+    for key in keys:
+        value = payload.get(key)
+        if isinstance(value, dict):
+            return value
+    return {}
+
+
+def _github_repository_from_url(value: str) -> str:
+    parsed = urlparse(value)
+    if parsed.netloc.lower() not in {"github.com", "www.github.com"}:
+        return ""
+    segments = [segment for segment in parsed.path.split("/") if segment]
+    if len(segments) >= 2:
+        return f"{segments[0]}/{segments[1].removesuffix('.git')}"
+    return ""
+
+
+def _repository_from_git_remote() -> str:
+    try:
+        remote = _run_text(["git", "remote", "get-url", "origin"])
+    except PublishEvidenceError:
+        return ""
+    if remote.startswith("git@github.com:"):
+        path = remote.split("git@github.com:", 1)[1]
+        return path.removesuffix(".git").strip("/")
+    if remote.startswith("https://") or remote.startswith("http://"):
+        parsed = urlparse(remote)
+        if parsed.hostname and parsed.hostname.lower() == "github.com":
+            segments = [segment for segment in parsed.path.split("/") if segment]
+            if len(segments) >= 2:
+                return f"{segments[0]}/{segments[1].removesuffix('.git')}"
+    return ""
+
+
+def _local_head_required() -> str:
+    return _run_text(["git", "rev-parse", "HEAD"])
+
+
+def _local_head_optional() -> str:
+    try:
+        return _local_head_required()
+    except PublishEvidenceError:
+        return ""
+
+
+def _current_branch_optional() -> str:
+    try:
+        branch = _run_text(["git", "branch", "--show-current"])
+    except PublishEvidenceError:
+        return ""
+    return "" if branch == "HEAD" else branch
+
+
+def _remote_branch_head(branch: str) -> str:
+    if not branch:
+        raise PublishEvidenceError("branch is required for remote head verification")
+    output = _run_text(["git", "ls-remote", "origin", f"refs/heads/{branch}"])
+    first_line = output.splitlines()[0] if output else ""
+    sha = first_line.split()[0] if first_line.split() else ""
+    if not sha:
+        raise PublishEvidenceError(f"remote branch head not found for {branch}")
+    return sha
+
+
+def _remote_branch_head_optional(branch: str) -> str:
+    try:
+        return _remote_branch_head(branch)
+    except PublishEvidenceError:
+        return ""
+
+
+def _verify_exact_remote_head(branch: str) -> tuple[str, str, list[str]]:
+    local_head = _local_head_required()
+    remote_head = _remote_branch_head(branch)
+    if local_head != remote_head:
+        raise PublishEvidenceError(f"local HEAD does not match origin/{branch}")
+    return (
+        local_head,
+        remote_head,
+        [
+            "git rev-parse HEAD",
+            f"git ls-remote origin refs/heads/{branch}",
+        ],
+    )
+
+
+def _verify_pr_merged(pr_url: str) -> tuple[dict[str, Any], list[str]]:
+    if not pr_url:
+        raise PublishEvidenceError("prUrl is required for merged publish evidence")
+    command = [
+        "gh",
+        "pr",
+        "view",
+        pr_url,
+        "--json",
+        "state,mergedAt,mergeCommit,url,headRefName,headRefOid",
+    ]
+    payload = _run_json(command)
+    if _text(payload.get("state")).upper() != "MERGED":
+        raise PublishEvidenceError("PR is not merged")
+    if not _text(payload.get("mergedAt")) and not payload.get("mergeCommit"):
+        raise PublishEvidenceError("merged PR verification is incomplete")
+    return payload, [
+        "gh pr view <pr-url> --json state,mergedAt,mergeCommit,url,headRefName,headRefOid"
+    ]
+
+
+def _evidence_payload(
+    *,
+    skill_id: str,
+    status: str,
+    action: str,
+    repository: str,
+    branch: str,
+    local_head: str | None,
+    remote_branch_head: str | None,
+    remote_verified: bool,
+    pushed: bool,
+    merged: bool,
+    pr_url: str | None = None,
+    blocked_reason: str | None = None,
+    verification_commands: list[str] | None = None,
+) -> dict[str, Any]:
+    if not _text(skill_id):
+        raise PublishEvidenceError("skill-id is required")
+    if not _text(repository):
+        raise PublishEvidenceError("repo is required")
+    if not _text(branch):
+        raise PublishEvidenceError("branch is required")
+    return {
+        "schemaVersion": SCHEMA_VERSION,
+        "mode": "auto",
+        "owner": "agent",
+        "skillId": skill_id,
+        "status": status,
+        "action": action,
+        "repository": repository,
+        "branch": branch,
+        "localHead": local_head or None,
+        "remoteBranchHead": remote_branch_head or None,
+        "remoteVerified": bool(remote_verified),
+        "pushed": bool(pushed),
+        "merged": bool(merged),
+        "prUrl": pr_url or None,
+        "blockedReason": blocked_reason or None,
+        "verificationCommands": list(verification_commands or []),
+    }
+
+
+def _write_payload(payload: Mapping[str, Any], *, artifacts_dir: Path) -> Path:
+    artifacts_dir.mkdir(parents=True, exist_ok=True)
+    path = artifacts_dir / "publish_result.json"
+    path.write_text(json.dumps(dict(payload), indent=2) + "\n", encoding="utf-8")
+    return path
+
+
+def write_pushed(*, skill_id: str, repo: str, branch: str, artifacts_dir: Path) -> Path:
+    local_head, remote_head, commands = _verify_exact_remote_head(branch)
+    return _write_payload(
+        _evidence_payload(
+            skill_id=skill_id,
+            status="verified",
+            action="push",
+            repository=repo,
+            branch=branch,
+            local_head=local_head,
+            remote_branch_head=remote_head,
+            remote_verified=True,
+            pushed=True,
+            merged=False,
+            verification_commands=commands,
+        ),
+        artifacts_dir=artifacts_dir,
+    )
+
+
+def write_no_op(*, skill_id: str, repo: str, branch: str, artifacts_dir: Path) -> Path:
+    local_head, remote_head, commands = _verify_exact_remote_head(branch)
+    return _write_payload(
+        _evidence_payload(
+            skill_id=skill_id,
+            status="no_op_verified",
+            action="none",
+            repository=repo,
+            branch=branch,
+            local_head=local_head,
+            remote_branch_head=remote_head,
+            remote_verified=True,
+            pushed=False,
+            merged=False,
+            verification_commands=commands,
+        ),
+        artifacts_dir=artifacts_dir,
+    )
+
+
+def write_merged(
+    *,
+    skill_id: str,
+    repo: str,
+    branch: str,
+    pr_url: str,
+    artifacts_dir: Path,
+) -> Path:
+    gh_payload, commands = _verify_pr_merged(pr_url)
+    local_head = _local_head_optional() or _text(gh_payload.get("headRefOid")) or None
+    return _write_payload(
+        _evidence_payload(
+            skill_id=skill_id,
+            status="verified",
+            action="merge",
+            repository=repo,
+            branch=branch,
+            local_head=local_head,
+            remote_branch_head=None,
+            remote_verified=True,
+            pushed=False,
+            merged=True,
+            pr_url=pr_url,
+            verification_commands=commands,
+        ),
+        artifacts_dir=artifacts_dir,
+    )
+
+
+def write_blocked(
+    *,
+    skill_id: str,
+    repo: str,
+    branch: str,
+    reason: str,
+    artifacts_dir: Path,
+) -> Path:
+    return _write_payload(
+        _evidence_payload(
+            skill_id=skill_id,
+            status="blocked",
+            action="none",
+            repository=repo,
+            branch=branch,
+            local_head=_local_head_optional() or None,
+            remote_branch_head=_remote_branch_head_optional(branch) or None,
+            remote_verified=False,
+            pushed=False,
+            merged=False,
+            blocked_reason=reason,
+            verification_commands=[],
+        ),
+        artifacts_dir=artifacts_dir,
+    )
+
+
+def write_failed(
+    *,
+    skill_id: str,
+    repo: str,
+    branch: str,
+    reason: str,
+    artifacts_dir: Path,
+) -> Path:
+    return _write_payload(
+        _evidence_payload(
+            skill_id=skill_id,
+            status="failed",
+            action="none",
+            repository=repo,
+            branch=branch,
+            local_head=_local_head_optional() or None,
+            remote_branch_head=_remote_branch_head_optional(branch) or None,
+            remote_verified=False,
+            pushed=False,
+            merged=False,
+            blocked_reason=reason,
+            verification_commands=[],
+        ),
+        artifacts_dir=artifacts_dir,
+    )
+
+
+def _snapshot_pr(snapshot: Mapping[str, Any]) -> dict[str, Any]:
+    return snapshot.get("pr") if isinstance(snapshot.get("pr"), dict) else {}
+
+
+def _result_final(result: Mapping[str, Any]) -> dict[str, Any]:
+    return _nested_mapping(
+        result,
+        "final",
+        "final_state",
+        "finalState",
+        "merge",
+        "mergeOutcome",
+    )
+
+
+def _resolver_disposition(result: Mapping[str, Any]) -> str:
+    final = _result_final(result)
+    return _first_text(
+        result.get("mergeAutomationDisposition"),
+        result.get("merge_automation_disposition"),
+        result.get("disposition"),
+        final.get("mergeAutomationDisposition"),
+        final.get("merge_automation_disposition"),
+        final.get("disposition"),
+    ).lower()
+
+
+def _resolver_status(result: Mapping[str, Any]) -> str:
+    final = _result_final(result)
+    return _first_text(
+        result.get("status"),
+        result.get("state"),
+        result.get("merge_outcome"),
+        result.get("mergeOutcome"),
+        final.get("status"),
+        final.get("state"),
+        final.get("merge_outcome"),
+        final.get("mergeOutcome"),
+    ).lower()
+
+
+def _resolver_reason(result: Mapping[str, Any]) -> str:
+    final = _result_final(result)
+    return _first_text(
+        result.get("final_reason"),
+        result.get("reason"),
+        result.get("decision"),
+        final.get("final_reason"),
+        final.get("reason"),
+        final.get("decision"),
+        "unknown",
+    )
+
+
+def _resolver_pr_url(result: Mapping[str, Any], snapshot: Mapping[str, Any]) -> str:
+    final = _result_final(result)
+    pr = _snapshot_pr(snapshot)
+    return _first_text(
+        result.get("prUrl"),
+        result.get("pr_url"),
+        result.get("url"),
+        final.get("prUrl"),
+        final.get("pr_url"),
+        final.get("url"),
+        pr.get("url"),
+    )
+
+
+def _resolver_repo(result: Mapping[str, Any], snapshot: Mapping[str, Any]) -> str:
+    final = _result_final(result)
+    pr_url = _resolver_pr_url(result, snapshot)
+    repo = _first_text(
+        result.get("repository"),
+        result.get("repo"),
+        final.get("repository"),
+        final.get("repo"),
+        _github_repository_from_url(pr_url),
+    )
+    return repo or _repository_from_git_remote() or "unknown/unknown"
+
+
+def _resolver_branch(result: Mapping[str, Any], snapshot: Mapping[str, Any]) -> str:
+    final = _result_final(result)
+    pr = _snapshot_pr(snapshot)
+    branch = _first_text(
+        result.get("branch"),
+        result.get("headBranch"),
+        result.get("head_branch"),
+        final.get("branch"),
+        final.get("headBranch"),
+        final.get("head_branch"),
+        pr.get("headRefName"),
+    )
+    return branch or _current_branch_optional() or "unknown"
+
+
+def _resolver_head(result: Mapping[str, Any], snapshot: Mapping[str, Any]) -> str:
+    final = _result_final(result)
+    pr = _snapshot_pr(snapshot)
+    head = _first_text(
+        result.get("localHead"),
+        result.get("headSha"),
+        result.get("head_sha"),
+        final.get("localHead"),
+        final.get("headSha"),
+        final.get("head_sha"),
+        pr.get("headRefOid"),
+    )
+    return head or _local_head_optional()
+
+
+def _is_no_work_result(result: Mapping[str, Any]) -> bool:
+    disposition = _resolver_disposition(result)
+    status = _resolver_status(result)
+    reason = _resolver_reason(result).lower()
+    return (
+        disposition in {"no_op", "no_work", "no_work_needed", "already_current"}
+        or status in {"no_op", "noop", "no_work", "no_work_needed"}
+        or reason
+        in {
+            "no_op",
+            "noop",
+            "no_work",
+            "no_work_needed",
+            "already_current",
+            "already_up_to_date",
+        }
+    )
+
+
+def from_pr_resolver_result(
+    *,
+    result_path: Path,
+    snapshot_path: Path,
+    artifacts_dir: Path,
+) -> Path:
+    result = _read_json(result_path)
+    snapshot = _read_json_optional(snapshot_path)
+    disposition = _resolver_disposition(result)
+    status = _resolver_status(result)
+    reason = _resolver_reason(result)
+    repo = _resolver_repo(result, snapshot)
+    branch = _resolver_branch(result, snapshot)
+    pr_url = _resolver_pr_url(result, snapshot)
+
+    if disposition in {"merged", "already_merged"} or status == "merged":
+        if not pr_url:
+            return write_blocked(
+                skill_id="pr-resolver",
+                repo=repo,
+                branch=branch,
+                reason="pr_url_unavailable",
+                artifacts_dir=artifacts_dir,
+            )
+        try:
+            return write_merged(
+                skill_id="pr-resolver",
+                repo=repo,
+                branch=branch,
+                pr_url=pr_url,
+                artifacts_dir=artifacts_dir,
+            )
+        except PublishEvidenceError:
+            return write_blocked(
+                skill_id="pr-resolver",
+                repo=repo,
+                branch=branch,
+                reason="remote_merge_verification_unavailable",
+                artifacts_dir=artifacts_dir,
+            )
+
+    if disposition == "reenter_gate":
+        try:
+            local_head, remote_head, commands = _verify_exact_remote_head(branch)
+        except PublishEvidenceError:
+            return write_blocked(
+                skill_id="pr-resolver",
+                repo=repo,
+                branch=branch,
+                reason="remote_verification_unavailable",
+                artifacts_dir=artifacts_dir,
+            )
+        return _write_payload(
+            _evidence_payload(
+                skill_id="pr-resolver",
+                status="verified",
+                action="push",
+                repository=repo,
+                branch=branch,
+                local_head=local_head,
+                remote_branch_head=remote_head,
+                remote_verified=True,
+                pushed=True,
+                merged=False,
+                pr_url=pr_url or None,
+                verification_commands=commands,
+            ),
+            artifacts_dir=artifacts_dir,
+        )
+
+    if _is_no_work_result(result):
+        try:
+            local_head, remote_head, commands = _verify_exact_remote_head(branch)
+        except PublishEvidenceError:
+            return write_blocked(
+                skill_id="pr-resolver",
+                repo=repo,
+                branch=branch,
+                reason="remote_verification_unavailable",
+                artifacts_dir=artifacts_dir,
+            )
+        return _write_payload(
+            _evidence_payload(
+                skill_id="pr-resolver",
+                status="no_op_verified",
+                action="none",
+                repository=repo,
+                branch=branch,
+                local_head=local_head,
+                remote_branch_head=remote_head,
+                remote_verified=True,
+                pushed=False,
+                merged=False,
+                pr_url=pr_url or None,
+                verification_commands=commands,
+            ),
+            artifacts_dir=artifacts_dir,
+        )
+
+    if disposition == "failed" or status == "failed":
+        return write_failed(
+            skill_id="pr-resolver",
+            repo=repo,
+            branch=branch,
+            reason=reason,
+            artifacts_dir=artifacts_dir,
+        )
+
+    return write_blocked(
+        skill_id="pr-resolver",
+        repo=repo,
+        branch=branch,
+        reason=reason
+        if (
+            status in {"blocked", "attempts_exhausted"}
+            or disposition in {"manual_review", "blocked"}
+        )
+        else f"unsupported_pr_resolver_state:{status or disposition or 'unknown'}",
+        artifacts_dir=artifacts_dir,
+    )
+
+
+def _add_common_write_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--skill-id", required=True)
+    parser.add_argument("--repo", required=True)
+    parser.add_argument("--branch", required=True)
+    parser.add_argument("--artifacts-dir", default=str(DEFAULT_ARTIFACTS_DIR))
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Write canonical MoonMind auto-publish evidence."
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    pushed = subparsers.add_parser("write-pushed")
+    _add_common_write_args(pushed)
+
+    merged = subparsers.add_parser("write-merged")
+    _add_common_write_args(merged)
+    merged.add_argument("--pr-url", required=True)
+
+    no_op = subparsers.add_parser("write-no-op")
+    _add_common_write_args(no_op)
+
+    blocked = subparsers.add_parser("write-blocked")
+    _add_common_write_args(blocked)
+    blocked.add_argument("--reason", required=True)
+
+    failed = subparsers.add_parser("write-failed")
+    _add_common_write_args(failed)
+    failed.add_argument("--reason", required=True)
+
+    resolver = subparsers.add_parser("from-pr-resolver-result")
+    resolver.add_argument("--result", required=True)
+    resolver.add_argument(
+        "--snapshot",
+        default=str(DEFAULT_PR_RESOLVER_SNAPSHOT_PATH),
+        help="Optional pr-resolver snapshot artifact used to fill repo/branch/PR metadata.",
+    )
+    resolver.add_argument("--artifacts-dir", default=str(DEFAULT_ARTIFACTS_DIR))
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    artifacts_dir = Path(getattr(args, "artifacts_dir", DEFAULT_ARTIFACTS_DIR))
+    try:
+        if args.command == "write-pushed":
+            path = write_pushed(
+                skill_id=args.skill_id,
+                repo=args.repo,
+                branch=args.branch,
+                artifacts_dir=artifacts_dir,
+            )
+        elif args.command == "write-merged":
+            path = write_merged(
+                skill_id=args.skill_id,
+                repo=args.repo,
+                branch=args.branch,
+                pr_url=args.pr_url,
+                artifacts_dir=artifacts_dir,
+            )
+        elif args.command == "write-no-op":
+            path = write_no_op(
+                skill_id=args.skill_id,
+                repo=args.repo,
+                branch=args.branch,
+                artifacts_dir=artifacts_dir,
+            )
+        elif args.command == "write-blocked":
+            path = write_blocked(
+                skill_id=args.skill_id,
+                repo=args.repo,
+                branch=args.branch,
+                reason=args.reason,
+                artifacts_dir=artifacts_dir,
+            )
+        elif args.command == "write-failed":
+            path = write_failed(
+                skill_id=args.skill_id,
+                repo=args.repo,
+                branch=args.branch,
+                reason=args.reason,
+                artifacts_dir=artifacts_dir,
+            )
+        elif args.command == "from-pr-resolver-result":
+            path = from_pr_resolver_result(
+                result_path=Path(args.result),
+                snapshot_path=Path(args.snapshot),
+                artifacts_dir=artifacts_dir,
+            )
+        else:
+            raise PublishEvidenceError(f"unsupported command: {args.command}")
+    except PublishEvidenceError as exc:
+        print(f"publish evidence error: {exc}", file=sys.stderr)
+        return 2
+    print(f"Wrote {path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/batch-dependabot-resolver/SKILL.md
+++ b/.agents/skills/batch-dependabot-resolver/SKILL.md
@@ -2,11 +2,10 @@
 name: batch-dependabot-resolver
 description: Discover open Dependabot version-bump PRs and enqueue one `pr-resolver` workflow for each.
 metadata:
-  publish:
-    mode: auto
+  sideEffect:
+    kind: enqueue_children
     owner: agent
-    requiresEvidence: true
-    verifyRemoteHead: exact
+    outcomeArtifact: artifacts/batch_dependabot_resolver_result.json
   required-capabilities:
     - gh
 ---
@@ -23,6 +22,10 @@ same child `pr-resolver` payload shape, fork/cross-repo safety, runtime
 inheritance, and `/api/executions` submission path, and adds Dependabot-specific
 matching, a cross-run-stable idempotency key, a dry-run mode, an optional `maxPrs`
 cap, and a Dependabot-specific summary artifact.
+
+This parent batch skill does not publish repository changes itself. It records
+child workflow queueing evidence in `artifacts/batch_dependabot_resolver_result.json`;
+each queued `pr-resolver` child owns its repository publishing outcome.
 
 ## Inputs (skill args)
 

--- a/.agents/skills/batch-pr-resolver/SKILL.md
+++ b/.agents/skills/batch-pr-resolver/SKILL.md
@@ -2,11 +2,10 @@
 name: batch-pr-resolver
 description: Discover open PRs in a repository and enqueue one `pr-resolver` task for each.
 metadata:
-  publish:
-    mode: auto
+  sideEffect:
+    kind: enqueue_children
     owner: agent
-    requiresEvidence: true
-    verifyRemoteHead: exact
+    outcomeArtifact: artifacts/batch_pr_resolver_result.json
   required-capabilities:
     - gh
 ---
@@ -16,6 +15,10 @@ metadata:
 ## Purpose
 
 Create one queue task per open pull request so each PR branch can be resolved by `pr-resolver` on its existing branch. Fork PRs are skipped.
+
+This parent batch skill does not publish repository changes itself. It records
+child workflow queueing evidence in `artifacts/batch_pr_resolver_result.json`;
+each queued `pr-resolver` child owns its repository publishing outcome.
 
 ## Inputs (skill args)
 

--- a/.agents/skills/batch-workflows/SKILL.md
+++ b/.agents/skills/batch-workflows/SKILL.md
@@ -2,11 +2,10 @@
 name: batch-workflows
 description: Resolve Jira issues by project/status and enqueue one child MoonMind workflow per target using a selected run capability, inherited runtime, and a shared advanced publish policy.
 metadata:
-  publish:
-    mode: auto
+  sideEffect:
+    kind: enqueue_children
     owner: agent
-    requiresEvidence: true
-    verifyRemoteHead: exact
+    outcomeArtifact: artifacts/batch-workflows-result.json
   required-capabilities:
     - git
     - jira
@@ -22,6 +21,10 @@ running a selected child capability such as `skill:jira-verify` or
 `preset:jira-implement`. Every child inherits the parent runtime
 (`runtimeInheritance="caller"`) and a single shared publish policy. The parent
 records a summary artifact that links every queued child workflow.
+
+This parent batch skill does not publish repository changes itself. It records
+child workflow queueing evidence in `artifacts/batch-workflows-result.json`;
+each queued child workflow owns its configured publish outcome.
 
 This replaces one-off prompts like "Queue Jira Verify for every MM issue in In
 Progress" with a single batch run.

--- a/.agents/skills/fix-ci/SKILL.md
+++ b/.agents/skills/fix-ci/SKILL.md
@@ -55,18 +55,36 @@ If no inputs are provided, investigate the failing CI checks for the current bra
 - Record the exact local `HEAD` SHA after the push.
 - Confirm the PR branch on GitHub points at that same SHA. If it does not,
   stop as blocked; do not report success.
-- Write `artifacts/publish_result.json` proving the exact remote head
-  verification for pushed or no-op outcomes.
+- Write `artifacts/publish_result.json` through the shared helper after every
+  pushed or verified no-op outcome:
+  ```bash
+  python3 .agents/skills/_shared/publish_evidence.py write-pushed \
+    --skill-id fix-ci \
+    --repo "$REPO" \
+    --branch "$BRANCH"
+  ```
+  If no commit was needed, use:
+  ```bash
+  python3 .agents/skills/_shared/publish_evidence.py write-no-op \
+    --skill-id fix-ci \
+    --repo "$REPO" \
+    --branch "$BRANCH"
+  ```
 - Wait for required PR checks on that SHA to finish. Poll with bounded backoff.
 - If checks pass, finish successfully.
 - If checks fail, fetch the new failing logs and repeat steps 2-6, up to
   `maxIterations`.
 - If checks remain queued/running beyond the wait cap, GitHub is unavailable,
-  or the task explicitly forbids pushing, stop as blocked with the current SHA,
-  check state, next action, and `artifacts/publish_result.json` containing
-  `blockedReason=publish_unavailable` when push or remote verification is
-  unavailable. Do not report success while CI is running, degraded, unknown, or
-  failing.
+  or the task explicitly forbids pushing, write blocked evidence and stop with
+  the current SHA, check state, and next action:
+  ```bash
+  python3 .agents/skills/_shared/publish_evidence.py write-blocked \
+    --skill-id fix-ci \
+    --repo "$REPO" \
+    --branch "$BRANCH" \
+    --reason publish_unavailable
+  ```
+  Do not report success while CI is running, degraded, unknown, or failing.
 
 ## Output
 

--- a/.agents/skills/fix-comments/SKILL.md
+++ b/.agents/skills/fix-comments/SKILL.md
@@ -82,7 +82,30 @@ If no constraints are provided, default to addressing all applicable feedback.
 - If tracked or untracked code/documentation changes exist outside ignored artifacts, commit with a clear message (default: `Address PR feedback for #<number>`).
 - Push the current branch after committing.
 - If there was nothing to commit, still prove the current branch is published: verify the exact local `HEAD` SHA is visible on the remote PR branch using `gh pr view`, `git ls-remote`, or an equivalent GitHub connector path.
-- After any push or no-op verification, re-check that the remote PR branch head SHA equals local `HEAD`. If push or remote verification is unavailable, write `artifacts/publish_result.json` with `schemaVersion=moonmind.publish.auto.v1`, `mode=auto`, `owner=agent`, `status=blocked`, `action=none`, `blockedReason=publish_unavailable`, and the available repository/branch/head fields; then stop as blocked with reason `publish_unavailable`. Do not report success.
+- After any push or no-op verification, re-check that the remote PR branch head SHA equals local `HEAD` by writing canonical evidence through the shared helper:
+  ```bash
+  python3 .agents/skills/_shared/publish_evidence.py write-pushed \
+    --skill-id fix-comments \
+    --repo "$REPO" \
+    --branch "$BRANCH"
+  ```
+  If there was no commit to push, use:
+  ```bash
+  python3 .agents/skills/_shared/publish_evidence.py write-no-op \
+    --skill-id fix-comments \
+    --repo "$REPO" \
+    --branch "$BRANCH"
+  ```
+  If push or remote verification is unavailable, write blocked evidence and
+  stop as blocked with reason `publish_unavailable`:
+  ```bash
+  python3 .agents/skills/_shared/publish_evidence.py write-blocked \
+    --skill-id fix-comments \
+    --repo "$REPO" \
+    --branch "$BRANCH" \
+    --reason publish_unavailable
+  ```
+  Do not report success.
 - When fix-comments is delegated by pr-resolver and publication is unavailable, also ensure `var/pr_resolver/result.json` reflects `status=blocked`, `merge_outcome=blocked`, and `mergeAutomationDisposition=manual_review` so the parent resolver cannot report a stale merge-ready result.
 
 ## Output

--- a/.agents/skills/fix-merge-conflicts/SKILL.md
+++ b/.agents/skills/fix-merge-conflicts/SKILL.md
@@ -77,8 +77,29 @@ fi
 - Push current branch: `git push`
 - After push, record local `HEAD` with `git rev-parse HEAD` and verify the exact same SHA is visible on the remote branch with `git ls-remote origin refs/heads/<current-branch>` or an equivalent trusted GitHub path.
 - If there was nothing to commit, still verify the current local `HEAD` exactly matches the remote branch head.
-- If push or remote verification is unavailable, write `artifacts/publish_result.json` with `schemaVersion=moonmind.publish.auto.v1`, `mode=auto`, `owner=agent`, `status=blocked`, `action=none`, `blockedReason=publish_unavailable`, and the available repository/branch/head fields; then stop as blocked with reason `publish_unavailable`. Do not report success.
-- On successful push or verified no-op, write `artifacts/publish_result.json` proving the exact remote head verification.
+- On successful push, write canonical evidence:
+  ```bash
+  python3 .agents/skills/_shared/publish_evidence.py write-pushed \
+    --skill-id fix-merge-conflicts \
+    --repo "$REPO" \
+    --branch "$BRANCH"
+  ```
+- On verified no-op, write canonical no-op evidence:
+  ```bash
+  python3 .agents/skills/_shared/publish_evidence.py write-no-op \
+    --skill-id fix-merge-conflicts \
+    --repo "$REPO" \
+    --branch "$BRANCH"
+  ```
+- If push or remote verification is unavailable, write blocked evidence, then stop as blocked with reason `publish_unavailable`:
+  ```bash
+  python3 .agents/skills/_shared/publish_evidence.py write-blocked \
+    --skill-id fix-merge-conflicts \
+    --repo "$REPO" \
+    --branch "$BRANCH" \
+    --reason publish_unavailable
+  ```
+  Do not report success.
 
 ## Output
 

--- a/.agents/skills/pr-resolver/SKILL.md
+++ b/.agents/skills/pr-resolver/SKILL.md
@@ -50,8 +50,10 @@ python3 .agents/skills/pr-resolver/bin/pr_resolve_orchestrate.py \
 This writes:
 - `var/pr_resolver/result.json` (terminal orchestration summary)
 - `var/pr_resolver/attempts/*.json` (per-attempt finalize/full artifacts)
+- `artifacts/publish_result.json` (canonical auto-publish evidence, generated
+  by `.agents/skills/_shared/publish_evidence.py`)
 
-If this command does not run, does not write `var/pr_resolver/result.json`, or exits before producing a parseable result, stop as blocked with the command output and do not report success.
+If this command does not run, does not write `var/pr_resolver/result.json`, does not write `artifacts/publish_result.json`, or exits before producing parseable artifacts, stop as blocked with the command output and do not report success.
 
 ## Foreground Execution Contract (no backgrounding)
 This skill runs inside a one-shot managed agent run. When your process exits, the
@@ -162,6 +164,10 @@ python3 .agents/skills/pr-resolver/bin/pr_resolve_full.py --pr <pr_number_or_bra
 - Keep `pr_resolve_finalize.py` as a gate checker; do not add remediation mutations there.
 - Do NOT invent custom conflict/CI/comment workflows; always execute the specialized skill instructions.
 - Respect retry caps; if retries are exhausted, return `attempts_exhausted` and stop.
-- This skill owns publishing under `task.publish.mode = "auto"` and may commit, push, or merge only as required to resolve the target PR. Before reporting success, write `artifacts/publish_result.json` with auto publish evidence proving the verified outcome.
+- This skill owns publishing under `task.publish.mode = "auto"` and may commit, push, or merge only as required to resolve the target PR. Before reporting success, ensure `artifacts/publish_result.json` exists. The orchestration command normally generates it by running:
+  ```bash
+  python3 .agents/skills/_shared/publish_evidence.py from-pr-resolver-result \
+    --result var/pr_resolver/result.json
+  ```
 - A failed push, missing GitHub auth, or missing remote branch update is an unresolved PR blocker, even if all code changes are committed locally.
 - Never background the orchestration command or rely on notifications/scheduled wakeups to finish the merge; run it in the foreground and wait for it to return (see Foreground Execution Contract).

--- a/.agents/skills/pr-resolver/bin/pr_resolve_orchestrate.py
+++ b/.agents/skills/pr-resolver/bin/pr_resolve_orchestrate.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import shlex
 import subprocess
 import sys
@@ -31,6 +32,11 @@ from pr_resolve_contract import (  # noqa: E402
     now_utc_iso,
     parse_reason,
     remediation_next_step,
+)
+
+SECRET_LIKE_RE = re.compile(
+    r"(ghp_[A-Za-z0-9_]+|github_pat_[A-Za-z0-9_]+|"
+    r"(?i:token|password)=\S+)"
 )
 
 def _read_json(path: Path) -> dict[str, Any] | None:
@@ -473,7 +479,14 @@ def _write_publish_evidence_fallback(reason: str) -> None:
     )
 
 
-def _write_auto_publish_evidence(result_path: Path) -> None:
+def _redact_diagnostic_text(value: object) -> str:
+    text = str(value or "").strip()
+    if not text:
+        return ""
+    return SECRET_LIKE_RE.sub("[redacted]", text)[:1000]
+
+
+def _write_auto_publish_evidence(result_path: Path, snapshot_path: Path) -> None:
     helper = SCRIPT_DIR.parent.parent / "_shared" / "publish_evidence.py"
     if not helper.is_file():
         _write_publish_evidence_fallback("publish_evidence_helper_missing")
@@ -486,6 +499,8 @@ def _write_auto_publish_evidence(result_path: Path) -> None:
                 "from-pr-resolver-result",
                 "--result",
                 str(result_path),
+                "--snapshot",
+                str(snapshot_path),
             ],
             capture_output=True,
             text=True,
@@ -496,6 +511,12 @@ def _write_auto_publish_evidence(result_path: Path) -> None:
         _write_publish_evidence_fallback("publish_evidence_generation_failed")
         return
     if result.returncode != 0:
+        stderr_msg = _redact_diagnostic_text(result.stderr)
+        if stderr_msg:
+            print(
+                f"publish evidence helper failed: {stderr_msg}",
+                file=sys.stderr,
+            )
         _write_publish_evidence_fallback("publish_evidence_generation_failed")
 
 
@@ -648,7 +669,7 @@ def main() -> None:
     result_path.write_text(
         json.dumps(result_payload, indent=2) + "\n", encoding="utf-8"
     )
-    _write_auto_publish_evidence(result_path)
+    _write_auto_publish_evidence(result_path, snapshot_path)
     print(json.dumps(result_payload, indent=2))
     raise SystemExit(exit_code)
 

--- a/.agents/skills/pr-resolver/bin/pr_resolve_orchestrate.py
+++ b/.agents/skills/pr-resolver/bin/pr_resolve_orchestrate.py
@@ -446,6 +446,59 @@ def _build_full_command_from_template(
     )
     return shlex.split(rendered)
 
+
+def _write_publish_evidence_fallback(reason: str) -> None:
+    artifacts_dir = Path("artifacts")
+    artifacts_dir.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "schemaVersion": "moonmind.publish.auto.v1",
+        "mode": "auto",
+        "owner": "agent",
+        "skillId": "pr-resolver",
+        "status": "blocked",
+        "action": "none",
+        "repository": "unknown/unknown",
+        "branch": "unknown",
+        "localHead": None,
+        "remoteBranchHead": None,
+        "remoteVerified": False,
+        "pushed": False,
+        "merged": False,
+        "prUrl": None,
+        "blockedReason": reason,
+        "verificationCommands": [],
+    }
+    (artifacts_dir / "publish_result.json").write_text(
+        json.dumps(payload, indent=2) + "\n", encoding="utf-8"
+    )
+
+
+def _write_auto_publish_evidence(result_path: Path) -> None:
+    helper = SCRIPT_DIR.parent.parent / "_shared" / "publish_evidence.py"
+    if not helper.is_file():
+        _write_publish_evidence_fallback("publish_evidence_helper_missing")
+        return
+    try:
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(helper),
+                "from-pr-resolver-result",
+                "--result",
+                str(result_path),
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=60,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        _write_publish_evidence_fallback("publish_evidence_generation_failed")
+        return
+    if result.returncode != 0:
+        _write_publish_evidence_fallback("publish_evidence_generation_failed")
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(
         description="Orchestrate bounded finalize retries and full remediation escalations"
@@ -595,6 +648,7 @@ def main() -> None:
     result_path.write_text(
         json.dumps(result_payload, indent=2) + "\n", encoding="utf-8"
     )
+    _write_auto_publish_evidence(result_path)
     print(json.dumps(result_payload, indent=2))
     raise SystemExit(exit_code)
 

--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -7406,7 +7406,17 @@ async def _load_deployment_skill_metadata(
     stmt = select(AgentSkillDefinition).where(
         AgentSkillDefinition.slug.in_(sorted(skill_names))
     )
-    result = await session.execute(stmt)
+    try:
+        result = await session.execute(stmt)
+    except Exception as ex:
+        logger.warning(
+            "Deployment skill metadata unavailable; continuing without catalog publish metadata.",
+            extra={
+                "skill_count": len(skill_names),
+                "error_type": type(ex).__name__,
+            },
+        )
+        return {}
     definitions = list(result.scalars().all())
     artifact_refs = {
         str(definition.artifact_ref)
@@ -7415,19 +7425,23 @@ async def _load_deployment_skill_metadata(
     }
     if not artifact_refs:
         return {}
-    artifact_stmt = select(
-        TemporalArtifact.artifact_id,
-        TemporalArtifact.metadata_json,
-    ).where(TemporalArtifact.artifact_id.in_(artifact_refs))
-    artifact_result = await session.execute(artifact_stmt)
-    metadata_by_ref = {
-        str(artifact_id): metadata
-        for artifact_id, metadata in artifact_result.all()
-        if isinstance(metadata, Mapping)
-    }
     metadata_by_skill: dict[str, dict[str, Any]] = {}
     for definition in definitions:
-        metadata = metadata_by_ref.get(str(definition.artifact_ref or ""))
+        artifact_ref = str(definition.artifact_ref or "").strip()
+        if not artifact_ref:
+            continue
+        try:
+            artifact = await session.get(TemporalArtifact, artifact_ref)
+        except Exception as ex:
+            logger.warning(
+                "Deployment skill metadata artifact unavailable; continuing without catalog publish metadata.",
+                extra={
+                    "skill": str(definition.slug),
+                    "error_type": type(ex).__name__,
+                },
+            )
+            continue
+        metadata = getattr(artifact, "metadata_json", None)
         if isinstance(metadata, Mapping):
             metadata_by_skill[str(definition.slug)] = dict(metadata)
     return metadata_by_skill

--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -34,6 +34,7 @@ from api_service.auth_providers import get_current_user
 from api_service.core import sync as execution_sync
 from api_service.db.base import get_async_session
 from api_service.db.models import (
+    AgentSkillDefinition,
     ManagedAgentProviderProfile,
     MoonMindWorkflowState,
     TemporalExecutionCanonicalRecord,
@@ -7359,6 +7360,110 @@ def _copy_skill_contract_metadata(
         if isinstance(evidence_value, str) and evidence_value.strip():
             target[evidence_key] = evidence_value.strip()
 
+
+def _copy_trusted_skill_publish_metadata(
+    *,
+    metadata: Mapping[str, Any],
+    target: dict[str, Any],
+) -> None:
+    publish = metadata.get("publish")
+    if isinstance(publish, Mapping):
+        target["publish"] = dict(publish)
+    side_effect = metadata.get("sideEffect")
+    if not isinstance(side_effect, Mapping):
+        side_effect = metadata.get("side_effect")
+    if isinstance(side_effect, Mapping):
+        target["sideEffect"] = dict(side_effect)
+
+
+def _skill_names_for_metadata_enrichment(
+    *,
+    normalized_tool: Mapping[str, Any] | None,
+    steps: list[dict[str, Any]],
+) -> set[str]:
+    names: set[str] = set()
+    if isinstance(normalized_tool, Mapping):
+        name = str(normalized_tool.get("name") or "").strip()
+        if name:
+            names.add(name)
+    for step in steps:
+        skill = step.get("skill") if isinstance(step.get("skill"), Mapping) else None
+        if not skill:
+            continue
+        name = str(skill.get("id") or skill.get("name") or "").strip()
+        if name:
+            names.add(name)
+    return names
+
+
+async def _load_deployment_skill_metadata(
+    *,
+    session: AsyncSession | None,
+    skill_names: set[str],
+) -> dict[str, dict[str, Any]]:
+    if session is None or not skill_names:
+        return {}
+    stmt = select(AgentSkillDefinition).where(
+        AgentSkillDefinition.slug.in_(sorted(skill_names))
+    )
+    result = await session.execute(stmt)
+    definitions = list(result.scalars().all())
+    artifact_refs = {
+        str(definition.artifact_ref)
+        for definition in definitions
+        if str(definition.artifact_ref or "").strip()
+    }
+    if not artifact_refs:
+        return {}
+    artifact_stmt = select(
+        TemporalArtifact.artifact_id,
+        TemporalArtifact.metadata_json,
+    ).where(TemporalArtifact.artifact_id.in_(artifact_refs))
+    artifact_result = await session.execute(artifact_stmt)
+    metadata_by_ref = {
+        str(artifact_id): metadata
+        for artifact_id, metadata in artifact_result.all()
+        if isinstance(metadata, Mapping)
+    }
+    metadata_by_skill: dict[str, dict[str, Any]] = {}
+    for definition in definitions:
+        metadata = metadata_by_ref.get(str(definition.artifact_ref or ""))
+        if isinstance(metadata, Mapping):
+            metadata_by_skill[str(definition.slug)] = dict(metadata)
+    return metadata_by_skill
+
+
+async def _enrich_deployment_skill_metadata(
+    *,
+    session: AsyncSession | None,
+    normalized_tool: dict[str, Any] | None,
+    steps: list[dict[str, Any]],
+) -> dict[str, dict[str, Any]]:
+    metadata_by_skill = await _load_deployment_skill_metadata(
+        session=session,
+        skill_names=_skill_names_for_metadata_enrichment(
+            normalized_tool=normalized_tool,
+            steps=steps,
+        ),
+    )
+    if normalized_tool is not None:
+        metadata = metadata_by_skill.get(str(normalized_tool.get("name") or ""))
+        if isinstance(metadata, Mapping):
+            _copy_trusted_skill_publish_metadata(
+                metadata=metadata,
+                target=normalized_tool,
+            )
+    for step in steps:
+        skill = step.get("skill") if isinstance(step.get("skill"), dict) else None
+        if skill is None:
+            continue
+        skill_id = str(skill.get("id") or skill.get("name") or "").strip()
+        metadata = metadata_by_skill.get(skill_id)
+        if isinstance(metadata, Mapping):
+            _copy_trusted_skill_publish_metadata(metadata=metadata, target=skill)
+    return metadata_by_skill
+
+
 async def _resolve_step_runtime_selections(
     *,
     steps: list[dict[str, Any]],
@@ -7741,6 +7846,8 @@ def _resolve_workflow_publish_payload(
     payload: Mapping[str, Any],
     task_payload: Mapping[str, Any],
     normalized_tool: Mapping[str, Any] | None,
+    skill_publish_metadata: Mapping[str, Any] | None = None,
+    skill_side_effect_metadata: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     task_publish = _normalize_publish_payload(task_payload.get("publish"))
     top_publish = _normalize_publish_payload(payload.get("publish"))
@@ -7774,6 +7881,8 @@ def _resolve_workflow_publish_payload(
             skill_id,
             requested_mode,
             allow_repository_publish=allow_repository_publish,
+            publish_metadata=skill_publish_metadata,
+            side_effect_metadata=skill_side_effect_metadata,
         )
     except WorkflowContractError as exc:
         raise _invalid_workflow_request(str(exc)) from exc
@@ -9288,10 +9397,34 @@ async def _create_execution_from_workflow_request(
         user=user,
         request=(principal_context or {}).get("request"),
     )
+    deployment_skill_metadata = await _enrich_deployment_skill_metadata(
+        session=session,
+        normalized_tool=normalized_tool,
+        steps=normalized_steps,
+    )
+    publish_skill_id = _workflow_publish_skill_id(task_payload, normalized_tool)
+    publish_skill_metadata = deployment_skill_metadata.get(
+        str(publish_skill_id or "").strip()
+    )
+    publish_metadata = (
+        publish_skill_metadata.get("publish")
+        if isinstance(publish_skill_metadata, Mapping)
+        and isinstance(publish_skill_metadata.get("publish"), Mapping)
+        else None
+    )
+    side_effect_metadata = None
+    if isinstance(publish_skill_metadata, Mapping):
+        side_effect_metadata = publish_skill_metadata.get("sideEffect")
+        if not isinstance(side_effect_metadata, Mapping):
+            side_effect_metadata = publish_skill_metadata.get("side_effect")
+        if not isinstance(side_effect_metadata, Mapping):
+            side_effect_metadata = None
     publish_payload = _resolve_workflow_publish_payload(
         payload=payload,
         task_payload=task_payload,
         normalized_tool=normalized_tool,
+        skill_publish_metadata=publish_metadata,
+        skill_side_effect_metadata=side_effect_metadata,
     )
     normalized_task_skills = _normalize_task_skill_selectors(
         task_payload.get("skills"),
@@ -9328,9 +9461,14 @@ async def _create_execution_from_workflow_request(
     if normalized_tool is not None:
         normalized_task_for_planner["tool"] = normalized_tool
         # Keep legacy shape for compatibility while tool is canonical.
-        normalized_task_for_planner["skill"] = {
+        normalized_skill = {
             "name": normalized_tool["name"],
         }
+        for metadata_key in ("publish", "sideEffect"):
+            metadata_value = normalized_tool.get(metadata_key)
+            if isinstance(metadata_value, Mapping):
+                normalized_skill[metadata_key] = dict(metadata_value)
+        normalized_task_for_planner["skill"] = normalized_skill
         if isinstance(normalized_tool.get("inputs"), dict):
             normalized_task_for_planner["inputs"] = dict(normalized_tool["inputs"])
     if isinstance(task_payload.get("inputs"), dict):

--- a/api_service/api/routers/workflow_console.py
+++ b/api_service/api/routers/workflow_console.py
@@ -52,6 +52,7 @@ from moonmind.capabilities.input_contracts import (
     parse_skill_capability_input_contract,
 )
 from moonmind.services.skill_resolution import (
+    extract_publish_metadata_from_skill_markdown,
     extract_required_capabilities_from_skill_markdown,
 )
 from moonmind.workflows.skills.resolver import (
@@ -136,6 +137,15 @@ class DashboardSkillOption(BaseModel):
         default_factory=list,
         alias="requiredCapabilities",
         description="Default required capabilities declared by Skill metadata",
+    )
+    publish: dict[str, Any] | None = Field(
+        None,
+        description="Skill-declared publish ownership metadata, when present",
+    )
+    side_effect: dict[str, Any] | None = Field(
+        None,
+        alias="sideEffect",
+        description="Skill-declared non-repository side-effect metadata, when present",
     )
     markdown: str | None = Field(
         None, description="Markdown content of the skill, if requested"
@@ -369,6 +379,20 @@ def _skill_input_contract_ref(skill_id: str, contract_digest: str | None) -> str
         ref = f"{ref}?digest={quote(contract_digest, safe='')}"
     return ref
 
+def _skill_frontmatter_from_markdown(markdown: str) -> dict[str, Any]:
+    lines = markdown.splitlines()
+    if not lines or lines[0].strip() != "---":
+        return {}
+    frontmatter_lines: list[str] = []
+    for line in lines[1:]:
+        if line.strip() == "---":
+            break
+        frontmatter_lines.append(line)
+    else:
+        return {}
+    parsed = yaml.safe_load("\n".join(frontmatter_lines)) or {}
+    return parsed if isinstance(parsed, dict) else {}
+
 def _schema_inline_size(input_schema: dict[str, Any]) -> int:
     return len(
         json.dumps(input_schema, sort_keys=True, separators=(",", ":")).encode("utf-8")
@@ -380,6 +404,8 @@ def _skill_option_from_contract(
     label: str | None = None,
     description: str | None = None,
     required_capabilities: list[str] | None = None,
+    publish: dict[str, Any] | None = None,
+    side_effect: dict[str, Any] | None = None,
     markdown: str | None = None,
     contract: dict[str, Any],
     source: dict[str, Any] | None,
@@ -409,6 +435,8 @@ def _skill_option_from_contract(
             else None
         ),
         requiredCapabilities=required_capabilities or [],
+        publish=publish,
+        sideEffect=side_effect,
         markdown=markdown,
         inputSchema=input_schema,
         uiSchema=dict(contract.get("uiSchema") or {}),
@@ -429,6 +457,8 @@ async def _file_backed_skill_option(
 ) -> DashboardSkillOption:
     markdown_content = None
     required_capabilities: list[str] = []
+    publish: dict[str, Any] | None = None
+    side_effect: dict[str, Any] | None = None
     contract = {
         "inputSchema": {"type": "object", "properties": {}},
         "uiSchema": {},
@@ -454,6 +484,15 @@ async def _file_backed_skill_option(
                 source_label=str(skill_file),
             )
         )
+        publish = extract_publish_metadata_from_skill_markdown(
+            skill_markdown,
+            skill_name=skill_id,
+            source_label=str(skill_file),
+        ) or None
+        frontmatter = _skill_frontmatter_from_markdown(skill_markdown) or {}
+        metadata = frontmatter.get("metadata") if isinstance(frontmatter, dict) else {}
+        if isinstance(metadata, dict) and isinstance(metadata.get("sideEffect"), dict):
+            side_effect = dict(metadata["sideEffect"])
         source = {
             "kind": "file",
             "path": str(skill_file),
@@ -464,6 +503,8 @@ async def _file_backed_skill_option(
     return _skill_option_from_contract(
         skill_id=skill_id,
         required_capabilities=required_capabilities,
+        publish=publish,
+        side_effect=side_effect,
         markdown=markdown_content,
         contract=contract,
         source=source,
@@ -497,6 +538,18 @@ async def _deployment_skill_options(
             for item in metadata.get("required_capabilities") or []
             if str(item).strip()
         ]
+        publish = (
+            metadata.get("publish")
+            if isinstance(metadata.get("publish"), dict)
+            else None
+        )
+        side_effect = (
+            metadata.get("sideEffect")
+            if isinstance(metadata.get("sideEffect"), dict)
+            else metadata.get("side_effect")
+            if isinstance(metadata.get("side_effect"), dict)
+            else None
+        )
         source = {
             "kind": "deployment",
             "artifactRef": definition.artifact_ref,
@@ -508,6 +561,8 @@ async def _deployment_skill_options(
                 label=definition.title,
                 description=definition.description,
                 required_capabilities=required_capabilities,
+                publish=dict(publish) if publish is not None else None,
+                side_effect=dict(side_effect) if side_effect is not None else None,
                 contract=contract,
                 source=source,
             )
@@ -1264,11 +1319,23 @@ async def get_dashboard_skill_input_contract(
         for item in metadata.get("required_capabilities") or []
         if str(item).strip()
     ]
+    publish = (
+        metadata.get("publish") if isinstance(metadata.get("publish"), dict) else None
+    )
+    side_effect = (
+        metadata.get("sideEffect")
+        if isinstance(metadata.get("sideEffect"), dict)
+        else metadata.get("side_effect")
+        if isinstance(metadata.get("side_effect"), dict)
+        else None
+    )
     option = _skill_option_from_contract(
         skill_id=definition.slug,
         label=definition.title,
         description=definition.description,
         required_capabilities=required_capabilities,
+        publish=dict(publish) if publish is not None else None,
+        side_effect=dict(side_effect) if side_effect is not None else None,
         contract=contract,
         source={
             "kind": "deployment",

--- a/api_service/api/routers/workflow_console.py
+++ b/api_service/api/routers/workflow_console.py
@@ -54,6 +54,7 @@ from moonmind.capabilities.input_contracts import (
 from moonmind.services.skill_resolution import (
     extract_publish_metadata_from_skill_markdown,
     extract_required_capabilities_from_skill_markdown,
+    extract_side_effect_metadata_from_skill_markdown,
 )
 from moonmind.workflows.skills.resolver import (
     SkillResolutionError,
@@ -379,20 +380,6 @@ def _skill_input_contract_ref(skill_id: str, contract_digest: str | None) -> str
         ref = f"{ref}?digest={quote(contract_digest, safe='')}"
     return ref
 
-def _skill_frontmatter_from_markdown(markdown: str) -> dict[str, Any]:
-    lines = markdown.splitlines()
-    if not lines or lines[0].strip() != "---":
-        return {}
-    frontmatter_lines: list[str] = []
-    for line in lines[1:]:
-        if line.strip() == "---":
-            break
-        frontmatter_lines.append(line)
-    else:
-        return {}
-    parsed = yaml.safe_load("\n".join(frontmatter_lines)) or {}
-    return parsed if isinstance(parsed, dict) else {}
-
 def _schema_inline_size(input_schema: dict[str, Any]) -> int:
     return len(
         json.dumps(input_schema, sort_keys=True, separators=(",", ":")).encode("utf-8")
@@ -489,10 +476,11 @@ async def _file_backed_skill_option(
             skill_name=skill_id,
             source_label=str(skill_file),
         ) or None
-        frontmatter = _skill_frontmatter_from_markdown(skill_markdown) or {}
-        metadata = frontmatter.get("metadata") if isinstance(frontmatter, dict) else {}
-        if isinstance(metadata, dict) and isinstance(metadata.get("sideEffect"), dict):
-            side_effect = dict(metadata["sideEffect"])
+        side_effect = extract_side_effect_metadata_from_skill_markdown(
+            skill_markdown,
+            skill_name=skill_id,
+            source_label=str(skill_file),
+        ) or None
         source = {
             "kind": "file",
             "path": str(skill_file),

--- a/docs/Workflows/WorkflowPublishing.md
+++ b/docs/Workflows/WorkflowPublishing.md
@@ -13,7 +13,17 @@ Workflow publishing controls how agent-produced changes reach the repository aft
 
 ### `auto`
 
-Auto mode is the canonical mode for skills that own repository side effects inside the managed runtime. Initial auto-publish-capable skills are `pr-resolver`, `batch-pr-resolver`, `batch-dependabot-resolver`, `batch-workflows`, `fix-comments`, `fix-ci`, and `fix-merge-conflicts`.
+Auto mode is the canonical mode for skills that own repository side effects inside the managed runtime. Repository auto-publish capability is declared by skill metadata:
+
+```yaml
+metadata:
+  publish:
+    mode: auto
+    owner: agent
+    requiresEvidence: true
+```
+
+The built-in repository auto-publish skills are `pr-resolver`, `fix-comments`, `fix-ci`, and `fix-merge-conflicts`. The backend may retain a narrow migration fallback when metadata is temporarily unavailable, but catalog metadata is authoritative when present.
 
 Resolution rules:
 
@@ -24,6 +34,17 @@ Resolution rules:
 - `auto` is invalid for tasks that do not declare agent-owned publishing capability.
 
 Every successful auto run must produce `artifacts/publish_result.json` with `schemaVersion = "moonmind.publish.auto.v1"`, `mode = "auto"`, `owner = "agent"`, the selected skill id, status, action, repository, branch, local and remote head fields, remote verification status, push/merge booleans, optional PR URL, optional blocked reason, and verification commands.
+
+Built-in auto-publish skills produce this evidence through the portable helper:
+
+```bash
+python3 .agents/skills/_shared/publish_evidence.py write-pushed \
+  --skill-id <skill> \
+  --repo <owner/repo> \
+  --branch <branch>
+```
+
+The helper also supports `write-merged`, `write-no-op`, `write-blocked`, `write-failed`, and `from-pr-resolver-result`. It has no Temporal, database, or service-layer imports and can run in a local checkout outside MoonMind.
 
 Allowed status values are `verified`, `no_op_verified`, `blocked`, and `failed`. Allowed action values are `none`, `commit`, `push`, `merge`, `commit_and_push`, and `push_and_merge`.
 
@@ -40,6 +61,10 @@ Finish outcome mapping is evidence-driven:
 - verified no-op -> `NO_COMMIT`, not `PUBLISH_DISABLED`;
 - blocked or failed evidence -> publish-stage failure/block;
 - missing evidence -> publish-stage failure with `auto_publish_evidence_missing`.
+
+### Non-Repository Side-Effect Outcomes
+
+Some skills perform parent-level side effects without publishing repository changes. `batch-pr-resolver`, `batch-dependabot-resolver`, and `batch-workflows` queue child workflows and write summary artifacts such as `batch_pr_resolver_result.json`, `batch_dependabot_resolver_result.json`, `batch-workflows-result.json`, and `skill_outcome.json`. These parent skills resolve to `publish.mode = "none"` and must not be forced to produce repository remote-head evidence. Their child workflows keep their own publish mode, including `auto` for queued `pr-resolver` children.
 
 ### `none`
 

--- a/frontend/src/entrypoints/workflow-start.test.tsx
+++ b/frontend/src/entrypoints/workflow-start.test.tsx
@@ -6638,7 +6638,7 @@ describe.skip("Task Create Entrypoint", () => {
     await waitFor(() => {
       expect(
         (screen.getByLabelText("Publish Mode") as HTMLSelectElement).value,
-      ).toBe("auto");
+      ).toBe("pr");
     });
   });
 
@@ -7740,9 +7740,19 @@ describe.skip("Task Create Entrypoint", () => {
     });
   });
 
-  it("submits manually selected publish mode auto", async () => {
+  it("submits manually selected publish mode auto for an auto-capable skill", async () => {
     renderWithClient(<WorkflowStartPage payload={mockPayload} />);
 
+    const primaryStep = (await screen.findByText("Step 1")).closest(
+      "section",
+    );
+    expect(primaryStep).not.toBeNull();
+    fireEvent.change(
+      within(primaryStep as HTMLElement).getByLabelText(/Skill \(optional\)/),
+      {
+        target: { value: "fix-ci" },
+      },
+    );
     fireEvent.change(await screen.findByLabelText("Instructions"), {
       target: { value: "Run the publish-capable workflow." },
     });
@@ -7775,7 +7785,10 @@ describe.skip("Task Create Entrypoint", () => {
     )) as HTMLSelectElement;
     expect(
       Array.from(publishModeSelect.options).some(
-        (option) => option.value === "auto" && option.text === "Auto",
+        (option) =>
+          option.value === "auto" &&
+          option.text === "Auto — selected skill decides" &&
+          option.disabled,
       ),
     ).toBe(true);
     expect(
@@ -7885,10 +7898,18 @@ describe.skip("Task Create Entrypoint", () => {
     await waitFor(() => {
       expect(
         (screen.getByLabelText("Publish Mode") as HTMLSelectElement).value,
-      ).toBe("none");
+      ).toBe("auto");
     });
     expect(
       (screen.getByLabelText("Publish Mode") as HTMLSelectElement).disabled,
+    ).toBe(false);
+    const resolverPublishSelect = screen.getByLabelText(
+      "Publish Mode",
+    ) as HTMLSelectElement;
+    expect(
+      Array.from(resolverPublishSelect.options).find(
+        (option) => option.value === "branch",
+      )?.disabled,
     ).toBe(true);
     fireEvent.change(
       within(primaryStep as HTMLElement).getByLabelText("Instructions"),
@@ -7907,7 +7928,7 @@ describe.skip("Task Create Entrypoint", () => {
 
     const payload = latestCreateRequest().payload as Record<string, unknown>;
     const task = payload.task as Record<string, unknown>;
-    expect(task.publish).toMatchObject({ mode: "none" });
+    expect(task.publish).toMatchObject({ mode: "auto" });
     expect(payload).not.toHaveProperty("mergeAutomation");
   });
 
@@ -7938,12 +7959,12 @@ describe.skip("Task Create Entrypoint", () => {
     await waitFor(() => {
       expect(
         (screen.getByLabelText("Publish Mode") as HTMLSelectElement).value,
-      ).toBe("none");
+      ).toBe("auto");
     });
     const publishModeAfterPreset = screen.getByLabelText(
       "Publish Mode",
     ) as HTMLSelectElement;
-    expect(publishModeAfterPreset.disabled).toBe(true);
+    expect(publishModeAfterPreset.disabled).toBe(false);
     expect(
       Array.from(publishModeAfterPreset.options).find(
         (option) => option.value === "pr_with_merge_automation",
@@ -7961,9 +7982,9 @@ describe.skip("Task Create Entrypoint", () => {
 
     const payload = latestCreateRequest().payload as Record<string, unknown>;
     const task = payload.task as Record<string, unknown>;
-    expect(payload.publishMode).toBe("none");
+    expect(payload.publishMode).toBe("auto");
     expect(payload).not.toHaveProperty("mergeAutomation");
-    expect(task.publish).toMatchObject({ mode: "none" });
+    expect(task.publish).toMatchObject({ mode: "auto" });
     expect(task.skills).toEqual({ include: [{ name: "pr-resolver" }] });
   });
 

--- a/frontend/src/entrypoints/workflow-start.tsx
+++ b/frontend/src/entrypoints/workflow-start.tsx
@@ -43,6 +43,11 @@ const SELF_MANAGED_PUBLISH_SKILLS = new Set([
   "fix-ci",
   "fix-merge-conflicts",
 ]);
+const SIDE_EFFECT_PUBLISH_DISABLED_SKILLS = new Set([
+  "batch-pr-resolver",
+  "batch-dependabot-resolver",
+  "batch-workflows",
+]);
 const PUBLISH_DISABLED_SKILLS = new Set([
   JIRA_BREAKDOWN_PRESET_SLUG,
   JIRA_BREAKDOWN_ORCHESTRATE_PRESET_SLUG,
@@ -2001,6 +2006,18 @@ function skillPublishMetadataDeclaresAuto(
   );
 }
 
+function skillSideEffectMetadataDeclaresAgentOwned(
+  sideEffect: Record<string, unknown> | null | undefined,
+): boolean {
+  if (!sideEffect) {
+    return false;
+  }
+  return (
+    String(sideEffect.owner || "").trim().toLowerCase() === "agent" &&
+    String(sideEffect.kind || "").trim().length > 0
+  );
+}
+
 function isSelfManagedPublishSkill(
   skillId: string,
   detail?: SkillCapabilityDetail | null,
@@ -2015,13 +2032,30 @@ function isPublishDisabledSkill(skillId: string): boolean {
   return PUBLISH_DISABLED_SKILLS.has(skillId.trim().toLowerCase());
 }
 
+function isRepositoryPublishDisabledSkill(
+  skillId: string,
+  detail?: SkillCapabilityDetail | null,
+): boolean {
+  if (isPublishDisabledSkill(skillId)) {
+    return true;
+  }
+  if (detail?.sideEffect) {
+    return skillSideEffectMetadataDeclaresAgentOwned(detail.sideEffect);
+  }
+  return SIDE_EFFECT_PUBLISH_DISABLED_SKILLS.has(skillId.trim().toLowerCase());
+}
+
 function resolveEffectivePublishSkillId(
   primarySkillId: string,
   appliedTemplates: AppliedTemplateState[],
 ): string {
   for (const template of [...appliedTemplates].reverse()) {
     const slug = String(template.slug || "").trim();
-    if (slug && (isSelfManagedPublishSkill(slug) || isPublishDisabledSkill(slug))) {
+    if (
+      slug &&
+      (isSelfManagedPublishSkill(slug) ||
+        isRepositoryPublishDisabledSkill(slug))
+    ) {
       return slug;
     }
   }
@@ -6200,7 +6234,7 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
       skillsQuery.data?.detailsById[primarySkill] || null;
     if (isSelfManagedPublishSkill(primarySkill, primarySkillDetail)) {
       setPublishMode("auto");
-    } else if (isPublishDisabledSkill(primarySkill)) {
+    } else if (isRepositoryPublishDisabledSkill(primarySkill, primarySkillDetail)) {
       setPublishMode("none");
     }
   }, [skillsQuery.data?.detailsById, steps[0]?.skillId]);
@@ -6604,7 +6638,7 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
     } else if (
       pageMode.mode === "create" &&
       selectedPreset &&
-      isPublishDisabledSkill(selectedPreset.slug)
+      isRepositoryPublishDisabledSkill(selectedPreset.slug)
     ) {
       setPublishMode("none");
     }
@@ -6612,7 +6646,7 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
 
   const mergeAutomationAvailable =
     !isSelfManagedPublishSkill(effectiveSkillId, effectiveSkillDetail) &&
-    !isPublishDisabledSkill(effectiveSkillId);
+    !isRepositoryPublishDisabledSkill(effectiveSkillId, effectiveSkillDetail);
   const autoPublishAvailable = isSelfManagedPublishSkill(
     effectiveSkillId,
     effectiveSkillDetail,
@@ -7555,7 +7589,7 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
       setPublishMode("auto");
     } else if (
       pageMode.mode === "create" &&
-      isPublishDisabledSkill(preset.slug)
+      isRepositoryPublishDisabledSkill(preset.slug)
     ) {
       setPublishMode("none");
     }
@@ -8516,7 +8550,11 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
       String(expansion.appliedTemplate?.slug || preset.slug),
     )
       ? ` ${preset.title} manages its own PR/publish flow, so Publish Mode is Auto and merge automation is unavailable.`
-      : "";
+      : isRepositoryPublishDisabledSkill(
+            String(expansion.appliedTemplate?.slug || preset.slug),
+          )
+        ? ` ${preset.title} performs non-repository side effects, so Publish Mode is None.`
+        : "";
     setMessage(
       `Applied preset '${preset.title}' (${expandedSteps.length} steps).${autoFillSuffix}${warningSuffix}${publishConstraintSuffix}`,
     );
@@ -9298,9 +9336,12 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
         effectivePublishSkillDetailForSubmit,
       )
         ? "auto"
-        : isPublishDisabledSkill(effectivePublishSkillId)
+        : isRepositoryPublishDisabledSkill(
+            effectivePublishSkillId,
+            effectivePublishSkillDetailForSubmit,
+          )
           ? "none"
-        : normalizedPublishMode;
+          : normalizedPublishMode;
     if (effectivePublishMode === "branch" && !effectiveBranch) {
       setSubmitMessage(
         "Choose a branch before saving or rerunning this publish-mode workflow.",
@@ -10143,7 +10184,10 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
         effectivePublishSkillId,
         effectivePublishSkillDetailForSubmit,
       ) &&
-      !isPublishDisabledSkill(effectivePublishSkillId);
+      !isRepositoryPublishDisabledSkill(
+        effectivePublishSkillId,
+        effectivePublishSkillDetailForSubmit,
+      );
     // Never resolve a provider profile from placeholder data: during a runtime
     // switch refetch `data` still holds the previous runtime's profiles, which
     // must not be submitted under the newly selected runtime.

--- a/frontend/src/entrypoints/workflow-start.tsx
+++ b/frontend/src/entrypoints/workflow-start.tsx
@@ -32,15 +32,13 @@ const EFFORT_OPTIONS_DATALIST_ID = "queue-effort-options";
 const REPOSITORY_OPTIONS_DATALIST_ID = "queue-repository-options";
 const BRANCH_OPTIONS_DATALIST_ID = "queue-branch-options";
 const OWNER_REPO_PATTERN = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
-const PR_RESOLVER_SKILLS = new Set(["pr-resolver", "batch-pr-resolver"]);
+const PR_RESOLVER_SKILLS = new Set(["pr-resolver"]);
 const JIRA_BREAKDOWN_PRESET_SLUG = "jira-breakdown";
 const JIRA_BREAKDOWN_ORCHESTRATE_PRESET_SLUG = "jira-breakdown-orchestrate";
 const JIRA_BREAKDOWN_IMPLEMENT_PRESET_SLUG = "jira-breakdown-implement";
 const JIRA_ORCHESTRATE_PRESET_SLUG = "jira-orchestrate";
 const SELF_MANAGED_PUBLISH_SKILLS = new Set([
   ...PR_RESOLVER_SKILLS,
-  "batch-dependabot-resolver",
-  "batch-workflows",
   "fix-comments",
   "fix-ci",
   "fix-merge-conflicts",
@@ -643,6 +641,8 @@ interface SkillCapabilityDetail {
   source?: Record<string, unknown> | null;
   diagnostics?: Array<Record<string, unknown>>;
   requiredCapabilities?: string[];
+  publish?: Record<string, unknown> | null;
+  sideEffect?: Record<string, unknown> | null;
 }
 
 interface SkillCatalogResult {
@@ -1988,7 +1988,26 @@ function hasExplicitSkillSelection(skillId: string): boolean {
   return normalized !== "" && normalized !== "auto";
 }
 
-function isSelfManagedPublishSkill(skillId: string): boolean {
+function skillPublishMetadataDeclaresAuto(
+  publish: Record<string, unknown> | null | undefined,
+): boolean {
+  if (!publish) {
+    return false;
+  }
+  return (
+    String(publish.mode || "").trim().toLowerCase() === "auto" &&
+    String(publish.owner || "").trim().toLowerCase() === "agent" &&
+    publish.requiresEvidence === true
+  );
+}
+
+function isSelfManagedPublishSkill(
+  skillId: string,
+  detail?: SkillCapabilityDetail | null,
+): boolean {
+  if (detail?.publish) {
+    return skillPublishMetadataDeclaresAuto(detail.publish);
+  }
   return SELF_MANAGED_PUBLISH_SKILLS.has(skillId.trim().toLowerCase());
 }
 
@@ -6001,17 +6020,6 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
   ]);
 
   useEffect(() => {
-    const primarySkill = String(steps[0]?.skillId || "")
-      .trim()
-      .toLowerCase();
-    if (isSelfManagedPublishSkill(primarySkill)) {
-      setPublishMode("auto");
-    } else if (isPublishDisabledSkill(primarySkill)) {
-      setPublishMode("none");
-    }
-  }, [steps[0]?.skillId]);
-
-  useEffect(() => {
     if (isInitialMount.current) {
       isInitialMount.current = false;
       return;
@@ -6157,6 +6165,16 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
                   .filter(Boolean),
               }
             : {}),
+          ...(item.publish &&
+          typeof item.publish === "object" &&
+          !Array.isArray(item.publish)
+            ? { publish: item.publish }
+            : {}),
+          ...(item.sideEffect &&
+          typeof item.sideEffect === "object" &&
+          !Array.isArray(item.sideEffect)
+            ? { sideEffect: item.sideEffect }
+            : {}),
         };
       }
       const ids = Array.from(
@@ -6173,6 +6191,19 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
       };
     },
   });
+
+  useEffect(() => {
+    const primarySkill = String(steps[0]?.skillId || "")
+      .trim()
+      .toLowerCase();
+    const primarySkillDetail =
+      skillsQuery.data?.detailsById[primarySkill] || null;
+    if (isSelfManagedPublishSkill(primarySkill, primarySkillDetail)) {
+      setPublishMode("auto");
+    } else if (isPublishDisabledSkill(primarySkill)) {
+      setPublishMode("none");
+    }
+  }, [skillsQuery.data?.detailsById, steps[0]?.skillId]);
 
   const hasToolStep = steps.some((step) => step.stepType === "tool");
   const trustedToolsQuery = useQuery({
@@ -6560,6 +6591,8 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
       ),
     [appliedTemplates, steps],
   );
+  const effectiveSkillDetail =
+    skillsQuery.data?.detailsById[effectiveSkillId.trim()] || null;
 
   useEffect(() => {
     if (
@@ -6578,17 +6611,21 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
   }, [pageMode.mode, selectedPreset?.slug]);
 
   const mergeAutomationAvailable =
-    !isSelfManagedPublishSkill(effectiveSkillId) &&
+    !isSelfManagedPublishSkill(effectiveSkillId, effectiveSkillDetail) &&
     !isPublishDisabledSkill(effectiveSkillId);
-  const autoPublishAvailable = isSelfManagedPublishSkill(effectiveSkillId);
+  const autoPublishAvailable = isSelfManagedPublishSkill(
+    effectiveSkillId,
+    effectiveSkillDetail,
+  );
 
   useEffect(() => {
-    if (!mergeAutomationAvailable) {
-      const forcedPublishMode = isSelfManagedPublishSkill(effectiveSkillId)
-        ? "auto"
-        : "none";
-      if (publishMode !== forcedPublishMode) {
-        setPublishMode(forcedPublishMode);
+    if (autoPublishAvailable) {
+      if (publishMode !== "auto" && publishMode !== "none") {
+        setPublishMode("auto");
+      }
+    } else if (!mergeAutomationAvailable) {
+      if (publishMode !== "none") {
+        setPublishMode("none");
       }
     } else if (publishMode === "auto" && !autoPublishAvailable) {
       setPublishMode("pr");
@@ -9240,9 +9277,14 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
       primarySkillId,
       activeSubmissionAppliedTemplates,
     );
+    const effectivePublishSkillDetailForSubmit =
+      skillsQuery.data?.detailsById[effectivePublishSkillId.trim()] || null;
     if (
       normalizedPublishMode === "auto" &&
-      !isSelfManagedPublishSkill(effectivePublishSkillId)
+      !isSelfManagedPublishSkill(
+        effectivePublishSkillId,
+        effectivePublishSkillDetailForSubmit,
+      )
     ) {
       setSubmitMessage(
         "Publish mode Auto requires an auto-publish-capable skill.",
@@ -9251,7 +9293,10 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
       return;
     }
     const effectivePublishMode =
-      isSelfManagedPublishSkill(effectivePublishSkillId)
+      isSelfManagedPublishSkill(
+        effectivePublishSkillId,
+        effectivePublishSkillDetailForSubmit,
+      )
         ? "auto"
         : isPublishDisabledSkill(effectivePublishSkillId)
           ? "none"
@@ -10094,7 +10139,10 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
     const shouldSubmitMergeAutomation =
       isMergeAutomationPublishMode(publishMode) &&
       effectivePublishMode === "pr" &&
-      !isSelfManagedPublishSkill(effectivePublishSkillId) &&
+      !isSelfManagedPublishSkill(
+        effectivePublishSkillId,
+        effectivePublishSkillDetailForSubmit,
+      ) &&
       !isPublishDisabledSkill(effectivePublishSkillId);
     // Never resolve a provider profile from placeholder data: during a runtime
     // switch refetch `data` still holds the previous runtime's profiles, which
@@ -10504,11 +10552,11 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
       ? branchStatusMessage ||
         "Choose a valid GitHub repository before selecting a branch"
       : "Select the branch to check out before the workflow starts";
-  const publishModeTooltip = !mergeAutomationAvailable
-    ? isSelfManagedPublishSkill(effectiveSkillId)
-      ? "Publishing is Auto because the selected preset or resolver manages its own publish flow"
-      : "Publishing is disabled for the selected preset or skill"
-    : "Select how MoonMind publishes workflow changes";
+  const publishModeTooltip = autoPublishAvailable
+    ? "Auto is available because the selected skill owns publishing"
+    : !mergeAutomationAvailable
+      ? "Repository publishing is unavailable for the selected preset or skill"
+      : "Select how MoonMind publishes workflow changes";
   const expandStepPresetTooltip =
     "Expand the selected preset into editable steps at this position";
   const modeLoadError =
@@ -12646,14 +12694,17 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
                 title={publishModeTooltip}
                 value={publishMode}
                 onChange={(event) => setPublishMode(event.target.value)}
-                disabled={!mergeAutomationAvailable}
               >
                 <option value="auto" disabled={!autoPublishAvailable}>
-                  Auto
+                  Auto — selected skill decides
                 </option>
                 <option value="none">None</option>
-                <option value="branch">Branch</option>
-                <option value="pr">PR</option>
+                <option value="branch" disabled={!mergeAutomationAvailable}>
+                  Branch
+                </option>
+                <option value="pr" disabled={!mergeAutomationAvailable}>
+                  PR
+                </option>
                 <option
                   value={PR_WITH_MERGE_AUTOMATION_PUBLISH_MODE}
                   disabled={!mergeAutomationAvailable}

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -4869,6 +4869,20 @@ export interface components {
              */
             requiredCapabilities?: string[];
             /**
+             * Publish
+             * @description Skill-declared publish ownership metadata, when present
+             */
+            publish?: {
+                [key: string]: unknown;
+            } | null;
+            /**
+             * Sideeffect
+             * @description Skill-declared non-repository side-effect metadata, when present
+             */
+            sideEffect?: {
+                [key: string]: unknown;
+            } | null;
+            /**
              * Markdown
              * @description Markdown content of the skill, if requested
              */
@@ -4974,6 +4988,20 @@ export interface components {
              * @description Default required capabilities declared by Skill metadata
              */
             requiredCapabilities?: string[];
+            /**
+             * Publish
+             * @description Skill-declared publish ownership metadata, when present
+             */
+            publish?: {
+                [key: string]: unknown;
+            } | null;
+            /**
+             * Sideeffect
+             * @description Skill-declared non-repository side-effect metadata, when present
+             */
+            sideEffect?: {
+                [key: string]: unknown;
+            } | null;
             /**
              * Markdown
              * @description Markdown content of the skill, if requested

--- a/moonmind/services/skill_materialization.py
+++ b/moonmind/services/skill_materialization.py
@@ -119,6 +119,7 @@ class AgentSkillMaterializer:
                         self._extract_skill_bundle(payload, skill_dir)
                     else:
                         (skill_dir / "SKILL.md").write_bytes(payload)
+                self._copy_builtin_support_directories(staging_dir)
 
                 (staging_dir / "_manifest.json").write_text(
                     json.dumps(manifest_content, indent=2, sort_keys=True) + "\n",
@@ -266,6 +267,26 @@ class AgentSkillMaterializer:
         if self.workspace_root.name == "repo":
             return self.workspace_root.parent / "runtime" / "skills_active" / snapshot_id
         return self.workspace_root / "runtime" / "skills_active" / snapshot_id
+
+    @staticmethod
+    def _builtin_shared_skill_support_dir() -> Path | None:
+        candidates = [
+            Path("/app/.agents/skills/_shared"),
+            Path(__file__).resolve().parents[2] / ".agents" / "skills" / "_shared",
+        ]
+        for candidate in candidates:
+            if candidate.is_dir():
+                return candidate
+        return None
+
+    def _copy_builtin_support_directories(self, active_dir: Path) -> None:
+        shared_dir = self._builtin_shared_skill_support_dir()
+        if shared_dir is None:
+            return
+        target = active_dir / "_shared"
+        if target.exists() or target.is_symlink():
+            self._remove_directory_path(target)
+        shutil.copytree(shared_dir, target, symlinks=False)
 
     @staticmethod
     def _manifest_skill_entry(entry: Any) -> dict[str, Any]:

--- a/moonmind/services/skill_materialization.py
+++ b/moonmind/services/skill_materialization.py
@@ -171,6 +171,11 @@ class AgentSkillMaterializer:
                             if self._is_repo_authored_skills_dir(alias_dir)
                             else links.agents_skills_error or "canonical_alias_unavailable"
                         )
+                        if alias_skipped_reason == "repo_authored_skills_present":
+                            self._project_builtin_support_directory(
+                                alias_dir=alias_dir,
+                                active_dir=active_dir,
+                            )
                 except (OSError, SkillWorkspaceError) as ex:
                     raise RuntimeError(
                         self._projection_error_message(alias_dir, cause=str(ex))
@@ -287,6 +292,26 @@ class AgentSkillMaterializer:
         if target.exists() or target.is_symlink():
             self._remove_directory_path(target)
         shutil.copytree(shared_dir, target, symlinks=False)
+
+    def _project_builtin_support_directory(
+        self,
+        *,
+        alias_dir: Path,
+        active_dir: Path,
+    ) -> None:
+        shared_dir = active_dir / "_shared"
+        if not shared_dir.is_dir():
+            shared_dir = self._builtin_shared_skill_support_dir() or shared_dir
+        if not shared_dir.is_dir():
+            return
+        alias_dir.mkdir(parents=True, exist_ok=True)
+        target = alias_dir / "_shared"
+        if target.exists() or target.is_symlink():
+            return
+        try:
+            target.symlink_to(shared_dir, target_is_directory=True)
+        except OSError:
+            shutil.copytree(shared_dir, target, symlinks=False)
 
     @staticmethod
     def _manifest_skill_entry(entry: Any) -> dict[str, Any]:

--- a/moonmind/services/skill_resolution.py
+++ b/moonmind/services/skill_resolution.py
@@ -22,6 +22,7 @@ from moonmind.schemas.agent_skill_models import (
 
 _REQUIRED_SKILLS_METADATA_KEY = "required-skills"
 _REQUIRED_CAPABILITIES_METADATA_KEY = "required-capabilities"
+_PUBLISH_METADATA_KEY = "publish"
 _AGENT_SKILL_NAME_RE = re.compile(r"^[a-z0-9](?:[a-z0-9_-]{0,62}[a-z0-9])?$")
 _CAPABILITY_TOKEN_RE = re.compile(r"^[a-z0-9](?:[a-z0-9_.:-]{0,126}[a-z0-9])?$")
 
@@ -416,6 +417,37 @@ def extract_required_capabilities_from_skill_markdown(
         source_label=source_label or skill_name,
     )
     return _required_capabilities_from_frontmatter(frontmatter, owner=skill_name)
+
+
+def _publish_metadata_from_frontmatter(
+    frontmatter: dict[str, typing.Any],
+    *,
+    owner: str,
+) -> dict[str, typing.Any]:
+    metadata = frontmatter.get("metadata") or {}
+    if not isinstance(metadata, dict):
+        raise ValueError(f"skill '{owner}' metadata must be a mapping")
+    raw_publish = metadata.get(_PUBLISH_METADATA_KEY)
+    if raw_publish is None:
+        return {}
+    if not isinstance(raw_publish, dict):
+        raise ValueError(f"skill '{owner}' metadata.publish must be a mapping")
+    return dict(raw_publish)
+
+
+def extract_publish_metadata_from_skill_markdown(
+    markdown: str,
+    *,
+    skill_name: str,
+    source_label: str | None = None,
+) -> dict[str, typing.Any]:
+    """Return publish capability metadata from a skill markdown payload."""
+
+    frontmatter = _load_skill_frontmatter_from_markdown(
+        markdown,
+        source_label=source_label or skill_name,
+    )
+    return _publish_metadata_from_frontmatter(frontmatter, owner=skill_name)
 
 
 async def _required_skill_names_for_entry(entry: ResolvedSkillEntry) -> tuple[str, ...]:

--- a/moonmind/services/skill_resolution.py
+++ b/moonmind/services/skill_resolution.py
@@ -23,6 +23,7 @@ from moonmind.schemas.agent_skill_models import (
 _REQUIRED_SKILLS_METADATA_KEY = "required-skills"
 _REQUIRED_CAPABILITIES_METADATA_KEY = "required-capabilities"
 _PUBLISH_METADATA_KEY = "publish"
+_SIDE_EFFECT_METADATA_KEY = "sideEffect"
 _AGENT_SKILL_NAME_RE = re.compile(r"^[a-z0-9](?:[a-z0-9_-]{0,62}[a-z0-9])?$")
 _CAPABILITY_TOKEN_RE = re.compile(r"^[a-z0-9](?:[a-z0-9_.:-]{0,126}[a-z0-9])?$")
 
@@ -435,6 +436,24 @@ def _publish_metadata_from_frontmatter(
     return dict(raw_publish)
 
 
+def _side_effect_metadata_from_frontmatter(
+    frontmatter: dict[str, typing.Any],
+    *,
+    owner: str,
+) -> dict[str, typing.Any]:
+    metadata = frontmatter.get("metadata") or {}
+    if not isinstance(metadata, dict):
+        raise ValueError(f"skill '{owner}' metadata must be a mapping")
+    raw_side_effect = metadata.get(_SIDE_EFFECT_METADATA_KEY)
+    if raw_side_effect is None:
+        raw_side_effect = metadata.get("side_effect")
+    if raw_side_effect is None:
+        return {}
+    if not isinstance(raw_side_effect, dict):
+        raise ValueError(f"skill '{owner}' metadata.sideEffect must be a mapping")
+    return dict(raw_side_effect)
+
+
 def extract_publish_metadata_from_skill_markdown(
     markdown: str,
     *,
@@ -448,6 +467,21 @@ def extract_publish_metadata_from_skill_markdown(
         source_label=source_label or skill_name,
     )
     return _publish_metadata_from_frontmatter(frontmatter, owner=skill_name)
+
+
+def extract_side_effect_metadata_from_skill_markdown(
+    markdown: str,
+    *,
+    skill_name: str,
+    source_label: str | None = None,
+) -> dict[str, typing.Any]:
+    """Return non-repository side-effect metadata from a skill markdown payload."""
+
+    frontmatter = _load_skill_frontmatter_from_markdown(
+        markdown,
+        source_label=source_label or skill_name,
+    )
+    return _side_effect_metadata_from_frontmatter(frontmatter, owner=skill_name)
 
 
 async def _required_skill_names_for_entry(entry: ResolvedSkillEntry) -> tuple[str, ...]:

--- a/moonmind/workflows/executions/execution_contract.py
+++ b/moonmind/workflows/executions/execution_contract.py
@@ -812,10 +812,20 @@ def _is_agent_owned_auto_publish_metadata(metadata: Mapping[str, Any]) -> bool:
     )
 
 
-def _auto_publish_capability_source(skill_id: object) -> str:
+def _auto_publish_capability_source(
+    skill_id: object,
+    *,
+    publish_metadata: Mapping[str, Any] | None = None,
+) -> str:
     normalized = _normalize_skill_id(skill_id)
     if not normalized:
         return "none"
+    if publish_metadata is not None:
+        return (
+            "metadata"
+            if _is_agent_owned_auto_publish_metadata(publish_metadata)
+            else "none"
+        )
     metadata = _load_skill_publish_metadata(normalized)
     if metadata is not None:
         return "metadata" if _is_agent_owned_auto_publish_metadata(metadata) else "none"
@@ -866,6 +876,13 @@ def is_non_repository_side_effect_skill(skill_id: object) -> bool:
     return _normalize_skill_id(skill_id) in _NON_REPOSITORY_SIDE_EFFECT_SKILLS
 
 
+def _is_agent_owned_side_effect_metadata(metadata: Mapping[str, Any]) -> bool:
+    return (
+        bool(_clean_str(metadata.get("kind")))
+        and _clean_str(metadata.get("owner")).lower() == "agent"
+    )
+
+
 def _iter_applied_step_templates(value: object) -> list[object]:
     if isinstance(value, Mapping):
         return _safe_list(value.get("appliedStepTemplates"))
@@ -897,13 +914,23 @@ def resolve_publish_mode_for_skill(
     *,
     allow_repository_publish: bool = False,
     diagnostics: list[dict[str, object]] | None = None,
+    publish_metadata: Mapping[str, Any] | None = None,
+    side_effect_metadata: Mapping[str, Any] | None = None,
 ) -> str:
     """Resolve publish mode for a skill while enforcing skill publish constraints."""
 
     normalized_skill_id = _normalize_skill_id(skill_id)
-    auto_publish_source = _auto_publish_capability_source(normalized_skill_id)
+    auto_publish_source = _auto_publish_capability_source(
+        normalized_skill_id,
+        publish_metadata=publish_metadata,
+    )
     is_auto_publish_capable = auto_publish_source in {"metadata", "fallback"}
-    is_non_repository = is_non_repository_side_effect_skill(normalized_skill_id)
+    is_non_repository = is_non_repository_side_effect_skill(
+        normalized_skill_id
+    ) or (
+        side_effect_metadata is not None
+        and _is_agent_owned_side_effect_metadata(side_effect_metadata)
+    )
     if is_auto_publish_capable:
         if auto_publish_source == "fallback" and diagnostics is not None:
             diagnostics.append(_auto_publish_fallback_diagnostic(normalized_skill_id))
@@ -1227,6 +1254,8 @@ class WorkflowSkillSelection(BaseModel):
         None,
         alias="requiredCapabilities",
     )
+    publish: dict[str, Any] | None = Field(None, alias="publish")
+    side_effect: dict[str, Any] | None = Field(None, alias="sideEffect")
 
     @model_validator(mode="before")
     @classmethod
@@ -1254,6 +1283,15 @@ class WorkflowSkillSelection(BaseModel):
             raise WorkflowContractError("task.skill.requiredCapabilities must be a list")
         normalized = _normalize_capabilities(value)
         return normalized or None
+
+    @field_validator("publish", "side_effect", mode="before")
+    @classmethod
+    def _normalize_metadata_mapping(cls, value: object) -> dict[str, Any] | None:
+        if value is None:
+            return None
+        if not isinstance(value, Mapping):
+            raise WorkflowContractError("task.skill metadata must be an object")
+        return dict(value)
 
 class WorkflowRuntimeSelection(BaseModel):
     """Runtime mode and optional model/effort overrides."""
@@ -2226,23 +2264,30 @@ class WorkflowExecutionSpec(BaseModel):
     @model_validator(mode="after")
     def _validate_skill_publish_compatibility(self) -> "WorkflowExecutionSpec":
         allow_repository_publish = allows_repository_publish_for_skill_context(self)
-        skill_ids: set[str] = {_normalize_skill_id(self.skill.id)}
+        skills_by_id: dict[str, WorkflowSkillSelection] = {}
+        primary_skill_id = _normalize_skill_id(self.skill.id)
+        if primary_skill_id:
+            skills_by_id[primary_skill_id] = self.skill
         for step in self.steps:
             if step.skill is None:
                 continue
-            skill_ids.add(_normalize_skill_id(step.skill.id))
+            step_skill_id = _normalize_skill_id(step.skill.id)
+            if step_skill_id:
+                skills_by_id[step_skill_id] = step.skill
 
         requested_publish_mode = self.publish.mode if (
             allow_repository_publish or "mode" in self.publish.model_fields_set
         ) else None
         resolved_publish_mode: str | None = None
-        for skill_id in skill_ids:
+        for skill_id, skill_selection in skills_by_id.items():
             if not skill_id or skill_id == "auto":
                 continue
             mode = resolve_publish_mode_for_skill(
                 skill_id,
                 requested_publish_mode,
                 allow_repository_publish=allow_repository_publish,
+                publish_metadata=skill_selection.publish,
+                side_effect_metadata=skill_selection.side_effect,
             )
             if (
                 resolved_publish_mode is None
@@ -2734,10 +2779,20 @@ def build_canonical_workflow_view(
     skill_node = workflow_payload.get("skill") or {}
     skill = skill_node if isinstance(skill_node, Mapping) else {}
     skill_id = skill.get("id") or skill.get("name")
+    skill_publish_metadata = (
+        skill.get("publish") if isinstance(skill.get("publish"), Mapping) else None
+    )
+    skill_side_effect_metadata = (
+        skill.get("sideEffect")
+        if isinstance(skill.get("sideEffect"), Mapping)
+        else None
+    )
     publish_mode = resolve_publish_mode_for_skill(
         skill_id,
         publish_mode_candidate,
         allow_repository_publish=allows_repository_publish_for_skill_context(workflow_payload),
+        publish_metadata=skill_publish_metadata,
+        side_effect_metadata=skill_side_effect_metadata,
     )
     publish_node["mode"] = publish_mode
     if publish_mode == "pr":

--- a/moonmind/workflows/executions/execution_contract.py
+++ b/moonmind/workflows/executions/execution_contract.py
@@ -20,6 +20,7 @@ from pydantic import (
 
 from moonmind.config.settings import settings
 from moonmind.services.skill_resolution import (
+    extract_publish_metadata_from_skill_markdown,
     extract_required_capabilities_from_skill_markdown,
 )
 from moonmind.workflows.skills.resolver import (
@@ -54,19 +55,24 @@ _CONTAINER_VOLUME_NAME_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]*$")
 _CONTAINER_RESERVED_ENV_KEYS = frozenset({"ARTIFACT_DIR", "JOB_ID", "REPOSITORY"})
 _PROPOSAL_POLICY_TARGETS = ("workflow_repo", "moonmind")
 _PROPOSAL_SEVERITIES = ("low", "medium", "high", "critical")
-_AUTO_PUBLISH_CAPABLE_SKILLS = frozenset(
+_AUTO_PUBLISH_MIGRATION_FALLBACK_SKILLS = frozenset(
     {
         "pr-resolver",
-        "batch-pr-resolver",
-        "batch-dependabot-resolver",
-        "batch-workflows",
         "fix-comments",
         "fix-ci",
         "fix-merge-conflicts",
     }
 )
 _NON_REPOSITORY_SIDE_EFFECT_SKILLS = frozenset(
-    {"jira-issue-creator", "jira-issue-updater", "jira-pr-verify", "jira-verify"}
+    {
+        "batch-pr-resolver",
+        "batch-dependabot-resolver",
+        "batch-workflows",
+        "jira-issue-creator",
+        "jira-issue-updater",
+        "jira-pr-verify",
+        "jira-verify",
+    }
 )
 _REPOSITORY_PUBLISH_COMPATIBLE_SIDE_EFFECT_SKILLS = frozenset({"jira-issue-updater"})
 _JIRA_ORCHESTRATE_PRESET_SLUGS = frozenset({"jira-orchestrate"})
@@ -129,6 +135,7 @@ _CAPABILITY_IDENTITY_VERSION_KEYS = (
     | _PRESET_IDENTITY_VERSION_KEYS
 )
 _SKILL_METADATA_CAPABILITY_CACHE: dict[str, tuple[str, ...]] = {}
+_SKILL_PUBLISH_METADATA_CACHE: dict[str, dict[str, Any] | None] = {}
 
 class WorkflowContractError(ValueError):
     """Raised when queue payloads violate task contract requirements."""
@@ -763,13 +770,64 @@ def _normalize_publish_mode(value: object) -> str:
         raise WorkflowContractError(f"publish.mode must be one of: {supported}")
     return candidate
 
+
 def _normalize_skill_id(value: object) -> str:
     return (_clean_optional_str(value) or "").lower()
+
+
+def _load_skill_publish_metadata(skill_id: str) -> dict[str, Any] | None:
+    normalized = _normalize_skill_id(skill_id)
+    if not normalized:
+        return None
+    if normalized in _SKILL_PUBLISH_METADATA_CACHE:
+        return _SKILL_PUBLISH_METADATA_CACHE[normalized]
+    try:
+        skill_path = resolve_skill_markdown_path(normalized)
+    except SkillResolutionError:
+        _SKILL_PUBLISH_METADATA_CACHE[normalized] = None
+        return None
+    if skill_path is None:
+        _SKILL_PUBLISH_METADATA_CACHE[normalized] = None
+        return None
+    try:
+        markdown = skill_path.read_text(encoding="utf-8")
+        metadata = extract_publish_metadata_from_skill_markdown(
+            markdown,
+            skill_name=normalized,
+            source_label=str(skill_path),
+        )
+    except (OSError, ValueError) as exc:
+        raise WorkflowContractError(
+            f"skill '{normalized}' publish metadata is invalid: {exc}"
+        ) from exc
+    _SKILL_PUBLISH_METADATA_CACHE[normalized] = metadata
+    return metadata
+
+
+def _is_agent_owned_auto_publish_metadata(metadata: Mapping[str, Any]) -> bool:
+    return (
+        _clean_str(metadata.get("mode")).lower() == "auto"
+        and _clean_str(metadata.get("owner")).lower() == "agent"
+        and metadata.get("requiresEvidence") is True
+    )
+
+
+def _auto_publish_capability_source(skill_id: object) -> str:
+    normalized = _normalize_skill_id(skill_id)
+    if not normalized:
+        return "none"
+    metadata = _load_skill_publish_metadata(normalized)
+    if metadata is not None:
+        return "metadata" if _is_agent_owned_auto_publish_metadata(metadata) else "none"
+    if normalized in _AUTO_PUBLISH_MIGRATION_FALLBACK_SKILLS:
+        return "fallback"
+    return "none"
+
 
 def is_auto_publish_capable_skill(skill_id: object) -> bool:
     """Return True when the selected skill owns auto publish evidence/actions."""
 
-    return _normalize_skill_id(skill_id) in _AUTO_PUBLISH_CAPABLE_SKILLS
+    return _auto_publish_capability_source(skill_id) in {"metadata", "fallback"}
 
 
 def is_self_managed_publish_skill(skill_id: object) -> bool:
@@ -790,10 +848,23 @@ def _auto_publish_legacy_none_diagnostic(skill_id: str) -> dict[str, object]:
         ),
     }
 
+
+def _auto_publish_fallback_diagnostic(skill_id: str) -> dict[str, object]:
+    return {
+        "code": "auto_publish_capability_migration_fallback",
+        "skillId": skill_id,
+        "message": (
+            f"Auto publish capability for skill '{skill_id}' was resolved from "
+            "the migration fallback because publish metadata was unavailable."
+        ),
+    }
+
+
 def is_non_repository_side_effect_skill(skill_id: object) -> bool:
     """Return True when the selected skill performs side effects outside git publish."""
 
     return _normalize_skill_id(skill_id) in _NON_REPOSITORY_SIDE_EFFECT_SKILLS
+
 
 def _iter_applied_step_templates(value: object) -> list[object]:
     if isinstance(value, Mapping):
@@ -830,9 +901,12 @@ def resolve_publish_mode_for_skill(
     """Resolve publish mode for a skill while enforcing skill publish constraints."""
 
     normalized_skill_id = _normalize_skill_id(skill_id)
-    is_auto_publish_capable = is_auto_publish_capable_skill(normalized_skill_id)
+    auto_publish_source = _auto_publish_capability_source(normalized_skill_id)
+    is_auto_publish_capable = auto_publish_source in {"metadata", "fallback"}
     is_non_repository = is_non_repository_side_effect_skill(normalized_skill_id)
     if is_auto_publish_capable:
+        if auto_publish_source == "fallback" and diagnostics is not None:
+            diagnostics.append(_auto_publish_fallback_diagnostic(normalized_skill_id))
         if requested_mode is None:
             return "auto"
         publish_mode = _normalize_publish_mode(requested_mode)
@@ -866,7 +940,8 @@ def resolve_publish_mode_for_skill(
             return publish_mode
         if publish_mode != "none":
             raise WorkflowContractError(
-                f"task.publish.mode must be 'none' when using non-repository skill '{normalized_skill_id}'"
+                "task.publish.mode must be 'none' when using non-repository skill "
+                f"'{normalized_skill_id}'"
             )
         return "none"
     publish_mode = _normalize_publish_mode(requested_mode)
@@ -895,6 +970,7 @@ def _is_resolve_pr_objective(value: object) -> bool:
     if not text:
         return False
     return _RESOLVE_PR_OBJECTIVE_PATTERN.search(text) is not None
+
 
 def _contains_no_commit_push_constraint(value: object) -> bool:
     """Return True when text instructs the runtime not to commit/push."""

--- a/tests/unit/services/test_skill_materialization.py
+++ b/tests/unit/services/test_skill_materialization.py
@@ -122,9 +122,11 @@ async def test_materializer_projects_only_selected_skills(tmp_path: Path):
     visible_dir = tmp_path / ".agents" / "skills"
     assert sorted(path.name for path in visible_dir.iterdir()) == [
         "_manifest.json",
+        "_shared",
         "alpha",
         "beta",
     ]
+    assert (visible_dir / "_shared" / "publish_evidence.py").is_file()
     assert not (visible_dir / "unselected_skill").exists()
 
 @pytest.mark.asyncio

--- a/tests/unit/services/test_skill_materialization.py
+++ b/tests/unit/services/test_skill_materialization.py
@@ -129,6 +129,47 @@ async def test_materializer_projects_only_selected_skills(tmp_path: Path):
     assert (visible_dir / "_shared" / "publish_evidence.py").is_file()
     assert not (visible_dir / "unselected_skill").exists()
 
+
+@pytest.mark.asyncio
+async def test_materializer_projects_shared_helper_when_repo_skills_are_preserved(
+    tmp_path: Path,
+):
+    workspace = tmp_path / "repo"
+    repo_skill = workspace / ".agents" / "skills" / "repo_skill"
+    repo_skill.mkdir(parents=True)
+    (repo_skill / "SKILL.md").write_text(
+        "---\nname: repo_skill\ndescription: repo\n---\n",
+        encoding="utf-8",
+    )
+    artifact_service = _StaticArtifactService(
+        {"artifact-alpha": b"---\nname: alpha\ndescription: test\n---\n"}
+    )
+    materializer = AgentSkillMaterializer(
+        str(workspace),
+        artifact_service=artifact_service,
+    )
+    skillset = ResolvedSkillSet(
+        snapshot_id="repo_preserved_snap",
+        resolved_at=datetime.now(tz=UTC),
+        skills=[_skill("alpha", "artifact-alpha")],
+    )
+
+    result = await materializer.materialize(
+        resolved_skillset=skillset,
+        runtime_id="test_runtime",
+        mode=RuntimeMaterializationMode.WORKSPACE_MOUNTED,
+    )
+
+    alias_dir = workspace / ".agents" / "skills"
+    active_dir = tmp_path / "runtime" / "skills_active" / "repo_preserved_snap"
+    assert result.metadata["canonicalAliasAvailable"] is False
+    assert result.metadata["canonicalAliasSkippedReason"] == "repo_authored_skills_present"
+    assert result.metadata["visiblePath"] == str(active_dir)
+    assert (alias_dir / "repo_skill" / "SKILL.md").is_file()
+    assert (alias_dir / "_shared" / "publish_evidence.py").is_file()
+    assert (active_dir / "alpha" / "SKILL.md").is_file()
+
+
 @pytest.mark.asyncio
 async def test_materializer_extracts_skill_bundle_with_companion_files(
     tmp_path: Path,

--- a/tests/unit/services/test_skill_resolution.py
+++ b/tests/unit/services/test_skill_resolution.py
@@ -15,9 +15,33 @@ from moonmind.services.skill_resolution import (
     LocalSkillLoader,
     RepoSkillLoader,
     DeploymentSkillLoader,
+    extract_side_effect_metadata_from_skill_markdown,
 )
 
 pytestmark = [pytest.mark.asyncio]
+
+
+async def test_extract_side_effect_metadata_from_skill_markdown():
+    markdown = """---
+name: batch-skill
+metadata:
+  sideEffect:
+    kind: enqueue_children
+    owner: agent
+    outcomeArtifact: artifacts/result.json
+---
+# Batch Skill
+"""
+
+    assert extract_side_effect_metadata_from_skill_markdown(
+        markdown,
+        skill_name="batch-skill",
+    ) == {
+        "kind": "enqueue_children",
+        "owner": "agent",
+        "outcomeArtifact": "artifacts/result.json",
+    }
+
 
 async def test_resolver_can_resolve_empty_selector():
     resolver = AgentSkillResolver()

--- a/tests/unit/test_batch_workflows.py
+++ b/tests/unit/test_batch_workflows.py
@@ -440,11 +440,12 @@ def test_normalize_publish_mode_falls_back_to_pr():
     assert module["_normalize_publish_mode"]("bogus") == "pr"
 
 
-def test_batch_workflows_parent_is_self_managed_publish():
+def test_batch_workflows_parent_is_side_effect_only_publish():
     # The parent orchestration queues children and performs no repo publish, so
-    # its own publish mode is resolved to agent-owned auto publishing.
-    assert is_self_managed_publish_skill("batch-workflows") is True
-    assert resolve_publish_mode_for_skill("batch-workflows", None) == "auto"
-    assert resolve_publish_mode_for_skill("batch-workflows", "auto") == "auto"
+    # its own publish mode is not resolved to agent-owned repository publishing.
+    assert is_self_managed_publish_skill("batch-workflows") is False
+    assert resolve_publish_mode_for_skill("batch-workflows", None) == "none"
+    with pytest.raises(WorkflowContractError):
+        resolve_publish_mode_for_skill("batch-workflows", "auto")
     with pytest.raises(WorkflowContractError):
         resolve_publish_mode_for_skill("batch-workflows", "pr")

--- a/tests/unit/test_pr_resolver_tools.py
+++ b/tests/unit/test_pr_resolver_tools.py
@@ -1001,6 +1001,11 @@ def test_orchestrate_main_uses_extended_finalize_wait_defaults(
         )
 
     monkeypatch.setitem(globals_dict, "run_orchestration", _fake_run_orchestration)
+    monkeypatch.setitem(
+        globals_dict,
+        "_write_auto_publish_evidence",
+        lambda _result_path: None,
+    )
 
     result_path = tmp_path / "result.json"
     snapshot_path = tmp_path / "snapshot.json"

--- a/tests/unit/test_pr_resolver_tools.py
+++ b/tests/unit/test_pr_resolver_tools.py
@@ -1004,7 +1004,7 @@ def test_orchestrate_main_uses_extended_finalize_wait_defaults(
     monkeypatch.setitem(
         globals_dict,
         "_write_auto_publish_evidence",
-        lambda _result_path: None,
+        lambda _result_path, _snapshot_path: None,
     )
 
     result_path = tmp_path / "result.json"

--- a/tests/unit/test_publish_evidence_helper.py
+++ b/tests/unit/test_publish_evidence_helper.py
@@ -78,6 +78,44 @@ def test_write_pushed_verifies_exact_remote_head(
     assert evidence.local_head == "abc123"
 
 
+def test_write_pushed_reports_redacted_command_stderr(
+    helper_module: Any,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    def fake_run(cmd: list[str], **_: object) -> SimpleNamespace:
+        if cmd == ["git", "rev-parse", "HEAD"]:
+            return SimpleNamespace(
+                returncode=1,
+                stdout="",
+                stderr="fatal token=super-secret failed",
+            )
+        raise AssertionError(cmd)
+
+    monkeypatch.setattr(helper_module.subprocess, "run", fake_run)
+
+    assert (
+        helper_module.main(
+            [
+                "write-pushed",
+                "--skill-id",
+                "fix-ci",
+                "--repo",
+                "o/r",
+                "--branch",
+                "feature",
+            ]
+        )
+        == 2
+    )
+    stderr = capsys.readouterr().err
+    assert "[redacted]" in stderr
+    assert "super-secret" not in stderr
+
+
 def test_write_merged_verifies_pr_state(
     helper_module: Any,
     monkeypatch: pytest.MonkeyPatch,
@@ -183,6 +221,39 @@ def test_write_no_op_and_blocked_outcomes(
     )
     assert blocked.status == "blocked"
     assert blocked.blocked_reason == "publish_unavailable"
+
+
+def test_write_blocked_allows_unknown_repo_and_branch(
+    helper_module: Any,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    def fake_run(cmd: list[str], **_: object) -> SimpleNamespace:
+        return _completed("", returncode=1)
+
+    monkeypatch.setattr(helper_module.subprocess, "run", fake_run)
+
+    assert (
+        helper_module.main(
+            [
+                "write-blocked",
+                "--skill-id",
+                "fix-ci",
+                "--repo",
+                "",
+                "--branch",
+                "",
+                "--reason",
+                "publish_unavailable",
+            ]
+        )
+        == 0
+    )
+    payload = _payload(tmp_path / "artifacts" / "publish_result.json")
+    assert payload["repository"] == "unknown/unknown"
+    assert payload["branch"] == "unknown"
 
 
 @pytest.mark.parametrize(
@@ -334,6 +405,142 @@ def test_from_pr_resolver_result_reenter_gate_requires_remote_verification(
         _payload(tmp_path / "artifacts" / "publish_result.json")
     )
     assert evidence.finish_code == "PUBLISHED_BRANCH"
+
+
+def test_from_pr_resolver_result_blocks_unresolved_reenter_gate(
+    helper_module: Any,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    result_path = tmp_path / "var" / "pr_resolver" / "result.json"
+    snapshot_path = tmp_path / "var" / "pr_resolver" / "snapshot.json"
+    result_path.parent.mkdir(parents=True)
+    result_path.write_text(
+        json.dumps(
+            {
+                "status": "attempts_exhausted",
+                "reason": "actionable_comments",
+                "mergeAutomationDisposition": "reenter_gate",
+            }
+        ),
+        encoding="utf-8",
+    )
+    snapshot_path.write_text(
+        json.dumps(
+            {
+                "pr": {
+                    "url": "https://github.com/o/r/pull/1",
+                    "headRefName": "feature",
+                    "headRefOid": "abc123",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    def fake_run(cmd: list[str], **_: object) -> SimpleNamespace:
+        if cmd == ["git", "rev-parse", "HEAD"]:
+            return _completed("abc123\n")
+        if cmd == ["git", "ls-remote", "origin", "refs/heads/feature"]:
+            return _completed("abc123\trefs/heads/feature\n")
+        raise AssertionError(cmd)
+
+    monkeypatch.setattr(helper_module.subprocess, "run", fake_run)
+
+    assert (
+        helper_module.main(
+            [
+                "from-pr-resolver-result",
+                "--result",
+                str(result_path),
+                "--snapshot",
+                str(snapshot_path),
+            ]
+        )
+        == 0
+    )
+    evidence = parse_auto_publish_evidence(
+        _payload(tmp_path / "artifacts" / "publish_result.json")
+    )
+    assert evidence.status == "blocked"
+    assert evidence.blocked_reason == "actionable_comments"
+
+
+def test_from_pr_resolver_result_resolves_already_merged_pr_url(
+    helper_module: Any,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    result_path = tmp_path / "var" / "pr_resolver" / "result.json"
+    result_path.parent.mkdir(parents=True)
+    result_path.write_text(
+        json.dumps(
+            {
+                "status": "merged",
+                "mergeAutomationDisposition": "already_merged",
+                "pr_number": 123,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    def fake_run(cmd: list[str], **_: object) -> SimpleNamespace:
+        if cmd[:4] == ["gh", "pr", "view", "123"]:
+            return _completed(
+                json.dumps(
+                    {
+                        "state": "MERGED",
+                        "mergedAt": "2026-01-01T00:00:00Z",
+                        "mergeCommit": {"oid": "def456"},
+                        "url": "https://github.com/o/r/pull/123",
+                        "headRefName": "feature",
+                        "headRefOid": "abc123",
+                    }
+                )
+            )
+        if cmd[:4] == [
+            "gh",
+            "pr",
+            "view",
+            "https://github.com/o/r/pull/123",
+        ]:
+            return _completed(
+                json.dumps(
+                    {
+                        "state": "MERGED",
+                        "mergedAt": "2026-01-01T00:00:00Z",
+                        "mergeCommit": {"oid": "def456"},
+                        "headRefOid": "abc123",
+                    }
+                )
+            )
+        if cmd == ["git", "rev-parse", "HEAD"]:
+            return _completed("abc123\n")
+        if cmd == ["git", "branch", "--show-current"]:
+            return _completed("feature\n")
+        if cmd == ["git", "remote", "get-url", "origin"]:
+            return _completed("https://github.com/o/r.git\n")
+        raise AssertionError(cmd)
+
+    monkeypatch.setattr(helper_module.subprocess, "run", fake_run)
+
+    assert (
+        helper_module.main(
+            [
+                "from-pr-resolver-result",
+                "--result",
+                str(result_path),
+            ]
+        )
+        == 0
+    )
+    evidence = parse_auto_publish_evidence(
+        _payload(tmp_path / "artifacts" / "publish_result.json")
+    )
+    assert evidence.finish_code == "PUBLISHED_PR"
+    assert evidence.pr_url == "https://github.com/o/r/pull/123"
 
 
 def test_from_pr_resolver_result_fails_closed_for_missing_result(

--- a/tests/unit/test_publish_evidence_helper.py
+++ b/tests/unit/test_publish_evidence_helper.py
@@ -1,0 +1,356 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from moonmind.workflows.temporal.publish_auto_evidence import (
+    parse_auto_publish_evidence,
+)
+
+
+HELPER_PATH = (
+    Path(__file__).resolve().parents[2]
+    / ".agents"
+    / "skills"
+    / "_shared"
+    / "publish_evidence.py"
+)
+
+
+@pytest.fixture()
+def helper_module() -> Any:
+    spec = importlib.util.spec_from_file_location("publish_evidence_helper", HELPER_PATH)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _completed(stdout: str = "", returncode: int = 0) -> SimpleNamespace:
+    return SimpleNamespace(returncode=returncode, stdout=stdout, stderr="")
+
+
+def _payload(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_write_pushed_verifies_exact_remote_head(
+    helper_module: Any,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    def fake_run(cmd: list[str], **_: object) -> SimpleNamespace:
+        if cmd == ["git", "rev-parse", "HEAD"]:
+            return _completed("abc123\n")
+        if cmd == ["git", "ls-remote", "origin", "refs/heads/feature"]:
+            return _completed("abc123\trefs/heads/feature\n")
+        raise AssertionError(cmd)
+
+    monkeypatch.setattr(helper_module.subprocess, "run", fake_run)
+
+    assert (
+        helper_module.main(
+            [
+                "write-pushed",
+                "--skill-id",
+                "fix-ci",
+                "--repo",
+                "MoonLadderStudios/MoonMind",
+                "--branch",
+                "feature",
+            ]
+        )
+        == 0
+    )
+
+    evidence = parse_auto_publish_evidence(
+        _payload(tmp_path / "artifacts" / "publish_result.json")
+    )
+    assert evidence.finish_code == "PUBLISHED_BRANCH"
+    assert evidence.local_head == "abc123"
+
+
+def test_write_merged_verifies_pr_state(
+    helper_module: Any,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    def fake_run(cmd: list[str], **_: object) -> SimpleNamespace:
+        if cmd == ["git", "rev-parse", "HEAD"]:
+            return _completed("abc123\n")
+        if cmd[:4] == ["gh", "pr", "view", "https://github.com/o/r/pull/1"]:
+            return _completed(
+                json.dumps(
+                    {
+                        "state": "MERGED",
+                        "mergedAt": "2026-01-01T00:00:00Z",
+                        "mergeCommit": {"oid": "def456"},
+                        "headRefOid": "abc123",
+                    }
+                )
+            )
+        raise AssertionError(cmd)
+
+    monkeypatch.setattr(helper_module.subprocess, "run", fake_run)
+
+    assert (
+        helper_module.main(
+            [
+                "write-merged",
+                "--skill-id",
+                "pr-resolver",
+                "--repo",
+                "o/r",
+                "--branch",
+                "feature",
+                "--pr-url",
+                "https://github.com/o/r/pull/1",
+            ]
+        )
+        == 0
+    )
+
+    evidence = parse_auto_publish_evidence(
+        _payload(tmp_path / "artifacts" / "publish_result.json")
+    )
+    assert evidence.finish_code == "PUBLISHED_PR"
+    assert evidence.remote_verified is True
+
+
+def test_write_no_op_and_blocked_outcomes(
+    helper_module: Any,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    def fake_run(cmd: list[str], **_: object) -> SimpleNamespace:
+        if cmd == ["git", "rev-parse", "HEAD"]:
+            return _completed("abc123\n")
+        if cmd == ["git", "ls-remote", "origin", "refs/heads/feature"]:
+            return _completed("abc123\trefs/heads/feature\n")
+        raise AssertionError(cmd)
+
+    monkeypatch.setattr(helper_module.subprocess, "run", fake_run)
+
+    assert (
+        helper_module.main(
+            [
+                "write-no-op",
+                "--skill-id",
+                "fix-comments",
+                "--repo",
+                "o/r",
+                "--branch",
+                "feature",
+            ]
+        )
+        == 0
+    )
+    no_op = parse_auto_publish_evidence(
+        _payload(tmp_path / "artifacts" / "publish_result.json")
+    )
+    assert no_op.finish_code == "NO_COMMIT"
+
+    assert (
+        helper_module.main(
+            [
+                "write-blocked",
+                "--skill-id",
+                "fix-comments",
+                "--repo",
+                "o/r",
+                "--branch",
+                "feature",
+                "--reason",
+                "publish_unavailable",
+            ]
+        )
+        == 0
+    )
+    blocked = parse_auto_publish_evidence(
+        _payload(tmp_path / "artifacts" / "publish_result.json")
+    )
+    assert blocked.status == "blocked"
+    assert blocked.blocked_reason == "publish_unavailable"
+
+
+@pytest.mark.parametrize(
+    ("result", "expected_status", "expected_action"),
+    [
+        (
+            {
+                "status": "merged",
+                "merge_outcome": "merged",
+                "mergeAutomationDisposition": "merged",
+            },
+            "verified",
+            "merge",
+        ),
+        (
+            {
+                "status": "attempts_exhausted",
+                "reason": "ci_failures",
+                "mergeAutomationDisposition": "manual_review",
+            },
+            "blocked",
+            "none",
+        ),
+        (
+            {
+                "status": "failed",
+                "reason": "boom",
+                "mergeAutomationDisposition": "failed",
+            },
+            "failed",
+            "none",
+        ),
+    ],
+)
+def test_from_pr_resolver_result_translates_terminal_states(
+    helper_module: Any,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    result: dict[str, Any],
+    expected_status: str,
+    expected_action: str,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    result_path = tmp_path / "var" / "pr_resolver" / "result.json"
+    snapshot_path = tmp_path / "var" / "pr_resolver" / "snapshot.json"
+    result_path.parent.mkdir(parents=True)
+    result_path.write_text(json.dumps(result), encoding="utf-8")
+    snapshot_path.write_text(
+        json.dumps(
+            {
+                "pr": {
+                    "url": "https://github.com/o/r/pull/1",
+                    "headRefName": "feature",
+                    "headRefOid": "abc123",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    def fake_run(cmd: list[str], **_: object) -> SimpleNamespace:
+        if cmd[:4] == ["gh", "pr", "view", "https://github.com/o/r/pull/1"]:
+            return _completed(
+                json.dumps(
+                    {
+                        "state": "MERGED",
+                        "mergedAt": "2026-01-01T00:00:00Z",
+                        "mergeCommit": {"oid": "def456"},
+                    }
+                )
+            )
+        if cmd == ["git", "rev-parse", "HEAD"]:
+            return _completed("abc123\n")
+        if cmd == ["git", "ls-remote", "origin", "refs/heads/feature"]:
+            return _completed("abc123\trefs/heads/feature\n")
+        raise AssertionError(cmd)
+
+    monkeypatch.setattr(helper_module.subprocess, "run", fake_run)
+
+    assert (
+        helper_module.main(
+            [
+                "from-pr-resolver-result",
+                "--result",
+                str(result_path),
+                "--snapshot",
+                str(snapshot_path),
+            ]
+        )
+        == 0
+    )
+
+    evidence = parse_auto_publish_evidence(
+        _payload(tmp_path / "artifacts" / "publish_result.json")
+    )
+    assert evidence.status == expected_status
+    assert evidence.action == expected_action
+
+
+def test_from_pr_resolver_result_reenter_gate_requires_remote_verification(
+    helper_module: Any,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    result_path = tmp_path / "var" / "pr_resolver" / "result.json"
+    snapshot_path = tmp_path / "var" / "pr_resolver" / "snapshot.json"
+    result_path.parent.mkdir(parents=True)
+    result_path.write_text(
+        json.dumps({"mergeAutomationDisposition": "reenter_gate"}),
+        encoding="utf-8",
+    )
+    snapshot_path.write_text(
+        json.dumps(
+            {
+                "pr": {
+                    "url": "https://github.com/o/r/pull/1",
+                    "headRefName": "feature",
+                    "headRefOid": "abc123",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    def fake_run(cmd: list[str], **_: object) -> SimpleNamespace:
+        if cmd == ["git", "rev-parse", "HEAD"]:
+            return _completed("abc123\n")
+        if cmd == ["git", "ls-remote", "origin", "refs/heads/feature"]:
+            return _completed("abc123\trefs/heads/feature\n")
+        raise AssertionError(cmd)
+
+    monkeypatch.setattr(helper_module.subprocess, "run", fake_run)
+
+    assert (
+        helper_module.main(
+            [
+                "from-pr-resolver-result",
+                "--result",
+                str(result_path),
+                "--snapshot",
+                str(snapshot_path),
+            ]
+        )
+        == 0
+    )
+
+    evidence = parse_auto_publish_evidence(
+        _payload(tmp_path / "artifacts" / "publish_result.json")
+    )
+    assert evidence.finish_code == "PUBLISHED_BRANCH"
+
+
+def test_from_pr_resolver_result_fails_closed_for_missing_result(
+    helper_module: Any,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    assert (
+        helper_module.main(
+            [
+                "from-pr-resolver-result",
+                "--result",
+                str(tmp_path / "var" / "pr_resolver" / "result.json"),
+            ]
+        )
+        == 2
+    )
+    assert not (tmp_path / "artifacts" / "publish_result.json").exists()

--- a/tests/unit/workflows/executions/test_execution_contract.py
+++ b/tests/unit/workflows/executions/test_execution_contract.py
@@ -1382,6 +1382,51 @@ def test_auto_publish_fallback_emits_diagnostic(
     ]
 
 
+def test_workflow_skill_publish_metadata_enables_auto_for_unknown_skill() -> None:
+    payload = {
+        "repository": "MoonLadderStudios/MoonMind",
+        "targetRuntime": "codex",
+        "workflow": {
+            "instructions": "Run deployment skill.",
+            "skill": {
+                "id": "deployment-auto-skill",
+                "publish": {
+                    "mode": "auto",
+                    "owner": "agent",
+                    "requiresEvidence": True,
+                },
+            },
+            "publish": {"mode": "auto"},
+        },
+    }
+
+    result = CanonicalWorkflowExecutionPayload.model_validate(payload)
+
+    assert result.task.publish.mode == "auto"
+
+
+def test_workflow_skill_side_effect_metadata_forces_none_for_unknown_skill() -> None:
+    payload = {
+        "repository": "MoonLadderStudios/MoonMind",
+        "targetRuntime": "codex",
+        "workflow": {
+            "instructions": "Queue children.",
+            "skill": {
+                "id": "deployment-batch-skill",
+                "sideEffect": {
+                    "kind": "enqueue_children",
+                    "owner": "agent",
+                    "outcomeArtifact": "artifacts/result.json",
+                },
+            },
+            "publish": {"mode": "pr"},
+        },
+    }
+
+    with pytest.raises(ValidationError, match="non-repository skill"):
+        CanonicalWorkflowExecutionPayload.model_validate(payload)
+
+
 @pytest.mark.parametrize(
     "skill_id",
     ["fix-comments", "fix-ci", "fix-merge-conflicts"],

--- a/tests/unit/workflows/executions/test_execution_contract.py
+++ b/tests/unit/workflows/executions/test_execution_contract.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 from pydantic import ValidationError
 
+from moonmind.workflows.executions import execution_contract as execution_contract_module
 from moonmind.workflows.executions.execution_contract import (
     build_canonical_workflow_view,
     build_authoritative_workflow_input_snapshot,
@@ -11,6 +12,7 @@ from moonmind.workflows.executions.execution_contract import (
     CanonicalWorkflowExecutionPayload,
     ResumeFromFailedStepRef,
     SUPPORTED_PUBLISH_MODES,
+    is_auto_publish_capable_skill,
     reject_workflow_capability_identity_versions,
     resolve_publish_mode_for_skill,
     strip_workflow_capability_identity_versions,
@@ -1238,9 +1240,16 @@ def test_mm569_tool_validation_error_identifies_required_field_path() -> None:
 
 @pytest.mark.parametrize(
     "skill_id",
-    ["jira-issue-creator", "jira-pr-verify", "jira-verify"],
+    [
+        "batch-pr-resolver",
+        "batch-dependabot-resolver",
+        "batch-workflows",
+        "jira-issue-creator",
+        "jira-pr-verify",
+        "jira-verify",
+    ],
 )
-def test_jira_side_effect_skills_reject_repository_publish_modes(
+def test_non_repository_side_effect_skills_reject_repository_publish_modes(
     skill_id: str,
 ) -> None:
     with pytest.raises(WorkflowContractError, match="non-repository skill"):
@@ -1254,8 +1263,6 @@ def test_jira_side_effect_skills_reject_repository_publish_modes(
     "skill_id",
     [
         "pr-resolver",
-        "batch-pr-resolver",
-        "batch-dependabot-resolver",
         "fix-comments",
         "fix-ci",
         "fix-merge-conflicts",
@@ -1295,6 +1302,84 @@ def test_auto_publish_capable_skills_resolve_to_auto(skill_id: str) -> None:
 def test_non_capable_skill_rejects_auto_publish_mode() -> None:
     with pytest.raises(WorkflowContractError, match="auto-publish-capable"):
         resolve_publish_mode_for_skill("ordinary-skill", "auto")
+
+
+@pytest.mark.parametrize(
+    "skill_id",
+    ["batch-pr-resolver", "batch-dependabot-resolver", "batch-workflows"],
+)
+def test_batch_parent_skills_are_side_effect_not_auto_publish(
+    skill_id: str,
+) -> None:
+    assert is_auto_publish_capable_skill(skill_id) is False
+    assert resolve_publish_mode_for_skill(skill_id, None) == "none"
+    with pytest.raises(WorkflowContractError, match="non-repository skill"):
+        resolve_publish_mode_for_skill(skill_id, "auto")
+
+
+def test_auto_publish_capability_can_come_from_skill_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        execution_contract_module,
+        "_load_skill_publish_metadata",
+        lambda skill_id: {
+            "mode": "auto",
+            "owner": "agent",
+            "requiresEvidence": True,
+        },
+    )
+
+    diagnostics: list[dict[str, object]] = []
+
+    assert is_auto_publish_capable_skill("metadata-only-skill") is True
+    assert (
+        resolve_publish_mode_for_skill(
+            "metadata-only-skill",
+            None,
+            diagnostics=diagnostics,
+        )
+        == "auto"
+    )
+    assert diagnostics == []
+
+
+def test_auto_publish_metadata_precedes_migration_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        execution_contract_module,
+        "_load_skill_publish_metadata",
+        lambda skill_id: {},
+    )
+
+    assert is_auto_publish_capable_skill("fix-ci") is False
+
+
+def test_auto_publish_fallback_emits_diagnostic(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        execution_contract_module,
+        "_load_skill_publish_metadata",
+        lambda skill_id: None,
+    )
+    diagnostics: list[dict[str, object]] = []
+
+    assert (
+        resolve_publish_mode_for_skill("fix-ci", None, diagnostics=diagnostics)
+        == "auto"
+    )
+    assert diagnostics == [
+        {
+            "code": "auto_publish_capability_migration_fallback",
+            "skillId": "fix-ci",
+            "message": (
+                "Auto publish capability for skill 'fix-ci' was resolved from "
+                "the migration fallback because publish metadata was unavailable."
+            ),
+        }
+    ]
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/workflows/skills/test_run_projection.py
+++ b/tests/unit/workflows/skills/test_run_projection.py
@@ -138,9 +138,11 @@ async def test_materialize_only_includes_selected_skills(tmp_path: Path) -> None
     visible = Path(metadata["visiblePath"])
     assert sorted(p.name for p in visible.iterdir()) == [
         "_manifest.json",
+        "_shared",
         "alpha",
         "beta",
     ]
+    assert (visible / "_shared" / "publish_evidence.py").is_file()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Add a portable `.agents/skills/_shared/publish_evidence.py` helper for canonical auto-publish evidence, including direct write commands and pr-resolver result translation.
- Wire pr-resolver orchestration to produce deterministic `artifacts/publish_result.json`, update auto-publish skill instructions, and move batch parent skills to side-effect outcome semantics.
- Derive auto-publish capability from skill metadata with a narrow fallback diagnostic, expose publish metadata through the skill catalog, and show a manual Auto option in the Create page only when valid.
- Document repository auto publish versus non-repository side-effect outcomes and add targeted backend/helper/UI coverage.

## Validation
- `python3 -m py_compile .agents/skills/_shared/publish_evidence.py .agents/skills/pr-resolver/bin/pr_resolve_orchestrate.py moonmind/services/skill_resolution.py moonmind/workflows/executions/execution_contract.py api_service/api/routers/workflow_console.py moonmind/services/skill_materialization.py tests/unit/test_publish_evidence_helper.py tests/unit/test_pr_resolver_tools.py tests/unit/services/test_skill_materialization.py tests/unit/workflows/executions/test_execution_contract.py`
- `.venv/bin/pytest tests/unit/test_publish_evidence_helper.py tests/unit/services/test_skill_materialization.py tests/unit/workflows/executions/test_execution_contract.py tests/unit/test_pr_resolver_tools.py -q` (209 passed)
- `.venv/bin/pytest tests/unit/workflows/temporal/test_publish_auto_evidence.py tests/unit/workflows/temporal/workflows/test_run_integration.py tests/unit/workflows/adapters/test_managed_agent_adapter.py tests/unit/workflows/executions/test_execution_contract.py -q` (330 passed)
- `npm run ui:test -- frontend/src/entrypoints/workflow-start.test.tsx` (88 passed, 238 skipped)
- `git diff --check`

## Notes
- `./tools/test_unit.sh --ui-args frontend/src/entrypoints/workflow-start.test.tsx` did not reach Vitest in this local workspace because its precheck failed while following `.agents/skills/moonspec-tasks/SKILL.md` to a missing `../../../moonspec/bundle/skills/moonspec-tasks/SKILL.md` target. The targeted Vitest command above passed directly.