### PR TITLE
Fix workflow runtime regression coverage

### DIFF
--- a/.github/workflows/pytest-unit-tests.yml
+++ b/.github/workflows/pytest-unit-tests.yml
@@ -225,7 +225,7 @@ jobs:
         run: |
           set -euo pipefail
           python -m pytest tests/unit/workflows/temporal \
-            -m "temporal_boundary and not slow" \
+            -m "not slow" \
             -q --durations=25 \
             --junitxml=artifacts/pytest-temporal-boundary.xml
 

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -3033,7 +3033,7 @@ class TemporalSandboxActivities:
         self._managed_workspace_root = Path(
             managed_workspace_root
             or os.environ.get("MOONMIND_AGENT_RUNTIME_STORE", "/work/agent_jobs")
-        ).resolve()
+        ).expanduser().resolve()
 
     async def _put_checkpoint_bytes(
         self,
@@ -3861,9 +3861,18 @@ class TemporalSandboxActivities:
     ) -> Path:
         workspace = Path(workspace_ref).expanduser().resolve()
         sandbox_root = (self._workspace_root / "temporal_sandbox").resolve()
+        try:
+            managed_relative = workspace.relative_to(self._managed_workspace_root)
+        except ValueError:
+            managed_relative = None
+        is_managed_repo_workspace = (
+            managed_relative is not None
+            and len(managed_relative.parts) == 2
+            and managed_relative.parts[1] == "repo"
+        )
         if not (
             workspace.is_relative_to(sandbox_root)
-            or workspace.is_relative_to(self._managed_workspace_root)
+            or is_managed_repo_workspace
         ):
             raise TemporalActivityRuntimeError(
                 f"workspace path escapes approved checkpoint roots: {workspace}"

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -3022,12 +3022,17 @@ class TemporalSandboxActivities:
         artifact_store: Any | None = None,
         redactor: SecretRedactor | None = None,
         workspace_root: str | Path | None = None,
+        managed_workspace_root: str | Path | None = None,
     ) -> None:
         self._artifact_service = artifact_service
         self._artifact_store = artifact_store or InMemoryArtifactStore()
         self._redactor = redactor or SecretRedactor.from_environ()
         self._workspace_root = Path(
             workspace_root or settings.workflow.workspace_root
+        ).resolve()
+        self._managed_workspace_root = Path(
+            managed_workspace_root
+            or os.environ.get("MOONMIND_AGENT_RUNTIME_STORE", "/work/agent_jobs")
         ).resolve()
 
     async def _put_checkpoint_bytes(
@@ -3142,7 +3147,7 @@ class TemporalSandboxActivities:
             )
             return result.model_dump(by_alias=True, mode="json")
 
-        workspace = self._resolve_workspace(
+        workspace = self._resolve_checkpoint_workspace(
             model.workspace_path or model.workspace_root_ref or "",
             must_exist=True,
         )
@@ -3846,6 +3851,22 @@ class TemporalSandboxActivities:
         if not workspace.is_relative_to(sandbox_root):
             raise TemporalActivityRuntimeError(
                 f"workspace path escapes sandbox root: {workspace}"
+            )
+        if must_exist and not workspace.exists():
+            raise TemporalActivityRuntimeError(f"workspace does not exist: {workspace}")
+        return workspace
+
+    def _resolve_checkpoint_workspace(
+        self, workspace_ref: str | Path, *, must_exist: bool
+    ) -> Path:
+        workspace = Path(workspace_ref).expanduser().resolve()
+        sandbox_root = (self._workspace_root / "temporal_sandbox").resolve()
+        if not (
+            workspace.is_relative_to(sandbox_root)
+            or workspace.is_relative_to(self._managed_workspace_root)
+        ):
+            raise TemporalActivityRuntimeError(
+                f"workspace path escapes approved checkpoint roots: {workspace}"
             )
         if must_exist and not workspace.exists():
             raise TemporalActivityRuntimeError(f"workspace does not exist: {workspace}")

--- a/moonmind/workflows/temporal/runtime/codex_session_runtime.py
+++ b/moonmind/workflows/temporal/runtime/codex_session_runtime.py
@@ -69,6 +69,13 @@ _EMPTY_ASSISTANT_FAILURE_REASONS: tuple[str, ...] = (
     "codex app-server task_complete produced no assistant output",
     "codex app-server turn/completed produced no assistant output",
 )
+
+
+def _is_empty_assistant_failure_reason(value: str | None) -> bool:
+    return bool(
+        value
+        and value.strip().lower() in _EMPTY_ASSISTANT_FAILURE_REASONS
+    )
 _CODEX_PROVIDER_CREDITS_EXHAUSTED_REASON = (
     "Codex provider reported no remaining credits (usage limit reached); "
     "retry after a profile cooldown or update the provider profile."
@@ -167,6 +174,8 @@ class _RolloutLiveMirror:
     offset: int = 0
     turn_started_at: float | None = None
     last_assistant_text: str = ""
+    last_assistant_text_matches_active_turn: bool = False
+    inside_active_turn: bool = False
     emitted_assistant_texts: set[str] = field(default_factory=set)
     emitted_live_keys: set[str] = field(default_factory=set)
 
@@ -1294,6 +1303,20 @@ class CodexManagedSessionRuntime:
                         payload,
                         vendor_turn_id,
                     )
+                    entry_type = str(payload.get("type") or "").strip().lower()
+                    event_payload = payload.get("payload")
+                    event_type = ""
+                    if entry_type == "event_msg" and isinstance(
+                        event_payload, Mapping
+                    ):
+                        event_type = str(
+                            event_payload.get("type") or ""
+                        ).strip().lower()
+                    if event_type == "task_started" and references_turn:
+                        mirror.inside_active_turn = True
+                    belongs_to_active_turn = (
+                        references_turn or mirror.inside_active_turn
+                    )
                     if (
                         mirror.turn_started_at is not None
                         and (
@@ -1326,13 +1349,16 @@ class CodexManagedSessionRuntime:
                     mirror.emitted_live_keys.add(live_key)
                     if label == "assistant":
                         normalized_text = text.removeprefix("assistant: ").strip()
-                        if normalized_text:
+                        if normalized_text and belongs_to_active_turn:
                             mirror.last_assistant_text = normalized_text
+                            mirror.last_assistant_text_matches_active_turn = True
                         if normalized_text in mirror.emitted_assistant_texts:
                             mirror.offset = handle.tell()
                             continue
                         mirror.emitted_assistant_texts.add(normalized_text)
                     updates.append((stream_name, text))
+                    if event_type == "task_complete" and belongs_to_active_turn:
+                        mirror.inside_active_turn = False
                     mirror.offset = handle.tell()
                 for stream_name in ("stdout", "stderr"):
                     stream_text = "".join(
@@ -2777,8 +2803,9 @@ class CodexManagedSessionRuntime:
         completed_turn_inspection: _CompletedTurnInspection | None = None
         if (
             status == "failed"
-            and error_text in _EMPTY_ASSISTANT_FAILURE_REASONS
+            and _is_empty_assistant_failure_reason(error_text)
             and rollout_mirror.last_assistant_text
+            and rollout_mirror.last_assistant_text_matches_active_turn
         ):
             status = "completed"
             error_text = None
@@ -2820,7 +2847,7 @@ class CodexManagedSessionRuntime:
             metadata["reason"] = error_text
         if status == "failed" and failure_class:
             metadata["failureClass"] = failure_class
-            if error_text in _EMPTY_ASSISTANT_FAILURE_REASONS:
+            if _is_empty_assistant_failure_reason(error_text):
                 evidence_rollout_scan = (
                     completed_turn_inspection.rollout_scan
                     if completed_turn_inspection is not None

--- a/moonmind/workflows/temporal/runtime/codex_session_runtime.py
+++ b/moonmind/workflows/temporal/runtime/codex_session_runtime.py
@@ -166,6 +166,7 @@ class _RolloutLiveMirror:
     path: str | None = None
     offset: int = 0
     turn_started_at: float | None = None
+    last_assistant_text: str = ""
     emitted_assistant_texts: set[str] = field(default_factory=set)
     emitted_live_keys: set[str] = field(default_factory=set)
 
@@ -1325,6 +1326,8 @@ class CodexManagedSessionRuntime:
                     mirror.emitted_live_keys.add(live_key)
                     if label == "assistant":
                         normalized_text = text.removeprefix("assistant: ").strip()
+                        if normalized_text:
+                            mirror.last_assistant_text = normalized_text
                         if normalized_text in mirror.emitted_assistant_texts:
                             mirror.offset = handle.tell()
                             continue
@@ -2772,6 +2775,14 @@ class CodexManagedSessionRuntime:
         metadata: dict[str, Any] = {}
         disposition: str | None = None
         completed_turn_inspection: _CompletedTurnInspection | None = None
+        if (
+            status == "failed"
+            and error_text in _EMPTY_ASSISTANT_FAILURE_REASONS
+            and rollout_mirror.last_assistant_text
+        ):
+            status = "completed"
+            error_text = None
+            failure_class = None
         if status == "completed":
             completed_turn_inspection = self._inspect_completed_turn(
                 state=state,
@@ -2780,7 +2791,10 @@ class CodexManagedSessionRuntime:
                 client=client,
                 vendor_thread_id=vendor_thread_id,
             )
-            assistant_text = completed_turn_inspection.assistant_text
+            assistant_text = (
+                completed_turn_inspection.assistant_text
+                or rollout_mirror.last_assistant_text
+            )
             skill_outcome = self._read_skill_outcome(
                 turn_started_at=state.last_control_at
             )

--- a/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
+++ b/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
@@ -1018,6 +1018,102 @@ def test_runtime_send_turn_fails_empty_task_complete_event(
     )
     assert "lastAssistantText" not in handle.metadata
 
+
+def test_runtime_send_turn_preserves_live_assistant_output_outside_scan_tail(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.runtime.codex_session_runtime."
+        "_ROLLOUT_RECOVERY_MAX_BYTES",
+        1024,
+    )
+    request = launch_request(tmp_path)
+    transcript_path = (
+        Path(request.codex_home_path)
+        / "sessions"
+        / "2026"
+        / "07"
+        / "10"
+        / "rollout-2026-07-10T18-34-47-vendor-thread-1.jsonl"
+    )
+    transcript_path.parent.mkdir(parents=True, exist_ok=True)
+    script = write_fake_app_server(
+        tmp_path,
+        assistant_text="",
+        start_thread_path=str(transcript_path),
+        rollout_entries_on_read=[
+            {
+                "timestamp": _iso_timestamp(minutes_offset=0),
+                "type": "event_msg",
+                "payload": {
+                    "type": "agent_message",
+                    "turn_id": "vendor-turn-1",
+                    "message": "Implemented and verified the requested change.",
+                },
+            },
+            {
+                "timestamp": _iso_timestamp(minutes_offset=0),
+                "type": "response_item",
+                "payload": {
+                    "type": "function_call_output",
+                    "turn_id": "vendor-turn-1",
+                    "output": "x" * 2048,
+                },
+            },
+            {
+                "timestamp": _iso_timestamp(minutes_offset=0),
+                "type": "event_msg",
+                "payload": {
+                    "type": "task_complete",
+                    "turn_id": "vendor-turn-1",
+                    "last_agent_message": None,
+                },
+            },
+        ],
+    )
+    runtime = CodexManagedSessionRuntime(
+        workspace_path=request.workspace_path,
+        session_workspace_path=request.session_workspace_path,
+        artifact_spool_path=request.artifact_spool_path,
+        codex_home_path=request.codex_home_path,
+        image_ref=request.image_ref,
+        control_url="docker-exec://mm-codex-session-sess-1",
+        container_id="ctr-1",
+        app_server_command=("python3", str(script)),
+    )
+    runtime.launch_session(request)
+    monkeypatch.setattr(
+        runtime,
+        "_new_rollout_live_mirror",
+        lambda _state: _RolloutLiveMirror(
+            path=str(transcript_path),
+            offset=transcript_path.stat().st_size,
+            last_assistant_text=(
+                "Implemented and verified the requested change."
+            ),
+        ),
+    )
+
+    response = runtime.send_turn(
+        SendCodexManagedSessionTurnRequest(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            containerId="ctr-1",
+            threadId="logical-thread-1",
+            instructions="Reply with exactly the word OK",
+        )
+    )
+
+    assert response.status == "completed", response.model_dump(
+        by_alias=True, mode="json"
+    )
+    assert response.metadata["assistantText"] == (
+        "Implemented and verified the requested change."
+    )
+    assert "failureCause" not in response.metadata
+
+
 def test_runtime_send_turn_classifies_no_credits_token_count_as_provider_failure(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
+++ b/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
@@ -26,6 +26,7 @@ from moonmind.workflows.temporal.runtime.codex_session_runtime import (
     CodexSessionRuntimeState,
     _ROLLOUT_RECOVERY_MAX_BYTES,
     _RolloutLiveMirror,
+    _is_empty_assistant_failure_reason,
     _run_ready,
 )
 from tests.helpers.codex_session_runtime import (
@@ -364,6 +365,13 @@ def test_redaction_preserves_falsy_non_none_values() -> None:
     assert CodexManagedSessionRuntime._redact_diagnostic_text(False) == "False"
 
 
+def test_empty_assistant_failure_reason_normalizes_text() -> None:
+    assert _is_empty_assistant_failure_reason(
+        "  Codex app-server turn/completed produced no assistant output  "
+    )
+    assert not _is_empty_assistant_failure_reason("provider request failed")
+
+
 def test_runtime_send_turn_mirrors_rollout_updates_to_stdout_spool(
     tmp_path: Path,
 ) -> None:
@@ -574,6 +582,84 @@ def test_runtime_rollout_live_mirror_keeps_repeated_identical_tool_events(
     assert (runtime._artifact_spool_path / "stdout.log").read_text(
         encoding="utf-8"
     ) == stdout_text
+
+
+def test_runtime_live_mirror_caches_only_active_turn_assistant_text(
+    tmp_path: Path,
+) -> None:
+    runtime = _runtime_for_rollout_mirror(tmp_path)
+    rollout_path = (
+        runtime._codex_home_path
+        / "sessions"
+        / "2026"
+        / "07"
+        / "10"
+        / "rollout-2026-07-10T18-34-47-vendor-thread-1.jsonl"
+    )
+    rollout_path.parent.mkdir(parents=True)
+    entries = [
+        {
+            "timestamp": _iso_timestamp(minutes_offset=0),
+            "type": "event_msg",
+            "payload": {
+                "type": "agent_message",
+                "message": "Delayed previous-turn message",
+            },
+        },
+        {
+            "timestamp": _iso_timestamp(minutes_offset=0),
+            "type": "event_msg",
+            "payload": {
+                "type": "task_started",
+                "turn_id": "vendor-turn-1",
+            },
+        },
+        {
+            "timestamp": _iso_timestamp(minutes_offset=0),
+            "type": "event_msg",
+            "payload": {
+                "type": "agent_message",
+                "message": "Active-turn message",
+            },
+        },
+        {
+            "timestamp": _iso_timestamp(minutes_offset=0),
+            "type": "event_msg",
+            "payload": {
+                "type": "task_complete",
+                "turn_id": "vendor-turn-1",
+            },
+        },
+        {
+            "timestamp": _iso_timestamp(minutes_offset=0),
+            "type": "event_msg",
+            "payload": {
+                "type": "agent_message",
+                "message": "Delayed message after completion",
+            },
+        },
+    ]
+    rollout_path.write_text(
+        "".join(f"{json.dumps(entry)}\n" for entry in entries),
+        encoding="utf-8",
+    )
+    mirror = _RolloutLiveMirror(
+        path=str(rollout_path),
+        offset=0,
+        turn_started_at=time.time(),
+    )
+
+    runtime._publish_rollout_live_updates(
+        state=_rollout_state(rollout_path=rollout_path),
+        vendor_turn_id="vendor-turn-1",
+        thread_payload={},
+        mirror=mirror,
+    )
+
+    assert mirror.last_assistant_text == "Active-turn message"
+    assert mirror.last_assistant_text_matches_active_turn is True
+    assert mirror.inside_active_turn is False
+
 
 def test_runtime_session_status_fails_when_completed_turn_has_no_assistant_output(
     tmp_path: Path,
@@ -1092,6 +1178,7 @@ def test_runtime_send_turn_preserves_live_assistant_output_outside_scan_tail(
             last_assistant_text=(
                 "Implemented and verified the requested change."
             ),
+            last_assistant_text_matches_active_turn=True,
         ),
     )
 

--- a/tests/unit/test_pytest_unit_workflow.py
+++ b/tests/unit/test_pytest_unit_workflow.py
@@ -39,7 +39,7 @@ def test_unit_fast_physically_ignores_heavy_collection_paths() -> None:
     assert "--junitxml=artifacts/pytest-unit-fast.xml" in command
 
 
-def test_unit_workflow_keeps_api_and_temporal_boundary_ownership() -> None:
+def test_unit_workflow_keeps_api_and_temporal_ownership() -> None:
     api_command = _run_command("api-component", "Run API/component suite")
     temporal_command = _run_command("temporal-boundary", "Run Temporal boundary suite")
 
@@ -49,7 +49,8 @@ def test_unit_workflow_keeps_api_and_temporal_boundary_ownership() -> None:
     assert "--junitxml=artifacts/pytest-api-component.xml" in api_command
 
     assert "python -m pytest tests/unit/workflows/temporal" in temporal_command
-    assert '-m "temporal_boundary and not slow"' in temporal_command
+    assert '-m "not slow"' in temporal_command
+    assert "temporal_boundary and not slow" not in temporal_command
     assert "--junitxml=artifacts/pytest-temporal-boundary.xml" in temporal_command
 
 

--- a/tests/unit/workflows/temporal/test_activity_runtime.py
+++ b/tests/unit/workflows/temporal/test_activity_runtime.py
@@ -6,6 +6,7 @@ import asyncio
 import json
 import re
 import stat
+import subprocess
 import sys
 from contextlib import asynccontextmanager
 from datetime import datetime, timedelta, timezone
@@ -3973,6 +3974,105 @@ async def test_sandbox_rejects_workspace_outside_sandbox_root(tmp_path: Path):
             workspace_ref=outside_workspace,
             cmd=("pwd",),
         )
+
+
+async def test_checkpoint_capture_accepts_managed_agent_workspace(
+    tmp_path: Path,
+) -> None:
+    workspace_root = tmp_path / "workspaces"
+    managed_workspace_root = tmp_path / "agent_jobs"
+    workspace = managed_workspace_root / "mm:workflow-1" / "repo"
+    workspace.mkdir(parents=True)
+    subprocess.run(
+        ["git", "init"],
+        cwd=workspace,
+        check=True,
+        stdout=subprocess.PIPE,
+    )
+    subprocess.run(
+        ["git", "config", "user.email", "test@example.com"],
+        cwd=workspace,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test User"],
+        cwd=workspace,
+        check=True,
+    )
+    target = workspace / "README.md"
+    target.write_text("base\n", encoding="utf-8")
+    subprocess.run(["git", "add", "README.md"], cwd=workspace, check=True)
+    subprocess.run(
+        ["git", "commit", "-m", "base"],
+        cwd=workspace,
+        check=True,
+        stdout=subprocess.PIPE,
+    )
+    base_commit = subprocess.check_output(
+        ["git", "rev-parse", "HEAD"], cwd=workspace, text=True
+    ).strip()
+    target.write_text("base\nchanged\n", encoding="utf-8")
+
+    activities = TemporalSandboxActivities(
+        workspace_root=workspace_root,
+        managed_workspace_root=managed_workspace_root,
+    )
+
+    result = await activities.workspace_capture_checkpoint(
+        {
+            "identity": {
+                "workflowId": "workflow-1",
+                "runId": "run-1",
+                "logicalStepId": "implement",
+                "executionOrdinal": 1,
+            },
+            "boundary": "after_execution",
+            "kind": "git_patch",
+            "workspacePath": str(workspace),
+            "artifactNamespace": "checkpoint",
+            "idempotencyKey": "workflow-1:checkpoint:after_execution",
+            "baseCommit": base_commit,
+        }
+    )
+
+    assert result["status"] == "captured"
+    assert result["workspace"]["kind"] == "git_patch"
+    assert result["workspace"]["patchRef"]
+
+
+async def test_checkpoint_capture_rejects_workspace_outside_approved_roots(
+    tmp_path: Path,
+) -> None:
+    workspace_root = tmp_path / "workspaces"
+    managed_workspace_root = tmp_path / "agent_jobs"
+    outside_workspace = tmp_path / "outside" / "repo"
+    outside_workspace.mkdir(parents=True)
+    activities = TemporalSandboxActivities(
+        workspace_root=workspace_root,
+        managed_workspace_root=managed_workspace_root,
+    )
+
+    with pytest.raises(
+        TemporalActivityRuntimeError,
+        match="escapes approved checkpoint roots",
+    ):
+        await activities.workspace_capture_checkpoint(
+            {
+                "identity": {
+                    "workflowId": "workflow-1",
+                    "runId": "run-1",
+                    "logicalStepId": "implement",
+                    "executionOrdinal": 1,
+                },
+                "boundary": "after_execution",
+                "kind": "git_patch",
+                "workspacePath": str(outside_workspace),
+                "artifactNamespace": "checkpoint",
+                "idempotencyKey": "workflow-1:checkpoint:outside",
+                "baseCommit": "abc123",
+            }
+        )
+
 
 async def test_sandbox_checkout_rejects_local_path_outside_workspace_root(
     tmp_path: Path,

--- a/tests/unit/workflows/temporal/test_activity_runtime.py
+++ b/tests/unit/workflows/temporal/test_activity_runtime.py
@@ -4074,6 +4074,56 @@ async def test_checkpoint_capture_rejects_workspace_outside_approved_roots(
         )
 
 
+async def test_checkpoint_capture_rejects_shared_managed_workspace_levels(
+    tmp_path: Path,
+) -> None:
+    workspace_root = tmp_path / "workspaces"
+    managed_workspace_root = tmp_path / "agent_jobs"
+    managed_workspace_root.mkdir()
+    job_root = managed_workspace_root / "mm:workflow-1"
+    job_root.mkdir()
+    activities = TemporalSandboxActivities(
+        workspace_root=workspace_root,
+        managed_workspace_root=managed_workspace_root,
+    )
+
+    for unsafe_workspace in (managed_workspace_root, job_root):
+        with pytest.raises(
+            TemporalActivityRuntimeError,
+            match="escapes approved checkpoint roots",
+        ):
+            await activities.workspace_capture_checkpoint(
+                {
+                    "identity": {
+                        "workflowId": "workflow-1",
+                        "runId": "run-1",
+                        "logicalStepId": "implement",
+                        "executionOrdinal": 1,
+                    },
+                    "boundary": "after_execution",
+                    "kind": "worktree_archive",
+                    "workspacePath": str(unsafe_workspace),
+                    "artifactNamespace": "checkpoint",
+                    "idempotencyKey": (
+                        f"workflow-1:checkpoint:{unsafe_workspace.name}"
+                    ),
+                }
+            )
+
+
+async def test_managed_workspace_root_expands_user_directory(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    activities = TemporalSandboxActivities(
+        workspace_root=tmp_path / "workspaces",
+        managed_workspace_root="~/agent_jobs",
+    )
+
+    assert activities._managed_workspace_root == tmp_path / "agent_jobs"
+
+
 async def test_sandbox_checkout_rejects_local_path_outside_workspace_root(
     tmp_path: Path,
 ):


### PR DESCRIPTION
## Summary

- allow checkpoint capture for managed-agent workspaces while retaining fail-closed path validation
- preserve live Codex assistant output when long transcripts exceed the bounded recovery tail
- run all non-slow Temporal unit tests when Temporal code changes
- add incident-shaped regression coverage for both runtime failures

## Root cause

A completed Codex turn was misclassified after earlier assistant output fell outside the bounded transcript scan. The parent then masked that outcome because checkpoint capture accepted only sandbox workspaces, not the managed workspace tree it had been given. CI also skipped most fast Temporal activity tests on ordinary Temporal PRs.

## Validation

- 81 Codex session runtime tests
- 141 Temporal activity runtime tests
- focused checkpoint integration tests
- 16 CI selector tests
- Python compilation and diff checks
- live sandbox worker validation against the original managed workspace path