### PR TITLE
Soften the highlight-edge glow and keep it on the bottom edge

### DIFF
--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -22,14 +22,15 @@
   --mm-action-primary: 21 147 118;
   --mm-shadow: 0 18px 32px -26px rgb(10 8 30 / 0.55);
   /* Highlight-edge treatment: a bright top-edge inset, a faint lit
-   * bottom-edge inset (accent lightened toward white), and a tight accent
-   * glow hugging the bottom edge so it reads as backlit. Deliberately NO
-   * perimeter ring: the sides stay open — light on the top and bottom edges
-   * only — rather than reading as an outlined button. */
+   * bottom-edge inset (accent lightened toward white), and a quite faint
+   * accent glow kept almost entirely on the bottom edge so it reads as
+   * backlit (the negative spread pulls the blur off the sides). Deliberately
+   * NO perimeter ring: the sides stay open — light on the top and bottom
+   * edges only — rather than reading as an outlined button. */
   --mm-shadow-highlight-edge:
     inset 0 1px 0 rgb(255 255 255 / 0.26),
     inset 0 -1px 0 rgb(167 139 250 / 0.4),
-    0 3px 9px -2px rgb(var(--mm-accent) / 0.75);
+    0 5px 9px -5px rgb(var(--mm-accent) / 0.45);
   --mm-atmosphere-violet: radial-gradient(circle at 8% 0%, rgb(var(--mm-accent) / 0.18), transparent 44%);
   --mm-atmosphere-cyan: radial-gradient(circle at 98% 0%, rgb(var(--mm-accent-2) / 0.14), transparent 42%);
   --mm-atmosphere-warm: radial-gradient(circle at 50% 100%, rgb(var(--mm-accent-warm) / 0.10), transparent 52%);

--- a/frontend/src/styles/dashboardBrand.test.ts
+++ b/frontend/src/styles/dashboardBrand.test.ts
@@ -98,13 +98,13 @@ describe('dashboard masthead brand styles', () => {
 
   it('gives the nav buttons and list display control the highlight-edge look with a sliding thumb', () => {
     // The shared treatment: a bright top-edge inset, a faint lit bottom-edge
-    // inset, and a tight accent glow hugging the bottom edge so it reads as
-    // backlit (a wide diffuse glow does not register at 1x against the
-    // masthead's glass fill). The sides stay open — no perimeter ring.
+    // inset, and a quite faint accent glow kept almost entirely on the bottom
+    // edge so it reads as backlit — the negative spread pulls the blur off
+    // the sides. The sides stay open — no perimeter ring.
     const highlightShadow =
       /box-shadow:\s*var\(--mm-shadow-highlight-edge\);/;
     expect(dashboardCss).toMatch(
-      /--mm-shadow-highlight-edge:\s*inset 0 1px 0 rgb\(255 255 255 \/ 0\.26\),\s*inset 0 -1px 0 rgb\(167 139 250 \/ 0\.4\),\s*0 3px 9px -2px rgb\(var\(--mm-accent\) \/ 0\.75\);/,
+      /--mm-shadow-highlight-edge:\s*inset 0 1px 0 rgb\(255 255 255 \/ 0\.26\),\s*inset 0 -1px 0 rgb\(167 139 250 \/ 0\.4\),\s*0 5px 9px -5px rgb\(var\(--mm-accent\) \/ 0\.45\);/,
     );
     // The token must stay side-open: no perimeter ring, so the buttons read
     // as a top highlight plus a backlit bottom rim instead of an outline.


### PR DESCRIPTION
## Summary

The glow shipped in [#3237](https://github.com/MoonLadderStudios/MoonMind/pull/3237) (`0 3px 9px -2px accent/0.75`) is too intense and its blur wraps around the button sides. This retunes the glow component of `--mm-shadow-highlight-edge` to `0 5px 9px -5px rgb(var(--mm-accent) / 0.45)`:

- the larger negative spread (-5) pulls the blur off the sides entirely,
- the larger downward offset (5px) keeps what remains below the button,
- the lower alpha (0.45) makes it read as a quite faint backlight, matching the original reference look.

The top-edge and bottom-edge insets are unchanged, sides stay open (the brand test still asserts no perimeter ring), and nothing affects layout. The token's only consumers remain the masthead trio and the list-display radio group.

## Testing

- Four glow retunes were screenshotted against the live deployed masthead (dark theme, headless Chromium, style injection) and judged at 1x and 2x; the chosen one keeps a perceptible backlit bottom rim at actual size with no side spill.
- `frontend/src/styles/dashboardBrand.test.ts` (7 passed, token pin updated) and `frontend/src/entrypoints/dashboard.test.tsx` (130 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)