### PR TITLE
Complete create-first remediation backend gaps

### DIFF
--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -3031,6 +3031,7 @@ async def _get_service(
     return TemporalExecutionService(
         session,
         namespace=settings.temporal.namespace,
+        artifact_service_factory=lambda: get_temporal_artifact_service(session),
         integration_task_queue=settings.temporal.activity_integrations_task_queue,
         integration_poll_initial_seconds=(
             settings.temporal.integration_poll_initial_seconds

--- a/frontend/src/components/WorkflowRowActionsMenu.test.tsx
+++ b/frontend/src/components/WorkflowRowActionsMenu.test.tsx
@@ -124,6 +124,64 @@ describe('WorkflowRowActionsMenu', () => {
     expect(detailUrls.every((url) => url === '/api/executions/wf-123?source=temporal')).toBe(true);
   });
 
+  it('opens Create with a remediation draft instead of posting the direct remediation endpoint', async () => {
+    fetchSpy.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === '/api/executions/wf-123?source=temporal') {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            ...detailResponse,
+            state: 'failed',
+            targetRuntime: 'codex_cli',
+            model: 'gpt-5',
+            effort: 'high',
+            profileId: 'profile-codex',
+          }),
+        } as Response);
+      }
+      return Promise.resolve({ ok: true, json: async () => ({}) } as Response);
+    });
+
+    renderMenu();
+    fireEvent.click(screen.getByRole('button', { name: 'Actions' }));
+    await screen.findByRole('menuitem', { name: 'Remediate' });
+    await waitFor(() => {
+      expect(
+        fetchSpy.mock.calls.filter(
+          ([url]) => String(url) === '/api/executions/wf-123?source=temporal',
+        ),
+      ).not.toHaveLength(0);
+      expect(screen.queryByText('Checking availability…')).toBeNull();
+    });
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Remediate' }));
+
+    await waitFor(() => {
+      expect(window.location.pathname).toBe('/workflows/new');
+      expect(window.location.search).toContain('intent=remediate');
+      expect(window.location.search).toContain('draftId=');
+    });
+    expect(
+      fetchSpy.mock.calls.some(
+        ([url, init]) =>
+          String(url) === '/api/executions/wf-123/remediation' && init?.method === 'POST',
+      ),
+    ).toBe(false);
+
+    const draftId = new URLSearchParams(window.location.search).get('draftId') || '';
+    const rawDraft = window.sessionStorage.getItem(`moonmind.remediationDraft.${draftId}`);
+    expect(rawDraft).toBeTruthy();
+    expect(JSON.parse(String(rawDraft))).toMatchObject({
+      source: 'remediation',
+      target: { workflowId: 'wf-123', runId: 'run-1' },
+      remediation: {
+        target: { workflowId: 'wf-123', runId: 'run-1' },
+        mode: 'snapshot_then_follow',
+        authorityMode: 'approval_gated',
+      },
+    });
+  });
+
   it('invokes the signal endpoint when a lifecycle action is selected', async () => {
     renderMenu();
     fireEvent.click(screen.getByRole('button', { name: 'Actions' }));

--- a/frontend/src/components/WorkflowRowActionsMenu.tsx
+++ b/frontend/src/components/WorkflowRowActionsMenu.tsx
@@ -11,12 +11,14 @@ import {
   taskEditForRerunHref,
   taskEditHref,
 } from '../lib/temporalTaskEditing';
+import { navigateTo } from '../lib/navigation';
 import {
-  buildRemediationRuntimeRequestFields,
+  buildRemediationCreateDraft,
+  remediationCreateDraftUrl,
+  storeRemediationCreateDraft,
+} from '../lib/remediationCreateDraft';
+import {
   buildWorkflowActionMenuItems,
-  DEFAULT_REMEDIATION_ACTION_POLICY,
-  DEFAULT_REMEDIATION_AUTHORITY,
-  DEFAULT_REMEDIATION_MODE,
   ExecutionActionsSchema,
   isRemediationEligibleTarget,
   type WorkflowActionMenuItem,
@@ -289,45 +291,32 @@ export function WorkflowRowActionsMenu({
     onError: onMutationError,
   });
 
-  const createRemediationMutation = useMutation({
-    mutationFn: async () => {
-      const response = await fetch(`${apiBase}/executions/${encodeURIComponent(workflowId)}/remediation`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
-        body: JSON.stringify({
-          repository: execution?.repository ?? null,
-          ...buildRemediationRuntimeRequestFields(execution),
-          instructions: `Investigate and remediate target execution ${workflowId} using bounded evidence.`,
-          remediation: {
-            mode: DEFAULT_REMEDIATION_MODE,
-            authorityMode: DEFAULT_REMEDIATION_AUTHORITY,
-            target: { runId: runId || undefined },
-            actionPolicyRef: DEFAULT_REMEDIATION_ACTION_POLICY,
-            evidencePolicy: {
-              includeStepLedger: true,
-              includeDiagnostics: true,
-              tailLines: 2000,
-            },
-            trigger: { type: 'manual' },
-          },
-        }),
+  const openRemediationCreateDraft = useCallback(() => {
+    if (!execution) {
+      onMutationError(new Error('Workflow detail is required before remediation can start.'));
+      return;
+    }
+    try {
+      const draft = buildRemediationCreateDraft(execution, {
+        instructions: `Investigate and remediate target execution ${workflowId} using bounded evidence.`,
+        evidencePolicy: {
+          includeStepLedger: true,
+          includeDiagnostics: true,
+          tailLines: 2000,
+        },
       });
-      if (!response.ok) {
-        const text = await response.text();
-        throw new Error(text || response.statusText);
-      }
-      return response.json();
-    },
-    onSuccess: invalidate,
-    onError: onMutationError,
-  });
+      const draftId = storeRemediationCreateDraft(draft);
+      navigateTo(remediationCreateDraftUrl(draftId));
+    } catch (error) {
+      onMutationError(error);
+    }
+  }, [execution, onMutationError, workflowId]);
 
   const busy =
     updateMutation.isPending ||
     signalMutation.isPending ||
     cancelMutation.isPending ||
-    failedStepResumeMutation.isPending ||
-    createRemediationMutation.isPending;
+    failedStepResumeMutation.isPending;
 
   const editHref = workflowId
     ? actions?.canEditForRerun
@@ -464,7 +453,7 @@ export function WorkflowRowActionsMenu({
         },
         onCreateRemediation: () => {
           setActionError(null);
-          createRemediationMutation.mutate();
+          openRemediationCreateDraft();
         },
       },
     });
@@ -477,13 +466,13 @@ export function WorkflowRowActionsMenu({
     canShowEditWorkflow,
     cancelMutation,
     compareHref,
-    createRemediationMutation,
     disabledReason,
     detailHref,
     editHref,
     editTaskUnavailableReason,
     execution,
     failedStepResumeMutation,
+    openRemediationCreateDraft,
     rerunUnavailableReason,
     signalMutation,
     taskEditingEnabled,

--- a/frontend/src/entrypoints/workflow-detail.test.tsx
+++ b/frontend/src/entrypoints/workflow-detail.test.tsx
@@ -6106,33 +6106,39 @@ describe('Workflow Detail Entrypoint', () => {
     fireEvent.click(within(menu).getByRole('menuitem', { name: 'Remediate' }));
 
     await waitFor(() => {
-      const remediationCreateCall = fetchSpy.mock.calls.find(
-        ([url, init]) => String(url) === '/api/executions/test-123/remediation' && init?.method === 'POST',
+      expect(navigateTo).toHaveBeenCalledWith(
+        expect.stringMatching(/^\/workflows\/new\?intent=remediate&draftId=.+/),
       );
-      expect(remediationCreateCall).toBeTruthy();
-      const remediationBody = JSON.parse(String(remediationCreateCall?.[1]?.body));
-      expect(remediationBody).not.toHaveProperty('targetRuntime');
-      expect(remediationBody).not.toHaveProperty('profileId');
-      expect(remediationBody).toMatchObject({
-        repository: 'MoonLadderStudios/MoonMind',
-        runtime: {
-          mode: 'claude_code',
-          model: 'claude-opus-4-1-20250805',
-          effort: 'high',
-          profileId: 'claude_anthropic',
+    });
+    expect(
+      fetchSpy.mock.calls.some(
+        ([url, init]) => String(url) === '/api/executions/test-123/remediation' && init?.method === 'POST',
+      ),
+    ).toBe(false);
+    const draftUrl = String(vi.mocked(navigateTo).mock.calls.at(-1)?.[0] || '');
+    const draftId = new URL(draftUrl, window.location.origin).searchParams.get('draftId') || '';
+    const rawDraft = window.sessionStorage.getItem(`moonmind.remediationDraft.${draftId}`);
+    expect(rawDraft).toBeTruthy();
+    expect(JSON.parse(String(rawDraft))).toMatchObject({
+      repository: 'MoonLadderStudios/MoonMind',
+      target: { workflowId: 'test-123', runId: '01-run' },
+      runtime: {
+        mode: 'claude_code',
+        model: 'claude-opus-4-1-20250805',
+        effort: 'high',
+        profileId: 'claude_anthropic',
+      },
+      remediation: {
+        mode: 'snapshot_then_follow',
+        authorityMode: 'approval_gated',
+        target: { workflowId: 'test-123', runId: '01-run' },
+        evidencePolicy: {
+          includeStepLedger: true,
+          includeDiagnostics: true,
+          tailLines: 2000,
         },
-        remediation: {
-          mode: 'snapshot_then_follow',
-          authorityMode: 'approval_gated',
-          target: { runId: '01-run' },
-          evidencePolicy: {
-            includeStepLedger: true,
-            includeDiagnostics: true,
-            tailLines: 2000,
-          },
-          trigger: { type: 'manual' },
-        },
-      });
+        trigger: { type: 'manual' },
+      },
     });
 
     fireEvent.click(screen.getByRole('button', { name: 'Approve remediation action' }));
@@ -6211,25 +6217,33 @@ describe('Workflow Detail Entrypoint', () => {
     fireEvent.click(within(menu).getByRole('menuitem', { name: 'Remediate' }));
 
     await waitFor(() => {
-      const remediationCreateCall = fetchSpy.mock.calls.find(
+      expect(navigateTo).toHaveBeenCalledWith(
+        expect.stringMatching(/^\/workflows\/new\?intent=remediate&draftId=.+/),
+      );
+    });
+    expect(
+      fetchSpy.mock.calls.some(
         ([url, init]) =>
           String(url) === '/api/executions/test-remediation-create-choices/remediation' &&
           init?.method === 'POST',
-      );
-      expect(remediationCreateCall).toBeTruthy();
-      expect(JSON.parse(String(remediationCreateCall?.[1]?.body))).toMatchObject({
-        remediation: {
-          mode: 'snapshot',
-          authorityMode: 'observe_only',
-          actionPolicyRef: 'troubleshooting_only',
-          target: { runId: '01-run' },
-          evidencePolicy: {
-            includeStepLedger: true,
-            includeDiagnostics: true,
-            tailLines: 2000,
-          },
+      ),
+    ).toBe(false);
+    const draftUrl = String(vi.mocked(navigateTo).mock.calls.at(-1)?.[0] || '');
+    const draftId = new URL(draftUrl, window.location.origin).searchParams.get('draftId') || '';
+    const rawDraft = window.sessionStorage.getItem(`moonmind.remediationDraft.${draftId}`);
+    expect(rawDraft).toBeTruthy();
+    expect(JSON.parse(String(rawDraft))).toMatchObject({
+      remediation: {
+        mode: 'snapshot',
+        authorityMode: 'observe_only',
+        actionPolicyRef: 'troubleshooting_only',
+        target: { workflowId: 'test-remediation-create-choices', runId: '01-run' },
+        evidencePolicy: {
+          includeStepLedger: true,
+          includeDiagnostics: true,
+          tailLines: 2000,
         },
-      });
+      },
     });
   });
 

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -32,6 +32,12 @@ import {
   taskEditForRerunHref,
   taskEditHref,
 } from '../lib/temporalTaskEditing';
+import { navigateTo } from '../lib/navigation';
+import {
+  buildRemediationCreateDraft,
+  remediationCreateDraftUrl,
+  storeRemediationCreateDraft,
+} from '../lib/remediationCreateDraft';
 import {
   readWorkflowListDisplayMode,
   type WorkflowListDisplayMode,
@@ -44,7 +50,6 @@ import {
 import { workflowWorkspaceRowFromDetail } from '../lib/workflowWorkspaceList';
 import { WorkflowActionsMenu } from '../components/WorkflowActionsMenu';
 import {
-  buildRemediationRuntimeRequestFields,
   buildWorkflowActionMenuItems,
   DEFAULT_REMEDIATION_ACTION_POLICY,
   DEFAULT_REMEDIATION_AUTHORITY,
@@ -7227,43 +7232,35 @@ export function WorkflowDetailPage({ payload }: { payload: BootPayload }) {
     onError: (error: Error) => setActionError(error.message),
   });
 
-  const createRemediationMutation = useMutation({
-    mutationFn: async () => {
-      const response = await fetch(`${payload.apiBase}/executions/${encodeURIComponent(workflowId)}/remediation`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
-        body: JSON.stringify({
-          repository: execution?.repository ?? null,
-          ...buildRemediationRuntimeRequestFields(execution),
+  const openRemediationCreateDraft = () => {
+    if (!execution) {
+      setActionError('Workflow detail is required before remediation can start.');
+      return;
+    }
+    try {
+      const draft = buildRemediationCreateDraft(
+        {
+          ...execution,
+          runId: latestRunId || runId || execution.runId,
+        },
+        {
           instructions: `Investigate and remediate target execution ${workflowId} using bounded evidence.`,
-          remediation: {
-            mode: remediationMode,
-            authorityMode: remediationAuthority,
-            target: {
-              runId: latestRunId || runId || undefined,
-            },
-            actionPolicyRef: remediationActionPolicy.trim() || undefined,
-            evidencePolicy: {
-              includeStepLedger: true,
-              includeDiagnostics: true,
-              tailLines: 2000,
-            },
-            trigger: { type: 'manual' },
+          evidencePolicy: {
+            includeStepLedger: true,
+            includeDiagnostics: true,
+            tailLines: 2000,
           },
-        }),
-      });
-      if (!response.ok) {
-        const text = await response.text();
-        throw new Error(text || response.statusText);
-      }
-      return response.json();
-    },
-    onSuccess: () => {
-      setActionNotice('Remediation workflow creation submitted.');
-      invalidate();
-    },
-    onError: (error: Error) => setActionError(error.message),
-  });
+        },
+      );
+      draft.remediation.mode = remediationMode;
+      draft.remediation.authorityMode = remediationAuthority;
+      draft.remediation.actionPolicyRef = remediationActionPolicy.trim() || undefined;
+      const draftId = storeRemediationCreateDraft(draft);
+      navigateTo(remediationCreateDraftUrl(draftId));
+    } catch (error) {
+      setActionError(error instanceof Error ? error.message : 'Failed to prepare remediation draft.');
+    }
+  };
 
   const remediationApprovalMutation = useMutation({
     mutationFn: async ({
@@ -7488,7 +7485,6 @@ export function WorkflowDetailPage({ payload }: { payload: BootPayload }) {
     cancelMutation.isPending ||
     failedStepResumeMutation.isPending ||
     selectedStepRecoveryMutation.isPending ||
-    createRemediationMutation.isPending ||
     remediationApprovalMutation.isPending ||
     checkpointBranchMutation.isPending;
   const editHref = workflowId
@@ -7602,10 +7598,10 @@ export function WorkflowDetailPage({ payload }: { payload: BootPayload }) {
         setActiveWorkflowDialog('send-message');
       },
       onBypassDependencies,
-      onCreateRemediation: () => {
-        setActionError(null);
-        createRemediationMutation.mutate();
-      },
+    onCreateRemediation: () => {
+      setActionError(null);
+      openRemediationCreateDraft();
+    },
     },
   });
   const toolbarMenuItems: WorkflowActionMenuItem[] = [

--- a/frontend/src/entrypoints/workflow-start.test.tsx
+++ b/frontend/src/entrypoints/workflow-start.test.tsx
@@ -19,6 +19,10 @@ import {
   buildTemporalSubmissionDraftFromExecution,
   resolveTaskSubmitPageMode,
 } from "../lib/temporalTaskEditing";
+import {
+  buildRemediationCreateDraft,
+  storeRemediationCreateDraft,
+} from "../lib/remediationCreateDraft";
 import { renderWithClient } from "../utils/test-utils";
 import {
   ARTIFACT_COMPLETE_RETRY_DELAYS_MS,
@@ -905,6 +909,100 @@ describe("WorkflowStart schedule mode entry", () => {
     expect(scheduleMode.value).toBe("immediate");
   });
 
+});
+
+describe("WorkflowStart remediation draft intake", () => {
+  let fetchSpy: MockInstance;
+
+  beforeEach(() => {
+    window.sessionStorage.clear();
+    window.localStorage.clear();
+    vi.mocked(navigateTo).mockReset();
+    fetchSpy = vi.spyOn(window, "fetch").mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.startsWith("/api/workflows/skills")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ items: { worker: ["pr-resolver"] }, legacyItems: [] }),
+        } as Response);
+      }
+      if (url.startsWith("/api/v1/provider-profiles")) {
+        return Promise.resolve({ ok: true, json: async () => [] } as Response);
+      }
+      if (url.startsWith("/api/executions?")) {
+        return Promise.resolve({ ok: true, json: async () => ({ items: [] }) } as Response);
+      }
+      if (url === "/api/executions") {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            workflowId: "mm:remediation-created",
+            redirectPath: "/workflows/mm:remediation-created?source=temporal",
+          }),
+        } as Response);
+      }
+      return Promise.resolve({ ok: true, json: async () => ({ items: [] }) } as Response);
+    });
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+    window.sessionStorage.clear();
+  });
+
+  it("consumes remediation drafts and submits task.remediation through normal create", async () => {
+    const draft = buildRemediationCreateDraft(
+      {
+        workflowId: "mm:target-workflow",
+        runId: "run-target-1",
+        title: "Target workflow",
+        state: "failed",
+        repository: "MoonLadderStudios/MoonMind",
+        targetRuntime: "codex_cli",
+        model: "gpt-5",
+        effort: "high",
+        profileId: "profile-codex",
+      },
+      { instructions: "Fix the failed workflow with bounded evidence." },
+    );
+    const draftId = storeRemediationCreateDraft(draft);
+    window.history.pushState(
+      {},
+      "Task Create",
+      `/workflows/new?intent=remediate&draftId=${encodeURIComponent(draftId)}`,
+    );
+
+    renderWorkflowStartPage(mockPayload);
+
+    expect(await screen.findByRole("heading", { name: "Remediation Draft" })).toBeTruthy();
+    expect(screen.getByText("mm:target-workflow")).toBeTruthy();
+    expect(screen.getByText("run-target-1")).toBeTruthy();
+    expect(window.sessionStorage.getItem(`moonmind.remediationDraft.${draftId}`)).toBeNull();
+
+    fireEvent.click(await screen.findByRole("button", { name: "Start Workflow" }));
+
+    await waitFor(() => {
+      expect(fetchSpy.mock.calls.some(([url]) => String(url) === "/api/executions")).toBe(true);
+    });
+    const createCall = fetchSpy.mock.calls.find(([url]) => String(url) === "/api/executions");
+    const requestBody = JSON.parse(String(createCall?.[1]?.body));
+    expect(requestBody.payload.task.remediation).toMatchObject({
+      target: {
+        workflowId: "mm:target-workflow",
+        runId: "run-target-1",
+      },
+      mode: "snapshot_then_follow",
+      authorityMode: "approval_gated",
+      actionPolicyRef: "admin_healer_default",
+      trigger: { type: "manual" },
+    });
+    expect(
+      fetchSpy.mock.calls.some(
+        ([url, init]) =>
+          String(url).includes("/remediation") && init?.method === "POST",
+      ),
+    ).toBe(false);
+  });
 });
 
 describe("WorkflowStart CSS Layout", () => {

--- a/frontend/src/entrypoints/workflow-start.tsx
+++ b/frontend/src/entrypoints/workflow-start.tsx
@@ -25,6 +25,10 @@ import {
   type TemporalTaskInputAttachmentRef,
 } from "../lib/temporalTaskEditing";
 import {
+  consumeRemediationCreateDraft,
+  type RemediationCreateDraft,
+} from "../lib/remediationCreateDraft";
+import {
   readWorkflowListDisplayMode,
 } from "../lib/workflowListDisplayMode";
 import { WorkflowWorkspaceSidebarPanel } from "../components/workflows/WorkflowWorkspaceSidebar";
@@ -5862,9 +5866,13 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
   const prevRuntimeRef = useRef(runtime);
   const prevProviderProfileRef = useRef(providerProfile);
   const temporalDraftAppliedRef = useRef<string | null>(null);
+  const remediationDraftAppliedRef = useRef<string | null>(null);
   const jiraProjectSelectionInitializedRef = useRef(false);
   const jiraBoardSelectionInitializedRef = useRef(false);
   const initialRouteGuardSnapshotRef = useRef<string>("");
+  const [remediationDraft, setRemediationDraft] =
+    useState<RemediationCreateDraft | null>(null);
+  const [remediationDraftError, setRemediationDraftError] = useState<string | null>(null);
 
   useEffect(() => {
     const captureSnapshot = () => {
@@ -6247,6 +6255,63 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
     pageMode.mode,
     temporalDraftQuery.data,
   ]);
+
+  useEffect(() => {
+    if (pageMode.mode !== "create") {
+      return;
+    }
+    const params = new URLSearchParams(window.location.search);
+    if (params.get("intent") !== "remediate") {
+      return;
+    }
+    const draftId = String(params.get("draftId") || "").trim();
+    if (!draftId || remediationDraftAppliedRef.current === draftId) {
+      return;
+    }
+    remediationDraftAppliedRef.current = draftId;
+    const draft = consumeRemediationCreateDraft(draftId);
+    if (!draft) {
+      setRemediationDraft(null);
+      setRemediationDraftError("The remediation draft is missing, expired, or malformed.");
+      return;
+    }
+
+    setRemediationDraft(draft);
+    setRemediationDraftError(null);
+    setRepository(draft.repository || "MoonLadderStudios/MoonMind");
+    if (draft.branch) {
+      setBranch(draft.branch);
+      setBranchTouched(false);
+    }
+    if (draft.publishMode) {
+      setPublishMode(normalizePublishModeForSubmit(draft.publishMode));
+    }
+    if (draft.runtime?.mode) {
+      prevRuntimeRef.current = draft.runtime.mode;
+      setRuntime(draft.runtime.mode);
+    }
+    if (draft.runtime?.profileId) {
+      prevProviderProfileRef.current = draft.runtime.profileId;
+      setProviderProfile(draft.runtime.profileId);
+    }
+    if (draft.runtime?.model) {
+      setModel(draft.runtime.model);
+      setModelManualOverride(true);
+    }
+    if (draft.runtime?.effort) {
+      setEffort(draft.runtime.effort);
+    }
+    setSteps((current) => {
+      const first = current[0] || createStepStateEntry(1);
+      const instructions =
+        draft.instructions ||
+        `Investigate and remediate target execution ${draft.target.workflowId} using bounded evidence.`;
+      return [
+        { ...first, instructions },
+        ...current.slice(1),
+      ];
+    });
+  }, [pageMode.mode]);
 
   const dependencyOptionsQuery = useQuery({
     queryKey: ["workflow-start", "dependency-options", temporalListEndpoint],
@@ -10367,6 +10432,7 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
       ...(selectedDependencies.length > 0
         ? { dependsOn: selectedDependencies }
         : {}),
+      ...(remediationDraft ? { remediation: remediationDraft.remediation } : {}),
     };
 
     const requestBody: Record<string, unknown> = {
@@ -10809,6 +10875,47 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
           You are starting a comparison run. Choose a different runtime or model
           to compare results with the source run.
         </p>
+      ) : null}
+
+      {remediationDraftError ? (
+        <p className="notice error" role="alert">
+          {remediationDraftError}
+        </p>
+      ) : null}
+
+      {remediationDraft ? (
+        <section
+          className="card stack"
+          aria-label="Remediation draft"
+          data-canonical-create-section="Remediation Draft"
+        >
+          <h3>Remediation Draft</h3>
+          <div className="grid-2">
+            <div>
+              <strong>Target workflow</strong>
+              <p className="small break-words">
+                <code>{remediationDraft.target.workflowId}</code>
+              </p>
+            </div>
+            <div>
+              <strong>Pinned run</strong>
+              <p className="small break-words">
+                <code>{remediationDraft.target.runId}</code>
+              </p>
+            </div>
+            <div>
+              <strong>Authority</strong>
+              <p className="small">{remediationDraft.remediation.authorityMode}</p>
+            </div>
+            <div>
+              <strong>Action policy</strong>
+              <p className="small">{remediationDraft.remediation.actionPolicyRef || "none"}</p>
+            </div>
+          </div>
+          <p className="small">
+            Evidence preview: step ledger, diagnostics, selected refs, and remediation context refs.
+          </p>
+        </section>
       ) : null}
 
       {jiraIntegration?.enabled && jiraBrowserOpen ? (

--- a/frontend/src/lib/remediationCreateDraft.test.ts
+++ b/frontend/src/lib/remediationCreateDraft.test.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  buildRemediationCreateDraft,
+  clearRemediationCreateDraft,
+  consumeRemediationCreateDraft,
+  loadRemediationCreateDraft,
+  remediationCreateDraftUrl,
+  storeRemediationCreateDraft,
+} from './remediationCreateDraft';
+
+const executionDetail = {
+  workflowId: 'mm:target-workflow',
+  runId: 'run-target-1',
+  title: 'Target workflow',
+  state: 'failed',
+  repository: 'MoonLadderStudios/MoonMind',
+  targetRuntime: 'codex_cli',
+  model: 'gpt-5',
+  effort: 'high',
+  profileId: 'profile-codex',
+};
+
+describe('remediationCreateDraft', () => {
+  beforeEach(() => {
+    window.sessionStorage.clear();
+    vi.useRealTimers();
+  });
+
+  it('builds a pinned remediation draft with create-first defaults', () => {
+    const draft = buildRemediationCreateDraft(executionDetail, {
+      now: new Date('2026-07-07T12:00:00.000Z'),
+    });
+
+    expect(draft).toMatchObject({
+      source: 'remediation',
+      createdAt: '2026-07-07T12:00:00.000Z',
+      target: {
+        workflowId: 'mm:target-workflow',
+        runId: 'run-target-1',
+        title: 'Target workflow',
+        state: 'failed',
+      },
+      repository: 'MoonLadderStudios/MoonMind',
+      runtime: {
+        mode: 'codex_cli',
+        model: 'gpt-5',
+        effort: 'high',
+        profileId: 'profile-codex',
+      },
+      remediation: {
+        mode: 'snapshot_then_follow',
+        authorityMode: 'approval_gated',
+        actionPolicyRef: 'admin_healer_default',
+        target: {
+          workflowId: 'mm:target-workflow',
+          runId: 'run-target-1',
+        },
+        trigger: { type: 'manual' },
+      },
+    });
+  });
+
+  it('stores, loads, consumes, and clears session-scoped drafts', () => {
+    const draft = buildRemediationCreateDraft(executionDetail);
+    const draftId = storeRemediationCreateDraft(draft);
+
+    expect(remediationCreateDraftUrl(draftId)).toBe(
+      `/workflows/new?intent=remediate&draftId=${encodeURIComponent(draftId)}`,
+    );
+    expect(loadRemediationCreateDraft(draftId)).toMatchObject({
+      target: { workflowId: 'mm:target-workflow', runId: 'run-target-1' },
+    });
+    expect(consumeRemediationCreateDraft(draftId)).toMatchObject({
+      target: { workflowId: 'mm:target-workflow', runId: 'run-target-1' },
+    });
+    expect(loadRemediationCreateDraft(draftId)).toBeNull();
+
+    const secondId = storeRemediationCreateDraft(draft);
+    clearRemediationCreateDraft(secondId);
+    expect(loadRemediationCreateDraft(secondId)).toBeNull();
+  });
+
+  it('rejects malformed and expired drafts without throwing', () => {
+    window.sessionStorage.setItem('moonmind.remediationDraft.bad', '{"source":"wrong"}');
+    expect(loadRemediationCreateDraft('bad')).toBeNull();
+
+    const draft = buildRemediationCreateDraft(executionDetail, {
+      now: new Date('2026-07-07T12:00:00.000Z'),
+    });
+    const draftId = storeRemediationCreateDraft(draft);
+    vi.setSystemTime(new Date('2026-07-08T12:00:01.000Z'));
+    expect(loadRemediationCreateDraft(draftId)).toBeNull();
+  });
+});

--- a/frontend/src/lib/remediationCreateDraft.ts
+++ b/frontend/src/lib/remediationCreateDraft.ts
@@ -1,0 +1,231 @@
+import {
+  DEFAULT_REMEDIATION_ACTION_POLICY,
+  DEFAULT_REMEDIATION_AUTHORITY,
+  DEFAULT_REMEDIATION_MODE,
+} from './workflowActions';
+
+const STORAGE_PREFIX = 'moonmind.remediationDraft.';
+const DEFAULT_REPOSITORY = 'MoonLadderStudios/MoonMind';
+const DRAFT_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+
+type UnknownRecord = Record<string, unknown>;
+
+export type RemediationTarget = {
+  workflowId: string;
+  runId: string;
+  title?: string;
+  state?: string;
+  stepSelectors?: UnknownRecord[];
+  agentRunIds?: string[];
+};
+
+export type RemediationCreateDraft = {
+  draftId?: string;
+  source: 'remediation';
+  createdAt: string;
+  target: RemediationTarget;
+  repository: string;
+  branch?: string;
+  publishMode?: string;
+  runtime?: {
+    mode?: string;
+    model?: string;
+    effort?: string;
+    profileId?: string;
+  };
+  instructions?: string;
+  remediation: {
+    target: RemediationTarget;
+    mode: 'snapshot' | 'live_follow' | 'snapshot_then_follow';
+    authorityMode: 'observe_only' | 'approval_gated' | 'admin_auto';
+    actionPolicyRef?: string;
+    evidencePolicy?: UnknownRecord;
+    checkpointBranchPolicy?: UnknownRecord;
+    trigger: { type: 'manual' };
+  };
+};
+
+export type RemediationCreateDraftOptions = {
+  now?: Date;
+  repository?: string | null;
+  branch?: string | null;
+  publishMode?: string | null;
+  instructions?: string | null;
+  stepSelectors?: UnknownRecord[];
+  agentRunIds?: string[];
+  evidencePolicy?: UnknownRecord;
+  checkpointBranchPolicy?: UnknownRecord;
+};
+
+function recordValue(value: unknown): UnknownRecord {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as UnknownRecord)
+    : {};
+}
+
+function stringValue(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function optionalString(value: unknown): string | undefined {
+  const normalized = stringValue(value);
+  return normalized || undefined;
+}
+
+function storageKey(draftId: string): string {
+  return `${STORAGE_PREFIX}${draftId}`;
+}
+
+function createDraftId(): string {
+  const cryptoApi = globalThis.crypto;
+  if (cryptoApi && typeof cryptoApi.randomUUID === 'function') {
+    return cryptoApi.randomUUID();
+  }
+  return `draft-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function readRunId(executionDetail: UnknownRecord): string {
+  return (
+    stringValue(executionDetail.runId) ||
+    stringValue(executionDetail.temporalRunId) ||
+    stringValue(executionDetail.latestRunId)
+  );
+}
+
+function readWorkflowId(executionDetail: UnknownRecord): string {
+  return stringValue(executionDetail.workflowId) || stringValue(executionDetail.id);
+}
+
+function readRuntime(executionDetail: UnknownRecord): RemediationCreateDraft['runtime'] {
+  const runtime = recordValue(executionDetail.runtime);
+  const mode = stringValue(runtime.mode) || stringValue(executionDetail.targetRuntime);
+  const model =
+    stringValue(runtime.model) ||
+    stringValue(executionDetail.model) ||
+    stringValue(executionDetail.resolvedModel) ||
+    stringValue(executionDetail.requestedModel);
+  const effort = stringValue(runtime.effort) || stringValue(executionDetail.effort);
+  const profileId =
+    stringValue(runtime.profileId) ||
+    stringValue(runtime.providerProfile) ||
+    stringValue(executionDetail.profileId);
+  const value = {
+    ...(mode ? { mode } : {}),
+    ...(model ? { model } : {}),
+    ...(effort ? { effort } : {}),
+    ...(profileId ? { profileId } : {}),
+  };
+  return Object.keys(value).length > 0 ? value : undefined;
+}
+
+function normalizeDraft(value: unknown): RemediationCreateDraft | null {
+  const draft = recordValue(value);
+  if (draft.source !== 'remediation') return null;
+  const target = recordValue(draft.target);
+  const remediation = recordValue(draft.remediation);
+  const remediationTarget = recordValue(remediation.target);
+  const workflowId = stringValue(target.workflowId);
+  const runId = stringValue(target.runId);
+  const remediationWorkflowId = stringValue(remediationTarget.workflowId);
+  const remediationRunId = stringValue(remediationTarget.runId);
+  const createdAt = stringValue(draft.createdAt);
+  const createdAtTime = Date.parse(createdAt);
+  if (
+    !workflowId ||
+    !runId ||
+    workflowId !== remediationWorkflowId ||
+    runId !== remediationRunId ||
+    !Number.isFinite(createdAtTime) ||
+    Date.now() - createdAtTime > DRAFT_MAX_AGE_MS
+  ) {
+    return null;
+  }
+  return draft as RemediationCreateDraft;
+}
+
+export function buildRemediationCreateDraft(
+  executionDetail: unknown,
+  options: RemediationCreateDraftOptions = {},
+): RemediationCreateDraft {
+  const detail = recordValue(executionDetail);
+  const workflowId = readWorkflowId(detail);
+  const runId = readRunId(detail);
+  if (!workflowId || !runId) {
+    throw new Error('Target workflow and run are required to create a remediation draft.');
+  }
+
+  const target: RemediationTarget = {
+    workflowId,
+    runId,
+    ...(optionalString(detail.title) ? { title: optionalString(detail.title) } : {}),
+    ...(optionalString(detail.state || detail.rawState || detail.status)
+      ? { state: optionalString(detail.state || detail.rawState || detail.status) }
+      : {}),
+    ...(options.stepSelectors && options.stepSelectors.length > 0
+      ? { stepSelectors: options.stepSelectors }
+      : {}),
+    ...(options.agentRunIds && options.agentRunIds.length > 0
+      ? { agentRunIds: options.agentRunIds }
+      : {}),
+  };
+  const createdAt = (options.now || new Date()).toISOString();
+  const repository =
+    stringValue(options.repository) || stringValue(detail.repository) || DEFAULT_REPOSITORY;
+  const runtime = readRuntime(detail);
+
+  return {
+    source: 'remediation',
+    createdAt,
+    target,
+    repository,
+    ...(optionalString(options.branch) ? { branch: optionalString(options.branch) } : {}),
+    ...(optionalString(options.publishMode)
+      ? { publishMode: optionalString(options.publishMode) }
+      : {}),
+    ...(runtime ? { runtime } : {}),
+    ...(optionalString(options.instructions) ? { instructions: optionalString(options.instructions) } : {}),
+    remediation: {
+      target,
+      mode: DEFAULT_REMEDIATION_MODE,
+      authorityMode: DEFAULT_REMEDIATION_AUTHORITY,
+      actionPolicyRef: DEFAULT_REMEDIATION_ACTION_POLICY,
+      evidencePolicy: options.evidencePolicy ?? {},
+      checkpointBranchPolicy: options.checkpointBranchPolicy ?? {},
+      trigger: { type: 'manual' },
+    },
+  };
+}
+
+export function storeRemediationCreateDraft(draft: RemediationCreateDraft): string {
+  const draftId = draft.draftId || createDraftId();
+  window.sessionStorage.setItem(storageKey(draftId), JSON.stringify({ ...draft, draftId }));
+  return draftId;
+}
+
+export function loadRemediationCreateDraft(draftId: string): RemediationCreateDraft | null {
+  const normalizedId = draftId.trim();
+  if (!normalizedId) return null;
+  try {
+    const raw = window.sessionStorage.getItem(storageKey(normalizedId));
+    if (!raw) return null;
+    return normalizeDraft(JSON.parse(raw));
+  } catch {
+    return null;
+  }
+}
+
+export function clearRemediationCreateDraft(draftId: string): void {
+  const normalizedId = draftId.trim();
+  if (!normalizedId) return;
+  window.sessionStorage.removeItem(storageKey(normalizedId));
+}
+
+export function consumeRemediationCreateDraft(draftId: string): RemediationCreateDraft | null {
+  const draft = loadRemediationCreateDraft(draftId);
+  clearRemediationCreateDraft(draftId);
+  return draft;
+}
+
+export function remediationCreateDraftUrl(draftId: string): string {
+  return `/workflows/new?intent=remediate&draftId=${encodeURIComponent(draftId)}`;
+}

--- a/moonmind/omnigent/execute.py
+++ b/moonmind/omnigent/execute.py
@@ -656,6 +656,62 @@ def _assert_no_provider_native_refs(refs: list[str]) -> None:
         )
 
 
+def _validate_omnigent_remediation_request(request: AgentExecutionRequest) -> None:
+    parameters = request.parameters if isinstance(request.parameters, dict) else {}
+    omnigent = parameters.get("omnigent") if isinstance(parameters, dict) else {}
+    omnigent_mapping = omnigent if isinstance(omnigent, dict) else {}
+    remediation = parameters.get("remediation") or omnigent_mapping.get("remediation")
+    if remediation is None:
+        return
+    if not isinstance(remediation, dict):
+        raise OmnigentContractError("Omnigent remediation must be an object")
+    action_kind = str(remediation.get("actionKind") or "").strip()
+    if action_kind and action_kind != "checkpoint_branch.create_from_remediation_context":
+        raise OmnigentContractError(
+            "Omnigent v1 remediation only supports checkpoint_branch.create_from_remediation_context"
+        )
+    runtime_policy = str(
+        remediation.get("runtimeContextPolicy")
+        or remediation.get("runtime_context_policy")
+        or remediation.get("continuationMode")
+        or remediation.get("continuation_mode")
+        or "fresh_agent_run"
+    ).strip()
+    if runtime_policy in {
+        "reuse_session_same_epoch",
+        "reuse_session_new_epoch",
+        "external_provider_continuation",
+        "same_session",
+    }:
+        raise OmnigentContractError(
+            "Omnigent v1 remediation does not support same-session continuation"
+        )
+    if runtime_policy != "fresh_agent_run":
+        raise OmnigentContractError(
+            "Omnigent v1 remediation requires fresh_agent_run checkpoint branch repair"
+        )
+    if remediation.get("sameSessionContinuation") is True:
+        raise OmnigentContractError(
+            "Omnigent v1 remediation does not support same-session continuation"
+        )
+
+    def visit(value: Any, path: str) -> None:
+        if isinstance(value, dict):
+            for key, item in value.items():
+                visit(item, f"{path}.{key}" if path else str(key))
+            return
+        if isinstance(value, list):
+            for index, item in enumerate(value):
+                visit(item, f"{path}[{index}]")
+            return
+        if isinstance(value, str) and value.strip().startswith("omnigent://"):
+            raise OmnigentContractError(
+                f"Omnigent remediation requires MoonMind artifact refs: {path}"
+            )
+
+    visit(remediation, "remediation")
+
+
 async def _cancel_omnigent_session(
     client: OmnigentHttpClient,
     session_id: str,
@@ -1469,6 +1525,7 @@ async def run_omnigent_execution(
         raise RuntimeError(
             f"{OMNIGENT_DISABLED_MESSAGE} (missing: {', '.join(gate.missing)})"
         )
+    _validate_omnigent_remediation_request(request)
 
     client: OmnigentHttpClient | None = None
     session_id = ""

--- a/moonmind/workflows/temporal/remediation_actions.py
+++ b/moonmind/workflows/temporal/remediation_actions.py
@@ -111,6 +111,24 @@ _ACTION_CATALOG: dict[str, dict[str, Any]] = {
         "idempotency": "same target/action/reason key returns the prior decision",
         "verification_hint": "verify a fresh execution is created and linked to the target",
     },
+    "checkpoint_branch.create_from_remediation_context": {
+        "risk": "medium",
+        "enabled": True,
+        "target_type": "checkpoint_branch",
+        "input_metadata": {
+            **_COMMON_REASON_INPUT,
+            "checkpointRef": {"type": "string", "required": True},
+            "instructionRef": {"type": "string", "required": False},
+        },
+        "preconditions": (
+            "target_visible",
+            "remediation_context_available",
+            "source_checkpoint_valid",
+            "fresh_agent_run",
+        ),
+        "idempotency": "same remediation/context/checkpoint/instruction key returns the prior branch turn",
+        "verification_hint": "verify checkpoint branch turn launches with remediation provenance",
+    },
     "execution.cancel": {
         "risk": "medium",
         "enabled": True,

--- a/moonmind/workflows/temporal/remediation_context.py
+++ b/moonmind/workflows/temporal/remediation_context.py
@@ -36,6 +36,8 @@ REMEDIATION_ARTIFACT_TYPES = frozenset(
         "remediation.target_annotation",
         "remediation.verification",
         "remediation.summary",
+        "remediation.corrected_instructions",
+        "remediation.checkpoint_branch_provenance",
     }
 )
 REMEDIATION_PHASES = frozenset(

--- a/moonmind/workflows/temporal/remediation_tools.py
+++ b/moonmind/workflows/temporal/remediation_tools.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 import re
+import hashlib
 from collections.abc import Awaitable, Callable, Mapping, Sequence
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -17,10 +18,15 @@ from typing import Any, Literal, Protocol
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from api_service.db import models as db_models
+from api_service.services.checkpoint_branch_service import (
+    CheckpointBranchService,
+    build_branch_turn_launch_idempotency_key,
+)
 from moonmind.workflows.temporal.artifacts import TemporalArtifactService
 from moonmind.workflows.temporal.remediation_context import (
     REMEDIATION_CONTEXT_LINK_TYPE,
     RemediationLifecyclePublisher,
+    build_corrected_instruction_retry_provenance,
     build_remediation_audit_event,
     build_remediation_decision_log,
     build_remediation_final_summary,
@@ -638,6 +644,266 @@ class RemediationEvidenceToolService:
             "lockRelease": final_summary.get("lockRelease"),
         }
 
+    async def create_checkpoint_branch_from_remediation_context(
+        self,
+        *,
+        remediation_workflow_id: str,
+        request: Mapping[str, Any],
+        checkpoint_branch_service: CheckpointBranchService | None = None,
+        principal: str = "service:remediation-tools",
+    ) -> dict[str, Any]:
+        """Create and launch a fresh-session checkpoint branch repair turn."""
+
+        if not isinstance(request, Mapping):
+            raise RemediationEvidenceToolError("checkpoint branch request must be an object.")
+        link = await self._load_link(remediation_workflow_id)
+        context = await self._read_context_payload(link=link, principal=principal)
+        source = request.get("source")
+        source_mapping = source if isinstance(source, Mapping) else {}
+        checkpoint_ref = _required_artifact_ref(
+            source_mapping.get("checkpointRef") or source_mapping.get("checkpoint_ref"),
+            "source.checkpointRef",
+        )
+        checkpoint_boundary = _required_string(
+            source_mapping.get("checkpointBoundary")
+            or source_mapping.get("checkpoint_boundary")
+            or "after_execution",
+            "source.checkpointBoundary",
+        )
+        if checkpoint_boundary not in {
+            "before_execution",
+            "after_execution",
+            "before_recovery_restoration",
+        }:
+            raise RemediationEvidenceToolError(
+                "source.checkpointBoundary is not supported."
+            )
+        target = context.get("target") if isinstance(context.get("target"), Mapping) else {}
+        target_run_id = _required_string(target.get("runId"), "context.target.runId")
+        requested_run_id = str(
+            source_mapping.get("runId") or source_mapping.get("run_id") or target_run_id
+        ).strip()
+        if requested_run_id != target_run_id or target_run_id != link.target_run_id:
+            raise RemediationEvidenceToolError(
+                "source.runId must match the pinned remediation target run."
+            )
+        evidence = context.get("evidence")
+        evidence_mapping = evidence if isinstance(evidence, Mapping) else {}
+        allowed_refs = set(_artifact_ref_list(evidence_mapping.get("targetArtifactRefs")))
+        if checkpoint_ref not in allowed_refs:
+            raise RemediationEvidenceToolError(
+                "source.checkpointRef is not listed in remediation context evidence."
+            )
+
+        branch_payload = request.get("branch")
+        branch_mapping = branch_payload if isinstance(branch_payload, Mapping) else {}
+        workspace_policy = _required_string(
+            branch_mapping.get("workspacePolicy")
+            or branch_mapping.get("workspace_policy")
+            or "apply_previous_execution_diff_to_clean_baseline",
+            "branch.workspacePolicy",
+        )
+        runtime_context_policy = _required_string(
+            branch_mapping.get("runtimeContextPolicy")
+            or branch_mapping.get("runtime_context_policy")
+            or "fresh_agent_run",
+            "branch.runtimeContextPolicy",
+        )
+        if runtime_context_policy != "fresh_agent_run":
+            raise RemediationEvidenceToolError(
+                "Omnigent v1 remediation checkpoint branches require fresh_agent_run."
+            )
+
+        instruction_ref, instruction_digest, instruction_artifact_ref = (
+            await self._checkpoint_branch_instruction(
+                link=link,
+                request=request,
+                principal=principal,
+            )
+        )
+        stable_material = json.dumps(
+            {
+                "remediationWorkflowId": link.remediation_workflow_id,
+                "contextArtifactRef": link.context_artifact_ref,
+                "checkpointRef": checkpoint_ref,
+                "instructionDigest": instruction_digest,
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+        stable_digest = hashlib.sha256(stable_material).hexdigest()[:20]
+        branch_id = str(branch_mapping.get("branchId") or f"cbr-rem-{stable_digest}").strip()
+        branch_turn_id = str(
+            branch_mapping.get("branchTurnId") or f"{branch_id}:turn:1"
+        ).strip()
+        idempotency_key = str(
+            request.get("idempotencyKey")
+            or f"{link.remediation_workflow_id}:checkpoint_branch:{stable_digest}"
+        ).strip()
+
+        service = checkpoint_branch_service or CheckpointBranchService(self._session)
+        graph = await service.create_branch_graph(
+            {
+                "branchId": branch_id,
+                "branchTurnId": branch_turn_id,
+                "source": {
+                    "workflowId": link.target_workflow_id,
+                    "runId": link.target_run_id,
+                    "logicalStepId": _string_or_none(
+                        source_mapping.get("logicalStepId")
+                        or source_mapping.get("logical_step_id")
+                    ),
+                    "sourceExecutionOrdinal": _positive_int_or_none(
+                        source_mapping.get("executionOrdinal")
+                        or source_mapping.get("execution_ordinal")
+                    ),
+                    "checkpointBoundary": checkpoint_boundary,
+                    "checkpointRef": checkpoint_ref,
+                    "checkpointDigest": _string_or_none(
+                        source_mapping.get("checkpointDigest")
+                        or source_mapping.get("checkpoint_digest")
+                    ),
+                },
+                "label": _string_or_none(branch_mapping.get("label"))
+                or "Remediation checkpoint repair",
+                "workspacePolicy": workspace_policy,
+                "runtimeContextPolicy": runtime_context_policy,
+                "instructionRef": instruction_ref,
+                "instructionDigest": instruction_digest,
+                "contextBundleRef": link.context_artifact_ref,
+                "idempotencyKey": idempotency_key,
+                "gitRepository": _string_or_none(branch_mapping.get("gitRepository")),
+                "gitBaseBranch": _string_or_none(branch_mapping.get("gitBaseBranch")),
+                "gitBaseCommit": _string_or_none(branch_mapping.get("gitBaseCommit")),
+                "gitWorkBranch": _string_or_none(branch_mapping.get("gitWorkBranch")),
+                "createdBy": principal,
+            }
+        )
+
+        launch = request.get("launch")
+        launch_mapping = launch if isinstance(launch, Mapping) else {}
+        launch_idempotency_key = build_branch_turn_launch_idempotency_key(
+            workflow_id=link.target_workflow_id,
+            branch_id=branch_id,
+            branch_turn_id=branch_turn_id,
+        )
+        turn = await service.launch_turn(
+            workflow_id=link.target_workflow_id,
+            branch_id=branch_id,
+            branch_turn_id=branch_turn_id,
+            context_bundle_ref=_required_artifact_ref(
+                launch_mapping.get("contextBundleRef") or link.context_artifact_ref,
+                "launch.contextBundleRef",
+            ),
+            step_execution_manifest_ref=_required_artifact_ref(
+                launch_mapping.get("stepExecutionManifestRef"),
+                "launch.stepExecutionManifestRef",
+            ),
+            checkpoint_ref=checkpoint_ref,
+            diagnostics_ref=_required_artifact_ref(
+                launch_mapping.get("diagnosticsRef"),
+                "launch.diagnosticsRef",
+            ),
+            idempotency_key=launch_idempotency_key,
+            created_step_execution_id=_required_string(
+                launch_mapping.get("createdStepExecutionId"),
+                "launch.createdStepExecutionId",
+            ),
+            runtime_agent_run_id=_string_or_none(
+                launch_mapping.get("runtimeAgentRunId")
+            ),
+            provider_session_id=_string_or_none(
+                launch_mapping.get("providerSessionId")
+            ),
+            agent_request_ref=_string_or_none(launch_mapping.get("runtimeRequestRef")),
+            agent_result_ref=_string_or_none(launch_mapping.get("runtimeResultRef")),
+        )
+        provenance = build_corrected_instruction_retry_provenance(
+            original_input_ref=checkpoint_ref,
+            remediation_context_ref=link.context_artifact_ref,
+            corrected_instructions_ref=instruction_ref,
+            retry_action_kind="checkpoint_branch.create_from_remediation_context",
+            reason=_string_or_none(request.get("reason"))
+            or "Remediation requested a fresh-session checkpoint branch repair.",
+            metadata={
+                "branchId": branch_id,
+                "branchTurnId": branch_turn_id,
+                "launchIdempotencyKey": launch_idempotency_key,
+                "instructionArtifactRef": instruction_artifact_ref,
+            },
+        )
+        provenance_artifact = await self._lifecycle_publisher.publish_json_artifact(
+            remediation_workflow_id=link.remediation_workflow_id,
+            artifact_type="remediation.checkpoint_branch_provenance",
+            name=f"reports/remediation_checkpoint_branch-{branch_id}.json",
+            payload=provenance,
+            target_workflow_id=link.target_workflow_id,
+            target_run_id=link.target_run_id,
+            principal=principal,
+        )
+        link.latest_action_summary = "checkpoint_branch.create_from_remediation_context"
+        link.outcome = "applied"
+        await self._session.commit()
+        return {
+            "schemaVersion": "v1",
+            "actionKind": "checkpoint_branch.create_from_remediation_context",
+            "status": "applied",
+            "targetWorkflowId": link.target_workflow_id,
+            "branchId": branch_id,
+            "branchTurnId": turn.branch_turn_id,
+            "launchIdempotencyKey": launch_idempotency_key,
+            "artifactRefs": {
+                "remediationContext": link.context_artifact_ref,
+                "correctedInstructions": instruction_ref,
+                "instructionArtifact": instruction_artifact_ref,
+                "provenance": provenance_artifact.artifact_id,
+            },
+            "graph": graph.model_dump(by_alias=True),
+        }
+
+    async def _checkpoint_branch_instruction(
+        self,
+        *,
+        link: db_models.TemporalExecutionRemediationLink,
+        request: Mapping[str, Any],
+        principal: str,
+    ) -> tuple[str, str, str | None]:
+        instructions = request.get("instructions")
+        instruction_mapping = instructions if isinstance(instructions, Mapping) else {}
+        instruction_ref = _string_or_none(
+            instruction_mapping.get("instructionRef")
+            or instruction_mapping.get("instruction_ref")
+        )
+        instruction_digest = _string_or_none(
+            instruction_mapping.get("instructionDigest")
+            or instruction_mapping.get("instruction_digest")
+        )
+        if instruction_ref:
+            _required_artifact_ref(instruction_ref, "instructions.instructionRef")
+            if not instruction_digest or not instruction_digest.startswith("sha256:"):
+                raise RemediationEvidenceToolError(
+                    "instructions.instructionDigest is required with instructionRef."
+                )
+            return instruction_ref, instruction_digest, None
+        text = _required_string(instruction_mapping.get("text"), "instructions.text")
+        payload_bytes = text.encode("utf-8")
+        digest = "sha256:" + hashlib.sha256(payload_bytes).hexdigest()
+        artifact = await self._lifecycle_publisher.publish_json_artifact(
+            remediation_workflow_id=link.remediation_workflow_id,
+            artifact_type="remediation.corrected_instructions",
+            name="reports/remediation_corrected_instructions.json",
+            payload={
+                "schemaVersion": "v1",
+                "text": text,
+                "digest": digest,
+                "immutable": True,
+            },
+            target_workflow_id=link.target_workflow_id,
+            target_run_id=link.target_run_id,
+            principal=principal,
+        )
+        return artifact.artifact_id, digest, artifact.artifact_id
+
     async def _load_link(
         self, remediation_workflow_id: str
     ) -> db_models.TemporalExecutionRemediationLink:
@@ -895,11 +1161,56 @@ def _required_string(value: Any, field_name: str) -> str:
         raise RemediationEvidenceToolError(f"{field_name} is required.")
     return normalized
 
+def _required_artifact_ref(value: Any, field_name: str) -> str:
+    normalized = _required_string(value, field_name)
+    if normalized.startswith(("omnigent://", "http://", "https://", "file://", "/")):
+        raise RemediationEvidenceToolError(
+            f"{field_name} must be a MoonMind artifact ref, not a raw provider resource."
+        )
+    if not (
+        normalized.startswith("art_")
+        or normalized.startswith("artifact://")
+        or normalized.startswith("artifact:v1:")
+    ):
+        raise RemediationEvidenceToolError(
+            f"{field_name} must be a MoonMind artifact ref."
+        )
+    return normalized
+
 def _string_or_none(value: Any) -> str | None:
     if value is None:
         return None
     normalized = str(value).strip()
     return normalized or None
+
+def _positive_int_or_none(value: Any) -> int | None:
+    if value is None or value == "":
+        return None
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError) as exc:
+        raise RemediationEvidenceToolError(
+            "source.executionOrdinal must be a positive integer."
+        ) from exc
+    if parsed < 1:
+        raise RemediationEvidenceToolError(
+            "source.executionOrdinal must be a positive integer."
+        )
+    return parsed
+
+def _artifact_ref_list(value: Any) -> list[str]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes, bytearray)):
+        return []
+    refs: list[str] = []
+    for item in value:
+        if isinstance(item, Mapping):
+            raw = item.get("artifact_id") or item.get("artifactId") or item.get("ref")
+        else:
+            raw = item
+        ref = str(raw or "").strip()
+        if ref:
+            refs.append(ref)
+    return refs
 
 def _safe_sequence(value: Any) -> list[Any]:
     if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):

--- a/moonmind/workflows/temporal/service.py
+++ b/moonmind/workflows/temporal/service.py
@@ -11,7 +11,7 @@ import base64
 import binascii
 import hashlib
 import json
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from typing import Any
@@ -67,6 +67,7 @@ from moonmind.services.skill_step_inputs import validate_skill_step_inputs
 from moonmind.security.outbound_scan import scan_outbound_text
 from moonmind.workflows.temporal.client import TemporalClientAdapter
 from moonmind.workflows.temporal.checkpoint_policy import resolve_checkpoint_policy
+from moonmind.workflows.temporal.artifacts import TemporalArtifactService
 from moonmind.workflows.temporal.hard_switch_cutover import (
     resolve_user_workflow_start_contract,
 )
@@ -82,6 +83,7 @@ from moonmind.workflows.temporal.runtime.managed_session_store import (
     ManagedSessionStore,
     TERMINAL_MANAGED_SESSION_STATUSES,
 )
+from moonmind.workflows.temporal.remediation_context import RemediationContextBuilder
 from moonmind.schemas.managed_session_models import canonical_managed_session_runtime_id
 from moonmind.statuses.integration import (
     INTEGRATION_STATUS_VALUES,
@@ -263,7 +265,34 @@ def _recovery_plan_digest_from_record(record: TemporalExecutionRecord) -> str | 
         resume_block.get("sourcePlanDigest"),
         resume_block.get("source_plan_digest"),
     )
-ALLOWED_REMEDIATION_ACTION_POLICY_REFS = frozenset({"admin_healer_default"})
+ALLOWED_REMEDIATION_ACTION_POLICY_REFS = frozenset(
+    {"admin_healer_default", "checkpoint_branch_repair"}
+)
+ALLOWED_REMEDIATION_CHECKPOINT_BRANCH_WORKSPACE_POLICIES = frozenset(
+    {
+        "apply_previous_execution_diff_to_clean_baseline",
+        "fresh_branch_from_source",
+        "restore_pre_execution",
+        "start_from_last_passed_commit",
+    }
+)
+ALLOWED_REMEDIATION_CHECKPOINT_BRANCH_RUNTIME_POLICIES = frozenset(
+    {"fresh_agent_run"}
+)
+ALLOWED_REMEDIATION_CHECKPOINT_BOUNDARIES = frozenset(
+    {"before_execution", "after_execution", "before_recovery_restoration"}
+)
+REMEDIATION_EVIDENCE_REF_KEYS = frozenset(
+    {
+        "recoveryEvidenceRefs",
+        "incidentEvidenceRefs",
+        "branchEvidenceRefs",
+        "adapterEvidenceRefs",
+        "observabilityEvidenceRefs",
+        "artifactEvidenceRefs",
+        "checkpointRefs",
+    }
+)
 PENDING_REMEDIATION_APPROVAL_STATUSES = frozenset(
     {"awaiting_approval", "approval_required"}
 )
@@ -383,6 +412,8 @@ class TemporalExecutionService:
         run_continue_as_new_step_threshold: int = 500,
         run_continue_as_new_wait_cycle_threshold: int = 200,
         manifest_continue_as_new_phase_threshold: int = 5,
+        artifact_service: TemporalArtifactService | None = None,
+        artifact_service_factory: Callable[[], TemporalArtifactService] | None = None,
     ) -> None:
         self._session = session
         self._namespace = namespace
@@ -407,6 +438,8 @@ class TemporalExecutionService:
             manifest_continue_as_new_phase_threshold
         )
         self._client_adapter = client_adapter or TemporalClientAdapter()
+        self._artifact_service = artifact_service
+        self._artifact_service_factory = artifact_service_factory
 
     async def check_system_paused(self) -> bool:
         """Return True if the system-wide worker pause singleton is active.
@@ -550,6 +583,149 @@ class TemporalExecutionService:
             and authority_mode == "observe_only"
         )
 
+    @staticmethod
+    def _is_moonmind_artifact_ref(value: Any) -> bool:
+        candidate = str(value or "").strip()
+        return bool(
+            candidate.startswith("art_")
+            or candidate.startswith("artifact://")
+            or candidate.startswith("artifact:v1:")
+        )
+
+    @classmethod
+    def _validate_moonmind_artifact_ref(cls, value: Any, field_name: str) -> str:
+        candidate = str(value or "").strip()
+        if not candidate:
+            raise TemporalExecutionValidationError(f"{field_name} is required.")
+        if candidate.startswith(("omnigent://", "http://", "https://", "file://", "/")):
+            raise TemporalExecutionValidationError(
+                f"{field_name} must be a MoonMind artifact ref, not a raw provider resource."
+            )
+        if not cls._is_moonmind_artifact_ref(candidate):
+            raise TemporalExecutionValidationError(
+                f"{field_name} must be a MoonMind artifact ref."
+            )
+        return candidate
+
+    @classmethod
+    def _validate_remediation_step_selectors(cls, target: Mapping[str, Any]) -> None:
+        selectors = target.get("stepSelectors") or target.get("step_selectors")
+        if selectors is None:
+            return
+        if not isinstance(selectors, list):
+            raise TemporalExecutionValidationError(
+                "workflow.remediation.target.stepSelectors must be a list."
+            )
+        for index, selector in enumerate(selectors):
+            field = f"workflow.remediation.target.stepSelectors[{index}]"
+            if not isinstance(selector, Mapping):
+                raise TemporalExecutionValidationError(f"{field} must be an object.")
+            logical_step_id = str(
+                selector.get("logicalStepId") or selector.get("logical_step_id") or ""
+            ).strip()
+            execution_ordinal = selector.get("executionOrdinal") or selector.get(
+                "execution_ordinal"
+            )
+            if execution_ordinal is not None and not logical_step_id:
+                raise TemporalExecutionValidationError(
+                    f"{field}.logicalStepId is required with executionOrdinal."
+                )
+            if execution_ordinal is not None:
+                try:
+                    ordinal = int(execution_ordinal)
+                except (TypeError, ValueError) as exc:
+                    raise TemporalExecutionValidationError(
+                        f"{field}.executionOrdinal must be a positive integer."
+                    ) from exc
+                if ordinal < 1:
+                    raise TemporalExecutionValidationError(
+                        f"{field}.executionOrdinal must be a positive integer."
+                    )
+            checkpoint_ref = selector.get("checkpointRef") or selector.get(
+                "checkpoint_ref"
+            )
+            if checkpoint_ref is not None:
+                cls._validate_moonmind_artifact_ref(
+                    checkpoint_ref, f"{field}.checkpointRef"
+                )
+                boundary = str(
+                    selector.get("checkpointBoundary")
+                    or selector.get("checkpoint_boundary")
+                    or ""
+                ).strip()
+                if boundary not in ALLOWED_REMEDIATION_CHECKPOINT_BOUNDARIES:
+                    supported = ", ".join(
+                        sorted(ALLOWED_REMEDIATION_CHECKPOINT_BOUNDARIES)
+                    )
+                    raise TemporalExecutionValidationError(
+                        f"{field}.checkpointBoundary must be one of: {supported}."
+                    )
+
+    @classmethod
+    def _validate_remediation_evidence_refs(cls, remediation: Mapping[str, Any]) -> None:
+        def visit(value: Any, path: str) -> None:
+            if isinstance(value, Mapping):
+                for key, item in value.items():
+                    next_path = f"{path}.{key}" if path else str(key)
+                    if key in REMEDIATION_EVIDENCE_REF_KEYS:
+                        if not isinstance(item, list):
+                            raise TemporalExecutionValidationError(
+                                f"workflow.remediation.{next_path} must be a list."
+                            )
+                        for index, ref in enumerate(item):
+                            cls._validate_moonmind_artifact_ref(
+                                ref,
+                                f"workflow.remediation.{next_path}[{index}]",
+                            )
+                    elif key in {"artifactRef", "artifact_ref", "checkpointRef", "checkpoint_ref"}:
+                        cls._validate_moonmind_artifact_ref(
+                            item, f"workflow.remediation.{next_path}"
+                        )
+                    else:
+                        visit(item, next_path)
+                return
+            if isinstance(value, list | tuple):
+                for index, item in enumerate(value):
+                    visit(item, f"{path}[{index}]")
+
+        visit(remediation, "")
+
+    @staticmethod
+    def _validate_remediation_checkpoint_branch_policy(
+        remediation: Mapping[str, Any],
+    ) -> None:
+        policy = remediation.get("checkpointBranchPolicy") or remediation.get(
+            "checkpoint_branch_policy"
+        )
+        if policy is None:
+            return
+        if not isinstance(policy, Mapping):
+            raise TemporalExecutionValidationError(
+                "workflow.remediation.checkpointBranchPolicy must be an object."
+            )
+        workspace_policy = str(policy.get("workspacePolicy") or "").strip()
+        if workspace_policy and workspace_policy not in (
+            ALLOWED_REMEDIATION_CHECKPOINT_BRANCH_WORKSPACE_POLICIES
+        ):
+            supported = ", ".join(
+                sorted(ALLOWED_REMEDIATION_CHECKPOINT_BRANCH_WORKSPACE_POLICIES)
+            )
+            raise TemporalExecutionValidationError(
+                "Unsupported workflow.remediation.checkpointBranchPolicy.workspacePolicy "
+                f"'{workspace_policy}'. Supported values: {supported}."
+            )
+        runtime_policy = str(
+            policy.get("runtimeContextPolicy") or "fresh_agent_run"
+        ).strip()
+        if runtime_policy not in ALLOWED_REMEDIATION_CHECKPOINT_BRANCH_RUNTIME_POLICIES:
+            supported = ", ".join(
+                sorted(ALLOWED_REMEDIATION_CHECKPOINT_BRANCH_RUNTIME_POLICIES)
+            )
+            raise TemporalExecutionValidationError(
+                "Unsupported workflow.remediation.checkpointBranchPolicy.runtimeContextPolicy "
+                f"'{runtime_policy}'. Supported values: {supported}."
+            )
+
     async def _validate_remediation_link(
         self,
         *,
@@ -661,6 +837,10 @@ class TemporalExecutionService:
                     raise TemporalExecutionValidationError(
                         "workflow.remediation.target.agentRunIds must belong to the target execution."
                     )
+
+        self._validate_remediation_step_selectors(target)
+        self._validate_remediation_evidence_refs(remediation)
+        self._validate_remediation_checkpoint_branch_policy(remediation)
 
         trigger = remediation.get("trigger")
         trigger_type = None
@@ -1319,6 +1499,31 @@ class TemporalExecutionService:
             logger.exception(
                 "Failed to start Temporal workflow for execution %s", record.workflow_id
             )
+
+        if remediation_link is not None:
+            artifact_service = self._artifact_service
+            if artifact_service is None and self._artifact_service_factory is not None:
+                artifact_service = self._artifact_service_factory()
+            if artifact_service is None:
+                artifact_service = None
+        else:
+            artifact_service = None
+        if remediation_link is not None and artifact_service is not None:
+            try:
+                await RemediationContextBuilder(
+                    session=self._session,
+                    artifact_service=artifact_service,
+                ).build_context(remediation_workflow_id=record.workflow_id)
+                await self._session.refresh(record)
+                await self._session.refresh(remediation_link)
+            except Exception as exc:
+                logger.exception(
+                    "Failed to build remediation context for execution %s",
+                    record.workflow_id,
+                )
+                raise TemporalExecutionValidationError(
+                    "Failed to build remediation context artifact for workflow.remediation."
+                ) from exc
 
         synced_record = await self._sync_projection_best_effort(record)
         if scheduled_for is not None and isinstance(

--- a/tests/integration/temporal/test_remediation_action_contracts.py
+++ b/tests/integration/temporal/test_remediation_action_contracts.py
@@ -8,7 +8,12 @@ from datetime import datetime, timezone
 import pytest
 from sqlalchemy import select
 
-from api_service.db.models import TemporalArtifactLink
+from api_service.db.models import (
+    TemporalArtifactLink,
+    TemporalExecutionCanonicalRecord,
+    WorkflowCheckpointBranchTurn,
+)
+from api_service.services.checkpoint_branch_service import CheckpointBranchService
 from moonmind.workflows.temporal import (
     LocalTemporalArtifactStore,
     TemporalArtifactRepository,
@@ -25,7 +30,10 @@ from moonmind.workflows.temporal.remediation_context import (
     build_remediation_repair_decision,
     build_remediation_summary_block,
 )
-from moonmind.workflows.temporal.remediation_tools import RemediationEvidenceToolService
+from moonmind.workflows.temporal.remediation_tools import (
+    RemediationEvidenceToolError,
+    RemediationEvidenceToolService,
+)
 from tests.unit.workflows.temporal.test_remediation_context import (
     RecordingActionExecutor,
     _admin_permissions,
@@ -153,6 +161,117 @@ async def test_remediation_action_contract_publishes_request_result_and_verifica
         ).scalars().all()
         assert len(audit_links) == 1
         assert len(target_annotation_links) == 1
+
+
+async def test_remediation_checkpoint_branch_action_creates_fresh_session_turn(
+    tmp_path, mock_client_adapter
+) -> None:
+    async with temporal_db(tmp_path) as session:
+        target, remediation = await _create_target_and_remediation(
+            session,
+            mock_client_adapter,
+            authority_mode="admin_auto",
+            action_policy_ref="checkpoint_branch_repair",
+        )
+        target_source = await session.get(
+            TemporalExecutionCanonicalRecord, target.workflow_id
+        )
+        assert target_source is not None
+        target_source.artifact_refs = [
+            "art_checkpoint_after_implement",
+            "art_step_execution_manifest",
+            "art_diagnostics_branch_launch",
+        ]
+        await session.commit()
+        artifact_service = TemporalArtifactService(
+            TemporalArtifactRepository(session),
+            store=LocalTemporalArtifactStore(tmp_path / "artifacts"),
+        )
+        await RemediationContextBuilder(
+            session=session,
+            artifact_service=artifact_service,
+        ).build_context(remediation_workflow_id=remediation.workflow_id)
+        tools = RemediationEvidenceToolService(
+            session=session,
+            artifact_service=artifact_service,
+        )
+
+        result = await tools.create_checkpoint_branch_from_remediation_context(
+            remediation_workflow_id=remediation.workflow_id,
+            checkpoint_branch_service=CheckpointBranchService(session),
+            principal="service:test",
+            request={
+                "reason": "Try corrected test command",
+                "source": {
+                    "runId": target.run_id,
+                    "logicalStepId": "implement",
+                    "executionOrdinal": 2,
+                    "checkpointBoundary": "after_execution",
+                    "checkpointRef": "art_checkpoint_after_implement",
+                    "checkpointDigest": "sha256:checkpoint",
+                },
+                "instructions": {"text": "Run the corrected focused backend tests."},
+                "branch": {
+                    "branchId": "cbr-remediation-focused",
+                    "branchTurnId": "cbr-remediation-focused:turn:1",
+                    "label": "Focused remediation repair",
+                    "workspacePolicy": (
+                        "apply_previous_execution_diff_to_clean_baseline"
+                    ),
+                    "runtimeContextPolicy": "fresh_agent_run",
+                },
+                "launch": {
+                    "createdStepExecutionId": "step-exec-remediation-1",
+                    "stepExecutionManifestRef": "art_step_execution_manifest",
+                    "diagnosticsRef": "art_diagnostics_branch_launch",
+                },
+            },
+        )
+
+        assert result["status"] == "applied"
+        assert result["actionKind"] == "checkpoint_branch.create_from_remediation_context"
+        assert result["branchId"] == "cbr-remediation-focused"
+        turn = (
+            await session.execute(
+                select(WorkflowCheckpointBranchTurn).where(
+                    WorkflowCheckpointBranchTurn.branch_turn_id
+                    == "cbr-remediation-focused:turn:1"
+                )
+            )
+        ).scalar_one()
+        assert turn.status == "running"
+        assert turn.created_step_execution_id == "step-exec-remediation-1"
+        assert turn.runtime_context_policy == "fresh_agent_run"
+        instruction_payload = await _read_artifact_json(
+            artifact_service, result["artifactRefs"]["instructionArtifact"]
+        )
+        provenance_payload = await _read_artifact_json(
+            artifact_service, result["artifactRefs"]["provenance"]
+        )
+        assert instruction_payload["immutable"] is True
+        assert provenance_payload["retryActionKind"] == (
+            "checkpoint_branch.create_from_remediation_context"
+        )
+        assert provenance_payload["metadata"]["branchId"] == "cbr-remediation-focused"
+
+        with pytest.raises(RemediationEvidenceToolError, match="raw provider"):
+            await tools.create_checkpoint_branch_from_remediation_context(
+                remediation_workflow_id=remediation.workflow_id,
+                checkpoint_branch_service=CheckpointBranchService(session),
+                request={
+                    "source": {
+                        "runId": target.run_id,
+                        "checkpointBoundary": "after_execution",
+                        "checkpointRef": "omnigent://native/checkpoint",
+                    },
+                    "instructions": {"text": "Unsafe"},
+                    "launch": {
+                        "createdStepExecutionId": "step-exec-remediation-unsafe",
+                        "stepExecutionManifestRef": "art_step_execution_manifest",
+                        "diagnosticsRef": "art_diagnostics_branch_launch",
+                    },
+                },
+            )
 
 
 async def test_remediation_raw_action_rejection_does_not_publish_side_effect_artifacts(

--- a/tests/unit/omnigent/test_execute.py
+++ b/tests/unit/omnigent/test_execute.py
@@ -357,6 +357,62 @@ async def test_run_omnigent_execution_reports_httpx_transport_errors(
 
 
 @pytest.mark.asyncio
+async def test_run_omnigent_execution_rejects_same_session_remediation_before_provider(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("OMNIGENT_ENABLED", "true")
+    monkeypatch.setenv("OMNIGENT_SERVER_URL", "https://omnigent.test")
+
+    with pytest.raises(OmnigentContractError, match="same-session continuation"):
+        await run_omnigent_execution(
+            AgentExecutionRequest(
+                agentKind="external",
+                agentId="omnigent",
+                correlationId="corr-1",
+                idempotencyKey="idem-1",
+                parameters={
+                    "omnigent": {
+                        "endpointRef": "omnigent:endpoint:test",
+                        "remediation": {
+                            "actionKind": (
+                                "checkpoint_branch.create_from_remediation_context"
+                            ),
+                            "runtimeContextPolicy": "reuse_session_same_epoch",
+                        },
+                    }
+                },
+            )
+        )
+
+
+@pytest.mark.asyncio
+async def test_run_omnigent_execution_rejects_provider_native_remediation_refs(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("OMNIGENT_ENABLED", "true")
+    monkeypatch.setenv("OMNIGENT_SERVER_URL", "https://omnigent.test")
+
+    with pytest.raises(OmnigentContractError, match="MoonMind artifact refs"):
+        await run_omnigent_execution(
+            AgentExecutionRequest(
+                agentKind="external",
+                agentId="omnigent",
+                correlationId="corr-1",
+                idempotencyKey="idem-1",
+                parameters={
+                    "remediation": {
+                        "actionKind": (
+                            "checkpoint_branch.create_from_remediation_context"
+                        ),
+                        "runtimeContextPolicy": "fresh_agent_run",
+                        "evidenceRefs": ["omnigent://session/native-log"],
+                    }
+                },
+            )
+        )
+
+
+@pytest.mark.asyncio
 async def test_run_omnigent_execution_uses_nested_session_parameters(
     monkeypatch,
 ) -> None:

--- a/tests/unit/workflows/temporal/test_remediation_context.py
+++ b/tests/unit/workflows/temporal/test_remediation_context.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 from contextlib import asynccontextmanager
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 from uuid import uuid4
@@ -79,8 +80,15 @@ async def _create_target_and_remediation(
         SimpleNamespace(run_id="target-run"),
         SimpleNamespace(run_id="remediation-run"),
     ]
+    db_path = Path(str(session.bind.url.database))
+    artifact_service = TemporalArtifactService(
+        TemporalArtifactRepository(session),
+        store=LocalTemporalArtifactStore(db_path.parent / "artifacts"),
+    )
     execution_service = TemporalExecutionService(
-        session, client_adapter=mock_client_adapter
+        session,
+        client_adapter=mock_client_adapter,
+        artifact_service=artifact_service,
     )
     target = await execution_service.create_execution(
         workflow_type="MoonMind.UserWorkflow",
@@ -144,6 +152,7 @@ CANONICAL_REMEDIATION_ACTIONS = {
     "execution.resume",
     "execution.request_rerun_same_workflow",
     "execution.start_fresh_rerun",
+    "checkpoint_branch.create_from_remediation_context",
     "execution.cancel",
     "execution.force_terminate",
     "session.interrupt_turn",

--- a/tests/unit/workflows/temporal/test_temporal_service.py
+++ b/tests/unit/workflows/temporal/test_temporal_service.py
@@ -46,6 +46,11 @@ from moonmind.workflows.temporal.service import (
     _visibility_runtime_from_parameters,
     _visibility_skill_from_parameters,
 )
+from moonmind.workflows.temporal.artifacts import (
+    LocalTemporalArtifactStore,
+    TemporalArtifactRepository,
+    TemporalArtifactService,
+)
 from moonmind.workflows.temporal.hard_switch_cutover import RENAMED_USER_WORKFLOW_TYPE
 from moonmind.schemas.temporal_models import (
     CreateExecutionRequest,
@@ -788,7 +793,15 @@ async def test_create_execution_rejects_dependency_run_id_identifier(
 ):
     async with temporal_db(tmp_path) as session:
         owner_id = uuid4()
-        service = TemporalExecutionService(session, client_adapter=mock_client_adapter)
+        artifact_service = TemporalArtifactService(
+            TemporalArtifactRepository(session),
+            store=LocalTemporalArtifactStore(tmp_path / "artifacts"),
+        )
+        service = TemporalExecutionService(
+            session,
+            client_adapter=mock_client_adapter,
+            artifact_service=artifact_service,
+        )
 
         existing = await service.create_execution(
             workflow_type="MoonMind.UserWorkflow",
@@ -1035,7 +1048,15 @@ async def test_create_execution_persists_remediation_link_and_supports_lookups(
             SimpleNamespace(run_id="target-temporal-run"),
             SimpleNamespace(run_id="remediation-temporal-run"),
         ]
-        service = TemporalExecutionService(session, client_adapter=mock_client_adapter)
+        artifact_service = TemporalArtifactService(
+            TemporalArtifactRepository(session),
+            store=LocalTemporalArtifactStore(tmp_path / "artifacts"),
+        )
+        service = TemporalExecutionService(
+            session,
+            client_adapter=mock_client_adapter,
+            artifact_service=artifact_service,
+        )
 
         target = await service.create_execution(
             workflow_type="MoonMind.UserWorkflow",
@@ -1078,6 +1099,23 @@ async def test_create_execution_persists_remediation_link_and_supports_lookups(
         assert link.remediation_run_id == remediation.run_id
         assert link.target_workflow_id == target.workflow_id
         assert link.target_run_id == target.run_id
+        assert link.context_artifact_ref
+        context_artifact = await session.get(TemporalArtifact, link.context_artifact_ref)
+        assert context_artifact is not None
+        assert context_artifact.status is TemporalArtifactStatus.COMPLETE
+        assert context_artifact.metadata_json["artifact_type"] == "remediation.context"
+        _artifact, context_body = await artifact_service.read(
+            artifact_id=link.context_artifact_ref,
+            principal="service:remediation-context",
+        )
+        context = json.loads(context_body.decode("utf-8"))
+        assert context["remediationWorkflowId"] == remediation.workflow_id
+        assert context["target"]["workflowId"] == target.workflow_id
+        assert link.context_artifact_ref in (
+            await session.get(
+                TemporalExecutionCanonicalRecord, remediation.workflow_id
+            )
+        ).artifact_refs
         assert link.mode == "snapshot"
         assert link.authority_mode == "approval_gated"
         assert link.status == "created"
@@ -1113,6 +1151,91 @@ async def test_create_execution_persists_remediation_link_and_supports_lookups(
 
         prerequisites = await service.list_prerequisites(remediation.workflow_id)
         assert prerequisites == []
+
+
+@pytest.mark.asyncio
+async def test_create_execution_remediation_rejects_raw_provider_evidence_and_same_session_branch_policy(
+    tmp_path, mock_client_adapter
+):
+    async with temporal_db(tmp_path) as session:
+        owner_id = uuid4()
+        mock_client_adapter.start_workflow.return_value = SimpleNamespace(run_id="target-run")
+        artifact_service = TemporalArtifactService(
+            TemporalArtifactRepository(session),
+            store=LocalTemporalArtifactStore(tmp_path / "artifacts"),
+        )
+        service = TemporalExecutionService(
+            session,
+            client_adapter=mock_client_adapter,
+            artifact_service=artifact_service,
+        )
+
+        target = await service.create_execution(
+            workflow_type="MoonMind.UserWorkflow",
+            owner_id=owner_id,
+            title="Target",
+            input_artifact_ref=None,
+            plan_artifact_ref=None,
+            manifest_artifact_ref=None,
+            failure_policy=None,
+            initial_parameters=_valid_user_workflow_parameters(),
+            idempotency_key=None,
+        )
+
+        with pytest.raises(
+            TemporalExecutionValidationError,
+            match="raw provider resource",
+        ):
+            await service.create_execution(
+                workflow_type="MoonMind.UserWorkflow",
+                owner_id=owner_id,
+                title="Unsafe remediation",
+                input_artifact_ref=None,
+                plan_artifact_ref=None,
+                manifest_artifact_ref=None,
+                failure_policy=None,
+                initial_parameters={
+                    "workflow": {
+                        "remediation": {
+                            "target": {"workflowId": target.workflow_id},
+                            "evidenceRefs": {
+                                "adapterEvidenceRefs": ["omnigent://session/native"]
+                            },
+                            "authorityMode": "approval_gated",
+                        }
+                    }
+                },
+                idempotency_key=None,
+            )
+
+        with pytest.raises(
+            TemporalExecutionValidationError,
+            match="runtimeContextPolicy",
+        ):
+            await service.create_execution(
+                workflow_type="MoonMind.UserWorkflow",
+                owner_id=owner_id,
+                title="Same session remediation",
+                input_artifact_ref=None,
+                plan_artifact_ref=None,
+                manifest_artifact_ref=None,
+                failure_policy=None,
+                initial_parameters={
+                    "workflow": {
+                        "remediation": {
+                            "target": {"workflowId": target.workflow_id},
+                            "authorityMode": "approval_gated",
+                            "checkpointBranchPolicy": {
+                                "workspacePolicy": (
+                                    "apply_previous_execution_diff_to_clean_baseline"
+                                ),
+                                "runtimeContextPolicy": "reuse_session_same_epoch",
+                            },
+                        }
+                    }
+                },
+                idempotency_key=None,
+            )
 
 @pytest.mark.asyncio
 async def test_record_remediation_approval_decision_appends_bounded_audit(


### PR DESCRIPTION
## Summary

Publishes the completed work from failed workflow `mm:8c692825-8fdf-499f-b24e-e8e94a20d822`.

This implements the remaining create-first remediation backend gaps by adding remediation context artifact creation, checkpoint-branch remediation launch support, validation for remediation evidence/checkpoint inputs, Omnigent v1 fail-closed handling, and targeted backend/Omnigent coverage.

## Validation

Reported by the workflow run before publish failed:

- `py_compile` passed for changed files.
- Targeted remediation/Omnigent pytest selection passed: `6 passed`.
- Remediation integration contract file passed: `5 passed`.
- Checkpoint branch service unit tests passed: `21 passed`.
- `git diff --check` passed before manual publish.

Broader suite notes from the workflow: one existing missing preset failure for `api_service/data/presets/moonspec-orchestrate.yaml`, plus unrelated fixture/environment failures around mock Temporal state, managed session store permissions, and artifact hydration refs.
