### PR TITLE
Fix checkpoint multipart finalization evidence

### DIFF
--- a/docker-compose.test.yaml
+++ b/docker-compose.test.yaml
@@ -34,8 +34,8 @@ services:
       # setting turn the generic pytest service into a destructive janitor.
       - MOONMIND_MANAGED_RUNTIME_JANITOR_ENABLED=false
       - TEMPORAL_ARTIFACT_BACKEND=${TEMPORAL_ARTIFACT_BACKEND:-s3}
-      - TEMPORAL_ARTIFACT_S3_ENDPOINT=${TEMPORAL_ARTIFACT_S3_ENDPOINT:-http://moonmind-test-temporal-artifacts-s3:9000}
-      - TEMPORAL_ARTIFACT_S3_PUBLIC_ENDPOINT=${TEMPORAL_ARTIFACT_S3_PUBLIC_ENDPOINT:-http://moonmind-test-temporal-artifacts-s3:9000}
+      - TEMPORAL_ARTIFACT_S3_ENDPOINT=http://moonmind-test-temporal-artifacts-s3:9000
+      - TEMPORAL_ARTIFACT_S3_PUBLIC_ENDPOINT=http://moonmind-test-temporal-artifacts-s3:9000
       - TEMPORAL_ARTIFACT_S3_BUCKET=${TEMPORAL_ARTIFACT_S3_BUCKET:-moonmind-temporal-artifacts}
       - TEMPORAL_ARTIFACT_S3_ACCESS_KEY_ID=${TEMPORAL_ARTIFACT_S3_ACCESS_KEY_ID:-minioadmin}
       - TEMPORAL_ARTIFACT_S3_SECRET_ACCESS_KEY=${TEMPORAL_ARTIFACT_S3_SECRET_ACCESS_KEY:-minioadmin}

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -7273,7 +7273,7 @@ class TemporalAgentRuntimeActivities:
             principal="system", content_type=content_type,
             size_bytes=len(payload), metadata_json={"artifact_kind": artifact_kind},
         )
-        completed = await self._artifact_service.write_complete(
+        completed = await self._artifact_service.write_payload_complete(
             artifact_id=artifact.artifact_id, principal="system",
             payload=payload, content_type=content_type,
         )

--- a/moonmind/workflows/temporal/artifacts.py
+++ b/moonmind/workflows/temporal/artifacts.py
@@ -37,6 +37,7 @@ logger = logging.getLogger(__name__)
 _CROCKFORD_BASE32 = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
 _PREVIEW_MAX_BYTES = 16 * 1024
 _STREAM_CHUNK_BYTES = 64 * 1024
+_MULTIPART_WRITE_CHUNK_BYTES = 8 * 1024 * 1024
 _RUN_DIGEST_INDEXING_TIMEOUT_SECONDS = 10
 _SINGLE_PUT_READ_RETRY_DELAYS_SECONDS = (0.1, 0.2, 0.4, 0.8, 1.6)
 _SINGLE_PUT_READ_RETRYABLE_S3_ERROR_CODES = {"404", "NoSuchKey", "NotFound"}
@@ -393,6 +394,18 @@ class TemporalArtifactStore:
             "multipart upload is not supported by storage backend"
         )
 
+    def upload_multipart_part(
+        self,
+        *,
+        storage_key: str,
+        upload_id: str,
+        part_number: int,
+        payload: bytes,
+    ) -> str:
+        raise TemporalArtifactValidationError(
+            "multipart upload is not supported by storage backend"
+        )
+
     def complete_multipart_upload(
         self,
         *,
@@ -686,6 +699,28 @@ class S3TemporalArtifactStore(TemporalArtifactStore):
             HttpMethod="PUT",
         )
         return self._rewrite_presigned_url(url), {}
+
+    def upload_multipart_part(
+        self,
+        *,
+        storage_key: str,
+        upload_id: str,
+        part_number: int,
+        payload: bytes,
+    ) -> str:
+        response = self._client.upload_part(
+            Bucket=self._bucket,
+            Key=storage_key,
+            UploadId=upload_id,
+            PartNumber=part_number,
+            Body=payload,
+        )
+        etag = str(response.get("ETag") or "").strip()
+        if not etag:
+            raise TemporalArtifactStateError(
+                "multipart part upload did not return an etag"
+            )
+        return etag
 
     def complete_multipart_upload(
         self,
@@ -1546,6 +1581,85 @@ class TemporalArtifactService:
             artifact.artifact_id,
         )
         return artifact
+
+    async def write_payload_complete(
+        self,
+        *,
+        artifact_id: str,
+        principal: str,
+        payload: bytes,
+        content_type: str | None = None,
+    ) -> db_models.TemporalArtifact:
+        """Persist a trusted in-process payload through its declared upload mode.
+
+        HTTP single-put uploads continue to use :meth:`write_complete`, which
+        rejects multipart artifacts. Activity-owned payloads already resident in
+        process use this method so large evidence does not need to round-trip
+        through presigned HTTP URLs.
+        """
+
+        artifact = await self._repository.get_artifact(artifact_id)
+        self._assert_mutation_access(artifact, principal=principal)
+        if artifact.upload_mode is not db_models.TemporalArtifactUploadMode.MULTIPART:
+            return await self.write_complete(
+                artifact_id=artifact_id,
+                principal=principal,
+                payload=payload,
+                content_type=content_type,
+            )
+        if artifact.status is db_models.TemporalArtifactStatus.COMPLETE:
+            return artifact
+        if artifact.status is db_models.TemporalArtifactStatus.DELETED:
+            raise TemporalArtifactStateError("artifact is deleted")
+        if not artifact.upload_id:
+            raise TemporalArtifactStateError("multipart upload session is missing")
+        if not payload:
+            raise TemporalArtifactValidationError(
+                "multipart payload must not be empty"
+            )
+
+        upload_id = artifact.upload_id
+        parts: list[dict[str, Any]] = []
+        try:
+            for offset in range(0, len(payload), _MULTIPART_WRITE_CHUNK_BYTES):
+                part_number = len(parts) + 1
+                chunk = payload[offset : offset + _MULTIPART_WRITE_CHUNK_BYTES]
+                etag = await asyncio.get_running_loop().run_in_executor(
+                    None,
+                    lambda part_number=part_number, chunk=chunk: (
+                        self._store.upload_multipart_part(
+                            storage_key=artifact.storage_key,
+                            upload_id=upload_id,
+                            part_number=part_number,
+                            payload=chunk,
+                        )
+                    ),
+                )
+                parts.append({"part_number": part_number, "etag": etag})
+        except Exception:
+            try:
+                await asyncio.get_running_loop().run_in_executor(
+                    None,
+                    lambda: self._store.abort_multipart_upload(
+                        storage_key=artifact.storage_key,
+                        upload_id=upload_id,
+                    ),
+                )
+            except Exception as abort_exc:  # pragma: no cover - cleanup is best effort
+                logger.warning(
+                    "Failed to abort trusted multipart artifact upload artifact_id=%s: %s",
+                    artifact.artifact_id,
+                    abort_exc,
+                )
+            artifact.status = db_models.TemporalArtifactStatus.FAILED
+            await self._repository.commit()
+            raise
+
+        return await self.complete(
+            artifact_id=artifact_id,
+            principal=principal,
+            parts=parts,
+        )
 
     async def presign_upload_part(
         self,

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -73,7 +73,7 @@ with workflow.unsafe.imports_passed_through():
     )
     from moonmind.workflows.agent_skills.selection import selected_agent_skill
     from moonmind.config.settings import settings
-    from moonmind.utils.logging import scrub_github_tokens
+    from moonmind.utils.logging import redact_sensitive_text, scrub_github_tokens
     from moonmind.workflows.temporal.jira_agent_skills import (
         JIRA_AGENT_SKILLS,
         JIRA_BACKED_AGENT_SKILLS,
@@ -820,7 +820,9 @@ class MoonMindRunWorkflow:
         """Return redacted nested failure evidence suitable for durable summaries."""
 
         raw_message = self._operator_failure_summary(exc)
-        sanitized = self._sanitize_operator_summary(raw_message) or raw_message
+        sanitized = self._sanitize_operator_summary(
+            redact_sensitive_text(raw_message)
+        )
         return self._coerce_text(sanitized, max_chars=max_chars) or (
             exc.__class__.__name__
         )

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -814,6 +814,17 @@ class MoonMindRunWorkflow:
             return chain[-1][1][:1000]
         return exc.__class__.__name__
 
+    def _bounded_operator_failure(
+        self, exc: BaseException, *, max_chars: int = 500
+    ) -> str:
+        """Return redacted nested failure evidence suitable for durable summaries."""
+
+        raw_message = self._operator_failure_summary(exc)
+        sanitized = self._sanitize_operator_summary(raw_message) or raw_message
+        return self._coerce_text(sanitized, max_chars=max_chars) or (
+            exc.__class__.__name__
+        )
+
     @staticmethod
     def _failure_root_cause(exc: BaseException) -> BaseException:
         """Walk the exception chain to the deepest non-generic cause."""
@@ -5362,7 +5373,7 @@ class MoonMindRunWorkflow:
                 "failureCode": FINALIZATION_CHECKPOINT_FAILED,
                 "terminalFailureCode": FINALIZATION_RETRY_EXHAUSTED,
                 "retryCount": retry_count + 1,
-                "message": self._coerce_text(exc, max_chars=500),
+                "message": self._bounded_operator_failure(exc),
                 "updatedAt": workflow.now().isoformat(),
             }
             self._summary = (
@@ -5434,7 +5445,7 @@ class MoonMindRunWorkflow:
             "failureCode": FINALIZATION_PUBLICATION_FAILED,
             "terminalFailureCode": FINALIZATION_RETRY_EXHAUSTED,
             "retryCount": retry_count,
-            "message": self._coerce_text(exc, max_chars=500),
+            "message": self._bounded_operator_failure(exc),
             "updatedAt": updated_at.isoformat(),
         }
         previous_publish_reason = self._publish_reason
@@ -5478,7 +5489,7 @@ class MoonMindRunWorkflow:
                     "failureCode": FINALIZATION_CHECKPOINT_FAILED,
                     "terminalFailureCode": FINALIZATION_RETRY_EXHAUSTED,
                     "retryCount": 1,
-                    "message": self._coerce_text(exc, max_chars=500),
+                    "message": self._bounded_operator_failure(exc),
                     "updatedAt": workflow.now().isoformat(),
                 }
             self._summary = (
@@ -14532,13 +14543,26 @@ class MoonMindRunWorkflow:
                 finalization_outcome.get("status") == "failed"
                 and finalization_outcome.get("criticality") == "required"
             ):
+                failure_message = self._coerce_text(
+                    finalization_outcome.get("message"), max_chars=500
+                )
+                if not failure_message and self._publish_status == "failed":
+                    failure_message = self._coerce_text(
+                        self._publish_reason, max_chars=500
+                    )
+                if not failure_message:
+                    phase = self._coerce_text(
+                        finalization_outcome.get("phase"), max_chars=100
+                    )
+                    failure_message = (
+                        "Required step finalization failed during "
+                        f"{phase.replace('_', ' ')}."
+                        if phase
+                        else "Required step finalization failed."
+                    )
                 return (
                     "failed",
-                    self._coerce_text(
-                        finalization_outcome.get("message"), max_chars=500
-                    )
-                    or self._summary
-                    or "Required step finalization failed.",
+                    failure_message,
                     True,
                 )
 

--- a/tests/integration/reliability/replays/checkpoint-multipart-finalization-summary/expected-outcome.json
+++ b/tests/integration/reliability/replays/checkpoint-multipart-finalization-summary/expected-outcome.json
@@ -1,0 +1,7 @@
+{
+  "status": "failed",
+  "message": "artifact expects multipart completion; use /complete with parts",
+  "publishReason": "Execution succeeded; finalization failed during the pre-publication checkpoint.",
+  "publishFailure": true,
+  "forbiddenSummary": "Finalizing execution."
+}

--- a/tests/integration/reliability/replays/checkpoint-multipart-finalization-summary/manifest.json
+++ b/tests/integration/reliability/replays/checkpoint-multipart-finalization-summary/manifest.json
@@ -1,0 +1,18 @@
+{
+  "incidentWorkflowId": "mm:2ca7d450-7dbb-4152-8314-96782f924291",
+  "logicalStepId": "tpl:jira-implement:02:d24a37b0",
+  "archiveFailure": "artifact expects multipart completion; use /complete with parts",
+  "publishStatus": "failed",
+  "publishReason": "Execution succeeded; finalization failed during the pre-publication checkpoint.",
+  "transientSummary": "Finalizing execution.",
+  "finalizationOutcome": {
+    "status": "failed",
+    "phase": "before_publication_checkpoint",
+    "criticality": "required",
+    "failureCode": "FINALIZATION_CHECKPOINT_FAILED",
+    "terminalFailureCode": "FINALIZATION_RETRY_EXHAUSTED",
+    "retryCount": 1,
+    "message": "artifact expects multipart completion; use /complete with parts",
+    "updatedAt": "2026-07-15T01:11:35.277604Z"
+  }
+}

--- a/tests/integration/reliability/test_escaped_failure_journeys.py
+++ b/tests/integration/reliability/test_escaped_failure_journeys.py
@@ -926,6 +926,49 @@ async def test_checkpoint_capture_heartbeat_backpressure_replay(
     assert heartbeat_queue.qsize() <= expected["maxQueuedHeartbeats"]
 
 
+async def test_checkpoint_multipart_failure_replay_preserves_terminal_reason(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Replay mm:2ca7d450 without allowing a transient summary to win."""
+
+    replay_id = "checkpoint-multipart-finalization-summary"
+    manifest = load_replay(replay_id, "manifest.json")
+    expected = load_replay(replay_id, "expected-outcome.json")
+    parent = MoonMindRunWorkflow()
+    now = datetime(2026, 7, 15, tzinfo=timezone.utc)
+    parent._initialize_step_ledger(
+        ordered_nodes=[{"id": manifest["logicalStepId"], "inputs": {}}],
+        dependency_map={manifest["logicalStepId"]: []},
+        updated_at=now,
+    )
+    row = parent._step_ledger_row_for(manifest["logicalStepId"])
+    assert row is not None
+    row["finalizationOutcome"] = manifest["finalizationOutcome"]
+    parent._publish_status = manifest["publishStatus"]
+    parent._publish_reason = manifest["publishReason"]
+    parent._summary = manifest["transientSummary"]
+
+    status, message, publish_failure = parent._determine_publish_completion(
+        parameters={"publishMode": "pr"}
+    )
+
+    assert status == expected["status"]
+    assert message == expected["message"]
+    assert publish_failure is expected["publishFailure"]
+    assert message != expected["forbiddenSummary"]
+
+    monkeypatch.setattr(run_workflow_module.workflow, "now", lambda: now)
+    summary = await _finalize_and_capture_summary(
+        monkeypatch,
+        parent,
+        parameters={"publishMode": "pr"},
+        status=status,
+        error=message,
+    )
+    assert summary["finishOutcome"]["reason"] == expected["message"]
+    assert summary["publish"]["reason"] == expected["publishReason"]
+
+
 async def test_codex_system_error_waits_for_delayed_oauth_failure_log(
     tmp_path: Path,
 ) -> None:

--- a/tests/integration/temporal/test_temporal_artifact_lifecycle.py
+++ b/tests/integration/temporal/test_temporal_artifact_lifecycle.py
@@ -66,6 +66,41 @@ async def test_lifecycle_soft_then_hard_delete(tmp_path: Path) -> None:
             refreshed = await service._repository.get_artifact(artifact.artifact_id)
             assert refreshed.hard_deleted_at is not None
 
+
+async def test_trusted_multipart_payload_round_trips_through_configured_store(
+    tmp_path: Path,
+) -> None:
+    """Activity-owned large payloads should complete against the real S3 backend."""
+
+    async with _db(tmp_path) as maker:
+        async with maker() as session:
+            service = TemporalArtifactService(
+                TemporalArtifactRepository(session),
+                direct_upload_max_bytes=1,
+            )
+            payload = b"m" * ((8 * 1024 * 1024) + 17)
+            artifact, upload = await service.create(
+                principal="system:integration-test",
+                content_type="application/vnd.moonmind.worktree-archive",
+                size_bytes=len(payload),
+            )
+
+            assert upload.mode == "multipart"
+            completed = await service.write_payload_complete(
+                artifact_id=artifact.artifact_id,
+                principal="system:integration-test",
+                payload=payload,
+                content_type="application/vnd.moonmind.worktree-archive",
+            )
+            _stored, stored_payload = await service.read(
+                artifact_id=artifact.artifact_id,
+                principal="system:integration-test",
+            )
+
+            assert completed.status is TemporalArtifactStatus.COMPLETE
+            assert completed.size_bytes == len(payload)
+            assert stored_payload == payload
+
 async def test_report_delete_does_not_cascade_to_observability_artifacts(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/test_integration_test_taxonomy.py
+++ b/tests/unit/test_integration_test_taxonomy.py
@@ -162,6 +162,22 @@ def test_compose_tests_use_an_explicit_isolated_project() -> None:
         assert "--remove-orphans" in runner, relative_path
 
 
+def test_compose_test_artifact_endpoints_ignore_deployment_env() -> None:
+    compose_file = (REPO_ROOT / "docker-compose.test.yaml").read_text(
+        encoding="utf-8"
+    )
+    isolated_endpoint = "http://moonmind-test-temporal-artifacts-s3:9000"
+
+    assert (
+        f"TEMPORAL_ARTIFACT_S3_ENDPOINT={isolated_endpoint}" in compose_file
+    )
+    assert (
+        f"TEMPORAL_ARTIFACT_S3_PUBLIC_ENDPOINT={isolated_endpoint}" in compose_file
+    )
+    assert "TEMPORAL_ARTIFACT_S3_ENDPOINT=${" not in compose_file
+    assert "TEMPORAL_ARTIFACT_S3_PUBLIC_ENDPOINT=${" not in compose_file
+
+
 def test_powershell_compose_runners_preserve_test_exit_codes_after_cleanup() -> None:
     for relative_path in (
         "tools/test-unit.ps1",

--- a/tests/unit/workflows/temporal/test_artifacts.py
+++ b/tests/unit/workflows/temporal/test_artifacts.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 from contextlib import asynccontextmanager
 from pathlib import Path
 
@@ -116,6 +117,17 @@ class _MultipartMemoryStore(TemporalArtifactStore):
     ):
         _ = storage_key, expires_in_seconds
         return f"https://example.test/upload-part/{upload_id}/{part_number}", {}
+
+    def upload_multipart_part(
+        self,
+        *,
+        storage_key: str,
+        upload_id: str,
+        part_number: int,
+        payload: bytes,
+    ) -> str:
+        _ = storage_key
+        return self.put_part(upload_id, part_number, payload)
 
     def complete_multipart_upload(
         self, *, storage_key: str, upload_id: str, parts: list[dict]
@@ -1473,6 +1485,56 @@ async def test_complete_multipart_upload_sets_integrity_metadata(
 
             assert completed.size_bytes == 8
             assert completed.sha256 is not None
+
+
+async def test_write_payload_complete_persists_trusted_multipart_bytes(
+    tmp_path: Path,
+) -> None:
+    """Trusted activity payloads should honor multipart artifact mode."""
+
+    async with temporal_db(tmp_path) as session_maker:
+        async with session_maker() as session:
+            store = _MultipartMemoryStore()
+            repo = TemporalArtifactRepository(session)
+            service = TemporalArtifactService(
+                repo,
+                store=store,
+                direct_upload_max_bytes=4,
+            )
+            payload = b"multipart checkpoint archive"
+            artifact, upload = await service.create(
+                principal="system",
+                content_type="application/octet-stream",
+                size_bytes=len(payload),
+            )
+
+            assert upload.mode == "multipart"
+            with pytest.raises(
+                TemporalArtifactStateError,
+                match="expects multipart completion",
+            ):
+                await service.write_complete(
+                    artifact_id=artifact.artifact_id,
+                    principal="system",
+                    payload=payload,
+                    content_type="application/octet-stream",
+                )
+
+            completed = await service.write_payload_complete(
+                artifact_id=artifact.artifact_id,
+                principal="system",
+                payload=payload,
+                content_type="application/octet-stream",
+            )
+            _stored, stored_payload = await service.read(
+                artifact_id=artifact.artifact_id,
+                principal="system",
+            )
+
+            assert completed.status.value == "complete"
+            assert completed.size_bytes == len(payload)
+            assert completed.sha256 == hashlib.sha256(payload).hexdigest()
+            assert stored_payload == payload
 
 async def test_write_integration_event_artifact_creates_restricted_preview(
     tmp_path: Path,

--- a/tests/unit/workflows/temporal/test_managed_checkpoint_capture.py
+++ b/tests/unit/workflows/temporal/test_managed_checkpoint_capture.py
@@ -53,6 +53,45 @@ def test_managed_capture_contract_and_catalog_reject_other_authorities() -> None
 
 
 @pytest.mark.asyncio
+async def test_managed_checkpoint_artifact_uses_mode_aware_payload_writer() -> None:
+    calls: list[tuple[str, bytes]] = []
+
+    class ArtifactService:
+        async def create(self, **_kwargs: object) -> tuple[object, object]:
+            return SimpleNamespace(artifact_id="art-checkpoint"), SimpleNamespace(
+                mode="multipart"
+            )
+
+        async def write_payload_complete(
+            self, *, artifact_id: str, payload: bytes, **_kwargs: object
+        ) -> object:
+            calls.append((artifact_id, payload))
+            return SimpleNamespace(
+                artifact_id=artifact_id,
+                sha256=hashlib.sha256(payload).hexdigest(),
+                size_bytes=len(payload),
+                content_type="application/vnd.moonmind.worktree-archive",
+                encryption=SimpleNamespace(value="none"),
+            )
+
+    activities = TemporalAgentRuntimeActivities(
+        run_store=object(),
+        artifact_service=ArtifactService(),
+        client_adapter=object(),
+    )
+    payload = b"large checkpoint payload"
+
+    artifact_ref = await activities._put_managed_checkpoint_artifact(
+        payload,
+        "application/vnd.moonmind.worktree-archive",
+        "checkpoint_archive",
+    )
+
+    assert artifact_ref == "art-checkpoint"
+    assert calls == [("art-checkpoint", payload)]
+
+
+@pytest.mark.asyncio
 async def test_managed_capture_trusts_the_resolved_workspace_for_every_git_command(
     tmp_path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
@@ -3565,7 +3565,13 @@ async def test_after_execution_finalization_failure_preserves_primary_outcome(
     )
 
     async def fail_checkpoint(*args: Any, **kwargs: Any) -> None:
-        raise RuntimeError("checkpoint service unavailable")
+        try:
+            raise ValueError(
+                "checkpoint service unavailable password=raw-secret "
+                "Authorization: Bearer raw-token"
+            )
+        except ValueError as cause:
+            raise RuntimeError("Activity task failed") from cause
 
     monkeypatch.setattr(workflow, "_record_canonical_step_checkpoint", fail_checkpoint)
     await workflow._finalize_after_execution_checkpoint("implement", updated_at=now)
@@ -3588,6 +3594,12 @@ async def test_after_execution_finalization_failure_preserves_primary_outcome(
         "FINALIZATION_CHECKPOINT_FAILED"
     )
     assert step["finalizationOutcome"]["phase"] == "after_execution_checkpoint"
+    assert step["finalizationOutcome"]["message"] == (
+        "checkpoint service unavailable password=[REDACTED] "
+        "[REDACTED_AUTHORIZATION]"
+    )
+    assert "raw-secret" not in str(step["finalizationOutcome"])
+    assert "raw-token" not in str(step["finalizationOutcome"])
     assert workflow._attention_required is attention_required
     assert workflow._summary.startswith("Execution succeeded; finalization failed")
     completion = workflow._determine_publish_completion(

--- a/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
@@ -3737,6 +3737,9 @@ async def test_prepublication_checkpoint_failure_blocks_publish_repair(
     assert workflow._publish_reason == (
         "Execution succeeded; finalization failed during the pre-publication checkpoint."
     )
+    assert workflow.get_step_ledger()["steps"][0]["finalizationOutcome"]["message"] == (
+        "QueueFull"
+    )
     assert workflow._publish_repair_is_available(parameters={"publishMode": "pr"}) is False
     monkeypatch.setattr(run_module.workflow, "patched", lambda _patch_id: False)
     assert workflow._publish_repair_is_available(parameters={"publishMode": "pr"}) is True


### PR DESCRIPTION
## What changed

- add a trusted in-process multipart writer that uploads large activity-owned artifacts in S3-compatible chunks and completes them through the existing artifact integrity path
- route managed workspace checkpoint archives through the mode-aware writer while preserving the public single-put size boundary
- unwrap and redact nested finalization exceptions before recording durable step evidence
- prevent transient lifecycle text such as `Finalizing execution.` from becoming a terminal failure summary when durable finalization evidence exists
- add a production replay fixture for workflow `mm:2ca7d450-7dbb-4152-8314-96782f924291`

## Root cause

The checkpoint archive exceeded the direct-upload threshold, so artifact creation correctly selected multipart mode. The managed checkpoint activity then called the single-put completion method, which rejected the multipart artifact. Temporal's outer activity exception had an empty string representation, so the finalization ledger recorded no message. Terminal selection fell back to the current workflow summary after it had been changed to `Finalizing execution.`

## Impact

Large managed workspace checkpoints now persist through the declared multipart contract. If a finalization failure still occurs, the workflow memo, finish artifact, terminal-state record, and thrown application error use nested durable failure evidence or a stable phase-specific fallback instead of transient progress text.

## Validation

- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_artifacts.py tests/unit/workflows/temporal/test_managed_checkpoint_capture.py tests/unit/workflows/temporal/workflows/test_run_step_ledger.py` — 155 backend tests passed; selector-equivalent frontend suite also passed (1,088 passed, 238 skipped)
- focused multipart/checkpoint/replay regressions — 4 passed
- `./tools/test_integration.sh` — 443 passed, 1 skipped, including a two-part MinIO round trip through the production S3 store
