### PR TITLE
Corner-anchored gradient ring + light-blue hover glow for nav buttons

### DIFF
--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -21,26 +21,31 @@
   --mm-danger: 244 63 94;
   --mm-action-primary: 21 147 118;
   --mm-shadow: 0 18px 32px -26px rgb(10 8 30 / 0.55);
-  /* Highlight-edge treatment, liquid-glass style: faint uniform top/bottom
-   * edge lines plus diagonally offset corner boosts, so the top-left corner
-   * catches white light and the bottom-right corner catches the violet rim —
-   * deliberately asymmetric rather than horizontally uniform. A quite faint
-   * accent glow sits almost entirely under the bottom edge so it reads as
-   * backlit (the negative spread pulls the blur off the sides). No perimeter
-   * ring: the sides stay open. The hover variant swaps the under-glow to the
-   * cyan accent (the executing-pill hue). */
-  --mm-shadow-highlight-edge:
-    inset 0 1px 0 rgb(255 255 255 / 0.12),
-    inset 2px 2px 3px -2px rgb(255 255 255 / 0.3),
-    inset 0 -1px 0 rgb(167 139 250 / 0.18),
-    inset -2px -2px 3px -2px rgb(167 139 250 / 0.55),
-    0 5px 9px -5px rgb(var(--mm-accent) / 0.45);
-  --mm-shadow-highlight-edge-hover:
-    inset 0 1px 0 rgb(255 255 255 / 0.12),
-    inset 2px 2px 3px -2px rgb(255 255 255 / 0.3),
-    inset 0 -1px 0 rgb(167 139 250 / 0.18),
-    inset -2px -2px 3px -2px rgb(167 139 250 / 0.55),
-    0 5px 9px -5px rgb(var(--mm-accent-2) / 0.55);
+  /* Highlight-edge treatment, liquid-glass style. The edge light is a masked
+   * gradient ring (--mm-highlight-edge-ring, applied via pseudo-element):
+   * two corner-anchored radial gradients — white bleeding out of the top-left
+   * corner, violet out of the bottom-right — fading to nothing before they
+   * reach the top-right and bottom-left corners. Radials (not a 135° linear)
+   * so the light hugs the corners at any button aspect ratio, and a gradient
+   * (not box-shadow insets) because a shadow cannot fade along an edge. The
+   * shadow tokens carry only the faint under-glow, kept almost entirely on
+   * the bottom edge (the negative spread pulls the blur off the sides); the
+   * hover variant swaps it to light blue. */
+  --mm-highlight-edge-ring:
+    radial-gradient(
+      130% 220% at 0% 0%,
+      rgb(255 255 255 / 0.6) 0%,
+      rgb(255 255 255 / 0.12) 22%,
+      transparent 45%
+    ),
+    radial-gradient(
+      130% 220% at 100% 100%,
+      rgb(167 139 250 / 0.7) 0%,
+      rgb(167 139 250 / 0.16) 22%,
+      transparent 45%
+    );
+  --mm-shadow-highlight-edge: 0 5px 9px -5px rgb(var(--mm-accent) / 0.45);
+  --mm-shadow-highlight-edge-hover: 0 5px 9px -5px rgb(110 180 255 / 0.6);
   --mm-atmosphere-violet: radial-gradient(circle at 8% 0%, rgb(var(--mm-accent) / 0.18), transparent 44%);
   --mm-atmosphere-cyan: radial-gradient(circle at 98% 0%, rgb(var(--mm-accent-2) / 0.14), transparent 42%);
   --mm-atmosphere-warm: radial-gradient(circle at 50% 100%, rgb(var(--mm-accent-warm) / 0.10), transparent 52%);
@@ -702,11 +707,33 @@ h1 {
 }
 
 /* Hovered nav buttons brighten, grow slightly, and swap the purple under-glow
- * for the cyan accent — matching the System trigger's hover feel. */
+ * for light blue — matching the System trigger's hover feel. */
 .route-nav-primary a:hover {
   box-shadow: var(--mm-shadow-highlight-edge-hover);
   transform: scale(var(--mm-control-hover-scale));
   filter: brightness(1.08) saturate(1.04);
+}
+
+/* Diagonal liquid-glass edge: a 1px gradient ring drawn on a pseudo-element
+ * (the border-box gradient is masked down to the ring between border-box and
+ * content-box), bright white at the top-left corner and violet at the
+ * bottom-right, fading to nothing at the other two corners. The radio group
+ * uses ::after because its ::before is the sliding selection thumb. The ring
+ * scales with the hover transform and never intercepts pointer events. */
+.route-nav-primary a::before,
+.dashboard-system-trigger::before,
+.workflow-list-display-control::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  padding: 1px;
+  background: var(--mm-highlight-edge-ring);
+  -webkit-mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
+  -webkit-mask-composite: xor;
+  mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
+  mask-composite: exclude;
+  pointer-events: none;
 }
 
 .route-nav-icon {
@@ -7832,6 +7859,12 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
     backdrop-filter: none;
     -webkit-backdrop-filter: none;
     transform: none;
+  }
+
+  /* The collapsed nav renders flat menu rows: drop the desktop liquid-glass
+   * gradient ring along with the shadows it accompanies. */
+  .route-nav-primary a::before {
+    content: none;
   }
 
   .route-nav a:hover {

--- a/frontend/src/styles/dashboardBrand.test.ts
+++ b/frontend/src/styles/dashboardBrand.test.ts
@@ -97,30 +97,45 @@ describe('dashboard masthead brand styles', () => {
   });
 
   it('gives the nav buttons and list display control the highlight-edge look with a sliding thumb', () => {
-    // The shared liquid-glass treatment: faint uniform edge lines plus
-    // diagonally offset corner boosts (top-left white, bottom-right violet),
-    // and a quite faint accent glow kept almost entirely on the bottom edge —
-    // the negative spread pulls the blur off the sides. The sides stay open —
-    // no perimeter ring. The hover variant swaps the under-glow to the cyan
-    // accent (executing-pill hue).
+    // The shared liquid-glass treatment: the edge light is a masked gradient
+    // ring built from two corner-anchored radials — white bleeding out of the
+    // top-left corner, violet out of the bottom-right, fading to nothing
+    // before the other two corners — plus a quite faint under-glow kept
+    // almost entirely on the bottom edge. The hover variant swaps the glow to
+    // light blue.
     const highlightShadow =
       /box-shadow:\s*var\(--mm-shadow-highlight-edge\);/;
-    const asymmetricInsets =
-      String.raw`inset 0 1px 0 rgb\(255 255 255 \/ 0\.12\),\s*inset 2px 2px 3px -2px rgb\(255 255 255 \/ 0\.3\),\s*inset 0 -1px 0 rgb\(167 139 250 \/ 0\.18\),\s*inset -2px -2px 3px -2px rgb\(167 139 250 \/ 0\.55\)`;
     expect(dashboardCss).toMatch(
-      new RegExp(
-        String.raw`--mm-shadow-highlight-edge:\s*${asymmetricInsets},\s*0 5px 9px -5px rgb\(var\(--mm-accent\) \/ 0\.45\);`,
-      ),
+      /--mm-highlight-edge-ring:\s*radial-gradient\(\s*130% 220% at 0% 0%,\s*rgb\(255 255 255 \/ 0\.6\) 0%,[\s\S]*?transparent 45%\s*\),\s*radial-gradient\(\s*130% 220% at 100% 100%,\s*rgb\(167 139 250 \/ 0\.7\) 0%,[\s\S]*?transparent 45%\s*\);/,
     );
     expect(dashboardCss).toMatch(
-      new RegExp(
-        String.raw`--mm-shadow-highlight-edge-hover:\s*${asymmetricInsets},\s*0 5px 9px -5px rgb\(var\(--mm-accent-2\) \/ 0\.55\);`,
-      ),
+      /--mm-shadow-highlight-edge:\s*0 5px 9px -5px rgb\(var\(--mm-accent\) \/ 0\.45\);/,
     );
-    // The tokens must stay side-open: no perimeter ring, so the buttons read
-    // as corner-lit glass instead of an outline.
+    expect(dashboardCss).toMatch(
+      /--mm-shadow-highlight-edge-hover:\s*0 5px 9px -5px rgb\(110 180 255 \/ 0\.6\);/,
+    );
+    // The shadow tokens carry only the under-glow — no inset edge lines and
+    // no perimeter ring — so the edge light comes solely from the diagonal
+    // gradient ring and cannot read as a full outline.
     expect(dashboardCss).not.toMatch(
-      /--mm-shadow-highlight-edge(?:-hover)?:[^;]*0 0 0 1px/s,
+      /--mm-shadow-highlight-edge(?:-hover)?:[^;]*(?:inset|0 0 0 1px)/s,
+    );
+    // The ring is drawn on a pseudo-element masked down to a 1px border band;
+    // the radio group uses ::after because ::before is its sliding thumb.
+    const ring = cssRuleBlock('.route-nav-primary a::before');
+    expect(ring).toContain('background: var(--mm-highlight-edge-ring);');
+    expect(ring).toContain('padding: 1px;');
+    expect(ring).toContain('mask-composite: exclude;');
+    expect(ring).toContain('pointer-events: none;');
+    expect(cssRuleBlock('.dashboard-system-trigger::before')).toContain(
+      'background: var(--mm-highlight-edge-ring);',
+    );
+    expect(cssRuleBlock('.workflow-list-display-control::after')).toContain(
+      'background: var(--mm-highlight-edge-ring);',
+    );
+    // The collapsed mobile nav renders flat menu rows without the ring.
+    expect(dashboardCss).toMatch(
+      /@media \(max-width: 1180px\)\s*\{[\s\S]*\.route-nav-primary a::before\s*\{[^}]*content:\s*none;/s,
     );
 
     // Radio group: highlight-edge chrome, tightened enough (option < 2rem,
@@ -158,7 +173,7 @@ describe('dashboard masthead brand styles', () => {
     expect(trigger).toMatch(highlightShadow);
 
     // Hover: all three buttons brighten, grow slightly, and swap the purple
-    // under-glow for the cyan accent. The trigger states these explicitly so
+    // under-glow for light blue. The trigger states these explicitly so
     // the filled-CTA global button:hover shadow cannot leak onto it.
     for (const hover of [
       cssRuleBlock('.route-nav-primary a:hover'),


### PR DESCRIPTION
## Summary

Two refinements to the masthead liquid-glass treatment, per feedback on the deployed look:

### Edge light hugs the corners instead of wrapping the button
The inset-based edge lights still read as a border wrapping the whole button — box-shadow insets are uniform along an edge and cannot fade. The edge light is now a **masked 1px gradient ring** on a pseudo-element (`::before` on the nav links and System trigger; `::after` on the radio group, whose `::before` is the sliding thumb), built from **two corner-anchored radial gradients**: white bleeding out of the top-left corner and violet out of the bottom-right, each fading to nothing before reaching the top-right / bottom-left corners — matching the provided liquid-glass reference. Radials rather than a 135° linear so the light stays corner-anchored at any button aspect ratio (on wide buttons a linear gradient tints the whole left and right edges). The collapsed mobile nav suppresses the ring along with the shadows it already drops.

### Hover glow: teal → light blue
The hover under-glow moves from `--mm-accent-2` (which reads greenish) to light blue `rgb(110 180 255 / 0.6)`, chosen from four hue candidates screenshotted on the live masthead at 3x.

The shadow tokens now carry only the faint bottom under-glow; grow/brighten hover behavior, the sliding thumb, and the active underline geometry are unchanged.

## Testing

- Linear-vs-radial ring comparison and four hover hues screenshotted against the live deployed masthead (dark theme, headless Chromium style injection) at 1x and 3x; the chosen combination shows corner-anchored light with dark top-right/bottom-left corners and a clearly light-blue hover glow.
- Computed-style checks against the real stylesheet confirm the ring pseudo-elements resolve on all three controls (mask-composite exclude, 1px band), the radio thumb still slides, and the trigger hover shadow resolves to the light-blue glow.
- `frontend/src/styles/dashboardBrand.test.ts` (7 passed; pins the radial ring token, glow-only shadow tokens, ring pseudo-element rules, and the mobile suppression) and `frontend/src/entrypoints/dashboard.test.tsx` (130 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)