### PR TITLE
There is currently a vertical scrollbar in the nav bar controlling the nav bar links and hiding the purple selection underline by default. This should

### DIFF
--- a/frontend/src/entrypoints/dashboard.test.tsx
+++ b/frontend/src/entrypoints/dashboard.test.tsx
@@ -3221,7 +3221,7 @@ describe('Dashboard shared entry', () => {
     expect(desktopMastheadRule('.workflow-list-display-control')).toBe('');
     expect(desktopMastheadRule('.masthead-nav')).toContain('grid-column: 2;');
     expect(desktopMastheadRule('.masthead-nav')).not.toContain('overflow');
-    expect(desktopMastheadRule('.route-nav-primary')).toContain('overflow-x: auto;');
+    expect(desktopMastheadRule('.route-nav-primary')).not.toContain('overflow');
     expect(desktopMastheadRule('.masthead-title-meta')).toContain('grid-column: 3;');
     expect(cssRuleBlock(dashboardCss, '.masthead-title-meta .version-badge')).toContain('white-space: nowrap;');
   });

--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -533,7 +533,6 @@ h1 {
 
   .route-nav-primary {
     flex: 1 1 auto;
-    overflow-x: auto;
   }
 
   .masthead-title-meta {

--- a/frontend/src/styles/dashboardBrand.test.ts
+++ b/frontend/src/styles/dashboardBrand.test.ts
@@ -74,8 +74,8 @@ describe('dashboard masthead brand styles', () => {
     expect(popover).toContain('z-index: 60;');
     expect(popover).toContain('background: rgb(var(--mm-panel));');
     expect(popover).toContain('box-shadow: var(--mm-elevation-panel);');
-    expect(dashboardCss).toMatch(
-      /@media \(min-width: 1181px\)\s*\{[\s\S]*\.route-nav-primary\s*\{[^}]*overflow-x:\s*auto;/s,
+    expect(dashboardCss).not.toMatch(
+      /@media \(min-width: 1181px\)\s*\{[\s\S]*\.route-nav-primary\s*\{[^}]*overflow-[xy]:\s*(?:auto|hidden|scroll);/s,
     );
     expect(dashboardCss).not.toMatch(
       /@media \(min-width: 1181px\)\s*\{[\s\S]*\.masthead-nav\s*\{[^}]*overflow-[xy]:\s*(?:auto|hidden|scroll);/s,


### PR DESCRIPTION
There is currently a vertical scrollbar in the nav bar controlling the nav bar links and hiding the purple selection underline by default. This should definitely not be there. There should be no scrollbar in the nav bar and it should not hide the purple selection underline, which should appear as though it's on top of the horizontal line below the nav bar. This is how it looked previously and this was correct.