### PR TITLE
[codex] Fix Jira assessment verdict heading parsing

### DIFF
--- a/moonmind/workflows/temporal/story_output_tools.py
+++ b/moonmind/workflows/temporal/story_output_tools.py
@@ -4528,7 +4528,7 @@ def _assessment_verdict_from_text(value: Any) -> str:
     assessment_separator = r"[\s:.,;!?\-\u2010-\u2015`*_\"'\[\]\(\)]*"
     issue_ref_pattern = r"`?[A-Z][A-Z0-9]+-\d+`?"
     patterns = (
-        r"(?is)(?:^|[\s.])#{1,6}\s*verdict\s*[:\-]\s*"
+        r"(?im)^\s*#{1,6}\s*verdict\s*[:\-]\s*"
         rf"{verdict_prefix}{verdict_pattern}{verdict_suffix}",
         r"(?im)^\s*verdict\s*[:\-]\s*"
         rf"{verdict_prefix}{verdict_pattern}{verdict_suffix}",

--- a/moonmind/workflows/temporal/story_output_tools.py
+++ b/moonmind/workflows/temporal/story_output_tools.py
@@ -4528,6 +4528,8 @@ def _assessment_verdict_from_text(value: Any) -> str:
     assessment_separator = r"[\s:.,;!?\-\u2010-\u2015`*_\"'\[\]\(\)]*"
     issue_ref_pattern = r"`?[A-Z][A-Z0-9]+-\d+`?"
     patterns = (
+        r"(?is)(?:^|[\s.])#{1,6}\s*verdict\s*[:\-]\s*"
+        rf"{verdict_prefix}{verdict_pattern}{verdict_suffix}",
         r"(?im)^\s*verdict\s*[:\-]\s*"
         rf"{verdict_prefix}{verdict_pattern}{verdict_suffix}",
         r"(?is)\bassessment\s+complete\b"

--- a/tests/unit/workflows/temporal/test_story_output_tools.py
+++ b/tests/unit/workflows/temporal/test_story_output_tools.py
@@ -982,6 +982,47 @@ async def test_update_jira_issue_status_accepts_concise_previous_verdict(
 
 
 @pytest.mark.asyncio
+async def test_update_jira_issue_status_accepts_markdown_heading_previous_verdict(
+    tmp_path,
+) -> None:
+    service = _FakeJiraService()
+    service.issue_responses["MM-1139"] = {
+        "key": "MM-1139",
+        "fields": {"status": {"id": "1", "name": "Backlog"}},
+    }
+    service.transition_responses["MM-1139"] = {
+        "key": "MM-1139",
+        "fields": {"status": {"id": "3", "name": "In Progress"}},
+    }
+    service.transitions_response = {
+        "transitions": [
+            {"id": "31", "name": "In Progress", "to": {"name": "In Progress"}}
+        ]
+    }
+
+    result = await update_jira_issue_status(
+        {
+            "issueKey": "MM-1139",
+            "targetStatus": "In Progress",
+            "assessmentArtifactPath": str(tmp_path / "missing-assessment.json"),
+            "previousOutputs": {
+                "summary": (
+                    "Both handoff artifacts are written and valid. "
+                    "Here is the assessment result.\n\n"
+                    "## Verdict: NOT_IMPLEMENTED\n\n"
+                    "Evidence follows."
+                ),
+            },
+        },
+        jira_service_factory=lambda: service,
+    )
+
+    assert result.status == "COMPLETED"
+    assert result.outputs["decision"] == "transitioned"
+    assert service.transition_requests[0].transition_id == "31"
+
+
+@pytest.mark.asyncio
 async def test_update_jira_issue_status_blocks_for_malformed_assessment_artifact(
     tmp_path,
 ) -> None:
@@ -3429,6 +3470,35 @@ async def test_check_jira_blockers_preserves_sentence_previous_assessment_verdic
     assert result.status == "COMPLETED"
     assert result.outputs["decision"] == "continue"
     assert result.outputs["assessmentVerdict"] == "PARTIALLY_IMPLEMENTED"
+
+
+@pytest.mark.asyncio
+async def test_check_jira_blockers_preserves_markdown_heading_previous_assessment_verdict():
+    service = _FakeJiraService()
+    service.issue_responses["MM-1139"] = {
+        "key": "MM-1139",
+        "fields": {"issuelinks": []},
+    }
+
+    result = await check_jira_blockers(
+        {
+            "targetIssueKey": "MM-1139",
+            "assessmentArtifactPath": "artifacts/jira-implement-assessment.json",
+            "previousOutputs": {
+                "summary": (
+                    "Both handoff artifacts are written and valid. "
+                    "Here is the assessment result.\n\n"
+                    "## Verdict: NOT_IMPLEMENTED\n\n"
+                    "Evidence follows."
+                ),
+            },
+        },
+        jira_service_factory=lambda: service,
+    )
+
+    assert result.status == "COMPLETED"
+    assert result.outputs["decision"] == "continue"
+    assert result.outputs["assessmentVerdict"] == "NOT_IMPLEMENTED"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/workflows/temporal/test_story_output_tools.py
+++ b/tests/unit/workflows/temporal/test_story_output_tools.py
@@ -1009,7 +1009,7 @@ async def test_update_jira_issue_status_accepts_markdown_heading_previous_verdic
                 "summary": (
                     "Both handoff artifacts are written and valid. "
                     "Here is the assessment result.\n\n"
-                    "## Verdict: NOT_IMPLEMENTED\n\n"
+                    "  ## Verdict: NOT_IMPLEMENTED\n\n"
                     "Evidence follows."
                 ),
             },
@@ -3488,7 +3488,7 @@ async def test_check_jira_blockers_preserves_markdown_heading_previous_assessmen
                 "summary": (
                     "Both handoff artifacts are written and valid. "
                     "Here is the assessment result.\n\n"
-                    "## Verdict: NOT_IMPLEMENTED\n\n"
+                    "  ## Verdict: NOT_IMPLEMENTED\n\n"
                     "Evidence follows."
                 ),
             },


### PR DESCRIPTION
## Summary

Fixes Jira workflow status preflight handling when an assessment agent reports its verdict as a Markdown heading such as `## Verdict: NOT_IMPLEMENTED`.

## Root Cause

Workflow `mm:58666ee3-55dc-4efd-8ab2-7d85fd73193c` failed at `jira.update_issue_status` because the prior assessment verdict was present only in the agent summary as a Markdown heading. The deterministic Jira tools parsed plain `Verdict: ...` text and several assessment-complete variants, but not Markdown heading verdicts, so the blocker/status handoff treated the assessment verdict as unavailable.

## Changes

- Teach assessment verdict parsing to recognize Markdown heading verdicts.
- Add regression coverage for both `jira.check_blockers` preserving that verdict and `jira.update_issue_status` using it when the local assessment artifact path is unavailable.

## Validation

- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_story_output_tools.py`
- The wrapper also completed the frontend unit segment: 58 files passed, 897 tests passed, 238 skipped.