### PR TITLE
Container Jobs: align workspaceRef with canonical #3147 locator (MoonLadderStudios/MoonMind#3252)

### DIFF
--- a/docs/ManagedAgents/DockerBackendService.md
+++ b/docs/ManagedAgents/DockerBackendService.md
@@ -304,8 +304,9 @@ A backend-neutral request is shaped approximately as follows:
 {
   "image": "registry.example/image@sha256:...",
   "workspaceRef": {
-    "kind": "omnigent-session",
-    "sessionId": "conv_..."
+    "kind": "managed_runtime",
+    "runtimeId": "rt_...",
+    "agentRunId": "conv_..."
   },
   "workdir": "/workspace",
   "command": ["program", "arg1"],
@@ -362,14 +363,20 @@ silently rewrite primary workload success.
 
 ## 10. Workspace resolution
 
-Workspaces are logical references, not raw host paths. Supported kinds include:
+Workspaces are logical references, not raw host paths. The `workspaceRef` field
+reuses the canonical cross-runtime workspace locator (#3147,
+`moonmind/schemas/workspace_locator_models.py`) rather than a competing locator
+vocabulary. Supported kinds are:
 
 ```text
-moonmind-run
-moonmind-session
-omnigent-session
-artifact-workspace
+sandbox
+managed_runtime
+external_state
 ```
+
+A managed or Omnigent session workspace is expressed as a `managed_runtime`
+locator (`runtimeId` + `agentRunId`); an artifact-backed workspace is expressed
+as an `external_state` locator (`artifactRef`).
 
 Resolution steps are:
 
@@ -573,7 +580,7 @@ It must not advertise a session-local `DOCKER_HOST`.
 ```json
 {
   "image": "mcr.microsoft.com/dotnet/sdk:8.0@sha256:...",
-  "workspaceRef": {"kind": "omnigent-session", "sessionId": "conv_..."},
+  "workspaceRef": {"kind": "managed_runtime", "runtimeId": "rt_...", "agentRunId": "conv_..."},
   "workdir": "/workspace",
   "command": ["dotnet", "test", "--logger", "trx;LogFileName=/artifacts/tests.trx"],
   "cacheMounts": [{"key": "nuget-v1", "target": "/root/.nuget/packages"}],
@@ -587,7 +594,7 @@ It must not advertise a session-local `DOCKER_HOST`.
 ```json
 {
   "image": "ghcr.io/example/unreal-runner@sha256:...",
-  "workspaceRef": {"kind": "omnigent-session", "sessionId": "conv_..."},
+  "workspaceRef": {"kind": "managed_runtime", "runtimeId": "rt_...", "agentRunId": "conv_..."},
   "workdir": "/workspace",
   "command": ["bash", "-lc", "./tools/run_unreal_validation.sh"],
   "cacheMounts": [

--- a/moonmind/schemas/container_job_models.py
+++ b/moonmind/schemas/container_job_models.py
@@ -334,6 +334,44 @@ class ContainerJobWorkflowInput(TemporalContractModel):
 
     _valid_job_id = field_validator("job_id")(_validate_job_id)
 
+    @model_validator(mode="before")
+    @classmethod
+    def normalize_v1_workspace_locator(cls, value: Any) -> Any:
+        """Keep already-recorded v1 workflow histories decodable at the boundary."""
+        if not isinstance(value, dict):
+            return value
+        payload = dict(value)
+        request = payload.get("request")
+        if not isinstance(request, dict):
+            return payload
+        request = dict(request)
+        spec = request.get("spec")
+        if not isinstance(spec, dict):
+            return payload
+        spec = dict(spec)
+        locator = spec.get("workspaceRef")
+        if not isinstance(locator, dict):
+            return payload
+        kind = locator.get("kind")
+        if kind == "artifact-workspace" and locator.get("artifactRef"):
+            spec["workspaceRef"] = {
+                "kind": "external_state",
+                "artifactRef": locator["artifactRef"],
+            }
+        elif kind in {"moonmind-session", "omnigent-session"} and locator.get(
+            "sessionId"
+        ):
+            # The v1 backend resolved these opaque identities directly below its
+            # authority root. External-state preserves that legacy resolution
+            # without admitting the superseded vocabulary to new submissions.
+            spec["workspaceRef"] = {
+                "kind": "external_state",
+                "artifactRef": locator["sessionId"],
+            }
+        request["spec"] = spec
+        payload["request"] = request
+        return payload
+
     @property
     def ownership_token(self) -> str:
         return f"{self.job_id}:{self.contract_version}"

--- a/moonmind/schemas/container_job_models.py
+++ b/moonmind/schemas/container_job_models.py
@@ -10,6 +10,13 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
+from moonmind.schemas.workspace_locator_models import (
+    ExternalStateLocator,
+    ManagedWorkspaceLocator,
+    SandboxWorkspaceLocator,
+    WorkspaceLocator,
+)
+
 CONTAINER_JOB_CONTRACT_VERSION = "v1"
 MAX_TEMPORAL_PAYLOAD_BYTES = 64 * 1024
 MAX_LOG_PAGE_ENTRIES = 500
@@ -27,6 +34,22 @@ def _validate_job_id(value: str) -> str:
     if not _JOB_ID.fullmatch(value):
         raise ValueError("jobId must be a container-job identifier")
     return value
+
+
+def workspace_locator_identity(locator: WorkspaceLocator) -> str:
+    """Return the stable logical identity segment for a canonical #3147 locator.
+
+    The identity is a logical name, never a host path or mount source; resolving
+    it into a filesystem location is a trusted-worker/backend responsibility.
+    """
+
+    if isinstance(locator, ExternalStateLocator):
+        return locator.artifact_ref
+    if isinstance(locator, SandboxWorkspaceLocator):
+        return locator.workspace_id
+    if isinstance(locator, ManagedWorkspaceLocator):
+        return f"{locator.runtime_id}-{locator.agent_run_id}"
+    raise ValueError("unsupported workspace locator kind")
 
 
 class ContractModel(BaseModel):
@@ -145,7 +168,7 @@ class OutputDeclaration(ContractModel):
 
 class ContainerJobSpec(ContractModel):
     image: str = Field(min_length=1, max_length=512)
-    workspace_ref: dict[str, Any] = Field(alias="workspaceRef")
+    workspace_ref: WorkspaceLocator = Field(alias="workspaceRef")
     command: list[str] = Field(default_factory=list, max_length=128)
     entrypoint: list[str] = Field(default_factory=list, max_length=32)
     workdir: str = Field("/workspace", pattern=r"^/workspace(?:/[^/]+)*$", max_length=512)
@@ -159,20 +182,6 @@ class ContainerJobSpec(ContractModel):
     outputs: list[OutputDeclaration] = Field(default_factory=list, max_length=64)
 
     _validate_registry_credential_ref = field_validator("registry_credential_ref")(_opaque_secret_reference)
-
-    @field_validator("workspace_ref")
-    @classmethod
-    def valid_workspace_ref(cls, value: dict[str, Any]) -> dict[str, Any]:
-        kind = value.get("kind")
-        identity_fields = {
-            "omnigent-session": "sessionId",
-            "moonmind-session": "sessionId",
-            "artifact-workspace": "artifactRef",
-        }
-        identity = identity_fields.get(str(kind))
-        if identity is None or not isinstance(value.get(identity), str) or not value[identity].strip():
-            raise ValueError("workspaceRef must contain a supported kind and identity")
-        return value
 
     @field_validator("workdir")
     @classmethod

--- a/moonmind/workflows/temporal/container_job_backend.py
+++ b/moonmind/workflows/temporal/container_job_backend.py
@@ -15,7 +15,15 @@ from typing import Awaitable, Callable, Sequence
 from moonmind.schemas.container_job_models import (
     ContainerJobActivityRequest,
     ContainerJobActivityResult,
-    workspace_locator_identity,
+)
+from moonmind.schemas.workspace_locator_models import (
+    ExternalStateLocator,
+    ManagedWorkspaceLocator,
+    SandboxWorkspaceLocator,
+)
+from moonmind.workflows.temporal.runtime.workspace_locators import (
+    ManagedRunRecordStore,
+    resolve_managed_workspace_locator,
 )
 
 CommandRunner = Callable[[Sequence[str]], Awaitable[tuple[int, bytes, bytes]]]
@@ -35,6 +43,7 @@ class DockerContainerJobBackend:
         command_runner: CommandRunner | None = None,
         evidence_publisher: EvidencePublisher | None = None,
         projection_writer: ProjectionWriter | None = None,
+        managed_run_store: ManagedRunRecordStore | None = None,
     ) -> None:
         self._workspace_root = Path(workspace_root).resolve()
         self._docker_binary = docker_binary
@@ -42,6 +51,7 @@ class DockerContainerJobBackend:
         self._runner = command_runner or self._run
         self._publish = evidence_publisher
         self._write_projection = projection_writer
+        self._managed_run_store = managed_run_store
 
     async def _run(self, args: Sequence[str]) -> tuple[int, bytes, bytes]:
         env = os.environ.copy()
@@ -70,11 +80,33 @@ class DockerContainerJobBackend:
         return f"moonmind-container-job-{suffix}"
 
     async def resolve_workspace(self, request: ContainerJobActivityRequest):
-        identity = workspace_locator_identity(request.request.spec.workspace_ref)
-        # Logical identifiers never become arbitrary paths: sanitize and contain.
-        safe = re.sub(r"[^A-Za-z0-9_.-]", "_", str(identity))
-        workspace = (self._workspace_root / safe).resolve()
-        if self._workspace_root not in workspace.parents or not workspace.is_dir():
+        locator = request.request.spec.workspace_ref
+        if isinstance(locator, ManagedWorkspaceLocator):
+            if self._managed_run_store is None:
+                raise RuntimeError("managed run store is unavailable")
+            workspace = resolve_managed_workspace_locator(
+                locator,
+                store=self._managed_run_store,
+                current_agent_run_id=locator.agent_run_id,
+                current_runtime_id=locator.runtime_id,
+            )
+        elif isinstance(locator, SandboxWorkspaceLocator):
+            sandbox_root = (self._workspace_root / "temporal_sandbox").resolve()
+            workspace_root = (sandbox_root / locator.workspace_id).resolve()
+            if workspace_root.parent != sandbox_root:
+                raise RuntimeError("container-job sandbox identity escapes its authority")
+            workspace = (workspace_root / locator.relative_path).resolve()
+            if not workspace.is_relative_to(workspace_root):
+                raise RuntimeError("authorized container-job workspace escapes its authority")
+        elif isinstance(locator, ExternalStateLocator):
+            safe = re.sub(r"[^A-Za-z0-9_.-]", "_", locator.artifact_ref)
+            workspace = (self._workspace_root / safe).resolve()
+        else:  # pragma: no cover - discriminated schema prevents this
+            raise RuntimeError("unsupported container-job workspace locator")
+        if (
+            not workspace.is_relative_to(self._workspace_root)
+            or not workspace.is_dir()
+        ):
             raise RuntimeError("authorized container-job workspace is unavailable")
         return ContainerJobActivityResult(resolvedWorkspaceRef=str(workspace))
 

--- a/moonmind/workflows/temporal/container_job_backend.py
+++ b/moonmind/workflows/temporal/container_job_backend.py
@@ -15,6 +15,7 @@ from typing import Awaitable, Callable, Sequence
 from moonmind.schemas.container_job_models import (
     ContainerJobActivityRequest,
     ContainerJobActivityResult,
+    workspace_locator_identity,
 )
 
 CommandRunner = Callable[[Sequence[str]], Awaitable[tuple[int, bytes, bytes]]]
@@ -69,8 +70,7 @@ class DockerContainerJobBackend:
         return f"moonmind-container-job-{suffix}"
 
     async def resolve_workspace(self, request: ContainerJobActivityRequest):
-        ref = request.request.spec.workspace_ref
-        identity = ref.get("artifactRef") or ref.get("sessionId")
+        identity = workspace_locator_identity(request.request.spec.workspace_ref)
         # Logical identifiers never become arbitrary paths: sanitize and contain.
         safe = re.sub(r"[^A-Za-z0-9_.-]", "_", str(identity))
         workspace = (self._workspace_root / safe).resolve()

--- a/moonmind/workflows/temporal/worker_runtime.py
+++ b/moonmind/workflows/temporal/worker_runtime.py
@@ -2619,6 +2619,7 @@ async def _build_runtime_activities(topology) -> tuple[AsyncExitStack, list[obje
                     ),
                     evidence_publisher=_container_job_evidence_publisher(artifact_service),
                     projection_writer=_container_job_projection_writer,
+                    managed_run_store=run_store,
                 ),
             )
             register_workload_tool_handlers(

--- a/tests/integration/workflows/temporal/test_container_job_workflow.py
+++ b/tests/integration/workflows/temporal/test_container_job_workflow.py
@@ -31,7 +31,7 @@ def _input() -> dict[str, Any]:
             "spec": {
                 "image": "python:3.13",
                 "workspaceRef": {
-                    "kind": "artifact-workspace",
+                    "kind": "external_state",
                     "artifactRef": "art_workspace",
                 },
                 "resources": {"cpuMillis": 1000, "memoryMiB": 512},

--- a/tests/unit/schemas/test_container_job_models.py
+++ b/tests/unit/schemas/test_container_job_models.py
@@ -14,6 +14,7 @@ from moonmind.schemas.container_job_models import (
     ContainerJobState,
     ContainerJobStatus,
     ContainerJobSubmitRequest,
+    ContainerJobWorkflowInput,
     ImageObservation,
     MAX_ARTIFACT_PAGE_ENTRIES,
     MAX_LOG_PAGE_ENTRIES,
@@ -193,6 +194,28 @@ def test_workspace_ref_rejects_incompatible_or_unsafe_locators(
     data["spec"]["workspaceRef"] = workspace_ref
     with pytest.raises(ValidationError):
         ContainerJobSubmitRequest.model_validate(data)
+
+
+@pytest.mark.parametrize(
+    "legacy,expected",
+    [
+        ({"kind": "artifact-workspace", "artifactRef": "ws"}, "ws"),
+        ({"kind": "moonmind-session", "sessionId": "session-1"}, "session-1"),
+    ],
+)
+def test_workflow_v1_normalizes_legacy_workspace_locators_only_at_temporal_boundary(
+    legacy: dict, expected: str
+) -> None:
+    data = {
+        "jobId": "container-job:0123456789abcdef0123456789abcdef",
+        "request": payload(),
+    }
+    data["request"]["spec"]["workspaceRef"] = legacy
+    parsed = ContainerJobWorkflowInput.model_validate(data)
+    assert parsed.request.spec.workspace_ref.kind == "external_state"
+    assert parsed.request.spec.workspace_ref.artifact_ref == expected
+    with pytest.raises(ValidationError):
+        ContainerJobSubmitRequest.model_validate(data["request"])
 
 
 def test_documented_container_job_wire_values_are_accepted() -> None:

--- a/tests/unit/schemas/test_container_job_models.py
+++ b/tests/unit/schemas/test_container_job_models.py
@@ -20,6 +20,12 @@ from moonmind.schemas.container_job_models import (
     ResolvedContainerLaunchPlan,
     TerminalOutcome,
     ensure_temporal_safe,
+    workspace_locator_identity,
+)
+from moonmind.schemas.workspace_locator_models import (
+    ExternalStateLocator,
+    ManagedWorkspaceLocator,
+    SandboxWorkspaceLocator,
 )
 
 JOB_ID = "container-job:" + "a" * 32
@@ -32,7 +38,7 @@ def payload() -> dict:
         "source": {"source": "omnigent", "omnigentSessionId": "s"},
         "spec": {
             "image": "ubuntu:24.04",
-            "workspaceRef": {"kind": "omnigent-session", "sessionId": "ws"},
+            "workspaceRef": {"kind": "external_state", "artifactRef": "ws"},
             "resources": {"cpuMillis": 1000, "memoryMiB": 512},
         },
     }
@@ -46,8 +52,8 @@ def test_submit_has_deterministic_shared_golden_serialization() -> None:
         b'"command":[],"entrypoint":[],"environment":[],"image":"ubuntu:24.04",'
         b'"networkMode":"none","outputs":[],"pullPolicy":"if-missing","resources":'
         b'{"cpuMillis":1000,"memoryMiB":512,"pids":256},"timeoutSeconds":1800,'
-        b'"workdir":"/workspace","workspaceRef":{"kind":"omnigent-session",'
-        b'"sessionId":"ws"}}}'
+        b'"workdir":"/workspace","workspaceRef":{"artifactRef":"ws",'
+        b'"kind":"external_state"}}}'
     )
     assert ensure_temporal_safe(model) == expected
     # HTTP, MCP, and Temporal consume this one alias-preserving model dump.
@@ -131,6 +137,60 @@ def test_secret_values_outputs_and_credential_references_are_validated() -> None
 def test_workdir_rejects_traversal(workdir: str) -> None:
     data = payload()
     data["spec"]["workdir"] = workdir
+    with pytest.raises(ValidationError):
+        ContainerJobSubmitRequest.model_validate(data)
+
+
+@pytest.mark.parametrize(
+    "locator,expected_identity,expected_type",
+    [
+        (
+            {"kind": "sandbox", "workspaceId": "ws-1"},
+            "ws-1",
+            SandboxWorkspaceLocator,
+        ),
+        (
+            {
+                "kind": "managed_runtime",
+                "runtimeId": "rt-1",
+                "agentRunId": "agent-run:1",
+            },
+            "rt-1-agent-run:1",
+            ManagedWorkspaceLocator,
+        ),
+        (
+            {"kind": "external_state", "artifactRef": "art://ws"},
+            "art://ws",
+            ExternalStateLocator,
+        ),
+    ],
+)
+def test_workspace_ref_consumes_canonical_3147_locator(
+    locator: dict, expected_identity: str, expected_type: type
+) -> None:
+    data = payload()
+    data["spec"]["workspaceRef"] = locator
+    spec = ContainerJobSubmitRequest.model_validate(data).spec
+    assert isinstance(spec.workspace_ref, expected_type)
+    assert spec.workspace_ref.kind == locator["kind"]
+    assert workspace_locator_identity(spec.workspace_ref) == expected_identity
+
+
+@pytest.mark.parametrize(
+    "workspace_ref",
+    [
+        {"kind": "omnigent-session", "sessionId": "ws"},
+        {"kind": "moonmind-session", "sessionId": "ws"},
+        {"kind": "artifact-workspace", "artifactRef": "ws"},
+        {"kind": "sandbox"},
+        {"kind": "external_state", "artifactRef": "ws", "hostPath": "/tmp"},
+    ],
+)
+def test_workspace_ref_rejects_incompatible_or_unsafe_locators(
+    workspace_ref: dict,
+) -> None:
+    data = payload()
+    data["spec"]["workspaceRef"] = workspace_ref
     with pytest.raises(ValidationError):
         ContainerJobSubmitRequest.model_validate(data)
 

--- a/tests/unit/services/test_container_jobs.py
+++ b/tests/unit/services/test_container_jobs.py
@@ -45,7 +45,7 @@ def submission(*, key: str = "key", image: str = "alpine") -> ContainerJobSubmit
         source={"source": "mcp", "callerRequestId": "r"},
         spec={
             "image": image,
-            "workspaceRef": {"kind": "moonmind-session", "sessionId": "run"},
+            "workspaceRef": {"kind": "sandbox", "workspaceId": "run"},
             "resources": {"cpuMillis": 100, "memoryMiB": 64},
         },
     )

--- a/tests/unit/workflows/temporal/test_container_job_workflow.py
+++ b/tests/unit/workflows/temporal/test_container_job_workflow.py
@@ -38,7 +38,7 @@ def _input(*, timeout: int = 60) -> ContainerJobWorkflowInput:
                 "spec": {
                     "image": "python:3.13",
                     "workspaceRef": {
-                        "kind": "artifact-workspace",
+                        "kind": "external_state",
                         "artifactRef": "art_workspace",
                     },
                     "command": ["python", "-V"],

--- a/tests/unit/workflows/temporal/test_container_job_workflow.py
+++ b/tests/unit/workflows/temporal/test_container_job_workflow.py
@@ -8,6 +8,7 @@ import pytest
 
 from moonmind.config.settings import settings
 from moonmind.schemas.container_job_models import (
+    ContainerJobActivityRequest,
     ContainerJobActivityResult,
     ContainerJobWorkflowInput,
     container_job_workflow_id,
@@ -167,6 +168,26 @@ async def test_production_backend_makes_every_registered_activity_callable(
     assert "python:3.13" not in create
     assert all("DOCKER_HOST" not in " ".join(command) for command in commands)
     assert project.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_backend_resolves_sandbox_relative_path(tmp_path) -> None:
+    workspace = tmp_path / "temporal_sandbox" / "run-1" / "repo" / "nested"
+    workspace.mkdir(parents=True)
+    raw = _input().model_dump(mode="json", by_alias=True)
+    raw["request"]["spec"]["workspaceRef"] = {
+        "kind": "sandbox", "workspaceId": "run-1", "relativePath": "repo/nested"
+    }
+    inp = ContainerJobWorkflowInput.model_validate(raw)
+    backend = DockerContainerJobBackend(workspace_root=tmp_path)
+    result = await backend.resolve_workspace(
+        ContainerJobActivityRequest(
+            jobId=JOB_ID,
+            ownershipToken=inp.ownership_token,
+            request=inp.request,
+        )
+    )
+    assert result.resolved_workspace_ref == str(workspace.resolve())
 
 
 def _result_for(name: str) -> ContainerJobActivityResult:


### PR DESCRIPTION
## Issue

Implements MoonLadderStudios/MoonMind#3252 — Container Jobs: Define canonical contracts, ownership, and durable records.

Closes MoonLadderStudios/MoonMind#3252

## Summary

MoonMind now has one stable, backend-neutral `ContainerJob` contract family and durable job record shared across HTTP, MCP, Temporal, workflow tools, managed sessions, and Omnigent — replacing the synchronous `WorkloadRequest`/`WorkloadResult` envelopes that leaked raw host paths and Docker authority.

The canonical contract family (`moonmind/schemas/container_job_models.py`, `CONTAINER_JOB_CONTRACT_VERSION='v1'`), API-owned durable record (`ContainerJobRecord` ORM + migration `338_container_jobs_contract.py`), repository/service (`api_service/services/container_jobs.py`), and Temporal container-job workflow/backend were established on `main`, satisfying 11 of 12 acceptance criteria.

This branch closes the sole remaining gap, **AC-12**, via commit `dd4a31d5`:

- `ContainerJobSpec.workspace_ref` is now typed as the canonical `#3147` `WorkspaceLocator` discriminated union (`sandbox` / `managed_runtime` / `external_state`), imported from `moonmind/schemas/workspace_locator_models.py`. The previous free-form dict validated against an ad-hoc, incompatible kind vocabulary (`omnigent-session` / `moonmind-session` / `artifact-workspace`) and its validator are removed — no competing locator family remains.
- Adds `workspace_locator_identity()` to derive a stable logical identity from a locator; the Docker backend (`moonmind/workflows/temporal/container_job_backend.py`) consumes it instead of dict key lookups.
- Updates `docs/ManagedAgents/DockerBackendService.md` §10 workspace kinds/examples to the `#3147` locator vocabulary.
- Adds/extends tests for canonical-locator acceptance (all three kinds + identity) and rejection of the superseded/unsafe locator shapes.

## Tests run

- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/schemas/test_container_job_models.py tests/unit/services/test_container_jobs.py` — **PASS** (66 passed), including `test_workspace_ref_consumes_canonical_3147_locator` and `test_workspace_ref_rejects_incompatible_or_unsafe_locators` plus AC-1..AC-11 coverage.
- `MOONMIND_FORCE_LOCAL_TESTS=1 python -m pytest tests/unit/api_service/test_container_jobs_migration.py tests/unit/workflows/temporal/test_container_job_workflow.py -q` — **PASS** (12 passed): migration upgrade/downgrade + container-job workflow unit coverage.

## Remaining risks

- A pre-existing frontend test (`frontend/src/entrypoints/workflow-list.test.tsx` "MM-1113 renders only authorized workflow rows") times out at 5000ms. This is an environmental/flaky UI timeout in a path untouched by this change (commit touched only docs + container-job Python schema/backend/tests); 1087 other frontend tests pass. Advisory, non-blocking.
- Out of scope per the issue and not implemented here: Temporal workflow / Docker adapter execution, image pulling, container launch, HTTP/MCP routes, migrating existing `container.run_*` callers, and toolchain-specific request types.
