### PR TITLE
Fix terminal step ledger observability

### DIFF
--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -5290,13 +5290,17 @@ async def _query_workflow_for_detail(
     temporal_client: Client,
     workflow_id: str,
     query_name: str,
+    *,
+    timeout_seconds: float | None = None,
 ) -> Any:
-    timeout_seconds = float(
-        settings.temporal_dashboard.live_query_timeout_seconds
+    effective_timeout_seconds = float(
+        timeout_seconds
+        if timeout_seconds is not None
+        else settings.temporal_dashboard.live_query_timeout_seconds
     )
     return await asyncio.wait_for(
         query_workflow(temporal_client, workflow_id, query_name),
-        timeout=timeout_seconds,
+        timeout=effective_timeout_seconds,
     )
 
 
@@ -5718,6 +5722,9 @@ def _fallback_current_step_order(record: Any) -> int | None:
 
 
 def _fallback_step_ledger_from_record(record: Any) -> StepLedgerSnapshotModel | None:
+    close_status = _enum_value(getattr(record, "close_status", None))
+    if close_status:
+        return None
     parameters = getattr(record, "parameters", None)
     if not isinstance(parameters, Mapping):
         return None
@@ -5816,6 +5823,26 @@ def _fallback_step_ledger_from_record(record: Any) -> StepLedgerSnapshotModel | 
         )
         return None
 
+
+def _step_ledger_query_timeout_seconds(fallback_record: Any | None) -> float:
+    live_timeout_seconds = float(
+        settings.temporal_dashboard.live_query_timeout_seconds
+    )
+    close_status = (
+        _enum_value(getattr(fallback_record, "close_status", None))
+        if fallback_record is not None
+        else None
+    )
+    if close_status:
+        return max(
+            live_timeout_seconds,
+            float(
+                settings.temporal_dashboard.terminal_step_ledger_query_timeout_seconds
+            ),
+        )
+    return live_timeout_seconds
+
+
 async def _load_execution_progress(
     *,
     temporal_client: Client,
@@ -5884,6 +5911,7 @@ async def _load_execution_step_ledger(
             temporal_client,
             workflow_id,
             "get_step_ledger",
+            timeout_seconds=_step_ledger_query_timeout_seconds(fallback_record),
         )
     except (RPCError, TimeoutError) as exc:
         logger.warning(

--- a/moonmind/config/settings.py
+++ b/moonmind/config/settings.py
@@ -302,6 +302,13 @@ class TemporalDashboardSettings(BaseSettings):
         validation_alias=AliasChoices("TEMPORAL_DASHBOARD_LIVE_QUERY_TIMEOUT_SECONDS"),
         gt=0,
     )
+    terminal_step_ledger_query_timeout_seconds: float = Field(
+        30.0,
+        validation_alias=AliasChoices(
+            "TEMPORAL_DASHBOARD_TERMINAL_STEP_LEDGER_QUERY_TIMEOUT_SECONDS"
+        ),
+        gt=0,
+    )
     list_count_timeout_seconds: float = Field(
         1.0,
         validation_alias=AliasChoices("TEMPORAL_DASHBOARD_LIST_COUNT_TIMEOUT_SECONDS"),

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -10845,8 +10845,14 @@ def test_get_execution_steps_uses_terminal_step_ledger_timeout(
     )
     observed_timeouts: list[float] = []
 
-    async def passthrough_timeout(awaitable, *, timeout: float):
-        observed_timeouts.append(timeout)
+    async def passthrough_timeout(
+        awaitable,
+        timeout: float | None = None,
+        *_args,
+        **_kwargs,
+    ):
+        if timeout is not None:
+            observed_timeouts.append(timeout)
         return await awaitable
 
     with (

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -10817,6 +10817,108 @@ def test_get_execution_steps_fallback_preserves_independent_steps(
     assert payload["steps"][1]["status"] == "ready"
     assert payload["steps"][2]["status"] == "ready"
 
+
+def test_get_execution_steps_uses_terminal_step_ledger_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app = FastAPI()
+    app.include_router(router)
+    mock_service = AsyncMock()
+    record = _build_execution_record(state=MoonMindWorkflowState.FAILED)
+    record.close_status = TemporalExecutionCloseStatus.FAILED
+    mock_service.describe_execution.return_value = record
+    app.dependency_overrides[_get_service] = lambda: mock_service
+    _override_query_client(
+        app,
+        ledger={"workflowId": "mm:wf-1", "runId": "run-99", "steps": []},
+    )
+    _override_user_dependencies(app, is_superuser=True)
+    monkeypatch.setattr(
+        settings.temporal_dashboard,
+        "live_query_timeout_seconds",
+        0.01,
+    )
+    monkeypatch.setattr(
+        settings.temporal_dashboard,
+        "terminal_step_ledger_query_timeout_seconds",
+        12.0,
+    )
+    observed_timeouts: list[float] = []
+
+    async def passthrough_timeout(awaitable, *, timeout: float):
+        observed_timeouts.append(timeout)
+        return await awaitable
+
+    with (
+        patch(
+            "api_service.api.routers.executions.asyncio.wait_for",
+            side_effect=passthrough_timeout,
+        ),
+        TestClient(app) as test_client,
+    ):
+        response = test_client.get("/api/executions/mm:wf-1/steps")
+
+    assert response.status_code == 200
+    assert observed_timeouts == [12.0]
+
+
+def test_get_execution_steps_does_not_use_projection_fallback_for_terminal_runs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app = FastAPI()
+    app.include_router(router)
+    mock_service = AsyncMock()
+    record = _build_execution_record(state=MoonMindWorkflowState.FAILED)
+    record.close_status = TemporalExecutionCloseStatus.FAILED
+    record.memo = {
+        **record.memo,
+        "summary": "Executing plan step 2/3: verify",
+        "mm_current_step_order": 2,
+    }
+    record.parameters = {
+        "workflow": {
+            "steps": [
+                {
+                    "id": "plan",
+                    "title": "Plan",
+                    "type": "skill",
+                    "skill": {"id": "plan"},
+                },
+                {
+                    "id": "verify",
+                    "title": "Verify",
+                    "type": "skill",
+                    "skill": {"id": "verify"},
+                },
+                {
+                    "id": "publish",
+                    "title": "Publish",
+                    "type": "skill",
+                    "skill": {"id": "publish"},
+                },
+            ],
+        },
+    }
+    mock_service.describe_execution.return_value = record
+    app.dependency_overrides[_get_service] = lambda: mock_service
+    _override_query_client(
+        app,
+        error=RPCError("Connection failed", RPCStatusCode.UNAVAILABLE, None),
+    )
+    _override_user_dependencies(app, is_superuser=True)
+    monkeypatch.setattr(
+        settings.temporal_dashboard,
+        "terminal_step_ledger_query_timeout_seconds",
+        12.0,
+    )
+
+    with TestClient(app) as test_client:
+        response = test_client.get("/api/executions/mm:wf-1/steps")
+
+    assert response.status_code == 503
+    assert response.json()["detail"]["code"] == "temporal_unavailable"
+
+
 def test_get_execution_steps_returns_500_for_invalid_ledger_payload() -> None:
     app = FastAPI()
     app.include_router(router)

--- a/tests/unit/config/test_settings.py
+++ b/tests/unit/config/test_settings.py
@@ -139,17 +139,27 @@ class TestTemporalDashboardSettings:
         settings = TemporalDashboardSettings(_env_file=None)
         assert settings.actions_enabled is True
         assert settings.submit_enabled is True
+        assert settings.terminal_step_ledger_query_timeout_seconds == 30.0
 
     def test_env_overrides(self, monkeypatch):
         monkeypatch.setenv("TEMPORAL_DASHBOARD_ACTIONS_ENABLED", "false")
         monkeypatch.setenv("TEMPORAL_DASHBOARD_SUBMIT_ENABLED", "false")
+        monkeypatch.setenv(
+            "TEMPORAL_DASHBOARD_TERMINAL_STEP_LEDGER_QUERY_TIMEOUT_SECONDS",
+            "12.5",
+        )
 
         settings = TemporalDashboardSettings(_env_file=None)
         assert settings.actions_enabled is False
         assert settings.submit_enabled is False
+        assert settings.terminal_step_ledger_query_timeout_seconds == 12.5
 
         monkeypatch.delenv("TEMPORAL_DASHBOARD_ACTIONS_ENABLED", raising=False)
         monkeypatch.delenv("TEMPORAL_DASHBOARD_SUBMIT_ENABLED", raising=False)
+        monkeypatch.delenv(
+            "TEMPORAL_DASHBOARD_TERMINAL_STEP_LEDGER_QUERY_TIMEOUT_SECONDS",
+            raising=False,
+        )
 
 class TestFeatureFlagsSettings:
     def test_preset_catalog_reads_prefixed_env(self, monkeypatch):


### PR DESCRIPTION
## Summary
- Troubleshot `mm:06e1f01e-b2f9-4d24-8572-c3034d6f8d92`: the authoritative Temporal `get_step_ledger` query returned the final ledger, but the API step endpoint timed out after the 1s live-dashboard budget and served authored-parameter fallback state instead.
- Added a configurable terminal step-ledger query timeout with a 30s default and use it for closed executions.
- Disabled stored-parameter projection fallback for terminal executions so closed workflows fail visibly if the authoritative ledger is unavailable instead of showing fabricated `READY`/`EXECUTING` step state.
- Added unit coverage for terminal timeout selection and no terminal projection fallback.

## Verification
- `git diff --check -- api_service/api/routers/executions.py moonmind/config/settings.py tests/unit/api/routers/test_executions.py tests/unit/config/test_settings.py`
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/routers/test_executions.py -k "get_execution_steps_uses_terminal_step_ledger_timeout or get_execution_steps_does_not_use_projection_fallback_for_terminal_runs or get_execution_steps_falls_back_to_stored_task_steps_when_temporal_query_times_out or get_execution_steps_fallback_preserves_independent_steps or get_execution_steps_returns_503_for_slow_temporal_query"`
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/config/test_settings.py -k TemporalDashboardSettings`
- `PYTHONPYCACHEPREFIX=/tmp/moonmind-pycache .venv/bin/python -m py_compile api_service/api/routers/executions.py moonmind/config/settings.py tests/unit/api/routers/test_executions.py tests/unit/config/test_settings.py`

Notes: `ruff` and `black` were not installed in the local virtualenv. The unit wrapper also completed its frontend unit phase in both test runs: 56 files passed, 847 tests passed, 238 skipped.
