### PR TITLE
[codex] Canonicalize MoonSpec verifier next actions

### DIFF
--- a/api_service/data/presets/github-issue-orchestrate.yaml
+++ b/api_service/data/presets/github-issue-orchestrate.yaml
@@ -355,8 +355,9 @@ steps:
     skip every remaining remediation attempt, and do not create a pull request.
 
 
-    Continue toward pull request creation only when the latest post-remediation verdict is
-    FULLY_IMPLEMENTED.'
+    When the latest post-remediation verdict is FULLY_IMPLEMENTED, set recommendedNextAction
+    to "advance". The workflow runtime owns pull request creation; do not encode pull
+    request creation or any step-specific destination in recommendedNextAction.'
   skill:
     id: moonspec-verify
     args:
@@ -423,8 +424,9 @@ steps:
     skip every remaining remediation attempt, and do not create a pull request.
 
 
-    Continue toward pull request creation only when the latest post-remediation verdict is
-    FULLY_IMPLEMENTED.'
+    When the latest post-remediation verdict is FULLY_IMPLEMENTED, set recommendedNextAction
+    to "advance". The workflow runtime owns pull request creation; do not encode pull
+    request creation or any step-specific destination in recommendedNextAction.'
   skill:
     id: moonspec-verify
     args:
@@ -491,8 +493,9 @@ steps:
     skip every remaining remediation attempt, and do not create a pull request.
 
 
-    Continue toward pull request creation only when the latest post-remediation verdict is
-    FULLY_IMPLEMENTED.'
+    When the latest post-remediation verdict is FULLY_IMPLEMENTED, set recommendedNextAction
+    to "advance". The workflow runtime owns pull request creation; do not encode pull
+    request creation or any step-specific destination in recommendedNextAction.'
   skill:
     id: moonspec-verify
     args:
@@ -559,8 +562,9 @@ steps:
     skip every remaining remediation attempt, and do not create a pull request.
 
 
-    Continue toward pull request creation only when the latest post-remediation verdict is
-    FULLY_IMPLEMENTED.'
+    When the latest post-remediation verdict is FULLY_IMPLEMENTED, set recommendedNextAction
+    to "advance". The workflow runtime owns pull request creation; do not encode pull
+    request creation or any step-specific destination in recommendedNextAction.'
   skill:
     id: moonspec-verify
     args:
@@ -627,8 +631,9 @@ steps:
     skip every remaining remediation attempt, and do not create a pull request.
 
 
-    Continue toward pull request creation only when the latest post-remediation verdict is
-    FULLY_IMPLEMENTED.'
+    When the latest post-remediation verdict is FULLY_IMPLEMENTED, set recommendedNextAction
+    to "advance". The workflow runtime owns pull request creation; do not encode pull
+    request creation or any step-specific destination in recommendedNextAction.'
   skill:
     id: moonspec-verify
     args:
@@ -693,7 +698,9 @@ steps:
     do not create a pull request.
 
 
-    Continue to pull request creation only when this post-remediation verdict is FULLY_IMPLEMENTED.'
+    If this post-remediation verdict is FULLY_IMPLEMENTED, set recommendedNextAction
+    to "advance". The workflow runtime owns pull request creation; do not encode pull
+    request creation or any step-specific destination in recommendedNextAction.'
   skill:
     id: moonspec-verify
     args:

--- a/api_service/data/presets/issue-implement-work-pr.yaml
+++ b/api_service/data/presets/issue-implement-work-pr.yaml
@@ -223,7 +223,9 @@ steps:
 
 
     Write the complete structured verifier result to {{ inputs.verify_artifact_path }}.
-    Continue to pull request creation only when this post-remediation verdict is FULLY_IMPLEMENTED.'
+    If this post-remediation verdict is FULLY_IMPLEMENTED, set recommendedNextAction
+    to "advance". The workflow runtime owns pull request creation; do not encode
+    pull request creation or any step-specific destination in recommendedNextAction.'
   skill:
     id: moonspec-verify
     args:
@@ -297,7 +299,9 @@ steps:
 
 
     Write the complete structured verifier result to {{ inputs.verify_artifact_path }}.
-    Continue to pull request creation only when this post-remediation verdict is FULLY_IMPLEMENTED.'
+    If this post-remediation verdict is FULLY_IMPLEMENTED, set recommendedNextAction
+    to "advance". The workflow runtime owns pull request creation; do not encode
+    pull request creation or any step-specific destination in recommendedNextAction.'
   skill:
     id: moonspec-verify
     args:
@@ -371,7 +375,9 @@ steps:
 
 
     Write the complete structured verifier result to {{ inputs.verify_artifact_path }}.
-    Continue to pull request creation only when this post-remediation verdict is FULLY_IMPLEMENTED.'
+    If this post-remediation verdict is FULLY_IMPLEMENTED, set recommendedNextAction
+    to "advance". The workflow runtime owns pull request creation; do not encode
+    pull request creation or any step-specific destination in recommendedNextAction.'
   skill:
     id: moonspec-verify
     args:
@@ -445,7 +451,9 @@ steps:
 
 
     Write the complete structured verifier result to {{ inputs.verify_artifact_path }}.
-    Continue to pull request creation only when this post-remediation verdict is FULLY_IMPLEMENTED.'
+    If this post-remediation verdict is FULLY_IMPLEMENTED, set recommendedNextAction
+    to "advance". The workflow runtime owns pull request creation; do not encode
+    pull request creation or any step-specific destination in recommendedNextAction.'
   skill:
     id: moonspec-verify
     args:
@@ -519,7 +527,9 @@ steps:
 
 
     Write the complete structured verifier result to {{ inputs.verify_artifact_path }}.
-    Continue to pull request creation only when this post-remediation verdict is FULLY_IMPLEMENTED.'
+    If this post-remediation verdict is FULLY_IMPLEMENTED, set recommendedNextAction
+    to "advance". The workflow runtime owns pull request creation; do not encode
+    pull request creation or any step-specific destination in recommendedNextAction.'
   skill:
     id: moonspec-verify
     args:
@@ -593,7 +603,9 @@ steps:
 
 
     Write the complete structured verifier result to {{ inputs.verify_artifact_path }}.
-    Continue to pull request creation only when this post-remediation verdict is FULLY_IMPLEMENTED.'
+    If this post-remediation verdict is FULLY_IMPLEMENTED, set recommendedNextAction
+    to "advance". The workflow runtime owns pull request creation; do not encode
+    pull request creation or any step-specific destination in recommendedNextAction.'
   skill:
     id: moonspec-verify
     args:

--- a/api_service/data/presets/jira-orchestrate.yaml
+++ b/api_service/data/presets/jira-orchestrate.yaml
@@ -256,7 +256,7 @@ steps:
       If the verdict is ADDITIONAL_WORK_NEEDED and another remediation attempt remains, preserve the verification report as the mandatory input for the next remediation attempt.
       If the verdict is NO_DETERMINATION, stop and report the missing evidence, commands, or context unless the missing evidence is recoverable in the current runtime by the next remediation attempt. If the verdict is BLOCKED, FAILED_UNRECOVERABLE, or ENVIRONMENT_CONTAMINATED_BY_SKILL_PROJECTION, treat it as terminal, classify runtime or infrastructure causes as environment failure, skip every remaining remediation attempt, and do not create a pull request.
 
-      Continue toward pull request creation only when the latest post-remediation verdict is FULLY_IMPLEMENTED.
+      When the latest post-remediation verdict is FULLY_IMPLEMENTED, set recommendedNextAction to "advance". The workflow runtime owns pull request creation; do not encode pull request creation or any step-specific destination in recommendedNextAction.
     skill:
       id: moonspec-verify
       args:
@@ -299,7 +299,7 @@ steps:
       If the verdict is ADDITIONAL_WORK_NEEDED and another remediation attempt remains, preserve the verification report as the mandatory input for the next remediation attempt.
       If the verdict is NO_DETERMINATION, stop and report the missing evidence, commands, or context unless the missing evidence is recoverable in the current runtime by the next remediation attempt. If the verdict is BLOCKED, FAILED_UNRECOVERABLE, or ENVIRONMENT_CONTAMINATED_BY_SKILL_PROJECTION, treat it as terminal, classify runtime or infrastructure causes as environment failure, skip every remaining remediation attempt, and do not create a pull request.
 
-      Continue toward pull request creation only when the latest post-remediation verdict is FULLY_IMPLEMENTED.
+      When the latest post-remediation verdict is FULLY_IMPLEMENTED, set recommendedNextAction to "advance". The workflow runtime owns pull request creation; do not encode pull request creation or any step-specific destination in recommendedNextAction.
     skill:
       id: moonspec-verify
       args:
@@ -342,7 +342,7 @@ steps:
       If the verdict is ADDITIONAL_WORK_NEEDED and another remediation attempt remains, preserve the verification report as the mandatory input for the next remediation attempt.
       If the verdict is NO_DETERMINATION, stop and report the missing evidence, commands, or context unless the missing evidence is recoverable in the current runtime by the next remediation attempt. If the verdict is BLOCKED, FAILED_UNRECOVERABLE, or ENVIRONMENT_CONTAMINATED_BY_SKILL_PROJECTION, treat it as terminal, classify runtime or infrastructure causes as environment failure, skip every remaining remediation attempt, and do not create a pull request.
 
-      Continue toward pull request creation only when the latest post-remediation verdict is FULLY_IMPLEMENTED.
+      When the latest post-remediation verdict is FULLY_IMPLEMENTED, set recommendedNextAction to "advance". The workflow runtime owns pull request creation; do not encode pull request creation or any step-specific destination in recommendedNextAction.
     skill:
       id: moonspec-verify
       args:
@@ -385,7 +385,7 @@ steps:
       If the verdict is ADDITIONAL_WORK_NEEDED and another remediation attempt remains, preserve the verification report as the mandatory input for the next remediation attempt.
       If the verdict is NO_DETERMINATION, stop and report the missing evidence, commands, or context unless the missing evidence is recoverable in the current runtime by the next remediation attempt. If the verdict is BLOCKED, FAILED_UNRECOVERABLE, or ENVIRONMENT_CONTAMINATED_BY_SKILL_PROJECTION, treat it as terminal, classify runtime or infrastructure causes as environment failure, skip every remaining remediation attempt, and do not create a pull request.
 
-      Continue toward pull request creation only when the latest post-remediation verdict is FULLY_IMPLEMENTED.
+      When the latest post-remediation verdict is FULLY_IMPLEMENTED, set recommendedNextAction to "advance". The workflow runtime owns pull request creation; do not encode pull request creation or any step-specific destination in recommendedNextAction.
     skill:
       id: moonspec-verify
       args:
@@ -428,7 +428,7 @@ steps:
       If the verdict is ADDITIONAL_WORK_NEEDED and another remediation attempt remains, preserve the verification report as the mandatory input for the next remediation attempt.
       If the verdict is NO_DETERMINATION, stop and report the missing evidence, commands, or context unless the missing evidence is recoverable in the current runtime by the next remediation attempt. If the verdict is BLOCKED, FAILED_UNRECOVERABLE, or ENVIRONMENT_CONTAMINATED_BY_SKILL_PROJECTION, treat it as terminal, classify runtime or infrastructure causes as environment failure, skip every remaining remediation attempt, and do not create a pull request.
 
-      Continue toward pull request creation only when the latest post-remediation verdict is FULLY_IMPLEMENTED.
+      When the latest post-remediation verdict is FULLY_IMPLEMENTED, set recommendedNextAction to "advance". The workflow runtime owns pull request creation; do not encode pull request creation or any step-specific destination in recommendedNextAction.
     skill:
       id: moonspec-verify
       args:
@@ -470,7 +470,7 @@ steps:
 
       This is the controlling verification gate for Jira Orchestrate publication. If the verdict is ADDITIONAL_WORK_NEEDED or NO_DETERMINATION, the remediation budget is exhausted: stop the orchestration, report the gaps or missing evidence, and do not continue to pull request creation. If the verdict is BLOCKED, FAILED_UNRECOVERABLE, or ENVIRONMENT_CONTAMINATED_BY_SKILL_PROJECTION, classify runtime or infrastructure causes as environment failure, stop immediately, and do not create a pull request.
 
-      Continue to pull request creation only when this post-remediation verdict is FULLY_IMPLEMENTED.
+      If this post-remediation verdict is FULLY_IMPLEMENTED, set recommendedNextAction to "advance". The workflow runtime owns pull request creation; do not encode pull request creation or any step-specific destination in recommendedNextAction.
     skill:
       id: moonspec-verify
       args:

--- a/docs/Workflows/WorkflowPublishing.md
+++ b/docs/Workflows/WorkflowPublishing.md
@@ -291,8 +291,11 @@ The gate distinguishes a verifier judgment from a malformed verdict envelope:
 
 - The runtime injects the canonical output contract (allowed `verdict` and
   `recommendedNextAction` values) into moonspec-verify instructions, and the
-  artifact-publication boundary records `contractViolations` on the structured
-  gate payload when the verifier JSON drifts from that contract.
+  artifact-publication boundary derives the canonical `recommendedNextAction`
+  from the verifier `verdict`. When the model-authored action drifts from the
+  canonical vocabulary or encodes a step-specific destination, MoonMind
+  preserves the raw action as diagnostic evidence but validates the derived
+  action.
 - A gate payload that fails contract validation is downgraded fail-closed to
   `NO_DETERMINATION`, and the gate records a `downgradeReason` naming the
   declared verdict and the violating field in publish context, the blocking

--- a/moonmind/workflows/skills/approval_policy.py
+++ b/moonmind/workflows/skills/approval_policy.py
@@ -37,6 +37,30 @@ def recommended_next_actions() -> tuple[str, ...]:
     return tuple(sorted(_RECOMMENDED_NEXT_ACTIONS))
 
 
+def recommended_next_action_for_verdict(
+    verdict: Any,
+    *,
+    recoverable_in_current_runtime: bool = False,
+) -> str | None:
+    """Return the runtime-owned next action for a canonical gate verdict."""
+
+    normalized = str(verdict or "").strip().upper()
+    normalized = _VERDICT_SYNONYMS.get(normalized, normalized)
+    if normalized == "FULLY_IMPLEMENTED":
+        return "advance"
+    if normalized == "ADDITIONAL_WORK_NEEDED":
+        return "reattempt_current_step"
+    if normalized == "NO_DETERMINATION":
+        return (
+            "reattempt_current_step"
+            if recoverable_in_current_runtime
+            else "needs_human"
+        )
+    if normalized in {"BLOCKED", "FAILED_UNRECOVERABLE"}:
+        return "blocked"
+    return None
+
+
 def step_gate_contract_violations(payload: Mapping[str, Any]) -> list[str]:
     """Return the contract violations that force a fail-closed downgrade.
 

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -185,6 +185,7 @@ from moonmind.workflows.skills.skill_registry import (
     parse_skill_registry,
 )
 from moonmind.workflows.skills.approval_policy import (
+    recommended_next_action_for_verdict,
     recommended_next_actions,
     step_gate_contract_violations,
 )
@@ -7192,6 +7193,8 @@ class TemporalAgentRuntimeActivities:
                 "verification_report_ref",
                 "reportRef",
                 "report_ref",
+                "rawRecommendedNextAction",
+                "raw_recommended_next_action",
             )
             for key in scalar_keys:
                 value = _scalar(gate_payload.get(key))
@@ -7230,6 +7233,42 @@ class TemporalAgentRuntimeActivities:
                 compact["contractViolations"] = compact_violations
 
             return compact
+
+        def _canonicalize_moonspec_verify_gate_payload(
+            gate_payload: Mapping[str, Any],
+        ) -> dict[str, Any]:
+            """Derive MoonSpec gate action from verdict, preserving model output."""
+
+            canonical_payload = dict(gate_payload)
+            recoverable_raw = (
+                canonical_payload.get("recoverableInCurrentRuntime")
+                if "recoverableInCurrentRuntime" in canonical_payload
+                else canonical_payload.get("recoverable_in_current_runtime")
+            )
+            try:
+                recoverable = _coerce_bool(recoverable_raw, default=False)
+            except ValueError:
+                recoverable = False
+            canonical_action = recommended_next_action_for_verdict(
+                canonical_payload.get("verdict"),
+                recoverable_in_current_runtime=recoverable,
+            )
+            if not canonical_action:
+                return canonical_payload
+            raw_action = canonical_payload.get("recommendedNextAction")
+            if raw_action is None:
+                raw_action = canonical_payload.get("recommended_next_action")
+            raw_action_text = (
+                raw_action.strip() if isinstance(raw_action, str) else None
+            )
+            if raw_action is not None and raw_action_text != canonical_action:
+                canonical_payload.setdefault(
+                    "rawRecommendedNextAction",
+                    raw_action if isinstance(raw_action, str) else str(raw_action),
+                )
+            canonical_payload["recommendedNextAction"] = canonical_action
+            canonical_payload.pop("recommended_next_action", None)
+            return canonical_payload
 
         async def _publish_moonspec_verify_artifact() -> dict[str, Any]:
             verify_path = _metadata_text(
@@ -7273,7 +7312,7 @@ class TemporalAgentRuntimeActivities:
                     verify_path,
                 )
                 return {}
-            gate_payload = dict(payload)
+            gate_payload = _canonicalize_moonspec_verify_gate_payload(payload)
             contract_violations = step_gate_contract_violations(gate_payload)
             if contract_violations:
                 # Surface violations at the boundary where the verifier JSON
@@ -8479,9 +8518,12 @@ class TemporalAgentRuntimeActivities:
             "`recoverableInCurrentRuntime`, and `remainingWork` fields.\n"
             f"- `verdict` must be exactly one of: {verdict_values}.\n"
             f"- `recommendedNextAction` must be exactly one of: {next_action_values}. "
-            "Any other value (for example \"create_pull_request\") is a contract "
-            "violation that forces the publication gate to fail closed, discarding "
-            "an otherwise passing verdict.\n"
+            "Any other model-authored value is contract drift; MoonMind preserves "
+            "it as a raw diagnostic and derives the canonical action from the "
+            "verdict.\n"
+            '- For `FULLY_IMPLEMENTED`, set `recommendedNextAction` to "advance"; '
+            "do not encode pull request creation or any other workflow-specific "
+            "destination in this field.\n"
             "- Still return the Markdown MoonSpec Verification Report in the assistant response."
         )
         return instructions.rstrip() + "\n\n" + block

--- a/tests/unit/workflows/temporal/test_activity_runtime.py
+++ b/tests/unit/workflows/temporal/test_activity_runtime.py
@@ -120,7 +120,8 @@ async def test_prepare_managed_codex_turn_adds_moonspec_verify_artifact_hint() -
     assert '"BLOCKED"' in prepared
     assert '"advance"' in prepared
     assert '"reattempt_current_step"' in prepared
-    assert "create_pull_request" in prepared
+    assert '`FULLY_IMPLEMENTED`, set `recommendedNextAction` to "advance"' in prepared
+    assert "raw diagnostic" in prepared
 
 
 async def test_prepare_managed_codex_turn_appends_vocab_when_path_already_present() -> None:
@@ -137,7 +138,7 @@ async def test_prepare_managed_codex_turn_appends_vocab_when_path_already_presen
     assert prepared.count("complete structured verifier JSON") == 0
     assert '"FULLY_IMPLEMENTED"' in prepared
     assert '"advance"' in prepared
-    assert "create_pull_request" in prepared
+    assert "workflow-specific destination" in prepared
 
 
 async def test_codex_skill_payload_rejects_auto_publish_mode() -> None:
@@ -5050,7 +5051,7 @@ async def test_agent_runtime_publish_artifacts_publishes_moonspec_verify_json(
             )
 
 
-async def test_agent_runtime_publish_artifacts_flags_moonspec_contract_violations(
+async def test_agent_runtime_publish_artifacts_canonicalizes_moonspec_next_action(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -5123,8 +5124,13 @@ async def test_agent_runtime_publish_artifacts_flags_moonspec_contract_violation
                 )
             )
 
-            violations = result.metadata["moonSpecVerify"]["contractViolations"]
-            assert any("create_pull_request" in item for item in violations)
+            verify_payload = result.metadata["moonSpecVerify"]
+            assert verify_payload["recommendedNextAction"] == "advance"
+            assert (
+                verify_payload["rawRecommendedNextAction"]
+                == "create_pull_request"
+            )
+            assert "contractViolations" not in verify_payload
             AgentRunResult(**result.model_dump(mode="json", by_alias=True))
 
 


### PR DESCRIPTION
## Summary

- Derive MoonSpec verifier `recommendedNextAction` from the verifier verdict at artifact publication time.
- Preserve model-authored action drift as `rawRecommendedNextAction` diagnostic evidence instead of letting a PR-specific enum veto an otherwise passing verdict.
- Update Jira/GitHub orchestration preset verifier instructions and publishing docs to use `FULLY_IMPLEMENTED -> advance`.

## Root Cause

MoonSpec verifier prompts included workflow prose about pull request creation. A verifier could turn that prose into a non-canonical action such as `advance_to_pull_request_creation`, which failed the structured gate contract even when the verdict and evidence were `FULLY_IMPLEMENTED`.

## Validation

- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_activity_runtime.py tests/unit/workflows/skills/test_review_gate_contracts.py tests/unit/api/test_presets_service.py tests/integration/test_startup_preset_seeding.py`
- `python3 -m py_compile moonmind/workflows/skills/approval_policy.py moonmind/workflows/temporal/activity_runtime.py`
- `git diff --check`