### PR TITLE
Fix Codex usage-limit classification and session reaping

### DIFF
--- a/docs/ManagedAgents/CodexCliManagedSessions.md
+++ b/docs/ManagedAgents/CodexCliManagedSessions.md
@@ -275,6 +275,12 @@ Codex turns surface provider rate limits through the shared managed-runtime
 failure taxonomy. The controller applies bounded exponential backoff with jitter,
 honors retry hints where available, and keeps attempt evidence bounded.
 
+Codex `token_count.rate_limits.credits` telemetry describes optional purchased
+add-on credits. `has_credits: false` or a zero balance is not evidence that the
+included ChatGPT plan allowance is exhausted. MoonMind classifies exhaustion
+only from an explicit reached-limit signal or an included primary, secondary,
+or individual usage window at 100 percent when no add-on credits are available.
+
 If retries are exhausted, summaries and diagnostics explicitly classify the
 rate-limit failure and set the canonical `AgentRunResult` metadata.
 

--- a/docs/ManagedAgents/ManagedRuntimeCleanup.md
+++ b/docs/ManagedAgents/ManagedRuntimeCleanup.md
@@ -123,10 +123,11 @@ candidateSource:
     moonmind.session_id: required
 truthSource:
   store: ManagedSessionStore
+  temporalOwnerStatus: required for terminal records
   activePredicate: status not in [terminated, degraded, failed]
 eligibility:
   deleteWhen:
-    - session record is absent or terminal
+    - session record is absent, or both the record and Temporal owner are terminal
     - container age >= MOONMIND_MANAGED_SESSION_REAP_GRACE_SECONDS
   forceTerminalWhen:
     - session record is active
@@ -134,6 +135,7 @@ eligibility:
     - or ready session has no activeTurnId beyond max age
 safety:
   failClosedWhenStoreUnavailable: true
+  failClosedWhenTerminalOwnerStatusUnavailable: true
   skipWhenSessionActive: true
   skipWhenYoungerThanGrace: true
 deletionAuthority: DockerCodexManagedSessionController.reap_orphan_session_containers
@@ -340,9 +342,12 @@ The schedule should continue to run every 10 minutes by default. Its activity re
 A managed-session container is eligible for orphan reaping when:
 
 1. it carries the managed-session Docker labels required for ownership discovery;
-2. its session is not active in `ManagedSessionStore`, or its active record was proven stale;
+2. its session record is absent, both its session record and Temporal owner are
+   terminal, or its active record was proven stale;
 3. it is older than the configured grace window unless it is being force-reaped as stale;
-4. the session store was readable for the pass.
+4. the session store was readable for the pass;
+5. a terminal session record is protected when Temporal owner status is
+   non-terminal or unavailable.
 
 A sidecar volume is eligible when:
 

--- a/moonmind/workflows/temporal/runtime/codex_session_runtime.py
+++ b/moonmind/workflows/temporal/runtime/codex_session_runtime.py
@@ -84,9 +84,10 @@ def _is_empty_assistant_failure_reason(value: str | None) -> bool:
         value
         and value.strip().lower() in _EMPTY_ASSISTANT_FAILURE_REASONS
     )
-_CODEX_PROVIDER_CREDITS_EXHAUSTED_REASON = (
-    "Codex provider reported no remaining credits (usage limit reached); "
-    "retry after a profile cooldown or update the provider profile."
+_CODEX_PROVIDER_USAGE_LIMIT_REACHED_REASON = (
+    "Codex provider reported that its usage limit was reached and no additional "
+    "credits are available; retry after a profile cooldown or update the provider "
+    "profile."
 )
 _DIAGNOSTIC_TEXT_MAX_CHARS = 1000
 _RPC_TRACE_MAX_ENTRIES = 80
@@ -1193,13 +1194,35 @@ class CodexManagedSessionRuntime:
         rate_limits = event_payload.get("rate_limits")
         if not isinstance(rate_limits, Mapping):
             return None
+        reached_type = str(
+            rate_limits.get("rate_limit_reached_type") or ""
+        ).strip()
+        if reached_type:
+            return _CODEX_PROVIDER_USAGE_LIMIT_REACHED_REASON
         credits = rate_limits.get("credits")
         if not isinstance(credits, Mapping):
             return None
         has_credits = credits.get("has_credits")
         unlimited = credits.get("unlimited")
-        if has_credits is False and unlimited is not True:
-            return _CODEX_PROVIDER_CREDITS_EXHAUSTED_REASON
+        if has_credits is not False or unlimited is True:
+            return None
+        # ``credits`` describes optional purchased add-on credits. A zero
+        # balance is normal while included ChatGPT plan usage remains. Older
+        # Codex payloads may omit ``rate_limit_reached_type``, so only infer
+        # exhaustion when an included usage window is itself at 100%.
+        for limit_name in ("primary", "secondary", "individual_limit"):
+            limit = rate_limits.get(limit_name)
+            if not isinstance(limit, Mapping):
+                continue
+            used_percent = limit.get("used_percent")
+            if isinstance(used_percent, bool):
+                continue
+            try:
+                exhausted = float(used_percent) >= 100.0
+            except (TypeError, ValueError):
+                exhausted = False
+            if exhausted:
+                return _CODEX_PROVIDER_USAGE_LIMIT_REACHED_REASON
         return None
 
     @staticmethod

--- a/moonmind/workflows/temporal/runtime/managed_session_controller.py
+++ b/moonmind/workflows/temporal/runtime/managed_session_controller.py
@@ -59,7 +59,10 @@ from .github_auth_broker import (
 )
 from .git_auth import build_github_token_git_environment
 from .managed_session_observability import ManagedSessionObservabilityBridge
-from .managed_session_store import ManagedSessionStore
+from .managed_session_store import (
+    TERMINAL_MANAGED_SESSION_STATUSES,
+    ManagedSessionStore,
+)
 from .managed_session_supervisor import ManagedSessionSupervisor
 
 _RUNTIME_MODULE = "moonmind.workflows.temporal.runtime.codex_session_runtime"
@@ -4249,8 +4252,13 @@ class DockerCodexManagedSessionController:
         by_session: dict[str, list[_ManagedSessionContainer]] = {}
         for container in containers:
             by_session.setdefault(container.session_id, []).append(container)
+        all_records = {
+            record.session_id: record for record in self._session_store.iter_all()
+        }
         active_records = {
-            record.session_id: record for record in self._session_store.list_active()
+            session_id: record
+            for session_id, record in all_records.items()
+            if record.status not in TERMINAL_MANAGED_SESSION_STATUSES
         }
         stale_active_session_ids = self._stale_active_session_ids(
             active_records=active_records,
@@ -4259,6 +4267,17 @@ class DockerCodexManagedSessionController:
             now=now,
         )
         active_session_ids = set(active_records) - stale_active_session_ids
+        # A terminal session-store status is not authoritative proof that the
+        # owning Temporal workflow has finished. Provider failures and retry
+        # cooldowns can make the record terminal while the workflow still owns
+        # and polls the container. Protect those containers unless Temporal
+        # positively confirms terminal ownership; lookup failures fail closed.
+        for session_id, record in all_records.items():
+            if record.status not in TERMINAL_MANAGED_SESSION_STATUSES:
+                continue
+            terminal_owner_status = await self._terminal_owner_workflow_status(record)
+            if terminal_owner_status is None:
+                active_session_ids.add(session_id)
 
         skipped_active = 0
         skipped_recent = 0

--- a/moonmind/workflows/temporal/runtime/managed_session_controller.py
+++ b/moonmind/workflows/temporal/runtime/managed_session_controller.py
@@ -4177,11 +4177,11 @@ class DockerCodexManagedSessionController:
     async def _reap_orphan_sidecar_volumes(
         self,
         *,
+        volumes: Sequence[_ManagedSessionSidecarVolume],
         active_session_ids: set[str],
         grace_seconds: float,
         now: datetime,
     ) -> tuple[int, int, int, int]:
-        volumes = await self._list_managed_session_sidecar_volumes()
         if not volumes:
             return (0, 0, 0, 0)
         active_mounts = await self._list_active_docker_volume_mounts()
@@ -4252,6 +4252,11 @@ class DockerCodexManagedSessionController:
         by_session: dict[str, list[_ManagedSessionContainer]] = {}
         for container in containers:
             by_session.setdefault(container.session_id, []).append(container)
+        volumes = await self._list_managed_session_sidecar_volumes()
+        resource_session_ids = set(by_session)
+        resource_session_ids.update(
+            volume.session_id for volume in volumes if volume.session_id
+        )
         all_records = {
             record.session_id: record for record in self._session_store.iter_all()
         }
@@ -4272,7 +4277,10 @@ class DockerCodexManagedSessionController:
         # cooldowns can make the record terminal while the workflow still owns
         # and polls the container. Protect those containers unless Temporal
         # positively confirms terminal ownership; lookup failures fail closed.
-        for session_id, record in all_records.items():
+        for session_id in resource_session_ids:
+            record = all_records.get(session_id)
+            if record is None:
+                continue
             if record.status not in TERMINAL_MANAGED_SESSION_STATUSES:
                 continue
             terminal_owner_status = await self._terminal_owner_workflow_status(record)
@@ -4380,6 +4388,7 @@ class DockerCodexManagedSessionController:
             skipped_active_volumes,
             skipped_recent_volumes,
         ) = await self._reap_orphan_sidecar_volumes(
+            volumes=volumes,
             active_session_ids=active_session_ids,
             grace_seconds=grace_seconds,
             now=now,

--- a/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
+++ b/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
@@ -21,7 +21,7 @@ from moonmind.schemas.managed_session_models import (
 from moonmind.workflows.automation import models as automation_models
 from moonmind.workflows.automation.preflight import CodexPreflightResult
 from moonmind.workflows.temporal.runtime.codex_session_runtime import (
-    _CODEX_PROVIDER_CREDITS_EXHAUSTED_REASON,
+    _CODEX_PROVIDER_USAGE_LIMIT_REACHED_REASON,
     CodexAppServerRpcClient,
     CodexManagedSessionRuntime,
     CodexSessionRuntimeState,
@@ -1202,7 +1202,104 @@ def test_runtime_send_turn_preserves_live_assistant_output_outside_scan_tail(
     assert "failureCause" not in response.metadata
 
 
-def test_runtime_send_turn_classifies_no_credits_token_count_as_provider_failure(
+def test_runtime_send_turn_allows_zero_add_on_credits_with_included_usage_remaining(
+    tmp_path: Path,
+) -> None:
+    request = launch_request(tmp_path)
+    transcript_path = (
+        Path(request.codex_home_path)
+        / "sessions"
+        / "2026"
+        / "04"
+        / "10"
+        / "rollout-2026-04-10T17-55-14-vendor-thread-1.jsonl"
+    )
+    transcript_path.parent.mkdir(parents=True, exist_ok=True)
+    script = write_fake_app_server(
+        tmp_path,
+        assistant_text="Completed with included plan usage.",
+        start_thread_path=str(transcript_path),
+        rollout_entries_on_read=[
+            {
+                "timestamp": "2026-04-10T17:57:54.661Z",
+                "type": "event_msg",
+                "payload": {
+                    "type": "task_started",
+                    "turn_id": "vendor-turn-1",
+                },
+            },
+            {
+                "timestamp": "2026-04-10T17:57:55.100Z",
+                "type": "event_msg",
+                "payload": {
+                    "type": "token_count",
+                    "rate_limits": {
+                        "limit_id": "codex",
+                        "primary": {
+                            "used_percent": 0.0,
+                            "window_minutes": 10080,
+                        },
+                        "credits": {
+                            "has_credits": False,
+                            "unlimited": False,
+                            "balance": "0",
+                        },
+                        "plan_type": "pro",
+                        "rate_limit_reached_type": None,
+                    },
+                },
+            },
+            {
+                "timestamp": "2026-04-10T17:57:55.661Z",
+                "type": "event_msg",
+                "payload": {
+                    "type": "task_complete",
+                    "turn_id": "vendor-turn-1",
+                    "last_agent_message": None,
+                },
+            },
+        ],
+    )
+    runtime = CodexManagedSessionRuntime(
+        workspace_path=request.workspace_path,
+        session_workspace_path=request.session_workspace_path,
+        artifact_spool_path=request.artifact_spool_path,
+        codex_home_path=request.codex_home_path,
+        image_ref=request.image_ref,
+        control_url="docker-exec://mm-codex-session-sess-1",
+        container_id="ctr-1",
+        app_server_command=("python3", str(script)),
+    )
+    runtime.launch_session(request)
+
+    response = runtime.send_turn(
+        SendCodexManagedSessionTurnRequest(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            containerId="ctr-1",
+            threadId="logical-thread-1",
+            instructions="Reply with exactly the word OK",
+        )
+    )
+
+    assert response.status == "completed"
+    assert response.turn_id == "vendor-turn-1"
+    assert response.metadata["assistantText"] == "Completed with included plan usage."
+    assert "failureClass" not in response.metadata
+    handle = runtime.session_status(
+        CodexManagedSessionLocator(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            containerId="ctr-1",
+            threadId="logical-thread-1",
+        )
+    )
+    assert handle.status == "ready"
+    assert "failureClass" not in handle.metadata
+    assert "lastTurnError" not in handle.metadata
+
+
+def test_runtime_send_turn_classifies_exhausted_included_usage_window(
     tmp_path: Path,
 ) -> None:
     request = launch_request(tmp_path)
@@ -1234,12 +1331,15 @@ def test_runtime_send_turn_classifies_no_credits_token_count_as_provider_failure
                 "payload": {
                     "type": "token_count",
                     "rate_limits": {
-                        "limit_id": "premium",
+                        "limit_id": "codex",
+                        "primary": {"used_percent": 100.0},
                         "credits": {
                             "has_credits": False,
                             "unlimited": False,
-                            "balance": None,
+                            "balance": "0",
                         },
+                        "plan_type": "pro",
+                        "rate_limit_reached_type": None,
                     },
                 },
             },
@@ -1279,7 +1379,7 @@ def test_runtime_send_turn_classifies_no_credits_token_count_as_provider_failure
     assert response.status == "failed"
     assert response.turn_id == "vendor-turn-1"
     assert response.metadata == {
-        "reason": _CODEX_PROVIDER_CREDITS_EXHAUSTED_REASON,
+        "reason": _CODEX_PROVIDER_USAGE_LIMIT_REACHED_REASON,
         "failureClass": "integration_error",
     }
     handle = runtime.session_status(
@@ -1292,8 +1392,28 @@ def test_runtime_send_turn_classifies_no_credits_token_count_as_provider_failure
     )
     assert handle.status == "failed"
     assert handle.metadata["failureClass"] == "integration_error"
-    assert handle.metadata["lastTurnError"] == _CODEX_PROVIDER_CREDITS_EXHAUSTED_REASON
+    assert (
+        handle.metadata["lastTurnError"]
+        == _CODEX_PROVIDER_USAGE_LIMIT_REACHED_REASON
+    )
     assert "retryRecommendedAction" not in response.metadata
+
+
+def test_runtime_provider_failure_reason_honors_explicit_reached_type() -> None:
+    reason = CodexManagedSessionRuntime._provider_failure_reason_from_rollout_event(
+        {
+            "type": "token_count",
+            "rate_limits": {
+                "limit_id": "codex",
+                "primary": {"used_percent": 99.0},
+                "credits": None,
+                "rate_limit_reached_type": "primary",
+            },
+        }
+    )
+
+    assert reason == _CODEX_PROVIDER_USAGE_LIMIT_REACHED_REASON
+
 
 def test_runtime_send_turn_recovers_usage_limit_from_recent_log_for_empty_task_complete(
     tmp_path: Path,

--- a/tests/unit/services/temporal/runtime/test_managed_session_controller.py
+++ b/tests/unit/services/temporal/runtime/test_managed_session_controller.py
@@ -5745,6 +5745,80 @@ async def test_controller_reap_protects_terminal_record_when_owner_lookup_fails(
 
 
 @pytest.mark.asyncio
+async def test_controller_reap_limits_owner_lookups_to_sessions_with_resources(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.delenv("MOONMIND_MANAGED_SESSION_REAP_ENABLED", raising=False)
+    store = ManagedSessionStore(tmp_path / "session-store")
+    volume_owner = _reap_active_record("sess-volume-owner")
+    volume_owner.agent_run_id = "workflow-volume-owner"
+    volume_owner.status = "failed"
+    retained_without_resources = _reap_active_record("sess-retained")
+    retained_without_resources.agent_run_id = "workflow-retained"
+    retained_without_resources.status = "failed"
+    store.save(volume_owner)
+    store.save(retained_without_resources)
+
+    owner_lookups: list[str] = []
+
+    async def _owner_workflow_status(workflow_id: str) -> str:
+        owner_lookups.append(workflow_id)
+        if workflow_id == "workflow-retained":
+            raise AssertionError("resource-free records must not query Temporal")
+        return "RUNNING"
+
+    async def _fake_runner(
+        command: tuple[str, ...],
+        *,
+        input_text: str | None = None,
+        env: dict[str, str] | None = None,
+    ) -> tuple[int, str, str]:
+        if command[:2] == ("docker", "ps") and command != ("docker", "ps", "-q"):
+            return 0, "", ""
+        if command[:4] == ("docker", "volume", "ls", "--format"):
+            return 0, "moonmind-session-sess-volume-owner-docker-graph\n", ""
+        if command[:3] == ("docker", "volume", "inspect"):
+            return (
+                0,
+                json.dumps(
+                    [
+                        {
+                            "Name": "moonmind-session-sess-volume-owner-docker-graph",
+                            "CreatedAt": "2020-01-01T00:00:00Z",
+                            "Labels": {
+                                "moonmind.session_id": "sess-volume-owner",
+                                "moonmind.volume_role": "docker-graph",
+                                "moonmind.kind": "session-docker-sidecar-volume",
+                            },
+                        }
+                    ]
+                ),
+                "",
+            )
+        if command == ("docker", "ps", "-q"):
+            return 0, "", ""
+        raise AssertionError(f"protected volume must not be removed: {command}")
+
+    controller = DockerCodexManagedSessionController(
+        workspace_volume_name="agent_workspaces",
+        codex_volume_name="codex_auth_volume",
+        workspace_root="/tmp/agent_jobs",
+        session_store=store,
+        command_runner=_fake_runner,
+        owner_workflow_status_resolver=_owner_workflow_status,
+    )
+
+    result = await controller.reap_orphan_session_containers()
+
+    assert owner_lookups == ["workflow-volume-owner"]
+    assert result.scanned_containers == 0
+    assert result.scanned_volumes == 1
+    assert result.reaped_volumes == 0
+    assert result.skipped_active_volumes == 1
+
+
+@pytest.mark.asyncio
 async def test_controller_reaps_stale_ready_session_after_max_age(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/unit/services/temporal/runtime/test_managed_session_controller.py
+++ b/tests/unit/services/temporal/runtime/test_managed_session_controller.py
@@ -5624,6 +5624,127 @@ async def test_controller_reaps_orphan_session_containers_and_skips_active(
 
 
 @pytest.mark.asyncio
+async def test_controller_reap_protects_terminal_record_until_owner_is_terminal(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.delenv("MOONMIND_MANAGED_SESSION_REAP_ENABLED", raising=False)
+    monkeypatch.delenv("MOONMIND_MANAGED_SESSION_REAP_GRACE_SECONDS", raising=False)
+    store = ManagedSessionStore(tmp_path / "session-store")
+    running_owner = _reap_active_record("sess-running-owner")
+    running_owner.agent_run_id = "workflow-running"
+    running_owner.status = "failed"
+    terminal_owner = _reap_active_record("sess-terminal-owner")
+    terminal_owner.agent_run_id = "workflow-completed"
+    terminal_owner.status = "failed"
+    store.save(running_owner)
+    store.save(terminal_owner)
+
+    async def _owner_workflow_status(workflow_id: str) -> str:
+        return {
+            "workflow-running": "RUNNING",
+            "workflow-completed": "COMPLETED",
+        }[workflow_id]
+
+    commands: list[tuple[str, ...]] = []
+
+    async def _fake_runner(
+        command: tuple[str, ...],
+        *,
+        input_text: str | None = None,
+        env: dict[str, str] | None = None,
+    ) -> tuple[int, str, str]:
+        commands.append(command)
+        if command[:2] == ("docker", "ps"):
+            return 0, "c-running\nc-completed\n", ""
+        if command[:3] == ("docker", "inspect", "--format"):
+            return (
+                0,
+                "c-running|sess-running-owner|managed-session"
+                "|2020-01-01T00:00:00Z\n"
+                "c-completed|sess-terminal-owner|managed-session"
+                "|2020-01-01T00:00:00Z\n",
+                "",
+            )
+        if command[:3] == ("docker", "rm", "-f"):
+            if command[-1].startswith("moonmind-session-"):
+                return 1, "", "No such container"
+            return 0, "", ""
+        if command[:4] == ("docker", "volume", "rm", "-f"):
+            return 0, "", ""
+        if command[:4] == ("docker", "volume", "ls", "--format"):
+            return 0, "", ""
+        raise AssertionError(f"unexpected command: {command}")
+
+    controller = DockerCodexManagedSessionController(
+        workspace_volume_name="agent_workspaces",
+        codex_volume_name="codex_auth_volume",
+        workspace_root="/tmp/agent_jobs",
+        session_store=store,
+        command_runner=_fake_runner,
+        owner_workflow_status_resolver=_owner_workflow_status,
+    )
+
+    result = await controller.reap_orphan_session_containers()
+
+    assert result.reaped_session_ids == ("sess-terminal-owner",)
+    assert result.reaped_containers == 1
+    assert result.skipped_active == 1
+    removed = {cmd[-1] for cmd in commands if cmd[:3] == ("docker", "rm", "-f")}
+    assert "c-completed" in removed
+    assert "c-running" not in removed
+
+
+@pytest.mark.asyncio
+async def test_controller_reap_protects_terminal_record_when_owner_lookup_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.delenv("MOONMIND_MANAGED_SESSION_REAP_ENABLED", raising=False)
+    store = ManagedSessionStore(tmp_path / "session-store")
+    record = _reap_active_record("sess-lookup-failed")
+    record.status = "failed"
+    store.save(record)
+
+    async def _owner_workflow_status(_workflow_id: str) -> str:
+        raise RuntimeError("Temporal unavailable")
+
+    async def _fake_runner(
+        command: tuple[str, ...],
+        *,
+        input_text: str | None = None,
+        env: dict[str, str] | None = None,
+    ) -> tuple[int, str, str]:
+        if command[:2] == ("docker", "ps"):
+            return 0, "c-failed\n", ""
+        if command[:3] == ("docker", "inspect", "--format"):
+            return (
+                0,
+                "c-failed|sess-lookup-failed|managed-session"
+                "|2020-01-01T00:00:00Z\n",
+                "",
+            )
+        if command[:4] == ("docker", "volume", "ls", "--format"):
+            return 0, "", ""
+        raise AssertionError(f"protected session must not be removed: {command}")
+
+    controller = DockerCodexManagedSessionController(
+        workspace_volume_name="agent_workspaces",
+        codex_volume_name="codex_auth_volume",
+        workspace_root="/tmp/agent_jobs",
+        session_store=store,
+        command_runner=_fake_runner,
+        owner_workflow_status_resolver=_owner_workflow_status,
+    )
+
+    result = await controller.reap_orphan_session_containers()
+
+    assert result.skipped_active == 1
+    assert result.reaped_containers == 0
+    assert result.reaped_session_ids == ()
+
+
+@pytest.mark.asyncio
 async def test_controller_reaps_stale_ready_session_after_max_age(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/unit/workflows/adapters/test_codex_session_adapter.py
+++ b/tests/unit/workflows/adapters/test_codex_session_adapter.py
@@ -49,7 +49,7 @@ from moonmind.workflows.temporal.managed_session_errors import (
     is_managed_session_locator_mismatch_error,
 )
 from moonmind.workflows.temporal.runtime.codex_session_runtime import (
-    _CODEX_PROVIDER_CREDITS_EXHAUSTED_REASON,
+    _CODEX_PROVIDER_USAGE_LIMIT_REACHED_REASON,
 )
 from moonmind.workflows.temporal.runtime.store import ManagedRunStore
 
@@ -2389,7 +2389,7 @@ async def test_start_recovers_after_second_empty_assistant_clear(
     ]
 
 
-async def test_start_does_not_clear_session_for_codex_no_credits_failure(
+async def test_start_does_not_clear_session_for_codex_usage_limit_failure(
     tmp_path: Path,
 ) -> None:
     binding = _binding()
@@ -2416,7 +2416,7 @@ async def test_start_does_not_clear_session_for_codex_no_credits_failure(
     async def _send_turn(request: Any) -> CodexManagedSessionTurnResponse:
         send_turn_calls.append(request)
         metadata = {
-            "reason": _CODEX_PROVIDER_CREDITS_EXHAUSTED_REASON,
+            "reason": _CODEX_PROVIDER_USAGE_LIMIT_REACHED_REASON,
             "failureClass": "integration_error",
         }
         _raise_activity_error_from_application_error(


### PR DESCRIPTION
## What changed

- Distinguish included ChatGPT plan usage from optional Codex add-on credits when classifying provider limits.
- Preserve managed Codex session containers until Temporal confirms their owning workflow is terminal.
- Add production-shaped regression coverage and document both runtime contracts.

## Why

Codex CLI telemetry can report `credits.has_credits=false` and a zero add-on balance while the included plan window remains unused. MoonMind treated that optional credit state as total exhaustion, failed otherwise healthy workflows, and then allowed the session reaper to remove containers whose Temporal workflows were still active.

## Impact

Included-plan users no longer receive false `no remaining credits` failures, while genuine explicit or fully consumed usage windows still fail normally. Cleanup now requires authoritative Temporal terminal evidence before deleting a terminal-looking session owned by a workflow.

## Checks

- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --python-only tests/unit/services/temporal/runtime/test_codex_session_runtime.py tests/unit/services/temporal/runtime/test_managed_session_controller.py tests/unit/workflows/adapters/test_codex_session_adapter.py` — 253 passed
- Frontend selector-equivalent suite — 1,090 passed, 239 skipped
- `git diff --check`
