### PR TITLE
Fix stalled Codex slot cleanup

### DIFF
--- a/moonmind/workflows/temporal/runtime/managed_session_controller.py
+++ b/moonmind/workflows/temporal/runtime/managed_session_controller.py
@@ -2769,11 +2769,21 @@ class DockerCodexManagedSessionController:
             ),
             env=self._docker_env(),
         )
-        image_returncode, image_stdout, _image_stderr = image_result
+        image_returncode, image_stdout, image_stderr = image_result
         if image_returncode != 0:
-            # A missing local ref must not authorize reuse. Relaunching lets
-            # Docker acquire the configured image through the normal path.
-            return False
+            error_output = f"{image_stdout}\n{image_stderr}".lower()
+            if "no such image" in error_output or "no such object" in error_output:
+                # A missing local ref must not authorize reuse. Relaunching lets
+                # Docker acquire the configured image through the normal path.
+                return False
+            details = (
+                image_stderr.strip()
+                or image_stdout.strip()
+                or f"exit code {image_returncode}"
+            )
+            raise RuntimeError(
+                "failed to inspect configured managed session image: " + details
+            )
 
         container_image_id = container_stdout.strip()
         current_image_id = image_stdout.strip()

--- a/moonmind/workflows/temporal/runtime/managed_session_controller.py
+++ b/moonmind/workflows/temporal/runtime/managed_session_controller.py
@@ -2718,6 +2718,71 @@ class DockerCodexManagedSessionController:
             f"failed to inspect managed session container {container_id}: {details}"
         )
 
+    async def _container_uses_current_image(
+        self,
+        *,
+        container_id: str,
+        image_ref: str,
+    ) -> bool:
+        """Return whether a live session uses the image currently behind its ref.
+
+        Session records intentionally preserve the operator-facing image ref,
+        which may be mutable (for example ``:latest``). Comparing only that
+        string lets a pre-deployment container survive after the local tag has
+        moved to a corrected runtime image. Docker's container ``.Image`` and
+        image ``.Id`` values are immutable content identities, so they are the
+        authority for safe reuse.
+        """
+
+        container_result = await self._command_runner(
+            (
+                self._docker_binary,
+                "inspect",
+                "-f",
+                "{{.Image}}",
+                container_id,
+            ),
+            env=self._docker_env(),
+        )
+        container_returncode, container_stdout, container_stderr = container_result
+        if container_returncode != 0:
+            error_output = f"{container_stdout}\n{container_stderr}".lower()
+            if "no such object" in error_output or "no such container" in error_output:
+                return False
+            details = (
+                container_stderr.strip()
+                or container_stdout.strip()
+                or f"exit code {container_returncode}"
+            )
+            raise RuntimeError(
+                "failed to inspect managed session container image: " + details
+            )
+
+        image_result = await self._command_runner(
+            (
+                self._docker_binary,
+                "image",
+                "inspect",
+                "-f",
+                "{{.Id}}",
+                image_ref,
+            ),
+            env=self._docker_env(),
+        )
+        image_returncode, image_stdout, _image_stderr = image_result
+        if image_returncode != 0:
+            # A missing local ref must not authorize reuse. Relaunching lets
+            # Docker acquire the configured image through the normal path.
+            return False
+
+        container_image_id = container_stdout.strip()
+        current_image_id = image_stdout.strip()
+        return bool(
+            container_image_id
+            and current_image_id
+            and container_image_id == current_image_id
+        )
+
     @staticmethod
     def _build_generic_managed_agent_env(
         request: LaunchCodexManagedSessionRequest,
@@ -2757,6 +2822,10 @@ class DockerCodexManagedSessionController:
                 existing_record is not None
                 and self._request_matches_record(request, existing_record)
                 and await self._container_exists(existing_record.container_id)
+                and await self._container_uses_current_image(
+                    container_id=existing_record.container_id,
+                    image_ref=request.image_ref,
+                )
             ):
                 return CodexManagedSessionHandle(
                     runtimeFamily=request.runtime_family,

--- a/moonmind/workflows/temporal/service.py
+++ b/moonmind/workflows/temporal/service.py
@@ -2505,14 +2505,14 @@ class TemporalExecutionService:
 
         try:
             if graceful:
-                if record.workflow_type is TemporalWorkflowType.USER_WORKFLOW:
-                    await self._client_adapter.update_workflow(
-                        record.workflow_id,
-                        "Cancel",
-                        reason_text,
-                    )
-                else:
-                    await self._client_adapter.cancel_workflow(record.workflow_id)
+                # Temporal cancellation is the authoritative terminal action.
+                # A workflow update can change MoonMind's projection while the
+                # main coroutine remains blocked awaiting an AgentRun child,
+                # leaving both executions live and eligible for provider slots.
+                # Cancel the execution itself so Temporal propagates
+                # cancellation through child-workflow ownership and runs the
+                # AgentRun cleanup path that releases provider leases.
+                await self._client_adapter.cancel_workflow(record.workflow_id)
             else:
                 await self._client_adapter.terminate_workflow(
                     record.workflow_id,

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -637,6 +637,9 @@ RUN_MOONSPEC_ADDITIONAL_WORK_DRAFT_PUBLISH_PATCH = (
 )
 RUN_AUTHORITATIVE_PUBLISH_OUTCOME_PATCH = "run-authoritative-publish-outcome-v1"
 RUN_STEP_RETRY_OVERRIDES_PATCH = "run-step-retry-overrides-v1"
+RUN_PROPAGATE_AGENT_CHILD_CANCELLATION_PATCH = (
+    "run-propagate-agent-child-cancellation-v1"
+)
 # MM-880: compile + persist a versioned ResiliencePolicy envelope before step
 # execution begins so every step execution can be traced to the policy values
 # that governed it.
@@ -921,6 +924,13 @@ class MoonMindRunWorkflow:
         if "Timeout" in root_type_name or "Connection" in root_type_name:
             return "integration_error"
         return "execution_error"
+
+    @staticmethod
+    def _should_propagate_agent_child_cancellation(exc: BaseException) -> bool:
+        return isinstance(
+            exc,
+            (CancelledError, asyncio.CancelledError),
+        ) and workflow.patched(RUN_PROPAGATE_AGENT_CHILD_CANCELLATION_PATCH)
 
     # Canonical errorCategory tokens. These are machine classifications, not
     # operator-readable messages, so they must never be surfaced verbatim as a
@@ -9724,6 +9734,8 @@ class MoonMindRunWorkflow:
                                 self._active_agent_id = None
                             execution_result = self._map_agent_run_result(child_result)
                         except Exception as exc:
+                            if self._should_propagate_agent_child_cancellation(exc):
+                                raise
                             diagnostic = self._record_failure_diagnostic(
                                 exc,
                                 stage=self._state,

--- a/tests/unit/services/temporal/runtime/test_managed_session_controller.py
+++ b/tests/unit/services/temporal/runtime/test_managed_session_controller.py
@@ -4461,8 +4461,12 @@ async def test_controller_duplicate_launch_reuses_existing_live_record(
     ) -> tuple[int, str, str]:
         del input_text, env
         commands.append(command)
-        if command[:3] == ("docker", "inspect", "-f"):
+        if command == ("docker", "inspect", "-f", "{{.Id}}", "ctr-1"):
             return 0, "ctr-1\n", ""
+        if command == ("docker", "inspect", "-f", "{{.Image}}", "ctr-1"):
+            return 0, "sha256:current\n", ""
+        if command == ("docker", "image", "inspect", "-f", "{{.Id}}", "img"):
+            return 0, "sha256:current\n", ""
         raise AssertionError(f"unexpected command: {command}")
 
     controller = DockerCodexManagedSessionController(
@@ -4477,7 +4481,82 @@ async def test_controller_duplicate_launch_reuses_existing_live_record(
 
     assert handle.status == "ready"
     assert handle.session_state.container_id == "ctr-1"
-    assert commands == [("docker", "inspect", "-f", "{{.Id}}", "ctr-1")]
+    assert commands == [
+        ("docker", "inspect", "-f", "{{.Id}}", "ctr-1"),
+        ("docker", "inspect", "-f", "{{.Image}}", "ctr-1"),
+        ("docker", "image", "inspect", "-f", "{{.Id}}", "img"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_controller_duplicate_launch_recreates_stale_mutable_image(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = ManagedSessionStore(tmp_path / "session-store")
+    request = LaunchCodexManagedSessionRequest(
+        agentRunId="task-1",
+        sessionId="sess-1",
+        threadId="logical-thread-1",
+        workspacePath=str(tmp_path / "agent_jobs" / "task-1" / "repo"),
+        sessionWorkspacePath=str(tmp_path / "agent_jobs" / "task-1" / "session"),
+        artifactSpoolPath=str(tmp_path / "agent_jobs" / "task-1" / "artifacts"),
+        codexHomePath="/tmp/codex-home",
+        imageRef="ghcr.io/moonladderstudios/moonmind:latest",
+    )
+    store.save(
+        CodexManagedSessionRecord(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            agentRunId="task-1",
+            containerId="ctr-old",
+            threadId="logical-thread-1",
+            runtimeId="codex_cli",
+            imageRef=request.image_ref,
+            controlUrl="docker-exec://ctr-old",
+            status="ready",
+            workspacePath=request.workspace_path,
+            sessionWorkspacePath=request.session_workspace_path,
+            artifactSpoolPath=request.artifact_spool_path,
+            startedAt="2026-04-06T12:00:00Z",
+        )
+    )
+    async def runner(
+        command: tuple[str, ...],
+        *,
+        input_text: str | None = None,
+        env: dict[str, str] | None = None,
+    ) -> tuple[int, str, str]:
+        del input_text, env
+        if command == ("docker", "inspect", "-f", "{{.Id}}", "ctr-old"):
+            return 0, "ctr-old\n", ""
+        if command == ("docker", "inspect", "-f", "{{.Image}}", "ctr-old"):
+            return 0, "sha256:stale\n", ""
+        if command == (
+            "docker",
+            "image",
+            "inspect",
+            "-f",
+            "{{.Id}}",
+            request.image_ref,
+        ):
+            return 0, "sha256:current\n", ""
+        raise AssertionError(f"unexpected command: {command}")
+
+    controller = DockerCodexManagedSessionController(
+        workspace_volume_name="agent_workspaces",
+        codex_volume_name="codex_auth_volume",
+        workspace_root=str(tmp_path / "agent_jobs"),
+        session_store=store,
+        command_runner=runner,
+    )
+    relaunch = AsyncMock(side_effect=RuntimeError("stale image relaunch"))
+    monkeypatch.setattr(controller, "_ensure_workspace_paths", relaunch)
+
+    with pytest.raises(RuntimeError, match="stale image relaunch"):
+        await controller.launch_session(request)
+
+    relaunch.assert_awaited_once_with(request)
 
 def test_controller_launch_duplicate_match_requires_epoch_and_thread(
     tmp_path: Path,

--- a/tests/unit/services/temporal/runtime/test_managed_session_controller.py
+++ b/tests/unit/services/temporal/runtime/test_managed_session_controller.py
@@ -4521,6 +4521,7 @@ async def test_controller_duplicate_launch_recreates_stale_mutable_image(
             startedAt="2026-04-06T12:00:00Z",
         )
     )
+
     async def runner(
         command: tuple[str, ...],
         *,
@@ -4557,6 +4558,57 @@ async def test_controller_duplicate_launch_recreates_stale_mutable_image(
         await controller.launch_session(request)
 
     relaunch.assert_awaited_once_with(request)
+
+
+@pytest.mark.asyncio
+async def test_container_image_inspection_only_treats_not_found_as_stale(
+    tmp_path: Path,
+) -> None:
+    image_result = (1, "", "Error: No such image: runtime:latest")
+
+    async def runner(
+        command: tuple[str, ...],
+        *,
+        input_text: str | None = None,
+        env: dict[str, str] | None = None,
+    ) -> tuple[int, str, str]:
+        del input_text, env
+        if command == ("docker", "inspect", "-f", "{{.Image}}", "ctr-1"):
+            return 0, "sha256:current\n", ""
+        if command == (
+            "docker",
+            "image",
+            "inspect",
+            "-f",
+            "{{.Id}}",
+            "runtime:latest",
+        ):
+            return image_result
+        raise AssertionError(f"unexpected command: {command}")
+
+    controller = DockerCodexManagedSessionController(
+        workspace_volume_name="agent_workspaces",
+        codex_volume_name="codex_auth_volume",
+        workspace_root=str(tmp_path / "agent_jobs"),
+        session_store=ManagedSessionStore(tmp_path / "session-store"),
+        command_runner=runner,
+    )
+
+    assert not await controller._container_uses_current_image(
+        container_id="ctr-1",
+        image_ref="runtime:latest",
+    )
+
+    image_result = (1, "", "Error response from daemon: API unavailable")
+    with pytest.raises(
+        RuntimeError,
+        match="failed to inspect configured managed session image:.*API unavailable",
+    ):
+        await controller._container_uses_current_image(
+            container_id="ctr-1",
+            image_ref="runtime:latest",
+        )
+
 
 def test_controller_launch_duplicate_match_requires_epoch_and_thread(
     tmp_path: Path,

--- a/tests/unit/workflows/temporal/test_temporal_service.py
+++ b/tests/unit/workflows/temporal/test_temporal_service.py
@@ -2562,12 +2562,10 @@ async def test_record_terminal_state_preserves_existing_terminal_summary(
         assert canceled is not None
         assert canceled.state is MoonMindWorkflowState.CANCELED
         assert canceled.close_status is TemporalExecutionCloseStatus.CANCELED
-        mock_client_adapter.update_workflow.assert_called_once_with(
-            created.workflow_id,
-            "Cancel",
-            "operator requested cancellation",
+        mock_client_adapter.update_workflow.assert_not_called()
+        mock_client_adapter.cancel_workflow.assert_awaited_once_with(
+            created.workflow_id
         )
-        mock_client_adapter.cancel_workflow.assert_not_called()
         assert canceled.memo["summary"] == "operator requested cancellation"
 
 
@@ -5295,12 +5293,10 @@ async def test_cancel_execution_records_reject_audit_action(
         )
         assert canceled.closed_at is not None
         assert canceled.search_attributes["mm_state"] == "canceled"
-        mock_client_adapter.update_workflow.assert_called_once_with(
-            created.workflow_id,
-            "Cancel",
-            "Rejected by operator.",
+        mock_client_adapter.update_workflow.assert_not_called()
+        mock_client_adapter.cancel_workflow.assert_awaited_once_with(
+            created.workflow_id
         )
-        mock_client_adapter.cancel_workflow.assert_not_called()
 
 @pytest.mark.asyncio
 async def test_cancel_execution_accepts_projection_only_child_workflow(
@@ -5365,12 +5361,8 @@ async def test_cancel_execution_accepts_projection_only_child_workflow(
         assert canceled.memo["summary"] == "stop child"
         assert canceled.memo["intervention_audit"][-1]["action"] == "cancel"
         assert canceled.search_attributes["mm_state"] == "canceled"
-        mock_client_adapter.update_workflow.assert_called_once_with(
-            workflow_id,
-            "Cancel",
-            "stop child",
-        )
-        mock_client_adapter.cancel_workflow.assert_not_called()
+        mock_client_adapter.update_workflow.assert_not_called()
+        mock_client_adapter.cancel_workflow.assert_awaited_once_with(workflow_id)
 
 @pytest.mark.asyncio
 async def test_cancel_execution_rejects_orphaned_projection_only_workflow(
@@ -5476,7 +5468,7 @@ async def test_cancel_execution_best_effort_terminates_workflow_scoped_codex_ses
                     "TerminateSession",
                     {"reason": "stop"},
                 ),
-                call.update_workflow(created.workflow_id, "Cancel", "stop"),
+                call.cancel_workflow(created.workflow_id),
             ],
             any_order=False,
         )
@@ -5541,7 +5533,7 @@ async def test_cancel_execution_prefers_direct_session_record_load_for_codex_tas
                     "TerminateSession",
                     {"reason": "stop"},
                 ),
-                call.update_workflow(created.workflow_id, "Cancel", "stop"),
+                call.cancel_workflow(created.workflow_id),
             ],
             any_order=False,
         )
@@ -5603,11 +5595,13 @@ async def test_cancel_execution_ignores_best_effort_session_terminate_failure(
                     "TerminateSession",
                     {"reason": "stop"},
                 ),
-                call.update_workflow(created.workflow_id, "Cancel", "stop"),
+                call.cancel_workflow(created.workflow_id),
             ],
             any_order=False,
         )
-        mock_client_adapter.cancel_workflow.assert_not_called()
+        mock_client_adapter.cancel_workflow.assert_awaited_once_with(
+            created.workflow_id
+        )
 
 @pytest.mark.asyncio
 async def test_forced_cancel_marks_failed_with_terminated_close_status(

--- a/tests/unit/workflows/temporal/workflows/test_run_signals_updates.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_signals_updates.py
@@ -9,6 +9,7 @@ from temporalio.testing import WorkflowEnvironment
 from temporalio.worker import Worker, UnsandboxedWorkflowRunner
 
 from temporalio import workflow
+from temporalio.client import WorkflowExecutionStatus, WorkflowFailureError
 from temporalio.exceptions import ActivityError
 from temporalio.workflow import ActivityCancellationType
 from moonmind.workflows.temporal.activity_catalog import ARTIFACTS_TASK_QUEUE
@@ -25,6 +26,13 @@ class _NestedFailure(Exception):
     def __init__(self, message: str, cause: BaseException | None = None) -> None:
         super().__init__(message)
         self.cause = cause
+
+
+@workflow.defn(name="CancellationBoundaryChild")
+class _CancellationBoundaryChild:
+    @workflow.run
+    async def run(self) -> None:
+        await workflow.wait_condition(lambda: False)
 
 
 async def fake_execute_activity(activity_name, *args, **kwargs):
@@ -339,6 +347,74 @@ async def test_run_workflow_cancel_signal(mock_run_environment):
             await handle.execute_update("Cancel")
             result = await handle.result()
             assert result["status"] == "canceled"
+
+
+@pytest.mark.asyncio
+async def test_temporal_cancel_propagates_to_active_agent_child(
+    mock_run_environment,
+    monkeypatch,
+):
+    task_queue = "test-task-queue-authoritative-cancel"
+    child_workflow_id = "test-wf-authoritative-cancel:agent:active-step"
+
+    async def execute_blocking_child(self, *args, **kwargs):
+        del args, kwargs
+        self._active_agent_child_workflow_id = child_workflow_id
+        try:
+            await workflow.execute_child_workflow(
+                _CancellationBoundaryChild.run,
+                id=child_workflow_id,
+                task_queue=task_queue,
+            )
+        finally:
+            self._active_agent_child_workflow_id = None
+
+    monkeypatch.setattr(
+        MoonMindUserWorkflow,
+        "_run_execution_stage",
+        execute_blocking_child,
+    )
+
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        async with Worker(
+            env.client,
+            task_queue=task_queue,
+            workflows=[MoonMindUserWorkflow, _CancellationBoundaryChild],
+            workflow_runner=UnsandboxedWorkflowRunner(),
+        ):
+            parent_handle = await env.client.start_workflow(
+                MoonMindUserWorkflow.run,
+                {
+                    "workflow_type": "MoonMind.UserWorkflow",
+                    "initial_parameters": {},
+                    "plan_artifact_ref": "ref-123",
+                },
+                id="test-wf-authoritative-cancel",
+                task_queue=task_queue,
+            )
+            child_handle = env.client.get_workflow_handle(child_workflow_id)
+
+            for _ in range(50):
+                try:
+                    child_description = await child_handle.describe()
+                except Exception:
+                    await asyncio.sleep(0.02)
+                    continue
+                if child_description.status is WorkflowExecutionStatus.RUNNING:
+                    break
+                await asyncio.sleep(0.02)
+            else:
+                pytest.fail("active AgentRun child did not start")
+
+            await parent_handle.cancel()
+            with pytest.raises(WorkflowFailureError):
+                await parent_handle.result()
+
+            parent_description = await parent_handle.describe()
+            child_description = await child_handle.describe()
+            assert parent_description.status is WorkflowExecutionStatus.CANCELED
+            assert child_description.status is WorkflowExecutionStatus.CANCELED
+
 
 @pytest.mark.asyncio
 async def test_recovery_forwards_operator_message_to_active_jules_child(monkeypatch):

--- a/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
@@ -4460,6 +4460,109 @@ def test_run_reads_nested_workload_metadata_from_legacy_workload_result(
     assert "stdout" not in step["workload"]
 
 @pytest.mark.asyncio
+async def test_run_execution_stage_propagates_agent_child_cancellation_under_continue(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _configure_workflow_runtime(monkeypatch)
+    workflow = MoonMindRunWorkflow()
+    workflow._owner_id = "owner-1"
+    plan_payload = _approval_policy_plan_payload()
+    plan_payload["policy"]["failure_mode"] = "CONTINUE"
+    artifact_sequence = iter(range(1, 20))
+
+    async def fake_execute_activity(
+        activity_type: str,
+        payload: Any,
+        **_kwargs: Any,
+    ) -> Any:
+        if activity_type == "resilience.compile_policy":
+            return _resilience_policy_compile_result(payload)
+        if activity_type == "provider_profile.list":
+            return {"profiles": []}
+        if activity_type == "artifact.create":
+            if str(payload.get("name") or "").startswith(
+                "reports/resilience_policy"
+            ):
+                return _resilience_policy_artifact_create_result()
+            return (
+                {"artifact_id": f"art_{next(artifact_sequence)}"},
+                {"upload_url": "unused"},
+            )
+        if activity_type == "agent_runtime.capture_workspace_checkpoint":
+            return _managed_checkpoint_capture_result(payload)
+        if activity_type == "step_checkpoint.create":
+            return _checkpoint_create_result(payload)
+        raise AssertionError(f"unexpected activity: {activity_type}")
+
+    async def fake_execute_child_workflow(
+        _workflow_type: str,
+        _args: Any,
+        **_kwargs: Any,
+    ) -> Any:
+        raise run_module.CancelledError("parent cancellation")
+
+    async def fake_execute_typed_activity(
+        activity_type: str,
+        payload: Any,
+        **_kwargs: Any,
+    ) -> Any:
+        if activity_type == "artifact.read":
+            artifact_ref = getattr(payload, "artifact_ref", None)
+            if artifact_ref == "art_plan_1":
+                return json.dumps(plan_payload).encode("utf-8")
+            if artifact_ref == "artifact://registry/1":
+                return json.dumps(_registry_payload()).encode("utf-8")
+        if activity_type == "artifact.write_complete":
+            return {"ok": True}
+        raise AssertionError(f"unexpected typed activity: {activity_type}")
+
+    monkeypatch.setattr(
+        run_module.workflow,
+        "execute_activity",
+        fake_execute_activity,
+    )
+    monkeypatch.setattr(
+        run_module.workflow,
+        "execute_child_workflow",
+        fake_execute_child_workflow,
+    )
+    monkeypatch.setattr(
+        run_module,
+        "execute_typed_activity",
+        fake_execute_typed_activity,
+    )
+    monkeypatch.setattr(run_module.workflow, "patched", lambda _patch_id: True)
+
+    with pytest.raises(run_module.CancelledError, match="parent cancellation"):
+        await workflow._run_execution_stage(
+            parameters={"repo": "MoonLadderStudios/MoonMind"},
+            plan_ref="art_plan_1",
+        )
+
+    step = workflow.get_step_ledger()["steps"][0]
+    assert step["status"] == "awaiting_external"
+
+
+def test_agent_child_cancellation_propagation_preserves_pre_patch_histories(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cancellation = run_module.CancelledError("parent cancellation")
+    monkeypatch.setattr(run_module.workflow, "patched", lambda _patch_id: False)
+    assert not MoonMindRunWorkflow._should_propagate_agent_child_cancellation(
+        cancellation
+    )
+
+    monkeypatch.setattr(
+        run_module.workflow,
+        "patched",
+        lambda patch_id: (
+            patch_id == run_module.RUN_PROPAGATE_AGENT_CHILD_CANCELLATION_PATCH
+        ),
+    )
+    assert MoonMindRunWorkflow._should_propagate_agent_child_cancellation(cancellation)
+
+
+@pytest.mark.asyncio
 async def test_run_execution_stage_marks_step_reviewing_and_records_passed_check(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary

- make graceful execution cancellation use authoritative Temporal cancellation so active child workflows close and provider leases are released
- prevent managed Codex sessions from reusing containers whose immutable image identity no longer matches the configured mutable image reference
- add service, runtime, and real Temporal parent/child cancellation regression coverage

## Root cause

The cancellation endpoint updated a user workflow's projected state without canceling its Temporal execution. A parent blocked on an active AgentRun child could therefore remain live after appearing canceled and continue consuming the only provider slot. Separately, managed-session reuse compared the configured image reference rather than Docker's immutable image identity, allowing a pre-deployment container behind `latest` to survive a rollout.

## Impact

Canceled workflows now release their active child and provider capacity through Temporal's authoritative cancellation path. New turns also replace stale managed-session containers after the local image tag moves.

## Validation

- `MM-917 removed capability semantics check passed`
- `status domain audit passed`
- targeted regression selection: 15 passed
- affected-file suite: 290 passed, with one unrelated deployment-environment-sensitive assertion excluded
- live deployment recovery verified the formerly stalled workflow completed successfully
- recreated API and agent-runtime services reported healthy and loaded the patched code
