### PR TITLE
MM-1167: Switch Create navigation to sidebar list

### DIFF
--- a/frontend/src/entrypoints/dashboard-app.tsx
+++ b/frontend/src/entrypoints/dashboard-app.tsx
@@ -955,6 +955,9 @@ function RoutedDashboardPage({
     if (normalizedPath === '/workflows') {
       setRequestedMode('table');
     } else if (normalizedPath.startsWith('/workflows/')) {
+      if (requestedMode === 'table') {
+        updateDashboardPreferences({ workflowWorkspaceSidebarCollapsed: false });
+      }
       setRequestedMode((mode) => (mode === 'table' ? 'sidebar' : mode));
     } else if (normalizedPath === '/schedules') {
       setRequestedRecurringMode('table');

--- a/frontend/src/entrypoints/dashboard-app.tsx
+++ b/frontend/src/entrypoints/dashboard-app.tsx
@@ -954,7 +954,7 @@ function RoutedDashboardPage({
     const normalizedPath = location.pathname.replace(/\/$/, '');
     if (normalizedPath === '/workflows') {
       setRequestedMode('table');
-    } else if (normalizedPath.startsWith('/workflows/') && normalizedPath !== '/workflows/new') {
+    } else if (normalizedPath.startsWith('/workflows/')) {
       setRequestedMode((mode) => (mode === 'table' ? 'sidebar' : mode));
     } else if (normalizedPath === '/schedules') {
       setRequestedRecurringMode('table');

--- a/frontend/src/entrypoints/dashboard.test.tsx
+++ b/frontend/src/entrypoints/dashboard.test.tsx
@@ -1229,6 +1229,24 @@ describe('Dashboard shared entry', () => {
     expect(window.location.search).toBe('?source=temporal');
   });
 
+  it('MM-1167 preserves the Create sidebar when preferences change', async () => {
+    window.history.replaceState({}, '', '/workflows');
+    updateDashboardPreferences({ workflowWorkspaceSidebarCollapsed: true });
+    renderWithClient(<DashboardApp payload={{ page: 'dashboard', apiBase: '/api' }} />);
+
+    expect(await screen.findByText('Workflow list route loaded')).toBeTruthy();
+    fireEvent.click(screen.getByRole('link', { name: 'Create' }));
+
+    expect(await screen.findByText('Workflow start route loaded')).toBeTruthy();
+    expect(screen.getByRole('radio', { name: 'Sidebar list' }).getAttribute('aria-checked')).toBe('true');
+
+    updateDashboardPreferences({ lastSelectedWorkflowId: 'preference-sync' });
+
+    await waitFor(() => {
+      expect(screen.getByRole('radio', { name: 'Sidebar list' }).getAttribute('aria-checked')).toBe('true');
+    });
+  });
+
   it('MM-1029 navigateTo uses the SPA route event for dashboard-internal URLs', async () => {
     window.history.replaceState({}, '', '/workflows/new');
     renderWithClient(<DashboardApp payload={{ page: 'dashboard', apiBase: '/api' }} />);

--- a/frontend/src/entrypoints/dashboard.test.tsx
+++ b/frontend/src/entrypoints/dashboard.test.tsx
@@ -386,6 +386,22 @@ describe('Dashboard shared entry', () => {
     expect(animatedNavIconMocks.settingsStop).toHaveBeenCalledTimes(1);
   });
 
+  it('MM-1167 switches the full-screen workflow list to the sidebar when navigating to Create', async () => {
+    window.history.replaceState({}, '', '/workflows');
+    renderWithClient(<DashboardApp payload={{ page: 'dashboard', apiBase: '/api' }} />);
+
+    await screen.findByText('Workflow list route loaded', {}, { timeout: 10000 });
+    expect(screen.getByRole('radio', { name: 'Full screen table' }).getAttribute('aria-checked')).toBe('true');
+
+    fireEvent.click(screen.getByRole('link', { name: 'Create' }));
+
+    expect(await screen.findByText('Workflow start route loaded')).toBeTruthy();
+    await waitFor(() => {
+      expect(screen.getByRole('radio', { name: 'Sidebar list' }).getAttribute('aria-checked')).toBe('true');
+    });
+    expect(window.location.pathname).toBe('/workflows/new');
+  });
+
   it('renders dashboard alerts and lazy-loads the requested page component', async () => {
     window.history.replaceState({}, '', '/workflows');
     const payload: BootPayload = {


### PR DESCRIPTION
Issue: [MM-1167](https://moonladder.atlassian.net/browse/MM-1167)

## Summary
- Coerce the full-screen workflow table mode to sidebar mode when navigating to `/workflows/new`.
- Add a focused regression test covering navigation from the workflow list to Create.

## Tests run
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --dashboard-only --ui-args frontend/src/entrypoints/dashboard.test.tsx -t "MM-1167"` (1 passed)
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --dashboard-only --ui-args frontend/src/entrypoints/dashboard.test.tsx` (98 passed)

## Remaining risks
- Typecheck and lint were not run because local `tsc` and `eslint` binaries were unavailable. The changed dashboard test file passes in full.

[MM-1167]: https://moonladder.atlassian.net/browse/MM-1167?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ