### PR TITLE
MM-1113 Add workflow fallback selection memory

### DIFF
--- a/docs/tmp/jira-orchestrate-mm-1113-handoff.json
+++ b/docs/tmp/jira-orchestrate-mm-1113-handoff.json
@@ -1,0 +1,109 @@
+{
+  "handoffType": "jira-orchestrate-intake",
+  "updatedAt": "2026-07-05T00:00:00Z",
+  "jiraIssueKey": "MM-1113",
+  "sourceIssueTraceability": {
+    "sourceIssueKey": "MM-1111",
+    "preserveInDownstreamArtifacts": true,
+    "reason": "The managed task instruction explicitly requires preserving source issue MM-1111 traceability."
+  },
+  "classification": {
+    "inputType": "single-story feature request",
+    "reason": "The trusted Jira preset brief identifies one Jira Story with one bounded UI behavior change: add first-workflow fallback and selected-workflow memory for mode changes. The brief references a canonical UI design document as runtime source requirements, but it does not ask to split a broad declarative design into multiple independently testable stories or select an existing feature directory."
+  },
+  "intent": "runtime implementation workflow",
+  "sourceStory": {
+    "summary": "Add first-workflow fallback and selected-workflow memory for mode changes",
+    "sourceDesignPath": "docs/UI/WorkflowListDisplayModes.md",
+    "sourceSections": [
+      "4. Route and presentation matrix",
+      "5. First-workflow fallback",
+      "10. State persistence",
+      "11. Data fetching and cache reuse"
+    ],
+    "claimIds": [
+      "CLAIM-docs-ui-workflowlistdisplaymodes-004",
+      "CLAIM-docs-ui-workflowlistdisplaymodes-005",
+      "CLAIM-docs-ui-workflowlistdisplaymodes-010",
+      "CLAIM-docs-ui-workflowlistdisplaymodes-011"
+    ],
+    "coverageIds": [
+      "DESIGN-REQ-004",
+      "DESIGN-REQ-005",
+      "DESIGN-REQ-010",
+      "DESIGN-REQ-011"
+    ]
+  },
+  "canonicalInput": {
+    "trustedSource": "moonmind.jira.get_issue",
+    "jiraPresetBrief": "MM-1113: Add first-workflow fallback and selected-workflow memory for mode changes",
+    "sourceDesignClassification": "canonical declarative UI contract used as runtime source requirements",
+    "acceptanceCriteria": [
+      "Resolve fallback targets in order: route workflow ID, last explicitly selected authorized workflow, then the first visible row from the current effective list query.",
+      "Expose a resolving state such as Opening first workflow... while the matching list is loading.",
+      "Stay on /workflows and avoid guessed navigation when the list fails or has no rows.",
+      "Open remembered selections absent from active filters only after detail authorization succeeds and label them as current rather than filter-matching.",
+      "Add tests proving unauthorized workflows are not exposed through remembered, first-row, sidebar, table, or pinned-current states."
+    ],
+    "requirements": [
+      "Persist lastSelectedWorkflowId from explicit user workflow selections.",
+      "Use the exact current list query or matching cache for first-row fallback.",
+      "Keep detail data authorization separate from list row presence."
+    ],
+    "alreadyImplementedEvidence": [
+      "frontend/src/entrypoints/workflow-detail.tsx derives sidebar list requests from workflowListContextParams and fetches selected workflow detail separately with a distinct workflow-detail query.",
+      "frontend/src/entrypoints/workflow-detail.tsx can pin the current workflow from authorized detail data when the selected workflow is absent from the sidebar list.",
+      "frontend/src/utils/dashboardPreferences.ts persists workflowWorkspaceSidebarCollapsed but has no lastSelectedWorkflowId preference."
+    ]
+  },
+  "artifactResumeInspection": {
+    "status": "no_existing_moonspec_artifacts_found",
+    "checkedLocations": [
+      "artifacts/",
+      "docs/tmp/",
+      "repository root and workspace MoonSpec artifact paths"
+    ],
+    "checkedPatterns": [
+      "MM-1113",
+      "mm-1113",
+      "spec.md",
+      "plan.md",
+      "tasks.md",
+      "research.md",
+      "quickstart.md",
+      "moonspec-verify"
+    ],
+    "validArtifactsToPreserve": [],
+    "evidence": [
+      "No spec.md, plan.md, tasks.md, research.md, or quickstart.md files were found under the repository or job workspace search paths.",
+      "No existing docs/tmp or artifact handoff for MM-1113 was found before this intake handoff.",
+      "The referenced artifacts/jira-orchestrate-brief.json file is absent in this checkout, so this step used the trusted inline MoonMind issue context as the authoritative brief."
+    ],
+    "resumeFrom": "Specify",
+    "nextStageReason": "Specify is the first incomplete MoonSpec stage because there is no active spec.md to pass the specify gate and no later-stage MoonSpec artifacts to preserve."
+  },
+  "stageGateStatus": {
+    "Specify": "INCOMPLETE",
+    "Plan": "NOT_STARTED",
+    "Tasks": "NOT_STARTED",
+    "Align": "NOT_STARTED",
+    "Implement": "NOT_STARTED",
+    "Verify": "NOT_STARTED"
+  },
+  "stageExecution": {
+    "performedInThisStep": false,
+    "reason": "This managed step is limited to Jira Orchestrate intake classification and artifact resume inspection. It must not run specification, planning, task generation, implementation, verification, publishing, pull request creation, or Jira transitions."
+  },
+  "downstreamInstructions": {
+    "useBriefAsCanonicalInput": true,
+    "treatImplementationDocumentAsRuntimeSourceRequirements": true,
+    "sourceDesignPath": "docs/UI/WorkflowListDisplayModes.md",
+    "resumeFromFirstIncompleteStage": "Specify",
+    "runAsRuntimeImplementationWorkflow": true,
+    "doNotRegenerateValidLaterStageArtifacts": true,
+    "preserveSourceIssueTraceability": [
+      "MM-1111",
+      "MM-1113"
+    ]
+  }
+}

--- a/frontend/src/entrypoints/dashboard-app.tsx
+++ b/frontend/src/entrypoints/dashboard-app.tsx
@@ -1,6 +1,7 @@
 import {
   Suspense,
   lazy,
+  useCallback,
   useEffect,
   useMemo,
   useRef,
@@ -20,7 +21,7 @@ import {
   useNavigate,
 } from 'react-router-dom';
 import { QueryErrorResetBoundary, useQuery, useQueryClient } from '@tanstack/react-query';
-import { ScrollText } from 'lucide-react';
+import { PanelLeft, Rows3, ScrollText, Square } from 'lucide-react';
 import {
   MoonIcon,
   type MoonIconHandle,
@@ -44,6 +45,15 @@ import {
   type DashboardUiInfo,
 } from '../lib/dashboardRoutes';
 import { DashboardAlerts } from './dashboard-alerts';
+import {
+  readDashboardPreferences,
+  updateDashboardPreferences,
+} from '../utils/dashboardPreferences';
+import {
+  workflowDetailHref,
+  workflowListApiQueryFromContext,
+  workflowListHrefFromContext,
+} from '../lib/workflowListContext';
 
 type PageComponent = ComponentType<{ payload: BootPayload }>;
 type PageImport = () => Promise<{ default: PageComponent }>;
@@ -63,6 +73,16 @@ const PAGE_IMPORTS = {
 } satisfies Record<DashboardPage, PageImport>;
 
 const NAV_ICON_SIZE = 16;
+
+type WorkflowListDisplayMode = 'hidden' | 'sidebar' | 'table';
+
+type WorkflowListResolutionState = 'idle' | 'resolving' | 'empty' | 'error';
+
+const WORKFLOW_LIST_DISPLAY_OPTIONS = [
+  { value: 'hidden', label: 'No list', icon: Square },
+  { value: 'sidebar', label: 'Sidebar list', icon: PanelLeft },
+  { value: 'table', label: 'Full screen table', icon: Rows3 },
+] as const;
 
 type SharedLayoutConfig = {
   dataWidePanel?: boolean;
@@ -171,6 +191,48 @@ function AnimatedRouteNavLink({
 
 function isSupportedPage(page: string): page is DashboardPage {
   return Object.hasOwn(PAGE_IMPORTS, page);
+}
+
+function workflowIdFromPathname(pathname: string): string | null {
+  const match = pathname.match(/^\/workflows\/([^/]+)(?:\/(?:steps|artifacts|runs|debug))?\/?$/);
+  if (!match?.[1]) {
+    return null;
+  }
+  try {
+    const decoded = decodeURIComponent(match[1]);
+    return decoded.includes('/') ? null : decoded;
+  } catch {
+    return null;
+  }
+}
+
+function workflowRowId(row: unknown): string {
+  if (!row || typeof row !== 'object') {
+    return '';
+  }
+  const record = row as Record<string, unknown>;
+  return String(record.workflowId || record.taskId || '').trim();
+}
+
+async function authorizedWorkflowId(apiBase: string, workflowId: string, search: URLSearchParams): Promise<string | null> {
+  const encoded = encodeURIComponent(workflowId);
+  const source = search.get('source') || 'temporal';
+  const params = new URLSearchParams({ source });
+  const response = await fetch(`${apiBase}/executions/${encoded}?${params}`);
+  if (!response.ok) {
+    return null;
+  }
+  return workflowId;
+}
+
+async function firstVisibleWorkflowId(apiBase: string, search: URLSearchParams): Promise<string | null> {
+  const response = await fetch(`${apiBase}/executions?${workflowListApiQueryFromContext(search)}`);
+  if (!response.ok) {
+    throw new Error(`Failed to resolve first workflow: ${response.statusText}`);
+  }
+  const body = (await response.json()) as { items?: unknown[] };
+  const firstRow = Array.isArray(body.items) ? body.items.find((row) => workflowRowId(row)) : null;
+  return firstRow ? workflowRowId(firstRow) : null;
 }
 
 function readSharedLayout(payload: BootPayload): SharedLayoutConfig {
@@ -338,30 +400,144 @@ function DashboardLiveUpdateProvider({
 
 function DashboardNavigation({ uiInfo }: { uiInfo: DashboardUiInfo | null }) {
   const [open, setOpen] = useState(false);
+  const [sidebarCollapsed, setSidebarCollapsed] = useState(
+    () => readDashboardPreferences().workflowWorkspaceSidebarCollapsed,
+  );
+  const [resolutionState, setResolutionState] = useState<WorkflowListResolutionState>('idle');
   const location = useLocation();
+  const navigate = useNavigate();
   const isWorkflowStart = location.pathname.replace(/\/$/, '') === '/workflows/new';
+  const isWorkflowTable = location.pathname.replace(/\/$/, '') === '/workflows';
   const isWorkflowDetail = location.pathname.startsWith('/workflows/') && !isWorkflowStart;
+  const isWorkflowSurface = isWorkflowTable || isWorkflowStart || isWorkflowDetail;
   const buildId = typeof uiInfo?.buildId === 'string' && uiInfo.buildId.trim() ? uiInfo.buildId : null;
+  const apiBase = typeof uiInfo?.apiBase === 'string' ? uiInfo.apiBase : '/api';
 
   useEffect(() => {
     setOpen(false);
   }, [location.pathname]);
 
+  useEffect(() => {
+    setResolutionState('idle');
+    setSidebarCollapsed(readDashboardPreferences().workflowWorkspaceSidebarCollapsed);
+  }, [location.pathname, location.search]);
+
+  const currentMode: WorkflowListDisplayMode = isWorkflowTable
+    ? 'table'
+    : sidebarCollapsed
+      ? 'hidden'
+      : 'sidebar';
+
+  const handleWorkflowListModeChange = useCallback(
+    async (mode: WorkflowListDisplayMode) => {
+      if (!isWorkflowSurface || mode === currentMode) {
+        return;
+      }
+      const search = new URLSearchParams(location.search);
+      setResolutionState('idle');
+      if (mode === 'table') {
+        updateDashboardPreferences({ workflowWorkspaceSidebarCollapsed: false });
+        setSidebarCollapsed(false);
+        navigate(workflowListHrefFromContext(search, { markDetailReturn: isWorkflowDetail }));
+        return;
+      }
+
+      const nextCollapsed = mode === 'hidden';
+      updateDashboardPreferences({ workflowWorkspaceSidebarCollapsed: nextCollapsed });
+      setSidebarCollapsed(nextCollapsed);
+
+      const routeWorkflowId = workflowIdFromPathname(location.pathname);
+      if (routeWorkflowId || isWorkflowStart) {
+        return;
+      }
+
+      setResolutionState('resolving');
+      const prefs = readDashboardPreferences();
+      const rememberedId = prefs.lastSelectedWorkflowId.trim();
+      try {
+        const authorizedRememberedId = rememberedId
+          ? await authorizedWorkflowId(apiBase, rememberedId, search)
+          : null;
+        const targetWorkflowId = authorizedRememberedId
+          || await firstVisibleWorkflowId(apiBase, search);
+        if (!targetWorkflowId) {
+          setResolutionState('empty');
+          return;
+        }
+        setResolutionState('idle');
+        navigate(workflowDetailHref(targetWorkflowId, search));
+      } catch {
+        setResolutionState('error');
+      }
+    },
+    [
+      apiBase,
+      currentMode,
+      isWorkflowDetail,
+      isWorkflowSurface,
+      isWorkflowStart,
+      location.pathname,
+      location.search,
+      navigate,
+    ],
+  );
+
+  const resolutionMessage = resolutionState === 'resolving'
+    ? 'Opening first workflow...'
+    : resolutionState === 'empty'
+      ? 'No workflow to open.'
+      : resolutionState === 'error'
+        ? 'Workflow list is unavailable.'
+        : '';
+
   return (
     <header className="masthead">
-      <Link className="masthead-brand" to="/workflows" aria-label="MoonMind workflows">
-        <img
-          className="masthead-logo"
-          src="/static/workflow_console/moonmindlogo.webp"
-          alt="MoonMind owl and moon logo"
-          width="256"
-          height="199"
-        />
-        <h1>
-          <span className="masthead-brand-moon">Moon</span>
-          <span className="masthead-brand-mind">Mind</span>
-        </h1>
-      </Link>
+      <div className="masthead-primary">
+        <Link className="masthead-brand" to="/workflows" aria-label="MoonMind workflows">
+          <img
+            className="masthead-logo"
+            src="/static/workflow_console/moonmindlogo.webp"
+            alt="MoonMind owl and moon logo"
+            width="256"
+            height="199"
+          />
+          <h1>
+            <span className="masthead-brand-moon">Moon</span>
+            <span className="masthead-brand-mind">Mind</span>
+          </h1>
+        </Link>
+
+        {isWorkflowSurface ? (
+          <div
+            className="workflow-list-display-control"
+            role="radiogroup"
+            aria-label="Workflow list display"
+            aria-busy={resolutionState === 'resolving' ? 'true' : undefined}
+          >
+            {WORKFLOW_LIST_DISPLAY_OPTIONS.map(({ value, label, icon: Icon }) => (
+              <button
+                key={value}
+                type="button"
+                role="radio"
+                aria-checked={currentMode === value}
+                aria-label={label}
+                title={label}
+                className="workflow-list-display-option"
+                data-active={currentMode === value ? 'true' : 'false'}
+                disabled={resolutionState === 'resolving'}
+                onClick={() => void handleWorkflowListModeChange(value)}
+              >
+                <Icon aria-hidden="true" focusable="false" />
+              </button>
+            ))}
+            {resolutionMessage ? (
+              <span className="workflow-list-display-status" role="status">
+                {resolutionMessage}
+              </span>
+            ) : null}
+          </div>
+        ) : null}
+      </div>
 
       <button
         className="nav-hamburger"

--- a/frontend/src/entrypoints/dashboard-app.tsx
+++ b/frontend/src/entrypoints/dashboard-app.tsx
@@ -230,8 +230,9 @@ async function firstVisibleWorkflowId(apiBase: string, search: URLSearchParams):
   if (!response.ok) {
     throw new Error(`Failed to resolve first workflow: ${response.statusText}`);
   }
-  const body = (await response.json()) as { items?: unknown[] };
-  const firstRow = Array.isArray(body.items) ? body.items.find((row) => workflowRowId(row)) : null;
+  const body = (await response.json()) as { items?: unknown[] } | null;
+  const items = body && typeof body === 'object' && Array.isArray(body.items) ? body.items : null;
+  const firstRow = items ? items.find((row) => workflowRowId(row)) : null;
   return firstRow ? workflowRowId(firstRow) : null;
 }
 
@@ -404,6 +405,7 @@ function DashboardNavigation({ uiInfo }: { uiInfo: DashboardUiInfo | null }) {
     () => readDashboardPreferences().workflowWorkspaceSidebarCollapsed,
   );
   const [resolutionState, setResolutionState] = useState<WorkflowListResolutionState>('idle');
+  const pendingRequestRef = useRef<symbol | null>(null);
   const location = useLocation();
   const navigate = useNavigate();
   const isWorkflowStart = location.pathname.replace(/\/$/, '') === '/workflows/new';
@@ -420,6 +422,7 @@ function DashboardNavigation({ uiInfo }: { uiInfo: DashboardUiInfo | null }) {
   useEffect(() => {
     setResolutionState('idle');
     setSidebarCollapsed(readDashboardPreferences().workflowWorkspaceSidebarCollapsed);
+    pendingRequestRef.current = null;
   }, [location.pathname, location.search]);
 
   const currentMode: WorkflowListDisplayMode = isWorkflowTable
@@ -451,6 +454,8 @@ function DashboardNavigation({ uiInfo }: { uiInfo: DashboardUiInfo | null }) {
         return;
       }
 
+      const requestId = Symbol();
+      pendingRequestRef.current = requestId;
       setResolutionState('resolving');
       const prefs = readDashboardPreferences();
       const rememberedId = prefs.lastSelectedWorkflowId.trim();
@@ -458,8 +463,14 @@ function DashboardNavigation({ uiInfo }: { uiInfo: DashboardUiInfo | null }) {
         const authorizedRememberedId = rememberedId
           ? await authorizedWorkflowId(apiBase, rememberedId, search)
           : null;
+        if (pendingRequestRef.current !== requestId) {
+          return;
+        }
         const targetWorkflowId = authorizedRememberedId
           || await firstVisibleWorkflowId(apiBase, search);
+        if (pendingRequestRef.current !== requestId) {
+          return;
+        }
         if (!targetWorkflowId) {
           setResolutionState('empty');
           return;
@@ -467,7 +478,9 @@ function DashboardNavigation({ uiInfo }: { uiInfo: DashboardUiInfo | null }) {
         setResolutionState('idle');
         navigate(workflowDetailHref(targetWorkflowId, search));
       } catch {
-        setResolutionState('error');
+        if (pendingRequestRef.current === requestId) {
+          setResolutionState('error');
+        }
       }
     },
     [

--- a/frontend/src/entrypoints/dashboard.test.tsx
+++ b/frontend/src/entrypoints/dashboard.test.tsx
@@ -15,6 +15,7 @@ import type { BootPayload } from '../boot/parseBootPayload';
 import { fireEvent, renderWithClient, screen, waitFor } from '../utils/test-utils';
 import { DashboardApp } from './dashboard-app';
 import { navigateTo } from '../lib/navigation';
+import { readDashboardPreferences, updateDashboardPreferences } from '../utils/dashboardPreferences';
 
 const animatedNavIconMocks = vi.hoisted(() => ({
   moonStart: vi.fn(),
@@ -321,6 +322,7 @@ describe('Dashboard shared entry', () => {
     fetchSpy.mockRestore();
     window.WebSocket = originalWebSocket;
     document.querySelectorAll('[data-nav]').forEach((node) => node.remove());
+    window.localStorage.clear();
     window.history.replaceState({}, '', '/');
   });
 
@@ -580,6 +582,115 @@ describe('Dashboard shared entry', () => {
 
     expect(await screen.findByText('Workflow detail route loaded: /workflows/second')).toBeTruthy();
     expect(screen.queryByText('Workflow detail route loaded: /workflows/first/debug')).toBeNull();
+  });
+
+  it('MM-1113 opens an authorized remembered workflow when leaving the full table', async () => {
+    window.history.replaceState({}, '', '/workflows?stateIn=completed&limit=50');
+    updateDashboardPreferences({ lastSelectedWorkflowId: 'remembered-123' });
+    renderWithClient(<DashboardApp payload={{ page: 'dashboard', apiBase: '/api' }} />);
+
+    expect(await screen.findByText('Workflow list route loaded')).toBeTruthy();
+    fetchSpy.mockClear();
+
+    fireEvent.click(screen.getByRole('radio', { name: 'No list' }));
+
+    await waitFor(() => {
+      expect(window.location.pathname).toBe('/workflows/remembered-123');
+    });
+    expect(window.location.search).toContain('stateIn=completed');
+    expect(window.location.search).toContain('limit=50');
+    expect(window.location.search).toContain('source=temporal');
+    expect(fetchSpy).toHaveBeenCalledWith('/api/executions/remembered-123?source=temporal');
+    expect(fetchSpy.mock.calls.some(([url]) => String(url).startsWith('/api/executions?'))).toBe(false);
+    expect(readDashboardPreferences().workflowWorkspaceSidebarCollapsed).toBe(true);
+  });
+
+  it('MM-1113 ignores unauthorized remembered selections and opens the first visible row', async () => {
+    window.history.replaceState({}, '', '/workflows?stateIn=completed&limit=50');
+    updateDashboardPreferences({ lastSelectedWorkflowId: 'unauthorized-123' });
+    fetchSpy.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === '/api/ui/info') {
+        return Promise.resolve({ ok: true, json: async () => uiInfo() } as Response);
+      }
+      if (url === '/api/executions/unauthorized-123?source=temporal') {
+        return Promise.resolve({ ok: false, status: 403, statusText: 'Forbidden' } as Response);
+      }
+      if (url === '/api/executions?stateIn=completed&source=temporal&pageSize=50') {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            items: [{ workflowId: 'visible-456', taskId: 'visible-456', title: 'Visible authorized row' }],
+          }),
+        } as Response);
+      }
+      return Promise.resolve({ ok: false, status: 404, statusText: 'Not Found' } as Response);
+    });
+    renderWithClient(<DashboardApp payload={{ page: 'dashboard', apiBase: '/api' }} />);
+
+    expect(await screen.findByText('Workflow list route loaded')).toBeTruthy();
+    fireEvent.click(screen.getByRole('radio', { name: 'Sidebar list' }));
+
+    await waitFor(() => {
+      expect(window.location.pathname).toBe('/workflows/visible-456');
+    });
+    expect(window.location.pathname).not.toBe('/workflows/unauthorized-123');
+    expect(readDashboardPreferences().workflowWorkspaceSidebarCollapsed).toBe(false);
+  });
+
+  it('MM-1113 exposes a resolving state while the matching workflow list is loading', async () => {
+    window.history.replaceState({}, '', '/workflows?limit=25');
+    let resolveList: ((response: Response) => void) | undefined;
+    fetchSpy.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === '/api/ui/info') {
+        return Promise.resolve({ ok: true, json: async () => uiInfo() } as Response);
+      }
+      if (url === '/api/executions?source=temporal&pageSize=25') {
+        return new Promise<Response>((resolve) => {
+          resolveList = resolve;
+        });
+      }
+      return Promise.resolve({ ok: false, status: 404, statusText: 'Not Found' } as Response);
+    });
+    renderWithClient(<DashboardApp payload={{ page: 'dashboard', apiBase: '/api' }} />);
+
+    expect(await screen.findByText('Workflow list route loaded')).toBeTruthy();
+    fireEvent.click(screen.getByRole('radio', { name: 'No list' }));
+
+    expect((await screen.findByRole('status')).textContent).toContain('Opening first workflow...');
+    const completeList = resolveList;
+    if (!completeList) {
+      throw new Error('Expected workflow list request to be pending.');
+    }
+    completeList({
+      ok: true,
+      json: async () => ({ items: [{ workflowId: 'first-loading-row' }] }),
+    } as Response);
+    await waitFor(() => {
+      expect(window.location.pathname).toBe('/workflows/first-loading-row');
+    });
+  });
+
+  it('MM-1113 stays on the table when fallback list resolution fails or has no rows', async () => {
+    window.history.replaceState({}, '', '/workflows?stateIn=failed');
+    fetchSpy.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === '/api/ui/info') {
+        return Promise.resolve({ ok: true, json: async () => uiInfo() } as Response);
+      }
+      if (url === '/api/executions?stateIn=failed&source=temporal&pageSize=25') {
+        return Promise.resolve({ ok: true, json: async () => ({ items: [] }) } as Response);
+      }
+      return Promise.resolve({ ok: false, status: 404, statusText: 'Not Found' } as Response);
+    });
+    renderWithClient(<DashboardApp payload={{ page: 'dashboard', apiBase: '/api' }} />);
+
+    expect(await screen.findByText('Workflow list route loaded')).toBeTruthy();
+    fireEvent.click(screen.getByRole('radio', { name: 'No list' }));
+
+    expect((await screen.findByRole('status')).textContent).toContain('No workflow to open.');
+    expect(window.location.pathname).toBe('/workflows');
   });
 
   it('does not render operational metrics on the workflows home dashboard', async () => {

--- a/frontend/src/entrypoints/dashboard.test.tsx
+++ b/frontend/src/entrypoints/dashboard.test.tsx
@@ -587,6 +587,16 @@ describe('Dashboard shared entry', () => {
   it('MM-1113 opens an authorized remembered workflow when leaving the full table', async () => {
     window.history.replaceState({}, '', '/workflows?stateIn=completed&limit=50');
     updateDashboardPreferences({ lastSelectedWorkflowId: 'remembered-123' });
+    fetchSpy.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === '/api/ui/info') {
+        return Promise.resolve({ ok: true, json: async () => uiInfo() } as Response);
+      }
+      if (url === '/api/executions/remembered-123?source=temporal') {
+        return Promise.resolve({ ok: true, json: async () => ({ workflowId: 'remembered-123' }) } as Response);
+      }
+      return Promise.resolve({ ok: false, status: 404, statusText: 'Not Found' } as Response);
+    });
     renderWithClient(<DashboardApp payload={{ page: 'dashboard', apiBase: '/api' }} />);
 
     expect(await screen.findByText('Workflow list route loaded')).toBeTruthy();
@@ -603,6 +613,65 @@ describe('Dashboard shared entry', () => {
     expect(fetchSpy).toHaveBeenCalledWith('/api/executions/remembered-123?source=temporal');
     expect(fetchSpy.mock.calls.some(([url]) => String(url).startsWith('/api/executions?'))).toBe(false);
     expect(readDashboardPreferences().workflowWorkspaceSidebarCollapsed).toBe(true);
+  });
+
+  it('MM-1113 keeps a route-selected workflow when switching detail-compatible modes', async () => {
+    window.history.replaceState({}, '', '/workflows/route-123?stateIn=failed&limit=10');
+    updateDashboardPreferences({ lastSelectedWorkflowId: 'remembered-123' });
+    renderWithClient(<DashboardApp payload={{ page: 'dashboard', apiBase: '/api' }} />);
+
+    expect(await screen.findByText('Workflow detail route loaded: /workflows/route-123')).toBeTruthy();
+    fetchSpy.mockClear();
+
+    fireEvent.click(screen.getByRole('radio', { name: 'No list' }));
+
+    await waitFor(() => {
+      expect(readDashboardPreferences().workflowWorkspaceSidebarCollapsed).toBe(true);
+    });
+    expect(window.location.pathname).toBe('/workflows/route-123');
+    expect(window.location.search).toBe('?stateIn=failed&limit=10');
+    expect(fetchSpy.mock.calls.some(([url]) => String(url).startsWith('/api/executions/remembered-123'))).toBe(false);
+    expect(fetchSpy.mock.calls.some(([url]) => String(url).startsWith('/api/executions?'))).toBe(false);
+  });
+
+  it('MM-1113 resolves the first row from the exact current list query context', async () => {
+    window.history.replaceState(
+      {},
+      '',
+      '/workflows?stateIn=completed&source=jules&limit=50&nextPageToken=cursor-1&repoIn=MoonLadderStudios%2FMoonMind&targetRuntime=codex_cli&sort=updatedAt',
+    );
+    fetchSpy.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === '/api/ui/info') {
+        return Promise.resolve({ ok: true, json: async () => uiInfo() } as Response);
+      }
+      if (
+        url ===
+        '/api/executions?stateIn=completed&source=jules&nextPageToken=cursor-1&repoIn=MoonLadderStudios%2FMoonMind&targetRuntime=codex_cli&pageSize=50'
+      ) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ items: [{ workflowId: 'first-query-row', title: 'First query row' }] }),
+        } as Response);
+      }
+      return Promise.resolve({ ok: false, status: 404, statusText: 'Not Found' } as Response);
+    });
+    renderWithClient(<DashboardApp payload={{ page: 'dashboard', apiBase: '/api' }} />);
+
+    expect(await screen.findByText('Workflow list route loaded')).toBeTruthy();
+    fireEvent.click(screen.getByRole('radio', { name: 'Sidebar list' }));
+
+    await waitFor(() => {
+      expect(window.location.pathname).toBe('/workflows/first-query-row');
+    });
+    expect(fetchSpy).toHaveBeenCalledWith(
+      '/api/executions?stateIn=completed&source=jules&nextPageToken=cursor-1&repoIn=MoonLadderStudios%2FMoonMind&targetRuntime=codex_cli&pageSize=50',
+    );
+    expect(window.location.search).toContain('stateIn=completed');
+    expect(window.location.search).toContain('source=jules');
+    expect(window.location.search).toContain('limit=50');
+    expect(window.location.search).toContain('nextPageToken=cursor-1');
+    expect(window.location.search).not.toContain('sort=updatedAt');
   });
 
   it('MM-1113 ignores unauthorized remembered selections and opens the first visible row', async () => {
@@ -636,6 +705,68 @@ describe('Dashboard shared entry', () => {
     });
     expect(window.location.pathname).not.toBe('/workflows/unauthorized-123');
     expect(readDashboardPreferences().workflowWorkspaceSidebarCollapsed).toBe(false);
+    expect(readDashboardPreferences().lastSelectedWorkflowId).toBe('unauthorized-123');
+  });
+
+  it('MM-1113 never navigates to or renders an unauthorized remembered workflow during fallback', async () => {
+    window.history.replaceState({}, '', '/workflows?stateIn=completed');
+    updateDashboardPreferences({ lastSelectedWorkflowId: 'secret-remembered' });
+    fetchSpy.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === '/api/ui/info') {
+        return Promise.resolve({ ok: true, json: async () => uiInfo() } as Response);
+      }
+      if (url === '/api/executions/secret-remembered?source=temporal') {
+        return Promise.resolve({ ok: false, status: 403, statusText: 'Forbidden' } as Response);
+      }
+      if (url === '/api/executions?stateIn=completed&source=temporal&pageSize=25') {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            items: [{ workflowId: 'authorized-row', taskId: 'authorized-row', title: 'Authorized row' }],
+          }),
+        } as Response);
+      }
+      return Promise.resolve({ ok: false, status: 404, statusText: 'Not Found' } as Response);
+    });
+    renderWithClient(<DashboardApp payload={{ page: 'dashboard', apiBase: '/api' }} />);
+
+    expect(await screen.findByText('Workflow list route loaded')).toBeTruthy();
+    fireEvent.click(screen.getByRole('radio', { name: 'No list' }));
+
+    await waitFor(() => {
+      expect(window.location.pathname).toBe('/workflows/authorized-row');
+    });
+    expect(window.location.pathname).not.toBe('/workflows/secret-remembered');
+    expect(screen.queryByText(/secret-remembered/i)).toBeNull();
+    expect(readDashboardPreferences().lastSelectedWorkflowId).toBe('secret-remembered');
+  });
+
+  it('MM-1113 selects only returned authorized first-row data', async () => {
+    window.history.replaceState({}, '', '/workflows?stateIn=running');
+    fetchSpy.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === '/api/ui/info') {
+        return Promise.resolve({ ok: true, json: async () => uiInfo() } as Response);
+      }
+      if (url === '/api/executions?stateIn=running&source=temporal&pageSize=25') {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ items: [{ taskId: 'authorized-task-row', title: 'Authorized task row' }] }),
+        } as Response);
+      }
+      return Promise.resolve({ ok: false, status: 404, statusText: 'Not Found' } as Response);
+    });
+    renderWithClient(<DashboardApp payload={{ page: 'dashboard', apiBase: '/api' }} />);
+
+    expect(await screen.findByText('Workflow list route loaded')).toBeTruthy();
+    fireEvent.click(screen.getByRole('radio', { name: 'No list' }));
+
+    await waitFor(() => {
+      expect(window.location.pathname).toBe('/workflows/authorized-task-row');
+    });
+    expect(window.location.pathname).not.toContain('unauthorized');
+    expect(screen.queryByText(/unauthorized/i)).toBeNull();
   });
 
   it('MM-1113 exposes a resolving state while the matching workflow list is loading', async () => {
@@ -691,6 +822,28 @@ describe('Dashboard shared entry', () => {
 
     expect((await screen.findByRole('status')).textContent).toContain('No workflow to open.');
     expect(window.location.pathname).toBe('/workflows');
+  });
+
+  it('MM-1113 stays on the table and exposes a recoverable state when fallback list loading fails', async () => {
+    window.history.replaceState({}, '', '/workflows?stateIn=failed');
+    fetchSpy.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === '/api/ui/info') {
+        return Promise.resolve({ ok: true, json: async () => uiInfo() } as Response);
+      }
+      if (url === '/api/executions?stateIn=failed&source=temporal&pageSize=25') {
+        return Promise.resolve({ ok: false, status: 503, statusText: 'Service Unavailable' } as Response);
+      }
+      return Promise.resolve({ ok: false, status: 404, statusText: 'Not Found' } as Response);
+    });
+    renderWithClient(<DashboardApp payload={{ page: 'dashboard', apiBase: '/api' }} />);
+
+    expect(await screen.findByText('Workflow list route loaded')).toBeTruthy();
+    fireEvent.click(screen.getByRole('radio', { name: 'No list' }));
+
+    expect((await screen.findByRole('status')).textContent).toContain('Workflow list is unavailable.');
+    expect(window.location.pathname).toBe('/workflows');
+    expect(window.location.search).toBe('?stateIn=failed');
   });
 
   it('does not render operational metrics on the workflows home dashboard', async () => {

--- a/frontend/src/entrypoints/dashboard.test.tsx
+++ b/frontend/src/entrypoints/dashboard.test.tsx
@@ -824,6 +824,27 @@ describe('Dashboard shared entry', () => {
     expect(window.location.pathname).toBe('/workflows');
   });
 
+  it('MM-1113 treats non-object fallback list responses as empty', async () => {
+    window.history.replaceState({}, '', '/workflows?stateIn=completed');
+    fetchSpy.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === '/api/ui/info') {
+        return Promise.resolve({ ok: true, json: async () => uiInfo() } as Response);
+      }
+      if (url === '/api/executions?stateIn=completed&source=temporal&pageSize=25') {
+        return Promise.resolve({ ok: true, json: async () => null } as Response);
+      }
+      return Promise.resolve({ ok: false, status: 404, statusText: 'Not Found' } as Response);
+    });
+    renderWithClient(<DashboardApp payload={{ page: 'dashboard', apiBase: '/api' }} />);
+
+    expect(await screen.findByText('Workflow list route loaded')).toBeTruthy();
+    fireEvent.click(screen.getByRole('radio', { name: 'No list' }));
+
+    expect((await screen.findByRole('status')).textContent).toContain('No workflow to open.');
+    expect(window.location.pathname).toBe('/workflows');
+  });
+
   it('MM-1113 stays on the table and exposes a recoverable state when fallback list loading fails', async () => {
     window.history.replaceState({}, '', '/workflows?stateIn=failed');
     fetchSpy.mockImplementation((input: RequestInfo | URL) => {
@@ -844,6 +865,45 @@ describe('Dashboard shared entry', () => {
     expect((await screen.findByRole('status')).textContent).toContain('Workflow list is unavailable.');
     expect(window.location.pathname).toBe('/workflows');
     expect(window.location.search).toBe('?stateIn=failed');
+  });
+
+  it('MM-1113 ignores stale fallback navigation after leaving the workflow surface', async () => {
+    window.history.replaceState({}, '', '/workflows?stateIn=running');
+    let resolveList: ((response: Response) => void) | undefined;
+    fetchSpy.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === '/api/ui/info') {
+        return Promise.resolve({ ok: true, json: async () => uiInfo() } as Response);
+      }
+      if (url === '/api/executions?stateIn=running&source=temporal&pageSize=25') {
+        return new Promise<Response>((resolve) => {
+          resolveList = resolve;
+        });
+      }
+      return Promise.resolve({ ok: false, status: 404, statusText: 'Not Found' } as Response);
+    });
+    renderWithClient(<DashboardApp payload={{ page: 'dashboard', apiBase: '/api' }} />);
+
+    expect(await screen.findByText('Workflow list route loaded')).toBeTruthy();
+    fireEvent.click(screen.getByRole('radio', { name: 'No list' }));
+    expect((await screen.findByRole('status')).textContent).toContain('Opening first workflow...');
+    fireEvent.click(screen.getByRole('link', { name: 'Settings' }));
+    expect(await screen.findByText('Settings permissions:')).toBeTruthy();
+
+    const completeList = resolveList;
+    if (!completeList) {
+      throw new Error('Expected workflow list request to be pending.');
+    }
+    completeList({
+      ok: true,
+      json: async () => ({ items: [{ workflowId: 'stale-row' }] }),
+    } as Response);
+
+    await waitFor(() => {
+      expect(window.location.pathname).toBe('/settings');
+    });
+    expect(window.location.search).toBe('');
+    expect(screen.queryByText(/stale-row/i)).toBeNull();
   });
 
   it('does not render operational metrics on the workflows home dashboard', async () => {
@@ -1807,7 +1867,7 @@ describe('Dashboard shared entry', () => {
       /\.masthead\s*\{[^}]*display:\s*grid;[^}]*grid-template-columns:\s*minmax\(0,\s*1fr\)\s+auto\s+minmax\(0,\s*1fr\);/s,
     );
     expect(dashboardCss).toMatch(
-      /\.masthead-brand\s*\{[^}]*justify-self:\s*start;/s,
+      /\.masthead-primary\s*\{[^}]*justify-self:\s*start;/s,
     );
     expect(dashboardCss).toMatch(
       /\.masthead-nav\s*\{[^}]*align-self:\s*stretch;[^}]*justify-content:\s*center;[^}]*justify-self:\s*center;/s,

--- a/frontend/src/entrypoints/workflow-detail.test.tsx
+++ b/frontend/src/entrypoints/workflow-detail.test.tsx
@@ -728,6 +728,47 @@ describe('Workflow Detail Entrypoint', () => {
     expect(await screen.findByRole('heading', { name: 'Workflow Detail' })).toBeTruthy();
   });
 
+  it('MM-1113 keeps authorized remembered workflows outside filters in the current group only', async () => {
+    window.history.pushState({}, 'Workspace Remembered Current Test', '/workflows/test-123?source=temporal&stateIn=completed');
+    mockDesktopViewport(true);
+    mockWorkflowWorkspaceFetchesWithSelectedOutsideList();
+
+    renderWithClient(<WorkflowDetailEntrypoint payload={stepsPayload} />);
+
+    const sidebar = await screen.findByRole('complementary', { name: 'Workflow navigation' });
+    const pinnedGroup = await within(sidebar).findByRole('list', { name: 'Current workflow' });
+    const filterMatchingList = within(sidebar).getByRole('list', { name: 'Workflow navigation list' });
+    expect(within(pinnedGroup).getByRole('link', { name: /MM-999 selected workflow outside filters/i })).toBeTruthy();
+    expect(within(filterMatchingList).queryByRole('link', { name: /MM-999 selected workflow outside filters/i })).toBeNull();
+    expect(within(filterMatchingList).getByRole('link', { name: /Filtered workflow/i })).toBeTruthy();
+  });
+
+  it('MM-1113 renders only authorized sidebar rows returned by the list endpoint', async () => {
+    window.history.pushState({}, 'Workspace Authorized Sidebar Test', '/workflows/test-123?source=temporal');
+    mockDesktopViewport(true);
+    mockWorkflowWorkspaceFetches({
+      rows: [
+        {
+          workflowId: 'test-123',
+          taskId: 'test-123',
+          source: 'temporal',
+          title: 'Authorized sidebar workflow',
+          status: 'running',
+          state: 'executing',
+          rawState: 'executing',
+          createdAt: '2026-04-09T00:00:00Z',
+        },
+      ],
+    });
+
+    renderWithClient(<WorkflowDetailEntrypoint payload={stepsPayload} />);
+
+    const sidebar = await screen.findByRole('complementary', { name: 'Workflow navigation' });
+    expect(await within(sidebar).findByRole('link', { name: /Authorized sidebar workflow/i })).toBeTruthy();
+    expect(within(sidebar).queryByText(/unauthorized/i)).toBeNull();
+    expect(within(sidebar).queryByRole('link', { name: /unauthorized/i })).toBeNull();
+  });
+
   it('MM-1064 renders compact sidebar status icons for canonical lifecycle states', async () => {
     window.history.pushState({}, 'Workspace Sidebar Icons Test', '/workflows/test-123?source=temporal');
     mockDesktopViewport(true);

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -49,8 +49,8 @@ import {
 } from '../lib/temporalTaskEditing';
 import {
   markWorkflowListReturnFocusIntent,
+  workflowListApiQueryFromContext,
   workflowDetailHref,
-  workflowListContextParams,
   workflowListHrefFromContext,
 } from '../lib/workflowListContext';
 import { WorkflowActionsMenu } from '../components/WorkflowActionsMenu';
@@ -363,11 +363,7 @@ function useWorkflowDetailSubroute(
 }
 
 function workflowWorkspaceListQuery(search: URLSearchParams): string {
-  const pageSize = search.get('limit') || search.get('pageSize') || '25';
-  const params = workflowListContextParams(search);
-  params.delete('limit');
-  params.set('pageSize', pageSize);
-  return params.toString();
+  return workflowListApiQueryFromContext(search);
 }
 
 function sidebarStatusLabel(status: string | null | undefined): string {
@@ -419,11 +415,17 @@ function WorkflowSidebarRow({
   const active = workflowId === activeWorkflowId;
   const status = row.rawState || row.state || row.status || 'unknown';
   const title = row.title?.trim() || workflowId || 'Untitled workflow';
+  const rememberSelection = () => {
+    if (workflowId) {
+      updateDashboardPreferences({ lastSelectedWorkflowId: workflowId });
+    }
+  };
   return (
     <li>
       <a
         className={`workflow-workspace-sidebar-row${pinned ? ' workflow-workspace-sidebar-row-pinned' : ''}`}
         href={workflowDetailHref(workflowId, search)}
+        onClick={rememberSelection}
         aria-current={active ? 'page' : undefined}
         data-active={active ? 'true' : 'false'}
         data-pinned={pinned ? 'true' : 'false'}

--- a/frontend/src/entrypoints/workflow-list.test.tsx
+++ b/frontend/src/entrypoints/workflow-list.test.tsx
@@ -67,6 +67,32 @@ describe('Workflows Entrypoint', () => {
     expect(document.querySelector('.queue-table-wrapper')).toBeTruthy();
   });
 
+  it('MM-1113 renders only authorized workflow rows returned by the list endpoint', async () => {
+    fetchSpy.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        items: [
+          {
+            taskId: 'authorized-table-row',
+            workflowId: 'authorized-table-row',
+            source: 'temporal',
+            title: 'Authorized table workflow',
+            status: 'completed',
+            state: 'completed',
+            rawState: 'completed',
+            createdAt: '2026-03-28T00:00:00Z',
+          },
+        ],
+      }),
+    } as Response);
+
+    renderWithClient(<WorkflowListPage payload={mockPayload} />);
+
+    expect(await screen.findByRole('row', { name: /Authorized table workflow/i })).toBeTruthy();
+    expect(screen.queryByText(/unauthorized/i)).toBeNull();
+    expect(screen.queryByRole('link', { name: /unauthorized/i })).toBeNull();
+  });
+
   it('shows structured API validation detail when the workflow list request fails', async () => {
     fetchSpy.mockResolvedValue({
       ok: false,

--- a/frontend/src/entrypoints/workflow-list.tsx
+++ b/frontend/src/entrypoints/workflow-list.tsx
@@ -1290,6 +1290,12 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
     updateDashboardPreferences({ liveUpdatesEnabled: enabled });
   }, []);
 
+  const rememberExplicitWorkflowSelection = useCallback((workflowId: string) => {
+    if (workflowId) {
+      updateDashboardPreferences({ lastSelectedWorkflowId: workflowId });
+    }
+  }, []);
+
   const handlePageSizeChange = useCallback(
     (size: number) => {
       setPageSize(size);
@@ -2556,6 +2562,7 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
                             <a
                               href={workflowDetailHref(rowWorkflowId(row), detailListContext)}
                               className="workflow-list-row-title"
+                              onClick={() => rememberExplicitWorkflowSelection(rowWorkflowId(row))}
                             >
                               {row.title}
                             </a>
@@ -2616,6 +2623,7 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
                         <a
                           href={workflowDetailHref(rowWorkflowId(row), detailListContext)}
                           className="queue-card-title"
+                          onClick={() => rememberExplicitWorkflowSelection(rowWorkflowId(row))}
                         >
                           {row.title}
                         </a>
@@ -2654,6 +2662,7 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
                         href={workflowDetailHref(rowWorkflowId(row), detailListContext)}
                         className="button secondary queue-card-details-action"
                         role="button"
+                        onClick={() => rememberExplicitWorkflowSelection(rowWorkflowId(row))}
                       >
                         View details
                       </a>

--- a/frontend/src/lib/workflowListContext.test.ts
+++ b/frontend/src/lib/workflowListContext.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import { workflowListContextParams } from "./workflowListContext";
+import {
+  workflowListApiQueryFromContext,
+  workflowListContextParams,
+} from "./workflowListContext";
 
 describe("workflowListContextParams", () => {
   it("preserves supported workflow list filters for detail sidebar queries", () => {
@@ -21,5 +24,17 @@ describe("workflowListContextParams", () => {
     );
 
     expect(params.toString()).toBe("integration=jira");
+  });
+
+  it("normalizes a list route query into the matching executions API query", () => {
+    const query = workflowListApiQueryFromContext(
+      new URLSearchParams(
+        "stateIn=executing&limit=50&progressSignalIn=awaiting_external&unsafe=1",
+      ),
+    );
+
+    expect(query).toBe(
+      "stateIn=executing&progressSignalIn=awaiting_external&source=temporal&pageSize=50",
+    );
   });
 });

--- a/frontend/src/lib/workflowListContext.ts
+++ b/frontend/src/lib/workflowListContext.ts
@@ -46,6 +46,14 @@ const WORKFLOW_LIST_CONTEXT_ALLOWLIST = new Set([
   'targetSkillNotIn',
   'targetSkillBlank',
   'titleContains',
+  'progressPctFrom',
+  'progressPctTo',
+  'progressBucketIn',
+  'progressBucketNotIn',
+  'progressSignalIn',
+  'progressSignalNotIn',
+  'progressStepTitleContains',
+  'progressBlank',
   'scheduledFrom',
   'scheduledTo',
   'scheduledBlank',
@@ -66,6 +74,15 @@ export function workflowListContextParams(source: URLSearchParams): URLSearchPar
     }
   });
   return params;
+}
+
+export function workflowListApiQueryFromContext(source: URLSearchParams): string {
+  const pageSize = source.get('limit') || source.get('pageSize') || '25';
+  const params = workflowListContextParams(source);
+  params.delete('limit');
+  params.set('source', params.get('source') || 'temporal');
+  params.set('pageSize', pageSize);
+  return params.toString();
 }
 
 export function workflowDetailHref(workflowId: string, source: URLSearchParams): string {

--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -240,10 +240,17 @@ samp {
   border-bottom: 1px solid rgb(var(--mm-border) / 0.7);
 }
 
-.masthead-brand {
+.masthead-primary {
   display: inline-flex;
   align-items: center;
   justify-self: start;
+  gap: 0.65rem;
+  min-width: 0;
+}
+
+.masthead-brand {
+  display: inline-flex;
+  align-items: center;
   gap: 0.55rem;
   min-width: 0;
   color: rgb(var(--mm-ink));
@@ -276,6 +283,67 @@ samp {
 
 .masthead-brand-mind {
   color: inherit;
+}
+
+.workflow-list-display-control {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  min-width: 0;
+  padding: 0.16rem;
+  border: 1px solid rgb(var(--mm-border) / 0.66);
+  border-radius: 0.55rem;
+  background: rgb(var(--mm-panel) / 0.52);
+}
+
+.workflow-list-display-option {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  padding: 0;
+  border: 0;
+  border-radius: 0.42rem;
+  background: transparent;
+  color: rgb(var(--mm-ink) / 0.72);
+  cursor: pointer;
+  transition: background 130ms ease, color 130ms ease;
+}
+
+.workflow-list-display-option svg {
+  width: 1rem;
+  height: 1rem;
+  stroke-width: 2;
+}
+
+.workflow-list-display-option:hover {
+  background: rgb(var(--mm-ink) / 0.06);
+  color: rgb(var(--mm-ink));
+}
+
+.workflow-list-display-option[data-active="true"] {
+  background: rgb(var(--mm-accent) / 0.16);
+  color: rgb(var(--mm-ink));
+}
+
+.workflow-list-display-option:focus-visible {
+  outline: none;
+  box-shadow: var(--mm-control-focus-ring);
+}
+
+.workflow-list-display-option:disabled {
+  cursor: wait;
+  opacity: 0.72;
+}
+
+.workflow-list-display-status {
+  max-width: 18ch;
+  padding: 0 0.38rem;
+  color: rgb(var(--mm-muted));
+  font-size: 0.76rem;
+  line-height: 1.15;
+  white-space: normal;
 }
 
 .masthead-title-meta {

--- a/frontend/src/utils/dashboardPreferences.test.ts
+++ b/frontend/src/utils/dashboardPreferences.test.ts
@@ -46,6 +46,7 @@ describe('dashboardPreferences', () => {
         debugFieldsVisible: false,
         workflowWorkspaceSidebarCollapsed: true,
         preferredDetailTab: 'steps',
+        lastSelectedWorkflowId: 'workflow-123',
         defaultRuntime: 'codex_cli',
       });
 
@@ -57,6 +58,7 @@ describe('dashboardPreferences', () => {
       expect(reloaded.createExpertMode).toBe(true);
       expect(reloaded.debugFieldsVisible).toBe(false);
       expect(reloaded.workflowWorkspaceSidebarCollapsed).toBe(true);
+      expect(reloaded.lastSelectedWorkflowId).toBe('workflow-123');
       expect(reloaded.preferredDetailTab).toBe('steps');
     });
 
@@ -110,6 +112,7 @@ describe('dashboardPreferences', () => {
             preferredDetailTab: 'nope', // invalid enum
             liveUpdatesEnabled: 'yes', // wrong type
             workflowWorkspaceSidebarCollapsed: 'yes', // wrong type
+            lastSelectedWorkflowId: '  workflow-456  ',
             createExpertMode: true, // valid
             workflowListColumnVisibility: { repository: false, bogus: true },
             workflowListDefaultStatuses: ['executing', 42, '  failed  ', ''],
@@ -123,6 +126,7 @@ describe('dashboardPreferences', () => {
       expect(prefs.preferredDetailTab).toBe('overview'); // reset
       expect(prefs.liveUpdatesEnabled).toBe(true); // reset to default
       expect(prefs.workflowWorkspaceSidebarCollapsed).toBe(false); // reset to default
+      expect(prefs.lastSelectedWorkflowId).toBe('workflow-456'); // trimmed
       expect(prefs.createExpertMode).toBe(true); // kept
       expect(prefs.workflowListColumnVisibility.repository).toBe(false); // kept
       expect(prefs.workflowListColumnVisibility).not.toHaveProperty('bogus'); // dropped
@@ -189,6 +193,14 @@ describe('dashboardPreferences', () => {
       });
 
       expect(prefs.workflowWorkspaceSidebarCollapsed).toBe(true);
+    });
+
+    it('MM-1113 keeps a valid last selected workflow preference', () => {
+      const prefs = sanitizeDashboardPreferences({
+        lastSelectedWorkflowId: '  remembered-workflow  ',
+      });
+
+      expect(prefs.lastSelectedWorkflowId).toBe('remembered-workflow');
     });
   });
 

--- a/frontend/src/utils/dashboardPreferences.test.ts
+++ b/frontend/src/utils/dashboardPreferences.test.ts
@@ -202,6 +202,12 @@ describe('dashboardPreferences', () => {
 
       expect(prefs.lastSelectedWorkflowId).toBe('remembered-workflow');
     });
+
+    it('MM-1113 sanitizes invalid last selected workflow values to the default', () => {
+      for (const candidate of [null, undefined, 42, false, {}, []]) {
+        expect(sanitizeDashboardPreferences({ lastSelectedWorkflowId: candidate }).lastSelectedWorkflowId).toBe('');
+      }
+    });
   });
 
   describe('reset behavior (MM-964 reset behavior)', () => {
@@ -210,11 +216,13 @@ describe('dashboardPreferences', () => {
         ...DEFAULT_DASHBOARD_PREFERENCES,
         workflowListDensity: 'compact',
         createExpertMode: true,
+        lastSelectedWorkflowId: 'remembered-workflow',
       });
       expect(storedRaw()).not.toBeNull();
 
       const reset = resetDashboardPreferences();
       expect(reset).toEqual(DEFAULT_DASHBOARD_PREFERENCES);
+      expect(reset.lastSelectedWorkflowId).toBe('');
       expect(storedRaw()).toBeNull();
       // A subsequent read also yields defaults.
       expect(readDashboardPreferences()).toEqual(DEFAULT_DASHBOARD_PREFERENCES);

--- a/frontend/src/utils/dashboardPreferences.ts
+++ b/frontend/src/utils/dashboardPreferences.ts
@@ -70,6 +70,8 @@ export type DashboardPreferences = {
   debugFieldsVisible: boolean;
   /** Whether the desktop workflow detail sidebar is collapsed on reload. */
   workflowWorkspaceSidebarCollapsed: boolean;
+  /** Last workflow explicitly opened by the operator. */
+  lastSelectedWorkflowId: string;
   /** Preferred default workflow detail tab. */
   preferredDetailTab: WorkflowDetailTab;
   /** Preferred runtime default for the create page, where safe. */
@@ -95,6 +97,7 @@ export const DEFAULT_DASHBOARD_PREFERENCES: DashboardPreferences = {
   createExpertMode: false,
   debugFieldsVisible: true,
   workflowWorkspaceSidebarCollapsed: false,
+  lastSelectedWorkflowId: '',
   preferredDetailTab: 'overview',
   defaultRuntime: '',
   defaultProviderProfile: '',
@@ -188,6 +191,7 @@ export function sanitizeDashboardPreferences(value: unknown): DashboardPreferenc
       value.workflowWorkspaceSidebarCollapsed,
       DEFAULT_DASHBOARD_PREFERENCES.workflowWorkspaceSidebarCollapsed,
     ),
+    lastSelectedWorkflowId: sanitizeString(value.lastSelectedWorkflowId),
     preferredDetailTab: sanitizeDetailTab(value.preferredDetailTab),
     defaultRuntime: sanitizeString(value.defaultRuntime),
     defaultProviderProfile: sanitizeString(value.defaultProviderProfile),


### PR DESCRIPTION
## Jira
- Jira issue key: MM-1113
- Active MoonSpec feature path: docs/tmp/jira-orchestrate-mm-1113-handoff.json

## Verification
- MoonSpec verify verdict: FULLY_IMPLEMENTED (`var/artifacts/moonspec-verify/jira-orchestrate.json`)
- Tests run:
  - `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --ui-args frontend/src/utils/dashboardPreferences.test.ts frontend/src/lib/workflowListContext.test.ts frontend/src/entrypoints/dashboard.test.tsx frontend/src/entrypoints/workflow-detail.test.tsx` failed before Vitest because `.specify/templates/spec-template.md` is absent.
  - `./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/utils/dashboardPreferences.test.ts frontend/src/lib/workflowListContext.test.ts frontend/src/entrypoints/dashboard.test.tsx frontend/src/entrypoints/workflow-detail.test.tsx -t "MM-1113|MM-1010 keeps an empty filtered sidebar state|MM-999 does not show a pinned current row"` passed in a disposable colon-free copy: 15 passed, 248 skipped.
  - `./node_modules/.bin/tsc --noEmit -p frontend/tsconfig.json` passed in the primary workspace.

## Remaining Risks
- The repository test wrapper could not reach frontend tests because `.specify/templates/spec-template.md` is absent in this checkout.
- The broader dashboard suite has one unrelated masthead CSS assertion failure noted by verification; focused MM-1113 coverage passed.

## Doc Reconciliation Outcome
- `var/artifacts/jira-orchestrate-doc-reconcile.json` reports `no_update_required`.
- Canonical doc path reviewed: `docs/UI/WorkflowListDisplayModes.md`.
- No canonical docs were updated because verified canonical claim coverage reported `driftStatus NONE`, no doc-discovery ledger was present, and no definite source document drift required an edit or escalation.

## Documentation Conformance
- Canonical sources: `docs/UI/WorkflowListDisplayModes.md`, `README.md`, repository `AGENTS.md` instructions.
- Temporary artifacts consulted: `docs/tmp/jira-orchestrate-mm-1113-handoff.json`, `var/artifacts/moonspec-verify/jira-orchestrate.json`, `var/artifacts/jira-orchestrate-doc-reconcile.json`.
- Claim coverage: `CLAIM-docs-ui-workflowlistdisplaymodes-005`, `CLAIM-docs-ui-workflowlistdisplaymodes-010`, and `CLAIM-docs-ui-workflowlistdisplaymodes-011` are verified with no drift in the MoonSpec verification report; MM-1113 acceptance coverage is verified.
- Reconciliation outcome: no canonical update required; no escalation issue created.
