### PR TITLE
Fix PR publish base branch propagation

### DIFF
--- a/moonmind/workflows/temporal/worker_runtime.py
+++ b/moonmind/workflows/temporal/worker_runtime.py
@@ -1558,6 +1558,19 @@ def _build_runtime_planner():
         )
         if isinstance(commit_message, str) and commit_message.strip():
             node_inputs["commitMessage"] = commit_message.strip()
+        publish_base_branch = _first_non_empty_text(
+            publish_payload.get("prBaseBranch"),
+            publish_payload.get("baseBranch"),
+            parameter_payload.get("publishBaseBranch"),
+            parameter_payload.get("prBaseBranch"),
+            parameter_payload.get("baseBranch"),
+        )
+        if (
+            isinstance(publish_mode, str)
+            and publish_mode.strip().lower() == "pr"
+            and publish_base_branch
+        ):
+            node_inputs["publishBaseBranch"] = publish_base_branch
 
         repository = (
             task_payload.get("repository")

--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -348,6 +348,9 @@ AGENT_RUN_WORKFLOW_CHILD_TASK_QUEUE_V2_PATCH = (
 MANAGED_SESSION_TURN_DEADLINE_PATCH_ID = (
     "agent-run-managed-session-turn-deadline-v1"
 )
+MANAGED_SESSION_PR_PUBLISH_BASE_BRANCH_PATCH_ID = (
+    "agent-run-managed-session-pr-publish-base-branch-v1"
+)
 
 # Module-level activity catalog — deterministic, safe for Temporal replay.
 # Mirrors the pattern used by MoonMind.UserWorkflow (run.py:50).
@@ -1755,11 +1758,31 @@ class MoonMindAgentRun:
         if isinstance(raw_commit_message, str) and raw_commit_message.strip():
             activity_input["commitMessage"] = raw_commit_message.strip()
 
-        target_branch = str(
-            params.get("publishBaseBranch")
-            or self._request_workspace_starting_branch(request)
-            or ""
-        ).strip()
+        if workflow.patched(MANAGED_SESSION_PR_PUBLISH_BASE_BRANCH_PATCH_ID):
+            publish_payload = (
+                params.get("publish")
+                if isinstance(params.get("publish"), Mapping)
+                else {}
+            )
+            publish_base_branch = str(
+                params.get("publishBaseBranch")
+                or params.get("prBaseBranch")
+                or params.get("baseBranch")
+                or publish_payload.get("prBaseBranch")
+                or publish_payload.get("baseBranch")
+                or ""
+            ).strip()
+            target_branch = str(
+                publish_base_branch
+                or self._request_workspace_starting_branch(request)
+                or ""
+            ).strip()
+        else:
+            target_branch = str(
+                params.get("publishBaseBranch")
+                or self._request_workspace_starting_branch(request)
+                or ""
+            ).strip()
         if target_branch:
             activity_input["targetBranch"] = target_branch
 

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -13441,6 +13441,8 @@ class MoonMindRunWorkflow:
             "repo",
             "startingBranch",
             "targetBranch",
+            "baseBranch",
+            "publishBaseBranch",
             "branch",
         ):
             ws_val = node_inputs.get(ws_key)
@@ -13453,6 +13455,7 @@ class MoonMindRunWorkflow:
             "effort",
             "publishMode",
             "commitMessage",
+            "publishBaseBranch",
             "allowed_tools",
             "priority",
             "stepCount",

--- a/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
+++ b/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
@@ -3530,6 +3530,38 @@ def test_runtime_planner_publish_pr_treats_authored_branch_as_base():
     assert node_inputs["targetBranch"].startswith("fix-create-branch-publish-")
     assert re.fullmatch(r"[a-z0-9-]+-[0-9a-f]{8}", node_inputs["targetBranch"])
 
+
+def test_runtime_planner_publish_pr_flattens_publish_base_for_managed_fetch():
+    planner = _build_runtime_planner()
+    snapshot = _make_snapshot()
+
+    plan = planner(
+        inputs={
+            "task": {
+                "instructions": "Continue the follow-up work",
+                "title": "Complete create-first remediation backend",
+                "git": {"branch": "use-this-preselected-single-story-reques-e5921fb9"},
+                "runtime": {"mode": "codex_cli"},
+                "publish": {"mode": "pr", "baseBranch": "main"},
+            }
+        },
+        parameters={},
+        snapshot=snapshot,
+    )
+
+    node_inputs = plan["nodes"][-1]["inputs"]
+    assert node_inputs["branch"] == "use-this-preselected-single-story-reques-e5921fb9"
+    assert (
+        node_inputs["startingBranch"]
+        == "use-this-preselected-single-story-reques-e5921fb9"
+    )
+    assert node_inputs["publishBaseBranch"] == "main"
+    assert node_inputs["targetBranch"] != node_inputs["startingBranch"]
+    assert node_inputs["targetBranch"].startswith(
+        "complete-create-first-remediation-backen-"
+    )
+
+
 @pytest.mark.parametrize(
     ("inputs", "parameters", "expected_branch"),
     [

--- a/tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py
@@ -300,6 +300,31 @@ async def test_managed_fetch_result_input_ignores_legacy_workspace_branch_for_he
     assert activity_input.target_branch == "main"
     assert activity_input.head_branch is None
 
+
+async def test_managed_fetch_result_input_uses_publish_base_for_pr_target_branch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _configure_workflow_runtime(monkeypatch)
+    run = MoonMindAgentRun()
+    request = _managed_session_request(
+        parameters={"publishMode": "pr", "publishBaseBranch": "main"},
+        workspace_spec={
+            "branch": "use-this-preselected-single-story-reques-e5921fb9",
+            "startingBranch": "use-this-preselected-single-story-reques-e5921fb9",
+            "targetBranch": "complete-create-first-remediation-backen-dc3ddf43",
+        },
+    )
+
+    activity_input = run._build_managed_fetch_result_activity_input(request)
+
+    assert isinstance(activity_input, AgentRuntimeFetchResultInput)
+    assert activity_input.target_branch == "main"
+    assert (
+        activity_input.head_branch
+        == "complete-create-first-remediation-backen-dc3ddf43"
+    )
+
+
 async def test_managed_fetch_result_marks_pr_resolver_from_task_tool_contract(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py
@@ -1602,6 +1602,35 @@ class TestBuildAgentExecutionRequest(unittest.TestCase):
         self.assertEqual(request.agent_id, "codex")
         self.assertEqual(request.resolved_skillset_ref, "skills:snap:12345")
 
+    def test_build_agent_execution_request_propagates_publish_base_branch(self) -> None:
+        from unittest.mock import patch
+
+        wf = MoonMindRunWorkflow()
+
+        class MockInfo:
+            workflow_id = "test-wf-id"
+            run_id = "test-run-id"
+
+        with patch(
+            "moonmind.workflows.temporal.workflows.run.workflow.info",
+            return_value=MockInfo(),
+        ):
+            request = wf._build_agent_execution_request(
+                node_inputs={
+                    "targetRuntime": "codex",
+                    "repository": "MoonLadderStudios/MoonMind",
+                    "startingBranch": "codex/fix-pr-publish-base-branch",
+                    "targetBranch": "codex/fix-pr-publish-base-branch",
+                    "publishMode": "pr",
+                    "publishBaseBranch": "main",
+                },
+                node_id="node-publish",
+                tool_name="auto",
+            )
+
+        self.assertEqual(request.parameters["publishBaseBranch"], "main")
+        self.assertEqual(request.workspace_spec["publishBaseBranch"], "main")
+
     def test_build_agent_execution_request_passes_compact_skill_payload(self) -> None:
         from unittest.mock import patch
 


### PR DESCRIPTION
## Summary

Fixes managed Codex PR publishing when a task continues from an existing work branch and also specifies an explicit PR base branch.

The runtime planner now flattens `publish.prBaseBranch` / `publish.baseBranch` into `publishBaseBranch` for managed AgentRun parameters, and AgentRun fetch-result input reads that explicit base before falling back to `startingBranch`. The AgentRun behavior is protected by a Temporal patch marker so older histories can replay with the previous mapping.

## Root Cause

Workflow `mm:8c692825-8fdf-499f-b24e-e8e94a20d822` had `publish.baseBranch = main`, but the child AgentRun did not receive a flattened `publishBaseBranch`. During fetch-result publishing, AgentRun fell back to `workspaceSpec.startingBranch` as `targetBranch`, so `_push_workspace_branch` treated the continuation work branch as protected and refused to push it.

## Validation

- `python3 -m compileall -q moonmind/workflows/temporal/workflows/agent_run.py moonmind/workflows/temporal/worker_runtime.py tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py tests/unit/workflows/temporal/test_temporal_worker_runtime.py`
- `./tools/test_unit.sh tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py tests/unit/workflows/temporal/test_temporal_worker_runtime.py`
  - Python: `139 passed`
  - Frontend wrapper phase: `57 passed`, `888 passed | 238 skipped`
