### PR TITLE
[codex] Fix MoonSpec skill bundle publishing

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -44,6 +44,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
+        with:
+          submodules: recursive
 
       - name: Set up Python
         if: matrix.platform == 'linux/amd64'

--- a/api_service/Dockerfile
+++ b/api_service/Dockerfile
@@ -205,6 +205,11 @@ COPY config /app/config/
 COPY docs/ReleaseNotes /app/docs/ReleaseNotes/
 COPY .agents /app/.agents/
 COPY moonspec /app/moonspec/
+# MoonSpec skills are symlinked through .agents; fail builds before broken
+# projections can reach the published runtime image.
+RUN test -f /app/moonspec/bundle/moonspec.bundle.yaml \
+    && test -f /app/moonspec/bundle/skills/moonspec-verify/SKILL.md \
+    && test -f /app/.agents/skills/moonspec-verify/SKILL.md
 RUN pip install --disable-pip-version-check --no-deps .
 
 # Copy pre-built frontend assets from the frontend-builder stage

--- a/docs/tmp/MoonSpecVerifyResolutionFailure.md
+++ b/docs/tmp/MoonSpecVerifyResolutionFailure.md
@@ -1,0 +1,47 @@
+# MoonSpec Verify Resolution Failure
+
+Document Class: Imperative Working Document
+Working Type: Implementation Plan
+Status: Active
+Date: 2026-07-04
+Source Workflow: `mm:c6720d9c-10c7-4fe7-87de-4b3ed06c74fb`
+
+## Failure
+
+The workflow failed in the parent `MoonMind.UserWorkflow` during `agent_skill.resolve` for the final `moonspec-verify` step. Temporal reported:
+
+```text
+ValueError: Could not resolve selected skill 'moonspec-verify'
+```
+
+The running workflow worker had `/app/.agents/skills/moonspec-verify/SKILL.md` as a symlink to `../../../moonspec/bundle/skills/moonspec-verify/SKILL.md`, but `/app/moonspec` was empty. The local checkout also had an uninitialized `moonspec` submodule before remediation, so the compose bind mount `./moonspec:/app/moonspec:ro` exposed an empty directory to the worker.
+
+The published `ghcr.io/moonladderstudios/moonmind:latest` image also had an empty `/app/moonspec`. The release workflow checked out the repository without submodules before building `api_service/Dockerfile`, so `COPY moonspec /app/moonspec/` shipped an empty submodule directory while `.agents/skills/moonspec-*` symlinks still pointed into it.
+
+## Possible Solutions
+
+1. Operator remediation only: run `git submodule update --init --recursive moonspec` and restart affected containers. This fixes the current local bind mount, but it does not prevent another broken GHCR image.
+2. Remove the `./moonspec:/app/moonspec:ro` compose bind mount and rely only on image-bundled MoonSpec content. This avoids local empty-submodule shadowing, but it makes local MoonSpec bundle iteration less direct and still requires correct image packaging.
+3. Fix image publishing: check out submodules in `docker-publish.yml` and add a Dockerfile guard that fails the build if `moonspec.bundle.yaml` or `moonspec-verify/SKILL.md` is absent. This prevents broken runtime images while preserving the existing source-mounted local development path.
+4. Improve resolver diagnostics: make broken skill symlinks visible during discovery and fail selected skills with the existing submodule remediation hint instead of reporting a generic unresolved skill.
+
+## Selected Fix
+
+Implement solutions 3 and 4.
+
+This is the most direct durable fix because the release workflow created the broken image, and the resolver behavior hid the real missing-submodule cause. The compose/local workaround remains available for already-running deployments: initialize the `moonspec` submodule and restart workers, or pull a rebuilt image after this fix lands.
+
+## Verification Plan
+
+- Unit-test the Docker publish workflow checkout for `submodules: recursive`.
+- Unit-test the Dockerfile guard for required MoonSpec bundle files.
+- Unit-test skill resolution with a broken `moonspec-verify` symlink to confirm the actionable remediation message.
+- Run the targeted unit tests for the changed workflow, Dockerfile, and skill resolver.
+
+## Verification Results
+
+- `git submodule update --init --recursive moonspec` populated the local bundle at pinned commit `2a2d9e703ed7b8545c7d0556844a783408826df0`.
+- `python3 tools/link_moonspec_submodule.py --check --prune` passed.
+- `./tools/test_unit.sh tests/unit/test_docker_publish_workflow.py tests/unit/services/test_skill_resolution.py` passed, including the unit runner's frontend checks.
+- `./tools/test_integration.sh` passed: 407 passed, 1 skipped, 87 deselected.
+- After restoring the local compose stack, `temporal-worker-agent-runtime` successfully resolved `moonspec-verify` in a container smoke check.

--- a/moonmind/services/skill_resolution.py
+++ b/moonmind/services/skill_resolution.py
@@ -208,7 +208,7 @@ def _scan_for_skills(
     for item in sorted(skills_dir.iterdir(), key=lambda path: path.name):
         if item.name in skip_names:
             continue
-        if item.is_dir() and (item / "SKILL.md").exists():
+        if item.is_dir() and _has_skill_document(item):
             results.append(
                 ResolvedSkillEntry(
                     skill_name=item.name,
@@ -219,6 +219,17 @@ def _scan_for_skills(
                 )
             )
     return results
+
+
+def _has_skill_document(skill_dir: Path) -> bool:
+    skill_file = skill_dir / "SKILL.md"
+    if skill_file.exists() or skill_file.is_symlink():
+        return True
+
+    from moonmind.workflows.skills.pointer_files import flattened_symlink_target
+
+    return flattened_symlink_target(skill_file) is not None
+
 
 def _is_moonmind_active_projection(skills_dir: Path) -> bool:
     if not skills_dir.is_symlink():
@@ -269,6 +280,13 @@ def _load_skill_frontmatter(skill_dir: Path) -> dict[str, typing.Any]:
             f"failed to read skill frontmatter from {skill_file}: "
             f"SKILL.md contains untrusted pointer-shaped text {pointer_target!r} "
             f"instead of skill content; {SUBMODULE_REMEDIATION_HINT}"
+        )
+    elif skill_file.is_symlink() and not skill_file.exists():
+        raise ValueError(
+            f"failed to read skill frontmatter from {skill_file}: "
+            "SKILL.md symlink target is missing: "
+            f"{skill_file} -> {skill_file.readlink()}; "
+            f"{SUBMODULE_REMEDIATION_HINT}"
         )
     try:
         lines = skill_file.read_text(encoding="utf-8").splitlines()

--- a/tests/unit/services/test_skill_resolution.py
+++ b/tests/unit/services/test_skill_resolution.py
@@ -96,6 +96,26 @@ async def test_built_in_loader_discovers_packaged_agent_skills():
     assert discovered["moonspec-breakdown"].provenance.source_kind == AgentSkillSourceKind.BUILT_IN
     assert discovered["moonspec-breakdown"].provenance.source_path
 
+async def test_resolver_reports_missing_skill_symlink_target(tmp_path):
+    skills_root = tmp_path / ".agents" / "skills"
+    skill_dir = skills_root / "moonspec-verify"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").symlink_to(
+        "../../../moonspec/bundle/skills/moonspec-verify/SKILL.md"
+    )
+
+    resolver = AgentSkillResolver(loaders=[BuiltInSkillLoader(skills_root=skills_root)])
+    context = SkillResolutionContext(snapshot_id="snap-123")
+    selector = SkillSelector(include=[{"name": "moonspec-verify"}])
+
+    with pytest.raises(ValueError) as excinfo:
+        await resolver.resolve(selector, context)
+
+    message = str(excinfo.value)
+    assert "Could not resolve selected skill" not in message
+    assert "SKILL.md symlink target is missing" in message
+    assert "git submodule update --init" in message
+
 async def test_built_in_loader_resolves_batch_dependabot_resolver_by_name(tmp_path):
     """FR-012: batch-dependabot-resolver MUST be resolvable by name through the
     built-in fallback list so a recurring queue_task schedule can target it.

--- a/tests/unit/test_docker_publish_workflow.py
+++ b/tests/unit/test_docker_publish_workflow.py
@@ -6,6 +6,7 @@ import yaml
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "docker-publish.yml"
+DOCKERFILE_PATH = REPO_ROOT / "api_service" / "Dockerfile"
 
 def _load_workflow() -> dict:
     assert WORKFLOW_PATH.exists(), f"Missing workflow: {WORKFLOW_PATH}"
@@ -35,6 +36,27 @@ def test_docker_publish_generates_version_before_platform_builds() -> None:
 
     build_job = workflow["jobs"]["build"]
     assert build_job["needs"] == "metadata"
+
+
+def test_docker_publish_checks_out_moonspec_submodule() -> None:
+    workflow = _load_workflow()
+
+    checkout = workflow["jobs"]["build"]["steps"][0]
+
+    assert checkout["uses"].startswith("actions/checkout@")
+    assert checkout["with"]["submodules"] == "recursive"
+
+
+def test_app_image_build_validates_moonspec_bundle_content() -> None:
+    dockerfile = DOCKERFILE_PATH.read_text(encoding="utf-8")
+
+    copy_index = dockerfile.index("COPY moonspec /app/moonspec/")
+    guard_index = dockerfile.index("/app/moonspec/bundle/moonspec.bundle.yaml")
+
+    assert copy_index < guard_index
+    assert "/app/moonspec/bundle/skills/moonspec-verify/SKILL.md" in dockerfile
+    assert "/app/.agents/skills/moonspec-verify/SKILL.md" in dockerfile
+
 
 def test_docker_publish_passes_manifest_tag_into_image_build_metadata() -> None:
     workflow = _load_workflow()

--- a/tests/unit/test_docker_publish_workflow.py
+++ b/tests/unit/test_docker_publish_workflow.py
@@ -41,9 +41,16 @@ def test_docker_publish_generates_version_before_platform_builds() -> None:
 def test_docker_publish_checks_out_moonspec_submodule() -> None:
     workflow = _load_workflow()
 
-    checkout = workflow["jobs"]["build"]["steps"][0]
+    checkout = next(
+        (
+            step
+            for step in workflow["jobs"]["build"]["steps"]
+            if step.get("uses", "").startswith("actions/checkout@")
+        ),
+        None,
+    )
 
-    assert checkout["uses"].startswith("actions/checkout@")
+    assert checkout is not None, "Checkout step not found"
     assert checkout["with"]["submodules"] == "recursive"
 
 


### PR DESCRIPTION
## Summary

Fixes the `moonspec-verify` resolution failure seen in workflow `mm:c6720d9c-10c7-4fe7-87de-4b3ed06c74fb`.

Root cause: the Docker publish workflow built the app image without checking out the `moonspec` submodule, so the image shipped `.agents/skills/moonspec-*` symlinks that pointed into an empty `/app/moonspec` directory. When local deployments also had an uninitialized `moonspec` submodule mounted into the agent-runtime worker, `agent_skill.resolve` could not discover `moonspec-verify`.

## Changes

- Check out submodules recursively in `.github/workflows/docker-publish.yml` before building the GHCR image.
- Add a Dockerfile build guard that fails if the MoonSpec bundle or `moonspec-verify` skill is missing.
- Preserve broken skill symlink candidates during discovery so selected skills fail with the existing submodule remediation hint instead of a generic unresolved-skill error.
- Add `docs/tmp/MoonSpecVerifyResolutionFailure.md` with troubleshooting notes, alternatives, selected fix, and verification evidence.
- Add unit coverage for Docker publish checkout, Dockerfile guard, and missing skill symlink diagnostics.

## Validation

- `python3 tools/link_moonspec_submodule.py --check --prune`
- `./tools/test_unit.sh tests/unit/test_docker_publish_workflow.py tests/unit/services/test_skill_resolution.py`
- `./tools/test_integration.sh`
- Container smoke check in `temporal-worker-agent-runtime`: resolving `moonspec-verify` returned `['moonspec-verify']`.
