### PR TITLE
Change the scheduled status icon for the sidebar to a lucide moon instead of a calendar

### DIFF
--- a/frontend/src/components/workflows/WorkflowWorkspaceSidebar.tsx
+++ b/frontend/src/components/workflows/WorkflowWorkspaceSidebar.tsx
@@ -17,6 +17,7 @@ import {
   RouteIcon,
   type RouteIconHandle,
 } from 'lucide-animated';
+import { Moon } from 'lucide-react';
 import { z } from 'zod';
 import type { BootPayload } from '../../boot/parseBootPayload';
 import {
@@ -158,6 +159,21 @@ function WorkflowSidebarStatusIcon({ status }: { status: string | null | undefin
     .replace(/\s+/g, '_');
   if (normalizedStatus === 'running') {
     normalizedStatus = 'executing';
+  }
+  if (normalizedStatus === 'scheduled') {
+    const label = sidebarStatusLabel(status);
+    const pillProps = executionStatusPillProps(normalizedStatus, { enableMotion: false });
+    return (
+      <span
+        {...pillProps}
+        className={`${pillProps.className} workflow-workspace-sidebar-status-icon`}
+        aria-label={`Status: ${label}`}
+        title={label}
+        data-testid="workflow-workspace-sidebar-status-icon"
+      >
+        <Moon size={16} aria-hidden="true" />
+      </span>
+    );
   }
   if (isSidebarAnimatedWorkflowStatus(normalizedStatus)) {
     const label = sidebarStatusLabel(status);

--- a/frontend/src/components/workflows/WorkflowWorkspaceSidebar.tsx
+++ b/frontend/src/components/workflows/WorkflowWorkspaceSidebar.tsx
@@ -17,7 +17,6 @@ import {
   RouteIcon,
   type RouteIconHandle,
 } from 'lucide-animated';
-import { Moon } from 'lucide-react';
 import { z } from 'zod';
 import type { BootPayload } from '../../boot/parseBootPayload';
 import {
@@ -159,21 +158,6 @@ function WorkflowSidebarStatusIcon({ status }: { status: string | null | undefin
     .replace(/\s+/g, '_');
   if (normalizedStatus === 'running') {
     normalizedStatus = 'executing';
-  }
-  if (normalizedStatus === 'scheduled') {
-    const label = sidebarStatusLabel(status);
-    const pillProps = executionStatusPillProps(normalizedStatus, { enableMotion: false });
-    return (
-      <span
-        {...pillProps}
-        className={`${pillProps.className} workflow-workspace-sidebar-status-icon`}
-        aria-label={`Status: ${label}`}
-        title={label}
-        data-testid="workflow-workspace-sidebar-status-icon"
-      >
-        <Moon size={16} aria-hidden="true" />
-      </span>
-    );
   }
   if (isSidebarAnimatedWorkflowStatus(normalizedStatus)) {
     const label = sidebarStatusLabel(status);

--- a/frontend/src/entrypoints/workflow-detail.test.tsx
+++ b/frontend/src/entrypoints/workflow-detail.test.tsx
@@ -994,7 +994,7 @@ describe('Workflow Detail Entrypoint', () => {
 
     const sidebar = await screen.findByRole('complementary', { name: 'Workflow navigation' });
     const expectedIcons = [
-      ['Scheduled workflow', 'Status: Scheduled', 'status-scheduled', 'lucide-calendar-clock'],
+      ['Scheduled workflow', 'Status: Scheduled', 'status-scheduled', 'lucide-moon'],
       ['Initializing workflow', 'Status: Initializing', 'status-initializing', null],
       ['Running workflow', 'Status: Running', 'status-running', null],
       ['Dependency wait workflow', 'Status: Awaiting dependencies', 'status-awaiting-dependencies', 'lucide-link'],

--- a/frontend/src/utils/statusIcons.tsx
+++ b/frontend/src/utils/statusIcons.tsx
@@ -1,6 +1,5 @@
 import {
   Ban,
-  CalendarClock,
   Check,
   Hand,
   Hourglass,
@@ -8,6 +7,7 @@ import {
   Link,
   Map as MapIcon,
   Minus,
+  Moon,
   PackageCheck,
   Play,
   Power,
@@ -19,7 +19,7 @@ import { formatStatusLabel } from './formatters';
 import { stepStatusPillProps } from '../status/stepStatus';
 
 export const WORKFLOW_STATUS_ICONS = {
-  scheduled: CalendarClock,
+  scheduled: Moon,
   initializing: Power,
   waiting_on_dependencies: Link,
   planning: MapIcon,


### PR DESCRIPTION
Change the scheduled status icon for the sidebar to a lucide moon instead of a calendar