### PR TITLE
MM-1131 consolidate workflow workers

### DIFF
--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -8535,14 +8535,6 @@ def _derive_task_title(
     normalized_tool: Mapping[str, Any] | None = None,
     normalized_steps: Sequence[Mapping[str, Any]] = (),
 ) -> str | None:
-    synthesized = synthesize_workflow_title(
-        current_title=task_payload.get("title"),
-        task_payload=task_payload,
-        normalized_tool=normalized_tool,
-        normalized_steps=normalized_steps,
-    )
-    if synthesized:
-        return synthesized
     raw_steps = task_payload.get("steps")
     if isinstance(raw_steps, list):
         for item in raw_steps:
@@ -8552,12 +8544,30 @@ def _derive_task_title(
             if step_title:
                 return step_title[:_MAX_TASK_TITLE_LENGTH]
     instructions = str(task_payload.get("instructions") or "").strip()
+    has_tool_context = normalized_tool is not None or any(
+        isinstance(task_payload.get(key), Mapping)
+        for key in ("tool", "skill", "workflow")
+    )
+    if instructions and not has_tool_context and not normalized_steps:
+        normalized = " ".join(instructions[: _MAX_TASK_TITLE_LENGTH * 2].split())
+        if normalized:
+            return normalized[:_MAX_TASK_TITLE_LENGTH]
+
+    synthesized = synthesize_workflow_title(
+        current_title=task_payload.get("title"),
+        task_payload=task_payload,
+        normalized_tool=normalized_tool,
+        normalized_steps=normalized_steps,
+    )
+    if synthesized:
+        return synthesized
     if not instructions:
         return None
     normalized = " ".join(instructions[: _MAX_TASK_TITLE_LENGTH * 2].split())
     if not normalized:
         return None
     return normalized[:_MAX_TASK_TITLE_LENGTH]
+
 
 def _derive_workflow_summary(
     task_payload: dict[str, Any], input_artifact_ref: str | None

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -280,7 +280,10 @@ services:
       - TEMPORAL_NAMESPACE=${TEMPORAL_NAMESPACE:-default}
       - TEMPORAL_WORKER_FLEET=workflow
       - TEMPORAL_WORKFLOW_TASK_QUEUE=${TEMPORAL_WORKFLOW_TASK_QUEUE:-mm.workflow}
+      - TEMPORAL_USER_WORKFLOW_V2_TASK_QUEUE=${TEMPORAL_USER_WORKFLOW_V2_TASK_QUEUE:-mm.workflow.user.v2}
+      - TEMPORAL_MERGE_AUTOMATION_WORKFLOW_TASK_QUEUE=${TEMPORAL_MERGE_AUTOMATION_WORKFLOW_TASK_QUEUE:-mm.workflow.merge_automation}
       - TEMPORAL_WORKFLOW_WORKER_CONCURRENCY=${TEMPORAL_WORKFLOW_WORKER_CONCURRENCY:-8}
+      - TEMPORAL_MERGE_AUTOMATION_WORKFLOW_WORKER_CONCURRENCY=${TEMPORAL_MERGE_AUTOMATION_WORKFLOW_WORKER_CONCURRENCY:-2}
       - TEMPORAL_WORKER_COMMAND=${TEMPORAL_WORKER_COMMAND:-python -m
         moonmind.workflows.temporal.worker_runtime}
       - MOONMIND_URL=${MOONMIND_URL:-http://api:8000}
@@ -302,65 +305,8 @@ services:
       - moonmind_secrets:/app/var/secrets
       - agent_workspaces:/work/agent_jobs
     entrypoint:
-      - /bin/sh
-      - /app/services/temporal/scripts/start-worker.sh
-    healthcheck:
-      test: [
-          "CMD",
-          "python",
-          "-c",
-          "import urllib.request;
-          urllib.request.urlopen('http://localhost:8080/healthz')",
-        ]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 30s
-    depends_on:
-      temporal:
-        condition: service_started
-      temporal-namespace-init:
-        condition: service_completed_successfully
-    networks:
-      - local-network
-    restart: unless-stopped
-
-  temporal-worker-workflow-merge-automation:
-    image: ${MOONMIND_IMAGE:-ghcr.io/moonladderstudios/moonmind:latest}
-    init: true
-    environment:
-      - PYTHONPATH=/app
-      - LOG_LEVEL=${LOG_LEVEL:-DEBUG}
-      - PYTHONUNBUFFERED=1
-      - TEMPORAL_ADDRESS=${TEMPORAL_ADDRESS:-temporal-internal:7233}
-      - TEMPORAL_NAMESPACE=${TEMPORAL_NAMESPACE:-default}
-      - TEMPORAL_WORKER_FLEET=workflow
-      - TEMPORAL_WORKFLOW_TASK_QUEUE=${TEMPORAL_WORKFLOW_TASK_QUEUE:-mm.workflow}
-      - TEMPORAL_USER_WORKFLOW_V2_TASK_QUEUE=${TEMPORAL_MERGE_AUTOMATION_WORKFLOW_TASK_QUEUE:-mm.workflow.merge_automation}
-      - TEMPORAL_WORKFLOW_WORKER_CONCURRENCY=${TEMPORAL_MERGE_AUTOMATION_WORKFLOW_WORKER_CONCURRENCY:-2}
-      - TEMPORAL_WORKER_COMMAND=${TEMPORAL_WORKER_COMMAND:-python -m
-        moonmind.workflows.temporal.worker_runtime}
-      - MOONMIND_URL=${MOONMIND_URL:-http://api:8000}
-      - TEMPORAL_ARTIFACT_BACKEND=${TEMPORAL_ARTIFACT_BACKEND:-s3}
-      - TEMPORAL_ARTIFACT_S3_ENDPOINT=${TEMPORAL_ARTIFACT_S3_ENDPOINT:-http://moonmind-temporal-artifacts-s3:9000}
-      - TEMPORAL_ARTIFACT_S3_PUBLIC_ENDPOINT=${TEMPORAL_ARTIFACT_S3_PUBLIC_ENDPOINT:-http://localhost:9000}
-      - TEMPORAL_ARTIFACT_S3_BUCKET=${TEMPORAL_ARTIFACT_S3_BUCKET:-moonmind-temporal-artifacts}
-      - TEMPORAL_ARTIFACT_S3_ACCESS_KEY_ID=${TEMPORAL_ARTIFACT_S3_ACCESS_KEY_ID:-minioadmin}
-      - TEMPORAL_ARTIFACT_S3_SECRET_ACCESS_KEY=${TEMPORAL_ARTIFACT_S3_SECRET_ACCESS_KEY:-minioadmin}
-      - MOONMIND_ALLOW_LOCAL_ENCRYPTION_KEY_GENERATION=${MOONMIND_ALLOW_LOCAL_ENCRYPTION_KEY_GENERATION:-1}
-    env_file:
-      - path: .env
-        required: false
-    volumes:
-      - ./moonmind:/app/moonmind:ro
-      - ./api_service:/app/api_service:ro
-      - ./docs:/app/docs:ro
-      - ./services:/app/services:ro
-      - moonmind_secrets:/app/var/secrets
-      - agent_workspaces:/work/agent_jobs
-    entrypoint:
-      - /bin/sh
-      - /app/services/temporal/scripts/start-worker.sh
+      - python
+      - /app/services/temporal/scripts/start-workflow-worker-group.py
     healthcheck:
       test: [
           "CMD",

--- a/moonmind/workflows/skills/ops_diagnostics_execution.py
+++ b/moonmind/workflows/skills/ops_diagnostics_execution.py
@@ -63,7 +63,6 @@ DEFAULT_MOONMIND_SERVICES = frozenset(
         "temporal-worker-llm",
         "temporal-worker-sandbox",
         "temporal-worker-workflow",
-        "temporal-worker-workflow-merge-automation",
         "qdrant",
         "minio",
         "docker-proxy",

--- a/services/temporal/scripts/start-workflow-worker-group.py
+++ b/services/temporal/scripts/start-workflow-worker-group.py
@@ -253,8 +253,12 @@ def _terminate_children(
         print(f"[workflow-worker-group] terminating {role.name}", flush=True)
         try:
             process.terminate()
-        except OSError:
-            pass
+        except OSError as exc:
+            print(
+                f"[workflow-worker-group] ignored terminate failure for "
+                f"{role.name}: {exc}",
+                flush=True,
+            )
 
     deadline = time.monotonic() + timeout_seconds
     for role, process in live_children:
@@ -265,14 +269,25 @@ def _terminate_children(
             print(f"[workflow-worker-group] killing {role.name}", flush=True)
             try:
                 process.kill()
-            except OSError:
-                pass
+            except OSError as exc:
+                print(
+                    f"[workflow-worker-group] ignored kill failure for "
+                    f"{role.name}: {exc}",
+                    flush=True,
+                )
             try:
                 process.wait(timeout=5.0)
-            except OSError:
-                pass
-        except OSError:
-            pass
+            except OSError as exc:
+                print(
+                    f"[workflow-worker-group] ignored post-kill wait failure for "
+                    f"{role.name}: {exc}",
+                    flush=True,
+                )
+        except OSError as exc:
+            print(
+                f"[workflow-worker-group] ignored wait failure for {role.name}: {exc}",
+                flush=True,
+            )
 
 
 def supervise_workers(

--- a/services/temporal/scripts/start-workflow-worker-group.py
+++ b/services/temporal/scripts/start-workflow-worker-group.py
@@ -11,23 +11,37 @@ import signal
 import subprocess
 import threading
 import time
+import urllib.error
+import urllib.request
 from typing import Callable, Iterable, Mapping, Protocol, Sequence
 
 START_WORKER_SCRIPT = "/app/services/temporal/scripts/start-worker.sh"
 DEFAULT_HEALTHCHECK_PORT = 8080
 DEFAULT_SHUTDOWN_TIMEOUT_SECONDS = 20.0
+CHILD_HEALTHCHECK_PORTS = {
+    "normal-workflow-worker": 8081,
+    "merge-automation-workflow-worker": 8082,
+}
+CHILD_PROMETHEUS_BIND_ADDRESSES = {
+    "normal-workflow-worker": "127.0.0.1:9090",
+    "merge-automation-workflow-worker": "127.0.0.1:9091",
+}
 
 
 class WorkerProcess(Protocol):
     stdout: object
 
-    def poll(self) -> int | None: ...
+    def poll(self) -> int | None:
+        pass
 
-    def terminate(self) -> None: ...
+    def terminate(self) -> None:
+        pass
 
-    def kill(self) -> None: ...
+    def kill(self) -> None:
+        pass
 
-    def wait(self, timeout: float | None = None) -> int: ...
+    def wait(self, timeout: float | None = None) -> int:
+        pass
 
 
 @dataclass(frozen=True, slots=True)
@@ -44,12 +58,13 @@ WORKER_ROLES = (
 @dataclass(slots=True)
 class GroupHealthState:
     children: Sequence[WorkerProcess]
+    child_health_urls: Sequence[str] = ()
     shutting_down: bool = False
 
     def is_healthy(self) -> bool:
         return not self.shutting_down and all(
             child.poll() is None for child in self.children
-        )
+        ) and all(_probe_child_health(url) for url in self.child_health_urls)
 
 
 def _env_default(env: Mapping[str, str], name: str, default: str) -> str:
@@ -65,7 +80,12 @@ def build_child_environment(
 ) -> dict[str, str]:
     env = dict(os.environ if base_env is None else base_env)
     env["TEMPORAL_WORKER_FLEET"] = "workflow"
-    env["WORKER_HEALTHCHECK_ENABLED"] = "false"
+    env["WORKER_HEALTHCHECK_ENABLED"] = "true"
+    env["WORKER_HEALTHCHECK_PORT"] = str(_child_healthcheck_port(role))
+    env["MOONMIND_PROMETHEUS_BIND_ADDRESS"] = _child_prometheus_bind_address(
+        role,
+        env.get("MOONMIND_PROMETHEUS_BIND_ADDRESS"),
+    )
 
     if role.name == "normal-workflow-worker":
         env["TEMPORAL_WORKFLOW_WORKER_CONCURRENCY"] = _env_default(
@@ -95,6 +115,32 @@ def _worker_command() -> list[str]:
     return ["/bin/sh", START_WORKER_SCRIPT]
 
 
+def _child_healthcheck_port(role: WorkerRole) -> int:
+    try:
+        return CHILD_HEALTHCHECK_PORTS[role.name]
+    except KeyError as exc:
+        raise ValueError(f"Unsupported worker role: {role.name}") from exc
+
+
+def _child_prometheus_bind_address(
+    role: WorkerRole,
+    inherited_bind_address: str | None,
+) -> str:
+    if role.name == "normal-workflow-worker":
+        return inherited_bind_address or CHILD_PROMETHEUS_BIND_ADDRESSES[role.name]
+    if role.name == "merge-automation-workflow-worker":
+        if inherited_bind_address:
+            host, separator, port = inherited_bind_address.rpartition(":")
+            if separator and port.isdigit():
+                return f"{host}:{int(port) + 1}"
+        return CHILD_PROMETHEUS_BIND_ADDRESSES[role.name]
+    raise ValueError(f"Unsupported worker role: {role.name}")
+
+
+def _child_health_url(role: WorkerRole) -> str:
+    return f"http://127.0.0.1:{_child_healthcheck_port(role)}/healthz"
+
+
 def start_child_process(role: WorkerRole) -> WorkerProcess:
     return subprocess.Popen(
         _worker_command(),
@@ -112,7 +158,7 @@ def _stream_child_output(role_name: str, process: WorkerProcess) -> threading.Th
         if stream is None:
             return
         for line in stream:  # type: ignore[union-attr]
-            print(f"[{role_name}] {line}", end="", flush=True)
+            print(_format_child_log_line(role_name, line), end="", flush=True)
 
     thread = threading.Thread(
         target=_stream,
@@ -121,6 +167,27 @@ def _stream_child_output(role_name: str, process: WorkerProcess) -> threading.Th
     )
     thread.start()
     return thread
+
+
+def _format_child_log_line(role_name: str, line: str) -> str:
+    trailing_newline = "\n" if line.endswith("\n") else ""
+    raw_line = line[:-1] if trailing_newline else line
+    try:
+        payload = json.loads(raw_line)
+    except json.JSONDecodeError:
+        return f"[{role_name}] {line}"
+    if not isinstance(payload, dict):
+        return f"[{role_name}] {line}"
+    payload.setdefault("worker_role", role_name)
+    return json.dumps(payload, separators=(",", ":")) + trailing_newline
+
+
+def _probe_child_health(url: str, *, timeout_seconds: float = 0.5) -> bool:
+    try:
+        with urllib.request.urlopen(url, timeout=timeout_seconds) as response:
+            return 200 <= response.status < 300
+    except (OSError, urllib.error.URLError, TimeoutError):
+        return False
 
 
 class _HealthHandler(BaseHTTPRequestHandler):
@@ -184,7 +251,10 @@ def _terminate_children(
     ]
     for role, process in live_children:
         print(f"[workflow-worker-group] terminating {role.name}", flush=True)
-        process.terminate()
+        try:
+            process.terminate()
+        except OSError:
+            pass
 
     deadline = time.monotonic() + timeout_seconds
     for role, process in live_children:
@@ -193,8 +263,16 @@ def _terminate_children(
             process.wait(timeout=remaining)
         except subprocess.TimeoutExpired:
             print(f"[workflow-worker-group] killing {role.name}", flush=True)
-            process.kill()
-            process.wait(timeout=5.0)
+            try:
+                process.kill()
+            except OSError:
+                pass
+            try:
+                process.wait(timeout=5.0)
+            except OSError:
+                pass
+        except OSError:
+            pass
 
 
 def supervise_workers(
@@ -225,6 +303,9 @@ def supervise_workers(
             _stream_child_output(role.name, process)
 
         state.children = [process for _role, process in children]
+        state.child_health_urls = [
+            _child_health_url(role) for role, _process in children
+        ]
         health_server = start_health_server(
             state,
             port=_healthcheck_port() if health_port is None else health_port,

--- a/services/temporal/scripts/start-workflow-worker-group.py
+++ b/services/temporal/scripts/start-workflow-worker-group.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python
+"""Supervise the default workflow worker lanes in one Compose service."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+import os
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+import signal
+import subprocess
+import threading
+import time
+from typing import Callable, Iterable, Mapping, Protocol, Sequence
+
+START_WORKER_SCRIPT = "/app/services/temporal/scripts/start-worker.sh"
+DEFAULT_HEALTHCHECK_PORT = 8080
+DEFAULT_SHUTDOWN_TIMEOUT_SECONDS = 20.0
+
+
+class WorkerProcess(Protocol):
+    stdout: object
+
+    def poll(self) -> int | None: ...
+
+    def terminate(self) -> None: ...
+
+    def kill(self) -> None: ...
+
+    def wait(self, timeout: float | None = None) -> int: ...
+
+
+@dataclass(frozen=True, slots=True)
+class WorkerRole:
+    name: str
+
+
+WORKER_ROLES = (
+    WorkerRole("normal-workflow-worker"),
+    WorkerRole("merge-automation-workflow-worker"),
+)
+
+
+@dataclass(slots=True)
+class GroupHealthState:
+    children: Sequence[WorkerProcess]
+    shutting_down: bool = False
+
+    def is_healthy(self) -> bool:
+        return not self.shutting_down and all(
+            child.poll() is None for child in self.children
+        )
+
+
+def _env_default(env: Mapping[str, str], name: str, default: str) -> str:
+    value = env.get(name)
+    if value is None or value == "":
+        return default
+    return value
+
+
+def build_child_environment(
+    role: WorkerRole,
+    base_env: Mapping[str, str] | None = None,
+) -> dict[str, str]:
+    env = dict(os.environ if base_env is None else base_env)
+    env["TEMPORAL_WORKER_FLEET"] = "workflow"
+    env["WORKER_HEALTHCHECK_ENABLED"] = "false"
+
+    if role.name == "normal-workflow-worker":
+        env["TEMPORAL_WORKFLOW_WORKER_CONCURRENCY"] = _env_default(
+            env,
+            "TEMPORAL_WORKFLOW_WORKER_CONCURRENCY",
+            "8",
+        )
+        return env
+
+    if role.name == "merge-automation-workflow-worker":
+        env["TEMPORAL_USER_WORKFLOW_V2_TASK_QUEUE"] = _env_default(
+            env,
+            "TEMPORAL_MERGE_AUTOMATION_WORKFLOW_TASK_QUEUE",
+            "mm.workflow.merge_automation",
+        )
+        env["TEMPORAL_WORKFLOW_WORKER_CONCURRENCY"] = _env_default(
+            env,
+            "TEMPORAL_MERGE_AUTOMATION_WORKFLOW_WORKER_CONCURRENCY",
+            "2",
+        )
+        return env
+
+    raise ValueError(f"Unsupported worker role: {role.name}")
+
+
+def _worker_command() -> list[str]:
+    return ["/bin/sh", START_WORKER_SCRIPT]
+
+
+def start_child_process(role: WorkerRole) -> WorkerProcess:
+    return subprocess.Popen(
+        _worker_command(),
+        env=build_child_environment(role),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        bufsize=1,
+    )
+
+
+def _stream_child_output(role_name: str, process: WorkerProcess) -> threading.Thread:
+    def _stream() -> None:
+        stream = process.stdout
+        if stream is None:
+            return
+        for line in stream:  # type: ignore[union-attr]
+            print(f"[{role_name}] {line}", end="", flush=True)
+
+    thread = threading.Thread(
+        target=_stream,
+        name=f"{role_name}-log-stream",
+        daemon=True,
+    )
+    thread.start()
+    return thread
+
+
+class _HealthHandler(BaseHTTPRequestHandler):
+    def do_GET(self) -> None:  # noqa: N802 - stdlib handler API
+        state: GroupHealthState = self.server.state  # type: ignore[attr-defined]
+        healthy = state.is_healthy()
+        status = 200 if healthy else 503
+        payload = json.dumps(
+            {
+                "status": "ok" if healthy else "unhealthy",
+                "workers": len(state.children),
+                "shutting_down": state.shutting_down,
+            }
+        ).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Connection", "close")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def log_message(self, _format: str, *_args: object) -> None:
+        return
+
+
+def _healthcheck_port(env: Mapping[str, str] | None = None) -> int:
+    raw = (os.environ if env is None else env).get("WORKER_HEALTHCHECK_PORT", "")
+    return int(raw) if raw.strip().isdigit() else DEFAULT_HEALTHCHECK_PORT
+
+
+def start_health_server(
+    state: GroupHealthState,
+    *,
+    port: int | None = None,
+) -> ThreadingHTTPServer:
+    server = ThreadingHTTPServer(
+        ("0.0.0.0", DEFAULT_HEALTHCHECK_PORT if port is None else port),
+        _HealthHandler,
+    )
+    server.state = state  # type: ignore[attr-defined]
+    thread = threading.Thread(
+        target=server.serve_forever,
+        name="workflow-worker-group-healthcheck",
+        daemon=True,
+    )
+    thread.start()
+    print(
+        f"[workflow-worker-group] healthcheck listening on port {server.server_port}",
+        flush=True,
+    )
+    return server
+
+
+def _terminate_children(
+    children: Iterable[tuple[WorkerRole, WorkerProcess]],
+    *,
+    timeout_seconds: float = DEFAULT_SHUTDOWN_TIMEOUT_SECONDS,
+) -> None:
+    live_children = [
+        (role, process) for role, process in children if process.poll() is None
+    ]
+    for role, process in live_children:
+        print(f"[workflow-worker-group] terminating {role.name}", flush=True)
+        process.terminate()
+
+    deadline = time.monotonic() + timeout_seconds
+    for role, process in live_children:
+        remaining = max(0.0, deadline - time.monotonic())
+        try:
+            process.wait(timeout=remaining)
+        except subprocess.TimeoutExpired:
+            print(f"[workflow-worker-group] killing {role.name}", flush=True)
+            process.kill()
+            process.wait(timeout=5.0)
+
+
+def supervise_workers(
+    *,
+    start_process: Callable[[WorkerRole], WorkerProcess] = start_child_process,
+    sleep: Callable[[float], None] = time.sleep,
+    install_signal_handlers: bool = True,
+    poll_interval_seconds: float = 0.5,
+    health_port: int | None = None,
+) -> int:
+    children: list[tuple[WorkerRole, WorkerProcess]] = []
+    state = GroupHealthState(children=[])
+    health_server: ThreadingHTTPServer | None = None
+
+    def _request_shutdown(_signum: int, _frame: object) -> None:
+        state.shutting_down = True
+
+    if install_signal_handlers:
+        signal.signal(signal.SIGTERM, _request_shutdown)
+        signal.signal(signal.SIGINT, _request_shutdown)
+
+    exit_code = 0
+    try:
+        for role in WORKER_ROLES:
+            process = start_process(role)
+            children.append((role, process))
+            print(f"[workflow-worker-group] started {role.name}", flush=True)
+            _stream_child_output(role.name, process)
+
+        state.children = [process for _role, process in children]
+        health_server = start_health_server(
+            state,
+            port=_healthcheck_port() if health_port is None else health_port,
+        )
+
+        while not state.shutting_down:
+            exited = [
+                (role, process.poll())
+                for role, process in children
+                if process.poll() is not None
+            ]
+            if exited:
+                role, code = exited[0]
+                print(
+                    f"[workflow-worker-group] {role.name} exited unexpectedly "
+                    f"with code {code}; stopping group",
+                    flush=True,
+                )
+                state.shutting_down = True
+                exit_code = 1
+                break
+            sleep(poll_interval_seconds)
+    finally:
+        state.shutting_down = True
+        if health_server is not None:
+            health_server.shutdown()
+            health_server.server_close()
+        _terminate_children(children)
+
+    return exit_code
+
+
+def main() -> int:
+    return supervise_workers()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/integration/temporal/test_compose_foundation.py
+++ b/tests/integration/temporal/test_compose_foundation.py
@@ -169,7 +169,6 @@ def test_api_host_port_mapping_and_optional_env_file_for_mm_969():
 
     runtime_service_names = [
         "temporal-worker-workflow",
-        "temporal-worker-workflow-merge-automation",
         "temporal-worker-agent-runtime",
     ]
     for service_name in runtime_service_names:
@@ -241,19 +240,37 @@ def test_omnigent_trusted_origins_render_local_and_public_defaults():
         "https://omnigent.example.test,https://admin.example.test"
     )
 
-def test_merge_automation_workflow_worker_polls_dedicated_user_workflow_queue():
+
+def test_workflow_worker_service_supervises_normal_and_merge_automation_roles():
     compose = _load_compose()
     services = compose["services"]
 
-    merge_worker_env = _env_map(
-        services["temporal-worker-workflow-merge-automation"]["environment"]
-    )
-    assert merge_worker_env["TEMPORAL_WORKFLOW_TASK_QUEUE"] == (
+    assert "temporal-worker-workflow" in services
+    assert "temporal-worker-workflow-merge-automation" not in services
+
+    workflow_worker = services["temporal-worker-workflow"]
+    assert workflow_worker["entrypoint"] == [
+        "python",
+        "/app/services/temporal/scripts/start-workflow-worker-group.py",
+    ]
+
+    workflow_env = _env_map(workflow_worker["environment"])
+    assert workflow_env["TEMPORAL_WORKFLOW_TASK_QUEUE"] == (
         "${TEMPORAL_WORKFLOW_TASK_QUEUE:-mm.workflow}"
     )
-    assert merge_worker_env["TEMPORAL_USER_WORKFLOW_V2_TASK_QUEUE"] == (
+    assert workflow_env["TEMPORAL_USER_WORKFLOW_V2_TASK_QUEUE"] == (
+        "${TEMPORAL_USER_WORKFLOW_V2_TASK_QUEUE:-mm.workflow.user.v2}"
+    )
+    assert workflow_env["TEMPORAL_MERGE_AUTOMATION_WORKFLOW_TASK_QUEUE"] == (
         "${TEMPORAL_MERGE_AUTOMATION_WORKFLOW_TASK_QUEUE:-mm.workflow.merge_automation}"
     )
+    assert workflow_env["TEMPORAL_WORKFLOW_WORKER_CONCURRENCY"] == (
+        "${TEMPORAL_WORKFLOW_WORKER_CONCURRENCY:-8}"
+    )
+    assert workflow_env["TEMPORAL_MERGE_AUTOMATION_WORKFLOW_WORKER_CONCURRENCY"] == (
+        "${TEMPORAL_MERGE_AUTOMATION_WORKFLOW_WORKER_CONCURRENCY:-2}"
+    )
+
 
 def test_sandbox_worker_compose_egress_is_restricted_for_mm_785():
     compose = _load_compose()

--- a/tests/unit/workflows/temporal/test_workflow_worker_group_launcher.py
+++ b/tests/unit/workflows/temporal/test_workflow_worker_group_launcher.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 from pathlib import Path
 import subprocess
 import sys
@@ -29,9 +30,15 @@ class FakeProcess:
         returncode: int | None = None,
         *,
         exit_on_terminate: bool = True,
+        raise_on_terminate: bool = False,
+        raise_on_kill: bool = False,
+        raise_on_wait: bool = False,
     ) -> None:
         self.returncode = returncode
         self.exit_on_terminate = exit_on_terminate
+        self.raise_on_terminate = raise_on_terminate
+        self.raise_on_kill = raise_on_kill
+        self.raise_on_wait = raise_on_wait
         self.stdout: list[str] = []
         self.terminated = False
         self.killed = False
@@ -40,15 +47,21 @@ class FakeProcess:
         return self.returncode
 
     def terminate(self) -> None:
+        if self.raise_on_terminate:
+            raise OSError("already exited")
         self.terminated = True
         if self.exit_on_terminate:
             self.returncode = 0
 
     def kill(self) -> None:
+        if self.raise_on_kill:
+            raise OSError("already exited")
         self.killed = True
         self.returncode = -9
 
     def wait(self, timeout: float | None = None) -> int:
+        if self.raise_on_wait:
+            raise OSError("already reaped")
         if self.returncode is None:
             raise subprocess.TimeoutExpired("fake-worker", timeout)
         return self.returncode
@@ -72,7 +85,9 @@ def test_child_environments_preserve_independent_workflow_lane_defaults() -> Non
     assert normal_env["TEMPORAL_WORKER_FLEET"] == "workflow"
     assert normal_env["TEMPORAL_USER_WORKFLOW_V2_TASK_QUEUE"] == "mm.workflow.user.v2"
     assert normal_env["TEMPORAL_WORKFLOW_WORKER_CONCURRENCY"] == "8"
-    assert normal_env["WORKER_HEALTHCHECK_ENABLED"] == "false"
+    assert normal_env["WORKER_HEALTHCHECK_ENABLED"] == "true"
+    assert normal_env["WORKER_HEALTHCHECK_PORT"] == "8081"
+    assert normal_env["MOONMIND_PROMETHEUS_BIND_ADDRESS"] == "127.0.0.1:9090"
 
     assert merge_env["TEMPORAL_WORKER_FLEET"] == "workflow"
     assert (
@@ -80,7 +95,9 @@ def test_child_environments_preserve_independent_workflow_lane_defaults() -> Non
         == "mm.workflow.merge_automation"
     )
     assert merge_env["TEMPORAL_WORKFLOW_WORKER_CONCURRENCY"] == "2"
-    assert merge_env["WORKER_HEALTHCHECK_ENABLED"] == "false"
+    assert merge_env["WORKER_HEALTHCHECK_ENABLED"] == "true"
+    assert merge_env["WORKER_HEALTHCHECK_PORT"] == "8082"
+    assert merge_env["MOONMIND_PROMETHEUS_BIND_ADDRESS"] == "127.0.0.1:9091"
 
 
 def test_child_environments_honor_explicit_merge_queue_and_concurrency() -> None:
@@ -94,6 +111,17 @@ def test_child_environments_honor_explicit_merge_queue_and_concurrency() -> None
 
     assert env["TEMPORAL_USER_WORKFLOW_V2_TASK_QUEUE"] == "custom.merge"
     assert env["TEMPORAL_WORKFLOW_WORKER_CONCURRENCY"] == "4"
+
+
+def test_merge_worker_prometheus_bind_address_is_distinct_when_inherited() -> None:
+    env = launcher.build_child_environment(
+        launcher.WorkerRole("merge-automation-workflow-worker"),
+        {
+            "MOONMIND_PROMETHEUS_BIND_ADDRESS": "0.0.0.0:9200",
+        },
+    )
+
+    assert env["MOONMIND_PROMETHEUS_BIND_ADDRESS"] == "0.0.0.0:9201"
 
 
 def test_parent_health_endpoint_requires_both_children_alive() -> None:
@@ -115,6 +143,40 @@ def test_parent_health_endpoint_requires_both_children_alive() -> None:
     finally:
         server.shutdown()
         server.server_close()
+
+
+def test_parent_health_endpoint_probes_child_health_urls() -> None:
+    child_server = launcher.start_health_server(
+        launcher.GroupHealthState(children=[]),
+        port=0,
+    )
+    parent_state = launcher.GroupHealthState(
+        children=[FakeProcess()],
+        child_health_urls=[f"http://127.0.0.1:{child_server.server_port}/healthz"],
+    )
+    parent_server = launcher.start_health_server(parent_state, port=0)
+    try:
+        response = urllib.request.urlopen(
+            f"http://127.0.0.1:{parent_server.server_port}/healthz",
+            timeout=5,
+        )
+        assert response.status == 200
+
+        child_server.shutdown()
+        child_server.server_close()
+
+        try:
+            urllib.request.urlopen(
+                f"http://127.0.0.1:{parent_server.server_port}/healthz",
+                timeout=5,
+            )
+        except urllib.error.HTTPError as exc:
+            assert exc.code == 503
+        else:
+            raise AssertionError("expected unhealthy response")
+    finally:
+        parent_server.shutdown()
+        parent_server.server_close()
 
 
 def test_supervisor_exits_nonzero_and_stops_group_when_child_exits() -> None:
@@ -144,3 +206,42 @@ def test_terminate_children_kills_process_after_grace_timeout() -> None:
 
     assert stuck.terminated is True
     assert stuck.killed is True
+
+
+def test_terminate_children_ignores_os_errors_from_exited_processes() -> None:
+    already_exited = FakeProcess(
+        exit_on_terminate=False,
+        raise_on_terminate=True,
+        raise_on_kill=True,
+        raise_on_wait=True,
+    )
+
+    launcher._terminate_children(
+        [(launcher.WorkerRole("normal-workflow-worker"), already_exited)],
+        timeout_seconds=0,
+    )
+
+    assert already_exited.terminated is False
+
+
+def test_structured_child_log_lines_preserve_json_and_add_role() -> None:
+    formatted = launcher._format_child_log_line(
+        "normal-workflow-worker",
+        '{"event":"started","level":"info"}\n',
+    )
+
+    payload = json.loads(formatted)
+    assert payload == {
+        "event": "started",
+        "level": "info",
+        "worker_role": "normal-workflow-worker",
+    }
+
+
+def test_unstructured_child_log_lines_keep_human_role_prefix() -> None:
+    formatted = launcher._format_child_log_line(
+        "merge-automation-workflow-worker",
+        "plain log line\n",
+    )
+
+    assert formatted == "[merge-automation-workflow-worker] plain log line\n"

--- a/tests/unit/workflows/temporal/test_workflow_worker_group_launcher.py
+++ b/tests/unit/workflows/temporal/test_workflow_worker_group_launcher.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+LAUNCHER_PATH = (
+    REPO_ROOT / "services" / "temporal" / "scripts" / "start-workflow-worker-group.py"
+)
+
+spec = importlib.util.spec_from_file_location(
+    "workflow_worker_group_launcher",
+    LAUNCHER_PATH,
+)
+assert spec is not None
+launcher = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = launcher
+assert spec.loader is not None
+spec.loader.exec_module(launcher)
+
+
+class FakeProcess:
+    def __init__(
+        self,
+        returncode: int | None = None,
+        *,
+        exit_on_terminate: bool = True,
+    ) -> None:
+        self.returncode = returncode
+        self.exit_on_terminate = exit_on_terminate
+        self.stdout: list[str] = []
+        self.terminated = False
+        self.killed = False
+
+    def poll(self) -> int | None:
+        return self.returncode
+
+    def terminate(self) -> None:
+        self.terminated = True
+        if self.exit_on_terminate:
+            self.returncode = 0
+
+    def kill(self) -> None:
+        self.killed = True
+        self.returncode = -9
+
+    def wait(self, timeout: float | None = None) -> int:
+        if self.returncode is None:
+            raise subprocess.TimeoutExpired("fake-worker", timeout)
+        return self.returncode
+
+
+def test_child_environments_preserve_independent_workflow_lane_defaults() -> None:
+    base_env = {
+        "TEMPORAL_WORKFLOW_TASK_QUEUE": "mm.workflow",
+        "TEMPORAL_USER_WORKFLOW_V2_TASK_QUEUE": "mm.workflow.user.v2",
+    }
+
+    normal_env = launcher.build_child_environment(
+        launcher.WorkerRole("normal-workflow-worker"),
+        base_env,
+    )
+    merge_env = launcher.build_child_environment(
+        launcher.WorkerRole("merge-automation-workflow-worker"),
+        base_env,
+    )
+
+    assert normal_env["TEMPORAL_WORKER_FLEET"] == "workflow"
+    assert normal_env["TEMPORAL_USER_WORKFLOW_V2_TASK_QUEUE"] == "mm.workflow.user.v2"
+    assert normal_env["TEMPORAL_WORKFLOW_WORKER_CONCURRENCY"] == "8"
+    assert normal_env["WORKER_HEALTHCHECK_ENABLED"] == "false"
+
+    assert merge_env["TEMPORAL_WORKER_FLEET"] == "workflow"
+    assert (
+        merge_env["TEMPORAL_USER_WORKFLOW_V2_TASK_QUEUE"]
+        == "mm.workflow.merge_automation"
+    )
+    assert merge_env["TEMPORAL_WORKFLOW_WORKER_CONCURRENCY"] == "2"
+    assert merge_env["WORKER_HEALTHCHECK_ENABLED"] == "false"
+
+
+def test_child_environments_honor_explicit_merge_queue_and_concurrency() -> None:
+    env = launcher.build_child_environment(
+        launcher.WorkerRole("merge-automation-workflow-worker"),
+        {
+            "TEMPORAL_MERGE_AUTOMATION_WORKFLOW_TASK_QUEUE": "custom.merge",
+            "TEMPORAL_MERGE_AUTOMATION_WORKFLOW_WORKER_CONCURRENCY": "4",
+        },
+    )
+
+    assert env["TEMPORAL_USER_WORKFLOW_V2_TASK_QUEUE"] == "custom.merge"
+    assert env["TEMPORAL_WORKFLOW_WORKER_CONCURRENCY"] == "4"
+
+
+def test_parent_health_endpoint_requires_both_children_alive() -> None:
+    healthy_child = FakeProcess()
+    state = launcher.GroupHealthState(children=[healthy_child, FakeProcess()])
+    server = launcher.start_health_server(state, port=0)
+    port = server.server_port
+    try:
+        response = urllib.request.urlopen(f"http://127.0.0.1:{port}/healthz", timeout=5)
+        assert response.status == 200
+
+        healthy_child.returncode = 1
+        try:
+            urllib.request.urlopen(f"http://127.0.0.1:{port}/healthz", timeout=5)
+        except urllib.error.HTTPError as exc:
+            assert exc.code == 503
+        else:
+            raise AssertionError("expected unhealthy response")
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def test_supervisor_exits_nonzero_and_stops_group_when_child_exits() -> None:
+    processes = {
+        "normal-workflow-worker": FakeProcess(),
+        "merge-automation-workflow-worker": FakeProcess(returncode=7),
+    }
+
+    exit_code = launcher.supervise_workers(
+        start_process=lambda role: processes[role.name],
+        sleep=lambda _seconds: None,
+        install_signal_handlers=False,
+        health_port=0,
+    )
+
+    assert exit_code == 1
+    assert processes["normal-workflow-worker"].terminated is True
+
+
+def test_terminate_children_kills_process_after_grace_timeout() -> None:
+    stuck = FakeProcess(exit_on_terminate=False)
+
+    launcher._terminate_children(
+        [(launcher.WorkerRole("normal-workflow-worker"), stuck)],
+        timeout_seconds=0,
+    )
+
+    assert stuck.terminated is True
+    assert stuck.killed is True


### PR DESCRIPTION
Issue reference: MM-1131

Summary:
- Consolidates the normal workflow worker and merge-automation workflow worker into one Compose service.
- Adds a grouped workflow-worker launcher that supervises both roles while preserving separate task queues and concurrency defaults.
- Updates Compose foundation and focused unit coverage for the consolidated topology, health behavior, shutdown, and queue separation.

Tests run:
- MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_workflow_worker_group_launcher.py tests/unit/workflows/temporal/test_temporal_workers.py tests/unit/workflows/skills/test_ops_diagnostics_execution.py
- pytest tests/integration/temporal/test_compose_foundation.py -q --tb=short
- docker compose config
- docker compose config --services

Remaining risks:
- Live docker compose deployment, real Temporal workflow probes, and child-failure restart fault injection were not run in this managed verification runtime; repo-visible topology and supervisor behavior are covered by focused tests.
