### PR TITLE
MM-1171 Add validated model tier runtime intent

### DIFF
--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -9919,15 +9919,15 @@ async def _create_execution_from_workflow_request(
         or ""
     )
     raw_profile_id = str(
-        runtime_payload.get("profileId")
+        runtime_payload.get("providerProfileRef")
+        or runtime_payload.get("profileId")
         or runtime_payload.get("providerProfile")
-        or runtime_payload.get("providerProfileRef")
+        or task_payload.get("providerProfileRef")
         or task_payload.get("profileId")
         or task_payload.get("providerProfile")
-        or task_payload.get("providerProfileRef")
+        or payload.get("providerProfileRef")
         or payload.get("profileId")
         or payload.get("providerProfile")
-        or payload.get("providerProfileRef")
         or ""
     ).strip() or None
     # Preserve the original requested model byte-for-byte (Compatibility Policy:
@@ -9952,6 +9952,10 @@ async def _create_execution_from_workflow_request(
             normalized_task_for_planner.get("runtime") or {}
         )
         normalized_runtime_for_planner["mode"] = canonical_target_runtime
+        if isinstance(runtime_payload.get("profileSelector"), Mapping):
+            normalized_runtime_for_planner["profileSelector"] = dict(
+                runtime_payload["profileSelector"]
+            )
         normalized_task_for_planner["runtime"] = normalized_runtime_for_planner
 
     # Load provider profile when a profileId is supplied. For tier-aware
@@ -10026,6 +10030,9 @@ async def _create_execution_from_workflow_request(
         initial_parameters["tierFallback"] = runtime_payload.get("tierFallback")
     if isinstance(runtime_payload.get("profileSelector"), Mapping):
         initial_parameters["profileSelector"] = dict(
+            runtime_payload["profileSelector"]
+        )
+        initial_parameters.setdefault("runtime", {})["profileSelector"] = dict(
             runtime_payload["profileSelector"]
         )
     if model_tier_resolution is not None:
@@ -10316,6 +10323,17 @@ async def _resolve_recurring_runtime_metadata(
         raw_runtime_payload,
         field_name="payload.workflow.runtime",
     )
+    steps_payload = task_payload.get("steps")
+    if isinstance(steps_payload, Sequence) and not isinstance(steps_payload, (str, bytes)):
+        for index, step_payload in enumerate(steps_payload):
+            if not isinstance(step_payload, Mapping):
+                continue
+            step_runtime = step_payload.get("runtime")
+            if isinstance(step_runtime, Mapping):
+                _validate_runtime_tier_intent_for_submit(
+                    step_runtime,
+                    field_name=f"payload.workflow.steps[{index}].runtime",
+                )
     raw_target_runtime = (
         request_payload.get("targetRuntime")
         or parameter_payload.get("targetRuntime")
@@ -10335,19 +10353,19 @@ async def _resolve_recurring_runtime_metadata(
 
     raw_profile_id = None
     for candidate_profile_id in (
+        runtime_payload.get("providerProfileRef"),
         runtime_payload.get("profileId"),
         runtime_payload.get("providerProfile"),
-        runtime_payload.get("providerProfileRef"),
         runtime_payload.get("executionProfileRef"),
+        task_payload.get("providerProfileRef"),
         task_payload.get("profileId"),
         task_payload.get("providerProfile"),
-        task_payload.get("providerProfileRef"),
+        parameter_payload.get("providerProfileRef"),
         parameter_payload.get("profileId"),
         parameter_payload.get("providerProfile"),
-        parameter_payload.get("providerProfileRef"),
+        request_payload.get("providerProfileRef"),
         request_payload.get("profileId"),
         request_payload.get("providerProfile"),
-        request_payload.get("providerProfileRef"),
     ):
         if candidate_profile_id is None:
             continue

--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -67,6 +67,10 @@ from moonmind.workflows.executions.title_derivation import (
     synthesize_workflow_title,
 )
 from moonmind.workflows.executions.routing import _coerce_bool
+from moonmind.runtime_intent import (
+    RuntimeIntentValidationError,
+    validate_runtime_tier_intent,
+)
 from moonmind.schemas.manifest_ingest_models import (
     ManifestNodePageModel,
     ManifestStatusSnapshotModel,
@@ -6907,6 +6911,18 @@ def _invalid_workflow_request(message: str) -> HTTPException:
         },
     )
 
+
+def _validate_runtime_tier_intent_for_submit(
+    runtime_payload: Mapping[str, Any] | None,
+    *,
+    field_name: str,
+) -> dict[str, Any]:
+    try:
+        return validate_runtime_tier_intent(runtime_payload, field_name=field_name)
+    except RuntimeIntentValidationError as exc:
+        raise _invalid_workflow_request(str(exc)) from exc
+
+
 def _reject_submit_version_identity(task_payload: dict[str, Any]) -> None:
     try:
         reject_workflow_capability_identity_versions(
@@ -7301,7 +7317,11 @@ def _normalize_task_steps(task_payload: dict[str, Any]) -> list[dict[str, Any]]:
                 raise _invalid_workflow_request(
                     f"payload.workflow.steps[{index}].runtime must be an object."
                 )
-            normalized_runtime: dict[str, str] = {}
+            validated_runtime = _validate_runtime_tier_intent_for_submit(
+                runtime_payload,
+                field_name=f"payload.workflow.steps[{index}].runtime",
+            )
+            normalized_runtime: dict[str, Any] = {}
             for source_key, target_key in (
                 ("mode", "mode"),
                 ("targetRuntime", "mode"),
@@ -7310,10 +7330,11 @@ def _normalize_task_steps(task_payload: dict[str, Any]) -> list[dict[str, Any]]:
                 ("effort", "effort"),
                 ("profileId", "profileId"),
                 ("providerProfile", "providerProfile"),
+                ("providerProfileRef", "providerProfileRef"),
                 ("executionProfileRef", "executionProfileRef"),
                 ("execution_profile_ref", "executionProfileRef"),
             ):
-                value = runtime_payload.get(source_key)
+                value = validated_runtime.get(source_key)
                 if value is not None and not isinstance(value, (Mapping, list)):
                     normalized_value = str(value).strip()
                     if not normalized_value:
@@ -7328,6 +7349,18 @@ def _normalize_task_steps(task_payload: dict[str, Any]) -> list[dict[str, Any]]:
                                 "codex_cloud, jules."
                             )
                     normalized_runtime[target_key] = normalized_value
+            if "modelTier" in validated_runtime:
+                normalized_runtime["modelTier"] = validated_runtime["modelTier"]
+            if "tierFallback" in validated_runtime:
+                normalized_runtime["tierFallback"] = validated_runtime["tierFallback"]
+            if isinstance(validated_runtime.get("profileSelector"), Mapping):
+                normalized_runtime["profileSelector"] = dict(
+                    validated_runtime["profileSelector"]
+                )
+            if isinstance(validated_runtime.get("hardOverrideAudit"), Mapping):
+                normalized_runtime["hardOverrideAudit"] = dict(
+                    validated_runtime["hardOverrideAudit"]
+                )
             if normalized_runtime:
                 normalized_step["runtime"] = normalized_runtime
 
@@ -7666,6 +7699,7 @@ async def _resolve_step_runtime_selections(
         raw_step_profile_id = str(
             runtime_payload.get("profileId")
             or runtime_payload.get("providerProfile")
+            or runtime_payload.get("providerProfileRef")
             or runtime_payload.get("executionProfileRef")
             or ""
         ).strip() or None
@@ -7710,6 +7744,7 @@ async def _resolve_step_runtime_selections(
         if raw_step_profile_id:
             resolved_runtime["profileId"] = raw_step_profile_id
             resolved_runtime["providerProfile"] = raw_step_profile_id
+            resolved_runtime["providerProfileRef"] = raw_step_profile_id
         elif task_profile_id and not raw_step_profile_id:
             resolved_runtime.setdefault("inheritedProfileId", task_profile_id)
         if "effort" not in resolved_runtime and isinstance(
@@ -9551,7 +9586,10 @@ async def _create_execution_from_workflow_request(
         task_payload.get("manifestArtifactRef") or payload.get("manifestArtifactRef")
     )
     runtime_payload = (
-        task_payload.get("runtime")
+        _validate_runtime_tier_intent_for_submit(
+            task_payload.get("runtime"),
+            field_name="payload.workflow.runtime",
+        )
         if isinstance(task_payload.get("runtime"), dict)
         else {}
     )
@@ -9748,10 +9786,13 @@ async def _create_execution_from_workflow_request(
     raw_profile_id = str(
         runtime_payload.get("profileId")
         or runtime_payload.get("providerProfile")
+        or runtime_payload.get("providerProfileRef")
         or task_payload.get("profileId")
         or task_payload.get("providerProfile")
+        or task_payload.get("providerProfileRef")
         or payload.get("profileId")
         or payload.get("providerProfile")
+        or payload.get("providerProfileRef")
         or ""
     ).strip() or None
     # Preserve the original requested model byte-for-byte (Compatibility Policy:
@@ -9782,7 +9823,11 @@ async def _create_execution_from_workflow_request(
     _provider_profile = None
     if raw_profile_id and session is not None:
         from api_service.db.models import ManagedAgentProviderProfile
-        _provider_profile = await session.get(ManagedAgentProviderProfile, raw_profile_id)
+
+        _provider_profile = await session.get(
+            ManagedAgentProviderProfile,
+            raw_profile_id,
+        )
         if _provider_profile is None:
             raise _invalid_workflow_request(
                 f"Provider profile not found: {raw_profile_id!r}."
@@ -9833,6 +9878,14 @@ async def _create_execution_from_workflow_request(
         "publishMode": publish_payload["mode"],
         "stepCount": step_count,
     }
+    if "modelTier" in runtime_payload:
+        initial_parameters["modelTier"] = runtime_payload.get("modelTier")
+    if "tierFallback" in runtime_payload:
+        initial_parameters["tierFallback"] = runtime_payload.get("tierFallback")
+    if isinstance(runtime_payload.get("profileSelector"), Mapping):
+        initial_parameters["profileSelector"] = dict(
+            runtime_payload["profileSelector"]
+        )
     if known_refs:
         initial_parameters["knownRefs"] = sorted(known_refs)
     if story_output_payload:
@@ -10108,12 +10161,16 @@ async def _resolve_recurring_runtime_metadata(
     if not task_payload and parameter_payload is not request_payload:
         _task_key, task_payload = _recurring_workflow_payload(request_payload)
 
-    runtime_payload = (
+    raw_runtime_payload = (
         task_payload.get("runtime")
         if isinstance(task_payload.get("runtime"), Mapping)
         else parameter_payload.get("runtime")
         if isinstance(parameter_payload.get("runtime"), Mapping)
         else {}
+    )
+    runtime_payload = _validate_runtime_tier_intent_for_submit(
+        raw_runtime_payload,
+        field_name="payload.workflow.runtime",
     )
     raw_target_runtime = (
         request_payload.get("targetRuntime")
@@ -10136,13 +10193,17 @@ async def _resolve_recurring_runtime_metadata(
     for candidate_profile_id in (
         runtime_payload.get("profileId"),
         runtime_payload.get("providerProfile"),
+        runtime_payload.get("providerProfileRef"),
         runtime_payload.get("executionProfileRef"),
         task_payload.get("profileId"),
         task_payload.get("providerProfile"),
+        task_payload.get("providerProfileRef"),
         parameter_payload.get("profileId"),
         parameter_payload.get("providerProfile"),
+        parameter_payload.get("providerProfileRef"),
         request_payload.get("profileId"),
         request_payload.get("providerProfile"),
+        request_payload.get("providerProfileRef"),
     ):
         if candidate_profile_id is None:
             continue
@@ -10188,6 +10249,12 @@ async def _resolve_recurring_runtime_metadata(
         metadata["effort"] = runtime_payload.get("effort")
     elif "effort" in parameter_payload:
         metadata["effort"] = parameter_payload.get("effort")
+    if "modelTier" in runtime_payload:
+        metadata["modelTier"] = runtime_payload.get("modelTier")
+    if "tierFallback" in runtime_payload:
+        metadata["tierFallback"] = runtime_payload.get("tierFallback")
+    if isinstance(runtime_payload.get("profileSelector"), Mapping):
+        metadata["profileSelector"] = dict(runtime_payload["profileSelector"])
     return metadata
 
 
@@ -10210,6 +10277,10 @@ def _stamp_recurring_runtime_metadata(
         initial_parameters["profileId"] = runtime_metadata["profileId"]
     if "effort" in runtime_metadata:
         initial_parameters["effort"] = runtime_metadata.get("effort")
+    if "modelTier" in runtime_metadata:
+        initial_parameters["modelTier"] = runtime_metadata.get("modelTier")
+    if "tierFallback" in runtime_metadata:
+        initial_parameters["tierFallback"] = runtime_metadata.get("tierFallback")
 
     task_key, task_payload = _recurring_workflow_payload(initial_parameters)
     if task_key is None:
@@ -10230,6 +10301,13 @@ def _stamp_recurring_runtime_metadata(
         profile_id = runtime_metadata["profileId"]
         runtime_payload["profileId"] = profile_id
         runtime_payload["providerProfile"] = profile_id
+        runtime_payload["providerProfileRef"] = profile_id
+    if "modelTier" in runtime_metadata:
+        runtime_payload["modelTier"] = runtime_metadata.get("modelTier")
+    if "tierFallback" in runtime_metadata:
+        runtime_payload["tierFallback"] = runtime_metadata.get("tierFallback")
+    if isinstance(runtime_metadata.get("profileSelector"), Mapping):
+        runtime_payload["profileSelector"] = dict(runtime_metadata["profileSelector"])
     if runtime_payload:
         task_payload["runtime"] = runtime_payload
         initial_parameters[task_key] = task_payload

--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -7479,18 +7479,13 @@ def _normalize_task_steps(task_payload: dict[str, Any]) -> list[dict[str, Any]]:
                         normalized_runtime[target_key] = value
                     else:
                         normalized_runtime[target_key] = normalized_value
-            if "modelTier" in validated_runtime:
-                normalized_runtime["modelTier"] = validated_runtime["modelTier"]
-            if "tierFallback" in validated_runtime:
-                normalized_runtime["tierFallback"] = validated_runtime["tierFallback"]
-            if isinstance(validated_runtime.get("profileSelector"), Mapping):
-                normalized_runtime["profileSelector"] = dict(
-                    validated_runtime["profileSelector"]
-                )
-            if isinstance(validated_runtime.get("hardOverrideAudit"), Mapping):
-                normalized_runtime["hardOverrideAudit"] = dict(
-                    validated_runtime["hardOverrideAudit"]
-                )
+            for key in ("modelTier", "tierFallback"):
+                if key in validated_runtime:
+                    normalized_runtime[key] = validated_runtime[key]
+            for key in ("profileSelector", "hardOverrideAudit"):
+                value = validated_runtime.get(key)
+                if isinstance(value, Mapping):
+                    normalized_runtime[key] = dict(value)
             if normalized_runtime:
                 normalized_step["runtime"] = normalized_runtime
 
@@ -9724,12 +9719,13 @@ async def _create_execution_from_workflow_request(
     manifest_artifact_ref = _coerce_artifact_ref(
         task_payload.get("manifestArtifactRef") or payload.get("manifestArtifactRef")
     )
+    runtime_from_task = task_payload.get("runtime")
     runtime_payload = (
         _validate_runtime_tier_intent_for_submit(
-            task_payload.get("runtime"),
+            runtime_from_task,
             field_name="payload.workflow.runtime",
         )
-        if isinstance(task_payload.get("runtime"), dict)
+        if isinstance(runtime_from_task, dict)
         else {}
     )
     merge_automation_payload = _normalize_merge_automation_payload(

--- a/api_service/api/schemas.py
+++ b/api_service/api/schemas.py
@@ -2,9 +2,20 @@ import uuid
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, Literal, Optional
 
-from pydantic import BaseModel, ConfigDict, Field, computed_field, field_validator, model_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    computed_field,
+    field_validator,
+    model_validator,
+)
 
 from moonmind.statuses.temporal_status import TemporalStatusValue
+from moonmind.runtime_intent import (
+    RuntimeIntentValidationError,
+    validate_runtime_tier_intent,
+)
 
 if TYPE_CHECKING:
     pass
@@ -404,6 +415,21 @@ class PresetStepSkillSchema(BaseModel):
     permissions: dict[str, Any] = Field(default_factory=dict)
     autonomy: dict[str, Any] = Field(default_factory=dict)
     runtime: dict[str, Any] = Field(default_factory=dict)
+
+    @field_validator("runtime", mode="before")
+    @classmethod
+    def validate_runtime_intent(cls, value: object) -> object:
+        if value is None:
+            return {}
+        if not isinstance(value, dict):
+            return value
+        try:
+            return validate_runtime_tier_intent(
+                value,
+                field_name="skill.runtime",
+            )
+        except RuntimeIntentValidationError as exc:
+            raise ValueError(str(exc)) from exc
 
 class PresetStepToolSchema(BaseModel):
     """Tool payload attached to a template step."""

--- a/api_service/services/presets/catalog.py
+++ b/api_service/services/presets/catalog.py
@@ -2008,7 +2008,6 @@ class PresetCatalogService:
                 step_payload["skill"] = _normalize_skill_payload(
                     raw_step.get("skill"), index=index
                 )
-                _promote_skill_runtime(step_payload)
             else:
                 if (
                     raw_step.get("tool") is not None

--- a/api_service/services/presets/catalog.py
+++ b/api_service/services/presets/catalog.py
@@ -44,6 +44,10 @@ from moonmind.workflows.checkpoint_branches import (
     CheckpointBranchGitBindingError,
     _validate_work_branch,
 )
+from moonmind.runtime_intent import (
+    RuntimeIntentValidationError,
+    validate_runtime_tier_intent,
+)
 
 _FORBIDDEN_STEP_KEYS = frozenset(
     {
@@ -514,7 +518,18 @@ def _normalize_skill_payload(raw_skill: Any, *, index: int) -> dict[str, Any]:
                 raise PresetValidationError(
                     f"Step {index} skill.{key} must be an object when provided."
                 )
-            skill_payload[key] = dict(value) if isinstance(value, Mapping) else value
+            if key == "runtime":
+                try:
+                    skill_payload[key] = validate_runtime_tier_intent(
+                        value,
+                        field_name=f"steps[{index - 1}].skill.runtime",
+                    )
+                except RuntimeIntentValidationError as exc:
+                    raise PresetValidationError(str(exc)) from exc
+            else:
+                skill_payload[key] = (
+                    dict(value) if isinstance(value, Mapping) else value
+                )
     return skill_payload
 
 

--- a/api_service/services/presets/catalog.py
+++ b/api_service/services/presets/catalog.py
@@ -527,9 +527,7 @@ def _normalize_skill_payload(raw_skill: Any, *, index: int) -> dict[str, Any]:
                 except RuntimeIntentValidationError as exc:
                     raise PresetValidationError(str(exc)) from exc
             else:
-                skill_payload[key] = (
-                    dict(value) if isinstance(value, Mapping) else value
-                )
+                skill_payload[key] = dict(value)
     return skill_payload
 
 

--- a/api_service/services/presets/catalog.py
+++ b/api_service/services/presets/catalog.py
@@ -531,6 +531,24 @@ def _normalize_skill_payload(raw_skill: Any, *, index: int) -> dict[str, Any]:
     return skill_payload
 
 
+def _promote_skill_runtime(step_payload: dict[str, Any]) -> None:
+    skill_payload = step_payload.get("skill")
+    if not isinstance(skill_payload, Mapping):
+        return
+    skill_runtime = skill_payload.get("runtime")
+    if not isinstance(skill_runtime, Mapping):
+        return
+    step_runtime = (
+        dict(step_payload.get("runtime"))
+        if isinstance(step_payload.get("runtime"), Mapping)
+        else {}
+    )
+    for key, value in skill_runtime.items():
+        step_runtime.setdefault(key, value)
+    if step_runtime:
+        step_payload["runtime"] = step_runtime
+
+
 def _normalize_preset_payload(raw_preset: Any, *, index: int) -> dict[str, Any]:
     if not isinstance(raw_preset, Mapping):
         raise _step_validation_error(
@@ -1990,6 +2008,7 @@ class PresetCatalogService:
                 step_payload["skill"] = _normalize_skill_payload(
                     raw_step.get("skill"), index=index
                 )
+                _promote_skill_runtime(step_payload)
             else:
                 if (
                     raw_step.get("tool") is not None
@@ -2295,6 +2314,7 @@ class PresetCatalogService:
                 step_payload["skill"] = _normalize_skill_payload(
                     rendered.get("skill"), index=source_index
                 )
+                _promote_skill_runtime(step_payload)
             step_payload.update(
                 {
                     str(key).strip(): value

--- a/frontend/src/entrypoints/dashboard.test.tsx
+++ b/frontend/src/entrypoints/dashboard.test.tsx
@@ -650,6 +650,7 @@ describe('Dashboard shared entry', () => {
     expect(await screen.findByText('Recurring schedule not found.')).toBeTruthy();
     navigateTo('/schedules');
     expect(await screen.findByRole('heading', { name: 'Recurring Schedules' })).toBeTruthy();
+    expect(await screen.findByRole('link', { name: /Daily recurring scan/ })).toBeTruthy();
 
     fireEvent.click(screen.getByRole('radio', { name: 'Sidebar list' }));
 

--- a/moonmind/runtime_intent.py
+++ b/moonmind/runtime_intent.py
@@ -7,6 +7,7 @@ from typing import Any
 
 MODEL_TIER_KEY = "modelTier"
 TIER_FALLBACK_KEY = "tierFallback"
+HARD_OVERRIDE_AUDIT_KEY = "hardOverrideAudit"
 SUPPORTED_TIER_FALLBACKS = frozenset({"clamp", "strict"})
 
 
@@ -44,12 +45,18 @@ def validate_runtime_tier_intent(
             raise RuntimeIntentValidationError(
                 f"{field_name}.tierFallback must be one of: {supported}."
             )
+    if HARD_OVERRIDE_AUDIT_KEY in payload:
+        hard_override_audit = payload[HARD_OVERRIDE_AUDIT_KEY]
+        if not isinstance(hard_override_audit, Mapping) or not hard_override_audit:
+            raise RuntimeIntentValidationError(
+                f"{field_name}.hardOverrideAudit must be a non-empty object."
+            )
     if MODEL_TIER_KEY in payload:
         override_fields = [
             key for key in ("model", "effort") if payload.get(key) is not None
         ]
-        if override_fields and "hardOverrideAudit" not in payload:
-            payload["hardOverrideAudit"] = {
+        if override_fields and HARD_OVERRIDE_AUDIT_KEY not in payload:
+            payload[HARD_OVERRIDE_AUDIT_KEY] = {
                 "source": "runtime_metadata",
                 "fields": override_fields,
                 "trace": ["MM-1168", "MM-1171"],

--- a/moonmind/runtime_intent.py
+++ b/moonmind/runtime_intent.py
@@ -1,0 +1,57 @@
+"""Validation helpers for authored workflow runtime intent."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+MODEL_TIER_KEY = "modelTier"
+TIER_FALLBACK_KEY = "tierFallback"
+SUPPORTED_TIER_FALLBACKS = frozenset({"clamp", "strict"})
+
+
+class RuntimeIntentValidationError(ValueError):
+    """Raised when authored runtime tier intent is invalid."""
+
+
+def validate_runtime_tier_intent(
+    runtime: Mapping[str, Any] | None,
+    *,
+    field_name: str,
+) -> dict[str, Any]:
+    """Return a copied runtime payload after validating tier intent fields.
+
+    MM-1171 implements the preset/workflow submission boundary from MM-1168's
+    provider profile tier design. Generic runtime metadata remains open-ended,
+    but modelTier and tierFallback are now explicit contract fields.
+    """
+
+    payload = dict(runtime or {})
+    if MODEL_TIER_KEY in payload:
+        model_tier = payload[MODEL_TIER_KEY]
+        if isinstance(model_tier, bool) or not isinstance(model_tier, int):
+            raise RuntimeIntentValidationError(
+                f"{field_name}.modelTier must be an integer."
+            )
+        if model_tier < 1:
+            raise RuntimeIntentValidationError(
+                f"{field_name}.modelTier must be greater than or equal to 1."
+            )
+    if TIER_FALLBACK_KEY in payload:
+        tier_fallback = payload[TIER_FALLBACK_KEY]
+        if tier_fallback not in SUPPORTED_TIER_FALLBACKS:
+            supported = ", ".join(sorted(SUPPORTED_TIER_FALLBACKS))
+            raise RuntimeIntentValidationError(
+                f"{field_name}.tierFallback must be one of: {supported}."
+            )
+    if MODEL_TIER_KEY in payload:
+        override_fields = [
+            key for key in ("model", "effort") if payload.get(key) is not None
+        ]
+        if override_fields and "hardOverrideAudit" not in payload:
+            payload["hardOverrideAudit"] = {
+                "source": "runtime_metadata",
+                "fields": override_fields,
+                "trace": ["MM-1168", "MM-1171"],
+            }
+    return payload

--- a/moonmind/workflows/executions/runtime_inheritance.py
+++ b/moonmind/workflows/executions/runtime_inheritance.py
@@ -182,11 +182,19 @@ def has_explicit_child_runtime(
 
     runtime_node = task_payload.get("runtime") if isinstance(task_payload, Mapping) else None
     if isinstance(runtime_node, Mapping):
-        for key in ("mode", "model", "effort", "providerProfile", "profileId", "executionProfileRef"):
+        for key in (
+            "mode",
+            "model",
+            "effort",
+            "providerProfileRef",
+            "providerProfile",
+            "profileId",
+            "executionProfileRef",
+        ):
             if _coerce_str(runtime_node.get(key)):
                 return True
 
-    for key in ("profileId", "providerProfile"):
+    for key in ("providerProfileRef", "profileId", "providerProfile"):
         if _coerce_str(payload.get(key)) or _coerce_str(task_payload.get(key)):
             return True
 
@@ -406,7 +414,7 @@ def apply_inherited_runtime_to_payload(
     runtime resolution path then sees the merged request.
 
     Note: when the caller has supplied an explicit profile selector
-    (``profileId`` / ``providerProfile`` anywhere in the payload),
+    (``providerProfileRef`` / ``profileId`` / ``providerProfile`` anywhere in the payload),
     ``executionProfileRef`` is *also* left blank.  Downstream selection
     prefers ``executionProfileRef`` over ``profileId``/``providerProfile``
     (see ``run.py``), so backfilling the parent's ref would silently
@@ -423,11 +431,14 @@ def apply_inherited_runtime_to_payload(
         payload.get("targetRuntime")
     ) or _coerce_str(runtime_block.get("mode"))
     explicit_profile_id = (
-        _coerce_str(runtime_block.get("profileId"))
+        _coerce_str(runtime_block.get("providerProfileRef"))
+        or _coerce_str(runtime_block.get("profileId"))
         or _coerce_str(runtime_block.get("providerProfile"))
         or _coerce_str(runtime_block.get("executionProfileRef"))
+        or _coerce_str(payload.get("providerProfileRef"))
         or _coerce_str(payload.get("profileId"))
         or _coerce_str(payload.get("providerProfile"))
+        or _coerce_str(task_payload.get("providerProfileRef"))
         or _coerce_str(task_payload.get("profileId"))
         or _coerce_str(task_payload.get("providerProfile"))
     )

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -5942,6 +5942,118 @@ def test_create_task_shaped_execution_normalizes_scalar_step_runtime_fields(
     assert runtime["providerProfile"] == "123"
 
 
+def test_mm1171_create_execution_preserves_runtime_tier_intent(
+    client: tuple[TestClient, AsyncMock, SimpleNamespace],
+) -> None:
+    test_client, service, _user = client
+    service.create_execution.return_value = _build_execution_record()
+    test_client.app.dependency_overrides[get_async_session] = lambda: None
+
+    response = test_client.post(
+        "/api/executions",
+        json={
+            "type": "workflow",
+            "payload": {
+                "repository": "MoonLadderStudios/MoonMind",
+                "targetRuntime": "codex_cli",
+                "workflow": {
+                    "title": "Preserve MM-1168 tier intent",
+                    "instructions": "Run a portable tiered workflow.",
+                    "runtime": {
+                        "providerProfileRef": "codex-openai",
+                        "profileSelector": {"providerId": "openai"},
+                        "modelTier": 2,
+                        "tierFallback": "clamp",
+                    },
+                    "steps": [
+                        {
+                            "id": "implement",
+                            "instructions": "Implement.",
+                            "runtime": {
+                                "providerProfileRef": "codex-openai",
+                                "profileSelector": {"providerId": "openai"},
+                                "modelTier": 3,
+                                "tierFallback": "strict",
+                            },
+                        }
+                    ],
+                },
+            },
+        },
+    )
+
+    assert response.status_code == 201, response.json()
+    initial_parameters = service.create_execution.await_args.kwargs[
+        "initial_parameters"
+    ]
+    workflow_runtime = initial_parameters["workflow"]["runtime"]
+    assert workflow_runtime["providerProfileRef"] == "codex-openai"
+    assert workflow_runtime["profileSelector"] == {"providerId": "openai"}
+    assert workflow_runtime["modelTier"] == 2
+    assert workflow_runtime["tierFallback"] == "clamp"
+    assert "requestedModel" not in workflow_runtime
+    assert "model" not in workflow_runtime
+
+    step_runtime = initial_parameters["workflow"]["steps"][0]["runtime"]
+    assert step_runtime["providerProfileRef"] == "codex-openai"
+    assert step_runtime["profileSelector"] == {"providerId": "openai"}
+    assert step_runtime["modelTier"] == 3
+    assert step_runtime["tierFallback"] == "strict"
+    assert "requestedModel" not in step_runtime
+
+
+def test_mm1171_create_execution_rejects_invalid_runtime_tier_intent(
+    client: tuple[TestClient, AsyncMock, SimpleNamespace],
+) -> None:
+    test_client, service, _user = client
+    service.create_execution.return_value = _build_execution_record()
+    test_client.app.dependency_overrides[get_async_session] = lambda: None
+
+    response = test_client.post(
+        "/api/executions",
+        json={
+            "type": "workflow",
+            "payload": {
+                "repository": "MoonLadderStudios/MoonMind",
+                "targetRuntime": "codex_cli",
+                "workflow": {
+                    "title": "Reject bad tier",
+                    "instructions": "Run a workflow.",
+                    "runtime": {"modelTier": "2"},
+                },
+            },
+        },
+    )
+
+    assert response.status_code == 422
+    assert "modelTier" in response.json()["detail"]["message"]
+
+    response = test_client.post(
+        "/api/executions",
+        json={
+            "type": "workflow",
+            "payload": {
+                "repository": "MoonLadderStudios/MoonMind",
+                "targetRuntime": "codex_cli",
+                "workflow": {
+                    "title": "Reject bad fallback",
+                    "instructions": "Run a workflow.",
+                    "steps": [
+                        {
+                            "id": "verify",
+                            "instructions": "Verify.",
+                            "runtime": {"modelTier": 1, "tierFallback": "soft"},
+                        }
+                    ],
+                },
+            },
+        },
+    )
+
+    assert response.status_code == 422
+    assert "tierFallback" in response.json()["detail"]["message"]
+
+
 def test_create_task_shaped_execution_preserves_preset_schedule_provenance(
     client: tuple[TestClient, AsyncMock, SimpleNamespace],
 ) -> None:

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -6102,6 +6102,8 @@ def test_mm1171_create_execution_preserves_runtime_tier_intent(
     initial_parameters = service.create_execution.await_args.kwargs[
         "initial_parameters"
     ]
+    assert initial_parameters["profileSelector"] == {"providerId": "openai"}
+    assert initial_parameters["runtime"]["profileSelector"] == {"providerId": "openai"}
     workflow_runtime = initial_parameters["workflow"]["runtime"]
     assert workflow_runtime["providerProfileRef"] == "codex-openai"
     assert workflow_runtime["profileSelector"] == {"providerId": "openai"}
@@ -6168,6 +6170,29 @@ def test_mm1171_create_execution_rejects_invalid_runtime_tier_intent(
 
     assert response.status_code == 422
     assert "tierFallback" in response.json()["detail"]["message"]
+
+    response = test_client.post(
+        "/api/executions",
+        json={
+            "type": "workflow",
+            "payload": {
+                "repository": "MoonLadderStudios/MoonMind",
+                "targetRuntime": "codex_cli",
+                "workflow": {
+                    "title": "Reject bad hard override audit",
+                    "instructions": "Run a workflow.",
+                    "runtime": {
+                        "modelTier": 1,
+                        "model": "gpt-x",
+                        "hardOverrideAudit": "yes",
+                    },
+                },
+            },
+        },
+    )
+
+    assert response.status_code == 422
+    assert "hardOverrideAudit" in response.json()["detail"]["message"]
 
 
 def test_create_task_shaped_execution_preserves_preset_schedule_provenance(
@@ -8150,6 +8175,48 @@ def test_create_task_shaped_recurring_schedule_preserves_runtime_selection(
     assert stored_runtime["effort"] == "xhigh"
     assert stored_runtime["profileId"] == "codex-profile"
     assert stored_runtime["providerProfile"] == "codex-profile"
+
+
+def test_create_task_shaped_recurring_schedule_rejects_invalid_step_runtime_tier(
+    client: tuple[TestClient, AsyncMock, SimpleNamespace],
+) -> None:
+    test_client, _service, _user = client
+    test_client.app.dependency_overrides[get_async_session] = _empty_session_override
+
+    with patch(
+        "api_service.services.recurring_workflows_service.RecurringWorkflowsService"
+    ) as service_cls:
+        service = service_cls.return_value
+        service.create_definition = AsyncMock()
+
+        response = test_client.post(
+            "/api/executions",
+            json={
+                "type": "workflow",
+                "payload": {
+                    "targetRuntime": "codex",
+                    "schedule": {
+                        "mode": "recurring",
+                        "cron": "0 * * * *",
+                    },
+                    "workflow": {
+                        "instructions": "Resolve Dependabot PRs.",
+                        "runtime": {"mode": "codex"},
+                        "steps": [
+                            {
+                                "id": "bad-tier",
+                                "instructions": "Run invalid tier.",
+                                "runtime": {"modelTier": "2"},
+                            }
+                        ],
+                    },
+                },
+            },
+        )
+
+    assert response.status_code == 422
+    assert "payload.workflow.steps[0].runtime.modelTier" in response.json()["detail"]["message"]
+    service.create_definition.assert_not_awaited()
 
 
 def test_create_task_shaped_recurring_schedule_passes_metadata_and_response(

--- a/tests/unit/api/test_presets_service.py
+++ b/tests/unit/api/test_presets_service.py
@@ -159,6 +159,7 @@ async def test_mm1171_preset_runtime_tier_intent_is_validated_and_preserved(tmp_
         "modelTier": 2,
         "tierFallback": "strict",
     }
+    assert expanded["steps"][0]["runtime"] == runtime
 
 
 async def test_mm1171_preset_runtime_rejects_invalid_tier_values(tmp_path):

--- a/tests/unit/api/test_presets_service.py
+++ b/tests/unit/api/test_presets_service.py
@@ -108,6 +108,112 @@ async def test_create_and_expand_template_deterministic_ids(tmp_path):
     assert "version" not in expanded["appliedTemplate"]
     assert "checkpointBranching" not in expanded
 
+
+async def test_mm1171_preset_runtime_tier_intent_is_validated_and_preserved(tmp_path):
+    user_id = uuid4()
+    async with template_db(tmp_path) as session_maker:
+        async with session_maker() as session:
+            service = PresetCatalogService(session)
+            await service.create_template(
+                slug="tiered-workflow",
+                title="Tiered Workflow",
+                description="Template carrying MM-1168 model tier intent.",
+                scope="personal",
+                scope_ref=str(user_id),
+                tags=["runtime"],
+                inputs_schema=[],
+                steps=[
+                    {
+                        "title": "Implement",
+                        "instructions": "Implement the issue.",
+                        "skill": {
+                            "id": "auto",
+                            "runtime": {
+                                "providerProfileRef": "codex-openai",
+                                "profileSelector": {"providerId": "openai"},
+                                "modelTier": 2,
+                                "tierFallback": "strict",
+                            },
+                        },
+                    }
+                ],
+                annotations={},
+                required_capabilities=[],
+                created_by=user_id,
+            )
+
+            expanded = await service.expand_template(
+                slug="tiered-workflow",
+                scope="personal",
+                scope_ref=str(user_id),
+                inputs={},
+                context={},
+                options=ExpandOptions(should_enforce_step_limit=True),
+                user_id=user_id,
+            )
+
+    runtime = expanded["steps"][0]["skill"]["runtime"]
+    assert runtime == {
+        "providerProfileRef": "codex-openai",
+        "profileSelector": {"providerId": "openai"},
+        "modelTier": 2,
+        "tierFallback": "strict",
+    }
+
+
+async def test_mm1171_preset_runtime_rejects_invalid_tier_values(tmp_path):
+    user_id = uuid4()
+    async with template_db(tmp_path) as session_maker:
+        async with session_maker() as session:
+            service = PresetCatalogService(session)
+
+            with pytest.raises(PresetValidationError, match="modelTier"):
+                await service.create_template(
+                    slug="bad-tier",
+                    title="Bad Tier",
+                    description="Template with invalid tier intent.",
+                    scope="personal",
+                    scope_ref=str(user_id),
+                    tags=[],
+                    inputs_schema=[],
+                    steps=[
+                        {
+                            "title": "Run",
+                            "instructions": "Run.",
+                            "skill": {"runtime": {"modelTier": "2"}},
+                        }
+                    ],
+                    annotations={},
+                    required_capabilities=[],
+                    created_by=user_id,
+                )
+
+            with pytest.raises(PresetValidationError, match="tierFallback"):
+                await service.create_template(
+                    slug="bad-fallback",
+                    title="Bad Fallback",
+                    description="Template with invalid fallback intent.",
+                    scope="personal",
+                    scope_ref=str(user_id),
+                    tags=[],
+                    inputs_schema=[],
+                    steps=[
+                        {
+                            "title": "Run",
+                            "instructions": "Run.",
+                            "skill": {
+                                "runtime": {
+                                    "modelTier": 1,
+                                    "tierFallback": "soft",
+                                }
+                            },
+                        }
+                    ],
+                    annotations={},
+                    required_capabilities=[],
+                    created_by=user_id,
+                )
+
 async def test_checkpoint_branching_policy_expands_only_when_enabled(tmp_path):
     user_id = uuid4()
     async with template_db(tmp_path) as session_maker:

--- a/tests/unit/workflows/executions/test_runtime_inheritance.py
+++ b/tests/unit/workflows/executions/test_runtime_inheritance.py
@@ -75,6 +75,12 @@ def test_has_explicit_child_runtime_profile_id() -> None:
     assert has_explicit_child_runtime({"task": {"profileId": "p-1"}})
 
 
+def test_has_explicit_child_runtime_provider_profile_ref() -> None:
+    assert has_explicit_child_runtime(
+        {"task": {"runtime": {"providerProfileRef": "child-profile"}}}
+    )
+
+
 def test_has_explicit_child_runtime_false_when_only_inheritance() -> None:
     assert not has_explicit_child_runtime({"runtimeInheritance": "caller", "task": {}})
 
@@ -482,6 +488,28 @@ def test_apply_inherited_runtime_skips_execution_profile_ref_when_explicit_profi
 
     assert task_payload["runtime"]["profileId"] == "child-explicit"
     assert "executionProfileRef" not in task_payload["runtime"]
+
+
+def test_apply_inherited_runtime_preserves_explicit_provider_profile_ref() -> None:
+    payload: dict[str, Any] = {
+        "task": {"runtime": {"providerProfileRef": "child-explicit"}}
+    }
+    task_payload = payload["task"]
+    inherited = InheritedRuntime(
+        target_runtime="codex_cli",
+        profile_id="parent-default",
+        execution_profile_ref="parent-default",
+    )
+
+    apply_inherited_runtime_to_payload(
+        payload=payload,
+        task_payload=task_payload,
+        inherited=inherited,
+    )
+
+    assert task_payload["runtime"]["providerProfileRef"] == "child-explicit"
+    assert "executionProfileRef" not in task_payload["runtime"]
+    assert "profileId" not in task_payload["runtime"]
 
 
 def test_apply_inherited_runtime_skips_profile_backfill_when_child_sets_execution_profile_ref() -> None:


### PR DESCRIPTION
Issue reference
- MM-1171: https://moonladder.atlassian.net/browse/MM-1171

Summary
- Added shared runtime intent validation for modelTier and tierFallback while preserving open-ended runtime metadata.
- Validates preset skill runtime and workflow submission runtime boundaries, including providerProfileRef/profileSelector tier intent.
- Records hard override audit metadata when modelTier is submitted with explicit model or effort overrides.
- Added unit coverage for preset expansion, execution submission preservation, invalid tier rejection, and audit behavior.

Tests run
- MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --python-only tests/unit/api/routers/test_executions.py tests/unit/api/test_presets_service.py
- python -m pytest -q tests/integration/temporal/test_task_shaped_submission_normalization.py --durations=10

Remaining risks
- Tier resolution remains intentionally deferred to backend provider profile resolution; this change validates and preserves intent at submission/preset boundaries.