### PR TITLE
Fix Jira assessment verdict dash parsing

### DIFF
--- a/moonmind/workflows/temporal/story_output_tools.py
+++ b/moonmind/workflows/temporal/story_output_tools.py
@@ -4525,7 +4525,7 @@ def _assessment_verdict_from_text(value: Any) -> str:
     )
     verdict_prefix = r"[\s:`*_\"']*"
     verdict_suffix = r"(?:_+(?!\w)|(?![-\w]))"
-    assessment_separator = r"[\s:.,;!?\-`*_\"'\[\]\(\)]*"
+    assessment_separator = r"[\s:.,;!?\-\u2010-\u2015`*_\"'\[\]\(\)]*"
     issue_ref_pattern = r"`?[A-Z][A-Z0-9]+-\d+`?"
     patterns = (
         r"(?im)^\s*verdict\s*[:\-]\s*"

--- a/tests/unit/workflows/temporal/test_story_output_tools.py
+++ b/tests/unit/workflows/temporal/test_story_output_tools.py
@@ -705,6 +705,7 @@ async def test_update_jira_issue_status_accepts_bold_previous_assessment_verdict
         "Assessment complete. Verdict: `PARTIALLY_IMPLEMENTED`.",
         "Assessment complete! Verdict: `PARTIALLY_IMPLEMENTED`.",
         "Assessment complete? Verdict: `PARTIALLY_IMPLEMENTED`.",
+        "Assessment complete \u2014 verdict: **PARTIALLY_IMPLEMENTED**.",
     ],
 )
 async def test_update_jira_issue_status_accepts_sentence_previous_assessment_verdict(
@@ -741,6 +742,33 @@ async def test_update_jira_issue_status_accepts_sentence_previous_assessment_ver
     assert result.status == "COMPLETED"
     assert result.outputs["decision"] == "transitioned"
     assert service.transition_requests[0].transition_id == "31"
+
+
+@pytest.mark.asyncio
+async def test_check_jira_blockers_preserves_em_dash_previous_assessment_verdict() -> None:
+    service = _FakeJiraService()
+    service.issue_responses["MM-1137"] = {
+        "key": "MM-1137",
+        "fields": {"status": {"id": "1", "name": "Backlog"}, "issuelinks": []},
+    }
+
+    result = await check_jira_blockers(
+        {
+            "targetIssueKey": "MM-1137",
+            "assessmentArtifactPath": "artifacts/missing-assessment.json",
+            "previousOutputs": {
+                "operator_summary": (
+                    "## Assessment complete \u2014 verdict: "
+                    "**PARTIALLY_IMPLEMENTED**"
+                ),
+            },
+        },
+        jira_service_factory=lambda: service,
+    )
+
+    assert result.status == "COMPLETED"
+    assert result.outputs["decision"] == "continue"
+    assert result.outputs["assessmentVerdict"] == "PARTIALLY_IMPLEMENTED"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Accept Unicode dash separators when parsing assessment verdict text.
- Add regression coverage for Jira blocker handoff preserving an em-dash assessment verdict.

## Root cause
A failed Jira workflow reported `Assessment complete — verdict: **PARTIALLY_IMPLEMENTED**`, but the deterministic Jira status tool only treated ASCII hyphen as an assessment separator. The blocker step dropped the verdict, so the In Progress transition blocked as missing assessment evidence.

## Validation
- `.venv/bin/python -m pytest -q tests/unit/workflows/temporal/test_story_output_tools.py -k "assessment_verdict or check_jira_blockers_preserves_em_dash"`
- `git diff --check -- moonmind/workflows/temporal/story_output_tools.py tests/unit/workflows/temporal/test_story_output_tools.py`