### PR TITLE
Fix Codex OAuth recovery failures

### DIFF
--- a/moonmind/provider_profiles/lease_client.py
+++ b/moonmind/provider_profiles/lease_client.py
@@ -115,12 +115,15 @@ class ProviderProfileLeaseClient:
         owner_id: str,
         purpose: CredentialLeasePurpose,
         metadata: Mapping[str, Any] | None,
+        owner_is_workflow: bool,
     ) -> CredentialLease:
         workflow_id = await self._ensure_manager(runtime_id)
         safe_metadata = dict(metadata or {})
-        # This client runs at an Activity/HTTP boundary. Its deterministic
-        # owner is an idempotency identity, not a Temporal workflow ID.
-        safe_metadata["ownerIsWorkflow"] = False
+        # Most callers use an activity idempotency identity. A workflow may
+        # delegate an acknowledged Update through an Activity when the
+        # workflow-context ExternalWorkflowHandle cannot execute Updates; in
+        # that case the stable owner really is the delegating workflow ID.
+        safe_metadata["ownerIsWorkflow"] = owner_is_workflow
         result = await self._adapter.update_workflow(
             workflow_id,
             (
@@ -154,6 +157,7 @@ class ProviderProfileLeaseClient:
         owner_id: str,
         purpose: CredentialLeasePurpose = CredentialLeasePurpose.EXECUTION_DIRECT,
         metadata: Mapping[str, Any] | None = None,
+        owner_is_workflow: bool = False,
     ) -> CredentialLease:
         if purpose.is_maintenance:
             raise ValueError("execution lease requires an execution purpose")
@@ -163,6 +167,7 @@ class ProviderProfileLeaseClient:
             owner_id=owner_id,
             purpose=purpose,
             metadata=metadata,
+            owner_is_workflow=owner_is_workflow,
         )
 
     async def acquire_maintenance_lease(
@@ -173,6 +178,7 @@ class ProviderProfileLeaseClient:
         owner_id: str,
         purpose: CredentialLeasePurpose,
         metadata: Mapping[str, Any] | None = None,
+        owner_is_workflow: bool = False,
     ) -> CredentialLease:
         if not purpose.is_maintenance:
             raise ValueError("maintenance lease requires a maintenance purpose")
@@ -182,6 +188,7 @@ class ProviderProfileLeaseClient:
             owner_id=owner_id,
             purpose=purpose,
             metadata=metadata,
+            owner_is_workflow=owner_is_workflow,
         )
 
     async def release_lease(self, lease: CredentialLease) -> None:

--- a/moonmind/workflows/temporal/activity_catalog.py
+++ b/moonmind/workflows/temporal/activity_catalog.py
@@ -641,8 +641,11 @@ def build_default_activity_catalog(
             capability_class="artifacts",
             task_queue=cfg.activity_artifacts_task_queue,
             fleet=ARTIFACTS_FLEET,
-            timeouts=TemporalActivityTimeouts(1800, 1860),
-            retries=_activity_retries(max_attempts=1, max_interval_seconds=30),
+            timeouts=TemporalActivityTimeouts(
+                1800, 1860, heartbeat_timeout_seconds=30
+            ),
+            retries=_activity_retries(max_attempts=3, max_interval_seconds=30),
+            heartbeat_required=True,
         ),
         TemporalActivityDefinition(
             activity_type="provider_profile.reset_manager",

--- a/moonmind/workflows/temporal/activity_catalog.py
+++ b/moonmind/workflows/temporal/activity_catalog.py
@@ -636,6 +636,15 @@ def build_default_activity_catalog(
             retries=_activity_retries(max_attempts=3, max_interval_seconds=30),
         ),
         TemporalActivityDefinition(
+            activity_type="provider_profile.acquire_credential_maintenance_lease",
+            family="provider_profile",
+            capability_class="artifacts",
+            task_queue=cfg.activity_artifacts_task_queue,
+            fleet=ARTIFACTS_FLEET,
+            timeouts=TemporalActivityTimeouts(1800, 1860),
+            retries=_activity_retries(max_attempts=1, max_interval_seconds=30),
+        ),
+        TemporalActivityDefinition(
             activity_type="provider_profile.reset_manager",
             family="provider_profile",
             capability_class="artifacts",

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -1213,6 +1213,10 @@ _ACTIVITY_HANDLER_ATTRS: dict[str, tuple[str, str]] = {
     "workspace.classify_git_effect": ("sandbox", "workspace_classify_git_effect"),
     "provider_profile.list": ("artifacts", "provider_profile_list"),
     "provider_profile.ensure_manager": ("artifacts", "provider_profile_ensure_manager"),
+    "provider_profile.acquire_credential_maintenance_lease": (
+        "artifacts",
+        "provider_profile_acquire_credential_maintenance_lease",
+    ),
     "provider_profile.reset_manager": ("artifacts", "provider_profile_reset_manager"),
     "provider_profile.manager_state": ("artifacts", "provider_profile_manager_state"),
     "provider_profile.verify_lease_holders": (

--- a/moonmind/workflows/temporal/artifacts.py
+++ b/moonmind/workflows/temporal/artifacts.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import contextlib
 import hashlib
 import json
 import logging
@@ -3362,8 +3361,7 @@ class TemporalArtifactActivities:
         except BaseException:
             if not lease_task.done():
                 lease_task.cancel()
-                with contextlib.suppress(asyncio.CancelledError):
-                    await lease_task
+                await asyncio.gather(lease_task, return_exceptions=True)
             raise
         return {
             "profile_id": lease.profile_id,

--- a/moonmind/workflows/temporal/artifacts.py
+++ b/moonmind/workflows/temporal/artifacts.py
@@ -3322,6 +3322,42 @@ class TemporalArtifactActivities:
             )
             return {"started": False, "workflow_id": workflow_id}
 
+    async def provider_profile_acquire_credential_maintenance_lease(
+        self,
+        *,
+        runtime_id: str,
+        profile_id: str,
+        owner_id: str,
+        purpose: str,
+        metadata: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Acquire an acknowledged maintenance lease for a workflow owner."""
+
+        from moonmind.provider_profiles.lease_client import (
+            CredentialLeasePurpose,
+            ProviderProfileLeaseClient,
+        )
+        from moonmind.workflows.temporal.client import TemporalClientAdapter
+
+        lease = await ProviderProfileLeaseClient(
+            TemporalClientAdapter()
+        ).acquire_maintenance_lease(
+            runtime_id=runtime_id,
+            profile_id=profile_id,
+            owner_id=owner_id,
+            purpose=CredentialLeasePurpose(purpose),
+            metadata=metadata,
+            owner_is_workflow=True,
+        )
+        return {
+            "profile_id": lease.profile_id,
+            "runtime_id": lease.runtime_id,
+            "lease_id": lease.lease_id,
+            "owner_id": lease.owner_id,
+            "purpose": lease.purpose.value,
+            "already_held": lease.already_held,
+        }
+
     async def provider_profile_reset_manager(
         self,
         *,

--- a/moonmind/workflows/temporal/artifacts.py
+++ b/moonmind/workflows/temporal/artifacts.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import hashlib
 import json
 import logging
@@ -3338,17 +3339,32 @@ class TemporalArtifactActivities:
             ProviderProfileLeaseClient,
         )
         from moonmind.workflows.temporal.client import TemporalClientAdapter
+        from temporalio import activity
 
-        lease = await ProviderProfileLeaseClient(
-            TemporalClientAdapter()
-        ).acquire_maintenance_lease(
-            runtime_id=runtime_id,
-            profile_id=profile_id,
-            owner_id=owner_id,
-            purpose=CredentialLeasePurpose(purpose),
-            metadata=metadata,
-            owner_is_workflow=True,
+        lease_task = asyncio.create_task(
+            ProviderProfileLeaseClient(
+                TemporalClientAdapter()
+            ).acquire_maintenance_lease(
+                runtime_id=runtime_id,
+                profile_id=profile_id,
+                owner_id=owner_id,
+                purpose=CredentialLeasePurpose(purpose),
+                metadata=metadata,
+                owner_is_workflow=True,
+            )
         )
+        try:
+            while not lease_task.done():
+                await asyncio.wait({lease_task}, timeout=10)
+                if not lease_task.done():
+                    activity.heartbeat({"phase": "waiting_for_maintenance_lease"})
+            lease = await lease_task
+        except BaseException:
+            if not lease_task.done():
+                lease_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await lease_task
+            raise
         return {
             "profile_id": lease.profile_id,
             "runtime_id": lease.runtime_id,

--- a/moonmind/workflows/temporal/runtime/codex_session_runtime.py
+++ b/moonmind/workflows/temporal/runtime/codex_session_runtime.py
@@ -69,6 +69,8 @@ _ROLLOUT_RECOVERY_TIMESTAMP_SKEW_SECONDS = 5.0
 _LOG_RECOVERY_MAX_ROWS = 200
 _LOG_RECOVERY_PROVIDER_MAX_ROWS = 200
 _LOG_RECOVERY_SQLITE_TIMEOUT_SECONDS = 1.0
+_PROVIDER_LOG_SETTLE_GRACE_SECONDS = 1.0
+_PROVIDER_LOG_SETTLE_RETRY_SECONDS = 0.1
 _LOG_RECOVERY_PROVIDER_MARKERS: tuple[str, ...] = provider_failure_search_markers()
 EMPTY_ASSISTANT_FAILURE_CAUSE = "app_server_protocol_empty_turn"
 _EMPTY_ASSISTANT_FAILURE_REASONS: tuple[str, ...] = (
@@ -1684,6 +1686,27 @@ class CodexManagedSessionRuntime:
                 break
         return None
 
+    def _settled_turn_error_from_logs(
+        self,
+        vendor_turn_id: str,
+        *,
+        turn_started_at: float | None = None,
+    ) -> str | None:
+        """Allow Codex's asynchronous SQLite logger to commit terminal errors."""
+
+        deadline = time.monotonic() + _PROVIDER_LOG_SETTLE_GRACE_SECONDS
+        while True:
+            recovered = self._extract_turn_error_from_logs(
+                vendor_turn_id,
+                turn_started_at=turn_started_at,
+            )
+            if recovered:
+                return recovered
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return None
+            time.sleep(min(_PROVIDER_LOG_SETTLE_RETRY_SECONDS, remaining))
+
     def _recent_runtime_log_excerpts(
         self,
         *,
@@ -2268,6 +2291,17 @@ class CodexManagedSessionRuntime:
     ) -> _TurnTerminalOutcome | None:
         thread_outcome = self._terminal_thread_outcome(thread_payload)
         if thread_outcome is not None and thread_outcome.status != "completed":
+            if self._thread_status_type(thread_payload) == "systemerror":
+                recovered_error = self._settled_turn_error_from_logs(
+                    vendor_turn_id,
+                    turn_started_at=state.last_control_at,
+                )
+                if recovered_error:
+                    return _TurnTerminalOutcome(
+                        status="failed",
+                        error_text=recovered_error,
+                        failure_class="permanent",
+                    )
             return thread_outcome
 
         if rollout_scan is None:
@@ -2586,10 +2620,10 @@ class CodexManagedSessionRuntime:
         status_type = cls._thread_status_type(thread_payload)
         if status_type == "idle":
             return _TurnTerminalOutcome(status="completed")
-        if status_type in {"failed", "error"}:
+        if status_type in {"failed", "error", "systemerror"}:
             return _TurnTerminalOutcome(
                 status="failed",
-                error_text=cls._thread_status_reason(thread_payload),
+                error_text=cls._thread_status_reason(thread_payload) or status_type,
                 failure_class="permanent",
             )
         if status_type in {"interrupted", "cancelled", "canceled"}:

--- a/moonmind/workflows/temporal/runtime/codex_session_runtime.py
+++ b/moonmind/workflows/temporal/runtime/codex_session_runtime.py
@@ -2289,20 +2289,14 @@ class CodexManagedSessionRuntime:
         vendor_turn_id: str,
         rollout_scan: _RolloutTurnScan | None = None,
     ) -> _TurnTerminalOutcome | None:
+        failed_thread_outcome = self._failed_thread_terminal_outcome(
+            state=state,
+            thread_payload=thread_payload,
+            vendor_turn_id=vendor_turn_id,
+        )
+        if failed_thread_outcome is not None:
+            return failed_thread_outcome
         thread_outcome = self._terminal_thread_outcome(thread_payload)
-        if thread_outcome is not None and thread_outcome.status != "completed":
-            if self._thread_status_type(thread_payload) == "systemerror":
-                recovered_error = self._settled_turn_error_from_logs(
-                    vendor_turn_id,
-                    turn_started_at=state.last_control_at,
-                )
-                if recovered_error:
-                    return _TurnTerminalOutcome(
-                        status="failed",
-                        error_text=recovered_error,
-                        failure_class="permanent",
-                    )
-            return thread_outcome
 
         if rollout_scan is None:
             vendor_thread_path = self._resolved_rollout_path(
@@ -2330,6 +2324,29 @@ class CodexManagedSessionRuntime:
         if thread_outcome is not None and not rollout_scan.references_turn:
             return thread_outcome
         return None
+
+    def _failed_thread_terminal_outcome(
+        self,
+        *,
+        state: CodexSessionRuntimeState,
+        thread_payload: Mapping[str, Any],
+        vendor_turn_id: str,
+    ) -> _TurnTerminalOutcome | None:
+        thread_outcome = self._terminal_thread_outcome(thread_payload)
+        if thread_outcome is None or thread_outcome.status == "completed":
+            return None
+        if self._thread_status_type(thread_payload) == "systemerror":
+            recovered_error = self._settled_turn_error_from_logs(
+                vendor_turn_id,
+                turn_started_at=state.last_control_at,
+            )
+            if recovered_error:
+                return _TurnTerminalOutcome(
+                    status="failed",
+                    error_text=recovered_error,
+                    failure_class="permanent",
+                )
+        return thread_outcome
 
     def _wait_for_turn_completion(
         self,
@@ -2389,6 +2406,13 @@ class CodexManagedSessionRuntime:
             if isinstance(turn_payload, Mapping):
                 missing_turn_first_seen_at = None
                 outcome = self._terminal_turn_outcome(turn_payload)
+                if outcome is not None:
+                    return thread_payload, outcome
+                outcome = self._failed_thread_terminal_outcome(
+                    state=state,
+                    thread_payload=thread_payload,
+                    vendor_turn_id=vendor_turn_id,
+                )
                 if outcome is not None:
                     return thread_payload, outcome
             else:

--- a/moonmind/workflows/temporal/workflows/oauth_session.py
+++ b/moonmind/workflows/temporal/workflows/oauth_session.py
@@ -31,6 +31,9 @@ logger = logging.getLogger(__name__)
 OAUTH_CREDENTIAL_MAINTENANCE_LEASE_PATCH = (
     "oauth-session-credential-maintenance-lease-v1"
 )
+OAUTH_CREDENTIAL_MAINTENANCE_ACTIVITY_PATCH = (
+    "oauth-session-credential-maintenance-activity-v1"
+)
 
 # ---------------------------------------------------------------------------
 # Input / Output types
@@ -453,34 +456,56 @@ class MoonMindOAuthSessionWorkflow:
                 "profile_id is required for OAuth credential maintenance",
                 non_retryable=True,
             )
-        await workflow.execute_activity(
-            "provider_profile.ensure_manager",
-            {"runtime_id": runtime_id},
-            task_queue=ACTIVITY_TASK_QUEUE,
-            start_to_close_timeout=timedelta(seconds=30),
-            retry_policy=RetryPolicy(
-                initial_interval=timedelta(seconds=1), maximum_attempts=3
-            ),
-        )
         owner_id = f"oauth-session:{self._session_id}"
-        manager = workflow.get_external_workflow_handle(
-            f"provider-profile-manager:{runtime_id}"
-        )
-        result = await manager.execute_update(
-            "AcquireCredentialMaintenanceLease",
-            {
-                "requester_workflow_id": owner_id,
-                "owner_id": owner_id,
-                "runtime_id": runtime_id,
-                "execution_profile_ref": profile_id,
-                "purpose": purpose,
-                "metadata": {
-                    "workflowId": workflow.info().workflow_id,
-                    "oauthSessionId": self._session_id,
-                    "ownerIsWorkflow": True,
-                },
+        payload = {
+            "runtime_id": runtime_id,
+            "profile_id": profile_id,
+            "owner_id": owner_id,
+            "purpose": purpose,
+            "metadata": {
+                "workflowId": workflow.info().workflow_id,
+                "oauthSessionId": self._session_id,
+                "ownerIsWorkflow": True,
             },
-        )
+        }
+        if workflow.patched(OAUTH_CREDENTIAL_MAINTENANCE_ACTIVITY_PATCH):
+            result = await workflow.execute_activity(
+                "provider_profile.acquire_credential_maintenance_lease",
+                payload,
+                task_queue=ACTIVITY_TASK_QUEUE,
+                start_to_close_timeout=timedelta(seconds=1800),
+                retry_policy=RetryPolicy(maximum_attempts=1),
+            )
+        else:
+            # Replay-only path for histories recorded before workflow-context
+            # ExternalWorkflowHandle Updates were moved to an Activity boundary.
+            await workflow.execute_activity(
+                "provider_profile.ensure_manager",
+                {"runtime_id": runtime_id},
+                task_queue=ACTIVITY_TASK_QUEUE,
+                start_to_close_timeout=timedelta(seconds=30),
+                retry_policy=RetryPolicy(
+                    initial_interval=timedelta(seconds=1), maximum_attempts=3
+                ),
+            )
+            manager = workflow.get_external_workflow_handle(
+                f"provider-profile-manager:{runtime_id}"
+            )
+            result = await manager.execute_update(
+                "AcquireCredentialMaintenanceLease",
+                {
+                    "requester_workflow_id": owner_id,
+                    "owner_id": owner_id,
+                    "runtime_id": runtime_id,
+                    "execution_profile_ref": profile_id,
+                    "purpose": purpose,
+                    "metadata": {
+                        "workflowId": workflow.info().workflow_id,
+                        "oauthSessionId": self._session_id,
+                        "ownerIsWorkflow": True,
+                    },
+                },
+            )
         self._maintenance_lease_acquired = True
         self._maintenance_profile_id = profile_id
         self._maintenance_runtime_id = runtime_id

--- a/moonmind/workflows/temporal/workflows/oauth_session.py
+++ b/moonmind/workflows/temporal/workflows/oauth_session.py
@@ -474,7 +474,10 @@ class MoonMindOAuthSessionWorkflow:
                 payload,
                 task_queue=ACTIVITY_TASK_QUEUE,
                 start_to_close_timeout=timedelta(seconds=1800),
-                retry_policy=RetryPolicy(maximum_attempts=1),
+                heartbeat_timeout=timedelta(seconds=30),
+                retry_policy=RetryPolicy(
+                    initial_interval=timedelta(seconds=1), maximum_attempts=3
+                ),
             )
         else:
             # Replay-only path for histories recorded before workflow-context

--- a/tests/integration/reliability/replays/codex-oauth-log-settle-race/expected-outcome.json
+++ b/tests/integration/reliability/replays/codex-oauth-log-settle-race/expected-outcome.json
@@ -1,0 +1,7 @@
+{
+  "runtimeFailureClass": "permanent",
+  "failureClass": "user_error",
+  "providerErrorCode": "401",
+  "retryRecommendation": "reauthenticate",
+  "reason": "Your access token could not be refreshed because your refresh token was already used. Please log out and sign in again."
+}

--- a/tests/integration/reliability/replays/codex-oauth-log-settle-race/manifest.json
+++ b/tests/integration/reliability/replays/codex-oauth-log-settle-race/manifest.json
@@ -1,0 +1,20 @@
+{
+  "failureShapeId": "codex-oauth-log-settle-race",
+  "incidentWorkflowId": "mm:32a5549d-f87c-4670-9001-2e2539cf1b3f",
+  "runtime": "codex_cli",
+  "threadStatusType": "systemError",
+  "terminalRolloutEvent": {
+    "timestamp": "2026-07-13T16:58:47.056Z",
+    "type": "event_msg",
+    "payload": {
+      "type": "task_complete",
+      "turn_id": "vendor-turn-1",
+      "last_agent_message": null
+    }
+  },
+  "rolloutRelativePath": "sessions/2026/07/13/rollout-2026-07-13T16-58-45-vendor-thread-1.jsonl",
+  "providerLogDelaySeconds": 0.2,
+  "providerLog": "model_client:auth: Failed to refresh token: Your access token could not be refreshed because your refresh token was already used. Please log out and sign in again.",
+  "escapedFailure": "app_server_protocol_empty_turn",
+  "invariant": "A terminal Codex systemError waits for its provider log and routes OAuth failure to reauthentication instead of clearing the session"
+}

--- a/tests/integration/reliability/replays/oauth-maintenance-external-update/expected-outcome.json
+++ b/tests/integration/reliability/replays/oauth-maintenance-external-update/expected-outcome.json
@@ -1,0 +1,6 @@
+{
+  "leaseAcquired": true,
+  "acknowledgedBy": "AcquireCredentialMaintenanceLease",
+  "ownerIsWorkflow": true,
+  "externalWorkflowHandleUpdateAttempted": false
+}

--- a/tests/integration/reliability/replays/oauth-maintenance-external-update/manifest.json
+++ b/tests/integration/reliability/replays/oauth-maintenance-external-update/manifest.json
@@ -1,0 +1,18 @@
+{
+  "failureShapeId": "oauth-maintenance-external-update",
+  "incidentReference": "oauth-screen-2026-07-13",
+  "runtimeId": "codex_cli",
+  "profileId": "codex_openai_oauth",
+  "workflowType": "MoonMind.OAuthSession",
+  "failure": {
+    "type": "AttributeError",
+    "message": "ExternalWorkflowHandle has no execute_update method"
+  },
+  "leaseRequest": {
+    "ownerId": "oauth-session:oas-replay",
+    "purpose": "oauth_reconnect",
+    "ownerIsWorkflow": true
+  },
+  "expectedActivityType": "provider_profile.acquire_credential_maintenance_lease",
+  "expectedTaskQueue": "mm.activity.artifacts"
+}

--- a/tests/integration/reliability/test_escaped_failure_journeys.py
+++ b/tests/integration/reliability/test_escaped_failure_journeys.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 
 import hashlib
 import json
+import sqlite3
+import threading
+import time
 from datetime import datetime, timezone
 from pathlib import Path
 from types import SimpleNamespace
@@ -11,11 +14,19 @@ import pytest
 from moonmind.schemas.managed_session_models import SendCodexManagedSessionTurnRequest
 from moonmind.schemas.agent_runtime_models import AgentExecutionRequest, AgentRunResult
 from moonmind.schemas.workspace_locator_models import WorkspaceLocatorResolutionError
+from moonmind.provider_profiles.lease_client import (
+    CredentialLeasePurpose,
+    ProviderProfileLeaseClient,
+)
 from moonmind.workflows.adapters.codex_session_adapter import _pr_resolver_terminal_contract
 from moonmind.workflows.provider_failures import classify_provider_failure
 from moonmind.workflows.temporal.activity_runtime import (
     TemporalAgentRuntimeActivities,
     TemporalSandboxActivities,
+)
+from moonmind.workflows.temporal.activity_catalog import build_default_activity_catalog
+from moonmind.workflows.temporal.runtime.codex_session_runtime import (
+    CodexManagedSessionRuntime,
 )
 from moonmind.workflows.temporal.workflows import agent_run as agent_run_module
 from moonmind.workflows.temporal.workflows import run as run_workflow_module
@@ -23,6 +34,7 @@ from moonmind.workflows.temporal.workflows.agent_run import MoonMindAgentRun
 from moonmind.workflows.temporal.workflows.run import MoonMindRunWorkflow
 from moonmind.workflows.terminal_evidence import evaluate_terminal_evidence
 from tests.integration.reliability.helpers import NestedYieldProcess, load_replay
+from tests.helpers.codex_session_runtime import launch_request, write_fake_app_server
 from tests.unit.workflows.adapters.test_codex_session_adapter import (
     _binding,
     _pr_resolver_request,
@@ -40,6 +52,54 @@ pytestmark = [
     pytest.mark.integration_ci,
     pytest.mark.reliability_journey,
 ]
+
+
+async def test_oauth_maintenance_lease_replays_through_activity_update_boundary() -> (
+    None
+):
+    manifest = load_replay("oauth-maintenance-external-update", "manifest.json")
+    expected = load_replay(
+        "oauth-maintenance-external-update", "expected-outcome.json"
+    )
+
+    class Adapter:
+        def __init__(self) -> None:
+            self.update_name = ""
+            self.payload: dict[str, object] = {}
+
+        async def get_client(self):
+            return self
+
+        async def start_workflow(self, *_args, **_kwargs):
+            return None
+
+        async def update_workflow(self, _workflow_id, update_name, payload):
+            self.update_name = update_name
+            self.payload = payload
+            return {
+                "profile_id": manifest["profileId"],
+                "lease_id": payload["owner_id"],
+            }
+
+    route = build_default_activity_catalog().resolve_activity(
+        manifest["expectedActivityType"]
+    )
+    adapter = Adapter()
+    lease = await ProviderProfileLeaseClient(adapter).acquire_maintenance_lease(
+        runtime_id=manifest["runtimeId"],
+        profile_id=manifest["profileId"],
+        owner_id=manifest["leaseRequest"]["ownerId"],
+        purpose=CredentialLeasePurpose(manifest["leaseRequest"]["purpose"]),
+        metadata={"oauthSessionId": "oas-replay"},
+        owner_is_workflow=True,
+    )
+
+    assert route.task_queue == manifest["expectedTaskQueue"]
+    assert lease.lease_id == manifest["leaseRequest"]["ownerId"]
+    assert adapter.update_name == expected["acknowledgedBy"]
+    assert adapter.payload["metadata"]["ownerIsWorkflow"] is expected[
+        "ownerIsWorkflow"
+    ]
 
 
 async def test_completed_batch_turn_without_fanout_evidence_fails() -> None:
@@ -359,6 +419,82 @@ async def test_codex_oauth_failure_preserves_primary_error_and_managed_authority
     assert parent._step_checkpoint_capture_outcomes["node-1"] == (
         expected["checkpointOutcome"]
     )
+
+
+async def test_codex_system_error_waits_for_delayed_oauth_failure_log(
+    tmp_path: Path,
+) -> None:
+    """Replay mm:32a5549d through the real managed-session runtime boundary."""
+
+    replay_id = "codex-oauth-log-settle-race"
+    manifest = load_replay(replay_id, "manifest.json")
+    expected = load_replay(replay_id, "expected-outcome.json")
+    request = launch_request(tmp_path)
+    transcript_path = Path(request.codex_home_path) / manifest["rolloutRelativePath"]
+    transcript_path.parent.mkdir(parents=True, exist_ok=True)
+    script = write_fake_app_server(
+        tmp_path,
+        assistant_text="",
+        omit_turns_on_read=True,
+        thread_status_type=manifest["threadStatusType"],
+        start_thread_path=str(transcript_path),
+        rollout_entries_on_read=[manifest["terminalRolloutEvent"]],
+    )
+    runtime = CodexManagedSessionRuntime(
+        workspace_path=request.workspace_path,
+        session_workspace_path=request.session_workspace_path,
+        artifact_spool_path=request.artifact_spool_path,
+        codex_home_path=request.codex_home_path,
+        image_ref=request.image_ref,
+        control_url="docker-exec://mm-codex-session-sess-1",
+        container_id="ctr-1",
+        app_server_command=("python3", str(script)),
+    )
+    runtime.launch_session(request)
+    log_path = Path(request.codex_home_path) / "logs_1.sqlite"
+    with sqlite3.connect(log_path) as connection:
+        connection.execute(
+            "CREATE TABLE logs ("
+            "id INTEGER PRIMARY KEY AUTOINCREMENT, "
+            "ts INTEGER, "
+            "feedback_log_body TEXT"
+            ")"
+        )
+
+    def commit_provider_failure_after_terminal_event() -> None:
+        time.sleep(manifest["providerLogDelaySeconds"])
+        with sqlite3.connect(log_path) as connection:
+            connection.execute(
+                "INSERT INTO logs (ts, feedback_log_body) VALUES (?, ?)",
+                (int(time.time()), manifest["providerLog"]),
+            )
+
+    writer = threading.Thread(
+        target=commit_provider_failure_after_terminal_event,
+        daemon=True,
+    )
+    writer.start()
+    response = runtime.send_turn(
+        SendCodexManagedSessionTurnRequest(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            containerId="ctr-1",
+            threadId="logical-thread-1",
+            instructions="Reply with exactly the word OK",
+        )
+    )
+    writer.join(timeout=2)
+
+    assert not writer.is_alive()
+    assert response.status == "failed"
+    assert response.metadata["failureClass"] == expected["runtimeFailureClass"]
+    assert response.metadata["reason"] == expected["reason"]
+    assert "retryRecommendedAction" not in response.metadata
+    classified = classify_provider_failure(response.metadata["reason"])
+    assert classified is not None
+    assert classified.failure_class == expected["failureClass"]
+    assert classified.provider_error_code == expected["providerErrorCode"]
+    assert classified.retry_recommendation == expected["retryRecommendation"]
 
 
 async def test_checkpoint_finalization_fault_is_retryable(

--- a/tests/integration/temporal/test_oauth_session.py
+++ b/tests/integration/temporal/test_oauth_session.py
@@ -4,7 +4,7 @@ from collections.abc import AsyncIterator, Sequence
 from contextlib import AsyncExitStack, asynccontextmanager
 
 import pytest
-from temporalio import activity
+from temporalio import activity, workflow
 from temporalio.testing import WorkflowEnvironment
 from temporalio.worker import Worker, UnsandboxedWorkflowRunner
 
@@ -58,6 +58,23 @@ async def mock_stop_auth_runner(request: dict) -> dict:
 @activity.defn(name="oauth_session.mark_failed")
 async def mock_mark_failed(request: dict) -> dict:
     return {}
+
+
+@workflow.defn(name="MoonMind.TestOAuthMaintenanceLeaseBoundary")
+class TestOAuthMaintenanceLeaseBoundaryWorkflow:
+    @workflow.run
+    async def run(self, request: dict) -> dict:
+        oauth_workflow = MoonMindOAuthSessionWorkflow()
+        oauth_workflow._session_id = request["session_id"]
+        await oauth_workflow._acquire_maintenance_lease(
+            runtime_id=request["runtime_id"],
+            profile_id=request["profile_id"],
+            purpose=request["purpose"],
+        )
+        return {
+            "acquired": oauth_workflow._maintenance_lease_acquired,
+            "lease_id": oauth_workflow._maintenance_lease_id,
+        }
 
 @asynccontextmanager
 async def _oauth_workers(
@@ -129,6 +146,62 @@ async def test_oauth_session_workflow_success() -> None:
             
             assert result["session_id"] == "sess_default"
             assert result["status"] == "succeeded"
+
+
+async def test_oauth_maintenance_lease_uses_acknowledged_activity_boundary() -> None:
+    requests: list[dict] = []
+
+    @activity.defn(
+        name="provider_profile.acquire_credential_maintenance_lease"
+    )
+    async def acquire_maintenance_lease(request: dict) -> dict:
+        requests.append(request)
+        return {
+            "profile_id": request["profile_id"],
+            "lease_id": request["owner_id"],
+            "already_held": False,
+        }
+
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        async with Worker(
+            env.client,
+            task_queue=ACTIVITY_TASK_QUEUE,
+            activities=[acquire_maintenance_lease],
+        ), Worker(
+            env.client,
+            task_queue=WORKFLOW_TASK_QUEUE,
+            workflows=[TestOAuthMaintenanceLeaseBoundaryWorkflow],
+            workflow_runner=UnsandboxedWorkflowRunner(),
+        ):
+            result = await env.client.execute_workflow(
+                TestOAuthMaintenanceLeaseBoundaryWorkflow.run,
+                {
+                    "session_id": "oas-lease-boundary",
+                    "runtime_id": "codex_cli",
+                    "profile_id": "codex_openai_oauth",
+                    "purpose": "oauth_reconnect",
+                },
+                id="test-oauth-maintenance-lease-boundary",
+                task_queue=WORKFLOW_TASK_QUEUE,
+            )
+
+    assert result == {
+        "acquired": True,
+        "lease_id": "oauth-session:oas-lease-boundary",
+    }
+    assert requests == [
+        {
+            "runtime_id": "codex_cli",
+            "profile_id": "codex_openai_oauth",
+            "owner_id": "oauth-session:oas-lease-boundary",
+            "purpose": "oauth_reconnect",
+            "metadata": {
+                "workflowId": "test-oauth-maintenance-lease-boundary",
+                "oauthSessionId": "oas-lease-boundary",
+                "ownerIsWorkflow": True,
+            },
+        }
+    ]
             
 async def test_oauth_session_workflow_cancel() -> None:
     """Test OAuth session workflow cancellation."""

--- a/tests/unit/auth/test_oauth_session_activities.py
+++ b/tests/unit/auth/test_oauth_session_activities.py
@@ -66,6 +66,16 @@ class TestOAuthSessionCatalogRegistration:
         assert route.activity_type == "oauth_session.update_status"
         assert route.fleet == ARTIFACTS_FLEET
 
+    def test_maintenance_lease_acquisition_routes_to_artifacts(self) -> None:
+        catalog = build_default_activity_catalog()
+        route = catalog.resolve_activity(
+            "provider_profile.acquire_credential_maintenance_lease"
+        )
+        assert route.fleet == ARTIFACTS_FLEET
+        assert route.task_queue == "mm.activity.artifacts"
+        assert route.timeouts.start_to_close_seconds == 1800
+        assert route.retries.max_attempts == 1
+
     def test_mark_failed_in_catalog(self) -> None:
         catalog = build_default_activity_catalog()
         route = catalog.resolve_activity("oauth_session.mark_failed")

--- a/tests/unit/auth/test_oauth_session_activities.py
+++ b/tests/unit/auth/test_oauth_session_activities.py
@@ -2,13 +2,16 @@
 
 from __future__ import annotations
 
+import asyncio
 from contextlib import asynccontextmanager
+from types import SimpleNamespace
 
 import pytest
 import pytest_asyncio
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
 from temporalio import exceptions
+from temporalio import activity as temporal_activity
 
 from api_service.db.models import (
     Base,
@@ -32,6 +35,11 @@ from moonmind.workflows.temporal.activity_catalog import AGENT_RUNTIME_FLEET
 from moonmind.workflows.temporal.activity_catalog import ARTIFACTS_FLEET
 from moonmind.workflows.temporal.runtime.providers import registry as provider_registry
 from moonmind.workflows.temporal.workers import list_registered_workflow_types
+from moonmind.provider_profiles.lease_client import (
+    CredentialLeasePurpose,
+    ProviderProfileLeaseClient,
+)
+from moonmind.workflows.temporal.artifacts import TemporalArtifactActivities
 
 @pytest_asyncio.fixture
 async def _oauth_activity_session_factory(tmp_path):
@@ -74,7 +82,9 @@ class TestOAuthSessionCatalogRegistration:
         assert route.fleet == ARTIFACTS_FLEET
         assert route.task_queue == "mm.activity.artifacts"
         assert route.timeouts.start_to_close_seconds == 1800
-        assert route.retries.max_attempts == 1
+        assert route.timeouts.heartbeat_timeout_seconds == 30
+        assert route.retries.max_attempts == 3
+        assert route.heartbeat_required is True
 
     def test_mark_failed_in_catalog(self) -> None:
         catalog = build_default_activity_catalog()
@@ -117,6 +127,62 @@ class TestOAuthSessionCatalogRegistration:
         assert route.fleet == "artifacts"
         assert route.timeouts.start_to_close_seconds == 30
         assert route.timeouts.schedule_to_close_seconds == 60
+
+
+@pytest.mark.asyncio
+async def test_maintenance_lease_activity_heartbeats_while_waiting(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    lease_ready = asyncio.Event()
+    heartbeat_details: list[dict] = []
+    original_wait = asyncio.wait
+    wait_calls = 0
+
+    async def acquire_maintenance_lease(_self, **_kwargs):
+        await lease_ready.wait()
+        return SimpleNamespace(
+            profile_id="codex_openai_oauth",
+            runtime_id="codex_cli",
+            lease_id="oauth-session:oas-heartbeat",
+            owner_id="oauth-session:oas-heartbeat",
+            purpose=CredentialLeasePurpose.OAUTH_RECONNECT,
+            already_held=False,
+        )
+
+    async def controlled_wait(tasks, *, timeout):
+        nonlocal wait_calls
+        wait_calls += 1
+        if wait_calls == 1:
+            lease_ready.set()
+            return set(), set(tasks)
+        return await original_wait(tasks, timeout=timeout)
+
+    monkeypatch.setattr(
+        ProviderProfileLeaseClient,
+        "acquire_maintenance_lease",
+        acquire_maintenance_lease,
+    )
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.artifacts.asyncio.wait",
+        controlled_wait,
+    )
+    monkeypatch.setattr(
+        temporal_activity,
+        "heartbeat",
+        lambda details: heartbeat_details.append(details),
+    )
+
+    result = await TemporalArtifactActivities(
+        None  # type: ignore[arg-type]
+    ).provider_profile_acquire_credential_maintenance_lease(
+        runtime_id="codex_cli",
+        profile_id="codex_openai_oauth",
+        owner_id="oauth-session:oas-heartbeat",
+        purpose="oauth_reconnect",
+    )
+
+    assert result["lease_id"] == "oauth-session:oas-heartbeat"
+    assert heartbeat_details == [{"phase": "waiting_for_maintenance_lease"}]
 
 class TestOAuthSessionWorkflowRegistration:
     """Verify the OAuth session workflow is registered."""

--- a/tests/unit/omnigent/test_oauth_profile_lifecycle.py
+++ b/tests/unit/omnigent/test_oauth_profile_lifecycle.py
@@ -155,6 +155,41 @@ async def test_activity_lease_client_marks_deterministic_owner_as_non_workflow()
 
 
 @pytest.mark.asyncio
+async def test_activity_lease_client_preserves_delegating_workflow_owner() -> None:
+    class Adapter:
+        def __init__(self) -> None:
+            self.payload = None
+
+        async def get_client(self):
+            return self
+
+        async def start_workflow(self, *_args, **_kwargs):
+            return None
+
+        async def update_workflow(self, _workflow_id, _update_name, payload):
+            self.payload = payload
+            return {
+                "profile_id": "codex",
+                "lease_id": payload["requester_workflow_id"],
+            }
+
+    adapter = Adapter()
+    await ProviderProfileLeaseClient(adapter).acquire_maintenance_lease(
+        runtime_id="codex_cli",
+        profile_id="codex",
+        owner_id="oauth-session:oas-1",
+        purpose=CredentialLeasePurpose.OAUTH_RECONNECT,
+        metadata={"workflowId": "oauth-session:oas-1"},
+        owner_is_workflow=True,
+    )
+
+    assert adapter.payload["metadata"] == {
+        "workflowId": "oauth-session:oas-1",
+        "ownerIsWorkflow": True,
+    }
+
+
+@pytest.mark.asyncio
 async def test_on_demand_host_initializes_state_before_unprivileged_launch(
     tmp_path,
 ) -> None:

--- a/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
+++ b/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
@@ -1438,6 +1438,89 @@ def test_runtime_send_turn_recovers_auth_failure_from_recent_log_for_empty_task_
     }
 
 
+def test_runtime_send_turn_waits_for_auth_log_after_system_error(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    request = launch_request(tmp_path)
+    transcript_path = (
+        Path(request.codex_home_path)
+        / "sessions"
+        / "2026"
+        / "07"
+        / "13"
+        / "rollout-2026-07-13T16-58-45-vendor-thread-1.jsonl"
+    )
+    transcript_path.parent.mkdir(parents=True, exist_ok=True)
+    script = write_fake_app_server(
+        tmp_path,
+        assistant_text="",
+        omit_turns_on_read=True,
+        thread_status_type="systemError",
+        start_thread_path=str(transcript_path),
+        rollout_entries_on_read=[
+            {
+                "timestamp": "2026-07-13T16:58:47.056Z",
+                "type": "event_msg",
+                "payload": {
+                    "type": "task_complete",
+                    "turn_id": "vendor-turn-1",
+                    "last_agent_message": None,
+                },
+            }
+        ],
+    )
+    runtime = CodexManagedSessionRuntime(
+        workspace_path=request.workspace_path,
+        session_workspace_path=request.session_workspace_path,
+        artifact_spool_path=request.artifact_spool_path,
+        codex_home_path=request.codex_home_path,
+        image_ref=request.image_ref,
+        control_url="docker-exec://mm-codex-session-sess-1",
+        container_id="ctr-1",
+        app_server_command=("python3", str(script)),
+    )
+    runtime.launch_session(request)
+    auth_summary = (
+        "Your access token could not be refreshed because your refresh token "
+        "was already used. Please log out and sign in again."
+    )
+    recovery_attempts = iter((None, auth_summary))
+    monkeypatch.setattr(
+        runtime,
+        "_extract_turn_error_from_logs",
+        lambda *_args, **_kwargs: next(recovery_attempts),
+    )
+
+    response = runtime.send_turn(
+        SendCodexManagedSessionTurnRequest(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            containerId="ctr-1",
+            threadId="logical-thread-1",
+            instructions="Reply with exactly the word OK",
+        )
+    )
+
+    assert response.status == "failed"
+    assert response.metadata == {
+        "failureClass": "permanent",
+        "reason": auth_summary,
+    }
+    assert "retryRecommendedAction" not in response.metadata
+
+
+def test_system_error_thread_status_is_terminal_failure() -> None:
+    outcome = CodexManagedSessionRuntime._terminal_thread_outcome(
+        {"thread": {"status": {"type": "systemError"}}}
+    )
+
+    assert outcome is not None
+    assert outcome.status == "failed"
+    assert outcome.error_text == "systemerror"
+    assert outcome.failure_class == "permanent"
+
+
 def _spool_skill_outcome_path(request: LaunchCodexManagedSessionRequest) -> Path:
     return Path(request.artifact_spool_path) / "skill_outcome.json"
 

--- a/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
+++ b/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
@@ -1510,6 +1510,59 @@ def test_runtime_send_turn_waits_for_auth_log_after_system_error(
     assert "retryRecommendedAction" not in response.metadata
 
 
+def test_runtime_send_turn_honors_system_error_with_visible_in_progress_turn(
+    tmp_path: Path,
+) -> None:
+    request = launch_request(tmp_path)
+    script = write_fake_app_server(
+        tmp_path,
+        assistant_text="",
+        completion_notification_method=None,
+        complete_turn_on_read=False,
+        thread_status_type="systemError",
+    )
+    runtime = CodexManagedSessionRuntime(
+        workspace_path=request.workspace_path,
+        session_workspace_path=request.session_workspace_path,
+        artifact_spool_path=request.artifact_spool_path,
+        codex_home_path=request.codex_home_path,
+        image_ref=request.image_ref,
+        control_url="docker-exec://mm-codex-session-sess-1",
+        container_id="ctr-1",
+        app_server_command=("python3", str(script)),
+    )
+    runtime.launch_session(request)
+    auth_summary = (
+        "Your access token could not be refreshed because your refresh token "
+        "was already used. Please log out and sign in again."
+    )
+    _write_fake_codex_logs_with_timestamps(
+        request.codex_home_path,
+        entries=[
+            (
+                int(time.time()) + 1,
+                "model_client:auth: Failed to refresh token: " + auth_summary,
+            )
+        ],
+    )
+
+    response = runtime.send_turn(
+        SendCodexManagedSessionTurnRequest(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            containerId="ctr-1",
+            threadId="logical-thread-1",
+            instructions="Reply with exactly the word OK",
+        )
+    )
+
+    assert response.status == "failed"
+    assert response.metadata == {
+        "failureClass": "permanent",
+        "reason": auth_summary,
+    }
+
+
 def test_system_error_thread_status_is_terminal_failure() -> None:
     outcome = CodexManagedSessionRuntime._terminal_thread_outcome(
         {"thread": {"status": {"type": "systemError"}}}


### PR DESCRIPTION
## Summary

- preserve the underlying Codex OAuth failure when app-server terminal state arrives before its asynchronous diagnostic log
- recognize `systemError` as terminal and allow a bounded diagnostic settle window
- acquire OAuth credential-maintenance leases through an acknowledged artifacts activity instead of calling a client-only update method on a workflow handle
- add redacted escaped-failure replays plus unit and Temporal workflow-boundary coverage

## Root cause

The original workflow failure combined two separate defects:

1. Codex reported a terminal system error before its SQLite logger committed the provider authentication failure, so MoonMind mislabeled the turn as an empty assistant response.
2. The OAuth workflow called `execute_update` on Temporal's workflow-context `ExternalWorkflowHandle`, which does not expose client-side update execution.

## Impact

Codex authentication failures now retain their actionable reauthentication classification, and the OAuth Connect/Reconnect screen can acquire exclusive credential-maintenance capacity through the supported Temporal client boundary. A patch marker preserves the recorded command path for already-started OAuth histories.

## Validation

- `tests/unit/services/temporal/runtime/test_codex_session_runtime.py`: 90 passed
- `tests/unit/auth/test_oauth_session_activities.py`: 22 passed
- `tests/integration/temporal/test_oauth_session.py`: 11 passed
- `tests/integration/reliability/test_escaped_failure_journeys.py`: 9 passed
- `tests/unit/workflows/temporal/test_temporal_workers.py`: 15 passed
- `tests/unit/workflows/temporal/test_activity_catalog.py`: 13 passed
- `tests/unit/omnigent/test_oauth_profile_lifecycle.py`: 10 passed
- Python compile checks, JSON validation, and `git diff --check` passed
