### PR TITLE
MM-1206: Make remediation continuation progress-aware

### DIFF
--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -1,5 +1,6 @@
 import asyncio
 import dataclasses
+import hashlib
 import json
 import logging
 import re
@@ -5624,6 +5625,23 @@ class MoonMindRunWorkflow:
         terminal_disposition = (
             "accepted" if terminal == "accepted" else "failed_with_remaining_work"
         )
+        progress_payload = {
+            "verdict": gate_result.verdict,
+            "issues": [dict(issue) for issue in gate_result.issues],
+            "recommendedNextAction": gate_result.recommended_next_action,
+            "workspacePolicyRecommendation": (
+                gate_result.workspace_policy_recommendation
+            ),
+            "recoverableInCurrentRuntime": gate_result.recoverable_in_current_runtime,
+        }
+        progress_signature = hashlib.sha256(
+            json.dumps(
+                progress_payload,
+                ensure_ascii=True,
+                sort_keys=True,
+                separators=(",", ":"),
+            ).encode("utf-8")
+        ).hexdigest()
         return TypedGateResult.model_validate(
             {
                 "verdict": gate_result.verdict,
@@ -5637,6 +5655,7 @@ class MoonMindRunWorkflow:
                 "diagnosticsRef": self._bounded_story_loop_artifact_ref(
                     next(iter(gate_result.blocking_evidence_refs), None)
                 ),
+                "progressSignature": progress_signature,
                 "degraded": gate_result.degraded,
             }
         )
@@ -5711,6 +5730,20 @@ class MoonMindRunWorkflow:
             logical_step_id=logical_step_id,
             remediation_gate=remediation_gate,
         )
+        loop_context = self._publish_context.get("boundedStoryLoop")
+        prior_progress_signature = None
+        if isinstance(loop_context, Mapping):
+            prior_decision = loop_context.get("continuationDecision")
+            if isinstance(prior_decision, Mapping):
+                prior_gate = prior_decision.get("gate")
+                if isinstance(prior_gate, Mapping):
+                    prior_progress_signature = str(
+                        prior_gate.get("progressSignature") or ""
+                    ).strip() or None
+        repeated_progress = bool(
+            gate.progress_signature
+            and prior_progress_signature == gate.progress_signature
+        )
         budget = LoopBudget.model_validate(
             {
                 "maxAttempts": 1,
@@ -5719,7 +5752,7 @@ class MoonMindRunWorkflow:
                 "maxUnsafeOrPolicyDeniedAttempts": 1,
                 "consumed": {
                     "attempts": 0 if has_remaining_remediation_step else 1,
-                    "consecutive_no_progress_attempts": 0,
+                    "consecutiveNoProgressAttempts": 1 if repeated_progress else 0,
                     "repeated_failed_commands": 0,
                     "unsafe_or_policy_denied_attempts": 0,
                 },
@@ -5739,6 +5772,7 @@ class MoonMindRunWorkflow:
             "gateResultRef": gate.gate_result_ref,
             "remainingWorkRef": gate.remaining_work_ref,
             "diagnosticsRef": gate.diagnostics_ref,
+            "progressSignature": gate.progress_signature,
         }
         self._publish_context.setdefault("boundedStoryLoop", {})[
             "continuationDecision"

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -579,6 +579,9 @@ RUN_MOONSPEC_TITLE_REMEDIATION_DETECTION_PATCH = (
     "run-moonspec-title-remediation-detection-v1"
 )
 RUN_MOONSPEC_GATE_CONTRACT_REPAIR_PATCH = "run-moonspec-gate-contract-repair-v1"
+RUN_BOUNDED_STORY_LOOP_PROGRESS_BUDGET_PATCH = (
+    "run-bounded-story-loop-progress-budget-v1"
+)
 RUN_MOONSPEC_GATE_CONTRACT_REPAIR_FRESH_SOURCE_PATCH = (
     "run-moonspec-gate-contract-repair-fresh-source-v1"
 )
@@ -5620,6 +5623,7 @@ class MoonMindRunWorkflow:
         gate_result: StepGateResult,
         gate_result_ref: str | None,
         logical_step_id: str,
+        progress_budget_enabled: bool,
     ) -> TypedGateResult:
         terminal = self._step_terminal_dispositions.get(logical_step_id)
         terminal_disposition = (
@@ -5628,6 +5632,8 @@ class MoonMindRunWorkflow:
         progress_payload = {
             "verdict": gate_result.verdict,
             "issues": [dict(issue) for issue in gate_result.issues],
+            "remainingWorkRef": gate_result.remaining_work_ref,
+            "blockingEvidenceRefs": list(gate_result.blocking_evidence_refs),
             "recommendedNextAction": gate_result.recommended_next_action,
             "workspacePolicyRecommendation": (
                 gate_result.workspace_policy_recommendation
@@ -5655,7 +5661,9 @@ class MoonMindRunWorkflow:
                 "diagnosticsRef": self._bounded_story_loop_artifact_ref(
                     next(iter(gate_result.blocking_evidence_refs), None)
                 ),
-                "progressSignature": progress_signature,
+                "progressSignature": (
+                    progress_signature if progress_budget_enabled else None
+                ),
                 "degraded": gate_result.degraded,
             }
         )
@@ -5721,10 +5729,14 @@ class MoonMindRunWorkflow:
             ordered_nodes=ordered_nodes,
             current_index=current_index,
         )
+        progress_budget_enabled = self._patched_or_false_outside_workflow(
+            RUN_BOUNDED_STORY_LOOP_PROGRESS_BUDGET_PATCH
+        )
         gate = self._bounded_story_loop_gate_from_step_gate(
             gate_result=gate_result,
             gate_result_ref=gate_result_ref,
             logical_step_id=logical_step_id,
+            progress_budget_enabled=progress_budget_enabled,
         )
         attempt = self._bounded_story_loop_attempt_for_gate(
             logical_step_id=logical_step_id,
@@ -5741,13 +5753,21 @@ class MoonMindRunWorkflow:
                         prior_gate.get("progressSignature") or ""
                     ).strip() or None
         repeated_progress = bool(
-            gate.progress_signature
+            progress_budget_enabled
+            and gate.progress_signature
             and prior_progress_signature == gate.progress_signature
         )
+        max_no_progress_attempts = 1
+        if progress_budget_enabled and isinstance(loop_context, Mapping):
+            loop_budgets = loop_context.get("budgets")
+            if isinstance(loop_budgets, Mapping):
+                max_no_progress_attempts = int(
+                    loop_budgets.get("maxConsecutiveNoProgressAttempts") or 1
+                )
         budget = LoopBudget.model_validate(
             {
                 "maxAttempts": 1,
-                "maxConsecutiveNoProgressAttempts": 1,
+                "maxConsecutiveNoProgressAttempts": max_no_progress_attempts,
                 "maxRepeatedFailedCommands": 1,
                 "maxUnsafeOrPolicyDeniedAttempts": 1,
                 "consumed": {
@@ -7695,6 +7715,7 @@ class MoonMindRunWorkflow:
             "nodeKinds": [node.kind for node in compiled.nodes],
             "publishMode": loop_input.publish_mode,
             "mergeAutomationEnabled": loop_input.merge_automation_enabled,
+            "budgets": loop_input.budgets.model_dump(by_alias=True, mode="json"),
             "scopeGuard": scope,
         }
 

--- a/tests/unit/workflows/temporal/workflows/test_run_bounded_story_loop.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_bounded_story_loop.py
@@ -159,6 +159,16 @@ def test_workflow_payload_records_compiled_bounded_story_loop_context() -> None:
         ],
         "publishMode": "pr",
         "mergeAutomationEnabled": True,
+        "budgets": {
+            "maxAttempts": 3,
+            "maxConsecutiveNoProgressAttempts": 2,
+            "maxRepeatedFailedCommands": 2,
+            "maxUnsafeOrPolicyDeniedAttempts": 0,
+            "providerBudget": None,
+            "tokenBudget": None,
+            "costBudget": None,
+            "consumed": {},
+        },
         "scopeGuard": {"allowed": True, "reason": "selected_item_only"},
     }
 
@@ -185,8 +195,11 @@ def test_workflow_payload_rejects_full_supervisor_for_bounded_story_loop() -> No
         )
 
 
-def test_parent_loop_continues_from_structured_gate_when_remediation_remains() -> None:
+def test_parent_loop_continues_from_structured_gate_when_remediation_remains(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     workflow = MoonMindRunWorkflow()
+    monkeypatch.setattr(workflow, "_patched_or_false_outside_workflow", lambda _: True)
     workflow._step_ledger_rows = [
         {"logicalStepId": "verify-1", "attempt": 1, "artifacts": {}}
     ]
@@ -231,8 +244,11 @@ def test_parent_loop_continues_from_structured_gate_when_remediation_remains() -
     assert decision["gate"]["progressSignature"]
 
 
-def test_parent_loop_stops_when_verification_makes_no_progress() -> None:
+def test_parent_loop_stops_when_verification_makes_no_progress(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     workflow = MoonMindRunWorkflow()
+    monkeypatch.setattr(workflow, "_patched_or_false_outside_workflow", lambda _: True)
     workflow._step_ledger_rows = [
         {"logicalStepId": "verify-1", "attempt": 1, "artifacts": {}},
         {"logicalStepId": "verify-2", "attempt": 1, "artifacts": {}},
@@ -286,8 +302,11 @@ def test_parent_loop_stops_when_verification_makes_no_progress() -> None:
     assert second["hasRemainingRemediationStep"] is True
 
 
-def test_parent_loop_continues_when_verification_progress_changes() -> None:
+def test_parent_loop_continues_when_verification_progress_changes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     workflow = MoonMindRunWorkflow()
+    monkeypatch.setattr(workflow, "_patched_or_false_outside_workflow", lambda _: True)
     workflow._step_ledger_rows = [
         {"logicalStepId": "verify-1", "attempt": 1, "artifacts": {}},
         {"logicalStepId": "verify-2", "attempt": 1, "artifacts": {}},
@@ -340,6 +359,144 @@ def test_parent_loop_continues_when_verification_progress_changes() -> None:
     assert first["gate"]["progressSignature"] != second["gate"]["progressSignature"]
     assert second["continueLoop"] is True
     assert second["reason"] == "verification_requested_remediation"
+
+
+def test_parent_loop_progress_tracks_remaining_work_refs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workflow = MoonMindRunWorkflow()
+    monkeypatch.setattr(workflow, "_patched_or_false_outside_workflow", lambda _: True)
+    workflow._step_terminal_dispositions.update(
+        {"verify-1": "accepted", "verify-2": "accepted"}
+    )
+    ordered_nodes = [
+        {"id": "verify-1", "inputs": {"selectedSkill": "moonspec-verify"}},
+        {
+            "id": "remediate-1",
+            "inputs": {
+                "annotations": {"jiraOrchestrateRole": "moonspec-remediation"}
+            },
+        },
+        {"id": "verify-2", "inputs": {"selectedSkill": "moonspec-verify"}},
+        {
+            "id": "remediate-2",
+            "inputs": {
+                "annotations": {"jiraOrchestrateRole": "moonspec-remediation"}
+            },
+        },
+    ]
+    first = workflow._bounded_story_loop_continuation_decision(
+        logical_step_id="verify-1",
+        gate_result=StepGateResult(
+            verdict="ADDITIONAL_WORK_NEEDED",
+            remaining_work_ref="artifact://remaining/one",
+        ),
+        gate_result_ref="artifact://gate/one",
+        ordered_nodes=ordered_nodes,
+        current_index=0,
+    )
+    second = workflow._bounded_story_loop_continuation_decision(
+        logical_step_id="verify-2",
+        gate_result=StepGateResult(
+            verdict="ADDITIONAL_WORK_NEEDED",
+            remaining_work_ref="artifact://remaining/two",
+        ),
+        gate_result_ref="artifact://gate/two",
+        ordered_nodes=ordered_nodes,
+        current_index=2,
+    )
+
+    assert first["gate"]["progressSignature"] != second["gate"]["progressSignature"]
+    assert second["continueLoop"] is True
+
+
+def test_parent_loop_honors_configured_no_progress_budget(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workflow = MoonMindRunWorkflow()
+    monkeypatch.setattr(workflow, "_patched_or_false_outside_workflow", lambda _: True)
+    workflow._publish_context["boundedStoryLoop"] = {
+        "budgets": {"maxConsecutiveNoProgressAttempts": 2}
+    }
+    workflow._step_terminal_dispositions.update(
+        {"verify-1": "accepted", "verify-2": "accepted"}
+    )
+    ordered_nodes = [
+        {"id": "verify-1", "inputs": {"selectedSkill": "moonspec-verify"}},
+        {
+            "id": "remediate-1",
+            "inputs": {
+                "annotations": {"jiraOrchestrateRole": "moonspec-remediation"}
+            },
+        },
+        {"id": "verify-2", "inputs": {"selectedSkill": "moonspec-verify"}},
+        {
+            "id": "remediate-2",
+            "inputs": {
+                "annotations": {"jiraOrchestrateRole": "moonspec-remediation"}
+            },
+        },
+    ]
+    gate = StepGateResult(
+        verdict="ADDITIONAL_WORK_NEEDED",
+        remaining_work_ref="artifact://remaining/same",
+    )
+    workflow._bounded_story_loop_continuation_decision(
+        logical_step_id="verify-1",
+        gate_result=gate,
+        gate_result_ref="artifact://gate/one",
+        ordered_nodes=ordered_nodes,
+        current_index=0,
+    )
+    second = workflow._bounded_story_loop_continuation_decision(
+        logical_step_id="verify-2",
+        gate_result=gate,
+        gate_result_ref="artifact://gate/two",
+        ordered_nodes=ordered_nodes,
+        current_index=2,
+    )
+
+    assert second["continueLoop"] is True
+
+
+def test_parent_loop_replay_before_progress_patch_keeps_legacy_continuation() -> None:
+    workflow = MoonMindRunWorkflow()
+    workflow._step_terminal_dispositions.update(
+        {"verify-1": "accepted", "verify-2": "accepted"}
+    )
+    ordered_nodes = [
+        {"id": "verify-1", "inputs": {"selectedSkill": "moonspec-verify"}},
+        {
+            "id": "remediate-1",
+            "inputs": {
+                "annotations": {"jiraOrchestrateRole": "moonspec-remediation"}
+            },
+        },
+        {"id": "verify-2", "inputs": {"selectedSkill": "moonspec-verify"}},
+        {
+            "id": "remediate-2",
+            "inputs": {
+                "annotations": {"jiraOrchestrateRole": "moonspec-remediation"}
+            },
+        },
+    ]
+    gate = StepGateResult(verdict="ADDITIONAL_WORK_NEEDED")
+    workflow._bounded_story_loop_continuation_decision(
+        logical_step_id="verify-1",
+        gate_result=gate,
+        gate_result_ref=None,
+        ordered_nodes=ordered_nodes,
+        current_index=0,
+    )
+    second = workflow._bounded_story_loop_continuation_decision(
+        logical_step_id="verify-2",
+        gate_result=gate,
+        gate_result_ref=None,
+        ordered_nodes=ordered_nodes,
+        current_index=2,
+    )
+
+    assert second["continueLoop"] is True
 
 
 def test_parent_loop_continues_to_scheduled_remediation_without_remaining_work_ref() -> None:

--- a/tests/unit/workflows/temporal/workflows/test_run_bounded_story_loop.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_bounded_story_loop.py
@@ -228,6 +228,118 @@ def test_parent_loop_continues_from_structured_gate_when_remediation_remains() -
         workflow._publish_context["boundedStoryLoop"]["continuationDecision"]
         == decision
     )
+    assert decision["gate"]["progressSignature"]
+
+
+def test_parent_loop_stops_when_verification_makes_no_progress() -> None:
+    workflow = MoonMindRunWorkflow()
+    workflow._step_ledger_rows = [
+        {"logicalStepId": "verify-1", "attempt": 1, "artifacts": {}},
+        {"logicalStepId": "verify-2", "attempt": 1, "artifacts": {}},
+    ]
+    workflow._step_terminal_dispositions.update(
+        {"verify-1": "accepted", "verify-2": "accepted"}
+    )
+    gate_result = StepGateResult(
+        verdict="ADDITIONAL_WORK_NEEDED",
+        confidence="medium",
+        issues=({"requirement": "still failing", "status": "unmet"},),
+        remaining_work_ref="artifact://remaining-work/unchanged",
+        recommended_next_action="reattempt_current_step",
+        target_logical_step_id="remediate-2",
+    )
+    ordered_nodes = [
+        {"id": "verify-1", "inputs": {"selectedSkill": "moonspec-verify"}},
+        {
+            "id": "remediate-1",
+            "inputs": {
+                "annotations": {"jiraOrchestrateRole": "moonspec-remediation"}
+            },
+        },
+        {"id": "verify-2", "inputs": {"selectedSkill": "moonspec-verify"}},
+        {
+            "id": "remediate-2",
+            "inputs": {
+                "annotations": {"jiraOrchestrateRole": "moonspec-remediation"}
+            },
+        },
+    ]
+
+    first = workflow._bounded_story_loop_continuation_decision(
+        logical_step_id="verify-1",
+        gate_result=gate_result,
+        gate_result_ref="artifact://gate/attempt-1",
+        ordered_nodes=ordered_nodes,
+        current_index=0,
+    )
+    second = workflow._bounded_story_loop_continuation_decision(
+        logical_step_id="verify-2",
+        gate_result=gate_result,
+        gate_result_ref="artifact://gate/attempt-2",
+        ordered_nodes=ordered_nodes,
+        current_index=2,
+    )
+
+    assert first["continueLoop"] is True
+    assert second["continueLoop"] is False
+    assert second["reason"] == "no_progress_attempts_exhausted"
+    assert second["hasRemainingRemediationStep"] is True
+
+
+def test_parent_loop_continues_when_verification_progress_changes() -> None:
+    workflow = MoonMindRunWorkflow()
+    workflow._step_ledger_rows = [
+        {"logicalStepId": "verify-1", "attempt": 1, "artifacts": {}},
+        {"logicalStepId": "verify-2", "attempt": 1, "artifacts": {}},
+    ]
+    workflow._step_terminal_dispositions.update(
+        {"verify-1": "accepted", "verify-2": "accepted"}
+    )
+    ordered_nodes = [
+        {"id": "verify-1", "inputs": {"selectedSkill": "moonspec-verify"}},
+        {
+            "id": "remediate-1",
+            "inputs": {
+                "annotations": {"jiraOrchestrateRole": "moonspec-remediation"}
+            },
+        },
+        {"id": "verify-2", "inputs": {"selectedSkill": "moonspec-verify"}},
+        {
+            "id": "remediate-2",
+            "inputs": {
+                "annotations": {"jiraOrchestrateRole": "moonspec-remediation"}
+            },
+        },
+    ]
+
+    first = workflow._bounded_story_loop_continuation_decision(
+        logical_step_id="verify-1",
+        gate_result=StepGateResult(
+            verdict="ADDITIONAL_WORK_NEEDED",
+            confidence="medium",
+            issues=({"requirement": "first gap", "status": "unmet"},),
+            recommended_next_action="reattempt_current_step",
+        ),
+        gate_result_ref="artifact://gate/attempt-1",
+        ordered_nodes=ordered_nodes,
+        current_index=0,
+    )
+    second = workflow._bounded_story_loop_continuation_decision(
+        logical_step_id="verify-2",
+        gate_result=StepGateResult(
+            verdict="ADDITIONAL_WORK_NEEDED",
+            confidence="medium",
+            issues=({"requirement": "different gap", "status": "unmet"},),
+            recommended_next_action="reattempt_current_step",
+        ),
+        gate_result_ref="artifact://gate/attempt-2",
+        ordered_nodes=ordered_nodes,
+        current_index=2,
+    )
+
+    assert first["gate"]["progressSignature"] != second["gate"]["progressSignature"]
+    assert second["continueLoop"] is True
+    assert second["reason"] == "verification_requested_remediation"
 
 
 def test_parent_loop_continues_to_scheduled_remediation_without_remaining_work_ref() -> None:


### PR DESCRIPTION
Issue: [MM-1206](https://moonladder.atlassian.net/browse/MM-1206)

## Summary

- Derive a stable verification progress signature from the structured gate result.
- Stop bounded remediation when consecutive verification results show no progress.
- Continue to the scheduled remediation step when the verification result changes.
- Add workflow-boundary regression coverage for unchanged and changed progress.

## Tests run

- `PATH="$HOME/.local/bin:$PATH" MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/workflows/test_run_bounded_story_loop.py tests/unit/workflows/temporal/test_bounded_story_loop.py`
- Result: 39 targeted Python tests passed; the invoked frontend suite also passed 65 files / 1073 tests, with 238 skipped.

## Remaining risks

- Integration tests were not run because this change does not alter compose, database, service, adapter, activity-signature, or external-runtime boundaries.

[MM-1206]: https://moonladder.atlassian.net/browse/MM-1206?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ