### PR TITLE
Fix the workflow header being weirdly tall in the sidebar all of a sudden

### DIFF
--- a/frontend/src/browser/collectionSidebarRail.browser.test.ts
+++ b/frontend/src/browser/collectionSidebarRail.browser.test.ts
@@ -140,6 +140,28 @@ describe('collection sidebar rail separator and height', () => {
     expect(getComputedStyle(long.sidebar).borderRightWidth).toBe('1px');
   });
 
+  it('keeps the sticky header at its natural height instead of stretching it to fill the rail', () => {
+    // The rail owns a full-height block size and the table fills it, so a short
+    // list leaves free vertical space. A grid without `align-content: start`
+    // defaults to `stretch` and balloons the auto header row to absorb the
+    // slack. The header height must not depend on how much slack there is: a
+    // three-row list (lots of free space) and a thirty-row list (none) must
+    // render the same header height.
+    const short = render(3, 600);
+    const shortHeader = short.list.querySelector<HTMLElement>('.workflow-workspace-sidebar-header')!;
+    const shortHeaderHeight = shortHeader.getBoundingClientRect().height;
+
+    const long = render(30, 600);
+    const longHeader = long.list.querySelector<HTMLElement>('.workflow-workspace-sidebar-header')!;
+    const longHeaderHeight = longHeader.getBoundingClientRect().height;
+
+    // Same natural height regardless of list length...
+    expect(Math.round(shortHeaderHeight)).toBe(Math.round(longHeaderHeight));
+    // ...and nowhere near the full rail height (a stretched header would be
+    // hundreds of px tall; the natural header row is ~44px + padding).
+    expect(shortHeaderHeight).toBeLessThan(80);
+  });
+
   it('does not move the separator or shrink the rail when the list is filtered down', () => {
     // Begin overflowing, then filter to a single entry (scrollbar disappears).
     const before = render(30, 600);

--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -8316,6 +8316,14 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
 .workflow-workspace-sidebar-table {
   display: grid;
   grid-template-columns: minmax(0, 1fr);
+  /* Pack the header and list rows at the top. The rail now owns a full
+   * `--mm-collection-workspace-block-size` height and this table fills it
+   * (flex: 1 1 auto), so a short list leaves free vertical space. Without an
+   * explicit `align-content`, a grid defaults to `stretch` and would grow the
+   * auto rows — most visibly ballooning the sticky header — to absorb that
+   * slack. `start` keeps the header and rows at their natural height and lets
+   * the leftover space fall below the list instead. */
+  align-content: start;
   flex: 1 1 auto;
   min-height: 0;
   min-width: 0;


### PR DESCRIPTION
Fix the workflow header being weirdly tall in the sidebar all of a sudden