### PR TITLE
Fix init-db provider profile migration JSON default

### DIFF
--- a/api_service/db/models.py
+++ b/api_service/db/models.py
@@ -25,6 +25,7 @@ from sqlalchemy import (
     UniqueConstraint,
     Uuid,
     func,
+    literal_column,
     text,
 )
 from sqlalchemy.dialects.postgresql import ARRAY, JSONB
@@ -2443,7 +2444,7 @@ class ManagedAgentProviderProfile(Base):
         JSON,
         nullable=False,
         default=_provider_profile_model_tiers_default,
-        server_default=text(
+        server_default=literal_column(
             """'[{"label":"Runtime default","model":null,"effort":null,"parameters":{},"annotations":{}}]'"""
         ),
     )

--- a/api_service/migrations/versions/335_provider_profile_model_tiers.py
+++ b/api_service/migrations/versions/335_provider_profile_model_tiers.py
@@ -54,7 +54,8 @@ def upgrade() -> None:
             "model_tiers",
             _json_type(),
             nullable=False,
-            server_default=sa.text(_DEFAULT_MODEL_TIERS),
+            # TextClause treats the compact JSON's ``:null`` as a bind parameter.
+            server_default=sa.literal_column(_DEFAULT_MODEL_TIERS),
         ),
     )
     op.add_column(

--- a/tests/unit/api_service/test_provider_profile_model_tiers_migration.py
+++ b/tests/unit/api_service/test_provider_profile_model_tiers_migration.py
@@ -1,0 +1,66 @@
+"""Regression coverage for the provider profile model tiers migration."""
+
+from __future__ import annotations
+
+import importlib
+import json
+
+from sqlalchemy.dialects import postgresql
+from sqlalchemy.schema import CreateColumn
+
+
+class _RecordingOp:
+    def __init__(self) -> None:
+        self.columns = []
+
+    def add_column(self, table_name, column) -> None:
+        self.columns.append((table_name, column))
+
+    def get_bind(self):
+        return self
+
+    def execute(self, _statement):
+        return []
+
+    def create_check_constraint(self, *_args, **_kwargs) -> None:
+        return None
+
+
+def test_model_tiers_server_default_compiles_as_valid_postgresql_json(
+    monkeypatch,
+) -> None:
+    migration = importlib.import_module(
+        "api_service.migrations.versions.335_provider_profile_model_tiers"
+    )
+    operations = _RecordingOp()
+    monkeypatch.setattr(migration, "op", operations)
+
+    migration.upgrade()
+
+    model_tiers_column = next(
+        column
+        for table_name, column in operations.columns
+        if table_name == "managed_agent_provider_profiles"
+        and column.name == "model_tiers"
+    )
+    default_sql = str(
+        model_tiers_column.server_default.arg.compile(
+            dialect=postgresql.dialect(),
+        )
+    )
+    assert default_sql.startswith("'") and default_sql.endswith("'")
+    assert json.loads(default_sql[1:-1]) == [
+        {
+            "label": "Runtime default",
+            "model": None,
+            "effort": None,
+            "parameters": {},
+            "annotations": {},
+        }
+    ]
+
+    ddl = str(
+        CreateColumn(model_tiers_column).compile(dialect=postgresql.dialect())
+    )
+    assert '"model":null' in ddl
+    assert '"effort":null' in ddl

--- a/tests/unit/api_service/test_provider_profile_model_tiers_migration.py
+++ b/tests/unit/api_service/test_provider_profile_model_tiers_migration.py
@@ -8,6 +8,8 @@ import json
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.schema import CreateColumn
 
+from api_service.db.models import ManagedAgentProviderProfile
+
 
 class _RecordingOp:
     def __init__(self) -> None:
@@ -24,6 +26,28 @@ class _RecordingOp:
 
     def create_check_constraint(self, *_args, **_kwargs) -> None:
         return None
+
+
+def _assert_valid_model_tiers_default(column) -> None:
+    default_sql = str(
+        column.server_default.arg.compile(
+            dialect=postgresql.dialect(),
+        )
+    )
+    assert default_sql.startswith("'") and default_sql.endswith("'")
+    assert json.loads(default_sql[1:-1]) == [
+        {
+            "label": "Runtime default",
+            "model": None,
+            "effort": None,
+            "parameters": {},
+            "annotations": {},
+        }
+    ]
+
+    ddl = str(CreateColumn(column).compile(dialect=postgresql.dialect()))
+    assert '"model":null' in ddl
+    assert '"effort":null' in ddl
 
 
 def test_model_tiers_server_default_compiles_as_valid_postgresql_json(
@@ -43,24 +67,10 @@ def test_model_tiers_server_default_compiles_as_valid_postgresql_json(
         if table_name == "managed_agent_provider_profiles"
         and column.name == "model_tiers"
     )
-    default_sql = str(
-        model_tiers_column.server_default.arg.compile(
-            dialect=postgresql.dialect(),
-        )
-    )
-    assert default_sql.startswith("'") and default_sql.endswith("'")
-    assert json.loads(default_sql[1:-1]) == [
-        {
-            "label": "Runtime default",
-            "model": None,
-            "effort": None,
-            "parameters": {},
-            "annotations": {},
-        }
-    ]
+    _assert_valid_model_tiers_default(model_tiers_column)
 
-    ddl = str(
-        CreateColumn(model_tiers_column).compile(dialect=postgresql.dialect())
+
+def test_model_tiers_model_default_compiles_as_valid_postgresql_json() -> None:
+    _assert_valid_model_tiers_default(
+        ManagedAgentProviderProfile.__table__.c.model_tiers
     )
-    assert '"model":null' in ddl
-    assert '"effort":null' in ddl


### PR DESCRIPTION
## Summary

- preserve the provider-profile model-tier JSON server default as a literal SQL expression
- add a regression test that compiles the migration column with the PostgreSQL dialect and parses the emitted default as JSON

## Root cause

The migration passed compact JSON through SQLAlchemy's `TextClause`. SQLAlchemy interpreted the `:null` fragments after the `model` and `effort` keys as bind parameters and emitted malformed DDL containing `"model"NULL` and `"effort"NULL`. PostgreSQL rejected that default, causing the `init-db` one-shot container to exit with code 1.

## Validation

- targeted migration unit test: 1 passed
- existing PostgreSQL volume upgrade: `init-db` applied revision 335 and exited with code 0
- persisted schema inspection: Alembic is at revision 335 and PostgreSQL stores the expected JSONB default
- hermetic integration suite: 420 passed, 1 skipped, 89 deselected
- an unrelated dashboard timing test failed once in the general unit wrapper; its focused retry passed
