### PR TITLE
Make backend test shards mutually exclusive for MoonLadderStudios/MoonMind#3324

### DIFF
--- a/.github/workflows/pytest-unit-tests.yml
+++ b/.github/workflows/pytest-unit-tests.yml
@@ -24,6 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       unit_fast: ${{ steps.select.outputs.unit_fast }}
+      unit_slow: ${{ steps.select.outputs.unit_slow }}
       api_component: ${{ steps.select.outputs.api_component }}
       temporal_boundary: ${{ steps.select.outputs.temporal_boundary }}
       integration_ci: ${{ steps.select.outputs.integration_ci }}
@@ -107,35 +108,16 @@ jobs:
         run: |
           python -m pip install --upgrade pip uv
           uv pip install --system -e .[tests]
-      - name: Set up Node.js for full backend path
-        if: needs.select-test-suites.outputs.full_backend == 'true'
-        uses: actions/setup-node@v6
-        with:
-          node-version: "20"
-          cache: npm
-      - name: Build frontend assets for full backend path
-        if: needs.select-test-suites.outputs.full_backend == 'true'
-        run: |
-          npm ci
-          npm run ui:build
       - name: Run selected unit suite
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-          MOONMIND_PYTEST_DURATIONS: "50"
-          MOONMIND_PYTEST_JUNITXML: artifacts/pytest-unit.xml
         run: |
           set -euo pipefail
-          if [[ "${{ needs.select-test-suites.outputs.full_backend }}" == "true" ]]; then
-            ./tools/test_unit.sh --python-only
-          else
-            python -m pytest tests/unit \
-              --ignore=tests/unit/workflows/temporal \
-              --ignore=tests/unit/api \
-              --ignore=tests/unit/api_service \
-              -m "not temporal_boundary and not component and not slow" \
-              -q -n auto --dist loadfile --durations=25 \
-              --junitxml=artifacts/pytest-unit-fast.xml
-          fi
+          python -m pytest tests/unit \
+            --ignore=tests/unit/workflows/temporal \
+            --ignore=tests/unit/api \
+            --ignore=tests/unit/api_service \
+            -m "unit_fast and not provider_verification and not requires_credentials" \
+            -q -n auto --dist loadfile --durations=25 \
+            --junitxml=artifacts/pytest-unit-fast.xml
       - name: Verify workflow terminology guardrails
         run: |
           set -euo pipefail
@@ -172,6 +154,39 @@ jobs:
           python -m pip install --upgrade pip PyYAML
           python3 tools/sync_moonspec.py --check
 
+  unit-slow:
+    needs: select-test-suites
+    if: needs.select-test-suites.outputs.unit_slow == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 1
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: Install system dependencies
+        run: |
+          sudo rm -f /etc/apt/sources.list.d/azure-cli.list /etc/apt/sources.list.d/microsoft-prod.list
+          sudo apt-get update
+          sudo apt-get install -y libcairo2-dev pkg-config
+      - name: Install dependencies via uv
+        run: |
+          python -m pip install --upgrade pip uv
+          uv pip install --system -e .[tests]
+      - name: Run slow unit suite
+        run: |
+          set -euo pipefail
+          python -m pytest tests/unit \
+            -m "slow and not provider_verification and not requires_credentials and not integration" \
+            -q --durations=50 \
+            --junitxml=artifacts/pytest-unit-slow.xml
+
   api-component:
     needs: select-test-suites
     if: needs.select-test-suites.outputs.api_component == 'true'
@@ -202,7 +217,7 @@ jobs:
         run: |
           set -euo pipefail
           python -m pytest tests/unit/api tests/unit/api_service tests/component/api \
-            -m "not temporal_boundary and not slow" \
+            -m "component and not temporal_boundary and not slow and not provider_verification and not requires_credentials" \
             -q -n auto --dist loadfile --durations=25 \
             --junitxml=artifacts/pytest-api-component.xml
 
@@ -230,7 +245,7 @@ jobs:
         run: |
           set -euo pipefail
           python -m pytest tests/unit/workflows/temporal \
-            -m "not slow" \
+            -m "temporal_boundary and not slow and not provider_verification and not requires_credentials" \
             -q --durations=25 \
             --junitxml=artifacts/pytest-temporal-boundary.xml
 
@@ -346,15 +361,45 @@ jobs:
           path: /tmp/pytest-reliability-journey
           if-no-files-found: error
 
+  verify-test-shard-ownership:
+    needs: select-test-suites
+    if: needs.select-test-suites.outputs.full_backend == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 1
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: Install system dependencies
+        run: |
+          sudo rm -f /etc/apt/sources.list.d/azure-cli.list /etc/apt/sources.list.d/microsoft-prod.list
+          sudo apt-get update
+          sudo apt-get install -y libcairo2-dev pkg-config
+      - name: Install dependencies via uv
+        run: |
+          python -m pip install --upgrade pip uv
+          uv pip install --system -e .[tests]
+      - name: Verify exclusive backend shard ownership
+        run: python tools/verify_test_shard_ownership.py
+
   ci-required:
     needs:
       - select-test-suites
       - moonspec-projection
       - unit-fast
+      - unit-slow
       - api-component
       - temporal-boundary
       - integration-ci
       - reliability-journey-checkpoint-resume
+      - verify-test-shard-ownership
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -407,6 +452,10 @@ jobs:
                        "${{ needs.unit-fast.result }}" \
                        "unit-fast"
 
+          check_result "${{ needs.select-test-suites.outputs.unit_slow }}" \
+                       "${{ needs.unit-slow.result }}" \
+                       "unit-slow"
+
           check_result "${{ needs.select-test-suites.outputs.api_component }}" \
                        "${{ needs.api-component.result }}" \
                        "api-component"
@@ -422,6 +471,10 @@ jobs:
           check_result "${{ needs.select-test-suites.outputs.reliability_journey }}" \
                        "${{ needs.reliability-journey-checkpoint-resume.result }}" \
                        "reliability-journey-checkpoint-resume"
+
+          check_result "${{ needs.select-test-suites.outputs.full_backend }}" \
+                       "${{ needs.verify-test-shard-ownership.result }}" \
+                       "verify-test-shard-ownership"
 
           echo "All selected backend suites passed."
 

--- a/docs/Development/BackendTestSelection.md
+++ b/docs/Development/BackendTestSelection.md
@@ -20,6 +20,7 @@ Backend tests are classified by the runtime resources they start, not by the imp
 | Category | Marker | Resource boundary | PR behavior |
 | --- | --- | --- | --- |
 | Fast unit | `unit_fast` | Pure Python logic, schemas, validation, and services with mocks. No Docker, network, external process, or Temporal test server. | Required for backend-impacting pull requests. |
+| Slow unit | `slow` | Remaining slow tests under `tests/unit`, with precedence over component and Temporal ownership. | Runs on main pushes, schedules, manual/full runs, fail-open runs, and direct changes to known slow tests. |
 | Component | `component` | FastAPI `TestClient`, dependency overrides, and in-process router/service wiring. | Required for API, auth, database, service, and generated OpenAPI type changes. |
 | Temporal boundary | `temporal_boundary` | Temporal `WorkflowEnvironment`, `Worker`, `Replayer`, workflow signal/update/query/replay, activity-boundary, and serialized payload behavior. | Required for Temporal workflow, runtime, worker, or Temporal schema-sensitive changes. |
 | Reliability journey | `reliability_journey` | Hermetic production composition across the Temporal test server, real workflows, managed-session/runtime adapters, scripted provider or subprocess behavior, terminal artifacts, and checkpoint/finalization routing. No external network or credentials. | Required for orchestration seams, managed runtime packaging, skill contracts, checkpoints, and replay fixtures. |
@@ -35,6 +36,7 @@ The pytest marker registry lives in `pyproject.toml`. Runtime classification for
 
 ```text
 unit_fast=true|false
+unit_slow=true|false
 api_component=true|false
 temporal_boundary=true|false
 integration_ci=true|false
@@ -120,6 +122,8 @@ The selector enables `integration_ci=true` for changes under or matching:
 - `uv.lock`
 
 This suite validates compose-backed local infrastructure seams and must remain free of external-provider credentials.
+Tests under `tests/integration/reliability/` are explicitly excluded because
+the reliability journey shard owns them.
 
 ## Full Backend Path
 
@@ -136,20 +140,23 @@ The selector enables `full_backend=true` and selects all backend suites when any
 - Test runner or selector files changed, including `tools/test_unit.sh`, `tools/test_unit_docker.sh`, `tools/test_integration.sh`, or `tools/select_test_suites.py`.
 - Global pytest configuration changed, including `tests/conftest.py` or `tests/unit/conftest.py`.
 
-The full backend path uses the canonical unit runner:
+The full backend path selects the same exclusive shards used by targeted runs:
 
 ```bash
-./tools/test_unit.sh --python-only
+unit-fast + unit-slow + api-component + temporal-boundary + reliability-journey + integration-ci
 ```
 
-`./tools/test_unit.sh` reports slow tests with `--durations=${MOONMIND_PYTEST_DURATIONS:-25}` and emits JUnit XML in CI.
+The `unit-fast` command is invariant: full runs do not switch it to the broad
+unit wrapper. Ownership precedence is `slow > temporal_boundary > component >
+unit_fast`. `tools/verify_test_shard_ownership.py` collects the provider-free
+CI corpus and fails on missing, duplicate, or conflicting ownership.
 
 ## Required Check Model
 
 Conditional GitHub Actions jobs are not suitable as individual branch-protection requirements because skipped jobs can leave required checks unresolved. MoonMind uses one always-running required summary job instead:
 
 - `select-test-suites` computes backend suite outputs.
-- `unit-fast`, `api-component`, `temporal-boundary`, `integration-ci`, and `reliability-journey-checkpoint-resume` run only when selected.
+- `unit-fast`, `unit-slow`, `api-component`, `temporal-boundary`, `integration-ci`, and `reliability-journey-checkpoint-resume` run only when selected.
 - `ci-required` always runs and fails if any selected backend suite did not complete successfully.
 
 Branch protection must require `ci-required` for backend selection, plus any separately required frontend, generated-contract, CodeQL, or repository policy checks. It must also require the standalone `migration-gate` check so migration-graph and clean-database upgrade failures block merges independently of impact selection.
@@ -180,7 +187,10 @@ Run the fast unit PR safety net:
 
 ```bash
 pytest tests/unit \
-  -m "not temporal_boundary and not component and not slow" \
+  --ignore=tests/unit/workflows/temporal \
+  --ignore=tests/unit/api \
+  --ignore=tests/unit/api_service \
+  -m "unit_fast and not provider_verification and not requires_credentials" \
   -q -n auto --dist loadfile --durations=25
 ```
 
@@ -188,7 +198,7 @@ Run component coverage:
 
 ```bash
 pytest tests/unit/api tests/unit/api_service tests/component/api \
-  -m "component and not temporal_boundary and not slow" \
+  -m "component and not temporal_boundary and not slow and not provider_verification and not requires_credentials" \
   -q -n auto --dist loadfile --durations=25
 ```
 
@@ -196,8 +206,16 @@ Run Temporal boundary coverage:
 
 ```bash
 pytest tests/unit/workflows/temporal \
-  -m "temporal_boundary and not slow" \
+  -m "temporal_boundary and not slow and not provider_verification and not requires_credentials" \
   -q --durations=25
+```
+
+Run slow unit coverage without xdist:
+
+```bash
+pytest tests/unit \
+  -m "slow and not provider_verification and not requires_credentials and not integration" \
+  -q --durations=50
 ```
 
 Run hermetic integration CI:
@@ -234,10 +252,10 @@ restore idempotently. It exercises production capture/restore engines and the
 artifact boundary, but does not substitute for the Temporal-to-managed-AgentRun
 journey. The required CI reliability job has a 30-minute budget.
 
-Run full backend unit verification:
+Verify that every eligible provider-free node has exactly one owner:
 
 ```bash
-./tools/test_unit.sh --python-only
+python tools/verify_test_shard_ownership.py
 ```
 
 ## Maintaining The Selector

--- a/docs/Development/PreCommitWorkflow.md
+++ b/docs/Development/PreCommitWorkflow.md
@@ -47,6 +47,7 @@ In WSL, `./tools/test_unit.sh` automatically delegates to `./tools/test_unit_doc
 The GitHub unit-test workflow uses impact-aware backend suite selection for pull requests. A `select-test-suites` job runs `tools/select_test_suites.py` against the changed files and emits suite decisions for:
 
 - `unit_fast`
+- `unit_slow`
 - `api_component`
 - `temporal_boundary`
 - `integration_ci`
@@ -57,10 +58,19 @@ Branch protection should require the always-running `ci-required` summary job in
 
 Routine backend pull requests run the cheap unit safety net first. API/router/auth/db/service changes also run the component suite. Temporal workflow, runtime, activity-boundary, signal/update, replay, or Temporal schema changes run the Temporal boundary suite. Changes under workflow adapters, Temporal workflows, checked-in `.agents/skills` bundles, Docker runtime paths, checkpoint schemas, and reliability replay fixtures run the hermetic reliability journey suite. Docker, integration, database, compose, migration, dependency, or test-runner changes run hermetic `integration_ci` as needed.
 
-The selector fails open. Empty changed-file input, unknown paths, CI workflow changes, dependency file changes, test-runner changes, pytest configuration changes, selector changes, pushes to `main`, scheduled runs, and manual dispatches all force `full_backend=true`. On that path, the workflow runs the canonical backend unit command:
+The selector fails open. Empty changed-file input, unknown paths, CI workflow changes, dependency file changes, test-runner changes, pytest configuration changes, selector changes, pushes to `main`, scheduled runs, and manual dispatches all force `full_backend=true`. That path selects every exclusive backend shard, including `unit_slow`; it does not replace `unit-fast` with the broad unit wrapper.
+
+The ownership verifier runs on full-backend paths and checks that every eligible provider-free pytest node has exactly one CI owner. The precedence is `slow > temporal_boundary > component > unit_fast`.
+
+The invariant fast-unit command is:
 
 ```bash
-./tools/test_unit.sh --python-only
+python -m pytest tests/unit \
+  --ignore=tests/unit/workflows/temporal \
+  --ignore=tests/unit/api \
+  --ignore=tests/unit/api_service \
+  -m "unit_fast and not provider_verification and not requires_credentials" \
+  -q -n auto --dist loadfile --durations=25
 ```
 
 `./tools/test_unit.sh` reports the slowest Python tests with `--durations`; set `MOONMIND_PYTEST_DURATIONS` to tune the count. In CI it also writes JUnit XML unless `MOONMIND_PYTEST_JUNITXML` points at a different output path.
@@ -104,16 +114,25 @@ pre-commit install
 
 ```bash
 python -m pytest tests/unit \
-  -m "not temporal_boundary and not component and not slow" \
+  --ignore=tests/unit/workflows/temporal \
+  --ignore=tests/unit/api \
+  --ignore=tests/unit/api_service \
+  -m "unit_fast and not provider_verification and not requires_credentials" \
   -q -n auto --dist loadfile --durations=25
 
 python -m pytest tests/unit/api tests/unit/api_service tests/component/api \
-  -m "component and not temporal_boundary and not slow" \
+  -m "component and not temporal_boundary and not slow and not provider_verification and not requires_credentials" \
   -q -n auto --dist loadfile --durations=25
 
 python -m pytest tests/unit/workflows/temporal \
-  -m "temporal_boundary and not slow" \
+  -m "temporal_boundary and not slow and not provider_verification and not requires_credentials" \
   -q --durations=25
+
+python -m pytest tests/unit \
+  -m "slow and not provider_verification and not requires_credentials and not integration" \
+  -q --durations=50
+
+python tools/verify_test_shard_ownership.py
 ```
 
 7. Run `./tools/test_integration.sh` only when Docker, compose, migrations, integration tests, runtime infrastructure, or another selector-selected hermetic integration boundary changed.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,7 +38,7 @@ _TEMPORAL_BOUNDARY_TEST_PATHS = {
     Path("tests/unit/workflows/temporal/workflows/test_run_signals_updates.py"),
 }
 
-_TEMPORAL_BOUNDARY_TEST_PATH_PREFIXES: tuple[Path, ...] = ()
+_TEMPORAL_BOUNDARY_TEST_PATH_PREFIXES = (Path("tests/unit/workflows/temporal"),)
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -83,8 +83,7 @@ def _path_is_relative_to(path: Path, prefix: Path) -> bool:
 
 def _is_component_test_path(path: Path) -> bool:
     return any(
-        _path_is_relative_to(path, prefix)
-        for prefix in _COMPONENT_TEST_PATH_PREFIXES
+        _path_is_relative_to(path, prefix) for prefix in _COMPONENT_TEST_PATH_PREFIXES
     )
 
 
@@ -113,14 +112,12 @@ def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
         is_component = _item_has_marker(item, "component") or _is_component_test_path(
             rel_path
         )
-        is_temporal_boundary = (
-            _item_has_marker(item, "temporal_boundary")
-            or _is_temporal_boundary_test_path(rel_path)
-        )
-        is_reliability_journey = (
-            _item_has_marker(item, "reliability_journey")
-            or _is_reliability_journey_test_path(rel_path)
-        )
+        is_temporal_boundary = _item_has_marker(
+            item, "temporal_boundary"
+        ) or _is_temporal_boundary_test_path(rel_path)
+        is_reliability_journey = _item_has_marker(
+            item, "reliability_journey"
+        ) or _is_reliability_journey_test_path(rel_path)
         is_slow = _item_has_marker(item, "slow") or rel_path in _SLOW_TEST_MODULES
 
         if is_component:
@@ -141,6 +138,7 @@ def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
             and not is_slow
             and not _item_has_marker(item, "integration")
             and not _item_has_marker(item, "provider_verification")
+            and not _item_has_marker(item, "requires_credentials")
         ):
             item.add_marker(pytest.mark.unit_fast)
 
@@ -160,12 +158,15 @@ def disabled_env_keys(monkeypatch):
     monkeypatch.setattr(settings.google, "google_api_key", "g-test", raising=False)
     yield
 
+
 @pytest.fixture
 def keycloak_mode(monkeypatch):
     from moonmind.config.settings import settings
 
     monkeypatch.setattr(settings.oidc, "AUTH_PROVIDER", "keycloak", raising=False)
     yield
+
+
 @pytest.hookimpl(tryfirst=True)
 def pytest_pyfunc_call(pyfuncitem: pytest.Function) -> bool | None:
     """Execute `@pytest.mark.asyncio` tests without requiring pytest-asyncio."""
@@ -205,6 +206,7 @@ def pytest_pyfunc_call(pyfuncitem: pytest.Function) -> bool | None:
     asyncio.run(_run_test_with_keepalive())
     return True
 
+
 # ── atexit cleanup for orphaned Temporal test-server processes ──────────────
 #
 # ``WorkflowEnvironment.start_time_skipping()`` spawns a ``temporal-test-server``
@@ -216,6 +218,7 @@ def pytest_pyfunc_call(pyfuncitem: pytest.Function) -> bool | None:
 # early enough to kill the orphaned child before the pipe blocks.
 import atexit
 import subprocess
+
 
 def _kill_owned_temporal_servers() -> None:
     """Terminate ``temporal-test-server`` subprocesses owned by this process."""
@@ -236,5 +239,6 @@ def _kill_owned_temporal_servers() -> None:
         # Best-effort cleanup: if `pgrep` is unavailable, fails, or output is unexpected,
         # we silently ignore it to avoid disrupting test shutdown.
         pass
+
 
 atexit.register(_kill_owned_temporal_servers)

--- a/tests/integration/reliability/README.md
+++ b/tests/integration/reliability/README.md
@@ -38,7 +38,7 @@ the incident escape, and failure messages should name the violated invariant.
 Bounded-continuation journeys drive AgentRun's terminal-contract owner directly
 and cross the production activity route (asserting the managed agent-runtime task
 queue) instead of standing up a time-skipping Temporal server, which keeps them
-inside the hermetic `integration_ci` budget while still asserting stable
+inside the hermetic reliability-journey budget while still asserting stable
 session/thread/epoch identity across each continuation turn. Finalization faults
 use the shared fail-first injector so checkpoint or publication retries can be
 tested independently from the exactly-once primary agent execution.

--- a/tests/integration/reliability/test_checkpoint_cold_resume.py
+++ b/tests/integration/reliability/test_checkpoint_cold_resume.py
@@ -30,7 +30,6 @@ from moonmind.workflows.temporal.workflows.run import MoonMindRunWorkflow
 pytestmark = [
     pytest.mark.asyncio,
     pytest.mark.integration,
-    pytest.mark.integration_ci,
     pytest.mark.reliability_journey,
 ]
 

--- a/tests/integration/reliability/test_escaped_failure_journeys.py
+++ b/tests/integration/reliability/test_escaped_failure_journeys.py
@@ -69,7 +69,6 @@ from tests.unit.workflows.temporal.workflows.test_run_integration import (
 pytestmark = [
     pytest.mark.asyncio,
     pytest.mark.integration,
-    pytest.mark.integration_ci,
     pytest.mark.reliability_journey,
 ]
 

--- a/tests/unit/test_pytest_collection_classification.py
+++ b/tests/unit/test_pytest_collection_classification.py
@@ -54,12 +54,12 @@ def test_mm849_temporal_boundary_paths_are_marked_by_structure() -> None:
     assert "unit_fast" not in item.marker_names
 
 
-def test_mm849_regular_temporal_unit_paths_remain_unit_fast() -> None:
+def test_temporal_directory_is_classified_as_temporal_boundary() -> None:
     item = _item_for("tests/unit/workflows/temporal/test_activity_runtime.py")
 
     conftest.pytest_collection_modifyitems([item])
 
-    assert item.marker_names == {"unit_fast"}
+    assert item.marker_names == {"temporal_boundary"}
 
 
 def test_mm849_collection_classification_does_not_read_source(monkeypatch) -> None:

--- a/tests/unit/test_pytest_unit_workflow.py
+++ b/tests/unit/test_pytest_unit_workflow.py
@@ -4,7 +4,6 @@ from pathlib import Path
 
 import yaml
 
-
 REPO_ROOT = Path(__file__).resolve().parents[2]
 WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "pytest-unit-tests.yml"
 STANDALONE_INTEGRATION_PATH = (
@@ -193,11 +192,17 @@ def test_frontend_jobs_are_impact_aware_and_keep_stable_aggregator() -> None:
     assert "frontend_browser_firefox" in browser["strategy"]["matrix"]["engine"]
     assert "@sha256:" in browser["container"]["image"]
     assert browser["env"]["HOME"] == "/root"
-    assert not any("playwright install" in step.get("run", "") for step in browser["steps"])
+    assert not any(
+        "playwright install" in step.get("run", "") for step in browser["steps"]
+    )
 
     aggregator = jobs["test-frontend"]
     assert aggregator["if"] == "always()"
-    assert aggregator["needs"] == ["select-test-suites", "frontend-static", "frontend-browser"]
+    assert aggregator["needs"] == [
+        "select-test-suites",
+        "frontend-static",
+        "frontend-browser",
+    ]
     assert not any("uses" in step for step in aggregator["steps"])
     script = "\n".join(step.get("run", "") for step in aggregator["steps"])
     assert "frontend-static was selected" in script
@@ -227,8 +232,18 @@ def test_unit_fast_physically_ignores_heavy_collection_paths() -> None:
     assert "--ignore=tests/unit/workflows/temporal" in command
     assert "--ignore=tests/unit/api" in command
     assert "--ignore=tests/unit/api_service" in command
-    assert '-m "not temporal_boundary and not component and not slow"' in command
+    assert (
+        '-m "unit_fast and not provider_verification and not requires_credentials"'
+        in command
+    )
     assert "--junitxml=artifacts/pytest-unit-fast.xml" in command
+    assert "full_backend" not in command
+    unit_fast_steps = _load_workflow()["jobs"]["unit-fast"]["steps"]
+    assert not any(
+        (step.get("uses") or "").startswith("actions/setup-node@")
+        or "npm run ui:build" in (step.get("run") or "")
+        for step in unit_fast_steps
+    )
 
 
 def test_unit_workflow_keeps_api_and_temporal_ownership() -> None:
@@ -236,14 +251,45 @@ def test_unit_workflow_keeps_api_and_temporal_ownership() -> None:
     temporal_command = _run_command("temporal-boundary", "Run Temporal boundary suite")
 
     assert "tests/unit/api tests/unit/api_service tests/component/api" in api_command
-    assert '-m "not temporal_boundary and not slow"' in api_command
-    assert "component and not temporal_boundary" not in api_command
+    assert (
+        '-m "component and not temporal_boundary and not slow and not provider_verification and not requires_credentials"'
+        in api_command
+    )
     assert "--junitxml=artifacts/pytest-api-component.xml" in api_command
 
     assert "python -m pytest tests/unit/workflows/temporal" in temporal_command
-    assert '-m "not slow"' in temporal_command
-    assert "temporal_boundary and not slow" not in temporal_command
+    assert (
+        '-m "temporal_boundary and not slow and not provider_verification and not requires_credentials"'
+        in temporal_command
+    )
     assert "--junitxml=artifacts/pytest-temporal-boundary.xml" in temporal_command
+
+
+def test_unit_slow_has_separate_non_parallel_job_and_required_contract() -> None:
+    workflow = _load_workflow()
+    job = workflow["jobs"]["unit-slow"]
+    command = _run_command("unit-slow", "Run slow unit suite")
+
+    assert job["if"] == "needs.select-test-suites.outputs.unit_slow == 'true'"
+    assert job["timeout-minutes"] == 45
+    assert (
+        '-m "slow and not provider_verification and not requires_credentials and not integration"'
+        in command
+    )
+    assert "-n " not in command
+    assert "--junitxml=artifacts/pytest-unit-slow.xml" in command
+    assert "unit-slow" in workflow["jobs"]["ci-required"]["needs"]
+
+
+def test_full_backend_runs_shard_ownership_verifier() -> None:
+    workflow = _load_workflow()
+    job = workflow["jobs"]["verify-test-shard-ownership"]
+
+    assert job["if"] == "needs.select-test-suites.outputs.full_backend == 'true'"
+    assert any(
+        "tools/verify_test_shard_ownership.py" in step.get("run", "")
+        for step in job["steps"]
+    )
 
 
 def test_reliability_job_runs_the_canonical_journey_suite() -> None:

--- a/tests/unit/tools/test_select_test_suites.py
+++ b/tests/unit/tools/test_select_test_suites.py
@@ -13,6 +13,7 @@ def test_docs_only_change_does_not_select_heavy_backend_suites() -> None:
 
     assert outputs == {
         "unit_fast": "false",
+        "unit_slow": "false",
         "api_component": "false",
         "temporal_boundary": "false",
         "integration_ci": "false",
@@ -47,7 +48,11 @@ def test_generated_openapi_client_selects_static_only() -> None:
 
 
 def test_browser_sensitive_changes_select_both_engines() -> None:
-    for path in ("frontend/src/browser/layout.browser.test.ts", "frontend/src/styles/dashboard.css", "frontend/vitest.browser.config.ts"):
+    for path in (
+        "frontend/src/browser/layout.browser.test.ts",
+        "frontend/src/styles/dashboard.css",
+        "frontend/vitest.browser.config.ts",
+    ):
         outputs = _outputs([path])
         assert outputs["frontend_static"] == "true"
         assert outputs["frontend_browser_chromium"] == "true"
@@ -173,6 +178,25 @@ def test_integration_test_change_selects_integration_ci() -> None:
 
     assert outputs["unit_fast"] == "true"
     assert outputs["integration_ci"] == "true"
+
+
+def test_reliability_only_change_does_not_select_integration_ci() -> None:
+    outputs = _outputs(["tests/integration/reliability/test_checkpoint_resume.py"])
+
+    assert outputs["reliability_journey"] == "true"
+    assert outputs["integration_ci"] == "false"
+
+
+def test_known_slow_test_change_selects_unit_slow() -> None:
+    outputs = _outputs(["tests/unit/api/routers/test_agent_runs.py"])
+
+    assert outputs["unit_slow"] == "true"
+
+
+def test_full_backend_includes_unit_slow() -> None:
+    outputs = select_suites([], event_name="schedule").as_outputs()
+
+    assert outputs["unit_slow"] == "true"
 
 
 def test_api_service_migration_change_selects_integration_ci() -> None:

--- a/tests/unit/tools/test_verify_test_shard_ownership.py
+++ b/tests/unit/tools/test_verify_test_shard_ownership.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from tools.verify_test_shard_ownership import CollectedNode, owners, verify
+
+
+def _node(path: str, *markers: str) -> CollectedNode:
+    return CollectedNode(path, path, frozenset(markers))
+
+
+def test_each_backend_shard_has_one_owner() -> None:
+    nodes = [
+        _node("tests/unit/services/test_a.py", "unit_fast"),
+        _node("tests/unit/api/test_a.py", "component"),
+        _node("tests/unit/workflows/temporal/test_a.py", "temporal_boundary"),
+        _node("tests/unit/api/routers/test_agent_runs.py", "component", "slow"),
+        _node("tests/integration/reliability/test_a.py", "reliability_journey"),
+        _node("tests/integration/api/test_a.py", "integration", "integration_ci"),
+    ]
+
+    assert verify(nodes) == []
+    assert owners(nodes[3]) == {"unit-slow"}
+
+
+def test_verifier_reports_missing_duplicate_and_marker_conflicts() -> None:
+    errors = verify(
+        [
+            _node("tests/unit/test_missing.py"),
+            _node("tests/unit/test_conflict.py", "unit_fast", "slow"),
+            _node(
+                "tests/integration/reliability/test_overlap.py",
+                "integration_ci",
+                "reliability_journey",
+            ),
+        ]
+    )
+
+    assert any("no CI owner" in error for error in errors)
+    assert any("unit_fast conflicts" in error for error in errors)
+    assert any("multiple CI owners" in error for error in errors)
+    assert any("integration_ci conflicts" in error for error in errors)

--- a/tools/select_test_suites.py
+++ b/tools/select_test_suites.py
@@ -14,9 +14,9 @@ from dataclasses import dataclass
 from pathlib import PurePosixPath
 from typing import Iterable
 
-
 OUTPUT_KEYS = (
     "unit_fast",
+    "unit_slow",
     "api_component",
     "temporal_boundary",
     "integration_ci",
@@ -29,15 +29,22 @@ OUTPUT_KEYS = (
 )
 
 FRONTEND_STATIC_EXACT = {
-    "package.json", "package-lock.json", "postcss.config.cjs",
-    "tailwind.config.cjs", "tools/test_unit.sh", "tools/run_repo_python.sh",
-    "tools/verify_vite_manifest.py", "tools/export_openapi.py",
+    "package.json",
+    "package-lock.json",
+    "postcss.config.cjs",
+    "tailwind.config.cjs",
+    "tools/test_unit.sh",
+    "tools/run_repo_python.sh",
+    "tools/verify_vite_manifest.py",
+    "tools/export_openapi.py",
     "tools/generate_openapi_types.py",
 }
 FRONTEND_STATIC_PREFIXES = ("frontend/", "api_service/templates/")
 FRONTEND_CHROMIUM_PREFIXES = ("frontend/src/", "api_service/templates/")
 FRONTEND_FIREFOX_EXACT = {
-    "package.json", "package-lock.json", "frontend/vitest.browser.config.ts",
+    "package.json",
+    "package-lock.json",
+    "frontend/vitest.browser.config.ts",
 }
 FRONTEND_FIREFOX_PREFIXES = ("frontend/src/browser/", "frontend/src/styles/")
 
@@ -53,9 +60,7 @@ FORCE_FULL_EXACT = {
     "tests/unit/conftest.py",
 }
 
-FORCE_FULL_PREFIXES = (
-    ".github/workflows/",
-)
+FORCE_FULL_PREFIXES = (".github/workflows/",)
 
 API_COMPONENT_EXACT = {
     "api_service/auth_providers.py",
@@ -73,9 +78,7 @@ API_COMPONENT_PREFIXES = (
     "tests/component/api/",
 )
 
-API_COMPONENT_GLOBS = (
-    "api_service/auth*",
-)
+API_COMPONENT_GLOBS = ("api_service/auth*",)
 
 TEMPORAL_BOUNDARY_EXACT = {
     "moonmind/schemas/managed_session_models.py",
@@ -111,6 +114,10 @@ INTEGRATION_CI_PREFIXES = (
     "migrations/",
     "alembic/",
 )
+
+INTEGRATION_CI_EXCLUDED_PREFIXES = ("tests/integration/reliability/",)
+
+UNIT_SLOW_PREFIXES = ("tests/unit/api/routers/test_agent_runs.py",)
 
 RELIABILITY_JOURNEY_EXACT = {
     ".github/workflows/pytest-unit-tests.yml",
@@ -174,6 +181,7 @@ NON_BACKEND_EXACT = {
 @dataclass(frozen=True)
 class SuiteSelection:
     unit_fast: bool = False
+    unit_slow: bool = False
     api_component: bool = False
     temporal_boundary: bool = False
     integration_ci: bool = False
@@ -185,9 +193,7 @@ class SuiteSelection:
     full_frontend: bool = False
 
     def as_outputs(self) -> dict[str, str]:
-        return {
-            key: "true" if getattr(self, key) else "false" for key in OUTPUT_KEYS
-        }
+        return {key: "true" if getattr(self, key) else "false" for key in OUTPUT_KEYS}
 
 
 def _normalize_path(raw_path: str) -> str | None:
@@ -246,6 +252,7 @@ def _is_backend_path(path: str) -> bool:
 def _full_backend_selection() -> SuiteSelection:
     return SuiteSelection(
         unit_fast=True,
+        unit_slow=True,
         api_component=True,
         temporal_boundary=True,
         integration_ci=True,
@@ -297,13 +304,26 @@ def select_suites(
         return _full_selection()
 
     backend_paths = [path for path in paths if _is_backend_path(path)]
-    static = any(_matches(path, exact=FRONTEND_STATIC_EXACT, prefixes=FRONTEND_STATIC_PREFIXES) for path in paths)
-    firefox = any(_matches(path, exact=FRONTEND_FIREFOX_EXACT, prefixes=FRONTEND_FIREFOX_PREFIXES) for path in paths)
-    chromium = firefox or any(path != "frontend/src/generated/openapi.ts" and _matches(path, prefixes=FRONTEND_CHROMIUM_PREFIXES) for path in paths)
+    static = any(
+        _matches(path, exact=FRONTEND_STATIC_EXACT, prefixes=FRONTEND_STATIC_PREFIXES)
+        for path in paths
+    )
+    firefox = any(
+        _matches(path, exact=FRONTEND_FIREFOX_EXACT, prefixes=FRONTEND_FIREFOX_PREFIXES)
+        for path in paths
+    )
+    chromium = firefox or any(
+        path != "frontend/src/generated/openapi.ts"
+        and _matches(path, prefixes=FRONTEND_CHROMIUM_PREFIXES)
+        for path in paths
+    )
     full_frontend = any(path in {"package.json", "package-lock.json"} for path in paths)
 
     return SuiteSelection(
         unit_fast=bool(backend_paths),
+        unit_slow=any(
+            _matches(path, prefixes=UNIT_SLOW_PREFIXES) for path in backend_paths
+        ),
         api_component=any(
             _matches(
                 path,
@@ -328,6 +348,7 @@ def select_suites(
                 exact=INTEGRATION_CI_EXACT,
                 prefixes=INTEGRATION_CI_PREFIXES,
             )
+            and not _matches(path, prefixes=INTEGRATION_CI_EXCLUDED_PREFIXES)
             for path in backend_paths
         ),
         reliability_journey=any(

--- a/tools/verify_test_shard_ownership.py
+++ b/tools/verify_test_shard_ownership.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Verify exclusive CI ownership for provider-free backend pytest nodes.
+
+MoonLadderStudios/MoonMind#3324 defines the shard commands mirrored here.
+Pytest remains the classification authority: this tool collects nodes through
+the repository conftest hooks and evaluates their final marker sets.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PROVIDER_MARKERS = {"provider_verification", "requires_credentials"}
+
+
+@dataclass(frozen=True)
+class CollectedNode:
+    nodeid: str
+    path: str
+    markers: frozenset[str]
+
+
+class _Collector:
+    def __init__(self) -> None:
+        self.nodes: list[CollectedNode] = []
+
+    def pytest_collection_finish(self, session: pytest.Session) -> None:
+        self.nodes = [
+            CollectedNode(
+                nodeid=item.nodeid,
+                path=Path(str(item.fspath)).resolve().relative_to(REPO_ROOT).as_posix(),
+                markers=frozenset(marker.name for marker in item.iter_markers()),
+            )
+            for item in session.items
+        ]
+
+
+def _eligible(node: CollectedNode) -> bool:
+    if node.markers & PROVIDER_MARKERS:
+        return False
+    if node.path.startswith("tests/unit/"):
+        return True
+    if node.path.startswith("tests/component/api/"):
+        return True
+    return bool(
+        node.path.startswith("tests/integration/")
+        and node.markers & {"integration_ci", "reliability_journey"}
+    )
+
+
+def owners(node: CollectedNode) -> set[str]:
+    """Return the CI shard commands that select a collected node."""
+
+    markers = node.markers
+    result: set[str] = set()
+
+    if (
+        node.path.startswith("tests/unit/")
+        and not node.path.startswith(
+            (
+                "tests/unit/workflows/temporal/",
+                "tests/unit/api/",
+                "tests/unit/api_service/",
+            )
+        )
+        and "unit_fast" in markers
+    ):
+        result.add("unit-fast")
+    if (
+        node.path.startswith("tests/unit/")
+        and "slow" in markers
+        and "integration" not in markers
+    ):
+        result.add("unit-slow")
+    if (
+        node.path.startswith(
+            ("tests/unit/api/", "tests/unit/api_service/", "tests/component/api/")
+        )
+        and "component" in markers
+        and not markers & {"temporal_boundary", "slow"}
+    ):
+        result.add("api-component")
+    if (
+        node.path.startswith("tests/unit/workflows/temporal/")
+        and "temporal_boundary" in markers
+        and "slow" not in markers
+    ):
+        result.add("temporal-boundary")
+    if (
+        node.path.startswith("tests/integration/reliability/")
+        and "reliability_journey" in markers
+    ):
+        result.add("reliability-journey-checkpoint-resume")
+    if "integration_ci" in markers:
+        result.add("integration-ci")
+    return result
+
+
+def verify(nodes: list[CollectedNode]) -> list[str]:
+    errors: list[str] = []
+    for node in nodes:
+        markers = node.markers
+        if "unit_fast" in markers and markers & {
+            "component",
+            "temporal_boundary",
+            "slow",
+            "provider_verification",
+            "requires_credentials",
+        }:
+            errors.append(
+                f"{node.nodeid}: unit_fast conflicts with ownership marker(s)"
+            )
+        if "integration_ci" in markers and "reliability_journey" in markers:
+            errors.append(
+                f"{node.nodeid}: integration_ci conflicts with reliability_journey"
+            )
+        if not _eligible(node):
+            continue
+        node_owners = owners(node)
+        if not node_owners:
+            errors.append(f"{node.nodeid}: no CI owner")
+        elif len(node_owners) > 1:
+            errors.append(
+                f"{node.nodeid}: multiple CI owners: {', '.join(sorted(node_owners))}"
+            )
+    return errors
+
+
+def main() -> int:
+    collector = _Collector()
+    result = pytest.main(
+        [
+            "tests/unit",
+            "tests/component/api",
+            "tests/integration",
+            "--collect-only",
+            "-q",
+        ],
+        plugins=[collector],
+    )
+    if result != pytest.ExitCode.OK:
+        print(f"pytest collection failed with exit code {int(result)}")
+        return 2
+
+    errors = verify(collector.nodes)
+    if errors:
+        print("Backend test shard ownership verification failed:")
+        for error in errors:
+            print(f"  - {error}")
+        return 1
+
+    eligible_count = sum(_eligible(node) for node in collector.nodes)
+    print(f"Verified exactly one CI owner for {eligible_count} provider-free nodes.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Issue: MoonLadderStudios/MoonMind#3324

Closes MoonLadderStudios/MoonMind#3324

## Summary
- assign every eligible provider-free pytest node to exactly one backend CI shard
- make unit-fast invariant and add the unit-slow shard
- exclude reliability-only changes from Compose integration selection
- add shard-ownership verification and align workflow contracts and documentation

## Tests run
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --python-only tests/unit/tools/test_select_test_suites.py tests/unit/tools/test_verify_test_shard_ownership.py tests/unit/test_pytest_unit_workflow.py tests/unit/test_pytest_collection_classification.py` (55 passed)
- `MOONMIND_FORCE_LOCAL_TESTS=1 python tools/verify_test_shard_ownership.py` (9719 collected; exactly one owner for 9626 eligible provider-free nodes)

## Remaining risks
- Compose-backed integration tests were not run because runtime implementation was unchanged; focused workflow contracts and full pytest collection covered the affected selection boundaries.