### PR TITLE
Preserve runtime selection for recurring schedules

### DIFF
--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -9998,7 +9998,166 @@ def _first_mapping_value(
             return source[key]
     return None
 
-def _build_recurring_target(request_payload: dict[str, Any]) -> dict[str, Any]:
+def _recurring_task_payload(
+    parameters: Mapping[str, Any],
+) -> tuple[str | None, dict[str, Any]]:
+    for key in ("workflow", "task"):
+        task_payload = parameters.get(key)
+        if isinstance(task_payload, Mapping):
+            return key, dict(task_payload)
+    return None, {}
+
+
+async def _resolve_recurring_runtime_metadata(
+    request_payload: Mapping[str, Any],
+    *,
+    session: Any | None,
+) -> dict[str, Any]:
+    workflow_type = str(
+        request_payload.get("workflowType")
+        or request_payload.get("workflow_type")
+        or "MoonMind.UserWorkflow"
+    ).strip()
+    if workflow_type != "MoonMind.UserWorkflow":
+        return {}
+
+    parameter_payload = request_payload
+    raw_initial_parameters = request_payload.get("initialParameters")
+    if raw_initial_parameters is None:
+        raw_initial_parameters = request_payload.get("initial_parameters")
+    if isinstance(raw_initial_parameters, Mapping):
+        parameter_payload = raw_initial_parameters
+
+    _task_key, task_payload = _recurring_task_payload(parameter_payload)
+    if not task_payload and parameter_payload is not request_payload:
+        _task_key, task_payload = _recurring_task_payload(request_payload)
+
+    runtime_payload = (
+        task_payload.get("runtime")
+        if isinstance(task_payload.get("runtime"), Mapping)
+        else parameter_payload.get("runtime")
+        if isinstance(parameter_payload.get("runtime"), Mapping)
+        else {}
+    )
+    raw_target_runtime = (
+        request_payload.get("targetRuntime")
+        or parameter_payload.get("targetRuntime")
+        or runtime_payload.get("mode")
+        or settings.workflow.default_runtime
+        or ""
+    )
+    canonical_target_runtime: str | None = None
+    if raw_target_runtime:
+        normalized_rt = normalize_runtime_id(raw_target_runtime)
+        if normalized_rt not in _SUPPORTED_TASK_RUNTIMES:
+            raise _invalid_workflow_request(
+                f"Unsupported targetRuntime: {raw_target_runtime!r}. "
+                "Must be one of: codex_cli, claude_code, codex_cloud, jules."
+            )
+        canonical_target_runtime = normalized_rt
+
+    raw_profile_id = str(
+        runtime_payload.get("profileId")
+        or runtime_payload.get("providerProfile")
+        or runtime_payload.get("executionProfileRef")
+        or task_payload.get("profileId")
+        or task_payload.get("providerProfile")
+        or parameter_payload.get("profileId")
+        or parameter_payload.get("providerProfile")
+        or request_payload.get("profileId")
+        or request_payload.get("providerProfile")
+        or ""
+    ).strip() or None
+    raw_requested_model: str | None = runtime_payload.get("model") or None
+    if raw_requested_model is None:
+        raw_requested_model = parameter_payload.get(
+            "requestedModel"
+        ) or parameter_payload.get("model")
+    if raw_requested_model is not None:
+        raw_requested_model = str(raw_requested_model)
+
+    provider_profile = None
+    session_get = getattr(session, "get", None)
+    if raw_profile_id and callable(session_get):
+        provider_profile = await session_get(
+            ManagedAgentProviderProfile,
+            raw_profile_id,
+        )
+        if provider_profile is None:
+            raise _invalid_workflow_request(
+                f"Provider profile not found: {raw_profile_id!r}."
+            )
+
+    resolved_model, model_source = resolve_effective_model(
+        runtime_id=canonical_target_runtime,
+        profile=provider_profile,
+        requested_model=raw_requested_model,
+        workflow_settings=settings.workflow,
+    )
+    metadata: dict[str, Any] = {
+        "targetRuntime": canonical_target_runtime,
+        "model": resolved_model,
+        "requestedModel": raw_requested_model,
+        "modelSource": model_source,
+    }
+    if raw_profile_id:
+        metadata["profileId"] = raw_profile_id
+    if "effort" in runtime_payload:
+        metadata["effort"] = runtime_payload.get("effort")
+    elif "effort" in parameter_payload:
+        metadata["effort"] = parameter_payload.get("effort")
+    return metadata
+
+
+def _stamp_recurring_runtime_metadata(
+    initial_parameters: dict[str, Any],
+    runtime_metadata: Mapping[str, Any] | None,
+) -> None:
+    if not runtime_metadata:
+        return
+
+    if runtime_metadata.get("targetRuntime"):
+        initial_parameters["targetRuntime"] = runtime_metadata["targetRuntime"]
+    if runtime_metadata.get("model"):
+        initial_parameters["model"] = runtime_metadata["model"]
+    if runtime_metadata.get("requestedModel") is not None:
+        initial_parameters["requestedModel"] = runtime_metadata["requestedModel"]
+    if runtime_metadata.get("modelSource"):
+        initial_parameters["modelSource"] = runtime_metadata["modelSource"]
+    if runtime_metadata.get("profileId"):
+        initial_parameters["profileId"] = runtime_metadata["profileId"]
+    if "effort" in runtime_metadata:
+        initial_parameters["effort"] = runtime_metadata.get("effort")
+
+    task_key, task_payload = _recurring_task_payload(initial_parameters)
+    if task_key is None:
+        return
+
+    runtime_payload = (
+        dict(task_payload.get("runtime"))
+        if isinstance(task_payload.get("runtime"), Mapping)
+        else {}
+    )
+    if runtime_metadata.get("targetRuntime"):
+        runtime_payload["mode"] = runtime_metadata["targetRuntime"]
+    if runtime_metadata.get("model"):
+        runtime_payload["model"] = runtime_metadata["model"]
+    if "effort" in runtime_metadata:
+        runtime_payload["effort"] = runtime_metadata.get("effort")
+    if runtime_metadata.get("profileId"):
+        profile_id = runtime_metadata["profileId"]
+        runtime_payload["profileId"] = profile_id
+        runtime_payload["providerProfile"] = profile_id
+    if runtime_payload:
+        task_payload["runtime"] = runtime_payload
+        initial_parameters[task_key] = task_payload
+
+
+def _build_recurring_target(
+    request_payload: dict[str, Any],
+    *,
+    runtime_metadata: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
     """Transform a workflow request payload into a RecurringWorkflowsService target.
 
     Constructs the Temporal workflow-start target expected by
@@ -10011,7 +10170,10 @@ def _build_recurring_target(request_payload: dict[str, Any]) -> dict[str, Any]:
         or target_payload.get("workflow_type")
         or "MoonMind.UserWorkflow"
     ).strip()
-    if "initialParameters" in target_payload or "initial_parameters" in target_payload:
+    has_initial_parameters = (
+        "initialParameters" in target_payload or "initial_parameters" in target_payload
+    )
+    if has_initial_parameters:
         initial_parameters = (
             target_payload.get("initialParameters")
             if "initialParameters" in target_payload
@@ -10025,6 +10187,11 @@ def _build_recurring_target(request_payload: dict[str, Any]) -> dict[str, Any]:
                 else initial_parameters
             ),
         }
+        if isinstance(target["initialParameters"], dict):
+            _stamp_recurring_runtime_metadata(
+                target["initialParameters"],
+                runtime_metadata,
+            )
         for source_keys, target_key in (
             (("title",), "title"),
             (("inputArtifactRef", "input_artifact_ref"), "inputArtifactRef"),
@@ -10042,9 +10209,8 @@ def _build_recurring_target(request_payload: dict[str, Any]) -> dict[str, Any]:
 
     root_propose_tasks = target_payload.pop("proposeTasks", None)
     root_proposal_policy = target_payload.pop("proposalPolicy", None)
-    task_node = target_payload.get("workflow")
-    if isinstance(task_node, Mapping):
-        task_payload = dict(task_node)
+    task_key, task_payload = _recurring_task_payload(target_payload)
+    if task_key is not None:
         propose_tasks_value = (
             task_payload["proposeTasks"]
             if "proposeTasks" in task_payload
@@ -10066,7 +10232,8 @@ def _build_recurring_target(request_payload: dict[str, Any]) -> dict[str, Any]:
             task_payload["proposalPolicy"] = normalized_proposal_policy
         else:
             task_payload.pop("proposalPolicy", None)
-        target_payload["workflow"] = task_payload
+        target_payload[task_key] = task_payload
+    _stamp_recurring_runtime_metadata(target_payload, runtime_metadata)
     return {
         "workflowType": workflow_type,
         "title": str(target_payload.get("title") or "").strip() or None,
@@ -10089,6 +10256,7 @@ def _build_recurring_target(request_payload: dict[str, Any]) -> dict[str, Any]:
         ),
     }
 
+
 async def _handle_recurring_schedule(
     *,
     schedule: ScheduleParameters,
@@ -10102,8 +10270,6 @@ async def _handle_recurring_schedule(
         RecurringWorkflowsService,
     )
 
-    svc = RecurringWorkflowsService(session)
-    target = _build_recurring_target(request_payload)
     scope_type = schedule.scope_type or "personal"
     if scope_type == "global" and not _is_execution_admin(user):
         raise HTTPException(
@@ -10113,6 +10279,15 @@ async def _handle_recurring_schedule(
                 "message": "Operator privileges are required for global schedules.",
             },
         )
+    svc = RecurringWorkflowsService(session)
+    runtime_metadata = await _resolve_recurring_runtime_metadata(
+        request_payload,
+        session=session,
+    )
+    target = _build_recurring_target(
+        request_payload,
+        runtime_metadata=runtime_metadata,
+    )
     try:
         definition = await svc.create_definition(
             name=schedule.name or "Inline schedule",

--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -10056,18 +10056,24 @@ async def _resolve_recurring_runtime_metadata(
             )
         canonical_target_runtime = normalized_rt
 
-    raw_profile_id = str(
-        runtime_payload.get("profileId")
-        or runtime_payload.get("providerProfile")
-        or runtime_payload.get("executionProfileRef")
-        or task_payload.get("profileId")
-        or task_payload.get("providerProfile")
-        or parameter_payload.get("profileId")
-        or parameter_payload.get("providerProfile")
-        or request_payload.get("profileId")
-        or request_payload.get("providerProfile")
-        or ""
-    ).strip() or None
+    raw_profile_id = None
+    for candidate_profile_id in (
+        runtime_payload.get("profileId"),
+        runtime_payload.get("providerProfile"),
+        runtime_payload.get("executionProfileRef"),
+        task_payload.get("profileId"),
+        task_payload.get("providerProfile"),
+        parameter_payload.get("profileId"),
+        parameter_payload.get("providerProfile"),
+        request_payload.get("profileId"),
+        request_payload.get("providerProfile"),
+    ):
+        if candidate_profile_id is None:
+            continue
+        normalized_profile_id = str(candidate_profile_id).strip()
+        if normalized_profile_id:
+            raw_profile_id = normalized_profile_id
+            break
     raw_requested_model: str | None = runtime_payload.get("model") or None
     if raw_requested_model is None:
         raw_requested_model = parameter_payload.get(

--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -9998,7 +9998,7 @@ def _first_mapping_value(
             return source[key]
     return None
 
-def _recurring_task_payload(
+def _recurring_workflow_payload(
     parameters: Mapping[str, Any],
 ) -> tuple[str | None, dict[str, Any]]:
     for key in ("workflow", "task"):
@@ -10028,9 +10028,9 @@ async def _resolve_recurring_runtime_metadata(
     if isinstance(raw_initial_parameters, Mapping):
         parameter_payload = raw_initial_parameters
 
-    _task_key, task_payload = _recurring_task_payload(parameter_payload)
+    _task_key, task_payload = _recurring_workflow_payload(parameter_payload)
     if not task_payload and parameter_payload is not request_payload:
-        _task_key, task_payload = _recurring_task_payload(request_payload)
+        _task_key, task_payload = _recurring_workflow_payload(request_payload)
 
     runtime_payload = (
         task_payload.get("runtime")
@@ -10135,7 +10135,7 @@ def _stamp_recurring_runtime_metadata(
     if "effort" in runtime_metadata:
         initial_parameters["effort"] = runtime_metadata.get("effort")
 
-    task_key, task_payload = _recurring_task_payload(initial_parameters)
+    task_key, task_payload = _recurring_workflow_payload(initial_parameters)
     if task_key is None:
         return
 
@@ -10215,7 +10215,7 @@ def _build_recurring_target(
 
     root_propose_tasks = target_payload.pop("proposeTasks", None)
     root_proposal_policy = target_payload.pop("proposalPolicy", None)
-    task_key, task_payload = _recurring_task_payload(target_payload)
+    task_key, task_payload = _recurring_workflow_payload(target_payload)
     if task_key is not None:
         propose_tasks_value = (
             task_payload["proposeTasks"]

--- a/tests/integration/skills/test_batch_dependabot_resolver_e2e.py
+++ b/tests/integration/skills/test_batch_dependabot_resolver_e2e.py
@@ -120,7 +120,12 @@ class _FakeAsyncClient:
 
 
 def _run_main(
-    module: dict[str, Any], argv: list[str], monkeypatch: Any, tmp_path: Path
+    module: dict[str, Any],
+    argv: list[str],
+    monkeypatch: Any,
+    tmp_path: Path,
+    *,
+    extra_env: dict[str, str] | None = None,
 ) -> dict[str, Any]:
     _FakeAsyncClient.submissions = []
     monkeypatch.setenv("MOONMIND_URL", "http://api:8000")
@@ -133,8 +138,15 @@ def _run_main(
         "MOONMIND_SESSION_ARTIFACT_SPOOL_PATH",
         "MOONMIND_DEFAULT_RUNTIME",
         "MOONMIND_EXECUTION_PROFILE_REF",
+        "MOONMIND_TASK_CONTEXT_PATH",
+        "TASK_CONTEXT_PATH",
+        "MOONMIND_AGENT_RUN_ID",
+        "MOONMIND_RUN_ID",
+        "AGENT_RUN_ID",
     ):
         monkeypatch.delenv(env_key, raising=False)
+    for key, value in (extra_env or {}).items():
+        monkeypatch.setenv(key, value)
 
     completed = subprocess.CompletedProcess(
         args=["gh"], returncode=0, stdout=json.dumps(_mixed_pr_set()), stderr=""
@@ -188,6 +200,58 @@ def test_end_to_end_mixed_pr_set(monkeypatch: Any, tmp_path: Path) -> None:
         assert body["payload"]["idempotencyKey"].startswith(
             "batch-dependabot-resolver:MoonLadderStudios/MoonMind:pr:"
         )
+
+
+def test_end_to_end_inherits_runtime_selection_from_parent_context(
+    monkeypatch: Any,
+    tmp_path: Path,
+) -> None:
+    module = _load_module()
+    task_context_path = tmp_path / "artifacts" / "task_context.json"
+    task_context_path.parent.mkdir(parents=True)
+    task_context_path.write_text(
+        json.dumps(
+            {
+                "runtimeConfig": {
+                    "mode": "codex_cli",
+                    "model": "gpt-5.3-codex-spark",
+                    "effort": "xhigh",
+                    "providerProfile": "codex-profile",
+                }
+            }
+        )
+    )
+
+    summary = _run_main(
+        module,
+        ["--repo", "MoonLadderStudios/MoonMind", "--max-prs", "1"],
+        monkeypatch,
+        tmp_path,
+        extra_env={
+            "MOONMIND_TASK_CONTEXT_PATH": str(task_context_path),
+            "MOONMIND_TASK_WORKFLOW_ID": "mm:parent-workflow",
+            "MOONMIND_AGENT_RUN_ID": "agent-run-1",
+        },
+    )
+
+    assert summary["runtime"] == {
+        "mode": "codex_cli",
+        "model": "gpt-5.3-codex-spark",
+        "effort": "xhigh",
+        "executionProfileRef": "codex-profile",
+    }
+    assert summary["created"] == 1
+    assert len(_FakeAsyncClient.submissions) == 1
+
+    payload = _FakeAsyncClient.submissions[0]["payload"]
+    assert payload["runtimeInheritance"] == "caller"
+    assert payload["targetRuntime"] == "codex_cli"
+    assert payload["task"]["runtime"] == {
+        "mode": "codex_cli",
+        "model": "gpt-5.3-codex-spark",
+        "effort": "xhigh",
+        "executionProfileRef": "codex-profile",
+    }
 
 
 def test_end_to_end_dry_run_submits_nothing(monkeypatch: Any, tmp_path: Path) -> None:

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -7699,6 +7699,65 @@ def test_create_task_shaped_recurring_schedule_uses_root_proposal_fallbacks(
     assert stored_payload["workflow"]["proposalPolicy"] == {"targets": ["moonmind"]}
 
 
+def test_create_task_shaped_recurring_schedule_preserves_runtime_selection(
+    client: tuple[TestClient, AsyncMock, SimpleNamespace],
+) -> None:
+    test_client, _service, _user = client
+    test_client.app.dependency_overrides[get_async_session] = _empty_session_override
+    next_run_at = datetime.now(UTC) + timedelta(hours=1)
+
+    with patch(
+        "api_service.services.recurring_workflows_service.RecurringWorkflowsService"
+    ) as service_cls:
+        service = service_cls.return_value
+        service.create_definition = AsyncMock(
+            return_value=SimpleNamespace(
+                id=uuid4(),
+                name="Dependabot schedule",
+                cron="0 * * * *",
+                timezone="UTC",
+                next_run_at=next_run_at,
+            )
+        )
+
+        response = test_client.post(
+            "/api/executions",
+            json={
+                "type": "workflow",
+                "payload": {
+                    "targetRuntime": "codex",
+                    "schedule": {
+                        "mode": "recurring",
+                        "cron": "0 * * * *",
+                    },
+                    "workflow": {
+                        "instructions": "Resolve Dependabot PRs.",
+                        "skill": {"name": "batch-dependabot-resolver"},
+                        "runtime": {
+                            "mode": "codex",
+                            "model": "gpt-5.3-codex-spark",
+                            "effort": "xhigh",
+                        },
+                    },
+                },
+            },
+        )
+
+    assert response.status_code == 201, response.json()
+    target = service.create_definition.await_args.kwargs["target"]
+    stored_payload = target["initialParameters"]
+    stored_runtime = stored_payload["workflow"]["runtime"]
+
+    assert stored_payload["targetRuntime"] == "codex_cli"
+    assert stored_payload["model"] == "gpt-5.3-codex-spark"
+    assert stored_payload["requestedModel"] == "gpt-5.3-codex-spark"
+    assert stored_payload["modelSource"] == "task_override"
+    assert stored_payload["effort"] == "xhigh"
+    assert stored_runtime["mode"] == "codex_cli"
+    assert stored_runtime["model"] == "gpt-5.3-codex-spark"
+    assert stored_runtime["effort"] == "xhigh"
+
+
 def test_create_task_shaped_recurring_schedule_passes_metadata_and_response(
     client: tuple[TestClient, AsyncMock, SimpleNamespace],
 ) -> None:

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -7726,6 +7726,7 @@ def test_create_task_shaped_recurring_schedule_preserves_runtime_selection(
                 "type": "workflow",
                 "payload": {
                     "targetRuntime": "codex",
+                    "providerProfile": "codex-profile",
                     "schedule": {
                         "mode": "recurring",
                         "cron": "0 * * * *",
@@ -7737,6 +7738,7 @@ def test_create_task_shaped_recurring_schedule_preserves_runtime_selection(
                             "mode": "codex",
                             "model": "gpt-5.3-codex-spark",
                             "effort": "xhigh",
+                            "profileId": "   ",
                         },
                     },
                 },
@@ -7753,9 +7755,12 @@ def test_create_task_shaped_recurring_schedule_preserves_runtime_selection(
     assert stored_payload["requestedModel"] == "gpt-5.3-codex-spark"
     assert stored_payload["modelSource"] == "task_override"
     assert stored_payload["effort"] == "xhigh"
+    assert stored_payload["profileId"] == "codex-profile"
     assert stored_runtime["mode"] == "codex_cli"
     assert stored_runtime["model"] == "gpt-5.3-codex-spark"
     assert stored_runtime["effort"] == "xhigh"
+    assert stored_runtime["profileId"] == "codex-profile"
+    assert stored_runtime["providerProfile"] == "codex-profile"
 
 
 def test_create_task_shaped_recurring_schedule_passes_metadata_and_response(


### PR DESCRIPTION
## Summary
- Stamp recurring schedule targets with the same effective runtime metadata used by immediate task submissions.
- Preserve selected Codex model, effort, profile, and canonical runtime in both top-level workflow parameters and the nested workflow runtime block.
- Add regressions for scheduled batch Dependabot runs and child pr-resolver fan-out runtime inheritance.

## Verification
- PYTHONDONTWRITEBYTECODE=1 python3 -m pytest tests/unit/api/routers/test_executions.py -q -k 'recurring_schedule'\n- PYTHONDONTWRITEBYTECODE=1 python3 -m pytest tests/integration/skills/test_batch_dependabot_resolver_e2e.py -q\n- PYTHONDONTWRITEBYTECODE=1 python3 -m pytest tests/unit/services/test_recurring_workflows_service.py -q\n- PYTHONDONTWRITEBYTECODE=1 python3 -m pytest tests/unit/workflows/executions/test_runtime_inheritance.py -q\n\nNote: ./tools/test_unit.sh did not reach pytest in this workspace because status_domain_audit.py hit PermissionError reading deploy/state/desired-state.json; the targeted pytest commands above were run directly.