### PR TITLE
Close the nav highlight edge with a hairline ring so the bottom edge reads as lit

### DIFF
--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -333,14 +333,15 @@ samp {
    * and its presence/absence stops changing the masthead height. */
   padding: 0.12rem;
   /* Same highlight-edge treatment as the primary nav buttons: a bright
-   * top-edge inset that wraps the rounded corners plus a soft accent
-   * under-glow, with no flat 1px perimeter ring. */
+   * top-edge inset, a hairline ring that closes the shape so the bottom edge
+   * reads as lit, and an accent under-glow. */
   border: 0;
   border-radius: 0.5rem;
   background: transparent;
   box-shadow:
-    inset 0 1px 0 rgb(255 255 255 / 0.2),
-    0 12px 24px -16px rgb(var(--mm-accent) / 0.82);
+    inset 0 1px 0 rgb(255 255 255 / 0.26),
+    0 0 0 1px rgb(255 255 255 / 0.34),
+    0 18px 32px -16px rgb(var(--mm-accent) / 0.94);
 }
 
 /* Sliding selection thumb, echoing the create page's segmented control: the
@@ -672,17 +673,20 @@ h1 {
 }
 
 /* Workflows and Create adopt the System trigger's original highlight-edge
- * treatment: a bright top-edge inset that wraps the rounded corners plus a
- * soft accent under-glow, with no flat 1px perimeter ring. Scoped to
+ * treatment: a bright top-edge inset, a hairline ring that closes the shape
+ * (so the bottom edge reads as lit, not open), and an accent under-glow. The
+ * mid-strength idle glow alone is too diffuse to register against the
+ * masthead's glass fill, so the ring carries the bottom-edge light. Scoped to
  * `.route-nav-primary` so the System popover menu items — which also match
- * `.route-nav a` — keep their flat menu-row look. Both shadows are
+ * `.route-nav a` — keep their flat menu-row look. All three shadows are
  * non-layout-affecting, so the link box height, and thus the active underline
  * on the masthead edge, is unchanged. Higher-specificity :hover /
  * :focus-visible / .active rules still win, so those states are preserved. */
 .route-nav-primary a {
   box-shadow:
-    inset 0 1px 0 rgb(255 255 255 / 0.2),
-    0 12px 24px -16px rgb(var(--mm-accent) / 0.82);
+    inset 0 1px 0 rgb(255 255 255 / 0.26),
+    0 0 0 1px rgb(255 255 255 / 0.34),
+    0 18px 32px -16px rgb(var(--mm-accent) / 0.94);
 }
 
 .route-nav-icon {
@@ -739,16 +743,17 @@ h1 {
   padding: 0.48rem 0.82rem;
   border: 0;
   border-radius: 0.5rem;
-  /* Highlight-edge button: transparent fill with a bright top-edge inset that
-   * wraps the rounded corners plus a soft accent under-glow (the trigger's
-   * original look, stated explicitly rather than inherited from the global
-   * button rule). Both shadows are non-layout-affecting, so the box size — and
-   * therefore the active underline position on the masthead's bottom edge — is
-   * unchanged. */
+  /* Highlight-edge button: transparent fill with a bright top-edge inset, a
+   * hairline ring that closes the shape so the bottom edge reads as lit, and
+   * an accent under-glow (the trigger's original look, stated explicitly
+   * rather than inherited from the global button rules). All three shadows
+   * are non-layout-affecting, so the box size — and therefore the active
+   * underline position on the masthead's bottom edge — is unchanged. */
   background: transparent;
   box-shadow:
-    inset 0 1px 0 rgb(255 255 255 / 0.2),
-    0 12px 24px -16px rgb(var(--mm-accent) / 0.82);
+    inset 0 1px 0 rgb(255 255 255 / 0.26),
+    0 0 0 1px rgb(255 255 255 / 0.34),
+    0 18px 32px -16px rgb(var(--mm-accent) / 0.94);
   color: rgb(var(--mm-ink) / 0.82);
   font: inherit;
   font-size: 0.9rem;

--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -21,6 +21,10 @@
   --mm-danger: 244 63 94;
   --mm-action-primary: 21 147 118;
   --mm-shadow: 0 18px 32px -26px rgb(10 8 30 / 0.55);
+  --mm-shadow-highlight-edge:
+    inset 0 1px 0 rgb(255 255 255 / 0.26),
+    0 0 0 1px rgb(255 255 255 / 0.34),
+    0 18px 32px -16px rgb(var(--mm-accent) / 0.94);
   --mm-atmosphere-violet: radial-gradient(circle at 8% 0%, rgb(var(--mm-accent) / 0.18), transparent 44%);
   --mm-atmosphere-cyan: radial-gradient(circle at 98% 0%, rgb(var(--mm-accent-2) / 0.14), transparent 42%);
   --mm-atmosphere-warm: radial-gradient(circle at 50% 100%, rgb(var(--mm-accent-warm) / 0.10), transparent 52%);
@@ -338,10 +342,7 @@ samp {
   border: 0;
   border-radius: 0.5rem;
   background: transparent;
-  box-shadow:
-    inset 0 1px 0 rgb(255 255 255 / 0.26),
-    0 0 0 1px rgb(255 255 255 / 0.34),
-    0 18px 32px -16px rgb(var(--mm-accent) / 0.94);
+  box-shadow: var(--mm-shadow-highlight-edge);
 }
 
 /* Sliding selection thumb, echoing the create page's segmented control: the
@@ -683,10 +684,7 @@ h1 {
  * on the masthead edge, is unchanged. Higher-specificity :hover /
  * :focus-visible / .active rules still win, so those states are preserved. */
 .route-nav-primary a {
-  box-shadow:
-    inset 0 1px 0 rgb(255 255 255 / 0.26),
-    0 0 0 1px rgb(255 255 255 / 0.34),
-    0 18px 32px -16px rgb(var(--mm-accent) / 0.94);
+  box-shadow: var(--mm-shadow-highlight-edge);
 }
 
 .route-nav-icon {
@@ -750,10 +748,7 @@ h1 {
    * are non-layout-affecting, so the box size — and therefore the active
    * underline position on the masthead's bottom edge — is unchanged. */
   background: transparent;
-  box-shadow:
-    inset 0 1px 0 rgb(255 255 255 / 0.26),
-    0 0 0 1px rgb(255 255 255 / 0.34),
-    0 18px 32px -16px rgb(var(--mm-accent) / 0.94);
+  box-shadow: var(--mm-shadow-highlight-edge);
   color: rgb(var(--mm-ink) / 0.82);
   font: inherit;
   font-size: 0.9rem;
@@ -4377,7 +4372,7 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
     rgb(var(--mm-accent) / 0.98) 100%
   );
   border-color: rgb(255 255 255 / 0.82);
-  box-shadow: inset 0 1px 0 rgb(255 255 255 / 0.26), 0 0 0 1px rgb(255 255 255 / 0.34), 0 18px 32px -16px rgb(var(--mm-accent) / 0.94);
+  box-shadow: var(--mm-shadow-highlight-edge);
   transform: scale(var(--mm-control-hover-scale));
   filter: brightness(1.08) saturate(1.04);
 }
@@ -4472,7 +4467,7 @@ button.workflow-list-column-filter-button.is-active {
     rgb(var(--mm-accent) / 0.98) 100%
   );
   border-color: rgb(255 255 255 / 0.82);
-  box-shadow: inset 0 1px 0 rgb(255 255 255 / 0.26), 0 0 0 1px rgb(255 255 255 / 0.34), 0 18px 32px -16px rgb(var(--mm-accent) / 0.94);
+  box-shadow: var(--mm-shadow-highlight-edge);
   transform: scale(var(--mm-control-hover-scale));
   filter: brightness(1.08) saturate(1.04);
 }

--- a/frontend/src/styles/dashboardBrand.test.ts
+++ b/frontend/src/styles/dashboardBrand.test.ts
@@ -97,10 +97,11 @@ describe('dashboard masthead brand styles', () => {
   });
 
   it('gives the nav buttons and list display control the highlight-edge look with a sliding thumb', () => {
-    // The shared treatment: a bright top-edge inset plus a soft accent
-    // under-glow, with no flat 1px perimeter ring.
+    // The shared treatment: a bright top-edge inset, a hairline ring that
+    // closes the shape so the bottom edge reads as lit, and an accent
+    // under-glow.
     const highlightShadow =
-      /box-shadow:\s*inset 0 1px 0 rgb\(255 255 255 \/ 0\.2\),\s*0 12px 24px -16px rgb\(var\(--mm-accent\) \/ 0\.82\);/;
+      /box-shadow:\s*inset 0 1px 0 rgb\(255 255 255 \/ 0\.26\),\s*0 0 0 1px rgb\(255 255 255 \/ 0\.34\),\s*0 18px 32px -16px rgb\(var\(--mm-accent\) \/ 0\.94\);/;
 
     // Radio group: highlight-edge chrome, tightened enough (option < 2rem,
     // padding < 0.18rem) that it does not out-size the nav buttons, plus a

--- a/frontend/src/styles/dashboardBrand.test.ts
+++ b/frontend/src/styles/dashboardBrand.test.ts
@@ -101,7 +101,7 @@ describe('dashboard masthead brand styles', () => {
     // closes the shape so the bottom edge reads as lit, and an accent
     // under-glow.
     const highlightShadow =
-      /box-shadow:\s*inset 0 1px 0 rgb\(255 255 255 \/ 0\.26\),\s*0 0 0 1px rgb\(255 255 255 \/ 0\.34\),\s*0 18px 32px -16px rgb\(var\(--mm-accent\) \/ 0\.94\);/;
+      /box-shadow:\s*var\(--mm-shadow-highlight-edge\);/;
 
     // Radio group: highlight-edge chrome, tightened enough (option < 2rem,
     // padding < 0.18rem) that it does not out-size the nav buttons, plus a


### PR DESCRIPTION
## Summary

After [#3228](https://github.com/MoonLadderStudios/MoonMind/pull/3228), the nav buttons and list radio group show a bright top rim but **no visible bottom edge at all** in the deployed masthead. Diagnosis against the live app (v20260712.3688): the restored idle under-glow (`0 12px 24px -16px accent/0.82`) is present in the computed styles but is too diffuse to register against the masthead's glass fill — nothing occludes it, it's simply imperceptible.

The look the original reference screenshot actually showed was the global button rule's **hover** shadow leaking onto the `<button>`-based System trigger (nav links are `<a>`s and never picked it up): a hairline white ring that closes the shape, a brighter top-edge inset, and a stronger accent under-glow. That ring is what made the bottom edge read as lit.

This PR adopts that stack as the idle state for `.route-nav-primary a`, `.dashboard-system-trigger`, and `.workflow-list-display-control`:

```css
box-shadow:
  inset 0 1px 0 rgb(255 255 255 / 0.26),
  0 0 0 1px rgb(255 255 255 / 0.34),
  0 18px 32px -16px rgb(var(--mm-accent) / 0.94);
```

All shadows are non-layout-affecting, so the active-route underline geometry and masthead height are unchanged. The radio group's sliding thumb and all hover/focus/active states are untouched.

## Testing

- Candidate treatments were screenshotted directly against the deployed masthead (dark theme, headless Chromium, live style injection); this stack is the one that reproduces the original reference — complete rounded outline, brighter top edge, lit bottom edge — on all three buttons and the radio group.
- `frontend/src/styles/dashboardBrand.test.ts` (7 passed, shared highlight-shadow assertion updated) and `frontend/src/entrypoints/dashboard.test.tsx` (130 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)