### PR TITLE
Fix batch workflow Jira fan-out

### DIFF
--- a/api_service/data/presets/batch-workflows.yaml
+++ b/api_service/data/presets/batch-workflows.yaml
@@ -11,6 +11,7 @@ tags:
 - jira
 requiredCapabilities:
 - git
+- jira
 - gh
 annotations:
   sourceSkill: batch-workflows
@@ -250,5 +251,6 @@ steps:
     id: batch-workflows
     requiredCapabilities:
     - git
+    - jira
     - gh
     args: {}

--- a/moonmind/workflows/temporal/jira_tool_hints.py
+++ b/moonmind/workflows/temporal/jira_tool_hints.py
@@ -86,6 +86,22 @@ _COMMENT_CALL_HINT = (
     '"arguments":{"issueKey":"<ISSUE_KEY>",'
     '"body":"<COMMENT_TEXT>"}}`.'
 )
+_BATCH_SEARCH_HINT = (
+    "- Resolve the batch cohort through `jira.search_issues`; do not request "
+    "an external Jira/Atlassian connector."
+)
+_BATCH_SEARCH_CALL_HINT = (
+    "- Example batch search call: "
+    '`{"tool":"jira.search_issues",'
+    '"arguments":{"jql":"project = <PROJECT_KEY> AND status = '
+    '\\\"<STATUS>\\\"","projectKey":"<PROJECT_KEY>","maxResults":25}}`.'
+)
+_BATCH_BLOCKED_HINT = (
+    "- Treat the task as blocked if trusted Jira search is unavailable; do not "
+    "wait for connector discovery or infer issue content."
+)
+
+_JIRA_TOOL_HINT_AGENT_SKILLS = frozenset({*JIRA_AGENT_SKILLS, "batch-workflows"})
 _BRANCH_VERIFY_BLOCKED_HINT = (
     "- Treat the task as blocked if trusted Jira tool calls are "
     "unavailable, the issue fetch is denied, or comment posting "
@@ -102,7 +118,7 @@ def append_selected_jira_tool_hint(
 
     params = parameters if isinstance(parameters, Mapping) else {}
     selected_skill = selected_agent_skill(params)
-    if selected_skill not in JIRA_AGENT_SKILLS:
+    if selected_skill not in _JIRA_TOOL_HINT_AGENT_SKILLS:
         return instructions
     if "MoonMind trusted Jira tools" in instructions:
         return instructions
@@ -111,7 +127,15 @@ def append_selected_jira_tool_hint(
         "- List available tools with `GET $MOONMIND_URL/mcp/tools`.",
         "- Invoke Jira tools with `POST $MOONMIND_URL/mcp/tools/call`.",
     ]
-    if selected_skill == "jira-issue-creator":
+    if selected_skill == "batch-workflows":
+        tool_lines.extend(
+            [
+                _BATCH_SEARCH_HINT,
+                _BATCH_SEARCH_CALL_HINT,
+                _BATCH_BLOCKED_HINT,
+            ]
+        )
+    elif selected_skill == "jira-issue-creator":
         story_breakdown_path = str(params.get("storyBreakdownPath") or "").strip()
         if story_breakdown_path:
             tool_lines.insert(

--- a/tests/unit/api/test_batch_workflows_preset.py
+++ b/tests/unit/api/test_batch_workflows_preset.py
@@ -191,13 +191,12 @@ async def test_batch_workflows_seed_validates_and_exposes_batch_contract(tmp_pat
             assert len(template.steps) == 1
             step = template.steps[0]
             assert step["skill"]["id"] == "batch-workflows"
-            # The parent only orchestrates/queues; it must not hard-require the
-            # jira capability or GitHub-only batches would be blocked at launch
-            # in environments without a trusted Jira integration. Per-target
-            # jira readiness is enforced on the child workflows instead.
+            # The parent resolves a Jira status cohort before queueing children,
+            # so trusted Jira readiness must be enforced before agent launch.
             assert sorted(step["skill"]["requiredCapabilities"]) == [
                 "gh",
                 "git",
+                "jira",
             ]
 
 
@@ -266,9 +265,7 @@ async def test_batch_workflows_expands_orchestration_step(tmp_path):
 
             assert "git" in expanded["capabilities"]
             assert "gh" in expanded["capabilities"]
-            # GitHub-only batches must not be gated on Jira readiness, so the
-            # parent preset no longer advertises the jira capability.
-            assert "jira" not in expanded["capabilities"]
+            assert "jira" in expanded["capabilities"]
 
 
 async def test_batch_workflows_expands_repository_from_context_when_not_provided(tmp_path):

--- a/tests/unit/workflows/temporal/test_agent_runtime_activities.py
+++ b/tests/unit/workflows/temporal/test_agent_runtime_activities.py
@@ -4004,6 +4004,52 @@ async def test_agent_runtime_prepare_turn_instructions_adds_jira_tool_hint(
     assert "jira.create_issue" in result
     assert "Managed Codex CLI note:" in result
 
+
+@pytest.mark.asyncio
+async def test_agent_runtime_prepare_turn_instructions_adds_batch_jira_search_hint() -> None:
+    activities = TemporalAgentRuntimeActivities()
+
+    result = await activities.agent_runtime_prepare_turn_instructions(
+        {
+            "request": {
+                "agentKind": "managed",
+                "agentId": "codex",
+                "correlationId": "corr-batch",
+                "idempotencyKey": "idem-batch",
+                "parameters": {
+                    "instructions": (
+                        "Resolve project THOR issues in Selected for Development "
+                        "and queue child workflows."
+                    ),
+                    "publishMode": "none",
+                    "metadata": {
+                        "moonmind": {
+                            "selectedSkill": "batch-workflows",
+                        },
+                    },
+                },
+            },
+        }
+    )
+
+    assert "MoonMind trusted Jira tools:" in result
+    assert "GET $MOONMIND_URL/mcp/tools" in result
+    assert "POST $MOONMIND_URL/mcp/tools/call" in result
+    assert "jira.search_issues" in result
+    example_line = next(
+        line
+        for line in result.splitlines()
+        if line.startswith("- Example batch search call: ")
+    )
+    example_payload = json.loads(example_line.split("`", 2)[1])
+    assert example_payload["arguments"]["jql"] == (
+        'project = <PROJECT_KEY> AND status = "<STATUS>"'
+    )
+    assert "do not request an external Jira/Atlassian connector" in result
+    assert "do not wait for connector discovery" in result
+    assert "Managed Codex CLI note:" in result
+
+
 async def test_agent_runtime_prepare_turn_instructions_adds_pr_resolver_blocker_hint() -> None:
     activities = TemporalAgentRuntimeActivities()
 


### PR DESCRIPTION
## Summary

- declare trusted Jira access as a required capability for the batch-workflows preset and its orchestration step
- direct managed agents to MoonMind's internal `jira.search_issues` tool instead of external connector discovery
- fail fast when trusted Jira search is unavailable and cover the managed Codex turn-preparation boundary

## Root cause

Workflow `mm:ae8c4ceb-416a-4355-972b-9c84297f2743` started its managed Codex turn, but `batch-workflows` was excluded from the Jira tool-hint path. Codex attempted external Atlassian connector discovery and waited until the 3,600-second execution budget expired, so it never produced the target manifest or queued child workflows.

## Validation

- `5 passed`: focused batch preset and managed-runtime regression tests
- `1 passed`: startup preset-seeding integration test
- `143 passed`: broader affected backend suites
- `git diff --check`
- The unit wrapper's unrelated frontend sweep completed 1,001 tests but hit one existing 5-second focus-trap timeout; no frontend files changed.