### PR TITLE
MoonLadderStudios/MoonMind#3140: Make PR-resolver terminal artifacts authoritative

### DIFF
--- a/docs/Steps/SkillGithubPrResolver.md
+++ b/docs/Steps/SkillGithubPrResolver.md
@@ -86,6 +86,13 @@ Write a machine-readable result to the Workflow artifact directory:
 * `artifacts/pr_resolver_snapshot.json`
 * `artifacts/pr_resolver_result.json`
 
+The managed-agent adapter treats `var/pr_resolver/result.json` as the canonical
+terminal orchestration summary. `artifacts/pr_resolver_result.json` remains a
+supported terminal compatibility path for older resolver producers. Both paths
+must contain a valid terminal disposition and current-run evidence; files under
+`var/pr_resolver/attempts/` are diagnostic evidence only and never determine the
+parent workflow disposition.
+
 Result should include:
 * Resolved PR identity
 * Decision summary (actions taken)

--- a/moonmind/workflows/adapters/managed_agent_adapter.py
+++ b/moonmind/workflows/adapters/managed_agent_adapter.py
@@ -85,6 +85,9 @@ _PR_RESOLVER_MERGED_STATUSES: frozenset[str] = frozenset({"merged"})
 _PR_RESOLVER_TERMINAL_STATUSES: frozenset[str] = (
     _PR_RESOLVER_FAILURE_STATUSES | _PR_RESOLVER_MERGED_STATUSES
 )
+_PR_RESOLVER_TERMINAL_DISPOSITIONS: frozenset[str] = frozenset(
+    {"merged", "already_merged", "reenter_gate", "manual_review", "hard_failure"}
+)
 _PR_RESOLVER_REENTER_NEXT_STEPS: frozenset[str] = frozenset(
     {
         "run_fix_comments_skill",
@@ -684,7 +687,11 @@ def _load_pr_resolver_terminal_result(
         if payload is None:
             failures.append(f"{provenance}: malformed JSON object")
             continue
-        if _pr_resolver_disposition(payload) is None:
+        disposition = _pr_resolver_disposition(payload, merge_gate_owned=True)
+        if (
+            _pr_resolver_status(payload) not in _PR_RESOLVER_TERMINAL_STATUSES
+            and disposition not in _PR_RESOLVER_TERMINAL_DISPOSITIONS
+        ):
             failures.append(f"{provenance}: unrecognized terminal status/disposition")
             continue
         artifact_run_id = _payload_identity(

--- a/moonmind/workflows/adapters/managed_agent_adapter.py
+++ b/moonmind/workflows/adapters/managed_agent_adapter.py
@@ -708,11 +708,15 @@ def _load_pr_resolver_terminal_result(
         # Filesystems and the run store do not share guaranteed sub-second clock
         # precision. Allow a narrow boundary tolerance while still rejecting
         # artifacts left by an earlier execution.
-        if not_before is not None and timestamp < (
-            not_before.astimezone(UTC) - timedelta(seconds=1)
-        ):
-            failures.append(f"{provenance}: stale terminal artifact")
-            continue
+        if not_before is not None:
+            cutoff = (
+                not_before
+                if not_before.tzinfo is not None
+                else not_before.replace(tzinfo=UTC)
+            )
+            if timestamp < (cutoff.astimezone(UTC) - timedelta(seconds=1)):
+                failures.append(f"{provenance}: stale terminal artifact")
+                continue
         return _PrResolverEvidence(payload, provenance, tuple(failures))
     return _PrResolverEvidence(None, None, tuple(failures))
 

--- a/moonmind/workflows/adapters/managed_agent_adapter.py
+++ b/moonmind/workflows/adapters/managed_agent_adapter.py
@@ -28,7 +28,7 @@ import json
 import logging
 from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import dataclass
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 from uuid import uuid4
@@ -276,6 +276,8 @@ def _pr_resolver_disposition(
         or next_step.startswith("run_fix_")
     ):
         return "reenter_gate"
+    if status in _PR_RESOLVER_FAILURE_STATUSES:
+        return "manual_review"
     return ""
 
 
@@ -696,7 +698,12 @@ def _load_pr_resolver_terminal_result(
             failures.append(f"{provenance}: workflow identity mismatch")
             continue
         timestamp = _payload_sort_timestamp(path, payload)
-        if not_before is not None and timestamp < not_before.astimezone(UTC):
+        # Filesystems and the run store do not share guaranteed sub-second clock
+        # precision. Allow a narrow boundary tolerance while still rejecting
+        # artifacts left by an earlier execution.
+        if not_before is not None and timestamp < (
+            not_before.astimezone(UTC) - timedelta(seconds=1)
+        ):
             failures.append(f"{provenance}: stale terminal artifact")
             continue
         return _PrResolverEvidence(payload, provenance, tuple(failures))

--- a/moonmind/workflows/adapters/managed_agent_adapter.py
+++ b/moonmind/workflows/adapters/managed_agent_adapter.py
@@ -637,41 +637,96 @@ def _payload_sort_timestamp(path: Path, payload: dict[str, Any]) -> datetime:
     except OSError:
         return datetime.min.replace(tzinfo=UTC)
 
-def _load_pr_resolver_result(workspace_path: str | None) -> dict[str, Any] | None:
-    """Load the most recent pr-resolver payload from result/attempt artifacts."""
+@dataclass(frozen=True, slots=True)
+class _PrResolverEvidence:
+    payload: dict[str, Any] | None
+    provenance: str | None
+    validation_failures: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class _PrResolverDiagnostics:
+    attempt_count: int
+    latest: dict[str, Any] | None
+    provenance: str | None
+
+
+def _payload_identity(payload: Mapping[str, Any], *keys: str) -> str | None:
+    for key in keys:
+        value = str(payload.get(key) or "").strip()
+        if value:
+            return value
+    return None
+
+
+def _load_pr_resolver_terminal_result(
+    workspace_path: str | None,
+    *,
+    run_id: str | None = None,
+    workflow_id: str | None = None,
+    not_before: datetime | None = None,
+) -> _PrResolverEvidence:
+    """Load and validate only authoritative terminal resolver artifacts."""
 
     workspace = str(workspace_path or "").strip()
     if not workspace:
-        return None
-
-    workspace_root = Path(workspace)
-    candidates: list[tuple[datetime, Path, dict[str, Any]]] = []
-
+        return _PrResolverEvidence(None, None, ())
+    root = Path(workspace)
+    failures: list[str] = []
     for rel_path in _PR_RESOLVER_RESULT_PATHS:
-        result_path = workspace_root / rel_path
-        payload = _load_json_dict(result_path)
-        if payload is not None:
-            candidates.append(
-                (_payload_sort_timestamp(result_path, payload), result_path, payload)
-            )
+        path = root / rel_path
+        if not path.exists():
+            continue
+        payload = _load_json_dict(path)
+        provenance = str(rel_path)
+        if payload is None:
+            failures.append(f"{provenance}: malformed JSON object")
+            continue
+        if _pr_resolver_disposition(payload) is None:
+            failures.append(f"{provenance}: unrecognized terminal status/disposition")
+            continue
+        artifact_run_id = _payload_identity(
+            payload, "runId", "run_id", "executionId", "execution_id"
+        )
+        if artifact_run_id and run_id and artifact_run_id != run_id:
+            failures.append(f"{provenance}: run identity mismatch")
+            continue
+        artifact_workflow_id = _payload_identity(payload, "workflowId", "workflow_id")
+        if artifact_workflow_id and workflow_id and artifact_workflow_id != workflow_id:
+            failures.append(f"{provenance}: workflow identity mismatch")
+            continue
+        timestamp = _payload_sort_timestamp(path, payload)
+        if not_before is not None and timestamp < not_before.astimezone(UTC):
+            failures.append(f"{provenance}: stale terminal artifact")
+            continue
+        return _PrResolverEvidence(payload, provenance, tuple(failures))
+    return _PrResolverEvidence(None, None, tuple(failures))
 
-    attempts_dir = workspace_root / _PR_RESOLVER_ATTEMPTS_DIR
+
+def _load_pr_resolver_diagnostics(workspace_path: str | None) -> _PrResolverDiagnostics:
+    """Load bounded attempt evidence which never controls terminal disposition."""
+
+    workspace = str(workspace_path or "").strip()
+    if not workspace:
+        return _PrResolverDiagnostics(0, None, None)
+    root = Path(workspace)
+    attempts_dir = root / _PR_RESOLVER_ATTEMPTS_DIR
+    candidates: list[tuple[datetime, Path, dict[str, Any]]] = []
     try:
-        attempt_paths = sorted(attempts_dir.glob("*.json"))
+        paths = sorted(attempts_dir.glob("*.json"))
     except OSError:
-        attempt_paths = []
-    for attempt_path in attempt_paths:
-        payload = _load_json_dict(attempt_path)
+        paths = []
+    for path in paths:
+        payload = _load_json_dict(path)
         if payload is not None:
-            candidates.append(
-                (_payload_sort_timestamp(attempt_path, payload), attempt_path, payload)
-            )
-
+            candidates.append((_payload_sort_timestamp(path, payload), path, payload))
     if not candidates:
-        return None
-
+        return _PrResolverDiagnostics(0, None, None)
     candidates.sort(key=lambda item: (item[0], str(item[1])))
-    return candidates[-1][2]
+    _, latest_path, latest = candidates[-1]
+    return _PrResolverDiagnostics(
+        len(candidates), latest, str(latest_path.relative_to(root))
+    )
 
 # Type aliases for async signal callables injected by the caller/workflow.
 ProfileFetcherFunc = Callable[..., Awaitable[dict[str, Any]]]
@@ -685,9 +740,15 @@ def _derive_pr_resolver_failure(
     workspace_path: str | None,
     *,
     merge_gate_owned: bool = False,
+    run_id: str | None = None,
+    workflow_id: str | None = None,
+    not_before: datetime | None = None,
 ) -> tuple[str | None, str | None]:
     """Return failure metadata from pr-resolver artifacts when present."""
-    payload = _load_pr_resolver_result(workspace_path)
+    evidence = _load_pr_resolver_terminal_result(
+        workspace_path, run_id=run_id, workflow_id=workflow_id, not_before=not_before
+    )
+    payload = evidence.payload
     if payload is None:
         return (
             "user_error",
@@ -722,15 +783,42 @@ def _derive_pr_resolver_metadata(
     workspace_path: str | None,
     *,
     merge_gate_owned: bool = False,
+    run_id: str | None = None,
+    workflow_id: str | None = None,
+    not_before: datetime | None = None,
 ) -> dict[str, Any]:
     """Return compact metadata from pr-resolver artifacts for parent workflows."""
-    payload = _load_pr_resolver_result(workspace_path)
+    evidence = _load_pr_resolver_terminal_result(
+        workspace_path, run_id=run_id, workflow_id=workflow_id, not_before=not_before
+    )
+    diagnostics = _load_pr_resolver_diagnostics(workspace_path)
+    metadata: dict[str, Any] = {}
+    if evidence.provenance:
+        metadata["prResolverTerminalProvenance"] = evidence.provenance
+    if evidence.validation_failures:
+        metadata["prResolverTerminalValidationFailures"] = list(
+            evidence.validation_failures
+        )
+    if diagnostics.latest is not None:
+        latest = diagnostics.latest
+        compact = {
+            "attemptCount": diagnostics.attempt_count,
+            "provenance": diagnostics.provenance,
+        }
+        for source, target in (
+            ("final_reason", "reason"), ("reason", "reason"),
+            ("next_step", "nextStep"), ("nextStep", "nextStep"),
+        ):
+            value = str(latest.get(source) or "").strip()
+            if value and target not in compact:
+                compact[target] = value
+        metadata["prResolverLatestAttempt"] = compact
+    payload = evidence.payload
     if payload is None:
-        return {}
+        return metadata
 
     status = _pr_resolver_status(payload)
     reason = str(payload.get("final_reason") or payload.get("reason") or "").strip()
-    metadata: dict[str, Any] = {}
     disposition = _pr_resolver_disposition(
         payload, merge_gate_owned=merge_gate_owned
     )
@@ -1043,11 +1131,19 @@ class ManagedAgentAdapter:
                 metadata = _derive_pr_resolver_metadata(
                     record.workspace_path,
                     merge_gate_owned=pr_resolver_merge_gate_owned,
+                    run_id=record.run_id,
+                    workflow_id=record.workflow_id,
+                    not_before=record.started_at,
                 )
                 if (
                     include_workspace_auto_publish_evidence
                     and "publishResult" not in metadata
-                    and _load_pr_resolver_result(record.workspace_path) is None
+                    and _load_pr_resolver_terminal_result(
+                        record.workspace_path,
+                        run_id=record.run_id,
+                        workflow_id=record.workflow_id,
+                        not_before=record.started_at,
+                    ).payload is None
                 ):
                     publish_payload = _load_auto_publish_result_payload(
                         record.workspace_path,
@@ -1063,6 +1159,9 @@ class ManagedAgentAdapter:
                     derived_failure_class, derived_summary = _derive_pr_resolver_failure(
                         record.workspace_path,
                         merge_gate_owned=pr_resolver_merge_gate_owned,
+                        run_id=record.run_id,
+                        workflow_id=record.workflow_id,
+                        not_before=record.started_at,
                     )
                     resolver_disposition = str(
                         metadata.get("mergeAutomationDisposition") or ""

--- a/reports/remediation_attempt-1.json
+++ b/reports/remediation_attempt-1.json
@@ -1,89 +1,57 @@
 {
   "artifact_type": "remediation.attempt",
   "attempt": 1,
-  "issue_ref": "MM-1172",
-  "issue_url": "https://moonladder.atlassian.net/browse/MM-1172",
-  "source_verification_artifact": "artifacts/jira-implement-verify.json",
+  "issue_ref": "MoonLadderStudios/MoonMind#3140",
+  "source_verification_artifact": "artifacts/github-issue-implement-verify.json",
   "source_verdict": "ADDITIONAL_WORK_NEEDED",
-  "brief_truncated": false,
-  "summary": "Remediated the verifier-reported execution-router gaps for provider profile model tier launch metadata. Legacy provider profiles that only expose default_model/default_effort now preserve the compatibility modelSource provider_profile_default instead of being reclassified as profile_default_tier. Execution launch paths now record modelTierResolution only when tier policy is actually involved: an explicit modelTier, an advisory tierPreview, or a provider profile with configured model_tiers. Added focused launch-path coverage proving stale tierPreview data is advisory, backend resolution re-runs against the current profile policy, and modelTierResolution.previewMismatch is recorded.",
+  "summary": "Corrected stale terminal evidence coverage and resolved focused adapter-suite failures exposed once the documented test dependencies were installed. Terminal failures now retain manual-review disposition, and terminal artifact freshness allows a one-second precision boundary between filesystem timestamps and run-store start timestamps while still rejecting genuinely stale evidence.",
   "changed_files": [
-    "api_service/api/routers/executions.py",
-    "moonmind/workflows/executions/model_resolver.py",
-    "tests/unit/api/routers/test_executions.py",
+    "moonmind/workflows/adapters/managed_agent_adapter.py",
+    "tests/unit/workflows/adapters/test_managed_agent_adapter.py",
     "reports/remediation_attempt-1.json"
   ],
   "gap_statuses": [
     {
-      "requirement": "Preview output is advisory and does not replace launch-time backend resolution.",
+      "requirement": "Add coverage for stale terminal evidence",
       "gap_type": "verification",
       "status": "fixed",
-      "evidence": [
-        "api_service/api/routers/executions.py now gates modelTierResolution emission through _should_record_model_tier_resolution so ordinary non-tier launch payloads retain their prior shape while tier-policy launches still record resolved metadata.",
-        "tests/unit/api/routers/test_executions.py::test_create_task_shaped_execution_records_tier_preview_mismatch submits stale tierPreview data and verifies launch-time backend resolution stores the current profile model/effort instead of trusting the preview snapshot.",
-        "./tools/test_unit.sh tests/unit/api/routers/test_executions.py passed."
-      ]
+      "evidence": "The malformed-and-stale test now uses the current run identity and asserts 'stale terminal artifact', reaching the freshness rejection branch."
     },
     {
-      "requirement": "Backend can detect and record preview mismatch when submitted preview state differs from current profile policy.",
+      "requirement": "Run the focused adapter unit and boundary coverage",
       "gap_type": "verification",
       "status": "fixed",
-      "evidence": [
-        "tests/unit/api/routers/test_executions.py::test_create_task_shaped_execution_records_tier_preview_mismatch asserts modelTierResolution.previewMismatch is true in initial_parameters when the submitted preview model differs from the resolver output.",
-        "The same test asserts requestedModelTier, effectiveModelTier, resolvedModel, resolvedEffort, modelSource, effortSource, and fallbackReason in the recorded modelTierResolution payload."
-      ]
+      "evidence": "Installed the declared tests extra and the exact focused runner completed successfully: 78 Python tests passed; the automatic frontend phase also passed."
     },
     {
-      "requirement": "Provider profile default compatibility during migration.",
+      "requirement": "Preserve established manual-review terminal result behavior",
       "gap_type": "implementation",
       "status": "fixed",
-      "evidence": [
-        "moonmind/workflows/executions/model_resolver.py now distinguishes explicitly configured model_tiers from tiers derived from legacy default_model/default_effort fields.",
-        "Legacy profiles without configured model_tiers continue to resolve modelSource=provider_profile_default unless an explicit requested model tier is supplied.",
-        "Previously failing tests test_step_runtime_inherits_task_profile_default_model and test_create_task_shaped_execution_accepts_provider_profile_alias now pass in ./tools/test_unit.sh tests/unit/api/routers/test_executions.py."
-      ]
+      "evidence": "Focused execution revealed that failed, blocked, and attempts_exhausted terminal results lost mergeAutomationDisposition. They now derive manual_review unless an owned merge gate derives reenter_gate."
+    },
+    {
+      "requirement": "Reject stale artifacts without rejecting run-boundary writes",
+      "gap_type": "implementation",
+      "status": "fixed",
+      "evidence": "Freshness validation now permits a one-second filesystem/run-store timestamp precision tolerance; the explicit 2020 stale artifact remains rejected."
     }
-  ],
-  "unchanged_verified_requirements": [
-    "Provider Profile create/update accepts model_tiers and default_model_tier.",
-    "Provider Profile responses include tier policy plus compatibility fields during migration.",
-    "The preview endpoint returns requested tier, effective tier, model, effort, and fallback reason for each requested step.",
-    "Use backend resolver logic for preview parity.",
-    "Do not require presets to name concrete models for preview."
   ],
   "targeted_checks": [
     {
-      "command": "./tools/test_unit.sh tests/unit/api/routers/test_executions.py",
+      "command": "MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/adapters/test_managed_agent_adapter.py",
       "result": "PASS",
-      "notes": "357 Python tests passed, including the new launch-path preview mismatch coverage and the four previously failing execution-router tests. The runner UI phase also passed: 60 files passed, 942 tests passed, 238 skipped. Warnings were existing Starlette deprecation, AsyncMock resource, and jsdom canvas getContext warnings."
-    },
-    {
-      "command": "./tools/test_unit.sh tests/unit/api_service/api/routers/test_provider_profiles.py tests/unit/workflows/executions/test_model_resolver.py",
-      "result": "PASS",
-      "notes": "82 Python tests passed for provider profile API and model resolver coverage. The runner UI phase also passed: 60 files passed, 942 tests passed, 238 skipped. Warnings were existing google.generativeai deprecation and jsdom canvas getContext warnings."
+      "notes": "78 Python tests passed with four non-blocking pytest marker warnings. Automatic frontend phase: 63 files passed; 972 tests passed and 238 skipped."
     },
     {
       "command": "git diff --check",
       "result": "PASS",
-      "notes": "No whitespace errors reported for the working tree diff."
+      "notes": "No whitespace errors."
     }
   ],
   "remaining_work": [],
-  "environment_notes": [
-    {
-      "item": "MoonMind RAG retrieved context",
-      "status": "NOT_USED",
-      "detail": "Retrieved context was delivered in degraded local fallback mode and was not needed for this bounded remediation; direct repository files and the authoritative verifier artifact controlled the work."
-    },
-    {
-      "item": "Stale prior artifact overwritten",
-      "status": "NOTE",
-      "detail": "reports/remediation_attempt-1.json previously described MM-1146. It was replaced with this MM-1172 remediation attempt record."
-    }
-  ],
   "scope_controls": {
     "pull_request_created": false,
-    "jira_status_changed": false,
+    "github_issue_status_changed": false,
     "scope_broadened": false
   }
 }

--- a/reports/remediation_attempt-2.json
+++ b/reports/remediation_attempt-2.json
@@ -1,0 +1,45 @@
+{
+  "artifact_type": "remediation.attempt",
+  "attempt": 2,
+  "issue_ref": "MoonLadderStudios/MoonMind#3140",
+  "source_verification_artifact": "artifacts/github-issue-implement-verify.json",
+  "source_verdict": "ADDITIONAL_WORK_NEEDED",
+  "summary": "Terminal artifact validation now rejects parseable payloads unless they contain a recognized terminal status or a recognized terminal disposition. A focused regression test covers an arbitrary parseable object while preserving established status-based and disposition-only result shapes.",
+  "changed_files": [
+    "moonmind/workflows/adapters/managed_agent_adapter.py",
+    "tests/unit/workflows/adapters/test_managed_agent_adapter.py",
+    "reports/remediation_attempt-2.json"
+  ],
+  "gap_statuses": [
+    {
+      "requirement": "A terminal result must have a recognized terminal status/disposition",
+      "gap_type": "implementation",
+      "status": "fixed",
+      "evidence": "Terminal loading now requires membership in the recognized terminal-status or terminal-disposition sets; empty and arbitrary dispositions cannot become authoritative evidence."
+    },
+    {
+      "requirement": "Unrecognized parseable terminal evidence must be covered",
+      "gap_type": "verification",
+      "status": "fixed",
+      "evidence": "test_pr_resolver_rejects_unrecognized_terminal_evidence writes a valid JSON object without terminal semantics and asserts rejection plus the compact validation failure."
+    }
+  ],
+  "targeted_checks": [
+    {
+      "command": "MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/adapters/test_managed_agent_adapter.py && git diff --check",
+      "result": "FAIL",
+      "notes": "The first run exposed four established reenter-gate cases that use recognized terminal statuses while disposition derivation is context-dependent. Validation was narrowed to accept recognized statuses or a recognized disposition."
+    },
+    {
+      "command": "MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/adapters/test_managed_agent_adapter.py && git diff --check",
+      "result": "PASS",
+      "notes": "79 Python tests passed with five non-blocking pytest marker warnings. Automatic frontend phase passed 63 files and 972 tests with 238 skipped. Diff hygiene passed."
+    }
+  ],
+  "remaining_work": [],
+  "scope_controls": {
+    "pull_request_created": false,
+    "github_issue_status_changed": false,
+    "scope_broadened": false
+  }
+}

--- a/reports/remediation_verification-1.json
+++ b/reports/remediation_verification-1.json
@@ -1,223 +1,40 @@
 {
   "artifact_type": "remediation.verification",
-  "skill": "moonspec-verify",
-  "mode": "issue_brief",
-  "verification_target": "issue_brief",
   "attempt": 1,
-  "maxAttempts": 6,
-  "verifiesRemediationAttempt": 1,
-  "remediationAttemptArtifact": "reports/remediation_attempt-1.json",
-  "verificationArtifact": "artifacts/jira-implement-verify.json",
-  "sourceBriefArtifact": "artifacts/jira-implement-brief.json",
-  "sourceAssessmentArtifact": "artifacts/jira-implement-assessment.json",
-  "issueProvider": "jira",
-  "issueRef": "MM-1172",
-  "issueUrl": "https://moonladder.atlassian.net/browse/MM-1172",
-  "branch": "run-jira-implement-for-mm-1172-expose-pr-f0c41c59",
-  "baseRef": "origin/main",
-  "headCommit": "ed194f39bccf5923db0760231c4e864ad2a57b86",
-  "verdict": "FULLY_IMPLEMENTED",
-  "authoritativeVerdict": "FULLY_IMPLEMENTED",
-  "recommendedNextAction": "advance",
+  "remediation_attempt": 1,
+  "remediation_attempt_artifact": "reports/remediation_attempt-1.json",
+  "authoritative_verification_artifact": "artifacts/github-issue-implement-verify.json",
+  "verification_target": "issue_brief",
+  "issue_ref": "MoonLadderStudios/MoonMind#3140",
+  "verdict": "ADDITIONAL_WORK_NEEDED",
+  "recommendedNextAction": "reattempt_current_step",
   "recoverableInCurrentRuntime": true,
-  "remainingWork": [],
-  "confidence": "HIGH",
-  "briefTruncated": false,
-  "summary": "Remediation verification attempt 1 of 6 verifies remediation attempt 1 for Jira MM-1172. Direct production-code inspection and focused unit evidence show Provider Profile tier fields, response compatibility fields, advisory preview endpoint behavior, shared backend resolver parity, launch-time authoritative re-resolution, and stale preview mismatch recording are implemented. Every repo-verifiable in-scope requirement is VERIFIED. The stale prior MM-1146 remediation verification artifact has been replaced with this MM-1172 result.",
-  "requirementCoverage": [
-    {
-      "requirement": "Provider Profile create/update accepts model_tiers and default_model_tier.",
-      "status": "VERIFIED",
-      "evidence": [
-        "api_service/api/routers/provider_profiles.py:76",
-        "api_service/api/routers/provider_profiles.py:165",
-        "api_service/api/routers/provider_profiles.py:431",
-        "api_service/db/models.py:2407",
-        "api_service/migrations/versions/335_mm1172_provider_profile_model_tiers.py:55",
-        "tests/unit/api_service/api/routers/test_provider_profiles.py:672"
-      ],
-      "notes": "Create and update schemas accept tier policy, persistence and migration add fields, and API tests cover create/update validation."
-    },
-    {
-      "requirement": "Provider Profile responses include tier policy plus compatibility fields during migration.",
-      "status": "VERIFIED",
-      "evidence": [
-        "api_service/api/routers/provider_profiles.py:238",
-        "api_service/api/routers/provider_profiles.py:1690",
-        "tests/unit/api_service/api/routers/test_provider_profiles.py:713"
-      ],
-      "notes": "Response model and row serialization include default_model/default_effort/model_overrides plus model_tiers/default_model_tier."
-    },
-    {
-      "requirement": "The preview endpoint returns requested tier, effective tier, model, effort, and fallback reason for each requested step.",
-      "status": "VERIFIED",
-      "evidence": [
-        "api_service/api/routers/provider_profiles.py:280",
-        "api_service/api/routers/provider_profiles.py:604",
-        "tests/unit/api_service/api/routers/test_provider_profiles.py:720"
-      ],
-      "notes": "Preview response model and endpoint return requestedTier, effectiveTier, model, effort, and fallbackReason per step."
-    },
-    {
-      "requirement": "Preview output is advisory and does not replace launch-time backend resolution.",
-      "status": "VERIFIED",
-      "evidence": [
-        "docs/Security/ProviderProfileModelEffortTiers.md:414",
-        "api_service/api/routers/provider_profiles.py:624",
-        "api_service/api/routers/executions.py:9818",
-        "api_service/api/routers/executions.py:9863",
-        "tests/unit/api/routers/test_executions.py:5462"
-      ],
-      "notes": "Preview endpoint is advisory, and launch paths call resolve_model_effort again using current profile policy; test coverage submits stale tierPreview and verifies current backend resolution wins."
-    },
-    {
-      "requirement": "Backend can detect and record preview mismatch when submitted preview state differs from current profile policy.",
-      "status": "VERIFIED",
-      "evidence": [
-        "moonmind/workflows/executions/model_resolver.py:307",
-        "moonmind/workflows/executions/model_resolver.py:73",
-        "api_service/api/routers/executions.py:9914",
-        "tests/unit/workflows/executions/test_model_resolver.py:320",
-        "tests/unit/api/routers/test_executions.py:5525"
-      ],
-      "notes": "Resolver compares advisory preview fields to authoritative resolution and exposes previewMismatch in metadata; execution tests assert previewMismatch true in stored launch parameters."
-    },
-    {
-      "requirement": "Use backend resolver logic for preview parity.",
-      "status": "VERIFIED",
-      "evidence": [
-        "api_service/api/routers/provider_profiles.py:627",
-        "moonmind/workflows/executions/model_resolver.py:111",
-        "tests/unit/workflows/executions/test_model_resolver.py:265"
-      ],
-      "notes": "Provider profile preview calls the same resolve_model_effort backend resolver used by launch paths."
-    },
-    {
-      "requirement": "Do not require presets to name concrete models for preview.",
-      "status": "VERIFIED",
-      "evidence": [
-        "api_service/api/routers/provider_profiles.py:280",
-        "api_service/api/routers/provider_profiles.py:604",
-        "tests/unit/api_service/api/routers/test_provider_profiles.py:703"
-      ],
-      "notes": "Preview accepts step id and modelTier without concrete model strings."
-    }
-  ],
-  "canonicalClaimCoverage": [
-    {
-      "claim": "CLAIM-docs-security-providerprofilemodelefforttiers-006 / DESIGN-REQ-003",
-      "implementationStatus": "VERIFIED",
-      "verificationStatus": "VERIFIED",
-      "driftStatus": "NONE",
-      "codeEvidence": [
-        "docs/Security/ProviderProfileModelEffortTiers.md:414",
-        "api_service/api/routers/provider_profiles.py:238",
-        "api_service/api/routers/provider_profiles.py:604"
-      ],
-      "testEvidence": [
-        "tests/unit/api_service/api/routers/test_provider_profiles.py:672"
-      ],
-      "artifactEvidence": [
-        "artifacts/jira-implement-brief.json",
-        "artifacts/jira-implement-assessment.json",
-        "reports/remediation_attempt-1.json"
-      ],
-      "gapReason": ""
-    },
-    {
-      "claim": "CLAIM-docs-security-providerprofilemodelefforttiers-010 / DESIGN-REQ-012 / DESIGN-REQ-013",
-      "implementationStatus": "VERIFIED",
-      "verificationStatus": "VERIFIED",
-      "driftStatus": "NONE",
-      "codeEvidence": [
-        "docs/Security/ProviderProfileModelEffortTiers.md:456",
-        "docs/Security/ProviderProfileModelEffortTiers.md:768",
-        "moonmind/workflows/executions/model_resolver.py:307",
-        "api_service/api/routers/executions.py:9914"
-      ],
-      "testEvidence": [
-        "tests/unit/workflows/executions/test_model_resolver.py:320",
-        "tests/unit/api/routers/test_executions.py:5462"
-      ],
-      "artifactEvidence": [
-        "artifacts/jira-implement-brief.json",
-        "artifacts/jira-implement-assessment.json",
-        "reports/remediation_attempt-1.json"
-      ],
-      "gapReason": ""
-    }
-  ],
+  "summary": "Remediation attempt 1 passes the focused adapter suite and closes the previously reported freshness and established-shape failures, but terminal validation still accepts a parseable payload with no recognized terminal status/disposition because an empty string is compared to None.",
   "testResults": [
     {
-      "suite": "Unit",
-      "command": "MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api_service/api/routers/test_provider_profiles.py tests/unit/workflows/executions/test_model_resolver.py",
+      "command": "MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/adapters/test_managed_agent_adapter.py",
       "result": "PASS",
-      "notes": "82 Python tests passed. The runner UI phase also completed successfully for this command with 60 files passed, 942 tests passed, 238 skipped."
+      "notes": "78 Python tests passed; frontend phase passed 972 tests with 238 skipped."
     },
     {
-      "suite": "Unit",
-      "command": "MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/routers/test_executions.py",
-      "result": "PASS_WITH_NON_BLOCKING_UNRELATED_UI_FAILURE",
-      "notes": "The MM-1172 controlling Python suite passed with 357 tests passed. The same shared runner then executed its broad frontend phase and failed 2 unrelated recurring-schedules dashboard tests in frontend/src/entrypoints/dashboard.test.tsx. Those tests are outside the changed backend/API scope and do not identify an in-scope MM-1172 implementation defect."
-    },
-    {
-      "suite": "Diff Check",
       "command": "git diff --check",
-      "result": "PASS",
-      "notes": "No whitespace errors reported."
-    },
-    {
-      "suite": "Integration",
-      "command": "./tools/test_integration.sh targeted integration_ci",
-      "result": "NOT RUN",
-      "notes": "Not selected for this issue-brief verification after focused repo-local API/resolver/execution unit coverage passed; any broader integration check would be advisory unless selected by runtime infrastructure impact."
+      "result": "PASS"
     }
   ],
-  "workspaceProjectionPreflight": {
-    "result": "CLEAN",
-    "detail": ".agents/skills and .gemini/skills are not projection symlinks; skills_active is absent or symlink-compatible; git status showed no tracked projection contamination for those paths."
-  },
-  "disclosedScopeExclusions": [
+  "remainingWork": [
     {
-      "item": "Automatic frontend runner failures in recurring schedules dashboard tests",
-      "reason": "The shared unit runner executed broad frontend tests after the targeted backend Python tests passed. The two failing tests are outside MM-1172 acceptance criteria, assessment backlog, and changed backend/API files.",
-      "type": "non_blocking_unrelated_test_failure"
-    }
-  ],
-  "environmentNotes": [
-    {
-      "tooling": "MoonMind RAG retrieved context",
-      "status": "NOT RUN",
-      "gatesVerdict": false,
-      "reason": "Retrieved context was delivered in degraded local fallback mode and was not needed; verification relied on direct repository inspection and focused repo-local tests."
+      "requirement": "A terminal result must have a recognized terminal status/disposition",
+      "gapType": "implementation",
+      "remainingWork": "Reject empty/unrecognized dispositions in _load_pr_resolver_terminal_result.",
+      "suggestedEvidence": ["moonmind/workflows/adapters/managed_agent_adapter.py:687"],
+      "recoverableInCurrentRuntime": true
     },
     {
-      "tooling": "Issue brief recovery",
-      "status": "NOT RUN",
-      "gatesVerdict": false,
-      "reason": "artifacts/jira-implement-brief.json has truncated=false and no truncated_fields."
+      "requirement": "Unrecognized parseable terminal evidence must be covered",
+      "gapType": "verification",
+      "remainingWork": "Add a regression test for a parseable terminal-path JSON object with no recognized terminal status/disposition and rerun the focused adapter suite.",
+      "suggestedEvidence": ["tests/unit/workflows/adapters/test_managed_agent_adapter.py:94"],
+      "recoverableInCurrentRuntime": true
     }
-  ],
-  "sourceDocumentDrift": [],
-  "gapsClosedThisAttempt": [
-    {
-      "requirement": "Preview output is advisory and does not replace launch-time backend resolution.",
-      "priorStatus": "PARTIAL",
-      "postStatus": "VERIFIED",
-      "evidence": "tests/unit/api/routers/test_executions.py:5462 submits stale tierPreview data and asserts launch-time backend resolution stores the current profile model and effort."
-    },
-    {
-      "requirement": "Backend can detect and record preview mismatch when submitted preview state differs from current profile policy.",
-      "priorStatus": "PARTIAL",
-      "postStatus": "VERIFIED",
-      "evidence": "tests/unit/api/routers/test_executions.py:5525 asserts modelTierResolution.previewMismatch is true, with resolved current model/effort metadata recorded."
-    },
-    {
-      "requirement": "Provider profile default compatibility during migration.",
-      "priorStatus": "PARTIAL",
-      "postStatus": "VERIFIED",
-      "evidence": "moonmind/workflows/executions/model_resolver.py:126 distinguishes configured tiers from legacy defaults; tests/unit/api/routers/test_executions.py passed 357 Python tests."
-    }
-  ],
-  "reportMarkdown": "# MoonSpec Verification Report: MM-1172\n\n## Verdict\nFULLY_IMPLEMENTED\n\nRecommended next action: advance\nRecoverable in current runtime: true\n\n## Scope\nVerification target: Jira issue brief for MM-1172 after remediation attempt 1 of 6.\nAuthoritative brief: artifacts/jira-implement-brief.json.\nInitial assessment: artifacts/jira-implement-assessment.json.\nRemediation attempt artifact: reports/remediation_attempt-1.json.\nThe brief is not truncated, so no issue-content recovery was required.\n\n## Summary\nMM-1172 is fully implemented for all repo-verifiable in-scope requirements. Provider Profile create/update accepts model_tiers and default_model_tier, responses include tier policy alongside compatibility fields, the preview endpoint returns requested/effective tier resolution details, preview uses shared backend resolver logic, launch-time resolution remains authoritative, and execution launch metadata records stale preview mismatch when submitted preview data differs from current profile policy.\n\nThe previous verification gap in tests/unit/api/routers/test_executions.py has been remediated: the focused execution-router Python suite now passes, including explicit stale tierPreview coverage. The shared unit runner's automatic frontend phase failed two unrelated recurring-schedules dashboard tests in frontend/src/entrypoints/dashboard.test.tsx; those files are outside the MM-1172 backend/API scope and do not identify an in-scope implementation defect.\n\n## Requirement Coverage\n- Provider Profile create/update accepts model_tiers and default_model_tier: VERIFIED. Evidence: api_service/api/routers/provider_profiles.py:76, api_service/api/routers/provider_profiles.py:165, api_service/api/routers/provider_profiles.py:431, api_service/db/models.py:2407, api_service/migrations/versions/335_mm1172_provider_profile_model_tiers.py:55, tests/unit/api_service/api/routers/test_provider_profiles.py:672.\n- Provider Profile responses include tier policy plus compatibility fields during migration: VERIFIED. Evidence: api_service/api/routers/provider_profiles.py:238, api_service/api/routers/provider_profiles.py:1690, tests/unit/api_service/api/routers/test_provider_profiles.py:713.\n- Preview endpoint returns requested tier, effective tier, model, effort, and fallback reason for each requested step: VERIFIED. Evidence: api_service/api/routers/provider_profiles.py:280, api_service/api/routers/provider_profiles.py:604, tests/unit/api_service/api/routers/test_provider_profiles.py:720.\n- Preview output is advisory and does not replace launch-time backend resolution: VERIFIED. Evidence: docs/Security/ProviderProfileModelEffortTiers.md:414, api_service/api/routers/provider_profiles.py:624, api_service/api/routers/executions.py:9818, api_service/api/routers/executions.py:9863, tests/unit/api/routers/test_executions.py:5462.\n- Backend can detect and record preview mismatch when submitted preview state differs from current profile policy: VERIFIED. Evidence: moonmind/workflows/executions/model_resolver.py:307, moonmind/workflows/executions/model_resolver.py:73, api_service/api/routers/executions.py:9914, tests/unit/workflows/executions/test_model_resolver.py:320, tests/unit/api/routers/test_executions.py:5525.\n- Use backend resolver logic for preview parity: VERIFIED. Evidence: api_service/api/routers/provider_profiles.py:627, moonmind/workflows/executions/model_resolver.py:111, tests/unit/workflows/executions/test_model_resolver.py:265.\n- Do not require presets to name concrete models for preview: VERIFIED. Evidence: api_service/api/routers/provider_profiles.py:280, api_service/api/routers/provider_profiles.py:604, tests/unit/api_service/api/routers/test_provider_profiles.py:703.\n\n## Test Results\n- PASS: MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api_service/api/routers/test_provider_profiles.py tests/unit/workflows/executions/test_model_resolver.py. Result: 82 Python tests passed. The runner UI phase also completed successfully for this command with 60 files passed, 942 tests passed, 238 skipped.\n- PASS with non-blocking unrelated runner failure: MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/routers/test_executions.py. The MM-1172 controlling Python suite passed with 357 tests passed. The same test runner then executed its broad frontend phase, where 2 unrelated recurring-schedules dashboard tests failed in frontend/src/entrypoints/dashboard.test.tsx while looking for Recurring Schedules content. This is outside the MM-1172 changed backend/API scope and does not gate this verdict.\n- PASS: git diff --check.\n\n## Canonical Claim Coverage\n- CLAIM-docs-security-providerprofilemodelefforttiers-006 / DESIGN-REQ-003: VERIFIED. Provider profile API contract includes tier policy fields and preview response shape. Drift status: NONE.\n- CLAIM-docs-security-providerprofilemodelefforttiers-010 / DESIGN-REQ-012 / DESIGN-REQ-013: VERIFIED. Backend resolver authoritatively resolves tier policy at preview and launch boundaries, and stale advisory preview mismatch is recorded. Drift status: NONE.\n\n## Disclosed Scope Exclusions and Environment Notes\n- MoonMind retrieved context was provided in degraded local fallback mode. It was not needed for the verdict and does not gate verification.\n- The automatic frontend phase failure in dashboard recurring-schedules tests is recorded as a non-blocking unrelated suite failure. It is not an MM-1172 repo-verifiable requirement and is not remaining work for this issue.\n- No integration_ci suite was run; the issue is covered by direct code inspection and focused repo-local unit coverage. Integration checks would be advisory here unless selected by broader runtime infrastructure impact.\n\n## Remaining Work\nNone.\n"
+  ]
 }

--- a/reports/remediation_verification-2.json
+++ b/reports/remediation_verification-2.json
@@ -1,0 +1,25 @@
+{
+  "artifact_type": "remediation.verification",
+  "attempt": 2,
+  "remediation_attempt_verified": 2,
+  "remediation_attempt_artifact": "reports/remediation_attempt-2.json",
+  "verification_report_artifact": "artifacts/github-issue-implement-verify.json",
+  "verification_target": "issue_brief",
+  "issue_ref": "MoonLadderStudios/MoonMind#3140",
+  "verdict": "FULLY_IMPLEMENTED",
+  "recommendedNextAction": "advance",
+  "recoverableInCurrentRuntime": true,
+  "summary": "Remediation attempt 2 closes the final recognized-terminal validation and regression-test gaps. The authoritative verdict for the complete issue target state is FULLY_IMPLEMENTED.",
+  "remainingWork": [],
+  "testResults": [
+    {
+      "command": "MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/adapters/test_managed_agent_adapter.py",
+      "result": "PASS",
+      "notes": "79 Python tests passed; five non-blocking marker warnings."
+    },
+    {
+      "command": "git diff --check",
+      "result": "PASS"
+    }
+  ]
+}

--- a/tests/unit/workflows/adapters/test_managed_agent_adapter.py
+++ b/tests/unit/workflows/adapters/test_managed_agent_adapter.py
@@ -119,6 +119,24 @@ def test_pr_resolver_rejects_malformed_and_stale_terminal_evidence(
     )
 
 
+def test_pr_resolver_treats_naive_terminal_cutoff_as_utc(tmp_path: Path) -> None:
+    from datetime import datetime
+
+    resolver = tmp_path / "var" / "pr_resolver"
+    resolver.mkdir(parents=True)
+    (resolver / "result.json").write_text(
+        '{"status":"merged","finished_at":"2026-07-10T12:00:00Z"}',
+        encoding="utf-8",
+    )
+
+    terminal = _load_pr_resolver_terminal_result(
+        str(tmp_path), not_before=datetime(2026, 7, 10, 11, 59, 59)
+    )
+
+    assert terminal.payload is not None
+    assert terminal.payload["status"] == "merged"
+
+
 def test_pr_resolver_rejects_unrecognized_terminal_evidence(tmp_path: Path) -> None:
     resolver = tmp_path / "var" / "pr_resolver"
     resolver.mkdir(parents=True)

--- a/tests/unit/workflows/adapters/test_managed_agent_adapter.py
+++ b/tests/unit/workflows/adapters/test_managed_agent_adapter.py
@@ -119,6 +119,21 @@ def test_pr_resolver_rejects_malformed_and_stale_terminal_evidence(
     )
 
 
+def test_pr_resolver_rejects_unrecognized_terminal_evidence(tmp_path: Path) -> None:
+    resolver = tmp_path / "var" / "pr_resolver"
+    resolver.mkdir(parents=True)
+    (resolver / "result.json").write_text(
+        '{"message":"resolver still running"}', encoding="utf-8"
+    )
+
+    terminal = _load_pr_resolver_terminal_result(str(tmp_path))
+
+    assert terminal.payload is None
+    assert terminal.validation_failures == (
+        "var/pr_resolver/result.json: unrecognized terminal status/disposition",
+    )
+
+
 def test_pr_resolver_accepts_compatibility_path_with_matching_identity(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/workflows/adapters/test_managed_agent_adapter.py
+++ b/tests/unit/workflows/adapters/test_managed_agent_adapter.py
@@ -102,7 +102,7 @@ def test_pr_resolver_rejects_malformed_and_stale_terminal_evidence(
     artifacts.mkdir()
     (resolver / "result.json").write_text("not json", encoding="utf-8")
     (artifacts / "pr_resolver_result.json").write_text(
-        '{"status":"merged","runId":"prior","finished_at":"2020-01-01T00:00:00Z"}',
+        '{"status":"merged","runId":"current","finished_at":"2020-01-01T00:00:00Z"}',
         encoding="utf-8",
     )
 
@@ -115,7 +115,7 @@ def test_pr_resolver_rejects_malformed_and_stale_terminal_evidence(
     assert terminal.payload is None
     assert terminal.validation_failures == (
         "var/pr_resolver/result.json: malformed JSON object",
-        "artifacts/pr_resolver_result.json: run identity mismatch",
+        "artifacts/pr_resolver_result.json: stale terminal artifact",
     )
 
 

--- a/tests/unit/workflows/adapters/test_managed_agent_adapter.py
+++ b/tests/unit/workflows/adapters/test_managed_agent_adapter.py
@@ -38,6 +38,8 @@ from moonmind.auth.env_shaping import (
 from moonmind.workflows.adapters.managed_agent_adapter import (
     ManagedAgentAdapter,
     ProfileResolutionError,
+    _load_pr_resolver_diagnostics,
+    _load_pr_resolver_terminal_result,
     _pr_resolver_status,
     build_managed_profile_launch_context,
 )
@@ -50,6 +52,89 @@ from moonmind.workflows.temporal.artifacts import (
 from moonmind.workflows.temporal.activity_runtime import TemporalAgentRuntimeActivities
 
 pytestmark = [pytest.mark.asyncio]
+
+
+def test_pr_resolver_attempts_are_diagnostic_only(tmp_path: Path) -> None:
+    attempts = tmp_path / "var" / "pr_resolver" / "attempts"
+    attempts.mkdir(parents=True)
+    (attempts / "attempt-1.json").write_text(
+        '{"status":"blocked","reason":"ci_running","next_step":"retry"}',
+        encoding="utf-8",
+    )
+
+    terminal = _load_pr_resolver_terminal_result(str(tmp_path))
+    diagnostics = _load_pr_resolver_diagnostics(str(tmp_path))
+
+    assert terminal.payload is None
+    assert diagnostics.attempt_count == 1
+    assert diagnostics.latest is not None
+    assert diagnostics.latest["reason"] == "ci_running"
+
+
+def test_pr_resolver_terminal_result_wins_over_newer_attempt(tmp_path: Path) -> None:
+    resolver = tmp_path / "var" / "pr_resolver"
+    attempts = resolver / "attempts"
+    attempts.mkdir(parents=True)
+    (resolver / "result.json").write_text(
+        '{"status":"merged","runId":"run-current"}', encoding="utf-8"
+    )
+    (attempts / "attempt-2.json").write_text(
+        '{"status":"blocked","reason":"newer diagnostic"}', encoding="utf-8"
+    )
+
+    terminal = _load_pr_resolver_terminal_result(
+        str(tmp_path), run_id="run-current"
+    )
+
+    assert terminal.payload is not None
+    assert terminal.payload["status"] == "merged"
+    assert terminal.provenance == "var/pr_resolver/result.json"
+
+
+def test_pr_resolver_rejects_malformed_and_stale_terminal_evidence(
+    tmp_path: Path,
+) -> None:
+    from datetime import UTC, datetime, timedelta
+
+    resolver = tmp_path / "var" / "pr_resolver"
+    artifacts = tmp_path / "artifacts"
+    resolver.mkdir(parents=True)
+    artifacts.mkdir()
+    (resolver / "result.json").write_text("not json", encoding="utf-8")
+    (artifacts / "pr_resolver_result.json").write_text(
+        '{"status":"merged","runId":"prior","finished_at":"2020-01-01T00:00:00Z"}',
+        encoding="utf-8",
+    )
+
+    terminal = _load_pr_resolver_terminal_result(
+        str(tmp_path),
+        run_id="current",
+        not_before=datetime.now(tz=UTC) - timedelta(minutes=1),
+    )
+
+    assert terminal.payload is None
+    assert terminal.validation_failures == (
+        "var/pr_resolver/result.json: malformed JSON object",
+        "artifacts/pr_resolver_result.json: run identity mismatch",
+    )
+
+
+def test_pr_resolver_accepts_compatibility_path_with_matching_identity(
+    tmp_path: Path,
+) -> None:
+    artifacts = tmp_path / "artifacts"
+    artifacts.mkdir()
+    (artifacts / "pr_resolver_result.json").write_text(
+        '{"mergeAutomationDisposition":"already_merged","workflowId":"wf-current"}',
+        encoding="utf-8",
+    )
+
+    terminal = _load_pr_resolver_terminal_result(
+        str(tmp_path), workflow_id="wf-current"
+    )
+
+    assert terminal.payload is not None
+    assert terminal.provenance == "artifacts/pr_resolver_result.json"
 
 
 @pytest.mark.parametrize(
@@ -2090,7 +2175,7 @@ async def test_fetch_result_clears_generic_failed_exit_for_reenter_gate(
     assert result.summary == "pr-resolver requested merge automation re-entry."
     assert result.metadata["mergeAutomationDisposition"] == "reenter_gate"
 
-async def test_fetch_result_prefers_newer_pr_resolver_attempt_over_stale_result(
+async def test_fetch_result_prefers_terminal_result_over_newer_attempt(
     tmp_path: Path,
 ):
     from datetime import UTC, datetime
@@ -2107,8 +2192,7 @@ async def test_fetch_result_prefers_newer_pr_resolver_attempt_over_stale_result(
             "{\n"
             '  "status": "attempts_exhausted",\n'
             '  "final_reason": "merge_conflicts",\n'
-            '  "next_step": "run_fix_merge_conflicts_skill",\n'
-            '  "finished_at": "2026-04-05T16:57:44+00:00"\n'
+            '  "next_step": "run_fix_merge_conflicts_skill"\n'
             "}\n"
         ),
         encoding="utf-8",
@@ -2153,8 +2237,9 @@ async def test_fetch_result_prefers_newer_pr_resolver_attempt_over_stale_result(
     )
     assert result.failure_class is None
     assert result.metadata["mergeAutomationDisposition"] == "reenter_gate"
+    assert result.metadata["prResolverLatestAttempt"]["reason"] == "ci_running"
 
-async def test_fetch_result_ignores_stale_failure_when_newer_attempt_is_merged(
+async def test_fetch_result_does_not_let_merged_attempt_override_terminal_failure(
     tmp_path: Path,
 ):
     from datetime import UTC, datetime
@@ -2171,8 +2256,7 @@ async def test_fetch_result_ignores_stale_failure_when_newer_attempt_is_merged(
             "{\n"
             '  "status": "attempts_exhausted",\n'
             '  "final_reason": "merge_conflicts",\n'
-            '  "next_step": "run_fix_merge_conflicts_skill",\n'
-            '  "finished_at": "2026-04-05T16:57:44+00:00"\n'
+            '  "next_step": "manual_review"\n'
             "}\n"
         ),
         encoding="utf-8",
@@ -2213,9 +2297,9 @@ async def test_fetch_result_ignores_stale_failure_when_newer_attempt_is_merged(
     result = await adapter.fetch_result(
         "run-result-pr-merged-attempt", pr_resolver_expected=True
     )
-    assert result.failure_class is None
-    assert result.summary is not None
-    assert "pr-resolver" not in result.summary
+    assert result.failure_class == "user_error"
+    assert "attempts_exhausted" in (result.summary or "")
+    assert result.metadata["mergeAutomationDisposition"] == "manual_review"
 
 async def test_fetch_result_ignores_merged_pr_resolver_artifact(tmp_path: Path):
     from datetime import UTC, datetime
@@ -2621,6 +2705,12 @@ async def test_fetch_result_fails_when_expected_pr_resolver_artifact_missing(
 
     workspace_path = tmp_path / "workspace"
     workspace_path.mkdir()
+    attempts = workspace_path / "var" / "pr_resolver" / "attempts"
+    attempts.mkdir(parents=True)
+    (attempts / "attempt-1.json").write_text(
+        '{"status":"blocked","reason":"ci_running","next_step":"retry"}',
+        encoding="utf-8",
+    )
     store = ManagedRunStore(tmp_path / "run_store")
     store.save(
         ManagedRunRecord(
@@ -2648,6 +2738,9 @@ async def test_fetch_result_fails_when_expected_pr_resolver_artifact_missing(
 
     assert result.failure_class == "user_error"
     assert "pr-resolver result artifact missing" in (result.summary or "")
+    assert "reported status 'blocked'" not in (result.summary or "")
+    assert result.metadata["prResolverLatestAttempt"]["reason"] == "ci_running"
+    assert "mergeAutomationDisposition" not in result.metadata
 
 async def test_fetch_result_maps_final_state_merged_pr_resolver_artifact_metadata(
     tmp_path: Path,


### PR DESCRIPTION
Issue: MoonLadderStudios/MoonMind#3140

## Summary
- separate authoritative terminal PR-resolver result loading from attempt diagnostics
- validate terminal semantics, execution correlation, freshness, and expose provenance/validation failures
- keep attempt artifacts diagnostic-only and add adapter-boundary regression coverage
- document the retained compatibility terminal artifact path

## Tests run
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/adapters/test_managed_agent_adapter.py` (79 passed; frontend phase passed)
- `git diff --check`

## Remaining risks
- No known functional risks remain. Focused verification covered the adapter boundary; the full repository test suite was not run.