### PR TITLE
Fix MoonSpec verifier contract repair retries

### DIFF
--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -558,6 +558,9 @@ RUN_MOONSPEC_TITLE_REMEDIATION_DETECTION_PATCH = (
     "run-moonspec-title-remediation-detection-v1"
 )
 RUN_MOONSPEC_GATE_CONTRACT_REPAIR_PATCH = "run-moonspec-gate-contract-repair-v1"
+RUN_MOONSPEC_GATE_CONTRACT_REPAIR_FRESH_SOURCE_PATCH = (
+    "run-moonspec-gate-contract-repair-fresh-source-v1"
+)
 RUN_MOONSPEC_GATE_ENVIRONMENT_DRAFT_PUBLISH_PATCH = (
     "run-moonspec-gate-environment-draft-publish-v1"
 )
@@ -1109,6 +1112,7 @@ class MoonMindRunWorkflow:
         self._step_workspace_capture_inputs: dict[str, dict[str, Any]] = {}
         self._step_external_agent_ids: dict[str, str] = {}
         self._step_execution_launch_blocks: set[str] = set()
+        self._fresh_source_step_execution_attempts: set[str] = set()
         self._step_dependency_effects: dict[str, dict[str, Any]] = {}
         self._step_terminal_dispositions: dict[str, str] = {}
         self._step_execution_context_projections: dict[
@@ -2097,6 +2101,36 @@ class MoonMindRunWorkflow:
     def _step_execution_launch_block_key(logical_step_id: str, attempt: int) -> str:
         return f"{logical_step_id}:{attempt}"
 
+    def _prepare_moonspec_contract_repair_attempt(
+        self,
+        logical_step_id: str,
+    ) -> None:
+        """Allow the next read-only verifier attempt to start from source state.
+
+        MoonSpec contract repair re-runs verification only; it does not continue
+        source mutation from the previous verifier process. Managed agent runs
+        already launch with fresh agent context against the workflow's durable
+        branch, so requiring a mutable-workspace checkpoint here prevents the
+        bounded repair from running without adding safety.
+        """
+
+        current_attempt = self._step_execution_for(logical_step_id) or 0
+        next_attempt = current_attempt + 1
+        self._fresh_source_step_execution_attempts.add(
+            self._step_execution_launch_block_key(logical_step_id, next_attempt)
+        )
+
+    def _step_execution_uses_fresh_source(
+        self,
+        logical_step_id: str,
+        *,
+        attempt: int,
+    ) -> bool:
+        return (
+            self._step_execution_launch_block_key(logical_step_id, attempt)
+            in self._fresh_source_step_execution_attempts
+        )
+
     def _record_workspace_policy_launch_block(
         self,
         logical_step_id: str,
@@ -2161,7 +2195,10 @@ class MoonMindRunWorkflow:
             logical_step_id
         ) or self._previous_step_checkpoint_refs.get(logical_step_id)
         boundary_refs = self._step_checkpoint_refs_by_boundary.get(logical_step_id, {})
-        if attempt > 1:
+        if attempt > 1 and not self._step_execution_uses_fresh_source(
+            logical_step_id,
+            attempt=attempt,
+        ):
             workspace = workspace_policy_metadata(
                 policy="continue_from_previous_execution",
                 checkpoint_ref=checkpoint_ref,
@@ -2175,6 +2212,12 @@ class MoonMindRunWorkflow:
             checkpoint_ref=checkpoint_ref,
             checkpoint_valid=None,
         )
+        if attempt > 1:
+            workspace["sourceExecutionOrdinal"] = (
+                dict(source_execution_ordinal)
+                if source_execution_ordinal
+                else None
+            )
         self._apply_step_checkpoint_manifest_refs(workspace, boundary_refs)
         return workspace
 
@@ -8399,6 +8442,10 @@ class MoonMindRunWorkflow:
                         < _MOONSPEC_GATE_CONTRACT_REPAIR_MAX_ATTEMPTS
                     ):
                         moonspec_contract_repair_attempts += 1
+                        if workflow.patched(
+                            RUN_MOONSPEC_GATE_CONTRACT_REPAIR_FRESH_SOURCE_PATCH
+                        ):
+                            self._prepare_moonspec_contract_repair_attempt(node_id)
                         self._upsert_step_check(
                             node_id,
                             kind="moonspec_gate_contract",

--- a/tests/integration/workflows/temporal/test_step_execution_manifest_evidence.py
+++ b/tests/integration/workflows/temporal/test_step_execution_manifest_evidence.py
@@ -128,6 +128,86 @@ async def test_step_execution_manifest_refs_are_append_only_for_reexecution(
     assert step["lastError"] == "missing_required_checkpoint_evidence"
 
 
+async def test_moonspec_contract_repair_manifest_uses_fresh_source_without_checkpoint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _configure_workflow_runtime(monkeypatch)
+    workflow = MoonMindRunWorkflow()
+    writes: list[dict[str, Any]] = []
+    now = datetime(2026, 5, 17, 12, 0, tzinfo=UTC)
+
+    async def fake_write_json_artifact(
+        *,
+        name: str,
+        payload: dict[str, Any],
+        content_type: str = "application/json",
+        metadata_json: dict[str, Any] | None = None,
+    ) -> str:
+        writes.append(
+            {
+                "name": name,
+                "payload": payload,
+                "content_type": content_type,
+                "metadata_json": metadata_json,
+            }
+        )
+        return f"artifact-execution-{len(writes)}"
+
+    monkeypatch.setattr(workflow, "_write_json_artifact", fake_write_json_artifact)
+    workflow._initialize_step_ledger(
+        ordered_nodes=[
+            {
+                "id": "verify",
+                "tool": {"type": "agent_runtime", "name": "claude_code"},
+                "inputs": {
+                    "title": "Verify completion",
+                    "selectedSkill": "moonspec-verify",
+                },
+            }
+        ],
+        dependency_map={"verify": []},
+        updated_at=now,
+    )
+
+    workflow._mark_step_running("verify", updated_at=now, summary="Initial verify")
+    await workflow._record_step_execution_manifest(
+        "verify",
+        phase="start",
+        updated_at=now,
+        reason="initial_execution",
+    )
+    workflow._mark_step_terminal(
+        "verify",
+        status="completed",
+        updated_at=now,
+        summary="Structured gate artifact missing",
+    )
+    workflow._prepare_moonspec_contract_repair_attempt("verify")
+    workflow._mark_step_running("verify", updated_at=now, summary="Repair gate")
+    await workflow._record_step_execution_manifest(
+        "verify",
+        phase="start",
+        updated_at=now,
+        reason="quality_gate_failed",
+    )
+
+    repair_manifest = writes[1]["payload"]
+    assert repair_manifest["executionOrdinal"] == 2
+    assert repair_manifest["reason"] == "quality_gate_failed"
+    assert repair_manifest["workspace"]["policy"] == "fresh_branch_from_source"
+    assert repair_manifest["workspace"]["evidenceRequired"] is False
+    assert repair_manifest["workspace"]["evidenceAccepted"] is True
+    assert repair_manifest["workspace"]["sourceExecutionOrdinal"] == {
+        "workflowId": "wf-boundary",
+        "runId": "run-boundary",
+        "logicalStepId": "verify",
+        "executionOrdinal": 1,
+    }
+    assert repair_manifest["status"] == "running"
+    assert "terminalDisposition" not in repair_manifest
+    assert workflow.get_step_ledger()["steps"][0]["status"] == "executing"
+
+
 async def test_recovery_step_execution_manifest_carries_lineage_without_large_payloads(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/workflows/temporal/workflows/test_run_integration.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_integration.py
@@ -3296,6 +3296,38 @@ def test_moonspec_contract_repair_feedback_for_degraded_verify_output(
     )
 
 
+def test_moonspec_contract_repair_reexecutes_from_fresh_source_without_checkpoint(
+    mock_run_workflow: MoonMindRunWorkflow,
+) -> None:
+    now = datetime.now(timezone.utc)
+    node_id = "verify-final"
+    mock_run_workflow._initialize_step_ledger(
+        ordered_nodes=[{"id": node_id, "title": "Verify completion"}],
+        dependency_map={node_id: []},
+        updated_at=now,
+    )
+    mock_run_workflow._mark_step_running(node_id, updated_at=now)
+
+    mock_run_workflow._prepare_moonspec_contract_repair_attempt(node_id)
+    mock_run_workflow._mark_step_running(node_id, updated_at=now)
+
+    source_execution = mock_run_workflow._step_execution_source_identity(
+        node_id,
+        attempt=2,
+    )
+    workspace = mock_run_workflow._step_execution_workspace(
+        node_id,
+        attempt=2,
+        source_execution_ordinal=source_execution,
+    )
+
+    assert workspace["policy"] == "fresh_branch_from_source"
+    assert workspace["evidenceRequired"] is False
+    assert workspace["evidenceAccepted"] is True
+    assert workspace["sourceExecutionOrdinal"] == source_execution
+    assert not mock_run_workflow._workspace_policy_launch_blocked(workspace)
+
+
 def test_moonspec_gate_draft_publish_qualification(
     mock_run_workflow: MoonMindRunWorkflow,
 ) -> None:


### PR DESCRIPTION
## What changed

- mark the next MoonSpec verifier contract-repair Step Execution as a fresh-source attempt;
- preserve checkpoint enforcement for every ordinary re-execution;
- carry the prior execution identity into the repair manifest for auditability;
- gate the new command path behind a Temporal patch marker for replay safety;
- add unit and integration-boundary regressions for both the repaired and fail-closed paths.

## Root cause

When a MoonSpec verifier returned a prose report but omitted its structured JSON verdict artifact, the workflow correctly scheduled one bounded contract-repair attempt. The generic re-execution policy then classified that second attempt as `continue_from_previous_execution`, which requires checkpoint evidence. Managed verifier runs had no checkpoint ref, so the repair was rejected before launch with `missing_required_checkpoint_evidence` and the workflow failed after implementation and verification work had already completed.

The repair is read-only and runs with fresh agent context against the workflow's durable branch, so it does not need mutable workspace continuity. Ordinary implementation and quality-gate retries remain checkpoint-gated.

## Validation

- `./tools/test_unit.sh tests/unit/workflows/temporal/workflows/test_run_integration.py tests/unit/workflows/temporal/test_step_executions.py tests/unit/workflows/temporal/test_step_checkpoints.py`
  - 166 Python tests passed
  - 946 frontend tests passed, 238 skipped
- `pytest tests/integration/workflows/temporal/test_step_execution_manifest_evidence.py -q`
  - 9 passed
- `python -m moonmind.workflows.temporal.step_execution_conformance`
  - all manifest, checkpoint, gate, terminology, API-contract, golden, replay, and degraded-input families passed

## Impact

Malformed or missing MoonSpec structured verdict envelopes can now reach their bounded corrective verifier run instead of failing on an unrelated checkpoint requirement. Publication still remains fail-closed until a contract-valid structured verdict is produced.
