### PR TITLE
Handle concise Jira assessment verdicts

### DIFF
--- a/moonmind/workflows/temporal/story_output_tools.py
+++ b/moonmind/workflows/temporal/story_output_tools.py
@@ -4524,6 +4524,8 @@ def _assessment_verdict_from_text(value: Any) -> str:
     assessment_separator = r"[\s:`*_\"'\[\]\(\)]*"
     issue_ref_pattern = r"`?[A-Z][A-Z0-9]+-\d+`?"
     patterns = (
+        r"(?im)^\s*verdict\s*[:\-]\s*"
+        rf"{verdict_prefix}{verdict_pattern}{verdict_suffix}",
         r"(?is)\bassessment\s+complete\b"
         rf"{assessment_separator}"
         rf"(?:(?:for|on)\b{assessment_separator}"

--- a/tests/unit/workflows/temporal/test_story_output_tools.py
+++ b/tests/unit/workflows/temporal/test_story_output_tools.py
@@ -781,6 +781,42 @@ async def test_update_jira_issue_status_accepts_single_quoted_previous_verdict(
 
 
 @pytest.mark.asyncio
+async def test_update_jira_issue_status_accepts_concise_previous_verdict(
+    tmp_path,
+) -> None:
+    service = _FakeJiraService()
+    service.issue_responses["MM-1130"] = {
+        "key": "MM-1130",
+        "fields": {"status": {"id": "1", "name": "Backlog"}},
+    }
+    service.transition_responses["MM-1130"] = {
+        "key": "MM-1130",
+        "fields": {"status": {"id": "3", "name": "In Progress"}},
+    }
+    service.transitions_response = {
+        "transitions": [
+            {"id": "31", "name": "In Progress", "to": {"name": "In Progress"}}
+        ]
+    }
+
+    result = await update_jira_issue_status(
+        {
+            "issueKey": "MM-1130",
+            "targetStatus": "In Progress",
+            "assessmentArtifactPath": str(tmp_path / "missing-assessment.json"),
+            "previousOutputs": {
+                "lastAssistantText": "Verdict: `PARTIALLY_IMPLEMENTED`.",
+            },
+        },
+        jira_service_factory=lambda: service,
+    )
+
+    assert result.status == "COMPLETED"
+    assert result.outputs["decision"] == "transitioned"
+    assert service.transition_requests[0].transition_id == "31"
+
+
+@pytest.mark.asyncio
 async def test_update_jira_issue_status_blocks_for_malformed_assessment_artifact(
     tmp_path,
 ) -> None:
@@ -3219,6 +3255,30 @@ async def test_check_jira_blockers_preserves_issue_key_before_bold_verdict():
                     "Assessment complete: `MM-1133` is "
                     "**PARTIALLY_IMPLEMENTED**."
                 ),
+            },
+        },
+        jira_service_factory=lambda: service,
+    )
+
+    assert result.status == "COMPLETED"
+    assert result.outputs["decision"] == "continue"
+    assert result.outputs["assessmentVerdict"] == "PARTIALLY_IMPLEMENTED"
+
+
+@pytest.mark.asyncio
+async def test_check_jira_blockers_preserves_concise_previous_verdict():
+    service = _FakeJiraService()
+    service.issue_responses["MM-1130"] = {
+        "key": "MM-1130",
+        "fields": {"issuelinks": []},
+    }
+
+    result = await check_jira_blockers(
+        {
+            "targetIssueKey": "MM-1130",
+            "assessmentArtifactPath": "artifacts/jira-implement-assessment.json",
+            "previousOutputs": {
+                "lastAssistantText": "Verdict: `PARTIALLY_IMPLEMENTED`.",
             },
         },
         jira_service_factory=lambda: service,


### PR DESCRIPTION
## Summary
- Accept concise `Verdict:` assessment output when carrying Jira implementation verdicts between workflow steps.
- Add regression coverage for blocker preflight and Jira In Progress handoff when the local assessment artifact is missing but previous agent output contains `Verdict: PARTIALLY_IMPLEMENTED`.

## Root Cause
The assessment agent for MM-1130 produced `Verdict: PARTIALLY_IMPLEMENTED`, but the deterministic Jira handoff parser only recognized phrasing such as `Assessment complete: PARTIALLY_IMPLEMENTED` or JSON-shaped verdict text. The blocker step therefore failed to preserve `assessmentVerdict`, and `jira.update_issue_status` stopped with “assessment verdict ... unavailable.”

## Validation
- `MOONMIND_FORCE_LOCAL_TESTS=1 pytest tests/unit/workflows/temporal/test_story_output_tools.py -q`
- `./tools/test_unit.sh tests/unit/workflows/temporal/test_story_output_tools.py` was attempted but stopped before pytest because `tools/status_domain_audit.py` could not read local `deploy/state/desired-state.json` due filesystem permissions.
