### PR TITLE
[codex] Harden PR resolver merge automation

### DIFF
--- a/.agents/skills/pr-resolver/bin/pr_resolve_finalize.py
+++ b/.agents/skills/pr-resolver/bin/pr_resolve_finalize.py
@@ -111,14 +111,14 @@ def evaluate_finalize_action(snapshot: dict[str, Any]) -> dict[str, str]:
     if normalize_text(pr.get("state")).upper() == "MERGED":
         return {"action": "already_merged", "reason": "already_merged"}
 
+    if _is_conflicting(pr):
+        return {"action": "blocked", "reason": "merge_conflicts"}
     if not bool(comments_fetch.get("succeeded")):
         return {"action": "blocked", "reason": "comments_unavailable"}
     if comments_summary.get("includeBotReviewComments") is not True:
         return {"action": "blocked", "reason": "comment_policy_not_enforced"}
     if bool(comments_summary.get("hasActionableComments")):
         return {"action": "blocked", "reason": "actionable_comments"}
-    if _is_conflicting(pr):
-        return {"action": "blocked", "reason": "merge_conflicts"}
     if normalize_text(ci.get("signalQuality")).lower() not in {"", "ok"}:
         return {"action": "blocked", "reason": "ci_signal_degraded"}
     if bool(ci.get("hasFailures")):

--- a/docs/Workflows/PrMergeAutomation.md
+++ b/docs/Workflows/PrMergeAutomation.md
@@ -508,6 +508,9 @@ This is required because `pr-resolver` itself owns git push and merge behavior.
         "repo": "owner/repo",
         "pr": "123",
         "mergeMethod": "squash"
+      },
+      "timeoutPolicy": {
+        "timeout_seconds": 9000
       }
     }
   }
@@ -515,9 +518,11 @@ This is required because `pr-resolver` itself owns git push and merge behavior.
 ```
 
 The resolver child timeout MUST cover the resolver's own orchestration budget
-plus setup and artifact-publication time. The default resolver launch uses a
-9000-second `timeoutPolicy.timeout_seconds`, which is intentionally larger than
-the `pr-resolver` tool's 7200-second default `finalizeMaxElapsedSeconds`.
+plus setup and artifact-publication time. The default resolver launch carries a
+9000-second `timeoutPolicy.timeout_seconds` both at the child workflow input
+level and inside the task payload that becomes plan node inputs. This is
+intentionally larger than the `pr-resolver` tool's 7200-second default
+`finalizeMaxElapsedSeconds`.
 
 ### 13.3 Resolver child result contract extension
 
@@ -602,13 +607,20 @@ The recommended pattern is:
 4. `MoonMind.MergeAutomation` re-enters `awaiting_external`,
 5. once signal is re-established, it launches the next resolver child attempt.
 
-If a resolver child exits unsuccessfully or without a valid disposition, merge
-automation MUST refresh PR readiness before failing the parent. If that refresh
-shows the PR already merged, merge automation completes as `already_merged`. If
-the PR is still open but the head SHA advanced, merge automation treats that as
-durable resolver progress, updates the tracked head SHA, and re-enters the gate
-instead of failing immediately. If neither merge nor head advancement is
-observed, the resolver issue remains a terminal merge-automation failure.
+If a resolver child fails before returning a result, exits unsuccessfully, or
+returns a malformed disposition, merge automation MUST refresh PR readiness
+before failing the parent. If that refresh shows the PR already merged, merge
+automation completes as `already_merged`. If the PR is still open but the head
+SHA advanced, merge automation treats that as durable resolver progress, updates
+the tracked head SHA, and re-enters the gate instead of failing immediately. If
+neither merge nor head advancement is observed, the resolver issue remains a
+terminal merge-automation failure.
+
+Valid terminal resolver dispositions remain authoritative. A successful resolver
+child result with `mergeAutomationDisposition = "manual_review"` or
+`mergeAutomationDisposition = "failed"` MUST fail merge automation even if the PR
+head changed; those states intentionally request human review or report resolver
+failure rather than asking the gate to continue.
 
 ---
 

--- a/docs/Workflows/PrMergeAutomation.md
+++ b/docs/Workflows/PrMergeAutomation.md
@@ -495,6 +495,9 @@ This is required because `pr-resolver` itself owns git push and merge behavior.
     "targetRuntime": "codex",
     "requiredCapabilities": ["git", "gh"],
     "publishMode": "none",
+    "timeoutPolicy": {
+      "timeout_seconds": 9000
+    },
     "task": {
       "instructions": "Resolve and merge PR #123 for parent workflow mm:parent.",
       "tool": {
@@ -510,6 +513,11 @@ This is required because `pr-resolver` itself owns git push and merge behavior.
   }
 }
 ```
+
+The resolver child timeout MUST cover the resolver's own orchestration budget
+plus setup and artifact-publication time. The default resolver launch uses a
+9000-second `timeoutPolicy.timeout_seconds`, which is intentionally larger than
+the `pr-resolver` tool's 7200-second default `finalizeMaxElapsedSeconds`.
 
 ### 13.3 Resolver child result contract extension
 
@@ -593,6 +601,14 @@ The recommended pattern is:
 3. resolver returns `mergeAutomationDisposition = "reenter_gate"`,
 4. `MoonMind.MergeAutomation` re-enters `awaiting_external`,
 5. once signal is re-established, it launches the next resolver child attempt.
+
+If a resolver child exits unsuccessfully or without a valid disposition, merge
+automation MUST refresh PR readiness before failing the parent. If that refresh
+shows the PR already merged, merge automation completes as `already_merged`. If
+the PR is still open but the head SHA advanced, merge automation treats that as
+durable resolver progress, updates the tracked head SHA, and re-enters the gate
+instead of failing immediately. If neither merge nor head advancement is
+observed, the resolver issue remains a terminal merge-automation failure.
 
 ---
 

--- a/moonmind/workflows/temporal/workflows/merge_automation.py
+++ b/moonmind/workflows/temporal/workflows/merge_automation.py
@@ -700,6 +700,17 @@ class MoonMindMergeAutomationWorkflow:
                     await self._write_resolver_attempt(workflow_id=resolver_workflow_id)
                     self._publish_visibility()
                     return await self._finish()
+                except Exception:
+                    await self._write_resolver_attempt(workflow_id=resolver_workflow_id)
+                    recovery, recovered = await self._recover_after_resolver_issue()
+                    if recovered is not None:
+                        return recovered
+                    if recovery == RESOLVER_ISSUE_RECOVERY_REENTER_GATE:
+                        continue
+                    return await self._failed_resolver_summary(
+                        summary="pr-resolver child workflow failed before returning a result.",
+                        blocker_kind=DISPOSITION_FAILED,
+                    )
                 await self._write_resolver_attempt(
                     workflow_id=resolver_workflow_id,
                     result=resolver_result,
@@ -775,21 +786,11 @@ class MoonMindMergeAutomationWorkflow:
                     self._publish_visibility()
                     return await self._finish()
                 if resolver_disposition == DISPOSITION_MANUAL_REVIEW:
-                    recovery, recovered = await self._recover_after_resolver_issue()
-                    if recovered is not None:
-                        return recovered
-                    if recovery == RESOLVER_ISSUE_RECOVERY_REENTER_GATE:
-                        continue
                     return await self._failed_resolver_summary(
                         summary="pr-resolver requested manual review.",
                         blocker_kind=DISPOSITION_MANUAL_REVIEW,
                     )
                 if resolver_disposition == DISPOSITION_FAILED:
-                    recovery, recovered = await self._recover_after_resolver_issue()
-                    if recovered is not None:
-                        return recovered
-                    if recovery == RESOLVER_ISSUE_RECOVERY_REENTER_GATE:
-                        continue
                     return await self._failed_resolver_summary(
                         summary="pr-resolver reported failure.",
                         blocker_kind=DISPOSITION_FAILED,

--- a/moonmind/workflows/temporal/workflows/merge_automation.py
+++ b/moonmind/workflows/temporal/workflows/merge_automation.py
@@ -61,6 +61,12 @@ MERGE_AUTOMATION_WORKFLOW_CHILD_TASK_QUEUE_V2_PATCH = (
 MERGE_AUTOMATION_RESOLVER_PARENT_GATE_ID_PATCH = (
     "merge-automation-resolver-parent-gate-id-v1"
 )
+MERGE_AUTOMATION_POST_RESOLVER_PROGRESS_RECOVERY_PATCH = (
+    "merge-automation-post-resolver-progress-recovery-v1"
+)
+RESOLVER_ISSUE_RECOVERY_NONE = "none"
+RESOLVER_ISSUE_RECOVERY_COMPLETED = "completed"
+RESOLVER_ISSUE_RECOVERY_REENTER_GATE = "reenter_gate"
 
 
 @workflow.defn(name=WORKFLOW_NAME)
@@ -541,12 +547,23 @@ class MoonMindMergeAutomationWorkflow:
         )
         return evaluation, evidence
 
-    async def _finish_if_pr_merged_after_resolver_issue(self) -> dict[str, Any] | None:
+    async def _recover_after_resolver_issue(
+        self,
+    ) -> tuple[str, dict[str, Any] | None]:
         if self._input is None:
-            return None
+            return RESOLVER_ISSUE_RECOVERY_NONE, None
         if not workflow.patched("merge-automation-post-resolver-merged-recovery-v1"):
-            return None
+            return RESOLVER_ISSUE_RECOVERY_NONE, None
+        previous_head_sha = self._input.pull_request.head_sha
         evaluation, evidence = await self._evaluate_readiness_once()
+        observed_head_sha = (
+            self._head_sha_from_mapping(evaluation)
+            if isinstance(evaluation, Mapping)
+            else ""
+        )
+        head_advanced = bool(
+            observed_head_sha and observed_head_sha != previous_head_sha
+        )
         if self._refresh_tracked_head_sha(evaluation):
             evidence = classify_readiness(
                 evaluation if isinstance(evaluation, Mapping) else {},
@@ -556,7 +573,17 @@ class MoonMindMergeAutomationWorkflow:
         self._blockers = list(evidence.blockers)
         await self._write_gate_snapshot(evidence_ready=evidence.ready)
         if not evidence.pull_request_merged:
-            return None
+            if head_advanced and workflow.patched(
+                MERGE_AUTOMATION_POST_RESOLVER_PROGRESS_RECOVERY_PATCH
+            ):
+                self._status = STATE_WAITING
+                self._summary = (
+                    "pr-resolver advanced the pull request head before ending "
+                    "incompletely; returning to the merge gate."
+                )
+                self._publish_visibility()
+                return RESOLVER_ISSUE_RECOVERY_REENTER_GATE, None
+            return RESOLVER_ISSUE_RECOVERY_NONE, None
         self._summary = (
             "Pull request is already merged; recovered after resolver "
             "disposition validation failed."
@@ -564,10 +591,10 @@ class MoonMindMergeAutomationWorkflow:
         if not await self._complete_post_merge_jira(
             resolver_disposition=DISPOSITION_ALREADY_MERGED
         ):
-            return await self._finish()
+            return RESOLVER_ISSUE_RECOVERY_COMPLETED, await self._finish()
         self._status = STATE_ALREADY_MERGED
         self._publish_visibility()
-        return await self._finish()
+        return RESOLVER_ISSUE_RECOVERY_COMPLETED, await self._finish()
 
     @workflow.run
     async def run(self, payload: dict[str, Any]) -> dict[str, Any]:
@@ -684,17 +711,21 @@ class MoonMindMergeAutomationWorkflow:
                 ).strip()
                 resolver_disposition = self._resolver_disposition(resolver_result)
                 if resolver_status != "success":
-                    recovered = await self._finish_if_pr_merged_after_resolver_issue()
+                    recovery, recovered = await self._recover_after_resolver_issue()
                     if recovered is not None:
                         return recovered
+                    if recovery == RESOLVER_ISSUE_RECOVERY_REENTER_GATE:
+                        continue
                     return await self._failed_resolver_summary(
                         summary="pr-resolver child run did not complete successfully.",
                         blocker_kind=DISPOSITION_FAILED,
                     )
                 if not resolver_disposition:
-                    recovered = await self._finish_if_pr_merged_after_resolver_issue()
+                    recovery, recovered = await self._recover_after_resolver_issue()
                     if recovered is not None:
                         return recovered
+                    if recovery == RESOLVER_ISSUE_RECOVERY_REENTER_GATE:
+                        continue
                     return await self._failed_resolver_summary(
                         summary=(
                             "pr-resolver child result missing "
@@ -703,9 +734,11 @@ class MoonMindMergeAutomationWorkflow:
                         blocker_kind="resolver_disposition_invalid",
                     )
                 if resolver_disposition not in ALLOWED_DISPOSITIONS:
-                    recovered = await self._finish_if_pr_merged_after_resolver_issue()
+                    recovery, recovered = await self._recover_after_resolver_issue()
                     if recovered is not None:
                         return recovered
+                    if recovery == RESOLVER_ISSUE_RECOVERY_REENTER_GATE:
+                        continue
                     return await self._failed_resolver_summary(
                         summary=(
                             "pr-resolver child result has unsupported "
@@ -728,6 +761,7 @@ class MoonMindMergeAutomationWorkflow:
                         resolver_disposition=resolver_disposition
                     ):
                         return await self._finish()
+                    self._summary = None
                     self._status = STATE_ALREADY_MERGED
                     self._publish_visibility()
                     return await self._finish()
@@ -736,21 +770,26 @@ class MoonMindMergeAutomationWorkflow:
                         resolver_disposition=resolver_disposition
                     ):
                         return await self._finish()
+                    self._summary = None
                     self._status = STATE_MERGED
                     self._publish_visibility()
                     return await self._finish()
                 if resolver_disposition == DISPOSITION_MANUAL_REVIEW:
-                    recovered = await self._finish_if_pr_merged_after_resolver_issue()
+                    recovery, recovered = await self._recover_after_resolver_issue()
                     if recovered is not None:
                         return recovered
+                    if recovery == RESOLVER_ISSUE_RECOVERY_REENTER_GATE:
+                        continue
                     return await self._failed_resolver_summary(
                         summary="pr-resolver requested manual review.",
                         blocker_kind=DISPOSITION_MANUAL_REVIEW,
                     )
                 if resolver_disposition == DISPOSITION_FAILED:
-                    recovered = await self._finish_if_pr_merged_after_resolver_issue()
+                    recovery, recovered = await self._recover_after_resolver_issue()
                     if recovered is not None:
                         return recovered
+                    if recovery == RESOLVER_ISSUE_RECOVERY_REENTER_GATE:
+                        continue
                     return await self._failed_resolver_summary(
                         summary="pr-resolver reported failure.",
                         blocker_kind=DISPOSITION_FAILED,

--- a/moonmind/workflows/temporal/workflows/merge_gate.py
+++ b/moonmind/workflows/temporal/workflows/merge_gate.py
@@ -51,6 +51,7 @@ DEFAULT_ACTIVITY_RETRY_POLICY = RetryPolicy(
     maximum_attempts=5,
 )
 MERGE_AUTOMATION_RESOLVER_PRIORITY = 10
+DEFAULT_RESOLVER_TIMEOUT_SECONDS = 9000
 _TOKEN_ASSIGNMENT_PATTERN = re.compile(
     r"(?i)(token|password|authorization|cookie)=\S+"
 )
@@ -360,6 +361,16 @@ def build_resolver_run_request(
     }
     if required_capabilities:
         initial_parameters["requiredCapabilities"] = required_capabilities
+    timeout_policy = template.get("timeoutPolicy")
+    initial_parameters["timeoutPolicy"] = (
+        dict(timeout_policy)
+        if isinstance(timeout_policy, Mapping)
+        else {"timeout_seconds": DEFAULT_RESOLVER_TIMEOUT_SECONDS}
+    )
+    initial_parameters["timeoutPolicy"].setdefault(
+        "timeout_seconds",
+        DEFAULT_RESOLVER_TIMEOUT_SECONDS,
+    )
     return {
         "workflow_type": "MoonMind.UserWorkflow",
         "title": title,

--- a/moonmind/workflows/temporal/workflows/merge_gate.py
+++ b/moonmind/workflows/temporal/workflows/merge_gate.py
@@ -331,6 +331,13 @@ def build_resolver_run_request(
         runtime_payload["model"] = runtime_model
     if runtime_effort:
         runtime_payload["effort"] = runtime_effort
+    timeout_policy = (
+        dict(template["timeoutPolicy"])
+        if isinstance(template.get("timeoutPolicy"), Mapping)
+        else {}
+    )
+    if timeout_policy.get("timeout_seconds") is None:
+        timeout_policy["timeout_seconds"] = DEFAULT_RESOLVER_TIMEOUT_SECONDS
     initial_parameters: dict[str, Any] = {
         "repo": pr.repo,
         "repository": pr.repo,
@@ -346,7 +353,9 @@ def build_resolver_run_request(
             "skill": {"id": "pr-resolver", "args": args},
             "runtime": runtime_payload,
             "publish": {"mode": "auto"},
+            "timeoutPolicy": dict(timeout_policy),
         },
+        "timeoutPolicy": dict(timeout_policy),
         "workspaceSpec": {
             "repository": pr.repo,
             "branch": pr.head_branch,
@@ -361,16 +370,6 @@ def build_resolver_run_request(
     }
     if required_capabilities:
         initial_parameters["requiredCapabilities"] = required_capabilities
-    timeout_policy = template.get("timeoutPolicy")
-    initial_parameters["timeoutPolicy"] = (
-        dict(timeout_policy)
-        if isinstance(timeout_policy, Mapping)
-        else {"timeout_seconds": DEFAULT_RESOLVER_TIMEOUT_SECONDS}
-    )
-    initial_parameters["timeoutPolicy"].setdefault(
-        "timeout_seconds",
-        DEFAULT_RESOLVER_TIMEOUT_SECONDS,
-    )
     return {
         "workflow_type": "MoonMind.UserWorkflow",
         "title": title,

--- a/tests/unit/test_pr_resolver_tools.py
+++ b/tests/unit/test_pr_resolver_tools.py
@@ -538,6 +538,29 @@ def test_finalize_blocks_when_actionable_comments_exist(
 
     assert decision == {"action": "blocked", "reason": "actionable_comments"}
 
+def test_finalize_prioritizes_merge_conflicts_before_comments_and_ci(
+    pr_resolve_finalize_module: dict[str, Any],
+) -> None:
+    evaluate_finalize_action = pr_resolve_finalize_module["evaluate_finalize_action"]
+
+    decision = evaluate_finalize_action(
+        {
+            "pr": {"mergeable": "CONFLICTING", "mergeStateStatus": "DIRTY"},
+            "ci": {
+                "isRunning": False,
+                "hasFailures": True,
+                "signalQuality": "degraded",
+            },
+            "commentsFetch": {"succeeded": True, "source": "fixture"},
+            "commentsSummary": {
+                "hasActionableComments": True,
+                "includeBotReviewComments": True,
+            },
+        }
+    )
+
+    assert decision == {"action": "blocked", "reason": "merge_conflicts"}
+
 def test_finalize_blocks_when_ci_running_and_comments_addressed(
     pr_resolve_finalize_module: dict[str, Any],
 ) -> None:

--- a/tests/unit/workflows/temporal/test_merge_gate_workflow.py
+++ b/tests/unit/workflows/temporal/test_merge_gate_workflow.py
@@ -261,6 +261,9 @@ def test_build_resolver_run_request_uses_pr_resolver_and_publish_auto() -> None:
     assert request["initial_parameters"]["timeoutPolicy"] == {
         "timeout_seconds": DEFAULT_RESOLVER_TIMEOUT_SECONDS
     }
+    assert request["initial_parameters"]["task"]["timeoutPolicy"] == {
+        "timeout_seconds": DEFAULT_RESOLVER_TIMEOUT_SECONDS
+    }
 
 def test_build_resolver_run_request_pins_parent_provider_profile() -> None:
     request = build_resolver_run_request(
@@ -305,6 +308,26 @@ def test_build_resolver_run_request_preserves_explicit_timeout_policy() -> None:
     assert request["initial_parameters"]["timeoutPolicy"] == {
         "timeout_seconds": 12000,
         "heartbeat_seconds": 30,
+    }
+    assert request["initial_parameters"]["task"]["timeoutPolicy"] == {
+        "timeout_seconds": 12000,
+        "heartbeat_seconds": 30,
+    }
+
+def test_build_resolver_run_request_replaces_none_timeout_with_default() -> None:
+    request = build_resolver_run_request(
+        parent_workflow_id="mm:parent",
+        pull_request=_pull_request(),
+        jira_issue_key=None,
+        merge_method="squash",
+        resolver_template={"timeoutPolicy": {"timeout_seconds": None}},
+    )
+
+    assert request["initial_parameters"]["timeoutPolicy"] == {
+        "timeout_seconds": DEFAULT_RESOLVER_TIMEOUT_SECONDS
+    }
+    assert request["initial_parameters"]["task"]["timeoutPolicy"] == {
+        "timeout_seconds": DEFAULT_RESOLVER_TIMEOUT_SECONDS
     }
 
 def test_build_continue_as_new_input_preserves_compact_wait_state() -> None:

--- a/tests/unit/workflows/temporal/test_merge_gate_workflow.py
+++ b/tests/unit/workflows/temporal/test_merge_gate_workflow.py
@@ -4,6 +4,7 @@ from moonmind.workflows.temporal.activity_catalog import build_default_activity_
 from moonmind.workflows.temporal.activity_runtime import _ACTIVITY_HANDLER_ATTRS
 from moonmind.workflows.temporal.workflows import merge_gate
 from moonmind.workflows.temporal.workflows.merge_gate import (
+    DEFAULT_RESOLVER_TIMEOUT_SECONDS,
     build_resolver_run_request,
     classify_readiness,
     deterministic_resolver_idempotency_key,
@@ -257,6 +258,9 @@ def test_build_resolver_run_request_uses_pr_resolver_and_publish_auto() -> None:
     assert "version" not in request["initial_parameters"]["task"]["tool"]
     assert request["initial_parameters"]["publishMode"] == "auto"
     assert request["initial_parameters"]["task"]["skill"]["args"]["pr"] == "341"
+    assert request["initial_parameters"]["timeoutPolicy"] == {
+        "timeout_seconds": DEFAULT_RESOLVER_TIMEOUT_SECONDS
+    }
 
 def test_build_resolver_run_request_pins_parent_provider_profile() -> None:
     request = build_resolver_run_request(
@@ -283,6 +287,25 @@ def test_build_resolver_run_request_pins_parent_provider_profile() -> None:
     assert runtime["effort"] == "high"
     assert "profileId" not in runtime
     assert "providerProfile" not in runtime
+
+def test_build_resolver_run_request_preserves_explicit_timeout_policy() -> None:
+    request = build_resolver_run_request(
+        parent_workflow_id="mm:parent",
+        pull_request=_pull_request(),
+        jira_issue_key=None,
+        merge_method="squash",
+        resolver_template={
+            "timeoutPolicy": {
+                "timeout_seconds": 12000,
+                "heartbeat_seconds": 30,
+            },
+        },
+    )
+
+    assert request["initial_parameters"]["timeoutPolicy"] == {
+        "timeout_seconds": 12000,
+        "heartbeat_seconds": 30,
+    }
 
 def test_build_continue_as_new_input_preserves_compact_wait_state() -> None:
     payload = build_continue_as_new_input(

--- a/tests/unit/workflows/temporal/workflows/test_merge_automation_temporal.py
+++ b/tests/unit/workflows/temporal/workflows/test_merge_automation_temporal.py
@@ -1605,6 +1605,110 @@ async def test_merge_automation_recovers_resolver_contract_issue_when_pr_is_merg
     )
 
 @pytest.mark.asyncio
+async def test_merge_automation_reenters_gate_when_failed_resolver_advances_head(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workflow = MoonMindMergeAutomationWorkflow()
+    readiness_calls = 0
+    child_calls = 0
+
+    async def fake_execute_activity(
+        activity_type: str,
+        _payload: dict[str, Any],
+        **_kwargs: Any,
+    ) -> dict[str, Any]:
+        nonlocal readiness_calls
+        if activity_type != "merge_automation.evaluate_readiness":
+            return {}
+        readiness_calls += 1
+        if readiness_calls == 1:
+            return {
+                "headSha": "abc123",
+                "ready": True,
+                "pullRequestOpen": True,
+                "policyAllowed": True,
+                "checksComplete": True,
+                "checksPassing": True,
+                "automatedReviewComplete": True,
+                "jiraStatusAllowed": True,
+            }
+        if readiness_calls == 2:
+            return {
+                "headSha": "def456",
+                "ready": False,
+                "pullRequestOpen": True,
+                "policyAllowed": True,
+                "checksComplete": False,
+                "checksPassing": None,
+                "automatedReviewComplete": True,
+                "jiraStatusAllowed": True,
+            }
+        return {
+            "headSha": "def456",
+            "ready": True,
+            "pullRequestOpen": True,
+            "policyAllowed": True,
+            "checksComplete": True,
+            "checksPassing": True,
+            "automatedReviewComplete": True,
+            "jiraStatusAllowed": True,
+        }
+
+    async def fake_execute_child_workflow(
+        workflow_type: str,
+        _payload: dict[str, Any],
+        **_kwargs: Any,
+    ) -> dict[str, Any]:
+        nonlocal child_calls
+        assert workflow_type == "MoonMind.UserWorkflow"
+        child_calls += 1
+        if child_calls == 1:
+            return {"status": "failed", "failureClass": "execution_error"}
+        return {"status": "success", "mergeAutomationDisposition": "merged"}
+
+    monkeypatch.setattr(
+        merge_automation_module.workflow,
+        "execute_activity",
+        fake_execute_activity,
+    )
+    monkeypatch.setattr(
+        merge_automation_module.workflow,
+        "execute_child_workflow",
+        fake_execute_child_workflow,
+    )
+    monkeypatch.setattr(merge_automation_module.workflow, "now", lambda: datetime.now(timezone.utc))
+    monkeypatch.setattr(merge_automation_module.workflow, "upsert_memo", lambda _memo: None)
+    monkeypatch.setattr(
+        merge_automation_module.workflow,
+        "upsert_search_attributes",
+        lambda _attrs: None,
+    )
+
+    result = await workflow.run(_payload())
+
+    assert readiness_calls == 3
+    assert child_calls == 2
+    assert result["status"] == "merged"
+    assert result["latestHeadSha"] == "def456"
+    assert "summary" not in result
+    expected_first_resolver_id = deterministic_resolver_idempotency_key(
+        parent_workflow_id="wf-parent",
+        repo="MoonLadderStudios/MoonMind",
+        pr_number=350,
+        head_sha="abc123",
+    )
+    expected_second_resolver_id = deterministic_resolver_idempotency_key(
+        parent_workflow_id="wf-parent",
+        repo="MoonLadderStudios/MoonMind",
+        pr_number=350,
+        head_sha="def456",
+    )
+    assert result["resolverChildWorkflowIds"] == [
+        f"{expected_first_resolver_id}:1",
+        f"{expected_second_resolver_id}:2",
+    ]
+
+@pytest.mark.asyncio
 async def test_merge_automation_ignores_wait_condition_timeout_only(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/workflows/temporal/workflows/test_merge_automation_temporal.py
+++ b/tests/unit/workflows/temporal/workflows/test_merge_automation_temporal.py
@@ -1518,7 +1518,6 @@ async def test_merge_automation_invalid_dispositions_fail_deterministically(
     "resolver_result",
     [
         {"status": "success"},
-        {"status": "success", "mergeAutomationDisposition": "manual_review"},
         {"status": "failed"},
     ],
 )
@@ -1707,6 +1706,163 @@ async def test_merge_automation_reenters_gate_when_failed_resolver_advances_head
         f"{expected_first_resolver_id}:1",
         f"{expected_second_resolver_id}:2",
     ]
+
+@pytest.mark.asyncio
+async def test_merge_automation_reenters_gate_when_child_exception_advances_head(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workflow = MoonMindMergeAutomationWorkflow()
+    readiness_calls = 0
+    child_calls = 0
+
+    async def fake_execute_activity(
+        activity_type: str,
+        _payload: dict[str, Any],
+        **_kwargs: Any,
+    ) -> dict[str, Any]:
+        nonlocal readiness_calls
+        if activity_type != "merge_automation.evaluate_readiness":
+            return {}
+        readiness_calls += 1
+        if readiness_calls == 1:
+            return {
+                "headSha": "abc123",
+                "ready": True,
+                "pullRequestOpen": True,
+                "policyAllowed": True,
+                "checksComplete": True,
+                "checksPassing": True,
+                "automatedReviewComplete": True,
+                "jiraStatusAllowed": True,
+            }
+        if readiness_calls == 2:
+            return {
+                "headSha": "def456",
+                "ready": False,
+                "pullRequestOpen": True,
+                "policyAllowed": True,
+                "checksComplete": False,
+                "automatedReviewComplete": True,
+                "jiraStatusAllowed": True,
+            }
+        return {
+            "headSha": "def456",
+            "ready": True,
+            "pullRequestOpen": True,
+            "policyAllowed": True,
+            "checksComplete": True,
+            "checksPassing": True,
+            "automatedReviewComplete": True,
+            "jiraStatusAllowed": True,
+        }
+
+    async def fake_execute_child_workflow(
+        workflow_type: str,
+        _payload: dict[str, Any],
+        **_kwargs: Any,
+    ) -> dict[str, Any]:
+        nonlocal child_calls
+        assert workflow_type == "MoonMind.UserWorkflow"
+        child_calls += 1
+        if child_calls == 1:
+            raise RuntimeError("child failed after push")
+        return {"status": "success", "mergeAutomationDisposition": "merged"}
+
+    monkeypatch.setattr(
+        merge_automation_module.workflow,
+        "execute_activity",
+        fake_execute_activity,
+    )
+    monkeypatch.setattr(
+        merge_automation_module.workflow,
+        "execute_child_workflow",
+        fake_execute_child_workflow,
+    )
+    monkeypatch.setattr(merge_automation_module.workflow, "now", lambda: datetime.now(timezone.utc))
+    monkeypatch.setattr(merge_automation_module.workflow, "upsert_memo", lambda _memo: None)
+    monkeypatch.setattr(
+        merge_automation_module.workflow,
+        "upsert_search_attributes",
+        lambda _attrs: None,
+    )
+
+    result = await workflow.run(_payload())
+
+    assert readiness_calls == 3
+    assert child_calls == 2
+    assert result["status"] == "merged"
+    assert result["latestHeadSha"] == "def456"
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("disposition", "expected_summary"),
+    [
+        ("manual_review", "pr-resolver requested manual review."),
+        ("failed", "pr-resolver reported failure."),
+    ],
+)
+async def test_merge_automation_honors_terminal_disposition_after_head_advance(
+    monkeypatch: pytest.MonkeyPatch,
+    disposition: str,
+    expected_summary: str,
+) -> None:
+    workflow = MoonMindMergeAutomationWorkflow()
+    readiness_calls = 0
+    child_calls = 0
+
+    async def fake_execute_activity(
+        activity_type: str,
+        _payload: dict[str, Any],
+        **_kwargs: Any,
+    ) -> dict[str, Any]:
+        nonlocal readiness_calls
+        assert activity_type == "merge_automation.evaluate_readiness"
+        readiness_calls += 1
+        return {
+            "headSha": "abc123" if readiness_calls == 1 else "def456",
+            "ready": True,
+            "pullRequestOpen": True,
+            "policyAllowed": True,
+            "checksComplete": True,
+            "checksPassing": True,
+            "automatedReviewComplete": True,
+            "jiraStatusAllowed": True,
+        }
+
+    async def fake_execute_child_workflow(
+        workflow_type: str,
+        _payload: dict[str, Any],
+        **_kwargs: Any,
+    ) -> dict[str, Any]:
+        nonlocal child_calls
+        assert workflow_type == "MoonMind.UserWorkflow"
+        child_calls += 1
+        return {"status": "success", "mergeAutomationDisposition": disposition}
+
+    monkeypatch.setattr(
+        merge_automation_module.workflow,
+        "execute_activity",
+        fake_execute_activity,
+    )
+    monkeypatch.setattr(
+        merge_automation_module.workflow,
+        "execute_child_workflow",
+        fake_execute_child_workflow,
+    )
+    monkeypatch.setattr(merge_automation_module.workflow, "now", lambda: datetime.now(timezone.utc))
+    monkeypatch.setattr(merge_automation_module.workflow, "upsert_memo", lambda _memo: None)
+    monkeypatch.setattr(
+        merge_automation_module.workflow,
+        "upsert_search_attributes",
+        lambda _attrs: None,
+    )
+
+    result = await workflow.run(_payload())
+
+    assert readiness_calls == 1
+    assert child_calls == 1
+    assert result["status"] == "failed"
+    assert result["summary"] == expected_summary
 
 @pytest.mark.asyncio
 async def test_merge_automation_ignores_wait_condition_timeout_only(


### PR DESCRIPTION
## Summary
- prioritize merge conflicts ahead of comments/CI in pr-resolver finalization
- give merge-automation resolver children an explicit 9000s timeout policy so the outer AgentRun budget exceeds the resolver internal orchestration cap
- recover from resolver timeout/failure when the PR head advanced by refreshing the tracked SHA and re-entering the merge gate

## Validation
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/test_pr_resolver_tools.py tests/unit/workflows/temporal/test_merge_gate_workflow.py tests/unit/workflows/temporal/workflows/test_merge_automation_temporal.py`
- `git diff --check`
- `PYTHONPYCACHEPREFIX=/tmp/moonmind-pycompile python3 -m py_compile .agents/skills/pr-resolver/bin/pr_resolve_finalize.py moonmind/workflows/temporal/workflows/merge_gate.py moonmind/workflows/temporal/workflows/merge_automation.py tests/unit/test_pr_resolver_tools.py tests/unit/workflows/temporal/test_merge_gate_workflow.py tests/unit/workflows/temporal/workflows/test_merge_automation_temporal.py`
