### PR TITLE
[codex] Fix managed workflow artifact state permissions

### DIFF
--- a/moonmind/workflows/adapters/codex_session_adapter.py
+++ b/moonmind/workflows/adapters/codex_session_adapter.py
@@ -969,6 +969,7 @@ class CodexSessionAdapter(ManagedAgentAdapter):
                         instruction_ref=original_instruction_ref,
                         resolved_skillset_ref=original_skillset_ref,
                     ),
+                    "workspacePath": workspace_path,
                     "sessionSummary": _compact_session_summary_metadata(summary),
                     "sessionArtifacts": _compact_session_artifacts_metadata(
                         publication
@@ -2031,6 +2032,8 @@ class CodexSessionAdapter(ManagedAgentAdapter):
             instruction_ref=instruction_ref,
             resolved_skillset_ref=resolved_skillset_ref,
         )
+        if workspace_path:
+            metadata["workspacePath"] = workspace_path
         if profile_id:
             metadata["profileId"] = profile_id
         if turn_id:

--- a/moonmind/workflows/skills/deployment_execution.py
+++ b/moonmind/workflows/skills/deployment_execution.py
@@ -2418,7 +2418,22 @@ def _compose_env_value(value: Any) -> str:
     return _env_value(value).replace("\\", "\\\\").replace('"', '\\"')
 
 
-def _atomic_write_bytes(path: Path, payload: bytes) -> None:
+def _normalize_deployment_state_file_permissions(path: Path) -> None:
+    with contextlib.suppress(OSError):
+        parent_stat = path.parent.stat()
+        geteuid = getattr(os, "geteuid", lambda: -1)
+        if hasattr(os, "chown") and geteuid() == 0:
+            os.chown(path, parent_stat.st_uid, parent_stat.st_gid)
+    with contextlib.suppress(OSError):
+        path.chmod(0o664)
+
+
+def _atomic_write_bytes(
+    path: Path,
+    payload: bytes,
+    *,
+    normalize_permissions: bool = False,
+) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     fd, temp_name = tempfile.mkstemp(
         prefix=f".{path.name}.",
@@ -2432,6 +2447,8 @@ def _atomic_write_bytes(path: Path, payload: bytes) -> None:
             handle.flush()
             os.fsync(handle.fileno())
         os.replace(temp_path, path)
+        if normalize_permissions:
+            _normalize_deployment_state_file_permissions(path)
         _fsync_parent_directory(path)
     finally:
         with contextlib.suppress(FileNotFoundError):
@@ -2554,9 +2571,17 @@ def _write_desired_state_files(
         for key, value in env_payload.items()
         if _env_value(value)
     )
-    _atomic_write_bytes(env_path, env_text.encode("utf-8"))
+    _atomic_write_bytes(
+        env_path,
+        env_text.encode("utf-8"),
+        normalize_permissions=True,
+    )
     json_text = json.dumps(record, sort_keys=True, default=str, indent=2) + "\n"
-    _atomic_write_bytes(json_path, json_text.encode("utf-8"))
+    _atomic_write_bytes(
+        json_path,
+        json_text.encode("utf-8"),
+        normalize_permissions=True,
+    )
 
 
 def _execution_ref_from_context(context: Mapping[str, Any]) -> Mapping[str, Any] | None:

--- a/moonmind/workflows/temporal/runtime/launcher.py
+++ b/moonmind/workflows/temporal/runtime/launcher.py
@@ -9,6 +9,7 @@ import os
 import re
 import shlex
 import shutil
+import stat
 from collections.abc import Mapping
 from datetime import UTC, datetime
 from pathlib import Path
@@ -439,9 +440,19 @@ class ManagedRuntimeLauncher:
         if os.geteuid() != 0 or resolved_workspace_path is None:
             return
         artifacts_dir = Path(resolved_workspace_path).resolve() / "artifacts"
-        if not artifacts_dir.exists():
+        try:
+            artifacts_stat = artifacts_dir.lstat()
+        except FileNotFoundError:
             return
-        await self._run_checked_command("chown", "-R", "app:app", str(artifacts_dir))
+        if stat.S_ISLNK(artifacts_stat.st_mode):
+            raise RuntimeError(
+                f"repo-local artifacts path must not be a symlink: {artifacts_dir}"
+            )
+        if not stat.S_ISDIR(artifacts_stat.st_mode):
+            raise RuntimeError(
+                f"repo-local artifacts path must be a directory: {artifacts_dir}"
+            )
+        await self._run_checked_command("chown", "-R", "-h", "app:app", str(artifacts_dir))
 
     def _resolve_workspace_ownership_root(
         self,

--- a/moonmind/workflows/temporal/runtime/launcher.py
+++ b/moonmind/workflows/temporal/runtime/launcher.py
@@ -429,6 +429,20 @@ class ManagedRuntimeLauncher:
             resolved_root
         )
 
+    async def _ensure_repo_artifacts_writable_by_runtime_user(
+        self,
+        *,
+        resolved_workspace_path: str | None,
+    ) -> None:
+        """Make MoonMind-created repo-local artifacts writable by managed runtimes."""
+
+        if os.geteuid() != 0 or resolved_workspace_path is None:
+            return
+        artifacts_dir = Path(resolved_workspace_path).resolve() / "artifacts"
+        if not artifacts_dir.exists():
+            return
+        await self._run_checked_command("chown", "-R", "app:app", str(artifacts_dir))
+
     def _resolve_workspace_ownership_root(
         self,
         *,
@@ -1280,6 +1294,17 @@ class ManagedRuntimeLauncher:
             except Exception:
                 logger.warning(
                     "strategy.prepare_workspace failed for run_id=%s runtime=%s",
+                    run_id,
+                    profile.runtime_id,
+                    exc_info=True,
+                )
+            try:
+                await self._ensure_repo_artifacts_writable_by_runtime_user(
+                    resolved_workspace_path=resolved_workspace_path,
+                )
+            except Exception:
+                logger.warning(
+                    "repo-local artifacts ownership repair failed for run_id=%s runtime=%s",
                     run_id,
                     profile.runtime_id,
                     exc_info=True,

--- a/tests/unit/services/temporal/runtime/test_launcher.py
+++ b/tests/unit/services/temporal/runtime/test_launcher.py
@@ -2713,7 +2713,7 @@ async def test_launch_privilege_drop_chowns_repo_and_artifacts_for_external_work
     chown_calls: list[tuple[object, ...]] = []
 
     async def _fake_run_checked_command(self, *cmd, **kw):
-        if cmd and cmd[0] == "chown":
+        if cmd[:2] == ("chown", "-R"):
             chown_calls.append(cmd)
         return None
 

--- a/tests/unit/services/temporal/runtime/test_launcher.py
+++ b/tests/unit/services/temporal/runtime/test_launcher.py
@@ -3645,6 +3645,36 @@ def test_build_generic_managed_agent_env_falls_back_to_run_id_without_workspace(
     assert "workspaces" not in env["MOONMIND_RUN_ROOT"]
 
 
+@pytest.mark.asyncio
+async def test_ensure_repo_artifacts_writable_chowns_context_artifacts_when_root(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setattr(os, "geteuid", lambda: 0)
+    workspace = tmp_path / "run-1" / "repo"
+    artifacts_dir = workspace / "artifacts"
+    (artifacts_dir / "context").mkdir(parents=True)
+
+    chown_calls: list[tuple[object, ...]] = []
+
+    async def _fake_run_checked_command(self, *cmd, **kw):
+        if cmd[:2] == ("chown", "-R"):
+            chown_calls.append(cmd)
+        return None
+
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.runtime.launcher.ManagedRuntimeLauncher._run_checked_command",
+        _fake_run_checked_command,
+    )
+
+    launcher = ManagedRuntimeLauncher(ManagedRunStore(tmp_path / "managed_runs"))
+
+    await launcher._ensure_repo_artifacts_writable_by_runtime_user(
+        resolved_workspace_path=str(workspace)
+    )
+
+    assert chown_calls == [("chown", "-R", "app:app", str(artifacts_dir.resolve()))]
+
+
 def test_sanitize_artifacts_step_segment_blocks_traversal():
     sanitized = ManagedRuntimeLauncher._sanitize_artifacts_step_segment(
         "../../etc/passwd"

--- a/tests/unit/services/temporal/runtime/test_launcher.py
+++ b/tests/unit/services/temporal/runtime/test_launcher.py
@@ -2713,7 +2713,7 @@ async def test_launch_privilege_drop_chowns_repo_and_artifacts_for_external_work
     chown_calls: list[tuple[object, ...]] = []
 
     async def _fake_run_checked_command(self, *cmd, **kw):
-        if cmd[:2] == ("chown", "-R"):
+        if cmd and cmd[0] == "chown":
             chown_calls.append(cmd)
         return None
 
@@ -3672,7 +3672,39 @@ async def test_ensure_repo_artifacts_writable_chowns_context_artifacts_when_root
         resolved_workspace_path=str(workspace)
     )
 
-    assert chown_calls == [("chown", "-R", "app:app", str(artifacts_dir.resolve()))]
+    assert chown_calls == [("chown", "-R", "-h", "app:app", str(artifacts_dir.resolve()))]
+
+
+@pytest.mark.asyncio
+async def test_ensure_repo_artifacts_writable_rejects_artifacts_symlink_when_root(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setattr(os, "geteuid", lambda: 0)
+    workspace = tmp_path / "run-1" / "repo"
+    workspace.mkdir(parents=True)
+    target = tmp_path / "sensitive"
+    target.mkdir()
+    (workspace / "artifacts").symlink_to(target, target_is_directory=True)
+
+    chown_calls: list[tuple[object, ...]] = []
+
+    async def _fake_run_checked_command(self, *cmd, **kw):
+        chown_calls.append(cmd)
+        return None
+
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.runtime.launcher.ManagedRuntimeLauncher._run_checked_command",
+        _fake_run_checked_command,
+    )
+
+    launcher = ManagedRuntimeLauncher(ManagedRunStore(tmp_path / "managed_runs"))
+
+    with pytest.raises(RuntimeError, match="must not be a symlink"):
+        await launcher._ensure_repo_artifacts_writable_by_runtime_user(
+            resolved_workspace_path=str(workspace)
+        )
+
+    assert chown_calls == []
 
 
 def test_sanitize_artifacts_step_segment_blocks_traversal():

--- a/tests/unit/workflows/adapters/test_codex_session_adapter.py
+++ b/tests/unit/workflows/adapters/test_codex_session_adapter.py
@@ -425,6 +425,7 @@ async def test_start_launches_missing_workflow_scoped_session_and_persists_resul
         "artifact:session-checkpoint",
     ]
     assert result.metadata["instructionRef"] == "artifact:instructions"
+    assert result.metadata["workspacePath"] == str(workspace_path)
     assert (
         result.metadata["sessionSummary"]["latestSummaryRef"]
         == "artifact:session-summary"

--- a/tests/unit/workflows/skills/test_deployment_update_execution.py
+++ b/tests/unit/workflows/skills/test_deployment_update_execution.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+import stat
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any, Mapping
@@ -553,6 +554,47 @@ async def test_file_desired_state_store_writes_compose_env_and_audit_json(
     assert audit["stack"] == "moonmind"
     assert audit["operator"] == "admin@example.com"
     assert audit["reason"] == "Operator requested stable"
+
+
+@pytest.mark.asyncio
+async def test_file_desired_state_store_normalizes_replaced_file_permissions(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    env_file = tmp_path / "state" / ".env.deploy"
+    json_file = tmp_path / "state" / "desired-state.json"
+    json_file.parent.mkdir(parents=True)
+    parent_stat = json_file.parent.stat()
+    chown_calls: list[tuple[str, int, int]] = []
+
+    monkeypatch.setattr(
+        "moonmind.workflows.skills.deployment_execution.os.geteuid",
+        lambda: 0,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "moonmind.workflows.skills.deployment_execution.os.chown",
+        lambda path, uid, gid: chown_calls.append((str(path), uid, gid)),
+        raising=False,
+    )
+    store = FileDesiredStateStore(
+        env_file_path=str(env_file),
+        json_file_path=str(json_file),
+    )
+
+    await store.persist(
+        {
+            "stack": "moonmind",
+            "imageRepository": "ghcr.io/moonladderstudios/moonmind",
+            "requestedReference": "stable",
+            "sourceRunId": "depupd_123",
+        }
+    )
+
+    assert stat.S_IMODE(json_file.stat().st_mode) == 0o664
+    assert stat.S_IMODE(env_file.stat().st_mode) == 0o664
+    assert (str(json_file), parent_stat.st_uid, parent_stat.st_gid) in chown_calls
+    assert (str(env_file), parent_stat.st_uid, parent_stat.st_gid) in chown_calls
 
 
 @pytest.mark.asyncio

--- a/tests/unit/workflows/temporal/test_story_output_tools.py
+++ b/tests/unit/workflows/temporal/test_story_output_tools.py
@@ -533,6 +533,33 @@ async def test_update_jira_issue_status_skips_start_for_fully_implemented_assess
 
 
 @pytest.mark.asyncio
+async def test_update_jira_issue_status_reads_relative_assessment_from_previous_workspace(
+    tmp_path,
+) -> None:
+    workspace = tmp_path / "repo"
+    assessment = workspace / "artifacts" / "jira-implement-assessment.json"
+    assessment.parent.mkdir(parents=True)
+    assessment.write_text('{"verdict": "FULLY_IMPLEMENTED"}', encoding="utf-8")
+    service = _FakeJiraService()
+
+    result = await update_jira_issue_status(
+        {
+            "issueKey": "MM-1125",
+            "targetStatus": "In Progress",
+            "assessmentArtifactPath": "artifacts/jira-implement-assessment.json",
+            "previousOutputs": {"workspacePath": str(workspace)},
+        },
+        jira_service_factory=lambda: service,
+    )
+
+    assert result.status == "COMPLETED"
+    assert result.outputs["decision"] == "skipped"
+    assert result.outputs["assessmentVerdict"] == "FULLY_IMPLEMENTED"
+    assert service.get_issue_requests == []
+    assert service.transition_requests == []
+
+
+@pytest.mark.asyncio
 async def test_update_jira_issue_status_uses_previous_assessment_text_when_artifact_missing(
     tmp_path,
 ) -> None:


### PR DESCRIPTION
## Summary

- make managed runtime launch repair repo-local `artifacts/` ownership before Codex runs so context-injected files are writable by the `app` runtime user
- persist `workspacePath` in Codex session results so deterministic Jira status tools can resolve relative assessment artifact paths from previous step outputs
- normalize deployment desired-state writes so atomic replacements of `.env.deploy` and `desired-state.json` keep parent-directory ownership and `0664` permissions

## Root Cause

Two recurring failures had the same underlying shape: files created or atomically replaced by root-running workflow infrastructure became unwritable to the process that needed them later. For Jira implementation workflows, root-owned repo-local artifacts blocked managed agent writes and relative assessment artifacts were not resolvable by later deterministic tools. For deployment desired state, each atomic rewrite recreated `deploy/state/desired-state.json` with restrictive root-owned permissions, undoing manual repairs.

## Validation

- `pytest tests/unit/workflows/adapters/test_codex_session_adapter.py tests/unit/services/temporal/runtime/test_launcher.py tests/unit/workflows/temporal/test_story_output_tools.py -q`
- `pytest tests/unit/workflows/skills/test_deployment_update_execution.py::test_file_desired_state_store_writes_compose_env_and_audit_json tests/unit/workflows/skills/test_deployment_update_execution.py::test_file_desired_state_store_normalizes_replaced_file_permissions -q`
- `./tools/test_unit.sh tests/unit/workflows/skills/test_deployment_update_execution.py`
- `git diff --check`

The local stale deployment state files were also repaired to `nsticco:nsticco` with `0664`, and `temporal-worker-deployment-control` was restarted so the live writer uses the new behavior.