### PR TITLE
MM-1211: project workflow.git.branch as startingBranch

### DIFF
--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -3747,13 +3747,15 @@ def _serialize_execution(
 
     publish_payload = _normalize_publish_payload(task_payload.get("publish"))
 
-    # Precedence: task.git.startingBranch > task.startingBranch > params.startingBranch
-    starting_branch = str(
-        git_payload.get("startingBranch")
-        or task_payload.get("startingBranch")
-        or params.get("startingBranch")
-        or ""
-    ).strip() or None
+    # Precedence: task.git.startingBranch > task.git.branch >
+    # task.startingBranch > params.startingBranch
+    starting_branch = (
+        _coerce_temporal_scalar(git_payload.get("startingBranch"))
+        or _coerce_temporal_scalar(git_payload.get("branch"))
+        or _coerce_temporal_scalar(task_payload.get("startingBranch"))
+        or _coerce_temporal_scalar(params.get("startingBranch"))
+        or None
+    )
     # Only show the "(default)" fallback when git context exists in the payload.
     has_git_context = bool(git_payload) or any(
         task_payload.get(k) or params.get(k)

--- a/tests/unit/api/routers/test_execution_branch_projection.py
+++ b/tests/unit/api/routers/test_execution_branch_projection.py
@@ -1,0 +1,87 @@
+from datetime import UTC, datetime
+from types import SimpleNamespace
+
+from api_service.api.routers.executions import _serialize_execution
+from api_service.db.models import MoonMindWorkflowState, TemporalWorkflowType
+
+
+def _make_execution_record(*, parameters: dict) -> SimpleNamespace:
+    now = datetime.now(UTC)
+    return SimpleNamespace(
+        namespace="default",
+        workflow_id="mm:wf-1",
+        run_id="run-1",
+        workflow_type=TemporalWorkflowType.USER_WORKFLOW,
+        state=MoonMindWorkflowState.EXECUTING,
+        close_status=None,
+        search_attributes={"mm_entry": "run"},
+        memo={"title": "MM-1211 branch projection"},
+        artifact_refs=[],
+        manifest_ref=None,
+        plan_ref=None,
+        scheduled_for=None,
+        created_at=now,
+        started_at=now,
+        updated_at=now,
+        closed_at=None,
+        entry="run",
+        parameters=parameters,
+        owner_id="system",
+    )
+
+
+def test_serialize_execution_projects_git_branch_as_starting_branch():
+    record = _make_execution_record(
+        parameters={
+            "workflow": {"git": {"branch": "agent/mm-38abc67f-recovered"}}
+        }
+    )
+
+    result = _serialize_execution(record)
+
+    assert result.starting_branch == "agent/mm-38abc67f-recovered"
+    assert (
+        result.model_dump(by_alias=True)["startingBranch"]
+        == "agent/mm-38abc67f-recovered"
+    )
+
+
+def test_explicit_git_starting_branch_keeps_precedence_over_git_branch():
+    record = _make_execution_record(
+        parameters={
+            "workflow": {
+                "git": {
+                    "startingBranch": "legacy-explicit-base",
+                    "branch": "canonical-authored-branch",
+                }
+            }
+        }
+    )
+
+    assert _serialize_execution(record).starting_branch == "legacy-explicit-base"
+
+
+def test_whitespace_git_starting_branch_does_not_mask_git_branch():
+    record = _make_execution_record(
+        parameters={
+            "workflow": {
+                "git": {
+                    "startingBranch": " ",
+                    "branch": "agent/mm-38abc67f-recovered",
+                }
+            }
+        }
+    )
+
+    assert (
+        _serialize_execution(record).starting_branch
+        == "agent/mm-38abc67f-recovered"
+    )
+
+
+def test_git_context_without_authored_branch_keeps_default_fallback():
+    record = _make_execution_record(
+        parameters={"workflow": {"git": {"defaultBranch": "develop"}}}
+    )
+
+    assert _serialize_execution(record).starting_branch == "develop (default)"


### PR DESCRIPTION
Issue reference: MM-1211
Issue tracker: https://moonladder.atlassian.net/browse/MM-1211

Summary
- Project canonical workflow.git.branch as startingBranch after explicit git.startingBranch.
- Ignore whitespace-only compatibility values so they do not mask the authored branch.
- Preserve genuine default-branch fallback and leave targetBranch and publishing behavior unchanged.
- Add focused regression coverage for projection, precedence, whitespace handling, and fallback.

Tests run
- MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/routers/test_execution_branch_projection.py (pass: 4 focused Python tests; repository UI suite also passed)
- python -m pytest -q --tb=short tests/integration/test_proposal_delivery_status_surfaces.py tests/integration/test_proposal_delivery_status_execution_detail.py tests/integration/temporal/test_task_runtime_inheritance.py tests/integration/temporal/test_workflow_execution_terminology.py (pass: 8 tests)

Remaining risks
- None identified; the serializer-only change is covered at unit and existing serialization integration boundaries.