### PR TITLE
MM-1169 Add Provider Profile model tier contract and migration

### DIFF
--- a/api_service/api/routers/provider_profiles.py
+++ b/api_service/api/routers/provider_profiles.py
@@ -35,6 +35,10 @@ from moonmind.auth.secret_refs import (
     SecretReferenceError,
     parse_secret_ref,
 )
+from moonmind.provider_profiles.model_tiers import (
+    ProviderModelEffortTier,
+    coerce_model_effort_tier_policy,
+)
 from moonmind.schemas.agent_runtime_models import validate_codex_oauth_profile_refs
 from moonmind.utils.logging import (
     redact_profile_file_templates,
@@ -75,6 +79,8 @@ class ProviderProfileCreate(BaseModel):
     provider_label: Optional[str] = None
     default_model: Optional[str] = None
     default_effort: Optional[str] = Field(default=None, max_length=64)
+    model_tiers: Optional[list[ProviderModelEffortTier]] = None
+    default_model_tier: Optional[int] = Field(default=None, ge=1)
     model_overrides: Optional[dict[str, str]] = None
     
     credential_source: str = Field(..., pattern="^(oauth_volume|secret_ref|none)$")
@@ -153,6 +159,8 @@ class ProviderProfileUpdate(BaseModel):
     provider_label: Optional[str] = None
     default_model: Optional[str] = None
     default_effort: Optional[str] = Field(default=None, max_length=64)
+    model_tiers: Optional[list[ProviderModelEffortTier]] = None
+    default_model_tier: Optional[int] = Field(default=None, ge=1)
     model_overrides: Optional[dict[str, str]] = None
     credential_source: Optional[str] = Field(default=None, pattern="^(oauth_volume|secret_ref|none)$")
     runtime_materialization_mode: Optional[str] = Field(default=None, pattern="^(oauth_home|api_key_env|env_bundle|config_bundle|composite)$")
@@ -219,6 +227,8 @@ class ProviderProfileResponse(BaseModel):
     provider_label: Optional[str]
     default_model: Optional[str] = None
     default_effort: Optional[str] = None
+    model_tiers: list[ProviderModelEffortTier]
+    default_model_tier: int
     model_overrides: dict[str, str] = Field(default_factory=dict)
     credential_source: str
     runtime_materialization_mode: str
@@ -382,6 +392,19 @@ async def create_profile(
     existing = await session.get(ManagedAgentProviderProfile, body.profile_id)
     if existing:
         raise HTTPException(status_code=409, detail="Profile already exists")
+    try:
+        model_tiers, default_model_tier = coerce_model_effort_tier_policy(
+            model_tiers=(
+                [tier.model_dump(mode="json") for tier in body.model_tiers]
+                if body.model_tiers is not None
+                else None
+            ),
+            default_model_tier=body.default_model_tier,
+            legacy_default_model=body.default_model,
+            legacy_default_effort=body.default_effort,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
 
     profile = ManagedAgentProviderProfile(
         profile_id=body.profile_id,
@@ -390,6 +413,8 @@ async def create_profile(
         provider_label=body.provider_label,
         default_model=body.default_model,
         default_effort=body.default_effort,
+        model_tiers=model_tiers,
+        default_model_tier=default_model_tier,
         model_overrides=body.model_overrides,
         credential_source=ProviderCredentialSource(body.credential_source),
         runtime_materialization_mode=RuntimeMaterializationMode(body.runtime_materialization_mode),
@@ -477,6 +502,28 @@ async def update_profile(
 
     update_data = body.model_dump(exclude_unset=True)
     requested_is_default = update_data.pop("is_default", None)
+    model_tiers_supplied = "model_tiers" in update_data
+    default_model_tier_supplied = "default_model_tier" in update_data
+    if model_tiers_supplied or default_model_tier_supplied:
+        raw_model_tiers = update_data.pop("model_tiers", None)
+        raw_default_model_tier = update_data.pop("default_model_tier", None)
+        try:
+            model_tiers, default_model_tier = coerce_model_effort_tier_policy(
+                model_tiers=(
+                    raw_model_tiers if model_tiers_supplied else profile.model_tiers
+                ),
+                default_model_tier=(
+                    raw_default_model_tier
+                    if default_model_tier_supplied
+                    else profile.default_model_tier
+                ),
+                legacy_default_model=profile.default_model,
+                legacy_default_effort=profile.default_effort,
+            )
+        except ValueError as exc:
+            raise HTTPException(status_code=422, detail=str(exc)) from exc
+        profile.model_tiers = model_tiers
+        profile.default_model_tier = default_model_tier
     for key, value in update_data.items():
         if key == "rate_limit_policy" and value is not None:
             value = ManagedAgentRateLimitPolicy(value)
@@ -1589,6 +1636,13 @@ def _row_to_dict(
         managed_secret_statuses=managed_secret_statuses,
         secret_ref_results=secret_ref_results,
     )
+    model_tiers, default_model_tier = coerce_model_effort_tier_policy(
+        model_tiers=row.model_tiers,
+        default_model_tier=row.default_model_tier,
+        legacy_default_model=row.default_model,
+        legacy_default_effort=row.default_effort,
+        empty_as_missing=True,
+    )
     payload = {
         "profile_id": row.profile_id,
         "runtime_id": row.runtime_id,
@@ -1596,6 +1650,8 @@ def _row_to_dict(
         "provider_label": row.provider_label,
         "default_model": row.default_model,
         "default_effort": row.default_effort,
+        "model_tiers": model_tiers,
+        "default_model_tier": default_model_tier,
         "model_overrides": row.model_overrides or {},
         "credential_source": row.credential_source.value if row.credential_source else None,
         "runtime_materialization_mode": row.runtime_materialization_mode.value if row.runtime_materialization_mode else None,

--- a/api_service/api/routers/provider_profiles.py
+++ b/api_service/api/routers/provider_profiles.py
@@ -38,6 +38,8 @@ from moonmind.auth.secret_refs import (
 from moonmind.provider_profiles.model_tiers import (
     ProviderModelEffortTier,
     coerce_model_effort_tier_policy,
+    is_single_runtime_default_model_effort_tier,
+    legacy_default_model_effort_tier,
 )
 from moonmind.schemas.agent_runtime_models import validate_codex_oauth_profile_refs
 from moonmind.utils.logging import (
@@ -504,21 +506,59 @@ async def update_profile(
     requested_is_default = update_data.pop("is_default", None)
     model_tiers_supplied = "model_tiers" in update_data
     default_model_tier_supplied = "default_model_tier" in update_data
-    if model_tiers_supplied or default_model_tier_supplied:
+    legacy_default_supplied = (
+        "default_model" in update_data or "default_effort" in update_data
+    )
+    should_refresh_single_default_tier = (
+        legacy_default_supplied
+        and not model_tiers_supplied
+        and not default_model_tier_supplied
+        and (
+            is_single_runtime_default_model_effort_tier(profile.model_tiers)
+            or (
+                isinstance(profile.model_tiers, list)
+                and len(profile.model_tiers) == 1
+                and profile.default_model_tier == 1
+                and profile.model_tiers[0]
+                == legacy_default_model_effort_tier(
+                    legacy_default_model=profile.default_model,
+                    legacy_default_effort=profile.default_effort,
+                )
+            )
+        )
+    )
+    if (
+        model_tiers_supplied
+        or default_model_tier_supplied
+        or should_refresh_single_default_tier
+    ):
         raw_model_tiers = update_data.pop("model_tiers", None)
         raw_default_model_tier = update_data.pop("default_model_tier", None)
+        legacy_default_model = update_data.get(
+            "default_model",
+            profile.default_model,
+        )
+        legacy_default_effort = update_data.get(
+            "default_effort",
+            profile.default_effort,
+        )
         try:
             model_tiers, default_model_tier = coerce_model_effort_tier_policy(
                 model_tiers=(
-                    raw_model_tiers if model_tiers_supplied else profile.model_tiers
+                    raw_model_tiers
+                    if model_tiers_supplied
+                    else None
+                    if should_refresh_single_default_tier
+                    else profile.model_tiers
                 ),
                 default_model_tier=(
                     raw_default_model_tier
                     if default_model_tier_supplied
                     else profile.default_model_tier
                 ),
-                legacy_default_model=profile.default_model,
-                legacy_default_effort=profile.default_effort,
+                legacy_default_model=legacy_default_model,
+                legacy_default_effort=legacy_default_effort,
+                empty_as_missing=should_refresh_single_default_tier,
             )
         except ValueError as exc:
             raise HTTPException(status_code=422, detail=str(exc)) from exc

--- a/api_service/db/models.py
+++ b/api_service/db/models.py
@@ -51,6 +51,38 @@ def _enum_values(enum_cls: type[enum.Enum]) -> list[str]:
 
     return [member.value for member in enum_cls]
 
+def _runtime_default_model_tier() -> dict[str, Any]:
+    return {
+        "label": "Runtime default",
+        "model": None,
+        "effort": None,
+        "parameters": {},
+        "annotations": {},
+    }
+
+def _provider_profile_model_tiers_default_for_values(
+    default_model: str | None,
+    default_effort: str | None,
+) -> list[dict[str, Any]]:
+    if default_model is not None or default_effort is not None:
+        return [
+            {
+                "label": "Legacy default",
+                "model": default_model,
+                "effort": default_effort,
+                "parameters": {},
+                "annotations": {},
+            }
+        ]
+    return [_runtime_default_model_tier()]
+
+def _provider_profile_model_tiers_default(context: Any = None) -> list[dict[str, Any]]:
+    params = context.get_current_parameters() if context is not None else {}
+    return _provider_profile_model_tiers_default_for_values(
+        params.get("default_model"),
+        params.get("default_effort"),
+    )
+
 # Note: fastapi-users[sqlalchemy] uses GUID/UUID by default for id.
 # If you need an Integer ID, you would use SQLAlchemyBaseUserTable[int]
 # and ensure your UserManager and FastAPIUsers instances are typed accordingly.
@@ -2406,15 +2438,7 @@ class ManagedAgentProviderProfile(Base):
     model_tiers: Mapped[list[dict[str, Any]]] = mapped_column(
         JSON,
         nullable=False,
-        default=lambda: [
-            {
-                "label": "Runtime default",
-                "model": None,
-                "effort": None,
-                "parameters": {},
-                "annotations": {},
-            }
-        ],
+        default=_provider_profile_model_tiers_default,
         server_default=text(
             """'[{"label":"Runtime default","model":null,"effort":null,"parameters":{},"annotations":{}}]'"""
         ),
@@ -2423,7 +2447,15 @@ class ManagedAgentProviderProfile(Base):
         Integer, nullable=False, default=1, server_default=text("1")
     )
     model_overrides: Mapped[Optional[dict[str, Any]]] = mapped_column(JSON, nullable=True)
-    
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        if kwargs.get("model_tiers") is None:
+            self.model_tiers = _provider_profile_model_tiers_default_for_values(
+                self.default_model,
+                self.default_effort,
+            )
+
     credential_source: Mapped[ProviderCredentialSource] = mapped_column(
         Enum(
             ProviderCredentialSource,

--- a/api_service/db/models.py
+++ b/api_service/db/models.py
@@ -2403,6 +2403,25 @@ class ManagedAgentProviderProfile(Base):
     provider_label: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
     default_model: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
     default_effort: Mapped[Optional[str]] = mapped_column(String(64), nullable=True)
+    model_tiers: Mapped[list[dict[str, Any]]] = mapped_column(
+        JSON,
+        nullable=False,
+        default=lambda: [
+            {
+                "label": "Runtime default",
+                "model": None,
+                "effort": None,
+                "parameters": {},
+                "annotations": {},
+            }
+        ],
+        server_default=text(
+            """'[{"label":"Runtime default","model":null,"effort":null,"parameters":{},"annotations":{}}]'"""
+        ),
+    )
+    default_model_tier: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=1, server_default=text("1")
+    )
     model_overrides: Mapped[Optional[dict[str, Any]]] = mapped_column(JSON, nullable=True)
     
     credential_source: Mapped[ProviderCredentialSource] = mapped_column(

--- a/api_service/migrations/versions/335_mm1169_provider_profile_model_tiers.py
+++ b/api_service/migrations/versions/335_mm1169_provider_profile_model_tiers.py
@@ -20,7 +20,14 @@ down_revision: Union[str, None] = "334_mm1152_bridge_sessions"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
-__all__ = ["revision", "down_revision", "upgrade", "downgrade"]
+__all__ = [
+    "revision",
+    "down_revision",
+    "branch_labels",
+    "depends_on",
+    "upgrade",
+    "downgrade",
+]
 
 profiles_table = table(
     "managed_agent_provider_profiles",

--- a/api_service/migrations/versions/335_mm1169_provider_profile_model_tiers.py
+++ b/api_service/migrations/versions/335_mm1169_provider_profile_model_tiers.py
@@ -1,0 +1,97 @@
+"""add provider profile model tiers
+
+Revision ID: 335_mm1169_profile_tiers
+Revises: 334_mm1152_bridge_sessions
+Create Date: 2026-07-10 00:00:00.000000
+
+Implementation issue: MM-1169
+Source issue traceability: MM-1168
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.sql import column, table
+
+revision: str = "335_mm1169_profile_tiers"
+down_revision: Union[str, None] = "334_mm1152_bridge_sessions"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+__all__ = ["revision", "down_revision", "upgrade", "downgrade"]
+
+profiles_table = table(
+    "managed_agent_provider_profiles",
+    column("profile_id", sa.String),
+    column("default_model", sa.String),
+    column("default_effort", sa.String),
+    column("model_tiers", sa.JSON),
+    column("default_model_tier", sa.Integer),
+)
+
+
+def upgrade() -> None:
+    op.add_column(
+        "managed_agent_provider_profiles",
+        sa.Column(
+            "model_tiers",
+            sa.JSON(),
+            nullable=False,
+            server_default=sa.text(
+                """'[{"label":"Runtime default","model":null,"effort":null,"parameters":{},"annotations":{}}]'"""
+            ),
+        ),
+    )
+    op.add_column(
+        "managed_agent_provider_profiles",
+        sa.Column(
+            "default_model_tier",
+            sa.Integer(),
+            nullable=False,
+            server_default=sa.text("1"),
+        ),
+    )
+
+    bind = op.get_bind()
+    rows = list(
+        bind.execute(
+            sa.select(
+                profiles_table.c.profile_id,
+                profiles_table.c.default_model,
+                profiles_table.c.default_effort,
+            )
+        )
+    )
+    for row in rows:
+        if row.default_model is not None or row.default_effort is not None:
+            tiers = [
+                {
+                    "label": "Legacy default",
+                    "model": row.default_model,
+                    "effort": row.default_effort,
+                    "parameters": {},
+                    "annotations": {},
+                }
+            ]
+        else:
+            tiers = [
+                {
+                    "label": "Runtime default",
+                    "model": None,
+                    "effort": None,
+                    "parameters": {},
+                    "annotations": {},
+                }
+            ]
+        bind.execute(
+            profiles_table.update()
+            .where(profiles_table.c.profile_id == row.profile_id)
+            .values(model_tiers=tiers, default_model_tier=1)
+        )
+
+
+def downgrade() -> None:
+    op.drop_column("managed_agent_provider_profiles", "default_model_tier")
+    op.drop_column("managed_agent_provider_profiles", "model_tiers")

--- a/api_service/services/provider_profile_service.py
+++ b/api_service/services/provider_profile_service.py
@@ -108,6 +108,7 @@ def _manager_profile_payload(
         legacy_default_effort=row.default_effort,
         empty_as_missing=True,
     )
+    redacted_model_tiers = redact_sensitive_payload(model_tiers)
     return {
         "profile_id": row.profile_id,
         "is_default": row.is_default,
@@ -116,7 +117,7 @@ def _manager_profile_payload(
         "provider_label": row.provider_label,
         "default_model": row.default_model,
         "default_effort": row.default_effort,
-        "model_tiers": model_tiers,
+        "model_tiers": redacted_model_tiers,
         "default_model_tier": default_model_tier,
         "model_overrides": row.model_overrides or {},
         "credential_source": row.credential_source.value if row.credential_source else None,

--- a/api_service/services/provider_profile_service.py
+++ b/api_service/services/provider_profile_service.py
@@ -16,6 +16,7 @@ from api_service.db.models import (
 from api_service.services.provider_profile_readiness import (
     provider_profile_launch_ready,
 )
+from moonmind.provider_profiles.model_tiers import coerce_model_effort_tier_policy
 from moonmind.utils.logging import redact_profile_file_templates, redact_sensitive_payload
 
 logger = logging.getLogger(__name__)
@@ -100,6 +101,13 @@ def _manager_profile_payload(
     *,
     managed_secret_statuses: dict[str, str] | None = None,
 ) -> dict[str, Any]:
+    model_tiers, default_model_tier = coerce_model_effort_tier_policy(
+        model_tiers=row.model_tiers,
+        default_model_tier=row.default_model_tier,
+        legacy_default_model=row.default_model,
+        legacy_default_effort=row.default_effort,
+        empty_as_missing=True,
+    )
     return {
         "profile_id": row.profile_id,
         "is_default": row.is_default,
@@ -108,6 +116,8 @@ def _manager_profile_payload(
         "provider_label": row.provider_label,
         "default_model": row.default_model,
         "default_effort": row.default_effort,
+        "model_tiers": model_tiers,
+        "default_model_tier": default_model_tier,
         "model_overrides": row.model_overrides or {},
         "credential_source": row.credential_source.value if row.credential_source else None,
         "runtime_materialization_mode": row.runtime_materialization_mode.value if row.runtime_materialization_mode else None,

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -8169,6 +8169,26 @@ export interface components {
             /** Secret Ref */
             secret_ref: string;
         };
+        /**
+         * ProviderModelEffortTier
+         * @description Profile-local model/effort tier definition.
+         */
+        ProviderModelEffortTier: {
+            /** Label */
+            label?: string | null;
+            /** Model */
+            model?: string | null;
+            /** Effort */
+            effort?: string | null;
+            /** Parameters */
+            parameters?: {
+                [key: string]: unknown;
+            };
+            /** Annotations */
+            annotations?: {
+                [key: string]: unknown;
+            };
+        };
         /** ProviderProfileCreate */
         ProviderProfileCreate: {
             /** Profile Id */
@@ -8186,6 +8206,10 @@ export interface components {
             default_model?: string | null;
             /** Default Effort */
             default_effort?: string | null;
+            /** Model Tiers */
+            model_tiers?: components["schemas"]["ProviderModelEffortTier"][] | null;
+            /** Default Model Tier */
+            default_model_tier?: number | null;
             /** Model Overrides */
             model_overrides?: {
                 [key: string]: string;
@@ -8301,6 +8325,10 @@ export interface components {
             default_model?: string | null;
             /** Default Effort */
             default_effort?: string | null;
+            /** Model Tiers */
+            model_tiers: components["schemas"]["ProviderModelEffortTier"][];
+            /** Default Model Tier */
+            default_model_tier: number;
             /** Model Overrides */
             model_overrides?: {
                 [key: string]: string;
@@ -8407,6 +8435,10 @@ export interface components {
             default_model?: string | null;
             /** Default Effort */
             default_effort?: string | null;
+            /** Model Tiers */
+            model_tiers?: components["schemas"]["ProviderModelEffortTier"][] | null;
+            /** Default Model Tier */
+            default_model_tier?: number | null;
             /** Model Overrides */
             model_overrides?: {
                 [key: string]: string;

--- a/moonmind/provider_profiles/__init__.py
+++ b/moonmind/provider_profiles/__init__.py
@@ -1,0 +1,13 @@
+"""Provider Profile shared contracts."""
+
+from moonmind.provider_profiles.model_tiers import (
+    ProviderModelEffortTier,
+    coerce_model_effort_tier_policy,
+    runtime_default_model_effort_tier,
+)
+
+__all__ = [
+    "ProviderModelEffortTier",
+    "coerce_model_effort_tier_policy",
+    "runtime_default_model_effort_tier",
+]

--- a/moonmind/provider_profiles/model_tiers.py
+++ b/moonmind/provider_profiles/model_tiers.py
@@ -1,0 +1,113 @@
+"""Provider Profile model/effort tier contract helpers."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+_SENSITIVE_KEY_TERMS = (
+    "token",
+    "password",
+    "secret",
+    "api_key",
+    "apikey",
+    "credential",
+    "authorization",
+    "auth_header",
+    "private_key",
+    "refresh",
+    "oauth",
+    "cookie",
+    "session",
+)
+
+
+class ProviderModelEffortTier(BaseModel):
+    """Profile-local model/effort tier definition."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    label: str | None = None
+    model: str | None = None
+    effort: str | None = None
+    parameters: dict[str, Any] = Field(default_factory=dict)
+    annotations: dict[str, Any] = Field(default_factory=dict)
+
+    @field_validator("parameters", "annotations", mode="after")
+    @classmethod
+    def _reject_raw_credential_keys(
+        cls, value: dict[str, Any]
+    ) -> dict[str, Any]:
+        if _contains_sensitive_key(value):
+            raise ValueError("tier metadata must not contain raw credential-like keys")
+        return value
+
+
+def runtime_default_model_effort_tier() -> dict[str, Any]:
+    return {
+        "label": "Runtime default",
+        "model": None,
+        "effort": None,
+        "parameters": {},
+        "annotations": {},
+    }
+
+
+def coerce_model_effort_tier_policy(
+    *,
+    model_tiers: Any,
+    default_model_tier: int | None,
+    legacy_default_model: str | None,
+    legacy_default_effort: str | None,
+    empty_as_missing: bool = False,
+) -> tuple[list[dict[str, Any]], int]:
+    """Validate and normalize persisted Provider Profile tier policy.
+
+    Missing tier policy is migrated from legacy defaults when present, otherwise
+    it receives a runtime-default tier.
+    """
+
+    if model_tiers is None or (empty_as_missing and model_tiers == []):
+        if legacy_default_model is not None or legacy_default_effort is not None:
+            raw_tiers: Any = [
+                {
+                    "label": "Legacy default",
+                    "model": legacy_default_model,
+                    "effort": legacy_default_effort,
+                    "parameters": {},
+                    "annotations": {},
+                }
+            ]
+        else:
+            raw_tiers = [runtime_default_model_effort_tier()]
+    else:
+        raw_tiers = model_tiers
+
+    if not isinstance(raw_tiers, list):
+        raise ValueError("model_tiers must be a JSON array")
+    if not raw_tiers:
+        raise ValueError("model_tiers must contain at least one tier")
+
+    normalized = [
+        ProviderModelEffortTier.model_validate(item).model_dump(mode="json")
+        for item in raw_tiers
+    ]
+
+    normalized_default = 1 if default_model_tier is None else int(default_model_tier)
+    if normalized_default < 1 or normalized_default > len(normalized):
+        raise ValueError("default_model_tier must be within configured model_tiers")
+    return normalized, normalized_default
+
+
+def _contains_sensitive_key(value: Any) -> bool:
+    if isinstance(value, Mapping):
+        for key, nested in value.items():
+            normalized_key = str(key).strip().lower().replace("-", "_")
+            if any(term in normalized_key for term in _SENSITIVE_KEY_TERMS):
+                return True
+            if _contains_sensitive_key(nested):
+                return True
+    elif isinstance(value, list):
+        return any(_contains_sensitive_key(item) for item in value)
+    return False

--- a/moonmind/provider_profiles/model_tiers.py
+++ b/moonmind/provider_profiles/model_tiers.py
@@ -22,6 +22,18 @@ _SENSITIVE_KEY_TERMS = (
     "session",
 )
 
+_SAFE_KEY_EXCLUSIONS = frozenset(
+    {
+        "max_tokens",
+        "prompt_tokens",
+        "completion_tokens",
+        "tokens_per_minute",
+        "session_timeout",
+        "refresh_interval",
+        "auto_refresh",
+    }
+)
+
 
 class ProviderModelEffortTier(BaseModel):
     """Profile-local model/effort tier definition."""
@@ -54,6 +66,35 @@ def runtime_default_model_effort_tier() -> dict[str, Any]:
     }
 
 
+def legacy_default_model_effort_tier(
+    *,
+    legacy_default_model: str | None,
+    legacy_default_effort: str | None,
+) -> dict[str, Any]:
+    return {
+        "label": "Legacy default",
+        "model": legacy_default_model,
+        "effort": legacy_default_effort,
+        "parameters": {},
+        "annotations": {},
+    }
+
+
+def is_single_runtime_default_model_effort_tier(model_tiers: Any) -> bool:
+    if not isinstance(model_tiers, list) or len(model_tiers) != 1:
+        return False
+    tier = model_tiers[0]
+    if not isinstance(tier, Mapping):
+        return False
+    return (
+        tier.get("label") == "Runtime default"
+        and tier.get("model") is None
+        and tier.get("effort") is None
+        and (tier.get("parameters") or {}) == {}
+        and (tier.get("annotations") or {}) == {}
+    )
+
+
 def coerce_model_effort_tier_policy(
     *,
     model_tiers: Any,
@@ -68,16 +109,24 @@ def coerce_model_effort_tier_policy(
     it receives a runtime-default tier.
     """
 
-    if model_tiers is None or (empty_as_missing and model_tiers == []):
-        if legacy_default_model is not None or legacy_default_effort is not None:
+    has_legacy_default = (
+        legacy_default_model is not None or legacy_default_effort is not None
+    )
+    if (
+        model_tiers is None
+        or (empty_as_missing and model_tiers == [])
+        or (
+            empty_as_missing
+            and has_legacy_default
+            and is_single_runtime_default_model_effort_tier(model_tiers)
+        )
+    ):
+        if has_legacy_default:
             raw_tiers: Any = [
-                {
-                    "label": "Legacy default",
-                    "model": legacy_default_model,
-                    "effort": legacy_default_effort,
-                    "parameters": {},
-                    "annotations": {},
-                }
+                legacy_default_model_effort_tier(
+                    legacy_default_model=legacy_default_model,
+                    legacy_default_effort=legacy_default_effort,
+                )
             ]
         else:
             raw_tiers = [runtime_default_model_effort_tier()]
@@ -104,6 +153,10 @@ def _contains_sensitive_key(value: Any) -> bool:
     if isinstance(value, Mapping):
         for key, nested in value.items():
             normalized_key = str(key).strip().lower().replace("-", "_")
+            if normalized_key in _SAFE_KEY_EXCLUSIONS:
+                if _contains_sensitive_key(nested):
+                    return True
+                continue
             if any(term in normalized_key for term in _SENSITIVE_KEY_TERMS):
                 return True
             if _contains_sensitive_key(nested):

--- a/moonmind/schemas/agent_runtime_models.py
+++ b/moonmind/schemas/agent_runtime_models.py
@@ -21,6 +21,7 @@ from moonmind.schemas.managed_session_models import (
     CodexManagedSessionBinding,
     canonical_managed_session_runtime_id,
 )
+from moonmind.provider_profiles.model_tiers import ProviderModelEffortTier
 from moonmind.schemas.temporal_payload_policy import validate_compact_temporal_mapping
 from moonmind.schemas.workload_models import parse_cpu_units, parse_size_bytes
 
@@ -716,6 +717,11 @@ class ManagedAgentProviderProfile(BaseModel):
     provider_id: str | None = Field(None, alias="providerId")
     provider_label: str | None = Field(None, alias="providerLabel")
     default_model: str | None = Field(None, alias="defaultModel")
+    default_effort: str | None = Field(None, alias="defaultEffort")
+    model_tiers: list[ProviderModelEffortTier] = Field(
+        default_factory=list, alias="modelTiers"
+    )
+    default_model_tier: int = Field(1, alias="defaultModelTier", ge=1)
     model_overrides: dict[str, str] = Field(default_factory=dict, alias="modelOverrides")
 
     # -- Credential & materialization strategy (required) --
@@ -806,6 +812,18 @@ class ManagedAgentProviderProfile(BaseModel):
             )
         if _contains_sensitive_key(self.rate_limit_policy):
             raise ValueError("rateLimitPolicy must not contain raw credential keys")
+        if not self.model_tiers:
+            self.model_tiers = [
+                ProviderModelEffortTier(
+                    label="Runtime default",
+                    model=None,
+                    effort=None,
+                    parameters={},
+                    annotations={},
+                )
+            ]
+        if self.default_model_tier > len(self.model_tiers):
+            raise ValueError("defaultModelTier must be within configured modelTiers")
 
         if self.credential_source not in self._ALLOWED_CREDENTIAL_SOURCES:
             allowed = ", ".join(sorted(self._ALLOWED_CREDENTIAL_SOURCES))

--- a/moonmind/workflows/temporal/artifacts.py
+++ b/moonmind/workflows/temporal/artifacts.py
@@ -2936,6 +2936,9 @@ class TemporalArtifactActivities:
         from api_service.services.provider_profile_service import (
             _managed_secret_statuses_for_profiles,
         )
+        from moonmind.provider_profiles.model_tiers import (
+            coerce_model_effort_tier_policy,
+        )
 
         async with get_async_session_context() as session:
             stmt = select(ManagedAgentProviderProfile).where(
@@ -2971,6 +2974,13 @@ class TemporalArtifactActivities:
                 if isinstance(command_behavior, dict)
                 else None
             )
+            model_tiers, default_model_tier = coerce_model_effort_tier_policy(
+                model_tiers=row.model_tiers,
+                default_model_tier=row.default_model_tier,
+                legacy_default_model=row.default_model,
+                legacy_default_effort=row.default_effort,
+                empty_as_missing=True,
+            )
             profiles.append(
                 {
                     "profile_id": row.profile_id,
@@ -2994,6 +3004,8 @@ class TemporalArtifactActivities:
                     "billing": billing_metadata or pricing_metadata or {},
                     "default_model": row.default_model,
                     "default_effort": row.default_effort,
+                    "model_tiers": model_tiers,
+                    "default_model_tier": default_model_tier,
                     "model_overrides": row.model_overrides or {},
                     "max_parallel_runs": row.max_parallel_runs,
                     "cooldown_after_429_seconds": row.cooldown_after_429_seconds,

--- a/tests/unit/api_service/api/routers/test_provider_profiles.py
+++ b/tests/unit/api_service/api/routers/test_provider_profiles.py
@@ -530,6 +530,16 @@ def test_provider_profile_manager_payload_redacts_secret_like_runtime_fields() -
     assert payload["file_templates"][2]["content_template"]["api_key"] == "[REDACTED]"
     assert payload["command_behavior"]["authorization"] == "[REDACTED_AUTHORIZATION]"
     assert payload["secret_refs"] == {"provider_api_key": "env://OPENAI_API_KEY"}
+    assert payload["model_tiers"] == [
+        {
+            "label": "Runtime default",
+            "model": None,
+            "effort": None,
+            "parameters": {},
+            "annotations": {},
+        }
+    ]
+    assert payload["default_model_tier"] == 1
 
 @pytest.mark.asyncio
 async def test_create_codex_oauth_profile_requires_volume_ref_and_mount_path(
@@ -661,6 +671,16 @@ async def test_create_provider_profile(client_app: AsyncClient, _module_db):
     assert data["rate_limit_policy"] == "queue"
     assert data["default_model"] == "test-model-v2"
     assert data["default_effort"] == "high"
+    assert data["model_tiers"] == [
+        {
+            "label": "Legacy default",
+            "model": "test-model-v2",
+            "effort": "high",
+            "parameters": {},
+            "annotations": {},
+        }
+    ]
+    assert data["default_model_tier"] == 1
     assert data["model_overrides"] == {"smart": "test-model-v3"}
     assert data["is_default"] is True
     assert data["auth_state"] == "connected"
@@ -685,6 +705,144 @@ async def test_create_provider_profile_rejects_overlong_default_effort(
         response = await client.post("/api/v1/provider-profiles", json=payload)
 
     assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_mm1169_create_provider_profile_persists_explicit_model_tiers(
+    client_app: AsyncClient, _module_db
+) -> None:
+    payload = {
+        "profile_id": "explicit_model_tier_profile",
+        "runtime_id": "codex_cli",
+        "provider_id": "openai",
+        "credential_source": "none",
+        "runtime_materialization_mode": "composite",
+        "model_tiers": [
+            {
+                "label": "Plan",
+                "model": "provider-model-one",
+                "effort": "medium",
+                "parameters": {"temperature": 0},
+                "annotations": {"costClass": "standard"},
+            },
+            {
+                "label": "Implement",
+                "model": "provider-model-two",
+                "effort": "xhigh",
+                "parameters": {},
+                "annotations": {"recommendedFor": ["implementation"]},
+            },
+        ],
+        "default_model_tier": 2,
+    }
+
+    async with client_app as client:
+        response = await client.post("/api/v1/provider-profiles", json=payload)
+
+    assert response.status_code == 201
+    data = response.json()
+    assert data["model_tiers"] == payload["model_tiers"]
+    assert data["default_model_tier"] == 2
+
+    async with db_base.async_session_maker() as session:
+        row = await session.get(
+            ManagedAgentProviderProfile,
+            "explicit_model_tier_profile",
+        )
+        assert row is not None
+        assert row.model_tiers == payload["model_tiers"]
+        assert row.default_model_tier == 2
+
+
+@pytest.mark.asyncio
+async def test_mm1169_create_profile_rejects_empty_and_secret_like_tiers(
+    client_app: AsyncClient, _module_db
+) -> None:
+    base_payload = {
+        "profile_id": "invalid_model_tier_profile",
+        "runtime_id": "codex_cli",
+        "provider_id": "openai",
+        "credential_source": "none",
+        "runtime_materialization_mode": "composite",
+    }
+
+    async with client_app as client:
+        empty_response = await client.post(
+            "/api/v1/provider-profiles",
+            json={**base_payload, "model_tiers": []},
+        )
+        secret_response = await client.post(
+            "/api/v1/provider-profiles",
+            json={
+                **base_payload,
+                "profile_id": "secret_model_tier_profile",
+                "model_tiers": [
+                    {
+                        "label": "Unsafe",
+                        "model": "opaque-model",
+                        "effort": "opaque-effort",
+                        "parameters": {"api_key": "raw"},
+                        "annotations": {},
+                    }
+                ],
+            },
+        )
+
+    assert empty_response.status_code == 422
+    assert "model_tiers" in empty_response.text
+    assert secret_response.status_code == 422
+    assert "credential-like" in secret_response.text
+
+
+@pytest.mark.asyncio
+async def test_mm1169_reordering_model_tiers_persists_policy_order(
+    client_app: AsyncClient, _module_db
+) -> None:
+    profile_id = "reordered_model_tier_profile"
+    payload = {
+        "profile_id": profile_id,
+        "runtime_id": "codex_cli",
+        "provider_id": "openai",
+        "credential_source": "none",
+        "runtime_materialization_mode": "composite",
+        "model_tiers": [
+            {"label": "Tier A", "model": "model-a", "effort": "low"},
+            {"label": "Tier B", "model": "model-b", "effort": "high"},
+        ],
+        "default_model_tier": 1,
+    }
+    reordered = [
+        {"label": "Tier B", "model": "model-b", "effort": "high"},
+        {"label": "Tier A", "model": "model-a", "effort": "low"},
+    ]
+
+    async with client_app as client:
+        create_response = await client.post("/api/v1/provider-profiles", json=payload)
+        update_response = await client.patch(
+            f"/api/v1/provider-profiles/{profile_id}",
+            json={"model_tiers": reordered, "default_model_tier": 2},
+        )
+
+    assert create_response.status_code == 201
+    assert update_response.status_code == 200
+    data = update_response.json()
+    assert data["model_tiers"] == [
+        {
+            "label": "Tier B",
+            "model": "model-b",
+            "effort": "high",
+            "parameters": {},
+            "annotations": {},
+        },
+        {
+            "label": "Tier A",
+            "model": "model-a",
+            "effort": "low",
+            "parameters": {},
+            "annotations": {},
+        },
+    ]
+    assert data["default_model_tier"] == 2
 
 
 @pytest.mark.asyncio

--- a/tests/unit/api_service/api/routers/test_provider_profiles.py
+++ b/tests/unit/api_service/api/routers/test_provider_profiles.py
@@ -541,6 +541,38 @@ def test_provider_profile_manager_payload_redacts_secret_like_runtime_fields() -
     ]
     assert payload["default_model_tier"] == 1
 
+
+def test_manager_profile_payload_redacts_model_tier_metadata() -> None:
+    raw_secret = "Bearer sk-manager-tier-secret"
+    row = ManagedAgentProviderProfile(
+        profile_id="redacted_tier_metadata",
+        runtime_id="codex_cli",
+        provider_id="openai",
+        model_tiers=[
+            {
+                "label": "Tier 1",
+                "model": "gpt-test",
+                "effort": "medium",
+                "parameters": {"max_tokens": 4096},
+                "annotations": {"note": raw_secret},
+            }
+        ],
+        default_model_tier=1,
+    )
+
+    payload = _manager_profile_payload(row)
+
+    assert raw_secret not in repr(payload)
+    assert payload["model_tiers"] == [
+        {
+            "label": "Tier 1",
+            "model": "gpt-test",
+            "effort": "medium",
+            "parameters": {"max_tokens": 4096},
+            "annotations": {"note": "[REDACTED_AUTHORIZATION]"},
+        }
+    ]
+
 @pytest.mark.asyncio
 async def test_create_codex_oauth_profile_requires_volume_ref_and_mount_path(
     client_app: AsyncClient, _module_db
@@ -795,6 +827,41 @@ async def test_mm1169_create_profile_rejects_empty_and_secret_like_tiers(
 
 
 @pytest.mark.asyncio
+async def test_mm1169_create_profile_accepts_safe_token_parameter_names(
+    client_app: AsyncClient, _module_db
+) -> None:
+    payload = {
+        "profile_id": "safe_token_parameter_profile",
+        "runtime_id": "codex_cli",
+        "provider_id": "openai",
+        "credential_source": "none",
+        "runtime_materialization_mode": "composite",
+        "model_tiers": [
+            {
+                "label": "Safe metadata",
+                "model": "provider-model",
+                "effort": "medium",
+                "parameters": {
+                    "max_tokens": 4096,
+                    "prompt_tokens": 128,
+                    "completion_tokens": 512,
+                    "tokens_per_minute": 10000,
+                    "refresh_interval": 60,
+                    "auto_refresh": False,
+                },
+                "annotations": {"session_timeout": 300},
+            }
+        ],
+    }
+
+    async with client_app as client:
+        response = await client.post("/api/v1/provider-profiles", json=payload)
+
+    assert response.status_code == 201
+    assert response.json()["model_tiers"][0]["parameters"]["max_tokens"] == 4096
+
+
+@pytest.mark.asyncio
 async def test_mm1169_reordering_model_tiers_persists_policy_order(
     client_app: AsyncClient, _module_db
 ) -> None:
@@ -843,6 +910,114 @@ async def test_mm1169_reordering_model_tiers_persists_policy_order(
         },
     ]
     assert data["default_model_tier"] == 2
+
+
+@pytest.mark.asyncio
+async def test_mm1169_update_legacy_default_refreshes_single_default_tier(
+    client_app: AsyncClient, _module_db
+) -> None:
+    profile_id = "legacy_patch_refreshes_tier"
+    payload = {
+        "profile_id": profile_id,
+        "runtime_id": "codex_cli",
+        "provider_id": "openai",
+        "credential_source": "none",
+        "runtime_materialization_mode": "composite",
+        "default_model": "old-model",
+        "default_effort": "low",
+    }
+
+    async with client_app as client:
+        create_response = await client.post("/api/v1/provider-profiles", json=payload)
+        update_response = await client.patch(
+            f"/api/v1/provider-profiles/{profile_id}",
+            json={"default_model": "new-model", "default_effort": "high"},
+        )
+
+    assert create_response.status_code == 201
+    assert update_response.status_code == 200
+    data = update_response.json()
+    assert data["default_model"] == "new-model"
+    assert data["default_effort"] == "high"
+    assert data["model_tiers"] == [
+        {
+            "label": "Legacy default",
+            "model": "new-model",
+            "effort": "high",
+            "parameters": {},
+            "annotations": {},
+        }
+    ]
+    assert data["default_model_tier"] == 1
+
+
+@pytest.mark.asyncio
+async def test_mm1169_update_legacy_default_preserves_explicit_tiers(
+    client_app: AsyncClient, _module_db
+) -> None:
+    profile_id = "legacy_patch_preserves_explicit_tiers"
+    payload = {
+        "profile_id": profile_id,
+        "runtime_id": "codex_cli",
+        "provider_id": "openai",
+        "credential_source": "none",
+        "runtime_materialization_mode": "composite",
+        "default_model": "old-model",
+        "model_tiers": [
+            {"label": "Tier A", "model": "tier-model", "effort": "medium"}
+        ],
+    }
+
+    async with client_app as client:
+        create_response = await client.post("/api/v1/provider-profiles", json=payload)
+        update_response = await client.patch(
+            f"/api/v1/provider-profiles/{profile_id}",
+            json={"default_model": "new-model"},
+        )
+
+    assert create_response.status_code == 201
+    assert update_response.status_code == 200
+    assert update_response.json()["model_tiers"] == [
+        {
+            "label": "Tier A",
+            "model": "tier-model",
+            "effort": "medium",
+            "parameters": {},
+            "annotations": {},
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_mm1169_orm_insert_uses_legacy_defaults_for_model_tiers(
+    _module_db,
+) -> None:
+    profile_id = "orm_insert_legacy_default_tier"
+    async with db_base.async_session_maker() as session:
+        session.add(
+            ManagedAgentProviderProfile(
+                profile_id=profile_id,
+                runtime_id="codex_cli",
+                provider_id="openai",
+                default_model="seeded-model",
+                default_effort="medium",
+            )
+        )
+        await session.commit()
+
+    async with db_base.async_session_maker() as session:
+        row = await session.get(ManagedAgentProviderProfile, profile_id)
+
+    assert row is not None
+    assert row.model_tiers == [
+        {
+            "label": "Legacy default",
+            "model": "seeded-model",
+            "effort": "medium",
+            "parameters": {},
+            "annotations": {},
+        }
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/provider_profiles/test_model_tiers.py
+++ b/tests/unit/provider_profiles/test_model_tiers.py
@@ -1,0 +1,81 @@
+import pytest
+from pydantic import ValidationError
+
+from moonmind.provider_profiles.model_tiers import (
+    ProviderModelEffortTier,
+    coerce_model_effort_tier_policy,
+)
+
+
+def test_mm1169_legacy_defaults_migrate_to_one_model_tier() -> None:
+    model_tiers, default_model_tier = coerce_model_effort_tier_policy(
+        model_tiers=None,
+        default_model_tier=None,
+        legacy_default_model="gpt-custom",
+        legacy_default_effort="xhigh",
+    )
+
+    assert default_model_tier == 1
+    assert model_tiers == [
+        {
+            "label": "Legacy default",
+            "model": "gpt-custom",
+            "effort": "xhigh",
+            "parameters": {},
+            "annotations": {},
+        }
+    ]
+
+
+def test_mm1169_missing_legacy_defaults_get_runtime_default_tier() -> None:
+    model_tiers, default_model_tier = coerce_model_effort_tier_policy(
+        model_tiers=None,
+        default_model_tier=None,
+        legacy_default_model=None,
+        legacy_default_effort=None,
+    )
+
+    assert default_model_tier == 1
+    assert model_tiers == [
+        {
+            "label": "Runtime default",
+            "model": None,
+            "effort": None,
+            "parameters": {},
+            "annotations": {},
+        }
+    ]
+
+
+def test_mm1169_default_model_tier_must_be_in_configured_range() -> None:
+    with pytest.raises(ValueError, match="default_model_tier"):
+        coerce_model_effort_tier_policy(
+            model_tiers=[{"label": "Only", "model": "opaque", "effort": "opaque"}],
+            default_model_tier=2,
+            legacy_default_model=None,
+            legacy_default_effort=None,
+        )
+
+
+def test_mm1169_tier_metadata_rejects_raw_credential_like_keys() -> None:
+    with pytest.raises(ValidationError, match="credential-like"):
+        ProviderModelEffortTier.model_validate(
+            {
+                "label": "Unsafe",
+                "model": "opaque",
+                "effort": "opaque",
+                "parameters": {"api_key": "sk-secret"},
+                "annotations": {},
+            }
+        )
+
+    with pytest.raises(ValidationError, match="credential-like"):
+        ProviderModelEffortTier.model_validate(
+            {
+                "label": "Unsafe annotation",
+                "model": "opaque",
+                "effort": "opaque",
+                "parameters": {},
+                "annotations": {"billing": {"token": "secret"}},
+            }
+        )


### PR DESCRIPTION
## Issue

MM-1169: Add Provider Profile model tier contract and migration

## Summary

- Adds ordered provider profile `model_tiers` with typed label, model, effort, parameters, and annotations fields plus `default_model_tier` validation.
- Adds migration/backfill so legacy `default_model` and `default_effort` become a preserved Legacy default tier, while profiles without legacy defaults receive a Runtime default tier with null model and effort.
- Preserves legacy read/migration compatibility fields while exposing tier-aware policy through API, runtime schemas, service payloads, and artifact snapshots.
- Rejects credential-like keys in tier parameters and annotations, and preserves submitted tier order as policy.

## Tests Run

- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/provider_profiles/test_model_tiers.py tests/unit/api_service/api/routers/test_provider_profiles.py` (pass)
- `python -m py_compile moonmind/provider_profiles/model_tiers.py api_service/api/routers/provider_profiles.py api_service/db/models.py api_service/migrations/versions/335_mm1169_provider_profile_model_tiers.py moonmind/schemas/agent_runtime_models.py api_service/services/provider_profile_service.py moonmind/workflows/temporal/artifacts.py` (pass)
- Alembic migration backfill smoke test against temporary SQLite table (pass)
- `./tools/test_integration.sh` (not completed: Docker build environment lacks BuildKit/buildx support required by `RUN --mount`)

## Remaining Risks

- Hermetic integration tests could not run in this environment because the Docker build failed before tests due unavailable BuildKit/buildx support. Focused unit, compile, and migration smoke coverage passed.
