### PR TITLE
Fix step timeline status icons collapsing to ~4px in Workflow Detail

### DIFF
--- a/frontend/src/entrypoints/dashboard.test.tsx
+++ b/frontend/src/entrypoints/dashboard.test.tsx
@@ -2510,10 +2510,14 @@ describe('Dashboard shared entry', () => {
     expect(iconBlock).toContain('width: 1.35rem');
     expect(iconBlock).toContain('height: 1.35rem');
     expect(iconBlock).toContain('border-radius: 50%');
+    // The .status pill padding must be reset here: with border-box sizing it
+    // starves the circle's content box and the svg flex-shrinks to ~4px.
+    expect(iconBlock).toContain('padding: 0');
 
     const svgBlock = cssRuleBlock(dashboardCss, '.step-tl-icon svg');
-    expect(svgBlock).toContain('width: 1.3rem');
-    expect(svgBlock).toContain('height: 1.3rem');
+    expect(svgBlock).toContain('width: 1.05rem');
+    expect(svgBlock).toContain('height: 1.05rem');
+    expect(svgBlock).toContain('flex: none');
     expect(svgBlock).toContain('stroke-width: 2');
   });
 

--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -4654,6 +4654,9 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
   justify-content: center;
   width: 1.35rem;
   height: 1.35rem;
+  /* Reset the .status pill padding; with border-box it starves the content
+     box and the flex-shrinking svg collapses to a few pixels. */
+  padding: 0;
   border-radius: 50%;
   flex-shrink: 0;
   border: 1.5px solid rgb(var(--mm-border) / 0.6);
@@ -4662,8 +4665,10 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
 }
 
 .step-tl-icon svg {
-  width: 1.3rem;
-  height: 1.3rem;
+  width: 1.05rem;
+  height: 1.05rem;
+  /* flex: none keeps the declared size authoritative inside the circle. */
+  flex: none;
   stroke-width: 2;
 }
 


### PR DESCRIPTION
## Related issue

Related to MM-1132 (#3214, prior attempt)

## Summary

- Workflow Detail step timeline icons rendered as tiny ~4px dots despite repeated enlargement attempts. The `StatusIcon` span carries both the `.status` pill classes and `.step-tl-icon`; the pill rule''s `padding: 0.12rem 0.46rem` was never reset on the circle. With the global `* { box-sizing: border-box }`, the 1.35rem circle minus padding and border left a ~4px content box, and the svg (a flex item with default `flex-shrink: 1`) silently collapsed to fit — so bumping the declared svg width in #3214 had no visible effect.
- Fix: reset `padding: 0` on `.step-tl-icon`, set `flex: none` on the svg so its declared size is authoritative, and size it at `1.05rem` to honestly fit the circle''s 18.6px interior (the previous 1.3rem declaration never actually rendered and would overflow the border).
- Pinned `padding: 0` and `flex: none` in the MM-1132 assertions in `dashboard.test.tsx` so the collapse cannot silently regress.

**ELI5:** the icon circle secretly kept pill-shaped padding from a shared class, which squeezed the icon''s available space down to a few pixels, and the icon shrank to fit. Making the icon "bigger" in CSS did nothing because the squeeze happened after. We removed the padding and forbade the shrink.

## Test Plan

```bash
npm run ui:test -- frontend/src/entrypoints/dashboard.test.tsx frontend/src/utils/statusIcons.test.tsx
# 2 files, 135 tests passed
```

Manual: rendered a harness page linking the real `dashboard.css` against production step-row markup (dark theme, before/after) and screenshotted with headless Chromium. Before reproduces the tiny dots; after shows distinguishable check / play / X / ban glyphs filling their circles.

## Demo

Verified via the harness screenshot described above (before/after side by side). Note: the deployed dashboard bundle is image-baked, so the fix appears only after the dashboard image is rebuilt.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / dashboard change
- [ ] Runtime / agent adapter change
- [ ] Workflow / Temporal change
- [ ] Security / policy / sandboxing change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] Frontend tests added / updated
- [ ] Workflow boundary tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## AI assistance

- [ ] No material AI assistance
- [x] AI-assisted or AI-generated contribution

If AI-assisted:

- Tool or workflow used: Claude Code (Claude Fable 5)
- What the AI helped with: root-cause investigation, CSS fix, test pin updates, harness verification
- What I manually reviewed: diff and rendered before/after screenshot
- What I verified independently: targeted Vitest suites pass

I understand that I am responsible for the final submitted change.

## Risk notes

CSS-only change scoped to `.step-tl-icon`; no secrets, workflows, or runtime paths touched.

## Coverage notes

Manual verification: headless-Chromium screenshot of a harness page linking the real stylesheet against production markup, per the repo''s UI verification guidance.

## Changelog

Workflow Detail step timeline status icons are now legible instead of collapsing to a few pixels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)