### PR TITLE
Fix unavailable Omnigent host image tag

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -828,7 +828,7 @@ services:
 
   omnigent-host-claude:
     profiles: ["omnigent-host-claude"]
-    image: ${OMNIGENT_HOST_IMAGE:-ghcr.io/omnigent-ai/omnigent-host}:${OMNIGENT_HOST_IMAGE_TAG:-0.2.11}
+    image: ${OMNIGENT_HOST_IMAGE:-ghcr.io/omnigent-ai/omnigent-host}:${OMNIGENT_HOST_IMAGE_TAG:-latest}
     hostname: omnigent-host-claude
     user: "1000:1000"
     command: ["omnigent", "host", "--server", "http://omnigent:8000", "--non-interactive"]
@@ -867,7 +867,7 @@ services:
 
   omnigent-host-codex-init:
     profiles: ["omnigent-host-codex"]
-    image: ${OMNIGENT_HOST_IMAGE:-ghcr.io/omnigent-ai/omnigent-host}:${OMNIGENT_HOST_IMAGE_TAG:-0.2.11}
+    image: ${OMNIGENT_HOST_IMAGE:-ghcr.io/omnigent-ai/omnigent-host}:${OMNIGENT_HOST_IMAGE_TAG:-latest}
     user: "0:0"
     entrypoint: ["/opt/moonmind/init-codex-oauth-host.sh"]
     environment:
@@ -884,7 +884,7 @@ services:
 
   omnigent-host-codex:
     profiles: ["omnigent-host-codex"]
-    image: ${OMNIGENT_HOST_IMAGE:-ghcr.io/omnigent-ai/omnigent-host}:${OMNIGENT_HOST_IMAGE_TAG:-0.2.11}
+    image: ${OMNIGENT_HOST_IMAGE:-ghcr.io/omnigent-ai/omnigent-host}:${OMNIGENT_HOST_IMAGE_TAG:-latest}
     hostname: omnigent-host-codex
     user: "1000:1000"
     entrypoint: ["/usr/bin/env", "-u", "OPENAI_API_KEY", "-u", "CODEX_ACCESS_TOKEN", "-u", "OPENAI_BASE_URL", "-u", "MINIMAX_API_KEY", "-u", "ANTHROPIC_API_KEY", "-u", "ANTHROPIC_AUTH_TOKEN", "-u", "CLAUDE_API_KEY", "-u", "CLAUDE_CODE_OAUTH_TOKEN", "-u", "GEMINI_API_KEY", "-u", "GOOGLE_API_KEY"]

--- a/moonmind/omnigent/oauth_host_runtime.py
+++ b/moonmind/omnigent/oauth_host_runtime.py
@@ -49,9 +49,17 @@ class OmnigentOAuthHostRuntime:
         workspace_root: Path | None = None,
     ) -> None:
         self._client = client
-        self._image = image or os.getenv(
-            "OMNIGENT_HOST_IMAGE", "ghcr.io/omnigent-ai/omnigent-host:latest"
-        )
+        if image:
+            self._image = image
+        else:
+            base_image = os.getenv(
+                "OMNIGENT_HOST_IMAGE", "ghcr.io/omnigent-ai/omnigent-host"
+            )
+            if "@" in base_image or ":" in base_image.rsplit("/", 1)[-1]:
+                self._image = base_image
+            else:
+                tag = os.getenv("OMNIGENT_HOST_IMAGE_TAG", "latest")
+                self._image = f"{base_image}:{tag}"
         self._network = network or os.getenv(
             "OMNIGENT_HOST_NETWORK", "moonmind_local-network"
         )

--- a/moonmind/omnigent/oauth_host_runtime.py
+++ b/moonmind/omnigent/oauth_host_runtime.py
@@ -50,7 +50,7 @@ class OmnigentOAuthHostRuntime:
     ) -> None:
         self._client = client
         self._image = image or os.getenv(
-            "OMNIGENT_HOST_IMAGE", "ghcr.io/omnigent-ai/omnigent-host:0.2.11"
+            "OMNIGENT_HOST_IMAGE", "ghcr.io/omnigent-ai/omnigent-host:latest"
         )
         self._network = network or os.getenv(
             "OMNIGENT_HOST_NETWORK", "moonmind_local-network"

--- a/tests/integration/temporal/test_compose_foundation.py
+++ b/tests/integration/temporal/test_compose_foundation.py
@@ -500,7 +500,7 @@ def test_omnigent_claude_host_profile_uses_only_canonical_oauth_credentials():
     assert host_service["hostname"] == "omnigent-host-claude"
     assert host_service["image"] == (
         "${OMNIGENT_HOST_IMAGE:-ghcr.io/omnigent-ai/omnigent-host}:"
-        "${OMNIGENT_HOST_IMAGE_TAG:-0.2.11}"
+        "${OMNIGENT_HOST_IMAGE_TAG:-latest}"
     )
     assert host_service["command"] == [
         "omnigent",
@@ -558,9 +558,15 @@ def test_omnigent_claude_host_profile_uses_only_canonical_oauth_credentials():
 def test_omnigent_codex_host_profile_uses_only_canonical_oauth_credentials():
     compose = _load_compose()
     host_service = compose["services"]["omnigent-host-codex"]
+    expected_image = (
+        "${OMNIGENT_HOST_IMAGE:-ghcr.io/omnigent-ai/omnigent-host}:"
+        "${OMNIGENT_HOST_IMAGE_TAG:-latest}"
+    )
 
     assert host_service["profiles"] == ["omnigent-host-codex"]
     assert host_service["hostname"] == "omnigent-host-codex"
+    assert host_service["image"] == expected_image
+    assert compose["services"]["omnigent-host-codex-init"]["image"] == expected_image
     assert host_service["user"] == "1000:1000"
     assert "env_file" not in host_service
     assert _env_map(host_service["environment"]) == {

--- a/tests/unit/omnigent/test_oauth_profile_lifecycle.py
+++ b/tests/unit/omnigent/test_oauth_profile_lifecycle.py
@@ -104,6 +104,14 @@ def _checkpoint() -> OmnigentCheckpointIdentity:
     )
 
 
+def test_oauth_host_runtime_defaults_to_published_image(monkeypatch) -> None:
+    monkeypatch.delenv("OMNIGENT_HOST_IMAGE", raising=False)
+
+    runtime = OmnigentOAuthHostRuntime(client=SimpleNamespace())
+
+    assert runtime._image == "ghcr.io/omnigent-ai/omnigent-host:latest"
+
+
 def test_deterministic_owner_reuses_activity_retry_identity() -> None:
     kwargs = {
         "profile_id": "codex",

--- a/tests/unit/omnigent/test_oauth_profile_lifecycle.py
+++ b/tests/unit/omnigent/test_oauth_profile_lifecycle.py
@@ -106,10 +106,38 @@ def _checkpoint() -> OmnigentCheckpointIdentity:
 
 def test_oauth_host_runtime_defaults_to_published_image(monkeypatch) -> None:
     monkeypatch.delenv("OMNIGENT_HOST_IMAGE", raising=False)
+    monkeypatch.delenv("OMNIGENT_HOST_IMAGE_TAG", raising=False)
 
     runtime = OmnigentOAuthHostRuntime(client=SimpleNamespace())
 
     assert runtime._image == "ghcr.io/omnigent-ai/omnigent-host:latest"
+
+
+def test_oauth_host_runtime_respects_image_tag_override(monkeypatch) -> None:
+    monkeypatch.setenv("OMNIGENT_HOST_IMAGE", "ghcr.io/omnigent-ai/omnigent-host")
+    monkeypatch.setenv("OMNIGENT_HOST_IMAGE_TAG", "0.2.12")
+
+    runtime = OmnigentOAuthHostRuntime(client=SimpleNamespace())
+
+    assert runtime._image == "ghcr.io/omnigent-ai/omnigent-host:0.2.12"
+
+
+@pytest.mark.parametrize(
+    "image",
+    [
+        "localhost:5000/omnigent-host:stable",
+        "ghcr.io/omnigent-ai/omnigent-host@sha256:1234",
+    ],
+)
+def test_oauth_host_runtime_preserves_complete_image_reference(
+    monkeypatch, image: str
+) -> None:
+    monkeypatch.setenv("OMNIGENT_HOST_IMAGE", image)
+    monkeypatch.setenv("OMNIGENT_HOST_IMAGE_TAG", "ignored")
+
+    runtime = OmnigentOAuthHostRuntime(client=SimpleNamespace())
+
+    assert runtime._image == image
 
 
 def test_deterministic_owner_reuses_activity_retry_identity() -> None:


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Replace the nonexistent OmniGent host tag 0.2.11 with the published latest default across the Claude host, Codex host, Codex initialization service, and on-demand OAuth host runtime.
- Keep the default aligned with .env-template and the generic OmniGent host while preserving explicit OMNIGENT_HOST_IMAGE and OMNIGENT_HOST_IMAGE_TAG overrides.
- Add unit and Compose-boundary regression coverage for every affected launch path.

Root cause: the dedicated host services were pinned to a tag that was never published to GHCR, so Docker aborted the entire Compose pull with manifest unknown.

## Test Plan

```bash
MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/omnigent/test_oauth_profile_lifecycle.py
./tools/test_integration.sh
docker compose --env-file /dev/null --profile omnigent-host-claude --profile omnigent-host-codex config --images
docker manifest inspect ghcr.io/omnigent-ai/omnigent-host:latest
```

Results: 12 focused Python tests passed; 65 dashboard files passed with 1,090 tests and 239 skipped; 427 hermetic integration tests passed with 1 skipped; the rendered image resolves to ghcr.io/omnigent-ai/omnigent-host:latest and its multi-architecture manifest is available.

## Demo

N/A — non-visual startup fix.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / dashboard change
- [x] Runtime / agent adapter change
- [ ] Workflow / Temporal change
- [ ] Security / policy / sandboxing change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] Frontend tests added / updated
- [ ] Workflow boundary tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## AI assistance

- [ ] No material AI assistance
- [x] AI-assisted or AI-generated contribution

If AI-assisted:

- Tool or workflow used: Codex
- What the AI helped with: root-cause analysis, implementation, regression tests, validation, and PR preparation
- What I manually reviewed: final diff, rendered Compose image selection, registry manifest result, and test results
- What I verified independently: the unavailable tag fails registry lookup while latest resolves for amd64 and arm64

I understand that I am responsible for the final submitted change.

## Risk notes

This changes the default Docker image selected for OmniGent OAuth hosts. Explicit operator image and tag overrides remain unchanged. No credential, workflow payload, or Temporal history contract changes are involved.

## Coverage notes

Manual verification confirmed all affected Compose profiles render the published latest image and that GHCR exposes its multi-architecture manifest.

## Changelog

Fix local startup failures caused by an unavailable OmniGent host image tag.