### PR TITLE
There is a bug where if I click on the "Full screen table" radio button in the nav bar while it's already selected, the page will stay in the same vie

### DIFF
--- a/frontend/src/entrypoints/dashboard-app.tsx
+++ b/frontend/src/entrypoints/dashboard-app.tsx
@@ -755,7 +755,7 @@ function RoutedDashboardPage({
       // `sidebar` whenever a preference change fires (for example when the
       // already-selected "Full screen table" button re-persists preferences),
       // so leave the route-owned `table` mode untouched on this surface.
-      if (location.pathname.replace(/\/$/, '') !== '/workflows') {
+      if (window.location.pathname.replace(/\/$/, '') !== '/workflows') {
         setRequestedMode(prefs.workflowWorkspaceSidebarCollapsed ? 'hidden' : 'sidebar');
       }
       setLastSelectedWorkflowId(prefs.lastSelectedWorkflowId.trim() || null);
@@ -766,7 +766,7 @@ function RoutedDashboardPage({
       window.removeEventListener(DASHBOARD_PREFERENCES_CHANGED_EVENT, syncPreferences);
       window.removeEventListener('storage', syncPreferences);
     };
-  }, [location.pathname]);
+  }, []);
 
   useEffect(() => {
     const normalizedPath = location.pathname.replace(/\/$/, '');

--- a/frontend/src/entrypoints/dashboard-app.tsx
+++ b/frontend/src/entrypoints/dashboard-app.tsx
@@ -749,7 +749,15 @@ function RoutedDashboardPage({
   useEffect(() => {
     const syncPreferences = () => {
       const prefs = readDashboardPreferences();
-      setRequestedMode(prefs.workflowWorkspaceSidebarCollapsed ? 'hidden' : 'sidebar');
+      // The `/workflows` route is always the full-screen table surface, and
+      // `table` is not representable in the persisted collapse boolean. Deriving
+      // the mode from that boolean here would clobber the table selection back to
+      // `sidebar` whenever a preference change fires (for example when the
+      // already-selected "Full screen table" button re-persists preferences),
+      // so leave the route-owned `table` mode untouched on this surface.
+      if (location.pathname.replace(/\/$/, '') !== '/workflows') {
+        setRequestedMode(prefs.workflowWorkspaceSidebarCollapsed ? 'hidden' : 'sidebar');
+      }
       setLastSelectedWorkflowId(prefs.lastSelectedWorkflowId.trim() || null);
     };
     window.addEventListener(DASHBOARD_PREFERENCES_CHANGED_EVENT, syncPreferences);
@@ -758,7 +766,7 @@ function RoutedDashboardPage({
       window.removeEventListener(DASHBOARD_PREFERENCES_CHANGED_EVENT, syncPreferences);
       window.removeEventListener('storage', syncPreferences);
     };
-  }, []);
+  }, [location.pathname]);
 
   useEffect(() => {
     const normalizedPath = location.pathname.replace(/\/$/, '');

--- a/frontend/src/entrypoints/dashboard.test.tsx
+++ b/frontend/src/entrypoints/dashboard.test.tsx
@@ -418,6 +418,23 @@ describe('Dashboard shared entry', () => {
     expect(screen.queryByRole('link', { name: 'Expand to full list' })).toBeNull();
   });
 
+  it('keeps the full screen table selected when its radio button is re-clicked on the workflows table', async () => {
+    window.history.replaceState({}, '', '/workflows');
+    updateDashboardPreferences({ lastSelectedWorkflowId: 'mm:97d44980-355c-4300-96a7-0ad166440d95' });
+    renderWithClient(<DashboardApp payload={{ page: 'dashboard', apiBase: '/api' }} />);
+
+    await screen.findByText('Workflow list route loaded', {}, { timeout: 10000 });
+
+    const tableButton = screen.getByRole('button', { name: 'Full screen table' });
+    expect(tableButton.getAttribute('aria-pressed')).toBe('true');
+
+    fireEvent.click(tableButton);
+
+    expect(screen.getByRole('button', { name: 'Full screen table' }).getAttribute('aria-pressed')).toBe('true');
+    expect(screen.getByRole('button', { name: 'Sidebar list' }).getAttribute('aria-pressed')).toBe('false');
+    expect(window.location.pathname).toBe('/workflows');
+  });
+
   it('opens a visible workflow when sidebar mode is selected from the workflows table', async () => {
     window.history.replaceState({}, '', '/workflows?source=temporal');
     renderWithClient(<DashboardApp payload={{ page: 'dashboard', apiBase: '/api' }} />);


### PR DESCRIPTION
There is a bug where if I click on the "Full screen table" radio button in the nav bar while it's already selected, the page will stay in the same view but the radio button will shift to highlighting the "Sidebar list" button instead of the "Full screen table" button. Fix this bug.