### PR TITLE
The dropdown for publish mode should just list Auto as Auto and not have the longer text explaining it, i.e. "Auto - the selected skill...". The longe

### DIFF
--- a/frontend/src/entrypoints/workflow-start.test.tsx
+++ b/frontend/src/entrypoints/workflow-start.test.tsx
@@ -7873,6 +7873,7 @@ describe.skip("Task Create Entrypoint", () => {
         (option) =>
           option.value === "auto" &&
           option.text === "Auto" &&
+          option.getAttribute("title") === "Auto — selected skill decides" &&
           option.disabled,
       ),
     ).toBe(true);

--- a/frontend/src/entrypoints/workflow-start.test.tsx
+++ b/frontend/src/entrypoints/workflow-start.test.tsx
@@ -7872,7 +7872,7 @@ describe.skip("Task Create Entrypoint", () => {
       Array.from(publishModeSelect.options).some(
         (option) =>
           option.value === "auto" &&
-          option.text === "Auto — selected skill decides" &&
+          option.text === "Auto" &&
           option.disabled,
       ),
     ).toBe(true);

--- a/frontend/src/entrypoints/workflow-start.tsx
+++ b/frontend/src/entrypoints/workflow-start.tsx
@@ -12744,7 +12744,11 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
                 value={publishMode}
                 onChange={(event) => setPublishMode(event.target.value)}
               >
-                <option value="auto" disabled={!autoPublishAvailable}>
+                <option
+                  value="auto"
+                  disabled={!autoPublishAvailable}
+                  title="Auto — selected skill decides"
+                >
                   Auto
                 </option>
                 <option value="none">None</option>

--- a/frontend/src/entrypoints/workflow-start.tsx
+++ b/frontend/src/entrypoints/workflow-start.tsx
@@ -12745,7 +12745,7 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
                 onChange={(event) => setPublishMode(event.target.value)}
               >
                 <option value="auto" disabled={!autoPublishAvailable}>
-                  Auto — selected skill decides
+                  Auto
                 </option>
                 <option value="none">None</option>
                 <option value="branch" disabled={!mergeAutomationAvailable}>


### PR DESCRIPTION
The dropdown for publish mode should just list Auto as Auto and not have the longer text explaining it, i.e. "Auto - the selected skill...". The longer text can still be used as a tooltip value, but should not be visible with the normal dropdown selection alone.