### PR TITLE
Fix MoonSpec remediation title detection

### DIFF
--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -362,6 +362,10 @@ _MOONSPEC_GATE_VERDICT_TEXT_PATTERN = re.compile(
     r")\b",
     re.IGNORECASE,
 )
+_MOONSPEC_REMEDIATION_TITLE_ATTEMPT_PATTERN = re.compile(
+    r"\b(?P<attempt>\d+)\s+of\s+(?P<max_attempts>\d+)\b",
+    re.IGNORECASE,
+)
 class RunWorkflowInput(TypedDict, total=False):
     """Input payload for the MoonMind.UserWorkflow workflow."""
 
@@ -538,6 +542,9 @@ RUN_MOONSPEC_VERIFY_REMEDIATION_INDEX_PATCH = (
     "run-moonspec-verify-remediation-index-v1"
 )
 RUN_MOONSPEC_REMEDIATION_STEP_SKIP_PATCH = "run-moonspec-remediation-step-skip-v1"
+RUN_MOONSPEC_TITLE_REMEDIATION_DETECTION_PATCH = (
+    "run-moonspec-title-remediation-detection-v1"
+)
 RUN_MOONSPEC_GATE_CONTRACT_REPAIR_PATCH = "run-moonspec-gate-contract-repair-v1"
 RUN_MOONSPEC_GATE_ENVIRONMENT_DRAFT_PUBLISH_PATCH = (
     "run-moonspec-gate-environment-draft-publish-v1"
@@ -4641,13 +4648,36 @@ class MoonMindRunWorkflow:
         annotations = node_inputs.get("annotations") or node.get("annotations")
         return annotations if isinstance(annotations, Mapping) else {}
 
+    @staticmethod
+    def _moonspec_title_remediation_detection_enabled() -> bool:
+        try:
+            workflow.info()
+        except Exception:
+            return True
+        return workflow.patched(RUN_MOONSPEC_TITLE_REMEDIATION_DETECTION_PATCH)
+
+    def _moonspec_remediation_title_role(self, node: Mapping[str, Any]) -> str:
+        if not self._moonspec_title_remediation_detection_enabled():
+            return ""
+        node_inputs = self._node_inputs_mapping(node)
+        title = (
+            str(node_inputs.get("title") or node.get("title") or "")
+            .strip()
+            .lower()
+        )
+        if title.startswith("remediate verification gaps"):
+            return "moonspec-remediation"
+        if title.startswith("verify remediation"):
+            return "moonspec-verification-gate"
+        return ""
+
     def _moonspec_step_role(self, node: Mapping[str, Any]) -> str:
         annotations = self._node_annotations_mapping(node)
         for key in ("jiraOrchestrateRole", "issueImplementRole"):
             role = str(annotations.get(key) or "").strip().lower()
             if role:
                 return role
-        return ""
+        return self._moonspec_remediation_title_role(node)
 
     @staticmethod
     def _coerce_positive_int(value: Any) -> int | None:
@@ -4670,6 +4700,22 @@ class MoonMindRunWorkflow:
         max_attempts = self._coerce_positive_int(
             annotations.get("moonSpecRemediationMaxAttempts")
         )
+        if attempt is None or max_attempts is None:
+            node_inputs = self._node_inputs_mapping(node)
+            title = str(node_inputs.get("title") or node.get("title") or "").strip()
+            if self._moonspec_remediation_title_role(node):
+                match = _MOONSPEC_REMEDIATION_TITLE_ATTEMPT_PATTERN.search(title)
+                if match:
+                    title_attempt = self._coerce_positive_int(
+                        match.group("attempt")
+                    )
+                    title_max_attempts = self._coerce_positive_int(
+                        match.group("max_attempts")
+                    )
+                    if attempt is None:
+                        attempt = title_attempt
+                    if max_attempts is None:
+                        max_attempts = title_max_attempts
         return attempt, max_attempts
 
     def _moonspec_remediation_attempt_within_budget(

--- a/tests/unit/workflows/temporal/workflows/test_run_bounded_story_loop.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_bounded_story_loop.py
@@ -265,6 +265,54 @@ def test_parent_loop_continues_to_scheduled_remediation_without_remaining_work_r
     assert decision["hasRemainingRemediationStep"] is True
     assert decision["gate"]["remainingWorkRef"] is None
 
+
+def test_parent_loop_continues_to_unannotated_issue_implement_remediation_step(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workflow = MoonMindRunWorkflow()
+    monkeypatch.setattr(
+        workflow,
+        "_moonspec_title_remediation_detection_enabled",
+        lambda: True,
+    )
+    workflow._step_ledger_rows = [
+        {"logicalStepId": "verify-implementation", "attempt": 1, "artifacts": {}}
+    ]
+    workflow._step_terminal_dispositions["verify-implementation"] = "accepted"
+
+    decision = workflow._bounded_story_loop_continuation_decision(
+        logical_step_id="verify-implementation",
+        gate_result=StepGateResult(
+            verdict="ADDITIONAL_WORK_NEEDED",
+            confidence="high",
+            recommended_next_action="reattempt_current_step",
+            target_logical_step_id="remediate-1",
+        ),
+        gate_result_ref="artifact://gate/implementation",
+        ordered_nodes=[
+            {
+                "id": "verify-implementation",
+                "inputs": {"selectedSkill": "moonspec-verify"},
+            },
+            {
+                "id": "remediate-1",
+                "skill": {"id": "auto"},
+                "inputs": {"title": "Remediate verification gaps 1 of 6"},
+            },
+            {
+                "id": "verify-remediation-1",
+                "skill": {"id": "moonspec-verify"},
+                "inputs": {"title": "Verify remediation 1 of 6"},
+            },
+        ],
+        current_index=0,
+    )
+
+    assert decision["continueLoop"] is True
+    assert decision["nextAttemptKind"] == "remediation"
+    assert decision["hasRemainingRemediationStep"] is True
+
+
 def test_parent_loop_stops_on_structured_gate_when_remediation_budget_exhausted() -> None:
     workflow = MoonMindRunWorkflow()
     workflow._step_ledger_rows = [

--- a/tests/unit/workflows/temporal/workflows/test_run_integration.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_integration.py
@@ -2925,6 +2925,67 @@ def test_moonspec_verify_gate_detects_issue_implement_remediation_role(
     )
 
 
+def test_moonspec_verify_gate_detects_unannotated_issue_implement_remediation_title(
+    mock_run_workflow: MoonMindRunWorkflow,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        mock_run_workflow,
+        "_moonspec_title_remediation_detection_enabled",
+        lambda: True,
+    )
+    ordered_nodes = [
+        {
+            "id": "verify-implementation",
+            "inputs": {
+                "title": "Verify implementation",
+                "selectedSkill": "moonspec-verify",
+            },
+        },
+        {
+            "id": "remediate-1",
+            "skill": {"id": "auto"},
+            "inputs": {"title": "Remediate verification gaps 1 of 6"},
+        },
+    ]
+
+    assert mock_run_workflow._has_remaining_moonspec_remediation_step(
+        ordered_nodes=ordered_nodes,
+        current_index=0,
+    )
+    assert mock_run_workflow._moonspec_remediation_attempt_metadata(
+        ordered_nodes[1]
+    ) == (1, 6)
+
+
+def test_moonspec_verify_gate_skips_unannotated_remediation_gate_after_pass(
+    mock_run_workflow: MoonMindRunWorkflow,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        mock_run_workflow,
+        "_moonspec_title_remediation_detection_enabled",
+        lambda: True,
+    )
+    verify_node = {
+        "id": "verify-remediation-1",
+        "skill": {"id": "moonspec-verify"},
+        "inputs": {"title": "Verify remediation 1 of 6"},
+    }
+    mock_run_workflow._moonspec_gate_verdict = "FULLY_IMPLEMENTED"
+
+    reason = mock_run_workflow._moonspec_remediation_loop_skip_reason(
+        verify_node,
+        tool_name="moonspec-verify",
+        node_inputs=verify_node["inputs"],
+    )
+
+    assert reason == (
+        "Skipped MoonSpec remediation loop step because verification already "
+        "passed with verdict FULLY_IMPLEMENTED."
+    )
+
+
 def test_moonspec_verify_text_verdict_parser_is_not_a_branch_boundary(
     mock_run_workflow: MoonMindRunWorkflow,
 ) -> None:


### PR DESCRIPTION
## Summary
- Detect MoonSpec remediation and remediation-verification steps from generated step titles when annotation metadata is absent.
- Parse remediation attempt budget from titles such as `Remediate verification gaps 1 of 6`.
- Gate the new detection with a Temporal patch marker for replay safety.

## Tests
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/workflows/test_run_integration.py tests/unit/workflows/temporal/workflows/test_run_bounded_story_loop.py`
