### PR TITLE
Preserve Jira blocker assessment context

### DIFF
--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -442,6 +442,9 @@ RUN_JIRA_BLOCKER_WAIT_COALESCING_PATCH = "run-jira-blocker-wait-coalescing-v1"
 RUN_JIRA_BLOCKER_RECHECK_RETRY_FLOOR_PATCH = (
     "run-jira-blocker-recheck-retry-floor-v1"
 )
+RUN_JIRA_BLOCKER_RECHECK_ASSESSMENT_CONTEXT_PATCH = (
+    "run-jira-blocker-recheck-assessment-context-v1"
+)
 # Replay-stable patch id for the v2 workflow-scoped Codex termination path. The
 # identifier says "update" for in-flight history continuity, but current
 # Temporal external workflow handles expose the session control surface by signal.
@@ -5786,6 +5789,45 @@ class MoonMindRunWorkflow:
             if value not in (None, "", {}, []):
                 self._assessment_context[key] = value
 
+    def _merge_assessment_context_into_result(self, execution_result: Any) -> Any:
+        if not self._assessment_context:
+            return execution_result
+        outputs = self._get_from_result(execution_result, "outputs")
+        if not isinstance(outputs, Mapping):
+            return execution_result
+
+        merged_outputs = dict(outputs)
+        changed = False
+        for key in (
+            "assessmentArtifactRef",
+            "assessment_artifact_ref",
+            "assessmentVerdict",
+            "assessment_verdict",
+        ):
+            value = self._assessment_context.get(key)
+            if value in (None, "", {}, []):
+                continue
+            if merged_outputs.get(key) not in (None, "", {}, []):
+                continue
+            merged_outputs[key] = value
+            changed = True
+        if not changed:
+            return execution_result
+
+        if isinstance(execution_result, Mapping):
+            merged_result = dict(execution_result)
+            merged_result["outputs"] = merged_outputs
+            return merged_result
+        model_copy = getattr(execution_result, "model_copy", None)
+        if callable(model_copy):
+            return model_copy(update={"outputs": merged_outputs})
+        if dataclasses.is_dataclass(execution_result):
+            try:
+                return dataclasses.replace(execution_result, outputs=merged_outputs)
+            except TypeError:
+                return execution_result
+        return execution_result
+
     def _merge_trusted_issue_context(
         self,
         previous_outputs: Mapping[str, Any],
@@ -9853,6 +9895,13 @@ class MoonMindRunWorkflow:
         skipped = False
         recheck_count = 0
         current_result = execution_result
+        preserve_assessment_context = workflow.patched(
+            RUN_JIRA_BLOCKER_RECHECK_ASSESSMENT_CONTEXT_PATCH
+        )
+        if preserve_assessment_context:
+            outputs = self._get_from_result(current_result, "outputs")
+            if isinstance(outputs, Mapping):
+                self._record_assessment_context(outputs)
         while self._jira_blocker_waitable_result(
             current_result,
             tool_type=tool_type,
@@ -10021,6 +10070,13 @@ class MoonMindRunWorkflow:
                     if failure_mode == "FAIL_FAST":
                         raise
                     break
+            if preserve_assessment_context:
+                current_result = self._merge_assessment_context_into_result(
+                    current_result
+                )
+                outputs = self._get_from_result(current_result, "outputs")
+                if isinstance(outputs, Mapping):
+                    self._record_assessment_context(outputs)
             self._record_step_result_evidence(
                 node_id,
                 execution_result=current_result,

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -5779,15 +5779,17 @@ class MoonMindRunWorkflow:
             self._trusted_issue_context = context
 
     def _record_assessment_context(self, outputs: Mapping[str, Any]) -> None:
-        for key in (
-            "assessmentArtifactRef",
-            "assessment_artifact_ref",
-            "assessmentVerdict",
-            "assessment_verdict",
+        for aliases in (
+            ("assessmentArtifactRef", "assessment_artifact_ref"),
+            ("assessmentVerdict", "assessment_verdict"),
         ):
-            value = outputs.get(key)
-            if value not in (None, "", {}, []):
-                self._assessment_context[key] = value
+            for key in aliases:
+                value = outputs.get(key)
+                if value in (None, "", {}, []):
+                    continue
+                for alias in aliases:
+                    self._assessment_context[alias] = value
+                break
 
     def _merge_assessment_context_into_result(self, execution_result: Any) -> Any:
         if not self._assessment_context:
@@ -5798,19 +5800,21 @@ class MoonMindRunWorkflow:
 
         merged_outputs = dict(outputs)
         changed = False
-        for key in (
-            "assessmentArtifactRef",
-            "assessment_artifact_ref",
-            "assessmentVerdict",
-            "assessment_verdict",
+        for aliases in (
+            ("assessmentArtifactRef", "assessment_artifact_ref"),
+            ("assessmentVerdict", "assessment_verdict"),
         ):
-            value = self._assessment_context.get(key)
-            if value in (None, "", {}, []):
+            if any(
+                merged_outputs.get(alias) not in (None, "", {}, [])
+                for alias in aliases
+            ):
                 continue
-            if merged_outputs.get(key) not in (None, "", {}, []):
-                continue
-            merged_outputs[key] = value
-            changed = True
+            for alias in aliases:
+                value = self._assessment_context.get(alias)
+                if value in (None, "", {}, []):
+                    continue
+                merged_outputs[alias] = value
+                changed = True
         if not changed:
             return execution_result
 

--- a/tests/unit/workflows/temporal/test_run_artifacts.py
+++ b/tests/unit/workflows/temporal/test_run_artifacts.py
@@ -1857,6 +1857,148 @@ async def test_jira_blocker_wait_rechecks_with_compact_payload_and_no_manifest(
 
 
 @pytest.mark.asyncio
+async def test_jira_blocker_recheck_preserves_assessment_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workflow = MoonMindRunWorkflow()
+    captured_payloads: list[dict[str, Any]] = []
+    blocked_result = {
+        "status": "COMPLETED",
+        "outputs": {
+            "targetIssueKey": "MM-686",
+            "decision": "blocked",
+            "assessmentVerdict": "PARTIALLY_IMPLEMENTED",
+            "blockingIssues": [
+                {"issueKey": "MM-685", "status": "In Progress", "done": False}
+            ],
+            "summary": "MM-686 is blocked by MM-685.",
+        },
+    }
+    continue_result = {
+        "status": "COMPLETED",
+        "outputs": {
+            "targetIssueKey": "MM-686",
+            "decision": "continue",
+            "blockingIssues": [],
+            "summary": "All Jira blockers are Done.",
+        },
+    }
+    execute_payload = {
+        "registry_snapshot_ref": "art_registry",
+        "principal": "owner-1",
+        "invocation_payload": {
+            "id": "check-blockers",
+            "tool": {
+                "type": "skill",
+                "name": "jira.check_blockers",
+            },
+            "skill": {"name": "jira.check_blockers"},
+            "inputs": {
+                "targetIssueKey": "MM-686",
+                "blockerPreflight": {
+                    "targetIssueKey": "MM-686",
+                    "linkType": "Blocks",
+                },
+                "assessmentArtifactPath": "artifacts/assessment.json",
+                "previousOutputs": {
+                    "lastAssistantText": "Verdict: `PARTIALLY_IMPLEMENTED`."
+                },
+            },
+            "options": {},
+        },
+        "idempotency_key": "base-key",
+    }
+    route = TemporalActivityRoute(
+        activity_type="mm.tool.execute",
+        task_queue="mm.activity.integrations",
+        fleet="integrations",
+        capability_class="tools",
+        timeouts=TemporalActivityTimeouts(
+            start_to_close_seconds=30,
+            schedule_to_close_seconds=30,
+        ),
+        retries=TemporalActivityRetries(max_attempts=1, max_interval_seconds=1),
+    )
+
+    async def fake_execute_activity(
+        _activity_type: str,
+        payload: Any,
+        **_kwargs: Any,
+    ) -> dict[str, Any]:
+        captured_payloads.append(_normalize_payload(payload))
+        return continue_result
+
+    async def fake_noop_async(*_args: Any, **_kwargs: Any) -> None:
+        return None
+
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "execute_activity",
+        fake_execute_activity,
+    )
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "now",
+        lambda: datetime.now(timezone.utc),
+    )
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "upsert_memo",
+        lambda _memo: None,
+    )
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "upsert_search_attributes",
+        lambda _attributes: None,
+    )
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "wait_condition",
+        _timeout_wait_condition,
+    )
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "patched",
+        lambda patch_id: patch_id
+        in {
+            run_workflow_module.RUN_JIRA_BLOCKER_WAIT_COALESCING_PATCH,
+            run_workflow_module.RUN_JIRA_BLOCKER_RECHECK_ASSESSMENT_CONTEXT_PATCH,
+        },
+    )
+    monkeypatch.setattr(
+        MoonMindRunWorkflow,
+        "_wait_if_paused_at_safe_boundary",
+        fake_noop_async,
+    )
+
+    result, skipped = await workflow._wait_for_jira_blocker_resolution(
+        execution_result=blocked_result,
+        node_id="check-blockers",
+        tool_name="jira.check_blockers",
+        tool_type="skill",
+        failure_mode="FAIL_FAST",
+        route=route,
+        execute_payload=execute_payload,
+    )
+
+    assert skipped is False
+    assert result["outputs"]["decision"] == "continue"
+    assert result["outputs"]["assessmentVerdict"] == "PARTIALLY_IMPLEMENTED"
+    assert workflow._assessment_context["assessmentVerdict"] == (
+        "PARTIALLY_IMPLEMENTED"
+    )
+    compact_inputs = captured_payloads[0]["invocation_payload"]["inputs"]
+    assert compact_inputs == {
+        "targetIssueKey": "MM-686",
+        "blockerPreflight": {
+            "targetIssueKey": "MM-686",
+            "linkType": "Blocks",
+        },
+        "linkType": "Blocks",
+    }
+
+
+@pytest.mark.asyncio
 async def test_jira_blocker_recheck_applies_retry_floor_for_one_attempt_route(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/workflows/temporal/test_run_artifacts.py
+++ b/tests/unit/workflows/temporal/test_run_artifacts.py
@@ -1998,6 +1998,26 @@ async def test_jira_blocker_recheck_preserves_assessment_context(
     }
 
 
+def test_assessment_context_merge_treats_aliases_as_one_field() -> None:
+    workflow = MoonMindRunWorkflow()
+    workflow._record_assessment_context(
+        {"assessmentVerdict": "PARTIALLY_IMPLEMENTED"}
+    )
+
+    result = workflow._merge_assessment_context_into_result(
+        {
+            "status": "COMPLETED",
+            "outputs": {"assessment_verdict": "NOT_IMPLEMENTED"},
+        }
+    )
+
+    assert result["outputs"]["assessment_verdict"] == "NOT_IMPLEMENTED"
+    assert "assessmentVerdict" not in result["outputs"]
+    workflow._record_assessment_context(result["outputs"])
+    assert workflow._assessment_context["assessmentVerdict"] == "NOT_IMPLEMENTED"
+    assert workflow._assessment_context["assessment_verdict"] == "NOT_IMPLEMENTED"
+
+
 @pytest.mark.asyncio
 async def test_jira_blocker_recheck_applies_retry_floor_for_one_attempt_route(
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary
- Preserve assessment verdict/ref fields across Jira blocker recheck loops.
- Keep compact blocker recheck payloads compact while repairing omitted assessment context in the result.
- Add regression coverage for the THOR-686 failure mode where final blocker recheck returned continue without the assessment verdict.

## Root Cause
The Jira blocker wait loop compacts periodic recheck payloads. Those compact rechecks dropped assessment context, so a later jira.update_issue_status step could receive decision=continue but no assessment verdict and fail safely.

## Verification
- ./tools/test_unit.sh tests/unit/workflows/temporal/test_run_artifacts.py -q