### PR TITLE
[codex] fix Jira assessment verdict parsing with issue key

### DIFF
--- a/moonmind/workflows/temporal/story_output_tools.py
+++ b/moonmind/workflows/temporal/story_output_tools.py
@@ -4520,9 +4520,16 @@ def _assessment_verdict_from_text(value: Any) -> str:
         r"(FULLY_IMPLEMENTED|PARTIALLY_IMPLEMENTED|NOT_IMPLEMENTED|BLOCKED)"
     )
     verdict_prefix = r"[\s:`*_\"']*"
-    verdict_suffix = r"(?:\b|_+(?!\w))"
+    verdict_suffix = r"(?:_+(?!\w)|(?![-\w]))"
+    assessment_separator = r"[\s:`*_\"'\[\]\(\)]*"
+    issue_ref_pattern = r"`?[A-Z][A-Z0-9]+-\d+`?"
     patterns = (
-        r"(?is)\bassessment\s+complete\b[^.\n]*?"
+        r"(?is)\bassessment\s+complete\b"
+        rf"{assessment_separator}"
+        rf"(?:(?:for|on)\b{assessment_separator}"
+        rf"{issue_ref_pattern}{assessment_separator})?"
+        rf"(?:{issue_ref_pattern}{assessment_separator})?"
+        rf"(?:(?:is|was|has|verdict|status)\b{assessment_separator})?"
         rf"{verdict_pattern}{verdict_suffix}",
         r"(?is)\brecorded\s+verdict\b[^.\n:]*[:\s`]+"
         rf"{verdict_prefix}{verdict_pattern}{verdict_suffix}",

--- a/moonmind/workflows/temporal/story_output_tools.py
+++ b/moonmind/workflows/temporal/story_output_tools.py
@@ -4522,8 +4522,8 @@ def _assessment_verdict_from_text(value: Any) -> str:
     verdict_prefix = r"[\s:`*_\"']*"
     verdict_suffix = r"(?:\b|_+(?!\w))"
     patterns = (
-        r"(?is)\bassessment\s+complete\b[^.\n:]*[:\s`]+"
-        rf"{verdict_prefix}{verdict_pattern}{verdict_suffix}",
+        r"(?is)\bassessment\s+complete\b[^.\n]*?"
+        rf"{verdict_pattern}{verdict_suffix}",
         r"(?is)\brecorded\s+verdict\b[^.\n:]*[:\s`]+"
         rf"{verdict_prefix}{verdict_pattern}{verdict_suffix}",
         r"(?is)['\"]verdict['\"]\s*:\s*['\"]"

--- a/tests/unit/workflows/temporal/test_story_output_tools.py
+++ b/tests/unit/workflows/temporal/test_story_output_tools.py
@@ -646,6 +646,69 @@ async def test_update_jira_issue_status_accepts_issue_key_before_bold_verdict(
 
 
 @pytest.mark.asyncio
+async def test_update_jira_issue_status_accepts_newline_assessment_verdict(
+    tmp_path,
+) -> None:
+    service = _FakeJiraService()
+    service.issue_responses["MM-1125"] = {
+        "key": "MM-1125",
+        "fields": {"status": {"id": "1", "name": "Backlog"}},
+    }
+    service.transition_responses["MM-1125"] = {
+        "key": "MM-1125",
+        "fields": {"status": {"id": "3", "name": "In Progress"}},
+    }
+    service.transitions_response = {
+        "transitions": [
+            {"id": "31", "name": "In Progress", "to": {"name": "In Progress"}}
+        ]
+    }
+
+    result = await update_jira_issue_status(
+        {
+            "issueKey": "MM-1125",
+            "targetStatus": "In Progress",
+            "assessmentArtifactPath": str(tmp_path / "missing-assessment.json"),
+            "previousOutputs": {
+                "lastAssistantText": (
+                    "Assessment complete:\n**PARTIALLY_IMPLEMENTED**."
+                ),
+            },
+        },
+        jira_service_factory=lambda: service,
+    )
+
+    assert result.status == "COMPLETED"
+    assert result.outputs["decision"] == "transitioned"
+    assert service.transition_requests[0].transition_id == "31"
+
+
+@pytest.mark.asyncio
+async def test_update_jira_issue_status_does_not_parse_negated_verdict(
+    tmp_path,
+) -> None:
+    service = _FakeJiraService()
+
+    result = await update_jira_issue_status(
+        {
+            "issueKey": "MM-1125",
+            "targetStatus": "In Progress",
+            "assessmentArtifactPath": str(tmp_path / "missing-assessment.json"),
+            "previousOutputs": {
+                "lastAssistantText": "Assessment complete: NOT FULLY_IMPLEMENTED.",
+            },
+        },
+        jira_service_factory=lambda: service,
+    )
+
+    assert result.status == "FAILED"
+    assert result.outputs["decision"] == "blocked"
+    assert "assessment verdict" in result.outputs["summary"]
+    assert service.get_issue_requests == []
+    assert service.transition_requests == []
+
+
+@pytest.mark.asyncio
 async def test_update_jira_issue_status_accepts_underscore_wrapped_assessment_verdict(
     tmp_path,
 ) -> None:
@@ -3154,6 +3217,33 @@ async def test_check_jira_blockers_preserves_issue_key_before_bold_verdict():
             "previousOutputs": {
                 "lastAssistantText": (
                     "Assessment complete: `MM-1133` is "
+                    "**PARTIALLY_IMPLEMENTED**."
+                ),
+            },
+        },
+        jira_service_factory=lambda: service,
+    )
+
+    assert result.status == "COMPLETED"
+    assert result.outputs["decision"] == "continue"
+    assert result.outputs["assessmentVerdict"] == "PARTIALLY_IMPLEMENTED"
+
+
+@pytest.mark.asyncio
+async def test_check_jira_blockers_does_not_parse_verdict_shaped_issue_key():
+    service = _FakeJiraService()
+    service.issue_responses["BLOCKED-123"] = {
+        "key": "BLOCKED-123",
+        "fields": {"issuelinks": []},
+    }
+
+    result = await check_jira_blockers(
+        {
+            "targetIssueKey": "BLOCKED-123",
+            "assessmentArtifactPath": "artifacts/jira-implement-assessment.json",
+            "previousOutputs": {
+                "lastAssistantText": (
+                    "Assessment complete: `BLOCKED-123` is "
                     "**PARTIALLY_IMPLEMENTED**."
                 ),
             },

--- a/tests/unit/workflows/temporal/test_story_output_tools.py
+++ b/tests/unit/workflows/temporal/test_story_output_tools.py
@@ -607,6 +607,45 @@ async def test_update_jira_issue_status_accepts_bold_previous_assessment_verdict
 
 
 @pytest.mark.asyncio
+async def test_update_jira_issue_status_accepts_issue_key_before_bold_verdict(
+    tmp_path,
+) -> None:
+    service = _FakeJiraService()
+    service.issue_responses["MM-1133"] = {
+        "key": "MM-1133",
+        "fields": {"status": {"id": "1", "name": "Backlog"}},
+    }
+    service.transition_responses["MM-1133"] = {
+        "key": "MM-1133",
+        "fields": {"status": {"id": "3", "name": "In Progress"}},
+    }
+    service.transitions_response = {
+        "transitions": [
+            {"id": "31", "name": "In Progress", "to": {"name": "In Progress"}}
+        ]
+    }
+
+    result = await update_jira_issue_status(
+        {
+            "issueKey": "MM-1133",
+            "targetStatus": "In Progress",
+            "assessmentArtifactPath": str(tmp_path / "missing-assessment.json"),
+            "previousOutputs": {
+                "lastAssistantText": (
+                    "Assessment complete: `MM-1133` is "
+                    "**PARTIALLY_IMPLEMENTED**."
+                ),
+            },
+        },
+        jira_service_factory=lambda: service,
+    )
+
+    assert result.status == "COMPLETED"
+    assert result.outputs["decision"] == "transitioned"
+    assert service.transition_requests[0].transition_id == "31"
+
+
+@pytest.mark.asyncio
 async def test_update_jira_issue_status_accepts_underscore_wrapped_assessment_verdict(
     tmp_path,
 ) -> None:
@@ -3090,6 +3129,33 @@ async def test_check_jira_blockers_preserves_bold_previous_assessment_verdict():
             "assessmentArtifactPath": "artifacts/jira-implement-assessment.json",
             "previousOutputs": {
                 "lastAssistantText": "Assessment complete: **PARTIALLY_IMPLEMENTED**.",
+            },
+        },
+        jira_service_factory=lambda: service,
+    )
+
+    assert result.status == "COMPLETED"
+    assert result.outputs["decision"] == "continue"
+    assert result.outputs["assessmentVerdict"] == "PARTIALLY_IMPLEMENTED"
+
+
+@pytest.mark.asyncio
+async def test_check_jira_blockers_preserves_issue_key_before_bold_verdict():
+    service = _FakeJiraService()
+    service.issue_responses["MM-1133"] = {
+        "key": "MM-1133",
+        "fields": {"issuelinks": []},
+    }
+
+    result = await check_jira_blockers(
+        {
+            "targetIssueKey": "MM-1133",
+            "assessmentArtifactPath": "artifacts/jira-implement-assessment.json",
+            "previousOutputs": {
+                "lastAssistantText": (
+                    "Assessment complete: `MM-1133` is "
+                    "**PARTIALLY_IMPLEMENTED**."
+                ),
             },
         },
         jira_service_factory=lambda: service,


### PR DESCRIPTION
## Summary
- Parse Jira assessment verdicts when the assistant includes the issue key before the canonical verdict.
- Add regressions for jira.check_blockers and jira.update_issue_status using the live "Assessment complete: `MM-1133` is **PARTIALLY_IMPLEMENTED**." wording.

## Root Cause
Workflow `mm:04cf9ea8-d2d2-4f9d-8a12-951d5ebd8e0e` failed at `tpl:jira-implement:04:83c1996b` because `jira.update_issue_status` could not find an assessment verdict. The assessment child completed cleanly, but the verdict parser only recognized verdicts placed immediately after `Assessment complete`; the live text placed `MM-1133 is` before `PARTIALLY_IMPLEMENTED`, so `jira.check_blockers` did not preserve `assessmentVerdict` for the status-update step.

## Validation
- `./tools/test_unit.sh tests/unit/workflows/temporal/test_story_output_tools.py`
