### PR TITLE
Remove this text from the workflows page: "Live updates enabled. Polling every 5s"

### DIFF
--- a/frontend/src/entrypoints/workflow-list.test.tsx
+++ b/frontend/src/entrypoints/workflow-list.test.tsx
@@ -1963,7 +1963,7 @@ describe('Workflows Entrypoint', () => {
     const paginationBlock = footer?.querySelector('.workflow-list-footer-pagination');
     const paginationSummary = footer?.querySelector('.workflow-list-footer-page-summary');
     expect(liveBlock?.querySelector('input[type="checkbox"]')).toBeNull();
-    expect(liveBlock?.textContent).toContain('Live updates enabled. Polling every 5s');
+    expect(liveBlock?.textContent).not.toMatch(/Live updates enabled\. Polling every \d+s/);
     expect(paginationBlock?.contains(screen.getByLabelText('Show'))).toBe(true);
     expect(getComputedStyle(paginationBlock as Element).flexWrap).toBe('wrap');
     expect(paginationSummary?.textContent).toContain('1 - 1');
@@ -2035,8 +2035,8 @@ describe('Workflows Entrypoint', () => {
     expect(screen.queryByRole('button', { name: /^Workflow Type\./i })).toBeNull();
     expect(screen.queryByRole('button', { name: /^Entry\./i })).toBeNull();
 
-    expect(dataSlab?.querySelector('.workflow-list-results-footer')?.textContent).toContain(
-      'Live updates enabled. Polling every 5s',
+    expect(dataSlab?.querySelector('.workflow-list-results-footer')?.textContent).not.toMatch(
+      /Live updates enabled\. Polling every \d+s/,
     );
     expect(screen.queryByText('Showing all task executions.')).toBeNull();
     expect(dataSlab).toBeTruthy();

--- a/frontend/src/entrypoints/workflow-list.tsx
+++ b/frontend/src/entrypoints/workflow-list.tsx
@@ -1536,13 +1536,11 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
   const resultsFooter = (
     <div className="queue-results-toolbar workflow-list-results-footer">
       <div className="workflow-list-footer-live">
-        <span className="small">
-          {!listEnabled
-            ? 'Live updates unavailable while the list is disabled.'
-            : liveUpdatesPref
-              ? `Live updates enabled. Polling every ${Math.round(listPollMs / 1000)}s`
-              : 'Live updates paused.'}
-        </span>
+        {!listEnabled ? (
+          <span className="small">Live updates unavailable while the list is disabled.</span>
+        ) : !liveUpdatesPref ? (
+          <span className="small">Live updates paused.</span>
+        ) : null}
         {sortedItems.length > 0 ? (
           <span className="small workflow-list-sort-scope-note">{CURRENT_PAGE_SORT_NOTICE}</span>
         ) : null}


### PR DESCRIPTION
Remove this text from the workflows page: "Live updates enabled. Polling every 5s"