### PR TITLE
[codex] Pretrust Claude Code managed workspaces

### DIFF
--- a/moonmind/workflows/temporal/runtime/launcher.py
+++ b/moonmind/workflows/temporal/runtime/launcher.py
@@ -20,7 +20,7 @@ from moonmind.schemas.agent_runtime_models import (
     ManagedRuntimeProfile,
     TERMINAL_AGENT_RUN_STATES,
 )
-from moonmind.utils.logging import SecretRedactor
+from moonmind.utils.logging import SecretRedactor, redact_sensitive_text
 from moonmind.workflows.skills.run_projection import (
     load_resolved_skillset,
     materialize_run_skill_snapshot,
@@ -50,6 +50,46 @@ _MANAGED_RUNTIME_ATLASSIAN_ENV_PREFIX_BLOCKLIST: frozenset[str] = frozenset(
 logger = logging.getLogger(__name__)
 
 _LIVE_LOG_SPOOL_FILENAME = "live_streams.spool"
+
+_CLAUDE_WORKSPACE_TRUST_CONFIG_SCRIPT = r"""
+import json
+import sys
+from pathlib import Path
+
+config_dir = Path(sys.argv[1])
+config_file = Path(sys.argv[2])
+workspace_path = sys.argv[3]
+
+config_file.parent.mkdir(parents=True, exist_ok=True)
+config_dir.mkdir(parents=True, exist_ok=True)
+
+if config_file.exists():
+    raw_config = config_file.read_text(encoding="utf-8").strip()
+    if raw_config:
+        config = json.loads(raw_config)
+        if not isinstance(config, dict):
+            raise ValueError("Claude config root must be a JSON object")
+    else:
+        config = {}
+else:
+    config = {}
+
+config.setdefault("version", 1)
+if workspace_path:
+    projects = config.setdefault("projects", {})
+    if not isinstance(projects, dict):
+        raise ValueError("Claude config projects must be a JSON object")
+
+    project_config = projects.setdefault(workspace_path, {})
+    if not isinstance(project_config, dict):
+        raise ValueError("Claude config project entry must be a JSON object")
+    project_config["hasTrustDialogAccepted"] = True
+
+config_file.write_text(
+    json.dumps(config, indent=2, sort_keys=True) + "\n",
+    encoding="utf-8",
+)
+""".strip()
 
 _SECRET_LIKE_PATTERN = re.compile(
     r"(ghp_[A-Za-z0-9_]+|github_pat_[A-Za-z0-9_]+|AIza[A-Za-z0-9_-]+|ATATT[A-Za-z0-9_-]+|AKIA[A-Za-z0-9]+|-----BEGIN [A-Z ]*PRIVATE KEY-----|(?:token|password)=\S+)",
@@ -576,13 +616,43 @@ class ManagedRuntimeLauncher:
         )
         if returncode == 0:
             return
-        
+
         redactor = SecretRedactor.from_environ()
-        detail = redactor.scrub(stderr_text or stdout_text or "no output")
-        rendered_cmd = redactor.scrub(" ".join(shlex.quote(part) for part in cmd))
+        detail = redact_sensitive_text(
+            redactor.scrub(stderr_text or stdout_text or "no output")
+        )
+        rendered_cmd = redact_sensitive_text(
+            redactor.scrub(" ".join(shlex.quote(part) for part in cmd))
+        )
         raise RuntimeError(
             f"Command failed with exit code {returncode}: {rendered_cmd}; {detail}"
         )
+
+    async def _ensure_claude_workspace_trust_config(
+        self,
+        *,
+        config_dir: Path,
+        config_file: Path,
+        workspace_path: str | None,
+        run_as_user: str | None,
+    ) -> None:
+        """Pre-accept Claude Code's workspace trust prompt for managed runs."""
+
+        resolved_workspace = (
+            str(Path(workspace_path).resolve()) if workspace_path else ""
+        )
+        command = [
+            "python3",
+            "-c",
+            _CLAUDE_WORKSPACE_TRUST_CONFIG_SCRIPT,
+            str(config_dir),
+            str(config_file),
+            resolved_workspace,
+        ]
+        if run_as_user:
+            command = ["runuser", "-u", run_as_user, "--", *command]
+
+        await self._run_checked_command(*command)
 
     @staticmethod
     def _workspace_key_for_request(
@@ -1376,43 +1446,29 @@ class ManagedRuntimeLauncher:
                 env_overrides["USER"] = "app"
                 env_overrides["LOGNAME"] = "app"
 
-                # Ensure Claude Code's config file exists in the app user's HOME.
-                # Without ~/.claude.json, claude CLI prints repeated warnings and
-                # may hang waiting for user interaction even with -p flag.
+                # Ensure Claude Code's config file exists in the app user's HOME
+                # and trusts the MoonMind-managed workspace. Without this, the
+                # CLI ignores permissions.allow entries until an interactive
+                # trust dialog is accepted.
                 #
-                # Create the config as the app user (via runuser) to avoid:
+                # Update the config as the app user (via runuser) to avoid:
                 # - Symlink traversal risks when writing as root
                 # - File ownership mismatches (root-owned files used by app user)
                 app_home_dir = Path(env_overrides["HOME"])
                 claude_config_dir = app_home_dir / ".claude"
                 claude_config_file = app_home_dir / ".claude.json"
 
-                if not claude_config_file.exists():
-                    try:
-                        # Create directory structure as app user
-                        await self._run_checked_command(
-                            "runuser", "-u", "app", "--",
-                            "python3", "-c",
-                            (
-                                "from pathlib import Path; "
-                                f"config_dir = Path('{claude_config_dir}'); "
-                                f"config_file = Path('{claude_config_file}'); "
-                                "config_dir.mkdir(parents=True, exist_ok=True); "
-                                "config_file.write_text("
-                                "'{\\\"version\\\": 1}\\n', encoding='utf-8'"
-                                ")"
-                            ),
-                        )
-                    except RuntimeError as exc:
-                        raise RuntimeError(
-                            f"Unable to ensure Claude config exists at {claude_config_file}"
-                        ) from exc
-
-                    # Verify the file was created and is readable
-                    if not claude_config_file.is_file():
-                        raise RuntimeError(
-                            f"Claude config file not created at {claude_config_file}"
-                        )
+                try:
+                    await self._ensure_claude_workspace_trust_config(
+                        config_dir=claude_config_dir,
+                        config_file=claude_config_file,
+                        workspace_path=resolved_workspace_path,
+                        run_as_user="app",
+                    )
+                except RuntimeError as exc:
+                    raise RuntimeError(
+                        "Unable to ensure Claude workspace trust config"
+                    ) from exc
 
                 # Use runuser with env= so secrets do not appear in process argv.
                 process = await asyncio.create_subprocess_exec(

--- a/moonmind/workflows/temporal/runtime/launcher.py
+++ b/moonmind/workflows/temporal/runtime/launcher.py
@@ -52,6 +52,7 @@ logger = logging.getLogger(__name__)
 _LIVE_LOG_SPOOL_FILENAME = "live_streams.spool"
 
 _CLAUDE_WORKSPACE_TRUST_CONFIG_SCRIPT = r"""
+import fcntl
 import json
 import sys
 from pathlib import Path
@@ -59,36 +60,46 @@ from pathlib import Path
 config_dir = Path(sys.argv[1])
 config_file = Path(sys.argv[2])
 workspace_path = sys.argv[3]
+lock_file = config_file.with_suffix(config_file.suffix + ".lock")
 
 config_file.parent.mkdir(parents=True, exist_ok=True)
 config_dir.mkdir(parents=True, exist_ok=True)
+lock_file.parent.mkdir(parents=True, exist_ok=True)
 
-if config_file.exists():
-    raw_config = config_file.read_text(encoding="utf-8").strip()
-    if raw_config:
-        config = json.loads(raw_config)
-        if not isinstance(config, dict):
-            raise ValueError("Claude config root must be a JSON object")
+with lock_file.open("w", encoding="utf-8") as lock_handle:
+    fcntl.flock(lock_handle.fileno(), fcntl.LOCK_EX)
+
+    if config_file.exists():
+        raw_config = config_file.read_text(encoding="utf-8").strip()
+        if raw_config:
+            try:
+                config = json.loads(raw_config)
+            except json.JSONDecodeError:
+                config = {}
+            if not isinstance(config, dict):
+                config = {}
+        else:
+            config = {}
     else:
         config = {}
-else:
-    config = {}
 
-config.setdefault("version", 1)
-if workspace_path:
-    projects = config.setdefault("projects", {})
-    if not isinstance(projects, dict):
-        raise ValueError("Claude config projects must be a JSON object")
+    config.setdefault("version", 1)
+    if workspace_path:
+        projects = config.get("projects")
+        if not isinstance(projects, dict):
+            projects = {}
+            config["projects"] = projects
 
-    project_config = projects.setdefault(workspace_path, {})
-    if not isinstance(project_config, dict):
-        raise ValueError("Claude config project entry must be a JSON object")
-    project_config["hasTrustDialogAccepted"] = True
+        project_config = projects.get(workspace_path)
+        if not isinstance(project_config, dict):
+            project_config = {}
+            projects[workspace_path] = project_config
+        project_config["hasTrustDialogAccepted"] = True
 
-config_file.write_text(
-    json.dumps(config, indent=2, sort_keys=True) + "\n",
-    encoding="utf-8",
-)
+    config_file.write_text(
+        json.dumps(config, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
 """.strip()
 
 _SECRET_LIKE_PATTERN = re.compile(
@@ -1441,35 +1452,38 @@ class ManagedRuntimeLauncher:
             if _needs_priv_drop:
                 # runuser -u does not rewrite HOME/USER/LOGNAME for us when we pass
                 # an explicit env block, so seed the target-user login context
-                # explicitly before launching Claude Code.
+                # explicitly before any app-user command.
                 env_overrides["HOME"] = "/home/app"
                 env_overrides["USER"] = "app"
                 env_overrides["LOGNAME"] = "app"
 
-                # Ensure Claude Code's config file exists in the app user's HOME
-                # and trusts the MoonMind-managed workspace. Without this, the
-                # CLI ignores permissions.allow entries until an interactive
+            if _is_claude_code:
+                # Ensure Claude Code's config file exists in the runtime user's
+                # HOME and trusts the MoonMind-managed workspace. Without this,
+                # the CLI ignores permissions.allow entries until an interactive
                 # trust dialog is accepted.
                 #
-                # Update the config as the app user (via runuser) to avoid:
-                # - Symlink traversal risks when writing as root
-                # - File ownership mismatches (root-owned files used by app user)
-                app_home_dir = Path(env_overrides["HOME"])
-                claude_config_dir = app_home_dir / ".claude"
-                claude_config_file = app_home_dir / ".claude.json"
+                # When privileges are dropped, update the config as the app user
+                # to avoid symlink traversal risks and root-owned config files.
+                claude_home_dir = Path(
+                    env_overrides.get("HOME") or os.path.expanduser("~")
+                )
+                claude_config_dir = claude_home_dir / ".claude"
+                claude_config_file = claude_home_dir / ".claude.json"
 
                 try:
                     await self._ensure_claude_workspace_trust_config(
                         config_dir=claude_config_dir,
                         config_file=claude_config_file,
                         workspace_path=resolved_workspace_path,
-                        run_as_user="app",
+                        run_as_user="app" if _needs_priv_drop else None,
                     )
                 except RuntimeError as exc:
                     raise RuntimeError(
                         "Unable to ensure Claude workspace trust config"
                     ) from exc
 
+            if _needs_priv_drop:
                 # Use runuser with env= so secrets do not appear in process argv.
                 process = await asyncio.create_subprocess_exec(
                     "runuser", "-u", "app", "--",

--- a/tests/unit/services/temporal/runtime/test_launcher.py
+++ b/tests/unit/services/temporal/runtime/test_launcher.py
@@ -3194,6 +3194,9 @@ async def test_launch_adds_trusted_jira_tool_hint_for_claude_jira_skill(
         async def wait(self) -> int:
             return 0
 
+        async def communicate(self) -> tuple[bytes, bytes]:
+            return b"", b""
+
     async def _fake_create_subprocess_exec(*args, **_kwargs):
         nonlocal captured_args
         captured_args = args
@@ -3261,6 +3264,9 @@ async def test_launch_preserves_missing_instruction_ref_without_jira_skill(
 
         async def wait(self) -> int:
             return 0
+
+        async def communicate(self) -> tuple[bytes, bytes]:
+            return b"", b""
 
     async def _fake_create_subprocess_exec(*_args, **_kwargs):
         return _FakeProcess()

--- a/tests/unit/services/temporal/runtime/test_launcher.py
+++ b/tests/unit/services/temporal/runtime/test_launcher.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 import os
 import subprocess
 from pathlib import Path
@@ -37,6 +38,72 @@ def _make_request(**overrides) -> AgentExecutionRequest:
     )
     defaults.update(overrides)
     return AgentExecutionRequest(**defaults)
+
+@pytest.mark.asyncio
+async def test_claude_workspace_trust_config_merges_existing_projects(tmp_path):
+    store = ManagedRunStore(tmp_path / "managed_runs")
+    launcher = ManagedRuntimeLauncher(store)
+    config_dir = tmp_path / "home" / ".claude"
+    config_file = tmp_path / "home" / ".claude.json"
+    workspace = tmp_path / "workspaces" / "mm:trust-run" / "repo"
+    workspace.mkdir(parents=True)
+    existing_workspace = tmp_path / "workspaces" / "existing" / "repo"
+    existing_workspace.mkdir(parents=True)
+    config_file.parent.mkdir(parents=True)
+    config_file.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "theme": "dark",
+                "projects": {
+                    str(existing_workspace.resolve()): {"custom": "kept"},
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    await launcher._ensure_claude_workspace_trust_config(
+        config_dir=config_dir,
+        config_file=config_file,
+        workspace_path=str(workspace),
+        run_as_user=None,
+    )
+
+    config = json.loads(config_file.read_text(encoding="utf-8"))
+    assert config["theme"] == "dark"
+    assert config["projects"][str(existing_workspace.resolve())]["custom"] == "kept"
+    assert (
+        config["projects"][str(workspace.resolve())]["hasTrustDialogAccepted"]
+        is True
+    )
+
+@pytest.mark.asyncio
+async def test_run_checked_command_redacts_auth_paths(tmp_path, monkeypatch):
+    store = ManagedRunStore(tmp_path / "managed_runs")
+    launcher = ManagedRuntimeLauncher(store)
+
+    class _FakeProcess:
+        returncode = 1
+
+        async def communicate(self) -> tuple[bytes, bytes]:
+            return b"", b"/home/app/.claude.json token=raw-secret failed"
+
+    async def _fake_create_subprocess_exec(*_args, **_kwargs):
+        return _FakeProcess()
+
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.runtime.launcher.asyncio.create_subprocess_exec",
+        _fake_create_subprocess_exec,
+    )
+
+    with pytest.raises(RuntimeError) as exc_info:
+        await launcher._run_checked_command("python3", "/home/app/.claude.json")
+
+    message = str(exc_info.value)
+    assert "/home/app/.claude.json" not in message
+    assert "[REDACTED_AUTH_PATH]" in message
+    assert "token=[REDACTED]" in message
 
 def test_build_command_default():
     store = ManagedRunStore("/tmp/test-store")
@@ -2335,13 +2402,14 @@ async def test_launch_privilege_drop_for_claude_code_as_root(tmp_path, monkeypat
     assert "app:app" in chown_call
     assert str(run_root) in chown_call
 
-    # Verify config creation was attempted via runuser
+    # Verify config trust materialization was attempted via runuser
     assert len(config_creation_calls) == 1, (
         f"Expected 1 config creation call, got {len(config_creation_calls)}"
     )
     config_call_str = " ".join(str(arg) for arg in config_creation_calls[0])
     assert "python3" in config_call_str
-    assert "pathlib" in config_call_str
+    assert "hasTrustDialogAccepted" in config_call_str
+    assert str(workspace_root.resolve()) in config_creation_calls[0]
 
     # Verify runuser was used instead of direct subprocess exec
     # Filter to find the final launch runuser (not the config creation one)

--- a/tests/unit/services/temporal/runtime/test_launcher.py
+++ b/tests/unit/services/temporal/runtime/test_launcher.py
@@ -79,6 +79,67 @@ async def test_claude_workspace_trust_config_merges_existing_projects(tmp_path):
     )
 
 @pytest.mark.asyncio
+async def test_claude_workspace_trust_config_resets_invalid_json(tmp_path):
+    store = ManagedRunStore(tmp_path / "managed_runs")
+    launcher = ManagedRuntimeLauncher(store)
+    config_dir = tmp_path / "home" / ".claude"
+    config_file = tmp_path / "home" / ".claude.json"
+    workspace = tmp_path / "workspaces" / "trust-run" / "repo"
+    workspace.mkdir(parents=True)
+    config_file.parent.mkdir(parents=True)
+    config_file.write_text("{not-json", encoding="utf-8")
+
+    await launcher._ensure_claude_workspace_trust_config(
+        config_dir=config_dir,
+        config_file=config_file,
+        workspace_path=str(workspace),
+        run_as_user=None,
+    )
+
+    config = json.loads(config_file.read_text(encoding="utf-8"))
+    assert config["version"] == 1
+    assert (
+        config["projects"][str(workspace.resolve())]["hasTrustDialogAccepted"]
+        is True
+    )
+
+@pytest.mark.asyncio
+async def test_claude_workspace_trust_config_resets_non_object_sections(tmp_path):
+    store = ManagedRunStore(tmp_path / "managed_runs")
+    launcher = ManagedRuntimeLauncher(store)
+    config_dir = tmp_path / "home" / ".claude"
+    config_file = tmp_path / "home" / ".claude.json"
+    workspace = tmp_path / "workspaces" / "trust-run" / "repo"
+    workspace.mkdir(parents=True)
+    config_file.parent.mkdir(parents=True)
+    config_file.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "projects": {
+                    str(workspace.resolve()): ["not", "an", "object"],
+                    "other": {"kept": True},
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    await launcher._ensure_claude_workspace_trust_config(
+        config_dir=config_dir,
+        config_file=config_file,
+        workspace_path=str(workspace),
+        run_as_user=None,
+    )
+
+    config = json.loads(config_file.read_text(encoding="utf-8"))
+    assert config["projects"]["other"]["kept"] is True
+    assert (
+        config["projects"][str(workspace.resolve())]["hasTrustDialogAccepted"]
+        is True
+    )
+
+@pytest.mark.asyncio
 async def test_run_checked_command_redacts_auth_paths(tmp_path, monkeypatch):
     store = ManagedRunStore(tmp_path / "managed_runs")
     launcher = ManagedRuntimeLauncher(store)
@@ -2298,6 +2359,67 @@ async def test_launch_keeps_direct_github_env_for_codex_cli_managed_runs(
     assert (run_root / ".moonmind" / "bin" / "gh").exists()
 
 @pytest.mark.asyncio
+async def test_launch_pretrusts_claude_code_without_privilege_drop(
+    tmp_path, monkeypatch
+):
+    captured_launches: list[tuple[tuple[object, ...], dict[str, object]]] = []
+    trust_calls: list[dict[str, object]] = []
+
+    class _FakeProcess:
+        pid = 4242
+        returncode = 0
+
+        async def wait(self) -> int:
+            return 0
+
+        async def communicate(self) -> tuple[bytes, bytes]:
+            return b"", b""
+
+    async def _fake_create_subprocess_exec(*args, **kwargs):
+        captured_launches.append((args, kwargs))
+        return _FakeProcess()
+
+    async def _fake_ensure(self, **kwargs):
+        trust_calls.append(kwargs)
+
+    monkeypatch.setattr(os, "geteuid", lambda: 1000)
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.runtime.launcher.asyncio.create_subprocess_exec",
+        _fake_create_subprocess_exec,
+    )
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.runtime.launcher.ManagedRuntimeLauncher._ensure_claude_workspace_trust_config",
+        _fake_ensure,
+    )
+
+    store = ManagedRunStore(tmp_path / "managed_runs")
+    launcher = ManagedRuntimeLauncher(store)
+    workspace_root = tmp_path / "workspaces" / "non-root-run" / "repo"
+    workspace_root.mkdir(parents=True)
+
+    profile = _make_profile(
+        runtime_id="claude_code",
+        command_template=["claude", "-p", "hello"],
+        passthrough_env_keys=[],
+    )
+
+    _record, process, _cleanup, _deferred_cleanup = await launcher.launch(
+        run_id="non-root-run",
+        request=_make_request(),
+        profile=profile,
+        workspace_path=str(workspace_root),
+    )
+    await process.wait()
+
+    assert len(trust_calls) == 1
+    trust_call = trust_calls[0]
+    assert trust_call["run_as_user"] is None
+    assert trust_call["workspace_path"] == str(workspace_root)
+    assert trust_call["config_file"] == Path(os.environ["HOME"]) / ".claude.json"
+    assert captured_launches
+    assert captured_launches[-1][0][0] == "claude"
+
 @pytest.mark.asyncio
 async def test_launch_privilege_drop_for_claude_code_as_root(tmp_path, monkeypatch):
     """When launched as root for claude_code runtime, the process should:


### PR DESCRIPTION
## Summary

Pre-accept Claude Code workspace trust for MoonMind-managed runs by merging the resolved workspace path into `/home/app/.claude.json` before launching the CLI as the `app` user.

This prevents Claude Code from ignoring `permissions.allow` entries in sandboxed MoonMind workspaces when no interactive trust dialog has been accepted.

## Details

- Merge `projects[workspace].hasTrustDialogAccepted = true` into Claude Code home config while preserving existing config.
- Run the trust config materialization through `runuser -u app` during root-to-app Claude launches.
- Redact Claude auth/config paths in launcher command-error messages.
- Add launcher unit coverage for trust config merging, redaction, and root privilege-drop launch wiring.

## Validation

- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/services/temporal/runtime/test_launcher.py -q --tb=short`
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_integration.sh`