### PR TITLE
Define Omnigent host OAuth and reorder the runtime roadmap

### DIFF
--- a/docs/MoonMindRoadmap.md
+++ b/docs/MoonMindRoadmap.md
@@ -6,7 +6,7 @@
 >
 > **Document class:** this roadmap is an *imperative execution tracker* (milestones, tasks, status). Per `docs/Workflows/MoonSpecDocumentModel.md`, durable desired state lives in the canonical declarative `docs/` files each milestone names in its `X.0` task — not here. When the two disagree, the declarative docs win.
 >
-> Last updated: 2026-07-10
+> Last updated: 2026-07-11
 
 ---
 
@@ -20,6 +20,13 @@ The target split is:
 - **Omnigent host owns** live harness execution, Codex/Claude process lifecycle inside the host environment, host-side workspace resources, live session events, and harness-specific launch details.
 - **The MoonMind Omnigent bridge owns** the compatibility boundary between those systems: session creation/attachment, event streaming, Workflow Detail chat projection, resource harvesting, artifact publication, and retry-safe external-state evidence.
 - **Direct Codex/Claude managed-session code remains compatibility substrate** until the bridge and host path can fully replace it. New roadmap work should land through the Omnigent host/bridge path or produce evidence compatible with that path.
+
+The critical path is intentionally ordered:
+
+1. reuse the Claude and Codex OAuth profiles created in Settings in one profile-bound Omnigent host at a time;
+2. stabilize the Omnigent bridge and Workflow Detail communication model against that credentialed host;
+3. let workflows request retry-safe, on-demand Omnigent host containers through the same profile and bridge contracts; and
+4. checkpoint Omnigent sessions from bridge/artifact evidence so recovery does not depend on one container remaining alive.
 
 Completed historical milestones have been removed from the active roadmap. The sections below track only remaining work that materially advances the Omnigent-host direction.
 
@@ -60,6 +67,9 @@ These are not active roadmap milestones, but they are important assumptions for 
 - `omnigent_bridge_sessions` is the canonical durable store for Omnigent bridge/session state, first-message idempotency, terminal refs, and normalized event indexing.
 - Omnigent terminal evidence can include normalized/raw stream artifacts, initial/final snapshots, capture manifests, diagnostics, changed files, workspace files, optional diffs, session files, child-session evidence, and `checkpoint.omnigent.external_state.json`.
 - The run workflow records per-step Omnigent external-agent identity and passes it into checkpoint policy resolution, so Omnigent checkpoint captures select the `external_state_ref` lane.
+- The Settings/OAuth Session path already creates or reuses named Claude and Codex auth volumes, verifies CLI credential state, and registers connected Provider Profiles; Omnigent host reuse and hard OAuth concurrency enforcement remain unfinished.
+- `ProviderProfileManager` already owns durable per-runtime profile leases, cooldowns, stale-lease recovery, and `max_parallel_runs`; the Omnigent path must use that same capacity ledger rather than creating a parallel host-only counter.
+- A dedicated local Claude Omnigent host Compose overlay proves the basic volume/home-path wiring, but supported profile routing, lifecycle ownership, Codex parity, and zero-manual-step startup remain incomplete.
 - Workflow RAG already has the core ContextPack, gateway/direct transport, Qdrant, multi-collection, overlay, budgeting, and artifact/ref model used by the current managed-session path.
 - Dashboard list/detail display modes exist for Workflows and Recurring Schedules through the shared collection workspace and sidebar primitives.
 - The Checkpoint Branch API and persistence model already support branch create, turn launch, continue, fork, compare, promote, archive, source checkpoint identity, instruction digest, workspace policy, turn ids, git binding, and remediation-created branches; remaining work is the operator/UI/default-flow and Omnigent runtime handoff.
@@ -90,92 +100,98 @@ These are not active roadmap milestones, but they are important assumptions for 
 
 ---
 
-## Milestone 2 — Omnigent Host Auth Volumes & Runtime Profile Contract 🚧
+## Milestone 2 — Omnigent Host OAuth from MoonMind Settings 🚧
 
-**Goal:** Codex and Claude Code auth volumes can be used safely and predictably with Omnigent hosts.
+**Goal:** Claude Code / Anthropic and Codex CLI / OpenAI OAuth configured through MoonMind Settings can be used by profile-bound Omnigent hosts with one global concurrent consumer per OAuth profile.
 
-**Why it matters:** Omnigent host becomes the unified runtime only if it can consume the same operator-authenticated Codex and Claude credentials that MoonMind currently manages, without leaking raw secrets into workflow payloads or making auth state ambient across runtimes.
+**Why it matters:** OAuth-backed CLI homes contain mutable access, refresh, and account state. Omnigent host can become the unified runtime only if it consumes the same verified Provider Profiles and volumes as direct MoonMind execution while preventing concurrent refresh writers, second login ceremonies, ambient credentials, and manual host selection.
 
 ### Remaining work
 
-- [ ] **2.0 Declarative design first** — define the runtime-neutral `AuthVolumeRef`/`CredentialMountRef` contract and the provider-profile→host-volume mapping as target state in `docs/Security/ProviderProfiles.md` and `docs/Security/SecretsSystem.md`, cross-linked from `docs/Omnigent/OmnigentAdapter.md`, before materialization code.
-- [ ] **2.1 Auth materialization inventory** — document how Codex and Claude OAuth/API-key auth state is currently created, stored, refreshed, redacted, and mounted by direct MoonMind managed sessions.
-- [ ] **2.2 Host auth volume contract** — define a runtime-neutral `AuthVolumeRef`/`CredentialMountRef` contract that maps MoonMind provider profiles to Omnigent host-visible credential volumes.
-- [ ] **2.3 Codex host volume support** — make Codex auth volumes available to Omnigent hosts with correct mount paths, ownership, permissions, refresh boundaries, and redaction metadata.
-- [ ] **2.4 Claude Code host volume support** — make Claude Code auth volumes available to Omnigent hosts with equivalent lifecycle, isolation, and validation guarantees.
-- [ ] **2.5 SecretRef-only durable state** — ensure workflow, checkpoint, bridge, and remediation payloads carry only profile refs, endpoint refs, and auth-volume refs; raw tokens and generated credential bodies must remain launch-boundary only.
-- [ ] **2.6 Local compose/dev profile** — add local Docker Compose and documented development configuration that can run MoonMind + Omnigent host with Codex/Claude auth volumes mounted through the supported contract.
-- [ ] **2.7 Host auth diagnostics** — expose actionable diagnostics when auth volume creation, mounting, refresh, or runtime detection fails.
-- [ ] **2.8 Boundary tests** — cover credential non-leakage, wrong-runtime isolation, revoked/missing auth, volume cleanup, and retry-safe remount behavior.
+- [x] **2.0 Declarative design first** — `docs/Omnigent/OmnigentHostOAuth.md` defines the Settings-to-Provider-Profile-to-host desired state, the global concurrency-one invariant, profile-bound host model, bridge/checkpoint handoff, and acceptance criteria.
+- [ ] **2.1 OAuth concurrency invariant** — enforce `max_parallel_runs = 1` for supported Claude/Codex `oauth_volume` profiles in OAuth finalization, Provider Profile create/update APIs, Settings UI, migrations/readiness, and the Provider Profile Manager; do not allow workflow-level overrides.
+- [ ] **2.2 Shared credential-capacity lane** — make direct managed execution, Omnigent execution, and reconnect/disconnect maintenance acquire the same backing Provider Profile lease so only one active consumer can read/refresh/write the OAuth identity.
+- [ ] **2.3 Runtime-neutral host credential binding** — implement safe `AuthVolumeRef`, `CredentialMountRef`, profile-to-host binding, credential-generation, and host-lease references without putting credential bodies into Temporal, bridge, checkpoint, or artifact payloads.
+- [ ] **2.4 Claude Code host OAuth** — bind the selected Claude OAuth volume to one dedicated host at the correct home path, clear competing credentials, manage `.claude.json` separately, run `claude auth status` in the exact host environment, and allow at most one active runner.
+- [ ] **2.5 Codex CLI host OAuth** — provide equivalent Codex volume/home/config shaping and login-status verification, with no ambient API-key/custom-provider override and at most one active runner.
+- [ ] **2.6 Profile-aware host routing** — let Omnigent requests select `executionProfileRef`; resolve the compatible harness and exact host binding automatically, and remove manual `hostId` extraction or workflow JSON editing from the operator path.
+- [ ] **2.7 Supported local Compose path** — make init, UID/GID repair, state-volume setup, OAuth readiness wait, stable host identity, registration, restart behavior, Claude/Codex service activation, and diagnostics part of Compose/init scripts rather than manual runbook steps.
+- [ ] **2.8 Reconnect, disconnect, and generation drain** — block or explicitly terminate active consumers before credential mutation, increment credential generation after successful reconnect, drain stale hosts, and fail closed rather than silently falling back to API-key auth.
+- [ ] **2.9 Boundary and end-to-end tests** — cover one direct-versus-Omnigent lease, second-host rejection/queueing, wrong-runtime volume isolation, refresh-state persistence, reconnect drain, missing/revoked auth, host restart, retry-safe reuse, and credential non-leakage.
 
-**Done means:** a user who has authenticated Codex or Claude Code through MoonMind can run the corresponding harness inside an Omnigent host, and MoonMind can prove which profile/ref was used without exposing credential values.
+**Done means:** a user who completes Claude or Codex OAuth in Settings can select that Provider Profile for an Omnigent-backed workflow without logging in again; MoonMind automatically binds one compatible host, allows only one active consumer/host/session for the OAuth identity, persists authorized refresh-state writes, and proves the profile/lease/host/session refs without exposing credential values.
 
 ---
 
-## Milestone 3 — MoonMind-Launched Omnigent Host Containers 🚧
+## Milestone 3 — Omnigent Bridge Communication & Workflow Detail Chat 🚧
 
-**Goal:** MoonMind can launch Omnigent host agent containers as needed.
+**Goal:** Credentialed Omnigent hosts and MoonMind communicate through the Omnigent bridge, and Workflow Detail chat with Omnigent hosts works similarly to other cloud agents.
 
-**Why it matters:** Treating Omnigent only as an already-running external server is not enough for a managed runtime product. MoonMind needs to provision, supervise, and clean up host containers while preserving the boundary that Omnigent owns live harness execution.
+**Why it matters:** The bridge should be stabilized against a known profile-bound host before MoonMind automates host provisioning. Operators should not care whether a run is backed by a direct managed process, a cloud agent, or an Omnigent host; Workflow Detail should show the conversation, events, approvals, resources, diagnostics, and artifacts through one familiar model.
 
 ### Remaining work
 
-- [ ] **3.0 Declarative design first** — document the supported host-launch model, capacity/lease semantics, and mount/network policy in `docs/Omnigent/OmnigentAdapter.md` and `docs/Temporal/ManagedAndExternalAgentExecutionModel.md` before adding launch code.
-- [ ] **3.1 Host launch model** — define the supported host types MoonMind can launch first: local Docker host container, compose-managed host, and any explicitly supported remote/managed host profile.
-- [ ] **3.2 Launch activity/service** — add a MoonMind-owned launch path that creates an Omnigent host container with endpoint refs, auth-volume refs, workspace policy, network policy, labels, and idempotency keys.
-- [ ] **3.3 Host registration and readiness** — wait for host registration/heartbeat with the Omnigent server or bridge before session creation, and surface readiness diagnostics in the dashboard.
-- [ ] **3.4 Capacity and lease model** — model host slots, active sessions, cooldowns, stale leases, and cleanup so repeated workflows do not orphan host containers or overrun local resources.
-- [ ] **3.5 Workspace and artifact mounts** — standardize what is mounted into a host: repository workspace, temporary work area, auth volumes, tool/cache volumes, and artifact handoff paths.
-- [ ] **3.6 Lifecycle operations** — support stop, interrupt, terminate, cleanup, and log/diagnostic harvest through typed MoonMind actions.
-- [ ] **3.7 Cutover compatibility** — keep direct Codex/Claude managed-session execution available behind feature gates until Omnigent host launch is reliable for those harnesses.
-- [ ] **3.8 End-to-end launch tests** — cover launch, registration, session start, cancellation, terminal harvest, cleanup, and retry after MoonMind worker restart.
+- [ ] **3.0 Declarative design reconciliation** — reconcile `docs/Omnigent/OmnigentBridge.md`, `docs/Omnigent/OmnigentHostOAuth.md`, `docs/Security/SettingsSystem.md`, `docs/UI/WorkflowChatPanel.md`, and `docs/UI/WorkflowDetailsPage.md` around profile-aware host routing, bridge ownership, failed-start evidence, and the unchanged-host proxy-first topology.
+- [ ] **3.1 Proxy-mode bridge routes** — implement or complete the MoonMind bridge facade for Omnigent-shaped session, event, stream, agent, host, and resource routes while proxying to a stock Omnigent server/host.
+- [ ] **3.2 Profile/lease-aware session creation** — require the selected Provider Profile and active lease when targeting an OAuth-bound host; persist profile, binding, host lease, host, session, endpoint, and idempotency refs before posting the first message.
+- [ ] **3.3 Bridge event normalizer** — normalize host/session events into durable MoonMind event records while preserving raw event journals as artifacts.
+- [ ] **3.4 Bridge session projection API** — expose `GET /api/omnigent/bridge-sessions/{bridge_session_id}/events` and `/stream` as the canonical Workflow Chat/read-model surface.
+- [ ] **3.5 Workflow Detail chat projection** — render Omnigent sent messages, assistant deltas, tool/session events, elicitations, approvals, interrupts, stop events, resource notices, terminal outcomes, diagnostics, and artifact links before falling back to legacy logs.
+- [ ] **3.6 Artifact/resource harvesting in chat** — link changed files, diffs, workspace files, session files, snapshots, and capture manifests directly from chat and step detail.
+- [ ] **3.7 Failed-launch visibility** — create visible bridge diagnostics and a Chat timeline when profile resolution, lease acquisition, OAuth preflight, host registration, or session creation fails before a normal terminal stream exists.
+- [ ] **3.8 Direct Codex compatibility producer** — during migration, have direct Codex managed sessions emit bridge-compatible events so Workflow Detail no longer depends on runtime-specific observability records.
+- [ ] **3.9 Conformance and smoke tests** — add fake Omnigent server tests, proxy-mode route tests, profile/lease authorization tests, event-normalization tests, chat projection tests, and live combined-stack smoke coverage.
+- [ ] **3.10 Omnigent-compatible MoonMind server auth shim** 🔒 — for embedded compatibility mode, reuse the existing upstream Omnigent server/host auth verifier as a narrow library dependency or vendored module with a MoonMind adapter layer. Map verified Omnigent host/API principals to MoonMind service principals and bridge-session ownership; keep Omnigent token parsing, signature/JWKS validation, host-runner credential semantics, and conformance fixtures unchanged where possible. Add only config/SecretRef resolution, audit redaction, and FastAPI dependency glue in MoonMind. Do not reimplement the auth protocol, fork the host, or forward MoonMind user JWT/cookie headers as Omnigent credentials.
+- [ ] **3.11 Embedded compatibility mode** 🔒 — implement MoonMind-as-Omnigent-compatible host/server surface only after proxy mode has conformance and live smoke evidence.
 
-**Done means:** a workflow can request an Omnigent-backed Codex or Claude run without a manually pre-provisioned host, and MoonMind can launch the host, bind credentials/workspace/policy, observe it, and clean it up.
+**Done means:** an OAuth-backed workflow can be created against a profile-bound stock Omnigent host through MoonMind-owned routing; Workflow Detail provides durable conversation replay, failure visibility, and artifact links even after the host is gone; and embedded mode, when enabled later, remains Omnigent-compatible rather than a MoonMind-specific host fork.
 
 ---
 
-## Milestone 4 — Omnigent Bridge Communication & Workflow Detail Chat 🚧
+## Milestone 4 — Workflow-Requested Omnigent Host Containers 🚧
 
-**Goal:** Omnigent hosts and MoonMind communicate through the Omnigent bridge, and Workflow Detail chat with Omnigent hosts works similarly to other cloud agents.
+**Goal:** MoonMind can launch, supervise, assign, and clean up an Omnigent host container on demand when a workflow requests an Omnigent-backed run.
 
-**Why it matters:** Operators should not care whether a run is backed by a direct managed process, a cloud agent, or an Omnigent host. Workflow Detail should show the conversation, events, approvals, resources, diagnostics, and artifacts through one familiar model.
+**Why it matters:** Static Compose hosts are useful for proving OAuth and bridge contracts, but they are not the managed-runtime product. Once credential binding and bridge semantics are stable, MoonMind should provision exactly the host capacity a workflow/profile lease requires without orphaning containers or bypassing policy.
 
 ### Remaining work
 
-- [ ] **4.0 Declarative design first** — capture the bridge proxy routes, embedded host-facing auth topology, event-normalization contract, and Workflow Detail chat projection as target state in `docs/Omnigent/OmnigentBridge.md`, `docs/Security/SettingsSystem.md`, `docs/UI/WorkflowChatPanel.md`, and `docs/UI/WorkflowDetailsPage.md` before implementation.
-- [ ] **4.1 Proxy-mode bridge routes** — implement or complete the MoonMind bridge facade for Omnigent-shaped session, event, stream, agent, and resource routes while proxying to a stock Omnigent server/host.
-- [ ] **4.2 Bridge event normalizer** — normalize host/session events into durable MoonMind event records while preserving raw event journals as artifacts.
-- [ ] **4.3 Bridge session projection API** — expose `GET /api/omnigent/bridge-sessions/{bridge_session_id}/events` and `/stream` as the canonical Workflow Chat/read-model surface.
-- [ ] **4.4 Workflow Detail chat projection** — render Omnigent sent messages, assistant deltas, tool/session events, elicitations, approvals, interrupts, stop events, resource notices, terminal outcomes, diagnostics, and artifact links before falling back to legacy logs.
-- [ ] **4.5 Artifact/resource harvesting in chat** — link changed files, diffs, workspace files, session files, snapshots, and capture manifests directly from chat and step detail.
-- [ ] **4.6 Failed-launch visibility** — create visible bridge diagnostics and a Chat timeline even when host launch or session creation fails before a normal terminal stream exists.
-- [ ] **4.7 Direct Codex compatibility producer** — during migration, have direct Codex managed sessions emit bridge-compatible events so Workflow Detail no longer depends on runtime-specific observability records.
-- [ ] **4.8 Conformance and smoke tests** — add fake Omnigent server tests, proxy-mode route tests, event-normalization tests, chat projection tests, and live combined-stack smoke coverage.
-- [ ] **4.9 Omnigent-compatible MoonMind server auth shim** 🔒 — for embedded compatibility mode, reuse the existing upstream Omnigent server/host auth verifier as a narrow library dependency or vendored module with a MoonMind adapter layer. Map verified Omnigent host/API principals to MoonMind service principals and bridge-session ownership; keep Omnigent token parsing, signature/JWKS validation, host-runner credential semantics, and conformance fixtures unchanged where possible. Add only config/SecretRef resolution, audit redaction, and FastAPI dependency glue in MoonMind. Do not reimplement the auth protocol, fork the host, or forward MoonMind user JWT/cookie headers as Omnigent credentials.
-- [ ] **4.10 Embedded compatibility mode** 🔒 — implement MoonMind-as-Omnigent-compatible host/server surface only after proxy mode has conformance and live smoke evidence.
+- [ ] **4.0 Declarative design first** — update `docs/Omnigent/OmnigentAdapter.md`, `docs/Omnigent/OmnigentHostOAuth.md`, and `docs/Temporal/ManagedAndExternalAgentExecutionModel.md` with the supported host-launch model, durable host lease, registration/readiness contract, capacity layers, mount/network policy, and cleanup semantics before launch code.
+- [ ] **4.1 First launch model** — support one local Docker `omnigent-host` container per active Provider Profile lease and Omnigent session; preserve `maxHosts = 1` and `maxSessionsPerHost = 1` for OAuth profiles.
+- [ ] **4.2 Launch activity/service** — add a MoonMind-owned launch path that creates an unchanged Omnigent host with endpoint refs, profile/binding refs, credential mounts, workspace policy, network policy, resource limits, labels, deterministic identity, and idempotency keys.
+- [ ] **4.3 Durable host lease and retry reconciliation** — persist container/host/session ownership, credential generation, state transitions, heartbeat timestamps, and expiry so Temporal retries reattach or replace safely rather than launch duplicates.
+- [ ] **4.4 Host registration and bridge readiness** — wait for exact host registration/heartbeat, ownership, configured harness, OAuth preflight, and bridge reachability before session creation, and surface each readiness stage in Workflow Detail.
+- [ ] **4.5 Capacity hierarchy** — combine Provider Profile capacity, host-pool/session capacity, and machine/Docker capacity without creating conflicting counters; provider-account capacity remains authoritative in `ProviderProfileManager`.
+- [ ] **4.6 Workspace, artifact, auth, and cache mounts** — standardize workflow-scoped repositories, temporary work areas, profile-bound OAuth volumes, artifact handoff paths, optional caches, UID/GID, and safe mount targets.
+- [ ] **4.7 Lifecycle operations and janitor** — support interrupt, stop, terminate, log/resource harvest, host removal, stale-lease reconciliation, credential-generation drain, and orphan cleanup through typed MoonMind actions.
+- [ ] **4.8 Static-to-managed compatibility** — retain the supported static Compose host as a local/bootstrap mode while routing both static and on-demand hosts through the same binding, bridge, diagnostics, and artifact contracts.
+- [ ] **4.9 Cutover compatibility** — keep direct Codex/Claude managed-session execution behind feature gates until on-demand Omnigent launch is reliable for those harnesses.
+- [ ] **4.10 End-to-end launch tests** — cover launch, registration, session start, worker restart, duplicate prevention, cancellation, terminal harvest, host cleanup, OAuth reconnect drain, profile cooldown, and retry after partial failure.
 
-**Done means:** an Omnigent-backed workflow produces a Workflow Detail chat experience equivalent to existing cloud-agent conversations, with durable replay and artifact links even after the host container is gone; when embedded mode is enabled, its host-facing auth path remains Omnigent-compatible rather than a MoonMind-specific fork.
+**Done means:** a workflow can request an Omnigent-backed Claude or Codex run without a pre-provisioned host; MoonMind acquires the selected profile, launches exactly one policy-bound host, observes it through the bridge, runs and harvests one session, cleans the host up, and releases all leases idempotently.
 
 ---
 
-## Milestone 5 — Checkpoints, Resume & Branching 🚧
+## Milestone 5 — Omnigent Host Session Checkpoints, Resume & Branching 🚧
 
-**Goal:** The checkpoint system is fully implemented with resume and branching for Omnigent-backed executions and existing local execution paths.
+**Goal:** Omnigent-backed sessions can be checkpointed, resumed, retried, and branched from MoonMind evidence whether the original host container is still alive or has been replaced.
 
-**Why it matters:** Omnigent v1 owns live session execution, but MoonMind still owns durable recovery semantics. Resume and branching must work from MoonMind evidence, not from raw host internals.
+**Why it matters:** Omnigent owns live session execution, while MoonMind owns durable recovery semantics. Checkpoints must be built from bridge/session/artifact evidence and selected Provider Profile identity, not from an assumption that one host container or mutable OAuth home snapshot remains available forever.
 
 ### Remaining work
 
-- [ ] **5.0 Declarative design first** — update `docs/Workflows/CheckpointBranchSystem.md` and `docs/Steps/StepExecutionsAndCheckpointing.md` to define Omnigent external-state checkpoint completeness, resume-default semantics, and local-vs-external restore rules before code.
-- [ ] **5.1 External-state checkpoint completeness** — ensure every relevant Omnigent boundary captures `externalStateRef`, `idempotencyKey`, `omnigentSessionId`, diagnostics refs, terminal refs, and patch/diff availability metadata.
-- [ ] **5.2 Resume-from-checkpoint default flow** — make failed-run recovery default to evidence-gated resume when checkpoint evidence is valid, with clear reasons when resume is unavailable.
-- [ ] **5.3 Checkpoint Branch UI and runtime-profile gaps** — connect the existing Checkpoint Branch API to Workflow Detail actions, runtime/profile selection, publish-mode selection, and Omnigent-compatible launch evidence without duplicating branch endpoints.
-- [ ] **5.4 Omnigent branch execution** — start a fresh Omnigent session for a branch turn, carrying corrected instructions and validated external-state evidence without mutating the original workflow input.
-- [ ] **5.5 Local vs external restore semantics** — split or normalize ambiguous workspace refs so local sandbox paths and provider-owned external-state artifact refs cannot be confused.
-- [ ] **5.6 UI flows** — add Workflow Detail actions for resume, retry, branch, compare branch, and inspect checkpoint evidence.
-- [ ] **5.7 Replay and idempotency tests** — cover worker restart, Temporal retry, duplicate first-message prevention, checkpoint validation failures, branch duplicate prevention, and unsupported restore attempts.
+- [ ] **5.0 Declarative design first** — update `docs/Workflows/CheckpointBranchSystem.md` and `docs/Steps/StepExecutionsAndCheckpointing.md` to define Omnigent bridge external-state completeness, profile/host/session refs, live-reattach versus cold-restore semantics, branch isolation, and local-vs-external restore rules before code.
+- [ ] **5.1 Checkpoint boundary and completeness** — capture checkpoints at defined bridge/session boundaries with `externalStateRef`, `idempotencyKey`, `bridgeSessionId`, `omnigentSessionId`, endpoint/profile/binding/host-lease refs, credential generation, diagnostics/terminal refs, workspace or diff refs, and patch availability metadata.
+- [ ] **5.2 Host-independent restore contract** — treat the host container as replaceable execution infrastructure; define what must be artifact-backed so a checkpoint can restore onto a newly launched profile-bound host without copying OAuth credential bodies into the checkpoint.
+- [ ] **5.3 Live reattach versus cold resume** — reattach only when the original session, host, bridge binding, profile lease, and idempotency evidence remain valid; otherwise acquire the same profile again and start a fresh session from validated checkpoint evidence.
+- [ ] **5.4 Resume-from-checkpoint default flow** — make failed-run recovery default to evidence-gated resume when checkpoint evidence is valid, with clear reasons when live reattach, cold restore, or any resume is unavailable.
+- [ ] **5.5 Checkpoint Branch UI and runtime-profile gaps** — connect the existing Checkpoint Branch API to Workflow Detail actions, Provider Profile selection, Omnigent agent/harness selection, publish-mode selection, and host-launch evidence without duplicating branch endpoints.
+- [ ] **5.6 Omnigent branch execution** — acquire a new profile/host lease and start a fresh Omnigent session for a branch turn, carrying corrected instructions and validated external-state evidence without mutating the original workflow input or concurrently reusing its OAuth lease.
+- [ ] **5.7 Local versus external restore semantics** — split or normalize ambiguous workspace refs so local sandbox paths, host-local paths, and provider-owned external-state artifact refs cannot be confused.
+- [ ] **5.8 UI flows** — add Workflow Detail actions for resume, retry, branch, compare branch, inspect checkpoint evidence, and understand why the original or replacement host was selected.
+- [ ] **5.9 Replay and idempotency tests** — cover worker restart, Temporal retry, live session reattach, cold host recreation, duplicate first-message prevention, stale credential generations, checkpoint validation failures, branch duplicate prevention, lease cleanup, and unsupported restore attempts.
 
-**Done means:** failed workflows can resume from validated checkpoints by default, operators can intentionally branch with new instructions or runtime/profile settings, and Omnigent external state is handled as MoonMind artifact evidence rather than host-local mutable state.
+**Done means:** failed Omnigent workflows can resume from validated checkpoints by default; a live session can be reattached when safe, a removed host can be recreated for cold restore, operators can intentionally branch with new instructions or runtime/profile settings, and all recovery evidence remains MoonMind-owned artifact/ref state rather than host-local mutable state.
 
 ---
 
@@ -289,7 +305,7 @@ These are not active roadmap milestones, but they are important assumptions for 
 
 **Why the change:** Pentest was intended as a minor capability, but the dedicated runner image plus MoonMind-specific scope-governance, provider-lease, heartbeat, settings, and scope-authoring UI machinery grew into a large maintenance surface (~12–13k lines) disproportionate to its value. Under **Orchestrate, don't recreate agents** and **Portable capabilities over MoonMind coupling**, MoonMind should consume the upstream PentestGPT container through the generic workload launcher (`moonmind/workloads/*`, which already has no pentest coupling) rather than carry a bespoke execution and governance stack. What must not regress is safety: the runner still runs on Docker `bridge`, which is not an enforced egress boundary, so external targets stay gated.
 
-**Recommended disposition (product decision pending):** keep a thin version — the runner image plus a small skill/preset that launches it through the generic workload path and publishes one `security_pentest_report` artifact — and delete the MoonMind-specific pentest machinery (the bulk of `moonmind/integrations/pentest/models.py`, the provider-lease/heartbeat/orphan-cleanup block in `activity_runtime.py`, most of `pentest_activities.py` and `PentestSettings`, and the scope-authoring UI). Fold enforced egress into the generic launched-workload/host **network-policy** substrate (Milestone 3 host launch and the omnipresent **safety** goal) so it is a substrate property, not a pentest-only feature. If the decision is instead full removal, delete the capability, its docs (`docs/Steps/PentestTool.md`, `docs/Security/PentestOperations.md`), and its pinned docs-policy tests in one cohesive change per the **Pre-release means delete, don't deprecate** policy.
+**Recommended disposition (product decision pending):** keep a thin version — the runner image plus a small skill/preset that launches it through the generic workload path and publishes one `security_pentest_report` artifact — and delete the MoonMind-specific pentest machinery (the bulk of `moonmind/integrations/pentest/models.py`, the provider-lease/heartbeat/orphan-cleanup block in `activity_runtime.py`, most of `pentest_activities.py` and `PentestSettings`, and the scope-authoring UI). Fold enforced egress into the generic launched-workload/host **network-policy** substrate (Milestone 4 host launch and the omnipresent **safety** goal) so it is a substrate property, not a pentest-only feature. If the decision is instead full removal, delete the capability, its docs (`docs/Steps/PentestTool.md`, `docs/Security/PentestOperations.md`), and its pinned docs-policy tests in one cohesive change per the **Pre-release means delete, don't deprecate** policy.
 
 ### Retained safety gate
 
@@ -305,13 +321,13 @@ These are not active roadmap milestones, but they are important assumptions for 
 
 | Previous theme | New disposition |
 | --- | --- |
-| Claude Code parity on the direct shared managed-session plane | Reframed as Claude Code via Omnigent host auth volumes, profiles, host launch, bridge events, and Workflow Chat. A parallel direct Claude controller is no longer the primary path. |
+| Claude Code parity on the direct shared managed-session plane | Reframed as Claude Code via Settings-created Omnigent host OAuth, bridge events/Workflow Chat, workflow-requested host launch, and host-independent checkpoint recovery. A parallel direct Claude controller is no longer the primary path. |
 | Automatic RAG context injection and RAG context packs | Moved into Milestone 7, with Omnigent first-message delivery and host-initiated retrieval gateway support as the acceptance path. |
-| Dashboard artifact browsing and remediation panels | Split across Milestone 1 for reusable navigation/list surfaces, Milestone 4 for Omnigent chat/artifact projection, and Milestone 6 for remediation-specific panels. |
-| Resume-from-checkpoint and recovery actions | Consolidated into Milestone 5 as checkpoint resume/branching, with Milestone 6 owning remediation’s custom-instruction branch flow. |
-| Safety guardrails, governance telemetry, and secret lifecycle | Reframed as the omnipresent **safety** goal applied to every milestone, and embedded in Milestones 2, 3, 6, and 8 as auth-volume boundaries, host launch/network policy, remediation audit, and Omnigent policy enforcement. Standalone safety work should be added only when it is not tied to those paths. |
+| Dashboard artifact browsing and remediation panels | Split across Milestone 1 for reusable navigation/list surfaces, Milestone 3 for Omnigent chat/artifact projection, and Milestone 6 for remediation-specific panels. |
+| Resume-from-checkpoint and recovery actions | Consolidated into Milestone 5 as Omnigent host-session checkpoint resume/branching, with Milestone 6 owning remediation’s custom-instruction branch flow. |
+| Safety guardrails, governance telemetry, and secret lifecycle | Reframed as the omnipresent **safety** goal applied to every milestone, and embedded in Milestones 2, 3, 4, 6, and 8 as OAuth concurrency/auth-volume boundaries, bridge authorization, host launch/network policy, remediation audit, and Omnigent policy enforcement. Standalone safety work should be added only when it is not tied to those paths. |
 | PentestGPT restricted egress and external target safety | Pentest is de-scoped from a first-class feature to a thin skill over the generic workload path (Milestone 11). Enforced egress becomes a generic launched-workload/host safety property under the omnipresent safety goal; the current Docker `bridge` runner is not a restricted-egress boundary, so external targets stay gated until enforcement exists. |
-| Deep observability, live logs, and trace/log links | Embedded into Milestones 4, 5, and 6 as bridge chat replay, checkpoint evidence, remediation evidence access, and artifact diagnostics. Full OTel/cost expansion can follow after Omnigent-host execution is stable. |
+| Deep observability, live logs, and trace/log links | Embedded into Milestones 3, 5, and 6 as bridge chat replay, checkpoint evidence, remediation evidence access, and artifact diagnostics. Full OTel/cost expansion can follow after Omnigent-host execution is stable. |
 | Responses API feature parity | Not on the critical path for Omnigent host cutover unless a concrete Omnigent/cloud-agent integration requires it. |
 | Completed resiliency, sandbox, memory, vendor portability, and baseline observability milestones | Removed from active roadmap tracking. They remain part of the product substrate and should be documented elsewhere, not tracked as unfinished roadmap items. |
 
@@ -322,11 +338,11 @@ These are not active roadmap milestones, but they are important assumptions for 
 | Priority | Milestone | Status | Primary dependency |
 | --- | --- | --- | --- |
 | 🔴 P0 | 1 — Dashboard navigation, sidebars, and full-page lists | ✅ Complete | Can proceed in parallel |
-| 🔴 P0 | 2 — Omnigent host auth volumes and runtime profile contract | 🚧 Active | Required for Codex/Claude host parity |
-| 🔴 P0 | 3 — MoonMind-launched Omnigent host containers | 🚧 Active | Depends on 2 for credentialed harnesses |
-| 🔴 P0 | 4 — Omnigent bridge communication and Workflow Detail chat | 🚧 Active | Required for usable operator experience |
-| 🔴 P0 | 5 — Checkpoints, resume, and branching | 🚧 Active | Required for resilient Omnigent execution |
-| 🔴 P0 | 6 — Remediation workflows and evidence-based repair | 🚧 Active | Depends on 4 and 5 for full power |
+| 🔴 P0 | 2 — Omnigent host OAuth from MoonMind Settings | 🚧 Active | Required for credentialed Claude/Codex host execution |
+| 🔴 P0 | 3 — Omnigent bridge communication and Workflow Detail chat | 🚧 Active | Builds on a profile-bound OAuth host; required before dynamic launch |
+| 🔴 P0 | 4 — Workflow-requested Omnigent host containers | 🚧 Active | Depends on 2 for credentials and 3 for registration/session communication |
+| 🔴 P0 | 5 — Omnigent host-session checkpoints, resume, and branching | 🚧 Active | Depends on stable bridge evidence and host lifecycle from 3 and 4 |
+| 🔴 P0 | 6 — Remediation workflows and evidence-based repair | 🚧 Active | Depends on 3 and 5 for full power |
 | 🟠 P1 | 7 — RAG for Omnigent host agents | 🔧 Partial | Depends on basic Omnigent execution and profile selection |
 | 🟠 P1 | 8 — Omnigent policy management UI | 📐 Designed | Depends on launch/bridge enforcement points |
 | 🟠 P1 | 9 — Omnigent agent profiles UI | 📐 Designed | Depends on endpoint/profile/policy data model |

--- a/docs/Omnigent/OmnigentHostOAuth.md
+++ b/docs/Omnigent/OmnigentHostOAuth.md
@@ -1,0 +1,722 @@
+# Omnigent Host OAuth
+
+**Status:** Desired-state design  
+**Owners:** MoonMind Platform  
+**Last updated:** 2026-07-11
+
+**Implementation tracking:** rollout notes, spikes, and temporary handoffs belong under `docs/tmp/` or in issue/PR tracking. This document defines the durable target-state contract.
+
+## Related documents
+
+- [`docs/Security/ProviderProfiles.md`](../Security/ProviderProfiles.md)
+- [`docs/Security/SecretsSystem.md`](../Security/SecretsSystem.md)
+- [`docs/ManagedAgents/OAuthTerminal.md`](../ManagedAgents/OAuthTerminal.md)
+- [`docs/ManagedAgents/ClaudeAnthropicOAuth.md`](../ManagedAgents/ClaudeAnthropicOAuth.md)
+- [`docs/Omnigent/OmnigentAdapter.md`](./OmnigentAdapter.md)
+- [`docs/Omnigent/OmnigentBridge.md`](./OmnigentBridge.md)
+- [`docs/Temporal/ManagedAndExternalAgentExecutionModel.md`](../Temporal/ManagedAndExternalAgentExecutionModel.md)
+- [`docs/Workflows/CheckpointBranchSystem.md`](../Workflows/CheckpointBranchSystem.md)
+- [`docs/MoonMindRoadmap.md`](../MoonMindRoadmap.md)
+
+---
+
+## 1. Purpose
+
+MoonMind already provides first-party OAuth setup for Claude Code with Anthropic and Codex CLI with OpenAI through the Settings UI. Those flows write provider-managed credential state into durable Docker auth volumes and register connected Provider Profiles.
+
+This document defines how the same Settings-created OAuth profiles become usable by **unchanged `omnigent-host` containers** without a second login ceremony, without extracting OAuth tokens, and without allowing several concurrent writers to one mutable OAuth identity.
+
+The desired operator experience is:
+
+```text
+Settings -> Provider Profiles -> Connect OAuth
+  -> MoonMind OAuth Session
+  -> verified Claude or Codex OAuth volume
+  -> connected Provider Profile with max_parallel_runs = 1
+  -> MoonMind selects that profile for an Omnigent-backed workflow
+  -> one profile-bound omnigent-host container
+  -> one Omnigent session / runner
+  -> Claude Code or Codex uses the existing OAuth login
+```
+
+The OAuth setup surface remains MoonMind Settings. Operators must not have to run `/login`, `claude auth login`, or `codex login` inside an ordinary Omnigent workflow session.
+
+---
+
+## 2. Scope
+
+This document covers:
+
+- Claude Code / Anthropic OAuth profiles created through MoonMind Settings;
+- Codex CLI / OpenAI OAuth profiles created through MoonMind Settings;
+- the Provider Profile concurrency invariant for mutable OAuth homes;
+- profile-to-host credential-volume binding;
+- static local Compose hosts as the first supported slice;
+- MoonMind-launched profile-bound hosts as the managed target state;
+- host/session routing, readiness, cleanup, reconnect, and disconnect behavior;
+- the relationship between OAuth host use, the Omnigent bridge, and checkpoints;
+- secret-safe diagnostics and durable references.
+
+This document does not define:
+
+- API-key Provider Profile materialization into Omnigent hosts;
+- more than one concurrent host or runtime consumer for one OAuth identity;
+- one Omnigent host multiplexing unrelated Provider Profiles;
+- a custom MoonMind fork of `omnigent-host`;
+- a new OAuth protocol or token broker;
+- raw-token extraction from Claude or Codex credential files;
+- the complete Omnigent bridge protocol, which belongs to `OmnigentBridge.md`;
+- checkpoint and branching semantics in full, which belong to the checkpoint documents.
+
+API-key profiles should eventually use the same host-launch and binding framework, but their secret materialization contract remains owned by Provider Profiles and the Secrets System rather than this OAuth-specific document.
+
+---
+
+## 3. Architectural decision summary
+
+The target design is governed by these decisions:
+
+1. **MoonMind Settings is the enrollment authority.** Claude and Codex OAuth are configured, repaired, reconnected, validated, and disconnected through the existing OAuth Session and Provider Profile systems.
+2. **The Provider Profile is the durable selection identity.** Workflows select `executionProfileRef`; they do not select raw Docker volume names or paste credentials into `parameters.omnigent`.
+3. **The OAuth volume is the canonical mutable credential store.** The selected CLI may refresh or rotate credential state while it runs, so the active profile-bound host must be able to persist authorized credential-home writes.
+4. **OAuth Provider Profiles have a hard concurrency limit of one.** `credential_source = oauth_volume` implies `max_parallel_runs = 1` for the first-party Claude and Codex OAuth paths.
+5. **The concurrency limit is global across execution substrates.** A direct MoonMind managed runtime and an Omnigent host must acquire the same Provider Profile lease. They must never use the same OAuth profile concurrently.
+6. **One OAuth profile maps to at most one active Omnigent host container.** That host runs at most one active Omnigent session/runner while holding the profile lease.
+7. **The host is profile-bound, not generic.** A Claude OAuth host mounts only the selected Claude profile credential home; a Codex OAuth host mounts only the selected Codex profile credential home.
+8. **Omnigent server/host authentication is separate.** The credential used by `omnigent-host` to register with an Omnigent server or bridge is not the Anthropic/OpenAI OAuth credential.
+9. **Only references cross durable boundaries.** Temporal history, bridge rows, checkpoints, diagnostics, and artifacts may carry profile, volume, binding, lease, host, and session references, but never OAuth access or refresh token values.
+10. **Stock Omnigent compatibility is preserved.** The first supported topology configures and launches an unchanged upstream `omnigent-host`; MoonMind owns orchestration and policy around it.
+
+---
+
+## 4. Why OAuth concurrency is fixed at one
+
+### 4.1 OAuth homes are mutable credential state
+
+Claude Code and Codex CLI do not consume a permanently immutable bearer token file. Their OAuth homes may contain access tokens, refresh tokens, account metadata, session state, and runtime-managed files that the CLI updates over time.
+
+A successful request may cause the CLI to:
+
+- refresh an expired access token;
+- rotate or replace a refresh token;
+- rewrite a credential JSON file atomically or non-atomically;
+- update account or organization metadata;
+- migrate credential-file format between CLI versions;
+- create locks, temporary files, or cached state used by later invocations.
+
+MoonMind must not assume that two CLI processes can safely read, refresh, and rewrite one OAuth home concurrently. Even when an upstream provider happens to tolerate concurrent access tokens, the local file-update and refresh-token semantics remain provider- and CLI-version-specific.
+
+### 4.2 The invariant is credential-wide, not host-local
+
+The safety invariant is:
+
+```text
+For one OAuth Provider Profile / backing OAuth identity:
+
+active direct managed consumers
++ active Omnigent host consumers
++ active credential-maintenance operations
+<= 1
+```
+
+Restricting only the number of Omnigent hosts is insufficient. A direct Claude or Codex run overlapping an Omnigent run could still race on the same credential home. Both execution paths must acquire a lease from the same `ProviderProfileManager` runtime family.
+
+### 4.3 Required enforcement points
+
+For first-party OAuth profiles, MoonMind must enforce all of the following:
+
+| Boundary | Required behavior |
+| --- | --- |
+| Settings OAuth start/finalize | Create or preserve the profile with `max_parallel_runs = 1`; reject a caller-supplied higher value. |
+| Provider Profile create/update API | Reject `credential_source = oauth_volume` with `max_parallel_runs != 1` for the supported Claude/Codex OAuth contract. |
+| Settings UI | Show OAuth concurrency as fixed at one rather than an editable capacity field. |
+| Provider Profile Manager | Grant no more than one lease for the backing profile and share that ledger across direct and Omnigent execution. |
+| Omnigent host binding | Allow at most one active host container for the profile. |
+| Omnigent session creation | Allow at most one active session/runner on the profile-bound host. |
+| Reconnect/disconnect | Require the profile to be drained or explicitly terminate the current run before mutating or invalidating the OAuth volume. |
+| Migration/readiness | Normalize or block legacy OAuth profiles configured above one and surface an actionable diagnostic. |
+
+A workflow, schedule, agent profile, or bridge request must not override this invariant.
+
+### 4.4 Future relaxation
+
+Concurrency greater than one is not forbidden forever, but it requires a separate, provider-specific design that proves safe refresh ownership. Examples include a supported token broker, immutable short-lived credential snapshots, or provider-documented multi-writer semantics with tested CLI behavior.
+
+Until such a design ships, `max_parallel_runs = 1` is a hard contract rather than a conservative default.
+
+---
+
+## 5. Canonical Provider Profile shapes
+
+The first-party OAuth profiles use the existing Provider Profile model.
+
+### 5.1 Claude Code / Anthropic OAuth
+
+```yaml
+profile_id: claude_anthropic_oauth
+runtime_id: claude_code
+provider_id: anthropic
+provider_label: Anthropic
+
+credential_source: oauth_volume
+runtime_materialization_mode: oauth_home
+volume_ref: claude_auth_volume
+volume_mount_path: /home/app/.claude
+
+max_parallel_runs: 1
+rate_limit_policy: backoff
+cooldown_after_429_seconds: 900
+enabled: true
+auth_state: connected
+last_auth_method: oauth_volume
+```
+
+### 5.2 Codex CLI / OpenAI OAuth
+
+```yaml
+profile_id: codex_openai_oauth
+runtime_id: codex_cli
+provider_id: openai
+provider_label: OpenAI
+
+credential_source: oauth_volume
+runtime_materialization_mode: oauth_home
+volume_ref: codex_auth_volume
+volume_mount_path: /home/app/.codex
+
+max_parallel_runs: 1
+rate_limit_policy: backoff
+cooldown_after_429_seconds: 900
+enabled: true
+auth_state: connected
+last_auth_method: oauth_volume
+```
+
+Profile IDs and volume names may be deployment-configurable, but the selected profile, runtime, provider, credential source, and volume reference must agree. MoonMind must fail fast on a Claude profile bound to a Codex home or vice versa.
+
+---
+
+## 6. Runtime-neutral host credential contracts
+
+The desired implementation separates the canonical credential identity from one concrete host mount.
+
+### 6.1 `AuthVolumeRef`
+
+```yaml
+AuthVolumeRef:
+  providerProfileId: claude_anthropic_oauth
+  runtimeId: claude_code
+  providerId: anthropic
+  volumeRef: claude_auth_volume
+  credentialGeneration: 7
+  ownerUserId: user_123
+```
+
+`AuthVolumeRef` identifies the canonical OAuth backing store. It contains no credential body.
+
+`credentialGeneration` changes when a successful reconnect or credential replacement makes existing host materialization stale. The generation is metadata, not a token version exposed by the provider.
+
+### 6.2 `CredentialMountRef`
+
+```yaml
+CredentialMountRef:
+  authVolumeRef: authvol_123
+  targetPath: /home/app/.claude
+  access: read_write
+  uid: 1000
+  gid: 1000
+  runtimeId: claude_code
+```
+
+For the initial supported contract, the canonical OAuth volume is mounted read/write into the **exclusive profile-bound host**. Read/write access is required because the CLI may persist refresh or credential migration state.
+
+A future copy-on-start design is valid only if it also defines exclusive refresh ownership and reliable atomic writeback or broker-managed replacement. A read-only seed that silently discards refreshed credentials must not become the default for long-lived OAuth hosts.
+
+### 6.3 `OmnigentOAuthHostBinding`
+
+```yaml
+OmnigentOAuthHostBinding:
+  bindingId: omnigent-oauth:claude_anthropic_oauth
+  providerProfileId: claude_anthropic_oauth
+  runtimeId: claude_code
+  endpointRef: default
+  harness: claude-native
+  credentialMountRef: credmount_123
+  hostMode: static_compose        # later: on_demand_docker
+  maxHosts: 1
+  maxSessionsPerHost: 1
+```
+
+The binding describes how a Provider Profile is made available to Omnigent. It is not a second Provider Profile and does not own credential setup.
+
+### 6.4 `OmnigentHostLease`
+
+```yaml
+OmnigentHostLease:
+  leaseId: ohl_123
+  bindingId: omnigent-oauth:claude_anthropic_oauth
+  providerProfileId: claude_anthropic_oauth
+  providerLeaseId: provider-lease-workflow-id
+  credentialGeneration: 7
+  workflowId: workflow_123
+  agentRunId: run_123
+  containerId: container_abc
+  omnigentHostId: host_def
+  omnigentSessionId: conv_ghi
+  state: assigned
+  expiresAt: 2026-07-11T20:00:00Z
+```
+
+The host lease makes container/session ownership retry-safe. It stores only identifiers and safe lifecycle metadata.
+
+---
+
+## 7. Settings and OAuth lifecycle
+
+### 7.1 Initial connection
+
+When the operator selects **Connect OAuth** in Settings:
+
+1. MoonMind creates an OAuth Session for the selected first-party profile.
+2. The OAuth Session acquires exclusive credential-maintenance authority for the profile.
+3. A short-lived auth runner mounts the canonical OAuth volume at the provider enrollment path.
+4. The operator completes the provider's interactive login ceremony through the MoonMind terminal bridge.
+5. MoonMind verifies the CLI credential state without returning credential contents.
+6. MoonMind updates the Provider Profile to `credential_source = oauth_volume`, `runtime_materialization_mode = oauth_home`, `auth_state = connected`, and `enabled = true`.
+7. MoonMind fixes `max_parallel_runs = 1` and synchronizes the Provider Profile Manager.
+8. MoonMind increments or initializes `credentialGeneration`.
+9. The auth runner exits. The profile is now eligible for direct or Omnigent-backed execution.
+
+### 7.2 Reconnect or repair
+
+Reconnect is a credential mutation and therefore requires exclusive ownership.
+
+MoonMind must either:
+
+- wait until the active profile lease and host lease are released; or
+- present an explicit operator action to interrupt/stop the active run, drain the host, and then reconnect.
+
+After successful reconnect:
+
+- increment `credentialGeneration`;
+- mark any existing host lease using an older generation stale;
+- stop or recycle stale hosts before new session assignment;
+- keep `max_parallel_runs = 1`.
+
+MoonMind must not reconnect the canonical volume while an active Claude or Codex process may be refreshing it.
+
+### 7.3 Disconnect
+
+Disconnect must:
+
+- prevent new profile leases;
+- stop or drain a profile-bound Omnigent host;
+- mark the Provider Profile disabled/disconnected;
+- invalidate the Omnigent host binding until OAuth is connected again;
+- preserve or remove the backing volume according to the explicit disconnect policy;
+- never silently fall back to an ambient API key.
+
+### 7.4 Settings status projection
+
+The Settings UI should distinguish:
+
+```text
+Not connected
+OAuth connected and available
+OAuth connected and in use
+OAuth reconnect waiting for active run
+OAuth validation failed
+OAuth disconnected
+Omnigent host starting
+Omnigent host ready
+Omnigent host failed auth preflight
+```
+
+The OAuth concurrency field should be displayed as **1 (fixed for OAuth)**.
+
+---
+
+## 8. Host materialization rules
+
+### 8.1 Profile-bound host
+
+An OAuth-enabled `omnigent-host` container must be bound to exactly one Provider Profile. It must not mount both Claude and Codex OAuth volumes, and it must not serve unrelated users or profiles.
+
+The host receives four distinct state classes:
+
+| State | Example target | Lifecycle |
+| --- | --- | --- |
+| Omnigent host identity/state | `/home/app/.omnigent` | host-specific; never shared with another profile-bound host identity |
+| Provider OAuth home | `/home/app/.claude` or `/home/app/.codex` | canonical profile credential volume; exclusive read/write use |
+| Workspace | `/workspaces/<run>` | workflow/session-scoped and policy-controlled |
+| Temporary/runtime support | `/tmp`, run support paths | host/run-scoped and removable |
+
+Omnigent state and provider OAuth state must never share one volume.
+
+### 8.2 Claude Code environment
+
+A Claude OAuth host uses the profile mount path consistently:
+
+```text
+HOME=/home/app
+CLAUDE_HOME=/home/app/.claude
+CLAUDE_VOLUME_PATH=/home/app/.claude
+CLAUDE_CONFIG_DIR=/home/app/.claude
+```
+
+The host must clear competing credential variables, including the profile's complete `clear_env_keys` set. Typical first-party OAuth blockers include:
+
+```text
+ANTHROPIC_API_KEY
+ANTHROPIC_AUTH_TOKEN
+CLAUDE_API_KEY
+CLAUDE_CODE_OAUTH_TOKEN
+OPENAI_API_KEY
+```
+
+`$HOME/.claude.json` is host/session configuration and workspace-trust state, not the canonical OAuth volume contract. It must be managed separately from the OAuth credential home.
+
+### 8.3 Codex CLI environment
+
+A Codex OAuth host uses:
+
+```text
+HOME=/home/app
+CODEX_HOME=/home/app/.codex
+CODEX_CONFIG_HOME=/home/app/.codex
+CODEX_CONFIG_PATH=/home/app/.codex/config.toml
+```
+
+The host must clear profile-defined competing credentials and custom-provider overrides when OpenAI OAuth is selected. Typical blockers include:
+
+```text
+OPENAI_API_KEY
+CODEX_ACCESS_TOKEN
+OPENAI_BASE_URL
+```
+
+Provider Profile materialization remains authoritative for any allowed Codex config overlay. The host must not rewrite the profile to a different provider because an ambient environment variable is present.
+
+### 8.4 Ownership and permissions
+
+The auth runner, profile-bound host, and runner process must agree on the runtime user. The supported local container convention is UID/GID `1000:1000` with `HOME=/home/app`.
+
+Initialization must be automatic and idempotent:
+
+- create state directories;
+- set the expected owner/group;
+- apply restrictive permissions compatible with the CLI;
+- refuse symlink/path traversal outside the mounted credential root;
+- avoid recursively changing ownership on an unrelated volume;
+- fail before host registration when the mount is missing or unusable.
+
+### 8.5 Credential preflight
+
+Before the host is eligible for assignment, MoonMind must run the runtime-specific preflight inside the exact host environment:
+
+```text
+Claude: claude auth status
+Codex:  codex login status, or the canonical registered verifier
+```
+
+The result must be reduced to safe readiness metadata. Raw command output is not durable evidence unless redacted and explicitly approved.
+
+---
+
+## 9. Selection, leasing, and session launch
+
+### 9.1 Request shape
+
+An Omnigent-backed run continues to use the canonical external identity while selecting the Provider Profile explicitly:
+
+```json
+{
+  "agentKind": "external",
+  "agentId": "omnigent",
+  "executionProfileRef": "claude_anthropic_oauth",
+  "parameters": {
+    "omnigent": {
+      "agent": {
+        "agentName": "claude-native-ui"
+      }
+    }
+  }
+}
+```
+
+The request does not contain a Docker volume name, OAuth token, refresh token, or manually copied host ID.
+
+### 9.2 Resolution order
+
+Before creating an Omnigent session, MoonMind must:
+
+1. resolve the exact Provider Profile or selector result;
+2. verify that it is enabled, connected, launch ready, and OAuth-backed;
+3. verify the requested Omnigent agent/harness matches the profile runtime;
+4. acquire the profile's single `ProviderProfileManager` lease;
+5. resolve or create the `OmnigentOAuthHostBinding`;
+6. ensure there is no other active host for the binding;
+7. start or reuse the one profile-bound host according to deployment mode;
+8. validate credential generation, mount, CLI auth, host registration, and harness readiness;
+9. create the Omnigent session on that exact host;
+10. persist the bridge/session/host lease references before posting the first message.
+
+If any step fails, MoonMind must not fall back to another credential method or generic host silently.
+
+### 9.3 Static Compose slice
+
+The first local-development slice may use one dedicated Compose service per first-party OAuth profile:
+
+```text
+omnigent-host-claude-oauth
+omnigent-host-codex-oauth
+```
+
+Compose and init scripts should automatically provide:
+
+- the correct OAuth volume mount;
+- separate Omnigent state volume;
+- correct UID/GID and home variables;
+- credential-env clearing;
+- runtime auth preflight;
+- stable host identity;
+- host registration readiness;
+- restart behavior.
+
+MoonMind must discover the configured binding and host ID. Operators should not extract host IDs or manually edit workflow JSON.
+
+This static slice is a trusted local/single-tenant transitional topology. The profile lease still controls session assignment, and each host runs at most one active runner.
+
+### 9.4 On-demand managed slice
+
+The managed target state launches the profile-bound host only after acquiring the profile lease:
+
+```text
+Acquire profile lease
+  -> launch host container with exact OAuth mount
+  -> wait for bridge/server registration
+  -> create one session
+  -> harvest terminal evidence
+  -> stop/remove host
+  -> release profile lease
+```
+
+One Provider Profile lease corresponds to one host lease and one active Omnigent session. This simple one-to-one model is the required first production topology.
+
+---
+
+## 10. Omnigent bridge relationship
+
+The bridge is the required session communication and observability boundary after OAuth host materialization works.
+
+The bridge must:
+
+- resolve `executionProfileRef` to the profile-bound host rather than accepting an arbitrary host choice;
+- enforce the Provider Profile lease before session creation;
+- persist safe profile, binding, host lease, host, and session references;
+- expose failed host/auth/session startup in Workflow Detail even when no normal stream starts;
+- normalize session events and harvest resources into MoonMind artifacts;
+- prevent manual or alternate bridge routes from bypassing the one-profile/one-session rule.
+
+A profile-bound OAuth host must not be treated as a general-purpose host in an unrestricted Omnigent host picker. Direct selection through a stock Omnigent UI is unsupported unless that route participates in the same MoonMind lease and authorization checks.
+
+Host authentication remains separate:
+
+```text
+omnigent-host -> Omnigent server/bridge credential
+Claude/Codex -> Anthropic/OpenAI OAuth volume
+```
+
+Neither credential may substitute for the other.
+
+---
+
+## 11. Lifecycle, retries, and cleanup
+
+### 11.1 Idempotent startup
+
+A retry must first inspect durable bridge and host-lease state.
+
+For the same idempotency key, MoonMind should:
+
+- reattach to the existing registered host/session when still valid;
+- finish a partially completed readiness sequence;
+- replace a failed/stale host only after marking the old lease draining or failed;
+- never launch a second host while the first may still own the profile lease;
+- never post the first message twice.
+
+### 11.2 Terminal cleanup
+
+After terminal evidence is harvested, MoonMind must:
+
+1. interrupt or stop the Omnigent session as needed;
+2. collect final stream/resource/diagnostic artifacts;
+3. stop and remove an on-demand host, or mark a static host idle;
+4. verify no runner remains attached to the OAuth home;
+5. persist terminal host/session state;
+6. release the host lease;
+7. release the Provider Profile lease.
+
+The profile lease is released last so another consumer cannot start while cleanup or credential writes are still in progress.
+
+### 11.3 Crash and stale-lease recovery
+
+The host/container janitor and Provider Profile Manager must cooperate:
+
+- a terminated workflow cannot hold the OAuth profile indefinitely;
+- a live host with a lost workflow owner is drained before lease reclamation;
+- an absent container with a durable lease is marked failed and released;
+- an old credential generation invalidates host reuse;
+- lease recovery is observable and auditable;
+- cleanup remains idempotent across Temporal retries and worker restarts.
+
+### 11.4 Provider failure and cooldown
+
+A provider-attributed 429 or quota failure should:
+
+- be recorded against the selected Provider Profile;
+- trigger its existing cooldown policy;
+- stop or drain the session/host after evidence capture;
+- release the active lease;
+- prevent immediate retry on the same profile until policy permits it.
+
+A credential-invalid response should fail closed, surface **Reconnect OAuth**, and transition the profile to the appropriate validation-failed or disconnected state after confirmation.
+
+---
+
+## 12. Checkpoint relationship
+
+Checkpoints must not depend on the continued existence of a particular host container.
+
+A checkpoint for an Omnigent OAuth session may safely reference:
+
+```text
+providerProfileId
+credentialGeneration
+omnigentEndpointRef
+omnigentHostBindingRef
+omnigentHostLeaseRef
+omnigentHostId
+omnigentSessionId
+bridgeSessionId
+externalStateRef
+idempotencyKey
+workspace/diff/artifact refs
+terminal and diagnostics refs
+```
+
+It must not contain credential files or token values.
+
+Resume has two modes:
+
+1. **Live reattach:** the same session and host are still valid, the profile lease is still owned, and the bridge can prove identity and idempotency.
+2. **Cold restore:** MoonMind acquires the same Provider Profile again, launches or selects a new profile-bound host, and starts a fresh Omnigent session from validated checkpoint artifacts and corrected instructions.
+
+Branching always creates a new session and host lease. It does not mutate the original session or reuse its credential lease concurrently.
+
+---
+
+## 13. Security model
+
+The following boundaries are mandatory:
+
+- OAuth hosts are dedicated to one Provider Profile and one runtime family.
+- One host must not mount both `claude_auth_volume` and `codex_auth_volume`.
+- One OAuth profile has one active runtime consumer across all MoonMind execution paths.
+- The canonical OAuth volume is mounted only into trusted auth runners and profile-bound runtime hosts.
+- The host container and every runner inside it are considered able to read and modify the mounted OAuth home.
+- No unrelated tenant, workflow, or manually selected Omnigent session may target that host.
+- Raw OAuth credentials never enter Temporal history, request parameters, bridge rows, checkpoints, logs, diagnostics, or artifacts.
+- Credential variables that would override the intended OAuth path are cleared before launch.
+- Host identity/state is stored separately from provider OAuth state.
+- Omnigent host/server credentials are resolved separately from provider OAuth.
+- Docker daemon administrators remain privileged and can inspect or mount host volumes; this topology does not defend against a malicious Docker administrator.
+- Multi-tenant or multi-profile sharing of one host waits for a stronger per-runner isolation boundary, such as runner containers or mount namespaces.
+
+---
+
+## 14. Diagnostics and observability
+
+MoonMind should expose secret-safe diagnostics for these stages:
+
+```text
+profile_resolution
+profile_lease_wait
+host_binding_resolution
+container_start
+credential_mount
+credential_preflight
+host_registration
+harness_readiness
+session_creation
+session_running
+resource_harvest
+host_cleanup
+profile_lease_release
+```
+
+Safe diagnostic fields include:
+
+- Provider Profile ID, runtime ID, and provider ID;
+- credential source and materialization mode;
+- OAuth volume reference and expected mount path;
+- credential generation;
+- profile lease and host lease identifiers;
+- container and Omnigent host identifiers;
+- bridge and Omnigent session identifiers;
+- readiness state, timestamps, and bounded redacted error summaries;
+- whether cleanup and lease release completed.
+
+Unsafe fields include:
+
+- credential file contents;
+- access or refresh tokens;
+- pasted authorization codes;
+- unredacted environment dumps;
+- raw OAuth home listings when filenames or paths may disclose sensitive metadata.
+
+Workflow Detail should show enough lifecycle evidence to answer:
+
+```text
+Which Provider Profile was selected?
+Why did the run wait?
+Which host was bound?
+Did OAuth preflight pass?
+Did the host register?
+Which Omnigent session ran?
+Was the host cleaned up and the profile lease released?
+```
+
+---
+
+## 15. Acceptance criteria
+
+The desired state is satisfied when all of the following are true:
+
+1. A user can connect Claude OAuth in Settings and later run `claude-native` through Omnigent without another login.
+2. A user can connect Codex OAuth in Settings and later run `codex-native` through Omnigent without another login.
+3. OAuth setup and Provider Profile APIs enforce `max_parallel_runs = 1`.
+4. A direct managed run and an Omnigent-backed run cannot consume the same OAuth profile concurrently.
+5. A second Omnigent request for the same OAuth profile queues or fails according to the Provider Profile rate-limit policy; it never launches a second host.
+6. The profile-bound host exposes only the selected runtime's OAuth home and clears competing credentials.
+7. The active CLI can persist refresh-state updates to the canonical OAuth volume while it holds the exclusive lease.
+8. Reconnect and disconnect drain active hosts or require explicit operator termination before credential mutation.
+9. Workflow requests select the Provider Profile, while MoonMind resolves the host binding and host ID automatically.
+10. Temporal retries and worker restarts do not duplicate hosts, sessions, or first messages.
+11. Terminal evidence is harvested before host cleanup and remains available after the container is gone.
+12. Checkpoints carry only safe refs and can cold-restore onto a newly launched profile-bound host.
+13. Wrong-runtime volumes, stale credential generations, missing mounts, invalid OAuth, and host-registration failures produce actionable diagnostics.
+14. No OAuth token or credential body appears in workflow history, bridge persistence, logs, artifacts, checkpoints, or API responses.
+
+---
+
+## 16. Delivery sequence
+
+The implementation order is intentional:
+
+1. **Omnigent host OAuth:** prove that Settings-created Claude and Codex OAuth profiles can drive one profile-bound static host with the global concurrency-one invariant.
+2. **Omnigent bridge:** make profile-aware session creation, events, chat projection, resources, and failure diagnostics reliable against that host.
+3. **On-demand host containers:** replace manual/static provisioning with retry-safe workflow-requested host launch and cleanup while preserving the same profile/binding/bridge contracts.
+4. **Omnigent session checkpointing:** capture bridge external state and restore onto a live or newly launched profile-bound host without depending on container-local mutable state.
+
+This sequence keeps credential correctness ahead of automation, communication semantics ahead of dynamic provisioning, and durable recovery after both runtime and bridge identity are stable.

--- a/tests/integration/docs/test_final_docs_cleanup_contract.py
+++ b/tests/integration/docs/test_final_docs_cleanup_contract.py
@@ -52,7 +52,7 @@ def test_temp_plan_cleanup_matches_closed_final_definition_of_done() -> None:
     assert not TEMP_PLAN.exists()
     assert "Status: Execution plan (disposable; not canonical)" not in docs_text
     assert "Final definition of done" not in docs_text
-    assert "- [ ] **5.2 Resume-from-checkpoint default flow**" in roadmap_text
+    assert "- [ ] **5.4 Resume-from-checkpoint default flow**" in roadmap_text
 
 
 def test_roadmap_and_implementation_evidence_remain_consistent() -> None:
@@ -60,7 +60,7 @@ def test_roadmap_and_implementation_evidence_remain_consistent() -> None:
 
     The pinned roadmap substrings below encode durable invariants, not prose:
     the Omnigent-host direction, the checkpoint ``external_state_ref`` lane and
-    Checkpoint Branch API claims, the ``5.2``/``6.2``/``7.1`` acceptance tasks,
+    Checkpoint Branch API claims, the ``5.4``/``6.2``/``7.1`` acceptance tasks,
     and the ``11.1`` PentestGPT external-egress safety gate. Update the roadmap
     to preserve the invariant rather than deleting an assertion here.
     """
@@ -72,7 +72,7 @@ def test_roadmap_and_implementation_evidence_remain_consistent() -> None:
     assert "Omnigent host as the unified managed agent runtime" in roadmap_text
     assert "checkpoint captures select the `external_state_ref` lane" in roadmap_text
     assert "Checkpoint Branch API and persistence model already support" in roadmap_text
-    assert "- [ ] **5.2 Resume-from-checkpoint default flow**" in roadmap_text
+    assert "- [ ] **5.4 Resume-from-checkpoint default flow**" in roadmap_text
     assert "- [ ] **6.2 Omnigent remediation context enrichment**" in roadmap_text
     assert "- [ ] **7.1 Initial context injection for Omnigent**" in roadmap_text
     assert "- [ ] **11.1 Restricted egress boundary for PentestGPT external targets**" in roadmap_text

--- a/tests/unit/docs/test_final_docs_cleanup_policy.py
+++ b/tests/unit/docs/test_final_docs_cleanup_policy.py
@@ -86,7 +86,7 @@ def test_roadmap_milestones_are_evidence_aligned_and_gated() -> None:
 
     These assertions are not stylistic. The ``11.1`` line and the "external
     targets stay gated until enforcement exists" phrase encode the PentestGPT
-    external-egress safety gate; the ``5.1``/``5.2``/``5.3``/``6.2``/``7.1``
+    external-egress safety gate; the ``5.1``/``5.4``/``5.5``/``6.2``/``7.1``
     task labels pin the checkpoint-resume, remediation-evidence, and
     RAG-injection acceptance claims. Do not delete an assertion here to make a
     roadmap edit pass — update the roadmap so the invariant still holds, or
@@ -97,9 +97,9 @@ def test_roadmap_milestones_are_evidence_aligned_and_gated() -> None:
     assert "Completed historical milestones have been removed from the active roadmap" in text
     assert "Omnigent host as the unified managed agent runtime" in text
     assert "checkpoint captures select the `external_state_ref` lane" in text
-    assert "- [ ] **5.1 External-state checkpoint completeness**" in text
-    assert "- [ ] **5.2 Resume-from-checkpoint default flow**" in text
-    assert "- [ ] **5.3 Checkpoint Branch UI and runtime-profile gaps**" in text
+    assert "- [ ] **5.1 Checkpoint boundary and completeness**" in text
+    assert "- [ ] **5.4 Resume-from-checkpoint default flow**" in text
+    assert "- [ ] **5.5 Checkpoint Branch UI and runtime-profile gaps**" in text
     assert "- [ ] **6.2 Omnigent remediation context enrichment**" in text
     assert "- [ ] **7.1 Initial context injection for Omnigent**" in text
     assert "- [ ] **11.1 Restricted egress boundary for PentestGPT external targets**" in text


### PR DESCRIPTION
## What changed

- Added `docs/Omnigent/OmnigentHostOAuth.md` as the canonical desired-state design for reusing Claude Code / Anthropic and Codex CLI / OpenAI OAuth configured through MoonMind Settings in profile-bound `omnigent-host` containers.
- Updated `docs/MoonMindRoadmap.md` so the critical path is ordered as:
  1. Omnigent host OAuth from Settings
  2. Omnigent bridge communication and Workflow Detail chat
  3. workflow-requested Omnigent host containers
  4. Omnigent host-session checkpointing, resume, and branching

## Key design decisions

- First-party OAuth Provider Profiles have a hard `max_parallel_runs = 1` contract.
- The limit applies to the backing OAuth identity across direct managed execution, Omnigent execution, and reconnect/disconnect maintenance—not only to the number of Omnigent containers.
- One OAuth profile maps to at most one active profile-bound host and one active Omnigent session/runner.
- The active host has exclusive read/write access to the canonical OAuth home so Claude or Codex can persist refresh-state and credential migrations while it owns the lease.
- Workflows select `executionProfileRef`; MoonMind resolves the credential binding and exact host automatically.
- OAuth enrollment remains in MoonMind Settings, and ordinary Omnigent sessions must not require another login.
- Host/server registration credentials remain separate from Anthropic/OpenAI OAuth credentials.
- Checkpoints retain only profile, binding, lease, host, session, bridge, external-state, and artifact references—never token or credential bodies.

## Important current-state distinction

The current OAuth request and registration paths default `max_parallel_runs` to `1`, but do not yet enforce it as a hard invariant. The roadmap now tracks enforcement across OAuth finalization, Provider Profile APIs, Settings UI, migrations/readiness, and the shared Provider Profile Manager lease lane.

## Validation

- Fetched both files back from the branch and inspected the concurrency, lifecycle, bridge, launch, and checkpoint sections.
- Compared the branch with `main`; only the two requested documentation paths are changed.
- Documentation-only change; no code tests were run.