### PR TITLE
Publish drafts when MoonSpec needs more work

### DIFF
--- a/docs/Steps/StepExecutionsAndCheckpointing.md
+++ b/docs/Steps/StepExecutionsAndCheckpointing.md
@@ -932,7 +932,7 @@ For Jira Orchestrate, the MoonSpec remediation loop is represented as bounded pl
 
 Remediation steps carry `annotations.jiraOrchestrateRole = "moonspec-remediation"` plus attempt and maximum-attempt metadata. Verification steps carry `annotations.jiraOrchestrateRole = "moonspec-verification-gate"` and mark only the final remediation verification as `moonSpecFinalRemediationGate`.
 
-`ADDITIONAL_WORK_NEEDED` is retryable only while a later MoonSpec remediation step remains in the plan. When no later remediation step remains, or when the gate reports a non-retryable blocking verdict such as `NO_DETERMINATION`, `BLOCKED`, or `FAILED_UNRECOVERABLE`, the parent workflow stops before publication and skips downstream handoff steps.
+`ADDITIONAL_WORK_NEEDED` is retryable only while a later MoonSpec remediation step remains in the plan. When no later remediation step remains and publish mode is `pr`, the parent workflow publishes the accumulated work as a draft pull request with `attention_required: true`, then skips downstream promotion and trusted handoff steps. Non-retryable blocking verdicts such as `NO_DETERMINATION`, `BLOCKED`, or `FAILED_UNRECOVERABLE` stop before publication unless an explicit environment-blocked draft policy applies.
 
 ---
 
@@ -1174,7 +1174,7 @@ Desired behavior:
 
 The default Jira Orchestrate budget allows up to six remediation/verification pairs after the initial verification gate. The loop may exit earlier when any MoonSpec verification returns `FULLY_IMPLEMENTED`.
 
-If the post-remediation gate remains `ADDITIONAL_WORK_NEEDED` after budget exhaustion, `MoonMind.UserWorkflow` stops before pull request creation and Jira movement. The final state includes the latest verification report, remaining work, attempted remediation evidence, side-effect dispositions, and a recommended next action.
+If the post-remediation gate remains `ADDITIONAL_WORK_NEEDED` after budget exhaustion, `MoonMind.UserWorkflow` creates a draft pull request, completes with `attention_required: true`, and does not move Jira or perform any other downstream promotion. The draft annotation and final state include the latest verification report, remaining work, attempted remediation evidence, side-effect dispositions, and a recommended next action.
 
 ### 20.2 Failed-step recovery
 

--- a/docs/Workflows/WorkflowPublishing.md
+++ b/docs/Workflows/WorkflowPublishing.md
@@ -296,7 +296,7 @@ Provider-native publishing may supply pull request metadata directly when the pr
 
 Workflows that include MoonSpec verification gates must use the latest structured verification verdict to decide publication eligibility.
 
-`FULLY_IMPLEMENTED` permits PR publication and downstream trusted side effects. `ADDITIONAL_WORK_NEEDED` keeps the workflow in the bounded remediation loop while a later MoonSpec remediation step remains. Once that retry budget is exhausted, `ADDITIONAL_WORK_NEEDED` blocks publication.
+`FULLY_IMPLEMENTED` permits PR publication and downstream trusted side effects. `ADDITIONAL_WORK_NEEDED` keeps the workflow in the bounded remediation loop while a later MoonSpec remediation step remains. Once that retry budget is exhausted, a workflow whose publish mode is `pr` opens a draft pull request annotated with the remaining-work verdict and verification report, completes with `attention_required: true`, and skips downstream promotion or trusted handoff steps. This preserves reviewable work without representing it as verified or ready.
 
 Non-retryable blocking verdicts, including `NO_DETERMINATION`, `BLOCKED`, and `FAILED_UNRECOVERABLE`, block publication without waiting for additional remediation attempts unless the workflow explicitly models the missing evidence as recoverable work inside the same bounded plan.
 
@@ -318,7 +318,7 @@ The gate distinguishes a verifier judgment from a malformed verdict envelope:
   the verifier can rewrite its structured JSON. Remediation implement cycles
   are never spent on a malformed verdict envelope.
 
-When MoonSpec verification blocks publication, the workflow records
+When MoonSpec verification blocks publication without a permitted draft handoff, the workflow records
 `publicationBlockedBy: "moonspec_verify"` in publish context, preserves the
 latest verification report and evidence refs, writes a compact
 `failureSummary.type = "moonspec_verification_gate"` block in
@@ -333,8 +333,9 @@ or `NO_DETERMINATION` produced by a degraded/malformed gate payload — publishe
 a **draft** pull request annotated with a "MoonSpec verification incomplete"
 section and the verification report ref, and the run completes with
 `attention_required: true` and a distinct summary instead of failing.
-Implementation-gap verdicts (`ADDITIONAL_WORK_NEEDED`, `FAILED_UNRECOVERABLE`)
-and verifier-declared `NO_DETERMINATION` always remain fail-closed.
+`FAILED_UNRECOVERABLE` and verifier-declared `NO_DETERMINATION` remain
+fail-closed. `ADDITIONAL_WORK_NEEDED` uses the automatic draft handoff described
+above only after the bounded remediation budget is exhausted.
 
 ### Agent Instructions
 

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -5929,10 +5929,18 @@ class MoonMindRunWorkflow:
         gate_context = self._publish_context.get("moonSpecGate")
         verdict = None
         diagnostics_ref = None
+        gate_result_ref = None
+        remaining_work_ref = None
         if isinstance(gate_context, Mapping):
             verdict = self._coerce_text(gate_context.get("verdict"), max_chars=80)
             diagnostics_ref = self._coerce_text(
                 gate_context.get("diagnosticsRef"), max_chars=400
+            )
+            gate_result_ref = self._coerce_text(
+                gate_context.get("gateResultRef"), max_chars=400
+            )
+            remaining_work_ref = self._coerce_text(
+                gate_context.get("remainingWorkRef"), max_chars=400
             )
         draft_context = self._publish_context.get("moonSpecDraftPublication")
         policy = (
@@ -5966,6 +5974,10 @@ class MoonMindRunWorkflow:
             lines.append(f"- Gate outcome: {reason}")
         if diagnostics_ref:
             lines.append(f"- Verification report: {diagnostics_ref}")
+        if remaining_work_ref:
+            lines.append(f"- Remaining work: {remaining_work_ref}")
+        if gate_result_ref and gate_result_ref != diagnostics_ref:
+            lines.append(f"- Verification gate result: {gate_result_ref}")
         lines.append("")
         lines.append(
             "Review the verification evidence before marking this pull "
@@ -9912,7 +9924,10 @@ class MoonMindRunWorkflow:
                     self._get_logger().info(
                         "Skipping native PR creation: publish output not required."
                     )
-                elif push_status == "no_commits":
+                elif (
+                    push_status == "no_commits"
+                    and self._moonspec_draft_publication_reason is None
+                ):
                     self._get_logger().info(
                         "Skipping native PR creation: agent made no commits "
                         "on branch '%s'.",
@@ -9964,6 +9979,7 @@ class MoonMindRunWorkflow:
                         )
                         pr_url = self._get_from_result(create_result, "url")
                         created = self._get_from_result(create_result, "created")
+                        adopted = self._get_from_result(create_result, "adopted")
                         summary = self._get_from_result(create_result, "summary") or ""
                         created_head_sha = self._coerce_text(
                             self._get_from_result(create_result, "headSha"),
@@ -9971,6 +9987,15 @@ class MoonMindRunWorkflow:
                         )
                         if created_head_sha:
                             self._publish_context["headSha"] = created_head_sha
+                        if (
+                            self._moonspec_draft_publication_reason is not None
+                            and not created
+                            and not adopted
+                        ):
+                            raise ValueError(
+                                "draft PR publication was rejected: "
+                                f"{summary or 'existing pull request is not a draft'}"
+                            )
                         if pr_url:
                             pull_request_url = pr_url
                             self._get_logger().info(
@@ -14223,6 +14248,13 @@ class MoonMindRunWorkflow:
         pull_request_url: str | None,
     ) -> None:
         if not pull_request_url:
+            return
+        if self._moonspec_draft_publication_reason is not None:
+            self._publish_context["mergeAutomationStatus"] = "not_applicable"
+            self._publish_context["mergeAutomationSummary"] = (
+                "Merge automation is disabled for an attention-required "
+                "MoonSpec draft pull request."
+            )
             return
         info = workflow.info()
         payload = self._build_merge_gate_start_payload(

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -589,6 +589,9 @@ RUN_MOONSPEC_GATE_CONTRACT_REPAIR_FRESH_SOURCE_PATCH = (
 RUN_MOONSPEC_GATE_ENVIRONMENT_DRAFT_PUBLISH_PATCH = (
     "run-moonspec-gate-environment-draft-publish-v1"
 )
+RUN_MOONSPEC_ADDITIONAL_WORK_DRAFT_PUBLISH_PATCH = (
+    "run-moonspec-additional-work-draft-publish-v1"
+)
 RUN_STEP_RETRY_OVERRIDES_PATCH = "run-step-retry-overrides-v1"
 # MM-880: compile + persist a versioned ResiliencePolicy envelope before step
 # execution begins so every step execution can be traced to the policy values
@@ -5882,7 +5885,31 @@ class MoonMindRunWorkflow:
             return False
         return bool(gate_context.get("degraded") or gate_context.get("invalid"))
 
-    def _activate_moonspec_draft_publication(self, gate_reason: str) -> str:
+    def _moonspec_draft_publication_policy(
+        self,
+        *,
+        environment_blocked_enabled: bool,
+        additional_work_enabled: bool,
+    ) -> str | None:
+        verdict = self._normalize_moonspec_verify_verdict(
+            self._moonspec_gate_verdict
+        )
+        if additional_work_enabled and verdict == "ADDITIONAL_WORK_NEEDED":
+            return "draft_pr_on_additional_work_needed"
+        if (
+            environment_blocked_enabled
+            and self._moonspec_environment_blocked_publish_action() == "draft_pr"
+            and self._moonspec_gate_qualifies_for_draft_publish()
+        ):
+            return "draft_pr_on_environment_blocked"
+        return None
+
+    def _activate_moonspec_draft_publication(
+        self,
+        gate_reason: str,
+        *,
+        policy: str = "draft_pr_on_environment_blocked",
+    ) -> str:
         summary = (
             "MoonSpec verification incomplete; publishing draft pull request "
             f"for operator review. {gate_reason}"
@@ -5891,11 +5918,9 @@ class MoonMindRunWorkflow:
         self._attention_required = True
         gate_context = self._publish_context.get("moonSpecGate")
         if isinstance(gate_context, dict):
-            gate_context["publicationPolicy"] = (
-                "draft_pr_on_environment_blocked"
-            )
+            gate_context["publicationPolicy"] = policy
         self._publish_context["moonSpecDraftPublication"] = {
-            "policy": "draft_pr_on_environment_blocked",
+            "policy": policy,
             "reason": gate_reason,
         }
         return summary
@@ -5909,15 +5934,30 @@ class MoonMindRunWorkflow:
             diagnostics_ref = self._coerce_text(
                 gate_context.get("diagnosticsRef"), max_chars=400
             )
+        draft_context = self._publish_context.get("moonSpecDraftPublication")
+        policy = (
+            draft_context.get("policy")
+            if isinstance(draft_context, Mapping)
+            else None
+        )
+        if policy == "draft_pr_on_additional_work_needed":
+            explanation = (
+                "the bounded remediation budget was exhausted with remaining "
+                "implementation work"
+            )
+        else:
+            explanation = (
+                "the operator policy "
+                "`workflow.moonspec_environment_blocked_publish_action` is "
+                "`draft_pr`"
+            )
         lines = [
             "## MoonSpec verification incomplete",
             "",
             (
                 "This pull request was opened as a **draft** because MoonSpec "
                 f"verification did not approve publication (verdict "
-                f"{verdict or 'unknown'}) and the operator policy "
-                "`workflow.moonspec_environment_blocked_publish_action` is "
-                "`draft_pr`."
+                f"{verdict or 'unknown'}) and {explanation}."
             ),
             "",
         ]
@@ -9599,18 +9639,30 @@ class MoonMindRunWorkflow:
                     if blocking_gate_reason and not bool(
                         continuation_decision.get("continueLoop")
                     ):
-                        if (
-                            workflow.patched(
-                                RUN_MOONSPEC_GATE_ENVIRONMENT_DRAFT_PUBLISH_PATCH
+                        environment_draft_publish_enabled = workflow.patched(
+                            RUN_MOONSPEC_GATE_ENVIRONMENT_DRAFT_PUBLISH_PATCH
+                        )
+                        additional_work_draft_publish_enabled = workflow.patched(
+                            RUN_MOONSPEC_ADDITIONAL_WORK_DRAFT_PUBLISH_PATCH
+                        )
+                        draft_publication_policy = (
+                            self._moonspec_draft_publication_policy(
+                                environment_blocked_enabled=(
+                                    environment_draft_publish_enabled
+                                ),
+                                additional_work_enabled=(
+                                    additional_work_draft_publish_enabled
+                                ),
                             )
-                            and self._moonspec_environment_blocked_publish_action()
-                            == "draft_pr"
-                            and publish_mode == "pr"
-                            and self._moonspec_gate_qualifies_for_draft_publish()
+                        )
+                        if (
+                            publish_mode == "pr"
+                            and draft_publication_policy is not None
                         ):
                             draft_summary = (
                                 self._activate_moonspec_draft_publication(
-                                    blocking_gate_reason
+                                    blocking_gate_reason,
+                                    policy=draft_publication_policy,
                                 )
                             )
                             self._summary = draft_summary

--- a/tests/unit/workflows/temporal/workflows/test_run_integration.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_integration.py
@@ -3522,9 +3522,38 @@ def test_additional_work_needed_publishes_draft_after_remediation_exhaustion(
     assert mock_run_workflow._publish_context["moonSpecGate"][
         "publicationPolicy"
     ] == "draft_pr_on_additional_work_needed"
-    assert "bounded remediation budget was exhausted" in (
-        mock_run_workflow._moonspec_draft_publication_body_section()
+    mock_run_workflow._publish_context["moonSpecGate"].update(
+        {
+            "gateResultRef": "artifact://gate/result",
+            "remainingWorkRef": "artifact://remaining/work",
+        }
     )
+    body = mock_run_workflow._moonspec_draft_publication_body_section()
+    assert "bounded remediation budget was exhausted" in body
+    assert "Remaining work: artifact://remaining/work" in body
+    assert "Verification gate result: artifact://gate/result" in body
+
+
+@pytest.mark.asyncio
+async def test_moonspec_draft_publication_disables_merge_automation(
+    mock_run_workflow: MoonMindRunWorkflow,
+) -> None:
+    mock_run_workflow._moonspec_draft_publication_reason = (
+        "Additional implementation work remains."
+    )
+
+    await mock_run_workflow._maybe_start_merge_gate(
+        parameters={"mergeAutomation": {"enabled": True}},
+        pull_request_url="https://github.com/org/repo/pull/123",
+    )
+
+    assert (
+        mock_run_workflow._publish_context["mergeAutomationStatus"]
+        == "not_applicable"
+    )
+    assert "disabled" in mock_run_workflow._publish_context[
+        "mergeAutomationSummary"
+    ]
 
 
 def test_additional_work_draft_publish_patch_preserves_old_history_behavior(

--- a/tests/unit/workflows/temporal/workflows/test_run_integration.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_integration.py
@@ -3494,6 +3494,56 @@ def test_moonspec_environment_blocked_publish_action_defaults_to_fail(
     )
 
 
+def test_additional_work_needed_publishes_draft_after_remediation_exhaustion(
+    mock_run_workflow: MoonMindRunWorkflow,
+) -> None:
+    mock_run_workflow._record_moonspec_verify_gate(
+        node_id="verify-final",
+        outputs={
+            "verdict": "ADDITIONAL_WORK_NEEDED",
+            "diagnostics_ref": "art_verify_remaining_work",
+        },
+    )
+    blocking_reason = mock_run_workflow._blocking_moonspec_gate_reason()
+    assert blocking_reason is not None
+
+    policy = mock_run_workflow._moonspec_draft_publication_policy(
+        environment_blocked_enabled=False,
+        additional_work_enabled=True,
+    )
+
+    assert policy == "draft_pr_on_additional_work_needed"
+    summary = mock_run_workflow._activate_moonspec_draft_publication(
+        blocking_reason,
+        policy=policy,
+    )
+    assert "draft pull request" in summary
+    assert mock_run_workflow._apply_blocking_moonspec_gate_to_publish() is False
+    assert mock_run_workflow._publish_context["moonSpecGate"][
+        "publicationPolicy"
+    ] == "draft_pr_on_additional_work_needed"
+    assert "bounded remediation budget was exhausted" in (
+        mock_run_workflow._moonspec_draft_publication_body_section()
+    )
+
+
+def test_additional_work_draft_publish_patch_preserves_old_history_behavior(
+    mock_run_workflow: MoonMindRunWorkflow,
+) -> None:
+    mock_run_workflow._record_moonspec_verify_gate(
+        node_id="verify-final",
+        outputs={"verdict": "ADDITIONAL_WORK_NEEDED"},
+    )
+
+    assert (
+        mock_run_workflow._moonspec_draft_publication_policy(
+            environment_blocked_enabled=True,
+            additional_work_enabled=False,
+        )
+        is None
+    )
+
+
 def test_moonspec_draft_publication_supersedes_blocking_gate(
     mock_run_workflow: MoonMindRunWorkflow,
 ) -> None:


### PR DESCRIPTION
## What changed

- automatically opens a draft PR when MoonSpec verification remains `ADDITIONAL_WORK_NEEDED` after the bounded remediation budget is exhausted
- keeps downstream promotion and trusted handoff steps skipped
- annotates the draft with the verdict, verification evidence, and remaining-work context
- adds a new Temporal patch marker so pre-change histories preserve their original fail-closed replay behavior
- aligns the canonical publishing and Step Execution documentation

## Root cause

MoonMind deliberately classified `ADDITIONAL_WORK_NEEDED` as an implementation-gap verdict that could never qualify for draft publication. The only existing draft path was opt-in and limited to environment-class `BLOCKED` or degraded `NO_DETERMINATION` outcomes, so the workflow stopped before native PR creation even though its publish mode was `pr` and its work was reviewable.

## Behavior after this change

When remediation remains available, the workflow continues remediation exactly as before. After the budget is exhausted, `ADDITIONAL_WORK_NEEDED` publishes a draft PR, completes with `attention_required: true`, and does not advance Jira, merge automation, or other trusted side effects.

## Validation

- `tests/unit/workflows/temporal/workflows/test_run_integration.py`: 126 passed
- `tests/unit/workflows/temporal/workflows/test_run_step_ledger.py`: 71 passed
- Ruff checks passed for the changed Python files
- `git diff --check` passed
