### PR TITLE
Split session-state and workspace-checkpoint conformance

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Where this is headed: typed policy envelopes that declare per-run what an agent 
 
 Submit a refactoring job, close your laptop, and let MoonMind handle the rest. Every run is backed by [Temporal](https://temporal.io/), so workflows survive container crashes, worker restarts, and host reboots:
 
-- **Durable step ledger and checkpoints.** Long workflows are decomposed into steps whose state, attempts, and outputs are persisted as immutable artifacts. When a step fails, you resume from the last good checkpoint — completed work is never re-bought.
+- **Durable step ledger and step-boundary checkpoints.** Long workflows are decomposed into steps whose state, attempts, and outputs are persisted as immutable artifacts. When compatible workspace capture and restore evidence exists, a failed step can resume from the last good step boundary — completed work is never re-bought.
 - **Stuck detection and escalating intervention.** MoonMind detects looping or silently stalled agents and applies escalating responses — soft reset, hard reset, termination — before they burn through your API budget.
 - **Rate limits as a first-class citizen.** Runtime strategies recognize provider rate-limit signals in live output and respond with slot-based concurrency control and cooldowns instead of blind retry storms.
 - **Idempotent by design.** Externally visible side effects — starting runs, publishing results, posting to GitHub or Jira — are retry-safe, so a crash mid-operation never produces duplicates.

--- a/docs/ManagedAgents/CodexCliManagedSessions.md
+++ b/docs/ManagedAgents/CodexCliManagedSessions.md
@@ -233,11 +233,18 @@ Artifact-backed logs and diagnostics remain authoritative even when live streami
 
 Every managed Codex step must remain execution-centric even when a container is reused across steps.
 
-At minimum, each step must produce durable evidence through the existing artifact system, including step outputs and runtime diagnostics. Session continuity should be represented with summary, checkpoint, and control-boundary artifacts rather than inferred from container state.
+At minimum, each step must produce durable evidence through the existing artifact
+system, including step outputs and runtime diagnostics. Session continuity is
+represented with a session summary, session-state checkpoint refs, and
+control/reset-boundary artifacts rather than inferred from container state.
+These refs do not assert that the Codex runtime captured the Step Execution
+workspace as a `git_patch` or `worktree_archive`, and they do not assert that a
+workspace can be restored or materialized later.
 
 For the current production path, `managed_session_controller` plus the managed-session
-supervisor are the production artifact publishers for summary/checkpoint/control/reset
-refs and related session observability. The transitional in-container
+supervisor are the production artifact publishers for session summary,
+session-state checkpoint, control, and reset-boundary refs and related session
+observability. The transitional in-container
 `fetch_session_summary()` and `publish_session_artifacts()` helpers may still exist as
 fallback or bring-up helpers, but they are not the production publication path while
 they return empty publication refs.

--- a/docs/Temporal/ManagedAndExternalAgentExecutionModel.md
+++ b/docs/Temporal/ManagedAndExternalAgentExecutionModel.md
@@ -183,6 +183,39 @@ Automatic step recovery therefore has two layers:
   Temporal versioning or a reset/resume operation from a safe parent/child
   boundary.
 
+### 2.6 Checkpoint capability layers
+
+Runtime descriptors and conformance reports use distinct checkpoint capabilities:
+
+* `session_state_checkpoint` publishes and retrieves durable session, thread,
+  epoch, or external-provider state refs. It proves session continuity only.
+* `step_workspace_checkpoint_capture` captures the workspace owned by a completed
+  Step Execution. Its descriptor names the request type, activity/adapter owner,
+  workspace locator authority, supported checkpoint kinds, evidence, retry and
+  idempotency behavior, security boundary, and boundary test.
+* `step_workspace_checkpoint_restore` restores or materializes a declared
+  workspace checkpoint kind for explicitly compatible workspace policies. It is
+  a separate invocation and claim from capture.
+
+A session-state checkpoint ref is never evidence of local workspace capture or
+restore. An `external_state_ref` can preserve provider continuity without being
+locally restorable. Policy decides whether a workspace capability gap blocks the
+requested execution or only reduces recoverability; the gap is not itself a
+generic runtime failure.
+
+Codex currently conforms for `session_state_checkpoint`. Until the managed
+runtime workspace lane has its own real capture and restore invocations and
+boundary tests, its `step_workspace_checkpoint_capture` and
+`step_workspace_checkpoint_restore` decisions remain explicit capability gaps.
+
+Serialized managed-session conformance reports use `reportSchemaVersion: 2`.
+Readers of an unversioned/v1 report must migrate the former generic `checkpoint`
+decision to `session_state_checkpoint` only and add workspace capture and restore
+as capability gaps. They must never promote `latestCheckpointRef` or
+`latestResetBoundaryRef` into workspace claims. Producers write v2; external
+consumers should accept v1 during their read migration window and persist or
+forward only v2 after conversion. Unknown future report versions fail closed.
+
 ---
 
 ## 3. Canonical contract rule

--- a/moonmind/workflows/temporal/managed_session_conformance.py
+++ b/moonmind/workflows/temporal/managed_session_conformance.py
@@ -8,14 +8,15 @@ sessions. It does two things:
    (:class:`ManagedSessionRuntimeCapabilities`).
 2. Evaluates that metadata against the canonical set of required managed-session
    behaviors (launch, turn control, interrupt, reset/epoch, resume, terminate,
-   rate-limit, no-progress, checkpoint, outbound scan, and correlation) and
+   rate-limit, no-progress, session-state checkpointing, step-workspace
+   checkpoint capture/restore, outbound scan, and correlation) and
    produces a deterministic conformance report.
 
-The determination is *truthful* and *binary*: a runtime is either session-capable
-(every required behavior conforms) or it is not. There is intentionally no
-"partially session-capable" verdict. Non-conforming runtimes are reported with
-precise, actionable capability gaps so they cannot be surfaced as session-capable
-by mistake.
+The session determination is *truthful* and *binary*: a runtime is either capable
+of the required managed-session lifecycle or it is not. Step-workspace capture and
+restore are reported independently because policy may treat those gaps as
+recoverability-only. There is intentionally no "partially session-capable"
+verdict. Non-conforming behaviors are reported with precise, actionable gaps.
 
 Concrete adapters expose their descriptor at the adapter boundary (for example
 ``CodexSessionAdapter.managed_session_capabilities()``) so the suite runs against
@@ -41,6 +42,7 @@ from moonmind.schemas.managed_session_models import (
 )
 
 MANAGED_SESSION_CONFORMANCE_SUITE_ID = "managed-session-conformance"
+MANAGED_SESSION_CONFORMANCE_REPORT_VERSION = 2
 
 ManagedSessionConformanceBehavior = Literal[
     "launch",
@@ -51,14 +53,16 @@ ManagedSessionConformanceBehavior = Literal[
     "terminate",
     "rate_limit",
     "no_progress",
-    "checkpoint",
+    "session_state_checkpoint",
+    "step_workspace_checkpoint_capture",
+    "step_workspace_checkpoint_restore",
     "outbound_scan",
     "correlation",
 ]
 
-# The canonical, ordered set of behaviors a managed-session runtime must satisfy
-# before it can be surfaced as session-capable. These map one-to-one to the
-# MM-883 acceptance criteria.
+# The canonical, ordered set of behaviors every descriptor must report. Workspace
+# capture and restore are execution-policy capabilities rather than prerequisites
+# for preserving a managed session.
 REQUIRED_MANAGED_SESSION_BEHAVIORS: tuple[ManagedSessionConformanceBehavior, ...] = (
     "launch",
     "turn_control",
@@ -68,7 +72,9 @@ REQUIRED_MANAGED_SESSION_BEHAVIORS: tuple[ManagedSessionConformanceBehavior, ...
     "terminate",
     "rate_limit",
     "no_progress",
-    "checkpoint",
+    "session_state_checkpoint",
+    "step_workspace_checkpoint_capture",
+    "step_workspace_checkpoint_restore",
     "outbound_scan",
     "correlation",
 )
@@ -96,6 +102,26 @@ KNOWN_MANAGED_SESSION_RUNTIMES: tuple[str, ...] = (
 )
 
 ManagedSessionBehaviorDecision = Literal["conforms", "capability_gap"]
+WorkspaceAuthority = Literal[
+    "moonmind_sandbox", "managed_runtime", "external_provider", "none"
+]
+
+_CHECKPOINT_BEHAVIORS = frozenset(
+    {
+        "session_state_checkpoint",
+        "step_workspace_checkpoint_capture",
+        "step_workspace_checkpoint_restore",
+    }
+)
+
+# Workspace capture and restore are execution-policy capabilities. They are
+# deliberately not prerequisites for preserving a managed session/thread.
+_SESSION_CAPABILITY_BEHAVIORS = tuple(
+    behavior
+    for behavior in REQUIRED_MANAGED_SESSION_BEHAVIORS
+    if behavior
+    not in {"step_workspace_checkpoint_capture", "step_workspace_checkpoint_restore"}
+)
 
 
 class ManagedSessionBehaviorSupport(BaseModel):
@@ -106,7 +132,19 @@ class ManagedSessionBehaviorSupport(BaseModel):
     behavior: ManagedSessionConformanceBehavior = Field(..., alias="behavior")
     supported: bool = Field(..., alias="supported")
     invocation: str | None = Field(None, alias="invocation")
+    owner: str | None = Field(None, alias="owner")
+    workspace_authorities: tuple[WorkspaceAuthority, ...] = Field(
+        default=(), alias="workspaceAuthorities"
+    )
+    checkpoint_kinds: tuple[str, ...] = Field(default=(), alias="checkpointKinds")
+    compatible_workspace_policies: tuple[str, ...] = Field(
+        default=(), alias="compatibleWorkspacePolicies"
+    )
     evidence: tuple[str, ...] = Field(default=(), alias="evidence")
+    idempotency: str | None = Field(None, alias="idempotency")
+    retry_replay: str | None = Field(None, alias="retryReplay")
+    security_boundary: str | None = Field(None, alias="securityBoundary")
+    boundary_test: str | None = Field(None, alias="boundaryTest")
     gap_reason: str | None = Field(None, alias="gapReason")
 
     @model_validator(mode="after")
@@ -127,6 +165,34 @@ class ManagedSessionBehaviorSupport(BaseModel):
                     f"behavior '{self.behavior}' is supported and must not carry "
                     "a gapReason"
                 )
+            if self.behavior in _CHECKPOINT_BEHAVIORS:
+                required = {
+                    "owner": self.owner,
+                    "workspaceAuthorities": self.workspace_authorities,
+                    "checkpointKinds": self.checkpoint_kinds,
+                    "idempotency": self.idempotency,
+                    "retryReplay": self.retry_replay,
+                    "securityBoundary": self.security_boundary,
+                    "boundaryTest": self.boundary_test,
+                }
+                missing = [
+                    name
+                    for name, value in required.items()
+                    if not value or (isinstance(value, str) and not value.strip())
+                ]
+                if missing:
+                    raise ValueError(
+                        f"checkpoint behavior '{self.behavior}' is supported but "
+                        f"is missing required conformance fields: {', '.join(missing)}"
+                    )
+                if (
+                    self.behavior == "step_workspace_checkpoint_restore"
+                    and not self.compatible_workspace_policies
+                ):
+                    raise ValueError(
+                        "step workspace checkpoint restore support must declare "
+                        "compatibleWorkspacePolicies"
+                    )
         else:
             if not (self.gap_reason or "").strip():
                 raise ValueError(
@@ -147,15 +213,26 @@ class ManagedSessionRuntimeCapabilities(BaseModel):
     control_actions: tuple[ManagedSessionControlAction, ...] = Field(
         default=(), alias="controlActions"
     )
-    behaviors: tuple[ManagedSessionBehaviorSupport, ...] = Field(
-        ..., alias="behaviors"
-    )
+    behaviors: tuple[ManagedSessionBehaviorSupport, ...] = Field(..., alias="behaviors")
 
     @model_validator(mode="after")
     def _validate(self) -> "ManagedSessionRuntimeCapabilities":
         keys = [support.behavior for support in self.behaviors]
         if len(keys) != len(set(keys)):
             raise ValueError("behaviors must be unique per behavior key")
+        capture = self.behavior("step_workspace_checkpoint_capture")
+        restore = self.behavior("step_workspace_checkpoint_restore")
+        if capture and restore and capture.supported and restore.supported:
+            if capture.invocation == restore.invocation:
+                raise ValueError(
+                    "workspace capture and restore must declare distinct compatible "
+                    "invocations"
+                )
+            if set(capture.evidence) == set(restore.evidence):
+                raise ValueError(
+                    "workspace capture and restore cannot use identical evidence "
+                    "surfaces"
+                )
         return self
 
     def behavior(
@@ -167,8 +244,101 @@ class ManagedSessionRuntimeCapabilities(BaseModel):
         return None
 
 
+class RuntimeExecutionCapabilities(BaseModel):
+    """Compact execution-policy projection of managed-session conformance.
+
+    This is the checkpoint-focused integration boundary for the general runtime
+    descriptor tracked by #3148. It intentionally exposes separate session state,
+    workspace capture, and workspace restore decisions and has no generic
+    ``checkpointSupported`` field.
+    """
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid", frozen=True)
+
+    capability_set_version: Literal["managed-session-checkpoints-v2"] = Field(
+        "managed-session-checkpoints-v2", alias="capabilitySetVersion"
+    )
+    runtime_id: NonBlankStr = Field(..., alias="runtimeId")
+    runtime_family: str | None = Field(None, alias="runtimeFamily")
+    workspace_authority: WorkspaceAuthority = Field(..., alias="workspaceAuthority")
+    session_state_checkpoint: ManagedSessionBehaviorDecision = Field(
+        ..., alias="sessionStateCheckpoint"
+    )
+    step_workspace_checkpoint_capture: ManagedSessionBehaviorDecision = Field(
+        ..., alias="stepWorkspaceCheckpointCapture"
+    )
+    step_workspace_checkpoint_restore: ManagedSessionBehaviorDecision = Field(
+        ..., alias="stepWorkspaceCheckpointRestore"
+    )
+    checkpoint_capture_kinds: tuple[str, ...] = Field(
+        default=(), alias="checkpointCaptureKinds"
+    )
+    checkpoint_restore_kinds: tuple[str, ...] = Field(
+        default=(), alias="checkpointRestoreKinds"
+    )
+    checkpoint_capture_activity: str | None = Field(
+        None, alias="checkpointCaptureActivity"
+    )
+    checkpoint_restore_activity: str | None = Field(
+        None, alias="checkpointRestoreActivity"
+    )
+    supports_same_session_continuation: bool = Field(
+        ..., alias="supportsSameSessionContinuation"
+    )
+    supports_active_command_introspection: bool = Field(
+        False, alias="supportsActiveCommandIntrospection"
+    )
+    terminal_contract_ids: tuple[str, ...] = Field(
+        default=(), alias="terminalContractIds"
+    )
+    post_execution_checkpoint_criticality: Literal[
+        "required", "recoverability_only", "unsupported"
+    ] = Field(..., alias="postExecutionCheckpointCriticality")
+
+    @model_validator(mode="after")
+    def _validate_checkpoint_claims(self) -> "RuntimeExecutionCapabilities":
+        capture_conforms = self.step_workspace_checkpoint_capture == "conforms"
+        restore_conforms = self.step_workspace_checkpoint_restore == "conforms"
+        if capture_conforms != bool(
+            self.checkpoint_capture_kinds and self.checkpoint_capture_activity
+        ):
+            raise ValueError(
+                "workspace capture conformance must match declared capture kinds "
+                "and activity owner"
+            )
+        if restore_conforms != bool(
+            self.checkpoint_restore_kinds and self.checkpoint_restore_activity
+        ):
+            raise ValueError(
+                "workspace restore conformance must match declared restore kinds "
+                "and activity owner"
+            )
+        return self
+
+
 def _gap(behavior: str, reason: str) -> dict[str, Any]:
     return {"behavior": behavior, "reason": reason}
+
+
+def _decision_details(
+    support: ManagedSessionBehaviorSupport | None,
+) -> dict[str, Any]:
+    """Serialize bounded invocation and evidence metadata for one behavior."""
+
+    return {
+        "invocation": support.invocation if support else None,
+        "owner": support.owner if support else None,
+        "workspaceAuthorities": list(support.workspace_authorities) if support else [],
+        "checkpointKinds": list(support.checkpoint_kinds) if support else [],
+        "compatibleWorkspacePolicies": (
+            list(support.compatible_workspace_policies) if support else []
+        ),
+        "evidence": list(support.evidence) if support else [],
+        "idempotency": support.idempotency if support else None,
+        "retryReplay": support.retry_replay if support else None,
+        "securityBoundary": support.security_boundary if support else None,
+        "boundaryTest": support.boundary_test if support else None,
+    }
 
 
 def evaluate_managed_session_conformance(
@@ -177,9 +347,9 @@ def evaluate_managed_session_conformance(
     """Evaluate one runtime's capability metadata against the required behaviors.
 
     Returns a deterministic report. ``sessionCapable`` is a truthful binary
-    determination: it is ``True`` only when every required behavior conforms.
-    Any missing or unsupported behavior produces an actionable capability gap and
-    forces ``sessionCapable`` to ``False`` -- there is no partial verdict.
+    determination over the managed-session lifecycle behaviors. Workspace capture
+    and restore decisions remain independent capability gaps so execution policy
+    can treat them as required, recoverability-only, or unsupported.
     """
 
     behavior_decisions: list[dict[str, Any]] = []
@@ -198,8 +368,7 @@ def evaluate_managed_session_conformance(
                     "behavior": behavior,
                     "decision": "capability_gap",
                     "supported": False,
-                    "invocation": None,
-                    "evidence": [],
+                    **_decision_details(None),
                     "gapReason": reason,
                 }
             )
@@ -215,8 +384,7 @@ def evaluate_managed_session_conformance(
                     "behavior": behavior,
                     "decision": "capability_gap",
                     "supported": False,
-                    "invocation": support.invocation,
-                    "evidence": list(support.evidence),
+                    **_decision_details(support),
                     "gapReason": reason,
                 }
             )
@@ -226,15 +394,12 @@ def evaluate_managed_session_conformance(
                 "behavior": behavior,
                 "decision": "conforms",
                 "supported": True,
-                "invocation": support.invocation,
-                "evidence": list(support.evidence),
+                **_decision_details(support),
                 "gapReason": None,
             }
         )
 
-    canonical_runtime_id = canonical_managed_session_runtime_id(
-        capabilities.runtime_id
-    )
+    canonical_runtime_id = canonical_managed_session_runtime_id(capabilities.runtime_id)
     # Defense in depth: a runtime with no canonical managed-session id must never
     # be determined session-capable, even if it declares every behavior.
     if canonical_runtime_id is None and not capability_gaps:
@@ -244,10 +409,15 @@ def evaluate_managed_session_conformance(
         )
         capability_gaps.append(_gap("runtime_identity", reason))
 
-    session_capable = not capability_gaps
+    gap_behaviors = {gap["behavior"] for gap in capability_gaps}
+    session_capable = (
+        not any(behavior in gap_behaviors for behavior in _SESSION_CAPABILITY_BEHAVIORS)
+        and canonical_runtime_id is not None
+    )
     claim_truthful = session_capable == capabilities.session_capable_claim
 
     return {
+        "reportSchemaVersion": MANAGED_SESSION_CONFORMANCE_REPORT_VERSION,
         "runtimeId": capabilities.runtime_id,
         "runtimeFamily": capabilities.runtime_family,
         "canonicalRuntimeId": canonical_runtime_id,
@@ -261,16 +431,107 @@ def evaluate_managed_session_conformance(
     }
 
 
+def migrate_managed_session_conformance_report(
+    report: dict[str, Any],
+) -> dict[str, Any]:
+    """Upgrade a serialized v1 report to the precise v2 checkpoint model.
+
+    V1's generic ``checkpoint`` decision proves only session-state reference
+    publication. It is therefore migrated to ``session_state_checkpoint``.
+    Workspace capture and restore are added as explicit capability gaps; the
+    migration never manufactures those stronger claims from legacy evidence.
+    """
+
+    version = report.get("reportSchemaVersion", 1)
+    if version == MANAGED_SESSION_CONFORMANCE_REPORT_VERSION:
+        return dict(report)
+    if version != 1:
+        raise ValueError(
+            f"unsupported managed-session report schema version: {version}"
+        )
+
+    if isinstance(report.get("reports"), list):
+        migrated_summary = dict(report)
+        migrated_summary["reportSchemaVersion"] = (
+            MANAGED_SESSION_CONFORMANCE_REPORT_VERSION
+        )
+        migrated_summary["reports"] = [
+            migrate_managed_session_conformance_report(dict(child))
+            for child in report["reports"]
+        ]
+        required = report.get("requiredBehaviors")
+        if isinstance(required, list):
+            migrated_required: list[str] = []
+            for behavior in required:
+                if behavior == "checkpoint":
+                    migrated_required.extend(
+                        (
+                            "session_state_checkpoint",
+                            "step_workspace_checkpoint_capture",
+                            "step_workspace_checkpoint_restore",
+                        )
+                    )
+                else:
+                    migrated_required.append(behavior)
+            migrated_summary["requiredBehaviors"] = migrated_required
+        return migrated_summary
+
+    migrated = dict(report)
+    decisions: list[dict[str, Any]] = []
+    for raw in report.get("behaviorDecisions", []):
+        decision = dict(raw)
+        if decision.get("behavior") == "checkpoint":
+            decision["behavior"] = "session_state_checkpoint"
+        for key, default in _decision_details(None).items():
+            decision.setdefault(key, default)
+        decisions.append(decision)
+
+    existing = {item.get("behavior") for item in decisions}
+    gaps = []
+    for raw_gap in report.get("capabilityGaps", []):
+        gap = dict(raw_gap)
+        if gap.get("behavior") == "checkpoint":
+            gap["behavior"] = "session_state_checkpoint"
+        gaps.append(gap)
+    for behavior in (
+        "step_workspace_checkpoint_capture",
+        "step_workspace_checkpoint_restore",
+    ):
+        if behavior in existing:
+            continue
+        reason = (
+            f"legacy v1 report for runtime '{report.get('runtimeId', 'unknown')}' "
+            f"did not distinguish or prove {behavior}"
+        )
+        decisions.append(
+            {
+                "behavior": behavior,
+                "decision": "capability_gap",
+                "supported": False,
+                **_decision_details(None),
+                "gapReason": reason,
+            }
+        )
+        gaps.append(_gap(behavior, reason))
+
+    migrated["reportSchemaVersion"] = MANAGED_SESSION_CONFORMANCE_REPORT_VERSION
+    migrated["behaviorDecisions"] = decisions
+    migrated["capabilityGaps"] = gaps
+    return migrated
+
+
 def _codex_behavior(
     behavior: ManagedSessionConformanceBehavior,
     invocation: str,
     evidence: tuple[str, ...],
+    **checkpoint_contract: Any,
 ) -> ManagedSessionBehaviorSupport:
     return ManagedSessionBehaviorSupport(
         behavior=behavior,
         supported=True,
         invocation=invocation,
         evidence=evidence,
+        **checkpoint_contract,
     )
 
 
@@ -357,11 +618,51 @@ def codex_managed_session_capabilities() -> ManagedSessionRuntimeCapabilities:
                 ),
             ),
             _codex_behavior(
-                "checkpoint",
+                "session_state_checkpoint",
                 "PublishCodexManagedSessionArtifactsRequest",
                 (
                     "CodexManagedSessionSummary.latestCheckpointRef",
                     "latestResetBoundaryRef",
+                ),
+                owner="CodexSessionAdapter.fetch_result",
+                workspaceAuthorities=("managed_runtime",),
+                checkpointKinds=(
+                    "session_state_ref",
+                    "session_reset_boundary_ref",
+                ),
+                idempotency=(
+                    "publication reuses the managed session identity and artifact refs"
+                ),
+                retryReplay=(
+                    "adapter fetch/publish retries preserve sessionId, threadId, and "
+                    "sessionEpoch"
+                ),
+                securityBoundary=(
+                    "Codex managed-session controller resolves state inside the "
+                    "runtime-owned session container"
+                ),
+                boundaryTest=(
+                    "tests/unit/workflows/adapters/"
+                    "test_managed_session_conformance_boundary.py::"
+                    "test_session_state_checkpoint_boundary_invocation_and_evidence"
+                ),
+            ),
+            ManagedSessionBehaviorSupport(
+                behavior="step_workspace_checkpoint_capture",
+                supported=False,
+                gapReason=(
+                    "Codex managed sessions can publish session-state refs but do "
+                    "not yet declare a managed-runtime-owned Step Execution "
+                    "workspace capture invocation for git_patch or worktree_archive"
+                ),
+            ),
+            ManagedSessionBehaviorSupport(
+                behavior="step_workspace_checkpoint_restore",
+                supported=False,
+                gapReason=(
+                    "Codex managed sessions do not yet declare a workspace "
+                    "restore/materialization invocation or compatible workspace "
+                    "policies"
                 ),
             ),
             _codex_behavior(
@@ -426,6 +727,45 @@ def managed_session_capabilities_for_runtime(
     return unsupported_runtime_managed_session_capabilities(runtime_id)
 
 
+def runtime_execution_capabilities_for_runtime(
+    runtime_id: str,
+) -> RuntimeExecutionCapabilities:
+    """Project precise conformance decisions into execution checkpoint policy."""
+
+    managed = managed_session_capabilities_for_runtime(runtime_id)
+    report = evaluate_managed_session_conformance(managed)
+    decisions = {
+        decision["behavior"]: decision for decision in report["behaviorDecisions"]
+    }
+    capture = decisions["step_workspace_checkpoint_capture"]
+    restore = decisions["step_workspace_checkpoint_restore"]
+    session_state = decisions["session_state_checkpoint"]
+    resume = decisions["resume"]
+    canonical_id = report["canonicalRuntimeId"]
+
+    return RuntimeExecutionCapabilities(
+        runtimeId=managed.runtime_id,
+        runtimeFamily=managed.runtime_family,
+        workspaceAuthority="managed_runtime" if canonical_id else "none",
+        sessionStateCheckpoint=session_state["decision"],
+        stepWorkspaceCheckpointCapture=capture["decision"],
+        stepWorkspaceCheckpointRestore=restore["decision"],
+        checkpointCaptureKinds=tuple(capture["checkpointKinds"]),
+        checkpointRestoreKinds=tuple(restore["checkpointKinds"]),
+        checkpointCaptureActivity=capture["owner"],
+        checkpointRestoreActivity=restore["owner"],
+        supportsSameSessionContinuation=(
+            session_state["decision"] == "conforms" and resume["decision"] == "conforms"
+        ),
+        terminalContractIds=(
+            ("codex_managed_session_summary_v1",) if canonical_id else ()
+        ),
+        postExecutionCheckpointCriticality=(
+            "recoverability_only" if canonical_id else "unsupported"
+        ),
+    )
+
+
 def build_managed_session_conformance_summary(
     *,
     capabilities: Iterable[ManagedSessionRuntimeCapabilities] | None = None,
@@ -444,10 +784,13 @@ def build_managed_session_conformance_summary(
         evaluate_managed_session_conformance(descriptor) for descriptor in descriptors
     ]
     overall_result = (
-        "passed" if all(report["result"] == "passed" for report in reports) else "failed"
+        "passed"
+        if all(report["result"] == "passed" for report in reports)
+        else "failed"
     )
     return {
         "suite": MANAGED_SESSION_CONFORMANCE_SUITE_ID,
+        "reportSchemaVersion": MANAGED_SESSION_CONFORMANCE_REPORT_VERSION,
         "overallResult": overall_result,
         "requiredBehaviors": list(REQUIRED_MANAGED_SESSION_BEHAVIORS),
         "coverageIds": list(MM883_COVERAGE_IDS),
@@ -467,6 +810,7 @@ def run_managed_session_conformance() -> dict[str, Any]:
     summary = build_managed_session_conformance_summary()
     return {
         "suite": summary["suite"],
+        "reportSchemaVersion": summary["reportSchemaVersion"],
         "overallResult": summary["overallResult"],
         "sessionCapableRuntimes": summary["sessionCapableRuntimes"],
         "failedRuntimes": summary["failedRuntimes"],

--- a/moonmind/workflows/temporal/managed_session_conformance.py
+++ b/moonmind/workflows/temporal/managed_session_conformance.py
@@ -185,6 +185,11 @@ class ManagedSessionBehaviorSupport(BaseModel):
                         f"checkpoint behavior '{self.behavior}' is supported but "
                         f"is missing required conformance fields: {', '.join(missing)}"
                     )
+                if any(not kind.strip() for kind in self.checkpoint_kinds):
+                    raise ValueError(
+                        f"checkpoint behavior '{self.behavior}' is supported but "
+                        "declares a blank checkpointKind"
+                    )
                 if (
                     self.behavior == "step_workspace_checkpoint_restore"
                     and not self.compatible_workspace_policies
@@ -402,7 +407,7 @@ def evaluate_managed_session_conformance(
     canonical_runtime_id = canonical_managed_session_runtime_id(capabilities.runtime_id)
     # Defense in depth: a runtime with no canonical managed-session id must never
     # be determined session-capable, even if it declares every behavior.
-    if canonical_runtime_id is None and not capability_gaps:
+    if canonical_runtime_id is None:
         reason = (
             f"runtime '{capabilities.runtime_id}' has no canonical managed-session "
             "runtime id and must not be surfaced as session-capable"
@@ -477,6 +482,35 @@ def migrate_managed_session_conformance_report(
         return migrated_summary
 
     migrated = dict(report)
+
+    compact_gaps = report.get("capabilityGaps")
+    if isinstance(compact_gaps, dict):
+        migrated_compact_gaps: dict[str, list[dict[str, Any]]] = {}
+        for runtime_id, raw_gaps in compact_gaps.items():
+            gaps = []
+            for raw_gap in raw_gaps:
+                gap = dict(raw_gap)
+                if gap.get("behavior") == "checkpoint":
+                    gap["behavior"] = "session_state_checkpoint"
+                gaps.append(gap)
+            existing = {gap.get("behavior") for gap in gaps}
+            for behavior in (
+                "step_workspace_checkpoint_capture",
+                "step_workspace_checkpoint_restore",
+            ):
+                if behavior not in existing:
+                    gaps.append(
+                        _gap(
+                            behavior,
+                            f"legacy v1 report for runtime '{runtime_id}' did not "
+                            f"distinguish or prove {behavior}",
+                        )
+                    )
+            migrated_compact_gaps[runtime_id] = gaps
+        migrated["reportSchemaVersion"] = MANAGED_SESSION_CONFORMANCE_REPORT_VERSION
+        migrated["capabilityGaps"] = migrated_compact_gaps
+        return migrated
+
     decisions: list[dict[str, Any]] = []
     for raw in report.get("behaviorDecisions", []):
         decision = dict(raw)

--- a/tests/unit/workflows/adapters/test_managed_session_conformance_boundary.py
+++ b/tests/unit/workflows/adapters/test_managed_session_conformance_boundary.py
@@ -24,6 +24,7 @@ from moonmind.schemas.managed_session_models import (
     CodexManagedSessionTurnResponse,
     InterruptCodexManagedSessionTurnRequest,
     LaunchCodexManagedSessionRequest,
+    PublishCodexManagedSessionArtifactsRequest,
     SendCodexManagedSessionTurnRequest,
     TerminateCodexManagedSessionRequest,
 )
@@ -193,13 +194,16 @@ def _descriptor_invocation(behavior: str) -> str | None:
     return support.invocation
 
 
-async def test_launch_and_turn_boundary_shapes_and_correlation(tmp_path: Path) -> None:
+async def test_session_state_checkpoint_boundary_invocation_and_evidence(
+    tmp_path: Path,
+) -> None:
     from moonmind.workflows.temporal.runtime.store import ManagedRunStore
 
     binding = _binding()
     workspace_path = tmp_path / "agent_jobs" / binding.agent_run_id / "repo"
     launch_calls: list[Any] = []
     send_turn_calls: list[Any] = []
+    publication_calls: list[Any] = []
     control_calls: list[dict[str, Any]] = []
 
     async def _load_snapshot(_workflow_id: str) -> CodexManagedSessionSnapshot:
@@ -221,11 +225,14 @@ async def test_launch_and_turn_boundary_shapes_and_correlation(tmp_path: Path) -
         )
 
     async def _fetch_summary(_request: Any) -> CodexManagedSessionSummary:
-        return _summary(binding=binding, container_id="container-1", thread_id="thread-1")
+        return _summary(
+            binding=binding, container_id="container-1", thread_id="thread-1"
+        )
 
     async def _publish_artifacts(
-        _request: Any,
+        publication_request: Any,
     ) -> CodexManagedSessionArtifactsPublication:
+        publication_calls.append(publication_request)
         return _publication(
             binding=binding, container_id="container-1", thread_id="thread-1"
         )
@@ -276,7 +283,9 @@ async def test_launch_and_turn_boundary_shapes_and_correlation(tmp_path: Path) -
     # --- turn-control boundary invocation shape ---
     assert len(send_turn_calls) == 1
     assert isinstance(send_turn_calls[0], SendCodexManagedSessionTurnRequest)
-    assert _descriptor_invocation("turn_control") == "SendCodexManagedSessionTurnRequest"
+    assert (
+        _descriptor_invocation("turn_control") == "SendCodexManagedSessionTurnRequest"
+    )
 
     # --- trace/artifact correlation ---
     assert request.correlation_id == "corr-1"
@@ -292,6 +301,20 @@ async def test_launch_and_turn_boundary_shapes_and_correlation(tmp_path: Path) -
     assert (
         result.metadata["sessionArtifacts"]["latestCheckpointRef"]
         == "artifact:session-checkpoint"
+    )
+    assert len(publication_calls) == 1
+    assert isinstance(publication_calls[0], PublishCodexManagedSessionArtifactsRequest)
+    assert publication_calls[0].session_id == binding.session_id
+    checkpoint_support = CodexSessionAdapter.managed_session_capabilities().behavior(
+        "session_state_checkpoint"
+    )
+    assert checkpoint_support is not None
+    assert checkpoint_support.invocation == "PublishCodexManagedSessionArtifactsRequest"
+    assert checkpoint_support.owner == "CodexSessionAdapter.fetch_result"
+    assert checkpoint_support.workspace_authorities == ("managed_runtime",)
+    assert checkpoint_support.checkpoint_kinds == (
+        "session_state_ref",
+        "session_reset_boundary_ref",
     )
     # control events correlate to the same session container/thread.
     start_event = next(c for c in control_calls if c["action"] == "start_session")
@@ -344,7 +367,9 @@ async def test_interrupt_boundary_invocation_shape() -> None:
     control_calls: list[dict[str, Any]] = []
 
     async def _load_snapshot(_workflow_id: str) -> CodexManagedSessionSnapshot:
-        return _snapshot(binding=binding, container_id="container-1", thread_id="thread-1")
+        return _snapshot(
+            binding=binding, container_id="container-1", thread_id="thread-1"
+        )
 
     async def _interrupt_turn(request: Any) -> CodexManagedSessionTurnResponse:
         interrupt_calls.append(request)
@@ -373,7 +398,9 @@ async def test_interrupt_boundary_invocation_shape() -> None:
     assert isinstance(interrupt_calls[0], InterruptCodexManagedSessionTurnRequest)
     assert interrupt_calls[0].turn_id == "turn-1"
     assert response.status == "interrupted"
-    assert _descriptor_invocation("interrupt") == "InterruptCodexManagedSessionTurnRequest"
+    assert (
+        _descriptor_invocation("interrupt") == "InterruptCodexManagedSessionTurnRequest"
+    )
     assert any(c["action"] == "interrupt_turn" for c in control_calls)
 
 
@@ -383,7 +410,9 @@ async def test_reset_epoch_boundary_invocation_shape() -> None:
     control_calls: list[dict[str, Any]] = []
 
     async def _load_snapshot(_workflow_id: str) -> CodexManagedSessionSnapshot:
-        return _snapshot(binding=binding, container_id="container-1", thread_id="thread-1")
+        return _snapshot(
+            binding=binding, container_id="container-1", thread_id="thread-1"
+        )
 
     async def _clear_remote_session(request: Any) -> CodexManagedSessionHandle:
         clear_calls.append(request)
@@ -425,7 +454,9 @@ async def test_terminate_boundary_invocation_shape() -> None:
     control_calls: list[dict[str, Any]] = []
 
     async def _load_snapshot(_workflow_id: str) -> CodexManagedSessionSnapshot:
-        return _snapshot(binding=binding, container_id="container-1", thread_id="thread-1")
+        return _snapshot(
+            binding=binding, container_id="container-1", thread_id="thread-1"
+        )
 
     async def _terminate_remote_session(request: Any) -> CodexManagedSessionHandle:
         terminate_calls.append(request)
@@ -463,4 +494,7 @@ async def test_adapter_capability_descriptor_runs_conformance_at_boundary() -> N
 
     assert capabilities.runtime_id == "codex_cli"
     assert report["sessionCapable"] is True
-    assert report["capabilityGaps"] == []
+    assert {gap["behavior"] for gap in report["capabilityGaps"]} == {
+        "step_workspace_checkpoint_capture",
+        "step_workspace_checkpoint_restore",
+    }

--- a/tests/unit/workflows/temporal/test_managed_session_conformance.py
+++ b/tests/unit/workflows/temporal/test_managed_session_conformance.py
@@ -11,30 +11,54 @@ from moonmind.schemas.managed_session_models import (
 from moonmind.workflows.temporal.managed_session_conformance import (
     KNOWN_MANAGED_SESSION_RUNTIMES,
     MANAGED_SESSION_CONFORMANCE_SUITE_ID,
+    MANAGED_SESSION_CONFORMANCE_REPORT_VERSION,
     MM883_COVERAGE_IDS,
     REQUIRED_MANAGED_SESSION_BEHAVIORS,
     ManagedSessionBehaviorSupport,
     ManagedSessionRuntimeCapabilities,
+    RuntimeExecutionCapabilities,
     build_managed_session_conformance_summary,
     codex_managed_session_capabilities,
     evaluate_managed_session_conformance,
     managed_session_capabilities_for_runtime,
+    migrate_managed_session_conformance_report,
+    runtime_execution_capabilities_for_runtime,
     run_managed_session_conformance,
     unsupported_runtime_managed_session_capabilities,
 )
 
 
 def _supported(behavior: str) -> ManagedSessionBehaviorSupport:
+    checkpoint_fields = {}
+    if behavior in {
+        "session_state_checkpoint",
+        "step_workspace_checkpoint_capture",
+        "step_workspace_checkpoint_restore",
+    }:
+        checkpoint_fields = {
+            "owner": f"{behavior}-owner",
+            "workspaceAuthorities": ("managed_runtime",),
+            "checkpointKinds": (f"{behavior}-kind",),
+            "idempotency": "stable idempotency key",
+            "retryReplay": "same invocation on retry and replay",
+            "securityBoundary": "owning worker resolves local state",
+            "boundaryTest": f"test_{behavior}_boundary",
+        }
+    if behavior == "step_workspace_checkpoint_restore":
+        checkpoint_fields["compatibleWorkspacePolicies"] = ("restore_pre_execution",)
     return ManagedSessionBehaviorSupport(
         behavior=behavior,
         supported=True,
         invocation=f"{behavior}-invocation",
         evidence=(f"{behavior}-evidence",),
+        **checkpoint_fields,
     )
 
 
 def _fully_supported_behaviors() -> tuple[ManagedSessionBehaviorSupport, ...]:
-    return tuple(_supported(behavior) for behavior in REQUIRED_MANAGED_SESSION_BEHAVIORS)
+    return tuple(
+        _supported(behavior) for behavior in REQUIRED_MANAGED_SESSION_BEHAVIORS
+    )
 
 
 def test_required_behaviors_match_acceptance_criteria() -> None:
@@ -47,13 +71,15 @@ def test_required_behaviors_match_acceptance_criteria() -> None:
         "terminate",
         "rate_limit",
         "no_progress",
-        "checkpoint",
+        "session_state_checkpoint",
+        "step_workspace_checkpoint_capture",
+        "step_workspace_checkpoint_restore",
         "outbound_scan",
         "correlation",
     )
 
 
-def test_codex_descriptor_conforms_and_is_truthfully_session_capable() -> None:
+def test_codex_session_state_checkpoint_conforms_independently() -> None:
     capabilities = codex_managed_session_capabilities()
 
     report = evaluate_managed_session_conformance(capabilities)
@@ -63,28 +89,36 @@ def test_codex_descriptor_conforms_and_is_truthfully_session_capable() -> None:
     assert report["sessionCapable"] is True
     assert report["claimTruthful"] is True
     assert report["result"] == "passed"
-    assert report["capabilityGaps"] == []
+    assert report["reportSchemaVersion"] == MANAGED_SESSION_CONFORMANCE_REPORT_VERSION
+    assert {gap["behavior"] for gap in report["capabilityGaps"]} == {
+        "step_workspace_checkpoint_capture",
+        "step_workspace_checkpoint_restore",
+    }
     covered = {decision["behavior"] for decision in report["behaviorDecisions"]}
     assert covered == set(REQUIRED_MANAGED_SESSION_BEHAVIORS)
-    assert all(
-        decision["decision"] == "conforms"
-        for decision in report["behaviorDecisions"]
-    )
+    session_checkpoint = capabilities.behavior("session_state_checkpoint")
+    assert session_checkpoint is not None
+    assert session_checkpoint.supported is True
+    assert "latestCheckpointRef" in " ".join(session_checkpoint.evidence)
 
 
-def test_codex_descriptor_declares_every_required_behavior_with_evidence() -> None:
+def test_codex_descriptor_declares_every_required_behavior_truthfully() -> None:
     capabilities = codex_managed_session_capabilities()
 
     for behavior in REQUIRED_MANAGED_SESSION_BEHAVIORS:
         support = capabilities.behavior(behavior)
         assert support is not None, behavior
-        assert support.supported is True
-        assert support.invocation
-        assert support.evidence
+        if support.supported:
+            assert support.invocation
+            assert support.evidence
+        else:
+            assert support.gap_reason
 
 
 @pytest.mark.parametrize("runtime_id", ["claude", "claude_code"])
-def test_unsupported_runtimes_report_capability_gaps_not_partial(runtime_id: str) -> None:
+def test_unsupported_runtimes_report_capability_gaps_not_partial(
+    runtime_id: str,
+) -> None:
     capabilities = managed_session_capabilities_for_runtime(runtime_id)
 
     report = evaluate_managed_session_conformance(capabilities)
@@ -154,7 +188,9 @@ def test_runtime_falsely_claiming_session_capability_fails_truthfully() -> None:
     assert {gap["behavior"] for gap in report["capabilityGaps"]} == {"interrupt"}
 
 
-def test_non_canonical_runtime_cannot_be_session_capable_even_if_fully_declared() -> None:
+def test_non_canonical_runtime_cannot_be_session_capable_even_if_fully_declared() -> (
+    None
+):
     # Defense in depth: a runtime with no canonical managed-session id must never
     # be determined session-capable even if it declares every behavior.
     capabilities = ManagedSessionRuntimeCapabilities(
@@ -189,9 +225,9 @@ def test_summary_only_surfaces_codex_as_session_capable() -> None:
 
 def test_summary_fails_when_a_runtime_misrepresents_session_capability() -> None:
     truthful_codex = codex_managed_session_capabilities()
-    misrepresented = unsupported_runtime_managed_session_capabilities("future_runtime").model_copy(
-        update={"session_capable_claim": True}
-    )
+    misrepresented = unsupported_runtime_managed_session_capabilities(
+        "future_runtime"
+    ).model_copy(update={"session_capable_claim": True})
 
     summary = build_managed_session_conformance_summary(
         capabilities=[truthful_codex, misrepresented]
@@ -210,17 +246,17 @@ def test_run_managed_session_conformance_compact_result() -> None:
     assert result["sessionCapableRuntimes"] == ["codex_cli"]
     assert result["failedRuntimes"] == []
     # Non-session-capable runtimes report their gaps for operator action.
-    assert set(result["capabilityGaps"]) == {"claude", "claude_code"}
+    assert set(result["capabilityGaps"]) == {"codex_cli", "claude", "claude_code"}
 
 
 def test_behavior_support_requires_invocation_and_evidence_when_supported() -> None:
     with pytest.raises(ValidationError, match="declares no invocation contract"):
-        ManagedSessionBehaviorSupport(behavior="launch", supported=True, evidence=("e",))
+        ManagedSessionBehaviorSupport(
+            behavior="launch", supported=True, evidence=("e",)
+        )
 
     with pytest.raises(ValidationError, match="declares no evidence surfaces"):
-        ManagedSessionBehaviorSupport(
-            behavior="launch", supported=True, invocation="x"
-        )
+        ManagedSessionBehaviorSupport(behavior="launch", supported=True, invocation="x")
 
 
 def test_behavior_support_requires_gap_reason_when_unsupported() -> None:
@@ -235,3 +271,201 @@ def test_capabilities_reject_duplicate_behaviors() -> None:
             sessionCapableClaim=True,
             behaviors=(_supported("launch"), _supported("launch")),
         )
+
+
+def test_codex_workspace_capture_is_not_inferred_from_session_refs() -> None:
+    capabilities = codex_managed_session_capabilities()
+
+    session_state = capabilities.behavior("session_state_checkpoint")
+    capture = capabilities.behavior("step_workspace_checkpoint_capture")
+
+    assert session_state is not None and session_state.supported
+    assert capture is not None and not capture.supported
+    assert capture.invocation is None
+    assert capture.checkpoint_kinds == ()
+
+
+def test_capture_and_restore_cannot_reuse_one_invocation_or_evidence_claim() -> None:
+    behaviors = list(_fully_supported_behaviors())
+    capture_index = next(
+        index
+        for index, support in enumerate(behaviors)
+        if support.behavior == "step_workspace_checkpoint_capture"
+    )
+    restore_index = next(
+        index
+        for index, support in enumerate(behaviors)
+        if support.behavior == "step_workspace_checkpoint_restore"
+    )
+    shared_evidence = ("latestCheckpointRef",)
+    behaviors[capture_index] = behaviors[capture_index].model_copy(
+        update={"invocation": "WorkspaceCheckpointRequest", "evidence": shared_evidence}
+    )
+    behaviors[restore_index] = behaviors[restore_index].model_copy(
+        update={"invocation": "WorkspaceCheckpointRequest", "evidence": shared_evidence}
+    )
+
+    with pytest.raises(ValidationError, match="distinct compatible invocations"):
+        ManagedSessionRuntimeCapabilities(
+            runtimeId="codex_cli",
+            sessionCapableClaim=True,
+            behaviors=tuple(behaviors),
+        )
+
+
+def test_supported_managed_capture_declares_managed_locator_authority() -> None:
+    support = _supported("step_workspace_checkpoint_capture")
+
+    assert support.workspace_authorities == ("managed_runtime",)
+    assert support.checkpoint_kinds
+    assert support.owner
+
+
+def test_external_state_capture_does_not_imply_local_workspace_restore() -> None:
+    behaviors = list(_fully_supported_behaviors())
+    capture_index = next(
+        index
+        for index, support in enumerate(behaviors)
+        if support.behavior == "step_workspace_checkpoint_capture"
+    )
+    restore_index = next(
+        index
+        for index, support in enumerate(behaviors)
+        if support.behavior == "step_workspace_checkpoint_restore"
+    )
+    behaviors[capture_index] = behaviors[capture_index].model_copy(
+        update={
+            "workspace_authorities": ("external_provider",),
+            "checkpoint_kinds": ("external_state_ref",),
+        }
+    )
+    behaviors[restore_index] = ManagedSessionBehaviorSupport(
+        behavior="step_workspace_checkpoint_restore",
+        supported=False,
+        gapReason="external provider state has no local materialization bridge",
+    )
+    capabilities = ManagedSessionRuntimeCapabilities(
+        runtimeId="codex_cli",
+        runtimeFamily="codex",
+        sessionCapableClaim=True,
+        behaviors=tuple(behaviors),
+    )
+
+    report = evaluate_managed_session_conformance(capabilities)
+
+    decisions = {item["behavior"]: item for item in report["behaviorDecisions"]}
+    assert decisions["step_workspace_checkpoint_capture"]["decision"] == "conforms"
+    assert (
+        decisions["step_workspace_checkpoint_restore"]["decision"] == "capability_gap"
+    )
+
+
+def test_unsupported_runtime_has_three_distinct_checkpoint_gaps() -> None:
+    report = evaluate_managed_session_conformance(
+        unsupported_runtime_managed_session_capabilities("claude")
+    )
+
+    checkpoint_gaps = {
+        gap["behavior"]
+        for gap in report["capabilityGaps"]
+        if "checkpoint" in gap["behavior"]
+    }
+    assert checkpoint_gaps == {
+        "session_state_checkpoint",
+        "step_workspace_checkpoint_capture",
+        "step_workspace_checkpoint_restore",
+    }
+
+
+def test_v1_report_migration_never_upgrades_generic_checkpoint_evidence() -> None:
+    legacy = {
+        "runtimeId": "codex_cli",
+        "behaviorDecisions": [
+            {
+                "behavior": "checkpoint",
+                "decision": "conforms",
+                "supported": True,
+                "invocation": "PublishCodexManagedSessionArtifactsRequest",
+                "evidence": ["CodexManagedSessionSummary.latestCheckpointRef"],
+                "gapReason": None,
+            }
+        ],
+        "capabilityGaps": [],
+    }
+
+    migrated = migrate_managed_session_conformance_report(legacy)
+
+    assert migrated["reportSchemaVersion"] == 2
+    decisions = {item["behavior"]: item for item in migrated["behaviorDecisions"]}
+    assert decisions["session_state_checkpoint"]["decision"] == "conforms"
+    assert (
+        decisions["step_workspace_checkpoint_capture"]["decision"] == "capability_gap"
+    )
+    assert (
+        decisions["step_workspace_checkpoint_restore"]["decision"] == "capability_gap"
+    )
+
+
+def test_v1_summary_migration_updates_nested_reports_and_required_behaviors() -> None:
+    legacy_report = {
+        "runtimeId": "codex_cli",
+        "behaviorDecisions": [
+            {
+                "behavior": "checkpoint",
+                "decision": "conforms",
+                "supported": True,
+                "invocation": "PublishCodexManagedSessionArtifactsRequest",
+                "evidence": ["latestCheckpointRef"],
+                "gapReason": None,
+            }
+        ],
+        "capabilityGaps": [],
+    }
+    legacy_summary = {
+        "suite": MANAGED_SESSION_CONFORMANCE_SUITE_ID,
+        "requiredBehaviors": ["launch", "checkpoint", "correlation"],
+        "reports": [legacy_report],
+    }
+
+    migrated = migrate_managed_session_conformance_report(legacy_summary)
+
+    assert migrated["reportSchemaVersion"] == 2
+    assert migrated["requiredBehaviors"] == [
+        "launch",
+        "session_state_checkpoint",
+        "step_workspace_checkpoint_capture",
+        "step_workspace_checkpoint_restore",
+        "correlation",
+    ]
+    nested = migrated["reports"][0]
+    assert nested["reportSchemaVersion"] == 2
+    assert len(nested["capabilityGaps"]) == 2
+
+
+def test_checkpoint_claim_requires_boundary_test_fixture() -> None:
+    with pytest.raises(ValidationError, match="boundaryTest"):
+        ManagedSessionBehaviorSupport(
+            behavior="session_state_checkpoint",
+            supported=True,
+            invocation="SessionStateRequest",
+            owner="session.activity",
+            workspaceAuthorities=("managed_runtime",),
+            checkpointKinds=("session_state_ref",),
+            evidence=("sessionStateRef",),
+            idempotency="stable request key",
+            retryReplay="same request on retry",
+            securityBoundary="managed runtime owner",
+        )
+
+
+def test_runtime_execution_capabilities_consume_precise_codex_results() -> None:
+    capabilities = runtime_execution_capabilities_for_runtime("codex_cli")
+
+    assert isinstance(capabilities, RuntimeExecutionCapabilities)
+    assert capabilities.workspace_authority == "managed_runtime"
+    assert capabilities.session_state_checkpoint == "conforms"
+    assert capabilities.step_workspace_checkpoint_capture == "capability_gap"
+    assert capabilities.step_workspace_checkpoint_restore == "capability_gap"
+    assert capabilities.checkpoint_capture_activity is None
+    assert capabilities.checkpoint_restore_activity is None
+    assert capabilities.post_execution_checkpoint_criticality == "recoverability_only"

--- a/tests/unit/workflows/temporal/test_managed_session_conformance.py
+++ b/tests/unit/workflows/temporal/test_managed_session_conformance.py
@@ -128,9 +128,12 @@ def test_unsupported_runtimes_report_capability_gaps_not_partial(
     assert report["sessionCapableClaim"] is False
     assert report["claimTruthful"] is True
     assert report["result"] == "passed"
-    assert len(report["capabilityGaps"]) == len(REQUIRED_MANAGED_SESSION_BEHAVIORS)
+    assert len(report["capabilityGaps"]) == len(REQUIRED_MANAGED_SESSION_BEHAVIORS) + 1
     gap_behaviors = {gap["behavior"] for gap in report["capabilityGaps"]}
-    assert gap_behaviors == set(REQUIRED_MANAGED_SESSION_BEHAVIORS)
+    assert gap_behaviors == {
+        *REQUIRED_MANAGED_SESSION_BEHAVIORS,
+        "runtime_identity",
+    }
     assert all(gap["reason"] for gap in report["capabilityGaps"])
     assert "partial" not in str(report).lower()
 
@@ -208,6 +211,33 @@ def test_non_canonical_runtime_cannot_be_session_capable_even_if_fully_declared(
     assert any(
         gap["behavior"] == "runtime_identity" for gap in report["capabilityGaps"]
     )
+
+
+def test_non_canonical_runtime_reports_identity_gap_alongside_checkpoint_gaps() -> None:
+    behaviors = list(_fully_supported_behaviors())
+    capture_index = next(
+        index
+        for index, support in enumerate(behaviors)
+        if support.behavior == "step_workspace_checkpoint_capture"
+    )
+    behaviors[capture_index] = ManagedSessionBehaviorSupport(
+        behavior="step_workspace_checkpoint_capture",
+        supported=False,
+        gapReason="workspace capture is not implemented",
+    )
+    capabilities = ManagedSessionRuntimeCapabilities(
+        runtimeId="future_runtime",
+        runtimeFamily="future",
+        sessionCapableClaim=False,
+        behaviors=tuple(behaviors),
+    )
+
+    report = evaluate_managed_session_conformance(capabilities)
+
+    assert {gap["behavior"] for gap in report["capabilityGaps"]} == {
+        "runtime_identity",
+        "step_workspace_checkpoint_capture",
+    }
 
 
 def test_summary_only_surfaces_codex_as_session_capable() -> None:
@@ -440,6 +470,46 @@ def test_v1_summary_migration_updates_nested_reports_and_required_behaviors() ->
     nested = migrated["reports"][0]
     assert nested["reportSchemaVersion"] == 2
     assert len(nested["capabilityGaps"]) == 2
+
+
+def test_v1_compact_result_migration_updates_runtime_gap_map() -> None:
+    legacy = {
+        "suite": MANAGED_SESSION_CONFORMANCE_SUITE_ID,
+        "overallResult": "passed",
+        "capabilityGaps": {
+            "codex_cli": [
+                {"behavior": "checkpoint", "reason": "legacy checkpoint gap"}
+            ]
+        },
+    }
+
+    migrated = migrate_managed_session_conformance_report(legacy)
+
+    assert migrated["reportSchemaVersion"] == 2
+    assert {
+        gap["behavior"] for gap in migrated["capabilityGaps"]["codex_cli"]
+    } == {
+        "session_state_checkpoint",
+        "step_workspace_checkpoint_capture",
+        "step_workspace_checkpoint_restore",
+    }
+
+
+def test_checkpoint_claim_rejects_blank_checkpoint_kind() -> None:
+    with pytest.raises(ValidationError, match="blank checkpointKind"):
+        ManagedSessionBehaviorSupport(
+            behavior="session_state_checkpoint",
+            supported=True,
+            invocation="SessionStateRequest",
+            owner="session.activity",
+            workspaceAuthorities=("managed_runtime",),
+            checkpointKinds=("  ",),
+            evidence=("sessionStateRef",),
+            idempotency="stable request key",
+            retryReplay="same invocation on retry and replay",
+            securityBoundary="owning worker resolves local state",
+            boundaryTest="test_session_state_boundary",
+        )
 
 
 def test_checkpoint_claim_requires_boundary_test_fixture() -> None:


### PR DESCRIPTION
## Summary

- split managed-session checkpoint conformance into session-state, step-workspace capture, and step-workspace restore capabilities
- require precise invocation, owner, locator authority, checkpoint kind, evidence, retry, idempotency, security, and boundary-test declarations for supported checkpoint behavior
- keep Codex session continuity conforming while reporting managed workspace capture and restore as actionable capability gaps
- project the precise decisions into `RuntimeExecutionCapabilities` without a generic checkpoint boolean
- add fail-closed v1-to-v2 conformance report migration and clarify checkpoint terminology in canonical documentation

## Why

`CodexManagedSessionSummary.latestCheckpointRef` and reset-boundary refs prove durable session continuity, but they do not prove that a runtime can capture or restore the root Step Execution workspace. The prior broad checkpoint claim allowed those distinct capabilities to be treated as interchangeable.

This change makes the interim Codex state truthful until the managed workspace capture lane is implemented.

Closes #3149.

## Validation

- `pytest -q tests/unit/workflows/temporal/test_managed_session_conformance.py tests/unit/workflows/adapters/test_managed_session_conformance_boundary.py --tb=short` — 28 passed
- expanded Codex adapter and conformance Python selection — 88 passed
- Ruff check and format validation passed
- `git diff --check` passed

The repository unit wrapper also ran its unrelated full frontend phase. That phase reported 14 existing timeout/render failures across dashboard, workflow detail/list, and workflow-start tests; this PR changes no frontend files.
