### PR TITLE
Force recreate services after source updates

### DIFF
--- a/.agents/skills/update-moonmind/SKILL.md
+++ b/.agents/skills/update-moonmind/SKILL.md
@@ -27,7 +27,7 @@ metadata:
    - `git fetch` from `origin` and checkout/reset local `<branch>` from `origin/<branch>`
    - `git pull --ff-only origin <branch>`
    - optionally `docker compose pull` (unless `noComposePull` is set)
-  - detect files changed between pre-pull and post-pull commits and restart only those changed containers
+  - detect files changed between pre-pull and post-pull commits and force-recreate only those changed containers so bind-mounted source updates are loaded by new processes
   - restart services with image drift or stopped service state so runtime stays healthy
   - run a final reconciliation pass for services flagged for restart so updates stay targeted
 4. By default, do not restart the `orchestrator` container, even when it changed.

--- a/.agents/skills/update-moonmind/SKILL.md
+++ b/.agents/skills/update-moonmind/SKILL.md
@@ -27,7 +27,7 @@ metadata:
    - `git fetch` from `origin` and checkout/reset local `<branch>` from `origin/<branch>`
    - `git pull --ff-only origin <branch>`
    - optionally `docker compose pull` (unless `noComposePull` is set)
-  - detect files changed between pre-pull and post-pull commits and force-recreate only those changed containers so bind-mounted source updates are loaded by new processes
+  - detect files changed between pre-pull and post-pull commits, force-recreate only application processes affected by bind-mounted runtime source, and use normal Compose reconciliation for other selected services
   - restart services with image drift or stopped service state so runtime stays healthy
-  - run a final reconciliation pass for services flagged for restart so updates stay targeted
+  - exclude the deployment-control worker from update targets so it can finish and verify the operation
 4. By default, do not restart the `orchestrator` container, even when it changed.

--- a/.agents/skills/update-moonmind/scripts/run-update-moonmind.sh
+++ b/.agents/skills/update-moonmind/scripts/run-update-moonmind.sh
@@ -502,6 +502,7 @@ for service in "${COMPOSE_SERVICES[@]}"; do
 done
 
 declare -A target_services=()
+declare -A force_recreate_services=()
 
 add_target() {
   local service="$1"
@@ -528,6 +529,28 @@ add_all_services() {
   done
 }
 
+add_force_recreate_target() {
+  local service="$1"
+  add_target "$service"
+  if [[ "$service" == "temporal-worker-deployment-control" ]]; then
+    return
+  fi
+  if [[ -v target_services["$service"] ]]; then
+    force_recreate_services["$service"]=1
+  fi
+}
+
+add_runtime_source_services_for_recreate() {
+  local service
+  for service in "${COMPOSE_SERVICES[@]}"; do
+    case "$service" in
+      api | orchestrator | temporal-worker-*)
+        add_force_recreate_target "$service"
+        ;;
+    esac
+  done
+}
+
 if load_compose_service_images; then
   mark_stale_services_for_restart
 fi
@@ -540,15 +563,11 @@ for changed_file in "${CHANGED_FILES[@]}"; do
     docker-compose*.y*ml | .env* | AGENTS.md | .env-template* | .env.vllm-template* | .gitmodules )
       add_all_services
       ;;
-    services/*)
-      service="${changed_file#services/}"
-      service="${service%%/*}"
-      add_target "$service"
-      ;;
-    moonmind/*|tools/*|.agents/*|.gemini/*|specs/*|.specify/*|docs/*|README*|LICENSE|.gitignore )
+    moonmind/* | api_service/* | services/*)
       add_all_services
+      add_runtime_source_services_for_recreate
       ;;
-    api_service/*)
+    tools/* | .agents/* | .gemini/* | specs/* | .specify/* | docs/* | README* | LICENSE | .gitignore)
       add_all_services
       ;;
     init_db/*)
@@ -565,11 +584,11 @@ for changed_file in "${CHANGED_FILES[@]}"; do
   esac
 done
 
-readarray -t SERVICES_TO_RESTART < <(
-  for target in "${!target_services[@]}"; do
+readarray -t SERVICES_TO_RECREATE < <(
+  for target in "${!force_recreate_services[@]}"; do
     [[ -n "${target//[[:space:]]/}" ]] || continue
     case "$target" in
-      agent-workspaces-init | codex-auth-init | gemini-auth-init | init-db )
+      agent-workspaces-init | codex-auth-init | gemini-auth-init | init-db | temporal-worker-deployment-control)
         continue
         ;;
       *)
@@ -579,43 +598,42 @@ readarray -t SERVICES_TO_RESTART < <(
   done | sort
 )
 
-if [[ ${#SERVICES_TO_RESTART[@]} -eq 0 ]]; then
+readarray -t SERVICES_TO_RESTART < <(
+  for target in "${!target_services[@]}"; do
+    [[ -n "${target//[[:space:]]/}" ]] || continue
+    case "$target" in
+      agent-workspaces-init | codex-auth-init | gemini-auth-init | init-db | temporal-worker-deployment-control)
+        continue
+        ;;
+      *)
+        if [[ ! -v force_recreate_services["$target"] ]]; then
+          printf '%s\n' "$target"
+        fi
+        ;;
+    esac
+  done | sort
+)
+
+if [[ ${#SERVICES_TO_RESTART[@]} -eq 0 && ${#SERVICES_TO_RECREATE[@]} -eq 0 ]]; then
   say "No restartable services detected after filtering."
-else
+fi
+
+if [[ ${#SERVICES_TO_RESTART[@]} -gt 0 ]]; then
   if [[ "$RESTART_ORCHESTRATOR" == "true" ]]; then
     say "Restarting changed services: ${SERVICES_TO_RESTART[*]}"
   else
     say "Restarting changed services (excluding orchestrator): ${SERVICES_TO_RESTART[*]}"
   fi
-  # Most MoonMind application sources are bind-mounted into long-lived
-  # containers. A plain `compose up` treats those containers as unchanged even
-  # after git updates the mounted files, leaving already-imported Python modules
-  # running until some unrelated restart. Recreate every selected service so
-  # the refreshed source is loaded by a new process.
-  run_cmd "${COMPOSE_CMD[@]}" up -d --no-deps --force-recreate "${SERVICES_TO_RESTART[@]}"
+  run_cmd "${COMPOSE_CMD[@]}" up -d --no-deps "${SERVICES_TO_RESTART[@]}"
 fi
 
-if [[ ${#SERVICES_TO_RESTART[@]} -eq 0 ]]; then
-  say "No selected services require reconciliation."
-else
-  readarray -t RECONCILE_SERVICES < <(
-    for target in "${SERVICES_TO_RESTART[@]}"; do
-      [[ -n "${target//[[:space:]]/}" ]] || continue
-      printf '%s\n' "$target"
-    done
-  )
-
-  if [[ ${#RECONCILE_SERVICES[@]} -eq 0 ]]; then
-    say "No selected services require reconciliation."
-    :
-  else
+if [[ ${#SERVICES_TO_RECREATE[@]} -gt 0 ]]; then
   if [[ "$RESTART_ORCHESTRATOR" == "true" ]]; then
-    say "Reconciling selected services for reconciliation: ${RECONCILE_SERVICES[*]}"
+    say "Force-recreating services with updated bind-mounted runtime source: ${SERVICES_TO_RECREATE[*]}"
   else
-    say "Reconciling selected services for reconciliation (excluding orchestrator): ${RECONCILE_SERVICES[*]}"
+    say "Force-recreating services with updated bind-mounted runtime source (excluding orchestrator): ${SERVICES_TO_RECREATE[*]}"
   fi
-  run_cmd "${COMPOSE_CMD[@]}" up -d --no-deps "${RECONCILE_SERVICES[@]}"
-  fi
+  run_cmd "${COMPOSE_CMD[@]}" up -d --no-deps --force-recreate "${SERVICES_TO_RECREATE[@]}"
 fi
 
 say "MoonMind update complete"

--- a/.agents/skills/update-moonmind/scripts/run-update-moonmind.sh
+++ b/.agents/skills/update-moonmind/scripts/run-update-moonmind.sh
@@ -587,7 +587,12 @@ else
   else
     say "Restarting changed services (excluding orchestrator): ${SERVICES_TO_RESTART[*]}"
   fi
-  run_cmd "${COMPOSE_CMD[@]}" up -d --no-deps "${SERVICES_TO_RESTART[@]}"
+  # Most MoonMind application sources are bind-mounted into long-lived
+  # containers. A plain `compose up` treats those containers as unchanged even
+  # after git updates the mounted files, leaving already-imported Python modules
+  # running until some unrelated restart. Recreate every selected service so
+  # the refreshed source is loaded by a new process.
+  run_cmd "${COMPOSE_CMD[@]}" up -d --no-deps --force-recreate "${SERVICES_TO_RESTART[@]}"
 fi
 
 if [[ ${#SERVICES_TO_RESTART[@]} -eq 0 ]]; then

--- a/tests/unit/test_update_moonmind_skill.py
+++ b/tests/unit/test_update_moonmind_skill.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+UPDATE_SCRIPT = (
+    ROOT
+    / ".agents"
+    / "skills"
+    / "update-moonmind"
+    / "scripts"
+    / "run-update-moonmind.sh"
+)
+
+
+def _run_git(*args: str, cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _modern_bash() -> str:
+    bash = shutil.which("bash")
+    if bash is None:
+        pytest.skip("update-moonmind requires Bash")
+    version = subprocess.run(
+        [bash, "-c", 'printf "%s" "${BASH_VERSINFO[0]}"'],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+    if int(version) < 4:
+        pytest.skip("update-moonmind requires Bash 4 or newer")
+    return bash
+
+
+def test_source_update_force_recreates_selected_services(tmp_path: Path) -> None:
+    bash = _modern_bash()
+    seed = tmp_path / "seed"
+    remote = tmp_path / "origin.git"
+    checkout = tmp_path / "checkout"
+    fake_bin = tmp_path / "bin"
+    docker_log = tmp_path / "docker.log"
+
+    seed.mkdir()
+    _run_git("init", "-b", "main", cwd=seed)
+    _run_git("config", "user.name", "MoonMind Test", cwd=seed)
+    _run_git("config", "user.email", "moonmind-test@example.invalid", cwd=seed)
+    (seed / "moonmind").mkdir()
+    source_file = seed / "moonmind" / "example.py"
+    source_file.write_text("VERSION = 1\n", encoding="utf-8")
+    _run_git("add", "moonmind/example.py", cwd=seed)
+    _run_git("commit", "-m", "initial", cwd=seed)
+
+    _run_git("init", "--bare", str(remote), cwd=tmp_path)
+    _run_git("remote", "add", "origin", str(remote), cwd=seed)
+    _run_git("push", "-u", "origin", "main", cwd=seed)
+    _run_git("symbolic-ref", "HEAD", "refs/heads/main", cwd=remote)
+    _run_git("clone", str(remote), str(checkout), cwd=tmp_path)
+
+    source_file.write_text("VERSION = 2\n", encoding="utf-8")
+    _run_git("add", "moonmind/example.py", cwd=seed)
+    _run_git("commit", "-m", "update source", cwd=seed)
+    _run_git("push", "origin", "main", cwd=seed)
+    expected_head = _run_git("rev-parse", "HEAD", cwd=seed).stdout.strip()
+
+    fake_bin.mkdir()
+    fake_docker = fake_bin / "docker"
+    fake_docker.write_text(
+        """#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >> "$DOCKER_LOG"
+
+if [[ "${1:-}" == "ps" ]]; then
+  exit 0
+fi
+if [[ "${1:-}" != "compose" ]]; then
+  exit 0
+fi
+shift
+
+case "${1:-} ${2:-}" in
+  "version ")
+    exit 0
+    ;;
+  "config --services")
+    printf '%s\\n' api temporal-worker-workflow
+    ;;
+  "config --format")
+    printf '%s\\n' '{"services":{"api":{"image":"moonmind:test"},"temporal-worker-workflow":{"image":"moonmind:test"}}}'
+    ;;
+  "pull ")
+    exit 0
+    ;;
+  "ps -a"|"ps -q")
+    exit 0
+    ;;
+  "up -d")
+    exit 0
+    ;;
+esac
+""",
+        encoding="utf-8",
+    )
+    fake_docker.chmod(0o755)
+
+    env = dict(os.environ)
+    env["PATH"] = f"{fake_bin}{os.pathsep}{env['PATH']}"
+    env["DOCKER_LOG"] = str(docker_log)
+    subprocess.run(
+        [bash, str(UPDATE_SCRIPT), "--repo", str(checkout), "--branch", "main"],
+        cwd=ROOT,
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert _run_git("rev-parse", "HEAD", cwd=checkout).stdout.strip() == expected_head
+    up_commands = [
+        line
+        for line in docker_log.read_text(encoding="utf-8").splitlines()
+        if line.startswith("compose up ")
+    ]
+    assert len(up_commands) == 2
+    assert "--force-recreate" in up_commands[0]
+    assert "api" in up_commands[0]
+    assert "temporal-worker-workflow" in up_commands[0]
+    assert "--force-recreate" not in up_commands[1]

--- a/tests/unit/test_update_moonmind_skill.py
+++ b/tests/unit/test_update_moonmind_skill.py
@@ -44,7 +44,7 @@ def _modern_bash() -> str:
     return bash
 
 
-def test_source_update_force_recreates_selected_services(tmp_path: Path) -> None:
+def _run_update_scenario(tmp_path: Path, *, changed_file: str) -> list[str]:
     bash = _modern_bash()
     seed = tmp_path / "seed"
     remote = tmp_path / "origin.git"
@@ -56,10 +56,10 @@ def test_source_update_force_recreates_selected_services(tmp_path: Path) -> None
     _run_git("init", "-b", "main", cwd=seed)
     _run_git("config", "user.name", "MoonMind Test", cwd=seed)
     _run_git("config", "user.email", "moonmind-test@example.invalid", cwd=seed)
-    (seed / "moonmind").mkdir()
-    source_file = seed / "moonmind" / "example.py"
+    source_file = seed / changed_file
+    source_file.parent.mkdir(parents=True)
     source_file.write_text("VERSION = 1\n", encoding="utf-8")
-    _run_git("add", "moonmind/example.py", cwd=seed)
+    _run_git("add", changed_file, cwd=seed)
     _run_git("commit", "-m", "initial", cwd=seed)
 
     _run_git("init", "--bare", str(remote), cwd=tmp_path)
@@ -69,7 +69,7 @@ def test_source_update_force_recreates_selected_services(tmp_path: Path) -> None
     _run_git("clone", str(remote), str(checkout), cwd=tmp_path)
 
     source_file.write_text("VERSION = 2\n", encoding="utf-8")
-    _run_git("add", "moonmind/example.py", cwd=seed)
+    _run_git("add", changed_file, cwd=seed)
     _run_git("commit", "-m", "update source", cwd=seed)
     _run_git("push", "origin", "main", cwd=seed)
     expected_head = _run_git("rev-parse", "HEAD", cwd=seed).stdout.strip()
@@ -94,10 +94,10 @@ case "${1:-} ${2:-}" in
     exit 0
     ;;
   "config --services")
-    printf '%s\\n' api temporal-worker-workflow
+    printf '%s\\n' api postgres temporal-worker-deployment-control temporal-worker-workflow
     ;;
   "config --format")
-    printf '%s\\n' '{"services":{"api":{"image":"moonmind:test"},"temporal-worker-workflow":{"image":"moonmind:test"}}}'
+    printf '%s\\n' '{"services":{"api":{"image":"moonmind:test"},"postgres":{"image":"postgres:test"},"temporal-worker-deployment-control":{"image":"moonmind:test"},"temporal-worker-workflow":{"image":"moonmind:test"}}}'
     ;;
   "pull ")
     exit 0
@@ -127,13 +127,46 @@ esac
     )
 
     assert _run_git("rev-parse", "HEAD", cwd=checkout).stdout.strip() == expected_head
-    up_commands = [
+    return [
         line
         for line in docker_log.read_text(encoding="utf-8").splitlines()
         if line.startswith("compose up ")
     ]
+
+
+def test_runtime_source_update_force_recreates_only_application_services(
+    tmp_path: Path,
+) -> None:
+    up_commands = _run_update_scenario(
+        tmp_path,
+        changed_file="moonmind/example.py",
+    )
+
     assert len(up_commands) == 2
-    assert "--force-recreate" in up_commands[0]
+    recreate_command = next(
+        command for command in up_commands if "--force-recreate" in command
+    )
+    restart_command = next(
+        command for command in up_commands if "--force-recreate" not in command
+    )
+    assert "api" in recreate_command
+    assert "temporal-worker-workflow" in recreate_command
+    assert "postgres" not in recreate_command
+    assert "postgres" in restart_command
+    assert all("temporal-worker-deployment-control" not in row for row in up_commands)
+
+
+def test_documentation_update_does_not_force_recreate_services(
+    tmp_path: Path,
+) -> None:
+    up_commands = _run_update_scenario(
+        tmp_path,
+        changed_file="docs/guide.md",
+    )
+
+    assert len(up_commands) == 1
+    assert "--force-recreate" not in up_commands[0]
     assert "api" in up_commands[0]
+    assert "postgres" in up_commands[0]
     assert "temporal-worker-workflow" in up_commands[0]
-    assert "--force-recreate" not in up_commands[1]
+    assert "temporal-worker-deployment-control" not in up_commands[0]


### PR DESCRIPTION
## What changed

- Force-recreate services selected by the `update-moonmind` skill after a Git or image update.
- Keep the second reconciliation pass non-forcing.
- Document the bind-mounted source behavior in the skill contract.
- Add a boundary test that fast-forwards a temporary checkout and verifies the selected API and workflow-worker services are recreated.

## Root cause

Workflow `mm:bc689115-e389-4cdf-b221-89df19bcca08-2026-07-14T13:00:00Z` ran on Python processes that had loaded repository code before the scheduled-parent inheritance fix reached the checkout. The update skill later fast-forwarded the bind-mounted source, but its plain `docker compose up -d --no-deps` calls considered the existing containers unchanged. The long-lived API and Temporal workers therefore kept the old imported modules and rejected both Dependabot child submissions with `parent_execution_not_found`.

## Impact

After an update selects a service, a new container process now loads the refreshed bind-mounted source immediately. This prevents the deployment from reporting a successful update while continuing to execute stale application code.

## Validation

- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/test_update_moonmind_skill.py` (skipped on macOS system Bash 3; the updater requires Bash 4+)
- Linux/Bash 5 container: `python -m pytest -q tests/unit/test_update_moonmind_skill.py --tb=short` (passed)
- `ruff check --no-cache tests/unit/test_update_moonmind_skill.py` (passed)
