### PR TITLE
Fail fast on Temporal activity routing drift

### DIFF
--- a/docs/Temporal/ActivityCatalogAndWorkerTopology.md
+++ b/docs/Temporal/ActivityCatalogAndWorkerTopology.md
@@ -48,6 +48,13 @@ activity types, build/deployment identity, registry fingerprint, versioning
 state, and resolver-core identity. `MoonMind.PRResolver` may appear only when
 that exact workflow class was supplied to the SDK worker.
 
+Worker topology construction validates the canonical catalog against the
+concrete runtime-handler inventory before any fleet starts polling. A handler
+without a catalog route, or a catalog route without its owning handler, is a
+startup/readiness failure rather than a runtime workflow-task failure. The
+capability-routed `mm.tool.execute` alias and the separately registered
+workflow-fleet helper are explicit ownership exceptions.
+
 The workflow fleet remains Temporal-only. It receives no repository mutation,
 GitHub credential, sandbox, local-git, or agent-runtime capabilities.
 
@@ -476,12 +483,14 @@ Current implemented activities:
 - `agent_runtime.steer_turn`
 - `agent_runtime.interrupt_turn`
 - `agent_runtime.clear_session`
+- `agent_runtime.ensure_docker_sidecar`
 - `agent_runtime.terminate_session`
 - `agent_runtime.fetch_session_summary`
 - `agent_runtime.publish_session_artifacts`
 - `agent_runtime.reconcile_managed_sessions`
 - `agent_runtime.status`
 - `agent_runtime.fetch_result`
+- `agent_runtime.evaluate_terminal_evidence`
 - `agent_runtime.cancel`
 
 Worker queue: `mm.activity.agent_runtime`
@@ -498,10 +507,12 @@ Worker queue: `mm.activity.agent_runtime`
 - `agent_runtime.steer_turn(...) -> ManagedSessionTurnResponse`
 - `agent_runtime.interrupt_turn(...) -> ManagedSessionTurnResponse`
 - `agent_runtime.clear_session(...) -> ManagedSessionHandle`
+- `agent_runtime.ensure_docker_sidecar(...) -> ManagedSessionEnsureDockerSidecarResponse`
 - `agent_runtime.terminate_session(...) -> ManagedSessionHandle`
 - `agent_runtime.fetch_session_summary(...) -> ManagedSessionSummary`
 - `agent_runtime.publish_session_artifacts(...) -> ManagedSessionArtifactsPublication`
 - `agent_runtime.reconcile_managed_sessions(...) -> reconciliation summary payload`
+- `agent_runtime.evaluate_terminal_evidence(...) -> AgentRunResult`
 
 `agent_runtime.publish_artifacts` should return a canonical-result-compatible enriched payload that can be materialized as `AgentRunResult`.
 

--- a/moonmind/workflows/temporal/activity_catalog.py
+++ b/moonmind/workflows/temporal/activity_catalog.py
@@ -1131,6 +1131,16 @@ def build_default_activity_catalog(
             heartbeat_required=True,
         ),
         TemporalActivityDefinition(
+            activity_type="agent_runtime.ensure_docker_sidecar",
+            family="agent_runtime",
+            capability_class="agent_runtime",
+            task_queue=cfg.activity_agent_runtime_task_queue,
+            fleet=AGENT_RUNTIME_FLEET,
+            timeouts=TemporalActivityTimeouts(60, 180, heartbeat_timeout_seconds=30),
+            retries=_activity_retries(max_attempts=2, max_interval_seconds=60),
+            heartbeat_required=True,
+        ),
+        TemporalActivityDefinition(
             activity_type="agent_runtime.terminate_session",
             family="agent_runtime",
             capability_class="agent_runtime",
@@ -1199,6 +1209,15 @@ def build_default_activity_catalog(
         ),
         TemporalActivityDefinition(
             activity_type="agent_runtime.fetch_result",
+            family="agent_runtime",
+            capability_class="agent_runtime",
+            task_queue=cfg.activity_agent_runtime_task_queue,
+            fleet=AGENT_RUNTIME_FLEET,
+            timeouts=TemporalActivityTimeouts(60, 180),
+            retries=_activity_retries(max_attempts=2, max_interval_seconds=30),
+        ),
+        TemporalActivityDefinition(
+            activity_type="agent_runtime.evaluate_terminal_evidence",
             family="agent_runtime",
             capability_class="agent_runtime",
             task_queue=cfg.activity_agent_runtime_task_queue,

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -1366,6 +1366,45 @@ _ACTIVITY_HANDLER_ATTRS: dict[str, tuple[str, str]] = {
     "agent_skill.request_on_demand": ("agent_skills", "request_on_demand"),
 }
 
+# ``mm.tool.execute`` is registered as a capability-routed alias on multiple
+# fleets rather than as one catalog route. The workflow-fleet helper is bound
+# by ``workflow_registry`` because workflow workers do not use this module's
+# side-effecting activity implementations.
+_CAPABILITY_ROUTED_ACTIVITY_ALIASES = frozenset({"mm.tool.execute"})
+_EXTERNALLY_BOUND_CATALOG_ACTIVITIES = frozenset(
+    {"integration.resolve_adapter_metadata"}
+)
+
+
+def validate_activity_catalog_runtime_bindings(
+    catalog: TemporalActivityCatalog,
+) -> None:
+    """Fail startup when canonical routes and concrete handlers drift apart."""
+    catalog_types = {definition.activity_type for definition in catalog.activities}
+    runtime_types = set(_ACTIVITY_HANDLER_ATTRS)
+    missing_catalog_routes = sorted(
+        runtime_types - catalog_types - _CAPABILITY_ROUTED_ACTIVITY_ALIASES
+    )
+    missing_runtime_handlers = sorted(
+        catalog_types - runtime_types - _EXTERNALLY_BOUND_CATALOG_ACTIVITIES
+    )
+    if not missing_catalog_routes and not missing_runtime_handlers:
+        return
+
+    details: list[str] = []
+    if missing_catalog_routes:
+        details.append(
+            "handlers without catalog routes: " + ", ".join(missing_catalog_routes)
+        )
+    if missing_runtime_handlers:
+        details.append(
+            "catalog routes without handlers: " + ", ".join(missing_runtime_handlers)
+        )
+    raise TemporalActivityRuntimeError(
+        "Temporal activity catalog/runtime binding mismatch; " + "; ".join(details)
+    )
+
+
 def _artifact_id_from_ref(value: ArtifactRef | str) -> str:
     if isinstance(value, ArtifactRef):
         return value.artifact_id
@@ -13118,4 +13157,5 @@ __all__ = [
     "TemporalSkillActivities",
     "TemporalSandboxActivities",
     "build_activity_bindings",
+    "validate_activity_catalog_runtime_bindings",
 ]

--- a/moonmind/workflows/temporal/workers.py
+++ b/moonmind/workflows/temporal/workers.py
@@ -35,6 +35,7 @@ from moonmind.workflows.temporal.activity_catalog import (
 from moonmind.workflows.temporal.activity_runtime import (
     TemporalActivityBinding,
     build_activity_bindings,
+    validate_activity_catalog_runtime_bindings,
 )
 from moonmind.workflows.temporal.workflow_registry import (
     workflow_fleet_workflow_types,
@@ -383,6 +384,7 @@ def build_worker_topology(
     app_cfg = app_settings or settings
     temporal_cfg = temporal_settings or app_cfg.temporal
     resolved_catalog = catalog or build_default_activity_catalog(temporal_cfg)
+    validate_activity_catalog_runtime_bindings(resolved_catalog)
     entry = _fleet_entry(resolved_catalog, fleet=fleet)
     normalized = entry.fleet
     activity_types = entry.activity_types

--- a/tests/integration/reliability/replays/agent-run-terminal-evidence-routing/manifest.json
+++ b/tests/integration/reliability/replays/agent-run-terminal-evidence-routing/manifest.json
@@ -1,0 +1,24 @@
+{
+  "failureShapeId": "agent-run-terminal-evidence-routing",
+  "incidentWorkflowId": "mm:72c1d916-2c9b-4a59-8240-b2a5a3c9bcb0",
+  "activityName": "agent_runtime.evaluate_terminal_evidence",
+  "expectedTaskQueue": "mm.activity.agent_runtime",
+  "terminalContract": {
+    "contractId": "batch_workflows_fanout.v1",
+    "relativePath": "artifacts/batch-workflows-result.json",
+    "expectedSchemaVersion": "moonmind.batch-workflows-result.v1",
+    "executionRef": "workflow:run:batch-workflows:execution:1"
+  },
+  "resolvedTargets": [],
+  "terminalEvidence": {
+    "schemaVersion": "moonmind.batch-workflows-result.v1",
+    "contractId": "batch_workflows_fanout.v1",
+    "executionRef": "workflow:run:batch-workflows:execution:1",
+    "status": "no_op",
+    "requested": 0,
+    "created": 0,
+    "queued": [],
+    "skipped": [],
+    "errors": []
+  }
+}

--- a/tests/integration/reliability/test_escaped_failure_journeys.py
+++ b/tests/integration/reliability/test_escaped_failure_journeys.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import json
 from datetime import datetime, timezone
 from pathlib import Path
@@ -14,6 +15,7 @@ from moonmind.workflows.temporal.activity_runtime import (
     TemporalAgentRuntimeActivities,
     TemporalSandboxActivities,
 )
+from moonmind.workflows.temporal.workflows import agent_run as agent_run_module
 from moonmind.workflows.temporal.workflows.agent_run import MoonMindAgentRun
 from moonmind.workflows.temporal.workflows.run import MoonMindRunWorkflow
 from moonmind.workflows.terminal_evidence import evaluate_terminal_evidence
@@ -60,13 +62,17 @@ async def test_completed_batch_turn_is_rejected_at_agent_run_boundary(
     expected = load_replay(replay_id, "expected-outcome.json")
     agent_run = MoonMindAgentRun()
 
-    async def execute_activity(name: str, payload: dict, **_kwargs: object) -> dict:
+    async def execute_activity(name: str, payload: dict, **kwargs: object) -> dict:
         assert name == "agent_runtime.evaluate_terminal_evidence"
+        assert kwargs["task_queue"] == "mm.activity.agent_runtime"
         activities = TemporalAgentRuntimeActivities(client_adapter=object())
         evaluated = await activities.agent_runtime_evaluate_terminal_evidence(payload)
         return evaluated.model_dump(mode="json", by_alias=True)
 
-    monkeypatch.setattr(agent_run, "_execute_routed_activity", execute_activity)
+    # Patch only the Temporal SDK handoff. Keep AgentRun's production catalog
+    # lookup and route construction in the replay so catalog drift cannot be
+    # hidden by a test double.
+    monkeypatch.setattr(agent_run_module, "execute_typed_activity", execute_activity)
     request = AgentExecutionRequest(
         agentKind="managed",
         agentId="codex_cli",
@@ -122,6 +128,52 @@ async def test_completed_batch_turn_is_rejected_at_agent_run_boundary(
     assert summary["failure"]["terminalContractMissingEvidence"] == expected[
         "missingEvidence"
     ]
+
+
+async def test_completed_batch_no_op_replays_through_production_activity_route(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Replay the endless WorkflowTaskFailed incident at its routing boundary."""
+    manifest = load_replay("agent-run-terminal-evidence-routing", "manifest.json")
+    workspace = tmp_path / "repo"
+    artifacts = workspace / "artifacts"
+    artifacts.mkdir(parents=True)
+    targets_bytes = json.dumps(manifest["resolvedTargets"]).encode("utf-8")
+    (artifacts / "batch-workflows-targets.json").write_bytes(targets_bytes)
+    terminal_evidence = dict(manifest["terminalEvidence"])
+    terminal_evidence["targetsSha256"] = hashlib.sha256(targets_bytes).hexdigest()
+    (artifacts / "batch-workflows-result.json").write_text(
+        json.dumps(terminal_evidence), encoding="utf-8"
+    )
+
+    async def execute_activity(name: str, payload: dict, **kwargs: object) -> dict:
+        assert name == manifest["activityName"]
+        assert kwargs["task_queue"] == manifest["expectedTaskQueue"]
+        activities = TemporalAgentRuntimeActivities(client_adapter=object())
+        evaluated = await activities.agent_runtime_evaluate_terminal_evidence(payload)
+        return evaluated.model_dump(mode="json", by_alias=True)
+
+    monkeypatch.setattr(agent_run_module, "execute_typed_activity", execute_activity)
+    request = AgentExecutionRequest(
+        agentKind="managed",
+        agentId="codex_cli",
+        correlationId=manifest["incidentWorkflowId"],
+        idempotencyKey=f"{manifest['incidentWorkflowId']}:replay",
+        workspaceSpec={"workspacePath": str(workspace)},
+        terminalContract=manifest["terminalContract"],
+    )
+
+    result = await MoonMindAgentRun()._evaluate_terminal_contract(
+        request=request,
+        result=AgentRunResult(
+            summary="No child workflows were queued.",
+            metadata={"workspacePath": str(workspace)},
+        ),
+    )
+
+    assert result.failure_class is None
+    assert result.metadata["terminalContractId"] == "batch_workflows_fanout.v1"
+    assert result.metadata["queuedChildCount"] == 0
 
 
 def _materialize_workspace_fixture(replay_id: str, workspace: Path) -> None:

--- a/tests/integration/temporal/test_temporal_boundary_inventory_contract.py
+++ b/tests/integration/temporal/test_temporal_boundary_inventory_contract.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import ast
+from pathlib import Path
+
 import pytest
 
 from moonmind.schemas.temporal_models import (
@@ -17,6 +20,40 @@ from moonmind.workflows.temporal.boundary_inventory import (
 
 pytestmark = [pytest.mark.integration, pytest.mark.integration_ci]
 
+
+def test_literal_workflow_activity_calls_exist_in_default_catalog() -> None:
+    """Derive routed calls from workflow source instead of a hand-kept list."""
+    workflow_root = (
+        Path(__file__).resolve().parents[3]
+        / "moonmind"
+        / "workflows"
+        / "temporal"
+        / "workflows"
+    )
+    routed_calls: dict[str, set[str]] = {}
+    for workflow_path in workflow_root.glob("*.py"):
+        tree = ast.parse(workflow_path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call) or not isinstance(
+                node.func, ast.Attribute
+            ):
+                continue
+            if node.func.attr != "_execute_routed_activity" or not node.args:
+                continue
+            activity_name = node.args[0]
+            if not isinstance(activity_name, ast.Constant) or not isinstance(
+                activity_name.value, str
+            ):
+                continue
+            routed_calls.setdefault(activity_name.value, set()).add(workflow_path.name)
+
+    assert routed_calls, "no literal routed workflow activity calls were discovered"
+    catalog = build_default_activity_catalog()
+    for activity_name, source_files in sorted(routed_calls.items()):
+        route = catalog.resolve_activity(activity_name)
+        assert route.activity_type == activity_name, sorted(source_files)
+
+
 def test_inventory_activity_names_exist_in_default_activity_catalog() -> None:
     catalog = build_default_activity_catalog()
     activity_names = {
@@ -28,6 +65,7 @@ def test_inventory_activity_names_exist_in_default_activity_catalog() -> None:
     for activity_name in activity_names:
         route = catalog.resolve_activity(activity_name)
         assert route.activity_type == activity_name
+
 
 def test_inventory_workflow_message_names_match_known_constants() -> None:
     signal_names = {

--- a/tests/unit/workflows/temporal/test_activity_catalog.py
+++ b/tests/unit/workflows/temporal/test_activity_catalog.py
@@ -22,6 +22,11 @@ from moonmind.workflows.temporal.activity_catalog import (
     build_default_activity_catalog,
     manifest_ingest_activity_routes,
 )
+from moonmind.workflows.temporal.activity_runtime import (
+    _ACTIVITY_HANDLER_ATTRS,
+    validate_activity_catalog_runtime_bindings,
+)
+
 
 def _skill_definition(
     *,
@@ -123,6 +128,29 @@ def test_default_catalog_exposes_canonical_queues_and_fleets():
     assert fleets[DEPLOYMENT_FLEET].task_queues == (DEPLOYMENT_TASK_QUEUE,)
     assert "deployment_control" in fleets[DEPLOYMENT_FLEET].capabilities
     assert "docker_workload" in fleets[AGENT_RUNTIME_FLEET].capabilities
+
+
+def test_default_catalog_matches_runtime_binding_inventory() -> None:
+    """Every concrete handler must be routable, and every route executable."""
+    catalog = build_default_activity_catalog()
+    catalog_activity_types = {
+        definition.activity_type for definition in catalog.activities
+    }
+
+    validate_activity_catalog_runtime_bindings(catalog)
+    assert catalog_activity_types - {"integration.resolve_adapter_metadata"} == (
+        set(_ACTIVITY_HANDLER_ATTRS) - {"mm.tool.execute"}
+    )
+
+
+def test_terminal_evidence_evaluation_routes_to_agent_runtime_fleet() -> None:
+    route = build_default_activity_catalog().resolve_activity(
+        "agent_runtime.evaluate_terminal_evidence"
+    )
+
+    assert route.fleet == AGENT_RUNTIME_FLEET
+    assert route.task_queue == AGENT_RUNTIME_TASK_QUEUE
+
 
 def test_plan_generate_timeout_budget_allows_retry_after_attempt_timeout():
     catalog = build_default_activity_catalog()

--- a/tests/unit/workflows/temporal/test_temporal_workers.py
+++ b/tests/unit/workflows/temporal/test_temporal_workers.py
@@ -36,7 +36,11 @@ from moonmind.workflows.temporal.artifacts import (
     TemporalArtifactRepository,
     TemporalArtifactService,
 )
-from moonmind.workflows.temporal.activity_runtime import TemporalProposalActivities
+from moonmind.workflows.temporal import activity_runtime
+from moonmind.workflows.temporal.activity_runtime import (
+    TemporalActivityRuntimeError,
+    TemporalProposalActivities,
+)
 from moonmind.workflows.temporal.activity_runtime import TemporalAgentRuntimeActivities
 from moonmind.workflows.temporal.activity_runtime import TemporalManifestActivities
 from moonmind.workflows.temporal.publish_auto_evidence import parse_auto_publish_evidence
@@ -53,6 +57,7 @@ from moonmind.workflows.temporal.workflow_registry import (
     workflow_fleet_activity_handlers,
     workflow_fleet_workflow_classes,
 )
+
 
 async def _artifact_service(
     tmp_path: Path,
@@ -103,6 +108,23 @@ def test_build_all_worker_topologies_covers_canonical_fleets():
         "temporal-worker-deployment-control"
     )
     assert topologies[DEPLOYMENT_FLEET].activity_types == ("mm.tool.execute",)
+
+
+def test_workflow_worker_startup_rejects_unroutable_activity_handler(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setitem(
+        activity_runtime._ACTIVITY_HANDLER_ATTRS,
+        "agent_runtime.unroutable_test_handler",
+        ("agent_runtime", "unroutable_test_handler"),
+    )
+
+    with pytest.raises(
+        TemporalActivityRuntimeError,
+        match="handlers without catalog routes: agent_runtime.unroutable_test_handler",
+    ):
+        build_worker_topology(fleet=WORKFLOW_FLEET)
+
 
 def test_registered_workflow_types_include_manifest_ingest():
     assert list_registered_workflow_types() == (


### PR DESCRIPTION
## Summary

- register the missing terminal-evidence and Docker-sidecar activity routes
- reject catalog/runtime-handler drift during worker topology construction
- derive routed activity coverage from workflow source and add an escaped-failure replay
- document the startup/readiness invariant

## Root cause

AgentRun terminal finalization called agent_runtime.evaluate_terminal_evidence, but the concrete handler was omitted from the canonical Temporal activity catalog. Existing tests mocked the routed activity helper and therefore skipped the broken production catalog lookup. Temporal retried the resulting WorkflowTaskFailed indefinitely.

## Validation

- 429 passed, 1 skipped in the isolated integration_ci Compose suite
- 10 reliability and boundary replay tests passed
- 28 worker/catalog unit tests passed
- 34 AgentRun session tests passed
- 1,027 frontend selector tests passed
- git diff --check passed