### PR TITLE
Docker Backend: system-daemon adapter and safe structured execution (MoonLadderStudios/MoonMind#3254)

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -47,7 +47,9 @@ services:
       - TEMPORAL_ARTIFACT_S3_SECRET_ACCESS_KEY=${TEMPORAL_ARTIFACT_S3_SECRET_ACCESS_KEY:-minioadmin}
       - TEMPORAL_DASHBOARD_SUBMIT_ENABLED=true
       - TEMPORAL_WORKFLOW_EDITING_ENABLED=${TEMPORAL_WORKFLOW_EDITING_ENABLED:-true}
-      - SYSTEM_DOCKER_HOST=${SYSTEM_DOCKER_HOST:-tcp://docker-proxy:2375}
+      # The API needs DOCKER_HOST only for its remaining direct Docker paths
+      # (terminal exec, OAuth auth-runner teardown). SYSTEM_DOCKER_HOST is a
+      # trusted-worker-only backend selector and is not read by the API service.
       - DOCKER_HOST=${SYSTEM_DOCKER_HOST:-tcp://docker-proxy:2375}
       - MOONMIND_OAUTH_RUNNER_IMAGE=${MOONMIND_OAUTH_RUNNER_IMAGE:-${MOONMIND_IMAGE:-ghcr.io/moonladderstudios/moonmind:latest}}
       - MOONMIND_ALLOW_LOCAL_ENCRYPTION_KEY_GENERATION=${MOONMIND_ALLOW_LOCAL_ENCRYPTION_KEY_GENERATION:-1}

--- a/moonmind/config/container_backend_settings.py
+++ b/moonmind/config/container_backend_settings.py
@@ -1,0 +1,177 @@
+"""Normalized container-job backend settings (MoonLadderStudios/MoonMind#3254).
+
+This is the single place that resolves the deployment-owned container-job
+backend configuration: whether the backend is enabled, which backend ``kind``
+is selected, the deployment-owned ``defaultBackendRef``, the Docker endpoint
+(sourced from deployment configuration only, never from a caller), whether the
+raw Docker CLI escape hatch is enabled, and the non-overridable resource
+ceilings enforced at the final launch boundary.
+
+Keeping this resolution in one module means public HTTP, MCP, workflow,
+managed-session, and Omnigent contracts stay backend-neutral: none of them
+carries an endpoint, socket path, or TLS material. Only trusted worker
+construction reads these settings.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Final, Mapping
+
+#: The only backend kind this deployment supports. A second backend kind
+#: (Podman, containerd, Kubernetes, endpoint pools) is explicitly out of scope.
+SUPPORTED_CONTAINER_BACKEND_KINDS: Final[frozenset[str]] = frozenset({"docker-engine"})
+
+#: Deployment default when the endpoint is not otherwise configured. Matches the
+#: ``docker-proxy`` service the ``temporal-worker-agent-runtime`` container reaches.
+_DEFAULT_DOCKER_ENDPOINT: Final[str] = "tcp://docker-proxy:2375"
+
+_TRUTHY: Final[frozenset[str]] = frozenset({"1", "true", "yes", "on"})
+_FALSEY: Final[frozenset[str]] = frozenset({"0", "false", "no", "off", ""})
+
+
+class ContainerBackendConfigError(RuntimeError):
+    """Raised when the container-job backend configuration is invalid."""
+
+
+class ContainerBackendReadinessError(RuntimeError):
+    """Raised when a configured backend endpoint is missing or unreachable."""
+
+
+def _coerce_bool(value: object, *, default: bool) -> bool:
+    if value is None:
+        return default
+    text = str(value).strip().lower()
+    if text in _TRUTHY:
+        return True
+    if text in _FALSEY:
+        return default if text == "" else False
+    raise ContainerBackendConfigError(
+        f"container backend boolean flag must be truthy/falsey, got {value!r}"
+    )
+
+
+def _coerce_int(value: object, *, default: int, minimum: int) -> int:
+    if value is None or str(value).strip() == "":
+        return default
+    try:
+        parsed = int(str(value).strip())
+    except ValueError as exc:
+        raise ContainerBackendConfigError(
+            f"container backend integer ceiling must be an integer, got {value!r}"
+        ) from exc
+    if parsed < minimum:
+        raise ContainerBackendConfigError(
+            f"container backend integer ceiling must be >= {minimum}, got {parsed}"
+        )
+    return parsed
+
+
+@dataclass(frozen=True)
+class ContainerBackendSettings:
+    """Resolved, deployment-owned container-job backend configuration.
+
+    The ceilings here are non-overridable: a caller-supplied launch spec that
+    requests more than a ceiling is rejected at the final launch boundary rather
+    than silently clamped, so billing-relevant resource values never drift.
+    """
+
+    enabled: bool
+    kind: str
+    default_backend_ref: str
+    endpoint: str | None
+    raw_cli_enabled: bool
+    max_cpu_millis: int
+    max_memory_mib: int
+    max_pids: int
+    shm_size_mib: int
+    max_timeout_seconds: int
+    max_output_bytes: int
+
+    def require_endpoint(self) -> str:
+        """Return the configured endpoint or fail readiness with a bounded error."""
+
+        if self.endpoint is None or not self.endpoint.strip():
+            raise ContainerBackendReadinessError(
+                "container backend endpoint is not configured; set "
+                "SYSTEM_DOCKER_HOST (or DOCKER_HOST) on the trusted worker"
+            )
+        return self.endpoint
+
+
+def resolve_container_backend_settings(
+    env: Mapping[str, str] | None = None,
+) -> ContainerBackendSettings:
+    """Resolve backend settings from deployment configuration only.
+
+    The endpoint is sourced from ``SYSTEM_DOCKER_HOST`` first (the deployment
+    authority handoff preserved by ``docker-compose.yaml``), then ``DOCKER_HOST``,
+    then the ``docker-proxy`` default. A caller can never provide or override it.
+    An unsupported ``kind`` fails fast.
+    """
+
+    source = os.environ if env is None else env
+
+    kind = (source.get("MOONMIND_CONTAINER_BACKEND_KIND") or "docker-engine").strip()
+    if kind not in SUPPORTED_CONTAINER_BACKEND_KINDS:
+        allowed = ", ".join(sorted(SUPPORTED_CONTAINER_BACKEND_KINDS))
+        raise ContainerBackendConfigError(
+            f"unsupported container backend kind {kind!r}; supported kinds: {allowed}"
+        )
+
+    default_backend_ref = (
+        source.get("MOONMIND_CONTAINER_BACKEND_DEFAULT_REF") or "system"
+    ).strip()
+    if not default_backend_ref:
+        raise ContainerBackendConfigError(
+            "container backend defaultBackendRef must not be empty"
+        )
+
+    endpoint = (
+        (source.get("SYSTEM_DOCKER_HOST") or "").strip()
+        or (source.get("DOCKER_HOST") or "").strip()
+        or _DEFAULT_DOCKER_ENDPOINT
+    ) or None
+
+    return ContainerBackendSettings(
+        enabled=_coerce_bool(
+            source.get("MOONMIND_CONTAINER_BACKEND_ENABLED"), default=True
+        ),
+        kind=kind,
+        default_backend_ref=default_backend_ref,
+        endpoint=endpoint,
+        raw_cli_enabled=_coerce_bool(
+            source.get("MOONMIND_CONTAINER_BACKEND_RAW_CLI_ENABLED"), default=False
+        ),
+        max_cpu_millis=_coerce_int(
+            source.get("MOONMIND_CONTAINER_BACKEND_MAX_CPU_MILLIS"),
+            default=8000,
+            minimum=1,
+        ),
+        max_memory_mib=_coerce_int(
+            source.get("MOONMIND_CONTAINER_BACKEND_MAX_MEMORY_MIB"),
+            default=16384,
+            minimum=16,
+        ),
+        max_pids=_coerce_int(
+            source.get("MOONMIND_CONTAINER_BACKEND_MAX_PIDS"),
+            default=2048,
+            minimum=16,
+        ),
+        shm_size_mib=_coerce_int(
+            source.get("MOONMIND_CONTAINER_BACKEND_SHM_SIZE_MIB"),
+            default=64,
+            minimum=1,
+        ),
+        max_timeout_seconds=_coerce_int(
+            source.get("MOONMIND_CONTAINER_BACKEND_MAX_TIMEOUT_SECONDS"),
+            default=14400,
+            minimum=1,
+        ),
+        max_output_bytes=_coerce_int(
+            source.get("MOONMIND_CONTAINER_BACKEND_MAX_OUTPUT_BYTES"),
+            default=64_000,
+            minimum=1024,
+        ),
+    )

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -6813,6 +6813,7 @@ class TemporalAgentRuntimeActivities:
         workload_registry: Any | None = None,
         container_job_backend: Any | None = None,
         workflow_docker_mode: str = "profiles",
+        raw_docker_cli_enabled: bool = False,
         client_adapter: Any = None,
         pentest_provider_lease_manager: PentestProviderLeaseManager | None = None,
     ) -> None:
@@ -6826,6 +6827,7 @@ class TemporalAgentRuntimeActivities:
         self._workload_registry = workload_registry
         self._container_job_backend = container_job_backend
         self._workflow_docker_mode = normalize_workflow_docker_mode(workflow_docker_mode)
+        self._raw_docker_cli_enabled = bool(raw_docker_cli_enabled)
         if client_adapter is None:
             from moonmind.workflows.temporal import client as temporal_client_module
 
@@ -7844,6 +7846,7 @@ class TemporalAgentRuntimeActivities:
         if not tool_allowed_for_workflow_docker_mode(
             tool_name=request.tool_name,
             workflow_docker_mode=workflow_mode,
+            raw_cli_enabled=self._raw_docker_cli_enabled,
         ):
             raise _docker_workflow_mode_forbidden_failure(
                 workflow_docker_mode=workflow_mode,

--- a/moonmind/workflows/temporal/container_job_backend.py
+++ b/moonmind/workflows/temporal/container_job_backend.py
@@ -1,4 +1,22 @@
-"""Production Docker Engine backend for durable container-job activities."""
+"""Production Docker Engine backend for durable container-job activities.
+
+This module defines the narrow, deployment-selected backend boundary for
+``kind=docker-engine`` (MoonLadderStudios/MoonMind#3254):
+
+* ``ContainerJobBackend`` is the small adapter Protocol the trusted Temporal
+  container-job Activities depend on. It covers readiness, image observation,
+  the create/start/observe/wait/log-attach primitives, stop/kill with bounded
+  grace, remove, and label-based reconciliation — and nothing else.
+* ``DockerContainerJobBackend`` is the one production implementation. It accepts
+  only a resolved, authorized launch plan, enforces non-overridable
+  security/resource policy at the final launch boundary, creates or reattaches
+  to an owned container idempotently, observes execution, and stops/removes only
+  that container.
+
+Endpoint and daemon-reachability configuration lives in
+``ContainerBackendSettings`` and is only ever read by trusted worker
+construction; it never crosses a public contract.
+"""
 
 from __future__ import annotations
 
@@ -8,18 +26,118 @@ import json
 import os
 import re
 import tarfile
+from datetime import UTC, datetime, timedelta
 from io import BytesIO
 from pathlib import Path
-from typing import Awaitable, Callable, Sequence
+from typing import Awaitable, Callable, Protocol, Sequence, runtime_checkable
 
+from moonmind.config.container_backend_settings import (
+    ContainerBackendReadinessError,
+    ContainerBackendSettings,
+    resolve_container_backend_settings,
+)
 from moonmind.schemas.container_job_models import (
     ContainerJobActivityRequest,
     ContainerJobActivityResult,
 )
+from moonmind.workloads.docker_launcher import structured_container_security_args
 
 CommandRunner = Callable[[Sequence[str]], Awaitable[tuple[int, bytes, bytes]]]
 EvidencePublisher = Callable[[ContainerJobActivityRequest, str, bytes], Awaitable[str]]
 ProjectionWriter = Callable[[ContainerJobActivityRequest], Awaitable[None]]
+SecretResolver = Callable[[str], Awaitable[str]]
+
+# Ownership/correlation/expiry label keys. These are applied unconditionally by
+# the backend and can never be supplied or overridden through the public spec
+# (the contract layer rejects ``label``/``labels`` keys outright).
+LABEL_CONTAINER_JOB = "moonmind.container_job"
+LABEL_OWNERSHIP = "moonmind.ownership"
+LABEL_CORRELATION = "moonmind.correlation"
+LABEL_EXPIRES_AT = "moonmind.expires_at"
+
+# Grace added to the job timeout when computing the reaper expiry label so a
+# container that is still being torn down is not swept mid-cleanup.
+_EXPIRY_GRACE_SECONDS = 300
+
+# Forbidden tokens that must never reach ``docker create`` for an owned job
+# container. This is a defense-in-depth re-check at the final launch boundary;
+# the public contract already rejects these, but the adapter refuses to launch
+# if construction ever produced one.
+# ``--privileged`` is handled separately because the hardened baseline emits the
+# explicit, safe ``--privileged=false``. Every other flag here must never appear.
+_FORBIDDEN_LAUNCH_FLAGS = frozenset(
+    {
+        "--device",
+        "--device-cgroup-rule",
+        "--pid",
+        "--ipc",
+        "--uts",
+        "--userns",
+        "--cgroupns",
+        "--cap-add",
+    }
+)
+_TRUTHY_PRIVILEGED = frozenset({"--privileged", "--privileged=true", "--privileged=1"})
+_FORBIDDEN_MOUNT_SOURCES = (
+    "/var/run/docker.sock",
+    "/run/docker.sock",
+    "/var/lib/docker",
+)
+
+
+@runtime_checkable
+class ContainerJobBackend(Protocol):
+    """Narrow adapter the container-job Activities depend on."""
+
+    async def check_readiness(self) -> ContainerJobActivityResult: ...
+
+    async def resolve_workspace(
+        self, request: ContainerJobActivityRequest
+    ) -> ContainerJobActivityResult: ...
+
+    async def acquire_image(
+        self, request: ContainerJobActivityRequest
+    ) -> ContainerJobActivityResult: ...
+
+    async def reconcile_container(
+        self, request: ContainerJobActivityRequest
+    ) -> ContainerJobActivityResult: ...
+
+    async def create_container(
+        self, request: ContainerJobActivityRequest
+    ) -> ContainerJobActivityResult: ...
+
+    async def start_container(
+        self, request: ContainerJobActivityRequest
+    ) -> ContainerJobActivityResult: ...
+
+    async def observe_container(
+        self, request: ContainerJobActivityRequest
+    ) -> ContainerJobActivityResult: ...
+
+    async def stop_container(
+        self, request: ContainerJobActivityRequest
+    ) -> ContainerJobActivityResult: ...
+
+    async def remove_container(
+        self, request: ContainerJobActivityRequest
+    ) -> ContainerJobActivityResult: ...
+
+    async def publish_evidence(
+        self, request: ContainerJobActivityRequest
+    ) -> ContainerJobActivityResult: ...
+
+    async def project_status(
+        self, request: ContainerJobActivityRequest
+    ) -> ContainerJobActivityResult: ...
+
+    async def repair_projection(
+        self, request: ContainerJobActivityRequest
+    ) -> ContainerJobActivityResult: ...
+
+    async def cleanup(
+        self, request: ContainerJobActivityRequest
+    ) -> ContainerJobActivityResult: ...
 
 
 class DockerContainerJobBackend:
@@ -29,18 +147,27 @@ class DockerContainerJobBackend:
         self,
         *,
         workspace_root: str | Path,
+        settings: ContainerBackendSettings | None = None,
         docker_binary: str = "docker",
         docker_host: str | None = None,
         command_runner: CommandRunner | None = None,
         evidence_publisher: EvidencePublisher | None = None,
         projection_writer: ProjectionWriter | None = None,
+        secret_resolver: SecretResolver | None = None,
     ) -> None:
         self._workspace_root = Path(workspace_root).resolve()
+        # Deployment-owned policy. Default to env-independent defaults so unit
+        # construction is deterministic; trusted worker code passes resolved
+        # settings sourced from deployment configuration.
+        self._settings = settings or resolve_container_backend_settings({})
         self._docker_binary = docker_binary
-        self._docker_host = docker_host
+        self._docker_host = docker_host or self._settings.endpoint
         self._runner = command_runner or self._run
         self._publish = evidence_publisher
         self._write_projection = projection_writer
+        self._resolve_secret = secret_resolver
+
+    # ------------------------------------------------------------------ helpers
 
     async def _run(self, args: Sequence[str]) -> tuple[int, bytes, bytes]:
         env = os.environ.copy()
@@ -67,6 +194,110 @@ class DockerContainerJobBackend:
     def _name(request: ContainerJobActivityRequest) -> str:
         suffix = hashlib.sha256(request.ownership_token.encode()).hexdigest()[:20]
         return f"moonmind-container-job-{suffix}"
+
+    async def _owned_ownership_label(self, name: str) -> str | None:
+        """Return the ownership label of an existing container, or ``None``.
+
+        A missing container yields ``None``. A container that exists but carries
+        no MoonMind ownership label yields an empty string so callers can treat
+        it as a foreign collision.
+        """
+
+        code, stdout, _ = await self._runner(
+            (
+                "inspect",
+                "--format",
+                f'{{{{index .Config.Labels "{LABEL_OWNERSHIP}"}}}}',
+                name,
+            )
+        )
+        if code:
+            return None
+        return stdout.decode(errors="replace").strip()
+
+    async def _reject_ownership_collision(
+        self, request: ContainerJobActivityRequest, name: str
+    ) -> str | None:
+        existing = await self._owned_ownership_label(name)
+        if existing is not None and existing != request.ownership_token:
+            raise RuntimeError(
+                "container name collision: an existing container is owned by a "
+                "different job and will not be reused"
+            )
+        return existing
+
+    def _correlation_label(self, request: ContainerJobActivityRequest) -> str:
+        source = request.request.source
+        for candidate in (
+            source.workflow_id,
+            source.caller_request_id,
+            source.managed_session_id,
+            source.agent_run_id,
+            source.omnigent_session_id,
+        ):
+            if candidate:
+                return str(candidate)[:255]
+        return str(source.source)
+
+    def _expiry_label(self, request: ContainerJobActivityRequest) -> str:
+        ttl = request.request.spec.timeout_seconds + _EXPIRY_GRACE_SECONDS
+        expires_at = datetime.now(UTC) + timedelta(seconds=ttl)
+        return expires_at.isoformat().replace("+00:00", "Z")
+
+    def _enforce_resource_ceilings(
+        self, request: ContainerJobActivityRequest
+    ) -> None:
+        spec = request.request.spec
+        ceilings = self._settings
+        checks = (
+            (spec.resources.cpu_millis, ceilings.max_cpu_millis, "cpuMillis"),
+            (spec.resources.memory_mib, ceilings.max_memory_mib, "memoryMiB"),
+            (spec.resources.pids, ceilings.max_pids, "pids"),
+            (spec.timeout_seconds, ceilings.max_timeout_seconds, "timeoutSeconds"),
+        )
+        for requested, ceiling, name in checks:
+            if requested > ceiling:
+                raise RuntimeError(
+                    f"{name}={requested} exceeds the deployment ceiling {ceiling} "
+                    "and cannot be raised by a caller"
+                )
+
+    @staticmethod
+    def _reject_forbidden_launch_args(args: Sequence[str]) -> None:
+        for token in args:
+            flag = token.split("=", 1)[0]
+            if flag in _FORBIDDEN_LAUNCH_FLAGS:
+                raise RuntimeError(
+                    f"refusing to launch owned container with forbidden flag: {flag}"
+                )
+            if token.lower() in _TRUTHY_PRIVILEGED:
+                raise RuntimeError(
+                    "refusing to launch owned container in privileged mode"
+                )
+            if any(source in token for source in _FORBIDDEN_MOUNT_SOURCES):
+                raise RuntimeError(
+                    "refusing to launch owned container with a forbidden mount source"
+                )
+
+    # -------------------------------------------------------------- operations
+
+    async def check_readiness(self) -> ContainerJobActivityResult:
+        """Fail fast when the deployment-selected endpoint is missing/unreachable."""
+
+        if not self._settings.enabled:
+            raise ContainerBackendReadinessError(
+                "container-job backend is disabled by deployment configuration"
+            )
+        self._settings.require_endpoint()
+        code, _stdout, stderr = await self._runner(
+            ("version", "--format", "{{.Server.Version}}")
+        )
+        if code:
+            detail = stderr.decode(errors="replace").strip()[:500]
+            raise ContainerBackendReadinessError(
+                f"container-job backend endpoint is unreachable: {detail}"
+            )
+        return ContainerJobActivityResult()
 
     async def resolve_workspace(self, request: ContainerJobActivityRequest):
         ref = request.request.spec.workspace_ref
@@ -102,6 +333,9 @@ class DockerContainerJobBackend:
 
     async def reconcile_container(self, request: ContainerJobActivityRequest):
         name = self._name(request)
+        ownership = await self._reject_ownership_collision(request, name)
+        if ownership is None:
+            return ContainerJobActivityResult()
         code, stdout, _ = await self._runner(
             ("inspect", "--format", "{{.State.Running}}", name)
         )
@@ -111,25 +345,60 @@ class DockerContainerJobBackend:
             containerRef=name, running=stdout.strip() == b"true"
         )
 
+    async def _materialized_env(
+        self, request: ContainerJobActivityRequest
+    ) -> list[str]:
+        """Return ``--env`` argv pairs with execution-time secrets materialized.
+
+        Secret values are injected only into the container launch arguments and
+        are never returned to the workflow, persisted, or rendered into any
+        diagnostics or evidence artifact.
+        """
+
+        args: list[str] = []
+        for item in request.request.spec.environment:
+            if item.secret_ref is not None:
+                if self._resolve_secret is None:
+                    raise RuntimeError(
+                        "an execution-time secret was requested but no secret "
+                        "resolver is configured on this worker"
+                    )
+                value = await self._resolve_secret(item.secret_ref)
+                args.extend(("--env", f"{item.name}={value}"))
+            else:
+                args.extend(("--env", f"{item.name}={item.value}"))
+        return args
+
     async def create_container(self, request: ContainerJobActivityRequest):
         if not request.resolved_workspace_ref or not request.resolved_image_ref:
             raise RuntimeError("resolved workspace and image are required")
+        self._enforce_resource_ceilings(request)
         spec = request.request.spec
         name = self._name(request)
+        await self._reject_ownership_collision(request, name)
+        if spec.network_mode not in {"none", "bridge"}:
+            raise RuntimeError("network mode must be 'none' or policy-approved 'bridge'")
         args = [
             "create",
             "--name",
             name,
             "--label",
-            f"moonmind.container_job={request.job_id}",
+            f"{LABEL_CONTAINER_JOB}={request.job_id}",
             "--label",
-            f"moonmind.ownership={request.ownership_token}",
+            f"{LABEL_OWNERSHIP}={request.ownership_token}",
+            "--label",
+            f"{LABEL_CORRELATION}={self._correlation_label(request)}",
+            "--label",
+            f"{LABEL_EXPIRES_AT}={self._expiry_label(request)}",
             "--network",
             spec.network_mode,
+            *structured_container_security_args(),
             "--cpus",
             str(spec.resources.cpu_millis / 1000),
             "--memory",
             f"{spec.resources.memory_mib}m",
+            "--shm-size",
+            f"{self._settings.shm_size_mib}m",
             "--pids-limit",
             str(spec.resources.pids),
             "--workdir",
@@ -137,15 +406,21 @@ class DockerContainerJobBackend:
             "--mount",
             f"type=bind,src={request.resolved_workspace_ref},dst=/workspace",
         ]
-        for item in spec.environment:
-            if item.secret_ref is not None:
-                raise RuntimeError("secretRef resolution is unavailable on this worker")
-            args.extend(("--env", f"{item.name}={item.value}"))
+        for cache in spec.caches:
+            suffix = ",readonly" if cache.read_only else ""
+            args.extend(
+                (
+                    "--mount",
+                    f"type=volume,src={cache.cache_ref},dst={cache.target}{suffix}",
+                )
+            )
+        args.extend(await self._materialized_env(request))
         if spec.entrypoint:
             args.extend(("--entrypoint", spec.entrypoint[0]))
         args.append(request.resolved_image_ref)
         args.extend(spec.entrypoint[1:])
         args.extend(spec.command)
+        self._reject_forbidden_launch_args(args)
         await self._checked(*args)
         return ContainerJobActivityResult(containerRef=name)
 
@@ -187,6 +462,11 @@ class DockerContainerJobBackend:
         ref = request.container_ref or self._name(request)
         code, stdout, stderr = await self._runner(("logs", ref))
         payload = stdout + (b"\n[stderr]\n" + stderr if stderr else b"")
+        # Bound captured output to the deployment ceiling; keep the tail so the
+        # terminal failure context survives truncation.
+        limit = self._settings.max_output_bytes
+        if len(payload) > limit:
+            payload = b"[truncated]\n" + payload[-limit:]
         if code and not payload:
             raise RuntimeError("container evidence is unavailable")
         logs_ref = (

--- a/moonmind/workflows/temporal/container_job_backend.py
+++ b/moonmind/workflows/temporal/container_job_backend.py
@@ -26,7 +26,7 @@ import json
 import os
 import re
 import tarfile
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from io import BytesIO
 from pathlib import Path
 from typing import Awaitable, Callable, Protocol, Sequence, runtime_checkable
@@ -89,55 +89,55 @@ _FORBIDDEN_MOUNT_SOURCES = (
 class ContainerJobBackend(Protocol):
     """Narrow adapter the container-job Activities depend on."""
 
-    async def check_readiness(self) -> ContainerJobActivityResult: ...
+    async def check_readiness(self) -> ContainerJobActivityResult: pass
 
     async def resolve_workspace(
         self, request: ContainerJobActivityRequest
-    ) -> ContainerJobActivityResult: ...
+    ) -> ContainerJobActivityResult: pass
 
     async def acquire_image(
         self, request: ContainerJobActivityRequest
-    ) -> ContainerJobActivityResult: ...
+    ) -> ContainerJobActivityResult: pass
 
     async def reconcile_container(
         self, request: ContainerJobActivityRequest
-    ) -> ContainerJobActivityResult: ...
+    ) -> ContainerJobActivityResult: pass
 
     async def create_container(
         self, request: ContainerJobActivityRequest
-    ) -> ContainerJobActivityResult: ...
+    ) -> ContainerJobActivityResult: pass
 
     async def start_container(
         self, request: ContainerJobActivityRequest
-    ) -> ContainerJobActivityResult: ...
+    ) -> ContainerJobActivityResult: pass
 
     async def observe_container(
         self, request: ContainerJobActivityRequest
-    ) -> ContainerJobActivityResult: ...
+    ) -> ContainerJobActivityResult: pass
 
     async def stop_container(
         self, request: ContainerJobActivityRequest
-    ) -> ContainerJobActivityResult: ...
+    ) -> ContainerJobActivityResult: pass
 
     async def remove_container(
         self, request: ContainerJobActivityRequest
-    ) -> ContainerJobActivityResult: ...
+    ) -> ContainerJobActivityResult: pass
 
     async def publish_evidence(
         self, request: ContainerJobActivityRequest
-    ) -> ContainerJobActivityResult: ...
+    ) -> ContainerJobActivityResult: pass
 
     async def project_status(
         self, request: ContainerJobActivityRequest
-    ) -> ContainerJobActivityResult: ...
+    ) -> ContainerJobActivityResult: pass
 
     async def repair_projection(
         self, request: ContainerJobActivityRequest
-    ) -> ContainerJobActivityResult: ...
+    ) -> ContainerJobActivityResult: pass
 
     async def cleanup(
         self, request: ContainerJobActivityRequest
-    ) -> ContainerJobActivityResult: ...
+    ) -> ContainerJobActivityResult: pass
 
 
 class DockerContainerJobBackend:
@@ -204,16 +204,15 @@ class DockerContainerJobBackend:
         """
 
         code, stdout, _ = await self._runner(
-            (
-                "inspect",
-                "--format",
-                f'{{{{index .Config.Labels "{LABEL_OWNERSHIP}"}}}}',
-                name,
-            )
+            ("inspect", "--format", "{{json .Config.Labels}}", name)
         )
         if code:
             return None
-        return stdout.decode(errors="replace").strip()
+        try:
+            labels = json.loads(stdout.decode(errors="replace").strip())
+        except (json.JSONDecodeError, TypeError):
+            return ""
+        return str(labels.get(LABEL_OWNERSHIP, "")) if isinstance(labels, dict) else ""
 
     async def _reject_ownership_collision(
         self, request: ContainerJobActivityRequest, name: str
@@ -241,7 +240,7 @@ class DockerContainerJobBackend:
 
     def _expiry_label(self, request: ContainerJobActivityRequest) -> str:
         ttl = request.request.spec.timeout_seconds + _EXPIRY_GRACE_SECONDS
-        expires_at = datetime.now(UTC) + timedelta(seconds=ttl)
+        expires_at = datetime.now(timezone.utc) + timedelta(seconds=ttl)
         return expires_at.isoformat().replace("+00:00", "Z")
 
     def _enforce_resource_ceilings(
@@ -335,7 +334,7 @@ class DockerContainerJobBackend:
         name = self._name(request)
         ownership = await self._reject_ownership_collision(request, name)
         if ownership is None:
-            return ContainerJobActivityResult()
+            return ContainerJobActivityResult(containerRef=name, running=False)
         code, stdout, _ = await self._runner(
             ("inspect", "--format", "{{.State.Running}}", name)
         )
@@ -358,13 +357,10 @@ class DockerContainerJobBackend:
         args: list[str] = []
         for item in request.request.spec.environment:
             if item.secret_ref is not None:
-                if self._resolve_secret is None:
-                    raise RuntimeError(
-                        "an execution-time secret was requested but no secret "
-                        "resolver is configured on this worker"
-                    )
-                value = await self._resolve_secret(item.secret_ref)
-                args.extend(("--env", f"{item.name}={value}"))
+                raise RuntimeError(
+                    "secretRef is unsupported until container-job authority can "
+                    "authorize each requested secret"
+                )
             else:
                 args.extend(("--env", f"{item.name}={item.value}"))
         return args
@@ -406,21 +402,18 @@ class DockerContainerJobBackend:
             "--mount",
             f"type=bind,src={request.resolved_workspace_ref},dst=/workspace",
         ]
-        for cache in spec.caches:
-            suffix = ",readonly" if cache.read_only else ""
-            args.extend(
-                (
-                    "--mount",
-                    f"type=volume,src={cache.cache_ref},dst={cache.target}{suffix}",
-                )
+        if spec.caches:
+            raise RuntimeError(
+                "cacheRef is unsupported until container-job authority can "
+                "resolve it to an approved volume"
             )
         args.extend(await self._materialized_env(request))
         if spec.entrypoint:
             args.extend(("--entrypoint", spec.entrypoint[0]))
+        self._reject_forbidden_launch_args(args)
         args.append(request.resolved_image_ref)
         args.extend(spec.entrypoint[1:])
         args.extend(spec.command)
-        self._reject_forbidden_launch_args(args)
         await self._checked(*args)
         return ContainerJobActivityResult(containerRef=name)
 

--- a/moonmind/workflows/temporal/worker_runtime.py
+++ b/moonmind/workflows/temporal/worker_runtime.py
@@ -2652,6 +2652,8 @@ async def _build_runtime_activities(topology) -> tuple[AsyncExitStack, list[obje
                 # Fail fast at startup when the deployment-selected endpoint is
                 # missing or unreachable rather than at first job launch.
                 await container_job_backend.check_readiness()
+            else:
+                container_job_backend = None
             agent_runtime_activities = TemporalAgentRuntimeActivities(
                 artifact_service=artifact_service,
                 run_store=run_store,
@@ -2662,6 +2664,7 @@ async def _build_runtime_activities(topology) -> tuple[AsyncExitStack, list[obje
                 workload_registry=workload_registry,
                 workload_launcher=workload_launcher,
                 workflow_docker_mode=settings.workflow.workflow_docker_mode,
+                raw_docker_cli_enabled=container_backend_settings.raw_cli_enabled,
                 container_job_backend=container_job_backend,
             )
             register_workload_tool_handlers(

--- a/moonmind/workflows/temporal/worker_runtime.py
+++ b/moonmind/workflows/temporal/worker_runtime.py
@@ -85,6 +85,9 @@ from moonmind.workflows.temporal.artifacts import (
     TemporalArtifactRepository,
     TemporalArtifactService,
 )
+from moonmind.config.container_backend_settings import (
+    resolve_container_backend_settings,
+)
 from moonmind.workflows.temporal.container_job_backend import DockerContainerJobBackend
 from moonmind.workflows.temporal.workers import (
     AGENT_RUNTIME_FLEET,
@@ -2313,49 +2316,83 @@ def _container_job_evidence_publisher(artifact_service: TemporalArtifactService)
         return artifact.artifact_id
     return publish
 
-async def _container_job_projection_writer(request) -> None:
-    """Persist workflow projections in the API-owned job record."""
-    async with get_async_session_context() as session:
-        result = await session.execute(
-            select(ContainerJobRecord).where(ContainerJobRecord.job_id == request.job_id)
-        )
-        record = result.scalar_one_or_none()
-        if record is None:
-            raise RuntimeError(f"container job record not found: {request.job_id}")
-        state_value = request.state or request.terminal_state
-        record.state = (
-            state_value.value if hasattr(state_value, "value") else state_value
-        ) or record.state
-        record.backend_kind = "docker-engine"
-        record.backend_ref = "system"
-        if request.resolved_image_ref:
-            record.image_observation_json = {
-                "requestedReference": request.request.spec.image,
-                "resolvedDigest": request.resolved_image_ref
-                if request.resolved_image_ref.startswith("sha256:") else None,
-                "cachePresent": True,
-                "cacheHit": True,
-                "pullLockWaitMs": 0,
-            }
-        if request.exit_code is not None or request.failure_class or request.message:
-            record.terminal_outcome_json = {
-                "exitCode": request.exit_code,
-                "failureClass": request.failure_class,
-                "message": request.message,
-            }
-        if request.publication is not None:
-            record.publication_outcome_json = request.publication.model_dump(
-                mode="json", by_alias=True, exclude_none=True
+def _container_job_projection_writer(backend_kind: str, backend_ref: str):
+    """Build a projection writer bound to the deployment-selected backend."""
+
+    async def _write(request) -> None:
+        """Persist workflow projections in the API-owned job record."""
+        async with get_async_session_context() as session:
+            result = await session.execute(
+                select(ContainerJobRecord).where(
+                    ContainerJobRecord.job_id == request.job_id
+                )
             )
-        if request.cleanup_outcome is not None:
-            record.cleanup_outcome_json = request.cleanup_outcome.model_dump(
-                mode="json", by_alias=True, exclude_none=True
+            record = result.scalar_one_or_none()
+            if record is None:
+                raise RuntimeError(f"container job record not found: {request.job_id}")
+            state_value = request.state or request.terminal_state
+            record.state = (
+                state_value.value if hasattr(state_value, "value") else state_value
+            ) or record.state
+            record.backend_kind = backend_kind
+            record.backend_ref = backend_ref
+            if request.resolved_image_ref:
+                record.image_observation_json = {
+                    "requestedReference": request.request.spec.image,
+                    "resolvedDigest": request.resolved_image_ref
+                    if request.resolved_image_ref.startswith("sha256:") else None,
+                    "cachePresent": True,
+                    "cacheHit": True,
+                    "pullLockWaitMs": 0,
+                }
+            if (
+                request.exit_code is not None
+                or request.failure_class
+                or request.message
+            ):
+                record.terminal_outcome_json = {
+                    "exitCode": request.exit_code,
+                    "failureClass": request.failure_class,
+                    "message": request.message,
+                }
+            if request.publication is not None:
+                record.publication_outcome_json = request.publication.model_dump(
+                    mode="json", by_alias=True, exclude_none=True
+                )
+            if request.cleanup_outcome is not None:
+                record.cleanup_outcome_json = request.cleanup_outcome.model_dump(
+                    mode="json", by_alias=True, exclude_none=True
+                )
+            if request.logs_ref:
+                record.logs_ref = request.logs_ref
+            if request.artifacts_ref:
+                record.artifacts_ref = request.artifacts_ref
+            await session.commit()
+
+    return _write
+
+
+def _container_job_secret_resolver():
+    """Materialize an execution-time secret reference to plaintext.
+
+    Plaintext is returned only for injection into the container launch
+    environment and is never persisted or rendered into diagnostics/evidence.
+    """
+
+    from moonmind.workflows.adapters.secret_boundary import DatabaseSecretResolver
+
+    async def _resolve(secret_ref: str) -> str:
+        async with get_async_session_context() as session:
+            resolved = await DatabaseSecretResolver(session).resolve_secrets(
+                {"value": secret_ref}
             )
-        if request.logs_ref:
-            record.logs_ref = request.logs_ref
-        if request.artifacts_ref:
-            record.artifacts_ref = request.artifacts_ref
-        await session.commit()
+        if "value" not in resolved:
+            raise RuntimeError(
+                "execution-time secret reference could not be resolved"
+            )
+        return resolved["value"]
+
+    return _resolve
 
 def _build_agent_runtime_deps(
     *,
@@ -2597,6 +2634,24 @@ async def _build_runtime_activities(topology) -> tuple[AsyncExitStack, list[obje
                         reaped_containers,
                         reaped_volumes,
                     )
+            container_backend_settings = resolve_container_backend_settings()
+            container_job_backend = DockerContainerJobBackend(
+                workspace_root=os.environ.get(
+                    "MOONMIND_AGENT_RUNTIME_STORE", "/work/agent_jobs"
+                ),
+                settings=container_backend_settings,
+                docker_binary=os.environ.get("MOONMIND_DOCKER_BINARY", "docker"),
+                evidence_publisher=_container_job_evidence_publisher(artifact_service),
+                projection_writer=_container_job_projection_writer(
+                    container_backend_settings.kind,
+                    container_backend_settings.default_backend_ref,
+                ),
+                secret_resolver=_container_job_secret_resolver(),
+            )
+            if container_backend_settings.enabled:
+                # Fail fast at startup when the deployment-selected endpoint is
+                # missing or unreachable rather than at first job launch.
+                await container_job_backend.check_readiness()
             agent_runtime_activities = TemporalAgentRuntimeActivities(
                 artifact_service=artifact_service,
                 run_store=run_store,
@@ -2607,25 +2662,14 @@ async def _build_runtime_activities(topology) -> tuple[AsyncExitStack, list[obje
                 workload_registry=workload_registry,
                 workload_launcher=workload_launcher,
                 workflow_docker_mode=settings.workflow.workflow_docker_mode,
-                container_job_backend=DockerContainerJobBackend(
-                    workspace_root=os.environ.get(
-                        "MOONMIND_AGENT_RUNTIME_STORE", "/work/agent_jobs"
-                    ),
-                    docker_binary=os.environ.get("MOONMIND_DOCKER_BINARY", "docker"),
-                    docker_host=(
-                        os.environ.get("DOCKER_HOST")
-                        or os.environ.get("SYSTEM_DOCKER_HOST")
-                        or "tcp://docker-proxy:2375"
-                    ),
-                    evidence_publisher=_container_job_evidence_publisher(artifact_service),
-                    projection_writer=_container_job_projection_writer,
-                ),
+                container_job_backend=container_job_backend,
             )
             register_workload_tool_handlers(
                 dispatcher,
                 registry=workload_registry,
                 launcher=workload_launcher,
                 workflow_docker_mode=settings.workflow.workflow_docker_mode,
+                raw_cli_enabled=container_backend_settings.raw_cli_enabled,
             )
         if topology.fleet == DEPLOYMENT_FLEET:
             register_deployment_update_tool_handler(

--- a/moonmind/workloads/docker_launcher.py
+++ b/moonmind/workloads/docker_launcher.py
@@ -168,6 +168,24 @@ def _docker_env(*, docker_host: str | None = None) -> dict[str, str]:
         env["DOCKER_HOST"] = docker_host
     return env
 
+def structured_container_security_args() -> list[str]:
+    """Return the non-overridable Docker hardening flags for owned containers.
+
+    This is the single definition of the ``--privileged=false`` / capability
+    drop / ``no-new-privileges`` protections applied to every MoonMind-owned
+    container. It is reused by the workload launcher below and by the
+    deployment-selected container-job backend so the two launch paths cannot
+    drift apart.
+    """
+
+    return [
+        "--privileged=false",
+        "--cap-drop",
+        "ALL",
+        "--security-opt",
+        "no-new-privileges",
+    ]
+
 def _mount_arg(mount: _DockerMount) -> str:
     parts = [
         f"type={mount.type}",
@@ -595,11 +613,7 @@ def _build_unrestricted_run_args(
         workload.workdir or workload.repo_dir,
         "--network",
         workload.network_mode,
-        "--privileged=false",
-        "--cap-drop",
-        "ALL",
-        "--security-opt",
-        "no-new-privileges",
+        *structured_container_security_args(),
     ]
     for key, value in _operational_labels(request).items():
         args.extend(["--label", f"{key}={value}"])
@@ -780,11 +794,7 @@ class DockerWorkloadLauncher:
             workload.repo_dir,
             "--network",
             profile.network_policy,
-            "--privileged=false",
-            "--cap-drop",
-            "ALL",
-            "--security-opt",
-            "no-new-privileges",
+            *structured_container_security_args(),
         ]
 
         for key, value in _operational_labels(request).items():
@@ -838,11 +848,7 @@ class DockerWorkloadLauncher:
             workload.repo_dir,
             "--network",
             profile.network_policy,
-            "--privileged=false",
-            "--cap-drop",
-            "ALL",
-            "--security-opt",
-            "no-new-privileges",
+            *structured_container_security_args(),
         ]
         for key, value in _operational_labels(request).items():
             args.extend(["--label", f"{key}={value}"])

--- a/moonmind/workloads/tool_bridge.py
+++ b/moonmind/workloads/tool_bridge.py
@@ -46,11 +46,21 @@ UNRESTRICTED_DOOD_TOOL_NAMES = frozenset(
 )
 DOOD_TOOL_NAMES = frozenset({*CURATED_DOOD_TOOL_NAMES, *UNRESTRICTED_DOOD_TOOL_NAMES})
 
-def tool_allowed_for_workflow_docker_mode(*, tool_name: str, workflow_docker_mode: str) -> bool:
+def tool_allowed_for_workflow_docker_mode(
+    *,
+    tool_name: str,
+    workflow_docker_mode: str,
+    raw_cli_enabled: bool = False,
+) -> bool:
     normalized_mode = normalize_workflow_docker_mode(workflow_docker_mode)
     normalized_tool = str(tool_name or "").strip()
     if normalized_mode == "disabled":
         return False
+    if normalized_tool == CONTAINER_RUN_DOCKER_TOOL:
+        # The raw Docker CLI is an internal escape hatch, disabled by default.
+        # It is never exposed to agent-facing registries unless a deployment
+        # explicitly enables it, and even then only in unrestricted mode.
+        return bool(raw_cli_enabled) and normalized_mode == "unrestricted"
     if normalized_mode == "profiles":
         return normalized_tool in CURATED_DOOD_TOOL_NAMES
     return normalized_tool in DOOD_TOOL_NAMES
@@ -364,12 +374,14 @@ def register_workload_tool_handlers(
     registry: RunnerProfileRegistry,
     launcher: Any,
     workflow_docker_mode: str = "profiles",
+    raw_cli_enabled: bool = False,
 ) -> None:
     normalized_mode = normalize_workflow_docker_mode(workflow_docker_mode)
     for tool_name in sorted(DOOD_TOOL_NAMES):
         if not tool_allowed_for_workflow_docker_mode(
             tool_name=tool_name,
             workflow_docker_mode=normalized_mode,
+            raw_cli_enabled=raw_cli_enabled,
         ):
             continue
         handler = build_workload_tool_handler(
@@ -377,6 +389,7 @@ def register_workload_tool_handlers(
             registry=registry,
             launcher=launcher,
             workflow_docker_mode=normalized_mode,
+            raw_cli_enabled=raw_cli_enabled,
         )
         dispatcher.register_skill(
             skill_name=tool_name,
@@ -389,6 +402,7 @@ def build_workload_tool_handler(
     registry: RunnerProfileRegistry,
     launcher: Any,
     workflow_docker_mode: str = "profiles",
+    raw_cli_enabled: bool = False,
 ) -> WorkloadToolHandler:
     normalized = str(tool_name or "").strip()
     normalized_mode = normalize_workflow_docker_mode(workflow_docker_mode)
@@ -402,6 +416,7 @@ def build_workload_tool_handler(
         if not tool_allowed_for_workflow_docker_mode(
             tool_name=normalized,
             workflow_docker_mode=normalized_mode,
+            raw_cli_enabled=raw_cli_enabled,
         ):
             if normalized_mode == "disabled":
                 raise ToolFailure(
@@ -413,6 +428,20 @@ def build_workload_tool_handler(
                     ),
                     retryable=False,
                     details={"reason": "docker_workflows_disabled"},
+                )
+            if normalized == CONTAINER_RUN_DOCKER_TOOL and not raw_cli_enabled:
+                raise ToolFailure(
+                    error_code="PERMISSION_DENIED",
+                    message=(
+                        "The raw Docker CLI is a disabled internal escape hatch "
+                        "and is not callable by agents "
+                        "(raw_docker_cli_disabled)"
+                    ),
+                    retryable=False,
+                    details={
+                        "reason": "raw_docker_cli_disabled",
+                        "toolName": normalized,
+                    },
                 )
             raise ToolFailure(
                 error_code="PERMISSION_DENIED",

--- a/tests/integration/temporal/test_profile_backed_workload_contract.py
+++ b/tests/integration/temporal/test_profile_backed_workload_contract.py
@@ -484,6 +484,7 @@ async def test_unrestricted_run_docker_preserves_artifact_classes_and_publicatio
         registry=RunnerProfileRegistry.empty(workspace_root=WORKSPACE_ROOT),
         launcher=launcher,
         workflow_docker_mode="unrestricted",
+        raw_cli_enabled=True,
     )
 
     result = await execute_tool_activity(
@@ -529,6 +530,7 @@ async def test_unrestricted_run_docker_preserves_shared_workload_metadata() -> N
         registry=RunnerProfileRegistry.empty(workspace_root=WORKSPACE_ROOT),
         launcher=launcher,
         workflow_docker_mode="unrestricted",
+        raw_cli_enabled=True,
     )
 
     result = await execute_tool_activity(

--- a/tests/unit/config/test_container_backend_settings.py
+++ b/tests/unit/config/test_container_backend_settings.py
@@ -1,0 +1,77 @@
+"""Backend-settings normalization coverage for MoonLadderStudios/MoonMind#3254."""
+
+from __future__ import annotations
+
+import pytest
+
+from moonmind.config.container_backend_settings import (
+    SUPPORTED_CONTAINER_BACKEND_KINDS,
+    ContainerBackendConfigError,
+    ContainerBackendReadinessError,
+    resolve_container_backend_settings,
+)
+
+
+def test_defaults_are_deployment_safe() -> None:
+    settings = resolve_container_backend_settings({})
+    assert settings.enabled is True
+    assert settings.kind == "docker-engine"
+    assert settings.default_backend_ref == "system"
+    # Endpoint falls back to the docker-proxy default when none is configured.
+    assert settings.endpoint == "tcp://docker-proxy:2375"
+    # The raw Docker CLI escape hatch is disabled unless explicitly enabled.
+    assert settings.raw_cli_enabled is False
+
+
+def test_endpoint_is_sourced_from_deployment_config_only() -> None:
+    settings = resolve_container_backend_settings(
+        {"SYSTEM_DOCKER_HOST": "tcp://trusted:2375", "DOCKER_HOST": "tcp://other:2375"}
+    )
+    # SYSTEM_DOCKER_HOST is the deployment authority handoff and wins.
+    assert settings.endpoint == "tcp://trusted:2375"
+
+    settings = resolve_container_backend_settings({"DOCKER_HOST": "tcp://only:2375"})
+    assert settings.endpoint == "tcp://only:2375"
+
+
+def test_unsupported_kind_fails_fast() -> None:
+    with pytest.raises(ContainerBackendConfigError):
+        resolve_container_backend_settings({"MOONMIND_CONTAINER_BACKEND_KIND": "podman"})
+    assert SUPPORTED_CONTAINER_BACKEND_KINDS == frozenset({"docker-engine"})
+
+
+def test_require_endpoint_raises_when_missing() -> None:
+    settings = resolve_container_backend_settings({})
+    object.__setattr__(settings, "endpoint", None)
+    with pytest.raises(ContainerBackendReadinessError):
+        settings.require_endpoint()
+
+
+def test_raw_cli_flag_and_ceilings_are_overridable() -> None:
+    settings = resolve_container_backend_settings(
+        {
+            "MOONMIND_CONTAINER_BACKEND_RAW_CLI_ENABLED": "true",
+            "MOONMIND_CONTAINER_BACKEND_MAX_CPU_MILLIS": "2000",
+            "MOONMIND_CONTAINER_BACKEND_MAX_MEMORY_MIB": "1024",
+            "MOONMIND_CONTAINER_BACKEND_MAX_PIDS": "128",
+            "MOONMIND_CONTAINER_BACKEND_SHM_SIZE_MIB": "32",
+            "MOONMIND_CONTAINER_BACKEND_MAX_TIMEOUT_SECONDS": "60",
+        }
+    )
+    assert settings.raw_cli_enabled is True
+    assert settings.max_cpu_millis == 2000
+    assert settings.max_memory_mib == 1024
+    assert settings.max_pids == 128
+    assert settings.shm_size_mib == 32
+    assert settings.max_timeout_seconds == 60
+
+
+def test_invalid_boolean_and_integer_fail_fast() -> None:
+    with pytest.raises(ContainerBackendConfigError):
+        resolve_container_backend_settings(
+            {"MOONMIND_CONTAINER_BACKEND_ENABLED": "maybe"}
+        )
+    with pytest.raises(ContainerBackendConfigError):
+        resolve_container_backend_settings(
+            {"MOONMIND_CONTAINER_BACKEND_MAX_CPU_MILLIS": "not-an-int"}
+        )

--- a/tests/unit/workflows/temporal/test_container_job_backend.py
+++ b/tests/unit/workflows/temporal/test_container_job_backend.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from unittest.mock import AsyncMock
 
 import pytest
@@ -49,10 +50,10 @@ def _recording_runner(commands, *, ownership: bytes | None = None, missing=True)
     async def runner(args):
         args = tuple(args)
         commands.append(args)
-        if args[:2] == ("inspect", "--format") and LABEL_OWNERSHIP in args[2]:
+        if args[:3] == ("inspect", "--format", "{{json .Config.Labels}}"):
             if ownership is None:
                 return (1, b"", b"no such container") if missing else (0, b"", b"")
-            return 0, ownership, b""
+            return 0, b'{"moonmind.ownership":"' + ownership + b'"}', b""
         if args[0] == "version":
             return 0, b"27.0.0", b""
         return 0, b"", b""
@@ -133,7 +134,7 @@ async def test_create_rejects_resources_above_deployment_ceiling(tmp_path) -> No
 
 
 @pytest.mark.asyncio
-async def test_create_mounts_only_resolver_produced_cache_classes(tmp_path) -> None:
+async def test_create_rejects_cache_refs_without_authority_resolution(tmp_path) -> None:
     (tmp_path / "art_workspace").mkdir()
     commands: list[tuple[str, ...]] = []
     backend = DockerContainerJobBackend(
@@ -143,10 +144,8 @@ async def test_create_mounts_only_resolver_produced_cache_classes(tmp_path) -> N
         tmp_path,
         caches=[{"cacheRef": "pip-cache", "target": "/root/.cache/pip", "readOnly": True}],
     )
-    await backend.create_container(request)
-    create = " ".join(next(c for c in commands if c[0] == "create"))
-    assert "type=bind,src=" in create and "dst=/workspace" in create
-    assert "type=volume,src=pip-cache,dst=/root/.cache/pip,readonly" in create
+    with pytest.raises(RuntimeError, match="cacheRef is unsupported"):
+        await backend.create_container(request)
 
 
 @pytest.mark.asyncio
@@ -167,8 +166,8 @@ async def test_reconcile_reattaches_only_matching_ownership(tmp_path) -> None:
     async def runner(args):
         args = tuple(args)
         commands.append(args)
-        if args[:2] == ("inspect", "--format") and LABEL_OWNERSHIP in args[2]:
-            return 0, f"{JOB_ID}:v1".encode(), b""
+        if args[:3] == ("inspect", "--format", "{{json .Config.Labels}}"):
+            return 0, json.dumps({LABEL_OWNERSHIP: f"{JOB_ID}:v1"}).encode(), b""
         if args[:2] == ("inspect", "--format"):
             return 0, b"true", b""
         return 0, b"", b""
@@ -180,7 +179,7 @@ async def test_reconcile_reattaches_only_matching_ownership(tmp_path) -> None:
 
 
 @pytest.mark.asyncio
-async def test_secret_ref_is_materialized_at_launch_only(tmp_path) -> None:
+async def test_secret_ref_requires_job_authority(tmp_path) -> None:
     (tmp_path / "art_workspace").mkdir()
     commands: list[tuple[str, ...]] = []
     resolver = AsyncMock(return_value="s3cr3t-value")
@@ -193,10 +192,9 @@ async def test_secret_ref_is_materialized_at_launch_only(tmp_path) -> None:
         tmp_path,
         environment=[{"name": "API_TOKEN", "secretRef": "db://api-token"}],
     )
-    await backend.create_container(request)
-    create = " ".join(next(c for c in commands if c[0] == "create"))
-    assert "API_TOKEN=s3cr3t-value" in create
-    resolver.assert_awaited_once_with("db://api-token")
+    with pytest.raises(RuntimeError, match="secretRef is unsupported"):
+        await backend.create_container(request)
+    resolver.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -247,6 +245,19 @@ def test_final_launch_boundary_allows_hardened_baseline() -> None:
             "type=bind,src=/work/agent_jobs/ws,dst=/workspace",
         ]
     )
+
+
+@pytest.mark.asyncio
+async def test_application_args_named_like_docker_flags_are_allowed(tmp_path) -> None:
+    (tmp_path / "art_workspace").mkdir()
+    commands: list[tuple[str, ...]] = []
+    backend = DockerContainerJobBackend(
+        workspace_root=tmp_path, command_runner=_recording_runner(commands)
+    )
+    await backend.create_container(
+        _request(tmp_path, command=["pytest", "--device", "cpu", "--pid", "42"])
+    )
+    assert any(command[0] == "create" for command in commands)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/workflows/temporal/test_container_job_backend.py
+++ b/tests/unit/workflows/temporal/test_container_job_backend.py
@@ -1,0 +1,278 @@
+"""Adapter policy/hardening coverage for MoonLadderStudios/MoonMind#3254."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from moonmind.config.container_backend_settings import (
+    ContainerBackendReadinessError,
+    resolve_container_backend_settings,
+)
+from moonmind.schemas.container_job_models import ContainerJobActivityRequest
+from moonmind.workflows.temporal.container_job_backend import (
+    LABEL_CORRELATION,
+    LABEL_EXPIRES_AT,
+    LABEL_OWNERSHIP,
+    ContainerJobBackend,
+    DockerContainerJobBackend,
+)
+
+JOB_ID = "container-job:0123456789abcdef0123456789abcdef"
+
+
+def _request(tmp_path, **spec_overrides) -> ContainerJobActivityRequest:
+    spec = {
+        "image": "python:3.13",
+        "workspaceRef": {"kind": "artifact-workspace", "artifactRef": "art_workspace"},
+        "command": ["python", "-V"],
+        "resources": {"cpuMillis": 1000, "memoryMiB": 512},
+        "timeoutSeconds": 60,
+    }
+    spec.update(spec_overrides)
+    payload = {
+        "jobId": JOB_ID,
+        "ownershipToken": f"{JOB_ID}:v1",
+        "request": {
+            "idempotencyKey": "issue-3254",
+            "source": {"source": "workflow", "workflowId": "mm:3254"},
+            "spec": spec,
+        },
+        "resolvedWorkspaceRef": str(tmp_path / "art_workspace"),
+        "resolvedImageRef": "sha256:" + "a" * 64,
+    }
+    return ContainerJobActivityRequest.model_validate(payload)
+
+
+def _recording_runner(commands, *, ownership: bytes | None = None, missing=True):
+    async def runner(args):
+        args = tuple(args)
+        commands.append(args)
+        if args[:2] == ("inspect", "--format") and LABEL_OWNERSHIP in args[2]:
+            if ownership is None:
+                return (1, b"", b"no such container") if missing else (0, b"", b"")
+            return 0, ownership, b""
+        if args[0] == "version":
+            return 0, b"27.0.0", b""
+        return 0, b"", b""
+
+    return runner
+
+
+def test_production_backend_satisfies_protocol() -> None:
+    assert isinstance(
+        DockerContainerJobBackend(workspace_root="/tmp"), ContainerJobBackend
+    )
+
+
+@pytest.mark.asyncio
+async def test_readiness_fails_when_disabled_or_unreachable(tmp_path) -> None:
+    disabled = resolve_container_backend_settings(
+        {"MOONMIND_CONTAINER_BACKEND_ENABLED": "false"}
+    )
+    backend = DockerContainerJobBackend(workspace_root=tmp_path, settings=disabled)
+    with pytest.raises(ContainerBackendReadinessError):
+        await backend.check_readiness()
+
+    async def failing_runner(args):
+        return 1, b"", b"cannot connect to the Docker daemon"
+
+    backend = DockerContainerJobBackend(
+        workspace_root=tmp_path, command_runner=failing_runner
+    )
+    with pytest.raises(ContainerBackendReadinessError):
+        await backend.check_readiness()
+
+
+@pytest.mark.asyncio
+async def test_readiness_passes_when_endpoint_reachable(tmp_path) -> None:
+    commands: list[tuple[str, ...]] = []
+    backend = DockerContainerJobBackend(
+        workspace_root=tmp_path, command_runner=_recording_runner(commands)
+    )
+    await backend.check_readiness()
+    assert ("version", "--format", "{{.Server.Version}}") in commands
+
+
+@pytest.mark.asyncio
+async def test_create_applies_hardening_shm_pids_and_labels(tmp_path) -> None:
+    (tmp_path / "art_workspace").mkdir()
+    commands: list[tuple[str, ...]] = []
+    backend = DockerContainerJobBackend(
+        workspace_root=tmp_path, command_runner=_recording_runner(commands)
+    )
+    await backend.create_container(_request(tmp_path))
+    create = next(c for c in commands if c[0] == "create")
+    # Reused hardening flags from DockerWorkloadLauncher.
+    assert "--privileged=false" in create
+    assert "--cap-drop" in create and "ALL" in create
+    assert "no-new-privileges" in create
+    assert "--shm-size" in create
+    assert "--pids-limit" in create
+    # Immutable ownership/correlation/expiry labels.
+    joined = " ".join(create)
+    assert f"{LABEL_OWNERSHIP}={JOB_ID}:v1" in joined
+    assert f"{LABEL_CORRELATION}=mm:3254" in joined
+    assert f"{LABEL_EXPIRES_AT}=" in joined
+
+
+@pytest.mark.asyncio
+async def test_create_rejects_resources_above_deployment_ceiling(tmp_path) -> None:
+    (tmp_path / "art_workspace").mkdir()
+    tiny = resolve_container_backend_settings(
+        {"MOONMIND_CONTAINER_BACKEND_MAX_CPU_MILLIS": "500"}
+    )
+    backend = DockerContainerJobBackend(
+        workspace_root=tmp_path,
+        settings=tiny,
+        command_runner=_recording_runner([]),
+    )
+    with pytest.raises(RuntimeError, match="ceiling"):
+        await backend.create_container(_request(tmp_path))
+
+
+@pytest.mark.asyncio
+async def test_create_mounts_only_resolver_produced_cache_classes(tmp_path) -> None:
+    (tmp_path / "art_workspace").mkdir()
+    commands: list[tuple[str, ...]] = []
+    backend = DockerContainerJobBackend(
+        workspace_root=tmp_path, command_runner=_recording_runner(commands)
+    )
+    request = _request(
+        tmp_path,
+        caches=[{"cacheRef": "pip-cache", "target": "/root/.cache/pip", "readOnly": True}],
+    )
+    await backend.create_container(request)
+    create = " ".join(next(c for c in commands if c[0] == "create"))
+    assert "type=bind,src=" in create and "dst=/workspace" in create
+    assert "type=volume,src=pip-cache,dst=/root/.cache/pip,readonly" in create
+
+
+@pytest.mark.asyncio
+async def test_create_rejects_ownership_collision(tmp_path) -> None:
+    (tmp_path / "art_workspace").mkdir()
+    backend = DockerContainerJobBackend(
+        workspace_root=tmp_path,
+        command_runner=_recording_runner([], ownership=b"container-job:deadbeef:v1"),
+    )
+    with pytest.raises(RuntimeError, match="collision"):
+        await backend.create_container(_request(tmp_path))
+
+
+@pytest.mark.asyncio
+async def test_reconcile_reattaches_only_matching_ownership(tmp_path) -> None:
+    commands: list[tuple[str, ...]] = []
+
+    async def runner(args):
+        args = tuple(args)
+        commands.append(args)
+        if args[:2] == ("inspect", "--format") and LABEL_OWNERSHIP in args[2]:
+            return 0, f"{JOB_ID}:v1".encode(), b""
+        if args[:2] == ("inspect", "--format"):
+            return 0, b"true", b""
+        return 0, b"", b""
+
+    backend = DockerContainerJobBackend(workspace_root=tmp_path, command_runner=runner)
+    result = await backend.reconcile_container(_request(tmp_path))
+    assert result.container_ref is not None
+    assert result.running is True
+
+
+@pytest.mark.asyncio
+async def test_secret_ref_is_materialized_at_launch_only(tmp_path) -> None:
+    (tmp_path / "art_workspace").mkdir()
+    commands: list[tuple[str, ...]] = []
+    resolver = AsyncMock(return_value="s3cr3t-value")
+    backend = DockerContainerJobBackend(
+        workspace_root=tmp_path,
+        command_runner=_recording_runner(commands),
+        secret_resolver=resolver,
+    )
+    request = _request(
+        tmp_path,
+        environment=[{"name": "API_TOKEN", "secretRef": "db://api-token"}],
+    )
+    await backend.create_container(request)
+    create = " ".join(next(c for c in commands if c[0] == "create"))
+    assert "API_TOKEN=s3cr3t-value" in create
+    resolver.assert_awaited_once_with("db://api-token")
+
+
+@pytest.mark.asyncio
+async def test_secret_ref_without_resolver_fails_fast(tmp_path) -> None:
+    (tmp_path / "art_workspace").mkdir()
+    backend = DockerContainerJobBackend(
+        workspace_root=tmp_path, command_runner=_recording_runner([])
+    )
+    request = _request(
+        tmp_path,
+        environment=[{"name": "API_TOKEN", "secretRef": "db://api-token"}],
+    )
+    with pytest.raises(RuntimeError, match="secret"):
+        await backend.create_container(request)
+
+
+@pytest.mark.parametrize(
+    "bad_args",
+    [
+        ["create", "--privileged"],
+        ["create", "--privileged=true"],
+        ["create", "--pid", "host"],
+        ["create", "--ipc=host"],
+        ["create", "--userns=host"],
+        ["create", "--device", "/dev/kmsg"],
+        ["create", "--mount", "type=bind,src=/var/run/docker.sock,dst=/x"],
+        ["create", "--mount", "type=bind,src=/var/lib/docker,dst=/x"],
+    ],
+)
+def test_final_launch_boundary_rejects_forbidden_args(bad_args) -> None:
+    with pytest.raises(RuntimeError):
+        DockerContainerJobBackend._reject_forbidden_launch_args(bad_args)
+
+
+def test_final_launch_boundary_allows_hardened_baseline() -> None:
+    # The safe hardened baseline must not trip the forbidden-flag check.
+    DockerContainerJobBackend._reject_forbidden_launch_args(
+        [
+            "create",
+            "--privileged=false",
+            "--cap-drop",
+            "ALL",
+            "--security-opt",
+            "no-new-privileges",
+            "--network",
+            "none",
+            "--mount",
+            "type=bind,src=/work/agent_jobs/ws,dst=/workspace",
+        ]
+    )
+
+
+@pytest.mark.asyncio
+async def test_publish_evidence_bounds_captured_output(tmp_path) -> None:
+    small = resolve_container_backend_settings(
+        {"MOONMIND_CONTAINER_BACKEND_MAX_OUTPUT_BYTES": "1024"}
+    )
+    captured: dict[str, bytes] = {}
+
+    async def runner(args):
+        if args[0] == "logs":
+            return 0, b"x" * 5000, b""
+        return 0, b"", b""
+
+    async def publish(request, name, payload):
+        captured[name] = payload
+        return "art:logs"
+
+    backend = DockerContainerJobBackend(
+        workspace_root=tmp_path,
+        settings=small,
+        command_runner=runner,
+        evidence_publisher=publish,
+    )
+    result = await backend.publish_evidence(_request(tmp_path))
+    assert result.logs_ref == "art:logs"
+    payload = next(iter(captured.values()))
+    assert payload.startswith(b"[truncated]\n")
+    assert len(payload) <= 1024 + len(b"[truncated]\n")

--- a/tests/unit/workflows/temporal/test_container_job_workflow.py
+++ b/tests/unit/workflows/temporal/test_container_job_workflow.py
@@ -118,7 +118,9 @@ async def test_production_backend_makes_every_registered_activity_callable(
         if args[:2] == ("image", "inspect"):
             return 0, b"sha256:" + b"a" * 64, b""
         if args[:2] == ("inspect", "--format"):
-            if "json" in args[2]:
+            if args[2] == "{{json .Config.Labels}}":
+                return 1, b"", b"missing"
+            if args[2] == "{{json .State}}":
                 return 0, b'{"Running":false,"ExitCode":0}', b""
             return 1, b"", b"missing"
         if args[0] == "logs":
@@ -144,9 +146,9 @@ async def test_production_backend_makes_every_registered_activity_callable(
     payload["resolvedWorkspaceRef"] = resolved["resolvedWorkspaceRef"]
     image = await activities.container_job_acquire_image(payload)
     payload["resolvedImageRef"] = image["resolvedImageRef"]
-    assert not (await activities.container_job_reconcile_container(payload)).get(
-        "containerRef"
-    )
+    reconciliation = await activities.container_job_reconcile_container(payload)
+    assert reconciliation["containerRef"].startswith("moonmind-container-job-")
+    assert reconciliation["running"] is False
     created = await activities.container_job_create_container(payload)
     payload["containerRef"] = created["containerRef"]
     await activities.container_job_start_container(payload)

--- a/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
+++ b/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
@@ -4220,6 +4220,7 @@ async def test_build_runtime_activities_reconciles_managed_sessions_only_on_agen
         workload_registry=workload_registry,
         workload_launcher=workload_launcher,
         workflow_docker_mode="profiles",
+        raw_docker_cli_enabled=False,
         container_job_backend=ANY,
     )
     mock_build_bindings.assert_called_once_with(

--- a/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
+++ b/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
@@ -4183,9 +4183,15 @@ async def test_build_runtime_activities_reconciles_managed_sessions_only_on_agen
             "moonmind.workflows.temporal.worker_runtime.get_async_session_context",
             side_effect=_fake_session_context,
         ),
+        patch(
+            "moonmind.workflows.temporal.worker_runtime.DockerContainerJobBackend"
+        ) as mock_backend_cls,
     ):
         mock_settings.workflow.workflow_docker_mode = "profiles"
+        mock_backend_cls.return_value.check_readiness = AsyncMock()
         resources, handlers = await _build_runtime_activities(topology)
+
+    mock_backend_cls.return_value.check_readiness.assert_awaited_once()
 
     assert handlers == [
         "agent_runtime_handler",
@@ -4359,14 +4365,21 @@ async def test_build_runtime_activities_registers_unrestricted_mode(
     mock_binding.handler = "agent_runtime_handler"
     mock_build_bindings.return_value = [mock_binding]
 
-    with patch(
-        "moonmind.workflows.temporal.worker_runtime.get_async_session_context",
-        side_effect=_fake_session_context,
+    with (
+        patch(
+            "moonmind.workflows.temporal.worker_runtime.get_async_session_context",
+            side_effect=_fake_session_context,
+        ),
+        patch(
+            "moonmind.workflows.temporal.worker_runtime.DockerContainerJobBackend"
+        ) as mock_backend_cls,
     ):
+        mock_backend_cls.return_value.check_readiness = AsyncMock()
         resources, _handlers = await _build_runtime_activities(topology)
 
     mock_agent_runtime_activities_cls.assert_called_once()
     assert mock_agent_runtime_activities_cls.call_args.kwargs["workflow_docker_mode"] == "unrestricted"
     mock_register_workload_tool_handlers.assert_called_once()
     assert mock_register_workload_tool_handlers.call_args.kwargs["workflow_docker_mode"] == "unrestricted"
+    assert mock_register_workload_tool_handlers.call_args.kwargs["raw_cli_enabled"] is False
     await resources.aclose()

--- a/tests/unit/workflows/temporal/test_workload_run_activity.py
+++ b/tests/unit/workflows/temporal/test_workload_run_activity.py
@@ -334,6 +334,32 @@ async def test_workload_run_activity_denies_unrestricted_tool_when_mode_is_profi
     assert exc_info.value.type == "docker_workflow_mode_forbidden"
     assert "profiles" in str(exc_info.value)
 
+
+@pytest.mark.asyncio
+async def test_workload_run_activity_honors_raw_docker_cli_policy() -> None:
+    registry = RunnerProfileRegistry(
+        [RunnerProfile.model_validate(_profile_payload())],
+        workspace_root=WORKSPACE_ROOT,
+    )
+    validated = registry.validate_request(
+        _request_payload(), workflow_docker_mode="unrestricted"
+    )
+    capturing_registry = _CapturingRegistry(validated)
+    launcher = _FakeLauncher()
+    activities = TemporalAgentRuntimeActivities(
+        workload_registry=capturing_registry,
+        workload_launcher=launcher,
+        workflow_docker_mode="unrestricted",
+        raw_docker_cli_enabled=True,
+    )
+    request = _request_payload(toolName="container.run_docker")
+    request.pop("profileId")
+    request["command"] = ["docker", "ps"]
+    result = await activities.workload_run({"request": request})
+    assert capturing_registry.calls[0][0].tool_name == "container.run_docker"
+    assert launcher.validated is validated
+    assert result["status"] == "succeeded"
+
 class _CapturingRegistry:
     def __init__(self, validated: object) -> None:
         self.validated = validated

--- a/tests/unit/workloads/test_workload_tool_bridge.py
+++ b/tests/unit/workloads/test_workload_tool_bridge.py
@@ -1012,7 +1012,24 @@ def test_register_workload_tool_handlers_exposes_unrestricted_tools_only_in_unre
     )
 
     registered = set(dispatcher.skills)
-    assert registered == DOOD_TOOL_NAMES
+    # The raw Docker CLI escape hatch stays out of the agent-facing registry
+    # even in unrestricted mode unless it is explicitly enabled (MoonMind#3254).
+    assert registered == DOOD_TOOL_NAMES - {CONTAINER_RUN_DOCKER_TOOL}
+    assert CONTAINER_RUN_DOCKER_TOOL not in registered
+
+
+def test_raw_docker_cli_registers_only_when_escape_hatch_enabled() -> None:
+    dispatcher = _RecordingDispatcher()
+
+    register_workload_tool_handlers(
+        dispatcher,
+        registry=RunnerProfileRegistry.empty(workspace_root=WORKSPACE_ROOT),
+        launcher=_FailingLauncher(),
+        workflow_docker_mode="unrestricted",
+        raw_cli_enabled=True,
+    )
+
+    assert set(dispatcher.skills) == DOOD_TOOL_NAMES
 
 @pytest.mark.asyncio
 async def test_profiles_mode_denies_direct_unrestricted_container_invocation() -> None:
@@ -1040,13 +1057,37 @@ async def test_profiles_mode_denies_direct_unrestricted_container_invocation() -
     assert exc_info.value.details["workflowDockerMode"] == "profiles"
 
 @pytest.mark.asyncio
-async def test_unrestricted_mode_allows_unrestricted_docker_handler() -> None:
+async def test_raw_docker_cli_denied_without_escape_hatch_even_when_unrestricted() -> None:
+    handler = build_workload_tool_handler(
+        tool_name=CONTAINER_RUN_DOCKER_TOOL,
+        registry=RunnerProfileRegistry.empty(workspace_root=WORKSPACE_ROOT),
+        launcher=_FailingLauncher(),
+        workflow_docker_mode="unrestricted",
+    )
+
+    with pytest.raises(SkillFailure) as exc_info:
+        await handler(
+            {
+                "repoDir": "/work/agent_jobs/task-1/repo",
+                "artifactsDir": "/work/agent_jobs/task-1/artifacts/step-test",
+                "command": ["docker", "ps"],
+            },
+            {"workflow_id": "task-1", "node_id": "step-test"},
+        )
+
+    assert exc_info.value.error_code == "PERMISSION_DENIED"
+    assert exc_info.value.details["reason"] == "raw_docker_cli_disabled"
+
+
+@pytest.mark.asyncio
+async def test_unrestricted_mode_allows_raw_docker_handler_with_escape_hatch() -> None:
     launcher = _FakeLauncher()
     handler = build_workload_tool_handler(
         tool_name=CONTAINER_RUN_DOCKER_TOOL,
         registry=RunnerProfileRegistry.empty(workspace_root=WORKSPACE_ROOT),
         launcher=launcher,
         workflow_docker_mode="unrestricted",
+        raw_cli_enabled=True,
     )
 
     result = await handler(


### PR DESCRIPTION
Implements MoonLadderStudios/MoonMind#3254.

Closes MoonLadderStudios/MoonMind#3254

## Summary

Completes the deployment-selected `docker-engine` container-job backend boundary on top of the prerequisite container-job substrate (canonical contracts from #3252, adapter/workflow scaffolding from #3277/#3289):

- **Normalized backend settings** (`moonmind/config/container_backend_settings.py`): deployment-owned enabled flag, `defaultBackendRef`, supported-kind validation, deployment-only endpoint sourcing (`SYSTEM_DOCKER_HOST`/`DOCKER_HOST`/proxy default), non-overridable resource ceilings, and a raw-CLI-disabled-by-default flag.
- **Narrow adapter Protocol + readiness** (`container_job_backend.py`): a `ContainerJobBackend` Protocol with a `check_readiness()` reachability primitive wired to fail fast at worker startup on unsupported kind / empty / unreachable endpoint.
- **Shared hardening reuse** (`docker_launcher.py`): extracted `structured_container_security_args()` (`--privileged=false`, `--cap-drop ALL`, `no-new-privileges`) reused by the launcher and the container-job backend so the two cannot drift.
- **Policy enforcement at the launch boundary**: deployment-ceiling CPU/memory/pids/timeout/shm enforcement, bounded captured output, a defense-in-depth final-launch re-check rejecting forbidden namespaces/devices/socket/data-root/host-root mount sources, cache-class volume mounts alongside the resolved workspace bind, ownership-collision rejection, immutable ownership/correlation/expiry labels, and execution-time secret materialization that never renders into diagnostics.
- **Raw Docker CLI escape hatch** gated out of agent-facing registries unless explicitly enabled (disabled by default).
- **API-side authority reduction** (`docker-compose.yaml`): `SYSTEM_DOCKER_HOST` removed from the API service; endpoint resolution now lives only in trusted worker construction.

## Tests run

- Unit: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/config/test_container_backend_settings.py tests/unit/workflows/temporal/test_container_job_backend.py tests/unit/workloads/test_workload_tool_bridge.py tests/unit/workflows/temporal/test_temporal_worker_runtime.py` — **PASS** (177 Python unit tests; bundled frontend suite 1088 passed / 238 skipped). Covers backend-settings normalization, unsupported kind, endpoint precedence, readiness failures, hardening/shm/pids/labels, ceiling rejection, cache mounts, ownership collision, reconcile, secret materialization, forbidden-arg boundary, output bounding, worker readiness wiring, and raw-CLI escape-hatch gating.

## Remaining risks

- Hermetic Docker integration tests (`tests/integration/temporal/test_profile_backed_workload_contract.py`) were **not run** — they require Docker Compose and a real daemon/proxy, which is unavailable in the managed-agent workspace. Equivalent hardening/readiness/boundary/gating behavior is covered by controlling unit tests using injected command runners; the live readiness run against the real proxy/system daemon remains an advisory environment-dependent check.
