### PR TITLE
MM-1125 synthesize workflow titles

### DIFF
--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -10,7 +10,7 @@ import json
 import logging
 import os
 import re
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any, Literal, Optional
@@ -62,6 +62,10 @@ from moonmind.statuses.compat import (
 )
 from moonmind.utils.metrics import get_metrics_emitter
 from moonmind.workflows.report_output import normalize_report_output_primary_path
+from moonmind.workflows.executions.title_derivation import (
+    is_generic_title,
+    synthesize_workflow_title,
+)
 from moonmind.workflows.executions.routing import _coerce_bool
 from moonmind.schemas.manifest_ingest_models import (
     ManifestNodePageModel,
@@ -8497,24 +8501,20 @@ def _validate_workflow_runtime_requirements(
     raise _invalid_workflow_request(_PR_RESOLVER_SELECTOR_ERROR)
 
 
-def _derive_task_title(task_payload: dict[str, Any]) -> str | None:
-    explicit = str(task_payload.get("title") or "").strip()
-    if explicit:
-        return explicit
-    tool_payload = _coerce_mapping(task_payload.get("tool")) or _coerce_mapping(
-        task_payload.get("skill")
+def _derive_task_title(
+    task_payload: dict[str, Any],
+    *,
+    normalized_tool: Mapping[str, Any] | None = None,
+    normalized_steps: Sequence[Mapping[str, Any]] = (),
+) -> str | None:
+    synthesized = synthesize_workflow_title(
+        current_title=task_payload.get("title"),
+        task_payload=task_payload,
+        normalized_tool=normalized_tool,
+        normalized_steps=normalized_steps,
     )
-    tool_name = ""
-    if tool_payload:
-        tool_name = str(
-            tool_payload.get("name") or tool_payload.get("id") or ""
-        ).strip()
-    if tool_name.lower() == "pr-resolver":
-        starting_branch = _pr_resolver_structured_selector(
-            task_payload=task_payload,
-        )
-        if starting_branch:
-            return starting_branch[:_MAX_TASK_TITLE_LENGTH]
+    if synthesized:
+        return synthesized
     raw_steps = task_payload.get("steps")
     if isinstance(raw_steps, list):
         for item in raw_steps:
@@ -9658,8 +9658,15 @@ async def _create_execution_from_workflow_request(
         normalized_tool=normalized_tool,
         normalized_task_for_planner=normalized_task_for_planner,
     )
-    derived_task_title = _derive_task_title(task_payload)
-    if derived_task_title and "title" not in normalized_task_for_planner:
+    derived_task_title = _derive_task_title(
+        task_payload,
+        normalized_tool=normalized_tool,
+        normalized_steps=normalized_steps,
+    )
+    if derived_task_title and (
+        "title" not in normalized_task_for_planner
+        or is_generic_title(str(normalized_task_for_planner.get("title") or ""))
+    ):
         normalized_task_for_planner["title"] = derived_task_title
 
     # --- Model resolution ---

--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -9665,7 +9665,7 @@ async def _create_execution_from_workflow_request(
     )
     if derived_task_title and (
         "title" not in normalized_task_for_planner
-        or is_generic_title(str(normalized_task_for_planner.get("title") or ""))
+        or is_generic_title(normalized_task_for_planner.get("title"))
     ):
         normalized_task_for_planner["title"] = derived_task_title
 

--- a/moonmind/workflows/executions/title_derivation.py
+++ b/moonmind/workflows/executions/title_derivation.py
@@ -28,8 +28,27 @@ _ACRONYMS = {
     "pr": "PR",
 }
 
-_REPOSITORY_KEYS = {"repository", "repo", "reporef", "repo_ref"}
-_ISSUE_KEYS = {"jiraissuekey", "jira_issue_key", "issuekey", "issue", "issueurl"}
+_REPOSITORY_KEYS = {
+    "repository",
+    "repository_url",
+    "reporef",
+    "repo",
+    "repo_ref",
+    "repo_url",
+}
+_ISSUE_KEYS = {
+    "issue",
+    "issue_key",
+    "issue_url",
+    "issuekey",
+    "issueurl",
+    "jira_issue",
+    "jira_issue_key",
+    "jira_issue_url",
+    "jiraissue",
+    "jiraissuekey",
+    "jiraissueurl",
+}
 _PR_KEYS = {
     "pr",
     "prnumber",
@@ -38,6 +57,8 @@ _PR_KEYS = {
     "pr_url",
     "pullrequest",
     "pull_request",
+    "pullrequestnumber",
+    "pull_request_number",
     "pullrequesturl",
     "pull_request_url",
 }
@@ -63,9 +84,10 @@ _IGNORED_VALUE_KEYS = {
 }
 
 _ISSUE_RE = re.compile(r"\b([A-Z][A-Z0-9]+-\d+)\b")
-_PR_URL_RE = re.compile(r"/pull/(\d+)(?:\b|/)?", re.IGNORECASE)
+_PR_URL_RE = re.compile(r"/pull/(\d+)(?=$|[/?#]|\b)", re.IGNORECASE)
 _PR_TEXT_RE = re.compile(r"\b(?:PR|pull request)\s*#?(\d+)\b", re.IGNORECASE)
 _GITHUB_SHORTHAND_RE = re.compile(r"(?<![\w/])#(\d+)\b")
+_MAX_PR_NUMBER_DIGITS = 10
 
 
 @dataclass(frozen=True)
@@ -77,7 +99,7 @@ class _TitleTarget:
 
 
 def is_generic_title(title: str | None) -> bool:
-    normalized = re.sub(r"[^\w\s]+", " ", str(title or "").strip().casefold())
+    normalized = re.sub(r"[\W_]+", " ", str(title or "").strip().casefold())
     normalized = " ".join(normalized.split())
     return normalized in _GENERIC_TITLES
 
@@ -92,8 +114,6 @@ def synthesize_workflow_title(
     explicit = str(current_title or "").strip()
     if explicit and not is_generic_title(explicit):
         return explicit
-    if explicit == "" and current_title is not None and not is_generic_title(current_title):
-        return current_title
 
     label = _capability_label(task_payload, normalized_tool, normalized_steps)
     targets = _collect_structured_targets(task_payload)
@@ -121,17 +141,23 @@ def _capability_label(
         )
 
     if tool_payload is not None:
-        for key in ("label", "displayName", "display_name", "title"):
+        for key in ("label", "displayName", "display_name"):
             value = _clean_text(tool_payload.get(key))
             if value:
                 return value
-        for key in ("name", "id", "slug", "type"):
+        value = _clean_text(tool_payload.get("title"))
+        if value and not is_generic_title(value):
+            return value
+        for key in ("name", "id", "slug"):
             value = _clean_text(tool_payload.get(key))
             if value:
                 return _identifier_to_label(value)
+        value = _clean_text(tool_payload.get("type"))
+        if value and not is_generic_title(value) and value.casefold() != "skill":
+            return _identifier_to_label(value)
 
-    for step in normalized_steps:
-        value = _clean_text(step.get("title"))
+    if len(normalized_steps) == 1:
+        value = _clean_text(normalized_steps[0].get("title"))
         if value:
             return value
 
@@ -207,11 +233,21 @@ def _append_targets_for_value(
         if issue:
             targets.append(_TitleTarget("issue", issue, 0, path))
             return
-    if key in _PR_KEYS:
         pr = _extract_pr(text)
         if pr:
             targets.append(_TitleTarget("pull_request", pr, 1, path))
             return
+        return
+    if key in _PR_KEYS:
+        pr = _extract_pr(text, allow_bare_number=True, allow_shorthand=True)
+        if pr:
+            targets.append(_TitleTarget("pull_request", pr, 1, path))
+            return
+        issue = _extract_issue(text)
+        if issue:
+            targets.append(_TitleTarget("issue", issue, 0, path))
+            return
+        return
     if key in _BRANCH_KEYS and _looks_like_branch(text):
         targets.append(_TitleTarget("branch", text, 2, path))
         return
@@ -243,8 +279,7 @@ def _collect_text_fallback_targets(
         issue = _extract_issue(text)
         if issue:
             targets.append(_TitleTarget("issue", issue, 0, f"text[{index}]"))
-            continue
-        pr = _extract_pr(text)
+        pr = _extract_pr(text, allow_shorthand=True)
         if pr:
             targets.append(_TitleTarget("pull_request", pr, 1, f"text[{index}]"))
     return _rank_targets(targets)
@@ -269,14 +304,29 @@ def _extract_issue(text: str) -> str | None:
     return match.group(1) if match else None
 
 
-def _extract_pr(text: str) -> str | None:
-    for pattern in (_PR_URL_RE, _PR_TEXT_RE, _GITHUB_SHORTHAND_RE):
+def _extract_pr(
+    text: str,
+    *,
+    allow_bare_number: bool = False,
+    allow_shorthand: bool = False,
+) -> str | None:
+    patterns = [_PR_URL_RE, _PR_TEXT_RE]
+    if allow_shorthand:
+        patterns.append(_GITHUB_SHORTHAND_RE)
+    for pattern in patterns:
         match = pattern.search(text)
         if match:
-            return f"PR #{int(match.group(1))}"
-    if text.isdigit():
-        return f"PR #{int(text)}"
+            return _render_pr_number(match.group(1))
+    if allow_bare_number and text.isdigit():
+        return _render_pr_number(text)
     return None
+
+
+def _render_pr_number(digits: str) -> str | None:
+    pr_num = digits.lstrip("0") or "0"
+    if len(pr_num) > _MAX_PR_NUMBER_DIGITS:
+        return None
+    return f"PR #{pr_num}"
 
 
 def _looks_like_branch(text: str) -> bool:

--- a/moonmind/workflows/executions/title_derivation.py
+++ b/moonmind/workflows/executions/title_derivation.py
@@ -1,0 +1,299 @@
+"""Deterministic workflow title synthesis for task-shaped submissions."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+_MAX_TASK_TITLE_LENGTH = 150
+_MAX_TRAVERSAL_DEPTH = 6
+_MAX_VISITED_VALUES = 200
+
+_GENERIC_TITLES = {
+    "",
+    "run",
+    "new run",
+    "untitled",
+    "untitled run",
+    "workflow",
+    "new workflow",
+}
+
+_ACRONYMS = {
+    "ci": "CI",
+    "github": "GitHub",
+    "jira": "Jira",
+    "pr": "PR",
+}
+
+_REPOSITORY_KEYS = {"repository", "repo", "reporef", "repo_ref"}
+_ISSUE_KEYS = {"jiraissuekey", "jira_issue_key", "issuekey", "issue", "issueurl"}
+_PR_KEYS = {
+    "pr",
+    "prnumber",
+    "pr_number",
+    "prurl",
+    "pr_url",
+    "pullrequest",
+    "pull_request",
+    "pullrequesturl",
+    "pull_request_url",
+}
+_BRANCH_KEYS = {
+    "branch",
+    "ref",
+    "startingbranch",
+    "starting_branch",
+    "headbranch",
+    "head_branch",
+}
+_CHECK_KEYS = {"check", "checkname", "check_name", "job", "jobname", "job_name"}
+_IGNORED_VALUE_KEYS = {
+    "effort",
+    "mode",
+    "model",
+    "profileid",
+    "profile_id",
+    "requestedmodel",
+    "requested_model",
+    "targetruntime",
+    "target_runtime",
+}
+
+_ISSUE_RE = re.compile(r"\b([A-Z][A-Z0-9]+-\d+)\b")
+_PR_URL_RE = re.compile(r"/pull/(\d+)(?:\b|/)?", re.IGNORECASE)
+_PR_TEXT_RE = re.compile(r"\b(?:PR|pull request)\s*#?(\d+)\b", re.IGNORECASE)
+_GITHUB_SHORTHAND_RE = re.compile(r"(?<![\w/])#(\d+)\b")
+
+
+@dataclass(frozen=True)
+class _TitleTarget:
+    kind: str
+    value: str
+    priority: int
+    path: str
+
+
+def is_generic_title(title: str | None) -> bool:
+    normalized = re.sub(r"[^\w\s]+", " ", str(title or "").strip().casefold())
+    normalized = " ".join(normalized.split())
+    return normalized in _GENERIC_TITLES
+
+
+def synthesize_workflow_title(
+    *,
+    current_title: str | None,
+    task_payload: Mapping[str, Any],
+    normalized_tool: Mapping[str, Any] | None,
+    normalized_steps: Sequence[Mapping[str, Any]] = (),
+) -> str | None:
+    explicit = str(current_title or "").strip()
+    if explicit and not is_generic_title(explicit):
+        return explicit
+    if explicit == "" and current_title is not None and not is_generic_title(current_title):
+        return current_title
+
+    label = _capability_label(task_payload, normalized_tool, normalized_steps)
+    targets = _collect_structured_targets(task_payload)
+    if not targets:
+        targets = _collect_text_fallback_targets(current_title, task_payload)
+    if not targets:
+        return None
+
+    rendered_targets = " — ".join(target.value for target in targets[:2])
+    return f"{label}: {rendered_targets}"[:_MAX_TASK_TITLE_LENGTH]
+
+
+def _capability_label(
+    task_payload: Mapping[str, Any],
+    normalized_tool: Mapping[str, Any] | None,
+    normalized_steps: Sequence[Mapping[str, Any]],
+) -> str:
+    tool_payload = normalized_tool or _mapping(task_payload.get("tool")) or _mapping(
+        task_payload.get("skill")
+    )
+    workflow_payload = _mapping(task_payload.get("workflow"))
+    if tool_payload is None and workflow_payload is not None:
+        tool_payload = _mapping(workflow_payload.get("tool")) or _mapping(
+            workflow_payload.get("skill")
+        )
+
+    if tool_payload is not None:
+        for key in ("label", "displayName", "display_name", "title"):
+            value = _clean_text(tool_payload.get(key))
+            if value:
+                return value
+        for key in ("name", "id", "slug", "type"):
+            value = _clean_text(tool_payload.get(key))
+            if value:
+                return _identifier_to_label(value)
+
+    for step in normalized_steps:
+        value = _clean_text(step.get("title"))
+        if value:
+            return value
+
+    raw_steps = task_payload.get("steps")
+    if isinstance(raw_steps, list) and len(raw_steps) == 1:
+        step = _mapping(raw_steps[0])
+        value = _clean_text(step.get("title") if step else None)
+        if value:
+            return value
+
+    return "Workflow"
+
+
+def _identifier_to_label(value: str) -> str:
+    words = re.sub(r"([a-z0-9])([A-Z])", r"\1 \2", value)
+    words = re.sub(r"[-_.:/]+", " ", words)
+    rendered: list[str] = []
+    for word in words.split():
+        normalized = word.casefold()
+        rendered.append(_ACRONYMS.get(normalized, word[:1].upper() + word[1:].lower()))
+    return " ".join(rendered) or "Workflow"
+
+
+def _collect_structured_targets(task_payload: Mapping[str, Any]) -> list[_TitleTarget]:
+    targets: list[_TitleTarget] = []
+    visited = 0
+
+    def walk(value: Any, path: str, depth: int, parent_key: str = "") -> None:
+        nonlocal visited
+        if visited >= _MAX_VISITED_VALUES or depth > _MAX_TRAVERSAL_DEPTH:
+            return
+        visited += 1
+
+        if isinstance(value, Mapping):
+            for raw_key, raw_child in value.items():
+                key = str(raw_key)
+                normalized_key = _normalize_key(key)
+                if normalized_key in _REPOSITORY_KEYS or normalized_key in _IGNORED_VALUE_KEYS:
+                    continue
+                child_path = f"{path}.{key}" if path else key
+                if normalized_key in {"instructions", "title"}:
+                    continue
+                _append_targets_for_value(
+                    targets=targets,
+                    key=normalized_key,
+                    value=raw_child,
+                    path=child_path,
+                )
+                walk(raw_child, child_path, depth + 1, normalized_key)
+            return
+
+        if isinstance(value, list):
+            for index, item in enumerate(value):
+                walk(item, f"{path}[{index}]", depth + 1, parent_key)
+
+    walk(task_payload, "", 0)
+    return _rank_targets(targets)
+
+
+def _append_targets_for_value(
+    *,
+    targets: list[_TitleTarget],
+    key: str,
+    value: Any,
+    path: str,
+) -> None:
+    text = _clean_text(value)
+    if not text:
+        return
+
+    if key in _ISSUE_KEYS:
+        issue = _extract_issue(text)
+        if issue:
+            targets.append(_TitleTarget("issue", issue, 0, path))
+            return
+    if key in _PR_KEYS:
+        pr = _extract_pr(text)
+        if pr:
+            targets.append(_TitleTarget("pull_request", pr, 1, path))
+            return
+    if key in _BRANCH_KEYS and _looks_like_branch(text):
+        targets.append(_TitleTarget("branch", text, 2, path))
+        return
+    if key in _CHECK_KEYS:
+        targets.append(_TitleTarget("check", f"failing check: {text}", 3, path))
+        return
+
+    issue = _extract_issue(text)
+    if issue:
+        targets.append(_TitleTarget("issue", issue, 0, path))
+        return
+    pr = _extract_pr(text)
+    if pr:
+        targets.append(_TitleTarget("pull_request", pr, 1, path))
+        return
+
+
+def _collect_text_fallback_targets(
+    current_title: str | None,
+    task_payload: Mapping[str, Any],
+) -> list[_TitleTarget]:
+    candidates = [_clean_text(current_title), _clean_text(task_payload.get("instructions"))]
+    workflow = _mapping(task_payload.get("workflow"))
+    if workflow is not None:
+        candidates.append(_clean_text(workflow.get("instructions")))
+
+    targets: list[_TitleTarget] = []
+    for index, text in enumerate(candidate for candidate in candidates if candidate):
+        issue = _extract_issue(text)
+        if issue:
+            targets.append(_TitleTarget("issue", issue, 0, f"text[{index}]"))
+            continue
+        pr = _extract_pr(text)
+        if pr:
+            targets.append(_TitleTarget("pull_request", pr, 1, f"text[{index}]"))
+    return _rank_targets(targets)
+
+
+def _rank_targets(targets: list[_TitleTarget]) -> list[_TitleTarget]:
+    seen: set[tuple[str, str]] = set()
+    seen_kinds: set[str] = set()
+    unique: list[_TitleTarget] = []
+    for target in sorted(targets, key=lambda item: item.priority):
+        key = (target.kind, target.value)
+        if key in seen or target.kind in seen_kinds:
+            continue
+        seen.add(key)
+        seen_kinds.add(target.kind)
+        unique.append(target)
+    return unique
+
+
+def _extract_issue(text: str) -> str | None:
+    match = _ISSUE_RE.search(text.upper())
+    return match.group(1) if match else None
+
+
+def _extract_pr(text: str) -> str | None:
+    for pattern in (_PR_URL_RE, _PR_TEXT_RE, _GITHUB_SHORTHAND_RE):
+        match = pattern.search(text)
+        if match:
+            return f"PR #{int(match.group(1))}"
+    if text.isdigit():
+        return f"PR #{int(text)}"
+    return None
+
+
+def _looks_like_branch(text: str) -> bool:
+    return bool(text and not text.isspace())
+
+
+def _clean_text(value: Any) -> str:
+    if isinstance(value, bool) or value is None:
+        return ""
+    if isinstance(value, (str, int)):
+        return str(value).strip()
+    return ""
+
+
+def _mapping(value: Any) -> Mapping[str, Any] | None:
+    return value if isinstance(value, Mapping) else None
+
+
+def _normalize_key(key: str) -> str:
+    return re.sub(r"[^a-z0-9_]+", "", key.casefold())

--- a/moonmind/workflows/executions/title_derivation.py
+++ b/moonmind/workflows/executions/title_derivation.py
@@ -30,11 +30,15 @@ _ACRONYMS = {
 
 _REPOSITORY_KEYS = {
     "repository",
+    "repositoryref",
+    "repositoryurl",
     "repository_url",
     "reporef",
     "repo",
     "repo_ref",
+    "repourl",
     "repo_url",
+    "giturl",
 }
 _ISSUE_KEYS = {
     "issue",
@@ -117,8 +121,13 @@ def synthesize_workflow_title(
 
     label = _capability_label(task_payload, normalized_tool, normalized_steps)
     targets = _collect_structured_targets(task_payload)
+    fallback_targets = _collect_text_fallback_targets(current_title, task_payload)
     if not targets:
-        targets = _collect_text_fallback_targets(current_title, task_payload)
+        targets = fallback_targets
+    elif fallback_targets and not any(
+        target.kind in {"issue", "pull_request"} for target in targets
+    ):
+        targets = _rank_targets([*targets, *fallback_targets])
     if not targets:
         return None
 
@@ -131,16 +140,32 @@ def _capability_label(
     normalized_tool: Mapping[str, Any] | None,
     normalized_steps: Sequence[Mapping[str, Any]],
 ) -> str:
-    tool_payload = normalized_tool or _mapping(task_payload.get("tool")) or _mapping(
-        task_payload.get("skill")
-    )
+    raw_tool_payloads = [
+        payload
+        for payload in (
+            _mapping(task_payload.get("tool")),
+            _mapping(task_payload.get("skill")),
+        )
+        if payload is not None
+    ]
     workflow_payload = _mapping(task_payload.get("workflow"))
-    if tool_payload is None and workflow_payload is not None:
-        tool_payload = _mapping(workflow_payload.get("tool")) or _mapping(
-            workflow_payload.get("skill")
+    if workflow_payload is not None:
+        raw_tool_payloads.extend(
+            payload
+            for payload in (
+                _mapping(workflow_payload.get("tool")),
+                _mapping(workflow_payload.get("skill")),
+            )
+            if payload is not None
         )
 
-    if tool_payload is not None:
+    tool_payloads = [
+        payload
+        for payload in (normalized_tool, *raw_tool_payloads)
+        if payload is not None
+    ]
+
+    for tool_payload in tool_payloads:
         for key in ("label", "displayName", "display_name"):
             value = _clean_text(tool_payload.get(key))
             if value:
@@ -148,6 +173,8 @@ def _capability_label(
         value = _clean_text(tool_payload.get("title"))
         if value and not is_generic_title(value):
             return value
+
+    for tool_payload in tool_payloads:
         for key in ("name", "id", "slug"):
             value = _clean_text(tool_payload.get(key))
             if value:

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -6462,6 +6462,45 @@ def test_create_task_shaped_execution_synthesizes_generic_title(
     assert initial_parameters["workflow"]["title"] == "Jira Verify: KANDY-123"
 
 
+def test_create_task_shaped_execution_synthesizes_issue_pr_title_without_repo(
+    client: tuple[TestClient, AsyncMock, SimpleNamespace],
+) -> None:
+    test_client, service, _user = client
+    service.create_execution.return_value = _build_execution_record()
+
+    response = test_client.post(
+        "/api/executions",
+        json={
+            "type": "workflow",
+            "payload": {
+                "workflow": {
+                    "title": "Run",
+                    "runtime": {"mode": "claude_code"},
+                    "repository": "MoonLadderStudios/MoonMind",
+                    "tool": {
+                        "type": "skill",
+                        "name": "jira-pr-verify",
+                        "inputs": {
+                            "issueKey": "KANDY-123",
+                            "pullRequestUrl": "https://github.com/org/repo/pull/456",
+                            "repository": "org/repo",
+                        },
+                    },
+                }
+            },
+        },
+    )
+
+    assert response.status_code == 201
+    called_kwargs = service.create_execution.await_args.kwargs
+    assert called_kwargs["title"] == "Jira PR Verify: KANDY-123 — PR #456"
+    initial_parameters = called_kwargs["initial_parameters"]
+    assert (
+        initial_parameters["workflow"]["title"]
+        == "Jira PR Verify: KANDY-123 — PR #456"
+    )
+
+
 def test_create_task_shaped_execution_keeps_meaningful_title_after_synthesis(
     client: tuple[TestClient, AsyncMock, SimpleNamespace],
 ) -> None:

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -6356,11 +6356,11 @@ def test_create_task_shaped_execution_allows_pr_resolver_with_starting_branch(
 
     assert response.status_code == 201
     called_kwargs = service.create_execution.await_args.kwargs
-    assert called_kwargs["title"] == "feature/resolve-pr"
+    assert called_kwargs["title"] == "PR Resolver: feature/resolve-pr"
     initial_parameters = service.create_execution.await_args.kwargs[
         "initial_parameters"
     ]
-    assert initial_parameters["workflow"]["title"] == "feature/resolve-pr"
+    assert initial_parameters["workflow"]["title"] == "PR Resolver: feature/resolve-pr"
     assert initial_parameters["workflow"]["git"] == {
         "startingBranch": "feature/resolve-pr",
     }
@@ -6392,9 +6392,9 @@ def test_create_task_shaped_execution_allows_pr_resolver_with_non_default_git_br
 
     assert response.status_code == 201
     called_kwargs = service.create_execution.await_args.kwargs
-    assert called_kwargs["title"] == "feature/resolve-pr"
+    assert called_kwargs["title"] == "PR Resolver: feature/resolve-pr"
     initial_parameters = called_kwargs["initial_parameters"]
-    assert initial_parameters["workflow"]["title"] == "feature/resolve-pr"
+    assert initial_parameters["workflow"]["title"] == "PR Resolver: feature/resolve-pr"
     assert initial_parameters["workflow"]["git"] == {
         "branch": "feature/resolve-pr",
     }
@@ -6429,6 +6429,71 @@ def test_create_task_shaped_execution_allows_pr_resolver_with_numeric_pr_selecto
         "initial_parameters"
     ]
     assert initial_parameters["workflow"]["inputs"] == {"pr": 2733}
+
+
+def test_create_task_shaped_execution_synthesizes_generic_title(
+    client: tuple[TestClient, AsyncMock, SimpleNamespace],
+) -> None:
+    test_client, service, _user = client
+    service.create_execution.return_value = _build_execution_record()
+
+    response = test_client.post(
+        "/api/executions",
+        json={
+            "type": "workflow",
+            "payload": {
+                "workflow": {
+                    "title": "Run",
+                    "runtime": {"mode": "claude_code"},
+                    "tool": {
+                        "type": "skill",
+                        "name": "jira-verify",
+                        "inputs": {"issueKey": "KANDY-123"},
+                    },
+                }
+            },
+        },
+    )
+
+    assert response.status_code == 201
+    called_kwargs = service.create_execution.await_args.kwargs
+    assert called_kwargs["title"] == "Jira Verify: KANDY-123"
+    initial_parameters = called_kwargs["initial_parameters"]
+    assert initial_parameters["workflow"]["title"] == "Jira Verify: KANDY-123"
+
+
+def test_create_task_shaped_execution_keeps_meaningful_title_after_synthesis(
+    client: tuple[TestClient, AsyncMock, SimpleNamespace],
+) -> None:
+    test_client, service, _user = client
+    service.create_execution.return_value = _build_execution_record()
+
+    response = test_client.post(
+        "/api/executions",
+        json={
+            "type": "workflow",
+            "payload": {
+                "workflow": {
+                    "title": "Verify auth redirect fix",
+                    "runtime": {"mode": "claude_code"},
+                    "tool": {
+                        "type": "skill",
+                        "name": "jira-pr-verify",
+                        "inputs": {
+                            "issueKey": "KANDY-123",
+                            "pullRequestUrl": "https://github.com/org/repo/pull/456",
+                        },
+                    },
+                }
+            },
+        },
+    )
+
+    assert response.status_code == 201
+    called_kwargs = service.create_execution.await_args.kwargs
+    assert called_kwargs["title"] == "Verify auth redirect fix"
+    initial_parameters = called_kwargs["initial_parameters"]
+    assert initial_parameters["workflow"]["title"] == "Verify auth redirect fix"
 
 
 def _pentest_workflow_payload(
@@ -7555,9 +7620,9 @@ def test_create_task_shaped_execution_derives_pr_resolver_title_from_tool_inputs
 
     assert response.status_code == 201
     called_kwargs = service.create_execution.await_args.kwargs
-    assert called_kwargs["title"] == "feature/from-tool-inputs"
+    assert called_kwargs["title"] == "PR Resolver: feature/from-tool-inputs"
     initial_parameters = called_kwargs["initial_parameters"]
-    assert initial_parameters["workflow"]["title"] == "feature/from-tool-inputs"
+    assert initial_parameters["workflow"]["title"] == "PR Resolver: feature/from-tool-inputs"
 
 def test_create_task_shaped_execution_once_schedule_sets_start_delay(
     client: tuple[TestClient, AsyncMock, SimpleNamespace],

--- a/tests/unit/workflows/executions/test_title_derivation.py
+++ b/tests/unit/workflows/executions/test_title_derivation.py
@@ -66,6 +66,27 @@ def test_derives_capability_labels(tool: dict[str, object], expected: str) -> No
     )
 
 
+def test_raw_tool_label_takes_priority_over_normalized_skill_name() -> None:
+    assert (
+        synthesize_workflow_title(
+            current_title="Run",
+            task_payload={
+                "workflow": {
+                    "tool": {
+                        "type": "skill",
+                        "name": "jira-pr-verify",
+                        "label": "Custom Label",
+                        "inputs": {"issueKey": "KANDY-123"},
+                    }
+                }
+            },
+            normalized_tool={"type": "skill", "name": "jira-pr-verify"},
+            normalized_steps=[],
+        )
+        == "Custom Label: KANDY-123"
+    )
+
+
 def test_uses_workflow_tool_skill_git_steps_and_top_level_targets() -> None:
     payload = {
         "workflow": {
@@ -242,6 +263,23 @@ def test_extracts_branch_ref_check_and_job_targets(
     )
 
 
+def test_instruction_issue_overrides_checkout_branch_target() -> None:
+    assert (
+        synthesize_workflow_title(
+            current_title="Run",
+            task_payload={
+                "workflow": {
+                    "git": {"branch": "main"},
+                    "instructions": "Fix MM-123 before launch.",
+                }
+            },
+            normalized_tool={"name": "future-skill"},
+            normalized_steps=[],
+        )
+        == "Future Skill: MM-123 — main"
+    )
+
+
 @pytest.mark.parametrize(
     ("payload", "expected"),
     [
@@ -359,8 +397,11 @@ def test_excludes_repository_fields_and_caps_synthesized_title() -> None:
         current_title="Run",
         task_payload={
             "repository": "MoonLadderStudios/MoonMind",
+            "repositoryUrl": "https://github.com/MM-123/service",
             "repo": "other/repo",
+            "repo-url": "https://github.com/MM-456/another",
             "repoRef": "repo-ref",
+            "gitUrl": "https://github.com/MM-789/git",
             "inputs": {"branch": "feature/" + "x" * 180},
         },
         normalized_tool={"name": "fix-merge-conflicts"},
@@ -372,6 +413,9 @@ def test_excludes_repository_fields_and_caps_synthesized_title() -> None:
     assert "MoonMind" not in title
     assert "other/repo" not in title
     assert "repo-ref" not in title
+    assert "MM-123" not in title
+    assert "MM-456" not in title
+    assert "MM-789" not in title
     assert title.startswith("Fix Merge Conflicts: feature/")
 
 

--- a/tests/unit/workflows/executions/test_title_derivation.py
+++ b/tests/unit/workflows/executions/test_title_derivation.py
@@ -1,0 +1,276 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from moonmind.workflows.executions.title_derivation import (
+    is_generic_title,
+    synthesize_workflow_title,
+)
+
+
+@pytest.mark.parametrize(
+    "title",
+    [
+        None,
+        "",
+        "Run",
+        "run",
+        " Run ",
+        "Run!",
+        "New run",
+        "Untitled",
+        "Untitled run",
+        "Workflow",
+        "New workflow",
+        " new workflow. ",
+    ],
+)
+def test_classifies_low_information_titles(title: str | None) -> None:
+    assert is_generic_title(title)
+
+
+@pytest.mark.parametrize(
+    "title",
+    ["Verify KANDY-123", "Fix failing CI on auth redirect", "Run MM-123 checks"],
+)
+def test_classifies_meaningful_titles(title: str) -> None:
+    assert not is_generic_title(title)
+
+
+@pytest.mark.parametrize(
+    ("tool", "expected"),
+    [
+        ({"label": "Custom Label"}, "Custom Label: KANDY-123"),
+        ({"displayName": "Jira reviewer"}, "Jira reviewer: KANDY-123"),
+        ({"name": "jira-pr-verify"}, "Jira PR Verify: KANDY-123"),
+        ({"id": "fix-ci"}, "Fix CI: KANDY-123"),
+        ({}, "Review Step: KANDY-123"),
+    ],
+)
+def test_derives_capability_labels(tool: dict[str, object], expected: str) -> None:
+    steps = [{"title": "Review Step"}] if not tool else []
+
+    assert (
+        synthesize_workflow_title(
+            current_title="Run",
+            task_payload={"inputs": {"issueKey": "KANDY-123"}},
+            normalized_tool=tool,
+            normalized_steps=steps,
+        )
+        == expected
+    )
+
+
+def test_uses_workflow_tool_skill_git_steps_and_top_level_targets() -> None:
+    payload = {
+        "workflow": {
+            "inputs": {"ignored": "plain text"},
+            "tool": {"inputs": {"issueUrl": "https://example.atlassian.net/browse/KANDY-123"}},
+            "skill": {"inputs": {"pullRequestUrl": "https://github.com/org/repo/pull/456"}},
+            "git": {"startingBranch": "feature/auth-redirect"},
+            "steps": [
+                {
+                    "inputs": {"checkName": "unit-tests"},
+                    "tool": {"inputs": {"jobName": "lint"}},
+                    "skill": {"inputs": {"branch": "feature/from-step"}},
+                }
+            ],
+        },
+        "issueKey": "MM-777",
+    }
+
+    assert (
+        synthesize_workflow_title(
+            current_title="Untitled",
+            task_payload=payload,
+            normalized_tool={"name": "jira-pr-verify"},
+            normalized_steps=[],
+        )
+        == "Jira PR Verify: KANDY-123 — PR #456"
+    )
+
+
+@pytest.mark.parametrize(
+    ("tool_name", "payload", "expected"),
+    [
+        ("pr-resolver", {"inputs": {"pr": 456}}, "PR Resolver: PR #456"),
+        (
+            "pr-resolver",
+            {"inputs": {"pullRequestUrl": "https://github.com/org/repo/pull/456"}},
+            "PR Resolver: PR #456",
+        ),
+        ("fix-comments", {"inputs": {"pull_request": 456}}, "Fix Comments: PR #456"),
+        ("fix-ci", {"inputs": {"prUrl": "https://github.com/org/repo/pull/456"}}, "Fix CI: PR #456"),
+    ],
+)
+def test_extracts_pull_request_targets(
+    tool_name: str, payload: dict[str, object], expected: str
+) -> None:
+    assert (
+        synthesize_workflow_title(
+            current_title="Run",
+            task_payload=payload,
+            normalized_tool={"name": tool_name},
+            normalized_steps=[],
+        )
+        == expected
+    )
+
+
+def test_combines_issue_and_pull_request_in_priority_order() -> None:
+    assert (
+        synthesize_workflow_title(
+            current_title="Run",
+            task_payload={
+                "inputs": {
+                    "pullRequestUrl": "https://github.com/org/repo/pull/456",
+                    "issueKey": "KANDY-123",
+                }
+            },
+            normalized_tool={"name": "jira-pr-verify"},
+            normalized_steps=[],
+        )
+        == "Jira PR Verify: KANDY-123 — PR #456"
+    )
+
+
+def test_orders_targets_deterministically_and_renders_at_most_two() -> None:
+    assert (
+        synthesize_workflow_title(
+            current_title="Workflow",
+            task_payload={
+                "inputs": {
+                    "checkName": "unit-tests",
+                    "pr": 456,
+                    "issueKey": "KANDY-123",
+                }
+            },
+            normalized_tool={"name": "fix-ci"},
+            normalized_steps=[],
+        )
+        == "Fix CI: KANDY-123 — PR #456"
+    )
+
+
+@pytest.mark.parametrize(
+    ("payload", "expected"),
+    [
+        ({"git": {"startingBranch": "feature/auth-redirect"}}, "Fix Merge Conflicts: feature/auth-redirect"),
+        ({"inputs": {"headBranch": "feature/head"}}, "Fix Merge Conflicts: feature/head"),
+        ({"inputs": {"checkName": "unit-tests"}}, "Fix Merge Conflicts: failing check: unit-tests"),
+        ({"inputs": {"jobName": "lint"}}, "Fix Merge Conflicts: failing check: lint"),
+    ],
+)
+def test_extracts_branch_ref_check_and_job_targets(
+    payload: dict[str, object], expected: str
+) -> None:
+    assert (
+        synthesize_workflow_title(
+            current_title="Run",
+            task_payload=payload,
+            normalized_tool={"name": "fix-merge-conflicts"},
+            normalized_steps=[],
+        )
+        == expected
+    )
+
+
+@pytest.mark.parametrize(
+    ("payload", "expected"),
+    [
+        ({"instructions": "Verify KANDY-123 and report back."}, "Future Skill: KANDY-123"),
+        (
+            {"instructions": "Review https://github.com/org/repo/pull/456"},
+            "Future Skill: PR #456",
+        ),
+        ({"instructions": "Review pull request #456"}, "Future Skill: PR #456"),
+        ({"instructions": "Review #456"}, "Future Skill: PR #456"),
+    ],
+)
+def test_regex_fallback_runs_after_structured_targets(
+    payload: dict[str, object], expected: str
+) -> None:
+    assert (
+        synthesize_workflow_title(
+            current_title="Run",
+            task_payload=payload,
+            normalized_tool={"name": "future-skill"},
+            normalized_steps=[],
+        )
+        == expected
+    )
+
+    with_structured = dict(payload)
+    with_structured["inputs"] = {"issueKey": "KANDY-123"}
+    assert (
+        synthesize_workflow_title(
+            current_title="Run",
+            task_payload=with_structured,
+            normalized_tool={"name": "future-skill"},
+            normalized_steps=[],
+        )
+        == "Future Skill: KANDY-123"
+    )
+
+
+def test_preserves_meaningful_explicit_title() -> None:
+    assert (
+        synthesize_workflow_title(
+            current_title="Verify auth redirect fix",
+            task_payload={"inputs": {"issueKey": "KANDY-123"}},
+            normalized_tool={"name": "jira-verify"},
+            normalized_steps=[],
+        )
+        == "Verify auth redirect fix"
+    )
+
+
+def test_excludes_repository_fields_and_caps_synthesized_title() -> None:
+    title = synthesize_workflow_title(
+        current_title="Run",
+        task_payload={
+            "repository": "MoonLadderStudios/MoonMind",
+            "repo": "other/repo",
+            "repoRef": "repo-ref",
+            "inputs": {"branch": "feature/" + "x" * 180},
+        },
+        normalized_tool={"name": "fix-merge-conflicts"},
+        normalized_steps=[],
+    )
+
+    assert title is not None
+    assert len(title) == 150
+    assert "MoonMind" not in title
+    assert "other/repo" not in title
+    assert "repo-ref" not in title
+    assert title.startswith("Fix Merge Conflicts: feature/")
+
+
+def test_unknown_future_skill_with_no_target_returns_none() -> None:
+    assert (
+        synthesize_workflow_title(
+            current_title="Run",
+            task_payload={"inputs": {"repository": "MoonLadderStudios/MoonMind"}},
+            normalized_tool={"name": "future-skill"},
+            normalized_steps=[],
+        )
+        is None
+    )
+
+
+def test_title_synthesis_has_no_external_or_skill_runtime_imports() -> None:
+    before = set(sys.modules)
+    synthesize_workflow_title(
+        current_title="Run",
+        task_payload={"inputs": {"issueKey": "KANDY-123"}},
+        normalized_tool={"name": "jira-verify"},
+        normalized_steps=[],
+    )
+    loaded = set(sys.modules) - before
+
+    assert not any(name.startswith("jira") for name in loaded)
+    assert not any("github" in name.lower() for name in loaded)
+    assert ".agents/skills" not in str(Path(__file__).resolve())

--- a/tests/unit/workflows/executions/test_title_derivation.py
+++ b/tests/unit/workflows/executions/test_title_derivation.py
@@ -20,6 +20,8 @@ from moonmind.workflows.executions.title_derivation import (
         "run",
         " Run ",
         "Run!",
+        "New-run",
+        "New_run",
         "New run",
         "Untitled",
         "Untitled run",
@@ -120,6 +122,68 @@ def test_extracts_pull_request_targets(
     )
 
 
+def test_restricts_bare_numeric_pr_targets_to_explicit_pr_fields() -> None:
+    assert (
+        synthesize_workflow_title(
+            current_title="Run",
+            task_payload={"inputs": {"port": 8080, "issue_number": 123}},
+            normalized_tool={"name": "future-skill"},
+            normalized_steps=[],
+        )
+        is None
+    )
+
+    assert (
+        synthesize_workflow_title(
+            current_title="Run",
+            task_payload={"inputs": {"pr": 456}},
+            normalized_tool={"name": "future-skill"},
+            normalized_steps=[],
+        )
+        == "Future Skill: PR #456"
+    )
+
+
+def test_rejects_extremely_long_pr_numbers_without_integer_conversion() -> None:
+    assert (
+        synthesize_workflow_title(
+            current_title="Run",
+            task_payload={"inputs": {"pr": "1" * 5000}},
+            normalized_tool={"name": "pr-resolver"},
+            normalized_steps=[],
+        )
+        is None
+    )
+
+
+def test_pr_url_extraction_requires_number_boundary() -> None:
+    assert (
+        synthesize_workflow_title(
+            current_title="Run",
+            task_payload={
+                "inputs": {"pullRequestUrl": "https://github.com/org/repo/pull/456abc"}
+            },
+            normalized_tool={"name": "pr-resolver"},
+            normalized_steps=[],
+        )
+        is None
+    )
+
+    assert (
+        synthesize_workflow_title(
+            current_title="Run",
+            task_payload={
+                "inputs": {
+                    "pullRequestUrl": "https://github.com/org/repo/pull/456?diff=split"
+                }
+            },
+            normalized_tool={"name": "pr-resolver"},
+            normalized_steps=[],
+        )
+        == "PR Resolver: PR #456"
+    )
+
+
 def test_combines_issue_and_pull_request_in_priority_order() -> None:
     assert (
         synthesize_workflow_title(
@@ -213,6 +277,68 @@ def test_regex_fallback_runs_after_structured_targets(
             normalized_steps=[],
         )
         == "Future Skill: KANDY-123"
+    )
+
+
+def test_regex_fallback_can_extract_issue_and_pr_from_same_text() -> None:
+    assert (
+        synthesize_workflow_title(
+            current_title="Run",
+            task_payload={"instructions": "Fix MM-123 and review PR #456"},
+            normalized_tool={"name": "jira-pr-verify"},
+            normalized_steps=[],
+        )
+        == "Jira PR Verify: MM-123 — PR #456"
+    )
+
+
+def test_structured_github_shorthand_is_only_pr_target_for_pr_fields() -> None:
+    assert (
+        synthesize_workflow_title(
+            current_title="Run",
+            task_payload={"inputs": {"comment": "#456"}},
+            normalized_tool={"name": "future-skill"},
+            normalized_steps=[],
+        )
+        is None
+    )
+
+    assert (
+        synthesize_workflow_title(
+            current_title="Run",
+            task_payload={"inputs": {"pr": "#456"}},
+            normalized_tool={"name": "future-skill"},
+            normalized_steps=[],
+        )
+        == "Future Skill: PR #456"
+    )
+
+
+def test_single_step_title_fallback_requires_exactly_one_step() -> None:
+    assert (
+        synthesize_workflow_title(
+            current_title="Run",
+            task_payload={"inputs": {"issueKey": "KANDY-123"}},
+            normalized_tool={},
+            normalized_steps=[{"title": "First Step"}, {"title": "Second Step"}],
+        )
+        == "Workflow: KANDY-123"
+    )
+
+
+def test_generic_tool_title_falls_back_to_skill_name() -> None:
+    assert (
+        synthesize_workflow_title(
+            current_title="Run",
+            task_payload={"inputs": {"issueKey": "KANDY-123"}},
+            normalized_tool={
+                "type": "skill",
+                "name": "jira-pr-verify",
+                "title": "Run",
+            },
+            normalized_steps=[],
+        )
+        == "Jira PR Verify: KANDY-123"
     )
 
 


### PR DESCRIPTION
## Summary
- Add deterministic workflow title synthesis for task-shaped submissions.
- Prefer structured issue, PR, branch, and check targets while excluding repository metadata.
- Harden PR target extraction against ambiguous numeric fields and oversized numeric input.

## Tests
- ./tools/test_unit.sh --python-only tests/unit/workflows/executions/test_title_derivation.py tests/unit/api/routers/test_executions.py::test_create_task_shaped_execution_synthesizes_generic_title tests/unit/api/routers/test_executions.py::test_create_task_shaped_execution_synthesizes_issue_pr_title_without_repo tests/unit/api/routers/test_executions.py::test_create_task_shaped_execution_keeps_meaningful_title_after_synthesis

## Remaining Risk
- Full router test file currently has unrelated preset seed fixture failures for missing api_service/data/presets/moonspec-orchestrate.yaml in this workspace.