### PR TITLE
MoonLadderStudios/MoonMind#3141: Classify incomplete resolver execution

### DIFF
--- a/moonmind/workflows/adapters/managed_agent_adapter.py
+++ b/moonmind/workflows/adapters/managed_agent_adapter.py
@@ -100,6 +100,10 @@ _PR_RESOLVER_REENTER_NEXT_STEPS: frozenset[str] = frozenset(
 _PR_RESOLVER_RESULT_PATH_LIST = ", ".join(
     str(path) for path in _PR_RESOLVER_RESULT_PATHS
 )
+_PR_RESOLVER_CONTRACT_ID = "pr-resolver.v1"
+_PR_RESOLVER_USER_ACTIONABLE_REASONS: frozenset[str] = frozenset(
+    {"actionable_comments"}
+)
 _AUTO_PUBLISH_SCHEMA_VERSION = "moonmind.publish.auto.v1"
 _AUTO_PUBLISH_ALLOWED_STATUSES = frozenset(
     {"verified", "no_op_verified", "blocked", "failed"}
@@ -762,16 +766,16 @@ def _derive_pr_resolver_failure(
     workflow_id: str | None = None,
     not_before: datetime | None = None,
 ) -> tuple[str | None, str | None]:
-    """Return failure metadata from pr-resolver artifacts when present."""
+    """Return a broad failure class and operator-safe summary."""
     evidence = _load_pr_resolver_terminal_result(
         workspace_path, run_id=run_id, workflow_id=workflow_id, not_before=not_before
     )
     payload = evidence.payload
     if payload is None:
         return (
-            "user_error",
+            "execution_error",
             (
-                "pr-resolver result artifact missing; expected one of "
+                "pr-resolver execution incomplete: no valid terminal result; expected one of "
                 f"{_PR_RESOLVER_RESULT_PATH_LIST}"
             ),
         )
@@ -792,10 +796,24 @@ def _derive_pr_resolver_failure(
         summary_parts.append(reason)
     if next_step:
         summary_parts.append(f"next_step={next_step}")
-    failure_class = (
-        "user_error" if status in _PR_RESOLVER_BLOCKED_STATUSES else "execution_error"
-    )
+    normalized_reason = reason.lower().replace("-", "_").replace(" ", "_")
+    # User fault is intentionally allow-listed and can only come from a terminal
+    # artifact that passed identity, freshness, and terminal-shape validation.
+    failure_class = "user_error" if (
+        _pr_resolver_disposition(payload, merge_gate_owned=merge_gate_owned)
+        == "manual_review"
+        and normalized_reason in _PR_RESOLVER_USER_ACTIONABLE_REASONS
+    ) else "execution_error"
     return failure_class, "; ".join(summary_parts)
+
+
+def _pr_resolver_terminal_failure_code(evidence: _PrResolverEvidence) -> str:
+    failures = " ".join(evidence.validation_failures).lower()
+    if "stale terminal artifact" in failures:
+        return "TERMINAL_ARTIFACT_STALE"
+    if failures:
+        return "TERMINAL_ARTIFACT_INVALID"
+    return "INCOMPLETE_TERMINAL_CONTRACT"
 
 def _derive_pr_resolver_metadata(
     workspace_path: str | None,
@@ -833,6 +851,19 @@ def _derive_pr_resolver_metadata(
         metadata["prResolverLatestAttempt"] = compact
     payload = evidence.payload
     if payload is None:
+        metadata.update(
+            {
+                "contractId": _PR_RESOLVER_CONTRACT_ID,
+                "failureCode": _pr_resolver_terminal_failure_code(evidence),
+                "terminalResultPresent": False,
+                "missingEvidence": [str(_PR_RESOLVER_RESULT_PATHS[0])],
+                "retryRecommendation": (
+                    "continue_same_session" if merge_gate_owned else "retry_new_session"
+                ),
+            }
+        )
+        if diagnostics.provenance:
+            metadata["latestAttemptRef"] = diagnostics.provenance
         return metadata
 
     status = _pr_resolver_status(payload)
@@ -1211,6 +1242,7 @@ class ManagedAgentAdapter:
                     output_refs=output_refs,
                     failure_class=failure_class,
                     provider_error_code=record.provider_error_code,
+                    retry_recommendation=metadata.get("retryRecommendation"),
                     metadata=metadata,
                 )
         return AgentRunResult()

--- a/moonmind/workflows/adapters/managed_agent_adapter.py
+++ b/moonmind/workflows/adapters/managed_agent_adapter.py
@@ -789,7 +789,13 @@ def _derive_pr_resolver_failure(
     if status not in _PR_RESOLVER_FAILURE_STATUSES:
         return None, None
 
-    reason = str(payload.get("final_reason") or payload.get("reason") or "").strip()
+    final = _pr_resolver_final_payload(payload)
+    reason = _first_stripped_text(
+        payload.get("final_reason"),
+        payload.get("reason"),
+        final.get("final_reason"),
+        final.get("reason"),
+    )
     next_step = _pr_resolver_next_step(payload)
     summary_parts = [f"pr-resolver reported status '{status}'"]
     if reason:
@@ -856,7 +862,7 @@ def _derive_pr_resolver_metadata(
                 "contractId": _PR_RESOLVER_CONTRACT_ID,
                 "failureCode": _pr_resolver_terminal_failure_code(evidence),
                 "terminalResultPresent": False,
-                "missingEvidence": [str(_PR_RESOLVER_RESULT_PATHS[0])],
+                "missingEvidence": [_PR_RESOLVER_RESULT_PATHS[0].as_posix()],
                 "retryRecommendation": (
                     "continue_same_session" if merge_gate_owned else "retry_new_session"
                 ),
@@ -1184,6 +1190,8 @@ class ManagedAgentAdapter:
                     workflow_id=record.workflow_id,
                     not_before=record.started_at,
                 )
+                if not pr_resolver_expected:
+                    metadata.pop("retryRecommendation", None)
                 if (
                     include_workspace_auto_publish_evidence
                     and "publishResult" not in metadata

--- a/reports/remediation_attempt-1.json
+++ b/reports/remediation_attempt-1.json
@@ -1,46 +1,39 @@
 {
   "artifact_type": "remediation.attempt",
   "attempt": 1,
-  "issue_ref": "MoonLadderStudios/MoonMind#3140",
+  "issue_ref": "MoonLadderStudios/MoonMind#3141",
   "source_verification_artifact": "artifacts/github-issue-implement-verify.json",
   "source_verdict": "ADDITIONAL_WORK_NEEDED",
-  "summary": "Corrected stale terminal evidence coverage and resolved focused adapter-suite failures exposed once the documented test dependencies were installed. Terminal failures now retain manual-review disposition, and terminal artifact freshness allows a one-second precision boundary between filesystem timestamps and run-store start timestamps while still rejecting genuinely stale evidence.",
+  "summary": "Closed the bounded verification gaps by aligning non-allow-listed terminal reasons with execution_error, preserving the actionable_comments user_error case, and adding explicit missing-result/no-attempt continuation coverage.",
   "changed_files": [
-    "moonmind/workflows/adapters/managed_agent_adapter.py",
     "tests/unit/workflows/adapters/test_managed_agent_adapter.py",
     "reports/remediation_attempt-1.json"
   ],
   "gap_statuses": [
     {
-      "requirement": "Add coverage for stale terminal evidence",
+      "requirement": "user_error is emitted only from a validated terminal result with an explicitly user-actionable reason",
       "gap_type": "verification",
       "status": "fixed",
-      "evidence": "The malformed-and-stale test now uses the current run identity and asserts 'stale terminal artifact', reaching the freshness rejection branch."
+      "evidence": "Updated ci_failures, merge_conflicts, and free-form hard-failure expectations to execution_error; actionable_comments/manual_review remains explicitly asserted as user_error."
     },
     {
-      "requirement": "Run the focused adapter unit and boundary coverage",
+      "requirement": "Add unit tests for all seven named scenarios",
       "gap_type": "verification",
       "status": "fixed",
-      "evidence": "Installed the declared tests extra and the exact focused runner completed successfully: 78 Python tests passed; the automatic frontend phase also passed."
+      "evidence": "Added result-level no-terminal/no-attempt coverage asserting INCOMPLETE_TERMINAL_CONTRACT, missingEvidence, absent latestAttemptRef, and continue_same_session; existing attempt-present coverage asserts retry_new_session. Existing focused tests cover malformed, stale, actionable manual review, hard execution failure, and canonical serialization."
     },
     {
-      "requirement": "Preserve established manual-review terminal result behavior",
-      "gap_type": "implementation",
+      "requirement": "Relevant focused tests pass",
+      "gap_type": "environment",
       "status": "fixed",
-      "evidence": "Focused execution revealed that failed, blocked, and attempts_exhausted terminal results lost mergeAutomationDisposition. They now derive manual_review unless an owned merge gate derives reenter_gate."
-    },
-    {
-      "requirement": "Reject stale artifacts without rejecting run-boundary writes",
-      "gap_type": "implementation",
-      "status": "fixed",
-      "evidence": "Freshness validation now permits a one-second filesystem/run-store timestamp precision tolerance; the explicit 2020 stale artifact remains rejected."
+      "evidence": "Restored the declared pytest dependencies in the runtime and reran the exact verification command successfully."
     }
   ],
   "targeted_checks": [
     {
-      "command": "MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/adapters/test_managed_agent_adapter.py",
+      "command": "MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/adapters/test_managed_agent_adapter.py tests/unit/workflows/temporal/test_agent_runtime_activities.py",
       "result": "PASS",
-      "notes": "78 Python tests passed with four non-blocking pytest marker warnings. Automatic frontend phase: 63 files passed; 972 tests passed and 238 skipped."
+      "notes": "220 Python tests passed with 23 non-blocking warnings; automatic frontend phase passed 64 files with 980 tests passed and 238 skipped."
     },
     {
       "command": "git diff --check",

--- a/reports/remediation_verification-1.json
+++ b/reports/remediation_verification-1.json
@@ -1,40 +1,14 @@
 {
-  "artifact_type": "remediation.verification",
+  "artifactType": "remediation.verification",
   "attempt": 1,
-  "remediation_attempt": 1,
-  "remediation_attempt_artifact": "reports/remediation_attempt-1.json",
-  "authoritative_verification_artifact": "artifacts/github-issue-implement-verify.json",
-  "verification_target": "issue_brief",
-  "issue_ref": "MoonLadderStudios/MoonMind#3140",
-  "verdict": "ADDITIONAL_WORK_NEEDED",
-  "recommendedNextAction": "reattempt_current_step",
+  "remediationAttempt": 1,
+  "remediationAttemptArtifact": "/work/agent_jobs/mm:d123453a-8c16-4c46-837b-7d2b7d09c8f2/repo/reports/remediation_attempt-1.json",
+  "verificationArtifact": "/work/agent_jobs/mm:d123453a-8c16-4c46-837b-7d2b7d09c8f2/repo/artifacts/github-issue-implement-verify.json",
+  "issueRef": "MoonLadderStudios/MoonMind#3141",
+  "verificationTarget": "issue_brief",
+  "verdict": "FULLY_IMPLEMENTED",
+  "recommendedNextAction": "advance",
   "recoverableInCurrentRuntime": true,
-  "summary": "Remediation attempt 1 passes the focused adapter suite and closes the previously reported freshness and established-shape failures, but terminal validation still accepts a parseable payload with no recognized terminal status/disposition because an empty string is compared to None.",
-  "testResults": [
-    {
-      "command": "MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/adapters/test_managed_agent_adapter.py",
-      "result": "PASS",
-      "notes": "78 Python tests passed; frontend phase passed 972 tests with 238 skipped."
-    },
-    {
-      "command": "git diff --check",
-      "result": "PASS"
-    }
-  ],
-  "remainingWork": [
-    {
-      "requirement": "A terminal result must have a recognized terminal status/disposition",
-      "gapType": "implementation",
-      "remainingWork": "Reject empty/unrecognized dispositions in _load_pr_resolver_terminal_result.",
-      "suggestedEvidence": ["moonmind/workflows/adapters/managed_agent_adapter.py:687"],
-      "recoverableInCurrentRuntime": true
-    },
-    {
-      "requirement": "Unrecognized parseable terminal evidence must be covered",
-      "gapType": "verification",
-      "remainingWork": "Add a regression test for a parseable terminal-path JSON object with no recognized terminal status/disposition and rerun the focused adapter suite.",
-      "suggestedEvidence": ["tests/unit/workflows/adapters/test_managed_agent_adapter.py:94"],
-      "recoverableInCurrentRuntime": true
-    }
-  ]
+  "remainingWork": [],
+  "summary": "Remediation attempt 1 closes all assessment backlog items. Direct code inspection and the focused selector-equivalent unit/workflow-boundary suite verify the complete target state."
 }

--- a/tests/unit/workflows/adapters/test_codex_session_adapter.py
+++ b/tests/unit/workflows/adapters/test_codex_session_adapter.py
@@ -4640,7 +4640,7 @@ async def test_fetch_result_reports_standalone_pr_resolver_reentry_as_failure(
 
     result = await adapter.fetch_result(run_id, pr_resolver_expected=True)
 
-    assert result.failure_class == "user_error"
+    assert result.failure_class == "execution_error"
     assert result.summary is not None
     assert "pr-resolver reported status 'attempts_exhausted'" in result.summary
     assert "ci_failures" in result.summary

--- a/tests/unit/workflows/adapters/test_managed_agent_adapter.py
+++ b/tests/unit/workflows/adapters/test_managed_agent_adapter.py
@@ -129,7 +129,7 @@ def test_pr_resolver_rejects_malformed_and_stale_terminal_evidence(
     terminal = _load_pr_resolver_terminal_result(
         str(tmp_path),
         run_id="current",
-        not_before=datetime.now(tz=UTC) - timedelta(minutes=1),
+        not_before=datetime.now(tz=timezone.utc) - timedelta(minutes=1),
     )
 
     assert terminal.payload is None
@@ -142,7 +142,7 @@ def test_pr_resolver_rejects_malformed_and_stale_terminal_evidence(
 def test_pr_resolver_metadata_distinguishes_invalid_stale_and_missing(
     tmp_path: Path,
 ) -> None:
-    from datetime import UTC, datetime, timedelta
+    from datetime import datetime, timedelta, timezone
 
     resolver = tmp_path / "var" / "pr_resolver"
     resolver.mkdir(parents=True)

--- a/tests/unit/workflows/adapters/test_managed_agent_adapter.py
+++ b/tests/unit/workflows/adapters/test_managed_agent_adapter.py
@@ -2015,7 +2015,7 @@ async def test_fetch_result_reports_standalone_pr_resolver_next_step_as_failure(
         pr_resolver_expected=True,
     )
 
-    assert result.failure_class == "user_error"
+    assert result.failure_class == "execution_error"
     assert result.summary is not None
     assert "pr-resolver reported status 'attempts_exhausted'" in result.summary
     assert "ci_failures" in result.summary
@@ -2358,7 +2358,7 @@ async def test_fetch_result_does_not_let_merged_attempt_override_terminal_failur
     result = await adapter.fetch_result(
         "run-result-pr-merged-attempt", pr_resolver_expected=True
     )
-    assert result.failure_class == "user_error"
+    assert result.failure_class == "execution_error"
     assert "attempts_exhausted" in (result.summary or "")
     assert result.metadata["mergeAutomationDisposition"] == "manual_review"
 
@@ -2808,6 +2808,49 @@ async def test_fetch_result_fails_when_expected_pr_resolver_artifact_missing(
     assert result.metadata["latestAttemptRef"].endswith("attempt-1.json")
     assert result.metadata["prResolverLatestAttempt"]["reason"] == "ci_running"
     assert "mergeAutomationDisposition" not in result.metadata
+
+
+async def test_fetch_result_fails_when_pr_resolver_artifact_and_attempts_missing(
+    tmp_path: Path,
+):
+    from datetime import UTC, datetime
+
+    from moonmind.schemas.agent_runtime_models import ManagedRunRecord
+    from moonmind.workflows.temporal.runtime.store import ManagedRunStore
+
+    workspace_path = tmp_path / "workspace"
+    workspace_path.mkdir()
+    store = ManagedRunStore(tmp_path / "run_store")
+    store.save(
+        ManagedRunRecord(
+            run_id="run-result-pr-no-evidence",
+            agent_id="codex_cli",
+            runtime_id="codex_cli",
+            status="completed",
+            started_at=datetime.now(tz=UTC),
+            workspace_path=str(workspace_path),
+        )
+    )
+    adapter = ManagedAgentAdapter(
+        profile_fetcher=_fake_profiles([]),
+        slot_requester=_async_noop,
+        slot_releaser=_async_noop,
+        cooldown_reporter=_async_noop,
+        workflow_id="wf-result-pr-no-evidence",
+        run_store=store,
+    )
+
+    result = await adapter.fetch_result(
+        "run-result-pr-no-evidence",
+        pr_resolver_expected=True,
+        pr_resolver_merge_gate_owned=True,
+    )
+
+    assert result.failure_class == "execution_error"
+    assert result.retry_recommendation == "continue_same_session"
+    assert result.metadata["failureCode"] == "INCOMPLETE_TERMINAL_CONTRACT"
+    assert result.metadata["missingEvidence"] == ["var/pr_resolver/result.json"]
+    assert "latestAttemptRef" not in result.metadata
 
 async def test_fetch_result_maps_final_state_merged_pr_resolver_artifact_metadata(
     tmp_path: Path,

--- a/tests/unit/workflows/adapters/test_managed_agent_adapter.py
+++ b/tests/unit/workflows/adapters/test_managed_agent_adapter.py
@@ -38,6 +38,7 @@ from moonmind.auth.env_shaping import (
 from moonmind.workflows.adapters.managed_agent_adapter import (
     ManagedAgentAdapter,
     ProfileResolutionError,
+    _derive_pr_resolver_failure,
     _derive_pr_resolver_metadata,
     _load_pr_resolver_diagnostics,
     _load_pr_resolver_terminal_result,
@@ -72,6 +73,24 @@ def test_pr_resolver_attempts_are_diagnostic_only(tmp_path: Path) -> None:
     assert diagnostics.latest["reason"] == "ci_running"
 
 
+def test_pr_resolver_failure_reads_actionable_reason_from_nested_final(
+    tmp_path: Path,
+) -> None:
+    resolver = tmp_path / "var" / "pr_resolver"
+    resolver.mkdir(parents=True)
+    (resolver / "result.json").write_text(
+        '{"status":"blocked","mergeAutomationDisposition":"manual_review",'
+        '"final":{"reason":"actionable_comments"}}',
+        encoding="utf-8",
+    )
+
+    failure_class, summary = _derive_pr_resolver_failure(str(tmp_path))
+
+    assert failure_class == "user_error"
+    assert summary is not None
+    assert "actionable_comments" in summary
+
+
 def test_pr_resolver_terminal_result_wins_over_newer_attempt(tmp_path: Path) -> None:
     resolver = tmp_path / "var" / "pr_resolver"
     attempts = resolver / "attempts"
@@ -95,7 +114,7 @@ def test_pr_resolver_terminal_result_wins_over_newer_attempt(tmp_path: Path) -> 
 def test_pr_resolver_rejects_malformed_and_stale_terminal_evidence(
     tmp_path: Path,
 ) -> None:
-    from datetime import UTC, datetime, timedelta
+    from datetime import datetime, timedelta, timezone
 
     resolver = tmp_path / "var" / "pr_resolver"
     artifacts = tmp_path / "artifacts"
@@ -137,7 +156,8 @@ def test_pr_resolver_metadata_distinguishes_invalid_stale_and_missing(
         encoding="utf-8",
     )
     stale = _derive_pr_resolver_metadata(
-        str(tmp_path), not_before=datetime.now(tz=UTC) - timedelta(minutes=1)
+        str(tmp_path),
+        not_before=datetime.now(tz=timezone.utc) - timedelta(minutes=1),
     )
     assert stale["failureCode"] == "TERMINAL_ARTIFACT_STALE"
 
@@ -2813,7 +2833,7 @@ async def test_fetch_result_fails_when_expected_pr_resolver_artifact_missing(
 async def test_fetch_result_fails_when_pr_resolver_artifact_and_attempts_missing(
     tmp_path: Path,
 ):
-    from datetime import UTC, datetime
+    from datetime import datetime, timezone
 
     from moonmind.schemas.agent_runtime_models import ManagedRunRecord
     from moonmind.workflows.temporal.runtime.store import ManagedRunStore
@@ -2827,7 +2847,7 @@ async def test_fetch_result_fails_when_pr_resolver_artifact_and_attempts_missing
             agent_id="codex_cli",
             runtime_id="codex_cli",
             status="completed",
-            started_at=datetime.now(tz=UTC),
+            started_at=datetime.now(tz=timezone.utc),
             workspace_path=str(workspace_path),
         )
     )
@@ -3269,6 +3289,7 @@ async def test_fetch_result_ignores_pr_resolver_artifact_when_not_expected(
     assert result.failure_class is None
     assert result.summary is not None
     assert "pr-resolver" not in result.summary
+    assert result.retry_recommendation is None
 
 # ---------------------------------------------------------------------------
 # Regression: env_overrides must be delta-only (not full shaped env)

--- a/tests/unit/workflows/adapters/test_managed_agent_adapter.py
+++ b/tests/unit/workflows/adapters/test_managed_agent_adapter.py
@@ -38,6 +38,7 @@ from moonmind.auth.env_shaping import (
 from moonmind.workflows.adapters.managed_agent_adapter import (
     ManagedAgentAdapter,
     ProfileResolutionError,
+    _derive_pr_resolver_metadata,
     _load_pr_resolver_diagnostics,
     _load_pr_resolver_terminal_result,
     _pr_resolver_status,
@@ -117,6 +118,33 @@ def test_pr_resolver_rejects_malformed_and_stale_terminal_evidence(
         "var/pr_resolver/result.json: malformed JSON object",
         "artifacts/pr_resolver_result.json: stale terminal artifact",
     )
+
+
+def test_pr_resolver_metadata_distinguishes_invalid_stale_and_missing(
+    tmp_path: Path,
+) -> None:
+    from datetime import UTC, datetime, timedelta
+
+    resolver = tmp_path / "var" / "pr_resolver"
+    resolver.mkdir(parents=True)
+    result_path = resolver / "result.json"
+    result_path.write_text("not json", encoding="utf-8")
+    invalid = _derive_pr_resolver_metadata(str(tmp_path))
+    assert invalid["failureCode"] == "TERMINAL_ARTIFACT_INVALID"
+
+    result_path.write_text(
+        '{"status":"failed","timestamp":"2020-01-01T00:00:00Z"}',
+        encoding="utf-8",
+    )
+    stale = _derive_pr_resolver_metadata(
+        str(tmp_path), not_before=datetime.now(tz=UTC) - timedelta(minutes=1)
+    )
+    assert stale["failureCode"] == "TERMINAL_ARTIFACT_STALE"
+
+    result_path.unlink()
+    missing = _derive_pr_resolver_metadata(str(tmp_path), merge_gate_owned=True)
+    assert missing["failureCode"] == "INCOMPLETE_TERMINAL_CONTRACT"
+    assert missing["retryRecommendation"] == "continue_same_session"
 
 
 def test_pr_resolver_treats_naive_terminal_cutoff_as_utc(tmp_path: Path) -> None:
@@ -2769,9 +2797,15 @@ async def test_fetch_result_fails_when_expected_pr_resolver_artifact_missing(
         "run-result-pr-missing-artifact", pr_resolver_expected=True
     )
 
-    assert result.failure_class == "user_error"
-    assert "pr-resolver result artifact missing" in (result.summary or "")
+    assert result.failure_class == "execution_error"
+    assert "pr-resolver execution incomplete" in (result.summary or "")
     assert "reported status 'blocked'" not in (result.summary or "")
+    assert result.retry_recommendation == "retry_new_session"
+    assert result.metadata["failureCode"] == "INCOMPLETE_TERMINAL_CONTRACT"
+    assert result.metadata["contractId"] == "pr-resolver.v1"
+    assert result.metadata["terminalResultPresent"] is False
+    assert result.metadata["missingEvidence"] == ["var/pr_resolver/result.json"]
+    assert result.metadata["latestAttemptRef"].endswith("attempt-1.json")
     assert result.metadata["prResolverLatestAttempt"]["reason"] == "ci_running"
     assert "mergeAutomationDisposition" not in result.metadata
 

--- a/tests/unit/workflows/temporal/test_agent_runtime_activities.py
+++ b/tests/unit/workflows/temporal/test_agent_runtime_activities.py
@@ -1445,6 +1445,27 @@ async def test_publish_artifacts_no_service_returns_result_unchanged() -> None:
     assert isinstance(result, AgentRunResult)
     assert result.summary == "done"
 
+
+def test_incomplete_pr_resolver_failure_survives_canonical_serialization() -> None:
+    """MoonLadderStudios/MoonMind#3141 workflow-boundary regression."""
+    original = AgentRunResult(
+        summary="pr-resolver execution incomplete",
+        failure_class="execution_error",
+        retry_recommendation="continue_same_session",
+        metadata={
+            "failureCode": "INCOMPLETE_TERMINAL_CONTRACT",
+            "missingEvidence": ["var/pr_resolver/result.json"],
+        },
+    )
+
+    restored = AgentRunResult.model_validate(
+        original.model_dump(by_alias=True, mode="json")
+    )
+
+    assert restored.failure_class == "execution_error"
+    assert restored.retry_recommendation == "continue_same_session"
+    assert restored.metadata["failureCode"] == "INCOMPLETE_TERMINAL_CONTRACT"
+
 async def test_publish_artifacts_none_input_returns_none() -> None:
     """T3.3 — None input returns None."""
     activities = TemporalAgentRuntimeActivities()


### PR DESCRIPTION
Issue: MoonLadderStudios/MoonMind#3141

## Summary

- Classify missing authoritative PR-resolver terminal evidence as incomplete execution with stable failure codes.
- Distinguish missing, malformed, and stale terminal artifacts and preserve diagnostic attempt metadata.
- Restrict `user_error` to validated allow-listed user-actionable terminal reasons.
- Add adapter and workflow-boundary coverage for classification, retry recommendations, summaries, and serialization.

## Tests run

- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/adapters/test_managed_agent_adapter.py tests/unit/workflows/temporal/test_agent_runtime_activities.py` (220 Python tests passed; frontend phase: 980 passed, 238 skipped)
- `git diff --check`

## Remaining risks

- No known remaining issue-scope risks. The bounded continuation loop remains explicitly outside this issue.
