### PR TITLE
Fix Omnigent OAuth host working directories

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -831,6 +831,7 @@ services:
     image: ${OMNIGENT_HOST_IMAGE:-ghcr.io/omnigent-ai/omnigent-host}:${OMNIGENT_HOST_IMAGE_TAG:-latest}
     hostname: omnigent-host-claude
     user: "1000:1000"
+    working_dir: /home/app
     command: ["omnigent", "host", "--server", "http://omnigent:8000", "--non-interactive"]
     environment:
       HOME: /home/app
@@ -887,6 +888,7 @@ services:
     image: ${OMNIGENT_HOST_IMAGE:-ghcr.io/omnigent-ai/omnigent-host}:${OMNIGENT_HOST_IMAGE_TAG:-latest}
     hostname: omnigent-host-codex
     user: "1000:1000"
+    working_dir: /home/app
     entrypoint: ["/usr/bin/env", "-u", "OPENAI_API_KEY", "-u", "CODEX_ACCESS_TOKEN", "-u", "OPENAI_BASE_URL", "-u", "MINIMAX_API_KEY", "-u", "ANTHROPIC_API_KEY", "-u", "ANTHROPIC_AUTH_TOKEN", "-u", "CLAUDE_API_KEY", "-u", "CLAUDE_CODE_OAUTH_TOKEN", "-u", "GEMINI_API_KEY", "-u", "GOOGLE_API_KEY"]
     command: ["/opt/moonmind/start-codex-oauth-host.sh"]
     environment:

--- a/moonmind/omnigent/oauth_host_runtime.py
+++ b/moonmind/omnigent/oauth_host_runtime.py
@@ -249,6 +249,8 @@ class OmnigentOAuthHostRuntime:
             container_name,
             "--user",
             "1000:1000",
+            "--workdir",
+            "/home/app",
             "--network",
             self._network,
             "--read-only",

--- a/tests/integration/temporal/test_compose_foundation.py
+++ b/tests/integration/temporal/test_compose_foundation.py
@@ -510,6 +510,7 @@ def test_omnigent_claude_host_profile_uses_only_canonical_oauth_credentials():
         "--non-interactive",
     ]
     assert host_service["user"] == "1000:1000"
+    assert host_service["working_dir"] == "/home/app"
     assert "env_file" not in host_service
 
     host_env = _env_map(host_service["environment"])
@@ -568,6 +569,7 @@ def test_omnigent_codex_host_profile_uses_only_canonical_oauth_credentials():
     assert host_service["image"] == expected_image
     assert compose["services"]["omnigent-host-codex-init"]["image"] == expected_image
     assert host_service["user"] == "1000:1000"
+    assert host_service["working_dir"] == "/home/app"
     assert "env_file" not in host_service
     assert _env_map(host_service["environment"]) == {
         "HOME": "/home/app",
@@ -631,6 +633,7 @@ def test_canonical_omnigent_codex_host_uses_base_owned_oauth_volume():
 
     assert oauth_mount["type"] == "volume"
     assert oauth_mount["source"] == "codex_auth_volume"
+    assert host_service["working_dir"] == "/home/app"
     assert config["volumes"]["codex_auth_volume"]["name"] == "codex_auth_volume"
     assert config["volumes"]["codex_auth_volume"].get("external") is not True
     assert config["volumes"]["omnigent-host-codex-state"].get("name")

--- a/tests/unit/omnigent/test_oauth_profile_lifecycle.py
+++ b/tests/unit/omnigent/test_oauth_profile_lifecycle.py
@@ -253,6 +253,7 @@ async def test_on_demand_host_initializes_state_before_unprivileged_launch(
     assert "/opt/moonmind/init-codex-oauth-host.sh" in commands[1]
     assert commands[2][:3] == ("docker", "run", "-d")
     assert commands[1][commands[1].index("--user") + 1] == "0:0"
+    assert commands[2][commands[2].index("--workdir") + 1] == "/home/app"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- run dedicated Claude and Codex OAuth hosts from the non-root home directory
- apply the same working-directory contract to on-demand Codex OAuth hosts
- cover raw Compose, rendered Compose, and generated Docker launch arguments

## Root cause

The upstream Omnigent host image defaults to `/root` as its working directory. MoonMind launches dedicated OAuth hosts as UID/GID `1000:1000`, so Omnigent failed while probing the project-local config path at `/root/.omnigent/config.yaml` before it could register with the server.

## Impact

Dedicated OAuth hosts can now load Omnigent configuration, complete registration, and reuse their mounted provider OAuth home without a second login.

## Validation

- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/omnigent/test_oauth_profile_lifecycle.py` — 15 passed
- Compose-backed `tests/integration/temporal/test_compose_foundation.py` — 19 passed
- `docker compose config --quiet` — passed
- recreated `omnigent-host-codex` — healthy
- exact-container Codex OAuth preflight — passed
- Omnigent server tunnel — connected as `omnigent-host-codex`

The full `./tools/test_integration.sh` run reached 75% with the changed Compose tests passing, then the test container was killed with exit 137 due to local resource exhaustion. The affected integration file was rerun in isolation and passed.