### PR TITLE
MM-1112 complete workflow list display modes

### DIFF
--- a/frontend/src/entrypoints/dashboard-app.tsx
+++ b/frontend/src/entrypoints/dashboard-app.tsx
@@ -387,7 +387,7 @@ function WorkflowListDisplayModeControl({
   return (
     <div
       className="workflow-list-display-control"
-      role="radiogroup"
+      role="group"
       aria-label="Workflow list display"
     >
       {WORKFLOW_LIST_DISPLAY_MODES.map((mode) => {
@@ -397,8 +397,7 @@ function WorkflowListDisplayModeControl({
           <button
             key={mode.value}
             type="button"
-            role="radio"
-            aria-checked={checked}
+            aria-pressed={checked}
             aria-label={mode.label}
             title={mode.label}
             className={`workflow-list-display-option${checked ? ' workflow-list-display-option--selected' : ''}`}

--- a/frontend/src/entrypoints/dashboard-app.tsx
+++ b/frontend/src/entrypoints/dashboard-app.tsx
@@ -48,6 +48,7 @@ import {
   resolveWorkflowListDisplay,
   type WorkflowListDisplayMode,
 } from '../lib/workflowListDisplayMode';
+import { readDashboardPreferences } from '../utils/dashboardPreferences';
 import { DashboardAlerts } from './dashboard-alerts';
 
 type PageComponent = ComponentType<{ payload: BootPayload }>;
@@ -580,7 +581,9 @@ function RoutedDashboardPage({
 }) {
   const location = useLocation();
   const navigate = useNavigate();
-  const [requestedMode, setRequestedMode] = useState<WorkflowListDisplayMode>('sidebar');
+  const [requestedMode, setRequestedMode] = useState<WorkflowListDisplayMode>(() => (
+    readDashboardPreferences().workflowWorkspaceSidebarCollapsed ? 'hidden' : 'sidebar'
+  ));
   const [lastSelectedWorkflowId, setLastSelectedWorkflowId] = useState<string | null>(null);
   const route = resolveDashboardRoute(location.pathname);
   const resolvedDisplay = resolveWorkflowListDisplay({
@@ -599,8 +602,11 @@ function RoutedDashboardPage({
   }, [location.pathname]);
 
   useEffect(() => {
-    if (location.pathname.replace(/\/$/, '') === '/workflows') {
+    const normalizedPath = location.pathname.replace(/\/$/, '');
+    if (normalizedPath === '/workflows') {
       setRequestedMode('table');
+    } else if (normalizedPath.startsWith('/workflows/') && normalizedPath !== '/workflows/new') {
+      setRequestedMode((mode) => (mode === 'table' ? 'sidebar' : mode));
     }
   }, [location.pathname]);
 

--- a/frontend/src/entrypoints/dashboard-app.tsx
+++ b/frontend/src/entrypoints/dashboard-app.tsx
@@ -20,7 +20,7 @@ import {
   useNavigate,
 } from 'react-router-dom';
 import { QueryErrorResetBoundary, useQuery, useQueryClient } from '@tanstack/react-query';
-import { ScrollText } from 'lucide-react';
+import { PanelLeft, Rows3, ScrollText, Square } from 'lucide-react';
 import {
   MoonIcon,
   type MoonIconHandle,
@@ -43,6 +43,11 @@ import {
   type DashboardPage,
   type DashboardUiInfo,
 } from '../lib/dashboardRoutes';
+import {
+  WORKFLOW_LIST_DISPLAY_MODES,
+  resolveWorkflowListDisplay,
+  type WorkflowListDisplayMode,
+} from '../lib/workflowListDisplayMode';
 import { DashboardAlerts } from './dashboard-alerts';
 
 type PageComponent = ComponentType<{ payload: BootPayload }>;
@@ -63,6 +68,7 @@ const PAGE_IMPORTS = {
 } satisfies Record<DashboardPage, PageImport>;
 
 const NAV_ICON_SIZE = 16;
+const LIST_MODE_ICON_SIZE = 15;
 
 type SharedLayoutConfig = {
   dataWidePanel?: boolean;
@@ -171,6 +177,41 @@ function AnimatedRouteNavLink({
 
 function isSupportedPage(page: string): page is DashboardPage {
   return Object.hasOwn(PAGE_IMPORTS, page);
+}
+
+function iconForWorkflowListMode(icon: string) {
+  if (icon === 'Square') {
+    return Square;
+  }
+  if (icon === 'PanelLeft') {
+    return PanelLeft;
+  }
+  return Rows3;
+}
+
+function workflowIdFromPath(pathname: string): string | null {
+  const match = pathname.match(/^\/workflows\/([^/]+)(?:\/(?:steps|artifacts|runs|debug))?\/?$/);
+  if (!match?.[1] || match[1] === 'new') {
+    return null;
+  }
+  try {
+    const decoded = decodeURIComponent(match[1]);
+    return decoded.includes('/') ? null : decoded;
+  } catch {
+    return null;
+  }
+}
+
+function firstVisibleWorkflowId(): string | null {
+  const links = Array.from(document.querySelectorAll<HTMLAnchorElement>('a[href^="/workflows/"]'));
+  for (const link of links) {
+    const url = new URL(link.href, window.location.origin);
+    const id = workflowIdFromPath(url.pathname);
+    if (id) {
+      return id;
+    }
+  }
+  return null;
 }
 
 function readSharedLayout(payload: BootPayload): SharedLayoutConfig {
@@ -336,7 +377,50 @@ function DashboardLiveUpdateProvider({
   return <>{children}</>;
 }
 
-function DashboardNavigation({ uiInfo }: { uiInfo: DashboardUiInfo | null }) {
+function WorkflowListDisplayModeControl({
+  effectiveMode,
+  onSelect,
+}: {
+  effectiveMode: WorkflowListDisplayMode;
+  onSelect: (mode: WorkflowListDisplayMode) => void;
+}) {
+  return (
+    <div
+      className="workflow-list-display-control"
+      role="radiogroup"
+      aria-label="Workflow list display"
+    >
+      {WORKFLOW_LIST_DISPLAY_MODES.map((mode) => {
+        const Icon = iconForWorkflowListMode(mode.icon);
+        const checked = effectiveMode === mode.value;
+        return (
+          <button
+            key={mode.value}
+            type="button"
+            role="radio"
+            aria-checked={checked}
+            aria-label={mode.label}
+            title={mode.label}
+            className={`workflow-list-display-option${checked ? ' workflow-list-display-option--selected' : ''}`}
+            onClick={() => onSelect(mode.value)}
+          >
+            <Icon size={LIST_MODE_ICON_SIZE} aria-hidden="true" />
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function DashboardNavigation({
+  uiInfo,
+  workflowListMode,
+  onWorkflowListModeSelect,
+}: {
+  uiInfo: DashboardUiInfo | null;
+  workflowListMode: WorkflowListDisplayMode | null;
+  onWorkflowListModeSelect: (mode: WorkflowListDisplayMode) => void;
+}) {
   const [open, setOpen] = useState(false);
   const location = useLocation();
   const isWorkflowStart = location.pathname.replace(/\/$/, '') === '/workflows/new';
@@ -362,6 +446,13 @@ function DashboardNavigation({ uiInfo }: { uiInfo: DashboardUiInfo | null }) {
           <span className="masthead-brand-mind">Mind</span>
         </h1>
       </Link>
+
+      {workflowListMode ? (
+        <WorkflowListDisplayModeControl
+          effectiveMode={workflowListMode}
+          onSelect={onWorkflowListModeSelect}
+        />
+      ) : null}
 
       <button
         className="nav-hamburger"
@@ -433,10 +524,14 @@ function DashboardNavigation({ uiInfo }: { uiInfo: DashboardUiInfo | null }) {
 function AppShell({
   dataWidePanel,
   uiInfo,
+  workflowListMode,
+  onWorkflowListModeSelect,
   children,
 }: {
   dataWidePanel: boolean;
   uiInfo: DashboardUiInfo | null;
+  workflowListMode: WorkflowListDisplayMode | null;
+  onWorkflowListModeSelect: (mode: WorkflowListDisplayMode) => void;
   children: ReactNode;
 }) {
   return (
@@ -455,7 +550,11 @@ function AppShell({
         </section>
 
         <div className="dashboard-shell-full">
-          <DashboardNavigation uiInfo={uiInfo} />
+          <DashboardNavigation
+            uiInfo={uiInfo}
+            workflowListMode={workflowListMode}
+            onWorkflowListModeSelect={onWorkflowListModeSelect}
+          />
         </div>
 
         <div
@@ -481,11 +580,60 @@ function RoutedDashboardPage({
   isUiInfoPending: boolean;
 }) {
   const location = useLocation();
+  const navigate = useNavigate();
+  const [requestedMode, setRequestedMode] = useState<WorkflowListDisplayMode>('sidebar');
+  const [lastSelectedWorkflowId, setLastSelectedWorkflowId] = useState<string | null>(null);
   const route = resolveDashboardRoute(location.pathname);
+  const resolvedDisplay = resolveWorkflowListDisplay({
+    pathname: location.pathname,
+    search: location.search,
+    requestedMode,
+    selectedWorkflowId: lastSelectedWorkflowId,
+    firstVisibleWorkflowId: null,
+  });
+
+  useEffect(() => {
+    const routeWorkflowId = workflowIdFromPath(location.pathname);
+    if (routeWorkflowId) {
+      setLastSelectedWorkflowId(routeWorkflowId);
+    }
+  }, [location.pathname]);
+
+  useEffect(() => {
+    if (location.pathname.replace(/\/$/, '') === '/workflows') {
+      setRequestedMode('table');
+    }
+  }, [location.pathname]);
+
+  const handleWorkflowListModeSelect = (mode: WorkflowListDisplayMode) => {
+    const resolved = resolveWorkflowListDisplay({
+      pathname: location.pathname,
+      search: location.search,
+      requestedMode: mode,
+      selectedWorkflowId: lastSelectedWorkflowId,
+      firstVisibleWorkflowId: firstVisibleWorkflowId(),
+    });
+    if (!resolved) {
+      return;
+    }
+    setRequestedMode(mode);
+    if (resolved.selection.workflowId) {
+      setLastSelectedWorkflowId(resolved.selection.workflowId);
+    }
+    const current = `${location.pathname}${location.search}`;
+    if (resolved.targetPath !== current) {
+      navigate(resolved.targetPath);
+    }
+  };
 
   if (!route) {
     return (
-      <AppShell dataWidePanel={false} uiInfo={uiInfo}>
+      <AppShell
+        dataWidePanel={false}
+        uiInfo={uiInfo}
+        workflowListMode={null}
+        onWorkflowListModeSelect={handleWorkflowListModeSelect}
+      >
         <UnknownPage page={location.pathname} />
       </AppShell>
     );
@@ -493,20 +641,39 @@ function RoutedDashboardPage({
 
   if (route.page === 'workflow-start' && isUiInfoPending) {
     return (
-      <AppShell dataWidePanel={route.dataWidePanel} uiInfo={uiInfo}>
+      <AppShell
+        dataWidePanel={route.dataWidePanel}
+        uiInfo={uiInfo}
+        workflowListMode={resolvedDisplay?.effectiveMode ?? null}
+        onWorkflowListModeSelect={handleWorkflowListModeSelect}
+      >
         <LoadingPage />
       </AppShell>
     );
   }
 
   const routedPayload = payloadForDashboardRoute(payload, route, uiInfo);
+  if (resolvedDisplay) {
+    routedPayload.initialData = {
+      ...(routedPayload.initialData && typeof routedPayload.initialData === 'object'
+        ? routedPayload.initialData
+        : {}),
+      workflowListDisplayMode: resolvedDisplay.effectiveMode,
+      workflowListDisplayStatus: resolvedDisplay.status,
+    };
+  }
   const layout = readSharedLayout(routedPayload);
   const routeKey = route.page === 'workflows-workspace'
     ? 'workflows-workspace'
     : `${route.page}:${route.currentPath}${location.search}${location.hash}`;
 
   return (
-    <AppShell dataWidePanel={layout.dataWidePanel === true} uiInfo={uiInfo}>
+    <AppShell
+      dataWidePanel={layout.dataWidePanel === true}
+      uiInfo={uiInfo}
+      workflowListMode={resolvedDisplay?.effectiveMode ?? null}
+      onWorkflowListModeSelect={handleWorkflowListModeSelect}
+    >
       <PageContent key={routeKey} payload={routedPayload} />
     </AppShell>
   );
@@ -573,7 +740,12 @@ function DashboardRouter({ payload }: { payload: BootPayload }) {
       <Route
         path="*"
         element={
-          <AppShell dataWidePanel={false} uiInfo={uiInfo}>
+          <AppShell
+            dataWidePanel={false}
+            uiInfo={uiInfo}
+            workflowListMode={null}
+            onWorkflowListModeSelect={() => undefined}
+          >
             <UnknownPage page={window.location.pathname} />
           </AppShell>
         }

--- a/frontend/src/entrypoints/dashboard.test.tsx
+++ b/frontend/src/entrypoints/dashboard.test.tsx
@@ -388,6 +388,45 @@ describe('Dashboard shared entry', () => {
     });
   });
 
+  it('renders one workflow list display radio group on covered workflow surfaces', async () => {
+    window.history.replaceState({}, '', '/workflows');
+    renderWithClient(<DashboardApp payload={{ page: 'dashboard', apiBase: '/api' }} />);
+
+    await screen.findByText('Workflow list route loaded', {}, { timeout: 10000 });
+
+    const group = screen.getByRole('radiogroup', { name: 'Workflow list display' });
+    expect(group).toBeTruthy();
+    expect(screen.getByRole('radio', { name: 'No list' }).getAttribute('aria-checked')).toBe('false');
+    expect(screen.getByRole('radio', { name: 'Sidebar list' }).getAttribute('aria-checked')).toBe('false');
+    expect(screen.getByRole('radio', { name: 'Full screen table' }).getAttribute('aria-checked')).toBe('true');
+    expect(screen.queryByRole('button', { name: 'Close sidebar' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Open workflow sidebar' })).toBeNull();
+    expect(screen.queryByRole('link', { name: 'Expand to full list' })).toBeNull();
+  });
+
+  it('opens a visible workflow when sidebar mode is selected from the workflows table', async () => {
+    window.history.replaceState({}, '', '/workflows?source=temporal');
+    renderWithClient(<DashboardApp payload={{ page: 'dashboard', apiBase: '/api' }} />);
+
+    await screen.findByText('Workflow list route loaded', {}, { timeout: 10000 });
+    fireEvent.click(screen.getByRole('radio', { name: 'Sidebar list' }));
+
+    await waitFor(() => {
+      expect(window.location.pathname).toBe('/workflows/mm%3A97d44980-355c-4300-96a7-0ad166440d95');
+    });
+    expect(await screen.findByText(/Workflow detail route loaded:/)).toBeTruthy();
+    expect(screen.getByRole('radio', { name: 'Sidebar list' }).getAttribute('aria-checked')).toBe('true');
+  });
+
+  it('hides the workflow list display control on unsupported routes', async () => {
+    window.history.replaceState({}, '', '/settings');
+    renderWithClient(<DashboardApp payload={{ page: 'dashboard', apiBase: '/api' }} />);
+
+    await screen.findByText('Settings permissions:');
+
+    expect(screen.queryByRole('radiogroup', { name: 'Workflow list display' })).toBeNull();
+  });
+
   it('does not register a dashboard proposal review page for MM-859', async () => {
     window.history.replaceState({}, '', '/proposals');
     renderWithClient(<DashboardApp payload={{ page: 'dashboard', apiBase: '/api' }} />);

--- a/frontend/src/entrypoints/dashboard.test.tsx
+++ b/frontend/src/entrypoints/dashboard.test.tsx
@@ -394,11 +394,11 @@ describe('Dashboard shared entry', () => {
 
     await screen.findByText('Workflow list route loaded', {}, { timeout: 10000 });
 
-    const group = screen.getByRole('radiogroup', { name: 'Workflow list display' });
+    const group = screen.getByRole('group', { name: 'Workflow list display' });
     expect(group).toBeTruthy();
-    expect(screen.getByRole('radio', { name: 'No list' }).getAttribute('aria-checked')).toBe('false');
-    expect(screen.getByRole('radio', { name: 'Sidebar list' }).getAttribute('aria-checked')).toBe('false');
-    expect(screen.getByRole('radio', { name: 'Full screen table' }).getAttribute('aria-checked')).toBe('true');
+    expect(screen.getByRole('button', { name: 'No list' }).getAttribute('aria-pressed')).toBe('false');
+    expect(screen.getByRole('button', { name: 'Sidebar list' }).getAttribute('aria-pressed')).toBe('false');
+    expect(screen.getByRole('button', { name: 'Full screen table' }).getAttribute('aria-pressed')).toBe('true');
     expect(screen.queryByRole('button', { name: 'Close sidebar' })).toBeNull();
     expect(screen.queryByRole('button', { name: 'Open workflow sidebar' })).toBeNull();
     expect(screen.queryByRole('link', { name: 'Expand to full list' })).toBeNull();
@@ -409,13 +409,13 @@ describe('Dashboard shared entry', () => {
     renderWithClient(<DashboardApp payload={{ page: 'dashboard', apiBase: '/api' }} />);
 
     await screen.findByText('Workflow list route loaded', {}, { timeout: 10000 });
-    fireEvent.click(screen.getByRole('radio', { name: 'Sidebar list' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Sidebar list' }));
 
     await waitFor(() => {
       expect(window.location.pathname).toBe('/workflows/mm%3A97d44980-355c-4300-96a7-0ad166440d95');
     });
     expect(await screen.findByText(/Workflow detail route loaded:/)).toBeTruthy();
-    expect(screen.getByRole('radio', { name: 'Sidebar list' }).getAttribute('aria-checked')).toBe('true');
+    expect(screen.getByRole('button', { name: 'Sidebar list' }).getAttribute('aria-pressed')).toBe('true');
   });
 
   it('hides the workflow list display control on unsupported routes', async () => {

--- a/frontend/src/entrypoints/workflow-detail.test.tsx
+++ b/frontend/src/entrypoints/workflow-detail.test.tsx
@@ -1151,6 +1151,9 @@ describe('Workflow Detail Entrypoint', () => {
     expect(dashboardCss).toMatch(
       /\.workflow-workspace-detail\s*\{[^}]*max-width:\s*66rem;/,
     );
+    expect(dashboardCss).toMatch(
+      /\.workflow-workspace-shell\[data-sidebar-collapsed="true"\] \.workflow-workspace-detail\s*\{[^}]*grid-column:\s*1 \/ -1;/,
+    );
   });
 
   it('MM-997 keeps workflow detail standalone when the workflow list is disabled', async () => {

--- a/frontend/src/entrypoints/workflow-detail.test.tsx
+++ b/frontend/src/entrypoints/workflow-detail.test.tsx
@@ -829,9 +829,7 @@ describe('Workflow Detail Entrypoint', () => {
     const pinned = within(pinnedGroup).getByRole('link', { name: /MM-997 selected workflow/i });
     expect(pinned.getAttribute('aria-current')).toBe('page');
     expect(pinned.getAttribute('data-pinned')).toBe('true');
-    expect(within(sidebar).getByRole('link', { name: 'Expand to full list' }).getAttribute('href')).toBe(
-      '/workflows?stateIn=failed&returnFromWorkflowDetail=1',
-    );
+    expect(within(sidebar).queryByRole('link', { name: 'Expand to full list' })).toBeNull();
     expect(await screen.findByRole('heading', { name: 'Workflow Detail' })).toBeTruthy();
     expect(lastFetchUrl(fetchSpy, '/api/executions?')).toBe('/api/executions?source=temporal&stateIn=failed&pageSize=25');
   });
@@ -927,11 +925,7 @@ describe('Workflow Detail Entrypoint', () => {
     expect(anotherWorkflow.getAttribute('href')).toBe(
       '/workflows/test-456?source=temporal&limit=10&nextPageToken=page-2&repoContains=moon%2Frepo&integration=jira',
     );
-    const expandLink = within(sidebar).getByRole('link', { name: 'Expand to full list' });
-    expect(expandLink.getAttribute('href')).toBe(
-      '/workflows?limit=10&repoContains=moon%2Frepo&integration=jira&returnFromWorkflowDetail=1',
-    );
-    expect(expandLink.getAttribute('href')).not.toContain('token=');
+    expect(within(sidebar).queryByRole('link', { name: 'Expand to full list' })).toBeNull();
     expect(lastFetchUrl(fetchSpy, '/api/executions?')).not.toContain('selectedWorkflowId=');
     expect(lastFetchUrl(fetchSpy, '/api/executions?')).not.toContain('sort=');
     expect(lastFetchUrl(fetchSpy, '/api/executions?')).not.toContain('token=');
@@ -954,43 +948,58 @@ describe('Workflow Detail Entrypoint', () => {
     );
   });
 
-  it('MM-1000 persists collapsed sidebar state across desktop detail reloads without changing the route', async () => {
+  it('renders hidden mode from the shared display model without changing the detail route', async () => {
     window.history.pushState({}, 'Workspace Collapse Test', '/workflows/test-123?source=temporal');
     mockDesktopViewport(true);
     mockWorkflowWorkspaceFetches();
 
-    renderWithClient(<WorkflowDetailEntrypoint payload={stepsPayload} />);
+    const { container } = renderWithClient(
+      <WorkflowDetailEntrypoint
+        payload={{
+          ...stepsPayload,
+          initialData: {
+            ...(stepsPayload.initialData as Record<string, unknown>),
+            workflowListDisplayMode: 'hidden',
+          },
+        }}
+      />,
+    );
 
-    const closeSidebar = await screen.findByRole('button', { name: 'Close sidebar' });
-    fireEvent.click(closeSidebar);
-
-    const openSidebar = await screen.findByRole('button', { name: 'Open workflow sidebar' });
-    expect(openSidebar).toBeTruthy();
-    expect(document.activeElement).toBe(openSidebar);
+    expect(await screen.findByRole('heading', { name: 'Workflow Detail' })).toBeTruthy();
+    expect(screen.queryByRole('complementary', { name: 'Workflow navigation' })).toBeNull();
+    expect(container.querySelector('.workflow-workspace-shell')?.getAttribute('data-workflow-list-display-mode')).toBe(
+      'hidden',
+    );
     expect(window.location.pathname).toBe('/workflows/test-123');
-    expect(readDashboardPreferences().workflowWorkspaceSidebarCollapsed).toBe(true);
     expect(screen.getByRole('main', { name: 'Workflow detail' })).toBeTruthy();
   });
 
-  it('MM-1000 opens desktop detail routes by default unless the sidebar collapse preference is persisted', async () => {
+  it('defaults desktop detail routes to sidebar unless the previous collapse preference requests hidden mode', async () => {
     window.history.pushState({}, 'Workspace Reload Default Test', '/workflows/test-123?source=temporal');
     mockDesktopViewport(true);
     mockWorkflowWorkspaceFetches();
 
-    renderWithClient(<WorkflowDetailEntrypoint payload={stepsPayload} />);
+    const firstRender = renderWithClient(<WorkflowDetailEntrypoint payload={stepsPayload} />);
 
     expect(await screen.findByRole('complementary', { name: 'Workflow navigation' })).toBeTruthy();
+    expect(firstRender.container.querySelector('.workflow-workspace-shell')?.getAttribute('data-workflow-list-display-mode')).toBe(
+      'sidebar',
+    );
 
     cleanup();
     window.localStorage.clear();
     updateDashboardPreferences({ workflowWorkspaceSidebarCollapsed: true });
 
-    renderWithClient(<WorkflowDetailEntrypoint payload={stepsPayload} />);
+    const secondRender = renderWithClient(<WorkflowDetailEntrypoint payload={stepsPayload} />);
 
-    expect(await screen.findByRole('button', { name: 'Open workflow sidebar' })).toBeTruthy();
+    expect(await screen.findByRole('heading', { name: 'Workflow Detail' })).toBeTruthy();
+    expect(screen.queryByRole('complementary', { name: 'Workflow navigation' })).toBeNull();
+    expect(secondRender.container.querySelector('.workflow-workspace-shell')?.getAttribute('data-workflow-list-display-mode')).toBe(
+      'hidden',
+    );
   });
 
-  it('MM-1000 restores the sidebar from persisted collapse without refetching selected detail data', async () => {
+  it('shared sidebar mode overrides a persisted collapse preference without refetching selected detail data', async () => {
     window.history.pushState({}, 'Workspace Reopen Test', '/workflows/test-123?source=temporal');
     mockDesktopViewport(true);
     mockWorkflowWorkspaceFetches();
@@ -1001,6 +1010,7 @@ describe('Workflow Detail Entrypoint', () => {
         payload={{
           ...stepsPayload,
           initialData: {
+            workflowListDisplayMode: 'sidebar',
             dashboardConfig: {
               ...((stepsPayload.initialData as { dashboardConfig: Record<string, unknown> }).dashboardConfig),
               pollIntervalsMs: { detail: 60000, list: 60000 },
@@ -1010,17 +1020,14 @@ describe('Workflow Detail Entrypoint', () => {
       />,
     );
 
-    await screen.findByRole('button', { name: 'Open workflow sidebar' });
     await screen.findByRole('heading', { name: 'Workflow Detail' });
     const detailCallsBeforeOpen = fetchSpy.mock.calls.filter(
       ([input]) => String(input) === '/api/executions/test-123?source=temporal',
     ).length;
-    fireEvent.click(screen.getByRole('button', { name: 'Open workflow sidebar' }));
 
     const sidebar = await screen.findByRole('complementary', { name: 'Workflow navigation' });
-    expect(document.activeElement).toBe(screen.getByRole('button', { name: 'Close sidebar' }));
     expect(sidebar).toBeTruthy();
-    expect(readDashboardPreferences().workflowWorkspaceSidebarCollapsed).toBe(false);
+    expect(readDashboardPreferences().workflowWorkspaceSidebarCollapsed).toBe(true);
     expect(
       fetchSpy.mock.calls.filter(
         ([input]) => String(input) === '/api/executions/test-123?source=temporal',
@@ -1041,7 +1048,7 @@ describe('Workflow Detail Entrypoint', () => {
     expect(screen.queryByRole('complementary', { name: 'Workflow navigation' })).toBeNull();
   });
 
-  it('MM-1000 keeps workspace sidebar full-list navigation compact', async () => {
+  it('replaces workspace sidebar full-list navigation with the shared mode model', async () => {
     window.history.pushState(
       {},
       'Workspace Expand Test',
@@ -1053,27 +1060,11 @@ describe('Workflow Detail Entrypoint', () => {
     renderWithClient(<WorkflowDetailEntrypoint payload={stepsPayload} />);
 
     const sidebar = await screen.findByRole('complementary', { name: 'Workflow navigation' });
-    const expand = within(sidebar).getByRole('link', { name: 'Expand to full list' });
-    expect(expand.getAttribute('href')).toBe(
-      '/workflows?stateIn=completed&repoContains=moon%2Frepo&limit=10&returnFromWorkflowDetail=1',
-    );
-    expect(expand.getAttribute('href')).not.toContain('source=');
-    expect(expand.getAttribute('href')).not.toContain('nextPageToken=');
-    expect(expand.getAttribute('href')).not.toContain('sort=');
-    expect(expand.getAttribute('href')).not.toContain('selectedWorkflowId=');
-    expect(expand.getAttribute('href')).not.toContain('unsafe=');
-    expect(expand.getAttribute('class') || '').toContain('workflow-workspace-expand-list');
-    expect(expand.getAttribute('class') || '').toContain('secondary');
-    expect(expand.getAttribute('class') || '').not.toContain('button');
-    expect(expand.querySelector('svg.lucide-arrow-right')).toBeTruthy();
-    const closeSidebar = within(sidebar).getByRole('button', { name: 'Close sidebar' });
-    expect(closeSidebar.getAttribute('class') || '').toContain(
-      'workflow-workspace-close-sidebar',
-    );
-    expect(closeSidebar.compareDocumentPosition(expand) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(within(sidebar).queryByRole('link', { name: 'Expand to full list' })).toBeNull();
+    expect(within(sidebar).queryByRole('button', { name: 'Close sidebar' })).toBeNull();
   });
 
-  it('MM-1008 keeps the close-sidebar control compact', async () => {
+  it('MM-1008 does not render separate covered-page sidebar controls', async () => {
     window.history.pushState({}, 'Workspace Controls Test', '/workflows/test-123?source=temporal');
     mockDesktopViewport(true);
     mockWorkflowWorkspaceFetches();
@@ -1081,19 +1072,12 @@ describe('Workflow Detail Entrypoint', () => {
     renderWithClient(<WorkflowDetailEntrypoint payload={stepsPayload} />);
 
     const sidebar = await screen.findByRole('complementary', { name: 'Workflow navigation' });
-    expect(within(sidebar).getByRole('button', { name: 'Close sidebar' }).getAttribute('class') || '').toContain(
-      'workflow-workspace-close-sidebar',
-    );
-    expect(within(sidebar).getByRole('link', { name: 'Expand to full list' }).getAttribute('class') || '').toContain(
-      'workflow-workspace-expand-list',
-    );
+    expect(within(sidebar).queryByRole('button', { name: 'Close sidebar' })).toBeNull();
+    expect(within(sidebar).queryByRole('button', { name: 'Open workflow sidebar' })).toBeNull();
+    expect(within(sidebar).queryByRole('link', { name: 'Expand to full list' })).toBeNull();
 
     const dashboardCss = await readDashboardCss();
-    expect(dashboardCss).toMatch(/\.workflow-workspace-expand-list,[\s\S]*?\.workflow-workspace-close-sidebar,[\s\S]*?width:\s*2rem;/);
-    expect(dashboardCss).toMatch(/\.workflow-workspace-control-icon,[\s\S]*?\.workflow-workspace-expand-list svg[\s\S]*?width:\s*1\.05rem;/);
-    expect(dashboardCss).toMatch(
-      /\.workflow-workspace-sidebar-control:hover,[\s\S]*?background-image:\s*linear-gradient\(145deg,\s*rgb\(var\(--mm-accent\) \/ 0\.35\),\s*rgb\(var\(--mm-accent-2\) \/ 0\.25\)\);/,
-    );
+    expect(dashboardCss).not.toMatch(/\.workflow-workspace-expand-list,[\s\S]*?\.workflow-workspace-close-sidebar/);
   });
 
   it('MM-1002 renders sidebar titles and statuses as React text', async () => {
@@ -1127,7 +1111,7 @@ describe('Workflow Detail Entrypoint', () => {
     expect(sidebar.querySelector('script')).toBeNull();
   });
 
-  it('MM-1005 expands to the plain workflow list when no filter context exists', async () => {
+  it('MM-1005 leaves table expansion to the shared masthead mode model', async () => {
     window.history.pushState({}, 'Workspace Plain Expand Test', '/workflows/test-123?source=temporal');
     mockDesktopViewport(true);
     mockWorkflowWorkspaceFetches();
@@ -1135,11 +1119,8 @@ describe('Workflow Detail Entrypoint', () => {
     renderWithClient(<WorkflowDetailEntrypoint payload={stepsPayload} />);
 
     const sidebar = await screen.findByRole('complementary', { name: 'Workflow navigation' });
-    const expandLink = within(sidebar).getByRole('link', { name: 'Expand to full list' });
-    expect(expandLink.getAttribute('href')).toBe('/workflows');
-
-    fireEvent.click(expandLink);
-    expect(window.sessionStorage.getItem(WORKFLOW_LIST_RETURN_FOCUS_INTENT_KEY)).toBe('1');
+    expect(within(sidebar).queryByRole('link', { name: 'Expand to full list' })).toBeNull();
+    expect(window.sessionStorage.getItem(WORKFLOW_LIST_RETURN_FOCUS_INTENT_KEY)).toBeNull();
   });
 
   it('keeps desktop detail positioning stable when the workspace sidebar is collapsed', async () => {
@@ -1150,7 +1131,9 @@ describe('Workflow Detail Entrypoint', () => {
 
     const { container } = renderWithClient(<WorkflowDetailEntrypoint payload={stepsPayload} />);
 
-    expect(await screen.findByRole('button', { name: 'Open workflow sidebar' })).toBeTruthy();
+    expect(await screen.findByRole('heading', { name: 'Workflow Detail' })).toBeTruthy();
+    expect(screen.queryByRole('button', { name: 'Open workflow sidebar' })).toBeNull();
+    expect(screen.queryByRole('complementary', { name: 'Workflow navigation' })).toBeNull();
     expect(container.querySelector('.workflow-workspace-shell')?.getAttribute('data-sidebar-collapsed')).toBe(
       'true',
     );

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -48,7 +48,7 @@ import {
   workflowListContextParams,
 } from '../lib/workflowListContext';
 import {
-  isWorkflowListDisplayMode,
+  readWorkflowListDisplayMode,
   type WorkflowListDisplayMode,
 } from '../lib/workflowListDisplayMode';
 import { WorkflowActionsMenu } from '../components/WorkflowActionsMenu';
@@ -8941,12 +8941,6 @@ export function WorkflowDetailPage({ payload }: { payload: BootPayload }) {
       )}
     </div>
   );
-}
-
-function readWorkflowListDisplayMode(payload: BootPayload): WorkflowListDisplayMode | undefined {
-  const raw = payload.initialData as { workflowListDisplayMode?: unknown } | undefined;
-  const value = typeof raw?.workflowListDisplayMode === 'string' ? raw.workflowListDisplayMode : '';
-  return isWorkflowListDisplayMode(value) ? value : undefined;
 }
 
 export function WorkflowDetailEntrypoint({ payload }: { payload: BootPayload }) {

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -8,14 +8,10 @@ import {
   type KeyboardEvent,
   type ReactNode,
   type Ref,
-  type RefObject,
   type SetStateAction,
 } from 'react';
 import { useMutation, useQuery, useQueryClient, type UseQueryResult } from '@tanstack/react-query';
 import Anser from 'anser';
-import {
-  ArrowRight,
-} from 'lucide-react';
 import {
   BotIcon,
   type BotIconHandle,
@@ -48,11 +44,13 @@ import {
   taskEditHref,
 } from '../lib/temporalTaskEditing';
 import {
-  markWorkflowListReturnFocusIntent,
   workflowDetailHref,
   workflowListContextParams,
-  workflowListHrefFromContext,
 } from '../lib/workflowListContext';
+import {
+  isWorkflowListDisplayMode,
+  type WorkflowListDisplayMode,
+} from '../lib/workflowListDisplayMode';
 import { WorkflowActionsMenu } from '../components/WorkflowActionsMenu';
 import {
   buildRemediationRuntimeRequestFields,
@@ -438,65 +436,6 @@ function WorkflowSidebarRow({
   );
 }
 
-function WorkspaceControlIcon({ children }: { children: ReactNode }) {
-  return (
-    <svg
-      className="workflow-workspace-control-icon"
-      viewBox="0 0 24 24"
-      aria-hidden="true"
-      focusable="false"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    >
-      {children}
-    </svg>
-  );
-}
-
-const SIDEBAR_TOGGLE_ICON = (
-  <WorkspaceControlIcon>
-    <rect x="3" y="4" width="18" height="16" rx="2" />
-    <path d="M9 4v16" />
-  </WorkspaceControlIcon>
-);
-
-function WorkflowSidebarControls({
-  closeButtonRef,
-  onClose,
-  search,
-}: {
-  closeButtonRef: RefObject<HTMLButtonElement | null>;
-  onClose: () => void;
-  search: URLSearchParams;
-}) {
-  return (
-    <div className="workflow-workspace-sidebar-controls">
-      <button
-        ref={closeButtonRef}
-        type="button"
-        className="secondary workflow-workspace-close-sidebar workflow-workspace-sidebar-control"
-        onClick={onClose}
-        aria-label="Close sidebar"
-        title="Close sidebar"
-      >
-        {SIDEBAR_TOGGLE_ICON}
-      </button>
-      <a
-        href={workflowListHrefFromContext(search, { markDetailReturn: true })}
-        className="secondary workflow-workspace-expand-list workflow-workspace-sidebar-control"
-        onClick={markWorkflowListReturnFocusIntent}
-        aria-label="Expand to full list"
-        title="Expand to full list"
-      >
-        <ArrowRight aria-hidden="true" focusable="false" />
-      </a>
-    </div>
-  );
-}
-
 function WorkflowSidebarList({
   rows,
   activeWorkflowId,
@@ -538,24 +477,15 @@ function WorkflowSidebar({
   filteredRows,
   pinnedCurrentRow,
   search,
-  closeButtonRef,
-  onClose,
 }: {
   workflowId: string;
   workflowsQuery: UseQueryResult<z.infer<typeof WorkflowWorkspaceListResponseSchema>, Error>;
   filteredRows: WorkflowWorkspaceRow[];
   pinnedCurrentRow: WorkflowWorkspaceRow | null;
   search: URLSearchParams;
-  closeButtonRef: RefObject<HTMLButtonElement | null>;
-  onClose: () => void;
 }) {
   return (
     <aside className="workflow-workspace-sidebar" aria-label="Workflow navigation">
-      <WorkflowSidebarControls
-        closeButtonRef={closeButtonRef}
-        onClose={onClose}
-        search={search}
-      />
       {workflowsQuery.isLoading ? (
         <p className="workflow-workspace-sidebar-state">Loading workflows...</p>
       ) : null}
@@ -588,19 +518,19 @@ export function WorkflowWorkspaceShell({
   payload,
   workflowId,
   search,
+  displayMode,
 }: {
   payload: BootPayload;
   workflowId: string;
   search: URLSearchParams;
+  displayMode?: WorkflowListDisplayMode | undefined;
 }) {
   const cfg = readDashboardConfig(payload);
   const listPoll = cfg?.pollIntervalsMs?.list ?? 5000;
   const listEnabled = cfg?.features?.temporalDashboard?.listEnabled !== false;
-  const [sidebarOpen, setSidebarOpen] = useState(
-    () => !readDashboardPreferences().workflowWorkspaceSidebarCollapsed,
+  const effectiveDisplayMode = displayMode ?? (
+    readDashboardPreferences().workflowWorkspaceSidebarCollapsed ? 'hidden' : 'sidebar'
   );
-  const closeButtonRef = useRef<HTMLButtonElement | null>(null);
-  const openButtonRef = useRef<HTMLButtonElement | null>(null);
   const listQuery = useMemo(() => workflowWorkspaceListQuery(search), [search]);
   const sourceTemporal = search.get('source') === 'temporal';
   const encodedWorkflowId = encodeURIComponent(workflowId);
@@ -643,40 +573,20 @@ export function WorkflowWorkspaceShell({
   return (
     <div
       className="workflow-workspace-shell"
-      data-sidebar-collapsed={sidebarOpen ? 'false' : 'true'}
+      data-sidebar-collapsed={effectiveDisplayMode === 'sidebar' ? 'false' : 'true'}
+      data-workflow-list-display-mode={effectiveDisplayMode}
       data-jira-issue="MM-997 MM-999 MM-1000 MM-1002 MM-1005 MM-1008"
       data-source-issue="MM-975"
     >
-      {sidebarOpen ? (
+      {effectiveDisplayMode === 'sidebar' ? (
         <WorkflowSidebar
           workflowId={workflowId}
           workflowsQuery={workflowsQuery}
           filteredRows={filteredRows}
           pinnedCurrentRow={pinnedCurrentRow}
           search={search}
-          closeButtonRef={closeButtonRef}
-          onClose={() => {
-            updateDashboardPreferences({ workflowWorkspaceSidebarCollapsed: true });
-            setSidebarOpen(false);
-            window.setTimeout(() => openButtonRef.current?.focus(), 0);
-          }}
         />
-      ) : (
-        <button
-          ref={openButtonRef}
-          type="button"
-          className="secondary workflow-workspace-open-sidebar workflow-workspace-sidebar-control"
-          onClick={() => {
-            updateDashboardPreferences({ workflowWorkspaceSidebarCollapsed: false });
-            setSidebarOpen(true);
-            window.setTimeout(() => closeButtonRef.current?.focus(), 0);
-          }}
-          aria-label="Open workflow sidebar"
-          title="Open workflow sidebar"
-        >
-          {SIDEBAR_TOGGLE_ICON}
-        </button>
-      )}
+      ) : null}
       <main className="workflow-workspace-detail" aria-label="Workflow detail">
         <WorkflowDetailPage payload={payload} />
       </main>
@@ -9033,6 +8943,12 @@ export function WorkflowDetailPage({ payload }: { payload: BootPayload }) {
   );
 }
 
+function readWorkflowListDisplayMode(payload: BootPayload): WorkflowListDisplayMode | undefined {
+  const raw = payload.initialData as { workflowListDisplayMode?: unknown } | undefined;
+  const value = typeof raw?.workflowListDisplayMode === 'string' ? raw.workflowListDisplayMode : '';
+  return isWorkflowListDisplayMode(value) ? value : undefined;
+}
+
 export function WorkflowDetailEntrypoint({ payload }: { payload: BootPayload }) {
   const cfg = readDashboardConfig(payload);
   const isDesktop = useWorkflowWorkspaceDesktop();
@@ -9043,9 +8959,17 @@ export function WorkflowDetailEntrypoint({ payload }: { payload: BootPayload }) 
   const search = useMemo(() => new URLSearchParams(typeof window !== 'undefined' ? window.location.search : ''), []);
   const workspaceShellEnabled = cfg?.features?.temporalDashboard?.workspaceShellEnabled !== false;
   const listEnabled = cfg?.features?.temporalDashboard?.listEnabled !== false;
+  const displayMode = readWorkflowListDisplayMode(payload);
 
   if (workspaceShellEnabled && listEnabled && isDesktop && workflowId) {
-    return <WorkflowWorkspaceShell payload={payload} workflowId={workflowId} search={search} />;
+    return (
+      <WorkflowWorkspaceShell
+        payload={payload}
+        workflowId={workflowId}
+        search={search}
+        displayMode={displayMode}
+      />
+    );
   }
 
   return <WorkflowDetailPage payload={payload} />;

--- a/frontend/src/entrypoints/workflow-start.test.tsx
+++ b/frontend/src/entrypoints/workflow-start.test.tsx
@@ -240,7 +240,7 @@ describe("WorkflowStartPage workflow list display modes", () => {
 
     const sidebar = await screen.findByRole("complementary", { name: "Workflow navigation" });
     expect((await within(sidebar).findByRole("link", { name: /Sidebar workflow/i })).getAttribute("href")).toBe(
-      "/workflows/mm%3Acreate-sidebar",
+      "/workflows/mm%3Acreate-sidebar?source=temporal",
     );
     expect(screen.getByRole("button", { name: "Start Workflow" })).toBeTruthy();
   });

--- a/frontend/src/entrypoints/workflow-start.test.tsx
+++ b/frontend/src/entrypoints/workflow-start.test.tsx
@@ -120,6 +120,12 @@ describe("WorkflowStartPage loading placeholders", () => {
           json: async () => ({ items: { worker: [] }, legacyItems: [] }),
         } as Response);
       }
+      if (url.startsWith("/api/v1/provider-profiles")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => [],
+        } as Response);
+      }
       return Promise.resolve({
         ok: true,
         json: async () => ({}),
@@ -155,6 +161,88 @@ describe("WorkflowStartPage loading placeholders", () => {
     expect(screen.getByRole("heading", { name: "Edit Workflow" })).toBeTruthy();
     expect(screen.getByText("Workflow start editable draft loading placeholder").closest('[role="status"]')).toBeTruthy();
     expect(screen.getByTestId("loading-placeholder-form-controls")).toBeTruthy();
+  });
+});
+
+describe("WorkflowStartPage workflow list display modes", () => {
+  let fetchSpy: MockInstance;
+
+  beforeEach(() => {
+    window.history.pushState({}, "Create Workflow", "/workflows/new");
+    fetchSpy = vi.spyOn(window, "fetch").mockImplementation((input: RequestInfo | URL) => {
+      const url = input instanceof Request ? input.url : String(input);
+      if (url.startsWith("/api/executions?")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            items: [
+              {
+                workflowId: "mm:create-sidebar",
+                title: "Sidebar workflow",
+                status: "completed",
+              },
+            ],
+          }),
+        } as Response);
+      }
+      if (url.startsWith("/api/workflows/skills")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ items: { worker: [] }, legacyItems: [] }),
+        } as Response);
+      }
+      if (url.includes("/api/v1/provider-profiles")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => [],
+        } as Response);
+      }
+      return Promise.resolve({
+        ok: true,
+        json: async () => ({}),
+      } as Response);
+    });
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  it("renders Create without a workflow list in hidden mode", () => {
+    renderWithClient(
+      <WorkflowStartPage
+        payload={{
+          ...mockPayload,
+          initialData: {
+            ...(mockPayload.initialData as Record<string, unknown>),
+            workflowListDisplayMode: "hidden",
+          },
+        }}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Start Workflow" })).toBeTruthy();
+    expect(screen.queryByRole("complementary", { name: "Workflow navigation" })).toBeNull();
+  });
+
+  it("renders Create with the workflow list as a sidebar in sidebar mode", async () => {
+    renderWithClient(
+      <WorkflowStartPage
+        payload={{
+          ...mockPayload,
+          initialData: {
+            ...(mockPayload.initialData as Record<string, unknown>),
+            workflowListDisplayMode: "sidebar",
+          },
+        }}
+      />,
+    );
+
+    const sidebar = await screen.findByRole("complementary", { name: "Workflow navigation" });
+    expect((await within(sidebar).findByRole("link", { name: /Sidebar workflow/i })).getAttribute("href")).toBe(
+      "/workflows/mm%3Acreate-sidebar",
+    );
+    expect(screen.getByRole("button", { name: "Start Workflow" })).toBeTruthy();
   });
 });
 
@@ -637,7 +725,7 @@ describe("WorkflowStart schedule mode entry", () => {
             json: async () => ({ items: [] }),
           } as Response);
         }
-        if (url.startsWith("/api/v1/provider-profiles")) {
+      if (url.includes("/api/v1/provider-profiles")) {
           return Promise.resolve({
             ok: true,
             json: async () => [],

--- a/frontend/src/entrypoints/workflow-start.tsx
+++ b/frontend/src/entrypoints/workflow-start.tsx
@@ -23,8 +23,7 @@ import {
   type TemporalTaskInputAttachmentRef,
 } from "../lib/temporalTaskEditing";
 import {
-  isWorkflowListDisplayMode,
-  type WorkflowListDisplayMode,
+  readWorkflowListDisplayMode,
 } from "../lib/workflowListDisplayMode";
 
 // This cutoff is enforced on UTF-8 encoded request bytes, not JavaScript string length.
@@ -5502,17 +5501,11 @@ function workflowStartSidebarRowId(row: WorkflowStartSidebarRow): string {
   return row.workflowId || row.taskId || "";
 }
 
-function readWorkflowStartListDisplayMode(payload: BootPayload): WorkflowListDisplayMode | undefined {
-  const raw = payload.initialData as { workflowListDisplayMode?: unknown } | undefined;
-  const value = typeof raw?.workflowListDisplayMode === "string" ? raw.workflowListDisplayMode : "";
-  return isWorkflowListDisplayMode(value) ? value : undefined;
-}
-
 function WorkflowStartSidebar({ apiBase }: { apiBase: string }) {
   const workflowsQuery = useQuery({
     queryKey: ["workflow-start-sidebar"],
-    queryFn: async (): Promise<WorkflowStartSidebarRow[]> => {
-      const response = await fetch(`${apiBase}/executions?pageSize=25`);
+    queryFn: async ({ signal }): Promise<WorkflowStartSidebarRow[]> => {
+      const response = await fetch(`${apiBase}/executions?pageSize=25`, { signal });
       if (!response.ok) {
         throw new Error(`Failed to fetch workflows: ${response.statusText}`);
       }
@@ -13010,7 +13003,7 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
 }
 
 export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
-  const displayMode = readWorkflowStartListDisplayMode(payload);
+  const displayMode = readWorkflowListDisplayMode(payload);
   if (displayMode !== "sidebar") {
     return <WorkflowStartPageContent payload={payload} />;
   }

--- a/frontend/src/entrypoints/workflow-start.tsx
+++ b/frontend/src/entrypoints/workflow-start.tsx
@@ -5505,7 +5505,8 @@ function WorkflowStartSidebar({ apiBase }: { apiBase: string }) {
   const workflowsQuery = useQuery({
     queryKey: ["workflow-start-sidebar"],
     queryFn: async ({ signal }): Promise<WorkflowStartSidebarRow[]> => {
-      const response = await fetch(`${apiBase}/executions?pageSize=25`, { signal });
+      const params = new URLSearchParams({ source: "temporal", pageSize: "25" });
+      const response = await fetch(`${apiBase}/executions?${params.toString()}`, { signal });
       if (!response.ok) {
         throw new Error(`Failed to fetch workflows: ${response.statusText}`);
       }
@@ -5542,7 +5543,7 @@ function WorkflowStartSidebar({ apiBase }: { apiBase: string }) {
             const status = row.rawState || row.state || row.status || "unknown";
             return (
               <li key={workflowId}>
-                <a className="workflow-workspace-sidebar-row" href={`/workflows/${encodeURIComponent(workflowId)}`}>
+                <a className="workflow-workspace-sidebar-row" href={`/workflows/${encodeURIComponent(workflowId)}?source=temporal`}>
                   <span className="workflow-workspace-sidebar-row-main">
                     <span className="workflow-workspace-sidebar-title">{title}</span>
                   </span>

--- a/frontend/src/entrypoints/workflow-start.tsx
+++ b/frontend/src/entrypoints/workflow-start.tsx
@@ -22,6 +22,10 @@ import {
   type TemporalTaskEditingExecutionContract,
   type TemporalTaskInputAttachmentRef,
 } from "../lib/temporalTaskEditing";
+import {
+  isWorkflowListDisplayMode,
+  type WorkflowListDisplayMode,
+} from "../lib/workflowListDisplayMode";
 
 // This cutoff is enforced on UTF-8 encoded request bytes, not JavaScript string length.
 const INLINE_TASK_INPUT_LIMIT_BYTES = 8_000;
@@ -5485,7 +5489,82 @@ function StepContextBar({
   );
 }
 
-export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
+type WorkflowStartSidebarRow = {
+  workflowId?: string;
+  taskId?: string;
+  title?: string;
+  status?: string;
+  state?: string;
+  rawState?: string;
+};
+
+function workflowStartSidebarRowId(row: WorkflowStartSidebarRow): string {
+  return row.workflowId || row.taskId || "";
+}
+
+function readWorkflowStartListDisplayMode(payload: BootPayload): WorkflowListDisplayMode | undefined {
+  const raw = payload.initialData as { workflowListDisplayMode?: unknown } | undefined;
+  const value = typeof raw?.workflowListDisplayMode === "string" ? raw.workflowListDisplayMode : "";
+  return isWorkflowListDisplayMode(value) ? value : undefined;
+}
+
+function WorkflowStartSidebar({ apiBase }: { apiBase: string }) {
+  const workflowsQuery = useQuery({
+    queryKey: ["workflow-start-sidebar"],
+    queryFn: async (): Promise<WorkflowStartSidebarRow[]> => {
+      const response = await fetch(`${apiBase}/executions?pageSize=25`);
+      if (!response.ok) {
+        throw new Error(`Failed to fetch workflows: ${response.statusText}`);
+      }
+      const data = (await response.json()) as { items?: WorkflowStartSidebarRow[] };
+      return Array.isArray(data.items) ? data.items : [];
+    },
+    staleTime: 30_000,
+  });
+
+  return (
+    <aside className="workflow-workspace-sidebar" aria-label="Workflow navigation">
+      {workflowsQuery.isLoading ? (
+        <p className="workflow-workspace-sidebar-state">Loading workflows...</p>
+      ) : null}
+      {workflowsQuery.isError ? (
+        <div className="workflow-workspace-sidebar-state" role="status">
+          <p>Workflow navigation is unavailable.</p>
+          <button type="button" className="secondary" onClick={() => void workflowsQuery.refetch()}>
+            Retry
+          </button>
+        </div>
+      ) : null}
+      {!workflowsQuery.isLoading && !workflowsQuery.isError && workflowsQuery.data?.length === 0 ? (
+        <p className="workflow-workspace-sidebar-state">No workflows are available.</p>
+      ) : null}
+      {!workflowsQuery.isLoading && !workflowsQuery.isError && workflowsQuery.data?.length ? (
+        <ul className="workflow-workspace-sidebar-list" aria-label="Workflow navigation list">
+          {workflowsQuery.data.map((row) => {
+            const workflowId = workflowStartSidebarRowId(row);
+            if (!workflowId) {
+              return null;
+            }
+            const title = row.title?.trim() || workflowId;
+            const status = row.rawState || row.state || row.status || "unknown";
+            return (
+              <li key={workflowId}>
+                <a className="workflow-workspace-sidebar-row" href={`/workflows/${encodeURIComponent(workflowId)}`}>
+                  <span className="workflow-workspace-sidebar-row-main">
+                    <span className="workflow-workspace-sidebar-title">{title}</span>
+                  </span>
+                  <span className="workflow-workspace-sidebar-status-text">{status}</span>
+                </a>
+              </li>
+            );
+          })}
+        </ul>
+      ) : null}
+    </aside>
+  );
+}
+
+function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
   useLiquidGL({ options: LIQUID_GL_OPTIONS });
   const dashboardConfig = readDashboardConfig(payload);
   const pageMode = useMemo(
@@ -12929,4 +13008,25 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
     </div>
   );
 }
+
+export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
+  const displayMode = readWorkflowStartListDisplayMode(payload);
+  if (displayMode !== "sidebar") {
+    return <WorkflowStartPageContent payload={payload} />;
+  }
+
+  return (
+    <div
+      className="workflow-start-workspace workflow-workspace-shell"
+      data-sidebar-collapsed="false"
+      data-workflow-list-display-mode="sidebar"
+    >
+      <WorkflowStartSidebar apiBase={payload.apiBase} />
+      <main className="workflow-start-primary" aria-label="Create workflow">
+        <WorkflowStartPageContent payload={payload} />
+      </main>
+    </div>
+  );
+}
+
 export default WorkflowStartPage;

--- a/frontend/src/entrypoints/workflows-workspace.test.tsx
+++ b/frontend/src/entrypoints/workflows-workspace.test.tsx
@@ -11,7 +11,15 @@ vi.mock('./workflow-list', () => ({
 
 vi.mock('./workflow-detail', () => ({
   default: () => <div data-testid="workflow-detail-entrypoint">Workflow detail entrypoint</div>,
-  WorkflowWorkspaceShell: () => <div data-testid="workflow-workspace-shell">Workflow workspace shell</div>,
+  WorkflowWorkspaceShell: ({
+    displayMode,
+  }: {
+    displayMode?: 'hidden' | 'sidebar' | 'table';
+  }) => (
+    <div data-testid="workflow-workspace-shell" data-display-mode={displayMode ?? 'unset'}>
+      Workflow workspace shell
+    </div>
+  ),
 }));
 
 function mockDesktopViewport(matches: boolean) {
@@ -69,5 +77,26 @@ describe('WorkflowsWorkspacePage', () => {
 
     expect(screen.getByTestId('workflow-workspace-shell')).toBeTruthy();
     expect(screen.queryByTestId('workflow-detail-entrypoint')).toBeNull();
+  });
+
+  it('keeps /workflows as the table primary surface', () => {
+    window.history.pushState({}, 'Workspace Table Test', '/workflows');
+
+    renderWorkspace({ page: 'dashboard', apiBase: '/api' });
+
+    expect(screen.getByTestId('workflow-list-page')).toBeTruthy();
+    expect(screen.queryByTestId('workflow-workspace-shell')).toBeNull();
+  });
+
+  it('passes the resolved hidden/sidebar mode into detail workspace composition', () => {
+    renderWorkspace({
+      page: 'dashboard',
+      apiBase: '/api',
+      initialData: {
+        workflowListDisplayMode: 'hidden',
+      },
+    });
+
+    expect(screen.getByTestId('workflow-workspace-shell').getAttribute('data-display-mode')).toBe('hidden');
   });
 });

--- a/frontend/src/entrypoints/workflows-workspace.tsx
+++ b/frontend/src/entrypoints/workflows-workspace.tsx
@@ -4,6 +4,10 @@ import { useLocation } from 'react-router-dom';
 import type { BootPayload } from '../boot/parseBootPayload';
 import WorkflowListPage from './workflow-list';
 import WorkflowDetailEntrypoint, { WorkflowWorkspaceShell } from './workflow-detail';
+import {
+  isWorkflowListDisplayMode,
+  type WorkflowListDisplayMode,
+} from '../lib/workflowListDisplayMode';
 
 const DESKTOP_MEDIA_QUERY = '(min-width: 768px)';
 
@@ -58,6 +62,12 @@ function readWorkflowsWorkspaceDashboardConfig(
   return raw?.dashboardConfig;
 }
 
+function readWorkflowListDisplayMode(payload: BootPayload): WorkflowListDisplayMode | undefined {
+  const raw = payload.initialData as { workflowListDisplayMode?: unknown } | undefined;
+  const value = typeof raw?.workflowListDisplayMode === 'string' ? raw.workflowListDisplayMode : '';
+  return isWorkflowListDisplayMode(value) ? value : undefined;
+}
+
 export function WorkflowsWorkspacePage({ payload }: { payload: BootPayload }) {
   const location = useLocation();
   const workflowId = decodeWorkflowIdFromPath(location.pathname);
@@ -67,6 +77,7 @@ export function WorkflowsWorkspacePage({ payload }: { payload: BootPayload }) {
   const temporalDashboard = cfg?.features?.temporalDashboard;
   const workspaceShellEnabled = temporalDashboard?.workspaceShellEnabled !== false;
   const listEnabled = temporalDashboard?.listEnabled !== false;
+  const displayMode = readWorkflowListDisplayMode(payload);
 
   if (!workflowId) {
     return (
@@ -86,7 +97,12 @@ export function WorkflowsWorkspacePage({ payload }: { payload: BootPayload }) {
       aria-label="Workflows workspace"
       data-jira-issue="MM-1061"
     >
-      <WorkflowWorkspaceShell payload={payload} workflowId={workflowId} search={search} />
+      <WorkflowWorkspaceShell
+        payload={payload}
+        workflowId={workflowId}
+        search={search}
+        displayMode={displayMode}
+      />
     </section>
   );
 }

--- a/frontend/src/entrypoints/workflows-workspace.tsx
+++ b/frontend/src/entrypoints/workflows-workspace.tsx
@@ -5,8 +5,7 @@ import type { BootPayload } from '../boot/parseBootPayload';
 import WorkflowListPage from './workflow-list';
 import WorkflowDetailEntrypoint, { WorkflowWorkspaceShell } from './workflow-detail';
 import {
-  isWorkflowListDisplayMode,
-  type WorkflowListDisplayMode,
+  readWorkflowListDisplayMode,
 } from '../lib/workflowListDisplayMode';
 
 const DESKTOP_MEDIA_QUERY = '(min-width: 768px)';
@@ -60,12 +59,6 @@ function readWorkflowsWorkspaceDashboardConfig(
 ): WorkflowsWorkspaceDashboardConfig | undefined {
   const raw = payload.initialData as { dashboardConfig?: WorkflowsWorkspaceDashboardConfig } | undefined;
   return raw?.dashboardConfig;
-}
-
-function readWorkflowListDisplayMode(payload: BootPayload): WorkflowListDisplayMode | undefined {
-  const raw = payload.initialData as { workflowListDisplayMode?: unknown } | undefined;
-  const value = typeof raw?.workflowListDisplayMode === 'string' ? raw.workflowListDisplayMode : '';
-  return isWorkflowListDisplayMode(value) ? value : undefined;
 }
 
 export function WorkflowsWorkspacePage({ payload }: { payload: BootPayload }) {

--- a/frontend/src/lib/workflowListDisplayMode.test.ts
+++ b/frontend/src/lib/workflowListDisplayMode.test.ts
@@ -118,7 +118,7 @@ describe('resolveWorkflowListDisplay', () => {
   it('navigates detail routes and create to the workflows table for table mode', () => {
     expect(resolveWorkflowListDisplay({
       pathname: '/workflows/mm%3A123/debug',
-      search: '?source=temporal&limit=10',
+      search: '?source=temporal&limit=10&token=secret&unsafe=1',
       requestedMode: 'table',
     })).toMatchObject({
       effectiveMode: 'table',

--- a/frontend/src/lib/workflowListDisplayMode.test.ts
+++ b/frontend/src/lib/workflowListDisplayMode.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  WORKFLOW_LIST_DISPLAY_MODES,
+  resolveWorkflowListDisplay,
+  workflowListDisplayModeByValue,
+  type WorkflowListDisplayMode,
+} from './workflowListDisplayMode';
+
+const modeValues = (): WorkflowListDisplayMode[] => WORKFLOW_LIST_DISPLAY_MODES.map((mode) => mode.value);
+
+describe('workflow list display mode registry', () => {
+  it('exposes exactly the canonical hidden, sidebar, and table modes', () => {
+    expect(modeValues()).toEqual(['hidden', 'sidebar', 'table']);
+    expect(WORKFLOW_LIST_DISPLAY_MODES).toHaveLength(3);
+  });
+
+  it('uses canonical labels, icon identities, and list regions without label matching', () => {
+    expect(WORKFLOW_LIST_DISPLAY_MODES).toEqual([
+      { value: 'hidden', label: 'No list', icon: 'Square', listRegion: 'none' },
+      { value: 'sidebar', label: 'Sidebar list', icon: 'PanelLeft', listRegion: 'sidebar' },
+      { value: 'table', label: 'Full screen table', icon: 'Rows3', listRegion: 'primary-surface' },
+    ]);
+    expect(workflowListDisplayModeByValue('hidden')?.label).toBe('No list');
+    expect(workflowListDisplayModeByValue('No list')).toBeNull();
+  });
+});
+
+describe('resolveWorkflowListDisplay', () => {
+  it('returns the full declarative shape for the workflows table route', () => {
+    expect(resolveWorkflowListDisplay({ pathname: '/workflows', requestedMode: 'table' })).toEqual({
+      requestedMode: 'table',
+      effectiveMode: 'table',
+      surface: 'workflows-table',
+      routeAction: 'none',
+      primarySurface: 'workflow-table',
+      listSurface: 'table',
+      selection: { workflowId: null, source: 'none' },
+      targetPath: '/workflows',
+      status: null,
+    });
+  });
+
+  it('opens the selected workflow from /workflows for hidden and sidebar modes', () => {
+    for (const requestedMode of ['hidden', 'sidebar'] as const) {
+      expect(resolveWorkflowListDisplay({
+        pathname: '/workflows',
+        requestedMode,
+        selectedWorkflowId: 'mm:selected',
+        search: '?source=temporal',
+      })).toMatchObject({
+        requestedMode,
+        effectiveMode: requestedMode,
+        surface: 'workflows-table',
+        routeAction: 'navigate-selected-detail',
+        primarySurface: 'workflow-detail',
+        listSurface: requestedMode === 'hidden' ? 'none' : 'sidebar',
+        selection: { workflowId: 'mm:selected', source: 'last-selected' },
+        targetPath: '/workflows/mm%3Aselected?source=temporal',
+      });
+    }
+  });
+
+  it('uses the first visible workflow from /workflows when no selected workflow exists', () => {
+    expect(resolveWorkflowListDisplay({
+      pathname: '/workflows',
+      requestedMode: 'sidebar',
+      firstVisibleWorkflowId: 'mm:first-visible',
+    })).toMatchObject({
+      effectiveMode: 'sidebar',
+      routeAction: 'resolve-first-workflow',
+      primarySurface: 'workflow-detail',
+      listSurface: 'sidebar',
+      selection: { workflowId: 'mm:first-visible', source: 'first-visible-row' },
+      targetPath: '/workflows/mm%3Afirst-visible',
+    });
+  });
+
+  it('keeps /workflows effective as table when no workflow can be opened', () => {
+    expect(resolveWorkflowListDisplay({ pathname: '/workflows', requestedMode: 'hidden' })).toEqual({
+      requestedMode: 'hidden',
+      effectiveMode: 'table',
+      surface: 'workflows-table',
+      routeAction: 'none',
+      primarySurface: 'empty-workflows',
+      listSurface: 'table',
+      selection: { workflowId: null, source: 'none' },
+      targetPath: '/workflows',
+      status: 'No workflow can be opened from the current list.',
+    });
+  });
+
+  it('preserves detail subroutes when switching only between hidden and sidebar', () => {
+    expect(resolveWorkflowListDisplay({
+      pathname: '/workflows/mm%3A123/steps',
+      search: '?source=temporal',
+      requestedMode: 'hidden',
+    })).toMatchObject({
+      effectiveMode: 'hidden',
+      surface: 'workflow-detail',
+      routeAction: 'none',
+      primarySurface: 'workflow-detail',
+      listSurface: 'none',
+      selection: { workflowId: 'mm:123', source: 'route' },
+      targetPath: '/workflows/mm%3A123/steps?source=temporal',
+    });
+
+    expect(resolveWorkflowListDisplay({
+      pathname: '/workflows/mm%3A123/steps',
+      requestedMode: 'sidebar',
+    })).toMatchObject({
+      effectiveMode: 'sidebar',
+      routeAction: 'none',
+      targetPath: '/workflows/mm%3A123/steps',
+    });
+  });
+
+  it('navigates detail routes and create to the workflows table for table mode', () => {
+    expect(resolveWorkflowListDisplay({
+      pathname: '/workflows/mm%3A123/debug',
+      search: '?source=temporal&limit=10',
+      requestedMode: 'table',
+    })).toMatchObject({
+      effectiveMode: 'table',
+      surface: 'workflow-detail',
+      routeAction: 'navigate-workflows',
+      primarySurface: 'workflow-table',
+      listSurface: 'table',
+      targetPath: '/workflows?source=temporal&limit=10',
+    });
+
+    expect(resolveWorkflowListDisplay({
+      pathname: '/workflows/new',
+      requestedMode: 'table',
+    })).toMatchObject({
+      effectiveMode: 'table',
+      surface: 'workflow-start',
+      routeAction: 'navigate-workflows',
+      primarySurface: 'workflow-table',
+      listSurface: 'table',
+      targetPath: '/workflows',
+    });
+  });
+
+  it('keeps create as primary for hidden and sidebar modes', () => {
+    expect(resolveWorkflowListDisplay({ pathname: '/workflows/new', requestedMode: 'sidebar' })).toMatchObject({
+      effectiveMode: 'sidebar',
+      surface: 'workflow-start',
+      routeAction: 'none',
+      primarySurface: 'workflow-start',
+      listSurface: 'sidebar',
+      targetPath: '/workflows/new',
+    });
+  });
+
+  it('returns null for unsupported dashboard routes', () => {
+    expect(resolveWorkflowListDisplay({ pathname: '/settings', requestedMode: 'table' })).toBeNull();
+  });
+});

--- a/frontend/src/lib/workflowListDisplayMode.ts
+++ b/frontend/src/lib/workflowListDisplayMode.ts
@@ -1,3 +1,5 @@
+import { workflowListContextParams } from './workflowListContext';
+
 export type WorkflowListDisplayMode = 'hidden' | 'sidebar' | 'table';
 
 export type WorkflowListRegion = 'none' | 'sidebar' | 'primary-surface';
@@ -107,6 +109,13 @@ function normalizedSearch(search: string | URLSearchParams | null | undefined): 
 
 function pathWithSearch(pathname: string, search: string | URLSearchParams | null | undefined): string {
   return `${pathname}${normalizedSearch(search)}`;
+}
+
+function workflowListPathFromContext(search: string | URLSearchParams | null | undefined): string {
+  const source = typeof search === 'string' ? new URLSearchParams(search.replace(/^\?/, '')) : search;
+  const params = workflowListContextParams(source ?? new URLSearchParams());
+  const query = params.toString();
+  return query ? `/workflows?${query}` : '/workflows';
 }
 
 function encodeWorkflowDetailPath(workflowId: string, search: string | URLSearchParams | null | undefined): string {
@@ -241,7 +250,7 @@ export function resolveWorkflowListDisplay(
       primarySurface: 'workflow-table',
       listSurface: 'table',
       selection: { workflowId: detail.workflowId, source: 'route' },
-      targetPath: pathWithSearch('/workflows', input.search),
+      targetPath: workflowListPathFromContext(input.search),
       status: null,
     };
   }

--- a/frontend/src/lib/workflowListDisplayMode.ts
+++ b/frontend/src/lib/workflowListDisplayMode.ts
@@ -86,6 +86,12 @@ export function isWorkflowListDisplayMode(value: string): value is WorkflowListD
   return workflowListDisplayModeByValue(value) !== null;
 }
 
+export function readWorkflowListDisplayMode(payload: { initialData?: unknown }): WorkflowListDisplayMode | undefined {
+  const raw = payload.initialData as { workflowListDisplayMode?: unknown } | undefined;
+  const value = typeof raw?.workflowListDisplayMode === 'string' ? raw.workflowListDisplayMode : '';
+  return isWorkflowListDisplayMode(value) ? value : undefined;
+}
+
 function normalizedPathname(pathname: string): string {
   const rawPath = pathname || '/';
   return rawPath.length > 1 && rawPath.endsWith('/') ? rawPath.slice(0, -1) : rawPath;

--- a/frontend/src/lib/workflowListDisplayMode.ts
+++ b/frontend/src/lib/workflowListDisplayMode.ts
@@ -1,0 +1,254 @@
+export type WorkflowListDisplayMode = 'hidden' | 'sidebar' | 'table';
+
+export type WorkflowListRegion = 'none' | 'sidebar' | 'primary-surface';
+
+export type WorkflowListDisplayModeDefinition = {
+  value: WorkflowListDisplayMode;
+  label: string;
+  icon: 'Square' | 'PanelLeft' | 'Rows3';
+  listRegion: WorkflowListRegion;
+};
+
+export type WorkflowListDisplaySurface =
+  | 'workflows-table'
+  | 'workflow-detail'
+  | 'workflow-start';
+
+export type WorkflowListSelection = {
+  workflowId: string | null;
+  source: 'route' | 'last-selected' | 'first-visible-row' | 'none';
+};
+
+export type WorkflowListDisplayRouteAction =
+  | 'none'
+  | 'navigate-workflows'
+  | 'navigate-selected-detail'
+  | 'resolve-first-workflow';
+
+export type WorkflowListDisplayPrimarySurface =
+  | 'workflow-detail'
+  | 'workflow-start'
+  | 'workflow-table'
+  | 'empty-workflows';
+
+export type WorkflowListDisplayListSurface = 'none' | 'sidebar' | 'table';
+
+export type ResolvedWorkflowListDisplay = {
+  requestedMode: WorkflowListDisplayMode;
+  effectiveMode: WorkflowListDisplayMode;
+  surface: WorkflowListDisplaySurface;
+  routeAction: WorkflowListDisplayRouteAction;
+  primarySurface: WorkflowListDisplayPrimarySurface;
+  listSurface: WorkflowListDisplayListSurface;
+  selection: WorkflowListSelection;
+  targetPath: string;
+  status: string | null;
+};
+
+export type ResolveWorkflowListDisplayInput = {
+  pathname: string;
+  requestedMode: WorkflowListDisplayMode;
+  search?: string | URLSearchParams | null;
+  selectedWorkflowId?: string | null;
+  firstVisibleWorkflowId?: string | null;
+};
+
+const DETAIL_TABS = new Set(['steps', 'artifacts', 'runs', 'debug']);
+
+export const WORKFLOW_LIST_DISPLAY_MODES = [
+  {
+    value: 'hidden',
+    label: 'No list',
+    icon: 'Square',
+    listRegion: 'none',
+  },
+  {
+    value: 'sidebar',
+    label: 'Sidebar list',
+    icon: 'PanelLeft',
+    listRegion: 'sidebar',
+  },
+  {
+    value: 'table',
+    label: 'Full screen table',
+    icon: 'Rows3',
+    listRegion: 'primary-surface',
+  },
+] as const satisfies readonly WorkflowListDisplayModeDefinition[];
+
+export function workflowListDisplayModeByValue(
+  value: string,
+): WorkflowListDisplayModeDefinition | null {
+  return WORKFLOW_LIST_DISPLAY_MODES.find((mode) => mode.value === value) ?? null;
+}
+
+export function isWorkflowListDisplayMode(value: string): value is WorkflowListDisplayMode {
+  return workflowListDisplayModeByValue(value) !== null;
+}
+
+function normalizedPathname(pathname: string): string {
+  const rawPath = pathname || '/';
+  return rawPath.length > 1 && rawPath.endsWith('/') ? rawPath.slice(0, -1) : rawPath;
+}
+
+function normalizedSearch(search: string | URLSearchParams | null | undefined): string {
+  if (!search) {
+    return '';
+  }
+  const query = typeof search === 'string' ? search.replace(/^\?/, '') : search.toString();
+  return query ? `?${query}` : '';
+}
+
+function pathWithSearch(pathname: string, search: string | URLSearchParams | null | undefined): string {
+  return `${pathname}${normalizedSearch(search)}`;
+}
+
+function encodeWorkflowDetailPath(workflowId: string, search: string | URLSearchParams | null | undefined): string {
+  return pathWithSearch(`/workflows/${encodeURIComponent(workflowId)}`, search);
+}
+
+function decodeWorkflowDetail(pathname: string): { workflowId: string; subroute: string | null } | null {
+  const parts = normalizedPathname(pathname).split('/').slice(1);
+  if (parts.length !== 2 && parts.length !== 3) {
+    return null;
+  }
+  if (parts[0] !== 'workflows' || parts[1] === 'new') {
+    return null;
+  }
+  let workflowId: string;
+  try {
+    workflowId = decodeURIComponent(parts[1] ?? '');
+  } catch {
+    return null;
+  }
+  if (!workflowId || workflowId.includes('/')) {
+    return null;
+  }
+  const subroute = parts[2] ?? null;
+  if (subroute !== null && !DETAIL_TABS.has(subroute)) {
+    return null;
+  }
+  return { workflowId, subroute };
+}
+
+function selectedWorkflow(input: ResolveWorkflowListDisplayInput): WorkflowListSelection {
+  const selected = input.selectedWorkflowId?.trim();
+  if (selected) {
+    return { workflowId: selected, source: 'last-selected' };
+  }
+  const first = input.firstVisibleWorkflowId?.trim();
+  if (first) {
+    return { workflowId: first, source: 'first-visible-row' };
+  }
+  return { workflowId: null, source: 'none' };
+}
+
+export function resolveWorkflowListDisplay(
+  input: ResolveWorkflowListDisplayInput,
+): ResolvedWorkflowListDisplay | null {
+  const pathname = normalizedPathname(input.pathname);
+  const requestedMode = input.requestedMode;
+
+  if (pathname === '/workflows') {
+    if (requestedMode === 'table') {
+      return {
+        requestedMode,
+        effectiveMode: 'table',
+        surface: 'workflows-table',
+        routeAction: 'none',
+        primarySurface: 'workflow-table',
+        listSurface: 'table',
+        selection: { workflowId: null, source: 'none' },
+        targetPath: pathWithSearch('/workflows', input.search),
+        status: null,
+      };
+    }
+
+    const selection = selectedWorkflow(input);
+    if (selection.workflowId) {
+      return {
+        requestedMode,
+        effectiveMode: requestedMode,
+        surface: 'workflows-table',
+        routeAction: selection.source === 'first-visible-row'
+          ? 'resolve-first-workflow'
+          : 'navigate-selected-detail',
+        primarySurface: 'workflow-detail',
+        listSurface: requestedMode === 'hidden' ? 'none' : 'sidebar',
+        selection,
+        targetPath: encodeWorkflowDetailPath(selection.workflowId, input.search),
+        status: null,
+      };
+    }
+
+    return {
+      requestedMode,
+      effectiveMode: 'table',
+      surface: 'workflows-table',
+      routeAction: 'none',
+      primarySurface: 'empty-workflows',
+      listSurface: 'table',
+      selection,
+      targetPath: pathWithSearch('/workflows', input.search),
+      status: 'No workflow can be opened from the current list.',
+    };
+  }
+
+  if (pathname === '/workflows/new') {
+    if (requestedMode === 'table') {
+      return {
+        requestedMode,
+        effectiveMode: 'table',
+        surface: 'workflow-start',
+        routeAction: 'navigate-workflows',
+        primarySurface: 'workflow-table',
+        listSurface: 'table',
+        selection: { workflowId: null, source: 'none' },
+        targetPath: '/workflows',
+        status: null,
+      };
+    }
+    return {
+      requestedMode,
+      effectiveMode: requestedMode,
+      surface: 'workflow-start',
+      routeAction: 'none',
+      primarySurface: 'workflow-start',
+      listSurface: requestedMode === 'hidden' ? 'none' : 'sidebar',
+      selection: { workflowId: null, source: 'none' },
+      targetPath: pathWithSearch('/workflows/new', input.search),
+      status: null,
+    };
+  }
+
+  const detail = decodeWorkflowDetail(pathname);
+  if (!detail) {
+    return null;
+  }
+
+  if (requestedMode === 'table') {
+    return {
+      requestedMode,
+      effectiveMode: 'table',
+      surface: 'workflow-detail',
+      routeAction: 'navigate-workflows',
+      primarySurface: 'workflow-table',
+      listSurface: 'table',
+      selection: { workflowId: detail.workflowId, source: 'route' },
+      targetPath: pathWithSearch('/workflows', input.search),
+      status: null,
+    };
+  }
+
+  return {
+    requestedMode,
+    effectiveMode: requestedMode,
+    surface: 'workflow-detail',
+    routeAction: 'none',
+    primarySurface: 'workflow-detail',
+    listSurface: requestedMode === 'hidden' ? 'none' : 'sidebar',
+    selection: { workflowId: detail.workflowId, source: 'route' },
+    targetPath: pathWithSearch(pathname, input.search),
+    status: null,
+  };
+}

--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -7402,6 +7402,10 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
   margin-inline: auto;
 }
 
+.workflow-workspace-shell[data-sidebar-collapsed="true"] .workflow-workspace-detail {
+  grid-column: 1 / -1;
+}
+
 @media (min-width: 768px) and (max-width: 85rem) {
   .workflow-workspace-shell[data-sidebar-collapsed="true"] {
     grid-template-columns: auto minmax(0, 1fr);

--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -322,7 +322,7 @@ samp {
 }
 
 .workflow-list-display-option--selected,
-.workflow-list-display-option[aria-checked="true"] {
+.workflow-list-display-option[aria-pressed="true"] {
   border-color: rgb(var(--mm-accent) / 0.6);
   background: rgb(var(--mm-accent) / 0.14);
   color: rgb(var(--mm-accent));

--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -278,6 +278,63 @@ samp {
   color: inherit;
 }
 
+.workflow-list-display-control {
+  display: inline-flex;
+  align-items: center;
+  justify-self: start;
+  gap: 0.25rem;
+  min-width: 0;
+  padding: 0.18rem;
+  border: 1px solid rgb(var(--mm-border) / 0.7);
+  border-radius: 0.55rem;
+  background: rgb(var(--mm-panel) / 0.68);
+}
+
+.workflow-list-display-option {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  min-width: 2rem;
+  padding: 0;
+  border: 1px solid transparent;
+  border-radius: 0.42rem;
+  background: transparent;
+  color: rgb(var(--mm-muted));
+  box-shadow: none;
+  transform: none;
+  filter: none;
+}
+
+.workflow-list-display-option:hover,
+.workflow-list-display-option:focus-visible {
+  border-color: rgb(var(--mm-accent) / 0.45);
+  background: rgb(var(--mm-accent) / 0.1);
+  color: rgb(var(--mm-ink));
+  transform: none;
+  filter: none;
+}
+
+.workflow-list-display-option:focus-visible {
+  outline: none;
+  box-shadow: var(--mm-control-focus-ring);
+}
+
+.workflow-list-display-option--selected,
+.workflow-list-display-option[aria-checked="true"] {
+  border-color: rgb(var(--mm-accent) / 0.6);
+  background: rgb(var(--mm-accent) / 0.14);
+  color: rgb(var(--mm-accent));
+}
+
+.workflow-list-display-option svg {
+  width: 0.95rem;
+  height: 0.95rem;
+  flex: 0 0 auto;
+  stroke-width: 2;
+}
+
 .masthead-title-meta {
   display: flex;
   align-items: center;
@@ -7208,95 +7265,6 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
   border-right: 1px solid rgb(var(--mm-border) / 0.55);
 }
 
-.workflow-workspace-sidebar-controls {
-  display: flex;
-  gap: 0.4rem;
-  align-items: center;
-  justify-content: space-between;
-  padding-bottom: 0.4rem;
-}
-
-/* Shared icon-button styling for compact workflow sidebar controls. */
-.workflow-workspace-sidebar-control {
-  background: rgb(var(--mm-panel));
-  background-image: linear-gradient(145deg, rgb(var(--mm-panel) / 0.95), rgb(var(--mm-panel) / 0.65));
-  border-color: rgb(var(--mm-border) / 0.7);
-  box-shadow: 0 10px 25px -18px rgb(var(--mm-ink) / 0.8);
-  transform-origin: center;
-}
-
-/* The sidebar controls are compact icon buttons rather than full-text buttons. */
-.workflow-workspace-expand-list,
-.workflow-workspace-close-sidebar,
-.workflow-workspace-open-sidebar {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 2rem;
-  height: 2rem;
-  padding: 0;
-  border: 1px solid rgb(var(--mm-border));
-  border-radius: 0.5rem;
-  background: rgb(var(--mm-panel));
-  color: rgb(var(--mm-ink));
-  flex: 0 0 auto;
-  text-decoration: none;
-  transition: var(--mm-control-transition);
-}
-
-.workflow-workspace-sidebar-control:hover,
-.workflow-workspace-sidebar-control:focus-visible {
-  background-image: linear-gradient(145deg, rgb(var(--mm-accent) / 0.35), rgb(var(--mm-accent-2) / 0.25));
-  color: rgb(var(--mm-ink));
-  border-color: rgb(var(--mm-accent));
-  box-shadow: inset 0 1px 0 rgb(255 255 255 / 0.28), 0 12px 24px -14px rgb(var(--mm-accent) / 0.78);
-  transform: scale(var(--mm-control-hover-scale));
-  filter: brightness(1.08) saturate(1.04);
-}
-
-.workflow-workspace-sidebar-control:active,
-.workflow-workspace-sidebar-control.is-clicked {
-  background-image: linear-gradient(145deg, rgb(var(--mm-accent) / 0.5), rgb(var(--mm-accent-2) / 0.4));
-  box-shadow:
-    inset 0 1px 0 rgb(255 255 255 / 0.42),
-    0 0 0 1px rgb(255 255 255 / 0.56),
-    0 0 14px 1px rgb(var(--mm-accent) / 0.76);
-  transform: scale(var(--mm-control-press-scale));
-  filter: brightness(1.2) saturate(1.12);
-}
-
-.workflow-workspace-sidebar-control:disabled,
-.workflow-workspace-sidebar-control:disabled:hover {
-  opacity: var(--mm-control-disabled-opacity);
-  cursor: not-allowed;
-  background: rgb(var(--mm-panel) / 0.4);
-  border-color: rgb(var(--mm-border) / 0.4);
-  box-shadow: none;
-  transform: none;
-  filter: none;
-}
-
-.workflow-workspace-sidebar-control:focus-visible {
-  outline: none;
-  box-shadow:
-    var(--mm-control-focus-ring),
-    inset 0 1px 0 rgb(255 255 255 / 0.28),
-    0 12px 24px -14px rgb(var(--mm-accent) / 0.78);
-}
-
-.workflow-workspace-control-icon,
-.workflow-workspace-expand-list svg {
-  width: 1.05rem;
-  height: 1.05rem;
-  flex: 0 0 auto;
-  fill: none;
-  stroke: currentcolor;
-  stroke-width: 2;
-  stroke-linecap: round;
-  stroke-linejoin: round;
-}
-
-
 .workflow-workspace-sidebar-list {
   display: flex;
   flex-direction: column;
@@ -7434,12 +7402,6 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
   margin-inline: auto;
 }
 
-.workflow-workspace-open-sidebar {
-  justify-self: start;
-  align-self: start;
-  margin-bottom: 0.75rem;
-}
-
 @media (min-width: 768px) and (max-width: 85rem) {
   .workflow-workspace-shell[data-sidebar-collapsed="true"] {
     grid-template-columns: auto minmax(0, 1fr);
@@ -7456,7 +7418,6 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
 
 @media (prefers-reduced-motion: reduce) {
   .workflow-workspace-sidebar,
-  .workflow-workspace-open-sidebar,
   .workflow-workspace-detail {
     transition-duration: 1ms !important;
     animation-duration: 1ms !important;
@@ -7515,8 +7476,7 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
     max-width: none;
   }
 
-  .workflow-workspace-sidebar,
-  .workflow-workspace-open-sidebar {
+  .workflow-workspace-sidebar {
     display: none;
   }
 
@@ -7583,7 +7543,6 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
 @media (prefers-reduced-motion: reduce) {
   .workflow-workspace-shell,
   .workflow-workspace-sidebar,
-  .workflow-workspace-open-sidebar,
   .workflow-workspace-detail {
     transition: none !important;
     animation: none !important;


### PR DESCRIPTION
## Jira
- Issue: MM-1112
- Active MoonSpec feature path: specs/001-workflow-list-modes/spec.md

## Verification
- Verdict: FULLY_IMPLEMENTED
- Verification artifact: var/artifacts/moonspec-verify/jira-orchestrate.json

## Tests Run
- PASS: ./tools/test_unit.sh --dashboard-only --ui-args frontend/src/lib/workflowListDisplayMode.test.ts frontend/src/entrypoints/dashboard.test.tsx frontend/src/entrypoints/workflow-detail.test.tsx frontend/src/entrypoints/workflows-workspace.test.tsx frontend/src/entrypoints/workflow-start.test.tsx
- PASS: ./node_modules/.bin/tsc --noEmit -p frontend/tsconfig.json
- PASS: ./node_modules/.bin/eslint -c frontend/eslint.config.mjs frontend/src/lib/workflowListDisplayMode.ts frontend/src/lib/workflowListDisplayMode.test.ts frontend/src/entrypoints/dashboard-app.tsx frontend/src/entrypoints/dashboard.test.tsx frontend/src/entrypoints/workflow-detail.tsx frontend/src/entrypoints/workflow-detail.test.tsx frontend/src/entrypoints/workflows-workspace.tsx frontend/src/entrypoints/workflows-workspace.test.tsx frontend/src/entrypoints/workflow-start.tsx frontend/src/entrypoints/workflow-start.test.tsx
- NOT RUN: Hermetic integration; not selected by impact because this is frontend state/routing/presentation work only.
- NOTE: Full unit wrapper attempt failed before frontend tests in tools/status_domain_audit.py because .specify/templates/spec-template.md target was unavailable to pathlib.read_text in that precheck; the dashboard-only selector passed.

## Doc Reconciliation Outcome
- artifacts/jira-orchestrate-doc-reconcile.json reported no canonical doc update required.
- Canonical doc path reviewed: docs/UI/WorkflowListDisplayModes.md
- Rationale: sourceDocumentDrift was empty, canonical claim coverage had driftStatus NONE for all MM-1112 claims, and no doc-discovery ledger required a doc change.

## Documentation Conformance
- Canonical sources: docs/UI/WorkflowListDisplayModes.md; README.md; AGENTS.md.
- Temporary artifacts consulted: specs/001-workflow-list-modes/spec.md; artifacts/jira-orchestrate-brief.json; var/artifacts/moonspec-verify/jira-orchestrate.json; artifacts/jira-orchestrate-doc-reconcile.json.
- Claim coverage: CLAIM-docs-ui-workflowlistdisplaymodes-001 through CLAIM-docs-ui-workflowlistdisplaymodes-004 verified with driftStatus NONE.
- Reconciliation outcomes: no canonical document edits were required and no escalation Jira issue was created.

## Remaining Risks
- The full unit wrapper still has an environment/precheck issue unrelated to the frontend selector: .specify/templates/spec-template.md could not be read through its symlink target during status_domain_audit.py.
- jsdom emitted non-fatal canvas getContext notices during focused frontend tests.
