### PR TITLE
MM-1214: Project tools into static and on-demand runner shells

### DIFF
--- a/.env-template
+++ b/.env-template
@@ -37,6 +37,11 @@ OMNIGENT_DOMAIN=""
 OMNIGENT_CONFIG=""
 OMNIGENT_HOST_IMAGE="ghcr.io/omnigent-ai/omnigent-host"
 OMNIGENT_HOST_IMAGE_TAG="latest"
+# Preserve the selected upstream host image PATH here when it differs from the
+# conventional default. The tools directory is prepended idempotently.
+OMNIGENT_HOST_BASE_PATH="/opt/venv/bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin"
+# Bundle publishers create a new immutable named volume for each version.
+OMNIGENT_TOOL_BUNDLE_VERSION="v1"
 OMNIGENT_MOONMIND_WORKSPACE="./omnigent_workspaces/MoonMind"
 # Optional dedicated hosts that expose MoonMind-managed OAuth volumes to exactly
 # one matching Omnigent runtime. Separate multiple profiles with commas.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -807,6 +807,7 @@ services:
     image: ${OMNIGENT_HOST_IMAGE:-ghcr.io/omnigent-ai/omnigent-host}:${OMNIGENT_HOST_IMAGE_TAG:-latest}
     command: ["omnigent", "host", "--server", "http://omnigent:8000", "--non-interactive"]
     environment:
+      - PATH=/opt/moonmind-tools/bin:${OMNIGENT_HOST_BASE_PATH:-/opt/venv/bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin}
       - OPENAI_API_KEY=${OPENAI_API_KEY:-}
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
       - GEMINI_API_KEY=${GEMINI_API_KEY:-}
@@ -815,6 +816,8 @@ services:
       - path: .env
         required: false
     volumes:
+      - omnigent-tools:/opt/moonmind-tools:ro
+      - ./services/omnigent/profile/moonmind-tools.sh:/etc/profile.d/moonmind-tools.sh:ro
       - omnigent-host-state:/root/.omnigent
       - ./omnigent_workspaces:/workspaces
       # Mount an operator-managed sanitized workspace, not the repo root with local secrets.
@@ -834,6 +837,7 @@ services:
     working_dir: /home/app
     command: ["omnigent", "host", "--server", "http://omnigent:8000", "--non-interactive"]
     environment:
+      PATH: /opt/moonmind-tools/bin:${OMNIGENT_HOST_BASE_PATH:-/opt/venv/bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin}
       HOME: /home/app
       CLAUDE_HOME: /home/app/.claude
       CLAUDE_VOLUME_PATH: /home/app/.claude
@@ -846,6 +850,8 @@ services:
       GEMINI_API_KEY: ""
       GOOGLE_API_KEY: ""
     volumes:
+      - omnigent-tools:/opt/moonmind-tools:ro
+      - ./services/omnigent/profile/moonmind-tools.sh:/etc/profile.d/moonmind-tools.sh:ro
       - omnigent-host-claude-state:/home/app/.omnigent
       - claude_auth_volume:/home/app/.claude
       - ./omnigent_workspaces:/workspaces
@@ -892,6 +898,7 @@ services:
     entrypoint: ["/usr/bin/env", "-u", "OPENAI_API_KEY", "-u", "CODEX_ACCESS_TOKEN", "-u", "OPENAI_BASE_URL", "-u", "MINIMAX_API_KEY", "-u", "ANTHROPIC_API_KEY", "-u", "ANTHROPIC_AUTH_TOKEN", "-u", "CLAUDE_API_KEY", "-u", "CLAUDE_CODE_OAUTH_TOKEN", "-u", "GEMINI_API_KEY", "-u", "GOOGLE_API_KEY"]
     command: ["/opt/moonmind/start-codex-oauth-host.sh"]
     environment:
+      PATH: /opt/moonmind-tools/bin:${OMNIGENT_HOST_BASE_PATH:-/opt/venv/bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin}
       HOME: /home/app
       CODEX_HOME: /home/app/.codex
       CODEX_CONFIG_HOME: /home/app/.codex
@@ -900,6 +907,8 @@ services:
       CODEX_CREDENTIAL_GENERATION: ${CODEX_CREDENTIAL_GENERATION:-1}
       OMNIGENT_SERVER_URL: http://omnigent:8000
     volumes:
+      - omnigent-tools:/opt/moonmind-tools:ro
+      - ./services/omnigent/profile/moonmind-tools.sh:/etc/profile.d/moonmind-tools.sh:ro
       - omnigent-host-codex-state:/home/app/.omnigent
       - codex_auth_volume:/home/app/.codex
       - ./services/omnigent/scripts:/opt/moonmind:ro
@@ -1104,6 +1113,9 @@ services:
     restart: unless-stopped
 
 volumes:
+  # MM-1214: immutable bundle versions receive distinct daemon-visible volumes.
+  omnigent-tools:
+    name: moonmind-omnigent-tools-${OMNIGENT_TOOL_BUNDLE_VERSION:-v1}
   qdrant-storage:
   omnigent-host-state:
   omnigent-host-claude-state:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -839,6 +839,8 @@ services:
     depends_on:
       omnigent:
         condition: service_started
+      omnigent-tools-init:
+        condition: service_completed_successfully
     networks:
       - local-network
     restart: unless-stopped
@@ -874,6 +876,8 @@ services:
     depends_on:
       omnigent:
         condition: service_started
+      omnigent-tools-init:
+        condition: service_completed_successfully
       claude-auth-init:
         condition: service_completed_successfully
     networks:
@@ -932,6 +936,8 @@ services:
     depends_on:
       omnigent:
         condition: service_started
+      omnigent-tools-init:
+        condition: service_completed_successfully
       omnigent-host-codex-init:
         condition: service_completed_successfully
     networks:

--- a/moonmind/omnigent/oauth_host_runtime.py
+++ b/moonmind/omnigent/oauth_host_runtime.py
@@ -85,7 +85,12 @@ class OmnigentOAuthHostRuntime:
         )
         self._tools_profile_path = (
             tools_profile_path
-            or Path(__file__).resolve().parents[2]
+            or Path(
+                os.getenv(
+                    "MOONMIND_DEPLOYMENT_LOCAL_PROJECT_DIR",
+                    "/workspace/host_project",
+                )
+            )
             / "services"
             / "omnigent"
             / "profile"
@@ -116,6 +121,7 @@ class OmnigentOAuthHostRuntime:
                 workspace_source=workspace_source,
             )
             await self._exec_check(container_name)
+            await self._exec_tools_check(container_name)
         else:
             await self._compose_static_check()
 
@@ -330,10 +336,12 @@ class OmnigentOAuthHostRuntime:
             "--format",
             "{{range .Config.Env}}{{println .}}{{end}}",
             self._image,
+            check=False,
         )
-        for line in result[1].splitlines():
-            if line.startswith("PATH="):
-                return line.removeprefix("PATH=") or _DEFAULT_HOST_PATH
+        if result[0] == 0:
+            for line in result[1].splitlines():
+                if line.startswith("PATH="):
+                    return line.removeprefix("PATH=") or _DEFAULT_HOST_PATH
         return _DEFAULT_HOST_PATH
 
     async def _validate_tools_profile_bind_source(self) -> None:
@@ -359,6 +367,19 @@ class OmnigentOAuthHostRuntime:
     def _prepend_tools_path(upstream_path: str) -> str:
         entries = [entry for entry in upstream_path.split(":") if entry]
         return ":".join([_TOOLS_PATH, *(e for e in entries if e != _TOOLS_PATH)])
+
+    async def _exec_tools_check(self, container_name: str) -> None:
+        """Verify the mounted bundle through the host's login-shell boundary."""
+
+        await self._run(
+            "docker",
+            "exec",
+            container_name,
+            "bash",
+            "-lc",
+            "test -f /opt/moonmind-tools/manifest.json "
+            "&& command -v gh >/dev/null && gh --version >/dev/null",
+        )
 
     async def _prepare_workspace(
         self, *, workspace_key: str, repository_url: str | None

--- a/moonmind/omnigent/oauth_host_runtime.py
+++ b/moonmind/omnigent/oauth_host_runtime.py
@@ -234,6 +234,7 @@ class OmnigentOAuthHostRuntime:
             return
         mount = binding.credential_mount_ref
         state_volume = f"{container_name}-state"
+        await self._validate_tools_profile_bind_source()
         host_path = await self._discover_upstream_path()
         # A retry may find a stopped container with this deterministic name.
         # Remove only that lease-owned container, then initialize the dedicated
@@ -326,12 +327,6 @@ class OmnigentOAuthHostRuntime:
 
     async def _discover_upstream_path(self) -> str:
         """Read the selected image's PATH without replacing image-specific entries."""
-
-        if not self._tools_profile_path.is_file():
-            raise OmnigentOAuthHostError(
-                "Omnigent tools profile bind source does not exist",
-                code=HostPreflightFailure.LOGIN_STATUS_FAILED.value,
-            )
         result = await self._run(
             "docker",
             "image",
@@ -344,6 +339,25 @@ class OmnigentOAuthHostRuntime:
             if line.startswith("PATH="):
                 return line.removeprefix("PATH=") or _DEFAULT_HOST_PATH
         return _DEFAULT_HOST_PATH
+
+    async def _validate_tools_profile_bind_source(self) -> None:
+        """Prove the profile bind source is a file in the Docker daemon namespace."""
+
+        await self._run(
+            "docker",
+            "run",
+            "--rm",
+            "--mount",
+            (
+                f"type=bind,src={self._tools_profile_path},"
+                "dst=/etc/profile.d/moonmind-tools.sh,readonly"
+            ),
+            "--entrypoint",
+            "/usr/bin/test",
+            self._image,
+            "-f",
+            "/etc/profile.d/moonmind-tools.sh",
+        )
 
     @staticmethod
     def _prepend_tools_path(upstream_path: str) -> str:

--- a/moonmind/omnigent/oauth_host_runtime.py
+++ b/moonmind/omnigent/oauth_host_runtime.py
@@ -34,6 +34,11 @@ _FORBIDDEN_ENV = (
     "GOOGLE_API_KEY",
 )
 
+_TOOLS_PATH = "/opt/moonmind-tools/bin"
+_DEFAULT_HOST_PATH = (
+    "/opt/venv/bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin"
+)
+
 
 class OmnigentOAuthHostRuntime:
     """Launch/check/stop hosts using server-resolved resources only."""
@@ -47,6 +52,8 @@ class OmnigentOAuthHostRuntime:
         server_url: str | None = None,
         scripts_dir: Path | None = None,
         workspace_root: Path | None = None,
+        tools_volume: str | None = None,
+        tools_profile_path: Path | None = None,
     ) -> None:
         self._client = client
         if image:
@@ -72,6 +79,21 @@ class OmnigentOAuthHostRuntime:
         self._workspace_root = (
             workspace_root
             or Path(os.getenv("OMNIGENT_WORKSPACE_ROOT", "omnigent_workspaces"))
+        ).resolve()
+        bundle_version = (
+            os.getenv("OMNIGENT_TOOL_BUNDLE_VERSION", "v1").strip() or "v1"
+        )
+        self._tools_volume = tools_volume or os.getenv(
+            "OMNIGENT_TOOLS_VOLUME_NAME",
+            f"moonmind-omnigent-tools-{bundle_version}",
+        )
+        self._tools_profile_path = (
+            tools_profile_path
+            or Path(__file__).resolve().parents[2]
+            / "services"
+            / "omnigent"
+            / "profile"
+            / "moonmind-tools.sh"
         ).resolve()
 
     async def prepare_host(
@@ -212,6 +234,7 @@ class OmnigentOAuthHostRuntime:
             return
         mount = binding.credential_mount_ref
         state_volume = f"{container_name}-state"
+        host_path = await self._discover_upstream_path()
         # A retry may find a stopped container with this deterministic name.
         # Remove only that lease-owned container, then initialize the dedicated
         # state volume as root before the actual host drops to UID/GID 1000.
@@ -264,6 +287,15 @@ class OmnigentOAuthHostRuntime:
             f"type=bind,src={self._scripts_dir},dst=/opt/moonmind,readonly",
             "--mount",
             f"type=bind,src={workspace_source},dst=/workspaces/run",
+            "--mount",
+            f"type=volume,src={self._tools_volume},dst=/opt/moonmind-tools,readonly",
+            "--mount",
+            (
+                f"type=bind,src={self._tools_profile_path},"
+                "dst=/etc/profile.d/moonmind-tools.sh,readonly"
+            ),
+            "--env",
+            f"PATH={self._prepend_tools_path(host_path)}",
             "--env",
             "HOME=/home/app",
             "--env",
@@ -291,6 +323,32 @@ class OmnigentOAuthHostRuntime:
             args.extend(["-u", key])
         args.extend([self._image, "/opt/moonmind/start-codex-oauth-host.sh"])
         await self._run(*args, env=child_env)
+
+    async def _discover_upstream_path(self) -> str:
+        """Read the selected image's PATH without replacing image-specific entries."""
+
+        if not self._tools_profile_path.is_file():
+            raise OmnigentOAuthHostError(
+                "Omnigent tools profile bind source does not exist",
+                code=HostPreflightFailure.LOGIN_STATUS_FAILED.value,
+            )
+        result = await self._run(
+            "docker",
+            "image",
+            "inspect",
+            "--format",
+            "{{range .Config.Env}}{{println .}}{{end}}",
+            self._image,
+        )
+        for line in result[1].splitlines():
+            if line.startswith("PATH="):
+                return line.removeprefix("PATH=") or _DEFAULT_HOST_PATH
+        return _DEFAULT_HOST_PATH
+
+    @staticmethod
+    def _prepend_tools_path(upstream_path: str) -> str:
+        entries = [entry for entry in upstream_path.split(":") if entry]
+        return ":".join([_TOOLS_PATH, *(e for e in entries if e != _TOOLS_PATH)])
 
     async def _prepare_workspace(
         self, *, workspace_key: str, repository_url: str | None

--- a/services/omnigent/profile/moonmind-tools.sh
+++ b/services/omnigent/profile/moonmind-tools.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+# MM-1214: keep the deployment tool bundle visible when login shells rebuild PATH.
+case ":${PATH:-}:" in
+  *:/opt/moonmind-tools/bin:*) ;;
+  *)
+    if [ -n "${PATH:-}" ]; then
+      export PATH="/opt/moonmind-tools/bin:${PATH}"
+    else
+      export PATH="/opt/moonmind-tools/bin"
+    fi
+    ;;
+esac

--- a/tests/integration/temporal/test_compose_foundation.py
+++ b/tests/integration/temporal/test_compose_foundation.py
@@ -575,6 +575,7 @@ def test_omnigent_claude_host_profile_uses_only_canonical_oauth_credentials():
 
     assert host_service["depends_on"] == {
         "omnigent": {"condition": "service_started"},
+        "omnigent-tools-init": {"condition": "service_completed_successfully"},
         "claude-auth-init": {"condition": "service_completed_successfully"},
     }
     assert _network_names(host_service) == {"local-network"}
@@ -646,6 +647,7 @@ def test_omnigent_codex_host_profile_uses_only_canonical_oauth_credentials():
     assert "omnigent-host-codex-state" in compose["volumes"]
     assert host_service["depends_on"] == {
         "omnigent": {"condition": "service_started"},
+        "omnigent-tools-init": {"condition": "service_completed_successfully"},
         "omnigent-host-codex-init": {
             "condition": "service_completed_successfully"
         },

--- a/tests/integration/temporal/test_compose_foundation.py
+++ b/tests/integration/temporal/test_compose_foundation.py
@@ -472,6 +472,10 @@ def test_omnigent_host_profile_service_is_wired_for_mm_971():
     assert _network_names(host_service) == {"local-network"}
 
     host_env = _env_map(host_service["environment"])
+    assert host_env["PATH"] == (
+        "/opt/moonmind-tools/bin:${OMNIGENT_HOST_BASE_PATH:-/opt/venv/bin:"
+        "/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin}"
+    )
     assert host_env["OPENAI_API_KEY"] == "${OPENAI_API_KEY:-}"
     assert "CODEX_HOME" not in host_env
     assert host_env["ANTHROPIC_API_KEY"] == "${ANTHROPIC_API_KEY:-}"
@@ -480,6 +484,11 @@ def test_omnigent_host_profile_service_is_wired_for_mm_971():
 
     host_volumes = set(host_service["volumes"])
     assert "omnigent-host-state:/root/.omnigent" in host_volumes
+    assert "omnigent-tools:/opt/moonmind-tools:ro" in host_volumes
+    assert (
+        "./services/omnigent/profile/moonmind-tools.sh:"
+        "/etc/profile.d/moonmind-tools.sh:ro"
+    ) in host_volumes
     assert "./omnigent_workspaces:/workspaces" in host_volumes
     assert "codex_auth_volume:/root/.codex" not in host_volumes
     # Operator-managed sanitized workspace, exposed read-only.
@@ -488,6 +497,9 @@ def test_omnigent_host_profile_service_is_wired_for_mm_971():
         "/workspaces/MoonMind:ro"
     ) in host_volumes
     assert "omnigent-host-state" in volumes
+    assert volumes["omnigent-tools"]["name"] == (
+        "moonmind-omnigent-tools-${OMNIGENT_TOOL_BUNDLE_VERSION:-v1}"
+    )
     assert "codex_auth_volume" in volumes
     assert "omnigent-server-state" not in volumes
 
@@ -515,6 +527,10 @@ def test_omnigent_claude_host_profile_uses_only_canonical_oauth_credentials():
 
     host_env = _env_map(host_service["environment"])
     assert host_env == {
+        "PATH": (
+            "/opt/moonmind-tools/bin:${OMNIGENT_HOST_BASE_PATH:-/opt/venv/bin:"
+            "/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin}"
+        ),
         "HOME": "/home/app",
         "CLAUDE_HOME": "/home/app/.claude",
         "CLAUDE_VOLUME_PATH": "/home/app/.claude",
@@ -531,6 +547,11 @@ def test_omnigent_claude_host_profile_uses_only_canonical_oauth_credentials():
     host_volumes = set(host_service["volumes"])
     assert "omnigent-host-claude-state:/home/app/.omnigent" in host_volumes
     assert "claude_auth_volume:/home/app/.claude" in host_volumes
+    assert "omnigent-tools:/opt/moonmind-tools:ro" in host_volumes
+    assert (
+        "./services/omnigent/profile/moonmind-tools.sh:"
+        "/etc/profile.d/moonmind-tools.sh:ro"
+    ) in host_volumes
     assert "./omnigent_workspaces:/workspaces" in host_volumes
     assert (
         "${OMNIGENT_MOONMIND_WORKSPACE:-./omnigent_workspaces/MoonMind}:"
@@ -572,6 +593,10 @@ def test_omnigent_codex_host_profile_uses_only_canonical_oauth_credentials():
     assert host_service["working_dir"] == "/home/app"
     assert "env_file" not in host_service
     assert _env_map(host_service["environment"]) == {
+        "PATH": (
+            "/opt/moonmind-tools/bin:${OMNIGENT_HOST_BASE_PATH:-/opt/venv/bin:"
+            "/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin}"
+        ),
         "HOME": "/home/app",
         "CODEX_HOME": "/home/app/.codex",
         "CODEX_CONFIG_HOME": "/home/app/.codex",
@@ -604,6 +629,11 @@ def test_omnigent_codex_host_profile_uses_only_canonical_oauth_credentials():
             "/workspaces/MoonMind:ro"
         ),
         "./services/omnigent/scripts:/opt/moonmind:ro",
+        "omnigent-tools:/opt/moonmind-tools:ro",
+        (
+            "./services/omnigent/profile/moonmind-tools.sh:"
+            "/etc/profile.d/moonmind-tools.sh:ro"
+        ),
     }
     assert "omnigent-host-codex-state" in compose["volumes"]
     assert host_service["depends_on"] == {

--- a/tests/integration/temporal/test_compose_foundation.py
+++ b/tests/integration/temporal/test_compose_foundation.py
@@ -201,7 +201,9 @@ def test_omnigent_hosts_use_versioned_read_only_tool_bundle():
         host = services[service_name]
         environment = _env_map(host["environment"])
         assert environment["PATH"].startswith("/opt/moonmind-tools/bin:")
-        assert "omnigent-tools-init" not in host["depends_on"]
+        assert host["depends_on"]["omnigent-tools-init"]["condition"] == (
+            "service_completed_successfully"
+        )
         assert "omnigent-tools:/opt/moonmind-tools:ro" in host["volumes"]
         assert (
             "./services/omnigent/profile/moonmind-tools.sh:"

--- a/tests/unit/omnigent/test_host_tool_projection.py
+++ b/tests/unit/omnigent/test_host_tool_projection.py
@@ -18,6 +18,9 @@ def test_static_hosts_project_versioned_tools_without_covering_usr_local_bin() -
         else:
             assert environment["PATH"] == expected_path
         assert "omnigent-tools:/opt/moonmind-tools:ro" in service["volumes"]
+        assert service["depends_on"]["omnigent-tools-init"]["condition"] == (
+            "service_completed_successfully"
+        )
         assert (
             "./services/omnigent/profile/moonmind-tools.sh:"
             "/etc/profile.d/moonmind-tools.sh:ro"

--- a/tests/unit/omnigent/test_host_tool_projection.py
+++ b/tests/unit/omnigent/test_host_tool_projection.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+
+import yaml
+
+
+def test_static_hosts_project_versioned_tools_without_covering_usr_local_bin() -> None:
+    compose = yaml.safe_load(Path("docker-compose.yaml").read_text())
+    expected_path = (
+        "/opt/moonmind-tools/bin:${OMNIGENT_HOST_BASE_PATH:-/opt/venv/bin:"
+        "/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin}"
+    )
+
+    for name in ("omnigent-host", "omnigent-host-claude", "omnigent-host-codex"):
+        service = compose["services"][name]
+        environment = service["environment"]
+        if isinstance(environment, list):
+            assert f"PATH={expected_path}" in environment
+        else:
+            assert environment["PATH"] == expected_path
+        assert "omnigent-tools:/opt/moonmind-tools:ro" in service["volumes"]
+        assert (
+            "./services/omnigent/profile/moonmind-tools.sh:"
+            "/etc/profile.d/moonmind-tools.sh:ro"
+        ) in service["volumes"]
+        assert all("/usr/local/bin" not in volume for volume in service["volumes"])
+
+    assert compose["volumes"]["omnigent-tools"]["name"] == (
+        "moonmind-omnigent-tools-${OMNIGENT_TOOL_BUNDLE_VERSION:-v1}"
+    )
+
+
+def test_login_profile_prepends_tools_path_idempotently() -> None:
+    profile = Path("services/omnigent/profile/moonmind-tools.sh").read_text()
+
+    assert "*:/opt/moonmind-tools/bin:*)" in profile
+    assert 'export PATH="/opt/moonmind-tools/bin:${PATH}"' in profile

--- a/tests/unit/omnigent/test_oauth_profile_lifecycle.py
+++ b/tests/unit/omnigent/test_oauth_profile_lifecycle.py
@@ -318,6 +318,55 @@ def test_tools_path_prepend_is_idempotent_and_preserves_upstream_path() -> None:
 
 
 @pytest.mark.asyncio
+async def test_tools_path_discovery_falls_back_when_image_is_not_local(tmp_path) -> None:
+    runtime = OmnigentOAuthHostRuntime(
+        client=SimpleNamespace(),
+        scripts_dir=tmp_path,
+        workspace_root=tmp_path / "workspaces",
+    )
+    runtime._run = AsyncMock(return_value=(1, "", "No such image"))
+
+    assert await runtime._discover_upstream_path() == (
+        "/opt/venv/bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin"
+    )
+    assert runtime._run.await_args.kwargs["check"] is False
+
+
+def test_default_tools_profile_uses_daemon_visible_project_root(
+    monkeypatch, tmp_path
+) -> None:
+    monkeypatch.setenv("MOONMIND_DEPLOYMENT_LOCAL_PROJECT_DIR", str(tmp_path))
+
+    runtime = OmnigentOAuthHostRuntime(
+        client=SimpleNamespace(),
+        scripts_dir=tmp_path,
+        workspace_root=tmp_path / "workspaces",
+    )
+
+    assert runtime._tools_profile_path == (
+        tmp_path / "services/omnigent/profile/moonmind-tools.sh"
+    )
+
+
+@pytest.mark.asyncio
+async def test_tools_check_uses_host_login_shell_and_manifest(tmp_path) -> None:
+    runtime = OmnigentOAuthHostRuntime(
+        client=SimpleNamespace(),
+        scripts_dir=tmp_path,
+        workspace_root=tmp_path / "workspaces",
+    )
+    runtime._run = AsyncMock(return_value=(0, "", ""))
+
+    await runtime._exec_tools_check("mm-host-lease-1")
+
+    command = runtime._run.await_args.args
+    assert command[:5] == ("docker", "exec", "mm-host-lease-1", "bash", "-lc")
+    assert "test -f /opt/moonmind-tools/manifest.json" in command[-1]
+    assert "command -v gh" in command[-1]
+    assert "gh --version" in command[-1]
+
+
+@pytest.mark.asyncio
 async def test_static_host_runtime_uses_only_canonical_compose_file(tmp_path) -> None:
     runtime = OmnigentOAuthHostRuntime(
         client=SimpleNamespace(),

--- a/tests/unit/omnigent/test_oauth_profile_lifecycle.py
+++ b/tests/unit/omnigent/test_oauth_profile_lifecycle.py
@@ -252,26 +252,60 @@ async def test_on_demand_host_initializes_state_before_unprivileged_launch(
     )
 
     commands = [call.args for call in runtime._run.await_args_list]
-    assert commands[0][:4] == ("docker", "rm", "-f", "mm-host-lease-1")
-    assert "/opt/moonmind/init-codex-oauth-host.sh" in commands[1]
-    assert commands[2][:3] == ("docker", "run", "-d")
-    assert commands[1][commands[1].index("--user") + 1] == "0:0"
-    assert commands[2][commands[2].index("--workdir") + 1] == "/home/app"
-    launch = commands[2]
+    validation = commands[0]
+    assert validation[:3] == ("docker", "run", "--rm")
+    assert validation[validation.index("--entrypoint") + 1] == "/usr/bin/test"
+    assert validation[-2:] == ("-f", "/etc/profile.d/moonmind-tools.sh")
+    assert commands[1][:4] == ("docker", "rm", "-f", "mm-host-lease-1")
+    assert "/opt/moonmind/init-codex-oauth-host.sh" in commands[2]
+    assert commands[3][:3] == ("docker", "run", "-d")
+    assert commands[2][commands[2].index("--user") + 1] == "0:0"
+    assert commands[3][commands[3].index("--workdir") + 1] == "/home/app"
+    launch = commands[3]
     assert (
         "type=volume,src=moonmind-omnigent-tools-v1,dst=/opt/moonmind-tools,readonly"
         in launch
     )
     assert any(
-        value.endswith(
-            ",dst=/etc/profile.d/moonmind-tools.sh,readonly"
-        )
+        value.endswith(",dst=/etc/profile.d/moonmind-tools.sh,readonly")
         for value in launch
     )
     assert (
         "PATH=/opt/moonmind-tools/bin:/opt/venv/bin:/usr/local/bin:/usr/bin:/bin"
         in launch
     )
+
+
+@pytest.mark.asyncio
+async def test_on_demand_host_fails_before_launch_when_profile_is_not_daemon_visible(
+    tmp_path,
+) -> None:
+    runtime = OmnigentOAuthHostRuntime(
+        client=SimpleNamespace(),
+        scripts_dir=tmp_path,
+        workspace_root=tmp_path / "workspaces",
+        tools_profile_path=tmp_path / "worker-only-profile.sh",
+    )
+    runtime.container_exists = AsyncMock(return_value=False)
+    runtime._run = AsyncMock(
+        side_effect=OmnigentOAuthHostError("profile bind is not daemon-visible")
+    )
+
+    with pytest.raises(OmnigentOAuthHostError, match="not daemon-visible"):
+        await runtime._launch_on_demand(
+            binding=_binding().model_copy(
+                update={
+                    "static_host_id": None,
+                    "host_launch_profile_ref": "codex-oauth-v1",
+                }
+            ),
+            host_lease=_host_lease(),
+            container_name="mm-host-lease-1",
+            workspace_source=tmp_path,
+        )
+
+    assert runtime._run.await_count == 1
+    assert runtime._run.await_args.args[:3] == ("docker", "run", "--rm")
 
 
 def test_tools_path_prepend_is_idempotent_and_preserves_upstream_path() -> None:

--- a/tests/unit/omnigent/test_oauth_profile_lifecycle.py
+++ b/tests/unit/omnigent/test_oauth_profile_lifecycle.py
@@ -235,6 +235,9 @@ async def test_on_demand_host_initializes_state_before_unprivileged_launch(
         workspace_root=tmp_path / "workspaces",
     )
     runtime.container_exists = AsyncMock(return_value=False)
+    runtime._discover_upstream_path = AsyncMock(
+        return_value="/opt/venv/bin:/usr/local/bin:/usr/bin:/bin"
+    )
     runtime._run = AsyncMock(return_value=(0, "", ""))
     binding = _binding().model_copy(
         update={"static_host_id": None, "host_launch_profile_ref": "codex-oauth-v1"}
@@ -254,6 +257,29 @@ async def test_on_demand_host_initializes_state_before_unprivileged_launch(
     assert commands[2][:3] == ("docker", "run", "-d")
     assert commands[1][commands[1].index("--user") + 1] == "0:0"
     assert commands[2][commands[2].index("--workdir") + 1] == "/home/app"
+    launch = commands[2]
+    assert (
+        "type=volume,src=moonmind-omnigent-tools-v1,dst=/opt/moonmind-tools,readonly"
+        in launch
+    )
+    assert any(
+        value.endswith(
+            ",dst=/etc/profile.d/moonmind-tools.sh,readonly"
+        )
+        for value in launch
+    )
+    assert (
+        "PATH=/opt/moonmind-tools/bin:/opt/venv/bin:/usr/local/bin:/usr/bin:/bin"
+        in launch
+    )
+
+
+def test_tools_path_prepend_is_idempotent_and_preserves_upstream_path() -> None:
+    upstream = "/custom/bin:/usr/local/bin:/usr/bin:/bin"
+    expected = "/opt/moonmind-tools/bin:/custom/bin:/usr/local/bin:/usr/bin:/bin"
+
+    assert OmnigentOAuthHostRuntime._prepend_tools_path(upstream) == expected
+    assert OmnigentOAuthHostRuntime._prepend_tools_path(expected) == expected
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Issue

- Jira: [MM-1214](https://moonladder.atlassian.net/browse/MM-1214)
- Issue tracker reference: MM-1214

## Summary

- Project the versioned MoonMind tools bundle and login profile read-only into static Omnigent hosts.
- Apply the same projection to on-demand hosts while preserving the upstream image PATH.
- Validate daemon-visible bind sources before lease mutation or host launch.
- Add unit and Compose-boundary coverage for static and on-demand behavior.

## Tests

- git diff --check origin/main...HEAD
- python -m py_compile for the changed production and test modules
- docker compose config --quiet for all affected Omnigent host profiles
- Focused unit and hermetic integration tests were not run because the managed runtime lacks pytest (No module named pytest).

## Remaining risks

- The focused pytest suites still need execution in CI or another environment with repository test dependencies installed.

[MM-1214]: https://moonladder.atlassian.net/browse/MM-1214?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ