### PR TITLE
Nav highlight-edge look on all three buttons + list radio group with sliding selection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,6 +92,15 @@ When writing code that interacts with skills:
 - Executable tools are identified by **tool-name**.
 - Do not introduce internal ID aliases, display-name matching, provider-specific synonyms, or compatibility translation tables for these identities. Rename by updating every caller, test, mock, seed, and doc reference in the same change.
 
+## UI and Visual Changes
+
+- All dashboard styling lives in one stylesheet: `frontend/src/styles/dashboard.css`. Shared design tokens (`--mm-*`) are defined at the top in `:root` (light theme) and `.dark` (dark theme); prefer tokens over hardcoded values.
+- Brand-critical rules are pinned by `frontend/src/styles/dashboardBrand.test.ts`; update its assertions in the same change as the style change.
+- Global element rules (for example the `button` rules) cascade into components, so a control's visible style may not be fully described by its own class rule. Check the full cascade, and remember `<a>`-based and `<button>`-based controls pick up different globals.
+- The masthead/nav renders its desktop layout at `min-width: 1181px`; below that it collapses to the mobile hamburger nav. Verify desktop visuals at a viewport at least that wide.
+- To verify a visual change without deploying, render a small harness page that links the real `dashboard.css` against production markup (correct wrapper classes, plus the `.dark` class for dark theme) and screenshot it with headless Chromium (for example the `mcr.microsoft.com/playwright` Docker image). The deployed UI is baked into the dashboard image — never hot-patch deployed static assets to preview changes; verify with `tools/verify_deployed_ui_assets.py` when the deployed bundle is in question.
+- For selection controls, reuse the canonical segmented-control system (`.segmented-control`, MM-1138) or its sliding-thumb pattern (an `--*-active-index` custom property driving `translateX` on an absolutely positioned `::before` thumb) rather than inventing a new selection affordance.
+
 ## Pull Request Preparation
 
 - Create non-draft pull requests by default. Use a draft PR only when the user or task explicitly requests a draft, or when the workflow publish policy explicitly allows draft publication for a readiness/publish gate that cannot complete validation in the current environment but can still publish a safe, reviewable handoff with clear missing evidence and next steps.

--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -322,6 +322,8 @@ samp {
 }
 
 .workflow-list-display-control {
+  --list-display-active-index: 0;
+  position: relative;
   display: inline-flex;
   align-items: center;
   justify-self: start;
@@ -330,15 +332,59 @@ samp {
   /* Tightened so the group no longer out-sizes the always-present nav buttons
    * and its presence/absence stops changing the masthead height. */
   padding: 0.12rem;
-  /* Liquid-glass border: the inset top edge highlight makes the perimeter
-   * read as non-uniform glass rather than a flat 1px stroke. */
-  border: 1px solid var(--mm-glass-border);
+  /* Same highlight-edge treatment as the primary nav buttons: a bright
+   * top-edge inset that wraps the rounded corners plus a soft accent
+   * under-glow, with no flat 1px perimeter ring. */
+  border: 0;
   border-radius: 0.5rem;
-  background: var(--mm-glass-fill);
-  box-shadow: inset 0 1px 0 var(--mm-glass-edge);
+  background: transparent;
+  box-shadow:
+    inset 0 1px 0 rgb(255 255 255 / 0.2),
+    0 12px 24px -16px rgb(var(--mm-accent) / 0.82);
+}
+
+/* Sliding selection thumb, echoing the create page's segmented control: the
+ * checked option's index (derived below via :has(), like the loud segmented
+ * tier) drives a translateX so the accent fill glides between slots. Pitch is
+ * the fixed option width (1.6rem) plus the control gap (0.2rem). Options sit
+ * at z-index 1, so icons, hover tints, and focus rings paint above the thumb. */
+.workflow-list-display-control::before {
+  content: "";
+  position: absolute;
+  top: 0.12rem;
+  left: 0.12rem;
+  z-index: 0;
+  width: 1.6rem;
+  height: 1.6rem;
+  border-radius: 0.4rem;
+  background: rgb(var(--mm-accent) / 0.14);
+  box-shadow: inset 0 0 0 1px rgb(var(--mm-accent) / 0.6);
+  transform: translateX(calc(var(--list-display-active-index) * 1.8rem));
+  transition: transform 360ms cubic-bezier(0.34, 1.3, 0.5, 1);
+  pointer-events: none;
+}
+
+.workflow-list-display-control:not(:has(.workflow-list-display-option[aria-checked="true"]))::before {
+  opacity: 0;
+}
+
+.workflow-list-display-control:has(.workflow-list-display-option:nth-child(2)[aria-checked="true"]) {
+  --list-display-active-index: 1;
+}
+
+.workflow-list-display-control:has(.workflow-list-display-option:nth-child(3)[aria-checked="true"]) {
+  --list-display-active-index: 2;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .workflow-list-display-control::before {
+    transition: none;
+  }
 }
 
 .workflow-list-display-option {
+  position: relative;
+  z-index: 1;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -369,10 +415,10 @@ samp {
   box-shadow: var(--mm-control-focus-ring);
 }
 
+/* The sliding thumb on the control's ::before carries the selected fill and
+ * ring, so the selected option itself only tints its icon. */
 .workflow-list-display-option--selected,
 .workflow-list-display-option[aria-checked="true"] {
-  border-color: rgb(var(--mm-accent) / 0.6);
-  background: rgb(var(--mm-accent) / 0.14);
   color: rgb(var(--mm-accent));
 }
 

--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -330,9 +330,8 @@ samp {
   /* Tightened so the group no longer out-sizes the always-present nav buttons
    * and its presence/absence stops changing the masthead height. */
   padding: 0.12rem;
-  /* Liquid-glass border to match the System trigger and the primary nav
-   * buttons: the inset top edge highlight makes the perimeter read as
-   * non-uniform glass rather than a flat 1px stroke. */
+  /* Liquid-glass border: the inset top edge highlight makes the perimeter
+   * read as non-uniform glass rather than a flat 1px stroke. */
   border: 1px solid var(--mm-glass-border);
   border-radius: 0.5rem;
   background: var(--mm-glass-fill);
@@ -626,19 +625,18 @@ h1 {
   transition: background 130ms ease, color 130ms ease;
 }
 
-/* Workflows and Create adopt the same liquid-glass button treatment as the
- * System trigger (translucent fill + inset glass border/edge highlight), minus
- * the dropdown arrow and menu behavior. Scoped to `.route-nav-primary` so the
- * System popover menu items — which also match `.route-nav a` — keep their flat
- * menu-row look. The border is an inset box-shadow (not a real border) so the
- * link box height, and thus the active underline on the masthead edge, is
- * unchanged. Higher-specificity :hover / :focus-visible / .active rules still
- * win, so those states are preserved. */
+/* Workflows and Create adopt the System trigger's original highlight-edge
+ * treatment: a bright top-edge inset that wraps the rounded corners plus a
+ * soft accent under-glow, with no flat 1px perimeter ring. Scoped to
+ * `.route-nav-primary` so the System popover menu items — which also match
+ * `.route-nav a` — keep their flat menu-row look. Both shadows are
+ * non-layout-affecting, so the link box height, and thus the active underline
+ * on the masthead edge, is unchanged. Higher-specificity :hover /
+ * :focus-visible / .active rules still win, so those states are preserved. */
 .route-nav-primary a {
-  background: var(--mm-glass-fill);
   box-shadow:
-    inset 0 0 0 1px var(--mm-glass-border),
-    inset 0 1px 0 var(--mm-glass-edge);
+    inset 0 1px 0 rgb(255 255 255 / 0.2),
+    0 12px 24px -16px rgb(var(--mm-accent) / 0.82);
 }
 
 .route-nav-icon {
@@ -695,14 +693,16 @@ h1 {
   padding: 0.48rem 0.82rem;
   border: 0;
   border-radius: 0.5rem;
-  /* Liquid-glass button: translucent fill with the border drawn as an inset
-   * box-shadow (not a real border) so the box size — and therefore the active
-   * underline position on the masthead's bottom edge — is unchanged. The extra
-   * top-edge highlight makes the perimeter read as non-uniform glass. */
-  background: var(--mm-glass-fill);
+  /* Highlight-edge button: transparent fill with a bright top-edge inset that
+   * wraps the rounded corners plus a soft accent under-glow (the trigger's
+   * original look, stated explicitly rather than inherited from the global
+   * button rule). Both shadows are non-layout-affecting, so the box size — and
+   * therefore the active underline position on the masthead's bottom edge — is
+   * unchanged. */
+  background: transparent;
   box-shadow:
-    inset 0 0 0 1px var(--mm-glass-border),
-    inset 0 1px 0 var(--mm-glass-edge);
+    inset 0 1px 0 rgb(255 255 255 / 0.2),
+    0 12px 24px -16px rgb(var(--mm-accent) / 0.82);
   color: rgb(var(--mm-ink) / 0.82);
   font: inherit;
   font-size: 0.9rem;

--- a/frontend/src/styles/dashboardBrand.test.ts
+++ b/frontend/src/styles/dashboardBrand.test.ts
@@ -48,7 +48,7 @@ describe('dashboard masthead brand styles', () => {
       'box-shadow: var(--mm-control-focus-ring);',
     );
     expect(cssRuleBlock('.workflow-list-display-option[aria-checked="true"]')).toContain(
-      'border-color: rgb(var(--mm-accent) / 0.6);',
+      'color: rgb(var(--mm-accent));',
     );
     expect(cssRuleBlock('.workflow-list-display-option[aria-checked="true"]:hover')).toContain(
       'border-color: rgb(var(--mm-accent-2) / 0.72);',
@@ -96,25 +96,39 @@ describe('dashboard masthead brand styles', () => {
     );
   });
 
-  it('gives the list display control the liquid-glass treatment and the nav buttons the highlight-edge look', () => {
-    // Radio group: liquid-glass border/fill with the inset top-edge highlight,
-    // and tightened enough (option < 2rem, padding < 0.18rem) that it no longer
-    // out-sizes the nav buttons.
+  it('gives the nav buttons and list display control the highlight-edge look with a sliding thumb', () => {
+    // The shared treatment: a bright top-edge inset plus a soft accent
+    // under-glow, with no flat 1px perimeter ring.
+    const highlightShadow =
+      /box-shadow:\s*inset 0 1px 0 rgb\(255 255 255 \/ 0\.2\),\s*0 12px 24px -16px rgb\(var\(--mm-accent\) \/ 0\.82\);/;
+
+    // Radio group: highlight-edge chrome, tightened enough (option < 2rem,
+    // padding < 0.18rem) that it does not out-size the nav buttons, plus a
+    // segmented-control-style sliding thumb driven by the checked option.
     const control = cssRuleBlock('.workflow-list-display-control');
-    expect(control).toContain('border: 1px solid var(--mm-glass-border);');
-    expect(control).toContain('background: var(--mm-glass-fill);');
-    expect(control).toContain('box-shadow: inset 0 1px 0 var(--mm-glass-edge);');
+    expect(control).toContain('border: 0;');
+    expect(control).toContain('background: transparent;');
+    expect(control).toMatch(highlightShadow);
     expect(control).toContain('padding: 0.12rem;');
+    const thumb = cssRuleBlock('.workflow-list-display-control::before');
+    expect(thumb).toContain(
+      'transform: translateX(calc(var(--list-display-active-index) * 1.8rem));',
+    );
+    expect(thumb).toContain('box-shadow: inset 0 0 0 1px rgb(var(--mm-accent) / 0.6);');
+    expect(thumb).toMatch(/transition: transform \d+ms/);
+    expect(dashboardCss).toMatch(
+      /\.workflow-list-display-control:has\(\.workflow-list-display-option:nth-child\(2\)\[aria-checked="true"\]\)\s*\{[^}]*--list-display-active-index: 1;/s,
+    );
+    expect(dashboardCss).toMatch(
+      /@media \(prefers-reduced-motion: reduce\)\s*\{[\s\S]*\.workflow-list-display-control::before\s*\{[^}]*transition:\s*none;/s,
+    );
     expect(cssRuleBlock('.workflow-list-display-option')).toContain('width: 1.6rem;');
     // Icons keep their size regardless of the tighter borders.
     expect(cssRuleBlock('.workflow-list-display-option svg')).toContain('width: 0.95rem;');
 
-    // Workflows/Create and the System trigger share the trigger's original
-    // highlight-edge look: a bright top-edge inset plus a soft accent
-    // under-glow, with no flat 1px perimeter ring. Both shadows are
-    // non-layout-affecting so the active underline geometry is unchanged.
-    const highlightShadow =
-      /box-shadow:\s*inset 0 1px 0 rgb\(255 255 255 \/ 0\.2\),\s*0 12px 24px -16px rgb\(var\(--mm-accent\) \/ 0\.82\);/;
+    // Workflows/Create and the System trigger share the same highlight-edge
+    // look. Both shadows are non-layout-affecting so the active underline
+    // geometry is unchanged.
     const primary = cssRuleBlock('.route-nav-primary a');
     expect(primary).not.toContain('var(--mm-glass-fill)');
     expect(primary).toMatch(highlightShadow);

--- a/frontend/src/styles/dashboardBrand.test.ts
+++ b/frontend/src/styles/dashboardBrand.test.ts
@@ -96,7 +96,7 @@ describe('dashboard masthead brand styles', () => {
     );
   });
 
-  it('gives the list display control and primary nav buttons the liquid-glass treatment', () => {
+  it('gives the list display control the liquid-glass treatment and the nav buttons the highlight-edge look', () => {
     // Radio group: liquid-glass border/fill with the inset top-edge highlight,
     // and tightened enough (option < 2rem, padding < 0.18rem) that it no longer
     // out-sizes the nav buttons.
@@ -109,15 +109,18 @@ describe('dashboard masthead brand styles', () => {
     // Icons keep their size regardless of the tighter borders.
     expect(cssRuleBlock('.workflow-list-display-option svg')).toContain('width: 0.95rem;');
 
-    // Workflows/Create and the System trigger share the glass button look. The
-    // border is an inset box-shadow (no real border) so the active underline
-    // geometry is unchanged.
+    // Workflows/Create and the System trigger share the trigger's original
+    // highlight-edge look: a bright top-edge inset plus a soft accent
+    // under-glow, with no flat 1px perimeter ring. Both shadows are
+    // non-layout-affecting so the active underline geometry is unchanged.
+    const highlightShadow =
+      /box-shadow:\s*inset 0 1px 0 rgb\(255 255 255 \/ 0\.2\),\s*0 12px 24px -16px rgb\(var\(--mm-accent\) \/ 0\.82\);/;
     const primary = cssRuleBlock('.route-nav-primary a');
-    expect(primary).toContain('background: var(--mm-glass-fill);');
-    expect(primary).toMatch(/box-shadow:\s*inset 0 0 0 1px var\(--mm-glass-border\),\s*inset 0 1px 0 var\(--mm-glass-edge\);/);
+    expect(primary).not.toContain('var(--mm-glass-fill)');
+    expect(primary).toMatch(highlightShadow);
     const trigger = cssRuleBlock('.dashboard-system-trigger');
-    expect(trigger).toContain('background: var(--mm-glass-fill);');
-    expect(trigger).toMatch(/box-shadow:\s*inset 0 0 0 1px var\(--mm-glass-border\),\s*inset 0 1px 0 var\(--mm-glass-edge\);/);
+    expect(trigger).toContain('background: transparent;');
+    expect(trigger).toMatch(highlightShadow);
   });
 
   it('marks the open System selection like the sidebar instead of the trigger underline', () => {


### PR DESCRIPTION
## Summary

[#3226](https://github.com/MoonLadderStudios/MoonMind/pull/3226) unified Workflows/Create/System under a new liquid-glass style (glass fill + flat 1px inset ring + faint top edge). That made the three buttons consistent, but it regressed the look of the System trigger: before #3226 the trigger picked up the global button rule's box-shadow — a bright top-edge inset highlight (`rgb(255 255 255 / 0.2)`) that wraps the rounded corners, plus a soft accent under-glow (`0 12px 24px -16px rgb(var(--mm-accent) / 0.82)`) — which read as light catching a glass rim rather than a flat stroke.

### Nav buttons
- `.route-nav-primary a` (Workflows, Create) and `.dashboard-system-trigger` now state the original highlight shadow explicitly, and drop the glass fill + flat inset ring introduced in #3226. Backgrounds stay transparent, matching the trigger's pre-#3226 computed style.
- Both shadows are non-layout-affecting, so the active-route underline geometry on the masthead's bottom edge is unchanged. System popover menu rows keep their flat menu-row look.

### List-display radio group
- The masthead list-display radio group gets the same highlight-edge treatment (replacing its liquid-glass border), so the whole masthead control row reads as one family.
- The selected option's static accent fill/ring is replaced by a sliding thumb on the control's `::before`, echoing the create page's segmented control: the checked option's index is derived via `:has()` (like the loud segmented tier) and drives a `translateX` with the same springy cubic-bezier, so selection changes glide between slots. Options sit at `z-index: 1` so icons, hover tints, and focus rings paint above the thumb; `prefers-reduced-motion` disables the transition.

### AGENTS.md
- New **UI and Visual Changes** section documenting where dashboard styles live, the brand-pinning test, cascade/breakpoint gotchas, the harness-screenshot verification workflow, and the canonical segmented-control pattern — so future visual changes need less trial and error.

## Testing

- `frontend/src/styles/dashboardBrand.test.ts` (7 passed, assertions updated to pin the restored highlight shadow and the sliding thumb) and `frontend/src/entrypoints/dashboard.test.tsx` (130 passed).
- Rendered the modified stylesheet against real masthead markup (desktop width, dark theme) via headless Chromium: all three nav buttons and the radio group show the bright top-edge highlight + accent under-glow with no flat perimeter ring; the active underline is unchanged.
- Verified the slide by sampling the thumb's computed transform after a selection change: it glides from 28.8px (slot 2) through intermediate values, overshoots to 58.3px on the springy curve, and settles at 57.6px (slot 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
