### PR TITLE
Fix MoonSpec remediation and draft handoff

### DIFF
--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -626,6 +626,9 @@ RUN_MOONSPEC_GATE_CONTRACT_REPAIR_PATCH = "run-moonspec-gate-contract-repair-v1"
 RUN_BOUNDED_STORY_LOOP_PROGRESS_BUDGET_PATCH = (
     "run-bounded-story-loop-progress-budget-v1"
 )
+RUN_BOUNDED_STORY_LOOP_FEEDBACK_PROGRESS_PATCH = (
+    "run-bounded-story-loop-feedback-progress-v1"
+)
 RUN_MOONSPEC_GATE_CONTRACT_REPAIR_FRESH_SOURCE_PATCH = (
     "run-moonspec-gate-contract-repair-fresh-source-v1"
 )
@@ -634,6 +637,9 @@ RUN_MOONSPEC_GATE_ENVIRONMENT_DRAFT_PUBLISH_PATCH = (
 )
 RUN_MOONSPEC_ADDITIONAL_WORK_DRAFT_PUBLISH_PATCH = (
     "run-moonspec-additional-work-draft-publish-v1"
+)
+RUN_MOONSPEC_DRAFT_PUBLISH_RECOVERY_HANDOFF_PATCH = (
+    "run-moonspec-draft-publish-recovery-handoff-v1"
 )
 RUN_AUTHORITATIVE_PUBLISH_OUTCOME_PATCH = "run-authoritative-publish-outcome-v1"
 RUN_STEP_RETRY_OVERRIDES_PATCH = "run-step-retry-overrides-v1"
@@ -6315,6 +6321,15 @@ class MoonMindRunWorkflow:
             ),
             "recoverableInCurrentRuntime": gate_result.recoverable_in_current_runtime,
         }
+        if self._patched_or_false_outside_workflow(
+            RUN_BOUNDED_STORY_LOOP_FEEDBACK_PROGRESS_PATCH
+        ):
+            # Verifiers may report their remaining gaps in feedback even when
+            # they omit the optional structured issues/remainingWorkRef fields.
+            # Excluding that authoritative summary makes distinct verifier
+            # reports look identical and can exhaust the no-progress budget
+            # after the first remediation attempt.
+            progress_payload["feedback"] = gate_result.feedback
         progress_signature = hashlib.sha256(
             json.dumps(
                 progress_payload,
@@ -10838,6 +10853,29 @@ class MoonMindRunWorkflow:
                                 )
                             )
                             self._summary = draft_summary
+                            # Draft publication is an explicit recovery handoff.
+                            # The remaining plan is skipped below, so preserve
+                            # already-pushed changes for the post-loop native PR
+                            # boundary even when an earlier auxiliary tool result
+                            # left a stale not_required/no-commit projection.
+                            if workflow.patched(
+                                RUN_MOONSPEC_DRAFT_PUBLISH_RECOVERY_HANDOFF_PATCH
+                            ) and self._execution_result_has_publishable_changes(
+                                execution_result
+                            ):
+                                require_pull_request_url = True
+                                if self._publish_status in {
+                                    "not_required",
+                                    "skipped",
+                                }:
+                                    self._publish_status = None
+                                    self._publish_reason = None
+                                    self._publish_context.pop(
+                                        "noCommitPublish", None
+                                    )
+                                    self._publish_context.pop(
+                                        "noChangePublish", None
+                                    )
                             self._mark_remaining_plan_steps_skipped(
                                 ordered_nodes=ordered_nodes,
                                 completed_index=index - 1,

--- a/tests/unit/workflows/temporal/test_run_artifacts.py
+++ b/tests/unit/workflows/temporal/test_run_artifacts.py
@@ -5075,6 +5075,213 @@ async def test_run_execution_stage_moonspec_verify_blocks_native_pr_creation(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("recovery_handoff_enabled", "expect_create_pr"),
+    [(False, False), (True, True)],
+)
+async def test_run_execution_stage_additional_work_publishes_pushed_branch_as_draft(
+    monkeypatch: pytest.MonkeyPatch,
+    recovery_handoff_enabled: bool,
+    expect_create_pr: bool,
+) -> None:
+    """A skipped normal handoff must not suppress the recovery draft."""
+    workflow = MoonMindRunWorkflow()
+    workflow._owner_id = "owner-1"
+    workflow._repo = "MoonLadderStudios/MoonMind"
+    workflow._publish_status = "not_required"
+    workflow._publish_reason = "Earlier issue update required no PR output."
+    create_pr_payload: dict[str, object] | None = None
+
+    async def fake_execute_activity(
+        activity_type: str,
+        payload: dict[str, object] | None = None,
+        **_kwargs: object,
+    ) -> object:
+        nonlocal create_pr_payload
+        if activity_type == "repo.create_pr":
+            create_pr_payload = dict(payload or {})
+            return {
+                "url": "https://github.com/MoonLadderStudios/MoonMind/pull/999",
+                "created": True,
+                "adopted": False,
+                "headSha": "abc123",
+            }
+        if activity_type == "agent_skill.resolve":
+            return {
+                "manifestRef": "art_skill_snapshot_1",
+                "skills": [{"name": "moonspec-verify"}],
+            }
+        if activity_type == "artifact.read":
+            artifact_ref = (
+                payload.get("artifact_ref")
+                if isinstance(payload, dict)
+                else getattr(payload, "artifact_ref", None)
+            ) if payload is not None else None
+            if artifact_ref == "artifact://registry/1":
+                return json.dumps({"skills": []}).encode("utf-8")
+            return json.dumps(
+                {
+                    "plan_version": "1.0",
+                    "metadata": {
+                        "title": "MoonSpec exhausted remediation draft",
+                        "created_at": "2026-07-17T00:00:00Z",
+                        "registry_snapshot": {
+                            "digest": "reg:sha256:" + ("a" * 64),
+                            "artifact_ref": "artifact://registry/1",
+                        },
+                    },
+                    "policy": {
+                        "failure_mode": "FAIL_FAST",
+                        "max_concurrency": 1,
+                    },
+                    "nodes": [
+                        {
+                            "id": "verify-remediation-1",
+                            "tool": {
+                                "type": "agent_runtime",
+                                "name": "auto",
+                            },
+                            "inputs": {
+                                "runtime": {"mode": "codex"},
+                                "selectedSkill": "moonspec-verify",
+                                "targetBranch": "partial-work",
+                                "title": "Verify remediation attempt 1 of 1",
+                                "annotations": {
+                                    "issueImplementRole": (
+                                        "moonspec-verification-gate"
+                                    ),
+                                    "moonSpecRemediationAttempt": 1,
+                                    "moonSpecRemediationMaxAttempts": 1,
+                                    "moonSpecFinalRemediationGate": True,
+                                },
+                                "instructions": "Verify the final remediation.",
+                            },
+                            "options": {},
+                        }
+                    ],
+                    "edges": [],
+                }
+            ).encode("utf-8")
+        return {"status": "COMPLETED", "outputs": {}}
+
+    async def fake_execute_child_workflow(
+        _workflow_type: str,
+        _request: object,
+        **_kwargs: object,
+    ) -> object:
+        return {
+            "summary": "Verdict: ADDITIONAL_WORK_NEEDED",
+            "metadata": {
+                "verdict": "ADDITIONAL_WORK_NEEDED",
+                "recommendedNextAction": "reattempt_current_step",
+                "operator_summary": "One retry-stability gap remains.",
+                "diagnostics_ref": "art_verify_remaining_work",
+                "push_status": "pushed",
+                "push_branch": "partial-work",
+                "push_base_ref": "origin/main",
+                "push_commit_count": 2,
+                "push_head_sha": "abc123",
+            },
+            "output_refs": [],
+        }
+
+    async def fake_bind_workflow_scoped_session(
+        self: MoonMindRunWorkflow,
+        request: object,
+    ) -> object:
+        return request
+
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "execute_activity",
+        fake_execute_activity,
+    )
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "execute_child_workflow",
+        fake_execute_child_workflow,
+    )
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "wait_condition",
+        _immediate_wait_condition,
+    )
+    monkeypatch.setattr(
+        MoonMindRunWorkflow,
+        "_maybe_bind_workflow_scoped_session",
+        fake_bind_workflow_scoped_session,
+    )
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "upsert_memo",
+        lambda _memo: None,
+    )
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "upsert_search_attributes",
+        lambda _attributes: None,
+    )
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "now",
+        lambda: datetime.now(timezone.utc),
+    )
+    workflow_info = type(
+        "WorkflowInfo",
+        (),
+        {"namespace": "default", "workflow_id": "wf-1", "run_id": "run-1"},
+    )
+    monkeypatch.setattr(run_workflow_module.workflow, "info", workflow_info)
+    enabled_patches = {
+        run_workflow_module.RUN_CONDITIONAL_REGISTRY_READ_PATCH,
+        run_workflow_module.NATIVE_PR_BRANCH_DEFAULTS_PATCH,
+        run_workflow_module.RUN_MOONSPEC_VERIFY_PUBLICATION_GATE_PATCH,
+        run_workflow_module.RUN_MOONSPEC_VERIFY_REMEDIATION_INDEX_PATCH,
+        run_workflow_module.RUN_PLAN_ROUTED_MOONSPEC_REMEDIATION_PATCH,
+        run_workflow_module.RUN_MOONSPEC_ADDITIONAL_WORK_DRAFT_PUBLISH_PATCH,
+    }
+    if recovery_handoff_enabled:
+        enabled_patches.add(
+            run_workflow_module.RUN_MOONSPEC_DRAFT_PUBLISH_RECOVERY_HANDOFF_PATCH
+        )
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "patched",
+        lambda patch_id: patch_id in enabled_patches,
+    )
+
+    await workflow._run_execution_stage(
+        parameters={
+            "repo": "MoonLadderStudios/MoonMind",
+            "publishMode": "pr",
+        },
+        plan_ref="art_plan_1",
+    )
+
+    if not expect_create_pr:
+        assert create_pr_payload is None
+        assert workflow._pull_request_url is None
+        assert workflow._publish_status == "not_required"
+        assert workflow._publish_context["moonSpecDraftPublication"]["policy"] == (
+            "draft_pr_on_additional_work_needed"
+        )
+        return
+
+    assert create_pr_payload is not None
+    assert create_pr_payload["head"] == "partial-work"
+    assert create_pr_payload["base"] == "main"
+    assert create_pr_payload["draft"] is True
+    assert "MoonSpec verification incomplete" in str(create_pr_payload["body"])
+    assert workflow._pull_request_url == (
+        "https://github.com/MoonLadderStudios/MoonMind/pull/999"
+    )
+    assert workflow._publish_status == "published"
+    assert workflow._publish_context["moonSpecDraftPublication"]["policy"] == (
+        "draft_pr_on_additional_work_needed"
+    )
+
+
+@pytest.mark.asyncio
 async def test_run_execution_stage_moonspec_verify_uses_remaining_remediation_budget(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/workflows/temporal/workflows/test_run_bounded_story_loop.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_bounded_story_loop.py
@@ -5,6 +5,7 @@ import pytest
 from moonmind.workflows.skills.approval_policy import StepGateResult
 from moonmind.workflows.temporal.bounded_story_loop import LoopAttempt, TypedGateResult
 from moonmind.workflows.temporal.workflows.run import (
+    RUN_BOUNDED_STORY_LOOP_PROGRESS_BUDGET_PATCH,
     MoonMindRunWorkflow,
     bounded_story_loop_resume_decision,
     bounded_story_loop_scope_guard,
@@ -359,6 +360,93 @@ def test_parent_loop_continues_when_verification_progress_changes(
     assert first["gate"]["progressSignature"] != second["gate"]["progressSignature"]
     assert second["continueLoop"] is True
     assert second["reason"] == "verification_requested_remediation"
+
+
+def test_parent_loop_progress_tracks_changed_verifier_feedback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Sparse structured gates still carry progress in verifier feedback."""
+    workflow = MoonMindRunWorkflow()
+    monkeypatch.setattr(workflow, "_patched_or_false_outside_workflow", lambda _: True)
+    workflow._step_terminal_dispositions.update(
+        {"verify-1": "accepted", "verify-2": "accepted"}
+    )
+    ordered_nodes = [
+        {"id": "verify-1", "inputs": {"selectedSkill": "moonspec-verify"}},
+        {
+            "id": "remediate-1",
+            "inputs": {
+                "annotations": {"jiraOrchestrateRole": "moonspec-remediation"}
+            },
+        },
+        {"id": "verify-2", "inputs": {"selectedSkill": "moonspec-verify"}},
+        {
+            "id": "remediate-2",
+            "inputs": {
+                "annotations": {"jiraOrchestrateRole": "moonspec-remediation"}
+            },
+        },
+    ]
+
+    first = workflow._bounded_story_loop_continuation_decision(
+        logical_step_id="verify-1",
+        gate_result=StepGateResult(
+            verdict="ADDITIONAL_WORK_NEEDED",
+            feedback="Proxy events are buffered until terminal capture.",
+            recommended_next_action="reattempt_current_step",
+        ),
+        gate_result_ref="artifact://gate/initial",
+        ordered_nodes=ordered_nodes,
+        current_index=0,
+    )
+    second = workflow._bounded_story_loop_continuation_decision(
+        logical_step_id="verify-2",
+        gate_result=StepGateResult(
+            verdict="ADDITIONAL_WORK_NEEDED",
+            feedback="Active journals exist; retry-stable cursors remain.",
+            recommended_next_action="reattempt_current_step",
+        ),
+        gate_result_ref="artifact://gate/remediation-1",
+        ordered_nodes=ordered_nodes,
+        current_index=2,
+    )
+
+    assert first["gate"]["progressSignature"] != second["gate"]["progressSignature"]
+    assert second["continueLoop"] is True
+    assert second["nextAttemptKind"] == "remediation"
+
+
+def test_feedback_progress_patch_preserves_prior_history_signature(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workflow = MoonMindRunWorkflow()
+    monkeypatch.setattr(
+        workflow,
+        "_patched_or_false_outside_workflow",
+        lambda patch_id: patch_id
+        == RUN_BOUNDED_STORY_LOOP_PROGRESS_BUDGET_PATCH,
+    )
+
+    first = workflow._bounded_story_loop_gate_from_step_gate(
+        gate_result=StepGateResult(
+            verdict="ADDITIONAL_WORK_NEEDED",
+            feedback="Initial remaining work.",
+        ),
+        gate_result_ref="artifact://gate/one",
+        logical_step_id="verify-1",
+        progress_budget_enabled=True,
+    )
+    second = workflow._bounded_story_loop_gate_from_step_gate(
+        gate_result=StepGateResult(
+            verdict="ADDITIONAL_WORK_NEEDED",
+            feedback="Changed remaining work.",
+        ),
+        gate_result_ref="artifact://gate/two",
+        logical_step_id="verify-2",
+        progress_budget_enabled=True,
+    )
+
+    assert first.progress_signature == second.progress_signature
 
 
 def test_parent_loop_progress_tracks_remaining_work_refs(


### PR DESCRIPTION
## Summary

- include verifier feedback in MoonSpec remediation progress signatures so materially changed sparse reports advance to the next bounded attempt
- preserve already-pushed partial work when draft publication activates, clearing stale auxiliary `not_required` projections before the native PR handoff
- guard both workflow changes with Temporal patch markers and cover prior-history behavior

## Root cause

Workflow `mm:e4d54314-1573-464b-9972-a4ca02fe9fc8` had five remediation attempts remaining, but its verifier omitted optional structured issue and remaining-work references. The no-progress signature therefore ignored the changed verifier summary and stopped after attempt 1.

Draft policy then activated, but an earlier auxiliary step had left the run-level publish projection at `not_required`. The native PR boundary honored that stale projection and skipped draft creation despite two pushed commits.

## Validation

- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/workflows/test_run_bounded_story_loop.py tests/unit/workflows/temporal/test_run_artifacts.py` — 105 Python tests and 1,090 frontend tests passed
- `.venv/bin/pytest tests/unit/workflows/temporal/test_run_replayer.py -q --tb=short` — 5 passed
- `uvx ruff check ...` — passed
- `git diff --check` — passed
