### PR TITLE
Fix Codex OAuth failure routing

### DIFF
--- a/docs/ManagedAgents/CodexCliManagedSessions.md
+++ b/docs/ManagedAgents/CodexCliManagedSessions.md
@@ -261,7 +261,9 @@ rotates `auth.json`, MoonMind writes the rotated credential state back through a
 compare-and-swap boundary. The write is allowed only when the durable source
 still matches the digest that seeded the session; a concurrent reconnect or
 another credential owner wins and must never be overwritten by stale session
-state.
+state. Lock acquisition is non-blocking, and filesystem failures remain
+auxiliary to the authoritative assistant turn: MoonMind records a diagnostic
+and retries persistence at a later session lifecycle boundary.
 
 Provider responses such as `token_expired`, `refresh_token_reused`, or an access
 token that cannot be refreshed are authentication failures. They terminate with

--- a/docs/ManagedAgents/CodexCliManagedSessions.md
+++ b/docs/ManagedAgents/CodexCliManagedSessions.md
@@ -2,7 +2,7 @@
 
 Status: Desired state
 Owners: MoonMind Platform
-Last updated: 2026-04-09
+Last updated: 2026-07-13
 Related:
 - [`docs/Temporal/ManagedAndExternalAgentExecutionModel.md`](../Temporal/ManagedAndExternalAgentExecutionModel.md)
 - [`docs/Temporal/ArtifactPresentationContract.md`](../Temporal/ArtifactPresentationContract.md)
@@ -249,7 +249,26 @@ observability. The transitional in-container
 fallback or bring-up helpers, but they are not the production publication path while
 they return empty publication refs.
 
-## 9. Rate-limit retry behavior
+## 9. OAuth token rotation
+
+OAuth-backed Codex sessions use two distinct filesystem authorities:
+
+- the provider profile's OAuth volume owns durable credential state;
+- the workflow-scoped writable Codex home owns disposable per-run state.
+
+At launch, MoonMind seeds the per-run home from the OAuth volume. When Codex
+rotates `auth.json`, MoonMind writes the rotated credential state back through a
+compare-and-swap boundary. The write is allowed only when the durable source
+still matches the digest that seeded the session; a concurrent reconnect or
+another credential owner wins and must never be overwritten by stale session
+state.
+
+Provider responses such as `token_expired`, `refresh_token_reused`, or an access
+token that cannot be refreshed are authentication failures. They terminate with
+the canonical reauthentication recommendation and must not be retried as empty
+assistant turns.
+
+## 10. Rate-limit retry behavior
 
 Codex managed-session turns must surface model-provider rate limits through the
 shared managed-runtime failure taxonomy. The session controller should retry
@@ -262,7 +281,7 @@ state that the turn hit a model-provider rate limit. The terminal result should
 set the same `AgentRunResult` rate-limit metadata used by other managed
 runtimes.
 
-## 10. Non-goals for This Contract Slice
+## 11. Non-goals for This Contract Slice
 
 This contract does not define:
 

--- a/moonmind/workflows/provider_failures.py
+++ b/moonmind/workflows/provider_failures.py
@@ -84,6 +84,9 @@ _AUTH_FAILURE_MARKERS = (
     "not logged in",
     "please run /login",
     "refresh token was revoked",
+    "refresh token was already used",
+    "refresh_token_reused",
+    "token_expired",
 )
 
 # Credential-scope markers are deliberately scoped to HTTP 403 wording or

--- a/moonmind/workflows/temporal/runtime/codex_session_runtime.py
+++ b/moonmind/workflows/temporal/runtime/codex_session_runtime.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import argparse
+import fcntl
+import hashlib
 import json
 import os
 import queue
@@ -56,7 +58,11 @@ _DEFAULT_TURN_COMPLETION_TIMEOUT_SECONDS = (
 )
 _STDOUT_EOF = object()
 _AUTH_SEED_EXCLUDED_NAMES = frozenset({".tmp", "config.toml", "sessions", "tmp"})
-_AUTH_SEED_EXCLUDED_FILE_NAMES = frozenset({".codex-remote-plugin-install.json"})
+_AUTH_STATE_FILENAME = "auth.json"
+_AUTH_SYNC_LOCK_FILENAME = ".moonmind-auth-sync.lock"
+_AUTH_SEED_EXCLUDED_FILE_NAMES = frozenset(
+    {".codex-remote-plugin-install.json", _AUTH_SYNC_LOCK_FILENAME}
+)
 _AUTH_SEED_EXCLUDED_PREFIXES: tuple[str, ...] = ("logs_", "state_")
 _ROLLOUT_RECOVERY_MAX_BYTES = 4 * 1024 * 1024
 _ROLLOUT_RECOVERY_TIMESTAMP_SKEW_SECONDS = 5.0
@@ -539,6 +545,7 @@ class CodexManagedSessionRuntime:
         self._auth_volume_path = (
             Path(auth_volume_path) if str(auth_volume_path or "").strip() else None
         )
+        self._auth_seed_digest: str | None = None
         self._image_ref = image_ref
         self._control_url = control_url
         self._container_id = container_id
@@ -629,6 +636,8 @@ class CodexManagedSessionRuntime:
             )
 
         self._ensure_directories()
+        durable_auth = source_root / _AUTH_STATE_FILENAME
+        self._auth_seed_digest = self._file_digest(durable_auth)
         for source_path in sorted(source_root.iterdir()):
             if not self._should_seed_auth_entry(source_path):
                 continue
@@ -644,6 +653,56 @@ class CodexManagedSessionRuntime:
                 )
                 continue
             self._copy_auth_seed_file(source_path, destination)
+
+    @staticmethod
+    def _file_digest(path: Path) -> str | None:
+        if path.is_symlink() or not path.is_file():
+            return None
+        digest = hashlib.sha256()
+        with path.open("rb") as handle:
+            for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+                digest.update(chunk)
+        return digest.hexdigest()
+
+    def _sync_codex_auth_to_volume(self) -> None:
+        """Persist a rotated Codex OAuth token without clobbering newer auth.
+
+        Codex needs a writable per-run home for its runtime state, while the
+        provider profile owns the durable OAuth volume.  Refresh tokens rotate,
+        so a successful refresh in the per-run home must be copied back.  The
+        seed digest plus a volume-local lock form a compare-and-swap boundary:
+        if another session or a reconnect changed durable auth, this session
+        refuses to overwrite it.
+        """
+
+        if self._auth_volume_path is None or self._auth_seed_digest is None:
+            return
+        local_auth = self._codex_home_path / _AUTH_STATE_FILENAME
+        local_digest = self._file_digest(local_auth)
+        if local_digest is None or local_digest == self._auth_seed_digest:
+            return
+
+        durable_auth = self._auth_volume_path / _AUTH_STATE_FILENAME
+        lock_path = self._auth_volume_path / _AUTH_SYNC_LOCK_FILENAME
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        with lock_path.open("a+b") as lock_handle:
+            fcntl.flock(lock_handle.fileno(), fcntl.LOCK_EX)
+            if self._file_digest(durable_auth) != self._auth_seed_digest:
+                return
+            temp_fd, temp_name = tempfile.mkstemp(
+                prefix=f".{_AUTH_STATE_FILENAME}.",
+                dir=str(self._auth_volume_path),
+            )
+            os.close(temp_fd)
+            temp_path = Path(temp_name)
+            try:
+                shutil.copy2(local_auth, temp_path)
+                with temp_path.open("rb") as temp_handle:
+                    os.fsync(temp_handle.fileno())
+                os.replace(temp_path, durable_auth)
+                self._auth_seed_digest = local_digest
+            finally:
+                temp_path.unlink(missing_ok=True)
 
     def _append_spool(self, stream_name: str, text: str) -> None:
         if stream_name not in {"stdout", "stderr"}:
@@ -1472,6 +1531,12 @@ class CodexManagedSessionRuntime:
         marker_index = text.find(marker)
         if marker_index >= 0:
             recovered = text[marker_index + len(marker) :].strip()
+            if recovered:
+                return recovered
+        refresh_marker = "Failed to refresh token:"
+        refresh_index = text.find(refresh_marker)
+        if refresh_index >= 0:
+            recovered = text[refresh_index + len(refresh_marker) :].strip()
             if recovered:
                 return recovered
         recovered = cls._extract_quoted_log_field(text, "error.message")
@@ -2535,6 +2600,7 @@ class CodexManagedSessionRuntime:
         if status == "completed":
             state.last_assistant_text = assistant_text or None
         self._save_state(state)
+        self._sync_codex_auth_to_volume()
         if (
             append_assistant_to_spool
             and status == "completed"
@@ -2675,6 +2741,7 @@ class CodexManagedSessionRuntime:
             lastControlAt=time.time(),
         )
         self._save_state(state)
+        self._sync_codex_auth_to_volume()
         self._append_spool(
             "stdout",
             f"session started: {request.session_id} thread={request.thread_id}\n",
@@ -3013,6 +3080,7 @@ class CodexManagedSessionRuntime:
         state.last_control_action = "clear_session"
         state.last_control_at = time.time()
         self._save_state(state)
+        self._sync_codex_auth_to_volume()
         self._append_spool(
             "stdout",
             f"session cleared: epoch={state.session_epoch} thread={state.logical_thread_id}\n",
@@ -3028,6 +3096,7 @@ class CodexManagedSessionRuntime:
         state.last_control_action = "terminate_session"
         state.last_control_at = time.time()
         self._save_state(state)
+        self._sync_codex_auth_to_volume()
         self._append_spool("stdout", f"session terminated: {request.session_id}\n")
         return self._handle(state, status="terminated")
 

--- a/moonmind/workflows/temporal/runtime/codex_session_runtime.py
+++ b/moonmind/workflows/temporal/runtime/codex_session_runtime.py
@@ -677,32 +677,57 @@ class CodexManagedSessionRuntime:
 
         if self._auth_volume_path is None or self._auth_seed_digest is None:
             return
-        local_auth = self._codex_home_path / _AUTH_STATE_FILENAME
-        local_digest = self._file_digest(local_auth)
-        if local_digest is None or local_digest == self._auth_seed_digest:
-            return
-
-        durable_auth = self._auth_volume_path / _AUTH_STATE_FILENAME
-        lock_path = self._auth_volume_path / _AUTH_SYNC_LOCK_FILENAME
-        lock_path.parent.mkdir(parents=True, exist_ok=True)
-        with lock_path.open("a+b") as lock_handle:
-            fcntl.flock(lock_handle.fileno(), fcntl.LOCK_EX)
-            if self._file_digest(durable_auth) != self._auth_seed_digest:
+        try:
+            local_auth = self._codex_home_path / _AUTH_STATE_FILENAME
+            local_digest = self._file_digest(local_auth)
+            if local_digest is None or local_digest == self._auth_seed_digest:
                 return
-            temp_fd, temp_name = tempfile.mkstemp(
-                prefix=f".{_AUTH_STATE_FILENAME}.",
-                dir=str(self._auth_volume_path),
+
+            durable_auth = self._auth_volume_path / _AUTH_STATE_FILENAME
+            lock_path = self._auth_volume_path / _AUTH_SYNC_LOCK_FILENAME
+            lock_path.parent.mkdir(parents=True, exist_ok=True)
+            with lock_path.open("a+b") as lock_handle:
+                try:
+                    fcntl.flock(
+                        lock_handle.fileno(),
+                        fcntl.LOCK_EX | fcntl.LOCK_NB,
+                    )
+                except BlockingIOError:
+                    self._record_auth_sync_warning(
+                        "durable auth volume lock is busy; a later lifecycle "
+                        "boundary will retry"
+                    )
+                    return
+                if self._file_digest(durable_auth) != self._auth_seed_digest:
+                    return
+                temp_fd, temp_name = tempfile.mkstemp(
+                    prefix=f".{_AUTH_STATE_FILENAME}.",
+                    dir=str(self._auth_volume_path),
+                )
+                os.close(temp_fd)
+                temp_path = Path(temp_name)
+                try:
+                    shutil.copy2(local_auth, temp_path)
+                    with temp_path.open("rb") as temp_handle:
+                        os.fsync(temp_handle.fileno())
+                    os.replace(temp_path, durable_auth)
+                    self._auth_seed_digest = local_digest
+                finally:
+                    temp_path.unlink(missing_ok=True)
+        except Exception as exc:
+            self._record_auth_sync_warning(f"rotated auth persistence failed: {exc}")
+
+    def _record_auth_sync_warning(self, message: str) -> None:
+        try:
+            self._append_spool(
+                "stderr",
+                "auth sync deferred: "
+                f"{_redact_text(message, max_chars=_DIAGNOSTIC_TEXT_MAX_CHARS)}\n",
             )
-            os.close(temp_fd)
-            temp_path = Path(temp_name)
-            try:
-                shutil.copy2(local_auth, temp_path)
-                with temp_path.open("rb") as temp_handle:
-                    os.fsync(temp_handle.fileno())
-                os.replace(temp_path, durable_auth)
-                self._auth_seed_digest = local_digest
-            finally:
-                temp_path.unlink(missing_ok=True)
+        except OSError:
+            # Synchronization diagnostics are best-effort and must not replace
+            # the authoritative assistant turn outcome.
+            pass
 
     def _append_spool(self, stream_name: str, text: str) -> None:
         if stream_name not in {"stdout", "stderr"}:

--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -1272,43 +1272,47 @@ class MoonMindAgentRun:
         if agent_run_id:
             metadata.setdefault("agentRunId", agent_run_id)
 
-        runtime_id = (
-            request.managed_session.runtime_id
-            if request.managed_session is not None
-            else request.agent_id
-        )
-        capabilities = resolve_runtime_execution_capabilities(runtime_id)
-        metadata["agentKind"] = request.agent_kind
-        metadata["agentId"] = capabilities.runtime_id
-        metadata["runtimeCapabilities"] = capabilities.model_dump(
-            by_alias=True,
-            mode="json",
-        )
-        if capabilities.workspace_authority == "managed_runtime" and agent_run_id:
-            metadata["workspaceLocator"] = {
-                "kind": "managed_runtime",
-                "runtimeId": capabilities.runtime_id,
-                "agentRunId": agent_run_id,
-                "relativePath": "repo",
-            }
-            for legacy_path_key in (
-                "workspacePath",
-                "workspace_path",
-                "workspaceRoot",
-                "workspace_root",
+        if request.agent_kind == "managed":
+            runtime_id = (
+                request.managed_session.runtime_id
+                if request.managed_session is not None
+                else request.agent_id
+            )
+            capabilities = resolve_runtime_execution_capabilities(runtime_id)
+            metadata["agentKind"] = request.agent_kind
+            metadata["agentId"] = capabilities.runtime_id
+            metadata["runtimeCapabilities"] = capabilities.model_dump(
+                by_alias=True,
+                mode="json",
+            )
+            if (
+                capabilities.workspace_authority == "managed_runtime"
+                and agent_run_id
             ):
-                metadata.pop(legacy_path_key, None)
-            nested_workspace_spec = metadata.get("workspaceSpec")
-            if isinstance(nested_workspace_spec, Mapping):
-                sanitized_workspace_spec = dict(nested_workspace_spec)
+                metadata["workspaceLocator"] = {
+                    "kind": "managed_runtime",
+                    "runtimeId": capabilities.runtime_id,
+                    "agentRunId": agent_run_id,
+                    "relativePath": "repo",
+                }
                 for legacy_path_key in (
                     "workspacePath",
                     "workspace_path",
                     "workspaceRoot",
                     "workspace_root",
                 ):
-                    sanitized_workspace_spec.pop(legacy_path_key, None)
-                metadata["workspaceSpec"] = sanitized_workspace_spec
+                    metadata.pop(legacy_path_key, None)
+                nested_workspace_spec = metadata.get("workspaceSpec")
+                if isinstance(nested_workspace_spec, Mapping):
+                    sanitized_workspace_spec = dict(nested_workspace_spec)
+                    for legacy_path_key in (
+                        "workspacePath",
+                        "workspace_path",
+                        "workspaceRoot",
+                        "workspace_root",
+                    ):
+                        sanitized_workspace_spec.pop(legacy_path_key, None)
+                    metadata["workspaceSpec"] = sanitized_workspace_spec
 
         request_params = (
             request.parameters if isinstance(request.parameters, Mapping) else {}

--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -1291,8 +1291,24 @@ class MoonMindAgentRun:
                 "agentRunId": agent_run_id,
                 "relativePath": "repo",
             }
-            metadata.pop("workspacePath", None)
-            metadata.pop("workspaceRoot", None)
+            for legacy_path_key in (
+                "workspacePath",
+                "workspace_path",
+                "workspaceRoot",
+                "workspace_root",
+            ):
+                metadata.pop(legacy_path_key, None)
+            nested_workspace_spec = metadata.get("workspaceSpec")
+            if isinstance(nested_workspace_spec, Mapping):
+                sanitized_workspace_spec = dict(nested_workspace_spec)
+                for legacy_path_key in (
+                    "workspacePath",
+                    "workspace_path",
+                    "workspaceRoot",
+                    "workspace_root",
+                ):
+                    sanitized_workspace_spec.pop(legacy_path_key, None)
+                metadata["workspaceSpec"] = sanitized_workspace_spec
 
         request_params = (
             request.parameters if isinstance(request.parameters, Mapping) else {}

--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -1272,6 +1272,28 @@ class MoonMindAgentRun:
         if agent_run_id:
             metadata.setdefault("agentRunId", agent_run_id)
 
+        runtime_id = (
+            request.managed_session.runtime_id
+            if request.managed_session is not None
+            else request.agent_id
+        )
+        capabilities = resolve_runtime_execution_capabilities(runtime_id)
+        metadata["agentKind"] = request.agent_kind
+        metadata["agentId"] = capabilities.runtime_id
+        metadata["runtimeCapabilities"] = capabilities.model_dump(
+            by_alias=True,
+            mode="json",
+        )
+        if capabilities.workspace_authority == "managed_runtime" and agent_run_id:
+            metadata["workspaceLocator"] = {
+                "kind": "managed_runtime",
+                "runtimeId": capabilities.runtime_id,
+                "agentRunId": agent_run_id,
+                "relativePath": "repo",
+            }
+            metadata.pop("workspacePath", None)
+            metadata.pop("workspaceRoot", None)
+
         request_params = (
             request.parameters if isinstance(request.parameters, Mapping) else {}
         )

--- a/tests/integration/reliability/replays/codex-oauth-checkpoint-masking/expected-outcome.json
+++ b/tests/integration/reliability/replays/codex-oauth-checkpoint-masking/expected-outcome.json
@@ -1,0 +1,19 @@
+{
+  "failureClass": "user_error",
+  "providerErrorCode": "401",
+  "retryRecommendation": "reauthenticate",
+  "workspaceLocator": {
+    "kind": "managed_runtime",
+    "runtimeId": "codex_cli",
+    "agentRunId": "mm:28dae38e-0488-4e0f-8add-b2249441a28c",
+    "relativePath": "repo"
+  },
+  "checkpointOutcome": {
+    "status": "unsupported",
+    "failureCode": "CHECKPOINT_CAPABILITY_UNSUPPORTED",
+    "boundary": "after_execution",
+    "captureAuthority": "managed_runtime",
+    "captureActivity": null,
+    "capabilityCriticality": "recoverability_only"
+  }
+}

--- a/tests/integration/reliability/replays/codex-oauth-checkpoint-masking/manifest.json
+++ b/tests/integration/reliability/replays/codex-oauth-checkpoint-masking/manifest.json
@@ -1,0 +1,9 @@
+{
+  "failureShapeId": "codex-oauth-checkpoint-masking",
+  "incidentWorkflowId": "mm:28dae38e-0488-4e0f-8add-b2249441a28c",
+  "runtime": "codex_cli",
+  "providerLog": "Failed to refresh token: Your access token could not be refreshed because your refresh token was already used. Please log out and sign in again. error_code=refresh_token_reused",
+  "legacyWorkspacePath": "/work/agent_jobs/mm:28dae38e-0488-4e0f-8add-b2249441a28c/repo",
+  "escapedFailure": "workspace path escapes sandbox root",
+  "invariant": "A managed-runtime checkpoint gap cannot mask the primary provider authentication failure"
+}

--- a/tests/integration/reliability/test_escaped_failure_journeys.py
+++ b/tests/integration/reliability/test_escaped_failure_journeys.py
@@ -4,6 +4,7 @@ import hashlib
 import json
 from datetime import datetime, timezone
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -11,11 +12,13 @@ from moonmind.schemas.managed_session_models import SendCodexManagedSessionTurnR
 from moonmind.schemas.agent_runtime_models import AgentExecutionRequest, AgentRunResult
 from moonmind.schemas.workspace_locator_models import WorkspaceLocatorResolutionError
 from moonmind.workflows.adapters.codex_session_adapter import _pr_resolver_terminal_contract
+from moonmind.workflows.provider_failures import classify_provider_failure
 from moonmind.workflows.temporal.activity_runtime import (
     TemporalAgentRuntimeActivities,
     TemporalSandboxActivities,
 )
 from moonmind.workflows.temporal.workflows import agent_run as agent_run_module
+from moonmind.workflows.temporal.workflows import run as run_workflow_module
 from moonmind.workflows.temporal.workflows.agent_run import MoonMindAgentRun
 from moonmind.workflows.temporal.workflows.run import MoonMindRunWorkflow
 from moonmind.workflows.terminal_evidence import evaluate_terminal_evidence
@@ -265,6 +268,97 @@ async def test_sandbox_checkpoint_rejects_managed_workspace_without_resolving_pa
 
     assert exc_info.value.code == "WORKSPACE_AUTHORITY_MISMATCH"
     assert sandbox_calls == expected["sandboxResolverCalls"] == 0
+
+
+async def test_codex_oauth_failure_preserves_primary_error_and_managed_authority(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Replay mm:28dae38e through the child-to-parent authority handoff."""
+    replay_id = "codex-oauth-checkpoint-masking"
+    manifest = load_replay(replay_id, "manifest.json")
+    expected = load_replay(replay_id, "expected-outcome.json")
+    classified = classify_provider_failure(manifest["providerLog"])
+
+    assert classified is not None
+    assert classified.failure_class == expected["failureClass"]
+    assert classified.provider_error_code == expected["providerErrorCode"]
+    assert classified.retry_recommendation == expected["retryRecommendation"]
+
+    workflow_info = SimpleNamespace(
+        namespace="default",
+        workflow_id=f"{manifest['incidentWorkflowId']}:agent:node-1",
+        run_id="replay-run",
+        search_attributes={},
+        parent=None,
+    )
+    monkeypatch.setattr(agent_run_module.workflow, "info", lambda: workflow_info)
+    monkeypatch.setattr(agent_run_module.workflow, "patched", lambda _patch: True)
+    request = AgentExecutionRequest(
+        agentKind="managed",
+        agentId="codex",
+        executionProfileRef="codex-default",
+        correlationId=manifest["incidentWorkflowId"],
+        idempotencyKey=f"{manifest['incidentWorkflowId']}:replay",
+        managedSession={
+            "workflowId": f"{manifest['incidentWorkflowId']}:session:codex_cli",
+            "agentRunId": manifest["incidentWorkflowId"],
+            "sessionId": f"sess:{manifest['incidentWorkflowId']}:codex_cli",
+            "sessionEpoch": 1,
+            "runtimeId": "codex_cli",
+            "executionProfileRef": "codex-default",
+        },
+    )
+    result = MoonMindAgentRun()._enrich_result_metadata(
+        request=request,
+        result=AgentRunResult(
+            summary=manifest["providerLog"],
+            failureClass=classified.failure_class,
+            providerErrorCode=classified.provider_error_code,
+            retryRecommendation=classified.retry_recommendation,
+            metadata={"workspacePath": manifest["legacyWorkspacePath"]},
+        ),
+    )
+
+    assert result is not None
+    assert result.metadata["workspaceLocator"] == expected["workspaceLocator"]
+    assert "workspacePath" not in result.metadata
+
+    parent_info = SimpleNamespace(
+        namespace="default",
+        workflow_id=manifest["incidentWorkflowId"],
+        run_id="replay-parent-run",
+        task_queue="mm.workflow",
+        search_attributes={},
+    )
+    monkeypatch.setattr(run_workflow_module.workflow, "info", lambda: parent_info)
+    monkeypatch.setattr(run_workflow_module.workflow, "patched", lambda _patch: True)
+
+    async def unexpected_activity(*_args: object, **_kwargs: object) -> object:
+        raise AssertionError("managed workspace must not reach a sandbox activity")
+
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "execute_activity",
+        unexpected_activity,
+    )
+    parent = MoonMindRunWorkflow()
+    now = datetime(2026, 7, 13, tzinfo=timezone.utc)
+    parent._initialize_step_ledger(
+        ordered_nodes=[{"id": "node-1", "inputs": {"title": "Replay"}}],
+        dependency_map={"node-1": []},
+        updated_at=now,
+    )
+    parent._mark_step_running("node-1", updated_at=now, summary="Running")
+    parent._record_step_workspace_capture_input("node-1", result.metadata)
+
+    checkpoint_ref = await parent._record_canonical_step_checkpoint(
+        "node-1", boundary="after_execution", updated_at=now
+    )
+
+    assert checkpoint_ref is None
+    assert parent._step_checkpoint_capture_outcomes["node-1"] == (
+        expected["checkpointOutcome"]
+    )
 
 
 async def test_checkpoint_finalization_fault_is_retryable(

--- a/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
+++ b/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import fcntl
 import json
 import os
 import shutil
@@ -4218,7 +4219,7 @@ def test_runtime_syncs_rotated_auth_to_durable_volume(tmp_path: Path) -> None:
     assert durable_auth_path.read_text(encoding="utf-8") == (
         '{"credentialVersion":"rotated"}'
     )
-    assert not Path(request.codex_home_path, ".moonmind-auth-sync.lock").exists()
+    assert (auth_volume_path / ".moonmind-auth-sync.lock").is_file()
 
 
 def test_runtime_auth_sync_preserves_concurrent_reconnect(tmp_path: Path) -> None:
@@ -4252,6 +4253,91 @@ def test_runtime_auth_sync_preserves_concurrent_reconnect(tmp_path: Path) -> Non
     assert durable_auth_path.read_text(encoding="utf-8") == (
         '{"credentialVersion":"reconnected"}'
     )
+
+
+def test_runtime_auth_sync_defers_when_volume_lock_is_busy(tmp_path: Path) -> None:
+    request = launch_request(tmp_path)
+    auth_volume_path = tmp_path / "auth-volume"
+    auth_volume_path.mkdir()
+    durable_auth_path = auth_volume_path / "auth.json"
+    durable_auth_path.write_text(
+        '{"credentialVersion":"seed"}', encoding="utf-8"
+    )
+    runtime = CodexManagedSessionRuntime(
+        workspace_path=request.workspace_path,
+        session_workspace_path=request.session_workspace_path,
+        artifact_spool_path=request.artifact_spool_path,
+        codex_home_path=request.codex_home_path,
+        auth_volume_path=str(auth_volume_path),
+        image_ref=request.image_ref,
+        control_url="docker-exec://mm-codex-session-sess-1",
+        container_id="ctr-1",
+    )
+    runtime._seed_codex_home_from_auth_volume()
+    Path(request.codex_home_path, "auth.json").write_text(
+        '{"credentialVersion":"rotated"}', encoding="utf-8"
+    )
+    lock_path = auth_volume_path / ".moonmind-auth-sync.lock"
+    with lock_path.open("a+b") as lock_handle:
+        fcntl.flock(lock_handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        runtime._sync_codex_auth_to_volume()
+
+    assert durable_auth_path.read_text(encoding="utf-8") == (
+        '{"credentialVersion":"seed"}'
+    )
+    assert "auth sync deferred" in Path(
+        request.artifact_spool_path, "stderr.log"
+    ).read_text(encoding="utf-8")
+
+    runtime._sync_codex_auth_to_volume()
+
+    assert durable_auth_path.read_text(encoding="utf-8") == (
+        '{"credentialVersion":"rotated"}'
+    )
+
+
+def test_runtime_auth_sync_contains_filesystem_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    request = launch_request(tmp_path)
+    auth_volume_path = tmp_path / "auth-volume"
+    auth_volume_path.mkdir()
+    durable_auth_path = auth_volume_path / "auth.json"
+    durable_auth_path.write_text(
+        '{"credentialVersion":"seed"}', encoding="utf-8"
+    )
+    runtime = CodexManagedSessionRuntime(
+        workspace_path=request.workspace_path,
+        session_workspace_path=request.session_workspace_path,
+        artifact_spool_path=request.artifact_spool_path,
+        codex_home_path=request.codex_home_path,
+        auth_volume_path=str(auth_volume_path),
+        image_ref=request.image_ref,
+        control_url="docker-exec://mm-codex-session-sess-1",
+        container_id="ctr-1",
+    )
+    runtime._seed_codex_home_from_auth_volume()
+    Path(request.codex_home_path, "auth.json").write_text(
+        '{"credentialVersion":"rotated"}', encoding="utf-8"
+    )
+
+    def fail_copy(*_args: object, **_kwargs: object) -> None:
+        raise OSError("injected auth-volume write failure")
+
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.runtime.codex_session_runtime.shutil.copy2",
+        fail_copy,
+    )
+
+    runtime._sync_codex_auth_to_volume()
+
+    assert durable_auth_path.read_text(encoding="utf-8") == (
+        '{"credentialVersion":"seed"}'
+    )
+    assert "rotated auth persistence failed" in Path(
+        request.artifact_spool_path, "stderr.log"
+    ).read_text(encoding="utf-8")
 
 
 def test_runtime_launch_session_rejects_missing_auth_volume_path(

--- a/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
+++ b/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
@@ -1365,6 +1365,78 @@ def test_runtime_send_turn_recovers_usage_limit_from_recent_log_for_empty_task_c
         "reason": quota_summary,
     }
 
+
+def test_runtime_send_turn_recovers_auth_failure_from_recent_log_for_empty_task_complete(
+    tmp_path: Path,
+) -> None:
+    request = launch_request(tmp_path)
+    transcript_path = (
+        Path(request.codex_home_path)
+        / "sessions"
+        / "2026"
+        / "07"
+        / "13"
+        / "rollout-2026-07-13T17-55-14-vendor-thread-1.jsonl"
+    )
+    transcript_path.parent.mkdir(parents=True, exist_ok=True)
+    script = write_fake_app_server(
+        tmp_path,
+        assistant_text="",
+        start_thread_path=str(transcript_path),
+        rollout_entries_on_read=[
+            {
+                "timestamp": "2026-07-13T17:57:55.661Z",
+                "type": "event_msg",
+                "payload": {
+                    "type": "task_complete",
+                    "turn_id": "vendor-turn-1",
+                    "last_agent_message": None,
+                },
+            }
+        ],
+    )
+    runtime = CodexManagedSessionRuntime(
+        workspace_path=request.workspace_path,
+        session_workspace_path=request.session_workspace_path,
+        artifact_spool_path=request.artifact_spool_path,
+        codex_home_path=request.codex_home_path,
+        image_ref=request.image_ref,
+        control_url="docker-exec://mm-codex-session-sess-1",
+        container_id="ctr-1",
+        app_server_command=("python3", str(script)),
+    )
+    runtime.launch_session(request)
+    auth_summary = (
+        "Your access token could not be refreshed because your refresh token "
+        "was already used. Please log out and sign in again."
+    )
+    _write_fake_codex_logs_with_timestamps(
+        request.codex_home_path,
+        entries=[
+            (
+                int(time.time()) + 1,
+                "model_client:auth: Failed to refresh token: " + auth_summary,
+            )
+        ],
+    )
+
+    response = runtime.send_turn(
+        SendCodexManagedSessionTurnRequest(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            containerId="ctr-1",
+            threadId="logical-thread-1",
+            instructions="Reply with exactly the word OK",
+        )
+    )
+
+    assert response.status == "failed"
+    assert response.metadata == {
+        "failureClass": "permanent",
+        "reason": auth_summary,
+    }
+
+
 def _spool_skill_outcome_path(request: LaunchCodexManagedSessionRequest) -> Path:
     return Path(request.artifact_spool_path) / "skill_outcome.json"
 
@@ -4116,6 +4188,71 @@ def test_runtime_launch_session_auth_seed_overwrites_read_only_files_on_retry(
         '{"token":"oauth-refresh"}'
     )
     assert destination_auth.stat().st_mode & 0o777 == 0o444
+
+
+def test_runtime_syncs_rotated_auth_to_durable_volume(tmp_path: Path) -> None:
+    request = launch_request(tmp_path)
+    auth_volume_path = tmp_path / "auth-volume"
+    auth_volume_path.mkdir()
+    durable_auth_path = auth_volume_path / "auth.json"
+    durable_auth_path.write_text(
+        '{"credentialVersion":"seed"}', encoding="utf-8"
+    )
+    runtime = CodexManagedSessionRuntime(
+        workspace_path=request.workspace_path,
+        session_workspace_path=request.session_workspace_path,
+        artifact_spool_path=request.artifact_spool_path,
+        codex_home_path=request.codex_home_path,
+        auth_volume_path=str(auth_volume_path),
+        image_ref=request.image_ref,
+        control_url="docker-exec://mm-codex-session-sess-1",
+        container_id="ctr-1",
+    )
+    runtime._seed_codex_home_from_auth_volume()
+    Path(request.codex_home_path, "auth.json").write_text(
+        '{"credentialVersion":"rotated"}', encoding="utf-8"
+    )
+
+    runtime._sync_codex_auth_to_volume()
+
+    assert durable_auth_path.read_text(encoding="utf-8") == (
+        '{"credentialVersion":"rotated"}'
+    )
+    assert not Path(request.codex_home_path, ".moonmind-auth-sync.lock").exists()
+
+
+def test_runtime_auth_sync_preserves_concurrent_reconnect(tmp_path: Path) -> None:
+    request = launch_request(tmp_path)
+    auth_volume_path = tmp_path / "auth-volume"
+    auth_volume_path.mkdir()
+    durable_auth_path = auth_volume_path / "auth.json"
+    durable_auth_path.write_text(
+        '{"credentialVersion":"seed"}', encoding="utf-8"
+    )
+    runtime = CodexManagedSessionRuntime(
+        workspace_path=request.workspace_path,
+        session_workspace_path=request.session_workspace_path,
+        artifact_spool_path=request.artifact_spool_path,
+        codex_home_path=request.codex_home_path,
+        auth_volume_path=str(auth_volume_path),
+        image_ref=request.image_ref,
+        control_url="docker-exec://mm-codex-session-sess-1",
+        container_id="ctr-1",
+    )
+    runtime._seed_codex_home_from_auth_volume()
+    Path(request.codex_home_path, "auth.json").write_text(
+        '{"credentialVersion":"rotated-by-run"}', encoding="utf-8"
+    )
+    durable_auth_path.write_text(
+        '{"credentialVersion":"reconnected"}', encoding="utf-8"
+    )
+
+    runtime._sync_codex_auth_to_volume()
+
+    assert durable_auth_path.read_text(encoding="utf-8") == (
+        '{"credentialVersion":"reconnected"}'
+    )
+
 
 def test_runtime_launch_session_rejects_missing_auth_volume_path(
     tmp_path: Path,

--- a/tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py
@@ -862,7 +862,10 @@ async def test_managed_session_result_enrichment_omits_large_inline_instruction(
 
     result = run._enrich_result_metadata(
         request=request,
-        result=AgentRunResult(summary="done", metadata={}),
+        result=AgentRunResult(
+            summary="done",
+            metadata={"workspacePath": "/work/agent_jobs/wf-task-1/repo"},
+        ),
     )
 
     assert result is not None
@@ -871,6 +874,20 @@ async def test_managed_session_result_enrichment_omits_large_inline_instruction(
     assert len(result.metadata["instructionRefSha256"]) == 64
     assert "instructionRef" not in result.metadata
     assert result.metadata["managedSession"]["agentRunId"] == "wf-task-1"
+    assert result.metadata["agentKind"] == "managed"
+    assert result.metadata["agentId"] == "codex_cli"
+    assert result.metadata["runtimeCapabilities"]["workspaceAuthority"] == (
+        "managed_runtime"
+    )
+    assert result.metadata["runtimeCapabilities"]["checkpointCaptureKinds"] == []
+    assert result.metadata["workspaceLocator"] == {
+        "kind": "managed_runtime",
+        "runtimeId": "codex_cli",
+        "agentRunId": "wf-task-1",
+        "relativePath": "repo",
+    }
+    assert "workspacePath" not in result.metadata
+    assert "workspaceRoot" not in result.metadata
 
 async def test_managed_session_result_enrichment_carries_story_output_paths(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py
@@ -858,7 +858,16 @@ async def test_managed_session_result_enrichment_omits_large_inline_instruction(
     large_instruction = "Use this request as the canonical input:\n" + (
         "Implement the workflow cleanup. " * 400
     )
-    request = _managed_session_request(instruction_ref=large_instruction)
+    request = _managed_session_request(
+        instruction_ref=large_instruction,
+        workspace_spec={
+            "workspacePath": "/work/agent_jobs/wf-task-1/repo",
+            "workspaceRoot": "/work/agent_jobs/wf-task-1/repo",
+            "workspace_path": "/work/agent_jobs/wf-task-1/repo",
+            "workspace_root": "/work/agent_jobs/wf-task-1/repo",
+            "baseCommit": "abc123",
+        },
+    )
 
     result = run._enrich_result_metadata(
         request=request,
@@ -888,6 +897,7 @@ async def test_managed_session_result_enrichment_omits_large_inline_instruction(
     }
     assert "workspacePath" not in result.metadata
     assert "workspaceRoot" not in result.metadata
+    assert result.metadata["workspaceSpec"] == {"baseCommit": "abc123"}
 
 async def test_managed_session_result_enrichment_carries_story_output_paths(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit/workflows/test_provider_failures.py
+++ b/tests/unit/workflows/test_provider_failures.py
@@ -139,6 +139,19 @@ def test_classifies_codex_revoked_refresh_token_as_auth_user_error() -> None:
     assert result.retry_recommendation == "reauthenticate"
 
 
+def test_classifies_codex_reused_refresh_token_as_auth_user_error() -> None:
+    result = classify_provider_failure(
+        "Your access token could not be refreshed because your refresh token "
+        "was already used. Please log out and sign in again. "
+        "error_code=refresh_token_reused"
+    )
+
+    assert result is not None
+    assert result.failure_class == "user_error"
+    assert result.provider_error_code == "401"
+    assert result.retry_recommendation == "reauthenticate"
+
+
 def test_provider_cooldown_accepts_capacity_code_or_retry_recommendation() -> None:
     assert provider_error_requires_cooldown(
         provider_error_code="provider_capacity",


### PR DESCRIPTION
## Summary

- persist Codex OAuth refresh rotation from each writable run home back to the durable provider-profile volume using a locked compare-and-swap write
- recover and classify Codex refresh failures as authentication errors that require reauthentication instead of retrying them as empty assistant turns
- publish canonical managed-runtime workspace metadata so checkpoint finalization cannot route an absolute managed path through the sandbox and mask the primary failure
- add a required-CI replay fixture for workflow `mm:28dae38e-0488-4e0f-8add-b2249441a28c`

## Root cause

The failed run used an expired access credential whose rotating refresh credential had already been consumed in an earlier per-run Codex home. MoonMind copied durable auth into each run but did not persist successful rotation back to the provider-profile volume. Codex logged the authentication failure, then emitted a terminal turn with no assistant output. The runtime log recovery did not recognize Codex's refresh-failure log shape, so the primary failure was reported as an empty turn.

AgentRun then returned a host-absolute managed workspace path without the canonical runtime capability snapshot and typed locator. Parent finalization treated that path as sandbox-owned, failed checkpoint capture with `workspace path escapes sandbox root`, and replaced the useful authentication diagnosis.

## Verification

- targeted Python suite: 164 passed
- escaped-failure reliability replay: 7 passed
- hermetic integration CI suite: 435 passed, 1 skipped
- frontend suite: 1,080 passed and 238 skipped, with one unrelated focus-trap timeout that passed on targeted retry
- final affected runtime subset: 4 passed

## Operator note

The already-consumed credential behind the incident still requires one provider-profile reconnect after this change is deployed. The fix preserves subsequent refresh rotations and surfaces the reconnect requirement directly if authentication fails again.
