### PR TITLE
Fix managed session artifact ownership

### DIFF
--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -943,6 +943,13 @@ _SESSION_CONTROLLER_HEARTBEAT_INTERVAL_SECONDS = 10.0
 class ManagedSessionController(Protocol):
     """Remote control surface for managed session containers."""
 
+    async def ensure_repo_artifacts_writable_by_runtime_user(
+        self,
+        workspace_path: str,
+        /,
+    ) -> None:
+        pass
+
     async def launch_session(
         self, request: LaunchCodexManagedSessionRequest, /
     ) -> CodexManagedSessionHandle | Mapping[str, Any]:
@@ -8399,6 +8406,10 @@ class TemporalAgentRuntimeActivities:
                 request=request,
                 workspace_path=Path(workspace_path_raw),
             )
+            if self._session_controller is not None:
+                await self._session_controller.ensure_repo_artifacts_writable_by_runtime_user(
+                    workspace_path_raw
+                )
             instruction_ref = str(request.instruction_ref or "").strip()
             if instruction_ref:
                 prepared = self._prepare_managed_codex_turn_text(

--- a/moonmind/workflows/temporal/runtime/managed_session_controller.py
+++ b/moonmind/workflows/temporal/runtime/managed_session_controller.py
@@ -12,6 +12,7 @@ import posixpath
 import re
 import shlex
 import shutil
+import stat
 import time
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -2054,6 +2055,34 @@ class DockerCodexManagedSessionController:
             request=request,
             git_env=git_env,
         )
+
+    async def ensure_repo_artifacts_writable_by_runtime_user(
+        self,
+        workspace_path: str,
+    ) -> None:
+        """Normalize repo-local artifacts created after session launch."""
+
+        resolved_workspace = Path(workspace_path).expanduser().resolve()
+        if not self._is_within_workspace_root(resolved_workspace):
+            raise RuntimeError(
+                "managed session workspace path must be within the configured "
+                f"workspace root: {resolved_workspace}"
+            )
+
+        artifacts_path = resolved_workspace / "artifacts"
+        try:
+            artifacts_stat = artifacts_path.lstat()
+        except FileNotFoundError:
+            return
+        if stat.S_ISLNK(artifacts_stat.st_mode):
+            raise RuntimeError(
+                f"repo-local artifacts path must not be a symlink: {artifacts_path}"
+            )
+        if not stat.S_ISDIR(artifacts_stat.st_mode):
+            raise RuntimeError(
+                f"repo-local artifacts path must be a directory: {artifacts_path}"
+            )
+        self._normalize_container_path_ownership((artifacts_path,))
 
     def _collect_managed_support_paths(
         self,

--- a/moonmind/workflows/temporal/runtime/managed_session_controller.py
+++ b/moonmind/workflows/temporal/runtime/managed_session_controller.py
@@ -2059,6 +2059,7 @@ class DockerCodexManagedSessionController:
     async def ensure_repo_artifacts_writable_by_runtime_user(
         self,
         workspace_path: str,
+        /,
     ) -> None:
         """Normalize repo-local artifacts created after session launch."""
 
@@ -2082,7 +2083,7 @@ class DockerCodexManagedSessionController:
             raise RuntimeError(
                 f"repo-local artifacts path must be a directory: {artifacts_path}"
             )
-        self._normalize_container_path_ownership((artifacts_path,))
+        self._normalize_container_directory_ownership_no_follow(artifacts_path)
 
     def _collect_managed_support_paths(
         self,
@@ -2234,6 +2235,54 @@ class DockerCodexManagedSessionController:
                     DockerCodexManagedSessionController._chown_path(root_path / dirname)
                 for filename in filenames:
                     DockerCodexManagedSessionController._chown_path(root_path / filename)
+
+    @staticmethod
+    def _normalize_container_directory_ownership_no_follow(path: Path) -> None:
+        if (
+            not DockerCodexManagedSessionController
+            ._can_normalize_container_path_ownership()
+        ):
+            return
+        directory_flag = getattr(os, "O_DIRECTORY", None)
+        no_follow_flag = getattr(os, "O_NOFOLLOW", None)
+        if directory_flag is None or no_follow_flag is None:
+            raise RuntimeError(
+                "managed session artifact ownership repair requires "
+                "O_DIRECTORY and O_NOFOLLOW support"
+            )
+        try:
+            root_fd = os.open(path, os.O_RDONLY | directory_flag | no_follow_flag)
+        except OSError as exc:
+            raise RuntimeError(
+                "repo-local artifacts path could not be opened without following "
+                f"symlinks: {path}"
+            ) from exc
+        try:
+            if not stat.S_ISDIR(os.fstat(root_fd).st_mode):
+                raise RuntimeError(
+                    f"repo-local artifacts path must be a directory: {path}"
+                )
+            os.fchown(
+                root_fd,
+                _MANAGED_SESSION_CONTAINER_UID,
+                _MANAGED_SESSION_CONTAINER_GID,
+            )
+            for _root, dirnames, filenames, directory_fd in os.fwalk(
+                ".",
+                topdown=True,
+                follow_symlinks=False,
+                dir_fd=root_fd,
+            ):
+                for name in (*dirnames, *filenames):
+                    os.chown(
+                        name,
+                        _MANAGED_SESSION_CONTAINER_UID,
+                        _MANAGED_SESSION_CONTAINER_GID,
+                        dir_fd=directory_fd,
+                        follow_symlinks=False,
+                    )
+        finally:
+            os.close(root_fd)
 
     @staticmethod
     def _deduplicate_ownership_roots(paths: Sequence[Path]) -> list[Path]:

--- a/tests/unit/services/temporal/runtime/test_managed_session_controller.py
+++ b/tests/unit/services/temporal/runtime/test_managed_session_controller.py
@@ -2798,6 +2798,102 @@ async def test_controller_launch_normalizes_support_paths_before_git_failures(
     assert session_path in chown_calls
     assert artifacts_path in chown_calls
 
+
+@pytest.mark.asyncio
+async def test_controller_normalizes_repo_artifacts_created_after_session_launch(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    workspace_root = tmp_path / "agent_jobs"
+    workspace_path = workspace_root / "mm:task-1" / "repo"
+    context_path = workspace_path / "artifacts" / "context"
+    context_path.mkdir(parents=True)
+    context_file = context_path / "rag-context.json"
+    context_file.write_text("{}\n", encoding="utf-8")
+    chown_calls: list[tuple[Path, int, int, bool]] = []
+
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.runtime.managed_session_controller.os.geteuid",
+        lambda: 0,
+    )
+
+    def _fake_chown(
+        path: str | Path,
+        uid: int,
+        gid: int,
+        *,
+        follow_symlinks: bool = True,
+    ) -> None:
+        chown_calls.append((Path(path), uid, gid, follow_symlinks))
+
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.runtime.managed_session_controller.os.chown",
+        _fake_chown,
+    )
+    controller = DockerCodexManagedSessionController(
+        workspace_volume_name="agent_workspaces",
+        codex_volume_name="codex_auth_volume",
+        workspace_root=str(workspace_root),
+    )
+
+    await controller.ensure_repo_artifacts_writable_by_runtime_user(
+        str(workspace_path)
+    )
+
+    chowned_paths = {path for path, _uid, _gid, _follow in chown_calls}
+    assert chowned_paths == {
+        workspace_path / "artifacts",
+        context_path,
+        context_file,
+    }
+    assert all(uid == 1000 and gid == 1000 for _path, uid, gid, _follow in chown_calls)
+    assert all(follow is False for _path, _uid, _gid, follow in chown_calls)
+
+
+@pytest.mark.asyncio
+async def test_controller_rejects_repo_artifacts_outside_workspace_root(
+    tmp_path: Path,
+) -> None:
+    workspace_root = tmp_path / "agent_jobs"
+    outside_workspace = tmp_path / "outside" / "repo"
+    (outside_workspace / "artifacts").mkdir(parents=True)
+    controller = DockerCodexManagedSessionController(
+        workspace_volume_name="agent_workspaces",
+        codex_volume_name="codex_auth_volume",
+        workspace_root=str(workspace_root),
+    )
+
+    with pytest.raises(RuntimeError, match="within the configured workspace root"):
+        await controller.ensure_repo_artifacts_writable_by_runtime_user(
+            str(outside_workspace)
+        )
+
+
+@pytest.mark.asyncio
+async def test_controller_rejects_repo_artifacts_symlink(
+    tmp_path: Path,
+) -> None:
+    workspace_root = tmp_path / "agent_jobs"
+    workspace_path = workspace_root / "mm:task-1" / "repo"
+    workspace_path.mkdir(parents=True)
+    outside_artifacts = tmp_path / "outside-artifacts"
+    outside_artifacts.mkdir()
+    (workspace_path / "artifacts").symlink_to(
+        outside_artifacts,
+        target_is_directory=True,
+    )
+    controller = DockerCodexManagedSessionController(
+        workspace_volume_name="agent_workspaces",
+        codex_volume_name="codex_auth_volume",
+        workspace_root=str(workspace_root),
+    )
+
+    with pytest.raises(RuntimeError, match="must not be a symlink"):
+        await controller.ensure_repo_artifacts_writable_by_runtime_user(
+            str(workspace_path)
+        )
+
+
 @pytest.mark.asyncio
 async def test_controller_launch_reclones_invalid_workspace_before_target_checkout(
     tmp_path: Path,

--- a/tests/unit/services/temporal/runtime/test_managed_session_controller.py
+++ b/tests/unit/services/temporal/runtime/test_managed_session_controller.py
@@ -2810,7 +2810,15 @@ async def test_controller_normalizes_repo_artifacts_created_after_session_launch
     context_path.mkdir(parents=True)
     context_file = context_path / "rag-context.json"
     context_file.write_text("{}\n", encoding="utf-8")
-    chown_calls: list[tuple[Path, int, int, bool]] = []
+    outside_path = tmp_path / "outside"
+    outside_path.mkdir()
+    (outside_path / "sensitive.txt").write_text("unchanged\n", encoding="utf-8")
+    (workspace_path / "artifacts" / "outside-link").symlink_to(
+        outside_path,
+        target_is_directory=True,
+    )
+    fchown_calls: list[tuple[int, int, int]] = []
+    chown_calls: list[tuple[str, int, int, int | None, bool]] = []
 
     monkeypatch.setattr(
         "moonmind.workflows.temporal.runtime.managed_session_controller.os.geteuid",
@@ -2822,13 +2830,21 @@ async def test_controller_normalizes_repo_artifacts_created_after_session_launch
         uid: int,
         gid: int,
         *,
+        dir_fd: int | None = None,
         follow_symlinks: bool = True,
     ) -> None:
-        chown_calls.append((Path(path), uid, gid, follow_symlinks))
+        chown_calls.append((str(path), uid, gid, dir_fd, follow_symlinks))
+
+    def _fake_fchown(fd: int, uid: int, gid: int) -> None:
+        fchown_calls.append((fd, uid, gid))
 
     monkeypatch.setattr(
         "moonmind.workflows.temporal.runtime.managed_session_controller.os.chown",
         _fake_chown,
+    )
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.runtime.managed_session_controller.os.fchown",
+        _fake_fchown,
     )
     controller = DockerCodexManagedSessionController(
         workspace_volume_name="agent_workspaces",
@@ -2840,14 +2856,21 @@ async def test_controller_normalizes_repo_artifacts_created_after_session_launch
         str(workspace_path)
     )
 
-    chowned_paths = {path for path, _uid, _gid, _follow in chown_calls}
-    assert chowned_paths == {
-        workspace_path / "artifacts",
-        context_path,
-        context_file,
+    assert len(fchown_calls) == 1
+    assert fchown_calls[0][1:] == (1000, 1000)
+    assert {name for name, _uid, _gid, _dir_fd, _follow in chown_calls} == {
+        "context",
+        "outside-link",
+        "rag-context.json",
     }
-    assert all(uid == 1000 and gid == 1000 for _path, uid, gid, _follow in chown_calls)
-    assert all(follow is False for _path, _uid, _gid, follow in chown_calls)
+    assert all(
+        uid == 1000 and gid == 1000
+        for _name, uid, gid, _dir_fd, _follow in chown_calls
+    )
+    assert all(
+        isinstance(dir_fd, int) and follow is False
+        for _name, _uid, _gid, dir_fd, follow in chown_calls
+    )
 
 
 @pytest.mark.asyncio
@@ -2889,6 +2912,48 @@ async def test_controller_rejects_repo_artifacts_symlink(
     )
 
     with pytest.raises(RuntimeError, match="must not be a symlink"):
+        await controller.ensure_repo_artifacts_writable_by_runtime_user(
+            str(workspace_path)
+        )
+
+
+@pytest.mark.asyncio
+async def test_controller_rejects_repo_artifacts_symlink_swap_before_open(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    workspace_root = tmp_path / "agent_jobs"
+    workspace_path = workspace_root / "mm:task-1" / "repo"
+    artifacts_path = workspace_path / "artifacts"
+    artifacts_path.mkdir(parents=True)
+    outside_artifacts = tmp_path / "outside-artifacts"
+    outside_artifacts.mkdir()
+    real_open = os.open
+
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.runtime.managed_session_controller.os.geteuid",
+        lambda: 0,
+    )
+
+    def _swap_then_open(path: str | Path, flags: int) -> int:
+        artifacts_path.rmdir()
+        artifacts_path.symlink_to(outside_artifacts, target_is_directory=True)
+        return real_open(path, flags)
+
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.runtime.managed_session_controller.os.open",
+        _swap_then_open,
+    )
+    controller = DockerCodexManagedSessionController(
+        workspace_volume_name="agent_workspaces",
+        codex_volume_name="codex_auth_volume",
+        workspace_root=str(workspace_root),
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match="could not be opened without following symlinks",
+    ):
         await controller.ensure_repo_artifacts_writable_by_runtime_user(
             str(workspace_path)
         )

--- a/tests/unit/workflows/temporal/test_agent_runtime_activities.py
+++ b/tests/unit/workflows/temporal/test_agent_runtime_activities.py
@@ -3905,7 +3905,20 @@ async def test_agent_runtime_prepare_turn_instructions_injects_context(
         "moonmind.rag.context_injection.ContextInjectionService",
         _FakeContextInjectionService,
     )
-    activities = TemporalAgentRuntimeActivities()
+    class _FakeSessionController:
+        def __init__(self) -> None:
+            self.repaired_workspace_paths: list[str] = []
+
+        async def ensure_repo_artifacts_writable_by_runtime_user(
+            self,
+            workspace_path: str,
+        ) -> None:
+            self.repaired_workspace_paths.append(workspace_path)
+
+    session_controller = _FakeSessionController()
+    activities = TemporalAgentRuntimeActivities(
+        session_controller=session_controller,
+    )
 
     result = await activities.agent_runtime_prepare_turn_instructions(
         {
@@ -3923,6 +3936,7 @@ async def test_agent_runtime_prepare_turn_instructions_injects_context(
 
     assert result.startswith("Injected context instruction")
     assert "Managed Codex CLI note:" in result
+    assert session_controller.repaired_workspace_paths == [str(tmp_path)]
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- normalize repo-local artifact ownership after deferred context injection
- keep ownership repair constrained to the managed workspace and reject symlink targets
- cover the activity and managed-session controller boundaries with regression tests

## Root cause

Deferred RAG context injection runs after managed-session launch and creates `repo/artifacts` as the root-running activity worker. The managed agent runs as UID 1000 and could not write required structured handoff artifacts, causing later workflow gates to report a missing assessment verdict.

## Validation

- `MOONMIND_FORCE_LOCAL_TESTS=1 .venv/bin/pytest -q --tb=short tests/unit/services/temporal/runtime/test_managed_session_controller.py tests/unit/workflows/temporal/test_agent_runtime_activities.py` (232 passed)
- `.venv/bin/python -m compileall -q moonmind/workflows/temporal/activity_runtime.py moonmind/workflows/temporal/runtime/managed_session_controller.py`
- `git diff --check`