### PR TITLE
[codex] Fix auto publish evidence propagation

### DIFF
--- a/moonmind/workflows/adapters/managed_agent_adapter.py
+++ b/moonmind/workflows/adapters/managed_agent_adapter.py
@@ -51,6 +51,10 @@ from moonmind.workflows.executions.runtime_defaults import resolve_runtime_defau
 from api_service.services.provider_profile_readiness import (
     provider_profile_launch_ready_from_payload,
 )
+from moonmind.workflows.temporal.publish_auto_evidence import (
+    AutoPublishEvidenceError,
+    parse_auto_publish_evidence,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -298,15 +302,62 @@ def _github_repository_from_pr_url(value: str) -> str:
     return ""
 
 
-def _load_auto_publish_result(
+def _load_auto_publish_result_payload(
     workspace_path: str | None,
+    *,
+    not_before: datetime | None = None,
 ) -> dict[str, Any] | None:
-    """Load agent-written auto-publish evidence from the repo workspace."""
+    """Load raw agent-written auto-publish evidence from the repo workspace."""
 
     workspace = str(workspace_path or "").strip()
     if not workspace:
         return None
-    return _load_json_dict(Path(workspace) / _AUTO_PUBLISH_RESULT_PATH)
+    path = Path(workspace) / _AUTO_PUBLISH_RESULT_PATH
+    if not _path_modified_at_or_after(path, not_before):
+        return None
+    return _load_json_dict(path)
+
+
+def _path_modified_at_or_after(path: Path, not_before: datetime | None) -> bool:
+    """Return whether *path* exists and is fresh enough for this run."""
+
+    if not path.exists():
+        return False
+    if not_before is None:
+        return True
+    cutoff = not_before if not_before.tzinfo is not None else not_before.replace(tzinfo=UTC)
+    try:
+        modified_at = datetime.fromtimestamp(path.stat().st_mtime, tz=UTC)
+    except OSError:
+        return False
+    return modified_at >= cutoff
+
+
+def _canonical_auto_publish_result(payload: Mapping[str, Any]) -> dict[str, Any] | None:
+    """Return a compact canonical evidence payload, dropping unknown fields."""
+
+    try:
+        evidence = parse_auto_publish_evidence(payload)
+    except AutoPublishEvidenceError:
+        return None
+    return {
+        "schemaVersion": evidence.schema_version,
+        "mode": evidence.mode,
+        "owner": evidence.owner,
+        "skillId": evidence.skill_id,
+        "status": evidence.status,
+        "action": evidence.action,
+        "repository": evidence.repository,
+        "branch": evidence.branch,
+        "localHead": evidence.local_head,
+        "remoteBranchHead": evidence.remote_branch_head,
+        "remoteVerified": evidence.remote_verified,
+        "pushed": evidence.pushed,
+        "merged": evidence.merged,
+        "prUrl": evidence.pr_url,
+        "blockedReason": evidence.blocked_reason,
+        "verificationCommands": list(evidence.verification_commands),
+    }
 
 
 def _pr_resolver_auto_publish_verification_commands(
@@ -351,7 +402,7 @@ def _normalize_pr_resolver_auto_publish_result(
         schema_version == _AUTO_PUBLISH_SCHEMA_VERSION
         and status in _AUTO_PUBLISH_ALLOWED_STATUSES
     ):
-        return dict(payload)
+        return _canonical_auto_publish_result(payload)
 
     disposition = _pr_resolver_disposition(dict(resolver_payload))
     resolver_status = _pr_resolver_status(dict(resolver_payload))
@@ -707,7 +758,7 @@ def _derive_pr_resolver_metadata(
     )
     if head_sha:
         metadata["headSha"] = head_sha
-    publish_payload = _load_auto_publish_result(workspace_path)
+    publish_payload = _load_auto_publish_result_payload(workspace_path)
     if publish_payload is not None:
         publish_result = _normalize_pr_resolver_auto_publish_result(
             publish_payload,
@@ -954,6 +1005,7 @@ class ManagedAgentAdapter:
         *,
         pr_resolver_expected: bool = False,
         pr_resolver_merge_gate_owned: bool = False,
+        include_workspace_auto_publish_evidence: bool = False,
     ) -> AgentRunResult:
         """Return result from the run store, falling back to empty if no store.
 
@@ -990,10 +1042,21 @@ class ManagedAgentAdapter:
                     record.workspace_path,
                     merge_gate_owned=pr_resolver_merge_gate_owned,
                 )
-                if "publishResult" not in metadata:
-                    publish_payload = _load_auto_publish_result(record.workspace_path)
+                if (
+                    include_workspace_auto_publish_evidence
+                    and "publishResult" not in metadata
+                    and _load_pr_resolver_result(record.workspace_path) is None
+                ):
+                    publish_payload = _load_auto_publish_result_payload(
+                        record.workspace_path,
+                        not_before=record.started_at,
+                    )
                     if publish_payload is not None:
-                        metadata["publishResult"] = publish_payload
+                        publish_result = _canonical_auto_publish_result(
+                            publish_payload
+                        )
+                        if publish_result is not None:
+                            metadata["publishResult"] = publish_result
                 if pr_resolver_expected:
                     derived_failure_class, derived_summary = _derive_pr_resolver_failure(
                         record.workspace_path,

--- a/moonmind/workflows/adapters/managed_agent_adapter.py
+++ b/moonmind/workflows/adapters/managed_agent_adapter.py
@@ -69,7 +69,7 @@ _PR_RESOLVER_RESULT_PATHS: tuple[Path, ...] = (
     Path("var/pr_resolver/result.json"),
     Path("artifacts/pr_resolver_result.json"),
 )
-_PR_RESOLVER_AUTO_PUBLISH_RESULT_PATH = Path("artifacts/publish_result.json")
+_AUTO_PUBLISH_RESULT_PATH = Path("artifacts/publish_result.json")
 _PR_RESOLVER_ATTEMPTS_DIR = Path("var/pr_resolver/attempts")
 _PR_RESOLVER_FAILURE_STATUSES: frozenset[str] = frozenset(
     {"failed", "blocked", "attempts_exhausted"}
@@ -298,7 +298,7 @@ def _github_repository_from_pr_url(value: str) -> str:
     return ""
 
 
-def _load_pr_resolver_auto_publish_result(
+def _load_auto_publish_result(
     workspace_path: str | None,
 ) -> dict[str, Any] | None:
     """Load agent-written auto-publish evidence from the repo workspace."""
@@ -306,7 +306,7 @@ def _load_pr_resolver_auto_publish_result(
     workspace = str(workspace_path or "").strip()
     if not workspace:
         return None
-    return _load_json_dict(Path(workspace) / _PR_RESOLVER_AUTO_PUBLISH_RESULT_PATH)
+    return _load_json_dict(Path(workspace) / _AUTO_PUBLISH_RESULT_PATH)
 
 
 def _pr_resolver_auto_publish_verification_commands(
@@ -707,7 +707,7 @@ def _derive_pr_resolver_metadata(
     )
     if head_sha:
         metadata["headSha"] = head_sha
-    publish_payload = _load_pr_resolver_auto_publish_result(workspace_path)
+    publish_payload = _load_auto_publish_result(workspace_path)
     if publish_payload is not None:
         publish_result = _normalize_pr_resolver_auto_publish_result(
             publish_payload,
@@ -990,6 +990,10 @@ class ManagedAgentAdapter:
                     record.workspace_path,
                     merge_gate_owned=pr_resolver_merge_gate_owned,
                 )
+                if "publishResult" not in metadata:
+                    publish_payload = _load_auto_publish_result(record.workspace_path)
+                    if publish_payload is not None:
+                        metadata["publishResult"] = publish_payload
                 if pr_resolver_expected:
                     derived_failure_class, derived_summary = _derive_pr_resolver_failure(
                         record.workspace_path,

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -9182,11 +9182,13 @@ class TemporalAgentRuntimeActivities:
         )
         workspace_github_token: str | None = None
         try:
-            result = await adapter.fetch_result(
-                run_id,
-                pr_resolver_expected=pr_resolver_expected,
-                pr_resolver_merge_gate_owned=pr_resolver_merge_gate_owned,
-            )
+            fetch_kwargs: dict[str, Any] = {
+                "pr_resolver_expected": pr_resolver_expected,
+                "pr_resolver_merge_gate_owned": pr_resolver_merge_gate_owned,
+            }
+            if publish_mode == "auto":
+                fetch_kwargs["include_workspace_auto_publish_evidence"] = True
+            result = await adapter.fetch_result(run_id, **fetch_kwargs)
             record = self._run_store.load(run_id)
             if record is not None:
                 if record.workspace_path:

--- a/tests/unit/workflows/adapters/test_managed_agent_adapter.py
+++ b/tests/unit/workflows/adapters/test_managed_agent_adapter.py
@@ -1417,7 +1417,7 @@ async def test_fetch_result_reads_from_store(tmp_path: Path):
 async def test_fetch_result_surfaces_auto_publish_evidence_for_fix_comments(
     tmp_path: Path,
 ):
-    from datetime import UTC, datetime
+    from datetime import UTC, datetime, timedelta
 
     from moonmind.schemas.agent_runtime_models import ManagedRunRecord
     from moonmind.workflows.temporal.publish_auto_evidence import (
@@ -1428,6 +1428,7 @@ async def test_fetch_result_surfaces_auto_publish_evidence_for_fix_comments(
     workspace_path = tmp_path / "workspace"
     artifacts_path = workspace_path / "artifacts"
     artifacts_path.mkdir(parents=True)
+    started_at = datetime.now(tz=UTC) - timedelta(seconds=1)
     (artifacts_path / "publish_result.json").write_text(
         (
             "{\n"
@@ -1446,6 +1447,7 @@ async def test_fetch_result_surfaces_auto_publish_evidence_for_fix_comments(
             '  "merged": false,\n'
             '  "prUrl": null,\n'
             '  "blockedReason": null,\n'
+            '  "rawLog": "must not enter Temporal metadata",\n'
             '  "verificationCommands": [\n'
             '    "git rev-parse HEAD",\n'
             '    "git ls-remote origin refs/heads/codex/dnd-barbarian-class-design-20260705"\n'
@@ -1462,7 +1464,7 @@ async def test_fetch_result_surfaces_auto_publish_evidence_for_fix_comments(
             agent_id="codex_cli",
             runtime_id="codex_cli",
             status="completed",
-            started_at=datetime.now(tz=UTC),
+            started_at=started_at,
             workspace_path=str(workspace_path),
         )
     )
@@ -1476,16 +1478,170 @@ async def test_fetch_result_surfaces_auto_publish_evidence_for_fix_comments(
         run_store=store,
     )
 
-    result = await adapter.fetch_result("run-result-fix-comments-publish-evidence")
+    direct_result = await adapter.fetch_result(
+        "run-result-fix-comments-publish-evidence"
+    )
+    assert "publishResult" not in direct_result.metadata
+
+    result = await adapter.fetch_result(
+        "run-result-fix-comments-publish-evidence",
+        include_workspace_auto_publish_evidence=True,
+    )
 
     publish_result = result.metadata["publishResult"]
     assert result.failure_class is None
     assert publish_result["skillId"] == "fix-comments"
     assert publish_result["pushed"] is True
+    assert "rawLog" not in publish_result
     assert (
         parse_auto_publish_evidence(publish_result).finish_code
         == "PUBLISHED_BRANCH"
     )
+
+
+async def test_fetch_result_ignores_stale_auto_publish_evidence(
+    tmp_path: Path,
+):
+    import os
+    from datetime import UTC, datetime, timedelta
+
+    from moonmind.schemas.agent_runtime_models import ManagedRunRecord
+    from moonmind.workflows.temporal.runtime.store import ManagedRunStore
+
+    workspace_path = tmp_path / "workspace"
+    artifacts_path = workspace_path / "artifacts"
+    artifacts_path.mkdir(parents=True)
+    publish_path = artifacts_path / "publish_result.json"
+    publish_path.write_text(
+        (
+            "{\n"
+            '  "schemaVersion": "moonmind.publish.auto.v1",\n'
+            '  "mode": "auto",\n'
+            '  "owner": "agent",\n'
+            '  "skillId": "fix-comments",\n'
+            '  "status": "verified",\n'
+            '  "action": "push",\n'
+            '  "repository": "MoonLadderStudios/Tactics",\n'
+            '  "branch": "codex/dnd-barbarian-class-design-20260705",\n'
+            '  "localHead": "96ff4e3852352a8afab9e4251d0221bda5acefea",\n'
+            '  "remoteBranchHead": "96ff4e3852352a8afab9e4251d0221bda5acefea",\n'
+            '  "remoteVerified": true,\n'
+            '  "pushed": true,\n'
+            '  "merged": false,\n'
+            '  "prUrl": null,\n'
+            '  "blockedReason": null,\n'
+            '  "verificationCommands": ["git rev-parse HEAD"]\n'
+            "}\n"
+        ),
+        encoding="utf-8",
+    )
+    started_at = datetime.now(tz=UTC)
+    stale_time = (started_at - timedelta(minutes=5)).timestamp()
+    os.utime(publish_path, (stale_time, stale_time))
+
+    store = ManagedRunStore(tmp_path / "run_store")
+    store.save(
+        ManagedRunRecord(
+            run_id="run-result-stale-publish-evidence",
+            agent_id="codex_cli",
+            runtime_id="codex_cli",
+            status="completed",
+            started_at=started_at,
+            workspace_path=str(workspace_path),
+        )
+    )
+
+    adapter = ManagedAgentAdapter(
+        profile_fetcher=_fake_profiles([]),
+        slot_requester=_async_noop,
+        slot_releaser=_async_noop,
+        cooldown_reporter=_async_noop,
+        workflow_id="wf-result-stale-publish-evidence",
+        run_store=store,
+    )
+
+    result = await adapter.fetch_result(
+        "run-result-stale-publish-evidence",
+        include_workspace_auto_publish_evidence=True,
+    )
+
+    assert "publishResult" not in result.metadata
+
+
+async def test_fetch_result_does_not_bypass_pr_resolver_publish_normalization(
+    tmp_path: Path,
+):
+    from datetime import UTC, datetime, timedelta
+
+    from moonmind.schemas.agent_runtime_models import ManagedRunRecord
+    from moonmind.workflows.temporal.runtime.store import ManagedRunStore
+
+    workspace_path = tmp_path / "workspace"
+    resolver_dir = workspace_path / "var" / "pr_resolver"
+    artifact_dir = workspace_path / "artifacts"
+    resolver_dir.mkdir(parents=True)
+    artifact_dir.mkdir(parents=True)
+    (resolver_dir / "result.json").write_text(
+        (
+            "{\n"
+            '  "status": "merged",\n'
+            '  "merge_outcome": "merged",\n'
+            '  "mergeAutomationDisposition": "merged"\n'
+            "}\n"
+        ),
+        encoding="utf-8",
+    )
+    (artifact_dir / "publish_result.json").write_text(
+        (
+            "{\n"
+            '  "schemaVersion": "moonmind.publish.auto.v1",\n'
+            '  "mode": "auto",\n'
+            '  "owner": "agent",\n'
+            '  "skillId": "pr-resolver",\n'
+            '  "status": "verified",\n'
+            '  "action": "merge",\n'
+            '  "repository": "MoonLadderStudios/MoonMind",\n'
+            '  "branch": "codex/fix-auto-publish-evidence-adapter",\n'
+            '  "remoteVerified": true,\n'
+            '  "pushed": false,\n'
+            '  "merged": true,\n'
+            '  "prUrl": null,\n'
+            '  "blockedReason": null,\n'
+            '  "verificationCommands": ["gh pr view 3008"]\n'
+            "}\n"
+        ),
+        encoding="utf-8",
+    )
+
+    store = ManagedRunStore(tmp_path / "run_store")
+    store.save(
+        ManagedRunRecord(
+            run_id="run-result-pr-invalid-publish-evidence",
+            agent_id="codex_cli",
+            runtime_id="codex_cli",
+            status="completed",
+            started_at=datetime.now(tz=UTC) - timedelta(seconds=1),
+            workspace_path=str(workspace_path),
+        )
+    )
+
+    adapter = ManagedAgentAdapter(
+        profile_fetcher=_fake_profiles([]),
+        slot_requester=_async_noop,
+        slot_releaser=_async_noop,
+        cooldown_reporter=_async_noop,
+        workflow_id="wf-result-pr-invalid-publish-evidence",
+        run_store=store,
+    )
+
+    result = await adapter.fetch_result(
+        "run-result-pr-invalid-publish-evidence",
+        pr_resolver_expected=True,
+        include_workspace_auto_publish_evidence=True,
+    )
+
+    assert result.metadata["mergeAutomationDisposition"] == "merged"
+    assert "publishResult" not in result.metadata
 
 
 async def test_fetch_result_marks_failed_pr_resolver_artifact_as_failure(

--- a/tests/unit/workflows/adapters/test_managed_agent_adapter.py
+++ b/tests/unit/workflows/adapters/test_managed_agent_adapter.py
@@ -1413,6 +1413,81 @@ async def test_fetch_result_reads_from_store(tmp_path: Path):
     assert "artifact://logs/stdout" in result.output_refs
     assert "artifact://diag/123" in result.output_refs
 
+
+async def test_fetch_result_surfaces_auto_publish_evidence_for_fix_comments(
+    tmp_path: Path,
+):
+    from datetime import UTC, datetime
+
+    from moonmind.schemas.agent_runtime_models import ManagedRunRecord
+    from moonmind.workflows.temporal.publish_auto_evidence import (
+        parse_auto_publish_evidence,
+    )
+    from moonmind.workflows.temporal.runtime.store import ManagedRunStore
+
+    workspace_path = tmp_path / "workspace"
+    artifacts_path = workspace_path / "artifacts"
+    artifacts_path.mkdir(parents=True)
+    (artifacts_path / "publish_result.json").write_text(
+        (
+            "{\n"
+            '  "schemaVersion": "moonmind.publish.auto.v1",\n'
+            '  "mode": "auto",\n'
+            '  "owner": "agent",\n'
+            '  "skillId": "fix-comments",\n'
+            '  "status": "verified",\n'
+            '  "action": "push",\n'
+            '  "repository": "MoonLadderStudios/Tactics",\n'
+            '  "branch": "codex/dnd-barbarian-class-design-20260705",\n'
+            '  "localHead": "96ff4e3852352a8afab9e4251d0221bda5acefea",\n'
+            '  "remoteBranchHead": "96ff4e3852352a8afab9e4251d0221bda5acefea",\n'
+            '  "remoteVerified": true,\n'
+            '  "pushed": true,\n'
+            '  "merged": false,\n'
+            '  "prUrl": null,\n'
+            '  "blockedReason": null,\n'
+            '  "verificationCommands": [\n'
+            '    "git rev-parse HEAD",\n'
+            '    "git ls-remote origin refs/heads/codex/dnd-barbarian-class-design-20260705"\n'
+            "  ]\n"
+            "}\n"
+        ),
+        encoding="utf-8",
+    )
+
+    store = ManagedRunStore(tmp_path / "run_store")
+    store.save(
+        ManagedRunRecord(
+            run_id="run-result-fix-comments-publish-evidence",
+            agent_id="codex_cli",
+            runtime_id="codex_cli",
+            status="completed",
+            started_at=datetime.now(tz=UTC),
+            workspace_path=str(workspace_path),
+        )
+    )
+
+    adapter = ManagedAgentAdapter(
+        profile_fetcher=_fake_profiles([]),
+        slot_requester=_async_noop,
+        slot_releaser=_async_noop,
+        cooldown_reporter=_async_noop,
+        workflow_id="wf-result-fix-comments-publish-evidence",
+        run_store=store,
+    )
+
+    result = await adapter.fetch_result("run-result-fix-comments-publish-evidence")
+
+    publish_result = result.metadata["publishResult"]
+    assert result.failure_class is None
+    assert publish_result["skillId"] == "fix-comments"
+    assert publish_result["pushed"] is True
+    assert (
+        parse_auto_publish_evidence(publish_result).finish_code
+        == "PUBLISHED_BRANCH"
+    )
+
+
 async def test_fetch_result_marks_failed_pr_resolver_artifact_as_failure(
     tmp_path: Path,
 ):


### PR DESCRIPTION
## Summary
- Load canonical `artifacts/publish_result.json` for all managed auto-publish skills, not only `pr-resolver`.
- Surface the loaded payload as `AgentRunResult.metadata["publishResult"]` so the parent workflow auto-publish gate can validate it.
- Add regression coverage for a completed `fix-comments` run that wrote verified push evidence.

## Root Cause
A `fix-comments` managed run could write valid auto-publish evidence, but `ManagedAgentAdapter.fetch_result()` only surfaced publish evidence through the `pr-resolver` metadata path. The parent workflow then failed finalization with `auto_publish_evidence_missing` even though the agent had pushed and verified the remote head.

## Validation
- `MOONMIND_DISABLE_DEFAULT_USER_DB_LOOKUP=1 MOONMIND_ALLOW_LIVE_TEMPORAL_IN_TESTS=0 .venv/bin/python -m pytest -q tests/unit/workflows/adapters/test_managed_agent_adapter.py` passed: `72 passed`.
- `git diff --check -- moonmind/workflows/adapters/managed_agent_adapter.py tests/unit/workflows/adapters/test_managed_agent_adapter.py` passed.

## Notes
`./tools/test_unit.sh tests/unit/workflows/adapters/test_managed_agent_adapter.py` is blocked before pytest by pre-existing local permissions on `deploy/state/desired-state.json` (`0600`, owned by root).