### PR TITLE
MM-1151: Declarative Omnigent Bridge configuration and compatibility contract

### DIFF
--- a/moonmind/omnigent/bridge_config.py
+++ b/moonmind/omnigent/bridge_config.py
@@ -35,7 +35,7 @@ errors.
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, Iterator, Literal, Union
+from typing import Any, Iterator, Literal
 
 import yaml
 from pydantic import (
@@ -78,7 +78,7 @@ FirstMessageState = Literal[
     "terminal",
 ]
 
-WorkspaceDiffsCapture = Union[bool, Literal["capability_probe"]]
+WorkspaceDiffsCapture = bool | Literal["capability_probe"]
 
 # §2.1 Omnigent nouns recognized in bridge routes. Route values must reference at
 # least one of these so the boundary keeps Omnigent vocabulary.
@@ -188,7 +188,11 @@ def _is_host_build_key(normalized_key: str) -> bool:
         return False
     if "custom" in normalized_key:
         return True
-    return any(marker in normalized_key for marker in _HOST_BUILD_MARKERS)
+    # "dispatch" contains the "patch" build marker; strip it first so common
+    # dispatch-style keys (hostDispatch, hostDispatcher) are not mistaken for a
+    # custom host build request.
+    key_for_checking = normalized_key.replace("dispatch", "")
+    return any(marker in key_for_checking for marker in _HOST_BUILD_MARKERS)
 
 
 def _reject_host_build_configuration(data: Mapping[str, Any]) -> None:

--- a/moonmind/omnigent/bridge_config.py
+++ b/moonmind/omnigent/bridge_config.py
@@ -1,0 +1,606 @@
+"""Declarative Omnigent Bridge configuration and compatibility contract.
+
+MM-1151 (source: MM-1140): Declarative Omnigent Bridge configuration and
+compatibility contract.
+
+This module parses and validates the ``schemaVersion:
+moonmind.omnigent_bridge.v1`` declarative configuration defined in
+``docs/Omnigent/OmnigentBridge.md`` §6, with safe defaults and actionable
+errors. It is the single canonical entrypoint (§18.2 component-to-module
+ownership) through which downstream bridge components read the operator-declared
+bridge boundary configuration.
+
+The contract enforces the design principles that make the bridge safe by
+construction:
+
+* **Omnigent vocabulary at the boundary (§2.1).** Routes and profiles must use
+  Omnigent-style nouns (``session``, ``event``, ``stream``, ``host``,
+  ``runner``, ``resource``). A new external product vocabulary such as
+  ``runtime bus``, ``agent socket``, or ``conversation broker`` is rejected.
+* **Keep the host unchanged (§2.3).** ``compatibility.hostUnchanged`` must be
+  ``true``. Only deployment configuration is accepted; any configuration that
+  requires a custom host build is rejected.
+* **Proxy-first compatibility (§2.4).** ``hostProtocolMode`` accepts
+  ``upstream_omnigent_server_proxy`` and ``embedded_omnigent_compatible_server``
+  and defaults to the proxy mode. Unknown modes fail fast.
+* **MoonMind authority (§1).** The authority map (``temporal=moonmind``,
+  ``artifacts=moonmind``, ``liveExecution=omnigent_host``) is validated and
+  surfaced to downstream components.
+
+Parsing is deterministic and side-effect-free so the configuration can be
+validated at workflow/activity/adapter boundaries and fail fast with actionable
+errors.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, Iterator, Literal, Union
+
+import yaml
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    ValidationError,
+    field_validator,
+    model_validator,
+)
+
+# ---------------------------------------------------------------------------
+# Contract constants
+# ---------------------------------------------------------------------------
+
+OMNIGENT_BRIDGE_CONFIG_SCHEMA_VERSION = "moonmind.omnigent_bridge.v1"
+
+# §2.4 host protocol modes. Proxy is preferred (proxy-first default).
+HOST_PROTOCOL_MODE_PROXY = "upstream_omnigent_server_proxy"
+HOST_PROTOCOL_MODE_EMBEDDED = "embedded_omnigent_compatible_server"
+
+HostProtocolMode = Literal[
+    "upstream_omnigent_server_proxy",
+    "embedded_omnigent_compatible_server",
+]
+
+# §9.3 first-message idempotency state machine, in canonical order.
+CANONICAL_FIRST_MESSAGE_STATES: tuple[str, ...] = (
+    "not_prepared",
+    "prepared",
+    "posting",
+    "posted",
+    "terminal",
+)
+FirstMessageState = Literal[
+    "not_prepared",
+    "prepared",
+    "posting",
+    "posted",
+    "terminal",
+]
+
+WorkspaceDiffsCapture = Union[bool, Literal["capability_probe"]]
+
+# §2.1 Omnigent nouns recognized in bridge routes. Route values must reference at
+# least one of these so the boundary keeps Omnigent vocabulary.
+_OMNIGENT_ROUTE_NOUNS: tuple[str, ...] = (
+    "agents",
+    "session",
+    "sessions",
+    "event",
+    "events",
+    "stream",
+    "resource",
+    "resources",
+    "snapshot",
+    "interrupt",
+    "stop_session",
+    "host",
+    "runner",
+    "elicitation",
+    "elicitations",
+)
+
+# §2.1 banned external product vocabulary. Stored as (normalized, display) pairs
+# so we can detect the concept regardless of separators or casing.
+_BANNED_EXTERNAL_VOCABULARY: tuple[tuple[str, str], ...] = (
+    ("runtimebus", "runtime bus"),
+    ("agentsocket", "agent socket"),
+    ("conversationbroker", "conversation broker"),
+)
+
+# §2.3 markers that indicate a configuration key is requesting a custom host
+# build rather than stock deployment configuration.
+_HOST_BUILD_MARKERS: tuple[str, ...] = (
+    "build",
+    "dockerfile",
+    "sourcepatch",
+    "patch",
+    "rebuild",
+    "recompile",
+    "compile",
+    "fork",
+)
+
+_OMNIGENT_PROFILE_PREFIX = "omnigent."
+
+
+class BridgeConfigError(ValueError):
+    """Raised when the declarative Omnigent Bridge configuration is invalid.
+
+    Used for fail-fast handling at parse boundaries with actionable messages.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Raw-input policy scans (run before structural validation so unknown keys and
+# arbitrary string values are still subject to the vocabulary/host-build gates).
+# ---------------------------------------------------------------------------
+
+
+def _normalize_identifier(text: str) -> str:
+    """Collapse a token to lowercase alphanumerics only.
+
+    ``runtime-bus``, ``runtime_bus``, ``runtime bus`` and ``runtimeBus`` all
+    normalize to ``runtimebus`` so vocabulary detection is separator/case
+    insensitive.
+    """
+
+    return "".join(ch for ch in text.lower() if ch.isalnum())
+
+
+def _iter_strings(data: Any, prefix: str = "") -> Iterator[tuple[str, bool, str]]:
+    """Yield ``(path, is_key, text)`` for every mapping key and string value."""
+
+    if isinstance(data, Mapping):
+        for key, value in data.items():
+            key_str = str(key)
+            key_path = f"{prefix}.{key_str}" if prefix else key_str
+            yield key_path, True, key_str
+            yield from _iter_strings(value, key_path)
+    elif isinstance(data, (list, tuple)):
+        for index, item in enumerate(data):
+            yield from _iter_strings(item, f"{prefix}[{index}]")
+    elif isinstance(data, str):
+        yield prefix, False, data
+
+
+def _reject_external_vocabulary(data: Mapping[str, Any]) -> None:
+    """Reject any key/value that introduces non-Omnigent product vocabulary."""
+
+    for path, is_key, text in _iter_strings(data):
+        normalized = _normalize_identifier(text)
+        for banned_normalized, banned_display in _BANNED_EXTERNAL_VOCABULARY:
+            if banned_normalized in normalized:
+                where = "key" if is_key else "value"
+                raise BridgeConfigError(
+                    f"bridge config {where} at '{path}' uses non-Omnigent external "
+                    f"vocabulary '{text}': the bridge boundary must use Omnigent "
+                    f"nouns (session, event, stream, host, runner, resource) and "
+                    f"must not introduce a new product vocabulary such as "
+                    f"'{banned_display}' (§2.1)."
+                )
+
+
+def _is_host_build_key(normalized_key: str) -> bool:
+    """Return True when a key requests a custom host build (§2.3)."""
+
+    if "host" not in normalized_key:
+        return False
+    if "custom" in normalized_key:
+        return True
+    return any(marker in normalized_key for marker in _HOST_BUILD_MARKERS)
+
+
+def _reject_host_build_configuration(data: Mapping[str, Any]) -> None:
+    """Reject configuration keys that require modifying/building the host."""
+
+    for path, is_key, text in _iter_strings(data):
+        if not is_key:
+            continue
+        if _is_host_build_key(_normalize_identifier(text)):
+            raise BridgeConfigError(
+                f"bridge config key '{path}' requests a custom host build, which is "
+                f"out of scope: the Omnigent Bridge must run against an unchanged, "
+                f"stock Omnigent host (compatibility.hostUnchanged=true). Only "
+                f"deployment configuration (server/base URL, host auth, endpoint "
+                f"refs, network routing, standard Omnigent host settings) is "
+                f"accepted (§2.3)."
+            )
+
+
+def _validate_omnigent_route(field_name: str, path: str) -> str:
+    """Validate a single bridge route path is absolute and Omnigent-shaped."""
+
+    candidate = str(path).strip()
+    if not candidate:
+        raise BridgeConfigError(
+            f"publicApi.routes.{field_name} must not be empty"
+        )
+    if not candidate.startswith("/"):
+        raise BridgeConfigError(
+            f"publicApi.routes.{field_name} '{candidate}' must be an absolute path "
+            f"beginning with '/'."
+        )
+    lowered = candidate.lower()
+    if not any(noun in lowered for noun in _OMNIGENT_ROUTE_NOUNS):
+        raise BridgeConfigError(
+            f"publicApi.routes.{field_name} '{candidate}' is not an Omnigent-shaped "
+            f"route: bridge routes must use Omnigent nouns such as "
+            f"agents/sessions/events/stream/resources (§2.1)."
+        )
+    return candidate
+
+
+def _require_omnigent_profile(field_name: str, value: Any) -> str:
+    candidate = str(value).strip()
+    if not candidate:
+        raise BridgeConfigError(f"{field_name} must not be empty")
+    if not candidate.startswith(_OMNIGENT_PROFILE_PREFIX):
+        raise BridgeConfigError(
+            f"{field_name} '{candidate}' must be an Omnigent-namespaced profile "
+            f"(e.g. 'omnigent.server.v1'); a non-Omnigent external product "
+            f"vocabulary is not allowed at the bridge boundary (§2.1)."
+        )
+    return candidate
+
+
+# ---------------------------------------------------------------------------
+# Configuration blocks (§6)
+# ---------------------------------------------------------------------------
+
+
+class BridgeAuthority(BaseModel):
+    """Authority map (§1): who owns each responsibility.
+
+    MoonMind owns durable orchestration (Temporal) and artifact authority; the
+    Omnigent host owns live runtime execution. These are fixed by the contract
+    and surfaced to downstream components.
+    """
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    temporal: Literal["moonmind"] = "moonmind"
+    artifacts: Literal["moonmind"] = "moonmind"
+    live_execution: Literal["omnigent_host"] = Field(
+        "omnigent_host", alias="liveExecution"
+    )
+
+
+class BridgeCompatibility(BaseModel):
+    """Compatibility block (§2.3, §2.4): host-unchanged + protocol mode."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    profile: str = "omnigent.server.v1"
+    host_unchanged: bool = Field(True, alias="hostUnchanged")
+    host_protocol_mode: HostProtocolMode = Field(
+        HOST_PROTOCOL_MODE_PROXY, alias="hostProtocolMode"
+    )
+
+    @field_validator("profile")
+    @classmethod
+    def _profile_must_be_omnigent(cls, value: Any) -> str:
+        return _require_omnigent_profile("compatibility.profile", value)
+
+    @field_validator("host_unchanged")
+    @classmethod
+    def _host_must_be_unchanged(cls, value: bool) -> bool:
+        if value is not True:
+            raise BridgeConfigError(
+                "compatibility.hostUnchanged must be true: the Omnigent Bridge must "
+                "run against an unchanged, stock Omnigent host. A custom "
+                "MoonMind-specific host build is out of scope (§2.3)."
+            )
+        return value
+
+
+class BridgePublicApiRoutes(BaseModel):
+    """Omnigent-shaped public API routes (§4.1, §6)."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    agents: str = "/api/agents"
+    create_session: str = Field("/v1/sessions", alias="createSession")
+    get_session: str = Field("/v1/sessions/{session_id}", alias="getSession")
+    post_event: str = Field("/v1/sessions/{session_id}/events", alias="postEvent")
+    stream_events: str = Field(
+        "/v1/sessions/{session_id}/stream", alias="streamEvents"
+    )
+    changed_files: str = Field(
+        "/v1/sessions/{session_id}/resources/environments/default/changes",
+        alias="changedFiles",
+    )
+    workspace_files: str = Field(
+        "/v1/sessions/{session_id}/resources/environments/default/filesystem",
+        alias="workspaceFiles",
+    )
+    workspace_diffs: str = Field(
+        "/v1/sessions/{session_id}/resources/environments/default/diff/{path}",
+        alias="workspaceDiffs",
+    )
+    session_files: str = Field(
+        "/v1/sessions/{session_id}/resources/files", alias="sessionFiles"
+    )
+
+    @model_validator(mode="after")
+    def _routes_are_omnigent_shaped(self) -> "BridgePublicApiRoutes":
+        for field_name in type(self).model_fields:
+            value = getattr(self, field_name)
+            setattr(self, field_name, _validate_omnigent_route(field_name, value))
+        return self
+
+
+class BridgePublicApi(BaseModel):
+    """Public API surface (§6): mount path + Omnigent-compatible routes."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    mount_path: str = Field("/api/omnigent", alias="mountPath")
+    expose_omnigent_compatible_routes: bool = Field(
+        True, alias="exposeOmnigentCompatibleRoutes"
+    )
+    routes: BridgePublicApiRoutes = Field(default_factory=BridgePublicApiRoutes)
+
+    @field_validator("mount_path")
+    @classmethod
+    def _validate_mount_path(cls, value: Any) -> str:
+        candidate = str(value).strip()
+        if not candidate.startswith("/"):
+            raise BridgeConfigError(
+                "publicApi.mountPath must be an absolute path beginning with '/'."
+            )
+        return candidate
+
+
+class BridgeEmbeddedHostConnection(BaseModel):
+    """Embedded host-facing server settings (§6) for embedded mode."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    bind_address: str = Field("0.0.0.0", alias="bindAddress")
+    port: int = Field(8000, ge=1, le=65535)
+    auth_mode: str = Field("header_or_token", alias="authMode")
+    protocol_profile: str = Field(
+        "omnigent.host_runner.v1", alias="protocolProfile"
+    )
+
+    @field_validator("protocol_profile")
+    @classmethod
+    def _protocol_profile_must_be_omnigent(cls, value: Any) -> str:
+        return _require_omnigent_profile(
+            "hostConnection.embedded.protocolProfile", value
+        )
+
+
+class BridgeHostConnection(BaseModel):
+    """Host connection block (§6).
+
+    ``mode`` defaults to (and must agree with) ``compatibility.hostProtocolMode``
+    so there is a single source of truth for the active protocol mode.
+    """
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    mode: HostProtocolMode | None = None
+    upstream_server_url_ref: str = Field("default", alias="upstreamServerUrlRef")
+    embedded: BridgeEmbeddedHostConnection = Field(
+        default_factory=BridgeEmbeddedHostConnection
+    )
+
+
+class BridgeCaptureDefaults(BaseModel):
+    """Per-session capture defaults (§6)."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    stream: bool = True
+    snapshots: bool = True
+    changed_files: bool = Field(True, alias="changedFiles")
+    workspace_files: bool = Field(True, alias="workspaceFiles")
+    workspace_diffs: WorkspaceDiffsCapture = Field(
+        "capability_probe", alias="workspaceDiffs"
+    )
+    session_files: bool = Field(True, alias="sessionFiles")
+    child_sessions: bool = Field(True, alias="childSessions")
+
+
+class BridgeSessionDefaults(BaseModel):
+    """Session defaults (§6)."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    host_type: Literal["managed", "external"] = Field("managed", alias="hostType")
+    delete_provider_session_after_harvest: bool = Field(
+        False, alias="deleteProviderSessionAfterHarvest"
+    )
+    capture: BridgeCaptureDefaults = Field(default_factory=BridgeCaptureDefaults)
+
+
+class BridgeIdempotency(BaseModel):
+    """First-message idempotency block (§6, §9.3)."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    first_message_state_machine: tuple[FirstMessageState, ...] = Field(
+        default=CANONICAL_FIRST_MESSAGE_STATES,
+        alias="firstMessageStateMachine",
+    )
+    include_idempotency_marker: bool = Field(True, alias="includeIdempotencyMarker")
+    reconcile_posting_state: bool = Field(True, alias="reconcilePostingState")
+
+    @field_validator("first_message_state_machine")
+    @classmethod
+    def _canonical_order(
+        cls, value: tuple[FirstMessageState, ...]
+    ) -> tuple[FirstMessageState, ...]:
+        if tuple(value) != CANONICAL_FIRST_MESSAGE_STATES:
+            raise BridgeConfigError(
+                "idempotency.firstMessageStateMachine must be the canonical order: "
+                "not_prepared -> prepared -> posting -> posted -> terminal (§9.3)."
+            )
+        return tuple(value)
+
+
+class BridgeObservability(BaseModel):
+    """Observability block (§6)."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    write_raw_event_journal: bool = Field(True, alias="writeRawEventJournal")
+    write_normalized_event_journal: bool = Field(
+        True, alias="writeNormalizedEventJournal"
+    )
+    feed_workflow_chat: bool = Field(True, alias="feedWorkflowChat")
+    feed_agent_run_observability: bool = Field(
+        True, alias="feedAgentRunObservability"
+    )
+    fallback_to_legacy_managed_run_logs: bool = Field(
+        True, alias="fallbackToLegacyManagedRunLogs"
+    )
+
+
+class OmnigentBridgeConfig(BaseModel):
+    """Parsed ``moonmind.omnigent_bridge.v1`` declarative bridge configuration.
+
+    Built with safe defaults so a minimal document (or an empty one) yields a
+    valid proxy-first bridge configuration, while unsupported values fail fast.
+    """
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    schema_version: Literal["moonmind.omnigent_bridge.v1"] = Field(
+        OMNIGENT_BRIDGE_CONFIG_SCHEMA_VERSION, alias="schemaVersion"
+    )
+    enabled: bool = True
+    authority: BridgeAuthority = Field(default_factory=BridgeAuthority)
+    compatibility: BridgeCompatibility = Field(default_factory=BridgeCompatibility)
+    public_api: BridgePublicApi = Field(
+        default_factory=BridgePublicApi, alias="publicApi"
+    )
+    host_connection: BridgeHostConnection = Field(
+        default_factory=BridgeHostConnection, alias="hostConnection"
+    )
+    session_defaults: BridgeSessionDefaults = Field(
+        default_factory=BridgeSessionDefaults, alias="sessionDefaults"
+    )
+    idempotency: BridgeIdempotency = Field(default_factory=BridgeIdempotency)
+    observability: BridgeObservability = Field(
+        default_factory=BridgeObservability
+    )
+
+    @model_validator(mode="after")
+    def _resolve_host_protocol_mode(self) -> "OmnigentBridgeConfig":
+        compat_mode = self.compatibility.host_protocol_mode
+        if self.host_connection.mode is None:
+            self.host_connection.mode = compat_mode
+        elif self.host_connection.mode != compat_mode:
+            raise BridgeConfigError(
+                f"hostConnection.mode '{self.host_connection.mode}' must match "
+                f"compatibility.hostProtocolMode '{compat_mode}': the bridge has a "
+                f"single active host protocol mode (§2.4)."
+            )
+        return self
+
+    @property
+    def host_protocol_mode(self) -> HostProtocolMode:
+        """Resolved active host protocol mode."""
+
+        return self.compatibility.host_protocol_mode
+
+    def authority_map(self) -> dict[str, str]:
+        """Return the authority map for surfacing to downstream components."""
+
+        return {
+            "temporal": self.authority.temporal,
+            "artifacts": self.authority.artifacts,
+            "liveExecution": self.authority.live_execution,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Parse / load entrypoints
+# ---------------------------------------------------------------------------
+
+
+def _format_validation_error(exc: ValidationError) -> str:
+    parts: list[str] = []
+    for err in exc.errors():
+        loc = ".".join(str(piece) for piece in err.get("loc", ()))
+        message = err.get("msg", "invalid value")
+        # Pydantic prefixes custom validator messages with "Value error, "; drop
+        # that so the actionable message reads cleanly.
+        if message.startswith("Value error, "):
+            message = message[len("Value error, ") :]
+        parts.append(f"{loc}: {message}" if loc else message)
+    return "invalid Omnigent bridge configuration: " + "; ".join(parts)
+
+
+def parse_bridge_config(data: Mapping[str, Any]) -> OmnigentBridgeConfig:
+    """Parse and validate a §6 declarative bridge configuration mapping.
+
+    Applies the Omnigent-vocabulary and host-build policy gates to the raw input
+    (so unknown keys are still covered) before structural validation, then
+    returns a fully-defaulted :class:`OmnigentBridgeConfig`. Raises
+    :class:`BridgeConfigError` with an actionable message on any invalid input.
+    """
+
+    if not isinstance(data, Mapping):
+        raise BridgeConfigError(
+            "bridge config must be a mapping/object, got "
+            f"{type(data).__name__}"
+        )
+
+    _reject_external_vocabulary(data)
+    _reject_host_build_configuration(data)
+
+    try:
+        return OmnigentBridgeConfig.model_validate(dict(data))
+    except BridgeConfigError:
+        raise
+    except ValidationError as exc:
+        raise BridgeConfigError(_format_validation_error(exc)) from exc
+
+
+def load_bridge_config(text: str) -> OmnigentBridgeConfig:
+    """Load a §6 declarative bridge configuration from YAML or JSON text."""
+
+    if not isinstance(text, str):
+        raise BridgeConfigError("bridge config text must be a string")
+    try:
+        loaded = yaml.safe_load(text)
+    except yaml.YAMLError as exc:
+        raise BridgeConfigError(
+            f"bridge config is not valid YAML/JSON: {exc}"
+        ) from exc
+    if loaded is None:
+        raise BridgeConfigError("bridge config document is empty")
+    if not isinstance(loaded, Mapping):
+        raise BridgeConfigError(
+            "bridge config document must be a mapping/object at the top level"
+        )
+    return parse_bridge_config(loaded)
+
+
+__all__ = [
+    "CANONICAL_FIRST_MESSAGE_STATES",
+    "HOST_PROTOCOL_MODE_EMBEDDED",
+    "HOST_PROTOCOL_MODE_PROXY",
+    "OMNIGENT_BRIDGE_CONFIG_SCHEMA_VERSION",
+    "BridgeAuthority",
+    "BridgeCaptureDefaults",
+    "BridgeCompatibility",
+    "BridgeConfigError",
+    "BridgeEmbeddedHostConnection",
+    "BridgeHostConnection",
+    "BridgeIdempotency",
+    "BridgeObservability",
+    "BridgePublicApi",
+    "BridgePublicApiRoutes",
+    "BridgeSessionDefaults",
+    "FirstMessageState",
+    "HostProtocolMode",
+    "OmnigentBridgeConfig",
+    "WorkspaceDiffsCapture",
+    "load_bridge_config",
+    "parse_bridge_config",
+]

--- a/tests/unit/omnigent/test_bridge_config.py
+++ b/tests/unit/omnigent/test_bridge_config.py
@@ -278,6 +278,18 @@ def test_deployment_configuration_is_accepted() -> None:
     assert config.host_connection.embedded.port == 7000
 
 
+def test_host_dispatch_is_not_rejected_as_custom_build() -> None:
+    # "hostDispatch" normalizes to contain "patch" (from "dispatch") but must not
+    # be treated as a custom host build request. It still fails structural
+    # validation as an unknown/extra field, but not via the host-build gate.
+    with pytest.raises(BridgeConfigError) as exc_info:
+        parse_bridge_config({"hostConnection": {"hostDispatch": "value"}})
+
+    message = str(exc_info.value)
+    assert "custom host build" not in message
+    assert "Extra inputs are not permitted" in message
+
+
 # ---------------------------------------------------------------------------
 # AC: The authority map is validated and surfaced to downstream components.
 # ---------------------------------------------------------------------------

--- a/tests/unit/omnigent/test_bridge_config.py
+++ b/tests/unit/omnigent/test_bridge_config.py
@@ -1,0 +1,328 @@
+"""Unit tests for the declarative Omnigent Bridge configuration (MM-1151).
+
+MM-1151 (source: MM-1140): validate the ``moonmind.omnigent_bridge.v1``
+declarative configuration and compatibility contract defined in
+``docs/Omnigent/OmnigentBridge.md`` §6.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from moonmind.omnigent.bridge_config import (
+    CANONICAL_FIRST_MESSAGE_STATES,
+    HOST_PROTOCOL_MODE_EMBEDDED,
+    HOST_PROTOCOL_MODE_PROXY,
+    OMNIGENT_BRIDGE_CONFIG_SCHEMA_VERSION,
+    BridgeConfigError,
+    OmnigentBridgeConfig,
+    load_bridge_config,
+    parse_bridge_config,
+)
+
+# The exact §6 declarative document from docs/Omnigent/OmnigentBridge.md.
+SECTION_6_DOCUMENT = """
+schemaVersion: moonmind.omnigent_bridge.v1
+
+enabled: true
+
+authority:
+  temporal: moonmind
+  artifacts: moonmind
+  liveExecution: omnigent_host
+
+compatibility:
+  profile: omnigent.server.v1
+  hostUnchanged: true
+  hostProtocolMode: upstream_omnigent_server_proxy
+
+publicApi:
+  mountPath: /api/omnigent
+  exposeOmnigentCompatibleRoutes: true
+  routes:
+    agents: /api/agents
+    createSession: /v1/sessions
+    getSession: /v1/sessions/{session_id}
+    postEvent: /v1/sessions/{session_id}/events
+    streamEvents: /v1/sessions/{session_id}/stream
+    changedFiles: /v1/sessions/{session_id}/resources/environments/default/changes
+    workspaceFiles: /v1/sessions/{session_id}/resources/environments/default/filesystem
+    workspaceDiffs: /v1/sessions/{session_id}/resources/environments/default/diff/{path}
+    sessionFiles: /v1/sessions/{session_id}/resources/files
+
+hostConnection:
+  mode: upstream_omnigent_server_proxy
+  upstreamServerUrlRef: default
+  embedded:
+    bindAddress: 0.0.0.0
+    port: 8000
+    authMode: header_or_token
+    protocolProfile: omnigent.host_runner.v1
+
+sessionDefaults:
+  hostType: managed
+  deleteProviderSessionAfterHarvest: false
+  capture:
+    stream: true
+    snapshots: true
+    changedFiles: true
+    workspaceFiles: true
+    workspaceDiffs: capability_probe
+    sessionFiles: true
+    childSessions: true
+
+idempotency:
+  firstMessageStateMachine:
+    - not_prepared
+    - prepared
+    - posting
+    - posted
+    - terminal
+  includeIdempotencyMarker: true
+  reconcilePostingState: true
+
+observability:
+  writeRawEventJournal: true
+  writeNormalizedEventJournal: true
+  feedWorkflowChat: true
+  feedAgentRunObservability: true
+  fallbackToLegacyManagedRunLogs: true
+"""
+
+
+# ---------------------------------------------------------------------------
+# AC: A schemaVersion moonmind.omnigent_bridge.v1 document with all blocks
+# parses and validates.
+# ---------------------------------------------------------------------------
+
+
+def test_section_6_document_parses_and_validates() -> None:
+    config = load_bridge_config(SECTION_6_DOCUMENT)
+
+    assert isinstance(config, OmnigentBridgeConfig)
+    assert config.schema_version == OMNIGENT_BRIDGE_CONFIG_SCHEMA_VERSION
+    assert config.enabled is True
+
+    # All §6 blocks are modeled.
+    assert config.authority.temporal == "moonmind"
+    assert config.compatibility.profile == "omnigent.server.v1"
+    assert config.public_api.mount_path == "/api/omnigent"
+    assert config.public_api.routes.create_session == "/v1/sessions"
+    assert config.host_connection.upstream_server_url_ref == "default"
+    assert config.host_connection.embedded.port == 8000
+    assert config.session_defaults.host_type == "managed"
+    assert config.session_defaults.capture.workspace_diffs == "capability_probe"
+    assert (
+        config.idempotency.first_message_state_machine
+        == CANONICAL_FIRST_MESSAGE_STATES
+    )
+    assert config.observability.feed_workflow_chat is True
+
+
+def test_minimal_document_uses_safe_defaults() -> None:
+    config = parse_bridge_config(
+        {"schemaVersion": OMNIGENT_BRIDGE_CONFIG_SCHEMA_VERSION}
+    )
+
+    # Safe defaults reproduce the §6 proxy-first shape.
+    assert config.enabled is True
+    assert config.compatibility.host_unchanged is True
+    assert config.host_protocol_mode == HOST_PROTOCOL_MODE_PROXY
+    assert config.public_api.routes.agents == "/api/agents"
+    assert config.session_defaults.capture.stream is True
+
+
+def test_empty_document_is_rejected_with_actionable_error() -> None:
+    with pytest.raises(BridgeConfigError, match="empty"):
+        load_bridge_config("")
+
+
+def test_non_mapping_top_level_is_rejected() -> None:
+    with pytest.raises(BridgeConfigError, match="mapping/object"):
+        load_bridge_config("- just\n- a\n- list\n")
+
+
+def test_unknown_schema_version_is_rejected() -> None:
+    with pytest.raises(BridgeConfigError, match="schemaVersion"):
+        parse_bridge_config({"schemaVersion": "moonmind.omnigent_bridge.v2"})
+
+
+# ---------------------------------------------------------------------------
+# AC: hostProtocolMode accepts both modes, defaults proxy-first, rejects unknown.
+# ---------------------------------------------------------------------------
+
+
+def test_host_protocol_mode_defaults_to_proxy_first() -> None:
+    config = parse_bridge_config({})
+
+    assert config.host_protocol_mode == HOST_PROTOCOL_MODE_PROXY
+    assert config.host_connection.mode == HOST_PROTOCOL_MODE_PROXY
+
+
+def test_host_protocol_mode_accepts_embedded() -> None:
+    config = parse_bridge_config(
+        {"compatibility": {"hostProtocolMode": HOST_PROTOCOL_MODE_EMBEDDED}}
+    )
+
+    assert config.host_protocol_mode == HOST_PROTOCOL_MODE_EMBEDDED
+    # hostConnection.mode is resolved from the compatibility mode.
+    assert config.host_connection.mode == HOST_PROTOCOL_MODE_EMBEDDED
+
+
+def test_unknown_host_protocol_mode_is_rejected() -> None:
+    with pytest.raises(BridgeConfigError, match="hostProtocolMode"):
+        parse_bridge_config(
+            {"compatibility": {"hostProtocolMode": "carrier_pigeon"}}
+        )
+
+
+def test_host_connection_mode_must_match_compatibility_mode() -> None:
+    with pytest.raises(BridgeConfigError, match="must match"):
+        parse_bridge_config(
+            {
+                "compatibility": {"hostProtocolMode": HOST_PROTOCOL_MODE_PROXY},
+                "hostConnection": {"mode": HOST_PROTOCOL_MODE_EMBEDDED},
+            }
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC: Bridge boundary exposes Omnigent nouns/routes and rejects new external
+# product vocabulary.
+# ---------------------------------------------------------------------------
+
+
+def test_non_omnigent_vocabulary_in_route_value_is_rejected() -> None:
+    with pytest.raises(BridgeConfigError, match="non-Omnigent"):
+        parse_bridge_config(
+            {"publicApi": {"routes": {"createSession": "/v1/conversation-broker"}}}
+        )
+
+
+def test_non_omnigent_vocabulary_in_key_is_rejected() -> None:
+    with pytest.raises(BridgeConfigError, match="runtime bus"):
+        parse_bridge_config({"runtime_bus": {"enabled": True}})
+
+
+def test_agent_socket_vocabulary_is_rejected() -> None:
+    with pytest.raises(BridgeConfigError, match="agent socket"):
+        parse_bridge_config({"hostConnection": {"agentSocket": "/tmp/x.sock"}})
+
+
+def test_route_must_be_absolute_and_omnigent_shaped() -> None:
+    with pytest.raises(BridgeConfigError, match="absolute path"):
+        parse_bridge_config({"publicApi": {"routes": {"agents": "api/agents"}}})
+
+    with pytest.raises(BridgeConfigError, match="Omnigent-shaped"):
+        parse_bridge_config(
+            {"publicApi": {"routes": {"agents": "/api/widgets"}}}
+        )
+
+
+def test_compatibility_profile_must_be_omnigent_namespaced() -> None:
+    with pytest.raises(BridgeConfigError, match="Omnigent-namespaced"):
+        parse_bridge_config({"compatibility": {"profile": "acme.server.v1"}})
+
+
+def test_embedded_protocol_profile_must_be_omnigent_namespaced() -> None:
+    with pytest.raises(BridgeConfigError, match="Omnigent-namespaced"):
+        parse_bridge_config(
+            {"hostConnection": {"embedded": {"protocolProfile": "acme.host.v1"}}}
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC: compatibility.hostUnchanged=true is honored; host-modifying config
+# is rejected.
+# ---------------------------------------------------------------------------
+
+
+def test_host_unchanged_true_is_honored() -> None:
+    config = parse_bridge_config({"compatibility": {"hostUnchanged": True}})
+
+    assert config.compatibility.host_unchanged is True
+
+
+def test_host_unchanged_false_is_rejected() -> None:
+    with pytest.raises(BridgeConfigError, match="hostUnchanged must be true"):
+        parse_bridge_config({"compatibility": {"hostUnchanged": False}})
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"compatibility": {"customHostImage": "ghcr.io/org/host:custom"}},
+        {"hostConnection": {"hostBuildArgs": {"FOO": "bar"}}},
+        {"hostConnection": {"embedded": {"hostDockerfile": "./Dockerfile"}}},
+        {"hostSourcePatch": "patches/host.diff"},
+    ],
+)
+def test_custom_host_build_configuration_is_rejected(payload: dict) -> None:
+    with pytest.raises(BridgeConfigError, match="custom host build"):
+        parse_bridge_config(payload)
+
+
+def test_deployment_configuration_is_accepted() -> None:
+    # A stock host image *reference* and standard deployment settings are
+    # allowed; only custom-build configuration is rejected.
+    config = parse_bridge_config(
+        {
+            "hostConnection": {
+                "upstreamServerUrlRef": "prod-endpoint",
+                "embedded": {"bindAddress": "127.0.0.1", "port": 7000},
+            }
+        }
+    )
+
+    assert config.host_connection.upstream_server_url_ref == "prod-endpoint"
+    assert config.host_connection.embedded.port == 7000
+
+
+# ---------------------------------------------------------------------------
+# AC: The authority map is validated and surfaced to downstream components.
+# ---------------------------------------------------------------------------
+
+
+def test_authority_map_is_surfaced() -> None:
+    config = parse_bridge_config({})
+
+    assert config.authority_map() == {
+        "temporal": "moonmind",
+        "artifacts": "moonmind",
+        "liveExecution": "omnigent_host",
+    }
+
+
+@pytest.mark.parametrize(
+    "authority",
+    [
+        {"temporal": "omnigent"},
+        {"artifacts": "omnigent_host"},
+        {"liveExecution": "moonmind"},
+    ],
+)
+def test_invalid_authority_map_is_rejected(authority: dict) -> None:
+    with pytest.raises(BridgeConfigError):
+        parse_bridge_config({"authority": authority})
+
+
+# ---------------------------------------------------------------------------
+# Additional fail-fast coverage.
+# ---------------------------------------------------------------------------
+
+
+def test_first_message_state_machine_must_be_canonical_order() -> None:
+    with pytest.raises(BridgeConfigError, match="canonical order"):
+        parse_bridge_config(
+            {"idempotency": {"firstMessageStateMachine": ["posted", "prepared"]}}
+        )
+
+
+def test_unknown_block_is_rejected() -> None:
+    with pytest.raises(BridgeConfigError):
+        parse_bridge_config({"totallyUnknownBlock": {"x": 1}})
+
+
+def test_invalid_yaml_is_rejected() -> None:
+    with pytest.raises(BridgeConfigError, match="valid YAML/JSON"):
+        load_bridge_config("schemaVersion: [unterminated")


### PR DESCRIPTION
## Issue

- Jira: [MM-1151 — Declarative Omnigent Bridge configuration and compatibility contract](https://moonladder.atlassian.net/browse/MM-1151)
- Source issue: MM-1140
- Source design: `docs/Omnigent/OmnigentBridge.md` (§1, §2.1, §2.3, §2.4, §6, §18.2, §21, §22)

## Summary

Adds the single canonical parser/validator for the `schemaVersion: moonmind.omnigent_bridge.v1`
declarative Omnigent Bridge configuration defined in `docs/Omnigent/OmnigentBridge.md` §6.

- New module `moonmind/omnigent/bridge_config.py` (placed in the existing canonical
  `moonmind/omnigent/` package per §18.1/§18.2 — no parallel package introduced).
- Models all eight blocks — `enabled` / `authority` / `compatibility` / `publicApi` /
  `hostConnection` / `sessionDefaults` / `idempotency` / `observability` — with safe
  defaults, so a minimal document yields a valid proxy-first configuration.
- `hostProtocolMode` accepts `upstream_omnigent_server_proxy` and
  `embedded_omnigent_compatible_server`, defaults proxy-first (§2.4), and rejects unknown
  values; `hostConnection.mode` must agree with the compatibility mode.
- Enforces Omnigent vocabulary at the boundary (§2.1): routes/profiles must use Omnigent
  nouns, and non-Omnigent product vocabulary (runtime bus / agent socket / conversation
  broker) is rejected.
- Honors `compatibility.hostUnchanged=true` and rejects any host-modifying / custom
  host-build configuration while accepting stock deployment configuration (§2.3, §22).
- Validates and surfaces the authority map (`temporal=moonmind`, `artifacts=moonmind`,
  `liveExecution=omnigent_host`) to downstream components via `authority_map()` (§1).
- Fails fast with actionable `BridgeConfigError` messages.

## Tests run

- `MOONMIND_FORCE_LOCAL_TESTS=1 python -m pytest tests/unit/omnigent/test_bridge_config.py -q`
  → **29 passed**. Covers §6 document parse, minimal/empty/non-mapping inputs, unknown
  `schemaVersion`, protocol-mode default/embedded/unknown/mode-mismatch, Omnigent vocabulary
  enforcement, absolute/Omnigent-shaped routes, profile namespacing, host-unchanged
  honor/reject, custom-host-build rejection, deployment-config acceptance, authority-map
  surfacing + invalid rejection, canonical first-message state order, unknown-block
  rejection, and invalid YAML.
- Integration tier: not applicable — this change is a hermetic, deterministic,
  side-effect-free config parser/validator (no Docker, DB, migrations, Temporal, or external
  service), so no integration boundary is in scope per the AGENTS.md impact selector.

## Remaining risks

- The parser is not yet re-exported from `moonmind/omnigent/__init__.py`; downstream
  consumers import from `moonmind.omnigent.bridge_config` directly (the surfacing contract
  `authority_map()` / `host_protocol_mode` is public on the class). Not a blocking gap for
  this issue's acceptance criteria.
- Downstream bridge components (`bridge_store.py`, `bridge_events.py`, `bridge_proxy.py`,
  routers, schemas, ORM/migrations per §18.2) are separate issues; MM-1151 is scoped to
  `bridge_config.py` only.
- OB-§21 open questions are non-normative and impose no verifiable config-contract
  requirement for MM-1151; excluded as out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
