### PR TITLE
Require fresh Alembic merge checks

### DIFF
--- a/docs/Development/BackendTestSelection.md
+++ b/docs/Development/BackendTestSelection.md
@@ -146,7 +146,9 @@ Conditional GitHub Actions jobs are not suitable as individual branch-protection
 - `unit-fast`, `api-component`, `temporal-boundary`, `integration-ci`, and `reliability-journey` run only when selected.
 - `ci-required` always runs and fails if any selected backend suite did not complete successfully.
 
-Branch protection should require `ci-required` for backend selection, plus any separately required frontend, generated-contract, CodeQL, or repository policy checks.
+Branch protection must require `ci-required` for backend selection, plus any separately required frontend, generated-contract, CodeQL, or repository policy checks. It must also require the standalone `migration-gate` check so migration-graph and clean-database upgrade failures block merges independently of impact selection.
+
+Required checks must run against the current merge candidate. Prefer GitHub Merge Queue, which exercises the checked-in `merge_group` triggers before each queued merge. If Merge Queue is unavailable, require branches to be up to date with `main` before merging. A successful check from an older base revision is not authoritative: two concurrent pull requests can each have a valid migration graph while their combined result creates multiple Alembic heads.
 
 ## Main, Manual, And Scheduled Runs
 

--- a/docs/Development/PreCommitWorkflow.md
+++ b/docs/Development/PreCommitWorkflow.md
@@ -53,7 +53,7 @@ The GitHub unit-test workflow uses impact-aware backend suite selection for pull
 - `reliability_journey`
 - `full_backend`
 
-Branch protection should require the always-running `ci-required` summary job instead of the conditional backend suite jobs. `ci-required` fails when any suite selected by the selector is skipped, cancelled, or unsuccessful.
+Branch protection should require the always-running `ci-required` summary job instead of the conditional backend suite jobs, plus the standalone `migration-gate` check. `ci-required` fails when any suite selected by the selector is skipped, cancelled, or unsuccessful; `migration-gate` independently blocks migration-graph and clean-database upgrade failures.
 
 Routine backend pull requests run the cheap unit safety net first. API/router/auth/db/service changes also run the component suite. Temporal workflow, runtime, activity-boundary, signal/update, replay, or Temporal schema changes run the Temporal boundary suite. Changes under workflow adapters, Temporal workflows, checked-in `.agents/skills` bundles, Docker runtime paths, checkpoint schemas, and reliability replay fixtures run the hermetic reliability journey suite. Docker, integration, database, compose, migration, dependency, or test-runner changes run hermetic `integration_ci` as needed.
 

--- a/tests/unit/tools/test_check_alembic_graph.py
+++ b/tests/unit/tools/test_check_alembic_graph.py
@@ -16,9 +16,8 @@ import check_alembic_graph
 def test_repository_migration_graph_has_exactly_one_head(capsys) -> None:
     assert check_alembic_graph.main() == 0
 
-    assert capsys.readouterr().out == (
+    assert capsys.readouterr().out.startswith(
         "Alembic migration graph has one head: "
-        "339_merge_migration_heads\n"
     )
 
 

--- a/tests/unit/tools/test_check_alembic_graph.py
+++ b/tests/unit/tools/test_check_alembic_graph.py
@@ -13,6 +13,15 @@ if str(TOOLS_DIR) not in sys.path:
 import check_alembic_graph
 
 
+def test_repository_migration_graph_has_exactly_one_head(capsys) -> None:
+    assert check_alembic_graph.main() == 0
+
+    assert capsys.readouterr().out == (
+        "Alembic migration graph has one head: "
+        "339_merge_migration_heads\n"
+    )
+
+
 def test_main_accepts_exactly_one_head(capsys) -> None:
     script = SimpleNamespace(get_heads=lambda: ["revision_1"])
 


### PR DESCRIPTION
## Summary

- exercise the repository's real Alembic graph in the normal unit suite
- require `migration-gate` as a separately enforced merge check in the canonical CI guidance
- require merge candidates to be current through Merge Queue or strict up-to-date branch protection

## Root cause

Two concurrent pull requests each introduced a valid merge revision for the same pair of Alembic heads. Both checks passed against an older `main`, then the second PR merged without being retested after the first merge. The combined graph therefore had two heads.

The immediate duplicate revision was removed independently on `main` by #3286 while this fix was being validated. This PR adds the durable regression and policy protection. Repository branch protection has also been configured to require `ci-required` and `migration-gate`, with strict up-to-date checks and admin enforcement.

## Validation

- `.venv/bin/python -m pytest tests/unit/tools/test_check_alembic_graph.py tests/unit/test_alembic_migration_gate_workflow.py -q --tb=short` — 5 passed
- clean PostgreSQL 17: `alembic upgrade head` — passed
- clean PostgreSQL 17: `alembic current --check-heads` — passed