### PR TITLE
Preserve terminal-evidence and runtime review fixes

### DIFF
--- a/.agents/skills/batch-workflows/bin/batch_workflows.py
+++ b/.agents/skills/batch-workflows/bin/batch_workflows.py
@@ -743,7 +743,7 @@ def _submit_jobs_via_http(
             )
         except urllib.error.HTTPError as exc:
             try:
-                detail = exc.read().decode("utf-8")
+                detail = exc.read(65536).decode("utf-8", errors="replace")
                 error_message = f"{exc}: {detail}"
             except Exception:
                 error_message = str(exc)

--- a/.agents/skills/batch-workflows/bin/batch_workflows.py
+++ b/.agents/skills/batch-workflows/bin/batch_workflows.py
@@ -741,6 +741,19 @@ def _submit_jobs_via_http(
                     ),
                 }
             )
+        except urllib.error.HTTPError as exc:
+            try:
+                detail = exc.read().decode("utf-8")
+                error_message = f"{exc}: {detail}"
+            except Exception:
+                error_message = str(exc)
+            errors.append(
+                {
+                    "provider": submission.provider,
+                    "ref": submission.ref,
+                    "error": error_message,
+                }
+            )
         except Exception as exc:  # noqa: BLE001 - reported per target
             errors.append(
                 {

--- a/.agents/skills/pr-resolver/SKILL.md
+++ b/.agents/skills/pr-resolver/SKILL.md
@@ -2,6 +2,12 @@
 name: pr-resolver
 description: Master orchestrator to resolve a PR by diagnosing state and delegating to specialized skills.
 metadata:
+  sideEffect:
+    kind: merge_pull_request
+    owner: agent
+    outcomeArtifact: var/pr_resolver/result.json
+    terminalContractId: pr_resolver_terminal.v1
+    terminalSchemaVersion: moonmind.pr-resolver-result.v1
   publish:
     mode: auto
     owner: agent

--- a/.agents/skills/pr-resolver/bin/pr_resolve_contract.py
+++ b/.agents/skills/pr-resolver/bin/pr_resolve_contract.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import os
 from datetime import UTC, datetime
 from typing import Any
 
@@ -47,6 +48,9 @@ def now_utc_iso() -> str:
 
 def normalize_text(value: Any) -> str:
     return str(value or "").strip()
+
+def current_execution_ref() -> str | None:
+    return normalize_text(os.getenv("MOONMIND_STEP_EXECUTION_ID")) or None
 
 def parse_reason(result_payload: dict[str, Any]) -> str:
     return normalize_text(

--- a/.agents/skills/pr-resolver/bin/pr_resolve_finalize.py
+++ b/.agents/skills/pr-resolver/bin/pr_resolve_finalize.py
@@ -35,6 +35,7 @@ from pr_resolve_contract import (  # noqa: E402
     FINALIZE_ONLY_RETRY_REASONS,
     FULL_REMEDIATION_REASONS,
     RESULT_SCHEMA_VERSION,
+    current_execution_ref,
     merge_automation_disposition_for_result,
     normalize_text,
     now_utc_iso,
@@ -158,6 +159,7 @@ def _write_result(
 
     payload: dict[str, Any] = {
         "schema_version": RESULT_SCHEMA_VERSION,
+        "executionRef": current_execution_ref(),
         "tool": "pr_resolve_finalize",
         "timestamp": now_utc_iso(),
         "pr_number": pr.get("number"),
@@ -347,6 +349,7 @@ def main() -> None:
     except (RuntimeError, subprocess.CalledProcessError) as exc:
         payload = {
             "schema_version": RESULT_SCHEMA_VERSION,
+            "executionRef": current_execution_ref(),
             "tool": "pr_resolve_finalize",
             "timestamp": now_utc_iso(),
             "decision": "failed",

--- a/.agents/skills/pr-resolver/bin/pr_resolve_full.py
+++ b/.agents/skills/pr-resolver/bin/pr_resolve_full.py
@@ -24,6 +24,7 @@ from pr_resolve_contract import (  # noqa: E402
     EXIT_CODE_MERGED,
     FULL_REMEDIATION_REASONS,
     RESULT_SCHEMA_VERSION,
+    current_execution_ref,
     merge_automation_disposition_for_result,
     normalize_text,
     now_utc_iso,
@@ -64,6 +65,7 @@ def _write_result(
     pr = snapshot.get("pr") if isinstance(snapshot.get("pr"), dict) else {}
     payload: dict[str, Any] = {
         "schema_version": RESULT_SCHEMA_VERSION,
+        "executionRef": current_execution_ref(),
         "tool": "pr_resolve_full",
         "timestamp": now_utc_iso(),
         "status": status,

--- a/api_service/data/presets/batch-github-workflows.yaml
+++ b/api_service/data/presets/batch-github-workflows.yaml
@@ -12,7 +12,7 @@ requiredCapabilities:
 - git
 - gh
 annotations:
-  sourceSkill: queue-moonmind-workflows
+  sourceSkill: batch-workflows
   output: child-workflows
   runtimeInheritance: caller
   workflowPublish:
@@ -188,7 +188,7 @@ steps:
     summaryArtifact: artifacts/batch-workflows-result.json
     targetListArtifact: artifacts/batch-workflows-targets.json
   skill:
-    id: queue-moonmind-workflows
+    id: batch-workflows
     requiredCapabilities:
     - git
     - gh

--- a/moonmind/schemas/agent_runtime_models.py
+++ b/moonmind/schemas/agent_runtime_models.py
@@ -526,7 +526,7 @@ class AgentTerminalContract(BaseModel):
     @field_validator("relative_path")
     @classmethod
     def _confine_workspace_path(cls, value: str) -> str:
-        normalized = value.strip()
+        normalized = value.strip().replace("\\", "/")
         if normalized.startswith("/") or ".." in normalized.split("/"):
             raise ValueError("terminal evidence path must be relative and traversal-free")
         return normalized

--- a/moonmind/schemas/managed_session_models.py
+++ b/moonmind/schemas/managed_session_models.py
@@ -1264,6 +1264,9 @@ class LaunchCodexManagedSessionRequest(_CodexManagedSessionRemoteContract):
 class SendCodexManagedSessionTurnRequest(CodexManagedSessionLocator):
     """Send a new turn to the remote session container."""
 
+    # Session snapshots may report the valid initial epoch before the first
+    # persisted transition.
+    session_epoch: int = Field(..., alias="sessionEpoch", ge=0)
     instructions: NonBlankStr = Field(..., alias="instructions")
     reason: NonBlankStr | None = Field(None, alias="reason")
     request_id: NonBlankStr | None = Field(None, alias="requestId")

--- a/moonmind/services/skill_resolution.py
+++ b/moonmind/services/skill_resolution.py
@@ -248,18 +248,20 @@ def _terminal_contract_from_side_effect(
         return None
     known = {
         "batch_workflows_fanout.v1": "moonmind.batch-workflows-result.v1",
+        "pr_resolver_terminal.v1": "moonmind.pr-resolver-result.v1",
     }
     if contract_id not in known:
         raise ValueError(
             f"skill '{owner}' selects unknown terminal contract '{contract_id}'"
         )
     relative_path = str(side_effect.get("outcomeArtifact") or "").strip()
-    path = Path(relative_path)
+    normalized_path = relative_path.replace("\\", "/")
+    path = Path(normalized_path)
     if not relative_path or path.is_absolute() or ".." in path.parts:
         raise ValueError(f"skill '{owner}' terminal outcomeArtifact is unsafe")
     return SkillTerminalContract(
         contract_id=contract_id,
-        relative_path=relative_path,
+        relative_path=normalized_path,
         expected_schema_version=known[contract_id],
     )
 

--- a/moonmind/services/skill_resolution.py
+++ b/moonmind/services/skill_resolution.py
@@ -257,7 +257,12 @@ def _terminal_contract_from_side_effect(
     relative_path = str(side_effect.get("outcomeArtifact") or "").strip()
     normalized_path = relative_path.replace("\\", "/")
     path = Path(normalized_path)
-    if not relative_path or path.is_absolute() or ".." in path.parts:
+    if (
+        not relative_path
+        or normalized_path.startswith("/")
+        or path.is_absolute()
+        or ".." in path.parts
+    ):
         raise ValueError(f"skill '{owner}' terminal outcomeArtifact is unsafe")
     return SkillTerminalContract(
         contract_id=contract_id,

--- a/moonmind/workflows/adapters/codex_session_adapter.py
+++ b/moonmind/workflows/adapters/codex_session_adapter.py
@@ -1788,7 +1788,7 @@ class CodexSessionAdapter(ManagedAgentAdapter):
         request: AgentExecutionRequest,
         workspace_path: str,
     ) -> None:
-        """Populate launch-safe durable metadata without installing skill projections."""
+        """Populate launch metadata, including the active skill projection."""
 
         if self._prepare_turn_instructions is None:
             return
@@ -1802,10 +1802,12 @@ class CodexSessionAdapter(ManagedAgentAdapter):
                     ),
                     "workspacePath": workspace_path,
                     "includePreparedRequestMetadata": True,
-                    "skipSkillMaterialization": True,
+                    "metadataOnly": True,
                 }
             )
         except Exception:
+            if selected_agent_skill(request.parameters):
+                raise
             logger.debug(
                 "Launch metadata preflight failed; real turn preparation will run after session launch.",
                 exc_info=True,
@@ -1816,6 +1818,14 @@ class CodexSessionAdapter(ManagedAgentAdapter):
                 request,
                 prepared.get("durableRetrievalMetadata"),
             )
+            active_skills_dir = str(prepared.get("activeSkillsDir") or "").strip()
+            if active_skills_dir:
+                request.parameters["_moonmindActiveSkillsDir"] = active_skills_dir
+            terminal_contract = prepared.get("terminalContract")
+            if isinstance(terminal_contract, Mapping):
+                request.terminal_contract = AgentTerminalContract.model_validate(
+                    dict(terminal_contract)
+                )
 
     def _managed_session_launch_environment(
         self,

--- a/moonmind/workflows/adapters/managed_agent_adapter.py
+++ b/moonmind/workflows/adapters/managed_agent_adapter.py
@@ -37,6 +37,7 @@ from moonmind.schemas.agent_runtime_models import (
     _ALLOWED_MANAGED_LAUNCH_METADATA_KEYS,
     _contains_sensitive_key,
     AgentExecutionRequest,
+    AgentTerminalContract,
     AgentRunHandle,
     AgentRunResult,
     AgentRunStatus,
@@ -1113,6 +1114,11 @@ class ManagedAgentAdapter:
                     "workspace_path": workspace_path,
                 }
             )
+            terminal_contract = record_dict.get("terminalContract")
+            if isinstance(terminal_contract, Mapping):
+                request.terminal_contract = AgentTerminalContract.model_validate(
+                    dict(terminal_contract)
+                )
             status = record_dict.get("status", "launching")
         elif self._run_store is not None:
             record = ManagedRunRecord(

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -7039,9 +7039,15 @@ class TemporalAgentRuntimeActivities:
             record_run_id = str(getattr(record, "run_id", "") or run_id).strip()
             await self._report_task_run_binding(workflow_id, record_run_id)
 
+        response = record.model_dump(mode="json")
+        if request.terminal_contract is not None:
+            response["terminalContract"] = request.terminal_contract.model_dump(
+                mode="json", by_alias=True
+            )
+
         if process is None:
             # Idempotent path: run is already active, skip secondary supervision
-            return record.model_dump(mode="json")
+            return response
 
         # Start background supervision — hold a strong reference so the task
         # is not garbage-collected before it completes.
@@ -7072,7 +7078,7 @@ class TemporalAgentRuntimeActivities:
         self._supervision_tasks.add(task)
         task.add_done_callback(self._supervision_tasks.discard)
 
-        return record.model_dump(mode="json")
+        return response
 
     async def workload_run(
         self,
@@ -8714,6 +8720,23 @@ class TemporalAgentRuntimeActivities:
                 request=request,
                 workspace_path=workspace_path_raw,
             )
+        if payload.get("metadataOnly") or payload.get("metadata_only"):
+            prepared_payload: dict[str, Any] = {
+                "durableRetrievalMetadata": extract_durable_retrieval_metadata(
+                    request.parameters
+                )
+            }
+            if skill_materialization_metadata:
+                prepared_payload["activeSkillsDir"] = str(
+                    skill_materialization_metadata.get("visiblePath") or ""
+                )
+            if request.terminal_contract is not None:
+                prepared_payload["terminalContract"] = (
+                    request.terminal_contract.model_dump(
+                        by_alias=True, exclude_none=True
+                    )
+                )
+            return prepared_payload
         instruction_ref = str(request.instruction_ref or "").strip()
         if instruction_ref:
             if not workspace_path_raw:
@@ -10308,7 +10331,7 @@ class TemporalAgentRuntimeActivities:
 
         result = AgentRunResult.model_validate(request.get("result") or {})
         contract = request.get("terminalContract")
-        if not isinstance(contract, Mapping) or result.failure_class is not None:
+        if not isinstance(contract, Mapping):
             return result
 
         workspace_path = str(request.get("workspacePath") or "").strip()
@@ -10320,7 +10343,9 @@ class TemporalAgentRuntimeActivities:
             workspace_path = str(getattr(record, "workspace_path", "") or "").strip()
 
         evaluation = evaluate_terminal_evidence(
-            dict(contract), workspace_path=workspace_path
+            dict(contract),
+            workspace_path=workspace_path,
+            artifact_spool_path=str(request.get("artifactSpoolPath") or "").strip(),
         )
         metadata = {**dict(result.metadata or {}), **dict(evaluation.metadata)}
         metadata["terminalContractId"] = str(contract.get("contractId") or "")
@@ -10339,6 +10364,15 @@ class TemporalAgentRuntimeActivities:
             }
         )
         missing = ", ".join(evaluation.missing_evidence) or "valid terminal evidence"
+        if result.failure_class is not None:
+            return result.model_copy(
+                update={
+                    "provider_error_code": result.provider_error_code
+                    or evaluation.failure_code
+                    or "missing_terminal_evidence",
+                    "metadata": metadata,
+                }
+            )
         return result.model_copy(
             update={
                 "summary": f"Agent completed without required terminal evidence: {missing}",

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -8720,7 +8720,8 @@ class TemporalAgentRuntimeActivities:
                 request=request,
                 workspace_path=workspace_path_raw,
             )
-        if payload.get("metadataOnly") or payload.get("metadata_only"):
+
+        def _prepared_request_metadata() -> dict[str, Any]:
             prepared_payload: dict[str, Any] = {
                 "durableRetrievalMetadata": extract_durable_retrieval_metadata(
                     request.parameters
@@ -8737,6 +8738,7 @@ class TemporalAgentRuntimeActivities:
                     )
                 )
             return prepared_payload
+
         instruction_ref = str(request.instruction_ref or "").strip()
         if instruction_ref:
             if not workspace_path_raw:
@@ -8755,6 +8757,8 @@ class TemporalAgentRuntimeActivities:
                     workspace_path_raw
                 )
             instruction_ref = str(request.instruction_ref or "").strip()
+            if payload.get("metadataOnly") or payload.get("metadata_only"):
+                return _prepared_request_metadata()
             if instruction_ref:
                 prepared = self._prepare_managed_codex_turn_text(
                     instruction_ref,
@@ -8780,6 +8784,8 @@ class TemporalAgentRuntimeActivities:
                         )
                     return prepared_payload
                 return prepared
+        if payload.get("metadataOnly") or payload.get("metadata_only"):
+            return _prepared_request_metadata()
         parameters = request.parameters if isinstance(request.parameters, dict) else {}
         instructions = str(parameters.get("instructions") or "").strip()
         if instructions:

--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -1936,7 +1936,11 @@ class MoonMindAgentRun:
             payload = await self._execute_routed_activity(
                 "agent_runtime.evaluate_terminal_evidence",
                 {
-                    "runId": str(self.run_id or ""),
+                    "runId": (
+                        request.managed_session.agent_run_id
+                        if request.managed_session is not None
+                        else str(self.run_id or "")
+                    ),
                     "workspacePath": workspace_path,
                     "artifactSpoolPath": (
                         os.path.join(

--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -1938,6 +1938,15 @@ class MoonMindAgentRun:
                 {
                     "runId": str(self.run_id or ""),
                     "workspacePath": workspace_path,
+                    "artifactSpoolPath": (
+                        os.path.join(
+                            _MANAGED_RUNTIME_STORE_ROOT,
+                            request.managed_session.agent_run_id,
+                            "artifacts",
+                        )
+                        if request.managed_session is not None
+                        else ""
+                    ),
                     "terminalContract": request.terminal_contract.model_dump(
                         mode="json", by_alias=True
                     ),
@@ -1956,7 +1965,7 @@ class MoonMindAgentRun:
             continuation_enabled = workflow.patched(
                 TERMINAL_CONTRACT_CONTINUATION_PATCH_ID
             )
-        except BaseException as exc:
+        except Exception as exc:
             # Direct activity-boundary tests execute this helper outside a
             # Temporal workflow event loop.
             if type(exc).__name__ != "_NotInWorkflowEventLoopError":
@@ -2014,9 +2023,14 @@ class MoonMindAgentRun:
                 snapshot_request,
                 cancellation_type=ActivityCancellationType.TRY_CANCEL,
             )
+            epoch_value = snapshot.get("sessionEpoch")
             turn_request = SendCodexManagedSessionTurnRequest(
                 sessionId=request.managed_session.session_id,
-                sessionEpoch=int(snapshot.get("sessionEpoch") or request.managed_session.session_epoch),
+                sessionEpoch=int(
+                    epoch_value
+                    if epoch_value is not None
+                    else request.managed_session.session_epoch
+                ),
                 containerId=snapshot.get("containerId"),
                 threadId=snapshot.get("threadId"),
                 instructions=_terminal_contract_continuation_instruction(missing),

--- a/moonmind/workflows/terminal_evidence.py
+++ b/moonmind/workflows/terminal_evidence.py
@@ -18,19 +18,25 @@ class TerminalEvidenceEvaluation:
 
 
 def evaluate_terminal_evidence(
-    contract: Mapping[str, Any], *, workspace_path: str
+    contract: Mapping[str, Any], *, workspace_path: str, artifact_spool_path: str = ""
 ) -> TerminalEvidenceEvaluation:
     contract_id = str(contract.get("contractId") or contract.get("contract_id") or "")
-    if contract_id != "batch_workflows_fanout.v1":
+    if contract_id not in {"batch_workflows_fanout.v1", "pr_resolver_terminal.v1"}:
         return TerminalEvidenceEvaluation(False, "UNSUPPORTED_TERMINAL_CONTRACT")
     relative = str(contract.get("relativePath") or contract.get("relative_path") or "")
-    relative_path = Path(relative)
+    normalized_relative = relative.replace("\\", "/")
+    relative_path = Path(normalized_relative)
     workspace = Path(workspace_path).resolve()
     if not relative or relative_path.is_absolute() or ".." in relative_path.parts:
         return TerminalEvidenceEvaluation(False, "INVALID_TERMINAL_EVIDENCE_PATH")
-    evidence_path = (workspace / relative_path).resolve()
+    evidence_root = workspace
+    evidence_relative = relative_path
+    if artifact_spool_path and relative_path.parts[:1] == ("artifacts",):
+        evidence_root = Path(artifact_spool_path).resolve()
+        evidence_relative = Path(*relative_path.parts[1:])
+    evidence_path = (evidence_root / evidence_relative).resolve()
     try:
-        evidence_path.relative_to(workspace)
+        evidence_path.relative_to(evidence_root)
     except ValueError:
         return TerminalEvidenceEvaluation(False, "INVALID_TERMINAL_EVIDENCE_PATH")
     if not evidence_path.is_file():
@@ -43,6 +49,33 @@ def evaluate_terminal_evidence(
         return TerminalEvidenceEvaluation(False, "MALFORMED_TERMINAL_EVIDENCE")
     if not isinstance(payload, dict):
         return TerminalEvidenceEvaluation(False, "MALFORMED_TERMINAL_EVIDENCE")
+    if contract_id == "pr_resolver_terminal.v1":
+        disposition = str(payload.get("mergeAutomationDisposition") or "").strip()
+        metadata = {
+            "terminalContractId": contract_id,
+            "terminalContractEvidencePath": normalized_relative,
+            "mergeAutomationDisposition": disposition,
+        }
+        if disposition not in {
+            "merged",
+            "already_merged",
+            "reenter_gate",
+            "manual_review",
+            "failed",
+        }:
+            return TerminalEvidenceEvaluation(
+                False, "MALFORMED_TERMINAL_EVIDENCE", metadata=metadata
+            )
+        if disposition in {"merged", "already_merged"}:
+            publish_path = (workspace / "artifacts/publish_result.json").resolve()
+            if not publish_path.is_file():
+                return TerminalEvidenceEvaluation(
+                    False,
+                    "INCOMPLETE_TERMINAL_CONTRACT",
+                    ("artifacts/publish_result.json",),
+                    metadata,
+                )
+        return TerminalEvidenceEvaluation(True, metadata=metadata)
     expected_schema = str(
         contract.get("expectedSchemaVersion")
         or contract.get("expected_schema_version")
@@ -55,7 +88,7 @@ def evaluate_terminal_evidence(
         return TerminalEvidenceEvaluation(False, "INVALID_TERMINAL_EVIDENCE")
     if not expected_execution or payload.get("executionRef") != expected_execution:
         return TerminalEvidenceEvaluation(False, "STALE_TERMINAL_EVIDENCE")
-    targets_relative = str(contract.get("targetsRelativePath") or "artifacts/batch-workflows-targets.json")
+    targets_relative = str(contract.get("targetsRelativePath") or "artifacts/batch-workflows-targets.json").replace("\\", "/")
     targets_path = (workspace / targets_relative).resolve()
     try:
         targets_path.relative_to(workspace)

--- a/moonmind/workflows/terminal_evidence.py
+++ b/moonmind/workflows/terminal_evidence.py
@@ -51,11 +51,19 @@ def evaluate_terminal_evidence(
         return TerminalEvidenceEvaluation(False, "MALFORMED_TERMINAL_EVIDENCE")
     if contract_id == "pr_resolver_terminal.v1":
         disposition = str(payload.get("mergeAutomationDisposition") or "").strip()
+        expected_execution = str(
+            contract.get("executionRef") or contract.get("execution_ref") or ""
+        ).strip()
+        evidence_execution = str(payload.get("executionRef") or "").strip()
         metadata = {
             "terminalContractId": contract_id,
             "terminalContractEvidencePath": normalized_relative,
             "mergeAutomationDisposition": disposition,
         }
+        if not expected_execution or evidence_execution != expected_execution:
+            return TerminalEvidenceEvaluation(
+                False, "STALE_TERMINAL_EVIDENCE", metadata=metadata
+            )
         if disposition not in {
             "merged",
             "already_merged",
@@ -79,7 +87,15 @@ def evaluate_terminal_evidence(
                     ("artifacts/publish_result.json",),
                     metadata,
                 )
-        return TerminalEvidenceEvaluation(True, metadata=metadata)
+            return TerminalEvidenceEvaluation(True, metadata=metadata)
+        failure_codes = {
+            "reenter_gate": "PR_RESOLVER_REENTER_GATE",
+            "manual_review": "PR_RESOLVER_MANUAL_REVIEW",
+            "failed": "PR_RESOLVER_FAILED",
+        }
+        return TerminalEvidenceEvaluation(
+            False, failure_codes[disposition], metadata=metadata
+        )
     expected_schema = str(
         contract.get("expectedSchemaVersion")
         or contract.get("expected_schema_version")

--- a/moonmind/workflows/terminal_evidence.py
+++ b/moonmind/workflows/terminal_evidence.py
@@ -68,6 +68,10 @@ def evaluate_terminal_evidence(
             )
         if disposition in {"merged", "already_merged"}:
             publish_path = (workspace / "artifacts/publish_result.json").resolve()
+            if artifact_spool_path and not publish_path.is_file():
+                publish_path = (
+                    Path(artifact_spool_path) / "publish_result.json"
+                ).resolve()
             if not publish_path.is_file():
                 return TerminalEvidenceEvaluation(
                     False,

--- a/tests/unit/api/test_batch_github_workflows_preset.py
+++ b/tests/unit/api/test_batch_github_workflows_preset.py
@@ -106,6 +106,4 @@ async def test_batch_github_workflows_uses_repository_context(tmp_path):
     assert source["githubIssueRange"]["repository"] == (
         "MoonLadderStudios/MoonMind"
     )
-    assert expanded["steps"][0]["skill"]["id"] == (
-        "queue-moonmind-workflows"
-    )
+    assert expanded["steps"][0]["skill"]["id"] == "batch-workflows"

--- a/tests/unit/schemas/test_agent_runtime_models.py
+++ b/tests/unit/schemas/test_agent_runtime_models.py
@@ -7,6 +7,7 @@ from pydantic import ValidationError
 
 from moonmind.schemas.agent_runtime_models import (
     AgentExecutionRequest,
+    AgentTerminalContract,
     AgentRuntimeStepExecutionLaunch,
     AgentRunResult,
     AgentRunStatus,
@@ -22,6 +23,24 @@ from moonmind.schemas.agent_runtime_models import (
     is_terminal_agent_run_state,
     resolve_managed_runtime_workload_mode,
 )
+
+
+def test_terminal_contract_normalizes_backslash_separators() -> None:
+    contract = AgentTerminalContract(
+        contractId="batch_workflows_fanout.v1",
+        relativePath="artifacts\\result.json",
+        expectedSchemaVersion="v1",
+        executionRef="step-1",
+    )
+    assert contract.relative_path == "artifacts/result.json"
+
+    with pytest.raises(ValidationError, match="traversal-free"):
+        AgentTerminalContract(
+            contractId="batch_workflows_fanout.v1",
+            relativePath="..\\result.json",
+            expectedSchemaVersion="v1",
+            executionRef="step-1",
+        )
 
 
 def _removed_runtime_marker() -> str:

--- a/tests/unit/services/test_skill_resolution.py
+++ b/tests/unit/services/test_skill_resolution.py
@@ -109,6 +109,9 @@ async def test_built_in_pr_resolver_declares_portable_native_contract():
     assert entry.implementation.supported_hosts == ["cli", "temporal"]
     assert entry.implementation.native_host_eligible is True
     assert entry.provenance.source_kind == AgentSkillSourceKind.BUILT_IN
+    assert entry.terminal_contract is not None
+    assert entry.terminal_contract.contract_id == "pr_resolver_terminal.v1"
+    assert entry.terminal_contract.relative_path == "var/pr_resolver/result.json"
 
 async def test_built_in_loader_resolves_batch_dependabot_resolver_by_name(tmp_path):
     """FR-012: batch-dependabot-resolver MUST be resolvable by name through the

--- a/tests/unit/services/test_skill_resolution.py
+++ b/tests/unit/services/test_skill_resolution.py
@@ -15,6 +15,7 @@ from moonmind.services.skill_resolution import (
     LocalSkillLoader,
     RepoSkillLoader,
     DeploymentSkillLoader,
+    _terminal_contract_from_side_effect,
     extract_side_effect_metadata_from_skill_markdown,
 )
 
@@ -41,6 +42,17 @@ metadata:
         "owner": "agent",
         "outcomeArtifact": "artifacts/result.json",
     }
+
+
+async def test_terminal_contract_rejects_rooted_posix_path() -> None:
+    with pytest.raises(ValueError, match="outcomeArtifact is unsafe"):
+        _terminal_contract_from_side_effect(
+            {
+                "terminalContractId": "batch_workflows_fanout.v1",
+                "outcomeArtifact": "/absolute/result.json",
+            },
+            owner="batch-workflows",
+        )
 
 
 async def test_resolver_can_resolve_empty_selector():

--- a/tests/unit/test_batch_workflows.py
+++ b/tests/unit/test_batch_workflows.py
@@ -14,6 +14,7 @@ import shutil
 import subprocess
 import sys
 import threading
+import urllib.error
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from typing import Any
@@ -39,6 +40,37 @@ def _load_module() -> dict[str, Any]:
             / "batch_workflows.py"
         )
     )
+
+
+def test_http_error_body_read_is_bounded(monkeypatch: pytest.MonkeyPatch) -> None:
+    module = _load_module()
+    read_sizes: list[int | None] = []
+
+    class BoundedHTTPError(urllib.error.HTTPError):
+        def read(self, amt: int | None = None) -> bytes:
+            read_sizes.append(amt)
+            return b"invalid response: \xff"
+
+    def raise_http_error(*_args: object, **_kwargs: object) -> None:
+        raise BoundedHTTPError(
+            "https://moonmind.invalid/api/executions", 503, "unavailable", {}, None
+        )
+
+    submit = module["_submit_jobs_via_http"]
+    monkeypatch.setattr(submit.__globals__["urllib"].request, "urlopen", raise_http_error)
+    submission = module["ChildSubmission"](
+        queue_request={"type": "run", "payload": {}},
+        provider="jira",
+        ref="MM-1",
+    )
+
+    created, errors = submit(
+        [submission], moonmind_url="https://moonmind.invalid", worker_token=None
+    )
+
+    assert created == []
+    assert read_sizes == [65536]
+    assert "invalid response" in errors[0]["error"]
 
 
 _JIRA_TARGET: dict[str, Any] = {

--- a/tests/unit/test_batch_workflows.py
+++ b/tests/unit/test_batch_workflows.py
@@ -690,4 +690,5 @@ def test_materialized_helper_failure_matrix_preserves_authoritative_evidence(tmp
     assert partial_evidence["created"] == 2
     assert [item["workflowId"] for item in partial_evidence["queued"]] == ["child-1", "child-2"]
     assert len(partial_evidence["errors"]) == 3
+    assert "injected partial failure" in partial_evidence["errors"][0]["error"]
     assert partial_evidence["executionRef"] == "step-matrix"

--- a/tests/unit/workflows/adapters/test_codex_session_adapter.py
+++ b/tests/unit/workflows/adapters/test_codex_session_adapter.py
@@ -720,10 +720,10 @@ async def test_start_prepares_turn_instructions_after_cold_session_launch(
 
     async def _prepare_after_launch(payload: dict[str, Any]) -> str:
         assert payload["workspacePath"] == str(workspace_path)
-        if payload.get("skipSkillMaterialization") is True:
+        if payload.get("metadataOnly") is True:
             call_order.append("preflight")
             assert not (workspace_path / ".launch-complete").exists()
-            return "metadata preflight\n\nManaged Codex CLI note:"
+            return {"durableRetrievalMetadata": {}}
         call_order.append("prepare")
         assert (workspace_path / ".launch-complete").is_file()
         return "prepared after launch\n\nManaged Codex CLI note:"
@@ -3603,6 +3603,7 @@ async def test_start_populates_launch_metadata_from_prepared_turn_request(
         prepare_calls.append(bool(payload.get("skipSkillMaterialization")))
         return {
             "instructions": "Injected context instruction\n\nManaged Codex CLI note:",
+            "activeSkillsDir": "/work/runtime/skills_active/snapshot-1",
             "durableRetrievalMetadata": {
                 "latestContextPackRef": "artifacts/context/rag-context-prepared.json",
                 "retrievedContextArtifactPath": "artifacts/context/rag-context-prepared.json",
@@ -3674,8 +3675,12 @@ async def test_start_populates_launch_metadata_from_prepared_turn_request(
     await adapter.start(request)
 
     assert len(launch_calls) == 1
-    assert prepare_calls == [True, False]
+    assert prepare_calls == [False, False]
     launch_request = launch_calls[0]["request"]
+    assert (
+        launch_request["environment"]["MOONMIND_ACTIVE_SKILLS_DIR"]
+        == "/work/runtime/skills_active/snapshot-1"
+    )
     assert (
         launch_request["metadata"]["latestContextPackRef"]
         == "artifacts/context/rag-context-prepared.json"

--- a/tests/unit/workflows/adapters/test_managed_agent_adapter.py
+++ b/tests/unit/workflows/adapters/test_managed_agent_adapter.py
@@ -953,6 +953,47 @@ async def test_start_falls_back_to_runtime_default_model_when_profile_blank() ->
     assert profile_payload.get("defaultModel") == "gpt-5.5"
     assert profile_payload.get("defaultEffort") == "high"
 
+
+async def test_start_carries_launcher_terminal_contract_back_to_workflow_request() -> None:
+    from moonmind.schemas.agent_runtime_models import AgentExecutionRequest
+
+    async def _run_launcher(**_kwargs: Any):
+        return {
+            "status": "launching",
+            "terminalContract": {
+                "contractId": "batch_workflows_fanout.v1",
+                "owner": "agent",
+                "evidenceKind": "workspace_json",
+                "relativePath": "artifacts/batch-workflows-result.json",
+                "expectedSchemaVersion": "moonmind.batch-workflows-result.v1",
+                "executionRef": "step-1",
+            },
+        }
+
+    adapter = ManagedAgentAdapter(
+        profile_fetcher=_fake_profiles(
+            [{"profile_id": "claude-default", "command_template": ["claude"]}]
+        ),
+        slot_requester=_async_noop,
+        slot_releaser=_async_noop,
+        cooldown_reporter=_async_noop,
+        workflow_id="wf-terminal-contract",
+        runtime_id="claude_code",
+        run_launcher=_run_launcher,
+    )
+    request = AgentExecutionRequest(
+        agentKind="managed",
+        agentId="claude_code",
+        executionProfileRef="claude-default",
+        correlationId="corr-terminal-contract",
+        idempotencyKey="idem-terminal-contract",
+    )
+
+    await adapter.start(request)
+
+    assert request.terminal_contract is not None
+    assert request.terminal_contract.contract_id == "batch_workflows_fanout.v1"
+
 async def test_start_applies_proxy_mode_when_tagged_proxy_first(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("MOONMIND_ALLOW_LOCAL_ENCRYPTION_KEY_GENERATION", "1")
     profiles = [

--- a/tests/unit/workflows/temporal/test_agent_runtime_activities.py
+++ b/tests/unit/workflows/temporal/test_agent_runtime_activities.py
@@ -5360,9 +5360,11 @@ async def test_agent_runtime_prepare_turn_instructions_includes_context_artifact
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("metadata_only", [False, True])
 async def test_agent_runtime_prepare_turn_instructions_returns_durable_retrieval_metadata_when_requested(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
+    metadata_only: bool,
 ) -> None:
     async def _fake_to_thread(func, *args, **kwargs):
         return func(*args, **kwargs)
@@ -5402,11 +5404,15 @@ async def test_agent_runtime_prepare_turn_instructions_returns_durable_retrieval
             },
             "workspacePath": str(tmp_path),
             "includePreparedRequestMetadata": True,
+            "metadataOnly": metadata_only,
         }
     )
 
     assert isinstance(result, dict)
-    assert "BEGIN_RETRIEVED_CONTEXT" in result["instructions"]
+    if metadata_only:
+        assert "instructions" not in result
+    else:
+        assert "BEGIN_RETRIEVED_CONTEXT" in result["instructions"]
     assert result["durableRetrievalMetadata"]["latestContextPackRef"].startswith(
         "artifacts/context/"
     )

--- a/tests/unit/workflows/temporal/test_agent_runtime_activities.py
+++ b/tests/unit/workflows/temporal/test_agent_runtime_activities.py
@@ -6161,3 +6161,54 @@ async def test_terminal_evidence_activity_fails_completed_prose_without_artifact
     assert result.failure_class == "execution_error"
     assert result.metadata["terminalContractAuthority"] == "MoonMind.AgentRun"
     assert result.metadata["failureCode"] == "INCOMPLETE_TERMINAL_CONTRACT"
+
+
+@pytest.mark.asyncio
+async def test_terminal_evidence_activity_enriches_existing_helper_failure(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "repo"
+    spool = tmp_path / "spool"
+    targets = workspace / "artifacts/batch-workflows-targets.json"
+    targets.parent.mkdir(parents=True)
+    targets.write_text("[]", encoding="utf-8")
+    spool.mkdir()
+    (spool / "batch-workflows-result.json").write_text(
+        json.dumps(
+            {
+                "schemaVersion": "moonmind.batch-workflows-result.v1",
+                "contractId": "batch_workflows_fanout.v1",
+                "executionRef": "step-1",
+                "targetsSha256": hashlib.sha256(b"[]").hexdigest(),
+                "status": "partial_failure",
+                "requested": 2,
+                "created": 1,
+                "queued": [{"executionId": "child-1"}],
+                "skipped": [],
+                "errors": [{"ref": "MM-2", "error": "unavailable"}],
+            }
+        ),
+        encoding="utf-8",
+    )
+    activities = TemporalAgentRuntimeActivities()
+    result = await activities.agent_runtime_evaluate_terminal_evidence(
+        {
+            "workspacePath": str(workspace),
+            "artifactSpoolPath": str(spool),
+            "terminalContract": {
+                "contractId": "batch_workflows_fanout.v1",
+                "relativePath": "artifacts/batch-workflows-result.json",
+                "expectedSchemaVersion": "moonmind.batch-workflows-result.v1",
+                "executionRef": "step-1",
+            },
+            "result": {
+                "summary": "helper exited 1",
+                "failureClass": "execution_error",
+                "providerErrorCode": "process_exit_1",
+            },
+        }
+    )
+    assert result.summary == "helper exited 1"
+    assert result.provider_error_code == "process_exit_1"
+    assert result.metadata["failureCode"] == "BATCH_FANOUT_PARTIAL_FAILURE"
+    assert result.metadata["queuedChildren"] == [{"executionId": "child-1"}]

--- a/tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py
@@ -138,6 +138,7 @@ async def test_terminal_contract_continuation_is_agent_run_owned_and_bounded(
     assert result.failure_class is None
     assert result.metadata["terminalContractRecoveryOutcome"] == "recovered"
     assert result.metadata["terminalContractContinuationCount"] == 1
+    assert calls[0][1]["runId"] == "wf-task-1"
     assert [name for name, _ in calls] == [
         "agent_runtime.evaluate_terminal_evidence",
         "agent_runtime.load_session_snapshot",

--- a/tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py
@@ -123,7 +123,7 @@ async def test_terminal_contract_continuation_is_agent_run_owned_and_bounded(
                 }
             return {"summary": "recovered", "metadata": {}}
         if name == "agent_runtime.load_session_snapshot":
-            return {"sessionEpoch": 1, "containerId": "ctr-1", "threadId": "thr-1"}
+            return {"sessionEpoch": 0, "containerId": "ctr-1", "threadId": "thr-1"}
         if name == "agent_runtime.send_turn":
             return {"status": "completed"}
         if name == "agent_runtime.fetch_result":
@@ -147,6 +147,7 @@ async def test_terminal_contract_continuation_is_agent_run_owned_and_bounded(
     ]
     turn = calls[2][1]
     assert turn.request_id == "idem-managed-1:terminal-contract:1"
+    assert turn.session_epoch == 0
 
 
 async def test_terminal_contract_fails_immediately_when_runtime_cannot_continue(
@@ -222,6 +223,7 @@ async def test_terminal_contract_continuation_exhaustion_is_agent_run_owned(
     assert {(turn.session_id, turn.thread_id) for turn in turns} == {
         ("sess:wf-task-1:codex_cli", "thr-1")
     }
+    assert {turn.session_epoch for turn in turns} == {1}
 
 
 async def test_terminal_contract_provider_failure_retains_contract_context(

--- a/tests/unit/workflows/test_terminal_evidence.py
+++ b/tests/unit/workflows/test_terminal_evidence.py
@@ -100,7 +100,13 @@ def test_pr_resolver_terminal_requires_result_and_publish_evidence(tmp_path: Pat
     result_path = tmp_path / "var/pr_resolver/result.json"
     result_path.parent.mkdir(parents=True)
     result_path.write_text(
-        json.dumps({"mergeAutomationDisposition": "merged"}), encoding="utf-8"
+        json.dumps(
+            {
+                "mergeAutomationDisposition": "merged",
+                "executionRef": "step-1",
+            }
+        ),
+        encoding="utf-8",
     )
     missing_publish = evaluate_terminal_evidence(contract, workspace_path=str(tmp_path))
     assert missing_publish.failure_code == "INCOMPLETE_TERMINAL_CONTRACT"
@@ -116,7 +122,12 @@ def test_pr_resolver_terminal_accepts_publish_evidence_from_spool(tmp_path: Path
     result_path = workspace / "var/pr_resolver/result.json"
     result_path.parent.mkdir(parents=True)
     result_path.write_text(
-        json.dumps({"mergeAutomationDisposition": "already_merged"}),
+        json.dumps(
+            {
+                "mergeAutomationDisposition": "already_merged",
+                "executionRef": "step-1",
+            }
+        ),
         encoding="utf-8",
     )
     spool.mkdir()
@@ -135,3 +146,57 @@ def test_pr_resolver_terminal_accepts_publish_evidence_from_spool(tmp_path: Path
     )
 
     assert result.satisfied is True
+
+
+@pytest.mark.parametrize(
+    ("disposition", "failure_code"),
+    [
+        ("reenter_gate", "PR_RESOLVER_REENTER_GATE"),
+        ("manual_review", "PR_RESOLVER_MANUAL_REVIEW"),
+        ("failed", "PR_RESOLVER_FAILED"),
+    ],
+)
+def test_pr_resolver_terminal_rejects_unsuccessful_dispositions(
+    tmp_path: Path, disposition: str, failure_code: str
+) -> None:
+    result_path = tmp_path / "var/pr_resolver/result.json"
+    result_path.parent.mkdir(parents=True)
+    result_path.write_text(
+        json.dumps(
+            {"mergeAutomationDisposition": disposition, "executionRef": "step-1"}
+        ),
+        encoding="utf-8",
+    )
+    contract = {
+        "contractId": "pr_resolver_terminal.v1",
+        "relativePath": "var/pr_resolver/result.json",
+        "expectedSchemaVersion": "moonmind.pr-resolver-result.v1",
+        "executionRef": "step-1",
+    }
+
+    result = evaluate_terminal_evidence(contract, workspace_path=str(tmp_path))
+
+    assert result.satisfied is False
+    assert result.failure_code == failure_code
+
+
+def test_pr_resolver_terminal_rejects_stale_execution(tmp_path: Path) -> None:
+    result_path = tmp_path / "var/pr_resolver/result.json"
+    result_path.parent.mkdir(parents=True)
+    result_path.write_text(
+        json.dumps(
+            {"mergeAutomationDisposition": "merged", "executionRef": "old-step"}
+        ),
+        encoding="utf-8",
+    )
+    contract = {
+        "contractId": "pr_resolver_terminal.v1",
+        "relativePath": "var/pr_resolver/result.json",
+        "expectedSchemaVersion": "moonmind.pr-resolver-result.v1",
+        "executionRef": "current-step",
+    }
+
+    result = evaluate_terminal_evidence(contract, workspace_path=str(tmp_path))
+
+    assert result.satisfied is False
+    assert result.failure_code == "STALE_TERMINAL_EVIDENCE"

--- a/tests/unit/workflows/test_terminal_evidence.py
+++ b/tests/unit/workflows/test_terminal_evidence.py
@@ -69,3 +69,42 @@ def test_batch_terminal_rejects_missing_stale_and_traversal(tmp_path: Path) -> N
     assert evaluate_terminal_evidence(_contract("other"), workspace_path=str(tmp_path)).failure_code == "STALE_TERMINAL_EVIDENCE"
     unsafe = {**_contract(), "relativePath": "../result.json"}
     assert evaluate_terminal_evidence(unsafe, workspace_path=str(tmp_path)).failure_code == "INVALID_TERMINAL_EVIDENCE_PATH"
+    backslash_unsafe = {**_contract(), "relativePath": "..\\result.json"}
+    assert evaluate_terminal_evidence(backslash_unsafe, workspace_path=str(tmp_path)).failure_code == "INVALID_TERMINAL_EVIDENCE_PATH"
+
+
+def test_batch_terminal_reads_result_from_artifact_spool(tmp_path: Path) -> None:
+    workspace = tmp_path / "repo"
+    spool = tmp_path / "spool"
+    _write(workspace, status="queued", requested=1, queued=[{"executionId": "child-1"}])
+    spool.mkdir()
+    (workspace / "artifacts/batch-workflows-result.json").replace(
+        spool / "batch-workflows-result.json"
+    )
+    result = evaluate_terminal_evidence(
+        _contract(),
+        workspace_path=str(workspace),
+        artifact_spool_path=str(spool),
+    )
+    assert result.satisfied is True
+    assert result.metadata["queuedChildren"] == [{"executionId": "child-1"}]
+
+
+def test_pr_resolver_terminal_requires_result_and_publish_evidence(tmp_path: Path) -> None:
+    contract = {
+        "contractId": "pr_resolver_terminal.v1",
+        "relativePath": "var/pr_resolver/result.json",
+        "expectedSchemaVersion": "moonmind.pr-resolver-result.v1",
+        "executionRef": "step-1",
+    }
+    result_path = tmp_path / "var/pr_resolver/result.json"
+    result_path.parent.mkdir(parents=True)
+    result_path.write_text(
+        json.dumps({"mergeAutomationDisposition": "merged"}), encoding="utf-8"
+    )
+    missing_publish = evaluate_terminal_evidence(contract, workspace_path=str(tmp_path))
+    assert missing_publish.failure_code == "INCOMPLETE_TERMINAL_CONTRACT"
+    publish_path = tmp_path / "artifacts/publish_result.json"
+    publish_path.parent.mkdir()
+    publish_path.write_text("{}", encoding="utf-8")
+    assert evaluate_terminal_evidence(contract, workspace_path=str(tmp_path)).satisfied

--- a/tests/unit/workflows/test_terminal_evidence.py
+++ b/tests/unit/workflows/test_terminal_evidence.py
@@ -108,3 +108,30 @@ def test_pr_resolver_terminal_requires_result_and_publish_evidence(tmp_path: Pat
     publish_path.parent.mkdir()
     publish_path.write_text("{}", encoding="utf-8")
     assert evaluate_terminal_evidence(contract, workspace_path=str(tmp_path)).satisfied
+
+
+def test_pr_resolver_terminal_accepts_publish_evidence_from_spool(tmp_path: Path) -> None:
+    workspace = tmp_path / "repo"
+    spool = tmp_path / "spool"
+    result_path = workspace / "var/pr_resolver/result.json"
+    result_path.parent.mkdir(parents=True)
+    result_path.write_text(
+        json.dumps({"mergeAutomationDisposition": "already_merged"}),
+        encoding="utf-8",
+    )
+    spool.mkdir()
+    (spool / "publish_result.json").write_text("{}", encoding="utf-8")
+    contract = {
+        "contractId": "pr_resolver_terminal.v1",
+        "relativePath": "var/pr_resolver/result.json",
+        "expectedSchemaVersion": "moonmind.pr-resolver-result.v1",
+        "executionRef": "step-1",
+    }
+
+    result = evaluate_terminal_evidence(
+        contract,
+        workspace_path=str(workspace),
+        artifact_spool_path=str(spool),
+    )
+
+    assert result.satisfied is True


### PR DESCRIPTION
## Summary

Preserves the automated review fixes that were pushed after #3196 had already merged.

- hardens terminal-evidence path confinement against backslash traversal
- makes selected skill snapshots and terminal contracts available at managed-runtime launch boundaries
- preserves batch fan-out evidence for partial helper failures and reads managed-session results from the artifact spool
- restores PR-resolver CLI fallback terminal recovery alongside the newer native Temporal host
- fixes epoch-zero continuation, HTTP error diagnostics, and GitHub batch helper ownership

## Why

PR #3196 merged during comment remediation, so commit `509f3590a` landed on its source branch after the squash merge and never reached `main`. This rebases those fixes onto current `main`, including the native PR-resolver work from #3204.

## Validation

- focused changed-area matrix: 528 passed
- full backend suite: 8,651 passed; 2 known macOS-only `/tmp` versus `/private/tmp` path assertion failures in `test_github_auth_broker.py`
- hermetic `integration_ci`: 428 passed, 1 skipped
