### PR TITLE
[codex] Fix Jira assessment verdict parsing

### DIFF
--- a/moonmind/workflows/temporal/story_output_tools.py
+++ b/moonmind/workflows/temporal/story_output_tools.py
@@ -4521,7 +4521,7 @@ def _assessment_verdict_from_text(value: Any) -> str:
     )
     verdict_prefix = r"[\s:`*_\"']*"
     verdict_suffix = r"(?:_+(?!\w)|(?![-\w]))"
-    assessment_separator = r"[\s:`*_\"'\[\]\(\)]*"
+    assessment_separator = r"[\s:.,;\-`*_\"'\[\]\(\)]*"
     issue_ref_pattern = r"`?[A-Z][A-Z0-9]+-\d+`?"
     patterns = (
         r"(?im)^\s*verdict\s*[:\-]\s*"

--- a/moonmind/workflows/temporal/story_output_tools.py
+++ b/moonmind/workflows/temporal/story_output_tools.py
@@ -4521,7 +4521,7 @@ def _assessment_verdict_from_text(value: Any) -> str:
     )
     verdict_prefix = r"[\s:`*_\"']*"
     verdict_suffix = r"(?:_+(?!\w)|(?![-\w]))"
-    assessment_separator = r"[\s:.,;\-`*_\"'\[\]\(\)]*"
+    assessment_separator = r"[\s:.,;!?\-`*_\"'\[\]\(\)]*"
     issue_ref_pattern = r"`?[A-Z][A-Z0-9]+-\d+`?"
     patterns = (
         r"(?im)^\s*verdict\s*[:\-]\s*"

--- a/tests/unit/workflows/temporal/test_story_output_tools.py
+++ b/tests/unit/workflows/temporal/test_story_output_tools.py
@@ -634,8 +634,17 @@ async def test_update_jira_issue_status_accepts_bold_previous_assessment_verdict
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "assistant_text",
+    [
+        "Assessment complete. Verdict: `PARTIALLY_IMPLEMENTED`.",
+        "Assessment complete! Verdict: `PARTIALLY_IMPLEMENTED`.",
+        "Assessment complete? Verdict: `PARTIALLY_IMPLEMENTED`.",
+    ],
+)
 async def test_update_jira_issue_status_accepts_sentence_previous_assessment_verdict(
     tmp_path,
+    assistant_text,
 ) -> None:
     service = _FakeJiraService()
     service.issue_responses["MM-1125"] = {
@@ -658,9 +667,7 @@ async def test_update_jira_issue_status_accepts_sentence_previous_assessment_ver
             "targetStatus": "In Progress",
             "assessmentArtifactPath": str(tmp_path / "missing-assessment.json"),
             "previousOutputs": {
-                "lastAssistantText": (
-                    "Assessment complete. Verdict: `PARTIALLY_IMPLEMENTED`."
-                ),
+                "lastAssistantText": assistant_text,
             },
         },
         jira_service_factory=lambda: service,
@@ -3317,7 +3324,7 @@ async def test_check_jira_blockers_preserves_sentence_previous_assessment_verdic
             "assessmentArtifactPath": "artifacts/jira-implement-assessment.json",
             "previousOutputs": {
                 "lastAssistantText": (
-                    "Assessment complete. Verdict: `PARTIALLY_IMPLEMENTED`."
+                    "Assessment complete! Verdict: `PARTIALLY_IMPLEMENTED`."
                 ),
             },
         },
@@ -3435,7 +3442,7 @@ async def test_jira_implement_status_update_uses_blocker_preserved_assessment_ve
             "assessmentArtifactPath": "artifacts/jira-implement-assessment.json",
             "previousOutputs": {
                 "lastAssistantText": (
-                    "Assessment complete. Verdict: `PARTIALLY_IMPLEMENTED`."
+                    "Assessment complete? Verdict: `PARTIALLY_IMPLEMENTED`."
                 ),
             },
         },

--- a/tests/unit/workflows/temporal/test_story_output_tools.py
+++ b/tests/unit/workflows/temporal/test_story_output_tools.py
@@ -634,6 +634,44 @@ async def test_update_jira_issue_status_accepts_bold_previous_assessment_verdict
 
 
 @pytest.mark.asyncio
+async def test_update_jira_issue_status_accepts_sentence_previous_assessment_verdict(
+    tmp_path,
+) -> None:
+    service = _FakeJiraService()
+    service.issue_responses["MM-1125"] = {
+        "key": "MM-1125",
+        "fields": {"status": {"id": "1", "name": "Backlog"}},
+    }
+    service.transition_responses["MM-1125"] = {
+        "key": "MM-1125",
+        "fields": {"status": {"id": "3", "name": "In Progress"}},
+    }
+    service.transitions_response = {
+        "transitions": [
+            {"id": "31", "name": "In Progress", "to": {"name": "In Progress"}}
+        ]
+    }
+
+    result = await update_jira_issue_status(
+        {
+            "issueKey": "MM-1125",
+            "targetStatus": "In Progress",
+            "assessmentArtifactPath": str(tmp_path / "missing-assessment.json"),
+            "previousOutputs": {
+                "lastAssistantText": (
+                    "Assessment complete. Verdict: `PARTIALLY_IMPLEMENTED`."
+                ),
+            },
+        },
+        jira_service_factory=lambda: service,
+    )
+
+    assert result.status == "COMPLETED"
+    assert result.outputs["decision"] == "transitioned"
+    assert service.transition_requests[0].transition_id == "31"
+
+
+@pytest.mark.asyncio
 async def test_update_jira_issue_status_accepts_issue_key_before_bold_verdict(
     tmp_path,
 ) -> None:
@@ -3266,6 +3304,32 @@ async def test_check_jira_blockers_preserves_bold_previous_assessment_verdict():
 
 
 @pytest.mark.asyncio
+async def test_check_jira_blockers_preserves_sentence_previous_assessment_verdict():
+    service = _FakeJiraService()
+    service.issue_responses["MM-2"] = {
+        "key": "MM-2",
+        "fields": {"issuelinks": []},
+    }
+
+    result = await check_jira_blockers(
+        {
+            "targetIssueKey": "MM-2",
+            "assessmentArtifactPath": "artifacts/jira-implement-assessment.json",
+            "previousOutputs": {
+                "lastAssistantText": (
+                    "Assessment complete. Verdict: `PARTIALLY_IMPLEMENTED`."
+                ),
+            },
+        },
+        jira_service_factory=lambda: service,
+    )
+
+    assert result.status == "COMPLETED"
+    assert result.outputs["decision"] == "continue"
+    assert result.outputs["assessmentVerdict"] == "PARTIALLY_IMPLEMENTED"
+
+
+@pytest.mark.asyncio
 async def test_check_jira_blockers_preserves_issue_key_before_bold_verdict():
     service = _FakeJiraService()
     service.issue_responses["MM-1133"] = {
@@ -3370,7 +3434,9 @@ async def test_jira_implement_status_update_uses_blocker_preserved_assessment_ve
             "targetIssueKey": "MM-2",
             "assessmentArtifactPath": "artifacts/jira-implement-assessment.json",
             "previousOutputs": {
-                "lastAssistantText": "Assessment complete: **PARTIALLY_IMPLEMENTED**.",
+                "lastAssistantText": (
+                    "Assessment complete. Verdict: `PARTIALLY_IMPLEMENTED`."
+                ),
             },
         },
         jira_service_factory=lambda: service,


### PR DESCRIPTION
## Summary
- accept sentence-style Jira assessment verdict text such as `Assessment complete. Verdict: PARTIALLY_IMPLEMENTED`
- preserve that verdict through Jira blocker checks so the In Progress transition can continue
- add regression tests for direct status updates and the blocker-to-status handoff

## Root Cause
Jira Implement runs could fail with `Jira In Progress update requires an assessment verdict, but it was unavailable` even when the previous agent step reported a valid assessment. The verdict parser accepted colon/newline forms but not the sentence form emitted by the failed workflow.

## Validation
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --python-only tests/unit/workflows/temporal/test_story_output_tools.py`
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_story_output_tools.py -k 'assessment_verdict or jira_implement_status_update'`\n