### PR TITLE
[codex] Fix Claude Code silent progress watchdog

### DIFF
--- a/moonmind/workflows/temporal/runtime/strategies/claude_code.py
+++ b/moonmind/workflows/temporal/runtime/strategies/claude_code.py
@@ -19,6 +19,33 @@ from moonmind.workflows.temporal.runtime.strategies.base import (
 from moonmind.workflows.provider_failures import classify_provider_failure
 
 _CLAUDE_PROGRESS_MTIME_PADDING_SECONDS = 5.0
+_CLAUDE_WORKSPACE_PROGRESS_MAX_FILES = 50_000
+_CLAUDE_WORKSPACE_PROGRESS_SKIP_DIRS = frozenset(
+    {
+        ".git",
+        ".hg",
+        ".svn",
+        ".moonmind",
+        ".mypy_cache",
+        ".nox",
+        ".pytest_cache",
+        ".ruff_cache",
+        ".tox",
+        ".venv",
+        "__pycache__",
+        "build",
+        "coverage",
+        "dist",
+        "node_modules",
+        "skills_active",
+        "venv",
+    }
+)
+_CLAUDE_WORKSPACE_PROGRESS_SKIP_FILES = frozenset(
+    {
+        "live_streams.spool",
+    }
+)
 _CLAUDE_PR_RESOLVER_PROGRESS_FILES: tuple[Path, ...] = (
     Path("var/pr_resolver/result.json"),
     Path("var/pr_resolver/snapshot.json"),
@@ -147,7 +174,7 @@ class ClaudeCodeStrategy(ManagedRuntimeStrategy):
         run_id: str,
         started_at: datetime,
     ) -> datetime | None:
-        """Use MoonMind pr-resolver artifacts as a silent-run progress signal."""
+        """Use workspace file mtimes as a silent-run progress signal."""
 
         if not workspace_path:
             return None
@@ -160,7 +187,7 @@ class ClaudeCodeStrategy(ManagedRuntimeStrategy):
 
         threshold_ts = started_at.timestamp() - _CLAUDE_PROGRESS_MTIME_PADDING_SECONDS
         latest_ts: float | None = None
-        for candidate in self._iter_pr_resolver_progress_candidates(workspace_root):
+        for candidate in self._iter_progress_candidates(workspace_root):
             try:
                 stat = candidate.stat()
             except OSError:
@@ -175,6 +202,30 @@ class ClaudeCodeStrategy(ManagedRuntimeStrategy):
         return datetime.fromtimestamp(latest_ts, tz=UTC)
 
     @staticmethod
+    def _iter_progress_candidates(workspace_root: Path) -> Iterator[Path]:
+        yielded: set[Path] = set()
+        for candidate in ClaudeCodeStrategy._iter_pr_resolver_progress_candidates(
+            workspace_root
+        ):
+            try:
+                resolved = candidate.resolve()
+            except OSError:
+                resolved = candidate
+            yielded.add(resolved)
+            yield candidate
+
+        for candidate in ClaudeCodeStrategy._iter_workspace_progress_candidates(
+            workspace_root
+        ):
+            try:
+                resolved = candidate.resolve()
+            except OSError:
+                resolved = candidate
+            if resolved in yielded:
+                continue
+            yield candidate
+
+    @staticmethod
     def _iter_pr_resolver_progress_candidates(workspace_root: Path) -> Iterator[Path]:
         for rel_path in _CLAUDE_PR_RESOLVER_PROGRESS_FILES:
             yield workspace_root / rel_path
@@ -186,6 +237,40 @@ class ClaudeCodeStrategy(ManagedRuntimeStrategy):
         artifacts_dir = workspace_root / "artifacts"
         if artifacts_dir.is_dir():
             yield from artifacts_dir.glob("pr_resolver*.json")
+
+    @staticmethod
+    def _iter_workspace_progress_candidates(workspace_root: Path) -> Iterator[Path]:
+        pending: list[Path] = [workspace_root]
+        scanned_files = 0
+
+        while pending:
+            current = pending.pop()
+            try:
+                entries = list(current.iterdir())
+            except OSError:
+                continue
+
+            for entry in entries:
+                name = entry.name
+                if name in _CLAUDE_WORKSPACE_PROGRESS_SKIP_FILES:
+                    continue
+                try:
+                    if entry.is_symlink():
+                        continue
+                    if entry.is_dir():
+                        if name in _CLAUDE_WORKSPACE_PROGRESS_SKIP_DIRS:
+                            continue
+                        pending.append(entry)
+                        continue
+                    if not entry.is_file():
+                        continue
+                except OSError:
+                    continue
+
+                scanned_files += 1
+                yield entry
+                if scanned_files >= _CLAUDE_WORKSPACE_PROGRESS_MAX_FILES:
+                    return
 
     async def prepare_workspace(
         self,

--- a/moonmind/workflows/temporal/runtime/strategies/claude_code.py
+++ b/moonmind/workflows/temporal/runtime/strategies/claude_code.py
@@ -19,7 +19,6 @@ from moonmind.workflows.temporal.runtime.strategies.base import (
 from moonmind.workflows.provider_failures import classify_provider_failure
 
 _CLAUDE_PROGRESS_MTIME_PADDING_SECONDS = 5.0
-_CLAUDE_WORKSPACE_PROGRESS_MAX_FILES = 50_000
 _CLAUDE_WORKSPACE_PROGRESS_SKIP_DIRS = frozenset(
     {
         ".git",
@@ -203,9 +202,14 @@ class ClaudeCodeStrategy(ManagedRuntimeStrategy):
 
     @staticmethod
     def _iter_progress_candidates(workspace_root: Path) -> Iterator[Path]:
+        try:
+            resolved_root = workspace_root.resolve()
+        except OSError:
+            resolved_root = workspace_root
+
         yielded: set[Path] = set()
         for candidate in ClaudeCodeStrategy._iter_pr_resolver_progress_candidates(
-            workspace_root
+            resolved_root
         ):
             try:
                 resolved = candidate.resolve()
@@ -215,13 +219,9 @@ class ClaudeCodeStrategy(ManagedRuntimeStrategy):
             yield candidate
 
         for candidate in ClaudeCodeStrategy._iter_workspace_progress_candidates(
-            workspace_root
+            resolved_root
         ):
-            try:
-                resolved = candidate.resolve()
-            except OSError:
-                resolved = candidate
-            if resolved in yielded:
+            if candidate in yielded:
                 continue
             yield candidate
 
@@ -241,36 +241,30 @@ class ClaudeCodeStrategy(ManagedRuntimeStrategy):
     @staticmethod
     def _iter_workspace_progress_candidates(workspace_root: Path) -> Iterator[Path]:
         pending: list[Path] = [workspace_root]
-        scanned_files = 0
 
         while pending:
             current = pending.pop()
             try:
-                entries = list(current.iterdir())
+                for entry in current.iterdir():
+                    name = entry.name
+                    if name in _CLAUDE_WORKSPACE_PROGRESS_SKIP_FILES:
+                        continue
+                    try:
+                        if entry.is_symlink():
+                            continue
+                        if entry.is_dir():
+                            if name in _CLAUDE_WORKSPACE_PROGRESS_SKIP_DIRS:
+                                continue
+                            pending.append(entry)
+                            continue
+                        if not entry.is_file():
+                            continue
+                    except OSError:
+                        continue
+
+                    yield entry
             except OSError:
                 continue
-
-            for entry in entries:
-                name = entry.name
-                if name in _CLAUDE_WORKSPACE_PROGRESS_SKIP_FILES:
-                    continue
-                try:
-                    if entry.is_symlink():
-                        continue
-                    if entry.is_dir():
-                        if name in _CLAUDE_WORKSPACE_PROGRESS_SKIP_DIRS:
-                            continue
-                        pending.append(entry)
-                        continue
-                    if not entry.is_file():
-                        continue
-                except OSError:
-                    continue
-
-                scanned_files += 1
-                yield entry
-                if scanned_files >= _CLAUDE_WORKSPACE_PROGRESS_MAX_FILES:
-                    return
 
     async def prepare_workspace(
         self,

--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -315,6 +315,9 @@ RUNTIME_SELECTION_PROFILE_CLEAR_PATCH_ID = (
     "agent-run-runtime-selection-profile-clear-v1"
 )
 AGENT_RUN_RESILIENCY_POLICY_PATCH_ID = "agent-run-resiliency-policy-v1"
+AGENT_RUN_CLAUDE_NO_PROGRESS_POLICY_PATCH_ID = (
+    "agent-run-claude-code-no-progress-policy-v2"
+)
 # Prefer the canonical structured provider failure event (retry_after_seconds /
 # reset_at / quota_scope / provider_error_class) when deciding profile cooldowns,
 # falling back to text-marker classification only when the structured fields are
@@ -953,6 +956,8 @@ class MoonMindAgentRun:
     @staticmethod
     def _resiliency_policy_for_request(
         request: AgentExecutionRequest,
+        *,
+        use_extended_claude_no_progress_window: bool = True,
     ) -> dict[str, Any]:
         """Return runtime-specific retry and stuck-detection policy metadata."""
 
@@ -988,10 +993,15 @@ class MoonMindAgentRun:
                 "retryPolicy": "session_turn_self_heal_then_cooldown_retry",
             }
         if runtime_id == "claude_code":
+            no_progress_timeout_seconds = 1500
+            no_progress_grace_seconds = 600
+            if use_extended_claude_no_progress_window:
+                no_progress_timeout_seconds = _CLAUDE_CODE_NO_PROGRESS_TIMEOUT_SECONDS
+                no_progress_grace_seconds = _CLAUDE_CODE_NO_PROGRESS_GRACE_SECONDS
             return {
                 "runtime": runtime_id,
-                "noProgressTimeoutSeconds": _CLAUDE_CODE_NO_PROGRESS_TIMEOUT_SECONDS,
-                "noProgressGraceSeconds": _CLAUDE_CODE_NO_PROGRESS_GRACE_SECONDS,
+                "noProgressTimeoutSeconds": no_progress_timeout_seconds,
+                "noProgressGraceSeconds": no_progress_grace_seconds,
                 "stuckAction": "request_intervention",
                 "retryPolicy": "managed_runtime_polling_with_profile_cooldown",
             }
@@ -3031,7 +3041,20 @@ class MoonMindAgentRun:
         requested_execution_profile_ref = request.execution_profile_ref
         resiliency_policy: Mapping[str, Any] = {}
         if workflow.patched(AGENT_RUN_RESILIENCY_POLICY_PATCH_ID):
-            resiliency_policy = self._resiliency_policy_for_request(request)
+            use_extended_claude_no_progress_window = True
+            if (
+                request.agent_kind == "managed"
+                and self._managed_runtime_id(request.agent_id) == "claude_code"
+            ):
+                use_extended_claude_no_progress_window = workflow.patched(
+                    AGENT_RUN_CLAUDE_NO_PROGRESS_POLICY_PATCH_ID
+                )
+            resiliency_policy = self._resiliency_policy_for_request(
+                request,
+                use_extended_claude_no_progress_window=(
+                    use_extended_claude_no_progress_window
+                ),
+            )
 
         try:
             while True:

--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -361,6 +361,8 @@ DEFAULT_ACTIVITY_CATALOG = build_default_activity_catalog()
 _SLOT_WAIT_TIMEOUT_SECONDS = 120
 _SLOT_WAIT_MAX_RESETS = 3
 _DEFAULT_NO_PROGRESS_TIMEOUT_SECONDS = 1800
+_CLAUDE_CODE_NO_PROGRESS_TIMEOUT_SECONDS = 2400
+_CLAUDE_CODE_NO_PROGRESS_GRACE_SECONDS = 900
 _DEFAULT_MANAGED_429_RETRY_DELAY_SECONDS = 900
 _MAX_PROVIDER_COOLDOWN_BACKOFF_SECONDS = 3600
 _MANAGED_RUNTIME_STORE_ROOT = os.environ.get(
@@ -988,8 +990,8 @@ class MoonMindAgentRun:
         if runtime_id == "claude_code":
             return {
                 "runtime": runtime_id,
-                "noProgressTimeoutSeconds": 1500,
-                "noProgressGraceSeconds": 600,
+                "noProgressTimeoutSeconds": _CLAUDE_CODE_NO_PROGRESS_TIMEOUT_SECONDS,
+                "noProgressGraceSeconds": _CLAUDE_CODE_NO_PROGRESS_GRACE_SECONDS,
                 "stuckAction": "request_intervention",
                 "retryPolicy": "managed_runtime_polling_with_profile_cooldown",
             }

--- a/tests/unit/services/temporal/runtime/test_supervisor.py
+++ b/tests/unit/services/temporal/runtime/test_supervisor.py
@@ -761,6 +761,61 @@ async def test_heartbeat_persists_claude_pr_resolver_artifact_progress(
     assert result.status == "completed"
     assert any("last_log_at" in update for update in running_updates)
 
+
+@pytest.mark.asyncio
+async def test_heartbeat_persists_claude_workspace_file_progress(
+    supervisor_env,
+    tmp_path,
+):
+    store, _, _, supervisor = supervisor_env
+    workspace_path = tmp_path / "repo"
+    source_path = workspace_path / "frontend" / "src" / "workflow-detail.tsx"
+    workspace_path.mkdir(parents=True)
+    record = ManagedRunRecord(
+        run_id="run-1",
+        agent_id="agent-1",
+        runtime_id="claude_code",
+        status="launching",
+        started_at=datetime.now(tz=UTC),
+        workspace_path=str(workspace_path),
+    )
+    store.save(record)
+
+    process = await asyncio.create_subprocess_exec(
+        "sleep", "1",
+        stdin=asyncio.subprocess.DEVNULL,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+
+    async def _write_source_file() -> None:
+        await asyncio.sleep(0.1)
+        source_path.parent.mkdir(parents=True)
+        source_path.write_text("export const changed = true;\n", encoding="utf-8")
+
+    progress_writer = asyncio.create_task(_write_source_file())
+    running_updates: list[dict] = []
+    original_update = store.update_status
+
+    def _spy_update(run_id, status, **kwargs):
+        if status == "running":
+            running_updates.append(dict(kwargs))
+        return original_update(run_id, status, **kwargs)
+
+    with patch(
+        "moonmind.workflows.temporal.runtime.supervisor.HEARTBEAT_INTERVAL",
+        0.1,
+    ):
+        with patch.object(store, "update_status", side_effect=_spy_update):
+            result = await supervisor.supervise(
+                run_id="run-1", process=process, timeout_seconds=30
+            )
+    writer_result = await progress_writer
+    assert writer_result is None
+
+    assert result.status == "completed"
+    assert any("last_log_at" in update for update in running_updates)
+
 # ---------------------------------------------------------------------------
 # Completion callback tests
 # ---------------------------------------------------------------------------

--- a/tests/unit/workflows/temporal/runtime/strategies/test_remaining_strategies.py
+++ b/tests/unit/workflows/temporal/runtime/strategies/test_remaining_strategies.py
@@ -219,6 +219,61 @@ class TestClaudeCodeProgressProbe:
 
         assert observed is None
 
+    def test_probe_progress_uses_workspace_source_file_mtime(self, tmp_path) -> None:
+        strategy = ClaudeCodeStrategy()
+        workspace_path = tmp_path / "repo"
+        source_path = workspace_path / "frontend" / "src" / "workflow-detail.tsx"
+        git_index = workspace_path / ".git" / "index"
+        live_spool = workspace_path / "live_streams.spool"
+        source_path.parent.mkdir(parents=True)
+        git_index.parent.mkdir(parents=True)
+        source_path.write_text("export const changed = true;\n", encoding="utf-8")
+        git_index.write_text("git metadata", encoding="utf-8")
+        live_spool.write_text("system annotation", encoding="utf-8")
+
+        started_at = datetime(2026, 7, 7, 23, 11, 26, tzinfo=UTC)
+        expected_progress_at = datetime(2026, 7, 7, 23, 44, 58, tzinfo=UTC)
+        later_internal_ts = datetime(2026, 7, 7, 23, 45, 30, tzinfo=UTC).timestamp()
+        os.utime(
+            source_path,
+            (expected_progress_at.timestamp(), expected_progress_at.timestamp()),
+        )
+        os.utime(git_index, (later_internal_ts, later_internal_ts))
+        os.utime(live_spool, (later_internal_ts, later_internal_ts))
+
+        observed = strategy.probe_progress_at(
+            workspace_path=str(workspace_path),
+            run_id="run-source-progress",
+            started_at=started_at,
+        )
+
+        assert observed == expected_progress_at
+
+    def test_probe_progress_ignores_internal_only_workspace_updates(
+        self,
+        tmp_path,
+    ) -> None:
+        strategy = ClaudeCodeStrategy()
+        workspace_path = tmp_path / "repo"
+        git_index = workspace_path / ".git" / "index"
+        live_spool = workspace_path / "live_streams.spool"
+        git_index.parent.mkdir(parents=True)
+        git_index.write_text("git metadata", encoding="utf-8")
+        live_spool.write_text("system annotation", encoding="utf-8")
+
+        started_at = datetime(2026, 7, 7, 23, 11, 26, tzinfo=UTC)
+        internal_ts = datetime(2026, 7, 7, 23, 45, 30, tzinfo=UTC).timestamp()
+        os.utime(git_index, (internal_ts, internal_ts))
+        os.utime(live_spool, (internal_ts, internal_ts))
+
+        observed = strategy.probe_progress_at(
+            workspace_path=str(workspace_path),
+            run_id="run-internal-only",
+            started_at=started_at,
+        )
+
+        assert observed is None
+
 
 _RUNTIME_MODEL_ENV_KEYS = (
     "MOONMIND_CODEX_MODEL",

--- a/tests/unit/workflows/temporal/workflows/test_agent_run_status_payloads.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_run_status_payloads.py
@@ -78,9 +78,16 @@ def test_resiliency_policy_is_runtime_specific() -> None:
         correlationId="run-2",
         idempotencyKey="run-2:step-1",
     )
+    claude_request = AgentExecutionRequest(
+        agentKind="managed",
+        agentId="claude_code",
+        correlationId="run-3",
+        idempotencyKey="run-3:step-1",
+    )
 
     codex_policy = MoonMindAgentRun._resiliency_policy_for_request(codex_request)
     jules_policy = MoonMindAgentRun._resiliency_policy_for_request(jules_request)
+    claude_policy = MoonMindAgentRun._resiliency_policy_for_request(claude_request)
 
     assert codex_policy["runtime"] == "codex_cli"
     assert codex_policy["retryPolicy"] == "session_turn_self_heal_then_cooldown_retry"
@@ -92,6 +99,9 @@ def test_resiliency_policy_is_runtime_specific() -> None:
     assert codex_policy["noProgressTimeoutSeconds"] != jules_policy[
         "noProgressTimeoutSeconds"
     ]
+    assert claude_policy["runtime"] == "claude_code"
+    assert claude_policy["noProgressTimeoutSeconds"] == 2400
+    assert claude_policy["noProgressGraceSeconds"] == 900
 
 def test_status_progress_signature_tracks_metadata_progress_keys() -> None:
     first = AgentRunStatus(

--- a/tests/unit/workflows/temporal/workflows/test_agent_run_status_payloads.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_run_status_payloads.py
@@ -103,6 +103,23 @@ def test_resiliency_policy_is_runtime_specific() -> None:
     assert claude_policy["noProgressTimeoutSeconds"] == 2400
     assert claude_policy["noProgressGraceSeconds"] == 900
 
+def test_claude_resiliency_policy_preserves_legacy_window_for_replay() -> None:
+    claude_request = AgentExecutionRequest(
+        agentKind="managed",
+        agentId="claude_code",
+        correlationId="run-1",
+        idempotencyKey="run-1:step-1",
+    )
+
+    policy = MoonMindAgentRun._resiliency_policy_for_request(
+        claude_request,
+        use_extended_claude_no_progress_window=False,
+    )
+
+    assert policy["runtime"] == "claude_code"
+    assert policy["noProgressTimeoutSeconds"] == 1500
+    assert policy["noProgressGraceSeconds"] == 600
+
 def test_status_progress_signature_tracks_metadata_progress_keys() -> None:
     first = AgentRunStatus(
         runId="run-1",


### PR DESCRIPTION
## Summary

Fixes a false no-progress intervention path for quiet Claude Code managed runs.

## What changed

- Treat ordinary workspace file mtimes as Claude Code silent-run progress while ignoring `.git`, common cache/dependency directories, and MoonMind's own `live_streams.spool`.
- Increase the Claude Code workflow no-progress window from `1500s + 600s` grace to `2400s + 900s` grace.
- Add regression coverage for workspace-file progress, internal-only updates, supervisor status persistence, and the new runtime-specific policy values.

## Root cause

Claude Code managed runs can edit files without emitting stdout/stderr. The previous progress probe only recognized a narrow set of pr-resolver artifacts, so a normal implementation run could keep changing source files while the workflow-level watchdog saw no `lastLogAt`/`lastLogOffset` movement and escalated to intervention.

## Validation

- `./tools/test_unit.sh tests/unit/workflows/temporal/runtime/strategies/test_remaining_strategies.py tests/unit/services/temporal/runtime/test_supervisor.py tests/unit/workflows/temporal/workflows/test_agent_run_status_payloads.py`
- `./tools/test_unit.sh tests/unit/workflows/temporal/runtime/strategies/test_remaining_strategies.py`
- `git diff --check`