### PR TITLE
PR 3004 was meant to address a number of issues with the list radio buttons, but some issues remain.

### DIFF
--- a/frontend/src/components/WorkflowColumnHeader.tsx
+++ b/frontend/src/components/WorkflowColumnHeader.tsx
@@ -21,7 +21,7 @@ export function WorkflowColumnFilterButton({
       aria-expanded={expanded}
       onClick={onClick}
     >
-      <ListFilter className="workflow-list-column-filter-icon" size={15} aria-hidden="true" />
+      <ListFilter className="workflow-list-column-filter-icon" aria-hidden="true" />
     </button>
   );
 }
@@ -39,7 +39,7 @@ export function WorkflowColumnHeader({
 }) {
   return (
     <div className="workflow-list-column-header">
-      <span className="workflow-list-column-header-label">{label}</span>
+      {label}
       <div className="workflow-list-column-filter" ref={filterRef}>
         {filterButton}
         {children}

--- a/frontend/src/components/WorkflowColumnHeader.tsx
+++ b/frontend/src/components/WorkflowColumnHeader.tsx
@@ -1,0 +1,49 @@
+import { ListFilter } from 'lucide-react';
+import type { ReactNode, Ref } from 'react';
+
+export function WorkflowColumnFilterButton({
+  active,
+  expanded,
+  ariaLabel,
+  onClick,
+}: {
+  active: boolean;
+  expanded: boolean;
+  ariaLabel: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      className={`workflow-list-column-filter-button${active ? ' is-active' : ''}`}
+      aria-label={ariaLabel}
+      aria-haspopup="dialog"
+      aria-expanded={expanded}
+      onClick={onClick}
+    >
+      <ListFilter className="workflow-list-column-filter-icon" size={15} aria-hidden="true" />
+    </button>
+  );
+}
+
+export function WorkflowColumnHeader({
+  label,
+  filterButton,
+  filterRef,
+  children,
+}: {
+  label: ReactNode;
+  filterButton: ReactNode;
+  filterRef?: Ref<HTMLDivElement>;
+  children?: ReactNode;
+}) {
+  return (
+    <div className="workflow-list-column-header">
+      <span className="workflow-list-column-header-label">{label}</span>
+      <div className="workflow-list-column-filter" ref={filterRef}>
+        {filterButton}
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/entrypoints/dashboard.test.tsx
+++ b/frontend/src/entrypoints/dashboard.test.tsx
@@ -1388,8 +1388,6 @@ describe('Dashboard shared entry', () => {
   });
 
   it('enforces MM-961 reduced-motion suppression for the panel entry animation', async () => {
-    expect(cssRuleBlock(dashboardCss, '.panel')).toContain('margin-top: 0;');
-
     const panelReducedMotionBlock = cssRuleBlockMatching(
       dashboardCss,
       (rule) =>
@@ -1399,6 +1397,10 @@ describe('Dashboard shared entry', () => {
         rule.parent.params.includes('prefers-reduced-motion: reduce'),
     );
     expect(panelReducedMotionBlock).toContain('animation: none !important');
+  });
+
+  it('keeps the dashboard panel flush with the masthead', async () => {
+    expect(cssRuleBlock(dashboardCss, '.panel')).toContain('margin-top: 0;');
   });
 
   it('disables MM-961 fixed background attachment on mobile and touch/low-power devices', async () => {

--- a/frontend/src/entrypoints/dashboard.test.tsx
+++ b/frontend/src/entrypoints/dashboard.test.tsx
@@ -1912,19 +1912,28 @@ describe('Dashboard shared entry', () => {
     expect(dashboardCss).toMatch(
       /\.masthead-brand\s*\{[^}]*justify-self:\s*start;/s,
     );
-    expect(cssRuleBlock(dashboardCss, '.masthead-brand')).toContain('grid-column: 1;');
     expect(dashboardCss).toMatch(
       /\.workflow-list-display-control\s*\{[^}]*justify-self:\s*start;/s,
     );
-    expect(cssRuleBlock(dashboardCss, '.workflow-list-display-control')).toContain('grid-column: 2;');
     expect(dashboardCss).toMatch(
       /\.masthead-nav\s*\{[^}]*align-self:\s*stretch;[^}]*justify-content:\s*center;[^}]*justify-self:\s*center;/s,
     );
-    expect(cssRuleBlock(dashboardCss, '.masthead-nav')).toContain('grid-column: 3;');
     expect(dashboardCss).toMatch(
       /\.masthead-title-meta\s*\{[^}]*justify-self:\s*end;[^}]*justify-content:\s*flex-end;/s,
     );
-    expect(cssRuleBlock(dashboardCss, '.masthead-title-meta')).toContain('grid-column: 4;');
+    const desktopMastheadRule = (selector: string) =>
+      cssRuleBlockMatching(
+        dashboardCss,
+        (rule) =>
+          normalizeCssSelector(rule.selector) === selector &&
+          rule.parent?.type === 'atrule' &&
+          rule.parent.name === 'media' &&
+          rule.parent.params.includes('min-width: 1181px'),
+      );
+    expect(desktopMastheadRule('.masthead-brand')).toContain('grid-column: 1;');
+    expect(desktopMastheadRule('.workflow-list-display-control')).toContain('grid-column: 2;');
+    expect(desktopMastheadRule('.masthead-nav')).toContain('grid-column: 1 / -1;');
+    expect(desktopMastheadRule('.masthead-title-meta')).toContain('grid-column: 4;');
     expect(cssRuleBlock(dashboardCss, '.masthead-title-meta .version-badge')).toContain('white-space: nowrap;');
   });
 

--- a/frontend/src/entrypoints/dashboard.test.tsx
+++ b/frontend/src/entrypoints/dashboard.test.tsx
@@ -1388,6 +1388,8 @@ describe('Dashboard shared entry', () => {
   });
 
   it('enforces MM-961 reduced-motion suppression for the panel entry animation', async () => {
+    expect(cssRuleBlock(dashboardCss, '.panel')).toContain('margin-top: 0;');
+
     const panelReducedMotionBlock = cssRuleBlockMatching(
       dashboardCss,
       (rule) =>
@@ -1908,15 +1910,19 @@ describe('Dashboard shared entry', () => {
     expect(dashboardCss).toMatch(
       /\.masthead-brand\s*\{[^}]*justify-self:\s*start;/s,
     );
+    expect(cssRuleBlock(dashboardCss, '.masthead-brand')).toContain('grid-column: 1;');
     expect(dashboardCss).toMatch(
       /\.workflow-list-display-control\s*\{[^}]*justify-self:\s*start;/s,
     );
+    expect(cssRuleBlock(dashboardCss, '.workflow-list-display-control')).toContain('grid-column: 2;');
     expect(dashboardCss).toMatch(
       /\.masthead-nav\s*\{[^}]*align-self:\s*stretch;[^}]*justify-content:\s*center;[^}]*justify-self:\s*center;/s,
     );
+    expect(cssRuleBlock(dashboardCss, '.masthead-nav')).toContain('grid-column: 3;');
     expect(dashboardCss).toMatch(
       /\.masthead-title-meta\s*\{[^}]*justify-self:\s*end;[^}]*justify-content:\s*flex-end;/s,
     );
+    expect(cssRuleBlock(dashboardCss, '.masthead-title-meta')).toContain('grid-column: 4;');
     expect(cssRuleBlock(dashboardCss, '.masthead-title-meta .version-badge')).toContain('white-space: nowrap;');
   });
 

--- a/frontend/src/entrypoints/workflow-detail.test.tsx
+++ b/frontend/src/entrypoints/workflow-detail.test.tsx
@@ -724,7 +724,7 @@ describe('Workflow Detail Entrypoint', () => {
 
     const workflowFilter = within(sidebar).getByRole('button', { name: 'Workflow sidebar filter. No filter applied.' });
     const workflowHeader = workflowFilter.closest('.workflow-list-column-header');
-    expect(workflowHeader?.querySelector('.workflow-list-column-header-label')?.textContent).toContain('Workflow');
+    expect(workflowHeader?.querySelector('.workflow-workspace-sidebar-header-title')?.textContent).toContain('Workflow');
 
     fireEvent.click(workflowFilter);
     fireEvent.change(screen.getByLabelText('Workflow sidebar filter value'), {

--- a/frontend/src/entrypoints/workflow-detail.test.tsx
+++ b/frontend/src/entrypoints/workflow-detail.test.tsx
@@ -722,7 +722,11 @@ describe('Workflow Detail Entrypoint', () => {
     expect(await within(sidebar).findByRole('link', { name: /MM-997 selected workflow/i })).toBeTruthy();
     expect(await within(sidebar).findByRole('link', { name: /Another workflow/i })).toBeTruthy();
 
-    fireEvent.click(within(sidebar).getByRole('button', { name: 'Workflow sidebar filter. No filter applied.' }));
+    const workflowFilter = within(sidebar).getByRole('button', { name: 'Workflow sidebar filter. No filter applied.' });
+    const workflowHeader = workflowFilter.closest('.workflow-list-column-header');
+    expect(workflowHeader?.querySelector('.workflow-list-column-header-label')?.textContent).toContain('Workflow');
+
+    fireEvent.click(workflowFilter);
     fireEvent.change(screen.getByLabelText('Workflow sidebar filter value'), {
       target: { value: 'Another' },
     });

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -22,12 +22,15 @@ import {
   RouteIcon,
   type RouteIconHandle,
 } from 'lucide-animated';
-import { ListFilter } from 'lucide-react';
 import { Virtuoso } from 'react-virtuoso';
 import { z } from 'zod';
 import { BootPayload } from '../boot/parseBootPayload';
 import { ExecutionStatusPill } from '../components/ExecutionStatusPill';
 import { DashboardActionDialog } from '../components/DashboardActionDialog';
+import {
+  WorkflowColumnFilterButton,
+  WorkflowColumnHeader,
+} from '../components/WorkflowColumnHeader';
 import { executionStatusPillProps } from '../utils/executionStatusPillClasses';
 import { CANONICAL_STEP_STATUSES, StatusIcon } from '../utils/statusIcons';
 import { SkillProvenanceBadge } from '../components/skills/SkillProvenanceBadge';
@@ -520,22 +523,18 @@ function WorkflowSidebarHeader({
 
   return (
     <header className="workflow-workspace-sidebar-header">
-      <span className="workflow-workspace-sidebar-header-title">Workflow</span>
       <div className="workflow-workspace-sidebar-filter" ref={filterRef}>
-        <button
-          type="button"
-          className={`workflow-list-column-filter-button${active ? ' is-active' : ''}`}
-          aria-label={active ? `Workflow sidebar filter: ${filterText}` : 'Workflow sidebar filter. No filter applied.'}
-          aria-haspopup="dialog"
-          aria-expanded={open}
-          onClick={() => setOpen((value) => !value)}
-        >
-          <ListFilter
-            className="workflow-list-column-filter-icon"
-            size={15}
-            aria-hidden="true"
-          />
-        </button>
+        <WorkflowColumnHeader
+          label={<span className="workflow-workspace-sidebar-header-title">Workflow</span>}
+          filterButton={
+            <WorkflowColumnFilterButton
+              active={active}
+              expanded={open}
+              ariaLabel={active ? `Workflow sidebar filter: ${filterText}` : 'Workflow sidebar filter. No filter applied.'}
+              onClick={() => setOpen((value) => !value)}
+            />
+          }
+        />
         {open ? (
           <div
             className="workflow-workspace-sidebar-filter-popover workflow-list-column-filter-popover"

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -523,18 +523,18 @@ function WorkflowSidebarHeader({
 
   return (
     <header className="workflow-workspace-sidebar-header">
-      <div className="workflow-workspace-sidebar-filter" ref={filterRef}>
-        <WorkflowColumnHeader
-          label={<span className="workflow-workspace-sidebar-header-title">Workflow</span>}
-          filterButton={
-            <WorkflowColumnFilterButton
-              active={active}
-              expanded={open}
-              ariaLabel={active ? `Workflow sidebar filter: ${filterText}` : 'Workflow sidebar filter. No filter applied.'}
-              onClick={() => setOpen((value) => !value)}
-            />
-          }
-        />
+      <WorkflowColumnHeader
+        label={<span className="workflow-workspace-sidebar-header-title">Workflow</span>}
+        filterButton={
+          <WorkflowColumnFilterButton
+            active={active}
+            expanded={open}
+            ariaLabel={active ? `Workflow sidebar filter: ${filterText}` : 'Workflow sidebar filter. No filter applied.'}
+            onClick={() => setOpen((value) => !value)}
+          />
+        }
+        filterRef={filterRef}
+      >
         {open ? (
           <div
             className="workflow-workspace-sidebar-filter-popover workflow-list-column-filter-popover"
@@ -579,7 +579,7 @@ function WorkflowSidebarHeader({
             </div>
           </div>
         ) : null}
-      </div>
+      </WorkflowColumnHeader>
     </header>
   );
 }

--- a/frontend/src/entrypoints/workflow-list.test.tsx
+++ b/frontend/src/entrypoints/workflow-list.test.tsx
@@ -121,7 +121,7 @@ describe('Workflows Entrypoint', () => {
       name: 'Workflow filter. No filter applied.',
     });
     const workflowHeader = workflowFilter.closest('.workflow-list-column-header');
-    expect(workflowHeader?.querySelector('.workflow-list-column-header-label')?.textContent).toContain('Workflow');
+    expect(workflowHeader?.querySelector('.table-sort-button')?.textContent).toContain('Workflow');
     fireEvent.click(workflowFilter);
     expect(screen.getByRole('dialog', { name: 'Workflow filter' })).toBeTruthy();
     expect(screen.getByRole('button', { name: 'Progress filter. No filter applied.' })).toBeTruthy();

--- a/frontend/src/entrypoints/workflow-list.test.tsx
+++ b/frontend/src/entrypoints/workflow-list.test.tsx
@@ -120,6 +120,8 @@ describe('Workflows Entrypoint', () => {
     const workflowFilter = screen.getByRole('button', {
       name: 'Workflow filter. No filter applied.',
     });
+    const workflowHeader = workflowFilter.closest('.workflow-list-column-header');
+    expect(workflowHeader?.querySelector('.workflow-list-column-header-label')?.textContent).toContain('Workflow');
     fireEvent.click(workflowFilter);
     expect(screen.getByRole('dialog', { name: 'Workflow filter' })).toBeTruthy();
     expect(screen.getByRole('button', { name: 'Progress filter. No filter applied.' })).toBeTruthy();

--- a/frontend/src/entrypoints/workflow-list.tsx
+++ b/frontend/src/entrypoints/workflow-list.tsx
@@ -7,6 +7,10 @@ import { formatRuntimeLabel, formatStatusLabel } from '../utils/formatters';
 import { WorkflowLifecycleStatusPill } from '../components/ExecutionStatusPill';
 import { LoadingPlaceholder } from '../components/dashboard/LoadingPlaceholder';
 import { PageSizeSelector, parsePageSize } from '../components/PageSizeSelector';
+import {
+  WorkflowColumnFilterButton,
+  WorkflowColumnHeader,
+} from '../components/WorkflowColumnHeader';
 import { WorkflowRowActionsMenu } from '../components/WorkflowRowActionsMenu';
 import {
   WORKFLOW_LIST_CONTEXT_RETURN_PARAM,
@@ -2438,51 +2442,42 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
                             aria-sort={sortable ? ariaSort : undefined}
                             className="workflow-list-header-cell"
                           >
-                            <div className="workflow-list-column-header">
-                              {sortable ? (
-                                <button
-                                  type="button"
-                                  className="table-sort-button"
-                                  onClick={() => onHeaderClick(field)}
-                                  aria-label={ariaLabel}
-                                  title={CURRENT_PAGE_SORT_NOTICE}
-                                >
-                                  {label}
-                                  {sortIndicator(field)}
-                                  <span className="sr-only">{sortHint}</span>
-                                </button>
-                              ) : (
-                                <span className="workflow-list-static-header">{label}</span>
-                              )}
-                              {filterField ? (
-                                <div
-                                  className="workflow-list-column-filter"
-                                  ref={isFilterOpen ? desktopFilterRef : null}
-                                >
-                                  <button
-                                    type="button"
-                                    className={`workflow-list-column-filter-button${filterValue ? ' is-active' : ''}`}
-                                    aria-label={
+                            {filterField ? (
+                              <WorkflowColumnHeader
+                                label={
+                                  sortable ? (
+                                    <button
+                                      type="button"
+                                      className="table-sort-button"
+                                      onClick={() => onHeaderClick(field)}
+                                      aria-label={ariaLabel}
+                                      title={CURRENT_PAGE_SORT_NOTICE}
+                                    >
+                                      {label}
+                                      {sortIndicator(field)}
+                                      <span className="sr-only">{sortHint}</span>
+                                    </button>
+                                  ) : (
+                                    <span className="workflow-list-static-header">{label}</span>
+                                  )
+                                }
+                                filterButton={
+                                  <WorkflowColumnFilterButton
+                                    active={Boolean(filterValue)}
+                                    expanded={isFilterOpen}
+                                    ariaLabel={
                                       filterValue
                                         ? `${label} column filter: ${filterValue}`
                                         : `${label} filter. No filter applied.`
                                     }
-                                    aria-haspopup="dialog"
-                                    aria-expanded={isFilterOpen}
                                     onClick={() => {
                                       setDraftFilters(filters);
                                       setDesktopFilterField((current) => (current === filterField ? null : filterField));
                                     }}
-                                  >
-                                    <svg
-                                      aria-hidden="true"
-                                      className="workflow-list-column-filter-icon"
-                                      viewBox="0 0 16 16"
-                                      focusable="false"
-                                    >
-                                      <path d="M2 4h12v1.6H2V4ZM4.5 7.2h7v1.6h-7V7.2ZM6.5 10.4h3v1.6h-3v-1.6Z" />
-                                    </svg>
-                                  </button>
+                                  />
+                                }
+                                filterRef={isFilterOpen ? desktopFilterRef : null}
+                              >
                                   {isFilterOpen ? (
                                     <div
                                       className="workflow-list-column-filter-popover"
@@ -2534,9 +2529,22 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
                                       </div>
                                     </div>
                                   ) : null}
-                                </div>
-                              ) : null}
-                            </div>
+                              </WorkflowColumnHeader>
+                            ) : sortable ? (
+                              <button
+                                type="button"
+                                className="table-sort-button"
+                                onClick={() => onHeaderClick(field)}
+                                aria-label={ariaLabel}
+                                title={CURRENT_PAGE_SORT_NOTICE}
+                              >
+                                {label}
+                                {sortIndicator(field)}
+                                <span className="sr-only">{sortHint}</span>
+                              </button>
+                            ) : (
+                              <span className="workflow-list-static-header">{label}</span>
+                            )}
                           </th>
                         );
                       })}

--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -243,7 +243,6 @@ samp {
 .masthead-brand {
   display: inline-flex;
   align-items: center;
-  grid-column: 1;
   justify-self: start;
   gap: 0.55rem;
   min-width: 0;
@@ -282,7 +281,6 @@ samp {
 .workflow-list-display-control {
   display: inline-flex;
   align-items: center;
-  grid-column: 2;
   justify-self: start;
   gap: 0.25rem;
   min-width: 0;
@@ -350,7 +348,6 @@ samp {
 .masthead-title-meta {
   display: flex;
   align-items: center;
-  grid-column: 4;
   justify-self: end;
   justify-content: flex-end;
   flex-wrap: nowrap;
@@ -465,11 +462,32 @@ h1 {
 .masthead-nav {
   position: relative;
   display: flex;
-  grid-column: 3;
   align-self: stretch;
   justify-content: center;
   justify-self: center;
   min-width: 0;
+}
+
+@media (min-width: 1181px) {
+  .masthead-brand {
+    grid-column: 1;
+    grid-row: 1;
+  }
+
+  .workflow-list-display-control {
+    grid-column: 2;
+    grid-row: 1;
+  }
+
+  .masthead-nav {
+    grid-column: 1 / -1;
+    grid-row: 1;
+  }
+
+  .masthead-title-meta {
+    grid-column: 4;
+    grid-row: 1;
+  }
 }
 
 .nav-hamburger {
@@ -7321,12 +7339,6 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
 .workflow-workspace-sidebar-header-title {
   color: inherit;
   font: inherit;
-}
-
-.workflow-workspace-sidebar-filter {
-  position: relative;
-  display: block;
-  width: 100%;
 }
 
 .workflow-workspace-sidebar-filter-popover {

--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -243,6 +243,7 @@ samp {
 .masthead-brand {
   display: inline-flex;
   align-items: center;
+  grid-column: 1;
   justify-self: start;
   gap: 0.55rem;
   min-width: 0;
@@ -281,6 +282,7 @@ samp {
 .workflow-list-display-control {
   display: inline-flex;
   align-items: center;
+  grid-column: 2;
   justify-self: start;
   gap: 0.25rem;
   min-width: 0;
@@ -348,6 +350,7 @@ samp {
 .masthead-title-meta {
   display: flex;
   align-items: center;
+  grid-column: 4;
   justify-self: end;
   justify-content: flex-end;
   flex-wrap: nowrap;
@@ -462,6 +465,7 @@ h1 {
 .masthead-nav {
   position: relative;
   display: flex;
+  grid-column: 3;
   align-self: stretch;
   justify-content: center;
   justify-self: center;
@@ -575,7 +579,7 @@ h1 {
 }
 
 .panel {
-  margin-top: 1rem;
+  margin-top: 0;
   margin-left: auto;
   margin-right: auto;
   max-width: min(72rem, calc(100vw - 2rem));
@@ -903,6 +907,14 @@ h1 {
   min-width: 0;
 }
 
+.workflow-list-column-header-label {
+  min-width: 0;
+  color: rgb(var(--mm-ink));
+  font-size: 0.82rem;
+  font-weight: 720;
+  line-height: 1.2;
+}
+
 .workflow-list-column-filter {
   position: relative;
   flex: 0 0 auto;
@@ -912,8 +924,8 @@ h1 {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 1.65rem;
-  height: 1.65rem;
+  width: 2rem;
+  height: 2rem;
   padding: 0;
   border: 1px solid transparent;
   border-radius: 0.45rem;
@@ -937,9 +949,9 @@ h1 {
 
 .workflow-list-column-filter-icon {
   display: block;
-  width: 0.82rem;
-  height: 0.82rem;
-  fill: currentColor;
+  width: 0.95rem;
+  height: 0.95rem;
+  stroke-width: 2;
 }
 
 .workflow-list-column-filter-popover {
@@ -7307,14 +7319,14 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
 }
 
 .workflow-workspace-sidebar-header-title {
-  color: rgb(var(--mm-ink));
-  font-size: 0.82rem;
-  font-weight: 720;
+  color: inherit;
+  font: inherit;
 }
 
 .workflow-workspace-sidebar-filter {
   position: relative;
-  display: inline-flex;
+  display: block;
+  width: 100%;
 }
 
 .workflow-workspace-sidebar-filter-popover {


### PR DESCRIPTION
PR 3004 was meant to address a number of issues with the list radio buttons, but some issues remain.

1. The .panel CSS still has a margin-top value of 1 rem. This is causing a gap between the top of the workflows list table and the bottom of the nav bar. We want this margin set to 0 so the gap is removed.
2. When I switch to the schedules page, the nav bar nav links collapses to the left as the list radio buttons are removed. The addition and removal of the list radio buttons should not move the nav bar nav links. They should be independent of this.
3. The Workflow column header label and filter button look different on the full screen table view vs the sidebar list view. They should look identical and use shared components in the UI for proper DRYness, i.e. if you change one you should change the other. Right now, the full table view has a larger Workflow font and a smaller filter button.