### PR TITLE
Improve plan step failure summaries

### DIFF
--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -574,6 +574,7 @@ RUN_STEP_RESILIENCE_POLICY_PATCH = "run-step-resilience-policy-v1"
 RUN_AGENT_RUNTIME_RETRY_CLASSIFICATION_PATCH = (
     "run-agent-runtime-retry-classification-v1"
 )
+RUN_FAIL_FAST_STEP_FAILURE_SUMMARY_PATCH = "run-fail-fast-step-failure-summary-v1"
 # MM-884: stamp a stable correlation (trace) ref onto step-execution manifests
 # and emit a single incident reconstruction manifest before terminal failure so
 # policy, provider/profile/credential source, failed step, progress, workspace
@@ -806,6 +807,48 @@ class MoonMindRunWorkflow:
                 "diagnostic detail — inspect step diagnostics/artifacts."
             )
         return f"{tool_name} failed"
+
+    def _format_step_failure_exception_message(
+        self,
+        *,
+        node_id: str,
+        tool_name: str,
+        result_status: str,
+        step_failure_summary: str,
+        failure_message: str | None,
+        child_workflow_id: str | None,
+        diagnostics_ref: str | None,
+    ) -> str:
+        """Build the fail-fast ApplicationError text for a failed plan step."""
+
+        summary = (
+            self._sanitize_operator_summary(step_failure_summary)
+            or step_failure_summary
+            or f"{tool_name} failed"
+        )
+        bounded_summary = self._coerce_text(summary, max_chars=900) or (
+            f"{tool_name} failed"
+        )
+        message = (
+            f"Plan step '{node_id}' ({tool_name}) returned status "
+            f"{result_status}: {bounded_summary}"
+        )
+        details: list[str] = []
+        raw_last_error = self._coerce_text(failure_message, max_chars=240)
+        last_error = (
+            self._sanitize_operator_summary(raw_last_error) or raw_last_error
+        )
+        if last_error and last_error not in bounded_summary:
+            details.append(f"lastError={last_error}")
+        child_id = self._coerce_text(child_workflow_id, max_chars=400)
+        if child_id:
+            details.append(f"childWorkflowId={child_id}")
+        diag_ref = self._coerce_text(diagnostics_ref, max_chars=400)
+        if diag_ref:
+            details.append(f"diagnosticsRef={diag_ref}")
+        if details:
+            message = f"{message} ({'; '.join(details)})"
+        return self._coerce_text(message, max_chars=1200) or message
 
     def _failure_diagnostic_from_exception(
         self,
@@ -8309,6 +8352,20 @@ class MoonMindRunWorkflow:
                         if failure_mode == "FAIL_FAST":
                             if provider_failure_summary:
                                 raise ValueError(provider_failure_summary)
+                            if workflow.patched(
+                                RUN_FAIL_FAST_STEP_FAILURE_SUMMARY_PATCH
+                            ):
+                                raise ValueError(
+                                    self._format_step_failure_exception_message(
+                                        node_id=node_id,
+                                        tool_name=tool_name,
+                                        result_status=result_status,
+                                        step_failure_summary=step_failure_summary,
+                                        failure_message=failure_message,
+                                        child_workflow_id=child_workflow_id,
+                                        diagnostics_ref=diagnostics_ref,
+                                    )
+                                )
                             detail = (
                                 f" with error '{failure_message}'"
                                 if failure_message

--- a/tests/integration/workflows/temporal/workflows/test_run.py
+++ b/tests/integration/workflows/temporal/workflows/test_run.py
@@ -525,10 +525,12 @@ class TestMoonMindUserWorkflow(unittest.IsolatedAsyncioTestCase):
                 self.assertIsInstance(
                     exc_info.exception.cause, exceptions.ApplicationError
                 )
+                failure_message = exc_info.exception.cause.message
                 self.assertIn(
-                    "plan node execution returned status FAILED",
-                    exc_info.exception.cause.message,
+                    "Plan step 'step-1' (repo.run_tests) returned status FAILED",
+                    failure_message,
                 )
+                self.assertIn("forced skill failure", failure_message)
                 
                 handle = env.client.get_workflow_handle("test-workflow-id-failed-skill-status")
                 desc = await handle.describe()

--- a/tests/unit/workflows/temporal/test_run_artifacts.py
+++ b/tests/unit/workflows/temporal/test_run_artifacts.py
@@ -2491,14 +2491,17 @@ async def test_run_execution_stage_fail_fast_raises_when_tool_returns_failed_sta
     monkeypatch.setattr(run_workflow_module.workflow, "info", workflow_info)
     monkeypatch.setattr(run_workflow_module.workflow, "patched", lambda patch_id: True)
 
-    with pytest.raises(
-        ValueError,
-        match="plan node execution returned status FAILED",
-    ):
+    with pytest.raises(ValueError) as exc_info:
         await workflow._run_execution_stage(
             parameters={"repo": "MoonLadderStudios/MoonMind"},
             plan_ref="art_plan_1",
         )
+
+    message = str(exc_info.value)
+    assert "Plan step 'step-1' (codex_cli) returned status FAILED" in message
+    assert "Failed to execute generic LLM handler" in message
+    assert "lastError=gemini CLI command failed" in message
+    assert "childWorkflowId=wf-1:agent:step-1" in message
 
 @pytest.mark.asyncio
 async def test_run_execution_stage_continue_mode_keeps_running_after_failed_status(


### PR DESCRIPTION
## Summary

- Surface step id, tool name, status, operator summary, last error, child workflow id, and diagnostics refs in fail-fast plan-step failures.
- Keep provider-specific failure summaries as the highest-priority message.
- Update unit and Temporal workflow integration assertions for the richer failure text.

## Root Cause

Failed plan nodes already computed useful step summaries, but the fail-fast exception still fell back to the generic status-only message when no provider-specific summary was present.

## Validation

- python3 -m compileall -q moonmind/workflows/temporal/workflows/run.py
- ./tools/test_unit.sh tests/unit/workflows/temporal/test_run_artifacts.py -k 'fail_fast_raises_when_tool_returns_failed_status or fail_fast_raises_provider_failure_summary or fail_fast_raises_agent_runtime_failure_summary or does_not_retry_permanent_agent_runtime_failure'
- .venv/bin/python -m pytest -q tests/unit/workflows/temporal/test_run_artifacts.py -k 'fail_fast_raises_when_tool_returns_failed_status or fail_fast_raises_provider_failure_summary or fail_fast_raises_agent_runtime_failure_summary or does_not_retry_permanent_agent_runtime_failure'

The focused Temporal integration test was attempted locally and interrupted after 5:28 without a result; these tests are documented as slow under the Temporal test server.