### PR TITLE
Implement the Jira issue:

### DIFF
--- a/frontend/src/entrypoints/dashboard.test.tsx
+++ b/frontend/src/entrypoints/dashboard.test.tsx
@@ -1024,6 +1024,28 @@ describe('Dashboard shared entry', () => {
     );
   });
 
+  it('bleeds workflow list chrome while keeping cell content inset', async () => {
+    const slabBlock = cssRuleBlock(dashboardCss, '.workflow-list-data-slab');
+    expect(slabBlock).toContain('--workflow-list-slab-bleed-inline: 1rem');
+
+    const workflowWrapperBlock = cssRuleBlock(dashboardCss, '.workflow-list-data-slab .queue-table-wrapper');
+    expect(workflowWrapperBlock).toContain('width: calc(100% + (var(--workflow-list-slab-bleed-inline) * 2))');
+    expect(workflowWrapperBlock).toContain('margin-inline: calc(var(--workflow-list-slab-bleed-inline) * -1)');
+    expect(workflowWrapperBlock).toContain('max-width: none');
+
+    const firstCellBlock = cssRuleBlock(
+      dashboardCss,
+      '.workflow-list-data-slab .queue-table-wrapper th:first-child,\n.workflow-list-data-slab .queue-table-wrapper td:first-child',
+    );
+    expect(firstCellBlock).toContain('padding-left: 1rem');
+
+    const lastCellBlock = cssRuleBlock(
+      dashboardCss,
+      '.workflow-list-data-slab .queue-table-wrapper th:last-child,\n.workflow-list-data-slab .queue-table-wrapper td:last-child',
+    );
+    expect(lastCellBlock).toContain('padding-right: 1rem');
+  });
+
   it('MM-1116 defines one workflow-list row metric token family for table and sidebar modes', async () => {
     const rootBlock = cssRuleBlock(dashboardCss, ':root');
     expect(rootBlock).toContain('--workflow-list-header-row-height: 2.75rem');
@@ -1039,22 +1061,29 @@ describe('Dashboard shared entry', () => {
     expect(shellBlock).toContain('grid-template-columns: var(--workflow-list-column-workflow-width) minmax(0, 1fr)');
 
     const sidebarBlock = cssRuleBlock(dashboardCss, '.workflow-workspace-sidebar');
-    expect(sidebarBlock).toContain('border-right: var(--workflow-list-divider-width) solid var(--workflow-list-divider-color)');
+    expect(sidebarBlock).not.toContain('border-right');
   });
 
-  it('MM-1116 matches sidebar and full-table Workflow header styling through shared selectors', async () => {
-    const sharedHeaderBlock = cssRuleBlock(
-      dashboardCss,
-      '.queue-table-wrapper th,\n.workflow-workspace-sidebar-header-cell',
-    );
-    expect(sharedHeaderBlock).toContain('height: var(--workflow-list-header-row-height)');
-    expect(sharedHeaderBlock).toContain('background: rgb(var(--mm-panel) / 0.98)');
-    expect(sharedHeaderBlock).toContain('box-shadow: 0 1px 0 var(--workflow-list-divider-color)');
-    expect(sharedHeaderBlock).toContain('font-weight: 600');
-    expect(sharedHeaderBlock).toContain('color: rgb(var(--mm-ink) / 0.85)');
+  it('keeps sidebar Workflow header chrome owned by the sidebar header container', async () => {
+    const tableHeaderBlock = cssRuleBlock(dashboardCss, '.queue-table-wrapper th');
+    expect(tableHeaderBlock).toContain('height: var(--workflow-list-header-row-height)');
+    expect(tableHeaderBlock).toContain('background: rgb(var(--mm-panel) / 0.98)');
+    expect(tableHeaderBlock).toContain('box-shadow: 0 1px 0 var(--workflow-list-divider-color)');
+    expect(tableHeaderBlock).toContain('font-weight: 600');
+    expect(tableHeaderBlock).toContain('color: rgb(var(--mm-ink) / 0.85)');
+
+    const sidebarHeaderContainerBlock = cssRuleBlock(dashboardCss, '.workflow-workspace-sidebar-header');
+    expect(sidebarHeaderContainerBlock).toContain('display: grid');
+    expect(sidebarHeaderContainerBlock).toContain('min-height: var(--workflow-list-header-row-height)');
+    expect(sidebarHeaderContainerBlock).toContain('background: rgb(var(--mm-panel) / 0.98)');
+    expect(sidebarHeaderContainerBlock).toContain('box-shadow: 0 1px 0 var(--workflow-list-divider-color)');
+    expect(sidebarHeaderContainerBlock).toContain('font-weight: 600');
+    expect(sidebarHeaderContainerBlock).toContain('color: rgb(var(--mm-ink) / 0.85)');
 
     const sidebarHeaderBlock = cssRuleBlock(dashboardCss, '.workflow-workspace-sidebar-header-cell');
-    expect(sidebarHeaderBlock).toContain('padding: 0.5rem 0.75rem');
+    expect(sidebarHeaderBlock).toContain('padding: 0');
+    expect(sidebarHeaderBlock).toContain('background: transparent');
+    expect(sidebarHeaderBlock).toContain('box-shadow: none');
     expect(sidebarHeaderBlock).toContain('text-align: left');
   });
 
@@ -1114,7 +1143,7 @@ describe('Dashboard shared entry', () => {
 
   it('MM-1116 keeps sidebar/table mode changes aligned and reduced-motion safe', async () => {
     const tableWorkflowCellBlock = cssRuleBlock(dashboardCss, '.queue-table-cell-workflow');
-    expect(tableWorkflowCellBlock).toContain('border-right: var(--workflow-list-divider-width) solid var(--workflow-list-divider-color)');
+    expect(tableWorkflowCellBlock).not.toContain('border-right');
 
     const workflowWrapperBlock = cssRuleBlock(dashboardCss, '.workflow-list-data-slab .queue-table-wrapper');
     expect(workflowWrapperBlock).toContain('transition: opacity 120ms ease');
@@ -1134,7 +1163,7 @@ describe('Dashboard shared entry', () => {
 
   it('keeps the workflow sidebar scrollbar close to its divider', async () => {
     const sidebarBlock = cssRuleBlock(dashboardCss, '.workflow-workspace-sidebar');
-    expect(sidebarBlock).toContain('padding: 0 0.125rem 0 0');
+    expect(sidebarBlock).toContain('padding: 0');
 
     const sidebarTableBlock = cssRuleBlock(dashboardCss, '.workflow-workspace-sidebar-table');
     expect(sidebarTableBlock).toContain('scrollbar-width: thin');

--- a/frontend/src/entrypoints/workflow-detail.test.tsx
+++ b/frontend/src/entrypoints/workflow-detail.test.tsx
@@ -1299,6 +1299,9 @@ describe('Workflow Detail Entrypoint', () => {
       /\.workflow-workspace-detail\s*\{[^}]*max-width:\s*66rem;/,
     );
     expect(dashboardCss).toMatch(
+      /\.workflow-workspace-detail\s*\{[^}]*padding-top:\s*0\.85rem;/,
+    );
+    expect(dashboardCss).toMatch(
       /\.workflow-workspace-shell\[data-sidebar-collapsed="true"\] \.workflow-workspace-detail\s*\{[^}]*grid-column:\s*1 \/ -1;/,
     );
   });

--- a/frontend/src/entrypoints/workflow-list.test.tsx
+++ b/frontend/src/entrypoints/workflow-list.test.tsx
@@ -2049,8 +2049,10 @@ describe('Workflows Entrypoint', () => {
     // The slab intentionally allows overflow so the row actions popover
     // can extend below the table without being clipped.
     expect(getComputedStyle(dataSlab as HTMLElement).overflow).toBe('visible');
-    expect(getComputedStyle(tableWrapper as HTMLElement).width).toBe('100%');
-    expect(getComputedStyle(tableWrapper as HTMLElement).maxWidth).toBe('100%');
+    expect(getComputedStyle(tableWrapper as HTMLElement).width).toBe(
+      'calc(100% + (var(--workflow-list-slab-bleed-inline) * 2))',
+    );
+    expect(getComputedStyle(tableWrapper as HTMLElement).maxWidth).toBe('none');
     expect(getComputedStyle(tableWrapper as HTMLElement).overflowX).toBe('auto');
     expect(getComputedStyle(tableWrapper as HTMLElement).overflowY).toBe('visible');
     expect(getComputedStyle(tableWrapper as HTMLElement).scrollPaddingTop).not.toBe('auto');

--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -1998,6 +1998,8 @@ tbody tr:hover {
 }
 
 .workflow-list-data-slab {
+  --workflow-list-slab-bleed-inline: 1rem;
+
   gap: 0;
   overflow: visible;
   padding: 0;
@@ -2019,6 +2021,8 @@ tbody tr:hover {
 }
 
 .workflow-list-data-slab .queue-results-toolbar {
+  width: calc(100% + (var(--workflow-list-slab-bleed-inline) * 2));
+  margin-inline: calc(var(--workflow-list-slab-bleed-inline) * -1);
   padding: 0.85rem 1rem;
   border-bottom: 1px solid rgb(var(--mm-border) / 0.28);
 }
@@ -2031,6 +2035,11 @@ tbody tr:hover {
   padding: 0.7rem 1rem;
   border-bottom: 1px solid rgb(var(--mm-border) / 0.28);
   background: rgb(var(--mm-panel) / 0.85);
+}
+
+.workflow-list-data-slab .workflow-list-results-header {
+  width: calc(100% + (var(--workflow-list-slab-bleed-inline) * 2));
+  margin-inline: calc(var(--workflow-list-slab-bleed-inline) * -1);
 }
 
 .workflow-list-results-header .page-title {
@@ -2047,6 +2056,8 @@ tbody tr:hover {
 .workflow-list-data-slab .workflow-list-results-footer {
   position: relative;
   z-index: 1;
+  width: calc(100% + (var(--workflow-list-slab-bleed-inline) * 2));
+  margin-inline: calc(var(--workflow-list-slab-bleed-inline) * -1);
   border-top: 1px solid rgb(var(--mm-border) / 0.28);
   border-bottom: 0;
 }
@@ -2105,8 +2116,9 @@ tbody tr:hover {
 .workflow-list-data-slab .queue-table-wrapper {
   position: relative;
   z-index: 5;
-  width: 100%;
-  max-width: 100%;
+  width: calc(100% + (var(--workflow-list-slab-bleed-inline) * 2));
+  max-width: none;
+  margin-inline: calc(var(--workflow-list-slab-bleed-inline) * -1);
   border: 0;
   border-radius: 0;
   background: transparent;
@@ -2165,16 +2177,10 @@ tbody tr:hover {
   position: sticky;
   top: 0;
   z-index: 7;
-  background: rgb(var(--mm-panel) / 0.98);
-  border-bottom: 0;
-  box-shadow: 0 1px 0 rgb(var(--mm-border) / 0.72);
-}
-
-.queue-table-wrapper th,
-.workflow-workspace-sidebar-header-cell {
   height: var(--workflow-list-header-row-height);
   padding: 0.5rem 0.75rem;
   background: rgb(var(--mm-panel) / 0.98);
+  border-bottom: 0;
   box-shadow: 0 1px 0 var(--workflow-list-divider-color);
   color: rgb(var(--mm-ink) / 0.85);
   font-weight: 600;
@@ -2245,7 +2251,6 @@ tbody tr:hover {
 
 .queue-table-cell-workflow {
   height: var(--workflow-list-body-row-height);
-  border-right: var(--workflow-list-divider-width) solid var(--workflow-list-divider-color);
   font-weight: 500;
 }
 
@@ -2832,6 +2837,8 @@ tr[data-proposal-id].proposal-consuming td {
   }
 
   .workflow-list-data-slab {
+    --workflow-list-slab-bleed-inline: 0rem;
+
     border: 0;
     border-radius: 0;
     background: transparent;
@@ -7379,22 +7386,45 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
   max-height: 100vh;
   overflow: visible;
   /* Not a card: the sidebar is a plain left column separated from the detail by
-   * the grid gap and a single hairline divider, like ChatGPT. */
-  padding: 0 0.125rem 0 0;
-  border-right: var(--workflow-list-divider-width) solid var(--workflow-list-divider-color);
+   * the grid gap rather than a vertical divider. */
+  padding: 0;
 }
 
 .workflow-workspace-sidebar-header {
   position: sticky;
   top: 0;
   z-index: 8;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  min-height: 3.1rem;
-  padding: 0.5rem 0.55rem;
+  display: grid;
+  min-height: var(--workflow-list-header-row-height);
+  min-width: 0;
+  padding: 0.5rem 0.75rem;
   background: rgb(var(--mm-panel) / 0.98);
-  box-shadow: 0 1px 0 rgb(var(--mm-border) / 0.72);
+  box-shadow: 0 1px 0 var(--workflow-list-divider-color);
+  color: rgb(var(--mm-ink) / 0.85);
+  font-weight: 600;
+}
+
+.workflow-workspace-sidebar-header-row {
+  display: grid;
+  width: 100%;
+  min-width: 0;
+}
+
+.workflow-workspace-sidebar-header-cell {
+  display: grid;
+  align-items: center;
+  width: 100%;
+  min-width: 0;
+  height: 100%;
+  padding: 0;
+  background: transparent;
+  box-shadow: none;
+  text-align: left;
+}
+
+.workflow-workspace-sidebar-header-cell .workflow-list-column-header {
+  width: 100%;
+  min-width: 0;
 }
 
 .workflow-workspace-sidebar-header-title {
@@ -7435,7 +7465,6 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
   background: transparent;
 }
 
-.workflow-workspace-sidebar-header,
 .workflow-workspace-sidebar-list,
 .workflow-workspace-sidebar-state-group {
   display: grid;
@@ -7577,6 +7606,7 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
   width: 100%;
   max-width: 66rem;
   margin-inline: auto;
+  padding-top: 0.85rem;
 }
 
 .workflow-workspace-opening-state {


### PR DESCRIPTION
Implement the Jira issue:

Current status

The unwanted vertical line is still present.


There are actually two possible contributors still in the CSS: the sidebar still draws a right border on .workflow-workspace-sidebar, and the full workflow table still draws a border-right on .queue-table-cell-workflow.

The sidebar Workflow header/filter line is still likely broken.


The sidebar header draws its own sticky background and bottom box-shadow, while .workflow-workspace-sidebar-header-cell is still grouped with normal table header cells and receives its own height, padding, background, and box-shadow. There is also a later rule that overrides the sidebar header to display: grid, which conflicts with the earlier flex-style header intent. The shared WorkflowColumnHeader component itself is simple and reusable, so the issue appears to be CSS ownership/overrides rather than the component structure.

Edge-to-edge table chrome is only partially addressed.


The panel is now allowed to go full width for workflow table/workspace surfaces, which is good. But the dashboard root still has 1rem horizontal padding, and the workflow table wrapper is still width: 100% / max-width: 100%, so the table header background and row dividers do not actually bleed past the padded content area. The table already has first/last-cell padding, which is the right mechanism for keeping text inset after a bleed is added.

The workflow detail title/top spacing is still not addressed.


The detail container still only defines width/max-width/margins and has no top padding, while WorkflowDetailPage starts immediately with the toolbar and “Workflow Detail” title.

Updated Jira issue description

Title

Fix remaining Workflows table/sidebar chrome alignment and workflow detail top spacing

Description

After MM-1116 and MM-1117, the Workflows page still has unresolved visual/layout issues in the workflow list/table and workflow detail workspace. The display-mode persistence work is merged, and the sidebar table-slice work is merged, but the remaining chrome/alignment issues are still present in the current frontend CSS.

The remaining work should cleanly separate paint/chrome from content padding:

Header backgrounds and horizontal dividers may extend to the intended page/workspace edge.

Text, icons, filter buttons, and row content must remain padded/inset.

Sidebar and full-table workflow headers should use the same visual language without duplicate borders or broken divider lines.

Current problems

Unwanted vertical divider remains

The workflow sidebar still draws a right-side border.

The full workflow table still draws a right border on the Workflow column body cells.

Desired behavior: remove the unintended vertical divider(s) while preserving horizontal row separation.

Sidebar Workflow header/filter line is visually broken

The sidebar header container and the inner sidebar header cell both paint header chrome.

The sidebar header has conflicting layout rules, including flex-style declarations and a later grid override.

Desired behavior: exactly one element owns the sidebar header background and bottom divider; the shared Workflow header/filter control should align cleanly with the full-table Workflow header.

Table header background and horizontal row lines still stop short

The workflow panel itself can be full width, but the table wrapper remains constrained inside the dashboard root padding.

Desired behavior: table header background, header bottom rule, row dividers, and results header/footer rules extend to the intended page/workspace edge, while cell text remains inset.

Workflow detail title is too close to the nav bar

The detail column has no top padding.

Desired behavior: add a small, consistent top gap above the workflow detail toolbar/title in detail and sidebar modes.

Scope

Update the Workflows UI layout/chrome only. This should not change workflow data fetching, routing, filtering semantics, pagination, persistence behavior, or workflow execution behavior.

Likely files:

frontend/src/styles/dashboard.css

frontend/src/components/WorkflowColumnHeader.tsx only if component-level class hooks are needed

frontend/src/entrypoints/workflow-list.tsx only if markup hooks are needed

frontend/src/entrypoints/workflow-detail.tsx only if a detail/workspace wrapper hook is needed

Existing dashboard/workflow tests and, if appropriate, browser layout tests

Implementation notes

Remove or override the unwanted border-right from:

.workflow-workspace-sidebar

.queue-table-cell-workflow

Do not replace those vertical borders with another vertical divider unless explicitly required by design.

Make .workflow-workspace-sidebar-header the single owner of the sidebar header background and bottom divider, or move ownership to .workflow-workspace-sidebar-header-cell, but not both.

Reset .workflow-workspace-sidebar-header-cell so it does not inherit the full-table th paint styles unless those styles are intentionally shared.

Ensure .workflow-workspace-sidebar-header-row, .workflow-workspace-sidebar-header-cell, and .workflow-list-column-header fill the sidebar width.

Add a table/workflow-slab bleed model:

Header backgrounds and row dividers extend to the intended edge.

First and last cells keep enough inline padding so text does not start/end at the page edge.

Avoid introducing horizontal page scrollbars.

Add top spacing to .workflow-workspace-detail or the workspace shell, depending on whether the sidebar should remain flush or move down with the detail column.

Acceptance criteria

In full-table workflow list mode, there is no unintended vertical line after the Workflow column.

In sidebar workflow list mode, there is no unintended vertical line on the right side of the workflow column/sidebar unless explicitly required by the final design.

The sidebar Workflow header label and filter button align cleanly and do not show a broken or doubled horizontal line.

The full-table Workflow header and sidebar Workflow header use consistent sizing, spacing, and filter-button treatment.

The workflow table header background and horizontal row separators extend to the intended page/workspace edge.

Table and sidebar text remain padded/inset; no text starts directly at the viewport edge.

The workflow detail page has visible breathing room between the masthead/nav and the “Workflow Detail” title area.

No horizontal scrollbar is introduced at common desktop widths.

Behavior remains correct across:

Full screen table mode

Sidebar list mode

Hidden/no-list mode

Compact and comfortable densities

Active filters and open filter popovers

Desktop and mobile breakpoints

Suggested test plan

Add or update browser/layout coverage for the Workflows page at desktop width.

Verify bounding boxes for:

workflow table wrapper vs page/workspace edge

first/last cell text inset

sidebar header vs sidebar row width

workflow detail top offset

Run existing dashboard/workflow frontend tests and typecheck.

Manually verify the screenshot scenario in dark mode with the sidebar list visible and a workflow detail selected.