### PR TITLE
Preserve verification evidence for issue finalization

### DIFF
--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -612,6 +612,9 @@ RUN_ALREADY_IMPLEMENTED_JIRA_COMPLETION_PATCH = (
 RUN_MOONSPEC_VERIFY_PUBLICATION_GATE_PATCH = (
     "run-moonspec-verify-publication-gate-v1"
 )
+RUN_MOONSPEC_GATE_PREVIOUS_OUTPUTS_HANDOFF_PATCH = (
+    "run-moonspec-gate-previous-outputs-handoff-v1"
+)
 RUN_MOONSPEC_VERIFY_REMEDIATION_INDEX_PATCH = (
     "run-moonspec-verify-remediation-index-v1"
 )
@@ -7254,6 +7257,22 @@ class MoonMindRunWorkflow:
             value = self._assessment_context.get(key)
             if value not in (None, "", {}, []):
                 merged.setdefault(key, value)
+        if self._patched_or_false_outside_workflow(
+            RUN_MOONSPEC_GATE_PREVIOUS_OUTPUTS_HANDOFF_PATCH
+        ):
+            gate_context = self._publish_context.get("moonSpecGate")
+            if isinstance(gate_context, Mapping) and gate_context:
+                # The workflow-owned gate is the latest controlling verifier
+                # result. Carry it across intervening agent steps so trusted
+                # finalizers do not depend on another workspace's relative path
+                # or on unstructured agent prose.
+                merged["moonSpecVerify"] = dict(gate_context)
+                gate_result_ref = self._coerce_text(
+                    gate_context.get("gateResultRef"),
+                    max_chars=400,
+                )
+                if gate_result_ref:
+                    merged["moonSpecVerifyArtifactRef"] = gate_result_ref
         if not self._trusted_issue_context:
             return merged if merged != previous_outputs else previous_outputs
         if self._trusted_previous_outputs_context(previous_outputs):

--- a/tests/unit/workflows/temporal/workflows/test_run_integration.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_integration.py
@@ -18,6 +18,7 @@ from moonmind.workflows.temporal.workflows.run import (
     RUN_DIRECT_TOOL_REPORT_OUTPUTS_PATCH,
     RUN_DURABLE_PUBLISH_CONTEXT_MERGE_HANDOFF_PATCH,
     RUN_HANDOFF_ACCEPTED_DISPOSITION_GATE_PATCH,
+    RUN_MOONSPEC_GATE_PREVIOUS_OUTPUTS_HANDOFF_PATCH,
     RUN_PAUSE_SAFE_BOUNDARIES_PATCH,
     RUN_PUBLISH_REPAIR_FEEDBACK_PATCH,
     RUN_PR_RESOLVER_PUBLISH_EVIDENCE_REF_PATCH,
@@ -739,6 +740,124 @@ async def test_run_execution_stage_uses_user_max_attempts_for_skill_retry_policy
     retry_policy = tool_calls[0][2]["retry_policy"]
     assert retry_policy.maximum_attempts == 3
     assert tool_calls[0][1]["invocation_payload"]["inputs"]["maxAttempts"] == 3
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("handoff_enabled", "expects_verification"),
+    [(True, True), (False, False)],
+)
+async def test_run_execution_stage_hands_controlling_verification_to_finalizer(
+    mock_run_workflow: MoonMindRunWorkflow,
+    monkeypatch: pytest.MonkeyPatch,
+    handoff_enabled: bool,
+    expects_verification: bool,
+) -> None:
+    """Regression for workflow mm:341551dd-06d0-4c80-9563-77b12b144499."""
+
+    mock_run_workflow._integration = None
+    mock_run_workflow._publish_context["moonSpecGate"] = {
+        "logicalStepId": "verify",
+        "verdict": "FULLY_IMPLEMENTED",
+        "gateResultRef": "art_verify_gate",
+    }
+    captured: list[tuple[str, Any]] = []
+
+    async def fake_execute_activity(
+        activity_type: str,
+        payload: Any,
+        **_kwargs: Any,
+    ) -> Any:
+        captured.append((activity_type, _normalize_payload(payload)))
+        if activity_type == "artifact.read":
+            artifact_ref = (
+                payload.get("artifact_ref")
+                if isinstance(payload, dict)
+                else getattr(payload, "artifact_ref", None)
+            )
+            if artifact_ref == "art:sha256:456":
+                import json
+
+                return json.dumps(
+                    {
+                        "skills": [
+                            {
+                                "name": "github.update_issue_status",
+                                "description": "Finalize a GitHub issue",
+                                "inputs": {"schema": {"type": "object"}},
+                                "outputs": {"schema": {"type": "object"}},
+                                "executor": {
+                                    "activity_type": "mm.tool.execute",
+                                    "selector": {"mode": "by_capability"},
+                                },
+                                "requirements": {
+                                    "capabilities": ["integration:github"]
+                                },
+                                "policies": {
+                                    "timeouts": {
+                                        "start_to_close_seconds": 60,
+                                        "schedule_to_close_seconds": 120,
+                                    },
+                                    "retries": {"max_attempts": 1},
+                                },
+                            }
+                        ]
+                    }
+                ).encode("utf-8")
+            return _mock_plan_payload(
+                [
+                    {
+                        "id": "finalize-issue",
+                        "tool": {
+                            "type": "skill",
+                            "name": "github.update_issue_status",
+                        },
+                        "inputs": {
+                            "repository": "MoonLadderStudios/MoonMind",
+                            "issueNumber": 3258,
+                            "mode": "finalize_after_pr_or_done",
+                            "pullRequestArtifactPath": "artifacts/pr.json",
+                            "verificationArtifactPath": "artifacts/verify.json",
+                            "requireVerification": True,
+                        },
+                    }
+                ]
+            )
+        return {"status": "COMPLETED", "outputs": {}}
+
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "patched",
+        lambda patch_id: (
+            handoff_enabled
+            and patch_id == RUN_MOONSPEC_GATE_PREVIOUS_OUTPUTS_HANDOFF_PATCH
+        ),
+    )
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "execute_activity",
+        fake_execute_activity,
+    )
+
+    await mock_run_workflow._run_execution_stage(
+        parameters={},
+        plan_ref="art:sha256:plan",
+    )
+
+    tool_call = next(call for call in captured if call[0] == "mm.tool.execute")
+    inputs = tool_call[1]["invocation_payload"]["inputs"]
+    if expects_verification:
+        assert inputs["previousOutputs"]["moonSpecVerify"] == {
+            "logicalStepId": "verify",
+            "verdict": "FULLY_IMPLEMENTED",
+            "gateResultRef": "art_verify_gate",
+        }
+        assert (
+            inputs["previousOutputs"]["moonSpecVerifyArtifactRef"]
+            == "art_verify_gate"
+        )
+    else:
+        assert "previousOutputs" not in inputs
 
 
 def test_execute_kwargs_retry_override_preserves_route_retry_policy() -> None:


### PR DESCRIPTION
## Summary

- preserve the workflow-owned MoonSpec verification gate and durable artifact reference across intervening step outputs
- pass that structured evidence to trusted issue-finalization tools instead of relying on a relative path in another managed workspace
- replay-guard the invocation-shape change and cover both new and pre-marker histories

## Root cause

Workflow `mm:341551dd-06d0-4c80-9563-77b12b144499` completed its verifier child with a structured `FULLY_IMPLEMENTED` verdict and durable gate result reference. The parent recorded that evidence, but each step replaced `previousOutputs` with only the immediately preceding step's outputs. After PR publication, `github.update_issue_status` received the PR URL but not the verifier evidence, and its configured relative verification path was unavailable from the integrations worker.

## Impact

GitHub issue finalization now receives the latest workflow-controlled verification verdict and artifact reference even when another agent step runs between verification and finalization. Existing Temporal histories without the patch marker keep their original invocation shape.

## Validation

- `.venv/bin/ruff check moonmind/workflows/temporal/workflows/run.py tests/unit/workflows/temporal/workflows/test_run_integration.py`
- `.venv/bin/pytest tests/unit/workflows/temporal/workflows/test_run_integration.py -q --tb=short` — 145 passed
- `.venv/bin/pytest tests/unit/workflows/temporal/test_story_output_tools.py -k 'update_github_issue_status' -q --tb=short` — 16 passed
- The repository test wrapper was attempted but stopped before pytest because an unrelated existing `.claude/worktrees/ui-regressions` tree fails the global status-domain audit; that user-owned worktree was left untouched.
