### PR TITLE
Fix GitHub no-commit workflow finalization

### DIFF
--- a/moonmind/workflows/temporal/story_output_tools.py
+++ b/moonmind/workflows/temporal/story_output_tools.py
@@ -5188,14 +5188,27 @@ async def update_github_issue_status(
         except (httpx.TransportError, httpx.TimeoutException) as exc:
             return ToolResult(status="FAILED", outputs={"issueRef": issue_ref, "summary": f"GitHub issue update failed: {exc.__class__.__name__}"})
     updated_issue = _github_issue_payload(updated, repository)
+    issue_url = updated_issue.get("url") or issue.get("url")
+    summary = f"Updated GitHub issue {issue_ref} with mode {mode}."
     return ToolResult(
         status="COMPLETED",
         outputs={
-            "issueUrl": updated_issue.get("url") or issue.get("url"),
+            "issueUrl": issue_url,
             "appliedActions": applied,
             "confirmedState": updated_issue.get("state"),
             "confirmedLabels": updated_issue.get("labels"),
-            "summary": f"Updated GitHub issue {issue_ref} with mode {mode}.",
+            "summary": summary,
+            "sideEffect": {
+                "effectClass": "external_non_idempotent",
+                "kind": "github",
+                "operation": (
+                    "github.issue.close"
+                    if actions.get("closeIssue")
+                    else "github.issue.update"
+                ),
+                "target": issue_url,
+                "summary": summary,
+            },
         },
     )
 

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -3596,6 +3596,8 @@ class MoonMindRunWorkflow:
             workflow_state_accepted=True,
             reason=self._coerce_text(declaration.get("summary"), max_chars=300),
         )
+        if record is None:
+            return
         provider_kind = self._coerce_text(
             declaration.get("kind") or declaration.get("provider"),
             max_chars=80,
@@ -7204,7 +7206,7 @@ class MoonMindRunWorkflow:
         }
         self._dependency_outcomes_by_id[prerequisite_workflow_id] = outcome
 
-        if terminal_state == STATE_COMPLETED:
+        if terminal_state in {STATE_COMPLETED, STATE_NO_COMMIT}:
             self._unresolved_dependency_ids.discard(prerequisite_workflow_id)
             if not self._unresolved_dependency_ids and self._dependency_failure is None:
                 self._dependency_resolution = DEPENDENCY_RESOLUTION_SATISFIED
@@ -7242,7 +7244,7 @@ class MoonMindRunWorkflow:
         ):
             return
 
-        if terminal_state == STATE_COMPLETED:
+        if terminal_state in {STATE_COMPLETED, STATE_NO_COMMIT}:
             # Idempotency: stale completed signals after already satisfied are no-ops.
             if existing_resolution in (
                 DEPENDENCY_RESOLUTION_SATISFIED,
@@ -7428,13 +7430,13 @@ class MoonMindRunWorkflow:
             )
             return
 
-        # Normalize "succeeded" to "completed" so the outcome recorder
-        # (which only treats "completed" as success) can satisfy the gate.
+        # Normalize "succeeded" to "completed" so the outcome recorder can
+        # satisfy the gate with either canonical successful terminal state.
         terminal_state = signal.terminal_state
         if terminal_state == "succeeded":
             terminal_state = "completed"
 
-        is_terminal_failure = terminal_state != "completed"
+        is_terminal_failure = terminal_state not in {STATE_COMPLETED, STATE_NO_COMMIT}
         if is_terminal_failure:
             self._get_logger().warning(
                 "DependencyResolved signal indicates non-success terminal state %s for %s",
@@ -7581,7 +7583,7 @@ class MoonMindRunWorkflow:
                 )
                 continue
 
-            if state == STATE_COMPLETED:
+            if state in {STATE_COMPLETED, STATE_NO_COMMIT}:
                 self._record_dependency_outcome(
                     prerequisite_workflow_id=dependency_id,
                     terminal_state=state,
@@ -10110,6 +10112,12 @@ class MoonMindRunWorkflow:
                 or self._summary,
                 last_error=None,
             )
+            outputs = self._effective_result_outputs(execution_result)
+            if isinstance(outputs, Mapping):
+                self._record_declared_side_effect(
+                    logical_step_id=node_id,
+                    outputs=outputs,
+                )
             self._record_downstream_dependency_effects(
                 node_id,
                 updated_at=workflow.now(),
@@ -12760,8 +12768,11 @@ class MoonMindRunWorkflow:
         self._record_publish_metadata_context(outputs)
 
         if push_status == "no_commits":
-            if publish_mode == "pr" and self._pr_publish_optional_for_task(
-                parameters, include_applied_templates=True
+            if publish_mode == "pr" and (
+                self._pr_publish_optional_for_task(
+                    parameters, include_applied_templates=True
+                )
+                or self._is_canonical_no_commit_task(parameters)
             ):
                 self._publish_status = "not_required"
                 self._publish_reason = self._compose_no_commit_publish_reason(
@@ -13230,10 +13241,6 @@ class MoonMindRunWorkflow:
             return
 
         self._last_step_id = node_id
-        self._record_declared_side_effect(
-            logical_step_id=node_id,
-            outputs=outputs,
-        )
         operator_summary = self._sanitize_operator_summary(
             self._coerce_text(
                 outputs.get("operator_summary") or outputs.get("operatorSummary"),
@@ -13573,12 +13580,21 @@ class MoonMindRunWorkflow:
             skill_names = skill_names | applied_template_slugs
         if not skill_names:
             return False
-        optional_task_skills = _PR_OPTIONAL_TASK_SKILLS
-        if self._canonical_no_commit_outcome_enabled:
-            optional_task_skills = (
-                optional_task_skills | _CANONICAL_NO_COMMIT_TASK_PRESETS
-            )
-        return skill_names.issubset(optional_task_skills)
+        return skill_names.issubset(_PR_OPTIONAL_TASK_SKILLS)
+
+    def _is_canonical_no_commit_task(
+        self,
+        parameters: Mapping[str, Any],
+    ) -> bool:
+        if not self._canonical_no_commit_outcome_enabled:
+            return False
+        task_payload = self._mapping_value(parameters, "workflow")
+        if not task_payload:
+            task_payload = self._mapping_value(parameters, "task")
+        return bool(
+            self._task_applied_template_slugs(parameters, task_payload)
+            & _CANONICAL_NO_COMMIT_TASK_PRESETS
+        )
 
     def _task_skill_names(
         self,

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -289,6 +289,7 @@ _PR_OPTIONAL_AGENT_SKILLS = JIRA_AGENT_SKILLS
 _PR_OPTIONAL_TASK_SKILLS = frozenset(
     {"jira-implement", *_PR_OPTIONAL_AGENT_SKILLS}
 )
+_CANONICAL_NO_COMMIT_TASK_PRESETS = frozenset({"github-issue-implement"})
 _EXTERNAL_INTEGRATION_MONITOR_IDS = frozenset({"codex_cloud", "jules"})
 _PUBLISH_NOT_REQUIRED_STATUSES = frozenset(
     {
@@ -511,6 +512,7 @@ RUN_HANDOFF_ACCEPTED_DISPOSITION_GATE_PATCH = (
     "run-handoff-accepted-disposition-gate-v1"
 )
 RUN_WORKFLOW_PUBLISH_OUTCOME_PATCH = "run-workflow-publish-outcome-v1"
+RUN_CANONICAL_NO_COMMIT_OUTCOME_PATCH = "run-canonical-no-commit-outcome-v1"
 RUN_UNGATED_CONTINUATION_DISPOSITION_PATCH = (
     "run-ungated-continuation-disposition-v1"
 )
@@ -1144,6 +1146,7 @@ class MoonMindRunWorkflow:
         self._publish_status: Optional[str] = None
         self._publish_reason: Optional[str] = None
         self._publish_context: dict[str, Any] = {}
+        self._canonical_no_commit_outcome_enabled: bool = False
         self._publish_repair_attempts: int = 0
         self._operator_summary: Optional[str] = None
         self._last_step_id: Optional[str] = None
@@ -3533,20 +3536,75 @@ class MoonMindRunWorkflow:
                 disposition = self._coerce_text(record.get("disposition"), max_chars=40)
                 if not operation and not disposition:
                     continue
+                provider_kind = self._coerce_text(
+                    record.get("providerKind"),
+                    max_chars=80,
+                )
+                summary = self._coerce_text(record.get("summary"), max_chars=300)
                 side_effects.append(
                     {
-                        "kind": self._coerce_text(
-                            record.get("class") or record.get("kind"),
-                            max_chars=80,
+                        "kind": provider_kind
+                        or self._coerce_text(
+                            record.get("class") or record.get("kind"), max_chars=80
                         )
                         or "external",
                         "status": "completed"
                         if disposition == "accepted"
                         else (disposition or "recorded"),
-                        "summary": operation or "Side effect recorded.",
+                        "summary": summary or operation or "Side effect recorded.",
                     }
                 )
         return side_effects[:20]
+
+    def _record_declared_side_effect(
+        self,
+        *,
+        logical_step_id: str,
+        outputs: Mapping[str, Any],
+    ) -> None:
+        if not self._canonical_no_commit_outcome_enabled:
+            return
+        declaration = outputs.get("sideEffect") or outputs.get("side_effect")
+        if not isinstance(declaration, Mapping):
+            return
+        effect_class = self._coerce_text(
+            declaration.get("effectClass") or declaration.get("effect_class"),
+            max_chars=80,
+        )
+        if effect_class not in {
+            "external_idempotent",
+            "external_non_idempotent",
+            "publication",
+            "provider_account",
+        }:
+            return
+        operation = self._coerce_text(declaration.get("operation"), max_chars=120)
+        if not operation:
+            return
+        idempotency_key = self._coerce_text(
+            declaration.get("idempotencyKey") or declaration.get("idempotency_key"),
+            max_chars=200,
+        )
+        if effect_class == "external_idempotent" and not idempotency_key:
+            return
+        record = self._record_step_side_effect(
+            logical_step_id,
+            effect_class=effect_class,
+            operation=operation,
+            target=self._coerce_text(declaration.get("target"), max_chars=500),
+            idempotency_key=idempotency_key,
+            workflow_state_accepted=True,
+            reason=self._coerce_text(declaration.get("summary"), max_chars=300),
+        )
+        provider_kind = self._coerce_text(
+            declaration.get("kind") or declaration.get("provider"),
+            max_chars=80,
+        )
+        summary = self._coerce_text(declaration.get("summary"), max_chars=300)
+        if provider_kind:
+            record["providerKind"] = provider_kind
+        if summary:
+            record["summary"] = summary
 
     def _is_jira_orchestrate_external_handoff_node(
         self,
@@ -7684,6 +7742,9 @@ class MoonMindRunWorkflow:
                 str(exc),
                 non_retryable=True,
             ) from exc
+        self._canonical_no_commit_outcome_enabled = workflow.patched(
+            RUN_CANONICAL_NO_COMMIT_OUTCOME_PATCH
+        )
         self._get_logger().info(
             "Starting MoonMind.UserWorkflow workflow",
             extra={"workflow_type": workflow_type},
@@ -13169,6 +13230,10 @@ class MoonMindRunWorkflow:
             return
 
         self._last_step_id = node_id
+        self._record_declared_side_effect(
+            logical_step_id=node_id,
+            outputs=outputs,
+        )
         operator_summary = self._sanitize_operator_summary(
             self._coerce_text(
                 outputs.get("operator_summary") or outputs.get("operatorSummary"),
@@ -13508,7 +13573,12 @@ class MoonMindRunWorkflow:
             skill_names = skill_names | applied_template_slugs
         if not skill_names:
             return False
-        return skill_names.issubset(_PR_OPTIONAL_TASK_SKILLS)
+        optional_task_skills = _PR_OPTIONAL_TASK_SKILLS
+        if self._canonical_no_commit_outcome_enabled:
+            optional_task_skills = (
+                optional_task_skills | _CANONICAL_NO_COMMIT_TASK_PRESETS
+            )
+        return skill_names.issubset(optional_task_skills)
 
     def _task_skill_names(
         self,
@@ -13702,7 +13772,8 @@ class MoonMindRunWorkflow:
         parts: list[str] = []
         if publish_mode == "pr" and pr_publish_optional:
             parts.append(
-                "No pull request was required because this Jira-oriented workflow "
+                "No pull request was required because this issue implementation "
+                "workflow "
                 "completed without repository changes"
             )
         elif publish_mode == "pr":
@@ -13725,7 +13796,7 @@ class MoonMindRunWorkflow:
             parts.append(f"final agent report: {operator_summary}")
         elif publish_mode == "pr" and pr_publish_optional:
             parts.append(
-                "no structured agent report confirmed whether the Jira issue was "
+                "no structured agent report confirmed whether the issue was "
                 "already implemented"
             )
 
@@ -14086,6 +14157,15 @@ class MoonMindRunWorkflow:
                     "reportOutput requested but no final report was created",
                     True,
                 )
+            if self._is_canonical_no_commit_outcome(parameters):
+                return (
+                    "no_commit",
+                    self._compose_success_completion_message(
+                        publish_detail=self._publish_reason,
+                        publish_mode=publish_mode,
+                    ),
+                    False,
+                )
             return (
                 "success",
                 self._compose_success_completion_message(
@@ -14160,6 +14240,20 @@ class MoonMindRunWorkflow:
             self._compose_success_completion_message(publish_mode=publish_mode),
             False,
         )
+
+    def _is_canonical_no_commit_outcome(
+        self,
+        parameters: Mapping[str, Any],
+    ) -> bool:
+        if not self._canonical_no_commit_outcome_enabled:
+            return False
+        if self._publish_mode(parameters) not in {"pr", "branch"}:
+            return False
+        if self._report_requested(parameters):
+            return False
+        if not self._has_no_commit_publish_evidence():
+            return False
+        return not self._pull_request_created() and not self._branch_published()
 
     def _missing_required_outcome_reason(
         self,
@@ -17715,7 +17809,11 @@ class MoonMindRunWorkflow:
                             or "No repository changes were available to commit or publish."
                         )
                     elif self._publish_status == "not_required":
-                        code = "NO_COMMIT" if publish_mode == "auto" else "PUBLISH_DISABLED"
+                        code = (
+                            "NO_COMMIT"
+                            if self._is_canonical_no_commit_outcome(parameters)
+                            else "PUBLISH_DISABLED"
+                        )
                         publish_status = "skipped"
                         publish_reason = (
                             self._publish_reason or "publish output not required"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,6 +49,24 @@ def global_test_settings():
     settings.workflow.enable_proposals = False
 
 
+@pytest.fixture(scope="session", autouse=True)
+def pin_temporal_test_server_download():
+    """Use an explicit Temporal test-server release for hermetic test startup."""
+    from temporalio.testing import WorkflowEnvironment
+
+    original_start_time_skipping = WorkflowEnvironment.start_time_skipping
+
+    async def start_time_skipping(**kwargs):
+        kwargs.setdefault("test_server_download_version", "v1.29.0")
+        return await original_start_time_skipping(**kwargs)
+
+    WorkflowEnvironment.start_time_skipping = staticmethod(start_time_skipping)
+    try:
+        yield
+    finally:
+        WorkflowEnvironment.start_time_skipping = original_start_time_skipping
+
+
 def _relative_test_path(path: Path) -> Path:
     try:
         return path.resolve().relative_to(_REPO_ROOT)

--- a/tests/unit/workflows/temporal/test_run_replayer.py
+++ b/tests/unit/workflows/temporal/test_run_replayer.py
@@ -1,4 +1,5 @@
 import inspect
+from typing import Any
 
 import pytest
 from temporalio import workflow
@@ -7,6 +8,7 @@ from temporalio.worker import Worker, UnsandboxedWorkflowRunner, Replayer
 
 from moonmind.workflows.temporal.workflows.run import (
     GateTransitionDecision,
+    RUN_CANONICAL_NO_COMMIT_OUTCOME_PATCH,
     RUN_PLAN_ROUTED_MOONSPEC_REMEDIATION_PATCH,
     MoonMindRunWorkflow,
     MoonMindUserWorkflow,
@@ -89,6 +91,53 @@ class _CurrentRemediationReplayFixture:
         assert decision.successor is not None
         return ["verify-1", decision.successor.logical_step_id]
 
+
+@workflow.defn(name="MMCanonicalNoCommitReplayFixture")
+class _LegacyCanonicalNoCommitReplayFixture:
+    @workflow.run
+    async def run(self) -> list[Any]:
+        return ["skipped", "failed", True]
+
+
+@workflow.defn(name="MMCanonicalNoCommitReplayFixture")
+class _CurrentCanonicalNoCommitReplayFixture:
+    @workflow.run
+    async def run(self) -> list[Any]:
+        run_workflow = MoonMindRunWorkflow()
+        run_workflow._canonical_no_commit_outcome_enabled = workflow.patched(
+            RUN_CANONICAL_NO_COMMIT_OUTCOME_PATCH
+        )
+        parameters = {
+            "publishMode": "pr",
+            "workflow": {
+                "tool": {"type": "skill", "name": "auto"},
+                "skill": {"name": "auto"},
+                "appliedStepTemplates": [
+                    {"slug": "github-issue-implement", "version": "1.0.0"},
+                ],
+            },
+        }
+        result = {
+            "outputs": {
+                "push_status": "no_commits",
+                "push_branch": "feature/no-op",
+                "push_base_ref": "origin/main",
+                "push_commit_count": 0,
+            }
+        }
+        run_workflow._record_execution_context(
+            node_id="create-pull-request",
+            execution_result=result,
+        )
+        run_workflow._record_publish_result(
+            parameters=parameters,
+            execution_result=result,
+        )
+        status, _message, publish_failure = (
+            run_workflow._determine_publish_completion(parameters=parameters)
+        )
+        return [run_workflow._publish_status, status, publish_failure]
+
 @pytest.mark.asyncio
 async def test_workflow_determinism_replay(mock_run_environment):
     async with await WorkflowEnvironment.start_time_skipping() as env:
@@ -135,6 +184,17 @@ def test_plan_routed_moonspec_patch_is_snapshotted_before_node_execution() -> No
     assert snapshot_index < node_loop_index
 
 
+def test_canonical_no_commit_patch_is_snapshotted_at_workflow_start() -> None:
+    source = inspect.getsource(MoonMindRunWorkflow.run)
+    patch_name = "RUN_CANONICAL_NO_COMMIT_OUTCOME_PATCH"
+
+    assert RUN_CANONICAL_NO_COMMIT_OUTCOME_PATCH.endswith("-v1")
+    assert source.count(patch_name) == 1
+    assert source.index(patch_name) < source.index(
+        "Starting MoonMind.UserWorkflow workflow"
+    )
+
+
 @pytest.mark.asyncio
 async def test_moonspec_remediation_pre_and_post_patch_histories_replay() -> None:
     async with await WorkflowEnvironment.start_time_skipping() as env:
@@ -170,6 +230,45 @@ async def test_moonspec_remediation_pre_and_post_patch_histories_replay() -> Non
     assert current_commands.count("verify-1") == 1
     replayer = Replayer(
         workflows=[_CurrentRemediationReplayFixture],
+        workflow_runner=UnsandboxedWorkflowRunner(),
+    )
+    await replayer.replay_workflow(legacy_history)
+    await replayer.replay_workflow(current_history)
+
+
+@pytest.mark.asyncio
+async def test_canonical_no_commit_pre_and_post_patch_histories_replay() -> None:
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        async with Worker(
+            env.client,
+            task_queue="test-no-commit-legacy-replay",
+            workflows=[_LegacyCanonicalNoCommitReplayFixture],
+            workflow_runner=UnsandboxedWorkflowRunner(),
+        ):
+            legacy = await env.client.start_workflow(
+                _LegacyCanonicalNoCommitReplayFixture.run,
+                id="test-no-commit-legacy-history",
+                task_queue="test-no-commit-legacy-replay",
+            )
+            assert await legacy.result() == ["skipped", "failed", True]
+            legacy_history = await legacy.fetch_history()
+
+        async with Worker(
+            env.client,
+            task_queue="test-no-commit-current-replay",
+            workflows=[_CurrentCanonicalNoCommitReplayFixture],
+            workflow_runner=UnsandboxedWorkflowRunner(),
+        ):
+            current = await env.client.start_workflow(
+                _CurrentCanonicalNoCommitReplayFixture.run,
+                id="test-no-commit-current-history",
+                task_queue="test-no-commit-current-replay",
+            )
+            assert await current.result() == ["not_required", "no_commit", False]
+            current_history = await current.fetch_history()
+
+    replayer = Replayer(
+        workflows=[_CurrentCanonicalNoCommitReplayFixture],
         workflow_runner=UnsandboxedWorkflowRunner(),
     )
     await replayer.replay_workflow(legacy_history)

--- a/tests/unit/workflows/temporal/test_story_output_tools.py
+++ b/tests/unit/workflows/temporal/test_story_output_tools.py
@@ -393,6 +393,34 @@ async def test_update_github_issue_status_allows_code_review_without_verificatio
 
 
 @pytest.mark.asyncio
+async def test_update_github_issue_status_declares_completed_close_side_effect(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(story_tools.httpx, "AsyncClient", _FakeHttpClient)
+    service = _FakeGitHubService()
+
+    result = await update_github_issue_status(
+        {
+            "repository": "MoonLadderStudios/MoonMind",
+            "issueNumber": 1067,
+            "mode": "finalize_after_pr_or_done",
+        },
+        github_service_factory=lambda: service,
+    )
+
+    assert result.status == "COMPLETED"
+    assert result.outputs["sideEffect"] == {
+        "effectClass": "external_non_idempotent",
+        "kind": "github",
+        "operation": "github.issue.close",
+        "target": "https://github.com/MoonLadderStudios/MoonMind/issues/1067",
+        "summary": (
+            "Updated GitHub issue MoonLadderStudios/MoonMind#1067 with mode done."
+        ),
+    }
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("require_verification", [None, "", "   "])
 async def test_update_github_issue_status_requires_verification_for_blank_values(
     tmp_path,

--- a/tests/unit/workflows/temporal/workflows/test_run_dependency_wait_through_rerun.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_dependency_wait_through_rerun.py
@@ -94,6 +94,27 @@ def test_failed_prerequisite_keeps_dependent_waiting(monkeypatch) -> None:
     assert outcome["terminalState"] == "failed"
 
 
+def test_no_commit_prerequisite_satisfies_dependency(monkeypatch) -> None:
+    """A safely completed no-change run is a successful prerequisite."""
+
+    wf = _make_workflow_under_rerun_patch(monkeypatch, declared=["dep-1"])
+
+    wf._record_dependency_outcome(
+        prerequisite_workflow_id="dep-1",
+        terminal_state="no_commit",
+        close_status="completed",
+        resolved_at="2026-05-08T12:00:00Z",
+        failure_category=None,
+        message="No repository commit was needed.",
+    )
+
+    assert wf._unresolved_dependency_ids == set()
+    assert wf._dependency_resolution == DEPENDENCY_RESOLUTION_SATISFIED
+    outcome = wf._dependency_outcomes_by_id["dep-1"]
+    assert outcome["terminalState"] == "no_commit"
+    assert outcome["resolution"] == DEPENDENCY_RESOLUTION_SATISFIED
+
+
 @pytest.mark.parametrize(
     "terminal_state,close_status",
     [

--- a/tests/unit/workflows/temporal/workflows/test_run_integration.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_integration.py
@@ -1470,6 +1470,7 @@ def test_determine_publish_completion_fails_for_no_commit_pr_publish(
 def test_jira_implement_no_commit_pr_handoff_is_not_required(
     mock_run_workflow: MoonMindRunWorkflow,
 ) -> None:
+    mock_run_workflow._canonical_no_commit_outcome_enabled = True
     execution_result = {
         "outputs": {
             "push_status": "no_commits",
@@ -1501,9 +1502,11 @@ def test_jira_implement_no_commit_pr_handoff_is_not_required(
     )
 
     assert mock_run_workflow._publish_status == "not_required"
-    assert status == "success"
+    assert status == "no_commit"
     assert "No pull request was required" in message
-    assert "Jira-oriented workflow completed without repository changes" in message
+    assert (
+        "issue implementation workflow completed without repository changes" in message
+    )
     assert "MM-675 was already implemented" in message
     assert "no publishable diff was produced" not in message
     assert publish_failure is False
@@ -1512,6 +1515,7 @@ def test_jira_implement_no_commit_pr_handoff_is_not_required(
 def test_jira_implement_no_commit_pr_handoff_without_agent_report_is_explicit(
     mock_run_workflow: MoonMindRunWorkflow,
 ) -> None:
+    mock_run_workflow._canonical_no_commit_outcome_enabled = True
     execution_result = {
         "outputs": {
             "push_status": "no_commits",
@@ -1542,14 +1546,99 @@ def test_jira_implement_no_commit_pr_handoff_without_agent_report_is_explicit(
     )
 
     assert mock_run_workflow._publish_status == "not_required"
-    assert status == "success"
+    assert status == "no_commit"
     assert "No pull request was required" in message
-    assert "Jira-oriented workflow completed without repository changes" in message
     assert (
-        "no structured agent report confirmed whether the Jira issue was "
+        "issue implementation workflow completed without repository changes" in message
+    )
+    assert (
+        "no structured agent report confirmed whether the issue was "
         "already implemented"
     ) in message
     assert publish_failure is False
+
+
+@pytest.mark.asyncio
+async def test_github_issue_implement_no_commit_closure_finalizes_as_no_commit(
+    mock_run_workflow: MoonMindRunWorkflow,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    mock_run_workflow._canonical_no_commit_outcome_enabled = True
+    parameters = {
+        "publishMode": "pr",
+        "workflow": {
+            "tool": {"type": "skill", "name": "auto"},
+            "skill": {"name": "auto"},
+            "appliedStepTemplates": [
+                {"slug": "github-issue-implement", "version": "1.0.0"},
+            ],
+        },
+    }
+    no_commit_result = {
+        "outputs": {
+            "push_status": "no_commits",
+            "push_branch": "feature/no-op",
+            "push_base_ref": "origin/main",
+            "push_commit_count": 0,
+            "operator_summary": "GitHub issue #3144 was already implemented.",
+        }
+    }
+    mock_run_workflow._record_execution_context(
+        node_id="create-pull-request",
+        execution_result=no_commit_result,
+    )
+    mock_run_workflow._record_publish_result(
+        parameters=parameters,
+        execution_result=no_commit_result,
+    )
+    mock_run_workflow._record_execution_context(
+        node_id="finalize-github-issue",
+        execution_result={
+            "outputs": {
+                "summary": (
+                    "Updated GitHub issue MoonLadderStudios/MoonMind#3144 "
+                    "with mode done."
+                ),
+                "sideEffect": {
+                    "effectClass": "external_non_idempotent",
+                    "kind": "github",
+                    "operation": "github.issue.close",
+                    "target": (
+                        "https://github.com/MoonLadderStudios/MoonMind/issues/3144"
+                    ),
+                    "summary": "Closed GitHub issue MoonLadderStudios/MoonMind#3144.",
+                },
+            }
+        },
+    )
+
+    status, message, publish_failure = mock_run_workflow._determine_publish_completion(
+        parameters=parameters
+    )
+    summary = await _finalize_and_capture_summary(
+        monkeypatch,
+        mock_run_workflow,
+        parameters=parameters,
+    )
+
+    assert mock_run_workflow._publish_status == "not_required"
+    assert status == "no_commit"
+    assert "No pull request was required" in message
+    assert "Jira" not in message
+    assert publish_failure is False
+    assert summary["finishOutcome"]["code"] == "NO_COMMIT"
+    assert summary["publish"]["status"] == "skipped"
+    assert summary["publish"]["reasonCode"] == "no_commit"
+    assert summary["publish"]["commitCreated"] is False
+    assert summary["publish"]["branchPushed"] is False
+    assert summary["publish"]["prUrl"] is None
+    assert summary["sideEffects"] == [
+        {
+            "kind": "github",
+            "status": "completed",
+            "summary": "Closed GitHub issue MoonLadderStudios/MoonMind#3144.",
+        }
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/workflows/temporal/workflows/test_run_integration.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_integration.py
@@ -1611,6 +1611,18 @@ async def test_github_issue_implement_no_commit_closure_finalizes_as_no_commit(
             }
         },
     )
+    mock_run_workflow._record_declared_side_effect(
+        logical_step_id="finalize-github-issue",
+        outputs={
+            "sideEffect": {
+                "effectClass": "external_non_idempotent",
+                "kind": "github",
+                "operation": "github.issue.close",
+                "target": "https://github.com/MoonLadderStudios/MoonMind/issues/3144",
+                "summary": "Closed GitHub issue MoonLadderStudios/MoonMind#3144.",
+            }
+        },
+    )
 
     status, message, publish_failure = mock_run_workflow._determine_publish_completion(
         parameters=parameters
@@ -2507,6 +2519,51 @@ def test_jira_implement_task_makes_pr_publish_optional(
                 ],
             },
         }
+    )
+
+
+def test_github_issue_template_only_relaxes_pr_after_no_commit_evidence(
+    mock_run_workflow: MoonMindRunWorkflow,
+) -> None:
+    mock_run_workflow._canonical_no_commit_outcome_enabled = True
+    parameters = {
+        "publishMode": "pr",
+        "workflow": {
+            "tool": {"type": "skill", "name": "auto"},
+            "skill": {"name": "auto"},
+            "appliedStepTemplates": [
+                {"slug": "github-issue-implement", "version": "1.0.0"},
+            ],
+        },
+    }
+
+    assert not mock_run_workflow._pr_publish_optional_for_task(
+        parameters,
+        include_applied_templates=True,
+    )
+    assert mock_run_workflow._is_canonical_no_commit_task(parameters)
+
+
+def test_record_declared_side_effect_tolerates_missing_record(
+    mock_run_workflow: MoonMindRunWorkflow,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    mock_run_workflow._canonical_no_commit_outcome_enabled = True
+    monkeypatch.setattr(
+        mock_run_workflow,
+        "_record_step_side_effect",
+        lambda *_args, **_kwargs: None,
+    )
+
+    mock_run_workflow._record_declared_side_effect(
+        logical_step_id="finalize-github-issue",
+        outputs={
+            "sideEffect": {
+                "effectClass": "external_non_idempotent",
+                "kind": "github",
+                "operation": "github.issue.close",
+            }
+        },
     )
 
 

--- a/tools/test_unit.sh
+++ b/tools/test_unit.sh
@@ -142,7 +142,9 @@ from temporalio.testing import WorkflowEnvironment
 
 
 async def main() -> None:
-    env = await WorkflowEnvironment.start_time_skipping()
+    env = await WorkflowEnvironment.start_time_skipping(
+        test_server_download_version="v1.29.0"
+    )
     await env.shutdown()
 
 


### PR DESCRIPTION
## Summary

- classify GitHub Issue Implement runs with verified zero-commit evidence as the canonical `no_commit` terminal outcome
- preserve generic PR failure behavior when a missing diff is not an allowed outcome
- emit successful GitHub issue updates as structured side-effect evidence in finish summaries
- guard the behavior with a replay-stable Temporal patch cutover

## Root cause

The PR-optional task classifier recognized Jira Implement but not the `github-issue-implement` preset. Its zero-commit result therefore stayed `skipped`, and PR finalization converted it into an execution failure even after the GitHub issue was successfully closed. The existing `not_required` path also mapped non-auto publication to `PUBLISH_DISABLED` instead of `NO_COMMIT`.

## Validation

- affected Python files: 317 passed
- focused post-rebase regression set: 6 passed
- Temporal pre/post-cutover replay coverage: passed
- workflow-list frontend rerun: 86 passed (the initial full-wrapper run had one contention-related timeout while another process was running the same file)
- `git diff --check` and Python compilation: passed