### PR TITLE
Fix remediation attempt budget precedence

### DIFF
--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -6527,16 +6527,16 @@ class MoonMindRunWorkflow:
             # let that declared budget govern repeated verifier results as well.
             # Defaulting this guard to one makes the first unchanged/sparse
             # post-remediation report shadow an explicit "attempt 1 of 6" plan.
-            declared_remediation_maxima = {
-                maximum
-                for candidate in ordered_nodes
-                if self._moonspec_step_role(candidate)
-                in {"moonspec-remediation", "moonspec-verification-gate"}
-                for _, maximum in [
-                    self._moonspec_remediation_attempt_metadata(candidate)
-                ]
-                if maximum is not None
-            }
+            declared_remediation_maxima: set[int] = set()
+            for candidate in ordered_nodes:
+                if self._moonspec_step_role(candidate) not in {
+                    "moonspec-remediation",
+                    "moonspec-verification-gate",
+                }:
+                    continue
+                _, maximum = self._moonspec_remediation_attempt_metadata(candidate)
+                if maximum is not None:
+                    declared_remediation_maxima.add(maximum)
             if len(declared_remediation_maxima) == 1:
                 max_no_progress_attempts = next(iter(declared_remediation_maxima))
         budget = LoopBudget.model_validate(

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -629,6 +629,9 @@ RUN_BOUNDED_STORY_LOOP_PROGRESS_BUDGET_PATCH = (
 RUN_BOUNDED_STORY_LOOP_FEEDBACK_PROGRESS_PATCH = (
     "run-bounded-story-loop-feedback-progress-v1"
 )
+RUN_BOUNDED_STORY_LOOP_REMEDIATION_BUDGET_PATCH = (
+    "run-bounded-story-loop-remediation-budget-v1"
+)
 RUN_MOONSPEC_GATE_CONTRACT_REPAIR_FRESH_SOURCE_PATCH = (
     "run-moonspec-gate-contract-repair-fresh-source-v1"
 )
@@ -6502,12 +6505,40 @@ class MoonMindRunWorkflow:
             prior_no_progress_attempts + 1 if repeated_progress else 0
         )
         max_no_progress_attempts = 1
+        explicit_no_progress_budget = False
         if progress_budget_enabled and isinstance(loop_context, Mapping):
             loop_budgets = loop_context.get("budgets")
             if isinstance(loop_budgets, Mapping):
-                max_no_progress_attempts = int(
-                    loop_budgets.get("maxConsecutiveNoProgressAttempts") or 1
+                configured_no_progress_attempts = self._coerce_positive_int(
+                    loop_budgets.get("maxConsecutiveNoProgressAttempts")
                 )
+                if configured_no_progress_attempts is not None:
+                    max_no_progress_attempts = configured_no_progress_attempts
+                    explicit_no_progress_budget = True
+        if (
+            progress_budget_enabled
+            and not explicit_no_progress_budget
+            and self._patched_or_false_outside_workflow(
+                RUN_BOUNDED_STORY_LOOP_REMEDIATION_BUDGET_PATCH
+            )
+        ):
+            # A compiled remediation chain already has a finite, operator-visible
+            # attempt budget. When no independent no-progress policy was authored,
+            # let that declared budget govern repeated verifier results as well.
+            # Defaulting this guard to one makes the first unchanged/sparse
+            # post-remediation report shadow an explicit "attempt 1 of 6" plan.
+            declared_remediation_maxima = {
+                maximum
+                for candidate in ordered_nodes
+                if self._moonspec_step_role(candidate)
+                in {"moonspec-remediation", "moonspec-verification-gate"}
+                for _, maximum in [
+                    self._moonspec_remediation_attempt_metadata(candidate)
+                ]
+                if maximum is not None
+            }
+            if len(declared_remediation_maxima) == 1:
+                max_no_progress_attempts = next(iter(declared_remediation_maxima))
         budget = LoopBudget.model_validate(
             {
                 "maxAttempts": 1,

--- a/tests/unit/workflows/temporal/test_run_replayer.py
+++ b/tests/unit/workflows/temporal/test_run_replayer.py
@@ -6,15 +6,19 @@ from temporalio import workflow
 from temporalio.testing import WorkflowEnvironment
 from temporalio.worker import Worker, UnsandboxedWorkflowRunner, Replayer
 
+from moonmind.workflows.skills.approval_policy import StepGateResult
 from moonmind.workflows.temporal.workflows.run import (
     GateTransitionDecision,
+    RUN_BOUNDED_STORY_LOOP_FEEDBACK_PROGRESS_PATCH,
+    RUN_BOUNDED_STORY_LOOP_PROGRESS_BUDGET_PATCH,
     RUN_CANONICAL_NO_COMMIT_OUTCOME_PATCH,
+    RUN_MOONSPEC_TITLE_REMEDIATION_DETECTION_PATCH,
     RUN_PLAN_ROUTED_MOONSPEC_REMEDIATION_PATCH,
     MoonMindRunWorkflow,
     MoonMindUserWorkflow,
 )
 from tests.unit.workflows.temporal.workflows.test_run_signals_updates import (
-    mock_run_environment,
+    mock_run_environment as _mock_run_environment,  # noqa: F401
 )
 
 
@@ -90,6 +94,85 @@ class _CurrentRemediationReplayFixture:
         )
         assert decision.successor is not None
         return ["verify-1", decision.successor.logical_step_id]
+
+
+def _mm3379_remediation_nodes() -> list[dict[str, Any]]:
+    nodes: list[dict[str, Any]] = [
+        {
+            "id": "verify-initial",
+            "inputs": {"selectedSkill": "moonspec-verify"},
+        }
+    ]
+    for attempt in range(1, 3):
+        nodes.extend(
+            [
+                {
+                    "id": f"remediate-{attempt}",
+                    "inputs": {
+                        "annotations": {
+                            "issueImplementRole": "moonspec-remediation",
+                            "moonSpecRemediationAttempt": attempt,
+                            "moonSpecRemediationMaxAttempts": 2,
+                        }
+                    },
+                },
+                {
+                    "id": f"verify-{attempt}",
+                    "inputs": {
+                        "selectedSkill": "moonspec-verify",
+                        "annotations": {
+                            "issueImplementRole": "moonspec-verification-gate",
+                            "moonSpecRemediationAttempt": attempt,
+                            "moonSpecRemediationMaxAttempts": 2,
+                            "moonSpecFinalRemediationGate": attempt == 2,
+                        },
+                    },
+                },
+            ]
+        )
+    return nodes
+
+
+@workflow.defn(name="MM3379NoProgressBudgetReplayFixture")
+class _LegacyNoProgressBudgetReplayFixture:
+    @workflow.run
+    async def run(self) -> list[str]:
+        # Patch-marker shape of the release that stopped the example after its
+        # first unchanged post-remediation verification.
+        workflow.patched(RUN_MOONSPEC_TITLE_REMEDIATION_DETECTION_PATCH)
+        workflow.patched(RUN_BOUNDED_STORY_LOOP_PROGRESS_BUDGET_PATCH)
+        workflow.patched(RUN_BOUNDED_STORY_LOOP_FEEDBACK_PROGRESS_PATCH)
+        return ["verify-initial", "stop"]
+
+
+@workflow.defn(name="MM3379NoProgressBudgetReplayFixture")
+class _CurrentNoProgressBudgetReplayFixture:
+    @workflow.run
+    async def run(self) -> list[str]:
+        run_workflow = MoonMindRunWorkflow()
+        nodes = _mm3379_remediation_nodes()
+        gate = StepGateResult(
+            verdict="ADDITIONAL_WORK_NEEDED",
+            feedback="Unchanged sparse remaining-work summary.",
+        )
+        run_workflow._bounded_story_loop_continuation_decision(
+            logical_step_id="verify-initial",
+            gate_result=gate,
+            gate_result_ref="artifact://gate/initial",
+            ordered_nodes=nodes,
+            current_index=0,
+        )
+        decision = run_workflow._bounded_story_loop_continuation_decision(
+            logical_step_id="verify-1",
+            gate_result=gate,
+            gate_result_ref="artifact://gate/1",
+            ordered_nodes=nodes,
+            current_index=2,
+        )
+        return [
+            "verify-initial",
+            "remediate-2" if decision["continueLoop"] else "stop",
+        ]
 
 
 @workflow.defn(name="MMCanonicalNoCommitReplayFixture")
@@ -230,6 +313,45 @@ async def test_moonspec_remediation_pre_and_post_patch_histories_replay() -> Non
     assert current_commands.count("verify-1") == 1
     replayer = Replayer(
         workflows=[_CurrentRemediationReplayFixture],
+        workflow_runner=UnsandboxedWorkflowRunner(),
+    )
+    await replayer.replay_workflow(legacy_history)
+    await replayer.replay_workflow(current_history)
+
+
+@pytest.mark.asyncio
+async def test_no_progress_budget_pre_and_post_fix_histories_replay() -> None:
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        async with Worker(
+            env.client,
+            task_queue="test-mm3379-legacy-replay",
+            workflows=[_LegacyNoProgressBudgetReplayFixture],
+            workflow_runner=UnsandboxedWorkflowRunner(),
+        ):
+            legacy = await env.client.start_workflow(
+                _LegacyNoProgressBudgetReplayFixture.run,
+                id="test-mm3379-legacy-history",
+                task_queue="test-mm3379-legacy-replay",
+            )
+            assert await legacy.result() == ["verify-initial", "stop"]
+            legacy_history = await legacy.fetch_history()
+
+        async with Worker(
+            env.client,
+            task_queue="test-mm3379-current-replay",
+            workflows=[_CurrentNoProgressBudgetReplayFixture],
+            workflow_runner=UnsandboxedWorkflowRunner(),
+        ):
+            current = await env.client.start_workflow(
+                _CurrentNoProgressBudgetReplayFixture.run,
+                id="test-mm3379-current-history",
+                task_queue="test-mm3379-current-replay",
+            )
+            assert await current.result() == ["verify-initial", "remediate-2"]
+            current_history = await current.fetch_history()
+
+    replayer = Replayer(
+        workflows=[_CurrentNoProgressBudgetReplayFixture],
         workflow_runner=UnsandboxedWorkflowRunner(),
     )
     await replayer.replay_workflow(legacy_history)

--- a/tests/unit/workflows/temporal/test_run_replayer.py
+++ b/tests/unit/workflows/temporal/test_run_replayer.py
@@ -18,7 +18,7 @@ from moonmind.workflows.temporal.workflows.run import (
     MoonMindUserWorkflow,
 )
 from tests.unit.workflows.temporal.workflows.test_run_signals_updates import (
-    mock_run_environment as _mock_run_environment,  # noqa: F401
+    mock_run_environment,  # noqa: F401
 )
 
 
@@ -222,7 +222,7 @@ class _CurrentCanonicalNoCommitReplayFixture:
         return [run_workflow._publish_status, status, publish_failure]
 
 @pytest.mark.asyncio
-async def test_workflow_determinism_replay(mock_run_environment):
+async def test_workflow_determinism_replay(mock_run_environment):  # noqa: F811
     async with await WorkflowEnvironment.start_time_skipping() as env:
         async with Worker(
             env.client,

--- a/tests/unit/workflows/temporal/workflows/test_run_bounded_story_loop.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_bounded_story_loop.py
@@ -5,12 +5,53 @@ import pytest
 from moonmind.workflows.skills.approval_policy import StepGateResult
 from moonmind.workflows.temporal.bounded_story_loop import LoopAttempt, TypedGateResult
 from moonmind.workflows.temporal.workflows.run import (
+    RUN_BOUNDED_STORY_LOOP_FEEDBACK_PROGRESS_PATCH,
     RUN_BOUNDED_STORY_LOOP_PROGRESS_BUDGET_PATCH,
+    RUN_BOUNDED_STORY_LOOP_REMEDIATION_BUDGET_PATCH,
     MoonMindRunWorkflow,
     bounded_story_loop_resume_decision,
     bounded_story_loop_scope_guard,
     bounded_story_loop_step_effects,
 )
+
+
+def _explicit_remediation_chain(max_attempts: int) -> list[dict[str, object]]:
+    nodes: list[dict[str, object]] = [
+        {
+            "id": "verify-initial",
+            "inputs": {"selectedSkill": "moonspec-verify"},
+        }
+    ]
+    for attempt in range(1, max_attempts + 1):
+        nodes.extend(
+            [
+                {
+                    "id": f"remediate-{attempt}",
+                    "inputs": {
+                        "annotations": {
+                            "issueImplementRole": "moonspec-remediation",
+                            "moonSpecRemediationAttempt": attempt,
+                            "moonSpecRemediationMaxAttempts": max_attempts,
+                        }
+                    },
+                },
+                {
+                    "id": f"verify-{attempt}",
+                    "inputs": {
+                        "selectedSkill": "moonspec-verify",
+                        "annotations": {
+                            "issueImplementRole": "moonspec-verification-gate",
+                            "moonSpecRemediationAttempt": attempt,
+                            "moonSpecRemediationMaxAttempts": max_attempts,
+                            "moonSpecFinalRemediationGate": (
+                                attempt == max_attempts
+                            ),
+                        },
+                    },
+                },
+            ]
+        )
+    return nodes
 
 
 def test_workflow_boundary_records_failed_attempt_refs_without_publication() -> None:
@@ -301,6 +342,126 @@ def test_parent_loop_stops_when_verification_makes_no_progress(
     assert second["continueLoop"] is False
     assert second["reason"] == "no_progress_attempts_exhausted"
     assert second["hasRemainingRemediationStep"] is True
+
+
+def test_explicit_remediation_budget_governs_repeated_verifier_results(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression for mm:bd3dedc3-6cf3-4801-95b4-be177b70ef6b."""
+    run = MoonMindRunWorkflow()
+    monkeypatch.setattr(run, "_patched_or_false_outside_workflow", lambda _: True)
+    ordered_nodes = _explicit_remediation_chain(max_attempts=6)
+    gate = StepGateResult(
+        verdict="ADDITIONAL_WORK_NEEDED",
+        feedback="The verifier emitted the same sparse remaining-work summary.",
+        recommended_next_action="reattempt_current_step",
+    )
+
+    decisions = []
+    for attempt in range(0, 7):
+        logical_step_id = "verify-initial" if attempt == 0 else f"verify-{attempt}"
+        run._step_terminal_dispositions[logical_step_id] = "accepted"
+        decisions.append(
+            run._bounded_story_loop_continuation_decision(
+                logical_step_id=logical_step_id,
+                gate_result=gate,
+                gate_result_ref=f"artifact://gate/{attempt}",
+                ordered_nodes=ordered_nodes,
+                current_index=attempt * 2,
+            )
+        )
+
+    first_post_remediation = decisions[1]
+    assert first_post_remediation["continueLoop"] is True
+    assert first_post_remediation["reason"] == "verification_requested_remediation"
+    assert first_post_remediation["nextLogicalStepId"] == "remediate-2"
+    assert first_post_remediation["budget"][
+        "maxConsecutiveNoProgressAttempts"
+    ] == 6
+    assert first_post_remediation["budget"]["consumed"][
+        "consecutiveNoProgressAttempts"
+    ] == 1
+
+    assert all(decision["continueLoop"] for decision in decisions[:-1])
+    assert decisions[-1]["continueLoop"] is False
+    assert decisions[-1]["reason"] == "max_attempts_exhausted"
+    assert decisions[-1]["remediationBudget"]["maxAttempts"] == 6
+    assert decisions[-1]["remediationBudget"]["currentAttempt"] == 6
+
+
+def test_explicit_no_progress_policy_overrides_remediation_attempt_budget(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    run = MoonMindRunWorkflow()
+    monkeypatch.setattr(run, "_patched_or_false_outside_workflow", lambda _: True)
+    run._publish_context["boundedStoryLoop"] = {
+        "budgets": {"maxConsecutiveNoProgressAttempts": 1}
+    }
+    ordered_nodes = _explicit_remediation_chain(max_attempts=6)
+    gate = StepGateResult(
+        verdict="ADDITIONAL_WORK_NEEDED",
+        feedback="Unchanged remaining work.",
+    )
+
+    run._bounded_story_loop_continuation_decision(
+        logical_step_id="verify-initial",
+        gate_result=gate,
+        gate_result_ref="artifact://gate/initial",
+        ordered_nodes=ordered_nodes,
+        current_index=0,
+    )
+    decision = run._bounded_story_loop_continuation_decision(
+        logical_step_id="verify-1",
+        gate_result=gate,
+        gate_result_ref="artifact://gate/1",
+        ordered_nodes=ordered_nodes,
+        current_index=2,
+    )
+
+    assert decision["continueLoop"] is False
+    assert decision["reason"] == "no_progress_attempts_exhausted"
+    assert decision["budget"]["maxConsecutiveNoProgressAttempts"] == 1
+    assert decision["remediationBudget"]["remainingAttempts"] == 6
+
+
+def test_remediation_budget_patch_preserves_legacy_no_progress_stop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    run = MoonMindRunWorkflow()
+    monkeypatch.setattr(
+        run,
+        "_patched_or_false_outside_workflow",
+        lambda patch_id: patch_id
+        in {
+            RUN_BOUNDED_STORY_LOOP_PROGRESS_BUDGET_PATCH,
+            RUN_BOUNDED_STORY_LOOP_FEEDBACK_PROGRESS_PATCH,
+        },
+    )
+    ordered_nodes = _explicit_remediation_chain(max_attempts=6)
+    gate = StepGateResult(
+        verdict="ADDITIONAL_WORK_NEEDED",
+        feedback="Unchanged remaining work.",
+    )
+
+    run._bounded_story_loop_continuation_decision(
+        logical_step_id="verify-initial",
+        gate_result=gate,
+        gate_result_ref="artifact://gate/initial",
+        ordered_nodes=ordered_nodes,
+        current_index=0,
+    )
+    decision = run._bounded_story_loop_continuation_decision(
+        logical_step_id="verify-1",
+        gate_result=gate,
+        gate_result_ref="artifact://gate/1",
+        ordered_nodes=ordered_nodes,
+        current_index=2,
+    )
+
+    assert RUN_BOUNDED_STORY_LOOP_REMEDIATION_BUDGET_PATCH.endswith("-v1")
+    assert decision["continueLoop"] is False
+    assert decision["reason"] == "no_progress_attempts_exhausted"
+    assert decision["budget"]["maxConsecutiveNoProgressAttempts"] == 1
 
 
 def test_parent_loop_continues_when_verification_progress_changes(


### PR DESCRIPTION
## Summary

- let an explicitly bounded remediation chain use its declared attempt count as the default no-progress ceiling
- preserve explicitly authored no-progress limits
- add Temporal replay coverage for histories created before and after the fix

## Root cause

MoonMind tracked the six-attempt remediation budget correctly, but the independent no-progress budget defaulted to one. An unchanged or sparse verifier result after remediation attempt 1 therefore stopped the workflow even when five plan-authored remediation attempts remained.

## Impact

Workflows with attempt-scoped remediation can now continue through their declared bounded attempts. Explicit no-progress policy remains authoritative, and the loop is still finite.

## Validation

- `.venv/bin/python -m pytest -q --no-header --tb=short tests/unit/workflows/temporal/workflows/test_run_bounded_story_loop.py tests/unit/workflows/temporal/test_run_replayer.py::test_no_progress_budget_pre_and_post_fix_histories_replay` — 24 passed
- focused execution-stage and replay-boundary checks — 4 passed
- Ruff checks and `git diff --check` passed