### PR TITLE
Open the highlight-edge sides: top highlight + backlit bottom rim, no ring

### DIFF
--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -21,15 +21,14 @@
   --mm-danger: 244 63 94;
   --mm-action-primary: 21 147 118;
   --mm-shadow: 0 18px 32px -26px rgb(10 8 30 / 0.55);
-  /* Highlight-edge treatment: bright top-edge inset, a lit bottom-edge inset
-   * (accent lightened toward white), a hairline ring that closes the shape,
-   * and a tight accent glow hugging the bottom edge. The previous wide glow
-   * (0 18px 32px -16px) was too diffuse to register at 1x against the
-   * masthead's glass fill, which left the bottom edge reading as unlit. */
+  /* Highlight-edge treatment: a bright top-edge inset, a faint lit
+   * bottom-edge inset (accent lightened toward white), and a tight accent
+   * glow hugging the bottom edge so it reads as backlit. Deliberately NO
+   * perimeter ring: the sides stay open — light on the top and bottom edges
+   * only — rather than reading as an outlined button. */
   --mm-shadow-highlight-edge:
     inset 0 1px 0 rgb(255 255 255 / 0.26),
-    inset 0 -1px 0 rgb(167 139 250 / 0.75),
-    0 0 0 1px rgb(255 255 255 / 0.34),
+    inset 0 -1px 0 rgb(167 139 250 / 0.4),
     0 3px 9px -2px rgb(var(--mm-accent) / 0.75);
   --mm-atmosphere-violet: radial-gradient(circle at 8% 0%, rgb(var(--mm-accent) / 0.18), transparent 44%);
   --mm-atmosphere-cyan: radial-gradient(circle at 98% 0%, rgb(var(--mm-accent-2) / 0.14), transparent 42%);
@@ -4378,7 +4377,10 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
     rgb(var(--mm-accent) / 0.98) 100%
   );
   border-color: rgb(255 255 255 / 0.82);
-  box-shadow: var(--mm-shadow-highlight-edge);
+  /* Filled CTAs keep their own hover shadow (ring + wide glow): the shared
+   * highlight-edge token is side-open by design, but a hovered solid button
+   * still wants its full outline pop. */
+  box-shadow: inset 0 1px 0 rgb(255 255 255 / 0.26), 0 0 0 1px rgb(255 255 255 / 0.34), 0 18px 32px -16px rgb(var(--mm-accent) / 0.94);
   transform: scale(var(--mm-control-hover-scale));
   filter: brightness(1.08) saturate(1.04);
 }
@@ -4473,7 +4475,10 @@ button.workflow-list-column-filter-button.is-active {
     rgb(var(--mm-accent) / 0.98) 100%
   );
   border-color: rgb(255 255 255 / 0.82);
-  box-shadow: var(--mm-shadow-highlight-edge);
+  /* Filled CTAs keep their own hover shadow (ring + wide glow): the shared
+   * highlight-edge token is side-open by design, but a hovered solid button
+   * still wants its full outline pop. */
+  box-shadow: inset 0 1px 0 rgb(255 255 255 / 0.26), 0 0 0 1px rgb(255 255 255 / 0.34), 0 18px 32px -16px rgb(var(--mm-accent) / 0.94);
   transform: scale(var(--mm-control-hover-scale));
   filter: brightness(1.08) saturate(1.04);
 }

--- a/frontend/src/styles/dashboardBrand.test.ts
+++ b/frontend/src/styles/dashboardBrand.test.ts
@@ -97,14 +97,19 @@ describe('dashboard masthead brand styles', () => {
   });
 
   it('gives the nav buttons and list display control the highlight-edge look with a sliding thumb', () => {
-    // The shared treatment: a bright top-edge inset, a lit bottom-edge inset,
-    // a hairline ring that closes the shape, and a tight accent glow hugging
-    // the bottom edge (a wide diffuse glow does not register at 1x against
-    // the masthead's glass fill).
+    // The shared treatment: a bright top-edge inset, a faint lit bottom-edge
+    // inset, and a tight accent glow hugging the bottom edge so it reads as
+    // backlit (a wide diffuse glow does not register at 1x against the
+    // masthead's glass fill). The sides stay open — no perimeter ring.
     const highlightShadow =
       /box-shadow:\s*var\(--mm-shadow-highlight-edge\);/;
     expect(dashboardCss).toMatch(
-      /--mm-shadow-highlight-edge:\s*inset 0 1px 0 rgb\(255 255 255 \/ 0\.26\),\s*inset 0 -1px 0 rgb\(167 139 250 \/ 0\.75\),\s*0 0 0 1px rgb\(255 255 255 \/ 0\.34\),\s*0 3px 9px -2px rgb\(var\(--mm-accent\) \/ 0\.75\);/,
+      /--mm-shadow-highlight-edge:\s*inset 0 1px 0 rgb\(255 255 255 \/ 0\.26\),\s*inset 0 -1px 0 rgb\(167 139 250 \/ 0\.4\),\s*0 3px 9px -2px rgb\(var\(--mm-accent\) \/ 0\.75\);/,
+    );
+    // The token must stay side-open: no perimeter ring, so the buttons read
+    // as a top highlight plus a backlit bottom rim instead of an outline.
+    expect(dashboardCss).not.toMatch(
+      /--mm-shadow-highlight-edge:[^;]*0 0 0 1px/s,
     );
 
     // Radio group: highlight-edge chrome, tightened enough (option < 2rem,


### PR DESCRIPTION
## Summary

After [#3234](https://github.com/MoonLadderStudios/MoonMind/pull/3234) the bottom glow is present, but the hairline perimeter ring (`0 0 0 1px rgb(255 255 255 / 0.34)`, introduced in #3230) makes the nav buttons read as fully **outlined**. The intended look is light on the horizontal edges only: a bright top highlight and a bottom rim that reads as backlit, with the sides open.

- `--mm-shadow-highlight-edge` drops the perimeter ring and softens the bottom inset (`rgb(167 139 250)` at 0.75 → **0.4**) so it reads as a lighting effect rather than a border; the bright top inset and the tight accent glow hugging the bottom edge are kept.
- The filled `button`/`.button` **hover** rules previously shared this token, but a hovered solid CTA still wants its full outline pop — they return to their long-standing inline hover shadow (ring + wide glow), byte-identical to what they had before the token refactor. The token's only consumers are now the masthead trio (Workflows/Create/System) and the list-display radio group.
- The brand test pins the new token stack and additionally asserts the token stays side-open (no `0 0 0 1px` component), so the outline can't quietly come back.

## Testing

- Four no-ring candidates were screenshotted against the live deployed masthead (dark theme, headless Chromium, style injection) and judged at both 1x and 2x; the chosen stack shows open sides, a lit top edge, and a clearly backlit bottom rim at actual size on all three nav buttons and the radio group.
- `frontend/src/styles/dashboardBrand.test.ts` (7 passed) and `frontend/src/entrypoints/dashboard.test.tsx` (130 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)