### PR TITLE
Enrich preset workflow titles with issue targets

### DIFF
--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -8915,8 +8915,6 @@ def _derive_task_title(
     normalized_steps: Sequence[Mapping[str, Any]] = (),
 ) -> str | None:
     current_title = str(task_payload.get("title") or "").strip()
-    if current_title and not is_generic_title(current_title):
-        return current_title[:_MAX_TASK_TITLE_LENGTH]
     instructions = str(task_payload.get("instructions") or "").strip()
     has_tool_context = normalized_tool is not None or any(
         isinstance(task_payload.get(key), Mapping)
@@ -10086,10 +10084,7 @@ async def _create_execution_from_workflow_request(
         normalized_tool=normalized_tool,
         normalized_steps=normalized_steps,
     )
-    if derived_task_title and (
-        "title" not in normalized_task_for_planner
-        or is_generic_title(normalized_task_for_planner.get("title"))
-    ):
+    if derived_task_title:
         normalized_task_for_planner["title"] = derived_task_title
 
     # --- Model resolution ---

--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -8920,7 +8920,12 @@ def _derive_task_title(
         isinstance(task_payload.get(key), Mapping)
         for key in ("tool", "skill", "workflow")
     )
-    if instructions and not has_tool_context and not normalized_steps:
+    if (
+        instructions
+        and not has_tool_context
+        and not normalized_steps
+        and (not current_title or is_generic_title(current_title))
+    ):
         normalized = " ".join(instructions[: _MAX_TASK_TITLE_LENGTH * 2].split())
         if normalized:
             return normalized[:_MAX_TASK_TITLE_LENGTH]

--- a/docs/Api/ExecutionsApiContract.md
+++ b/docs/Api/ExecutionsApiContract.md
@@ -4,7 +4,7 @@
 **Doc type:** API contract 
 **Status:** Draft 
 **Owner:** MoonMind Platform 
-**Last updated:** 2026-06-25 (UTC)
+**Last updated:** 2026-07-16 (UTC)
 **Audience:** backend, dashboard, integrations
 
 **Implementation tracking:** Rollout and backlog notes live under `docs/tmp/` or in gitignored local-only handoffs (for example `artifacts/`), not as migration checklists in canonical `docs/`.
@@ -373,6 +373,15 @@ On successful create:
 - `state` begins as `initializing`,
 - baseline `searchAttributes` and `memo` are materialized,
 - the response body is an `ExecutionModel`.
+
+Display titles are resolved deterministically before `memo` and Visibility
+metadata are materialized. A caller-provided title wins when it is meaningfully
+different from the selected preset or capability label. Otherwise MoonMind
+combines that label with up to two structured targets, such as a Jira issue,
+GitHub `owner/repository#number` issue reference, pull request, branch, or
+failing check. A preset label with no recognized target remains the fallback.
+Generated step identifiers and other execution bookkeeping fields are not title
+targets. Resolved titles are limited to 150 characters.
 
 ### 9.6 Success response
 

--- a/moonmind/workflows/executions/title_derivation.py
+++ b/moonmind/workflows/executions/title_derivation.py
@@ -119,6 +119,10 @@ _PR_URL_RE = re.compile(r"/pull/(\d+)(?=$|[/?#]|\b)", re.IGNORECASE)
 _PR_TEXT_RE = re.compile(r"\b(?:PR|pull request)\s*#?(\d+)\b", re.IGNORECASE)
 _GITHUB_SHORTHAND_RE = re.compile(r"(?<![\w/])#(\d+)\b")
 _MAX_PR_NUMBER_DIGITS = 10
+_MAX_GITHUB_REPOSITORY_LENGTH = 200
+_GITHUB_REPOSITORY_CHARS = frozenset(
+    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_.-"
+)
 
 
 @dataclass(frozen=True)
@@ -268,24 +272,7 @@ def _capability_label(
             if payload is not None
         )
 
-    template_payloads = [
-        payload
-        for payload in (
-            _mapping(task_payload.get("taskTemplate")),
-            _mapping(task_payload.get("task_template")),
-            (
-                _mapping(workflow_payload.get("taskTemplate"))
-                if workflow_payload
-                else None
-            ),
-            (
-                _mapping(workflow_payload.get("task_template"))
-                if workflow_payload
-                else None
-            ),
-        )
-        if payload is not None
-    ]
+    template_payloads = _preset_payloads(task_payload)
     # A selected preset is the workflow-level capability. Its label must win over
     # the normalized first-step tool, which is only one implementation detail of
     # the expanded preset.
@@ -622,7 +609,16 @@ def _first_step_title(
 
 
 def _preset_slug(task_payload: Mapping[str, Any]) -> str | None:
-    candidates: list[Any] = []
+    for template in _preset_payloads(task_payload):
+        for key in ("slug", "name", "id"):
+            value = _clean_text(template.get(key))
+            if value:
+                return value
+    return None
+
+
+def _preset_payloads(task_payload: Mapping[str, Any]) -> list[Mapping[str, Any]]:
+    presets: list[Mapping[str, Any]] = []
     for payload in (task_payload, _mapping(task_payload.get("workflow"))):
         if payload is None:
             continue
@@ -630,14 +626,15 @@ def _preset_slug(task_payload: Mapping[str, Any]) -> str | None:
             payload.get("task_template")
         )
         if template is not None:
-            candidates.extend(
-                template.get(key) for key in ("slug", "name", "id") if template.get(key)
+            presets.append(template)
+        applied_templates = payload.get("appliedStepTemplates") or payload.get(
+            "applied_step_templates"
+        )
+        if isinstance(applied_templates, list):
+            presets.extend(
+                item for item in applied_templates if isinstance(item, Mapping)
             )
-    for candidate in candidates:
-        value = _clean_text(candidate)
-        if value:
-            return value
-    return None
+    return presets
 
 
 def _extract_issue_from_mapping(
@@ -728,13 +725,19 @@ def _extract_github_issue(text: str) -> str | None:
 
 def _render_github_issue(repository: str, digits: str) -> str | None:
     normalized_repository = repository.strip()
-    if not re.fullmatch(
-        r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+",
-        normalized_repository,
+    if len(normalized_repository) > _MAX_GITHUB_REPOSITORY_LENGTH:
+        return None
+    repository_parts = normalized_repository.split("/")
+    if len(repository_parts) != 2 or any(not part for part in repository_parts):
+        return None
+    if any(
+        character not in _GITHUB_REPOSITORY_CHARS
+        for part in repository_parts
+        for character in part
     ):
         return None
-    issue_num = digits.lstrip("0") or "0"
-    if not issue_num.isdigit() or len(issue_num) > _MAX_PR_NUMBER_DIGITS:
+    issue_num = digits.lstrip("0")
+    if not issue_num or not issue_num.isdigit() or len(issue_num) > _MAX_PR_NUMBER_DIGITS:
         return None
     return f"{normalized_repository}#{issue_num}"
 

--- a/moonmind/workflows/executions/title_derivation.py
+++ b/moonmind/workflows/executions/title_derivation.py
@@ -48,10 +48,16 @@ _REPOSITORY_KEYS = {
     "giturl",
 }
 _ISSUE_KEYS = {
+    "github_issue",
+    "github_issue_ref",
+    "githubissue",
+    "githubissueref",
     "issue",
     "issue_key",
+    "issue_ref",
     "issue_url",
     "issuekey",
+    "issueref",
     "issueurl",
     "jira_issue",
     "jira_issue_key",
@@ -85,6 +91,7 @@ _BRANCH_KEYS = {
 _CHECK_KEYS = {"check", "checkname", "check_name", "job", "jobname", "job_name"}
 _IGNORED_VALUE_KEYS = {
     "effort",
+    "id",
     "mode",
     "model",
     "profileid",
@@ -93,9 +100,21 @@ _IGNORED_VALUE_KEYS = {
     "requested_model",
     "targetruntime",
     "target_runtime",
+    "stepid",
+    "step_id",
+    "templatestepid",
+    "template_step_id",
 }
 
 _ISSUE_RE = re.compile(r"\b([A-Z][A-Z0-9]+-\d+)\b")
+_GITHUB_ISSUE_REF_RE = re.compile(
+    r"(?<![\w/])([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)#(\d+)\b"
+)
+_GITHUB_ISSUE_URL_RE = re.compile(
+    r"github\.com/([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)/issues/(\d+)"
+    r"(?=$|[/?#]|\b)",
+    re.IGNORECASE,
+)
 _PR_URL_RE = re.compile(r"/pull/(\d+)(?=$|[/?#]|\b)", re.IGNORECASE)
 _PR_TEXT_RE = re.compile(r"\b(?:PR|pull request)\s*#?(\d+)\b", re.IGNORECASE)
 _GITHUB_SHORTHAND_RE = re.compile(r"(?<![\w/])#(\d+)\b")
@@ -166,13 +185,14 @@ def synthesize_execution_title(
 ) -> SynthesizedWorkflowTitle:
     task_payload = parameters or {}
     explicit = str(requested_title or "").strip()
-    generated_explicit = _is_generated_step_title(
+    label = _capability_label(task_payload, normalized_tool, normalized_steps)
+    generated_explicit = _is_generated_title(
         explicit,
+        label=label,
         task_payload=task_payload,
         normalized_steps=normalized_steps,
     )
 
-    label = _capability_label(task_payload, normalized_tool, normalized_steps)
     targets = _collect_structured_targets(task_payload)
     fallback_targets = _collect_text_fallback_targets(requested_title, task_payload)
     if not targets:
@@ -266,9 +286,12 @@ def _capability_label(
         )
         if payload is not None
     ]
+    # A selected preset is the workflow-level capability. Its label must win over
+    # the normalized first-step tool, which is only one implementation detail of
+    # the expanded preset.
     tool_payloads = [
         payload
-        for payload in (normalized_tool, *raw_tool_payloads, *template_payloads)
+        for payload in (*template_payloads, normalized_tool, *raw_tool_payloads)
         if payload is not None
     ]
 
@@ -362,10 +385,11 @@ def _append_targets_for_value(
     path: str,
 ) -> None:
     if key in _ISSUE_KEYS and isinstance(value, Mapping):
+        provider = _issue_provider_for_key(key)
         issue = _extract_issue_from_mapping(
             value,
             path=path,
-            provider="jira" if "jira" in key else None,
+            provider=provider,
         )
         if issue is not None:
             targets.append(issue)
@@ -376,6 +400,20 @@ def _append_targets_for_value(
         return
 
     if key in _ISSUE_KEYS:
+        provider = _issue_provider_for_key(key)
+        github_issue = _extract_github_issue(text)
+        if github_issue and provider != "jira":
+            targets.append(
+                TitleTarget(
+                    "issue",
+                    github_issue,
+                    0,
+                    path,
+                    provider="github",
+                    key=github_issue,
+                )
+            )
+            return
         issue = _extract_issue(text)
         if issue:
             targets.append(
@@ -384,7 +422,7 @@ def _append_targets_for_value(
                     issue,
                     0,
                     path,
-                    provider="jira" if "jira" in key else None,
+                    provider="jira" if provider == "jira" else None,
                     key=issue,
                 )
             )
@@ -417,6 +455,19 @@ def _append_targets_for_value(
     if issue:
         targets.append(TitleTarget("issue", issue, 0, path, key=issue))
         return
+    github_issue = _extract_github_issue(text)
+    if github_issue:
+        targets.append(
+            TitleTarget(
+                "issue",
+                github_issue,
+                0,
+                path,
+                provider="github",
+                key=github_issue,
+            )
+        )
+        return
     pr = _extract_pr(text)
     if pr:
         targets.append(TitleTarget("pull_request", pr, 1, path, key=pr))
@@ -440,6 +491,18 @@ def _collect_text_fallback_targets(
         issue = _extract_issue(text)
         if issue:
             targets.append(TitleTarget("issue", issue, 0, f"text[{index}]", key=issue))
+        github_issue = _extract_github_issue(text)
+        if github_issue:
+            targets.append(
+                TitleTarget(
+                    "issue",
+                    github_issue,
+                    0,
+                    f"text[{index}]",
+                    provider="github",
+                    key=github_issue,
+                )
+            )
         pr = _extract_pr(text, allow_shorthand=True)
         if pr:
             targets.append(TitleTarget("pull_request", pr, 1, f"text[{index}]", key=pr))
@@ -505,9 +568,10 @@ def _workflow_type_fallback(workflow_type: str | None) -> str | None:
     return _identifier_to_label(value.rsplit(".", 1)[-1])
 
 
-def _is_generated_step_title(
+def _is_generated_title(
     title: str,
     *,
+    label: str,
     task_payload: Mapping[str, Any],
     normalized_steps: Sequence[Mapping[str, Any]],
 ) -> bool:
@@ -516,8 +580,15 @@ def _is_generated_step_title(
     normalized = " ".join(re.sub(r"[\W_]+", " ", title.casefold()).split())
     if normalized in _GENERATED_STEP_TITLES:
         return True
-    if not _preset_slug(task_payload):
+    preset_slug = _preset_slug(task_payload)
+    if not preset_slug:
         return False
+    preset_label = _identifier_to_label(preset_slug)
+    if title.strip().casefold() in {
+        label.strip().casefold(),
+        preset_label.strip().casefold(),
+    }:
+        return True
     first_step_title = _first_step_title(task_payload, normalized_steps)
     return bool(
         first_step_title
@@ -575,6 +646,33 @@ def _extract_issue_from_mapping(
     path: str,
     provider: str | None,
 ) -> TitleTarget | None:
+    repository = _first_clean_mapping_value(value, "repository", "repo")
+    number = _first_clean_mapping_value(
+        value,
+        "number",
+        "issueNumber",
+        "issue_number",
+    )
+    if provider == "github" or (repository and number):
+        github_issue = _render_github_issue(repository or "", number or "")
+        if not github_issue:
+            return None
+        issue_summary = _first_clean_mapping_value(value, "summary", "title")
+        issue_url = _first_clean_mapping_value(value, "url", "self")
+        display_value = github_issue
+        if issue_summary:
+            display_value = f"{github_issue} — {issue_summary}"
+        return TitleTarget(
+            "issue",
+            display_value,
+            0,
+            path,
+            provider="github",
+            key=github_issue,
+            summary=issue_summary,
+            url=issue_url,
+        )
+
     key = _first_clean_mapping_value(value, "key", "issueKey", "issue_key")
     if key:
         issue_key = _extract_issue(key)
@@ -610,6 +708,35 @@ def _first_clean_mapping_value(value: Mapping[str, Any], *keys: str) -> str | No
 def _extract_issue(text: str) -> str | None:
     match = _ISSUE_RE.search(text.upper())
     return match.group(1) if match else None
+
+
+def _issue_provider_for_key(key: str) -> str | None:
+    if "github" in key:
+        return "github"
+    if "jira" in key:
+        return "jira"
+    return None
+
+
+def _extract_github_issue(text: str) -> str | None:
+    for pattern in (_GITHUB_ISSUE_URL_RE, _GITHUB_ISSUE_REF_RE):
+        match = pattern.search(text)
+        if match:
+            return _render_github_issue(match.group(1), match.group(2))
+    return None
+
+
+def _render_github_issue(repository: str, digits: str) -> str | None:
+    normalized_repository = repository.strip()
+    if not re.fullmatch(
+        r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+",
+        normalized_repository,
+    ):
+        return None
+    issue_num = digits.lstrip("0") or "0"
+    if not issue_num.isdigit() or len(issue_num) > _MAX_PR_NUMBER_DIGITS:
+        return None
+    return f"{normalized_repository}#{issue_num}"
 
 
 def _extract_pr(

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -310,6 +310,17 @@ def test_derive_task_title_enriches_generated_preset_label() -> None:
     )
 
 
+def test_derive_task_title_preserves_explicit_instruction_only_title() -> None:
+    title = _derive_task_title(
+        {
+            "title": "My custom title",
+            "instructions": "Do the work",
+        }
+    )
+
+    assert title == "My custom title"
+
+
 def test_step_execution_detail_payload_exposes_phase_11_ref_only_evidence_summary() -> None:
     payload = _step_execution_detail_payload(
         _phase_11_manifest(),
@@ -7107,13 +7118,19 @@ def test_create_task_shaped_execution_enriches_github_issue_preset_title(
                     "title": "GitHub Issue Implement",
                     "instructions": "Implement the selected GitHub issue.",
                     "runtime": {"mode": "claude_code"},
-                    "taskTemplate": {"slug": "github-issue-implement"},
+                    "appliedStepTemplates": [
+                        {
+                            "slug": "github-issue-implement",
+                            "stepIds": ["step-1"],
+                        }
+                    ],
                     "tool": {
                         "type": "skill",
                         "name": "github.load_issue_preset_brief",
                     },
                     "steps": [
                         {
+                            "id": "step-1",
                             "title": "Load GitHub issue brief",
                             "instructions": "Load the selected GitHub issue.",
                             "tool": {

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -289,6 +289,27 @@ def test_mm_1129_derive_task_title_bounds_instruction_fallback() -> None:
     assert "token-999" not in title
 
 
+def test_derive_task_title_enriches_generated_preset_label() -> None:
+    title = _derive_task_title(
+        {
+            "title": "GitHub Issue Implement",
+            "taskTemplate": {"slug": "github-issue-implement"},
+            "inputs": {
+                "github_issue": {
+                    "repository": "MoonLadderStudios/MoonMind",
+                    "number": 3143,
+                    "title": "Improve generated workflow titles",
+                }
+            },
+        }
+    )
+
+    assert title == (
+        "GitHub Issue Implement: MoonLadderStudios/MoonMind#3143 — "
+        "Improve generated workflow titles"
+    )
+
+
 def test_step_execution_detail_payload_exposes_phase_11_ref_only_evidence_summary() -> None:
     payload = _step_execution_detail_payload(
         _phase_11_manifest(),
@@ -7069,6 +7090,59 @@ def test_create_task_shaped_execution_synthesizes_generic_title(
     assert called_kwargs["title"] == "Jira Verify: KANDY-123"
     initial_parameters = called_kwargs["initial_parameters"]
     assert initial_parameters["workflow"]["title"] == "Jira Verify: KANDY-123"
+
+
+def test_create_task_shaped_execution_enriches_github_issue_preset_title(
+    client: tuple[TestClient, AsyncMock, SimpleNamespace],
+) -> None:
+    test_client, service, _user = client
+    service.create_execution.return_value = _build_execution_record()
+
+    response = test_client.post(
+        "/api/executions",
+        json={
+            "type": "workflow",
+            "payload": {
+                "workflow": {
+                    "title": "GitHub Issue Implement",
+                    "instructions": "Implement the selected GitHub issue.",
+                    "runtime": {"mode": "claude_code"},
+                    "taskTemplate": {"slug": "github-issue-implement"},
+                    "tool": {
+                        "type": "skill",
+                        "name": "github.load_issue_preset_brief",
+                    },
+                    "steps": [
+                        {
+                            "title": "Load GitHub issue brief",
+                            "instructions": "Load the selected GitHub issue.",
+                            "tool": {
+                                "type": "skill",
+                                "name": "github.load_issue_preset_brief",
+                            },
+                        }
+                    ],
+                    "inputs": {
+                        "github_issue": {
+                            "repository": "MoonLadderStudios/MoonMind",
+                            "number": 3143,
+                            "title": "Improve generated workflow titles",
+                        },
+                        "github_issue_ref": "MoonLadderStudios/MoonMind#3143",
+                    },
+                }
+            },
+        },
+    )
+
+    assert response.status_code == 201
+    called_kwargs = service.create_execution.await_args.kwargs
+    expected = (
+        "GitHub Issue Implement: MoonLadderStudios/MoonMind#3143 — "
+        "Improve generated workflow titles"
+    )
+    assert called_kwargs["title"] == expected
+    assert called_kwargs["initial_parameters"]["workflow"]["title"] == expected
 
 
 def test_create_task_shaped_execution_synthesizes_issue_pr_title_without_repo(

--- a/tests/unit/api/test_execution_service.py
+++ b/tests/unit/api/test_execution_service.py
@@ -114,12 +114,8 @@ async def test_cancel_action_routes_to_temporal(
         workflow_id="mm:123", reason="testing", graceful=True
     )
 
-    mock_client_adapter.update_workflow.assert_called_once_with(
-        "mm:123",
-        "Cancel",
-        "testing",
-    )
-    mock_client_adapter.cancel_workflow.assert_not_called()
+    mock_client_adapter.update_workflow.assert_not_called()
+    mock_client_adapter.cancel_workflow.assert_awaited_once_with("mm:123")
     mock_client_adapter.terminate_workflow.assert_not_called()
 
 @pytest.mark.asyncio

--- a/tests/unit/workflows/executions/test_title_derivation.py
+++ b/tests/unit/workflows/executions/test_title_derivation.py
@@ -393,6 +393,76 @@ def test_preserves_meaningful_explicit_title() -> None:
     )
 
 
+def test_enriches_preset_label_from_structured_github_issue() -> None:
+    result = synthesize_execution_title(
+        requested_title="GitHub Issue Implement",
+        parameters={
+            "workflow": {
+                "title": "GitHub Issue Implement",
+                "taskTemplate": {"slug": "github-issue-implement"},
+                "inputs": {
+                    "github_issue": {
+                        "repository": "MoonLadderStudios/MoonMind",
+                        "number": 3143,
+                        "title": "Improve generated workflow titles",
+                    },
+                    "github_issue_ref": "MoonLadderStudios/MoonMind#3143",
+                },
+            }
+        },
+        integration="github",
+    )
+
+    assert result.display_title == (
+        "GitHub Issue Implement: MoonLadderStudios/MoonMind#3143 — "
+        "Improve generated workflow titles"
+    )
+    assert result.source == "integration_target"
+    assert result.confidence == "high"
+    assert result.targets[0].provider == "github"
+    assert result.targets[0].key == "MoonLadderStudios/MoonMind#3143"
+
+
+def test_enriches_any_preset_label_from_github_issue_reference() -> None:
+    result = synthesize_execution_title(
+        requested_title="Issue Quality Review",
+        parameters={
+            "workflow": {
+                "taskTemplate": {"slug": "issue-quality-review"},
+                "inputs": {
+                    "github_issue_ref": "MoonLadderStudios/AnotherRepo#27",
+                },
+            }
+        },
+    )
+
+    assert result.display_title == (
+        "Issue Quality Review: MoonLadderStudios/AnotherRepo#27"
+    )
+    assert result.source == "integration_target"
+
+
+def test_preserves_custom_title_for_structured_github_issue_preset() -> None:
+    result = synthesize_execution_title(
+        requested_title="Fix the workflow title regression",
+        parameters={
+            "workflow": {
+                "taskTemplate": {"slug": "github-issue-implement"},
+                "inputs": {
+                    "github_issue": {
+                        "repository": "MoonLadderStudios/MoonMind",
+                        "number": 3143,
+                    }
+                },
+            }
+        },
+        integration="github",
+    )
+
+    assert result.display_title == "Fix the workflow title regression"
+    assert result.source == "user_explicit"
+
+
 def test_jira_implement_ignores_load_brief_step_title() -> None:
     result = synthesize_execution_title(
         requested_title="Load Jira preset brief",

--- a/tests/unit/workflows/executions/test_title_derivation.py
+++ b/tests/unit/workflows/executions/test_title_derivation.py
@@ -442,6 +442,61 @@ def test_enriches_any_preset_label_from_github_issue_reference() -> None:
     assert result.source == "integration_target"
 
 
+def test_enriches_preset_label_from_applied_step_template_provenance() -> None:
+    result = synthesize_execution_title(
+        requested_title="GitHub Issue Implement",
+        parameters={
+            "workflow": {
+                "appliedStepTemplates": [
+                    {"slug": "github-issue-implement", "stepIds": ["step-1"]}
+                ],
+                "inputs": {
+                    "github_issue": {
+                        "repository": "MoonLadderStudios/MoonMind",
+                        "number": 3143,
+                    }
+                },
+            }
+        },
+        integration="github",
+    )
+
+    assert result.display_title == (
+        "GitHub Issue Implement: MoonLadderStudios/MoonMind#3143"
+    )
+    assert result.source == "integration_target"
+
+
+@pytest.mark.parametrize(
+    "inputs",
+    [
+        {
+            "github_issue": {
+                "repository": "MoonLadderStudios/MoonMind",
+                "number": 0,
+            }
+        },
+        {"github_issue_ref": "MoonLadderStudios/MoonMind#0"},
+        {"github_issue_ref": "MoonLadderStudios/MoonMind#000"},
+    ],
+)
+def test_rejects_non_positive_github_issue_numbers(inputs: dict[str, object]) -> None:
+    result = synthesize_execution_title(
+        requested_title="GitHub Issue Implement",
+        parameters={
+            "workflow": {
+                "taskTemplate": {"slug": "github-issue-implement"},
+                "inputs": inputs,
+            }
+        },
+        integration="github",
+    )
+
+    assert result.display_title == "GitHub Issue Implement"
+    assert result.source == "preset_template"
+    assert result.targets == ()
+
+
 def test_preserves_custom_title_for_structured_github_issue_preset() -> None:
     result = synthesize_execution_title(
         requested_title="Fix the workflow title regression",

--- a/tests/unit/workflows/temporal/test_temporal_service.py
+++ b/tests/unit/workflows/temporal/test_temporal_service.py
@@ -185,6 +185,49 @@ async def test_create_execution_synthesizes_jira_implement_title_metadata(
         ]
 
 
+@pytest.mark.asyncio
+async def test_create_execution_synthesizes_github_issue_preset_title_metadata(
+    tmp_path, mock_client_adapter
+):
+    async with temporal_db(tmp_path) as session:
+        service = TemporalExecutionService(session, client_adapter=mock_client_adapter)
+
+        created = await service.create_execution(
+            workflow_type="MoonMind.UserWorkflow",
+            owner_id=uuid4(),
+            title="GitHub Issue Implement",
+            input_artifact_ref=None,
+            plan_artifact_ref=None,
+            manifest_artifact_ref=None,
+            failure_policy=None,
+            initial_parameters={
+                "workflow": {
+                    "title": "GitHub Issue Implement",
+                    "instructions": "Implement the selected GitHub issue.",
+                    "taskTemplate": {"slug": "github-issue-implement"},
+                    "inputs": {
+                        "github_issue": {
+                            "repository": "MoonLadderStudios/MoonMind",
+                            "number": 3143,
+                            "title": "Improve generated workflow titles",
+                        },
+                        "github_issue_ref": "MoonLadderStudios/MoonMind#3143",
+                    },
+                }
+            },
+            idempotency_key=None,
+            integration="github",
+        )
+
+        assert created.memo["title"] == (
+            "GitHub Issue Implement: MoonLadderStudios/MoonMind#3143 — "
+            "Improve generated workflow titles"
+        )
+        assert created.memo["titleSource"] == "integration_target"
+        assert created.memo["titleConfidence"] == "high"
+        assert "3143" in created.search_attributes["mm_title"]
+
+
 def _write_mm730_cutover_files(tmp_path):
     release_notes = tmp_path / "MM-730-release-notes.md"
     release_notes.write_text(


### PR DESCRIPTION
## Summary

- treat selected preset labels as generated titles that may be enriched by structured targets
- recognize GitHub issue objects, `owner/repository#number` references, and issue URLs in the shared title synthesizer
- ignore generated execution identifiers so they cannot outrank semantic targets
- persist the synthesized title consistently in the API request and Temporal memo/search metadata
- document title precedence and add API, synthesis, and Temporal regression coverage

## Root cause

Preset submissions supplied their static label as the workflow title. The API and Temporal title layers classified that label as `user_explicit`, returned early, and never inspected the preset inputs. The target collector also understood Jira issue keys and pull requests but not the GitHub issue object/reference already provided by the preset.

## Validation

- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --python-only ...` — 64 passed
- `.venv/bin/ruff check` on changed Python and test files
- `.venv/bin/python -m compileall` on changed production modules
- `git diff --check`