### PR TITLE
Fix Codex slot diagnostics and sidecar workspace mounts

### DIFF
--- a/moonmind/workflows/temporal/artifacts.py
+++ b/moonmind/workflows/temporal/artifacts.py
@@ -3602,6 +3602,7 @@ class TemporalArtifactActivities:
         requester_pending = False
         requester_queue_position = None
         requester_request: dict[str, Any] | None = None
+        pending_requests_ordered = state.get("pending_requests_ordered") is True
         if requester_workflow_id and isinstance(pending_requests, list):
             for index, pending_request in enumerate(pending_requests):
                 if (
@@ -3610,7 +3611,8 @@ class TemporalArtifactActivities:
                     == requester_workflow_id
                 ):
                     requester_pending = True
-                    requester_queue_position = index + 1
+                    if pending_requests_ordered:
+                        requester_queue_position = index + 1
                     requester_request = pending_request
                     break
 
@@ -3622,6 +3624,43 @@ class TemporalArtifactActivities:
         requested_profile: dict[str, Any] | None = None
         if isinstance(profiles, dict):
             raw_profile = profiles.get(requested_profile_ref)
+            profile_selector = (
+                requester_request.get("profile_selector")
+                if requester_request is not None
+                else None
+            )
+            if not isinstance(raw_profile, dict) and isinstance(
+                profile_selector, dict
+            ):
+                matching_profiles = [
+                    profile
+                    for profile in profiles.values()
+                    if isinstance(profile, dict)
+                    and (
+                        not profile_selector.get("providerId")
+                        or profile.get("provider_id")
+                        == profile_selector.get("providerId")
+                    )
+                    and (
+                        not profile_selector.get("runtimeMaterializationMode")
+                        or profile.get("runtime_materialization_mode")
+                        == profile_selector.get("runtimeMaterializationMode")
+                    )
+                    and (
+                        not profile_selector.get("tagsAny")
+                        or set(profile.get("tags") or {}).intersection(
+                            profile_selector.get("tagsAny") or []
+                        )
+                    )
+                    and (
+                        not profile_selector.get("tagsAll")
+                        or set(profile_selector.get("tagsAll") or []).issubset(
+                            profile.get("tags") or []
+                        )
+                    )
+                ]
+                if len(matching_profiles) == 1:
+                    raw_profile = matching_profiles[0]
             if not isinstance(raw_profile, dict) and len(profiles) == 1:
                 only_profile = next(iter(profiles.values()))
                 raw_profile = only_profile if isinstance(only_profile, dict) else None

--- a/moonmind/workflows/temporal/artifacts.py
+++ b/moonmind/workflows/temporal/artifacts.py
@@ -3542,6 +3542,7 @@ class TemporalArtifactActivities:
         *,
         runtime_id: str,
         requester_workflow_id: str | None = None,
+        execution_profile_ref: str | None = None,
     ) -> dict[str, Any]:
         """Return a compact ProviderProfileManager health snapshot."""
 
@@ -3599,12 +3600,45 @@ class TemporalArtifactActivities:
         pending_requests = state.get("pending_requests")
         event_count = state.get("event_count")
         requester_pending = False
+        requester_queue_position = None
+        requester_request: dict[str, Any] | None = None
         if requester_workflow_id and isinstance(pending_requests, list):
-            requester_pending = any(
-                isinstance(request, dict)
-                and request.get("requester_workflow_id") == requester_workflow_id
-                for request in pending_requests
-            )
+            for index, pending_request in enumerate(pending_requests):
+                if (
+                    isinstance(pending_request, dict)
+                    and pending_request.get("requester_workflow_id")
+                    == requester_workflow_id
+                ):
+                    requester_pending = True
+                    requester_queue_position = index + 1
+                    requester_request = pending_request
+                    break
+
+        requested_profile_ref = str(execution_profile_ref or "").strip()
+        if not requested_profile_ref and requester_request is not None:
+            requested_profile_ref = str(
+                requester_request.get("execution_profile_ref") or ""
+            ).strip()
+        requested_profile: dict[str, Any] | None = None
+        if isinstance(profiles, dict):
+            raw_profile = profiles.get(requested_profile_ref)
+            if not isinstance(raw_profile, dict) and len(profiles) == 1:
+                only_profile = next(iter(profiles.values()))
+                raw_profile = only_profile if isinstance(only_profile, dict) else None
+            if isinstance(raw_profile, dict):
+                current_leases = raw_profile.get("current_leases")
+                requested_profile = {
+                    "profile_id": str(
+                        raw_profile.get("profile_id") or requested_profile_ref
+                    ),
+                    "max_parallel_runs": raw_profile.get("max_parallel_runs"),
+                    "current_leases_count": (
+                        len(current_leases) if isinstance(current_leases, list) else 0
+                    ),
+                    "cooldown_until": raw_profile.get("cooldown_until"),
+                    "enabled": raw_profile.get("enabled"),
+                    "launch_ready": raw_profile.get("launch_ready"),
+                }
 
         return {
             "running": True,
@@ -3616,6 +3650,8 @@ class TemporalArtifactActivities:
             ),
             "event_count": event_count if isinstance(event_count, int) else None,
             "requester_pending": requester_pending,
+            "requester_queue_position": requester_queue_position,
+            "requested_profile": requested_profile,
         }
 
     async def provider_profile_verify_lease_holders(

--- a/moonmind/workflows/temporal/runtime/managed_session_controller.py
+++ b/moonmind/workflows/temporal/runtime/managed_session_controller.py
@@ -803,14 +803,67 @@ class DockerCodexManagedSessionController:
     ) -> None:
         """Map the inner daemon's workspace volume to the mounted outer workspace."""
 
+        inner_docker_command = (
+            self._docker_binary,
+            "exec",
+            "-e",
+            f"DOCKER_HOST=unix://{_SESSION_DOCKER_SOCKET_PATH}",
+            sidecar_id,
+            "docker",
+        )
+        inspect_command = (
+            *inner_docker_command,
+            "volume",
+            "inspect",
+            "--format",
+            "{{json .Options}}",
+            self._workspace_volume_name,
+        )
+        returncode, stdout, stderr = await self._command_runner(
+            inspect_command,
+            env=self._docker_env(),
+        )
+        existing_options: dict[str, Any] | None = None
+        if returncode == 0:
+            try:
+                decoded_options = json.loads(stdout.strip() or "{}")
+            except json.JSONDecodeError as exc:
+                raise RuntimeError(
+                    "failed to inspect the Docker sidecar workspace volume"
+                ) from exc
+            existing_options = (
+                decoded_options if isinstance(decoded_options, dict) else {}
+            )
+        elif "no such volume" not in (stderr or stdout).lower():
+            rendered_command, rendered_detail = self._scrub_command_failure(
+                inspect_command,
+                stderr.strip() or stdout.strip(),
+            )
+            raise RuntimeError(
+                f"{rendered_command} failed with exit code {returncode}: "
+                f"{rendered_detail}"
+            )
+
+        expected_options = {
+            "device": self._workspace_root,
+            "o": "bind",
+            "type": "none",
+        }
+        if existing_options == expected_options:
+            return
+        if existing_options is not None:
+            await self._run(
+                (
+                    *inner_docker_command,
+                    "volume",
+                    "rm",
+                    "-f",
+                    self._workspace_volume_name,
+                )
+            )
         await self._run(
             (
-                self._docker_binary,
-                "exec",
-                "-e",
-                f"DOCKER_HOST=unix://{_SESSION_DOCKER_SOCKET_PATH}",
-                sidecar_id,
-                "docker",
+                *inner_docker_command,
                 "volume",
                 "create",
                 "--driver",

--- a/moonmind/workflows/temporal/runtime/managed_session_controller.py
+++ b/moonmind/workflows/temporal/runtime/managed_session_controller.py
@@ -794,7 +794,36 @@ class DockerCodexManagedSessionController:
         if not sidecar_id:
             raise RuntimeError("docker sidecar run returned a blank container id")
         await self._wait_docker_sidecar_ready(sidecar_id)
+        await self._prepare_docker_sidecar_workspace_volume(sidecar_id)
         return sidecar_id
+
+    async def _prepare_docker_sidecar_workspace_volume(
+        self,
+        sidecar_id: str,
+    ) -> None:
+        """Map the inner daemon's workspace volume to the mounted outer workspace."""
+
+        await self._run(
+            (
+                self._docker_binary,
+                "exec",
+                "-e",
+                f"DOCKER_HOST=unix://{_SESSION_DOCKER_SOCKET_PATH}",
+                sidecar_id,
+                "docker",
+                "volume",
+                "create",
+                "--driver",
+                "local",
+                "--opt",
+                "type=none",
+                "--opt",
+                "o=bind",
+                "--opt",
+                f"device={self._workspace_root}",
+                self._workspace_volume_name,
+            )
+        )
 
     async def _prepare_docker_sidecar_socket_volume(
         self,
@@ -1504,6 +1533,7 @@ class DockerCodexManagedSessionController:
         else:
             await self._run((self._docker_binary, "start", sidecar_name))
             await self._wait_docker_sidecar_ready(sidecar_name)
+            await self._prepare_docker_sidecar_workspace_volume(sidecar_name)
 
         probe_capability = ManagedSessionDockerCapabilityRequest(
             allowed=True,

--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -330,6 +330,7 @@ PR_RESOLVER_MERGE_GATE_OWNERSHIP_PATCH_ID = (
     "agent-run-pr-resolver-merge-gate-ownership-v1"
 )
 MANAGER_SLOT_WAIT_INSPECTION_PATCH_ID = "agent-run-slot-wait-manager-inspection-v1"
+ACCURATE_SLOT_WAIT_REASON_PATCH_ID = "agent-run-accurate-slot-wait-reason-v1"
 SLOT_HANDOFF_PATCH_ID = "agent-run-slot-handoff-v1"
 SYNC_PROFILES_BEFORE_SLOT_REQUEST_PATCH_ID = (
     "agent-run-sync-profiles-before-slot-request-v1"
@@ -990,6 +991,69 @@ class MoonMindAgentRun:
         return (
             "Waiting for provider profile slot; "
             f"runtime={runtime_id}; {intent}; missing_condition=capacity_or_cooldown."
+        )
+
+    def _build_manager_slot_waiting_reason(
+        self,
+        *,
+        runtime_id: str,
+        request: AgentExecutionRequest,
+        manager_state: Mapping[str, Any],
+    ) -> str:
+        """Describe the manager-owned condition that is blocking slot assignment."""
+
+        intent = self._provider_slot_intent_summary(request)
+        queue_position = manager_state.get("requester_queue_position")
+        queue_suffix = (
+            f"; queue_position={queue_position}"
+            if isinstance(queue_position, int) and queue_position > 0
+            else ""
+        )
+        profile = manager_state.get("requested_profile")
+        if not isinstance(profile, Mapping):
+            return (
+                "Waiting in MoonMind provider profile queue; "
+                f"runtime={runtime_id}; {intent}; missing_condition=manager_queue"
+                f"{queue_suffix}."
+            )
+
+        profile_id = str(profile.get("profile_id") or "").strip()
+        profile_suffix = f"; profile={profile_id}" if profile_id else ""
+        cooldown_until = str(profile.get("cooldown_until") or "").strip()
+        if cooldown_until:
+            return (
+                "Waiting for provider cooldown to expire; "
+                f"runtime={runtime_id}; {intent}{profile_suffix}; "
+                f"missing_condition=provider_cooldown; cooldown_until={cooldown_until}"
+                f"{queue_suffix}."
+            )
+
+        slots_in_use = profile.get("current_leases_count")
+        max_parallel_runs = profile.get("max_parallel_runs")
+        if (
+            isinstance(slots_in_use, int)
+            and isinstance(max_parallel_runs, int)
+            and slots_in_use >= max_parallel_runs
+        ):
+            return (
+                "Waiting for MoonMind provider profile slot; "
+                f"runtime={runtime_id}; {intent}{profile_suffix}; "
+                "missing_condition=moonmind_slot_capacity; "
+                f"slots_in_use={slots_in_use}; max_parallel_runs={max_parallel_runs}"
+                f"{queue_suffix}."
+            )
+
+        if profile.get("enabled") is False or profile.get("launch_ready") is False:
+            return (
+                "Waiting for provider profile readiness; "
+                f"runtime={runtime_id}; {intent}{profile_suffix}; "
+                f"missing_condition=profile_not_launch_ready{queue_suffix}."
+            )
+
+        return (
+            "Waiting in MoonMind provider profile queue; "
+            f"runtime={runtime_id}; {intent}{profile_suffix}; "
+            f"missing_condition=manager_queue{queue_suffix}."
         )
 
     @staticmethod
@@ -2601,6 +2665,7 @@ class MoonMindAgentRun:
         *,
         runtime_id: str,
         requester_workflow_id: str,
+        execution_profile_ref: str | None = None,
     ) -> dict[str, Any]:
         """Fetch a compact manager-health snapshot before resetting it."""
 
@@ -2609,6 +2674,7 @@ class MoonMindAgentRun:
             {
                 "runtime_id": runtime_id,
                 "requester_workflow_id": requester_workflow_id,
+                "execution_profile_ref": execution_profile_ref,
             },
             cancellation_type=ActivityCancellationType.TRY_CANCEL,
         )
@@ -3847,7 +3913,6 @@ class MoonMindAgentRun:
                     # the parent sees awaiting_slot→launching in the same
                     # workflow task and the "queued" state is never visible.
                     if not self.slot_assigned_event.is_set():
-                        self.run_status = RunStatus.awaiting_slot
                         waiting_reason = (
                             self._awaiting_slot_reason_override
                             or self._build_provider_slot_waiting_reason(
@@ -3855,12 +3920,44 @@ class MoonMindAgentRun:
                                 request=request,
                             )
                         )
+                        if (
+                            self._awaiting_slot_reason_override is None
+                            and workflow.patched(ACCURATE_SLOT_WAIT_REASON_PATCH_ID)
+                        ):
+                            try:
+                                manager_state = (
+                                    await self._manager_state_for_slot_wait(
+                                        runtime_id=runtime_id,
+                                        requester_workflow_id=workflow.info().workflow_id,
+                                        execution_profile_ref=request.execution_profile_ref,
+                                    )
+                                )
+                                if manager_state.get("running") is True:
+                                    waiting_reason = (
+                                        self._build_manager_slot_waiting_reason(
+                                            runtime_id=runtime_id,
+                                            request=request,
+                                            manager_state=manager_state,
+                                        )
+                                    )
+                            except CancelledError:
+                                raise
+                            except Exception as exc:
+                                self._get_logger().warning(
+                                    "Auth profile manager %s state inspection failed while building the slot wait reason; using generic reason: %s",
+                                    manager_id,
+                                    exc,
+                                )
                         self._awaiting_slot_reason_override = None
-                        await self._signal_parent_child_state_changed(
-                            parent_info,
-                            "awaiting_slot",
-                            waiting_reason,
-                        )
+                        # The inspection activity creates a workflow-task boundary;
+                        # the manager can assign the slot while it runs.
+                        if not self.slot_assigned_event.is_set():
+                            self.run_status = RunStatus.awaiting_slot
+                            await self._signal_parent_child_state_changed(
+                                parent_info,
+                                "awaiting_slot",
+                                waiting_reason,
+                            )
 
                     if workflow.patched("agent_run_slot_wait_retry_v1"):
                         slot_resets = 0

--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -3989,8 +3989,8 @@ class MoonMindAgentRun:
                         ):
                             try:
                                 if (
-                                    refresh_waiting_reason
-                                    and not self.slot_assigned_event.is_set()
+                                    not self.slot_assigned_event.is_set()
+                                    and refresh_waiting_reason
                                     and not self.runtime_selection_updated_event.is_set()
                                     and workflow.patched(
                                         ACCURATE_SLOT_WAIT_REASON_PATCH_ID

--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -1019,6 +1019,15 @@ class MoonMindAgentRun:
 
         profile_id = str(profile.get("profile_id") or "").strip()
         profile_suffix = f"; profile={profile_id}" if profile_id else ""
+        slots_in_use = profile.get("current_leases_count")
+        max_parallel_runs = profile.get("max_parallel_runs")
+        if profile.get("enabled") is False or profile.get("launch_ready") is False:
+            return (
+                "Waiting for provider profile readiness; "
+                f"runtime={runtime_id}; {intent}{profile_suffix}; "
+                f"missing_condition=profile_not_launch_ready{queue_suffix}."
+            )
+
         cooldown_until = str(profile.get("cooldown_until") or "").strip()
         if cooldown_until:
             return (
@@ -1028,8 +1037,6 @@ class MoonMindAgentRun:
                 f"{queue_suffix}."
             )
 
-        slots_in_use = profile.get("current_leases_count")
-        max_parallel_runs = profile.get("max_parallel_runs")
         if (
             isinstance(slots_in_use, int)
             and isinstance(max_parallel_runs, int)
@@ -1041,13 +1048,6 @@ class MoonMindAgentRun:
                 "missing_condition=moonmind_slot_capacity; "
                 f"slots_in_use={slots_in_use}; max_parallel_runs={max_parallel_runs}"
                 f"{queue_suffix}."
-            )
-
-        if profile.get("enabled") is False or profile.get("launch_ready") is False:
-            return (
-                "Waiting for provider profile readiness; "
-                f"runtime={runtime_id}; {intent}{profile_suffix}; "
-                f"missing_condition=profile_not_launch_ready{queue_suffix}."
             )
 
         return (
@@ -2669,18 +2669,53 @@ class MoonMindAgentRun:
     ) -> dict[str, Any]:
         """Fetch a compact manager-health snapshot before resetting it."""
 
+        payload = {
+            "runtime_id": runtime_id,
+            "requester_workflow_id": requester_workflow_id,
+        }
+        if execution_profile_ref is not None:
+            payload["execution_profile_ref"] = execution_profile_ref
         result = await self._execute_routed_activity(
             "provider_profile.manager_state",
-            {
-                "runtime_id": runtime_id,
-                "requester_workflow_id": requester_workflow_id,
-                "execution_profile_ref": execution_profile_ref,
-            },
+            payload,
             cancellation_type=ActivityCancellationType.TRY_CANCEL,
         )
         if isinstance(result, dict):
             return result
         return {"running": False, "error": "invalid_manager_state_payload"}
+
+    async def _inspected_provider_slot_waiting_reason(
+        self,
+        *,
+        manager_id: str,
+        runtime_id: str,
+        request: AgentExecutionRequest,
+    ) -> str:
+        waiting_reason = self._build_provider_slot_waiting_reason(
+            runtime_id=runtime_id,
+            request=request,
+        )
+        try:
+            manager_state = await self._manager_state_for_slot_wait(
+                runtime_id=runtime_id,
+                requester_workflow_id=workflow.info().workflow_id,
+                execution_profile_ref=request.execution_profile_ref,
+            )
+            if manager_state.get("running") is True:
+                waiting_reason = self._build_manager_slot_waiting_reason(
+                    runtime_id=runtime_id,
+                    request=request,
+                    manager_state=manager_state,
+                )
+        except CancelledError:
+            raise
+        except Exception as exc:
+            self._get_logger().warning(
+                "Auth profile manager %s state inspection failed while building the slot wait reason; using generic reason: %s",
+                manager_id,
+                exc,
+            )
+        return waiting_reason
 
     async def _reset_and_request_slot(
         self,
@@ -3924,34 +3959,20 @@ class MoonMindAgentRun:
                             self._awaiting_slot_reason_override is None
                             and workflow.patched(ACCURATE_SLOT_WAIT_REASON_PATCH_ID)
                         ):
-                            try:
-                                manager_state = (
-                                    await self._manager_state_for_slot_wait(
-                                        runtime_id=runtime_id,
-                                        requester_workflow_id=workflow.info().workflow_id,
-                                        execution_profile_ref=request.execution_profile_ref,
-                                    )
+                            waiting_reason = (
+                                await self._inspected_provider_slot_waiting_reason(
+                                    manager_id=manager_id,
+                                    runtime_id=runtime_id,
+                                    request=request,
                                 )
-                                if manager_state.get("running") is True:
-                                    waiting_reason = (
-                                        self._build_manager_slot_waiting_reason(
-                                            runtime_id=runtime_id,
-                                            request=request,
-                                            manager_state=manager_state,
-                                        )
-                                    )
-                            except CancelledError:
-                                raise
-                            except Exception as exc:
-                                self._get_logger().warning(
-                                    "Auth profile manager %s state inspection failed while building the slot wait reason; using generic reason: %s",
-                                    manager_id,
-                                    exc,
-                                )
+                            )
                         self._awaiting_slot_reason_override = None
                         # The inspection activity creates a workflow-task boundary;
                         # the manager can assign the slot while it runs.
-                        if not self.slot_assigned_event.is_set():
+                        if (
+                            not self.slot_assigned_event.is_set()
+                            and not self.runtime_selection_updated_event.is_set()
+                        ):
                             self.run_status = RunStatus.awaiting_slot
                             await self._signal_parent_child_state_changed(
                                 parent_info,
@@ -3961,11 +3982,36 @@ class MoonMindAgentRun:
 
                     if workflow.patched("agent_run_slot_wait_retry_v1"):
                         slot_resets = 0
+                        refresh_waiting_reason = False
                         while (
                             not self.slot_assigned_event.is_set()
                             or self.runtime_selection_updated_event.is_set()
                         ):
                             try:
+                                if (
+                                    refresh_waiting_reason
+                                    and not self.slot_assigned_event.is_set()
+                                    and not self.runtime_selection_updated_event.is_set()
+                                    and workflow.patched(
+                                        ACCURATE_SLOT_WAIT_REASON_PATCH_ID
+                                    )
+                                ):
+                                    waiting_reason = await self._inspected_provider_slot_waiting_reason(
+                                        manager_id=manager_id,
+                                        runtime_id=runtime_id,
+                                        request=request,
+                                    )
+                                    if (
+                                        not self.slot_assigned_event.is_set()
+                                        and not self.runtime_selection_updated_event.is_set()
+                                    ):
+                                        self.run_status = RunStatus.awaiting_slot
+                                        await self._signal_parent_child_state_changed(
+                                            parent_info,
+                                            "awaiting_slot",
+                                            waiting_reason,
+                                        )
+                                        refresh_waiting_reason = False
                                 if self.runtime_selection_updated_event.is_set():
                                     (
                                         manager_handle,
@@ -3979,6 +4025,7 @@ class MoonMindAgentRun:
                                     requested_execution_profile_ref = (
                                         request.execution_profile_ref
                                     )
+                                    refresh_waiting_reason = True
                                     continue
                                 slot_wait_timeout_seconds = (
                                     self._slot_wait_timeout_override_seconds
@@ -4002,6 +4049,7 @@ class MoonMindAgentRun:
                                     requested_execution_profile_ref = (
                                         request.execution_profile_ref
                                     )
+                                    refresh_waiting_reason = True
                                     continue
                             except TimeoutError:
                                 if slot_resets >= _SLOT_WAIT_MAX_RESETS:

--- a/moonmind/workflows/temporal/workflows/provider_profile_manager.py
+++ b/moonmind/workflows/temporal/workflows/provider_profile_manager.py
@@ -458,6 +458,7 @@ class MoonMindProviderProfileManagerWorkflow:
         self._runtime_id: Optional[str] = None
         self._profiles: dict[str, ProfileSlotState] = {}
         self._pending_requests: list[PendingRequest] = []
+        self._pending_requests_ordered: bool = False
         self._handoff_reservations: dict[str, HandoffReservation] = {}
         self._event_count: int = 0
         self._shutdown_requested: bool = False
@@ -516,6 +517,7 @@ class MoonMindProviderProfileManagerWorkflow:
         priority = self._normalize_request_priority(payload.get("priority"))
         queue_order = self._normalize_queue_order(payload.get("queue_order"))
         queued_at = self._normalize_optional_string(payload.get("queued_at"))
+        self._pending_requests_ordered = False
         if not workflow.patched(SLOT_HANDOFF_RESERVATION_PATCH):
             self._pending_requests.append(
                 PendingRequest(
@@ -839,6 +841,7 @@ class MoonMindProviderProfileManagerWorkflow:
                 }
                 for r in self._pending_requests
             ],
+            "pending_requests_ordered": self._pending_requests_ordered,
             "handoff_reservations": {
                 group_id: {
                     "profile_id": reservation.profile_id,
@@ -1001,6 +1004,7 @@ class MoonMindProviderProfileManagerWorkflow:
             for req in pending_data
             if req.get("requester_workflow_id")
         ]
+        self._pending_requests_ordered = False
         self._handoff_reservations = {}
         if isinstance(reservations_data, dict):
             for group_id, reservation in reservations_data.items():
@@ -1371,6 +1375,7 @@ class MoonMindProviderProfileManagerWorkflow:
             else:
                 remaining.append(req)
         self._pending_requests = remaining
+        self._pending_requests_ordered = True
 
         # Persist lease changes to DB for crash recovery
         if leases_changed and workflow.patched(DB_LEASE_PERSISTENCE_PATCH):

--- a/tests/unit/services/temporal/runtime/test_managed_session_controller.py
+++ b/tests/unit/services/temporal/runtime/test_managed_session_controller.py
@@ -541,6 +541,25 @@ async def test_mm866_docker_enabled_session_launches_agent_with_sidecar(
         and "moonmind-session-sess-1-docker" in command
         for command in commands
     )
+    assert (
+        "docker",
+        "exec",
+        "-e",
+        "DOCKER_HOST=unix:///var/run/moonmind-docker/docker.sock",
+        "sidecar-ctr",
+        "docker",
+        "volume",
+        "create",
+        "--driver",
+        "local",
+        "--opt",
+        "type=none",
+        "--opt",
+        "o=bind",
+        "--opt",
+        f"device={workspace_root}",
+        "agent_workspaces",
+    ) in commands
     agent_run = next(
         command
         for command in commands
@@ -1117,6 +1136,21 @@ async def test_mm866_ensure_docker_sidecar_starts_existing_sidecar_before_ready(
 
     assert response.state == "ready"
     assert ("docker", "start", "moonmind-session-sess-1-docker") in commands
+    assert any(
+        command[:8]
+        == (
+            "docker",
+            "exec",
+            "-e",
+            "DOCKER_HOST=unix:///var/run/moonmind-docker/docker.sock",
+            "moonmind-session-sess-1-docker",
+            "docker",
+            "volume",
+            "create",
+        )
+        and command[-1] == "agent_workspaces"
+        for command in commands
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/temporal/runtime/test_managed_session_controller.py
+++ b/tests/unit/services/temporal/runtime/test_managed_session_controller.py
@@ -483,6 +483,10 @@ async def test_mm866_docker_enabled_session_launches_agent_with_sidecar(
                 return 0, "sidecar-ctr\n", ""
             if name.endswith("-agent"):
                 return 0, "agent-ctr\n", ""
+        if command[:3] == ("docker", "exec", "-e") and "volume" in command:
+            if "inspect" in command:
+                return 1, "", "No such volume"
+            return 0, command[-1] + "\n", ""
         if command[:3] == ("docker", "exec", "-e") and "docker" in command:
             return 0, '"27.0.0"\n', ""
         if "ready" in command:
@@ -1033,6 +1037,10 @@ async def test_mm866_ensure_docker_sidecar_starts_sidecar_on_demand(
             return 0, command[-1] + "\n", ""
         if command[:2] == ("docker", "run"):
             return 0, "sidecar-ctr\n", ""
+        if command[:3] == ("docker", "exec", "-e") and "volume" in command:
+            if "inspect" in command:
+                return 1, "", "No such volume"
+            return 0, command[-1] + "\n", ""
         if command[:3] == ("docker", "exec", "-e"):
             return 0, '"27.0.0"\n', ""
         if command[:4] == ("docker", "exec", "agent-ctr", "docker"):
@@ -1110,6 +1118,10 @@ async def test_mm866_ensure_docker_sidecar_starts_existing_sidecar_before_ready(
             return 0, "true\n", ""
         if command[:3] == ("docker", "start", "moonmind-session-sess-1-docker"):
             return 0, "moonmind-session-sess-1-docker\n", ""
+        if command[:3] == ("docker", "exec", "-e") and "volume" in command:
+            if "inspect" in command:
+                return 0, "{}\n", ""
+            return 0, command[-1] + "\n", ""
         if command[:3] == ("docker", "exec", "-e"):
             return 0, '"27.0.0"\n', ""
         if command[:4] == ("docker", "exec", "agent-ctr", "docker"):
@@ -1136,6 +1148,17 @@ async def test_mm866_ensure_docker_sidecar_starts_existing_sidecar_before_ready(
 
     assert response.state == "ready"
     assert ("docker", "start", "moonmind-session-sess-1-docker") in commands
+    remove_index = next(
+        index
+        for index, command in enumerate(commands)
+        if "volume" in command and "rm" in command
+    )
+    create_index = next(
+        index
+        for index, command in enumerate(commands)
+        if "volume" in command and "create" in command
+    )
+    assert remove_index < create_index
     assert any(
         command[:8]
         == (

--- a/tests/unit/workflows/temporal/test_provider_profile_manager.py
+++ b/tests/unit/workflows/temporal/test_provider_profile_manager.py
@@ -2686,9 +2686,22 @@ async def test_provider_profile_manager_state_returns_compact_running_snapshot(
         async def query(self, query_name):
             assert query_name == "get_state"
             return {
-                "profiles": {"p1": {}, "p2": {}},
+                "profiles": {
+                    "p1": {
+                        "profile_id": "p1",
+                        "max_parallel_runs": 1,
+                        "current_leases": ["agent-run-active"],
+                        "cooldown_until": None,
+                        "enabled": True,
+                        "launch_ready": True,
+                    },
+                    "p2": {},
+                },
                 "pending_requests": [
-                    {"requester_workflow_id": "agent-run-1"},
+                    {
+                        "requester_workflow_id": "agent-run-1",
+                        "execution_profile_ref": "p1",
+                    },
                     {"requester_workflow_id": "agent-run-2"},
                 ],
                 "event_count": 7,
@@ -2723,6 +2736,15 @@ async def test_provider_profile_manager_state_returns_compact_running_snapshot(
         "pending_requests_count": 2,
         "event_count": 7,
         "requester_pending": True,
+        "requester_queue_position": 1,
+        "requested_profile": {
+            "profile_id": "p1",
+            "max_parallel_runs": 1,
+            "current_leases_count": 1,
+            "cooldown_until": None,
+            "enabled": True,
+            "launch_ready": True,
+        },
     }
     assert "state" not in result
 

--- a/tests/unit/workflows/temporal/test_provider_profile_manager.py
+++ b/tests/unit/workflows/temporal/test_provider_profile_manager.py
@@ -2704,6 +2704,7 @@ async def test_provider_profile_manager_state_returns_compact_running_snapshot(
                     },
                     {"requester_workflow_id": "agent-run-2"},
                 ],
+                "pending_requests_ordered": True,
                 "event_count": 7,
             }
 
@@ -2747,6 +2748,91 @@ async def test_provider_profile_manager_state_returns_compact_running_snapshot(
         },
     }
     assert "state" not in result
+
+
+@pytest.mark.asyncio
+async def test_provider_profile_manager_state_resolves_unique_selector_profile(
+    monkeypatch,
+):
+    from moonmind.workflows.temporal.artifacts import TemporalArtifactActivities
+
+    class FakeHandle:
+        async def describe(self):
+            return SimpleNamespace(status=SimpleNamespace(name="RUNNING"))
+
+        async def query(self, query_name):
+            assert query_name == "get_state"
+            return {
+                "profiles": {
+                    "openai": {
+                        "profile_id": "openai",
+                        "provider_id": "openai",
+                        "runtime_materialization_mode": "oauth",
+                        "tags": ["primary"],
+                        "max_parallel_runs": 1,
+                        "current_leases": ["agent-run-active"],
+                        "cooldown_until": None,
+                        "enabled": True,
+                        "launch_ready": True,
+                    },
+                    "anthropic": {
+                        "profile_id": "anthropic",
+                        "provider_id": "anthropic",
+                        "runtime_materialization_mode": "api_key",
+                        "tags": [],
+                        "max_parallel_runs": 2,
+                        "current_leases": [],
+                        "cooldown_until": None,
+                        "enabled": True,
+                        "launch_ready": True,
+                    },
+                },
+                "pending_requests": [
+                    {
+                        "requester_workflow_id": "agent-run-1",
+                        "execution_profile_ref": None,
+                        "profile_selector": {
+                            "providerId": "openai",
+                            "runtimeMaterializationMode": "oauth",
+                            "tagsAll": ["primary"],
+                        },
+                    }
+                ],
+                "pending_requests_ordered": False,
+                "event_count": 1,
+            }
+
+    class FakeClient:
+        def get_workflow_handle(self, workflow_id):
+            assert workflow_id == "provider-profile-manager:codex_cli"
+            return FakeHandle()
+
+    class FakeAdapter:
+        async def get_client(self):
+            return FakeClient()
+
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.client.TemporalClientAdapter",
+        FakeAdapter,
+    )
+
+    result = await TemporalArtifactActivities(
+        object()
+    ).provider_profile_manager_state(
+        runtime_id="codex_cli",
+        requester_workflow_id="agent-run-1",
+    )
+
+    assert result["requester_pending"] is True
+    assert result["requester_queue_position"] is None
+    assert result["requested_profile"] == {
+        "profile_id": "openai",
+        "max_parallel_runs": 1,
+        "current_leases_count": 1,
+        "cooldown_until": None,
+        "enabled": True,
+        "launch_ready": True,
+    }
 
 @pytest.mark.asyncio
 async def test_provider_profile_manager_state_checks_status_before_query(

--- a/tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py
@@ -602,6 +602,62 @@ async def test_manager_slot_waiting_reason_identifies_provider_cooldown() -> Non
     assert "cooldown_until=2026-07-16T22:00:00+00:00" in reason
     assert "moonmind_slot_capacity" not in reason
 
+
+async def test_manager_slot_waiting_reason_prioritizes_profile_readiness() -> None:
+    run = MoonMindAgentRun()
+    request = _managed_session_request().model_copy(
+        update={"execution_profile_ref": "codex-openai"}
+    )
+
+    reason = run._build_manager_slot_waiting_reason(
+        runtime_id="codex_cli",
+        request=request,
+        manager_state={
+            "requested_profile": {
+                "profile_id": "codex-openai",
+                "max_parallel_runs": 1,
+                "current_leases_count": 1,
+                "cooldown_until": "2026-07-16T22:00:00+00:00",
+                "enabled": False,
+                "launch_ready": False,
+            },
+        },
+    )
+
+    assert "missing_condition=profile_not_launch_ready" in reason
+    assert "provider_cooldown" not in reason
+    assert "moonmind_slot_capacity" not in reason
+
+
+async def test_manager_state_omits_optional_profile_ref_from_legacy_payload() -> None:
+    run = MoonMindAgentRun()
+    calls: list[tuple[str, dict[str, Any]]] = []
+
+    async def fake_activity(
+        activity_name: str,
+        payload: dict[str, Any],
+        **_kwargs: Any,
+    ) -> dict[str, Any]:
+        calls.append((activity_name, payload))
+        return {"running": True}
+
+    run._execute_routed_activity = fake_activity  # type: ignore[method-assign]
+
+    await run._manager_state_for_slot_wait(
+        runtime_id="codex_cli",
+        requester_workflow_id="wf-agent-run-1",
+    )
+
+    assert calls == [
+        (
+            "provider_profile.manager_state",
+            {
+                "runtime_id": "codex_cli",
+                "requester_workflow_id": "wf-agent-run-1",
+            },
+        )
+    ]
+
 async def test_provider_cooldown_backoff_doubles_and_caps_per_profile() -> None:
     run = MoonMindAgentRun()
 

--- a/tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py
@@ -546,6 +546,62 @@ async def test_slot_waiting_reason_summarizes_capacity_or_cooldown() -> None:
     assert "provider=openai" in reason
     assert "missing_condition=capacity_or_cooldown" in reason
 
+
+async def test_manager_slot_waiting_reason_identifies_moonmind_capacity() -> None:
+    run = MoonMindAgentRun()
+    request = _managed_session_request().model_copy(
+        update={"execution_profile_ref": "codex-openai"}
+    )
+
+    reason = run._build_manager_slot_waiting_reason(
+        runtime_id="codex_cli",
+        request=request,
+        manager_state={
+            "requester_queue_position": 3,
+            "requested_profile": {
+                "profile_id": "codex-openai",
+                "max_parallel_runs": 1,
+                "current_leases_count": 1,
+                "cooldown_until": None,
+                "enabled": True,
+                "launch_ready": True,
+            },
+        },
+    )
+
+    assert "missing_condition=moonmind_slot_capacity" in reason
+    assert "slots_in_use=1" in reason
+    assert "max_parallel_runs=1" in reason
+    assert "queue_position=3" in reason
+    assert "capacity_or_cooldown" not in reason
+
+
+async def test_manager_slot_waiting_reason_identifies_provider_cooldown() -> None:
+    run = MoonMindAgentRun()
+    request = _managed_session_request().model_copy(
+        update={"execution_profile_ref": "codex-openai"}
+    )
+
+    reason = run._build_manager_slot_waiting_reason(
+        runtime_id="codex_cli",
+        request=request,
+        manager_state={
+            "requester_queue_position": 1,
+            "requested_profile": {
+                "profile_id": "codex-openai",
+                "max_parallel_runs": 1,
+                "current_leases_count": 0,
+                "cooldown_until": "2026-07-16T22:00:00+00:00",
+                "enabled": True,
+                "launch_ready": True,
+            },
+        },
+    )
+
+    assert "missing_condition=provider_cooldown" in reason
+    assert "cooldown_until=2026-07-16T22:00:00+00:00" in reason
+    assert "moonmind_slot_capacity" not in reason
+
 async def test_provider_cooldown_backoff_doubles_and_caps_per_profile() -> None:
     run = MoonMindAgentRun()
 

--- a/tests/unit/workflows/temporal/workflows/test_agent_run_slot_wait_timeout.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_run_slot_wait_timeout.py
@@ -187,6 +187,13 @@ class TestSlotWaitRetryBehavior:
         assert "workflow.patched(ACCURATE_SLOT_WAIT_REASON_PATCH_ID)" in source
         assert "execution_profile_ref=request.execution_profile_ref" in source
 
+    def test_runtime_selection_refreshes_wait_reason_after_inspection(self):
+        source = inspect.getsource(MoonMindAgentRun.run)
+
+        assert "refresh_waiting_reason = True" in source
+        assert "not self.runtime_selection_updated_event.is_set()" in source
+        assert "_inspected_provider_slot_waiting_reason" in source
+
     def test_reset_and_request_slot_uses_ensure_signal_fallback(self):
         """The reset path must tolerate the fresh-manager signal race."""
         source = inspect.getsource(MoonMindAgentRun._reset_and_request_slot)

--- a/tests/unit/workflows/temporal/workflows/test_agent_run_slot_wait_timeout.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_run_slot_wait_timeout.py
@@ -12,6 +12,7 @@ import inspect
 import textwrap
 
 from moonmind.workflows.temporal.workflows.agent_run import (
+    ACCURATE_SLOT_WAIT_REASON_PATCH_ID,
     MANAGER_SLOT_WAIT_INSPECTION_PATCH_ID,
     MoonMindAgentRun,
     RunStatus,
@@ -175,6 +176,16 @@ class TestSlotWaitRetryBehavior:
             "_reset_and_request_slot"
         )
         assert "re-requesting without reset" in source
+
+    def test_accurate_initial_wait_reason_is_replay_gated(self):
+        source = inspect.getsource(MoonMindAgentRun.run)
+
+        assert (
+            ACCURATE_SLOT_WAIT_REASON_PATCH_ID
+            == "agent-run-accurate-slot-wait-reason-v1"
+        )
+        assert "workflow.patched(ACCURATE_SLOT_WAIT_REASON_PATCH_ID)" in source
+        assert "execution_profile_ref=request.execution_profile_ref" in source
 
     def test_reset_and_request_slot_uses_ensure_signal_fallback(self):
         """The reset path must tolerate the fresh-manager signal race."""


### PR DESCRIPTION
## Summary

- replace the ambiguous `capacity_or_cooldown` projection with replay-safe manager-backed reasons that distinguish provider cooldown, MoonMind slot capacity, queue order, and profile readiness
- include queue position and compact slot counts without exposing lease identities
- bind the outer agent workspace into the per-session Docker daemon so nested validation containers receive the real checkout instead of an empty inner `agent_workspaces` volume
- cover new workflow, activity, and managed-session controller boundaries

## Root cause

The observed Codex wait banner conflated provider exhaustion with MoonMind queueing. In the affected run, Codex included-plan usage was low and the profile was not cooling down; MoonMind had one exclusive OAuth slot and queued the remaining work. Separately, the sidecar Docker daemon resolved `agent_workspaces` in its own volume namespace, so nested Unreal validation saw an empty workspace and could not find `Tactics.uproject`.

## Verification

- `./tools/test_unit.sh --python-only tests/unit/workflows/temporal/test_provider_profile_manager.py tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py tests/unit/workflows/temporal/workflows/test_agent_run_slot_wait_timeout.py tests/unit/services/temporal/runtime/test_managed_session_controller.py`
- 272 tests passed
- `git diff --check`

A full frontend run was also attempted by the unqualified unit runner and surfaced unrelated timing failures in untouched dashboard/workflow-start/workflow-detail tests; this change has no frontend files.