### PR TITLE
Implement improvements for a number of UI elements in MoonMind: 1. The border around the radio buttons in the top left is slightly too far away from t

### DIFF
--- a/frontend/src/entrypoints/dashboard-app.tsx
+++ b/frontend/src/entrypoints/dashboard-app.tsx
@@ -21,7 +21,7 @@ import {
   useNavigate,
 } from 'react-router-dom';
 import { QueryErrorResetBoundary, useQuery, useQueryClient } from '@tanstack/react-query';
-import { PanelLeft, Rows3, ScrollText, Square } from 'lucide-react';
+import { PanelLeft, Plus, Rows3, ScrollText, Square } from 'lucide-react';
 import {
   RocketIcon,
   type RocketIconHandle,
@@ -63,6 +63,7 @@ import {
   workflowListApiQueryFromContext,
 } from '../lib/workflowListContext';
 import { requestWorkflowStartRouteChange } from '../lib/workflowStartRouteGuard';
+import { requestSkillsCreate } from '../lib/skillsCreateRequest';
 import { decodeWorkflowIdFromPath } from '../lib/workflowDetailRoutes';
 
 type PageComponent = ComponentType<{ payload: BootPayload }>;
@@ -673,6 +674,8 @@ function DashboardNavigation({
   const location = useLocation();
   const isWorkflowStart = location.pathname.replace(/\/$/, '') === '/workflows/new';
   const isWorkflowDetail = location.pathname.startsWith('/workflows/') && !isWorkflowStart;
+  const normalizedPath = location.pathname.replace(/\/$/, '');
+  const isSkillsRoute = normalizedPath === '/skills' || normalizedPath.startsWith('/skills/');
   const visiblePrimaryKeys = new Set(visiblePrimaryDestinations(uiInfo).map(({ key }) => key));
   const buildId = typeof uiInfo?.buildId === 'string' && uiInfo.buildId.trim() ? uiInfo.buildId : null;
 
@@ -816,6 +819,18 @@ function DashboardNavigation({
             ) : null}
           </div>
           <DashboardSystemMenu uiInfo={uiInfo} mobileDrawerOpen={open} />
+          {isSkillsRoute ? (
+            <button
+              type="button"
+              className="skills-create-nav-button"
+              data-skills-create-trigger
+              onClick={() => requestSkillsCreate()}
+              aria-label="Create New Skill"
+              title="Create New Skill"
+            >
+              <Plus size={18} aria-hidden="true" />
+            </button>
+          ) : null}
         </nav>
       </div>
 

--- a/frontend/src/entrypoints/dashboard-app.tsx
+++ b/frontend/src/entrypoints/dashboard-app.tsx
@@ -819,7 +819,7 @@ function DashboardNavigation({
             ) : null}
           </div>
           <DashboardSystemMenu uiInfo={uiInfo} mobileDrawerOpen={open} />
-          {isSkillsRoute ? (
+          {isSkillsRoute && uiInfo?.features?.skills === true ? (
             <button
               type="button"
               className="skills-create-nav-button"

--- a/frontend/src/entrypoints/dashboard.test.tsx
+++ b/frontend/src/entrypoints/dashboard.test.tsx
@@ -23,6 +23,7 @@ import {
   updateDashboardPreferences,
 } from '../utils/dashboardPreferences';
 import { DASHBOARD_DESTINATIONS } from '../lib/dashboardRoutes';
+import { SKILLS_CREATE_REQUEST_EVENT } from '../lib/skillsCreateRequest';
 
 const animatedNavIconMocks = vi.hoisted(() => ({
   moonStart: vi.fn(),
@@ -1005,6 +1006,42 @@ describe('Dashboard shared entry', () => {
     // Skills mode changes never touch the Workflow or Recurring preferences.
     expect(prefs.workflowListDisplayMode).toBe('sidebar');
     expect(prefs.recurringListDisplayMode).toBe('table');
+  });
+
+  it('mounts the green Create New Skill button in the masthead to the right of System on skill routes', async () => {
+    mockSkillsCatalogFetch(['speckit-orchestrate', 'pr-resolver']);
+
+    window.history.replaceState({}, '', '/skills');
+    renderWithClient(<DashboardApp payload={{ page: 'dashboard', apiBase: '/api' }} />);
+
+    expect(await screen.findByText('Skills page loaded')).toBeTruthy();
+
+    const createButton = screen.getByRole('button', { name: 'Create New Skill' });
+    expect(createButton.classList.contains('skills-create-nav-button')).toBe(true);
+
+    // It lives in the masthead route-nav, immediately after the System dropdown.
+    const systemMenu = document.querySelector<HTMLElement>('.dashboard-system-menu')!;
+    expect(systemMenu).toBeTruthy();
+    expect(createButton.closest('.route-nav')).toBe(systemMenu.closest('.route-nav'));
+    expect(
+      systemMenu.compareDocumentPosition(createButton) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+
+    // Clicking it asks the Skills page to open its create drawer via the window
+    // event (the drawer is owned by the Skills page, not the masthead).
+    const handler = vi.fn();
+    window.addEventListener(SKILLS_CREATE_REQUEST_EVENT, handler);
+    fireEvent.click(createButton);
+    window.removeEventListener(SKILLS_CREATE_REQUEST_EVENT, handler);
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not mount the Create New Skill button off skill routes', async () => {
+    window.history.replaceState({}, '', '/workflows');
+    renderWithClient(<DashboardApp payload={{ page: 'dashboard', apiBase: '/api' }} />);
+
+    await screen.findByText('Workflow list route loaded', {}, { timeout: 10000 });
+    expect(screen.queryByRole('button', { name: 'Create New Skill' })).toBeNull();
   });
 
   it('opens a remembered skill from /skills and clears a stale remembered skill before fallback', async () => {

--- a/frontend/src/entrypoints/dashboard.test.tsx
+++ b/frontend/src/entrypoints/dashboard.test.tsx
@@ -955,11 +955,11 @@ describe('Dashboard shared entry', () => {
     expect(fetchSpy.mock.calls.some(([url]) => String(url) === '/api/recurring-workflows/stale-schedule')).toBe(true);
   });
 
-  function mockSkillsCatalogFetch(skillIds: string[]) {
+  function mockSkillsCatalogFetch(skillIds: string[], uiInfoOverrides: Record<string, unknown> = {}) {
     fetchSpy.mockImplementation((input: RequestInfo | URL) => {
       const url = String(input);
       if (url === '/api/ui/info') {
-        return Promise.resolve({ ok: true, json: async () => uiInfo() } as Response);
+        return Promise.resolve({ ok: true, json: async () => uiInfo(uiInfoOverrides) } as Response);
       }
       if (url === '/api/workflows/skills') {
         return Promise.resolve({
@@ -1041,6 +1041,20 @@ describe('Dashboard shared entry', () => {
     renderWithClient(<DashboardApp payload={{ page: 'dashboard', apiBase: '/api' }} />);
 
     await screen.findByText('Workflow list route loaded', {}, { timeout: 10000 });
+    expect(screen.queryByRole('button', { name: 'Create New Skill' })).toBeNull();
+  });
+
+  it('does not mount the Create New Skill button when the skills feature is disabled', async () => {
+    mockSkillsCatalogFetch(['speckit-orchestrate', 'pr-resolver'], {
+      features: { ...uiInfo().features, skills: false },
+    });
+
+    window.history.replaceState({}, '', '/skills');
+    renderWithClient(<DashboardApp payload={{ page: 'dashboard', apiBase: '/api' }} />);
+
+    // The skills page still renders for the route, but the masthead create
+    // affordance must stay hidden while the skills feature flag is off.
+    expect(await screen.findByText('Skills page loaded')).toBeTruthy();
     expect(screen.queryByRole('button', { name: 'Create New Skill' })).toBeNull();
   });
 

--- a/frontend/src/entrypoints/skills.test.tsx
+++ b/frontend/src/entrypoints/skills.test.tsx
@@ -5,6 +5,14 @@ import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import type { BootPayload } from '../boot/parseBootPayload';
 import { renderWithClient } from '../utils/test-utils';
 import { SkillsPage } from './skills';
+import { SKILLS_CREATE_REQUEST_EVENT } from '../lib/skillsCreateRequest';
+
+// The "Create New Skill" trigger now lives in the masthead nav (outside the
+// SkillsPage subtree these tests mount), so open the drawer the same way the
+// nav button does: by dispatching the create-request window event.
+function requestSkillCreateDrawer() {
+  fireEvent(window, new Event(SKILLS_CREATE_REQUEST_EVENT));
+}
 
 type SkillsDisplayMode = 'hidden' | 'sidebar' | 'table';
 
@@ -391,8 +399,8 @@ describe('Skills Entrypoint', () => {
   it('creates a new skill, refreshes the list, and navigates to the created skill', async () => {
     renderSkills({ path: '/skills' });
 
-    fireEvent.click(await screen.findByRole('button', { name: 'Create New Skill' }));
-    fireEvent.change(screen.getByLabelText('Skill Name'), {
+    requestSkillCreateDrawer();
+    fireEvent.change(await screen.findByLabelText('Skill Name'), {
       target: { value: 'fresh-skill' },
     });
     fireEvent.change(screen.getByLabelText('Skill Markdown'), {
@@ -431,7 +439,7 @@ describe('Skills Entrypoint', () => {
   it('uploads a skill zip, refreshes the list, and navigates to the uploaded skill', async () => {
     renderSkills({ path: '/skills' });
 
-    fireEvent.click(await screen.findByRole('button', { name: 'Create New Skill' }));
+    requestSkillCreateDrawer();
     const file = new File(['zip-content'], 'zip-skill.zip', { type: 'application/zip' });
     fireEvent.change(screen.getByLabelText('Skill Zip'), {
       target: { files: [file] },
@@ -459,7 +467,7 @@ describe('Skills Entrypoint', () => {
   it('keeps the shared skill sidebar mounted while create and upload are open', async () => {
     renderSkills({ path: '/skills/speckit-orchestrate', mode: 'sidebar' });
 
-    fireEvent.click(await screen.findByRole('button', { name: 'Create New Skill' }));
+    requestSkillCreateDrawer();
 
     expect(screen.getByRole('dialog', { name: 'Create or upload skill' })).toBeTruthy();
     expect(screen.getByRole('complementary', { name: 'Skill navigation' })).toBeTruthy();
@@ -497,7 +505,7 @@ describe('Skills Entrypoint', () => {
   it('validates the skill name before submitting a create request', async () => {
     renderSkills({ path: '/skills' });
 
-    fireEvent.click(await screen.findByRole('button', { name: 'Create New Skill' }));
+    requestSkillCreateDrawer();
     fireEvent.change(screen.getByLabelText('Skill Markdown'), {
       target: { value: '# Body\n\nNeeds a name.' },
     });
@@ -528,7 +536,7 @@ describe('Skills Entrypoint', () => {
   it('shows an error when uploading a zip without choosing a file', async () => {
     renderSkills({ path: '/skills' });
 
-    fireEvent.click(await screen.findByRole('button', { name: 'Create New Skill' }));
+    requestSkillCreateDrawer();
     fireEvent.click(screen.getByRole('button', { name: 'Upload Zip' }));
 
     await waitFor(() => {
@@ -544,7 +552,7 @@ describe('Skills Entrypoint', () => {
   it('sends the collision policy when uploading a zip and does not expose the unsupported new-version mode', async () => {
     renderSkills({ path: '/skills' });
 
-    fireEvent.click(await screen.findByRole('button', { name: 'Create New Skill' }));
+    requestSkillCreateDrawer();
     const file = new File(['zip-content'], 'zip-skill.zip', { type: 'application/zip' });
     fireEvent.change(screen.getByLabelText('Skill Zip'), {
       target: { files: [file] },
@@ -569,7 +577,7 @@ describe('Skills Entrypoint', () => {
   it('closes the create drawer when cancel or escape is used', async () => {
     renderSkills({ path: '/skills' });
 
-    fireEvent.click(await screen.findByRole('button', { name: 'Create New Skill' }));
+    requestSkillCreateDrawer();
     expect(screen.getByRole('dialog', { name: 'Create or upload skill' })).toBeTruthy();
 
     fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
@@ -577,7 +585,7 @@ describe('Skills Entrypoint', () => {
       expect(screen.queryByRole('dialog', { name: 'Create or upload skill' })).toBeNull();
     });
 
-    fireEvent.click(screen.getByRole('button', { name: 'Create New Skill' }));
+    requestSkillCreateDrawer();
     const dialog = screen.getByRole('dialog', { name: 'Create or upload skill' });
     expect(dialog).toBeTruthy();
 
@@ -587,13 +595,18 @@ describe('Skills Entrypoint', () => {
     });
   });
 
-  it('traps focus in the create drawer and restores it to the trigger', async () => {
+  it('traps focus in the create drawer and restores it to the nav trigger', async () => {
+    // The real trigger lives in the masthead nav outside this subtree; stand in
+    // for it with a matching element so the drawer's focus-restore has a target.
+    const navTrigger = document.createElement('button');
+    navTrigger.setAttribute('data-skills-create-trigger', '');
+    document.body.appendChild(navTrigger);
+
     renderSkills({ path: '/skills' });
 
-    const trigger = await screen.findByRole('button', { name: 'Create New Skill' });
-    trigger.focus();
-    fireEvent.click(trigger);
-    const dialog = screen.getByRole('dialog', { name: 'Create or upload skill' });
+    navTrigger.focus();
+    requestSkillCreateDrawer();
+    const dialog = await screen.findByRole('dialog', { name: 'Create or upload skill' });
     const close = screen.getByRole('button', { name: 'Close create skill' });
     const lastAction = screen.getByRole('button', { name: 'Upload Zip' });
     dialog.querySelectorAll<HTMLElement>('button, input, textarea, select').forEach((element) => {
@@ -609,7 +622,9 @@ describe('Skills Entrypoint', () => {
     expect(document.activeElement).toBe(close);
 
     fireEvent.keyDown(dialog, { key: 'Escape' });
-    await waitFor(() => expect(document.activeElement).toBe(trigger));
+    await waitFor(() => expect(document.activeElement).toBe(navTrigger));
+
+    navTrigger.remove();
   });
 
   it('renders markdown without unsafe HTML or links', async () => {

--- a/frontend/src/entrypoints/skills.tsx
+++ b/frontend/src/entrypoints/skills.tsx
@@ -10,7 +10,6 @@ import {
 } from 'react';
 import { useMutation, useQuery, useQueryClient, type UseQueryResult } from '@tanstack/react-query';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
-import { Plus } from 'lucide-react';
 import { marked } from 'marked';
 
 import type { BootPayload } from '../boot/parseBootPayload';
@@ -30,6 +29,7 @@ import {
   type CollectionListDisplayMode,
 } from '../lib/collectionListDisplayMode';
 import { updateDashboardPreferences } from '../utils/dashboardPreferences';
+import { SKILLS_CREATE_REQUEST_EVENT } from '../lib/skillsCreateRequest';
 
 /**
  * Normalized Skills catalog item shared by the full table, the sidebar, and
@@ -620,7 +620,6 @@ export function SkillsPage({ payload }: { payload: BootPayload }) {
   const [message, setMessage] = useState<string | null>(null);
 
   const drawerRef = useRef<HTMLDivElement | null>(null);
-  const drawerTriggerRef = useRef<HTMLButtonElement | null>(null);
   const detailHeadingRef = useRef<HTMLHeadingElement | null>(null);
 
   // Selection is route-derived: `/skills/:skillId` selects a skill, `/skills`
@@ -682,7 +681,11 @@ export function SkillsPage({ payload }: { payload: BootPayload }) {
   const closeDrawer = useCallback(() => {
     setIsDrawerOpen(false);
     setMessage(null);
-    drawerTriggerRef.current?.focus();
+    // The trigger now lives in the masthead nav (to the right of System), so
+    // return focus there rather than to a page-local button.
+    if (typeof document !== 'undefined') {
+      document.querySelector<HTMLElement>('[data-skills-create-trigger]')?.focus();
+    }
   }, []);
 
   const openDrawer = useCallback(() => {
@@ -690,6 +693,14 @@ export function SkillsPage({ payload }: { payload: BootPayload }) {
     setShowCreatePreview(false);
     setIsDrawerOpen(true);
   }, []);
+
+  // The masthead "+" button opens this drawer via a window event because the
+  // button and the drawer render in separate component subtrees.
+  useEffect(() => {
+    const handleCreateRequest = () => openDrawer();
+    window.addEventListener(SKILLS_CREATE_REQUEST_EVENT, handleCreateRequest);
+    return () => window.removeEventListener(SKILLS_CREATE_REQUEST_EVENT, handleCreateRequest);
+  }, [openDrawer]);
 
   // Focus the first field when the drawer opens so keyboard users land inside
   // the dialog rather than the inert background.
@@ -831,21 +842,6 @@ export function SkillsPage({ payload }: { payload: BootPayload }) {
     createMutation.mutate();
   };
 
-  const pageHeader = (
-    <header className="flex items-center justify-end gap-4 px-1 sm:px-0">
-      <button
-        ref={drawerTriggerRef}
-        type="button"
-        className="skills-create-button shrink-0"
-        onClick={openDrawer}
-        aria-label="Create New Skill"
-        title="Create New Skill"
-      >
-        <Plus size={20} aria-hidden="true" />
-      </button>
-    </header>
-  );
-
   const createDrawer = isDrawerOpen ? (
     <div
       className="fixed inset-0 z-[120] flex justify-end bg-[rgb(var(--mm-ink)/0.45)]"
@@ -983,19 +979,16 @@ export function SkillsPage({ payload }: { payload: BootPayload }) {
         mode={isDrawerOpen ? 'create' : 'table'}
         className="skills-page skills-catalog-page"
         primaryAs="div"
-        primaryClassName="skills-catalog-primary px-4 py-4 sm:px-6 sm:py-6"
+        primaryClassName="skills-catalog-primary px-4 pb-4 sm:px-6 sm:pb-6"
         primaryLabel="Skills catalog"
         data-skills-list-display-mode="table"
       >
-        <div className="space-y-5 sm:space-y-6">
-          {pageHeader}
-          <SkillsCatalogTable
-            skills={filteredSkills}
-            filterText={filterText}
-            setFilterText={setFilterText}
-            skillsQuery={skillsQuery}
-          />
-        </div>
+        <SkillsCatalogTable
+          skills={filteredSkills}
+          filterText={filterText}
+          setFilterText={setFilterText}
+          skillsQuery={skillsQuery}
+        />
         {createDrawer}
       </CollectionWorkspace>
     );
@@ -1021,17 +1014,14 @@ export function SkillsPage({ payload }: { payload: BootPayload }) {
         />
       ) : null}
     >
-      <div className="space-y-5 sm:space-y-6">
-        {pageHeader}
-        <SkillDetail
-          routeSkillId={routeSkillId}
-          selectedSkill={selectedSkill}
-          skillsQuery={skillsQuery}
-          previewTab={previewTab}
-          setPreviewTab={setPreviewTab}
-          detailHeadingRef={detailHeadingRef}
-        />
-      </div>
+      <SkillDetail
+        routeSkillId={routeSkillId}
+        selectedSkill={selectedSkill}
+        skillsQuery={skillsQuery}
+        previewTab={previewTab}
+        setPreviewTab={setPreviewTab}
+        detailHeadingRef={detailHeadingRef}
+      />
       {createDrawer}
     </CollectionWorkspace>
   );

--- a/frontend/src/lib/skillsCreateRequest.ts
+++ b/frontend/src/lib/skillsCreateRequest.ts
@@ -1,0 +1,14 @@
+export const SKILLS_CREATE_REQUEST_EVENT = 'moonmind:skills-create-request';
+
+// The "Create New Skill" affordance lives in the masthead nav (to the right of
+// the System menu) while the create/upload drawer it opens is owned by the
+// Skills page. They render in separate component subtrees, so the nav button
+// asks the page to open its drawer through this window event — mirroring the
+// other cross-component nav requests (workflow-start route guard, recurring
+// focus).
+export function requestSkillsCreate(): void {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  window.dispatchEvent(new CustomEvent(SKILLS_CREATE_REQUEST_EVENT));
+}

--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -325,24 +325,30 @@ samp {
   display: inline-flex;
   align-items: center;
   justify-self: start;
-  gap: 0.25rem;
+  gap: 0.2rem;
   min-width: 0;
-  padding: 0.18rem;
-  border: 1px solid rgb(var(--mm-border) / 0.7);
-  border-radius: 0.55rem;
-  background: rgb(var(--mm-panel) / 0.68);
+  /* Tightened so the group no longer out-sizes the always-present nav buttons
+   * and its presence/absence stops changing the masthead height. */
+  padding: 0.12rem;
+  /* Liquid-glass border to match the System trigger and the primary nav
+   * buttons: the inset top edge highlight makes the perimeter read as
+   * non-uniform glass rather than a flat 1px stroke. */
+  border: 1px solid var(--mm-glass-border);
+  border-radius: 0.5rem;
+  background: var(--mm-glass-fill);
+  box-shadow: inset 0 1px 0 var(--mm-glass-edge);
 }
 
 .workflow-list-display-option {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 2rem;
-  height: 2rem;
-  min-width: 2rem;
+  width: 1.6rem;
+  height: 1.6rem;
+  min-width: 1.6rem;
   padding: 0;
   border: 1px solid transparent;
-  border-radius: 0.42rem;
+  border-radius: 0.4rem;
   background: transparent;
   color: rgb(var(--mm-muted));
   box-shadow: none;
@@ -620,6 +626,21 @@ h1 {
   transition: background 130ms ease, color 130ms ease;
 }
 
+/* Workflows and Create adopt the same liquid-glass button treatment as the
+ * System trigger (translucent fill + inset glass border/edge highlight), minus
+ * the dropdown arrow and menu behavior. Scoped to `.route-nav-primary` so the
+ * System popover menu items — which also match `.route-nav a` — keep their flat
+ * menu-row look. The border is an inset box-shadow (not a real border) so the
+ * link box height, and thus the active underline on the masthead edge, is
+ * unchanged. Higher-specificity :hover / :focus-visible / .active rules still
+ * win, so those states are preserved. */
+.route-nav-primary a {
+  background: var(--mm-glass-fill);
+  box-shadow:
+    inset 0 0 0 1px var(--mm-glass-border),
+    inset 0 1px 0 var(--mm-glass-edge);
+}
+
 .route-nav-icon {
   width: 1rem;
   height: 1rem;
@@ -674,7 +695,14 @@ h1 {
   padding: 0.48rem 0.82rem;
   border: 0;
   border-radius: 0.5rem;
-  background: transparent;
+  /* Liquid-glass button: translucent fill with the border drawn as an inset
+   * box-shadow (not a real border) so the box size — and therefore the active
+   * underline position on the masthead's bottom edge — is unchanged. The extra
+   * top-edge highlight makes the perimeter read as non-uniform glass. */
+  background: var(--mm-glass-fill);
+  box-shadow:
+    inset 0 0 0 1px var(--mm-glass-border),
+    inset 0 1px 0 var(--mm-glass-edge);
   color: rgb(var(--mm-ink) / 0.82);
   font: inherit;
   font-size: 0.9rem;
@@ -740,6 +768,22 @@ h1 {
 .dashboard-system-popover a {
   display: flex;
   width: 100%;
+}
+
+/* The System trigger keeps its purple underline when a System destination is
+ * active, but the selected row inside the open popover must not repeat that
+ * underline. Suppress the masthead underline on every popover row (it also
+ * matches `.route-nav a`) and mark the open selection the way the collection
+ * sidebar does instead: a left accent bar plus a faint accent fill. */
+.dashboard-system-popover a::after,
+.dashboard-system-popover a.active::after {
+  content: none;
+}
+
+.dashboard-system-popover a.active {
+  color: rgb(var(--mm-ink));
+  background: rgb(var(--mm-accent) / 0.12);
+  box-shadow: inset 3px 0 0 rgb(var(--mm-accent));
 }
 
 .dashboard-system-inline {
@@ -1584,6 +1628,13 @@ h1 {
 
 .schedules-page {
   width: 100%;
+}
+
+/* Recurring Schedules list: the routed panel bleeds to the nav's bottom border,
+ * so give the heading a little breathing room below that line. The detail view
+ * lives in a workspace shell that already insets its content, so exclude it. */
+.schedules-page:not(.schedules-detail-page) {
+  padding-top: 1.25rem;
 }
 
 .entity-detail-frame {
@@ -5936,6 +5987,12 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
   object-fit: contain;
 }
 
+/* Create workflow page: the routed panel bleeds to the nav's bottom border, so
+ * give the page's first heading a little breathing room below that line. */
+.workflow-start-page {
+  padding-top: 1.25rem;
+}
+
 .workflow-start-heading {
   margin-bottom: 0.35rem;
 }
@@ -7994,32 +8051,45 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
   overflow-wrap: anywhere;
 }
 
-/* Compact "+" affordance that opens the create-skill drawer. The accessible
- * name and native tooltip both read "Create New Skill". */
-.skills-create-button {
+/* Green "+" affordance that lives in the masthead nav (to the right of the
+ * System dropdown) and opens the create-skill drawer on the Skills pages. The
+ * accessible name and native tooltip both read "Create New Skill". It uses the
+ * same inset glass-border technique as the nav buttons, tinted with the success
+ * green, and stays a touch shorter than the nav links so it never drives the
+ * masthead height. */
+.skills-create-nav-button {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 2.5rem;
-  height: 2.5rem;
-  padding: 0;
-  border: 1px solid rgb(var(--mm-accent) / 0.6);
-  border-radius: 0.6rem;
-  background: rgb(var(--mm-accent) / 0.14);
-  color: rgb(var(--mm-accent));
+  padding: 0.45rem 0.55rem;
+  border: 0;
+  border-radius: 0.5rem;
+  background: rgb(var(--mm-ok) / 0.16);
+  box-shadow:
+    inset 0 0 0 1px rgb(var(--mm-ok) / 0.55),
+    inset 0 1px 0 var(--mm-glass-edge);
+  color: rgb(var(--mm-ok));
   cursor: pointer;
+  transition: background 130ms ease, color 130ms ease, box-shadow 130ms ease;
 }
 
-.skills-create-button:hover,
-.skills-create-button:focus-visible {
-  border-color: rgb(var(--mm-accent-2) / 0.72);
-  background: rgb(var(--mm-accent-2) / 0.16);
-  color: rgb(var(--mm-ink));
+.skills-create-nav-button:hover {
+  background: rgb(var(--mm-ok) / 0.24);
+  box-shadow:
+    inset 0 0 0 1px rgb(var(--mm-ok) / 0.8),
+    inset 0 1px 0 var(--mm-glass-edge);
 }
 
-.skills-create-button:focus-visible {
+.skills-create-nav-button:focus-visible {
   outline: none;
   box-shadow: var(--mm-control-focus-ring);
+}
+
+.skills-create-nav-button svg {
+  width: 1.125rem;
+  height: 1.125rem;
+  flex: 0 0 auto;
+  stroke-width: 2.4;
 }
 
 .workflow-start-primary,

--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -786,6 +786,15 @@ h1 {
   box-shadow: inset 3px 0 0 rgb(var(--mm-accent));
 }
 
+/* The active-row rule above shares specificity with the earlier
+ * `.dashboard-system-popover a:focus-visible` rule, so on the currently active
+ * destination it would otherwise clobber the focus ring and leave keyboard
+ * users without a distinct focus indicator. Combine both here so the focused
+ * active row keeps its selected-row accent and regains the focus ring. */
+.dashboard-system-popover a.active:focus-visible {
+  box-shadow: var(--mm-control-focus-ring), inset 3px 0 0 rgb(var(--mm-accent));
+}
+
 .dashboard-system-inline {
   display: none;
 }

--- a/frontend/src/styles/dashboardBrand.test.ts
+++ b/frontend/src/styles/dashboardBrand.test.ts
@@ -129,6 +129,15 @@ describe('dashboard masthead brand styles', () => {
     const activeRow = cssRuleBlock('.dashboard-system-popover a.active');
     expect(activeRow).toContain('box-shadow: inset 3px 0 0 rgb(var(--mm-accent));');
     expect(activeRow).toContain('background: rgb(var(--mm-accent) / 0.12);');
+
+    // The active-row rule shares specificity with the earlier
+    // `a:focus-visible` rule, so a later, more specific rule must combine the
+    // focus ring with the active inset shadow; otherwise a keyboard-focused
+    // active row loses its distinct focus indicator.
+    const activeFocus = cssRuleBlock('.dashboard-system-popover a.active:focus-visible');
+    expect(activeFocus).toContain(
+      'box-shadow: var(--mm-control-focus-ring), inset 3px 0 0 rgb(var(--mm-accent));',
+    );
   });
 
   it('keeps the masthead-nav skills create button green and offset below the nav height', () => {

--- a/frontend/src/styles/dashboardBrand.test.ts
+++ b/frontend/src/styles/dashboardBrand.test.ts
@@ -95,4 +95,46 @@ describe('dashboard masthead brand styles', () => {
       /@media \(prefers-reduced-motion: reduce\)\s*\{[\s\S]*\.dashboard-system-trigger,[\s\S]*\.dashboard-system-popover\s*\{[^}]*animation:\s*none !important;[^}]*transition:\s*none !important;[^}]*transform:\s*none !important;/s,
     );
   });
+
+  it('gives the list display control and primary nav buttons the liquid-glass treatment', () => {
+    // Radio group: liquid-glass border/fill with the inset top-edge highlight,
+    // and tightened enough (option < 2rem, padding < 0.18rem) that it no longer
+    // out-sizes the nav buttons.
+    const control = cssRuleBlock('.workflow-list-display-control');
+    expect(control).toContain('border: 1px solid var(--mm-glass-border);');
+    expect(control).toContain('background: var(--mm-glass-fill);');
+    expect(control).toContain('box-shadow: inset 0 1px 0 var(--mm-glass-edge);');
+    expect(control).toContain('padding: 0.12rem;');
+    expect(cssRuleBlock('.workflow-list-display-option')).toContain('width: 1.6rem;');
+    // Icons keep their size regardless of the tighter borders.
+    expect(cssRuleBlock('.workflow-list-display-option svg')).toContain('width: 0.95rem;');
+
+    // Workflows/Create and the System trigger share the glass button look. The
+    // border is an inset box-shadow (no real border) so the active underline
+    // geometry is unchanged.
+    const primary = cssRuleBlock('.route-nav-primary a');
+    expect(primary).toContain('background: var(--mm-glass-fill);');
+    expect(primary).toMatch(/box-shadow:\s*inset 0 0 0 1px var\(--mm-glass-border\),\s*inset 0 1px 0 var\(--mm-glass-edge\);/);
+    const trigger = cssRuleBlock('.dashboard-system-trigger');
+    expect(trigger).toContain('background: var(--mm-glass-fill);');
+    expect(trigger).toMatch(/box-shadow:\s*inset 0 0 0 1px var\(--mm-glass-border\),\s*inset 0 1px 0 var\(--mm-glass-edge\);/);
+  });
+
+  it('marks the open System selection like the sidebar instead of the trigger underline', () => {
+    // The trigger keeps its purple underline when a System destination is
+    // active (asserted above); the selected row inside the open popover must
+    // not repeat it, and instead gets the sidebar-style left accent bar + fill.
+    const underlineSuppression = cssRuleBlock('.dashboard-system-popover a.active::after');
+    expect(underlineSuppression).toContain('content: none;');
+    const activeRow = cssRuleBlock('.dashboard-system-popover a.active');
+    expect(activeRow).toContain('box-shadow: inset 3px 0 0 rgb(var(--mm-accent));');
+    expect(activeRow).toContain('background: rgb(var(--mm-accent) / 0.12);');
+  });
+
+  it('keeps the masthead-nav skills create button green and offset below the nav height', () => {
+    const button = cssRuleBlock('.skills-create-nav-button');
+    expect(button).toContain('color: rgb(var(--mm-ok));');
+    expect(button).toContain('background: rgb(var(--mm-ok) / 0.16);');
+    expect(button).toMatch(/box-shadow:\s*inset 0 0 0 1px rgb\(var\(--mm-ok\) \/ 0\.55\),\s*inset 0 1px 0 var\(--mm-glass-edge\);/);
+  });
 });


### PR DESCRIPTION
Implement improvements for a number of UI elements in MoonMind:

1. The border around the radio buttons in the top left is slightly too far away from the icons. The button icons should stay the same size, but the inner and outer border can be tightened. This should be enough of a change so that the addition and removal of the list radio buttons should stop changing the height of the nav bar. If not, shrink the whole element.
2. The list radio button borders should be styled in a liquid glass border more similar to that seen on the system dropdown button currently where all of the borders are not uniform 360 degrees
3. I want workflows and create to also have the liquid glass button look of the System dropdown, just without the arrow icon and dropdown behavior
4. The "+" button on the skills page should be green and it should be moved up into the nav bar to the right of the System dropdown button
5. The skills table start right beneath the nav bar horizontal line just like the workflows table. The skills table should reach the edges of the window just like the workflows table without a margin around the edge. The body of the table should not have the dark background, only the header should have that, the same as the workflows table.
6. The skill details page should also have the + button in the nav bar
7. Skill details should be just a bit under the nav bar
8. The create workflow page and the recurring schedules page should have a little more space between the horizontal line at the bottom of the nav bar and the first text on the page
9. There should be a purple line under the system menu button when it's selected, but there should not be a purple line underneath the selection in the system dropdown menu when you have it open. We should indicate the selection in some other way - perhaps similar to what we do with the sidebar.