### PR TITLE
Defer managed checkpoint capture until locator exists

### DIFF
--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -567,6 +567,9 @@ RUN_CANONICAL_STEP_STATUS_VOCAB_PATCH = "run-canonical-step-status-vocabulary-v1
 RUN_CANONICAL_STEP_CHECKPOINTS_PATCH = "run-canonical-step-checkpoints-v1"
 RUN_MANAGED_CHECKPOINT_AUTHORITY_PATCH = "run-managed-checkpoint-authority-v1"
 RUN_MANAGED_CHECKPOINT_CAPTURE_PATCH = "run-managed-checkpoint-capture-v1"
+RUN_MANAGED_CHECKPOINT_LOCATOR_GUARD_PATCH = (
+    "run-managed-checkpoint-locator-guard-v1"
+)
 RUN_RUNTIME_EXECUTION_CAPABILITIES_PATCH = "run-runtime-execution-capabilities-v1"
 RUN_DURABLE_FINALIZATION_OUTCOME_PATCH = "run-durable-finalization-outcome-v1"
 FINALIZATION_CHECKPOINT_FAILED = "FINALIZATION_CHECKPOINT_FAILED"
@@ -5029,6 +5032,26 @@ class MoonMindRunWorkflow:
                     and not managed_capture_enabled
                     else resolved_policy.capture_activity
                 ),
+                "capabilityCriticality": resolved_policy.criticality,
+            }
+            return None
+
+        if (
+            resolved_policy.capture_activity
+            == "agent_runtime.capture_workspace_checkpoint"
+            and workflow.patched(RUN_MANAGED_CHECKPOINT_LOCATOR_GUARD_PATCH)
+            and not isinstance(capture_input.get("workspaceLocator"), Mapping)
+        ):
+            # The parent cannot address a managed workspace until AgentRun returns
+            # the runtime-owned locator. In particular, after_prepare and
+            # before_execution run before the child exists. Defer capture instead
+            # of sending a payload the strict activity contract must reject.
+            self._step_checkpoint_capture_outcomes[logical_step_id] = {
+                "status": "deferred",
+                "failureCode": "CHECKPOINT_WORKSPACE_LOCATOR_UNAVAILABLE",
+                "boundary": str(boundary),
+                "captureAuthority": resolved_policy.capture_authority,
+                "captureActivity": resolved_policy.capture_activity,
                 "capabilityCriticality": resolved_policy.criticality,
             }
             return None

--- a/tests/integration/reliability/replays/managed-checkpoint-missing-locator/expected-outcome.json
+++ b/tests/integration/reliability/replays/managed-checkpoint-missing-locator/expected-outcome.json
@@ -1,0 +1,11 @@
+{
+  "activityCalls": [],
+  "captureOutcome": {
+    "status": "deferred",
+    "failureCode": "CHECKPOINT_WORKSPACE_LOCATOR_UNAVAILABLE",
+    "boundary": "after_prepare",
+    "captureAuthority": "managed_runtime",
+    "captureActivity": "agent_runtime.capture_workspace_checkpoint",
+    "capabilityCriticality": "recoverability_only"
+  }
+}

--- a/tests/integration/reliability/replays/managed-checkpoint-missing-locator/manifest.json
+++ b/tests/integration/reliability/replays/managed-checkpoint-missing-locator/manifest.json
@@ -1,0 +1,15 @@
+{
+  "incidentWorkflowId": "mm:8a09888d-27cf-4d15-b351-70615ca21821",
+  "runId": "019f5f15-ea74-73d0-a9d0-255221701af3",
+  "failureShape": "managed checkpoint capture was scheduled before AgentRun returned workspaceLocator",
+  "boundary": "after_prepare",
+  "stepInputs": {
+    "agentKind": "managed",
+    "agentId": "codex_cli"
+  },
+  "escapedActivityPayload": {
+    "schemaVersion": "v1",
+    "checkpointKind": "worktree_archive",
+    "expectedRuntimeId": "codex_cli"
+  }
+}

--- a/tests/integration/reliability/test_escaped_failure_journeys.py
+++ b/tests/integration/reliability/test_escaped_failure_journeys.py
@@ -330,6 +330,61 @@ async def test_sandbox_checkpoint_rejects_managed_workspace_without_resolving_pa
     assert sandbox_calls == expected["sandboxResolverCalls"] == 0
 
 
+async def test_managed_checkpoint_waits_for_authoritative_locator(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Replay mm:8a09888d before the AgentRun workspace exists."""
+    replay_id = "managed-checkpoint-missing-locator"
+    manifest = load_replay(replay_id, "manifest.json")
+    expected = load_replay(replay_id, "expected-outcome.json")
+    parent = MoonMindRunWorkflow()
+    parent_info = SimpleNamespace(
+        namespace="default",
+        workflow_id=manifest["incidentWorkflowId"],
+        run_id=manifest["runId"],
+        task_queue="mm.workflow.merge_automation",
+        search_attributes={},
+    )
+    monkeypatch.setattr(run_workflow_module.workflow, "info", lambda: parent_info)
+    monkeypatch.setattr(run_workflow_module.workflow, "patched", lambda _patch: True)
+
+    activity_calls: list[str] = []
+
+    async def capture_activity(
+        activity_type: str,
+        _payload: dict[str, object],
+        **_kwargs: object,
+    ) -> object:
+        activity_calls.append(activity_type)
+        raise AssertionError("managed capture ran without an authoritative locator")
+
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "execute_activity",
+        capture_activity,
+    )
+    now = datetime(2026, 7, 14, 5, 25, tzinfo=timezone.utc)
+    parent._initialize_step_ledger(
+        ordered_nodes=[{"id": "node-1", "inputs": {"title": "Investigate"}}],
+        dependency_map={"node-1": []},
+        updated_at=now,
+    )
+    parent._mark_step_running("node-1", updated_at=now, summary="Investigating")
+    parent._record_step_workspace_capture_input("node-1", manifest["stepInputs"])
+
+    checkpoint_ref = await parent._record_canonical_step_checkpoint(
+        "node-1",
+        boundary=manifest["boundary"],
+        updated_at=now,
+    )
+
+    assert checkpoint_ref is None
+    assert activity_calls == expected["activityCalls"]
+    assert parent._step_checkpoint_capture_outcomes["node-1"] == expected[
+        "captureOutcome"
+    ]
+
+
 async def test_codex_oauth_failure_preserves_primary_error_and_managed_authority(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
@@ -3326,6 +3326,103 @@ async def test_managed_checkpoint_capability_gap_reaches_finalization_outcome(
     }
 
 
+@pytest.mark.asyncio
+async def test_managed_checkpoint_defers_until_runtime_locator_is_available(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _configure_workflow_runtime(monkeypatch)
+    monkeypatch.setattr(run_module.workflow, "patched", lambda _patch_id: True)
+    workflow = MoonMindRunWorkflow()
+    now = datetime(2026, 7, 14, 5, 25, tzinfo=UTC)
+    workflow._initialize_step_ledger(
+        ordered_nodes=[{"id": "node-1", "inputs": {"title": "Investigate"}}],
+        dependency_map={"node-1": []},
+        updated_at=now,
+    )
+    workflow._mark_step_running("node-1", updated_at=now, summary="Investigating")
+    workflow._record_step_workspace_capture_input(
+        "node-1",
+        {
+            "agentKind": "managed",
+            "agentId": "codex_cli",
+        },
+    )
+
+    async def unexpected_activity(*_args: Any, **_kwargs: Any) -> Any:
+        raise AssertionError("capture must wait for the AgentRun workspace locator")
+
+    monkeypatch.setattr(run_module.workflow, "execute_activity", unexpected_activity)
+
+    checkpoint_ref = await workflow._record_canonical_step_checkpoint(
+        "node-1", boundary="after_prepare", updated_at=now
+    )
+
+    assert checkpoint_ref is None
+    assert workflow._step_checkpoint_capture_outcomes["node-1"] == {
+        "status": "deferred",
+        "failureCode": "CHECKPOINT_WORKSPACE_LOCATOR_UNAVAILABLE",
+        "boundary": "after_prepare",
+        "captureAuthority": "managed_runtime",
+        "captureActivity": "agent_runtime.capture_workspace_checkpoint",
+        "capabilityCriticality": "recoverability_only",
+    }
+
+
+@pytest.mark.asyncio
+async def test_managed_checkpoint_locator_guard_replays_previous_activity_shape(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _configure_workflow_runtime(monkeypatch)
+    monkeypatch.setattr(
+        run_module.workflow,
+        "patched",
+        lambda patch_id: patch_id
+        != run_module.RUN_MANAGED_CHECKPOINT_LOCATOR_GUARD_PATCH,
+    )
+    workflow = MoonMindRunWorkflow()
+    workflow._record_step_workspace_capture_input(
+        "node-1",
+        {
+            "agentKind": "managed",
+            "agentId": "codex_cli",
+        },
+    )
+    captured: list[dict[str, Any]] = []
+
+    async def previous_capture_activity(
+        activity_type: str,
+        payload: dict[str, Any],
+        **_kwargs: Any,
+    ) -> dict[str, Any]:
+        captured.append({"activity": activity_type, "payload": payload})
+        return {
+            "status": "captured",
+            "workspace": {"kind": "worktree_archive"},
+            "diagnosticRefs": [],
+        }
+
+    monkeypatch.setattr(
+        run_module.workflow,
+        "execute_activity",
+        previous_capture_activity,
+    )
+    identity = StepExecutionIdentityModel(
+        workflowId="workflow-1",
+        runId="run-1",
+        logicalStepId="node-1",
+        executionOrdinal=1,
+    )
+
+    await workflow._capture_canonical_step_checkpoint_workspace(
+        "node-1", identity=identity, boundary="after_prepare"
+    )
+
+    assert [call["activity"] for call in captured] == [
+        "agent_runtime.capture_workspace_checkpoint"
+    ]
+    assert "workspaceLocator" not in captured[0]["payload"]
+
+
 def test_run_derives_managed_authority_from_agent_id() -> None:
     workflow = MoonMindRunWorkflow()
 


### PR DESCRIPTION
## Summary

- defer managed-runtime checkpoint capture until `MoonMind.AgentRun` returns an authoritative `workspaceLocator`
- preserve replay compatibility for histories recorded before the locator guard with a Temporal patch marker
- add unit coverage for new and prior command shapes plus an escaped-failure replay for `mm:8a09888d-27cf-4d15-b351-70615ca21821`

## Root cause and impact

Managed checkpoint capture was enabled for the `after_prepare` boundary even though the managed AgentRun had not started and no runtime-owned workspace locator existed. The parent therefore scheduled `agent_runtime.capture_workspace_checkpoint` without its required `workspaceLocator`, producing the repeated Pydantic validation failure seen in three consecutive workflows.

New histories now record a deferred, recoverability-only capture outcome at pre-AgentRun boundaries. After the child returns the authoritative locator, normal managed checkpoint capture can proceed. Existing histories retain their recorded command shape.

## Validation

- affected step-ledger unit file: 85 passed
- escaped-failure reliability corpus: 10 passed
- isolated Compose `integration_ci` suite: 445 passed, 1 skipped
- full Temporal boundary suite: 2,789 passed; one local-configuration-sensitive assertion expected the repository `fail` default while this checkout's `.env` selects `draft_pr`; the assertion passed when rerun with the CI/default value
- Ruff: passed for all changed Python files
