### PR TITLE
Liquid-glass corner asymmetry + cyan grow/brighten hover for nav buttons

### DIFF
--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -21,16 +21,26 @@
   --mm-danger: 244 63 94;
   --mm-action-primary: 21 147 118;
   --mm-shadow: 0 18px 32px -26px rgb(10 8 30 / 0.55);
-  /* Highlight-edge treatment: a bright top-edge inset, a faint lit
-   * bottom-edge inset (accent lightened toward white), and a quite faint
-   * accent glow kept almost entirely on the bottom edge so it reads as
-   * backlit (the negative spread pulls the blur off the sides). Deliberately
-   * NO perimeter ring: the sides stay open — light on the top and bottom
-   * edges only — rather than reading as an outlined button. */
+  /* Highlight-edge treatment, liquid-glass style: faint uniform top/bottom
+   * edge lines plus diagonally offset corner boosts, so the top-left corner
+   * catches white light and the bottom-right corner catches the violet rim —
+   * deliberately asymmetric rather than horizontally uniform. A quite faint
+   * accent glow sits almost entirely under the bottom edge so it reads as
+   * backlit (the negative spread pulls the blur off the sides). No perimeter
+   * ring: the sides stay open. The hover variant swaps the under-glow to the
+   * cyan accent (the executing-pill hue). */
   --mm-shadow-highlight-edge:
-    inset 0 1px 0 rgb(255 255 255 / 0.26),
-    inset 0 -1px 0 rgb(167 139 250 / 0.4),
+    inset 0 1px 0 rgb(255 255 255 / 0.12),
+    inset 2px 2px 3px -2px rgb(255 255 255 / 0.3),
+    inset 0 -1px 0 rgb(167 139 250 / 0.18),
+    inset -2px -2px 3px -2px rgb(167 139 250 / 0.55),
     0 5px 9px -5px rgb(var(--mm-accent) / 0.45);
+  --mm-shadow-highlight-edge-hover:
+    inset 0 1px 0 rgb(255 255 255 / 0.12),
+    inset 2px 2px 3px -2px rgb(255 255 255 / 0.3),
+    inset 0 -1px 0 rgb(167 139 250 / 0.18),
+    inset -2px -2px 3px -2px rgb(167 139 250 / 0.55),
+    0 5px 9px -5px rgb(var(--mm-accent-2) / 0.55);
   --mm-atmosphere-violet: radial-gradient(circle at 8% 0%, rgb(var(--mm-accent) / 0.18), transparent 44%);
   --mm-atmosphere-cyan: radial-gradient(circle at 98% 0%, rgb(var(--mm-accent-2) / 0.14), transparent 42%);
   --mm-atmosphere-warm: radial-gradient(circle at 50% 100%, rgb(var(--mm-accent-warm) / 0.10), transparent 52%);
@@ -679,18 +689,24 @@ h1 {
   transition: background 130ms ease, color 130ms ease;
 }
 
-/* Workflows and Create adopt the System trigger's original highlight-edge
- * treatment: a bright top-edge inset, a hairline ring that closes the shape
- * (so the bottom edge reads as lit, not open), and an accent under-glow. The
- * mid-strength idle glow alone is too diffuse to register against the
- * masthead's glass fill, so the ring carries the bottom-edge light. Scoped to
- * `.route-nav-primary` so the System popover menu items — which also match
- * `.route-nav a` — keep their flat menu-row look. All three shadows are
- * non-layout-affecting, so the link box height, and thus the active underline
- * on the masthead edge, is unchanged. Higher-specificity :hover /
- * :focus-visible / .active rules still win, so those states are preserved. */
+/* Workflows and Create share the liquid-glass highlight-edge treatment with
+ * the System trigger. Scoped to `.route-nav-primary` so the System popover
+ * menu items — which also match `.route-nav a` — keep their flat menu-row
+ * look. The shadows are non-layout-affecting and the hover scale is a
+ * transform, so the link box height, and thus the active underline on the
+ * masthead edge, is unchanged. :focus-visible / .active rules have higher
+ * specificity and still win. */
 .route-nav-primary a {
   box-shadow: var(--mm-shadow-highlight-edge);
+  transition: var(--mm-control-transition), color 130ms ease;
+}
+
+/* Hovered nav buttons brighten, grow slightly, and swap the purple under-glow
+ * for the cyan accent — matching the System trigger's hover feel. */
+.route-nav-primary a:hover {
+  box-shadow: var(--mm-shadow-highlight-edge-hover);
+  transform: scale(var(--mm-control-hover-scale));
+  filter: brightness(1.08) saturate(1.04);
 }
 
 .route-nav-icon {
@@ -747,12 +763,10 @@ h1 {
   padding: 0.48rem 0.82rem;
   border: 0;
   border-radius: 0.5rem;
-  /* Highlight-edge button: transparent fill with a bright top-edge inset, a
-   * hairline ring that closes the shape so the bottom edge reads as lit, and
-   * an accent under-glow (the trigger's original look, stated explicitly
-   * rather than inherited from the global button rules). All three shadows
-   * are non-layout-affecting, so the box size — and therefore the active
-   * underline position on the masthead's bottom edge — is unchanged. */
+  /* Liquid-glass highlight-edge button: transparent fill with the shared
+   * asymmetric edge shadows. Non-layout-affecting, so the box size — and
+   * therefore the active underline position on the masthead's bottom edge —
+   * is unchanged. */
   background: transparent;
   box-shadow: var(--mm-shadow-highlight-edge);
   color: rgb(var(--mm-ink) / 0.82);
@@ -761,10 +775,17 @@ h1 {
   cursor: pointer;
 }
 
+/* Same hover feel as the primary nav links: brighten, grow slightly, cyan
+ * under-glow. Stating box-shadow/transform/filter here also keeps the global
+ * button:hover rule (ring + wide purple glow, for filled CTAs) from leaking
+ * onto the trigger. */
 .dashboard-system-trigger:hover,
 .dashboard-system-trigger[aria-expanded="true"] {
   background: rgb(var(--mm-ink) / 0.06);
   color: rgb(var(--mm-ink));
+  box-shadow: var(--mm-shadow-highlight-edge-hover);
+  transform: scale(var(--mm-control-hover-scale));
+  filter: brightness(1.08) saturate(1.04);
 }
 
 .dashboard-system-trigger.active {
@@ -7882,6 +7903,7 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
     transform: none !important;
   }
 
+  .route-nav-primary a,
   .dashboard-system-trigger,
   .dashboard-system-popover {
     animation: none !important;

--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -775,15 +775,18 @@ h1 {
   cursor: pointer;
 }
 
-/* Same hover feel as the primary nav links: brighten, grow slightly, cyan
- * under-glow. Stating box-shadow/transform/filter here also keeps the global
- * button:hover rule (ring + wide purple glow, for filled CTAs) from leaking
- * onto the trigger. */
+/* The open and hover states share the highlighted surface and cyan under-glow.
+ * Stating box-shadow here also keeps the global button:hover rule (ring + wide
+ * purple glow, for filled CTAs) from leaking onto the trigger. */
 .dashboard-system-trigger:hover,
 .dashboard-system-trigger[aria-expanded="true"] {
   background: rgb(var(--mm-ink) / 0.06);
   color: rgb(var(--mm-ink));
   box-shadow: var(--mm-shadow-highlight-edge-hover);
+}
+
+/* Keep hover-only motion and brightening out of the persistent open state. */
+.dashboard-system-trigger:hover {
   transform: scale(var(--mm-control-hover-scale));
   filter: brightness(1.08) saturate(1.04);
 }

--- a/frontend/src/styles/dashboardBrand.test.ts
+++ b/frontend/src/styles/dashboardBrand.test.ts
@@ -168,6 +168,13 @@ describe('dashboard masthead brand styles', () => {
       expect(hover).toContain('transform: scale(var(--mm-control-hover-scale));');
       expect(hover).toMatch(/filter: brightness\([\d.]+\)/);
     }
+
+    // Opening the System popover keeps its highlighted surface without
+    // leaving the trigger scaled or brightened after hover ends.
+    const expandedTrigger = cssRuleBlock('.dashboard-system-trigger[aria-expanded="true"]');
+    expect(expandedTrigger).toContain('box-shadow: var(--mm-shadow-highlight-edge-hover);');
+    expect(expandedTrigger).not.toContain('transform:');
+    expect(expandedTrigger).not.toContain('filter:');
   });
 
   it('marks the open System selection like the sidebar instead of the trigger underline', () => {

--- a/frontend/src/styles/dashboardBrand.test.ts
+++ b/frontend/src/styles/dashboardBrand.test.ts
@@ -97,19 +97,30 @@ describe('dashboard masthead brand styles', () => {
   });
 
   it('gives the nav buttons and list display control the highlight-edge look with a sliding thumb', () => {
-    // The shared treatment: a bright top-edge inset, a faint lit bottom-edge
-    // inset, and a quite faint accent glow kept almost entirely on the bottom
-    // edge so it reads as backlit — the negative spread pulls the blur off
-    // the sides. The sides stay open — no perimeter ring.
+    // The shared liquid-glass treatment: faint uniform edge lines plus
+    // diagonally offset corner boosts (top-left white, bottom-right violet),
+    // and a quite faint accent glow kept almost entirely on the bottom edge —
+    // the negative spread pulls the blur off the sides. The sides stay open —
+    // no perimeter ring. The hover variant swaps the under-glow to the cyan
+    // accent (executing-pill hue).
     const highlightShadow =
       /box-shadow:\s*var\(--mm-shadow-highlight-edge\);/;
+    const asymmetricInsets =
+      String.raw`inset 0 1px 0 rgb\(255 255 255 \/ 0\.12\),\s*inset 2px 2px 3px -2px rgb\(255 255 255 \/ 0\.3\),\s*inset 0 -1px 0 rgb\(167 139 250 \/ 0\.18\),\s*inset -2px -2px 3px -2px rgb\(167 139 250 \/ 0\.55\)`;
     expect(dashboardCss).toMatch(
-      /--mm-shadow-highlight-edge:\s*inset 0 1px 0 rgb\(255 255 255 \/ 0\.26\),\s*inset 0 -1px 0 rgb\(167 139 250 \/ 0\.4\),\s*0 5px 9px -5px rgb\(var\(--mm-accent\) \/ 0\.45\);/,
+      new RegExp(
+        String.raw`--mm-shadow-highlight-edge:\s*${asymmetricInsets},\s*0 5px 9px -5px rgb\(var\(--mm-accent\) \/ 0\.45\);`,
+      ),
     );
-    // The token must stay side-open: no perimeter ring, so the buttons read
-    // as a top highlight plus a backlit bottom rim instead of an outline.
+    expect(dashboardCss).toMatch(
+      new RegExp(
+        String.raw`--mm-shadow-highlight-edge-hover:\s*${asymmetricInsets},\s*0 5px 9px -5px rgb\(var\(--mm-accent-2\) \/ 0\.55\);`,
+      ),
+    );
+    // The tokens must stay side-open: no perimeter ring, so the buttons read
+    // as corner-lit glass instead of an outline.
     expect(dashboardCss).not.toMatch(
-      /--mm-shadow-highlight-edge:[^;]*0 0 0 1px/s,
+      /--mm-shadow-highlight-edge(?:-hover)?:[^;]*0 0 0 1px/s,
     );
 
     // Radio group: highlight-edge chrome, tightened enough (option < 2rem,
@@ -137,7 +148,7 @@ describe('dashboard masthead brand styles', () => {
     expect(cssRuleBlock('.workflow-list-display-option svg')).toContain('width: 0.95rem;');
 
     // Workflows/Create and the System trigger share the same highlight-edge
-    // look. Both shadows are non-layout-affecting so the active underline
+    // look. The shadows are non-layout-affecting so the active underline
     // geometry is unchanged.
     const primary = cssRuleBlock('.route-nav-primary a');
     expect(primary).not.toContain('var(--mm-glass-fill)');
@@ -145,6 +156,18 @@ describe('dashboard masthead brand styles', () => {
     const trigger = cssRuleBlock('.dashboard-system-trigger');
     expect(trigger).toContain('background: transparent;');
     expect(trigger).toMatch(highlightShadow);
+
+    // Hover: all three buttons brighten, grow slightly, and swap the purple
+    // under-glow for the cyan accent. The trigger states these explicitly so
+    // the filled-CTA global button:hover shadow cannot leak onto it.
+    for (const hover of [
+      cssRuleBlock('.route-nav-primary a:hover'),
+      cssRuleBlock('.dashboard-system-trigger:hover'),
+    ]) {
+      expect(hover).toContain('box-shadow: var(--mm-shadow-highlight-edge-hover);');
+      expect(hover).toContain('transform: scale(var(--mm-control-hover-scale));');
+      expect(hover).toMatch(/filter: brightness\([\d.]+\)/);
+    }
   });
 
   it('marks the open System selection like the sidebar instead of the trigger underline', () => {


### PR DESCRIPTION
## Summary

Three refinements to the masthead highlight-edge treatment, per feedback on the current deployed look:

### Asymmetric corner light (liquid glass)
The top/bottom insets were horizontally uniform. `--mm-shadow-highlight-edge` now layers faint uniform edge lines with diagonally offset corner boosts (`inset 2px 2px 3px -2px` white, `inset -2px -2px 3px -2px` violet), so the top-left corner catches white light and the bottom-right catches the violet rim — the Apple liquid-glass read. Sides stay open (the brand test still rejects any perimeter-ring component in the tokens).

### Hover: brighten, grow, cyan under-glow
- A new `--mm-shadow-highlight-edge-hover` token keeps the same insets but swaps the purple under-glow for the cyan accent (`--mm-accent-2`, the executing-pill hue).
- Workflows, Create, and the System trigger all get `transform: scale(var(--mm-control-hover-scale))` + `filter: brightness(1.08) saturate(1.04)` on hover — the grow/brighten the trigger already had, now uniform across the trio.
- Stating box-shadow/transform/filter on the trigger's hover rule also stops the filled-CTA global `button:hover` shadow (ring + wide purple glow) from leaking onto it, so its hover now matches the links instead of sprouting an outline.
- Nav links pick up `var(--mm-control-transition)` so the hover glides; `.route-nav-primary a` joins the trigger's `prefers-reduced-motion` block so scale/transitions are disabled there.

The list-display radio group keeps the shared idle token (corner asymmetry included); its options keep their existing hover states. Shadows and the hover transform are non-layout-affecting, so the active underline geometry and masthead height are unchanged.

## Testing

- Three corner-asymmetry candidates were screenshotted against the live deployed masthead (idle + hovered, 1x and 2x, headless Chromium style injection); the chosen stack shows the diagonal corner light and a clearly cyan hover under-glow at actual size.
- Computed-style assertions against the real stylesheet confirm the trigger and links resolve identical hover values (cyan glow, scale 1.018, brightness filter, no gradient/ring leak).
- `frontend/src/styles/dashboardBrand.test.ts` (7 passed; pins both tokens, the side-open guarantee, and the hover rules) and `frontend/src/entrypoints/dashboard.test.tsx` (130 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)