### PR TITLE
Fix checkpoint heartbeat backpressure

### DIFF
--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -1000,6 +1000,7 @@ _PUBLISH_GIT_EXCLUDED_PATHS: tuple[str, ...] = (
     "live_streams.spool",
 )
 _SESSION_CONTROLLER_HEARTBEAT_INTERVAL_SECONDS = 10.0
+_CHECKPOINT_CAPTURE_HEARTBEAT_INTERVAL_SECONDS = 1.0
 
 class ManagedSessionController(Protocol):
     """Remote control surface for managed session containers."""
@@ -7087,14 +7088,39 @@ class TemporalAgentRuntimeActivities:
         entries: list[ManagedCheckpointEntry] = []
         total = 0
         output = BytesIO()
+        last_heartbeat_at: float | None = None
+
+        async def heartbeat_capture_progress() -> None:
+            """Emit bounded progress without overflowing the SDK heartbeat queue."""
+
+            nonlocal last_heartbeat_at
+            if not temporal_activity.in_activity():
+                return
+            now = time.monotonic()
+            if (
+                last_heartbeat_at is not None
+                and now - last_heartbeat_at
+                < _CHECKPOINT_CAPTURE_HEARTBEAT_INTERVAL_SECONDS
+            ):
+                return
+            last_heartbeat_at = now
+            try:
+                temporal_activity.heartbeat(
+                    {"phase": "archive", "filesCaptured": len(entries)}
+                )
+            except asyncio.QueueFull:
+                # A queued heartbeat already proves liveness. Coalesce progress
+                # instead of turning SDK backpressure into a checkpoint failure.
+                pass
+            # The archive loop is otherwise synchronous. Yield after each
+            # bounded heartbeat so the Temporal worker can drain its queue.
+            await asyncio.sleep(0)
+
         with gzip.GzipFile(fileobj=output, mode="wb", mtime=0) as compressed, tarfile.open(
             fileobj=compressed, mode="w", format=tarfile.PAX_FORMAT
         ) as archive:
             for relative_text in selected:
-                if temporal_activity.in_activity():
-                    temporal_activity.heartbeat(
-                        {"phase": "archive", "filesCaptured": len(entries)}
-                    )
+                await heartbeat_capture_progress()
                 path = workspace / relative_text
                 if not path.exists() and not path.is_symlink():
                     continue
@@ -7119,6 +7145,7 @@ class TemporalAgentRuntimeActivities:
                     with path.open("rb") as source:
                         while chunk := source.read(1024 * 1024):
                             digest.update(chunk)
+                            await heartbeat_capture_progress()
                     payload = None
                     target = None
                     entry_type = "file"

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -544,6 +544,9 @@ RUN_PUBLISH_REPAIR_FEEDBACK_PATCH = "run-publish-repair-feedback-v1"
 RUN_PREPUBLICATION_FAILURE_BLOCKS_REPAIR_PATCH = (
     "run-prepublication-failure-blocks-repair-v1"
 )
+RUN_PREPUBLICATION_FAILURE_BLOCKS_PUBLISH_PATCH = (
+    "run-prepublication-failure-blocks-publish-v1"
+)
 RUN_FETCH_PROFILE_SNAPSHOTS_PATCH = "fetch-profile-snapshots-v1"
 RUN_SLOT_CONTINUITY_PATCH = "run-slot-continuity-v1"
 RUN_DEFER_WORKFLOW_SCOPED_SESSION_UNTIL_SLOT_PATCH = (
@@ -10896,6 +10899,13 @@ class MoonMindRunWorkflow:
         await self._wait_if_paused_at_safe_boundary()
         if self._cancel_requested:
             return
+
+        if (
+            workflow.patched(RUN_PREPUBLICATION_FAILURE_BLOCKS_PUBLISH_PATCH)
+            and self._publish_status == "failed"
+        ):
+            require_pull_request_url = False
+            pull_request_url = None
 
         if (
             workflow.patched(RUN_MOONSPEC_VERIFY_PUBLICATION_GATE_PATCH)

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -541,6 +541,9 @@ GATED_CONTINUATION_GATE_REGISTRY: Mapping[str, frozenset[str]] = {
     "merge_automation": MERGE_AUTOMATION_CONTINUATION_DISPOSITIONS,
 }
 RUN_PUBLISH_REPAIR_FEEDBACK_PATCH = "run-publish-repair-feedback-v1"
+RUN_PREPUBLICATION_FAILURE_BLOCKS_REPAIR_PATCH = (
+    "run-prepublication-failure-blocks-repair-v1"
+)
 RUN_FETCH_PROFILE_SNAPSHOTS_PATCH = "fetch-profile-snapshots-v1"
 RUN_SLOT_CONTINUITY_PATCH = "run-slot-continuity-v1"
 RUN_DEFER_WORKFLOW_SCOPED_SESSION_UNTIL_SLOT_PATCH = (
@@ -5479,6 +5482,8 @@ class MoonMindRunWorkflow:
                 "Execution succeeded; finalization failed during the "
                 "pre-publication checkpoint."
             )
+            self._publish_status = "failed"
+            self._publish_reason = self._summary
             self._attention_required = True
             self._update_memo()
             return True
@@ -7287,6 +7292,11 @@ class MoonMindRunWorkflow:
         return "\n".join(lines)
 
     def _publish_repair_is_available(self, *, parameters: Mapping[str, Any]) -> bool:
+        if (
+            workflow.patched(RUN_PREPUBLICATION_FAILURE_BLOCKS_REPAIR_PATCH)
+            and self._publish_status == "failed"
+        ):
+            return False
         if self._publish_repair_attempts >= 1:
             return False
         if self._publish_mode(parameters) != "pr":

--- a/tests/integration/reliability/replays/checkpoint-heartbeat-backpressure/expected-outcome.json
+++ b/tests/integration/reliability/replays/checkpoint-heartbeat-backpressure/expected-outcome.json
@@ -1,0 +1,4 @@
+{
+  "checkpointStatus": "captured",
+  "maxQueuedHeartbeats": 1
+}

--- a/tests/integration/reliability/replays/checkpoint-heartbeat-backpressure/manifest.json
+++ b/tests/integration/reliability/replays/checkpoint-heartbeat-backpressure/manifest.json
@@ -1,0 +1,16 @@
+{
+  "incidentWorkflowId": "mm:c2723c5c-342e-4b7f-a07f-d4b94614f547",
+  "incidentRunId": "019f62a5-f3b0-7bbe-8e44-94535602edf0",
+  "logicalStepId": "tpl:github-issue-implement:02:6bbedb2a",
+  "runtime": "codex_cli",
+  "protocol": "managed-workspace-checkpoint-v1",
+  "failureShape": "archive progress emitted one Temporal heartbeat per file without yielding, overflowing the worker heartbeat queue",
+  "events": [
+    {"type": "checkpoint_requested", "boundary": "before_publication"},
+    {"type": "archive_file", "path": "alpha.txt"},
+    {"type": "archive_file", "path": "beta.txt"},
+    {"type": "archive_file", "path": "gamma.txt"}
+  ],
+  "heartbeatQueueCapacity": 1,
+  "heartbeatIntervalSeconds": 0.0
+}

--- a/tests/integration/reliability/replays/checkpoint-heartbeat-backpressure/workspace-manifest.json
+++ b/tests/integration/reliability/replays/checkpoint-heartbeat-backpressure/workspace-manifest.json
@@ -1,0 +1,7 @@
+{
+  "artifacts": [
+    {"path": "alpha.txt", "content": "alpha checkpoint evidence\n"},
+    {"path": "beta.txt", "content": "beta checkpoint evidence\n"},
+    {"path": "gamma.txt", "content": "gamma checkpoint evidence\n"}
+  ]
+}

--- a/tests/integration/reliability/test_escaped_failure_journeys.py
+++ b/tests/integration/reliability/test_escaped_failure_journeys.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import json
 import sqlite3
@@ -18,6 +19,7 @@ from moonmind.schemas.agent_runtime_models import (
     AgentRunResult,
     AgentRuntimeStepExecutionLaunch,
     AgentTerminalContract,
+    ManagedRunRecord,
 )
 from moonmind.schemas.workspace_locator_models import WorkspaceLocatorResolutionError
 from moonmind.provider_profiles.lease_client import (
@@ -36,6 +38,7 @@ from moonmind.workflows.temporal.activity_runtime import (
     TemporalAgentRuntimeActivities,
     TemporalSandboxActivities,
 )
+from moonmind.workflows.temporal import activity_runtime as activity_runtime_module
 from moonmind.workflows.temporal.activity_catalog import build_default_activity_catalog
 from moonmind.workflows.temporal.runtime.codex_session_runtime import (
     CodexManagedSessionRuntime,
@@ -816,6 +819,111 @@ async def test_codex_oauth_failure_preserves_primary_error_and_managed_authority
         "agent_runtime.capture_workspace_checkpoint",
         "step_checkpoint.create",
     ]
+
+
+async def test_checkpoint_capture_heartbeat_backpressure_replay(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Replay mm:c2723c5c through the managed checkpoint activity boundary."""
+
+    replay_id = "checkpoint-heartbeat-backpressure"
+    manifest = load_replay(replay_id, "manifest.json")
+    workspace_manifest = load_replay(replay_id, "workspace-manifest.json")
+    expected = load_replay(replay_id, "expected-outcome.json")
+    workspace = tmp_path / manifest["incidentWorkflowId"] / "repo"
+    workspace.mkdir(parents=True)
+    subprocess.run(["git", "init", "-q"], cwd=workspace, check=True)
+    for artifact in workspace_manifest["artifacts"]:
+        (workspace / artifact["path"]).write_text(
+            artifact["content"], encoding="utf-8"
+        )
+    subprocess.run(["git", "add", "."], cwd=workspace, check=True)
+    subprocess.run(
+        [
+            "git", "-c", "user.name=MoonMind Test", "-c",
+            "user.email=test@example.invalid", "commit", "-qm", "checkpoint replay",
+        ],
+        cwd=workspace,
+        check=True,
+    )
+
+    run_store = ManagedRunStore(tmp_path / "managed_runs")
+    now = datetime.now(timezone.utc)
+    run_store.save(
+        ManagedRunRecord(
+            runId=manifest["incidentWorkflowId"],
+            workflowId=manifest["incidentWorkflowId"],
+            ownerRunId=manifest["incidentRunId"],
+            logicalStepId=manifest["logicalStepId"],
+            executionOrdinal=1,
+            agentId=manifest["runtime"],
+            runtimeId=manifest["runtime"],
+            status="completed",
+            startedAt=now,
+            finishedAt=now,
+            workspacePath=str(workspace),
+        )
+    )
+    activities = TemporalAgentRuntimeActivities(
+        run_store=run_store, artifact_service=object(), client_adapter=object()
+    )
+
+    async def put(payload: bytes, _content_type: str, kind: str) -> str:
+        return f"artifact://{kind}/{hashlib.sha256(payload).hexdigest()}"
+
+    activities._put_managed_checkpoint_artifact = put
+    heartbeat_queue: asyncio.Queue[object] = asyncio.Queue(
+        maxsize=manifest["heartbeatQueueCapacity"]
+    )
+    monkeypatch.setattr(
+        activity_runtime_module.temporal_activity, "in_activity", lambda: True
+    )
+    monkeypatch.setattr(
+        activity_runtime_module.temporal_activity,
+        "heartbeat",
+        lambda payload: heartbeat_queue.put_nowait(payload),
+    )
+    monkeypatch.setattr(
+        activity_runtime_module,
+        "_CHECKPOINT_CAPTURE_HEARTBEAT_INTERVAL_SECONDS",
+        manifest["heartbeatIntervalSeconds"],
+    )
+    capabilities = resolve_runtime_execution_capabilities(manifest["runtime"])
+
+    capture = await activities.agent_runtime_capture_workspace_checkpoint(
+        {
+            "schemaVersion": "v1",
+            "identity": {
+                "workflowId": manifest["incidentWorkflowId"],
+                "runId": manifest["incidentRunId"],
+                "logicalStepId": manifest["logicalStepId"],
+                "executionOrdinal": 1,
+            },
+            "boundary": "before_publication",
+            "checkpointKind": "worktree_archive",
+            "workspaceLocator": {
+                "kind": "managed_runtime",
+                "runtimeId": manifest["runtime"],
+                "agentRunId": manifest["incidentWorkflowId"],
+                "relativePath": "repo",
+            },
+            "expectedRuntimeId": manifest["runtime"],
+            "capabilitySetVersion": capabilities.capability_set_version,
+            "capabilityDigest": capabilities.capability_digest,
+            "artifactNamespace": "step-checkpoints/assessment",
+            "idempotencyKey": "checkpoint-heartbeat-backpressure:capture",
+            "capturePolicy": {
+                "includeTracked": True,
+                "includeUntracked": True,
+                "includeIgnored": False,
+                "redactionProfile": "managed-code-workspace-v1",
+            },
+        }
+    )
+
+    assert capture["status"] == expected["checkpointStatus"]
+    assert heartbeat_queue.qsize() <= expected["maxQueuedHeartbeats"]
 
 
 async def test_codex_system_error_waits_for_delayed_oauth_failure_log(

--- a/tests/unit/workflows/temporal/test_managed_checkpoint_capture.py
+++ b/tests/unit/workflows/temporal/test_managed_checkpoint_capture.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import os
 import subprocess
@@ -112,6 +113,67 @@ async def test_managed_capture_trusts_the_resolved_workspace_for_every_git_comma
     assert result["workspace"]["archiveRef"].startswith("artifact://")
     assert len(commands) == 4
     assert all(command[: len(expected_prefix)] == expected_prefix for command in commands)
+
+
+@pytest.mark.asyncio
+async def test_managed_capture_bounds_heartbeats_during_archive_loop(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = tmp_path / "agent-run-1" / "repo"
+    repo.mkdir(parents=True)
+    for index in range(3):
+        (repo / f"tracked-{index}.txt").write_text("checkpoint evidence\n")
+
+    async def run_git(command, **_kwargs):
+        operation = [str(part) for part in command][5:]
+        if operation[0] == "ls-files":
+            return SimpleNamespace(
+                stdout="".join(f"tracked-{index}.txt\0" for index in range(3))
+            )
+        if operation[:2] == ["rev-parse", "HEAD"]:
+            return SimpleNamespace(stdout="abc123\n")
+        if operation[:2] == ["branch", "--show-current"]:
+            return SimpleNamespace(stdout="main\n")
+        if operation[0] == "status":
+            return SimpleNamespace(stdout="")
+        raise AssertionError(f"unexpected git command: {operation}")
+
+    heartbeat_queue: asyncio.Queue[object] = asyncio.Queue(maxsize=1)
+    monkeypatch.setattr(activity_runtime_module, "_run_command", run_git)
+    monkeypatch.setattr(
+        activity_runtime_module.temporal_activity, "in_activity", lambda: True
+    )
+    monkeypatch.setattr(
+        activity_runtime_module.temporal_activity,
+        "heartbeat",
+        lambda payload: heartbeat_queue.put_nowait(payload),
+    )
+    monkeypatch.setattr(
+        activity_runtime_module,
+        "_CHECKPOINT_CAPTURE_HEARTBEAT_INTERVAL_SECONDS",
+        0.0,
+    )
+    activities = TemporalAgentRuntimeActivities(
+        run_store=object(), artifact_service=object(), client_adapter=object()
+    )
+
+    async def put(payload: bytes, _content_type: str, _kind: str) -> str:
+        return "artifact://" + hashlib.sha256(payload).hexdigest()
+
+    activities._put_managed_checkpoint_artifact = put
+    model = ManagedWorkspaceCheckpointCaptureInput.model_validate(
+        _request(digest=resolve_runtime_execution_capabilities("codex_cli").capability_digest)
+    )
+    now = datetime.now(UTC)
+
+    result = await activities._capture_managed_worktree(
+        model,
+        repo,
+        SimpleNamespace(started_at=now, finished_at=now),
+    )
+
+    assert result["status"] == "captured"
+    assert heartbeat_queue.qsize() == 1
 
 
 @pytest.mark.asyncio

--- a/tests/unit/workflows/temporal/test_run_artifacts.py
+++ b/tests/unit/workflows/temporal/test_run_artifacts.py
@@ -5680,6 +5680,132 @@ async def test_run_execution_stage_non_jules_agent_with_session_id_creates_nativ
         "even when child result metadata contains jules_session_id"
     )
 
+
+@pytest.mark.asyncio
+async def test_run_execution_stage_skips_native_pr_after_prepublication_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workflow = MoonMindRunWorkflow()
+    workflow._owner_id = "owner-1"
+    workflow._repo = "MoonLadderStudios/MoonMind"
+    create_pr_called = False
+
+    async def fake_execute_activity(
+        activity_type: str,
+        payload: dict[str, object],
+        **_kwargs: object,
+    ) -> object:
+        nonlocal create_pr_called
+        if activity_type == "repo.create_pr":
+            create_pr_called = True
+            return {"url": "https://github.com/MoonLadderStudios/MoonMind/pull/999"}
+        if activity_type == "artifact.read":
+            return json.dumps(
+                {
+                    "plan_version": "1.0",
+                    "metadata": {
+                        "title": "Checkpoint Publish Plan",
+                        "created_at": "2026-07-14T00:00:00Z",
+                        "registry_snapshot": {
+                            "digest": "reg:sha256:" + ("a" * 64),
+                            "artifact_ref": "artifact://registry/1",
+                        },
+                    },
+                    "policy": {"failure_mode": "FAIL_FAST", "max_concurrency": 1},
+                    "nodes": [_agent_runtime_step("assess")],
+                    "edges": [],
+                }
+            ).encode("utf-8")
+        return {"status": "COMPLETED", "outputs": {}}
+
+    async def fake_execute_child_workflow(
+        _workflow_type: str,
+        _args: object,
+        **_kwargs: object,
+    ) -> object:
+        return {
+            "summary": "Assessment completed",
+            "metadata": {
+                "push_status": "pushed",
+                "push_branch": "feature/checkpoint-failure",
+            },
+            "output_refs": [],
+        }
+
+    async def fail_prepublication_checkpoint(
+        _logical_step_id: str,
+        *,
+        publish_mode: str,
+        updated_at: datetime,
+    ) -> bool:
+        assert publish_mode == "pr"
+        workflow._publish_status = "failed"
+        workflow._publish_reason = "pre-publication checkpoint failed"
+        return True
+
+    async def no_checkpoint(*_args: object, **_kwargs: object) -> None:
+        return None
+
+    async def bind_existing_request(request: object) -> object:
+        return request
+
+    monkeypatch.setattr(
+        workflow,
+        "_record_prepublication_checkpoint",
+        fail_prepublication_checkpoint,
+    )
+    monkeypatch.setattr(workflow, "_record_canonical_step_checkpoint", no_checkpoint)
+    monkeypatch.setattr(
+        workflow,
+        "_maybe_bind_workflow_scoped_session",
+        bind_existing_request,
+    )
+    monkeypatch.setattr(
+        run_workflow_module.workflow, "execute_activity", fake_execute_activity
+    )
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "execute_child_workflow",
+        fake_execute_child_workflow,
+    )
+    monkeypatch.setattr(run_workflow_module.workflow, "upsert_memo", lambda _memo: None)
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "upsert_search_attributes",
+        lambda _attributes: None,
+    )
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "now",
+        lambda: datetime.now(timezone.utc),
+    )
+    workflow_info = type(
+        "WorkflowInfo",
+        (),
+        {"namespace": "default", "workflow_id": "wf-1", "run_id": "run-1"},
+    )
+    monkeypatch.setattr(run_workflow_module.workflow, "info", workflow_info)
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "patched",
+        lambda patch_id: patch_id
+        in {
+            run_workflow_module.RUN_CONDITIONAL_REGISTRY_READ_PATCH,
+            run_workflow_module.RUN_PAUSE_SAFE_BOUNDARIES_PATCH,
+            run_workflow_module.RUN_PREPUBLICATION_FAILURE_BLOCKS_PUBLISH_PATCH,
+        },
+    )
+
+    await workflow._run_execution_stage(
+        parameters={"repo": "MoonLadderStudios/MoonMind", "publishMode": "pr"},
+        plan_ref="art_plan_1",
+    )
+
+    assert not create_pr_called
+    assert workflow._publish_status == "failed"
+    assert workflow._pull_request_url is None
+
+
 @pytest.mark.asyncio
 async def test_run_execution_stage_skips_native_pr_after_push_failure(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import json
 from datetime import UTC, datetime
 from pathlib import Path
@@ -3703,6 +3704,42 @@ async def test_legacy_history_preserves_prepublication_checkpoint_command(
 
     assert failed is False
     assert calls == ["before_publication"]
+
+
+@pytest.mark.asyncio
+async def test_prepublication_checkpoint_failure_blocks_publish_repair(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _configure_workflow_runtime(monkeypatch)
+    workflow = MoonMindRunWorkflow()
+    now = datetime(2026, 7, 14, 7, 14, tzinfo=UTC)
+    workflow._initialize_step_ledger(
+        ordered_nodes=[{"id": "assess", "inputs": {"title": "Assess"}}],
+        dependency_map={"assess": []},
+        updated_at=now,
+    )
+    workflow._last_publish_repair_request = SimpleNamespace(agent_kind="managed")
+
+    async def fail_checkpoint(*_args: Any, **_kwargs: Any) -> None:
+        raise asyncio.QueueFull
+
+    monkeypatch.setattr(workflow, "_record_canonical_step_checkpoint", fail_checkpoint)
+    monkeypatch.setattr(run_module.workflow, "patched", lambda _patch_id: True)
+
+    failed = await workflow._record_prepublication_checkpoint(
+        "assess",
+        publish_mode="pr",
+        updated_at=now,
+    )
+
+    assert failed is True
+    assert workflow._publish_status == "failed"
+    assert workflow._publish_reason == (
+        "Execution succeeded; finalization failed during the pre-publication checkpoint."
+    )
+    assert workflow._publish_repair_is_available(parameters={"publishMode": "pr"}) is False
+    monkeypatch.setattr(run_module.workflow, "patched", lambda _patch_id: False)
+    assert workflow._publish_repair_is_available(parameters={"publishMode": "pr"}) is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- throttle managed workspace checkpoint heartbeats and yield to the Temporal worker between emissions
- coalesce `asyncio.QueueFull` heartbeat backpressure instead of failing checkpoint capture
- preserve a pre-publication checkpoint failure as the authoritative publish failure and suppress unrelated publish repair
- add unit coverage and a hermetic escaped-incident replay for `mm:c2723c5c-342e-4b7f-a07f-d4b94614f547`

## Root cause

Checkpoint capture emitted one Temporal heartbeat per archived file from a synchronous loop. On a repository with enough files, the worker heartbeat queue filled faster than it could drain and raised `asyncio.QueueFull`. The recoverability-only post-execution checkpoint failure was tolerated, but the required pre-publication checkpoint failed the workflow after its read-only assessment step. Finalization then attempted publish repair against the assessment's expected zero-commit result, obscuring the checkpoint failure with an incomplete terminal-contract result.

## Impact

Managed checkpoint capture now remains live without flooding the worker heartbeat queue. If a required pre-publication checkpoint still fails for another reason, MoonMind reports that failure directly and does not start a misleading repair agent.

## Validation

- `MOONMIND_FORCE_LOCAL_TESTS=1 python3 -m pytest -q tests/unit/workflows/temporal/test_managed_checkpoint_capture.py tests/unit/workflows/temporal/workflows/test_run_step_ledger.py` — 99 passed
- `MOONMIND_FORCE_LOCAL_TESTS=1 python3 -m pytest -q tests/integration/reliability/test_escaped_failure_journeys.py::test_checkpoint_capture_heartbeat_backpressure_replay` — 1 passed
- `python3 -m py_compile` for all changed Python files
- `jq empty` for all replay JSON fixtures
- `git diff --check`

The project unit wrapper was also attempted, but its repository-wide status-domain audit failed on seven pre-existing findings under `.claude/worktrees/ui-regressions`; none are part of this diff.
