### PR TITLE
MM-1145: Persist Recurring list display mode and last-selected definition

### DIFF
--- a/frontend/src/entrypoints/dashboard-app.tsx
+++ b/frontend/src/entrypoints/dashboard-app.tsx
@@ -843,7 +843,12 @@ function RoutedDashboardPage({
         const definitionId = decodeURIComponent(match[1] || '').trim();
         if (definitionId) {
           setLastSelectedDefinitionId(definitionId);
-          updateDashboardPreferences({ lastSelectedDefinitionId: definitionId });
+          // This effect also runs on `location.search` changes, so only persist
+          // when the remembered definition actually changed to avoid a redundant
+          // localStorage write, JSON round-trip, and change-event dispatch.
+          if (readDashboardPreferences().lastSelectedDefinitionId !== definitionId) {
+            updateDashboardPreferences({ lastSelectedDefinitionId: definitionId });
+          }
         }
       } catch {
         // Ignore malformed paths; route validation handles unsupported pages.
@@ -854,16 +859,35 @@ function RoutedDashboardPage({
   useEffect(() => {
     const syncPreferences = () => {
       const prefs = readDashboardPreferences();
+      const normalizedPath = window.location.pathname.replace(/\/$/, '');
       // The `/workflows` route is always the full-screen table surface, and
       // `table` is not representable in the persisted collapse boolean. Deriving
       // the mode from that boolean here would clobber the table selection back to
       // `sidebar` whenever a preference change fires (for example when the
       // already-selected "Full screen table" button re-persists preferences),
       // so leave the route-owned `table` mode untouched on this surface.
-      if (window.location.pathname.replace(/\/$/, '') !== '/workflows') {
+      if (normalizedPath !== '/workflows') {
         setRequestedMode(prefs.workflowWorkspaceSidebarCollapsed ? 'hidden' : 'sidebar');
       }
       setLastSelectedWorkflowId(prefs.lastSelectedWorkflowId.trim() || null);
+      // Recurring preferences are seeded into local state on mount, so a
+      // preference change while the shell stays mounted (for example a reset from
+      // another route in the same SPA session or a `storage` event from another
+      // tab) must refresh them too; otherwise a stale recurring mode or remembered
+      // definition survives until a full reload. Mirror the route-ownership
+      // coercion applied on navigation: `/schedules` is route-owned `table`, and a
+      // detail route coerces `table` -> `sidebar` while honoring a persisted
+      // `hidden`.
+      if (normalizedPath === '/schedules') {
+        setRequestedRecurringMode('table');
+      } else if (normalizedPath.startsWith('/schedules/')) {
+        setRequestedRecurringMode(
+          prefs.recurringListDisplayMode === 'table' ? 'sidebar' : prefs.recurringListDisplayMode,
+        );
+      } else {
+        setRequestedRecurringMode(prefs.recurringListDisplayMode);
+      }
+      setLastSelectedDefinitionId(prefs.lastSelectedDefinitionId.trim() || null);
     };
     window.addEventListener(DASHBOARD_PREFERENCES_CHANGED_EVENT, syncPreferences);
     window.addEventListener('storage', syncPreferences);
@@ -940,11 +964,16 @@ function RoutedDashboardPage({
         return;
       }
       setRequestedRecurringMode(selectedMode);
-      updateDashboardPreferences({ recurringListDisplayMode: selectedMode });
+      // Batch both preference fields into a single persisted update to avoid a
+      // redundant localStorage write, JSON round-trip, and change-event dispatch.
+      const patch: Parameters<typeof updateDashboardPreferences>[0] = {
+        recurringListDisplayMode: selectedMode,
+      };
       if (resolved.selection.definitionId) {
         setLastSelectedDefinitionId(resolved.selection.definitionId);
-        updateDashboardPreferences({ lastSelectedDefinitionId: resolved.selection.definitionId });
+        patch.lastSelectedDefinitionId = resolved.selection.definitionId;
       }
+      updateDashboardPreferences(patch);
       const current = `${location.pathname}${location.search}`;
       if (resolved.targetPath !== current) {
         navigate(resolved.targetPath);

--- a/frontend/src/entrypoints/dashboard-app.tsx
+++ b/frontend/src/entrypoints/dashboard-app.tsx
@@ -799,11 +799,15 @@ function RoutedDashboardPage({
   const [requestedMode, setRequestedMode] = useState<WorkflowListDisplayMode>(() => (
     readDashboardPreferences().workflowWorkspaceSidebarCollapsed ? 'hidden' : 'sidebar'
   ));
-  const [requestedRecurringMode, setRequestedRecurringMode] = useState<WorkflowListDisplayMode>('table');
+  const [requestedRecurringMode, setRequestedRecurringMode] = useState<WorkflowListDisplayMode>(
+    () => readDashboardPreferences().recurringListDisplayMode,
+  );
   const [lastSelectedWorkflowId, setLastSelectedWorkflowId] = useState<string | null>(
     () => readDashboardPreferences().lastSelectedWorkflowId.trim() || null,
   );
-  const [lastSelectedDefinitionId, setLastSelectedDefinitionId] = useState<string | null>(null);
+  const [lastSelectedDefinitionId, setLastSelectedDefinitionId] = useState<string | null>(
+    () => readDashboardPreferences().lastSelectedDefinitionId.trim() || null,
+  );
   const [resolutionStatus, setResolutionStatus] = useState<string | null>(null);
   const route = resolveDashboardRoute(location.pathname);
   const apiBase = typeof uiInfo?.apiBase === 'string' ? uiInfo.apiBase : '/api';
@@ -839,6 +843,7 @@ function RoutedDashboardPage({
         const definitionId = decodeURIComponent(match[1] || '').trim();
         if (definitionId) {
           setLastSelectedDefinitionId(definitionId);
+          updateDashboardPreferences({ lastSelectedDefinitionId: definitionId });
         }
       } catch {
         // Ignore malformed paths; route validation handles unsupported pages.
@@ -894,6 +899,7 @@ function RoutedDashboardPage({
         const requestId = Symbol();
         pendingRequestRef.current = requestId;
         setRequestedRecurringMode(selectedMode);
+        updateDashboardPreferences({ recurringListDisplayMode: selectedMode });
         setResolutionStatus('Opening first recurring schedule...');
         try {
           const rememberedId = lastSelectedDefinitionId?.trim() || '';
@@ -912,6 +918,7 @@ function RoutedDashboardPage({
             return;
           }
           setLastSelectedDefinitionId(targetDefinitionId);
+          updateDashboardPreferences({ lastSelectedDefinitionId: targetDefinitionId });
           setResolutionStatus(null);
           navigate(`/schedules/${encodeURIComponent(targetDefinitionId)}`);
         } catch {
@@ -933,8 +940,10 @@ function RoutedDashboardPage({
         return;
       }
       setRequestedRecurringMode(selectedMode);
+      updateDashboardPreferences({ recurringListDisplayMode: selectedMode });
       if (resolved.selection.definitionId) {
         setLastSelectedDefinitionId(resolved.selection.definitionId);
+        updateDashboardPreferences({ lastSelectedDefinitionId: resolved.selection.definitionId });
       }
       const current = `${location.pathname}${location.search}`;
       if (resolved.targetPath !== current) {

--- a/frontend/src/entrypoints/dashboard.test.tsx
+++ b/frontend/src/entrypoints/dashboard.test.tsx
@@ -659,6 +659,194 @@ describe('Dashboard shared entry', () => {
     expect(screen.getByRole('radio', { name: 'Full screen table' }).getAttribute('aria-checked')).toBe('true');
   });
 
+  // MM-1145: persistence + reseeding of the Recurring list display mode and the
+  // last-selected definition (dashboard preferences), and honoring a persisted
+  // `hidden` on a direct `/schedules/{definitionId}` visit.
+  const recurringScheduleRow = (id: string, name: string) => ({
+    id,
+    name,
+    enabled: true,
+    cron: '0 9 * * *',
+    timezone: 'UTC',
+    nextRunAt: '2026-07-09T09:00:00Z',
+    lastDispatchStatus: 'enqueued',
+    target: {},
+    policy: {},
+  });
+  const recurringScheduleDetail = (id: string, name: string) => ({
+    ...recurringScheduleRow(id, name),
+    description: 'Runs every morning.',
+    lastScheduledFor: '2026-07-08T09:00:00Z',
+  });
+
+  it('MM-1145 honors a persisted hidden recurring mode on a direct detail visit', async () => {
+    updateDashboardPreferences({ recurringListDisplayMode: 'hidden' });
+    fetchSpy.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === '/api/ui/info') {
+        return Promise.resolve({ ok: true, json: async () => uiInfo() } as Response);
+      }
+      if (url === '/api/recurring-workflows?scope=personal') {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ items: [recurringScheduleRow('schedule-one', 'Daily recurring scan')] }),
+        } as Response);
+      }
+      if (url === '/api/recurring-workflows/schedule-one') {
+        return Promise.resolve({
+          ok: true,
+          json: async () => recurringScheduleDetail('schedule-one', 'Daily recurring scan'),
+        } as Response);
+      }
+      if (url === '/api/recurring-workflows/schedule-one/runs?limit=200') {
+        return Promise.resolve({ ok: true, json: async () => ({ items: [] }) } as Response);
+      }
+      return Promise.resolve({ ok: false, status: 404, statusText: 'Not Found' } as Response);
+    });
+
+    window.history.replaceState({}, '', '/schedules/schedule-one');
+    renderWithClient(<DashboardApp payload={{ page: 'dashboard', apiBase: '/api' }} />);
+
+    expect(await screen.findByRole('heading', { name: 'Daily recurring scan' })).toBeTruthy();
+    // A persisted `hidden` is honored on a direct detail visit: the sidebar list
+    // is not mounted (contrast with the sidebar-default direct-visit test above).
+    expect(screen.queryByRole('complementary', { name: 'Recurring schedule navigation' })).toBeNull();
+    expect(screen.getByRole('radio', { name: 'No list' }).getAttribute('aria-checked')).toBe('true');
+  });
+
+  it('MM-1145 reseeds the remembered recurring definition and opens it when switching to sidebar', async () => {
+    updateDashboardPreferences({ lastSelectedDefinitionId: 'remembered-schedule' });
+    fetchSpy.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === '/api/ui/info') {
+        return Promise.resolve({ ok: true, json: async () => uiInfo() } as Response);
+      }
+      if (url === '/api/recurring-workflows?scope=personal') {
+        // A different first-visible row proves the remembered ID was preferred.
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ items: [recurringScheduleRow('schedule-one', 'Daily recurring scan')] }),
+        } as Response);
+      }
+      if (url === '/api/recurring-workflows/remembered-schedule') {
+        return Promise.resolve({
+          ok: true,
+          json: async () => recurringScheduleDetail('remembered-schedule', 'Remembered schedule'),
+        } as Response);
+      }
+      if (url === '/api/recurring-workflows/remembered-schedule/runs?limit=200') {
+        return Promise.resolve({ ok: true, json: async () => ({ items: [] }) } as Response);
+      }
+      return Promise.resolve({ ok: false, status: 404, statusText: 'Not Found' } as Response);
+    });
+
+    window.history.replaceState({}, '', '/schedules');
+    renderWithClient(<DashboardApp payload={{ page: 'dashboard', apiBase: '/api' }} />);
+
+    expect(await screen.findByRole('heading', { name: 'Recurring Schedules' })).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('radio', { name: 'Sidebar list' }));
+
+    await waitFor(() => {
+      expect(window.location.pathname).toBe('/schedules/remembered-schedule');
+    });
+    // The persisted remembered definition was reauthorized before use...
+    expect(
+      fetchSpy.mock.calls.some(([url]) => String(url) === '/api/recurring-workflows/remembered-schedule'),
+    ).toBe(true);
+    expect(await screen.findByRole('heading', { name: 'Remembered schedule' })).toBeTruthy();
+    // ...and the mode + remembered definition are persisted for the next reload.
+    expect(readDashboardPreferences().recurringListDisplayMode).toBe('sidebar');
+    expect(readDashboardPreferences().lastSelectedDefinitionId).toBe('remembered-schedule');
+  });
+
+  it('MM-1145 discards an unauthorized persisted remembered definition and opens the first visible schedule', async () => {
+    updateDashboardPreferences({ lastSelectedDefinitionId: 'stale-schedule' });
+    fetchSpy.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === '/api/ui/info') {
+        return Promise.resolve({ ok: true, json: async () => uiInfo() } as Response);
+      }
+      if (url === '/api/recurring-workflows/stale-schedule') {
+        return Promise.resolve({ ok: false, status: 404, statusText: 'Not Found' } as Response);
+      }
+      if (url === '/api/recurring-workflows?scope=personal') {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ items: [recurringScheduleRow('schedule-one', 'Daily recurring scan')] }),
+        } as Response);
+      }
+      if (url === '/api/recurring-workflows/schedule-one') {
+        return Promise.resolve({
+          ok: true,
+          json: async () => recurringScheduleDetail('schedule-one', 'Daily recurring scan'),
+        } as Response);
+      }
+      if (url === '/api/recurring-workflows/schedule-one/runs?limit=200') {
+        return Promise.resolve({ ok: true, json: async () => ({ items: [] }) } as Response);
+      }
+      return Promise.resolve({ ok: false, status: 404, statusText: 'Not Found' } as Response);
+    });
+
+    window.history.replaceState({}, '', '/schedules');
+    renderWithClient(<DashboardApp payload={{ page: 'dashboard', apiBase: '/api' }} />);
+
+    expect(await screen.findByRole('heading', { name: 'Recurring Schedules' })).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('radio', { name: 'Sidebar list' }));
+
+    await waitFor(() => {
+      expect(window.location.pathname).toBe('/schedules/schedule-one');
+    });
+    // The stale remembered definition was reauthorized, found unauthorized, and
+    // silently discarded in favor of the first visible schedule.
+    expect(
+      fetchSpy.mock.calls.some(([url]) => String(url) === '/api/recurring-workflows/stale-schedule'),
+    ).toBe(true);
+    expect(window.location.pathname).not.toBe('/schedules/stale-schedule');
+    expect(readDashboardPreferences().lastSelectedDefinitionId).toBe('schedule-one');
+  });
+
+  it('MM-1145 persists the recurring mode and remembered definition when switching modes on a detail visit', async () => {
+    fetchSpy.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === '/api/ui/info') {
+        return Promise.resolve({ ok: true, json: async () => uiInfo() } as Response);
+      }
+      if (url === '/api/recurring-workflows?scope=personal') {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ items: [recurringScheduleRow('schedule-one', 'Daily recurring scan')] }),
+        } as Response);
+      }
+      if (url === '/api/recurring-workflows/schedule-one') {
+        return Promise.resolve({
+          ok: true,
+          json: async () => recurringScheduleDetail('schedule-one', 'Daily recurring scan'),
+        } as Response);
+      }
+      if (url === '/api/recurring-workflows/schedule-one/runs?limit=200') {
+        return Promise.resolve({ ok: true, json: async () => ({ items: [] }) } as Response);
+      }
+      return Promise.resolve({ ok: false, status: 404, statusText: 'Not Found' } as Response);
+    });
+
+    window.history.replaceState({}, '', '/schedules/schedule-one');
+    renderWithClient(<DashboardApp payload={{ page: 'dashboard', apiBase: '/api' }} />);
+
+    expect(await screen.findByRole('heading', { name: 'Daily recurring scan' })).toBeTruthy();
+    // Visiting a detail route remembers the definition for the next reload.
+    expect(readDashboardPreferences().lastSelectedDefinitionId).toBe('schedule-one');
+
+    fireEvent.click(screen.getByRole('radio', { name: 'No list' }));
+
+    await waitFor(() => {
+      expect(readDashboardPreferences().recurringListDisplayMode).toBe('hidden');
+    });
+    expect(window.location.pathname).toBe('/schedules/schedule-one');
+    expect(readDashboardPreferences().lastSelectedDefinitionId).toBe('schedule-one');
+  });
+
   it('hides the workflow list display control on unsupported routes', async () => {
     window.history.replaceState({}, '', '/settings');
     renderWithClient(<DashboardApp payload={{ page: 'dashboard', apiBase: '/api' }} />);

--- a/frontend/src/entrypoints/dashboard.test.tsx
+++ b/frontend/src/entrypoints/dashboard.test.tsx
@@ -12,10 +12,14 @@ import postcss from 'postcss';
 import type { Root, Rule } from 'postcss';
 
 import type { BootPayload } from '../boot/parseBootPayload';
-import { fireEvent, renderWithClient, screen, waitFor } from '../utils/test-utils';
+import { act, fireEvent, renderWithClient, screen, waitFor } from '../utils/test-utils';
 import { DashboardApp } from './dashboard-app';
 import { navigateTo } from '../lib/navigation';
-import { readDashboardPreferences, updateDashboardPreferences } from '../utils/dashboardPreferences';
+import {
+  readDashboardPreferences,
+  resetDashboardPreferences,
+  updateDashboardPreferences,
+} from '../utils/dashboardPreferences';
 
 const animatedNavIconMocks = vi.hoisted(() => ({
   moonStart: vi.fn(),
@@ -845,6 +849,56 @@ describe('Dashboard shared entry', () => {
     });
     expect(window.location.pathname).toBe('/schedules/schedule-one');
     expect(readDashboardPreferences().lastSelectedDefinitionId).toBe('schedule-one');
+  });
+
+  it('MM-1145 refreshes the recurring mode on a preference change so a reset default replaces a stale mode', async () => {
+    // Seed a persisted `hidden` and open a detail route directly so the shell
+    // seeds that stale mode into local state on mount.
+    updateDashboardPreferences({ recurringListDisplayMode: 'hidden' });
+    fetchSpy.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === '/api/ui/info') {
+        return Promise.resolve({ ok: true, json: async () => uiInfo() } as Response);
+      }
+      if (url === '/api/recurring-workflows?scope=personal') {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ items: [recurringScheduleRow('schedule-one', 'Daily recurring scan')] }),
+        } as Response);
+      }
+      if (url === '/api/recurring-workflows/schedule-one') {
+        return Promise.resolve({
+          ok: true,
+          json: async () => recurringScheduleDetail('schedule-one', 'Daily recurring scan'),
+        } as Response);
+      }
+      if (url === '/api/recurring-workflows/schedule-one/runs?limit=200') {
+        return Promise.resolve({ ok: true, json: async () => ({ items: [] }) } as Response);
+      }
+      return Promise.resolve({ ok: false, status: 404, statusText: 'Not Found' } as Response);
+    });
+
+    window.history.replaceState({}, '', '/schedules/schedule-one');
+    renderWithClient(<DashboardApp payload={{ page: 'dashboard', apiBase: '/api' }} />);
+
+    expect(await screen.findByRole('heading', { name: 'Daily recurring scan' })).toBeTruthy();
+    // The persisted `hidden` is honored on load: no sidebar list is mounted.
+    expect(screen.queryByRole('complementary', { name: 'Recurring schedule navigation' })).toBeNull();
+    expect(screen.getByRole('radio', { name: 'No list' }).getAttribute('aria-checked')).toBe('true');
+
+    // Resetting preferences (for example from another route in the same SPA
+    // session, or a `storage` event from another tab) fires the change event.
+    // The shell must refresh the recurring mode from storage so the reset default
+    // replaces the stale `hidden` without a full reload; on a detail route the
+    // route-owned default is `sidebar`.
+    act(() => {
+      resetDashboardPreferences();
+    });
+
+    expect(
+      await screen.findByRole('complementary', { name: 'Recurring schedule navigation' }),
+    ).toBeTruthy();
+    expect(screen.getByRole('radio', { name: 'Sidebar list' }).getAttribute('aria-checked')).toBe('true');
   });
 
   it('hides the workflow list display control on unsupported routes', async () => {

--- a/frontend/src/utils/dashboardPreferences.test.ts
+++ b/frontend/src/utils/dashboardPreferences.test.ts
@@ -208,6 +208,50 @@ describe('dashboardPreferences', () => {
         expect(sanitizeDashboardPreferences({ lastSelectedWorkflowId: candidate }).lastSelectedWorkflowId).toBe('');
       }
     });
+
+    it('MM-1145 defaults the recurring list display mode to table and the remembered definition to empty', () => {
+      expect(DEFAULT_DASHBOARD_PREFERENCES.recurringListDisplayMode).toBe('table');
+      expect(DEFAULT_DASHBOARD_PREFERENCES.lastSelectedDefinitionId).toBe('');
+    });
+
+    it('MM-1145 keeps a valid persisted recurring list display mode', () => {
+      for (const mode of ['hidden', 'sidebar', 'table'] as const) {
+        expect(
+          sanitizeDashboardPreferences({ recurringListDisplayMode: mode }).recurringListDisplayMode,
+        ).toBe(mode);
+      }
+    });
+
+    it('MM-1145 sanitizes an invalid recurring list display mode back to table', () => {
+      for (const candidate of ['collapsed', '', 42, null, undefined, {}, []]) {
+        expect(
+          sanitizeDashboardPreferences({ recurringListDisplayMode: candidate }).recurringListDisplayMode,
+        ).toBe('table');
+      }
+    });
+
+    it('MM-1145 trims the remembered recurring definition and rejects non-string values', () => {
+      expect(
+        sanitizeDashboardPreferences({ lastSelectedDefinitionId: '  schedule-one  ' }).lastSelectedDefinitionId,
+      ).toBe('schedule-one');
+      for (const candidate of [null, undefined, 42, false, {}, []]) {
+        expect(
+          sanitizeDashboardPreferences({ lastSelectedDefinitionId: candidate }).lastSelectedDefinitionId,
+        ).toBe('');
+      }
+    });
+
+    it('MM-1145 round-trips the recurring mode and remembered definition across a reload', () => {
+      writeDashboardPreferences({
+        ...DEFAULT_DASHBOARD_PREFERENCES,
+        recurringListDisplayMode: 'hidden',
+        lastSelectedDefinitionId: 'schedule-two',
+      });
+
+      const reloaded = readDashboardPreferences();
+      expect(reloaded.recurringListDisplayMode).toBe('hidden');
+      expect(reloaded.lastSelectedDefinitionId).toBe('schedule-two');
+    });
   });
 
   describe('reset behavior (MM-964 reset behavior)', () => {

--- a/frontend/src/utils/dashboardPreferences.ts
+++ b/frontend/src/utils/dashboardPreferences.ts
@@ -16,6 +16,10 @@
 // without a storage migration.
 
 import { DEFAULT_PAGE_SIZE, PAGE_SIZE_OPTIONS } from '../components/PageSizeSelector';
+import {
+  isWorkflowListDisplayMode,
+  type WorkflowListDisplayMode,
+} from '../lib/workflowListDisplayMode';
 
 export const DASHBOARD_PREFERENCES_STORAGE_KEY = 'moonmind.dashboard.preferences';
 export const DASHBOARD_PREFERENCES_CHANGED_EVENT = 'moonmind:dashboard-preferences-changed';
@@ -73,6 +77,14 @@ export type DashboardPreferences = {
   workflowWorkspaceSidebarCollapsed: boolean;
   /** Last workflow explicitly opened by the operator. */
   lastSelectedWorkflowId: string;
+  /**
+   * Persisted Recurring list display mode. Reseeded on load so a direct visit to
+   * `/schedules/{definitionId}` can honor a persisted `hidden`; `/schedules`
+   * always resolves to `table` regardless of this value (route-owned).
+   */
+  recurringListDisplayMode: WorkflowListDisplayMode;
+  /** Last recurring schedule definition explicitly opened by the operator. */
+  lastSelectedDefinitionId: string;
   /** Preferred default workflow detail tab. */
   preferredDetailTab: WorkflowDetailTab;
   /** Preferred runtime default for the create page, where safe. */
@@ -99,6 +111,8 @@ export const DEFAULT_DASHBOARD_PREFERENCES: DashboardPreferences = {
   debugFieldsVisible: true,
   workflowWorkspaceSidebarCollapsed: false,
   lastSelectedWorkflowId: '',
+  recurringListDisplayMode: 'table',
+  lastSelectedDefinitionId: '',
   preferredDetailTab: 'overview',
   defaultRuntime: '',
   defaultProviderProfile: '',
@@ -162,6 +176,12 @@ function sanitizeString(value: unknown): string {
   return typeof value === 'string' ? value.trim() : '';
 }
 
+function sanitizeRecurringListDisplayMode(value: unknown): WorkflowListDisplayMode {
+  return typeof value === 'string' && isWorkflowListDisplayMode(value)
+    ? value
+    : DEFAULT_DASHBOARD_PREFERENCES.recurringListDisplayMode;
+}
+
 /**
  * Coerce an arbitrary parsed value into a fully-populated, valid preferences
  * object. Unknown, missing, or wrong-typed fields fall back to their defaults
@@ -193,6 +213,8 @@ export function sanitizeDashboardPreferences(value: unknown): DashboardPreferenc
       DEFAULT_DASHBOARD_PREFERENCES.workflowWorkspaceSidebarCollapsed,
     ),
     lastSelectedWorkflowId: sanitizeString(value.lastSelectedWorkflowId),
+    recurringListDisplayMode: sanitizeRecurringListDisplayMode(value.recurringListDisplayMode),
+    lastSelectedDefinitionId: sanitizeString(value.lastSelectedDefinitionId),
     preferredDetailTab: sanitizeDetailTab(value.preferredDetailTab),
     defaultRuntime: sanitizeString(value.defaultRuntime),
     defaultProviderProfile: sanitizeString(value.defaultProviderProfile),


### PR DESCRIPTION
## Issue

- Jira: [MM-1145](https://moonladder.atlassian.net/browse/MM-1145) — Persist the Recurring list display mode and last-selected definition and honor a persisted `hidden` on direct detail visits.
- Canonical source: `docs/UI/RecurringSchedulesPage.md` (§5, §19, §20; DESIGN-REQ-006..009)

## Summary of implementation

The Recurring workspace resolution table, selection fallback, and reauthorization-on-use already existed from the parent redesign. This change adds the missing persistence/reseeding delta:

- **Persist recurring preferences** in `frontend/src/utils/dashboardPreferences.ts`: new `recurringListDisplayMode` (`hidden|sidebar|table`, default `table`) and `lastSelectedDefinitionId` (default `''`) fields, defaults, and a `sanitizeRecurringListDisplayMode` sanitizer wired into `sanitizeDashboardPreferences`.
- **Seed initial state from persisted preferences** in `frontend/src/entrypoints/dashboard-app.tsx`: `requestedRecurringMode` is seeded from the persisted mode (previously hardcoded to `'table'`) and `lastSelectedDefinitionId` is seeded from the persisted value (previously `null`).
- **Persist on navigation and mode switches**: `updateDashboardPreferences` is called when a detail route is visited and when the operator switches recurring mode / selects a definition.
- **Honor a persisted `hidden` on direct detail visits**: the `/schedules/{definitionId}` route effect coerces only `table -> sidebar`, preserving a persisted `hidden`. `/schedules` remains route-owned as `table` without overwriting the persisted preference.
- **Reauthorize the persisted remembered definition before use**: the reseeded `lastSelectedDefinitionId` is reauthorized via `authorizedRecurringDefinitionId`; unauthorized IDs are silently discarded in favor of the first visible row (no ID echoed to the UI).

## Tests run

- Frontend unit + integration (Vitest), via `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --dashboard-only`:
  - `frontend/src/utils/dashboardPreferences.test.ts` + `frontend/src/entrypoints/dashboard.test.tsx` — **PASS** (115 tests): new field defaults/sanitizer + reload round-trip; honor-persisted-`hidden` on direct detail visit; reseed + open remembered definition on switch to sidebar; discard unauthorized remembered definition to first visible; persist mode + definition on mode switch.
  - `frontend/src/lib/workflowListDisplayMode.test.ts` — **PASS** (24 tests): confirms the already-met route+mode resolution table and no-selectable fallback did not regress.
- Frontend typecheck: `tsc --noEmit -p frontend/tsconfig.json` — **PASS** (exit 0).
- Hermetic integration CI: not selected by impact — frontend-only dashboard-preferences change with no Docker/compose/database/migration/worker/Temporal touchpoints.

## Remaining risks

- Reduced-motion / visual continuity (testing-contract motion aspects) is CSS-driven and not assertable in the jsdom Vitest runtime; it requires manual/browser verification. It is pre-existing (DESIGN-REQ-009), unchanged by this delta, and previously assessed as met.
- Mobile desktop-only sidebar behavior is explicitly out of scope for the first implementation (belongs to parent redesign MM-1144).
- Persistence uses the existing `localStorage`-backed dashboard preferences store; behavior in environments without storage falls back to defaults, consistent with the existing workflow-preference fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[MM-1145]: https://moonladder.atlassian.net/browse/MM-1145?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ