### PR TITLE
Harden PR resolver native execution and deployment readiness

### DIFF
--- a/.agents/skills/pr-resolver/SKILL.md
+++ b/.agents/skills/pr-resolver/SKILL.md
@@ -11,6 +11,13 @@ metadata:
   required-capabilities:
     - git
     - gh
+  implementation:
+    contract: pr-resolver-core/v1
+    supportedHosts:
+      - cli
+      - temporal
+    nativeHostEligible: true
+    nativeHostPolicy: moonmind_trusted
 ---
 
 # PR Resolver Skill
@@ -42,10 +49,16 @@ The task is not complete until the target PR is merged or is proven already merg
 
 ## Temporal ownership contract
 
-`MoonMind.PRResolver` owns snapshot polling, classification, durable timers,
+When the resolved native-host decision is `temporal`, `MoonMind.PRResolver` owns snapshot polling, classification, durable timers,
 retry budgets, merge attempts, remote verification, cancellation, and terminal
 evidence. A managed agent must never run `pr_resolve_orchestrate.py` or host the
 outer retry loop in a shell process.
+
+When MoonMind explicitly records a `cli` native-host decision, this exact
+resolved Skill content remains authoritative and the portable CLI host owns the
+outer loop. That fallback must be visible in execution metadata and must never
+silently substitute MoonMind's built-in native implementation for repo, local,
+or otherwise incompatible content.
 
 When Temporal dispatches this skill as a remediation child, perform exactly the
 single classified action named in the instruction. Use the active immutable skill

--- a/.agents/skills/pr-resolver/bin/pr_resolve_contract.py
+++ b/.agents/skills/pr-resolver/bin/pr_resolve_contract.py
@@ -19,6 +19,7 @@ FINALIZE_ONLY_RETRY_REASONS = {
     "codex_review_grace_wait",
     "comments_unavailable",
     "ci_signal_degraded",
+    "external_state_transient",
     "snapshot_refresh_failed",
 }
 
@@ -92,6 +93,8 @@ def remediation_next_step(reason: str) -> str:
     if normalized in {"ci_signal_degraded", "comments_unavailable"}:
         return "inspect_ci_and_comment_signal"
     if normalized == "snapshot_refresh_failed":
+        return "retry_finalize_after_backoff"
+    if normalized == "external_state_transient":
         return "retry_finalize_after_backoff"
     if normalized == "ci_running":
         return "wait_for_ci_and_retry_finalize"

--- a/.agents/skills/pr-resolver/bin/pr_resolve_finalize.py
+++ b/.agents/skills/pr-resolver/bin/pr_resolve_finalize.py
@@ -18,6 +18,15 @@ from typing import Any
 SCRIPT_DIR = Path(__file__).resolve().parent
 if str(SCRIPT_DIR) not in sys.path:
     sys.path.insert(0, str(SCRIPT_DIR))
+for package_root in (SCRIPT_DIR.parent / "lib", *SCRIPT_DIR.parents):
+    if (package_root / "pr_resolver_core").is_dir():
+        sys.path.insert(0, str(package_root))
+        break
+
+from pr_resolver_core import (  # noqa: E402
+    classify_snapshot,
+    normalize_portable_snapshot,
+)
 
 from pr_resolve_contract import (  # noqa: E402
     EXIT_CODE_BLOCKED,
@@ -95,45 +104,14 @@ def _is_conflicting(pr: dict[str, Any]) -> bool:
     return mergeable_text in CONFLICTING_MERGEABLE
 
 def evaluate_finalize_action(snapshot: dict[str, Any]) -> dict[str, str]:
-    pr = snapshot.get("pr") if isinstance(snapshot.get("pr"), dict) else {}
-    ci = snapshot.get("ci") if isinstance(snapshot.get("ci"), dict) else {}
-    comments_fetch = (
-        snapshot.get("commentsFetch")
-        if isinstance(snapshot.get("commentsFetch"), dict)
-        else {}
-    )
-    comments_summary = (
-        snapshot.get("commentsSummary")
-        if isinstance(snapshot.get("commentsSummary"), dict)
-        else {}
-    )
-
-    if normalize_text(pr.get("state")).upper() == "MERGED":
+    decision = classify_snapshot(normalize_portable_snapshot(snapshot))
+    if decision.classification == "already_merged":
         return {"action": "already_merged", "reason": "already_merged"}
-
-    if _is_conflicting(pr):
-        return {"action": "blocked", "reason": "merge_conflicts"}
-    if not bool(comments_fetch.get("succeeded")):
-        return {"action": "blocked", "reason": "comments_unavailable"}
-    if comments_summary.get("includeBotReviewComments") is not True:
-        return {"action": "blocked", "reason": "comment_policy_not_enforced"}
-    if bool(comments_summary.get("hasActionableComments")):
-        return {"action": "blocked", "reason": "actionable_comments"}
-    if normalize_text(ci.get("signalQuality")).lower() not in {"", "ok"}:
-        return {"action": "blocked", "reason": "ci_signal_degraded"}
-    if bool(ci.get("hasFailures")):
-        return {"action": "blocked", "reason": "ci_failures"}
-    if bool(ci.get("isRunning")):
-        return {"action": "blocked", "reason": "ci_running"}
-    codex_review_grace = comments_summary.get("codexReviewGrace")
-    if isinstance(codex_review_grace, dict) and codex_review_grace.get("active") is True:
+    if decision.classification == "review_grace":
         return {"action": "blocked", "reason": "codex_review_grace_wait"}
-
-    merge_state = normalize_text(pr.get("mergeStateStatus")).upper()
-    if merge_state in DIRECT_MERGE_STATE:
+    if decision.classification == "ready_to_merge":
         return {"action": "merge_now", "reason": "ci_complete"}
-
-    return {"action": "blocked", "reason": "merge_not_ready"}
+    return {"action": "blocked", "reason": decision.reason_code}
 
 def _run_snapshot(snapshot_script: Path, pr: str | None, snapshot_path: Path) -> None:
     cmd = [sys.executable, str(snapshot_script)]

--- a/api_service/Dockerfile
+++ b/api_service/Dockerfile
@@ -218,6 +218,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 # Copy source code AFTER installing locked dependencies so code changes only
 # invalidate the lightweight project install.
 COPY moonmind /app/moonmind/
+COPY pr_resolver_core /app/pr_resolver_core/
 RUN --mount=type=cache,target=/root/.cache/pip \
     pip install --disable-pip-version-check --no-deps .
 COPY api_service /app/api_service/

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -283,6 +283,12 @@ services:
       - TEMPORAL_MERGE_AUTOMATION_WORKFLOW_TASK_QUEUE=${TEMPORAL_MERGE_AUTOMATION_WORKFLOW_TASK_QUEUE:-mm.workflow.merge_automation}
       - TEMPORAL_WORKFLOW_WORKER_CONCURRENCY=${TEMPORAL_WORKFLOW_WORKER_CONCURRENCY:-8}
       - TEMPORAL_MERGE_AUTOMATION_WORKFLOW_WORKER_CONCURRENCY=${TEMPORAL_MERGE_AUTOMATION_WORKFLOW_WORKER_CONCURRENCY:-2}
+      - TEMPORAL_WORKER_VERSIONING_ENABLED=${TEMPORAL_WORKER_VERSIONING_ENABLED:-false}
+      - TEMPORAL_WORKER_DEPLOYMENT_NAME=${TEMPORAL_WORKER_DEPLOYMENT_NAME:-moonmind-workflow-fleet}
+      - MOONMIND_BUILD_SHA=${MOONMIND_BUILD_SHA:-}
+      - MOONMIND_IMAGE_DIGEST=${MOONMIND_IMAGE_DIGEST:-}
+      - MOONMIND_DEPLOYMENT_MODE=${MOONMIND_DEPLOYMENT_MODE:-development}
+      - TEMPORAL_WORKFLOW_READINESS_URL=${TEMPORAL_WORKFLOW_READINESS_URL:-http://temporal-worker-workflow:8080/readyz}
       - TEMPORAL_WORKER_COMMAND=${TEMPORAL_WORKER_COMMAND:-python -m
         moonmind.workflows.temporal.worker_runtime}
       - MOONMIND_URL=${MOONMIND_URL:-http://api:8000}
@@ -312,7 +318,7 @@ services:
           "python",
           "-c",
           "import urllib.request;
-          urllib.request.urlopen('http://localhost:8080/healthz')",
+          urllib.request.urlopen('http://localhost:8080/readyz')",
         ]
       interval: 30s
       timeout: 10s

--- a/docs/Steps/SkillGithubPrResolver.md
+++ b/docs/Steps/SkillGithubPrResolver.md
@@ -2,7 +2,7 @@
 
 Status: Active
 Owners: MoonMind Engineering
-Last Updated: 2026-07-10
+Last Updated: 2026-07-11
 
 ## 1. Purpose
 
@@ -15,6 +15,12 @@ The **PR Resolver** skill is invoked from the dashboard (via Temporal `AgentTask
 
 The durable umbrella is a Temporal workflow, not a managed agent shell. Specialized agents do one remediation action; Temporal owns polling, timers, retry budgets, merge attempts, remote verification, cancellation, and terminal evidence.
 
+The checked-in skill is also a portable contract. Its provider-neutral models,
+normalization, classification, transition, and evidence rules live in
+`pr_resolver_core`; both the local scripts and the Temporal host consume that
+package. The core performs no network, filesystem, process, credential, clock,
+or Temporal operations. Host adapters gather state and perform actions.
+
 ---
 
 ## 2. Assumptions and Constraints
@@ -23,6 +29,8 @@ The durable umbrella is a Temporal workflow, not a managed agent shell. Speciali
 * The worker environment has GitHub auth available for private repo operations and includes `gh` usage in existing workflows.
 * Specialized sub-skills (like `fix-merge-conflicts`) are available in the `.agents/skills/` directory.
 * Resolver workflows use `publish.mode=auto`. Remediation children may commit and push when their selected skill requires it; trusted resolver activities own merge and terminal publication.
+* Publish authority and implementation hosting are independent decisions.
+  `publish.mode=auto` does not authorize native Temporal execution.
 
 ---
 
@@ -46,16 +54,31 @@ Shared repo skill mirror:
     pr_resolver_result.schema.json
 ```
 
-The Python scripts remain single-pass local helpers and migration fixtures. Normal execution routes through `MoonMind.PRResolver`; `pr_resolve_orchestrate.py` is not the default runtime path.
+The Python scripts remain a supported portable host. MoonMind routes the trusted
+built-in snapshot to `MoonMind.PRResolver`; standalone environments and
+non-native-compatible snapshots use the portable host.
 
-### 3.2 Required Worker Capabilities
+### 3.2 Trusted native binding
 
-The Temporal Workflow Task Queue routing should derive/declare:
+The portable contract declares `implementation.contract =
+pr-resolver-core/v1`, supported hosts, and native-host policy separately from
+publish metadata. Native routing requires the immutable resolved-skill entry to
+prove all of the following: canonical name, compatible contract, Temporal host
+support, trusted policy, built-in provenance, and non-empty content ref and
+digest. A repository or local override named `pr-resolver` does not inherit the
+native workflow or trusted privileges. It runs through the explicit CLI fallback
+with an observable reason code, or is rejected before launch when policy forbids
+that host.
 
-* `git`
-* `gh`
+Temporal workers load `pr_resolver_core` from their immutable application
+artifact. They never import repository skill code during workflow replay.
 
-This matches the standard `AgentTaskWorkflow` capability derivation pattern.
+### 3.3 Required Worker Capabilities
+
+The workflow fleet is orchestration-only and has no `git`, `gh`, repository
+write, sandbox, or agent-runtime privilege. GitHub reads and merge attempts run
+on the integrations activity fleet; remediation runs in bounded
+`MoonMind.AgentRun` children.
 
 ---
 

--- a/docs/Steps/SkillSystem.md
+++ b/docs/Steps/SkillSystem.md
@@ -2,7 +2,7 @@
 
 Status: Desired State
 Owners: MoonMind Engineering
-Last Updated: 2026-04-29
+Last Updated: 2026-07-11
 Canonical for: agent skills, Skill steps, skill-set resolution, runtime skill materialization, `.agents/skills` path policy
 Related: `docs/Steps/StepTypes.md`, `docs/Workflows/SkillAndPlanContracts.md`, `docs/Workflows/WorkflowArchitecture.md`, `docs/Workflows/RequiredCapabilities.md`, `docs/Temporal/ManagedAndExternalAgentExecutionModel.md`, `docs/UI/WorkflowConsoleArchitecture.md`, `AGENTS.md`
 
@@ -68,6 +68,19 @@ The desired-state skill model is:
 8. Managed runtimes receive a compact activation summary inline and a full read-only active skill bundle at the materialized `visiblePath`; `.agents/skills` is used only as a safe compatibility alias.
 9. Runtime adapters consume the resolved snapshot; they must not rediscover, broaden, or re-resolve Skills during execution.
 10. `.agents/skills/local` remains a local-only overlay input convention, not the active runtime projection.
+11. A native host is selected from trusted resolved-skill evidence, never from
+    canonical skill name or publish mode alone.
+
+### Native implementation contracts
+
+Skills may declare a portable semantic implementation contract and supported
+hosts independently of their publish metadata. The resolved entry preserves the
+winning source, content ref, digest, contract, supported hosts, and native-host
+policy. Native bindings consume that immutable evidence. Later-precedence repo
+or local content with the same skill name remains different content and receives
+no built-in native privileges by name. When a compatible binding is unavailable,
+the runtime records an explicit portable-host decision or rejects the step before
+launch with a policy diagnostic; it must not substitute other skill content.
 
 ---
 

--- a/docs/Temporal/ActivityCatalogAndWorkerTopology.md
+++ b/docs/Temporal/ActivityCatalogAndWorkerTopology.md
@@ -1,7 +1,7 @@
 # Activity Catalog and Worker Topology
 
 Status: Implemented in core runtime (catalog live; some target-state families still pending)
-Last updated: 2026-06-13
+Last updated: 2026-07-11
 Scope: Defines MoonMind’s canonical **Activity Types**, **worker fleets**, **Task Queue routing**, and the operational rules for executing artifacts, planning, skills, integrations, managed runtime supervision, and related Temporal-side support work.
 
 ## Related docs
@@ -31,6 +31,25 @@ This document standardizes:
 - the current implemented catalog and the target-state additions that are still pending
 
 This document covers the **Temporal-managed worker model** only.
+
+### Executable worker specification and readiness
+
+Every fleet is constructed from one immutable `WorkerSpec`. For the workflow
+fleet, the same class and activity tuples drive the Temporal SDK `Worker`,
+startup logs, `/readyz`, diagnostics, tests, and the registry fingerprint.
+Operator-facing workflow type lists are derived from those executable classes;
+an independent advertised string catalog is forbidden.
+
+`/healthz` proves only that the process event loop is responsive. `/readyz`
+remains unavailable until configuration and the executable specification are
+built, the Temporal client is connected, workers are constructed, and pollers
+have started. Its bounded response includes task queues, registered workflow and
+activity types, build/deployment identity, registry fingerprint, versioning
+state, and resolver-core identity. `MoonMind.PRResolver` may appear only when
+that exact workflow class was supplied to the SDK worker.
+
+The workflow fleet remains Temporal-only. It receives no repository mutation,
+GitHub credential, sandbox, local-git, or agent-runtime capabilities.
 
 ---
 

--- a/docs/Temporal/ops-runbook.md
+++ b/docs/Temporal/ops-runbook.md
@@ -18,6 +18,36 @@ Keys for model providers (e.g. Google and OpenAI) are injected from this user's 
 - **Credential validation**: Failed workflows often stem from missing provider or GitHub credentials. The first Activity attempt records the failure reason in Temporal's execution history. Once you resolve secrets, you can retry the workflow or rely on Temporal's native Activity retry policies.
 - **Artifact locations**: Patches, JSONL logs, and GitHub API responses are stored under `var/artifacts/workflows/<workflow_id>/`.
 
+### Workflow worker deployment and resolver registration
+
+Use `/healthz` only for liveness and `/readyz` for traffic readiness. Resolver
+traffic is ready only when the response is ready and lists the expected task
+queue, `MoonMind.PRResolver`, immutable build identity, and registry fingerprint.
+Production mode fails startup unless `MOONMIND_BUILD_SHA` or
+`MOONMIND_IMAGE_DIGEST` is set and Temporal worker deployment versioning is
+enabled. Deploy immutable images, promote a controlled worker version, drain old
+workers from the queue, and run:
+
+```bash
+python tools/run_pr_resolver_deployment_canary.py
+```
+
+The canary starts the real workflow type on the deployed queue and follows a
+non-mutating dry-run path. Do not recover affected executions until it reports
+the expected build and registry identity.
+
+Python workers do not hot-reload mounted workflow source. After workflow code or
+registration changes in local Compose, recreate the complete workflow worker
+service; a generic healthy container or a changed bind mount is not evidence of
+new registration.
+
+If a parent reports `worker_capability_unavailable`, no resolver or remediation
+agent was launched and resolver budgets were not consumed. Compare the reported
+workflow type and task queue with `/readyz`, inspect worker build/fingerprint
+distribution, recreate or drain stale workers, rerun the canary, then explicitly
+retry or recover the parent. Repeated unregistered-workflow task failures and
+mixed incompatible builds on one queue require an operator alert.
+
 ### Execution Observability
 
 - **Metrics detail**: Temporal workflows increment standard Prometheus series automatically:

--- a/docs/Workflows/PrMergeAutomation.md
+++ b/docs/Workflows/PrMergeAutomation.md
@@ -101,8 +101,9 @@ MoonMind's lifecycle model already expects `MoonMind.UserWorkflow` to mix direct
 
 ### 6.3 Why the resolver itself is a child `MoonMind.UserWorkflow`
 
-The current MoonMind execution model routes a selected `pr-resolver` step to the
-dedicated `MoonMind.PRResolver` child workflow. That workflow owns the durable
+The current MoonMind execution model routes a trusted, native-compatible
+`pr-resolver` resolved snapshot to the dedicated `MoonMind.PRResolver` child
+workflow. Skill name and auto-publish mode alone are insufficient. That workflow owns the durable
 gate loop and starts bounded `MoonMind.AgentRun` children only for
 `fix-comments`, `fix-ci`, or `fix-merge-conflicts`. It owns merge verification
 and terminal evidence; managed agents do not host the polling loop.
@@ -125,9 +126,9 @@ MoonMind.UserWorkflow (root parent workflow)
   |- child: MoonMind.MergeAutomation
   |    |- gate wait / external events / Jira checks
   |    |- child: MoonMind.UserWorkflow (resolver attempt 1)
-  |    |     `- executes tool=skill(pr-resolver), publishMode=none
+  |    |     `- child: MoonMind.PRResolver, publishMode=auto
   |    `- child: MoonMind.UserWorkflow (resolver attempt 2, if needed)
-  |          `- executes tool=skill(pr-resolver), publishMode=none
+  |          `- child: MoonMind.PRResolver, publishMode=auto
   `- terminal completion only after MergeAutomation returns success
 ```
 

--- a/docs/Workflows/WorkflowPublishing.md
+++ b/docs/Workflows/WorkflowPublishing.md
@@ -25,6 +25,12 @@ metadata:
 
 The built-in repository auto-publish skills are `pr-resolver`, `fix-comments`, `fix-ci`, and `fix-merge-conflicts`. The backend may retain a narrow migration fallback when metadata is temporarily unavailable, but catalog metadata is authoritative when present.
 
+Publishing does not choose an implementation host. In particular,
+`publish.mode = auto` grants the selected skill agent-owned publishing authority
+and requires evidence; it does not select `MoonMind.PRResolver`. Native hosting
+is a separate trusted binding over the immutable resolved-skill contract,
+provenance, content ref, and digest.
+
 Resolution rules:
 
 - Omitted publish mode resolves to `auto` for auto-publish-capable skills.
@@ -61,6 +67,13 @@ Finish outcome mapping is evidence-driven:
 - verified no-op -> `NO_COMMIT`, not `PUBLISH_DISABLED`;
 - blocked or failed evidence -> publish-stage failure/block;
 - missing evidence -> publish-stage failure with `auto_publish_evidence_missing`.
+
+Native resolver terminal publication returns artifact references at the child
+result boundary. The parent must load `publishEvidence` from either the direct
+result field or `outputRefs` before determining its finish outcome. A terminal
+projection row that has not yet been created is auxiliary lag: Temporal history
+and terminal artifacts remain authoritative, and projection lag must not replace
+a verified merge with a finalization failure.
 
 ### Non-Repository Side-Effect Outcomes
 

--- a/moonmind/schemas/agent_skill_models.py
+++ b/moonmind/schemas/agent_skill_models.py
@@ -60,6 +60,19 @@ class AgentSkillProvenance(BaseModel):
     
     model_config = ConfigDict(extra="forbid")
 
+
+class SkillImplementationContract(BaseModel):
+    """Portable semantics and native-host eligibility declared by a Skill."""
+
+    contract: str
+    supported_hosts: list[Literal["cli", "temporal"]] = Field(
+        default_factory=list, alias="supportedHosts"
+    )
+    native_host_eligible: bool = Field(False, alias="nativeHostEligible")
+    native_host_policy: str | None = Field(None, alias="nativeHostPolicy")
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
 class ResolvedSkillEntry(BaseModel):
     """An individual agent skill selected for a run."""
 
@@ -72,6 +85,7 @@ class ResolvedSkillEntry(BaseModel):
     required_capabilities: list[str] = Field(default_factory=list)
     selection_reason: str | None = None
     required_by: list[str] = Field(default_factory=list)
+    implementation: SkillImplementationContract | None = None
     
     model_config = ConfigDict(extra="forbid")
 

--- a/moonmind/schemas/temporal_models.py
+++ b/moonmind/schemas/temporal_models.py
@@ -1835,6 +1835,13 @@ class PRResolverStartInput(BaseModel):
     owned_by_merge_automation_gate: bool = Field(
         False, alias="ownedByMergeAutomationGate"
     )
+    implementation_identity: dict[str, Any] = Field(
+        default_factory=dict, alias="implementationIdentity"
+    )
+    worker_capability: dict[str, Any] = Field(
+        default_factory=dict, alias="workerCapability"
+    )
+    canary_mode: bool = Field(False, alias="canaryMode")
 
     @field_validator(
         "parent_workflow_id",
@@ -1893,6 +1900,23 @@ class PRResolverTerminalResultModel(BaseModel):
     workflow_id: str = Field(..., alias="workflowId")
     step_id: str = Field(..., alias="stepId")
     correlation_id: str = Field(..., alias="correlationId")
+    implementation_contract: str | None = Field(
+        None, alias="implementationContract"
+    )
+    resolver_core_version: str | None = Field(None, alias="resolverCoreVersion")
+    resolver_core_digest: str | None = Field(None, alias="resolverCoreDigest")
+    resolved_skill_content_digest: str | None = Field(
+        None, alias="resolvedSkillContentDigest"
+    )
+    resolved_skill_source: str | None = Field(None, alias="resolvedSkillSource")
+    worker_build_sha: str | None = Field(None, alias="workerBuildSha")
+    worker_image_digest: str | None = Field(None, alias="workerImageDigest")
+    worker_deployment_id: str | None = Field(None, alias="workerDeploymentId")
+    workflow_registry_fingerprint: str | None = Field(
+        None, alias="workflowRegistryFingerprint"
+    )
+    task_queue: str | None = Field(None, alias="taskQueue")
+    workflow_type: str | None = Field(None, alias="workflowType")
 
 class DependencyResolvedSignalPayload(BaseModel):
     """Signal payload emitted when a prerequisite execution reaches a terminal state."""

--- a/moonmind/services/skill_resolution.py
+++ b/moonmind/services/skill_resolution.py
@@ -17,6 +17,7 @@ from moonmind.schemas.agent_skill_models import (
     AgentSkillSourceKind,
     ResolvedSkillEntry,
     ResolvedSkillSet,
+    SkillImplementationContract,
     SkillSelector,
 )
 
@@ -178,6 +179,10 @@ class DeploymentSkillLoader(SkillLoader):
                     metadata,
                     owner=definition.slug,
                 )
+                implementation = _implementation_from_artifact_metadata(
+                    metadata,
+                    owner=definition.slug,
+                )
                 results.append(
                     ResolvedSkillEntry(
                         skill_name=definition.slug,
@@ -186,6 +191,7 @@ class DeploymentSkillLoader(SkillLoader):
                         content_digest=definition.content_digest,
                         required_skills=list(required_skills),
                         required_capabilities=list(required_capabilities),
+                        implementation=implementation,
                         provenance=AgentSkillProvenance(
                             source_kind=AgentSkillSourceKind.DEPLOYMENT
                         ),
@@ -209,9 +215,14 @@ def _scan_for_skills(
         if item.name in skip_names:
             continue
         if item.is_dir() and (item / "SKILL.md").exists():
+            frontmatter = _load_skill_frontmatter(item)
             results.append(
                 ResolvedSkillEntry(
                     skill_name=item.name,
+                    implementation=_implementation_from_frontmatter(
+                        frontmatter,
+                        owner=item.name,
+                    ),
                     provenance=AgentSkillProvenance(
                         source_kind=source_kind,
                         source_path=str(item),
@@ -453,6 +464,39 @@ def _side_effect_metadata_from_frontmatter(
     if not isinstance(raw_side_effect, dict):
         raise ValueError(f"skill '{owner}' metadata.sideEffect must be a mapping")
     return dict(raw_side_effect)
+
+
+def _implementation_from_frontmatter(
+    frontmatter: dict[str, typing.Any],
+    *,
+    owner: str,
+) -> SkillImplementationContract | None:
+    metadata = frontmatter.get("metadata") or {}
+    if not isinstance(metadata, dict):
+        raise ValueError(f"skill '{owner}' metadata must be a mapping")
+    raw = metadata.get("implementation")
+    if raw is None:
+        return None
+    if not isinstance(raw, dict):
+        raise ValueError(
+            f"skill '{owner}' metadata.implementation must be a mapping"
+        )
+    return SkillImplementationContract.model_validate(raw)
+
+
+def _implementation_from_artifact_metadata(
+    metadata: dict[str, typing.Any],
+    *,
+    owner: str,
+) -> SkillImplementationContract | None:
+    raw = metadata.get("implementation")
+    if raw is None:
+        return None
+    if not isinstance(raw, dict):
+        raise ValueError(
+            f"skill '{owner}' artifact metadata.implementation must be a mapping"
+        )
+    return SkillImplementationContract.model_validate(raw)
 
 
 def extract_publish_metadata_from_skill_markdown(

--- a/moonmind/workflows/agent_skills/agent_skills_activities.py
+++ b/moonmind/workflows/agent_skills/agent_skills_activities.py
@@ -7,6 +7,8 @@ from typing import Any
 
 from temporalio import activity
 
+from pr_resolver_core import IMPLEMENTATION_CONTRACT
+
 from moonmind.schemas.agent_skill_models import (
     AgentSkillFormat,
     ResolvedSkillSet,
@@ -99,7 +101,15 @@ class AgentSkillsActivities:
 
             skill_dir = Path(skill.provenance.source_path)
             try:
-                payload = self._build_skill_bundle_payload(skill_dir)
+                payload = self._build_skill_bundle_payload(
+                    skill_dir,
+                    include_pr_resolver_core=(
+                        skill.skill_name == "pr-resolver"
+                        and skill.provenance.source_kind.value == "built_in"
+                        and skill.implementation is not None
+                        and skill.implementation.contract == IMPLEMENTATION_CONTRACT
+                    ),
+                )
             except OSError as exc:
                 raise RuntimeError(
                     f"failed to persist selected skill '{skill.skill_name}' from {skill_dir}: {exc}"
@@ -145,7 +155,11 @@ class AgentSkillsActivities:
         return resolved_set.model_copy(update={"skills": updated_skills})
 
     @staticmethod
-    def _build_skill_bundle_payload(skill_dir: Path) -> bytes:
+    def _build_skill_bundle_payload(
+        skill_dir: Path,
+        *,
+        include_pr_resolver_core: bool = False,
+    ) -> bytes:
         if not skill_dir.is_dir():
             raise OSError(f"skill source path is not a directory: {skill_dir}")
         skill_doc = skill_dir / "SKILL.md"
@@ -180,6 +194,19 @@ class AgentSkillsActivities:
                             f"{path} -> {source_path}"
                         ) from exc
                 archive.add(source_path, arcname=str(path.relative_to(skill_dir)))
+            if include_pr_resolver_core:
+                core_root = allowed_root / "pr_resolver_core"
+                if not (core_root / "__init__.py").is_file():
+                    raise OSError(
+                        "built-in pr-resolver bundle is missing pr_resolver_core"
+                    )
+                for path in sorted(core_root.rglob("*.py")):
+                    archive.add(
+                        path,
+                        arcname=str(
+                            Path("lib") / "pr_resolver_core" / path.relative_to(core_root)
+                        ),
+                    )
         return buffer.getvalue()
 
     @staticmethod

--- a/moonmind/workflows/temporal/activity_catalog.py
+++ b/moonmind/workflows/temporal/activity_catalog.py
@@ -974,6 +974,15 @@ def build_default_activity_catalog(
             retries=_activity_retries(max_attempts=5, max_interval_seconds=60),
         ),
         TemporalActivityDefinition(
+            activity_type="worker.verify_workflow_capability",
+            family="worker_readiness",
+            capability_class="integration:internal_readiness",
+            task_queue=cfg.activity_integrations_task_queue,
+            fleet=INTEGRATIONS_FLEET,
+            timeouts=TemporalActivityTimeouts(15, 30),
+            retries=_activity_retries(max_attempts=1, max_interval_seconds=1),
+        ),
+        TemporalActivityDefinition(
             activity_type="pr_resolver.write_terminal_result",
             family="pr_resolver",
             capability_class="artifacts",

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -4727,28 +4727,29 @@ class TemporalIntegrationActivities:
         if not isinstance(readiness, Mapping):
             readiness = {}
         workflow_types = {
-            str(item) for item in readiness.get("workflowTypes", [])
+            str(item) for item in (readiness.get("workflowTypes") or [])
         }
-        task_queues = {str(item) for item in readiness.get("taskQueues", [])}
+        task_queues = {str(item) for item in (readiness.get("taskQueues") or [])}
         available = (
             readiness.get("ready") is True
             and workflow_type in workflow_types
             and task_queue in task_queues
         )
         fingerprints = [
-            str(item) for item in readiness.get("registryFingerprints", [])
+            str(item) for item in (readiness.get("registryFingerprints") or [])
         ]
         if not fingerprints and readiness.get("registryFingerprint"):
             fingerprints = [str(readiness["registryFingerprint"])]
-        build_ids = [str(item) for item in readiness.get("buildIds", [])]
+        build_ids = [str(item) for item in (readiness.get("buildIds") or [])]
         if not build_ids and readiness.get("buildId"):
             build_ids = [str(readiness["buildId"])]
         children = [
             item
-            for item in readiness.get("children", [])
+            for item in (readiness.get("children") or [])
             if isinstance(item, Mapping)
-            and workflow_type in {str(value) for value in item.get("workflowTypes", [])}
-            and task_queue in {str(value) for value in item.get("taskQueues", [])}
+            and workflow_type
+            in {str(value) for value in (item.get("workflowTypes") or [])}
+            and task_queue in {str(value) for value in (item.get("taskQueues") or [])}
         ]
         if not children and workflow_type in workflow_types and task_queue in task_queues:
             children = [readiness]

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -42,18 +42,18 @@ from moonmind.integrations.pentest.models import (
     PENTEST_HEARTBEAT_PHASES,
     PENTEST_RUNTIME_ID,
     PentestApprovedScope,
+    PentestExecutionPolicy,
     PentestLaunchPolicyError,
     PentestProviderMaterializationError,
     PentestScopeValidationError,
-    PentestExecutionPolicy,
     PentestWorkloadRequest,
     PentestWorkloadResult,
     build_pentest_execution_materialization,
-    build_pentest_publication_result,
+    build_pentest_launch_plan,
     build_pentest_provider_cooldown_diagnostic,
     build_pentest_progress_annotation,
+    build_pentest_publication_result,
     build_pentest_terminal_cleanup_result,
-    build_pentest_launch_plan,
     classify_pentest_failure,
     materialize_pentest_provider_profile,
     pentest_cleanup_selector,
@@ -1268,6 +1268,10 @@ _ACTIVITY_HANDLER_ATTRS: dict[str, tuple[str, str]] = {
         "pr_resolver_verify_remote_head",
     ),
     "pr_resolver.verify_merged": ("integrations", "pr_resolver_verify_merged"),
+    "worker.verify_workflow_capability": (
+        "integrations",
+        "worker_verify_workflow_capability",
+    ),
     "pr_resolver.write_terminal_result": (
         "artifacts",
         "pr_resolver_write_terminal_result",
@@ -4694,6 +4698,103 @@ class TemporalIntegrationActivities:
     async def repo_merge_pr(self, payload, /, **kwargs):
         from moonmind.workflows.temporal.activities.jules_activities import repo_merge_pr_activity
         return await repo_merge_pr_activity(payload)
+
+    async def worker_verify_workflow_capability(self, payload, /, **kwargs):
+        """Fail closed unless the deployed workflow fleet proves registration."""
+
+        request = dict(payload) if isinstance(payload, Mapping) else {}
+        workflow_type = str(request.get("workflowType") or "").strip()
+        task_queue = str(request.get("taskQueue") or "").strip()
+        url = str(
+            os.environ.get("TEMPORAL_WORKFLOW_READINESS_URL")
+            or "http://temporal-worker-workflow:8080/readyz"
+        ).strip()
+        try:
+            async with httpx.AsyncClient(timeout=5.0) as client:
+                response = await client.get(url)
+                response.raise_for_status()
+                readiness = response.json()
+        except Exception as exc:
+            return {
+                "available": False,
+                "status": "blocked_operator",
+                "reasonCode": "worker_capability_unavailable",
+                "workflowType": workflow_type,
+                "taskQueue": task_queue,
+                "agentExecutionLaunched": False,
+                "diagnostic": exc.__class__.__name__,
+            }
+        if not isinstance(readiness, Mapping):
+            readiness = {}
+        workflow_types = {
+            str(item) for item in readiness.get("workflowTypes", [])
+        }
+        task_queues = {str(item) for item in readiness.get("taskQueues", [])}
+        available = (
+            readiness.get("ready") is True
+            and workflow_type in workflow_types
+            and task_queue in task_queues
+        )
+        fingerprints = [
+            str(item) for item in readiness.get("registryFingerprints", [])
+        ]
+        if not fingerprints and readiness.get("registryFingerprint"):
+            fingerprints = [str(readiness["registryFingerprint"])]
+        build_ids = [str(item) for item in readiness.get("buildIds", [])]
+        if not build_ids and readiness.get("buildId"):
+            build_ids = [str(readiness["buildId"])]
+        children = [
+            item
+            for item in readiness.get("children", [])
+            if isinstance(item, Mapping)
+            and workflow_type in {str(value) for value in item.get("workflowTypes", [])}
+            and task_queue in {str(value) for value in item.get("taskQueues", [])}
+        ]
+        if not children and workflow_type in workflow_types and task_queue in task_queues:
+            children = [readiness]
+
+        def _single_value(key: str) -> str | None:
+            values = {
+                str(item.get(key))
+                for item in children
+                if item.get(key) is not None and str(item.get(key)).strip()
+            }
+            return next(iter(values)) if len(values) == 1 else None
+
+        result = {
+            "available": available,
+            "status": "ready" if available else "blocked_operator",
+            "reasonCode": (
+                "worker_capability_ready"
+                if available
+                else "worker_capability_unavailable"
+            ),
+            "workflowType": workflow_type,
+            "taskQueue": task_queue,
+            "agentExecutionLaunched": False,
+            "registryFingerprint": fingerprints[0] if len(fingerprints) == 1 else None,
+            "observedRegistryFingerprints": fingerprints,
+            "observedWorkerBuilds": build_ids,
+            "buildId": build_ids[0] if len(build_ids) == 1 else None,
+            "buildSha": _single_value("buildSha"),
+            "imageDigest": _single_value("imageDigest"),
+            "deploymentId": _single_value("deploymentId"),
+            "resolverCore": (
+                dict(children[0].get("resolverCore") or {})
+                if len(children) == 1
+                else {}
+            ),
+        }
+        if not available:
+            logger.error(
+                "workflow capability unavailable workflow_type=%s task_queue=%s "
+                "build_ids=%s registry_fingerprints=%s",
+                workflow_type,
+                task_queue,
+                build_ids,
+                fingerprints,
+            )
+        return result
 
     async def merge_automation_evaluate_readiness(self, payload, /, **kwargs):
         from moonmind.workflows.adapters.github_service import GitHubService

--- a/moonmind/workflows/temporal/artifacts.py
+++ b/moonmind/workflows/temporal/artifacts.py
@@ -2847,21 +2847,38 @@ class TemporalArtifactActivities:
         from moonmind.schemas.temporal_activity_models import (
             ExecutionTerminalStateInput,
         )
-        from moonmind.workflows.temporal.service import TemporalExecutionService
+        from moonmind.workflows.temporal.service import (
+            TemporalExecutionNotFoundError,
+            TemporalExecutionService,
+        )
 
         model = ExecutionTerminalStateInput.model_validate(request or {})
 
         async with get_async_session_context() as session:
             service = TemporalExecutionService(session)
-            record = await service.record_terminal_state(
-                workflow_id=model.workflow_id,
-                state=model.state,
-                close_status=model.close_status,
-                summary=model.summary,
-                error_category=model.error_category,
-                finish_outcome_code=model.finish_outcome_code,
-                finish_summary=model.finish_summary,
-            )
+            try:
+                record = await service.record_terminal_state(
+                    workflow_id=model.workflow_id,
+                    state=model.state,
+                    close_status=model.close_status,
+                    summary=model.summary,
+                    error_category=model.error_category,
+                    finish_outcome_code=model.finish_outcome_code,
+                    finish_summary=model.finish_summary,
+                )
+            except TemporalExecutionNotFoundError:
+                # Internally-started child workflows can reach terminal state
+                # before the asynchronous Temporal projection sees their start.
+                # Temporal history remains authoritative; the projector will
+                # reconcile the row after close, so this auxiliary handoff must
+                # not turn primary success into an Activity failure.
+                return {
+                    "workflowId": model.workflow_id,
+                    "state": model.state,
+                    "closeStatus": model.close_status,
+                    "projectionDeferred": True,
+                    "reasonCode": "temporal_projection_pending",
+                }
 
         await self._write_run_digest_best_effort(record)
 
@@ -3316,7 +3333,6 @@ class TemporalArtifactActivities:
         error causing workflow task failures). Terminates the existing manager
         if running, then starts a fresh one.
         """
-        from temporalio.exceptions import WorkflowAlreadyStartedError
         from temporalio.service import RPCError
 
         from moonmind.workflows.temporal.client import TemporalClientAdapter

--- a/moonmind/workflows/temporal/native_skill_bindings.py
+++ b/moonmind/workflows/temporal/native_skill_bindings.py
@@ -1,0 +1,93 @@
+"""Trusted bindings between resolved portable Skills and native workflow hosts."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+from pr_resolver_core import IMPLEMENTATION_CONTRACT, RESOLVER_CORE_VERSION
+
+
+@dataclass(frozen=True, slots=True)
+class NativeSkillBindingDecision:
+    eligible: bool
+    host: str
+    reason_code: str
+    identity: dict[str, Any]
+
+
+def _field(value: Any, *names: str) -> Any:
+    for name in names:
+        candidate = (
+            value.get(name)
+            if isinstance(value, Mapping)
+            else getattr(value, name, None)
+        )
+        if candidate is not None:
+            return candidate
+    return None
+
+
+def _implementation_payload(entry: Any) -> Mapping[str, Any]:
+    implementation = _field(entry, "implementation")
+    if isinstance(implementation, Mapping):
+        return implementation
+    if implementation is not None and hasattr(implementation, "model_dump"):
+        return implementation.model_dump(by_alias=True, mode="json")
+    return {}
+
+
+def evaluate_pr_resolver_native_binding(entry: Any) -> NativeSkillBindingDecision:
+    """Select native hosting only for the trusted built-in portable contract."""
+
+    name = str(_field(entry, "skill_name", "skillName", "name") or "").strip()
+    provenance = _field(entry, "provenance")
+    source_value = _field(provenance, "source_kind", "sourceKind")
+    source_kind = str(getattr(source_value, "value", source_value) or "").strip()
+    implementation = _implementation_payload(entry)
+    contract = str(implementation.get("contract") or "").strip()
+    supported_hosts = {
+        str(host).strip().lower()
+        for host in (
+            implementation.get("supportedHosts")
+            or implementation.get("supported_hosts")
+            or []
+        )
+    }
+    eligible_flag = bool(
+        implementation.get("nativeHostEligible")
+        if "nativeHostEligible" in implementation
+        else implementation.get("native_host_eligible")
+    )
+    policy = str(
+        implementation.get("nativeHostPolicy")
+        or implementation.get("native_host_policy")
+        or ""
+    ).strip()
+    content_digest = str(_field(entry, "content_digest", "contentDigest") or "").strip()
+    content_ref = str(_field(entry, "content_ref", "contentRef") or "").strip()
+    identity = {
+        "skillName": name,
+        "implementationContract": contract,
+        "resolverCoreVersion": RESOLVER_CORE_VERSION,
+        "contentDigest": content_digest or None,
+        "contentRef": content_ref or None,
+        "sourceKind": source_kind or None,
+        "nativeHostPolicy": policy or None,
+    }
+    checks = (
+        (name == "pr-resolver", "skill_name_mismatch"),
+        (contract == IMPLEMENTATION_CONTRACT, "implementation_contract_mismatch"),
+        ("temporal" in supported_hosts, "temporal_host_not_supported"),
+        (eligible_flag, "native_host_not_eligible"),
+        (policy == "moonmind_trusted", "native_host_policy_denied"),
+        (source_kind == "built_in", "untrusted_skill_source"),
+        (bool(content_digest and content_ref), "immutable_content_evidence_missing"),
+    )
+    for allowed, reason in checks:
+        if not allowed:
+            return NativeSkillBindingDecision(False, "cli", reason, identity)
+    return NativeSkillBindingDecision(
+        True, "temporal", "native_binding_accepted", identity
+    )

--- a/moonmind/workflows/temporal/worker_entrypoint.py
+++ b/moonmind/workflows/temporal/worker_entrypoint.py
@@ -1,19 +1,27 @@
 import asyncio
 import logging
 
-from temporalio.client import Client
-from temporalio.worker import UnsandboxedWorkflowRunner, Worker
+from temporalio.common import VersioningBehavior
+from temporalio.worker import (
+    UnsandboxedWorkflowRunner,
+    Worker,
+    WorkerDeploymentConfig,
+    WorkerDeploymentVersion,
+)
 from moonmind.workflows.temporal.client import get_temporal_client
 
 from moonmind.config.settings import settings
 from moonmind.workflows.temporal.workers import (
     WORKFLOW_FLEET,
     build_worker_activity_bindings,
+    build_worker_spec,
     describe_configured_worker,
 )
 from moonmind.workflows.temporal.workflow_registry import (
+    workflow_fleet_activity_handlers,
     workflow_fleet_workflow_classes,
 )
+
 
 async def main():
     logging.basicConfig(level=logging.INFO)
@@ -30,17 +38,38 @@ async def main():
     if topology.fleet == WORKFLOW_FLEET:
         workflows.extend(workflow_fleet_workflow_classes())
 
-    bindings = build_worker_activity_bindings(fleet=topology.fleet)
-    activities = [b.handler for b in bindings]
+    if topology.fleet == WORKFLOW_FLEET:
+        activities = list(workflow_fleet_activity_handlers())
+    else:
+        bindings = build_worker_activity_bindings(fleet=topology.fleet)
+        activities = [b.handler for b in bindings]
+
+    spec = build_worker_spec(
+        topology=topology,
+        workflows=workflows,
+        activities=activities,
+    )
+    worker_kwargs = {
+        "workflows": spec.workflows,
+        "activities": spec.activities,
+        "max_concurrent_activities": topology.concurrency_limit or 100,
+        "workflow_runner": UnsandboxedWorkflowRunner(),
+    }
+    if spec.versioning_enabled:
+        worker_kwargs["deployment_config"] = WorkerDeploymentConfig(
+            version=WorkerDeploymentVersion(
+                deployment_name=spec.deployment_id,
+                build_id=spec.build_id,
+            ),
+            use_worker_versioning=True,
+            default_versioning_behavior=VersioningBehavior.AUTO_UPGRADE,
+        )
 
     workers = [
         Worker(
             client,
             task_queue=task_queue,
-            workflows=workflows,
-            activities=activities,
-            max_concurrent_activities=topology.concurrency_limit or 100,
-            workflow_runner=UnsandboxedWorkflowRunner(),
+            **worker_kwargs,
         )
         for task_queue in topology.task_queues
     ]
@@ -50,9 +79,11 @@ async def main():
         topology.fleet,
         ", ".join(topology.task_queues),
     )
+    logger.info("Executable worker specification: %s", spec.readiness_payload())
     async with asyncio.TaskGroup() as tg:
         for worker in workers:
             tg.create_task(worker.run())
+
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/moonmind/workflows/temporal/worker_healthcheck.py
+++ b/moonmind/workflows/temporal/worker_healthcheck.py
@@ -18,6 +18,7 @@ import json
 import logging
 import os
 import time
+from dataclasses import dataclass, field
 from typing import Any
 
 logger = logging.getLogger(__name__)
@@ -26,6 +27,27 @@ _DEFAULT_PORT = 8080
 
 _start_time: float = time.monotonic()
 
+
+@dataclass(slots=True)
+class WorkerHealthState:
+    """Process liveness and executable-worker readiness are separate signals."""
+
+    temporal_connected: bool = False
+    workers_constructed: bool = False
+    pollers_started: bool = False
+    readiness_metadata: dict[str, Any] = field(default_factory=dict)
+    startup_error: str | None = None
+
+    @property
+    def ready(self) -> bool:
+        return (
+            self.temporal_connected
+            and self.workers_constructed
+            and self.pollers_started
+            and self.startup_error is None
+        )
+
+
 def _is_enabled() -> bool:
     return os.environ.get("WORKER_HEALTHCHECK_ENABLED", "true").lower() not in (
         "false",
@@ -33,32 +55,58 @@ def _is_enabled() -> bool:
         "no",
     )
 
+
 def _port() -> int:
     raw = os.environ.get("WORKER_HEALTHCHECK_PORT", "")
     if raw.strip().isdigit():
         return int(raw.strip())
     return _DEFAULT_PORT
 
-def _build_response_body() -> bytes:
+
+def _build_response_body(
+    state: WorkerHealthState | None = None,
+    *,
+    readiness: bool = False,
+) -> bytes:
     """Build the JSON health response payload."""
     fleet = os.environ.get("TEMPORAL_WORKER_FLEET", "unknown")
     uptime = int(time.monotonic() - _start_time)
 
-    body: dict[str, Any] = {
-        "status": "ok",
-        "fleet": fleet,
-        "uptime_seconds": uptime,
-    }
+    if not readiness:
+        body: dict[str, Any] = {
+            "status": "ok",
+            "live": True,
+            "fleet": fleet,
+            "uptime_seconds": uptime,
+        }
+    else:
+        current = state or WorkerHealthState()
+        body = {
+            **current.readiness_metadata,
+            "status": "ready" if current.ready else "not_ready",
+            "ready": current.ready,
+            "fleet": fleet,
+            "uptime_seconds": uptime,
+            "startup": {
+                "temporalConnected": current.temporal_connected,
+                "workersConstructed": current.workers_constructed,
+                "pollersStarted": current.pollers_started,
+            },
+        }
+        if current.startup_error:
+            body["reasonCode"] = "worker_startup_failed"
     return json.dumps(body).encode("utf-8")
+
 
 async def _handle_connection(
     reader: asyncio.StreamReader,
     writer: asyncio.StreamWriter,
+    state: WorkerHealthState,
 ) -> None:
     """Handle a single HTTP connection — respond to any request with health JSON."""
     try:
         # Read request line (we don't need the full request)
-        await asyncio.wait_for(reader.readline(), timeout=5.0)
+        request_line = await asyncio.wait_for(reader.readline(), timeout=5.0)
 
         # Consume remaining headers
         while True:
@@ -66,10 +114,16 @@ async def _handle_connection(
             if line in (b"\r\n", b"\n", b""):
                 break
 
-        payload = _build_response_body()
+        parts = request_line.decode("ascii", errors="ignore").split()
+        path = parts[1] if len(parts) >= 2 else "/healthz"
+        readiness = path == "/readyz"
+        payload = _build_response_body(state, readiness=readiness)
+        status = (
+            b"200 OK" if not readiness or state.ready else b"503 Service Unavailable"
+        )
 
         response = (
-            b"HTTP/1.1 200 OK\r\n"
+            b"HTTP/1.1 " + status + b"\r\n"
             b"Content-Type: application/json\r\n"
             b"Connection: close\r\n"
             b"Content-Length: " + str(len(payload)).encode() + b"\r\n"
@@ -86,7 +140,10 @@ async def _handle_connection(
         except (ConnectionError, OSError):
             pass
 
-async def start_healthcheck_server() -> asyncio.Server | None:
+
+async def start_healthcheck_server(
+    state: WorkerHealthState | None = None,
+) -> asyncio.Server | None:
     """Start the health-check HTTP server as a background asyncio task.
 
     Returns the ``asyncio.Server`` so callers can close it on shutdown,
@@ -100,6 +157,11 @@ async def start_healthcheck_server() -> asyncio.Server | None:
     _start_time = time.monotonic()
 
     port = _port()
-    server = await asyncio.start_server(_handle_connection, "0.0.0.0", port)
+    health_state = state or WorkerHealthState()
+    server = await asyncio.start_server(
+        lambda reader, writer: _handle_connection(reader, writer, health_state),
+        "0.0.0.0",
+        port,
+    )
     logger.info("Worker healthcheck server listening on port %d", port)
     return server

--- a/moonmind/workflows/temporal/worker_runtime.py
+++ b/moonmind/workflows/temporal/worker_runtime.py
@@ -30,9 +30,15 @@ import temporalio.workflow
 from opentelemetry import trace as otel_trace
 from sqlalchemy.ext.asyncio import AsyncSession
 from temporalio.client import Client
+from temporalio.common import VersioningBehavior
 from temporalio.contrib.pydantic import pydantic_data_converter
 from temporalio.runtime import PrometheusConfig, Runtime, TelemetryConfig
-from temporalio.worker import UnsandboxedWorkflowRunner, Worker
+from temporalio.worker import (
+    UnsandboxedWorkflowRunner,
+    Worker,
+    WorkerDeploymentConfig,
+    WorkerDeploymentVersion,
+)
 from structlog.stdlib import ProcessorFormatter
 
 from api_service.db.base import get_async_session_context
@@ -83,6 +89,7 @@ from moonmind.workflows.temporal.workers import (
     SANDBOX_FLEET,
     WORKFLOW_FLEET,
     build_worker_activity_bindings,
+    build_worker_spec,
     describe_configured_worker,
     list_registered_workflow_types,
 )
@@ -93,19 +100,23 @@ from moonmind.workflows.executions.preset_expansion import (
     expand_preset_for_child_run,
 )
 from moonmind.workflows.temporal.workflows.manifest_ingest import (
-    MoonMindManifestIngestWorkflow as MoonMindManifestIngest,
+    MoonMindManifestIngestWorkflow as MoonMindManifestIngest,  # noqa: F401
 )
 from moonmind.workflows.temporal.jules_bundle import JULES_AGENT_IDS
 from moonmind.workflows.temporal.jira_agent_skills import JIRA_AGENT_SKILLS
-from moonmind.workflows.temporal.worker_healthcheck import start_healthcheck_server
+from moonmind.workflows.temporal.worker_healthcheck import (
+    WorkerHealthState,
+    start_healthcheck_server,
+)
 from moonmind.workflows.temporal.workflows.agent_run import (
-    MoonMindAgentRun,
+    MoonMindAgentRun,  # noqa: F401
     resolve_adapter_metadata,
     get_activity_route,
     resolve_external_adapter,
     external_adapter_execution_style,
 )
 from moonmind.workflows.temporal.workflow_registry import (
+    workflow_fleet_activity_handlers,
     workflow_fleet_workflow_classes,
 )
 from moonmind.workflows.temporal.runtime.store import ManagedRunStore
@@ -2638,9 +2649,10 @@ async def main_async() -> None:
         f"concurrency={topology.concurrency_limit}"
     )
 
-    # Start healthcheck server before connecting to Temporal so probes
-    # can confirm the process is alive even during initial connection.
-    healthcheck_server = await start_healthcheck_server()
+    # Liveness starts immediately. Readiness remains false until the Temporal
+    # connection, executable spec, SDK workers, and polling tasks all exist.
+    health_state = WorkerHealthState()
+    healthcheck_server = await start_healthcheck_server(health_state)
 
     import os
     interceptors = []
@@ -2686,7 +2698,12 @@ async def main_async() -> None:
     if runtime:
         client_kwargs["runtime"] = runtime
 
-    client = await Client.connect(settings.temporal.address, **client_kwargs)
+    try:
+        client = await Client.connect(settings.temporal.address, **client_kwargs)
+        health_state.temporal_connected = True
+    except Exception as exc:
+        health_state.startup_error = exc.__class__.__name__
+        raise
 
     workflows = []
     activities = []
@@ -2694,12 +2711,7 @@ async def main_async() -> None:
 
     if topology.fleet == WORKFLOW_FLEET:
         workflows = workflow_fleet_workflow_classes()
-        activities = [
-            resolve_adapter_metadata,
-            get_activity_route,
-            resolve_external_adapter,
-            external_adapter_execution_style,
-        ]
+        activities = workflow_fleet_activity_handlers()
         logger.info(
             "Temporal workflow fleet registrations: %s",
             ", ".join(list_registered_workflow_types()),
@@ -2708,12 +2720,26 @@ async def main_async() -> None:
         runtime_resources, activities = await _build_runtime_activities(topology)
 
     try:
+        spec = build_worker_spec(
+            topology=topology,
+            workflows=workflows,
+            activities=activities,
+        )
         worker_kwargs = {
-            "workflows": workflows,
-            "activities": activities,
+            "workflows": spec.workflows,
+            "activities": spec.activities,
             "workflow_runner": UnsandboxedWorkflowRunner(),
             **_worker_concurrency_kwargs(topology),
         }
+        if spec.versioning_enabled:
+            worker_kwargs["deployment_config"] = WorkerDeploymentConfig(
+                version=WorkerDeploymentVersion(
+                    deployment_name=spec.deployment_id,
+                    build_id=spec.build_id,
+                ),
+                use_worker_versioning=True,
+                default_versioning_behavior=VersioningBehavior.AUTO_UPGRADE,
+            )
         workers = [
             Worker(
                 client,
@@ -2722,14 +2748,25 @@ async def main_async() -> None:
             )
             for task_queue in topology.task_queues
         ]
+        health_state.workers_constructed = True
+        health_state.readiness_metadata = spec.readiness_payload()
 
         logger.info(
-            "Worker started, polling task queues: %s",
-            ", ".join(topology.task_queues),
+            "Temporal executable worker specification: %s",
+            json.dumps(spec.readiness_payload(), sort_keys=True),
         )
         async with asyncio.TaskGroup() as tg:
             for worker in workers:
                 tg.create_task(worker.run())
+            await asyncio.sleep(0)
+            health_state.pollers_started = True
+            logger.info(
+                "Worker ready, polling task queues: %s",
+                ", ".join(topology.task_queues),
+            )
+    except Exception as exc:
+        health_state.startup_error = exc.__class__.__name__
+        raise
     finally:
         if runtime_resources is not None:
             await runtime_resources.aclose()

--- a/moonmind/workflows/temporal/workers.py
+++ b/moonmind/workflows/temporal/workers.py
@@ -3,9 +3,20 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
+import os
 from dataclasses import asdict, dataclass
-from typing import Any, Sequence
+from pathlib import Path
+from typing import Any, Callable, Sequence
+
+from temporalio import activity, workflow
+
+from pr_resolver_core import (
+    IMPLEMENTATION_CONTRACT,
+    RESOLVER_CORE_DIGEST,
+    RESOLVER_CORE_VERSION,
+)
 
 from moonmind.config.settings import AppSettings, TemporalSettings, settings
 from moonmind.workflows.temporal.activity_catalog import (
@@ -121,8 +132,11 @@ _FLEET_FORBIDDEN_CAPABILITIES = {
         "docker_workload",
     ),
 }
+
+
 class TemporalWorkerBootstrapError(ValueError):
     """Raised when the worker topology cannot be resolved safely."""
+
 
 def list_registered_workflow_types() -> tuple[str, ...]:
     """Return the workflow types owned by the workflow fleet."""
@@ -136,6 +150,7 @@ def list_registered_workflow_types_for_settings(
     """Return workflow registrations for the configured user-workflow contract."""
 
     return workflow_fleet_workflow_types(temporal_settings)
+
 
 @dataclass(frozen=True, slots=True)
 class TemporalWorkerTopology:
@@ -156,6 +171,140 @@ class TemporalWorkerTopology:
     def to_payload(self) -> dict[str, Any]:
         return asdict(self)
 
+
+@dataclass(frozen=True, slots=True)
+class WorkerSpec:
+    """One executable worker specification used by SDK wiring and diagnostics."""
+
+    fleet: str
+    task_queues: tuple[str, ...]
+    workflows: tuple[type[Any], ...]
+    activities: tuple[Callable[..., Any], ...]
+    workflow_types: tuple[str, ...]
+    activity_types: tuple[str, ...]
+    registry_fingerprint: str
+    build_id: str
+    build_sha: str | None
+    image_digest: str | None
+    deployment_id: str
+    versioning_enabled: bool
+    deployment_mode: str
+    immutable_release_identity: bool
+
+    def readiness_payload(self) -> dict[str, Any]:
+        return {
+            "ready": True,
+            "fleet": self.fleet,
+            "buildId": self.build_id,
+            "buildSha": self.build_sha,
+            "imageDigest": self.image_digest,
+            "deploymentId": self.deployment_id,
+            "registryFingerprint": self.registry_fingerprint,
+            "taskQueues": list(self.task_queues),
+            "workflowTypes": list(self.workflow_types),
+            "activityTypes": list(self.activity_types),
+            "workerVersioningEnabled": self.versioning_enabled,
+            "deploymentMode": self.deployment_mode,
+            "immutableReleaseIdentity": self.immutable_release_identity,
+            "resolverCore": {
+                "contract": IMPLEMENTATION_CONTRACT,
+                "version": RESOLVER_CORE_VERSION,
+                "digest": RESOLVER_CORE_DIGEST,
+            },
+        }
+
+
+def _workflow_type(workflow_class: type[Any]) -> str:
+    return workflow._Definition.must_from_class(workflow_class).name
+
+
+def _activity_type(handler: Callable[..., Any]) -> str:
+    return activity._Definition.must_from_callable(handler).name
+
+
+def _workflow_source_digest(workflow_class: type[Any]) -> str:
+    module = __import__(workflow_class.__module__, fromlist=[workflow_class.__name__])
+    path_value = getattr(module, "__file__", None)
+    if not path_value:
+        return f"{workflow_class.__module__}:{workflow_class.__qualname__}"
+    path = Path(path_value)
+    try:
+        return hashlib.sha256(path.read_bytes()).hexdigest()
+    except OSError:
+        return f"{workflow_class.__module__}:{workflow_class.__qualname__}"
+
+
+def build_worker_spec(
+    *,
+    topology: TemporalWorkerTopology,
+    workflows: Sequence[type[Any]],
+    activities: Sequence[Callable[..., Any]],
+    environ: dict[str, str] | None = None,
+) -> WorkerSpec:
+    """Build the exact immutable worker identity passed to Temporal."""
+
+    env = os.environ if environ is None else environ
+    workflow_classes = tuple(workflows)
+    activity_handlers = tuple(activities)
+    workflow_types = tuple(_workflow_type(item) for item in workflow_classes)
+    activity_types = tuple(_activity_type(item) for item in activity_handlers)
+    fingerprint_input = {
+        "workflowTypes": list(workflow_types),
+        "workflowSourceDigests": [
+            _workflow_source_digest(item) for item in workflow_classes
+        ],
+        "activityTypes": list(activity_types),
+        "resolverCoreDigest": RESOLVER_CORE_DIGEST,
+    }
+    fingerprint = (
+        "sha256:"
+        + hashlib.sha256(
+            json.dumps(fingerprint_input, sort_keys=True, separators=(",", ":")).encode(
+                "utf-8"
+            )
+        ).hexdigest()
+    )
+    build_sha = str(env.get("MOONMIND_BUILD_SHA") or "").strip() or None
+    image_digest = str(env.get("MOONMIND_IMAGE_DIGEST") or "").strip() or None
+    build_id = build_sha or image_digest or fingerprint.split(":", 1)[1][:32]
+    deployment_id = str(
+        env.get("TEMPORAL_WORKER_DEPLOYMENT_NAME") or "moonmind-workflow-fleet"
+    ).strip()
+    versioning_enabled = str(
+        env.get("TEMPORAL_WORKER_VERSIONING_ENABLED") or "false"
+    ).strip().lower() in {"1", "true", "yes", "on"}
+    deployment_mode = (
+        str(env.get("MOONMIND_DEPLOYMENT_MODE") or "development").strip().lower()
+    )
+    immutable_release_identity = bool(build_sha or image_digest)
+    if deployment_mode == "production" and not immutable_release_identity:
+        raise TemporalWorkerBootstrapError(
+            "production workflow workers require MOONMIND_BUILD_SHA or "
+            "MOONMIND_IMAGE_DIGEST"
+        )
+    if deployment_mode == "production" and not versioning_enabled:
+        raise TemporalWorkerBootstrapError(
+            "production workflow workers require "
+            "TEMPORAL_WORKER_VERSIONING_ENABLED=true"
+        )
+    return WorkerSpec(
+        fleet=topology.fleet,
+        task_queues=tuple(topology.task_queues),
+        workflows=workflow_classes,
+        activities=activity_handlers,
+        workflow_types=workflow_types,
+        activity_types=activity_types,
+        registry_fingerprint=fingerprint,
+        build_id=build_id,
+        build_sha=build_sha,
+        image_digest=image_digest,
+        deployment_id=deployment_id,
+        versioning_enabled=versioning_enabled,
+        deployment_mode=deployment_mode,
+        immutable_release_identity=immutable_release_identity,
+    )
+
+
 def normalize_worker_fleet(fleet: str) -> str:
     """Return a canonical fleet name or fail closed."""
 
@@ -167,6 +316,7 @@ def normalize_worker_fleet(fleet: str) -> str:
         )
     return normalized
 
+
 def _artifact_secrets(app_settings: AppSettings) -> tuple[str, ...]:
     if app_settings.workflow.temporal_artifact_backend == "s3":
         return (
@@ -176,6 +326,7 @@ def _artifact_secrets(app_settings: AppSettings) -> tuple[str, ...]:
             "TEMPORAL_ARTIFACT_S3_SECRET_ACCESS_KEY",
         )
     return ()
+
 
 def _required_secrets_for_fleet(
     fleet: str, *, app_settings: AppSettings
@@ -193,6 +344,7 @@ def _required_secrets_for_fleet(
         return ("JULES_API_URL", "JULES_API_KEY")
     return ()
 
+
 def _concurrency_limit_for_fleet(
     fleet: str, *, temporal_settings: TemporalSettings
 ) -> int | None:
@@ -206,6 +358,7 @@ def _concurrency_limit_for_fleet(
         DEPLOYMENT_FLEET: temporal_settings.deployment_worker_concurrency,
     }[fleet]
 
+
 def _fleet_entry(
     catalog: TemporalActivityCatalog, *, fleet: str
 ) -> TemporalWorkerFleet:
@@ -216,6 +369,7 @@ def _fleet_entry(
     raise TemporalWorkerBootstrapError(
         f"Temporal catalog does not define worker fleet '{normalized}'"
     )
+
 
 def build_worker_topology(
     *,
@@ -255,6 +409,7 @@ def build_worker_topology(
         egress_policy=_FLEET_EGRESS_POLICIES[normalized],
     )
 
+
 def build_all_worker_topologies(
     *,
     catalog: TemporalActivityCatalog | None = None,
@@ -275,6 +430,7 @@ def build_all_worker_topologies(
         )
         for fleet in ALLOWED_TEMPORAL_WORKER_FLEETS
     )
+
 
 def build_worker_activity_bindings(
     *,
@@ -313,6 +469,7 @@ def build_worker_activity_bindings(
         fleets=(normalized,),
     )
 
+
 def describe_configured_worker(
     *,
     temporal_settings: TemporalSettings | None = None,
@@ -330,6 +487,7 @@ def describe_configured_worker(
         app_settings=app_cfg,
     )
 
+
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="moonmind-temporal-worker-bootstrap")
     parser.add_argument(
@@ -342,6 +500,7 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Emit the resolved worker topology as JSON and exit.",
     )
     return parser
+
 
 def main(argv: Sequence[str] | None = None) -> int:
     """CLI entrypoint used by the shared worker launcher."""
@@ -366,6 +525,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             f"concurrency={payload['concurrency_limit']}"
         )
     return 0
+
 
 if __name__ == "__main__":  # pragma: no cover
     raise SystemExit(main())

--- a/moonmind/workflows/temporal/workflow_registry.py
+++ b/moonmind/workflows/temporal/workflow_registry.py
@@ -7,17 +7,15 @@ from functools import cache
 from importlib import import_module
 from typing import Any
 
+from temporalio import workflow
+
 from moonmind.config.settings import TemporalSettings
-from moonmind.workflows.temporal.hard_switch_cutover import (
-    registered_user_workflow_type,
-)
 
 
 @dataclass(frozen=True, slots=True)
 class WorkflowRegistration:
     """A workflow class and its canonical Temporal type name."""
 
-    workflow_type: str
     module: str
     class_name: str
 
@@ -28,7 +26,6 @@ class WorkflowRegistration:
 
 
 USER_WORKFLOW_REGISTRATION = WorkflowRegistration(
-    "MoonMind.UserWorkflow",
     "moonmind.workflows.temporal.workflows.run",
     "MoonMindUserWorkflow",
 )
@@ -36,47 +33,38 @@ USER_WORKFLOW_REGISTRATION = WorkflowRegistration(
 
 STATIC_WORKFLOW_REGISTRATIONS = (
     WorkflowRegistration(
-        "MoonMind.ManifestIngest",
         "moonmind.workflows.temporal.workflows.manifest_ingest",
         "MoonMindManifestIngestWorkflow",
     ),
     WorkflowRegistration(
-        "MoonMind.ProviderProfileManager",
         "moonmind.workflows.temporal.workflows.provider_profile_manager",
         "MoonMindProviderProfileManagerWorkflow",
     ),
     WorkflowRegistration(
-        "MoonMind.AgentSession",
         "moonmind.workflows.temporal.workflows.agent_session",
         "MoonMindAgentSessionWorkflow",
     ),
     WorkflowRegistration(
-        "MoonMind.ManagedSessionReconcile",
         "moonmind.workflows.temporal.workflows.managed_session_reconcile",
         "MoonMindManagedSessionReconcileWorkflow",
     ),
     WorkflowRegistration(
-        "MoonMind.ManagedRuntimeWorkspaceCleanup",
         "moonmind.workflows.temporal.workflows.managed_runtime_workspace_cleanup",
         "MoonMindManagedRuntimeWorkspaceCleanupWorkflow",
     ),
     WorkflowRegistration(
-        "MoonMind.AgentRun",
         "moonmind.workflows.temporal.workflows.agent_run",
         "MoonMindAgentRun",
     ),
     WorkflowRegistration(
-        "MoonMind.OAuthSession",
         "moonmind.workflows.temporal.workflows.oauth_session",
         "MoonMindOAuthSessionWorkflow",
     ),
     WorkflowRegistration(
-        "MoonMind.MergeAutomation",
         "moonmind.workflows.temporal.workflows.merge_automation",
         "MoonMindMergeAutomationWorkflow",
     ),
     WorkflowRegistration(
-        "MoonMind.PRResolver",
         "moonmind.workflows.temporal.workflows.pr_resolver",
         "MoonMindPRResolverWorkflow",
     ),
@@ -98,7 +86,27 @@ def workflow_fleet_workflow_types(
 ) -> tuple[str, ...]:
     """Return type names from the same registry used to construct workers."""
 
+    del temporal_settings
+    return tuple(
+        workflow._Definition.must_from_class(workflow_class).name
+        for workflow_class in workflow_fleet_workflow_classes()
+    )
+
+
+@cache
+def workflow_fleet_activity_handlers() -> tuple[Any, ...]:
+    """Return the exact local activities hosted beside deterministic workflows."""
+
+    from moonmind.workflows.temporal.workflows.agent_run import (
+        external_adapter_execution_style,
+        get_activity_route,
+        resolve_adapter_metadata,
+        resolve_external_adapter,
+    )
+
     return (
-        registered_user_workflow_type(temporal_settings),
-        *(registration.workflow_type for registration in STATIC_WORKFLOW_REGISTRATIONS),
+        resolve_adapter_metadata,
+        get_activity_route,
+        resolve_external_adapter,
+        external_adapter_execution_style,
     )

--- a/moonmind/workflows/temporal/workflows/pr_resolver.py
+++ b/moonmind/workflows/temporal/workflows/pr_resolver.py
@@ -13,6 +13,17 @@ from temporalio.exceptions import CancelledError
 from temporalio.workflow import ActivityCancellationType, ChildWorkflowCancellationType
 
 with workflow.unsafe.imports_passed_through():
+    from pr_resolver_core import (
+        IMPLEMENTATION_CONTRACT,
+        RESOLVER_CORE_DIGEST,
+        RESOLVER_CORE_VERSION,
+        ResolverEvent,
+        ResolverPolicy,
+        ResolverState,
+        classify_snapshot,
+        normalize_temporal_snapshot,
+        reduce_resolver_state,
+    )
     from moonmind.config.settings import settings
     from moonmind.schemas.agent_runtime_models import AgentExecutionRequest
     from moonmind.schemas.temporal_models import (
@@ -26,6 +37,8 @@ with workflow.unsafe.imports_passed_through():
 
 
 WORKFLOW_NAME = "MoonMind.PRResolver"
+PR_RESOLVER_IMPLEMENTATION_IDENTITY_PATCH = "pr-resolver-implementation-identity-v1"
+PR_RESOLVER_SHARED_CORE_PATCH = "pr-resolver-shared-core-v1"
 ACTIVITY_RETRY_POLICY = RetryPolicy(
     initial_interval=timedelta(seconds=5),
     backoff_coefficient=2.0,
@@ -45,6 +58,15 @@ REMEDIATION_SKILLS = {
 
 def _text(value: Any) -> str:
     return str(value or "").strip()
+
+
+def _workflow_patch_enabled(patch_id: str) -> bool:
+    try:
+        return workflow.patched(patch_id)
+    except Exception as exc:
+        if exc.__class__.__name__ == "_NotInWorkflowEventLoopError":
+            return True
+        raise
 
 
 def pr_resolver_identity_selector(
@@ -80,44 +102,14 @@ def pr_resolver_identity_selector(
 
 def classify_pr_resolver_snapshot(snapshot: Mapping[str, Any]) -> dict[str, Any]:
     """Deterministically classify a captured GitHub snapshot."""
-
-    if snapshot.get("pullRequestMerged") is True:
-        return {"classification": "already_merged", "reasonCode": "already_merged"}
-    if snapshot.get("pullRequestOpen") is False:
-        return {"classification": "manual_review", "reasonCode": "pull_request_closed"}
-
-    blockers = [item for item in snapshot.get("blockers", ()) if isinstance(item, Mapping)]
-    kinds = {_text(item.get("kind")) for item in blockers}
-    summaries = " ".join(_text(item.get("summary")).lower() for item in blockers)
-
-    if "merge_conflict" in kinds or "merge_conflicts" in kinds:
-        return {"classification": "merge_conflicts", "reasonCode": "merge_conflicts"}
-    if snapshot.get("checksComplete") is True and snapshot.get("checksPassing") is False:
-        return {"classification": "ci_failures", "reasonCode": "ci_failures"}
-    if "checks_failed" in kinds:
-        return {"classification": "ci_failures", "reasonCode": "ci_failures"}
-    if "checks_running" in kinds or snapshot.get("checksComplete") is False:
-        return {"classification": "ci_running", "reasonCode": "ci_running"}
-    if "automated_review_pending" in kinds:
-        if "requested changes" in summaries or "changes requested" in summaries:
-            return {
-                "classification": "actionable_comments",
-                "reasonCode": "actionable_comments",
-            }
-        return {"classification": "review_grace", "reasonCode": "review_grace"}
-    if snapshot.get("ready") is True and not blockers:
-        return {"classification": "ready_to_merge", "reasonCode": "ready_to_merge"}
-    if blockers and all(bool(item.get("retryable", True)) for item in blockers):
-        return {
-            "classification": "mergeability_transient",
-            "reasonCode": "external_state_transient",
-        }
-    return {"classification": "manual_review", "reasonCode": "unknown_blocker"}
+    decision = classify_snapshot(normalize_temporal_snapshot(snapshot))
+    return {
+        "classification": decision.classification,
+        "reasonCode": decision.reason_code,
+    }
 
 
-def blocker_progress_signature(
-    snapshot: Mapping[str, Any], classification: str
-) -> str:
+def blocker_progress_signature(snapshot: Mapping[str, Any], classification: str) -> str:
     """Return a stable signature used to bound identical no-progress blockers."""
 
     parts = [
@@ -141,6 +133,8 @@ def build_pr_resolver_start_input(
     principal: str,
     step_id: str,
     resolved_pull_request: Mapping[str, Any] | None = None,
+    implementation_identity: Mapping[str, Any] | None = None,
+    worker_capability: Mapping[str, Any] | None = None,
 ) -> PRResolverStartInput:
     """Build the resolver boundary from an already prepared agent request."""
 
@@ -158,9 +152,7 @@ def build_pr_resolver_start_input(
     merge_gate = workflow_parameters.get("mergeGate")
     merge_gate = merge_gate if isinstance(merge_gate, Mapping) else {}
     resolved = (
-        resolved_pull_request
-        if isinstance(resolved_pull_request, Mapping)
-        else {}
+        resolved_pull_request if isinstance(resolved_pull_request, Mapping) else {}
     )
     try:
         pr_number = int(resolved.get("prNumber") or pr_value)
@@ -215,6 +207,8 @@ def build_pr_resolver_start_input(
             "policy": policy,
             "shadowMode": bool(skill_inputs.get("shadowMode", False)),
             "ownedByMergeAutomationGate": bool(merge_gate),
+            "implementationIdentity": dict(implementation_identity or {}),
+            "workerCapability": dict(worker_capability or {}),
         }
     )
 
@@ -295,7 +289,9 @@ class MoonMindPRResolverWorkflow:
         self._record_timeline("github_snapshot", transition=transition, attempt=attempt)
         return snapshot
 
-    def _remediation_request(self, *, skill: str, snapshot: Mapping[str, Any]) -> AgentExecutionRequest:
+    def _remediation_request(
+        self, *, skill: str, snapshot: Mapping[str, Any]
+    ) -> AgentExecutionRequest:
         assert self._input is not None
         base = AgentExecutionRequest.model_validate(self._input.base_agent_request)
         count = self._remediation_counts[skill]
@@ -350,27 +346,50 @@ class MoonMindPRResolverWorkflow:
             disposition = "manual_review"
         elif status == "failed":
             disposition = "failed"
+        terminal_payload = {
+            "status": status,
+            "mergeOutcome": status,
+            "mergeAutomationDisposition": disposition,
+            "reason": reason,
+            "reasonCode": reason_code,
+            "nextStep": "done"
+            if status in {"merged", "already_merged"}
+            else "manual_review",
+            "repository": self._input.repository,
+            "prNumber": self._input.pr_number,
+            "prUrl": self._input.pr_url,
+            "verifiedHeadSha": self._head_sha,
+            "verifiedMergeSha": merge_sha,
+            "finalizeAttemptCount": self._finalize_attempts,
+            "remediationCounts": self._remediation_counts,
+            "latestSnapshot": self._latest_snapshot,
+            "timeline": self._timeline[-20:],
+            "workflowId": workflow.info().workflow_id,
+            "stepId": self._input.step_id,
+            "correlationId": self._input.correlation_id,
+        }
+        if _workflow_patch_enabled(PR_RESOLVER_IMPLEMENTATION_IDENTITY_PATCH):
+            identity = self._input.implementation_identity
+            capability = self._input.worker_capability
+            terminal_payload.update(
+                {
+                    "implementationContract": IMPLEMENTATION_CONTRACT,
+                    "resolverCoreVersion": RESOLVER_CORE_VERSION,
+                    "resolverCoreDigest": RESOLVER_CORE_DIGEST,
+                    "resolvedSkillContentDigest": identity.get("contentDigest"),
+                    "resolvedSkillSource": identity.get("sourceKind"),
+                    "workerBuildSha": capability.get("buildSha"),
+                    "workerImageDigest": capability.get("imageDigest"),
+                    "workerDeploymentId": capability.get("deploymentId"),
+                    "workflowRegistryFingerprint": capability.get(
+                        "registryFingerprint"
+                    ),
+                    "taskQueue": capability.get("taskQueue"),
+                    "workflowType": WORKFLOW_NAME,
+                }
+            )
         result = PRResolverTerminalResultModel.model_validate(
-            {
-                "status": status,
-                "mergeOutcome": status,
-                "mergeAutomationDisposition": disposition,
-                "reason": reason,
-                "reasonCode": reason_code,
-                "nextStep": "done" if status in {"merged", "already_merged"} else "manual_review",
-                "repository": self._input.repository,
-                "prNumber": self._input.pr_number,
-                "prUrl": self._input.pr_url,
-                "verifiedHeadSha": self._head_sha,
-                "verifiedMergeSha": merge_sha,
-                "finalizeAttemptCount": self._finalize_attempts,
-                "remediationCounts": self._remediation_counts,
-                "latestSnapshot": self._latest_snapshot,
-                "timeline": self._timeline[-20:],
-                "workflowId": workflow.info().workflow_id,
-                "stepId": self._input.step_id,
-                "correlationId": self._input.correlation_id,
-            }
+            terminal_payload
         ).model_dump(by_alias=True, mode="json")
         publication = await workflow.execute_activity(
             "pr_resolver.write_terminal_result",
@@ -418,6 +437,18 @@ class MoonMindPRResolverWorkflow:
     async def run(self, payload: dict[str, Any]) -> dict[str, Any]:
         self._input = PRResolverStartInput.model_validate(payload)
         self._head_sha = self._input.head_sha
+        if self._input.canary_mode:
+            return {
+                "summary": "MoonMind.PRResolver deployment canary accepted.",
+                "failureClass": None,
+                "outputRefs": {},
+                "metadata": {
+                    "canary": True,
+                    "workflowType": WORKFLOW_NAME,
+                    "implementationIdentity": self._input.implementation_identity,
+                    "workerCapability": self._input.worker_capability,
+                },
+            }
         self._base_sha = self._input.base_sha
         started_at = workflow.now()
         iteration = 0
@@ -434,7 +465,9 @@ class MoonMindPRResolverWorkflow:
                     )
 
                 self._state = "read_pr_snapshot"
-                snapshot = await self._read_snapshot(transition="snapshot", attempt=iteration)
+                snapshot = await self._read_snapshot(
+                    transition="snapshot", attempt=iteration
+                )
                 self._state = "classify_gate"
                 classified = await workflow.execute_activity(
                     "pr_resolver.classify_gate",
@@ -455,8 +488,46 @@ class MoonMindPRResolverWorkflow:
                     else classify_pr_resolver_snapshot(snapshot)
                 )
                 self._classification = decision["classification"]
+                progress_signature = blocker_progress_signature(
+                    snapshot, self._classification
+                )
+                transition = None
+                if _workflow_patch_enabled(PR_RESOLVER_SHARED_CORE_PATCH):
+                    transition = reduce_resolver_state(
+                        previous_state=ResolverState(
+                            finalize_attempts=self._finalize_attempts,
+                            remediation_counts=tuple(
+                                sorted(self._remediation_counts.items())
+                            ),
+                            identical_blocker_count=self._identical_no_progress_count,
+                            last_progress_signature=self._last_progress_signature,
+                        ),
+                        snapshot=normalize_temporal_snapshot(snapshot),
+                        policy=ResolverPolicy(
+                            max_finalize_attempts=(
+                                self._input.policy.max_finalize_attempts
+                            ),
+                            max_remediations_per_type=(
+                                self._input.policy.max_remediations_per_type
+                            ),
+                            max_identical_blockers_without_progress=(
+                                self._input.policy.max_identical_blockers_without_progress
+                            ),
+                        ),
+                        event=ResolverEvent(
+                            kind="snapshot",
+                            progress_signature=progress_signature,
+                        ),
+                    )
+                    self._classification = transition.decision.classification
+                transition_reason = (
+                    transition.decision.reason_code
+                    if transition is not None
+                    else _text(decision.get("reasonCode"))
+                )
                 self._record_timeline(
-                    "gate_classified", reasonCode=decision.get("reasonCode")
+                    "gate_classified",
+                    reasonCode=transition_reason,
                 )
 
                 if self._classification == "already_merged":
@@ -484,6 +555,24 @@ class MoonMindPRResolverWorkflow:
                         )
                     self._classification = "mergeability_transient"
 
+                if transition_reason == "finalize_budget_exhausted":
+                    self._state = "failed"
+                    return await self._publish_terminal(
+                        status="failed",
+                        reason_code="finalize_budget_exhausted",
+                        reason="PR merge finalize-attempt budget was exhausted.",
+                    )
+                if transition_reason == "repeated_blocker_without_progress":
+                    self._state = "manual_review"
+                    return await self._publish_terminal(
+                        status="manual_review",
+                        reason_code="repeated_blocker_without_progress",
+                        reason=(
+                            "The same actionable blocker repeated without a remote "
+                            "head change."
+                        ),
+                    )
+
                 if self._classification == "ready_to_merge":
                     if self._input.shadow_mode:
                         self._state = "shadow_complete"
@@ -492,15 +581,23 @@ class MoonMindPRResolverWorkflow:
                             reason_code="shadow_ready_to_merge",
                             reason="Shadow resolver classified the pull request as ready; mutations were disabled.",
                         )
-                    if self._finalize_attempts >= self._input.policy.max_finalize_attempts:
-                        self._state = "failed"
-                        return await self._publish_terminal(
-                            status="failed",
-                            reason_code="finalize_budget_exhausted",
-                            reason="PR merge finalize-attempt budget was exhausted.",
-                        )
+                    if transition is None:
+                        if (
+                            self._finalize_attempts
+                            >= self._input.policy.max_finalize_attempts
+                        ):
+                            self._state = "failed"
+                            return await self._publish_terminal(
+                                status="failed",
+                                reason_code="finalize_budget_exhausted",
+                                reason=(
+                                    "PR merge finalize-attempt budget was exhausted."
+                                ),
+                            )
+                        self._finalize_attempts += 1
+                    else:
+                        self._finalize_attempts = transition.state.finalize_attempts
                     self._state = "finalize_merge"
-                    self._finalize_attempts += 1
                     self._record_timeline(
                         "finalize_started", attempt=self._finalize_attempts
                     )
@@ -552,38 +649,28 @@ class MoonMindPRResolverWorkflow:
                             reason="Pull request merge was independently verified on GitHub.",
                             merge_sha=(
                                 _text(verified.get("mergeSha"))
-                                or (_text(finalize.get("mergeSha")) if isinstance(finalize, Mapping) else "")
+                                or (
+                                    _text(finalize.get("mergeSha"))
+                                    if isinstance(finalize, Mapping)
+                                    else ""
+                                )
                                 or None
                             ),
                         )
-                    await workflow.sleep(timedelta(seconds=self._input.policy.poll_interval_seconds))
+                    await workflow.sleep(
+                        timedelta(seconds=self._input.policy.poll_interval_seconds)
+                    )
                     continue
 
                 if self._classification in WAIT_CLASSIFICATIONS:
                     self._state = "durable_wait"
-                    await workflow.sleep(timedelta(seconds=self._input.policy.poll_interval_seconds))
+                    await workflow.sleep(
+                        timedelta(seconds=self._input.policy.poll_interval_seconds)
+                    )
                     continue
 
                 skill = REMEDIATION_SKILLS.get(self._classification or "")
                 if skill is not None:
-                    signature = blocker_progress_signature(snapshot, self._classification or "")
-                    if signature == self._last_progress_signature:
-                        self._identical_no_progress_count += 1
-                    else:
-                        self._last_progress_signature = signature
-                        self._identical_no_progress_count = 0
-                    if (
-                        self._identical_no_progress_count
-                        >= self._input.policy.max_identical_blockers_without_progress
-                        or self._remediation_counts[skill]
-                        >= self._input.policy.max_remediations_per_type
-                    ):
-                        self._state = "manual_review"
-                        return await self._publish_terminal(
-                            status="manual_review",
-                            reason_code="repeated_blocker_without_progress",
-                            reason="The same actionable blocker repeated without a remote head change.",
-                        )
                     if self._input.shadow_mode:
                         self._state = "shadow_complete"
                         return await self._publish_terminal(
@@ -591,7 +678,38 @@ class MoonMindPRResolverWorkflow:
                             reason_code=f"shadow_{self._classification}",
                             reason=f"Shadow resolver selected {skill}; child dispatch was disabled.",
                         )
-                    self._remediation_counts[skill] += 1
+                    if transition is None:
+                        if progress_signature == self._last_progress_signature:
+                            self._identical_no_progress_count += 1
+                        else:
+                            self._last_progress_signature = progress_signature
+                            self._identical_no_progress_count = 0
+                        if (
+                            self._identical_no_progress_count
+                            >= self._input.policy.max_identical_blockers_without_progress
+                            or self._remediation_counts[skill]
+                            >= self._input.policy.max_remediations_per_type
+                        ):
+                            self._state = "manual_review"
+                            return await self._publish_terminal(
+                                status="manual_review",
+                                reason_code="repeated_blocker_without_progress",
+                                reason=(
+                                    "The same actionable blocker repeated without "
+                                    "a remote head change."
+                                ),
+                            )
+                        self._remediation_counts[skill] += 1
+                    else:
+                        self._remediation_counts = dict(
+                            transition.state.remediation_counts
+                        )
+                        self._identical_no_progress_count = (
+                            transition.state.identical_blocker_count
+                        )
+                        self._last_progress_signature = (
+                            transition.state.last_progress_signature
+                        )
                     request = self._remediation_request(skill=skill, snapshot=snapshot)
                     child_id = (
                         f"{workflow.info().workflow_id}:remediation:{skill}:"
@@ -620,7 +738,8 @@ class MoonMindPRResolverWorkflow:
                         childWorkflowId=child_id,
                     )
                     failure = (
-                        child_result.get("failureClass") or child_result.get("failure_class")
+                        child_result.get("failureClass")
+                        or child_result.get("failure_class")
                         if isinstance(child_result, Mapping)
                         else getattr(child_result, "failure_class", None)
                     )
@@ -646,7 +765,11 @@ class MoonMindPRResolverWorkflow:
                         start_to_close_timeout=timedelta(minutes=2),
                         retry_policy=ACTIVITY_RETRY_POLICY,
                     )
-                    observed = _text(verified.get("headSha")) if isinstance(verified, Mapping) else ""
+                    observed = (
+                        _text(verified.get("headSha"))
+                        if isinstance(verified, Mapping)
+                        else ""
+                    )
                     if observed and observed != previous_head:
                         self._head_sha = observed
                         self._last_progress_signature = None

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -623,6 +623,20 @@ RUN_TRUSTED_PR_RESOLVER_NATIVE_BINDING_PATCH = (
 RUN_PR_RESOLVER_SELECTOR_RESOLUTION_PATCH = (
     "run-pr-resolver-selector-resolution-v1"
 )
+
+
+def _worker_capability_unavailable_error(
+    worker_capability: Mapping[str, Any],
+) -> exceptions.ApplicationError:
+    return exceptions.ApplicationError(
+        "MoonMind.PRResolver worker capability is unavailable; "
+        "no resolver or remediation agent was launched.",
+        dict(worker_capability),
+        type="WORKER_CAPABILITY_UNAVAILABLE",
+        non_retryable=True,
+    )
+
+
 MM_STARTED_AT_SEARCH_ATTRIBUTE = "mm_started_at"
 _PROFILE_SYNC_RUNTIME_IDS = ("codex_cli", "claude_code")
 _MANAGED_AGENT_IDS = frozenset(
@@ -8558,12 +8572,8 @@ class MoonMindRunWorkflow:
                                             else {}
                                         )
                                         if not worker_capability.get("available"):
-                                            raise exceptions.ApplicationError(
-                                                "MoonMind.PRResolver worker capability is unavailable; "
-                                                "no resolver or remediation agent was launched.",
-                                                type="WORKER_CAPABILITY_UNAVAILABLE",
-                                                non_retryable=True,
-                                                details=[worker_capability],
+                                            raise _worker_capability_unavailable_error(
+                                                worker_capability
                                             )
                                     resolved_pull_request = None
                                     merge_gate = parameters.get("mergeGate")

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -61,7 +61,6 @@ with workflow.unsafe.imports_passed_through():
         build_execution_context_bundle,
         build_prepared_input_manifest,
         build_recovery_prepared_artifact_refs,
-        merge_prepared_input_refs,
         merge_prepared_raw_input_refs,
         select_step_prepared_context,
     )
@@ -85,6 +84,9 @@ with workflow.unsafe.imports_passed_through():
     from moonmind.workflows.temporal.workflows.pr_resolver import (
         build_pr_resolver_start_input,
         pr_resolver_identity_selector,
+    )
+    from moonmind.workflows.temporal.native_skill_bindings import (
+        evaluate_pr_resolver_native_binding,
     )
     from moonmind.schemas.temporal_models import (
         DependencyResolvedSignalPayload,
@@ -609,6 +611,15 @@ RUN_INCIDENT_RECONSTRUCTION_PATCH = "run-incident-reconstruction-v1"
 RUN_STATUS_MEMO_UPSERT_PATCH = "run-status-memo-upsert-v1"
 RUN_JSON_ARTIFACT_WRITE_COMPLETE_PATCH = "run-json-artifact-write-complete-v1"
 RUN_TEMPORAL_PR_RESOLVER_OWNERSHIP_PATCH = "run-temporal-pr-resolver-ownership-v1"
+RUN_PR_RESOLVER_CAPABILITY_PREFLIGHT_PATCH = (
+    "run-pr-resolver-capability-preflight-v1"
+)
+RUN_PR_RESOLVER_PUBLISH_EVIDENCE_REF_PATCH = (
+    "run-pr-resolver-publish-evidence-ref-v1"
+)
+RUN_TRUSTED_PR_RESOLVER_NATIVE_BINDING_PATCH = (
+    "run-trusted-pr-resolver-native-binding-v1"
+)
 RUN_PR_RESOLVER_SELECTOR_RESOLUTION_PATCH = (
     "run-pr-resolver-selector-resolution-v1"
 )
@@ -781,11 +792,14 @@ class MoonMindRunWorkflow:
             "SlotAcquisitionTimeout",
             "RATE_LIMITED",
         }
+        system_error_types = {"WORKER_CAPABILITY_UNAVAILABLE"}
         for app_type in reversed(application_types):
             if app_type in user_error_types:
                 return "user_error"
             if app_type in integration_error_types:
                 return "integration_error"
+            if app_type in system_error_types:
+                return "system_error"
 
         # Heuristic fallback based on the deepest root-cause type.
         root_type_name = root.__class__.__name__
@@ -913,6 +927,36 @@ class MoonMindRunWorkflow:
             ),
             "diagnosticsRef": self._coerce_text(diagnostics_ref, max_chars=400),
         }
+        current: BaseException | None = exc
+        for _ in range(20):
+            if current is None:
+                break
+            if (
+                isinstance(current, exceptions.ApplicationError)
+                and getattr(current, "type", None)
+                == "WORKER_CAPABILITY_UNAVAILABLE"
+            ):
+                diagnostic.update(
+                    {
+                        "reasonCode": "worker_capability_unavailable",
+                        "agentExecutionLaunched": False,
+                    }
+                )
+                details = getattr(current, "details", ()) or ()
+                detail = details[0] if details and isinstance(details[0], Mapping) else {}
+                for source_key, target_key in (
+                    ("workflowType", "workflowType"),
+                    ("taskQueue", "taskQueue"),
+                    ("registryFingerprint", "registryFingerprint"),
+                    ("observedWorkerBuilds", "observedWorkerBuilds"),
+                ):
+                    if detail.get(source_key) is not None:
+                        diagnostic[target_key] = detail[source_key]
+                break
+            next_exc = getattr(current, "cause", None)
+            if not isinstance(next_exc, BaseException):
+                next_exc = current.__cause__
+            current = next_exc
         # Drop empty optional keys to keep the structure compact.
         return {key: value for key, value in diagnostic.items() if value is not None}
 
@@ -1091,6 +1135,7 @@ class MoonMindRunWorkflow:
         self._dependency_last_failed_at: dict[str, str] = {}
         self._remediation_context: dict[str, Any] = {}
         self._remediation_policy: dict[str, Any] = {}
+        self._native_skill_binding_by_step: dict[str, dict[str, Any]] = {}
 
         # Artifact refs
         self._input_ref: Optional[str] = None
@@ -8423,12 +8468,47 @@ class MoonMindRunWorkflow:
                                     f"{child_workflow_id}:retry{system_retries}"
                                 )
                             temporal_pr_resolver = (
-                                str(selected_skill_for_repair or "").strip().lower()
-                                == "pr-resolver"
+                                bool(
+                                    self._native_skill_binding_by_step.get(
+                                        node_id, {}
+                                    ).get("eligible")
+                                )
                                 and workflow.patched(
                                     RUN_TEMPORAL_PR_RESOLVER_OWNERSHIP_PATCH
                                 )
                             )
+                            if (
+                                str(selected_skill_for_repair or "").strip().lower()
+                                == "pr-resolver"
+                            ):
+                                binding = self._native_skill_binding_by_step.get(
+                                    node_id,
+                                    {
+                                        "eligible": False,
+                                        "host": "cli",
+                                        "reasonCode": "resolved_skill_evidence_unavailable",
+                                        "identity": {},
+                                    },
+                                )
+                                self._publish_context["prResolverNativeBinding"] = dict(
+                                    binding
+                                )
+                                if not temporal_pr_resolver:
+                                    portable_note = (
+                                        "\n\nNative host decision: use the portable CLI host "
+                                        f"because {binding.get('reasonCode')}. Run the "
+                                        "portable pr-resolver loop and publish its terminal "
+                                        "evidence; do not substitute MoonMind's built-in "
+                                        "native implementation."
+                                    )
+                                    request = request.model_copy(
+                                        update={
+                                            "instruction_ref": (
+                                                str(request.instruction_ref or "")
+                                                + portable_note
+                                            )
+                                        }
+                                    )
                             if temporal_pr_resolver:
                                 child_workflow_id = f"{child_workflow_id}:pr-resolver"
                             self._active_agent_child_workflow_id = child_workflow_id
@@ -8446,6 +8526,33 @@ class MoonMindRunWorkflow:
                             )
                             try:
                                 if temporal_pr_resolver:
+                                    worker_capability: dict[str, Any] = {}
+                                    if workflow.patched(
+                                        RUN_PR_RESOLVER_CAPABILITY_PREFLIGHT_PATCH
+                                    ):
+                                        capability_result = await workflow.execute_activity(
+                                            "worker.verify_workflow_capability",
+                                            {
+                                                "workflowType": "MoonMind.PRResolver",
+                                                "taskQueue": self._workflow_child_task_queue(),
+                                            },
+                                            task_queue=INTEGRATIONS_TASK_QUEUE,
+                                            start_to_close_timeout=timedelta(seconds=15),
+                                            retry_policy=RetryPolicy(maximum_attempts=1),
+                                        )
+                                        worker_capability = (
+                                            dict(capability_result)
+                                            if isinstance(capability_result, Mapping)
+                                            else {}
+                                        )
+                                        if not worker_capability.get("available"):
+                                            raise exceptions.ApplicationError(
+                                                "MoonMind.PRResolver worker capability is unavailable; "
+                                                "no resolver or remediation agent was launched.",
+                                                type="WORKER_CAPABILITY_UNAVAILABLE",
+                                                non_retryable=True,
+                                                details=[worker_capability],
+                                            )
                                     resolved_pull_request = None
                                     merge_gate = parameters.get("mergeGate")
                                     merge_gate = (
@@ -8506,6 +8613,13 @@ class MoonMindRunWorkflow:
                                         principal=self._principal(),
                                         step_id=node_id,
                                         resolved_pull_request=resolved_pull_request,
+                                        implementation_identity=(
+                                            self._native_skill_binding_by_step.get(
+                                                node_id, {}
+                                            ).get("identity")
+                                            or {}
+                                        ),
+                                        worker_capability=worker_capability,
                                     )
                                     child_result = await workflow.execute_child_workflow(
                                         "MoonMind.PRResolver",
@@ -9784,6 +9898,11 @@ class MoonMindRunWorkflow:
 
     def _auto_publish_evidence_sources(self, result: Any) -> list[Mapping[str, Any]]:
         sources: list[Mapping[str, Any]] = []
+        if (
+            isinstance(result, Mapping)
+            and workflow.patched(RUN_PR_RESOLVER_PUBLISH_EVIDENCE_REF_PATCH)
+        ):
+            sources.append(result)
         outputs = self._effective_result_outputs(result)
         metadata = (
             self._effective_result_metadata(result)
@@ -9791,9 +9910,26 @@ class MoonMindRunWorkflow:
             else None
         )
         for source in (outputs, metadata):
-            if isinstance(source, Mapping):
+            if isinstance(source, Mapping) and source not in sources:
                 sources.append(source)
         return sources
+
+    @staticmethod
+    def _inline_auto_publish_evidence(value: Any) -> Any:
+        if isinstance(value, Mapping) or isinstance(value, bytes):
+            return value
+        if isinstance(value, str) and value.lstrip().startswith("{"):
+            return value
+        return None
+
+    @staticmethod
+    def _auto_publish_artifact_ref(value: Any) -> str | None:
+        if not isinstance(value, str):
+            return None
+        candidate = value.strip()
+        if candidate.startswith("art_") or candidate.startswith("artifact:"):
+            return candidate
+        return None
 
     def _activity_result_status(self, result: Any) -> str | None:
         raw_status = self._get_from_result(result, "status")
@@ -11793,9 +11929,13 @@ class MoonMindRunWorkflow:
         )
 
     async def _resolve_auto_publish_evidence_ref(self, execution_result: Any) -> None:
+        resolver_ref_contract = workflow.patched(
+            RUN_PR_RESOLVER_PUBLISH_EVIDENCE_REF_PATCH
+        )
         sources = self._auto_publish_evidence_sources(execution_result)
         if not sources:
             return
+        ref: Any = None
         for source in sources:
             for key in (
                 "publishResult",
@@ -11806,9 +11946,12 @@ class MoonMindRunWorkflow:
                 "auto_publish_evidence",
             ):
                 if key in source:
-                    return
-
-        ref: Any = None
+                    if not resolver_ref_contract:
+                        return
+                    value = source.get(key)
+                    if self._inline_auto_publish_evidence(value) is not None:
+                        return
+                    ref = self._auto_publish_artifact_ref(value) or ref
         for source in sources:
             output_refs = source.get("outputRefs") or source.get("output_refs")
             if not isinstance(output_refs, Mapping):
@@ -11818,6 +11961,10 @@ class MoonMindRunWorkflow:
                 or output_refs.get("publishResult")
                 or output_refs.get("publish_result")
             )
+            if resolver_ref_contract and not ref:
+                ref = output_refs.get("publishEvidence") or output_refs.get(
+                    "publish_evidence"
+                )
             if isinstance(ref, str) and ref.strip():
                 break
         if not isinstance(ref, str) or not ref.strip():
@@ -11842,6 +11989,9 @@ class MoonMindRunWorkflow:
         self._publish_context["autoPublishEvidence"] = evidence_payload
 
     def _record_auto_publish_result(self, execution_result: Any) -> None:
+        resolver_ref_contract = workflow.patched(
+            RUN_PR_RESOLVER_PUBLISH_EVIDENCE_REF_PATCH
+        )
         evidence_payload: Any = None
         for source in self._auto_publish_evidence_sources(execution_result):
             for key in (
@@ -11853,8 +12003,17 @@ class MoonMindRunWorkflow:
                 "auto_publish_evidence",
             ):
                 if key in source:
-                    evidence_payload = source.get(key)
-                    break
+                    value = source.get(key)
+                    if not resolver_ref_contract:
+                        evidence_payload = value
+                        break
+                    inline = self._inline_auto_publish_evidence(value)
+                    if inline is not None:
+                        evidence_payload = inline
+                        break
+                    ref = self._auto_publish_artifact_ref(value)
+                    if ref:
+                        self._publish_context["evidenceRef"] = ref
             if evidence_payload is None:
                 output_refs = source.get("outputRefs") or source.get("output_refs")
                 if isinstance(output_refs, Mapping):
@@ -11863,6 +12022,10 @@ class MoonMindRunWorkflow:
                         or output_refs.get("publishResult")
                         or output_refs.get("publish_result")
                     )
+                    if resolver_ref_contract and not ref:
+                        ref = output_refs.get("publishEvidence") or output_refs.get(
+                            "publish_evidence"
+                        )
                     if isinstance(ref, str) and ref.strip():
                         self._publish_context["evidenceRef"] = ref.strip()
                         break
@@ -13985,6 +14148,30 @@ class MoonMindRunWorkflow:
                     f"selected skill '{selected_skill}' was not resolved into the "
                     "agent skill snapshot"
                 )
+            if normalized_skill == "pr-resolver":
+                selected_entry = self._resolved_skillset_entry(
+                    resolved,
+                    normalized_skill,
+                )
+                if workflow.patched(RUN_TRUSTED_PR_RESOLVER_NATIVE_BINDING_PATCH):
+                    decision = evaluate_pr_resolver_native_binding(selected_entry)
+                    self._native_skill_binding_by_step[node_id] = {
+                        "eligible": decision.eligible,
+                        "host": decision.host,
+                        "reasonCode": decision.reason_code,
+                        "identity": dict(decision.identity),
+                    }
+                else:
+                    # Replay path for histories created before native routing was
+                    # bound to immutable resolved-skill evidence. Those histories
+                    # selected the native host by canonical name, so preserve that
+                    # child-workflow command only for their replay.
+                    self._native_skill_binding_by_step[node_id] = {
+                        "eligible": True,
+                        "host": "temporal",
+                        "reasonCode": "legacy_name_binding_replay",
+                        "identity": {},
+                    }
         manifest_ref = self._resolved_skillset_field(
             resolved,
             "manifest_ref",
@@ -14028,6 +14215,30 @@ class MoonMindRunWorkflow:
             if name:
                 names.add(name)
         return names
+
+    @staticmethod
+    def _resolved_skillset_entry(resolved: Any, skill_name: str) -> Any:
+        skills = (
+            resolved.get("skills")
+            if isinstance(resolved, WorkflowMapping)
+            else getattr(resolved, "skills", None)
+        )
+        if not isinstance(skills, Iterable) or isinstance(skills, (str, bytes)):
+            return None
+        normalized = str(skill_name or "").strip().lower()
+        for entry in skills:
+            raw_name = (
+                entry.get("skill_name")
+                or entry.get("skillName")
+                or entry.get("name")
+                if isinstance(entry, WorkflowMapping)
+                else getattr(entry, "skill_name", None)
+                or getattr(entry, "skillName", None)
+                or getattr(entry, "name", None)
+            )
+            if str(raw_name or "").strip().lower() == normalized:
+                return entry
+        return None
 
     @staticmethod
     def _resolved_skillset_field(resolved: Any, *keys: str) -> Any:

--- a/pr_resolver_core/__init__.py
+++ b/pr_resolver_core/__init__.py
@@ -1,0 +1,38 @@
+"""Provider-neutral PR resolver semantics shared by all execution hosts."""
+
+from .classify import classify_snapshot
+from .evidence import (
+    IMPLEMENTATION_CONTRACT,
+    RESOLVER_CORE_DIGEST,
+    RESOLVER_CORE_VERSION,
+    portable_terminal_evidence,
+)
+from .models import (
+    CanonicalPullRequestSnapshot,
+    ResolverAction,
+    ResolverDecision,
+    ResolverEvent,
+    ResolverPolicy,
+    ResolverState,
+    ResolverTransition,
+)
+from .normalize import normalize_portable_snapshot, normalize_temporal_snapshot
+from .transition import reduce_resolver_state
+
+__all__ = [
+    "CanonicalPullRequestSnapshot",
+    "IMPLEMENTATION_CONTRACT",
+    "RESOLVER_CORE_DIGEST",
+    "RESOLVER_CORE_VERSION",
+    "ResolverAction",
+    "ResolverDecision",
+    "ResolverEvent",
+    "ResolverPolicy",
+    "ResolverState",
+    "ResolverTransition",
+    "classify_snapshot",
+    "normalize_portable_snapshot",
+    "normalize_temporal_snapshot",
+    "portable_terminal_evidence",
+    "reduce_resolver_state",
+]

--- a/pr_resolver_core/classify.py
+++ b/pr_resolver_core/classify.py
@@ -1,0 +1,100 @@
+"""Pure, fail-closed resolver classification."""
+
+from __future__ import annotations
+
+from .models import CanonicalPullRequestSnapshot, ResolverAction, ResolverDecision
+
+
+_REMEDIATIONS = {
+    "actionable_comments": "fix-comments",
+    "ci_failures": "fix-ci",
+    "merge_conflicts": "fix-merge-conflicts",
+}
+
+
+def _decision(
+    classification: str,
+    reason_code: str,
+    action: ResolverAction,
+    *,
+    terminal_status: str | None = None,
+) -> ResolverDecision:
+    return ResolverDecision(
+        classification=classification,
+        reason_code=reason_code,
+        action=action,
+        remediation_skill=_REMEDIATIONS.get(classification),
+        terminal_status=terminal_status,
+    )
+
+
+def classify_snapshot(snapshot: CanonicalPullRequestSnapshot) -> ResolverDecision:
+    if snapshot.merged:
+        return _decision(
+            "already_merged",
+            "already_merged",
+            ResolverAction.PUBLISH_TERMINAL,
+            terminal_status="already_merged",
+        )
+    if not snapshot.open:
+        return _decision(
+            "manual_review",
+            "pull_request_closed",
+            ResolverAction.STOP_MANUAL_REVIEW,
+            terminal_status="manual_review",
+        )
+    if snapshot.draft:
+        return _decision("manual_review", "draft", ResolverAction.STOP_MANUAL_REVIEW)
+    if not snapshot.publish_available:
+        return _decision(
+            "manual_review", "publish_unavailable", ResolverAction.STOP_MANUAL_REVIEW
+        )
+    if snapshot.merge_conflict:
+        return _decision(
+            "merge_conflicts", "merge_conflicts", ResolverAction.RUN_REMEDIATION
+        )
+    if not snapshot.comments_available:
+        return _decision(
+            "manual_review", "comments_unavailable", ResolverAction.STOP_MANUAL_REVIEW
+        )
+    if not snapshot.comment_policy_enforced:
+        return _decision(
+            "manual_review",
+            "comment_policy_not_enforced",
+            ResolverAction.STOP_MANUAL_REVIEW,
+        )
+    if snapshot.checks_degraded:
+        return _decision(
+            "manual_review", "ci_signal_degraded", ResolverAction.STOP_MANUAL_REVIEW
+        )
+    if snapshot.unknown_blocker:
+        return _decision(
+            "manual_review", "unknown_blocker", ResolverAction.STOP_MANUAL_REVIEW
+        )
+    if snapshot.actionable_comments:
+        return _decision(
+            "actionable_comments", "actionable_comments", ResolverAction.RUN_REMEDIATION
+        )
+    if snapshot.checks_complete and not snapshot.checks_passing:
+        return _decision("ci_failures", "ci_failures", ResolverAction.RUN_REMEDIATION)
+    if snapshot.automated_review_pending:
+        return _decision("review_grace", "review_grace", ResolverAction.WAIT)
+    if snapshot.checks_signal_available and not snapshot.checks_complete:
+        return _decision("ci_running", "ci_running", ResolverAction.WAIT)
+    if snapshot.mergeability_unknown:
+        return _decision(
+            "mergeability_transient", "external_state_transient", ResolverAction.WAIT
+        )
+    if not snapshot.checks_complete:
+        return _decision("ci_running", "ci_running", ResolverAction.WAIT)
+    if snapshot.malformed:
+        return _decision(
+            "manual_review", "snapshot_malformed", ResolverAction.STOP_MANUAL_REVIEW
+        )
+    if snapshot.checks_passing:
+        return _decision(
+            "ready_to_merge", "ready_to_merge", ResolverAction.ATTEMPT_MERGE
+        )
+    return _decision(
+        "manual_review", "unknown_blocker", ResolverAction.STOP_MANUAL_REVIEW
+    )

--- a/pr_resolver_core/classify.py
+++ b/pr_resolver_core/classify.py
@@ -71,6 +71,10 @@ def classify_snapshot(snapshot: CanonicalPullRequestSnapshot) -> ResolverDecisio
         return _decision(
             "manual_review", "unknown_blocker", ResolverAction.STOP_MANUAL_REVIEW
         )
+    if snapshot.malformed:
+        return _decision(
+            "manual_review", "snapshot_malformed", ResolverAction.STOP_MANUAL_REVIEW
+        )
     if snapshot.actionable_comments:
         return _decision(
             "actionable_comments", "actionable_comments", ResolverAction.RUN_REMEDIATION
@@ -87,10 +91,6 @@ def classify_snapshot(snapshot: CanonicalPullRequestSnapshot) -> ResolverDecisio
         )
     if not snapshot.checks_complete:
         return _decision("ci_running", "ci_running", ResolverAction.WAIT)
-    if snapshot.malformed:
-        return _decision(
-            "manual_review", "snapshot_malformed", ResolverAction.STOP_MANUAL_REVIEW
-        )
     if snapshot.checks_passing:
         return _decision(
             "ready_to_merge", "ready_to_merge", ResolverAction.ATTEMPT_MERGE

--- a/pr_resolver_core/evidence.py
+++ b/pr_resolver_core/evidence.py
@@ -12,7 +12,7 @@ RESOLVER_CORE_VERSION = "1.0.0"
 # order. It is deliberately embedded in the immutable package so workflow code
 # never reads mutable filesystem state during replay.
 RESOLVER_CORE_DIGEST = (
-    "sha256:e00fde695ee11f2151d78d89e41314c2fb63df3ce9e73544a1ffb84bcb0bc944"
+    "sha256:d8ed19dc1595c09b78e77f3f3b2164e675150fa6e33d8d748bacaa2fc5f3a522"
 )
 
 

--- a/pr_resolver_core/evidence.py
+++ b/pr_resolver_core/evidence.py
@@ -1,0 +1,45 @@
+"""Portable terminal evidence and immutable resolver implementation identity."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+import json
+from typing import Any
+
+IMPLEMENTATION_CONTRACT = "pr-resolver-core/v1"
+RESOLVER_CORE_VERSION = "1.0.0"
+# SHA-256 over models.py + normalize.py + classify.py + transition.py in that
+# order. It is deliberately embedded in the immutable package so workflow code
+# never reads mutable filesystem state during replay.
+RESOLVER_CORE_DIGEST = (
+    "sha256:90127b2d639a1842558ea6d65c25535bb6ab9a4c14da80b111b6d050b081734f"
+)
+
+
+def portable_terminal_evidence(
+    *,
+    status: str,
+    reason_code: str,
+    repository: str,
+    pr_number: int,
+    pr_url: str,
+    verified_head_sha: str | None,
+    verified_merge_sha: str | None,
+    extensions: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "schemaVersion": 4,
+        "implementationContract": IMPLEMENTATION_CONTRACT,
+        "resolverCoreVersion": RESOLVER_CORE_VERSION,
+        "resolverCoreDigest": RESOLVER_CORE_DIGEST,
+        "status": status,
+        "reasonCode": reason_code,
+        "repository": repository,
+        "prNumber": pr_number,
+        "prUrl": pr_url,
+        "verifiedHeadSha": verified_head_sha,
+        "verifiedMergeSha": verified_merge_sha,
+    }
+    if extensions:
+        payload["extensions"] = json.loads(json.dumps(dict(extensions), default=str))
+    return payload

--- a/pr_resolver_core/evidence.py
+++ b/pr_resolver_core/evidence.py
@@ -12,7 +12,7 @@ RESOLVER_CORE_VERSION = "1.0.0"
 # order. It is deliberately embedded in the immutable package so workflow code
 # never reads mutable filesystem state during replay.
 RESOLVER_CORE_DIGEST = (
-    "sha256:90127b2d639a1842558ea6d65c25535bb6ab9a4c14da80b111b6d050b081734f"
+    "sha256:e00fde695ee11f2151d78d89e41314c2fb63df3ce9e73544a1ffb84bcb0bc944"
 )
 
 

--- a/pr_resolver_core/models.py
+++ b/pr_resolver_core/models.py
@@ -1,0 +1,83 @@
+"""Pure resolver models with no provider, host, or persistence dependencies."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+
+
+class ResolverAction(str, Enum):
+    READ_SNAPSHOT = "read_snapshot"
+    WAIT = "wait"
+    RUN_REMEDIATION = "run_remediation"
+    ATTEMPT_MERGE = "attempt_merge"
+    PUBLISH_TERMINAL = "publish_terminal"
+    STOP_MANUAL_REVIEW = "stop_manual_review"
+
+
+@dataclass(frozen=True, slots=True)
+class CanonicalPullRequestSnapshot:
+    repository: str = ""
+    pr_number: int | None = None
+    pr_url: str = ""
+    head_sha: str = ""
+    base_sha: str = ""
+    merged: bool = False
+    open: bool = True
+    draft: bool = False
+    merge_conflict: bool = False
+    mergeability_unknown: bool = False
+    checks_complete: bool = False
+    checks_passing: bool = False
+    checks_degraded: bool = False
+    checks_signal_available: bool = False
+    actionable_comments: bool = False
+    comments_available: bool = True
+    comment_policy_enforced: bool = True
+    automated_review_pending: bool = False
+    publish_available: bool = True
+    malformed: bool = False
+    unknown_blocker: bool = False
+    blocker_kinds: tuple[str, ...] = ()
+    blocker_summaries: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class ResolverDecision:
+    classification: str
+    reason_code: str
+    action: ResolverAction
+    remediation_skill: str | None = None
+    terminal_status: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class ResolverPolicy:
+    max_finalize_attempts: int = 60
+    max_remediations_per_type: int = 2
+    max_identical_blockers_without_progress: int = 2
+
+
+@dataclass(frozen=True, slots=True)
+class ResolverState:
+    finalize_attempts: int = 0
+    remediation_counts: tuple[tuple[str, int], ...] = ()
+    identical_blocker_count: int = 0
+    last_progress_signature: str | None = None
+
+    def remediation_count(self, skill: str) -> int:
+        return dict(self.remediation_counts).get(skill, 0)
+
+
+@dataclass(frozen=True, slots=True)
+class ResolverEvent:
+    kind: str
+    progress_signature: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class ResolverTransition:
+    state: ResolverState
+    decision: ResolverDecision
+    action: ResolverAction
+    metadata: dict[str, str | int | bool | None] = field(default_factory=dict)

--- a/pr_resolver_core/normalize.py
+++ b/pr_resolver_core/normalize.py
@@ -1,0 +1,165 @@
+"""Normalize host/provider-shaped snapshots into one canonical model."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from .models import CanonicalPullRequestSnapshot
+
+
+def _text(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _bool(value: Any, default: bool = False) -> bool:
+    return value if isinstance(value, bool) else default
+
+
+def normalize_temporal_snapshot(
+    raw: Mapping[str, Any],
+) -> CanonicalPullRequestSnapshot:
+    blockers = tuple(
+        item for item in raw.get("blockers", ()) if isinstance(item, Mapping)
+    )
+    kinds = tuple(_text(item.get("kind")).lower() for item in blockers)
+    summaries = tuple(_text(item.get("summary")) for item in blockers)
+    checks_complete = raw.get("checksComplete")
+    checks_passing = raw.get("checksPassing")
+    recognized_blocker = bool(kinds)
+    ready = raw.get("ready") is True
+    malformed = not (
+        raw.get("pullRequestMerged") is True
+        or raw.get("pullRequestOpen") is False
+        or recognized_blocker
+        or isinstance(checks_complete, bool)
+        or ready
+    )
+    degraded_kinds = {
+        "checks_unavailable",
+        "readiness_evidence_unavailable",
+        "comments_unavailable",
+        "authentication_unavailable",
+        "publish_unavailable",
+    }
+    return CanonicalPullRequestSnapshot(
+        repository=_text(raw.get("repository")),
+        pr_number=raw.get("prNumber") if isinstance(raw.get("prNumber"), int) else None,
+        pr_url=_text(raw.get("prUrl")),
+        head_sha=_text(raw.get("headSha")),
+        base_sha=_text(raw.get("baseSha")),
+        merged=raw.get("pullRequestMerged") is True,
+        open=raw.get("pullRequestOpen") is not False,
+        draft=raw.get("draft") is True or "draft" in kinds,
+        merge_conflict=bool({"merge_conflict", "merge_conflicts"} & set(kinds)),
+        mergeability_unknown=bool(
+            {
+                "mergeability_unknown",
+                "mergeability_transient",
+                "external_state_unavailable",
+            }
+            & set(kinds)
+        ),
+        checks_complete=(ready or "checks_failed" in kinds or _bool(checks_complete)),
+        checks_passing=(
+            ready or ("checks_failed" not in kinds and _bool(checks_passing))
+        ),
+        checks_degraded=bool(degraded_kinds & set(kinds)),
+        checks_signal_available=isinstance(checks_complete, bool),
+        actionable_comments=(
+            "actionable_comments" in kinds
+            or any(
+                "requested changes" in summary.lower()
+                or "changes requested" in summary.lower()
+                for summary in summaries
+            )
+        ),
+        comments_available="comments_unavailable" not in kinds,
+        automated_review_pending="automated_review_pending" in kinds,
+        publish_available=not bool(
+            {"authentication_unavailable", "publish_unavailable"} & set(kinds)
+        ),
+        malformed=malformed,
+        unknown_blocker=bool(
+            set(kinds)
+            - {
+                "merge_conflict",
+                "merge_conflicts",
+                "checks_failed",
+                "checks_running",
+                "automated_review_pending",
+                "actionable_comments",
+                "mergeability_unknown",
+                "mergeability_transient",
+                "external_state_unavailable",
+                "checks_unavailable",
+                "readiness_evidence_unavailable",
+                "comments_unavailable",
+                "authentication_unavailable",
+                "publish_unavailable",
+                "draft",
+            }
+        ),
+        blocker_kinds=kinds,
+        blocker_summaries=summaries,
+    )
+
+
+def normalize_portable_snapshot(
+    raw: Mapping[str, Any],
+) -> CanonicalPullRequestSnapshot:
+    pr = raw.get("pr") if isinstance(raw.get("pr"), Mapping) else {}
+    ci = raw.get("ci") if isinstance(raw.get("ci"), Mapping) else {}
+    comments_fetch = (
+        raw.get("commentsFetch")
+        if isinstance(raw.get("commentsFetch"), Mapping)
+        else {}
+    )
+    comments_summary = (
+        raw.get("commentsSummary")
+        if isinstance(raw.get("commentsSummary"), Mapping)
+        else {}
+    )
+    state = _text(pr.get("state")).upper()
+    merge_state = _text(pr.get("mergeStateStatus")).upper()
+    mergeable = pr.get("mergeable")
+    mergeable_text = _text(mergeable).upper()
+    signal_quality = _text(ci.get("signalQuality")).lower()
+    grace = comments_summary.get("codexReviewGrace")
+    grace_active = isinstance(grace, Mapping) and grace.get("active") is True
+    required_shapes_present = bool(pr) and bool(ci) and bool(comments_fetch)
+    return CanonicalPullRequestSnapshot(
+        repository=_text(raw.get("repository")),
+        pr_number=pr.get("number") if isinstance(pr.get("number"), int) else None,
+        pr_url=_text(pr.get("url")),
+        head_sha=_text(pr.get("headRefOid") or raw.get("headSha")),
+        base_sha=_text(pr.get("baseRefOid") or raw.get("baseSha")),
+        merged=state == "MERGED",
+        open=state not in {"CLOSED", "MERGED"},
+        draft=pr.get("isDraft") is True,
+        merge_conflict=(
+            merge_state == "DIRTY"
+            or mergeable is False
+            or mergeable_text in {"CONFLICTING", "DIRTY", "CONFLICT"}
+        ),
+        mergeability_unknown=(
+            merge_state in {"UNKNOWN", "UNSTABLE", "BLOCKED"}
+            or mergeable_text in {"UNKNOWN", "UNSTABLE"}
+        ),
+        checks_complete=not _bool(ci.get("isRunning")),
+        checks_passing=(
+            not _bool(ci.get("hasFailures"))
+            and not _bool(ci.get("isRunning"))
+            and signal_quality in {"", "ok"}
+        ),
+        checks_degraded=signal_quality not in {"", "ok"},
+        checks_signal_available=bool(ci),
+        actionable_comments=_bool(comments_summary.get("hasActionableComments")),
+        comments_available=comments_fetch.get("succeeded") is True,
+        comment_policy_enforced=(
+            comments_summary.get("includeBotReviewComments") is True
+        ),
+        automated_review_pending=grace_active,
+        publish_available=raw.get("publishAvailable") is not False,
+        malformed=not required_shapes_present,
+    )

--- a/pr_resolver_core/normalize.py
+++ b/pr_resolver_core/normalize.py
@@ -20,7 +20,7 @@ def normalize_temporal_snapshot(
     raw: Mapping[str, Any],
 ) -> CanonicalPullRequestSnapshot:
     blockers = tuple(
-        item for item in raw.get("blockers", ()) if isinstance(item, Mapping)
+        item for item in (raw.get("blockers") or ()) if isinstance(item, Mapping)
     )
     kinds = tuple(_text(item.get("kind")).lower() for item in blockers)
     summaries = tuple(_text(item.get("summary")) for item in blockers)

--- a/pr_resolver_core/normalize.py
+++ b/pr_resolver_core/normalize.py
@@ -24,6 +24,11 @@ def normalize_temporal_snapshot(
     )
     kinds = tuple(_text(item.get("kind")).lower() for item in blockers)
     summaries = tuple(_text(item.get("summary")) for item in blockers)
+    non_retryable_external_state = any(
+        _text(item.get("kind")).lower() == "external_state_unavailable"
+        and item.get("retryable") is False
+        for item in blockers
+    )
     checks_complete = raw.get("checksComplete")
     checks_passing = raw.get("checksPassing")
     recognized_blocker = bool(kinds)
@@ -56,9 +61,12 @@ def normalize_temporal_snapshot(
             {
                 "mergeability_unknown",
                 "mergeability_transient",
-                "external_state_unavailable",
             }
             & set(kinds)
+        )
+        or (
+            "external_state_unavailable" in kinds
+            and not non_retryable_external_state
         ),
         checks_complete=(ready or "checks_failed" in kinds or _bool(checks_complete)),
         checks_passing=(
@@ -99,7 +107,8 @@ def normalize_temporal_snapshot(
                 "publish_unavailable",
                 "draft",
             }
-        ),
+        )
+        or non_retryable_external_state,
         blocker_kinds=kinds,
         blocker_summaries=summaries,
     )

--- a/pr_resolver_core/transition.py
+++ b/pr_resolver_core/transition.py
@@ -1,0 +1,78 @@
+"""Host-neutral resolver state reducer."""
+
+from __future__ import annotations
+
+from .models import (
+    CanonicalPullRequestSnapshot,
+    ResolverAction,
+    ResolverEvent,
+    ResolverPolicy,
+    ResolverState,
+    ResolverTransition,
+)
+from .classify import classify_snapshot
+
+
+def reduce_resolver_state(
+    *,
+    previous_state: ResolverState,
+    snapshot: CanonicalPullRequestSnapshot,
+    policy: ResolverPolicy,
+    event: ResolverEvent,
+) -> ResolverTransition:
+    decision = classify_snapshot(snapshot)
+    state = previous_state
+    metadata: dict[str, str | int | bool | None] = {}
+
+    if decision.action is ResolverAction.ATTEMPT_MERGE:
+        if previous_state.finalize_attempts >= policy.max_finalize_attempts:
+            decision = decision.__class__(
+                classification="manual_review",
+                reason_code="finalize_budget_exhausted",
+                action=ResolverAction.STOP_MANUAL_REVIEW,
+                terminal_status="manual_review",
+            )
+        else:
+            state = ResolverState(
+                finalize_attempts=previous_state.finalize_attempts + 1,
+                remediation_counts=previous_state.remediation_counts,
+                identical_blocker_count=previous_state.identical_blocker_count,
+                last_progress_signature=previous_state.last_progress_signature,
+            )
+    elif decision.action is ResolverAction.RUN_REMEDIATION:
+        skill = decision.remediation_skill or ""
+        signature = event.progress_signature
+        identical = (
+            previous_state.identical_blocker_count + 1
+            if signature and signature == previous_state.last_progress_signature
+            else 0
+        )
+        current_count = previous_state.remediation_count(skill)
+        if (
+            identical >= policy.max_identical_blockers_without_progress
+            or current_count >= policy.max_remediations_per_type
+        ):
+            decision = decision.__class__(
+                classification="manual_review",
+                reason_code="repeated_blocker_without_progress",
+                action=ResolverAction.STOP_MANUAL_REVIEW,
+                terminal_status="manual_review",
+            )
+        else:
+            counts = dict(previous_state.remediation_counts)
+            counts[skill] = current_count + 1
+            state = ResolverState(
+                finalize_attempts=previous_state.finalize_attempts,
+                remediation_counts=tuple(sorted(counts.items())),
+                identical_blocker_count=identical,
+                last_progress_signature=signature,
+            )
+            metadata["remediationSkill"] = skill
+            metadata["remediationAttempt"] = counts[skill]
+
+    return ResolverTransition(
+        state=state,
+        decision=decision,
+        action=decision.action,
+        metadata=metadata,
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "MoonMind RAG application and supporting tools."
 readme = "README.md"
 license = "Apache-2.0"
 authors = ["MoonMind Contributors <opensource@moonmind.ai>"]
-packages = [{ include = "moonmind" }]
+packages = [{ include = "moonmind" }, { include = "pr_resolver_core" }]
 
 [tool.poetry.dependencies]
 python = ">=3.10,<3.14"

--- a/services/temporal/scripts/start-workflow-worker-group.py
+++ b/services/temporal/scripts/start-workflow-worker-group.py
@@ -76,6 +76,8 @@ class GroupHealthState:
         ]
         if len(children) != len(self.child_health_urls):
             return False
+        if not all(child.get("ready") is True for child in children):
+            return False
         fingerprints = {
             str(child.get("registryFingerprint"))
             for child in children

--- a/services/temporal/scripts/start-workflow-worker-group.py
+++ b/services/temporal/scripts/start-workflow-worker-group.py
@@ -61,10 +61,37 @@ class GroupHealthState:
     child_health_urls: Sequence[str] = ()
     shutting_down: bool = False
 
-    def is_healthy(self) -> bool:
+    def is_live(self) -> bool:
         return not self.shutting_down and all(
             child.poll() is None for child in self.children
-        ) and all(_probe_child_health(url) for url in self.child_health_urls)
+        )
+
+    def is_ready(self) -> bool:
+        if not self.is_live():
+            return False
+        children = [
+            payload
+            for url in self.child_health_urls
+            if (payload := _read_child_readiness(url)) is not None
+        ]
+        if len(children) != len(self.child_health_urls):
+            return False
+        fingerprints = {
+            str(child.get("registryFingerprint"))
+            for child in children
+            if child.get("registryFingerprint")
+        }
+        build_ids = {
+            str(child.get("buildId"))
+            for child in children
+            if child.get("buildId")
+        }
+        return len(fingerprints) <= 1 and len(build_ids) <= 1
+
+    def is_healthy(self) -> bool:
+        """Backward-compatible internal name; Compose now probes readiness."""
+
+        return self.is_ready()
 
 
 def _env_default(env: Mapping[str, str], name: str, default: str) -> str:
@@ -138,7 +165,7 @@ def _child_prometheus_bind_address(
 
 
 def _child_health_url(role: WorkerRole) -> str:
-    return f"http://127.0.0.1:{_child_healthcheck_port(role)}/healthz"
+    return f"http://127.0.0.1:{_child_healthcheck_port(role)}/readyz"
 
 
 def start_child_process(role: WorkerRole) -> WorkerProcess:
@@ -182,26 +209,70 @@ def _format_child_log_line(role_name: str, line: str) -> str:
     return json.dumps(payload, separators=(",", ":")) + trailing_newline
 
 
-def _probe_child_health(url: str, *, timeout_seconds: float = 0.5) -> bool:
+def _read_child_readiness(
+    url: str, *, timeout_seconds: float = 0.5
+) -> dict[str, object] | None:
     try:
         with urllib.request.urlopen(url, timeout=timeout_seconds) as response:
-            return 200 <= response.status < 300
-    except (OSError, urllib.error.URLError, TimeoutError):
-        return False
+            payload = json.loads(response.read())
+        return payload if isinstance(payload, dict) else None
+    except (OSError, ValueError, urllib.error.URLError, TimeoutError):
+        return None
 
 
 class _HealthHandler(BaseHTTPRequestHandler):
     def do_GET(self) -> None:  # noqa: N802 - stdlib handler API
         state: GroupHealthState = self.server.state  # type: ignore[attr-defined]
-        healthy = state.is_healthy()
+        readiness = self.path == "/readyz"
+        healthy = state.is_ready() if readiness else state.is_live()
         status = 200 if healthy else 503
-        payload = json.dumps(
-            {
-                "status": "ok" if healthy else "unhealthy",
-                "workers": len(state.children),
-                "shutting_down": state.shutting_down,
-            }
-        ).encode("utf-8")
+        body: dict[str, object] = {
+            "status": (
+                "ready" if readiness and healthy else "ok" if healthy else "unhealthy"
+            ),
+            "live": state.is_live(),
+            "ready": state.is_ready(),
+            "workers": len(state.children),
+            "shutting_down": state.shutting_down,
+        }
+        if readiness:
+            children = [
+                payload
+                for url in state.child_health_urls
+                if (payload := _read_child_readiness(url)) is not None
+            ]
+            body["children"] = children
+            workflow_types = sorted(
+                {
+                    str(item)
+                    for child in children
+                    for item in child.get("workflowTypes", [])
+                }
+            )
+            task_queues = sorted(
+                {
+                    str(item)
+                    for child in children
+                    for item in child.get("taskQueues", [])
+                }
+            )
+            body["workflowTypes"] = workflow_types
+            body["taskQueues"] = task_queues
+            body["registryFingerprints"] = sorted(
+                {
+                    str(child.get("registryFingerprint"))
+                    for child in children
+                    if child.get("registryFingerprint")
+                }
+            )
+            body["buildIds"] = sorted(
+                {
+                    str(child.get("buildId"))
+                    for child in children
+                    if child.get("buildId")
+                }
+            )
+        payload = json.dumps(body).encode("utf-8")
         self.send_response(status)
         self.send_header("Content-Type", "application/json")
         self.send_header("Connection", "close")

--- a/tests/integration/temporal/test_compose_foundation.py
+++ b/tests/integration/temporal/test_compose_foundation.py
@@ -287,6 +287,19 @@ def test_workflow_worker_service_supervises_normal_and_merge_automation_roles():
     assert workflow_env["TEMPORAL_MERGE_AUTOMATION_WORKFLOW_WORKER_CONCURRENCY"] == (
         "${TEMPORAL_MERGE_AUTOMATION_WORKFLOW_WORKER_CONCURRENCY:-2}"
     )
+    assert workflow_env["TEMPORAL_WORKER_VERSIONING_ENABLED"] == (
+        "${TEMPORAL_WORKER_VERSIONING_ENABLED:-false}"
+    )
+    assert workflow_env["MOONMIND_DEPLOYMENT_MODE"] == (
+        "${MOONMIND_DEPLOYMENT_MODE:-development}"
+    )
+    assert workflow_env["TEMPORAL_WORKFLOW_READINESS_URL"] == (
+        "${TEMPORAL_WORKFLOW_READINESS_URL:-http://temporal-worker-workflow:8080/readyz}"
+    )
+    healthcheck = " ".join(
+        str(part) for part in workflow_worker["healthcheck"]["test"]
+    )
+    assert "http://localhost:8080/readyz" in healthcheck
 
 
 def test_sandbox_worker_compose_egress_is_restricted_for_mm_785():
@@ -531,6 +544,7 @@ def test_runtime_image_includes_agent_skill_sources():
     )
 
     assert "COPY .agents /app/.agents/" in dockerfile
+    assert "COPY pr_resolver_core /app/pr_resolver_core/" in dockerfile
 
 
 def test_omnigent_shared_postgres_compose_topology_for_mm_970():

--- a/tests/integration/workflows/temporal/workflows/test_pr_resolver_registration_boundary.py
+++ b/tests/integration/workflows/temporal/workflows/test_pr_resolver_registration_boundary.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+import uuid
+
+import pytest
+from temporalio import workflow
+from temporalio.testing import WorkflowEnvironment
+from temporalio.worker import UnsandboxedWorkflowRunner, Worker
+
+from moonmind.workflows.temporal.workflows.pr_resolver import (
+    MoonMindPRResolverWorkflow,
+)
+
+
+@workflow.defn(name="Test.PRResolverParent")
+class _ParentWorkflow:
+    @workflow.run
+    async def run(self, payload: dict[str, Any]) -> dict[str, Any]:
+        return await workflow.execute_child_workflow(
+            "MoonMind.PRResolver",
+            payload,
+            id=f"{workflow.info().workflow_id}:resolver",
+            task_queue=workflow.info().task_queue,
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.temporal_boundary
+async def test_real_worker_accepts_parent_to_pr_resolver_child_boundary() -> None:
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        queue = f"pr-resolver-canary-{uuid.uuid4()}"
+        async with Worker(
+            env.client,
+            task_queue=queue,
+            workflows=[_ParentWorkflow, MoonMindPRResolverWorkflow],
+            workflow_runner=UnsandboxedWorkflowRunner(),
+        ):
+            workflow_id = f"canary-{uuid.uuid4()}"
+            handle = await env.client.start_workflow(
+                "Test.PRResolverParent",
+                {
+                    "workflowType": "MoonMind.PRResolver",
+                    "parentWorkflowId": workflow_id,
+                    "principal": "canary",
+                    "repository": "canary/no-mutation",
+                    "prNumber": 1,
+                    "prUrl": "https://example.invalid/canary/pull/1",
+                    "stepId": "canary",
+                    "correlationId": workflow_id,
+                    "baseAgentRequest": {"canary": True},
+                    "canaryMode": True,
+                },
+                id=workflow_id,
+                task_queue=queue,
+            )
+            result = await asyncio.wait_for(handle.result(), timeout=15)
+    assert result["metadata"]["canary"] is True
+    assert result["metadata"]["workflowType"] == "MoonMind.PRResolver"

--- a/tests/unit/docs/test_final_docs_cleanup_policy.py
+++ b/tests/unit/docs/test_final_docs_cleanup_policy.py
@@ -57,7 +57,11 @@ def test_canonical_docs_are_declarative_not_migration_tracking_surfaces() -> Non
         text = _read(path)
         assert "Implementation tracking:" not in text, path
         assert "migration checklists in canonical `docs/`" not in text, path
-        assert "Last updated: 2026-06-13" in text or "Last Updated: 2026-06-13" in text, path
+        assert re.search(
+            r"^Last [Uu]pdated: 20\d{2}-\d{2}-\d{2}$",
+            text,
+            flags=re.MULTILINE,
+        ), path
 
     assert "**Status:** Draft" not in _read(RUN_HISTORY_DOC)
     assert "Status: Normative" in _read(LEDGER_DOC)

--- a/tests/unit/services/test_skill_resolution.py
+++ b/tests/unit/services/test_skill_resolution.py
@@ -96,6 +96,20 @@ async def test_built_in_loader_discovers_packaged_agent_skills():
     assert discovered["moonspec-breakdown"].provenance.source_kind == AgentSkillSourceKind.BUILT_IN
     assert discovered["moonspec-breakdown"].provenance.source_path
 
+
+async def test_built_in_pr_resolver_declares_portable_native_contract():
+    results = await BuiltInSkillLoader().load_skills(
+        SkillSelector(include=[{"name": "pr-resolver"}]),
+        SkillResolutionContext(snapshot_id="snap-pr-resolver"),
+    )
+
+    entry = next(item for item in results if item.skill_name == "pr-resolver")
+    assert entry.implementation is not None
+    assert entry.implementation.contract == "pr-resolver-core/v1"
+    assert entry.implementation.supported_hosts == ["cli", "temporal"]
+    assert entry.implementation.native_host_eligible is True
+    assert entry.provenance.source_kind == AgentSkillSourceKind.BUILT_IN
+
 async def test_built_in_loader_resolves_batch_dependabot_resolver_by_name(tmp_path):
     """FR-012: batch-dependabot-resolver MUST be resolvable by name through the
     built-in fallback list so a recurring queue_task schedule can target it.

--- a/tests/unit/test_docker_publish_workflow.py
+++ b/tests/unit/test_docker_publish_workflow.py
@@ -222,11 +222,15 @@ def test_runtime_project_install_precedes_non_package_asset_copies() -> None:
     dockerfile = DOCKERFILE_PATH.read_text(encoding="utf-8")
 
     moonmind_copy_index = dockerfile.index("COPY moonmind /app/moonmind/")
+    resolver_core_copy_index = dockerfile.index(
+        "COPY pr_resolver_core /app/pr_resolver_core/"
+    )
     project_install_index = dockerfile.index(
         "pip install --disable-pip-version-check --no-deps ."
     )
 
     assert moonmind_copy_index < project_install_index
+    assert resolver_core_copy_index < project_install_index
     for copied_path in (
         "COPY api_service /app/api_service/",
         "COPY config /app/config/",

--- a/tests/unit/test_pr_resolver_core.py
+++ b/tests/unit/test_pr_resolver_core.py
@@ -251,3 +251,29 @@ def test_temporal_snapshot_handles_null_blockers() -> None:
 
     assert snapshot.merge_conflict is False
     assert snapshot.actionable_comments is False
+
+
+def test_malformed_snapshot_stops_instead_of_waiting_for_ci() -> None:
+    decision = classify_snapshot(normalize_temporal_snapshot({}))
+
+    assert decision.classification == "manual_review"
+    assert decision.reason_code == "snapshot_malformed"
+    assert decision.action is ResolverAction.STOP_MANUAL_REVIEW
+
+
+@pytest.mark.parametrize("retryable", [False, None])
+def test_external_state_unavailable_honors_retryability(retryable) -> None:
+    blocker = {"kind": "external_state_unavailable"}
+    if retryable is not None:
+        blocker["retryable"] = retryable
+
+    decision = classify_snapshot(
+        normalize_temporal_snapshot({"blockers": [blocker]})
+    )
+
+    if retryable is False:
+        assert decision.classification == "manual_review"
+        assert decision.action is ResolverAction.STOP_MANUAL_REVIEW
+    else:
+        assert decision.classification == "mergeability_transient"
+        assert decision.action is ResolverAction.WAIT

--- a/tests/unit/test_pr_resolver_core.py
+++ b/tests/unit/test_pr_resolver_core.py
@@ -9,6 +9,8 @@ import pytest
 
 from pr_resolver_core import (
     CanonicalPullRequestSnapshot,
+    IMPLEMENTATION_CONTRACT,
+    RESOLVER_CORE_DIGEST,
     ResolverAction,
     ResolverEvent,
     ResolverPolicy,
@@ -18,7 +20,6 @@ from pr_resolver_core import (
     normalize_temporal_snapshot,
     reduce_resolver_state,
 )
-import pr_resolver_core
 
 
 @pytest.mark.parametrize(
@@ -232,12 +233,21 @@ def test_core_has_no_host_or_side_effect_imports() -> None:
 
 
 def test_core_exports_immutable_identity() -> None:
-    assert pr_resolver_core.IMPLEMENTATION_CONTRACT == "pr-resolver-core/v1"
-    core_root = Path(pr_resolver_core.__file__).parent
+    assert IMPLEMENTATION_CONTRACT == "pr-resolver-core/v1"
+    core_root = Path(inspect.getfile(classify_snapshot)).parent
     semantic_bytes = b"".join(
         (core_root / name).read_bytes()
         for name in ("models.py", "normalize.py", "classify.py", "transition.py")
     )
-    assert pr_resolver_core.RESOLVER_CORE_DIGEST == (
+    assert RESOLVER_CORE_DIGEST == (
         "sha256:" + hashlib.sha256(semantic_bytes).hexdigest()
     )
+
+
+def test_temporal_snapshot_handles_null_blockers() -> None:
+    snapshot = normalize_temporal_snapshot(
+        {"blockers": None, "checksComplete": False, "checksPassing": False}
+    )
+
+    assert snapshot.merge_conflict is False
+    assert snapshot.actionable_comments is False

--- a/tests/unit/test_pr_resolver_core.py
+++ b/tests/unit/test_pr_resolver_core.py
@@ -1,0 +1,243 @@
+from __future__ import annotations
+
+import ast
+import hashlib
+import inspect
+from pathlib import Path
+
+import pytest
+
+from pr_resolver_core import (
+    CanonicalPullRequestSnapshot,
+    ResolverAction,
+    ResolverEvent,
+    ResolverPolicy,
+    ResolverState,
+    classify_snapshot,
+    normalize_portable_snapshot,
+    normalize_temporal_snapshot,
+    reduce_resolver_state,
+)
+import pr_resolver_core
+
+
+@pytest.mark.parametrize(
+    ("temporal", "portable", "classification", "action"),
+    [
+        (
+            {"pullRequestMerged": True},
+            {"pr": {"state": "MERGED"}, "ci": {}, "commentsFetch": {}},
+            "already_merged",
+            ResolverAction.PUBLISH_TERMINAL,
+        ),
+        (
+            {"pullRequestOpen": False},
+            {"pr": {"state": "CLOSED"}, "ci": {}, "commentsFetch": {}},
+            "manual_review",
+            ResolverAction.STOP_MANUAL_REVIEW,
+        ),
+        (
+            {"draft": True, "checksComplete": True, "checksPassing": True},
+            {"pr": {"state": "OPEN", "isDraft": True}, "ci": {}, "commentsFetch": {}},
+            "manual_review",
+            ResolverAction.STOP_MANUAL_REVIEW,
+        ),
+        (
+            {"ready": True, "blockers": []},
+            {
+                "pr": {"state": "OPEN", "mergeStateStatus": "CLEAN"},
+                "ci": {"isRunning": False, "hasFailures": False, "signalQuality": "ok"},
+                "commentsFetch": {"succeeded": True},
+                "commentsSummary": {"includeBotReviewComments": True},
+            },
+            "ready_to_merge",
+            ResolverAction.ATTEMPT_MERGE,
+        ),
+        (
+            {"blockers": [{"kind": "merge_conflict"}]},
+            {
+                "pr": {"state": "OPEN", "mergeStateStatus": "DIRTY"},
+                "ci": {},
+                "commentsFetch": {},
+            },
+            "merge_conflicts",
+            ResolverAction.RUN_REMEDIATION,
+        ),
+        (
+            {"checksComplete": False, "checksPassing": False},
+            {
+                "pr": {"state": "OPEN", "mergeStateStatus": "CLEAN"},
+                "ci": {"isRunning": True, "hasFailures": False, "signalQuality": "ok"},
+                "commentsFetch": {"succeeded": True},
+                "commentsSummary": {"includeBotReviewComments": True},
+            },
+            "ci_running",
+            ResolverAction.WAIT,
+        ),
+        (
+            {"checksComplete": True, "checksPassing": False},
+            {
+                "pr": {"state": "OPEN", "mergeStateStatus": "CLEAN"},
+                "ci": {"isRunning": False, "hasFailures": True, "signalQuality": "ok"},
+                "commentsFetch": {"succeeded": True},
+                "commentsSummary": {"includeBotReviewComments": True},
+            },
+            "ci_failures",
+            ResolverAction.RUN_REMEDIATION,
+        ),
+        (
+            {"blockers": [{"kind": "checks_unavailable"}]},
+            {
+                "pr": {"state": "OPEN"},
+                "ci": {"signalQuality": "degraded"},
+                "commentsFetch": {"succeeded": True},
+                "commentsSummary": {"includeBotReviewComments": True},
+            },
+            "manual_review",
+            ResolverAction.STOP_MANUAL_REVIEW,
+        ),
+        (
+            {"blockers": [{"kind": "comments_unavailable"}]},
+            {
+                "pr": {"state": "OPEN"},
+                "ci": {"signalQuality": "ok"},
+                "commentsFetch": {"succeeded": False},
+            },
+            "manual_review",
+            ResolverAction.STOP_MANUAL_REVIEW,
+        ),
+        (
+            {
+                "blockers": [{"kind": "actionable_comments"}],
+                "checksComplete": True,
+                "checksPassing": True,
+            },
+            {
+                "pr": {"state": "OPEN"},
+                "ci": {"isRunning": False, "hasFailures": False, "signalQuality": "ok"},
+                "commentsFetch": {"succeeded": True},
+                "commentsSummary": {
+                    "includeBotReviewComments": True,
+                    "hasActionableComments": True,
+                },
+            },
+            "actionable_comments",
+            ResolverAction.RUN_REMEDIATION,
+        ),
+        (
+            {
+                "blockers": [{"kind": "automated_review_pending"}],
+                "checksComplete": True,
+                "checksPassing": True,
+            },
+            {
+                "pr": {"state": "OPEN"},
+                "ci": {"isRunning": False, "hasFailures": False, "signalQuality": "ok"},
+                "commentsFetch": {"succeeded": True},
+                "commentsSummary": {
+                    "includeBotReviewComments": True,
+                    "codexReviewGrace": {"active": True},
+                },
+            },
+            "review_grace",
+            ResolverAction.WAIT,
+        ),
+        (
+            {"blockers": [{"kind": "external_state_unavailable"}]},
+            {
+                "pr": {"state": "OPEN", "mergeStateStatus": "UNKNOWN"},
+                "ci": {"signalQuality": "ok"},
+                "commentsFetch": {"succeeded": True},
+                "commentsSummary": {"includeBotReviewComments": True},
+            },
+            "mergeability_transient",
+            ResolverAction.WAIT,
+        ),
+    ],
+)
+def test_temporal_and_portable_hosts_share_classification(
+    temporal, portable, classification, action
+) -> None:
+    temporal_decision = classify_snapshot(normalize_temporal_snapshot(temporal))
+    portable_decision = classify_snapshot(normalize_portable_snapshot(portable))
+    assert temporal_decision.classification == classification
+    assert portable_decision.classification == classification
+    assert temporal_decision.action is action
+    assert portable_decision.action is action
+
+
+def test_unknown_or_degraded_state_never_attempts_merge() -> None:
+    for snapshot in (
+        CanonicalPullRequestSnapshot(malformed=True),
+        CanonicalPullRequestSnapshot(checks_degraded=True),
+        CanonicalPullRequestSnapshot(comments_available=False),
+        CanonicalPullRequestSnapshot(mergeability_unknown=True),
+        CanonicalPullRequestSnapshot(publish_available=False),
+    ):
+        assert classify_snapshot(snapshot).action is not ResolverAction.ATTEMPT_MERGE
+
+
+def test_state_reducer_enforces_no_progress_and_finalize_budgets() -> None:
+    conflict = CanonicalPullRequestSnapshot(merge_conflict=True)
+    first = reduce_resolver_state(
+        previous_state=ResolverState(),
+        snapshot=conflict,
+        policy=ResolverPolicy(max_identical_blockers_without_progress=1),
+        event=ResolverEvent(kind="snapshot", progress_signature="same"),
+    )
+    second = reduce_resolver_state(
+        previous_state=first.state,
+        snapshot=conflict,
+        policy=ResolverPolicy(max_identical_blockers_without_progress=1),
+        event=ResolverEvent(kind="snapshot", progress_signature="same"),
+    )
+    assert first.action is ResolverAction.RUN_REMEDIATION
+    assert second.action is ResolverAction.STOP_MANUAL_REVIEW
+
+    ready = CanonicalPullRequestSnapshot(checks_complete=True, checks_passing=True)
+    exhausted = reduce_resolver_state(
+        previous_state=ResolverState(finalize_attempts=1),
+        snapshot=ready,
+        policy=ResolverPolicy(max_finalize_attempts=1),
+        event=ResolverEvent(kind="snapshot"),
+    )
+    assert exhausted.decision.reason_code == "finalize_budget_exhausted"
+
+
+def test_core_has_no_host_or_side_effect_imports() -> None:
+    forbidden = {
+        "temporalio",
+        "moonmind",
+        "subprocess",
+        "pathlib",
+        "os",
+        "random",
+        "time",
+        "requests",
+        "httpx",
+    }
+    for module_name in ("models", "normalize", "classify", "transition"):
+        module = __import__(f"pr_resolver_core.{module_name}", fromlist=[module_name])
+        tree = ast.parse(inspect.getsource(module))
+        imports = {
+            node.names[0].name.split(".", 1)[0]
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Import)
+        } | {
+            (node.module or "").split(".", 1)[0]
+            for node in ast.walk(tree)
+            if isinstance(node, ast.ImportFrom) and node.level == 0
+        }
+        assert not (imports & forbidden), (module_name, imports & forbidden)
+
+
+def test_core_exports_immutable_identity() -> None:
+    assert pr_resolver_core.IMPLEMENTATION_CONTRACT == "pr-resolver-core/v1"
+    core_root = Path(pr_resolver_core.__file__).parent
+    semantic_bytes = b"".join(
+        (core_root / name).read_bytes()
+        for name in ("models.py", "normalize.py", "classify.py", "transition.py")
+    )
+    assert pr_resolver_core.RESOLVER_CORE_DIGEST == (
+        "sha256:" + hashlib.sha256(semantic_bytes).hexdigest()
+    )

--- a/tests/unit/test_pr_resolver_tools.py
+++ b/tests/unit/test_pr_resolver_tools.py
@@ -1345,6 +1345,24 @@ def test_contract_snapshot_refresh_failed_is_finalize_only_retry(
     )
     assert action == "finalize_only_retry"
 
+
+def test_contract_external_state_transient_is_finalize_only_retry(
+    pr_resolve_contract_module: dict[str, Any],
+) -> None:
+    classify_retry_action = pr_resolve_contract_module["classify_retry_action"]
+    remediation_next_step = pr_resolve_contract_module["remediation_next_step"]
+
+    action = classify_retry_action(
+        "external_state_transient",
+        merge_not_ready_grace_remaining=0,
+    )
+
+    assert action == "finalize_only_retry"
+    assert (
+        remediation_next_step("external_state_transient")
+        == "retry_finalize_after_backoff"
+    )
+
 def test_contract_codex_review_grace_wait_is_finalize_only_retry(
     pr_resolve_contract_module: dict[str, Any],
 ) -> None:

--- a/tests/unit/workflows/agent_skills/test_agent_skills_activities.py
+++ b/tests/unit/workflows/agent_skills/test_agent_skills_activities.py
@@ -1,6 +1,9 @@
 from datetime import UTC, datetime
 import io
 import os
+from pathlib import Path
+import subprocess
+import sys
 import tarfile
 from types import SimpleNamespace
 from unittest.mock import patch
@@ -194,6 +197,47 @@ async def test_build_skill_bundle_payload_rejects_dangling_symlink(tmp_path):
 
     with pytest.raises(OSError, match="symlink target is missing"):
         AgentSkillsActivities._build_skill_bundle_payload(skill_dir)
+
+
+async def test_pr_resolver_bundle_includes_portable_core_and_runs_help(tmp_path):
+    repo = tmp_path / "repo"
+    skill_dir = repo / ".agents" / "skills" / "pr-resolver"
+    (skill_dir / "bin").mkdir(parents=True)
+    source_root = Path(__file__).resolve().parents[4]
+    for relative_path in (
+        "SKILL.md",
+        "bin/pr_resolve_contract.py",
+        "bin/pr_resolve_finalize.py",
+    ):
+        source = source_root / ".agents" / "skills" / "pr-resolver" / relative_path
+        destination = skill_dir / relative_path
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_bytes(source.read_bytes())
+    core_root = repo / "pr_resolver_core"
+    core_root.mkdir()
+    for source in (source_root / "pr_resolver_core").glob("*.py"):
+        (core_root / source.name).write_bytes(source.read_bytes())
+    (repo / "pyproject.toml").write_text("[project]\nname='test'\n", encoding="utf-8")
+
+    payload = AgentSkillsActivities._build_skill_bundle_payload(
+        skill_dir,
+        include_pr_resolver_core=True,
+    )
+    extracted = tmp_path / "extracted"
+    extracted.mkdir()
+    with tarfile.open(fileobj=io.BytesIO(payload), mode="r:gz") as archive:
+        archive.extractall(extracted, filter="data")
+
+    result = subprocess.run(
+        [sys.executable, str(extracted / "bin" / "pr_resolve_finalize.py"), "--help"],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert (extracted / "lib" / "pr_resolver_core" / "__init__.py").is_file()
 
 
 async def test_build_prompt_index_activity_returns_bundle():

--- a/tests/unit/workflows/temporal/test_artifacts_activities.py
+++ b/tests/unit/workflows/temporal/test_artifacts_activities.py
@@ -189,6 +189,62 @@ async def test_execution_record_terminal_state_indexes_run_digest_best_effort(
 
 
 @pytest.mark.asyncio
+async def test_execution_terminal_projection_lag_does_not_overwrite_success(
+    activities,
+    monkeypatch,
+):
+    """Internally-started children may close before their projection row exists."""
+
+    import api_service.db.base as db_base
+    import moonmind.workflows.temporal.service as temporal_service
+
+    class _SessionContext:
+        async def __aenter__(self):
+            return object()
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    class _TemporalExecutionService:
+        def __init__(self, session):
+            self.session = session
+
+        async def record_terminal_state(self, **_kwargs):
+            raise temporal_service.TemporalExecutionNotFoundError("projection pending")
+
+    digest_write = AsyncMock()
+    monkeypatch.setattr(db_base, "get_async_session_context", lambda: _SessionContext())
+    monkeypatch.setattr(
+        temporal_service,
+        "TemporalExecutionService",
+        _TemporalExecutionService,
+    )
+    monkeypatch.setattr(
+        activities,
+        "_write_run_digest_best_effort",
+        digest_write,
+    )
+
+    result = await activities.execution_record_terminal_state(
+        {
+            "workflowId": "resolver:child:3199",
+            "state": "completed",
+            "closeStatus": "completed",
+            "summary": "PR merged and remotely verified",
+        }
+    )
+
+    assert result == {
+        "workflowId": "resolver:child:3199",
+        "state": "completed",
+        "closeStatus": "completed",
+        "projectionDeferred": True,
+        "reasonCode": "temporal_projection_pending",
+    }
+    digest_write.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_write_run_digest_best_effort_runs_sync_indexing_in_executor(
     activities,
     monkeypatch,

--- a/tests/unit/workflows/temporal/test_native_skill_bindings.py
+++ b/tests/unit/workflows/temporal/test_native_skill_bindings.py
@@ -1,0 +1,47 @@
+from moonmind.schemas.agent_skill_models import (
+    AgentSkillProvenance,
+    AgentSkillSourceKind,
+    ResolvedSkillEntry,
+    SkillImplementationContract,
+)
+from moonmind.workflows.temporal.native_skill_bindings import (
+    evaluate_pr_resolver_native_binding,
+)
+
+
+def _entry(source: AgentSkillSourceKind) -> ResolvedSkillEntry:
+    return ResolvedSkillEntry(
+        skill_name="pr-resolver",
+        content_ref="art_skill",
+        content_digest="sha256:abc",
+        provenance=AgentSkillProvenance(source_kind=source),
+        implementation=SkillImplementationContract(
+            contract="pr-resolver-core/v1",
+            supportedHosts=["cli", "temporal"],
+            nativeHostEligible=True,
+            nativeHostPolicy="moonmind_trusted",
+        ),
+    )
+
+
+def test_trusted_built_in_pr_resolver_is_native_eligible() -> None:
+    result = evaluate_pr_resolver_native_binding(_entry(AgentSkillSourceKind.BUILT_IN))
+    assert result.eligible is True
+    assert result.host == "temporal"
+
+
+def test_repo_or_local_name_collision_uses_observable_portable_fallback() -> None:
+    for source in (AgentSkillSourceKind.REPO, AgentSkillSourceKind.LOCAL):
+        result = evaluate_pr_resolver_native_binding(_entry(source))
+        assert result.eligible is False
+        assert result.host == "cli"
+        assert result.reason_code == "untrusted_skill_source"
+
+
+def test_missing_immutable_content_evidence_rejects_native_host() -> None:
+    entry = _entry(AgentSkillSourceKind.BUILT_IN).model_copy(
+        update={"content_digest": None}
+    )
+    result = evaluate_pr_resolver_native_binding(entry)
+    assert result.eligible is False
+    assert result.reason_code == "immutable_content_evidence_missing"

--- a/tests/unit/workflows/temporal/test_run_merge_gate_start.py
+++ b/tests/unit/workflows/temporal/test_run_merge_gate_start.py
@@ -1,6 +1,22 @@
 from __future__ import annotations
 
-from moonmind.workflows.temporal.workflows.run import MoonMindRunWorkflow
+from moonmind.workflows.temporal.workflows.run import (
+    MoonMindRunWorkflow,
+    _worker_capability_unavailable_error,
+)
+
+
+def test_worker_capability_error_preserves_structured_details() -> None:
+    capability = {
+        "available": False,
+        "reasonCode": "worker_capability_unavailable",
+    }
+
+    error = _worker_capability_unavailable_error(capability)
+
+    assert error.type == "WORKER_CAPABILITY_UNAVAILABLE"
+    assert error.non_retryable is True
+    assert error.details == (capability,)
 
 def test_merge_automation_disabled_by_default() -> None:
     workflow = MoonMindRunWorkflow()

--- a/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
+++ b/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
@@ -7,6 +7,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch, ANY
 
 import pytest
+from temporalio import activity
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
 
@@ -3887,12 +3888,12 @@ async def test_main_async_workflow_fleet(
         MoonMindMergeAutomationWorkflow,
         MoonMindPRResolverWorkflow,
     )
-    assert kwargs["activities"] == [
+    assert kwargs["activities"] == (
         resolve_adapter_metadata,
         get_activity_route,
         resolve_external_adapter,
         external_adapter_execution_style,
-    ]
+    )
     assert "deployment_config" not in kwargs
     assert "build_id" not in kwargs
     assert "use_worker_versioning" not in kwargs
@@ -3933,8 +3934,12 @@ async def test_main_async_activity_fleet(
     mock_worker_cls.return_value = mock_worker
     mock_worker.run = AsyncMock()
 
+    @activity.defn(name="test.handler")
+    async def test_handler() -> None:
+        return None
+
     mock_resources = AsyncMock()
-    mock_runtime_activities.return_value = (mock_resources, ["test_handler"])
+    mock_runtime_activities.return_value = (mock_resources, [test_handler])
 
     # Run
     await main_async()
@@ -3943,8 +3948,8 @@ async def test_main_async_activity_fleet(
     mock_worker_cls.assert_called_once()
     kwargs = mock_worker_cls.call_args.kwargs
     assert kwargs["task_queue"] == "mm.activity.artifacts"
-    assert kwargs["workflows"] == []
-    assert kwargs["activities"] == ["test_handler"]
+    assert kwargs["workflows"] == ()
+    assert kwargs["activities"] == (test_handler,)
     assert "deployment_config" not in kwargs
     assert "build_id" not in kwargs
     assert "use_worker_versioning" not in kwargs

--- a/tests/unit/workflows/temporal/test_temporal_workers.py
+++ b/tests/unit/workflows/temporal/test_temporal_workers.py
@@ -3,8 +3,11 @@
 from __future__ import annotations
 
 import asyncio
+from dataclasses import replace
 from pathlib import Path
 from typing import Any
+
+import pytest
 
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
@@ -41,10 +44,13 @@ from moonmind.workflows.agent_skills.agent_skills_activities import AgentSkillsA
 from moonmind.workflows.temporal.workers import (
     build_all_worker_topologies,
     build_worker_activity_bindings,
+    build_worker_spec,
+    build_worker_topology,
     describe_configured_worker,
     list_registered_workflow_types,
 )
 from moonmind.workflows.temporal.workflow_registry import (
+    workflow_fleet_activity_handlers,
     workflow_fleet_workflow_classes,
 )
 
@@ -124,6 +130,61 @@ def test_advertised_workflow_types_match_production_worker_classes():
 
 def test_production_worker_classes_are_cached():
     assert workflow_fleet_workflow_classes() is workflow_fleet_workflow_classes()
+
+
+def test_executable_worker_spec_drives_registration_and_stable_identity() -> None:
+    topology = build_worker_topology(fleet=WORKFLOW_FLEET)
+    kwargs = {
+        "topology": topology,
+        "workflows": workflow_fleet_workflow_classes(),
+        "activities": workflow_fleet_activity_handlers(),
+        "environ": {
+            "MOONMIND_BUILD_SHA": "abc123",
+            "MOONMIND_IMAGE_DIGEST": "sha256:image",
+            "TEMPORAL_WORKER_DEPLOYMENT_NAME": "moonmind-test",
+            "TEMPORAL_WORKER_VERSIONING_ENABLED": "true",
+        },
+    }
+    first = build_worker_spec(**kwargs)
+    second = build_worker_spec(**kwargs)
+    assert first.registry_fingerprint == second.registry_fingerprint
+    assert first.workflow_types == list_registered_workflow_types()
+    assert "MoonMind.PRResolver" in first.readiness_payload()["workflowTypes"]
+    assert first.versioning_enabled is True
+    assert first.build_id == "abc123"
+
+    alternate_lane = build_worker_spec(
+        topology=replace(topology, task_queues=("mm.workflow.merge_automation",)),
+        workflows=workflow_fleet_workflow_classes(),
+        activities=workflow_fleet_activity_handlers(),
+        environ=kwargs["environ"],
+    )
+    assert alternate_lane.registry_fingerprint == first.registry_fingerprint
+
+
+def test_production_worker_spec_requires_immutable_release_identity() -> None:
+    topology = build_worker_topology(fleet=WORKFLOW_FLEET)
+    with pytest.raises(ValueError, match="MOONMIND_BUILD_SHA"):
+        build_worker_spec(
+            topology=topology,
+            workflows=workflow_fleet_workflow_classes(),
+            activities=workflow_fleet_activity_handlers(),
+            environ={"MOONMIND_DEPLOYMENT_MODE": "production"},
+        )
+
+
+def test_production_worker_spec_requires_temporal_worker_versioning() -> None:
+    topology = build_worker_topology(fleet=WORKFLOW_FLEET)
+    with pytest.raises(ValueError, match="TEMPORAL_WORKER_VERSIONING_ENABLED"):
+        build_worker_spec(
+            topology=topology,
+            workflows=workflow_fleet_workflow_classes(),
+            activities=workflow_fleet_activity_handlers(),
+            environ={
+                "MOONMIND_DEPLOYMENT_MODE": "production",
+                "MOONMIND_BUILD_SHA": "abc123",
+            },
+        )
 
 
 def test_pr_resolver_terminal_publication_is_idempotent(tmp_path: Path):

--- a/tests/unit/workflows/temporal/test_worker_capability_activity.py
+++ b/tests/unit/workflows/temporal/test_worker_capability_activity.py
@@ -83,3 +83,32 @@ async def test_capability_preflight_fails_closed_for_registration_mismatch(
     assert result["reasonCode"] == "worker_capability_unavailable"
     assert result["observedWorkerBuilds"] == ["old-build"]
     assert result["agentExecutionLaunched"] is False
+
+
+@pytest.mark.asyncio
+async def test_capability_preflight_handles_null_readiness_collections(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        activity_runtime_module.httpx,
+        "AsyncClient",
+        lambda **_kwargs: _Client(
+            {
+                "ready": True,
+                "workflowTypes": None,
+                "taskQueues": None,
+                "registryFingerprints": None,
+                "buildIds": None,
+                "children": None,
+            }
+        ),
+    )
+
+    result = await TemporalIntegrationActivities().worker_verify_workflow_capability(
+        {"workflowType": "MoonMind.PRResolver", "taskQueue": "mm.workflow"}
+    )
+
+    assert result["available"] is False
+    assert result["status"] == "blocked_operator"
+    assert result["observedRegistryFingerprints"] == []
+    assert result["observedWorkerBuilds"] == []

--- a/tests/unit/workflows/temporal/test_worker_capability_activity.py
+++ b/tests/unit/workflows/temporal/test_worker_capability_activity.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import pytest
+
+from moonmind.workflows.temporal import activity_runtime as activity_runtime_module
+from moonmind.workflows.temporal.activity_runtime import TemporalIntegrationActivities
+
+
+class _Response:
+    def __init__(self, payload: dict[str, object]) -> None:
+        self._payload = payload
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> dict[str, object]:
+        return self._payload
+
+
+class _Client:
+    def __init__(self, payload: dict[str, object]) -> None:
+        self._payload = payload
+
+    async def __aenter__(self) -> _Client:
+        return self
+
+    async def __aexit__(self, *_args: object) -> None:
+        return None
+
+    async def get(self, _url: str) -> _Response:
+        return _Response(self._payload)
+
+
+@pytest.mark.asyncio
+async def test_capability_preflight_reports_exact_ready_worker(monkeypatch) -> None:
+    readiness = {
+        "ready": True,
+        "workflowTypes": ["MoonMind.UserWorkflow", "MoonMind.PRResolver"],
+        "taskQueues": ["mm.workflow"],
+        "registryFingerprints": ["sha256:registry"],
+        "buildIds": ["build-3199"],
+    }
+    monkeypatch.setattr(
+        activity_runtime_module.httpx,
+        "AsyncClient",
+        lambda **_kwargs: _Client(readiness),
+    )
+
+    result = await TemporalIntegrationActivities().worker_verify_workflow_capability(
+        {"workflowType": "MoonMind.PRResolver", "taskQueue": "mm.workflow"}
+    )
+
+    assert result["available"] is True
+    assert result["registryFingerprint"] == "sha256:registry"
+    assert result["buildId"] == "build-3199"
+    assert result["agentExecutionLaunched"] is False
+
+
+@pytest.mark.asyncio
+async def test_capability_preflight_fails_closed_for_registration_mismatch(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        activity_runtime_module.httpx,
+        "AsyncClient",
+        lambda **_kwargs: _Client(
+            {
+                "ready": True,
+                "workflowTypes": ["MoonMind.UserWorkflow"],
+                "taskQueues": ["mm.workflow"],
+                "registryFingerprints": ["sha256:old"],
+                "buildIds": ["old-build"],
+            }
+        ),
+    )
+
+    result = await TemporalIntegrationActivities().worker_verify_workflow_capability(
+        {"workflowType": "MoonMind.PRResolver", "taskQueue": "mm.workflow"}
+    )
+
+    assert result["available"] is False
+    assert result["status"] == "blocked_operator"
+    assert result["reasonCode"] == "worker_capability_unavailable"
+    assert result["observedWorkerBuilds"] == ["old-build"]
+    assert result["agentExecutionLaunched"] is False

--- a/tests/unit/workflows/temporal/test_worker_healthcheck.py
+++ b/tests/unit/workflows/temporal/test_worker_healthcheck.py
@@ -9,6 +9,7 @@ import urllib.request
 import pytest
 
 from moonmind.workflows.temporal.worker_healthcheck import (
+    WorkerHealthState,
     _build_response_body,
     _is_enabled,
     _port,
@@ -102,6 +103,47 @@ async def test_start_healthcheck_server_responds(monkeypatch):
         assert body["status"] == "ok"
         assert body["fleet"] == "test_fleet"
         assert isinstance(body["uptime_seconds"], int)
+    finally:
+        server.close()
+        await server.wait_closed()
+
+
+@pytest.mark.asyncio
+async def test_readiness_fails_closed_until_worker_pollers_start(monkeypatch):
+    monkeypatch.setenv("WORKER_HEALTHCHECK_ENABLED", "true")
+    monkeypatch.setenv("WORKER_HEALTHCHECK_PORT", "0")
+    state = WorkerHealthState(
+        readiness_metadata={
+            "workflowTypes": ["MoonMind.PRResolver"],
+            "registryFingerprint": "sha256:abc",
+        }
+    )
+    server = await start_healthcheck_server(state)
+    assert server is not None
+    port = server.sockets[0].getsockname()[1]
+    loop = asyncio.get_running_loop()
+    try:
+        with pytest.raises(urllib.error.HTTPError) as exc_info:
+            await loop.run_in_executor(
+                None,
+                lambda: urllib.request.urlopen(
+                    f"http://127.0.0.1:{port}/readyz", timeout=5
+                ).read(),
+            )
+        assert exc_info.value.code == 503
+
+        state.temporal_connected = True
+        state.workers_constructed = True
+        state.pollers_started = True
+        response_bytes = await loop.run_in_executor(
+            None,
+            lambda: urllib.request.urlopen(
+                f"http://127.0.0.1:{port}/readyz", timeout=5
+            ).read(),
+        )
+        body = json.loads(response_bytes)
+        assert body["ready"] is True
+        assert body["workflowTypes"] == ["MoonMind.PRResolver"]
     finally:
         server.close()
         await server.wait_closed()

--- a/tests/unit/workflows/temporal/test_workflow_worker_group_launcher.py
+++ b/tests/unit/workflows/temporal/test_workflow_worker_group_launcher.py
@@ -195,6 +195,20 @@ def test_group_readiness_rejects_mixed_worker_registry_identity(monkeypatch) -> 
     assert state.is_ready() is False
 
 
+def test_group_readiness_rejects_child_that_is_not_ready(monkeypatch) -> None:
+    monkeypatch.setattr(
+        launcher,
+        "_read_child_readiness",
+        lambda _url: {"ready": False, "registryFingerprint": "sha256:new"},
+    )
+    state = launcher.GroupHealthState(
+        children=[FakeProcess()],
+        child_health_urls=["http://child-one/readyz"],
+    )
+
+    assert state.is_ready() is False
+
+
 def test_supervisor_exits_nonzero_and_stops_group_when_child_exits() -> None:
     processes = {
         "normal-workflow-worker": FakeProcess(),

--- a/tests/unit/workflows/temporal/test_workflow_worker_group_launcher.py
+++ b/tests/unit/workflows/temporal/test_workflow_worker_group_launcher.py
@@ -152,12 +152,12 @@ def test_parent_health_endpoint_probes_child_health_urls() -> None:
     )
     parent_state = launcher.GroupHealthState(
         children=[FakeProcess()],
-        child_health_urls=[f"http://127.0.0.1:{child_server.server_port}/healthz"],
+        child_health_urls=[f"http://127.0.0.1:{child_server.server_port}/readyz"],
     )
     parent_server = launcher.start_health_server(parent_state, port=0)
     try:
         response = urllib.request.urlopen(
-            f"http://127.0.0.1:{parent_server.server_port}/healthz",
+            f"http://127.0.0.1:{parent_server.server_port}/readyz",
             timeout=5,
         )
         assert response.status == 200
@@ -167,7 +167,7 @@ def test_parent_health_endpoint_probes_child_health_urls() -> None:
 
         try:
             urllib.request.urlopen(
-                f"http://127.0.0.1:{parent_server.server_port}/healthz",
+                f"http://127.0.0.1:{parent_server.server_port}/readyz",
                 timeout=5,
             )
         except urllib.error.HTTPError as exc:
@@ -177,6 +177,22 @@ def test_parent_health_endpoint_probes_child_health_urls() -> None:
     finally:
         parent_server.shutdown()
         parent_server.server_close()
+
+
+def test_group_readiness_rejects_mixed_worker_registry_identity(monkeypatch) -> None:
+    payloads = iter(
+        [
+            {"ready": True, "registryFingerprint": "sha256:new", "buildId": "new"},
+            {"ready": True, "registryFingerprint": "sha256:old", "buildId": "old"},
+        ]
+    )
+    monkeypatch.setattr(launcher, "_read_child_readiness", lambda _url: next(payloads))
+    state = launcher.GroupHealthState(
+        children=[FakeProcess(), FakeProcess()],
+        child_health_urls=["http://child-one/readyz", "http://child-two/readyz"],
+    )
+
+    assert state.is_ready() is False
 
 
 def test_supervisor_exits_nonzero_and_stops_group_when_child_exits() -> None:

--- a/tests/unit/workflows/temporal/workflows/test_run_integration.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_integration.py
@@ -2,6 +2,7 @@ import asyncio
 import inspect
 from datetime import datetime, timezone, timedelta
 from typing import Any, Callable
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -18,6 +19,7 @@ from moonmind.workflows.temporal.workflows.run import (
     RUN_HANDOFF_ACCEPTED_DISPOSITION_GATE_PATCH,
     RUN_PAUSE_SAFE_BOUNDARIES_PATCH,
     RUN_PUBLISH_REPAIR_FEEDBACK_PATCH,
+    RUN_PR_RESOLVER_PUBLISH_EVIDENCE_REF_PATCH,
     RUN_STEP_RETRY_OVERRIDES_PATCH,
     RUN_ALREADY_IMPLEMENTED_JIRA_COMPLETION_PATCH,
     RUN_AUTO_PUBLISH_METADATA_EVIDENCE_PATCH,
@@ -2164,6 +2166,88 @@ async def test_auto_publish_evidence_ref_is_loaded_before_recording(
     assert mock_run_workflow._publish_context["evidenceRef"] == (
         "artifact://publish-result"
     )
+
+
+@pytest.mark.asyncio
+async def test_pr_resolver_top_level_publish_evidence_ref_prevents_false_failure(
+    mock_run_workflow: MoonMindRunWorkflow,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression for merged resolver runs summarized as Finalizing execution."""
+
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "patched",
+        lambda patch_id: patch_id == RUN_PR_RESOLVER_PUBLISH_EVIDENCE_REF_PATCH,
+    )
+
+    evidence = _auto_publish_evidence(
+        skillId="pr-resolver",
+        action="merge",
+        pushed=False,
+        merged=True,
+        remoteVerified=False,
+        remoteBranchHead=None,
+        prUrl="https://github.com/MoonLadderStudios/MoonMind/pull/3199",
+    )
+
+    async def fake_execute_typed_activity(
+        activity_type: str,
+        payload: Any,
+        **_kwargs: Any,
+    ) -> bytes:
+        assert activity_type == "artifact.read"
+        assert getattr(payload, "artifact_ref", None) == "artifact://resolver-publish"
+        import json
+
+        return json.dumps(evidence).encode()
+
+    monkeypatch.setattr(
+        run_workflow_module,
+        "execute_typed_activity",
+        fake_execute_typed_activity,
+    )
+
+    await mock_run_workflow._record_publish_result_from_execution(
+        parameters={"publishMode": "auto"},
+        execution_result={
+            "publishEvidence": "artifact://resolver-publish",
+            "outputRefs": {
+                "prResolverResult": "artifact://resolver-result",
+                "publishEvidence": "artifact://resolver-publish",
+            },
+            "metadata": {"mergeAutomationDisposition": "merged"},
+        },
+    )
+
+    assert mock_run_workflow._publish_status == "published"
+    assert mock_run_workflow._publish_reason == "auto publish verified merge"
+    assert mock_run_workflow._publish_context["evidenceRef"] == (
+        "artifact://resolver-publish"
+    )
+    assert mock_run_workflow._publish_context["merged"] is True
+
+
+@pytest.mark.asyncio
+async def test_pr_resolver_publish_ref_preserves_unpatched_replay(
+    mock_run_workflow: MoonMindRunWorkflow,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    execute_activity = AsyncMock()
+    monkeypatch.setattr(
+        run_workflow_module,
+        "execute_typed_activity",
+        execute_activity,
+    )
+
+    await mock_run_workflow._record_publish_result_from_execution(
+        parameters={"publishMode": "auto"},
+        execution_result={"publishEvidence": "artifact://resolver-publish"},
+    )
+
+    execute_activity.assert_not_awaited()
+    assert mock_run_workflow._publish_status == "failed"
+    assert mock_run_workflow._publish_reason == "auto_publish_evidence_missing"
 
 
 def test_auto_publish_record_keeps_loaded_evidence_ref_when_later_metadata_ref_exists(

--- a/tools/run_pr_resolver_deployment_canary.py
+++ b/tools/run_pr_resolver_deployment_canary.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Non-mutating post-deployment canary for MoonMind.PRResolver registration."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import uuid
+
+import httpx
+from temporalio.client import Client
+from temporalio.contrib.pydantic import pydantic_data_converter
+
+
+async def _run(args: argparse.Namespace) -> int:
+    async with httpx.AsyncClient(timeout=10.0) as http_client:
+        response = await http_client.get(args.readiness_url)
+        response.raise_for_status()
+        readiness = response.json()
+    if not isinstance(readiness, dict) or readiness.get("ready") is not True:
+        raise RuntimeError("workflow fleet is not ready")
+    workflow_types = {str(item) for item in readiness.get("workflowTypes", [])}
+    task_queues = {str(item) for item in readiness.get("taskQueues", [])}
+    if "MoonMind.PRResolver" not in workflow_types:
+        raise RuntimeError("readiness does not advertise MoonMind.PRResolver")
+    if args.task_queue not in task_queues:
+        raise RuntimeError(f"readiness does not advertise task queue {args.task_queue}")
+    registry_fingerprint = str(
+        readiness.get("registryFingerprint")
+        or next(iter(readiness.get("registryFingerprints", [])), "")
+    )
+    build_id = str(
+        readiness.get("buildId") or next(iter(readiness.get("buildIds", [])), "")
+    )
+    if args.expected_registry_fingerprint and (
+        registry_fingerprint != args.expected_registry_fingerprint
+    ):
+        raise RuntimeError("workflow registry fingerprint does not match deployment")
+    if args.expected_build_id and build_id != args.expected_build_id:
+        raise RuntimeError("workflow worker build does not match deployment")
+
+    client = await Client.connect(
+        args.address,
+        namespace=args.namespace,
+        data_converter=pydantic_data_converter,
+    )
+    workflow_id = f"canary:pr-resolver:{uuid.uuid4()}"
+    result = await client.execute_workflow(
+        "MoonMind.PRResolver",
+        {
+            "workflowType": "MoonMind.PRResolver",
+            "parentWorkflowId": workflow_id,
+            "principal": "deployment-canary",
+            "repository": "canary/no-mutation",
+            "prNumber": 1,
+            "prUrl": "https://example.invalid/canary/pull/1",
+            "stepId": "canary",
+            "correlationId": workflow_id,
+            "baseAgentRequest": {"canary": True},
+            "canaryMode": True,
+            "implementationIdentity": {"implementationContract": "pr-resolver-core/v1"},
+            "workerCapability": {
+                "available": True,
+                "workflowType": "MoonMind.PRResolver",
+                "taskQueue": args.task_queue,
+                "registryFingerprint": registry_fingerprint,
+                "buildId": build_id,
+            },
+        },
+        id=workflow_id,
+        task_queue=args.task_queue,
+    )
+    metadata = result.get("metadata") if isinstance(result, dict) else {}
+    if not isinstance(metadata, dict) or metadata.get("canary") is not True:
+        raise RuntimeError("PR resolver canary returned an invalid terminal result")
+    observed_capability = metadata.get("workerCapability")
+    if not isinstance(observed_capability, dict) or (
+        observed_capability.get("registryFingerprint") != registry_fingerprint
+    ):
+        raise RuntimeError("PR resolver canary did not preserve worker identity")
+    print(
+        json.dumps(
+            {
+                "workflowId": workflow_id,
+                "buildId": build_id,
+                "registryFingerprint": registry_fingerprint,
+                "result": result,
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--address", default="localhost:7233")
+    parser.add_argument("--namespace", default="default")
+    parser.add_argument("--task-queue", default="mm.workflow")
+    parser.add_argument(
+        "--readiness-url",
+        default="http://localhost:8080/readyz",
+    )
+    parser.add_argument("--expected-registry-fingerprint")
+    parser.add_argument("--expected-build-id")
+    return asyncio.run(_run(parser.parse_args()))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- introduce a provider-neutral pr_resolver_core shared by the portable helper and durable Temporal state machine
- bind native resolver routing to immutable resolved-skill contract, provenance, content digest, and policy evidence with replay-safe cutovers
- derive worker registration, diagnostics, startup logs, and readiness from one executable WorkerSpec with immutable build and registry identity
- add fail-fast worker capability preflight, mixed-build readiness rejection, worker versioning requirements, and a non-mutating deployment canary
- fix the original false Finalizing execution incident by loading PR resolver publish-evidence refs and treating projection lag as auxiliary instead of overriding verified merge success
- update resolver, publishing, skill-system, worker-topology, deployment, and operator documentation

## Incident regression

The parent workflow now recognizes publishEvidence returned directly or through outputRefs by MoonMind.PRResolver, loads the authoritative artifact before finish-outcome mapping, and preserves the prior behavior for old histories through a Temporal patch marker. Internally-started resolver children may finish before their projection row exists; terminal-state recording now defers that projection without failing the successful child.

## Verification

- focused resolver/runtime/Compose suite: 436 passed
- portable resolver helper suite: 67 passed
- real Temporal parent-to-MoonMind.PRResolver boundary: passed
- Compose-backed integration_ci suite: 426 passed, 1 skipped
- image build and Poetry wheel install include pr_resolver_core
- full unit gate: 8,618 passed; two change-related failures were fixed and rerun successfully. Seven remaining local failures were unrelated to this branch: the pre-existing dirty moonspec submodule projection, local publish-policy configuration, macOS tmp-path canonicalization, and one parallel Temporal test-server startup failure.
- compileall, Ruff checks, diff checks, and poetry check completed successfully