### PR TITLE
Fix resolver continuation authority handoff

### DIFF
--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -7036,12 +7036,32 @@ class TemporalAgentRuntimeActivities:
                     "logicalStepId": model.identity.logical_step_id,
                     "executionOrdinal": model.identity.execution_ordinal,
                 }
-                if correlation != expected_correlation:
+                exact_execution_match = correlation == expected_correlation
+                prior_execution_baseline_match = (
+                    model.boundary == "before_execution"
+                    and record.status
+                    in {"completed", "failed", "canceled", "timed_out"}
+                    and record.finished_at is not None
+                    and correlation["workflowId"]
+                    == expected_correlation["workflowId"]
+                    and correlation["ownerRunId"]
+                    == expected_correlation["ownerRunId"]
+                    and correlation["logicalStepId"]
+                    == expected_correlation["logicalStepId"]
+                    and isinstance(correlation["executionOrdinal"], int)
+                    and correlation["executionOrdinal"] + 1
+                    == expected_correlation["executionOrdinal"]
+                )
+                if not exact_execution_match and not prior_execution_baseline_match:
                     logger.warning("managed_checkpoint_capture_authority_rejected")
                     raise temporal_exceptions.ApplicationError(
                         "managed run record does not belong to the source Step Execution",
                         type=WORKSPACE_IDENTITY_MISMATCH,
                         non_retryable=True,
+                    )
+                if prior_execution_baseline_match:
+                    logger.info(
+                        "managed_checkpoint_capture_prior_execution_baseline_accepted"
                     )
                 try:
                     workspace = resolve_managed_workspace_locator(

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -22,7 +22,7 @@ with workflow.unsafe.imports_passed_through():
     from api_service.services.provider_profile_readiness import (
         provider_profile_launch_ready_from_payload,
     )
-    from moonmind.schemas.agent_skill_models import SkillSelector
+    from moonmind.schemas.agent_skill_models import ResolvedSkillSet, SkillSelector
     from moonmind.schemas.container_job_models import (
         ContainerJobState,
         ContainerJobSubmitRequest,
@@ -698,6 +698,9 @@ RUN_PR_RESOLVER_SKILL_OWNED_EXECUTION_PATCH = (
 )
 RUN_RESOLVED_SKILL_TERMINAL_CONTRACT_PATCH = (
     "run-resolved-skill-terminal-contract-v1"
+)
+RUN_EXISTING_SKILLSET_TERMINAL_CONTRACT_PATCH = (
+    "run-existing-skillset-terminal-contract-v1"
 )
 RUN_PR_RESOLVER_SELECTOR_RESOLUTION_PATCH = (
     "run-pr-resolver-selector-resolution-v1"
@@ -15620,16 +15623,44 @@ class MoonMindRunWorkflow:
     ) -> str | None:
         """Resolve effective workflow/step skill intent before AgentRun launch."""
 
+        selected_skill = selected_agent_skill(node_inputs)
+        if selected_skill == "auto":
+            selected_skill = ""
         if existing_skillset_ref:
+            if selected_skill and self._workflow_patch_enabled(
+                RUN_EXISTING_SKILLSET_TERMINAL_CONTRACT_PATCH
+            ):
+                artifact_read_route = DEFAULT_ACTIVITY_CATALOG.resolve_activity(
+                    "artifact.read"
+                )
+                resolved_payload = await execute_typed_activity(
+                    "artifact.read",
+                    ArtifactReadInput(
+                        principal=self._principal(),
+                        artifact_ref=existing_skillset_ref,
+                    ),
+                    **self._execute_kwargs_for_route(artifact_read_route),
+                )
+                resolved = ResolvedSkillSet.model_validate(
+                    self._decode_json_payload(
+                        resolved_payload,
+                        error_message=(
+                            "resolvedSkillsetRef must resolve to a JSON object"
+                        ),
+                    )
+                )
+                self._record_resolved_selected_skill(
+                    resolved=resolved,
+                    selected_skill=selected_skill,
+                    node_id=node_id,
+                    terminal_contract_enabled=True,
+                )
             return existing_skillset_ref
 
         effective = build_effective_workflow_skill_selectors(
             task_skills,
             node_skills if node_skills is not None else node_inputs.get("skills"),
         )
-        selected_skill = selected_agent_skill(node_inputs)
-        if selected_skill == "auto":
-            selected_skill = ""
         if effective is None and not selected_skill:
             return None
 
@@ -15677,59 +15708,14 @@ class MoonMindRunWorkflow:
             **self._execute_kwargs_for_route(route),
         )
         if selected_skill:
-            normalized_skill = str(selected_skill).strip().lower()
-            resolved_skill_names = self._resolved_skillset_skill_names(resolved)
-            if normalized_skill not in resolved_skill_names:
-                raise ValueError(
-                    f"selected skill '{selected_skill}' was not resolved into the "
-                    "agent skill snapshot"
-                )
-            selected_entry = self._resolved_skillset_entry(
-                resolved,
-                normalized_skill,
+            self._record_resolved_selected_skill(
+                resolved=resolved,
+                selected_skill=selected_skill,
+                node_id=node_id,
+                terminal_contract_enabled=self._workflow_patch_enabled(
+                    RUN_RESOLVED_SKILL_TERMINAL_CONTRACT_PATCH
+                ),
             )
-            if self._workflow_patch_enabled(
-                RUN_RESOLVED_SKILL_TERMINAL_CONTRACT_PATCH
-            ):
-                terminal_contract = self._resolved_skill_terminal_contract(
-                    selected_entry
-                )
-                if terminal_contract is not None:
-                    self._resolved_skill_terminal_contract_by_step[node_id] = (
-                        terminal_contract
-                    )
-            if normalized_skill == "pr-resolver":
-                if workflow.patched(
-                    RUN_PR_RESOLVER_SKILL_OWNED_EXECUTION_PATCH
-                ):
-                    decision = require_skill_owned_pr_resolver_execution(
-                        selected_entry
-                    )
-                    self._native_skill_binding_by_step[node_id] = {
-                        "eligible": decision.eligible,
-                        "host": decision.host,
-                        "reasonCode": decision.reason_code,
-                        "identity": dict(decision.identity),
-                    }
-                elif workflow.patched(RUN_TRUSTED_PR_RESOLVER_NATIVE_BINDING_PATCH):
-                    decision = evaluate_pr_resolver_native_binding(selected_entry)
-                    self._native_skill_binding_by_step[node_id] = {
-                        "eligible": decision.eligible,
-                        "host": decision.host,
-                        "reasonCode": decision.reason_code,
-                        "identity": dict(decision.identity),
-                    }
-                else:
-                    # Replay path for histories created before native routing was
-                    # bound to immutable resolved-skill evidence. Those histories
-                    # selected the native host by canonical name, so preserve that
-                    # child-workflow command only for their replay.
-                    self._native_skill_binding_by_step[node_id] = {
-                        "eligible": True,
-                        "host": "temporal",
-                        "reasonCode": "legacy_name_binding_replay",
-                        "identity": {},
-                    }
         manifest_ref = self._resolved_skillset_field(
             resolved,
             "manifest_ref",
@@ -15743,6 +15729,63 @@ class MoonMindRunWorkflow:
             "snapshotId",
         )
         return str(snapshot_id) if snapshot_id else None
+
+    def _record_resolved_selected_skill(
+        self,
+        *,
+        resolved: Any,
+        selected_skill: str,
+        node_id: str,
+        terminal_contract_enabled: bool,
+    ) -> None:
+        """Record trusted selected-Skill launch metadata from its snapshot."""
+
+        normalized_skill = str(selected_skill).strip().lower()
+        resolved_skill_names = self._resolved_skillset_skill_names(resolved)
+        if normalized_skill not in resolved_skill_names:
+            raise ValueError(
+                f"selected skill '{selected_skill}' was not resolved into the "
+                "agent skill snapshot"
+            )
+        selected_entry = self._resolved_skillset_entry(
+            resolved,
+            normalized_skill,
+        )
+        if terminal_contract_enabled:
+            terminal_contract = self._resolved_skill_terminal_contract(selected_entry)
+            if terminal_contract is not None:
+                self._resolved_skill_terminal_contract_by_step[node_id] = (
+                    terminal_contract
+                )
+        if normalized_skill != "pr-resolver":
+            return
+        if workflow.patched(RUN_PR_RESOLVER_SKILL_OWNED_EXECUTION_PATCH):
+            decision = require_skill_owned_pr_resolver_execution(selected_entry)
+            self._native_skill_binding_by_step[node_id] = {
+                "eligible": decision.eligible,
+                "host": decision.host,
+                "reasonCode": decision.reason_code,
+                "identity": dict(decision.identity),
+            }
+        elif workflow.patched(RUN_TRUSTED_PR_RESOLVER_NATIVE_BINDING_PATCH):
+            decision = evaluate_pr_resolver_native_binding(selected_entry)
+            self._native_skill_binding_by_step[node_id] = {
+                "eligible": decision.eligible,
+                "host": decision.host,
+                "reasonCode": decision.reason_code,
+                "identity": dict(decision.identity),
+            }
+        else:
+            # Replay path for histories created before native routing was bound
+            # to immutable resolved-skill evidence. Those histories selected the
+            # native host by canonical name, so preserve that child-workflow
+            # command only for their replay.
+            self._native_skill_binding_by_step[node_id] = {
+                "eligible": True,
+                "host": "temporal",
+                "reasonCode": "legacy_name_binding_replay",
+                "identity": {},
+            }
 
     @staticmethod
     def _resolved_skillset_skill_names(resolved: Any) -> set[str]:

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -696,6 +696,9 @@ RUN_TRUSTED_PR_RESOLVER_NATIVE_BINDING_PATCH = (
 RUN_PR_RESOLVER_SKILL_OWNED_EXECUTION_PATCH = (
     "run-pr-resolver-skill-owned-execution-v1"
 )
+RUN_RESOLVED_SKILL_TERMINAL_CONTRACT_PATCH = (
+    "run-resolved-skill-terminal-contract-v1"
+)
 RUN_PR_RESOLVER_SELECTOR_RESOLUTION_PATCH = (
     "run-pr-resolver-selector-resolution-v1"
 )
@@ -1258,6 +1261,9 @@ class MoonMindRunWorkflow:
         self._remediation_context: dict[str, Any] = {}
         self._remediation_policy: dict[str, Any] = {}
         self._native_skill_binding_by_step: dict[str, dict[str, Any]] = {}
+        self._resolved_skill_terminal_contract_by_step: dict[
+            str, dict[str, Any]
+        ] = {}
 
         # Artifact refs
         self._input_ref: Optional[str] = None
@@ -15678,11 +15684,21 @@ class MoonMindRunWorkflow:
                     f"selected skill '{selected_skill}' was not resolved into the "
                     "agent skill snapshot"
                 )
-            if normalized_skill == "pr-resolver":
-                selected_entry = self._resolved_skillset_entry(
-                    resolved,
-                    normalized_skill,
+            selected_entry = self._resolved_skillset_entry(
+                resolved,
+                normalized_skill,
+            )
+            if self._workflow_patch_enabled(
+                RUN_RESOLVED_SKILL_TERMINAL_CONTRACT_PATCH
+            ):
+                terminal_contract = self._resolved_skill_terminal_contract(
+                    selected_entry
                 )
+                if terminal_contract is not None:
+                    self._resolved_skill_terminal_contract_by_step[node_id] = (
+                        terminal_contract
+                    )
+            if normalized_skill == "pr-resolver":
                 if workflow.patched(
                     RUN_PR_RESOLVER_SKILL_OWNED_EXECUTION_PATCH
                 ):
@@ -15781,6 +15797,61 @@ class MoonMindRunWorkflow:
             if str(raw_name or "").strip().lower() == normalized:
                 return entry
         return None
+
+    @staticmethod
+    def _resolved_skill_terminal_contract(
+        resolved_entry: Any,
+    ) -> dict[str, Any] | None:
+        """Return the compact terminal contract selected with the Skill."""
+
+        if resolved_entry is None:
+            return None
+        if isinstance(resolved_entry, WorkflowMapping):
+            raw_contract = resolved_entry.get(
+                "terminal_contract",
+                resolved_entry.get("terminalContract"),
+            )
+        else:
+            raw_contract = getattr(resolved_entry, "terminal_contract", None)
+            if raw_contract is None:
+                raw_contract = getattr(resolved_entry, "terminalContract", None)
+        if hasattr(raw_contract, "model_dump"):
+            raw_contract = raw_contract.model_dump(mode="json")
+        if not isinstance(raw_contract, WorkflowMapping):
+            return None
+
+        def _contract_text(*keys: str) -> str:
+            for key in keys:
+                value = raw_contract.get(key)
+                if isinstance(value, str) and value.strip():
+                    return value.strip()
+            return ""
+
+        contract_id = _contract_text("contract_id", "contractId")
+        owner = _contract_text("owner")
+        evidence_kind = _contract_text("evidence_kind", "evidenceKind")
+        relative_path = _contract_text("relative_path", "relativePath")
+        expected_schema_version = _contract_text(
+            "expected_schema_version",
+            "expectedSchemaVersion",
+        )
+        if not all(
+            (
+                contract_id,
+                owner,
+                evidence_kind,
+                relative_path,
+                expected_schema_version,
+            )
+        ):
+            return None
+        return {
+            "contractId": contract_id,
+            "owner": owner,
+            "evidenceKind": evidence_kind,
+            "relativePath": relative_path,
+            "expectedSchemaVersion": expected_schema_version,
+        }
 
     @staticmethod
     def _resolved_skillset_field(resolved: Any, *keys: str) -> Any:
@@ -16721,22 +16792,37 @@ class MoonMindRunWorkflow:
             )
 
         terminal_contract_payload: dict[str, Any] | None = None
-        side_effect = compact_skill_payload.get("sideEffect")
-        if isinstance(side_effect, Mapping):
-            contract_id = str(side_effect.get("terminalContractId") or "").strip()
-            outcome_artifact = str(side_effect.get("outcomeArtifact") or "").strip()
-            expected_schema_version = str(
-                side_effect.get("terminalSchemaVersion") or ""
-            ).strip()
-            if contract_id and outcome_artifact and expected_schema_version:
-                terminal_contract_payload = {
-                    "contractId": contract_id,
-                    "owner": "agent",
-                    "evidenceKind": "workspace_json",
-                    "relativePath": outcome_artifact,
-                    "expectedSchemaVersion": expected_schema_version,
-                    "executionRef": step_execution_payload["stepExecutionId"],
-                }
+        resolved_terminal_contract = (
+            self._resolved_skill_terminal_contract_by_step.get(node_id)
+        )
+        if isinstance(resolved_terminal_contract, Mapping):
+            terminal_contract_payload = {
+                **dict(resolved_terminal_contract),
+                "executionRef": step_execution_payload["stepExecutionId"],
+            }
+        else:
+            side_effect = compact_skill_payload.get("sideEffect")
+            if isinstance(side_effect, Mapping):
+                contract_id = str(
+                    side_effect.get("terminalContractId") or ""
+                ).strip()
+                outcome_artifact = str(
+                    side_effect.get("outcomeArtifact") or ""
+                ).strip()
+                expected_schema_version = str(
+                    side_effect.get("terminalSchemaVersion") or ""
+                ).strip()
+                if contract_id and outcome_artifact and expected_schema_version:
+                    terminal_contract_payload = {
+                        "contractId": contract_id,
+                        "owner": "agent",
+                        "evidenceKind": "workspace_json",
+                        "relativePath": outcome_artifact,
+                        "expectedSchemaVersion": expected_schema_version,
+                        "executionRef": step_execution_payload[
+                            "stepExecutionId"
+                        ],
+                    }
 
         terminal_continuation_authority = None
         if (

--- a/tests/integration/reliability/replays/managed-checkpoint-retry-baseline/expected-outcome.json
+++ b/tests/integration/reliability/replays/managed-checkpoint-retry-baseline/expected-outcome.json
@@ -1,0 +1,5 @@
+{
+  "checkpointStatus": "captured",
+  "checkpointKind": "worktree_archive",
+  "checkpointFailureCode": null
+}

--- a/tests/integration/reliability/replays/managed-checkpoint-retry-baseline/manifest.json
+++ b/tests/integration/reliability/replays/managed-checkpoint-retry-baseline/manifest.json
@@ -1,0 +1,17 @@
+{
+  "failureShapeId": "managed-checkpoint-retry-baseline",
+  "incidentWorkflowId": "resolver:pr:2189:head:4dc317593b0e:h:0c850e615e69fb2d:1",
+  "incidentRunId": "019f65db-6a64-7a93-ac90-0360bdf0f0df",
+  "runtime": "codex_cli",
+  "logicalStepId": "node-1",
+  "completedExecutionOrdinal": 1,
+  "retryExecutionOrdinal": 2,
+  "checkpointBoundary": "before_execution",
+  "eventScript": [
+    "execution_1_completed",
+    "execution_1_after_execution_checkpoint_captured",
+    "execution_2_before_execution_checkpoint_requested",
+    "prior_execution_workspace_authority_validated"
+  ],
+  "invariant": "A terminal execution may provide the same-step workspace baseline for the immediately following before_execution checkpoint"
+}

--- a/tests/integration/reliability/replays/pr-resolver-resolved-terminal-contract/expected-outcome.json
+++ b/tests/integration/reliability/replays/pr-resolver-resolved-terminal-contract/expected-outcome.json
@@ -1,0 +1,7 @@
+{
+  "terminalContractId": "pr_resolver_terminal.v1",
+  "terminalContractPath": "var/pr_resolver/result.json",
+  "terminalContractSchemaVersion": "moonmind.pr-resolver-result.v1",
+  "continuationOwnerWorkflowType": "MoonMind.MergeAutomation",
+  "continuationAction": "reenter_gate"
+}

--- a/tests/integration/reliability/replays/pr-resolver-resolved-terminal-contract/manifest.json
+++ b/tests/integration/reliability/replays/pr-resolver-resolved-terminal-contract/manifest.json
@@ -1,0 +1,48 @@
+{
+  "failureShapeId": "pr-resolver-resolved-terminal-contract",
+  "incidentWorkflowId": "resolver:pr:2189:head:4dc317593b0e:h:0c850e615e69fb2d:1",
+  "incidentRunId": "019f65db-6a64-7a93-ac90-0360bdf0f0df",
+  "parentWorkflowId": "merge-automation:mm:4858fff0-4708-41e3-9465-bb0904bb0b1e:MoonLadderStudios/Tactics:2189:4dc317593b0ec1d855e1d72cd233f23702a31643",
+  "parentRunId": "019f65d7-aba5-7ee5-b869-f5beb627efcb",
+  "logicalStepId": "node-1",
+  "planNodeInputs": {
+    "targetRuntime": "codex_cli",
+    "selectedSkill": "pr-resolver"
+  },
+  "mergeGate": {
+    "parentWorkflowId": "merge-automation:mm:4858fff0-4708-41e3-9465-bb0904bb0b1e:MoonLadderStudios/Tactics:2189:4dc317593b0ec1d855e1d72cd233f23702a31643",
+    "pullRequestUrl": "https://github.com/MoonLadderStudios/Tactics/pull/2189",
+    "headSha": "4dc317593b0ec1d855e1d72cd233f23702a31643"
+  },
+  "resolvedSkillSet": {
+    "snapshot_id": "skillset-resolver-pr-2189",
+    "resolved_at": "2026-07-15T12:58:28.395444Z",
+    "manifest_ref": "art_resolved_skillset_pr_2189",
+    "skills": [
+      {
+        "skill_name": "pr-resolver",
+        "format": "bundle",
+        "content_ref": "art_pr_resolver_bundle",
+        "content_digest": "sha256:7899a83c6a3f345f2bed4bd3bc4ebf414705ef05eff21e9473f434c1c8d3044d",
+        "provenance": {
+          "source_kind": "built_in"
+        },
+        "required_skills": [],
+        "required_capabilities": [
+          "git",
+          "gh"
+        ],
+        "terminal_contract": {
+          "contract_id": "pr_resolver_terminal.v1",
+          "owner": "agent",
+          "evidence_kind": "workspace_json",
+          "relative_path": "var/pr_resolver/result.json",
+          "expected_schema_version": "moonmind.pr-resolver-result.v1"
+        },
+        "selection_reason": "selected",
+        "required_by": []
+      }
+    ]
+  },
+  "invariant": "The selected resolved Skill entry, not optional plan-node metadata, supplies the AgentRun terminal contract"
+}

--- a/tests/integration/reliability/replays/pr-resolver-resolved-terminal-contract/manifest.json
+++ b/tests/integration/reliability/replays/pr-resolver-resolved-terminal-contract/manifest.json
@@ -5,6 +5,7 @@
   "parentWorkflowId": "merge-automation:mm:4858fff0-4708-41e3-9465-bb0904bb0b1e:MoonLadderStudios/Tactics:2189:4dc317593b0ec1d855e1d72cd233f23702a31643",
   "parentRunId": "019f65d7-aba5-7ee5-b869-f5beb627efcb",
   "logicalStepId": "node-1",
+  "existingResolvedSkillsetRef": "art_resolved_skillset_pr_2189",
   "planNodeInputs": {
     "targetRuntime": "codex_cli",
     "selectedSkill": "pr-resolver"

--- a/tests/integration/reliability/test_escaped_failure_journeys.py
+++ b/tests/integration/reliability/test_escaped_failure_journeys.py
@@ -774,6 +774,42 @@ async def test_resolved_pr_resolver_contract_owns_durable_continuation(
         request.terminal_continuation_authority.allowed_actions
     )
 
+    async def read_existing_skillset(*_args: object, **_kwargs: object) -> object:
+        return manifest["resolvedSkillSet"]
+
+    monkeypatch.setattr(
+        run_workflow_module,
+        "execute_typed_activity",
+        read_existing_skillset,
+    )
+    existing_parent = MoonMindRunWorkflow()
+    existing_parent._owner_id = "owner-replay-existing"
+    existing_ref = await existing_parent._resolve_agent_node_skillset_ref(
+        task_skills=None,
+        node_inputs=manifest["planNodeInputs"],
+        node_id=manifest["logicalStepId"],
+        existing_skillset_ref=manifest["existingResolvedSkillsetRef"],
+    )
+    existing_request = existing_parent._build_agent_execution_request(
+        node_inputs=manifest["planNodeInputs"],
+        node_id=manifest["logicalStepId"],
+        tool_name=manifest["planNodeInputs"]["targetRuntime"],
+        resolved_skillset_ref=existing_ref,
+        workflow_parameters={"mergeGate": manifest["mergeGate"]},
+    )
+
+    assert existing_ref == manifest["existingResolvedSkillsetRef"]
+    assert existing_request.terminal_contract is not None
+    assert (
+        existing_request.terminal_contract.contract_id
+        == expected["terminalContractId"]
+    )
+    assert existing_request.terminal_continuation_authority is not None
+    assert (
+        existing_request.terminal_continuation_authority.owner_workflow_type
+        == expected["continuationOwnerWorkflowType"]
+    )
+
 
 @pytest.mark.integration_ci
 async def test_retry_before_execution_captures_terminal_prior_workspace(

--- a/tests/integration/reliability/test_escaped_failure_journeys.py
+++ b/tests/integration/reliability/test_escaped_failure_journeys.py
@@ -700,6 +700,178 @@ async def test_codex_session_record_uses_step_workflow_checkpoint_authority(
     assert capture["workspace"]["kind"] == "worktree_archive"
 
 
+@pytest.mark.integration_ci
+async def test_resolved_pr_resolver_contract_owns_durable_continuation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Replay resolver PR 2189's missing terminal-contract launch payload."""
+
+    replay_id = "pr-resolver-resolved-terminal-contract"
+    manifest = load_replay(replay_id, "manifest.json")
+    expected = load_replay(replay_id, "expected-outcome.json")
+    parent_info = SimpleNamespace(
+        workflow_id=manifest["parentWorkflowId"],
+        run_id=manifest["parentRunId"],
+    )
+    workflow_info = SimpleNamespace(
+        namespace="default",
+        workflow_id=manifest["incidentWorkflowId"],
+        run_id=manifest["incidentRunId"],
+        parent=parent_info,
+        search_attributes={},
+    )
+
+    async def resolve_skillset(*_args: object, **_kwargs: object) -> object:
+        return manifest["resolvedSkillSet"]
+
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "execute_activity",
+        resolve_skillset,
+    )
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "patched",
+        lambda _patch: True,
+    )
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "info",
+        lambda: workflow_info,
+    )
+    parent = MoonMindRunWorkflow()
+    parent._owner_id = "owner-replay"
+    resolved_ref = await parent._resolve_agent_node_skillset_ref(
+        task_skills=None,
+        node_inputs=manifest["planNodeInputs"],
+        node_id=manifest["logicalStepId"],
+        existing_skillset_ref=None,
+    )
+    request = parent._build_agent_execution_request(
+        node_inputs=manifest["planNodeInputs"],
+        node_id=manifest["logicalStepId"],
+        tool_name=manifest["planNodeInputs"]["targetRuntime"],
+        resolved_skillset_ref=resolved_ref,
+        workflow_parameters={"mergeGate": manifest["mergeGate"]},
+    )
+
+    assert request.terminal_contract is not None
+    assert request.terminal_contract.contract_id == expected["terminalContractId"]
+    assert (
+        request.terminal_contract.relative_path
+        == expected["terminalContractPath"]
+    )
+    assert (
+        request.terminal_contract.expected_schema_version
+        == expected["terminalContractSchemaVersion"]
+    )
+    assert request.terminal_continuation_authority is not None
+    assert (
+        request.terminal_continuation_authority.owner_workflow_type
+        == expected["continuationOwnerWorkflowType"]
+    )
+    assert expected["continuationAction"] in (
+        request.terminal_continuation_authority.allowed_actions
+    )
+
+
+@pytest.mark.integration_ci
+async def test_retry_before_execution_captures_terminal_prior_workspace(
+    tmp_path: Path,
+) -> None:
+    """Replay resolver PR 2189's retry checkpoint authority handoff."""
+
+    replay_id = "managed-checkpoint-retry-baseline"
+    manifest = load_replay(replay_id, "manifest.json")
+    expected = load_replay(replay_id, "expected-outcome.json")
+    workspace = tmp_path / manifest["incidentWorkflowId"] / "repo"
+    workspace.mkdir(parents=True)
+    subprocess.run(["git", "init", "-q"], cwd=workspace, check=True)
+    (workspace / "resolver-result.txt").write_text(
+        "first execution requested durable gate continuation\n",
+        encoding="utf-8",
+    )
+    subprocess.run(["git", "add", "."], cwd=workspace, check=True)
+    subprocess.run(
+        [
+            "git", "-c", "user.name=MoonMind Test", "-c",
+            "user.email=test@example.invalid", "commit", "-qm",
+            "checkpoint replay",
+        ],
+        cwd=workspace,
+        check=True,
+    )
+
+    now = datetime.now(timezone.utc)
+    run_store = ManagedRunStore(tmp_path / "managed_runs")
+    run_store.save(
+        ManagedRunRecord(
+            runId=manifest["incidentWorkflowId"],
+            workflowId=f"{manifest['incidentWorkflowId']}:agent:node-1",
+            ownerRunId=manifest["incidentRunId"],
+            logicalStepId=manifest["logicalStepId"],
+            executionOrdinal=manifest["completedExecutionOrdinal"],
+            agentId=manifest["runtime"],
+            runtimeId=manifest["runtime"],
+            status="completed",
+            startedAt=now,
+            finishedAt=now,
+            workspacePath=str(workspace),
+            sessionId=f"sess:{manifest['incidentWorkflowId']}:codex_cli",
+            sessionEpoch=1,
+        )
+    )
+    activities = TemporalAgentRuntimeActivities(
+        run_store=run_store,
+        artifact_service=object(),
+        client_adapter=object(),
+    )
+
+    async def put(payload: bytes, _content_type: str, kind: str) -> str:
+        return f"artifact://{kind}/{hashlib.sha256(payload).hexdigest()}"
+
+    activities._put_managed_checkpoint_artifact = put
+    capabilities = resolve_runtime_execution_capabilities(manifest["runtime"])
+    capture = await activities.agent_runtime_capture_workspace_checkpoint(
+        {
+            "schemaVersion": "v1",
+            "identity": {
+                "workflowId": manifest["incidentWorkflowId"],
+                "runId": manifest["incidentRunId"],
+                "logicalStepId": manifest["logicalStepId"],
+                "executionOrdinal": manifest["retryExecutionOrdinal"],
+            },
+            "boundary": manifest["checkpointBoundary"],
+            "checkpointKind": "worktree_archive",
+            "workspaceLocator": {
+                "kind": "managed_runtime",
+                "runtimeId": manifest["runtime"],
+                "agentRunId": manifest["incidentWorkflowId"],
+                "relativePath": "repo",
+            },
+            "expectedRuntimeId": manifest["runtime"],
+            "capabilitySetVersion": capabilities.capability_set_version,
+            "capabilityDigest": capabilities.capability_digest,
+            "artifactNamespace": "step-checkpoints/node-1",
+            "idempotencyKey": (
+                f"{manifest['incidentWorkflowId']}:{manifest['incidentRunId']}:"
+                f"{manifest['logicalStepId']}:execution:"
+                f"{manifest['retryExecutionOrdinal']}:checkpoint:"
+                "before_execution:capture"
+            ),
+            "capturePolicy": {
+                "includeTracked": True,
+                "includeUntracked": True,
+                "includeIgnored": False,
+                "redactionProfile": "managed-code-workspace-v1",
+            },
+        }
+    )
+
+    assert capture["status"] == expected["checkpointStatus"]
+    assert capture["workspace"]["kind"] == expected["checkpointKind"]
+
+
 async def test_codex_oauth_failure_preserves_primary_error_and_managed_authority(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/workflows/temporal/test_managed_checkpoint_capture.py
+++ b/tests/unit/workflows/temporal/test_managed_checkpoint_capture.py
@@ -523,6 +523,110 @@ async def test_managed_capture_accepts_session_record_bound_to_parent_workflow(
 
 
 @pytest.mark.asyncio
+async def test_managed_capture_accepts_terminal_prior_execution_as_retry_baseline(
+    tmp_path,
+) -> None:
+    repo = tmp_path / "agent-run-1" / "repo"
+    repo.mkdir(parents=True)
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    subprocess.run(
+        [
+            "git", "-c", "user.name=test", "-c",
+            "user.email=test@example.invalid", "commit", "--allow-empty",
+            "-qm", "base",
+        ],
+        cwd=repo,
+        check=True,
+    )
+    now = datetime.now(UTC)
+    store = ManagedRunStore(tmp_path / "managed_runs")
+    store.save(
+        ManagedRunRecord(
+            runId="agent-run-1",
+            workflowId="wf-1",
+            ownerRunId="run-1",
+            logicalStepId="implement",
+            executionOrdinal=1,
+            agentId="codex_cli",
+            runtimeId="codex_cli",
+            status="completed",
+            startedAt=now,
+            finishedAt=now,
+            workspacePath=str(repo),
+        )
+    )
+    activities = TemporalAgentRuntimeActivities(
+        run_store=store, artifact_service=object(), client_adapter=object()
+    )
+
+    async def put(payload: bytes, _content_type: str, _kind: str) -> str:
+        return "artifact://" + hashlib.sha256(payload).hexdigest()
+
+    activities._put_managed_checkpoint_artifact = put
+    request = _request(
+        digest=resolve_runtime_execution_capabilities(
+            "codex_cli"
+        ).capability_digest
+    )
+    request["identity"] = {
+        "workflowId": "wf-1",
+        "runId": "run-1",
+        "logicalStepId": "implement",
+        "executionOrdinal": 2,
+    }
+    request["boundary"] = "before_execution"
+    request["idempotencyKey"] = "checkpoint-2:before_execution:capture"
+
+    result = await activities.agent_runtime_capture_workspace_checkpoint(request)
+
+    assert result["status"] == "captured"
+    assert result["workspace"]["kind"] == "worktree_archive"
+
+
+@pytest.mark.asyncio
+async def test_managed_capture_rejects_active_prior_execution_as_retry_baseline(
+    tmp_path,
+) -> None:
+    repo = tmp_path / "agent-run-1" / "repo"
+    repo.mkdir(parents=True)
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    store = ManagedRunStore(tmp_path / "managed_runs")
+    store.save(
+        ManagedRunRecord(
+            runId="agent-run-1",
+            workflowId="wf-1",
+            ownerRunId="run-1",
+            logicalStepId="implement",
+            executionOrdinal=1,
+            agentId="codex_cli",
+            runtimeId="codex_cli",
+            status="running",
+            startedAt=datetime.now(UTC),
+            workspacePath=str(repo),
+        )
+    )
+    activities = TemporalAgentRuntimeActivities(
+        run_store=store, artifact_service=object(), client_adapter=object()
+    )
+    request = _request(
+        digest=resolve_runtime_execution_capabilities(
+            "codex_cli"
+        ).capability_digest
+    )
+    request["identity"] = {
+        "workflowId": "wf-1",
+        "runId": "run-1",
+        "logicalStepId": "implement",
+        "executionOrdinal": 2,
+    }
+    request["boundary"] = "before_execution"
+    request["idempotencyKey"] = "checkpoint-2:before_execution:capture"
+
+    with pytest.raises(Exception, match="source Step Execution"):
+        await activities.agent_runtime_capture_workspace_checkpoint(request)
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("field", "value"),
     [

--- a/tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py
@@ -27,6 +27,7 @@ from moonmind.schemas.agent_skill_models import (
 from moonmind.workflows.temporal.workflows.run import (
     RUN_ASSESSMENT_PARAMETER_INJECTION_PATCH,
     RUN_CHECKPOINT_BRANCH_TURN_CONTEXT_PATCH,
+    RUN_EXISTING_SKILLSET_TERMINAL_CONTRACT_PATCH,
     RUN_JSON_ARTIFACT_WRITE_COMPLETE_PATCH,
     RUN_OMNIGENT_CHECKPOINT_BRANCH_TURN_REQUEST_PATCH,
     RUN_PR_RESOLVER_SKILL_OWNED_EXECUTION_PATCH,
@@ -226,6 +227,127 @@ class TestSlotContinuityMetadata(unittest.TestCase):
         self.assertEqual(request.parameters, {})
 
 class TestAgentSkillSnapshotResolution(unittest.IsolatedAsyncioTestCase):
+    async def test_existing_resolved_skillset_supplies_owned_terminal_contract(
+        self,
+    ) -> None:
+        wf = MoonMindRunWorkflow()
+        wf._owner_id = "owner-1"
+        existing_ref = "artifact://skillsets/pr-resolver-existing"
+        resolved = ResolvedSkillSet(
+            snapshot_id="skillset-pr-resolver-existing",
+            resolved_at=datetime.now(UTC),
+            skills=[
+                ResolvedSkillEntry(
+                    skill_name="pr-resolver",
+                    provenance=AgentSkillProvenance(
+                        source_kind=AgentSkillSourceKind.BUILT_IN
+                    ),
+                    terminal_contract=SkillTerminalContract(
+                        contract_id="pr_resolver_terminal.v1",
+                        relative_path="var/pr_resolver/result.json",
+                        expected_schema_version=(
+                            "moonmind.pr-resolver-result.v1"
+                        ),
+                    ),
+                )
+            ],
+        )
+        parent = SimpleNamespace(
+            workflow_id="merge-automation:owner",
+            run_id="merge-run-1",
+        )
+        info = SimpleNamespace(
+            namespace="default",
+            workflow_id="resolver:pr:3353",
+            run_id="resolver-run-1",
+            parent=parent,
+        )
+
+        with (
+            patch(
+                "moonmind.workflows.temporal.workflows.run.execute_typed_activity",
+                new=AsyncMock(return_value=resolved.model_dump(mode="json")),
+            ) as read_artifact,
+            patch(
+                "moonmind.workflows.temporal.workflows.run.workflow.patched",
+                return_value=True,
+            ),
+            patch(
+                "moonmind.workflows.temporal.workflows.run.workflow.info",
+                return_value=info,
+            ),
+        ):
+            resolved_ref = await wf._resolve_agent_node_skillset_ref(
+                task_skills=None,
+                node_inputs={"selectedSkill": "pr-resolver"},
+                node_id="node-1",
+                existing_skillset_ref=existing_ref,
+            )
+            request = wf._build_agent_execution_request(
+                node_inputs={
+                    "targetRuntime": "codex_cli",
+                    "selectedSkill": "pr-resolver",
+                },
+                node_id="node-1",
+                tool_name="codex_cli",
+                resolved_skillset_ref=resolved_ref,
+                workflow_parameters={
+                    "mergeGate": {
+                        "parentWorkflowId": parent.workflow_id,
+                        "pullRequestUrl": (
+                            "https://github.com/MoonLadderStudios/MoonMind/pull/3353"
+                        ),
+                    }
+                },
+            )
+
+        self.assertEqual(resolved_ref, existing_ref)
+        read_artifact.assert_awaited_once()
+        self.assertIsNotNone(request.terminal_contract)
+        self.assertEqual(
+            request.terminal_contract.contract_id,
+            "pr_resolver_terminal.v1",
+        )
+        self.assertIsNotNone(request.terminal_continuation_authority)
+        self.assertEqual(
+            request.terminal_continuation_authority.owner_workflow_id,
+            parent.workflow_id,
+        )
+
+    async def test_existing_skillset_history_does_not_add_artifact_read(
+        self,
+    ) -> None:
+        wf = MoonMindRunWorkflow()
+        wf._owner_id = "owner-1"
+        existing_ref = "artifact://skillsets/pr-resolver-existing"
+
+        with (
+            patch(
+                "moonmind.workflows.temporal.workflows.run.execute_typed_activity",
+                new=AsyncMock(),
+            ) as read_artifact,
+            patch(
+                "moonmind.workflows.temporal.workflows.run.workflow.patched",
+                side_effect=lambda patch_id: (
+                    patch_id
+                    != RUN_EXISTING_SKILLSET_TERMINAL_CONTRACT_PATCH
+                ),
+            ),
+        ):
+            resolved_ref = await wf._resolve_agent_node_skillset_ref(
+                task_skills=None,
+                node_inputs={"selectedSkill": "pr-resolver"},
+                node_id="node-1",
+                existing_skillset_ref=existing_ref,
+            )
+
+        self.assertEqual(resolved_ref, existing_ref)
+        read_artifact.assert_not_awaited()
+        self.assertNotIn(
+            "node-1",
+            wf._resolved_skill_terminal_contract_by_step,
+        )
+
     async def test_resolved_skill_terminal_contract_reaches_owned_agent_run(
         self,
     ) -> None:

--- a/tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py
@@ -22,6 +22,7 @@ from moonmind.schemas.agent_skill_models import (
     ResolvedSkillEntry,
     ResolvedSkillSet,
     SkillImplementationContract,
+    SkillTerminalContract,
 )
 from moonmind.workflows.temporal.workflows.run import (
     RUN_ASSESSMENT_PARAMETER_INJECTION_PATCH,
@@ -29,6 +30,7 @@ from moonmind.workflows.temporal.workflows.run import (
     RUN_JSON_ARTIFACT_WRITE_COMPLETE_PATCH,
     RUN_OMNIGENT_CHECKPOINT_BRANCH_TURN_REQUEST_PATCH,
     RUN_PR_RESOLVER_SKILL_OWNED_EXECUTION_PATCH,
+    RUN_RESOLVED_SKILL_TERMINAL_CONTRACT_PATCH,
     RUN_SLOT_CONTINUITY_PATCH,
     RUN_STEP_EXECUTION_NAMING_PATCH,
     RUN_TRUSTED_PR_RESOLVER_NATIVE_BINDING_PATCH,
@@ -224,6 +226,147 @@ class TestSlotContinuityMetadata(unittest.TestCase):
         self.assertEqual(request.parameters, {})
 
 class TestAgentSkillSnapshotResolution(unittest.IsolatedAsyncioTestCase):
+    async def test_resolved_skill_terminal_contract_reaches_owned_agent_run(
+        self,
+    ) -> None:
+        wf = MoonMindRunWorkflow()
+        wf._owner_id = "owner-1"
+        resolved = ResolvedSkillSet(
+            snapshot_id="skillset-pr-resolver",
+            resolved_at=datetime.now(UTC),
+            manifest_ref="artifact://skillsets/pr-resolver",
+            skills=[
+                ResolvedSkillEntry(
+                    skill_name="pr-resolver",
+                    provenance=AgentSkillProvenance(
+                        source_kind=AgentSkillSourceKind.BUILT_IN
+                    ),
+                    terminal_contract=SkillTerminalContract(
+                        contract_id="pr_resolver_terminal.v1",
+                        relative_path="var/pr_resolver/result.json",
+                        expected_schema_version=(
+                            "moonmind.pr-resolver-result.v1"
+                        ),
+                    ),
+                )
+            ],
+        )
+        parent = SimpleNamespace(
+            workflow_id="merge-automation:owner",
+            run_id="merge-run-1",
+        )
+        info = SimpleNamespace(
+            namespace="default",
+            workflow_id="resolver:pr:2189",
+            run_id="resolver-run-1",
+            parent=parent,
+        )
+
+        with (
+            patch(
+                "moonmind.workflows.temporal.workflows.run.workflow.execute_activity",
+                new=AsyncMock(return_value=resolved),
+            ),
+            patch(
+                "moonmind.workflows.temporal.workflows.run.workflow.patched",
+                return_value=True,
+            ),
+            patch(
+                "moonmind.workflows.temporal.workflows.run.workflow.info",
+                return_value=info,
+            ),
+        ):
+            resolved_ref = await wf._resolve_agent_node_skillset_ref(
+                task_skills=None,
+                node_inputs={"selectedSkill": "pr-resolver"},
+                node_id="node-1",
+                existing_skillset_ref=None,
+            )
+            request = wf._build_agent_execution_request(
+                node_inputs={
+                    "targetRuntime": "codex_cli",
+                    "selectedSkill": "pr-resolver",
+                },
+                node_id="node-1",
+                tool_name="codex_cli",
+                resolved_skillset_ref=resolved_ref,
+                workflow_parameters={
+                    "mergeGate": {
+                        "parentWorkflowId": parent.workflow_id,
+                        "pullRequestUrl": (
+                            "https://github.com/MoonLadderStudios/Tactics/pull/2189"
+                        ),
+                    }
+                },
+            )
+
+        self.assertIsNotNone(request.terminal_contract)
+        self.assertEqual(
+            request.terminal_contract.contract_id,
+            "pr_resolver_terminal.v1",
+        )
+        self.assertEqual(
+            request.terminal_contract.execution_ref,
+            "resolver:pr:2189:resolver-run-1:node-1:execution:1",
+        )
+        self.assertIsNotNone(request.terminal_continuation_authority)
+        self.assertEqual(
+            request.terminal_continuation_authority.owner_workflow_id,
+            parent.workflow_id,
+        )
+        self.assertEqual(
+            request.terminal_continuation_authority.owner_run_id,
+            parent.run_id,
+        )
+
+    async def test_existing_history_does_not_change_agent_request_shape(self) -> None:
+        wf = MoonMindRunWorkflow()
+        wf._owner_id = "owner-1"
+        resolved = ResolvedSkillSet(
+            snapshot_id="skillset-pr-resolver",
+            resolved_at=datetime.now(UTC),
+            manifest_ref="artifact://skillsets/pr-resolver",
+            skills=[
+                ResolvedSkillEntry(
+                    skill_name="pr-resolver",
+                    provenance=AgentSkillProvenance(
+                        source_kind=AgentSkillSourceKind.BUILT_IN
+                    ),
+                    terminal_contract=SkillTerminalContract(
+                        contract_id="pr_resolver_terminal.v1",
+                        relative_path="var/pr_resolver/result.json",
+                        expected_schema_version=(
+                            "moonmind.pr-resolver-result.v1"
+                        ),
+                    ),
+                )
+            ],
+        )
+
+        with (
+            patch(
+                "moonmind.workflows.temporal.workflows.run.workflow.execute_activity",
+                new=AsyncMock(return_value=resolved),
+            ),
+            patch(
+                "moonmind.workflows.temporal.workflows.run.workflow.patched",
+                side_effect=lambda patch_id: (
+                    patch_id != RUN_RESOLVED_SKILL_TERMINAL_CONTRACT_PATCH
+                ),
+            ),
+        ):
+            await wf._resolve_agent_node_skillset_ref(
+                task_skills=None,
+                node_inputs={"selectedSkill": "pr-resolver"},
+                node_id="node-1",
+                existing_skillset_ref=None,
+            )
+
+        self.assertNotIn(
+            "node-1",
+            wf._resolved_skill_terminal_contract_by_step,
+        )
+
     async def test_agent_node_resolves_effective_task_and_step_skills_before_launch(self) -> None:
         wf = MoonMindRunWorkflow()
         wf._owner_id = "owner-1"


### PR DESCRIPTION
## Summary

- Forward the selected resolved Skill entry's trusted terminal contract into the AgentRun request, with a Temporal patch marker that preserves replay behavior for existing histories.
- Accept an immediately preceding terminal managed execution as the same-step `before_execution` retry checkpoint baseline while retaining strict workflow, run, step, status, and ordinal checks.
- Add escaped-failure replay fixtures for the exact PR 2189 continuation and checkpoint failure shapes.

## Root cause

The resolved `pr-resolver` snapshot contained the authoritative `pr_resolver_terminal.v1` contract, but the parent workflow only built an AgentRun terminal contract from optional plan-node `skill.sideEffect` metadata. The production plan supplied only `selectedSkill`, so the AgentRun rejected the valid typed `reenter_gate` continuation as unowned and retried the step.

The retry then failed during its pre-execution checkpoint because the managed workspace record still correctly identified the completed first execution, while checkpoint correlation required an exact second-execution ordinal.

## Impact

Resolver runs can now hand a pending merge-gate result back to the owning merge-automation workflow without a false execution failure. If a retry is still required, the prior terminal execution's workspace can safely seed the next execution without weakening cross-workflow workspace authority.

## Validation

- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py tests/unit/workflows/temporal/test_managed_checkpoint_capture.py` — 105 Python tests and 1,088 frontend tests passed.
- `MOONMIND_FORCE_LOCAL_TESTS=1 .venv/bin/pytest tests/integration/reliability/test_escaped_failure_journeys.py -m integration_ci -k 'resolved_pr_resolver_contract or retry_before_execution' -q --tb=short` — 2 passed.
- `./tools/test_integration.sh` — 428 passed, 1 skipped.