### PR TITLE
[codex] Compact MoonSpec terminal metadata

### DIFF
--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -7108,6 +7108,129 @@ class TemporalAgentRuntimeActivities:
                 )
             return None
 
+        def _compact_moonspec_verify_metadata(
+            gate_payload: Mapping[str, Any],
+            *,
+            gate_result_ref: str,
+            contract_violations: Sequence[str],
+        ) -> dict[str, Any]:
+            """Return the compact gate projection safe to carry in workflow history."""
+
+            def _text(value: Any, *, max_chars: int = 700) -> str | None:
+                if not isinstance(value, str):
+                    return None
+                text = value.strip()
+                if not text:
+                    return None
+                if len(text) > max_chars:
+                    return text[: max_chars - 3].rstrip() + "..."
+                return text
+
+            def _scalar(value: Any) -> Any:
+                if isinstance(value, str):
+                    return _text(value)
+                if value is None or isinstance(value, (bool, int, float)):
+                    return value
+                return None
+
+            def _text_list(
+                value: Any,
+                *,
+                max_items: int = 20,
+                max_chars: int = 400,
+            ) -> list[str]:
+                if not isinstance(value, list):
+                    return []
+                compact: list[str] = []
+                for item in value:
+                    text = _text(item, max_chars=max_chars)
+                    if text:
+                        compact.append(text)
+                    if len(compact) >= max_items:
+                        break
+                return compact
+
+            def _text_mapping(value: Any) -> dict[str, str]:
+                if not isinstance(value, Mapping):
+                    return {}
+                compact: dict[str, str] = {}
+                for raw_key, raw_value in value.items():
+                    key = _text(str(raw_key), max_chars=120)
+                    text = _text(raw_value, max_chars=400)
+                    if key and text:
+                        compact[key] = text
+                    if len(compact) >= 20:
+                        break
+                return compact
+
+            compact: dict[str, Any] = {"gateResultRef": gate_result_ref}
+            scalar_keys = (
+                "schemaVersion",
+                "verdict",
+                "gateVerdict",
+                "gate_verdict",
+                "moonSpecVerdict",
+                "moonspecVerdict",
+                "verificationVerdict",
+                "verification_verdict",
+                "confidence",
+                "recommendedNextAction",
+                "recommended_next_action",
+                "targetLogicalStepId",
+                "target_logical_step_id",
+                "workspacePolicyRecommendation",
+                "workspace_policy_recommendation",
+                "recoverableInCurrentRuntime",
+                "recoverable_in_current_runtime",
+                "invalid",
+                "degraded",
+                "remainingWorkRef",
+                "remaining_work_ref",
+                "diagnosticsRef",
+                "diagnostics_ref",
+                "verificationReportRef",
+                "verification_report_ref",
+                "reportRef",
+                "report_ref",
+            )
+            for key in scalar_keys:
+                value = _scalar(gate_payload.get(key))
+                if value is not None:
+                    compact[key] = value
+
+            for key in ("feedback", "summary", "message", "downgradeReason"):
+                value = _text(gate_payload.get(key), max_chars=900)
+                if value:
+                    compact[key] = value
+
+            for key in ("invalidatedRefs", "invalidated_refs"):
+                refs = _text_list(gate_payload.get(key))
+                if refs:
+                    compact[key] = refs
+                    break
+            for key in ("blockingEvidenceRefs", "blocking_evidence_refs"):
+                refs = _text_list(gate_payload.get(key))
+                if refs:
+                    compact[key] = refs
+                    break
+
+            validated_refs = _text_mapping(
+                gate_payload.get("validatedRefs")
+                or gate_payload.get("validated_refs")
+            )
+            if validated_refs:
+                compact["validatedRefs"] = validated_refs
+
+            compact_violations = _text_list(
+                list(contract_violations),
+                max_items=10,
+                max_chars=700,
+            )
+            if compact_violations:
+                compact["contractViolations"] = compact_violations
+
+            return compact
+
         async def _publish_moonspec_verify_artifact() -> dict[str, Any]:
             verify_path = _metadata_text(
                 "verify_artifact_path",
@@ -7182,8 +7305,13 @@ class TemporalAgentRuntimeActivities:
                 },
             )
             gate_payload["gateResultRef"] = verify_ref.artifact_id
+            compact_gate_payload = _compact_moonspec_verify_metadata(
+                gate_payload,
+                gate_result_ref=verify_ref.artifact_id,
+                contract_violations=contract_violations,
+            )
             return {
-                "moonSpecVerify": gate_payload,
+                "moonSpecVerify": compact_gate_payload,
                 "gateResultRef": verify_ref.artifact_id,
                 "moonSpecVerifyArtifactRef": verify_ref.artifact_id,
             }

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -7139,7 +7139,7 @@ class TemporalAgentRuntimeActivities:
                 max_items: int = 20,
                 max_chars: int = 400,
             ) -> list[str]:
-                if not isinstance(value, list):
+                if not isinstance(value, (list, tuple)):
                     return []
                 compact: list[str] = []
                 for item in value:

--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -147,7 +147,7 @@ def _compact_workflow_text_list(
     max_items: int = 20,
     max_chars: int = 400,
 ) -> list[str]:
-    if not isinstance(value, list):
+    if not isinstance(value, (list, tuple)):
         return []
     compact: list[str] = []
     for item in value:

--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -121,6 +121,158 @@ def _setdefault_compact_ref_metadata(
     for key, compact_value in compact_temporal_ref_metadata(field_name, value).items():
         metadata.setdefault(key, compact_value)
 
+
+def _compact_workflow_text(value: Any, *, max_chars: int = 700) -> str | None:
+    if not isinstance(value, str):
+        return None
+    text = value.strip()
+    if not text:
+        return None
+    if len(text) > max_chars:
+        return text[: max_chars - 3].rstrip() + "..."
+    return text
+
+
+def _compact_workflow_scalar(value: Any) -> Any:
+    if isinstance(value, str):
+        return _compact_workflow_text(value)
+    if value is None or isinstance(value, (bool, int, float)):
+        return value
+    return None
+
+
+def _compact_workflow_text_list(
+    value: Any,
+    *,
+    max_items: int = 20,
+    max_chars: int = 400,
+) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    compact: list[str] = []
+    for item in value:
+        text = _compact_workflow_text(item, max_chars=max_chars)
+        if text:
+            compact.append(text)
+        if len(compact) >= max_items:
+            break
+    return compact
+
+
+def _compact_workflow_text_mapping(value: Any) -> dict[str, str]:
+    if not isinstance(value, Mapping):
+        return {}
+    compact: dict[str, str] = {}
+    for raw_key, raw_value in value.items():
+        key = _compact_workflow_text(str(raw_key), max_chars=120)
+        text = _compact_workflow_text(raw_value, max_chars=400)
+        if key and text:
+            compact[key] = text
+        if len(compact) >= 20:
+            break
+    return compact
+
+
+def _compact_moonspec_verify_for_workflow_history(
+    value: Mapping[str, Any],
+) -> dict[str, Any]:
+    compact: dict[str, Any] = {}
+    scalar_keys = (
+        "schemaVersion",
+        "verdict",
+        "gateVerdict",
+        "gate_verdict",
+        "moonSpecVerdict",
+        "moonspecVerdict",
+        "verificationVerdict",
+        "verification_verdict",
+        "confidence",
+        "recommendedNextAction",
+        "recommended_next_action",
+        "targetLogicalStepId",
+        "target_logical_step_id",
+        "workspacePolicyRecommendation",
+        "workspace_policy_recommendation",
+        "recoverableInCurrentRuntime",
+        "recoverable_in_current_runtime",
+        "invalid",
+        "degraded",
+        "remainingWorkRef",
+        "remaining_work_ref",
+        "diagnosticsRef",
+        "diagnostics_ref",
+        "verificationReportRef",
+        "verification_report_ref",
+        "reportRef",
+        "report_ref",
+        "gateResultRef",
+        "gate_result_ref",
+        "artifactRef",
+        "artifact_ref",
+    )
+    for key in scalar_keys:
+        field_value = _compact_workflow_scalar(value.get(key))
+        if field_value is not None:
+            compact[key] = field_value
+
+    for key in ("feedback", "summary", "message", "downgradeReason"):
+        text = _compact_workflow_text(value.get(key), max_chars=900)
+        if text:
+            compact[key] = text
+
+    for key in ("invalidatedRefs", "invalidated_refs"):
+        refs = _compact_workflow_text_list(value.get(key))
+        if refs:
+            compact[key] = refs
+            break
+    for key in ("blockingEvidenceRefs", "blocking_evidence_refs"):
+        refs = _compact_workflow_text_list(value.get(key))
+        if refs:
+            compact[key] = refs
+            break
+
+    validated_refs = _compact_workflow_text_mapping(
+        value.get("validatedRefs") or value.get("validated_refs")
+    )
+    if validated_refs:
+        compact["validatedRefs"] = validated_refs
+
+    contract_violations = _compact_workflow_text_list(
+        value.get("contractViolations") or value.get("contract_violations"),
+        max_items=10,
+        max_chars=700,
+    )
+    if contract_violations:
+        compact["contractViolations"] = contract_violations
+
+    return compact
+
+
+def _compact_agent_run_result_payload_for_workflow_history(
+    payload: Mapping[str, Any],
+) -> dict[str, Any]:
+    compact_payload = dict(payload)
+    metadata = compact_payload.get("metadata")
+    if not isinstance(metadata, Mapping):
+        return compact_payload
+
+    compact_metadata = dict(metadata)
+    for key in (
+        "moonSpecVerify",
+        "moonspecVerify",
+        "moonspec_verify",
+        "verificationResult",
+        "verification_result",
+    ):
+        value = compact_metadata.get(key)
+        if isinstance(value, Mapping):
+            compact_metadata[key] = _compact_moonspec_verify_for_workflow_history(
+                value
+            )
+    compact_payload["metadata"] = compact_metadata
+    return compact_payload
+
+
 # Default workflow-level execution timeouts
 DEFAULT_MANAGED_TIMEOUT_SECONDS = 3600      # 1 hour
 DEFAULT_EXTERNAL_TIMEOUT_SECONDS = 21600    # 6 hours
@@ -446,6 +598,7 @@ class MoonMindAgentRun:
         self._slot_wait_timeout_override_seconds: int | None = None
         self._skip_default_profile_pin_once: bool = False
         self._provider_cooldown_retry_counts: dict[str, int] = {}
+        self._terminal_result_payload_compacted_for_history: bool = False
         self.runtime_selection_updated_event = asyncio.Event()
         self._pending_runtime_selection_update: dict[str, Any] | None = None
         self._paused: bool = False
@@ -1206,12 +1359,47 @@ class MoonMindAgentRun:
 
         return result.model_copy(update={"metadata": metadata})
 
+    async def _publish_terminal_result_with_compacted_replay_cleanup(
+        self,
+        *,
+        request: AgentExecutionRequest,
+        result: AgentRunResult,
+        manager_handle: Any | None = None,
+    ) -> AgentRunResult:
+        terminal_result = await self._publish_terminal_result(
+            request=request,
+            result=result,
+        )
+        if (
+            self._terminal_result_payload_compacted_for_history
+            and request.agent_kind == "managed"
+            and request.execution_profile_ref
+        ):
+            handle = manager_handle
+            if handle is None:
+                runtime_id = self._managed_runtime_id(request.agent_id)
+                manager_id = self._manager_workflow_id(runtime_id)
+                handle = workflow.get_external_workflow_handle(manager_id)
+            # Preserve replay for histories where oversized terminal metadata
+            # raised after artifact publication and the old exception cleanup
+            # emitted this idempotent slot release before failing the task.
+            await handle.signal(
+                "release_slot",
+                self._release_slot_payload(
+                    profile_id=request.execution_profile_ref,
+                    request=request,
+                ),
+            )
+            self._terminal_result_payload_compacted_for_history = False
+        return terminal_result
+
     async def _publish_terminal_result(
         self,
         *,
         request: AgentExecutionRequest,
         result: AgentRunResult,
     ) -> AgentRunResult:
+        self._terminal_result_payload_compacted_for_history = False
         self.final_result = self._enrich_result_metadata(
             request=request,
             result=result,
@@ -1229,7 +1417,18 @@ class MoonMindAgentRun:
                 and "diagnostics_ref" in enriched_result
             ):
                 del enriched_result["diagnostics_ref"]
-            self.final_result = AgentRunResult(**enriched_result)
+            try:
+                self.final_result = AgentRunResult(**enriched_result)
+            except ValueError:
+                compacted_result = (
+                    _compact_agent_run_result_payload_for_workflow_history(
+                        enriched_result
+                    )
+                )
+                if compacted_result == enriched_result:
+                    raise
+                self._terminal_result_payload_compacted_for_history = True
+                self.final_result = AgentRunResult(**compacted_result)
         return self.final_result
 
     def _record_provider_native_pr_metadata(
@@ -2820,7 +3019,7 @@ class MoonMindAgentRun:
                 elapsed = (workflow.now() - overall_start).total_seconds()
                 if elapsed >= timeout_seconds:
                     self.run_status = RunStatus.timed_out
-                    return await self._publish_terminal_result(
+                    return await self._publish_terminal_result_with_compacted_replay_cleanup(
                         request=request,
                         result=self._timed_out_result(
                             request=request,
@@ -3763,7 +3962,7 @@ class MoonMindAgentRun:
                                 request=request,
                             ),
                         )
-                    return await self._publish_terminal_result(
+                    return await self._publish_terminal_result_with_compacted_replay_cleanup(
                         request=request,
                         result=self._timed_out_result(
                             request=request,
@@ -4065,9 +4264,10 @@ class MoonMindAgentRun:
                         update={"metadata": result_metadata}
                     )
 
-                return await self._publish_terminal_result(
+                return await self._publish_terminal_result_with_compacted_replay_cleanup(
                     request=request,
                     result=self.final_result,
+                    manager_handle=manager_handle,
                 )
 
         except asyncio.TimeoutError:

--- a/tests/unit/workflows/temporal/test_activity_runtime.py
+++ b/tests/unit/workflows/temporal/test_activity_runtime.py
@@ -4958,6 +4958,7 @@ async def test_agent_runtime_publish_artifacts_publishes_moonspec_verify_json(
             workspace = tmp_path / "workspace"
             verify_path = workspace / "var/artifacts/moonspec-verify/final.json"
             verify_path.parent.mkdir(parents=True)
+            large_evidence = "verified evidence " * 2000
             verify_path.write_text(
                 json.dumps(
                     {
@@ -4966,6 +4967,12 @@ async def test_agent_runtime_publish_artifacts_publishes_moonspec_verify_json(
                         "recommendedNextAction": "advance",
                         "recoverableInCurrentRuntime": True,
                         "remainingWork": [],
+                        "requirementCoverage": [
+                            {
+                                "requirement": "large verification evidence",
+                                "evidence": large_evidence,
+                            }
+                        ],
                     }
                 ),
                 encoding="utf-8",
@@ -5030,6 +5037,17 @@ async def test_agent_runtime_publish_artifacts_publishes_moonspec_verify_json(
                 result.metadata["gateResultRef"]
             )
             assert "contractViolations" not in result.metadata["moonSpecVerify"]
+            assert "requirementCoverage" not in result.metadata["moonSpecVerify"]
+            AgentRunResult(**result.model_dump(mode="json", by_alias=True))
+
+            _artifact, artifact_path = await service.read_path(
+                artifact_id=result.metadata["gateResultRef"],
+                principal="system:agent_runtime",
+            )
+            persisted_payload = json.loads(artifact_path.read_text(encoding="utf-8"))
+            assert persisted_payload["requirementCoverage"][0]["evidence"] == (
+                large_evidence
+            )
 
 
 async def test_agent_runtime_publish_artifacts_flags_moonspec_contract_violations(
@@ -5107,6 +5125,7 @@ async def test_agent_runtime_publish_artifacts_flags_moonspec_contract_violation
 
             violations = result.metadata["moonSpecVerify"]["contractViolations"]
             assert any("create_pull_request" in item for item in violations)
+            AgentRunResult(**result.model_dump(mode="json", by_alias=True))
 
 
 async def test_agent_runtime_publish_artifacts_uses_last_assistant_text_for_report_body(

--- a/tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py
@@ -82,6 +82,108 @@ async def test_managed_session_request_preserves_explicit_empty_inputs() -> None
     assert request.parameters == {}
     assert request.workspace_spec == {}
 
+
+async def test_publish_terminal_result_compacts_replayed_moonspec_verify_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _configure_workflow_runtime(monkeypatch)
+    run = MoonMindAgentRun()
+    request = _managed_session_request()
+    large_evidence = "verified evidence " * 2000
+
+    async def fake_publish_activity(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+        return {
+            "summary": "Completed.",
+            "outputRefs": [],
+            "diagnosticsRef": "art_agent_result",
+            "metadata": {
+                "gateResultRef": "art_gate_result",
+                "moonSpecVerifyArtifactRef": "art_gate_result",
+                "moonSpecVerify": {
+                    "schemaVersion": 1,
+                    "verdict": "FULLY_IMPLEMENTED",
+                    "recommendedNextAction": "advance",
+                    "recoverableInCurrentRuntime": True,
+                    "remainingWork": [],
+                    "requirementCoverage": [
+                        {
+                            "requirement": "large verification evidence",
+                            "evidence": large_evidence,
+                        }
+                    ],
+                    "gateResultRef": "art_gate_result",
+                },
+            },
+        }
+
+    run._execute_routed_activity = fake_publish_activity  # type: ignore[method-assign]
+
+    result = await run._publish_terminal_result(
+        request=request,
+        result=AgentRunResult(summary="Completed."),
+    )
+
+    assert result.metadata["moonSpecVerify"]["verdict"] == "FULLY_IMPLEMENTED"
+    assert result.metadata["moonSpecVerify"]["gateResultRef"] == "art_gate_result"
+    assert "requirementCoverage" not in result.metadata["moonSpecVerify"]
+    assert run._terminal_result_payload_compacted_for_history is True
+    AgentRunResult(**result.model_dump(mode="json", by_alias=True))
+
+
+async def test_publish_terminal_result_releases_slot_after_compacted_replay_cleanup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _configure_workflow_runtime(monkeypatch)
+    run = MoonMindAgentRun()
+    request = _managed_session_request()
+    large_evidence = "verified evidence " * 2000
+    signals: list[tuple[str, dict[str, Any]]] = []
+
+    class FakeManagerHandle:
+        async def signal(self, name: str, payload: dict[str, Any]) -> None:
+            signals.append((name, payload))
+
+    async def fake_publish_activity(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+        return {
+            "summary": "Completed.",
+            "outputRefs": [],
+            "diagnosticsRef": "art_agent_result",
+            "metadata": {
+                "moonSpecVerify": {
+                    "verdict": "FULLY_IMPLEMENTED",
+                    "recommendedNextAction": "advance",
+                    "requirementCoverage": [
+                        {
+                            "requirement": "large verification evidence",
+                            "evidence": large_evidence,
+                        }
+                    ],
+                    "gateResultRef": "art_gate_result",
+                },
+            },
+        }
+
+    run._execute_routed_activity = fake_publish_activity  # type: ignore[method-assign]
+
+    result = await run._publish_terminal_result_with_compacted_replay_cleanup(
+        request=request,
+        result=AgentRunResult(summary="Completed."),
+        manager_handle=FakeManagerHandle(),
+    )
+
+    assert result.metadata["moonSpecVerify"]["verdict"] == "FULLY_IMPLEMENTED"
+    assert run._terminal_result_payload_compacted_for_history is False
+    assert signals == [
+        (
+            "release_slot",
+            {
+                "requester_workflow_id": "wf-agent-run-1",
+                "profile_id": "codex-default",
+            },
+        )
+    ]
+
+
 async def test_profile_resolution_error_summarizes_setup_condition() -> None:
     run = MoonMindAgentRun()
     request = _managed_session_request().model_copy(

--- a/tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py
@@ -105,6 +105,7 @@ async def test_publish_terminal_result_compacts_replayed_moonspec_verify_metadat
                     "recommendedNextAction": "advance",
                     "recoverableInCurrentRuntime": True,
                     "remainingWork": [],
+                    "blockingEvidenceRefs": ("ref-a", "ref-b"),
                     "requirementCoverage": [
                         {
                             "requirement": "large verification evidence",
@@ -125,6 +126,10 @@ async def test_publish_terminal_result_compacts_replayed_moonspec_verify_metadat
 
     assert result.metadata["moonSpecVerify"]["verdict"] == "FULLY_IMPLEMENTED"
     assert result.metadata["moonSpecVerify"]["gateResultRef"] == "art_gate_result"
+    assert result.metadata["moonSpecVerify"]["blockingEvidenceRefs"] == [
+        "ref-a",
+        "ref-b",
+    ]
     assert "requirementCoverage" not in result.metadata["moonSpecVerify"]
     assert run._terminal_result_payload_compacted_for_history is True
     AgentRunResult(**result.model_dump(mode="json", by_alias=True))


### PR DESCRIPTION
## Summary

- Compact MoonSpec verification metadata before returning it from `agent_runtime.publish_artifacts`, while preserving the full verification JSON as an artifact.
- Add workflow-side compaction for already-recorded oversized terminal activity results so old histories can replay safely.
- Preserve the historical idempotent slot-release cleanup path when replaying old oversized terminal payload failures.

## Root Cause

A MoonSpec verification run returned full requirement coverage evidence inline in `AgentRunResult.metadata`. That exceeded the compact metadata limit during terminal result publication and caused the child workflow to fail workflow-task replay instead of completing.

## Validation

- `./tools/test_unit.sh tests/unit/workflows/temporal/test_activity_runtime.py -k 'agent_runtime_publish_artifacts'`
- `./tools/test_unit.sh tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py -k 'publish_artifacts or publish_terminal_result or moonspec_verify_path'`

Both targeted Python selectors passed, and each wrapper run completed the dashboard/Vitest phase with 795 passed and 238 skipped.