### PR TITLE
Run Jira Implement for MM-1172: Expose Provider Profile tier APIs and preview resolution

### DIFF
--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -7738,7 +7738,14 @@ async def _resolve_step_runtime_selections(
         if raw_requested_model is not None:
             resolved_runtime["requestedModel"] = raw_requested_model
         resolved_runtime["modelSource"] = resolved_model_effort.model_source
-        resolved_runtime["modelTierResolution"] = resolved_model_effort.as_metadata()
+        if _should_record_model_tier_resolution(
+            provider_profile=provider_profile,
+            requested_model_tier=requested_model_tier,
+            advisory_preview=advisory_preview,
+        ):
+            resolved_runtime["modelTierResolution"] = (
+                resolved_model_effort.as_metadata()
+            )
         if raw_step_profile_id:
             resolved_runtime["profileId"] = raw_step_profile_id
             resolved_runtime["providerProfile"] = raw_step_profile_id
@@ -7747,6 +7754,22 @@ async def _resolve_step_runtime_selections(
         if "effort" not in resolved_runtime and isinstance(task_runtime.get("effort"), str):
             resolved_runtime["effort"] = task_runtime["effort"]
         step["runtime"] = resolved_runtime
+
+
+def _should_record_model_tier_resolution(
+    *,
+    provider_profile: Any | None,
+    requested_model_tier: int | None,
+    advisory_preview: Mapping[str, Any] | None,
+) -> bool:
+    if requested_model_tier is not None or advisory_preview is not None:
+        return True
+    raw_tiers = (
+        getattr(provider_profile, "model_tiers", None)
+        if provider_profile is not None
+        else None
+    )
+    return isinstance(raw_tiers, list) and bool(raw_tiers)
 
 
 def _preset_seed_dir() -> Path:
@@ -9885,10 +9908,15 @@ async def _create_execution_from_workflow_request(
         "modelSource": resolved_model_effort.model_source,
         "profileId": raw_profile_id if _provider_profile is not None else None,
         "effort": resolved_model_effort.effort,
-        "modelTierResolution": resolved_model_effort.as_metadata(),
         "publishMode": publish_payload["mode"],
         "stepCount": step_count,
     }
+    if _should_record_model_tier_resolution(
+        provider_profile=_provider_profile,
+        requested_model_tier=requested_model_tier,
+        advisory_preview=advisory_preview,
+    ):
+        initial_parameters["modelTierResolution"] = resolved_model_effort.as_metadata()
     if known_refs:
         initial_parameters["knownRefs"] = sorted(known_refs)
     if story_output_payload:
@@ -10273,8 +10301,13 @@ async def _resolve_recurring_runtime_metadata(
         "model": resolved_model_effort.model,
         "requestedModel": raw_requested_model,
         "modelSource": resolved_model_effort.model_source,
-        "modelTierResolution": resolved_model_effort.as_metadata(),
     }
+    if _should_record_model_tier_resolution(
+        provider_profile=provider_profile,
+        requested_model_tier=requested_model_tier,
+        advisory_preview=advisory_preview,
+    ):
+        metadata["modelTierResolution"] = resolved_model_effort.as_metadata()
     if raw_profile_id:
         metadata["profileId"] = raw_profile_id
     metadata["effort"] = resolved_model_effort.effort

--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -164,7 +164,10 @@ from moonmind.workflows.temporal.client import TemporalClientAdapter, query_work
 from moonmind.workflows.temporal.hard_switch_cutover import (
     resolve_user_workflow_start_contract,
 )
-from moonmind.workflows.executions.model_resolver import resolve_effective_model
+from moonmind.workflows.executions.model_resolver import (
+    resolve_effective_model,
+    resolve_model_effort,
+)
 from moonmind.workflows.executions.preset_goal_scheduler import (
     GoalPresetSchedule,
     goal_from_payloads,
@@ -7672,6 +7675,25 @@ async def _resolve_step_runtime_selections(
         raw_requested_model: str | None = runtime_payload.get("model") or None
         if raw_requested_model is not None:
             raw_requested_model = str(raw_requested_model)
+        raw_requested_effort: str | None = runtime_payload.get("effort") or None
+        if raw_requested_effort is not None:
+            raw_requested_effort = str(raw_requested_effort)
+        raw_requested_tier = runtime_payload.get("modelTier")
+        try:
+            requested_model_tier = (
+                int(raw_requested_tier) if raw_requested_tier is not None else None
+            )
+        except (TypeError, ValueError) as exc:
+            raise _invalid_workflow_request(
+                f"Invalid payload.workflow.steps[{index}].runtime.modelTier: "
+                f"{raw_requested_tier!r}."
+            ) from exc
+        tier_fallback = str(runtime_payload.get("tierFallback") or "clamp")
+        advisory_preview = (
+            runtime_payload.get("tierPreview")
+            if isinstance(runtime_payload.get("tierPreview"), Mapping)
+            else None
+        )
 
         effective_profile_id = raw_step_profile_id or task_profile_id
         provider_profile = None
@@ -7692,29 +7714,37 @@ async def _resolve_step_runtime_selections(
                     f"payload.workflow.steps[{index}]: {task_profile_id!r}."
                 )
 
-        resolved_model, model_source = resolve_effective_model(
-            runtime_id=canonical_step_runtime,
-            profile=provider_profile,
-            requested_model=raw_requested_model,
-            workflow_settings=settings.workflow,
-        )
+        try:
+            resolved_model_effort = resolve_model_effort(
+                runtime_id=canonical_step_runtime,
+                profile=provider_profile,
+                requested_model=raw_requested_model,
+                requested_effort=raw_requested_effort,
+                requested_model_tier=requested_model_tier,
+                tier_fallback=tier_fallback,
+                advisory_preview=advisory_preview,
+                workflow_settings=settings.workflow,
+            )
+        except ValueError as exc:
+            raise _invalid_workflow_request(str(exc)) from exc
 
         resolved_runtime = dict(runtime_payload)
         if canonical_step_runtime:
             resolved_runtime["mode"] = canonical_step_runtime
-        if resolved_model:
-            resolved_runtime["model"] = resolved_model
+        if resolved_model_effort.model:
+            resolved_runtime["model"] = resolved_model_effort.model
+        if resolved_model_effort.effort:
+            resolved_runtime["effort"] = resolved_model_effort.effort
         if raw_requested_model is not None:
             resolved_runtime["requestedModel"] = raw_requested_model
-        resolved_runtime["modelSource"] = model_source
+        resolved_runtime["modelSource"] = resolved_model_effort.model_source
+        resolved_runtime["modelTierResolution"] = resolved_model_effort.as_metadata()
         if raw_step_profile_id:
             resolved_runtime["profileId"] = raw_step_profile_id
             resolved_runtime["providerProfile"] = raw_step_profile_id
         elif task_profile_id and not raw_step_profile_id:
             resolved_runtime.setdefault("inheritedProfileId", task_profile_id)
-        if "effort" not in resolved_runtime and isinstance(
-            task_runtime.get("effort"), str
-        ):
+        if "effort" not in resolved_runtime and isinstance(task_runtime.get("effort"), str):
             resolved_runtime["effort"] = task_runtime["effort"]
         step["runtime"] = resolved_runtime
 
@@ -9759,6 +9789,24 @@ async def _create_execution_from_workflow_request(
     raw_requested_model: str | None = runtime_payload.get("model") or None
     if raw_requested_model is not None:
         raw_requested_model = str(raw_requested_model)
+    raw_requested_effort: str | None = runtime_payload.get("effort") or None
+    if raw_requested_effort is not None:
+        raw_requested_effort = str(raw_requested_effort)
+    raw_requested_tier = runtime_payload.get("modelTier")
+    try:
+        requested_model_tier = (
+            int(raw_requested_tier) if raw_requested_tier is not None else None
+        )
+    except (TypeError, ValueError) as exc:
+        raise _invalid_workflow_request(
+            f"Invalid runtime.modelTier: {raw_requested_tier!r}."
+        ) from exc
+    tier_fallback = str(runtime_payload.get("tierFallback") or "clamp")
+    advisory_preview = (
+        runtime_payload.get("tierPreview")
+        if isinstance(runtime_payload.get("tierPreview"), Mapping)
+        else None
+    )
 
     # Normalize targetRuntime to canonical form and validate it.
     canonical_target_runtime: str | None = None
@@ -9788,12 +9836,19 @@ async def _create_execution_from_workflow_request(
                 f"Provider profile not found: {raw_profile_id!r}."
             )
 
-    resolved_model, model_source = resolve_effective_model(
-        runtime_id=canonical_target_runtime,
-        profile=_provider_profile,
-        requested_model=raw_requested_model,
-        workflow_settings=settings.workflow,
-    )
+    try:
+        resolved_model_effort = resolve_model_effort(
+            runtime_id=canonical_target_runtime,
+            profile=_provider_profile,
+            requested_model=raw_requested_model,
+            requested_effort=raw_requested_effort,
+            requested_model_tier=requested_model_tier,
+            tier_fallback=tier_fallback,
+            advisory_preview=advisory_preview,
+            workflow_settings=settings.workflow,
+        )
+    except ValueError as exc:
+        raise _invalid_workflow_request(str(exc)) from exc
 
     await _resolve_step_runtime_selections(
         steps=normalized_steps,
@@ -9825,11 +9880,12 @@ async def _create_execution_from_workflow_request(
         "priority": request.priority,
         "maxAttempts": request.max_attempts,
         "targetRuntime": canonical_target_runtime,
-        "model": resolved_model,
+        "model": resolved_model_effort.model,
         "requestedModel": raw_requested_model,
-        "modelSource": model_source,
+        "modelSource": resolved_model_effort.model_source,
         "profileId": raw_profile_id if _provider_profile is not None else None,
-        "effort": runtime_payload.get("effort"),
+        "effort": resolved_model_effort.effort,
+        "modelTierResolution": resolved_model_effort.as_metadata(),
         "publishMode": publish_payload["mode"],
         "stepCount": step_count,
     }
@@ -10157,6 +10213,35 @@ async def _resolve_recurring_runtime_metadata(
         ) or parameter_payload.get("model")
     if raw_requested_model is not None:
         raw_requested_model = str(raw_requested_model)
+    raw_requested_effort: str | None = runtime_payload.get("effort") or None
+    if raw_requested_effort is None:
+        raw_requested_effort = parameter_payload.get("effort")
+    if raw_requested_effort is not None:
+        raw_requested_effort = str(raw_requested_effort)
+    raw_requested_tier = runtime_payload.get("modelTier")
+    if raw_requested_tier is None:
+        raw_requested_tier = parameter_payload.get("modelTier")
+    try:
+        requested_model_tier = (
+            int(raw_requested_tier) if raw_requested_tier is not None else None
+        )
+    except (TypeError, ValueError) as exc:
+        raise _invalid_workflow_request(
+            f"Invalid runtime.modelTier: {raw_requested_tier!r}."
+        ) from exc
+    tier_fallback = str(
+        runtime_payload.get("tierFallback")
+        or parameter_payload.get("tierFallback")
+        or "clamp"
+    )
+    advisory_preview = None
+    for preview_candidate in (
+        runtime_payload.get("tierPreview"),
+        parameter_payload.get("tierPreview"),
+    ):
+        if isinstance(preview_candidate, Mapping):
+            advisory_preview = preview_candidate
+            break
 
     provider_profile = None
     session_get = getattr(session, "get", None)
@@ -10170,24 +10255,29 @@ async def _resolve_recurring_runtime_metadata(
                 f"Provider profile not found: {raw_profile_id!r}."
             )
 
-    resolved_model, model_source = resolve_effective_model(
-        runtime_id=canonical_target_runtime,
-        profile=provider_profile,
-        requested_model=raw_requested_model,
-        workflow_settings=settings.workflow,
-    )
+    try:
+        resolved_model_effort = resolve_model_effort(
+            runtime_id=canonical_target_runtime,
+            profile=provider_profile,
+            requested_model=raw_requested_model,
+            requested_effort=raw_requested_effort,
+            requested_model_tier=requested_model_tier,
+            tier_fallback=tier_fallback,
+            advisory_preview=advisory_preview,
+            workflow_settings=settings.workflow,
+        )
+    except ValueError as exc:
+        raise _invalid_workflow_request(str(exc)) from exc
     metadata: dict[str, Any] = {
         "targetRuntime": canonical_target_runtime,
-        "model": resolved_model,
+        "model": resolved_model_effort.model,
         "requestedModel": raw_requested_model,
-        "modelSource": model_source,
+        "modelSource": resolved_model_effort.model_source,
+        "modelTierResolution": resolved_model_effort.as_metadata(),
     }
     if raw_profile_id:
         metadata["profileId"] = raw_profile_id
-    if "effort" in runtime_payload:
-        metadata["effort"] = runtime_payload.get("effort")
-    elif "effort" in parameter_payload:
-        metadata["effort"] = parameter_payload.get("effort")
+    metadata["effort"] = resolved_model_effort.effort
     return metadata
 
 
@@ -10206,6 +10296,10 @@ def _stamp_recurring_runtime_metadata(
         initial_parameters["requestedModel"] = runtime_metadata["requestedModel"]
     if runtime_metadata.get("modelSource"):
         initial_parameters["modelSource"] = runtime_metadata["modelSource"]
+    if runtime_metadata.get("modelTierResolution"):
+        initial_parameters["modelTierResolution"] = runtime_metadata[
+            "modelTierResolution"
+        ]
     if runtime_metadata.get("profileId"):
         initial_parameters["profileId"] = runtime_metadata["profileId"]
     if "effort" in runtime_metadata:
@@ -10226,6 +10320,10 @@ def _stamp_recurring_runtime_metadata(
         runtime_payload["model"] = runtime_metadata["model"]
     if "effort" in runtime_metadata:
         runtime_payload["effort"] = runtime_metadata.get("effort")
+    if runtime_metadata.get("modelTierResolution"):
+        runtime_payload["modelTierResolution"] = runtime_metadata[
+            "modelTierResolution"
+        ]
     if runtime_metadata.get("profileId"):
         profile_id = runtime_metadata["profileId"]
         runtime_payload["profileId"] = profile_id

--- a/api_service/api/routers/provider_profiles.py
+++ b/api_service/api/routers/provider_profiles.py
@@ -36,6 +36,11 @@ from moonmind.auth.secret_refs import (
     parse_secret_ref,
 )
 from moonmind.schemas.agent_runtime_models import validate_codex_oauth_profile_refs
+from moonmind.workflows.executions.model_resolver import (
+    DEFAULT_MODEL_TIER,
+    normalize_model_tiers,
+    resolve_model_effort,
+)
 from moonmind.utils.logging import (
     redact_profile_file_templates,
     redact_sensitive_payload,
@@ -76,6 +81,8 @@ class ProviderProfileCreate(BaseModel):
     default_model: Optional[str] = None
     default_effort: Optional[str] = Field(default=None, max_length=64)
     model_overrides: Optional[dict[str, str]] = None
+    model_tiers: list[dict[str, Any]] = Field(default_factory=lambda: [dict(DEFAULT_MODEL_TIER)])
+    default_model_tier: int = Field(default=1, ge=1)
     
     credential_source: str = Field(..., pattern="^(oauth_volume|secret_ref|none)$")
     runtime_materialization_mode: str = Field(..., pattern="^(oauth_home|api_key_env|env_bundle|config_bundle|composite)$")
@@ -131,6 +138,11 @@ class ProviderProfileCreate(BaseModel):
     def _validate_secret_refs(cls, value: dict[str, str] | None) -> dict[str, str] | None:
         return validate_secret_refs_helper(value)
 
+    @field_validator("model_tiers", mode="after")
+    @classmethod
+    def _validate_model_tiers(cls, value: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        return _validate_model_tiers(value)
+
     @model_validator(mode="after")
     def _validate_runtime_env(self) -> "ProviderProfileCreate":
         if self.enabled and self.auth_state != ProviderProfileAuthState.CONNECTED.value:
@@ -146,6 +158,8 @@ class ProviderProfileCreate(BaseModel):
             volume_ref_field_name="volume_ref",
             volume_mount_path_field_name="volume_mount_path",
         )
+        if self.default_model_tier > len(self.model_tiers):
+            raise ValueError("default_model_tier must refer to a configured model_tiers entry")
         return self
 
 class ProviderProfileUpdate(BaseModel):
@@ -154,6 +168,8 @@ class ProviderProfileUpdate(BaseModel):
     default_model: Optional[str] = None
     default_effort: Optional[str] = Field(default=None, max_length=64)
     model_overrides: Optional[dict[str, str]] = None
+    model_tiers: Optional[list[dict[str, Any]]] = None
+    default_model_tier: Optional[int] = Field(default=None, ge=1)
     credential_source: Optional[str] = Field(default=None, pattern="^(oauth_volume|secret_ref|none)$")
     runtime_materialization_mode: Optional[str] = Field(default=None, pattern="^(oauth_home|api_key_env|env_bundle|config_bundle|composite)$")
     volume_ref: Optional[str] = None
@@ -208,6 +224,13 @@ class ProviderProfileUpdate(BaseModel):
     def _validate_secret_refs_update(cls, value: dict[str, str] | None) -> dict[str, str] | None:
         return validate_secret_refs_helper(value)
 
+    @field_validator("model_tiers", mode="after")
+    @classmethod
+    def _validate_model_tiers_update(
+        cls, value: list[dict[str, Any]] | None
+    ) -> list[dict[str, Any]] | None:
+        return _validate_model_tiers(value) if value is not None else value
+
     @model_validator(mode="after")
     def _validate_runtime_env_update(self) -> "ProviderProfileUpdate":
         return self
@@ -220,6 +243,8 @@ class ProviderProfileResponse(BaseModel):
     default_model: Optional[str] = None
     default_effort: Optional[str] = None
     model_overrides: dict[str, str] = Field(default_factory=dict)
+    model_tiers: list[dict[str, Any]] = Field(default_factory=lambda: [dict(DEFAULT_MODEL_TIER)])
+    default_model_tier: int = 1
     credential_source: str
     runtime_materialization_mode: str
     volume_ref: Optional[str]
@@ -250,6 +275,37 @@ class ProviderProfileResponse(BaseModel):
     updated_at: Optional[str]
 
     model_config = {"from_attributes": True}
+
+
+class ProviderProfileTierPreviewStep(BaseModel):
+    step_id: str = Field(..., alias="id")
+    model_tier: Optional[int] = Field(default=None, ge=1, alias="modelTier")
+    tier_fallback: Optional[str] = Field(default="clamp", pattern="^(clamp|strict)$", alias="tierFallback")
+
+    model_config = {"populate_by_name": True}
+
+
+class ProviderProfileTierPreviewRequest(BaseModel):
+    steps: list[ProviderProfileTierPreviewStep] = Field(default_factory=list)
+
+
+class ProviderProfileTierPreviewItem(BaseModel):
+    step_id: str = Field(..., alias="stepId")
+    requested_tier: Optional[int] = Field(default=None, alias="requestedTier")
+    effective_tier: Optional[int] = Field(default=None, alias="effectiveTier")
+    model: Optional[str] = None
+    effort: Optional[str] = None
+    fallback_reason: Optional[str] = Field(default=None, alias="fallbackReason")
+
+    model_config = {"populate_by_name": True}
+
+
+class ProviderProfileTierPreviewResponse(BaseModel):
+    profile_id: str = Field(..., alias="profileId")
+    advisory: bool = True
+    items: list[ProviderProfileTierPreviewItem]
+
+    model_config = {"populate_by_name": True}
 
 class ProviderReadinessCheck(BaseModel):
     id: str
@@ -391,6 +447,8 @@ async def create_profile(
         default_model=body.default_model,
         default_effort=body.default_effort,
         model_overrides=body.model_overrides,
+        model_tiers=_model_tiers_for_create(body),
+        default_model_tier=body.default_model_tier,
         credential_source=ProviderCredentialSource(body.credential_source),
         runtime_materialization_mode=RuntimeMaterializationMode(body.runtime_materialization_mode),
         volume_ref=body.volume_ref,
@@ -492,6 +550,12 @@ async def update_profile(
             value = ProviderProfileAuthMethod(value)
         setattr(profile, key, value)
 
+    if not profile.model_tiers:
+        profile.model_tiers = normalize_model_tiers(profile)
+    if not profile.default_model_tier:
+        profile.default_model_tier = 1
+    _validate_profile_tier_bounds(profile.model_tiers, profile.default_model_tier)
+
     if profile.enabled:
         if profile.auth_state != ProviderProfileAuthState.CONNECTED:
             raise HTTPException(
@@ -535,6 +599,51 @@ async def update_profile(
         managed_secret_statuses=secret_statuses,
         secret_ref_results=secret_ref_results.get(profile.profile_id),
     )
+
+
+@router.post(
+    "/{profile_id}/model-tiers:preview",
+    response_model=ProviderProfileTierPreviewResponse,
+)
+async def preview_model_tiers(
+    profile_id: str,
+    body: ProviderProfileTierPreviewRequest,
+    session: AsyncSession = Depends(_get_session()),  # type: ignore[assignment]
+    current_user: User = Depends(get_current_user()),
+) -> dict[str, Any]:
+    _require_provider_profile_permission(current_user, "provider_profiles.read")
+    profile = await session.get(ManagedAgentProviderProfile, profile_id)
+    if not profile:
+        raise HTTPException(status_code=404, detail="Profile not found")
+    if not _can_view_profile(profile, current_user):
+        raise HTTPException(
+            status_code=403,
+            detail="Not authorized to view this provider profile.",
+        )
+
+    items: list[dict[str, Any]] = []
+    for step in body.steps:
+        try:
+            resolved = resolve_model_effort(
+                runtime_id=profile.runtime_id,
+                profile=profile,
+                requested_model_tier=step.model_tier,
+                tier_fallback=step.tier_fallback,
+            )
+        except ValueError as exc:
+            raise HTTPException(status_code=422, detail=str(exc)) from exc
+        items.append(
+            {
+                "stepId": step.step_id,
+                "requestedTier": resolved.requested_model_tier,
+                "effectiveTier": resolved.effective_model_tier,
+                "model": resolved.model,
+                "effort": resolved.effort,
+                "fallbackReason": resolved.fallback_reason,
+            }
+        )
+
+    return {"profileId": profile.profile_id, "advisory": True, "items": items}
 
 @router.post(
     "/{profile_id}/credentials/api-key",
@@ -1597,6 +1706,8 @@ def _row_to_dict(
         "default_model": row.default_model,
         "default_effort": row.default_effort,
         "model_overrides": row.model_overrides or {},
+        "model_tiers": normalize_model_tiers(row),
+        "default_model_tier": row.default_model_tier or 1,
         "credential_source": row.credential_source.value if row.credential_source else None,
         "runtime_materialization_mode": row.runtime_materialization_mode.value if row.runtime_materialization_mode else None,
         "volume_ref": row.volume_ref,
@@ -1642,6 +1753,77 @@ def _row_to_dict(
         payload[key] = redact_sensitive_payload(payload[key])
     payload["file_templates"] = redact_profile_file_templates(payload["file_templates"])
     return payload
+
+
+def _validate_model_tiers(value: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    if not isinstance(value, list) or not value:
+        raise ValueError("model_tiers must contain at least one tier")
+    normalized: list[dict[str, Any]] = []
+    for index, raw_tier in enumerate(value):
+        if not isinstance(raw_tier, dict):
+            raise ValueError(f"model_tiers[{index}] must be a JSON object")
+        tier = {
+            "label": str(raw_tier.get("label") or f"Tier {index + 1}").strip(),
+            "model": _optional_tier_string(raw_tier.get("model")),
+            "effort": _optional_tier_string(raw_tier.get("effort")),
+            "parameters": dict(raw_tier.get("parameters") or {}),
+            "annotations": dict(raw_tier.get("annotations") or {}),
+        }
+        for field_name in ("parameters", "annotations"):
+            _reject_tier_secret_like_keys(
+                tier[field_name],
+                path=f"model_tiers[{index}].{field_name}",
+            )
+        normalized.append(tier)
+    return normalized
+
+
+def _model_tiers_for_create(body: ProviderProfileCreate) -> list[dict[str, Any]]:
+    if "model_tiers" in body.model_fields_set:
+        return body.model_tiers
+    if body.default_model or body.default_effort:
+        return [
+            {
+                "label": "Default",
+                "model": body.default_model,
+                "effort": body.default_effort,
+                "parameters": {},
+                "annotations": {"migratedFrom": "default_model_default_effort"},
+            }
+        ]
+    return body.model_tiers
+
+
+def _optional_tier_string(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _reject_tier_secret_like_keys(value: dict[str, Any], *, path: str) -> None:
+    for key, nested in value.items():
+        key_text = str(key).lower()
+        if any(marker in key_text for marker in ("secret", "token", "password", "api_key", "apikey", "credential")):
+            raise ValueError(f"{path} must not contain credential-like key {key!r}")
+        if isinstance(nested, dict):
+            _reject_tier_secret_like_keys(nested, path=f"{path}.{key}")
+
+
+def _validate_profile_tier_bounds(
+    model_tiers: list[dict[str, Any]] | None,
+    default_model_tier: int | None,
+) -> None:
+    tier_count = len(model_tiers or [])
+    if tier_count < 1:
+        raise HTTPException(status_code=422, detail="model_tiers must contain at least one tier")
+    if not default_model_tier or default_model_tier < 1:
+        raise HTTPException(status_code=422, detail="default_model_tier must be at least 1")
+    if default_model_tier > tier_count:
+        raise HTTPException(
+            status_code=422,
+            detail="default_model_tier must refer to a configured model_tiers entry",
+        )
 
 from api_service.services.provider_profile_service import (
     FirstPartyOAuthProfile,

--- a/api_service/db/models.py
+++ b/api_service/db/models.py
@@ -2404,6 +2404,20 @@ class ManagedAgentProviderProfile(Base):
     default_model: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
     default_effort: Mapped[Optional[str]] = mapped_column(String(64), nullable=True)
     model_overrides: Mapped[Optional[dict[str, Any]]] = mapped_column(JSON, nullable=True)
+    model_tiers: Mapped[list[dict[str, Any]]] = mapped_column(
+        JSON,
+        nullable=False,
+        default=list,
+        server_default=text(
+            """'[{"label":"Runtime default","model":null,"effort":null,"parameters":{},"annotations":{}}]'"""
+        ),
+    )
+    default_model_tier: Mapped[int] = mapped_column(
+        Integer,
+        nullable=False,
+        default=1,
+        server_default=text("1"),
+    )
     
     credential_source: Mapped[ProviderCredentialSource] = mapped_column(
         Enum(

--- a/api_service/migrations/versions/335_mm1172_provider_profile_model_tiers.py
+++ b/api_service/migrations/versions/335_mm1172_provider_profile_model_tiers.py
@@ -1,0 +1,112 @@
+"""add provider profile model tiers for MM-1172.
+
+Source traceability: MM-1172 / MM-1168.
+
+Revision ID: 335_mm1172_provider_tiers
+Revises: 334_mm1152_bridge_sessions
+Create Date: 2026-07-10
+"""
+
+from __future__ import annotations
+
+from typing import Any, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "335_mm1172_provider_tiers"
+down_revision: Union[str, None] = "334_mm1152_bridge_sessions"
+
+__all__ = ["revision", "down_revision", "upgrade", "downgrade"]
+
+_RUNTIME_DEFAULT_TIER = [
+    {
+        "label": "Runtime default",
+        "model": None,
+        "effort": None,
+        "parameters": {},
+        "annotations": {"migratedFrom": "runtime_default"},
+    }
+]
+
+
+def _backfilled_tiers(default_model: Any, default_effort: Any) -> list[dict[str, Any]]:
+    model = str(default_model).strip() if default_model is not None else None
+    effort = str(default_effort).strip() if default_effort is not None else None
+    model = model or None
+    effort = effort or None
+    if model or effort:
+        return [
+            {
+                "label": "Default",
+                "model": model,
+                "effort": effort,
+                "parameters": {},
+                "annotations": {"migratedFrom": "default_model_default_effort"},
+            }
+        ]
+    return [dict(_RUNTIME_DEFAULT_TIER[0])]
+
+
+def upgrade() -> None:
+    op.add_column(
+        "managed_agent_provider_profiles",
+        sa.Column(
+            "model_tiers",
+            sa.JSON(),
+            nullable=False,
+            server_default=sa.text(
+                """'[{"label":"Runtime default","model":null,"effort":null,"parameters":{},"annotations":{}}]'"""
+            ),
+        ),
+    )
+    op.add_column(
+        "managed_agent_provider_profiles",
+        sa.Column(
+            "default_model_tier",
+            sa.Integer(),
+            nullable=False,
+            server_default=sa.text("1"),
+        ),
+    )
+    op.create_check_constraint(
+        "ck_provider_profiles_default_model_tier_positive",
+        "managed_agent_provider_profiles",
+        "default_model_tier >= 1",
+    )
+
+    conn = op.get_bind()
+    profiles = sa.table(
+        "managed_agent_provider_profiles",
+        sa.column("profile_id", sa.String()),
+        sa.column("default_model", sa.String()),
+        sa.column("default_effort", sa.String()),
+        sa.column("model_tiers", sa.JSON()),
+        sa.column("default_model_tier", sa.Integer()),
+    )
+    rows = conn.execute(
+        sa.select(
+            profiles.c.profile_id,
+            profiles.c.default_model,
+            profiles.c.default_effort,
+        )
+    ).fetchall()
+    for profile_id, default_model, default_effort in rows:
+        conn.execute(
+            sa.update(profiles)
+            .where(profiles.c.profile_id == profile_id)
+            .values(
+                model_tiers=_backfilled_tiers(default_model, default_effort),
+                default_model_tier=1,
+            )
+        )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        "ck_provider_profiles_default_model_tier_positive",
+        "managed_agent_provider_profiles",
+        type_="check",
+    )
+    op.drop_column("managed_agent_provider_profiles", "default_model_tier")
+    op.drop_column("managed_agent_provider_profiles", "model_tiers")

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -797,6 +797,23 @@ export interface paths {
         patch: operations["update_profile_api_v1_provider_profiles__profile_id__patch"];
         trace?: never;
     };
+    "/api/v1/provider-profiles/{profile_id}/model-tiers:preview": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Preview Model Tiers */
+        post: operations["preview_model_tiers_api_v1_provider_profiles__profile_id__model_tiers_preview_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/provider-profiles/{profile_id}/credentials/api-key": {
         parameters: {
             query?: never;
@@ -8425,6 +8442,50 @@ export interface components {
             /** Rate Limit Policy */
             rate_limit_policy: string;
         };
+        /** ProviderProfileTierPreviewItem */
+        ProviderProfileTierPreviewItem: {
+            /** Stepid */
+            stepId: string;
+            /** Requestedtier */
+            requestedTier?: number | null;
+            /** Effectivetier */
+            effectiveTier?: number | null;
+            /** Model */
+            model?: string | null;
+            /** Effort */
+            effort?: string | null;
+            /** Fallbackreason */
+            fallbackReason?: string | null;
+        };
+        /** ProviderProfileTierPreviewRequest */
+        ProviderProfileTierPreviewRequest: {
+            /** Steps */
+            steps?: components["schemas"]["ProviderProfileTierPreviewStep"][];
+        };
+        /** ProviderProfileTierPreviewResponse */
+        ProviderProfileTierPreviewResponse: {
+            /** Profileid */
+            profileId: string;
+            /**
+             * Advisory
+             * @default true
+             */
+            advisory: boolean;
+            /** Items */
+            items: components["schemas"]["ProviderProfileTierPreviewItem"][];
+        };
+        /** ProviderProfileTierPreviewStep */
+        ProviderProfileTierPreviewStep: {
+            /** Id */
+            id: string;
+            /** Modeltier */
+            modelTier?: number | null;
+            /**
+             * Tierfallback
+             * @default clamp
+             */
+            tierFallback: string | null;
+        };
         /** ProviderProfileUpdate */
         ProviderProfileUpdate: {
             /** Provider Id */
@@ -12166,6 +12227,41 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["ProviderProfileResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    preview_model_tiers_api_v1_provider_profiles__profile_id__model_tiers_preview_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                profile_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ProviderProfileTierPreviewRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProviderProfileTierPreviewResponse"];
                 };
             };
             /** @description Validation Error */

--- a/moonmind/schemas/agent_runtime_models.py
+++ b/moonmind/schemas/agent_runtime_models.py
@@ -1655,6 +1655,11 @@ class ManagedRuntimeProfile(BaseModel):
     default_model: str | None = Field(None, alias="defaultModel")
     model_overrides: dict[str, str] = Field(default_factory=dict, alias="modelOverrides")
     default_effort: str | None = Field(None, alias="defaultEffort")
+    model_tiers: list[ProviderModelEffortTier] = Field(
+        default_factory=list,
+        alias="modelTiers",
+    )
+    default_model_tier: int = Field(1, alias="defaultModelTier", ge=1)
     default_timeout_seconds: int = Field(3600, alias="defaultTimeoutSeconds", ge=1)
     workspace_mode: WorkspaceMode = Field("tempdir", alias="workspaceMode")
     env_overrides: dict[str, str] = Field(default_factory=dict, alias="envOverrides")

--- a/moonmind/workflows/adapters/managed_agent_adapter.py
+++ b/moonmind/workflows/adapters/managed_agent_adapter.py
@@ -923,6 +923,8 @@ class ManagedAgentAdapter:
                 command_template=cmd_template,
                 default_model=profile.get("default_model") or runtime_default_model,
                 default_effort=profile.get("default_effort") or runtime_default_effort,
+                model_tiers=profile.get("model_tiers") or [],
+                default_model_tier=profile.get("default_model_tier") or 1,
                 model_overrides=profile.get("model_overrides") or {},
                 command_behavior=profile.get("command_behavior") or {},
                 env_template=profile.get("env_template") or {},

--- a/moonmind/workflows/executions/model_resolver.py
+++ b/moonmind/workflows/executions/model_resolver.py
@@ -123,6 +123,7 @@ def resolve_model_effort(
     """Resolve model and effort from explicit overrides, tiers, profile defaults, and runtime defaults."""
     clean_requested_model = str(requested_model or "").strip() or None
     clean_requested_effort = str(requested_effort or "").strip() or None
+    profile_has_configured_tiers = _profile_has_configured_tiers(profile)
     tiers = normalize_model_tiers(profile)
     default_tier = _default_model_tier(profile, len(tiers))
     effective_tier, fallback_reason = _effective_tier(
@@ -134,12 +135,9 @@ def resolve_model_effort(
     tier = tiers[effective_tier - 1]
     tier_model = str(tier.get("model") or "").strip() or None
     tier_effort = str(tier.get("effort") or "").strip() or None
-    tier_source = (
-        _MODEL_SOURCE_PROFILE_DEFAULT_TIER
-        if requested_model_tier is None
-        else _MODEL_SOURCE_REQUESTED_TIER
-    )
-    if requested_model_tier is None:
+    tier_source = _MODEL_SOURCE_REQUESTED_TIER
+    if requested_model_tier is None and profile_has_configured_tiers:
+        tier_source = _MODEL_SOURCE_PROFILE_DEFAULT_TIER
         fallback_reason = fallback_reason or _MODEL_SOURCE_PROFILE_DEFAULT_TIER
 
     runtime_model, runtime_effort = resolve_runtime_defaults(
@@ -161,7 +159,9 @@ def resolve_model_effort(
 
     if clean_requested_model:
         model, model_source = clean_requested_model, _MODEL_SOURCE_TASK_OVERRIDE
-    elif tier_model:
+    elif tier_model and (
+        requested_model_tier is not None or profile_has_configured_tiers
+    ):
         model, model_source = tier_model, tier_source
     elif profile_model:
         model, model_source = profile_model, _MODEL_SOURCE_PROFILE_DEFAULT
@@ -172,7 +172,9 @@ def resolve_model_effort(
 
     if clean_requested_effort:
         effort, effort_source = clean_requested_effort, _MODEL_SOURCE_TASK_OVERRIDE
-    elif tier_effort:
+    elif tier_effort and (
+        requested_model_tier is not None or profile_has_configured_tiers
+    ):
         effort, effort_source = tier_effort, tier_source
     elif profile_effort:
         effort, effort_source = profile_effort, _MODEL_SOURCE_PROFILE_DEFAULT
@@ -265,6 +267,11 @@ def _normalize_tier_entry(tier: Any) -> dict[str, Any]:
         "parameters": dict(tier.get("parameters") or {}),
         "annotations": dict(tier.get("annotations") or {}),
     }
+
+
+def _profile_has_configured_tiers(profile: Any | None) -> bool:
+    raw_tiers = getattr(profile, "model_tiers", None) if profile is not None else None
+    return isinstance(raw_tiers, list) and bool(raw_tiers)
 
 
 def _default_model_tier(profile: Any | None, tier_count: int) -> int:

--- a/moonmind/workflows/executions/model_resolver.py
+++ b/moonmind/workflows/executions/model_resolver.py
@@ -22,6 +22,7 @@ Usage::
 
 from __future__ import annotations
 
+from dataclasses import dataclass, replace
 from typing import Any, Mapping
 
 from moonmind.workflows.executions.runtime_defaults import (
@@ -29,7 +30,13 @@ from moonmind.workflows.executions.runtime_defaults import (
     resolve_runtime_defaults,
 )
 
-__all__ = ["resolve_effective_model"]
+__all__ = [
+    "DEFAULT_MODEL_TIER",
+    "ResolvedModelEffort",
+    "normalize_model_tiers",
+    "resolve_effective_model",
+    "resolve_model_effort",
+]
 
 # legacy_run contract — the model_source value "task_override" is persisted in
 # execution parameters/diagnostics; the value renames at the
@@ -38,6 +45,158 @@ _MODEL_SOURCE_TASK_OVERRIDE = "task_override"
 _MODEL_SOURCE_PROFILE_DEFAULT = "provider_profile_default"
 _MODEL_SOURCE_RUNTIME_DEFAULT = "runtime_default"
 _MODEL_SOURCE_NONE = "none"
+_MODEL_SOURCE_REQUESTED_TIER = "requested_tier"
+_MODEL_SOURCE_PROFILE_DEFAULT_TIER = "profile_default_tier"
+
+DEFAULT_MODEL_TIER: dict[str, Any] = {
+    "label": "Runtime default",
+    "model": None,
+    "effort": None,
+    "parameters": {},
+    "annotations": {},
+}
+
+
+@dataclass(frozen=True, slots=True)
+class ResolvedModelEffort:
+    model: str | None
+    effort: str | None
+    requested_model_tier: int | None
+    effective_model_tier: int | None
+    tier_label: str | None
+    model_source: str
+    effort_source: str
+    fallback_reason: str | None
+    effort_application_status: str | None = "unknown"
+    preview_mismatch: bool = False
+
+    def as_metadata(self) -> dict[str, Any]:
+        return {
+            "requestedModelTier": self.requested_model_tier,
+            "effectiveModelTier": self.effective_model_tier,
+            "tierLabel": self.tier_label,
+            "fallbackReason": self.fallback_reason,
+            "resolvedModel": self.model,
+            "resolvedEffort": self.effort,
+            "modelSource": self.model_source,
+            "effortSource": self.effort_source,
+            "effortApplicationStatus": self.effort_application_status,
+            "previewMismatch": self.preview_mismatch,
+        }
+
+
+def normalize_model_tiers(profile: Any | None) -> list[dict[str, Any]]:
+    """Return a validated tier list, deriving one tier from legacy defaults."""
+    if profile is None:
+        return [dict(DEFAULT_MODEL_TIER)]
+    raw_tiers = getattr(profile, "model_tiers", None)
+    if isinstance(raw_tiers, list) and raw_tiers:
+        return [_normalize_tier_entry(tier) for tier in raw_tiers]
+
+    legacy_model = str(getattr(profile, "default_model", None) or "").strip() or None
+    legacy_effort = str(getattr(profile, "default_effort", None) or "").strip() or None
+    if legacy_model or legacy_effort:
+        return [
+            {
+                "label": "Default",
+                "model": legacy_model,
+                "effort": legacy_effort,
+                "parameters": {},
+                "annotations": {"migratedFrom": "default_model_default_effort"},
+            }
+        ]
+    return [dict(DEFAULT_MODEL_TIER)]
+
+
+def resolve_model_effort(
+    *,
+    runtime_id: str | None,
+    profile: Any | None,
+    requested_model: str | None = None,
+    requested_effort: str | None = None,
+    requested_model_tier: int | None = None,
+    tier_fallback: str | None = None,
+    advisory_preview: Mapping[str, Any] | None = None,
+    workflow_settings: Any | None = None,
+    env: Mapping[str, str] | None = None,
+) -> ResolvedModelEffort:
+    """Resolve model and effort from explicit overrides, tiers, profile defaults, and runtime defaults."""
+    clean_requested_model = str(requested_model or "").strip() or None
+    clean_requested_effort = str(requested_effort or "").strip() or None
+    tiers = normalize_model_tiers(profile)
+    default_tier = _default_model_tier(profile, len(tiers))
+    effective_tier, fallback_reason = _effective_tier(
+        requested_model_tier,
+        default_tier=default_tier,
+        tier_count=len(tiers),
+        tier_fallback=tier_fallback,
+    )
+    tier = tiers[effective_tier - 1]
+    tier_model = str(tier.get("model") or "").strip() or None
+    tier_effort = str(tier.get("effort") or "").strip() or None
+    tier_source = (
+        _MODEL_SOURCE_PROFILE_DEFAULT_TIER
+        if requested_model_tier is None
+        else _MODEL_SOURCE_REQUESTED_TIER
+    )
+    if requested_model_tier is None:
+        fallback_reason = fallback_reason or _MODEL_SOURCE_PROFILE_DEFAULT_TIER
+
+    runtime_model, runtime_effort = resolve_runtime_defaults(
+        normalize_runtime_id(runtime_id),
+        workflow_settings=workflow_settings,
+        env=env,
+    )
+
+    profile_model = (
+        str(getattr(profile, "default_model", None) or "").strip() or None
+        if profile is not None
+        else None
+    )
+    profile_effort = (
+        str(getattr(profile, "default_effort", None) or "").strip() or None
+        if profile is not None
+        else None
+    )
+
+    if clean_requested_model:
+        model, model_source = clean_requested_model, _MODEL_SOURCE_TASK_OVERRIDE
+    elif tier_model:
+        model, model_source = tier_model, tier_source
+    elif profile_model:
+        model, model_source = profile_model, _MODEL_SOURCE_PROFILE_DEFAULT
+    elif runtime_model:
+        model, model_source = runtime_model, _MODEL_SOURCE_RUNTIME_DEFAULT
+    else:
+        model, model_source = None, _MODEL_SOURCE_NONE
+
+    if clean_requested_effort:
+        effort, effort_source = clean_requested_effort, _MODEL_SOURCE_TASK_OVERRIDE
+    elif tier_effort:
+        effort, effort_source = tier_effort, tier_source
+    elif profile_effort:
+        effort, effort_source = profile_effort, _MODEL_SOURCE_PROFILE_DEFAULT
+    elif runtime_effort:
+        effort, effort_source = runtime_effort, _MODEL_SOURCE_RUNTIME_DEFAULT
+    else:
+        effort, effort_source = None, _MODEL_SOURCE_NONE
+
+    resolved = ResolvedModelEffort(
+        model=model,
+        effort=effort,
+        requested_model_tier=requested_model_tier,
+        effective_model_tier=effective_tier,
+        tier_label=str(tier.get("label") or "").strip() or None,
+        model_source=model_source,
+        effort_source=effort_source,
+        fallback_reason=fallback_reason,
+        effort_application_status="unknown" if effort else None,
+        preview_mismatch=False,
+    )
+    return replace(
+        resolved,
+        preview_mismatch=_preview_mismatch(advisory_preview, resolved),
+    )
 
 def resolve_effective_model(
     *,
@@ -73,24 +232,17 @@ def resolve_effective_model(
         ``"task_override"``, ``"provider_profile_default"``,
         ``"runtime_default"``, or ``"none"``.
     """
-    # Preserve the raw requested_model exactly for pass-through; only use a
-    # clean copy internally to detect blankness. This keeps `codex.model` and
-    # `codex.effort` inputs unmodified (Compatibility Policy §codex).
+    # Preserve the legacy helper contract for callers that only ask for model
+    # resolution and assert persisted source values.
     clean_requested = (str(requested_model or "").strip()) or None
-
-    # 1. Explicit task-level model takes top priority.
     if clean_requested:
         return clean_requested, _MODEL_SOURCE_TASK_OVERRIDE
 
-    # 2. Provider profile default_model.
     if profile is not None:
         profile_model = str(getattr(profile, "default_model", None) or "").strip() or None
         if profile_model:
             return profile_model, _MODEL_SOURCE_PROFILE_DEFAULT
 
-    # 3. Runtime default.  Always normalize (normalize_runtime_id falls back to
-    # DEFAULT_WORKFLOW_RUNTIME for None/empty), so the runtime-default tier applies
-    # even when the caller omits targetRuntime.
     canonical_runtime = normalize_runtime_id(runtime_id)
     runtime_model, _ = resolve_runtime_defaults(
         canonical_runtime,
@@ -101,3 +253,64 @@ def resolve_effective_model(
         return runtime_model, _MODEL_SOURCE_RUNTIME_DEFAULT
 
     return None, _MODEL_SOURCE_NONE
+
+
+def _normalize_tier_entry(tier: Any) -> dict[str, Any]:
+    if not isinstance(tier, Mapping):
+        return dict(DEFAULT_MODEL_TIER)
+    return {
+        "label": str(tier.get("label") or "").strip() or "Tier",
+        "model": str(tier.get("model") or "").strip() or None,
+        "effort": str(tier.get("effort") or "").strip() or None,
+        "parameters": dict(tier.get("parameters") or {}),
+        "annotations": dict(tier.get("annotations") or {}),
+    }
+
+
+def _default_model_tier(profile: Any | None, tier_count: int) -> int:
+    raw_default = getattr(profile, "default_model_tier", 1) if profile is not None else 1
+    try:
+        default_tier = int(raw_default or 1)
+    except (TypeError, ValueError):
+        default_tier = 1
+    return max(1, min(default_tier, max(tier_count, 1)))
+
+
+def _effective_tier(
+    requested_tier: int | None,
+    *,
+    default_tier: int,
+    tier_count: int,
+    tier_fallback: str | None,
+) -> tuple[int, str | None]:
+    raw = requested_tier if requested_tier is not None else default_tier
+    try:
+        tier = int(raw or 1)
+    except (TypeError, ValueError):
+        tier = default_tier
+    if tier_fallback == "strict" and (tier < 1 or tier > tier_count):
+        raise ValueError("requested_model_tier_unavailable")
+    if tier < 1:
+        return 1, "requested_tier_below_configured_range"
+    if tier > tier_count:
+        return tier_count, "requested_tier_above_configured_range"
+    return tier, None
+
+
+def _preview_mismatch(
+    advisory_preview: Mapping[str, Any] | None,
+    resolved: ResolvedModelEffort,
+) -> bool:
+    if not advisory_preview:
+        return False
+    expected = {
+        "requestedTier": resolved.requested_model_tier,
+        "effectiveTier": resolved.effective_model_tier,
+        "model": resolved.model,
+        "effort": resolved.effort,
+        "fallbackReason": resolved.fallback_reason,
+    }
+    for key, value in expected.items():
+        if key in advisory_preview and advisory_preview.get(key) != value:
+            return True
+    return False

--- a/moonmind/workflows/temporal/artifacts.py
+++ b/moonmind/workflows/temporal/artifacts.py
@@ -2995,6 +2995,8 @@ class TemporalArtifactActivities:
                     "default_model": row.default_model,
                     "default_effort": row.default_effort,
                     "model_overrides": row.model_overrides or {},
+                    "model_tiers": row.model_tiers or [],
+                    "default_model_tier": row.default_model_tier,
                     "max_parallel_runs": row.max_parallel_runs,
                     "cooldown_after_429_seconds": row.cooldown_after_429_seconds,
                     "rate_limit_policy": row.rate_limit_policy.value,

--- a/moonmind/workflows/temporal/runtime/strategies/base.py
+++ b/moonmind/workflows/temporal/runtime/strategies/base.py
@@ -320,12 +320,24 @@ class ManagedRuntimeStrategy(ABC):
         2. ``profile.default_model`` (provider-profile default).
         3. Runtime default from the canonical registry.
         """
-        requested_model = request.parameters.get("model") if request.parameters else None
+        parameters = request.parameters or {}
+        requested_model = parameters.get("model")
 
         if requested_model:
             overrides = getattr(profile, "model_overrides", {}) or {}
             resolved = overrides.get(requested_model, requested_model)
             return resolved
+
+        if parameters.get("modelTier") is not None:
+            from moonmind.workflows.executions.model_resolver import resolve_model_effort
+
+            return resolve_model_effort(
+                runtime_id=self.runtime_id,
+                profile=profile,
+                requested_model_tier=parameters.get("modelTier"),
+                tier_fallback=parameters.get("tierFallback"),
+                advisory_preview=parameters.get("tierPreview"),
+            ).model
 
         profile_default = str(getattr(profile, "default_model", None) or "").strip() or None
         if profile_default:
@@ -338,9 +350,20 @@ class ManagedRuntimeStrategy(ABC):
 
     def get_effort(self, profile: Any, request: Any) -> str | None:
         """Extract effort from request parameters or profile default."""
-        return (
-            request.parameters.get("effort") if request.parameters else None
-        ) or getattr(profile, "default_effort", None)
+        parameters = request.parameters or {}
+        if parameters.get("effort"):
+            return parameters.get("effort")
+        if parameters.get("modelTier") is not None:
+            from moonmind.workflows.executions.model_resolver import resolve_model_effort
+
+            return resolve_model_effort(
+                runtime_id=self.runtime_id,
+                profile=profile,
+                requested_model_tier=parameters.get("modelTier"),
+                tier_fallback=parameters.get("tierFallback"),
+                advisory_preview=parameters.get("tierPreview"),
+            ).effort
+        return getattr(profile, "default_effort", None)
 
     def shape_environment(
         self,

--- a/reports/remediation_attempt-1.json
+++ b/reports/remediation_attempt-1.json
@@ -1,83 +1,89 @@
 {
   "artifact_type": "remediation.attempt",
   "attempt": 1,
-  "issue_ref": "MM-1146",
-  "issue_url": "https://moonladder.atlassian.net/browse/MM-1146",
+  "issue_ref": "MM-1172",
+  "issue_url": "https://moonladder.atlassian.net/browse/MM-1172",
   "source_verification_artifact": "artifacts/jira-implement-verify.json",
   "source_verdict": "ADDITIONAL_WORK_NEEDED",
   "brief_truncated": false,
-  "summary": "Remediated the two verifier-reported implementation gaps and the associated verification gap for the Recurring schedules desktop table (frontend/src/entrypoints/schedules.tsx). Added the documented 'Updated' (updatedAt) column at order 9 (after Policy) and an 'Actions' column at order 10 exposing only safe, common row actions (Run now, Pause/Resume) gated by the existing scheduleActionAvailability logic. Destructive delete remains detail-only per docs/UI/RecurringSchedulesPage.md#s21 / STORY-011. Extended schedules.test.tsx to assert both new columns, the safe row actions with no delete control, a triggered run-now action, and absence of spawned execution content in the list (testing contract item 16). Scope was bounded strictly to the verifier's remaining_work backlog; the issue scope was not broadened, no PR was created, and Jira status was not changed.",
+  "summary": "Remediated the verifier-reported execution-router gaps for provider profile model tier launch metadata. Legacy provider profiles that only expose default_model/default_effort now preserve the compatibility modelSource provider_profile_default instead of being reclassified as profile_default_tier. Execution launch paths now record modelTierResolution only when tier policy is actually involved: an explicit modelTier, an advisory tierPreview, or a provider profile with configured model_tiers. Added focused launch-path coverage proving stale tierPreview data is advisory, backend resolution re-runs against the current profile policy, and modelTierResolution.previewMismatch is recorded.",
   "changed_files": [
-    "frontend/src/entrypoints/schedules.tsx",
-    "frontend/src/entrypoints/schedules.test.tsx",
-    "frontend/src/styles/dashboard.css"
+    "api_service/api/routers/executions.py",
+    "moonmind/workflows/executions/model_resolver.py",
+    "tests/unit/api/routers/test_executions.py",
+    "reports/remediation_attempt-1.json"
   ],
   "gap_statuses": [
     {
-      "requirement": "AC-updated-column: The desktop table includes the 'Updated' column (updatedAt) in the documented order after Policy.",
-      "gap_type": "implementation",
-      "status": "fixed",
-      "evidence": [
-        "frontend/src/entrypoints/schedules.tsx now defines a DataTable column {key:'updatedAt', header:'Updated', render:(item)=>formatWhen(item.updatedAt)} immediately after the Policy column (order 9).",
-        "frontend/src/entrypoints/schedules.test.tsx asserts getByRole('columnheader',{name:'Updated'}) and the formatted updatedAt value rendered from the schedule row."
-      ]
-    },
-    {
-      "requirement": "AC-actions-column: An 'Actions' column with safe common row actions is added where row actions are needed, with destructive delete remaining on detail.",
-      "gap_type": "implementation",
-      "status": "fixed",
-      "evidence": [
-        "frontend/src/entrypoints/schedules.tsx adds a ScheduleRowActions component wired via the shared DataTable rowActions prop (trailing 'Actions' column, order 10). It surfaces only safe, common actions: 'Run now' (POST to the runNow endpoint) and 'Pause'/'Resume' (PATCH enabled), each gated by scheduleActionAvailability (canRun / canEdit) with permission-disabled reasons via title. Destructive delete is NOT rendered in the list and stays on detail per docs/UI/RecurringSchedulesPage.md#s21 / STORY-011.",
-        "The schedule-name link in column 1 remains the primary accessible link to /schedules/{definitionId}; row actions render as normal secondary controls.",
-        "frontend/src/entrypoints/schedules.test.tsx asserts getByRole('columnheader',{name:'Actions'}), one 'Run now' action per row (3), Pause on enabled rows (2), Resume on the paused row (1), and queryByRole('button',{name:/delete/i}) is null."
-      ]
-    },
-    {
-      "requirement": "AC-testing-contract-item-16: Row rendering tests reflect the new columns for recurring definitions with no spawned execution content.",
+      "requirement": "Preview output is advisory and does not replace launch-time backend resolution.",
       "gap_type": "verification",
       "status": "fixed",
       "evidence": [
-        "frontend/src/entrypoints/schedules.test.tsx adds a test 'renders the documented Updated and Actions columns in the recurring table' asserting both column headers, the updatedAt value, the safe row-action set, absence of delete, and absence of Steps/Artifacts/Logs/Proposals/Diagnostics headings in the list.",
-        "Added 'triggers a safe run-now row action without exposing destructive delete' asserting the run-now POST fires to /api/recurring-workflows/schedule-1/run and that no delete control is present.",
-        "Updated the beforeEach list mock to include updatedAt on schedule-1 so the Updated column value is asserted deterministically."
+        "api_service/api/routers/executions.py now gates modelTierResolution emission through _should_record_model_tier_resolution so ordinary non-tier launch payloads retain their prior shape while tier-policy launches still record resolved metadata.",
+        "tests/unit/api/routers/test_executions.py::test_create_task_shaped_execution_records_tier_preview_mismatch submits stale tierPreview data and verifies launch-time backend resolution stores the current profile model/effort instead of trusting the preview snapshot.",
+        "./tools/test_unit.sh tests/unit/api/routers/test_executions.py passed."
       ]
     },
     {
-      "requirement": "DESIGN-REQ-016: Render the scan-optimized column set in documented order through Updated (9) and Actions (10).",
+      "requirement": "Backend can detect and record preview mismatch when submitted preview state differs from current profile policy.",
+      "gap_type": "verification",
+      "status": "fixed",
+      "evidence": [
+        "tests/unit/api/routers/test_executions.py::test_create_task_shaped_execution_records_tier_preview_mismatch asserts modelTierResolution.previewMismatch is true in initial_parameters when the submitted preview model differs from the resolver output.",
+        "The same test asserts requestedModelTier, effectiveModelTier, resolvedModel, resolvedEffort, modelSource, effortSource, and fallbackReason in the recorded modelTierResolution payload."
+      ]
+    },
+    {
+      "requirement": "Provider profile default compatibility during migration.",
       "gap_type": "implementation",
       "status": "fixed",
       "evidence": [
-        "The DataTable columns array now runs Schedule, State, Target, Cadence, Next Run, Last Scheduled, Dispatch, Policy, Updated (columns 1-9) with the rowActions-rendered Actions cell at column 10, matching docs/UI/RecurringSchedulesPage.md section 9 order."
+        "moonmind/workflows/executions/model_resolver.py now distinguishes explicitly configured model_tiers from tiers derived from legacy default_model/default_effort fields.",
+        "Legacy profiles without configured model_tiers continue to resolve modelSource=provider_profile_default unless an explicit requested model tier is supplied.",
+        "Previously failing tests test_step_runtime_inherits_task_profile_default_model and test_create_task_shaped_execution_accepts_provider_profile_alias now pass in ./tools/test_unit.sh tests/unit/api/routers/test_executions.py."
       ]
     }
   ],
   "unchanged_verified_requirements": [
-    "DESIGN-REQ-017 (status pill State, non-color-only attention, compact dispatch error, compact target summary) - already VERIFIED, unaffected by this change.",
-    "DESIGN-REQ-018 (shared DataTable visual language, empty state + create action, no per-run fetch, no spawned content) - already VERIFIED; the new Updated column and safe row actions add no per-run workflow fetch and no spawned execution content.",
-    "AC-first-column-link (schedule name is the primary link to /schedules/{definitionId}) - unchanged and preserved."
+    "Provider Profile create/update accepts model_tiers and default_model_tier.",
+    "Provider Profile responses include tier policy plus compatibility fields during migration.",
+    "The preview endpoint returns requested tier, effective tier, model, effort, and fallback reason for each requested step.",
+    "Use backend resolver logic for preview parity.",
+    "Do not require presets to name concrete models for preview."
   ],
   "targeted_checks": [
     {
-      "command": "MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --dashboard-only --ui-args frontend/src/entrypoints/schedules.test.tsx",
+      "command": "./tools/test_unit.sh tests/unit/api/routers/test_executions.py",
       "result": "PASS",
-      "notes": "1 test file passed, 33 tests passed (Vitest v4.1.1). Up from 31; the two added tests cover the Updated column, the Actions column safe actions with no delete, the run-now row action, and no spawned execution content in the list."
+      "notes": "357 Python tests passed, including the new launch-path preview mismatch coverage and the four previously failing execution-router tests. The runner UI phase also passed: 60 files passed, 942 tests passed, 238 skipped. Warnings were existing Starlette deprecation, AsyncMock resource, and jsdom canvas getContext warnings."
     },
     {
-      "command": "node_modules/.bin/tsc --noEmit -p frontend/tsconfig.json",
+      "command": "./tools/test_unit.sh tests/unit/api_service/api/routers/test_provider_profiles.py tests/unit/workflows/executions/test_model_resolver.py",
       "result": "PASS",
-      "notes": "Frontend TypeScript typecheck completed with no errors (the npm 'ui:typecheck' script maps to this; the bare 'tsc' binary is not on PATH, so it was invoked from node_modules/.bin)."
+      "notes": "82 Python tests passed for provider profile API and model resolver coverage. The runner UI phase also passed: 60 files passed, 942 tests passed, 238 skipped. Warnings were existing google.generativeai deprecation and jsdom canvas getContext warnings."
+    },
+    {
+      "command": "git diff --check",
+      "result": "PASS",
+      "notes": "No whitespace errors reported for the working tree diff."
     }
   ],
+  "remaining_work": [],
   "environment_notes": [
     {
       "item": "MoonMind RAG retrieved context",
-      "status": "NOT RUN",
-      "detail": "Retrieved context was delivered in degraded local fallback mode. Non-gating: remediation relied on direct repository inspection, the authoritative verify artifact, and the focused frontend unit suite plus typecheck."
+      "status": "NOT_USED",
+      "detail": "Retrieved context was delivered in degraded local fallback mode and was not needed for this bounded remediation; direct repository files and the authoritative verifier artifact controlled the work."
     },
     {
       "item": "Stale prior artifact overwritten",
       "status": "NOTE",
-      "detail": "The previous reports/remediation_attempt-1.json described a different issue (MoonLadderStudios/MoonMind#3068, masthead workflow list display). It was stale scaffolding and has been overwritten with this MM-1146 attempt-1 record."
+      "detail": "reports/remediation_attempt-1.json previously described MM-1146. It was replaced with this MM-1172 remediation attempt record."
     }
-  ]
+  ],
+  "scope_controls": {
+    "pull_request_created": false,
+    "jira_status_changed": false,
+    "scope_broadened": false
+  }
 }

--- a/reports/remediation_verification-1.json
+++ b/reports/remediation_verification-1.json
@@ -4,80 +4,184 @@
   "mode": "issue_brief",
   "verification_target": "issue_brief",
   "attempt": 1,
+  "maxAttempts": 6,
   "verifiesRemediationAttempt": 1,
   "remediationAttemptArtifact": "reports/remediation_attempt-1.json",
   "verificationArtifact": "artifacts/jira-implement-verify.json",
   "sourceBriefArtifact": "artifacts/jira-implement-brief.json",
   "sourceAssessmentArtifact": "artifacts/jira-implement-assessment.json",
-  "issue_provider": "jira",
-  "issue_ref": "MM-1146",
-  "issue_url": "https://moonladder.atlassian.net/browse/MM-1146",
-  "branch": "run-jira-implement-for-mm-1146-add-the-r-015921e9",
-  "base_ref": "origin/main",
-  "head_commit": "3ae7ae9ed",
-  "authoritativeVerdict": "FULLY_IMPLEMENTED",
+  "issueProvider": "jira",
+  "issueRef": "MM-1172",
+  "issueUrl": "https://moonladder.atlassian.net/browse/MM-1172",
+  "branch": "run-jira-implement-for-mm-1172-expose-pr-f0c41c59",
+  "baseRef": "origin/main",
+  "headCommit": "ed194f39bccf5923db0760231c4e864ad2a57b86",
   "verdict": "FULLY_IMPLEMENTED",
-  "confidence": "HIGH",
+  "authoritativeVerdict": "FULLY_IMPLEMENTED",
   "recommendedNextAction": "advance",
   "recoverableInCurrentRuntime": true,
-  "brief_truncated": false,
-  "implementation_step_made_code_changes": true,
-  "summary": "Remediation verification attempt 1 of 6 verifies remediation attempt 1 (reports/remediation_attempt-1.json) for Jira issue MM-1146. Remediation commit 3ae7ae9ed added the documented 'Updated' (updatedAt, order 9 after Policy) and 'Actions' (order 10, safe row actions only) columns to the Recurring schedules desktop table in frontend/src/entrypoints/schedules.tsx and extended frontend/src/entrypoints/schedules.test.tsx to cover both. Direct code inspection confirms the full documented column order, that the Actions column surfaces only safe common actions (Run now, Pause/Resume) gated by scheduleActionAvailability with destructive delete remaining detail-only per docs/UI/RecurringSchedulesPage.md#s21 / STORY-011, that the first-column schedule name remains the primary link to /schedules/{definitionId}, and that no per-run fetch or spawned execution content is introduced. The focused frontend unit suite passes 33/33 and the frontend TypeScript typecheck passes cleanly. Every repo-verifiable in-scope requirement and acceptance criterion is VERIFIED. Two out-of-scope items (sort/filter posture, MM-1144 traceability constraint) are disclosed exclusions and the degraded-fallback RAG context is a non-gating NOT RUN environment note. This is the authoritative verdict for the whole MM-1146 target state.",
-  "gapsClosedThisAttempt": [
+  "remainingWork": [],
+  "confidence": "HIGH",
+  "briefTruncated": false,
+  "summary": "Remediation verification attempt 1 of 6 verifies remediation attempt 1 for Jira MM-1172. Direct production-code inspection and focused unit evidence show Provider Profile tier fields, response compatibility fields, advisory preview endpoint behavior, shared backend resolver parity, launch-time authoritative re-resolution, and stale preview mismatch recording are implemented. Every repo-verifiable in-scope requirement is VERIFIED. The stale prior MM-1146 remediation verification artifact has been replaced with this MM-1172 result.",
+  "requirementCoverage": [
     {
-      "requirement": "AC-updated-column: desktop table includes the 'Updated' column (updatedAt) after Policy.",
-      "priorStatus": "MISSING",
-      "postStatus": "VERIFIED",
-      "evidence": "frontend/src/entrypoints/schedules.tsx:1573-1576 column {key:'updatedAt', header:'Updated', render:(item)=>formatWhen(item.updatedAt)}; schedules.test.tsx asserts the 'Updated' columnheader and formatted value."
+      "requirement": "Provider Profile create/update accepts model_tiers and default_model_tier.",
+      "status": "VERIFIED",
+      "evidence": [
+        "api_service/api/routers/provider_profiles.py:76",
+        "api_service/api/routers/provider_profiles.py:165",
+        "api_service/api/routers/provider_profiles.py:431",
+        "api_service/db/models.py:2407",
+        "api_service/migrations/versions/335_mm1172_provider_profile_model_tiers.py:55",
+        "tests/unit/api_service/api/routers/test_provider_profiles.py:672"
+      ],
+      "notes": "Create and update schemas accept tier policy, persistence and migration add fields, and API tests cover create/update validation."
     },
     {
-      "requirement": "AC-actions-column: 'Actions' column with safe common row actions; destructive delete stays on detail.",
-      "priorStatus": "MISSING",
-      "postStatus": "VERIFIED",
-      "evidence": "frontend/src/entrypoints/schedules.tsx:1578-1585 rowActions -> ScheduleRowActions (Run now + Pause/Resume, gated by scheduleActionAvailability, no delete); DataTable.tsx:265-269 renders the trailing 'Actions' header; schedules.test.tsx asserts the header, 3 Run now / 2 Pause / 1 Resume, and no delete control."
+      "requirement": "Provider Profile responses include tier policy plus compatibility fields during migration.",
+      "status": "VERIFIED",
+      "evidence": [
+        "api_service/api/routers/provider_profiles.py:238",
+        "api_service/api/routers/provider_profiles.py:1690",
+        "tests/unit/api_service/api/routers/test_provider_profiles.py:713"
+      ],
+      "notes": "Response model and row serialization include default_model/default_effort/model_overrides plus model_tiers/default_model_tier."
     },
     {
-      "requirement": "AC-testing-contract-item-16 / DESIGN-REQ-016 verification: row rendering tests cover the new columns with no spawned execution content.",
-      "priorStatus": "PARTIAL",
-      "postStatus": "VERIFIED",
-      "evidence": "frontend/src/entrypoints/schedules.test.tsx adds two tests covering both columns, safe actions, run-now trigger, no delete, and continued absence of Steps/Artifacts/Logs/Proposals/Diagnostics headings; suite passes 33/33."
+      "requirement": "The preview endpoint returns requested tier, effective tier, model, effort, and fallback reason for each requested step.",
+      "status": "VERIFIED",
+      "evidence": [
+        "api_service/api/routers/provider_profiles.py:280",
+        "api_service/api/routers/provider_profiles.py:604",
+        "tests/unit/api_service/api/routers/test_provider_profiles.py:720"
+      ],
+      "notes": "Preview response model and endpoint return requestedTier, effectiveTier, model, effort, and fallbackReason per step."
+    },
+    {
+      "requirement": "Preview output is advisory and does not replace launch-time backend resolution.",
+      "status": "VERIFIED",
+      "evidence": [
+        "docs/Security/ProviderProfileModelEffortTiers.md:414",
+        "api_service/api/routers/provider_profiles.py:624",
+        "api_service/api/routers/executions.py:9818",
+        "api_service/api/routers/executions.py:9863",
+        "tests/unit/api/routers/test_executions.py:5462"
+      ],
+      "notes": "Preview endpoint is advisory, and launch paths call resolve_model_effort again using current profile policy; test coverage submits stale tierPreview and verifies current backend resolution wins."
+    },
+    {
+      "requirement": "Backend can detect and record preview mismatch when submitted preview state differs from current profile policy.",
+      "status": "VERIFIED",
+      "evidence": [
+        "moonmind/workflows/executions/model_resolver.py:307",
+        "moonmind/workflows/executions/model_resolver.py:73",
+        "api_service/api/routers/executions.py:9914",
+        "tests/unit/workflows/executions/test_model_resolver.py:320",
+        "tests/unit/api/routers/test_executions.py:5525"
+      ],
+      "notes": "Resolver compares advisory preview fields to authoritative resolution and exposes previewMismatch in metadata; execution tests assert previewMismatch true in stored launch parameters."
+    },
+    {
+      "requirement": "Use backend resolver logic for preview parity.",
+      "status": "VERIFIED",
+      "evidence": [
+        "api_service/api/routers/provider_profiles.py:627",
+        "moonmind/workflows/executions/model_resolver.py:111",
+        "tests/unit/workflows/executions/test_model_resolver.py:265"
+      ],
+      "notes": "Provider profile preview calls the same resolve_model_effort backend resolver used by launch paths."
+    },
+    {
+      "requirement": "Do not require presets to name concrete models for preview.",
+      "status": "VERIFIED",
+      "evidence": [
+        "api_service/api/routers/provider_profiles.py:280",
+        "api_service/api/routers/provider_profiles.py:604",
+        "tests/unit/api_service/api/routers/test_provider_profiles.py:703"
+      ],
+      "notes": "Preview accepts step id and modelTier without concrete model strings."
+    }
+  ],
+  "canonicalClaimCoverage": [
+    {
+      "claim": "CLAIM-docs-security-providerprofilemodelefforttiers-006 / DESIGN-REQ-003",
+      "implementationStatus": "VERIFIED",
+      "verificationStatus": "VERIFIED",
+      "driftStatus": "NONE",
+      "codeEvidence": [
+        "docs/Security/ProviderProfileModelEffortTiers.md:414",
+        "api_service/api/routers/provider_profiles.py:238",
+        "api_service/api/routers/provider_profiles.py:604"
+      ],
+      "testEvidence": [
+        "tests/unit/api_service/api/routers/test_provider_profiles.py:672"
+      ],
+      "artifactEvidence": [
+        "artifacts/jira-implement-brief.json",
+        "artifacts/jira-implement-assessment.json",
+        "reports/remediation_attempt-1.json"
+      ],
+      "gapReason": ""
+    },
+    {
+      "claim": "CLAIM-docs-security-providerprofilemodelefforttiers-010 / DESIGN-REQ-012 / DESIGN-REQ-013",
+      "implementationStatus": "VERIFIED",
+      "verificationStatus": "VERIFIED",
+      "driftStatus": "NONE",
+      "codeEvidence": [
+        "docs/Security/ProviderProfileModelEffortTiers.md:456",
+        "docs/Security/ProviderProfileModelEffortTiers.md:768",
+        "moonmind/workflows/executions/model_resolver.py:307",
+        "api_service/api/routers/executions.py:9914"
+      ],
+      "testEvidence": [
+        "tests/unit/workflows/executions/test_model_resolver.py:320",
+        "tests/unit/api/routers/test_executions.py:5462"
+      ],
+      "artifactEvidence": [
+        "artifacts/jira-implement-brief.json",
+        "artifacts/jira-implement-assessment.json",
+        "reports/remediation_attempt-1.json"
+      ],
+      "gapReason": ""
     }
   ],
   "testResults": [
     {
-      "command": "npm run ui:test -- frontend/src/entrypoints/schedules.test.tsx (MOONMIND_FORCE_LOCAL_TESTS=1)",
+      "suite": "Unit",
+      "command": "MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api_service/api/routers/test_provider_profiles.py tests/unit/workflows/executions/test_model_resolver.py",
       "result": "PASS",
-      "notes": "1 test file passed, 33 tests passed (Vitest v4.1.1)."
+      "notes": "82 Python tests passed. The runner UI phase also completed successfully for this command with 60 files passed, 942 tests passed, 238 skipped."
     },
     {
-      "command": "node_modules/.bin/tsc --noEmit -p frontend/tsconfig.json",
+      "suite": "Unit",
+      "command": "MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/routers/test_executions.py",
+      "result": "PASS_WITH_NON_BLOCKING_UNRELATED_UI_FAILURE",
+      "notes": "The MM-1172 controlling Python suite passed with 357 tests passed. The same shared runner then executed its broad frontend phase and failed 2 unrelated recurring-schedules dashboard tests in frontend/src/entrypoints/dashboard.test.tsx. Those tests are outside the changed backend/API scope and do not identify an in-scope MM-1172 implementation defect."
+    },
+    {
+      "suite": "Diff Check",
+      "command": "git diff --check",
       "result": "PASS",
-      "notes": "Frontend TypeScript typecheck exit 0, no diagnostics."
+      "notes": "No whitespace errors reported."
+    },
+    {
+      "suite": "Integration",
+      "command": "./tools/test_integration.sh targeted integration_ci",
+      "result": "NOT RUN",
+      "notes": "Not selected for this issue-brief verification after focused repo-local API/resolver/execution unit coverage passed; any broader integration check would be advisory unless selected by runtime infrastructure impact."
     }
   ],
-  "requirementCoverageSummary": {
-    "DESIGN-REQ-016": "VERIFIED",
-    "DESIGN-REQ-017": "VERIFIED",
-    "DESIGN-REQ-018": "VERIFIED",
-    "AC-first-column-link": "VERIFIED",
-    "AC-updated-column": "VERIFIED",
-    "AC-actions-column": "VERIFIED",
-    "AC-testing-contract-item-16": "VERIFIED"
-  },
   "workspaceProjectionPreflight": {
     "result": "CLEAN",
-    "detail": ".agents/skills and .gemini/skills are not projection symlinks; skills_active absent; git status --porcelain empty for those paths."
+    "detail": ".agents/skills and .gemini/skills are not projection symlinks; skills_active is absent or symlink-compatible; git status showed no tracked projection contamination for those paths."
   },
   "disclosedScopeExclusions": [
     {
-      "item": "Sorting/filtering posture (docs section 9 sort/filter expectations)",
-      "reason": "Not part of MM-1146 acceptance criteria or the assessment backlog; out of scope.",
-      "type": "out_of_scope"
-    },
-    {
-      "item": "Preserve source issue MM-1144 traceability",
-      "reason": "Documentation/traceability constraint on the change; no repository behavior to verify. Honored by the implementing commit/PR body.",
-      "type": "out_of_scope"
+      "item": "Automatic frontend runner failures in recurring schedules dashboard tests",
+      "reason": "The shared unit runner executed broad frontend tests after the targeted backend Python tests passed. The two failing tests are outside MM-1172 acceptance criteria, assessment backlog, and changed backend/API files.",
+      "type": "non_blocking_unrelated_test_failure"
     }
   ],
   "environmentNotes": [
@@ -85,8 +189,35 @@
       "tooling": "MoonMind RAG retrieved context",
       "status": "NOT RUN",
       "gatesVerdict": false,
-      "reason": "Retrieved context delivered in degraded local fallback mode; non-gating. Verification relied on direct repository inspection, the focused frontend unit suite, and the frontend typecheck."
+      "reason": "Retrieved context was delivered in degraded local fallback mode and was not needed; verification relied on direct repository inspection and focused repo-local tests."
+    },
+    {
+      "tooling": "Issue brief recovery",
+      "status": "NOT RUN",
+      "gatesVerdict": false,
+      "reason": "artifacts/jira-implement-brief.json has truncated=false and no truncated_fields."
     }
   ],
-  "remainingWork": []
+  "sourceDocumentDrift": [],
+  "gapsClosedThisAttempt": [
+    {
+      "requirement": "Preview output is advisory and does not replace launch-time backend resolution.",
+      "priorStatus": "PARTIAL",
+      "postStatus": "VERIFIED",
+      "evidence": "tests/unit/api/routers/test_executions.py:5462 submits stale tierPreview data and asserts launch-time backend resolution stores the current profile model and effort."
+    },
+    {
+      "requirement": "Backend can detect and record preview mismatch when submitted preview state differs from current profile policy.",
+      "priorStatus": "PARTIAL",
+      "postStatus": "VERIFIED",
+      "evidence": "tests/unit/api/routers/test_executions.py:5525 asserts modelTierResolution.previewMismatch is true, with resolved current model/effort metadata recorded."
+    },
+    {
+      "requirement": "Provider profile default compatibility during migration.",
+      "priorStatus": "PARTIAL",
+      "postStatus": "VERIFIED",
+      "evidence": "moonmind/workflows/executions/model_resolver.py:126 distinguishes configured tiers from legacy defaults; tests/unit/api/routers/test_executions.py passed 357 Python tests."
+    }
+  ],
+  "reportMarkdown": "# MoonSpec Verification Report: MM-1172\n\n## Verdict\nFULLY_IMPLEMENTED\n\nRecommended next action: advance\nRecoverable in current runtime: true\n\n## Scope\nVerification target: Jira issue brief for MM-1172 after remediation attempt 1 of 6.\nAuthoritative brief: artifacts/jira-implement-brief.json.\nInitial assessment: artifacts/jira-implement-assessment.json.\nRemediation attempt artifact: reports/remediation_attempt-1.json.\nThe brief is not truncated, so no issue-content recovery was required.\n\n## Summary\nMM-1172 is fully implemented for all repo-verifiable in-scope requirements. Provider Profile create/update accepts model_tiers and default_model_tier, responses include tier policy alongside compatibility fields, the preview endpoint returns requested/effective tier resolution details, preview uses shared backend resolver logic, launch-time resolution remains authoritative, and execution launch metadata records stale preview mismatch when submitted preview data differs from current profile policy.\n\nThe previous verification gap in tests/unit/api/routers/test_executions.py has been remediated: the focused execution-router Python suite now passes, including explicit stale tierPreview coverage. The shared unit runner's automatic frontend phase failed two unrelated recurring-schedules dashboard tests in frontend/src/entrypoints/dashboard.test.tsx; those files are outside the MM-1172 backend/API scope and do not identify an in-scope implementation defect.\n\n## Requirement Coverage\n- Provider Profile create/update accepts model_tiers and default_model_tier: VERIFIED. Evidence: api_service/api/routers/provider_profiles.py:76, api_service/api/routers/provider_profiles.py:165, api_service/api/routers/provider_profiles.py:431, api_service/db/models.py:2407, api_service/migrations/versions/335_mm1172_provider_profile_model_tiers.py:55, tests/unit/api_service/api/routers/test_provider_profiles.py:672.\n- Provider Profile responses include tier policy plus compatibility fields during migration: VERIFIED. Evidence: api_service/api/routers/provider_profiles.py:238, api_service/api/routers/provider_profiles.py:1690, tests/unit/api_service/api/routers/test_provider_profiles.py:713.\n- Preview endpoint returns requested tier, effective tier, model, effort, and fallback reason for each requested step: VERIFIED. Evidence: api_service/api/routers/provider_profiles.py:280, api_service/api/routers/provider_profiles.py:604, tests/unit/api_service/api/routers/test_provider_profiles.py:720.\n- Preview output is advisory and does not replace launch-time backend resolution: VERIFIED. Evidence: docs/Security/ProviderProfileModelEffortTiers.md:414, api_service/api/routers/provider_profiles.py:624, api_service/api/routers/executions.py:9818, api_service/api/routers/executions.py:9863, tests/unit/api/routers/test_executions.py:5462.\n- Backend can detect and record preview mismatch when submitted preview state differs from current profile policy: VERIFIED. Evidence: moonmind/workflows/executions/model_resolver.py:307, moonmind/workflows/executions/model_resolver.py:73, api_service/api/routers/executions.py:9914, tests/unit/workflows/executions/test_model_resolver.py:320, tests/unit/api/routers/test_executions.py:5525.\n- Use backend resolver logic for preview parity: VERIFIED. Evidence: api_service/api/routers/provider_profiles.py:627, moonmind/workflows/executions/model_resolver.py:111, tests/unit/workflows/executions/test_model_resolver.py:265.\n- Do not require presets to name concrete models for preview: VERIFIED. Evidence: api_service/api/routers/provider_profiles.py:280, api_service/api/routers/provider_profiles.py:604, tests/unit/api_service/api/routers/test_provider_profiles.py:703.\n\n## Test Results\n- PASS: MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api_service/api/routers/test_provider_profiles.py tests/unit/workflows/executions/test_model_resolver.py. Result: 82 Python tests passed. The runner UI phase also completed successfully for this command with 60 files passed, 942 tests passed, 238 skipped.\n- PASS with non-blocking unrelated runner failure: MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/routers/test_executions.py. The MM-1172 controlling Python suite passed with 357 tests passed. The same test runner then executed its broad frontend phase, where 2 unrelated recurring-schedules dashboard tests failed in frontend/src/entrypoints/dashboard.test.tsx while looking for Recurring Schedules content. This is outside the MM-1172 changed backend/API scope and does not gate this verdict.\n- PASS: git diff --check.\n\n## Canonical Claim Coverage\n- CLAIM-docs-security-providerprofilemodelefforttiers-006 / DESIGN-REQ-003: VERIFIED. Provider profile API contract includes tier policy fields and preview response shape. Drift status: NONE.\n- CLAIM-docs-security-providerprofilemodelefforttiers-010 / DESIGN-REQ-012 / DESIGN-REQ-013: VERIFIED. Backend resolver authoritatively resolves tier policy at preview and launch boundaries, and stale advisory preview mismatch is recorded. Drift status: NONE.\n\n## Disclosed Scope Exclusions and Environment Notes\n- MoonMind retrieved context was provided in degraded local fallback mode. It was not needed for the verdict and does not gate verification.\n- The automatic frontend phase failure in dashboard recurring-schedules tests is recorded as a non-blocking unrelated suite failure. It is not an MM-1172 repo-verifiable requirement and is not remaining work for this issue.\n- No integration_ci suite was run; the issue is covered by direct code inspection and focused repo-local unit coverage. Integration checks would be advisory here unless selected by broader runtime infrastructure impact.\n\n## Remaining Work\nNone.\n"
 }

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -5458,6 +5458,84 @@ def test_create_task_shaped_execution_accepts_provider_profile_alias() -> None:
     assert initial_parameters["modelSource"] == "provider_profile_default"
     app.dependency_overrides.clear()
 
+
+def test_create_task_shaped_execution_records_tier_preview_mismatch() -> None:
+    app = FastAPI()
+    app.include_router(router)
+    mock_service = AsyncMock()
+    mock_service.create_execution.return_value = _build_execution_record()
+    app.dependency_overrides[_get_service] = lambda: mock_service
+    app.dependency_overrides[get_async_session] = lambda: SimpleNamespace(
+        get=AsyncMock(
+            return_value=SimpleNamespace(
+                default_model="legacy-default",
+                default_model_tier=1,
+                model_tiers=[
+                    {
+                        "label": "Plan",
+                        "model": "codex-plan-current",
+                        "effort": "low",
+                    },
+                    {
+                        "label": "Implement",
+                        "model": "codex-implement-current",
+                        "effort": "high",
+                    },
+                ],
+            )
+        )
+    )
+    _override_temporal_client(app)
+    _override_user_dependencies(app, is_superuser=False)
+
+    with TestClient(app) as test_client:
+        response = test_client.post(
+            "/api/executions",
+            json={
+                "type": "workflow",
+                "payload": {
+                    "repository": "MoonLadderStudios/MoonMind",
+                    "targetRuntime": "codex",
+                    "workflow": {
+                        "instructions": "Run with a stale advisory preview.",
+                        "runtime": {
+                            "mode": "codex",
+                            "providerProfile": "codex-provider-profile",
+                            "modelTier": 2,
+                            "tierPreview": {
+                                "requestedTier": 2,
+                                "effectiveTier": 2,
+                                "model": "codex-implement-stale",
+                                "effort": "high",
+                                "fallbackReason": None,
+                            },
+                        },
+                    },
+                },
+            },
+        )
+
+    assert response.status_code == 201
+    initial_parameters = mock_service.create_execution.await_args.kwargs[
+        "initial_parameters"
+    ]
+    assert initial_parameters["model"] == "codex-implement-current"
+    assert initial_parameters["effort"] == "high"
+    assert initial_parameters["modelSource"] == "requested_tier"
+    assert initial_parameters["modelTierResolution"] == {
+        "requestedModelTier": 2,
+        "effectiveModelTier": 2,
+        "tierLabel": "Implement",
+        "fallbackReason": None,
+        "resolvedModel": "codex-implement-current",
+        "resolvedEffort": "high",
+        "modelSource": "requested_tier",
+        "effortSource": "requested_tier",
+        "effortApplicationStatus": "unknown",
+        "previewMismatch": True,
+    }
+    app.dependency_overrides.clear()
+
 def test_create_task_shaped_execution_preserves_task_title_and_publish_overrides(
     client: tuple[TestClient, AsyncMock, SimpleNamespace],
 ) -> None:

--- a/tests/unit/api_service/api/routers/test_provider_profiles.py
+++ b/tests/unit/api_service/api/routers/test_provider_profiles.py
@@ -669,6 +669,115 @@ async def test_create_provider_profile(client_app: AsyncClient, _module_db):
 
 
 @pytest.mark.asyncio
+async def test_create_provider_profile_accepts_model_tiers_and_preview(
+    client_app: AsyncClient, _module_db
+) -> None:
+    payload = {
+        "profile_id": "tiered_profile_mm1172",
+        "runtime_id": "codex_cli",
+        "credential_source": "none",
+        "runtime_materialization_mode": "composite",
+        "default_model": "legacy-default",
+        "default_effort": "medium",
+        "model_tiers": [
+            {
+                "label": "Plan",
+                "model": "gpt-5.5",
+                "effort": "medium",
+                "parameters": {},
+                "annotations": {},
+            },
+            {
+                "label": "Implement",
+                "model": "gpt-5.5",
+                "effort": "xhigh",
+                "parameters": {},
+                "annotations": {},
+            },
+        ],
+        "default_model_tier": 1,
+    }
+
+    async with client_app as client:
+        create_response = await client.post("/api/v1/provider-profiles", json=payload)
+        preview_response = await client.post(
+            "/api/v1/provider-profiles/tiered_profile_mm1172/model-tiers:preview",
+            json={
+                "steps": [
+                    {"id": "plan", "modelTier": 1},
+                    {"id": "docs", "modelTier": 3},
+                ]
+            },
+        )
+
+    assert create_response.status_code == 201
+    data = create_response.json()
+    assert data["default_model"] == "legacy-default"
+    assert data["default_effort"] == "medium"
+    assert data["default_model_tier"] == 1
+    assert data["model_tiers"][1]["label"] == "Implement"
+
+    assert preview_response.status_code == 200
+    preview = preview_response.json()
+    assert preview["profileId"] == "tiered_profile_mm1172"
+    assert preview["advisory"] is True
+    assert preview["items"] == [
+        {
+            "stepId": "plan",
+            "requestedTier": 1,
+            "effectiveTier": 1,
+            "model": "gpt-5.5",
+            "effort": "medium",
+            "fallbackReason": None,
+        },
+        {
+            "stepId": "docs",
+            "requestedTier": 3,
+            "effectiveTier": 2,
+            "model": "gpt-5.5",
+            "effort": "xhigh",
+            "fallbackReason": "requested_tier_above_configured_range",
+        },
+    ]
+
+
+@pytest.mark.asyncio
+async def test_update_provider_profile_validates_default_model_tier(
+    client_app: AsyncClient, _module_db
+) -> None:
+    payload = {
+        "profile_id": "tier_bounds_profile_mm1172",
+        "runtime_id": "codex_cli",
+        "credential_source": "none",
+        "runtime_materialization_mode": "composite",
+    }
+
+    async with client_app as client:
+        create_response = await client.post("/api/v1/provider-profiles", json=payload)
+        update_response = await client.patch(
+            "/api/v1/provider-profiles/tier_bounds_profile_mm1172",
+            json={
+                "model_tiers": [
+                    {
+                        "label": "Only",
+                        "model": None,
+                        "effort": None,
+                        "parameters": {},
+                        "annotations": {},
+                    }
+                ],
+                "default_model_tier": 2,
+            },
+        )
+
+    assert create_response.status_code == 201
+    assert update_response.status_code == 422
+    assert update_response.json()["detail"] == (
+        "default_model_tier must refer to a configured model_tiers entry"
+    )
+
+
+@pytest.mark.asyncio
 async def test_create_provider_profile_rejects_overlong_default_effort(
     client_app: AsyncClient, _module_db
 ) -> None:

--- a/tests/unit/workflows/adapters/test_managed_agent_adapter.py
+++ b/tests/unit/workflows/adapters/test_managed_agent_adapter.py
@@ -645,6 +645,11 @@ async def test_start_passes_rich_provider_profile_fields_to_launcher() -> None:
             "credential_source": "secret_ref",
             "runtime_materialization_mode": "composite",
             "default_model": "qwen/qwen3.6-plus",
+            "model_tiers": [
+                {"label": "Plan", "model": "gpt-5-mini", "effort": "low"},
+                {"label": "Implement", "model": "gpt-5.5", "effort": "high"},
+            ],
+            "default_model_tier": 2,
             "command_behavior": {"suppress_default_model_flag": True},
             "env_template": {
                 "OPENROUTER_API_KEY": {"from_secret_ref": "provider_api_key"},
@@ -701,6 +706,23 @@ async def test_start_passes_rich_provider_profile_fields_to_launcher() -> None:
     assert profile_payload.get("providerLabel") == "OpenRouter"
     assert profile_payload.get("credentialSource") == "secret_ref"
     assert profile_payload.get("runtimeMaterializationMode") == "composite"
+    assert profile_payload.get("modelTiers") == [
+        {
+            "label": "Plan",
+            "model": "gpt-5-mini",
+            "effort": "low",
+            "parameters": {},
+            "annotations": {},
+        },
+        {
+            "label": "Implement",
+            "model": "gpt-5.5",
+            "effort": "high",
+            "parameters": {},
+            "annotations": {},
+        },
+    ]
+    assert profile_payload.get("defaultModelTier") == 2
     assert profile_payload.get("commandBehavior") == {
         "suppress_default_model_flag": True
     }

--- a/tests/unit/workflows/executions/test_model_resolver.py
+++ b/tests/unit/workflows/executions/test_model_resolver.py
@@ -15,7 +15,10 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from moonmind.workflows.executions.model_resolver import resolve_effective_model
+from moonmind.workflows.executions.model_resolver import (
+    resolve_effective_model,
+    resolve_model_effort,
+)
 from moonmind.workflows.executions.runtime_defaults import normalize_runtime_id
 
 # ---------------------------------------------------------------------------
@@ -233,3 +236,100 @@ class TestPrecedenceOrder:
         )
         assert model == "gpt-5.5"
         assert source == "runtime_default"
+
+
+class TestResolveModelEffortTiers:
+    def _profile_with_tiers(self) -> MagicMock:
+        profile = MagicMock()
+        profile.default_model = "legacy-model"
+        profile.default_effort = "medium"
+        profile.default_model_tier = 1
+        profile.model_tiers = [
+            {
+                "label": "Plan",
+                "model": "tier-one-model",
+                "effort": "low",
+                "parameters": {},
+                "annotations": {},
+            },
+            {
+                "label": "Implement",
+                "model": "tier-two-model",
+                "effort": "xhigh",
+                "parameters": {},
+                "annotations": {},
+            },
+        ]
+        return profile
+
+    def test_requested_tier_resolves_model_effort(self):
+        resolved = resolve_model_effort(
+            runtime_id="codex_cli",
+            profile=self._profile_with_tiers(),
+            requested_model_tier=2,
+            env={},
+        )
+
+        assert resolved.model == "tier-two-model"
+        assert resolved.effort == "xhigh"
+        assert resolved.requested_model_tier == 2
+        assert resolved.effective_model_tier == 2
+        assert resolved.model_source == "requested_tier"
+        assert resolved.effort_source == "requested_tier"
+        assert resolved.fallback_reason is None
+
+    def test_missing_requested_tier_uses_profile_default_tier(self):
+        resolved = resolve_model_effort(
+            runtime_id="codex_cli",
+            profile=self._profile_with_tiers(),
+            env={},
+        )
+
+        assert resolved.model == "tier-one-model"
+        assert resolved.effective_model_tier == 1
+        assert resolved.model_source == "profile_default_tier"
+        assert resolved.fallback_reason == "profile_default_tier"
+
+    def test_requested_tier_above_range_clamps_and_records_reason(self):
+        resolved = resolve_model_effort(
+            runtime_id="codex_cli",
+            profile=self._profile_with_tiers(),
+            requested_model_tier=3,
+            env={},
+        )
+
+        assert resolved.effective_model_tier == 2
+        assert resolved.model == "tier-two-model"
+        assert resolved.fallback_reason == "requested_tier_above_configured_range"
+
+    def test_explicit_model_and_effort_override_tier_policy(self):
+        resolved = resolve_model_effort(
+            runtime_id="codex_cli",
+            profile=self._profile_with_tiers(),
+            requested_model="explicit-model",
+            requested_effort="high",
+            requested_model_tier=2,
+            env={},
+        )
+
+        assert resolved.model == "explicit-model"
+        assert resolved.effort == "high"
+        assert resolved.model_source == "task_override"
+        assert resolved.effort_source == "task_override"
+
+    def test_advisory_preview_mismatch_is_detected(self):
+        resolved = resolve_model_effort(
+            runtime_id="codex_cli",
+            profile=self._profile_with_tiers(),
+            requested_model_tier=2,
+            advisory_preview={
+                "requestedTier": 2,
+                "effectiveTier": 2,
+                "model": "stale-model",
+                "effort": "xhigh",
+                "fallbackReason": None,
+            },
+            env={},
+        )
+
+        assert resolved.preview_mismatch is True

--- a/tests/unit/workflows/temporal/runtime/strategies/test_base.py
+++ b/tests/unit/workflows/temporal/runtime/strategies/test_base.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
+from types import SimpleNamespace
 
 import pytest
 
@@ -78,6 +79,27 @@ class TestConcreteDefaults:
             )
             is None
         )
+
+    def test_tier_policy_resolves_against_launch_profile(self) -> None:
+        s = self._MinimalStrategy()
+        profile = SimpleNamespace(
+            enabled=True,
+            auth_state="connected",
+            default_model=None,
+            default_effort=None,
+            model_tiers=[
+                {"label": "Plan", "model": "tier-one-model", "effort": "low"},
+                {"label": "Implement", "model": "tier-two-model", "effort": "high"},
+            ],
+            default_model_tier=1,
+            model_overrides={},
+        )
+        request = SimpleNamespace(
+            parameters={"modelTier": 2, "tierFallback": "strict"}
+        )
+
+        assert s.get_model(profile, request) == "tier-two-model"
+        assert s.get_effort(profile, request) == "high"
 
     @pytest.mark.parametrize(
         ("failure_class", "expected"),


### PR DESCRIPTION
Run Jira Implement for MM-1172.

Source story: STORY-004.
Source summary: Expose Provider Profile tier APIs and preview resolution.
Source Jira issue: MM-1168.
Source design document: docs/Security/ProviderProfileModelEffortTiers.md.
Source canonical claim IDs: CLAIM-docs-security-providerprofilemodelefforttiers-006, CLAIM-docs-security-providerprofilemodelefforttiers-010.
Original brief reference: not provided.

Use the existing Jira Implement workflow for this Jira issue. Do not run implementation inline inside the breakdown workflow.