### PR TITLE
Coordinate Docker image acquisition and cross-workflow cache reuse (MoonLadderStudios/MoonMind#3256)

### DIFF
--- a/moonmind/schemas/container_job_models.py
+++ b/moonmind/schemas/container_job_models.py
@@ -91,7 +91,7 @@ class ContainerJobFailureClass(StrEnum):
     IMAGE = "image"
     IMAGE_NOT_FOUND = "image_not_found"
     IMAGE_PULL_TIMEOUT = "image_pull_timeout"
-    IMAGE_AUTH_FAILED = "image_auth_failed"
+    IMAGE_PULL_AUTH_FAILED = "image_pull_auth_failed"
     IMAGE_PLATFORM_MISMATCH = "image_platform_mismatch"
     IMAGE_BACKEND_UNAVAILABLE = "image_backend_unavailable"
     LAUNCH = "launch"

--- a/moonmind/schemas/container_job_models.py
+++ b/moonmind/schemas/container_job_models.py
@@ -66,6 +66,11 @@ class ContainerJobFailureClass(StrEnum):
     AUTHORIZATION = "authorization"
     WORKSPACE = "workspace"
     IMAGE = "image"
+    IMAGE_NOT_FOUND = "image_not_found"
+    IMAGE_PULL_TIMEOUT = "image_pull_timeout"
+    IMAGE_AUTH_FAILED = "image_auth_failed"
+    IMAGE_PLATFORM_MISMATCH = "image_platform_mismatch"
+    IMAGE_BACKEND_UNAVAILABLE = "image_backend_unavailable"
     LAUNCH = "launch"
     EXECUTION = "execution"
     TIMEOUT = "timeout"
@@ -349,6 +354,9 @@ class ContainerJobActivityRequest(TemporalContractModel):
     resolved_image_ref: str | None = Field(
         None, alias="resolvedImageRef", max_length=1024
     )
+    image_observation: ImageObservation | None = Field(
+        None, alias="imageObservation"
+    )
     container_ref: str | None = Field(None, alias="containerRef", max_length=1024)
     terminal_state: ContainerJobState | None = Field(None, alias="terminalState")
     projection_sequence: int = Field(0, alias="projectionSequence", ge=0)
@@ -375,6 +383,9 @@ class ContainerJobActivityResult(TemporalContractModel):
     )
     resolved_image_ref: str | None = Field(
         None, alias="resolvedImageRef", max_length=1024
+    )
+    image_observation: ImageObservation | None = Field(
+        None, alias="imageObservation"
     )
     container_ref: str | None = Field(None, alias="containerRef", max_length=1024)
     running: bool | None = None

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -7896,6 +7896,7 @@ class TemporalAgentRuntimeActivities:
             # ApplicationError type so the durable terminal outcome is exact.
             raise ApplicationError(
                 str(exc),
+                *([{"diagnosticsRef": exc.diagnostics_ref}] if exc.diagnostics_ref else []),
                 type=exc.failure_class.value,
                 non_retryable=exc.terminal,
             ) from exc

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -7875,13 +7875,27 @@ class TemporalAgentRuntimeActivities:
             raise TemporalActivityRuntimeError(
                 f"container-job backend is required for container_job.{operation}"
             )
+        from temporalio.exceptions import ApplicationError
+
         from moonmind.schemas.container_job_models import (
             ContainerJobActivityRequest,
             ContainerJobActivityResult,
         )
+        from moonmind.workflows.temporal.container_image_acquisition import (
+            ImageAcquisitionError,
+        )
 
         request = ContainerJobActivityRequest.model_validate(payload)
-        result = await getattr(self._container_job_backend, operation)(request)
+        try:
+            result = await getattr(self._container_job_backend, operation)(request)
+        except ImageAcquisitionError as exc:
+            # Surface the granular image failure class to the workflow via the
+            # ApplicationError type so the durable terminal outcome is exact.
+            raise ApplicationError(
+                str(exc),
+                type=exc.failure_class.value,
+                non_retryable=exc.terminal,
+            ) from exc
         return ContainerJobActivityResult.model_validate(result).model_dump(
             mode="json", by_alias=True, exclude_none=True
         )

--- a/moonmind/workflows/temporal/container_image_acquisition.py
+++ b/moonmind/workflows/temporal/container_image_acquisition.py
@@ -1,0 +1,305 @@
+"""Image acquisition coordination for the Docker container-job backend.
+
+Implements the normalization, failure classification, digest parsing, and
+cross-worker per-image acquisition lease used by the trusted ``docker-engine``
+backend to satisfy MoonLadderStudios/MoonMind#3256:
+
+- normalize an image reference into a stable identity for locking/diagnostics;
+- derive a bounded, backend-scoped lock key from that identity;
+- serialize acquisition of one missing image per normalized identity on a
+  selected backend without serializing unrelated images;
+- expire and recover a lease whose owning worker died;
+- classify pull failures into granular, non-secret failure classes.
+
+The lock is intentionally an injectable protocol so callers can supply a
+deterministic implementation in tests. The default implementation uses an
+atomic filesystem lease on a deployment-shared path, which matches the
+system-Docker cache scope (workers that share the daemon share the volume).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import re
+import time
+from dataclasses import dataclass
+from hashlib import sha256
+from pathlib import Path
+from typing import Awaitable, Callable, Protocol
+
+from moonmind.schemas.container_job_models import ContainerJobFailureClass
+
+_DEFAULT_REGISTRY = "docker.io"
+_DEFAULT_TAG = "latest"
+_SHA256 = re.compile(r"sha256:[0-9a-f]{64}")
+
+# Image failure classes that will not resolve by retrying the same request.
+_TERMINAL_IMAGE_FAILURES: frozenset[ContainerJobFailureClass] = frozenset(
+    {
+        ContainerJobFailureClass.IMAGE_NOT_FOUND,
+        ContainerJobFailureClass.IMAGE_AUTH_FAILED,
+        ContainerJobFailureClass.IMAGE_PLATFORM_MISMATCH,
+    }
+)
+
+
+@dataclass(frozen=True)
+class NormalizedImage:
+    """Canonical registry/repository/reference identity of a requested image."""
+
+    registry: str
+    repository: str
+    tag: str | None
+    digest: str | None
+
+    @property
+    def identity(self) -> str:
+        base = f"{self.registry}/{self.repository}"
+        if self.digest:
+            return f"{base}@{self.digest}"
+        return f"{base}:{self.tag or _DEFAULT_TAG}"
+
+
+def normalize_image_reference(image: str) -> NormalizedImage:
+    """Normalize a Docker image reference into a stable identity.
+
+    Applies Docker's default-registry, official-``library``-namespace, and
+    default-``latest``-tag rules so ``python`` and ``docker.io/library/python:latest``
+    lock and observe as the same identity.
+    """
+
+    ref = image.strip()
+    if not ref:
+        raise ValueError("image reference must not be empty")
+
+    digest: str | None = None
+    if "@" in ref:
+        ref, _, digest_part = ref.partition("@")
+        digest = digest_part.strip() or None
+
+    first, slash, rest = ref.partition("/")
+    if slash and ("." in first or ":" in first or first == "localhost"):
+        registry = first
+        remainder = rest
+    else:
+        registry = _DEFAULT_REGISTRY
+        remainder = ref
+
+    name = remainder
+    tag: str | None = None
+    last_slash = remainder.rfind("/")
+    colon = remainder.find(":", last_slash + 1)
+    if colon != -1:
+        name = remainder[:colon]
+        tag = remainder[colon + 1 :] or None
+
+    if not name:
+        raise ValueError("image reference must include a repository")
+
+    if registry == _DEFAULT_REGISTRY and "/" not in name:
+        name = f"library/{name}"
+
+    if digest is None and tag is None:
+        tag = _DEFAULT_TAG
+
+    return NormalizedImage(registry=registry, repository=name, tag=tag, digest=digest)
+
+
+def image_lock_key(backend_ref: str, normalized: NormalizedImage) -> str:
+    """Return a bounded, backend-scoped lock key for a normalized image.
+
+    The backend reference is part of the key so a future endpoint change cannot
+    reuse another backend's lease or report a false cache observation.
+    """
+
+    raw = f"{backend_ref}\n{normalized.identity}".encode()
+    return sha256(raw).hexdigest()
+
+
+def parse_resolved_digest(repo_digests: str, image_id: str) -> str | None:
+    """Return the exact ``sha256:`` digest for launch reproducibility.
+
+    Prefers a registry repo digest (``repo@sha256:...``); falls back to the
+    image config id when it is itself a content digest. Returns ``None`` when no
+    digest is observable (for example a locally built image without repo digests).
+    """
+
+    for candidate in re.split(r"[,\s]+", repo_digests or ""):
+        candidate = candidate.strip()
+        if not candidate:
+            continue
+        _, _, digest = candidate.partition("@")
+        match = _SHA256.fullmatch(digest.strip())
+        if match:
+            return match.group(0)
+    match = _SHA256.fullmatch((image_id or "").strip())
+    return match.group(0) if match else None
+
+
+def classify_pull_failure(stderr: str) -> ContainerJobFailureClass:
+    """Classify a ``docker pull`` failure into a granular, non-secret class."""
+
+    text = (stderr or "").lower()
+    if any(
+        token in text
+        for token in ("no matching manifest", "platform", "does not match")
+    ):
+        return ContainerJobFailureClass.IMAGE_PLATFORM_MISMATCH
+    if any(
+        token in text
+        for token in (
+            "cannot connect to the docker daemon",
+            "is the docker daemon running",
+            "connection refused",
+            "dial tcp",
+        )
+    ):
+        return ContainerJobFailureClass.IMAGE_BACKEND_UNAVAILABLE
+    if any(
+        token in text
+        for token in ("timeout", "timed out", "deadline exceeded", "context deadline")
+    ):
+        return ContainerJobFailureClass.IMAGE_PULL_TIMEOUT
+    if any(
+        token in text
+        for token in ("unauthorized", "authentication required", "docker login", "denied")
+    ):
+        return ContainerJobFailureClass.IMAGE_AUTH_FAILED
+    if any(
+        token in text
+        for token in (
+            "not found",
+            "manifest unknown",
+            "manifest for",
+            "repository does not exist",
+        )
+    ):
+        return ContainerJobFailureClass.IMAGE_NOT_FOUND
+    return ContainerJobFailureClass.IMAGE
+
+
+class ImageAcquisitionError(RuntimeError):
+    """Raised when image acquisition cannot satisfy the requested pull policy."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        failure_class: ContainerJobFailureClass,
+        diagnostics_ref: str | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.failure_class = failure_class
+        self.diagnostics_ref = diagnostics_ref
+
+    @property
+    def terminal(self) -> bool:
+        """Whether retrying the same request cannot change the outcome."""
+
+        return self.failure_class in _TERMINAL_IMAGE_FAILURES
+
+
+class ImageAcquisitionLock(Protocol):
+    """Cross-worker per-image acquisition lease abstraction."""
+
+    async def try_acquire(
+        self, key: str, *, ttl_seconds: float, owner_id: str
+    ) -> bool:
+        """Attempt to become the single pull owner for ``key``.
+
+        Returns ``True`` when this caller now owns the lease. An existing lease
+        whose deadline has passed is reclaimed so a dead owner never blocks
+        later jobs permanently.
+        """
+
+    async def release(self, key: str, owner_id: str) -> None:
+        """Release ``key`` only if still owned by ``owner_id``."""
+
+
+class FilesystemImageAcquisitionLock:
+    """Atomic filesystem lease keyed by backend-scoped normalized image identity.
+
+    Ownership is claimed with ``O_CREAT | O_EXCL`` so exactly one worker wins a
+    race. A lease records its owner and an expiry deadline; an expired lease is
+    reclaimed. The lease is never treated as proof that the image is present —
+    callers must re-inspect the daemon after acquiring or waiting.
+    """
+
+    def __init__(
+        self,
+        root: str | Path,
+        *,
+        clock: Callable[[], float] = time.time,
+    ) -> None:
+        self._root = Path(root)
+        self._clock = clock
+
+    def _path(self, key: str) -> Path:
+        return self._root / f"{key}.lease"
+
+    async def try_acquire(
+        self, key: str, *, ttl_seconds: float, owner_id: str
+    ) -> bool:
+        now = self._clock()
+        path = self._path(key)
+        payload = json.dumps(
+            {"owner": owner_id, "expiresAt": now + ttl_seconds}
+        ).encode()
+
+        def _attempt() -> bool:
+            self._root.mkdir(parents=True, exist_ok=True)
+            try:
+                fd = os.open(path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+            except FileExistsError:
+                if self._lease_active(path, now):
+                    return False
+                # Reclaim an expired/abandoned lease. A rare double-reclaim race
+                # is safe: correctness relies on re-inspection, not the lease.
+                try:
+                    os.unlink(path)
+                except FileNotFoundError:
+                    pass
+                try:
+                    fd = os.open(path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+                except FileExistsError:
+                    return False
+            with os.fdopen(fd, "wb") as handle:
+                handle.write(payload)
+            return True
+
+        return await asyncio.to_thread(_attempt)
+
+    async def release(self, key: str, owner_id: str) -> None:
+        path = self._path(key)
+
+        def _attempt() -> None:
+            record = self._read(path)
+            if record is not None and record.get("owner") == owner_id:
+                try:
+                    os.unlink(path)
+                except FileNotFoundError:
+                    pass
+
+        await asyncio.to_thread(_attempt)
+
+    @staticmethod
+    def _read(path: Path) -> dict | None:
+        try:
+            return json.loads(path.read_text())
+        except (OSError, ValueError):
+            return None
+
+    @classmethod
+    def _lease_active(cls, path: Path, now: float) -> bool:
+        record = cls._read(path)
+        if record is None:
+            return False
+        try:
+            return float(record.get("expiresAt", 0)) > now
+        except (TypeError, ValueError):
+            return False
+
+
+ProgressPublisher = Callable[[str, bytes], Awaitable[str | None]]

--- a/moonmind/workflows/temporal/container_image_acquisition.py
+++ b/moonmind/workflows/temporal/container_image_acquisition.py
@@ -39,7 +39,7 @@ _SHA256 = re.compile(r"sha256:[0-9a-f]{64}")
 _TERMINAL_IMAGE_FAILURES: frozenset[ContainerJobFailureClass] = frozenset(
     {
         ContainerJobFailureClass.IMAGE_NOT_FOUND,
-        ContainerJobFailureClass.IMAGE_AUTH_FAILED,
+        ContainerJobFailureClass.IMAGE_PULL_AUTH_FAILED,
         ContainerJobFailureClass.IMAGE_PLATFORM_MISMATCH,
     }
 )
@@ -166,7 +166,7 @@ def classify_pull_failure(stderr: str) -> ContainerJobFailureClass:
         token in text
         for token in ("unauthorized", "authentication required", "docker login", "denied")
     ):
-        return ContainerJobFailureClass.IMAGE_AUTH_FAILED
+        return ContainerJobFailureClass.IMAGE_PULL_AUTH_FAILED
     if any(
         token in text
         for token in (
@@ -260,6 +260,7 @@ class FilesystemImageAcquisitionLock:
                 try:
                     os.unlink(path)
                 except FileNotFoundError:
+                    # Another contender already reclaimed the expired lease.
                     pass
                 try:
                     fd = os.open(path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
@@ -280,6 +281,7 @@ class FilesystemImageAcquisitionLock:
                 try:
                     os.unlink(path)
                 except FileNotFoundError:
+                    # Another worker already released or reclaimed this lease.
                     pass
 
         await asyncio.to_thread(_attempt)
@@ -295,7 +297,12 @@ class FilesystemImageAcquisitionLock:
     def _lease_active(cls, path: Path, now: float) -> bool:
         record = cls._read(path)
         if record is None:
-            return False
+            try:
+                # A creator may have made the file but not written its payload.
+                # Preserve that atomic claim during this short initialization gap.
+                return (now - path.stat().st_mtime) < 10.0
+            except OSError:
+                return False
         try:
             return float(record.get("expiresAt", 0)) > now
         except (TypeError, ValueError):

--- a/moonmind/workflows/temporal/container_job_backend.py
+++ b/moonmind/workflows/temporal/container_job_backend.py
@@ -8,6 +8,8 @@ import json
 import os
 import re
 import tarfile
+import time
+import uuid
 from io import BytesIO
 from pathlib import Path
 from typing import Awaitable, Callable, Sequence
@@ -15,11 +17,29 @@ from typing import Awaitable, Callable, Sequence
 from moonmind.schemas.container_job_models import (
     ContainerJobActivityRequest,
     ContainerJobActivityResult,
+    ContainerJobFailureClass,
+    ImageObservation,
+)
+from moonmind.workflows.temporal.container_image_acquisition import (
+    FilesystemImageAcquisitionLock,
+    ImageAcquisitionError,
+    ImageAcquisitionLock,
+    classify_pull_failure,
+    image_lock_key,
+    normalize_image_reference,
+    parse_resolved_digest,
 )
 
 CommandRunner = Callable[[Sequence[str]], Awaitable[tuple[int, bytes, bytes]]]
 EvidencePublisher = Callable[[ContainerJobActivityRequest, str, bytes], Awaitable[str]]
 ProjectionWriter = Callable[[ContainerJobActivityRequest], Awaitable[None]]
+
+# Only the exact image id and registry repo digests are read; never the full
+# manifest, so unbounded inspect output cannot reach the observation payload.
+_INSPECT_FORMAT = "{{.Id}}\t{{join .RepoDigests \",\"}}"
+# Bytes of bounded pull progress retained as diagnostics evidence. The full,
+# unbounded pull output never crosses the activity/Temporal boundary.
+_PULL_DIAGNOSTICS_MAX_BYTES = 8192
 
 
 class DockerContainerJobBackend:
@@ -31,16 +51,32 @@ class DockerContainerJobBackend:
         workspace_root: str | Path,
         docker_binary: str = "docker",
         docker_host: str | None = None,
+        backend_ref: str = "system",
         command_runner: CommandRunner | None = None,
         evidence_publisher: EvidencePublisher | None = None,
         projection_writer: ProjectionWriter | None = None,
+        image_lock: ImageAcquisitionLock | None = None,
+        image_lock_root: str | Path | None = None,
+        pull_lease_ttl_seconds: float = 1800.0,
+        pull_lock_poll_seconds: float = 2.0,
+        pull_lock_max_wait_seconds: float = 280.0,
     ) -> None:
         self._workspace_root = Path(workspace_root).resolve()
         self._docker_binary = docker_binary
         self._docker_host = docker_host
+        self._backend_ref = backend_ref
         self._runner = command_runner or self._run
         self._publish = evidence_publisher
         self._write_projection = projection_writer
+        lock_root = (
+            Path(image_lock_root)
+            if image_lock_root is not None
+            else self._workspace_root / ".moonmind-image-acquisition-locks"
+        )
+        self._image_lock = image_lock or FilesystemImageAcquisitionLock(lock_root)
+        self._pull_lease_ttl_seconds = pull_lease_ttl_seconds
+        self._pull_lock_poll_seconds = pull_lock_poll_seconds
+        self._pull_lock_max_wait_seconds = pull_lock_max_wait_seconds
 
     async def _run(self, args: Sequence[str]) -> tuple[int, bytes, bytes]:
         env = os.environ.copy()
@@ -78,27 +114,207 @@ class DockerContainerJobBackend:
             raise RuntimeError("authorized container-job workspace is unavailable")
         return ContainerJobActivityResult(resolvedWorkspaceRef=str(workspace))
 
+    async def _inspect_image(
+        self, image: str
+    ) -> tuple[bool, str, str | None]:
+        """Return ``(present, resolved_launch_ref, resolved_digest)``.
+
+        Presence is probed on the selected daemon, never in the caller
+        container. The resolved launch reference is the exact image id so the
+        container launches the observed content, not a mutable tag.
+        """
+
+        code, stdout, _ = await self._runner(
+            ("image", "inspect", "--format", _INSPECT_FORMAT, image)
+        )
+        if code:
+            return False, image, None
+        text = stdout.decode(errors="replace").strip()
+        image_id, _, repo_digests = text.partition("\t")
+        image_id = image_id.strip()
+        digest = parse_resolved_digest(repo_digests, image_id)
+        return True, (image_id or image), digest
+
+    async def _publish_pull_diagnostics(
+        self,
+        request: ContainerJobActivityRequest,
+        stdout: bytes,
+        stderr: bytes,
+    ) -> str | None:
+        """Publish a bounded tail of pull output as durable diagnostics.
+
+        The bounded tail is the only pull output that leaves this activity; the
+        raw, potentially multi-gigabyte progress stream never reaches Temporal
+        history.
+        """
+
+        if self._publish is None:
+            return None
+        combined = stdout + (b"\n[stderr]\n" + stderr if stderr else b"")
+        bounded = combined[-_PULL_DIAGNOSTICS_MAX_BYTES:]
+        try:
+            return await self._publish(
+                request, f"{request.job_id}-image-pull.txt", bounded
+            )
+        except Exception:
+            # Diagnostics are auxiliary evidence and must never mask the pull
+            # outcome; a failure to persist them is tolerated.
+            return None
+
+    async def _pull_image(
+        self, request: ContainerJobActivityRequest, image: str
+    ) -> tuple[int, str | None]:
+        """Pull ``image``, returning ``(duration_ms, diagnostics_ref)``.
+
+        Raises :class:`ImageAcquisitionError` with a granular failure class when
+        the pull fails, attaching the bounded diagnostics reference.
+        """
+
+        started = time.monotonic()
+        code, stdout, stderr = await self._runner(("pull", image))
+        duration_ms = int((time.monotonic() - started) * 1000)
+        diagnostics_ref = await self._publish_pull_diagnostics(
+            request, stdout, stderr
+        )
+        if code:
+            failure = classify_pull_failure(stderr.decode(errors="replace"))
+            raise ImageAcquisitionError(
+                f"docker pull failed for the requested image ({failure.value})",
+                failure_class=failure,
+                diagnostics_ref=diagnostics_ref,
+            )
+        return duration_ms, diagnostics_ref
+
     async def acquire_image(self, request: ContainerJobActivityRequest):
-        if request.request.spec.registry_credential_ref:
+        spec = request.request.spec
+        if spec.registry_credential_ref:
             raise RuntimeError(
                 "registryCredentialRef is not supported by the selected Docker backend"
             )
-        image = request.request.spec.image
-        policy = request.request.spec.pull_policy
-        inspect_code, stdout, _ = await self._runner(
-            ("image", "inspect", "--format", "{{.Id}}", image)
+        # Workspace visibility is authorized before any expensive acquisition,
+        # so a missing-image pull can never precede workspace resolution.
+        if not request.resolved_workspace_ref:
+            raise ImageAcquisitionError(
+                "workspace must be resolved before image acquisition",
+                failure_class=ContainerJobFailureClass.WORKSPACE,
+            )
+
+        image = spec.image
+        policy = spec.pull_policy
+        normalized = normalize_image_reference(image)
+        key = image_lock_key(self._backend_ref, normalized)
+
+        present, resolved_ref, digest = await self._inspect_image(image)
+        present_at_start = present
+
+        # Cache reuse: a present image under a reuse policy pulls nothing.
+        if present and policy != "always":
+            return self._image_result(
+                resolved_ref,
+                requested=image,
+                digest=digest,
+                cache_present=True,
+                cache_hit=True,
+                lock_wait_ms=0,
+            )
+
+        if policy == "never":
+            raise ImageAcquisitionError(
+                "requested image is absent and pullPolicy=never",
+                failure_class=ContainerJobFailureClass.IMAGE_NOT_FOUND,
+            )
+
+        # A missing image (or an authorized `always` refresh) is acquired once
+        # per normalized identity on this backend while concurrent jobs wait and
+        # re-inspect. Unrelated images use distinct keys and are not serialized.
+        owner_id = f"{os.getpid()}:{request.job_id}:{uuid.uuid4().hex}"
+        waited_started = time.monotonic()
+        while True:
+            lock_wait_ms = int((time.monotonic() - waited_started) * 1000)
+            acquired = await self._image_lock.try_acquire(
+                key,
+                ttl_seconds=self._pull_lease_ttl_seconds,
+                owner_id=owner_id,
+            )
+            if acquired:
+                try:
+                    # Re-inspect after winning the lease: a concurrent owner may
+                    # have completed the pull, and the lease alone is never
+                    # treated as proof the image is present.
+                    present, resolved_ref, digest = await self._inspect_image(image)
+                    if present and policy != "always":
+                        return self._image_result(
+                            resolved_ref,
+                            requested=image,
+                            digest=digest,
+                            cache_present=present_at_start,
+                            cache_hit=True,
+                            lock_wait_ms=lock_wait_ms,
+                        )
+                    pull_ms, diagnostics_ref = await self._pull_image(request, image)
+                    present, resolved_ref, digest = await self._inspect_image(image)
+                    if not present:
+                        raise ImageAcquisitionError(
+                            "image is still absent after a completed pull",
+                            failure_class=ContainerJobFailureClass.IMAGE,
+                            diagnostics_ref=diagnostics_ref,
+                        )
+                    return self._image_result(
+                        resolved_ref,
+                        requested=image,
+                        digest=digest,
+                        cache_present=present_at_start,
+                        cache_hit=False,
+                        lock_wait_ms=lock_wait_ms,
+                        pull_duration_ms=pull_ms,
+                        diagnostics_ref=diagnostics_ref,
+                    )
+                finally:
+                    await self._image_lock.release(key, owner_id)
+
+            # Another worker owns the pull; wait, then re-inspect for reuse.
+            await asyncio.sleep(self._pull_lock_poll_seconds)
+            present, resolved_ref, digest = await self._inspect_image(image)
+            if present and policy != "always":
+                return self._image_result(
+                    resolved_ref,
+                    requested=image,
+                    digest=digest,
+                    cache_present=False,
+                    cache_hit=True,
+                    lock_wait_ms=int((time.monotonic() - waited_started) * 1000),
+                )
+            if time.monotonic() - waited_started > self._pull_lock_max_wait_seconds:
+                raise ImageAcquisitionError(
+                    "timed out waiting for a concurrent image pull to complete",
+                    failure_class=ContainerJobFailureClass.IMAGE_PULL_TIMEOUT,
+                )
+
+    def _image_result(
+        self,
+        resolved_ref: str,
+        *,
+        requested: str,
+        digest: str | None,
+        cache_present: bool,
+        cache_hit: bool,
+        lock_wait_ms: int,
+        pull_duration_ms: int | None = None,
+        diagnostics_ref: str | None = None,
+    ) -> ContainerJobActivityResult:
+        observation = ImageObservation(
+            requestedReference=requested,
+            resolvedDigest=digest,
+            cachePresent=cache_present,
+            cacheHit=cache_hit,
+            pullLockWaitMs=max(0, lock_wait_ms),
+            pullDurationMs=pull_duration_ms,
         )
-        if policy == "always" or (inspect_code and policy == "if-missing"):
-            await self._checked("pull", image)
-            inspect_code, stdout, _ = await self._runner(
-                ("image", "inspect", "--format", "{{.Id}}", image)
-            )
-        if inspect_code:
-            raise RuntimeError(
-                "container image is unavailable under the selected pull policy"
-            )
-        resolved = stdout.decode(errors="replace").strip() or image
-        return ContainerJobActivityResult(resolvedImageRef=resolved)
+        return ContainerJobActivityResult(
+            resolvedImageRef=resolved_ref,
+            imageObservation=observation,
+            diagnosticsRef=diagnostics_ref,
+        )
 
     async def reconcile_container(self, request: ContainerJobActivityRequest):
         name = self._name(request)

--- a/moonmind/workflows/temporal/container_job_backend.py
+++ b/moonmind/workflows/temporal/container_job_backend.py
@@ -185,7 +185,7 @@ class DockerContainerJobBackend:
         projection_writer: ProjectionWriter | None = None,
         image_lock: ImageAcquisitionLock | None = None,
         image_lock_root: str | Path | None = None,
-        pull_lease_ttl_seconds: float = 1800.0,
+        pull_lease_ttl_seconds: float = 240.0,
         pull_lock_poll_seconds: float = 2.0,
         pull_lock_max_wait_seconds: float = 280.0,
         secret_resolver: SecretResolver | None = None,
@@ -205,7 +205,7 @@ class DockerContainerJobBackend:
         lock_root = (
             Path(image_lock_root)
             if image_lock_root is not None
-            else self._workspace_root / ".moonmind-image-acquisition-locks"
+            else self._workspace_root.parent / ".moonmind-image-acquisition-locks"
         )
         self._image_lock = image_lock or FilesystemImageAcquisitionLock(lock_root)
         self._pull_lease_ttl_seconds = pull_lease_ttl_seconds
@@ -386,10 +386,19 @@ class DockerContainerJobBackend:
         container launches the observed content, not a mutable tag.
         """
 
-        code, stdout, _ = await self._runner(
+        code, stdout, stderr = await self._runner(
             ("image", "inspect", "--format", _INSPECT_FORMAT, image)
         )
         if code:
+            detail = stderr.decode(errors="replace")
+            if "no such image" not in detail.lower() and "not found" not in detail.lower():
+                failure = classify_pull_failure(detail)
+                if failure == ContainerJobFailureClass.IMAGE:
+                    failure = ContainerJobFailureClass.IMAGE_BACKEND_UNAVAILABLE
+                raise ImageAcquisitionError(
+                    "docker image inspection failed",
+                    failure_class=failure,
+                )
             return False, image, None
         text = stdout.decode(errors="replace").strip()
         image_id, _, repo_digests = text.partition("\t")

--- a/moonmind/workflows/temporal/worker_runtime.py
+++ b/moonmind/workflows/temporal/worker_runtime.py
@@ -2328,15 +2328,12 @@ async def _container_job_projection_writer(request) -> None:
         ) or record.state
         record.backend_kind = "docker-engine"
         record.backend_ref = "system"
-        if request.resolved_image_ref:
-            record.image_observation_json = {
-                "requestedReference": request.request.spec.image,
-                "resolvedDigest": request.resolved_image_ref
-                if request.resolved_image_ref.startswith("sha256:") else None,
-                "cachePresent": True,
-                "cacheHit": True,
-                "pullLockWaitMs": 0,
-            }
+        if request.image_observation is not None:
+            # Persist the exact, backend-scoped observation produced by the
+            # trusted acquisition service; never fabricate cache/pull evidence.
+            record.image_observation_json = request.image_observation.model_dump(
+                mode="json", by_alias=True, exclude_none=True
+            )
         if request.exit_code is not None or request.failure_class or request.message:
             record.terminal_outcome_json = {
                 "exitCode": request.exit_code,

--- a/moonmind/workflows/temporal/workflows/container_job.py
+++ b/moonmind/workflows/temporal/workflows/container_job.py
@@ -8,6 +8,7 @@ from typing import Any
 
 from temporalio import workflow
 from temporalio.common import RetryPolicy
+from temporalio.exceptions import ActivityError, ApplicationError
 
 with workflow.unsafe.imports_passed_through():
     from moonmind.schemas.container_job_models import (
@@ -26,6 +27,30 @@ with workflow.unsafe.imports_passed_through():
 
 CATALOG = build_default_activity_catalog()
 _TERMINAL = frozenset({"succeeded", "failed", "canceled", "timed_out"})
+# Granular image-acquisition failure classes surfaced by the trusted backend
+# through the ApplicationError type, mapped back onto the durable outcome.
+_IMAGE_FAILURE_TYPES = frozenset(
+    {
+        ContainerJobFailureClass.IMAGE.value,
+        ContainerJobFailureClass.IMAGE_NOT_FOUND.value,
+        ContainerJobFailureClass.IMAGE_PULL_TIMEOUT.value,
+        ContainerJobFailureClass.IMAGE_AUTH_FAILED.value,
+        ContainerJobFailureClass.IMAGE_PLATFORM_MISMATCH.value,
+        ContainerJobFailureClass.IMAGE_BACKEND_UNAVAILABLE.value,
+        ContainerJobFailureClass.WORKSPACE.value,
+    }
+)
+
+
+def _acquisition_failure_class(exc: BaseException) -> ContainerJobFailureClass | None:
+    """Return the granular failure class carried by an acquisition error."""
+
+    error: BaseException | None = exc
+    if isinstance(error, ActivityError) and error.cause is not None:
+        error = error.cause
+    if isinstance(error, ApplicationError) and error.type in _IMAGE_FAILURE_TYPES:
+        return ContainerJobFailureClass(error.type)
+    return None
 
 
 @workflow.defn(name="MoonMind.ContainerJob")
@@ -124,6 +149,7 @@ class MoonMindContainerJobWorkflow:
                 await self._project(request, ContainerJobState.ACQUIRING_IMAGE)
                 image = await self._activity("container_job.acquire_image", request)
                 request.resolved_image_ref = image.resolved_image_ref
+                request.image_observation = image.image_observation
             if not self._cancel_requested:
                 reconciled = await self._activity(
                     "container_job.reconcile_container", request
@@ -171,7 +197,10 @@ class MoonMindContainerJobWorkflow:
             message = "container job exceeded its timeout"
         except Exception as exc:
             terminal_state = ContainerJobState.FAILED
-            failure_class = ContainerJobFailureClass.INFRASTRUCTURE
+            failure_class = (
+                _acquisition_failure_class(exc)
+                or ContainerJobFailureClass.INFRASTRUCTURE
+            )
             message = str(exc)[:2048]
 
         request.terminal_state = terminal_state

--- a/moonmind/workflows/temporal/workflows/container_job.py
+++ b/moonmind/workflows/temporal/workflows/container_job.py
@@ -34,7 +34,7 @@ _IMAGE_FAILURE_TYPES = frozenset(
         ContainerJobFailureClass.IMAGE.value,
         ContainerJobFailureClass.IMAGE_NOT_FOUND.value,
         ContainerJobFailureClass.IMAGE_PULL_TIMEOUT.value,
-        ContainerJobFailureClass.IMAGE_AUTH_FAILED.value,
+        ContainerJobFailureClass.IMAGE_PULL_AUTH_FAILED.value,
         ContainerJobFailureClass.IMAGE_PLATFORM_MISMATCH.value,
         ContainerJobFailureClass.IMAGE_BACKEND_UNAVAILABLE.value,
         ContainerJobFailureClass.WORKSPACE.value,

--- a/tests/unit/workflows/temporal/test_container_image_acquisition.py
+++ b/tests/unit/workflows/temporal/test_container_image_acquisition.py
@@ -73,7 +73,7 @@ def test_digest_parsing_prefers_repo_digest_then_id() -> None:
     [
         ("manifest unknown", ContainerJobFailureClass.IMAGE_NOT_FOUND),
         ("repository does not exist", ContainerJobFailureClass.IMAGE_NOT_FOUND),
-        ("unauthorized: authentication required", ContainerJobFailureClass.IMAGE_AUTH_FAILED),
+        ("unauthorized: authentication required", ContainerJobFailureClass.IMAGE_PULL_AUTH_FAILED),
         ("net/http: request canceled (timeout)", ContainerJobFailureClass.IMAGE_PULL_TIMEOUT),
         ("no matching manifest for linux/arm64", ContainerJobFailureClass.IMAGE_PLATFORM_MISMATCH),
         ("Cannot connect to the Docker daemon", ContainerJobFailureClass.IMAGE_BACKEND_UNAVAILABLE),
@@ -112,6 +112,18 @@ async def test_expired_lease_is_reclaimed_without_permanent_block(tmp_path) -> N
     assert await lock.try_acquire("k", ttl_seconds=10, owner_id="later")
 
 
+@pytest.mark.asyncio
+async def test_recent_empty_lease_preserves_creator_claim(tmp_path) -> None:
+    now = 100.0
+    lease = tmp_path / "k.lease"
+    lease.touch()
+    lease.chmod(0o600)
+    lock = FilesystemImageAcquisitionLock(tmp_path, clock=lambda: now)
+
+    # Simulate the gap between O_EXCL creation and writing the lease payload.
+    assert not await lock.try_acquire("k", ttl_seconds=10, owner_id="contender")
+
+
 # --------------------------------------------------------------------------- #
 # Backend acquisition scenarios.
 # --------------------------------------------------------------------------- #
@@ -134,10 +146,10 @@ def _request(
                 "spec": {
                     "image": image,
                     "pullPolicy": policy,
-                    "workspaceRef": {
-                        "kind": "artifact-workspace",
-                        "artifactRef": "art_workspace",
-                    },
+                        "workspaceRef": {
+                            "kind": "sandbox",
+                            "workspaceId": "art_workspace",
+                        },
                     "resources": {"cpuMillis": 1000, "memoryMiB": 512},
                 },
             },
@@ -224,6 +236,24 @@ async def test_never_without_image_fails_image_not_found_without_pull(tmp_path) 
     assert excinfo.value.failure_class == ContainerJobFailureClass.IMAGE_NOT_FOUND
     assert excinfo.value.terminal is True
     assert daemon.pulls == []
+
+
+@pytest.mark.asyncio
+async def test_never_preserves_backend_inspect_failure(tmp_path) -> None:
+    async def unavailable(args):
+        return 1, b"", b"Cannot connect to the Docker daemon"
+
+    backend = DockerContainerJobBackend(
+        workspace_root=tmp_path,
+        command_runner=unavailable,
+        image_lock_root=tmp_path / "locks",
+    )
+    with pytest.raises(ImageAcquisitionError) as excinfo:
+        await backend.acquire_image(_request("python:3.13", policy="never"))
+    assert (
+        excinfo.value.failure_class
+        == ContainerJobFailureClass.IMAGE_BACKEND_UNAVAILABLE
+    )
 
 
 @pytest.mark.asyncio
@@ -363,3 +393,22 @@ async def test_activity_marks_transient_image_error_retryable() -> None:
         await activities.container_job_acquire_image(payload)
     assert excinfo.value.type == "image_backend_unavailable"
     assert excinfo.value.non_retryable is False
+
+
+@pytest.mark.asyncio
+async def test_activity_preserves_image_diagnostics_reference() -> None:
+    class Backend:
+        async def acquire_image(self, request):
+            raise ImageAcquisitionError(
+                "pull failed",
+                failure_class=ContainerJobFailureClass.IMAGE_PULL_AUTH_FAILED,
+                diagnostics_ref="artifact://pull-diagnostics",
+            )
+
+    activities = TemporalAgentRuntimeActivities(container_job_backend=Backend())
+    payload = _request("python:3.13").model_dump(
+        mode="json", by_alias=True, exclude_none=True
+    )
+    with pytest.raises(ApplicationError) as excinfo:
+        await activities.container_job_acquire_image(payload)
+    assert excinfo.value.details == ({"diagnosticsRef": "artifact://pull-diagnostics"},)

--- a/tests/unit/workflows/temporal/test_container_image_acquisition.py
+++ b/tests/unit/workflows/temporal/test_container_image_acquisition.py
@@ -1,0 +1,365 @@
+"""Image acquisition coordination coverage for MoonLadderStudios/MoonMind#3256."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from temporalio.exceptions import ApplicationError
+
+from moonmind.schemas.container_job_models import (
+    ContainerJobActivityRequest,
+    ContainerJobFailureClass,
+)
+from moonmind.workflows.temporal.activity_runtime import TemporalAgentRuntimeActivities
+from moonmind.workflows.temporal.container_image_acquisition import (
+    FilesystemImageAcquisitionLock,
+    ImageAcquisitionError,
+    classify_pull_failure,
+    image_lock_key,
+    normalize_image_reference,
+    parse_resolved_digest,
+)
+from moonmind.workflows.temporal.container_job_backend import DockerContainerJobBackend
+
+JOB_ID = "container-job:0123456789abcdef0123456789abcdef"
+DIGEST_A = "sha256:" + "a" * 64
+DIGEST_B = "sha256:" + "b" * 64
+
+
+# --------------------------------------------------------------------------- #
+# Pure helpers: normalization, lock keys, digest parsing, classification.
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    ("image", "identity"),
+    [
+        ("python", "docker.io/library/python:latest"),
+        ("python:3.13", "docker.io/library/python:3.13"),
+        ("library/python:3.13", "docker.io/library/python:3.13"),
+        ("docker.io/library/python:3.13", "docker.io/library/python:3.13"),
+        ("ghcr.io/org/app:1.2", "ghcr.io/org/app:1.2"),
+        ("localhost:5000/app:dev", "localhost:5000/app:dev"),
+        (f"org/app@{DIGEST_A}", f"docker.io/org/app@{DIGEST_A}"),
+    ],
+)
+def test_normalization_produces_stable_identity(image: str, identity: str) -> None:
+    assert normalize_image_reference(image).identity == identity
+
+
+def test_equivalent_references_share_a_lock_key_but_backends_do_not() -> None:
+    a = normalize_image_reference("python")
+    b = normalize_image_reference("docker.io/library/python:latest")
+    assert image_lock_key("system", a) == image_lock_key("system", b)
+    assert image_lock_key("system", a) != image_lock_key("other", a)
+
+
+def test_distinct_images_do_not_share_a_lock_key() -> None:
+    system = "system"
+    assert image_lock_key(
+        system, normalize_image_reference("python:3.13")
+    ) != image_lock_key(system, normalize_image_reference("python:3.12"))
+
+
+def test_digest_parsing_prefers_repo_digest_then_id() -> None:
+    assert parse_resolved_digest(f"repo@{DIGEST_A}", DIGEST_B) == DIGEST_A
+    assert parse_resolved_digest("", DIGEST_B) == DIGEST_B
+    assert parse_resolved_digest("", "not-a-digest") is None
+
+
+@pytest.mark.parametrize(
+    ("stderr", "expected"),
+    [
+        ("manifest unknown", ContainerJobFailureClass.IMAGE_NOT_FOUND),
+        ("repository does not exist", ContainerJobFailureClass.IMAGE_NOT_FOUND),
+        ("unauthorized: authentication required", ContainerJobFailureClass.IMAGE_AUTH_FAILED),
+        ("net/http: request canceled (timeout)", ContainerJobFailureClass.IMAGE_PULL_TIMEOUT),
+        ("no matching manifest for linux/arm64", ContainerJobFailureClass.IMAGE_PLATFORM_MISMATCH),
+        ("Cannot connect to the Docker daemon", ContainerJobFailureClass.IMAGE_BACKEND_UNAVAILABLE),
+        ("something unexpected", ContainerJobFailureClass.IMAGE),
+    ],
+)
+def test_pull_failure_classification(stderr: str, expected) -> None:
+    assert classify_pull_failure(stderr) == expected
+
+
+# --------------------------------------------------------------------------- #
+# Filesystem lease: mutual exclusion, ownership-scoped release, expiry recovery.
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_lease_is_mutually_exclusive_and_release_is_owner_scoped(tmp_path) -> None:
+    lock = FilesystemImageAcquisitionLock(tmp_path, clock=lambda: 0.0)
+    assert await lock.try_acquire("k", ttl_seconds=60, owner_id="a")
+    assert not await lock.try_acquire("k", ttl_seconds=60, owner_id="b")
+    # A non-owner cannot release the lease out from under the owner.
+    await lock.release("k", "b")
+    assert not await lock.try_acquire("k", ttl_seconds=60, owner_id="b")
+    await lock.release("k", "a")
+    assert await lock.try_acquire("k", ttl_seconds=60, owner_id="b")
+
+
+@pytest.mark.asyncio
+async def test_expired_lease_is_reclaimed_without_permanent_block(tmp_path) -> None:
+    now = {"t": 0.0}
+    lock = FilesystemImageAcquisitionLock(tmp_path, clock=lambda: now["t"])
+    assert await lock.try_acquire("k", ttl_seconds=10, owner_id="dead-owner")
+    now["t"] = 5.0
+    assert not await lock.try_acquire("k", ttl_seconds=10, owner_id="later")
+    now["t"] = 20.0  # the owning worker died; its lease has expired.
+    assert await lock.try_acquire("k", ttl_seconds=10, owner_id="later")
+
+
+# --------------------------------------------------------------------------- #
+# Backend acquisition scenarios.
+# --------------------------------------------------------------------------- #
+
+
+def _request(
+    image: str,
+    *,
+    policy: str = "if-missing",
+    workspace: str | None = "ws:resolved",
+) -> ContainerJobActivityRequest:
+    return ContainerJobActivityRequest.model_validate(
+        {
+            "jobId": JOB_ID,
+            "ownershipToken": f"{JOB_ID}:v1",
+            "resolvedWorkspaceRef": workspace,
+            "request": {
+                "idempotencyKey": "issue-3256",
+                "source": {"source": "workflow", "workflowId": "mm:3256"},
+                "spec": {
+                    "image": image,
+                    "pullPolicy": policy,
+                    "workspaceRef": {
+                        "kind": "artifact-workspace",
+                        "artifactRef": "art_workspace",
+                    },
+                    "resources": {"cpuMillis": 1000, "memoryMiB": 512},
+                },
+            },
+        }
+    )
+
+
+class FakeDaemon:
+    """In-memory Docker CLI stand-in tracking presence and pull commands."""
+
+    def __init__(self, present: dict[str, tuple[str, str]] | None = None) -> None:
+        # image -> (image_id, repo_digests_csv)
+        self.present: dict[str, tuple[str, str]] = dict(present or {})
+        self.pulls: list[str] = []
+        self.pull_fails_with: bytes | None = None
+        self._pull_hook = None
+
+    def set_pull_hook(self, hook) -> None:
+        self._pull_hook = hook
+
+    async def runner(self, args):
+        args = tuple(args)
+        if args[:2] == ("image", "inspect"):
+            image = args[-1]
+            if image in self.present:
+                image_id, repo = self.present[image]
+                return 0, f"{image_id}\t{repo}".encode(), b""
+            return 1, b"", b"No such image"
+        if args[0] == "pull":
+            image = args[1]
+            self.pulls.append(image)
+            if self._pull_hook is not None:
+                await self._pull_hook(image)
+            if self.pull_fails_with is not None:
+                return 1, b"", self.pull_fails_with
+            self.present.setdefault(image, (DIGEST_A, f"{image}@{DIGEST_A}"))
+            return 0, b"pull progress\n" * 3, b""
+        return 0, b"", b""
+
+
+def _backend(daemon: FakeDaemon, tmp_path, **kwargs) -> DockerContainerJobBackend:
+    return DockerContainerJobBackend(
+        workspace_root=tmp_path,
+        command_runner=daemon.runner,
+        image_lock_root=tmp_path / "locks",
+        pull_lock_poll_seconds=0.01,
+        pull_lock_max_wait_seconds=5.0,
+        **kwargs,
+    )
+
+
+@pytest.mark.asyncio
+async def test_if_missing_present_is_cache_hit_without_pull(tmp_path) -> None:
+    daemon = FakeDaemon({"python:3.13": (DIGEST_A, f"python@{DIGEST_A}")})
+    backend = _backend(daemon, tmp_path)
+    result = await backend.acquire_image(_request("python:3.13"))
+    assert daemon.pulls == []
+    obs = result.image_observation
+    assert obs.cache_present and obs.cache_hit
+    assert obs.resolved_digest == DIGEST_A
+    assert obs.pull_duration_ms is None
+    assert result.resolved_image_ref == DIGEST_A
+
+
+@pytest.mark.asyncio
+async def test_if_missing_absent_pulls_and_records_duration(tmp_path) -> None:
+    daemon = FakeDaemon()
+    backend = _backend(daemon, tmp_path)
+    result = await backend.acquire_image(_request("python:3.13"))
+    assert daemon.pulls == ["python:3.13"]
+    obs = result.image_observation
+    assert not obs.cache_present
+    assert not obs.cache_hit
+    assert obs.resolved_digest == DIGEST_A
+    assert obs.pull_duration_ms is not None and obs.pull_duration_ms >= 0
+
+
+@pytest.mark.asyncio
+async def test_never_without_image_fails_image_not_found_without_pull(tmp_path) -> None:
+    daemon = FakeDaemon()
+    backend = _backend(daemon, tmp_path)
+    with pytest.raises(ImageAcquisitionError) as excinfo:
+        await backend.acquire_image(_request("python:3.13", policy="never"))
+    assert excinfo.value.failure_class == ContainerJobFailureClass.IMAGE_NOT_FOUND
+    assert excinfo.value.terminal is True
+    assert daemon.pulls == []
+
+
+@pytest.mark.asyncio
+async def test_never_with_present_image_is_cache_hit(tmp_path) -> None:
+    daemon = FakeDaemon({"python:3.13": (DIGEST_A, f"python@{DIGEST_A}")})
+    backend = _backend(daemon, tmp_path)
+    result = await backend.acquire_image(_request("python:3.13", policy="never"))
+    assert daemon.pulls == []
+    assert result.image_observation.cache_hit
+
+
+@pytest.mark.asyncio
+async def test_always_refreshes_present_image_and_records_digest(tmp_path) -> None:
+    daemon = FakeDaemon({"python:3.13": (DIGEST_A, f"python@{DIGEST_A}")})
+    backend = _backend(daemon, tmp_path)
+    result = await backend.acquire_image(_request("python:3.13", policy="always"))
+    assert daemon.pulls == ["python:3.13"]
+    obs = result.image_observation
+    assert obs.cache_present  # present at start
+    assert not obs.cache_hit  # but refreshed anyway
+    assert obs.resolved_digest == DIGEST_A
+
+
+@pytest.mark.asyncio
+async def test_acquire_requires_resolved_workspace_before_pull(tmp_path) -> None:
+    daemon = FakeDaemon()
+    backend = _backend(daemon, tmp_path)
+    with pytest.raises(ImageAcquisitionError) as excinfo:
+        await backend.acquire_image(_request("python:3.13", workspace=None))
+    assert excinfo.value.failure_class == ContainerJobFailureClass.WORKSPACE
+    assert daemon.pulls == []
+
+
+@pytest.mark.asyncio
+async def test_pull_failure_is_classified_and_terminal(tmp_path) -> None:
+    daemon = FakeDaemon()
+    daemon.pull_fails_with = b"manifest unknown: manifest unknown"
+    backend = _backend(daemon, tmp_path)
+    with pytest.raises(ImageAcquisitionError) as excinfo:
+        await backend.acquire_image(_request("python:3.13"))
+    assert excinfo.value.failure_class == ContainerJobFailureClass.IMAGE_NOT_FOUND
+
+
+@pytest.mark.asyncio
+async def test_concurrent_jobs_pull_missing_image_once(tmp_path) -> None:
+    daemon = FakeDaemon()
+    slow = asyncio.Event()
+
+    async def hook(image: str) -> None:
+        # Hold the pull long enough that the second job must wait on the lease.
+        await asyncio.sleep(0.05)
+        slow.set()
+
+    daemon.set_pull_hook(hook)
+    backend = _backend(daemon, tmp_path)
+    results = await asyncio.gather(
+        backend.acquire_image(_request("python:3.13")),
+        backend.acquire_image(_request("python:3.13")),
+    )
+    assert daemon.pulls == ["python:3.13"]  # exactly one acquisition
+    hits = [r.image_observation.cache_hit for r in results]
+    # One job owned the pull; the other waited and reused the result.
+    assert sorted(hits) == [False, True]
+    waiter = next(r for r in results if r.image_observation.cache_hit)
+    assert waiter.image_observation.pull_lock_wait_ms >= 0
+
+
+@pytest.mark.asyncio
+async def test_concurrent_jobs_for_different_images_are_not_serialized(tmp_path) -> None:
+    daemon = FakeDaemon()
+    backend = _backend(daemon, tmp_path)
+    await asyncio.gather(
+        backend.acquire_image(_request("python:3.13")),
+        backend.acquire_image(_request("node:20")),
+    )
+    assert sorted(daemon.pulls) == ["node:20", "python:3.13"]
+
+
+@pytest.mark.asyncio
+async def test_lease_alone_is_not_proof_owner_reinspects_before_pull(tmp_path) -> None:
+    # The image appears (another worker pulled it) between the initial inspect
+    # and winning the lease; the owner must re-inspect and skip its own pull.
+    daemon = FakeDaemon()
+    backend = _backend(daemon, tmp_path)
+
+    original_inspect = backend._inspect_image
+    calls = {"n": 0}
+
+    async def inspect(image: str):
+        calls["n"] += 1
+        if calls["n"] == 2:
+            daemon.present[image] = (DIGEST_A, f"{image}@{DIGEST_A}")
+        return await original_inspect(image)
+
+    backend._inspect_image = inspect  # type: ignore[assignment]
+    result = await backend.acquire_image(_request("python:3.13"))
+    assert daemon.pulls == []
+    assert result.image_observation.cache_hit
+
+
+# --------------------------------------------------------------------------- #
+# Activity boundary: granular failure classes surface as ApplicationError types.
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_activity_translates_image_error_to_application_error() -> None:
+    class Backend:
+        async def acquire_image(self, request):
+            raise ImageAcquisitionError(
+                "absent", failure_class=ContainerJobFailureClass.IMAGE_NOT_FOUND
+            )
+
+    activities = TemporalAgentRuntimeActivities(container_job_backend=Backend())
+    req = _request("python:3.13", policy="never")
+    payload = req.model_dump(mode="json", by_alias=True, exclude_none=True)
+    with pytest.raises(ApplicationError) as excinfo:
+        await activities.container_job_acquire_image(payload)
+    assert excinfo.value.type == "image_not_found"
+    assert excinfo.value.non_retryable is True
+
+
+@pytest.mark.asyncio
+async def test_activity_marks_transient_image_error_retryable() -> None:
+    class Backend:
+        async def acquire_image(self, request):
+            raise ImageAcquisitionError(
+                "backend down",
+                failure_class=ContainerJobFailureClass.IMAGE_BACKEND_UNAVAILABLE,
+            )
+
+    activities = TemporalAgentRuntimeActivities(container_job_backend=Backend())
+    payload = _request("python:3.13").model_dump(
+        mode="json", by_alias=True, exclude_none=True
+    )
+    with pytest.raises(ApplicationError) as excinfo:
+        await activities.container_job_acquire_image(payload)
+    assert excinfo.value.type == "image_backend_unavailable"
+    assert excinfo.value.non_retryable is False

--- a/tests/unit/workflows/temporal/test_container_job_workflow.py
+++ b/tests/unit/workflows/temporal/test_container_job_workflow.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 from unittest.mock import AsyncMock
 
 import pytest
+from temporalio.exceptions import ApplicationError
 
 from moonmind.config.settings import settings
 from moonmind.schemas.container_job_models import (
     ContainerJobActivityResult,
     ContainerJobWorkflowInput,
+    ImageObservation,
     container_job_workflow_id,
 )
 from moonmind.workflows.temporal.activity_catalog import build_default_activity_catalog
@@ -284,3 +286,56 @@ async def test_terminal_projection_carries_authoritative_evidence(
     assert terminal.cleanup_outcome.state == "succeeded"
     assert terminal.logs_ref == "art:logs"
     assert terminal.artifacts_ref == "art:outputs"
+
+
+@pytest.mark.asyncio
+async def test_image_acquisition_failure_maps_to_granular_failure_class(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    job = MoonMindContainerJobWorkflow()
+
+    async def activity(name, request):
+        if name == "container_job.acquire_image":
+            # The trusted backend surfaces the class via the ApplicationError type.
+            raise ApplicationError("image absent", type="image_not_found")
+        return _result_for(name)
+
+    monkeypatch.setattr(job, "_activity", activity)
+    result = await job.run(_input().model_dump(mode="json", by_alias=True))
+    assert result["state"] == "failed"
+    assert result["terminal"]["failureClass"] == "image_not_found"
+
+
+@pytest.mark.asyncio
+async def test_image_observation_threads_into_terminal_projection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    job = MoonMindContainerJobWorkflow()
+    projections = []
+    digest = "sha256:" + "d" * 64
+
+    async def activity(name, request):
+        if name == "container_job.project_status":
+            projections.append(request.model_copy(deep=True))
+        if name == "container_job.acquire_image":
+            return ContainerJobActivityResult(
+                resolvedImageRef=digest,
+                imageObservation=ImageObservation(
+                    requestedReference="python:3.13",
+                    resolvedDigest=digest,
+                    cachePresent=False,
+                    cacheHit=False,
+                    pullLockWaitMs=12,
+                    pullDurationMs=345,
+                ),
+            )
+        return _result_for(name)
+
+    monkeypatch.setattr(job, "_activity", activity)
+    await job.run(_input().model_dump(mode="json", by_alias=True))
+
+    terminal = projections[-1]
+    assert terminal.image_observation is not None
+    assert terminal.image_observation.resolved_digest == digest
+    assert terminal.image_observation.pull_duration_ms == 345
+    assert terminal.image_observation.pull_lock_wait_ms == 12


### PR DESCRIPTION
## Issue

Implements MoonLadderStudios/MoonMind#3256 — Docker Backend: Coordinate image acquisition and cross-workflow cache reuse.

Closes MoonLadderStudios/MoonMind#3256

## Summary

The container-job Docker backend now governs image acquisition against the deployment-selected daemon instead of delegating availability to `docker run` and fabricating cache evidence.

- **New `container_image_acquisition` module**: reference normalization, backend-scoped lock keys, exact resolved-digest parsing (prefers `RepoDigests`, falls back to image id), granular pull-failure classification, and an atomic cross-worker filesystem acquisition lease (`O_CREAT|O_EXCL`) with TTL-based expiry/recovery when the owner worker dies.
- **Rewrote `DockerContainerJobBackend.acquire_image`**: inspect-before-pull; honors `if-missing` (default) / `always` / `never` policy; re-inspects after winning the lease (the lease is never treated as proof of presence); waiters re-inspect and reuse a single pull per normalized image identity while distinct images are not globally serialized; emits bounded (8192-byte) pull diagnostics without placing unbounded pull output in Temporal history.
- **Granular failure classes** (`image_not_found`, `image_pull_timeout`, `image_auth_failed`, `image_platform_mismatch`, `image_backend_unavailable`) surfaced to the durable terminal outcome via the `ApplicationError` type at the activity boundary; `never` on an absent image fails with `image_not_found` and never pulls.
- **Real `ImageObservation`** (`cachePresent` / `cacheHit` / `pullLockWaitMs` / `pullDurationMs` / `resolvedDigest` / `requestedReference`) threaded through the activity result, workflow, and durable projection; the projection writer no longer hardcodes cache evidence. Cache identity mixes `backendRef` into the lock key so an endpoint change does not report a false hit.
- **Cleanup safety preserved**: no `rmi` / `image rm` / prune anywhere; job, workflow, and session cleanup never delete shared, daemon-scoped images.

## Tests run

- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_container_image_acquisition.py tests/unit/workflows/temporal/test_container_job_workflow.py` — **PASS** (44 targeted tests). Covers normalization, lock keys, digest parsing, failure classification, lease exclusion/expiry recovery, policy decisions, one-pull-per-image under concurrency, non-serialization of distinct images, waiter reuse, workspace-visibility-before-pull, and image-observation threading into the terminal projection.
- Full accompanying unit suite also green (1088 passed, 238 skipped, 0 failed).

## Remaining risks

- End-to-end behavior against a **live** Docker daemon (real multi-GB pull, cross-process/cross-worker filesystem lease on a shared volume, actual `DOCKER_HOST` wiring) is exercised via an in-memory `FakeDaemon` and a real `tmp_path` filesystem lease, not a live daemon — advisory, not available in this hermetic runtime.
- Deployment-level last-used observations and image eviction/retention are **out of scope** (tracked by the separate retention issue) and intentionally not implemented here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
