### PR TITLE
Complete typed workspace locator migration gaps for MoonLadderStudios/MoonMind#3147

### DIFF
--- a/docs/Workflows/WorkspaceLocators.md
+++ b/docs/Workflows/WorkspaceLocators.md
@@ -19,4 +19,8 @@ During the Temporal replay window, checkpoint activities continue to read legacy
 `workspacePath` and `workspaceRootRef` fields. New producers prefer
 `workspaceLocator`; they do not derive a new authority from an old absolute path.
 The legacy fields can be removed after all histories recorded before this contract
-have passed their retention and rollback windows.
+have passed their retention and rollback windows. Activity workers emit
+`workspace_locator.compatibility_path_usage` with an `operation` tag whenever
+checkpoint capture, git-effect classification, or recovery/apply consumes a legacy
+path field; operators use this counter to determine when the compatibility window
+can close.

--- a/moonmind/schemas/temporal_models.py
+++ b/moonmind/schemas/temporal_models.py
@@ -1492,6 +1492,9 @@ class WorkspacePolicyApplyInput(BaseModel):
     workspace_policy: WorkspacePolicy = Field(..., alias="workspacePolicy")
     checkpoint_ref: str = Field(..., alias="checkpointRef", min_length=1)
     checkpoint: dict[str, Any] = Field(default_factory=dict, alias="checkpoint")
+    target_workspace_locator: WorkspaceLocator | None = Field(
+        None, alias="targetWorkspaceLocator"
+    )
     target_workspace_ref: str | None = Field(None, alias="targetWorkspaceRef")
     expected_plan_ref: str | None = Field(None, alias="expectedPlanRef")
     expected_plan_digest: str | None = Field(None, alias="expectedPlanDigest")

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -116,6 +116,7 @@ from moonmind.workflows.adapters.managed_agent_adapter import (
     managed_run_status_metadata,
 )
 from moonmind.utils.logging import SecretRedactor, redact_sensitive_payload, redact_sensitive_text
+from moonmind.utils.metrics import get_metrics_emitter
 from moonmind.workflows.adapters.jules_agent_adapter import JulesAgentAdapter
 from moonmind.workflows.adapters.codex_cloud_agent_adapter import CodexCloudAgentAdapter
 from moonmind.workflows.adapters.codex_cloud_client import CodexCloudClient as CodexCloudHttpClient
@@ -3267,6 +3268,8 @@ class TemporalSandboxActivities:
                 WORKSPACE_LOCATOR_UNSUPPORTED,
                 "external state cannot be used by a local checkpoint operation",
             )
+        if model.workspace_locator is None:
+            self._record_legacy_workspace_path_usage("capture_checkpoint")
         workspace = (
             self._resolve_sandbox_locator(model.workspace_locator, must_exist=True)
             if isinstance(model.workspace_locator, SandboxWorkspaceLocator)
@@ -3587,7 +3590,21 @@ class TemporalSandboxActivities:
         return decoded
 
     def _policy_target_workspace(self, model: WorkspacePolicyApplyInput) -> Path:
+        locator = model.target_workspace_locator
+        if isinstance(locator, ManagedWorkspaceLocator):
+            raise WorkspaceLocatorResolutionError(
+                WORKSPACE_AUTHORITY_MISMATCH,
+                "sandbox worker cannot apply recovery to a managed-runtime workspace",
+            )
+        if isinstance(locator, ExternalStateLocator):
+            raise WorkspaceLocatorResolutionError(
+                WORKSPACE_LOCATOR_UNSUPPORTED,
+                "external state cannot be used as a local recovery target",
+            )
+        if isinstance(locator, SandboxWorkspaceLocator):
+            return self._resolve_sandbox_locator(locator, must_exist=False)
         if model.target_workspace_ref:
+            self._record_legacy_workspace_path_usage("apply_policy")
             return self._resolve_workspace(model.target_workspace_ref, must_exist=False)
         digest = hashlib.sha256(model.idempotency_key.encode("utf-8")).hexdigest()[:16]
         target = (
@@ -3956,6 +3973,8 @@ class TemporalSandboxActivities:
                 WORKSPACE_LOCATOR_UNSUPPORTED,
                 "external state cannot be used for git-effect classification",
             )
+        if locator is None:
+            self._record_legacy_workspace_path_usage("classify_git_effect")
         workspace = (
             self._resolve_sandbox_locator(locator, must_exist=True)
             if isinstance(locator, SandboxWorkspaceLocator)
@@ -3982,6 +4001,13 @@ class TemporalSandboxActivities:
             "summary": f"git workspace is {disposition}",
             "diagnosticRefs": refs,
         }
+
+    @staticmethod
+    def _record_legacy_workspace_path_usage(operation: str) -> None:
+        get_metrics_emitter().increment(
+            "workspace_locator.compatibility_path_usage",
+            tags={"operation": operation},
+        )
 
     def _resolve_workspace(
         self, workspace_ref: str | Path, *, must_exist: bool

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -3233,6 +3233,8 @@ class TemporalSandboxActivities:
                     WORKSPACE_LOCATOR_UNSUPPORTED,
                     "filesystem workspace locator cannot be used as external state",
                 )
+            if model.workspace_locator is None and model.workspace_root_ref:
+                self._record_legacy_workspace_path_usage("capture_checkpoint")
             source_ref = (
                 model.workspace_locator.artifact_ref
                 if isinstance(model.workspace_locator, ExternalStateLocator)
@@ -4004,10 +4006,16 @@ class TemporalSandboxActivities:
 
     @staticmethod
     def _record_legacy_workspace_path_usage(operation: str) -> None:
-        get_metrics_emitter().increment(
-            "workspace_locator.compatibility_path_usage",
-            tags={"operation": operation},
-        )
+        try:
+            get_metrics_emitter().increment(
+                "workspace_locator.compatibility_path_usage",
+                tags={"operation": operation},
+            )
+        except Exception:
+            logger.warning(
+                "Failed to emit legacy workspace path compatibility metric",
+                exc_info=True,
+            )
 
     def _resolve_workspace(
         self, workspace_ref: str | Path, *, must_exist: bool

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -3226,13 +3226,24 @@ class MoonMindRunWorkflow:
                 f"recovery checkpoint validation failed: {failure_code}"
             )
 
+        target_workspace_locator = self._recovery_workspace.get(
+            "targetWorkspaceLocator"
+        )
+        if not isinstance(target_workspace_locator, Mapping):
+            target_workspace_locator = self._recovery_workspace.get(
+                "target_workspace_locator"
+            )
+        if not isinstance(target_workspace_locator, Mapping):
+            target_workspace_locator = None
         target_workspace_ref = self._recovery_source_text(
             self._recovery_workspace,
             "targetWorkspaceRef",
             "target_workspace_ref",
             "workspaceRef",
             "workspace_ref",
-        ) or checkpoint_ref
+        )
+        if target_workspace_locator is None:
+            target_workspace_ref = target_workspace_ref or checkpoint_ref
         apply_route = DEFAULT_ACTIVITY_CATALOG.resolve_activity("workspace.apply_policy")
         apply_payload = {
             "identity": {
@@ -3244,11 +3255,14 @@ class MoonMindRunWorkflow:
             "workspacePolicy": workspace_policy,
             "checkpointRef": checkpoint_ref,
             "checkpoint": dict(checkpoint_payload),
-            "targetWorkspaceRef": target_workspace_ref,
             "expectedPlanRef": source_plan_ref or None,
             "expectedPlanDigest": source_plan_digest or None,
             "idempotencyKey": f"{checkpoint_ref}:workspace_policy:{workspace_policy}",
         }
+        if target_workspace_locator is not None:
+            apply_payload["targetWorkspaceLocator"] = dict(target_workspace_locator)
+        if target_workspace_ref:
+            apply_payload["targetWorkspaceRef"] = target_workspace_ref
         policy = await workflow.execute_activity(
             apply_route.activity_type,
             apply_payload,

--- a/tests/integration/workflows/temporal/test_step_checkpoint_activities.py
+++ b/tests/integration/workflows/temporal/test_step_checkpoint_activities.py
@@ -360,7 +360,7 @@ async def test_workspace_locator_kinds_are_enforced_for_git_effect(
 ) -> None:
     store = InMemoryArtifactStore()
     root = _workspace_root(tmp_path)
-    repo = _repo(root, workspace_id="locator-workspace")
+    _repo(root, workspace_id="locator-workspace")
     sandbox = TemporalSandboxActivities(workspace_root=root, artifact_store=store)
 
     result = await sandbox.workspace_classify_git_effect(
@@ -517,6 +517,59 @@ async def test_legacy_workspace_path_usage_emits_compatibility_metric(
         "workspace_locator.compatibility_path_usage",
         tags={"operation": "classify_git_effect"},
     )
+
+
+async def test_external_state_capture_counts_legacy_workspace_root_ref(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    emitter = Mock()
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.activity_runtime.get_metrics_emitter",
+        lambda: emitter,
+    )
+    sandbox = TemporalSandboxActivities(
+        workspace_root=_workspace_root(tmp_path), artifact_store=InMemoryArtifactStore()
+    )
+
+    result = await sandbox.workspace_capture_checkpoint(
+        {
+            "identity": _identity().model_dump(by_alias=True),
+            "boundary": "after_execution",
+            "kind": "external_state_ref",
+            "workspaceRootRef": "legacy-external-state",
+            "artifactNamespace": "checkpoint",
+            "idempotencyKey": "legacy-external-state",
+        }
+    )
+
+    assert result["status"] == "captured"
+    emitter.increment.assert_called_once_with(
+        "workspace_locator.compatibility_path_usage",
+        tags={"operation": "capture_checkpoint"},
+    )
+
+
+async def test_legacy_workspace_metric_failure_does_not_block_operation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def fail_metrics() -> object:
+        raise ValueError("invalid metrics configuration")
+
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.activity_runtime.get_metrics_emitter",
+        fail_metrics,
+    )
+    root = _workspace_root(tmp_path)
+    repo = _repo(root)
+    sandbox = TemporalSandboxActivities(
+        workspace_root=root, artifact_store=InMemoryArtifactStore()
+    )
+
+    result = await sandbox.workspace_classify_git_effect(
+        {"workspacePath": str(repo)}
+    )
+
+    assert result["status"] == "dirty"
 
 
 async def test_workspace_apply_policy_handles_degraded_checkpoint_payload(
@@ -1292,6 +1345,54 @@ async def test_workflow_recovery_routes_checkpoint_validation_before_policy(
     policy_payload = calls[1][1]
     assert policy_payload["checkpointRef"] == "artifact-checkpoint"
     assert policy_payload["targetWorkspaceRef"] == "workspace-target"
+
+
+async def test_workflow_recovery_forwards_typed_target_workspace_locator(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[tuple[str, dict[str, object]]] = []
+
+    async def fake_execute_activity(
+        activity_type: str,
+        payload: dict[str, object],
+        **_kwargs: object,
+    ) -> dict[str, object]:
+        calls.append((activity_type, payload))
+        if activity_type == "step_checkpoint.validate":
+            return {"valid": True}
+        if activity_type == "workspace.apply_policy":
+            return {"status": "applied", "workspaceRef": "typed-workspace"}
+        raise AssertionError(f"unexpected activity {activity_type}")
+
+    monkeypatch.setattr(run_module.workflow, "execute_activity", fake_execute_activity)
+    workflow = MoonMindRunWorkflow()
+    workflow._recovery_source = _recovery_source_with_checkpoint_payload()
+    recovery_workspace = workflow._recovery_source["recoveryWorkspace"]
+    assert isinstance(recovery_workspace, dict)
+    recovery_workspace.pop("targetWorkspaceRef")
+    recovery_workspace["target_workspace_locator"] = {
+        "kind": "sandbox",
+        "workspaceId": "recovery-workspace",
+        "relativePath": "repo",
+    }
+    workflow._initialize_step_ledger(
+        ordered_nodes=[{"id": "implement", "title": "Implement"}],
+        dependency_map={"implement": []},
+        updated_at=datetime(2026, 6, 13, 12, 0, tzinfo=UTC),
+    )
+
+    restored_ref = await workflow._prepare_recovery_workspace_for_failed_step(
+        "implement"
+    )
+
+    assert restored_ref == "typed-workspace"
+    policy_payload = calls[1][1]
+    assert policy_payload["targetWorkspaceLocator"] == {
+        "kind": "sandbox",
+        "workspaceId": "recovery-workspace",
+        "relativePath": "repo",
+    }
+    assert "targetWorkspaceRef" not in policy_payload
 
 
 async def test_workflow_recovery_validation_failure_blocks_policy_application(

--- a/tests/integration/workflows/temporal/test_step_checkpoint_activities.py
+++ b/tests/integration/workflows/temporal/test_step_checkpoint_activities.py
@@ -8,7 +8,7 @@ from io import BytesIO
 from datetime import UTC, datetime
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 
@@ -16,6 +16,7 @@ from moonmind.schemas.temporal_models import (
     STEP_EXECUTION_CHECKPOINT_CONTENT_TYPE,
     StepExecutionIdentityModel,
 )
+from moonmind.schemas.workspace_locator_models import WorkspaceLocatorResolutionError
 from moonmind.workflows.skills.artifact_store import InMemoryArtifactStore
 from moonmind.workflows.temporal.activity_runtime import (
     TemporalCheckpointActivities,
@@ -42,8 +43,9 @@ def _workspace_root(tmp_path: Path) -> Path:
     return root
 
 
-def _repo(root: Path) -> Path:
-    repo = root / "temporal_sandbox" / "repo"
+def _repo(root: Path, *, workspace_id: str | None = None) -> Path:
+    repo = root / "temporal_sandbox"
+    repo = repo / workspace_id / "repo" if workspace_id else repo / "repo"
     repo.mkdir(parents=True)
     subprocess.run(["git", "init"], cwd=repo, check=True, stdout=subprocess.PIPE)
     subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=repo, check=True)
@@ -351,6 +353,170 @@ async def test_workspace_classify_git_effect_accepts_workspace_root_ref(
 
     assert result["status"] == "dirty"
     assert result["diagnosticRefs"]
+
+
+async def test_workspace_locator_kinds_are_enforced_for_git_effect(
+    tmp_path: Path,
+) -> None:
+    store = InMemoryArtifactStore()
+    root = _workspace_root(tmp_path)
+    repo = _repo(root, workspace_id="locator-workspace")
+    sandbox = TemporalSandboxActivities(workspace_root=root, artifact_store=store)
+
+    result = await sandbox.workspace_classify_git_effect(
+        {
+            "workspaceLocator": {
+                "kind": "sandbox",
+                "workspaceId": "locator-workspace",
+                "relativePath": "repo",
+            }
+        }
+    )
+    assert result["status"] == "dirty"
+
+    for locator, code in (
+        (
+            {"kind": "managed_runtime", "runtimeId": "codex", "agentRunId": "run-1"},
+            "WORKSPACE_AUTHORITY_MISMATCH",
+        ),
+        (
+            {"kind": "external_state", "artifactRef": "art:sha256:evidence"},
+            "WORKSPACE_LOCATOR_UNSUPPORTED",
+        ),
+    ):
+        with pytest.raises(WorkspaceLocatorResolutionError) as exc_info:
+            await sandbox.workspace_classify_git_effect({"workspaceLocator": locator})
+        assert exc_info.value.code == code
+
+
+async def test_workspace_locator_kinds_are_enforced_for_checkpoint_capture(
+    tmp_path: Path,
+) -> None:
+    store = InMemoryArtifactStore()
+    root = _workspace_root(tmp_path)
+    _repo(root, workspace_id="capture-workspace")
+    sandbox = TemporalSandboxActivities(workspace_root=root, artifact_store=store)
+    base_request = {
+        "identity": _identity().model_dump(by_alias=True),
+        "boundary": "after_execution",
+        "artifactNamespace": "checkpoint",
+        "idempotencyKey": "locator-capture",
+    }
+
+    captured = await sandbox.workspace_capture_checkpoint(
+        dict(
+            base_request,
+            kind="git_commit",
+            workspaceLocator={
+                "kind": "sandbox",
+                "workspaceId": "capture-workspace",
+                "relativePath": "repo",
+            },
+        )
+    )
+    assert captured["status"] == "captured"
+
+    external = await sandbox.workspace_capture_checkpoint(
+        dict(
+            base_request,
+            kind="external_state_ref",
+            idempotencyKey="locator-capture-external",
+            workspaceLocator={
+                "kind": "external_state",
+                "artifactRef": "art:sha256:evidence",
+            },
+        )
+    )
+    assert external["status"] == "captured"
+
+    with pytest.raises(WorkspaceLocatorResolutionError) as exc_info:
+        await sandbox.workspace_capture_checkpoint(
+            dict(
+                base_request,
+                kind="git_commit",
+                idempotencyKey="locator-capture-managed",
+                workspaceLocator={
+                    "kind": "managed_runtime",
+                    "runtimeId": "codex",
+                    "agentRunId": "run-1",
+                },
+            )
+        )
+    assert exc_info.value.code == "WORKSPACE_AUTHORITY_MISMATCH"
+
+
+async def test_workspace_locator_kinds_are_enforced_for_recovery_apply(
+    tmp_path: Path,
+) -> None:
+    store = InMemoryArtifactStore()
+    root = _workspace_root(tmp_path)
+    sandbox = TemporalSandboxActivities(workspace_root=root, artifact_store=store)
+    checkpoint_ref = _checkpoint_artifact(
+        store,
+        workspace={
+            "kind": "worktree_archive",
+            "archiveRef": store.put_bytes(
+                b"invalid", content_type="application/octet-stream"
+            ).artifact_ref,
+        },
+    )
+    base_request = {
+        "identity": _identity().model_dump(by_alias=True),
+        "workspacePolicy": "restore_pre_execution",
+        "checkpointRef": checkpoint_ref,
+        "checkpoint": {},
+        "expectedPlanDigest": "sha256:plan",
+        "idempotencyKey": "locator-recovery",
+    }
+
+    sandbox_request = dict(
+        base_request,
+        targetWorkspaceLocator={
+            "kind": "sandbox",
+            "workspaceId": "recovery-workspace",
+            "relativePath": "repo",
+        },
+    )
+    result = await sandbox.workspace_apply_policy(sandbox_request)
+    assert result["status"] == "rejected"
+    assert result["failureCode"] == "artifact_corrupted"
+
+    for locator, code in (
+        (
+            {"kind": "managed_runtime", "runtimeId": "codex", "agentRunId": "run-1"},
+            "WORKSPACE_AUTHORITY_MISMATCH",
+        ),
+        (
+            {"kind": "external_state", "artifactRef": "art:sha256:evidence"},
+            "WORKSPACE_LOCATOR_UNSUPPORTED",
+        ),
+    ):
+        request = dict(base_request, targetWorkspaceLocator=locator)
+        request["idempotencyKey"] = f"locator-recovery-{locator['kind']}"
+        with pytest.raises(WorkspaceLocatorResolutionError) as exc_info:
+            await sandbox.workspace_apply_policy(request)
+        assert exc_info.value.code == code
+
+
+async def test_legacy_workspace_path_usage_emits_compatibility_metric(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    emitter = Mock()
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.activity_runtime.get_metrics_emitter",
+        lambda: emitter,
+    )
+    store = InMemoryArtifactStore()
+    root = _workspace_root(tmp_path)
+    repo = _repo(root)
+    sandbox = TemporalSandboxActivities(workspace_root=root, artifact_store=store)
+
+    await sandbox.workspace_classify_git_effect({"workspacePath": str(repo)})
+
+    emitter.increment.assert_called_once_with(
+        "workspace_locator.compatibility_path_usage",
+        tags={"operation": "classify_git_effect"},
+    )
 
 
 async def test_workspace_apply_policy_handles_degraded_checkpoint_payload(


### PR DESCRIPTION
Issue: MoonLadderStudios/MoonMind#3147

Closes MoonLadderStudios/MoonMind#3147

## Summary

- accept typed workspace locators in recovery/apply handling with owner-specific authority errors
- add operation-tagged compatibility-path usage metrics for legacy raw workspace paths
- complete supported-locator-kind coverage across checkpoint, git-effect, and recovery paths
- document the compatibility metric and migration behavior

## Tests run

- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/schemas/test_workspace_locator_models.py tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py tests/unit/workflows/temporal/workflows/test_run_step_ledger.py` (140 Python tests passed; frontend selector run: 1087 passed, 238 skipped)
- `python -m pytest tests/integration/workflows/temporal/test_step_checkpoint_activities.py tests/integration/reliability/test_escaped_failure_journeys.py -q --tb=short` (38 passed)
- `git diff --check origin/main...HEAD`
- `python -m compileall -q moonmind/schemas/temporal_models.py moonmind/workflows/temporal/activity_runtime.py`

## Remaining risks

- Legacy absolute-path payloads remain intentionally supported during the documented migration window; the new metric is required to determine when that compatibility path can be removed safely.