### PR TITLE
Fetch GitHub issue MoonLadderStudios/MoonMind#3252 through the deterministic trusted GitHub tool surface. Build the canonical implementation input fro

### DIFF
--- a/api_service/db/models.py
+++ b/api_service/db/models.py
@@ -3018,13 +3018,19 @@ class SkillSetEntry(Base):
         return self.skill.slug
 
 
+def _default_container_job_auxiliary_outcome() -> dict[str, str]:
+    from moonmind.schemas.container_job_models import AuxiliaryOutcomeState
+
+    return {"state": AuxiliaryOutcomeState.NOT_ATTEMPTED.value}
+
+
 class ContainerJobRecord(Base):
     """API-owned durable container-job identity and compact observations."""
 
     __tablename__ = "container_jobs"
     __table_args__ = (
-        UniqueConstraint("owner_id", "idempotency_key", name="uq_container_jobs_owner_idempotency"),
-        Index("ix_container_jobs_owner_created", "owner_id", "created_at"),
+        UniqueConstraint("owner_type", "owner_id", "idempotency_key", name="uq_container_jobs_owner_idempotency"),
+        Index("ix_container_jobs_owner_created", "owner_type", "owner_id", "created_at"),
     )
 
     job_id: Mapped[str] = mapped_column(String(64), primary_key=True)
@@ -3039,8 +3045,8 @@ class ContainerJobRecord(Base):
     backend_ref: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
     image_observation_json: Mapped[Optional[dict[str, Any]]] = mapped_column(mutable_json_dict(), nullable=True)
     terminal_outcome_json: Mapped[Optional[dict[str, Any]]] = mapped_column(mutable_json_dict(), nullable=True)
-    publication_outcome_json: Mapped[dict[str, Any]] = mapped_column(mutable_json_dict(), nullable=False, default=dict)
-    cleanup_outcome_json: Mapped[dict[str, Any]] = mapped_column(mutable_json_dict(), nullable=False, default=dict)
+    publication_outcome_json: Mapped[dict[str, Any]] = mapped_column(mutable_json_dict(), nullable=False, default=_default_container_job_auxiliary_outcome)
+    cleanup_outcome_json: Mapped[dict[str, Any]] = mapped_column(mutable_json_dict(), nullable=False, default=_default_container_job_auxiliary_outcome)
     logs_ref: Mapped[Optional[str]] = mapped_column(String(1024), nullable=True)
     artifacts_ref: Mapped[Optional[str]] = mapped_column(String(1024), nullable=True)
     cancel_idempotency_key: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)

--- a/api_service/db/models.py
+++ b/api_service/db/models.py
@@ -3017,6 +3017,36 @@ class SkillSetEntry(Base):
         """Return the slug of the associated skill."""
         return self.skill.slug
 
+
+class ContainerJobRecord(Base):
+    """API-owned durable container-job identity and compact observations."""
+
+    __tablename__ = "container_jobs"
+    __table_args__ = (
+        UniqueConstraint("owner_id", "idempotency_key", name="uq_container_jobs_owner_idempotency"),
+        Index("ix_container_jobs_owner_created", "owner_id", "created_at"),
+    )
+
+    job_id: Mapped[str] = mapped_column(String(64), primary_key=True)
+    contract_version: Mapped[str] = mapped_column(String(16), nullable=False, default="v1")
+    owner_id: Mapped[str] = mapped_column(String(255), nullable=False)
+    owner_type: Mapped[str] = mapped_column(String(32), nullable=False)
+    idempotency_key: Mapped[str] = mapped_column(String(255), nullable=False)
+    source_json: Mapped[dict[str, Any]] = mapped_column(mutable_json_dict(), nullable=False)
+    request_json: Mapped[dict[str, Any]] = mapped_column(mutable_json_dict(), nullable=False)
+    state: Mapped[str] = mapped_column(String(32), nullable=False, default="queued")
+    backend_kind: Mapped[Optional[str]] = mapped_column(String(64), nullable=True)
+    backend_ref: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    image_observation_json: Mapped[Optional[dict[str, Any]]] = mapped_column(mutable_json_dict(), nullable=True)
+    terminal_outcome_json: Mapped[Optional[dict[str, Any]]] = mapped_column(mutable_json_dict(), nullable=True)
+    publication_outcome_json: Mapped[dict[str, Any]] = mapped_column(mutable_json_dict(), nullable=False, default=dict)
+    cleanup_outcome_json: Mapped[dict[str, Any]] = mapped_column(mutable_json_dict(), nullable=False, default=dict)
+    logs_ref: Mapped[Optional[str]] = mapped_column(String(1024), nullable=True)
+    artifacts_ref: Mapped[Optional[str]] = mapped_column(String(1024), nullable=True)
+    cancel_idempotency_key: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, server_default=func.now())
+    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, server_default=func.now(), onupdate=func.now())
+
 def _register_workflow_model_dependencies() -> None:
     """Import workflow ORM models so string relationships can resolve."""
 

--- a/api_service/migrations/versions/338_container_jobs_contract.py
+++ b/api_service/migrations/versions/338_container_jobs_contract.py
@@ -1,0 +1,41 @@
+"""Add API-owned durable container jobs for MoonLadderStudios/MoonMind#3252.
+
+Revision ID: 338_container_jobs_contract
+Revises: 337_mm1207_oauth_hosts
+"""
+from __future__ import annotations
+from typing import Sequence, Union
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "338_container_jobs_contract"
+down_revision: Union[str, None] = "337_mm1207_oauth_hosts"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+def upgrade() -> None:
+    op.create_table(
+        "container_jobs",
+        sa.Column("job_id", sa.String(64), primary_key=True),
+        sa.Column("contract_version", sa.String(16), nullable=False),
+        sa.Column("owner_id", sa.String(255), nullable=False),
+        sa.Column("owner_type", sa.String(32), nullable=False),
+        sa.Column("idempotency_key", sa.String(255), nullable=False),
+        sa.Column("source_json", sa.JSON(), nullable=False),
+        sa.Column("request_json", sa.JSON(), nullable=False),
+        sa.Column("state", sa.String(32), nullable=False),
+        sa.Column("backend_kind", sa.String(64)), sa.Column("backend_ref", sa.String(255)),
+        sa.Column("image_observation_json", sa.JSON()), sa.Column("terminal_outcome_json", sa.JSON()),
+        sa.Column("publication_outcome_json", sa.JSON(), nullable=False),
+        sa.Column("cleanup_outcome_json", sa.JSON(), nullable=False),
+        sa.Column("logs_ref", sa.String(1024)), sa.Column("artifacts_ref", sa.String(1024)),
+        sa.Column("cancel_idempotency_key", sa.String(255)),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.UniqueConstraint("owner_id", "idempotency_key", name="uq_container_jobs_owner_idempotency"),
+    )
+    op.create_index("ix_container_jobs_owner_created", "container_jobs", ["owner_id", "created_at"])
+
+def downgrade() -> None:
+    op.drop_index("ix_container_jobs_owner_created", table_name="container_jobs")
+    op.drop_table("container_jobs")

--- a/api_service/migrations/versions/338_container_jobs_contract.py
+++ b/api_service/migrations/versions/338_container_jobs_contract.py
@@ -32,9 +32,9 @@ def upgrade() -> None:
         sa.Column("cancel_idempotency_key", sa.String(255)),
         sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
         sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
-        sa.UniqueConstraint("owner_id", "idempotency_key", name="uq_container_jobs_owner_idempotency"),
+        sa.UniqueConstraint("owner_type", "owner_id", "idempotency_key", name="uq_container_jobs_owner_idempotency"),
     )
-    op.create_index("ix_container_jobs_owner_created", "container_jobs", ["owner_id", "created_at"])
+    op.create_index("ix_container_jobs_owner_created", "container_jobs", ["owner_type", "owner_id", "created_at"])
 
 def downgrade() -> None:
     op.drop_index("ix_container_jobs_owner_created", table_name="container_jobs")

--- a/api_service/services/container_jobs.py
+++ b/api_service/services/container_jobs.py
@@ -1,0 +1,138 @@
+"""Owner-scoped durable container-job operations for MoonMind#3252."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from uuid import uuid4
+
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from api_service.db.models import ContainerJobRecord
+from moonmind.schemas.container_job_models import (
+    AuxiliaryOutcome,
+    ContainerJobAccepted,
+    ContainerJobCancelRequest,
+    ContainerJobCancelResult,
+    ContainerJobState,
+    ContainerJobStatus,
+    ContainerJobSubmitRequest,
+    ImageObservation,
+    OwnerIdentity,
+    TerminalOutcome,
+)
+
+
+class ContainerJobNotFoundError(RuntimeError):
+    pass
+
+
+class ContainerJobIdempotencyConflictError(RuntimeError):
+    pass
+
+
+class ContainerJobRepository:
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def create_or_replay(self, *, owner: OwnerIdentity, request: ContainerJobSubmitRequest) -> tuple[ContainerJobRecord, bool]:
+        existing = await self._by_idempotency(owner.principal_id, request.idempotency_key)
+        request_json = request.model_dump(mode="json", by_alias=True, exclude_none=True)
+        if existing is not None:
+            if existing.request_json != request_json:
+                raise ContainerJobIdempotencyConflictError("idempotency key was already used with a different request")
+            return existing, True
+        record = ContainerJobRecord(
+            job_id=f"container-job:{uuid4().hex}",
+            owner_id=owner.principal_id,
+            owner_type=owner.principal_type,
+            idempotency_key=request.idempotency_key,
+            source_json=request.source.model_dump(mode="json", by_alias=True, exclude_none=True),
+            request_json=request_json,
+            state=ContainerJobState.QUEUED.value,
+            publication_outcome_json={"state": "not_attempted"},
+            cleanup_outcome_json={"state": "not_attempted"},
+        )
+        try:
+            async with self._session.begin_nested():
+                self._session.add(record)
+                await self._session.flush()
+            return record, False
+        except IntegrityError:
+            existing = await self._by_idempotency(owner.principal_id, request.idempotency_key)
+            if existing is None:
+                raise
+            if existing.request_json != request_json:
+                raise ContainerJobIdempotencyConflictError("idempotency key was already used with a different request")
+            return existing, True
+
+    async def _by_idempotency(self, owner_id: str, key: str) -> ContainerJobRecord | None:
+        result = await self._session.execute(select(ContainerJobRecord).where(ContainerJobRecord.owner_id == owner_id, ContainerJobRecord.idempotency_key == key))
+        return result.scalar_one_or_none()
+
+    async def get_for_owner(self, *, owner_id: str, job_id: str) -> ContainerJobRecord | None:
+        result = await self._session.execute(select(ContainerJobRecord).where(ContainerJobRecord.job_id == job_id, ContainerJobRecord.owner_id == owner_id))
+        return result.scalar_one_or_none()
+
+    async def record_observation(
+        self, *, owner_id: str, job_id: str, state: ContainerJobState,
+        backend_kind: str | None = None, backend_ref: str | None = None,
+        image: ImageObservation | None = None, terminal: TerminalOutcome | None = None,
+        publication: AuxiliaryOutcome | None = None, cleanup: AuxiliaryOutcome | None = None,
+        logs_ref: str | None = None, artifacts_ref: str | None = None,
+    ) -> ContainerJobRecord:
+        record = await self.get_for_owner(owner_id=owner_id, job_id=job_id)
+        if record is None:
+            raise ContainerJobNotFoundError(job_id)
+        record.state = state.value
+        record.backend_kind = backend_kind
+        record.backend_ref = backend_ref
+        if image is not None:
+            record.image_observation_json = image.model_dump(mode="json", by_alias=True, exclude_none=True)
+        if terminal is not None:
+            record.terminal_outcome_json = terminal.model_dump(mode="json", by_alias=True, exclude_none=True)
+        if publication is not None:
+            record.publication_outcome_json = publication.model_dump(mode="json", by_alias=True, exclude_none=True)
+        if cleanup is not None:
+            record.cleanup_outcome_json = cleanup.model_dump(mode="json", by_alias=True, exclude_none=True)
+        if logs_ref is not None:
+            record.logs_ref = logs_ref
+        if artifacts_ref is not None:
+            record.artifacts_ref = artifacts_ref
+        await self._session.flush()
+        return record
+
+
+class ContainerJobService:
+    def __init__(self, session: AsyncSession) -> None:
+        self.repository = ContainerJobRepository(session)
+
+    async def submit(self, *, owner: OwnerIdentity, request: ContainerJobSubmitRequest) -> ContainerJobAccepted:
+        record, replayed = await self.repository.create_or_replay(owner=owner, request=request)
+        created_at = record.created_at or datetime.now(timezone.utc)
+        return ContainerJobAccepted(jobId=record.job_id, replayed=replayed, createdAt=created_at)
+
+    async def status(self, *, owner_id: str, job_id: str) -> ContainerJobStatus:
+        record = await self.repository.get_for_owner(owner_id=owner_id, job_id=job_id)
+        if record is None:
+            raise ContainerJobNotFoundError(job_id)
+        return ContainerJobStatus(
+            jobId=record.job_id, state=record.state, backendKind=record.backend_kind,
+            backendRef=record.backend_ref, image=record.image_observation_json,
+            terminal=record.terminal_outcome_json, publication=record.publication_outcome_json,
+            cleanup=record.cleanup_outcome_json, logsRef=record.logs_ref,
+            artifactsRef=record.artifacts_ref, updatedAt=record.updated_at or record.created_at,
+        )
+
+    async def cancel(self, *, owner_id: str, job_id: str, request: ContainerJobCancelRequest) -> ContainerJobCancelResult:
+        record = await self.repository.get_for_owner(owner_id=owner_id, job_id=job_id)
+        if record is None:
+            raise ContainerJobNotFoundError(job_id)
+        replayed = record.cancel_idempotency_key == request.idempotency_key
+        terminal = record.state in {"succeeded", "failed", "canceled", "timed_out", "rejected"}
+        if not terminal and not replayed:
+            record.cancel_idempotency_key = request.idempotency_key
+            record.state = ContainerJobState.CANCELING.value
+            await self.repository._session.flush()
+        return ContainerJobCancelResult(jobId=job_id, state=record.state, accepted=not terminal, replayed=replayed)

--- a/api_service/services/container_jobs.py
+++ b/api_service/services/container_jobs.py
@@ -37,12 +37,13 @@ class ContainerJobRepository:
         self._session = session
 
     async def create_or_replay(self, *, owner: OwnerIdentity, request: ContainerJobSubmitRequest) -> tuple[ContainerJobRecord, bool]:
-        existing = await self._by_idempotency(owner.principal_id, request.idempotency_key)
+        existing = await self._by_idempotency(owner, request.idempotency_key)
         request_json = request.model_dump(mode="json", by_alias=True, exclude_none=True)
         if existing is not None:
             if existing.request_json != request_json:
                 raise ContainerJobIdempotencyConflictError("idempotency key was already used with a different request")
             return existing, True
+        now = datetime.now(timezone.utc)
         record = ContainerJobRecord(
             job_id=f"container-job:{uuid4().hex}",
             owner_id=owner.principal_id,
@@ -53,6 +54,8 @@ class ContainerJobRepository:
             state=ContainerJobState.QUEUED.value,
             publication_outcome_json={"state": "not_attempted"},
             cleanup_outcome_json={"state": "not_attempted"},
+            created_at=now,
+            updated_at=now,
         )
         try:
             async with self._session.begin_nested():
@@ -60,34 +63,36 @@ class ContainerJobRepository:
                 await self._session.flush()
             return record, False
         except IntegrityError:
-            existing = await self._by_idempotency(owner.principal_id, request.idempotency_key)
+            existing = await self._by_idempotency(owner, request.idempotency_key)
             if existing is None:
                 raise
             if existing.request_json != request_json:
                 raise ContainerJobIdempotencyConflictError("idempotency key was already used with a different request")
             return existing, True
 
-    async def _by_idempotency(self, owner_id: str, key: str) -> ContainerJobRecord | None:
-        result = await self._session.execute(select(ContainerJobRecord).where(ContainerJobRecord.owner_id == owner_id, ContainerJobRecord.idempotency_key == key))
+    async def _by_idempotency(self, owner: OwnerIdentity, key: str) -> ContainerJobRecord | None:
+        result = await self._session.execute(select(ContainerJobRecord).where(ContainerJobRecord.owner_id == owner.principal_id, ContainerJobRecord.owner_type == owner.principal_type, ContainerJobRecord.idempotency_key == key))
         return result.scalar_one_or_none()
 
-    async def get_for_owner(self, *, owner_id: str, job_id: str) -> ContainerJobRecord | None:
-        result = await self._session.execute(select(ContainerJobRecord).where(ContainerJobRecord.job_id == job_id, ContainerJobRecord.owner_id == owner_id))
+    async def get_for_owner(self, *, owner: OwnerIdentity, job_id: str) -> ContainerJobRecord | None:
+        result = await self._session.execute(select(ContainerJobRecord).where(ContainerJobRecord.job_id == job_id, ContainerJobRecord.owner_id == owner.principal_id, ContainerJobRecord.owner_type == owner.principal_type))
         return result.scalar_one_or_none()
 
     async def record_observation(
-        self, *, owner_id: str, job_id: str, state: ContainerJobState,
+        self, *, owner: OwnerIdentity, job_id: str, state: ContainerJobState,
         backend_kind: str | None = None, backend_ref: str | None = None,
         image: ImageObservation | None = None, terminal: TerminalOutcome | None = None,
         publication: AuxiliaryOutcome | None = None, cleanup: AuxiliaryOutcome | None = None,
         logs_ref: str | None = None, artifacts_ref: str | None = None,
     ) -> ContainerJobRecord:
-        record = await self.get_for_owner(owner_id=owner_id, job_id=job_id)
+        record = await self.get_for_owner(owner=owner, job_id=job_id)
         if record is None:
             raise ContainerJobNotFoundError(job_id)
         record.state = state.value
-        record.backend_kind = backend_kind
-        record.backend_ref = backend_ref
+        if backend_kind is not None:
+            record.backend_kind = backend_kind
+        if backend_ref is not None:
+            record.backend_ref = backend_ref
         if image is not None:
             record.image_observation_json = image.model_dump(mode="json", by_alias=True, exclude_none=True)
         if terminal is not None:
@@ -113,8 +118,8 @@ class ContainerJobService:
         created_at = record.created_at or datetime.now(timezone.utc)
         return ContainerJobAccepted(jobId=record.job_id, replayed=replayed, createdAt=created_at)
 
-    async def status(self, *, owner_id: str, job_id: str) -> ContainerJobStatus:
-        record = await self.repository.get_for_owner(owner_id=owner_id, job_id=job_id)
+    async def status(self, *, owner: OwnerIdentity, job_id: str) -> ContainerJobStatus:
+        record = await self.repository.get_for_owner(owner=owner, job_id=job_id)
         if record is None:
             raise ContainerJobNotFoundError(job_id)
         return ContainerJobStatus(
@@ -125,8 +130,8 @@ class ContainerJobService:
             artifactsRef=record.artifacts_ref, updatedAt=record.updated_at or record.created_at,
         )
 
-    async def cancel(self, *, owner_id: str, job_id: str, request: ContainerJobCancelRequest) -> ContainerJobCancelResult:
-        record = await self.repository.get_for_owner(owner_id=owner_id, job_id=job_id)
+    async def cancel(self, *, owner: OwnerIdentity, job_id: str, request: ContainerJobCancelRequest) -> ContainerJobCancelResult:
+        record = await self.repository.get_for_owner(owner=owner, job_id=job_id)
         if record is None:
             raise ContainerJobNotFoundError(job_id)
         replayed = record.cancel_idempotency_key == request.idempotency_key

--- a/moonmind/schemas/container_job_models.py
+++ b/moonmind/schemas/container_job_models.py
@@ -6,11 +6,9 @@ import json
 import re
 from datetime import datetime
 from enum import StrEnum
-from typing import Annotated, Any, Literal
+from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
-
-from moonmind.schemas.workspace_locator_models import WorkspaceLocator
 
 CONTAINER_JOB_CONTRACT_VERSION = "v1"
 MAX_TEMPORAL_PAYLOAD_BYTES = 64 * 1024
@@ -83,7 +81,7 @@ class AuxiliaryOutcomeState(StrEnum):
 
 class OwnerIdentity(ContractModel):
     principal_id: str = Field(alias="principalId", min_length=1, max_length=255)
-    principal_type: Literal["user", "service"] = Field(alias="principalType")
+    principal_type: Literal["user", "service", "system"] = Field(alias="principalType")
 
 
 class SourceCorrelation(ContractModel):
@@ -98,22 +96,18 @@ class SourceCorrelation(ContractModel):
     omnigent_conversation_id: str | None = Field(None, alias="omnigentConversationId", max_length=255)
 
 
-class ImageRequest(ContractModel):
-    reference: str = Field(min_length=1, max_length=512)
-    credential_ref: str | None = Field(None, alias="credentialRef", max_length=1024)
-
-    @field_validator("credential_ref")
-    @classmethod
-    def credential_is_reference(cls, value: str | None) -> str | None:
-        if value is not None and "://" not in value:
-            raise ValueError("credentialRef must be an opaque secret reference")
-        return value
+def _opaque_secret_reference(value: str | None) -> str | None:
+    if value is not None and "://" not in value:
+        raise ValueError("secret references must use an opaque reference URI")
+    return value
 
 
 class EnvironmentOverride(ContractModel):
     name: str = Field(pattern=r"^[A-Za-z_][A-Za-z0-9_]{0,127}$")
     value: str | None = Field(None, max_length=4096)
     secret_ref: str | None = Field(None, alias="secretRef", max_length=1024)
+
+    _validate_secret_ref = field_validator("secret_ref")(_opaque_secret_reference)
 
     @model_validator(mode="after")
     def exactly_one_value(self) -> "EnvironmentOverride":
@@ -150,18 +144,42 @@ class OutputDeclaration(ContractModel):
 
 
 class ContainerJobSpec(ContractModel):
-    image: ImageRequest
-    workspace: WorkspaceLocator
+    image: str = Field(min_length=1, max_length=512)
+    workspace_ref: dict[str, Any] = Field(alias="workspaceRef")
     command: list[str] = Field(default_factory=list, max_length=128)
     entrypoint: list[str] = Field(default_factory=list, max_length=32)
     workdir: str = Field("/workspace", pattern=r"^/workspace(?:/[^/]+)*$", max_length=512)
     environment: list[EnvironmentOverride] = Field(default_factory=list, max_length=128)
     caches: list[CacheMount] = Field(default_factory=list, max_length=32)
-    network_mode: Literal["none", "restricted", "standard"] = Field("restricted", alias="networkMode")
+    network_mode: Literal["none", "bridge"] = Field("none", alias="networkMode")
     resources: ResourceLimits
     timeout_seconds: int = Field(1800, alias="timeoutSeconds", ge=1, le=86400)
-    pull_policy: Literal["if_not_present", "always", "never"] = Field("if_not_present", alias="pullPolicy")
+    pull_policy: Literal["if-missing", "always", "never"] = Field("if-missing", alias="pullPolicy")
+    registry_credential_ref: str | None = Field(None, alias="registryCredentialRef", max_length=1024)
     outputs: list[OutputDeclaration] = Field(default_factory=list, max_length=64)
+
+    _validate_registry_credential_ref = field_validator("registry_credential_ref")(_opaque_secret_reference)
+
+    @field_validator("workspace_ref")
+    @classmethod
+    def valid_workspace_ref(cls, value: dict[str, Any]) -> dict[str, Any]:
+        kind = value.get("kind")
+        identity_fields = {
+            "omnigent-session": "sessionId",
+            "moonmind-session": "sessionId",
+            "artifact-workspace": "artifactRef",
+        }
+        identity = identity_fields.get(str(kind))
+        if identity is None or not isinstance(value.get(identity), str) or not value[identity].strip():
+            raise ValueError("workspaceRef must contain a supported kind and identity")
+        return value
+
+    @field_validator("workdir")
+    @classmethod
+    def normalized_workdir(cls, value: str) -> str:
+        if any(part in {".", ".."} for part in value.split("/")):
+            raise ValueError("workdir must remain within /workspace")
+        return value
 
     @field_validator("command", "entrypoint")
     @classmethod

--- a/moonmind/schemas/container_job_models.py
+++ b/moonmind/schemas/container_job_models.py
@@ -25,8 +25,29 @@ _FORBIDDEN_KEYS = {
 }
 
 
+def _validate_job_id(value: str) -> str:
+    if not _JOB_ID.fullmatch(value):
+        raise ValueError("jobId must be a container-job identifier")
+    return value
+
+
 class ContractModel(BaseModel):
     model_config = ConfigDict(populate_by_name=True, extra="forbid", use_enum_values=True)
+
+
+class TemporalContractModel(ContractModel):
+    """Compact public or worker contract permitted to cross workflow history."""
+
+    @model_validator(mode="before")
+    @classmethod
+    def reject_sensitive_or_authority_fields(cls, value: Any) -> Any:
+        _reject_forbidden(value)
+        return value
+
+    @model_validator(mode="after")
+    def temporal_size(self) -> "TemporalContractModel":
+        ensure_temporal_safe(self)
+        return self
 
 
 class ContainerJobState(StrEnum):
@@ -150,25 +171,14 @@ class ContainerJobSpec(ContractModel):
         return value
 
 
-class ContainerJobSubmitRequest(ContractModel):
+class ContainerJobSubmitRequest(TemporalContractModel):
     contract_version: Literal["v1"] = Field("v1", alias="contractVersion")
     idempotency_key: str = Field(alias="idempotencyKey", min_length=1, max_length=255)
     source: SourceCorrelation
     spec: ContainerJobSpec
 
-    @model_validator(mode="before")
-    @classmethod
-    def reject_sensitive_or_authority_fields(cls, value: Any) -> Any:
-        _reject_forbidden(value)
-        return value
 
-    @model_validator(mode="after")
-    def temporal_size(self) -> "ContainerJobSubmitRequest":
-        ensure_temporal_safe(self)
-        return self
-
-
-class ContainerJobAccepted(ContractModel):
+class ContainerJobAccepted(TemporalContractModel):
     contract_version: Literal["v1"] = Field("v1", alias="contractVersion")
     job_id: str = Field(alias="jobId")
     state: Literal["queued"] = "queued"
@@ -178,9 +188,7 @@ class ContainerJobAccepted(ContractModel):
     @field_validator("job_id")
     @classmethod
     def valid_id(cls, value: str) -> str:
-        if not _JOB_ID.fullmatch(value):
-            raise ValueError("jobId must be a container-job identifier")
-        return value
+        return _validate_job_id(value)
 
 
 class ImageObservation(ContractModel):
@@ -203,7 +211,7 @@ class AuxiliaryOutcome(ContractModel):
     diagnostics_ref: str | None = Field(None, alias="diagnosticsRef", max_length=1024)
 
 
-class ContainerJobStatus(ContractModel):
+class ContainerJobStatus(TemporalContractModel):
     contract_version: Literal["v1"] = Field("v1", alias="contractVersion")
     job_id: str = Field(alias="jobId")
     state: ContainerJobState
@@ -216,6 +224,8 @@ class ContainerJobStatus(ContractModel):
     logs_ref: str | None = Field(None, alias="logsRef", max_length=1024)
     artifacts_ref: str | None = Field(None, alias="artifactsRef", max_length=1024)
     updated_at: datetime = Field(alias="updatedAt")
+
+    _valid_job_id = field_validator("job_id")(_validate_job_id)
 
 
 class ContainerJobLogQuery(ContractModel):
@@ -235,6 +245,8 @@ class ContainerJobLogPage(ContractModel):
     entries: list[ContainerJobLogEntry] = Field(max_length=MAX_LOG_PAGE_ENTRIES)
     next_cursor: str | None = Field(None, alias="nextCursor", max_length=512)
 
+    _valid_job_id = field_validator("job_id")(_validate_job_id)
+
 
 class ContainerJobArtifact(ContractModel):
     name: str = Field(max_length=255)
@@ -249,20 +261,24 @@ class ContainerJobArtifactPage(ContractModel):
     next_cursor: str | None = Field(None, alias="nextCursor", max_length=512)
     publication: AuxiliaryOutcome
 
+    _valid_job_id = field_validator("job_id")(_validate_job_id)
 
-class ContainerJobCancelRequest(ContractModel):
+
+class ContainerJobCancelRequest(TemporalContractModel):
     idempotency_key: str = Field(alias="idempotencyKey", min_length=1, max_length=255)
     reason: str | None = Field(None, max_length=512)
 
 
-class ContainerJobCancelResult(ContractModel):
+class ContainerJobCancelResult(TemporalContractModel):
     job_id: str = Field(alias="jobId")
     state: ContainerJobState
     accepted: bool
     replayed: bool = False
 
+    _valid_job_id = field_validator("job_id")(_validate_job_id)
 
-class ResolvedContainerLaunchPlan(ContractModel):
+
+class ResolvedContainerLaunchPlan(TemporalContractModel):
     """Trusted-worker-only plan; backendRef is selected by deployment code."""
     contract_version: Literal["v1"] = Field("v1", alias="contractVersion")
     job_id: str = Field(alias="jobId")
@@ -270,6 +286,8 @@ class ResolvedContainerLaunchPlan(ContractModel):
     backend_ref: str = Field(alias="backendRef", max_length=255)
     resolved_workspace_ref: str = Field(alias="resolvedWorkspaceRef", max_length=1024)
     spec: ContainerJobSpec
+
+    _valid_job_id = field_validator("job_id")(_validate_job_id)
 
 
 def _reject_forbidden(value: Any, path: str = "request") -> None:

--- a/moonmind/schemas/container_job_models.py
+++ b/moonmind/schemas/container_job_models.py
@@ -1,0 +1,293 @@
+"""Canonical, backend-neutral container-job contracts (MoonMind#3252)."""
+
+from __future__ import annotations
+
+import json
+import re
+from datetime import datetime
+from enum import StrEnum
+from typing import Annotated, Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from moonmind.schemas.workspace_locator_models import WorkspaceLocator
+
+CONTAINER_JOB_CONTRACT_VERSION = "v1"
+MAX_TEMPORAL_PAYLOAD_BYTES = 64 * 1024
+MAX_LOG_PAGE_ENTRIES = 500
+MAX_ARTIFACT_PAGE_ENTRIES = 200
+_JOB_ID = re.compile(r"^container-job:[0-9a-f]{32}$")
+_SECRET_KEY = re.compile(r"(?:password|passwd|secret|token|api[_-]?key|auth|credential|docker_host|registry_auth)", re.I)
+_FORBIDDEN_KEYS = {
+    "dockerhost", "dockerurl", "socketpath", "tlspath", "hostpath", "sourcepath",
+    "privileged", "devices", "pidmode", "ipcmode", "utsmode", "usernsmode",
+    "label", "labels", "ownershiplabel", "registrycredentials",
+}
+
+
+class ContractModel(BaseModel):
+    model_config = ConfigDict(populate_by_name=True, extra="forbid", use_enum_values=True)
+
+
+class ContainerJobState(StrEnum):
+    QUEUED = "queued"
+    PREPARING = "preparing"
+    ACQUIRING_IMAGE = "acquiring_image"
+    RUNNING = "running"
+    CANCELING = "canceling"
+    SUCCEEDED = "succeeded"
+    FAILED = "failed"
+    CANCELED = "canceled"
+    TIMED_OUT = "timed_out"
+    REJECTED = "rejected"
+
+
+class ContainerJobFailureClass(StrEnum):
+    VALIDATION = "validation"
+    AUTHORIZATION = "authorization"
+    WORKSPACE = "workspace"
+    IMAGE = "image"
+    LAUNCH = "launch"
+    EXECUTION = "execution"
+    TIMEOUT = "timeout"
+    CANCELED = "canceled"
+    INFRASTRUCTURE = "infrastructure"
+
+
+class AuxiliaryOutcomeState(StrEnum):
+    NOT_ATTEMPTED = "not_attempted"
+    SUCCEEDED = "succeeded"
+    FAILED = "failed"
+
+
+class OwnerIdentity(ContractModel):
+    principal_id: str = Field(alias="principalId", min_length=1, max_length=255)
+    principal_type: Literal["user", "service"] = Field(alias="principalType")
+
+
+class SourceCorrelation(ContractModel):
+    source: Literal["http", "mcp", "workflow", "managed_session", "omnigent"]
+    caller_request_id: str | None = Field(None, alias="callerRequestId", max_length=255)
+    workflow_id: str | None = Field(None, alias="workflowId", max_length=255)
+    run_id: str | None = Field(None, alias="runId", max_length=255)
+    step_id: str | None = Field(None, alias="stepId", max_length=255)
+    managed_session_id: str | None = Field(None, alias="managedSessionId", max_length=255)
+    agent_run_id: str | None = Field(None, alias="agentRunId", max_length=255)
+    omnigent_session_id: str | None = Field(None, alias="omnigentSessionId", max_length=255)
+    omnigent_conversation_id: str | None = Field(None, alias="omnigentConversationId", max_length=255)
+
+
+class ImageRequest(ContractModel):
+    reference: str = Field(min_length=1, max_length=512)
+    credential_ref: str | None = Field(None, alias="credentialRef", max_length=1024)
+
+    @field_validator("credential_ref")
+    @classmethod
+    def credential_is_reference(cls, value: str | None) -> str | None:
+        if value is not None and "://" not in value:
+            raise ValueError("credentialRef must be an opaque secret reference")
+        return value
+
+
+class EnvironmentOverride(ContractModel):
+    name: str = Field(pattern=r"^[A-Za-z_][A-Za-z0-9_]{0,127}$")
+    value: str | None = Field(None, max_length=4096)
+    secret_ref: str | None = Field(None, alias="secretRef", max_length=1024)
+
+    @model_validator(mode="after")
+    def exactly_one_value(self) -> "EnvironmentOverride":
+        if (self.value is None) == (self.secret_ref is None):
+            raise ValueError("exactly one of value or secretRef is required")
+        if _SECRET_KEY.search(self.name) and self.value is not None:
+            raise ValueError("sensitive environment keys require secretRef")
+        return self
+
+
+class CacheMount(ContractModel):
+    cache_ref: str = Field(alias="cacheRef", min_length=1, max_length=255)
+    target: str = Field(pattern=r"^/[A-Za-z0-9._/@+-]+(?:/[A-Za-z0-9._@+-]+)*$", max_length=512)
+    read_only: bool = Field(False, alias="readOnly")
+
+
+class ResourceLimits(ContractModel):
+    cpu_millis: int = Field(alias="cpuMillis", ge=1, le=128000)
+    memory_mib: int = Field(alias="memoryMiB", ge=16, le=1048576)
+    pids: int = Field(256, ge=16, le=32768)
+
+
+class OutputDeclaration(ContractModel):
+    name: str = Field(min_length=1, max_length=128)
+    relative_path: str = Field(alias="relativePath", min_length=1, max_length=1000)
+
+    @field_validator("relative_path")
+    @classmethod
+    def relative_only(cls, value: str) -> str:
+        parts = value.replace("\\", "/").split("/")
+        if value.startswith("/") or any(part in {"", ".", ".."} for part in parts):
+            raise ValueError("relativePath must be normalized and relative")
+        return "/".join(parts)
+
+
+class ContainerJobSpec(ContractModel):
+    image: ImageRequest
+    workspace: WorkspaceLocator
+    command: list[str] = Field(default_factory=list, max_length=128)
+    entrypoint: list[str] = Field(default_factory=list, max_length=32)
+    workdir: str = Field("/workspace", pattern=r"^/workspace(?:/[^/]+)*$", max_length=512)
+    environment: list[EnvironmentOverride] = Field(default_factory=list, max_length=128)
+    caches: list[CacheMount] = Field(default_factory=list, max_length=32)
+    network_mode: Literal["none", "restricted", "standard"] = Field("restricted", alias="networkMode")
+    resources: ResourceLimits
+    timeout_seconds: int = Field(1800, alias="timeoutSeconds", ge=1, le=86400)
+    pull_policy: Literal["if_not_present", "always", "never"] = Field("if_not_present", alias="pullPolicy")
+    outputs: list[OutputDeclaration] = Field(default_factory=list, max_length=64)
+
+    @field_validator("command", "entrypoint")
+    @classmethod
+    def bounded_argv(cls, value: list[str]) -> list[str]:
+        if any(not item or len(item) > 4096 for item in value):
+            raise ValueError("argv entries must contain 1..4096 characters")
+        return value
+
+
+class ContainerJobSubmitRequest(ContractModel):
+    contract_version: Literal["v1"] = Field("v1", alias="contractVersion")
+    idempotency_key: str = Field(alias="idempotencyKey", min_length=1, max_length=255)
+    source: SourceCorrelation
+    spec: ContainerJobSpec
+
+    @model_validator(mode="before")
+    @classmethod
+    def reject_sensitive_or_authority_fields(cls, value: Any) -> Any:
+        _reject_forbidden(value)
+        return value
+
+    @model_validator(mode="after")
+    def temporal_size(self) -> "ContainerJobSubmitRequest":
+        ensure_temporal_safe(self)
+        return self
+
+
+class ContainerJobAccepted(ContractModel):
+    contract_version: Literal["v1"] = Field("v1", alias="contractVersion")
+    job_id: str = Field(alias="jobId")
+    state: Literal["queued"] = "queued"
+    replayed: bool = False
+    created_at: datetime = Field(alias="createdAt")
+
+    @field_validator("job_id")
+    @classmethod
+    def valid_id(cls, value: str) -> str:
+        if not _JOB_ID.fullmatch(value):
+            raise ValueError("jobId must be a container-job identifier")
+        return value
+
+
+class ImageObservation(ContractModel):
+    requested_reference: str = Field(alias="requestedReference", max_length=512)
+    resolved_digest: str | None = Field(None, alias="resolvedDigest", pattern=r"^sha256:[0-9a-f]{64}$")
+    cache_present: bool = Field(False, alias="cachePresent")
+    cache_hit: bool = Field(False, alias="cacheHit")
+    pull_lock_wait_ms: int = Field(0, alias="pullLockWaitMs", ge=0)
+    pull_duration_ms: int | None = Field(None, alias="pullDurationMs", ge=0)
+
+
+class TerminalOutcome(ContractModel):
+    exit_code: int | None = Field(None, alias="exitCode")
+    failure_class: ContainerJobFailureClass | None = Field(None, alias="failureClass")
+    message: str | None = Field(None, max_length=2048)
+
+
+class AuxiliaryOutcome(ContractModel):
+    state: AuxiliaryOutcomeState
+    diagnostics_ref: str | None = Field(None, alias="diagnosticsRef", max_length=1024)
+
+
+class ContainerJobStatus(ContractModel):
+    contract_version: Literal["v1"] = Field("v1", alias="contractVersion")
+    job_id: str = Field(alias="jobId")
+    state: ContainerJobState
+    backend_kind: str | None = Field(None, alias="backendKind", max_length=64)
+    backend_ref: str | None = Field(None, alias="backendRef", max_length=255)
+    image: ImageObservation | None = None
+    terminal: TerminalOutcome | None = None
+    publication: AuxiliaryOutcome = Field(default_factory=lambda: AuxiliaryOutcome(state="not_attempted"))
+    cleanup: AuxiliaryOutcome = Field(default_factory=lambda: AuxiliaryOutcome(state="not_attempted"))
+    logs_ref: str | None = Field(None, alias="logsRef", max_length=1024)
+    artifacts_ref: str | None = Field(None, alias="artifactsRef", max_length=1024)
+    updated_at: datetime = Field(alias="updatedAt")
+
+
+class ContainerJobLogQuery(ContractModel):
+    cursor: str | None = Field(None, max_length=512)
+    limit: int = Field(100, ge=1, le=MAX_LOG_PAGE_ENTRIES)
+
+
+class ContainerJobLogEntry(ContractModel):
+    sequence: int = Field(ge=0)
+    timestamp: datetime
+    stream: Literal["stdout", "stderr", "system"]
+    text: str = Field(max_length=8192)
+
+
+class ContainerJobLogPage(ContractModel):
+    job_id: str = Field(alias="jobId")
+    entries: list[ContainerJobLogEntry] = Field(max_length=MAX_LOG_PAGE_ENTRIES)
+    next_cursor: str | None = Field(None, alias="nextCursor", max_length=512)
+
+
+class ContainerJobArtifact(ContractModel):
+    name: str = Field(max_length=255)
+    artifact_ref: str = Field(alias="artifactRef", max_length=1024)
+    size_bytes: int = Field(alias="sizeBytes", ge=0)
+    sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+
+
+class ContainerJobArtifactPage(ContractModel):
+    job_id: str = Field(alias="jobId")
+    artifacts: list[ContainerJobArtifact] = Field(max_length=MAX_ARTIFACT_PAGE_ENTRIES)
+    next_cursor: str | None = Field(None, alias="nextCursor", max_length=512)
+    publication: AuxiliaryOutcome
+
+
+class ContainerJobCancelRequest(ContractModel):
+    idempotency_key: str = Field(alias="idempotencyKey", min_length=1, max_length=255)
+    reason: str | None = Field(None, max_length=512)
+
+
+class ContainerJobCancelResult(ContractModel):
+    job_id: str = Field(alias="jobId")
+    state: ContainerJobState
+    accepted: bool
+    replayed: bool = False
+
+
+class ResolvedContainerLaunchPlan(ContractModel):
+    """Trusted-worker-only plan; backendRef is selected by deployment code."""
+    contract_version: Literal["v1"] = Field("v1", alias="contractVersion")
+    job_id: str = Field(alias="jobId")
+    backend_kind: str = Field(alias="backendKind", max_length=64)
+    backend_ref: str = Field(alias="backendRef", max_length=255)
+    resolved_workspace_ref: str = Field(alias="resolvedWorkspaceRef", max_length=1024)
+    spec: ContainerJobSpec
+
+
+def _reject_forbidden(value: Any, path: str = "request") -> None:
+    if isinstance(value, dict):
+        for raw_key, nested in value.items():
+            key = re.sub(r"[^a-z0-9]", "", str(raw_key).lower())
+            if key in _FORBIDDEN_KEYS or _SECRET_KEY.fullmatch(key):
+                raise ValueError(f"{path}.{raw_key} is forbidden")
+            _reject_forbidden(nested, f"{path}.{raw_key}")
+    elif isinstance(value, list):
+        for index, nested in enumerate(value):
+            _reject_forbidden(nested, f"{path}[{index}]")
+
+
+def ensure_temporal_safe(model: BaseModel) -> bytes:
+    payload = model.model_dump(mode="json", by_alias=True, exclude_none=True)
+    _reject_forbidden(payload)
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), allow_nan=False).encode()
+    if len(encoded) > MAX_TEMPORAL_PAYLOAD_BYTES:
+        raise ValueError(f"payload must serialize to <= {MAX_TEMPORAL_PAYLOAD_BYTES} bytes")
+    return encoded

--- a/tests/unit/api_service/test_container_jobs_migration.py
+++ b/tests/unit/api_service/test_container_jobs_migration.py
@@ -24,7 +24,10 @@ def test_container_jobs_migration_upgrade_and_downgrade(monkeypatch) -> None:
         }
         unique = inspector.get_unique_constraints("container_jobs")
         assert [(item["name"], item["column_names"]) for item in unique] == [
-            ("uq_container_jobs_owner_idempotency", ["owner_id", "idempotency_key"])
+            (
+                "uq_container_jobs_owner_idempotency",
+                ["owner_type", "owner_id", "idempotency_key"],
+            )
         ]
         migration.downgrade()
         assert "container_jobs" not in sa.inspect(connection).get_table_names()

--- a/tests/unit/api_service/test_container_jobs_migration.py
+++ b/tests/unit/api_service/test_container_jobs_migration.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import importlib
+
+import sqlalchemy as sa
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+
+
+def test_container_jobs_migration_upgrade_and_downgrade(monkeypatch) -> None:
+    migration = importlib.import_module(
+        "api_service.migrations.versions.338_container_jobs_contract"
+    )
+    assert migration.down_revision == "337_mm1207_oauth_hosts"
+    engine = sa.create_engine("sqlite:///:memory:")
+    with engine.begin() as connection:
+        monkeypatch.setattr(migration, "op", Operations(MigrationContext.configure(connection)))
+        migration.upgrade()
+        inspector = sa.inspect(connection)
+        columns = {column["name"] for column in inspector.get_columns("container_jobs")}
+        assert {"job_id", "owner_id", "idempotency_key", "request_json", "state"} <= columns
+        assert {index["name"] for index in inspector.get_indexes("container_jobs")} == {
+            "ix_container_jobs_owner_created"
+        }
+        unique = inspector.get_unique_constraints("container_jobs")
+        assert [(item["name"], item["column_names"]) for item in unique] == [
+            ("uq_container_jobs_owner_idempotency", ["owner_id", "idempotency_key"])
+        ]
+        migration.downgrade()
+        assert "container_jobs" not in sa.inspect(connection).get_table_names()

--- a/tests/unit/schemas/test_container_job_models.py
+++ b/tests/unit/schemas/test_container_job_models.py
@@ -1,9 +1,9 @@
 from datetime import datetime, timezone
+import json
 
 import pytest
 from pydantic import ValidationError
 
-import moonmind.schemas.container_job_models as contracts
 from moonmind.schemas.container_job_models import (
     AuxiliaryOutcome,
     ContainerJobAccepted,
@@ -15,6 +15,8 @@ from moonmind.schemas.container_job_models import (
     ContainerJobStatus,
     ContainerJobSubmitRequest,
     ImageObservation,
+    MAX_ARTIFACT_PAGE_ENTRIES,
+    MAX_LOG_PAGE_ENTRIES,
     ResolvedContainerLaunchPlan,
     TerminalOutcome,
     ensure_temporal_safe,
@@ -29,8 +31,8 @@ def payload() -> dict:
         "idempotencyKey": "request-1",
         "source": {"source": "omnigent", "omnigentSessionId": "s"},
         "spec": {
-            "image": {"reference": "ubuntu:24.04"},
-            "workspace": {"kind": "sandbox", "workspaceId": "ws"},
+            "image": "ubuntu:24.04",
+            "workspaceRef": {"kind": "omnigent-session", "sessionId": "ws"},
             "resources": {"cpuMillis": 1000, "memoryMiB": 512},
         },
     }
@@ -41,15 +43,15 @@ def test_submit_has_deterministic_shared_golden_serialization() -> None:
     expected = (
         b'{"contractVersion":"v1","idempotencyKey":"request-1","source":'
         b'{"omnigentSessionId":"s","source":"omnigent"},"spec":{"caches":[],'
-        b'"command":[],"entrypoint":[],"environment":[],"image":{"reference":'
-        b'"ubuntu:24.04"},"networkMode":"restricted","outputs":[],"pullPolicy":'
-        b'"if_not_present","resources":{"cpuMillis":1000,"memoryMiB":512,"pids":256},'
-        b'"timeoutSeconds":1800,"workdir":"/workspace","workspace":{"kind":"sandbox",'
-        b'"relativePath":"repo","workspaceId":"ws"}}}'
+        b'"command":[],"entrypoint":[],"environment":[],"image":"ubuntu:24.04",'
+        b'"networkMode":"none","outputs":[],"pullPolicy":"if-missing","resources":'
+        b'{"cpuMillis":1000,"memoryMiB":512,"pids":256},"timeoutSeconds":1800,'
+        b'"workdir":"/workspace","workspaceRef":{"kind":"omnigent-session",'
+        b'"sessionId":"ws"}}}'
     )
     assert ensure_temporal_safe(model) == expected
     # HTTP, MCP, and Temporal consume this one alias-preserving model dump.
-    assert model.model_dump(mode="json", by_alias=True, exclude_none=True) == contracts.json.loads(expected)
+    assert model.model_dump(mode="json", by_alias=True, exclude_none=True) == json.loads(expected)
 
 
 @pytest.mark.parametrize(
@@ -59,7 +61,7 @@ def test_one_contract_family_serializes_every_caller_source(source: str) -> None
     data = payload()
     data["source"] = {"source": source, "callerRequestId": "request"}
     encoded = ensure_temporal_safe(ContainerJobSubmitRequest.model_validate(data))
-    assert contracts.json.loads(encoded)["source"] == {
+    assert json.loads(encoded)["source"] == {
         "callerRequestId": "request", "source": source
     }
 
@@ -116,9 +118,27 @@ def test_secret_values_outputs_and_credential_references_are_validated() -> None
     with pytest.raises(ValidationError):
         ContainerJobSubmitRequest.model_validate(data)
     data = payload()
-    data["spec"]["image"]["credentialRef"] = "raw-password"
+    data["spec"]["registryCredentialRef"] = "raw-password"
     with pytest.raises(ValidationError):
         ContainerJobSubmitRequest.model_validate(data)
+    data = payload()
+    data["spec"]["environment"] = [{"name": "API_TOKEN", "secretRef": "raw-value"}]
+    with pytest.raises(ValidationError):
+        ContainerJobSubmitRequest.model_validate(data)
+
+
+@pytest.mark.parametrize("workdir", ["/workspace/..", "/workspace/./repo"])
+def test_workdir_rejects_traversal(workdir: str) -> None:
+    data = payload()
+    data["spec"]["workdir"] = workdir
+    with pytest.raises(ValidationError):
+        ContainerJobSubmitRequest.model_validate(data)
+
+
+def test_documented_container_job_wire_values_are_accepted() -> None:
+    data = payload()
+    data["spec"].update({"networkMode": "bridge", "pullPolicy": "if-missing"})
+    assert ContainerJobSubmitRequest.model_validate(data).spec.image == "ubuntu:24.04"
 
 
 def test_image_observation_and_async_identity_serialization() -> None:
@@ -135,23 +155,23 @@ def test_image_observation_and_async_identity_serialization() -> None:
 
 def test_log_and_artifact_pages_enforce_bounds() -> None:
     entry = {"sequence": 1, "timestamp": NOW, "stream": "stdout", "text": "x"}
-    ContainerJobLogPage(jobId=JOB_ID, entries=[entry] * contracts.MAX_LOG_PAGE_ENTRIES)
+    ContainerJobLogPage(jobId=JOB_ID, entries=[entry] * MAX_LOG_PAGE_ENTRIES)
     with pytest.raises(ValidationError):
-        ContainerJobLogPage(jobId=JOB_ID, entries=[entry] * (contracts.MAX_LOG_PAGE_ENTRIES + 1))
+        ContainerJobLogPage(jobId=JOB_ID, entries=[entry] * (MAX_LOG_PAGE_ENTRIES + 1))
     artifact = {"name": "x", "artifactRef": "artifact://x", "sizeBytes": 1, "sha256": "c" * 64}
     ContainerJobArtifactPage(
-        jobId=JOB_ID, artifacts=[artifact] * contracts.MAX_ARTIFACT_PAGE_ENTRIES,
+        jobId=JOB_ID, artifacts=[artifact] * MAX_ARTIFACT_PAGE_ENTRIES,
         publication={"state": "succeeded"},
     )
     with pytest.raises(ValidationError):
         ContainerJobArtifactPage(
-            jobId=JOB_ID, artifacts=[artifact] * (contracts.MAX_ARTIFACT_PAGE_ENTRIES + 1),
+            jobId=JOB_ID, artifacts=[artifact] * (MAX_ARTIFACT_PAGE_ENTRIES + 1),
             publication={"state": "succeeded"},
         )
 
 
 def test_every_history_facing_contract_enforces_temporal_limit(monkeypatch) -> None:
-    monkeypatch.setattr(contracts, "MAX_TEMPORAL_PAYLOAD_BYTES", 100)
+    monkeypatch.setattr("moonmind.schemas.container_job_models.MAX_TEMPORAL_PAYLOAD_BYTES", 100)
     with pytest.raises(ValidationError, match="payload must serialize"):
         ContainerJobStatus(jobId=JOB_ID, state="running", backendRef="b" * 80, updatedAt=NOW)
     with pytest.raises(ValidationError, match="payload must serialize"):

--- a/tests/unit/schemas/test_container_job_models.py
+++ b/tests/unit/schemas/test_container_job_models.py
@@ -1,28 +1,164 @@
 from datetime import datetime, timezone
+
 import pytest
 from pydantic import ValidationError
-from moonmind.schemas.container_job_models import ContainerJobAccepted, ContainerJobSubmitRequest, ensure_temporal_safe
 
-def payload():
-    return {"idempotencyKey":"request-1","source":{"source":"omnigent","omnigentSessionId":"s"},"spec":{"image":{"reference":"ubuntu:24.04"},"workspace":{"kind":"sandbox","workspaceId":"ws"},"resources":{"cpuMillis":1000,"memoryMiB":512}}}
+import moonmind.schemas.container_job_models as contracts
+from moonmind.schemas.container_job_models import (
+    AuxiliaryOutcome,
+    ContainerJobAccepted,
+    ContainerJobArtifactPage,
+    ContainerJobCancelResult,
+    ContainerJobFailureClass,
+    ContainerJobLogPage,
+    ContainerJobState,
+    ContainerJobStatus,
+    ContainerJobSubmitRequest,
+    ImageObservation,
+    ResolvedContainerLaunchPlan,
+    TerminalOutcome,
+    ensure_temporal_safe,
+)
 
-def test_submit_is_versioned_compact_and_reuses_workspace_locator():
+JOB_ID = "container-job:" + "a" * 32
+NOW = datetime(2026, 1, 2, tzinfo=timezone.utc)
+
+
+def payload() -> dict:
+    return {
+        "idempotencyKey": "request-1",
+        "source": {"source": "omnigent", "omnigentSessionId": "s"},
+        "spec": {
+            "image": {"reference": "ubuntu:24.04"},
+            "workspace": {"kind": "sandbox", "workspaceId": "ws"},
+            "resources": {"cpuMillis": 1000, "memoryMiB": 512},
+        },
+    }
+
+
+def test_submit_has_deterministic_shared_golden_serialization() -> None:
     model = ContainerJobSubmitRequest.model_validate(payload())
-    data = model.model_dump(mode="json", by_alias=True)
-    assert data["contractVersion"] == "v1" and data["spec"]["workspace"]["kind"] == "sandbox"
-    assert ensure_temporal_safe(model) == ensure_temporal_safe(model)
+    expected = (
+        b'{"contractVersion":"v1","idempotencyKey":"request-1","source":'
+        b'{"omnigentSessionId":"s","source":"omnigent"},"spec":{"caches":[],'
+        b'"command":[],"entrypoint":[],"environment":[],"image":{"reference":'
+        b'"ubuntu:24.04"},"networkMode":"restricted","outputs":[],"pullPolicy":'
+        b'"if_not_present","resources":{"cpuMillis":1000,"memoryMiB":512,"pids":256},'
+        b'"timeoutSeconds":1800,"workdir":"/workspace","workspace":{"kind":"sandbox",'
+        b'"relativePath":"repo","workspaceId":"ws"}}}'
+    )
+    assert ensure_temporal_safe(model) == expected
+    # HTTP, MCP, and Temporal consume this one alias-preserving model dump.
+    assert model.model_dump(mode="json", by_alias=True, exclude_none=True) == contracts.json.loads(expected)
 
-@pytest.mark.parametrize("field,value", [("dockerHost","tcp://daemon"),("socketPath","/var/run/docker.sock"),("hostPath","/tmp"),("privileged",True),("devices",["/dev/kvm"]),("labels",{"moonmind.owner":"x"}),("registryCredentials",{"password":"x"})])
-def test_submit_rejects_caller_docker_authority(field, value):
-    data = payload(); data["spec"][field] = value
-    with pytest.raises(ValidationError): ContainerJobSubmitRequest.model_validate(data)
 
-def test_sensitive_environment_and_absolute_outputs_are_rejected():
-    data = payload(); data["spec"]["environment"] = [{"name":"API_TOKEN","value":"raw"}]
-    with pytest.raises(ValidationError): ContainerJobSubmitRequest.model_validate(data)
-    data = payload(); data["spec"]["outputs"] = [{"name":"x","relativePath":"/host/x"}]
-    with pytest.raises(ValidationError): ContainerJobSubmitRequest.model_validate(data)
+@pytest.mark.parametrize(
+    "source", ["http", "mcp", "workflow", "managed_session", "omnigent"]
+)
+def test_one_contract_family_serializes_every_caller_source(source: str) -> None:
+    data = payload()
+    data["source"] = {"source": source, "callerRequestId": "request"}
+    encoded = ensure_temporal_safe(ContainerJobSubmitRequest.model_validate(data))
+    assert contracts.json.loads(encoded)["source"] == {
+        "callerRequestId": "request", "source": source
+    }
 
-def test_accepted_response_has_async_queued_identity():
-    result = ContainerJobAccepted(jobId="container-job:" + "a" * 32, createdAt=datetime.now(timezone.utc))
-    assert result.state == "queued"
+
+@pytest.mark.parametrize("state", list(ContainerJobState))
+def test_status_accepts_every_canonical_state(state: ContainerJobState) -> None:
+    assert ContainerJobStatus(jobId=JOB_ID, state=state, updatedAt=NOW).state == state.value
+
+
+@pytest.mark.parametrize("failure", list(ContainerJobFailureClass))
+def test_terminal_accepts_every_failure_class(failure: ContainerJobFailureClass) -> None:
+    assert TerminalOutcome(failureClass=failure).failure_class == failure.value
+
+
+@pytest.mark.parametrize("state", ["not_attempted", "succeeded", "failed"])
+def test_auxiliary_outcomes_are_independent(state: str) -> None:
+    assert AuxiliaryOutcome(state=state).state == state
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("dockerHost", "tcp://daemon"), ("dockerUrl", "https://daemon"),
+        ("socketPath", "/var/run/docker.sock"), ("tlsPath", "/certs"),
+        ("hostPath", "/tmp"), ("sourcePath", "/host"), ("privileged", True),
+        ("devices", ["/dev/kvm"]), ("pidMode", "host"), ("ipcMode", "host"),
+        ("utsMode", "host"), ("usernsMode", "host"),
+        ("labels", {"moonmind.owner": "x"}),
+        ("registryCredentials", {"password": "x"}),
+    ],
+)
+def test_submit_rejects_every_caller_authority_field(field: str, value: object) -> None:
+    data = payload()
+    data["spec"][field] = value
+    with pytest.raises(ValidationError):
+        ContainerJobSubmitRequest.model_validate(data)
+
+
+@pytest.mark.parametrize("secret_key", ["password", "apiKey", "authToken", "credential"])
+def test_history_contracts_reject_secret_like_keys(secret_key: str) -> None:
+    data = payload()
+    data["source"][secret_key] = "raw"
+    with pytest.raises(ValidationError):
+        ContainerJobSubmitRequest.model_validate(data)
+
+
+def test_secret_values_outputs_and_credential_references_are_validated() -> None:
+    data = payload()
+    data["spec"]["environment"] = [{"name": "API_TOKEN", "value": "raw"}]
+    with pytest.raises(ValidationError):
+        ContainerJobSubmitRequest.model_validate(data)
+    data = payload()
+    data["spec"]["outputs"] = [{"name": "x", "relativePath": "/host/x"}]
+    with pytest.raises(ValidationError):
+        ContainerJobSubmitRequest.model_validate(data)
+    data = payload()
+    data["spec"]["image"]["credentialRef"] = "raw-password"
+    with pytest.raises(ValidationError):
+        ContainerJobSubmitRequest.model_validate(data)
+
+
+def test_image_observation_and_async_identity_serialization() -> None:
+    image = ImageObservation(
+        requestedReference="ubuntu:24.04", resolvedDigest="sha256:" + "b" * 64,
+        cachePresent=True, cacheHit=True, pullLockWaitMs=5, pullDurationMs=10,
+    )
+    accepted = ContainerJobAccepted(jobId=JOB_ID, createdAt=NOW)
+    assert accepted.state == "queued"
+    assert image.model_dump(mode="json", by_alias=True)["resolvedDigest"].startswith("sha256:")
+    with pytest.raises(ValidationError):
+        ContainerJobAccepted(jobId="job-1", createdAt=NOW)
+
+
+def test_log_and_artifact_pages_enforce_bounds() -> None:
+    entry = {"sequence": 1, "timestamp": NOW, "stream": "stdout", "text": "x"}
+    ContainerJobLogPage(jobId=JOB_ID, entries=[entry] * contracts.MAX_LOG_PAGE_ENTRIES)
+    with pytest.raises(ValidationError):
+        ContainerJobLogPage(jobId=JOB_ID, entries=[entry] * (contracts.MAX_LOG_PAGE_ENTRIES + 1))
+    artifact = {"name": "x", "artifactRef": "artifact://x", "sizeBytes": 1, "sha256": "c" * 64}
+    ContainerJobArtifactPage(
+        jobId=JOB_ID, artifacts=[artifact] * contracts.MAX_ARTIFACT_PAGE_ENTRIES,
+        publication={"state": "succeeded"},
+    )
+    with pytest.raises(ValidationError):
+        ContainerJobArtifactPage(
+            jobId=JOB_ID, artifacts=[artifact] * (contracts.MAX_ARTIFACT_PAGE_ENTRIES + 1),
+            publication={"state": "succeeded"},
+        )
+
+
+def test_every_history_facing_contract_enforces_temporal_limit(monkeypatch) -> None:
+    monkeypatch.setattr(contracts, "MAX_TEMPORAL_PAYLOAD_BYTES", 100)
+    with pytest.raises(ValidationError, match="payload must serialize"):
+        ContainerJobStatus(jobId=JOB_ID, state="running", backendRef="b" * 80, updatedAt=NOW)
+    with pytest.raises(ValidationError, match="payload must serialize"):
+        ResolvedContainerLaunchPlan(
+            jobId=JOB_ID, backendKind="docker", backendRef="local",
+            resolvedWorkspaceRef="workspace://" + "x" * 80,
+            spec=payload()["spec"],
+        )
+    with pytest.raises(ValidationError, match="payload must serialize"):
+        ContainerJobCancelResult(jobId=JOB_ID, state="canceling", accepted=True)

--- a/tests/unit/schemas/test_container_job_models.py
+++ b/tests/unit/schemas/test_container_job_models.py
@@ -1,0 +1,28 @@
+from datetime import datetime, timezone
+import pytest
+from pydantic import ValidationError
+from moonmind.schemas.container_job_models import ContainerJobAccepted, ContainerJobSubmitRequest, ensure_temporal_safe
+
+def payload():
+    return {"idempotencyKey":"request-1","source":{"source":"omnigent","omnigentSessionId":"s"},"spec":{"image":{"reference":"ubuntu:24.04"},"workspace":{"kind":"sandbox","workspaceId":"ws"},"resources":{"cpuMillis":1000,"memoryMiB":512}}}
+
+def test_submit_is_versioned_compact_and_reuses_workspace_locator():
+    model = ContainerJobSubmitRequest.model_validate(payload())
+    data = model.model_dump(mode="json", by_alias=True)
+    assert data["contractVersion"] == "v1" and data["spec"]["workspace"]["kind"] == "sandbox"
+    assert ensure_temporal_safe(model) == ensure_temporal_safe(model)
+
+@pytest.mark.parametrize("field,value", [("dockerHost","tcp://daemon"),("socketPath","/var/run/docker.sock"),("hostPath","/tmp"),("privileged",True),("devices",["/dev/kvm"]),("labels",{"moonmind.owner":"x"}),("registryCredentials",{"password":"x"})])
+def test_submit_rejects_caller_docker_authority(field, value):
+    data = payload(); data["spec"][field] = value
+    with pytest.raises(ValidationError): ContainerJobSubmitRequest.model_validate(data)
+
+def test_sensitive_environment_and_absolute_outputs_are_rejected():
+    data = payload(); data["spec"]["environment"] = [{"name":"API_TOKEN","value":"raw"}]
+    with pytest.raises(ValidationError): ContainerJobSubmitRequest.model_validate(data)
+    data = payload(); data["spec"]["outputs"] = [{"name":"x","relativePath":"/host/x"}]
+    with pytest.raises(ValidationError): ContainerJobSubmitRequest.model_validate(data)
+
+def test_accepted_response_has_async_queued_identity():
+    result = ContainerJobAccepted(jobId="container-job:" + "a" * 32, createdAt=datetime.now(timezone.utc))
+    assert result.state == "queued"

--- a/tests/unit/services/test_container_jobs.py
+++ b/tests/unit/services/test_container_jobs.py
@@ -1,31 +1,118 @@
-import pytest
-from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
-from api_service.db.models import Base
-from api_service.services.container_jobs import ContainerJobNotFoundError, ContainerJobService
-from moonmind.schemas.container_job_models import ContainerJobCancelRequest, ContainerJobSubmitRequest, OwnerIdentity
+import asyncio
 
-@pytest.fixture
-async def session(tmp_path):
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from api_service.db.models import Base
+from api_service.services.container_jobs import (
+    ContainerJobIdempotencyConflictError,
+    ContainerJobNotFoundError,
+    ContainerJobService,
+)
+from moonmind.schemas.container_job_models import (
+    AuxiliaryOutcome,
+    ContainerJobCancelRequest,
+    ContainerJobState,
+    ContainerJobSubmitRequest,
+    ImageObservation,
+    OwnerIdentity,
+    TerminalOutcome,
+)
+
+
+@pytest_asyncio.fixture
+async def session_factory(tmp_path):
     engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path}/jobs.db")
-    async with engine.begin() as connection: await connection.run_sync(Base.metadata.create_all)
-    async with async_sessionmaker(engine, expire_on_commit=False)() as value: yield value
+    async with engine.begin() as connection:
+        await connection.run_sync(Base.metadata.create_all)
+    yield async_sessionmaker(engine, expire_on_commit=False)
     await engine.dispose()
 
-def submission():
-    return ContainerJobSubmitRequest(idempotencyKey="key",source={"source":"mcp","callerRequestId":"r"},spec={"image":{"reference":"alpine"},"workspace":{"kind":"managed_runtime","runtimeId":"codex","agentRunId":"run"},"resources":{"cpuMillis":100,"memoryMiB":64}})
+
+def submission(*, key: str = "key", image: str = "alpine") -> ContainerJobSubmitRequest:
+    return ContainerJobSubmitRequest(
+        idempotencyKey=key,
+        source={"source": "mcp", "callerRequestId": "r"},
+        spec={
+            "image": {"reference": image},
+            "workspace": {"kind": "managed_runtime", "runtimeId": "codex", "agentRunId": "run"},
+            "resources": {"cpuMillis": 100, "memoryMiB": 64},
+        },
+    )
+
 
 @pytest.mark.asyncio
-async def test_create_or_replay_and_owner_scoped_reads(session):
-    service=ContainerJobService(session); owner=OwnerIdentity(principalId="user-1",principalType="user")
-    first=await service.submit(owner=owner,request=submission()); second=await service.submit(owner=owner,request=submission())
-    assert first.job_id == second.job_id and second.replayed
-    assert (await service.status(owner_id="user-1",job_id=first.job_id)).state == "queued"
-    with pytest.raises(ContainerJobNotFoundError): await service.status(owner_id="user-2",job_id=first.job_id)
+async def test_create_or_replay_conflict_and_owner_scoped_reads(session_factory) -> None:
+    async with session_factory() as session:
+        service = ContainerJobService(session)
+        owner = OwnerIdentity(principalId="user-1", principalType="user")
+        first = await service.submit(owner=owner, request=submission())
+        second = await service.submit(owner=owner, request=submission())
+        assert first.job_id == second.job_id and second.replayed
+        with pytest.raises(ContainerJobIdempotencyConflictError):
+            await service.submit(owner=owner, request=submission(image="busybox"))
+        assert (await service.status(owner_id="user-1", job_id=first.job_id)).state == "queued"
+        with pytest.raises(ContainerJobNotFoundError):
+            await service.status(owner_id="user-2", job_id=first.job_id)
+
 
 @pytest.mark.asyncio
-async def test_owner_scoped_idempotent_cancel(session):
-    service=ContainerJobService(session); accepted=await service.submit(owner=OwnerIdentity(principalId="u",principalType="user"),request=submission())
-    request=ContainerJobCancelRequest(idempotencyKey="cancel-1")
-    first=await service.cancel(owner_id="u",job_id=accepted.job_id,request=request); second=await service.cancel(owner_id="u",job_id=accepted.job_id,request=request)
-    assert first.accepted and second.replayed and second.state == "canceling"
-    with pytest.raises(ContainerJobNotFoundError): await service.cancel(owner_id="other",job_id=accepted.job_id,request=request)
+async def test_concurrent_duplicate_submission_has_one_durable_identity(session_factory) -> None:
+    owner = OwnerIdentity(principalId="concurrent-owner", principalType="service")
+
+    async def submit_once():
+        async with session_factory() as session:
+            result = await ContainerJobService(session).submit(owner=owner, request=submission())
+            await session.commit()
+            return result
+
+    first, second = await asyncio.gather(submit_once(), submit_once())
+    assert first.job_id == second.job_id
+    assert sorted([first.replayed, second.replayed]) == [False, True]
+
+
+@pytest.mark.asyncio
+async def test_terminal_observations_and_auxiliary_failures_project_independently(session_factory) -> None:
+    async with session_factory() as session:
+        service = ContainerJobService(session)
+        accepted = await service.submit(
+            owner=OwnerIdentity(principalId="u", principalType="user"), request=submission()
+        )
+        await service.repository.record_observation(
+            owner_id="u", job_id=accepted.job_id, state=ContainerJobState.FAILED,
+            backend_kind="docker", backend_ref="configured-backend",
+            image=ImageObservation(requestedReference="alpine", cachePresent=True),
+            terminal=TerminalOutcome(exitCode=2, failureClass="execution", message="failed"),
+            publication=AuxiliaryOutcome(state="failed", diagnosticsRef="artifact://publication"),
+            cleanup=AuxiliaryOutcome(state="succeeded"),
+            logs_ref="artifact://logs", artifacts_ref="artifact://outputs",
+        )
+        status = await service.status(owner_id="u", job_id=accepted.job_id)
+        assert status.terminal.exit_code == 2
+        assert status.publication.state == "failed"
+        assert status.cleanup.state == "succeeded"
+        assert status.logs_ref == "artifact://logs"
+
+
+@pytest.mark.asyncio
+async def test_owner_scoped_idempotent_and_terminal_cancel(session_factory) -> None:
+    async with session_factory() as session:
+        service = ContainerJobService(session)
+        accepted = await service.submit(
+            owner=OwnerIdentity(principalId="u", principalType="user"), request=submission()
+        )
+        request = ContainerJobCancelRequest(idempotencyKey="cancel-1")
+        first = await service.cancel(owner_id="u", job_id=accepted.job_id, request=request)
+        second = await service.cancel(owner_id="u", job_id=accepted.job_id, request=request)
+        assert first.accepted and second.replayed and second.state == "canceling"
+        await service.repository.record_observation(
+            owner_id="u", job_id=accepted.job_id, state=ContainerJobState.SUCCEEDED
+        )
+        terminal = await service.cancel(
+            owner_id="u", job_id=accepted.job_id,
+            request=ContainerJobCancelRequest(idempotencyKey="cancel-2"),
+        )
+        assert not terminal.accepted and terminal.state == "succeeded"
+        with pytest.raises(ContainerJobNotFoundError):
+            await service.cancel(owner_id="other", job_id=accepted.job_id, request=request)

--- a/tests/unit/services/test_container_jobs.py
+++ b/tests/unit/services/test_container_jobs.py
@@ -1,0 +1,31 @@
+import pytest
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from api_service.db.models import Base
+from api_service.services.container_jobs import ContainerJobNotFoundError, ContainerJobService
+from moonmind.schemas.container_job_models import ContainerJobCancelRequest, ContainerJobSubmitRequest, OwnerIdentity
+
+@pytest.fixture
+async def session(tmp_path):
+    engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path}/jobs.db")
+    async with engine.begin() as connection: await connection.run_sync(Base.metadata.create_all)
+    async with async_sessionmaker(engine, expire_on_commit=False)() as value: yield value
+    await engine.dispose()
+
+def submission():
+    return ContainerJobSubmitRequest(idempotencyKey="key",source={"source":"mcp","callerRequestId":"r"},spec={"image":{"reference":"alpine"},"workspace":{"kind":"managed_runtime","runtimeId":"codex","agentRunId":"run"},"resources":{"cpuMillis":100,"memoryMiB":64}})
+
+@pytest.mark.asyncio
+async def test_create_or_replay_and_owner_scoped_reads(session):
+    service=ContainerJobService(session); owner=OwnerIdentity(principalId="user-1",principalType="user")
+    first=await service.submit(owner=owner,request=submission()); second=await service.submit(owner=owner,request=submission())
+    assert first.job_id == second.job_id and second.replayed
+    assert (await service.status(owner_id="user-1",job_id=first.job_id)).state == "queued"
+    with pytest.raises(ContainerJobNotFoundError): await service.status(owner_id="user-2",job_id=first.job_id)
+
+@pytest.mark.asyncio
+async def test_owner_scoped_idempotent_cancel(session):
+    service=ContainerJobService(session); accepted=await service.submit(owner=OwnerIdentity(principalId="u",principalType="user"),request=submission())
+    request=ContainerJobCancelRequest(idempotencyKey="cancel-1")
+    first=await service.cancel(owner_id="u",job_id=accepted.job_id,request=request); second=await service.cancel(owner_id="u",job_id=accepted.job_id,request=request)
+    assert first.accepted and second.replayed and second.state == "canceling"
+    with pytest.raises(ContainerJobNotFoundError): await service.cancel(owner_id="other",job_id=accepted.job_id,request=request)

--- a/tests/unit/services/test_container_jobs.py
+++ b/tests/unit/services/test_container_jobs.py
@@ -35,8 +35,8 @@ def submission(*, key: str = "key", image: str = "alpine") -> ContainerJobSubmit
         idempotencyKey=key,
         source={"source": "mcp", "callerRequestId": "r"},
         spec={
-            "image": {"reference": image},
-            "workspace": {"kind": "managed_runtime", "runtimeId": "codex", "agentRunId": "run"},
+            "image": image,
+            "workspaceRef": {"kind": "moonmind-session", "sessionId": "run"},
             "resources": {"cpuMillis": 100, "memoryMiB": 64},
         },
     )
@@ -52,9 +52,22 @@ async def test_create_or_replay_conflict_and_owner_scoped_reads(session_factory)
         assert first.job_id == second.job_id and second.replayed
         with pytest.raises(ContainerJobIdempotencyConflictError):
             await service.submit(owner=owner, request=submission(image="busybox"))
-        assert (await service.status(owner_id="user-1", job_id=first.job_id)).state == "queued"
+        assert (await service.status(owner=owner, job_id=first.job_id)).state == "queued"
         with pytest.raises(ContainerJobNotFoundError):
-            await service.status(owner_id="user-2", job_id=first.job_id)
+            await service.status(owner=OwnerIdentity(principalId="user-2", principalType="user"), job_id=first.job_id)
+
+
+@pytest.mark.asyncio
+async def test_owner_type_is_part_of_identity_and_idempotency_scope(session_factory) -> None:
+    async with session_factory() as session:
+        service = ContainerJobService(session)
+        user = OwnerIdentity(principalId="shared", principalType="user")
+        system = OwnerIdentity(principalId="shared", principalType="system")
+        user_job = await service.submit(owner=user, request=submission())
+        system_job = await service.submit(owner=system, request=submission())
+        assert user_job.job_id != system_job.job_id
+        with pytest.raises(ContainerJobNotFoundError):
+            await service.status(owner=system, job_id=user_job.job_id)
 
 
 @pytest.mark.asyncio
@@ -80,7 +93,7 @@ async def test_terminal_observations_and_auxiliary_failures_project_independentl
             owner=OwnerIdentity(principalId="u", principalType="user"), request=submission()
         )
         await service.repository.record_observation(
-            owner_id="u", job_id=accepted.job_id, state=ContainerJobState.FAILED,
+            owner=OwnerIdentity(principalId="u", principalType="user"), job_id=accepted.job_id, state=ContainerJobState.FAILED,
             backend_kind="docker", backend_ref="configured-backend",
             image=ImageObservation(requestedReference="alpine", cachePresent=True),
             terminal=TerminalOutcome(exitCode=2, failureClass="execution", message="failed"),
@@ -88,11 +101,19 @@ async def test_terminal_observations_and_auxiliary_failures_project_independentl
             cleanup=AuxiliaryOutcome(state="succeeded"),
             logs_ref="artifact://logs", artifacts_ref="artifact://outputs",
         )
-        status = await service.status(owner_id="u", job_id=accepted.job_id)
+        status = await service.status(owner=OwnerIdentity(principalId="u", principalType="user"), job_id=accepted.job_id)
         assert status.terminal.exit_code == 2
         assert status.publication.state == "failed"
         assert status.cleanup.state == "succeeded"
         assert status.logs_ref == "artifact://logs"
+        await service.repository.record_observation(
+            owner=OwnerIdentity(principalId="u", principalType="user"),
+            job_id=accepted.job_id,
+            state=ContainerJobState.FAILED,
+        )
+        preserved = await service.status(owner=OwnerIdentity(principalId="u", principalType="user"), job_id=accepted.job_id)
+        assert preserved.backend_kind == "docker"
+        assert preserved.backend_ref == "configured-backend"
 
 
 @pytest.mark.asyncio
@@ -103,16 +124,17 @@ async def test_owner_scoped_idempotent_and_terminal_cancel(session_factory) -> N
             owner=OwnerIdentity(principalId="u", principalType="user"), request=submission()
         )
         request = ContainerJobCancelRequest(idempotencyKey="cancel-1")
-        first = await service.cancel(owner_id="u", job_id=accepted.job_id, request=request)
-        second = await service.cancel(owner_id="u", job_id=accepted.job_id, request=request)
+        owner = OwnerIdentity(principalId="u", principalType="user")
+        first = await service.cancel(owner=owner, job_id=accepted.job_id, request=request)
+        second = await service.cancel(owner=owner, job_id=accepted.job_id, request=request)
         assert first.accepted and second.replayed and second.state == "canceling"
         await service.repository.record_observation(
-            owner_id="u", job_id=accepted.job_id, state=ContainerJobState.SUCCEEDED
+            owner=owner, job_id=accepted.job_id, state=ContainerJobState.SUCCEEDED
         )
         terminal = await service.cancel(
-            owner_id="u", job_id=accepted.job_id,
+            owner=owner, job_id=accepted.job_id,
             request=ContainerJobCancelRequest(idempotencyKey="cancel-2"),
         )
         assert not terminal.accepted and terminal.state == "succeeded"
         with pytest.raises(ContainerJobNotFoundError):
-            await service.cancel(owner_id="other", job_id=accepted.job_id, request=request)
+            await service.cancel(owner=OwnerIdentity(principalId="other", principalType="user"), job_id=accepted.job_id, request=request)


### PR DESCRIPTION
MoonSpec verification incomplete; publishing draft pull request for operator review. MoonSpec verification did not approve publication. verdict ADDITIONAL_WORK_NEEDED. session started: sess:mm:b853f75b-a7b4-49a0-8b61-61ca2b256976:codex_cli thread=thread:sess:mm:b853f75b-a7b4-49a0-8b61-61ca2b256976:codex_cli:1 turn started: 019f5d91-b8cb-7811-9fa7-0df47907ded7 assistant: I’m using the GitHub-issue verification workflow because this step requires its branch/main-mode evidence model and authoritative handoff artifacts. I’ll first read its instructions, then recover the truncated brief through the trusted GitHub tooling if available. assistant: The trusted context is truncated in both the body and preset brief, so the workflow requires authenticated recovery before assessment. I’m checking that access and repository mode now; no remote state will be changed. a. verification report art_01KXET37MVP0TTX1BYY1RDHKT0.

## MoonSpec verification incomplete

This pull request was opened as a **draft** because MoonSpec verification did not approve publication (verdict ADDITIONAL_WORK_NEEDED) and the bounded remediation budget was exhausted with remaining implementation work.

- Gate outcome: MoonSpec verification did not approve publication. verdict ADDITIONAL_WORK_NEEDED. session started: sess:mm:b853f75b-a7b4-49a0-8b61-61ca2b256976:codex_cli thread=thread:sess:mm:b853f75b-a7b4-49a0-8b61-61ca2b256976:codex_cli:1 turn started: 019f5d91-b8cb-7811-9fa7-0df47907ded7 assistant: I’m using the GitHub-issue verification workflow because this step requires its branch/main-mode evidence model and authoritative handoff artifacts. I’ll first read its instructions, then recover the truncated brief through the trusted GitHub tooling if available. assistant: The trusted context is truncated in both the body and preset brief, so the workflow requires authenticated recovery before assessment. I’m checking that access and repository mode now; no remote state will be changed. a. verification report art_01KXET37MVP0TTX1BYY1RDHKT0.
- Verification report: art_01KXET37MVP0TTX1BYY1RDHKT0
- Verification gate result: art_01KXET37HWMHJ7J89Q5F8W2B64

Review the verification evidence before marking this pull request ready for review.