### PR TITLE
Fix merge automation PR handoff

### DIFF
--- a/moonmind/workflows/temporal/story_output_tools.py
+++ b/moonmind/workflows/temporal/story_output_tools.py
@@ -5017,9 +5017,19 @@ def _github_status_pull_request_url(
     inputs: Mapping[str, Any],
     context: Mapping[str, Any] | None,
 ) -> str:
+    previous_outputs = _github_status_previous_outputs(inputs, context)
+    previous_metadata = _mapping(previous_outputs.get("metadata"))
     return _first_string(
         inputs.get("pullRequestUrl"),
         inputs.get("pull_request_url"),
+        previous_outputs.get("pullRequestUrl"),
+        previous_outputs.get("pull_request_url"),
+        previous_outputs.get("prUrl"),
+        previous_outputs.get("pr_url"),
+        previous_metadata.get("pullRequestUrl"),
+        previous_metadata.get("pull_request_url"),
+        previous_metadata.get("prUrl"),
+        previous_metadata.get("pr_url"),
         _pull_request_url_from_artifact_path(inputs, context),
     )
 

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -11129,7 +11129,10 @@ class MoonMindRunWorkflow:
                         raise ValueError(
                             f"publishMode 'pr' requested; native PR creation failed: {e}"
                         ) from e
-        if workflow.patched(RUN_DURABLE_PUBLISH_CONTEXT_MERGE_HANDOFF_PATCH):
+        if (
+            workflow.patched(RUN_DURABLE_PUBLISH_CONTEXT_MERGE_HANDOFF_PATCH)
+            and not self._publish_context.get("publicationBlockedBy")
+        ):
             pull_request_url = pull_request_url or self._coerce_text(
                 self._publish_context.get("pullRequestUrl"),
                 max_chars=500,

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -515,6 +515,13 @@ NATIVE_PR_LEASE_CONFLICT_GATE_PATCH = "native-pr-lease-conflict-gate-v1"
 RUN_STOP_ON_PUBLISH_HANDOFF_FAILURE_PATCH = (
     "run-stop-on-publish-handoff-failure-v1"
 )
+# Replay-stable patch for recovering the confirmed PR URL from durable publish
+# context before starting merge automation. Older histories retain their local
+# variable-only handoff; new histories can no longer lose a PR observed by a
+# prior step when a later plan step carries no publication output.
+RUN_DURABLE_PUBLISH_CONTEXT_MERGE_HANDOFF_PATCH = (
+    "run-durable-publish-context-merge-handoff-v1"
+)
 RUN_DIRECT_TOOL_REPORT_OUTPUTS_PATCH = "run-direct-tool-report-outputs-v1"
 RUN_ASSESSMENT_PARAMETER_INJECTION_PATCH = (
     "run-assessment-parameter-injection-v1"
@@ -11122,6 +11129,11 @@ class MoonMindRunWorkflow:
                         raise ValueError(
                             f"publishMode 'pr' requested; native PR creation failed: {e}"
                         ) from e
+        if workflow.patched(RUN_DURABLE_PUBLISH_CONTEXT_MERGE_HANDOFF_PATCH):
+            pull_request_url = pull_request_url or self._coerce_text(
+                self._publish_context.get("pullRequestUrl"),
+                max_chars=500,
+            )
         if (
             pr_publish_optional
             and publish_mode == "pr"

--- a/tests/unit/workflows/temporal/test_story_output_tools.py
+++ b/tests/unit/workflows/temporal/test_story_output_tools.py
@@ -495,6 +495,37 @@ async def test_update_github_issue_status_uses_previous_verification_payload(
 
 
 @pytest.mark.asyncio
+async def test_update_github_issue_status_uses_previous_pull_request_output(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(story_tools.httpx, "AsyncClient", _FakeHttpClient)
+    service = _FakeGitHubService()
+
+    result = await update_github_issue_status(
+        {
+            "repository": "MoonLadderStudios/MoonMind",
+            "issueNumber": 3324,
+            "mode": "finalize_after_pr_or_done",
+            "pullRequestArtifactPath": str(tmp_path / "unavailable-pr.json"),
+            "verificationArtifactPath": str(tmp_path / "unavailable-verify.json"),
+            "previousOutputs": {
+                "pull_request_url": (
+                    "https://github.com/MoonLadderStudios/MoonMind/pull/3343"
+                ),
+                "moonSpecVerify": {"verdict": "FULLY_IMPLEMENTED"},
+            },
+        },
+        github_service_factory=lambda: service,
+    )
+
+    assert result.status == "COMPLETED"
+    assert result.outputs["appliedActions"] == ["patch_issue", "comment"]
+    assert "mode code_review" in result.outputs["summary"]
+    assert result.outputs["sideEffect"]["operation"] == "github.issue.update"
+
+
+@pytest.mark.asyncio
 async def test_update_github_issue_status_blocks_code_review_for_malformed_verification_artifact(
     tmp_path,
 ):

--- a/tests/unit/workflows/temporal/workflows/test_run_integration.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_integration.py
@@ -417,10 +417,16 @@ async def test_run_execution_stage_skips_integration_after_merge_gate_cancellati
     [True, False],
     ids=["new-history", "legacy-replay"],
 )
+@pytest.mark.parametrize(
+    "publication_blocked",
+    [False, True],
+    ids=["publication-allowed", "publication-blocked"],
+)
 async def test_run_execution_stage_recovers_merge_handoff_from_publish_context(
     mock_run_workflow: MoonMindRunWorkflow,
     monkeypatch: pytest.MonkeyPatch,
     durable_handoff_patch_enabled: bool,
+    publication_blocked: bool,
 ) -> None:
     pull_request_url = "https://github.com/org/repo/pull/3343"
     merge_gate_urls: list[str | None] = []
@@ -434,6 +440,10 @@ async def test_run_execution_stage_recovers_merge_handoff_from_publish_context(
             "noCommitPublish": {"status": "no_commits"},
         }
     )
+    if publication_blocked:
+        mock_run_workflow._publish_context["publicationBlockedBy"] = (
+            "moonspec_verify"
+        )
 
     async def fake_execute_activity(
         activity_type: str,
@@ -511,8 +521,12 @@ async def test_run_execution_stage_recovers_merge_handoff_from_publish_context(
         plan_ref="plan-1",
     )
 
-    expected_url = pull_request_url if durable_handoff_patch_enabled else None
-    expected_status = "published" if durable_handoff_patch_enabled else "not_required"
+    expected_url = (
+        pull_request_url
+        if durable_handoff_patch_enabled and not publication_blocked
+        else None
+    )
+    expected_status = "published" if expected_url else "not_required"
     assert merge_gate_urls == [expected_url]
     assert mock_run_workflow._pull_request_url == expected_url
     assert mock_run_workflow._publish_status == expected_status

--- a/tests/unit/workflows/temporal/workflows/test_run_integration.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_integration.py
@@ -16,6 +16,7 @@ from moonmind.workflows.temporal.workflows.run import (
     NATIVE_PR_PUSH_STATUS_GATE_PATCH,
     RUN_CONDITIONAL_REGISTRY_READ_PATCH,
     RUN_DIRECT_TOOL_REPORT_OUTPUTS_PATCH,
+    RUN_DURABLE_PUBLISH_CONTEXT_MERGE_HANDOFF_PATCH,
     RUN_HANDOFF_ACCEPTED_DISPOSITION_GATE_PATCH,
     RUN_PAUSE_SAFE_BOUNDARIES_PATCH,
     RUN_PUBLISH_REPAIR_FEEDBACK_PATCH,
@@ -408,6 +409,113 @@ async def test_run_execution_stage_skips_integration_after_merge_gate_cancellati
     )
 
     assert integration_calls == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "durable_handoff_patch_enabled",
+    [True, False],
+    ids=["new-history", "legacy-replay"],
+)
+async def test_run_execution_stage_recovers_merge_handoff_from_publish_context(
+    mock_run_workflow: MoonMindRunWorkflow,
+    monkeypatch: pytest.MonkeyPatch,
+    durable_handoff_patch_enabled: bool,
+) -> None:
+    pull_request_url = "https://github.com/org/repo/pull/3343"
+    merge_gate_urls: list[str | None] = []
+    mock_run_workflow._integration = None
+    mock_run_workflow._publish_status = "not_required"
+    mock_run_workflow._publish_reason = "Earlier assessment produced no commits."
+    mock_run_workflow._publish_context.update(
+        {
+            "pullRequestUrl": pull_request_url,
+            "headSha": "0fa9c6613",
+            "noCommitPublish": {"status": "no_commits"},
+        }
+    )
+
+    async def fake_execute_activity(
+        activity_type: str,
+        _payload: Any,
+        **_kwargs: Any,
+    ) -> Any:
+        assert activity_type == "artifact.read"
+        return _mock_plan_payload(
+            [
+                {
+                    "id": "final-status",
+                    "tool": {"type": "agent_runtime", "name": "jules"},
+                    "inputs": {"instructions": "Finalize status."},
+                }
+            ]
+        )
+
+    async def fake_execute_child_workflow(
+        _workflow_type: str,
+        _request: Any,
+        **_kwargs: Any,
+    ) -> Any:
+        return {
+            "summary": "Status finalized.",
+            "metadata": {"push_status": "not_requested"},
+            "output_refs": [],
+        }
+
+    async def fake_merge_gate(
+        *,
+        parameters: dict[str, Any],
+        pull_request_url: str | None,
+    ) -> None:
+        assert parameters["mergeAutomation"]["enabled"] is True
+        merge_gate_urls.append(pull_request_url)
+
+    async def noop_step_manifest(*_args: Any, **_kwargs: Any) -> None:
+        return None
+
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "execute_activity",
+        fake_execute_activity,
+    )
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "execute_child_workflow",
+        fake_execute_child_workflow,
+    )
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "patched",
+        lambda patch_id: (
+            durable_handoff_patch_enabled
+            and patch_id == RUN_DURABLE_PUBLISH_CONTEXT_MERGE_HANDOFF_PATCH
+        ),
+    )
+    monkeypatch.setattr(
+        mock_run_workflow,
+        "_pr_publish_optional_for_task",
+        lambda *_args, **_kwargs: True,
+    )
+    monkeypatch.setattr(
+        mock_run_workflow,
+        "_record_step_execution_manifest",
+        noop_step_manifest,
+    )
+    monkeypatch.setattr(mock_run_workflow, "_maybe_start_merge_gate", fake_merge_gate)
+
+    await mock_run_workflow._run_execution_stage(
+        parameters={
+            "publishMode": "pr",
+            "mergeAutomation": {"enabled": True},
+        },
+        plan_ref="plan-1",
+    )
+
+    expected_url = pull_request_url if durable_handoff_patch_enabled else None
+    expected_status = "published" if durable_handoff_patch_enabled else "not_required"
+    assert merge_gate_urls == [expected_url]
+    assert mock_run_workflow._pull_request_url == expected_url
+    assert mock_run_workflow._publish_status == expected_status
 
 @pytest.mark.asyncio
 async def test_run_integration_stage_poll_driven_completion(


### PR DESCRIPTION
## Summary

- recover a confirmed pull request URL from durable publish context before starting merge automation
- preserve replay behavior for older histories with a Temporal patch marker
- let GitHub issue finalization consume the pull request URL carried in `previousOutputs`
- add escaped-failure regression coverage for the workflow and trusted-tool boundaries

## Root cause

Workflow `mm:a08a45db-3dd2-4e66-9d75-e132f33c01f4` created PR #3343 and recorded it in durable publish context, but the final merge handoff still depended on a transient local URL variable. A later non-publishing step left that variable empty, so `MoonMind.MergeAutomation` was never scheduled and the parent failed with `merge automation requested but PR was not merged`.

The GitHub issue finalizer also tried to resolve the PR only from direct inputs or a workspace-local handoff file. The integration activity could not access that managed-agent workspace file and ignored the same PR URL already present in `previousOutputs`, so it treated the run as having no PR and closed issue #3324 instead of moving it to Code Review.

## Impact

New workflows retain the authoritative PR handoff across later plan steps and start merge automation as requested. GitHub issue finalization uses the durable step output and no longer closes an issue merely because a local artifact path is unavailable at the integration boundary.

## Validation

- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --python-only tests/unit/workflows/temporal/workflows/test_run_integration.py tests/unit/workflows/temporal/test_story_output_tools.py tests/unit/workflows/temporal/workflows/test_run_parent_owned_merge_automation_boundary.py tests/unit/workflows/temporal/test_run_merge_gate_start.py` (347 passed)
- `git diff --check`
- secret-pattern scan of the final diff
