### PR TITLE
MoonLadderStudios/MoonMind#3068 Redesign Recurring schedules workspace

### DIFF
--- a/frontend/src/components/dashboard/LoadingPlaceholder.tsx
+++ b/frontend/src/components/dashboard/LoadingPlaceholder.tsx
@@ -34,7 +34,7 @@ const surfaceLabels: Record<LoadingPlaceholderSurface, string> = {
   'workflow-list': 'Workflow list',
   'workflow-detail': 'Workflow detail',
   settings: 'Settings',
-  schedules: 'Schedules',
+  schedules: 'Recurring',
   manifests: 'Manifests',
   skills: 'Skills',
   'workflow-start': 'Workflow start',

--- a/frontend/src/entrypoints/dashboard-app.tsx
+++ b/frontend/src/entrypoints/dashboard-app.tsx
@@ -568,6 +568,9 @@ function WorkflowListDisplayModeControl({
 
     event.preventDefault();
     const nextMode = WORKFLOW_LIST_DISPLAY_MODES[nextIndex];
+    if (!nextMode) {
+      return;
+    }
     onSelect(nextMode.value);
     const nextRadio = event.currentTarget.parentElement?.querySelector<HTMLButtonElement>(
       `[data-list-display-mode="${nextMode.value}"]`,
@@ -652,7 +655,7 @@ function DashboardNavigation({
 
       {workflowListMode ? (
         <WorkflowListDisplayModeControl
-          accessibleName={listDisplayAccessibleName}
+          {...(listDisplayAccessibleName ? { accessibleName: listDisplayAccessibleName } : {})}
           effectiveMode={workflowListMode}
           status={workflowListDisplayStatus}
           onSelect={onWorkflowListModeSelect}

--- a/frontend/src/entrypoints/dashboard-app.tsx
+++ b/frontend/src/entrypoints/dashboard-app.tsx
@@ -248,12 +248,12 @@ async function firstVisibleWorkflowId(apiBase: string, search: URLSearchParams):
 }
 
 async function firstVisibleRecurringDefinitionId(apiBase: string): Promise<string | null> {
-  const response = await fetch(`${apiBase}/recurring-tasks?scope=personal`, { credentials: 'include' });
+  const response = await fetch(`${apiBase}/recurring-workflows?scope=personal`, { credentials: 'include' });
   if (!response.ok) {
     throw new Error(`Recurring schedule list request failed: ${response.status}`);
   }
-  const payload = (await response.json()) as { items?: Array<{ id?: unknown; definitionId?: unknown }> };
-  const first = payload.items?.find((item) => (
+  const payload = (await response.json()) as { items?: Array<{ id?: unknown; definitionId?: unknown }> } | null;
+  const first = payload?.items?.find((item) => (
     (typeof item.id === 'string' && item.id.trim()) ||
     (typeof item.definitionId === 'string' && item.definitionId.trim())
   ));
@@ -263,6 +263,15 @@ async function firstVisibleRecurringDefinitionId(apiBase: string): Promise<strin
   return typeof first.id === 'string' && first.id.trim()
     ? first.id.trim()
     : String(first.definitionId).trim();
+}
+
+async function authorizedRecurringDefinitionId(apiBase: string, definitionId: string): Promise<string | null> {
+  const encoded = encodeURIComponent(definitionId);
+  const response = await fetch(`${apiBase}/recurring-workflows/${encoded}`, { credentials: 'include' });
+  if (!response.ok) {
+    return null;
+  }
+  return definitionId;
 }
 
 function readSharedLayout(payload: BootPayload): SharedLayoutConfig {
@@ -876,7 +885,14 @@ function RoutedDashboardPage({
         setRequestedRecurringMode(selectedMode);
         setResolutionStatus('Opening first recurring schedule...');
         try {
-          const targetDefinitionId = lastSelectedDefinitionId?.trim() || await firstVisibleRecurringDefinitionId(apiBase);
+          const rememberedId = lastSelectedDefinitionId?.trim() || '';
+          const authorizedRememberedId = rememberedId
+            ? await authorizedRecurringDefinitionId(apiBase, rememberedId)
+            : null;
+          if (pendingRequestRef.current !== requestId) {
+            return;
+          }
+          const targetDefinitionId = authorizedRememberedId || await firstVisibleRecurringDefinitionId(apiBase);
           if (pendingRequestRef.current !== requestId) {
             return;
           }

--- a/frontend/src/entrypoints/dashboard-app.tsx
+++ b/frontend/src/entrypoints/dashboard-app.tsx
@@ -45,6 +45,7 @@ import {
 } from '../lib/dashboardRoutes';
 import {
   WORKFLOW_LIST_DISPLAY_MODES,
+  resolveRecurringListDisplay,
   resolveWorkflowListDisplay,
   type WorkflowListDisplayMode,
 } from '../lib/workflowListDisplayMode';
@@ -243,6 +244,24 @@ async function firstVisibleWorkflowId(apiBase: string, search: URLSearchParams):
   const items = body && typeof body === 'object' && Array.isArray(body.items) ? body.items : null;
   const firstRow = items ? items.find((row) => workflowRowId(row)) : null;
   return firstRow ? workflowRowId(firstRow) : null;
+}
+
+async function firstVisibleRecurringDefinitionId(apiBase: string): Promise<string | null> {
+  const response = await fetch(`${apiBase}/recurring-tasks?scope=personal`, { credentials: 'include' });
+  if (!response.ok) {
+    throw new Error(`Recurring schedule list request failed: ${response.status}`);
+  }
+  const payload = (await response.json()) as { items?: Array<{ id?: unknown; definitionId?: unknown }> };
+  const first = payload.items?.find((item) => (
+    (typeof item.id === 'string' && item.id.trim()) ||
+    (typeof item.definitionId === 'string' && item.definitionId.trim())
+  ));
+  if (!first) {
+    return null;
+  }
+  return typeof first.id === 'string' && first.id.trim()
+    ? first.id.trim()
+    : String(first.definitionId).trim();
 }
 
 function readSharedLayout(payload: BootPayload): SharedLayoutConfig {
@@ -506,10 +525,12 @@ function DashboardLiveUpdateProvider({
 }
 
 function WorkflowListDisplayModeControl({
+  accessibleName = 'Workflow list display',
   effectiveMode,
   status,
   onSelect,
 }: {
+  accessibleName?: string;
   effectiveMode: WorkflowListDisplayMode;
   status?: string | null | undefined;
   onSelect: (mode: WorkflowListDisplayMode) => void;
@@ -517,8 +538,8 @@ function WorkflowListDisplayModeControl({
   return (
     <div
       className="workflow-list-display-control"
-      role="group"
-      aria-label="Workflow list display"
+      role="radiogroup"
+      aria-label={accessibleName}
     >
       {WORKFLOW_LIST_DISPLAY_MODES.map((mode) => {
         const Icon = iconForWorkflowListMode(mode.icon);
@@ -548,11 +569,13 @@ function WorkflowListDisplayModeControl({
 
 function DashboardNavigation({
   uiInfo,
+  listDisplayAccessibleName,
   workflowListMode,
   workflowListDisplayStatus,
   onWorkflowListModeSelect,
 }: {
   uiInfo: DashboardUiInfo | null;
+  listDisplayAccessibleName?: string | undefined;
   workflowListMode: WorkflowListDisplayMode | null;
   workflowListDisplayStatus?: string | null | undefined;
   onWorkflowListModeSelect: (mode: WorkflowListDisplayMode) => void;
@@ -585,6 +608,7 @@ function DashboardNavigation({
 
       {workflowListMode ? (
         <WorkflowListDisplayModeControl
+          accessibleName={listDisplayAccessibleName}
           effectiveMode={workflowListMode}
           status={workflowListDisplayStatus}
           onSelect={onWorkflowListModeSelect}
@@ -628,7 +652,7 @@ function DashboardNavigation({
             icon={SchedulesNavIcon}
             className={({ isActive }) => (isActive ? 'active' : undefined)}
           >
-            Schedules
+            Recurring
           </AnimatedRouteNavLink>
           <AnimatedRouteNavLink
             to="/skills"
@@ -661,6 +685,7 @@ function DashboardNavigation({
 function AppShell({
   dataWidePanel,
   uiInfo,
+  listDisplayAccessibleName,
   workflowListMode,
   workflowListDisplayStatus,
   onWorkflowListModeSelect,
@@ -668,6 +693,7 @@ function AppShell({
 }: {
   dataWidePanel: boolean;
   uiInfo: DashboardUiInfo | null;
+  listDisplayAccessibleName?: string | undefined;
   workflowListMode: WorkflowListDisplayMode | null;
   workflowListDisplayStatus?: string | null | undefined;
   onWorkflowListModeSelect: (mode: WorkflowListDisplayMode) => void;
@@ -691,6 +717,7 @@ function AppShell({
         <div className="dashboard-shell-full">
           <DashboardNavigation
             uiInfo={uiInfo}
+            listDisplayAccessibleName={listDisplayAccessibleName}
             workflowListMode={workflowListMode}
             workflowListDisplayStatus={workflowListDisplayStatus}
             onWorkflowListModeSelect={onWorkflowListModeSelect}
@@ -725,9 +752,11 @@ function RoutedDashboardPage({
   const [requestedMode, setRequestedMode] = useState<WorkflowListDisplayMode>(() => (
     readDashboardPreferences().workflowWorkspaceSidebarCollapsed ? 'hidden' : 'sidebar'
   ));
+  const [requestedRecurringMode, setRequestedRecurringMode] = useState<WorkflowListDisplayMode>('table');
   const [lastSelectedWorkflowId, setLastSelectedWorkflowId] = useState<string | null>(
     () => readDashboardPreferences().lastSelectedWorkflowId.trim() || null,
   );
+  const [lastSelectedDefinitionId, setLastSelectedDefinitionId] = useState<string | null>(null);
   const [resolutionStatus, setResolutionStatus] = useState<string | null>(null);
   const route = resolveDashboardRoute(location.pathname);
   const apiBase = typeof uiInfo?.apiBase === 'string' ? uiInfo.apiBase : '/api';
@@ -738,11 +767,35 @@ function RoutedDashboardPage({
     selectedWorkflowId: lastSelectedWorkflowId,
     firstVisibleWorkflowId: null,
   });
+  const resolvedRecurringDisplay = resolveRecurringListDisplay({
+    pathname: location.pathname,
+    search: location.search,
+    requestedMode: requestedRecurringMode,
+    selectedDefinitionId: lastSelectedDefinitionId,
+    firstVisibleDefinitionId: null,
+  });
+  const activeListDisplay = resolvedDisplay ?? resolvedRecurringDisplay;
+  const activeListDisplayAccessibleName = resolvedRecurringDisplay
+    ? 'Recurring list display'
+    : resolvedDisplay
+      ? 'Workflow list display'
+      : undefined;
 
   useEffect(() => {
     const routeWorkflowId = decodeWorkflowIdFromPath(location.pathname);
     if (routeWorkflowId) {
       setLastSelectedWorkflowId(routeWorkflowId);
+    }
+    const match = location.pathname.match(/^\/schedules\/([^/]+)$/);
+    if (match) {
+      try {
+        const definitionId = decodeURIComponent(match[1] || '').trim();
+        if (definitionId) {
+          setLastSelectedDefinitionId(definitionId);
+        }
+      } catch {
+        // Ignore malformed paths; route validation handles unsupported pages.
+      }
     }
   }, [location.pathname, location.search]);
 
@@ -766,6 +819,10 @@ function RoutedDashboardPage({
       setRequestedMode('table');
     } else if (normalizedPath.startsWith('/workflows/') && normalizedPath !== '/workflows/new') {
       setRequestedMode((mode) => (mode === 'table' ? 'sidebar' : mode));
+    } else if (normalizedPath === '/schedules') {
+      setRequestedRecurringMode('table');
+    } else if (normalizedPath.startsWith('/schedules/')) {
+      setRequestedRecurringMode((mode) => (mode === 'table' ? 'sidebar' : mode));
     }
     pendingRequestRef.current = null;
     setResolutionStatus(null);
@@ -776,6 +833,53 @@ function RoutedDashboardPage({
     const search = new URLSearchParams(location.search);
     pendingRequestRef.current = null;
     setResolutionStatus(null);
+
+    if (resolvedRecurringDisplay) {
+      if (location.pathname.replace(/\/$/, '') === '/schedules' && selectedMode !== 'table') {
+        const requestId = Symbol();
+        pendingRequestRef.current = requestId;
+        setRequestedRecurringMode(selectedMode);
+        setResolutionStatus('Opening first recurring schedule...');
+        try {
+          const targetDefinitionId = lastSelectedDefinitionId?.trim() || await firstVisibleRecurringDefinitionId(apiBase);
+          if (pendingRequestRef.current !== requestId) {
+            return;
+          }
+          if (!targetDefinitionId) {
+            setResolutionStatus('No recurring schedule to open.');
+            return;
+          }
+          setLastSelectedDefinitionId(targetDefinitionId);
+          setResolutionStatus(null);
+          navigate(`/schedules/${encodeURIComponent(targetDefinitionId)}`);
+        } catch {
+          if (pendingRequestRef.current === requestId) {
+            setResolutionStatus('Recurring schedule list is unavailable.');
+          }
+        }
+        return;
+      }
+
+      const resolved = resolveRecurringListDisplay({
+        pathname: location.pathname,
+        search: location.search,
+        requestedMode: selectedMode,
+        selectedDefinitionId: lastSelectedDefinitionId,
+        firstVisibleDefinitionId: null,
+      });
+      if (!resolved) {
+        return;
+      }
+      setRequestedRecurringMode(selectedMode);
+      if (resolved.selection.definitionId) {
+        setLastSelectedDefinitionId(resolved.selection.definitionId);
+      }
+      const current = `${location.pathname}${location.search}`;
+      if (resolved.targetPath !== current) {
+        navigate(resolved.targetPath);
+      }
+      return;
+    }
 
     if (location.pathname.replace(/\/$/, '') === '/workflows' && selectedMode !== 'table') {
       const requestId = Symbol();
@@ -844,6 +948,7 @@ function RoutedDashboardPage({
       <AppShell
         dataWidePanel={false}
         uiInfo={uiInfo}
+        listDisplayAccessibleName={activeListDisplayAccessibleName}
         workflowListMode={null}
         workflowListDisplayStatus={resolutionStatus}
         onWorkflowListModeSelect={handleWorkflowListModeSelect}
@@ -861,8 +966,9 @@ function RoutedDashboardPage({
       <AppShell
         dataWidePanel={route.dataWidePanel}
         uiInfo={uiInfo}
-        workflowListMode={resolvedDisplay?.effectiveMode ?? null}
-        workflowListDisplayStatus={resolutionStatus ?? resolvedDisplay?.status}
+        listDisplayAccessibleName={activeListDisplayAccessibleName}
+        workflowListMode={activeListDisplay?.effectiveMode ?? null}
+        workflowListDisplayStatus={resolutionStatus ?? activeListDisplay?.status}
         onWorkflowListModeSelect={handleWorkflowListModeSelect}
       >
         <LoadingPage />
@@ -880,6 +986,15 @@ function RoutedDashboardPage({
       workflowListDisplayStatus: resolutionStatus ?? resolvedDisplay.status,
     };
   }
+  if (resolvedRecurringDisplay) {
+    routedPayload.initialData = {
+      ...(routedPayload.initialData && typeof routedPayload.initialData === 'object'
+        ? routedPayload.initialData
+        : {}),
+      recurringListDisplayMode: resolvedRecurringDisplay.effectiveMode,
+      recurringListDisplayStatus: resolutionStatus ?? resolvedRecurringDisplay.status,
+    };
+  }
   const layout = readSharedLayout(routedPayload);
   const routeKey = route.page === 'workflows-workspace'
     ? 'workflows-workspace'
@@ -889,8 +1004,9 @@ function RoutedDashboardPage({
     <AppShell
       dataWidePanel={layout.dataWidePanel === true}
       uiInfo={uiInfo}
-      workflowListMode={resolvedDisplay?.effectiveMode ?? null}
-      workflowListDisplayStatus={resolutionStatus ?? resolvedDisplay?.status}
+      listDisplayAccessibleName={activeListDisplayAccessibleName}
+      workflowListMode={activeListDisplay?.effectiveMode ?? null}
+      workflowListDisplayStatus={resolutionStatus ?? activeListDisplay?.status}
       onWorkflowListModeSelect={handleWorkflowListModeSelect}
     >
       <PageContent key={routeKey} payload={routedPayload} />

--- a/frontend/src/entrypoints/dashboard-app.tsx
+++ b/frontend/src/entrypoints/dashboard-app.tsx
@@ -6,6 +6,7 @@ import {
   useRef,
   useState,
   type ComponentType,
+  type KeyboardEvent,
   type Ref,
   type ReactNode,
 } from 'react';
@@ -535,24 +536,58 @@ function WorkflowListDisplayModeControl({
   status?: string | null | undefined;
   onSelect: (mode: WorkflowListDisplayMode) => void;
 }) {
+  const selectByKey = (
+    event: KeyboardEvent<HTMLButtonElement>,
+    currentIndex: number,
+  ) => {
+    const lastIndex = WORKFLOW_LIST_DISPLAY_MODES.length - 1;
+    let nextIndex: number | null = null;
+
+    if (event.key === 'ArrowRight' || event.key === 'ArrowDown') {
+      nextIndex = currentIndex === lastIndex ? 0 : currentIndex + 1;
+    } else if (event.key === 'ArrowLeft' || event.key === 'ArrowUp') {
+      nextIndex = currentIndex === 0 ? lastIndex : currentIndex - 1;
+    } else if (event.key === 'Home') {
+      nextIndex = 0;
+    } else if (event.key === 'End') {
+      nextIndex = lastIndex;
+    }
+
+    if (nextIndex === null) {
+      return;
+    }
+
+    event.preventDefault();
+    const nextMode = WORKFLOW_LIST_DISPLAY_MODES[nextIndex];
+    onSelect(nextMode.value);
+    const nextRadio = event.currentTarget.parentElement?.querySelector<HTMLButtonElement>(
+      `[data-list-display-mode="${nextMode.value}"]`,
+    );
+    nextRadio?.focus();
+  };
+
   return (
     <div
       className="workflow-list-display-control"
       role="radiogroup"
       aria-label={accessibleName}
     >
-      {WORKFLOW_LIST_DISPLAY_MODES.map((mode) => {
+      {WORKFLOW_LIST_DISPLAY_MODES.map((mode, index) => {
         const Icon = iconForWorkflowListMode(mode.icon);
         const checked = effectiveMode === mode.value;
         return (
           <button
             key={mode.value}
             type="button"
-            aria-pressed={checked}
+            role="radio"
+            aria-checked={checked}
             aria-label={mode.label}
+            tabIndex={checked ? 0 : -1}
             title={mode.label}
+            data-list-display-mode={mode.value}
             className={`workflow-list-display-option${checked ? ' workflow-list-display-option--selected' : ''}`}
             onClick={() => onSelect(mode.value)}
+            onKeyDown={(event) => selectByKey(event, index)}
           >
             <Icon size={LIST_MODE_ICON_SIZE} aria-hidden="true" />
           </button>

--- a/frontend/src/entrypoints/dashboard.test.tsx
+++ b/frontend/src/entrypoints/dashboard.test.tsx
@@ -446,7 +446,7 @@ describe('Dashboard shared entry', () => {
       if (url === '/api/ui/info') {
         return Promise.resolve({ ok: true, json: async () => uiInfo() } as Response);
       }
-      if (url === '/api/recurring-tasks?scope=personal') {
+      if (url === '/api/recurring-workflows?scope=personal') {
         return Promise.resolve({
           ok: true,
           json: async () => ({
@@ -506,13 +506,80 @@ describe('Dashboard shared entry', () => {
     expect(screen.getByRole('radio', { name: 'Sidebar list' }).getAttribute('aria-checked')).toBe('true');
   });
 
+  it('verifies remembered recurring IDs before opening sidebar mode from the schedules table', async () => {
+    fetchSpy.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === '/api/ui/info') {
+        return Promise.resolve({ ok: true, json: async () => uiInfo() } as Response);
+      }
+      if (url === '/api/recurring-workflows/stale-schedule') {
+        return Promise.resolve({ ok: false, status: 404, statusText: 'Not Found' } as Response);
+      }
+      if (url === '/api/recurring-workflows?scope=personal') {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            items: [{
+              id: 'schedule-one',
+              name: 'Daily recurring scan',
+              enabled: true,
+              cron: '0 9 * * *',
+              timezone: 'UTC',
+              nextRunAt: '2026-07-09T09:00:00Z',
+              lastDispatchStatus: 'enqueued',
+              target: {},
+              policy: {},
+            }],
+          }),
+        } as Response);
+      }
+      if (url === '/api/recurring-workflows/schedule-one') {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            id: 'schedule-one',
+            name: 'Daily recurring scan',
+            description: 'Runs every morning.',
+            enabled: true,
+            cron: '0 9 * * *',
+            timezone: 'UTC',
+            nextRunAt: '2026-07-09T09:00:00Z',
+            lastScheduledFor: '2026-07-08T09:00:00Z',
+            lastDispatchStatus: 'enqueued',
+            target: {},
+            policy: {},
+          }),
+        } as Response);
+      }
+      if (url === '/api/recurring-workflows/schedule-one/runs?limit=200') {
+        return Promise.resolve({ ok: true, json: async () => ({ items: [] }) } as Response);
+      }
+      return Promise.resolve({ ok: false, status: 404, statusText: 'Not Found' } as Response);
+    });
+
+    window.history.replaceState({}, '', '/schedules/stale-schedule');
+    renderWithClient(<DashboardApp payload={{ page: 'dashboard', apiBase: '/api' }} />);
+
+    expect(await screen.findByText('Recurring schedule not found.')).toBeTruthy();
+    navigateTo('/schedules');
+    expect(await screen.findByRole('heading', { name: 'Recurring Schedules' })).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('radio', { name: 'Sidebar list' }));
+
+    await waitFor(() => {
+      expect(window.location.pathname).toBe('/schedules/schedule-one');
+    });
+    expect(await screen.findByRole('heading', { name: 'Daily recurring scan' })).toBeTruthy();
+    expect(fetchSpy.mock.calls.some(([url]) => String(url) === '/api/recurring-workflows/stale-schedule')).toBe(true);
+  });
+
   it('switches Recurring detail between full table and hidden-list modes', async () => {
     fetchSpy.mockImplementation((input: RequestInfo | URL) => {
       const url = String(input);
       if (url === '/api/ui/info') {
         return Promise.resolve({ ok: true, json: async () => uiInfo() } as Response);
       }
-      if (url === '/api/recurring-tasks?scope=personal') {
+      if (url === '/api/recurring-workflows?scope=personal') {
         return Promise.resolve({
           ok: true,
           json: async () => ({

--- a/frontend/src/entrypoints/dashboard.test.tsx
+++ b/frontend/src/entrypoints/dashboard.test.tsx
@@ -357,7 +357,7 @@ describe('Dashboard shared entry', () => {
     fireEvent.mouseLeave(createLink);
     expect(animatedNavIconMocks.rocketStop).toHaveBeenCalledTimes(1);
 
-    const schedulesLink = screen.getByRole('link', { name: 'Schedules' });
+    const schedulesLink = screen.getByRole('link', { name: 'Recurring' });
     fireEvent.mouseEnter(schedulesLink);
     expect(animatedNavIconMocks.moonStart).toHaveBeenCalledTimes(1);
     fireEvent.mouseLeave(schedulesLink);
@@ -408,7 +408,7 @@ describe('Dashboard shared entry', () => {
 
     await screen.findByText('Workflow list route loaded', {}, { timeout: 10000 });
 
-    const group = screen.getByRole('group', { name: 'Workflow list display' });
+    const group = screen.getByRole('radiogroup', { name: 'Workflow list display' });
     expect(group).toBeTruthy();
     expect(screen.getByRole('button', { name: 'No list' }).getAttribute('aria-pressed')).toBe('false');
     expect(screen.getByRole('button', { name: 'Sidebar list' }).getAttribute('aria-pressed')).toBe('false');
@@ -430,6 +430,141 @@ describe('Dashboard shared entry', () => {
     });
     expect(await screen.findByText(/Workflow detail route loaded:/)).toBeTruthy();
     expect(screen.getByRole('button', { name: 'Sidebar list' }).getAttribute('aria-pressed')).toBe('true');
+  });
+
+  it('renders the Recurring list display selector on schedule routes and opens the first schedule in sidebar mode', async () => {
+    fetchSpy.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === '/api/ui/info') {
+        return Promise.resolve({ ok: true, json: async () => uiInfo() } as Response);
+      }
+      if (url === '/api/recurring-tasks?scope=personal') {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            items: [{
+              id: 'schedule-one',
+              name: 'Daily recurring scan',
+              enabled: true,
+              cron: '0 9 * * *',
+              timezone: 'UTC',
+              nextRunAt: '2026-07-09T09:00:00Z',
+              lastDispatchStatus: 'enqueued',
+              target: {},
+              policy: {},
+            }],
+          }),
+        } as Response);
+      }
+      if (url === '/api/recurring-workflows/schedule-one') {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            id: 'schedule-one',
+            name: 'Daily recurring scan',
+            description: 'Runs every morning.',
+            enabled: true,
+            cron: '0 9 * * *',
+            timezone: 'UTC',
+            nextRunAt: '2026-07-09T09:00:00Z',
+            lastScheduledFor: '2026-07-08T09:00:00Z',
+            lastDispatchStatus: 'enqueued',
+            target: {},
+            policy: {},
+          }),
+        } as Response);
+      }
+      if (url === '/api/recurring-workflows/schedule-one/runs?limit=200') {
+        return Promise.resolve({ ok: true, json: async () => ({ items: [] }) } as Response);
+      }
+      return Promise.resolve({ ok: false, status: 404, statusText: 'Not Found' } as Response);
+    });
+
+    window.history.replaceState({}, '', '/schedules');
+    renderWithClient(<DashboardApp payload={{ page: 'dashboard', apiBase: '/api' }} />);
+
+    expect(await screen.findByRole('heading', { name: 'Recurring Schedules' })).toBeTruthy();
+    expect(screen.getByRole('radiogroup', { name: 'Recurring list display' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Full screen table' }).getAttribute('aria-pressed')).toBe('true');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Sidebar list' }));
+
+    await waitFor(() => {
+      expect(window.location.pathname).toBe('/schedules/schedule-one');
+    });
+    expect(await screen.findByRole('heading', { name: 'Daily recurring scan' })).toBeTruthy();
+    expect(screen.getByRole('complementary', { name: 'Recurring schedule navigation' })).toBeTruthy();
+    expect(screen.getByRole('link', { name: /Daily recurring scan/ }).getAttribute('aria-current')).toBe('page');
+    expect(screen.getByRole('button', { name: 'Sidebar list' }).getAttribute('aria-pressed')).toBe('true');
+  });
+
+  it('switches Recurring detail between full table and hidden-list modes', async () => {
+    fetchSpy.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === '/api/ui/info') {
+        return Promise.resolve({ ok: true, json: async () => uiInfo() } as Response);
+      }
+      if (url === '/api/recurring-tasks?scope=personal') {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            items: [{
+              id: 'schedule-one',
+              name: 'Daily recurring scan',
+              enabled: true,
+              cron: '0 9 * * *',
+              timezone: 'UTC',
+              nextRunAt: '2026-07-09T09:00:00Z',
+              lastDispatchStatus: 'enqueued',
+              target: {},
+              policy: {},
+            }],
+          }),
+        } as Response);
+      }
+      if (url === '/api/recurring-workflows/schedule-one') {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            id: 'schedule-one',
+            name: 'Daily recurring scan',
+            description: 'Runs every morning.',
+            enabled: true,
+            cron: '0 9 * * *',
+            timezone: 'UTC',
+            nextRunAt: '2026-07-09T09:00:00Z',
+            lastScheduledFor: '2026-07-08T09:00:00Z',
+            lastDispatchStatus: 'enqueued',
+            target: {},
+            policy: {},
+          }),
+        } as Response);
+      }
+      if (url === '/api/recurring-workflows/schedule-one/runs?limit=200') {
+        return Promise.resolve({ ok: true, json: async () => ({ items: [] }) } as Response);
+      }
+      return Promise.resolve({ ok: false, status: 404, statusText: 'Not Found' } as Response);
+    });
+
+    window.history.replaceState({}, '', '/schedules/schedule-one');
+    renderWithClient(<DashboardApp payload={{ page: 'dashboard', apiBase: '/api' }} />);
+
+    expect(await screen.findByRole('heading', { name: 'Daily recurring scan' })).toBeTruthy();
+    expect(screen.getByRole('complementary', { name: 'Recurring schedule navigation' })).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'No list' }));
+    expect(window.location.pathname).toBe('/schedules/schedule-one');
+    await waitFor(() => {
+      expect(screen.queryByRole('complementary', { name: 'Recurring schedule navigation' })).toBeNull();
+    });
+    expect(screen.getByRole('button', { name: 'No list' }).getAttribute('aria-pressed')).toBe('true');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Full screen table' }));
+    await waitFor(() => {
+      expect(window.location.pathname).toBe('/schedules');
+    });
+    expect(await screen.findByRole('heading', { name: 'Recurring Schedules' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Full screen table' }).getAttribute('aria-pressed')).toBe('true');
   });
 
   it('hides the workflow list display control on unsupported routes', async () => {

--- a/frontend/src/entrypoints/dashboard.test.tsx
+++ b/frontend/src/entrypoints/dashboard.test.tsx
@@ -410,9 +410,17 @@ describe('Dashboard shared entry', () => {
 
     const group = screen.getByRole('radiogroup', { name: 'Workflow list display' });
     expect(group).toBeTruthy();
-    expect(screen.getByRole('button', { name: 'No list' }).getAttribute('aria-pressed')).toBe('false');
-    expect(screen.getByRole('button', { name: 'Sidebar list' }).getAttribute('aria-pressed')).toBe('false');
-    expect(screen.getByRole('button', { name: 'Full screen table' }).getAttribute('aria-pressed')).toBe('true');
+    const noList = screen.getByRole('radio', { name: 'No list' });
+    const sidebarList = screen.getByRole('radio', { name: 'Sidebar list' });
+    const fullTable = screen.getByRole('radio', { name: 'Full screen table' });
+    expect(noList.getAttribute('aria-checked')).toBe('false');
+    expect(sidebarList.getAttribute('aria-checked')).toBe('false');
+    expect(fullTable.getAttribute('aria-checked')).toBe('true');
+    expect(noList.getAttribute('aria-pressed')).toBeNull();
+    expect(sidebarList.getAttribute('aria-pressed')).toBeNull();
+    expect(fullTable.getAttribute('aria-pressed')).toBeNull();
+    expect(noList.getAttribute('tabindex')).toBe('-1');
+    expect(fullTable.getAttribute('tabindex')).toBe('0');
     expect(screen.queryByRole('button', { name: 'Close sidebar' })).toBeNull();
     expect(screen.queryByRole('button', { name: 'Open workflow sidebar' })).toBeNull();
     expect(screen.queryByRole('link', { name: 'Expand to full list' })).toBeNull();
@@ -423,13 +431,13 @@ describe('Dashboard shared entry', () => {
     renderWithClient(<DashboardApp payload={{ page: 'dashboard', apiBase: '/api' }} />);
 
     await screen.findByText('Workflow list route loaded', {}, { timeout: 10000 });
-    fireEvent.click(screen.getByRole('button', { name: 'Sidebar list' }));
+    fireEvent.click(screen.getByRole('radio', { name: 'Sidebar list' }));
 
     await waitFor(() => {
       expect(window.location.pathname).toBe('/workflows/mm%3A97d44980-355c-4300-96a7-0ad166440d95');
     });
     expect(await screen.findByText(/Workflow detail route loaded:/)).toBeTruthy();
-    expect(screen.getByRole('button', { name: 'Sidebar list' }).getAttribute('aria-pressed')).toBe('true');
+    expect(screen.getByRole('radio', { name: 'Sidebar list' }).getAttribute('aria-checked')).toBe('true');
   });
 
   it('renders the Recurring list display selector on schedule routes and opens the first schedule in sidebar mode', async () => {
@@ -485,9 +493,9 @@ describe('Dashboard shared entry', () => {
 
     expect(await screen.findByRole('heading', { name: 'Recurring Schedules' })).toBeTruthy();
     expect(screen.getByRole('radiogroup', { name: 'Recurring list display' })).toBeTruthy();
-    expect(screen.getByRole('button', { name: 'Full screen table' }).getAttribute('aria-pressed')).toBe('true');
+    expect(screen.getByRole('radio', { name: 'Full screen table' }).getAttribute('aria-checked')).toBe('true');
 
-    fireEvent.click(screen.getByRole('button', { name: 'Sidebar list' }));
+    fireEvent.click(screen.getByRole('radio', { name: 'Sidebar list' }));
 
     await waitFor(() => {
       expect(window.location.pathname).toBe('/schedules/schedule-one');
@@ -495,7 +503,7 @@ describe('Dashboard shared entry', () => {
     expect(await screen.findByRole('heading', { name: 'Daily recurring scan' })).toBeTruthy();
     expect(screen.getByRole('complementary', { name: 'Recurring schedule navigation' })).toBeTruthy();
     expect(screen.getByRole('link', { name: /Daily recurring scan/ }).getAttribute('aria-current')).toBe('page');
-    expect(screen.getByRole('button', { name: 'Sidebar list' }).getAttribute('aria-pressed')).toBe('true');
+    expect(screen.getByRole('radio', { name: 'Sidebar list' }).getAttribute('aria-checked')).toBe('true');
   });
 
   it('switches Recurring detail between full table and hidden-list modes', async () => {
@@ -552,19 +560,19 @@ describe('Dashboard shared entry', () => {
     expect(await screen.findByRole('heading', { name: 'Daily recurring scan' })).toBeTruthy();
     expect(screen.getByRole('complementary', { name: 'Recurring schedule navigation' })).toBeTruthy();
 
-    fireEvent.click(screen.getByRole('button', { name: 'No list' }));
+    fireEvent.click(screen.getByRole('radio', { name: 'No list' }));
     expect(window.location.pathname).toBe('/schedules/schedule-one');
     await waitFor(() => {
       expect(screen.queryByRole('complementary', { name: 'Recurring schedule navigation' })).toBeNull();
     });
-    expect(screen.getByRole('button', { name: 'No list' }).getAttribute('aria-pressed')).toBe('true');
+    expect(screen.getByRole('radio', { name: 'No list' }).getAttribute('aria-checked')).toBe('true');
 
-    fireEvent.click(screen.getByRole('button', { name: 'Full screen table' }));
+    fireEvent.click(screen.getByRole('radio', { name: 'Full screen table' }));
     await waitFor(() => {
       expect(window.location.pathname).toBe('/schedules');
     });
     expect(await screen.findByRole('heading', { name: 'Recurring Schedules' })).toBeTruthy();
-    expect(screen.getByRole('button', { name: 'Full screen table' }).getAttribute('aria-pressed')).toBe('true');
+    expect(screen.getByRole('radio', { name: 'Full screen table' }).getAttribute('aria-checked')).toBe('true');
   });
 
   it('hides the workflow list display control on unsupported routes', async () => {
@@ -696,17 +704,17 @@ describe('Dashboard shared entry', () => {
     renderWithClient(<DashboardApp payload={{ page: 'dashboard', apiBase: '/api' }} />);
 
     expect(await screen.findByText('Workflow start route loaded')).toBeTruthy();
-    expect(screen.getByRole('button', { name: 'Sidebar list' }).getAttribute('aria-pressed')).toBe('true');
+    expect(screen.getByRole('radio', { name: 'Sidebar list' }).getAttribute('aria-checked')).toBe('true');
     await waitFor(() => {
       expect(document.querySelector('.panel--data-wide')).toBeTruthy();
     });
 
-    fireEvent.click(screen.getByRole('button', { name: 'No list' }));
-    expect(screen.getByRole('button', { name: 'No list' }).getAttribute('aria-pressed')).toBe('true');
+    fireEvent.click(screen.getByRole('radio', { name: 'No list' }));
+    expect(screen.getByRole('radio', { name: 'No list' }).getAttribute('aria-checked')).toBe('true');
     expect(window.location.pathname).toBe('/workflows/new');
 
-    fireEvent.click(screen.getByRole('button', { name: 'Sidebar list' }));
-    expect(screen.getByRole('button', { name: 'Sidebar list' }).getAttribute('aria-pressed')).toBe('true');
+    fireEvent.click(screen.getByRole('radio', { name: 'Sidebar list' }));
+    expect(screen.getByRole('radio', { name: 'Sidebar list' }).getAttribute('aria-checked')).toBe('true');
     expect(window.location.pathname).toBe('/workflows/new');
     expect(window.location.search).toBe('?source=temporal');
   });
@@ -808,7 +816,7 @@ describe('Dashboard shared entry', () => {
     expect(await screen.findByText('Workflow list route loaded')).toBeTruthy();
     fetchSpy.mockClear();
 
-    fireEvent.click(screen.getByRole('button', { name: 'No list' }));
+    fireEvent.click(screen.getByRole('radio', { name: 'No list' }));
 
     await waitFor(() => {
       expect(window.location.pathname).toBe('/workflows/remembered-123');
@@ -829,7 +837,7 @@ describe('Dashboard shared entry', () => {
     expect(await screen.findByText('Workflow detail route loaded: /workflows/route-123')).toBeTruthy();
     fetchSpy.mockClear();
 
-    fireEvent.click(screen.getByRole('button', { name: 'No list' }));
+    fireEvent.click(screen.getByRole('radio', { name: 'No list' }));
 
     await waitFor(() => {
       expect(readDashboardPreferences().workflowWorkspaceSidebarCollapsed).toBe(true);
@@ -865,7 +873,7 @@ describe('Dashboard shared entry', () => {
     renderWithClient(<DashboardApp payload={{ page: 'dashboard', apiBase: '/api' }} />);
 
     expect(await screen.findByText('Workflow list route loaded')).toBeTruthy();
-    fireEvent.click(screen.getByRole('button', { name: 'Sidebar list' }));
+    fireEvent.click(screen.getByRole('radio', { name: 'Sidebar list' }));
 
     await waitFor(() => {
       expect(window.location.pathname).toBe('/workflows/first-query-row');
@@ -904,7 +912,7 @@ describe('Dashboard shared entry', () => {
     renderWithClient(<DashboardApp payload={{ page: 'dashboard', apiBase: '/api' }} />);
 
     expect(await screen.findByText('Workflow list route loaded')).toBeTruthy();
-    fireEvent.click(screen.getByRole('button', { name: 'Sidebar list' }));
+    fireEvent.click(screen.getByRole('radio', { name: 'Sidebar list' }));
 
     await waitFor(() => {
       expect(window.location.pathname).toBe('/workflows/visible-456');
@@ -938,7 +946,7 @@ describe('Dashboard shared entry', () => {
     renderWithClient(<DashboardApp payload={{ page: 'dashboard', apiBase: '/api' }} />);
 
     expect(await screen.findByText('Workflow list route loaded')).toBeTruthy();
-    fireEvent.click(screen.getByRole('button', { name: 'No list' }));
+    fireEvent.click(screen.getByRole('radio', { name: 'No list' }));
 
     await waitFor(() => {
       expect(window.location.pathname).toBe('/workflows/authorized-row');
@@ -966,7 +974,7 @@ describe('Dashboard shared entry', () => {
     renderWithClient(<DashboardApp payload={{ page: 'dashboard', apiBase: '/api' }} />);
 
     expect(await screen.findByText('Workflow list route loaded')).toBeTruthy();
-    fireEvent.click(screen.getByRole('button', { name: 'No list' }));
+    fireEvent.click(screen.getByRole('radio', { name: 'No list' }));
 
     await waitFor(() => {
       expect(window.location.pathname).toBe('/workflows/authorized-task-row');
@@ -993,7 +1001,7 @@ describe('Dashboard shared entry', () => {
     renderWithClient(<DashboardApp payload={{ page: 'dashboard', apiBase: '/api' }} />);
 
     expect(await screen.findByText('Workflow list route loaded')).toBeTruthy();
-    fireEvent.click(screen.getByRole('button', { name: 'No list' }));
+    fireEvent.click(screen.getByRole('radio', { name: 'No list' }));
 
     expect((await screen.findByRole('status')).textContent).toContain('Opening first workflow...');
     const completeList = resolveList;
@@ -1024,7 +1032,7 @@ describe('Dashboard shared entry', () => {
     renderWithClient(<DashboardApp payload={{ page: 'dashboard', apiBase: '/api' }} />);
 
     expect(await screen.findByText('Workflow list route loaded')).toBeTruthy();
-    fireEvent.click(screen.getByRole('button', { name: 'No list' }));
+    fireEvent.click(screen.getByRole('radio', { name: 'No list' }));
 
     await waitFor(() => {
       expect(screen.getByRole('status').textContent).toContain('No workflow to open.');
@@ -1047,7 +1055,7 @@ describe('Dashboard shared entry', () => {
     renderWithClient(<DashboardApp payload={{ page: 'dashboard', apiBase: '/api' }} />);
 
     expect(await screen.findByText('Workflow list route loaded')).toBeTruthy();
-    fireEvent.click(screen.getByRole('button', { name: 'No list' }));
+    fireEvent.click(screen.getByRole('radio', { name: 'No list' }));
 
     await waitFor(() => {
       expect(screen.getByRole('status').textContent).toContain('No workflow to open.');
@@ -1070,7 +1078,7 @@ describe('Dashboard shared entry', () => {
     renderWithClient(<DashboardApp payload={{ page: 'dashboard', apiBase: '/api' }} />);
 
     expect(await screen.findByText('Workflow list route loaded')).toBeTruthy();
-    fireEvent.click(screen.getByRole('button', { name: 'No list' }));
+    fireEvent.click(screen.getByRole('radio', { name: 'No list' }));
 
     await waitFor(() => {
       expect(screen.getByRole('status').textContent).toContain('Workflow list is unavailable.');
@@ -1097,7 +1105,7 @@ describe('Dashboard shared entry', () => {
     renderWithClient(<DashboardApp payload={{ page: 'dashboard', apiBase: '/api' }} />);
 
     expect(await screen.findByText('Workflow list route loaded')).toBeTruthy();
-    fireEvent.click(screen.getByRole('button', { name: 'No list' }));
+    fireEvent.click(screen.getByRole('radio', { name: 'No list' }));
     expect((await screen.findByRole('status')).textContent).toContain('Opening first workflow...');
     fireEvent.click(screen.getByRole('link', { name: 'Settings' }));
     expect(await screen.findByText('Settings permissions:')).toBeTruthy();
@@ -2449,6 +2457,9 @@ describe('Dashboard shared entry', () => {
     );
     expect(dashboardCss).toMatch(
       /@media \(max-width: 767px\)\s*\{[\s\S]*\.workflow-list-display-control\s*\{[^}]*display:\s*none/s,
+    );
+    expect(dashboardCss).toMatch(
+      /@media \(max-width: 720px\)\s*\{[\s\S]*\.recurring-schedule-sidebar\s*\{[^}]*display:\s*none/s,
     );
     expect(dashboardCss).toMatch(
       /@media \(max-width: 900px\)\s*\{[\s\S]*\.grid-2\s*\{/,

--- a/frontend/src/entrypoints/schedules.test.tsx
+++ b/frontend/src/entrypoints/schedules.test.tsx
@@ -135,6 +135,12 @@ function mockScheduleDetailFetch(fetchSpy: MockInstance, overrides: Record<strin
         json: async () => detailRuns,
       } as Response;
     }
+    if (url === "/console/schedules?scope=personal") {
+      return {
+        ok: true,
+        json: async () => ({ items: [schedule] }),
+      } as Response;
+    }
     if (url === "/console/schedules/schedule-alpha") {
       return {
         ok: true,
@@ -219,8 +225,8 @@ describe("SchedulesPage", () => {
     renderWithClient(<SchedulesPage payload={mockPayload} />);
 
     expect(screen.getByRole("heading", { name: "Recurring Schedules" })).toBeTruthy();
-    expect(screen.getByText("Schedules summary loading placeholder").closest('[role="status"]')).toBeTruthy();
-    expect(screen.getByText("Schedules list loading placeholder").closest('[role="status"]')).toBeTruthy();
+    expect(screen.getByText("Recurring summary loading placeholder").closest('[role="status"]')).toBeTruthy();
+    expect(screen.getByText("Recurring list loading placeholder").closest('[role="status"]')).toBeTruthy();
     expect(screen.getByTestId("loading-placeholder-metric-strip")).toBeTruthy();
     expect(screen.getByTestId("loading-placeholder-table")).toBeTruthy();
   });
@@ -356,9 +362,11 @@ describe("SchedulesPage", () => {
     expect(screen.queryByRole("heading", { name: "Logs" })).toBeNull();
     expect(screen.queryByRole("heading", { name: "Proposals" })).toBeNull();
     expect(screen.queryByRole("heading", { name: "Diagnostics" })).toBeNull();
-    expect(fetchSpy.mock.calls.some(([url]) => String(url) === "/console/schedules?scope=personal")).toBe(false);
+    expect(fetchSpy.mock.calls.some(([url]) => String(url) === "/console/schedules?scope=personal")).toBe(true);
     expect(fetchSpy.mock.calls.some(([url]) => String(url) === "/console/schedules/schedule-alpha")).toBe(true);
     expect(fetchSpy.mock.calls.some(([url]) => String(url) === "/console/schedules/schedule-alpha/runs?limit=200")).toBe(true);
+    expect(screen.getByRole("complementary", { name: "Recurring schedule navigation" })).not.toBeNull();
+    expect(screen.getByRole("link", { name: /Nightly detail sweep/ }).getAttribute("aria-current")).toBe("page");
     expect(screen.getByRole("button", { name: "Edit schedule" })).not.toBeNull();
     expect(screen.getByRole("button", { name: "Run now" })).not.toBeNull();
     expect(screen.getByRole("button", { name: "Pause schedule" })).not.toBeNull();
@@ -389,6 +397,9 @@ describe("SchedulesPage", () => {
       if (url === "/console/schedules/schedule-alpha/runs?limit=200") {
         return { ok: true, json: async () => detailRuns } as Response;
       }
+      if (url === "/console/schedules?scope=personal") {
+        return { ok: true, json: async () => ({ items: [] }) } as Response;
+      }
       if (url === "/console/schedules/schedule-alpha") {
         return { ok: false, status: 403, statusText: "Forbidden", json: async () => ({}) } as Response;
       }
@@ -398,7 +409,7 @@ describe("SchedulesPage", () => {
     renderWithClient(<SchedulesPage payload={detailPayload} />);
 
     expect(await screen.findByText("You do not have access to this recurring schedule.")).not.toBeNull();
-    expect(screen.getByRole("link", { name: "Back to schedules" }).getAttribute("href")).toBe("/schedules");
+    expect(screen.getByRole("link", { name: "Back to recurring schedules" }).getAttribute("href")).toBe("/schedules");
     expect(screen.queryByRole("heading", { name: "Nightly detail sweep" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Edit schedule" })).toBeNull();
   });

--- a/frontend/src/entrypoints/schedules.test.tsx
+++ b/frontend/src/entrypoints/schedules.test.tsx
@@ -267,8 +267,8 @@ describe("SchedulesPage", () => {
     });
     expect(mutationCalls).toEqual([]);
     expect(
-      fetchSpy.mock.calls.some(([url]) => String(url) === "/api/recurring-tasks"),
-    ).toBe(false);
+      fetchSpy.mock.calls.some(([url]) => String(url) === "/api/recurring-workflows?scope=personal"),
+    ).toBe(true);
   });
 
   it("shows an empty state without adding local create controls", async () => {
@@ -329,7 +329,7 @@ describe("SchedulesPage", () => {
     );
 
     expect(await screen.findByText("No recurring schedules yet. Create one from the workflow page.")).not.toBeNull();
-    expect(fetchSpy.mock.calls[0]?.[0]).toBe("/tenant/api/recurring-tasks?scope=personal");
+    expect(fetchSpy.mock.calls[0]?.[0]).toBe("/tenant/api/recurring-workflows?scope=personal");
   });
 
   it("loads the recurring schedule detail route by the routed definition id", async () => {

--- a/frontend/src/entrypoints/schedules.tsx
+++ b/frontend/src/entrypoints/schedules.tsx
@@ -1,5 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { FormEvent, useEffect, useMemo, useRef, useState } from 'react';
+import { FormEvent, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import { LoadingPlaceholder } from '../components/dashboard/LoadingPlaceholder';
 import { DataTable } from '../components/tables/DataTable';
 import { DashboardActionDialog } from '../components/DashboardActionDialog';
@@ -68,6 +68,8 @@ type ScheduleSources = {
 const SchedulesBootDataSchema = z
   .object({
     initialPath: z.string().optional(),
+    recurringListDisplayMode: z.enum(['hidden', 'sidebar', 'table']).optional(),
+    recurringListDisplayStatus: z.string().nullable().optional(),
     dashboardConfig: z
       .object({
         initialPath: z.string().optional(),
@@ -138,6 +140,14 @@ function scheduleRouteDefinitionId(payload: BootPayload): string | null {
   } catch {
     return null;
   }
+}
+
+function recurringListDisplayMode(payload: BootPayload, hasRouteDefinition: boolean): 'hidden' | 'sidebar' | 'table' {
+  const mode = scheduleBootData(payload)?.recurringListDisplayMode;
+  if (mode) {
+    return mode;
+  }
+  return hasRouteDefinition ? 'sidebar' : 'table';
 }
 
 function scheduleEndpoint(
@@ -593,7 +603,102 @@ function isDueSoon(schedule: Schedule, now: number): boolean {
   return Number.isFinite(nextRun) && nextRun >= now && nextRun <= now + 24 * 60 * 60 * 1000;
 }
 
-function ScheduleDetailPage({ payload, definitionId }: { payload: BootPayload; definitionId: string }) {
+function RecurringScheduleSidebar({
+  definitionId,
+  schedules,
+  isLoading,
+  error,
+}: {
+  definitionId: string;
+  schedules: Schedule[];
+  isLoading: boolean;
+  error: unknown;
+}) {
+  return (
+    <aside className="recurring-schedule-sidebar" aria-label="Recurring schedule navigation">
+      <div className="recurring-schedule-sidebar-header">
+        <strong>Recurring</strong>
+      </div>
+      {isLoading ? (
+        <p className="recurring-schedule-sidebar-state">Loading recurring schedules...</p>
+      ) : error ? (
+        <p className="recurring-schedule-sidebar-state" role="alert">
+          {errorMessage(error, 'Recurring schedule navigation unavailable')}
+        </p>
+      ) : schedules.length === 0 ? (
+        <p className="recurring-schedule-sidebar-state">No recurring schedules yet.</p>
+      ) : (
+        <nav className="recurring-schedule-sidebar-list">
+          {schedules.map((schedule) => {
+            const active = schedule.id === definitionId;
+            return (
+              <a
+                key={schedule.id}
+                href={`/schedules/${encodeURIComponent(schedule.id)}`}
+                aria-current={active ? 'page' : undefined}
+                className={`recurring-schedule-sidebar-row${active ? ' recurring-schedule-sidebar-row--active' : ''}`}
+              >
+                <span className="recurring-schedule-sidebar-name">{schedule.name}</span>
+                <span className="recurring-schedule-sidebar-meta">
+                  {stateLabel(schedule)} · next {formatWhen(schedule.nextRunAt)}
+                </span>
+              </a>
+            );
+          })}
+        </nav>
+      )}
+    </aside>
+  );
+}
+
+function RecurringScheduleWorkspace({
+  definitionId,
+  listDisplayMode,
+  schedules,
+  isLoading,
+  error,
+  children,
+}: {
+  definitionId: string;
+  listDisplayMode: 'hidden' | 'sidebar' | 'table';
+  schedules: Schedule[];
+  isLoading: boolean;
+  error: unknown;
+  children: ReactNode;
+}) {
+  if (listDisplayMode !== 'sidebar') {
+    return <>{children}</>;
+  }
+  return (
+    <div className="recurring-schedule-workspace">
+      <RecurringScheduleSidebar
+        definitionId={definitionId}
+        schedules={schedules}
+        isLoading={isLoading}
+        error={error}
+      />
+      <div className="recurring-schedule-workspace-detail">
+        {children}
+      </div>
+    </div>
+  );
+}
+
+function ScheduleDetailPage({
+  payload,
+  definitionId,
+  listDisplayMode = 'sidebar',
+  sidebarSchedules = [],
+  isSidebarLoading = false,
+  sidebarError = null,
+}: {
+  payload: BootPayload;
+  definitionId: string;
+  listDisplayMode?: 'hidden' | 'sidebar' | 'table';
+  sidebarSchedules?: Schedule[];
+  isSidebarLoading?: boolean;
+  sidebarError?: unknown;
+}) {
   const queryClient = useQueryClient();
   const [isEditing, setIsEditing] = useState(false);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
@@ -753,27 +858,50 @@ function ScheduleDetailPage({ payload, definitionId }: { payload: BootPayload; d
 
   if (detailQuery.isLoading) {
     return (
-      <div className="schedules-page stack">
-        <p className="loading">Loading recurring schedule...</p>
-      </div>
+      <RecurringScheduleWorkspace
+        definitionId={definitionId}
+        listDisplayMode={listDisplayMode}
+        schedules={sidebarSchedules}
+        isLoading={isSidebarLoading}
+        error={sidebarError}
+      >
+        <div className="schedules-page stack">
+          <p className="loading">Loading recurring schedule...</p>
+        </div>
+      </RecurringScheduleWorkspace>
     );
   }
 
   if (detailQuery.isError || !schedule) {
     return (
-      <div className="schedules-page stack">
-        <a href="/schedules" className="secondary">Back to schedules</a>
-        <div className="schedules-error" role="alert">{errorMessage(detailQuery.error, 'Schedule not found')}</div>
-      </div>
+      <RecurringScheduleWorkspace
+        definitionId={definitionId}
+        listDisplayMode={listDisplayMode}
+        schedules={sidebarSchedules}
+        isLoading={isSidebarLoading}
+        error={sidebarError}
+      >
+        <div className="schedules-page stack">
+          <a href="/schedules" className="secondary">Back to recurring schedules</a>
+          <div className="schedules-error" role="alert">{errorMessage(detailQuery.error, 'Schedule not found')}</div>
+        </div>
+      </RecurringScheduleWorkspace>
     );
   }
 
   return (
+    <RecurringScheduleWorkspace
+      definitionId={definitionId}
+      listDisplayMode={listDisplayMode}
+      schedules={sidebarSchedules}
+      isLoading={isSidebarLoading}
+      error={sidebarError}
+    >
     <div className="schedules-page schedules-detail-page stack">
       <header className="toolbar schedules-toolbar">
         <div className="schedules-detail-title">
           <nav className="page-meta" aria-label="Breadcrumb">
-            <a href="/schedules">Schedules</a>
+            <a href="/schedules">Recurring</a>
             <span>/</span>
             <span>{schedule.name}</span>
           </nav>
@@ -1185,18 +1313,18 @@ function ScheduleDetailPage({ payload, definitionId }: { payload: BootPayload; d
         <pre className="schedules-json-block">{formatJsonValue(schedule.target)}</pre>
       </section>
     </div>
+    </RecurringScheduleWorkspace>
   );
 }
 
 export function SchedulesPage({ payload }: { payload: BootPayload }) {
   const routeDefinitionId = useMemo(() => scheduleRouteDefinitionId(payload), [payload]);
-  if (routeDefinitionId) {
-    return <ScheduleDetailPage payload={payload} definitionId={routeDefinitionId} />;
-  }
+  const listDisplayMode = recurringListDisplayMode(payload, Boolean(routeDefinitionId));
 
   const listEndpoint = useMemo(() => scheduleListEndpoint(payload), [payload]);
   const { data, isLoading, isError, error, isFetching, refetch } = useQuery({
     queryKey: ['schedules', listEndpoint],
+    enabled: !routeDefinitionId || listDisplayMode === 'sidebar',
     queryFn: async () => {
       const response = await fetch(listEndpoint, { credentials: 'include' });
       if (!response.ok) {
@@ -1214,6 +1342,19 @@ export function SchedulesPage({ payload }: { payload: BootPayload }) {
     const dueSoon = schedules.filter((schedule) => isDueSoon(schedule, now)).length;
     return { active, attention, dueSoon, total: schedules.length };
   }, [schedules]);
+
+  if (routeDefinitionId) {
+    return (
+      <ScheduleDetailPage
+        payload={payload}
+        definitionId={routeDefinitionId}
+        listDisplayMode={listDisplayMode}
+        sidebarSchedules={schedules}
+        isSidebarLoading={isLoading}
+        sidebarError={isError ? error : null}
+      />
+    );
+  }
 
   return (
     <div className="schedules-page stack">

--- a/frontend/src/entrypoints/schedules.tsx
+++ b/frontend/src/entrypoints/schedules.tsx
@@ -123,7 +123,7 @@ function scheduleSources(payload: BootPayload): ScheduleSources | undefined {
 
 function scheduleListEndpoint(payload: BootPayload): string {
   const schedules = scheduleSources(payload);
-  return schedules?.list || `${payload.apiBase || '/api'}/recurring-tasks?scope=personal`;
+  return schedules?.list || `${payload.apiBase || '/api'}/recurring-workflows?scope=personal`;
 }
 
 function scheduleRouteDefinitionId(payload: BootPayload): string | null {
@@ -714,6 +714,7 @@ function ScheduleDetailPage({
   const runNowEndpoint = useMemo(() => scheduleEndpoint(payload, 'runNow', definitionId), [payload, definitionId]);
   const runsEndpoint = useMemo(() => scheduleEndpoint(payload, 'runs', definitionId), [payload, definitionId]);
   const deleteEndpoint = useMemo(() => scheduleEndpoint(payload, 'delete', definitionId), [payload, definitionId]);
+  const listEndpoint = useMemo(() => scheduleListEndpoint(payload), [payload]);
   const sources = useMemo(() => scheduleSources(payload), [payload]);
 
   const detailQuery = useQuery({
@@ -748,6 +749,7 @@ function ScheduleDetailPage({
     await Promise.all([
       queryClient.invalidateQueries({ queryKey: ['schedule-detail', definitionId] }),
       queryClient.invalidateQueries({ queryKey: ['schedule-runs', definitionId] }),
+      queryClient.invalidateQueries({ queryKey: ['schedules', listEndpoint] }),
     ]);
   };
 
@@ -803,6 +805,7 @@ function ScheduleDetailPage({
       }
     },
     onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['schedules', listEndpoint] });
       navigateTo('/schedules');
     },
   });

--- a/frontend/src/lib/workflowListDisplayMode.test.ts
+++ b/frontend/src/lib/workflowListDisplayMode.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   WORKFLOW_LIST_DISPLAY_MODES,
+  resolveRecurringListDisplay,
   resolveWorkflowListDisplay,
   workflowListDisplayModeByValue,
   type WorkflowListDisplayMode,
@@ -207,5 +208,110 @@ describe('resolveWorkflowListDisplay', () => {
 
   it('returns null for unsupported dashboard routes', () => {
     expect(resolveWorkflowListDisplay({ pathname: '/settings', requestedMode: 'table' })).toBeNull();
+  });
+});
+
+describe('resolveRecurringListDisplay', () => {
+  it('keeps /schedules as the recurring table surface in table mode', () => {
+    expect(resolveRecurringListDisplay({
+      pathname: '/schedules',
+      requestedMode: 'table',
+      search: '?scope=personal',
+    })).toEqual({
+      requestedMode: 'table',
+      effectiveMode: 'table',
+      surface: 'recurring-table',
+      routeAction: 'none',
+      primarySurface: 'recurring-table',
+      listSurface: 'table',
+      selection: { definitionId: null, source: 'none' },
+      targetPath: '/schedules?scope=personal',
+      status: null,
+    });
+  });
+
+  it('opens the selected recurring schedule from /schedules for sidebar and hidden modes', () => {
+    for (const requestedMode of ['sidebar', 'hidden'] as const) {
+      expect(resolveRecurringListDisplay({
+        pathname: '/schedules',
+        requestedMode,
+        selectedDefinitionId: 'daily:scan',
+      })).toMatchObject({
+        requestedMode,
+        effectiveMode: requestedMode,
+        surface: 'recurring-table',
+        routeAction: 'navigate-selected-detail',
+        primarySurface: 'recurring-detail',
+        listSurface: requestedMode === 'hidden' ? 'none' : 'sidebar',
+        selection: { definitionId: 'daily:scan', source: 'last-selected' },
+        targetPath: '/schedules/daily%3Ascan',
+      });
+    }
+  });
+
+  it('uses the first visible recurring schedule when no selected schedule exists', () => {
+    expect(resolveRecurringListDisplay({
+      pathname: '/schedules',
+      requestedMode: 'sidebar',
+      firstVisibleDefinitionId: 'first:recurring',
+    })).toMatchObject({
+      effectiveMode: 'sidebar',
+      routeAction: 'resolve-first-workflow',
+      primarySurface: 'recurring-detail',
+      listSurface: 'sidebar',
+      selection: { definitionId: 'first:recurring', source: 'first-visible-row' },
+      targetPath: '/schedules/first%3Arecurring',
+    });
+  });
+
+  it('keeps an empty /schedules route in table mode when no recurring schedule can be opened', () => {
+    expect(resolveRecurringListDisplay({ pathname: '/schedules', requestedMode: 'hidden' })).toEqual({
+      requestedMode: 'hidden',
+      effectiveMode: 'table',
+      surface: 'recurring-table',
+      routeAction: 'none',
+      primarySurface: 'empty-recurring',
+      listSurface: 'table',
+      selection: { definitionId: null, source: 'none' },
+      targetPath: '/schedules',
+      status: 'No recurring schedule can be opened from the current list.',
+    });
+  });
+
+  it('keeps detail routes on hidden and sidebar modes and returns to /schedules for table mode', () => {
+    expect(resolveRecurringListDisplay({
+      pathname: '/schedules/daily%3Ascan',
+      search: '?scope=personal',
+      requestedMode: 'hidden',
+    })).toMatchObject({
+      effectiveMode: 'hidden',
+      surface: 'recurring-detail',
+      routeAction: 'none',
+      primarySurface: 'recurring-detail',
+      listSurface: 'none',
+      selection: { definitionId: 'daily:scan', source: 'route' },
+      targetPath: '/schedules/daily%3Ascan?scope=personal',
+    });
+
+    expect(resolveRecurringListDisplay({
+      pathname: '/schedules/daily%3Ascan',
+      requestedMode: 'sidebar',
+    })).toMatchObject({
+      effectiveMode: 'sidebar',
+      routeAction: 'none',
+      listSurface: 'sidebar',
+      targetPath: '/schedules/daily%3Ascan',
+    });
+
+    expect(resolveRecurringListDisplay({
+      pathname: '/schedules/daily%3Ascan',
+      requestedMode: 'table',
+    })).toMatchObject({
+      effectiveMode: 'table',
+      routeAction: 'navigate-workflows',
+      primarySurface: 'recurring-table',
+      listSurface: 'table',
+      targetPath: '/schedules',
+    });
   });
 });

--- a/frontend/src/lib/workflowListDisplayMode.ts
+++ b/frontend/src/lib/workflowListDisplayMode.ts
@@ -48,6 +48,36 @@ export type ResolvedWorkflowListDisplay = {
   status: string | null;
 };
 
+export type RecurringListDisplaySurface =
+  | 'recurring-table'
+  | 'recurring-detail'
+  | 'future-recurring-create';
+
+export type RecurringListSelection = {
+  definitionId: string | null;
+  source: 'route' | 'last-selected' | 'first-visible-row' | 'none';
+};
+
+export type ResolvedRecurringListDisplay = {
+  requestedMode: WorkflowListDisplayMode;
+  effectiveMode: WorkflowListDisplayMode;
+  surface: RecurringListDisplaySurface;
+  routeAction: WorkflowListDisplayRouteAction;
+  primarySurface: 'recurring-detail' | 'recurring-table' | 'empty-recurring';
+  listSurface: WorkflowListDisplayListSurface;
+  selection: RecurringListSelection;
+  targetPath: string;
+  status: string | null;
+};
+
+export type ResolveRecurringListDisplayInput = {
+  pathname: string;
+  requestedMode: WorkflowListDisplayMode;
+  search?: string | URLSearchParams | null;
+  selectedDefinitionId?: string | null;
+  firstVisibleDefinitionId?: string | null;
+};
+
 export type ResolveWorkflowListDisplayInput = {
   pathname: string;
   requestedMode: WorkflowListDisplayMode;
@@ -162,6 +192,125 @@ function selectedWorkflow(input: ResolveWorkflowListDisplayInput): WorkflowListS
     return { workflowId: first, source: 'first-visible-row' };
   }
   return { workflowId: null, source: 'none' };
+}
+
+function decodeRecurringDetail(pathname: string): { definitionId: string } | null {
+  const parts = normalizedPathname(pathname).split('/').slice(1);
+  if (parts.length !== 2 || parts[0] !== 'schedules') {
+    return null;
+  }
+  let definitionId: string;
+  try {
+    definitionId = decodeURIComponent(parts[1] ?? '');
+  } catch {
+    return null;
+  }
+  if (!definitionId || definitionId.includes('/') || definitionId.toLowerCase() === 'new') {
+    return null;
+  }
+  return { definitionId };
+}
+
+function selectedRecurring(input: ResolveRecurringListDisplayInput): RecurringListSelection {
+  const selected = input.selectedDefinitionId?.trim();
+  if (selected) {
+    return { definitionId: selected, source: 'last-selected' };
+  }
+  const first = input.firstVisibleDefinitionId?.trim();
+  if (first) {
+    return { definitionId: first, source: 'first-visible-row' };
+  }
+  return { definitionId: null, source: 'none' };
+}
+
+function encodeRecurringDetailPath(
+  definitionId: string,
+  search: string | URLSearchParams | null | undefined,
+): string {
+  return pathWithSearch(`/schedules/${encodeURIComponent(definitionId)}`, search);
+}
+
+export function resolveRecurringListDisplay(
+  input: ResolveRecurringListDisplayInput,
+): ResolvedRecurringListDisplay | null {
+  const pathname = normalizedPathname(input.pathname);
+  const requestedMode = input.requestedMode;
+
+  if (pathname === '/schedules') {
+    if (requestedMode === 'table') {
+      return {
+        requestedMode,
+        effectiveMode: 'table',
+        surface: 'recurring-table',
+        routeAction: 'none',
+        primarySurface: 'recurring-table',
+        listSurface: 'table',
+        selection: { definitionId: null, source: 'none' },
+        targetPath: pathWithSearch('/schedules', input.search),
+        status: null,
+      };
+    }
+
+    const selection = selectedRecurring(input);
+    if (selection.definitionId) {
+      return {
+        requestedMode,
+        effectiveMode: requestedMode,
+        surface: 'recurring-table',
+        routeAction: selection.source === 'first-visible-row'
+          ? 'resolve-first-workflow'
+          : 'navigate-selected-detail',
+        primarySurface: 'recurring-detail',
+        listSurface: requestedMode === 'hidden' ? 'none' : 'sidebar',
+        selection,
+        targetPath: encodeRecurringDetailPath(selection.definitionId, input.search),
+        status: null,
+      };
+    }
+
+    return {
+      requestedMode,
+      effectiveMode: 'table',
+      surface: 'recurring-table',
+      routeAction: 'none',
+      primarySurface: 'empty-recurring',
+      listSurface: 'table',
+      selection,
+      targetPath: pathWithSearch('/schedules', input.search),
+      status: 'No recurring schedule can be opened from the current list.',
+    };
+  }
+
+  const detail = decodeRecurringDetail(pathname);
+  if (!detail) {
+    return null;
+  }
+
+  if (requestedMode === 'table') {
+    return {
+      requestedMode,
+      effectiveMode: 'table',
+      surface: 'recurring-detail',
+      routeAction: 'navigate-workflows',
+      primarySurface: 'recurring-table',
+      listSurface: 'table',
+      selection: { definitionId: detail.definitionId, source: 'route' },
+      targetPath: '/schedules',
+      status: null,
+    };
+  }
+
+  return {
+    requestedMode,
+    effectiveMode: requestedMode,
+    surface: 'recurring-detail',
+    routeAction: 'none',
+    primarySurface: 'recurring-detail',
+    listSurface: requestedMode === 'hidden' ? 'none' : 'sidebar',
+    selection: { definitionId: detail.definitionId, source: 'route' },
+    targetPath: pathWithSearch(pathname, input.search),
+    status: null,
+  };
 }
 
 export function resolveWorkflowListDisplay(

--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -328,14 +328,14 @@ samp {
 }
 
 .workflow-list-display-option--selected,
-.workflow-list-display-option[aria-pressed="true"] {
+.workflow-list-display-option[aria-checked="true"] {
   border-color: rgb(var(--mm-accent) / 0.6);
   background: rgb(var(--mm-accent) / 0.14);
   color: rgb(var(--mm-accent));
 }
 
 .workflow-list-display-option--selected:hover,
-.workflow-list-display-option[aria-pressed="true"]:hover {
+.workflow-list-display-option[aria-checked="true"]:hover {
   border-color: rgb(var(--mm-accent-2) / 0.72);
   background: rgb(var(--mm-accent-2) / 0.1);
 }

--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -1442,6 +1442,98 @@ h1 {
   gap: 0.75rem;
 }
 
+.recurring-schedule-workspace {
+  display: grid;
+  grid-template-columns: minmax(14rem, 18rem) minmax(0, 1fr);
+  gap: 0.9rem;
+  align-items: start;
+  min-width: 0;
+}
+
+.recurring-schedule-workspace-detail {
+  min-width: 0;
+}
+
+.recurring-schedule-sidebar {
+  position: sticky;
+  top: 0.85rem;
+  display: grid;
+  gap: 0;
+  min-width: 0;
+  overflow: hidden;
+  border: 1px solid rgb(var(--mm-border) / 0.76);
+  border-radius: 0.68rem;
+  background: rgb(var(--mm-panel) / 0.86);
+  box-shadow: 0 18px 32px -28px rgb(var(--mm-ink) / 0.48);
+}
+
+.recurring-schedule-sidebar-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  min-height: 2.65rem;
+  padding: 0 0.85rem;
+  border-bottom: 1px solid rgb(var(--mm-border) / 0.72);
+  color: rgb(var(--mm-ink));
+}
+
+.recurring-schedule-sidebar-list {
+  display: grid;
+  max-height: calc(100vh - 13rem);
+  overflow: auto;
+}
+
+.recurring-schedule-sidebar-row {
+  display: grid;
+  gap: 0.18rem;
+  min-height: 3.7rem;
+  min-width: 0;
+  padding: 0.65rem 0.85rem;
+  border-bottom: 1px solid rgb(var(--mm-border) / 0.56);
+  color: rgb(var(--mm-ink));
+  text-decoration: none;
+}
+
+.recurring-schedule-sidebar-row:hover,
+.recurring-schedule-sidebar-row:focus-visible {
+  background: rgb(var(--mm-accent-2) / 0.1);
+  outline: none;
+}
+
+.recurring-schedule-sidebar-row:focus-visible {
+  box-shadow: inset var(--mm-control-focus-ring);
+}
+
+.recurring-schedule-sidebar-row--active,
+.recurring-schedule-sidebar-row[aria-current="page"] {
+  background: rgb(var(--mm-accent) / 0.12);
+  color: rgb(var(--mm-accent));
+}
+
+.recurring-schedule-sidebar-name,
+.recurring-schedule-sidebar-meta {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.recurring-schedule-sidebar-name {
+  font-size: 0.9rem;
+  font-weight: 760;
+}
+
+.recurring-schedule-sidebar-meta,
+.recurring-schedule-sidebar-state {
+  color: rgb(var(--mm-muted));
+  font-size: 0.78rem;
+}
+
+.recurring-schedule-sidebar-state {
+  margin: 0;
+  padding: 0.8rem 0.85rem;
+}
+
 .schedules-detail-page {
   min-width: 0;
 }
@@ -2542,6 +2634,14 @@ tbody tr:hover {
 }
 
 @media (max-width: 720px) {
+  .recurring-schedule-workspace {
+    display: block;
+  }
+
+  .recurring-schedule-sidebar {
+    display: none;
+  }
+
   .schedules-summary-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }

--- a/frontend/src/styles/dashboardBrand.test.ts
+++ b/frontend/src/styles/dashboardBrand.test.ts
@@ -47,13 +47,13 @@ describe('dashboard masthead brand styles', () => {
     expect(cssRuleBlock('.workflow-list-display-option:focus-visible')).toContain(
       'box-shadow: var(--mm-control-focus-ring);',
     );
-    expect(cssRuleBlock('.workflow-list-display-option[aria-pressed="true"]')).toContain(
+    expect(cssRuleBlock('.workflow-list-display-option[aria-checked="true"]')).toContain(
       'border-color: rgb(var(--mm-accent) / 0.6);',
     );
-    expect(cssRuleBlock('.workflow-list-display-option[aria-pressed="true"]:hover')).toContain(
+    expect(cssRuleBlock('.workflow-list-display-option[aria-checked="true"]:hover')).toContain(
       'border-color: rgb(var(--mm-accent-2) / 0.72);',
     );
-    expect(cssRuleBlock('.workflow-list-display-option[aria-pressed="true"]:hover')).not.toContain(
+    expect(cssRuleBlock('.workflow-list-display-option[aria-checked="true"]:hover')).not.toContain(
       'color: rgb(var(--mm-ink));',
     );
   });

--- a/reports/remediation_attempt-1.json
+++ b/reports/remediation_attempt-1.json
@@ -1,0 +1,69 @@
+{
+  "artifact_type": "remediation.attempt",
+  "attempt": 1,
+  "issue_ref": "MoonLadderStudios/MoonMind#3068",
+  "source_verification_artifact": "artifacts/github-issue-implement-verify.json",
+  "source_verdict": "ADDITIONAL_WORK_NEEDED",
+  "summary": "Remediated the verifier-reported Recurring workspace gaps by changing the shared masthead list display control from pressed buttons to radio-role options with aria-checked state, adding focused Recurring mode-resolution and accessibility assertions, and adding mobile Recurring sidebar/control absence coverage where feasible.",
+  "changed_files": [
+    "frontend/src/entrypoints/dashboard-app.tsx",
+    "frontend/src/entrypoints/dashboard.test.tsx",
+    "frontend/src/lib/workflowListDisplayMode.test.ts",
+    "frontend/src/styles/dashboard.css",
+    "frontend/src/styles/dashboardBrand.test.ts",
+    "tests/e2e/test_masthead_workflow_list_display_browser.py"
+  ],
+  "gap_statuses": [
+    {
+      "requirement": "Masthead selector is a real radio group, not three disconnected buttons.",
+      "gap_type": "implementation",
+      "status": "fixed",
+      "evidence": [
+        "frontend/src/entrypoints/dashboard-app.tsx now renders each display-mode option with role=\"radio\", aria-checked, roving tabIndex, and arrow/Home/End key handling.",
+        "frontend/src/styles/dashboard.css selected-state styling now keys off aria-checked instead of aria-pressed.",
+        "frontend/src/entrypoints/dashboard.test.tsx asserts radio roles, aria-checked state, and absence of aria-pressed on the list display options."
+      ]
+    },
+    {
+      "requirement": "Tests cover mode resolution and accessibility labels.",
+      "gap_type": "verification",
+      "status": "fixed",
+      "evidence": [
+        "frontend/src/lib/workflowListDisplayMode.test.ts adds resolveRecurringListDisplay coverage for table, selected sidebar/hidden, first-visible fallback, empty-list fallback, and detail hidden/sidebar/table branches.",
+        "frontend/src/entrypoints/dashboard.test.tsx continues to cover Recurring list display accessible name, route transitions, and sidebar selection using radio semantics."
+      ]
+    },
+    {
+      "requirement": "Mobile keeps a usable list-to-detail flow without exposing non-rendered desktop sidebar controls.",
+      "gap_type": "verification",
+      "status": "partially_fixed_static_verified_browser_blocked",
+      "evidence": [
+        "frontend/src/entrypoints/dashboard.test.tsx asserts mobile CSS hides .workflow-list-display-control at max-width 767px and .recurring-schedule-sidebar at max-width 720px.",
+        "tests/e2e/test_masthead_workflow_list_display_browser.py was updated so future browser runs assert Recurring mobile routes expose neither the Recurring list display radiogroup nor Recurring schedule navigation complementary region."
+      ],
+      "remaining_blocker": "The existing browser/e2e path could not run in this runtime because Python pytest is not installed: `python -m pytest --version` failed with `/usr/local/bin/python: No module named pytest`."
+    }
+  ],
+  "targeted_checks": [
+    {
+      "command": "npm run ui:test -- frontend/src/lib/workflowListDisplayMode.test.ts frontend/src/entrypoints/dashboard.test.tsx frontend/src/entrypoints/schedules.test.tsx",
+      "result": "PASS",
+      "notes": "3 test files passed, 141 tests passed."
+    },
+    {
+      "command": "npm run ui:test -- frontend/src/styles/dashboardBrand.test.ts",
+      "result": "PASS",
+      "notes": "1 test file passed, 2 tests passed."
+    },
+    {
+      "command": "npm run ui:test -- frontend/src/lib/workflowListDisplayMode.test.ts frontend/src/entrypoints/dashboard.test.tsx frontend/src/entrypoints/schedules.test.tsx frontend/src/styles/dashboardBrand.test.ts",
+      "result": "PASS",
+      "notes": "4 test files passed, 143 tests passed."
+    },
+    {
+      "command": "python -m pytest --version",
+      "result": "FAIL",
+      "notes": "Python pytest is unavailable in this runtime: /usr/local/bin/python: No module named pytest. Browser/e2e execution was therefore not feasible locally."
+    }
+  ]
+}

--- a/reports/remediation_verification-1.json
+++ b/reports/remediation_verification-1.json
@@ -1,0 +1,37 @@
+{
+  "artifact_type": "remediation.verification",
+  "attempt": 1,
+  "verifiesRemediationAttempt": 1,
+  "remediationAttemptArtifact": "reports/remediation_attempt-1.json",
+  "issue_ref": "MoonLadderStudios/MoonMind#3068",
+  "sourceBriefArtifact": "artifacts/github-issue-implement-brief.json",
+  "sourceAssessmentArtifact": "artifacts/github-issue-implement-assessment.json",
+  "authoritativeVerdict": "FULLY_IMPLEMENTED",
+  "verdict": "FULLY_IMPLEMENTED",
+  "recommendedNextAction": "advance",
+  "recoverableInCurrentRuntime": true,
+  "summary": "Verification attempt 1 confirms remediation attempt 1 satisfies all repo-verifiable issue requirements. The remaining unavailable browser/mobile execution is recorded as a non-blocking environment limitation, not remaining implementation work.",
+  "verificationArtifact": "artifacts/github-issue-implement-verify.json",
+  "testResults": [
+    {
+      "command": "npm run ui:test -- frontend/src/lib/workflowListDisplayMode.test.ts frontend/src/entrypoints/dashboard.test.tsx frontend/src/entrypoints/schedules.test.tsx frontend/src/styles/dashboardBrand.test.ts",
+      "result": "PASS",
+      "notes": "4 test files passed, 143 tests passed."
+    },
+    {
+      "command": "MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --ui-args frontend/src/lib/workflowListDisplayMode.test.ts frontend/src/entrypoints/dashboard.test.tsx frontend/src/entrypoints/schedules.test.tsx frontend/src/styles/dashboardBrand.test.ts",
+      "result": "FAIL",
+      "nonBlocking": true,
+      "notes": "Failed before UI execution because Python pytest is unavailable: /usr/local/bin/python: No module named pytest."
+    }
+  ],
+  "remainingWork": [],
+  "environmentNotes": [
+    {
+      "tooling": "Python pytest / browser e2e harness",
+      "status": "NOT_AVAILABLE",
+      "gatesVerdict": false,
+      "reason": "Advisory browser/mobile checks depend on unavailable Python pytest in this runtime."
+    }
+  ]
+}

--- a/tests/e2e/test_masthead_workflow_list_display_browser.py
+++ b/tests/e2e/test_masthead_workflow_list_display_browser.py
@@ -83,7 +83,7 @@ def test_mm1114_desktop_masthead_order_and_radio_semantics(server, path: str) ->
     with sync_playwright() as p:
         with _playwright_page(p) as page:
             page.goto(f"http://127.0.0.1:8013{path}", wait_until="domcontentloaded")
-            group = page.get_by_role("group", name="Workflow list display")
+            group = page.get_by_role("radiogroup", name="Workflow list display")
             expect(group).to_be_visible(timeout=15_000)
 
             brand_box = page.get_by_role("link", name="MoonMind workflows").bounding_box()
@@ -94,37 +94,37 @@ def test_mm1114_desktop_masthead_order_and_radio_semantics(server, path: str) ->
             assert nav_box is not None
             assert brand_box["x"] < group_box["x"] < nav_box["x"]
 
-            expect(page.get_by_role("button", name="No list")).to_be_visible()
-            expect(page.get_by_role("button", name="Sidebar list")).to_be_visible()
-            expect(page.get_by_role("button", name="Full screen table")).to_be_visible()
+            expect(page.get_by_role("radio", name="No list")).to_be_visible()
+            expect(page.get_by_role("radio", name="Sidebar list")).to_be_visible()
+            expect(page.get_by_role("radio", name="Full screen table")).to_be_visible()
 
 
 def test_mm1114_keyboard_changes_options_and_restores_route_focus(server) -> None:
     with sync_playwright() as p:
         with _playwright_page(p) as page:
             page.goto("http://127.0.0.1:8013/workflows/new", wait_until="domcontentloaded")
-            expect(page.get_by_role("group", name="Workflow list display")).to_be_visible(timeout=15_000)
+            expect(page.get_by_role("radiogroup", name="Workflow list display")).to_be_visible(timeout=15_000)
 
             page.get_by_role("link", name="MoonMind workflows").focus()
-            expect(page.get_by_role("button", name="Sidebar list")).to_have_attribute("aria-pressed", "true")
-            expect(page.get_by_role("button", name="Sidebar list")).to_be_enabled()
+            expect(page.get_by_role("radio", name="Sidebar list")).to_have_attribute("aria-checked", "true")
+            expect(page.get_by_role("radio", name="Sidebar list")).to_be_enabled()
 
-            page.get_by_role("button", name="Full screen table").click()
+            page.get_by_role("radio", name="Full screen table").click()
             page.wait_for_url("**/workflows")
-            expect(page.get_by_role("button", name="Full screen table")).to_have_attribute("aria-pressed", "true")
-            expect(page.get_by_role("button", name="Full screen table")).to_be_focused()
+            expect(page.get_by_role("radio", name="Full screen table")).to_have_attribute("aria-checked", "true")
+            expect(page.get_by_role("radio", name="Full screen table")).to_be_focused()
 
 
 def test_mm1121_create_route_supports_sidebar_hidden_and_table_modes(server) -> None:
     with sync_playwright() as p:
         with _playwright_page(p, width=1280) as page:
             page.goto("http://127.0.0.1:8013/workflows/new", wait_until="domcontentloaded")
-            expect(page.get_by_role("group", name="Workflow list display")).to_be_visible(timeout=15_000)
+            expect(page.get_by_role("radiogroup", name="Workflow list display")).to_be_visible(timeout=15_000)
             expect(page.get_by_role("button", name="Start Workflow")).to_be_visible()
 
-            page.get_by_role("button", name="Sidebar list").click()
+            page.get_by_role("radio", name="Sidebar list").click()
             page.wait_for_url("**/workflows/new")
-            expect(page.get_by_role("button", name="Sidebar list")).to_have_attribute("aria-pressed", "true")
+            expect(page.get_by_role("radio", name="Sidebar list")).to_have_attribute("aria-checked", "true")
             expect(page.get_by_role("complementary", name="Workflow navigation")).to_be_visible()
             expect(page.get_by_role("main", name="Create workflow")).to_be_visible()
             expect(page.get_by_role("button", name="Start Workflow")).to_be_visible()
@@ -136,23 +136,33 @@ def test_mm1121_create_route_supports_sidebar_hidden_and_table_modes(server) -> 
             assert panel_box["width"] > 1200
             assert abs(panel_box["width"] - shell_box["width"]) <= 4
 
-            page.get_by_role("button", name="No list").click()
+            page.get_by_role("radio", name="No list").click()
             page.wait_for_url("**/workflows/new")
-            expect(page.get_by_role("button", name="No list")).to_have_attribute("aria-pressed", "true")
+            expect(page.get_by_role("radio", name="No list")).to_have_attribute("aria-checked", "true")
             expect(page.get_by_role("complementary", name="Workflow navigation")).to_have_count(0)
             expect(page.get_by_role("button", name="Start Workflow")).to_be_visible()
 
-            page.get_by_role("button", name="Full screen table").click()
+            page.get_by_role("radio", name="Full screen table").click()
             page.wait_for_url("**/workflows")
-            expect(page.get_by_role("button", name="Full screen table")).to_have_attribute("aria-pressed", "true")
+            expect(page.get_by_role("radio", name="Full screen table")).to_have_attribute("aria-checked", "true")
 
 
 def test_mm1114_non_participating_and_mobile_surfaces_hide_control(server) -> None:
     with sync_playwright() as p:
         with _playwright_page(p) as page:
             page.goto("http://127.0.0.1:8013/settings", wait_until="domcontentloaded")
-            expect(page.get_by_role("group", name="Workflow list display")).to_have_count(0)
+            expect(page.get_by_role("radiogroup", name="Workflow list display")).to_have_count(0)
 
         with _playwright_page(p, width=390, height=844) as page:
             page.goto("http://127.0.0.1:8013/workflows", wait_until="domcontentloaded")
-            expect(page.get_by_role("group", name="Workflow list display")).to_have_count(0)
+            expect(page.get_by_role("radiogroup", name="Workflow list display")).to_have_count(0)
+
+        with _playwright_page(p, width=390, height=844) as page:
+            page.goto("http://127.0.0.1:8013/schedules", wait_until="domcontentloaded")
+            expect(page.get_by_role("radiogroup", name="Recurring list display")).to_have_count(0)
+            expect(page.get_by_role("complementary", name="Recurring schedule navigation")).to_have_count(0)
+
+        with _playwright_page(p, width=390, height=844) as page:
+            page.goto("http://127.0.0.1:8013/schedules/mobile-check", wait_until="domcontentloaded")
+            expect(page.get_by_role("radiogroup", name="Recurring list display")).to_have_count(0)
+            expect(page.get_by_role("complementary", name="Recurring schedule navigation")).to_have_count(0)


### PR DESCRIPTION
Issue reference: MoonLadderStudios/MoonMind#3068

Summary:
- Renames the dashboard surface from Schedules to Recurring while keeping the existing /schedules route.
- Adds Recurring-aware list display mode routing so /schedules defaults to the table and detail routes default to the recurring schedule sidebar.
- Adds a recurring schedule sidebar for detail views with active schedule highlighting and aria-current support.
- Extends focused frontend coverage for mode resolution, route transitions, summary metrics, sidebar selection, and accessible masthead labels.

Tests run:
- npm run ui:test -- frontend/src/lib/workflowListDisplayMode.test.ts frontend/src/entrypoints/dashboard.test.tsx frontend/src/entrypoints/schedules.test.tsx frontend/src/styles/dashboardBrand.test.ts
- MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --ui-args frontend/src/lib/workflowListDisplayMode.test.ts frontend/src/entrypoints/dashboard.test.tsx frontend/src/entrypoints/schedules.test.tsx frontend/src/styles/dashboardBrand.test.ts (failed before running UI target: Python pytest is not installed in this runtime)
- python -m pytest --version (failed: Python pytest is not installed in this runtime)

Remaining risks:
- Browser/mobile accessibility execution was not available locally because Python pytest is missing; static CSS and e2e source coverage were verified by the post-remediation verifier.
- Hermetic integration tests were not selected because this change is limited to frontend route, masthead, sidebar, and styling behavior.
