### PR TITLE
Expose verification toggles on workflow presets

### DIFF
--- a/.agents/skills/batch-workflows/SKILL.md
+++ b/.agents/skills/batch-workflows/SKILL.md
@@ -39,6 +39,8 @@ Progress" with a single batch run.
   `preset:github-issue-implement` for non-default GitHub target files.
 - `max_workflows` (number, optional): hard cap on queued children. Default `25`.
 - `constraints` (string, optional): shared input copied to every child.
+- `run_verify` (boolean, optional): shared verification toggle copied to child
+  implement presets. Default `true`.
 - `additional_jql` (string, optional): advanced JQL AND-clause appended to the
   project/status query.
 - `repository` (string, optional): repository override when workflow context
@@ -79,6 +81,7 @@ Progress" with a single batch run.
      --run-ref <skill:jira-verify|preset:jira-implement> \
      --publish-mode <none|branch|pr|pr_with_merge_automation> \
      --constraints-file <optional path to shared constraints> \
+     --run-verify | --no-run-verify \
      --max-workflows <cap>
    ```
 
@@ -87,9 +90,9 @@ Progress" with a single batch run.
      `jira_issue_key`, `repository`, `verification_mode`, `update_status`, and
      `constraints`).
    - Auto-binds Jira issues into `preset:jira-implement` inputs
-     (`jira_issue`, `jira_issue_key`, and `constraints`).
+     (`jira_issue`, `jira_issue_key`, `constraints`, and `run_verify`).
    - Auto-binds GitHub issue targets into `preset:github-issue-implement` inputs
-     when a non-default GitHub target file is provided.
+     when a non-default GitHub target file is provided, including `run_verify`.
    - Stamps `runtimeInheritance="caller"` plus a fallback copy of the parent's
      effective runtime (mode/model/effort/provider profile) so children reuse the
      caller runtime even on deployments that do not honour the inheritance

--- a/.agents/skills/batch-workflows/bin/batch_workflows.py
+++ b/.agents/skills/batch-workflows/bin/batch_workflows.py
@@ -69,6 +69,7 @@ class TargetConfig:
     target_slug: str
     publish_mode: str = "pr"
     constraints: str = ""
+    run_verify: bool = True
     required_capabilities: list[str] = field(default_factory=list)
 
 
@@ -198,6 +199,7 @@ def bind_child_inputs(
     target_slug: str,
     constraints: str,
     fallback_repository: str | None = None,
+    run_verify: bool = True,
 ) -> dict[str, Any] | None:
     """Apply the default issue bindings for the selected child target.
 
@@ -245,6 +247,7 @@ def bind_child_inputs(
             "jira_issue": dict(issue) if issue else {"key": key},
             "jira_issue_key": key,
             "constraints": shared or "",
+            "run_verify": bool(run_verify),
         }
         return inputs
     if (
@@ -273,6 +276,7 @@ def bind_child_inputs(
             "github_issue": resolved_issue,
             "github_issue_ref": f"{repository}#{number}",
             "constraints": shared or "",
+            "run_verify": bool(run_verify),
         }
         return inputs
     return None
@@ -338,6 +342,7 @@ def build_child_request(
         config.target_slug,
         config.constraints,
         fallback_repository=repository,
+        run_verify=config.run_verify,
     )
     if goal is None or inputs is None:
         return None
@@ -771,6 +776,12 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--publish-mode", default="pr")
     parser.add_argument("--constraints", default=None)
     parser.add_argument("--constraints-file", default=None)
+    parser.add_argument(
+        "--run-verify",
+        dest="run_verify",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+    )
     parser.add_argument("--max-workflows", type=int, default=25)
     parser.add_argument("--task-context-path", default=None)
     parser.add_argument("--artifacts-dir", default="artifacts")
@@ -795,6 +806,7 @@ async def main(argv: list[str] | None = None) -> int:
         target_slug=target_slug,
         publish_mode=_normalize_publish_mode(args.publish_mode),
         constraints=constraints,
+        run_verify=bool(args.run_verify),
     )
 
     submissions, skipped = build_child_requests(

--- a/api_service/data/presets/batch-workflows.yaml
+++ b/api_service/data/presets/batch-workflows.yaml
@@ -197,6 +197,7 @@ steps:
     --run-ref "{{ inputs.run_ref }}" \
     --publish-mode "{{ inputs.publish_mode }}" \
     --max-workflows "{{ inputs.max_workflows }}" \
+    {% if inputs.run_verify %}--run-verify{% else %}--no-run-verify{% endif %} \
     --constraints "{{ inputs.constraints }}"
     The helper stamps runtimeInheritance="caller" plus a fallback copy of the parent
     runtime on each child and assigns a stable idempotency key per target kind,

--- a/api_service/data/presets/batch-workflows.yaml
+++ b/api_service/data/presets/batch-workflows.yaml
@@ -33,10 +33,12 @@ annotations:
       jira_issue: '{{ target.jiraIssue }}'
       jira_issue_key: '{{ target.jiraIssue.key }}'
       constraints: '{{ shared.constraints }}'
+      run_verify: '{{ shared.run_verify }}'
     preset:github-issue-implement:
       github_issue: '{{ target.githubIssue }}'
       github_issue_ref: '{{ target.githubIssue.repository }}#{{ target.githubIssue.number }}'
       constraints: '{{ shared.constraints }}'
+      run_verify: '{{ shared.run_verify }}'
   inputSchema:
     type: object
     required:
@@ -65,6 +67,11 @@ annotations:
       constraints:
         type: string
         title: Extra instructions / constraints
+      run_verify:
+        type: boolean
+        title: Run verification
+        description: Run verification in child implement workflows.
+        default: true
       additional_jql:
         type: string
         title: Additional JQL filter
@@ -87,6 +94,8 @@ annotations:
     constraints:
       widget: textarea
       advanced: true
+    run_verify:
+      widget: checkbox
     additional_jql:
       widget: textarea
       advanced: true
@@ -98,6 +107,7 @@ annotations:
   defaults:
     run_ref: skill:jira-verify
     max_workflows: '25'
+    run_verify: true
     publish_mode: none
 inputs:
 - name: jira_project_key
@@ -128,6 +138,11 @@ inputs:
   type: textarea
   required: false
   default: ''
+- name: run_verify
+  label: Run Verification
+  type: boolean
+  required: false
+  default: true
 - name: additional_jql
   label: Additional JQL Filter
   type: textarea
@@ -203,6 +218,7 @@ steps:
       runRef: '{{ inputs.run_ref }}'
     sharedInputs:
       constraints: '{{ inputs.constraints }}'
+      run_verify: '{{ inputs.run_verify }}'
     publish:
       mode: '{{ inputs.publish_mode }}'
     runtime:

--- a/api_service/data/presets/github-issue-breakdown-implement.yaml
+++ b/api_service/data/presets/github-issue-breakdown-implement.yaml
@@ -39,6 +39,11 @@ inputs:
       - pr
       - branch
       - none
+  - name: run_verify
+    label: Run Verification
+    type: boolean
+    required: false
+    default: true
   - name: source_issue_key
     label: Source Issue Key
     type: text
@@ -128,6 +133,8 @@ steps:
         repository: "{{ inputs.github_repository }}"
         runtime:
           mode: "{{ context.targetRuntime }}"
+        inputs:
+          run_verify: "{{ inputs.run_verify }}"
         publish:
           mode: "{{ inputs.publish_mode }}"
       traceability:

--- a/api_service/data/presets/github-issue-breakdown-orchestrate.yaml
+++ b/api_service/data/presets/github-issue-breakdown-orchestrate.yaml
@@ -39,6 +39,11 @@ inputs:
       - pr
       - branch
       - none
+  - name: run_verify
+    label: Run Verification
+    type: boolean
+    required: false
+    default: true
   - name: source_issue_key
     label: Source Issue Key
     type: text
@@ -129,6 +134,8 @@ steps:
         repository: "{{ inputs.github_repository }}"
         runtime:
           mode: "{{ context.targetRuntime }}"
+        inputs:
+          run_verify: "{{ inputs.run_verify }}"
         publish:
           mode: "{{ inputs.publish_mode }}"
       traceability:

--- a/api_service/data/presets/github-issue-implement.yaml
+++ b/api_service/data/presets/github-issue-implement.yaml
@@ -71,13 +71,19 @@ annotations:
             type: array
             items:
               type: string
+      run_verify:
+        type: boolean
+        title: Run verification
+        description: Run the MoonSpec verification and remediation gate before pull request creation and GitHub issue handoff.
+        default: true
   uiSchema:
     github_issue:
       widget: github.issue-picker
       dataSource: github.issues
       searchPlaceholder: Search GitHub issues
       allowManualIssueEntry: true
-  defaults: {}
+  defaults:
+    run_verify: true
 inputs:
 - name: github_issue_ref
   label: GitHub Issue Reference
@@ -89,6 +95,11 @@ inputs:
   type: textarea
   required: false
   default: ''
+- name: run_verify
+  label: Run Verification
+  type: boolean
+  required: false
+  default: true
 steps:
 - title: Load GitHub issue brief
   type: tool
@@ -179,6 +190,7 @@ steps:
     verification_target: issue_brief
     remediation_max_attempts: '6'
     constraints: '{{ inputs.constraints }}'
+    run_verify: '{{ inputs.run_verify }}'
 - title: Finalize GitHub issue status
   type: tool
   instructions: 'Read artifacts/github-issue-implement-assessment.json (or the recorded
@@ -187,15 +199,21 @@ steps:
 
     If the recorded verdict is BLOCKED, stop without changing GitHub and report the
     blocking evidence. If the recorded verdict is FULLY_IMPLEMENTED, apply the configured
-    Done strategy. Otherwise read artifacts/github-issue-implement-verify.json and
-    require the latest controlling verifier result to report FULLY_IMPLEMENTED before
-    any Code Review update. Then read artifacts/github-issue-implement-pr.json, verify
-    it contains a pull_request_url for {{ inputs.github_issue.repository }}#{{ inputs.github_issue.number
-    }}, and apply the configured Code Review strategy with the pull request URL.
-    If the verifier artifact is missing, terminal, or still reports ADDITIONAL_WORK_NEEDED
-    after remediation is exhausted, stop without changing GitHub. Do not assume a
-    single organization''s workflow; use the configured label/comment/close strategy
-    exposed by the trusted GitHub update tool.'
+    Done strategy. Otherwise {% if inputs.run_verify %}read artifacts/github-issue-implement-verify.json
+    and require the latest controlling verifier result to report FULLY_IMPLEMENTED
+    before any Code Review update.{% else %}confirm implementation is complete and
+    the focused tests required by the issue have passed. Verification was disabled
+    for this workflow execution, so do not require artifacts/github-issue-implement-verify.json
+    or a moonspec-verify verdict before any Code Review update.{% endif %} Then
+    read artifacts/github-issue-implement-pr.json, verify it contains a pull_request_url
+    for {{ inputs.github_issue.repository }}#{{ inputs.github_issue.number }}, and
+    apply the configured Code Review strategy with the pull request URL. {% if inputs.run_verify
+    %}If the verifier artifact is missing, terminal, or still reports ADDITIONAL_WORK_NEEDED
+    after remediation is exhausted, stop without changing GitHub.{% else %}If the
+    pull request artifact is missing or lacks a confirmed pull_request_url, stop
+    without changing GitHub.{% endif %} Do not assume a single organization''s workflow;
+    use the configured label/comment/close strategy exposed by the trusted GitHub
+    update tool.'
   tool:
     id: github.update_issue_status
     requiredCapabilities:
@@ -206,3 +224,4 @@ steps:
       mode: finalize_after_pr_or_done
       pullRequestArtifactPath: artifacts/github-issue-implement-pr.json
       verificationArtifactPath: artifacts/github-issue-implement-verify.json
+      requireVerification: '{{ inputs.run_verify }}'

--- a/api_service/data/presets/github-issue-orchestrate.yaml
+++ b/api_service/data/presets/github-issue-orchestrate.yaml
@@ -71,13 +71,19 @@ annotations:
             type: array
             items:
               type: string
+      run_verify:
+        type: boolean
+        title: Run verification
+        description: Run the MoonSpec verification and remediation gate before pull request creation and GitHub issue handoff.
+        default: true
   uiSchema:
     github_issue:
       widget: github.issue-picker
       dataSource: github.issues
       searchPlaceholder: Search GitHub issues
       allowManualIssueEntry: true
-  defaults: {}
+  defaults:
+    run_verify: true
   jiraIssue: MM-1067
   sourceReference: MM-1063
 inputs:
@@ -96,6 +102,11 @@ inputs:
   type: textarea
   required: false
   default: ''
+- name: run_verify
+  label: Run Verification
+  type: boolean
+  required: false
+  default: true
 steps:
 - title: Load GitHub issue brief
   type: tool
@@ -278,6 +289,7 @@ steps:
     requiredCapabilities:
     - git
 - title: Verify completion
+  enabled: '{{ inputs.run_verify }}'
   instructions: '/clear
 
 
@@ -303,6 +315,7 @@ steps:
     args:
       verify_artifact_path: var/artifacts/moonspec-verify/github-issue-orchestrate.json
 - title: Remediate verification gaps 1 of 6
+  enabled: '{{ inputs.run_verify }}'
   annotations:
     jiraOrchestrateRole: moonspec-remediation
     moonSpecRemediationAttempt: 1
@@ -342,6 +355,7 @@ steps:
     requiredCapabilities:
     - git
 - title: Verify remediation 1 of 6
+  enabled: '{{ inputs.run_verify }}'
   annotations:
     jiraOrchestrateRole: moonspec-verification-gate
     moonSpecRemediationAttempt: 1
@@ -372,6 +386,7 @@ steps:
     args:
       verify_artifact_path: var/artifacts/moonspec-verify/github-issue-orchestrate.json
 - title: Remediate verification gaps 2 of 6
+  enabled: '{{ inputs.run_verify }}'
   annotations:
     jiraOrchestrateRole: moonspec-remediation
     moonSpecRemediationAttempt: 2
@@ -411,6 +426,7 @@ steps:
     requiredCapabilities:
     - git
 - title: Verify remediation 2 of 6
+  enabled: '{{ inputs.run_verify }}'
   annotations:
     jiraOrchestrateRole: moonspec-verification-gate
     moonSpecRemediationAttempt: 2
@@ -441,6 +457,7 @@ steps:
     args:
       verify_artifact_path: var/artifacts/moonspec-verify/github-issue-orchestrate.json
 - title: Remediate verification gaps 3 of 6
+  enabled: '{{ inputs.run_verify }}'
   annotations:
     jiraOrchestrateRole: moonspec-remediation
     moonSpecRemediationAttempt: 3
@@ -480,6 +497,7 @@ steps:
     requiredCapabilities:
     - git
 - title: Verify remediation 3 of 6
+  enabled: '{{ inputs.run_verify }}'
   annotations:
     jiraOrchestrateRole: moonspec-verification-gate
     moonSpecRemediationAttempt: 3
@@ -510,6 +528,7 @@ steps:
     args:
       verify_artifact_path: var/artifacts/moonspec-verify/github-issue-orchestrate.json
 - title: Remediate verification gaps 4 of 6
+  enabled: '{{ inputs.run_verify }}'
   annotations:
     jiraOrchestrateRole: moonspec-remediation
     moonSpecRemediationAttempt: 4
@@ -549,6 +568,7 @@ steps:
     requiredCapabilities:
     - git
 - title: Verify remediation 4 of 6
+  enabled: '{{ inputs.run_verify }}'
   annotations:
     jiraOrchestrateRole: moonspec-verification-gate
     moonSpecRemediationAttempt: 4
@@ -579,6 +599,7 @@ steps:
     args:
       verify_artifact_path: var/artifacts/moonspec-verify/github-issue-orchestrate.json
 - title: Remediate verification gaps 5 of 6
+  enabled: '{{ inputs.run_verify }}'
   annotations:
     jiraOrchestrateRole: moonspec-remediation
     moonSpecRemediationAttempt: 5
@@ -618,6 +639,7 @@ steps:
     requiredCapabilities:
     - git
 - title: Verify remediation 5 of 6
+  enabled: '{{ inputs.run_verify }}'
   annotations:
     jiraOrchestrateRole: moonspec-verification-gate
     moonSpecRemediationAttempt: 5
@@ -648,6 +670,7 @@ steps:
     args:
       verify_artifact_path: var/artifacts/moonspec-verify/github-issue-orchestrate.json
 - title: Remediate verification gaps 6 of 6
+  enabled: '{{ inputs.run_verify }}'
   annotations:
     jiraOrchestrateRole: moonspec-remediation
     moonSpecRemediationAttempt: 6
@@ -687,6 +710,7 @@ steps:
     requiredCapabilities:
     - git
 - title: Verify remediation 6 of 6
+  enabled: '{{ inputs.run_verify }}'
   annotations:
     jiraOrchestrateRole: moonspec-verification-gate
     moonSpecRemediationAttempt: 6
@@ -715,6 +739,7 @@ steps:
     args:
       verify_artifact_path: var/artifacts/moonspec-verify/github-issue-orchestrate.json
 - title: Reconcile declarative docs
+  enabled: '{{ inputs.run_verify }}'
   annotations:
     jiraOrchestrateRole: doc-reconciliation
   instructions: '/clear
@@ -786,11 +811,14 @@ steps:
     }}#{{ inputs.github_issue.number }}.
 
 
-    Before committing, inspect the latest post-remediation moonspec-verify result and confirm
-    the verdict is FULLY_IMPLEMENTED. If the latest verdict is ADDITIONAL_WORK_NEEDED, NO_DETERMINATION,
-    BLOCKED, FAILED_UNRECOVERABLE, or ENVIRONMENT_CONTAMINATED_BY_SKILL_PROJECTION, stop without
-    committing, pushing, creating a pull request, or changing GitHub issue status. Classify
-    runtime or infrastructure causes as environment failure.
+    {% if inputs.run_verify %}Before committing, inspect the latest post-remediation moonspec-verify
+    result and confirm the verdict is FULLY_IMPLEMENTED. If the latest verdict is ADDITIONAL_WORK_NEEDED,
+    NO_DETERMINATION, BLOCKED, FAILED_UNRECOVERABLE, or ENVIRONMENT_CONTAMINATED_BY_SKILL_PROJECTION,
+    stop without committing, pushing, creating a pull request, or changing GitHub issue status.
+    Classify runtime or infrastructure causes as environment failure.{% else %}Before committing,
+    confirm implementation is complete and the focused tests required by the GitHub issue have
+    passed. Verification was disabled for this workflow execution, so do not require a moonspec-verify
+    report before creating a pull request.{% endif %}
 
 
     This GitHub Issue Orchestrate handoff step is the explicit PR-publication step for this
@@ -826,22 +854,25 @@ steps:
 
     - the active MoonSpec feature path
 
-    - verification verdict
+    - verification verdict, or a note that verification was disabled for this workflow execution
 
     - tests run
 
     - remaining risks
 
-    - the doc reconciliation outcome from artifacts/github-issue-orchestrate-doc-reconcile.json
+    - {% if inputs.run_verify %}the doc reconciliation outcome from artifacts/github-issue-orchestrate-doc-reconcile.json
     when present: updated canonical doc paths, the no-update rationale, or the escalation
-    issue reference
+    issue reference{% else %}a note that doc reconciliation was skipped because verification
+    was disabled{% endif %}
 
     - a Documentation Conformance section listing canonical sources, temporary artifacts consulted,
     claim coverage, and reconciliation outcomes
 
 
-    Canonical doc edits produced by the doc reconciliation step are intentional changes for
-    this issue and must be committed in the same pull request.
+    {% if inputs.run_verify %}Canonical doc edits produced by the doc reconciliation step
+    are intentional changes for this issue and must be committed in the same pull request.{% else
+    %}Do not require doc reconciliation output before committing because verification was
+    disabled and the doc reconciliation step was skipped.{% endif %}
 
 
     After creation and non-draft verification, record the confirmed pull request URL in the
@@ -867,13 +898,16 @@ steps:
     apply the configured Done strategy.
 
 
-    Otherwise read artifacts/github-issue-orchestrate-pr.json, verify it contains a pull_request_url
-    for {{ inputs.github_issue.repository }}#{{ inputs.github_issue.number }}, and apply the
-    configured Code Review strategy with the pull request URL. Before using the trusted GitHub
-    update tool, confirm the latest post-remediation moonspec-verify verdict is FULLY_IMPLEMENTED;
-    terminal verifier outcomes such as ADDITIONAL_WORK_NEEDED, NO_DETERMINATION, BLOCKED,
-    FAILED_UNRECOVERABLE, or ENVIRONMENT_CONTAMINATED_BY_SKILL_PROJECTION must stop before
-    this status update. Do not assume a single organization workflow; use the configured label/comment/close
+    Otherwise {% if inputs.run_verify %}before using the trusted GitHub update tool, confirm
+    the latest post-remediation moonspec-verify verdict is FULLY_IMPLEMENTED; terminal
+    verifier outcomes such as ADDITIONAL_WORK_NEEDED, NO_DETERMINATION, BLOCKED, FAILED_UNRECOVERABLE,
+    or ENVIRONMENT_CONTAMINATED_BY_SKILL_PROJECTION must stop before this status update.{% else
+    %}confirm implementation is complete and the focused tests required by the GitHub issue
+    have passed. Verification was disabled for this workflow execution, so do not require
+    a moonspec-verify report before this status update.{% endif %} Then read artifacts/github-issue-orchestrate-pr.json,
+    verify it contains a pull_request_url for {{ inputs.github_issue.repository }}#{{
+    inputs.github_issue.number }}, and apply the configured Code Review strategy with the
+    pull request URL. Do not assume a single organization workflow; use the configured label/comment/close
     strategy exposed by the trusted GitHub update tool.'
   tool:
     id: github.update_issue_status
@@ -885,3 +919,4 @@ steps:
       mode: finalize_after_pr_or_done
       pullRequestArtifactPath: artifacts/github-issue-orchestrate-pr.json
       verificationArtifactPath: var/artifacts/moonspec-verify/github-issue-orchestrate.json
+      requireVerification: '{{ inputs.run_verify }}'

--- a/api_service/data/presets/jira-breakdown-implement.yaml
+++ b/api_service/data/presets/jira-breakdown-implement.yaml
@@ -51,6 +51,11 @@ inputs:
     options:
       - pr
       - pr_with_merge_automation
+  - name: run_verify
+    label: Run Verification
+    type: boolean
+    required: false
+    default: true
   - name: source_issue_key
     label: Source Jira Issue Key
     type: text
@@ -163,6 +168,8 @@ steps:
         repository: "{{ context.repository }}"
         runtime:
           mode: "{{ context.targetRuntime }}"
+        inputs:
+          run_verify: "{{ inputs.run_verify }}"
         publish:
           mode: "pr"
           mergeAutomation:

--- a/api_service/data/presets/jira-breakdown-orchestrate.yaml
+++ b/api_service/data/presets/jira-breakdown-orchestrate.yaml
@@ -51,6 +51,11 @@ inputs:
     options:
       - pr
       - pr_with_merge_automation
+  - name: run_verify
+    label: Run Verification
+    type: boolean
+    required: false
+    default: true
   - name: source_issue_key
     label: Source Jira Issue Key
     type: text
@@ -164,6 +169,8 @@ steps:
         repository: "{{ context.repository }}"
         runtime:
           mode: "{{ context.targetRuntime }}"
+        inputs:
+          run_verify: "{{ inputs.run_verify }}"
         publish:
           mode: "pr"
           mergeAutomation:

--- a/moonmind/workflows/temporal/story_output_tools.py
+++ b/moonmind/workflows/temporal/story_output_tools.py
@@ -4725,7 +4725,17 @@ def _github_status_pull_request_url(
 def _github_status_requires_verification(inputs: Mapping[str, Any]) -> bool:
     if "requireVerification" not in inputs:
         return True
-    return _truthy(inputs.get("requireVerification"))
+    value = inputs.get("requireVerification")
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return True
+    if isinstance(value, (int, float)):
+        return value != 0
+    normalized = str(value).strip().lower()
+    if not normalized:
+        return True
+    return normalized not in {"0", "false", "no", "off"}
 
 
 async def update_github_issue_status(

--- a/moonmind/workflows/temporal/story_output_tools.py
+++ b/moonmind/workflows/temporal/story_output_tools.py
@@ -1392,6 +1392,7 @@ def _downstream_task_payload(
     )
     runtime = _mapping(task_payload.get("runtime"))
     publish = _mapping(task_payload.get("publish"))
+    configured_inputs = dict(_mapping(task_payload.get("inputs")))
     merge_automation_value = (
         task_payload.get("mergeAutomation")
         or task_payload.get("merge_automation")
@@ -1419,6 +1420,7 @@ def _downstream_task_payload(
         "title": f"Run {preset_label} for {issue_key}: {summary}",
         "instructions": instructions,
         "inputs": {
+            **configured_inputs,
             "jira_issue": jira_issue_input,
             "source_design_path": source_design_path,
             "source_claim_ids": source_claim_ids,
@@ -1845,6 +1847,7 @@ def _github_downstream_workflow_payload(
     )
     runtime = _mapping(task_payload.get("runtime"))
     publish = _mapping(task_payload.get("publish"))
+    configured_inputs = dict(_mapping(task_payload.get("inputs")))
     github_issue_input = _github_issue_input_from_mapping(
         mapping=mapping,
         repository=repository,
@@ -1855,6 +1858,7 @@ def _github_downstream_workflow_payload(
         "title": f"Run {preset_label} for {github_issue_ref}: {summary}",
         "instructions": instructions,
         "inputs": {
+            **configured_inputs,
             "github_issue": github_issue_input,
             "github_issue_ref": github_issue_ref,
             "source_design_path": source_design_path,
@@ -4718,6 +4722,12 @@ def _github_status_pull_request_url(
     )
 
 
+def _github_status_requires_verification(inputs: Mapping[str, Any]) -> bool:
+    if "requireVerification" not in inputs:
+        return True
+    return _truthy(inputs.get("requireVerification"))
+
+
 async def update_github_issue_status(
     inputs: Mapping[str, Any],
     _context: Mapping[str, Any] | None = None,
@@ -4731,6 +4741,7 @@ async def update_github_issue_status(
         _context,
     )
     issue_ref = f"{repository}#{issue_number}"
+    require_verification = _github_status_requires_verification(inputs)
     if mode in {"start", "in_progress"} and (
         inputs.get("assessmentArtifactPath") or inputs.get("assessment_artifact_path")
     ):
@@ -4765,7 +4776,7 @@ async def update_github_issue_status(
             )
     pull_request_url = _github_status_pull_request_url(inputs, _context)
     if mode == "finalize_after_pr_or_done":
-        if pull_request_url:
+        if pull_request_url and require_verification:
             if not (
                 inputs.get("verificationArtifactPath")
                 or inputs.get("verification_artifact_path")

--- a/tests/integration/test_startup_preset_seeding.py
+++ b/tests/integration/test_startup_preset_seeding.py
@@ -567,6 +567,9 @@ async def test_startup_seeds_default_task_templates(disabled_env_keys, tmp_path)
         assert "jira_board_id" not in {
             item["name"] for item in composite_template.inputs_schema
         }
+        assert "run_verify" in {
+            item["name"] for item in composite_template.inputs_schema
+        }
         assert [
             (step.get("skill") or step.get("tool"))["id"]
             for step in composite_template.steps
@@ -592,6 +595,9 @@ async def test_startup_seeds_default_task_templates(disabled_env_keys, tmp_path)
                 "enabled": "{{ inputs.publish_mode == 'pr_with_merge_automation' }}"
             },
         }
+        assert downstream_step["jiraOrchestration"]["task"]["inputs"] == {
+            "run_verify": "{{ inputs.run_verify }}"
+        }
 
         result = await session.execute(
             select(Preset)
@@ -606,6 +612,9 @@ async def test_startup_seeds_default_task_templates(disabled_env_keys, tmp_path)
         assert implement_composite_template is not None
         assert implement_composite_template.title == "Breakdown and Jira Implement"
         assert "jira_board_id" not in {
+            item["name"] for item in implement_composite_template.inputs_schema
+        }
+        assert "run_verify" in {
             item["name"] for item in implement_composite_template.inputs_schema
         }
         assert [
@@ -635,6 +644,9 @@ async def test_startup_seeds_default_task_templates(disabled_env_keys, tmp_path)
                 "enabled": "{{ inputs.publish_mode == 'pr_with_merge_automation' }}"
             },
         }
+        assert implement_downstream_step["jiraOrchestration"]["task"]["inputs"] == {
+            "run_verify": "{{ inputs.run_verify }}"
+        }
 
         for slug, title, downstream_skill in (
             (
@@ -659,6 +671,9 @@ async def test_startup_seeds_default_task_templates(disabled_env_keys, tmp_path)
             github_breakdown_template = result.scalar_one_or_none()
             assert github_breakdown_template is not None
             assert github_breakdown_template.title == title
+            assert "run_verify" in {
+                item["name"] for item in github_breakdown_template.inputs_schema
+            }
             assert [
                 (step.get("skill") or step.get("tool"))["id"]
                 for step in github_breakdown_template.steps
@@ -681,6 +696,9 @@ async def test_startup_seeds_default_task_templates(disabled_env_keys, tmp_path)
             assert github_downstream_step["githubOrchestration"]["task"]["publish"] == {
                 "mode": "{{ inputs.publish_mode }}",
             }
+            assert github_downstream_step["githubOrchestration"]["task"]["inputs"] == {
+                "run_verify": "{{ inputs.run_verify }}"
+            }
             assert github_downstream_step["githubOrchestration"]["traceability"] == {
                 "sourceIssueKey": "{{ inputs.source_issue_key }}"
             }
@@ -699,6 +717,9 @@ async def test_startup_seeds_default_task_templates(disabled_env_keys, tmp_path)
         assert final_status_step["tool"]["id"] == "github.update_issue_status"
         assert final_status_step["tool"]["inputs"]["verificationArtifactPath"] == (
             "var/artifacts/moonspec-verify/github-issue-orchestrate.json"
+        )
+        assert final_status_step["tool"]["inputs"]["requireVerification"] == (
+            "{{ inputs.run_verify }}"
         )
 
         result = await session.execute(
@@ -774,20 +795,28 @@ async def test_startup_seeds_default_task_templates(disabled_env_keys, tmp_path)
             "skill:jira-verify",
             "preset:jira-implement",
         ]
+        assert batch_schema["properties"]["run_verify"]["default"] is True
         assert "source_kind" not in batch_schema["properties"]
         assert "target_preset_slug" not in batch_schema["properties"]
         assert "target_preset_version" not in batch_schema["properties"]
         assert batch_annotations["uiSchema"]["run_ref"]["widget"] == "select"
         assert batch_annotations["uiSchema"]["constraints"]["widget"] == "textarea"
+        assert batch_annotations["uiSchema"]["run_verify"]["widget"] == "checkbox"
         assert batch_annotations["bindings"]["skill:jira-verify"][
             "jira_issue_key"
         ] == "{{ target.jiraIssue.key }}"
         assert batch_annotations["bindings"]["preset:jira-implement"][
             "jira_issue_key"
         ] == "{{ target.jiraIssue.key }}"
+        assert batch_annotations["bindings"]["preset:jira-implement"][
+            "run_verify"
+        ] == "{{ shared.run_verify }}"
         assert batch_annotations["bindings"]["preset:github-issue-implement"][
             "github_issue_ref"
         ] == "{{ target.githubIssue.repository }}#{{ target.githubIssue.number }}"
+        assert batch_annotations["bindings"]["preset:github-issue-implement"][
+            "run_verify"
+        ] == "{{ shared.run_verify }}"
         batch_steps = batch_template.steps
         assert len(batch_steps) == 1
         assert batch_steps[0]["skill"]["id"] == "batch-workflows"
@@ -801,6 +830,10 @@ async def test_startup_seeds_default_task_templates(disabled_env_keys, tmp_path)
         assert (
             batch_steps[0]["batchOrchestration"]["target"]["runRef"]
             == "{{ inputs.run_ref }}"
+        )
+        assert (
+            batch_steps[0]["batchOrchestration"]["sharedInputs"]["run_verify"]
+            == "{{ inputs.run_verify }}"
         )
 
 @pytest.mark.asyncio

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -215,7 +215,11 @@ def test_mm_1129_derive_task_title_synthesizes_issue_title_from_instructions() -
         }
     )
 
-    assert title == "Workflow: MM-1129"
+    assert (
+        title
+        == "Implement this Jira issue: MM-1129 titles should include description "
+        "text while title length remains available."
+    )
 
 
 def test_mm_1129_derive_task_title_bounds_instruction_fallback() -> None:

--- a/tests/unit/api/test_batch_workflows_preset.py
+++ b/tests/unit/api/test_batch_workflows_preset.py
@@ -246,6 +246,8 @@ async def test_batch_workflows_expands_orchestration_step(tmp_path):
             # Parent records a summary artifact that links child workflows.
             assert "artifacts/batch-workflows-result.json" in step["instructions"]
             assert "runtimeInheritance" in step["instructions"]
+            assert "--no-run-verify" in step["instructions"]
+            assert " --run-verify" not in step["instructions"]
 
             assert "git" in expanded["capabilities"]
             assert "gh" in expanded["capabilities"]

--- a/tests/unit/api/test_batch_workflows_preset.py
+++ b/tests/unit/api/test_batch_workflows_preset.py
@@ -88,6 +88,7 @@ async def test_batch_workflows_seed_validates_and_exposes_batch_contract(tmp_pat
                 "run_ref",
                 "max_workflows",
                 "constraints",
+                "run_verify",
                 "additional_jql",
                 "repository",
                 "publish_mode",
@@ -120,6 +121,7 @@ async def test_batch_workflows_seed_validates_and_exposes_batch_contract(tmp_pat
             ui_schema = annotations["uiSchema"]
             assert ui_schema["run_ref"]["widget"] == "select"
             assert ui_schema["constraints"] == {"widget": "textarea", "advanced": True}
+            assert ui_schema["run_verify"] == {"widget": "checkbox"}
             assert ui_schema["additional_jql"] == {
                 "widget": "textarea",
                 "advanced": True,
@@ -148,6 +150,14 @@ async def test_batch_workflows_seed_validates_and_exposes_batch_contract(tmp_pat
             assert (
                 bindings["preset:jira-implement"]["jira_issue_key"]
                 == "{{ target.jiraIssue.key }}"
+            )
+            assert (
+                bindings["preset:jira-implement"]["run_verify"]
+                == "{{ shared.run_verify }}"
+            )
+            assert (
+                bindings["preset:github-issue-implement"]["run_verify"]
+                == "{{ shared.run_verify }}"
             )
             assert (
                 bindings["preset:github-issue-implement"]["github_issue"]
@@ -195,6 +205,7 @@ async def test_batch_workflows_expands_orchestration_step(tmp_path):
                     "run_ref": "skill:jira-verify",
                     "publish_mode": "none",
                     "constraints": "Be careful",
+                    "run_verify": False,
                     "additional_jql": "assignee = currentUser()",
                     "repository": "MoonLadderStudios/MoonMind",
                     "max_workflows": "10",
@@ -226,6 +237,7 @@ async def test_batch_workflows_expands_orchestration_step(tmp_path):
             assert orchestration["runtime"]["inherit"] == "caller"
             assert orchestration["maxWorkflows"] == "10"
             assert orchestration["sharedInputs"]["constraints"] == "Be careful"
+            assert orchestration["sharedInputs"]["run_verify"] is False
             assert (
                 orchestration["summaryArtifact"]
                 == "artifacts/batch-workflows-result.json"

--- a/tests/unit/api/test_github_issue_breakdown_presets.py
+++ b/tests/unit/api/test_github_issue_breakdown_presets.py
@@ -96,6 +96,7 @@ async def test_github_issue_breakdown_seed_creates_issues_and_workflows(
         "source_design_path",
         "github_repository",
         "publish_mode",
+        "run_verify",
         "source_issue_key",
     ]
     assert [
@@ -134,6 +135,9 @@ async def test_github_issue_breakdown_seed_creates_issues_and_workflows(
     assert downstream_step["githubOrchestration"]["task"]["publish"] == {
         "mode": "{{ inputs.publish_mode }}",
     }
+    assert downstream_step["githubOrchestration"]["task"]["inputs"] == {
+        "run_verify": "{{ inputs.run_verify }}",
+    }
 
 
 async def test_github_issue_breakdown_implement_expands_downstream_contract(tmp_path):
@@ -166,6 +170,9 @@ async def test_github_issue_breakdown_implement_expands_downstream_contract(tmp_
         "MoonLadderStudios/MoonMind"
     )
     assert steps[3]["githubOrchestration"]["task"]["runtime"]["mode"] == "codex"
+    assert steps[3]["githubOrchestration"]["task"]["inputs"] == {
+        "run_verify": True
+    }
     assert steps[3]["githubOrchestration"]["traceability"] == {
         "sourceIssueKey": "MM-1063"
     }

--- a/tests/unit/api/test_github_issue_orchestrate_preset.py
+++ b/tests/unit/api/test_github_issue_orchestrate_preset.py
@@ -81,6 +81,13 @@ async def test_github_issue_orchestrate_seed_exposes_issue_picker_and_tools(tmp_
     assert annotations["inputSchema"]["required"] == ["github_issue"]
     github_issue = annotations["inputSchema"]["properties"]["github_issue"]
     assert github_issue["required"] == ["repository", "number"]
+    assert annotations["inputSchema"]["properties"]["run_verify"] == {
+        "type": "boolean",
+        "title": "Run verification",
+        "description": "Run the MoonSpec verification and remediation gate before pull request creation and GitHub issue handoff.",
+        "default": True,
+    }
+    assert annotations["defaults"]["run_verify"] is True
     assert annotations["uiSchema"]["github_issue"] == {
         "widget": "github.issue-picker",
         "dataSource": "github.issues",
@@ -243,6 +250,7 @@ async def test_github_issue_orchestrate_expands_required_order_and_gates(tmp_pat
             "mode": "finalize_after_pr_or_done",
             "pullRequestArtifactPath": "artifacts/github-issue-orchestrate-pr.json",
             "verificationArtifactPath": "var/artifacts/moonspec-verify/github-issue-orchestrate.json",
+            "requireVerification": True,
         },
     }
     assert "apply the configured Done strategy" in steps[25]["instructions"]

--- a/tests/unit/api/test_presets_service.py
+++ b/tests/unit/api/test_presets_service.py
@@ -2722,6 +2722,9 @@ async def test_jira_breakdown_orchestrate_uses_repository_policy_defaults(
             assert downstream_step["jiraOrchestration"]["task"]["runtime"] == {
                 "mode": "claude_code"
             }
+            assert downstream_step["jiraOrchestration"]["task"]["inputs"] == {
+                "run_verify": True
+            }
             assert downstream_step["jiraOrchestration"]["task"]["publish"] == {
                 "mode": "pr",
                 "mergeAutomation": {"enabled": False},
@@ -2821,6 +2824,9 @@ async def test_jira_breakdown_orchestrate_preserves_explicit_project_input(
             assert expanded["steps"][4]["jiraOrchestration"]["task"]["runtime"] == (
                 {"mode": "claude_code"}
             )
+            assert expanded["steps"][4]["jiraOrchestration"]["task"]["inputs"] == {
+                "run_verify": True
+            }
 
 async def test_jira_breakdown_uses_seeded_default_when_multiple_allowed_without_repo_policy(
     tmp_path,
@@ -3185,6 +3191,11 @@ async def test_seed_catalog_github_issue_implement_expands_shared_includes(tmp_p
             service = PresetCatalogService(session)
             await service.sync_seed_templates(seed_dir=seed_dir)
 
+            template = await service.get_template(
+                slug="github-issue-implement",
+                scope="global",
+                scope_ref=None,
+            )
             expanded = await service.expand_template(
                 slug="github-issue-implement",
                 scope="global",
@@ -3198,7 +3209,31 @@ async def test_seed_catalog_github_issue_implement_expands_shared_includes(tmp_p
                 },
                 context={},
             )
+            no_verify = await service.expand_template(
+                slug="github-issue-implement",
+                scope="global",
+                scope_ref=None,
+                inputs={
+                    "github_issue": {
+                        "repository": "MoonLadderStudios/MoonMind",
+                        "number": 123,
+                    },
+                    "constraints": "",
+                    "run_verify": False,
+                },
+                context={},
+            )
 
+    assert template["annotations"]["inputSchema"]["properties"]["run_verify"] == {
+        "type": "boolean",
+        "title": "Run verification",
+        "description": "Run the MoonSpec verification and remediation gate before pull request creation and GitHub issue handoff.",
+        "default": True,
+    }
+    assert template["annotations"]["defaults"]["run_verify"] is True
+    assert next(item for item in template["inputs"] if item["name"] == "run_verify")[
+        "default"
+    ] is True
     assert [step["title"] for step in expanded["steps"]] == [
         "Load GitHub issue brief",
         "Assess existing implementation state",
@@ -3295,6 +3330,20 @@ async def test_seed_catalog_github_issue_implement_expands_shared_includes(tmp_p
     assert expanded["steps"][19]["tool"]["inputs"]["verificationArtifactPath"] == (
         "artifacts/github-issue-implement-verify.json"
     )
+    assert expanded["steps"][19]["tool"]["inputs"]["requireVerification"] is True
+    no_verify_titles = [step["title"] for step in no_verify["steps"]]
+    assert no_verify_titles == [
+        "Load GitHub issue brief",
+        "Assess existing implementation state",
+        "Check GitHub issue blockers before implementation",
+        "Mark GitHub issue In Progress",
+        "Implement the issue",
+        "Create pull request",
+        "Finalize GitHub issue status",
+    ]
+    assert "Verification was disabled" in no_verify["steps"][-2]["instructions"]
+    assert "Verification was disabled" in no_verify["steps"][-1]["instructions"]
+    assert no_verify["steps"][-1]["tool"]["inputs"]["requireVerification"] is False
     assert [item["presetSlug"] for item in expanded["authoredPresets"]] == [
         "github-issue-implement",
         "issue-implement-assessment",
@@ -3374,6 +3423,11 @@ async def test_seed_catalog_github_issue_orchestrate_expands_gated_workflow(tmp_
                 scope=PresetScopeType.GLOBAL,
                 scope_ref=None,
             )
+            template_payload = await service.get_template(
+                slug="github-issue-orchestrate",
+                scope="global",
+                scope_ref=None,
+            )
             expanded = await service.expand_template(
                 slug="github-issue-orchestrate",
                 scope="global",
@@ -3388,7 +3442,32 @@ async def test_seed_catalog_github_issue_orchestrate_expands_gated_workflow(tmp_
                 },
                 context={},
             )
+            no_verify = await service.expand_template(
+                slug="github-issue-orchestrate",
+                scope="global",
+                scope_ref=None,
+                inputs={
+                    "github_issue": {
+                        "repository": "MoonLadderStudios/MoonMind",
+                        "number": 1067,
+                        "url": "https://github.com/MoonLadderStudios/MoonMind/issues/1067",
+                    },
+                    "constraints": "Keep preset scope bounded.",
+                    "run_verify": False,
+                },
+                context={},
+            )
 
+    assert template_payload["annotations"]["inputSchema"]["properties"]["run_verify"][
+        "type"
+    ] == "boolean"
+    assert template_payload["annotations"]["inputSchema"]["properties"]["run_verify"][
+        "default"
+    ] is True
+    assert template_payload["annotations"]["defaults"]["run_verify"] is True
+    assert next(
+        item for item in template_payload["inputs"] if item["name"] == "run_verify"
+    )["default"] is True
     assert [step["title"] for step in expanded["steps"]] == [
         "Load GitHub issue brief",
         "Assess existing implementation state",
@@ -3443,6 +3522,7 @@ async def test_seed_catalog_github_issue_orchestrate_expands_gated_workflow(tmp_
         "mode": "finalize_after_pr_or_done",
         "pullRequestArtifactPath": "artifacts/github-issue-orchestrate-pr.json",
         "verificationArtifactPath": "var/artifacts/moonspec-verify/github-issue-orchestrate.json",
+        "requireVerification": True,
     }
     assert expanded["steps"][10]["skill"]["id"] == "moonspec-verify"
     assert expanded["steps"][10]["skill"]["args"]["verify_artifact_path"] == (
@@ -3508,6 +3588,25 @@ async def test_seed_catalog_github_issue_orchestrate_expands_gated_workflow(tmp_
     assert expanded["appliedTemplate"]["inputs"]["github_issue_ref"] == (
         "MoonLadderStudios/MoonMind#1067"
     )
+    no_verify_titles = [step["title"] for step in no_verify["steps"]]
+    assert no_verify_titles == [
+        "Load GitHub issue brief",
+        "Assess existing implementation state",
+        "Check GitHub issue blockers before orchestration",
+        "Classify request and resume point",
+        "Mark GitHub issue In Progress",
+        "Create or select MoonSpec",
+        "Plan selected spec",
+        "Generate TDD task breakdown",
+        "Align MoonSpec artifacts",
+        "Implement the task breakdown",
+        "Create pull request",
+        "Finalize GitHub issue status",
+    ]
+    assert all("moonspec-verify" != step["skill"]["id"] for step in no_verify["steps"] if "skill" in step)
+    assert "Verification was disabled" in no_verify["steps"][-2]["instructions"]
+    assert "Verification was disabled" in no_verify["steps"][-1]["instructions"]
+    assert no_verify["steps"][-1]["tool"]["inputs"]["requireVerification"] is False
 
 
 async def test_seed_catalog_includes_jira_breakdown_orchestrate_preset(
@@ -3607,6 +3706,7 @@ async def test_seed_catalog_includes_jira_breakdown_orchestrate_preset(
             assert downstream["jiraOrchestration"]["task"] == {
                 "repository": "MoonLadderStudios/MoonMind",
                 "runtime": {"mode": "codex_cli"},
+                "inputs": {"run_verify": True},
                 "publish": {"mode": "pr", "mergeAutomation": {"enabled": True}},
             }
             assert downstream["jiraOrchestration"]["traceability"]["sourceIssueKey"] == (
@@ -3724,6 +3824,7 @@ async def test_seed_catalog_includes_jira_breakdown_implement_preset(tmp_path):
     assert downstream["jiraOrchestration"]["task"] == {
         "repository": "MoonLadderStudios/MoonMind",
         "runtime": {"mode": "codex_cli"},
+        "inputs": {"run_verify": True},
         "publish": {"mode": "pr", "mergeAutomation": {"enabled": True}},
     }
     assert downstream["jiraOrchestration"]["traceability"] == {
@@ -3836,6 +3937,11 @@ async def test_seed_catalog_includes_moonspec_orchestrate_without_report_step(
             assert "orchestration_mode" not in {
                 item["name"] for item in template_payload["inputs"]
             }
+            assert next(
+                item
+                for item in template_payload["inputs"]
+                if item["name"] == "run_verify"
+            )["default"] is True
 
             expanded = await service.expand_template(
                 slug="moonspec-orchestrate",
@@ -3846,6 +3952,18 @@ async def test_seed_catalog_includes_moonspec_orchestrate_without_report_step(
                     "orchestration_mode": "docs",
                     "source_design_path": "",
                     "constraints": "Keep the scope narrow.",
+                },
+                context={},
+            )
+            no_verify = await service.expand_template(
+                slug="moonspec-orchestrate",
+                scope="global",
+                scope_ref=None,
+                inputs={
+                    "feature_request": "MM-366: Simplify Orchestrate Summary",
+                    "source_design_path": "",
+                    "constraints": "Keep the scope narrow.",
+                    "run_verify": False,
                 },
                 context={},
             )
@@ -3874,6 +3992,13 @@ async def test_seed_catalog_includes_moonspec_orchestrate_without_report_step(
                 step["title"] != "Return orchestration report and defer publish actions"
                 for step in expanded["steps"]
             )
+            assert [step["title"] for step in no_verify["steps"]] == [
+                "Create or select MoonSpec",
+                "Plan selected spec",
+                "Generate TDD task breakdown",
+                "Align MoonSpec artifacts",
+                "Implement the task breakdown",
+            ]
 
             expanded_with_source_design = await service.expand_template(
                 slug="moonspec-orchestrate",

--- a/tests/unit/test_batch_workflows.py
+++ b/tests/unit/test_batch_workflows.py
@@ -124,10 +124,12 @@ def test_bind_child_inputs_jira_implement_preset_auto_binds_issue_object_and_key
         "preset",
         "jira-implement",
         "Be careful",
+        run_verify=False,
     )
     assert inputs["jira_issue"]["key"] == "THOR-123"
     assert inputs["jira_issue_key"] == "THOR-123"
     assert inputs["constraints"] == "Be careful"
+    assert inputs["run_verify"] is False
     assert "verification_mode" not in inputs
 
 
@@ -138,10 +140,12 @@ def test_bind_child_inputs_github_auto_binds_issue_object_and_ref():
         "preset",
         "github-issue-implement",
         "",
+        run_verify=False,
     )
     assert inputs["github_issue"]["number"] == 42
     assert inputs["github_issue_ref"] == "MoonLadderStudios/MoonMind#42"
     assert inputs["constraints"] == ""
+    assert inputs["run_verify"] is False
 
 
 def test_bind_child_inputs_returns_none_for_provider_mismatch():

--- a/tests/unit/workflows/temporal/test_story_output_tools.py
+++ b/tests/unit/workflows/temporal/test_story_output_tools.py
@@ -392,6 +392,38 @@ async def test_update_github_issue_status_allows_code_review_without_verificatio
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("require_verification", [None, "", "   "])
+async def test_update_github_issue_status_requires_verification_for_blank_values(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+    require_verification,
+):
+    monkeypatch.setattr(story_tools.httpx, "AsyncClient", _FakeHttpClient)
+    pr_artifact = tmp_path / "pr.json"
+    pr_artifact.write_text(
+        '{"pullRequestUrl": "https://github.com/MoonLadderStudios/MoonMind/pull/2913"}',
+        encoding="utf-8",
+    )
+    service = _FakeGitHubService()
+
+    result = await update_github_issue_status(
+        {
+            "repository": "MoonLadderStudios/MoonMind",
+            "issueNumber": 1067,
+            "mode": "finalize_after_pr_or_done",
+            "pullRequestArtifactPath": str(pr_artifact),
+            "requireVerification": require_verification,
+        },
+        github_service_factory=lambda: service,
+    )
+
+    assert result.status == "FAILED"
+    assert result.outputs["decision"] == "blocked"
+    assert "verification artifact path" in result.outputs["summary"]
+    assert service.token_requests == []
+
+
+@pytest.mark.asyncio
 async def test_update_github_issue_status_uses_previous_verification_payload(
     tmp_path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit/workflows/temporal/test_story_output_tools.py
+++ b/tests/unit/workflows/temporal/test_story_output_tools.py
@@ -359,6 +359,39 @@ async def test_update_github_issue_status_blocks_code_review_without_verificatio
 
 
 @pytest.mark.asyncio
+async def test_update_github_issue_status_allows_code_review_without_verification_when_disabled(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(story_tools.httpx, "AsyncClient", _FakeHttpClient)
+    pr_artifact = tmp_path / "pr.json"
+    pr_artifact.write_text(
+        '{"pullRequestUrl": "https://github.com/MoonLadderStudios/MoonMind/pull/2913"}',
+        encoding="utf-8",
+    )
+    service = _FakeGitHubService()
+
+    result = await update_github_issue_status(
+        {
+            "repository": "MoonLadderStudios/MoonMind",
+            "issueNumber": 1067,
+            "mode": "finalize_after_pr_or_done",
+            "pullRequestArtifactPath": str(pr_artifact),
+            "requireVerification": False,
+        },
+        github_service_factory=lambda: service,
+    )
+
+    assert result.status == "COMPLETED"
+    assert result.outputs["appliedActions"] == ["patch_issue", "comment"]
+    assert "mode code_review" in result.outputs["summary"]
+    assert service.token_requests == [
+        "MoonLadderStudios/MoonMind",
+        "MoonLadderStudios/MoonMind",
+    ]
+
+
+@pytest.mark.asyncio
 async def test_update_github_issue_status_uses_previous_verification_payload(
     tmp_path,
     monkeypatch: pytest.MonkeyPatch,
@@ -1455,6 +1488,7 @@ async def test_create_github_issue_workflows_from_issue_mappings():
                 },
                 "task": {
                     "runtime": {"mode": "codex"},
+                    "inputs": {"run_verify": False},
                     "publish": {"mode": "pr"},
                 },
             },
@@ -1483,6 +1517,7 @@ async def test_create_github_issue_workflows_from_issue_mappings():
         "number": 11,
         "title": "First story",
     }
+    assert workflow["inputs"]["run_verify"] is False
     assert workflow["inputs"]["github_issue_ref"] == "MoonLadderStudios/MoonMind#11"
     assert "Source issue: MM-1063." in workflow["instructions"]
     assert "Source canonical claim IDs: DESIGN-REQ-007." in workflow["instructions"]
@@ -3669,6 +3704,7 @@ async def test_create_jira_orchestrate_tasks_wires_ordered_dependencies_and_trac
             "task": {
                 "repository": "MoonLadderStudios/MoonMind",
                 "runtime": {"mode": "codex_cli"},
+                "inputs": {"run_verify": False},
                 "publish": {
                     "mode": "pr",
                     "mergeAutomation": {"enabled": True},
@@ -3719,6 +3755,7 @@ async def test_create_jira_orchestrate_tasks_wires_ordered_dependencies_and_trac
         "key": "MM-501",
         "summary": "First",
     }
+    assert first_parameters["workflow"]["inputs"]["run_verify"] is False
     assert "jira_issue_key" not in first_parameters["workflow"]["inputs"]
     assert "merge_automation" not in first_parameters["workflow"]["publish"]
     assert "MM-404" in first_parameters["workflow"]["instructions"]


### PR DESCRIPTION
## Summary
- add Run Verification checkboxes to GitHub implement/orchestrate, breakdown implement/orchestrate, batch workflow, and bundled MoonSpec orchestrate presets
- pass run_verify through generated Jira/GitHub child workflow payloads and batch bindings
- allow GitHub issue Code Review status updates to skip verifier artifacts only when requireVerification is explicitly false
- update the MoonSpec submodule pointer to MoonLadderStudios/MoonSpec#6 for the bundled moonspec-orchestrate preset change

## Tests
- MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/test_presets_service.py tests/unit/api/test_github_issue_orchestrate_preset.py tests/unit/api/test_github_issue_breakdown_presets.py tests/unit/api/test_batch_workflows_preset.py tests/unit/test_batch_workflows.py tests/unit/workflows/temporal/test_story_output_tools.py
- MOONMIND_FORCE_LOCAL_TESTS=1 .venv/bin/python -m pytest tests/integration/test_startup_preset_seeding.py -q