### PR TITLE
Add contributor onboarding docs and templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,60 @@
+name: Bug Report
+description: Report a bug or unexpected behavior
+title: "[Bug] "
+labels: ["bug", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Before submitting, please search existing issues. If one already exists, add a 👍 reaction and any new diagnostic details there.
+
+        Please redact secrets, tokens, private URLs, customer data, private repository contents, and internal configuration.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What happened? What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro-steps
+    attributes:
+      label: Steps to reproduce
+      description: >
+        Minimal steps to reproduce the issue. If you can't reproduce it
+        reliably, describe what you observed and when.
+      placeholder: |
+        1. ...
+        2. ...
+        3. ...
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: MoonMind version
+      description: Commit SHA, tag, branch, or Docker image digest.
+      placeholder: e.g. main@abc1234 or ghcr.io/...:latest
+    validations:
+      required: false
+
+  - type: input
+    id: environment
+    attributes:
+      label: Environment
+      description: Operating system, Docker/Desktop version, browser, or deployment target when relevant.
+      placeholder: e.g. macOS 15, Ubuntu 24.04, WSL2, Docker Desktop 4.x
+    validations:
+      required: false
+
+  - type: textarea
+    id: diagnostics
+    attributes:
+      label: Diagnostics and logs
+      description: Paste relevant redacted logs, workflow IDs, run IDs, screenshots, or terminal output.
+      render: text
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,7 +1,7 @@
 name: Bug Report
 description: Report a bug or unexpected behavior
 title: "[Bug] "
-labels: ["bug", "needs-triage"]
+labels: ["bug"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions & Help
+    url: https://github.com/MoonLadderStudios/MoonMind/discussions
+    about: Ask questions, share workflows, and get help from the community. Issues are for actionable bugs and feature requests.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: Questions & Help
-    url: https://github.com/MoonLadderStudios/MoonMind/discussions
-    about: Ask questions, share workflows, and get help from the community. Issues are for actionable bugs and feature requests.
+    url: https://github.com/MoonLadderStudios/MoonMind/blob/main/CONTRIBUTING.md#getting-help
+    about: Read the contributing guide for how to get help and where to ask questions. Issues are for actionable bugs and feature requests.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,43 @@
+name: Feature Request
+description: Suggest a new feature or improvement
+title: "[Feature] "
+labels: ["enhancement", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Before submitting, please search existing issues. If a similar request already exists, add a 👍 reaction and any new context there.
+
+        Please describe the problem or use case first. This helps maintainers evaluate the right solution.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or use case
+      description: What problem are you trying to solve, or what use case would this enable?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed-solution
+    attributes:
+      label: Proposed solution
+      description: How would you like this to work?
+    validations:
+      required: false
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Any workarounds or alternative approaches you've thought about.
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Links, screenshots, examples, or related issues that help explain the request.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,7 +1,7 @@
 name: Feature Request
 description: Suggest a new feature or improvement
 title: "[Feature] "
-labels: ["enhancement", "needs-triage"]
+labels: ["enhancement"]
 body:
   - type: markdown
     attributes:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,9 +10,7 @@ For AI-assisted or AI-written descriptions:
 
 ## Related issue
 
-Closes #
-Related to #
-N/A
+<!-- Replace with Closes #<issue_number>, Related to #<issue_number>, or N/A -->
 
 ## Summary
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,84 @@
+<!--
+For AI-assisted or AI-written descriptions:
+- Follow this template.
+- Keep it concise; reviewers skim long descriptions.
+- Base the summary on the actual diff, not just the prompt.
+- For non-trivial changes, include a short ELI5 and, if useful, an ASCII or Mermaid diagram.
+- Keep every section and checkbox row so reviewers and review agents can skim them.
+- For UI changes, attach screenshots or a short recording in Demo.
+-->
+
+## Related issue
+
+Closes #
+Related to #
+N/A
+
+## Summary
+
+<!-- What changed and why, in 1-3 bullets or a short paragraph. -->
+
+## Test Plan
+
+<!-- Exact commands, scenarios, or manual checks used. -->
+
+```bash
+# paste commands here
+```
+
+## Demo
+
+<!-- Required for dashboard/UI changes. Use N/A for non-visual changes. -->
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] Feature
+- [ ] UI / dashboard change
+- [ ] Runtime / agent adapter change
+- [ ] Workflow / Temporal change
+- [ ] Security / policy / sandboxing change
+- [ ] Refactor / chore
+- [ ] Docs
+- [ ] Test / CI
+- [ ] Breaking change
+
+## Test coverage
+
+- [ ] Unit tests added / updated
+- [ ] Integration tests added / updated
+- [ ] Frontend tests added / updated
+- [ ] Workflow boundary tests added / updated
+- [ ] Manual verification completed
+- [ ] Existing tests cover this change
+- [ ] Not applicable
+
+## AI assistance
+
+- [ ] No material AI assistance
+- [ ] AI-assisted or AI-generated contribution
+
+If AI-assisted:
+
+- Tool or workflow used:
+- What the AI helped with:
+- What I manually reviewed:
+- What I verified independently:
+
+I understand that I am responsible for the final submitted change.
+
+## Risk notes
+
+<!--
+Call out anything touching secrets, credentials, sandboxing, Docker, network access,
+provider profiles, billing-relevant settings, publish paths, migrations, or
+Temporal replay/in-flight compatibility.
+-->
+
+## Coverage notes
+
+<!-- Required if Manual verification or Not applicable is checked. -->
+
+## Changelog
+
+<!-- User-facing one-liner, or delete this section. -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,111 @@
+# Contributing to MoonMind
+
+Thanks for your interest in improving MoonMind. Issues and pull requests are welcome.
+
+For larger changes, please open an issue first so maintainers and contributors can align on the approach before code is written.
+
+Please do not include secrets, tokens, internal URLs, customer data, private configuration, private repository contents, or unredacted logs in issues, tests, examples, screenshots, or pull requests.
+
+## AI-assisted contributions are welcome
+
+You may use an AI coding workflow to prepare a contribution.
+
+We review the final contribution, not the tool that helped create it. AI-assisted pull requests are welcome when they are:
+
+- focused and reviewable
+- linked to an issue or a clear problem statement
+- manually reviewed by the contributor submitting the PR
+- tested with the relevant commands
+- safe with respect to secrets, credentials, sandboxing, Docker, network access, provider profiles, and publish paths
+- explained clearly in the PR description
+
+Low-effort generated rewrites, unrelated drive-by changes, fake validation claims, or PRs the submitter cannot explain may be closed or asked to revise.
+
+## Development setup
+
+Clone the repository and initialize submodules:
+
+```bash
+git clone https://github.com/MoonLadderStudios/MoonMind.git
+cd MoonMind
+git submodule update --init --recursive
+```
+
+Start the local stack:
+
+```bash
+docker compose up -d
+```
+
+Open [http://localhost:7000](http://localhost:7000), configure the provider credentials you need in Settings, and submit a workflow from the dashboard.
+
+For Python/backend development, use a repository-local virtual environment when possible:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+python -m pip install --upgrade pip uv
+uv pip install -e ".[tests]"
+```
+
+For frontend work, install the JavaScript dependencies from the lockfile:
+
+```bash
+npm ci
+```
+
+## Common checks
+
+Run the smallest validation that covers the change. Paste the exact commands and results into your pull request.
+
+For Python/backend changes:
+
+```bash
+./tools/test_unit.sh --python-only
+```
+
+For frontend changes:
+
+```bash
+npm run frontend:ci
+```
+
+For focused frontend tests:
+
+```bash
+./tools/test_unit.sh --ui-args frontend/src/path/to/test.tsx
+```
+
+For changes that affect Docker, compose, database, migrations, integration tests, runtime infrastructure, artifacts, worker topology, live logs, or startup seeding:
+
+```bash
+./tools/test_integration.sh
+```
+
+Provider verification tests that require live third-party credentials are not required for normal community pull requests unless a maintainer specifically asks for them.
+
+## Tests
+
+A change that alters behavior should usually include a test. A bug fix should add or update a test that would have failed before the fix when practical.
+
+Prefer the smallest focused test that covers the change. Use broader integration tests only when behavior genuinely crosses component boundaries.
+
+Changes to Temporal workflows, activity signatures, signal/update names, serialized payload shapes, status normalization, runtime adapters, sandboxing, credentials, provider profiles, or publish paths need boundary-oriented coverage or a clear explanation of why that coverage is not applicable.
+
+Pure refactors, formatting-only changes, docs-only changes, dependency bumps, type-only changes, and copy edits with no behavior change may not need new tests. Explain that in the PR when you mark test coverage as not applicable.
+
+## Pull requests
+
+- Branch from `main` and keep changes focused.
+- Use one pull request per issue or coherent change.
+- Fill in the pull request template.
+- Include tests or docs when relevant.
+- Include screenshots or a short recording for dashboard/UI behavior changes.
+- Be honest about what validation you did and did not run.
+- Call out risks around secrets, credentials, sandboxing, Docker, network access, provider profiles, billing-relevant settings, publish paths, migrations, and Temporal replay/in-flight compatibility.
+
+Draft pull requests are welcome when you want early feedback. Ready-for-review pull requests should contain enough context and validation evidence for maintainers to review confidently.
+
+## Getting help
+
+Open a GitHub issue for actionable bugs and feature requests. Use the issue templates so maintainers have the information needed to reproduce, triage, and review the request.

--- a/README.md
+++ b/README.md
@@ -108,6 +108,12 @@ MoonMind runs as a set of decoupled containers from a single `docker-compose.yam
 | **Qdrant & MinIO** | Vector database for RAG/memory, and S3-compatible artifact storage. |
 | **Docker Proxy** | Restricted Docker socket access for control-plane workload workers; ordinary managed sessions use their private sidecar daemon instead of the host socket. |
 
+## Contributing
+
+Contributions are welcome, including high-quality AI-assisted pull requests.
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for local setup, validation commands, testing expectations, and pull request guidelines. If you are using an AI coding agent, also read [AGENTS.md](AGENTS.md) before making changes.
+
 ## License
 
 MIT — free for personal and commercial use.


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Adds a concise README contributing section that welcomes high-quality AI-assisted pull requests and points contributors to `CONTRIBUTING.md` and `AGENTS.md`.
- Adds an Omnigent-inspired `CONTRIBUTING.md` with setup, common checks, testing expectations, PR expectations, and explicit guidance for AI-assisted contributions.
- Adds GitHub community templates for pull requests, bug reports, feature requests, and issue-template configuration.

## Test Plan

```bash
# Not run: docs and GitHub template changes only.
```

Verified through GitHub compare that the PR changes are limited to README/contributor documentation and GitHub issue/PR templates.

## Demo

N/A — non-visual docs/template change.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / dashboard change
- [ ] Runtime / agent adapter change
- [ ] Workflow / Temporal change
- [ ] Security / policy / sandboxing change
- [ ] Refactor / chore
- [x] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] Frontend tests added / updated
- [ ] Workflow boundary tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [x] Not applicable

## AI assistance

- [ ] No material AI assistance
- [x] AI-assisted or AI-generated contribution

If AI-assisted:

- Tool or workflow used: ChatGPT / GitHub connector
- What the AI helped with: Drafted docs/templates and created the branch/PR
- What I manually reviewed: Scope and repository context from current README/AGENTS guidance
- What I verified independently: GitHub compare output and requested file list

I understand that I am responsible for the final submitted change.

## Risk notes

No runtime, credential, sandbox, Docker, network, provider-profile, publish-path, migration, or Temporal behavior changes.

The issue template config routes questions/help to GitHub Discussions following Omnigent's pattern. If Discussions are not enabled yet, enable them before or soon after merging this PR.

## Coverage notes

Automated tests were not run because this is a documentation and GitHub-template-only change.

## Changelog

Add contributor onboarding docs and GitHub issue/PR templates.
