### PR TITLE
Prevent mixed-runtime managed session retries

### DIFF
--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -11,6 +11,8 @@ from temporalio.workflow import ActivityCancellationType
 from temporalio.common import RetryPolicy
 
 with workflow.unsafe.imports_passed_through():
+    from pydantic import ValidationError
+
     from moonmind.schemas.agent_runtime_models import (
         AgentExecutionRequest,
         AgentRunHandle,
@@ -642,6 +644,7 @@ class MoonMindAgentRun:
         self._terminal_result_payload_compacted_for_history: bool = False
         self.runtime_selection_updated_event = asyncio.Event()
         self._pending_runtime_selection_update: dict[str, Any] | None = None
+        self._managed_session_detached_for_runtime_selection: bool = False
         self._paused: bool = False
 
     @staticmethod
@@ -1736,6 +1739,8 @@ class MoonMindAgentRun:
         parent_info: Any,
     ) -> AgentExecutionRequest:
         if request.managed_session is not None:
+            return request
+        if self._managed_session_detached_for_runtime_selection:
             return request
         if not workflow.patched(MANAGED_SESSION_START_AFTER_SLOT_PATCH_ID):
             return request
@@ -3097,23 +3102,41 @@ class MoonMindAgentRun:
         Runtime-selection edits are accepted while an AgentRun waits for a
         provider slot. A retried step can already carry the workflow-scoped
         managed-session binding from its previous execution, so changing the
-        runtime must detach an incompatible binding before any activity
-        re-validates the request. The adapter-visible Step Execution projection
-        is updated at the same boundary so it never claims the old runtime,
-        profile, model, or effort after the executable request has changed.
+        runtime or credential profile must detach an incompatible binding before
+        any activity re-validates the request. The adapter-visible Step Execution
+        projection is updated at the same boundary so it never claims the old
+        runtime, profile, model, or effort after the executable request has
+        changed.
         """
 
         runtime_id = self._managed_runtime_id(request.agent_id)
         managed_session_runtime_id = canonical_managed_session_runtime_id(
             request.agent_id
         )
+        selected_profile_id = str(request.execution_profile_ref or "").strip()
+        bound_profile_id = str(
+            (
+                request.managed_session.execution_profile_ref
+                if request.managed_session is not None
+                else ""
+            )
+            or ""
+        ).strip()
         detached_managed_session = False
         if (
             request.managed_session is not None
-            and request.managed_session.runtime_id != managed_session_runtime_id
+            and (
+                request.managed_session.runtime_id != managed_session_runtime_id
+                or (
+                    selected_profile_id
+                    and bound_profile_id
+                    and bound_profile_id != selected_profile_id
+                )
+            )
         ):
             request.managed_session = None
             detached_managed_session = True
+            self._managed_session_detached_for_runtime_selection = True
 
         step_execution = request.step_execution
         if step_execution is not None:
@@ -3164,9 +3187,21 @@ class MoonMindAgentRun:
         # Pydantic model. Re-validate the complete payload here, immediately
         # before it can cross an Activity boundary, to catch any future partial
         # runtime-selection mutation at its orchestration source.
-        AgentExecutionRequest.model_validate(
-            request.model_dump(mode="json", by_alias=True)
-        )
+        try:
+            AgentExecutionRequest.model_validate(
+                request.model_dump(mode="json", by_alias=True)
+            )
+        except ValidationError as exc:
+            issue_summary = ", ".join(
+                f"{'.'.join(str(part) for part in issue['loc'])}:{issue['type']}"
+                for issue in exc.errors(include_input=False)
+            )
+            raise ApplicationError(
+                "Runtime selection produced an invalid AgentExecutionRequest "
+                f"({exc.error_count()} validation error(s): {issue_summary}).",
+                type="InvalidRuntimeSelection",
+                non_retryable=True,
+            ) from exc
 
     def _validate_synced_profile_selection(
         self,

--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -341,6 +341,9 @@ STICKY_PINNED_PROFILE_COOLDOWN_RETRY_PATCH_ID = (
 RUNTIME_SELECTION_PROFILE_CLEAR_PATCH_ID = (
     "agent-run-runtime-selection-profile-clear-v1"
 )
+RUNTIME_SELECTION_SESSION_REBIND_PATCH_ID = (
+    "agent-run-runtime-selection-session-rebind-v1"
+)
 AGENT_RUN_RESILIENCY_POLICY_PATCH_ID = "agent-run-resiliency-policy-v1"
 AGENT_RUN_CLAUDE_NO_PROGRESS_POLICY_PATCH_ID = (
     "agent-run-claude-code-no-progress-policy-v2"
@@ -3085,6 +3088,86 @@ class MoonMindAgentRun:
             params["workflow"] = workflow_payload
         request.parameters = params
 
+    def _synchronize_runtime_selection_authority(
+        self,
+        request: AgentExecutionRequest,
+    ) -> None:
+        """Keep session and step runtime evidence aligned with the launch request.
+
+        Runtime-selection edits are accepted while an AgentRun waits for a
+        provider slot. A retried step can already carry the workflow-scoped
+        managed-session binding from its previous execution, so changing the
+        runtime must detach an incompatible binding before any activity
+        re-validates the request. The adapter-visible Step Execution projection
+        is updated at the same boundary so it never claims the old runtime,
+        profile, model, or effort after the executable request has changed.
+        """
+
+        runtime_id = self._managed_runtime_id(request.agent_id)
+        managed_session_runtime_id = canonical_managed_session_runtime_id(
+            request.agent_id
+        )
+        detached_managed_session = False
+        if (
+            request.managed_session is not None
+            and request.managed_session.runtime_id != managed_session_runtime_id
+        ):
+            request.managed_session = None
+            detached_managed_session = True
+
+        step_execution = request.step_execution
+        if step_execution is not None:
+            runtime_selection = dict(step_execution.runtime_selection or {})
+            runtime_selection["runtimeId"] = runtime_id
+            runtime_selection["agentKind"] = request.agent_kind
+
+            parameters = (
+                request.parameters
+                if isinstance(request.parameters, Mapping)
+                else {}
+            )
+            for key, parameter_keys in (
+                ("model", ("model", "requestedModel")),
+                ("effort", ("effort",)),
+            ):
+                value = next(
+                    (
+                        parameters.get(parameter_key)
+                        for parameter_key in parameter_keys
+                        if parameters.get(parameter_key) is not None
+                    ),
+                    None,
+                )
+                if value is None and any(
+                    parameter_key in parameters
+                    for parameter_key in parameter_keys
+                ):
+                    runtime_selection.pop(key, None)
+                elif value is not None:
+                    runtime_selection[key] = value
+
+            if request.execution_profile_ref:
+                runtime_selection["executionProfileRef"] = (
+                    request.execution_profile_ref
+                )
+            else:
+                runtime_selection.pop("executionProfileRef", None)
+
+            step_update: dict[str, Any] = {
+                "runtime_selection": runtime_selection,
+            }
+            if detached_managed_session:
+                step_update["runtime_session_reset"] = None
+            request.step_execution = step_execution.model_copy(update=step_update)
+
+        # Assignment validation is intentionally not enabled on the canonical
+        # Pydantic model. Re-validate the complete payload here, immediately
+        # before it can cross an Activity boundary, to catch any future partial
+        # runtime-selection mutation at its orchestration source.
+        AgentExecutionRequest.model_validate(
+            request.model_dump(mode="json", by_alias=True)
+        )
+
     def _validate_synced_profile_selection(
         self,
         *,
@@ -3140,6 +3223,8 @@ class MoonMindAgentRun:
         assigned_profile_id = self._assigned_profile_id
         if payload:
             self._apply_runtime_selection_update(request, payload)
+            if workflow.patched(RUNTIME_SELECTION_SESSION_REBIND_PATCH_ID):
+                self._synchronize_runtime_selection_authority(request)
         runtime_id = self._managed_runtime_id(request.agent_id)
         manager_id = self._manager_workflow_id(runtime_id)
         selector_payload = request.profile_selector.model_dump(
@@ -3720,6 +3805,10 @@ class MoonMindAgentRun:
                             args=["launching", f"Slot acquired for {runtime_id}"]
                         )
                     request.execution_profile_ref = self._assigned_profile_id
+                    if workflow.patched(
+                        RUNTIME_SELECTION_SESSION_REBIND_PATCH_ID
+                    ):
+                        self._synchronize_runtime_selection_authority(request)
 
                     # Notify parent of the assigned profile so it can release the slot
                     # if this child exits in a terminal state (fallback for cancelled

--- a/tests/integration/reliability/replays/managed-session-runtime-switch/expected-outcome.json
+++ b/tests/integration/reliability/replays/managed-session-runtime-switch/expected-outcome.json
@@ -1,0 +1,14 @@
+{
+  "agentId": "claude_code",
+  "executionProfileRef": "claude_anthropic_oauth",
+  "managedSession": null,
+  "runtimeSessionReset": null,
+  "runtimeSelection": {
+    "runtimeId": "claude_code",
+    "agentKind": "managed",
+    "model": "claude-opus-4-7",
+    "effort": "high",
+    "executionProfileRef": "claude_anthropic_oauth",
+    "skillId": "pr-resolver"
+  }
+}

--- a/tests/integration/reliability/replays/managed-session-runtime-switch/manifest.json
+++ b/tests/integration/reliability/replays/managed-session-runtime-switch/manifest.json
@@ -1,0 +1,72 @@
+{
+  "incidentWorkflowId": "mm:d3ca1354-0d3f-49ea-a5e8-a4598fc98c52",
+  "request": {
+    "agentKind": "managed",
+    "agentId": "codex_cli",
+    "executionProfileRef": "codex_openai_oauth",
+    "correlationId": "mm:d3ca1354-0d3f-49ea-a5e8-a4598fc98c52",
+    "idempotencyKey": "mm:d3ca1354:node-1:execution:2",
+    "managedSession": {
+      "workflowId": "mm:d3ca1354-0d3f-49ea-a5e8-a4598fc98c52:session:codex_cli",
+      "agentRunId": "mm:d3ca1354-0d3f-49ea-a5e8-a4598fc98c52",
+      "sessionId": "sess:mm:d3ca1354-0d3f-49ea-a5e8-a4598fc98c52:codex_cli",
+      "sessionEpoch": 2,
+      "runtimeId": "codex_cli",
+      "executionProfileRef": "codex_openai_oauth"
+    },
+    "stepExecution": {
+      "schemaVersion": "v1",
+      "workflowId": "mm:d3ca1354-0d3f-49ea-a5e8-a4598fc98c52",
+      "runId": "019f66f5-161e-746b-b082-c797ce31d859",
+      "logicalStepId": "node-1",
+      "executionOrdinal": 2,
+      "stepExecutionId": "mm:d3ca1354-0d3f-49ea-a5e8-a4598fc98c52:019f66f5-161e-746b-b082-c797ce31d859:node-1:execution:2",
+      "reason": "runtime_recovered",
+      "runtimeContextPolicy": "fresh_agent_run",
+      "runtimeSelection": {
+        "runtimeId": "codex_cli",
+        "agentKind": "managed",
+        "model": "gpt-5.6-sol",
+        "effort": "high",
+        "executionProfileRef": "codex_openai_oauth",
+        "skillId": "pr-resolver"
+      },
+      "runtimeSessionReset": {
+        "resolvedPolicy": "fresh_agent_run"
+      }
+    },
+    "parameters": {
+      "targetRuntime": "codex_cli",
+      "model": "gpt-5.6-sol",
+      "effort": "high",
+      "profileId": "codex_openai_oauth",
+      "workflow": {
+        "runtime": {
+          "mode": "codex_cli",
+          "model": "gpt-5.6-sol",
+          "effort": "high",
+          "profileId": "codex_openai_oauth"
+        }
+      }
+    }
+  },
+  "runtimeUpdate": {
+    "targetRuntime": "claude_code",
+    "executionProfileRef": "claude_anthropic_oauth",
+    "model": "claude-opus-4-7",
+    "effort": "high",
+    "parametersPatch": {
+      "targetRuntime": "claude_code",
+      "model": "claude-opus-4-7",
+      "effort": "high",
+      "workflow": {
+        "runtime": {
+          "mode": "claude_code",
+          "model": "claude-opus-4-7",
+          "effort": "high",
+          "profileId": "claude_anthropic_oauth"
+        }
+      }
+    }
+  }
+}

--- a/tests/integration/reliability/test_escaped_failure_journeys.py
+++ b/tests/integration/reliability/test_escaped_failure_journeys.py
@@ -73,6 +73,37 @@ pytestmark = [
 ]
 
 
+async def test_runtime_switch_rebinds_managed_session_authority_before_activity() -> (
+    None
+):
+    """Replay mm:d3ca1354 at the AgentRun-to-Activity request boundary."""
+    replay_id = "managed-session-runtime-switch"
+    manifest = load_replay(replay_id, "manifest.json")
+    expected = load_replay(replay_id, "expected-outcome.json")
+    request = AgentExecutionRequest.model_validate(manifest["request"])
+    agent_run = MoonMindAgentRun()
+
+    agent_run._apply_runtime_selection_update(
+        request,
+        manifest["runtimeUpdate"],
+    )
+    agent_run._synchronize_runtime_selection_authority(request)
+    activity_payload = request.model_dump(mode="json", by_alias=True)
+
+    assert activity_payload["agentId"] == expected["agentId"]
+    assert activity_payload["executionProfileRef"] == expected[
+        "executionProfileRef"
+    ]
+    assert activity_payload["managedSession"] is expected["managedSession"]
+    assert activity_payload["stepExecution"]["runtimeSessionReset"] is expected[
+        "runtimeSessionReset"
+    ]
+    assert activity_payload["stepExecution"]["runtimeSelection"] == expected[
+        "runtimeSelection"
+    ]
+    AgentExecutionRequest.model_validate(activity_payload)
+
+
 async def test_oauth_maintenance_lease_replays_through_activity_update_boundary() -> (
     None
 ):

--- a/tests/integration/services/temporal/workflows/test_agent_run.py
+++ b/tests/integration/services/temporal/workflows/test_agent_run.py
@@ -1160,6 +1160,148 @@ async def test_managed_agent_runtime_switch_detaches_incompatible_session_before
 
 
 @pytest.mark.asyncio
+async def test_managed_agent_profile_switch_detaches_existing_session_before_launch():
+    """A queued Codex retry must not reuse a session from the previous profile."""
+    _managed_launch_requests.clear()
+
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        async with (
+            Worker(
+                env.client,
+                task_queue="agent-run-task-queue-session-profile-switch",
+                workflows=[MoonMindAgentRun, RuntimeUpdateProviderProfileManager],
+                workflow_runner=UnsandboxedWorkflowRunner(),
+            ),
+            Worker(
+                env.client,
+                task_queue="mm.activity.artifacts",
+                activities=_COMMON_AGENT_RUN_ACTIVITIES,
+            ),
+            Worker(
+                env.client,
+                task_queue="mm.activity.agent_runtime",
+                activities=_COMMON_AGENT_RUN_ACTIVITIES,
+            ),
+        ):
+            manager_id = "provider-profile-manager:codex_cli"
+            await env.client.start_workflow(
+                RuntimeUpdateProviderProfileManager.run,
+                {
+                    "runtime_id": "codex_cli",
+                    "assignable_profile_id": "alternate-managed",
+                },
+                id=manager_id,
+                task_queue="agent-run-task-queue-session-profile-switch",
+            )
+
+            child_id = "test-agent-session-profile-switch"
+            child_handle = await env.client.start_workflow(
+                MoonMindAgentRun.run,
+                AgentExecutionRequest(
+                    agentKind="managed",
+                    agentId="codex_cli",
+                    executionProfileRef="default-managed",
+                    correlationId="corr-session-profile-switch",
+                    idempotencyKey="idem-session-profile-switch",
+                    managedSession={
+                        "workflowId": "task:session:codex_cli",
+                        "agentRunId": "task",
+                        "sessionId": "sess:task:codex_cli",
+                        "sessionEpoch": 2,
+                        "runtimeId": "codex_cli",
+                        "executionProfileRef": "default-managed",
+                    },
+                    stepExecution={
+                        "schemaVersion": "v1",
+                        "workflowId": "task",
+                        "runId": "run",
+                        "logicalStepId": "node-1",
+                        "executionOrdinal": 2,
+                        "stepExecutionId": "task:run:node-1:execution:2",
+                        "reason": "runtime_recovered",
+                        "runtimeContextPolicy": "fresh_agent_run",
+                        "runtimeSelection": {
+                            "runtimeId": "codex_cli",
+                            "agentKind": "managed",
+                            "model": "gpt-5.6-sol",
+                            "effort": "high",
+                            "executionProfileRef": "default-managed",
+                            "skillId": "pr-resolver",
+                        },
+                        "runtimeSessionReset": {
+                            "resolvedPolicy": "fresh_agent_run",
+                        },
+                    },
+                    parameters={
+                        "targetRuntime": "codex_cli",
+                        "model": "gpt-5.6-sol",
+                        "effort": "high",
+                        "profileId": "default-managed",
+                        "metadata": {
+                            "moonmind": {
+                                "deferManagedSessionUntilSlot": {
+                                    "agentRunId": "task",
+                                }
+                            }
+                        },
+                    },
+                ),
+                id=child_id,
+                task_queue="agent-run-task-queue-session-profile-switch",
+            )
+
+            manager_handle = env.client.get_workflow_handle(manager_id)
+            for _ in range(80):
+                manager_state = await manager_handle.query(
+                    RuntimeUpdateProviderProfileManager.get_state
+                )
+                if manager_state["pending_requests"]:
+                    break
+                await asyncio.sleep(0.1)
+
+            await child_handle.signal(
+                "update_runtime_selection",
+                {
+                    "targetRuntime": "codex_cli",
+                    "executionProfileRef": "alternate-managed",
+                    "parametersPatch": {
+                        "profileId": "alternate-managed",
+                        "workflow": {
+                            "runtime": {
+                                "mode": "codex_cli",
+                                "profileId": "alternate-managed",
+                            }
+                        },
+                    },
+                },
+            )
+
+            for _ in range(80):
+                if _managed_launch_requests:
+                    break
+                await asyncio.sleep(0.1)
+
+            assert _managed_launch_requests, await manager_handle.query(
+                RuntimeUpdateProviderProfileManager.get_state
+            )
+            launched_request = _managed_launch_requests[-1]["request"]
+            assert launched_request["agentId"] == "codex_cli"
+            assert launched_request.get("managedSession") is None
+            assert launched_request["executionProfileRef"] == "alternate-managed"
+            assert launched_request["stepExecution"]["runtimeSessionReset"] is None
+            assert launched_request["stepExecution"]["runtimeSelection"][
+                "executionProfileRef"
+            ] == "alternate-managed"
+
+            await child_handle.signal(
+                MoonMindAgentRun.completion_signal,
+                {"summary": "completed after safe profile switch"},
+            )
+            result = await child_handle.result()
+            assert result.summary == "completed after safe profile switch"
+
+
+@pytest.mark.asyncio
 async def test_managed_agent_model_update_keeps_simultaneously_assigned_slot():
     """Model-only edits racing with slot assignment must keep the acquired slot."""
     _managed_launch_requests.clear()

--- a/tests/integration/services/temporal/workflows/test_agent_run.py
+++ b/tests/integration/services/temporal/workflows/test_agent_run.py
@@ -589,9 +589,17 @@ class RuntimeUpdateProviderProfileManager:
             handle = workflow.get_external_workflow_handle(
                 req["requester_workflow_id"]
             )
+            assigned_profile_id = (
+                req.get("execution_profile_ref")
+                or (
+                    "default-managed"
+                    if self.assignable_profile_id == "*"
+                    else self.assignable_profile_id
+                )
+            )
             await handle.signal(
                 "slot_assigned",
-                {"profile_id": self.assignable_profile_id},
+                {"profile_id": assigned_profile_id},
             )
             await workflow.sleep(3600)
 
@@ -989,6 +997,166 @@ async def test_managed_agent_runtime_selection_update_switches_runtime_manager()
             await child_handle.cancel()
             with pytest.raises(WorkflowFailureError):
                 await child_handle.result()
+
+
+@pytest.mark.asyncio
+async def test_managed_agent_runtime_switch_detaches_incompatible_session_before_launch():
+    """A queued Codex retry switched to Claude must not launch a mixed request."""
+    _managed_launch_requests.clear()
+
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        async with (
+            Worker(
+                env.client,
+                task_queue="agent-run-task-queue-session-runtime-switch",
+                workflows=[MoonMindAgentRun, RuntimeUpdateProviderProfileManager],
+                workflow_runner=UnsandboxedWorkflowRunner(),
+            ),
+            Worker(
+                env.client,
+                task_queue="mm.activity.artifacts",
+                activities=_COMMON_AGENT_RUN_ACTIVITIES,
+            ),
+            Worker(
+                env.client,
+                task_queue="mm.activity.agent_runtime",
+                activities=_COMMON_AGENT_RUN_ACTIVITIES,
+            ),
+        ):
+            codex_manager_id = "provider-profile-manager:codex_cli"
+            claude_manager_id = "provider-profile-manager:claude_code"
+            await env.client.start_workflow(
+                RuntimeUpdateProviderProfileManager.run,
+                {
+                    "runtime_id": "codex_cli",
+                    "assignable_profile_id": "hold-codex-slot",
+                },
+                id=codex_manager_id,
+                task_queue="agent-run-task-queue-session-runtime-switch",
+            )
+            await env.client.start_workflow(
+                RuntimeUpdateProviderProfileManager.run,
+                {
+                    "runtime_id": "claude_code",
+                    "assignable_profile_id": "*",
+                },
+                id=claude_manager_id,
+                task_queue="agent-run-task-queue-session-runtime-switch",
+            )
+
+            child_id = "test-agent-session-runtime-switch"
+            child_handle = await env.client.start_workflow(
+                MoonMindAgentRun.run,
+                AgentExecutionRequest(
+                    agentKind="managed",
+                    agentId="codex_cli",
+                    executionProfileRef="default-managed",
+                    correlationId="corr-session-runtime-switch",
+                    idempotencyKey="idem-session-runtime-switch",
+                    managedSession={
+                        "workflowId": "task:session:codex_cli",
+                        "agentRunId": "task",
+                        "sessionId": "sess:task:codex_cli",
+                        "sessionEpoch": 2,
+                        "runtimeId": "codex_cli",
+                        "executionProfileRef": "default-managed",
+                    },
+                    stepExecution={
+                        "schemaVersion": "v1",
+                        "workflowId": "task",
+                        "runId": "run",
+                        "logicalStepId": "node-1",
+                        "executionOrdinal": 2,
+                        "stepExecutionId": "task:run:node-1:execution:2",
+                        "reason": "runtime_recovered",
+                        "runtimeContextPolicy": "fresh_agent_run",
+                        "runtimeSelection": {
+                            "runtimeId": "codex_cli",
+                            "agentKind": "managed",
+                            "model": "gpt-5.6-sol",
+                            "effort": "high",
+                            "executionProfileRef": "default-managed",
+                            "skillId": "pr-resolver",
+                        },
+                        "runtimeSessionReset": {
+                            "resolvedPolicy": "fresh_agent_run",
+                        },
+                    },
+                    parameters={
+                        "targetRuntime": "codex_cli",
+                        "model": "gpt-5.6-sol",
+                        "effort": "high",
+                        "profileId": "default-managed",
+                    },
+                ),
+                id=child_id,
+                task_queue="agent-run-task-queue-session-runtime-switch",
+            )
+
+            codex_manager_handle = env.client.get_workflow_handle(codex_manager_id)
+            for _ in range(80):
+                codex_state = await codex_manager_handle.query(
+                    RuntimeUpdateProviderProfileManager.get_state
+                )
+                if codex_state["pending_requests"]:
+                    break
+                await asyncio.sleep(0.1)
+
+            await child_handle.signal(
+                "update_runtime_selection",
+                {
+                    "targetRuntime": "claude_code",
+                    "model": "claude-opus-4-7",
+                    "effort": "high",
+                    "parametersPatch": {
+                        "targetRuntime": "claude_code",
+                        "model": "claude-opus-4-7",
+                        "workflow": {
+                            "runtime": {
+                                "mode": "claude_code",
+                            }
+                        },
+                    },
+                },
+            )
+
+            for _ in range(80):
+                if _managed_launch_requests:
+                    break
+                await asyncio.sleep(0.1)
+
+            claude_manager_handle = env.client.get_workflow_handle(
+                claude_manager_id
+            )
+            claude_state = await claude_manager_handle.query(
+                RuntimeUpdateProviderProfileManager.get_state
+            )
+            assert _managed_launch_requests, {
+                "child": str((await child_handle.describe()).status),
+                "codexManager": await codex_manager_handle.query(
+                    RuntimeUpdateProviderProfileManager.get_state
+                ),
+                "claudeManager": claude_state,
+            }
+            launched_request = _managed_launch_requests[-1]["request"]
+            assert launched_request["agentId"] == "claude_code"
+            assert launched_request.get("managedSession") is None
+            assert launched_request["stepExecution"]["runtimeSessionReset"] is None
+            assert launched_request["stepExecution"]["runtimeSelection"] == {
+                "runtimeId": "claude_code",
+                "agentKind": "managed",
+                "model": "claude-opus-4-7",
+                "effort": "high",
+                "executionProfileRef": "default-managed",
+                "skillId": "pr-resolver",
+            }
+
+            await child_handle.signal(
+                MoonMindAgentRun.completion_signal,
+                {"summary": "completed after safe runtime switch"},
+            )
+            result = await child_handle.result()
+            assert result.summary == "completed after safe runtime switch"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py
@@ -2103,6 +2103,9 @@ async def test_agent_run_preserves_operator_profile_selection_after_cooldown_ret
     async def fake_fetch_managed_result(**_kwargs: Any) -> AgentRunResult:
         return fetch_results.pop(0)
 
+    async def fake_wait_condition(*_args: Any, **_kwargs: Any) -> bool:
+        return True
+
     async def fake_execute_routed_activity(
         activity_name: str,
         payload: Any,
@@ -2113,10 +2116,12 @@ async def test_agent_run_preserves_operator_profile_selection_after_cooldown_ret
         raise AssertionError(f"Unexpected routed activity: {activity_name}")
 
     monkeypatch.setattr(agent_run_module, "CodexSessionAdapter", _FakeCodexSessionAdapter)
+    monkeypatch.setattr(agent_run_module, "ManagedAgentAdapter", _FakeCodexSessionAdapter)
     monkeypatch.setattr(run, "_ensure_manager_and_signal", fake_ensure_manager_and_signal)
     monkeypatch.setattr(run, "_sync_manager_profiles", fake_sync_manager_profiles)
     monkeypatch.setattr(run, "_fetch_managed_result", fake_fetch_managed_result)
     monkeypatch.setattr(run, "_execute_routed_activity", fake_execute_routed_activity)
+    monkeypatch.setattr(agent_run_module.workflow, "wait_condition", fake_wait_condition)
     monkeypatch.setattr(
         agent_run_module.workflow,
         "get_external_workflow_handle",

--- a/tests/unit/workflows/temporal/workflows/test_agent_run_ensure_manager.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_run_ensure_manager.py
@@ -331,6 +331,78 @@ class TestEnsureManagerAutoStart:
         assert "profileSelector" not in request.parameters
         assert "profileSelector" not in request.parameters["task"]["runtime"]
 
+    def test_runtime_selection_update_detaches_incompatible_managed_session(self):
+        """Replay mm:d3ca1354: a Codex retry was switched to Claude while queued."""
+        workflow_instance = MoonMindAgentRun()
+        request = _agent_request(
+            managedSession={
+                "workflowId": "mm:d3ca1354:session:codex_cli",
+                "agentRunId": "mm:d3ca1354",
+                "sessionId": "sess:mm:d3ca1354:codex_cli",
+                "sessionEpoch": 2,
+                "runtimeId": "codex_cli",
+                "executionProfileRef": "codex-openrouter",
+            },
+            stepExecution={
+                "schemaVersion": "v1",
+                "workflowId": "mm:d3ca1354",
+                "runId": "replay-run",
+                "logicalStepId": "node-1",
+                "executionOrdinal": 2,
+                "stepExecutionId": "mm:d3ca1354:replay-run:node-1:execution:2",
+                "reason": "runtime_recovered",
+                "runtimeContextPolicy": "fresh_agent_run",
+                "runtimeSelection": {
+                    "runtimeId": "codex_cli",
+                    "agentKind": "managed",
+                    "model": "gpt-5.6-sol",
+                    "effort": "high",
+                    "executionProfileRef": "codex-openrouter",
+                    "skillId": "pr-resolver",
+                },
+                "runtimeSessionReset": {
+                    "resolvedPolicy": "fresh_agent_run",
+                },
+            },
+        )
+
+        workflow_instance._apply_runtime_selection_update(
+            request,
+            {
+                "targetRuntime": "claude_code",
+                "executionProfileRef": "claude-anthropic",
+                "model": "claude-opus-4-7",
+                "effort": "high",
+                "parametersPatch": {
+                    "targetRuntime": "claude_code",
+                    "model": "claude-opus-4-7",
+                    "workflow": {
+                        "runtime": {
+                            "mode": "claude_code",
+                            "profileId": "claude-anthropic",
+                        }
+                    },
+                },
+            },
+        )
+        workflow_instance._synchronize_runtime_selection_authority(request)
+
+        assert request.agent_id == "claude_code"
+        assert request.managed_session is None
+        assert request.step_execution is not None
+        assert request.step_execution.runtime_session_reset is None
+        assert request.step_execution.runtime_selection == {
+            "runtimeId": "claude_code",
+            "agentKind": "managed",
+            "model": "claude-opus-4-7",
+            "effort": "high",
+            "executionProfileRef": "claude-anthropic",
+            "skillId": "pr-resolver",
+        }
+        AgentExecutionRequest.model_validate(
+            request.model_dump(mode="json", by_alias=True)
+        )
+
     def test_runtime_selection_update_clears_profile_when_runtime_changes_without_new_profile(
         self,
     ):

--- a/tests/unit/workflows/temporal/workflows/test_agent_run_ensure_manager.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_run_ensure_manager.py
@@ -12,6 +12,9 @@ import inspect
 import textwrap
 from types import SimpleNamespace
 
+import pytest
+from temporalio.exceptions import ApplicationError
+
 from moonmind.schemas.agent_runtime_models import AgentExecutionRequest
 from moonmind.workflows.temporal.workflows.agent_run import MoonMindAgentRun
 
@@ -402,6 +405,73 @@ class TestEnsureManagerAutoStart:
         AgentExecutionRequest.model_validate(
             request.model_dump(mode="json", by_alias=True)
         )
+
+    def test_runtime_selection_update_detaches_session_for_new_profile(self):
+        """A queued Codex retry must not reuse credentials from its old profile."""
+        workflow_instance = MoonMindAgentRun()
+        request = _agent_request(
+            managedSession={
+                "workflowId": "task:session:codex_cli",
+                "agentRunId": "task",
+                "sessionId": "sess:task:codex_cli",
+                "sessionEpoch": 2,
+                "runtimeId": "codex_cli",
+                "executionProfileRef": "codex-openrouter",
+            },
+            stepExecution={
+                "schemaVersion": "v1",
+                "workflowId": "task",
+                "runId": "run",
+                "logicalStepId": "node-1",
+                "executionOrdinal": 2,
+                "stepExecutionId": "task:run:node-1:execution:2",
+                "reason": "runtime_recovered",
+                "runtimeContextPolicy": "fresh_agent_run",
+                "runtimeSelection": {
+                    "runtimeId": "codex_cli",
+                    "agentKind": "managed",
+                    "executionProfileRef": "codex-openrouter",
+                },
+                "runtimeSessionReset": {
+                    "resolvedPolicy": "fresh_agent_run",
+                },
+            },
+        )
+
+        workflow_instance._apply_runtime_selection_update(
+            request,
+            {
+                "targetRuntime": "codex_cli",
+                "executionProfileRef": "codex-openai",
+            },
+        )
+        workflow_instance._synchronize_runtime_selection_authority(request)
+
+        assert request.managed_session is None
+        assert workflow_instance._managed_session_detached_for_runtime_selection
+        assert request.step_execution is not None
+        assert request.step_execution.runtime_session_reset is None
+        assert request.step_execution.runtime_selection[
+            "executionProfileRef"
+        ] == "codex-openai"
+
+    def test_runtime_selection_validation_is_non_retryable_and_sanitized(self):
+        """Invalid input edits must fail AgentRun instead of looping a workflow task."""
+        workflow_instance = MoonMindAgentRun()
+        request = _agent_request()
+        secret_value = "do-not-include-this-secret"
+
+        workflow_instance._apply_runtime_selection_update(
+            request,
+            {"parametersPatch": {"apiKey": secret_value}},
+        )
+
+        with pytest.raises(ApplicationError) as exc_info:
+            workflow_instance._synchronize_runtime_selection_authority(request)
+
+        assert exc_info.value.type == "InvalidRuntimeSelection"
+        assert exc_info.value.non_retryable is True
+        assert secret_value not in str(exc_info.value)
 
     def test_runtime_selection_update_clears_profile_when_runtime_changes_without_new_profile(
         self,


### PR DESCRIPTION
## What changed

- atomically reconcile `AgentExecutionRequest` runtime authority after an operator runtime-selection edit
- detach an incompatible workflow-scoped managed-session binding before the request crosses an Activity boundary
- update the Step Execution runtime projection with the selected runtime, assigned profile, model, and effort
- validate the fully mutated canonical request before launch
- guard the new workflow behavior with a Temporal patch marker for replay safety
- add a minimized escaped-failure replay for workflow `mm:d3ca1354-0d3f-49ea-a5e8-a4598fc98c52` and a real Temporal runtime-switch boundary test

## Root cause

A retried Codex step reused its existing `managedSession` binding while waiting for a provider slot. An operator input edit then switched the active child to Claude. The slot-routing code updated `agentId` and the provider manager, but retained the Codex session binding and stale Codex Step Execution projection. `agent_runtime.prepare_turn_instructions` revalidated that mixed request and correctly rejected it because `managedSession` is unsupported for `claude_code`.

## Impact

Queued managed retries can now switch runtimes without producing a mixed-runtime request. Runtime metadata remains aligned with the request that actually launches, and future partial mutations fail at the AgentRun orchestration boundary rather than in a downstream Activity.

## Validation

- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/workflows/test_agent_run_ensure_manager.py tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py` — 67 backend tests passed; dashboard suite 1,088 passed and 238 skipped
- escaped-failure replay — 1 passed
- related Temporal runtime-selection tests — 3 passed
- `ruff check --ignore F401` on changed Python files — passed (the integration module retains a pre-existing unused `RPCError` import)
- JSON fixture validation and `git diff --check` — passed
