### PR TITLE
[codex] fix Jira assessment verdict parsing

### DIFF
--- a/moonmind/workflows/temporal/story_output_tools.py
+++ b/moonmind/workflows/temporal/story_output_tools.py
@@ -4520,11 +4520,12 @@ def _assessment_verdict_from_text(value: Any) -> str:
         r"(FULLY_IMPLEMENTED|PARTIALLY_IMPLEMENTED|NOT_IMPLEMENTED|BLOCKED)"
     )
     verdict_prefix = r"[\s:`*_\"']*"
+    verdict_suffix = r"(?:\b|_+(?!\w))"
     patterns = (
         r"(?is)\bassessment\s+complete\b[^.\n:]*[:\s`]+"
-        rf"{verdict_prefix}{verdict_pattern}\b",
+        rf"{verdict_prefix}{verdict_pattern}{verdict_suffix}",
         r"(?is)\brecorded\s+verdict\b[^.\n:]*[:\s`]+"
-        rf"{verdict_prefix}{verdict_pattern}\b",
+        rf"{verdict_prefix}{verdict_pattern}{verdict_suffix}",
         r"(?is)['\"]verdict['\"]\s*:\s*['\"]"
         rf"{verdict_pattern}['\"]",
     )

--- a/moonmind/workflows/temporal/story_output_tools.py
+++ b/moonmind/workflows/temporal/story_output_tools.py
@@ -4516,13 +4516,17 @@ def _assessment_verdict_from_text(value: Any) -> str:
     text = _string(value)
     if not text:
         return ""
+    verdict_pattern = (
+        r"(FULLY_IMPLEMENTED|PARTIALLY_IMPLEMENTED|NOT_IMPLEMENTED|BLOCKED)"
+    )
+    verdict_prefix = r"[\s:`*_\"']*"
     patterns = (
         r"(?is)\bassessment\s+complete\b[^.\n:]*[:\s`]+"
-        r"(FULLY_IMPLEMENTED|PARTIALLY_IMPLEMENTED|NOT_IMPLEMENTED|BLOCKED)\b",
+        rf"{verdict_prefix}{verdict_pattern}\b",
         r"(?is)\brecorded\s+verdict\b[^.\n:]*[:\s`]+"
-        r"(FULLY_IMPLEMENTED|PARTIALLY_IMPLEMENTED|NOT_IMPLEMENTED|BLOCKED)\b",
+        rf"{verdict_prefix}{verdict_pattern}\b",
         r"(?is)['\"]verdict['\"]\s*:\s*['\"]"
-        r"(FULLY_IMPLEMENTED|PARTIALLY_IMPLEMENTED|NOT_IMPLEMENTED|BLOCKED)['\"]",
+        rf"{verdict_pattern}['\"]",
     )
     for pattern in patterns:
         match = re.search(pattern, text)

--- a/tests/unit/workflows/temporal/test_story_output_tools.py
+++ b/tests/unit/workflows/temporal/test_story_output_tools.py
@@ -607,6 +607,42 @@ async def test_update_jira_issue_status_accepts_bold_previous_assessment_verdict
 
 
 @pytest.mark.asyncio
+async def test_update_jira_issue_status_accepts_underscore_wrapped_assessment_verdict(
+    tmp_path,
+) -> None:
+    service = _FakeJiraService()
+    service.issue_responses["MM-1125"] = {
+        "key": "MM-1125",
+        "fields": {"status": {"id": "1", "name": "Backlog"}},
+    }
+    service.transition_responses["MM-1125"] = {
+        "key": "MM-1125",
+        "fields": {"status": {"id": "3", "name": "In Progress"}},
+    }
+    service.transitions_response = {
+        "transitions": [
+            {"id": "31", "name": "In Progress", "to": {"name": "In Progress"}}
+        ]
+    }
+
+    result = await update_jira_issue_status(
+        {
+            "issueKey": "MM-1125",
+            "targetStatus": "In Progress",
+            "assessmentArtifactPath": str(tmp_path / "missing-assessment.json"),
+            "previousOutputs": {
+                "lastAssistantText": "Assessment complete: __PARTIALLY_IMPLEMENTED__.",
+            },
+        },
+        jira_service_factory=lambda: service,
+    )
+
+    assert result.status == "COMPLETED"
+    assert result.outputs["decision"] == "transitioned"
+    assert service.transition_requests[0].transition_id == "31"
+
+
+@pytest.mark.asyncio
 async def test_update_jira_issue_status_accepts_single_quoted_previous_verdict(
     tmp_path,
 ) -> None:

--- a/tests/unit/workflows/temporal/test_story_output_tools.py
+++ b/tests/unit/workflows/temporal/test_story_output_tools.py
@@ -571,6 +571,42 @@ async def test_update_jira_issue_status_uses_previous_assessment_text_when_artif
 
 
 @pytest.mark.asyncio
+async def test_update_jira_issue_status_accepts_bold_previous_assessment_verdict(
+    tmp_path,
+) -> None:
+    service = _FakeJiraService()
+    service.issue_responses["MM-1125"] = {
+        "key": "MM-1125",
+        "fields": {"status": {"id": "1", "name": "Backlog"}},
+    }
+    service.transition_responses["MM-1125"] = {
+        "key": "MM-1125",
+        "fields": {"status": {"id": "3", "name": "In Progress"}},
+    }
+    service.transitions_response = {
+        "transitions": [
+            {"id": "31", "name": "In Progress", "to": {"name": "In Progress"}}
+        ]
+    }
+
+    result = await update_jira_issue_status(
+        {
+            "issueKey": "MM-1125",
+            "targetStatus": "In Progress",
+            "assessmentArtifactPath": str(tmp_path / "missing-assessment.json"),
+            "previousOutputs": {
+                "lastAssistantText": "Assessment complete: **PARTIALLY_IMPLEMENTED**.",
+            },
+        },
+        jira_service_factory=lambda: service,
+    )
+
+    assert result.status == "COMPLETED"
+    assert result.outputs["decision"] == "transitioned"
+    assert service.transition_requests[0].transition_id == "31"
+
+
+@pytest.mark.asyncio
 async def test_update_jira_issue_status_accepts_single_quoted_previous_verdict(
     tmp_path,
 ) -> None:
@@ -3002,6 +3038,79 @@ async def test_check_jira_blockers_preserves_previous_assessment_verdict():
     assert result.status == "COMPLETED"
     assert result.outputs["decision"] == "continue"
     assert result.outputs["assessmentVerdict"] == "PARTIALLY_IMPLEMENTED"
+
+
+@pytest.mark.asyncio
+async def test_check_jira_blockers_preserves_bold_previous_assessment_verdict():
+    service = _FakeJiraService()
+    service.issue_responses["MM-2"] = {
+        "key": "MM-2",
+        "fields": {"issuelinks": []},
+    }
+
+    result = await check_jira_blockers(
+        {
+            "targetIssueKey": "MM-2",
+            "assessmentArtifactPath": "artifacts/jira-implement-assessment.json",
+            "previousOutputs": {
+                "lastAssistantText": "Assessment complete: **PARTIALLY_IMPLEMENTED**.",
+            },
+        },
+        jira_service_factory=lambda: service,
+    )
+
+    assert result.status == "COMPLETED"
+    assert result.outputs["decision"] == "continue"
+    assert result.outputs["assessmentVerdict"] == "PARTIALLY_IMPLEMENTED"
+
+
+@pytest.mark.asyncio
+async def test_jira_implement_status_update_uses_blocker_preserved_assessment_verdict(
+    tmp_path,
+) -> None:
+    service = _FakeJiraService()
+    service.issue_responses["MM-2"] = {
+        "key": "MM-2",
+        "fields": {
+            "issuelinks": [],
+            "status": {"id": "1", "name": "Backlog"},
+        },
+    }
+    service.transition_responses["MM-2"] = {
+        "key": "MM-2",
+        "fields": {"status": {"id": "3", "name": "In Progress"}},
+    }
+    service.transitions_response = {
+        "transitions": [
+            {"id": "31", "name": "In Progress", "to": {"name": "In Progress"}}
+        ]
+    }
+
+    blocker_result = await check_jira_blockers(
+        {
+            "targetIssueKey": "MM-2",
+            "assessmentArtifactPath": "artifacts/jira-implement-assessment.json",
+            "previousOutputs": {
+                "lastAssistantText": "Assessment complete: **PARTIALLY_IMPLEMENTED**.",
+            },
+        },
+        jira_service_factory=lambda: service,
+    )
+
+    status_result = await update_jira_issue_status(
+        {
+            "issueKey": "MM-2",
+            "targetStatus": "In Progress",
+            "assessmentArtifactPath": str(tmp_path / "missing-assessment.json"),
+            "previousOutputs": blocker_result.outputs,
+        },
+        jira_service_factory=lambda: service,
+    )
+
+    assert blocker_result.outputs["assessmentVerdict"] == "PARTIALLY_IMPLEMENTED"
+    assert status_result.status == "COMPLETED"
+    assert status_result.outputs["decision"] == "transitioned"
+    assert service.transition_requests[0].transition_id == "31"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Fix Jira implement status handoff when the assessment agent reports a Markdown-formatted verdict such as `Assessment complete: **PARTIALLY_IMPLEMENTED**`.

## Root Cause

`jira.check_blockers` and `jira.update_issue_status` already fall back to prior step text when the local assessment artifact is unavailable to the integrations worker, but the verdict parser only accepted bare or backtick-wrapped verdict tokens. Codex assessment output used bold Markdown, so the blocker step did not preserve `assessmentVerdict`, and the following Jira In Progress step failed with `assessment verdict unavailable`.

## Changes

- Allow Markdown emphasis/quote wrappers before assessment verdict tokens in the deterministic Jira assessment parser.
- Add regressions for direct Jira status fallback, blocker preflight preservation, and the chained Jira implement path from blocker output to In Progress update.

## Validation

- `./tools/test_unit.sh tests/unit/workflows/temporal/test_story_output_tools.py`