### PR TITLE
MM-1125 synthesize workflow titles

### DIFF
--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -10,7 +10,7 @@ import json
 import logging
 import os
 import re
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any, Literal, Optional
@@ -170,6 +170,10 @@ from moonmind.workflows.executions.runtime_inheritance import (
     RuntimeInheritanceError,
     apply_inherited_runtime_to_payload,
     resolve_child_runtime_inheritance,
+)
+from moonmind.workflows.executions.title_derivation import (
+    is_generic_title,
+    synthesize_workflow_title,
 )
 from moonmind.services.skill_step_inputs import validate_skill_step_inputs
 from api_service.api.execution_principal import (
@@ -8497,24 +8501,20 @@ def _validate_workflow_runtime_requirements(
     raise _invalid_workflow_request(_PR_RESOLVER_SELECTOR_ERROR)
 
 
-def _derive_task_title(task_payload: dict[str, Any]) -> str | None:
-    explicit = str(task_payload.get("title") or "").strip()
-    if explicit:
-        return explicit
-    tool_payload = _coerce_mapping(task_payload.get("tool")) or _coerce_mapping(
-        task_payload.get("skill")
+def _derive_task_title(
+    task_payload: dict[str, Any],
+    *,
+    normalized_tool: Mapping[str, Any] | None = None,
+    normalized_steps: Sequence[Mapping[str, Any]] = (),
+) -> str | None:
+    synthesized = synthesize_workflow_title(
+        current_title=str(task_payload.get("title") or "").strip() or None,
+        task_payload=task_payload,
+        normalized_tool=normalized_tool,
+        normalized_steps=normalized_steps,
     )
-    tool_name = ""
-    if tool_payload:
-        tool_name = str(
-            tool_payload.get("name") or tool_payload.get("id") or ""
-        ).strip()
-    if tool_name.lower() == "pr-resolver":
-        starting_branch = _pr_resolver_structured_selector(
-            task_payload=task_payload,
-        )
-        if starting_branch:
-            return starting_branch[:_MAX_TASK_TITLE_LENGTH]
+    if synthesized:
+        return synthesized[:_MAX_TASK_TITLE_LENGTH]
     raw_steps = task_payload.get("steps")
     if isinstance(raw_steps, list):
         for item in raw_steps:
@@ -9658,8 +9658,15 @@ async def _create_execution_from_workflow_request(
         normalized_tool=normalized_tool,
         normalized_task_for_planner=normalized_task_for_planner,
     )
-    derived_task_title = _derive_task_title(task_payload)
-    if derived_task_title and "title" not in normalized_task_for_planner:
+    derived_task_title = _derive_task_title(
+        task_payload,
+        normalized_tool=normalized_tool,
+        normalized_steps=normalized_steps,
+    )
+    if derived_task_title and (
+        "title" not in normalized_task_for_planner
+        or is_generic_title(str(normalized_task_for_planner.get("title") or ""))
+    ):
         normalized_task_for_planner["title"] = derived_task_title
 
     # --- Model resolution ---

--- a/moonmind/workflows/executions/title_derivation.py
+++ b/moonmind/workflows/executions/title_derivation.py
@@ -1,0 +1,335 @@
+from __future__ import annotations
+
+import re
+import string
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+MAX_WORKFLOW_TITLE_LENGTH = 150
+
+_GENERIC_TITLE_TOKENS = {
+    "",
+    "run",
+    "new run",
+    "untitled",
+    "untitled run",
+    "workflow",
+    "new workflow",
+}
+_ACRONYMS = {
+    "ci": "CI",
+    "github": "GitHub",
+    "jira": "Jira",
+    "pr": "PR",
+}
+_ISSUE_KEY_RE = re.compile(r"\b([A-Z][A-Z0-9]+-\d+)\b")
+_PR_URL_RE = re.compile(r"/pull/(\d+)(?:\b|[/?#])", re.IGNORECASE)
+_PR_TEXT_RE = re.compile(r"\b(?:PR|pull request)\s*#?(\d+)\b", re.IGNORECASE)
+_GITHUB_SHORTHAND_RE = re.compile(r"^#(\d+)$")
+
+_ISSUE_FIELDS = {
+    "jira_issue_key",
+    "jiraissuekey",
+    "issuekey",
+    "issue",
+    "issueurl",
+}
+_PR_FIELDS = {
+    "pr",
+    "pullrequest",
+    "pull_request",
+    "pullrequesturl",
+    "prurl",
+}
+_BRANCH_FIELDS = {
+    "branch",
+    "startingbranch",
+    "headbranch",
+}
+_CHECK_FIELDS = {
+    "check",
+    "checkname",
+    "job",
+    "jobname",
+}
+_REPOSITORY_FIELDS = {
+    "repo",
+    "reporef",
+    "repository",
+    "repositoryurl",
+}
+_CONTAINER_FIELDS = {
+    "workflow",
+    "tool",
+    "skill",
+    "steps",
+    "inputs",
+    "git",
+    "instructions",
+    "title",
+    "type",
+    "name",
+    "id",
+    "version",
+    "label",
+    "displayname",
+    "display_name",
+    "mode",
+    "model",
+    "effort",
+    "targetruntime",
+    "target_runtime",
+    "runtime",
+}
+_SEMANTIC_FIELDS = (
+    _ISSUE_FIELDS
+    | _PR_FIELDS
+    | _BRANCH_FIELDS
+    | _CHECK_FIELDS
+    | _REPOSITORY_FIELDS
+    | _CONTAINER_FIELDS
+)
+_TARGET_RANK = {
+    "issue": 0,
+    "pull_request": 1,
+    "branch": 2,
+    "check": 3,
+    "titled_input": 4,
+    "short_text": 5,
+}
+
+
+@dataclass(frozen=True)
+class TitleTarget:
+    kind: str
+    value: str
+    rank: int
+
+
+def is_generic_title(title: str | None) -> bool:
+    text = "" if title is None else str(title).strip()
+    punctuation_as_space = str.maketrans(
+        {character: " " for character in string.punctuation}
+    )
+    normalized = text.translate(punctuation_as_space).lower()
+    normalized = " ".join(normalized.split())
+    return normalized in _GENERIC_TITLE_TOKENS
+
+
+def capability_label_from_payload(
+    task_payload: Mapping[str, Any],
+    normalized_tool: Mapping[str, Any] | None,
+    normalized_steps: Sequence[Mapping[str, Any]] = (),
+) -> str | None:
+    for source in (
+        normalized_tool,
+        _mapping(task_payload.get("tool")),
+        _mapping(task_payload.get("skill")),
+    ):
+        if not source:
+            continue
+        label = _first_text(source, ("label", "displayName", "display_name", "title"))
+        if label:
+            return label
+        identifier = _first_text(source, ("name", "id", "skill", "tool"))
+        if identifier:
+            return _identifier_to_label(identifier)
+
+    steps = list(normalized_steps)
+    if len(steps) == 1:
+        title = _first_text(steps[0], ("title",))
+        if title:
+            return title
+
+    return "Workflow"
+
+
+def collect_title_targets(payload: Mapping[str, Any]) -> list[TitleTarget]:
+    targets: list[TitleTarget] = []
+    seen: set[tuple[str, str]] = set()
+
+    def add(kind: str, value: str) -> None:
+        text = str(value or "").strip()
+        if not text:
+            return
+        normalized = (kind, text.lower())
+        if normalized in seen:
+            return
+        seen.add(normalized)
+        targets.append(TitleTarget(kind=kind, value=text, rank=_TARGET_RANK[kind]))
+
+    for key, value in _walk_values(payload):
+        field = _normalize_field_name(key)
+        text = _scalar_text(value)
+        if not text or field in _REPOSITORY_FIELDS:
+            continue
+
+        if field in _ISSUE_FIELDS:
+            issue = _extract_issue_key(text)
+            if issue:
+                add("issue", issue)
+                continue
+        if field in _PR_FIELDS:
+            pr = _extract_pr_target(text)
+            if pr:
+                add("pull_request", pr)
+                continue
+        if field in _BRANCH_FIELDS:
+            add("branch", text)
+            continue
+        if field in _CHECK_FIELDS:
+            add("check", f"failing check: {text}")
+            continue
+
+        issue = _extract_issue_key(text)
+        if issue:
+            add("issue", issue)
+            continue
+        pr = _extract_pr_target(text)
+        if pr:
+            add("pull_request", pr)
+            continue
+        if field not in _SEMANTIC_FIELDS and _is_useful_short_text(text):
+            add("short_text", text)
+
+    return sorted(targets, key=lambda item: item.rank)
+
+
+def render_title(
+    label: str,
+    targets: Sequence[TitleTarget],
+    *,
+    max_length: int = MAX_WORKFLOW_TITLE_LENGTH,
+) -> str | None:
+    if not label.strip() or not targets:
+        return None
+
+    selected: list[TitleTarget] = [targets[0]]
+    for candidate in targets[1:]:
+        if candidate.kind != selected[0].kind:
+            selected.append(candidate)
+            break
+
+    target_text = " \u2014 ".join(target.value for target in selected)
+    title = f"{label.strip()}: {target_text}"
+    return title[:max_length]
+
+
+def synthesize_workflow_title(
+    *,
+    current_title: str | None,
+    task_payload: Mapping[str, Any],
+    normalized_tool: Mapping[str, Any] | None,
+    normalized_steps: Sequence[Mapping[str, Any]] = (),
+) -> str | None:
+    explicit = str(current_title or "").strip()
+    if explicit and not is_generic_title(explicit):
+        return explicit[:MAX_WORKFLOW_TITLE_LENGTH]
+    if not is_generic_title(current_title):
+        return None
+
+    label = capability_label_from_payload(
+        task_payload,
+        normalized_tool,
+        normalized_steps,
+    )
+    if not label:
+        return None
+    targets = collect_title_targets(task_payload)
+    if (
+        label == "Workflow"
+        and targets
+        and targets[0].rank >= _TARGET_RANK["titled_input"]
+    ):
+        return None
+    return render_title(label, targets)
+
+
+def _identifier_to_label(identifier: str) -> str:
+    tokens = re.split(r"[-_\s]+", identifier.strip())
+    rendered = [
+        _ACRONYMS.get(token.lower(), token.capitalize())
+        for token in tokens
+        if token
+    ]
+    return " ".join(rendered)
+
+
+def _mapping(value: Any) -> Mapping[str, Any] | None:
+    return value if isinstance(value, Mapping) else None
+
+
+def _first_text(source: Mapping[str, Any], keys: Sequence[str]) -> str:
+    for key in keys:
+        value = source.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return ""
+
+
+def _normalize_field_name(key: str) -> str:
+    return re.sub(r"[^a-z0-9_]", "", key.strip().lower())
+
+
+def _scalar_text(value: Any) -> str:
+    if isinstance(value, str):
+        return value.strip()
+    if isinstance(value, int) and not isinstance(value, bool):
+        return str(value)
+    return ""
+
+
+def _walk_values(
+    value: Any,
+    *,
+    key: str = "",
+    depth: int = 0,
+    max_depth: int = 5,
+) -> list[tuple[str, Any]]:
+    if depth > max_depth:
+        return []
+    if isinstance(value, Mapping):
+        items: list[tuple[str, Any]] = []
+        for child_key, child_value in value.items():
+            text_key = str(child_key)
+            items.extend(
+                _walk_values(
+                    child_value,
+                    key=text_key,
+                    depth=depth + 1,
+                    max_depth=max_depth,
+                )
+            )
+        return items
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        items = []
+        for child in value:
+            items.extend(
+                _walk_values(child, key=key, depth=depth + 1, max_depth=max_depth)
+            )
+        return items
+    return [(key, value)]
+
+
+def _extract_issue_key(text: str) -> str | None:
+    match = _ISSUE_KEY_RE.search(text)
+    return match.group(1) if match else None
+
+
+def _extract_pr_target(text: str) -> str | None:
+    for pattern in (_PR_URL_RE, _PR_TEXT_RE, _GITHUB_SHORTHAND_RE):
+        match = pattern.search(text)
+        if match:
+            return f"PR #{match.group(1)}"
+    if text.isdigit():
+        return f"PR #{text}"
+    return None
+
+
+def _is_useful_short_text(text: str) -> bool:
+    if len(text) > 80:
+        return False
+    if is_generic_title(text):
+        return False
+    return bool(re.search(r"[A-Za-z0-9]", text))

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -6356,11 +6356,11 @@ def test_create_task_shaped_execution_allows_pr_resolver_with_starting_branch(
 
     assert response.status_code == 201
     called_kwargs = service.create_execution.await_args.kwargs
-    assert called_kwargs["title"] == "feature/resolve-pr"
+    assert called_kwargs["title"] == "PR Resolver: feature/resolve-pr"
     initial_parameters = service.create_execution.await_args.kwargs[
         "initial_parameters"
     ]
-    assert initial_parameters["workflow"]["title"] == "feature/resolve-pr"
+    assert initial_parameters["workflow"]["title"] == "PR Resolver: feature/resolve-pr"
     assert initial_parameters["workflow"]["git"] == {
         "startingBranch": "feature/resolve-pr",
     }
@@ -6392,9 +6392,9 @@ def test_create_task_shaped_execution_allows_pr_resolver_with_non_default_git_br
 
     assert response.status_code == 201
     called_kwargs = service.create_execution.await_args.kwargs
-    assert called_kwargs["title"] == "feature/resolve-pr"
+    assert called_kwargs["title"] == "PR Resolver: feature/resolve-pr"
     initial_parameters = called_kwargs["initial_parameters"]
-    assert initial_parameters["workflow"]["title"] == "feature/resolve-pr"
+    assert initial_parameters["workflow"]["title"] == "PR Resolver: feature/resolve-pr"
     assert initial_parameters["workflow"]["git"] == {
         "branch": "feature/resolve-pr",
     }
@@ -7555,9 +7555,50 @@ def test_create_task_shaped_execution_derives_pr_resolver_title_from_tool_inputs
 
     assert response.status_code == 201
     called_kwargs = service.create_execution.await_args.kwargs
-    assert called_kwargs["title"] == "feature/from-tool-inputs"
+    assert called_kwargs["title"] == "PR Resolver: feature/from-tool-inputs"
     initial_parameters = called_kwargs["initial_parameters"]
-    assert initial_parameters["workflow"]["title"] == "feature/from-tool-inputs"
+    assert initial_parameters["workflow"]["title"] == (
+        "PR Resolver: feature/from-tool-inputs"
+    )
+
+
+def test_create_task_shaped_execution_synthesizes_generic_skill_title(
+    client: tuple[TestClient, AsyncMock, SimpleNamespace],
+) -> None:
+    test_client, service, _user = client
+    service.create_execution.return_value = _build_execution_record()
+
+    response = test_client.post(
+        "/api/executions",
+        json={
+            "type": "workflow",
+            "payload": {
+                "workflow": {
+                    "title": "Run",
+                    "runtime": {"mode": "claude_code"},
+                    "tool": {
+                        "type": "skill",
+                        "name": "jira-pr-verify",
+                        "inputs": {
+                            "issueKey": "KANDY-123",
+                            "pullRequestUrl": (
+                                "https://github.com/MoonLadderStudios/MoonMind/pull/456"
+                            ),
+                            "repository": "MoonLadderStudios/MoonMind",
+                        },
+                    },
+                }
+            },
+        },
+    )
+
+    assert response.status_code == 201
+    called_kwargs = service.create_execution.await_args.kwargs
+    assert called_kwargs["title"] == "Jira PR Verify: KANDY-123 \u2014 PR #456"
+    initial_parameters = called_kwargs["initial_parameters"]
+    assert initial_parameters["workflow"]["title"] == (
+        "Jira PR Verify: KANDY-123 \u2014 PR #456"
+    )
 
 def test_create_task_shaped_execution_once_schedule_sets_start_delay(
     client: tuple[TestClient, AsyncMock, SimpleNamespace],

--- a/tests/unit/workflows/executions/test_title_derivation.py
+++ b/tests/unit/workflows/executions/test_title_derivation.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+import pytest
+
+from moonmind.workflows.executions.title_derivation import (
+    MAX_WORKFLOW_TITLE_LENGTH,
+    is_generic_title,
+    synthesize_workflow_title,
+)
+
+
+@pytest.mark.parametrize(
+    ("title", "expected"),
+    [
+        ("", True),
+        ("Run", True),
+        (" run ", True),
+        ("New-run", True),
+        ("Untitled", True),
+        ("Untitled run", True),
+        ("Workflow", True),
+        ("New workflow", True),
+        ("Verify KANDY-123", False),
+        ("Fix failing CI on auth redirect", False),
+    ],
+)
+def test_is_generic_title_ignores_case_punctuation_and_whitespace(
+    title: str, expected: bool
+) -> None:
+    assert is_generic_title(title) is expected
+
+
+@pytest.mark.parametrize(
+    ("skill_name", "inputs", "expected"),
+    [
+        ("jira-verify", {"issueKey": "KANDY-123"}, "Jira Verify: KANDY-123"),
+        (
+            "jira-pr-verify",
+            {
+                "issueKey": "KANDY-123",
+                "pullRequestUrl": "https://github.com/org/repo/pull/456",
+            },
+            "Jira PR Verify: KANDY-123 \u2014 PR #456",
+        ),
+        ("pr-resolver", {"pr": "456"}, "PR Resolver: PR #456"),
+        ("fix-comments", {"pr": "456"}, "Fix Comments: PR #456"),
+        ("fix-ci", {"pr": "#456"}, "Fix CI: PR #456"),
+        (
+            "fix-merge-conflicts",
+            {"branch": "feature/auth-redirect"},
+            "Fix Merge Conflicts: feature/auth-redirect",
+        ),
+        (
+            "fix-ci",
+            {"pr": "456", "checkName": "unit-tests"},
+            "Fix CI: PR #456 \u2014 failing check: unit-tests",
+        ),
+    ],
+)
+def test_synthesize_workflow_title_for_skill_targets(
+    skill_name: str, inputs: dict[str, str], expected: str
+) -> None:
+    assert (
+        synthesize_workflow_title(
+            current_title="Run",
+            task_payload={
+                "title": "Run",
+                "tool": {"type": "skill", "name": skill_name, "inputs": inputs},
+            },
+            normalized_tool={"type": "skill", "name": skill_name, "inputs": inputs},
+        )
+        == expected
+    )
+
+
+def test_synthesize_workflow_title_normalizes_jira_issue_url() -> None:
+    assert (
+        synthesize_workflow_title(
+            current_title="Run",
+            task_payload={
+                "skill": {"id": "jira-verify"},
+                "inputs": {
+                    "issueUrl": "https://example.atlassian.net/browse/KANDY-123"
+                },
+            },
+            normalized_tool={"type": "skill", "name": "jira-verify"},
+        )
+        == "Jira Verify: KANDY-123"
+    )
+
+
+def test_synthesize_workflow_title_preserves_meaningful_explicit_title() -> None:
+    assert (
+        synthesize_workflow_title(
+            current_title="Verify auth redirect fix",
+            task_payload={
+                "title": "Verify auth redirect fix",
+                "tool": {"type": "skill", "name": "jira-verify"},
+                "inputs": {"issueKey": "KANDY-123"},
+            },
+            normalized_tool={"type": "skill", "name": "jira-verify"},
+        )
+        == "Verify auth redirect fix"
+    )
+
+
+def test_synthesize_workflow_title_ignores_repository_fields() -> None:
+    assert (
+        synthesize_workflow_title(
+            current_title="Run",
+            task_payload={
+                "tool": {
+                    "type": "skill",
+                    "name": "pr-resolver",
+                    "inputs": {
+                        "repo": "MoonLadderStudios/MoonMind",
+                        "repository": "MoonLadderStudios/MoonMind",
+                        "pr": "456",
+                    },
+                },
+            },
+            normalized_tool={"type": "skill", "name": "pr-resolver"},
+        )
+        == "PR Resolver: PR #456"
+    )
+
+
+def test_synthesize_workflow_title_handles_future_skill_target() -> None:
+    assert (
+        synthesize_workflow_title(
+            current_title="Run",
+            task_payload={
+                "tool": {
+                    "type": "skill",
+                    "name": "future-skill",
+                    "inputs": {"issueKey": "KANDY-123"},
+                },
+            },
+            normalized_tool={"type": "skill", "name": "future-skill"},
+        )
+        == "Future Skill: KANDY-123"
+    )
+
+
+def test_synthesize_workflow_title_returns_none_without_useful_target() -> None:
+    assert (
+        synthesize_workflow_title(
+            current_title="Run",
+            task_payload={
+                "instructions": "Run the task.",
+                "tool": {"type": "skill", "name": "future-skill"},
+            },
+            normalized_tool={"type": "skill", "name": "future-skill"},
+        )
+        is None
+    )
+
+
+def test_synthesize_workflow_title_caps_generated_title() -> None:
+    long_branch = "feature/" + ("very-long-branch-name-" * 10)
+    title = synthesize_workflow_title(
+        current_title="Run",
+        task_payload={
+            "tool": {
+                "type": "skill",
+                "name": "fix-merge-conflicts",
+                "inputs": {"branch": long_branch},
+            },
+        },
+        normalized_tool={"type": "skill", "name": "fix-merge-conflicts"},
+    )
+
+    assert title is not None
+    assert len(title) == MAX_WORKFLOW_TITLE_LENGTH


### PR DESCRIPTION
Issue reference: MM-1125

Summary:
- Adds a generic backend workflow title synthesis helper for blank or low-information titles.
- Derives capability labels and structured targets from local payload data without per-skill title registries or external calls.
- Wires synthesized titles into the execution creation path before service.create_execution and adds focused unit coverage.

Tests run:
- MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --python-only tests/unit/workflows/executions/test_title_derivation.py
- MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --python-only tests/unit/api/routers/test_executions.py -k "synthesizes_generic_skill_title or derives_pr_resolver_title_from_tool_inputs or allows_pr_resolver_with_starting_branch or allows_pr_resolver_with_non_default_git_branch or allows_pr_resolver_with_numeric_pr_selector or allows_pr_resolver_with_tool_input_branch"

Remaining risks:
- Hermetic integration tests were not run because this change is covered at the backend helper and route/unit boundary and does not touch integration_ci-selected infrastructure seams.
- Title quality depends on structured fields present in the submitted payload; unknown payload shapes without useful targets intentionally fall back to existing behavior.