### PR TITLE
A major change was made to the site to add a sidebar nav bar. This is NOT the current desired direction for MoonMind. I only want a sidebar for listin

### DIFF
--- a/docs/MoonMindRoadmap.md
+++ b/docs/MoonMindRoadmap.md
@@ -67,26 +67,26 @@ These are not active roadmap milestones, but they are important assumptions for 
 
 ---
 
-## Milestone 1 — Dashboard Navigation, Shared Sidebars & Detail Frames 🚧
+## Milestone 1 — Shared Collection Sidebars & Detail Frames 🚧
 
-**Goal:** Establish one far-left application rail, one reusable collection-sidebar system for Workflows, Recurring, and Skills, and one shared detail-frame language for Workflow and recurring schedule detail pages.
+**Goal:** Re-purpose the Workflow sidebar as one reusable contextual collection-sidebar system for Workflows, Recurring, and Skills, and establish one shared detail-frame language for Workflow and recurring schedule detail pages.
 
-**Why it matters:** Operators should experience MoonMind as one console. Top-level navigation must stay at the viewport edge; local collection navigation must start at the content edge; and related detail pages must reuse recognizable structure instead of inheriting centered wrappers or page-specific shells.
+**Why it matters:** Operators should have one contextual entity list beside the active workspace, never a page-navigation sidebar beside a collection sidebar. Top-level navigation remains in the masthead.
 
 ### Remaining work
 
-- [ ] **1.0 Declarative design first** — make `docs/UI/CollectionWorkspaceLayout.md` canonical for far-left shell geometry, shared collection sidebars, and the Workflow/Recurring entity-detail frame; reconcile `docs/UI/DashboardSPAArchitecture.md`, `docs/UI/DashboardDesignSystem.md`, `docs/UI/WorkflowListDisplayModes.md`, `docs/UI/WorkflowWorkspaceSidebar.md`, `docs/UI/RecurringSchedulesPage.md`, `docs/UI/SkillsTabDesign.md`, `docs/UI/WorkflowDetailsPage.md`, and `docs/UI/RecurringScheduleDetailsPage.md` before implementation.
-- [ ] **1.1 Far-left application shell** — replace centered/header-only primary navigation with a responsive application rail at the viewport's far-left edge, containing Workflows, Create, Recurring, Skills, RAG/Manifests, Omnigent Agents, Omnigent Policies, Remediation, Artifacts/Observability, and Settings.
-- [ ] **1.2 Reusable collection workspace** — implement a parent layout whose optional collection sidebar is the first column immediately right of the application rail and whose primary pane fills the remaining width; never wrap the split workspace in a centered/max-width page container.
+- [ ] **1.0 Declarative design first** — make `docs/UI/CollectionWorkspaceLayout.md` canonical for shared collection sidebars and the Workflow/Recurring entity-detail frame; reconcile the related UI documents before implementation.
+- [ ] **1.1 Masthead navigation** — retain responsive top-level page navigation in the masthead; do not introduce a page-navigation sidebar.
+- [ ] **1.2 Reusable collection workspace** — implement a parent layout whose optional collection sidebar lists entities from the active collection and whose primary pane fills the remaining width; never render two adjacent sidebars.
 - [ ] **1.3 Shared sidebar component system** — provide common header, filter, row metrics, active/focus states, pinned-current row, divider, scrolling, loading/empty/error states, accessibility, and responsive behavior with entity-specific adapters.
 - [ ] **1.4 Required collection sidebars** — use the shared primitive for Workflow detail/Create, Recurring detail, and Skills preview/create; Recurring lists schedules only, Skills lists skills only, and desktop Skills keeps its sidebar present.
 - [ ] **1.5 Shared Workflow/Recurring detail frame** — reuse breadcrumb/header, status and action placement, summary/facts strip, tabs/sections, main slab, optional facts rail, and loading/error/responsive patterns while retaining entity-specific content.
 - [ ] **1.6 Reusable list display modes** — generalize Workflows/Recurring `hidden`, `sidebar`, and `table` behavior with per-collection preferences and route-owned coercion; place controls in the shell/workspace utility area rather than a centered masthead.
 - [ ] **1.7 Full-page list and route inventory** — classify each major page and harden full-page list routes for workflows, recurring schedules, skills, manifests/RAG sources, Omnigent agents/policies, remediations, and artifacts/reports.
 - [ ] **1.8 Preferences, responsiveness, and accessibility** — prevent preference cross-talk, preserve deep links and selection, provide deterministic focus, and collapse to an accessible drawer or list-to-detail flow where three columns do not fit.
-- [ ] **1.9 UI regression coverage** — test far-left geometry, common sidebar anatomy, required Recurring/Skills sidebars, shared Workflow/Recurring detail regions, direct deep links, localized failures, and mobile accessibility.
+- [ ] **1.9 UI regression coverage** — test masthead navigation, single-sidebar geometry, common sidebar anatomy, required Recurring/Skills sidebars, shared detail regions, direct deep links, localized failures, and mobile accessibility.
 
-**Done means:** every major area is reachable from one far-left application rail; Workflow, Recurring, and Skills use the same sidebar shell at the content edge; Workflow and recurring schedule detail pages share a recognizable detail frame; no split workspace is centered with a large left margin; and routes, preferences, accessibility, and mobile fallbacks remain correct.
+**Done means:** every major area is reachable from masthead navigation; Workflow, Recurring, and Skills reuse one contextual sidebar shell without a neighboring page-nav sidebar; Workflow and recurring schedule detail pages share a recognizable detail frame; and routes, preferences, accessibility, and mobile fallbacks remain correct.
 
 ---
 

--- a/docs/UI/CollectionWorkspaceLayout.md
+++ b/docs/UI/CollectionWorkspaceLayout.md
@@ -3,37 +3,37 @@
 Status: **Target Architecture**
 Owners: MoonMind Engineering
 Last updated: 2026-07-10
-Canonical for: dashboard application rail placement, reusable collection sidebars, far-left workspace geometry, and the shared Workflow/Recurring entity-detail frame
+Canonical for: reusable collection sidebars, workspace geometry, and the shared Workflow/Recurring entity-detail frame
 
 **Implementation tracking:** implementation checklists belong in GitHub issues or `docs/tmp/`. This document defines durable desired state.
 
 ## 1. Purpose
 
-Define one application-wide desktop composition for MoonMind collection surfaces. Workflows, Recurring, and Skills must not invent separate left-navigation systems, and detail routes must not mount a sidebar inside a centered page wrapper.
+Define one desktop composition for MoonMind collection surfaces. Workflows, Recurring, and Skills share one contextual sidebar system; that sidebar lists entities and must never become page navigation. Detail routes must not mount a second sidebar beside it.
 
 ## 2. Non-negotiable geometry
 
-The desktop shell has three ordered regions:
+The desktop workspace has two ordered regions below the masthead:
 
 ```text
-┌──────────────────┬──────────────────────────┬───────────────────────────────────────────┐
-│ Application rail │ Collection sidebar       │ Primary page or entity-detail pane        │
-│ viewport far-left│ content-region far-left  │ fluid workspace; readable widths inside  │
-└──────────────────┴──────────────────────────┴───────────────────────────────────────────┘
+┌──────────────────────────┬───────────────────────────────────────────┐
+│ Collection sidebar       │ Primary page or entity-detail pane        │
+│ workspace left edge      │ fluid workspace; readable widths inside  │
+└──────────────────────────┴───────────────────────────────────────────┘
 ```
 
-1. The **application rail** is the first visual column at the far-left edge of the viewport. It contains the MoonMind brand and top-level destinations, including **Workflows**, **Create**, **Recurring**, and **Skills**.
-2. A **collection sidebar**, when the route owns one, is the first child of the dashboard content region immediately to the right of the application rail.
+1. Top-level destinations, including **Workflows**, **Create**, **Recurring**, and **Skills**, remain in the page masthead navigation.
+2. A **collection sidebar**, when the route owns one, is the first child of the route workspace and lists only entities from the active collection.
 3. The primary pane begins immediately after the collection sidebar and consumes the remaining width.
-4. Neither left-side region may be placed inside a centered, constrained, or `max-width` page container.
+4. The split workspace must not create a second sidebar or place the collection sidebar inside the detail frame.
 5. A detail pane may constrain prose, forms, logs, or evidence *inside itself*. Those constraints must never move the collection sidebar away from the content edge or create a large empty left margin.
-6. The application rail remains present across desktop dashboard routes. Collection sidebars are route-owned and may be absent only where the route contract explicitly calls for a full-table or focused single-pane presentation.
+6. Collection sidebars are route-owned and may be absent where the route contract calls for a full-table or focused single-pane presentation.
 
-On tablet and mobile, the shell may collapse into a drawer or list-to-detail flow. Hidden desktop rails and controls must leave the accessibility tree.
+On tablet and mobile, the collection sidebar may collapse into a drawer or list-to-detail flow. Hidden desktop controls must leave the accessibility tree.
 
-## 3. Application rail contract
+## 3. Masthead navigation contract
 
-The application rail is React-owned by `DashboardShell` and uses router-native links. Its shared anatomy is:
+The masthead is React-owned by `DashboardShell` and uses router-native links. It owns brand, top-level route navigation, responsive navigation controls, and global utilities. Collection sidebars must not contain these page links or duplicate this navigation.
 
 - brand/home control;
 - grouped top-level route links with icons and text labels;
@@ -42,7 +42,7 @@ The application rail is React-owned by `DashboardShell` and uses router-native l
 - environment, version, account, and settings utilities;
 - compact/collapsed state when supported.
 
-The rail uses the same tokens, border, focus ring, hover brightening, icon sizing, tooltip behavior, and responsive collapse behavior everywhere. Primary navigation must not be recreated as a centered pill row inside the page masthead.
+Primary navigation remains visually and structurally distinct from contextual collection lists.
 
 ## 4. Shared collection sidebar primitive
 
@@ -101,11 +101,11 @@ Shared detail elements must use the same typography, spacing, surface hierarchy,
 
 ## 6. Ownership and composition
 
-`DashboardShell` owns the application rail and global providers. A route-family workspace owns its collection sidebar and primary pane as siblings. The detail component owns only the content inside the primary pane.
+`DashboardShell` owns the masthead and global providers. A route-family workspace owns its collection sidebar and primary pane as siblings. The detail component owns only the content inside the primary pane.
 
 ```text
 DashboardShell
-├── ApplicationRail
+├── MastheadNavigation
 └── DashboardContent
     └── CollectionWorkspace
         ├── CollectionSidebar
@@ -119,7 +119,8 @@ Forbidden compositions include:
 - `EntityDetailFrame > CollectionSidebar`;
 - page-specific copies of sidebar CSS or state components;
 - a second top-level navigation system on Recurring or Skills;
-- a large decorative left gutter before either rail.
+- page-navigation links inside a collection sidebar;
+- two adjacent sidebars.
 
 ## 7. Tokens and component seams
 
@@ -135,7 +136,7 @@ Shared implementations should converge on neutral names such as:
 --mm-detail-facts-rail-width
 
 .dashboard-shell
-.application-rail
+.masthead
 .dashboard-content
 .collection-workspace
 .collection-sidebar
@@ -162,7 +163,7 @@ All rails, filters, rows, mode controls, tabs, and actions are keyboard reachabl
 
 Representative frontend tests must prove:
 
-1. the application rail is the viewport's far-left desktop column;
+1. page navigation remains in the masthead;
 2. Workflows, Recurring, and Skills links appear in the same rail with common active/focus behavior;
 3. each collection sidebar is the first content-region column and is not inside a centered/max-width wrapper;
 4. Workflow, Recurring, and Skills adapters share the same sidebar shell and state components;

--- a/docs/UI/DashboardDesignSystem.md
+++ b/docs/UI/DashboardDesignSystem.md
@@ -7,7 +7,7 @@ Last updated: 2026-07-10
 
 Define the desired-state design system for the MoonMind dashboard: visual language, design tokens, surface hierarchy, layout rules, motion, component behavior, and page composition. This document is declarative. It describes what the dashboard should look and feel like when it is correct.
 
-For application-rail placement, shared collection sidebars, and the common entity-detail frame, see `docs/UI/CollectionWorkspaceLayout.md`. For route ownership, runtime config, API boundaries, and workflow console architecture, see `docs/UI/WorkflowConsoleArchitecture.md`. For the workflow-specific desktop sidebar/workspace addendum that applies these surface, focus, and motion rules, see `docs/UI/WorkflowWorkspaceSidebar.md`.
+For masthead placement, shared collection sidebars, and the common entity-detail frame, see `docs/UI/CollectionWorkspaceLayout.md`. For route ownership, runtime config, API boundaries, and workflow console architecture, see `docs/UI/WorkflowConsoleArchitecture.md`. For the workflow-specific desktop sidebar/workspace addendum that applies these surface, focus, and motion rules, see `docs/UI/WorkflowWorkspaceSidebar.md`.
 
 ---
 
@@ -219,13 +219,13 @@ The dashboard uses two desktop width modes:
 
 The page shell may transition between these two modes within the same route.
 
-### 7.2 Application rail and workspace geometry
+### 7.2 Masthead and workspace geometry
 
-Desktop primary navigation uses a persistent far-left application rail, not viewport-centered masthead pills. The content region begins immediately to its right. When a collection sidebar is present, it is the content region's first column and the primary pane starts immediately after it.
+Desktop primary navigation remains in the masthead. When a collection sidebar is present, it is the workspace's first column and the primary pane starts immediately after it.
 
-The application rail, collection sidebar, and primary pane are siblings at their respective shell/workspace layers. Do not place either rail inside a constrained or centered page shell. Constrained and data-wide widths apply only inside the primary pane.
+The collection sidebar and primary pane are siblings at the workspace layer. Do not put the collection sidebar inside a detail frame or render a page-navigation sidebar beside it. Constrained and data-wide widths apply only inside the primary pane.
 
-The application rail and every collection sidebar share token-driven glass/matte surfaces, border light, icon sizing, hover brightening, visible focus, active state, tooltip posture, and responsive collapse behavior. Workflows, Recurring, and Skills use the same collection-sidebar component family.
+Workflows, Recurring, and Skills use the same token-driven collection-sidebar component family while masthead navigation remains a distinct shell component.
 
 ### 7.3 Control deck + data slab pattern
 
@@ -383,7 +383,7 @@ Run this checklist when changing dashboard motion, glass/LiquidGL surfaces, or a
 
 ### 10.1 Application rail and collection sidebars
 
-Top-level destinations render in the far-left application rail. The rail is a persistent shell primitive rather than a page-level card or a centered row of navigation pills.
+Top-level destinations render in the masthead. Collection sidebars are contextual entity lists, not a second home for page navigation.
 
 Application-rail rules:
 
@@ -543,7 +543,7 @@ Use subtle atmospheric separators instead of hard utilitarian dividers everywher
 
 Examples:
 
-- horizon or edge-light separator at the application-rail/content boundary or beneath a page header
+- horizon or edge-light separator beneath the masthead or a page header
 - soft orbital gradient behind section transitions
 - restrained border glows on major surface edges
 

--- a/docs/UI/DashboardSPAArchitecture.md
+++ b/docs/UI/DashboardSPAArchitecture.md
@@ -203,9 +203,9 @@ Rules:
 
 ---
 
-## 8. Shell, application rail, and collection workspaces
+## 8. Shell, masthead, and collection workspaces
 
-The React-owned `DashboardShell` provides global providers plus a persistent application rail.
+The React-owned `DashboardShell` provides global providers plus persistent masthead navigation.
 
 The shell owns:
 
@@ -219,15 +219,15 @@ The shell owns:
 - optional command palette provider;
 - shared workspace and collection-display state.
 
-On desktop, the application rail is the first column at the viewport's far-left edge. It contains the brand and top-level links, including Workflows, Create, Recurring, and Skills. Primary navigation is not recreated as a centered masthead pill row. Navigation uses router-native links (`Link`, `NavLink`, or equivalent), and active state comes from the current route rather than direct DOM mutation.
+On desktop, the masthead contains the brand and top-level links, including Workflows, Create, Recurring, and Skills. Navigation uses router-native links (`Link`, `NavLink`, or equivalent), and active state comes from the current route rather than direct DOM mutation.
 
-Immediately to the right, the dashboard content region hosts route-family workspaces. A collection workspace may render a collection sidebar as its first column and a primary pane as its second. The workspace grid is fluid and must not be nested in a centered/max-width page wrapper. Readable-width limits belong inside the primary pane.
+Below it, the dashboard content region hosts route-family workspaces. A collection workspace may render one contextual collection sidebar as its first column and a primary pane as its second. That sidebar lists Workflows, Recurring schedules, or Skills for the active route; it never contains top-level page links. The workspace must never render an application-navigation sidebar beside the collection sidebar.
 
 `docs/UI/CollectionWorkspaceLayout.md` is canonical for geometry, shared sidebar anatomy, and the common Workflow/Recurring detail frame. List-display controls for participating collections live in the shell/workspace utility area associated with that collection.
 
-Required shell primitives include `ApplicationRail`, `DashboardContent`, `CollectionWorkspace`, `CollectionSidebar`, and `EntityDetailFrame`. Workflows, Recurring, and Skills supply adapters rather than copying layout or CSS.
+Required primitives include `DashboardNavigation`, `CollectionWorkspace`, `CollectionSidebar`, and `EntityDetailFrame`. Workflows, Recurring, and Skills supply adapters rather than copying layout or CSS.
 
-Legacy server-rendered navigation partials should be removed after the SPA shell owns the application rail and global utilities. On tablet/mobile, the application rail and collection sidebar may collapse into drawers or list-to-detail flows. Non-rendered desktop controls must be absent from the accessibility tree.
+Legacy server-rendered navigation partials should be removed after the SPA shell owns masthead navigation and global utilities. On tablet/mobile, masthead navigation may use a menu and the collection sidebar may collapse into a list-to-detail flow. Non-rendered desktop controls must be absent from the accessibility tree.
 
 ---
 
@@ -400,7 +400,7 @@ Shared components should accept product-neutral inputs where practical, but shou
 MoonMind can be considered fully converted when:
 
 1. Dashboard routes are client-routed after initial shell load.
-2. The dashboard navigation is React-owned and renders as the far-left desktop application rail.
+2. The dashboard navigation is React-owned and renders in the desktop masthead.
 3. Internal dashboard route transitions do not reload the document.
 4. Direct refresh of supported dashboard deep links returns the SPA shell and renders the correct client route.
 5. FastAPI API/auth/health/static/artifact routes are never captured by SPA fallback.
@@ -422,8 +422,8 @@ Frontend tests should cover:
 
 - route rendering under the client router;
 - internal navigation without `window.location.assign`;
-- active application-rail state and shared Workflows/Recurring/Skills navigation;
-- far-left application-rail and collection-sidebar geometry;
+- active masthead state and shared Workflows/Recurring/Skills navigation;
+- masthead and single collection-sidebar geometry;
 - shared Workflow/Recurring detail-frame composition;
 - QueryClient persistence across route changes;
 - page-level error boundaries;

--- a/docs/UI/RecurringScheduleDetailsPage.md
+++ b/docs/UI/RecurringScheduleDetailsPage.md
@@ -52,7 +52,7 @@ Navigation rules:
 
 ## 5. Page Composition
 
-The recurring schedule detail page is a schedule adapter rendered through the same `EntityDetailFrame` as Workflow detail. The Recurring sidebar is a workspace sibling at the far-left content edge immediately right of the application rail; it is never mounted inside the frame or a centered/max-width wrapper.
+The recurring schedule detail page is a schedule adapter rendered through the same `EntityDetailFrame` as Workflow detail. The Recurring sidebar is the single contextual sidebar and a workspace sibling; it lists schedules only and is never mounted inside the frame or beside a page-navigation sidebar.
 
 Reuse from workflow detail:
 

--- a/docs/UI/RecurringSchedulesPage.md
+++ b/docs/UI/RecurringSchedulesPage.md
@@ -25,7 +25,7 @@ Use this document for Recurring schedules page behavior.
 
 Use related docs for shared concepts and adjacent surfaces:
 
-- `docs/UI/CollectionWorkspaceLayout.md` — canonical far-left application rail, shared collection-sidebar primitive, and Workflow/Recurring detail frame.
+- `docs/UI/CollectionWorkspaceLayout.md` — canonical masthead navigation, shared collection-sidebar primitive, and Workflow/Recurring detail frame.
 - `docs/UI/WorkflowsListPage.md` — reference for the full Workflows table visual rhythm, filtering posture, loading states, mobile cards, pagination, and row scanning behavior.
 - `docs/UI/WorkflowListDisplayModes.md` — reference for the shell/workspace list display radio group, the three-mode list model, and sidebar-as-table-slice visual contract.
 - `docs/UI/WorkflowWorkspaceSidebar.md` — reference for desktop list-to-detail workspace composition and route-owned sidebars.
@@ -167,7 +167,7 @@ Default behavior:
 The list display selector belongs to the current Recurring collection's shell/workspace utility region. It remains adjacent to route and collection context without becoming a centered masthead element or moving into page content, the Recurring sidebar, or the table toolbar.
 
 ```text
-[Application rail] [Recurring sidebar when visible] [Recurring utility + primary pane]
+[Masthead navigation] [Recurring sidebar when visible] [Recurring utility + primary pane]
 ```
 
 Recurring-specific control contract:
@@ -210,7 +210,7 @@ The default `/schedules` page should be a full-width table view, visually close 
 Desired layout:
 
 ```text
-Far-left application rail │ Recurring page
+Masthead navigation │ Recurring page
                           │ Page header / route context
                           │ Recurring table control band
                           │   [+] Total Active Next 24h Attention [optional refresh/live]
@@ -222,7 +222,7 @@ Rules:
 
 1. Leave deliberate space between the page header/route context and the table.
 2. Use that space for the compact create action and summary metrics.
-3. The `+` action should be visually near the summary strip, not buried inside the application rail or global shell.
+3. The `+` action should be visually near the summary strip, not buried inside the masthead or global shell.
 4. The table should use the wide data-panel layout because it is a multi-column scanning surface.
 5. The full table should occupy the available dashboard content width.
 6. The page should not render a selected detail pane in table mode.
@@ -383,7 +383,7 @@ Suggested shape:
 Rules:
 
 1. The sidebar uses the shared `CollectionSidebar` shell, header, filter, row metrics, selected/focus states, divider, scrolling, and localized state components.
-2. It is the first content-region column immediately right of the far-left application rail and is never wrapped inside the detail frame or a centered page container.
+2. It is the first content-region column immediately right of the masthead navigation and is never wrapped inside the detail frame or a centered page container.
 3. Sidebar rows link to `/schedules/{definitionId}`.
 4. The active schedule row exposes `aria-current="page"`.
 5. The sidebar has an accessible name such as `Recurring schedule navigation`.
@@ -418,7 +418,7 @@ Default desktop layout:
 
 ```text
 ┌──────────────────┬──────────────────────────┬──────────────────────────────────────────┐
-│ Application rail │ Recurring sidebar        │ Shared entity-detail frame               │
+│ Masthead navigation │ Recurring sidebar        │ Shared entity-detail frame               │
 │ viewport far-left│ content-region far-left  │ breadcrumb, title/state/actions          │
 │                  │                          │ summary/facts, tabs, main, optional rail │
 └──────────────────┴──────────────────────────┴──────────────────────────────────────────┘
@@ -673,7 +673,7 @@ Switching between full table and sidebar/detail should feel like changing how mu
 Rules:
 
 1. Avoid large page-slide animations.
-2. Preserve `DashboardShell`, application-rail, and collection-utility continuity.
+2. Preserve `DashboardShell`, masthead, and collection-utility continuity.
 3. Header row height should remain stable between table and sidebar.
 4. Sidebar row height should match or intentionally derive from the table first-column row height.
 5. Preserve selected schedule identity across mode changes.

--- a/docs/UI/SkillsTabDesign.md
+++ b/docs/UI/SkillsTabDesign.md
@@ -15,7 +15,7 @@ On desktop, `/skills` is a list–detail workspace that reuses the dashboard's e
 
 ## 2. Goals
 
-- Dedicated dashboard entry point for skills (route `/skills`) in the shared far-left application rail.
+- Dedicated dashboard entry point for skills (route `/skills`) in the shared masthead navigation.
 - Reuse the geometry and neutral primitives in [`CollectionWorkspaceLayout.md`](CollectionWorkspaceLayout.md).
 - Reuse the shared workspace/sidebar foundation defined by [`WorkflowWorkspaceSidebar.md`](WorkflowWorkspaceSidebar.md) and [`WorkflowListDisplayModes.md`](WorkflowListDisplayModes.md); do not create a parallel Skills-only sidebar implementation or copy its CSS.
 - List skills in the shared sidebar and preview the selected skill's `SKILL.md` content (Markdown → HTML) in the main pane.
@@ -27,13 +27,13 @@ On desktop, `/skills` is a list–detail workspace that reuses the dashboard's e
 
 ### 3.1 Navigation
 
-- Top-level **Skills** destination in the shared application rail → `/skills`, using the same icon/label, active, hover, focus, tooltip, and responsive behavior as Workflows and Recurring.
+- Top-level **Skills** destination in the shared masthead → `/skills`, using the same icon/label, active, hover, focus, tooltip, and responsive behavior as Workflows and Recurring.
 - The Skills sidebar is page-local content navigation. It complements rather than replaces the top-level **Skills** route entry.
 - Reusing the sidebar does not make Skills part of the workflow `hidden` / `sidebar` / `table` display-mode state machine. Unless that system is explicitly generalized later, `/skills` owns its own skills list and does not show workflow-list controls or workflow rows.
 
 ### 3.2 Desktop Workspace Layout
 
-- `/skills` uses the shared `CollectionWorkspace`: the Skills sidebar is the first content-region column immediately right of the far-left application rail, and the primary pane is its sibling.
+- `/skills` uses the shared `CollectionWorkspace`: the Skills sidebar is the first workspace column, lists skills only, and the primary pane is its sibling.
 - The Skills sidebar is always present for desktop preview and create states; it is not optional Workflow list-display state.
 - The sidebar starts at the dashboard content region's far-left edge and is never inside a centered/max-width page wrapper. It follows the shared sidebar width, divider, row-height, and independent-scroll behavior.
 - The primary pane uses the remaining width for the selected skill preview or create form. Readable-width constraints may be applied inside the pane, but not around the entire split workspace.

--- a/docs/UI/WorkflowListDisplayModes.md
+++ b/docs/UI/WorkflowListDisplayModes.md
@@ -37,7 +37,7 @@ This document narrows and supersedes only the list-display mode and shell/worksp
 
 Use these documents together:
 
-- `docs/UI/CollectionWorkspaceLayout.md` is canonical for the far-left application rail, shared collection-sidebar primitive, and workspace geometry.
+- `docs/UI/CollectionWorkspaceLayout.md` is canonical for the masthead navigation, shared collection-sidebar primitive, and workspace geometry.
 - `docs/UI/DashboardSPAArchitecture.md` remains canonical for the persistent SPA shell, route ownership, providers, and same-origin API model.
 - `docs/UI/DashboardDesignSystem.md` remains canonical for visual language, focus states, motion posture, glass/matte treatment, and shared tokens.
 - `docs/UI/WorkflowsListPage.md` remains canonical for table columns, filters, sorting, pagination, mobile cards, row data, and list API behavior.
@@ -174,7 +174,7 @@ Rules:
 The list display selector belongs to the current collection's shell/workspace utility region. It remains adjacent to route and collection context without becoming a centered masthead element or moving into page content, the collection sidebar, or a table toolbar.
 
 ```text
-[Application rail] [Workflow sidebar when visible] [Workflow utility + primary pane]
+[Masthead navigation] [Workflow sidebar when visible] [Workflow utility + primary pane]
 ```
 
 Control contract:
@@ -227,7 +227,7 @@ Rules:
 Rules:
 
 1. The sidebar is owned by the workspace/layout composition layer, not by the detail page body.
-2. It is the first dashboard-content column immediately right of the far-left application rail; it is never inside the detail page's centered/max-width wrapper.
+2. It is the first dashboard-content column immediately right of the masthead navigation; it is never inside the detail page's centered/max-width wrapper.
 3. Sidebar row links navigate to canonical workflow detail URLs.
 4. The active workflow row uses `aria-current="page"`.
 5. Sidebar list failures do not prevent the selected detail from rendering.
@@ -341,7 +341,7 @@ Rules:
 7. In reduced-motion mode, the mode change snaps or uses near-instant opacity changes.
 8. When the same list query and row set are used, preserve vertical scroll position where practical.
 9. If table and sidebar cannot share scroll position because of pagination or virtualization, preserve the selected row and focus target instead.
-10. The route may change, but `DashboardShell`, the application rail, and the collection utility region remain mounted.
+10. The route may change, but `DashboardShell`, the masthead, and the collection utility region remain mounted.
 
 ---
 

--- a/docs/UI/WorkflowWorkspaceSidebar.md
+++ b/docs/UI/WorkflowWorkspaceSidebar.md
@@ -17,7 +17,7 @@ Canonical for: desktop workflow workspace layout, SPA list-to-detail transitions
 
 MoonMind should make desktop workflow browsing feel like one continuous workspace.
 
-In the default desktop state, `/workflows` shows the full Workflows list with the table, filters, toolbar, pagination, and list-level scanning affordances. When a user clicks a workflow title, the same workspace should transition in place: the list compresses into a compact sidebar pinned to the far-left edge of the dashboard content region, immediately right of the application rail, and the selected Workflow Details surface loads into the space that opens to the right. The browser URL changes to the canonical workflow detail URL, but the SPA shell does not reload.
+In the default desktop state, `/workflows` shows the full Workflows list with the table, filters, toolbar, pagination, and list-level scanning affordances. When a user clicks a workflow title, the same workspace should transition in place: the list compresses into the workspace's single contextual sidebar, and the selected Workflow Details surface loads into the space that opens to the right. The browser URL changes to the canonical workflow detail URL, but the SPA shell does not reload.
 
 When the user chooses to expand the workflow list back to full screen, the selected detail view closes. The route returns to `/workflows`, the full list occupies the workspace again, and no hidden selected detail remains active in the UI.
 
@@ -25,7 +25,7 @@ On mobile, the split workspace is not used. Mobile keeps the straightforward car
 
 This document amends the existing UI contracts without replacing them:
 
-- `docs/UI/CollectionWorkspaceLayout.md` is canonical for the far-left application rail, shared collection-sidebar component, and shared entity-detail frame.
+- `docs/UI/CollectionWorkspaceLayout.md` is canonical for the masthead navigation, shared collection-sidebar component, and shared entity-detail frame.
 - `docs/UI/DashboardSPAArchitecture.md` is canonical for the persistent SPA shell, client routing authority, route fallback, providers, and same-origin API model.
 - `docs/UI/WorkflowsListPage.md` remains canonical for full Workflows list content, filters, table columns, pagination, and mobile cards.
 - `docs/UI/WorkflowDetailsPage.md` remains canonical for detail content, tabs, actions, evidence sections, logs, artifacts, and recovery flows.
@@ -133,7 +133,7 @@ Rules:
 
 In selected-detail workspace state, the workspace renders:
 
-1. a compact workflow sidebar pinned to the far-left edge of the dashboard content region, immediately right of the application rail;
+1. a compact workflow sidebar at the workspace left edge;
 2. the selected Workflow Details surface in the main pane;
 3. any right rail already owned by the Workflow Details page, if available and if width allows.
 
@@ -226,7 +226,7 @@ DashboardShell
 
 Rules:
 
-1. `DashboardShell` owns global app providers, the application rail, global utilities, route-level error boundaries, and capability state.
+1. `DashboardShell` owns global app providers, the masthead, global utilities, route-level error boundaries, and capability state.
 2. `WorkflowsWorkspacePage` owns desktop workspace composition, route-derived workspace mode, list context, sidebar visibility preference, split layout, and Workflow collection utility state.
 3. `WorkflowListSurface` owns full-list table/card rendering and can provide compact row data for the sidebar.
 4. `WorkflowSidebar` owns compact workflow navigation only.
@@ -334,7 +334,7 @@ Rules:
 8. `aria-current="page"` marks the active workflow row/link.
 9. Sidebar rows support keyboard navigation as ordinary links, with visible focus states.
 10. Sidebar state must not mutate detail state except by explicit workflow navigation.
-11. The sidebar must be mounted at the workspace grid level so its left edge aligns with the dashboard content region's far-left edge immediately right of the application rail.
+11. The sidebar must be mounted at the workspace grid level as the only sidebar beside the primary pane.
 
 ---
 
@@ -372,7 +372,7 @@ The selected-detail workspace should fit the Dashboard Design System while solvi
 Visual posture:
 
 - desktop-only left rail;
-- far-left sidebar alignment within the dashboard content region immediately right of the application rail;
+- collection-sidebar alignment at the workspace left edge;
 - no detail-page max-width wrapper around the entire split workspace;
 - glass control shell where performance allows;
 - matte or satin row interiors for legibility;
@@ -385,10 +385,10 @@ Visual posture:
 Layout rules:
 
 1. Use a top-level workspace grid or flex layout owned by `WorkflowsWorkspacePage`.
-2. In selected-detail workspace mode, the sidebar column starts at the dashboard content region's far-left edge immediately right of the application rail.
+2. In selected-detail workspace mode, the sidebar column starts at the workspace left edge.
 3. The detail pane starts immediately after the sidebar gutter.
 4. The split workspace must not be horizontally centered inside a narrow detail-page container.
-5. There is no decorative or layout gutter between the application rail and the collection sidebar beyond the shared shell divider.
+5. The masthead remains above the workspace; no page-navigation sidebar is inserted beside the collection sidebar.
 6. Workflow and Recurring sidebars share the neutral `CollectionSidebar` shell and state components; workflow-specific adapters provide row data and copy.
 7. Full-list mode uses the same workspace root and expands to one column.
 8. The detail pane may contain nested readable-width sections for logs, evidence, markdown, or dense tables, but those constraints apply inside the pane rather than to the entire workspace.
@@ -511,7 +511,7 @@ Implementation should add or preserve tests for these behaviors:
 2. Desktop workflow title links point to canonical detail URLs.
 3. Clicking a workflow title uses SPA routing and does not reload the document.
 4. `DashboardShell` and `QueryClientProvider` remain mounted across `/workflows` to `/workflows/{workflowId}` transitions.
-5. Desktop selecting a workflow renders the compact sidebar at the far-left edge of the dashboard content region, immediately right of the application rail.
+5. Desktop selecting a workflow renders the compact sidebar at the workspace left edge as the only sidebar.
 6. Desktop selecting a workflow renders existing Workflow Details content in the main pane.
 7. The split workspace is not wrapped in the detail page's centered max-width container.
 8. Detail loading appears in the detail pane while sidebar/list context remains visible.

--- a/frontend/src/entrypoints/dashboard-app.tsx
+++ b/frontend/src/entrypoints/dashboard-app.tsx
@@ -662,10 +662,18 @@ function CollectionListDisplayModeControl({
   );
 }
 
-function ApplicationRail({
+function DashboardNavigation({
   uiInfo,
+  listDisplayAccessibleName,
+  listDisplayMode,
+  listDisplayStatus,
+  onListDisplayModeSelect,
 }: {
   uiInfo: DashboardUiInfo | null;
+  listDisplayAccessibleName?: string | undefined;
+  listDisplayMode: CollectionListDisplayMode | null;
+  listDisplayStatus?: string | null | undefined;
+  onListDisplayModeSelect: (mode: CollectionListDisplayMode) => void;
 }) {
   const [open, setOpen] = useState(false);
   const menuButtonRef = useRef<HTMLButtonElement>(null);
@@ -735,7 +743,7 @@ function ApplicationRail({
   }, [open]);
 
   return (
-    <aside className="application-rail" aria-label="Application rail">
+    <header className="masthead">
       <Link className="masthead-brand" to="/workflows" aria-label="MoonMind workflows">
         <img
           className="masthead-logo"
@@ -749,6 +757,15 @@ function ApplicationRail({
           <span className="masthead-brand-mind">Mind</span>
         </h1>
       </Link>
+
+      {listDisplayMode ? (
+        <CollectionListDisplayModeControl
+          {...(listDisplayAccessibleName ? { accessibleName: listDisplayAccessibleName } : {})}
+          effectiveMode={listDisplayMode}
+          status={listDisplayStatus}
+          onSelect={onListDisplayModeSelect}
+        />
+      ) : null}
 
       <button
         ref={menuButtonRef}
@@ -775,7 +792,7 @@ function ApplicationRail({
         />
       ) : null}
 
-      <div className="application-rail-nav">
+      <div className="masthead-nav">
         <nav
           ref={navRef}
           className={`route-nav${open ? ' route-nav--open' : ''}`}
@@ -853,14 +870,14 @@ function ApplicationRail({
         </nav>
       </div>
 
-      <div className="application-rail-utilities">
-        {buildId ? (
+      {buildId ? (
+        <div className="masthead-title-meta">
           <div className="version-badge" title="MoonMind image version">
             <span className="version-badge-value">v{buildId}</span>
           </div>
-        ) : null}
-      </div>
-    </aside>
+        </div>
+      ) : null}
+    </header>
   );
 }
 
@@ -884,40 +901,36 @@ function AppShell({
   return (
     <DashboardLiveUpdateProvider uiInfo={uiInfo}>
       <main className="dashboard-root">
-        <ApplicationRail uiInfo={uiInfo} />
-        <div className="dashboard-content">
-          <section className="worker-pause-banner" data-worker-pause hidden aria-live="polite">
-            <p>
-              <span className="worker-pause-label" data-worker-pause-status>
-                Workers: Running
-              </span>
-              <span className="worker-pause-reason" data-worker-pause-reason />
-              <Link className="worker-pause-manage" to="/settings?section=operations" data-worker-pause-manage>
-                Manage operations
-              </Link>
-            </p>
-          </section>
+        <section className="worker-pause-banner" data-worker-pause hidden aria-live="polite">
+          <p>
+            <span className="worker-pause-label" data-worker-pause-status>
+              Workers: Running
+            </span>
+            <span className="worker-pause-reason" data-worker-pause-reason />
+            <Link className="worker-pause-manage" to="/settings?section=operations" data-worker-pause-manage>
+              Manage operations
+            </Link>
+          </p>
+        </section>
 
-          {listDisplayMode ? (
-            <div className="dashboard-collection-utilities">
-              <CollectionListDisplayModeControl
-                {...(listDisplayAccessibleName ? { accessibleName: listDisplayAccessibleName } : {})}
-                effectiveMode={listDisplayMode}
-                status={listDisplayStatus}
-                onSelect={onListDisplayModeSelect}
-              />
-            </div>
-          ) : null}
-
-          <div
-            className={`dashboard-shell-constrained${dataWidePanel ? ' dashboard-shell-constrained--data-wide' : ''}`}
-          >
-            <DashboardAlerts />
-          </div>
-          <section className={`panel${dataWidePanel ? ' panel--data-wide' : ''}`} aria-live="polite">
-            {children}
-          </section>
+        <div className="dashboard-shell-full">
+          <DashboardNavigation
+            uiInfo={uiInfo}
+            listDisplayAccessibleName={listDisplayAccessibleName}
+            listDisplayMode={listDisplayMode}
+            listDisplayStatus={listDisplayStatus}
+            onListDisplayModeSelect={onListDisplayModeSelect}
+          />
         </div>
+
+        <div
+          className={`dashboard-shell-constrained${dataWidePanel ? ' dashboard-shell-constrained--data-wide' : ''}`}
+        >
+          <DashboardAlerts />
+        </div>
+        <section className={`panel${dataWidePanel ? ' panel--data-wide' : ''}`} aria-live="polite">
+          {children}
+        </section>
       </main>
     </DashboardLiveUpdateProvider>
   );

--- a/frontend/src/entrypoints/dashboard.test.tsx
+++ b/frontend/src/entrypoints/dashboard.test.tsx
@@ -2592,14 +2592,14 @@ describe('Dashboard shared entry', () => {
     );
 
     expect(dashboardShellSource).toContain('className="dashboard-root"');
-    expect(dashboardShellSource).toContain('className="application-rail"');
+    expect(dashboardShellSource).toContain('className="masthead"');
     expect(dashboardShellSource).toContain('className={`route-nav');
     expect(dashboardShellSource).not.toContain('/proposals');
     expect(dashboardShellSource).not.toContain('Proposals');
 
     for (const selector of [
       '.dashboard-root',
-      '.application-rail',
+      '.masthead',
       '.route-nav',
       '.panel',
       '.card',
@@ -2618,30 +2618,6 @@ describe('Dashboard shared entry', () => {
     ]) {
       expect(cssRuleBlock(dashboardCss, selector)).not.toBe('');
     }
-  });
-
-  it('MM-1180 makes the application rail the first desktop column with non-color-only selection', async () => {
-    window.history.replaceState({}, '', '/workflows');
-    renderWithClient(<DashboardApp payload={{ page: 'dashboard', apiBase: '/api' }} />);
-
-    await screen.findByText('Workflow list route loaded', {}, { timeout: 10000 });
-    const root = document.querySelector('.dashboard-root');
-    const rail = screen.getByRole('complementary', { name: 'Application rail' });
-    expect(root?.firstElementChild).toBe(rail);
-    expect(screen.getByRole('link', { name: 'Workflows' }).classList.contains('active')).toBe(true);
-    expect(screen.queryByRole('link', { name: 'Omnigent Agents' })).toBeNull();
-    expect(screen.getByRole('link', { name: 'Settings' })).toBeTruthy();
-    expect(screen.getByText('vtest-build')).toBeTruthy();
-
-    expect(cssRuleBlock(dashboardCss, '.dashboard-root')).toContain(
-      'grid-template-columns: var(--mm-app-rail-width) minmax(0, 1fr);',
-    );
-    const activeRule = cssRuleBlock(dashboardCss, '.application-rail .route-nav a.active');
-    expect(activeRule).toContain('border-color: rgb(var(--mm-accent) / 0.5);');
-    expect(activeRule).toContain('box-shadow: inset 3px 0 0 rgb(var(--mm-accent));');
-    expect(cssRuleBlock(dashboardCss, '.application-rail .route-nav')).toContain(
-      'flex-wrap: nowrap;',
-    );
   });
 
   it('colors only Moon white in the masthead brand', async () => {
@@ -3183,20 +3159,6 @@ describe('Dashboard shared entry', () => {
     expect(
       activeBlocks.some(
         (block) =>
-          block.includes('background: linear-gradient(') &&
-          block.includes('var(--mm-mobile-nav-active-start)') &&
-          block.includes('inset 3px 0 0 var(--mm-mobile-nav-active-edge)'),
-      ),
-    ).toBe(true);
-
-    const scopedActiveBlocks = cssRuleBlocks(
-      dashboardCss,
-      '.application-rail .route-nav a.active',
-    );
-    expect(
-      scopedActiveBlocks.some(
-        (block) =>
-          block.includes('color: white;') &&
           block.includes('background: linear-gradient(') &&
           block.includes('var(--mm-mobile-nav-active-start)') &&
           block.includes('inset 3px 0 0 var(--mm-mobile-nav-active-edge)'),

--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -52,7 +52,6 @@
   --mm-mobile-nav-active-start: rgb(var(--mm-accent) / 0.30);
   --mm-mobile-nav-active-end: rgb(var(--mm-accent) / 0.10);
   --mm-mobile-nav-active-edge: rgb(var(--mm-accent) / 0.88);
-  --mm-app-rail-width: 14rem;
   --mm-font-sans: "IBM Plex Sans", system-ui, sans-serif;
   --mm-executing-sweep-cycle-duration: 2600ms;
   /* MM-1048: slightly more horizontal shimmer path while preserving the shared
@@ -193,43 +192,13 @@ samp {
 .dashboard-root {
   --dashboard-pt: 0;
 
-  display: grid;
-  grid-template-columns: var(--mm-app-rail-width) minmax(0, 1fr);
-  margin: 0;
+  margin: 0 auto;
   max-width: none;
-  min-height: 100dvh;
   width: 100%;
-  padding: 0;
+  padding: var(--dashboard-pt) 1rem 2.75rem;
   box-sizing: border-box;
   container-type: inline-size;
 }
-
-.dashboard-content { min-width: 0; padding: var(--dashboard-pt) 1rem 2.75rem; }
-.application-rail {
-  position: sticky; top: 0; z-index: 50; display: flex; flex-direction: column;
-  align-items: stretch; gap: 1rem; width: var(--mm-app-rail-width); height: 100dvh;
-  padding: 0.9rem 0.7rem; border-right: 1px solid rgb(var(--mm-border) / 0.72);
-  background: var(--mm-glass-fill); box-shadow: var(--mm-elevation-panel);
-}
-.application-rail .masthead-brand { padding: 0 0.45rem 0.65rem; border-bottom: 1px solid rgb(var(--mm-border) / 0.58); }
-.application-rail-nav { min-height: 0; overflow-y: auto; }
-.application-rail .route-nav { flex-direction: column; flex-wrap: nowrap; align-items: stretch; gap: 0.25rem; }
-.application-rail .route-nav a {
-  position: relative; display: flex; align-items: center; gap: 0.65rem; min-height: 2.7rem;
-  padding: 0.55rem 0.7rem; border: 1px solid transparent; border-radius: 0.6rem;
-}
-.application-rail .route-nav a::after { content: none; }
-.application-rail .route-nav a:hover { border-color: rgb(var(--mm-border) / 0.72); }
-.application-rail .route-nav a.active {
-  border-color: rgb(var(--mm-accent) / 0.5); background: rgb(var(--mm-accent) / 0.14);
-  box-shadow: inset 3px 0 0 rgb(var(--mm-accent)); font-weight: 650;
-}
-.application-rail-utilities {
-  display: flex; flex-direction: column; gap: 0.35rem; margin-top: auto; padding-top: 0.7rem;
-  border-top: 1px solid rgb(var(--mm-border) / 0.58);
-}
-.application-rail-utilities .version-badge { align-self: flex-start; margin: 0 0.7rem; }
-.dashboard-collection-utilities { display: flex; justify-content: flex-start; padding: 0.65rem 0; }
 
 /* Most pages read best in a centered working container; data-table routes opt into wide. */
 .dashboard-shell-constrained {
@@ -3703,17 +3672,6 @@ tr[data-proposal-id].proposal-consuming td {
 }
 
 @media (max-width: 1180px) {
-  .dashboard-root { display: block; }
-  .dashboard-content { padding: 0 1rem 2.75rem; }
-  .application-rail {
-    position: relative; width: 100%; height: auto; padding: 0.65rem 1rem;
-    flex-direction: row; align-items: center; border-right: 0;
-    border-bottom: 1px solid rgb(var(--mm-border) / 0.7);
-  }
-  .application-rail .masthead-brand { flex: 1 1 auto; padding: 0; border-bottom: 0; }
-  .application-rail-nav { display: contents; }
-  .application-rail-utilities { display: none; }
-
   .schedules-table-panel .data-table [data-column-key="policy"],
   .schedules-table-panel .data-table [data-column-key="updatedAt"] {
     display: none;
@@ -7569,18 +7527,6 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
   }
 
   .route-nav a.active {
-    color: white;
-    background: linear-gradient(
-      90deg,
-      var(--mm-mobile-nav-active-start),
-      var(--mm-mobile-nav-active-end)
-    );
-    box-shadow:
-      inset 3px 0 0 var(--mm-mobile-nav-active-edge),
-      inset 0 1px 0 var(--mm-mobile-nav-edge);
-  }
-
-  .application-rail .route-nav a.active {
     color: white;
     background: linear-gradient(
       90deg,


### PR DESCRIPTION
A major change was made to the site to add a sidebar nav bar. This is NOT the current desired direction for MoonMind. I only want a sidebar for listing workflows, skills, and recurring schedules. It should not be a page nav bar and I do not want two sidebars next to each other. Reverse this change and go back to the way it was. The goal with using the sidebar more was to re-purpose the workflow sidebar as a sidebar that could also be used to list skills and recurring schedules. NOT NAV LINKS. I need the implementation and documentation changed on this.