### PR TITLE
Make PR resolver skill semantics authoritative

### DIFF
--- a/.agents/skills/fix-comments/SKILL.md
+++ b/.agents/skills/fix-comments/SKILL.md
@@ -82,7 +82,16 @@ If no constraints are provided, default to addressing all applicable feedback.
 - If tracked or untracked code/documentation changes exist outside ignored artifacts, commit with a clear message (default: `Address PR feedback for #<number>`).
 - Push the current branch after committing.
 - If there was nothing to commit, still prove the current branch is published: verify the exact local `HEAD` SHA is visible on the remote PR branch using `gh pr view`, `git ls-remote`, or an equivalent GitHub connector path.
-- After the exact pushed/no-op head is verified, resolve every current GitHub review thread whose ledger disposition is `addressed` or `not-applicable`. The refreshed comments artifact exposes its GraphQL node as `thread_id`; resolve it with GitHub's `resolveReviewThread` mutation. Never resolve an outdated thread or a deferred comment. If a handled current thread cannot be resolved, stop as blocked with reason `publish_unavailable`; an unresolved current thread remains an authoritative merge blocker.
+- After the exact pushed/no-op head is verified, group review comments by
+  `thread_id`. Resolve a current GitHub review thread only when every
+  non-outdated comment in that thread has a ledger disposition of `addressed` or
+  `not-applicable`. If any comment in the thread is deferred, unclassified, or
+  still applicable, leave the entire thread unresolved. The refreshed comments
+  artifact exposes the GraphQL node as `thread_id`; resolve eligible threads with
+  GitHub's `resolveReviewThread` mutation. Never resolve an outdated thread. If a
+  fully handled current thread cannot be resolved, stop as blocked with reason
+  `publish_unavailable`; an unresolved current thread remains an authoritative
+  merge blocker.
   ```bash
   gh api graphql \
     -f threadId="$THREAD_ID" \

--- a/.agents/skills/fix-comments/SKILL.md
+++ b/.agents/skills/fix-comments/SKILL.md
@@ -82,6 +82,13 @@ If no constraints are provided, default to addressing all applicable feedback.
 - If tracked or untracked code/documentation changes exist outside ignored artifacts, commit with a clear message (default: `Address PR feedback for #<number>`).
 - Push the current branch after committing.
 - If there was nothing to commit, still prove the current branch is published: verify the exact local `HEAD` SHA is visible on the remote PR branch using `gh pr view`, `git ls-remote`, or an equivalent GitHub connector path.
+- After the exact pushed/no-op head is verified, resolve every current GitHub review thread whose ledger disposition is `addressed` or `not-applicable`. The refreshed comments artifact exposes its GraphQL node as `thread_id`; resolve it with GitHub's `resolveReviewThread` mutation. Never resolve an outdated thread or a deferred comment. If a handled current thread cannot be resolved, stop as blocked with reason `publish_unavailable`; an unresolved current thread remains an authoritative merge blocker.
+  ```bash
+  gh api graphql \
+    -f threadId="$THREAD_ID" \
+    -f query='mutation($threadId:ID!){resolveReviewThread(input:{threadId:$threadId}){thread{isResolved}}}'
+  ```
+- Refresh `var/pr_comments/current-branch-comments.json` after resolving threads. Do not report success while any handled, non-outdated review comment still has `thread_resolved=false`.
 - After any push or no-op verification, re-check that the remote PR branch head SHA equals local `HEAD` by writing canonical evidence through the shared helper:
   ```bash
   python3 .agents/skills/_shared/publish_evidence.py write-pushed \

--- a/.agents/skills/fix-comments/tools/get_pr_comments.py
+++ b/.agents/skills/fix-comments/tools/get_pr_comments.py
@@ -226,10 +226,10 @@ def api_post_json(
 
 def fetch_review_thread_status(
     owner: str, repo: str, pr_number: int, token: str | None
-) -> dict[int, dict[str, bool]]:
+) -> dict[int, dict[str, Any]]:
     """Fetch isResolved/isOutdated for each review thread comment via GraphQL.
 
-    Returns a mapping of comment database ID to {isResolved, isOutdated}.
+    Returns a mapping of comment database ID to thread identity and state.
     Returns {} on any failure so callers gracefully fall back.
     """
     if not token:
@@ -242,6 +242,7 @@ def fetch_review_thread_status(
           reviewThreads(first: 100, after: $cursor) {
             pageInfo { hasNextPage endCursor }
             nodes {
+              id
               isResolved
               isOutdated
               comments(first: 100) {
@@ -254,7 +255,7 @@ def fetch_review_thread_status(
     }
     """
 
-    result: dict[int, dict[str, bool]] = {}
+    result: dict[int, dict[str, Any]] = {}
     cursor: str | None = None
 
     try:
@@ -288,6 +289,7 @@ def fetch_review_thread_status(
                     db_id = comment.get("databaseId")
                     if db_id is not None:
                         result[db_id] = {
+                            "threadId": thread.get("id"),
                             "isResolved": is_resolved,
                             "isOutdated": is_outdated,
                         }
@@ -336,7 +338,7 @@ def normalize_issue_comment(comment: dict[str, Any]) -> dict[str, Any]:
 
 def normalize_review_comment(
     comment: dict[str, Any],
-    thread_status: dict[int, dict[str, bool]] | None = None,
+    thread_status: dict[int, dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     normalized: dict[str, Any] = {
         "type": "review_comment",
@@ -356,6 +358,7 @@ def normalize_review_comment(
         comment_id = comment.get("id")
         status = thread_status.get(comment_id) if comment_id else None
         if status:
+            normalized["thread_id"] = status.get("threadId")
             normalized["thread_resolved"] = status["isResolved"]
             normalized["thread_outdated"] = status["isOutdated"]
     return normalized

--- a/.agents/skills/pr-resolver/SKILL.md
+++ b/.agents/skills/pr-resolver/SKILL.md
@@ -21,9 +21,7 @@ metadata:
     contract: pr-resolver-core/v1
     supportedHosts:
       - cli
-      - temporal
-    nativeHostEligible: true
-    nativeHostPolicy: moonmind_trusted
+    nativeHostEligible: false
 ---
 
 # PR Resolver Skill
@@ -53,24 +51,63 @@ The task is not complete until the target PR is merged or is proven already merg
   minutes before merging. Any additional visible comment/review ends the grace
   wait immediately.
 
-## Temporal ownership contract
+## Skill authority and host boundary
 
-When the resolved native-host decision is `temporal`, `MoonMind.PRResolver` owns snapshot polling, classification, durable timers,
-retry budgets, merge attempts, remote verification, cancellation, and terminal
-evidence. A managed agent must never run `pr_resolve_orchestrate.py` or host the
-outer retry loop in a shell process.
+This resolved Skill bundle is the sole semantic implementation of
+`pr-resolver`, in MoonMind and outside it. The instructions in this file and the
+portable helpers beside it own GitHub snapshot collection, comment retrieval,
+comment actionability, CI interpretation, blocker priority, retry decisions,
+specialized-skill selection, merge gating, and terminal-result construction.
 
-When MoonMind explicitly records a `cli` native-host decision, this exact
-resolved Skill content remains authoritative and the portable CLI host owns the
-outer loop. That fallback must be visible in execution metadata and must never
-silently substitute MoonMind's built-in native implementation for repo, local,
-or otherwise incompatible content.
+MoonMind must execute this Skill through the ordinary agent Skill path. Native
+integration may resolve and materialize the immutable Skill bundle, provide the
+workspace and credentials, launch and supervise the runtime, enforce timeout or
+cancellation policy, capture logs, and persist or validate terminal artifacts.
+It must not replace any behavior listed above with MoonMind-only workflow,
+activity, adapter, or GitHub-client logic. In particular, MoonMind must not
+collect or classify PR comments on behalf of this Skill.
 
-When Temporal dispatches this skill as a remediation child, perform exactly the
-single classified action named in the instruction. Use the active immutable skill
-snapshot, commit and push only when the selected specialized skill requires it,
-return structured evidence, and stop. Do not wait for CI, retry merge, dispatch a
-second skill, or write a terminal resolver result; the parent workflow does those.
+If a host cannot execute the resolved Skill bundle and its required Skills, it
+must fail before mutation. It must never substitute a built-in implementation
+based on the `pr-resolver` name, source, publish mode, or an implementation
+metadata flag.
+
+## Workflow
+
+1. Resolve the active `pr-resolver` directory and use only the helpers from that
+   immutable active Skill set. Resolve `fix-comments`, `fix-ci`, and
+   `fix-merge-conflicts` from the same active set; do not use repo-global or
+   host-native substitutes.
+2. Run the finalize gate checker. It refreshes PR metadata, CI, and the complete
+   comment inventory before deciding whether merge is allowed:
+
+   ```bash
+   python3 "$PR_RESOLVER_SKILL_DIR/bin/pr_resolve_finalize.py" \
+     --pr <pr_number_or_branch> \
+     --merge-method <merge|squash|rebase> \
+     --strict-exit-codes
+   ```
+
+3. Read `var/pr_resolver/result.json` and perform exactly the indicated action:
+   - `merged` or independently verified `already_merged`: publish terminal
+     evidence and stop.
+   - `merge_conflicts`: follow `fix-merge-conflicts` completely.
+   - `ci_failures`: follow `fix-ci` completely.
+   - `actionable_comments`: follow `fix-comments` completely, including fresh
+     comment retrieval, its disposition ledger, push verification, and resolving
+     handled current review threads on GitHub.
+   - `ci_running`, `codex_review_grace_wait`, or another documented transient:
+     wait with the bounded backoff configured by the Skill inputs, then return to
+     step 2.
+   - any unavailable, ambiguous, permission-sensitive, or non-retryable state:
+     publish `manual_review` or `failed` evidence and stop without merging.
+4. After every remediation, verify the exact local `HEAD` is visible on the PR
+   branch, then return to step 2. Never reuse a pre-remediation snapshot.
+5. Enforce `maxIterations`, `finalizeMaxRetries`, and
+   `finalizeMaxElapsedSeconds`. Retryable/no-progress states receive at least five
+   finalize checks unless the elapsed-time limit or a hard failure is reached.
+6. Before reporting success, generate `artifacts/publish_result.json` from the
+   final resolver result with the shared publish-evidence helper.
 
 ## Terminal Success Contract
 Allowed successful terminal states:
@@ -108,9 +145,10 @@ When a delegated remediation step cannot publish, overwrite `var/pr_resolver/res
 - `actionable_comments` selects `fix-comments` once.
 - Transient waits and unknown/manual blockers never launch an agent remediation turn.
 
-After the child ends, Temporal independently checks the remote PR head. A child
-must not claim outer-loop success based on local commits, process output, or its
-own artifact alone.
+After a specialized Skill finishes, `pr-resolver` independently re-runs its
+portable gate against the remote PR head. A remediation Skill must not claim
+outer-loop success based on local commits, process output, or its own artifact
+alone.
 
 ## Lightweight Commands
 - Finalize-only gate checker:
@@ -128,6 +166,7 @@ python3 "$PR_RESOLVER_SKILL_DIR/bin/pr_resolve_full.py" --pr <pr_number_or_branc
 ## Constraints
 - Keep `pr_resolve_finalize.py` as a gate checker; do not add remediation mutations there.
 - Do NOT invent custom conflict/CI/comment workflows; always execute the specialized skill instructions.
+- Do not ask MoonMind or another host to collect, summarize, or classify GitHub comments for this Skill.
 - Respect retry caps; if retries are exhausted, return `attempts_exhausted` and stop.
 - This skill owns publishing under `task.publish.mode = "auto"` and may commit, push, or merge only as required to resolve the target PR. Before reporting success, ensure `artifacts/publish_result.json` exists. The orchestration command normally generates it by running:
   ```bash
@@ -135,4 +174,7 @@ python3 "$PR_RESOLVER_SKILL_DIR/bin/pr_resolve_full.py" --pr <pr_number_or_branc
     --result var/pr_resolver/result.json
   ```
 - A failed push, missing GitHub auth, or missing remote branch update is an unresolved PR blocker, even if all code changes are committed locally.
-- Never run the legacy orchestration command during normal workflow execution.
+- `pr_resolve_orchestrate.py` is a portable utility for non-agent automation and
+  tests. An agent executing this markdown owns specialized-skill dispatch and
+  must follow the workflow above rather than assuming that utility can perform
+  agent remediation.

--- a/.agents/skills/pr-resolver/SKILL.md
+++ b/.agents/skills/pr-resolver/SKILL.md
@@ -77,7 +77,16 @@ metadata flag.
 1. Resolve the active `pr-resolver` directory and use only the helpers from that
    immutable active Skill set. Resolve `fix-comments`, `fix-ci`, and
    `fix-merge-conflicts` from the same active set; do not use repo-global or
-   host-native substitutes.
+   host-native substitutes. MoonMind exports the active root as
+   `MOONMIND_ACTIVE_SKILLS_DIR`. Outside MoonMind, set `PR_RESOLVER_SKILL_DIR` to
+   the directory containing this `SKILL.md`. Establish the portable paths before
+   running a helper:
+
+   ```bash
+   PR_RESOLVER_SKILL_DIR="${PR_RESOLVER_SKILL_DIR:-${MOONMIND_ACTIVE_SKILLS_DIR:+$MOONMIND_ACTIVE_SKILLS_DIR/pr-resolver}}"
+   ACTIVE_SKILLS_DIR="${MOONMIND_ACTIVE_SKILLS_DIR:-$(dirname "$PR_RESOLVER_SKILL_DIR")}"
+   test -n "$PR_RESOLVER_SKILL_DIR" && test -f "$PR_RESOLVER_SKILL_DIR/SKILL.md"
+   ```
 2. Run the finalize gate checker. It refreshes PR metadata, CI, and the complete
    comment inventory before deciding whether merge is allowed:
 
@@ -90,7 +99,9 @@ metadata flag.
 
 3. Read `var/pr_resolver/result.json` and perform exactly the indicated action:
    - `merged` or independently verified `already_merged`: publish terminal
-     evidence and stop.
+     evidence and stop. A successful `gh pr merge` request is not terminal
+     evidence until a fresh `gh pr view` reports `state=MERGED`; merge-queue or
+     still-open states remain transient.
    - `merge_conflicts`: follow `fix-merge-conflicts` completely.
    - `ci_failures`: follow `fix-ci` completely.
    - `actionable_comments`: follow `fix-comments` completely, including fresh

--- a/.agents/skills/pr-resolver/bin/pr_resolve_contract.py
+++ b/.agents/skills/pr-resolver/bin/pr_resolve_contract.py
@@ -21,6 +21,7 @@ FINALIZE_ONLY_RETRY_REASONS = {
     "comments_unavailable",
     "ci_signal_degraded",
     "external_state_transient",
+    "merge_pending",
     "snapshot_refresh_failed",
 }
 
@@ -104,6 +105,8 @@ def remediation_next_step(reason: str) -> str:
         return "wait_for_ci_and_retry_finalize"
     if normalized == "codex_review_grace_wait":
         return "wait_for_codex_review_and_retry_finalize"
+    if normalized == "merge_pending":
+        return "retry_finalize_after_backoff"
     if normalized == "comment_policy_not_enforced":
         return "inspect_comment_policy"
     if normalized == "merge_not_ready":

--- a/.agents/skills/pr-resolver/bin/pr_resolve_finalize.py
+++ b/.agents/skills/pr-resolver/bin/pr_resolve_finalize.py
@@ -325,6 +325,17 @@ def main() -> None:
                 print("Merge gate passed (dry-run).")
                 sys.exit(EXIT_CODE_BLOCKED if args.strict_exit_codes else 0)
             _merge_pr(pr_selector, args.merge_method)
+            if not _check_pr_merged(pr_selector):
+                _write_result(
+                    result_path,
+                    snapshot=snapshot,
+                    decision="merge requested; awaiting authoritative merged state",
+                    merge_outcome="blocked",
+                    status="blocked",
+                    reason="merge_pending",
+                )
+                print("Blocked: merge_pending")
+                sys.exit(EXIT_CODE_BLOCKED if args.strict_exit_codes else 0)
             _write_result(
                 result_path,
                 snapshot=snapshot,

--- a/.agents/skills/pr-resolver/bin/pr_resolve_snapshot.py
+++ b/.agents/skills/pr-resolver/bin/pr_resolve_snapshot.py
@@ -60,7 +60,6 @@ _NON_VISIBLE_COMMENT_REASONS = {
     "addressed_in_ledger",
     "command_comment",
     "empty_body",
-    "stale_bot_comment",
     "thread_outdated",
     "thread_resolved",
 }
@@ -373,8 +372,6 @@ def _classify_comment_actionability(
     Actionability rules are intentionally simple and deterministic:
     - Ignore comments with empty bodies.
     - Ignore review comments only when explicitly marked resolved/outdated.
-    - Treat bot review comments on a *previous* commit as stale when the HEAD
-      commit differs (the fix was already pushed).
     - Treat issue comments and review bodies as actionable.
     - Treat review comments as actionable except resolved/outdated threads and
       bot-authored comments (unless explicitly enabled).
@@ -392,15 +389,6 @@ def _classify_comment_actionability(
             return False, "thread_resolved"
         if comment.get("thread_outdated", False):
             return False, "thread_outdated"
-        # Bot review comments left on a previous commit are stale — the agent
-        # already pushed a fix and the bot cannot re-evaluate its own feedback.
-        if (
-            head_commit_sha
-            and is_bot_user(comment.get("user") or "")
-            and comment.get("commit_id")
-            and str(comment["commit_id"]).strip() != head_commit_sha
-        ):
-            return False, "stale_bot_comment"
         if not include_bot_review_comments and is_bot_user(comment.get("user") or ""):
             return False, "bot_review_comment_excluded"
         return True, "actionable"
@@ -534,7 +522,11 @@ def summarize_comments(
 
     for comment in comments:
         cid = comment.get("id")
-        if isinstance(cid, int) and cid in resolved_ids:
+        if (
+            isinstance(cid, int)
+            and cid in resolved_ids
+            and comment.get("type") != "review_comment"
+        ):
             actionable = False
             reason = "addressed_in_ledger"
         else:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,16 @@ When writing code that interacts with skills:
 - Keep skills runnable outside MoonMind; isolate any MoonMind-specific services, paths, metadata, or runtime behavior behind an explicit adapter boundary.
 - Add workflow/activity or adapter-boundary tests.
 
+### Skill semantic authority
+
+- A resolved Skill bundle is the authoritative implementation of its behavior in every host. `SKILL.md` and the portable files shipped beside it must define the same decisions, data collection, ordering, and terminal evidence whether the Skill runs in Codex directly or through MoonMind.
+- Native integration may provide execution substrate only: resolution and immutable materialization, credentials, workspace isolation, process launch, durable scheduling, timeout/cancellation enforcement, logs, artifacts, approvals, and validation of declared terminal contracts.
+- Native workflows, Activities, adapters, and service clients must not reimplement Skill semantics such as provider data collection, comment or issue classification, blocker priority, retry decisions, remediation selection, or completion rules when the resolved Skill already performs that behavior.
+- A native host may execute the portable Skill implementation at a controlled Activity or runtime boundary. It may not replace that implementation with parallel logic merely for performance, durability, or convenience.
+- If required behavior cannot be executed from the resolved Skill bundle, select an explicit portable host or fail before mutation. Never substitute behavior based on Skill name, built-in provenance, publish mode, or a stale native binding.
+- Any proposed native binding must identify the irreducibly native capability it supplies and the exact portable semantic entrypoint it executes. If it cannot do both, do not add the binding.
+- Tests must prove that MoonMind executes the resolved Skill behavior, not merely that a separate native implementation produces similar classifications. Cross-host comparison tests are supplemental and never justify duplicate semantic implementations.
+
 ## Documentation: canonical vs feature artifacts
 
 - **Canonical docs** (`docs/`): describe **declarative desired state** — architecture, contracts, operator-visible behavior, target semantics. Avoid making phased migration or implementation checklists the main story in these files.

--- a/docs/Steps/SkillGithubPrResolver.md
+++ b/docs/Steps/SkillGithubPrResolver.md
@@ -10,16 +10,21 @@ The **PR Resolver** skill is invoked from the dashboard (via Temporal `AgentTask
 
 1. **Resolve target PR** (defaults to the PR associated with the current branch).
 2. **Fetch PR metadata + CI status + comments**.
-3. **Diagnose and Delegate**: let `MoonMind.PRResolver` classify durable gate state and launch one bounded `MoonMind.AgentRun` for the selected specialized skill.
+3. **Diagnose and Delegate**: classify the portable snapshot and follow the selected specialized Skill from the same resolved Skill set.
 4. **Merge the PR** if everything is already good **and** no CI is currently running.
 
-The durable umbrella is a Temporal workflow, not a managed agent shell. Specialized agents do one remediation action; Temporal owns polling, timers, retry budgets, merge attempts, remote verification, cancellation, and terminal evidence.
+MoonMind executes `pr-resolver` as an ordinary resolved Skill in
+`MoonMind.AgentRun`. The Skill markdown owns the loop and the packaged portable
+helpers own snapshot collection and merge gating. MoonMind supplies the managed
+runtime substrate and projects the Skill's terminal artifacts; it does not run a
+second resolver implementation.
 
 The checked-in skill is also a portable contract. Its provider-neutral models,
 normalization, classification, transition, and evidence rules live in
-`pr_resolver_core`; both the local scripts and the Temporal host consume that
-package. The core performs no network, filesystem, process, credential, clock,
-or Temporal operations. Host adapters gather state and perform actions.
+`pr_resolver_core`, while provider data collection and command execution live in
+the Skill bundle. The same bundle is used in direct Codex and MoonMind-managed
+runs. The core performs no network, filesystem, process, credential, clock, or
+Temporal operations.
 
 ---
 
@@ -28,7 +33,9 @@ or Temporal operations. Host adapters gather state and perform actions.
 * The `temporal-worker-sandbox` environment already supports run-scoped skills via `.agents/skills` symlinks to a single active set.
 * The worker environment has GitHub auth available for private repo operations and includes `gh` usage in existing workflows.
 * Specialized sub-skills (like `fix-merge-conflicts`) are available in the `.agents/skills/` directory.
-* Resolver workflows use `publish.mode=auto`. Remediation children may commit and push when their selected skill requires it; trusted resolver activities own merge and terminal publication.
+* Resolver workflows use `publish.mode=auto`. Specialized Skills may commit and
+  push when their instructions require it; the portable `pr-resolver` finalize
+  helper owns merge and terminal-evidence generation.
 * Publish authority and implementation hosting are independent decisions.
   `publish.mode=auto` does not authorize native Temporal execution.
 
@@ -54,31 +61,32 @@ Shared repo skill mirror:
     pr_resolver_result.schema.json
 ```
 
-The Python scripts remain a supported portable host. MoonMind routes the trusted
-built-in snapshot to `MoonMind.PRResolver`; standalone environments and
-non-native-compatible snapshots use the portable host.
+The Python scripts and this markdown form the portable implementation. MoonMind
+materializes and executes that same bundle through its ordinary agent runtime;
+there is no active native semantic host.
 
-### 3.2 Trusted native binding
+### 3.2 Skill-owned host contract
 
 The portable contract declares `implementation.contract =
-pr-resolver-core/v1`, supported hosts, and native-host policy separately from
-publish metadata. Native routing requires the immutable resolved-skill entry to
-prove all of the following: canonical name, compatible contract, Temporal host
-support, trusted policy, built-in provenance, and non-empty content ref and
-digest. A repository or local override named `pr-resolver` does not inherit the
-native workflow or trusted privileges. It runs through the explicit CLI fallback
-with an observable reason code, or is rejected before launch when policy forbids
-that host.
+pr-resolver-core/v1`, supports the `cli` host, and is not native-host eligible.
+All resolved sources—built-in, deployment, repository, or local—execute their
+exact immutable Skill content through the ordinary agent runtime path. Built-in
+provenance does not authorize MoonMind to replace the bundle with
+`MoonMind.PRResolver` or GitHub-adapter readiness logic.
 
-Temporal workers load `pr_resolver_core` from their immutable application
-artifact. They never import repository skill code during workflow replay.
+The former native resolver remains registered only for replay of Temporal
+histories that already recorded it. A new workflow records the
+`run-pr-resolver-skill-owned-execution-v1` cutover marker and cannot select that
+child type.
 
-### 3.3 Required Worker Capabilities
+### 3.3 Required Runtime Capabilities
 
-The workflow fleet is orchestration-only and has no `git`, `gh`, repository
-write, sandbox, or agent-runtime privilege. GitHub reads and merge attempts run
-on the integrations activity fleet; remediation runs in bounded
-`MoonMind.AgentRun` children.
+The selected managed runtime receives the resolved Skill set plus governed
+`git` and `gh` capabilities. MoonMind may materialize credentials, isolate the
+workspace, supervise the process, enforce cancellation and timeout policy, and
+persist artifacts. GitHub reads and merge attempts are initiated by the portable
+Skill helpers inside that boundary, not by an integrations activity that
+reimplements resolver behavior.
 
 ---
 
@@ -98,8 +106,9 @@ on the integrations activity fleet; remediation runs in bounded
 | `finalizeMaxSleepSeconds`   | int         |      120 | Max sleep between finalize-only retries.                                                                                            |
 | `finalizeMaxElapsedSeconds` | int         |     7200 | Hard wall-clock cap for one orchestration run.                                                                                      |
 
-These values compile into `PRResolverPolicyModel`. Temporal persists counters and
-uses durable timers; no managed agent process sleeps between polls.
+The Skill enforces these values in its own loop. MoonMind's runtime timeout and
+intervention policies remain an outer safety envelope and do not replace the
+Skill's retry semantics.
 
 ### 4.2 Outputs
 
@@ -108,10 +117,10 @@ Write a machine-readable result to the Workflow artifact directory:
 * `artifacts/pr_resolver_snapshot.json`
 * `artifacts/pr_resolver_result.json`
 
-Temporal state and artifact refs are authoritative. The terminal publication
-activity continues to name compatibility artifacts `var/pr_resolver/result.json`
-and `artifacts/publish_result.json`; those names do not make a workspace shell
-process authoritative.
+`var/pr_resolver/result.json` and `artifacts/publish_result.json` are the Skill's
+authoritative terminal evidence. MoonMind validates and projects those artifacts
+into workflow state; assistant prose or process exit alone is not completion
+evidence.
 
 Result should include:
 * Resolved PR identity
@@ -134,7 +143,11 @@ inside workflow state and are not terminal agent dispositions.
 Use `gh pr view --json` (fields: `number,title,url,isDraft,state,headRefName,baseRefName,mergeable,mergeStateStatus,reviewDecision,statusCheckRollup`).
 
 **B. Comments**
-Reuse existing scripts (`tools/get_branch_pr_comments.py` or `tools/get_pr_comments.py`) to yield a normalized list of comments.
+The Skill resolves `fix-comments/tools/get_branch_pr_comments.py` from the same
+immutable active Skill set. That helper retrieves issue comments, review bodies,
+inline review comments, and paginated review-thread resolution/outdated state.
+MoonMind workflows, Activities, and GitHub adapters do not retrieve or classify
+comments for `pr-resolver`.
 
 **C. CI / Checks / Running state**
 `bin/pr_resolve_snapshot.py` emits a unified snapshot, computing:
@@ -146,14 +159,14 @@ Reuse existing scripts (`tools/get_branch_pr_comments.py` or `tools/get_pr_comme
 
 ## 6. Decision Engine
 
-The workflow always re-reads authoritative GitHub state after each applied fix.
+The Skill always re-reads authoritative GitHub state after each applied fix.
 
 1. **Preflight stop conditions:** PR not found, PR is draft, or PR already merged/closed.
 2. **Merge conflicts:** If `mergeable` indicates conflict (`false`, `CONFLICTING`, or `DIRTY`) or `mergeStateStatus` is exactly `DIRTY` → Delegate to `fix-merge-conflicts` skill before any CI-fix or CI-wait decision.
 3. **CI failures:** If `ci.hasFailures == true` → Delegate to `fix-ci` skill (or fallback to manual diagnosis if skill missing).
 4. **Review comments:** If `reviewDecision` requests changes or comments are actionable → Delegate to `fix-comments` skill.
-5. **Merge:** If gates pass, execute one idempotent `pr_resolver.finalize_merge` activity and independently run `pr_resolver.verify_merged`.
-6. **Transient wait:** schedule a durable Temporal timer, then read a new snapshot.
+5. **Merge:** If gates pass, run the portable finalize helper with the selected merge method and independently verify the remote merge result through that helper.
+6. **Transient wait:** apply the Skill's bounded backoff, then read a new portable snapshot.
 7. **Blocked:** stop on budget exhaustion, non-retryable input, or an identical actionable blocker that repeats without a remote head change.
 
 ---
@@ -190,8 +203,9 @@ Merge only when:
 * **No CI currently running**
 * Review policy satisfied
 
-Execution: the bounded `pr_resolver.finalize_merge` activity calls the trusted
-GitHub adapter with an exact expected head and stable idempotency key.
+Execution: `bin/pr_resolve_finalize.py` refreshes the portable snapshot, verifies
+the exact head and all gates, invokes `gh pr merge` with the selected method, and
+writes terminal evidence.
 
 ---
 
@@ -239,52 +253,21 @@ Include in result:
 
 ---
 
-## 12. Suggested `SKILL.md` Skeleton (Agent Skill)
+## 12. Canonical Skill Instructions
 
-This enforces the "Read-and-Execute" pattern for the LLM:
-
-```markdown
----
-name: pr-resolver
-description: Master orchestrator to resolve a PR by diagnosing state and delegating to specialized skills.
----
-
-# PR Resolver Skill
-
-## Purpose
-You are the Master orchestrator for finishing Pull Requests. You diagnose the PR state using a snapshot script and resolve issues by reading and executing the instructions of specialized sub-skills (`fix-merge-conflicts`, `fix-ci`, etc.).
-
-## Inputs (skill args)
-- inputs.repo (optional)
-- inputs.pr (optional)
-- inputs.branch (optional)
-- inputs.mergeMethod (merge|squash|rebase)
-- inputs.maxIterations (default 5)
-- inputs.finalizeMaxRetries (default 60)
-- inputs.finalizeBackoffSeconds (default 30)
-- inputs.finalizeMaxSleepSeconds (default 120)
-- inputs.finalizeMaxElapsedSeconds (default 7200)
-
-## Workflow
-1. Run `bin/pr_resolve_snapshot.py` to generate `artifacts/pr_resolver_snapshot.json`.
-2. Inspect the snapshot output.
-3. Apply fixes in this strict priority order:
-   - **Merge Conflicts:** If `mergeable` indicates conflict (`false`, `CONFLICTING`, or `DIRTY`) or `mergeStateStatus` is exactly `DIRTY`, you MUST read `.agents/skills/fix-merge-conflicts/SKILL.md`. Follow its procedure exactly to resolve the conflict before attempting CI fixes or waiting for CI.
-   - **CI Failures:** If `ci.hasFailures` is true, you MUST read `.agents/skills/fix-ci/SKILL.md` (or similar available skill) and follow its procedure to fix the tests/build.
-   - **Review Comments:** If `reviewDecision` indicates changes requested, read `.agents/skills/fix-comments/SKILL.md` and follow its procedure.
-   - **Merge:** If all green, `mergeable` is clean, `mergeStateStatus` is `CLEAN`, and NO CI is running, execute `gh pr merge --<mergeMethod>`.
-   - **Finalize-only retry:** If CI is running but no failures while `mergeable` is clean and `mergeStateStatus` is exactly `CLEAN`, retry finalize after bounded exponential backoff until the transient retry budget is exhausted.
-4. After applying ANY fix (conflict, CI, or review), you MUST loop back to Step 1 and re-run the snapshot. Stop after `maxIterations`, but do not report `attempts_exhausted` for retryable/no-progress blockers before five finalize attempts unless a hard timeout, hard failure, or non-retryable blocker is reached first.
-5. Write `artifacts/pr_resolver_result.json` summarizing the actions taken and the final merge outcome.
-
-## Constraints
-- Do NOT try to invent your own conflict resolution or CI fixing workflow. Always load and follow the specialized sub-skill instructions.
-- This skill is allowed to commit/push and merge only under `task.publish.mode = "auto"` and must write `artifacts/publish_result.json` evidence before reporting success.
-```
+`.agents/skills/pr-resolver/SKILL.md` is the canonical executable instruction
+contract. This document intentionally does not duplicate its step-by-step
+workflow. Changes to resolver behavior begin in that Skill bundle and are then
+reflected here as durable architecture; MoonMind-native code must not become a
+second source of behavior.
 
 ---
 
 ## 13. Verification
 
 - Skill assets live under `.agents/skills/pr-resolver/`; snapshot logic is exercised by `tests/unit/test_pr_resolver_tools.py` (loads `pr_resolve_snapshot.py` from the skill tree).
+- Skill resolution tests require `supportedHosts = ["cli"]` and
+  `nativeHostEligible = false`.
+- New `MoonMind.UserWorkflow` histories route `pr-resolver` through
+  `MoonMind.AgentRun`; the dedicated native workflow is replay-only.
 - The dashboard submit flows reference `pr-resolver` in the React workflow-start surface and its focused entrypoint tests.

--- a/docs/Steps/SkillSystem.md
+++ b/docs/Steps/SkillSystem.md
@@ -69,18 +69,45 @@ The desired-state skill model is:
 9. Runtime adapters consume the resolved snapshot; they must not rediscover, broaden, or re-resolve Skills during execution.
 10. `.agents/skills/local` remains a local-only overlay input convention, not the active runtime projection.
 11. A native host is selected from trusted resolved-skill evidence, never from
-    canonical skill name or publish mode alone.
+    canonical skill name or publish mode alone, and is valid only when it
+    executes the exact portable semantic entrypoint from that resolved content.
 
 ### Native implementation contracts
 
 Skills may declare a portable semantic implementation contract and supported
 hosts independently of their publish metadata. The resolved entry preserves the
 winning source, content ref, digest, contract, supported hosts, and native-host
-policy. Native bindings consume that immutable evidence. Later-precedence repo
-or local content with the same skill name remains different content and receives
-no built-in native privileges by name. When a compatible binding is unavailable,
-the runtime records an explicit portable-host decision or rejects the step before
-launch with a policy diagnostic; it must not substitute other skill content.
+policy. A native binding may supply execution substrate, but the resolved Skill
+bundle remains the sole semantic authority. The binding must execute a portable
+entrypoint from that exact resolved content; it must not reproduce the Skill's
+data collection, classification, ordering, retry, remediation, or completion
+logic in MoonMind code.
+
+Allowed native responsibilities are limited to capabilities that cannot live in
+portable Skill content without violating platform boundaries: immutable
+resolution and materialization, credential delivery, workspace isolation,
+process supervision, durable scheduling, timeout and cancellation enforcement,
+approval enforcement, log and artifact transport, and validation or publication
+of the Skill's declared terminal evidence. Durability is not permission to move
+semantic decisions out of the Skill. A Temporal workflow may durably invoke the
+same portable entrypoint at Activity boundaries; it may not become a second
+implementation of that entrypoint.
+
+Later-precedence repo or local content with the same skill name remains different
+content and receives no built-in native privileges by name. When a compatible
+binding cannot execute the exact resolved implementation, the runtime records an
+explicit portable-host decision or rejects the step before launch with a policy
+diagnostic. It must not substitute other Skill content or a parallel built-in
+implementation.
+
+Native-binding review must answer both questions before implementation:
+
+1. Which irreducibly native capability is being supplied?
+2. Which portable semantic entrypoint from the resolved Skill is executed?
+
+If either answer is missing, the binding is invalid. Cross-host conformance tests
+may add defense in depth, but matching tests do not authorize duplicated semantic
+implementations.
 
 ---
 

--- a/docs/Temporal/ActivityCatalogAndWorkerTopology.md
+++ b/docs/Temporal/ActivityCatalogAndWorkerTopology.md
@@ -46,7 +46,9 @@ built, the Temporal client is connected, workers are constructed, and pollers
 have started. Its bounded response includes task queues, registered workflow and
 activity types, build/deployment identity, registry fingerprint, versioning
 state, and resolver-core identity. `MoonMind.PRResolver` may appear only when
-that exact workflow class was supplied to the SDK worker.
+that exact workflow class was supplied to the SDK worker. Its registration is
+replay support for previously recorded histories, not an active host-selection
+surface for new `pr-resolver` runs.
 
 The workflow fleet remains Temporal-only. It receives no repository mutation,
 GitHub credential, sandbox, local-git, or agent-runtime capabilities.

--- a/docs/Temporal/ManagedAndExternalAgentExecutionModel.md
+++ b/docs/Temporal/ManagedAndExternalAgentExecutionModel.md
@@ -253,7 +253,22 @@ Normalization does **not** belong in:
 * parent-to-child orchestration glue
 * ad hoc workflow coercion helpers
 
-### 3.2 Compatibility direction
+### 3.2 Skill semantics are not adapter normalization
+
+Provider/runtime normalization must not be used to move resolved Skill behavior
+into an adapter. When a Skill already defines how to retrieve and interpret
+provider data, select remediation, order work, or decide completion, the adapter
+may only expose the credentials, transport, workspace, process, and artifact
+capabilities needed to execute that Skill implementation. It must not perform a
+parallel provider query and return a MoonMind-authored semantic conclusion.
+
+For example, a Skill that retrieves GitHub review comments must retrieve and
+classify those comments through its resolved portable implementation in both a
+direct Codex run and a MoonMind-managed run. A MoonMind GitHub adapter may supply
+authenticated transport or execute that portable entrypoint in a controlled
+Activity, but it must not maintain a second comment-readiness algorithm.
+
+### 3.3 Compatibility direction
 
 Older compatibility code may continue to exist temporarily for replay safety or migration windows, but the target state is:
 

--- a/docs/Temporal/ops-runbook.md
+++ b/docs/Temporal/ops-runbook.md
@@ -20,9 +20,13 @@ Keys for model providers (e.g. Google and OpenAI) are injected from this user's 
 
 ### Workflow worker deployment and resolver registration
 
-Use `/healthz` only for liveness and `/readyz` for traffic readiness. Resolver
-traffic is ready only when the response is ready and lists the expected task
-queue, `MoonMind.PRResolver`, immutable build identity, and registry fingerprint.
+Use `/healthz` only for liveness and `/readyz` for traffic readiness. New
+`pr-resolver` traffic uses `MoonMind.UserWorkflow` plus `MoonMind.AgentRun` and
+must execute the resolved Skill bundle. `MoonMind.PRResolver` registration is
+required only while older histories that already recorded that child type remain
+within the replay/support window; its presence must not be used to route new
+resolver work. Readiness still requires the expected task queues, immutable build
+identity, and registry fingerprint.
 Production mode fails startup unless `MOONMIND_BUILD_SHA` or
 `MOONMIND_IMAGE_DIGEST` is set and Temporal worker deployment versioning is
 enabled. Deploy immutable images, promote a controlled worker version, drain old
@@ -32,9 +36,11 @@ workers from the queue, and run:
 python tools/run_pr_resolver_deployment_canary.py
 ```
 
-The canary starts the real workflow type on the deployed queue and follows a
-non-mutating dry-run path. Do not recover affected executions until it reports
-the expected build and registry identity.
+This legacy canary validates replay registration for the old workflow type. It
+does not validate the active Skill-owned resolver path. Validate new resolver
+deployments with a `MoonMind.UserWorkflow` dry run that resolves `pr-resolver`,
+records `skill_owned_execution_required`, starts `MoonMind.AgentRun`, and
+produces the Skill's terminal artifact without selecting the native child.
 
 Python workers do not hot-reload mounted workflow source. After workflow code or
 registration changes in local Compose, recreate the complete workflow worker

--- a/docs/Workflows/PrMergeAutomation.md
+++ b/docs/Workflows/PrMergeAutomation.md
@@ -101,14 +101,19 @@ MoonMind's lifecycle model already expects `MoonMind.UserWorkflow` to mix direct
 
 ### 6.3 Why the resolver itself is a child `MoonMind.UserWorkflow`
 
-The current MoonMind execution model routes a trusted, native-compatible
-`pr-resolver` resolved snapshot to the dedicated `MoonMind.PRResolver` child
-workflow. Skill name and auto-publish mode alone are insufficient. That workflow owns the durable
-gate loop and starts bounded `MoonMind.AgentRun` children only for
-`fix-comments`, `fix-ci`, or `fix-merge-conflicts`. It owns merge verification
-and terminal evidence; managed agents do not host the polling loop.
+`MoonMind.MergeAutomation` starts a child **`MoonMind.UserWorkflow`** so the
+resolver uses MoonMind's ordinary resolved-Skill execution path. The child
+materializes the exact `pr-resolver` bundle and runs it in `MoonMind.AgentRun`;
+the Skill markdown and packaged portable helpers own PR snapshots, comment
+retrieval, classification, remediation selection, retries, merge gating, and
+terminal evidence.
 
-Because of that, `MoonMind.MergeAutomation` SHOULD start a child **`MoonMind.UserWorkflow`** for the resolver, rather than trying to execute the resolver skill directly inside the gate workflow. This reuses:
+MoonMind must not route `pr-resolver` to a dedicated native semantic
+implementation. The former `MoonMind.PRResolver` workflow remains registered
+only while required to replay histories that already recorded that child type;
+new executions must not select it.
+
+The child `MoonMind.UserWorkflow` boundary reuses:
 
 - existing workspace/runtime setup,
 - artifact publishing,
@@ -126,9 +131,9 @@ MoonMind.UserWorkflow (root parent workflow)
   |- child: MoonMind.MergeAutomation
   |    |- gate wait / external events / Jira checks
   |    |- child: MoonMind.UserWorkflow (resolver attempt 1)
-  |    |     `- child: MoonMind.PRResolver, publishMode=auto
+  |    |     `- child: MoonMind.AgentRun (resolved pr-resolver Skill)
   |    `- child: MoonMind.UserWorkflow (resolver attempt 2, if needed)
-  |          `- child: MoonMind.PRResolver, publishMode=auto
+  |          `- child: MoonMind.AgentRun (resolved pr-resolver Skill)
   `- terminal completion only after MergeAutomation returns success
 ```
 
@@ -629,18 +634,24 @@ failure rather than asking the gate to continue.
 
 ---
 
-## 15. Shared Gate Semantics Between Gate and Resolver
+## 15. Resolver Skill Authority
 
-To avoid early merge after resolver-generated pushes, MoonMind SHOULD align the merge gate and `pr-resolver` on one shared semantic contract.
+The merge-automation gate decides only when to launch or relaunch the resolver
+child. It must not decide that the PR is safe to merge. The resolved
+`pr-resolver` Skill is the sole authority for head-SHA rules, review-comment
+retrieval and freshness, required-check completeness, blocker classification,
+remediation selection, and the final merge attempt.
 
-This does **not** require the same runtime process or exact same Python module. It does require the same logical contract:
+MoonMind may observe compact external state to avoid launching a resolver while
+a configured upstream review provider or required check is visibly pending. That
+observation is scheduling evidence only. It cannot bypass the resolver's fresh
+portable snapshot and cannot be treated as merge authorization.
 
-- same head-SHA rules,
-- same review-provider freshness rules,
-- same required-check completeness rules,
-- same blocker categories.
-
-The merge gate and the resolver snapshot/finalize logic may use different implementations, but they MUST agree on contract semantics.
+The gate and resolver must not maintain separate implementations that merely aim
+to agree. If merge automation needs a resolver semantic decision, it must launch
+the resolved Skill or consume terminal evidence produced by that Skill. A
+cross-implementation comparison test is not a substitute for this single-authority
+rule.
 
 Before any resolver child has launched, `MoonMind.MergeAutomation` MAY adopt the
 latest observed PR head SHA when a readiness evaluation sees that the published

--- a/docs/Workflows/WorkflowPublishing.md
+++ b/docs/Workflows/WorkflowPublishing.md
@@ -27,9 +27,9 @@ The built-in repository auto-publish skills are `pr-resolver`, `fix-comments`, `
 
 Publishing does not choose an implementation host. In particular,
 `publish.mode = auto` grants the selected skill agent-owned publishing authority
-and requires evidence; it does not select `MoonMind.PRResolver`. Native hosting
-is a separate trusted binding over the immutable resolved-skill contract,
-provenance, content ref, and digest.
+and requires evidence; it does not select or authorize a native semantic
+implementation. `pr-resolver` always executes its resolved Skill bundle through
+the ordinary agent runtime path.
 
 Resolution rules:
 

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -4930,7 +4930,11 @@ class TemporalIntegrationActivities:
         return result.model_dump(by_alias=True, mode="json")
 
     async def pr_resolver_read_snapshot(self, payload, /, **kwargs):
-        """Capture one compact, immutable GitHub gate snapshot."""
+        """Replay-only snapshot support for previously recorded native runs.
+
+        New pr-resolver executions must collect state through their resolved
+        Skill bundle and must not call this Activity.
+        """
 
         from moonmind.workflows.adapters.github_service import GitHubService
 
@@ -4953,7 +4957,10 @@ class TemporalIntegrationActivities:
         return result
 
     async def pr_resolver_finalize_merge(self, payload, /, **kwargs):
-        """Perform one idempotent merge attempt for an exact PR revision."""
+        """Replay-only merge support for previously recorded native runs.
+
+        New pr-resolver executions merge through the portable Skill helper.
+        """
 
         from moonmind.workflows.adapters.github_service import GitHubService
 
@@ -5001,7 +5008,7 @@ class TemporalIntegrationActivities:
         return output
 
     async def pr_resolver_classify_gate(self, payload, /, **kwargs):
-        """Classify only the captured snapshot supplied by the workflow."""
+        """Replay-only classifier for previously recorded native runs."""
 
         from moonmind.workflows.temporal.workflows.pr_resolver import (
             classify_pr_resolver_snapshot,

--- a/moonmind/workflows/temporal/native_skill_bindings.py
+++ b/moonmind/workflows/temporal/native_skill_bindings.py
@@ -39,7 +39,7 @@ def _implementation_payload(entry: Any) -> Mapping[str, Any]:
 
 
 def evaluate_pr_resolver_native_binding(entry: Any) -> NativeSkillBindingDecision:
-    """Select native hosting only for the trusted built-in portable contract."""
+    """Replay-only evaluator for histories that predate skill-owned execution."""
 
     name = str(_field(entry, "skill_name", "skillName", "name") or "").strip()
     provenance = _field(entry, "provenance")
@@ -90,4 +90,18 @@ def evaluate_pr_resolver_native_binding(entry: Any) -> NativeSkillBindingDecisio
             return NativeSkillBindingDecision(False, "cli", reason, identity)
     return NativeSkillBindingDecision(
         True, "temporal", "native_binding_accepted", identity
+    )
+
+
+def require_skill_owned_pr_resolver_execution(
+    entry: Any,
+) -> NativeSkillBindingDecision:
+    """Route every new resolver run through its exact resolved Skill bundle."""
+
+    legacy = evaluate_pr_resolver_native_binding(entry)
+    return NativeSkillBindingDecision(
+        eligible=False,
+        host="cli",
+        reason_code="skill_owned_execution_required",
+        identity=legacy.identity,
     )

--- a/moonmind/workflows/temporal/workflows/pr_resolver.py
+++ b/moonmind/workflows/temporal/workflows/pr_resolver.py
@@ -1,4 +1,9 @@
-"""Durable Temporal-owned pull-request resolution state machine."""
+"""Replay support for the superseded native PR-resolver state machine.
+
+New resolver runs execute the exact resolved Skill bundle through
+``MoonMind.AgentRun``. Keep this workflow registered only for histories that
+already recorded ``MoonMind.PRResolver`` before the skill-owned cutover.
+"""
 
 from __future__ import annotations
 

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -87,6 +87,7 @@ with workflow.unsafe.imports_passed_through():
     )
     from moonmind.workflows.temporal.native_skill_bindings import (
         evaluate_pr_resolver_native_binding,
+        require_skill_owned_pr_resolver_execution,
     )
     from moonmind.schemas.temporal_models import (
         DependencyResolvedSignalPayload,
@@ -619,6 +620,9 @@ RUN_PR_RESOLVER_PUBLISH_EVIDENCE_REF_PATCH = (
 )
 RUN_TRUSTED_PR_RESOLVER_NATIVE_BINDING_PATCH = (
     "run-trusted-pr-resolver-native-binding-v1"
+)
+RUN_PR_RESOLVER_SKILL_OWNED_EXECUTION_PATCH = (
+    "run-pr-resolver-skill-owned-execution-v1"
 )
 RUN_PR_RESOLVER_SELECTOR_RESOLUTION_PATCH = (
     "run-pr-resolver-selector-resolution-v1"
@@ -8521,11 +8525,12 @@ class MoonMindRunWorkflow:
                                 )
                                 if not temporal_pr_resolver:
                                     portable_note = (
-                                        "\n\nNative host decision: use the portable CLI host "
-                                        f"because {binding.get('reasonCode')}. Run the "
-                                        "portable pr-resolver loop and publish its terminal "
-                                        "evidence; do not substitute MoonMind's built-in "
-                                        "native implementation."
+                                        "\n\nHost decision: execute the resolved pr-resolver "
+                                        "Skill directly because "
+                                        f"{binding.get('reasonCode')}. Follow its SKILL.md "
+                                        "workflow and packaged helpers, and publish its "
+                                        "terminal evidence. MoonMind must not substitute "
+                                        "native PR snapshot, comment, gate, or merge logic."
                                     )
                                     request = request.model_copy(
                                         update={
@@ -14176,7 +14181,19 @@ class MoonMindRunWorkflow:
                     resolved,
                     normalized_skill,
                 )
-                if workflow.patched(RUN_TRUSTED_PR_RESOLVER_NATIVE_BINDING_PATCH):
+                if workflow.patched(
+                    RUN_PR_RESOLVER_SKILL_OWNED_EXECUTION_PATCH
+                ):
+                    decision = require_skill_owned_pr_resolver_execution(
+                        selected_entry
+                    )
+                    self._native_skill_binding_by_step[node_id] = {
+                        "eligible": decision.eligible,
+                        "host": decision.host,
+                        "reasonCode": decision.reason_code,
+                        "identity": dict(decision.identity),
+                    }
+                elif workflow.patched(RUN_TRUSTED_PR_RESOLVER_NATIVE_BINDING_PATCH):
                     decision = evaluate_pr_resolver_native_binding(selected_entry)
                     self._native_skill_binding_by_step[node_id] = {
                         "eligible": decision.eligible,

--- a/tests/unit/services/test_skill_resolution.py
+++ b/tests/unit/services/test_skill_resolution.py
@@ -109,7 +109,7 @@ async def test_built_in_loader_discovers_packaged_agent_skills():
     assert discovered["moonspec-breakdown"].provenance.source_path
 
 
-async def test_built_in_pr_resolver_declares_portable_native_contract():
+async def test_built_in_pr_resolver_requires_skill_owned_cli_execution():
     results = await BuiltInSkillLoader().load_skills(
         SkillSelector(include=[{"name": "pr-resolver"}]),
         SkillResolutionContext(snapshot_id="snap-pr-resolver"),
@@ -118,8 +118,8 @@ async def test_built_in_pr_resolver_declares_portable_native_contract():
     entry = next(item for item in results if item.skill_name == "pr-resolver")
     assert entry.implementation is not None
     assert entry.implementation.contract == "pr-resolver-core/v1"
-    assert entry.implementation.supported_hosts == ["cli", "temporal"]
-    assert entry.implementation.native_host_eligible is True
+    assert entry.implementation.supported_hosts == ["cli"]
+    assert entry.implementation.native_host_eligible is False
     assert entry.provenance.source_kind == AgentSkillSourceKind.BUILT_IN
     assert entry.terminal_contract is not None
     assert entry.terminal_contract.contract_id == "pr_resolver_terminal.v1"

--- a/tests/unit/test_pr_resolver_tools.py
+++ b/tests/unit/test_pr_resolver_tools.py
@@ -1384,6 +1384,20 @@ def test_contract_external_state_transient_is_finalize_only_retry(
         == "retry_finalize_after_backoff"
     )
 
+def test_contract_merge_pending_is_finalize_only_retry(
+    pr_resolve_contract_module: dict[str, Any],
+) -> None:
+    classify_retry_action = pr_resolve_contract_module["classify_retry_action"]
+    remediation_next_step = pr_resolve_contract_module["remediation_next_step"]
+
+    action = classify_retry_action(
+        "merge_pending",
+        merge_not_ready_grace_remaining=0,
+    )
+
+    assert action == "finalize_only_retry"
+    assert remediation_next_step("merge_pending") == "retry_finalize_after_backoff"
+
 def test_contract_codex_review_grace_wait_is_finalize_only_retry(
     pr_resolve_contract_module: dict[str, Any],
 ) -> None:
@@ -1675,6 +1689,76 @@ def test_finalize_already_merged_pr_returns_already_merged(
 
     assert decision == {"action": "already_merged", "reason": "already_merged"}
 
+def test_finalize_merge_request_waits_for_authoritative_merged_state(
+    pr_resolve_finalize_module: dict[str, Any],
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    import json
+
+    main = pr_resolve_finalize_module["main"]
+    globals_dict = main.__globals__
+    exit_code_blocked = pr_resolve_finalize_module["EXIT_CODE_BLOCKED"]
+
+    snapshot = {
+        "pr": {
+            "number": 3210,
+            "state": "OPEN",
+            "mergeable": "MERGEABLE",
+            "mergeStateStatus": "CLEAN",
+        },
+        "ci": {"isRunning": False, "hasFailures": False, "signalQuality": "ok"},
+        "commentsFetch": {"succeeded": True, "source": "fixture"},
+        "commentsSummary": {
+            "hasActionableComments": False,
+            "includeBotReviewComments": True,
+        },
+    }
+
+    def _write_snapshot(
+        _snapshot_script: Path,
+        _pr: str | None,
+        snapshot_path: Path,
+    ) -> None:
+        snapshot_path.parent.mkdir(parents=True, exist_ok=True)
+        snapshot_path.write_text(json.dumps(snapshot), encoding="utf-8")
+
+    merge_calls: list[tuple[str, str]] = []
+    monkeypatch.setitem(globals_dict, "_run_snapshot", _write_snapshot)
+    monkeypatch.setitem(
+        globals_dict,
+        "_merge_pr",
+        lambda selector, method: merge_calls.append((selector, method)),
+    )
+    monkeypatch.setitem(globals_dict, "_check_pr_merged", lambda _selector: False)
+
+    result_path = tmp_path / "result.json"
+    snapshot_path = tmp_path / "snapshot.json"
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "pr_resolve_finalize.py",
+            "--strict-exit-codes",
+            "--pr",
+            "3210",
+            "--snapshot-path",
+            str(snapshot_path),
+            "--result-path",
+            str(result_path),
+        ],
+    )
+
+    with pytest.raises(SystemExit) as raised:
+        main()
+
+    assert int(raised.value.code) == int(exit_code_blocked)
+    assert merge_calls == [("3210", "squash")]
+    payload = json.loads(result_path.read_text(encoding="utf-8"))
+    assert payload["status"] == "blocked"
+    assert payload["reason"] == "merge_pending"
+    assert payload["merge_outcome"] == "blocked"
+    assert payload["mergeAutomationDisposition"] == "reenter_gate"
+
 def test_finalize_pr_not_found_but_merged_succeeds(
     pr_resolve_finalize_module: dict[str, Any],
     monkeypatch: pytest.MonkeyPatch,
@@ -1955,6 +2039,8 @@ def test_pr_resolver_skill_owns_behavior_in_every_host() -> None:
     assert "actionable_comments" in skill_text
     assert "fix-comments" in skill_text
     assert "Never reuse a pre-remediation snapshot" in skill_text
+    assert "MOONMIND_ACTIVE_SKILLS_DIR" in skill_text
+    assert "fresh `gh pr view` reports `state=MERGED`" in skill_text
 
 
 def test_pr_resolver_snapshot_resolves_required_skill_from_active_root(
@@ -1992,3 +2078,5 @@ def test_fix_comments_skill_requires_fresh_comments_and_remote_verification() ->
     assert "Never print raw environment variables" in skill_text
     assert "var/pr_resolver/result.json" in skill_text
     assert "mergeAutomationDisposition=manual_review" in skill_text
+    assert "every\n  non-outdated comment in that thread" in skill_text
+    assert "leave the entire thread unresolved" in skill_text

--- a/tests/unit/test_pr_resolver_tools.py
+++ b/tests/unit/test_pr_resolver_tools.py
@@ -134,6 +134,27 @@ def test_parse_repo_slug_accepts_remote_urls_and_owner_repo_forms(
     with pytest.raises(ValueError, match="Invalid --repo value"):
         parse_repo_slug("owner_only")
 
+
+def test_normalize_review_comment_preserves_thread_node_identity(
+    get_pr_comments_module: dict[str, Any],
+) -> None:
+    normalize = get_pr_comments_module["normalize_review_comment"]
+
+    result = normalize(
+        {"id": 42, "user": {"login": "review-bot"}, "body": "Fix this."},
+        {
+            42: {
+                "threadId": "PRRT_kwDOExample",
+                "isResolved": False,
+                "isOutdated": False,
+            }
+        },
+    )
+
+    assert result["thread_id"] == "PRRT_kwDOExample"
+    assert result["thread_resolved"] is False
+    assert result["thread_outdated"] is False
+
 def test_infer_repo_from_pr_url_handles_pull_url(
     pr_resolve_snapshot_module: dict[str, Any],
 ) -> None:
@@ -1711,13 +1732,13 @@ def test_finalize_pr_not_found_but_merged_succeeds(
     assert payload["mergeAutomationDisposition"] == "already_merged"
 
 # ---------------------------------------------------------------------------
-# Stale-commit bot comment filtering (Phase 1)
+# Review-thread authority
 # ---------------------------------------------------------------------------
 
-def test_stale_bot_comment_on_old_commit_is_not_actionable(
+def test_unresolved_bot_comment_on_old_commit_remains_actionable(
     pr_resolve_snapshot_module: dict[str, Any],
 ) -> None:
-    """Bot review comment whose commit_id != HEAD should be classified as stale."""
+    """A pushed head does not replace authoritative GitHub thread resolution."""
     classify = pr_resolve_snapshot_module["_classify_comment_actionability"]
 
     comment = {
@@ -1732,8 +1753,8 @@ def test_stale_bot_comment_on_old_commit_is_not_actionable(
         include_bot_review_comments=True,
         head_commit_sha="bbb222",
     )
-    assert actionable is False
-    assert reason == "stale_bot_comment"
+    assert actionable is True
+    assert reason == "actionable"
 
 def test_human_comment_on_old_commit_stays_actionable(
     pr_resolve_snapshot_module: dict[str, Any],
@@ -1756,7 +1777,7 @@ def test_human_comment_on_old_commit_stays_actionable(
     assert actionable is True
     assert reason == "actionable"
 
-def test_stale_bot_comment_with_matching_sha_stays_actionable(
+def test_bot_comment_on_current_sha_stays_actionable(
     pr_resolve_snapshot_module: dict[str, Any],
 ) -> None:
     """Bot comment on the current HEAD commit should still be actionable."""
@@ -1776,6 +1797,31 @@ def test_stale_bot_comment_with_matching_sha_stays_actionable(
     )
     assert actionable is True
     assert reason == "actionable"
+
+
+def test_local_ledger_cannot_clear_unresolved_review_thread(
+    pr_resolve_snapshot_module: dict[str, Any],
+) -> None:
+    summarize_comments = pr_resolve_snapshot_module["summarize_comments"]
+
+    summary = summarize_comments(
+        [
+            {
+                "type": "review_comment",
+                "id": 42,
+                "user": "chatgpt-codex-connector",
+                "body": "This remains unresolved on GitHub.",
+                "thread_resolved": False,
+                "thread_outdated": False,
+                "commit_id": "old-head",
+            }
+        ],
+        addressed_comment_ids={42},
+        head_commit_sha="new-head",
+    )
+
+    assert summary["hasActionableComments"] is True
+    assert summary["actionableCommentIds"] == [42]
 
 # ---------------------------------------------------------------------------
 # Ledger path/format normalization (Phase 2)
@@ -1884,12 +1930,17 @@ def test_review_comment_with_thread_resolved_via_enrichment(
     assert summary["actionableCommentIds"] == [2]
     assert summary["nonActionableReasonCounts"].get("thread_resolved") == 1
 
-def test_pr_resolver_skill_delegates_orchestration_to_temporal() -> None:
+def test_pr_resolver_skill_owns_behavior_in_every_host() -> None:
     skill_text = (
         REPO_ROOT / ".agents" / "skills" / "pr-resolver" / "SKILL.md"
     ).read_text(encoding="utf-8")
 
-    assert "Temporal ownership contract" in skill_text
+    assert "Skill authority and host boundary" in skill_text
+    assert "sole semantic implementation" in skill_text
+    assert "MoonMind must execute this Skill through the ordinary agent Skill path" in skill_text
+    assert "MoonMind must not" in skill_text
+    assert "collect or classify PR comments" in skill_text
+    assert "## Workflow" in skill_text
     assert "Terminal Success Contract" in skill_text
     assert "Bounded remediation actions" in skill_text
     assert "A local fix, local commit" in skill_text
@@ -1900,12 +1951,10 @@ def test_pr_resolver_skill_delegates_orchestration_to_temporal() -> None:
     assert "status=blocked" in skill_text
     assert "mergeAutomationDisposition=manual_review" in skill_text
     assert "branch is ahead of origin" in skill_text
-    assert "`MoonMind.PRResolver` owns snapshot polling" in skill_text
-    assert "must never run `pr_resolve_orchestrate.py`" in skill_text
-    assert "single classified action named in the instruction" in skill_text
-    assert "python3 .agents/skills/pr-resolver/bin/" not in skill_text
-    assert "read `.agents/skills/fix-" not in skill_text
-    assert "After the child ends, Temporal independently checks" in skill_text
+    assert "pr_resolve_finalize.py" in skill_text
+    assert "actionable_comments" in skill_text
+    assert "fix-comments" in skill_text
+    assert "Never reuse a pre-remediation snapshot" in skill_text
 
 
 def test_pr_resolver_snapshot_resolves_required_skill_from_active_root(

--- a/tests/unit/workflows/temporal/test_native_skill_bindings.py
+++ b/tests/unit/workflows/temporal/test_native_skill_bindings.py
@@ -6,6 +6,7 @@ from moonmind.schemas.agent_skill_models import (
 )
 from moonmind.workflows.temporal.native_skill_bindings import (
     evaluate_pr_resolver_native_binding,
+    require_skill_owned_pr_resolver_execution,
 )
 
 
@@ -17,31 +18,59 @@ def _entry(source: AgentSkillSourceKind) -> ResolvedSkillEntry:
         provenance=AgentSkillProvenance(source_kind=source),
         implementation=SkillImplementationContract(
             contract="pr-resolver-core/v1",
-            supportedHosts=["cli", "temporal"],
-            nativeHostEligible=True,
-            nativeHostPolicy="moonmind_trusted",
+            supportedHosts=["cli"],
+            nativeHostEligible=False,
         ),
     )
 
 
-def test_trusted_built_in_pr_resolver_is_native_eligible() -> None:
+def test_built_in_pr_resolver_is_not_native_eligible() -> None:
     result = evaluate_pr_resolver_native_binding(_entry(AgentSkillSourceKind.BUILT_IN))
-    assert result.eligible is True
-    assert result.host == "temporal"
+    assert result.eligible is False
+    assert result.host == "cli"
+    assert result.reason_code == "temporal_host_not_supported"
 
 
-def test_repo_or_local_name_collision_uses_observable_portable_fallback() -> None:
+def test_repo_or_local_pr_resolver_uses_skill_owned_execution() -> None:
     for source in (AgentSkillSourceKind.REPO, AgentSkillSourceKind.LOCAL):
         result = evaluate_pr_resolver_native_binding(_entry(source))
         assert result.eligible is False
         assert result.host == "cli"
-        assert result.reason_code == "untrusted_skill_source"
+        assert result.reason_code == "temporal_host_not_supported"
 
 
 def test_missing_immutable_content_evidence_rejects_native_host() -> None:
     entry = _entry(AgentSkillSourceKind.BUILT_IN).model_copy(
-        update={"content_digest": None}
+        update={
+            "content_digest": None,
+            "implementation": SkillImplementationContract(
+                contract="pr-resolver-core/v1",
+                supportedHosts=["cli", "temporal"],
+                nativeHostEligible=True,
+                nativeHostPolicy="moonmind_trusted",
+            ),
+        }
     )
     result = evaluate_pr_resolver_native_binding(entry)
     assert result.eligible is False
     assert result.reason_code == "immutable_content_evidence_missing"
+
+
+def test_skill_owned_cutover_rejects_even_legacy_native_eligible_content() -> None:
+    entry = _entry(AgentSkillSourceKind.BUILT_IN).model_copy(
+        update={
+            "implementation": SkillImplementationContract(
+                contract="pr-resolver-core/v1",
+                supportedHosts=["cli", "temporal"],
+                nativeHostEligible=True,
+                nativeHostPolicy="moonmind_trusted",
+            )
+        }
+    )
+
+    result = require_skill_owned_pr_resolver_execution(entry)
+
+    assert result.eligible is False
+    assert result.host == "cli"
+    assert result.reason_code == "skill_owned_execution_required"
+    assert result.identity["contentDigest"] == "sha256:abc"

--- a/tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py
@@ -21,14 +21,17 @@ from moonmind.schemas.agent_skill_models import (
     AgentSkillSourceKind,
     ResolvedSkillEntry,
     ResolvedSkillSet,
+    SkillImplementationContract,
 )
 from moonmind.workflows.temporal.workflows.run import (
     RUN_ASSESSMENT_PARAMETER_INJECTION_PATCH,
     RUN_CHECKPOINT_BRANCH_TURN_CONTEXT_PATCH,
     RUN_JSON_ARTIFACT_WRITE_COMPLETE_PATCH,
     RUN_OMNIGENT_CHECKPOINT_BRANCH_TURN_REQUEST_PATCH,
+    RUN_PR_RESOLVER_SKILL_OWNED_EXECUTION_PATCH,
     RUN_SLOT_CONTINUITY_PATCH,
     RUN_STEP_EXECUTION_NAMING_PATCH,
+    RUN_TRUSTED_PR_RESOLVER_NATIVE_BINDING_PATCH,
     MoonMindRunWorkflow,
 )
 
@@ -380,6 +383,96 @@ class TestAgentSkillSnapshotResolution(unittest.IsolatedAsyncioTestCase):
             ["moonspec-breakdown"],
         )
         self.assertEqual(kwargs["args"][1:], ["owner-1", "/workspace/repo", False, False])
+
+    async def test_new_pr_resolver_run_requires_skill_owned_execution(self) -> None:
+        wf = MoonMindRunWorkflow()
+        wf._owner_id = "owner-1"
+        resolved = ResolvedSkillSet(
+            snapshot_id="skillset-pr-resolver",
+            resolved_at=datetime.now(UTC),
+            manifest_ref="artifact://skillsets/pr-resolver",
+            skills=[_resolved_skill("pr-resolver")],
+        )
+
+        with (
+            patch(
+                "moonmind.workflows.temporal.workflows.run.workflow.execute_activity",
+                new=AsyncMock(return_value=resolved),
+            ),
+            patch(
+                "moonmind.workflows.temporal.workflows.run.workflow.patched",
+                return_value=True,
+            ),
+        ):
+            ref = await wf._resolve_agent_node_skillset_ref(
+                task_skills=None,
+                node_inputs={
+                    "selectedSkill": "pr-resolver",
+                    "workspaceRoot": "/workspace/repo",
+                },
+                node_id="resolver-step",
+                existing_skillset_ref=None,
+            )
+
+        self.assertEqual(ref, "artifact://skillsets/pr-resolver")
+        binding = wf._native_skill_binding_by_step["resolver-step"]
+        self.assertFalse(binding["eligible"])
+        self.assertEqual(binding["host"], "cli")
+        self.assertEqual(binding["reasonCode"], "skill_owned_execution_required")
+        self.assertEqual(binding["identity"]["skillName"], "pr-resolver")
+
+    async def test_existing_pr_resolver_history_preserves_native_child_for_replay(
+        self,
+    ) -> None:
+        wf = MoonMindRunWorkflow()
+        wf._owner_id = "owner-1"
+        legacy_entry = ResolvedSkillEntry(
+            skill_name="pr-resolver",
+            content_ref="art-legacy-pr-resolver",
+            content_digest="sha256:legacy",
+            provenance=AgentSkillProvenance(
+                source_kind=AgentSkillSourceKind.BUILT_IN
+            ),
+            implementation=SkillImplementationContract(
+                contract="pr-resolver-core/v1",
+                supportedHosts=["cli", "temporal"],
+                nativeHostEligible=True,
+                nativeHostPolicy="moonmind_trusted",
+            ),
+        )
+        resolved = ResolvedSkillSet(
+            snapshot_id="skillset-legacy-pr-resolver",
+            resolved_at=datetime.now(UTC),
+            manifest_ref="artifact://skillsets/legacy-pr-resolver",
+            skills=[legacy_entry],
+        )
+
+        def replay_patch(patch_id: str) -> bool:
+            if patch_id == RUN_PR_RESOLVER_SKILL_OWNED_EXECUTION_PATCH:
+                return False
+            return patch_id == RUN_TRUSTED_PR_RESOLVER_NATIVE_BINDING_PATCH
+
+        with (
+            patch(
+                "moonmind.workflows.temporal.workflows.run.workflow.execute_activity",
+                new=AsyncMock(return_value=resolved),
+            ),
+            patch(
+                "moonmind.workflows.temporal.workflows.run.workflow.patched",
+                side_effect=replay_patch,
+            ),
+        ):
+            await wf._resolve_agent_node_skillset_ref(
+                task_skills=None,
+                node_inputs={"selectedSkill": "pr-resolver"},
+                node_id="legacy-resolver-step",
+                existing_skillset_ref=None,
+            )
+
+        binding = wf._native_skill_binding_by_step["legacy-resolver-step"]
+        self.assertTrue(binding["eligible"])
+        self.assertEqual(binding["host"], "temporal")
+        self.assertEqual(binding["reasonCode"], "native_binding_accepted")
 
     async def test_agent_node_adds_selected_skill_to_task_level_selector(self) -> None:
         wf = MoonMindRunWorkflow()


### PR DESCRIPTION
## Summary

- make the resolved `pr-resolver` Skill bundle the sole semantic implementation in MoonMind and direct Codex runs
- route all new resolver executions through the ordinary `MoonMind.AgentRun` Skill path while retaining the former native workflow only for Temporal replay
- keep GitHub comment retrieval and actionability in portable Skill helpers, require remote thread resolution, and prevent local ledgers or head movement from clearing unresolved threads
- document the Skill semantic-authority boundary in AGENTS and canonical runtime, publishing, merge automation, and operations documentation

## Root cause

MoonMind's native resolver independently reimplemented PR readiness and treated a top-level automated `COMMENTED` review as complete without reading its inline review threads. That duplicated behavior already owned by the portable Skill and allowed the native and direct-Codex paths to drift.

## Validation

- focused resolver, routing, and Skill resolution suite: 195 passed
- legacy replay and worker suite: 192 passed
- managed runtime and terminal evidence suite: 228 passed
- full Python unit suite: 8,660 passed; six unrelated existing/environment failures remain from MoonSpec projection drift, macOS `/tmp` canonicalization, and an environment-dependent default-setting assertion
- `git diff --check`
- Python compilation checks for changed runtime and Skill helper modules

## Operational impact

New workflows record `run-pr-resolver-skill-owned-execution-v1` and cannot select `MoonMind.PRResolver`. Existing histories that already recorded the native child preserve their replay path.
