### PR TITLE
Fully implement this:

### DIFF
--- a/api_service/data/presets/github-issue-orchestrate.yaml
+++ b/api_service/data/presets/github-issue-orchestrate.yaml
@@ -189,37 +189,39 @@ steps:
     Source design path (optional): {{ inputs.source_design_path }}.
 
 
-    Classify the input as a single-story feature request, broad technical or declarative design,
-    or existing feature directory.
+    Classify the input only to decide whether GitHub Issue Orchestrate is eligible for one-story
+    MoonSpec orchestration.
 
-    Inspect existing MoonSpec artifacts and resume from the first incomplete stage instead
-    of regenerating valid later-stage artifacts.'
+    Continue only when the GitHub issue preset brief is exactly one independently testable
+    story, or when Source design path points at an active feature directory with an existing
+    one-story spec.md. If the issue brief is broad, multi-story, requires implementing all
+    stories, or needs story selection before implementation, stop before MoonSpec lifecycle
+    work begins and report that the issue must be routed through moonspec-breakdown or another
+    upstream breakdown/selector workflow before GitHub Issue Orchestrate can continue.
+
+    For eligible one-story inputs, inspect existing MoonSpec artifacts and resume from the
+    first incomplete stage instead of regenerating valid later-stage artifacts.'
   skill:
     id: auto
     args: {}
 - title: Create or select MoonSpec
-  instructions: 'For a single-story GitHub issue preset brief, run moonspec-specify unless
-    an active spec.md already passes the specify gate.
+  instructions: 'Before running moonspec-specify, validate that the GitHub issue preset
+    brief is exactly one independently testable story or that the active feature directory
+    has an existing one-story spec.md.
 
-    For a broad technical or declarative design, run moonspec-breakdown first, then select
-    the recommended first generated spec unless the issue brief explicitly requires processing
-    all specs.
+    If the issue brief is not already one independently testable story, stop and report that
+    it must be routed through moonspec-breakdown or another upstream selector before this
+    orchestration can continue. Do not run moonspec-breakdown from this preset and do not
+    select a story inline.
+
+    For an eligible single-story GitHub issue preset brief, run moonspec-specify unless an
+    active spec.md already passes the specify gate.
 
     Preserve GitHub issue {{ inputs.github_issue.repository }}#{{ inputs.github_issue.number
     }} and the original preset brief in spec.md so final verification can compare against
     them.'
   skill:
     id: moonspec-specify
-    args: {}
-- title: Split broad designs when needed
-  instructions: 'Run moonspec-breakdown only when the GitHub issue preset brief is a broad
-    technical or declarative design with multiple independently testable stories.
-
-    Keep each generated spec isolated and process specs in dependency order when multiple
-    specs are required by {{ inputs.github_issue.repository }}#{{ inputs.github_issue.number
-    }}.'
-  skill:
-    id: auto
     args: {}
 - title: Plan selected spec
   instructions: 'Run moonspec-plan when plan.md or required design artifacts are missing or

--- a/api_service/data/presets/github-issue-orchestrate.yaml
+++ b/api_service/data/presets/github-issue-orchestrate.yaml
@@ -150,26 +150,6 @@ steps:
     inputs:
       repository: '{{ inputs.github_issue.repository }}'
       issueNumber: '{{ inputs.github_issue.number }}'
-- title: Mark GitHub issue In Progress
-  type: tool
-  instructions: 'Read artifacts/github-issue-orchestrate-assessment.json (or the recorded
-    verdict from the assess step) before changing GitHub.
-
-
-    If the recorded verdict is FULLY_IMPLEMENTED, skip the In Progress update because the
-    issue is already implemented. If the recorded verdict is BLOCKED, stop without changing
-    GitHub. Otherwise mark GitHub issue {{ inputs.github_issue.repository }}#{{ inputs.github_issue.number
-    }} as In Progress using the configured GitHub issue update strategy.'
-  tool:
-    id: github.update_issue_status
-    requiredCapabilities:
-    - gh
-    inputs:
-      repository: '{{ inputs.github_issue.repository }}'
-      issueNumber: '{{ inputs.github_issue.number }}'
-      targetStatus: In Progress
-      mode: start
-      assessmentArtifactPath: artifacts/github-issue-orchestrate-assessment.json
 - title: Classify request and resume point
   instructions: 'Use the GitHub issue preset brief for {{ inputs.github_issue.repository }}#{{
     inputs.github_issue.number }} as the canonical MoonSpec orchestration input.
@@ -192,10 +172,11 @@ steps:
     Classify the input only to decide whether GitHub Issue Orchestrate is eligible for one-story
     MoonSpec orchestration.
 
-    Continue only when the GitHub issue preset brief is exactly one independently testable
-    story, or when Source design path points at an active feature directory with an existing
-    one-story spec.md. If the issue brief is broad, multi-story, requires implementing all
-    stories, or needs story selection before implementation, stop before MoonSpec lifecycle
+    Continue when artifacts/github-issue-orchestrate-assessment.json records FULLY_IMPLEMENTED,
+    when the GitHub issue preset brief is exactly one independently testable story, or when
+    Source design path points at an active feature directory with an existing one-story spec.md.
+    If none of those exceptions apply and the issue brief is broad, multi-story, requires implementing
+    all stories, or needs story selection before implementation, stop before MoonSpec lifecycle
     work begins and report that the issue must be routed through moonspec-breakdown or another
     upstream breakdown/selector workflow before GitHub Issue Orchestrate can continue.
 
@@ -204,15 +185,41 @@ steps:
   skill:
     id: auto
     args: {}
+- title: Mark GitHub issue In Progress
+  type: tool
+  instructions: 'Read artifacts/github-issue-orchestrate-assessment.json (or the recorded
+    verdict from the assess step) before changing GitHub.
+
+
+    This step runs only after the classify step confirms the issue is eligible for GitHub
+    Issue Orchestrate, is already FULLY_IMPLEMENTED, or is resuming from an eligible source
+    design path. If the recorded verdict is FULLY_IMPLEMENTED, skip the In Progress update
+    because the issue is already implemented. If the recorded verdict is BLOCKED, stop without
+    changing GitHub. Otherwise mark GitHub issue {{ inputs.github_issue.repository }}#{{
+    inputs.github_issue.number }} as In Progress using the configured GitHub issue update
+    strategy.'
+  tool:
+    id: github.update_issue_status
+    requiredCapabilities:
+    - gh
+    inputs:
+      repository: '{{ inputs.github_issue.repository }}'
+      issueNumber: '{{ inputs.github_issue.number }}'
+      targetStatus: In Progress
+      mode: start
+      assessmentArtifactPath: artifacts/github-issue-orchestrate-assessment.json
 - title: Create or select MoonSpec
   instructions: 'Before running moonspec-specify, validate that the GitHub issue preset
     brief is exactly one independently testable story or that the active feature directory
     has an existing one-story spec.md.
 
-    If the issue brief is not already one independently testable story, stop and report that
-    it must be routed through moonspec-breakdown or another upstream selector before this
-    orchestration can continue. Do not run moonspec-breakdown from this preset and do not
-    select a story inline.
+    If artifacts/github-issue-orchestrate-assessment.json records FULLY_IMPLEMENTED, skip
+    MoonSpec creation and preserve the no-code-change result for final GitHub status update.
+    If the issue brief is not already one independently testable story and the active feature
+    directory does not have an existing one-story spec.md, stop and report that it must be
+    routed through moonspec-breakdown or another upstream selector before this orchestration
+    can continue. Do not run moonspec-breakdown from this preset and do not select a story
+    inline.
 
     For an eligible single-story GitHub issue preset brief, run moonspec-specify unless an
     active spec.md already passes the specify gate.

--- a/api_service/data/presets/jira-orchestrate.yaml
+++ b/api_service/data/presets/jira-orchestrate.yaml
@@ -150,25 +150,24 @@ steps:
       If the brief points at an implementation document, treat it as runtime source requirements.
       Source design path (optional): {{ inputs.source_design_path }}.
 
-      Classify the input as a single-story feature request, broad technical or declarative design, or existing feature directory.
-      Inspect existing MoonSpec artifacts and resume from the first incomplete stage instead of regenerating valid later-stage artifacts.
+      Classify the input only to decide whether Jira Orchestrate is eligible for one-story MoonSpec orchestration.
+
+      Continue only when the Jira preset brief is exactly one independently testable story, or when Source design path points at an active feature directory with an existing one-story spec.md. If the issue brief is broad, multi-story, requires implementing all stories, or needs story selection before implementation, stop before MoonSpec lifecycle work begins and report that the issue must be routed through moonspec-breakdown or another upstream breakdown/selector workflow before Jira Orchestrate can continue.
+
+      For eligible one-story inputs, inspect existing MoonSpec artifacts and resume from the first incomplete stage instead of regenerating valid later-stage artifacts.
     skill:
       id: auto
       args: {}
   - title: Create or select MoonSpec
     instructions: |-
-      For a single-story Jira preset brief, run moonspec-specify unless an active spec.md already passes the specify gate.
-      For a broad technical or declarative design, run moonspec-breakdown first, then select the recommended first generated spec unless the issue brief explicitly requires processing all specs.
+      Before running moonspec-specify, validate that the Jira preset brief is exactly one independently testable story or that the active feature directory has an existing one-story spec.md.
+
+      If the issue brief is not already one independently testable story, stop and report that it must be routed through moonspec-breakdown or another upstream selector before this orchestration can continue. Do not run moonspec-breakdown from this preset and do not select a story inline.
+
+      For an eligible single-story Jira preset brief, run moonspec-specify unless an active spec.md already passes the specify gate.
       Preserve Jira issue {{ inputs.jira_issue_key }} and the original preset brief in spec.md so final verification can compare against them.
     skill:
       id: moonspec-specify
-      args: {}
-  - title: Split broad designs when needed
-    instructions: |-
-      Run moonspec-breakdown only when the Jira preset brief is a broad technical or declarative design with multiple independently testable stories.
-      Keep each generated spec isolated and process specs in dependency order when multiple specs are required by {{ inputs.jira_issue_key }}.
-    skill:
-      id: auto
       args: {}
   - title: Plan selected spec
     instructions: |-

--- a/api_service/data/presets/jira-orchestrate.yaml
+++ b/api_service/data/presets/jira-orchestrate.yaml
@@ -86,16 +86,6 @@ inputs:
     required: false
     default: true
 steps:
-  - title: Move Jira issue to In Progress
-    instructions: |-
-      Change Jira issue {{ inputs.jira_issue_key }} to status In Progress before implementation starts.
-
-      Use the trusted Jira issue updater workflow and Jira transition tools. Match In Progress against the issue's available transitions or target statuses; do not guess transition IDs. Re-fetch the issue when possible and report the confirmed status.
-    skill:
-      id: jira-issue-updater
-      requiredCapabilities:
-        - jira
-      args: {}
   - title: Check Jira blockers before implementation
     type: tool
     instructions: |-
@@ -158,11 +148,21 @@ steps:
     skill:
       id: auto
       args: {}
+  - title: Move Jira issue to In Progress
+    instructions: |-
+      Change Jira issue {{ inputs.jira_issue_key }} to status In Progress only after blocker preflight passes and the classify step confirms this Jira issue is eligible for Jira Orchestrate or is resuming from an eligible source design path.
+
+      Use the trusted Jira issue updater workflow and Jira transition tools. Match In Progress against the issue's available transitions or target statuses; do not guess transition IDs. Re-fetch the issue when possible and report the confirmed status.
+    skill:
+      id: jira-issue-updater
+      requiredCapabilities:
+        - jira
+      args: {}
   - title: Create or select MoonSpec
     instructions: |-
       Before running moonspec-specify, validate that the Jira preset brief is exactly one independently testable story or that the active feature directory has an existing one-story spec.md.
 
-      If the issue brief is not already one independently testable story, stop and report that it must be routed through moonspec-breakdown or another upstream selector before this orchestration can continue. Do not run moonspec-breakdown from this preset and do not select a story inline.
+      If the issue brief is not already one independently testable story and the active feature directory does not have an existing one-story spec.md, stop and report that it must be routed through moonspec-breakdown or another upstream selector before this orchestration can continue. Do not run moonspec-breakdown from this preset and do not select a story inline.
 
       For an eligible single-story Jira preset brief, run moonspec-specify unless an active spec.md already passes the specify gate.
       Preserve Jira issue {{ inputs.jira_issue_key }} and the original preset brief in spec.md so final verification can compare against them.

--- a/tests/integration/test_startup_preset_seeding.py
+++ b/tests/integration/test_startup_preset_seeding.py
@@ -138,9 +138,10 @@ async def test_startup_seeds_default_task_templates(disabled_env_keys, tmp_path)
             (step.get("skill") or step.get("tool"))["id"]
             for step in jira_orchestrate_template.steps
         ]
-        assert jira_orchestrate_steps[0] == "jira-issue-updater"
-        assert jira_orchestrate_steps[1] == "jira.check_blockers"
-        assert jira_orchestrate_steps[2] == "jira.load_preset_brief"
+        assert jira_orchestrate_steps[0] == "jira.check_blockers"
+        assert jira_orchestrate_steps[1] == "jira.load_preset_brief"
+        assert jira_orchestrate_steps[2] == "auto"
+        assert jira_orchestrate_steps[3] == "jira-issue-updater"
         assert "moonspec-implement" in jira_orchestrate_steps
         assert "moonspec-verify" in jira_orchestrate_steps
         assert jira_orchestrate_steps[-1] == "jira-issue-updater"
@@ -168,7 +169,7 @@ async def test_startup_seeds_default_task_templates(disabled_env_keys, tmp_path)
         assert "Do not run moonspec-breakdown from this preset" in specify_step[
             "instructions"
         ]
-        blocker_step = jira_orchestrate_template.steps[1]
+        blocker_step = jira_orchestrate_template.steps[0]
         assert blocker_step["title"] == "Check Jira blockers before implementation"
         assert blocker_step["type"] == "tool"
         assert blocker_step["tool"]["id"] == "jira.check_blockers"

--- a/tests/integration/test_startup_preset_seeding.py
+++ b/tests/integration/test_startup_preset_seeding.py
@@ -180,7 +180,7 @@ async def test_startup_seeds_default_task_templates(disabled_env_keys, tmp_path)
         assert "non-blocker" in blocker_step["instructions"]
         assert "status cannot be determined" in blocker_step["instructions"]
         assert "stop the orchestration immediately" in blocker_step["instructions"]
-        brief_step = jira_orchestrate_template.steps[2]
+        brief_step = jira_orchestrate_template.steps[1]
         assert brief_step["title"] == "Load Jira preset brief"
         assert brief_step["type"] == "tool"
         assert brief_step["tool"]["id"] == "jira.load_preset_brief"

--- a/tests/integration/test_startup_preset_seeding.py
+++ b/tests/integration/test_startup_preset_seeding.py
@@ -144,10 +144,30 @@ async def test_startup_seeds_default_task_templates(disabled_env_keys, tmp_path)
         assert "moonspec-implement" in jira_orchestrate_steps
         assert "moonspec-verify" in jira_orchestrate_steps
         assert jira_orchestrate_steps[-1] == "jira-issue-updater"
-        assert len(jira_orchestrate_steps) == 26
+        assert len(jira_orchestrate_steps) == 25
         assert jira_orchestrate_steps.count("moonspec-implement") == 7
         assert jira_orchestrate_steps.count("moonspec-verify") == 7
         assert jira_orchestrate_steps.count("moonspec-doc-reconcile") == 1
+        jira_orchestrate_titles = [
+            step["title"] for step in jira_orchestrate_template.steps
+        ]
+        assert "Split broad designs when needed" not in jira_orchestrate_titles
+        classify_step = next(
+            step
+            for step in jira_orchestrate_template.steps
+            if step["title"] == "Classify request and resume point"
+        )
+        assert "upstream breakdown/selector workflow" in classify_step[
+            "instructions"
+        ]
+        specify_step = next(
+            step
+            for step in jira_orchestrate_template.steps
+            if step["title"] == "Create or select MoonSpec"
+        )
+        assert "Do not run moonspec-breakdown from this preset" in specify_step[
+            "instructions"
+        ]
         blocker_step = jira_orchestrate_template.steps[1]
         assert blocker_step["title"] == "Check Jira blockers before implementation"
         assert blocker_step["type"] == "tool"

--- a/tests/unit/api/test_github_issue_orchestrate_preset.py
+++ b/tests/unit/api/test_github_issue_orchestrate_preset.py
@@ -123,7 +123,7 @@ async def test_github_issue_orchestrate_seed_exposes_issue_picker_and_tools(tmp_
         "assessment_artifact_path": "artifacts/github-issue-orchestrate-assessment.json",
         "constraints": "{{ inputs.constraints }}",
     }
-    assert template.steps[3]["tool"]["inputs"]["assessmentArtifactPath"] == (
+    assert template.steps[4]["tool"]["inputs"]["assessmentArtifactPath"] == (
         "artifacts/github-issue-orchestrate-assessment.json"
     )
 

--- a/tests/unit/api/test_github_issue_orchestrate_preset.py
+++ b/tests/unit/api/test_github_issue_orchestrate_preset.py
@@ -150,7 +150,7 @@ async def test_github_issue_orchestrate_expands_required_order_and_gates(tmp_pat
             )
 
     steps = expanded["steps"]
-    assert len(steps) == 27
+    assert len(steps) == 26
     assert [step["title"] for step in steps[:4]] == [
         "Load GitHub issue brief",
         "Assess existing implementation state",
@@ -188,47 +188,51 @@ async def test_github_issue_orchestrate_expands_required_order_and_gates(tmp_pat
         },
     }
 
-    assert [steps[index]["skill"]["id"] for index in range(4, 11)] == [
+    assert [steps[index]["skill"]["id"] for index in range(4, 10)] == [
         "auto",
         "moonspec-specify",
-        "auto",
         "moonspec-plan",
         "moonspec-tasks",
         "moonspec-align",
         "moonspec-implement",
     ]
+    assert "Split broad designs when needed" not in [step["title"] for step in steps]
     assert "Preserve MM-1063 traceability." in steps[4]["instructions"]
     assert "FULLY_IMPLEMENTED" in steps[4]["instructions"]
-    assert "make no code changes" in steps[10]["instructions"]
-    assert steps[11]["skill"]["id"] == "moonspec-verify"
+    assert "one independently testable story" in steps[4]["instructions"]
+    assert "upstream breakdown/selector workflow" in steps[4]["instructions"]
+    assert "one independently testable story" in steps[5]["instructions"]
+    assert "Do not run moonspec-breakdown from this preset" in steps[5]["instructions"]
+    assert "make no code changes" in steps[9]["instructions"]
+    assert steps[10]["skill"]["id"] == "moonspec-verify"
 
-    assert steps[12]["title"] == "Remediate verification gaps 1 of 6"
-    assert steps[12]["annotations"]["jiraOrchestrateRole"] == "moonspec-remediation"
-    assert "ADDITIONAL_WORK_NEEDED" in steps[12]["instructions"]
-    assert steps[23]["title"] == "Verify remediation 6 of 6"
-    assert steps[23]["annotations"]["moonSpecFinalRemediationGate"] is True
-    assert "controlling verification gate" in steps[23]["instructions"]
+    assert steps[11]["title"] == "Remediate verification gaps 1 of 6"
+    assert steps[11]["annotations"]["jiraOrchestrateRole"] == "moonspec-remediation"
+    assert "ADDITIONAL_WORK_NEEDED" in steps[11]["instructions"]
+    assert steps[22]["title"] == "Verify remediation 6 of 6"
+    assert steps[22]["annotations"]["moonSpecFinalRemediationGate"] is True
+    assert "controlling verification gate" in steps[22]["instructions"]
 
-    assert steps[24]["title"] == "Reconcile declarative docs"
-    assert steps[24]["annotations"] == {"jiraOrchestrateRole": "doc-reconciliation"}
-    assert steps[24]["skill"]["id"] == "moonspec-doc-reconcile"
-    assert "FULLY_IMPLEMENTED" in steps[24]["instructions"]
-    assert "skip doc reconciliation" in steps[24]["instructions"]
-    assert "artifacts/github-issue-orchestrate-doc-reconcile.json" in steps[24][
+    assert steps[23]["title"] == "Reconcile declarative docs"
+    assert steps[23]["annotations"] == {"jiraOrchestrateRole": "doc-reconciliation"}
+    assert steps[23]["skill"]["id"] == "moonspec-doc-reconcile"
+    assert "FULLY_IMPLEMENTED" in steps[23]["instructions"]
+    assert "skip doc reconciliation" in steps[23]["instructions"]
+    assert "artifacts/github-issue-orchestrate-doc-reconcile.json" in steps[23][
         "instructions"
     ]
 
-    assert steps[25]["title"] == "Create pull request"
-    assert steps[25]["annotations"] == {"jiraOrchestrateRole": "pull-request-handoff"}
-    assert "skip pull request creation entirely" in steps[25]["instructions"]
-    assert "post-remediation moonspec-verify" in steps[25]["instructions"]
-    assert "terminal verifier outcomes" not in steps[25]["instructions"].lower()
-    assert "ADDITIONAL_WORK_NEEDED" in steps[25]["instructions"]
-    assert "artifacts/github-issue-orchestrate-pr.json" in steps[25]["instructions"]
+    assert steps[24]["title"] == "Create pull request"
+    assert steps[24]["annotations"] == {"jiraOrchestrateRole": "pull-request-handoff"}
+    assert "skip pull request creation entirely" in steps[24]["instructions"]
+    assert "post-remediation moonspec-verify" in steps[24]["instructions"]
+    assert "terminal verifier outcomes" not in steps[24]["instructions"].lower()
+    assert "ADDITIONAL_WORK_NEEDED" in steps[24]["instructions"]
+    assert "artifacts/github-issue-orchestrate-pr.json" in steps[24]["instructions"]
 
-    assert steps[26]["title"] == "Finalize GitHub issue status"
-    assert steps[26]["annotations"] == {"jiraOrchestrateRole": "code-review-handoff"}
-    assert steps[26]["tool"] == {
+    assert steps[25]["title"] == "Finalize GitHub issue status"
+    assert steps[25]["annotations"] == {"jiraOrchestrateRole": "code-review-handoff"}
+    assert steps[25]["tool"] == {
         "id": "github.update_issue_status",
         "requiredCapabilities": ["gh"],
         "inputs": {
@@ -239,6 +243,6 @@ async def test_github_issue_orchestrate_expands_required_order_and_gates(tmp_pat
             "verificationArtifactPath": "var/artifacts/moonspec-verify/github-issue-orchestrate.json",
         },
     }
-    assert "apply the configured Done strategy" in steps[26]["instructions"]
-    assert "terminal verifier outcomes" in steps[26]["instructions"]
-    assert "Code Review strategy" in steps[26]["instructions"]
+    assert "apply the configured Done strategy" in steps[25]["instructions"]
+    assert "terminal verifier outcomes" in steps[25]["instructions"]
+    assert "Code Review strategy" in steps[25]["instructions"]

--- a/tests/unit/api/test_github_issue_orchestrate_preset.py
+++ b/tests/unit/api/test_github_issue_orchestrate_preset.py
@@ -155,7 +155,7 @@ async def test_github_issue_orchestrate_expands_required_order_and_gates(tmp_pat
         "Load GitHub issue brief",
         "Assess existing implementation state",
         "Check GitHub issue blockers before orchestration",
-        "Mark GitHub issue In Progress",
+        "Classify request and resume point",
     ]
     assert steps[0]["tool"]["id"] == "github.load_issue_preset_brief"
     assert steps[0]["tool"]["inputs"] == {
@@ -176,7 +176,7 @@ async def test_github_issue_orchestrate_expands_required_order_and_gates(tmp_pat
     assert "deterministic trusted GitHub blocker preflight" in steps[2][
         "instructions"
     ]
-    assert steps[3]["tool"] == {
+    assert steps[4]["tool"] == {
         "id": "github.update_issue_status",
         "requiredCapabilities": ["gh"],
         "inputs": {
@@ -188,7 +188,7 @@ async def test_github_issue_orchestrate_expands_required_order_and_gates(tmp_pat
         },
     }
 
-    assert [steps[index]["skill"]["id"] for index in range(4, 10)] == [
+    assert [steps[index]["skill"]["id"] for index in [3, 5, 6, 7, 8, 9]] == [
         "auto",
         "moonspec-specify",
         "moonspec-plan",
@@ -197,10 +197,10 @@ async def test_github_issue_orchestrate_expands_required_order_and_gates(tmp_pat
         "moonspec-implement",
     ]
     assert "Split broad designs when needed" not in [step["title"] for step in steps]
-    assert "Preserve MM-1063 traceability." in steps[4]["instructions"]
-    assert "FULLY_IMPLEMENTED" in steps[4]["instructions"]
-    assert "one independently testable story" in steps[4]["instructions"]
-    assert "upstream breakdown/selector workflow" in steps[4]["instructions"]
+    assert "Preserve MM-1063 traceability." in steps[3]["instructions"]
+    assert "FULLY_IMPLEMENTED" in steps[3]["instructions"]
+    assert "one independently testable story" in steps[3]["instructions"]
+    assert "upstream breakdown/selector workflow" in steps[3]["instructions"]
     assert "one independently testable story" in steps[5]["instructions"]
     assert "Do not run moonspec-breakdown from this preset" in steps[5]["instructions"]
     assert "make no code changes" in steps[9]["instructions"]

--- a/tests/unit/api/test_github_issue_orchestrate_preset.py
+++ b/tests/unit/api/test_github_issue_orchestrate_preset.py
@@ -94,19 +94,21 @@ async def test_github_issue_orchestrate_seed_exposes_issue_picker_and_tools(tmp_
         "commentPullRequestUrl"
     ] is True
 
-    assert [step.get("kind", "step") for step in template.steps[:4]] == [
+    assert [step.get("kind", "step") for step in template.steps[:5]] == [
         "step",
         "include",
+        "step",
         "step",
         "step",
     ]
     assert [
         (step.get("tool") or step.get("skill") or {}).get("id")
-        for step in template.steps[:4]
+        for step in template.steps[:5]
     ] == [
         "github.load_issue_preset_brief",
         None,
         "github.check_issue_blockers",
+        "auto",
         "github.update_issue_status",
     ]
     assert template.steps[1]["slug"] == "issue-implement-assessment"

--- a/tests/unit/api/test_presets_service.py
+++ b/tests/unit/api/test_presets_service.py
@@ -2907,7 +2907,6 @@ async def test_seed_catalog_includes_jira_orchestrate_preset(tmp_path):
                 "jira.load_preset_brief",
                 "auto",
                 "moonspec-specify",
-                "auto",
                 "moonspec-plan",
                 "moonspec-tasks",
                 "moonspec-align",
@@ -2933,7 +2932,7 @@ async def test_seed_catalog_includes_jira_orchestrate_preset(tmp_path):
                 context={},
             )
 
-            assert len(expanded["steps"]) == 26
+            assert len(expanded["steps"]) == 25
             assert expanded["steps"][0]["skill"]["id"] == "jira-issue-updater"
             assert "MM-328" in expanded["steps"][0]["instructions"]
             assert "In Progress" in expanded["steps"][0]["instructions"]
@@ -2976,86 +2975,93 @@ async def test_seed_catalog_includes_jira_orchestrate_preset(tmp_path):
             }
             assert "Jira preset brief" in expanded["steps"][2]["instructions"]
             assert "Keep the scope narrow." in expanded["steps"][3]["instructions"]
-            assert expanded["steps"][11]["title"] == "Remediate verification gaps 1 of 6"
-            assert expanded["steps"][11]["skill"]["id"] == "moonspec-implement"
-            assert "ADDITIONAL_WORK_NEEDED" in expanded["steps"][11]["instructions"]
-            assert "verification report's gaps" in expanded["steps"][11]["instructions"]
-            assert expanded["steps"][10]["skill"]["id"] == "moonspec-verify"
-            assert "Verification robustness rules" in expanded["steps"][10][
+            assert "one independently testable story" in expanded["steps"][3]["instructions"]
+            assert "upstream breakdown/selector workflow" in expanded["steps"][3]["instructions"]
+            assert "one independently testable story" in expanded["steps"][4]["instructions"]
+            assert "Do not run moonspec-breakdown from this preset" in expanded["steps"][4]["instructions"]
+            assert "Split broad designs when needed" not in [
+                step["title"] for step in expanded["steps"]
+            ]
+            assert expanded["steps"][10]["title"] == "Remediate verification gaps 1 of 6"
+            assert expanded["steps"][10]["skill"]["id"] == "moonspec-implement"
+            assert "ADDITIONAL_WORK_NEEDED" in expanded["steps"][10]["instructions"]
+            assert "verification report's gaps" in expanded["steps"][10]["instructions"]
+            assert expanded["steps"][9]["skill"]["id"] == "moonspec-verify"
+            assert "Verification robustness rules" in expanded["steps"][9][
                 "instructions"
             ]
-            assert "embedding_provider_not_configured" in expanded["steps"][10][
+            assert "embedding_provider_not_configured" in expanded["steps"][9][
                 "instructions"
             ]
-            assert "disclosed scope exclusions" in expanded["steps"][10][
+            assert "disclosed scope exclusions" in expanded["steps"][9][
                 "instructions"
             ]
-            assert "Verification robustness rules" in expanded["steps"][12][
+            assert "Verification robustness rules" in expanded["steps"][11][
                 "instructions"
             ]
-            assert expanded["steps"][22]["title"] == "Verify remediation 6 of 6"
-            assert expanded["steps"][22]["skill"]["id"] == "moonspec-verify"
-            assert "controlling verification gate" in expanded["steps"][22][
+            assert expanded["steps"][21]["title"] == "Verify remediation 6 of 6"
+            assert expanded["steps"][21]["skill"]["id"] == "moonspec-verify"
+            assert "controlling verification gate" in expanded["steps"][21][
                 "instructions"
             ]
-            assert "Verification robustness rules" in expanded["steps"][22][
+            assert "Verification robustness rules" in expanded["steps"][21][
                 "instructions"
             ]
-            assert expanded["steps"][23]["title"] == "Reconcile declarative docs"
-            assert expanded["steps"][23]["annotations"] == {
+            assert expanded["steps"][22]["title"] == "Reconcile declarative docs"
+            assert expanded["steps"][22]["annotations"] == {
                 "jiraOrchestrateRole": "doc-reconciliation"
             }
-            assert expanded["steps"][23]["skill"]["id"] == "moonspec-doc-reconcile"
-            assert "FULLY_IMPLEMENTED" in expanded["steps"][23]["instructions"]
-            assert "no_update_required" in expanded["steps"][23]["instructions"]
-            assert "Source Document Drift" in expanded["steps"][23]["instructions"]
+            assert expanded["steps"][22]["skill"]["id"] == "moonspec-doc-reconcile"
+            assert "FULLY_IMPLEMENTED" in expanded["steps"][22]["instructions"]
+            assert "no_update_required" in expanded["steps"][22]["instructions"]
+            assert "Source Document Drift" in expanded["steps"][22]["instructions"]
             assert "artifacts/jira-orchestrate-doc-reconcile.json" in expanded[
                 "steps"
-            ][23]["instructions"]
+            ][22]["instructions"]
             assert "Escalation does not block pull request creation" in expanded[
                 "steps"
-            ][23]["instructions"]
+            ][22]["instructions"]
             assert "Do not commit, push, or create a pull request" in expanded[
                 "steps"
-            ][23]["instructions"]
-            assert expanded["steps"][24]["title"] == "Create pull request"
-            assert expanded["steps"][24]["annotations"] == {
+            ][22]["instructions"]
+            assert expanded["steps"][23]["title"] == "Create pull request"
+            assert expanded["steps"][23]["annotations"] == {
                 "jiraOrchestrateRole": "pull-request-handoff"
             }
-            assert "post-remediation moonspec-verify" in expanded["steps"][24][
+            assert "post-remediation moonspec-verify" in expanded["steps"][23][
                 "instructions"
             ]
-            assert "pull request title must include MM-328" in expanded["steps"][24][
+            assert "pull request title must include MM-328" in expanded["steps"][23][
                 "instructions"
             ]
-            assert "parent workflow must use the pull request URL" in expanded["steps"][24][
+            assert "parent workflow must use the pull request URL" in expanded["steps"][23][
                 "instructions"
             ]
-            assert "explicit PR-publication step" in expanded["steps"][24][
+            assert "explicit PR-publication step" in expanded["steps"][23][
                 "instructions"
             ]
-            assert "controlling instruction for this step only" in expanded["steps"][24][
+            assert "controlling instruction for this step only" in expanded["steps"][23][
                 "instructions"
             ]
-            assert "merge automation" in expanded["steps"][24]["instructions"]
-            assert "non-draft pull request" in expanded["steps"][24]["instructions"]
-            assert "isDraft value is false" in expanded["steps"][24]["instructions"]
-            assert "confirmed non-draft" in expanded["steps"][24]["instructions"]
-            assert "artifacts/jira-orchestrate-pr.json" in expanded["steps"][24][
+            assert "merge automation" in expanded["steps"][23]["instructions"]
+            assert "non-draft pull request" in expanded["steps"][23]["instructions"]
+            assert "isDraft value is false" in expanded["steps"][23]["instructions"]
+            assert "confirmed non-draft" in expanded["steps"][23]["instructions"]
+            assert "artifacts/jira-orchestrate-pr.json" in expanded["steps"][23][
                 "instructions"
             ]
-            assert "doc reconciliation outcome" in expanded["steps"][24][
+            assert "doc reconciliation outcome" in expanded["steps"][23][
                 "instructions"
             ]
-            assert expanded["steps"][25]["skill"]["id"] == "jira-issue-updater"
-            assert expanded["steps"][25]["annotations"] == {
+            assert expanded["steps"][24]["skill"]["id"] == "jira-issue-updater"
+            assert expanded["steps"][24]["annotations"] == {
                 "jiraOrchestrateRole": "code-review-handoff"
             }
-            assert "pull_request_url" in expanded["steps"][25]["instructions"]
-            assert "stop without changing Jira" in expanded["steps"][25][
+            assert "pull_request_url" in expanded["steps"][24]["instructions"]
+            assert "stop without changing Jira" in expanded["steps"][24][
                 "instructions"
             ]
-            assert "status Review" in expanded["steps"][25]["instructions"]
+            assert "status Review" in expanded["steps"][24]["instructions"]
             assert all(
                 step["title"] != "Return Jira orchestration report"
                 for step in expanded["steps"]
@@ -3377,7 +3383,6 @@ async def test_seed_catalog_github_issue_orchestrate_expands_gated_workflow(tmp_
         "Mark GitHub issue In Progress",
         "Classify request and resume point",
         "Create or select MoonSpec",
-        "Split broad designs when needed",
         "Plan selected spec",
         "Generate TDD task breakdown",
         "Align MoonSpec artifacts",
@@ -3399,6 +3404,10 @@ async def test_seed_catalog_github_issue_orchestrate_expands_gated_workflow(tmp_
         "Create pull request",
         "Finalize GitHub issue status",
     ]
+    assert "one independently testable story" in expanded["steps"][4]["instructions"]
+    assert "upstream breakdown/selector workflow" in expanded["steps"][4]["instructions"]
+    assert "one independently testable story" in expanded["steps"][5]["instructions"]
+    assert "Do not run moonspec-breakdown from this preset" in expanded["steps"][5]["instructions"]
     assert expanded["steps"][0]["tool"]["id"] == "github.load_issue_preset_brief"
     assert expanded["steps"][0]["tool"]["inputs"] == {
         "repository": "MoonLadderStudios/MoonMind",
@@ -3414,63 +3423,63 @@ async def test_seed_catalog_github_issue_orchestrate_expands_gated_workflow(tmp_
         "mode": "start",
         "assessmentArtifactPath": "artifacts/github-issue-orchestrate-assessment.json",
     }
-    assert expanded["steps"][26]["tool"]["id"] == "github.update_issue_status"
-    assert expanded["steps"][26]["tool"]["inputs"] == {
+    assert expanded["steps"][25]["tool"]["id"] == "github.update_issue_status"
+    assert expanded["steps"][25]["tool"]["inputs"] == {
         "repository": "MoonLadderStudios/MoonMind",
         "issueNumber": "1067",
         "mode": "finalize_after_pr_or_done",
         "pullRequestArtifactPath": "artifacts/github-issue-orchestrate-pr.json",
         "verificationArtifactPath": "var/artifacts/moonspec-verify/github-issue-orchestrate.json",
     }
-    assert expanded["steps"][11]["skill"]["id"] == "moonspec-verify"
-    assert expanded["steps"][11]["skill"]["args"]["verify_artifact_path"] == (
+    assert expanded["steps"][10]["skill"]["id"] == "moonspec-verify"
+    assert expanded["steps"][10]["skill"]["args"]["verify_artifact_path"] == (
         "var/artifacts/moonspec-verify/github-issue-orchestrate.json"
     )
-    assert expanded["steps"][23]["annotations"] == {
+    assert expanded["steps"][22]["annotations"] == {
         "jiraOrchestrateRole": "moonspec-verification-gate",
         "moonSpecRemediationAttempt": 6,
         "moonSpecRemediationMaxAttempts": 6,
         "moonSpecFinalRemediationGate": True,
     }
-    assert expanded["steps"][23]["skill"]["args"]["verify_artifact_path"] == (
+    assert expanded["steps"][22]["skill"]["args"]["verify_artifact_path"] == (
         "var/artifacts/moonspec-verify/github-issue-orchestrate.json"
     )
-    assert expanded["steps"][24]["annotations"] == {
+    assert expanded["steps"][23]["annotations"] == {
         "jiraOrchestrateRole": "doc-reconciliation"
     }
-    assert expanded["steps"][25]["annotations"] == {
+    assert expanded["steps"][24]["annotations"] == {
         "jiraOrchestrateRole": "pull-request-handoff"
     }
-    assert expanded["steps"][26]["annotations"] == {
+    assert expanded["steps"][25]["annotations"] == {
         "jiraOrchestrateRole": "code-review-handoff"
     }
-    assert "ADDITIONAL_WORK_NEEDED or NO_DETERMINATION" in expanded["steps"][23][
+    assert "ADDITIONAL_WORK_NEEDED or NO_DETERMINATION" in expanded["steps"][22][
         "instructions"
     ]
-    assert "do not continue to pull request creation" in expanded["steps"][23][
+    assert "do not continue to pull request creation" in expanded["steps"][22][
         "instructions"
     ]
     assert "only when the controlling post-remediation verdict is FULLY_IMPLEMENTED" in expanded[
         "steps"
-    ][24]["instructions"]
-    assert "If the latest verdict is not FULLY_IMPLEMENTED" in expanded["steps"][24][
+    ][23]["instructions"]
+    assert "If the latest verdict is not FULLY_IMPLEMENTED" in expanded["steps"][23][
         "instructions"
     ]
     assert "stop without committing, pushing, creating a pull request" in expanded["steps"][
-        25
+        24
     ]["instructions"]
-    assert "terminal verifier outcomes" in expanded["steps"][26]["instructions"]
-    assert "must stop before this status update" in expanded["steps"][26][
+    assert "terminal verifier outcomes" in expanded["steps"][25]["instructions"]
+    assert "must stop before this status update" in expanded["steps"][25][
         "instructions"
     ]
     assert "FULLY_IMPLEMENTED and no MoonSpec implementation work ran" in expanded[
         "steps"
-    ][11]["instructions"]
-    assert "skip doc reconciliation" in expanded["steps"][24]["instructions"]
-    assert "skip pull request creation entirely" in expanded["steps"][25][
+    ][10]["instructions"]
+    assert "skip doc reconciliation" in expanded["steps"][23]["instructions"]
+    assert "skip pull request creation entirely" in expanded["steps"][24][
         "instructions"
     ]
-    assert "apply the configured Done strategy" in expanded["steps"][26][
+    assert "apply the configured Done strategy" in expanded["steps"][25][
         "instructions"
     ]
     assert [item["presetSlug"] for item in expanded["authoredPresets"]] == [

--- a/tests/unit/api/test_presets_service.py
+++ b/tests/unit/api/test_presets_service.py
@@ -2902,10 +2902,10 @@ async def test_seed_catalog_includes_jira_orchestrate_preset(tmp_path):
                 (step.get("skill") or step.get("tool"))["id"]
                 for step in template.steps
             ] == [
-                "jira-issue-updater",
                 "jira.check_blockers",
                 "jira.load_preset_brief",
                 "auto",
+                "jira-issue-updater",
                 "moonspec-specify",
                 "moonspec-plan",
                 "moonspec-tasks",
@@ -2933,50 +2933,50 @@ async def test_seed_catalog_includes_jira_orchestrate_preset(tmp_path):
             )
 
             assert len(expanded["steps"]) == 25
-            assert expanded["steps"][0]["skill"]["id"] == "jira-issue-updater"
-            assert "MM-328" in expanded["steps"][0]["instructions"]
-            assert "In Progress" in expanded["steps"][0]["instructions"]
-            assert expanded["steps"][1]["title"] == "Check Jira blockers before implementation"
-            assert expanded["steps"][1]["type"] == "tool"
-            assert expanded["steps"][1]["tool"]["id"] == "jira.check_blockers"
-            assert expanded["steps"][1]["tool"]["inputs"] == {
+            assert expanded["steps"][0]["title"] == "Check Jira blockers before implementation"
+            assert expanded["steps"][0]["type"] == "tool"
+            assert expanded["steps"][0]["tool"]["id"] == "jira.check_blockers"
+            assert expanded["steps"][0]["tool"]["inputs"] == {
                 "targetIssueKey": "MM-328",
                 "blockerPreflight": {
                     "targetIssueKey": "MM-328",
                     "linkType": "Blocks",
                 },
             }
-            assert expanded["steps"][1]["targetIssueKey"] == "MM-328"
-            assert expanded["steps"][1]["blockerPreflight"] == {
+            assert expanded["steps"][0]["targetIssueKey"] == "MM-328"
+            assert expanded["steps"][0]["blockerPreflight"] == {
                 "targetIssueKey": "MM-328",
                 "linkType": "Blocks",
             }
-            assert "Jira issue MM-328" in expanded["steps"][1]["instructions"]
-            assert "deterministic trusted Jira blocker preflight" in expanded["steps"][1]["instructions"]
-            assert "other issue as outwardIssue" in expanded["steps"][1]["instructions"]
-            assert "other issue as inwardIssue" in expanded["steps"][1]["instructions"]
-            assert "MUST NOT block this orchestration" in expanded["steps"][1]["instructions"]
-            assert "blocker" in expanded["steps"][1]["instructions"]
-            assert "Done" in expanded["steps"][1]["instructions"]
-            assert "non-blocker" in expanded["steps"][1]["instructions"]
-            assert "status cannot be determined" in expanded["steps"][1][
+            assert "Jira issue MM-328" in expanded["steps"][0]["instructions"]
+            assert "deterministic trusted Jira blocker preflight" in expanded["steps"][0]["instructions"]
+            assert "other issue as outwardIssue" in expanded["steps"][0]["instructions"]
+            assert "other issue as inwardIssue" in expanded["steps"][0]["instructions"]
+            assert "MUST NOT block this orchestration" in expanded["steps"][0]["instructions"]
+            assert "blocker" in expanded["steps"][0]["instructions"]
+            assert "Done" in expanded["steps"][0]["instructions"]
+            assert "non-blocker" in expanded["steps"][0]["instructions"]
+            assert "status cannot be determined" in expanded["steps"][0][
                 "instructions"
             ]
-            assert "raw Jira credentials" in expanded["steps"][1]["instructions"]
-            assert "web scraping" in expanded["steps"][1]["instructions"]
-            assert "stop the orchestration immediately" in expanded["steps"][1][
+            assert "raw Jira credentials" in expanded["steps"][0]["instructions"]
+            assert "web scraping" in expanded["steps"][0]["instructions"]
+            assert "stop the orchestration immediately" in expanded["steps"][0][
                 "instructions"
             ]
-            assert expanded["steps"][2]["type"] == "tool"
-            assert expanded["steps"][2]["tool"]["id"] == "jira.load_preset_brief"
-            assert expanded["steps"][2]["tool"]["inputs"] == {
+            assert expanded["steps"][1]["type"] == "tool"
+            assert expanded["steps"][1]["tool"]["id"] == "jira.load_preset_brief"
+            assert expanded["steps"][1]["tool"]["inputs"] == {
                 "issueKey": "MM-328",
                 "artifactPath": "artifacts/jira-orchestrate-brief.json",
             }
-            assert "Jira preset brief" in expanded["steps"][2]["instructions"]
-            assert "Keep the scope narrow." in expanded["steps"][3]["instructions"]
-            assert "one independently testable story" in expanded["steps"][3]["instructions"]
-            assert "upstream breakdown/selector workflow" in expanded["steps"][3]["instructions"]
+            assert "Jira preset brief" in expanded["steps"][1]["instructions"]
+            assert "Keep the scope narrow." in expanded["steps"][2]["instructions"]
+            assert "one independently testable story" in expanded["steps"][2]["instructions"]
+            assert "upstream breakdown/selector workflow" in expanded["steps"][2]["instructions"]
+            assert expanded["steps"][3]["skill"]["id"] == "jira-issue-updater"
+            assert "MM-328" in expanded["steps"][3]["instructions"]
+            assert "In Progress" in expanded["steps"][3]["instructions"]
             assert "one independently testable story" in expanded["steps"][4]["instructions"]
             assert "Do not run moonspec-breakdown from this preset" in expanded["steps"][4]["instructions"]
             assert "Split broad designs when needed" not in [
@@ -3380,8 +3380,8 @@ async def test_seed_catalog_github_issue_orchestrate_expands_gated_workflow(tmp_
         "Load GitHub issue brief",
         "Assess existing implementation state",
         "Check GitHub issue blockers before orchestration",
-        "Mark GitHub issue In Progress",
         "Classify request and resume point",
+        "Mark GitHub issue In Progress",
         "Create or select MoonSpec",
         "Plan selected spec",
         "Generate TDD task breakdown",
@@ -3404,8 +3404,8 @@ async def test_seed_catalog_github_issue_orchestrate_expands_gated_workflow(tmp_
         "Create pull request",
         "Finalize GitHub issue status",
     ]
-    assert "one independently testable story" in expanded["steps"][4]["instructions"]
-    assert "upstream breakdown/selector workflow" in expanded["steps"][4]["instructions"]
+    assert "one independently testable story" in expanded["steps"][3]["instructions"]
+    assert "upstream breakdown/selector workflow" in expanded["steps"][3]["instructions"]
     assert "one independently testable story" in expanded["steps"][5]["instructions"]
     assert "Do not run moonspec-breakdown from this preset" in expanded["steps"][5]["instructions"]
     assert expanded["steps"][0]["tool"]["id"] == "github.load_issue_preset_brief"
@@ -3415,8 +3415,8 @@ async def test_seed_catalog_github_issue_orchestrate_expands_gated_workflow(tmp_
         "artifactPath": "artifacts/github-issue-orchestrate-brief.json",
     }
     assert expanded["steps"][2]["tool"]["id"] == "github.check_issue_blockers"
-    assert expanded["steps"][3]["tool"]["id"] == "github.update_issue_status"
-    assert expanded["steps"][3]["tool"]["inputs"] == {
+    assert expanded["steps"][4]["tool"]["id"] == "github.update_issue_status"
+    assert expanded["steps"][4]["tool"]["inputs"] == {
         "repository": "MoonLadderStudios/MoonMind",
         "issueNumber": "1067",
         "targetStatus": "In Progress",

--- a/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
+++ b/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
@@ -2086,9 +2086,14 @@ async def test_child_jira_orchestrate_run_expands_seeded_template_steps(tmp_path
     task = expanded_parameters["task"]
     assert expanded_parameters["stepCount"] == 26
     assert len(task["steps"]) == 26
-    assert task["steps"][0]["title"] == "Move Jira issue to In Progress"
-    assert task["steps"][0]["skill"]["id"] == "jira-issue-updater"
-    assert "MM-501" in task["steps"][0]["instructions"]
+    assert task["steps"][0]["title"] == "Check Jira blockers before implementation"
+    assert task["steps"][0]["tool"]["id"] == "jira.check_blockers"
+    assert task["steps"][1]["title"] == "Load Jira preset brief"
+    assert task["steps"][1]["tool"]["id"] == "jira.load_preset_brief"
+    assert task["steps"][2]["title"] == "Classify request and resume point"
+    assert task["steps"][3]["title"] == "Move Jira issue to In Progress"
+    assert task["steps"][3]["skill"]["id"] == "jira-issue-updater"
+    assert "MM-501" in task["steps"][3]["instructions"]
     assert task["steps"][7]["skill"]["id"] == "moonspec-tasks"
     assert task["steps"][9]["skill"]["id"] == "moonspec-implement"
     assert task["steps"][10]["skill"]["id"] == "moonspec-verify"


### PR DESCRIPTION
Fully implement this:

Title: Align MoonSpec Orchestrate presets with one-story orchestration contract

Description:

MoonSpec Orchestrate should only run against a preselected, independently testable single story or an active feature directory with an existing one-story spec.md.

The current MoonSpec source preset already enforces this boundary: it validates that the input is exactly one story, stops when the input is broad or multi-story, and explicitly says not to run moonspec-breakdown from inside the preset. It also states that any story splitting must be completed before MoonSpec Orchestrate starts.

However, MoonMind’s issue-based orchestrate presets still contain older broad-design handling. jira-orchestrate classifies briefs as single-story, broad design, or existing feature directory, then tells Create or select MoonSpec to run moonspec-breakdown for broad designs, followed by a separate “Split broad designs when needed” step. github-issue-orchestrate has the same pattern: it allows broad design classification, tells the MoonSpec creation step to run moonspec-breakdown, and includes a separate broad-design split step.

This creates an inconsistent orchestration contract: moonspec-orchestrate is now one-story-only, but issue orchestrators can still attempt in-line story splitting while entering the MoonSpec lifecycle.

Goal:

Update MoonMind’s orchestrate presets so broad issue briefs are handled as an upstream routing/selection concern, not as an in-line MoonSpec lifecycle step.

Required behavior:

moonspec-orchestrate must continue to require exactly one independently testable story before running moonspec-specify.

Issue-driven presets must not run moonspec-breakdown as part of the MoonSpec lifecycle step.

If a Jira or GitHub issue brief is broad, multi-story, or requires “implement all stories,” the preset should stop or route to an upstream breakdown/selector workflow before invoking the one-story MoonSpec lifecycle.

Once a story is selected, downstream steps must operate on exactly that one selected story:

specify

plan

tasks

align

implement

verify

doc reconcile, when applicable

Remove or replace the “Split broad designs when needed” step from issue orchestrate presets.

Replace old wording such as “run moonspec-breakdown first, then select the recommended first generated spec” with a clear precondition/gate, for example:

“If the issue brief is not already one independently testable story, stop and report that it must be routed through moonspec-breakdown or another upstream selector before this orchestration can continue.”

Suggested implementation:

Update these preset files:

api_service/data/presets/jira-orchestrate.yaml

api_service/data/presets/github-issue-orchestrate.yaml

For each preset:

Remove the Split broad designs when needed step.

Update Classify request and resume point so classification is used only to decide whether the issue is eligible for one-story orchestration.

Update Create or select MoonSpec so it does not instruct moonspec-specify or any auto step to run moonspec-breakdown.

Ensure the preset either:

continues only when the brief is one independently testable story, or

stops with a clear message that upstream breakdown/selection is required.

Acceptance criteria:

moonspec-orchestrate remains a one-story-only lifecycle preset.

jira-orchestrate no longer contains a step titled Split broad designs when needed.

github-issue-orchestrate no longer contains a step titled Split broad designs when needed.

No issue orchestrate preset tells a MoonSpec lifecycle step to run moonspec-breakdown.

Broad or multi-story issue briefs produce a clear stopped/routed outcome instead of proceeding into specification.

Existing single-story Jira issue orchestration still reaches moonspec-specify, moonspec-plan, moonspec-tasks, moonspec-align, moonspec-implement, and moonspec-verify.

Existing single-story GitHub issue orchestration still reaches the same MoonSpec lifecycle.

Tests are updated to assert the new contract for both Jira and GitHub issue orchestrate presets.

Test notes:

Add or update preset seeding/expansion tests to verify:

jira-orchestrate does not include Split broad designs when needed.

github-issue-orchestrate does not include Split broad designs when needed.

Neither preset includes instructions that run moonspec-breakdown inside Create or select MoonSpec.

The generated instructions explicitly state that broad/multi-story issue briefs must be handled by upstream breakdown/selection before one-story MoonSpec orchestration begins.