### PR TITLE
Make the highlight-edge bottom light visible at 1x

### DIFF
--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -21,10 +21,16 @@
   --mm-danger: 244 63 94;
   --mm-action-primary: 21 147 118;
   --mm-shadow: 0 18px 32px -26px rgb(10 8 30 / 0.55);
+  /* Highlight-edge treatment: bright top-edge inset, a lit bottom-edge inset
+   * (accent lightened toward white), a hairline ring that closes the shape,
+   * and a tight accent glow hugging the bottom edge. The previous wide glow
+   * (0 18px 32px -16px) was too diffuse to register at 1x against the
+   * masthead's glass fill, which left the bottom edge reading as unlit. */
   --mm-shadow-highlight-edge:
     inset 0 1px 0 rgb(255 255 255 / 0.26),
+    inset 0 -1px 0 rgb(167 139 250 / 0.75),
     0 0 0 1px rgb(255 255 255 / 0.34),
-    0 18px 32px -16px rgb(var(--mm-accent) / 0.94);
+    0 3px 9px -2px rgb(var(--mm-accent) / 0.75);
   --mm-atmosphere-violet: radial-gradient(circle at 8% 0%, rgb(var(--mm-accent) / 0.18), transparent 44%);
   --mm-atmosphere-cyan: radial-gradient(circle at 98% 0%, rgb(var(--mm-accent-2) / 0.14), transparent 42%);
   --mm-atmosphere-warm: radial-gradient(circle at 50% 100%, rgb(var(--mm-accent-warm) / 0.10), transparent 52%);

--- a/frontend/src/styles/dashboardBrand.test.ts
+++ b/frontend/src/styles/dashboardBrand.test.ts
@@ -97,11 +97,15 @@ describe('dashboard masthead brand styles', () => {
   });
 
   it('gives the nav buttons and list display control the highlight-edge look with a sliding thumb', () => {
-    // The shared treatment: a bright top-edge inset, a hairline ring that
-    // closes the shape so the bottom edge reads as lit, and an accent
-    // under-glow.
+    // The shared treatment: a bright top-edge inset, a lit bottom-edge inset,
+    // a hairline ring that closes the shape, and a tight accent glow hugging
+    // the bottom edge (a wide diffuse glow does not register at 1x against
+    // the masthead's glass fill).
     const highlightShadow =
       /box-shadow:\s*var\(--mm-shadow-highlight-edge\);/;
+    expect(dashboardCss).toMatch(
+      /--mm-shadow-highlight-edge:\s*inset 0 1px 0 rgb\(255 255 255 \/ 0\.26\),\s*inset 0 -1px 0 rgb\(167 139 250 \/ 0\.75\),\s*0 0 0 1px rgb\(255 255 255 \/ 0\.34\),\s*0 3px 9px -2px rgb\(var\(--mm-accent\) \/ 0\.75\);/,
+    );
 
     // Radio group: highlight-edge chrome, tightened enough (option < 2rem,
     // padding < 0.18rem) that it does not out-size the nav buttons, plus a


### PR DESCRIPTION
## Summary

[#3230](https://github.com/MoonLadderStudios/MoonMind/pull/3230) closed the nav-button shape with a hairline ring, but on the deployed dashboard (v20260712.3691, confirmed via live computed styles) the buttons still show no bottom-edge light at actual size: the ring reads as a flat uniform border, and the wide under-glow (`0 18px 32px -16px`) is too diffuse to register against the masthead's glass fill.

This reworks the shared `--mm-shadow-highlight-edge` token so the bottom edge visibly reads as lit at 1x:

- **Add a lit bottom-edge inset** — `inset 0 -1px 0 rgb(167 139 250 / 0.75)` (the accent lightened toward white), mirroring the bright top-edge inset.
- **Replace the wide diffuse glow with a tight one hugging the bottom edge** — `0 3px 9px -2px rgb(var(--mm-accent) / 0.75)`.
- Top-edge inset and hairline ring are unchanged; all shadows remain non-layout-affecting, so the active underline geometry and masthead height are untouched.

The token is also consumed by the global `button`/`.button` hover rules, so primary CTA hovers pick up the tighter glow as well — their ring and top highlight are unchanged.

## Testing

- Six candidate treatments were screenshotted against the live deployed masthead via style injection, judged at both 1x and 2x (the #3230 verification only judged 2x crops, which oversold the diffuse glow). The chosen stack shows a clearly lit bottom edge on all three nav buttons and the list radio group at both scales.
- `frontend/src/styles/dashboardBrand.test.ts` (7 passed; now pins the token's full shadow stack) and `frontend/src/entrypoints/dashboard.test.tsx` (130 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)