### PR TITLE
Authorize private container images with ephemeral registry credentials (MoonLadderStudios/MoonMind#3257)

### DIFF
--- a/api_service/db/models.py
+++ b/api_service/db/models.py
@@ -3044,6 +3044,7 @@ class ContainerJobRecord(Base):
     backend_kind: Mapped[Optional[str]] = mapped_column(String(64), nullable=True)
     backend_ref: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
     image_observation_json: Mapped[Optional[dict[str, Any]]] = mapped_column(mutable_json_dict(), nullable=True)
+    authorization_observation_json: Mapped[Optional[dict[str, Any]]] = mapped_column(mutable_json_dict(), nullable=True)
     terminal_outcome_json: Mapped[Optional[dict[str, Any]]] = mapped_column(mutable_json_dict(), nullable=True)
     publication_outcome_json: Mapped[dict[str, Any]] = mapped_column(mutable_json_dict(), nullable=False, default=_default_container_job_auxiliary_outcome)
     cleanup_outcome_json: Mapped[dict[str, Any]] = mapped_column(mutable_json_dict(), nullable=False, default=_default_container_job_auxiliary_outcome)

--- a/api_service/migrations/versions/340_container_job_registry_authorization.py
+++ b/api_service/migrations/versions/340_container_job_registry_authorization.py
@@ -1,0 +1,27 @@
+"""Record non-sensitive private-image authorization for MoonLadderStudios/MoonMind#3257.
+
+Revision ID: 340_container_job_registry_auth
+Revises: 339_merge_migration_heads
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "340_container_job_registry_auth"
+down_revision: Union[str, None] = "339_merge_migration_heads"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "container_jobs",
+        sa.Column("authorization_observation_json", sa.JSON(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("container_jobs", "authorization_observation_json")

--- a/api_service/services/container_jobs.py
+++ b/api_service/services/container_jobs.py
@@ -10,6 +10,10 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from api_service.db.models import ContainerJobRecord
+from api_service.services.registry_authorization import (
+    PrivateImageAuthorizationService,
+    load_default_authorization_policy,
+)
 from moonmind.schemas.container_job_models import (
     AuxiliaryOutcome,
     ContainerJobAccepted,
@@ -21,6 +25,7 @@ from moonmind.schemas.container_job_models import (
     ContainerJobWorkflowInput,
     ImageObservation,
     OwnerIdentity,
+    RegistryAuthorization,
     TerminalOutcome,
 )
 from moonmind.workflows.temporal.client import TemporalClientAdapter
@@ -34,11 +39,30 @@ class ContainerJobIdempotencyConflictError(RuntimeError):
     pass
 
 
+class ContainerJobAuthorizationError(RuntimeError):
+    """Raised when a submission is denied private-image authorization.
+
+    Carries the bounded, non-sensitive authorization outcome so callers can map
+    the specific failure class (denied image use, repository-scope mismatch, ...)
+    to a permission-denied response without leaking credential material.
+    """
+
+    def __init__(self, authorization: RegistryAuthorization) -> None:
+        self.authorization = authorization
+        super().__init__(authorization.message or "private-image use is denied")
+
+
 class ContainerJobRepository:
     def __init__(self, session: AsyncSession) -> None:
         self._session = session
 
-    async def create_or_replay(self, *, owner: OwnerIdentity, request: ContainerJobSubmitRequest) -> tuple[ContainerJobRecord, bool]:
+    async def create_or_replay(
+        self,
+        *,
+        owner: OwnerIdentity,
+        request: ContainerJobSubmitRequest,
+        authorization: RegistryAuthorization | None = None,
+    ) -> tuple[ContainerJobRecord, bool]:
         existing = await self._by_idempotency(owner, request.idempotency_key)
         request_json = request.model_dump(mode="json", by_alias=True, exclude_none=True)
         if existing is not None:
@@ -53,6 +77,11 @@ class ContainerJobRepository:
             idempotency_key=request.idempotency_key,
             source_json=request.source.model_dump(mode="json", by_alias=True, exclude_none=True),
             request_json=request_json,
+            authorization_observation_json=(
+                authorization.model_dump(mode="json", by_alias=True, exclude_none=True)
+                if authorization is not None
+                else None
+            ),
             state=ContainerJobState.QUEUED.value,
             publication_outcome_json={"state": "not_attempted"},
             cleanup_outcome_json={"state": "not_attempted"},
@@ -112,14 +141,36 @@ class ContainerJobRepository:
 
 
 class ContainerJobService:
-    def __init__(self, session: AsyncSession, *, temporal: TemporalClientAdapter | None = None) -> None:
+    def __init__(
+        self,
+        session: AsyncSession,
+        *,
+        temporal: TemporalClientAdapter | None = None,
+        authorizer: PrivateImageAuthorizationService | None = None,
+    ) -> None:
         self.repository = ContainerJobRepository(session)
         self._temporal = temporal or TemporalClientAdapter()
+        self._authorizer = authorizer or PrivateImageAuthorizationService(
+            load_default_authorization_policy()
+        )
 
     async def submit(self, *, owner: OwnerIdentity, request: ContainerJobSubmitRequest) -> ContainerJobAccepted:
-        record, replayed = await self.repository.create_or_replay(owner=owner, request=request)
+        # Authorize private-image execution and credential use before creating
+        # durable identity. Fails closed: a denied request never starts a
+        # workflow and never persists a queued record.
+        authorization = self._authorizer.authorize(owner=owner, spec=request.spec)
+        if not authorization.authorized:
+            raise ContainerJobAuthorizationError(authorization)
+        record, replayed = await self.repository.create_or_replay(
+            owner=owner, request=request, authorization=authorization
+        )
         await self._temporal.start_container_job(
-            ContainerJobWorkflowInput(jobId=record.job_id, owner=owner, request=request)
+            ContainerJobWorkflowInput(
+                jobId=record.job_id,
+                owner=owner,
+                request=request,
+                registryAuthorization=authorization,
+            )
         )
         created_at = record.created_at or datetime.now(timezone.utc)
         return ContainerJobAccepted(jobId=record.job_id, replayed=replayed, createdAt=created_at)
@@ -131,6 +182,7 @@ class ContainerJobService:
         return ContainerJobStatus(
             jobId=record.job_id, state=record.state, backendKind=record.backend_kind,
             backendRef=record.backend_ref, image=record.image_observation_json,
+            authorization=record.authorization_observation_json,
             terminal=record.terminal_outcome_json, publication=record.publication_outcome_json,
             cleanup=record.cleanup_outcome_json, logsRef=record.logs_ref,
             artifactsRef=record.artifacts_ref, updatedAt=record.updated_at or record.created_at,

--- a/api_service/services/registry_authorization.py
+++ b/api_service/services/registry_authorization.py
@@ -132,7 +132,7 @@ class PrivateImageAuthorizationService:
         *,
         owner: OwnerIdentity,
         reference: NormalizedImageReference,
-        credential_ref: str | None,
+        credential_ref: str,
     ) -> RegistryAuthorization:
         grants = self._policy.grants_for(credential_ref)
         if not grants:
@@ -195,7 +195,7 @@ class PrivateImageAuthorizationService:
     @staticmethod
     def _deny(
         reference: NormalizedImageReference,
-        credential_ref: str,
+        credential_ref: str | None,
         failure_class: ContainerJobFailureClass,
         message: str,
     ) -> RegistryAuthorization:

--- a/api_service/services/registry_authorization.py
+++ b/api_service/services/registry_authorization.py
@@ -1,0 +1,225 @@
+"""API-owned private-image authorization for container jobs (MoonMind#3257).
+
+The service authorizes, for every submission and run, that an authenticated
+principal may execute a requested image and use a referenced registry credential
+for the normalized registry/repository. It evaluates deployment-owned policy
+only; it never resolves, reads, or returns credential values. Its output is a
+bounded, non-sensitive :class:`RegistryAuthorization` that is safe to persist and
+to cross Temporal workflow history.
+
+Cache state is deliberately not an input: authorization is computed from the
+principal, the requested image, the credential reference, and policy alone, so an
+image already present in the shared daemon cannot bypass policy.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from fnmatch import fnmatch
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+logger = logging.getLogger(__name__)
+
+_POLICY_ENV_VAR = "MOONMIND_REGISTRY_CREDENTIAL_GRANTS"
+
+from moonmind.schemas.container_job_models import (
+    ContainerJobFailureClass,
+    ContainerJobSpec,
+    NormalizedImageReference,
+    OwnerIdentity,
+    RegistryAuthorization,
+    normalize_image_reference,
+)
+
+
+class RegistryCredentialGrant(BaseModel):
+    """One deployment-owned grant binding a credential ref to a bounded scope."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    credential_ref: str = Field(alias="credentialRef", min_length=1, max_length=1024)
+    registry: str = Field(min_length=1, max_length=255)
+    repositories: tuple[str, ...] = Field(default_factory=tuple)
+    principals: tuple[str, ...] = Field(default=("*",))
+    tags: tuple[str, ...] = Field(default_factory=tuple)
+    digests: tuple[str, ...] = Field(default_factory=tuple)
+
+    def matches_principal(self, owner: OwnerIdentity) -> bool:
+        if "*" in self.principals:
+            return True
+        token = f"{owner.principal_type}:{owner.principal_id}"
+        return owner.principal_id in self.principals or token in self.principals
+
+    def repository_scope_for(self, repository: str) -> str | None:
+        for pattern in self.repositories:
+            if fnmatch(repository, pattern):
+                return pattern
+        return None
+
+    def allows_tag(self, tag: str | None) -> bool:
+        if not self.tags:
+            return True
+        return tag is not None and any(fnmatch(tag, pattern) for pattern in self.tags)
+
+    def allows_digest(self, digest: str | None) -> bool:
+        if not self.digests:
+            return True
+        return digest is not None and digest in self.digests
+
+
+class PrivateImageAuthorizationPolicy(BaseModel):
+    """Deployment-owned set of registry credential grants."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    grants: tuple[RegistryCredentialGrant, ...] = Field(default_factory=tuple)
+
+    def grants_for(self, credential_ref: str) -> tuple[RegistryCredentialGrant, ...]:
+        return tuple(
+            grant for grant in self.grants if grant.credential_ref == credential_ref
+        )
+
+
+class PrivateImageAuthorizationService:
+    """Evaluate private-image execution and credential-use policy."""
+
+    def __init__(self, policy: PrivateImageAuthorizationPolicy | None = None) -> None:
+        self._policy = policy or PrivateImageAuthorizationPolicy()
+
+    def authorize(
+        self, *, owner: OwnerIdentity, spec: ContainerJobSpec
+    ) -> RegistryAuthorization:
+        reference = normalize_image_reference(spec.image)
+        credential_ref = spec.registry_credential_ref
+
+        if credential_ref is None:
+            # A public image needs no registry credential. Execution policy for
+            # public images is unrestricted in this deployment; a future policy
+            # can deny here without changing the authorization contract.
+            return RegistryAuthorization(
+                authorized=True,
+                registry=reference.registry,
+                repository=reference.repository,
+                reference=reference.reference,
+            )
+
+        return self._authorize_private(
+            owner=owner, reference=reference, credential_ref=credential_ref
+        )
+
+    def _authorize_private(
+        self,
+        *,
+        owner: OwnerIdentity,
+        reference: NormalizedImageReference,
+        credential_ref: str,
+    ) -> RegistryAuthorization:
+        grants = self._policy.grants_for(credential_ref)
+        if not grants:
+            return self._deny(
+                reference,
+                credential_ref,
+                ContainerJobFailureClass.IMAGE_USE_DENIED,
+                "no grant authorizes this credential reference",
+            )
+
+        # Track the most specific denial so the reported failure class reflects
+        # how close the request came to an authorized grant.
+        denial = self._deny(
+            reference,
+            credential_ref,
+            ContainerJobFailureClass.IMAGE_USE_DENIED,
+            "principal is not authorized to use this credential reference",
+        )
+        for grant in grants:
+            if not grant.matches_principal(owner):
+                continue
+            if grant.registry.lower() != reference.registry.lower():
+                denial = self._deny(
+                    reference,
+                    credential_ref,
+                    ContainerJobFailureClass.REPOSITORY_SCOPE_MISMATCH,
+                    "credential is not scoped to the requested registry",
+                )
+                continue
+            scope = grant.repository_scope_for(reference.repository)
+            if scope is None:
+                denial = self._deny(
+                    reference,
+                    credential_ref,
+                    ContainerJobFailureClass.REPOSITORY_SCOPE_MISMATCH,
+                    "credential is not scoped to the requested repository",
+                )
+                continue
+            if not grant.allows_tag(reference.tag) or not grant.allows_digest(
+                reference.digest
+            ):
+                denial = self._deny(
+                    reference,
+                    credential_ref,
+                    ContainerJobFailureClass.REPOSITORY_SCOPE_MISMATCH,
+                    "requested tag or digest is outside the credential scope",
+                )
+                continue
+            return RegistryAuthorization(
+                authorized=True,
+                registry=reference.registry,
+                repository=reference.repository,
+                reference=reference.reference,
+                credentialRef=credential_ref,
+                scope=scope,
+                requiredDigest=reference.digest,
+            )
+        return denial
+
+    @staticmethod
+    def _deny(
+        reference: NormalizedImageReference,
+        credential_ref: str,
+        failure_class: ContainerJobFailureClass,
+        message: str,
+    ) -> RegistryAuthorization:
+        return RegistryAuthorization(
+            authorized=False,
+            registry=reference.registry,
+            repository=reference.repository,
+            reference=reference.reference,
+            credentialRef=credential_ref,
+            failureClass=failure_class,
+            message=message,
+        )
+
+
+def load_default_authorization_policy() -> PrivateImageAuthorizationPolicy:
+    """Load the deployment-owned grant policy from the environment.
+
+    Grants are supplied as a JSON array in ``MOONMIND_REGISTRY_CREDENTIAL_GRANTS``.
+    Absent or malformed configuration yields an empty (fail-closed) policy: jobs
+    without a credential reference stay authorized, and any job that references a
+    credential is denied until an operator declares a matching grant.
+    """
+
+    raw = str(os.environ.get(_POLICY_ENV_VAR, "")).strip()
+    if not raw:
+        return PrivateImageAuthorizationPolicy()
+    try:
+        grants = json.loads(raw)
+        return PrivateImageAuthorizationPolicy.model_validate({"grants": grants})
+    except (json.JSONDecodeError, ValidationError, TypeError):
+        logger.warning(
+            "Ignoring malformed %s; private-image credential use will fail closed.",
+            _POLICY_ENV_VAR,
+            exc_info=True,
+        )
+        return PrivateImageAuthorizationPolicy()
+
+
+__all__ = [
+    "PrivateImageAuthorizationPolicy",
+    "PrivateImageAuthorizationService",
+    "RegistryCredentialGrant",
+    "load_default_authorization_policy",
+]

--- a/api_service/services/registry_authorization.py
+++ b/api_service/services/registry_authorization.py
@@ -109,7 +109,7 @@ class PrivateImageAuthorizationService:
             if self._policy.protects(reference):
                 return self._deny(
                     reference,
-                    "",
+                    None,
                     ContainerJobFailureClass.IMAGE_USE_DENIED,
                     "a registry credential reference is required for this private image",
                 )
@@ -132,7 +132,7 @@ class PrivateImageAuthorizationService:
         *,
         owner: OwnerIdentity,
         reference: NormalizedImageReference,
-        credential_ref: str,
+        credential_ref: str | None,
     ) -> RegistryAuthorization:
         grants = self._policy.grants_for(credential_ref)
         if not grants:

--- a/api_service/services/registry_authorization.py
+++ b/api_service/services/registry_authorization.py
@@ -14,10 +14,11 @@ image already present in the shared daemon cannot bypass policy.
 
 from __future__ import annotations
 
+import functools
 import json
 import logging
 import os
-from fnmatch import fnmatch
+from fnmatch import fnmatchcase
 
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
@@ -51,18 +52,18 @@ class RegistryCredentialGrant(BaseModel):
         if "*" in self.principals:
             return True
         token = f"{owner.principal_type}:{owner.principal_id}"
-        return owner.principal_id in self.principals or token in self.principals
+        return token in self.principals
 
     def repository_scope_for(self, repository: str) -> str | None:
         for pattern in self.repositories:
-            if fnmatch(repository, pattern):
+            if fnmatchcase(repository, pattern):
                 return pattern
         return None
 
     def allows_tag(self, tag: str | None) -> bool:
         if not self.tags:
             return True
-        return tag is not None and any(fnmatch(tag, pattern) for pattern in self.tags)
+        return tag is not None and any(fnmatchcase(tag, pattern) for pattern in self.tags)
 
     def allows_digest(self, digest: str | None) -> bool:
         if not self.digests:
@@ -82,6 +83,15 @@ class PrivateImageAuthorizationPolicy(BaseModel):
             grant for grant in self.grants if grant.credential_ref == credential_ref
         )
 
+    def protects(self, reference: NormalizedImageReference) -> bool:
+        """Return whether policy declares the image inside a private scope."""
+
+        return any(
+            grant.registry.lower() == reference.registry.lower()
+            and grant.repository_scope_for(reference.repository) is not None
+            for grant in self.grants
+        )
+
 
 class PrivateImageAuthorizationService:
     """Evaluate private-image execution and credential-use policy."""
@@ -96,6 +106,13 @@ class PrivateImageAuthorizationService:
         credential_ref = spec.registry_credential_ref
 
         if credential_ref is None:
+            if self._policy.protects(reference):
+                return self._deny(
+                    reference,
+                    "",
+                    ContainerJobFailureClass.IMAGE_USE_DENIED,
+                    "a registry credential reference is required for this private image",
+                )
             # A public image needs no registry credential. Execution policy for
             # public images is unrestricted in this deployment; a future policy
             # can deny here without changing the authorization contract.
@@ -193,6 +210,7 @@ class PrivateImageAuthorizationService:
         )
 
 
+@functools.lru_cache(maxsize=1)
 def load_default_authorization_policy() -> PrivateImageAuthorizationPolicy:
     """Load the deployment-owned grant policy from the environment.
 

--- a/docs/ManagedAgents/DockerBackendService.md
+++ b/docs/ManagedAgents/DockerBackendService.md
@@ -419,12 +419,32 @@ Waiters re-inspect after the owner finishes.
 
 ### 11.4 Private images
 
-Registry credentials are secret references. The service resolves them into an
-ephemeral Docker config, uses them only for the approved registry operation, and
-removes the config afterward.
+A job request carries a non-sensitive `registryCredentialRef` only; it never
+carries a username, token, password, or Docker auth blob. An API-owned
+private-image authorization service evaluates, for every submission and run, the
+authenticated principal, the normalized registry/repository/reference, the
+requested credential reference, the allowed registry/repository scope, image
+execution policy independent of cache state, and any digest/tag restriction. A
+submission that fails authorization fails closed: no workflow starts and no
+queued record is created. The bounded, non-sensitive authorization outcome is
+recorded in the durable job record and travels with the workflow to the worker.
 
-Authorization is checked on every run, including cache hits. A private image
-being present in the daemon does not grant other users permission to execute it.
+Registry credentials are secret references resolved by a generic registry-auth
+resolver only inside a trusted execution-time Activity, immediately before the
+authorized inspect/pull. The resolver reuses the repository's managed-secret
+backends rather than duplicating secret handling. The worker materializes a
+per-job Docker config in a dedicated auth directory with restrictive ownership
+and mode (`0700` directory, `0600` config), uses it only for the approved pull,
+redacts the credential from every observation, and removes it immediately after
+use. A deterministic, job-owned cleanup step re-removes the directory on success,
+failure, cancellation, timeout, and orphan reconciliation, and reports any
+credential-cleanup failure through the separate cleanup auxiliary outcome without
+rewriting the primary workload result.
+
+Authorization is enforced on every run before either a cache hit or a pull is
+accepted. A private image being present in the daemon does not grant another
+user permission to execute it, and a resolved registry/repository/digest outside
+the authorized scope fails closed.
 
 ### 11.5 Image lifetime
 
@@ -623,6 +643,11 @@ image_not_found
 image_pull_timeout
 image_pull_auth_failed
 image_platform_mismatch
+image_use_denied
+credential_unresolved
+repository_scope_mismatch
+registry_auth_failed
+credential_cleanup_failed
 resource_limit_exceeded
 container_start_failed
 workload_failed

--- a/moonmind/schemas/container_job_models.py
+++ b/moonmind/schemas/container_job_models.py
@@ -281,6 +281,9 @@ def normalize_image_reference(image: str) -> NormalizedImageReference:
         tag = tag_part.strip() or None
         path = path[: last_slash + 1] + name_tail
 
+    if tag is None and digest is None:
+        tag = "latest"
+
     repository = path.strip("/")
     if not repository:
         raise ValueError("image reference is missing a repository")

--- a/moonmind/schemas/container_job_models.py
+++ b/moonmind/schemas/container_job_models.py
@@ -71,6 +71,12 @@ class ContainerJobFailureClass(StrEnum):
     TIMEOUT = "timeout"
     CANCELED = "canceled"
     INFRASTRUCTURE = "infrastructure"
+    # Private-image authorization with ephemeral registry credentials (#3257).
+    IMAGE_USE_DENIED = "image_use_denied"
+    CREDENTIAL_UNRESOLVED = "credential_unresolved"
+    REPOSITORY_SCOPE_MISMATCH = "repository_scope_mismatch"
+    REGISTRY_AUTH_FAILED = "registry_auth_failed"
+    CREDENTIAL_CLEANUP_FAILED = "credential_cleanup_failed"
 
 
 class AuxiliaryOutcomeState(StrEnum):
@@ -209,6 +215,162 @@ class ContainerJobAccepted(TemporalContractModel):
         return _validate_job_id(value)
 
 
+_DIGEST = re.compile(r"^sha256:[0-9a-f]{64}$")
+_DOCKER_HUB_ALIASES = frozenset(
+    {"docker.io", "index.docker.io", "registry-1.docker.io", "registry.hub.docker.com"}
+)
+
+
+class NormalizedImageReference(ContractModel):
+    """Backend-neutral registry/repository/reference decomposition (#3257).
+
+    Normalization is authorization input only; it never carries credentials.
+    """
+
+    registry: str = Field(min_length=1, max_length=255)
+    repository: str = Field(min_length=1, max_length=255)
+    tag: str | None = Field(None, max_length=128)
+    digest: str | None = Field(None, pattern=r"^sha256:[0-9a-f]{64}$")
+    reference: str = Field(max_length=512)
+
+
+def normalize_image_reference(image: str) -> NormalizedImageReference:
+    """Decompose an image string into registry/repository/tag/digest.
+
+    Mirrors Docker's reference rules closely enough for repository-scope
+    authorization: an unqualified first path component defaults to ``docker.io``
+    and Docker Hub short names gain the ``library/`` prefix.
+    """
+
+    raw = str(image or "").strip()
+    if not raw:
+        raise ValueError("image reference must not be empty")
+
+    digest: str | None = None
+    remainder = raw
+    if "@" in remainder:
+        remainder, _, digest_part = remainder.partition("@")
+        digest = digest_part.strip()
+        if not _DIGEST.fullmatch(digest):
+            raise ValueError("image digest must be a sha256 reference")
+
+    first, sep, rest = remainder.partition("/")
+    if sep and ("." in first or ":" in first or first == "localhost"):
+        registry = first.lower()
+        path = rest
+    else:
+        registry = "docker.io"
+        path = remainder
+    if registry in _DOCKER_HUB_ALIASES:
+        registry = "docker.io"
+
+    tag: str | None = None
+    last_slash = path.rfind("/")
+    last_segment = path[last_slash + 1 :]
+    if ":" in last_segment:
+        name_tail, _, tag_part = last_segment.rpartition(":")
+        tag = tag_part.strip() or None
+        path = path[: last_slash + 1] + name_tail
+
+    repository = path.strip("/")
+    if not repository:
+        raise ValueError("image reference is missing a repository")
+    if registry == "docker.io" and "/" not in repository:
+        repository = f"library/{repository}"
+
+    reference = f"{registry}/{repository}"
+    if digest is not None:
+        reference = f"{reference}@{digest}"
+    elif tag is not None:
+        reference = f"{reference}:{tag}"
+
+    return NormalizedImageReference(
+        registry=registry,
+        repository=repository,
+        tag=tag,
+        digest=digest,
+        reference=reference,
+    )
+
+
+class RegistryAuthorization(ContractModel):
+    """Non-sensitive private-image authorization outcome (#3257).
+
+    Records the bounded decision and authorized scope only; it never carries a
+    username, token, password, or Docker auth blob. It is safe to persist and to
+    cross Temporal workflow history.
+    """
+
+    authorized: bool
+    registry: str = Field(min_length=1, max_length=255)
+    repository: str = Field(min_length=1, max_length=255)
+    reference: str = Field(max_length=512)
+    credential_ref: str | None = Field(None, alias="credentialRef", max_length=1024)
+    scope: str | None = Field(None, max_length=255)
+    digest: str | None = Field(
+        None, alias="requiredDigest", pattern=r"^sha256:[0-9a-f]{64}$"
+    )
+    failure_class: ContainerJobFailureClass | None = Field(
+        None, alias="failureClass"
+    )
+    message: str | None = Field(None, max_length=512)
+
+    _validate_credential_ref = field_validator("credential_ref")(
+        _opaque_secret_reference
+    )
+
+
+CONTAINER_JOB_FAILURE_MARKER = "container-job-failure:"
+
+
+class ContainerJobBackendError(RuntimeError):
+    """Trusted-backend error that carries a stable container-job failure class.
+
+    The failure class is encoded into the message with a stable marker so the
+    workflow can recover it even after Temporal wraps the activity failure and
+    the original Python type is lost.
+    """
+
+    def __init__(
+        self, failure_class: ContainerJobFailureClass, detail: str
+    ) -> None:
+        self.failure_class = failure_class
+        super().__init__(
+            f"{CONTAINER_JOB_FAILURE_MARKER}{failure_class.value}: {detail}"
+        )
+
+
+def failure_class_from_exception(
+    exc: BaseException,
+) -> ContainerJobFailureClass | None:
+    """Recover a container-job failure class from an exception, if present.
+
+    Prefers a direct ``failure_class`` attribute (in-process activity calls) and
+    falls back to parsing the stable marker embedded in the message. Temporal
+    wraps an activity failure and re-raises it with the original as ``__cause__``
+    (or ``__context__``), so the whole chain is walked to find either signal.
+    """
+
+    seen: set[int] = set()
+    current: BaseException | None = exc
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        direct = getattr(current, "failure_class", None)
+        if isinstance(direct, ContainerJobFailureClass):
+            return direct
+        text = str(current)
+        marker_index = text.find(CONTAINER_JOB_FAILURE_MARKER)
+        if marker_index != -1:
+            token = text[marker_index + len(CONTAINER_JOB_FAILURE_MARKER) :]
+            token = token.split(":", 1)[0].strip()
+            try:
+                return ContainerJobFailureClass(token)
+            except ValueError:
+                pass
+        current = current.__cause__ or current.__context__
+    return None
+
+
 class ImageObservation(ContractModel):
     requested_reference: str = Field(alias="requestedReference", max_length=512)
     resolved_digest: str | None = Field(None, alias="resolvedDigest", pattern=r"^sha256:[0-9a-f]{64}$")
@@ -236,6 +398,7 @@ class ContainerJobStatus(TemporalContractModel):
     backend_kind: str | None = Field(None, alias="backendKind", max_length=64)
     backend_ref: str | None = Field(None, alias="backendRef", max_length=255)
     image: ImageObservation | None = None
+    authorization: RegistryAuthorization | None = None
     terminal: TerminalOutcome | None = None
     publication: AuxiliaryOutcome = Field(default_factory=lambda: AuxiliaryOutcome(state="not_attempted"))
     cleanup: AuxiliaryOutcome = Field(default_factory=lambda: AuxiliaryOutcome(state="not_attempted"))
@@ -319,6 +482,9 @@ class ContainerJobWorkflowInput(TemporalContractModel):
         )
     )
     request: ContainerJobSubmitRequest
+    registry_authorization: RegistryAuthorization | None = Field(
+        None, alias="registryAuthorization"
+    )
     observe_interval_seconds: int = Field(
         10, alias="observeIntervalSeconds", ge=1, le=300
     )
@@ -342,6 +508,9 @@ class ContainerJobActivityRequest(TemporalContractModel):
     )
     ownership_token: str = Field(alias="ownershipToken", min_length=1, max_length=300)
     request: ContainerJobSubmitRequest
+    registry_authorization: RegistryAuthorization | None = Field(
+        None, alias="registryAuthorization"
+    )
     state: ContainerJobState | None = None
     resolved_workspace_ref: str | None = Field(
         None, alias="resolvedWorkspaceRef", max_length=1024

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -7878,10 +7878,28 @@ class TemporalAgentRuntimeActivities:
         from moonmind.schemas.container_job_models import (
             ContainerJobActivityRequest,
             ContainerJobActivityResult,
+            ContainerJobBackendError,
+            ContainerJobFailureClass,
         )
 
         request = ContainerJobActivityRequest.model_validate(payload)
-        result = await getattr(self._container_job_backend, operation)(request)
+        try:
+            result = await getattr(self._container_job_backend, operation)(request)
+        except ContainerJobBackendError as exc:
+            # Preserve the specific failure class across the activity boundary
+            # and fail fast on deterministic authority-sensitive denials so a
+            # denied image, credential, or scope is not retried pointlessly.
+            deterministic = {
+                ContainerJobFailureClass.IMAGE_USE_DENIED,
+                ContainerJobFailureClass.REPOSITORY_SCOPE_MISMATCH,
+                ContainerJobFailureClass.CREDENTIAL_UNRESOLVED,
+                ContainerJobFailureClass.REGISTRY_AUTH_FAILED,
+            }
+            raise temporal_exceptions.ApplicationError(
+                str(exc),
+                type=exc.failure_class.value,
+                non_retryable=exc.failure_class in deterministic,
+            ) from exc
         return ContainerJobActivityResult.model_validate(result).model_dump(
             mode="json", by_alias=True, exclude_none=True
         )

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -7896,7 +7896,6 @@ class TemporalAgentRuntimeActivities:
                 ContainerJobFailureClass.IMAGE_USE_DENIED,
                 ContainerJobFailureClass.REPOSITORY_SCOPE_MISMATCH,
                 ContainerJobFailureClass.CREDENTIAL_UNRESOLVED,
-                ContainerJobFailureClass.REGISTRY_AUTH_FAILED,
             }
             raise temporal_exceptions.ApplicationError(
                 str(exc),

--- a/moonmind/workflows/temporal/container_job_backend.py
+++ b/moonmind/workflows/temporal/container_job_backend.py
@@ -499,7 +499,10 @@ class DockerContainerJobBackend:
         self._remove_auth_dir(auth_dir, best_effort=True)
         auth_dir.mkdir(parents=True, exist_ok=True)
         os.chmod(auth_dir, stat.S_IRWXU)  # 0o700
-        config = {"auths": {registry: credential.docker_auth_entry()}}
+        auth_key = (
+            "https://index.docker.io/v1/" if registry == "docker.io" else registry
+        )
+        config = {"auths": {auth_key: credential.docker_auth_entry()}}
         config_path = auth_dir / "config.json"
         fd = os.open(
             config_path,
@@ -507,10 +510,13 @@ class DockerContainerJobBackend:
             stat.S_IRUSR | stat.S_IWUSR,  # 0o600
         )
         try:
-            with os.fdopen(fd, "w", encoding="utf-8") as handle:
-                json.dump(config, handle)
-        finally:
-            os.chmod(config_path, stat.S_IRUSR | stat.S_IWUSR)
+            os.fchmod(fd, stat.S_IRUSR | stat.S_IWUSR)
+            handle = os.fdopen(fd, "w", encoding="utf-8")
+        except Exception:
+            os.close(fd)
+            raise
+        with handle:
+            json.dump(config, handle)
 
     def _remove_auth_dir(self, auth_dir: Path, *, best_effort: bool) -> None:
         if best_effort:

--- a/moonmind/workflows/temporal/container_job_backend.py
+++ b/moonmind/workflows/temporal/container_job_backend.py
@@ -7,6 +7,8 @@ import hashlib
 import json
 import os
 import re
+import shutil
+import stat
 import tarfile
 from io import BytesIO
 from pathlib import Path
@@ -15,11 +17,32 @@ from typing import Awaitable, Callable, Sequence
 from moonmind.schemas.container_job_models import (
     ContainerJobActivityRequest,
     ContainerJobActivityResult,
+    ContainerJobBackendError,
+    ContainerJobFailureClass,
+    RegistryAuthorization,
+    normalize_image_reference,
+)
+from moonmind.workflows.temporal.runtime.registry_auth_resolve import (
+    RegistryAuthResolutionError,
+    RegistryCredential,
+    resolve_registry_pull_credentials,
 )
 
 CommandRunner = Callable[[Sequence[str]], Awaitable[tuple[int, bytes, bytes]]]
 EvidencePublisher = Callable[[ContainerJobActivityRequest, str, bytes], Awaitable[str]]
 ProjectionWriter = Callable[[ContainerJobActivityRequest], Awaitable[None]]
+RegistryAuthResolver = Callable[[str], Awaitable[RegistryCredential]]
+
+
+def _redact(text: str, secrets: Sequence[str]) -> str:
+    """Remove any resolved credential material from an observable string."""
+
+    redacted = text
+    for secret in secrets:
+        token = str(secret or "").strip()
+        if token:
+            redacted = redacted.replace(token, "[redacted]")
+    return redacted
 
 
 class DockerContainerJobBackend:
@@ -34,6 +57,8 @@ class DockerContainerJobBackend:
         command_runner: CommandRunner | None = None,
         evidence_publisher: EvidencePublisher | None = None,
         projection_writer: ProjectionWriter | None = None,
+        registry_auth_resolver: RegistryAuthResolver | None = None,
+        auth_root: str | Path | None = None,
     ) -> None:
         self._workspace_root = Path(workspace_root).resolve()
         self._docker_binary = docker_binary
@@ -41,6 +66,16 @@ class DockerContainerJobBackend:
         self._runner = command_runner or self._run
         self._publish = evidence_publisher
         self._write_projection = projection_writer
+        self._resolve_registry_auth = (
+            registry_auth_resolver or resolve_registry_pull_credentials
+        )
+        # Per-job ephemeral Docker auth material lives under a dedicated,
+        # deployment-writable root, never inside the mounted job workspace.
+        self._auth_root = (
+            Path(auth_root).resolve()
+            if auth_root is not None
+            else self._workspace_root.parent / ".mm-container-job-auth"
+        )
 
     async def _run(self, args: Sequence[str]) -> tuple[int, bytes, bytes]:
         env = os.environ.copy()
@@ -79,12 +114,16 @@ class DockerContainerJobBackend:
         return ContainerJobActivityResult(resolvedWorkspaceRef=str(workspace))
 
     async def acquire_image(self, request: ContainerJobActivityRequest):
-        if request.request.spec.registry_credential_ref:
-            raise RuntimeError(
-                "registryCredentialRef is not supported by the selected Docker backend"
-            )
-        image = request.request.spec.image
-        policy = request.request.spec.pull_policy
+        spec = request.request.spec
+        image = spec.image
+        policy = spec.pull_policy
+        credential_ref = spec.registry_credential_ref
+
+        if credential_ref is None:
+            return await self._acquire_public_image(image, policy)
+        return await self._acquire_private_image(request, image, policy, credential_ref)
+
+    async def _acquire_public_image(self, image: str, policy: str):
         inspect_code, stdout, _ = await self._runner(
             ("image", "inspect", "--format", "{{.Id}}", image)
         )
@@ -99,6 +138,138 @@ class DockerContainerJobBackend:
             )
         resolved = stdout.decode(errors="replace").strip() or image
         return ContainerJobActivityResult(resolvedImageRef=resolved)
+
+    async def _acquire_private_image(
+        self,
+        request: ContainerJobActivityRequest,
+        image: str,
+        policy: str,
+        credential_ref: str,
+    ):
+        # Authorization is re-checked on every run before either a cache hit or
+        # a pull is accepted: image presence in the shared daemon never bypasses
+        # policy. The API-owned decision travels with the request; the worker
+        # only enforces and resolves the credential, it does not re-decide.
+        authorization = request.registry_authorization
+        if authorization is None or not authorization.authorized:
+            raise ContainerJobBackendError(
+                ContainerJobFailureClass.IMAGE_USE_DENIED,
+                "private image use was not authorized for this job",
+            )
+        normalized = normalize_image_reference(image)
+        self._enforce_authorized_scope(normalized, authorization)
+
+        # A local inspect needs no registry authentication.
+        inspect_code, stdout, _ = await self._runner(
+            ("image", "inspect", "--format", "{{.Id}}", image)
+        )
+        cache_present = inspect_code == 0
+        need_pull = policy == "always" or (not cache_present and policy == "if-missing")
+        if policy == "never" and not cache_present:
+            raise ContainerJobBackendError(
+                ContainerJobFailureClass.IMAGE,
+                "private image is absent under the 'never' pull policy",
+            )
+
+        if need_pull:
+            credential = await self._resolve_credential(credential_ref)
+            secrets = (credential.username, credential.secret)
+            auth_dir = self._auth_dir(request)
+            try:
+                self._materialize_registry_auth(
+                    auth_dir, normalized.registry, credential
+                )
+                await self._authorized_pull(image, auth_dir, secrets)
+            finally:
+                # Remove ephemeral auth immediately after the pull. The terminal
+                # ``cleanup`` activity re-removes it deterministically so a crash
+                # between here and cleanup cannot leak credentials.
+                self._remove_auth_dir(auth_dir, best_effort=True)
+            inspect_code, stdout, _ = await self._runner(
+                ("image", "inspect", "--format", "{{.Id}}", image)
+            )
+
+        if inspect_code:
+            raise ContainerJobBackendError(
+                ContainerJobFailureClass.IMAGE,
+                "private image is unavailable under the selected pull policy",
+            )
+        resolved = stdout.decode(errors="replace").strip() or image
+        return ContainerJobActivityResult(resolvedImageRef=resolved)
+
+    @staticmethod
+    def _enforce_authorized_scope(
+        normalized, authorization: RegistryAuthorization
+    ) -> None:
+        if normalized.registry.lower() != authorization.registry.lower():
+            raise ContainerJobBackendError(
+                ContainerJobFailureClass.REPOSITORY_SCOPE_MISMATCH,
+                "resolved registry is outside the authorized scope",
+            )
+        if normalized.repository != authorization.repository:
+            raise ContainerJobBackendError(
+                ContainerJobFailureClass.REPOSITORY_SCOPE_MISMATCH,
+                "resolved repository is outside the authorized scope",
+            )
+        if authorization.digest is not None and normalized.digest != authorization.digest:
+            raise ContainerJobBackendError(
+                ContainerJobFailureClass.REPOSITORY_SCOPE_MISMATCH,
+                "resolved digest does not match the authorized digest",
+            )
+
+    async def _resolve_credential(self, credential_ref: str) -> RegistryCredential:
+        try:
+            return await self._resolve_registry_auth(credential_ref)
+        except RegistryAuthResolutionError as exc:
+            raise ContainerJobBackendError(
+                ContainerJobFailureClass.CREDENTIAL_UNRESOLVED,
+                "registry credential reference could not be resolved",
+            ) from exc
+
+    def _auth_dir(self, request: ContainerJobActivityRequest) -> Path:
+        suffix = hashlib.sha256(request.ownership_token.encode()).hexdigest()[:20]
+        return self._auth_root / f"job-{suffix}"
+
+    def _materialize_registry_auth(
+        self, auth_dir: Path, registry: str, credential: RegistryCredential
+    ) -> None:
+        """Write a per-job Docker config with restrictive ownership and mode."""
+
+        self._remove_auth_dir(auth_dir, best_effort=True)
+        auth_dir.mkdir(parents=True, exist_ok=True)
+        os.chmod(auth_dir, stat.S_IRWXU)  # 0o700
+        config = {"auths": {registry: credential.docker_auth_entry()}}
+        config_path = auth_dir / "config.json"
+        fd = os.open(
+            config_path,
+            os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
+            stat.S_IRUSR | stat.S_IWUSR,  # 0o600
+        )
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                json.dump(config, handle)
+        finally:
+            os.chmod(config_path, stat.S_IRUSR | stat.S_IWUSR)
+
+    def _remove_auth_dir(self, auth_dir: Path, *, best_effort: bool) -> None:
+        if best_effort:
+            shutil.rmtree(auth_dir, ignore_errors=True)
+            return
+        if auth_dir.exists():
+            shutil.rmtree(auth_dir)
+
+    async def _authorized_pull(
+        self, image: str, auth_dir: Path, secrets: tuple[str, ...]
+    ) -> None:
+        code, _, stderr = await self._runner(
+            ("--config", str(auth_dir), "pull", image)
+        )
+        if code:
+            detail = _redact(stderr.decode(errors="replace").strip()[:1000], secrets)
+            raise ContainerJobBackendError(
+                ContainerJobFailureClass.REGISTRY_AUTH_FAILED,
+                f"authorized registry pull failed: {detail}",
+            )
 
     async def reconcile_container(self, request: ContainerJobActivityRequest):
         name = self._name(request)
@@ -223,4 +394,17 @@ class DockerContainerJobBackend:
         return await self.project_status(request)
 
     async def cleanup(self, request: ContainerJobActivityRequest):
+        # Deterministic, job-owned removal of any ephemeral registry auth. This
+        # runs on success, failure, cancellation, timeout, and orphan
+        # reconciliation, so credential material never outlives the job. A
+        # cleanup failure is reported through the workflow's separate cleanup
+        # auxiliary outcome and never rewrites the primary workload result.
+        auth_dir = self._auth_dir(request)
+        try:
+            self._remove_auth_dir(auth_dir, best_effort=False)
+        except OSError as exc:
+            raise ContainerJobBackendError(
+                ContainerJobFailureClass.CREDENTIAL_CLEANUP_FAILED,
+                "ephemeral registry credential directory could not be removed",
+            ) from exc
         return ContainerJobActivityResult()

--- a/moonmind/workflows/temporal/runtime/registry_auth_resolve.py
+++ b/moonmind/workflows/temporal/runtime/registry_auth_resolve.py
@@ -1,0 +1,132 @@
+"""Generic execution-time registry credential resolution (MoonMind#3257).
+
+This module generalizes the managed-session-specific GHCR pull helper into a
+backend-neutral resolver for container jobs. It resolves a non-sensitive
+credential *reference* into plaintext registry authentication material through
+the repository's existing managed-secret backends (``env``/``db``/``exec``/
+``vault`` via :func:`resolve_managed_api_key_reference`) rather than duplicating
+secret handling.
+
+The returned plaintext is for immediate, single-operation Docker auth
+materialization only. Callers must not store it in workflow history, durable job
+records, logs, labels, command lines, or diagnostics.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+
+from moonmind.workflows.temporal.runtime.managed_api_key_resolve import (
+    resolve_managed_api_key_reference,
+)
+
+
+class RegistryAuthResolutionError(RuntimeError):
+    """Raised when a registry credential reference cannot be resolved.
+
+    The message is intentionally metadata-only: it never includes the resolved
+    username, token, password, or the raw secret value.
+    """
+
+
+@dataclass(frozen=True)
+class RegistryCredential:
+    """Resolved registry authentication material for one Docker operation."""
+
+    username: str
+    secret: str
+
+    def docker_auth_entry(self) -> dict[str, str]:
+        """Return a Docker ``auths`` entry value for this credential.
+
+        Docker accepts either ``username``/``password`` or a base64 ``auth``
+        token; the plaintext pair is materialized by the caller into a
+        restricted, per-job config directory and removed immediately after use.
+        """
+
+        return {"username": self.username, "password": self.secret}
+
+
+def _parse_resolved_credential(resolved: str) -> RegistryCredential:
+    """Parse a resolved secret value into a username/secret pair.
+
+    Two portable encodings are supported so operators can reuse existing secret
+    backends without a MoonMind-specific format:
+
+    - a JSON object with ``username`` and ``password`` (or ``token``);
+    - a ``username:secret`` string (the secret may itself contain colons).
+    """
+
+    text = str(resolved or "").strip()
+    if not text:
+        raise RegistryAuthResolutionError(
+            "registry credential reference resolved to an empty value"
+        )
+
+    if text.startswith("{"):
+        try:
+            payload = json.loads(text)
+        except json.JSONDecodeError as exc:
+            raise RegistryAuthResolutionError(
+                "registry credential JSON could not be parsed"
+            ) from exc
+        if not isinstance(payload, dict):
+            raise RegistryAuthResolutionError(
+                "registry credential JSON must be an object"
+            )
+        username = str(payload.get("username") or "").strip()
+        secret = str(
+            payload.get("password") or payload.get("token") or ""
+        ).strip()
+        if not username or not secret:
+            raise RegistryAuthResolutionError(
+                "registry credential JSON must contain username and password/token"
+            )
+        return RegistryCredential(username=username, secret=secret)
+
+    if ":" not in text:
+        raise RegistryAuthResolutionError(
+            "registry credential must be a 'username:secret' pair or a JSON object"
+        )
+    username, _, secret = text.partition(":")
+    username = username.strip()
+    secret = secret.strip()
+    if not username or not secret:
+        raise RegistryAuthResolutionError(
+            "registry credential must contain a non-empty username and secret"
+        )
+    return RegistryCredential(username=username, secret=secret)
+
+
+async def resolve_registry_pull_credentials(
+    credential_ref: str,
+) -> RegistryCredential:
+    """Resolve a credential reference into registry auth material.
+
+    Resolution runs at execution time only, immediately before the authorized
+    inspect/pull operation. Raises :class:`RegistryAuthResolutionError` on any
+    unresolved, empty, or malformed credential.
+    """
+
+    reference = str(credential_ref or "").strip()
+    if not reference:
+        raise RegistryAuthResolutionError(
+            "registry credential reference is empty"
+        )
+    try:
+        resolved = await resolve_managed_api_key_reference(
+            reference, field_name="registryCredentialRef"
+        )
+    except Exception as exc:  # noqa: BLE001 - normalize to a metadata-only error
+        raise RegistryAuthResolutionError(
+            "registry credential reference could not be resolved"
+        ) from exc
+    return _parse_resolved_credential(resolved)
+
+
+__all__ = [
+    "RegistryAuthResolutionError",
+    "RegistryCredential",
+    "resolve_registry_pull_credentials",
+]

--- a/moonmind/workflows/temporal/workflows/container_job.py
+++ b/moonmind/workflows/temporal/workflows/container_job.py
@@ -19,6 +19,7 @@ with workflow.unsafe.imports_passed_through():
         ContainerJobWorkflowInput,
         ContainerJobWorkflowResult,
         TerminalOutcome,
+        failure_class_from_exception,
     )
     from moonmind.workflows.temporal.activity_catalog import (
         build_default_activity_catalog,
@@ -106,6 +107,7 @@ class MoonMindContainerJobWorkflow:
             owner=inp.owner,
             ownershipToken=inp.ownership_token,
             request=inp.request,
+            registryAuthorization=inp.registry_authorization,
         )
         terminal_state = ContainerJobState.FAILED
         exit_code: int | None = None
@@ -171,7 +173,14 @@ class MoonMindContainerJobWorkflow:
             message = "container job exceeded its timeout"
         except Exception as exc:
             terminal_state = ContainerJobState.FAILED
-            failure_class = ContainerJobFailureClass.INFRASTRUCTURE
+            # Preserve the trusted backend's specific failure class (denied image
+            # use, unresolved credential, repository-scope mismatch, registry
+            # auth failure) across the activity boundary; fall back to
+            # infrastructure only when no class is carried.
+            failure_class = (
+                failure_class_from_exception(exc)
+                or ContainerJobFailureClass.INFRASTRUCTURE
+            )
             message = str(exc)[:2048]
 
         request.terminal_state = terminal_state

--- a/tests/unit/api_service/test_container_jobs_migration.py
+++ b/tests/unit/api_service/test_container_jobs_migration.py
@@ -31,3 +31,31 @@ def test_container_jobs_migration_upgrade_and_downgrade(monkeypatch) -> None:
         ]
         migration.downgrade()
         assert "container_jobs" not in sa.inspect(connection).get_table_names()
+
+
+def test_registry_authorization_migration_adds_and_drops_column(monkeypatch) -> None:
+    base = importlib.import_module(
+        "api_service.migrations.versions.338_container_jobs_contract"
+    )
+    auth = importlib.import_module(
+        "api_service.migrations.versions.340_container_job_registry_authorization"
+    )
+    assert auth.down_revision == "339_merge_migration_heads"
+    engine = sa.create_engine("sqlite:///:memory:")
+    with engine.begin() as connection:
+        operations = Operations(MigrationContext.configure(connection))
+        monkeypatch.setattr(base, "op", operations)
+        monkeypatch.setattr(auth, "op", operations)
+        base.upgrade()
+        auth.upgrade()
+        columns = {
+            column["name"]
+            for column in sa.inspect(connection).get_columns("container_jobs")
+        }
+        assert "authorization_observation_json" in columns
+        auth.downgrade()
+        columns = {
+            column["name"]
+            for column in sa.inspect(connection).get_columns("container_jobs")
+        }
+        assert "authorization_observation_json" not in columns

--- a/tests/unit/schemas/test_container_job_registry_auth.py
+++ b/tests/unit/schemas/test_container_job_registry_auth.py
@@ -23,13 +23,13 @@ DIGEST = "sha256:" + "c" * 64
 @pytest.mark.parametrize(
     ("image", "registry", "repository", "tag", "digest"),
     [
-        ("alpine", "docker.io", "library/alpine", None, None),
+        ("alpine", "docker.io", "library/alpine", "latest", None),
         ("ubuntu:24.04", "docker.io", "library/ubuntu", "24.04", None),
         ("org/app:1.2", "docker.io", "org/app", "1.2", None),
         ("ghcr.io/org/app:1.2", "ghcr.io", "org/app", "1.2", None),
         (f"ghcr.io/org/app@{DIGEST}", "ghcr.io", "org/app", None, DIGEST),
         ("localhost:5000/team/svc:dev", "localhost:5000", "team/svc", "dev", None),
-        ("registry.example.com:5000/a/b", "registry.example.com:5000", "a/b", None, None),
+        ("registry.example.com:5000/a/b", "registry.example.com:5000", "a/b", "latest", None),
         ("index.docker.io/library/redis:7", "docker.io", "library/redis", "7", None),
     ],
 )

--- a/tests/unit/schemas/test_container_job_registry_auth.py
+++ b/tests/unit/schemas/test_container_job_registry_auth.py
@@ -78,7 +78,7 @@ def test_authorization_is_temporal_safe_and_non_sensitive() -> None:
             "source": {"source": "mcp"},
             "spec": {
                 "image": "ghcr.io/org/app:1",
-                "workspaceRef": {"kind": "moonmind-session", "sessionId": "s"},
+                "workspaceRef": {"kind": "sandbox", "workspaceId": "s"},
                 "registryCredentialRef": "db://ghcr-pull",
                 "resources": {"cpuMillis": 100, "memoryMiB": 64},
             },
@@ -117,7 +117,7 @@ def test_workflow_input_accepts_optional_authorization_for_in_flight_compat() ->
             "source": {"source": "workflow"},
             "spec": {
                 "image": "alpine",
-                "workspaceRef": {"kind": "moonmind-session", "sessionId": "s"},
+                "workspaceRef": {"kind": "sandbox", "workspaceId": "s"},
                 "resources": {"cpuMillis": 100, "memoryMiB": 64},
             },
         },

--- a/tests/unit/schemas/test_container_job_registry_auth.py
+++ b/tests/unit/schemas/test_container_job_registry_auth.py
@@ -1,0 +1,141 @@
+"""Contract coverage for private-image authorization (MoonLadderStudios/MoonMind#3257)."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from moonmind.schemas.container_job_models import (
+    ContainerJobActivityRequest,
+    ContainerJobBackendError,
+    ContainerJobFailureClass,
+    ContainerJobWorkflowInput,
+    RegistryAuthorization,
+    ensure_temporal_safe,
+    failure_class_from_exception,
+    normalize_image_reference,
+)
+
+JOB_ID = "container-job:" + "b" * 32
+DIGEST = "sha256:" + "c" * 64
+
+
+@pytest.mark.parametrize(
+    ("image", "registry", "repository", "tag", "digest"),
+    [
+        ("alpine", "docker.io", "library/alpine", None, None),
+        ("ubuntu:24.04", "docker.io", "library/ubuntu", "24.04", None),
+        ("org/app:1.2", "docker.io", "org/app", "1.2", None),
+        ("ghcr.io/org/app:1.2", "ghcr.io", "org/app", "1.2", None),
+        (f"ghcr.io/org/app@{DIGEST}", "ghcr.io", "org/app", None, DIGEST),
+        ("localhost:5000/team/svc:dev", "localhost:5000", "team/svc", "dev", None),
+        ("registry.example.com:5000/a/b", "registry.example.com:5000", "a/b", None, None),
+        ("index.docker.io/library/redis:7", "docker.io", "library/redis", "7", None),
+    ],
+)
+def test_normalize_image_reference(image, registry, repository, tag, digest) -> None:
+    ref = normalize_image_reference(image)
+    assert (ref.registry, ref.repository, ref.tag, ref.digest) == (
+        registry,
+        repository,
+        tag,
+        digest,
+    )
+
+
+def test_normalize_rejects_empty_and_bad_digest() -> None:
+    with pytest.raises(ValueError):
+        normalize_image_reference("")
+    with pytest.raises(ValueError):
+        normalize_image_reference("ghcr.io/org/app@sha256:short")
+
+
+def test_new_failure_classes_exist() -> None:
+    values = {member.value for member in ContainerJobFailureClass}
+    assert {
+        "image_use_denied",
+        "credential_unresolved",
+        "repository_scope_mismatch",
+        "registry_auth_failed",
+        "credential_cleanup_failed",
+    } <= values
+
+
+def test_authorization_is_temporal_safe_and_non_sensitive() -> None:
+    authorization = RegistryAuthorization(
+        authorized=True,
+        registry="ghcr.io",
+        repository="org/app",
+        reference="ghcr.io/org/app:1",
+        credentialRef="db://ghcr-pull",
+        scope="org/*",
+    )
+    request = ContainerJobActivityRequest(
+        jobId=JOB_ID,
+        ownershipToken="token",
+        request={
+            "idempotencyKey": "k",
+            "source": {"source": "mcp"},
+            "spec": {
+                "image": "ghcr.io/org/app:1",
+                "workspaceRef": {"kind": "moonmind-session", "sessionId": "s"},
+                "registryCredentialRef": "db://ghcr-pull",
+                "resources": {"cpuMillis": 100, "memoryMiB": 64},
+            },
+        },
+        registryAuthorization=authorization,
+    )
+    # Crossing workflow history must succeed and carry only the reference/scope.
+    encoded = ensure_temporal_safe(request)
+    assert b"registryAuthorization" in encoded
+    assert b"db://ghcr-pull" in encoded
+    # No credential value or Docker auth blob leaks into history.
+    assert b'"password"' not in encoded
+    assert b'"auth"' not in encoded and b'"auths"' not in encoded
+
+
+def test_authorization_model_rejects_raw_credential_key() -> None:
+    # A credential *value* keyed as password/token/auth must never validate onto
+    # the non-sensitive authorization contract.
+    with pytest.raises(ValidationError):
+        RegistryAuthorization.model_validate(
+            {
+                "authorized": True,
+                "registry": "ghcr.io",
+                "repository": "org/app",
+                "reference": "ghcr.io/org/app:1",
+                "password": "s3cret",
+            }
+        )
+
+
+def test_workflow_input_accepts_optional_authorization_for_in_flight_compat() -> None:
+    base = {
+        "jobId": JOB_ID,
+        "request": {
+            "idempotencyKey": "k",
+            "source": {"source": "workflow"},
+            "spec": {
+                "image": "alpine",
+                "workspaceRef": {"kind": "moonmind-session", "sessionId": "s"},
+                "resources": {"cpuMillis": 100, "memoryMiB": 64},
+            },
+        },
+    }
+    # Old payloads without the field remain valid (default None).
+    legacy = ContainerJobWorkflowInput.model_validate(base)
+    assert legacy.registry_authorization is None
+
+
+def test_failure_class_survives_marker_and_wrapping() -> None:
+    error = ContainerJobBackendError(
+        ContainerJobFailureClass.REGISTRY_AUTH_FAILED, "denied by registry"
+    )
+    assert failure_class_from_exception(error) is (
+        ContainerJobFailureClass.REGISTRY_AUTH_FAILED
+    )
+    wrapped = RuntimeError(f"Activity task failed: {error}")
+    assert failure_class_from_exception(wrapped) is (
+        ContainerJobFailureClass.REGISTRY_AUTH_FAILED
+    )
+    assert failure_class_from_exception(RuntimeError("unrelated")) is None

--- a/tests/unit/services/test_container_jobs.py
+++ b/tests/unit/services/test_container_jobs.py
@@ -7,13 +7,19 @@ from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
 from api_service.db.models import Base
 from api_service.services.container_jobs import (
+    ContainerJobAuthorizationError,
     ContainerJobIdempotencyConflictError,
     ContainerJobNotFoundError,
     ContainerJobService,
 )
+from api_service.services.registry_authorization import (
+    PrivateImageAuthorizationPolicy,
+    PrivateImageAuthorizationService,
+)
 from moonmind.schemas.container_job_models import (
     AuxiliaryOutcome,
     ContainerJobCancelRequest,
+    ContainerJobFailureClass,
     ContainerJobState,
     ContainerJobSubmitRequest,
     ImageObservation,
@@ -39,16 +45,35 @@ def temporal():
     return adapter
 
 
-def submission(*, key: str = "key", image: str = "alpine") -> ContainerJobSubmitRequest:
+def submission(
+    *, key: str = "key", image: str = "alpine", credential_ref: str | None = None
+) -> ContainerJobSubmitRequest:
     return ContainerJobSubmitRequest(
         idempotencyKey=key,
         source={"source": "mcp", "callerRequestId": "r"},
         spec={
             "image": image,
             "workspaceRef": {"kind": "moonmind-session", "sessionId": "run"},
+            "registryCredentialRef": credential_ref,
             "resources": {"cpuMillis": 100, "memoryMiB": 64},
         },
     )
+
+
+def private_authorizer() -> PrivateImageAuthorizationService:
+    policy = PrivateImageAuthorizationPolicy.model_validate(
+        {
+            "grants": [
+                {
+                    "credentialRef": "db://ghcr",
+                    "registry": "ghcr.io",
+                    "repositories": ["org/*"],
+                    "principals": ["user-a"],
+                }
+            ]
+        }
+    )
+    return PrivateImageAuthorizationService(policy)
 
 
 @pytest.mark.asyncio
@@ -127,6 +152,84 @@ async def test_terminal_observations_and_auxiliary_failures_project_independentl
         preserved = await service.status(owner=OwnerIdentity(principalId="u", principalType="user"), job_id=accepted.job_id)
         assert preserved.backend_kind == "docker"
         assert preserved.backend_ref == "configured-backend"
+
+
+@pytest.mark.asyncio
+async def test_authorized_private_image_flows_authorization_into_workflow(
+    session_factory, temporal
+) -> None:
+    async with session_factory() as session:
+        service = ContainerJobService(
+            session, temporal=temporal, authorizer=private_authorizer()
+        )
+        owner = OwnerIdentity(principalId="user-a", principalType="user")
+        accepted = await service.submit(
+            owner=owner,
+            request=submission(image="ghcr.io/org/app:1", credential_ref="db://ghcr"),
+        )
+        started = temporal.start_container_job.await_args_list[-1].args[0]
+        assert started.registry_authorization is not None
+        assert started.registry_authorization.authorized
+        assert started.registry_authorization.scope == "org/*"
+        status = await service.status(owner=owner, job_id=accepted.job_id)
+        assert status.authorization is not None
+        assert status.authorization.credential_ref == "db://ghcr"
+        # The durable authorization observation carries no credential material.
+        record = await service.repository.get_for_owner(
+            owner=owner, job_id=accepted.job_id
+        )
+        assert "password" not in str(record.authorization_observation_json)
+        assert "token" not in str(record.authorization_observation_json)
+
+
+@pytest.mark.asyncio
+async def test_denied_private_image_fails_closed_without_workflow_or_record(
+    session_factory, temporal
+) -> None:
+    async with session_factory() as session:
+        service = ContainerJobService(
+            session, temporal=temporal, authorizer=private_authorizer()
+        )
+        # User B is not granted the credential -> denied at submission.
+        with pytest.raises(ContainerJobAuthorizationError) as excinfo:
+            await service.submit(
+                owner=OwnerIdentity(principalId="user-b", principalType="user"),
+                request=submission(
+                    image="ghcr.io/org/app:1", credential_ref="db://ghcr"
+                ),
+            )
+        assert (
+            excinfo.value.authorization.failure_class
+            == ContainerJobFailureClass.IMAGE_USE_DENIED
+        )
+        # Fail-closed: no workflow started and no durable queued record.
+        temporal.start_container_job.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_cached_image_still_authorized_per_principal(
+    session_factory, temporal
+) -> None:
+    # Cache presence must not become authorization: even after user A's job for a
+    # private image is accepted, user B's independent request for the same image
+    # is denied because authorization runs per submission, not per cached layer.
+    async with session_factory() as session:
+        service = ContainerJobService(
+            session, temporal=temporal, authorizer=private_authorizer()
+        )
+        await service.submit(
+            owner=OwnerIdentity(principalId="user-a", principalType="user"),
+            request=submission(
+                image="ghcr.io/org/app:1", credential_ref="db://ghcr", key="a"
+            ),
+        )
+        with pytest.raises(ContainerJobAuthorizationError):
+            await service.submit(
+                owner=OwnerIdentity(principalId="user-b", principalType="user"),
+                request=submission(
+                    image="ghcr.io/org/app:1", credential_ref="db://ghcr", key="b"
+                ),
+            )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/test_container_jobs.py
+++ b/tests/unit/services/test_container_jobs.py
@@ -68,7 +68,7 @@ def private_authorizer() -> PrivateImageAuthorizationService:
                     "credentialRef": "db://ghcr",
                     "registry": "ghcr.io",
                     "repositories": ["org/*"],
-                    "principals": ["user-a"],
+                    "principals": ["user:user-a"],
                 }
             ]
         }

--- a/tests/unit/services/test_registry_authorization.py
+++ b/tests/unit/services/test_registry_authorization.py
@@ -23,7 +23,7 @@ def _spec(image: str, credential_ref: str | None = None) -> ContainerJobSpec:
     return ContainerJobSpec.model_validate(
         {
             "image": image,
-            "workspaceRef": {"kind": "moonmind-session", "sessionId": "s"},
+            "workspaceRef": {"kind": "sandbox", "workspaceId": "s"},
             "registryCredentialRef": credential_ref,
             "resources": {"cpuMillis": 100, "memoryMiB": 64},
         }

--- a/tests/unit/services/test_registry_authorization.py
+++ b/tests/unit/services/test_registry_authorization.py
@@ -1,0 +1,130 @@
+"""Private-image authorization service (MoonLadderStudios/MoonMind#3257)."""
+
+from __future__ import annotations
+
+import pytest
+
+from api_service.services.registry_authorization import (
+    PrivateImageAuthorizationPolicy,
+    PrivateImageAuthorizationService,
+    load_default_authorization_policy,
+)
+from moonmind.schemas.container_job_models import (
+    ContainerJobFailureClass,
+    ContainerJobSpec,
+    OwnerIdentity,
+)
+
+USER_A = OwnerIdentity(principalId="user-a", principalType="user")
+USER_B = OwnerIdentity(principalId="user-b", principalType="user")
+
+
+def _spec(image: str, credential_ref: str | None = None) -> ContainerJobSpec:
+    return ContainerJobSpec.model_validate(
+        {
+            "image": image,
+            "workspaceRef": {"kind": "moonmind-session", "sessionId": "s"},
+            "registryCredentialRef": credential_ref,
+            "resources": {"cpuMillis": 100, "memoryMiB": 64},
+        }
+    )
+
+
+def _service(**grant) -> PrivateImageAuthorizationService:
+    policy = PrivateImageAuthorizationPolicy.model_validate({"grants": [grant]})
+    return PrivateImageAuthorizationService(policy)
+
+
+def test_public_image_needs_no_credential() -> None:
+    service = PrivateImageAuthorizationService()
+    result = service.authorize(owner=USER_A, spec=_spec("alpine"))
+    assert result.authorized and result.credential_ref is None
+
+
+def test_authorized_principal_gets_scope() -> None:
+    service = _service(
+        credentialRef="db://ghcr",
+        registry="ghcr.io",
+        repositories=["org/*"],
+        principals=["user-a"],
+    )
+    result = service.authorize(
+        owner=USER_A, spec=_spec("ghcr.io/org/app:1", "db://ghcr")
+    )
+    assert result.authorized
+    assert result.scope == "org/*"
+    assert result.credential_ref == "db://ghcr"
+
+
+def test_unauthorized_principal_is_denied_image_use() -> None:
+    service = _service(
+        credentialRef="db://ghcr",
+        registry="ghcr.io",
+        repositories=["org/*"],
+        principals=["user-a"],
+    )
+    result = service.authorize(
+        owner=USER_B, spec=_spec("ghcr.io/org/app:1", "db://ghcr")
+    )
+    assert not result.authorized
+    assert result.failure_class == ContainerJobFailureClass.IMAGE_USE_DENIED
+
+
+def test_unknown_credential_ref_is_denied() -> None:
+    service = _service(
+        credentialRef="db://ghcr", registry="ghcr.io", repositories=["org/*"]
+    )
+    result = service.authorize(
+        owner=USER_A, spec=_spec("ghcr.io/org/app:1", "db://other")
+    )
+    assert not result.authorized
+    assert result.failure_class == ContainerJobFailureClass.IMAGE_USE_DENIED
+
+
+@pytest.mark.parametrize(
+    "image",
+    ["ghcr.io/other/app:1", "docker.io/org/app:1", "ghcr.io/org/app:blocked"],
+)
+def test_scope_mismatch_fails_closed(image) -> None:
+    service = _service(
+        credentialRef="db://ghcr",
+        registry="ghcr.io",
+        repositories=["org/*"],
+        principals=["*"],
+        tags=["1", "2"],
+    )
+    result = service.authorize(owner=USER_A, spec=_spec(image, "db://ghcr"))
+    assert not result.authorized
+    assert result.failure_class == ContainerJobFailureClass.REPOSITORY_SCOPE_MISMATCH
+
+
+def test_digest_restriction_enforced() -> None:
+    good = "sha256:" + "a" * 64
+    service = _service(
+        credentialRef="db://ghcr",
+        registry="ghcr.io",
+        repositories=["org/*"],
+        principals=["*"],
+        digests=[good],
+    )
+    other = "sha256:" + "b" * 64
+    allowed = service.authorize(
+        owner=USER_A, spec=_spec(f"ghcr.io/org/app@{good}", "db://ghcr")
+    )
+    assert allowed.authorized
+    denied = service.authorize(
+        owner=USER_A, spec=_spec(f"ghcr.io/org/app@{other}", "db://ghcr")
+    )
+    assert not denied.authorized
+    assert denied.failure_class == ContainerJobFailureClass.REPOSITORY_SCOPE_MISMATCH
+
+
+def test_load_default_policy_from_env(monkeypatch) -> None:
+    monkeypatch.setenv(
+        "MOONMIND_REGISTRY_CREDENTIAL_GRANTS",
+        '[{"credentialRef": "db://ghcr", "registry": "ghcr.io", "repositories": ["org/*"]}]',
+    )
+    policy = load_default_authorization_policy()
+    assert policy.grants_for("db://ghcr")
+    monkeypatch.setenv("MOONMIND_REGISTRY_CREDENTIAL_GRANTS", "{not json")
+    assert load_default_authorization_policy().grants == ()

--- a/tests/unit/services/test_registry_authorization.py
+++ b/tests/unit/services/test_registry_authorization.py
@@ -46,7 +46,7 @@ def test_authorized_principal_gets_scope() -> None:
         credentialRef="db://ghcr",
         registry="ghcr.io",
         repositories=["org/*"],
-        principals=["user-a"],
+        principals=["user:user-a"],
     )
     result = service.authorize(
         owner=USER_A, spec=_spec("ghcr.io/org/app:1", "db://ghcr")
@@ -61,7 +61,7 @@ def test_unauthorized_principal_is_denied_image_use() -> None:
         credentialRef="db://ghcr",
         registry="ghcr.io",
         repositories=["org/*"],
-        principals=["user-a"],
+        principals=["user:user-a"],
     )
     result = service.authorize(
         owner=USER_B, spec=_spec("ghcr.io/org/app:1", "db://ghcr")
@@ -79,6 +79,31 @@ def test_unknown_credential_ref_is_denied() -> None:
     )
     assert not result.authorized
     assert result.failure_class == ContainerJobFailureClass.IMAGE_USE_DENIED
+
+
+def test_private_scope_requires_credential_even_for_cached_image() -> None:
+    service = _service(
+        credentialRef="db://ghcr",
+        registry="ghcr.io",
+        repositories=["org/*"],
+        principals=["user:user-a"],
+    )
+    result = service.authorize(owner=USER_A, spec=_spec("ghcr.io/org/app:1"))
+    assert not result.authorized
+    assert result.failure_class == ContainerJobFailureClass.IMAGE_USE_DENIED
+
+
+def test_principal_grants_require_type_qualified_identity() -> None:
+    service = _service(
+        credentialRef="db://ghcr",
+        registry="ghcr.io",
+        repositories=["org/*"],
+        principals=["user-a"],
+    )
+    result = service.authorize(
+        owner=USER_A, spec=_spec("ghcr.io/org/app:1", "db://ghcr")
+    )
+    assert not result.authorized
 
 
 @pytest.mark.parametrize(
@@ -120,6 +145,7 @@ def test_digest_restriction_enforced() -> None:
 
 
 def test_load_default_policy_from_env(monkeypatch) -> None:
+    load_default_authorization_policy.cache_clear()
     monkeypatch.setenv(
         "MOONMIND_REGISTRY_CREDENTIAL_GRANTS",
         '[{"credentialRef": "db://ghcr", "registry": "ghcr.io", "repositories": ["org/*"]}]',
@@ -127,4 +153,6 @@ def test_load_default_policy_from_env(monkeypatch) -> None:
     policy = load_default_authorization_policy()
     assert policy.grants_for("db://ghcr")
     monkeypatch.setenv("MOONMIND_REGISTRY_CREDENTIAL_GRANTS", "{not json")
+    assert load_default_authorization_policy() is policy
+    load_default_authorization_policy.cache_clear()
     assert load_default_authorization_policy().grants == ()

--- a/tests/unit/workflows/temporal/test_container_job_backend_registry_auth.py
+++ b/tests/unit/workflows/temporal/test_container_job_backend_registry_auth.py
@@ -37,6 +37,7 @@ def _request(
         {
             "jobId": JOB_ID,
             "ownershipToken": f"{JOB_ID}:v1",
+            "resolvedWorkspaceRef": str(workspace),
             "request": {
                 "idempotencyKey": "issue-3257",
                 "source": {"source": "workflow"},
@@ -253,6 +254,7 @@ async def test_public_image_never_materializes_auth(tmp_path: Path) -> None:
         {
             "jobId": JOB_ID,
             "ownershipToken": f"{JOB_ID}:v1",
+            "resolvedWorkspaceRef": str(tmp_path),
             "request": {
                 "idempotencyKey": "k",
                 "source": {"source": "workflow"},

--- a/tests/unit/workflows/temporal/test_container_job_backend_registry_auth.py
+++ b/tests/unit/workflows/temporal/test_container_job_backend_registry_auth.py
@@ -42,10 +42,7 @@ def _request(
                 "source": {"source": "workflow"},
                 "spec": {
                     "image": image,
-                    "workspaceRef": {
-                        "kind": "artifact-workspace",
-                        "artifactRef": "art_workspace",
-                    },
+                    "workspaceRef": {"kind": "sandbox", "workspaceId": "workspace"},
                     "registryCredentialRef": "db://ghcr",
                     "pullPolicy": pull_policy,
                     "resources": {"cpuMillis": 1000, "memoryMiB": 512},
@@ -261,10 +258,7 @@ async def test_public_image_never_materializes_auth(tmp_path: Path) -> None:
                 "source": {"source": "workflow"},
                 "spec": {
                     "image": "alpine",
-                    "workspaceRef": {
-                        "kind": "artifact-workspace",
-                        "artifactRef": "art_workspace",
-                    },
+                    "workspaceRef": {"kind": "sandbox", "workspaceId": "workspace"},
                     "resources": {"cpuMillis": 1000, "memoryMiB": 512},
                 },
             },

--- a/tests/unit/workflows/temporal/test_container_job_backend_registry_auth.py
+++ b/tests/unit/workflows/temporal/test_container_job_backend_registry_auth.py
@@ -1,0 +1,251 @@
+"""Ephemeral private-image auth in the Docker backend (MoonLadderStudios/MoonMind#3257)."""
+
+from __future__ import annotations
+
+import json
+import stat
+from pathlib import Path
+
+import pytest
+
+from moonmind.schemas.container_job_models import (
+    ContainerJobActivityRequest,
+    ContainerJobBackendError,
+    ContainerJobFailureClass,
+    RegistryAuthorization,
+)
+from moonmind.workflows.temporal.container_job_backend import DockerContainerJobBackend
+from moonmind.workflows.temporal.runtime.registry_auth_resolve import RegistryCredential
+
+JOB_ID = "container-job:" + "d" * 32
+IMAGE = "ghcr.io/org/app:1"
+DIGEST_ID = "sha256:" + "a" * 64
+TOKEN = "ghp_topsecret_value"
+
+
+def _request(
+    *,
+    workspace: Path,
+    authorized: bool = True,
+    image: str = IMAGE,
+    pull_policy: str = "if-missing",
+    scope: str = "org/*",
+    registry: str = "ghcr.io",
+    repository: str = "org/app",
+) -> ContainerJobActivityRequest:
+    return ContainerJobActivityRequest.model_validate(
+        {
+            "jobId": JOB_ID,
+            "ownershipToken": f"{JOB_ID}:v1",
+            "request": {
+                "idempotencyKey": "issue-3257",
+                "source": {"source": "workflow"},
+                "spec": {
+                    "image": image,
+                    "workspaceRef": {
+                        "kind": "artifact-workspace",
+                        "artifactRef": "art_workspace",
+                    },
+                    "registryCredentialRef": "db://ghcr",
+                    "pullPolicy": pull_policy,
+                    "resources": {"cpuMillis": 1000, "memoryMiB": 512},
+                },
+            },
+            "registryAuthorization": RegistryAuthorization(
+                authorized=authorized,
+                registry=registry,
+                repository=repository,
+                reference=image,
+                credentialRef="db://ghcr",
+                scope=scope,
+            ).model_dump(by_alias=True, exclude_none=True),
+        }
+    )
+
+
+def _backend(tmp_path: Path, runner, *, resolver=None):
+    async def default_resolver(ref):
+        return RegistryCredential(username="octo", secret=TOKEN)
+
+    return DockerContainerJobBackend(
+        workspace_root=tmp_path / "workspaces",
+        command_runner=runner,
+        registry_auth_resolver=resolver or default_resolver,
+        auth_root=tmp_path / "auth",
+    )
+
+
+@pytest.mark.asyncio
+async def test_authorized_pull_materializes_restricted_config_and_cleans_up(
+    tmp_path: Path,
+) -> None:
+    captured: dict[str, object] = {}
+    commands: list[tuple[str, ...]] = []
+
+    async def runner(args):
+        args = tuple(args)
+        commands.append(args)
+        if args[:2] == ("image", "inspect"):
+            # Missing until pulled.
+            return (1, b"", b"") if "pull" not in captured else (0, DIGEST_ID.encode(), b"")
+        if "pull" in args:
+            captured["pull"] = True
+            config_dir = Path(args[args.index("--config") + 1])
+            config = json.loads((config_dir / "config.json").read_text())
+            captured["auth"] = config
+            captured["dir_mode"] = stat.S_IMODE(config_dir.stat().st_mode)
+            captured["file_mode"] = stat.S_IMODE((config_dir / "config.json").stat().st_mode)
+            return 0, b"", b""
+        return 0, b"", b""
+
+    backend = _backend(tmp_path, runner)
+    result = await backend.acquire_image(_request(workspace=tmp_path))
+
+    assert result.resolved_image_ref == DIGEST_ID
+    # Pull used --config pointing at a per-job ephemeral directory.
+    assert any("--config" in cmd and "pull" in cmd for cmd in commands)
+    assert captured["auth"]["auths"]["ghcr.io"] == {
+        "username": "octo",
+        "password": TOKEN,
+    }
+    assert captured["dir_mode"] == 0o700
+    assert captured["file_mode"] == 0o600
+    # Ephemeral auth is removed immediately after the pull.
+    auth_dir = backend._auth_dir(_request(workspace=tmp_path))
+    assert not auth_dir.exists()
+
+
+@pytest.mark.asyncio
+async def test_cache_hit_enforces_authorization_without_pulling(tmp_path: Path) -> None:
+    commands: list[tuple[str, ...]] = []
+
+    async def runner(args):
+        args = tuple(args)
+        commands.append(args)
+        if args[:2] == ("image", "inspect"):
+            return 0, DIGEST_ID.encode(), b""
+        return 0, b"", b""
+
+    backend = _backend(tmp_path, runner)
+    # Authorized cache hit: image present, no pull, no credential materialization.
+    result = await backend.acquire_image(_request(workspace=tmp_path))
+    assert result.resolved_image_ref == DIGEST_ID
+    assert not any("pull" in cmd for cmd in commands)
+
+
+@pytest.mark.asyncio
+async def test_cache_hit_denied_when_not_authorized(tmp_path: Path) -> None:
+    async def runner(args):
+        # Image is cached, but policy must still block it.
+        if tuple(args)[:2] == ("image", "inspect"):
+            return 0, DIGEST_ID.encode(), b""
+        return 0, b"", b""
+
+    backend = _backend(tmp_path, runner)
+    with pytest.raises(ContainerJobBackendError) as excinfo:
+        await backend.acquire_image(_request(workspace=tmp_path, authorized=False))
+    assert excinfo.value.failure_class == ContainerJobFailureClass.IMAGE_USE_DENIED
+
+
+@pytest.mark.asyncio
+async def test_scope_mismatch_fails_closed_before_pull(tmp_path: Path) -> None:
+    async def runner(args):
+        return 1, b"", b"missing"
+
+    backend = _backend(tmp_path, runner)
+    request = _request(workspace=tmp_path, repository="other/app")
+    with pytest.raises(ContainerJobBackendError) as excinfo:
+        await backend.acquire_image(request)
+    assert (
+        excinfo.value.failure_class
+        == ContainerJobFailureClass.REPOSITORY_SCOPE_MISMATCH
+    )
+
+
+@pytest.mark.asyncio
+async def test_registry_auth_failure_is_classified_and_redacted(tmp_path: Path) -> None:
+    async def runner(args):
+        args = tuple(args)
+        if args[:2] == ("image", "inspect"):
+            return 1, b"", b""
+        if "pull" in args:
+            return 1, b"", f"denied for {TOKEN}".encode()
+        return 0, b"", b""
+
+    backend = _backend(tmp_path, runner)
+    with pytest.raises(ContainerJobBackendError) as excinfo:
+        await backend.acquire_image(_request(workspace=tmp_path))
+    assert excinfo.value.failure_class == ContainerJobFailureClass.REGISTRY_AUTH_FAILED
+    assert TOKEN not in str(excinfo.value)
+    assert "[redacted]" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_unresolved_credential_is_classified(tmp_path: Path) -> None:
+    from moonmind.workflows.temporal.runtime.registry_auth_resolve import (
+        RegistryAuthResolutionError,
+    )
+
+    async def failing_resolver(ref):
+        raise RegistryAuthResolutionError("nope")
+
+    async def runner(args):
+        return 1, b"", b""
+
+    backend = _backend(tmp_path, runner, resolver=failing_resolver)
+    with pytest.raises(ContainerJobBackendError) as excinfo:
+        await backend.acquire_image(_request(workspace=tmp_path))
+    assert excinfo.value.failure_class == ContainerJobFailureClass.CREDENTIAL_UNRESOLVED
+
+
+@pytest.mark.asyncio
+async def test_cleanup_removes_ephemeral_auth_and_reports_failure(tmp_path: Path) -> None:
+    async def runner(args):
+        return 0, b"", b""
+
+    backend = _backend(tmp_path, runner)
+    request = _request(workspace=tmp_path)
+    auth_dir = backend._auth_dir(request)
+    auth_dir.mkdir(parents=True)
+    (auth_dir / "config.json").write_text("{}")
+
+    # Deterministic cleanup removes the directory on any terminal path.
+    await backend.cleanup(request)
+    assert not auth_dir.exists()
+    # Idempotent: cleaning an already-removed directory succeeds.
+    await backend.cleanup(request)
+
+
+@pytest.mark.asyncio
+async def test_public_image_never_materializes_auth(tmp_path: Path) -> None:
+    commands: list[tuple[str, ...]] = []
+
+    async def runner(args):
+        args = tuple(args)
+        commands.append(args)
+        if args[:2] == ("image", "inspect"):
+            return 0, DIGEST_ID.encode(), b""
+        return 0, b"", b""
+
+    backend = _backend(tmp_path, runner)
+    request = ContainerJobActivityRequest.model_validate(
+        {
+            "jobId": JOB_ID,
+            "ownershipToken": f"{JOB_ID}:v1",
+            "request": {
+                "idempotencyKey": "k",
+                "source": {"source": "workflow"},
+                "spec": {
+                    "image": "alpine",
+                    "workspaceRef": {
+                        "kind": "artifact-workspace",
+                        "artifactRef": "art_workspace",
+                    },
+                    "resources": {"cpuMillis": 1000, "memoryMiB": 512},
+                },
+            },
+        }
+    )
+    result = await backend.acquire_image(request)
+    assert result.resolved_image_ref == DIGEST_ID
+    assert all("--config" not in cmd for cmd in commands)

--- a/tests/unit/workflows/temporal/test_container_job_backend_registry_auth.py
+++ b/tests/unit/workflows/temporal/test_container_job_backend_registry_auth.py
@@ -116,6 +116,30 @@ async def test_authorized_pull_materializes_restricted_config_and_cleans_up(
 
 
 @pytest.mark.asyncio
+async def test_docker_hub_auth_uses_cli_index_key(tmp_path: Path) -> None:
+    captured: dict[str, object] = {}
+
+    async def runner(args):
+        args = tuple(args)
+        if args[:2] == ("image", "inspect"):
+            return (1, b"", b"") if not captured else (0, DIGEST_ID.encode(), b"")
+        if "pull" in args:
+            config_dir = Path(args[args.index("--config") + 1])
+            captured.update(json.loads((config_dir / "config.json").read_text()))
+        return 0, b"", b""
+
+    backend = _backend(tmp_path, runner)
+    await backend.acquire_image(
+        _request(
+            workspace=tmp_path,
+            image="docker.io/org/app:1",
+            registry="docker.io",
+        )
+    )
+    assert "https://index.docker.io/v1/" in captured["auths"]
+
+
+@pytest.mark.asyncio
 async def test_cache_hit_enforces_authorization_without_pulling(tmp_path: Path) -> None:
     commands: list[tuple[str, ...]] = []
 

--- a/tests/unit/workflows/temporal/test_container_job_workflow.py
+++ b/tests/unit/workflows/temporal/test_container_job_workflow.py
@@ -104,6 +104,39 @@ async def test_typed_activity_boundary_delegates_to_backend() -> None:
 
 
 @pytest.mark.asyncio
+async def test_backend_denial_becomes_nonretryable_application_error() -> None:
+    from temporalio.exceptions import ApplicationError
+
+    from moonmind.schemas.container_job_models import (
+        ContainerJobBackendError,
+        ContainerJobFailureClass,
+        failure_class_from_exception,
+    )
+
+    async def deny(request):
+        raise ContainerJobBackendError(
+            ContainerJobFailureClass.IMAGE_USE_DENIED, "not authorized"
+        )
+
+    backend = type("Backend", (), {"acquire_image": staticmethod(deny)})()
+    activities = TemporalAgentRuntimeActivities(container_job_backend=backend)
+    inp = _input()
+    payload = {
+        "jobId": JOB_ID,
+        "ownershipToken": inp.ownership_token,
+        "request": inp.request.model_dump(mode="json", by_alias=True),
+    }
+    with pytest.raises(ApplicationError) as excinfo:
+        await activities.container_job_acquire_image(payload)
+    assert excinfo.value.non_retryable
+    assert excinfo.value.type == "image_use_denied"
+    assert (
+        failure_class_from_exception(excinfo.value)
+        == ContainerJobFailureClass.IMAGE_USE_DENIED
+    )
+
+
+@pytest.mark.asyncio
 async def test_production_backend_makes_every_registered_activity_callable(
     tmp_path,
 ) -> None:
@@ -260,6 +293,51 @@ async def test_primary_success_survives_publication_and_cleanup_failures(
     assert result["terminal"].get("failureClass") is None
     assert result["publication"]["state"] == "failed"
     assert result["cleanup"]["state"] == "failed"
+
+
+@pytest.mark.asyncio
+async def test_authorization_flows_to_acquire_image_and_failure_class_survives(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from moonmind.schemas.container_job_models import (
+        ContainerJobBackendError,
+        ContainerJobFailureClass,
+    )
+
+    job = MoonMindContainerJobWorkflow()
+    seen: dict[str, object] = {}
+
+    async def activity(name, request):
+        if name == "container_job.acquire_image":
+            seen["authorization"] = request.registry_authorization
+            # Simulate a trusted-backend denial after the API authorized the job;
+            # the specific failure class must reach the terminal outcome even
+            # after crossing the (simulated) activity boundary.
+            raise RuntimeError(
+                "Activity task failed: "
+                + str(
+                    ContainerJobBackendError(
+                        ContainerJobFailureClass.REGISTRY_AUTH_FAILED, "registry denied"
+                    )
+                )
+            )
+        return _result_for(name)
+
+    monkeypatch.setattr(job, "_activity", activity)
+    payload = _input().model_dump(mode="json", by_alias=True)
+    payload["registryAuthorization"] = {
+        "authorized": True,
+        "registry": "ghcr.io",
+        "repository": "org/app",
+        "reference": "ghcr.io/org/app:1",
+        "credentialRef": "db://ghcr",
+        "scope": "org/*",
+    }
+    result = await job.run(payload)
+    assert seen["authorization"] is not None
+    assert seen["authorization"].credential_ref == "db://ghcr"
+    assert result["state"] == "failed"
+    assert result["terminal"]["failureClass"] == "registry_auth_failed"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/workflows/temporal/test_registry_auth_resolve.py
+++ b/tests/unit/workflows/temporal/test_registry_auth_resolve.py
@@ -1,0 +1,69 @@
+"""Generic registry-auth resolver coverage (MoonLadderStudios/MoonMind#3257)."""
+
+from __future__ import annotations
+
+import pytest
+
+from moonmind.workflows.temporal.runtime import registry_auth_resolve
+from moonmind.workflows.temporal.runtime.registry_auth_resolve import (
+    RegistryAuthResolutionError,
+    resolve_registry_pull_credentials,
+)
+
+
+@pytest.fixture
+def fake_secret(monkeypatch):
+    values: dict[str, str] = {}
+
+    async def _resolve(ref, *, field_name="registryCredentialRef"):
+        if ref not in values:
+            raise ValueError(f"unresolved: {ref}")
+        return values[ref]
+
+    monkeypatch.setattr(
+        registry_auth_resolve, "resolve_managed_api_key_reference", _resolve
+    )
+    return values
+
+
+@pytest.mark.asyncio
+async def test_resolves_json_username_password(fake_secret) -> None:
+    fake_secret["db://ghcr"] = '{"username": "octo", "password": "s3cret"}'
+    credential = await resolve_registry_pull_credentials("db://ghcr")
+    assert credential.username == "octo"
+    assert credential.secret == "s3cret"
+    assert credential.docker_auth_entry() == {"username": "octo", "password": "s3cret"}
+
+
+@pytest.mark.asyncio
+async def test_resolves_json_token_alias(fake_secret) -> None:
+    fake_secret["db://ghcr"] = '{"username": "octo", "token": "ghp_abc"}'
+    credential = await resolve_registry_pull_credentials("db://ghcr")
+    assert credential.secret == "ghp_abc"
+
+
+@pytest.mark.asyncio
+async def test_resolves_colon_pair_preserving_secret_colons(fake_secret) -> None:
+    fake_secret["db://ghcr"] = "octo:tok:with:colons"
+    credential = await resolve_registry_pull_credentials("db://ghcr")
+    assert credential.username == "octo"
+    assert credential.secret == "tok:with:colons"
+
+
+@pytest.mark.asyncio
+async def test_empty_reference_is_rejected(fake_secret) -> None:
+    with pytest.raises(RegistryAuthResolutionError):
+        await resolve_registry_pull_credentials("   ")
+
+
+@pytest.mark.asyncio
+async def test_unresolvable_reference_is_normalized_error(fake_secret) -> None:
+    with pytest.raises(RegistryAuthResolutionError):
+        await resolve_registry_pull_credentials("db://missing")
+
+
+@pytest.mark.asyncio
+async def test_malformed_value_is_rejected(fake_secret) -> None:
+    fake_secret["db://ghcr"] = "no-colon-and-not-json"
+    with pytest.raises(RegistryAuthResolutionError):
+        await resolve_registry_pull_credentials("db://ghcr")


### PR DESCRIPTION
## Issue

Implements MoonLadderStudios/MoonMind#3257 — Docker Backend: Authorize private images with ephemeral registry credentials.

Closes MoonLadderStudios/MoonMind#3257

## Summary

Adds a generic private-image authorization boundary for container jobs, replacing the previous behavior where `container_job_backend.acquire_image()` rejected any `registryCredentialRef` and performed an unauthorized inspect/pull.

- **API-owned authorization service** (`api_service/services/registry_authorization.py`): `PrivateImageAuthorizationService` authorizes the authenticated principal, normalized registry/repository/reference, requested credential ref, allowed registry/repository scope, cache-independent execution policy, and optional tag/digest restrictions.
- **Fail-closed submission** (`api_service/services/container_jobs.py`): `submit()` authorizes before creating an identity/workflow; denial produces no workflow and no queued record, and only a non-sensitive `RegistryAuthorization` observation is persisted (new nullable `authorization_observation_json` column + migration `340`).
- **Execution-time registry-auth resolver** (`moonmind/workflows/temporal/runtime/registry_auth_resolve.py`): delegates to the existing managed-secret backends (`resolve_managed_api_key_reference`) rather than duplicating secret handling; sidecar-only raw GHCR credential settings are not promoted into the public contract.
- **Docker backend** (`container_job_backend.py`): re-authorizes every run before a cache hit or pull (image presence never bypasses policy), resolves the credential only at execution time, materializes a per-job Docker config (`0700` dir / `0600` file) outside the mounted workspace, redacts secrets from pull errors, removes ephemeral auth in a `finally` block and again via a deterministic job-owned `cleanup()` activity on success/failure/cancellation/timeout.
- **Contracts** (`moonmind/schemas/container_job_models.py`): non-sensitive `RegistryCredentialRef` / `RegistryAuthorization` / `NormalizedImageReference`; durable records carry references, observations, image identity, and resolved digest only — never usernames/tokens/passwords/auth blobs.
- **Five new failure classes**: `image_use_denied`, `credential_unresolved`, `repository_scope_mismatch`, `registry_auth_failed`, `credential_cleanup_failed`, preserved across the Temporal activity boundary via a stable marker with deterministic denials mapped to non-retryable `ApplicationError`s.
- **Docs**: `docs/ManagedAgents/DockerBackendService.md` §11.4/§18 updated to reflect realized behavior.

## Tests run

- Targeted unit suite (`MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`): **60/60 passed** across contracts, authorization service, service denial + per-principal cached-image denial, registry-auth resolver, backend ephemeral-auth path, workflow boundary, and migration upgrade/downgrade. Frontend Vitest also ran clean (1088 passed, 238 skipped).

## Remaining risks

The following are disclosed scope exclusions that require a live environment not available in the managed-agent workspace, and are therefore not exercised end-to-end here (in-scope logic is covered via injected command-runner/resolver seams):

- Live private-registry Docker integration (authorized/unauthorized pull, cached-image denial for a second user via the real daemon, scope mismatch, tag-to-digest).
- Filesystem ownership under a privileged worker and janitor/orphan recovery (mode bits verified via `tmp_path`; real ownership requires a live worker).
- Secret-leakage scan across a live daemon / Temporal payloads (contract-level forbidden-key rejection and pull-error redaction are unit-verified).
- Production authority-handoff through the configured system Docker proxy and real secret resolver.
