### PR TITLE
[codex] Keep advisory e2e checks from blocking verification

### DIFF
--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -8524,6 +8524,12 @@ class TemporalAgentRuntimeActivities:
             '- For `FULLY_IMPLEMENTED`, set `recommendedNextAction` to "advance"; '
             "do not encode pull request creation or any other workflow-specific "
             "destination in this field.\n"
+            "- Treat integration, e2e, smoke, quickstart, map-entry, UI/browser, "
+            "deployment, and external-service checks as advisory when they depend "
+            "on unavailable non-repo assets, services, credentials, or tooling; "
+            "missing map assets or environment-only failures must be reported as "
+            "non-blocking limitations, not used as the sole reason for a blocking "
+            "verdict.\n"
             "- Still return the Markdown MoonSpec Verification Report in the assistant response."
         )
         return instructions.rstrip() + "\n\n" + block

--- a/tests/unit/workflows/temporal/test_activity_runtime.py
+++ b/tests/unit/workflows/temporal/test_activity_runtime.py
@@ -122,6 +122,9 @@ async def test_prepare_managed_codex_turn_adds_moonspec_verify_artifact_hint() -
     assert '"reattempt_current_step"' in prepared
     assert '`FULLY_IMPLEMENTED`, set `recommendedNextAction` to "advance"' in prepared
     assert "raw diagnostic" in prepared
+    assert "map-entry" in prepared
+    assert "missing map assets" in prepared
+    assert "non-blocking limitations" in prepared
 
 
 async def test_prepare_managed_codex_turn_appends_vocab_when_path_already_present() -> None:
@@ -139,6 +142,7 @@ async def test_prepare_managed_codex_turn_appends_vocab_when_path_already_presen
     assert '"FULLY_IMPLEMENTED"' in prepared
     assert '"advance"' in prepared
     assert "workflow-specific destination" in prepared
+    assert "external-service checks as advisory" in prepared
 
 
 async def test_codex_skill_payload_rejects_auto_publish_mode() -> None:


### PR DESCRIPTION
## Summary
- Add a MoonSpec verify runtime hint so integration/e2e/smoke/map-entry checks are advisory when they depend on unavailable non-repo assets, services, credentials, or tooling.
- Assert that the managed Codex turn prompt includes the advisory map-asset guidance.
- Update the `moonspec` submodule to `f88f99177be04ca24cead3a82fe6b231ad4c610e`, published in MoonLadderStudios/MoonSpec#5.

## Root Cause
Workflow `mm:a30b7cde-4030-40c9-904f-36c0822b3849` failed verification because unavailable Tactics map assets were treated as a blocking MoonSpec verdict. Missing e2e/map assets should be recorded as non-blocking advisory evidence unless they expose a concrete in-scope implementation defect.

## Validation
- `./tools/test_unit.sh tests/unit/workflows/temporal/test_activity_runtime.py -k moonspec_verify_artifact_hint`
- MoonSpec: `python3 tools/validate_bundle.py`
- MoonSpec: `pytest`