### PR TITLE
Prevent missing Temporal workflow registrations

### DIFF
--- a/moonmind/workflows/temporal/worker_entrypoint.py
+++ b/moonmind/workflows/temporal/worker_entrypoint.py
@@ -11,31 +11,8 @@ from moonmind.workflows.temporal.workers import (
     build_worker_activity_bindings,
     describe_configured_worker,
 )
-from moonmind.workflows.temporal.hard_switch_cutover import registered_user_workflow_type
-from moonmind.workflows.temporal.workflows.agent_run import MoonMindAgentRun
-from moonmind.workflows.temporal.workflows.agent_session import (
-    MoonMindAgentSessionWorkflow,
-)
-from moonmind.workflows.temporal.workflows.managed_session_reconcile import (
-    MoonMindManagedSessionReconcileWorkflow,
-)
-from moonmind.workflows.temporal.workflows.managed_runtime_workspace_cleanup import (
-    MoonMindManagedRuntimeWorkspaceCleanupWorkflow,
-)
-from moonmind.workflows.temporal.workflows.oauth_session import (
-    MoonMindOAuthSessionWorkflow,
-)
-from moonmind.workflows.temporal.workflows.provider_profile_manager import (
-    MoonMindProviderProfileManagerWorkflow,
-)
-from moonmind.workflows.temporal.workflows.run import (
-    MoonMindUserWorkflow,
-)
-from moonmind.workflows.temporal.workflows.merge_automation import (
-    MoonMindMergeAutomationWorkflow,
-)
-from moonmind.workflows.temporal.workflows.pr_resolver import (
-    MoonMindPRResolverWorkflow,
+from moonmind.workflows.temporal.workflow_registry import (
+    workflow_fleet_workflow_classes,
 )
 
 async def main():
@@ -51,31 +28,7 @@ async def main():
 
     workflows = []
     if topology.fleet == WORKFLOW_FLEET:
-        registered_user_workflow_type(settings.temporal)
-        workflows.extend(
-            [
-                MoonMindUserWorkflow,
-                MoonMindProviderProfileManagerWorkflow,
-                MoonMindAgentSessionWorkflow,
-                MoonMindManagedSessionReconcileWorkflow,
-                MoonMindManagedRuntimeWorkspaceCleanupWorkflow,
-                MoonMindAgentRun,
-                MoonMindOAuthSessionWorkflow,
-                MoonMindMergeAutomationWorkflow,
-                MoonMindPRResolverWorkflow,
-            ]
-        )
-        # Import ManifestIngest workflow if it exists
-        try:
-            from moonmind.workflows.temporal.workflows.manifest_ingest import (
-                MoonMindManifestIngestWorkflow,
-            )
-
-            workflows.append(MoonMindManifestIngestWorkflow)
-        except ImportError:
-            logger.info(
-                "Optional MoonMindManifestIngestWorkflow not available; skipping registration"
-            )
+        workflows.extend(workflow_fleet_workflow_classes())
 
     bindings = build_worker_activity_bindings(fleet=topology.fleet)
     activities = [b.handler for b in bindings]

--- a/moonmind/workflows/temporal/worker_runtime.py
+++ b/moonmind/workflows/temporal/worker_runtime.py
@@ -98,7 +98,6 @@ from moonmind.workflows.temporal.workflows.manifest_ingest import (
 from moonmind.workflows.temporal.jules_bundle import JULES_AGENT_IDS
 from moonmind.workflows.temporal.jira_agent_skills import JIRA_AGENT_SKILLS
 from moonmind.workflows.temporal.worker_healthcheck import start_healthcheck_server
-from moonmind.workflows.temporal.workflows.run import MoonMindUserWorkflow
 from moonmind.workflows.temporal.workflows.agent_run import (
     MoonMindAgentRun,
     resolve_adapter_metadata,
@@ -2694,7 +2693,7 @@ async def main_async() -> None:
     runtime_resources: AsyncExitStack | None = None
 
     if topology.fleet == WORKFLOW_FLEET:
-        workflows = list(workflow_fleet_workflow_classes())
+        workflows = workflow_fleet_workflow_classes()
         activities = [
             resolve_adapter_metadata,
             get_activity_route,

--- a/moonmind/workflows/temporal/worker_runtime.py
+++ b/moonmind/workflows/temporal/worker_runtime.py
@@ -92,24 +92,13 @@ from moonmind.workflows.executions.execution_contract import (
 from moonmind.workflows.executions.preset_expansion import (
     expand_preset_for_child_run,
 )
-from moonmind.workflows.temporal.workflows.provider_profile_manager import MoonMindProviderProfileManagerWorkflow as MoonMindProviderProfileManager
 from moonmind.workflows.temporal.workflows.manifest_ingest import (
     MoonMindManifestIngestWorkflow as MoonMindManifestIngest,
 )
 from moonmind.workflows.temporal.jules_bundle import JULES_AGENT_IDS
 from moonmind.workflows.temporal.jira_agent_skills import JIRA_AGENT_SKILLS
-from moonmind.workflows.temporal.hard_switch_cutover import registered_user_workflow_type
-from moonmind.workflows.temporal.workflows.run import MoonMindUserWorkflow
 from moonmind.workflows.temporal.worker_healthcheck import start_healthcheck_server
-from moonmind.workflows.temporal.workflows.agent_session import (
-    MoonMindAgentSessionWorkflow as MoonMindAgentSession,
-)
-from moonmind.workflows.temporal.workflows.managed_session_reconcile import (
-    MoonMindManagedSessionReconcileWorkflow as MoonMindManagedSessionReconcile,
-)
-from moonmind.workflows.temporal.workflows.managed_runtime_workspace_cleanup import (
-    MoonMindManagedRuntimeWorkspaceCleanupWorkflow as MoonMindManagedRuntimeWorkspaceCleanup,
-)
+from moonmind.workflows.temporal.workflows.run import MoonMindUserWorkflow
 from moonmind.workflows.temporal.workflows.agent_run import (
     MoonMindAgentRun,
     resolve_adapter_metadata,
@@ -117,11 +106,8 @@ from moonmind.workflows.temporal.workflows.agent_run import (
     resolve_external_adapter,
     external_adapter_execution_style,
 )
-from moonmind.workflows.temporal.workflows.oauth_session import (
-    MoonMindOAuthSessionWorkflow as MoonMindOAuthSession,
-)
-from moonmind.workflows.temporal.workflows.merge_automation import (
-    MoonMindMergeAutomationWorkflow as MoonMindMergeAutomation,
+from moonmind.workflows.temporal.workflow_registry import (
+    workflow_fleet_workflow_classes,
 )
 from moonmind.workflows.temporal.runtime.store import ManagedRunStore
 from moonmind.workflows.temporal.runtime.launcher import ManagedRuntimeLauncher
@@ -2708,18 +2694,7 @@ async def main_async() -> None:
     runtime_resources: AsyncExitStack | None = None
 
     if topology.fleet == WORKFLOW_FLEET:
-        registered_user_workflow_type(settings.temporal)
-        workflows = [
-            MoonMindUserWorkflow,
-            MoonMindManifestIngest,
-            MoonMindProviderProfileManager,
-            MoonMindAgentSession,
-            MoonMindManagedSessionReconcile,
-            MoonMindManagedRuntimeWorkspaceCleanup,
-            MoonMindAgentRun,
-            MoonMindOAuthSession,
-            MoonMindMergeAutomation,
-        ]
+        workflows = list(workflow_fleet_workflow_classes())
         activities = [
             resolve_adapter_metadata,
             get_activity_route,

--- a/moonmind/workflows/temporal/workers.py
+++ b/moonmind/workflows/temporal/workers.py
@@ -25,8 +25,8 @@ from moonmind.workflows.temporal.activity_runtime import (
     TemporalActivityBinding,
     build_activity_bindings,
 )
-from moonmind.workflows.temporal.hard_switch_cutover import (
-    registered_user_workflow_type,
+from moonmind.workflows.temporal.workflow_registry import (
+    workflow_fleet_workflow_types,
 )
 
 ALLOWED_TEMPORAL_WORKER_FLEETS = (
@@ -121,18 +121,6 @@ _FLEET_FORBIDDEN_CAPABILITIES = {
         "docker_workload",
     ),
 }
-STATIC_TEMPORAL_WORKFLOW_TYPES = (
-    "MoonMind.ManifestIngest",
-    "MoonMind.ProviderProfileManager",
-    "MoonMind.AgentSession",
-    "MoonMind.ManagedSessionReconcile",
-    "MoonMind.ManagedRuntimeWorkspaceCleanup",
-    "MoonMind.AgentRun",
-    "MoonMind.OAuthSession",
-    "MoonMind.MergeAutomation",
-    "MoonMind.PRResolver",
-)
-
 class TemporalWorkerBootstrapError(ValueError):
     """Raised when the worker topology cannot be resolved safely."""
 
@@ -147,10 +135,7 @@ def list_registered_workflow_types_for_settings(
 ) -> tuple[str, ...]:
     """Return workflow registrations for the configured user-workflow contract."""
 
-    return (
-        registered_user_workflow_type(temporal_settings),
-        *STATIC_TEMPORAL_WORKFLOW_TYPES,
-    )
+    return workflow_fleet_workflow_types(temporal_settings)
 
 @dataclass(frozen=True, slots=True)
 class TemporalWorkerTopology:

--- a/moonmind/workflows/temporal/workflow_registry.py
+++ b/moonmind/workflows/temporal/workflow_registry.py
@@ -1,0 +1,102 @@
+"""Canonical workflow registrations for the Temporal workflow fleet."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from importlib import import_module
+from typing import Any
+
+from moonmind.config.settings import TemporalSettings
+from moonmind.workflows.temporal.hard_switch_cutover import (
+    registered_user_workflow_type,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class WorkflowRegistration:
+    """A workflow class and its canonical Temporal type name."""
+
+    workflow_type: str
+    module: str
+    class_name: str
+
+    def load_class(self) -> type[Any]:
+        """Import the workflow class without making topology imports cyclic."""
+
+        return getattr(import_module(self.module), self.class_name)
+
+
+USER_WORKFLOW_REGISTRATION = WorkflowRegistration(
+    "MoonMind.UserWorkflow",
+    "moonmind.workflows.temporal.workflows.run",
+    "MoonMindUserWorkflow",
+)
+
+
+STATIC_WORKFLOW_REGISTRATIONS = (
+    WorkflowRegistration(
+        "MoonMind.ManifestIngest",
+        "moonmind.workflows.temporal.workflows.manifest_ingest",
+        "MoonMindManifestIngestWorkflow",
+    ),
+    WorkflowRegistration(
+        "MoonMind.ProviderProfileManager",
+        "moonmind.workflows.temporal.workflows.provider_profile_manager",
+        "MoonMindProviderProfileManagerWorkflow",
+    ),
+    WorkflowRegistration(
+        "MoonMind.AgentSession",
+        "moonmind.workflows.temporal.workflows.agent_session",
+        "MoonMindAgentSessionWorkflow",
+    ),
+    WorkflowRegistration(
+        "MoonMind.ManagedSessionReconcile",
+        "moonmind.workflows.temporal.workflows.managed_session_reconcile",
+        "MoonMindManagedSessionReconcileWorkflow",
+    ),
+    WorkflowRegistration(
+        "MoonMind.ManagedRuntimeWorkspaceCleanup",
+        "moonmind.workflows.temporal.workflows.managed_runtime_workspace_cleanup",
+        "MoonMindManagedRuntimeWorkspaceCleanupWorkflow",
+    ),
+    WorkflowRegistration(
+        "MoonMind.AgentRun",
+        "moonmind.workflows.temporal.workflows.agent_run",
+        "MoonMindAgentRun",
+    ),
+    WorkflowRegistration(
+        "MoonMind.OAuthSession",
+        "moonmind.workflows.temporal.workflows.oauth_session",
+        "MoonMindOAuthSessionWorkflow",
+    ),
+    WorkflowRegistration(
+        "MoonMind.MergeAutomation",
+        "moonmind.workflows.temporal.workflows.merge_automation",
+        "MoonMindMergeAutomationWorkflow",
+    ),
+    WorkflowRegistration(
+        "MoonMind.PRResolver",
+        "moonmind.workflows.temporal.workflows.pr_resolver",
+        "MoonMindPRResolverWorkflow",
+    ),
+)
+
+
+def workflow_fleet_workflow_classes() -> tuple[type[Any], ...]:
+    """Return the exact workflow classes registered by production workers."""
+
+    return (
+        USER_WORKFLOW_REGISTRATION.load_class(),
+        *(registration.load_class() for registration in STATIC_WORKFLOW_REGISTRATIONS),
+    )
+
+
+def workflow_fleet_workflow_types(
+    temporal_settings: TemporalSettings,
+) -> tuple[str, ...]:
+    """Return type names from the same registry used to construct workers."""
+
+    return (
+        registered_user_workflow_type(temporal_settings),
+        *(registration.workflow_type for registration in STATIC_WORKFLOW_REGISTRATIONS),
+    )

--- a/moonmind/workflows/temporal/workflow_registry.py
+++ b/moonmind/workflows/temporal/workflow_registry.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from functools import cache
 from importlib import import_module
 from typing import Any
 
@@ -82,6 +83,7 @@ STATIC_WORKFLOW_REGISTRATIONS = (
 )
 
 
+@cache
 def workflow_fleet_workflow_classes() -> tuple[type[Any], ...]:
     """Return the exact workflow classes registered by production workers."""
 

--- a/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
+++ b/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
@@ -3866,6 +3866,9 @@ async def test_main_async_workflow_fleet(
     from moonmind.workflows.temporal.workflows.merge_automation import (
         MoonMindMergeAutomationWorkflow,
     )
+    from moonmind.workflows.temporal.workflows.pr_resolver import (
+        MoonMindPRResolverWorkflow,
+    )
     from moonmind.workflows.temporal.workflows.managed_session_reconcile import (
         MoonMindManagedSessionReconcileWorkflow,
     )
@@ -3882,6 +3885,7 @@ async def test_main_async_workflow_fleet(
         MoonMindAgentRun,
         MoonMindOAuthSession,
         MoonMindMergeAutomationWorkflow,
+        MoonMindPRResolverWorkflow,
     ]
     assert kwargs["activities"] == [
         resolve_adapter_metadata,

--- a/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
+++ b/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
@@ -24,7 +24,6 @@ from moonmind.workflows.temporal import worker_runtime
 from moonmind.workflows.temporal.worker_runtime import (
     MoonMindAgentRun,
     MoonMindManifestIngest,
-    MoonMindUserWorkflow,
     OpenTelemetryLoggingFilter,
     _OPENTELEMETRY_LOG_FORMAT,
     _build_agent_runtime_deps,
@@ -43,6 +42,7 @@ from moonmind.workflows.temporal.worker_runtime import (
     resolve_external_adapter,
     external_adapter_execution_style,
 )
+from moonmind.workflows.temporal.workflows.run import MoonMindUserWorkflow
 from moonmind.workflows.temporal.workers import (
     AGENT_RUNTIME_FLEET,
     DEPLOYMENT_FLEET,
@@ -3875,7 +3875,7 @@ async def test_main_async_workflow_fleet(
     from moonmind.workflows.temporal.workflows.managed_runtime_workspace_cleanup import (
         MoonMindManagedRuntimeWorkspaceCleanupWorkflow,
     )
-    assert kwargs["workflows"] == [
+    assert kwargs["workflows"] == (
         MoonMindUserWorkflow,
         MoonMindManifestIngest,
         MoonMindProviderProfileManagerWorkflow,
@@ -3886,7 +3886,7 @@ async def test_main_async_workflow_fleet(
         MoonMindOAuthSession,
         MoonMindMergeAutomationWorkflow,
         MoonMindPRResolverWorkflow,
-    ]
+    )
     assert kwargs["activities"] == [
         resolve_adapter_metadata,
         get_activity_route,

--- a/tests/unit/workflows/temporal/test_temporal_workers.py
+++ b/tests/unit/workflows/temporal/test_temporal_workers.py
@@ -8,6 +8,7 @@ from typing import Any
 
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
+from temporalio import workflow
 
 from api_service.db.models import Base
 from moonmind.config.settings import settings
@@ -42,6 +43,9 @@ from moonmind.workflows.temporal.workers import (
     build_worker_activity_bindings,
     describe_configured_worker,
     list_registered_workflow_types,
+)
+from moonmind.workflows.temporal.workflow_registry import (
+    workflow_fleet_workflow_classes,
 )
 
 async def _artifact_service(
@@ -107,6 +111,15 @@ def test_registered_workflow_types_include_manifest_ingest():
         "MoonMind.MergeAutomation",
         "MoonMind.PRResolver",
     )
+
+
+def test_advertised_workflow_types_match_production_worker_classes():
+    registered_class_names = tuple(
+        workflow._Definition.must_from_class(workflow_class).name
+        for workflow_class in workflow_fleet_workflow_classes()
+    )
+
+    assert registered_class_names == list_registered_workflow_types()
 
 
 def test_pr_resolver_terminal_publication_is_idempotent(tmp_path: Path):

--- a/tests/unit/workflows/temporal/test_temporal_workers.py
+++ b/tests/unit/workflows/temporal/test_temporal_workers.py
@@ -122,6 +122,10 @@ def test_advertised_workflow_types_match_production_worker_classes():
     assert registered_class_names == list_registered_workflow_types()
 
 
+def test_production_worker_classes_are_cached():
+    assert workflow_fleet_workflow_classes() is workflow_fleet_workflow_classes()
+
+
 def test_pr_resolver_terminal_publication_is_idempotent(tmp_path: Path):
     async def _run() -> None:
         service, session, engine = await _artifact_service(tmp_path)


### PR DESCRIPTION
## Summary

- register `MoonMind.PRResolver` in the production workflow worker
- replace duplicated workflow class and advertised-type lists with one canonical registry
- make both worker entrypoints consume the same registry
- add production-boundary coverage that compares advertised workflow types with the classes passed to the Temporal worker

## Root cause

The PR resolver was added to the alternate worker entrypoint and the advertised workflow-type list, but the Compose production path starts `worker_runtime.py`, which maintained a separate class list. Temporal therefore routed `MoonMind.PRResolver` to a healthy worker that could not instantiate it, leaving the parent waiting indefinitely on repeated workflow-task failures.

## Validation

- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_temporal_workers.py tests/unit/workflows/temporal/test_temporal_worker_runtime.py` (119 Python tests and 1,002 frontend tests passed)
- `.venv/bin/pytest -q tests/unit/workflows/temporal/test_temporal_workers.py tests/unit/workflows/temporal/test_temporal_worker_runtime.py --tb=short` (120 passed)
- recreated the Compose workflow worker and verified its startup registry includes `MoonMind.PRResolver` on both workflow lanes