### PR TITLE
MM-1132: Enlarge Workflow Detail step icons to mostly fill the circle

### DIFF
--- a/frontend/src/entrypoints/dashboard.test.tsx
+++ b/frontend/src/entrypoints/dashboard.test.tsx
@@ -2427,16 +2427,16 @@ describe('Dashboard shared entry', () => {
     expect(svgBlock).toContain('height: 0.8125rem');
   });
 
-  it('keeps workflow detail step timeline icons large inside their status circles', async () => {
+  it('MM-1132 makes workflow detail step timeline icons mostly fill their status circles', async () => {
     const iconBlock = cssRuleBlock(dashboardCss, '.step-tl-icon');
     expect(iconBlock).toContain('width: 1.35rem');
     expect(iconBlock).toContain('height: 1.35rem');
     expect(iconBlock).toContain('border-radius: 50%');
 
     const svgBlock = cssRuleBlock(dashboardCss, '.step-tl-icon svg');
-    expect(svgBlock).toContain('width: 1.05rem');
-    expect(svgBlock).toContain('height: 1.05rem');
-    expect(svgBlock).toContain('stroke-width: 2.4');
+    expect(svgBlock).toContain('width: 1.3rem');
+    expect(svgBlock).toContain('height: 1.3rem');
+    expect(svgBlock).toContain('stroke-width: 2');
   });
 
   it('keeps checkbox label hit areas bounded to visible control text', async () => {

--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -4546,9 +4546,9 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
 }
 
 .step-tl-icon svg {
-  width: 1.05rem;
-  height: 1.05rem;
-  stroke-width: 2.4;
+  width: 1.3rem;
+  height: 1.3rem;
+  stroke-width: 2;
 }
 
 .step-tl-icon.status-completed {


### PR DESCRIPTION
## Issue

- **Jira:** [MM-1132 — Workflow Detail Step Icons are still way too small](https://moonladder.atlassian.net/browse/MM-1132)

> Workflow Detail Step Icons are still way too small. They should mostly fill the circle.

## Summary of implementation

The step-timeline status icons in the Workflow Detail view (`.step-tl-icon svg`) were still too small inside their `1.35rem` status circles. Because Lucide stroke icons carry internal viewBox padding, the prior `1.05rem` glyph (~78% of the circle diameter) left a large visible gap to the circle edge.

- Enlarged the icon SVG from `1.05rem` to `1.3rem` in `frontend/src/styles/dashboard.css` so the glyph now spans ~96% of the `1.35rem` circle diameter and mostly fills the circle.
- Reduced `stroke-width` from `2.4` to `2` so the larger glyph reads crisp rather than chunky.
- The status circle itself (`.step-tl-icon`: `1.35rem`, `border-radius: 50%`, `1.5px` border) is unchanged.

This is the sole Workflow Detail step-icon render path: `StatusIcon domain="step" className="step-tl-icon"` at `frontend/src/entrypoints/workflow-detail.tsx:5009`.

## Tests run

- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --dashboard-only --ui-args frontend/src/entrypoints/dashboard.test.tsx -t MM-1132` — **PASS** (1 passed, 125 skipped). Targeted postcss-based CSS assertion in the updated regression test `MM-1132 makes workflow detail step timeline icons mostly fill their status circles` (`frontend/src/entrypoints/dashboard.test.tsx:2430-2440`), asserting the `1.3rem` svg width/height and `stroke-width: 2`.
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --dashboard-only --ui-args frontend/src/entrypoints/dashboard.test.tsx` — **PASS** (126 passed). Full `dashboard.test.tsx` file, no regressions from the sizing change.

## Remaining risks

- **Low.** CSS/UI-only change with hermetic frontend coverage; no source-authority, credential, billing, or Temporal workflow boundaries are touched.
- Pixel-perfect visual confirmation in a running browser was not performed (unavailable in the hermetic runtime). The behavior is deterministically encoded in CSS and covered by the postcss-based unit assertion, but final visual polish (e.g. whether `1.3rem` is the ideal fill vs. a slightly different value) is best confirmed by a quick visual review.
