### PR TITLE
Implement the following plan:

### DIFF
--- a/frontend/src/entrypoints/workflow-detail.test.tsx
+++ b/frontend/src/entrypoints/workflow-detail.test.tsx
@@ -2725,8 +2725,8 @@ describe('Workflow Detail Entrypoint', () => {
     expect(screen.getByText('Not started')).toBeTruthy();
     expect(screen.getAllByText('Ready').length).toBeGreaterThanOrEqual(1);
     expect(screen.getByText('Timing unavailable')).toBeTruthy();
-    expect(screen.getByLabelText('Step duration 1m 42s')).toBeTruthy();
-    expect(screen.getByLabelText('Step duration 3m 11s')).toBeTruthy();
+    expect(screen.queryByLabelText('Step duration 1m 42s')).toBeNull();
+    expect(screen.queryByLabelText('Step duration 3m 11s')).toBeNull();
     expect(screen.getByLabelText('Step timing overview').textContent).toContain(
       'Current step Run tests · 3m 11s so far',
     );
@@ -2737,6 +2737,8 @@ describe('Workflow Detail Entrypoint', () => {
       'Completed steps 2 of 5',
     );
     expect(screen.queryByRole('region', { name: 'Step duration timeline' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Show step duration timeline' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Hide step duration timeline' })).toBeNull();
 
     fireEvent.click(screen.getByRole('button', { name: 'Show details for Gather context' }));
     const timingHeading = screen.getByRole('heading', { name: 'Timing' });
@@ -2747,13 +2749,6 @@ describe('Workflow Detail Entrypoint', () => {
     expect(within(timingSection).getByText('Ended:')).toBeTruthy();
     expect(within(timingSection).getByText('Elapsed:')).toBeTruthy();
     expect(within(timingSection).getByText('Last update:')).toBeTruthy();
-
-    fireEvent.click(screen.getByRole('button', { name: 'Show step duration timeline' }));
-    const timeline = screen.getByRole('region', { name: 'Step duration timeline' });
-    expect(within(timeline).getByText('Gather context')).toBeTruthy();
-    expect(within(timeline).getByText('Run tests')).toBeTruthy();
-    expect(within(timeline).getByText('3m 11s so far')).toBeTruthy();
-    expect(screen.getByText('Hide step duration timeline')).toBeTruthy();
   });
 
   it('MM-801 renders Artifacts as the focused report and artifact route', async () => {

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -4376,26 +4376,6 @@ function StepTimingChip({ row }: { row: StepLedgerRow }) {
   return <span className="step-timing-chip">{stepTimingLabel(row)}</span>;
 }
 
-function StepDurationBar({
-  row,
-  maxDurationMs,
-}: {
-  row: StepLedgerRow;
-  maxDurationMs: number;
-}) {
-  const valueMs = rowTimingValueMs(row);
-  const percent =
-    valueMs !== null && valueMs > 0 && maxDurationMs > 0
-      ? Math.max(4, Math.min(100, (valueMs / maxDurationMs) * 100))
-      : 0;
-  const label = valueMs === null ? 'Step duration unavailable' : `Step duration ${formatDurationMs(valueMs)}`;
-  return (
-    <div className="step-duration-bar" aria-label={label}>
-      <span className="step-duration-bar-fill" style={{ width: `${percent}%` }} />
-    </div>
-  );
-}
-
 function StepTimingDetails({ row }: { row: StepLedgerRow }) {
   const timing = row.timing;
   const valueMs = rowTimingValueMs(row);
@@ -4441,63 +4421,6 @@ function StepTimingOverview({ rows }: { rows: StepLedgerRow[] }) {
         Completed steps <strong>{overview.completed} of {overview.total}</strong>
       </span>
     </div>
-  );
-}
-
-function timelineInstant(value: string | null | undefined): number | null {
-  if (!value) return null;
-  const parsed = Date.parse(value);
-  return Number.isFinite(parsed) ? parsed : null;
-}
-
-function StepDurationTimeline({ rows }: { rows: StepLedgerRow[] }) {
-  const items = rows.map((row) => {
-    const timing = row.timing;
-    const startMs = timelineInstant(timing?.startedAt ?? row.startedAt);
-    const endMs =
-      timelineInstant(timing?.endedAt) ??
-      timelineInstant(timing?.serverNow) ??
-      timelineInstant(row.updatedAt);
-    const durationMs = rowTimingValueMs(row);
-    return { row, startMs, endMs, durationMs };
-  });
-  const startedItems = items.filter(
-    (item): item is typeof item & { startMs: number; endMs: number; durationMs: number } =>
-      item.startMs !== null && item.endMs !== null && item.durationMs !== null,
-  );
-  const timelineStart = startedItems.length > 0 ? Math.min(...startedItems.map((item) => item.startMs)) : 0;
-  const timelineEnd = startedItems.length > 0 ? Math.max(...startedItems.map((item) => item.endMs)) : timelineStart + 1;
-  const spanMs = timelineEnd > timelineStart ? timelineEnd - timelineStart : 1;
-
-  return (
-    <section className="step-duration-timeline" aria-label="Step duration timeline">
-      <ol className="step-duration-timeline-list">
-        {items.map((item) => {
-          const hasTiming = item.startMs !== null && item.durationMs !== null;
-          const startMs = item.startMs ?? timelineStart;
-          const durationMs = item.durationMs ?? 0;
-          const left = hasTiming ? Math.max(0, ((startMs - timelineStart) / spanMs) * 100) : 0;
-          const width = hasTiming ? Math.max(4, Math.min(100 - left, (durationMs / spanMs) * 100)) : 0;
-          return (
-            <li key={item.row.logicalStepId} className="step-duration-timeline-row">
-              <span className="step-duration-timeline-title">{item.row.title}</span>
-              <span
-                className="step-duration-timeline-track"
-                aria-label={`${item.row.title}: ${stepTimingLabel(item.row)}`}
-              >
-                {hasTiming ? (
-                  <span
-                    className="step-duration-timeline-bar"
-                    style={{ insetInlineStart: `${left}%`, width: `${width}%` }}
-                  />
-                ) : null}
-              </span>
-              <span className="step-duration-timeline-label">{stepTimingLabel(item.row)}</span>
-            </li>
-          );
-        })}
-      </ol>
-    </section>
   );
 }
 
@@ -4751,7 +4674,6 @@ function StepLedgerRowCard({
   expanded,
   onToggle,
   isLast,
-  maxDurationMs,
   routes,
   branches,
 }: {
@@ -4767,7 +4689,6 @@ function StepLedgerRowCard({
   expanded: boolean;
   onToggle: () => void;
   isLast: boolean;
-  maxDurationMs: number;
   routes: AgentRunRouteTemplates;
   branches: CheckpointBranch[];
 }) {
@@ -4803,7 +4724,6 @@ function StepLedgerRowCard({
           {!expanded && row.summary ? (
             <p className="step-tl-summary">{row.summary}</p>
           ) : null}
-          {!expanded ? <StepDurationBar row={row} maxDurationMs={maxDurationMs} /> : null}
           {!expanded && row.dependsOn && row.dependsOn.length > 0 ? (
             <p className="step-tl-summary">Prior step evidence: {row.dependsOn.join(', ')}</p>
           ) : null}
@@ -6816,7 +6736,6 @@ export function WorkflowDetailPage({ payload }: { payload: BootPayload }) {
   });
   const [expandedSteps, setExpandedSteps] = useState<Record<string, boolean>>({});
   const [chatOptimisticMessages, setChatOptimisticMessages] = useState<OptimisticChatSessionMessage[]>([]);
-  const [stepTimelineVisible, setStepTimelineVisible] = useState(false);
   const [instructionsExpanded, setInstructionsExpanded] = useState(false);
   const [remediationMode, setRemediationMode] = useState(DEFAULT_REMEDIATION_MODE);
   const [remediationAuthority, setRemediationAuthority] = useState(DEFAULT_REMEDIATION_AUTHORITY);
@@ -8216,43 +8135,26 @@ export function WorkflowDetailPage({ payload }: { payload: BootPayload }) {
               ) : stepsQuery.data ? (
                 <>
                   <StepTimingOverview rows={stepsQuery.data.steps} />
-                  <button
-                    type="button"
-                    className="step-duration-timeline-toggle"
-                    onClick={() => setStepTimelineVisible((current) => !current)}
-                  >
-                    {stepTimelineVisible ? 'Hide step duration timeline' : 'Show step duration timeline'}
-                  </button>
-                  {stepTimelineVisible ? <StepDurationTimeline rows={stepsQuery.data.steps} /> : null}
                   <div className="step-tl-list">
-                    {(() => {
-                      const maxDurationMs = Math.max(
-                        0,
-                        ...stepsQuery.data.steps
-                          .map((item) => rowTimingValueMs(item))
-                          .filter((value): value is number => value !== null),
-                      );
-                      return stepsQuery.data.steps.map((row, idx) => (
-                        <StepLedgerRowCard
-                          key={row.logicalStepId}
-                          apiBase={payload.apiBase}
-                          logStreamingEnabled={logStreamingEnabled}
-                          sessionTimelineEnabled={sessionTimelineEnabled}
-                          structuredHistoryEnabled={structuredHistoryEnabled}
-                          row={row}
-                          workflowId={workflowId}
-                          runId={latestRunId}
-                          sourceTemporal={sourceTemporal}
-                          historyPollInterval={!isTerminalExecution ? detailPoll : false}
-                          expanded={Boolean(expandedSteps[row.logicalStepId])}
-                          onToggle={() => toggleStep(row.logicalStepId)}
-                          isLast={idx === stepsQuery.data.steps.length - 1}
-                          maxDurationMs={maxDurationMs}
-                          routes={agentRunRoutes}
-                          branches={branchesByStep.get(stepBranchKey(row)) ?? []}
-                        />
-                      ));
-                    })()}
+                    {stepsQuery.data.steps.map((row, idx) => (
+                      <StepLedgerRowCard
+                        key={row.logicalStepId}
+                        apiBase={payload.apiBase}
+                        logStreamingEnabled={logStreamingEnabled}
+                        sessionTimelineEnabled={sessionTimelineEnabled}
+                        structuredHistoryEnabled={structuredHistoryEnabled}
+                        row={row}
+                        workflowId={workflowId}
+                        runId={latestRunId}
+                        sourceTemporal={sourceTemporal}
+                        historyPollInterval={!isTerminalExecution ? detailPoll : false}
+                        expanded={Boolean(expandedSteps[row.logicalStepId])}
+                        onToggle={() => toggleStep(row.logicalStepId)}
+                        isLast={idx === stepsQuery.data.steps.length - 1}
+                        routes={agentRunRoutes}
+                        branches={branchesByStep.get(stepBranchKey(row)) ?? []}
+                      />
+                    ))}
                   </div>
                   <BranchExplorerPanel
                     apiBase={payload.apiBase}

--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -4240,22 +4240,6 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
   -webkit-box-orient: vertical;
 }
 
-.step-duration-bar {
-  position: relative;
-  overflow: hidden;
-  height: 0.22rem;
-  margin-top: 0.35rem;
-  border-radius: 999px;
-  background: rgb(var(--mm-border) / 0.38);
-}
-
-.step-duration-bar span {
-  position: absolute;
-  inset: 0 auto 0 0;
-  border-radius: inherit;
-  background: rgb(var(--mm-accent-2) / 0.62);
-}
-
 .step-execution-pill {
   display: inline-flex;
   align-items: center;
@@ -4305,23 +4289,6 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
   white-space: nowrap;
 }
 
-.step-duration-bar {
-  position: relative;
-  height: 0.25rem;
-  width: 100%;
-  overflow: hidden;
-  border-radius: 999px;
-  background: rgb(var(--mm-border) / 0.35);
-  margin-top: 0.35rem;
-}
-
-.step-duration-bar-fill {
-  display: block;
-  height: 100%;
-  border-radius: inherit;
-  background: rgb(var(--mm-accent-2));
-}
-
 .step-timing-overview {
   display: flex;
   flex-wrap: wrap;
@@ -4335,85 +4302,6 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
 .step-timing-overview strong {
   color: rgb(var(--mm-ink));
   font-variant-numeric: tabular-nums;
-}
-
-.step-duration-timeline-toggle {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: fit-content;
-  min-height: 2rem;
-  margin: 0 0 0.55rem;
-  padding: 0.25rem 0.65rem;
-  border: 1px solid rgb(var(--mm-border) / 0.72);
-  border-radius: 0.45rem;
-  background: rgb(var(--mm-panel));
-  color: rgb(var(--mm-ink));
-  font-size: 0.78rem;
-  font-weight: 600;
-  cursor: pointer;
-}
-
-.step-duration-timeline-toggle:hover,
-.step-duration-timeline-toggle:focus-visible {
-  border-color: rgb(var(--mm-accent-2) / 0.8);
-  background: rgb(var(--mm-accent-2) / 0.08);
-}
-
-.step-duration-timeline {
-  margin: 0 0 0.8rem;
-  padding: 0.65rem 0;
-  border-top: 1px solid rgb(var(--mm-border) / 0.45);
-  border-bottom: 1px solid rgb(var(--mm-border) / 0.45);
-}
-
-.step-duration-timeline-list {
-  display: grid;
-  gap: 0.45rem;
-  margin: 0;
-  padding: 0;
-  list-style: none;
-}
-
-.step-duration-timeline-row {
-  display: grid;
-  grid-template-columns: minmax(8rem, 0.9fr) minmax(9rem, 2fr) minmax(7rem, auto);
-  gap: 0.65rem;
-  align-items: center;
-  min-height: 1.75rem;
-  font-size: 0.78rem;
-}
-
-.step-duration-timeline-title {
-  min-width: 0;
-  overflow: hidden;
-  color: rgb(var(--mm-ink));
-  font-weight: 600;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.step-duration-timeline-track {
-  position: relative;
-  display: block;
-  height: 0.55rem;
-  overflow: hidden;
-  border-radius: 999px;
-  background: rgb(var(--mm-border) / 0.32);
-}
-
-.step-duration-timeline-bar {
-  position: absolute;
-  inset-block: 0;
-  border-radius: inherit;
-  background: rgb(var(--mm-accent-2));
-}
-
-.step-duration-timeline-label {
-  color: rgb(var(--mm-muted));
-  font-family: var(--mm-font-mono);
-  font-variant-numeric: tabular-nums;
-  white-space: nowrap;
 }
 
 /* MM-815: latest evidence refs surfaced (ref-only) in the default step row */


### PR DESCRIPTION
Implement the following plan:

Title

Remove blue timing bars from Workflow Steps UI

Description

The Workflow Steps page currently renders blue horizontal timing bars for step rows and also exposes a “Show step duration timeline” bar visualization. These bars are technically duration indicators, not progress indicators, but they read visually like progress bars. That creates confusion because completed steps often show partial blue fills when they simply took less time than the longest step.

We already render a StepTimingChip in each step row header, which gives the operator a quick timing signal such as elapsed duration, “so far,” “Ready,” “Not started,” or “Timing unavailable.” That chip is sufficient for quick timing comprehension. Expanded row details also retain the dedicated Timing section for deeper inspection. The bar-based timing UI should be removed entirely.

Current code has StepTimingChip rendered in the step row header, while StepDurationBar is separately rendered for collapsed rows. The duration bar itself computes a percentage width from the step timing value and renders the blue fill. The Steps tab also exposes the duration timeline toggle and StepDurationTimeline visualization.

Goals

Remove all blue bar-based timing visualizations from the Workflow Steps page.

Retain the existing StepTimingChip as the compact timing indicator for each step row.

Retain expanded Timing details for operators who need precise timestamps and elapsed duration.

Reduce visual noise and avoid the mistaken interpretation that duration bars represent completion progress.

Non-goals

Do not change the step ledger API contract.

Do not remove timing data from the backend or frontend schemas.

Do not remove StepTimingChip.

Do not remove expanded Timing details.

Do not replace the bars with another visual progress or duration bar.

Acceptance Criteria

Collapsed step rows no longer render the blue horizontal duration bar.

The “Show step duration timeline” / “Hide step duration timeline” toggle is removed from the Workflow Steps page.

StepDurationTimeline is no longer rendered anywhere in the Workflow Steps page.

Each step row still shows the timing chip in the row header.

Expanded step rows still show the Timing section with started time, ended time when available, elapsed duration, and last update.

No user-facing copy refers to a step duration timeline after this change.

No empty layout gap remains where the blue bar used to appear.

The Steps page remains visually stable for pending, ready, executing, completed, failed, skipped, canceled, and timing-unavailable rows.

Implementation Notes

In frontend/src/entrypoints/workflow-detail.tsx:

Remove the collapsed-row StepDurationBar render from StepLedgerRowCard.

Remove the StepDurationBar component if it becomes unused.

Remove the StepDurationTimeline component and the timelineInstant helper if they become unused.

Remove stepTimelineVisible state.

Remove the “Show step duration timeline” toggle button and conditional StepDurationTimeline render.

Remove the maxDurationMs calculation and maxDurationMs prop plumbing if no longer needed.

Keep StepTimingChip, stepTimingLabel, rowTimingValueMs, and StepTimingDetails, since those still support the timing chip and expanded timing detail.

Remove now-unused CSS selectors for step-duration-bar, step-duration-bar-fill, step-duration-timeline, step-duration-timeline-*, and step-duration-timeline-toggle.

Update tests/snapshots that expect the duration bar or timeline toggle.

Test Plan

Open a workflow with multiple completed steps and confirm no blue timing bars appear in collapsed rows.

Confirm each step row still shows a timing chip.

Expand a step and confirm the Timing section still renders correctly.

Verify active steps still show timing such as “so far” in the chip.

Verify pending/ready/unavailable timing states still show appropriate chip text.

Run frontend tests and update snapshots as needed.