### PR TITLE
[codex] Guard pr-resolver against delayed Codex reviews

### DIFF
--- a/.agents/skills/pr-resolver/SKILL.md
+++ b/.agents/skills/pr-resolver/SKILL.md
@@ -35,6 +35,10 @@ The task is not complete until the target PR is merged or is proven already merg
   non-retryable blocker is reached first.
 - `ci_running` finalize waits use at least 60 seconds before the next check,
   even when `finalizeBackoffSeconds` is lower.
+- If the only visible PR comment/review is from `gemini-code-assist`, the
+  resolver treats that as a Codex-review grace window and polls for up to 10
+  minutes before merging. Any additional visible comment/review ends the grace
+  wait immediately.
 
 ## Primary Command (mandatory first action)
 Run the orchestration entrypoint before making manual changes. **You MUST provide the `--pr` argument** (using either the PR number or the branch name) to ensure the script targets the correct PR, even if you are on a different branch or detached HEAD:
@@ -126,6 +130,7 @@ Repeat this state machine until a terminal success or manual blocker:
   - `merge_conflicts`
 - Finalize-only retry reasons:
   - `ci_running`
+  - `codex_review_grace_wait`
   - `comments_unavailable`
   - `ci_signal_degraded`
   - `merge_not_ready` (limited grace retries)
@@ -133,6 +138,8 @@ Repeat this state machine until a terminal success or manual blocker:
   queued or running checks can reach a terminal state; if they then become
   `ci_failures`, continue into `run_fix_ci_skill` instead of stopping early.
 - `ci_running` should not poll faster than once per minute.
+- `codex_review_grace_wait` polls once per minute and should be allowed to
+  expire naturally before finalizing the merge.
 - If retries transition from transient CI states into actionable `ci_failures`, continue into `run_fix_ci_skill` instead of stopping at manual review.
 - If `merge_not_ready` resolves into an actionable blocker such as `merge_conflicts`, continue into the matching remediation skill instead of stopping at manual review.
 - Non-retryable stop reasons:

--- a/.agents/skills/pr-resolver/bin/pr_resolve_contract.py
+++ b/.agents/skills/pr-resolver/bin/pr_resolve_contract.py
@@ -16,6 +16,7 @@ FULL_REMEDIATION_REASONS = {
 
 FINALIZE_ONLY_RETRY_REASONS = {
     "ci_running",
+    "codex_review_grace_wait",
     "comments_unavailable",
     "ci_signal_degraded",
     "snapshot_refresh_failed",
@@ -94,6 +95,8 @@ def remediation_next_step(reason: str) -> str:
         return "retry_finalize_after_backoff"
     if normalized == "ci_running":
         return "wait_for_ci_and_retry_finalize"
+    if normalized == "codex_review_grace_wait":
+        return "wait_for_codex_review_and_retry_finalize"
     if normalized == "comment_policy_not_enforced":
         return "inspect_comment_policy"
     if normalized == "merge_not_ready":
@@ -118,6 +121,7 @@ def merge_automation_disposition_for_result(
     if normalized_next_step in {
         "retry_finalize_after_backoff",
         "wait_for_ci_and_retry_finalize",
+        "wait_for_codex_review_and_retry_finalize",
     }:
         return MERGE_AUTOMATION_DISPOSITION_REENTER_GATE
     if normalized_status == "merged" and normalized_outcome == "merged":

--- a/.agents/skills/pr-resolver/bin/pr_resolve_finalize.py
+++ b/.agents/skills/pr-resolver/bin/pr_resolve_finalize.py
@@ -119,6 +119,9 @@ def evaluate_finalize_action(snapshot: dict[str, Any]) -> dict[str, str]:
         return {"action": "blocked", "reason": "comment_policy_not_enforced"}
     if bool(comments_summary.get("hasActionableComments")):
         return {"action": "blocked", "reason": "actionable_comments"}
+    codex_review_grace = comments_summary.get("codexReviewGrace")
+    if isinstance(codex_review_grace, dict) and codex_review_grace.get("active") is True:
+        return {"action": "blocked", "reason": "codex_review_grace_wait"}
     if normalize_text(ci.get("signalQuality")).lower() not in {"", "ok"}:
         return {"action": "blocked", "reason": "ci_signal_degraded"}
     if bool(ci.get("hasFailures")):

--- a/.agents/skills/pr-resolver/bin/pr_resolve_finalize.py
+++ b/.agents/skills/pr-resolver/bin/pr_resolve_finalize.py
@@ -119,15 +119,15 @@ def evaluate_finalize_action(snapshot: dict[str, Any]) -> dict[str, str]:
         return {"action": "blocked", "reason": "comment_policy_not_enforced"}
     if bool(comments_summary.get("hasActionableComments")):
         return {"action": "blocked", "reason": "actionable_comments"}
-    codex_review_grace = comments_summary.get("codexReviewGrace")
-    if isinstance(codex_review_grace, dict) and codex_review_grace.get("active") is True:
-        return {"action": "blocked", "reason": "codex_review_grace_wait"}
     if normalize_text(ci.get("signalQuality")).lower() not in {"", "ok"}:
         return {"action": "blocked", "reason": "ci_signal_degraded"}
     if bool(ci.get("hasFailures")):
         return {"action": "blocked", "reason": "ci_failures"}
     if bool(ci.get("isRunning")):
         return {"action": "blocked", "reason": "ci_running"}
+    codex_review_grace = comments_summary.get("codexReviewGrace")
+    if isinstance(codex_review_grace, dict) and codex_review_grace.get("active") is True:
+        return {"action": "blocked", "reason": "codex_review_grace_wait"}
 
     merge_state = normalize_text(pr.get("mergeStateStatus")).upper()
     if merge_state in DIRECT_MERGE_STATE:

--- a/.agents/skills/pr-resolver/bin/pr_resolve_orchestrate.py
+++ b/.agents/skills/pr-resolver/bin/pr_resolve_orchestrate.py
@@ -334,15 +334,20 @@ def run_orchestration(
                 grace_remaining -= 1
             effective_base_sleep_seconds = (
                 max(base_sleep_seconds, 60)
-                if normalized_reason == "ci_running"
+                if normalized_reason in {"ci_running", "codex_review_grace_wait"}
                 else base_sleep_seconds
+            )
+            effective_max_sleep_seconds = (
+                max(60, min(max_sleep_seconds, 60))
+                if normalized_reason == "codex_review_grace_wait"
+                else max_sleep_seconds
             )
             sleep_seconds = compute_backoff_seconds(
                 finalize_only_retry_index,
                 base_sleep_seconds=effective_base_sleep_seconds,
-                max_sleep_seconds=max_sleep_seconds,
+                max_sleep_seconds=effective_max_sleep_seconds,
             )
-            if normalized_reason == "ci_running":
+            if normalized_reason in {"ci_running", "codex_review_grace_wait"}:
                 sleep_seconds = max(sleep_seconds, 60)
             finalize_only_retry_index += 1
             history.append(

--- a/.agents/skills/pr-resolver/bin/pr_resolve_orchestrate.py
+++ b/.agents/skills/pr-resolver/bin/pr_resolve_orchestrate.py
@@ -338,7 +338,7 @@ def run_orchestration(
                 else base_sleep_seconds
             )
             effective_max_sleep_seconds = (
-                max(60, min(max_sleep_seconds, 60))
+                60
                 if normalized_reason == "codex_review_grace_wait"
                 else max_sleep_seconds
             )

--- a/.agents/skills/pr-resolver/bin/pr_resolve_snapshot.py
+++ b/.agents/skills/pr-resolver/bin/pr_resolve_snapshot.py
@@ -12,7 +12,7 @@ import shutil
 import subprocess
 import sys
 import time
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from urllib.parse import urlparse
 
@@ -54,6 +54,15 @@ _KNOWN_AUTOMATION_USERS = {
     "chatgpt-codex-connector",
     "gemini-code-assist",
     "github-actions",
+}
+_UTC = timezone.utc
+_NON_VISIBLE_COMMENT_REASONS = {
+    "addressed_in_ledger",
+    "command_comment",
+    "empty_body",
+    "stale_bot_comment",
+    "thread_outdated",
+    "thread_resolved",
 }
 
 def _build_subprocess_env() -> dict[str, str]:
@@ -297,7 +306,15 @@ def _is_gemini_code_assist_user(login: str | None) -> bool:
     return _strip_bot_suffix(login) == "gemini-code-assist"
 
 def _utc_now() -> datetime:
-    return datetime.now(UTC)
+    return datetime.now(_UTC)
+
+def _is_gemini_no_feedback_comment(comment: dict, normalized_body: str) -> bool:
+    if not _is_gemini_code_assist_user(comment.get("user")):
+        return False
+    if comment.get("type") not in {"issue_comment", "review"}:
+        return False
+    body = normalized_body.lower()
+    return "no review comments" in body or "no feedback to provide" in body
 
 def _parse_utc_timestamp(value: object) -> datetime | None:
     candidate = str(value or "").strip()
@@ -310,8 +327,8 @@ def _parse_utc_timestamp(value: object) -> datetime | None:
     except ValueError:
         return None
     if parsed.tzinfo is None:
-        return parsed.replace(tzinfo=UTC)
-    return parsed.astimezone(UTC)
+        return parsed.replace(tzinfo=_UTC)
+    return parsed.astimezone(_UTC)
 
 def _load_previous_codex_review_grace(snapshot_path: Path) -> dict | None:
     try:
@@ -388,6 +405,15 @@ def _classify_comment_actionability(
         )
     ):
         return False, "command_comment"
+
+    if _is_gemini_no_feedback_comment(comment, normalized_body):
+        return False, "gemini_no_feedback_review"
+
+    if _is_gemini_code_assist_user(comment.get("user")) and comment_type in {
+        "issue_comment",
+        "review",
+    }:
+        return True, "actionable"
 
     if is_bot_user(comment.get("user")):
         return False, "bot_comment_excluded"
@@ -554,14 +580,34 @@ def apply_codex_review_grace(
 ) -> dict:
     """Annotate a Gemini-only review state with a bounded Codex wait window."""
 
-    if comments_summary.get("hasActionableComments") is True or len(comments) != 1:
+    if comments_summary.get("hasActionableComments") is True:
         comments_summary["codexReviewGrace"] = {
             "active": False,
             "reason": "not_gemini_only",
         }
         return comments_summary
 
-    only_comment = comments[0] if isinstance(comments[0], dict) else {}
+    classified_comments = comments_summary.get("classifiedComments")
+    visible_comments: list[dict] = []
+    if isinstance(classified_comments, list) and len(classified_comments) == len(comments):
+        for comment, classified in zip(comments, classified_comments):
+            if not isinstance(comment, dict) or not isinstance(classified, dict):
+                continue
+            reason = str(classified.get("reason") or "").strip()
+            if reason in _NON_VISIBLE_COMMENT_REASONS:
+                continue
+            visible_comments.append(comment)
+    else:
+        visible_comments = [c for c in comments if isinstance(c, dict)]
+
+    if len(visible_comments) != 1:
+        comments_summary["codexReviewGrace"] = {
+            "active": False,
+            "reason": "not_gemini_only",
+        }
+        return comments_summary
+
+    only_comment = visible_comments[0]
     if not _is_gemini_code_assist_user(only_comment.get("user")):
         comments_summary["codexReviewGrace"] = {
             "active": False,
@@ -569,7 +615,7 @@ def apply_codex_review_grace(
         }
         return comments_summary
 
-    now_utc = (now or _utc_now()).astimezone(UTC)
+    now_utc = (now or _utc_now()).astimezone(_UTC)
     key = _comment_identity(only_comment, head_commit_sha=head_commit_sha)
     started_at = None
     if isinstance(previous_grace, dict) and previous_grace.get("key") == key:

--- a/.agents/skills/pr-resolver/bin/pr_resolve_snapshot.py
+++ b/.agents/skills/pr-resolver/bin/pr_resolve_snapshot.py
@@ -12,6 +12,7 @@ import shutil
 import subprocess
 import sys
 import time
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from urllib.parse import urlparse
 
@@ -47,6 +48,13 @@ _MENTION_COMMAND_ONLY_COMMENT_PATTERN = re.compile(
     r"(review|address\s+that\s+feedback)\.?$",
     re.IGNORECASE,
 )
+_CODEX_REVIEW_GRACE_TIMEOUT_SECONDS = 600
+_CODEX_REVIEW_GRACE_POLL_SECONDS = 60
+_KNOWN_AUTOMATION_USERS = {
+    "chatgpt-codex-connector",
+    "gemini-code-assist",
+    "github-actions",
+}
 
 def _build_subprocess_env() -> dict[str, str]:
     env = os.environ.copy()
@@ -276,7 +284,57 @@ def normalize_user(login: str | None) -> str:
 
 def is_bot_user(login: str | None) -> bool:
     user = normalize_user(login)
-    return user.endswith("[bot]") or user == "github-actions[bot]"
+    stripped = user[: -len("[bot]")] if user.endswith("[bot]") else user
+    return user.endswith("[bot]") or stripped in _KNOWN_AUTOMATION_USERS
+
+def _strip_bot_suffix(login: str | None) -> str:
+    user = normalize_user(login)
+    if user.endswith("[bot]"):
+        return user[: -len("[bot]")]
+    return user
+
+def _is_gemini_code_assist_user(login: str | None) -> bool:
+    return _strip_bot_suffix(login) == "gemini-code-assist"
+
+def _utc_now() -> datetime:
+    return datetime.now(UTC)
+
+def _parse_utc_timestamp(value: object) -> datetime | None:
+    candidate = str(value or "").strip()
+    if not candidate:
+        return None
+    if candidate.endswith("Z"):
+        candidate = candidate[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(candidate)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
+
+def _load_previous_codex_review_grace(snapshot_path: Path) -> dict | None:
+    try:
+        payload = json.loads(snapshot_path.read_text(encoding="utf-8"))
+    except (FileNotFoundError, OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    comments_summary = payload.get("commentsSummary")
+    if not isinstance(comments_summary, dict):
+        return None
+    grace = comments_summary.get("codexReviewGrace")
+    return grace if isinstance(grace, dict) else None
+
+def _comment_identity(comment: dict, *, head_commit_sha: str | None) -> str:
+    parts = [
+        str(head_commit_sha or "").strip(),
+        str(comment.get("id") or "").strip(),
+        str(comment.get("created_at") or comment.get("updated_at") or "").strip(),
+        str(comment.get("user") or "").strip(),
+        str(comment.get("type") or "").strip(),
+    ]
+    return "|".join(parts)
 
 def _classify_comment_actionability(
     comment: dict,
@@ -486,6 +544,58 @@ def summarize_comments(
         "classifiedComments": classified_comments,
     }
 
+def apply_codex_review_grace(
+    comments_summary: dict,
+    comments: list[dict],
+    *,
+    head_commit_sha: str | None,
+    previous_grace: dict | None = None,
+    now: datetime | None = None,
+) -> dict:
+    """Annotate a Gemini-only review state with a bounded Codex wait window."""
+
+    if comments_summary.get("hasActionableComments") is True or len(comments) != 1:
+        comments_summary["codexReviewGrace"] = {
+            "active": False,
+            "reason": "not_gemini_only",
+        }
+        return comments_summary
+
+    only_comment = comments[0] if isinstance(comments[0], dict) else {}
+    if not _is_gemini_code_assist_user(only_comment.get("user")):
+        comments_summary["codexReviewGrace"] = {
+            "active": False,
+            "reason": "not_gemini_only",
+        }
+        return comments_summary
+
+    now_utc = (now or _utc_now()).astimezone(UTC)
+    key = _comment_identity(only_comment, head_commit_sha=head_commit_sha)
+    started_at = None
+    if isinstance(previous_grace, dict) and previous_grace.get("key") == key:
+        started_at = _parse_utc_timestamp(previous_grace.get("startedAt"))
+    if started_at is None:
+        started_at = now_utc
+    expires_at = started_at + timedelta(
+        seconds=_CODEX_REVIEW_GRACE_TIMEOUT_SECONDS
+    )
+    remaining_seconds = max(0, int((expires_at - now_utc).total_seconds()))
+    active = remaining_seconds > 0
+    comments_summary["codexReviewGrace"] = {
+        "active": active,
+        "expired": not active,
+        "reason": "gemini_only_review",
+        "key": key,
+        "startedAt": started_at.isoformat(),
+        "expiresAt": expires_at.isoformat(),
+        "timeoutSeconds": _CODEX_REVIEW_GRACE_TIMEOUT_SECONDS,
+        "pollSeconds": _CODEX_REVIEW_GRACE_POLL_SECONDS,
+        "remainingSeconds": remaining_seconds,
+        "commentUser": only_comment.get("user"),
+        "commentType": only_comment.get("type"),
+    }
+    return comments_summary
+
 def _check_name(check: dict) -> str:
     return str(check.get("name") or check.get("context") or "Unknown Check").strip()
 
@@ -672,6 +782,7 @@ def main():
         help="Snapshot path to write",
     )
     args = parser.parse_args()
+    snapshot_path = Path(args.snapshot_path)
 
     # 1. Fetch PR metadata with resilient selector fallback.
     pr_data, resolved_selector, pr_errors = fetch_pr_data(args.pr)
@@ -832,6 +943,12 @@ def main():
         addressed_comment_ids=addressed_ids,
         head_commit_sha=head_sha,
     )
+    comments_summary = apply_codex_review_grace(
+        comments_summary,
+        comments,
+        head_commit_sha=head_sha,
+        previous_grace=_load_previous_codex_review_grace(snapshot_path),
+    )
 
     # 4. Construct Snapshot
     snapshot = {
@@ -845,7 +962,6 @@ def main():
         "commentsSummary": comments_summary,
     }
 
-    snapshot_path = Path(args.snapshot_path)
     snapshot_path.parent.mkdir(parents=True, exist_ok=True)
     snapshot_path.write_text(json.dumps(snapshot, indent=2))
 

--- a/tests/unit/test_pr_resolver_tools.py
+++ b/tests/unit/test_pr_resolver_tools.py
@@ -539,6 +539,65 @@ def test_second_visible_comment_disables_gemini_grace(
     assert summary["codexReviewGrace"]["active"] is False
     assert summary["codexReviewGrace"]["reason"] == "not_gemini_only"
 
+def test_historical_comments_do_not_disable_gemini_grace(
+    pr_resolve_snapshot_module: dict[str, Any],
+) -> None:
+    summarize_comments = pr_resolve_snapshot_module["summarize_comments"]
+    apply_codex_review_grace = pr_resolve_snapshot_module["apply_codex_review_grace"]
+
+    comments = [
+        {
+            "type": "review",
+            "id": 4649647799,
+            "user": "gemini-code-assist",
+            "body": "There are no review comments, so I have no feedback to provide.",
+            "created_at": "2026-07-07T23:21:05Z",
+        },
+        {
+            "type": "review_comment",
+            "id": 3540280148,
+            "user": "human-reviewer",
+            "body": "Please update this old diff.",
+            "thread_resolved": True,
+        },
+        {
+            "type": "issue_comment",
+            "id": 3540280149,
+            "user": "human-reviewer",
+            "body": "@codex review",
+        },
+    ]
+
+    summary = apply_codex_review_grace(
+        summarize_comments(comments, include_bot_review_comments=True),
+        comments,
+        head_commit_sha="0f3c29855026f4da35cbead50bfa2d6f0bde641c",
+        now=datetime(2026, 7, 7, 23, 30, 34, tzinfo=UTC),
+    )
+
+    assert summary["hasActionableComments"] is False
+    assert summary["codexReviewGrace"]["active"] is True
+    assert summary["codexReviewGrace"]["reason"] == "gemini_only_review"
+
+def test_actionable_gemini_review_body_stays_actionable(
+    pr_resolve_snapshot_module: dict[str, Any],
+) -> None:
+    summarize_comments = pr_resolve_snapshot_module["summarize_comments"]
+
+    comments = [
+        {
+            "type": "review",
+            "id": 4649647799,
+            "user": "gemini-code-assist",
+            "body": "Please add a regression test before merging.",
+        }
+    ]
+
+    summary = summarize_comments(comments, include_bot_review_comments=True)
+
+    assert summary["hasActionableComments"] is True
+    assert summary["actionableCommentIds"] == [4649647799]
+
 def test_resolved_review_threads_are_not_actionable(
     pr_resolve_snapshot_module: dict[str, Any],
 ) -> None:
@@ -654,6 +713,26 @@ def test_finalize_blocks_during_codex_review_grace(
     )
 
     assert decision == {"action": "blocked", "reason": "codex_review_grace_wait"}
+
+def test_finalize_reports_ci_before_codex_review_grace(
+    pr_resolve_finalize_module: dict[str, Any],
+) -> None:
+    evaluate_finalize_action = pr_resolve_finalize_module["evaluate_finalize_action"]
+
+    decision = evaluate_finalize_action(
+        {
+            "pr": {"mergeable": "MERGEABLE", "mergeStateStatus": "CLEAN"},
+            "ci": {"isRunning": False, "hasFailures": True, "signalQuality": "ok"},
+            "commentsFetch": {"succeeded": True, "source": "fixture"},
+            "commentsSummary": {
+                "hasActionableComments": False,
+                "includeBotReviewComments": True,
+                "codexReviewGrace": {"active": True},
+            },
+        }
+    )
+
+    assert decision == {"action": "blocked", "reason": "ci_failures"}
 
 def test_finalize_merges_after_codex_review_grace_expires(
     pr_resolve_finalize_module: dict[str, Any],

--- a/tests/unit/test_pr_resolver_tools.py
+++ b/tests/unit/test_pr_resolver_tools.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
@@ -442,6 +443,102 @@ def test_normal_human_issue_comment_stays_actionable(
     assert summary["actionableCommentCount"] == 1
     assert summary["actionableCommentIds"] == [1]
 
+def test_gemini_only_review_activates_codex_review_grace(
+    pr_resolve_snapshot_module: dict[str, Any],
+) -> None:
+    summarize_comments = pr_resolve_snapshot_module["summarize_comments"]
+    apply_codex_review_grace = pr_resolve_snapshot_module["apply_codex_review_grace"]
+
+    comments = [
+        {
+            "type": "review",
+            "id": 4649647799,
+            "user": "gemini-code-assist[bot]",
+            "body": "There are no review comments, so I have no feedback to provide.",
+            "created_at": "2026-07-07T23:21:05Z",
+        }
+    ]
+
+    summary = summarize_comments(comments, include_bot_review_comments=True)
+    summary = apply_codex_review_grace(
+        summary,
+        comments,
+        head_commit_sha="0f3c29855026f4da35cbead50bfa2d6f0bde641c",
+        now=datetime(2026, 7, 7, 23, 26, 44, tzinfo=UTC),
+    )
+
+    grace = summary["codexReviewGrace"]
+    assert grace["active"] is True
+    assert grace["reason"] == "gemini_only_review"
+    assert grace["timeoutSeconds"] == 600
+    assert grace["pollSeconds"] == 60
+
+def test_gemini_grace_expires_after_ten_minutes_without_restart(
+    pr_resolve_snapshot_module: dict[str, Any],
+) -> None:
+    summarize_comments = pr_resolve_snapshot_module["summarize_comments"]
+    apply_codex_review_grace = pr_resolve_snapshot_module["apply_codex_review_grace"]
+
+    comments = [
+        {
+            "type": "review",
+            "id": 4649647799,
+            "user": "gemini-code-assist",
+            "body": "There are no review comments.",
+            "created_at": "2026-07-07T23:21:05Z",
+        }
+    ]
+    first_now = datetime(2026, 7, 7, 23, 26, 44, tzinfo=UTC)
+    first_summary = apply_codex_review_grace(
+        summarize_comments(comments, include_bot_review_comments=True),
+        comments,
+        head_commit_sha="0f3c29855026f4da35cbead50bfa2d6f0bde641c",
+        now=first_now,
+    )
+
+    later_summary = apply_codex_review_grace(
+        summarize_comments(comments, include_bot_review_comments=True),
+        comments,
+        head_commit_sha="0f3c29855026f4da35cbead50bfa2d6f0bde641c",
+        previous_grace=first_summary["codexReviewGrace"],
+        now=first_now + timedelta(seconds=601),
+    )
+
+    assert later_summary["codexReviewGrace"]["active"] is False
+    assert later_summary["codexReviewGrace"]["expired"] is True
+    assert later_summary["codexReviewGrace"]["remainingSeconds"] == 0
+
+def test_second_visible_comment_disables_gemini_grace(
+    pr_resolve_snapshot_module: dict[str, Any],
+) -> None:
+    summarize_comments = pr_resolve_snapshot_module["summarize_comments"]
+    apply_codex_review_grace = pr_resolve_snapshot_module["apply_codex_review_grace"]
+
+    comments = [
+        {
+            "type": "review",
+            "id": 4649647799,
+            "user": "gemini-code-assist[bot]",
+            "body": "There are no review comments.",
+        },
+        {
+            "type": "review_comment",
+            "id": 3540280148,
+            "user": "chatgpt-codex-connector",
+            "body": "Please derive attack targets from TargetUnitId.",
+        },
+    ]
+
+    summary = apply_codex_review_grace(
+        summarize_comments(comments, include_bot_review_comments=True),
+        comments,
+        head_commit_sha="0f3c29855026f4da35cbead50bfa2d6f0bde641c",
+        now=datetime(2026, 7, 7, 23, 30, 34, tzinfo=UTC),
+    )
+
+    assert summary["codexReviewGrace"]["active"] is False
+    assert summary["codexReviewGrace"]["reason"] == "not_gemini_only"
+
 def test_resolved_review_threads_are_not_actionable(
     pr_resolve_snapshot_module: dict[str, Any],
 ) -> None:
@@ -537,6 +634,46 @@ def test_finalize_blocks_when_actionable_comments_exist(
     )
 
     assert decision == {"action": "blocked", "reason": "actionable_comments"}
+
+def test_finalize_blocks_during_codex_review_grace(
+    pr_resolve_finalize_module: dict[str, Any],
+) -> None:
+    evaluate_finalize_action = pr_resolve_finalize_module["evaluate_finalize_action"]
+
+    decision = evaluate_finalize_action(
+        {
+            "pr": {"mergeable": "MERGEABLE", "mergeStateStatus": "CLEAN"},
+            "ci": {"isRunning": False, "hasFailures": False, "signalQuality": "ok"},
+            "commentsFetch": {"succeeded": True, "source": "fixture"},
+            "commentsSummary": {
+                "hasActionableComments": False,
+                "includeBotReviewComments": True,
+                "codexReviewGrace": {"active": True},
+            },
+        }
+    )
+
+    assert decision == {"action": "blocked", "reason": "codex_review_grace_wait"}
+
+def test_finalize_merges_after_codex_review_grace_expires(
+    pr_resolve_finalize_module: dict[str, Any],
+) -> None:
+    evaluate_finalize_action = pr_resolve_finalize_module["evaluate_finalize_action"]
+
+    decision = evaluate_finalize_action(
+        {
+            "pr": {"mergeable": "MERGEABLE", "mergeStateStatus": "CLEAN"},
+            "ci": {"isRunning": False, "hasFailures": False, "signalQuality": "ok"},
+            "commentsFetch": {"succeeded": True, "source": "fixture"},
+            "commentsSummary": {
+                "hasActionableComments": False,
+                "includeBotReviewComments": True,
+                "codexReviewGrace": {"active": False, "expired": True},
+            },
+        }
+    )
+
+    assert decision == {"action": "merge_now", "reason": "ci_complete"}
 
 def test_finalize_prioritizes_merge_conflicts_before_comments_and_ci(
     pr_resolve_finalize_module: dict[str, Any],
@@ -814,6 +951,48 @@ def test_orchestrate_ci_running_uses_finalize_only_retry_path(
     assert sleeps == [60]
 
 
+def test_orchestrate_codex_review_grace_waits_then_merges(
+    pr_resolve_orchestrate_module: dict[str, Any],
+) -> None:
+    run_orchestration = pr_resolve_orchestrate_module["run_orchestration"]
+
+    finalize_results = iter(
+        [
+            {
+                "status": "blocked",
+                "merge_outcome": "blocked",
+                "reason": "codex_review_grace_wait",
+            },
+            {"status": "merged", "merge_outcome": "merged", "reason": "ci_complete"},
+        ]
+    )
+    sleeps: list[int] = []
+    full_invocations = 0
+
+    def full_runner(_attempt: int, _escalation: int, _reason: str) -> dict[str, Any]:
+        nonlocal full_invocations
+        full_invocations += 1
+        return {"status": "failed", "merge_outcome": "failed", "reason": "unexpected"}
+
+    result, exit_code = run_orchestration(
+        finalize_runner=lambda _attempt: next(finalize_results),
+        full_runner=full_runner,
+        sleep_fn=lambda seconds: sleeps.append(seconds),
+        monotonic_fn=lambda: 0.0,
+        finalize_max_retries=2,
+        fix_max_iterations=3,
+        base_sleep_seconds=15,
+        max_sleep_seconds=120,
+        max_elapsed_seconds=900,
+        merge_not_ready_grace_retries=1,
+    )
+
+    assert exit_code == 0
+    assert result["status"] == "merged"
+    assert full_invocations == 0
+    assert sleeps == [60]
+
+
 def test_orchestrate_ci_running_sleep_floor_overrides_low_max_sleep(
     pr_resolve_orchestrate_module: dict[str, Any],
 ) -> None:
@@ -1086,6 +1265,23 @@ def test_contract_snapshot_refresh_failed_is_finalize_only_retry(
         merge_not_ready_grace_remaining=1,
     )
     assert action == "finalize_only_retry"
+
+def test_contract_codex_review_grace_wait_is_finalize_only_retry(
+    pr_resolve_contract_module: dict[str, Any],
+) -> None:
+    classify_retry_action = pr_resolve_contract_module["classify_retry_action"]
+    remediation_next_step = pr_resolve_contract_module["remediation_next_step"]
+
+    action = classify_retry_action(
+        "codex_review_grace_wait",
+        merge_not_ready_grace_remaining=0,
+    )
+
+    assert action == "finalize_only_retry"
+    assert (
+        remediation_next_step("codex_review_grace_wait")
+        == "wait_for_codex_review_and_retry_finalize"
+    )
 
 def test_contract_run_fix_next_step_returns_reenter_gate(
     pr_resolve_contract_module: dict[str, Any],

--- a/tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py
@@ -1103,6 +1103,10 @@ class TestBuildAgentExecutionRequest(unittest.TestCase):
     def test_checkpoint_branch_turn_source_preserves_before_execution_boundary(self) -> None:
         wf = MoonMindRunWorkflow()
 
+        class MockInfo:
+            workflow_id = "test-wf-id"
+            run_id = "test-run-id"
+
         source = wf._checkpoint_branch_turn_source_checkpoint(
             {
                 "sourceWorkflowId": "source-wf",
@@ -1114,6 +1118,7 @@ class TestBuildAgentExecutionRequest(unittest.TestCase):
                 "checkpointBeforeDigest": "sha256:" + "a" * 64,
             },
             node_id="repair",
+            wf_info=MockInfo(),
         )
 
         self.assertEqual(source["checkpointRef"], "artifact://checkpoint/before")


### PR DESCRIPTION
## Summary

- Add a pr-resolver Codex-review grace window when the only visible review/comment is from gemini-code-assist.
- Poll once per minute for up to 10 minutes before allowing merge, while ending the wait immediately when any additional review/comment appears.
- Update the omnigent submodule pointer to latest main: 42177d0e394002938b450086bf17bf7e01a53dfc.

## Validation

- python3 -m py_compile .agents/skills/pr-resolver/bin/pr_resolve_snapshot.py .agents/skills/pr-resolver/bin/pr_resolve_finalize.py .agents/skills/pr-resolver/bin/pr_resolve_orchestrate.py .agents/skills/pr-resolver/bin/pr_resolve_contract.py
- .venv/bin/python -m pytest tests/unit/test_pr_resolver_tools.py -q (63 passed)
- ./tools/test_unit.sh tests/unit/test_pr_resolver_tools.py was attempted but stalled before pytest in tools/status_domain_audit.py; interrupted and ran the targeted pytest directly.
