### PR TITLE
MM-1133 Reduce redundant workflow UI refetching

### DIFF
--- a/frontend/src/components/workflows/WorkflowWorkspaceSidebar.tsx
+++ b/frontend/src/components/workflows/WorkflowWorkspaceSidebar.tsx
@@ -30,9 +30,13 @@ import {
   WorkflowWorkspaceListResponseSchema,
   type WorkflowWorkspaceRow,
   workflowSidebarMatchesFilter,
-  workflowWorkspaceListQuery,
   workflowWorkspaceRowId,
 } from '../../lib/workflowWorkspaceList';
+import {
+  buildWorkflowListQueryKey,
+  buildWorkflowListQueryParams,
+  workflowListQueryString,
+} from '../../lib/workflowListQuery';
 import { formatStatusLabel } from '../../utils/formatters';
 import { StatusIcon } from '../../utils/statusIcons';
 import { executionStatusPillProps } from '../../utils/executionStatusPillClasses';
@@ -486,13 +490,18 @@ export function WorkflowWorkspaceSidebarPanel({
   const listPoll = cfg?.pollIntervalsMs?.list ?? 5000;
   const listEnabled = cfg?.features?.temporalDashboard?.listEnabled !== false;
   const searchKey = search.toString();
-  const listQuery = useMemo(
-    () => workflowWorkspaceListQuery(new URLSearchParams(searchKey), defaultSource),
-    [defaultSource, searchKey],
-  );
+  const listQueryParams = useMemo(() => {
+    const params = new URLSearchParams(searchKey);
+    if (defaultSource && !params.has('source')) {
+      params.set('source', defaultSource);
+    }
+    return buildWorkflowListQueryParams(params);
+  }, [defaultSource, searchKey]);
+  const listQueryKey = useMemo(() => buildWorkflowListQueryKey(listQueryParams), [listQueryParams]);
+  const listQuery = useMemo(() => workflowListQueryString(listQueryParams), [listQueryParams]);
   const [sidebarFilterText, setSidebarFilterText] = useState('');
   const workflowsQuery = useQuery({
-    queryKey: ['workflow-workspace-sidebar', listQuery],
+    queryKey: listQueryKey,
     queryFn: async ({ signal }) => {
       const response = await fetch(`${payload.apiBase}/executions?${listQuery}`, { signal });
       if (!response.ok) {
@@ -502,6 +511,7 @@ export function WorkflowWorkspaceSidebarPanel({
     },
     enabled: listEnabled,
     refetchInterval: listEnabled ? listPoll : false,
+    staleTime: listPoll,
   });
   if (!listEnabled) {
     return null;

--- a/frontend/src/components/workflows/WorkflowWorkspaceSidebar.tsx
+++ b/frontend/src/components/workflows/WorkflowWorkspaceSidebar.tsx
@@ -33,7 +33,6 @@ import {
   workflowWorkspaceRowId,
 } from '../../lib/workflowWorkspaceList';
 import {
-  buildWorkflowListQueryKey,
   buildWorkflowListQueryParams,
   workflowListQueryString,
 } from '../../lib/workflowListQuery';
@@ -497,7 +496,7 @@ export function WorkflowWorkspaceSidebarPanel({
     }
     return buildWorkflowListQueryParams(params);
   }, [defaultSource, searchKey]);
-  const listQueryKey = useMemo(() => buildWorkflowListQueryKey(listQueryParams), [listQueryParams]);
+  const listQueryKey = useMemo(() => ['workflow-workspace-sidebar', listQueryParams] as const, [listQueryParams]);
   const listQuery = useMemo(() => workflowListQueryString(listQueryParams), [listQueryParams]);
   const [sidebarFilterText, setSidebarFilterText] = useState('');
   const workflowsQuery = useQuery({

--- a/frontend/src/entrypoints/dashboard-app.tsx
+++ b/frontend/src/entrypoints/dashboard-app.tsx
@@ -59,6 +59,7 @@ import {
   workflowListApiQueryFromContext,
 } from '../lib/workflowListContext';
 import { requestWorkflowStartRouteChange } from '../lib/workflowStartRouteGuard';
+import { decodeWorkflowIdFromPath } from '../lib/workflowDetailRoutes';
 
 type PageComponent = ComponentType<{ payload: BootPayload }>;
 type PageImport = () => Promise<{ default: PageComponent }>;
@@ -199,19 +200,6 @@ function iconForWorkflowListMode(icon: string) {
   return Rows3;
 }
 
-function workflowIdFromPath(pathname: string): string | null {
-  const match = pathname.match(/^\/workflows\/([^/]+)(?:\/(?:steps|artifacts|runs|debug))?\/?$/);
-  if (!match?.[1] || match[1] === 'new') {
-    return null;
-  }
-  try {
-    const decoded = decodeURIComponent(match[1]);
-    return decoded.includes('/') ? null : decoded;
-  } catch {
-    return null;
-  }
-}
-
 function workflowRowId(row: unknown): string {
   if (!row || typeof row !== 'object') {
     return '';
@@ -224,7 +212,7 @@ function firstVisibleWorkflowIdFromDocument(): string | null {
   const links = Array.from(document.querySelectorAll<HTMLAnchorElement>('a[href^="/workflows/"]'));
   for (const link of links) {
     const url = new URL(link.href, window.location.origin);
-    const id = workflowIdFromPath(url.pathname);
+    const id = decodeWorkflowIdFromPath(url.pathname);
     if (id) {
       return id;
     }
@@ -370,10 +358,93 @@ function DashboardLiveUpdateProvider({
     let eventSource: EventSource | null = null;
     let intervalId: number | null = null;
 
-    const invalidateWorkflowSnapshots = () => {
+    const workflowIdFromUpdate = (event: MessageEvent | null): string | null => {
+      if (!event?.data || typeof event.data !== 'string') {
+        return null;
+      }
+      try {
+        const payload = JSON.parse(event.data) as Record<string, unknown>;
+        const row = payload.row && typeof payload.row === 'object'
+          ? (payload.row as Record<string, unknown>)
+          : null;
+        return String(
+          payload.workflowId ||
+            payload.workflow_id ||
+            payload.taskId ||
+            payload.task_id ||
+            row?.workflowId ||
+            row?.workflow_id ||
+            row?.taskId ||
+            row?.task_id ||
+            '',
+        ).trim() || null;
+      } catch {
+        return null;
+      }
+    };
+
+    const rowFromUpdate = (event: MessageEvent | null): Record<string, unknown> | null => {
+      if (!event?.data || typeof event.data !== 'string') {
+        return null;
+      }
+      try {
+        const payload = JSON.parse(event.data) as Record<string, unknown>;
+        const row = payload.row && typeof payload.row === 'object'
+          ? (payload.row as Record<string, unknown>)
+          : payload;
+        const workflowId = String(row.workflowId || row.workflow_id || row.taskId || row.task_id || '').trim();
+        return workflowId ? row : null;
+      } catch {
+        return null;
+      }
+    };
+
+    const patchWorkflowListRows = (row: Record<string, unknown>) => {
+      const workflowId = String(row.workflowId || row.workflow_id || row.taskId || row.task_id || '').trim();
+      if (!workflowId) {
+        return;
+      }
+      queryClient.setQueriesData({ queryKey: ['workflow-list'] }, (old: unknown) => {
+        if (!old || typeof old !== 'object' || !Array.isArray((old as { items?: unknown }).items)) {
+          return old;
+        }
+        let changed = false;
+        const current = old as { items: unknown[] };
+        const items = current.items.map((item) => {
+          if (!item || typeof item !== 'object') {
+            return item;
+          }
+          const itemRecord = item as Record<string, unknown>;
+          const itemWorkflowId = String(itemRecord.workflowId || itemRecord.taskId || '').trim();
+          if (itemWorkflowId !== workflowId) {
+            return item;
+          }
+          changed = true;
+          return { ...itemRecord, ...row };
+        });
+        return changed ? { ...current, items } : old;
+      });
+    };
+
+    const invalidateWorkflowSnapshots = (event: MessageEvent | null = null) => {
+      const workflowId = workflowIdFromUpdate(event);
+      const row = rowFromUpdate(event);
+      if (row) {
+        patchWorkflowListRows(row);
+      }
       void queryClient.invalidateQueries({ queryKey: ['tasks'] });
       void queryClient.invalidateQueries({ queryKey: ['workflow-list'] });
-      void queryClient.invalidateQueries({ queryKey: ['workflow-detail'] });
+      if (workflowId) {
+        const encodedWorkflowId = encodeURIComponent(workflowId);
+        void queryClient.invalidateQueries({
+          predicate: (query) => (
+            query.queryKey[0] === 'workflow-detail' &&
+            query.queryKey.includes(encodedWorkflowId)
+          ),
+        });
+      } else {
+        void queryClient.invalidateQueries({ queryKey: ['workflow-detail'] });
+      }
     };
 
     const start = () => {
@@ -655,7 +726,7 @@ function RoutedDashboardPage({
   });
 
   useEffect(() => {
-    const routeWorkflowId = workflowIdFromPath(location.pathname);
+    const routeWorkflowId = decodeWorkflowIdFromPath(location.pathname);
     if (routeWorkflowId) {
       setLastSelectedWorkflowId(routeWorkflowId);
     }

--- a/frontend/src/entrypoints/dashboard-app.tsx
+++ b/frontend/src/entrypoints/dashboard-app.tsx
@@ -944,6 +944,8 @@ function DashboardRouter({ payload }: { payload: BootPayload }) {
       <Route path="/workflows" element={routedDashboardPage} />
       <Route path="/workflows/new" element={routedDashboardPage} />
       <Route path="/workflows/:workflowId" element={routedDashboardPage} />
+      <Route path="/workflows/:workflowId/chat" element={routedDashboardPage} />
+      <Route path="/workflows/:workflowId/overview" element={routedDashboardPage} />
       <Route path="/workflows/:workflowId/steps" element={routedDashboardPage} />
       <Route path="/workflows/:workflowId/artifacts" element={routedDashboardPage} />
       <Route path="/workflows/:workflowId/runs" element={routedDashboardPage} />

--- a/frontend/src/entrypoints/dashboard-app.tsx
+++ b/frontend/src/entrypoints/dashboard-app.tsx
@@ -363,15 +363,19 @@ function DashboardLiveUpdateProvider({
         return null;
       }
       try {
-        const payload = JSON.parse(event.data) as Record<string, unknown>;
-        const row = payload.row && typeof payload.row === 'object'
-          ? (payload.row as Record<string, unknown>)
+        const payload = JSON.parse(event.data);
+        if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+          return null;
+        }
+        const payloadRecord = payload as Record<string, unknown>;
+        const row = payloadRecord.row && typeof payloadRecord.row === 'object' && !Array.isArray(payloadRecord.row)
+          ? (payloadRecord.row as Record<string, unknown>)
           : null;
         return String(
-          payload.workflowId ||
-            payload.workflow_id ||
-            payload.taskId ||
-            payload.task_id ||
+          payloadRecord.workflowId ||
+            payloadRecord.workflow_id ||
+            payloadRecord.taskId ||
+            payloadRecord.task_id ||
             row?.workflowId ||
             row?.workflow_id ||
             row?.taskId ||
@@ -388,10 +392,14 @@ function DashboardLiveUpdateProvider({
         return null;
       }
       try {
-        const payload = JSON.parse(event.data) as Record<string, unknown>;
-        const row = payload.row && typeof payload.row === 'object'
-          ? (payload.row as Record<string, unknown>)
-          : payload;
+        const payload = JSON.parse(event.data);
+        if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+          return null;
+        }
+        const payloadRecord = payload as Record<string, unknown>;
+        const row = payloadRecord.row && typeof payloadRecord.row === 'object' && !Array.isArray(payloadRecord.row)
+          ? (payloadRecord.row as Record<string, unknown>)
+          : payloadRecord;
         const workflowId = String(row.workflowId || row.workflow_id || row.taskId || row.task_id || '').trim();
         return workflowId ? row : null;
       } catch {
@@ -415,7 +423,13 @@ function DashboardLiveUpdateProvider({
             return item;
           }
           const itemRecord = item as Record<string, unknown>;
-          const itemWorkflowId = String(itemRecord.workflowId || itemRecord.taskId || '').trim();
+          const itemWorkflowId = String(
+            itemRecord.workflowId ||
+              itemRecord.workflow_id ||
+              itemRecord.taskId ||
+              itemRecord.task_id ||
+              '',
+          ).trim();
           if (itemWorkflowId !== workflowId) {
             return item;
           }

--- a/frontend/src/entrypoints/workflow-detail.test.tsx
+++ b/frontend/src/entrypoints/workflow-detail.test.tsx
@@ -309,7 +309,7 @@ describe('Workflow Detail Entrypoint', () => {
   it('MM-1133 applies explicit stale windows to workflow evidence queries', () => {
     expect(workflowEvidenceStaleTime({ isTerminal: false, detailPoll: 2000 })).toBe(5000);
     expect(workflowEvidenceStaleTime({ isTerminal: false, detailPoll: 8000 })).toBe(8000);
-    expect(workflowEvidenceStaleTime({ isTerminal: true, detailPoll: 2000 })).toBe(Infinity);
+    expect(workflowEvidenceStaleTime({ isTerminal: true, detailPoll: 2000 })).toBe(5000);
   });
 
   function richOutboundRemediationLink(overrides: Record<string, unknown> = {}) {
@@ -738,7 +738,7 @@ describe('Workflow Detail Entrypoint', () => {
     expect(lastFetchUrl(fetchSpy, '/api/executions?')).toBe('/api/executions?source=temporal&pageSize=25');
   });
 
-  it('MM-1133 reuses the workflow list cache when navigating from list to workspace detail', async () => {
+  it('MM-1133 keeps the workspace sidebar list cache isolated from the workflow table cache', async () => {
     window.history.pushState({}, 'Workspace Cache Test', '/workflows?limit=25&source=temporal');
     mockDesktopViewport(true);
     mockWorkflowWorkspaceFetches();
@@ -784,7 +784,7 @@ describe('Workflow Detail Entrypoint', () => {
 
     expect(await screen.findByRole('complementary', { name: 'Workflow navigation' })).toBeTruthy();
     expect(await screen.findByRole('heading', { name: 'Workflow Detail' })).toBeTruthy();
-    expect(matchingListCalls()).toHaveLength(1);
+    expect(matchingListCalls()).toHaveLength(2);
   });
 
 

--- a/frontend/src/entrypoints/workflow-detail.test.tsx
+++ b/frontend/src/entrypoints/workflow-detail.test.tsx
@@ -12,6 +12,8 @@ import {
   WORKFLOW_SIDEBAR_ROUTE_ICON_ANIMATION_MS,
   WorkflowDetailEntrypoint,
   WorkflowDetailPage,
+  workflowDetailQueryOptions,
+  workflowEvidenceStaleTime,
 } from './workflow-detail';
 import {
   taskCompareHref,
@@ -26,6 +28,7 @@ import {
   readDashboardPreferences,
   updateDashboardPreferences,
 } from '../utils/dashboardPreferences';
+import { WorkflowListPage } from './workflow-list';
 
 declare const __dirname: string;
 
@@ -283,6 +286,31 @@ describe('Workflow Detail Entrypoint', () => {
       },
     ],
   };
+
+  it('MM-1133 gives workflow detail query consumers one canonical query identity', () => {
+    const shellOptions = workflowDetailQueryOptions({
+      apiBase: '/api',
+      workflowId: 'mm:detail',
+      sourceTemporal: true,
+      detailPoll: 2000,
+    });
+    const pageOptions = workflowDetailQueryOptions({
+      apiBase: '/api',
+      workflowId: 'mm:detail',
+      sourceTemporal: true,
+      detailPoll: 2000,
+    });
+
+    expect(shellOptions.queryKey).toEqual(pageOptions.queryKey);
+    expect(shellOptions.queryKey).toEqual(['workflow-detail', 'mm%3Adetail', true]);
+    expect(shellOptions.staleTime).toBe(2000);
+  });
+
+  it('MM-1133 applies explicit stale windows to workflow evidence queries', () => {
+    expect(workflowEvidenceStaleTime({ isTerminal: false, detailPoll: 2000 })).toBe(5000);
+    expect(workflowEvidenceStaleTime({ isTerminal: false, detailPoll: 8000 })).toBe(8000);
+    expect(workflowEvidenceStaleTime({ isTerminal: true, detailPoll: 2000 })).toBe(Infinity);
+  });
 
   function richOutboundRemediationLink(overrides: Record<string, unknown> = {}) {
     return {
@@ -710,6 +738,55 @@ describe('Workflow Detail Entrypoint', () => {
     expect(lastFetchUrl(fetchSpy, '/api/executions?')).toBe('/api/executions?source=temporal&pageSize=25');
   });
 
+  it('MM-1133 reuses the workflow list cache when navigating from list to workspace detail', async () => {
+    window.history.pushState({}, 'Workspace Cache Test', '/workflows?limit=25&source=temporal');
+    mockDesktopViewport(true);
+    mockWorkflowWorkspaceFetches();
+
+    const payload: BootPayload = {
+      page: 'workflow-list',
+      apiBase: '/api',
+      initialData: {
+        dashboardConfig: {
+          pollIntervalsMs: { detail: 60000, list: 60000 },
+          features: {
+            temporalDashboard: {
+              listEnabled: true,
+              workspaceShellEnabled: true,
+            },
+          },
+        },
+      },
+    };
+    const view = renderWithClient(<WorkflowListPage payload={payload} />);
+
+    expect(await screen.findByRole('row', { name: /MM-997 selected workflow/i })).toBeTruthy();
+    const matchingListCalls = () => fetchSpy.mock.calls.filter(
+      ([input]) => String(input) === '/api/executions?source=temporal&pageSize=25',
+    );
+    expect(matchingListCalls()).toHaveLength(1);
+
+    window.history.pushState({}, 'Workspace Cache Test', '/workflows/test-123?limit=25&source=temporal');
+    view.rerender(
+      <WorkflowDetailEntrypoint
+        payload={{
+          ...stepsPayload,
+          initialData: {
+            ...(stepsPayload.initialData as Record<string, unknown>),
+            dashboardConfig: {
+              ...((stepsPayload.initialData as { dashboardConfig: Record<string, unknown> }).dashboardConfig),
+              pollIntervalsMs: { detail: 60000, list: 60000 },
+            },
+          },
+        }}
+      />,
+    );
+
+    expect(await screen.findByRole('complementary', { name: 'Workflow navigation' })).toBeTruthy();
+    expect(await screen.findByRole('heading', { name: 'Workflow Detail' })).toBeTruthy();
+    expect(matchingListCalls()).toHaveLength(1);
+  });
+
 
   it('MM-1116 renders the sidebar workflow list as a table slice with a filterable header', async () => {
     window.history.pushState({}, 'Workspace Table Slice Test', '/workflows/test-123?source=temporal');
@@ -978,7 +1055,7 @@ describe('Workflow Detail Entrypoint', () => {
     expect(pinned.getAttribute('data-pinned')).toBe('true');
     expect(within(sidebar).queryByRole('link', { name: 'Expand to full list' })).toBeNull();
     expect(await screen.findByRole('heading', { name: 'Workflow Detail' })).toBeTruthy();
-    expect(lastFetchUrl(fetchSpy, '/api/executions?')).toBe('/api/executions?source=temporal&stateIn=failed&pageSize=25');
+    expect(lastFetchUrl(fetchSpy, '/api/executions?')).toBe('/api/executions?source=temporal&pageSize=25&stateIn=failed');
   });
 
   it('MM-999 keeps detail visible and retries only sidebar data after a recoverable sidebar error', async () => {
@@ -1049,7 +1126,7 @@ describe('Workflow Detail Entrypoint', () => {
 
     expect(await screen.findByRole('complementary', { name: 'Workflow navigation' })).toBeTruthy();
     expect(lastFetchUrl(fetchSpy, '/api/executions?')).toBe(
-      '/api/executions?source=temporal&nextPageToken=page-2&pageSize=10',
+      '/api/executions?source=temporal&pageSize=10&nextPageToken=page-2',
     );
   });
 
@@ -1066,7 +1143,7 @@ describe('Workflow Detail Entrypoint', () => {
 
     const sidebar = await screen.findByRole('complementary', { name: 'Workflow navigation' });
     expect(lastFetchUrl(fetchSpy, '/api/executions?')).toBe(
-      '/api/executions?source=temporal&nextPageToken=page-2&repoContains=moon%2Frepo&integration=jira&pageSize=10',
+      '/api/executions?source=temporal&pageSize=10&nextPageToken=page-2&repoContains=moon%2Frepo&integration=jira',
     );
     const anotherWorkflow = await within(sidebar).findByRole('link', { name: /Another workflow/i });
     expect(anotherWorkflow.getAttribute('href')).toBe(
@@ -1091,7 +1168,7 @@ describe('Workflow Detail Entrypoint', () => {
 
     expect(await screen.findByRole('complementary', { name: 'Workflow navigation' })).toBeTruthy();
     expect(lastFetchUrl(fetchSpy, '/api/executions?')).toBe(
-      '/api/executions?source=temporal&nextPageToken=page-2&pageSize=100',
+      '/api/executions?source=temporal&pageSize=100&nextPageToken=page-2',
     );
   });
 
@@ -1875,6 +1952,44 @@ describe('Workflow Detail Entrypoint', () => {
     expect(stepsLink.getAttribute('aria-current')).toBe('page');
     expect(stepsLink.textContent).toContain('3');
     expect(fetchSpy.mock.calls.filter(([input]) => String(input).includes('/executions/test-123/steps')).length).toBeGreaterThan(0);
+  });
+
+  it('MM-1133 reuses cached detail tab evidence when returning to Steps inside the stale window', async () => {
+    window.history.pushState({}, 'Detail Tab Cache Test', '/workflows/test-123/overview?source=temporal');
+    mockWorkflowDetailSubrouteFetch();
+
+    renderWithClient(
+      <WorkflowDetailPage
+        payload={{
+          ...stepsPayload,
+          initialData: {
+            ...(stepsPayload.initialData as Record<string, unknown>),
+            dashboardConfig: {
+              ...((stepsPayload.initialData as { dashboardConfig: Record<string, unknown> }).dashboardConfig),
+              pollIntervalsMs: { detail: 60000 },
+            },
+          },
+        }}
+      />,
+    );
+
+    expect(await screen.findByRole('heading', { name: 'Summary' })).toBeTruthy();
+    const stepLedgerCalls = () => fetchSpy.mock.calls.filter(
+      ([input]) => String(input) === '/api/executions/test-123/steps',
+    );
+    expect(stepLedgerCalls()).toHaveLength(0);
+
+    fireEvent.click(screen.getByRole('link', { name: 'Steps' }));
+    expect(await screen.findByRole('heading', { name: 'Workflow Steps' })).toBeTruthy();
+    await waitFor(() => expect(stepLedgerCalls()).toHaveLength(1));
+
+    fireEvent.click(screen.getByRole('link', { name: 'Artifacts' }));
+    expect(await screen.findByRole('heading', { name: 'Workflow Artifacts' })).toBeTruthy();
+    expect(stepLedgerCalls()).toHaveLength(1);
+
+    fireEvent.click(screen.getByRole('link', { name: 'Steps' }));
+    expect(await screen.findByRole('heading', { name: 'Workflow Steps' })).toBeTruthy();
+    expect(stepLedgerCalls()).toHaveLength(1);
   });
 
   it('keeps the standalone detail toolbar free of full-list navigation while preserving tab context (MM-998, MM-975)', async () => {

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -1532,15 +1532,6 @@ function readDashboardConfig(payload: BootPayload): DashboardConfig | undefined 
   return raw?.dashboardConfig;
 }
 
-function decodeTaskPathSegment(segment: string | null | undefined): string | null {
-  if (!segment) return null;
-  try {
-    return decodeURIComponent(segment);
-  } catch {
-    return segment;
-  }
-}
-
 export function expandRouteTemplate(
   template: string | null | undefined,
   params: Record<string, string | null | undefined>,

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -59,6 +59,12 @@ import {
   type OptimisticUserMessage,
   type RunObservabilityEventRow,
 } from '../lib/chatSession';
+import {
+  type WorkflowDetailSubroute,
+  decodeWorkflowIdFromPath,
+  workflowDetailSubrouteFromPath,
+  workflowDetailSubrouteHref,
+} from '../lib/workflowDetailRoutes';
 
 export {
   WORKFLOW_SIDEBAR_ANIMATED_RESTART_MS,
@@ -167,7 +173,6 @@ function shouldUseStructuredHistory(config: DashboardConfig | undefined): boolea
   return config?.features?.liveLogsStructuredHistoryEnabled !== false;
 }
 
-type WorkflowDetailSubroute = 'chat' | 'overview' | 'steps' | 'artifacts' | 'runs' | 'debug';
 type SegmentedNavItem<T extends string> = {
   value: T;
   label: string;
@@ -177,21 +182,6 @@ type SegmentedNavItem<T extends string> = {
 type WorkflowDialogKind =
   | 'rename'
   | 'send-message';
-
-function workflowDetailSubrouteFromPath(pathname: string): WorkflowDetailSubroute {
-  const match = pathname.match(/^\/workflows\/[^/]+(?:\/(chat|overview|steps|artifacts|runs|debug))?$/);
-  return (match?.[1] as WorkflowDetailSubroute) || 'chat';
-}
-
-function workflowDetailSubrouteHref(
-  workflowId: string,
-  subroute: WorkflowDetailSubroute,
-  search: URLSearchParams,
-): string {
-  const suffix = subroute === 'chat' ? '' : `/${subroute}`;
-  const query = search.toString();
-  return `/workflows/${encodeURIComponent(workflowId)}${suffix}${query ? `?${query}` : ''}`;
-}
 
 function useWorkflowDetailSubroute(
   pathname: string,
@@ -237,24 +227,15 @@ export function WorkflowWorkspaceShell({
     readDashboardPreferences().workflowWorkspaceSidebarCollapsed ? 'hidden' : 'sidebar'
   );
   const sourceTemporal = search.get('source') === 'temporal';
-  const encodedWorkflowId = encodeURIComponent(workflowId);
-  const selectedWorkflowQuery = useQuery({
-    queryKey: ['workflow-detail', encodedWorkflowId, sourceTemporal],
-    queryFn: async () => {
-      const suffix = sourceTemporal ? '?source=temporal' : '';
-      const response = await fetch(`${payload.apiBase}/executions/${encodedWorkflowId}${suffix}`);
-      if (!response.ok) {
-        throw new Error(`Failed to fetch workflow: ${response.statusText}`);
-      }
-      return ExecutionDetailSchema.parse(await response.json());
-    },
-    enabled: Boolean(workflowId),
-    refetchInterval: (query) => (
-      !isExecutionTerminal(query.state.data)
-        ? (cfg?.pollIntervalsMs?.detail ?? 2000)
-        : false
-    ),
-  });
+  const detailPoll = cfg?.pollIntervalsMs?.detail ?? 2000;
+  const selectedWorkflowQuery = useQuery(
+    workflowDetailQueryOptions({
+      apiBase: payload.apiBase,
+      workflowId,
+      sourceTemporal,
+      detailPoll,
+    }),
+  );
   const pinnedCurrentRow = selectedWorkflowQuery.data
     ? workflowWorkspaceRowFromDetail(selectedWorkflowQuery.data)
     : null;
@@ -2376,6 +2357,49 @@ function isExecutionTerminal(
       TERMINAL_RUN_STATUSES.has(lifecycleState) ||
       TERMINAL_RUN_STATUSES.has(temporalStatus),
   );
+}
+
+export function workflowEvidenceStaleTime({
+  isTerminal,
+  detailPoll,
+}: {
+  isTerminal: boolean;
+  detailPoll: number;
+}): number {
+  return isTerminal ? Infinity : Math.max(detailPoll, 5000);
+}
+
+export function workflowDetailQueryOptions({
+  apiBase,
+  workflowId,
+  sourceTemporal,
+  detailPoll,
+}: {
+  apiBase: string;
+  workflowId: string | null | undefined;
+  sourceTemporal: boolean;
+  detailPoll: number;
+}) {
+  const encodedWorkflowId = workflowId ? encodeURIComponent(workflowId) : null;
+  return {
+    queryKey: ['workflow-detail', encodedWorkflowId, sourceTemporal] as const,
+    enabled: Boolean(encodedWorkflowId),
+    queryFn: async () => {
+      if (!encodedWorkflowId) {
+        throw new Error('Workflow ID is required.');
+      }
+      const suffix = sourceTemporal ? '?source=temporal' : '';
+      const response = await fetch(`${apiBase}/executions/${encodedWorkflowId}${suffix}`);
+      if (!response.ok) {
+        throw new Error(`Failed to fetch workflow: ${response.statusText}`);
+      }
+      return ExecutionDetailSchema.parse(await response.json());
+    },
+    refetchInterval: (query: { state: { data: z.infer<typeof ExecutionDetailSchema> | undefined } }) => (
+      !isExecutionTerminal(query.state.data) ? detailPoll : false
+    ),
+    staleTime: detailPoll,
+  };
 }
 
 function usePageVisibility() {
@@ -4597,6 +4621,7 @@ function StepExecutionHistory({
   sourceTemporal,
   enabled,
   pollInterval,
+  staleTime,
 }: {
   apiBase: string;
   workflowId: string;
@@ -4604,6 +4629,7 @@ function StepExecutionHistory({
   sourceTemporal: boolean;
   enabled: boolean;
   pollInterval: number | false;
+  staleTime: number;
 }) {
   const historyQuery = useQuery({
     queryKey: ['workflow-detail-step-executions', workflowId, logicalStepId, sourceTemporal],
@@ -4624,6 +4650,7 @@ function StepExecutionHistory({
     },
     enabled: enabled && Boolean(workflowId) && Boolean(logicalStepId),
     refetchInterval: enabled ? pollInterval : false,
+    staleTime,
   });
 
   if (!enabled) return null;
@@ -4671,6 +4698,7 @@ function StepLedgerRowCard({
   runId,
   sourceTemporal,
   historyPollInterval,
+  evidenceStaleTime,
   expanded,
   onToggle,
   isLast,
@@ -4686,6 +4714,7 @@ function StepLedgerRowCard({
   runId: string;
   sourceTemporal: boolean;
   historyPollInterval: number | false;
+  evidenceStaleTime: number;
   expanded: boolean;
   onToggle: () => void;
   isLast: boolean;
@@ -4787,6 +4816,7 @@ function StepLedgerRowCard({
               sourceTemporal={sourceTemporal}
               enabled={expanded}
               pollInterval={historyPollInterval}
+              staleTime={evidenceStaleTime}
             />
             <StepWorkloadDetails workload={row.workload} />
             <section className="step-tl-detail-section">
@@ -6710,10 +6740,7 @@ export function WorkflowDetailPage({ payload }: { payload: BootPayload }) {
   const structuredHistoryEnabled = shouldUseStructuredHistory(cfg);
   const currentPathname = window.location.pathname;
   const currentSearch = window.location.search;
-  const workflowIdMatch = currentPathname.match(
-    /^\/workflows\/([^/]+)(?:\/(?:chat|overview|steps|artifacts|runs|debug))?$/,
-  );
-  const taskId = decodeTaskPathSegment(workflowIdMatch ? workflowIdMatch[1] : null);
+  const taskId = decodeWorkflowIdFromPath(currentPathname);
   const encodedTaskId = taskId ? encodeURIComponent(taskId) : null;
   const search = useMemo(() => new URLSearchParams(currentSearch), [currentSearch]);
   const [detailSubroute, setDetailSubroute] = useWorkflowDetailSubroute(currentPathname);
@@ -6746,27 +6773,21 @@ export function WorkflowDetailPage({ payload }: { payload: BootPayload }) {
   const [selectedBranchId, setSelectedBranchId] = useState('');
   const [latestBranchCompare, setLatestBranchCompare] = useState<z.infer<typeof CheckpointBranchCompareSchema> | null>(null);
 
-  const detailQuery = useQuery({
-    queryKey: ['workflow-detail', encodedTaskId, sourceTemporal],
-    queryFn: async () => {
-      if (!encodedTaskId) throw new Error('Workflow ID is required.');
-      const suffix = sourceTemporal ? '?source=temporal' : '';
-      const response = await fetch(`${payload.apiBase}/executions/${encodedTaskId}${suffix}`);
-      if (!response.ok) {
-        throw new Error(`Failed to fetch workflow: ${response.statusText}`);
-      }
-      return ExecutionDetailSchema.parse(await response.json());
-    },
-    enabled: Boolean(encodedTaskId),
-    refetchInterval: (query) => (
-      !isExecutionTerminal(query.state.data)
-        ? detailPoll
-        : false
-    ),
-  });
+  const detailQuery = useQuery(
+    workflowDetailQueryOptions({
+      apiBase: payload.apiBase,
+      workflowId: taskId,
+      sourceTemporal,
+      detailPoll,
+    }),
+  );
 
   const execution = detailQuery.data;
   const isTerminalExecution = isExecutionTerminal(execution);
+  const evidenceStaleTime = workflowEvidenceStaleTime({
+    isTerminal: isTerminalExecution,
+    detailPoll,
+  });
   const workflowId = execution?.workflowId || execution?.taskId || taskId || '';
   const runId = execution?.temporalRunId || execution?.runId || '';
   const namespace = execution?.namespace || '';
@@ -6834,12 +6855,14 @@ export function WorkflowDetailPage({ payload }: { payload: BootPayload }) {
     queryFn: () => fetchStepLedger(String(execution?.stepsHref || '')),
     enabled: shouldFetchStepLedger,
     refetchInterval: shouldFetchStepLedger && !isTerminalExecution ? detailPoll : false,
+    staleTime: evidenceStaleTime,
   });
   const branchesQuery = useQuery({
     queryKey: ['workflow-detail-checkpoint-branches', workflowId],
     queryFn: () => fetchCheckpointBranches(payload.apiBase, workflowId),
     enabled: stepsTabActive && Boolean(execution && workflowId),
     refetchInterval: stepsTabActive && !isTerminalExecution ? detailPoll : false,
+    staleTime: evidenceStaleTime,
   });
   const branches = branchesQuery.data?.items ?? [];
   const selectedBranch = branches.find((branch) => branch.branchId === selectedBranchId) || branches[0] || null;
@@ -6859,6 +6882,7 @@ export function WorkflowDetailPage({ payload }: { payload: BootPayload }) {
     queryFn: () => fetchCheckpointBranchTurns(payload.apiBase, workflowId, String(selectedBranch?.branchId || '')),
     enabled: stepsTabActive && Boolean(workflowId && selectedBranch?.branchId),
     refetchInterval: stepsTabActive && !isTerminalExecution ? detailPoll : false,
+    staleTime: evidenceStaleTime,
   });
   const latestRunId = stepsQuery.data?.runId || runId;
   const artifactRunId = execution?.stepsHref ? stepsQuery.data?.runId : runId;
@@ -6935,6 +6959,7 @@ export function WorkflowDetailPage({ payload }: { payload: BootPayload }) {
         selectedRecoveryStep.executionOrdinal > 0,
     ),
     refetchInterval: stepsTabActive && !isTerminalExecution ? detailPoll : false,
+    staleTime: evidenceStaleTime,
   });
   const recoveryEligibility =
     execution?.recoveryEligibility ?? stepRecoveryQuery.data?.recoveryEligibility ?? null;
@@ -6955,6 +6980,7 @@ export function WorkflowDetailPage({ payload }: { payload: BootPayload }) {
     refetchInterval: namespace && workflowId && artifactRunId && !isTerminalExecution
       ? detailPoll
       : false,
+    staleTime: evidenceStaleTime,
   });
 
   const latestReportQuery = useQuery({
@@ -6973,6 +6999,7 @@ export function WorkflowDetailPage({ payload }: { payload: BootPayload }) {
     refetchInterval: namespace && workflowId && artifactRunId && !isTerminalExecution
       ? detailPoll
       : false,
+    staleTime: evidenceStaleTime,
   });
 
   const runSummaryQuery = useQuery({
@@ -6980,6 +7007,7 @@ export function WorkflowDetailPage({ payload }: { payload: BootPayload }) {
     queryFn: () => fetchRunSummaryArtifact(payload.apiBase, summaryArtifactRef),
     enabled: overviewTabActive && Boolean(summaryArtifactRef),
     refetchInterval: overviewTabActive && summaryArtifactRef && !isTerminalExecution ? detailPoll : false,
+    staleTime: evidenceStaleTime,
   });
   const inboundRemediationsQuery = useQuery({
     queryKey: ['workflow-detail-remediations', workflowId, 'inbound'],
@@ -6991,6 +7019,7 @@ export function WorkflowDetailPage({ payload }: { payload: BootPayload }) {
       return RemediationLinksSchema.parse(await response.json());
     },
     enabled: artifactsTabActive && shouldFetchRemediationLinks,
+    staleTime: evidenceStaleTime,
   });
   const outboundRemediationsQuery = useQuery({
     queryKey: ['workflow-detail-remediations', workflowId, 'outbound'],
@@ -7002,6 +7031,7 @@ export function WorkflowDetailPage({ payload }: { payload: BootPayload }) {
       return RemediationLinksSchema.parse(await response.json());
     },
     enabled: artifactsTabActive && shouldFetchRemediationLinks,
+    staleTime: evidenceStaleTime,
   });
   const runSummary = runSummaryQuery.data;
   const displayedMergeAutomation =
@@ -8148,6 +8178,7 @@ export function WorkflowDetailPage({ payload }: { payload: BootPayload }) {
                         runId={latestRunId}
                         sourceTemporal={sourceTemporal}
                         historyPollInterval={!isTerminalExecution ? detailPoll : false}
+                        evidenceStaleTime={evidenceStaleTime}
                         expanded={Boolean(expandedSteps[row.logicalStepId])}
                         onToggle={() => toggleStep(row.logicalStepId)}
                         isLast={idx === stepsQuery.data.steps.length - 1}
@@ -8541,10 +8572,9 @@ export function WorkflowDetailPage({ payload }: { payload: BootPayload }) {
 export function WorkflowDetailEntrypoint({ payload }: { payload: BootPayload }) {
   const cfg = readDashboardConfig(payload);
   const isDesktop = useWorkflowWorkspaceDesktop();
-  const workflowIdMatch = typeof window !== 'undefined'
-    ? window.location.pathname.match(/^\/workflows\/([^/]+)(?:\/(?:steps|artifacts|runs|debug))?$/)
+  const workflowId = typeof window !== 'undefined'
+    ? decodeWorkflowIdFromPath(window.location.pathname)
     : null;
-  const workflowId = decodeTaskPathSegment(workflowIdMatch ? workflowIdMatch[1] : null);
   const search = useMemo(() => new URLSearchParams(typeof window !== 'undefined' ? window.location.search : ''), []);
   const workspaceShellEnabled = cfg?.features?.temporalDashboard?.workspaceShellEnabled !== false;
   const listEnabled = cfg?.features?.temporalDashboard?.listEnabled !== false;

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -2351,13 +2351,12 @@ function isExecutionTerminal(
 }
 
 export function workflowEvidenceStaleTime({
-  isTerminal,
   detailPoll,
 }: {
   isTerminal: boolean;
   detailPoll: number;
 }): number {
-  return isTerminal ? Infinity : Math.max(detailPoll, 5000);
+  return Math.max(detailPoll, 5000);
 }
 
 export function workflowDetailQueryOptions({

--- a/frontend/src/entrypoints/workflow-list.test.tsx
+++ b/frontend/src/entrypoints/workflow-list.test.tsx
@@ -2904,7 +2904,7 @@ describe('Workflows Entrypoint — dashboard preferences (MM-964)', () => {
     expect(window.localStorage.getItem('moonmind.dashboard.preferences')).toBeNull();
   });
 
-  it('stops window-focus refetches of the list while live updates are paused', async () => {
+  it('does not use duplicate manual window-focus refetches for a fresh list query', async () => {
     const executionListCalls = () =>
       vi.mocked(window.fetch).mock.calls.filter(([url]) =>
         String(url).startsWith('/api/executions?'),
@@ -2913,22 +2913,32 @@ describe('Workflows Entrypoint — dashboard preferences (MM-964)', () => {
     renderWithClient(<WorkflowListPage payload={mockPayload} />);
     await screen.findAllByText('Example task');
 
-    // Live updates default on: returning focus to the tab refetches /executions.
-    const beforeFocusOn = executionListCalls().length;
+    const afterInitialLoad = executionListCalls().length;
     window.dispatchEvent(new Event('visibilitychange'));
-    await waitFor(() => expect(executionListCalls().length).toBeGreaterThan(beforeFocusOn));
-    const afterFocusOn = executionListCalls().length;
+    window.dispatchEvent(new Event('focus'));
+    expect(executionListCalls()).toHaveLength(afterInitialLoad);
 
-    // Pause live updates, then dispatch another focus event.
     openViewOptions();
     fireEvent.click(screen.getByRole('checkbox', { name: 'Poll for live updates' }));
     window.dispatchEvent(new Event('visibilitychange'));
+    window.dispatchEvent(new Event('focus'));
+    expect(executionListCalls()).toHaveLength(afterInitialLoad);
+  });
 
-    // Re-enable live updates and dispatch a final focus event. Only this last
-    // focus (with the pref re-enabled) should produce a new request — proving the
-    // paused focus event in between did not refetch the list.
+  it('does not refetch on focus when live updates are disabled', async () => {
+    const executionListCalls = () =>
+      vi.mocked(window.fetch).mock.calls.filter(([url]) =>
+        String(url).startsWith('/api/executions?'),
+      );
+
+    renderWithClient(<WorkflowListPage payload={mockPayload} />);
+    await screen.findAllByText('Example task');
+
+    openViewOptions();
     fireEvent.click(screen.getByRole('checkbox', { name: 'Poll for live updates' }));
+    const afterPausing = executionListCalls().length;
     window.dispatchEvent(new Event('visibilitychange'));
-    await waitFor(() => expect(executionListCalls().length).toBe(afterFocusOn + 1));
+    window.dispatchEvent(new Event('focus'));
+    expect(executionListCalls()).toHaveLength(afterPausing);
   });
 });

--- a/frontend/src/entrypoints/workflow-list.tsx
+++ b/frontend/src/entrypoints/workflow-list.tsx
@@ -1181,7 +1181,7 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
   const listQueryKey = useMemo(() => buildWorkflowListQueryKey(listQueryParams), [listQueryParams]);
   const listQuery = useMemo(() => workflowListQueryString(listQueryParams), [listQueryParams]);
 
-  const { data, isLoading, isError, error, refetch } = useQuery({
+  const { data, isLoading, isError, error } = useQuery({
     queryKey: listQueryKey,
     enabled: listEnabled && filterValidationErrors.length === 0,
     queryFn: async () => {

--- a/frontend/src/entrypoints/workflow-list.tsx
+++ b/frontend/src/entrypoints/workflow-list.tsx
@@ -1202,24 +1202,6 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
     staleTime: listPollMs,
   });
 
-  useEffect(() => {
-    if (!listEnabled || !liveUpdatesPref || drawerOpen || desktopFilterField !== null) {
-      return undefined;
-    }
-    const refetchVisibleList = () => {
-      if (typeof document !== 'undefined' && document.visibilityState === 'hidden') {
-        return;
-      }
-      void refetch();
-    };
-    window.addEventListener('visibilitychange', refetchVisibleList);
-    window.addEventListener('focus', refetchVisibleList);
-    return () => {
-      window.removeEventListener('visibilitychange', refetchVisibleList);
-      window.removeEventListener('focus', refetchVisibleList);
-    };
-  }, [desktopFilterField, drawerOpen, listEnabled, liveUpdatesPref, refetch]);
-
   // Facets enrich the include/exclude dropdowns. The mobile drawer can show
   // every value field at once; desktop column popovers request the active field.
   // This reuses the existing single-facet backend contract without API changes.

--- a/frontend/src/entrypoints/workflow-start.tsx
+++ b/frontend/src/entrypoints/workflow-start.tsx
@@ -6249,7 +6249,6 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
   ]);
 
   const dependencyOptionsQuery = useQuery({
-    ...configQueryDefaults,
     queryKey: ["workflow-start", "dependency-options", temporalListEndpoint],
     queryFn: async (): Promise<DependencyPickerExecution[]> => {
       const response = await fetch(

--- a/frontend/src/entrypoints/workflow-start.tsx
+++ b/frontend/src/entrypoints/workflow-start.tsx
@@ -5,6 +5,7 @@ import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import { useInRouterContext, useLocation } from "react-router-dom";
 
 import type { BootPayload } from "../boot/parseBootPayload";
+import { configQueryDefaults } from "../boot/queryClient";
 import { LoadingPlaceholder } from "../components/dashboard/LoadingPlaceholder";
 import { SkillCombobox } from "../components/SkillCombobox";
 import { DashboardErrorDetails } from "../components/dashboard/DashboardErrorDetails";
@@ -6034,6 +6035,7 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
   });
 
   const providerProfilesQuery = useQuery({
+    ...configQueryDefaults,
     queryKey: ["workflow-start", "provider-profiles", runtime],
     queryFn: async (): Promise<ProviderProfile[]> => {
       const separator = providerProfilesEndpoint.includes("?") ? "&" : "?";
@@ -6247,6 +6249,7 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
   ]);
 
   const dependencyOptionsQuery = useQuery({
+    ...configQueryDefaults,
     queryKey: ["workflow-start", "dependency-options", temporalListEndpoint],
     queryFn: async (): Promise<DependencyPickerExecution[]> => {
       const response = await fetch(
@@ -6278,6 +6281,7 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
   });
 
   const skillsQuery = useQuery({
+    ...configQueryDefaults,
     queryKey: ["workflow-start", "skills"],
     queryFn: async (): Promise<SkillCatalogResult> => {
       const response = await fetch("/api/workflows/skills", {
@@ -6357,6 +6361,7 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
 
   const hasToolStep = steps.some((step) => step.stepType === "tool");
   const trustedToolsQuery = useQuery({
+    ...configQueryDefaults,
     queryKey: ["workflow-start", "trusted-tools"],
     enabled: hasToolStep,
     retry: false,
@@ -6399,6 +6404,7 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
   });
 
   const templateOptionsQuery = useQuery({
+    ...configQueryDefaults,
     queryKey: [
       "workflow-start",
       "task-template-catalog",
@@ -6444,6 +6450,7 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
   });
 
   const jiraProjectsQuery = useQuery({
+    ...configQueryDefaults,
     queryKey: ["workflow-start", "jira", "projects", jiraIntegration?.endpoints.projects],
     enabled: Boolean(jiraIntegration?.enabled && jiraBrowserOpen),
     queryFn: async (): Promise<JiraProject[]> => {
@@ -6461,6 +6468,7 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
   });
 
   const jiraBoardsQuery = useQuery({
+    ...configQueryDefaults,
     queryKey: [
       "workflow-start",
       "jira",
@@ -6489,6 +6497,7 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
   });
 
   const jiraColumnsQuery = useQuery({
+    ...configQueryDefaults,
     queryKey: [
       "workflow-start",
       "jira",
@@ -6521,6 +6530,7 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
   });
 
   const jiraIssuesQuery = useQuery({
+    ...configQueryDefaults,
     queryKey: [
       "workflow-start",
       "jira",
@@ -6559,6 +6569,7 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
   });
 
   const jiraIssueDetailQuery = useQuery({
+    ...configQueryDefaults,
     queryKey: [
       "workflow-start",
       "jira",
@@ -7551,6 +7562,7 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
     ? selectedRepositoryForBranchLookup.trim()
     : "";
   const branchOptionsQuery = useQuery({
+    ...configQueryDefaults,
     queryKey: ["workflow-start", "github-branches", branchLookupRepository],
     enabled: Boolean(branchLookupEndpoint && branchLookupRepository),
     queryFn: async () =>

--- a/frontend/src/entrypoints/workflows-workspace.tsx
+++ b/frontend/src/entrypoints/workflows-workspace.tsx
@@ -9,6 +9,7 @@ import WorkflowStartPage from './workflow-start';
 import {
   readWorkflowListDisplayMode,
 } from '../lib/workflowListDisplayMode';
+import { decodeWorkflowIdFromPath } from '../lib/workflowDetailRoutes';
 
 const DESKTOP_MEDIA_QUERY = '(min-width: 768px)';
 
@@ -32,19 +33,6 @@ function useIsDesktop(): boolean {
   }, []);
 
   return isDesktop;
-}
-
-function decodeWorkflowIdFromPath(pathname: string): string | null {
-  const match = pathname.match(/^\/workflows\/([^/]+)(?:\/(?:steps|artifacts|runs|debug))?\/?$/);
-  if (!match?.[1]) {
-    return null;
-  }
-  try {
-    const decoded = decodeURIComponent(match[1]);
-    return decoded.includes('/') ? null : decoded;
-  } catch {
-    return null;
-  }
 }
 
 function isCreatePath(pathname: string): boolean {

--- a/frontend/src/lib/dashboardRoutes.test.ts
+++ b/frontend/src/lib/dashboardRoutes.test.ts
@@ -13,10 +13,17 @@ describe('dashboard route resolution', () => {
     });
   });
 
-  it('resolves encoded workflow IDs with detail tabs', () => {
-    const path = '/workflows/mm%3A97d44980-355c-4300-96a7-0ad166440d95/steps';
+  it.each(['chat', 'overview', 'steps', 'artifacts', 'runs', 'debug'])(
+    'resolves encoded workflow IDs with the %s detail tab',
+    (tab) => {
+      const path = `/workflows/mm%3A97d44980-355c-4300-96a7-0ad166440d95/${tab}`;
 
-    expect(resolveDashboardRoute(path)?.page).toBe('workflows-workspace');
+      expect(resolveDashboardRoute(path)?.page).toBe('workflows-workspace');
+    },
+  );
+
+  it('rejects unknown workflow detail tabs', () => {
+    expect(resolveDashboardRoute('/workflows/mm%3A123/files')).toBeNull();
   });
 
   it('resolves reserved-looking workflow IDs as detail pages', () => {

--- a/frontend/src/lib/dashboardRoutes.ts
+++ b/frontend/src/lib/dashboardRoutes.ts
@@ -1,4 +1,5 @@
 import type { BootPayload } from '../boot/parseBootPayload';
+import { WORKFLOW_DETAIL_SUBROUTES } from './workflowDetailRoutes';
 
 export type DashboardPage =
   | 'index-health'
@@ -33,7 +34,7 @@ export type DashboardUiInfo = {
 
 const DETAIL_SEGMENT = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/;
 const WORKFLOW_ID_SEGMENT = /^[A-Za-z0-9][A-Za-z0-9._:{}-]{0,254}$/;
-const WORKFLOW_DETAIL_TABS = new Set(['steps', 'artifacts', 'runs', 'debug']);
+const WORKFLOW_DETAIL_TABS = new Set<string>(WORKFLOW_DETAIL_SUBROUTES);
 
 function withoutTrailingSlash(pathname: string): string {
   return pathname.length > 1 && pathname.endsWith('/') ? pathname.slice(0, -1) : pathname;

--- a/frontend/src/lib/workflowDetailRoutes.test.ts
+++ b/frontend/src/lib/workflowDetailRoutes.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  WORKFLOW_DETAIL_SUBROUTES,
+  decodeWorkflowIdFromPath,
+  isWorkflowDetailPath,
+  workflowDetailSubrouteFromPath,
+  workflowDetailSubrouteHref,
+} from './workflowDetailRoutes';
+
+describe('workflow detail route helpers', () => {
+  it.each([
+    ['/workflows/mm%3A123', 'mm:123', 'chat'],
+    ['/workflows/mm%3A123/chat', 'mm:123', 'chat'],
+    ['/workflows/mm%3A123/overview', 'mm:123', 'overview'],
+    ['/workflows/mm%3A123/steps', 'mm:123', 'steps'],
+    ['/workflows/mm%3A123/artifacts', 'mm:123', 'artifacts'],
+    ['/workflows/mm%3A123/runs', 'mm:123', 'runs'],
+    ['/workflows/mm%3A123/debug', 'mm:123', 'debug'],
+  ] as const)('decodes supported route %s', (path, workflowId, subroute) => {
+    expect(decodeWorkflowIdFromPath(path)).toBe(workflowId);
+    expect(workflowDetailSubrouteFromPath(path)).toBe(subroute);
+    expect(isWorkflowDetailPath(path)).toBe(true);
+  });
+
+  it('rejects unknown workflow detail subroutes and encoded slashes', () => {
+    expect(isWorkflowDetailPath('/workflows/mm%3A123/files')).toBe(false);
+    expect(decodeWorkflowIdFromPath('/workflows/mm%2Fbad/steps')).toBeNull();
+  });
+
+  it('builds hrefs for every supported subroute', () => {
+    const search = new URLSearchParams('source=temporal&stateIn=failed');
+    expect(WORKFLOW_DETAIL_SUBROUTES.map((subroute) => workflowDetailSubrouteHref('mm:123', subroute, search))).toEqual([
+      '/workflows/mm%3A123?source=temporal&stateIn=failed',
+      '/workflows/mm%3A123/overview?source=temporal&stateIn=failed',
+      '/workflows/mm%3A123/steps?source=temporal&stateIn=failed',
+      '/workflows/mm%3A123/artifacts?source=temporal&stateIn=failed',
+      '/workflows/mm%3A123/runs?source=temporal&stateIn=failed',
+      '/workflows/mm%3A123/debug?source=temporal&stateIn=failed',
+    ]);
+  });
+});

--- a/frontend/src/lib/workflowDetailRoutes.ts
+++ b/frontend/src/lib/workflowDetailRoutes.ts
@@ -1,0 +1,47 @@
+export const WORKFLOW_DETAIL_SUBROUTES = [
+  'chat',
+  'overview',
+  'steps',
+  'artifacts',
+  'runs',
+  'debug',
+] as const;
+
+export type WorkflowDetailSubroute = (typeof WORKFLOW_DETAIL_SUBROUTES)[number];
+
+const WORKFLOW_DETAIL_SUBROUTE_PATTERN = WORKFLOW_DETAIL_SUBROUTES.join('|');
+const WORKFLOW_DETAIL_PATH_PATTERN = new RegExp(
+  `^/workflows/([^/]+)(?:/(${WORKFLOW_DETAIL_SUBROUTE_PATTERN}))?/?$`,
+);
+
+export function decodeWorkflowIdFromPath(pathname: string): string | null {
+  const match = pathname.match(WORKFLOW_DETAIL_PATH_PATTERN);
+  if (!match?.[1] || match[1] === 'new') {
+    return null;
+  }
+  try {
+    const decoded = decodeURIComponent(match[1]);
+    return decoded.includes('/') ? null : decoded;
+  } catch {
+    return null;
+  }
+}
+
+export function workflowDetailSubrouteFromPath(pathname: string): WorkflowDetailSubroute {
+  const match = pathname.match(WORKFLOW_DETAIL_PATH_PATTERN);
+  return (match?.[2] as WorkflowDetailSubroute | undefined) || 'chat';
+}
+
+export function workflowDetailSubrouteHref(
+  workflowId: string,
+  subroute: WorkflowDetailSubroute,
+  search: URLSearchParams,
+): string {
+  const suffix = subroute === 'chat' ? '' : `/${subroute}`;
+  const query = search.toString();
+  return `/workflows/${encodeURIComponent(workflowId)}${suffix}${query ? `?${query}` : ''}`;
+}
+
+export function isWorkflowDetailPath(pathname: string): boolean {
+  return decodeWorkflowIdFromPath(pathname) !== null;
+}

--- a/frontend/src/lib/workflowListDisplayMode.test.ts
+++ b/frontend/src/lib/workflowListDisplayMode.test.ts
@@ -90,9 +90,38 @@ describe('resolveWorkflowListDisplay', () => {
     });
   });
 
-  it('preserves detail subroutes when switching only between hidden and sidebar', () => {
+  it.each(['chat', 'overview', 'steps', 'artifacts', 'runs', 'debug'])(
+    'preserves the %s detail subroute when switching only between hidden and sidebar',
+    (subroute) => {
+      const pathname = subroute === 'chat' ? '/workflows/mm%3A123/chat' : `/workflows/mm%3A123/${subroute}`;
+      expect(resolveWorkflowListDisplay({
+        pathname,
+        search: '?source=temporal',
+        requestedMode: 'hidden',
+      })).toMatchObject({
+        effectiveMode: 'hidden',
+        surface: 'workflow-detail',
+        routeAction: 'none',
+        primarySurface: 'workflow-detail',
+        listSurface: 'none',
+        selection: { workflowId: 'mm:123', source: 'route' },
+        targetPath: `${pathname}?source=temporal`,
+      });
+
+      expect(resolveWorkflowListDisplay({
+        pathname,
+        requestedMode: 'sidebar',
+      })).toMatchObject({
+        effectiveMode: 'sidebar',
+        routeAction: 'none',
+        targetPath: pathname,
+      });
+    },
+  );
+
+  it('preserves the default detail route when switching only between hidden and sidebar', () => {
     expect(resolveWorkflowListDisplay({
-      pathname: '/workflows/mm%3A123/steps',
+      pathname: '/workflows/mm%3A123',
       search: '?source=temporal',
       requestedMode: 'hidden',
     })).toMatchObject({
@@ -102,16 +131,16 @@ describe('resolveWorkflowListDisplay', () => {
       primarySurface: 'workflow-detail',
       listSurface: 'none',
       selection: { workflowId: 'mm:123', source: 'route' },
-      targetPath: '/workflows/mm%3A123/steps?source=temporal',
+      targetPath: '/workflows/mm%3A123?source=temporal',
     });
 
     expect(resolveWorkflowListDisplay({
-      pathname: '/workflows/mm%3A123/steps',
+      pathname: '/workflows/mm%3A123',
       requestedMode: 'sidebar',
     })).toMatchObject({
       effectiveMode: 'sidebar',
       routeAction: 'none',
-      targetPath: '/workflows/mm%3A123/steps',
+      targetPath: '/workflows/mm%3A123',
     });
   });
 

--- a/frontend/src/lib/workflowListDisplayMode.ts
+++ b/frontend/src/lib/workflowListDisplayMode.ts
@@ -1,4 +1,5 @@
 import { workflowListContextParams } from './workflowListContext';
+import { WORKFLOW_DETAIL_SUBROUTES } from './workflowDetailRoutes';
 
 export type WorkflowListDisplayMode = 'hidden' | 'sidebar' | 'table';
 
@@ -55,7 +56,7 @@ export type ResolveWorkflowListDisplayInput = {
   firstVisibleWorkflowId?: string | null;
 };
 
-const DETAIL_TABS = new Set(['steps', 'artifacts', 'runs', 'debug']);
+const DETAIL_TABS = new Set<string>(WORKFLOW_DETAIL_SUBROUTES);
 
 export const WORKFLOW_LIST_DISPLAY_MODES = [
   {

--- a/frontend/src/lib/workflowWorkspaceList.ts
+++ b/frontend/src/lib/workflowWorkspaceList.ts
@@ -1,5 +1,4 @@
 import { z } from 'zod';
-import { workflowListContextParams } from './workflowListContext';
 
 export const WorkflowWorkspaceRowSchema = z
   .object({
@@ -60,27 +59,6 @@ export function workflowWorkspaceRowFromDetail(
     repository: detail.repository,
     targetRuntime: detail.targetRuntime,
   };
-}
-
-export function workflowWorkspaceListQuery(search: URLSearchParams, defaultSource?: string): string {
-  const pageSize = search.get('limit') || search.get('pageSize') || '25';
-  const safe = workflowListContextParams(search);
-  const params = new URLSearchParams();
-  const source = safe.get('source') || defaultSource;
-  if (source) {
-    params.set('source', source);
-  }
-  const nextPageToken = safe.get('nextPageToken');
-  if (nextPageToken) {
-    params.set('nextPageToken', nextPageToken);
-  }
-  safe.forEach((value, key) => {
-    if (key !== 'source' && key !== 'limit' && key !== 'pageSize' && key !== 'nextPageToken') {
-      params.append(key, value);
-    }
-  });
-  params.set('pageSize', pageSize);
-  return params.toString();
 }
 
 export function workflowSidebarMatchesFilter(row: WorkflowWorkspaceRow, filter: string): boolean {


### PR DESCRIPTION
Issue reference: MM-1133

Summary:
- Consolidates workflow list/sidebar query identity and shared workflow detail query options.
- Reduces duplicate focus, live-update, and tab revisit refetches with scoped invalidation and explicit stale-time policies.
- Aligns workflow detail subroutes and adds cache persistence/tab reuse coverage.

Tests run:
- npm run ui:test -- frontend/src/lib/workflowListQuery.test.ts frontend/src/lib/workflowDetailRoutes.test.ts frontend/src/lib/workflowListDisplayMode.test.ts frontend/src/lib/dashboardRoutes.test.ts frontend/src/entrypoints/workflow-list.test.tsx frontend/src/entrypoints/workflow-detail.test.tsx frontend/src/entrypoints/workflow-start.test.tsx frontend/src/entrypoints/workflows-workspace.test.tsx
- MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --ui-args frontend/src/lib/workflowListQuery.test.ts frontend/src/lib/workflowDetailRoutes.test.ts frontend/src/lib/workflowListDisplayMode.test.ts frontend/src/lib/dashboardRoutes.test.ts frontend/src/entrypoints/workflow-list.test.tsx frontend/src/entrypoints/workflow-detail.test.tsx frontend/src/entrypoints/workflow-start.test.tsx frontend/src/entrypoints/workflows-workspace.test.tsx (not run: Python wrapper could not import pytest in this runtime)

Remaining risks:
- Manual browser network-panel QA was not run; targeted component tests cover the cache reuse and refetch behavior.
- Integration tests were not run because this change is limited to frontend query and routing behavior.