### PR TITLE
Fix batch workflow fan-out validation

### DIFF
--- a/.agents/skills/batch-dependabot-resolver/SKILL.md
+++ b/.agents/skills/batch-dependabot-resolver/SKILL.md
@@ -92,7 +92,9 @@ python3 .agents/skills/batch-dependabot-resolver/bin/batch_dependabot_resolver.p
    `task.git.startingBranch/branch`, `task.skill.name = pr-resolver`,
    `task.publish.mode = auto`, inherited runtime) and a stable idempotency key:
    `batch-dependabot-resolver:{repo}:pr:{number}:head:{headSha}`. Submit via
-   `POST /api/executions` (`MOONMIND_URL` must point at the MoonMind API).
+   `POST /api/executions`, require the canonical `workflowId`, and verify it via
+   `GET /api/executions/{workflowId}` before counting the child as queued
+   (`MOONMIND_URL` must point at the MoonMind API).
 
 5. Write a summary artifact `batch_dependabot_resolver_result.json` (under the managed
    session artifact spool when available, otherwise the configured `--artifacts-dir`) listing

--- a/.agents/skills/batch-dependabot-resolver/SKILL.md
+++ b/.agents/skills/batch-dependabot-resolver/SKILL.md
@@ -89,7 +89,7 @@ python3 .agents/skills/batch-dependabot-resolver/bin/batch_dependabot_resolver.p
 
 4. For each matched PR, submit a `pr-resolver` task with the canonical `batch-pr-resolver`
    payload (`repository`, `task.inputs = { repo, pr, branch, mergeMethod, maxIterations }`,
-   `task.git.startingBranch/targetBranch`, `task.skill.name = pr-resolver`,
+   `task.git.startingBranch/branch`, `task.skill.name = pr-resolver`,
    `task.publish.mode = auto`, inherited runtime) and a stable idempotency key:
    `batch-dependabot-resolver:{repo}:pr:{number}:head:{headSha}`. Submit via
    `POST /api/executions` (`MOONMIND_URL` must point at the MoonMind API).

--- a/.agents/skills/batch-dependabot-resolver/bin/batch_dependabot_resolver.py
+++ b/.agents/skills/batch-dependabot-resolver/bin/batch_dependabot_resolver.py
@@ -621,7 +621,7 @@ def _build_queue_request(
             },
             "git": {
                 "startingBranch": branch,
-                "targetBranch": branch,
+                "branch": branch,
             },
             "publish": {"mode": publish_mode},
         },
@@ -842,7 +842,7 @@ def _write_artifacts(path: Path, payload: dict[str, Any]) -> None:
 
 
 def _write_run_artifacts(artifacts_dir: Path, payload: dict[str, Any]) -> None:
-    """Write the result payload and (when applicable) the no-op outcome file.
+    """Write the result payload and its explicit non-success outcome marker.
 
     ``skill_outcome.json`` with ``status: "no_op"`` is written only when the run
     queued zero executions, hit no submission errors, and was not a dry run —
@@ -850,9 +850,24 @@ def _write_run_artifacts(artifacts_dir: Path, payload: dict[str, Any]) -> None:
     """
 
     _write_artifacts(artifacts_dir / "batch_dependabot_resolver_result.json", payload)
-    if (
-        payload.get("created") == 0
-        and not payload.get("errors")
+    errors = payload.get("errors") or []
+    created = int(payload.get("created") or 0)
+    if errors:
+        _write_artifacts(
+            artifacts_dir / "skill_outcome.json",
+            {
+                "schema_version": 1,
+                "status": "partial" if created else "failed",
+                "reason": "child_workflow_queue_failed",
+                "evidence": {
+                    "requested": payload.get("requested"),
+                    "created": created,
+                    "errors": errors,
+                },
+            },
+        )
+    elif (
+        created == 0
         and not payload.get("dryRun")
     ):
         _write_artifacts(

--- a/.agents/skills/batch-dependabot-resolver/bin/batch_dependabot_resolver.py
+++ b/.agents/skills/batch-dependabot-resolver/bin/batch_dependabot_resolver.py
@@ -24,6 +24,7 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
+from urllib.parse import quote
 
 import httpx
 from moonmind.workflows.executions.runtime_defaults import normalize_runtime_id
@@ -33,6 +34,7 @@ logger = logging.getLogger(__name__)
 
 API_EXECUTIONS_ENDPOINT = "/api/executions"
 IDEMPOTENCY_KEY_MAX_LENGTH = 128
+TERMINAL_FAILURE_STATES = {"failed", "canceled", "terminated"}
 DEFAULT_TITLE_REGEX = r"^Bump .+ from \S+ to \S+(?: in /.+)?$"
 DEPENDABOT_BRANCH_PREFIX = "dependabot/"
 
@@ -736,6 +738,8 @@ async def _submit_jobs_via_http(
     *,
     moonmind_url: str,
     worker_token: str | None,
+    verify_attempts: int = 5,
+    verify_delay_seconds: float = 1.0,
 ) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
     created: list[dict[str, Any]] = []
     errors: list[dict[str, Any]] = []
@@ -764,20 +768,23 @@ async def _submit_jobs_via_http(
                 response = await client.post(API_EXECUTIONS_ENDPOINT, json=body)
                 response.raise_for_status()
                 data = response.json()
-                job_id = (
-                    str(
-                        data.get("workflowId")
-                        or data.get("taskId")
-                        or data.get("id")
-                        or ""
-                    )
-                    or "(unknown)"
+                workflow_id = str(data.get("workflowId") or "").strip()
+                if not workflow_id:
+                    raise RuntimeError("create response did not include workflowId")
+                described = await _verify_execution_visible(
+                    client,
+                    workflow_id,
+                    attempts=verify_attempts,
+                    delay_seconds=verify_delay_seconds,
                 )
                 created.append(
                     {
                         "pr": submission.pr_number,
                         "branch": submission.branch,
-                        "jobId": job_id,
+                        "workflowId": workflow_id,
+                        "runId": described.get("runId") or data.get("runId"),
+                        "state": described.get("state"),
+                        "temporalStatus": described.get("temporalStatus"),
                     }
                 )
             except Exception as exc:  # noqa: BLE001 - record per-PR submission errors
@@ -785,10 +792,52 @@ async def _submit_jobs_via_http(
                     {
                         "pr": submission.pr_number,
                         "branch": submission.branch,
-                        "error": str(exc),
+                        "error": _http_error_text(exc),
                     }
                 )
     return created, errors
+
+
+def _http_error_text(exc: Exception) -> str:
+    if isinstance(exc, httpx.HTTPStatusError):
+        body = exc.response.text.strip()
+        return f"{exc.response.status_code} {exc.response.reason_phrase}: {body[:500]}"
+    return str(exc)
+
+
+async def _verify_execution_visible(
+    client: httpx.AsyncClient,
+    workflow_id: str,
+    *,
+    attempts: int,
+    delay_seconds: float,
+) -> dict[str, Any]:
+    encoded_workflow_id = quote(workflow_id, safe="")
+    last_error = "not checked"
+    for attempt in range(1, max(1, attempts) + 1):
+        try:
+            response = await client.get(
+                f"{API_EXECUTIONS_ENDPOINT}/{encoded_workflow_id}"
+            )
+            response.raise_for_status()
+            data = response.json()
+            actual_workflow_id = str(data.get("workflowId") or "").strip()
+            if actual_workflow_id != workflow_id:
+                raise RuntimeError(
+                    "describe returned workflowId "
+                    f"{actual_workflow_id!r}, expected {workflow_id!r}"
+                )
+            state = str(data.get("state") or "").strip().lower()
+            if state in TERMINAL_FAILURE_STATES:
+                raise RuntimeError(
+                    f"execution {workflow_id} is already terminal state {state}"
+                )
+            return data
+        except Exception as exc:  # noqa: BLE001 - preserve verification evidence
+            last_error = _http_error_text(exc)
+            if attempt < max(1, attempts) and delay_seconds > 0:
+                await asyncio.sleep(delay_seconds)
+    raise RuntimeError(f"workflow {workflow_id} was not verified: {last_error}")
 
 
 async def _submit_jobs(

--- a/.agents/skills/batch-pr-resolver/SKILL.md
+++ b/.agents/skills/batch-pr-resolver/SKILL.md
@@ -80,10 +80,15 @@ python3 .agents/skills/batch-pr-resolver/bin/batch_pr_resolver.py \
      - `payload.task.publish.mode`: `auto`
      - `payload.task.skill.name`: `pr-resolver`
      - `payload.task.inputs`: `{ repo, pr, branch, mergeMethod, maxIterations }`
-   - Submit via the internal Temporal execution API (`POST /api/executions`);
+   - Submit via the internal Temporal execution API (`POST /api/executions`),
+     require the canonical `workflowId` in the response, and verify that ID via
+     `GET /api/executions/{workflowId}` before counting it as queued;
      `MOONMIND_URL` must point at the MoonMind API from the managed session.
 4. Write one summary artifact at `batch_pr_resolver_result.json` under the managed session artifact spool path when available, otherwise under the configured `--artifacts-dir`.
-5. Print a short count summary to stdout (`queued`, `skipped`, `errors`).
+5. On any submission or verification error, write `skill_outcome.json` with a
+   `failed` or `partial` status so the managed runtime cannot report the batch
+   as successful.
+6. Print a short count summary to stdout (`queued`, `skipped`, `errors`).
 
 ## Safety constraints
 

--- a/.agents/skills/batch-pr-resolver/bin/batch_pr_resolver.py
+++ b/.agents/skills/batch-pr-resolver/bin/batch_pr_resolver.py
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 
 API_EXECUTIONS_ENDPOINT = "/api/executions"
 IDEMPOTENCY_KEY_MAX_LENGTH = 128
-TERMINAL_FAILURE_STATES = {"failed", "canceled"}
+TERMINAL_FAILURE_STATES = {"failed", "canceled", "terminated"}
 
 @dataclass
 class JobSubmission:

--- a/.agents/skills/batch-pr-resolver/bin/batch_pr_resolver.py
+++ b/.agents/skills/batch-pr-resolver/bin/batch_pr_resolver.py
@@ -15,6 +15,7 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
+from urllib.parse import quote
 
 import httpx
 from moonmind.workflows.executions.execution_contract import resolve_publish_mode_for_skill
@@ -24,6 +25,7 @@ logger = logging.getLogger(__name__)
 
 API_EXECUTIONS_ENDPOINT = "/api/executions"
 IDEMPOTENCY_KEY_MAX_LENGTH = 128
+TERMINAL_FAILURE_STATES = {"failed", "canceled"}
 
 @dataclass
 class JobSubmission:
@@ -515,7 +517,7 @@ def _build_queue_request(
             },
             "git": {
                 "startingBranch": branch,
-                "targetBranch": branch,
+                "branch": branch,
             },
             "publish": {"mode": publish_mode},
         },
@@ -633,6 +635,8 @@ async def _submit_jobs_via_http(
     *,
     moonmind_url: str,
     worker_token: str | None,
+    verify_attempts: int = 5,
+    verify_delay_seconds: float = 1.0,
 ) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
     """Submit jobs to the MoonMind queue API (Temporal-aware path)."""
     created: list[dict[str, Any]] = []
@@ -666,20 +670,23 @@ async def _submit_jobs_via_http(
                 response = await client.post(API_EXECUTIONS_ENDPOINT, json=body)
                 response.raise_for_status()
                 data = response.json()
-                job_id = (
-                    str(
-                        data.get("workflowId")
-                        or data.get("taskId")
-                        or data.get("id")
-                        or ""
-                    )
-                    or "(unknown)"
+                workflow_id = str(data.get("workflowId") or "").strip()
+                if not workflow_id:
+                    raise RuntimeError("create response did not include workflowId")
+                described = await _verify_execution_visible(
+                    client,
+                    workflow_id,
+                    attempts=verify_attempts,
+                    delay_seconds=verify_delay_seconds,
                 )
                 created.append(
                     {
                         "pr": submission.pr_number,
                         "branch": submission.branch,
-                        "jobId": job_id,
+                        "workflowId": workflow_id,
+                        "runId": described.get("runId") or data.get("runId"),
+                        "state": described.get("state"),
+                        "temporalStatus": described.get("temporalStatus"),
                     }
                 )
             except Exception as exc:
@@ -687,10 +694,52 @@ async def _submit_jobs_via_http(
                     {
                         "pr": submission.pr_number,
                         "branch": submission.branch,
-                        "error": str(exc),
+                        "error": _http_error_text(exc),
                     }
                 )
     return created, errors
+
+
+def _http_error_text(exc: Exception) -> str:
+    if isinstance(exc, httpx.HTTPStatusError):
+        body = exc.response.text.strip()
+        return f"{exc.response.status_code} {exc.response.reason_phrase}: {body[:500]}"
+    return str(exc)
+
+
+async def _verify_execution_visible(
+    client: httpx.AsyncClient,
+    workflow_id: str,
+    *,
+    attempts: int,
+    delay_seconds: float,
+) -> dict[str, Any]:
+    encoded_workflow_id = quote(workflow_id, safe="")
+    last_error = "not checked"
+    for attempt in range(1, max(1, attempts) + 1):
+        try:
+            response = await client.get(
+                f"{API_EXECUTIONS_ENDPOINT}/{encoded_workflow_id}"
+            )
+            response.raise_for_status()
+            data = response.json()
+            actual_workflow_id = str(data.get("workflowId") or "").strip()
+            if actual_workflow_id != workflow_id:
+                raise RuntimeError(
+                    "describe returned workflowId "
+                    f"{actual_workflow_id!r}, expected {workflow_id!r}"
+                )
+            state = str(data.get("state") or "").strip().lower()
+            if state in TERMINAL_FAILURE_STATES:
+                raise RuntimeError(
+                    f"execution {workflow_id} is already terminal state {state}"
+                )
+            return data
+        except Exception as exc:  # noqa: BLE001 - preserve verification evidence
+            last_error = _http_error_text(exc)
+            if attempt < max(1, attempts) and delay_seconds > 0:
+                await asyncio.sleep(delay_seconds)
+    raise RuntimeError(f"workflow {workflow_id} was not verified: {last_error}")
 
 async def _submit_jobs(
     queue_requests: list[JobSubmission],
@@ -777,7 +826,7 @@ def _write_artifacts(path: Path, payload: dict[str, Any]) -> None:
     path.write_text(json.dumps(payload, indent=2))
 
 def _write_run_artifacts(artifacts_dir: Path, payload: dict[str, Any]) -> None:
-    """Write the result payload and (when applicable) the no-op outcome file.
+    """Write the result payload and its explicit non-success outcome marker.
 
     A ``skill_outcome.json`` with ``status: "no_op"`` is written only when the
     run produced zero queued executions AND encountered no errors — i.e. the
@@ -786,7 +835,23 @@ def _write_run_artifacts(artifacts_dir: Path, payload: dict[str, Any]) -> None:
     the run as succeeded with a ``no_op`` disposition.
     """
     _write_artifacts(artifacts_dir / "batch_pr_resolver_result.json", payload)
-    if payload["created"] == 0 and not payload["errors"]:
+    errors = payload["errors"]
+    created = payload["created"]
+    if errors:
+        _write_artifacts(
+            artifacts_dir / "skill_outcome.json",
+            {
+                "schema_version": 1,
+                "status": "partial" if created else "failed",
+                "reason": "child_workflow_queue_failed",
+                "evidence": {
+                    "requested": payload["requested"],
+                    "created": created,
+                    "errors": errors,
+                },
+            },
+        )
+    elif created == 0:
         _write_artifacts(
             artifacts_dir / "skill_outcome.json",
             {

--- a/moonmind/workflows/temporal/runtime/codex_session_runtime.py
+++ b/moonmind/workflows/temporal/runtime/codex_session_runtime.py
@@ -158,6 +158,7 @@ class _ThreadRecoveryResult:
 
 _SKILL_OUTCOME_FILENAME = "skill_outcome.json"
 _SKILL_OUTCOME_SCHEMA_VERSION = 1
+_SKILL_OUTCOME_FAILURE_STATUSES = frozenset({"failed", "partial"})
 _SKILL_OUTCOME_FRESHNESS_SKEW_SECONDS = 2.0
 
 @dataclass
@@ -1827,17 +1828,17 @@ class CodexManagedSessionRuntime:
     ) -> dict[str, Any] | None:
         """Read the optional skill-declared outcome file from the spool.
 
-        Returns the parsed object only when it is a valid no-op declaration
-        produced during the current turn: single JSON object,
-        ``schema_version == 1``, ``status == "no_op"``, and file ``mtime``
-        at or after ``turn_started_at`` (minus a small skew tolerance for
-        filesystem granularity). ``send_turn`` removes any pre-existing
+        Returns the parsed object only when it is a valid declaration produced
+        during the current turn: single JSON object, ``schema_version == 1``,
+        a supported status (``no_op``, ``failed``, or ``partial``), and file
+        ``mtime`` at or after ``turn_started_at`` (minus a small skew tolerance
+        for filesystem granularity). ``send_turn`` removes any pre-existing
         marker at turn start; this freshness check is defense in depth.
 
         Any other shape (missing file, malformed JSON, wrong version, other
         status, stale mtime, or no turn-start timestamp) returns ``None`` so
-        the caller falls back to default classification. A malformed or
-        stale declaration cannot upgrade a failure to a success.
+        the caller falls back to default classification. A malformed or stale
+        declaration cannot change the runtime outcome.
         """
         if turn_started_at is None:
             return None
@@ -1863,9 +1864,30 @@ class CodexManagedSessionRuntime:
             return None
         if payload.get("schema_version") != _SKILL_OUTCOME_SCHEMA_VERSION:
             return None
-        if payload.get("status") != "no_op":
+        if payload.get("status") not in {
+            "no_op",
+            *_SKILL_OUTCOME_FAILURE_STATUSES,
+        }:
             return None
         return payload
+
+    @staticmethod
+    def _declared_skill_failure(
+        skill_outcome: Mapping[str, Any] | None,
+    ) -> _TurnTerminalOutcome | None:
+        if not isinstance(skill_outcome, Mapping):
+            return None
+        status = str(skill_outcome.get("status") or "").strip()
+        if status not in _SKILL_OUTCOME_FAILURE_STATUSES:
+            return None
+        reason = str(skill_outcome.get("reason") or "").strip()
+        if not reason:
+            reason = f"skill declared {status} outcome"
+        return _TurnTerminalOutcome(
+            status="failed",
+            error_text=reason,
+            failure_class="permanent",
+        )
 
     def _rollout_terminal_outcome_from_scan(
         self,
@@ -1880,6 +1902,12 @@ class CodexManagedSessionRuntime:
                 error_text=scan.error_text,
                 failure_class="permanent",
             )
+        skill_outcome = self._read_skill_outcome(
+            turn_started_at=turn_started_at
+        )
+        declared_failure = self._declared_skill_failure(skill_outcome)
+        if declared_failure is not None:
+            return declared_failure
         if scan.assistant_text:
             return _TurnTerminalOutcome(status="completed")
         if scan.provider_failure_reason:
@@ -1899,11 +1927,12 @@ class CodexManagedSessionRuntime:
                     error_text=recovered_error,
                     failure_class="permanent",
                 )
-            no_op = self._read_skill_outcome(turn_started_at=turn_started_at)
-            if no_op is not None:
+            if skill_outcome is not None and skill_outcome.get("status") == "no_op":
                 return _TurnTerminalOutcome(
                     status="completed",
-                    error_text=str(no_op.get("reason") or "").strip() or None,
+                    error_text=(
+                        str(skill_outcome.get("reason") or "").strip() or None
+                    ),
                     disposition="no_op",
                 )
         return None
@@ -1933,11 +1962,18 @@ class CodexManagedSessionRuntime:
         )
         if rollout_outcome is not None:
             return rollout_outcome
-        no_op = self._read_skill_outcome(turn_started_at=state.last_control_at)
-        if no_op is not None:
+        skill_outcome = self._read_skill_outcome(
+            turn_started_at=state.last_control_at
+        )
+        declared_failure = self._declared_skill_failure(skill_outcome)
+        if declared_failure is not None:
+            return declared_failure
+        if skill_outcome is not None and skill_outcome.get("status") == "no_op":
             return _TurnTerminalOutcome(
                 status="completed",
-                error_text=str(no_op.get("reason") or "").strip() or None,
+                error_text=(
+                    str(skill_outcome.get("reason") or "").strip() or None
+                ),
                 disposition="no_op",
             )
         return _TurnTerminalOutcome(
@@ -2736,7 +2772,15 @@ class CodexManagedSessionRuntime:
                 vendor_thread_id=vendor_thread_id,
             )
             assistant_text = completed_turn_inspection.assistant_text
-            if not assistant_text:
+            skill_outcome = self._read_skill_outcome(
+                turn_started_at=state.last_control_at
+            )
+            declared_failure = self._declared_skill_failure(skill_outcome)
+            if declared_failure is not None:
+                status = declared_failure.status
+                error_text = declared_failure.error_text
+                failure_class = declared_failure.failure_class
+            elif not assistant_text:
                 empty_outcome = self._completed_turn_without_assistant_outcome(
                     state=state,
                     thread_payload=thread_payload,

--- a/moonmind/workflows/temporal/runtime/codex_session_runtime.py
+++ b/moonmind/workflows/temporal/runtime/codex_session_runtime.py
@@ -539,6 +539,7 @@ class CodexManagedSessionRuntime:
             float(missing_turn_visibility_grace_seconds),
         )
         self._client: CodexAppServerRpcClient | None = None
+        self._skill_outcome_cache: tuple[float, dict[str, Any]] | None = None
 
     @property
     def _state_path(self) -> Path:
@@ -1813,6 +1814,7 @@ class CodexManagedSessionRuntime:
         session (or from any prior session that reused this spool) would
         otherwise mask a real transient empty-output failure.
         """
+        self._skill_outcome_cache = None
         outcome_path = self._artifact_spool_path / _SKILL_OUTCOME_FILENAME
         try:
             outcome_path.unlink()
@@ -1842,6 +1844,12 @@ class CodexManagedSessionRuntime:
         """
         if turn_started_at is None:
             return None
+        cache_key = float(turn_started_at)
+        if (
+            self._skill_outcome_cache is not None
+            and self._skill_outcome_cache[0] == cache_key
+        ):
+            return self._skill_outcome_cache[1]
         outcome_path = self._artifact_spool_path / _SKILL_OUTCOME_FILENAME
         try:
             stat_result = outcome_path.stat()
@@ -1869,6 +1877,7 @@ class CodexManagedSessionRuntime:
             *_SKILL_OUTCOME_FAILURE_STATUSES,
         }:
             return None
+        self._skill_outcome_cache = (cache_key, payload)
         return payload
 
     @staticmethod

--- a/tests/integration/services/temporal/test_codex_session_task_creation.py
+++ b/tests/integration/services/temporal/test_codex_session_task_creation.py
@@ -35,10 +35,31 @@ class _CreateTaskHandler(BaseHTTPRequestHandler):
                 "body": json.loads(body.decode("utf-8")),
             }
         )
-        payload = json.dumps({"taskId": "mm:child-task-1", "status": "queued"}).encode(
-            "utf-8"
-        )
+        payload = json.dumps(
+            {
+                "workflowId": "mm:child-task-1",
+                "runId": "run-child-task-1",
+                "state": "initializing",
+                "temporalStatus": "running",
+            }
+        ).encode("utf-8")
         self.send_response(201)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def do_GET(self) -> None:  # noqa: N802 - stdlib callback name
+        assert self.path == "/api/executions/mm%3Achild-task-1"
+        payload = json.dumps(
+            {
+                "workflowId": "mm:child-task-1",
+                "runId": "run-child-task-1",
+                "state": "initializing",
+                "temporalStatus": "running",
+            }
+        ).encode("utf-8")
+        self.send_response(200)
         self.send_header("Content-Type", "application/json")
         self.send_header("Content-Length", str(len(payload)))
         self.end_headers()
@@ -317,7 +338,10 @@ async def test_codex_session_launch_environment_can_create_child_tasks(
             {
                 "pr": 1337,
                 "branch": "codex/session-child-task",
-                "jobId": "mm:child-task-1",
+                "workflowId": "mm:child-task-1",
+                "runId": "run-child-task-1",
+                "state": "initializing",
+                "temporalStatus": "running",
             }
         ]
         assert len(_CreateTaskHandler.requests) == 1

--- a/tests/integration/skills/test_batch_dependabot_resolver_e2e.py
+++ b/tests/integration/skills/test_batch_dependabot_resolver_e2e.py
@@ -98,6 +98,7 @@ def _mixed_pr_set() -> list[dict[str, Any]]:
 
 class _FakeAsyncClient:
     submissions: list[dict[str, Any]] = []
+    workflow_ids: set[str] = set()
 
     def __init__(self, **_kwargs: Any) -> None:
         pass
@@ -111,10 +112,28 @@ class _FakeAsyncClient:
     async def post(self, _path: str, **kwargs: Any) -> Any:
         body = kwargs.get("json")
         _FakeAsyncClient.submissions.append(body)
+        workflow_id = f"mm:wf-{len(_FakeAsyncClient.submissions)}"
+        _FakeAsyncClient.workflow_ids.add(workflow_id)
         response = MagicMock()
         response.raise_for_status = MagicMock()
         response.json = MagicMock(
-            return_value={"workflowId": f"mm:wf-{len(_FakeAsyncClient.submissions)}"}
+            return_value={"workflowId": workflow_id, "runId": f"run-{workflow_id}"}
+        )
+        return response
+
+    async def get(self, path: str) -> Any:
+        workflow_id = path.rsplit("/", 1)[-1].replace("%3A", ":")
+        if workflow_id not in _FakeAsyncClient.workflow_ids:
+            raise AssertionError(f"unexpected workflow verification: {workflow_id}")
+        response = MagicMock()
+        response.raise_for_status = MagicMock()
+        response.json = MagicMock(
+            return_value={
+                "workflowId": workflow_id,
+                "runId": f"run-{workflow_id}",
+                "state": "initializing",
+                "temporalStatus": "running",
+            }
         )
         return response
 
@@ -128,6 +147,7 @@ def _run_main(
     extra_env: dict[str, str] | None = None,
 ) -> dict[str, Any]:
     _FakeAsyncClient.submissions = []
+    _FakeAsyncClient.workflow_ids = set()
     monkeypatch.setenv("MOONMIND_URL", "http://api:8000")
     monkeypatch.delenv("MOONMIND_WORKER_TOKEN", raising=False)
     monkeypatch.delenv("MOONMIND_WORKER_TOKEN_FILE", raising=False)

--- a/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
+++ b/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
@@ -1278,6 +1278,50 @@ def test_runtime_no_op_signal_ignored_when_assistant_text_present(
     assert response.status == "completed"
     assert "disposition" not in response.metadata
 
+
+@pytest.mark.parametrize("declared_status", ["failed", "partial"])
+def test_runtime_skill_failure_signal_overrides_assistant_text(
+    tmp_path: Path,
+    declared_status: str,
+) -> None:
+    request = launch_request(tmp_path)
+    script = write_fake_app_server(
+        tmp_path,
+        assistant_text="Queued 0 workflows after API validation errors.",
+        skill_outcome_path=_spool_skill_outcome_path(request),
+        skill_outcome_payload={
+            "schema_version": 1,
+            "status": declared_status,
+            "reason": "child_workflow_queue_failed",
+            "evidence": {"requested": 2, "created": 0},
+        },
+    )
+    runtime = CodexManagedSessionRuntime(
+        workspace_path=request.workspace_path,
+        session_workspace_path=request.session_workspace_path,
+        artifact_spool_path=request.artifact_spool_path,
+        codex_home_path=request.codex_home_path,
+        image_ref=request.image_ref,
+        control_url="docker-exec://mm-codex-session-sess-1",
+        container_id="ctr-1",
+        app_server_command=("python3", str(script)),
+    )
+    runtime.launch_session(request)
+
+    response = runtime.send_turn(
+        SendCodexManagedSessionTurnRequest(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            containerId="ctr-1",
+            threadId="logical-thread-1",
+            instructions="Reply with exactly the word OK",
+        )
+    )
+
+    assert response.status == "failed"
+    assert response.metadata["failureClass"] == "permanent"
+    assert response.metadata["reason"] == "child_workflow_queue_failed"
+
 def test_runtime_no_op_signal_ignored_when_schema_version_wrong(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
+++ b/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
@@ -1322,6 +1322,38 @@ def test_runtime_skill_failure_signal_overrides_assistant_text(
     assert response.metadata["failureClass"] == "permanent"
     assert response.metadata["reason"] == "child_workflow_queue_failed"
 
+
+def test_runtime_caches_valid_skill_outcome_for_current_turn(tmp_path: Path) -> None:
+    request = launch_request(tmp_path)
+    runtime = CodexManagedSessionRuntime(
+        workspace_path=request.workspace_path,
+        session_workspace_path=request.session_workspace_path,
+        artifact_spool_path=request.artifact_spool_path,
+        codex_home_path=request.codex_home_path,
+        image_ref=request.image_ref,
+        control_url="docker-exec://mm-codex-session-sess-1",
+        container_id="ctr-1",
+    )
+    turn_started_at = time.time()
+    outcome_path = _spool_skill_outcome_path(request)
+    outcome_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "status": "failed",
+                "reason": "child_workflow_queue_failed",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    first = runtime._read_skill_outcome(turn_started_at=turn_started_at)
+    outcome_path.unlink()
+    second = runtime._read_skill_outcome(turn_started_at=turn_started_at)
+
+    assert first is not None
+    assert second == first
+
 def test_runtime_no_op_signal_ignored_when_schema_version_wrong(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/test_batch_dependabot_resolver.py
+++ b/tests/unit/test_batch_dependabot_resolver.py
@@ -255,7 +255,8 @@ def test_build_queue_request_child_payload_shape() -> None:
         "maxIterations": 3,
     }
     assert task["git"]["startingBranch"] == "dependabot/pip/anthropic-0.107.1"
-    assert task["git"]["targetBranch"] == "dependabot/pip/anthropic-0.107.1"
+    assert task["git"]["branch"] == "dependabot/pip/anthropic-0.107.1"
+    assert "targetBranch" not in task["git"]
     assert task["publish"]["mode"] == "auto"
     assert task["runtime"]["mode"] == "codex"
     assert payload["targetRuntime"] == "codex"
@@ -432,7 +433,9 @@ def test_write_run_artifacts_skips_no_op_on_errors(tmp_path: Path) -> None:
         "errors": [{"pr": 9, "branch": "dependabot/pip/x", "error": "boom"}],
     }
     module["_write_run_artifacts"](tmp_path, payload)
-    assert not (tmp_path / "skill_outcome.json").exists()
+    outcome = json.loads((tmp_path / "skill_outcome.json").read_text())
+    assert outcome["status"] == "failed"
+    assert outcome["reason"] == "child_workflow_queue_failed"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_batch_dependabot_resolver.py
+++ b/tests/unit/test_batch_dependabot_resolver.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import asyncio
 import json
 import runpy
 from pathlib import Path
 from typing import Any
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -297,6 +299,94 @@ def test_build_queue_request_runtime_inheritance_opt_in() -> None:
         inherit_runtime_from_caller=True,
     )
     assert request["payload"]["runtimeInheritance"] == "caller"
+
+
+def test_submit_jobs_requires_and_verifies_workflow_id() -> None:
+    module = _load_module()
+    request = module["_build_queue_request"](
+        "MoonLadderStudios/MoonMind",
+        42,
+        "dependabot/pip/x",
+        head_sha="abc",
+        runtime=module["RuntimeSelection"](mode="codex"),
+        merge_method="squash",
+        max_iterations=3,
+        priority=0,
+        max_attempts=3,
+    )
+    submission = module["JobSubmission"](
+        queue_request=request,
+        pr_number=42,
+        branch="dependabot/pip/x",
+    )
+    fake_response = MagicMock()
+    fake_response.raise_for_status = MagicMock()
+    fake_response.json = MagicMock(
+        return_value={
+            "workflowId": "mm:dependabot-child",
+            "runId": "run-1",
+            "state": "initializing",
+            "temporalStatus": "running",
+        }
+    )
+    get_paths: list[str] = []
+
+    class FakeAsyncClient:
+        def __init__(self, **_kwargs: Any) -> None:
+            pass
+
+        async def __aenter__(self) -> "FakeAsyncClient":
+            return self
+
+        async def __aexit__(self, *_args: Any) -> None:
+            pass
+
+        async def post(self, _path: str, **_kwargs: Any) -> Any:
+            return fake_response
+
+        async def get(self, path: str) -> Any:
+            get_paths.append(path)
+            return fake_response
+
+    with patch.object(module["httpx"], "AsyncClient", FakeAsyncClient):
+        created, errors = asyncio.run(
+            module["_submit_jobs_via_http"](
+                [submission],
+                moonmind_url="http://api:8000",
+                worker_token=None,
+            )
+        )
+
+    assert errors == []
+    assert created[0]["workflowId"] == "mm:dependabot-child"
+    assert created[0]["runId"] == "run-1"
+    assert get_paths == ["/api/executions/mm%3Adependabot-child"]
+
+
+def test_verify_execution_visible_rejects_terminated_workflow() -> None:
+    module = _load_module()
+    fake_response = MagicMock()
+    fake_response.raise_for_status = MagicMock()
+    fake_response.json = MagicMock(
+        return_value={
+            "workflowId": "mm:terminated",
+            "state": "terminated",
+        }
+    )
+
+    class FakeClient:
+        async def get(self, _path: str) -> Any:
+            return fake_response
+
+    with pytest.raises(RuntimeError, match="terminal state terminated"):
+        asyncio.run(
+            module["_verify_execution_visible"](
+                FakeClient(),
+                "mm:terminated",
+                attempts=1,
+                delay_seconds=0,
+            )
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_batch_pr_resolver.py
+++ b/tests/unit/test_batch_pr_resolver.py
@@ -829,6 +829,15 @@ def test_build_queue_request_required_capabilities_toplevel() -> None:
         "requiredCapabilities" not in skill
     ), "requiredCapabilities must not be nested inside skill"
 
+
+def test_terminal_failure_states_include_terminated() -> None:
+    module = _load_module()
+    assert module["TERMINAL_FAILURE_STATES"] == {
+        "failed",
+        "canceled",
+        "terminated",
+    }
+
 def test_write_run_artifacts_emits_no_op_when_zero_queued_no_errors(tmp_path: Path) -> None:
     """A genuine no-op run writes skill_outcome.json declaring status=no_op."""
     module = _load_module()

--- a/tests/unit/test_batch_pr_resolver.py
+++ b/tests/unit/test_batch_pr_resolver.py
@@ -114,7 +114,8 @@ def test_build_queue_request_sets_none_publish_with_matching_branches():
     assert task["title"] == "feature/example"
     assert task["publish"]["mode"] == "auto"
     assert git["startingBranch"] == "feature/example"
-    assert git["targetBranch"] == "feature/example"
+    assert git["branch"] == "feature/example"
+    assert "targetBranch" not in git
 
 def test_build_queue_request_adds_batch_scoped_idempotency_key() -> None:
     module = _load_module()
@@ -604,7 +605,14 @@ def test_submit_jobs_posts_to_api(monkeypatch: Any) -> None:
 
     fake_response = MagicMock()
     fake_response.raise_for_status = MagicMock()
-    fake_response.json = MagicMock(return_value={"taskId": "mm:uuid-1234", "status": "queued"})
+    fake_response.json = MagicMock(
+        return_value={
+            "workflowId": "mm:uuid-1234",
+            "runId": "run-1",
+            "state": "initializing",
+            "temporalStatus": "running",
+        }
+    )
 
     mock_post = AsyncMock(return_value=fake_response)
 
@@ -623,6 +631,9 @@ def test_submit_jobs_posts_to_api(monkeypatch: Any) -> None:
         async def post(self, path: str, **kwargs: Any) -> Any:
             return await mock_post(path, **kwargs)
 
+        async def get(self, _path: str) -> Any:
+            return fake_response
+
     with patch.object(httpx, "AsyncClient", FakeAsyncClient):
         submission = _make_submission(module)
         created, errors = asyncio.run(
@@ -635,21 +646,22 @@ def test_submit_jobs_posts_to_api(monkeypatch: Any) -> None:
 
     assert errors == []
     assert len(created) == 1
-    assert created[0]["jobId"] == "mm:uuid-1234"
+    assert created[0]["workflowId"] == "mm:uuid-1234"
+    assert created[0]["runId"] == "run-1"
     assert created[0]["pr"] == 42
     mock_post.assert_awaited_once()
     call_path = mock_post.await_args[0][0]
     assert call_path == "/api/executions"
 
-def test_submit_jobs_records_temporal_workflow_id(monkeypatch: Any) -> None:
-    """The Temporal executions API returns workflowId rather than legacy taskId."""
+def test_submit_jobs_rejects_create_without_workflow_id(monkeypatch: Any) -> None:
+    """The create response must carry the canonical workflow identity."""
     module = _load_module()
     submit_jobs_via_http = module["_submit_jobs_via_http"]
 
     fake_response = MagicMock()
     fake_response.raise_for_status = MagicMock()
     fake_response.json = MagicMock(
-        return_value={"workflowId": "mm:wf-123", "status": "queued"}
+        return_value={"taskId": "legacy-task-id", "status": "queued"}
     )
 
     mock_post = AsyncMock(return_value=fake_response)
@@ -679,8 +691,8 @@ def test_submit_jobs_records_temporal_workflow_id(monkeypatch: Any) -> None:
             )
         )
 
-    assert errors == []
-    assert created[0]["jobId"] == "mm:wf-123"
+    assert created == []
+    assert errors[0]["error"] == "create response did not include workflowId"
 
 def test_submit_jobs_uses_http_when_moonmind_url_set(monkeypatch: Any) -> None:
     """_submit_jobs dispatches to HTTP when MOONMIND_URL is configured."""
@@ -697,7 +709,7 @@ def test_submit_jobs_uses_http_when_moonmind_url_set(monkeypatch: Any) -> None:
         requests: list, *, moonmind_url: str, worker_token: Any
     ) -> tuple:
         http_called.append(moonmind_url)
-        return [{"pr": 1, "branch": "b", "jobId": "x"}], []
+        return [{"pr": 1, "branch": "b", "workflowId": "x"}], []
 
     submission = _make_submission(module)
 
@@ -868,7 +880,9 @@ def test_write_run_artifacts_skips_no_op_when_errors_present(tmp_path: Path) -> 
     write(tmp_path, payload)
 
     assert (tmp_path / "batch_pr_resolver_result.json").exists()
-    assert not (tmp_path / "skill_outcome.json").exists()
+    outcome = json.loads((tmp_path / "skill_outcome.json").read_text())
+    assert outcome["status"] == "failed"
+    assert outcome["reason"] == "child_workflow_queue_failed"
 
 def test_write_run_artifacts_skips_no_op_when_executions_queued(tmp_path: Path) -> None:
     """When real work was queued, no skill_outcome.json is written."""
@@ -883,7 +897,7 @@ def test_write_run_artifacts_skips_no_op_when_executions_queued(tmp_path: Path) 
         "runtime": {"mode": "codex", "model": None, "effort": None, "executionProfileRef": None},
         "requested": 1,
         "created": 1,
-        "queued": [{"jobId": "mm:abc", "pr": 9, "branch": "feature/z"}],
+        "queued": [{"workflowId": "mm:abc", "pr": 9, "branch": "feature/z"}],
         "skipped": [],
         "errors": [],
     }
@@ -971,6 +985,9 @@ def test_submit_jobs_adds_task_workflow_header_when_in_managed_session(
         async def post(self, _path: str, **_kwargs: Any) -> Any:
             return fake_response
 
+        async def get(self, _path: str) -> Any:
+            return fake_response
+
     with patch.object(httpx, "AsyncClient", FakeAsyncClient):
         submission = _make_submission(module)
         asyncio.run(
@@ -1021,6 +1038,9 @@ def test_submit_jobs_omits_task_headers_without_env(monkeypatch: Any) -> None:
             pass
 
         async def post(self, _path: str, **_kwargs: Any) -> Any:
+            return fake_response
+
+        async def get(self, _path: str) -> Any:
             return fake_response
 
     with patch.object(httpx, "AsyncClient", FakeAsyncClient):


### PR DESCRIPTION
## What changed

- send the canonical `workflow.git.branch` field from batch PR and Dependabot resolvers
- require and verify each created `workflowId` through the execution API before counting it as queued
- preserve execution API response details in batch error artifacts
- emit explicit `failed` or `partial` skill outcomes for fan-out failures
- make the managed Codex runtime honor failed/partial skill outcomes even when the agent produced a final response

## Root cause

Workflow `mm:7216f861-1b4d-46b0-bef2-9e1c6e2bab2b` found two open PRs, but both child submissions returned HTTP 422 because `batch-pr-resolver` still sent the removed `payload.workflow.git.targetBranch` field. The helper returned a non-zero result, but the agent summarized the error in a final response, so the managed runtime classified the turn and parent workflow as completed.

## Impact

Batch fan-out now uses the current execution request contract, proves that each child is visible, and fails the parent outcome when any requested child was not queued. The two missing child workflows from the incident were also submitted and verified separately.

## Validation

- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/test_batch_pr_resolver.py tests/unit/test_batch_dependabot_resolver.py tests/unit/services/temporal/runtime/test_codex_session_runtime.py`
  - 161 Python tests passed
  - 944 frontend tests passed, 238 skipped
- queue recovery helper: 2 submitted, 2 verified, 0 errors
