### PR TITLE
Restore the approved shimmer aesthetic and fail soft on UI/API build skew

### DIFF
--- a/docs/UI/DashboardSPAArchitecture.md
+++ b/docs/UI/DashboardSPAArchitecture.md
@@ -287,6 +287,29 @@ Rules:
 
 ---
 
+## 9.1 Build coherence and version skew
+
+The SPA is code-split: the served HTML references a hashed entry bundle, and the entry bundle references hashed lazy page chunks. Every file must come from one build. Skew has two independent defenses; neither may be removed without the other being strengthened:
+
+- **Client-side skew detection (fail-soft, loud).** The client compiles in its dashboard destination registry and compares it against `destinations` from `/api/ui/info`. A mismatch means the browser is executing assets from a different build than the API. The client must **not** discard the `uiInfo` payload on mismatch — server-provided capability flags remain the runtime truth and feature-gated navigation (for example the System menu) must keep working. Instead it renders a visible `role="alert"` version-skew banner (`.ui-version-skew-banner`) naming the server build id and logs the mismatch. Lazy chunk-load failures reload once per build id (`dynamicImportRecovery`) and otherwise surface the styled route error state.
+- **Deployment-side coherence verification.** `tools/verify_deployed_ui_assets.py --base-url <deployment>` fetches the served HTML, every asset it references, and every lazy chunk referenced by the entry bundle, and fails on any 404 or cross-build incoherence. Run it after every deploy.
+
+Operational rule: never hot-patch individual dist files into a running container (`docker cp` of an entry bundle without its chunks leaves a mixed-build static directory that appears to work only for browsers with warm caches). Ship UI changes by rebuilding and redeploying the image; the frontend dist is always rebuilt from source during the image build and verified by `tools/verify_vite_manifest.py`.
+
+## 9.2 Frontend regression-testing layers
+
+Each layer exists because the one above it cannot see that failure class:
+
+| Layer | Runner | Catches |
+| --- | --- | --- |
+| jsdom contract tests (`frontend/src/**/*.test.tsx`) | `./tools/test_unit.sh --dashboard-only` | DOM structure, routing, feature gating, authored-CSS contracts |
+| Real-browser computed-style tests (`frontend/src/browser/*.browser.test.{ts,tsx}`) | `npm run ui:test:browser` (CI: Playwright Chromium) | Computed styles jsdom cannot resolve: custom-property scoping, pseudo-element gradients, animation, viewport-driven media queries. **Approved visual aesthetics (exact colors, angles, alpha ceilings) are pinned here** — "an effect renders" is not the contract, "the approved effect renders" is |
+| Deployed-asset smoke (`tools/verify_deployed_ui_assets.py`) | post-deploy, any host | Mixed-build static dirs, missing lazy chunks, dead deployments that tests can never see |
+
+When a visual treatment is operator-approved, encode its computed values in a browser test in the same PR. A later "restore/fix the effect" change that alters the look must then fail tests and force an explicit, reviewed baseline update — this is the guardrail that was missing when the status-pill shimmer was restored with the wrong (never-approved) palette.
+
+---
+
 ## 10. Data contract posture
 
 The SPA must not cache detail-grade payloads for list or picker surfaces.

--- a/docs/UI/EffectShimmerSweep.md
+++ b/docs/UI/EffectShimmerSweep.md
@@ -1,15 +1,17 @@
 # Shimmer Sweep Effect — Status-Aware Implementation Design
 Status: Active  
 Owners: MoonMind Engineering  
-Last updated: 2026-06-29
+Last updated: 2026-07-11
 
 ## 1. Intent
 
 Define the shared dashboard shimmer treatment used by active and transition workflow status pills.
 
-The effect communicates **active progress, preparation, or wrap-up** without implying error, urgency, or instability. It should feel like a premium “thinking” shimmer: focused, calm, phase-locked, readable at small sizes, and tied to the status pill’s semantic color.
+The effect communicates **active progress, preparation, or wrap-up** without implying error, urgency, or instability. It should feel like a premium “thinking” shimmer: focused, calm, phase-locked, and readable at small sizes.
 
-The shimmer must **not** always render in the executing/cyan hue. If a `planning` pill is blue, its shimmer should read as blue. If a `finalizing` pill is slate, its shimmer should read as slate. `executing` and `running` remain cyan because their pill color remains the live/executing hue.
+The **approved sweep palette is fixed and status-agnostic**: a translucent accent halo (`--mm-accent` at 14%) beneath a translucent accent-2 core (`--mm-accent-2` at 34%), giving the subtle purple/cyan two-tone edge interaction operators reviewed and approved (MM-1036 as shipped). Only the **glyph fallback letter treatment** is status-aware (`currentColor`-derived), because that is the MM-1048 portion that actually rendered and was accepted.
+
+History note: MM-1048 proposed re-tinting the whole sweep from the pill hue with brighter mixes (30% halo, fully opaque whitened core), but the same change broke gradient resolution, so that treatment never rendered. When the shimmer was later restored, the latent MM-1048 palette appeared for the first time and was rejected by the operator as far brighter and thicker than the approved look. The values in this document are the operator-approved on-screen aesthetic; do not change them without an operator-reviewed visual baseline update.
 
 ---
 
@@ -21,9 +23,9 @@ It defines:
 
 - the status-pill host contract
 - the shared moving light-field model
-- status-derived shimmer hue binding
+- the fixed approved sweep palette and the status-derived letter treatment
 - fill, border, and text mask behavior
-- the small horizontal-bias motion refinement
+- the approved motion path
 - reduced-motion, forced-colors, and unsupported text-mask fallbacks
 - the React/CSS implementation shape that keeps the effect reusable across list, card, and detail surfaces
 
@@ -68,7 +70,7 @@ source_of_truth:
     path: docs/UI/WorkflowStatusColorSemantics.md
     responsibility:
       - define which exact status hue each pill uses
-      - require status-aware shimmer hue when shimmer is enabled
+      - the sweep palette itself is fixed (section 8); only the glyph-fallback letter hue follows the pill color
 ```
 
 ---
@@ -145,8 +147,8 @@ Eligibility must come from `executionStatusPillProps(status)`, not from broad co
 ```yaml
 principles:
   - active_states_are_explicit_not_inferred_from_color_class_alone
-  - shimmer_hue_matches_the_status_pill_hue
-  - executing_hue_is_not_reused_for_non_executing_statuses
+  - sweep_palette_is_the_fixed_operator_approved_accent_two_tone
+  - only_the_glyph_fallback_letter_treatment_is_status_aware
   - motion_must_read_as_activity_not_alert
   - text_legibility_must_remain_primary
   - fill_border_and_text_must_share_one_moving_light_field
@@ -246,18 +248,17 @@ motion:
 
   path:
     start_x_pct: 135
-    start_y_pct_target: 120
+    start_y_pct: 160
     end_x_pct: -135
-    end_y_pct_target: -120
+    end_y_pct: -160
     y_behavior: diagonal_travel
-    horizontal_bias: horizontal travel delta (270%) exceeds vertical travel delta (240%)
-    angle_deg_target: -20
-    previous_values:
-      angle_deg: -24
-      start_y_pct: 128
-      end_y_pct: -128
+    angle_deg: -18
     keyframes: mm-status-pill-shimmer
-    note: small refinement only; do not turn the shimmer into a scanner beam or horizontal loading bar
+    note: >
+      These are the approved on-screen values (MM-1036 as shipped). MM-1048's
+      -20deg / +/-120% horizontal-bias refinement never rendered (its own
+      commit broke gradient resolution) and is retired. Do not turn the shimmer
+      into a scanner beam or horizontal loading bar.
 
   band:
     width_pct: 24
@@ -292,57 +293,39 @@ motion:
     note: fallback glyph brightening is not the primary path and exists only for browsers without text clipping support
 ```
 
-The desired motion change is intentionally small: the sweep should read **a little less vertical and a little more horizontal** than the previous `-24deg` / `±128%` vertical-travel treatment. The first implementation target is `-20deg` with a modest vertical-travel reduction to `±120%`; visual QA may keep the travel endpoints unchanged if the angle adjustment alone is sufficient.
+The motion profile is settled: `-18deg` with `±160%` vertical travel is the approved on-screen path. Any future motion refinement must ship with an operator-reviewed visual baseline update and matching computed-style test changes in the same PR.
 
 ---
 
-## 8. Status hue binding
+## 8. Shimmer palette
 
-The shimmer hue derives from the same semantic hue as the status pill. Prefer one shared status-derived token pair over copied per-status shimmer rules.
+The **sweep palette is fixed and status-agnostic** — the operator-approved MM-1036 look. Only the glyph-fallback letter treatment derives from the pill hue.
 
 ```yaml
-status_hue_binding:
-  source_of_truth: exact status pill color class
-  implementation_preference:
-    - use currentColor or status-local CSS custom properties on the host
-    - feed those values into the shared gradient token
-    - let ::before, ::after, and .status-letter-wave::after inherit the same hue inputs
-
-  expected_hues:
-    executing:
-      pill_class: status-running
-      shimmer_hue: live/executing cyan
-      token: --mm-accent-2
-    running:
-      pill_class: status-running
-      shimmer_hue: live/executing cyan
-      token: --mm-accent-2
-    initializing:
-      pill_class: status-initializing
-      shimmer_hue: near-execution blue
-      token: --mm-status-setup
-    planning:
-      pill_class: status-planning
-      shimmer_hue: near-execution blue
-      token: --mm-status-setup
-    finalizing:
-      pill_class: status-finalizing
-      shimmer_hue: finalization slate
-      token: --mm-status-finalizing
+shimmer_palette:
+  sweep:
+    halo: rgb(var(--mm-accent) / var(--mm-executing-sweep-halo-opacity))   # purple @ 14%
+    core: rgb(var(--mm-accent-2) / var(--mm-executing-sweep-core-opacity)) # cyan @ 34%
+    translucency: every gradient stop stays translucent (max alpha 0.34); an opaque or whitened stop is a regression
+    status_aware: false
+  letters:
+    halo: color-mix(in srgb, currentColor 32%, transparent)
+    bright: color-mix(in srgb, currentColor 68%, white 32%)
+    status_aware: true
 ```
 
-Suggested CSS shape:
+Canonical CSS shape (declared on the shimmer host rule):
 
 ```css
 .status[data-effect="shimmer-sweep"] {
-  --mm-status-shimmer-halo: color-mix(in srgb, currentColor 30%, transparent);
-  --mm-status-shimmer-core: color-mix(in srgb, currentColor 70%, white 30%);
+  --mm-status-shimmer-halo: rgb(var(--mm-accent) / var(--mm-executing-sweep-halo-opacity));
+  --mm-status-shimmer-core: rgb(var(--mm-accent-2) / var(--mm-executing-sweep-core-opacity));
   --mm-status-shimmer-letter-halo: color-mix(in srgb, currentColor 32%, transparent);
   --mm-status-shimmer-letter-bright: color-mix(in srgb, currentColor 68%, white 32%);
 }
 ```
 
-The exact percentages may be tuned for contrast, but the binding principle is stable: **the shimmer follows the pill hue**. `planning` should not receive the executing/cyan shimmer merely because the original shimmer was created for `executing`.
+MM-1048's status-derived sweep hue binding (`color-mix` from `currentColor`, whitened opaque core) is retired: it never rendered while it was in the tree, and when finally revealed it read as a different, far brighter effect than the approved design. If a status-aware sweep is ever wanted, it must be proposed as a new visual change with operator review and updated computed-style baselines — not reintroduced as part of a repair.
 
 ---
 
@@ -408,7 +391,8 @@ implementation_shape:
     overflow: hidden
     isolation: isolate
     background_color: preserve exact status class background
-    hue_tokens: derive from currentColor or status-local variables
+    sweep_palette_tokens: fixed accent halo/core declared on the host (see section 8)
+    letter_hue_tokens: derive from currentColor
 
   rendering_strategy:
     fill_mask: host::before
@@ -437,7 +421,7 @@ implementation_shape:
     - page_local_status_pill_wrappers
 ```
 
-Changing hue and angle should remain a low-risk CSS token update. It should not add DOM, change layout, or add animation work beyond the existing pseudo-element/text-mask animation.
+Palette and angle changes stay CSS-token updates — no DOM, layout, or animation-model changes — but they are **never** low-ceremony: the approved values are pinned by computed-style browser tests and require an operator-reviewed baseline update in the same PR.
 
 ---
 
@@ -489,25 +473,22 @@ forced_colors:
 
 ```yaml
 state_matrix:
+  # The sweep palette is identical for every shimmer state (fixed accent
+  # two-tone); only the glyph-fallback letter hue follows the pill color.
   executing:
     shimmer_sweep: on
-    shimmer_hue: live/executing cyan
 
   running:
     shimmer_sweep: on
-    shimmer_hue: live/executing cyan
 
   initializing:
     shimmer_sweep: on
-    shimmer_hue: near-execution blue
 
   planning:
     shimmer_sweep: on
-    shimmer_hue: near-execution blue
 
   finalizing:
     shimmer_sweep: on
-    shimmer_hue: finalization slate
 
   queued:
     shimmer_sweep: off
@@ -580,7 +561,7 @@ tone:
 ```yaml
 effect_tokens:
   --mm-executing-sweep-cycle-duration: 2600ms
-  --mm-executing-sweep-angle: -20deg
+  --mm-executing-sweep-angle: -18deg
   --mm-executing-sweep-band-width: 24%
   --mm-executing-sweep-band-height: 180%
   --mm-executing-sweep-halo-width-multiplier: 10
@@ -588,9 +569,9 @@ effect_tokens:
   --mm-executing-sweep-core-opacity: 0.34
   --mm-executing-sweep-halo-opacity: 0.14
   --mm-executing-sweep-start-x: 135%
-  --mm-executing-sweep-start-y: 120%
+  --mm-executing-sweep-start-y: 160%
   --mm-executing-sweep-end-x: -135%
-  --mm-executing-sweep-end-y: -120%
+  --mm-executing-sweep-end-y: -160%
   --mm-executing-sweep-layer-offset-x: -12%
   --mm-executing-sweep-layer-offset-y: -10%
   --mm-executing-border-glint-outset: 1px
@@ -600,14 +581,14 @@ effect_tokens:
   --mm-executing-letter-sweep-start-ratio: 0.2
   --mm-executing-letter-sweep-travel-ratio: 0.18
   --mm-executing-letter-sweep-direction: 1
-  --mm-status-shimmer-halo: status-derived halo color
-  --mm-status-shimmer-core: status-derived core color
-  --mm-status-shimmer-letter-halo: status-derived fallback glyph halo
-  --mm-status-shimmer-letter-bright: status-derived fallback glyph bright color
-  --mm-status-moving-light-gradient: shared halo/core linear-gradient stack using status-derived inputs (pill-scoped, never :root)
+  --mm-status-shimmer-halo: rgb(var(--mm-accent) / var(--mm-executing-sweep-halo-opacity))
+  --mm-status-shimmer-core: rgb(var(--mm-accent-2) / var(--mm-executing-sweep-core-opacity))
+  --mm-status-shimmer-letter-halo: status-derived fallback glyph halo (currentColor mix)
+  --mm-status-shimmer-letter-bright: status-derived fallback glyph bright color (currentColor mix)
+  --mm-status-moving-light-gradient: shared halo/core linear-gradient stack (pill-scoped, never :root)
 ```
 
-The `--mm-executing-*` geometry names are retained for compatibility even though the visual effect is now status-aware. Do not rename them in isolation unless all tests and references are migrated together.
+The `--mm-executing-*` geometry names are retained for compatibility even though the effect serves every shimmer status. Do not rename them in isolation unless all tests and references are migrated together.
 
 ---
 
@@ -619,10 +600,10 @@ acceptance_criteria:
   - executing, running, initializing, planning, and finalizing receive data-effect shimmer-sweep while enabled
   - non-shimmer statuses do not render glyph-wave markup
   - active shimmer hosts match the shared selector contract and remain reusable across list, card, and detail surfaces
-  - the shimmer hue follows the status pill hue rather than always using executing cyan
-  - planning and initializing shimmer as near-execution blue, not live/executing cyan
+  - the sweep renders the fixed approved palette (translucent accent halo, translucent accent-2 core) with no opaque stop
+  - only the glyph-fallback letter treatment derives from the pill hue
   - fill, border, and text masks use the same moving light-field token and keyframe animation
-  - the shimmer angle/path reads slightly less vertical and more horizontal than the previous -24deg treatment
+  - the sweep travels the approved -18deg / +/-160% path
   - the active pill remains readable throughout the sweep
   - the shimmer never escapes the rounded visual bounds of the pill
   - the effect produces no measurable layout shift
@@ -643,8 +624,8 @@ acceptance_criteria:
 verification:
   css_contract_tests:
     assert:
-      - status-derived shimmer color variables exist on the shimmer host
-      - shared gradient token uses status-derived color variables instead of hard-coded executing colors
+      - shimmer color variables exist on the shimmer host and carry the approved fixed accent palette
+      - shared gradient token consumes those host-scoped variables (never :root-scoped)
       - fill mask uses shared gradient and mm-status-pill-shimmer
       - border mask uses shared gradient, mm-status-pill-shimmer, and ring mask geometry
       - text mask uses shared gradient, mm-status-pill-shimmer, content attr(data-label), and text clipping

--- a/frontend/src/browser/statusPillShimmer.browser.test.tsx
+++ b/frontend/src/browser/statusPillShimmer.browser.test.tsx
@@ -43,6 +43,16 @@ function sleep(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+// Every color stop in a computed background-image, with its alpha channel.
+// rgb()/rgba() serializations both appear in Chromium output; a bare rgb()
+// (no alpha) is fully opaque.
+function gradientStopAlphas(backgroundImage: string): number[] {
+  return Array.from(backgroundImage.matchAll(/rgba?\(([^)]+)\)/g)).map(([, channels]) => {
+    const parts = channels.split(',').map((part) => part.trim());
+    return parts.length === 4 ? Number.parseFloat(parts[3]!) : 1;
+  });
+}
+
 afterEach(() => {
   root?.unmount();
   root = null;
@@ -72,6 +82,28 @@ describe('status pill shimmer computed styles', () => {
       expect(letterAfter).not.toBeNull();
       expect(letterAfter!.backgroundImage).not.toBe('none');
       expect(letterAfter!.backgroundImage).toContain('linear-gradient');
+
+      // The layers must carry the operator-approved MM-1036 palette: a
+      // translucent accent halo (14%) under a translucent accent-2 core (34%)
+      // on the approved -18deg path. This is the assertion that was missing
+      // when the shimmer was "restored" with MM-1048's never-rendered brighter
+      // treatment (30% halo, fully opaque whitened core): a gradient rendered
+      // and moved, so the old guardrail passed while the look had changed
+      // entirely. Computed colors, not authored CSS text, are compared so the
+      // contract survives refactors of the custom-property plumbing.
+      const expectedHalo = 'rgba(130, 72, 246, 0.14)';
+      const expectedCore = theme === 'dark' ? 'rgba(125, 249, 255, 0.34)' : 'rgba(34, 211, 238, 0.34)';
+      for (const layer of [before, after, letterAfter!]) {
+        expect(layer.backgroundImage).toContain('-18deg');
+        expect(layer.backgroundImage).toContain(expectedHalo);
+        expect(layer.backgroundImage).toContain(expectedCore);
+        // The sweep is a subtle translucent light field. An opaque (or
+        // near-opaque) stop means the effect has been rebuilt brighter than
+        // the approved design.
+        for (const alpha of gradientStopAlphas(layer.backgroundImage)) {
+          expect(alpha).toBeLessThanOrEqual(0.34);
+        }
+      }
 
       // The shared animation drives all layers on the 2.6s cycle.
       expect(before.animationName).toBe('mm-status-pill-shimmer');

--- a/frontend/src/browser/statusPillShimmer.browser.test.tsx
+++ b/frontend/src/browser/statusPillShimmer.browser.test.tsx
@@ -48,7 +48,7 @@ function sleep(ms: number) {
 // (no alpha) is fully opaque.
 function gradientStopAlphas(backgroundImage: string): number[] {
   return Array.from(backgroundImage.matchAll(/rgba?\(([^)]+)\)/g)).map(([, channels]) => {
-    const parts = channels.split(',').map((part) => part.trim());
+    const parts = (channels ?? '').split(',').map((part) => part.trim());
     return parts.length === 4 ? Number.parseFloat(parts[3]!) : 1;
   });
 }

--- a/frontend/src/browser/workflowListResponsiveToolbar.browser.test.tsx
+++ b/frontend/src/browser/workflowListResponsiveToolbar.browser.test.tsx
@@ -1,0 +1,90 @@
+import { afterEach, beforeEach, describe, expect, it, vi, type MockInstance } from 'vitest';
+import { page } from 'vitest/browser';
+
+import type { BootPayload } from '../boot/parseBootPayload';
+import { WorkflowListPage } from '../entrypoints/workflow-list';
+import { renderWithClient, screen, waitFor } from '../utils/test-utils';
+import '../styles/dashboard.css';
+
+// Real-browser guardrail for the responsive workflow-list toolbar. The jsdom
+// suite covers the same contract with a stubbed matchMedia, but only a real
+// browser exercises the actual 768px media query against the CSS that styles
+// both surfaces — the combination that regresses when mixed-build assets ship
+// (a stale chunk rendering the mobile header row into a desktop layout).
+
+const DESKTOP = { width: 1280, height: 800 } as const;
+const MOBILE = { width: 375, height: 812 } as const;
+
+const payload: BootPayload = {
+  page: 'workflow-list',
+  apiBase: '/api',
+  initialData: {
+    dashboardConfig: {
+      features: { temporalDashboard: { listEnabled: true, actionsEnabled: true } },
+    },
+  },
+};
+
+let fetchSpy: MockInstance;
+let cleanupRender: (() => void) | null = null;
+
+beforeEach(() => {
+  window.localStorage.clear();
+  window.history.replaceState({}, '', '/workflows');
+  fetchSpy = vi.spyOn(window, 'fetch').mockResolvedValue({
+    ok: true,
+    json: async () => ({
+      items: [
+        {
+          taskId: 'task-123',
+          source: 'temporal',
+          title: 'Example task',
+          status: 'running',
+          state: 'executing',
+          rawState: 'executing',
+          startedAt: '2026-03-28T00:00:01Z',
+          createdAt: '2026-03-28T00:00:00Z',
+        },
+      ],
+    }),
+  } as Response);
+});
+
+afterEach(async () => {
+  cleanupRender?.();
+  cleanupRender = null;
+  fetchSpy.mockRestore();
+  await page.viewport(DESKTOP.width, DESKTOP.height);
+});
+
+describe('workflow list responsive toolbar', () => {
+  it('keeps the mobile Filters/View-options header row off the desktop table and restores it on mobile', async () => {
+    await page.viewport(DESKTOP.width, DESKTOP.height);
+    const { unmount } = renderWithClient(<WorkflowListPage payload={payload} />);
+    cleanupRender = unmount;
+
+    await screen.findAllByText('Example task');
+
+    // Desktop: per-column filters own the table header, the "View options"
+    // control collapses into the Actions header, and the standalone results
+    // header row (Filters trigger + text "View options") must not render.
+    expect(screen.queryByRole('button', { name: 'Filters' })).toBeNull();
+    const viewOptions = screen.getByRole('button', { name: 'View options' });
+    expect(viewOptions.closest('th, [role="columnheader"]')).not.toBeNull();
+    expect(screen.getByRole('columnheader', { name: 'Actions' })).toBeTruthy();
+
+    // Mobile: the real media query flips the layout and the header row returns.
+    await page.viewport(MOBILE.width, MOBILE.height);
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Filters' })).toBeTruthy();
+    });
+    const mobileViewOptions = screen.getByRole('button', { name: 'View options' });
+    expect(mobileViewOptions.closest('th, [role="columnheader"]')).toBeNull();
+
+    // And back: returning to desktop drops the header row again.
+    await page.viewport(DESKTOP.width, DESKTOP.height);
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name: 'Filters' })).toBeNull();
+    });
+  });
+});

--- a/frontend/src/entrypoints/dashboard-app.tsx
+++ b/frontend/src/entrypoints/dashboard-app.tsx
@@ -384,7 +384,14 @@ function useDashboardUiInfo() {
       }
       const uiInfo = (await response.json()) as DashboardUiInfo;
       if (uiInfo.destinations && !matchesDashboardDestinationRegistry(uiInfo.destinations)) {
-        throw new Error('Dashboard destination registry does not match /api/ui/info');
+        // Version skew between the served JS bundle and the API (stale or
+        // partially patched static assets). Discarding uiInfo here would
+        // silently collapse feature-gated navigation (the System menu has no
+        // null-uiInfo fallback), so keep the payload usable and let AppShell
+        // surface the skew loudly instead.
+        console.error(
+          'Dashboard destination registry does not match /api/ui/info; the served UI assets are out of sync with the server build.',
+        );
       }
       return uiInfo;
     },
@@ -842,9 +849,31 @@ function AppShell({
   onListDisplayModeSelect: (mode: CollectionListDisplayMode) => void;
   children: ReactNode;
 }) {
+  // Version skew between the compiled-in client destination registry and the
+  // server's /api/ui/info registry means this browser is running UI assets
+  // from a different build than the API (stale cache, partially patched
+  // static dist, or an interrupted deploy). Navigation stays functional from
+  // the server-provided capability flags, but the skew must be loud instead
+  // of silently rendering a wrong shell.
+  const registrySkew = Boolean(
+    uiInfo?.destinations && !matchesDashboardDestinationRegistry(uiInfo.destinations),
+  );
   return (
     <DashboardLiveUpdateProvider uiInfo={uiInfo}>
       <main className="dashboard-root">
+        {registrySkew ? (
+          <section className="ui-version-skew-banner" role="alert" data-ui-version-skew>
+            <p>
+              <strong>Dashboard build mismatch.</strong> The UI assets in this browser do not
+              match the server
+              {typeof uiInfo?.buildId === 'string' && uiInfo.buildId.trim()
+                ? ` (server build ${uiInfo.buildId})`
+                : ''}
+              . Hard-refresh this page; if the mismatch persists, the deployment is serving stale
+              or partially patched static assets and needs a clean redeploy.
+            </p>
+          </section>
+        ) : null}
         <section className="worker-pause-banner" data-worker-pause hidden aria-live="polite">
           <p>
             <span className="worker-pause-label" data-worker-pause-status>

--- a/frontend/src/entrypoints/dashboard.test.tsx
+++ b/frontend/src/entrypoints/dashboard.test.tsx
@@ -2972,21 +2972,20 @@ describe('Dashboard shared entry', () => {
 
   it('defines the shared MM-488 executing shimmer modifier contract', async () => {
     expect(dashboardCss).toMatch(/--mm-executing-sweep-cycle-duration:\s*2600ms/);
-    // MM-1048: angle and vertical travel are slightly more horizontal than the
-    // previous -24deg / +/-128% treatment.
-    expect(dashboardCss).toMatch(/--mm-executing-sweep-angle:\s*-20deg/);
+    // Approved shimmer geometry (MM-1036 as shipped and operator-reviewed).
+    // MM-1048's -20deg / +/-120% re-angle never rendered (its own commit broke
+    // gradient resolution), so it is not the approved look.
+    expect(dashboardCss).toMatch(/--mm-executing-sweep-angle:\s*-18deg/);
     expect(dashboardCss).toMatch(/--mm-executing-sweep-band-width:\s*24%/);
     expect(dashboardCss).toMatch(/--mm-executing-sweep-band-height:\s*180%/);
     expect(dashboardCss).toMatch(/--mm-executing-sweep-halo-width-multiplier:\s*10/);
     expect(dashboardCss).toMatch(/--mm-executing-sweep-core-width-multiplier:\s*9\.1667/);
     expect(dashboardCss).not.toContain('--mm-executing-sweep-halo-peak-width-multiplier');
     expect(dashboardCss).not.toContain('--mm-executing-sweep-core-peak-width-multiplier');
-    // MM-1048: vertical travel is reduced to +/-120% so the horizontal delta
-    // exceeds the vertical delta and the sweep travels more horizontally.
     expect(dashboardCss).toMatch(/--mm-executing-sweep-start-x:\s*135%/);
-    expect(dashboardCss).toMatch(/--mm-executing-sweep-start-y:\s*120%/);
+    expect(dashboardCss).toMatch(/--mm-executing-sweep-start-y:\s*160%/);
     expect(dashboardCss).toMatch(/--mm-executing-sweep-end-x:\s*-135%/);
-    expect(dashboardCss).toMatch(/--mm-executing-sweep-end-y:\s*-120%/);
+    expect(dashboardCss).toMatch(/--mm-executing-sweep-end-y:\s*-160%/);
     expect(dashboardCss).toMatch(/--mm-executing-sweep-layer-offset-x:\s*-12%/);
     expect(dashboardCss).toMatch(/--mm-executing-sweep-layer-offset-y:\s*-10%/);
     expect(dashboardCss).toContain('--mm-executing-letter-cycle-duration: var(--mm-executing-sweep-cycle-duration)');
@@ -2998,14 +2997,23 @@ describe('Dashboard shared entry', () => {
     expect(dashboardCss).toContain('--mm-executing-border-glint-outset: 1px');
     expect(dashboardCss).toContain('--mm-executing-border-glint-width: 3px');
     expect(dashboardCss).toContain('--mm-executing-border-glint-opacity: 0.95');
-    expect(dashboardCss).toContain('--mm-status-shimmer-halo: color-mix(in srgb, currentColor 30%, transparent)');
-    expect(dashboardCss).toContain('--mm-status-shimmer-core: color-mix(in srgb, currentColor 70%, white 30%)');
+    // Approved shimmer palette (MM-1036 as shipped): translucent accent halo
+    // under a translucent accent-2 core. MM-1048's brighter currentColor mixes
+    // (30% halo, opaque whitened core) never rendered on screen and are
+    // explicitly rejected below so a "restore the shimmer" fix cannot silently
+    // reintroduce them.
+    expect(dashboardCss).toContain(
+      '--mm-status-shimmer-halo: rgb(var(--mm-accent) / var(--mm-executing-sweep-halo-opacity))',
+    );
+    expect(dashboardCss).toContain(
+      '--mm-status-shimmer-core: rgb(var(--mm-accent-2) / var(--mm-executing-sweep-core-opacity))',
+    );
+    expect(dashboardCss).not.toContain('--mm-status-shimmer-halo: color-mix');
+    expect(dashboardCss).not.toContain('--mm-status-shimmer-core: color-mix');
     expect(dashboardCss).toContain('--mm-status-shimmer-letter-halo: color-mix(in srgb, currentColor 32%, transparent)');
     expect(dashboardCss).toContain('--mm-status-shimmer-letter-bright: color-mix(in srgb, currentColor 68%, white 32%)');
     expect(dashboardCss).toContain('var(--mm-status-shimmer-halo) 50%');
     expect(dashboardCss).toContain('var(--mm-status-shimmer-core) 50%');
-    expect(dashboardCss).not.toContain('rgb(var(--mm-accent) / var(--mm-executing-sweep-halo-opacity)) 50%');
-    expect(dashboardCss).not.toContain('rgb(var(--mm-accent-2) / var(--mm-executing-sweep-core-opacity)) 50%');
 
     const shimmerBlock = cssRuleBlocks(
       dashboardCss,

--- a/frontend/src/entrypoints/dashboard.test.tsx
+++ b/frontend/src/entrypoints/dashboard.test.tsx
@@ -22,6 +22,7 @@ import {
   resetDashboardPreferences,
   updateDashboardPreferences,
 } from '../utils/dashboardPreferences';
+import { DASHBOARD_DESTINATIONS } from '../lib/dashboardRoutes';
 
 const animatedNavIconMocks = vi.hoisted(() => ({
   moonStart: vi.fn(),
@@ -436,6 +437,50 @@ describe('Dashboard shared entry', () => {
     fireEvent.keyDown(document.activeElement as Element, { key: 'Escape' });
     expect(trigger.getAttribute('aria-expanded')).toBe('false');
     expect(document.activeElement).toBe(trigger);
+
+    // No skew alert when the server does not report a drifted registry.
+    expect(document.querySelector('[data-ui-version-skew]')).toBeNull();
+  });
+
+  it('keeps feature-gated navigation and raises a version-skew alert when the server destination registry drifts', async () => {
+    // Reproduces the deployed regression where a stale JS bundle met a newer
+    // API registry: the old behavior threw the whole uiInfo payload away, so
+    // the System menu (which has no null-uiInfo fallback) silently vanished
+    // while the primary links fell back to a stale layout. The skew must be
+    // loud, and capability-gated navigation must keep working.
+    const driftedDestinations = DASHBOARD_DESTINATIONS
+      .map(({ page: _page, dataWidePanel: _wide, ...item }) => ({ ...item }))
+      .map((item) => (item.key === 'recurring' ? { ...item, navigationGroup: 'primary' as const } : item));
+
+    fetchSpy.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === '/api/ui/info') {
+        return Promise.resolve({
+          ok: true,
+          json: async () => uiInfo({ buildId: '20990101.1', destinations: driftedDestinations }),
+        } as Response);
+      }
+      return Promise.resolve({
+        ok: false,
+        status: 404,
+        statusText: 'Not Found',
+        text: async () => 'Unhandled fetch',
+      } as Response);
+    });
+
+    window.history.replaceState({}, '', '/workflows');
+    renderWithClient(<DashboardApp payload={{ page: 'dashboard', apiBase: '/api' }} />);
+    await screen.findByText('Workflow list route loaded', {}, { timeout: 10000 });
+
+    const banner = await screen.findByRole('alert');
+    expect(banner.textContent).toContain('Dashboard build mismatch');
+    expect(banner.textContent).toContain('20990101.1');
+
+    // uiInfo stays usable: the System menu and its feature-gated entries survive.
+    const trigger = screen.getByRole('button', { name: 'System' });
+    fireEvent.click(trigger);
+    expect(screen.getByRole('menuitem', { name: 'Skills' })).toBeTruthy();
+    expect(screen.getByRole('menuitem', { name: 'Settings' })).toBeTruthy();
   });
 
   it.each([

--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -54,18 +54,20 @@
   --mm-mobile-nav-active-edge: rgb(var(--mm-accent) / 0.88);
   --mm-font-sans: "IBM Plex Sans", system-ui, sans-serif;
   --mm-executing-sweep-cycle-duration: 2600ms;
-  /* MM-1048: slightly more horizontal shimmer path while preserving the shared
-     compatibility token names used by existing status-pill selectors. */
-  --mm-executing-sweep-angle: -20deg;
+  /* Approved shimmer geometry (MM-1036 as shipped and operator-reviewed).
+     MM-1048 later re-angled the path to -20deg / +/-120%, but that commit also
+     broke gradient resolution, so its geometry never rendered; the approved
+     on-screen look is this one. Change only with an operator-reviewed visual
+     baseline update. */
+  --mm-executing-sweep-angle: -18deg;
   --mm-executing-sweep-band-width: 24%;
   --mm-executing-sweep-band-height: 180%;
   --mm-executing-sweep-halo-width-multiplier: 10;
   --mm-executing-sweep-core-width-multiplier: 9.1667;
-  /* MM-1048: horizontal travel delta (270%) exceeds the vertical delta (240%). */
   --mm-executing-sweep-start-x: 135%;
-  --mm-executing-sweep-start-y: 120%;
+  --mm-executing-sweep-start-y: 160%;
   --mm-executing-sweep-end-x: -135%;
-  --mm-executing-sweep-end-y: -120%;
+  --mm-executing-sweep-end-y: -160%;
   --mm-executing-sweep-layer-offset-x: -12%;
   --mm-executing-sweep-layer-offset-y: -10%;
   --mm-executing-sweep-core-opacity: 0.34;
@@ -3307,8 +3309,14 @@ tr[data-proposal-id].proposal-consuming td {
 
 .status[data-effect="shimmer-sweep"],
 .status-running.is-executing {
-  --mm-status-shimmer-halo: color-mix(in srgb, currentColor 30%, transparent);
-  --mm-status-shimmer-core: color-mix(in srgb, currentColor 70%, white 30%);
+  /* Approved shimmer palette (MM-1036 as shipped and operator-reviewed): a
+     translucent accent halo under a translucent accent-2 core. MM-1048 swapped
+     these for brighter currentColor mixes (30% halo, opaque whitened core),
+     but the same commit broke gradient resolution, so that treatment never
+     rendered on screen; restoring the effect must not silently adopt it.
+     Change only with an operator-reviewed visual baseline update. */
+  --mm-status-shimmer-halo: rgb(var(--mm-accent) / var(--mm-executing-sweep-halo-opacity));
+  --mm-status-shimmer-core: rgb(var(--mm-accent-2) / var(--mm-executing-sweep-core-opacity));
   --mm-status-shimmer-letter-halo: color-mix(in srgb, currentColor 32%, transparent);
   --mm-status-shimmer-letter-bright: color-mix(in srgb, currentColor 68%, white 32%);
   --mm-executing-letter-halo: var(--mm-status-shimmer-letter-halo);

--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -218,6 +218,23 @@ samp {
   width: 100%;
 }
 
+/* Version-skew alert: the served JS bundle and the API registry disagree, so
+   the browser is running UI assets from a different build than the server. */
+.ui-version-skew-banner {
+  padding: 0.55rem 1rem;
+  border-bottom: 1px solid rgb(var(--mm-danger) / 0.55);
+  background: rgb(var(--mm-danger) / 0.14);
+  color: rgb(var(--mm-ink));
+  font-size: 0.86rem;
+  line-height: 1.4;
+}
+
+.ui-version-skew-banner p {
+  margin: 0;
+  max-width: min(72rem, calc(100vw - 2rem));
+  margin-inline: auto;
+}
+
 .masthead {
   --masthead-padding-block-end: 0.46rem;
 

--- a/tests/unit/tools/test_verify_deployed_ui_assets.py
+++ b/tests/unit/tools/test_verify_deployed_ui_assets.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 
 import importlib.util
 import sys
+import urllib.error
 from pathlib import Path
+from unittest.mock import patch
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 MODULE_PATH = REPO_ROOT / "tools" / "verify_deployed_ui_assets.py"
@@ -86,3 +88,36 @@ def test_unreachable_page_fails_fast() -> None:
         BASE, fetch=_fetcher({})
     )
     assert errors == [f"Page {BASE}/workflows returned HTTP 404"]
+
+
+def test_multiple_asset_dirs_resolves_chunk_from_secondary_directory() -> None:
+    responses = _coherent_responses()
+    responses[f"{BASE}/workflows"] = (
+        200,
+        PAGE_HTML.replace(
+            "</head>",
+            '<script type="module" src="/static/other_console/dist/assets/other-AAA.js"></script></head>',
+        ).encode(),
+    )
+    responses[f"{BASE}/static/other_console/dist/assets/other-AAA.js"] = (
+        200,
+        b'const chunk="assets/other-chunk.js";',
+    )
+    responses[f"{BASE}/static/other_console/dist/assets/other-chunk.js"] = (
+        200,
+        b"// other chunk",
+    )
+
+    errors = verify_deployed_ui_assets.verify_deployed_ui_assets(
+        BASE, fetch=_fetcher(responses)
+    )
+
+    assert errors == []
+
+
+def test_default_fetcher_maps_network_errors_to_zero_status() -> None:
+    with patch(
+        "verify_deployed_ui_assets.urllib.request.urlopen",
+        side_effect=urllib.error.URLError("connection refused"),
+    ):
+        assert verify_deployed_ui_assets._default_fetcher(BASE) == (0, b"")

--- a/tests/unit/tools/test_verify_deployed_ui_assets.py
+++ b/tests/unit/tools/test_verify_deployed_ui_assets.py
@@ -1,0 +1,88 @@
+"""Unit tests for the deployed dashboard asset coherence check."""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+MODULE_PATH = REPO_ROOT / "tools" / "verify_deployed_ui_assets.py"
+
+_spec = importlib.util.spec_from_file_location("verify_deployed_ui_assets", MODULE_PATH)
+assert _spec and _spec.loader
+verify_deployed_ui_assets = importlib.util.module_from_spec(_spec)
+sys.modules["verify_deployed_ui_assets"] = verify_deployed_ui_assets
+_spec.loader.exec_module(verify_deployed_ui_assets)
+
+PAGE_HTML = """
+<!doctype html>
+<html>
+<head>
+  <script type="module" crossorigin src="/static/workflow_console/dist/assets/dashboard-AAA.js"></script>
+  <link rel="stylesheet" crossorigin href="/static/workflow_console/dist/assets/dashboard-BBB.css">
+</head>
+<body><div id="dashboard-app-root"></div></body>
+</html>
+"""
+
+ENTRY_JS = 'import("./workflow-list-CCC.js");const x="assets/workflow-list-CCC.js";const y="assets/skills-DDD.js";'
+
+def _fetcher(responses: dict[str, tuple[int, bytes]]):
+    def fetch(url: str) -> tuple[int, bytes]:
+        return responses.get(url, (404, b""))
+
+    return fetch
+
+BASE = "http://deploy.example:7000"
+ASSET_BASE = f"{BASE}/static/workflow_console/dist/assets"
+
+def _coherent_responses() -> dict[str, tuple[int, bytes]]:
+    return {
+        f"{BASE}/workflows": (200, PAGE_HTML.encode()),
+        f"{ASSET_BASE}/dashboard-AAA.js": (200, ENTRY_JS.encode()),
+        f"{ASSET_BASE}/dashboard-BBB.css": (200, b"body{}"),
+        f"{ASSET_BASE}/workflow-list-CCC.js": (200, b"//chunk"),
+        f"{ASSET_BASE}/skills-DDD.js": (200, b"//chunk"),
+        f"{BASE}/api/ui/info": (200, b'{"buildId": "20260711.1"}'),
+    }
+
+def test_extracts_page_assets_and_chunk_refs() -> None:
+    assets = verify_deployed_ui_assets.extract_page_assets(PAGE_HTML)
+    assert assets == [
+        "/static/workflow_console/dist/assets/dashboard-AAA.js",
+        "/static/workflow_console/dist/assets/dashboard-BBB.css",
+    ]
+    chunks = verify_deployed_ui_assets.extract_chunk_refs(ENTRY_JS)
+    assert chunks == ["assets/workflow-list-CCC.js", "assets/skills-DDD.js"]
+
+def test_coherent_deployment_passes() -> None:
+    errors = verify_deployed_ui_assets.verify_deployed_ui_assets(
+        BASE, fetch=_fetcher(_coherent_responses())
+    )
+    assert errors == []
+
+def test_missing_lazy_chunk_fails() -> None:
+    # The exact production incident: the entry bundle and CSS were hot-patched
+    # into the running container, but the lazy page chunks they reference were
+    # not, so fresh clients 404 on navigation while cached browsers render a
+    # Franken-UI mixing builds.
+    responses = _coherent_responses()
+    del responses[f"{ASSET_BASE}/workflow-list-CCC.js"]
+    errors = verify_deployed_ui_assets.verify_deployed_ui_assets(
+        BASE, fetch=_fetcher(responses)
+    )
+    assert any("workflow-list-CCC.js" in error and "404" in error for error in errors)
+
+def test_missing_entry_asset_fails() -> None:
+    responses = _coherent_responses()
+    del responses[f"{ASSET_BASE}/dashboard-BBB.css"]
+    errors = verify_deployed_ui_assets.verify_deployed_ui_assets(
+        BASE, fetch=_fetcher(responses)
+    )
+    assert any("dashboard-BBB.css" in error for error in errors)
+
+def test_unreachable_page_fails_fast() -> None:
+    errors = verify_deployed_ui_assets.verify_deployed_ui_assets(
+        BASE, fetch=_fetcher({})
+    )
+    assert errors == [f"Page {BASE}/workflows returned HTTP 404"]

--- a/tools/verify_deployed_ui_assets.py
+++ b/tools/verify_deployed_ui_assets.py
@@ -40,6 +40,7 @@ _CHUNK_REF_RE = re.compile(r"assets/[A-Za-z0-9_.-]+\.(?:js|css)")
 
 Fetcher = Callable[[str], tuple[int, bytes]]
 
+
 def _default_fetcher(url: str) -> tuple[int, bytes]:
     request = urllib.request.Request(url, headers={"User-Agent": "moonmind-ui-asset-check"})
     try:
@@ -47,6 +48,9 @@ def _default_fetcher(url: str) -> tuple[int, bytes]:
             return response.status, response.read()
     except urllib.error.HTTPError as error:
         return error.code, b""
+    except OSError:
+        return 0, b""
+
 
 def extract_page_assets(html: str) -> list[str]:
     """Return script/stylesheet asset URLs referenced by a served page."""
@@ -58,6 +62,7 @@ def extract_page_assets(html: str) -> list[str]:
 def extract_chunk_refs(entry_js: str) -> list[str]:
     """Return hashed chunk paths referenced inside a built entry bundle."""
     return list(dict.fromkeys(_CHUNK_REF_RE.findall(entry_js)))
+
 
 def verify_deployed_ui_assets(
     base_url: str,
@@ -90,15 +95,22 @@ def verify_deployed_ui_assets(
 
     seen: set[str] = set()
     for chunk in chunk_refs:
+        last_url: str | None = None
+        last_status: int | None = None
         for asset_dir in asset_dirs or [page_url]:
             chunk_url = urljoin(asset_dir, chunk)
             if chunk_url in seen:
                 break
-            seen.add(chunk_url)
             chunk_status, _ = fetch(chunk_url)
-            if chunk_status != 200:
-                errors.append(f"Entry bundle references a missing chunk (HTTP {chunk_status}): {chunk_url}")
-            break
+            if chunk_status == 200:
+                seen.add(chunk_url)
+                break
+            last_url = chunk_url
+            last_status = chunk_status
+        else:
+            errors.append(
+                f"Entry bundle references a missing chunk (HTTP {last_status}): {last_url}"
+            )
 
     ui_info_url = urljoin(base_url, UI_INFO_PATH)
     info_status, info_body = fetch(ui_info_url)
@@ -112,6 +124,7 @@ def verify_deployed_ui_assets(
         print(f"Server build id: {build_id or '(unset)'}")
 
     return errors
+
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
@@ -132,6 +145,7 @@ def main() -> int:
         return 1
     print(f"OK: {args.base_url} serves a coherent dashboard asset set for {args.page}")
     return 0
+
 
 if __name__ == "__main__":
     raise SystemExit(main())

--- a/tools/verify_deployed_ui_assets.py
+++ b/tools/verify_deployed_ui_assets.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Verify a running MoonMind deployment serves a coherent dashboard asset set.
+
+The dashboard SPA is code-split: the served HTML references a hashed entry
+bundle, and the entry bundle references hashed lazy page chunks. Every one of
+those files must come from the same build. A partially patched static
+directory (for example a ``docker cp`` hot-patch that copies the entry bundle
+but not its chunks, or a stale volume mounted over the image's dist) serves a
+mix of builds: the page appears to work for browsers with cached chunks while
+fresh clients get 404s and silently degraded navigation.
+
+This check fetches the deployed HTML, the assets it references, and every
+lazy chunk referenced by the entry bundle, and fails on the first
+incoherence. Run it after any deploy or hot-patch:
+
+    python tools/verify_deployed_ui_assets.py --base-url http://localhost:7000
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import urllib.error
+import urllib.request
+from collections.abc import Callable
+from urllib.parse import urljoin
+
+DEFAULT_PAGE_PATH = "/workflows"
+UI_INFO_PATH = "/api/ui/info"
+
+# <script src="..."> and <link rel="stylesheet" href="..."> asset references.
+_SCRIPT_SRC_RE = re.compile(r"<script[^>]+src=\"([^\"]+)\"", re.IGNORECASE)
+_STYLESHEET_RE = re.compile(
+    r"<link[^>]+rel=\"stylesheet\"[^>]+href=\"([^\"]+)\"|<link[^>]+href=\"([^\"]+)\"[^>]+rel=\"stylesheet\"",
+    re.IGNORECASE,
+)
+# Hashed sibling-chunk references inside a built entry bundle.
+_CHUNK_REF_RE = re.compile(r"assets/[A-Za-z0-9_.-]+\.(?:js|css)")
+
+Fetcher = Callable[[str], tuple[int, bytes]]
+
+def _default_fetcher(url: str) -> tuple[int, bytes]:
+    request = urllib.request.Request(url, headers={"User-Agent": "moonmind-ui-asset-check"})
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            return response.status, response.read()
+    except urllib.error.HTTPError as error:
+        return error.code, b""
+
+def extract_page_assets(html: str) -> list[str]:
+    """Return script/stylesheet asset URLs referenced by a served page."""
+    assets = list(_SCRIPT_SRC_RE.findall(html))
+    for match in _STYLESHEET_RE.findall(html):
+        assets.extend(part for part in match if part)
+    return [asset for asset in dict.fromkeys(assets) if "/assets/" in asset or asset.endswith((".js", ".css"))]
+
+def extract_chunk_refs(entry_js: str) -> list[str]:
+    """Return hashed chunk paths referenced inside a built entry bundle."""
+    return list(dict.fromkeys(_CHUNK_REF_RE.findall(entry_js)))
+
+def verify_deployed_ui_assets(
+    base_url: str,
+    page_path: str = DEFAULT_PAGE_PATH,
+    fetch: Fetcher = _default_fetcher,
+) -> list[str]:
+    """Return a list of coherence errors for the deployment at ``base_url``."""
+    errors: list[str] = []
+    page_url = urljoin(base_url, page_path)
+    status, body = fetch(page_url)
+    if status != 200:
+        return [f"Page {page_url} returned HTTP {status}"]
+    html = body.decode("utf-8", errors="replace")
+
+    page_assets = extract_page_assets(html)
+    if not page_assets:
+        return [f"Page {page_url} references no script/stylesheet assets; cannot verify"]
+
+    chunk_refs: list[str] = []
+    asset_dirs: list[str] = []
+    for asset in page_assets:
+        asset_url = urljoin(page_url, asset)
+        asset_status, asset_body = fetch(asset_url)
+        if asset_status != 200:
+            errors.append(f"Referenced asset missing (HTTP {asset_status}): {asset_url}")
+            continue
+        if asset.endswith(".js"):
+            asset_dirs.append(asset_url.rsplit("/assets/", 1)[0] + "/" if "/assets/" in asset_url else asset_url)
+            chunk_refs.extend(extract_chunk_refs(asset_body.decode("utf-8", errors="replace")))
+
+    seen: set[str] = set()
+    for chunk in chunk_refs:
+        for asset_dir in asset_dirs or [page_url]:
+            chunk_url = urljoin(asset_dir, chunk)
+            if chunk_url in seen:
+                break
+            seen.add(chunk_url)
+            chunk_status, _ = fetch(chunk_url)
+            if chunk_status != 200:
+                errors.append(f"Entry bundle references a missing chunk (HTTP {chunk_status}): {chunk_url}")
+            break
+
+    ui_info_url = urljoin(base_url, UI_INFO_PATH)
+    info_status, info_body = fetch(ui_info_url)
+    if info_status != 200:
+        errors.append(f"{ui_info_url} returned HTTP {info_status}; cannot confirm server build id")
+    else:
+        try:
+            build_id = json.loads(info_body.decode("utf-8", errors="replace")).get("buildId")
+        except (ValueError, AttributeError):
+            build_id = None
+        print(f"Server build id: {build_id or '(unset)'}")
+
+    return errors
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--base-url", default="http://localhost:7000", help="Deployment root URL")
+    parser.add_argument("--page", default=DEFAULT_PAGE_PATH, help="SPA page path to verify")
+    args = parser.parse_args()
+
+    errors = verify_deployed_ui_assets(args.base_url, args.page)
+    if errors:
+        print("Deployed UI asset verification failed:", file=sys.stderr)
+        for error in errors:
+            print(f"  - {error}", file=sys.stderr)
+        print(
+            "The static asset set is incoherent (mixed builds). Redeploy the image cleanly; "
+            "do not hot-patch individual files into the running container.",
+            file=sys.stderr,
+        )
+        return 1
+    print(f"OK: {args.base_url} serves a coherent dashboard asset set for {args.page}")
+    return 0
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Why

Three reported dashboard regressions were investigated together:

1. **Shimmer looks wrong after restoration** — real code issue, fixed here.
2. **Mobile Filters/View-options row on desktop** — not a code bug at HEAD; the deployment serves a mixed-build static dist (see below).
3. **System dropdown missing** — same deployment skew, amplified by a real client fragility fixed here.

### The shimmer story

MM-1036 shipped the approved look: translucent accent halo (14%) under a translucent accent-2 core (34%) on a −18°/±160% path. **MM-1048 changed the palette to bright currentColor mixes (30% halo, fully opaque whitened core) and broke gradient resolution in the same commit** — so its brighter design never rendered. #3205 fixed the plumbing and thereby shipped MM-1048's never-reviewed palette for the first time; the operator rejected it. This PR keeps #3205's structural fix (host-scoped gradient) and restores the approved MM-1036 palette and geometry, keeping only the letter treatment status-aware (the MM-1048 portion that actually rendered and was accepted).

The missing guardrail is added: the real-browser suite now pins **computed gradient colors, angle, and a max-alpha translucency ceiling** in both themes. "A gradient renders and moves" is no longer the contract — "the approved gradient renders" is.

### The deployment skew story

The deployed instance serves an entry bundle whose lazy chunks 404 (a partial dist hot-patch), so browsers run stale JS whose compiled-in destination registry mismatches the newer API. The client used to **throw the whole `/api/ui/info` payload away** on that mismatch, silently deleting the System menu (no null-uiInfo fallback) while cached chunks rendered the mobile toolbar into the desktop layout.

## What

- `dashboard.css` / `EffectShimmerSweep.md`: restore the approved shimmer palette + geometry; record it as the durable aesthetic contract.
- `statusPillShimmer.browser.test.tsx`: pin computed colors/angle/alpha ceiling (light + dark).
- `dashboard-app.tsx`: registry mismatch is now fail-soft — uiInfo stays usable, a `role="alert"` version-skew banner names the server build id, mismatch is logged. Regression test reproduces the stale-bundle/newer-API scenario.
- `workflowListResponsiveToolbar.browser.test.tsx`: real-viewport guardrail that the mobile Filters row never renders into the desktop table.
- `tools/verify_deployed_ui_assets.py` (+ tests): post-deploy smoke check that fails on missing chunks / mixed-build static dirs — catches the exact corrupted state currently live.
- `DashboardSPAArchitecture.md`: build-coherence rules, fail-soft skew contract, no-hot-patch rule, and the frontend testing-layer model.

## Verification

- Real-browser suite (Playwright Chromium): 3 files / 7 tests pass, including the new computed-color and responsive-toolbar guardrails.
- `dashboard.test.tsx`: 126/126 pass (includes new skew regression test).
- `dashboardRoutes.test.ts`: 42/42 pass. `tsc --noEmit` and eslint clean on changed files.
- `tests/unit/tools/test_verify_deployed_ui_assets.py`: 5/5 pass; the missing-chunk case mirrors the live incident.
- Side-by-side animation frames captured in headless Chromium confirm the restored pill matches the subtle original while the rejected treatment reproduces the reported bright/thick look.

## Operator follow-up (not in this PR)

The running deployment needs a **clean image redeploy** (container recreate) — its static dist mixes builds and `workflow-list-*.js`/`skills-*.js` 404. After deploying: `python tools/verify_deployed_ui_assets.py --base-url http://asus-laptop:7000`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)