### PR TITLE
Fix awaiting-slot runtime and provider profile edits

### DIFF
--- a/frontend/src/entrypoints/workflow-start.test.tsx
+++ b/frontend/src/entrypoints/workflow-start.test.tsx
@@ -1388,7 +1388,7 @@ describe.skip("Task Create Entrypoint", () => {
             json: async () => ({
               workflowId: "mm:edit-123",
               workflowType: "MoonMind.UserWorkflow",
-              state: "executing",
+              state: "awaiting_slot",
               targetRuntime: "claude_code",
               profileId: "profile:claude-default",
               model: "claude-sonnet-test",
@@ -5172,6 +5172,53 @@ describe.skip("Task Create Entrypoint", () => {
       ]),
     );
     window.removeEventListener("moonmind:temporal-task-editing", onTelemetry);
+  });
+
+  it("submits the selected runtime's default profile when editing an awaiting-slot workflow", async () => {
+    renderForEdit("mm:edit-123");
+
+    expect(await screen.findByRole("heading", { name: "Edit Workflow" })).toBeTruthy();
+    await waitFor(() => {
+      expect(
+        (screen.getByLabelText("Provider profile") as HTMLSelectElement).value,
+      ).toBe("profile:claude-default");
+    });
+
+    fireEvent.change(screen.getByLabelText("Runtime"), {
+      target: { value: "codex_cli" },
+    });
+
+    await waitFor(() => {
+      expect(
+        (screen.getByLabelText("Provider profile") as HTMLSelectElement).value,
+      ).toBe("profile:codex-default");
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save Changes" }));
+
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledWith(
+        "/api/executions/mm%3Aedit-123/update",
+        expect.objectContaining({ method: "POST" }),
+      );
+    });
+    const updateCall = fetchSpy.mock.calls
+      .filter(([url]) => String(url) === "/api/executions/mm%3Aedit-123/update")
+      .at(-1);
+    const request = JSON.parse(String(updateCall?.[1]?.body || "{}"));
+    expect(request.parametersPatch).toMatchObject({
+      targetRuntime: "codex_cli",
+      profileId: "profile:codex-default",
+      model: null,
+      requestedModel: null,
+      resolvedModel: null,
+      effort: null,
+      workflow: {
+        runtime: {
+          mode: "codex_cli",
+          profileId: "profile:codex-default",
+        },
+      },
+    });
   });
 
   it("clears persisted merge automation when edit mode deselects the combined publish mode", async () => {

--- a/frontend/src/entrypoints/workflow-start.test.tsx
+++ b/frontend/src/entrypoints/workflow-start.test.tsx
@@ -32,6 +32,7 @@ import {
   previewModelTier,
   deriveExplicitWorkflowTitle,
   resolveDefaultProviderProfileId,
+  resolveLoadedProviderProfileId,
   resolveObjectiveInstructions,
   workflowStartFormSnapshot,
   WORKFLOW_START_HEADING_QUOTES,
@@ -18609,6 +18610,28 @@ describe("resolveDefaultProviderProfileId", () => {
     expect(resolveDefaultProviderProfileId(candidates, "disabled-default")).toBe(
       "high-priority",
     );
+  });
+
+  it("preserves an unavailable saved profile while editing unrelated fields", () => {
+    expect(
+      resolveLoadedProviderProfileId({
+        profiles,
+        providerProfile: "deleted-billing-profile",
+        configuredDefaultRef: "codex",
+        preserveUnavailableProfile: true,
+      }),
+    ).toBe("deleted-billing-profile");
+  });
+
+  it("selects the new runtime default after an explicit runtime switch clears the profile", () => {
+    expect(
+      resolveLoadedProviderProfileId({
+        profiles,
+        providerProfile: "",
+        configuredDefaultRef: "codex",
+        preserveUnavailableProfile: true,
+      }),
+    ).toBe("codex");
   });
 });
 

--- a/frontend/src/entrypoints/workflow-start.tsx
+++ b/frontend/src/entrypoints/workflow-start.tsx
@@ -713,6 +713,26 @@ export function resolveDefaultProviderProfileId(
   );
 }
 
+export function resolveLoadedProviderProfileId({
+  profiles,
+  providerProfile,
+  configuredDefaultRef,
+  preserveUnavailableProfile,
+}: {
+  profiles: ProviderProfile[];
+  providerProfile: string;
+  configuredDefaultRef?: string | null;
+  preserveUnavailableProfile: boolean;
+}): string {
+  if (profiles.some((profile) => profile.profile_id === providerProfile)) {
+    return providerProfile;
+  }
+  if (preserveUnavailableProfile && providerProfile) {
+    return providerProfile;
+  }
+  return resolveDefaultProviderProfileId(profiles, configuredDefaultRef);
+}
+
 interface SkillsResponse {
   items?: {
     worker?: string[];
@@ -6288,26 +6308,15 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
     if (providerProfilesQuery.isLoading || providerProfilesQuery.isFetching) {
       return;
     }
-    if (profiles.length === 0) {
-      if (providerProfile) {
-        setProviderProfile("");
-      }
-      return;
-    }
-
-    const stillValid = profiles.some(
-      (profile) => profile.profile_id === providerProfile,
-    );
-    if (stillValid) {
-      return;
-    }
-
-    const defaultProfileId = resolveDefaultProviderProfileId(
+    const resolvedProfileId = resolveLoadedProviderProfileId({
       profiles,
-      configuredDefaultProviderProfileRef,
-    );
-    if (defaultProfileId && providerProfile !== defaultProfileId) {
-      setProviderProfile(defaultProfileId);
+      providerProfile,
+      configuredDefaultRef: configuredDefaultProviderProfileRef,
+      preserveUnavailableProfile:
+        pageMode.mode !== "create" && Boolean(temporalDraftAppliedRef.current),
+    });
+    if (providerProfile !== resolvedProfileId) {
+      setProviderProfile(resolvedProfileId);
     }
   }, [
     pageMode.mode,

--- a/frontend/src/entrypoints/workflow-start.tsx
+++ b/frontend/src/entrypoints/workflow-start.tsx
@@ -6288,9 +6288,6 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
     if (providerProfilesQuery.isLoading || providerProfilesQuery.isFetching) {
       return;
     }
-    if (pageMode.mode !== "create" && temporalDraftAppliedRef.current) {
-      return;
-    }
     if (profiles.length === 0) {
       if (providerProfile) {
         setProviderProfile("");

--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -341,6 +341,9 @@ STICKY_PINNED_PROFILE_COOLDOWN_RETRY_PATCH_ID = (
 RUNTIME_SELECTION_PROFILE_CLEAR_PATCH_ID = (
     "agent-run-runtime-selection-profile-clear-v1"
 )
+AWAITING_SLOT_RUNTIME_PROFILE_EDIT_PATCH_ID = (
+    "agent-run-awaiting-slot-runtime-profile-edit-v1"
+)
 AGENT_RUN_RESILIENCY_POLICY_PATCH_ID = "agent-run-resiliency-policy-v1"
 AGENT_RUN_CLAUDE_NO_PROGRESS_POLICY_PATCH_ID = (
     "agent-run-claude-code-no-progress-policy-v2"
@@ -2838,6 +2841,29 @@ class MoonMindAgentRun:
             runtime_payload.pop(key, None)
 
     @staticmethod
+    def _drop_runtime_model_fields(runtime_payload: dict[str, Any]) -> None:
+        for key in (
+            "model",
+            "requestedModel",
+            "requested_model",
+            "resolvedModel",
+            "resolved_model",
+            "modelTier",
+            "model_tier",
+            "tierFallback",
+            "tier_fallback",
+            "tierPreview",
+            "modelTierResolution",
+            "modelSource",
+        ):
+            runtime_payload.pop(key, None)
+
+    @staticmethod
+    def _drop_runtime_effort_fields(runtime_payload: dict[str, Any]) -> None:
+        for key in ("effort", "requestedEffort", "requested_effort"):
+            runtime_payload.pop(key, None)
+
+    @staticmethod
     def _has_runtime_profile_field(runtime_payload: Mapping[str, Any]) -> bool:
         return any(
             key in runtime_payload
@@ -2913,13 +2939,20 @@ class MoonMindAgentRun:
         self,
         request: AgentExecutionRequest,
         payload: Mapping[str, Any],
+        *,
+        refresh_derived_selection: bool = False,
     ) -> None:
         previous_runtime_id = self._managed_runtime_id(request.agent_id)
         params = dict(request.parameters or {})
         parameters_patch = payload.get("parametersPatch")
+        editable_runtime_payload_keys = {"task", "authoredTaskInput"}
+        if refresh_derived_selection:
+            editable_runtime_payload_keys.add("authoredWorkflowInput")
         if isinstance(parameters_patch, Mapping):
             for key, value in parameters_patch.items():
-                if key in {"task", "authoredTaskInput"} and isinstance(value, Mapping):
+                if key in editable_runtime_payload_keys and isinstance(
+                    value, Mapping
+                ):
                     existing_payload = self._mapping_copy(params.get(key))
                     runtime_patch = value.get("runtime")
                     if isinstance(runtime_patch, Mapping):
@@ -2939,8 +2972,22 @@ class MoonMindAgentRun:
         task_runtime = self._mapping_copy(task_payload.get("runtime"))
         authored_payload = self._mapping_copy(params.get("authoredTaskInput"))
         authored_runtime = self._mapping_copy(authored_payload.get("runtime"))
+        authored_workflow_payload = (
+            self._mapping_copy(params.get("authoredWorkflowInput"))
+            if refresh_derived_selection
+            else {}
+        )
+        authored_workflow_runtime = self._mapping_copy(
+            authored_workflow_payload.get("runtime")
+        )
         workflow_payload = self._mapping_copy(params.get("workflow"))
         workflow_runtime = self._mapping_copy(workflow_payload.get("runtime"))
+
+        previous_profile_ref = request.execution_profile_ref
+        previous_selector_payload = request.profile_selector.model_dump(
+            by_alias=True,
+            exclude_none=True,
+        )
 
         profile_id = str(payload.get("executionProfileRef") or "").strip()
         explicit_profile_selection_update = self._has_profile_selection_update(
@@ -2956,6 +3003,7 @@ class MoonMindAgentRun:
             params["requestedModel"] = model
             task_runtime["model"] = model
             authored_runtime["model"] = model
+            authored_workflow_runtime["model"] = model
             workflow_runtime["model"] = model
 
         effort = str(payload.get("effort") or "").strip()
@@ -2963,6 +3011,7 @@ class MoonMindAgentRun:
             params["effort"] = effort
             task_runtime["effort"] = effort
             authored_runtime["effort"] = effort
+            authored_workflow_runtime["effort"] = effort
             workflow_runtime["effort"] = effort
 
         target_runtime = str(payload.get("targetRuntime") or "").strip()
@@ -2971,6 +3020,7 @@ class MoonMindAgentRun:
             params["targetRuntime"] = target_runtime
             task_runtime["mode"] = target_runtime
             authored_runtime["mode"] = target_runtime
+            authored_workflow_runtime["mode"] = target_runtime
             workflow_runtime["mode"] = target_runtime
         current_runtime_id = self._managed_runtime_id(request.agent_id)
         runtime_changed = current_runtime_id != previous_runtime_id
@@ -2990,18 +3040,21 @@ class MoonMindAgentRun:
             params["profileId"] = profile_id
             task_runtime["profileId"] = profile_id
             authored_runtime["profileId"] = profile_id
+            authored_workflow_runtime["profileId"] = profile_id
             workflow_runtime["profileId"] = profile_id
         elif runtime_changed:
             request.execution_profile_ref = None
             self._drop_runtime_profile_fields(params)
             self._drop_runtime_profile_fields(task_runtime)
             self._drop_runtime_profile_fields(authored_runtime)
+            self._drop_runtime_profile_fields(authored_workflow_runtime)
             self._drop_runtime_profile_fields(workflow_runtime)
         elif explicit_profile_selection_update:
             request.execution_profile_ref = None
             self._drop_runtime_profile_fields(params)
             self._drop_runtime_profile_fields(task_runtime)
             self._drop_runtime_profile_fields(authored_runtime)
+            self._drop_runtime_profile_fields(authored_workflow_runtime)
             self._drop_runtime_profile_fields(workflow_runtime)
 
         profile_selector_payload = payload.get("profileSelector")
@@ -3056,6 +3109,7 @@ class MoonMindAgentRun:
             params["profileSelector"] = selector_params
             task_runtime["profileSelector"] = selector_params
             authored_runtime["profileSelector"] = selector_params
+            authored_workflow_runtime["profileSelector"] = selector_params
             workflow_runtime["profileSelector"] = selector_params
         elif profile_id:
             request.profile_selector = ProfileSelector()
@@ -3065,6 +3119,8 @@ class MoonMindAgentRun:
             task_runtime.pop("profile_selector", None)
             authored_runtime.pop("profileSelector", None)
             authored_runtime.pop("profile_selector", None)
+            authored_workflow_runtime.pop("profileSelector", None)
+            authored_workflow_runtime.pop("profile_selector", None)
             workflow_runtime.pop("profileSelector", None)
             workflow_runtime.pop("profile_selector", None)
         elif runtime_changed or explicit_profile_selection_update:
@@ -3072,7 +3128,43 @@ class MoonMindAgentRun:
             self._drop_runtime_profile_selector_fields(params)
             self._drop_runtime_profile_selector_fields(task_runtime)
             self._drop_runtime_profile_selector_fields(authored_runtime)
+            self._drop_runtime_profile_selector_fields(authored_workflow_runtime)
             self._drop_runtime_profile_selector_fields(workflow_runtime)
+
+        runtime_or_profile_changed = False
+        if refresh_derived_selection:
+            current_selector_payload = request.profile_selector.model_dump(
+                by_alias=True,
+                exclude_none=True,
+            )
+            profile_selection_changed = (
+                request.execution_profile_ref != previous_profile_ref
+                or current_selector_payload != previous_selector_payload
+            )
+            runtime_or_profile_changed = runtime_changed or profile_selection_changed
+            requested_model_tier = params.get("modelTier")
+            if (
+                runtime_or_profile_changed
+                and not model
+                and requested_model_tier is None
+            ):
+                for runtime_payload in (
+                    params,
+                    task_runtime,
+                    authored_runtime,
+                    authored_workflow_runtime,
+                    workflow_runtime,
+                ):
+                    self._drop_runtime_model_fields(runtime_payload)
+            if runtime_or_profile_changed and not effort:
+                for runtime_payload in (
+                    params,
+                    task_runtime,
+                    authored_runtime,
+                    authored_workflow_runtime,
+                    workflow_runtime,
+                ):
+                    self._drop_runtime_effort_fields(runtime_payload)
 
         if task_runtime or "runtime" in task_payload:
             task_payload["runtime"] = task_runtime
@@ -3080,10 +3172,34 @@ class MoonMindAgentRun:
         if authored_runtime or "runtime" in authored_payload:
             authored_payload["runtime"] = authored_runtime
             params["authoredTaskInput"] = authored_payload
+        if refresh_derived_selection and (
+            authored_workflow_runtime or "runtime" in authored_workflow_payload
+        ):
+            authored_workflow_payload["runtime"] = authored_workflow_runtime
+            params["authoredWorkflowInput"] = authored_workflow_payload
         if workflow_runtime or "runtime" in workflow_payload:
             workflow_payload["runtime"] = workflow_runtime
             params["workflow"] = workflow_payload
         request.parameters = params
+
+        if refresh_derived_selection and request.step_execution is not None:
+            runtime_selection = dict(request.step_execution.runtime_selection)
+            runtime_selection["runtimeId"] = request.agent_id
+            if request.execution_profile_ref:
+                runtime_selection["executionProfileRef"] = (
+                    request.execution_profile_ref
+                )
+            else:
+                runtime_selection.pop("executionProfileRef", None)
+            if model:
+                runtime_selection["model"] = model
+            elif runtime_or_profile_changed:
+                runtime_selection.pop("model", None)
+            if effort:
+                runtime_selection["effort"] = effort
+            elif runtime_or_profile_changed:
+                runtime_selection.pop("effort", None)
+            request.step_execution.runtime_selection = runtime_selection
 
     def _validate_synced_profile_selection(
         self,
@@ -3139,7 +3255,13 @@ class MoonMindAgentRun:
         )
         assigned_profile_id = self._assigned_profile_id
         if payload:
-            self._apply_runtime_selection_update(request, payload)
+            self._apply_runtime_selection_update(
+                request,
+                payload,
+                refresh_derived_selection=workflow.patched(
+                    AWAITING_SLOT_RUNTIME_PROFILE_EDIT_PATCH_ID
+                ),
+            )
         runtime_id = self._managed_runtime_id(request.agent_id)
         manager_id = self._manager_workflow_id(runtime_id)
         selector_payload = request.profile_selector.model_dump(
@@ -3720,6 +3842,38 @@ class MoonMindAgentRun:
                             args=["launching", f"Slot acquired for {runtime_id}"]
                         )
                     request.execution_profile_ref = self._assigned_profile_id
+                    if workflow.patched(
+                        AWAITING_SLOT_RUNTIME_PROFILE_EDIT_PATCH_ID
+                    ):
+                        if request.step_execution is not None:
+                            runtime_selection = dict(
+                                request.step_execution.runtime_selection
+                            )
+                            runtime_selection["runtimeId"] = request.agent_id
+                            if request.execution_profile_ref:
+                                runtime_selection["executionProfileRef"] = (
+                                    request.execution_profile_ref
+                                )
+                            else:
+                                runtime_selection.pop("executionProfileRef", None)
+                            request.step_execution.runtime_selection = runtime_selection
+                        if workflow.patched(AGENT_RUN_RESILIENCY_POLICY_PATCH_ID):
+                            use_extended_claude_no_progress_window = True
+                            if (
+                                self._managed_runtime_id(request.agent_id)
+                                == "claude_code"
+                            ):
+                                use_extended_claude_no_progress_window = (
+                                    workflow.patched(
+                                        AGENT_RUN_CLAUDE_NO_PROGRESS_POLICY_PATCH_ID
+                                    )
+                                )
+                            resiliency_policy = self._resiliency_policy_for_request(
+                                request,
+                                use_extended_claude_no_progress_window=(
+                                    use_extended_claude_no_progress_window
+                                ),
+                            )
 
                     # Notify parent of the assigned profile so it can release the slot
                     # if this child exits in a terminal state (fallback for cancelled

--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -1046,6 +1046,31 @@ class MoonMindAgentRun:
             "retryPolicy": "managed_runtime_polling_with_profile_cooldown",
         }
 
+    def _refresh_selection_after_slot_assignment(
+        self,
+        request: AgentExecutionRequest,
+        *,
+        use_extended_claude_no_progress_window: bool,
+    ) -> dict[str, Any]:
+        """Refresh launch metadata and policy from the assigned selection."""
+
+        if request.step_execution is not None:
+            runtime_selection = dict(request.step_execution.runtime_selection or {})
+            runtime_selection["runtimeId"] = request.agent_id
+            if request.execution_profile_ref:
+                runtime_selection["executionProfileRef"] = (
+                    request.execution_profile_ref
+                )
+            else:
+                runtime_selection.pop("executionProfileRef", None)
+            request.step_execution.runtime_selection = runtime_selection
+        return self._resiliency_policy_for_request(
+            request,
+            use_extended_claude_no_progress_window=(
+                use_extended_claude_no_progress_window
+            ),
+        )
+
     @staticmethod
     def _status_progress_signature(status_obj: AgentRunStatusModel) -> tuple[Any, ...]:
         metadata = status_obj.metadata if isinstance(status_obj.metadata, Mapping) else {}
@@ -3142,7 +3167,31 @@ class MoonMindAgentRun:
                 or current_selector_payload != previous_selector_payload
             )
             runtime_or_profile_changed = runtime_changed or profile_selection_changed
-            requested_model_tier = params.get("modelTier")
+            requested_model_tier = None
+            if isinstance(parameters_patch, Mapping):
+                tier_sources: list[Mapping[str, Any]] = [parameters_patch]
+                runtime_patch = parameters_patch.get("runtime")
+                if isinstance(runtime_patch, Mapping):
+                    tier_sources.append(runtime_patch)
+                for container_key in (
+                    "task",
+                    "authoredTaskInput",
+                    "authoredWorkflowInput",
+                    "workflow",
+                ):
+                    container_patch = parameters_patch.get(container_key)
+                    nested_runtime_patch = (
+                        container_patch.get("runtime")
+                        if isinstance(container_patch, Mapping)
+                        else None
+                    )
+                    if isinstance(nested_runtime_patch, Mapping):
+                        tier_sources.append(nested_runtime_patch)
+                for tier_source in tier_sources:
+                    for tier_key in ("modelTier", "model_tier"):
+                        tier_value = tier_source.get(tier_key)
+                        if tier_value not in (None, ""):
+                            requested_model_tier = tier_value
             if (
                 runtime_or_profile_changed
                 and not model
@@ -3183,7 +3232,7 @@ class MoonMindAgentRun:
         request.parameters = params
 
         if refresh_derived_selection and request.step_execution is not None:
-            runtime_selection = dict(request.step_execution.runtime_selection)
+            runtime_selection = dict(request.step_execution.runtime_selection or {})
             runtime_selection["runtimeId"] = request.agent_id
             if request.execution_profile_ref:
                 runtime_selection["executionProfileRef"] = (
@@ -3845,18 +3894,6 @@ class MoonMindAgentRun:
                     if workflow.patched(
                         AWAITING_SLOT_RUNTIME_PROFILE_EDIT_PATCH_ID
                     ):
-                        if request.step_execution is not None:
-                            runtime_selection = dict(
-                                request.step_execution.runtime_selection
-                            )
-                            runtime_selection["runtimeId"] = request.agent_id
-                            if request.execution_profile_ref:
-                                runtime_selection["executionProfileRef"] = (
-                                    request.execution_profile_ref
-                                )
-                            else:
-                                runtime_selection.pop("executionProfileRef", None)
-                            request.step_execution.runtime_selection = runtime_selection
                         if workflow.patched(AGENT_RUN_RESILIENCY_POLICY_PATCH_ID):
                             use_extended_claude_no_progress_window = True
                             if (
@@ -3868,11 +3905,13 @@ class MoonMindAgentRun:
                                         AGENT_RUN_CLAUDE_NO_PROGRESS_POLICY_PATCH_ID
                                     )
                                 )
-                            resiliency_policy = self._resiliency_policy_for_request(
-                                request,
-                                use_extended_claude_no_progress_window=(
-                                    use_extended_claude_no_progress_window
-                                ),
+                            resiliency_policy = (
+                                self._refresh_selection_after_slot_assignment(
+                                    request,
+                                    use_extended_claude_no_progress_window=(
+                                        use_extended_claude_no_progress_window
+                                    ),
+                                )
                             )
 
                     # Notify parent of the assigned profile so it can release the slot

--- a/tests/unit/workflows/temporal/workflows/test_agent_run_ensure_manager.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_run_ensure_manager.py
@@ -12,7 +12,10 @@ import inspect
 import textwrap
 from types import SimpleNamespace
 
+import pytest
+
 from moonmind.schemas.agent_runtime_models import AgentExecutionRequest
+from moonmind.workflows.temporal.workflows import agent_run as agent_run_module
 from moonmind.workflows.temporal.workflows.agent_run import MoonMindAgentRun
 
 
@@ -377,6 +380,127 @@ class TestEnsureManagerAutoStart:
         )
         assert "profileSelector" not in request.parameters["workflow"]["runtime"]
 
+    def test_runtime_and_profile_edit_replaces_stale_launch_selection(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """Awaiting-slot edits must replace every runtime launch authority."""
+
+        monkeypatch.setattr(agent_run_module.workflow, "patched", lambda _patch: True)
+        workflow_instance = MoonMindAgentRun()
+        request = _agent_request(
+            parameters={
+                "targetRuntime": "codex_cli",
+                "profileId": "codex_openai_oauth",
+                "model": "gpt-5.6-sol",
+                "requestedModel": "gpt-5.6-sol",
+                "resolvedModel": "gpt-5.6-sol",
+                "effort": "high",
+                "modelTierResolution": {
+                    "providerProfileId": "codex_openai_oauth",
+                    "resolvedModel": "gpt-5.6-sol",
+                },
+                "task": {
+                    "runtime": {
+                        "mode": "codex_cli",
+                        "model": "gpt-5.6-sol",
+                        "effort": "high",
+                        "profileId": "codex_openai_oauth",
+                    }
+                },
+                "authoredTaskInput": {
+                    "runtime": {
+                        "mode": "codex_cli",
+                        "model": "gpt-5.6-sol",
+                        "effort": "high",
+                        "profileId": "codex_openai_oauth",
+                    }
+                },
+                "authoredWorkflowInput": {
+                    "runtime": {
+                        "mode": "codex_cli",
+                        "model": "gpt-5.6-sol",
+                        "effort": "high",
+                        "profileId": "codex_openai_oauth",
+                    }
+                },
+                "workflow": {
+                    "runtime": {
+                        "mode": "codex_cli",
+                        "model": "gpt-5.6-sol",
+                        "effort": "high",
+                        "profileId": "codex_openai_oauth",
+                    }
+                },
+            },
+            stepExecution={
+                "schemaVersion": "v1",
+                "workflowId": "mm:runtime-edit",
+                "runId": "run-1",
+                "logicalStepId": "node-1",
+                "executionOrdinal": 1,
+                "stepExecutionId": "mm:runtime-edit:run-1:node-1:execution:1",
+                "runtimeContextPolicy": "fresh_agent_run",
+                "runtimeSelection": {
+                    "runtimeId": "codex_cli",
+                    "model": "gpt-5.6-sol",
+                    "effort": "high",
+                    "executionProfileRef": "codex_openai_oauth",
+                },
+            },
+        )
+
+        workflow_instance._apply_runtime_selection_update(
+            request,
+            {
+                "targetRuntime": "claude_code",
+                "executionProfileRef": "claude_anthropic_oauth",
+                "parametersPatch": {
+                    "targetRuntime": "claude_code",
+                    "profileId": "claude_anthropic_oauth",
+                    "model": None,
+                    "requestedModel": None,
+                    "resolvedModel": None,
+                    "effort": None,
+                    "modelTier": None,
+                    "workflow": {
+                        "runtime": {
+                            "mode": "claude_code",
+                            "profileId": "claude_anthropic_oauth",
+                        }
+                    },
+                },
+            },
+            refresh_derived_selection=True,
+        )
+
+        assert request.agent_id == "claude_code"
+        assert request.execution_profile_ref == "claude_anthropic_oauth"
+        for field in (
+            "model",
+            "requestedModel",
+            "resolvedModel",
+            "effort",
+            "modelTierResolution",
+        ):
+            assert field not in request.parameters
+        for container in (
+            "task",
+            "authoredTaskInput",
+            "authoredWorkflowInput",
+            "workflow",
+        ):
+            runtime = request.parameters[container]["runtime"]
+            assert runtime["mode"] == "claude_code"
+            assert runtime["profileId"] == "claude_anthropic_oauth"
+            assert "model" not in runtime
+            assert "effort" not in runtime
+        assert request.step_execution is not None
+        assert request.step_execution.runtime_selection == {
+            "runtimeId": "claude_code",
+            "executionProfileRef": "claude_anthropic_oauth",
+        }
+
     def test_runtime_selection_update_clears_profile_when_profile_patch_is_empty(
         self,
     ):
@@ -735,6 +859,24 @@ class TestEnsureManagerAutoStart:
                 tuple_assignment_count += 1
 
         assert tuple_assignment_count == 2
+
+    def test_slot_wait_runtime_update_refreshes_launch_policy_after_assignment(self):
+        """Runtime-specific launch policy must follow an awaiting-slot edit."""
+
+        source = textwrap.dedent(inspect.getsource(MoonMindAgentRun.run))
+        assigned_profile_index = source.index(
+            "request.execution_profile_ref = self._assigned_profile_id"
+        )
+        edit_patch_index = source.index(
+            "AWAITING_SLOT_RUNTIME_PROFILE_EDIT_PATCH_ID",
+            assigned_profile_index,
+        )
+        policy_refresh_index = source.index(
+            "resiliency_policy = self._resiliency_policy_for_request(",
+            edit_patch_index,
+        )
+
+        assert assigned_profile_index < edit_patch_index < policy_refresh_index
 
     def test_slot_wait_runtime_update_validates_after_profile_sync(self):
         """Edited exact profiles must fail fast after the refreshed profile snapshot."""

--- a/tests/unit/workflows/temporal/workflows/test_agent_run_ensure_manager.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_run_ensure_manager.py
@@ -396,6 +396,8 @@ class TestEnsureManagerAutoStart:
                 "requestedModel": "gpt-5.6-sol",
                 "resolvedModel": "gpt-5.6-sol",
                 "effort": "high",
+                "modelTier": 4,
+                "tierFallback": "clamp",
                 "modelTierResolution": {
                     "providerProfileId": "codex_openai_oauth",
                     "resolvedModel": "gpt-5.6-sol",
@@ -482,6 +484,8 @@ class TestEnsureManagerAutoStart:
             "resolvedModel",
             "effort",
             "modelTierResolution",
+            "modelTier",
+            "tierFallback",
         ):
             assert field not in request.parameters
         for container in (
@@ -500,6 +504,74 @@ class TestEnsureManagerAutoStart:
             "runtimeId": "claude_code",
             "executionProfileRef": "claude_anthropic_oauth",
         }
+
+    def test_runtime_edit_without_tier_patch_clears_stale_tier_metadata(self):
+        """Automation runtime edits must not inherit the old profile's tier."""
+
+        workflow_instance = MoonMindAgentRun()
+        request = _agent_request(
+            parameters={
+                "targetRuntime": "codex_cli",
+                "modelTier": 4,
+                "tierFallback": "clamp",
+                "requestedModel": "gpt-5.6-sol",
+                "resolvedModel": "gpt-5.6-sol",
+                "modelTierResolution": {"resolvedModel": "gpt-5.6-sol"},
+                "workflow": {
+                    "runtime": {
+                        "mode": "codex_cli",
+                        "modelTier": 4,
+                        "tierFallback": "clamp",
+                        "requestedModel": "gpt-5.6-sol",
+                    }
+                },
+            },
+        )
+
+        workflow_instance._apply_runtime_selection_update(
+            request,
+            {
+                "targetRuntime": "claude_code",
+                "parametersPatch": {
+                    "targetRuntime": "claude_code",
+                    "workflow": {"runtime": {"mode": "claude_code"}},
+                },
+            },
+            refresh_derived_selection=True,
+        )
+
+        for field in (
+            "modelTier",
+            "tierFallback",
+            "requestedModel",
+            "resolvedModel",
+            "modelTierResolution",
+        ):
+            assert field not in request.parameters
+        assert request.parameters["workflow"]["runtime"] == {
+            "mode": "claude_code"
+        }
+
+    def test_runtime_edit_preserves_explicit_nested_model_tier(self):
+        """An explicit tier remains authoritative across a runtime edit."""
+
+        workflow_instance = MoonMindAgentRun()
+        request = _agent_request()
+
+        workflow_instance._apply_runtime_selection_update(
+            request,
+            {
+                "targetRuntime": "claude_code",
+                "parametersPatch": {
+                    "workflow": {
+                        "runtime": {"mode": "claude_code", "modelTier": 2}
+                    }
+                },
+            },
+            refresh_derived_selection=True,
+        )
+
+        assert request.parameters["workflow"]["runtime"]["modelTier"] == 2
 
     def test_runtime_selection_update_clears_profile_when_profile_patch_is_empty(
         self,
@@ -860,23 +932,58 @@ class TestEnsureManagerAutoStart:
 
         assert tuple_assignment_count == 2
 
-    def test_slot_wait_runtime_update_refreshes_launch_policy_after_assignment(self):
-        """Runtime-specific launch policy must follow an awaiting-slot edit."""
+    def test_slot_assignment_refreshes_launch_policy_from_edited_selection(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """Launch policy and step metadata must use the assigned selection."""
 
-        source = textwrap.dedent(inspect.getsource(MoonMindAgentRun.run))
-        assigned_profile_index = source.index(
-            "request.execution_profile_ref = self._assigned_profile_id"
+        workflow_instance = MoonMindAgentRun()
+        request = _agent_request(
+            agentId="claude_code",
+            executionProfileRef="claude_anthropic_oauth",
+            stepExecution={
+                "schemaVersion": "v1",
+                "workflowId": "mm:runtime-edit",
+                "runId": "run-1",
+                "logicalStepId": "node-1",
+                "executionOrdinal": 1,
+                "stepExecutionId": "mm:runtime-edit:run-1:node-1:execution:1",
+                "runtimeContextPolicy": "fresh_agent_run",
+                "runtimeSelection": {},
+            },
         )
-        edit_patch_index = source.index(
-            "AWAITING_SLOT_RUNTIME_PROFILE_EDIT_PATCH_ID",
-            assigned_profile_index,
-        )
-        policy_refresh_index = source.index(
-            "resiliency_policy = self._resiliency_policy_for_request(",
-            edit_patch_index,
+        assert request.step_execution is not None
+        request.step_execution.runtime_selection = None  # type: ignore[assignment]
+        observed: dict[str, object] = {}
+
+        def capture_policy(
+            policy_request: AgentExecutionRequest,
+            *,
+            use_extended_claude_no_progress_window: bool,
+        ) -> dict[str, object]:
+            observed["request"] = policy_request
+            observed["extended"] = use_extended_claude_no_progress_window
+            return {"runtime": policy_request.agent_id}
+
+        monkeypatch.setattr(
+            workflow_instance,
+            "_resiliency_policy_for_request",
+            capture_policy,
         )
 
-        assert assigned_profile_index < edit_patch_index < policy_refresh_index
+        policy = workflow_instance._refresh_selection_after_slot_assignment(
+            request,
+            use_extended_claude_no_progress_window=True,
+        )
+
+        assert policy == {"runtime": "claude_code"}
+        assert observed == {"request": request, "extended": True}
+        assert request.step_execution is not None
+        assert request.step_execution.runtime_selection == {
+            "runtimeId": "claude_code",
+            "executionProfileRef": "claude_anthropic_oauth",
+        }
 
     def test_slot_wait_runtime_update_validates_after_profile_sync(self):
         """Edited exact profiles must fail fast after the refreshed profile snapshot."""


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Re-select and submit a launch-ready provider profile after an active workflow's runtime changes.
- Replace stale model, effort, profile, authored-input, and step-execution runtime metadata before an awaiting-slot child launches.
- Recompute runtime-specific resilience policy after the edited profile slot is assigned.

ELI5: editing a queued workflow previously changed the runtime label but left parts of the old runtime attached to the launch request. The edit now updates the whole launch selection consistently.

## Test Plan

```bash
MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/workflows/test_agent_run_ensure_manager.py tests/unit/workflows/temporal/workflows/test_agent_run_status_payloads.py tests/unit/workflows/temporal/workflows/test_run_signals_updates.py
MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/workflows/test_agent_run_ensure_manager.py tests/unit/workflows/temporal/workflows/test_run_signals_updates.py --ui-args frontend/src/entrypoints/workflow-start.test.tsx
npm run ui:typecheck
npm run ui:lint -- --quiet
```

Validated against the failure shape from workflow `mm:3588d1ee-9f88-4cac-ab76-b58a13f71a91`: Codex CLI / OpenAI OAuth edited to Claude Code / Claude OAuth while awaiting a slot.

## Demo

N/A — behavioral fix with no visual styling change.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / dashboard change
- [x] Runtime / agent adapter change
- [x] Workflow / Temporal change
- [ ] Security / policy / sandboxing change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] Frontend tests added / updated
- [x] Workflow boundary tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## AI assistance

- [ ] No material AI assistance
- [x] AI-assisted or AI-generated contribution

If AI-assisted:

- Tool or workflow used: Codex
- What the AI helped with: Temporal history diagnosis, implementation, regression tests, and PR preparation.
- What I manually reviewed: Workflow history evidence, the complete staged diff, replay gating, and test output.
- What I verified independently: The selected profile reaches the update payload and stale launch selection is removed before dispatch.

I understand that I am responsible for the final submitted change.

## Risk notes

This changes provider-profile and billing-relevant runtime selection at the awaiting-slot handoff. New workflow behavior is protected by `agent-run-awaiting-slot-runtime-profile-edit-v1` so existing histories retain replay compatibility. Runtime/profile values remain exact; no credential or model fallback is introduced.

## Coverage notes

Manual verification used the supplied workflow's parent and child Temporal histories to confirm the original runtime/profile/model mismatch and the launch boundary affected by the fix.

## Changelog

Awaiting-slot workflows can now switch runtime and provider profile without launching with stale runtime settings.
