### PR TITLE
Fix GitHub Issue Implement preset completion

### DIFF
--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -62,11 +62,15 @@ from moonmind.statuses.compat import (
 )
 from moonmind.utils.metrics import get_metrics_emitter
 from moonmind.workflows.report_output import normalize_report_output_primary_path
+from moonmind.workflows.executions.preset_expansion import (
+    expand_preset_for_child_run,
+    has_unexpanded_task_template,
+)
+from moonmind.workflows.executions.routing import _coerce_bool
 from moonmind.workflows.executions.title_derivation import (
     is_generic_title,
     synthesize_workflow_title,
 )
-from moonmind.workflows.executions.routing import _coerce_bool
 from moonmind.runtime_intent import (
     RuntimeIntentValidationError,
     validate_runtime_tier_intent,
@@ -7974,6 +7978,26 @@ async def _expand_goal_preset_for_workflow_submission(
     session: Any,
     user_id: Any,
 ) -> None:
+    if has_unexpanded_task_template({"workflow": task_payload}):
+        expanded_parameters = await expand_preset_for_child_run(
+            session=session,
+            initial_parameters={
+                "workflow": task_payload,
+                "repository": request_payload.get("repository"),
+                "targetRuntime": request_payload.get("targetRuntime"),
+            },
+            allow_goal_schedule=False,
+            user_id=user_id,
+        )
+        expanded_task = expanded_parameters.get("workflow")
+        if not isinstance(expanded_task, Mapping):
+            raise _invalid_workflow_request(
+                "Explicit preset expansion did not produce a workflow payload."
+            )
+        task_payload.clear()
+        task_payload.update(expanded_task)
+        return
+
     if workflow_is_already_authored(task_payload):
         return
 

--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -30,6 +30,7 @@ from temporalio.api.operatorservice.v1 import ListSearchAttributesRequest
 from temporalio.client import Client
 from temporalio.service import RPCError
 
+from api_service.api.dependencies import resolve_template_scope_for_user
 from api_service.auth_providers import get_current_user
 from api_service.core import sync as execution_sync
 from api_service.db.base import get_async_session
@@ -7976,19 +7977,53 @@ async def _expand_goal_preset_for_workflow_submission(
     task_payload: dict[str, Any],
     request_payload: Mapping[str, Any],
     session: Any,
-    user_id: Any,
+    user: Any,
 ) -> None:
     if has_unexpanded_task_template({"workflow": task_payload}):
-        expanded_parameters = await expand_preset_for_child_run(
-            session=session,
-            initial_parameters={
-                "workflow": task_payload,
-                "repository": request_payload.get("repository"),
-                "targetRuntime": request_payload.get("targetRuntime"),
-            },
-            allow_goal_schedule=False,
-            user_id=user_id,
+        from api_service.services.presets.catalog import (
+            PresetNotFoundError,
+            PresetValidationError,
         )
+
+        template_payload = dict(task_payload.get("taskTemplate") or {})
+        template_scope, template_scope_ref = resolve_template_scope_for_user(
+            user=user,
+            scope=str(template_payload.get("scope") or "global"),
+            scope_ref=(
+                template_payload.get("scopeRef")
+                or template_payload.get("scope_ref")
+            ),
+            write=False,
+        )
+        template_payload["scope"] = template_scope
+        if template_scope_ref is None:
+            template_payload.pop("scopeRef", None)
+            template_payload.pop("scope_ref", None)
+        else:
+            template_payload["scopeRef"] = template_scope_ref
+            template_payload.pop("scope_ref", None)
+        task_payload["taskTemplate"] = template_payload
+        try:
+            expanded_parameters = await expand_preset_for_child_run(
+                session=session,
+                initial_parameters={
+                    "workflow": task_payload,
+                    "repository": request_payload.get("repository"),
+                    "targetRuntime": request_payload.get("targetRuntime"),
+                },
+                allow_goal_schedule=False,
+                user_id=getattr(user, "id", None),
+            )
+        except PresetNotFoundError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail={
+                    "code": "template_not_found",
+                    "message": str(exc),
+                },
+            ) from exc
+        except (PresetValidationError, RuntimeError) as exc:
+            raise _invalid_workflow_request(str(exc)) from exc
         expanded_task = expanded_parameters.get("workflow")
         if not isinstance(expanded_task, Mapping):
             raise _invalid_workflow_request(
@@ -8041,7 +8076,7 @@ async def _expand_goal_preset_for_workflow_submission(
         "inputs": template_inputs,
         "context": context,
         "options": ExpandOptions(should_enforce_step_limit=True),
-        "user_id": user_id,
+        "user_id": getattr(user, "id", None),
     }
     try:
         expanded = await catalog.expand_template(**expand_kwargs)
@@ -9715,7 +9750,7 @@ async def _create_execution_from_workflow_request(
             task_payload=task_payload,
             request_payload=payload,
             session=session,
-            user_id=user.id,
+            user=user,
         )
         _reject_submit_version_identity(task_payload)
 

--- a/api_service/data/presets/issue-implement-work-pr.yaml
+++ b/api_service/data/presets/issue-implement-work-pr.yaml
@@ -838,8 +838,11 @@ steps:
     instruction as the controlling instruction for this step only. If the workflow is
     submitted with PR merge automation enabled, the parent workflow must use the pull
     request URL produced by this step as the published PR and then run merge automation
-    against that PR; on a successful merge the parent workflow will transition {{
-    inputs.issue_provider }} issue {{ inputs.issue_ref }} to Done automatically. If
+    against that PR; {% if inputs.issue_provider == "github" %}the required closing
+    keyword in the pull request body makes the successful merge the authoritative
+    Done transition for issue {{ inputs.issue_ref }}{% else %}on a successful merge
+    the parent workflow will transition {{ inputs.issue_provider }} issue {{
+    inputs.issue_ref }} to Done automatically{% endif %}. If
     the runtime instructions, workflow parameters, authentication, remote configuration,
     branch protection, or repository permissions prevent committing, pushing, or creating
     the pull request in this step, stop before changing Jira to Review and report
@@ -863,6 +866,10 @@ steps:
     must include:
 
     - the issue reference
+
+    - {% if inputs.issue_provider == "github" %}a standalone `Closes {{ inputs.issue_ref
+    }}` line so GitHub closes the issue only after the pull request merges{% else %}the
+    issue tracker reference required by the configured review transition{% endif %}
 
     - a summary of the implementation
 

--- a/api_service/data/presets/issue-implement-work-pr.yaml
+++ b/api_service/data/presets/issue-implement-work-pr.yaml
@@ -839,8 +839,9 @@ steps:
     submitted with PR merge automation enabled, the parent workflow must use the pull
     request URL produced by this step as the published PR and then run merge automation
     against that PR; {% if inputs.issue_provider == "github" %}the required closing
-    keyword in the pull request body makes the successful merge the authoritative
-    Done transition for issue {{ inputs.issue_ref }}{% else %}on a successful merge
+    keyword closes issue {{ inputs.issue_ref }} when the pull request merges, and
+    parent-owned post-merge completion applies the configured Done labels and confirms
+    the closed state{% else %}on a successful merge
     the parent workflow will transition {{ inputs.issue_provider }} issue {{
     inputs.issue_ref }} to Done automatically{% endif %}. If
     the runtime instructions, workflow parameters, authentication, remote configuration,

--- a/docs/Workflows/PrMergeAutomation.md
+++ b/docs/Workflows/PrMergeAutomation.md
@@ -72,8 +72,9 @@ When PR publishing is enabled (`publishMode = "pr"` in `MoonMind.UserWorkflow` p
 7. The resolver child run attempts to remediate and merge.
 8. If resolver pushes a new commit and external review/check signal must be re-established, control returns to the gate.
 9. If the run is Jira-backed and post-merge Jira completion is enabled, `MoonMind.MergeAutomation` completes the selected Jira issue through the trusted Jira activity path after `merged` or `already_merged`.
-10. The parent workflow reaches terminal success only when merge automation returns `merged` or `already_merged` after any required post-merge Jira completion succeeds or no-ops.
-11. Terminal `blocked`, `failed`, or `expired` outcomes fail the parent workflow; terminal `canceled` cancels the parent workflow so operator-initiated cancellation is not reported as failure.
+10. If the run is GitHub-issue-backed and post-merge GitHub completion is enabled, `MoonMind.MergeAutomation` applies the configured Done issue update and confirms the issue is closed after `merged` or `already_merged`.
+11. The parent workflow reaches terminal success only when merge automation returns `merged` or `already_merged` after every required post-merge issue completion succeeds or no-ops.
+12. Terminal `blocked`, `failed`, or `expired` outcomes fail the parent workflow; terminal `canceled` cancels the parent workflow so operator-initiated cancellation is not reported as failure.
 
 ---
 
@@ -260,6 +261,11 @@ The post-merge step is intentionally owned by `MoonMind.MergeAutomation`, not by
 `pr-resolver`. The resolver reports the merge disposition; the workflow performs
 Jira mutation only after that disposition is `merged` or `already_merged`.
 
+GitHub-issue-backed merge automation carries the same ownership rule through a
+compact `postMergeGithub` block containing the canonical repository and issue
+number. `MoonMind.UserWorkflow` derives that identity from structured preset
+inputs and enables required completion by default.
+
 ### 10.2 Post-merge Jira completion
 
 Post-merge Jira completion uses the trusted Jira integration activity boundary.
@@ -291,7 +297,21 @@ If required completion returns `blocked` or `failed`, merge automation does not
 return terminal success. The failure is surfaced as a Jira-sourced blocker with
 operator-visible reason text.
 
-### 10.2.1 Already-implemented no-change completion
+### 10.2.1 Post-merge GitHub completion
+
+Post-merge GitHub completion uses the trusted GitHub issue update activity only
+after merge success. It applies the configured Done actions, including closing
+the issue, adding `status: done`, removing `status: code-review`, and confirming
+the resulting closed state. Pull-request closing keywords remain useful native
+GitHub linkage, but they are not accepted as evidence that configured Done labels
+were applied.
+
+The activity is idempotent across retry and replay: repeating the same Done
+update against an already closed issue preserves the terminal state. Required
+failure produces a GitHub-sourced merge-automation blocker instead of allowing
+the parent workflow to report success.
+
+### 10.2.2 Already-implemented no-change completion
 
 For Jira-oriented PR-publishing runs where PR output is optional, the run may
 finish with no repository changes because the Jira issue is already implemented.
@@ -309,7 +329,7 @@ must state that no confirmation was available.
 
 ### 10.3 Output
 
-Merge automation summaries include compact `postMergeJira` evidence:
+Merge automation summaries include compact post-merge issue evidence:
 
 ```json
 {
@@ -322,6 +342,13 @@ Merge automation summaries include compact `postMergeJira` evidence:
     "transitionName": "Done",
     "alreadyDone": false,
     "transitioned": true
+  },
+  "postMergeGithub": {
+    "status": "succeeded",
+    "repository": "MoonLadderStudios/MoonMind",
+    "issueNumber": 3143,
+    "confirmedState": "closed",
+    "confirmedLabels": ["status: done"]
   },
   "artifactRefs": {
     "postMergeJiraResolution": "artifact-id-resolution",

--- a/moonmind/schemas/temporal_models.py
+++ b/moonmind/schemas/temporal_models.py
@@ -1646,6 +1646,45 @@ class MergeAutomationPostMergeJiraModel(BaseModel):
     def _validate_fields(cls, value: Any) -> dict[str, Any]:
         return validate_compact_temporal_mapping(value, field_name="postMergeJira.fields")
 
+
+class MergeAutomationPostMergeGithubModel(BaseModel):
+    """Runtime policy for GitHub issue completion after verified merge success."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    enabled: bool = Field(False, alias="enabled")
+    repository: str | None = Field(None, alias="repository")
+    issue_number: int | None = Field(None, alias="issueNumber")
+    required: bool = Field(True, alias="required")
+
+    @field_validator("repository", mode="before")
+    @classmethod
+    def _normalize_repository(cls, value: Any) -> str | None:
+        if value is None:
+            return None
+        candidate = str(value).strip()
+        return candidate or None
+
+    @field_validator("issue_number", mode="before")
+    @classmethod
+    def _normalize_issue_number(cls, value: Any) -> int | None:
+        if value is None or value == "":
+            return None
+        try:
+            candidate = int(value)
+        except (TypeError, ValueError):
+            return None
+        return candidate if candidate > 0 else None
+
+    @model_validator(mode="after")
+    def _require_identity_when_enabled(self) -> "MergeAutomationPostMergeGithubModel":
+        if self.enabled and (not self.repository or self.issue_number is None):
+            raise ValueError(
+                "Enabled postMergeGithub requires repository and issueNumber."
+            )
+        return self
+
+
 class MergeAutomationConfigModel(BaseModel):
     """Full merge automation configuration carried by workflow input."""
 
@@ -1666,6 +1705,10 @@ class MergeAutomationConfigModel(BaseModel):
     post_merge_jira: MergeAutomationPostMergeJiraModel = Field(
         default_factory=MergeAutomationPostMergeJiraModel,
         alias="postMergeJira",
+    )
+    post_merge_github: MergeAutomationPostMergeGithubModel = Field(
+        default_factory=MergeAutomationPostMergeGithubModel,
+        alias="postMergeGithub",
     )
 
 ReadinessBlockerKind = Literal[

--- a/moonmind/workflows/executions/preset_expansion.py
+++ b/moonmind/workflows/executions/preset_expansion.py
@@ -59,6 +59,7 @@ async def expand_preset_for_child_run(
     session: Any,
     initial_parameters: Mapping[str, Any] | None,
     allow_goal_schedule: bool = True,
+    user_id: Any | None = None,
 ) -> dict[str, Any]:
     """Expand stored preset provenance into executable workflow steps."""
 
@@ -150,6 +151,8 @@ async def expand_preset_for_child_run(
         "context": template_context,
         "options": ExpandOptions(should_enforce_step_limit=True),
     }
+    if user_id is not None:
+        expand_kwargs["user_id"] = user_id
     try:
         expanded = await catalog.expand_template(**expand_kwargs)
     except PresetNotFoundError:
@@ -185,6 +188,20 @@ async def expand_preset_for_child_run(
             for item in authored_presets
         ]
     task_payload["steps"] = list(expanded_steps)
+    expanded_publish = (
+        expanded.get("publish") if isinstance(expanded, Mapping) else None
+    )
+    if isinstance(expanded_publish, Mapping) and not isinstance(
+        task_payload.get("publish"), Mapping
+    ):
+        task_payload["publish"] = dict(expanded_publish)
+    expanded_checkpoint_branching = (
+        expanded.get("checkpointBranching")
+        if isinstance(expanded, Mapping)
+        else None
+    )
+    if isinstance(expanded_checkpoint_branching, Mapping):
+        task_payload["checkpointBranching"] = dict(expanded_checkpoint_branching)
     task_payload["appliedStepTemplates"] = [applied_template_payload]
     task_payload["taskTemplate"] = {
         **template_payload,

--- a/moonmind/workflows/executions/preset_expansion.py
+++ b/moonmind/workflows/executions/preset_expansion.py
@@ -134,6 +134,15 @@ async def expand_preset_for_child_run(
     if isinstance(repository, str) and repository.strip():
         template_context["repository"] = repository.strip()
         template_context["repo"] = repository.strip()
+    git_payload = _coerce_mapping(task_payload.get("git"))
+    branch = (
+        git_payload.get("branch")
+        or git_payload.get("startingBranch")
+        or task_payload.get("branch")
+        or task_payload.get("startingBranch")
+    )
+    if isinstance(branch, str) and branch.strip():
+        template_context["branch"] = branch.strip()
     runtime_payload = _coerce_mapping(task_payload.get("runtime"))
     target_runtime = (
         parameters.get("targetRuntime")
@@ -200,7 +209,9 @@ async def expand_preset_for_child_run(
         if isinstance(expanded, Mapping)
         else None
     )
-    if isinstance(expanded_checkpoint_branching, Mapping):
+    if isinstance(expanded_checkpoint_branching, Mapping) and not isinstance(
+        task_payload.get("checkpointBranching"), Mapping
+    ):
         task_payload["checkpointBranching"] = dict(expanded_checkpoint_branching)
     task_payload["appliedStepTemplates"] = [applied_template_payload]
     task_payload["taskTemplate"] = {

--- a/moonmind/workflows/temporal/activity_catalog.py
+++ b/moonmind/workflows/temporal/activity_catalog.py
@@ -920,6 +920,15 @@ def build_default_activity_catalog(
             retries=_activity_retries(max_attempts=3, max_interval_seconds=60),
         ),
         TemporalActivityDefinition(
+            activity_type="merge_automation.complete_post_merge_github",
+            family="merge_automation",
+            capability_class="integration:github",
+            task_queue=cfg.activity_integrations_task_queue,
+            fleet=INTEGRATIONS_FLEET,
+            timeouts=TemporalActivityTimeouts(120, 300),
+            retries=_activity_retries(max_attempts=3, max_interval_seconds=60),
+        ),
+        TemporalActivityDefinition(
             activity_type="pr_resolver.resolve_selector",
             family="pr_resolver",
             capability_class="integration:github",

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -1256,6 +1256,10 @@ _ACTIVITY_HANDLER_ATTRS: dict[str, tuple[str, str]] = {
         "integrations",
         "merge_automation_complete_post_merge_jira",
     ),
+    "merge_automation.complete_post_merge_github": (
+        "integrations",
+        "merge_automation_complete_post_merge_github",
+    ),
     "pr_resolver.resolve_selector": (
         "integrations",
         "pr_resolver_resolve_selector",
@@ -4942,6 +4946,42 @@ class TemporalIntegrationActivities:
             transition_issue=transition_issue,
         )
         return decision.model_dump(by_alias=True, mode="json")
+
+    async def merge_automation_complete_post_merge_github(self, payload, /, **kwargs):
+        config = payload.get("postMergeGithub") if isinstance(payload, Mapping) else None
+        if not isinstance(config, Mapping):
+            return {
+                "status": "blocked",
+                "required": True,
+                "reason": "Post-merge GitHub completion payload is invalid.",
+            }
+
+        from moonmind.workflows.temporal.story_output_tools import (
+            update_github_issue_status,
+        )
+
+        required = bool(config.get("required", True))
+        repository = str(config.get("repository") or "").strip()
+        issue_number = config.get("issueNumber") or config.get("issue_number")
+        result = await update_github_issue_status(
+            {
+                "repository": repository,
+                "issueNumber": issue_number,
+                "mode": "done",
+            }
+        )
+        outputs = dict(result.outputs)
+        succeeded = (
+            result.status == "COMPLETED"
+            and outputs.get("confirmedState") == "closed"
+        )
+        return {
+            "status": "succeeded" if succeeded else "failed",
+            "required": required,
+            "repository": repository,
+            "issueNumber": issue_number,
+            **outputs,
+        }
 
     async def pr_resolver_resolve_selector(self, payload, /, **kwargs):
         """Resolve a PR number, URL, or branch to one canonical PR identity."""

--- a/moonmind/workflows/temporal/workflows/merge_automation.py
+++ b/moonmind/workflows/temporal/workflows/merge_automation.py
@@ -94,6 +94,7 @@ class MoonMindMergeAutomationWorkflow:
         self._post_merge_jira_resolution_artifact_ref: str | None = None
         self._post_merge_jira_transition_artifact_ref: str | None = None
         self._post_merge_jira_result: dict[str, Any] | None = None
+        self._post_merge_github_result: dict[str, Any] | None = None
         self._external_event_count = 0
         self._refresh_tracked_head_sha_on_next_evaluation = False
         self._summary: str | None = None
@@ -134,6 +135,8 @@ class MoonMindMergeAutomationWorkflow:
             payload["summary"] = self._summary
         if self._post_merge_jira_result is not None:
             payload["postMergeJira"] = dict(self._post_merge_jira_result)
+        if self._post_merge_github_result is not None:
+            payload["postMergeGithub"] = dict(self._post_merge_github_result)
         return payload
 
     @staticmethod
@@ -524,6 +527,72 @@ class MoonMindMergeAutomationWorkflow:
             return False
         return True
 
+    async def _complete_post_merge_github(
+        self,
+        *,
+        resolver_disposition: str,
+    ) -> bool:
+        if self._input is None:
+            return True
+        if not self._input.config.post_merge_github.enabled:
+            return True
+        decision = await workflow.execute_activity(
+            "merge_automation.complete_post_merge_github",
+            {
+                "parentWorkflowId": self._input.parent_workflow_id,
+                "parentRunId": self._input.parent_run_id,
+                "resolverDisposition": resolver_disposition,
+                "pullRequest": self._input.pull_request.model_dump(
+                    by_alias=True, mode="json"
+                ),
+                "postMergeGithub": self._input.config.post_merge_github.model_dump(
+                    by_alias=True, mode="json"
+                ),
+            },
+            start_to_close_timeout=timedelta(minutes=2),
+            task_queue=INTEGRATIONS_TASK_QUEUE,
+            retry_policy=DEFAULT_ACTIVITY_RETRY_POLICY,
+            cancellation_type=ActivityCancellationType.TRY_CANCEL,
+        )
+        decision_map = dict(decision) if isinstance(decision, Mapping) else {}
+        self._post_merge_github_result = decision_map
+        status = str(decision_map.get("status") or "").strip()
+        required = bool(decision_map.get("required", True))
+        if required and status in {"blocked", "failed"}:
+            reason = str(
+                decision_map.get("reason")
+                or decision_map.get("summary")
+                or "Required post-merge GitHub completion did not succeed."
+            ).strip()
+            self._status = STATE_FAILED
+            self._summary = reason
+            self._blockers = [
+                ReadinessBlockerModel.model_validate(
+                    {
+                        "kind": DISPOSITION_FAILED,
+                        "summary": reason,
+                        "retryable": False,
+                        "source": "github",
+                    }
+                )
+            ]
+            self._publish_visibility()
+            return False
+        return True
+
+    async def _complete_post_merge_integrations(
+        self,
+        *,
+        resolver_disposition: str,
+    ) -> bool:
+        if not await self._complete_post_merge_jira(
+            resolver_disposition=resolver_disposition
+        ):
+            return False
+        return await self._complete_post_merge_github(
+            resolver_disposition=resolver_disposition
+        )
+
     async def _evaluate_readiness_once(self) -> tuple[Any, Any]:
         if self._input is None:
             evaluation: dict[str, Any] = {}
@@ -588,7 +657,7 @@ class MoonMindMergeAutomationWorkflow:
             "Pull request is already merged; recovered after resolver "
             "disposition validation failed."
         )
-        if not await self._complete_post_merge_jira(
+        if not await self._complete_post_merge_integrations(
             resolver_disposition=DISPOSITION_ALREADY_MERGED
         ):
             return RESOLVER_ISSUE_RECOVERY_COMPLETED, await self._finish()
@@ -641,7 +710,7 @@ class MoonMindMergeAutomationWorkflow:
             await self._write_gate_snapshot(evidence_ready=evidence.ready)
             if evidence.pull_request_merged:
                 self._refresh_tracked_head_sha(evaluation)
-                if not await self._complete_post_merge_jira(
+                if not await self._complete_post_merge_integrations(
                     resolver_disposition=DISPOSITION_ALREADY_MERGED
                 ):
                     return await self._finish()
@@ -768,7 +837,7 @@ class MoonMindMergeAutomationWorkflow:
                     self._publish_visibility()
                     continue
                 if resolver_disposition == DISPOSITION_ALREADY_MERGED:
-                    if not await self._complete_post_merge_jira(
+                    if not await self._complete_post_merge_integrations(
                         resolver_disposition=resolver_disposition
                     ):
                         return await self._finish()
@@ -777,7 +846,7 @@ class MoonMindMergeAutomationWorkflow:
                     self._publish_visibility()
                     return await self._finish()
                 if resolver_disposition == DISPOSITION_MERGED:
-                    if not await self._complete_post_merge_jira(
+                    if not await self._complete_post_merge_integrations(
                         resolver_disposition=resolver_disposition
                     ):
                         return await self._finish()

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -13505,6 +13505,22 @@ class MoonMindRunWorkflow:
             if effective_jira_issue_key and "required" not in post_merge_jira:
                 post_merge_jira["required"] = True
             post_merge_jira.setdefault("strategy", "done_category")
+            raw_post_merge_github = candidate.get(
+                "postMergeGithub"
+            ) or candidate.get("post_merge_github")
+            post_merge_github = (
+                dict(raw_post_merge_github)
+                if isinstance(raw_post_merge_github, Mapping)
+                else {}
+            )
+            github_issue = self._canonical_github_issue_from_parameters(parameters)
+            if github_issue:
+                post_merge_github.setdefault("enabled", True)
+                post_merge_github.setdefault("required", True)
+                post_merge_github.setdefault("repository", github_issue["repository"])
+                post_merge_github.setdefault(
+                    "issueNumber", github_issue["issueNumber"]
+                )
             return {
                 "enabled": True,
                 "checks": self._coerce_text(candidate.get("checks"), max_chars=20)
@@ -13527,6 +13543,7 @@ class MoonMindRunWorkflow:
                 or "squash",
                 "jiraIssueKey": effective_jira_issue_key,
                 "postMergeJira": post_merge_jira,
+                "postMergeGithub": post_merge_github,
                 "fallbackPollSeconds": (
                     candidate.get("fallbackPollSeconds")
                     or candidate.get("fallback_poll_seconds")
@@ -13541,6 +13558,48 @@ class MoonMindRunWorkflow:
                     or timeout_config.get("expire_after_seconds")
                 ),
             }
+        return None
+
+    def _canonical_github_issue_from_parameters(
+        self,
+        parameters: Mapping[str, Any],
+    ) -> dict[str, Any] | None:
+        task_payload = self._mapping_value(parameters, "workflow")
+        if not task_payload:
+            task_payload = self._mapping_value(parameters, "task")
+        mappings: list[Mapping[str, Any]] = [parameters, task_payload]
+        for source in (parameters, task_payload):
+            for key in ("inputs", "input"):
+                nested = source.get(key)
+                if isinstance(nested, Mapping):
+                    mappings.append(nested)
+        templates = task_payload.get("appliedStepTemplates")
+        if isinstance(templates, Sequence) and not isinstance(
+            templates, (str, bytes)
+        ):
+            for template in templates:
+                if not isinstance(template, Mapping):
+                    continue
+                mappings.append(template)
+                nested = template.get("inputs")
+                if isinstance(nested, Mapping):
+                    mappings.append(nested)
+        for mapping in mappings:
+            issue = mapping.get("github_issue") or mapping.get("githubIssue")
+            if not isinstance(issue, Mapping):
+                continue
+            repository = self._coerce_text(
+                issue.get("repository") or issue.get("repo"), max_chars=240
+            )
+            try:
+                issue_number = int(issue.get("number") or issue.get("issueNumber"))
+            except (TypeError, ValueError):
+                issue_number = 0
+            if repository and issue_number > 0:
+                return {
+                    "repository": repository,
+                    "issueNumber": issue_number,
+                }
         return None
 
     def _canonical_jira_issue_key_from_parameters(
@@ -13808,6 +13867,7 @@ class MoonMindRunWorkflow:
                 },
                 "timeouts": timeouts,
                 "postMergeJira": request.get("postMergeJira") or {},
+                "postMergeGithub": request.get("postMergeGithub") or {},
             },
             "resolverTemplate": resolver_template,
             "idempotencyKey": (
@@ -13884,6 +13944,9 @@ class MoonMindRunWorkflow:
         post_merge_jira = result_map.get("postMergeJira")
         if isinstance(post_merge_jira, Mapping):
             summary["postMergeJira"] = dict(post_merge_jira)
+        post_merge_github = result_map.get("postMergeGithub")
+        if isinstance(post_merge_github, Mapping):
+            summary["postMergeGithub"] = dict(post_merge_github)
         return summary
 
     async def _complete_already_implemented_jira_if_needed(

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -766,6 +766,60 @@ async def test_goal_preset_submission_expands_before_planner(tmp_path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_explicit_github_issue_template_expands_before_planner(tmp_path) -> None:
+    db_url = f"sqlite+aiosqlite:///{tmp_path}/explicit_github_preset.db"
+    engine = create_async_engine(db_url, future=True)
+    session_factory = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    try:
+        async with session_factory() as session:
+            task_payload = {
+                "title": "Implement GitHub issue",
+                "instructions": (
+                    "Implement GitHub issue MoonLadderStudios/MoonMind#3143."
+                ),
+                "taskTemplate": {
+                    "slug": "github-issue-implement",
+                    "scope": "global",
+                },
+                "inputs": {
+                    "github_issue": {
+                        "repository": "MoonLadderStudios/MoonMind",
+                        "number": 3143,
+                    },
+                    "run_verify": True,
+                },
+            }
+            await _expand_goal_preset_for_workflow_submission(
+                task_payload=task_payload,
+                request_payload={
+                    "repository": "MoonLadderStudios/MoonMind",
+                    "targetRuntime": "codex_cli",
+                },
+                session=session,
+                user_id=uuid4(),
+            )
+    finally:
+        await engine.dispose()
+
+    assert len(task_payload["steps"]) == 20
+    assert task_payload["steps"][0]["tool"]["id"] == (
+        "github.load_issue_preset_brief"
+    )
+    assert task_payload["steps"][-1]["tool"]["id"] == (
+        "github.update_issue_status"
+    )
+    assert task_payload["appliedStepTemplates"][0]["slug"] == (
+        "github-issue-implement"
+    )
+    assert "Closes MoonLadderStudios/MoonMind#3143" in task_payload["steps"][-2][
+        "instructions"
+    ]
+
+
+@pytest.mark.asyncio
 async def test_goal_preset_submission_uses_default_runtime_for_composite_context(
     tmp_path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -748,7 +748,7 @@ async def test_goal_preset_submission_expands_before_planner(tmp_path) -> None:
                     "targetRuntime": "codex_cli",
                 },
                 session=session,
-                user_id=uuid4(),
+                user=SimpleNamespace(id=uuid4(), is_superuser=False),
             )
     finally:
         await engine.dispose()
@@ -799,7 +799,7 @@ async def test_explicit_github_issue_template_expands_before_planner(tmp_path) -
                     "targetRuntime": "codex_cli",
                 },
                 session=session,
-                user_id=uuid4(),
+                user=SimpleNamespace(id=uuid4(), is_superuser=False),
             )
     finally:
         await engine.dispose()
@@ -817,6 +817,117 @@ async def test_explicit_github_issue_template_expands_before_planner(tmp_path) -
     assert "Closes MoonLadderStudios/MoonMind#3143" in task_payload["steps"][-2][
         "instructions"
     ]
+
+
+@pytest.mark.asyncio
+async def test_explicit_template_rejects_another_users_personal_scope() -> None:
+    owner_id = uuid4()
+    caller_id = uuid4()
+    task_payload = {
+        "taskTemplate": {
+            "slug": "private-preset",
+            "scope": "personal",
+            "scopeRef": str(owner_id),
+        }
+    }
+
+    with pytest.raises(HTTPException) as exc_info:
+        await _expand_goal_preset_for_workflow_submission(
+            task_payload=task_payload,
+            request_payload={},
+            session=object(),
+            user=SimpleNamespace(id=caller_id, is_superuser=False),
+        )
+
+    assert exc_info.value.status_code == 403
+    assert exc_info.value.detail["code"] == "template_scope_forbidden"
+
+
+@pytest.mark.asyncio
+async def test_explicit_template_maps_missing_preset_to_not_found(tmp_path) -> None:
+    db_url = f"sqlite+aiosqlite:///{tmp_path}/missing_explicit_preset.db"
+    engine = create_async_engine(db_url, future=True)
+    session_factory = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    try:
+        async with session_factory() as session:
+            with pytest.raises(HTTPException) as exc_info:
+                await _expand_goal_preset_for_workflow_submission(
+                    task_payload={
+                        "taskTemplate": {
+                            "slug": "missing-explicit-preset",
+                            "scope": "global",
+                        }
+                    },
+                    request_payload={},
+                    session=session,
+                    user=SimpleNamespace(id=uuid4(), is_superuser=False),
+                )
+            with pytest.raises(HTTPException) as validation_exc_info:
+                await _expand_goal_preset_for_workflow_submission(
+                    task_payload={
+                        "taskTemplate": {
+                            "slug": "github-issue-implement",
+                            "scope": "global",
+                        },
+                        "inputs": {},
+                    },
+                    request_payload={},
+                    session=session,
+                    user=SimpleNamespace(id=uuid4(), is_superuser=False),
+                )
+    finally:
+        await engine.dispose()
+
+    assert exc_info.value.status_code == 404
+    assert exc_info.value.detail["code"] == "template_not_found"
+    assert validation_exc_info.value.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_explicit_template_preserves_branch_and_checkpoint_overrides(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    class FakePresetCatalogService:
+        def __init__(self, session: Any) -> None:
+            self.session = session
+
+        async def expand_template(self, **kwargs: Any) -> dict[str, Any]:
+            captured.update(kwargs)
+            return {
+                "steps": [{"id": "step-1", "title": "Run", "instructions": "Run"}],
+                "appliedTemplate": {
+                    "slug": kwargs["slug"],
+                    "inputs": kwargs["inputs"],
+                    "stepIds": ["step-1"],
+                    "appliedAt": "2026-07-12T00:00:00+00:00",
+                },
+                "checkpointBranching": {"enabled": True},
+            }
+
+    monkeypatch.setattr(
+        "api_service.services.presets.catalog.PresetCatalogService",
+        FakePresetCatalogService,
+    )
+    task_payload = {
+        "taskTemplate": {"slug": "branch-aware", "scope": "global"},
+        "git": {"branch": "release/next"},
+        "checkpointBranching": {"enabled": False},
+    }
+
+    await _expand_goal_preset_for_workflow_submission(
+        task_payload=task_payload,
+        request_payload={"repository": "MoonLadderStudios/MoonMind"},
+        session=object(),
+        user=SimpleNamespace(id=uuid4(), is_superuser=False),
+    )
+
+    assert captured["context"]["branch"] == "release/next"
+    assert task_payload["checkpointBranching"] == {"enabled": False}
 
 
 @pytest.mark.asyncio
@@ -841,7 +952,7 @@ async def test_goal_preset_submission_uses_default_runtime_for_composite_context
                 task_payload=task_payload,
                 request_payload={"repository": "MoonLadderStudios/MoonMind"},
                 session=session,
-                user_id=uuid4(),
+                user=SimpleNamespace(id=uuid4(), is_superuser=False),
             )
     finally:
         await engine.dispose()
@@ -915,7 +1026,7 @@ async def test_goal_preset_submission_carries_expanded_checkpoint_branching(
         task_payload=task_payload,
         request_payload={"repository": "MoonLadderStudios/MoonMind"},
         session=object(),
-        user_id=uuid4(),
+        user=SimpleNamespace(id=uuid4(), is_superuser=False),
     )
 
     assert task_payload["checkpointBranching"]["enabled"] is True

--- a/tests/unit/api/test_presets_service.py
+++ b/tests/unit/api/test_presets_service.py
@@ -3418,6 +3418,9 @@ async def test_seed_catalog_github_issue_implement_expands_shared_includes(tmp_p
     assert "controlling post-remediation moonspec-verify verdict is FULLY_IMPLEMENTED" in (
         expanded["steps"][18]["instructions"]
     )
+    assert "Closes MoonLadderStudios/MoonMind#123" in expanded["steps"][18][
+        "instructions"
+    ]
     assert (
         "recover that field's full content through the trusted MoonMind tool surface"
         in expanded["steps"][1]["instructions"]

--- a/tests/unit/workflows/temporal/test_activity_runtime.py
+++ b/tests/unit/workflows/temporal/test_activity_runtime.py
@@ -94,6 +94,52 @@ from moonmind.workflows.temporal.artifacts import (
     TemporalArtifactValidationError,
     build_artifact_ref,
 )
+
+
+@pytest.mark.asyncio
+async def test_post_merge_github_completion_applies_done_status(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from moonmind.workflows.temporal import story_output_tools
+
+    captured: dict[str, Any] = {}
+
+    async def fake_update_github_issue_status(inputs, _context=None):
+        captured.update(inputs)
+        return SimpleNamespace(
+            status="COMPLETED",
+            outputs={
+                "confirmedState": "closed",
+                "confirmedLabels": ["status: done"],
+                "appliedActions": ["patch_issue"],
+            },
+        )
+
+    monkeypatch.setattr(
+        story_output_tools,
+        "update_github_issue_status",
+        fake_update_github_issue_status,
+    )
+
+    result = await TemporalIntegrationActivities.merge_automation_complete_post_merge_github(
+        object(),
+        {
+            "postMergeGithub": {
+                "enabled": True,
+                "required": True,
+                "repository": "MoonLadderStudios/MoonMind",
+                "issueNumber": 3143,
+            }
+        },
+    )
+
+    assert captured == {
+        "repository": "MoonLadderStudios/MoonMind",
+        "issueNumber": 3143,
+        "mode": "done",
+    }
+    assert result["status"] == "succeeded"
+    assert result["confirmedLabels"] == ["status: done"]
 from moonmind.workflows.temporal.report_artifacts import validate_report_bundle_result
 from moonmind.workflows.temporal.runtime.store import ManagedRunStore
 from moonmind.workloads.registry import RunnerProfileRegistry

--- a/tests/unit/workflows/temporal/test_merge_gate_models.py
+++ b/tests/unit/workflows/temporal/test_merge_gate_models.py
@@ -94,6 +94,11 @@ def test_post_merge_jira_config_rejects_unsupported_strategy() -> None:
     with pytest.raises(ValidationError):
         MergeAutomationPostMergeJiraModel(strategy="first_transition")
 
+
+def test_post_merge_github_requires_issue_identity_when_enabled() -> None:
+    with pytest.raises(ValidationError):
+        MergeAutomationConfigModel(postMergeGithub={"enabled": True})
+
 def test_merge_automation_start_accepts_missing_post_merge_jira_for_compatibility() -> None:
     payload = MergeAutomationStartInput(
         workflowType="MoonMind.MergeAutomation",
@@ -104,5 +109,7 @@ def test_merge_automation_start_accepts_missing_post_merge_jira_for_compatibilit
     )
 
     assert payload.config.post_merge_jira.enabled is False
+    assert payload.config.post_merge_github.enabled is False
     dumped = payload.model_dump(by_alias=True)
     assert "postMergeJira" in dumped["mergeAutomationConfig"]
+    assert "postMergeGithub" in dumped["mergeAutomationConfig"]

--- a/tests/unit/workflows/temporal/test_run_merge_gate_start.py
+++ b/tests/unit/workflows/temporal/test_run_merge_gate_start.py
@@ -46,6 +46,67 @@ def test_merge_automation_request_can_be_enabled_from_task_publish() -> None:
     assert request["mergeMethod"] == "squash"
     assert request["jiraIssueKey"] == "MM-341"
 
+
+def test_merge_automation_request_infers_github_issue_completion() -> None:
+    workflow = MoonMindRunWorkflow()
+
+    request = workflow._merge_automation_request(
+        {
+            "publishMode": "pr",
+            "mergeAutomation": {"enabled": True},
+            "workflow": {
+                "inputs": {
+                    "github_issue": {
+                        "repository": "MoonLadderStudios/MoonMind",
+                        "number": 3143,
+                    }
+                }
+            },
+        }
+    )
+
+    assert request is not None
+    assert request["postMergeGithub"] == {
+        "enabled": True,
+        "required": True,
+        "repository": "MoonLadderStudios/MoonMind",
+        "issueNumber": 3143,
+    }
+
+
+def test_merge_gate_start_payload_carries_post_merge_github_completion() -> None:
+    workflow = MoonMindRunWorkflow()
+    workflow._repo = "MoonLadderStudios/MoonMind"
+    workflow._publish_context["branch"] = "implement-3143"
+    workflow._publish_context["baseRef"] = "main"
+
+    payload = workflow._build_merge_gate_start_payload(
+        parameters={
+            "publishMode": "pr",
+            "mergeAutomation": {"enabled": True},
+            "workflow": {
+                "inputs": {
+                    "github_issue": {
+                        "repository": "MoonLadderStudios/MoonMind",
+                        "number": 3143,
+                    }
+                }
+            },
+        },
+        pull_request_url="https://github.com/MoonLadderStudios/MoonMind/pull/3225",
+        head_sha="abc123",
+        parent_workflow_id="mm:github-issue",
+        parent_run_id="run-1",
+    )
+
+    assert payload is not None
+    assert payload["mergeAutomationConfig"]["postMergeGithub"] == {
+        "enabled": True,
+        "required": True,
+        "repository": "MoonLadderStudios/MoonMind",
+        "issueNumber": 3143,
+    }
+
 def test_merge_automation_request_infers_jira_orchestrate_issue_key() -> None:
     workflow = MoonMindRunWorkflow()
 

--- a/tests/unit/workflows/temporal/workflows/test_merge_automation_temporal.py
+++ b/tests/unit/workflows/temporal/workflows/test_merge_automation_temporal.py
@@ -59,6 +59,18 @@ def _payload_with_post_merge_jira(**post_merge_overrides: Any) -> dict[str, Any]
     }
     return payload
 
+
+def _payload_with_post_merge_github(**post_merge_overrides: Any) -> dict[str, Any]:
+    payload = _payload()
+    payload["mergeAutomationConfig"]["postMergeGithub"] = {
+        "enabled": True,
+        "required": True,
+        "repository": "MoonLadderStudios/MoonMind",
+        "issueNumber": 3143,
+        **post_merge_overrides,
+    }
+    return payload
+
 MERGE_AUTOMATION_WORKFLOW_ID = "merge-automation:wf-parent"
 
 
@@ -1072,6 +1084,79 @@ async def test_merge_automation_runs_post_merge_jira_before_merged_success(
         "merge_automation.complete_post_merge_jira"
     )
     assert result["postMergeJira"]["status"] == "succeeded"
+
+
+@pytest.mark.asyncio
+async def test_merge_automation_runs_post_merge_github_before_merged_success(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workflow = MoonMindMergeAutomationWorkflow()
+    activity_calls: list[str] = []
+
+    async def fake_execute_activity(
+        activity_type: str,
+        payload: dict[str, Any],
+        **_kwargs: Any,
+    ) -> dict[str, Any]:
+        activity_calls.append(activity_type)
+        if activity_type == "merge_automation.evaluate_readiness":
+            return {
+                "headSha": "abc123",
+                "ready": True,
+                "pullRequestOpen": True,
+                "policyAllowed": True,
+                "checksComplete": True,
+                "checksPassing": True,
+                "automatedReviewComplete": True,
+                "jiraStatusAllowed": True,
+            }
+        if activity_type == "merge_automation.complete_post_merge_github":
+            assert payload["resolverDisposition"] == "merged"
+            assert payload["postMergeGithub"]["issueNumber"] == 3143
+            return {
+                "status": "succeeded",
+                "required": True,
+                "confirmedState": "closed",
+                "confirmedLabels": ["status: done"],
+            }
+        raise AssertionError(activity_type)
+
+    async def fake_execute_child_workflow(
+        _workflow_type: str,
+        _payload: dict[str, Any],
+        **_kwargs: Any,
+    ) -> dict[str, Any]:
+        return {"status": "success", "mergeAutomationDisposition": "merged"}
+
+    monkeypatch.setattr(
+        merge_automation_module.workflow, "execute_activity", fake_execute_activity
+    )
+    monkeypatch.setattr(
+        merge_automation_module.workflow,
+        "execute_child_workflow",
+        fake_execute_child_workflow,
+    )
+    monkeypatch.setattr(
+        merge_automation_module.workflow,
+        "now",
+        lambda: datetime.now(timezone.utc),
+    )
+    monkeypatch.setattr(
+        merge_automation_module.workflow, "upsert_memo", lambda _memo: None
+    )
+    monkeypatch.setattr(
+        merge_automation_module.workflow,
+        "upsert_search_attributes",
+        lambda _attrs: None,
+    )
+
+    result = await workflow.run(_payload_with_post_merge_github())
+
+    assert result["status"] == "merged"
+    assert activity_calls.index("merge_automation.evaluate_readiness") < (
+        activity_calls.index("merge_automation.complete_post_merge_github")
+    )
+    assert result["postMergeGithub"]["confirmedState"] == "closed"
 
 @pytest.mark.asyncio
 async def test_merge_automation_blocks_when_required_post_merge_jira_blocks(


### PR DESCRIPTION
## Summary

- expand explicit `taskTemplate` submissions before workflow planning so the GitHub Issue Implement lifecycle steps actually run
- preserve expanded preset publish and checkpoint metadata through the shared expansion path
- require GitHub issue implementation pull requests to include a closing keyword so merge is the authoritative issue-completion handoff
- add regression coverage for the exact unexpanded request shape recorded by workflow `mm:e91a526a-ed02-4627-82f5-c8cac4045582`

## Root cause

The submission carried `taskTemplate.slug = github-issue-implement` but no expanded steps. The API classified the template itself as an already-authored workflow and skipped expansion, producing a one-node generic agent plan. None of the preset's GitHub lifecycle tools ran. The fallback publisher then created and merged a PR whose body only referenced the issue, so GitHub had no closing keyword to apply after merge.

## Impact

Explicit preset submissions now execute the configured issue brief, status, implementation, verification, PR handoff, and finalization steps. GitHub-backed implementation PRs close their source issue only after the PR merges.

## Verification

- `.venv/bin/pytest -q tests/unit/api/test_presets_service.py` — 96 passed
- focused preset-expansion regression tests — 6 passed
- `MOONMIND_TEST_COMPOSE_PROJECT_NAME=moonmind-test-preset-close ./tools/test_integration.sh` — 432 passed, 1 skipped

Closes #3143