### PR TITLE
I’d reduce Workflow Detail from 6 top-level tabs to 4 primary tabs, with Debug moved behind an Advanced / More affordance rather than treated as a nor

### DIFF
--- a/frontend/src/entrypoints/dashboard-app.tsx
+++ b/frontend/src/entrypoints/dashboard-app.tsx
@@ -946,6 +946,8 @@ function DashboardRouter({ payload }: { payload: BootPayload }) {
       <Route path="/workflows/:workflowId" element={routedDashboardPage} />
       <Route path="/workflows/:workflowId/chat" element={routedDashboardPage} />
       <Route path="/workflows/:workflowId/overview" element={routedDashboardPage} />
+      <Route path="/workflows/:workflowId/execution" element={routedDashboardPage} />
+      <Route path="/workflows/:workflowId/evidence" element={routedDashboardPage} />
       <Route path="/workflows/:workflowId/steps" element={routedDashboardPage} />
       <Route path="/workflows/:workflowId/artifacts" element={routedDashboardPage} />
       <Route path="/workflows/:workflowId/runs" element={routedDashboardPage} />

--- a/frontend/src/entrypoints/workflow-detail.test.tsx
+++ b/frontend/src/entrypoints/workflow-detail.test.tsx
@@ -1506,7 +1506,7 @@ describe('Workflow Detail Entrypoint', () => {
     const rendered = renderWithClient(<WorkflowDetailPage payload={stepsPayload} />);
 
     expect(await screen.findByRole('heading', { name: 'Workflow Steps' })).toBeTruthy();
-    expect(screen.getByRole('link', { name: 'Steps' }).getAttribute('aria-current')).toBe('page');
+    expect(screen.getByRole('link', { name: 'Execution' }).getAttribute('aria-current')).toBe('page');
 
     window.history.pushState({}, 'Detail Tab Sync Test', '/workflows/test-123/overview?source=temporal');
     rendered.rerender(<WorkflowDetailPage payload={stepsPayload} />);
@@ -1514,7 +1514,7 @@ describe('Workflow Detail Entrypoint', () => {
     await waitFor(() => {
       expect(screen.getByRole('link', { name: 'Overview' }).getAttribute('aria-current')).toBe('page');
     });
-    expect(screen.getByRole('link', { name: 'Steps' }).getAttribute('aria-current')).not.toBe('page');
+    expect(screen.getByRole('link', { name: 'Execution' }).getAttribute('aria-current')).not.toBe('page');
   });
 
   it('MM-1094/MM-1105 renders checkpoint branches, evidence links, and policy blocked action states', async () => {
@@ -1892,8 +1892,11 @@ describe('Workflow Detail Entrypoint', () => {
     expect(screen.getByRole('link', { name: 'Overview' }).getAttribute('href')).toBe(
       '/workflows/test-123/overview?source=temporal',
     );
-    expect(screen.getByRole('link', { name: 'Steps' }).getAttribute('href')).toBe(
-      '/workflows/test-123/steps?source=temporal',
+    expect(screen.getByRole('link', { name: 'Execution' }).getAttribute('href')).toBe(
+      '/workflows/test-123/execution?source=temporal',
+    );
+    expect(screen.getByRole('link', { name: 'Evidence' }).getAttribute('href')).toBe(
+      '/workflows/test-123/evidence?source=temporal',
     );
   });
 
@@ -1904,9 +1907,11 @@ describe('Workflow Detail Entrypoint', () => {
     renderWithClient(<WorkflowDetailPage payload={stepsPayload} />);
 
     expect((await screen.findByRole('link', { name: 'Chat' })).getAttribute('aria-current')).toBe('page');
-    for (const label of ['Overview', 'Steps', 'Artifacts', 'Runs', 'Debug']) {
+    for (const label of ['Overview', 'Execution', 'Evidence']) {
       expect(screen.getByRole('link', { name: label })).toBeTruthy();
     }
+    fireEvent.click(screen.getByRole('button', { name: 'More' }));
+    expect(screen.getByRole('menuitem', { name: 'Debug' })).toBeTruthy();
     expect(screen.queryByRole('link', { name: /file browser/i })).toBeNull();
     expect(screen.queryByRole('heading', { name: /file browser/i })).toBeNull();
   });
@@ -1923,9 +1928,9 @@ describe('Workflow Detail Entrypoint', () => {
       expect(screen.queryByRole('heading', { name: 'Workflow Preview' })).toBeNull();
       expect(screen.getByText('Focused route summary')).toBeTruthy();
       expect(screen.getByRole('link', { name: 'Overview' }).getAttribute('aria-current')).toBe('page');
-      expect(screen.getByRole('link', { name: 'Steps' }).getAttribute('href')).toBe('/workflows/test-123/steps?source=temporal');
-      expect(screen.getByRole('link', { name: 'Runs' }).getAttribute('href')).toBe('/workflows/test-123/runs?source=temporal');
-      expect(screen.getByRole('link', { name: 'Runs' }).textContent).toContain('2');
+      expect(screen.getByRole('link', { name: 'Execution' }).getAttribute('href')).toBe('/workflows/test-123/execution?source=temporal');
+      expect(screen.getByRole('link', { name: 'Evidence' }).getAttribute('href')).toBe('/workflows/test-123/evidence?source=temporal');
+      expect(screen.getByRole('link', { name: 'Execution' }).textContent).toContain('2');
       expect(screen.queryByRole('heading', { name: 'Workflow Steps' })).toBeNull();
       expect(screen.queryByRole('heading', { name: 'Workflow Artifacts' })).toBeNull();
       expect(screen.queryByRole('heading', { name: 'Execution History' })).toBeNull();
@@ -1944,11 +1949,11 @@ describe('Workflow Detail Entrypoint', () => {
     expect(await screen.findByRole('heading', { name: 'Summary' })).toBeTruthy();
     expect(fetchSpy.mock.calls.filter(([input]) => String(input).includes('/executions/test-123/steps')).length).toBe(0);
 
-    fireEvent.click(screen.getByRole('link', { name: 'Steps' }));
+    fireEvent.click(screen.getByRole('link', { name: 'Execution' }));
 
-    expect(window.location.pathname).toBe('/workflows/test-123/steps');
+    expect(window.location.pathname).toBe('/workflows/test-123/execution');
     expect(await screen.findByRole('heading', { name: 'Workflow Steps' })).toBeTruthy();
-    const stepsLink = await screen.findByRole('link', { name: 'Steps' });
+    const stepsLink = await screen.findByRole('link', { name: 'Execution' });
     expect(stepsLink.getAttribute('aria-current')).toBe('page');
     expect(stepsLink.textContent).toContain('3');
     expect(fetchSpy.mock.calls.filter(([input]) => String(input).includes('/executions/test-123/steps')).length).toBeGreaterThan(0);
@@ -1979,15 +1984,15 @@ describe('Workflow Detail Entrypoint', () => {
     );
     expect(stepLedgerCalls()).toHaveLength(0);
 
-    fireEvent.click(screen.getByRole('link', { name: 'Steps' }));
+    fireEvent.click(screen.getByRole('link', { name: 'Execution' }));
     expect(await screen.findByRole('heading', { name: 'Workflow Steps' })).toBeTruthy();
     await waitFor(() => expect(stepLedgerCalls()).toHaveLength(1));
 
-    fireEvent.click(screen.getByRole('link', { name: 'Artifacts' }));
+    fireEvent.click(screen.getByRole('link', { name: 'Evidence' }));
     expect(await screen.findByRole('heading', { name: 'Workflow Artifacts' })).toBeTruthy();
     expect(stepLedgerCalls()).toHaveLength(1);
 
-    fireEvent.click(screen.getByRole('link', { name: 'Steps' }));
+    fireEvent.click(screen.getByRole('link', { name: 'Execution' }));
     expect(await screen.findByRole('heading', { name: 'Workflow Steps' })).toBeTruthy();
     expect(stepLedgerCalls()).toHaveLength(1);
   });
@@ -2004,8 +2009,8 @@ describe('Workflow Detail Entrypoint', () => {
 
     await screen.findByText('Focused route summary');
     expect(screen.queryByRole('link', { name: 'Expand to full list' })).toBeNull();
-    expect(screen.getByRole('link', { name: 'Steps' }).getAttribute('href')).toBe(
-      '/workflows/test-123/steps?source=temporal&stateIn=completed&repoContains=moon%2Frepo&limit=25&nextPageToken=cursor-2&sort=status&selectedWorkflowId=test-123&unsafe=1',
+    expect(screen.getByRole('link', { name: 'Execution' }).getAttribute('href')).toBe(
+      '/workflows/test-123/execution?source=temporal&stateIn=completed&repoContains=moon%2Frepo&limit=25&nextPageToken=cursor-2&sort=status&selectedWorkflowId=test-123&unsafe=1',
     );
   });
 
@@ -2110,7 +2115,7 @@ describe('Workflow Detail Entrypoint', () => {
     );
   });
 
-  it('MM-801 renders Steps as the focused step ledger route', async () => {
+  it('MM-801 renders Execution as the focused step ledger and run history route', async () => {
     window.history.pushState({}, 'Steps Test', '/workflows/test-123/steps?source=temporal');
     mockWorkflowDetailSubrouteFetch();
 
@@ -2126,12 +2131,12 @@ describe('Workflow Detail Entrypoint', () => {
       expect(screen.queryByLabelText('plan to apply')).toBeNull();
       expect(screen.queryByLabelText('apply to verify')).toBeNull();
       expect(screen.queryByLabelText('Step dependency edges')).toBeNull();
-      expect(screen.getByRole('link', { name: 'Steps' }).getAttribute('aria-current')).toBe('page');
+      expect(screen.getByRole('link', { name: 'Execution' }).getAttribute('aria-current')).toBe('page');
       expect(screen.getByRole('heading', { name: 'Timeline' })).toBeTruthy();
       expect(screen.queryByRole('heading', { name: 'Workflow Preview' })).toBeNull();
       expect(screen.queryByRole('heading', { name: 'Workflow Artifacts' })).toBeNull();
-      expect(screen.queryByRole('heading', { name: 'Execution History' })).toBeNull();
-      expect(screen.queryByRole('heading', { name: 'Run Comparison' })).toBeNull();
+      expect(screen.getByRole('heading', { name: 'Execution History' })).toBeTruthy();
+      expect(screen.getByRole('heading', { name: 'Run Comparison' })).toBeTruthy();
       expect(screen.queryByRole('heading', { name: 'Report' })).toBeNull();
     });
 
@@ -2877,7 +2882,7 @@ describe('Workflow Detail Entrypoint', () => {
       expect(screen.getByRole('heading', { name: 'Report' })).toBeTruthy();
       expect(screen.getAllByText('Final report').length).toBeGreaterThan(0);
       expect(screen.getByText('evidence.json')).toBeTruthy();
-      expect(screen.getByRole('link', { name: 'Artifacts' }).getAttribute('aria-current')).toBe('page');
+      expect(screen.getByRole('link', { name: 'Evidence' }).getAttribute('aria-current')).toBe('page');
       expect(screen.queryByRole('heading', { name: 'Workflow Preview' })).toBeNull();
       expect(screen.queryByRole('heading', { name: 'Step DAG' })).toBeNull();
       expect(screen.queryByRole('heading', { name: 'Workflow Steps' })).toBeNull();
@@ -2887,7 +2892,7 @@ describe('Workflow Detail Entrypoint', () => {
     });
   });
 
-  it('MM-801 renders Runs as the focused execution history and comparison route', async () => {
+  it('MM-801 maps Runs to the combined Execution route', async () => {
     window.history.pushState({}, 'Runs Test', '/workflows/test-123/runs?source=temporal');
     mockWorkflowDetailSubrouteFetch();
 
@@ -2897,11 +2902,11 @@ describe('Workflow Detail Entrypoint', () => {
       expect(screen.getAllByRole('heading', { name: 'Execution History' }).length).toBeGreaterThan(0);
       expect(screen.getByRole('heading', { name: 'Run Comparison' })).toBeTruthy();
       expect(screen.getAllByText('test-456').length).toBeGreaterThan(0);
-      expect(screen.getByRole('link', { name: 'Runs' }).getAttribute('aria-current')).toBe('page');
+      expect(screen.getByRole('link', { name: 'Execution' }).getAttribute('aria-current')).toBe('page');
       expect(screen.queryByRole('heading', { name: 'Workflow Preview' })).toBeNull();
-      expect(screen.queryByRole('heading', { name: 'Workflow Steps' })).toBeNull();
+      expect(screen.getByRole('heading', { name: 'Workflow Steps' })).toBeTruthy();
       expect(screen.queryByRole('heading', { name: 'Workflow Artifacts' })).toBeNull();
-      expect(screen.queryByRole('heading', { name: 'Timeline' })).toBeNull();
+      expect(screen.getByRole('heading', { name: 'Timeline' })).toBeTruthy();
       expect(screen.queryByRole('heading', { name: 'Report' })).toBeNull();
     });
   });
@@ -2955,12 +2960,11 @@ describe('Workflow Detail Entrypoint', () => {
     }
     expect(screen.getAllByText('MoonMind.UserWorkflow').length).toBeGreaterThan(0);
 
-    // Deep-linking to the subroute selects the Debug tab, and tab navigation keeps
-    // focusable deep links.
-    const debugLink = screen.getByRole('link', { name: 'Debug' });
-    expect(debugLink.getAttribute('aria-current')).toBe('page');
-    expect(debugLink.tagName).toBe('A');
-    expect(debugLink.getAttribute('href')).toBe('/workflows/test-123/debug?source=temporal');
+    // Deep-linking to the subroute keeps Debug available behind More without
+    // consuming primary tab space.
+    expect(screen.queryByRole('link', { name: 'Debug' })).toBeNull();
+    fireEvent.click(screen.getByRole('button', { name: 'More' }));
+    expect(screen.getByRole('menuitem', { name: 'Debug' })).toBeTruthy();
     // Overview is reachable from the Debug subroute (deep links round-trip).
     expect(screen.getByRole('link', { name: 'Overview' }).getAttribute('href')).toBe('/workflows/test-123/overview?source=temporal');
 
@@ -2968,20 +2972,22 @@ describe('Workflow Detail Entrypoint', () => {
     expect(screen.queryByRole('heading', { name: 'Workflow Preview' })).toBeNull();
   });
 
-  it('MM-1020 keeps the Debug tab stable while the kebab menu toggles debug details', async () => {
+  it('MM-1020 keeps the Debug affordance stable while the kebab menu toggles debug details', async () => {
     window.history.pushState({}, 'Debug Pref Test', '/workflows/test-123/overview?source=temporal');
     mockWorkflowDetailSubrouteFetch();
 
     const view = renderWithClient(<WorkflowDetailPage payload={stepsPayload} />);
 
-    // Debug tab is visible by default.
-    expect(await screen.findByRole('link', { name: 'Debug' })).toBeTruthy();
+    // Debug is available from More by default.
+    expect(await screen.findByRole('button', { name: 'More' })).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: 'More' }));
+    expect(screen.getByRole('menuitem', { name: 'Debug' })).toBeTruthy();
 
     let menu = await openWorkflowActionsMenu();
     fireEvent.click(within(menu).getByRole('menuitem', { name: 'View: Hide debug details' }));
 
-    // The Debug tab remains visible and the preference is persisted.
-    expect(screen.getByRole('link', { name: 'Debug' })).toBeTruthy();
+    // The More affordance remains visible and the preference is persisted.
+    expect(screen.getByRole('button', { name: 'More' })).toBeTruthy();
     expect(window.localStorage.getItem('moonmind.dashboard.preferences')).toContain(
       '"debugFieldsVisible":false',
     );
@@ -2990,7 +2996,7 @@ describe('Workflow Detail Entrypoint', () => {
     view.unmount();
     renderWithClient(<WorkflowDetailPage payload={stepsPayload} />);
     await screen.findByRole('link', { name: 'Overview' });
-    expect(screen.getByRole('link', { name: 'Debug' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'More' })).toBeTruthy();
     menu = await openWorkflowActionsMenu();
     expect(within(menu).getByRole('menuitem', { name: 'View: Show debug details' })).toBeTruthy();
   });
@@ -3151,7 +3157,7 @@ describe('Workflow Detail Entrypoint', () => {
       expect(screen.getAllByText('test-123').length).toBeGreaterThan(0);
       expect(screen.getByRole('button', { name: 'Show Workflow Inputs' })).toBeTruthy();
       expect(screen.queryByRole('heading', { name: 'Workflow Preview' })).toBeNull();
-      expect(screen.getByRole('link', { name: 'Debug' })).toBeTruthy();
+      expect(screen.getByRole('button', { name: 'More' })).toBeTruthy();
       expect(screen.queryByRole('heading', { name: 'Workflow Steps' })).toBeNull();
       expect(screen.queryByRole('heading', { name: 'Workflow Artifacts' })).toBeNull();
       expect(screen.queryByText(/^Task ID:?$/)).toBeNull();
@@ -3927,7 +3933,7 @@ describe('Workflow Detail Entrypoint', () => {
     const executingIcon = await screen.findByLabelText('Status: executing');
     expect(executingIcon.classList.contains('step-tl-icon')).toBe(true);
     expect(executingIcon.querySelector('svg.lucide-play')).toBeTruthy();
-    expect(screen.getByText('executing')).toBeTruthy();
+    expect(screen.getAllByText('executing').length).toBeGreaterThan(0);
     expect(
       fetchSpy.mock.calls.some(([url]) => String(url).includes('/agent-runs/agent-run-step-1/observability-summary')),
     ).toBe(false);
@@ -7945,7 +7951,7 @@ describe('Workflow Detail Entrypoint', () => {
 
     await waitFor(() => {
       expect(screen.getAllByRole('heading', { name: 'Execution History' })).toHaveLength(1);
-      expect(screen.getByRole('link', { name: 'Runs' }).getAttribute('aria-current')).toBe('page');
+      expect(screen.getByRole('link', { name: 'Execution' }).getAttribute('aria-current')).toBe('page');
       expect(screen.getByRole('link', { name: 'Overview' }).getAttribute('href')).toBe('/workflows/test-123/overview?source=temporal');
       expect(screen.getAllByText(/^Current Run ID:?$/).length).toBeGreaterThan(0);
       expect(screen.getAllByText('01-run').length).toBeGreaterThan(0);

--- a/frontend/src/entrypoints/workflow-detail.test.tsx
+++ b/frontend/src/entrypoints/workflow-detail.test.tsx
@@ -2421,39 +2421,6 @@ describe('Workflow Detail Entrypoint', () => {
       updatedAt: '2026-04-09T00:00:04Z',
       actions: {},
     };
-    const stepsSnapshot = {
-      workflowId: 'test-123',
-      runId: '02-run',
-      runScope: 'latest',
-      steps: [
-        {
-          logicalStepId: 'apply',
-          order: 1,
-          title: 'Apply patch',
-          tool: { type: 'agent_runtime', name: 'codex_cli', version: '1' },
-          dependsOn: [],
-          status: 'completed',
-          waitingReason: null,
-          attentionRequired: false,
-          executionOrdinal: 2,
-          startedAt: '2026-04-09T00:00:03Z',
-          updatedAt: '2026-04-09T00:00:04Z',
-          summary: 'Applied repository changes',
-          checks: [],
-          refs: { childWorkflowId: null, childRunId: null, agentRunId: null },
-          artifacts: {
-            outputSummary: null,
-            outputPrimary: 'art-apply-output',
-            runtimeStdout: null,
-            runtimeStderr: null,
-            runtimeMergedLogs: null,
-            runtimeDiagnostics: null,
-            providerSnapshot: null,
-          },
-          lastError: null,
-        },
-      ],
-    };
     const stepExecutionsResponse = {
       workflowId: 'test-123',
       runId: '02-run',

--- a/frontend/src/entrypoints/workflow-detail.test.tsx
+++ b/frontend/src/entrypoints/workflow-detail.test.tsx
@@ -387,7 +387,13 @@ describe('Workflow Detail Entrypoint', () => {
     fireEvent.click(screen.getByRole('button', { name }));
   }
 
-  function mockWorkflowDetailSubrouteFetch() {
+  function mockWorkflowDetailSubrouteFetch({
+    stepsSnapshot = latestStepsSnapshot,
+    relatedRuns,
+  }: {
+    stepsSnapshot?: typeof latestStepsSnapshot;
+    relatedRuns?: Array<Record<string, unknown>>;
+  } = {}) {
     const mockExecution = {
       taskId: 'test-123',
       workflowId: 'test-123',
@@ -406,7 +412,7 @@ describe('Workflow Detail Entrypoint', () => {
       createdAt: '2026-04-09T00:00:00Z',
       updatedAt: '2026-04-09T00:00:04Z',
       actions: {},
-      relatedRuns: [
+      relatedRuns: relatedRuns ?? [
         {
           workflowId: 'test-456',
           runId: '03-run',
@@ -422,7 +428,7 @@ describe('Workflow Detail Entrypoint', () => {
       if (url.includes('/executions/test-123/steps')) {
         return Promise.resolve({
           ok: true,
-          json: async () => latestStepsSnapshot,
+          json: async () => stepsSnapshot,
         } as Response);
       }
       if (url.includes('/artifacts?link_type=report.primary&latest_only=true')) {
@@ -1940,6 +1946,23 @@ describe('Workflow Detail Entrypoint', () => {
     });
   });
 
+  it('keeps a zero step count badge instead of falling back to run count', async () => {
+    window.history.pushState({}, 'Zero Step Badge Test', '/workflows/test-123/execution?source=temporal');
+    mockWorkflowDetailSubrouteFetch({
+      stepsSnapshot: { ...latestStepsSnapshot, steps: [] },
+      relatedRuns: [],
+    });
+
+    renderWithClient(<WorkflowDetailPage payload={stepsPayload} />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Workflow Steps' })).toBeTruthy();
+      const executionLink = screen.getByRole('link', { name: 'Execution' });
+      expect(executionLink.textContent).toContain('0');
+      expect(executionLink.textContent).not.toContain('1');
+    });
+  });
+
   it('MM-1020 switches Workflow Detail tabs with pushState without remounting or preloading tab data', async () => {
     window.history.pushState({}, 'Client Tab Test', '/workflows/test-123/overview?source=temporal');
     mockWorkflowDetailSubrouteFetch();
@@ -2553,7 +2576,7 @@ describe('Workflow Detail Entrypoint', () => {
         return Promise.resolve({ ok: true, json: async () => stepExecutionsResponse } as Response);
       }
       if (url.includes('/executions/test-123/steps')) {
-        return Promise.resolve({ ok: true, json: async () => stepsSnapshot } as Response);
+        return Promise.resolve({ ok: true, json: async () => latestStepsSnapshot } as Response);
       }
       if (url.includes('/artifacts')) {
         return Promise.resolve({ ok: true, json: async () => ({ artifacts: [] }) } as Response);
@@ -2943,6 +2966,7 @@ describe('Workflow Detail Entrypoint', () => {
 
     await waitFor(() => {
       expect(screen.getByRole('heading', { name: 'Debug' })).toBeTruthy();
+      expect(screen.getByRole('button', { name: 'More' }).getAttribute('class')).toContain('active');
       expect(screen.getByRole('heading', { name: 'Temporal' })).toBeTruthy();
     });
 

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -1761,18 +1761,18 @@ function SegmentedNav<T extends string>({
   onNavigate,
 }: {
   items: Array<SegmentedNavItem<T>>;
-  active: T;
+  active: T | null;
   ariaLabel: string;
   onNavigate: (value: T, href: string) => void;
 }) {
-  const activeIndex = Math.max(0, items.findIndex((item) => item.value === active));
+  const activeIndex = items.findIndex((item) => item.value === active);
   return (
     <nav
-      className="segmented-nav"
+      className={['segmented-nav', activeIndex < 0 ? 'segmented-nav-no-active' : ''].filter(Boolean).join(' ')}
       aria-label={ariaLabel}
       style={{
         '--segmented-nav-count': items.length,
-        '--segmented-nav-active-index': activeIndex,
+        '--segmented-nav-active-index': Math.max(0, activeIndex),
       } as CSSProperties}
     >
       {items.map((item) => (
@@ -6560,32 +6560,40 @@ function WorkflowDetailSubrouteNav({
     { value: 'chat', label: 'Chat', href: workflowDetailSubrouteHref(workflowId, 'chat', search) },
     { value: 'overview', label: 'Overview', href: workflowDetailSubrouteHref(workflowId, 'overview', search) },
     {
-      value: 'steps',
-      label: 'Steps',
-      href: workflowDetailSubrouteHref(workflowId, 'steps', search),
-      badge: stepCount ?? null,
+      value: 'execution',
+      label: 'Execution',
+      href: workflowDetailSubrouteHref(workflowId, 'execution', search),
+      badge: (stepCount ?? null) || (runCount ?? null),
     },
     {
-      value: 'artifacts',
-      label: 'Artifacts',
-      href: workflowDetailSubrouteHref(workflowId, 'artifacts', search),
+      value: 'evidence',
+      label: 'Evidence',
+      href: workflowDetailSubrouteHref(workflowId, 'evidence', search),
       badge: artifactCount ?? null,
     },
-    {
-      value: 'runs',
-      label: 'Runs',
-      href: workflowDetailSubrouteHref(workflowId, 'runs', search),
-      badge: runCount ?? null,
-    },
-    { value: 'debug', label: 'Debug', href: workflowDetailSubrouteHref(workflowId, 'debug', search) },
   ];
+  const debugHref = workflowDetailSubrouteHref(workflowId, 'debug', search);
   return (
-    <SegmentedNav
-      items={items}
-      active={current}
-      ariaLabel="Workflow detail sections"
-      onNavigate={onNavigate}
-    />
+    <>
+      <SegmentedNav
+        items={items}
+        active={current === 'debug' ? null : current}
+        ariaLabel="Workflow detail sections"
+        onNavigate={onNavigate}
+      />
+      <WorkflowActionsMenu
+        items={[
+          {
+            id: 'workflow-detail-debug',
+            label: 'Debug',
+            onSelect: () => onNavigate('debug', debugHref),
+          },
+        ]}
+        triggerContent="More"
+        triggerClassName="secondary td-subroute-more-trigger"
+        menuAriaLabel="More workflow detail sections"
+      />
+    </>
   );
 }
 
@@ -6833,10 +6841,12 @@ export function WorkflowDetailPage({ payload }: { payload: BootPayload }) {
   const missingAgentRunState = execution && !resolvedAgentRunId ? inferMissingAgentRunState(execution) : null;
 
   const chatTabActive = detailSubroute === 'chat';
-  const stepsTabActive = detailSubroute === 'steps';
-  const artifactsTabActive = detailSubroute === 'artifacts';
+  const executionTabActive = detailSubroute === 'execution';
+  const evidenceTabActive = detailSubroute === 'evidence';
+  const stepsTabActive = executionTabActive;
+  const artifactsTabActive = evidenceTabActive;
   const overviewTabActive = detailSubroute === 'overview';
-  const runsTabActive = detailSubroute === 'runs';
+  const runsTabActive = executionTabActive;
   const debugTabActive = detailSubroute === 'debug';
   const shouldFetchStepLedger = (stepsTabActive || artifactsTabActive) && Boolean(execution?.stepsHref);
 

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -1787,7 +1787,9 @@ function SegmentedNav<T extends string>({
           }}
         >
           <span>{item.label}</span>
-          {item.badge ? <span className="segmented-nav-badge" aria-hidden="true">{item.badge}</span> : null}
+          {item.badge !== null && item.badge !== undefined ? (
+            <span className="segmented-nav-badge" aria-hidden="true">{item.badge}</span>
+          ) : null}
         </a>
       ))}
     </nav>
@@ -6563,7 +6565,7 @@ function WorkflowDetailSubrouteNav({
       value: 'execution',
       label: 'Execution',
       href: workflowDetailSubrouteHref(workflowId, 'execution', search),
-      badge: (stepCount ?? null) || (runCount ?? null),
+      badge: stepCount ?? runCount ?? null,
     },
     {
       value: 'evidence',
@@ -6590,7 +6592,7 @@ function WorkflowDetailSubrouteNav({
           },
         ]}
         triggerContent="More"
-        triggerClassName="secondary td-subroute-more-trigger"
+        triggerClassName={`secondary td-subroute-more-trigger${current === 'debug' ? ' active' : ''}`}
         menuAriaLabel="More workflow detail sections"
       />
     </>

--- a/frontend/src/lib/dashboardRoutes.test.ts
+++ b/frontend/src/lib/dashboardRoutes.test.ts
@@ -13,7 +13,7 @@ describe('dashboard route resolution', () => {
     });
   });
 
-  it.each(['chat', 'overview', 'steps', 'artifacts', 'runs', 'debug'])(
+  it.each(['chat', 'overview', 'execution', 'evidence', 'steps', 'artifacts', 'runs', 'debug'])(
     'resolves encoded workflow IDs with the %s detail tab',
     (tab) => {
       const path = `/workflows/mm%3A97d44980-355c-4300-96a7-0ad166440d95/${tab}`;

--- a/frontend/src/lib/dashboardRoutes.ts
+++ b/frontend/src/lib/dashboardRoutes.ts
@@ -1,5 +1,5 @@
 import type { BootPayload } from '../boot/parseBootPayload';
-import { WORKFLOW_DETAIL_SUBROUTES } from './workflowDetailRoutes';
+import { WORKFLOW_DETAIL_SUPPORTED_SUBROUTES } from './workflowDetailRoutes';
 
 export type DashboardPage =
   | 'index-health'
@@ -34,7 +34,7 @@ export type DashboardUiInfo = {
 
 const DETAIL_SEGMENT = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/;
 const WORKFLOW_ID_SEGMENT = /^[A-Za-z0-9][A-Za-z0-9._:{}-]{0,254}$/;
-const WORKFLOW_DETAIL_TABS = new Set<string>(WORKFLOW_DETAIL_SUBROUTES);
+const WORKFLOW_DETAIL_TABS = new Set<string>(WORKFLOW_DETAIL_SUPPORTED_SUBROUTES);
 
 function withoutTrailingSlash(pathname: string): string {
   return pathname.length > 1 && pathname.endsWith('/') ? pathname.slice(0, -1) : pathname;

--- a/frontend/src/lib/workflowDetailRoutes.test.ts
+++ b/frontend/src/lib/workflowDetailRoutes.test.ts
@@ -13,12 +13,21 @@ describe('workflow detail route helpers', () => {
     ['/workflows/mm%3A123', 'mm:123', 'chat'],
     ['/workflows/mm%3A123/chat', 'mm:123', 'chat'],
     ['/workflows/mm%3A123/overview', 'mm:123', 'overview'],
-    ['/workflows/mm%3A123/steps', 'mm:123', 'steps'],
-    ['/workflows/mm%3A123/artifacts', 'mm:123', 'artifacts'],
-    ['/workflows/mm%3A123/runs', 'mm:123', 'runs'],
+    ['/workflows/mm%3A123/execution', 'mm:123', 'execution'],
+    ['/workflows/mm%3A123/evidence', 'mm:123', 'evidence'],
     ['/workflows/mm%3A123/debug', 'mm:123', 'debug'],
   ] as const)('decodes supported route %s', (path, workflowId, subroute) => {
     expect(decodeWorkflowIdFromPath(path)).toBe(workflowId);
+    expect(workflowDetailSubrouteFromPath(path)).toBe(subroute);
+    expect(isWorkflowDetailPath(path)).toBe(true);
+  });
+
+  it.each([
+    ['/workflows/mm%3A123/steps', 'execution'],
+    ['/workflows/mm%3A123/runs', 'execution'],
+    ['/workflows/mm%3A123/artifacts', 'evidence'],
+  ] as const)('maps legacy route %s to %s', (path, subroute) => {
+    expect(decodeWorkflowIdFromPath(path)).toBe('mm:123');
     expect(workflowDetailSubrouteFromPath(path)).toBe(subroute);
     expect(isWorkflowDetailPath(path)).toBe(true);
   });
@@ -33,9 +42,8 @@ describe('workflow detail route helpers', () => {
     expect(WORKFLOW_DETAIL_SUBROUTES.map((subroute) => workflowDetailSubrouteHref('mm:123', subroute, search))).toEqual([
       '/workflows/mm%3A123?source=temporal&stateIn=failed',
       '/workflows/mm%3A123/overview?source=temporal&stateIn=failed',
-      '/workflows/mm%3A123/steps?source=temporal&stateIn=failed',
-      '/workflows/mm%3A123/artifacts?source=temporal&stateIn=failed',
-      '/workflows/mm%3A123/runs?source=temporal&stateIn=failed',
+      '/workflows/mm%3A123/execution?source=temporal&stateIn=failed',
+      '/workflows/mm%3A123/evidence?source=temporal&stateIn=failed',
       '/workflows/mm%3A123/debug?source=temporal&stateIn=failed',
     ]);
   });

--- a/frontend/src/lib/workflowDetailRoutes.ts
+++ b/frontend/src/lib/workflowDetailRoutes.ts
@@ -1,15 +1,25 @@
 export const WORKFLOW_DETAIL_SUBROUTES = [
   'chat',
   'overview',
-  'steps',
-  'artifacts',
-  'runs',
+  'execution',
+  'evidence',
   'debug',
 ] as const;
 
 export type WorkflowDetailSubroute = (typeof WORKFLOW_DETAIL_SUBROUTES)[number];
 
-const WORKFLOW_DETAIL_SUBROUTE_PATTERN = WORKFLOW_DETAIL_SUBROUTES.join('|');
+const WORKFLOW_DETAIL_SUBROUTE_ALIASES = {
+  steps: 'execution',
+  runs: 'execution',
+  artifacts: 'evidence',
+} as const satisfies Record<string, WorkflowDetailSubroute>;
+
+const WORKFLOW_DETAIL_SUPPORTED_SUBROUTES = [
+  ...WORKFLOW_DETAIL_SUBROUTES,
+  ...Object.keys(WORKFLOW_DETAIL_SUBROUTE_ALIASES),
+] as const;
+
+const WORKFLOW_DETAIL_SUBROUTE_PATTERN = WORKFLOW_DETAIL_SUPPORTED_SUBROUTES.join('|');
 const WORKFLOW_DETAIL_PATH_PATTERN = new RegExp(
   `^/workflows/([^/]+)(?:/(${WORKFLOW_DETAIL_SUBROUTE_PATTERN}))?/?$`,
 );
@@ -29,7 +39,14 @@ export function decodeWorkflowIdFromPath(pathname: string): string | null {
 
 export function workflowDetailSubrouteFromPath(pathname: string): WorkflowDetailSubroute {
   const match = pathname.match(WORKFLOW_DETAIL_PATH_PATTERN);
-  return (match?.[2] as WorkflowDetailSubroute | undefined) || 'chat';
+  const subroute = match?.[2] || '';
+  return (
+    WORKFLOW_DETAIL_SUBROUTE_ALIASES[
+      subroute as keyof typeof WORKFLOW_DETAIL_SUBROUTE_ALIASES
+    ] ||
+    (subroute as WorkflowDetailSubroute | undefined) ||
+    'chat'
+  );
 }
 
 export function workflowDetailSubrouteHref(

--- a/frontend/src/lib/workflowDetailRoutes.ts
+++ b/frontend/src/lib/workflowDetailRoutes.ts
@@ -8,13 +8,13 @@ export const WORKFLOW_DETAIL_SUBROUTES = [
 
 export type WorkflowDetailSubroute = (typeof WORKFLOW_DETAIL_SUBROUTES)[number];
 
-const WORKFLOW_DETAIL_SUBROUTE_ALIASES = {
+export const WORKFLOW_DETAIL_SUBROUTE_ALIASES = {
   steps: 'execution',
   runs: 'execution',
   artifacts: 'evidence',
 } as const satisfies Record<string, WorkflowDetailSubroute>;
 
-const WORKFLOW_DETAIL_SUPPORTED_SUBROUTES = [
+export const WORKFLOW_DETAIL_SUPPORTED_SUBROUTES = [
   ...WORKFLOW_DETAIL_SUBROUTES,
   ...Object.keys(WORKFLOW_DETAIL_SUBROUTE_ALIASES),
 ] as const;

--- a/frontend/src/lib/workflowListDisplayMode.test.ts
+++ b/frontend/src/lib/workflowListDisplayMode.test.ts
@@ -90,7 +90,7 @@ describe('resolveWorkflowListDisplay', () => {
     });
   });
 
-  it.each(['chat', 'overview', 'steps', 'artifacts', 'runs', 'debug'])(
+  it.each(['chat', 'overview', 'execution', 'evidence', 'steps', 'artifacts', 'runs', 'debug'])(
     'preserves the %s detail subroute when switching only between hidden and sidebar',
     (subroute) => {
       const pathname = subroute === 'chat' ? '/workflows/mm%3A123/chat' : `/workflows/mm%3A123/${subroute}`;

--- a/frontend/src/lib/workflowListDisplayMode.ts
+++ b/frontend/src/lib/workflowListDisplayMode.ts
@@ -1,5 +1,5 @@
 import { workflowListContextParams } from './workflowListContext';
-import { WORKFLOW_DETAIL_SUBROUTES } from './workflowDetailRoutes';
+import { WORKFLOW_DETAIL_SUPPORTED_SUBROUTES } from './workflowDetailRoutes';
 
 export type WorkflowListDisplayMode = 'hidden' | 'sidebar' | 'table';
 
@@ -56,7 +56,7 @@ export type ResolveWorkflowListDisplayInput = {
   firstVisibleWorkflowId?: string | null;
 };
 
-const DETAIL_TABS = new Set<string>(WORKFLOW_DETAIL_SUBROUTES);
+const DETAIL_TABS = new Set<string>(WORKFLOW_DETAIL_SUPPORTED_SUBROUTES);
 
 export const WORKFLOW_LIST_DISPLAY_MODES = [
   {

--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -7678,7 +7678,9 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
 }
 
 .td-subroute-nav-row {
-  display: block;
+  display: flex;
+  align-items: stretch;
+  gap: 0.5rem;
 }
 
 .segmented-nav {
@@ -7715,6 +7717,10 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
   transition: transform 180ms ease;
   pointer-events: none;
   z-index: 0;
+}
+
+.segmented-nav-no-active::before {
+  opacity: 0;
 }
 
 .segmented-nav-item {
@@ -7758,6 +7764,13 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
   font-size: 0.72rem;
   font-weight: 700;
   line-height: 1.25;
+}
+
+.td-subroute-more-trigger {
+  min-height: 2.65rem;
+  padding-inline: 0.9rem;
+  border-radius: 10px;
+  white-space: nowrap;
 }
 
 .td-facts-region {

--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -7773,6 +7773,12 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
   white-space: nowrap;
 }
 
+.td-subroute-more-trigger.active {
+  border-color: rgb(var(--mm-accent));
+  background: rgb(var(--mm-accent) / 0.14);
+  color: rgb(var(--mm-ink));
+}
+
 .td-facts-region {
   display: grid;
   gap: 0.2rem;


### PR DESCRIPTION
I’d reduce Workflow Detail from 6 top-level tabs to 4 primary tabs, with Debug moved behind an Advanced / More affordance rather than treated as a normal tab.

The current implementation has these six subroutes: chat, overview, steps, artifacts, runs, and debug, and the nav renders them as Chat, Overview, Steps, Artifacts, Runs, Debug.

Recommended tab model

New tab

Combine from

What belongs there

Chat

Keep current Chat

Session transcript, live runtime events, follow-up controls, interrupt/cancel/reset controls. This is already what the Chat tab is doing.

Overview

Keep current Overview

Summary, lifecycle, runtime, repo/publish facts, outcome, high-level run count/status. Keep it scannable.

Execution

Combine Steps + Runs

Step ledger, timing, branch explorer, recovery controls, audit trail, execution history, run comparison. Steps and Runs are both about “what happened during execution,” just at different granularity.

Evidence

Rename/expand Artifacts

Reports, input images, remediation evidence, artifact browser, remediation relationships, logs/diagnostic artifacts. The current Artifacts tab already contains most of this, so “Evidence” is a better label than “Artifacts.”

Then keep Debug as an Advanced drawer/menu item or conditional tab. The Debug screen is raw Temporal/runtime identifiers plus action capability/debug metadata, which is diagnostic-only and explicitly “does not affect the default overview,” so it should not consume normal navigation space.

The strongest combinations

Combine Steps + Runs → Execution.


This is the cleanest win. “Steps” shows the step ledger, timing, branch explorer, recovery, intervention monitor, audit trail, and observation fallback. “Runs” shows execution history and run comparison. Those are one mental model: execution state and execution history. The previous PR history also shows the page originally split into Overview, Steps, Artifacts, and Runs, while later work added Debug and then visual/count-aware tabs.

Rename Artifacts → Evidence rather than adding more artifact-like tabs.


The current Artifacts tab is not just a file browser; it renders report presentation, input images, remediation evidence, artifact browsing, and remediation relationships. That is broader than “Artifacts.” “Evidence” better matches what users are trying to find.

Move Debug to Advanced / More.


I would not combine Debug with Overview by default. It was intentionally split out because raw Temporal/runtime fields are noisy and diagnostic. A “More ▾ → Debug” item keeps deep-linkability without making everyday users choose among six tabs. PR #2743 says Debug moved raw Temporal/runtime details and debug metadata out of the default overview into a Debug subroute.

Keep Chat separate, but remove duplicate observability from Steps.


Chat is already the operational console: transcript, live events, and eligible operator controls. Steps still has fallback observation/live logs/static logs/diagnostics, which risks reintroducing the repeated-information problem. I’d make Chat the primary live-observability surface and let Execution link to “Open live logs in Chat” or show a compact embedded preview only when needed.

My final recommendation

Use this top-level nav:

Chat · Overview · Execution · Evidence · More

Where More contains Debug and possibly other rarely used diagnostic views.

This reduces visual choice from six tabs to four primary decisions, while preserving the core user journeys:

“Talk to or observe the running workflow” → Chat

“What is this workflow and how did it end?” → Overview

“What happened step-by-step or across runs?” → Execution

“Where are the outputs, reports, logs, and remediation evidence?” → Evidence

“I need raw internals” → More → Debug

Implementation-wise, the main code changes would be in WorkflowDetailSubroute, workflowDetailSubrouteFromPath, workflowDetailSubrouteHref, and WorkflowDetailSubrouteNav. I’d keep backwards-compatible aliases so /steps and /runs map to /execution, /artifacts maps to /evidence, and /debug still works even if it is no longer a primary tab.