### PR TITLE
Preserve controlled-failure work branches (#3229)

### DIFF
--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -4025,11 +4025,14 @@ def _verified_output_branch(
     ).strip()
     if not name:
         return None
+    intent_value = source.get("intent")
+    if intent_value not in {"normal", "terminal_checkpoint"}:
+        intent_value = "normal"
     result: dict[str, Any] = {
         "name": name,
         "headSha": source.get("headSha") or context.get("headSha"),
         "baseBranch": source.get("baseBranch") or context.get("baseRef"),
-        "intent": str(source.get("intent") or "normal"),
+        "intent": intent_value,
         "status": status_value,
         "evidenceRef": source.get("evidenceRef"),
     }

--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -3912,6 +3912,7 @@ def _serialize_execution(
         priority=priority,
         starting_branch=starting_branch,
         target_branch=target_branch,
+        output_branch=_verified_output_branch(finish_summary),
         repository=repository,
         pr_url=pr_url,
         publish_mode=publish_mode,
@@ -3992,6 +3993,48 @@ def _finish_summary_from_memo(memo: Mapping[str, Any]) -> dict[str, Any] | None:
     if isinstance(finish_summary, Mapping):
         return dict(finish_summary)
     return None
+
+
+def _verified_output_branch(
+    finish_summary: Mapping[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Project only independently verified publication evidence."""
+    if not isinstance(finish_summary, Mapping):
+        return None
+    publish = finish_summary.get("publish")
+    context = finish_summary.get("publishContext")
+    if not isinstance(publish, Mapping):
+        publish = {}
+    if not isinstance(context, Mapping):
+        context = {}
+    terminal = publish.get("terminalPublication")
+    if not isinstance(terminal, Mapping):
+        terminal = context.get("terminalPublication")
+    source = terminal if isinstance(terminal, Mapping) else {**context, **publish}
+    remote_verified = source.get("remoteVerified") is True
+    status_value = str(source.get("status") or publish.get("status") or "").strip()
+    if not remote_verified or status_value not in {"pushed", "already_published", "published"}:
+        return None
+    name = str(
+        source.get("branchName")
+        or source.get("branch")
+        or context.get("branch")
+        or ""
+    ).strip()
+    if not name:
+        return None
+    result: dict[str, Any] = {
+        "name": name,
+        "headSha": source.get("headSha") or context.get("headSha"),
+        "baseBranch": source.get("baseBranch") or context.get("baseRef"),
+        "intent": str(source.get("intent") or "normal"),
+        "status": status_value,
+        "evidenceRef": source.get("evidenceRef"),
+    }
+    url = source.get("branchUrl")
+    if isinstance(url, str) and url.startswith("https://github.com/"):
+        result["url"] = url
+    return {key: value for key, value in result.items() if value not in (None, "")}
 
 
 def _proposal_summary_from_memo(memo: Mapping[str, Any]) -> dict[str, Any] | None:

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -867,6 +867,18 @@ const ExecutionDetailSchema = z
     priority: z.number().nullable().optional(),
     startingBranch: z.string().nullable().optional(),
     targetBranch: z.string().nullable().optional(),
+    outputBranch: z
+      .object({
+        name: z.string(),
+        url: z.string().nullable().optional(),
+        headSha: z.string().nullable().optional(),
+        baseBranch: z.string().nullable().optional(),
+        intent: z.enum(['normal', 'terminal_checkpoint']),
+        status: z.string(),
+        evidenceRef: z.string().nullable().optional(),
+      })
+      .nullable()
+      .optional(),
     repository: z.string().nullable().optional(),
     prUrl: z.string().nullable().optional(),
     resolvedSkillsetRef: z.string().nullable().optional(),
@@ -8467,6 +8479,17 @@ function WorkflowDetailPageContent({ payload }: { payload: BootPayload }) {
                 {execution.targetBranch ? (
                   <Fact label="Target Branch">
                     <code className="text-xs break-all">{execution.targetBranch}</code>
+                  </Fact>
+                ) : null}
+                {execution.outputBranch ? (
+                  <Fact label={execution.outputBranch.intent === 'terminal_checkpoint' ? 'Saved Work Branch' : 'Published Branch'}>
+                    {execution.outputBranch.url ? (
+                      <a className="text-xs break-all" href={execution.outputBranch.url} target="_blank" rel="noreferrer">
+                        <code>{execution.outputBranch.name}</code>
+                      </a>
+                    ) : (
+                      <code className="text-xs break-all">{execution.outputBranch.name}</code>
+                    )}
                   </Fact>
                 ) : null}
                 {prUrl ? (

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -6619,6 +6619,8 @@ export interface components {
             startingBranch?: string | null;
             /** Targetbranch */
             targetBranch?: string | null;
+            /** @description Remotely verified branch produced by publication. */
+            outputBranch?: components["schemas"]["ExecutionOutputBranchModel"] | null;
             /** Repository */
             repository?: string | null;
             /**
@@ -6768,6 +6770,30 @@ export interface components {
             staleState: boolean;
             /** Refreshedat */
             refreshedAt?: string | null;
+        };
+        /**
+         * ExecutionOutputBranchModel
+         * @description Verified repository output evidence, distinct from authored inputs.
+         */
+        ExecutionOutputBranchModel: {
+            /** Name */
+            name: string;
+            /** Url */
+            url?: string | null;
+            /** Headsha */
+            headSha?: string | null;
+            /** Basebranch */
+            baseBranch?: string | null;
+            /**
+             * Intent
+             * @default normal
+             * @enum {string}
+             */
+            intent: "normal" | "terminal_checkpoint";
+            /** Status */
+            status: string;
+            /** Evidenceref */
+            evidenceRef?: string | null;
         };
         /**
          * ExecutionProgressModel

--- a/moonmind/schemas/temporal_activity_models.py
+++ b/moonmind/schemas/temporal_activity_models.py
@@ -271,6 +271,14 @@ class AgentRuntimeFetchResultInput(AgentRuntimeStatusInput):
             "pr_resolver_merge_gate_owned",
         ),
     )
+    terminal_checkpoint_publication_enabled: bool = Field(
+        default=False,
+        alias="terminalCheckpointPublicationEnabled",
+        validation_alias=AliasChoices(
+            "terminalCheckpointPublicationEnabled",
+            "terminal_checkpoint_publication_enabled",
+        ),
+    )
 
     @model_validator(mode="after")
     def _normalize_fetch(self) -> "AgentRuntimeFetchResultInput":

--- a/moonmind/schemas/temporal_activity_models.py
+++ b/moonmind/schemas/temporal_activity_models.py
@@ -282,6 +282,68 @@ class AgentRuntimeFetchResultInput(AgentRuntimeStatusInput):
         return self
 
 
+class AgentRuntimeTerminalCheckpointInput(AgentRuntimeStatusInput):
+    """Bounded request for best-effort controlled-failure publication."""
+
+    failure_class: Literal[
+        "user_error", "execution_error", "integration_error", "timed_out"
+    ] = Field(..., alias="failureClass")
+    target_branch: str | None = Field(None, alias="targetBranch")
+    existing_branch: str | None = Field(None, alias="existingBranch")
+    existing_head_sha: str | None = Field(None, alias="existingHeadSha")
+    existing_pr_url: str | None = Field(None, alias="existingPrUrl")
+    no_remote_writes: bool = Field(False, alias="noRemoteWrites")
+    source: Literal["live_workspace", "checkpoint_restore", "provider_native"] = (
+        "live_workspace"
+    )
+    idempotency_key: str = Field(..., alias="idempotencyKey", min_length=1)
+
+    @model_validator(mode="after")
+    def _normalize_terminal_checkpoint(self) -> "AgentRuntimeTerminalCheckpointInput":
+        for field_name in (
+            "target_branch",
+            "existing_branch",
+            "existing_head_sha",
+            "existing_pr_url",
+            "idempotency_key",
+        ):
+            value = getattr(self, field_name)
+            if isinstance(value, str):
+                setattr(self, field_name, value.strip() or None)
+        if not self.idempotency_key:
+            raise ValueError("idempotencyKey must be nonblank")
+        return self
+
+
+class AgentRuntimeTerminalCheckpointResult(BaseModel):
+    """Typed terminal-publication evidence; never changes primary failure."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    intent: Literal["terminal_checkpoint"] = "terminal_checkpoint"
+    status: Literal[
+        "pushed",
+        "already_published",
+        "no_changes",
+        "skipped",
+        "failed",
+    ]
+    reason_code: str = Field(..., alias="reasonCode")
+    source: Literal["live_workspace", "checkpoint_restore", "provider_native"]
+    attempted: bool
+    commit_created: bool = Field(False, alias="commitCreated")
+    branch_pushed: bool = Field(False, alias="branchPushed")
+    branch_name: str | None = Field(None, alias="branchName")
+    branch_url: str | None = Field(None, alias="branchUrl")
+    head_sha: str | None = Field(None, alias="headSha")
+    base_branch: str | None = Field(None, alias="baseBranch")
+    pr_url: str | None = Field(None, alias="prUrl")
+    remote_verified: bool = Field(False, alias="remoteVerified")
+    idempotency_key: str = Field(..., alias="idempotencyKey")
+    evidence_ref: str | None = Field(None, alias="evidenceRef")
+    error: str | None = None
+
+
 class ResiliencePolicyCompileInput(BaseModel):
     """Input for the ``resilience.compile_policy`` activity (MM-880).
 

--- a/moonmind/schemas/temporal_activity_models.py
+++ b/moonmind/schemas/temporal_activity_models.py
@@ -279,6 +279,13 @@ class AgentRuntimeFetchResultInput(AgentRuntimeStatusInput):
             "terminal_checkpoint_publication_enabled",
         ),
     )
+    no_remote_writes: bool = Field(False, alias="noRemoteWrites")
+    read_only: bool = Field(False, alias="readOnly")
+    dry_run: bool = Field(False, alias="dryRun")
+    workspace_authoritative: bool = Field(True, alias="workspaceAuthoritative")
+    terminal_checkpoint_capability_supported: bool = Field(
+        True, alias="terminalCheckpointCapabilitySupported"
+    )
 
     @model_validator(mode="after")
     def _normalize_fetch(self) -> "AgentRuntimeFetchResultInput":
@@ -301,6 +308,13 @@ class AgentRuntimeTerminalCheckpointInput(AgentRuntimeStatusInput):
     existing_head_sha: str | None = Field(None, alias="existingHeadSha")
     existing_pr_url: str | None = Field(None, alias="existingPrUrl")
     no_remote_writes: bool = Field(False, alias="noRemoteWrites")
+    publication_enabled: bool = Field(True, alias="publicationEnabled")
+    read_only: bool = Field(False, alias="readOnly")
+    dry_run: bool = Field(False, alias="dryRun")
+    workspace_authoritative: bool = Field(True, alias="workspaceAuthoritative")
+    runtime_capability_supported: bool = Field(
+        True, alias="runtimeCapabilitySupported"
+    )
     source: Literal["live_workspace", "checkpoint_restore", "provider_native"] = (
         "live_workspace"
     )

--- a/moonmind/schemas/temporal_models.py
+++ b/moonmind/schemas/temporal_models.py
@@ -3503,6 +3503,20 @@ class ExecutionTargetDiagnosticsModel(BaseModel):
     )
     degraded_reason: str | None = Field(None, alias="degradedReason")
 
+class ExecutionOutputBranchModel(BaseModel):
+    """Verified repository output evidence, distinct from authored inputs."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    name: str
+    url: str | None = None
+    head_sha: str | None = Field(None, alias="headSha")
+    base_branch: str | None = Field(None, alias="baseBranch")
+    intent: Literal["normal", "terminal_checkpoint"] = "normal"
+    status: str
+    evidence_ref: str | None = Field(None, alias="evidenceRef")
+
+
 class ExecutionModel(BaseModel):
     """Materialized execution view returned by lifecycle APIs."""
 
@@ -3578,6 +3592,11 @@ class ExecutionModel(BaseModel):
     priority: Optional[int] = Field(None, alias="priority")
     starting_branch: Optional[str] = Field(None, alias="startingBranch")
     target_branch: Optional[str] = Field(None, alias="targetBranch")
+    output_branch: Optional["ExecutionOutputBranchModel"] = Field(
+        None,
+        alias="outputBranch",
+        description="Remotely verified branch produced by publication.",
+    )
     repository: Optional[str] = Field(None, alias="repository")
     pr_url: Optional[str] = Field(
         None,

--- a/moonmind/workflows/temporal/activity_catalog.py
+++ b/moonmind/workflows/temporal/activity_catalog.py
@@ -1226,6 +1226,15 @@ def build_default_activity_catalog(
             retries=_activity_retries(max_attempts=2, max_interval_seconds=30),
         ),
         TemporalActivityDefinition(
+            activity_type="agent_runtime.publish_terminal_checkpoint",
+            family="agent_runtime",
+            capability_class="agent_runtime",
+            task_queue=cfg.activity_agent_runtime_task_queue,
+            fleet=AGENT_RUNTIME_FLEET,
+            timeouts=TemporalActivityTimeouts(60, 240),
+            retries=_activity_retries(max_attempts=2, max_interval_seconds=30),
+        ),
+        TemporalActivityDefinition(
             activity_type="agent_runtime.evaluate_terminal_evidence",
             family="agent_runtime",
             capability_class="agent_runtime",

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -69,6 +69,8 @@ from moonmind.schemas.temporal_activity_models import (
     AgentRuntimeCancelInput,
     AgentRuntimeFetchResultInput,
     AgentRuntimeStatusInput,
+    AgentRuntimeTerminalCheckpointInput,
+    AgentRuntimeTerminalCheckpointResult,
     ExternalAgentRunInput,
     PlanGenerateInput,
 )
@@ -1354,6 +1356,10 @@ _ACTIVITY_HANDLER_ATTRS: dict[str, tuple[str, str]] = {
     ),
     "agent_runtime.status": ("agent_runtime", "agent_runtime_status"),
     "agent_runtime.fetch_result": ("agent_runtime", "agent_runtime_fetch_result"),
+    "agent_runtime.publish_terminal_checkpoint": (
+        "agent_runtime",
+        "agent_runtime_publish_terminal_checkpoint",
+    ),
     "agent_runtime.evaluate_terminal_evidence": (
         "agent_runtime",
         "agent_runtime_evaluate_terminal_evidence",
@@ -2521,6 +2527,18 @@ def _validate_agent_runtime_fetch_result_input(
     except ValidationError as exc:
         raise TemporalActivityRuntimeError(
             f"agent_runtime.fetch_result payload is invalid: {exc}"
+        ) from exc
+
+def _validate_agent_runtime_terminal_checkpoint_input(
+    payload: Any,
+) -> AgentRuntimeTerminalCheckpointInput:
+    if isinstance(payload, AgentRuntimeTerminalCheckpointInput):
+        return payload
+    try:
+        return AgentRuntimeTerminalCheckpointInput.model_validate(payload)
+    except ValidationError as exc:
+        raise TemporalActivityRuntimeError(
+            f"agent_runtime.publish_terminal_checkpoint payload is invalid: {exc}"
         ) from exc
 
 def _validate_agent_runtime_cancel_input(payload: Any) -> AgentRuntimeCancelInput:
@@ -10231,6 +10249,131 @@ class TemporalAgentRuntimeActivities:
         )
         return status
 
+    async def agent_runtime_publish_terminal_checkpoint(
+        self,
+        request: Any = None,
+        /,
+    ) -> AgentRuntimeTerminalCheckpointResult:
+        """Preserve controlled-failure work without changing its outcome.
+
+        This is the single reusable semantic boundary for live workspaces and
+        restored checkpoints.  It deliberately returns failure evidence
+        instead of raising over the primary workflow failure.
+        """
+        request = _validate_agent_runtime_terminal_checkpoint_input(request)
+        if request.no_remote_writes:
+            return AgentRuntimeTerminalCheckpointResult(
+                status="skipped",
+                reasonCode="remote_writes_disabled",
+                source=request.source,
+                attempted=False,
+                idempotencyKey=request.idempotency_key,
+            )
+        record = self._run_store.load(request.run_id) if self._run_store else None
+        if record is None or not record.workspace_path:
+            return AgentRuntimeTerminalCheckpointResult(
+                status="skipped",
+                reasonCode="checkpoint_unavailable",
+                source=request.source,
+                attempted=False,
+                idempotencyKey=request.idempotency_key,
+            )
+        token = await self._resolve_workspace_push_github_token(record.workspace_path)
+        env = self._workspace_command_env(record.workspace_path, github_token=token)
+        if request.existing_branch and request.existing_head_sha:
+            try:
+                remote_sha = await self._resolve_workspace_remote_branch_sha(
+                    workspace=record.workspace_path,
+                    branch=request.existing_branch,
+                    run_id=request.run_id,
+                    env=env,
+                )
+            except Exception:
+                remote_sha = None
+            if remote_sha == request.existing_head_sha:
+                return AgentRuntimeTerminalCheckpointResult(
+                    status="already_published",
+                    reasonCode="equivalent_remote_head_verified",
+                    source=request.source,
+                    attempted=False,
+                    branchName=request.existing_branch,
+                    headSha=request.existing_head_sha,
+                    baseBranch=request.target_branch,
+                    prUrl=request.existing_pr_url,
+                    remoteVerified=True,
+                    idempotencyKey=request.idempotency_key,
+                )
+
+        recovery_branch = generate_checkpoint_branch_name(
+            workflow_id=request.run_id,
+            logical_step_id="workflow",
+            checkpoint_ref=f"managed-run:{request.run_id}",
+            product_branch_id="terminal",
+            label="recovered-work",
+            idempotency_key=request.idempotency_key,
+        )
+        try:
+            info = await self._push_workspace_branch(
+                request.run_id,
+                github_token=token,
+                target_branch=request.target_branch,
+                head_branch=recovery_branch,
+                allow_target_branch_push=False,
+                commit_message=(
+                    f"Preserve failed workflow work for {request.run_id} "
+                    "(MoonLadderStudios/MoonMind#3229)"
+                ),
+            )
+            raw_status = str(info.get("push_status") or "failed")
+            status = "no_changes" if raw_status == "no_commits" else raw_status
+            if status not in {"pushed", "already_published", "no_changes"}:
+                status = "failed"
+            verified = info.get("remote_verified") is True
+            if status == "pushed" and not verified:
+                expected_sha = str(info.get("push_head_sha") or "").strip()
+                remote_sha = await self._resolve_workspace_remote_branch_sha(
+                    workspace=record.workspace_path,
+                    branch=str(info.get("push_branch") or recovery_branch),
+                    run_id=request.run_id,
+                    env=env,
+                )
+                verified = bool(expected_sha and remote_sha == expected_sha)
+                if not verified:
+                    status = "failed"
+                    info["push_error"] = "remote head verification failed"
+            return AgentRuntimeTerminalCheckpointResult(
+                status=status,
+                reasonCode=(
+                    "graceful_failure_checkpoint_pushed"
+                    if status == "pushed"
+                    else f"terminal_checkpoint_{status}"
+                ),
+                source=request.source,
+                attempted=True,
+                commitCreated=bool(info.get("push_commit_message")),
+                branchPushed=status == "pushed",
+                branchName=info.get("push_branch"),
+                headSha=info.get("push_head_sha"),
+                baseBranch=info.get("push_base_branch"),
+                remoteVerified=verified,
+                idempotencyKey=request.idempotency_key,
+                error=info.get("push_error"),
+            )
+        except Exception as exc:
+            logger.warning(
+                "Terminal checkpoint publication failed for managed run %s: %s",
+                request.run_id,
+                exc,
+            )
+            return AgentRuntimeTerminalCheckpointResult(
+                status="failed",
+                reasonCode="terminal_checkpoint_failed",
+                source=request.source,
+                attempted=True,
+                idempotencyKey=request.idempotency_key,
+                error=str(exc),
+            )
+
     async def agent_runtime_fetch_result(
         self,
         request: Any = None,
@@ -10401,7 +10544,46 @@ class TemporalAgentRuntimeActivities:
                 "timed_out",
             }
             if (
-                (result.failure_class is None or controlled_failure)
+                controlled_failure
+                and publish_mode != "none"
+                and _normalize_provider_native_pr_agent_id(publish_agent_id)
+                not in _PROVIDER_NATIVE_PR_AGENT_IDS
+            ):
+                existing = meta.get("terminalPublication")
+                existing = existing if isinstance(existing, Mapping) else {}
+                publication = await self.agent_runtime_publish_terminal_checkpoint(
+                    AgentRuntimeTerminalCheckpointInput(
+                        runId=run_id,
+                        agentId=publish_agent_id,
+                        failureClass=result.failure_class,
+                        targetBranch=target_branch,
+                        existingBranch=(
+                            existing.get("branchName") or meta.get("push_branch")
+                        ),
+                        existingHeadSha=(
+                            existing.get("headSha") or meta.get("push_head_sha")
+                        ),
+                        existingPrUrl=(
+                            existing.get("prUrl") or meta.get("pull_request_url")
+                        ),
+                        idempotencyKey=f"terminal-checkpoint-v1:{run_id}",
+                    )
+                )
+                publication_payload = publication.model_dump(
+                    mode="json", by_alias=True, exclude_none=True
+                )
+                meta["terminalPublication"] = publication_payload
+                meta.update(
+                    {
+                        "push_status": publication.status,
+                        "push_branch": publication.branch_name,
+                        "push_head_sha": publication.head_sha,
+                        "push_base_branch": publication.base_branch,
+                        "remote_verified": publication.remote_verified,
+                    }
+                )
+            elif (
+                result.failure_class is None
                 and publish_mode != "none"
                 and _normalize_provider_native_pr_agent_id(publish_agent_id)
                 not in _PROVIDER_NATIVE_PR_AGENT_IDS
@@ -10418,21 +10600,6 @@ class TemporalAgentRuntimeActivities:
                     push_kwargs["allow_target_branch_push"] = True
                 if isinstance(head_branch, str) and head_branch.strip():
                     push_kwargs["head_branch"] = head_branch.strip()
-                if controlled_failure:
-                    recovery_branch = generate_checkpoint_branch_name(
-                        workflow_id=run_id,
-                        logical_step_id="workflow",
-                        checkpoint_ref=f"managed-run:{run_id}",
-                        product_branch_id="terminal",
-                        label="recovered-work",
-                        idempotency_key=f"terminal-checkpoint-v1:{run_id}",
-                    )
-                    push_kwargs["head_branch"] = recovery_branch
-                    push_kwargs["allow_target_branch_push"] = False
-                    push_kwargs["commit_message"] = (
-                        f"Preserve failed workflow work for {run_id} "
-                        "(MoonLadderStudios/MoonMind#3229)"
-                    )
                 if (
                     isinstance(raw_commit_message, str)
                     and raw_commit_message.strip()
@@ -10444,75 +10611,9 @@ class TemporalAgentRuntimeActivities:
                         github_token=workspace_github_token,
                         **push_kwargs,
                     )
-                except Exception as exc:
-                    if not controlled_failure:
-                        raise
-                    logger.warning(
-                        "Terminal checkpoint publication failed for managed run %s: %s",
-                        run_id,
-                        exc,
-                    )
-                    push_info = {
-                        "push_status": "failed",
-                        "push_error": str(exc),
-                        "remote_verified": False,
-                    }
-                if (
-                    controlled_failure
-                    and push_info.get("push_status") == "pushed"
-                    and push_info.get("remote_verified") is not True
-                    and record is not None
-                    and record.workspace_path
-                ):
-                    expected_sha = str(push_info.get("push_head_sha") or "").strip()
-                    published_branch = str(push_info.get("push_branch") or "").strip()
-                    try:
-                        remote_sha = await self._resolve_workspace_remote_branch_sha(
-                            workspace=record.workspace_path,
-                            branch=published_branch,
-                            run_id=run_id,
-                            env=self._workspace_command_env(
-                                record.workspace_path,
-                                github_token=workspace_github_token,
-                            ),
-                        )
-                    except Exception as exc:
-                        logger.warning(
-                            "Terminal checkpoint verification failed for managed run %s: %s",
-                            run_id,
-                            exc,
-                        )
-                        remote_sha = None
-                        push_info["push_error"] = str(exc)
-                    push_info["remote_verified"] = bool(
-                        expected_sha and remote_sha == expected_sha
-                    )
-                    if not push_info["remote_verified"]:
-                        push_info["push_status"] = "verification_failed"
-                        push_info["push_error"] = (
-                            "remote branch head did not match the expected workspace head"
-                        )
+                except Exception:
+                    raise
                 meta.update(push_info)
-                if controlled_failure:
-                    status_value = str(push_info.get("push_status") or "failed")
-                    meta["terminalPublication"] = {
-                        "intent": "terminal_checkpoint",
-                        "status": status_value,
-                        "reasonCode": (
-                            "graceful_failure_checkpoint_pushed"
-                            if status_value == "pushed"
-                            else f"terminal_checkpoint_{status_value}"
-                        ),
-                        "source": "live_workspace",
-                        "attempted": True,
-                        "commitCreated": bool(push_info.get("push_commit_message")),
-                        "branchPushed": status_value == "pushed",
-                        "branchName": push_info.get("push_branch"),
-                        "headSha": push_info.get("push_head_sha"),
-                        "baseBranch": push_info.get("push_base_branch"),
-                        "remoteVerified": push_info.get("remote_verified") is True,
-                        "idempotencyKey": f"terminal-checkpoint-v1:{run_id}",
-                    }
 
             # Enrich result with pull_request_url detected from workspace git
             # state (CLI stdout may not always surface PR URLs reliably).

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -10438,11 +10438,25 @@ class TemporalAgentRuntimeActivities:
                     and raw_commit_message.strip()
                 ):
                     push_kwargs["commit_message"] = raw_commit_message.strip()
-                push_info = await self._push_workspace_branch(
-                    run_id,
-                    github_token=workspace_github_token,
-                    **push_kwargs,
-                )
+                try:
+                    push_info = await self._push_workspace_branch(
+                        run_id,
+                        github_token=workspace_github_token,
+                        **push_kwargs,
+                    )
+                except Exception as exc:
+                    if not controlled_failure:
+                        raise
+                    logger.warning(
+                        "Terminal checkpoint publication failed for managed run %s: %s",
+                        run_id,
+                        exc,
+                    )
+                    push_info = {
+                        "push_status": "failed",
+                        "push_error": str(exc),
+                        "remote_verified": False,
+                    }
                 if (
                     controlled_failure
                     and push_info.get("push_status") == "pushed"
@@ -10452,15 +10466,24 @@ class TemporalAgentRuntimeActivities:
                 ):
                     expected_sha = str(push_info.get("push_head_sha") or "").strip()
                     published_branch = str(push_info.get("push_branch") or "").strip()
-                    remote_sha = await self._resolve_workspace_remote_branch_sha(
-                        workspace=record.workspace_path,
-                        branch=published_branch,
-                        run_id=run_id,
-                        env=self._workspace_command_env(
-                            record.workspace_path,
-                            github_token=workspace_github_token,
-                        ),
-                    )
+                    try:
+                        remote_sha = await self._resolve_workspace_remote_branch_sha(
+                            workspace=record.workspace_path,
+                            branch=published_branch,
+                            run_id=run_id,
+                            env=self._workspace_command_env(
+                                record.workspace_path,
+                                github_token=workspace_github_token,
+                            ),
+                        )
+                    except Exception as exc:
+                        logger.warning(
+                            "Terminal checkpoint verification failed for managed run %s: %s",
+                            run_id,
+                            exc,
+                        )
+                        remote_sha = None
+                        push_info["push_error"] = str(exc)
                     push_info["remote_verified"] = bool(
                         expected_sha and remote_sha == expected_sha
                     )

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -10261,10 +10261,50 @@ class TemporalAgentRuntimeActivities:
         instead of raising over the primary workflow failure.
         """
         request = _validate_agent_runtime_terminal_checkpoint_input(request)
+        if not request.publication_enabled:
+            return AgentRuntimeTerminalCheckpointResult(
+                status="skipped",
+                reasonCode="policy_disabled",
+                source=request.source,
+                attempted=False,
+                idempotencyKey=request.idempotency_key,
+            )
         if request.no_remote_writes:
             return AgentRuntimeTerminalCheckpointResult(
                 status="skipped",
-                reasonCode="remote_writes_disabled",
+                reasonCode="no_remote_writes",
+                source=request.source,
+                attempted=False,
+                idempotencyKey=request.idempotency_key,
+            )
+        if request.read_only:
+            return AgentRuntimeTerminalCheckpointResult(
+                status="skipped",
+                reasonCode="read_only",
+                source=request.source,
+                attempted=False,
+                idempotencyKey=request.idempotency_key,
+            )
+        if request.dry_run:
+            return AgentRuntimeTerminalCheckpointResult(
+                status="skipped",
+                reasonCode="dry_run",
+                source=request.source,
+                attempted=False,
+                idempotencyKey=request.idempotency_key,
+            )
+        if not request.runtime_capability_supported:
+            return AgentRuntimeTerminalCheckpointResult(
+                status="skipped",
+                reasonCode="runtime_capability_unsupported",
+                source=request.source,
+                attempted=False,
+                idempotencyKey=request.idempotency_key,
+            )
+        if not request.workspace_authoritative:
+            return AgentRuntimeTerminalCheckpointResult(
+                status="skipped",
+                reasonCode="workspace_unavailable",
                 source=request.source,
                 attempted=False,
                 idempotencyKey=request.idempotency_key,
@@ -10567,6 +10607,16 @@ class TemporalAgentRuntimeActivities:
                         ),
                         existingPrUrl=(
                             existing.get("prUrl") or meta.get("pull_request_url")
+                        ),
+                        publicationEnabled=(
+                            request.terminal_checkpoint_publication_enabled
+                        ),
+                        noRemoteWrites=request.no_remote_writes,
+                        readOnly=request.read_only,
+                        dryRun=request.dry_run,
+                        workspaceAuthoritative=request.workspace_authoritative,
+                        runtimeCapabilitySupported=(
+                            request.terminal_checkpoint_capability_supported
                         ),
                         idempotencyKey=f"terminal-checkpoint-v1:{run_id}",
                     )

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -10545,6 +10545,8 @@ class TemporalAgentRuntimeActivities:
             }
             if (
                 controlled_failure
+                and isinstance(request, AgentRuntimeFetchResultInput)
+                and request.terminal_checkpoint_publication_enabled
                 and publish_mode != "none"
                 and _normalize_provider_native_pr_agent_id(publish_agent_id)
                 not in _PROVIDER_NATIVE_PR_AGENT_IDS

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -93,6 +93,7 @@ from moonmind.schemas.workspace_locator_models import (
     WorkspaceLocatorResolutionError,
 )
 from moonmind.workflows.report_output import report_output_display_name
+from moonmind.workflows.checkpoint_branches import generate_checkpoint_branch_name
 from moonmind.workflows.executions.routing import _coerce_bool
 from moonmind.workflows.executions.prepared_context import (
     PreparedContextFailure,
@@ -10387,13 +10388,20 @@ class TemporalAgentRuntimeActivities:
                 if final_operator_summary:
                     meta["operator_summary"] = final_operator_summary
 
-            # Push the agent's work branch if publish_mode requires it and the
-            # agent completed without failure.
+            # Push successful results normally. Controlled failures use the
+            # same scan/commit/lease pipeline, but an isolated deterministic
+            # branch and explicitly secondary terminal-publication evidence.
             publish_agent_id = agent_id
             if record is not None:
                 publish_agent_id = record.runtime_id or record.agent_id or agent_id
+            controlled_failure = result.failure_class in {
+                "user_error",
+                "execution_error",
+                "integration_error",
+                "timed_out",
+            }
             if (
-                result.failure_class is None
+                (result.failure_class is None or controlled_failure)
                 and publish_mode != "none"
                 and _normalize_provider_native_pr_agent_id(publish_agent_id)
                 not in _PROVIDER_NATIVE_PR_AGENT_IDS
@@ -10410,6 +10418,21 @@ class TemporalAgentRuntimeActivities:
                     push_kwargs["allow_target_branch_push"] = True
                 if isinstance(head_branch, str) and head_branch.strip():
                     push_kwargs["head_branch"] = head_branch.strip()
+                if controlled_failure:
+                    recovery_branch = generate_checkpoint_branch_name(
+                        workflow_id=run_id,
+                        logical_step_id="workflow",
+                        checkpoint_ref=f"managed-run:{run_id}",
+                        product_branch_id="terminal",
+                        label="recovered-work",
+                        idempotency_key=f"terminal-checkpoint-v1:{run_id}",
+                    )
+                    push_kwargs["head_branch"] = recovery_branch
+                    push_kwargs["allow_target_branch_push"] = False
+                    push_kwargs["commit_message"] = (
+                        f"Preserve failed workflow work for {run_id} "
+                        "(MoonLadderStudios/MoonMind#3229)"
+                    )
                 if (
                     isinstance(raw_commit_message, str)
                     and raw_commit_message.strip()
@@ -10420,7 +10443,53 @@ class TemporalAgentRuntimeActivities:
                     github_token=workspace_github_token,
                     **push_kwargs,
                 )
+                if (
+                    controlled_failure
+                    and push_info.get("push_status") == "pushed"
+                    and push_info.get("remote_verified") is not True
+                    and record is not None
+                    and record.workspace_path
+                ):
+                    expected_sha = str(push_info.get("push_head_sha") or "").strip()
+                    published_branch = str(push_info.get("push_branch") or "").strip()
+                    remote_sha = await self._resolve_workspace_remote_branch_sha(
+                        workspace=record.workspace_path,
+                        branch=published_branch,
+                        run_id=run_id,
+                        env=self._workspace_command_env(
+                            record.workspace_path,
+                            github_token=workspace_github_token,
+                        ),
+                    )
+                    push_info["remote_verified"] = bool(
+                        expected_sha and remote_sha == expected_sha
+                    )
+                    if not push_info["remote_verified"]:
+                        push_info["push_status"] = "verification_failed"
+                        push_info["push_error"] = (
+                            "remote branch head did not match the expected workspace head"
+                        )
                 meta.update(push_info)
+                if controlled_failure:
+                    status_value = str(push_info.get("push_status") or "failed")
+                    meta["terminalPublication"] = {
+                        "intent": "terminal_checkpoint",
+                        "status": status_value,
+                        "reasonCode": (
+                            "graceful_failure_checkpoint_pushed"
+                            if status_value == "pushed"
+                            else f"terminal_checkpoint_{status_value}"
+                        ),
+                        "source": "live_workspace",
+                        "attempted": True,
+                        "commitCreated": bool(push_info.get("push_commit_message")),
+                        "branchPushed": status_value == "pushed",
+                        "branchName": push_info.get("push_branch"),
+                        "headSha": push_info.get("push_head_sha"),
+                        "baseBranch": push_info.get("push_base_branch"),
+                        "remoteVerified": push_info.get("remote_verified") is True,
+                        "idempotencyKey": f"terminal-checkpoint-v1:{run_id}",
+                    }
 
             # Enrich result with pull_request_url detected from workspace git
             # state (CLI stdout may not always surface PR URLs reliably).

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -12007,9 +12007,13 @@ class TemporalAgentRuntimeActivities:
             if target_branch_name and not target_branch_push_allowed:
                 protected.add(target_branch_name)
             if (
-                current_branch in {"main", "master"}
-                and head_branch_name
+                head_branch_name
+                and current_branch != head_branch_name
                 and head_branch_name not in protected
+                and (
+                    current_branch not in protected
+                    or current_branch in {"main", "master"}
+                )
             ):
                 checkout_proc = await asyncio.create_subprocess_exec(
                     *self._workspace_git_command(

--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -1858,7 +1858,7 @@ class MoonMindAgentRun:
                 activity_input["prResolverMergeGateOwned"] = (
                     _request_pr_resolver_merge_gate_owned(request)
                 )
-        activity_input["terminalCheckpointPublicationEnabled"] = workflow.patched(
+        terminal_checkpoint_patch_active = workflow.patched(
             TERMINAL_CHECKPOINT_PUBLICATION_PATCH_ID
         )
         workspace_spec = (
@@ -1869,23 +1869,23 @@ class MoonMindAgentRun:
             if isinstance(params.get("checkpointPolicy"), Mapping)
             else {}
         )
-        activity_input["terminalCheckpointPublicationEnabled"] = bool(
-            activity_input["terminalCheckpointPublicationEnabled"]
-            and checkpoint_policy.get("publishOnGracefulFailure", True)
-        )
-        activity_input["noRemoteWrites"] = bool(
-            params.get("noRemoteWrites") or workspace_spec.get("noRemoteWrites")
-        )
-        activity_input["readOnly"] = bool(
-            params.get("readOnly") or workspace_spec.get("readOnly")
-        )
-        activity_input["dryRun"] = bool(params.get("dryRun"))
-        activity_input["workspaceAuthoritative"] = not bool(
-            workspace_spec.get("authorityLost")
-        )
-        activity_input["terminalCheckpointCapabilitySupported"] = not bool(
-            workspace_spec.get("terminalCheckpointPublicationUnsupported")
-        )
+        if terminal_checkpoint_patch_active:
+            activity_input["terminalCheckpointPublicationEnabled"] = bool(
+                checkpoint_policy.get("publishOnGracefulFailure", True)
+            )
+            activity_input["noRemoteWrites"] = bool(
+                params.get("noRemoteWrites") or workspace_spec.get("noRemoteWrites")
+            )
+            activity_input["readOnly"] = bool(
+                params.get("readOnly") or workspace_spec.get("readOnly")
+            )
+            activity_input["dryRun"] = bool(params.get("dryRun"))
+            activity_input["workspaceAuthoritative"] = not bool(
+                workspace_spec.get("authorityLost")
+            )
+            activity_input["terminalCheckpointCapabilitySupported"] = not bool(
+                workspace_spec.get("terminalCheckpointPublicationUnsupported")
+            )
         return AgentRuntimeFetchResultInput.model_validate(activity_input)
 
     async def _fetch_managed_result(

--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -303,6 +303,9 @@ MANAGED_TASK_WORKFLOW_BINDING_PATCH_ID = "agent-run-managed-task-workflow-bindin
 MANAGED_SESSION_FETCH_RESULT_ACTIVITY_PATCH_ID = (
     "agent-run-managed-session-fetch-result-activity-v1"
 )
+TERMINAL_CHECKPOINT_PUBLICATION_PATCH_ID = (
+    "agent-run-terminal-checkpoint-publication-v1"
+)
 STORY_BREAKDOWN_ARTIFACT_HANDOFF_PATCH_ID = (
     "agent-run-story-breakdown-artifact-handoff-v1"
 )
@@ -1849,6 +1852,9 @@ class MoonMindAgentRun:
                 activity_input["prResolverMergeGateOwned"] = (
                     _request_pr_resolver_merge_gate_owned(request)
                 )
+        activity_input["terminalCheckpointPublicationEnabled"] = workflow.patched(
+            TERMINAL_CHECKPOINT_PUBLICATION_PATCH_ID
+        )
         return AgentRuntimeFetchResultInput.model_validate(activity_input)
 
     async def _fetch_managed_result(

--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -1855,6 +1855,31 @@ class MoonMindAgentRun:
         activity_input["terminalCheckpointPublicationEnabled"] = workflow.patched(
             TERMINAL_CHECKPOINT_PUBLICATION_PATCH_ID
         )
+        workspace_spec = (
+            request.workspace_spec if isinstance(request.workspace_spec, Mapping) else {}
+        )
+        checkpoint_policy = (
+            params.get("checkpointPolicy")
+            if isinstance(params.get("checkpointPolicy"), Mapping)
+            else {}
+        )
+        activity_input["terminalCheckpointPublicationEnabled"] = bool(
+            activity_input["terminalCheckpointPublicationEnabled"]
+            and checkpoint_policy.get("publishOnGracefulFailure", True)
+        )
+        activity_input["noRemoteWrites"] = bool(
+            params.get("noRemoteWrites") or workspace_spec.get("noRemoteWrites")
+        )
+        activity_input["readOnly"] = bool(
+            params.get("readOnly") or workspace_spec.get("readOnly")
+        )
+        activity_input["dryRun"] = bool(params.get("dryRun"))
+        activity_input["workspaceAuthoritative"] = not bool(
+            workspace_spec.get("authorityLost")
+        )
+        activity_input["terminalCheckpointCapabilitySupported"] = not bool(
+            workspace_spec.get("terminalCheckpointPublicationUnsupported")
+        )
         return AgentRuntimeFetchResultInput.model_validate(activity_input)
 
     async def _fetch_managed_result(

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -9485,6 +9485,13 @@ class MoonMindRunWorkflow:
                         or workflow.patched(RUN_FAILED_RESULT_BLOCKER_PATCH)
                     )
                 ):
+                    # Failed managed runs may still carry independently verified
+                    # terminal-checkpoint publication evidence. Project it before
+                    # the failure short-circuit so operators can recover the work.
+                    self._record_publish_result(
+                        parameters=parameters,
+                        execution_result=execution_result,
+                    )
                     self._plan_blocked_message = (
                         step_failure_summary
                         or self._activity_result_provider_failure_summary(

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -17056,6 +17056,35 @@ class MoonMindRunWorkflow:
                         self._publish_context.get("blockedReason")
                     )
             if self._publish_context:
+                terminal_publication = self._publish_context.get(
+                    "terminalPublication"
+                )
+                if isinstance(terminal_publication, Mapping):
+                    # Keep preservation evidence on the canonical publish block
+                    # consumed by terminal-state persistence and execution detail.
+                    # The failed finish outcome above remains authoritative.
+                    finish_summary["publish"].update(
+                        {
+                            key: terminal_publication.get(key)
+                            for key in (
+                                "intent",
+                                "status",
+                                "reasonCode",
+                                "source",
+                                "attempted",
+                                "commitCreated",
+                                "branchPushed",
+                                "branchName",
+                                "branchUrl",
+                                "headSha",
+                                "baseBranch",
+                                "remoteVerified",
+                                "evidenceRef",
+                                "idempotencyKey",
+                            )
+                            if terminal_publication.get(key) is not None
+                        }
+                    )
                 finish_summary["publishContext"] = dict(self._publish_context)
                 merge_automation_summary = self._merge_automation_summary_from_context()
                 if merge_automation_summary:

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -11916,6 +11916,23 @@ class MoonMindRunWorkflow:
         outputs = self._effective_result_outputs(execution_result)
         if not isinstance(outputs, Mapping):
             return
+        terminal_publication = outputs.get("terminalPublication")
+        if isinstance(terminal_publication, Mapping):
+            compact_terminal = {
+                key: terminal_publication.get(key)
+                for key in (
+                    "intent", "status", "reasonCode", "source", "attempted",
+                    "commitCreated", "branchPushed", "branchName", "branchUrl",
+                    "headSha", "baseBranch", "remoteVerified", "evidenceRef",
+                    "idempotencyKey",
+                )
+                if terminal_publication.get(key) is not None
+            }
+            self._publish_context["terminalPublication"] = compact_terminal
+            if compact_terminal.get("remoteVerified") is True:
+                self._publish_context["branch"] = compact_terminal.get("branchName")
+                self._publish_context["headSha"] = compact_terminal.get("headSha")
+                self._publish_context["baseRef"] = compact_terminal.get("baseBranch")
         self._record_no_commit_publish_evidence(outputs)
 
         not_required_reason = self._publish_not_required_reason(outputs)

--- a/reports/remediation_attempt-1.json
+++ b/reports/remediation_attempt-1.json
@@ -5,63 +5,73 @@
   "sourceVerificationArtifact": "artifacts/github-issue-implement-verify.json",
   "sourceVerdict": "ADDITIONAL_WORK_NEEDED",
   "status": "additional_work_remaining",
-  "summary": "Remediation attempt 1 added the missing explicit Temporal replay boundary for terminal checkpoint publication. New histories opt in through a replay-stable workflow.patched decision carried in the existing fetch-result activity payload; old histories retain the pre-publication behavior. The verifier's parent checkpoint restoration, durable evidence persistence, eligibility policy, and hermetic journey gaps remain open.",
+  "summary": "Remediation attempt 1 fixed the concrete primary-failure masking defect at the terminal publication boundary and added regression coverage. Controlled-failure push and remote-verification exceptions are now converted to secondary failed publication evidence while the original AgentRun failure remains canonical. The verifier's broader orchestration, adoption, persistence, replay, frontend, and hermetic journey gaps remain open.",
   "changedFiles": [
-    "moonmind/schemas/temporal_activity_models.py",
     "moonmind/workflows/temporal/activity_runtime.py",
-    "moonmind/workflows/temporal/workflows/agent_run.py",
     "tests/unit/services/temporal/test_fetch_result_push.py",
-    "tests/unit/workflows/executions/test_legacy_contract_compatibility.py",
-    "tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py",
     "reports/remediation_attempt-1.json"
   ],
   "gapStatuses": [
     {
-      "requirement": "Parent-level gate/review failures can publish from the latest authoritative checkpoint when the live workspace is gone.",
+      "requirement": "Authoritative source resolution and parent-level gate/review failure recovery",
       "gapType": "implementation",
       "status": "remaining",
-      "evidence": "No parent finalization or checkpoint restoration implementation was added in this bounded attempt.",
-      "remaining": "Adopt verified child evidence first or restore a digest-validated checkpoint and invoke terminal publication with source=checkpoint_restore."
+      "evidence": "Current implementation still publishes only from agent_runtime_fetch_result with a live managed workspace.",
+      "remaining": "Add checkpoint fallback and a parent finalization boundary that awaits publication before cleanup."
     },
     {
-      "requirement": "Finish summary, checkpoint binding, artifacts, execution detail, and UI agree on branch name, head SHA, intent, and status.",
+      "requirement": "Adopt already-published equivalent branch or PR evidence",
       "gapType": "implementation",
       "status": "remaining",
-      "evidence": "This attempt did not add authoritative checkpoint/git-binding or publication artifact persistence.",
-      "remaining": "Persist bounded terminal-publication evidence and derive API output from the durable binding."
+      "evidence": "Provider-native runtimes remain excluded from terminal publication and no verified adoption path was added.",
+      "remaining": "Verify expected remote SHA and adopt equivalent provider-native branch/PR evidence without republishing."
     },
     {
-      "requirement": "Old Temporal histories remain replay-compatible.",
+      "requirement": "Idempotent retries and durable evidence consistency",
       "gapType": "implementation",
-      "status": "remediated",
-      "evidence": "TERMINAL_CHECKPOINT_PUBLICATION_PATCH_ID gates a new terminalCheckpointPublicationEnabled activity field whose default is false; the activity publishes controlled failures only when enabled. Stable-ID and patched request-shape regression tests were added.",
-      "remaining": "Focused tests could not execute because pytest is absent from this runtime; compile and diff checks passed."
+      "status": "remaining",
+      "evidence": "Branch and idempotency-key generation are deterministic, but no durable publication record/binding or retry reuse test exists.",
+      "remaining": "Persist and deduplicate terminal publication evidence and project the same binding everywhere."
     },
     {
-      "requirement": "Hermetic journey coverage proves the end-to-end controlled-failure preservation path.",
+      "requirement": "Eligibility, authority, security, and primary-failure invariants",
+      "gapType": "verification",
+      "status": "partially_remediated",
+      "evidence": "activity_runtime.py now catches controlled-failure push and remote-verification exceptions; test_terminal_publication_exception_preserves_primary_failure proves the original execution_error and summary survive with failed secondary publication evidence.",
+      "remaining": "Add the verifier's full classification/policy/security matrix, including no_changes, noRemoteWrites, scan/protected-ref/lease failures, inaccessible workspaces, and verification mismatch."
+    },
+    {
+      "requirement": "Temporal replay/in-flight safety",
+      "gapType": "implementation",
+      "status": "remaining",
+      "evidence": "No new patch marker or replay fixture was added in this attempt.",
+      "remaining": "Guard command-shaping changes with a Temporal patch/cutover and add prior-history replay coverage."
+    },
+    {
+      "requirement": "Saved Work Branch frontend behavior",
       "gapType": "verification",
       "status": "remaining",
-      "evidence": "No issue-specific compose-backed journey was added or run in this attempt.",
-      "remaining": "Add and run the verifier-specified controlled-failure integration journey."
+      "evidence": "The existing UI suite passes, but no issue-specific rendering/order/absence test was added.",
+      "remaining": "Add schema/render tests for verified Saved Work Branch placement before PR Link and absence for unverified evidence."
     },
     {
-      "requirement": "Scan, protected-ref, workspace-authority, credential, lease, read-only, dry-run, and noRemoteWrites protections remain enforced through an explicit eligibility policy.",
-      "gapType": "implementation",
+      "requirement": "Hermetic end-to-end controlled-failure preservation journey",
+      "gapType": "verification",
       "status": "remaining",
-      "evidence": "This attempt introduced only the replay/version opt-in and did not expand terminal publication eligibility inputs.",
-      "remaining": "Add the typed eligibility policy and stable reason-code matrix at the activity boundary."
+      "evidence": "Focused unit and UI suites pass, but no new compose-backed end-to-end journey was added or run.",
+      "remaining": "Add the verifier-specified workflow/activity/API integration journey and run the selected integration_ci suite."
     }
   ],
   "targetedLocalChecks": [
     {
-      "command": "python -m compileall -q moonmind/schemas/temporal_activity_models.py moonmind/workflows/temporal/activity_runtime.py moonmind/workflows/temporal/workflows/agent_run.py",
+      "command": "python -m compileall -q moonmind/workflows/temporal/activity_runtime.py",
       "result": "PASS",
-      "details": "Changed Python modules compile successfully."
+      "details": "Updated activity runtime compiles successfully."
     },
     {
-      "command": "MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/services/temporal/test_fetch_result_push.py tests/unit/api/routers/test_executions.py tests/unit/workflows/executions/test_legacy_contract_compatibility.py tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py",
-      "result": "NOT_RUN",
-      "details": "The repository audits passed, then Python exited with: No module named pytest."
+      "command": "MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/services/temporal/test_fetch_result_push.py tests/unit/api/routers/test_executions.py",
+      "result": "PASS",
+      "details": "443 Python tests passed; the runner's UI phase also passed 1080 tests with 238 skipped. pytest and pytest-asyncio were installed into the ephemeral user environment because the managed image initially omitted them."
     },
     {
       "command": "git diff --check",

--- a/reports/remediation_attempt-1.json
+++ b/reports/remediation_attempt-1.json
@@ -1,50 +1,82 @@
 {
   "artifact_type": "remediation.attempt",
   "attempt": 1,
-  "issueRef": "MM-1205",
-  "sourceVerificationArtifact": "artifacts/jira-implement-verify.json",
+  "issueRef": "MoonLadderStudios/MoonMind#3229",
+  "sourceVerificationArtifact": "artifacts/github-issue-implement-verify.json",
   "sourceVerdict": "ADDITIONAL_WORK_NEEDED",
-  "status": "blocked_on_verification_environment",
-  "summary": "The latest MM-1205 verification report found no implementation gap and verified every repository-visible requirement. Remediation attempt 1 made no product or test changes because the only remaining work is execution evidence for existing Python and integration tests, and both required environments remain unavailable in this runtime.",
-  "changedFiles": [],
-  "artifactFilesUpdated": [
+  "status": "additional_work_remaining",
+  "summary": "Remediation attempt 1 fixed the concrete primary-failure masking defect at the terminal publication boundary and added regression coverage. Controlled-failure push and remote-verification exceptions are now converted to secondary failed publication evidence while the original AgentRun failure remains canonical. The verifier's broader orchestration, adoption, persistence, replay, frontend, and hermetic journey gaps remain open.",
+  "changedFiles": [
+    "moonmind/workflows/temporal/activity_runtime.py",
+    "tests/unit/services/temporal/test_fetch_result_push.py",
     "reports/remediation_attempt-1.json"
   ],
   "gapStatuses": [
     {
-      "requirement": "Focused preset and helper unit tests",
-      "gapType": "verification",
-      "status": "blocked_in_current_runtime",
-      "implementationStatus": "verified_by_inspection",
-      "evidence": "The verifier identified direct coverage in tests/unit/api/test_batch_workflows_preset.py and tests/unit/test_batch_workflows.py. A fresh environment check confirms /usr/local/bin/python has no pytest module.",
-      "remaining": "Run the focused Python unit suite in a MoonMind managed image that includes pytest and confirm it passes.",
-      "recoverableInCurrentRuntime": false
+      "requirement": "Authoritative source resolution and parent-level gate/review failure recovery",
+      "gapType": "implementation",
+      "status": "remaining",
+      "evidence": "Current implementation still publishes only from agent_runtime_fetch_result with a live managed workspace.",
+      "remaining": "Add checkpoint fallback and a parent finalization boundary that awaits publication before cleanup."
     },
     {
-      "requirement": "Startup-seeding and integration boundary regression evidence",
+      "requirement": "Adopt already-published equivalent branch or PR evidence",
+      "gapType": "implementation",
+      "status": "remaining",
+      "evidence": "Provider-native runtimes remain excluded from terminal publication and no verified adoption path was added.",
+      "remaining": "Verify expected remote SHA and adopt equivalent provider-native branch/PR evidence without republishing."
+    },
+    {
+      "requirement": "Idempotent retries and durable evidence consistency",
+      "gapType": "implementation",
+      "status": "remaining",
+      "evidence": "Branch and idempotency-key generation are deterministic, but no durable publication record/binding or retry reuse test exists.",
+      "remaining": "Persist and deduplicate terminal publication evidence and project the same binding everywhere."
+    },
+    {
+      "requirement": "Eligibility, authority, security, and primary-failure invariants",
       "gapType": "verification",
-      "status": "blocked_in_current_runtime",
-      "implementationStatus": "verified_by_inspection",
-      "evidence": "The verifier identified direct startup-seeding coverage in tests/integration/test_startup_preset_seeding.py and recorded that the isolated moonmind-test Compose build stops before test execution because the Docker daemon lacks required BuildKit support.",
-      "remaining": "Run the integration_ci suite, or at minimum the startup preset seeding test, with a BuildKit-capable Docker daemon and confirm it passes.",
-      "recoverableInCurrentRuntime": false
+      "status": "partially_remediated",
+      "evidence": "activity_runtime.py now catches controlled-failure push and remote-verification exceptions; test_terminal_publication_exception_preserves_primary_failure proves the original execution_error and summary survive with failed secondary publication evidence.",
+      "remaining": "Add the verifier's full classification/policy/security matrix, including no_changes, noRemoteWrites, scan/protected-ref/lease failures, inaccessible workspaces, and verification mismatch."
+    },
+    {
+      "requirement": "Temporal replay/in-flight safety",
+      "gapType": "implementation",
+      "status": "remaining",
+      "evidence": "No new patch marker or replay fixture was added in this attempt.",
+      "remaining": "Guard command-shaping changes with a Temporal patch/cutover and add prior-history replay coverage."
+    },
+    {
+      "requirement": "Saved Work Branch frontend behavior",
+      "gapType": "verification",
+      "status": "remaining",
+      "evidence": "The existing UI suite passes, but no issue-specific rendering/order/absence test was added.",
+      "remaining": "Add schema/render tests for verified Saved Work Branch placement before PR Link and absence for unverified evidence."
+    },
+    {
+      "requirement": "Hermetic end-to-end controlled-failure preservation journey",
+      "gapType": "verification",
+      "status": "remaining",
+      "evidence": "Focused unit and UI suites pass, but no new compose-backed end-to-end journey was added or run.",
+      "remaining": "Add the verifier-specified workflow/activity/API integration journey and run the selected integration_ci suite."
     }
   ],
   "targetedLocalChecks": [
     {
-      "command": "python -m pytest --version",
-      "result": "BLOCKED",
-      "details": "/usr/local/bin/python: No module named pytest"
+      "command": "python -m compileall -q moonmind/workflows/temporal/activity_runtime.py",
+      "result": "PASS",
+      "details": "Updated activity runtime compiles successfully."
     },
     {
-      "command": "MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/test_batch_workflows_preset.py tests/unit/api/test_batch_github_workflows_preset.py tests/unit/test_batch_workflows.py",
-      "result": "NOT_RERUN",
-      "details": "The immediately preceding authoritative verifier ran this command and it stopped before collection because pytest is absent; the fresh pytest availability check reproduces that prerequisite failure."
+      "command": "MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/services/temporal/test_fetch_result_push.py tests/unit/api/routers/test_executions.py",
+      "result": "PASS",
+      "details": "443 Python tests passed; the runner's UI phase also passed 1080 tests with 238 skipped. pytest and pytest-asyncio were installed into the ephemeral user environment because the managed image initially omitted them."
     },
     {
-      "command": "MOONMIND_TEST_COMPOSE_PROJECT_NAME=moonmind-test ./tools/test_integration.sh",
-      "result": "NOT_RERUN",
-      "details": "The immediately preceding authoritative verifier attempted this command and the isolated Compose build stopped before tests because the daemon does not support the Dockerfile's required BuildKit --mount syntax."
+      "command": "git diff --check",
+      "result": "PASS",
+      "details": "No whitespace errors."
     }
   ]
 }

--- a/reports/remediation_attempt-1.json
+++ b/reports/remediation_attempt-1.json
@@ -5,73 +5,63 @@
   "sourceVerificationArtifact": "artifacts/github-issue-implement-verify.json",
   "sourceVerdict": "ADDITIONAL_WORK_NEEDED",
   "status": "additional_work_remaining",
-  "summary": "Remediation attempt 1 fixed the concrete primary-failure masking defect at the terminal publication boundary and added regression coverage. Controlled-failure push and remote-verification exceptions are now converted to secondary failed publication evidence while the original AgentRun failure remains canonical. The verifier's broader orchestration, adoption, persistence, replay, frontend, and hermetic journey gaps remain open.",
+  "summary": "Remediation attempt 1 added the missing explicit Temporal replay boundary for terminal checkpoint publication. New histories opt in through a replay-stable workflow.patched decision carried in the existing fetch-result activity payload; old histories retain the pre-publication behavior. The verifier's parent checkpoint restoration, durable evidence persistence, eligibility policy, and hermetic journey gaps remain open.",
   "changedFiles": [
+    "moonmind/schemas/temporal_activity_models.py",
     "moonmind/workflows/temporal/activity_runtime.py",
+    "moonmind/workflows/temporal/workflows/agent_run.py",
     "tests/unit/services/temporal/test_fetch_result_push.py",
+    "tests/unit/workflows/executions/test_legacy_contract_compatibility.py",
+    "tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py",
     "reports/remediation_attempt-1.json"
   ],
   "gapStatuses": [
     {
-      "requirement": "Authoritative source resolution and parent-level gate/review failure recovery",
+      "requirement": "Parent-level gate/review failures can publish from the latest authoritative checkpoint when the live workspace is gone.",
       "gapType": "implementation",
       "status": "remaining",
-      "evidence": "Current implementation still publishes only from agent_runtime_fetch_result with a live managed workspace.",
-      "remaining": "Add checkpoint fallback and a parent finalization boundary that awaits publication before cleanup."
+      "evidence": "No parent finalization or checkpoint restoration implementation was added in this bounded attempt.",
+      "remaining": "Adopt verified child evidence first or restore a digest-validated checkpoint and invoke terminal publication with source=checkpoint_restore."
     },
     {
-      "requirement": "Adopt already-published equivalent branch or PR evidence",
+      "requirement": "Finish summary, checkpoint binding, artifacts, execution detail, and UI agree on branch name, head SHA, intent, and status.",
       "gapType": "implementation",
       "status": "remaining",
-      "evidence": "Provider-native runtimes remain excluded from terminal publication and no verified adoption path was added.",
-      "remaining": "Verify expected remote SHA and adopt equivalent provider-native branch/PR evidence without republishing."
+      "evidence": "This attempt did not add authoritative checkpoint/git-binding or publication artifact persistence.",
+      "remaining": "Persist bounded terminal-publication evidence and derive API output from the durable binding."
     },
     {
-      "requirement": "Idempotent retries and durable evidence consistency",
+      "requirement": "Old Temporal histories remain replay-compatible.",
       "gapType": "implementation",
-      "status": "remaining",
-      "evidence": "Branch and idempotency-key generation are deterministic, but no durable publication record/binding or retry reuse test exists.",
-      "remaining": "Persist and deduplicate terminal publication evidence and project the same binding everywhere."
+      "status": "remediated",
+      "evidence": "TERMINAL_CHECKPOINT_PUBLICATION_PATCH_ID gates a new terminalCheckpointPublicationEnabled activity field whose default is false; the activity publishes controlled failures only when enabled. Stable-ID and patched request-shape regression tests were added.",
+      "remaining": "Focused tests could not execute because pytest is absent from this runtime; compile and diff checks passed."
     },
     {
-      "requirement": "Eligibility, authority, security, and primary-failure invariants",
-      "gapType": "verification",
-      "status": "partially_remediated",
-      "evidence": "activity_runtime.py now catches controlled-failure push and remote-verification exceptions; test_terminal_publication_exception_preserves_primary_failure proves the original execution_error and summary survive with failed secondary publication evidence.",
-      "remaining": "Add the verifier's full classification/policy/security matrix, including no_changes, noRemoteWrites, scan/protected-ref/lease failures, inaccessible workspaces, and verification mismatch."
-    },
-    {
-      "requirement": "Temporal replay/in-flight safety",
-      "gapType": "implementation",
-      "status": "remaining",
-      "evidence": "No new patch marker or replay fixture was added in this attempt.",
-      "remaining": "Guard command-shaping changes with a Temporal patch/cutover and add prior-history replay coverage."
-    },
-    {
-      "requirement": "Saved Work Branch frontend behavior",
+      "requirement": "Hermetic journey coverage proves the end-to-end controlled-failure preservation path.",
       "gapType": "verification",
       "status": "remaining",
-      "evidence": "The existing UI suite passes, but no issue-specific rendering/order/absence test was added.",
-      "remaining": "Add schema/render tests for verified Saved Work Branch placement before PR Link and absence for unverified evidence."
+      "evidence": "No issue-specific compose-backed journey was added or run in this attempt.",
+      "remaining": "Add and run the verifier-specified controlled-failure integration journey."
     },
     {
-      "requirement": "Hermetic end-to-end controlled-failure preservation journey",
-      "gapType": "verification",
+      "requirement": "Scan, protected-ref, workspace-authority, credential, lease, read-only, dry-run, and noRemoteWrites protections remain enforced through an explicit eligibility policy.",
+      "gapType": "implementation",
       "status": "remaining",
-      "evidence": "Focused unit and UI suites pass, but no new compose-backed end-to-end journey was added or run.",
-      "remaining": "Add the verifier-specified workflow/activity/API integration journey and run the selected integration_ci suite."
+      "evidence": "This attempt introduced only the replay/version opt-in and did not expand terminal publication eligibility inputs.",
+      "remaining": "Add the typed eligibility policy and stable reason-code matrix at the activity boundary."
     }
   ],
   "targetedLocalChecks": [
     {
-      "command": "python -m compileall -q moonmind/workflows/temporal/activity_runtime.py",
+      "command": "python -m compileall -q moonmind/schemas/temporal_activity_models.py moonmind/workflows/temporal/activity_runtime.py moonmind/workflows/temporal/workflows/agent_run.py",
       "result": "PASS",
-      "details": "Updated activity runtime compiles successfully."
+      "details": "Changed Python modules compile successfully."
     },
     {
-      "command": "MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/services/temporal/test_fetch_result_push.py tests/unit/api/routers/test_executions.py",
-      "result": "PASS",
-      "details": "443 Python tests passed; the runner's UI phase also passed 1080 tests with 238 skipped. pytest and pytest-asyncio were installed into the ephemeral user environment because the managed image initially omitted them."
+      "command": "MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/services/temporal/test_fetch_result_push.py tests/unit/api/routers/test_executions.py tests/unit/workflows/executions/test_legacy_contract_compatibility.py tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py",
+      "result": "NOT_RUN",
+      "details": "The repository audits passed, then Python exited with: No module named pytest."
     },
     {
       "command": "git diff --check",

--- a/reports/remediation_verification-1.json
+++ b/reports/remediation_verification-1.json
@@ -1,18 +1,24 @@
 {
-  "artifactType": "remediation.verification",
+  "artifact_type": "remediation.verification",
   "attempt": 1,
+  "remediationAttempt": 1,
   "verifiesRemediationAttempt": 1,
+  "issueRef": "MoonLadderStudios/MoonMind#3229",
+  "verificationTarget": "issue_brief",
   "remediationAttemptArtifact": "reports/remediation_attempt-1.json",
   "authoritativeVerificationArtifact": "artifacts/github-issue-implement-verify.json",
-  "issueRef": "MoonLadderStudios/MoonMind#3229",
+  "authoritativeVerdictForTargetState": "ADDITIONAL_WORK_NEEDED",
   "verdict": "ADDITIONAL_WORK_NEEDED",
   "recommendedNextAction": "reattempt_current_step",
   "recoverableInCurrentRuntime": true,
   "remainingWork": [
-    "Implement parent-workflow adoption and authoritative checkpoint restoration publication.",
-    "Persist terminal publication in checkpoint/git bindings and bounded evidence artifacts, then derive outputBranch from durable verified state.",
-    "Complete typed eligibility/safety policy wiring without agent-name semantic selection.",
-    "Add hermetic end-to-end controlled-failure publication journey coverage."
+    "Add authoritative live-workspace/checkpoint finalization and cleanup ordering, including parent gate/review recovery.",
+    "Adopt verified equivalent branch/PR evidence without republishing.",
+    "Persist and deduplicate typed terminal-publication evidence and checkpoint bindings.",
+    "Complete the eligibility, authority, security, infrastructure-failure, and remote-verification test matrix.",
+    "Add a Temporal patch/version guard and replay coverage.",
+    "Add Saved Work Branch frontend behavior tests.",
+    "Add the required hermetic production-layer controlled-failure journey."
   ],
-  "summary": "Attempt 1 successfully added the replay-stable patch boundary, but the whole target state remains partially implemented. Continue only to the next remediation attempt using artifacts/github-issue-implement-verify.json as mandatory input."
+  "summary": "Attempt 1 fixes primary-failure masking by converting terminal push and verification exceptions into secondary publication evidence. Focused tests pass, but the authoritative whole-target state remains incomplete due to the unresolved orchestration, adoption, persistence/idempotency, replay, frontend verification, and hermetic journey gaps recorded in artifacts/github-issue-implement-verify.json."
 }

--- a/reports/remediation_verification-1.json
+++ b/reports/remediation_verification-1.json
@@ -3,14 +3,22 @@
   "attempt": 1,
   "remediationAttempt": 1,
   "verifiesRemediationAttempt": 1,
-  "issueRef": "MM-1205",
+  "issueRef": "MoonLadderStudios/MoonMind#3229",
   "verificationTarget": "issue_brief",
   "remediationAttemptArtifact": "reports/remediation_attempt-1.json",
-  "authoritativeVerificationArtifact": "artifacts/jira-implement-verify.json",
-  "authoritativeVerdictForTargetState": "FULLY_IMPLEMENTED",
-  "verdict": "FULLY_IMPLEMENTED",
-  "recommendedNextAction": "advance",
+  "authoritativeVerificationArtifact": "artifacts/github-issue-implement-verify.json",
+  "authoritativeVerdictForTargetState": "ADDITIONAL_WORK_NEEDED",
+  "verdict": "ADDITIONAL_WORK_NEEDED",
+  "recommendedNextAction": "reattempt_current_step",
   "recoverableInCurrentRuntime": true,
-  "remainingWork": [],
-  "summary": "Remediation attempt 1 is verified against the whole MM-1205 target state. All repository-verifiable requirements and controlling checks pass; external staging and deployed-asset checks are disclosed scope exclusions."
+  "remainingWork": [
+    "Add authoritative live-workspace/checkpoint finalization and cleanup ordering, including parent gate/review recovery.",
+    "Adopt verified equivalent branch/PR evidence without republishing.",
+    "Persist and deduplicate typed terminal-publication evidence and checkpoint bindings.",
+    "Complete the eligibility, authority, security, infrastructure-failure, and remote-verification test matrix.",
+    "Add a Temporal patch/version guard and replay coverage.",
+    "Add Saved Work Branch frontend behavior tests.",
+    "Add the required hermetic production-layer controlled-failure journey."
+  ],
+  "summary": "Attempt 1 fixes primary-failure masking by converting terminal push and verification exceptions into secondary publication evidence. Focused tests pass, but the authoritative whole-target state remains incomplete due to the unresolved orchestration, adoption, persistence/idempotency, replay, frontend verification, and hermetic journey gaps recorded in artifacts/github-issue-implement-verify.json."
 }

--- a/reports/remediation_verification-1.json
+++ b/reports/remediation_verification-1.json
@@ -1,24 +1,18 @@
 {
-  "artifact_type": "remediation.verification",
+  "artifactType": "remediation.verification",
   "attempt": 1,
-  "remediationAttempt": 1,
   "verifiesRemediationAttempt": 1,
-  "issueRef": "MoonLadderStudios/MoonMind#3229",
-  "verificationTarget": "issue_brief",
   "remediationAttemptArtifact": "reports/remediation_attempt-1.json",
   "authoritativeVerificationArtifact": "artifacts/github-issue-implement-verify.json",
-  "authoritativeVerdictForTargetState": "ADDITIONAL_WORK_NEEDED",
+  "issueRef": "MoonLadderStudios/MoonMind#3229",
   "verdict": "ADDITIONAL_WORK_NEEDED",
   "recommendedNextAction": "reattempt_current_step",
   "recoverableInCurrentRuntime": true,
   "remainingWork": [
-    "Add authoritative live-workspace/checkpoint finalization and cleanup ordering, including parent gate/review recovery.",
-    "Adopt verified equivalent branch/PR evidence without republishing.",
-    "Persist and deduplicate typed terminal-publication evidence and checkpoint bindings.",
-    "Complete the eligibility, authority, security, infrastructure-failure, and remote-verification test matrix.",
-    "Add a Temporal patch/version guard and replay coverage.",
-    "Add Saved Work Branch frontend behavior tests.",
-    "Add the required hermetic production-layer controlled-failure journey."
+    "Implement parent-workflow adoption and authoritative checkpoint restoration publication.",
+    "Persist terminal publication in checkpoint/git bindings and bounded evidence artifacts, then derive outputBranch from durable verified state.",
+    "Complete typed eligibility/safety policy wiring without agent-name semantic selection.",
+    "Add hermetic end-to-end controlled-failure publication journey coverage."
   ],
-  "summary": "Attempt 1 fixes primary-failure masking by converting terminal push and verification exceptions into secondary publication evidence. Focused tests pass, but the authoritative whole-target state remains incomplete due to the unresolved orchestration, adoption, persistence/idempotency, replay, frontend verification, and hermetic journey gaps recorded in artifacts/github-issue-implement-verify.json."
+  "summary": "Attempt 1 successfully added the replay-stable patch boundary, but the whole target state remains partially implemented. Continue only to the next remediation attempt using artifacts/github-issue-implement-verify.json as mandatory input."
 }

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -240,6 +240,22 @@ def test_verified_output_branch_rejects_unverified_claim() -> None:
     }) is None
 
 
+def test_verified_output_branch_coerces_unknown_intent() -> None:
+    result = _verified_output_branch({
+        "publishContext": {
+            "terminalPublication": {
+                "intent": "future_intent",
+                "status": "pushed",
+                "branchName": "mm/recovered",
+                "remoteVerified": True,
+            }
+        }
+    })
+
+    assert result is not None
+    assert result["intent"] == "normal"
+
+
 def test_mm_1129_derive_task_title_synthesizes_issue_title_from_instructions() -> None:
     title = _derive_task_title(
         {

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -51,6 +51,7 @@ from api_service.api.routers.executions import (
     _optional_temporal_search_attributes_cache,
     get_temporal_client,
     _serialize_execution,
+    _verified_output_branch,
     router,
     update_execution as update_execution_route,
 )
@@ -202,6 +203,41 @@ def _completed_attachment_artifact(
         size_bytes=size_bytes,
         created_by_principal=created_by_principal,
     )
+
+
+def test_verified_output_branch_projects_terminal_checkpoint_evidence() -> None:
+    result = _verified_output_branch({
+        "publish": {"status": "failed"},
+        "publishContext": {
+            "terminalPublication": {
+                "intent": "terminal_checkpoint",
+                "status": "pushed",
+                "branchName": "mm/run/workflow/cp-123/terminal-recovered-work",
+                "headSha": "abc123",
+                "baseBranch": "main",
+                "remoteVerified": True,
+            }
+        },
+    })
+    assert result == {
+        "name": "mm/run/workflow/cp-123/terminal-recovered-work",
+        "headSha": "abc123",
+        "baseBranch": "main",
+        "intent": "terminal_checkpoint",
+        "status": "pushed",
+    }
+
+
+def test_verified_output_branch_rejects_unverified_claim() -> None:
+    assert _verified_output_branch({
+        "publishContext": {
+            "terminalPublication": {
+                "status": "pushed",
+                "branchName": "mm/unverified",
+                "remoteVerified": False,
+            }
+        }
+    }) is None
 
 
 def test_mm_1129_derive_task_title_synthesizes_issue_title_from_instructions() -> None:

--- a/tests/unit/services/temporal/test_fetch_result_push.py
+++ b/tests/unit/services/temporal/test_fetch_result_push.py
@@ -2245,8 +2245,8 @@ class TestFetchResultPushIntegration:
         mock_normalize.assert_called_once_with("/work/agent_jobs/run-1/repo")
 
     @pytest.mark.asyncio
-    async def test_fetch_result_skips_push_on_failure(self):
-        """No push when agent failed (failure_class set)."""
+    async def test_fetch_result_publishes_controlled_failure_to_recovery_branch(self):
+        """Controlled failure preserves work without replacing the failure."""
         store = _make_mock_store(failure_class="execution_error")
         activities = TemporalAgentRuntimeActivities(run_store=store)
 
@@ -2257,7 +2257,16 @@ class TestFetchResultPushIntegration:
 
         with (
             patch.object(
-                activities, "_push_workspace_branch",
+                activities,
+                "_push_workspace_branch",
+                new_callable=AsyncMock,
+                return_value={
+                    "push_status": "pushed",
+                    "push_branch": "mm/run-1/workflow/cp-123/terminal-recovered-work",
+                    "push_head_sha": "abc123",
+                    "push_base_branch": "main",
+                    "remote_verified": True,
+                },
             ) as mock_push,
             patch.object(
                 activities, "_detect_pr_url_from_workspace",
@@ -2266,15 +2275,58 @@ class TestFetchResultPushIntegration:
             patch(
                 "moonmind.workflows.temporal.activity_runtime.ManagedAgentAdapter",
             ) as MockAdapter,
+            patch.object(
+                activities,
+                "_resolve_workspace_push_github_token",
+                new_callable=AsyncMock,
+                return_value="resolved-token",
+            ),
         ):
             adapter_instance = MockAdapter.return_value
             adapter_instance.fetch_result = AsyncMock(return_value=mock_result)
 
-            await activities.agent_runtime_fetch_result(
+            result = await activities.agent_runtime_fetch_result(
+                {"run_id": "run-1", "agent_id": "claude", "publish_mode": "pr"},
+            )
+
+        mock_push.assert_called_once()
+        push_kwargs = mock_push.call_args.kwargs
+        assert push_kwargs["head_branch"].startswith("mm/run-1/workflow/cp-")
+        assert push_kwargs["allow_target_branch_push"] is False
+        assert "MoonLadderStudios/MoonMind#3229" in push_kwargs["commit_message"]
+        assert result.failure_class == "execution_error"
+        assert result.metadata["terminalPublication"]["remoteVerified"] is True
+        assert result.metadata["terminalPublication"]["headSha"] == "abc123"
+
+    @pytest.mark.asyncio
+    async def test_fetch_result_does_not_publish_system_error(self):
+        store = _make_mock_store(failure_class="system_error")
+        activities = TemporalAgentRuntimeActivities(run_store=store)
+        with (
+            patch.object(activities, "_push_workspace_branch") as mock_push,
+            patch.object(
+                activities,
+                "_resolve_workspace_push_github_token",
+                new_callable=AsyncMock,
+                return_value="resolved-token",
+            ),
+            patch(
+                "moonmind.workflows.temporal.activity_runtime.ManagedAgentAdapter",
+            ) as MockAdapter,
+        ):
+            MockAdapter.return_value.fetch_result = AsyncMock(
+                return_value=AgentRunResult(
+                    summary="infrastructure lost",
+                    failure_class="system_error",
+                )
+            )
+            result = await activities.agent_runtime_fetch_result(
                 {"run_id": "run-1", "agent_id": "claude", "publish_mode": "pr"},
             )
 
         mock_push.assert_not_called()
+        assert result.failure_class == "system_error"
+        assert "terminalPublication" not in result.metadata
 
     @pytest.mark.asyncio
     async def test_fetch_result_reports_push_failure_in_metadata(self):

--- a/tests/unit/services/temporal/test_fetch_result_push.py
+++ b/tests/unit/services/temporal/test_fetch_result_push.py
@@ -2329,6 +2329,44 @@ class TestFetchResultPushIntegration:
         assert "terminalPublication" not in result.metadata
 
     @pytest.mark.asyncio
+    async def test_terminal_publication_exception_preserves_primary_failure(self):
+        store = _make_mock_store(failure_class="execution_error")
+        activities = TemporalAgentRuntimeActivities(run_store=store)
+
+        with (
+            patch.object(
+                activities,
+                "_push_workspace_branch",
+                new_callable=AsyncMock,
+                side_effect=RuntimeError("credential helper unavailable"),
+            ),
+            patch.object(
+                activities,
+                "_resolve_workspace_push_github_token",
+                new_callable=AsyncMock,
+                return_value="resolved-token",
+            ),
+            patch(
+                "moonmind.workflows.temporal.activity_runtime.ManagedAgentAdapter",
+            ) as MockAdapter,
+        ):
+            MockAdapter.return_value.fetch_result = AsyncMock(
+                return_value=AgentRunResult(
+                    summary="original controlled failure",
+                    failure_class="execution_error",
+                )
+            )
+            result = await activities.agent_runtime_fetch_result(
+                {"run_id": "run-1", "agent_id": "claude", "publish_mode": "pr"},
+            )
+
+        assert result.failure_class == "execution_error"
+        assert result.summary == "original controlled failure"
+        publication = result.metadata["terminalPublication"]
+        assert publication["status"] == "failed"
+        assert publication["remoteVerified"] is False
+
+    @pytest.mark.asyncio
     async def test_fetch_result_reports_push_failure_in_metadata(self):
         """Push failure details propagated to result metadata."""
         store = _make_mock_store()

--- a/tests/unit/services/temporal/test_fetch_result_push.py
+++ b/tests/unit/services/temporal/test_fetch_result_push.py
@@ -2286,7 +2286,12 @@ class TestFetchResultPushIntegration:
             adapter_instance.fetch_result = AsyncMock(return_value=mock_result)
 
             result = await activities.agent_runtime_fetch_result(
-                {"run_id": "run-1", "agent_id": "claude", "publish_mode": "pr"},
+                {
+                    "run_id": "run-1",
+                    "agent_id": "claude",
+                    "publish_mode": "pr",
+                    "terminal_checkpoint_publication_enabled": True,
+                },
             )
 
         mock_push.assert_called_once()
@@ -2419,7 +2424,12 @@ class TestFetchResultPushIntegration:
                 )
             )
             result = await activities.agent_runtime_fetch_result(
-                {"run_id": "run-1", "agent_id": "claude", "publish_mode": "pr"},
+                {
+                    "run_id": "run-1",
+                    "agent_id": "claude",
+                    "publish_mode": "pr",
+                    "terminal_checkpoint_publication_enabled": True,
+                },
             )
 
         assert result.failure_class == "execution_error"

--- a/tests/unit/services/temporal/test_fetch_result_push.py
+++ b/tests/unit/services/temporal/test_fetch_result_push.py
@@ -493,7 +493,10 @@ class TestPushWorkspaceBranch:
         assert result["push_branch"] == "main"
 
     @pytest.mark.asyncio
-    async def test_push_recovers_main_workspace_to_requested_pr_head_branch(self):
+    @pytest.mark.parametrize("starting_branch", ["main", "feature/live-task"])
+    async def test_push_recovers_workspace_to_requested_pr_head_branch(
+        self, starting_branch: str
+    ):
         store = _make_mock_store()
         activities = TemporalAgentRuntimeActivities(run_store=store)
         calls: list[tuple[object, ...]] = []
@@ -506,7 +509,9 @@ class TestPushWorkspaceBranch:
             calls.append(args)
             proc = AsyncMock()
             if call_count == 1:  # rev-parse --abbrev-ref HEAD
-                proc.communicate = AsyncMock(return_value=(b"main\n", b""))
+                proc.communicate = AsyncMock(
+                    return_value=(f"{starting_branch}\n".encode(), b"")
+                )
                 proc.returncode = 0
             elif call_count == 2:  # checkout -B requested head branch
                 proc.communicate = AsyncMock(return_value=(b"", b""))

--- a/tests/unit/services/temporal/test_fetch_result_push.py
+++ b/tests/unit/services/temporal/test_fetch_result_push.py
@@ -2392,7 +2392,45 @@ class TestFetchResultPushIntegration:
 
         mock_push.assert_not_awaited()
         assert result.status == "skipped"
-        assert result.reason_code == "remote_writes_disabled"
+        assert result.reason_code == "no_remote_writes"
+        assert result.attempted is False
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("policy_field", "reason_code"),
+        [
+            ("publicationEnabled", "policy_disabled"),
+            ("readOnly", "read_only"),
+            ("dryRun", "dry_run"),
+            ("workspaceAuthoritative", "workspace_unavailable"),
+            ("runtimeCapabilitySupported", "runtime_capability_unsupported"),
+        ],
+    )
+    async def test_terminal_publication_policy_returns_typed_skip(
+        self, policy_field, reason_code
+    ):
+        activities = TemporalAgentRuntimeActivities(run_store=_make_mock_store())
+        request = {
+            "runId": "run-1",
+            "agentId": "claude",
+            "failureClass": "execution_error",
+            "idempotencyKey": "terminal-checkpoint-v1:run-1",
+            policy_field: False if policy_field in {
+                "publicationEnabled",
+                "workspaceAuthoritative",
+                "runtimeCapabilitySupported",
+            } else True,
+        }
+        with patch.object(
+            activities, "_push_workspace_branch", new_callable=AsyncMock
+        ) as mock_push:
+            result = await activities.agent_runtime_publish_terminal_checkpoint(
+                request
+            )
+
+        mock_push.assert_not_awaited()
+        assert result.status == "skipped"
+        assert result.reason_code == reason_code
         assert result.attempted is False
 
     @pytest.mark.asyncio

--- a/tests/unit/services/temporal/test_fetch_result_push.py
+++ b/tests/unit/services/temporal/test_fetch_result_push.py
@@ -2329,6 +2329,68 @@ class TestFetchResultPushIntegration:
         assert "terminalPublication" not in result.metadata
 
     @pytest.mark.asyncio
+    async def test_terminal_publication_adopts_verified_existing_head(self):
+        """Equivalent remote evidence is adopted without another push."""
+        store = _make_mock_store(failure_class="execution_error")
+        activities = TemporalAgentRuntimeActivities(run_store=store)
+        with (
+            patch.object(
+                activities,
+                "_resolve_workspace_push_github_token",
+                new_callable=AsyncMock,
+                return_value="resolved-token",
+            ),
+            patch.object(
+                activities,
+                "_resolve_workspace_remote_branch_sha",
+                new_callable=AsyncMock,
+                return_value="abc123",
+            ),
+            patch.object(
+                activities, "_push_workspace_branch", new_callable=AsyncMock
+            ) as mock_push,
+        ):
+            result = await activities.agent_runtime_publish_terminal_checkpoint(
+                {
+                    "runId": "run-1",
+                    "agentId": "claude",
+                    "failureClass": "execution_error",
+                    "targetBranch": "main",
+                    "existingBranch": "mm/run-1/recovered-work",
+                    "existingHeadSha": "abc123",
+                    "existingPrUrl": "https://github.com/org/repo/pull/1",
+                    "idempotencyKey": "terminal-checkpoint-v1:run-1",
+                }
+            )
+
+        mock_push.assert_not_awaited()
+        assert result.status == "already_published"
+        assert result.remote_verified is True
+        assert result.branch_name == "mm/run-1/recovered-work"
+        assert result.pr_url == "https://github.com/org/repo/pull/1"
+
+    @pytest.mark.asyncio
+    async def test_terminal_publication_no_remote_writes_is_typed_skip(self):
+        activities = TemporalAgentRuntimeActivities(run_store=_make_mock_store())
+        with patch.object(
+            activities, "_push_workspace_branch", new_callable=AsyncMock
+        ) as mock_push:
+            result = await activities.agent_runtime_publish_terminal_checkpoint(
+                {
+                    "runId": "run-1",
+                    "agentId": "claude",
+                    "failureClass": "execution_error",
+                    "noRemoteWrites": True,
+                    "idempotencyKey": "terminal-checkpoint-v1:run-1",
+                }
+            )
+
+        mock_push.assert_not_awaited()
+        assert result.status == "skipped"
+        assert result.reason_code == "remote_writes_disabled"
+        assert result.attempted is False
+
+    @pytest.mark.asyncio
     async def test_terminal_publication_exception_preserves_primary_failure(self):
         store = _make_mock_store(failure_class="execution_error")
         activities = TemporalAgentRuntimeActivities(run_store=store)

--- a/tests/unit/workflows/executions/test_legacy_contract_compatibility.py
+++ b/tests/unit/workflows/executions/test_legacy_contract_compatibility.py
@@ -83,6 +83,12 @@ def test_workflow_scoped_session_patch_ids_keep_legacy_values() -> None:
     """Replay-stable workflow.patched ids must not change for MoonMind.UserWorkflow."""
 
     from moonmind.workflows.temporal.workflows import run as run_module
+    from moonmind.workflows.temporal.workflows import agent_run as agent_run_module
+
+    assert (
+        agent_run_module.TERMINAL_CHECKPOINT_PUBLICATION_PATCH_ID
+        == "agent-run-terminal-checkpoint-publication-v1"
+    )
 
     assert (
         run_module.RUN_WORKFLOW_SCOPED_SESSION_TERMINATION_PATCH

--- a/tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py
@@ -569,6 +569,40 @@ async def test_managed_fetch_result_versions_terminal_checkpoint_publication(
     assert activity_input.terminal_checkpoint_publication_enabled is True
 
 
+async def test_managed_fetch_result_wires_terminal_checkpoint_policy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _configure_workflow_runtime(monkeypatch)
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.workflows.agent_run.workflow.patched",
+        lambda patch_id: patch_id == "agent-run-terminal-checkpoint-publication-v1",
+    )
+    run = MoonMindAgentRun()
+    request = _managed_session_request(
+        parameters={
+            "publishMode": "pr",
+            "checkpointPolicy": {"publishOnGracefulFailure": False},
+            "dryRun": True,
+        },
+        workspace_spec={
+            "startingBranch": "main",
+            "noRemoteWrites": True,
+            "readOnly": True,
+            "authorityLost": True,
+            "terminalCheckpointPublicationUnsupported": True,
+        },
+    )
+
+    activity_input = run._build_managed_fetch_result_activity_input(request)
+
+    assert activity_input.terminal_checkpoint_publication_enabled is False
+    assert activity_input.no_remote_writes is True
+    assert activity_input.read_only is True
+    assert activity_input.dry_run is True
+    assert activity_input.workspace_authoritative is False
+    assert activity_input.terminal_checkpoint_capability_supported is False
+
+
 async def test_managed_fetch_result_input_uses_publish_base_for_pr_target_branch(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py
@@ -640,6 +640,27 @@ async def test_managed_fetch_result_versions_terminal_checkpoint_publication(
     assert activity_input.terminal_checkpoint_publication_enabled is True
 
 
+async def test_managed_fetch_result_omits_terminal_checkpoint_fields_before_patch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _configure_workflow_runtime(monkeypatch)
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.workflows.agent_run.workflow.patched",
+        lambda patch_id: False,
+    )
+    run = MoonMindAgentRun()
+    request = _managed_session_request(
+        parameters={"publishMode": "pr"},
+        workspace_spec={"startingBranch": "main"},
+    )
+
+    activity_input = run._build_managed_fetch_result_activity_input(request)
+
+    assert "terminal_checkpoint_publication_enabled" not in activity_input.model_fields_set
+    assert "no_remote_writes" not in activity_input.model_fields_set
+    assert "terminal_checkpoint_capability_supported" not in activity_input.model_fields_set
+
+
 async def test_managed_fetch_result_wires_terminal_checkpoint_policy(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py
@@ -550,6 +550,25 @@ async def test_managed_fetch_result_input_ignores_legacy_workspace_branch_for_he
     assert activity_input.head_branch is None
 
 
+async def test_managed_fetch_result_versions_terminal_checkpoint_publication(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _configure_workflow_runtime(monkeypatch)
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.workflows.agent_run.workflow.patched",
+        lambda patch_id: patch_id == "agent-run-terminal-checkpoint-publication-v1",
+    )
+    run = MoonMindAgentRun()
+    request = _managed_session_request(
+        parameters={"publishMode": "pr"},
+        workspace_spec={"startingBranch": "main"},
+    )
+
+    activity_input = run._build_managed_fetch_result_activity_input(request)
+
+    assert activity_input.terminal_checkpoint_publication_enabled is True
+
+
 async def test_managed_fetch_result_input_uses_publish_base_for_pr_target_branch(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/workflows/temporal/workflows/test_run_integration.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_integration.py
@@ -4451,3 +4451,40 @@ async def test_terminal_evidence_failure_projects_partial_fanout_consistently(
     assert summary["failure"]["queuedChildCount"] == len(queued)
     assert summary["failure"]["queuedChildren"] == queued
     assert summary["lastStep"]["diagnosticsRef"] == "artifact://mm-1201-diagnostics"
+
+
+@pytest.mark.asyncio
+async def test_failed_finish_summary_keeps_terminal_publication_evidence(
+    mock_run_workflow: MoonMindRunWorkflow,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    mock_run_workflow._publish_context["terminalPublication"] = {
+        "intent": "terminal_checkpoint",
+        "status": "pushed",
+        "reasonCode": "graceful_failure_checkpoint_pushed",
+        "source": "live_workspace",
+        "attempted": True,
+        "branchPushed": True,
+        "branchName": "mm/workflow/recovered-work",
+        "headSha": "abc123",
+        "baseBranch": "main",
+        "remoteVerified": True,
+        "evidenceRef": "artifact://terminal-publication",
+        "idempotencyKey": "terminal-checkpoint-v1:run-1",
+    }
+
+    summary = await _finalize_and_capture_summary(
+        monkeypatch,
+        mock_run_workflow,
+        parameters={"publishMode": "branch"},
+        status="failed",
+        error="validation failed",
+    )
+
+    assert summary["finishOutcome"]["code"] == "FAILED"
+    assert summary["finishOutcome"]["reason"] == "validation failed"
+    assert summary["publish"]["intent"] == "terminal_checkpoint"
+    assert summary["publish"]["status"] == "pushed"
+    assert summary["publish"]["branchName"] == "mm/workflow/recovered-work"
+    assert summary["publish"]["remoteVerified"] is True
+    assert summary["publish"]["evidenceRef"] == "artifact://terminal-publication"


### PR DESCRIPTION
## What changed

- recovered the implementation produced by workflow `mm:38abc67f-707b-4cbe-8c10-453f20e546c8`
- preserves controlled-failure work on a verified remote branch without replacing the primary workflow failure
- projects verified saved-work branch evidence through the execution API and workflow detail UI
- converts terminal push and remote-verification exceptions into secondary publication evidence

## Why

Issue #3229 requires MoonMind to preserve useful repository work after a controlled terminal failure while keeping the original failure authoritative.

## Current verification state

This is intentionally a draft. MoonSpec verification returned `ADDITIONAL_WORK_NEEDED` after the bounded remediation attempt. The focused selector passed (443 Python tests; UI phase passed 1080 tests with 238 skipped), but the verifier identified remaining orchestration, provider-native adoption, durable idempotency/evidence, policy/security, Temporal replay, frontend behavior, and hermetic journey coverage.

## Validation

- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/services/temporal/test_fetch_result_push.py tests/unit/api/routers/test_executions.py`

Closes #3229 only after the remaining acceptance criteria are completed and verification passes.
