### PR TITLE
MM-1215: Complete Omnigent host and runner CLI capability preflight

### DIFF
--- a/api_service/Dockerfile
+++ b/api_service/Dockerfile
@@ -219,6 +219,8 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 # invalidate the lightweight project install.
 COPY moonmind /app/moonmind/
 COPY pr_resolver_core /app/pr_resolver_core/
+COPY services/omnigent/tools/manifest.lock.json /app/services/omnigent/tools/manifest.lock.json
+COPY services/omnigent/profile/moonmind-tools.sh /app/services/omnigent/profile/moonmind-tools.sh
 RUN --mount=type=cache,target=/root/.cache/pip \
     pip install --disable-pip-version-check --no-deps .
 COPY api_service /app/api_service/

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -839,8 +839,6 @@ services:
     depends_on:
       omnigent:
         condition: service_started
-      omnigent-tools-init:
-        condition: service_completed_successfully
     networks:
       - local-network
     restart: unless-stopped
@@ -876,8 +874,6 @@ services:
     depends_on:
       omnigent:
         condition: service_started
-      omnigent-tools-init:
-        condition: service_completed_successfully
       claude-auth-init:
         condition: service_completed_successfully
     networks:
@@ -936,8 +932,6 @@ services:
     depends_on:
       omnigent:
         condition: service_started
-      omnigent-tools-init:
-        condition: service_completed_successfully
       omnigent-host-codex-init:
         condition: service_completed_successfully
     networks:

--- a/moonmind/omnigent/mounted_tool_preflight.py
+++ b/moonmind/omnigent/mounted_tool_preflight.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import shlex
+from urllib.parse import urlparse
 from collections.abc import Awaitable, Callable, Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
@@ -40,8 +41,12 @@ def _repository_name(repository: str) -> str:
     value = repository.strip().removesuffix(".git")
     if value.startswith("git@github.com:"):
         value = value.split(":", 1)[1]
-    elif "github.com/" in value:
-        value = value.split("github.com/", 1)[1]
+    elif "://" in value:
+        parsed = urlparse(value)
+        if parsed.hostname != "github.com":
+            value = ""
+        else:
+            value = parsed.path
     value = value.strip("/")
     parts = value.split("/")
     if len(parts) != 2 or not all(parts):
@@ -57,7 +62,7 @@ def _trusted_gh_digest_checks() -> str:
     path = Path(__file__).resolve().parents[2] / "services/omnigent/tools/manifest.lock.json"
     manifest = json.loads(path.read_text(encoding="utf-8"))
     tool = next(item for item in manifest["tools"] if item["name"] == "gh")
-    digests = {item["sha256"] for item in tool["platforms"].values()}
+    digests = {item["executableSha256"] for item in tool["platforms"].values()}
     executable = f'/opt/moonmind-tools/{tool["path"]}'
     return " || ".join(
         f'''test "$(sha256sum {executable} | awk '{{print $1}}')" = "{digest}"'''
@@ -83,9 +88,8 @@ def _gh_probes(repository: str, *, mutation_required: bool) -> tuple[Probe, ...]
         probes.append(
             Probe(
                 "mutation_permission",
-                f"test \"$(gh repo view {quoted_repo} --json viewerPermission --jq .viewerPermission)\" = ADMIN || "
-                f"test \"$(gh repo view {quoted_repo} --json viewerPermission --jq .viewerPermission)\" = MAINTAIN || "
-                f"test \"$(gh repo view {quoted_repo} --json viewerPermission --jq .viewerPermission)\" = WRITE",
+                f"case \"$(gh repo view {quoted_repo} --json viewerPermission --jq .viewerPermission)\" in "
+                "ADMIN|MAINTAIN|WRITE) true;; *) false;; esac",
                 "github_repository_unauthorized",
             )
         )

--- a/moonmind/omnigent/mounted_tool_preflight.py
+++ b/moonmind/omnigent/mounted_tool_preflight.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import shlex
 from collections.abc import Awaitable, Callable, Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
@@ -66,6 +67,7 @@ def _trusted_gh_digest_checks() -> str:
 
 def _gh_probes(repository: str, *, mutation_required: bool) -> tuple[Probe, ...]:
     repo = _repository_name(repository)
+    quoted_repo = shlex.quote(repo)
     probes = [
         Probe("manifest", _trusted_gh_digest_checks(), "tool_manifest_mismatch"),
         Probe("lookup", "command -v gh", "tool_not_visible_in_login_shell"),
@@ -73,7 +75,7 @@ def _gh_probes(repository: str, *, mutation_required: bool) -> tuple[Probe, ...]
         Probe("authentication", "gh auth status", "github_auth_unavailable"),
         Probe(
             "repository_access",
-            f"gh repo view {repo} --json nameWithOwner,viewerPermission",
+            f"gh repo view {quoted_repo} --json nameWithOwner,viewerPermission",
             "github_repository_unauthorized",
         ),
     ]
@@ -81,9 +83,9 @@ def _gh_probes(repository: str, *, mutation_required: bool) -> tuple[Probe, ...]
         probes.append(
             Probe(
                 "mutation_permission",
-                f"test \"$(gh repo view {repo} --json viewerPermission --jq .viewerPermission)\" = ADMIN || "
-                f"test \"$(gh repo view {repo} --json viewerPermission --jq .viewerPermission)\" = MAINTAIN || "
-                f"test \"$(gh repo view {repo} --json viewerPermission --jq .viewerPermission)\" = WRITE",
+                f"test \"$(gh repo view {quoted_repo} --json viewerPermission --jq .viewerPermission)\" = ADMIN || "
+                f"test \"$(gh repo view {quoted_repo} --json viewerPermission --jq .viewerPermission)\" = MAINTAIN || "
+                f"test \"$(gh repo view {quoted_repo} --json viewerPermission --jq .viewerPermission)\" = WRITE",
                 "github_repository_unauthorized",
             )
         )

--- a/moonmind/omnigent/mounted_tool_preflight.py
+++ b/moonmind/omnigent/mounted_tool_preflight.py
@@ -1,0 +1,131 @@
+"""Required mounted-tool readiness at the Omnigent host/runner boundary (MM-1215)."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Awaitable, Callable, Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from moonmind.utils.logging import redact_sensitive_text
+
+
+CommandRunner = Callable[..., Awaitable[tuple[int, str, str]]]
+MAX_EVIDENCE_CHARS = 512
+
+
+class MountedToolPreflightError(RuntimeError):
+    """Stable, bounded failure raised before an Omnigent session is created."""
+
+    def __init__(self, message: str, *, code: str, evidence: Mapping[str, Any]) -> None:
+        super().__init__(message)
+        self.code = code
+        self.evidence = dict(evidence)
+
+
+@dataclass(frozen=True)
+class Probe:
+    name: str
+    command: str
+    failure_code: str
+
+
+def _bounded(value: str) -> str:
+    return redact_sensitive_text(str(value or ""))[:MAX_EVIDENCE_CHARS]
+
+
+def _repository_name(repository: str) -> str:
+    value = repository.strip().removesuffix(".git")
+    if value.startswith("git@github.com:"):
+        value = value.split(":", 1)[1]
+    elif "github.com/" in value:
+        value = value.split("github.com/", 1)[1]
+    value = value.strip("/")
+    parts = value.split("/")
+    if len(parts) != 2 or not all(parts):
+        raise MountedToolPreflightError(
+            "GitHub capability requires an owner/repository target",
+            code="github_repository_unauthorized",
+            evidence={"phase": "authorization", "repository": _bounded(repository)},
+        )
+    return "/".join(parts)
+
+
+def _trusted_gh_digest_checks() -> str:
+    path = Path(__file__).resolve().parents[2] / "services/omnigent/tools/manifest.lock.json"
+    manifest = json.loads(path.read_text(encoding="utf-8"))
+    tool = next(item for item in manifest["tools"] if item["name"] == "gh")
+    digests = {item["sha256"] for item in tool["platforms"].values()}
+    executable = f'/opt/moonmind-tools/{tool["path"]}'
+    return " || ".join(
+        f'''test "$(sha256sum {executable} | awk '{{print $1}}')" = "{digest}"'''
+        for digest in sorted(digests)
+    )
+
+
+def _gh_probes(repository: str, *, mutation_required: bool) -> tuple[Probe, ...]:
+    repo = _repository_name(repository)
+    probes = [
+        Probe("manifest", _trusted_gh_digest_checks(), "tool_manifest_mismatch"),
+        Probe("lookup", "command -v gh", "tool_not_visible_in_login_shell"),
+        Probe("version", "gh --version", "tool_manifest_mismatch"),
+        Probe("authentication", "gh auth status", "github_auth_unavailable"),
+        Probe(
+            "repository_access",
+            f"gh repo view {repo} --json nameWithOwner,viewerPermission",
+            "github_repository_unauthorized",
+        ),
+    ]
+    if mutation_required:
+        probes.append(
+            Probe(
+                "mutation_permission",
+                f"test \"$(gh repo view {repo} --json viewerPermission --jq .viewerPermission)\" = ADMIN || "
+                f"test \"$(gh repo view {repo} --json viewerPermission --jq .viewerPermission)\" = MAINTAIN || "
+                f"test \"$(gh repo view {repo} --json viewerPermission --jq .viewerPermission)\" = WRITE",
+                "github_repository_unauthorized",
+            )
+        )
+    return tuple(probes)
+
+
+async def preflight_mounted_tools(
+    *,
+    required_capabilities: Sequence[str],
+    repository: str,
+    mutation_required: bool,
+    host_runner: CommandRunner,
+    runner_runner: CommandRunner,
+) -> dict[str, Any]:
+    """Probe only declared tools through both real shell construction paths."""
+
+    capabilities = {str(value).strip().lower() for value in required_capabilities}
+    if "gh" not in capabilities:
+        return {"status": "not_required", "boundaries": []}
+
+    evidence: list[dict[str, str]] = []
+    for boundary, command_runner in (("host", host_runner), ("runner", runner_runner)):
+        for probe in _gh_probes(repository, mutation_required=mutation_required):
+            rc, stdout, stderr = await command_runner(probe.command)
+            item = {
+                "boundary": boundary,
+                "probe": probe.name,
+                "status": "ready" if rc == 0 else "failed",
+            }
+            if stdout:
+                item["output"] = _bounded(stdout)
+            if rc != 0:
+                if stderr:
+                    item["error"] = _bounded(stderr)
+                evidence.append(item)
+                raise MountedToolPreflightError(
+                    f"Mounted gh preflight failed during {boundary} {probe.name}",
+                    code=probe.failure_code,
+                    evidence={"tool": "gh", "phase": probe.name, "probes": evidence},
+                )
+            evidence.append(item)
+    return {"status": "ready", "tool": "gh", "probes": evidence}
+
+
+__all__ = ["MountedToolPreflightError", "preflight_mounted_tools"]

--- a/moonmind/omnigent/oauth_host_runtime.py
+++ b/moonmind/omnigent/oauth_host_runtime.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import os
+import shlex
 from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
@@ -14,6 +15,10 @@ from moonmind.omnigent.oauth_hosts import (
     OmnigentOAuthHostError,
     deterministic_host_container_name,
     validate_preflight_result,
+)
+from moonmind.omnigent.mounted_tool_preflight import (
+    MountedToolPreflightError,
+    preflight_mounted_tools,
 )
 from moonmind.schemas.agent_runtime_models import (
     OmnigentOAuthHostBinding,
@@ -104,6 +109,10 @@ class OmnigentOAuthHostRuntime:
         host_lease: OmnigentHostLease,
         workspace_key: str,
         repository_url: str | None = None,
+        target_repository: str = "",
+        required_capabilities: tuple[str, ...] = (),
+        github_token: str | None = None,
+        github_mutation_required: bool = False,
     ) -> dict[str, Any]:
         workspace_source = await self._prepare_workspace(
             workspace_key=workspace_key,
@@ -119,6 +128,7 @@ class OmnigentOAuthHostRuntime:
                 host_lease=host_lease,
                 container_name=container_name,
                 workspace_source=workspace_source,
+                github_token=github_token,
             )
             await self._exec_check(container_name)
             await self._exec_tools_check(container_name)
@@ -135,6 +145,13 @@ class OmnigentOAuthHostRuntime:
                 "registered host does not advertise codex-native",
                 code=HostPreflightFailure.HARNESS_UNAVAILABLE.value,
             )
+        mounted_tool_evidence = await self._preflight_mounted_tools(
+            binding=binding,
+            host_lease=host_lease,
+            required_capabilities=required_capabilities,
+            repository=target_repository,
+            mutation_required=github_mutation_required,
+        )
         result = {
             "status": "ready",
             "providerProfileId": binding.provider_profile_id,
@@ -148,6 +165,7 @@ class OmnigentOAuthHostRuntime:
             "hostId": host_id,
             "harness": "codex-native",
             "competingCredentialsPresent": False,
+            "mountedTools": mounted_tool_evidence,
             "workspacePath": (
                 "/workspaces/run"
                 if binding.host_launch_profile_ref
@@ -160,6 +178,7 @@ class OmnigentOAuthHostRuntime:
             host_lease=host_lease.model_copy(update={"omnigent_host_id": host_id}),
         )
         validated["workspacePath"] = result["workspacePath"]
+        validated["mountedTools"] = mounted_tool_evidence
         return validated
 
     async def stop_host(
@@ -231,6 +250,7 @@ class OmnigentOAuthHostRuntime:
         host_lease: OmnigentHostLease,
         container_name: str,
         workspace_source: Path,
+        github_token: str | None = None,
     ) -> None:
         if await self.container_exists(container_name):
             return
@@ -319,6 +339,31 @@ class OmnigentOAuthHostRuntime:
         if token:
             child_env["OMNIGENT_API_TOKEN"] = token
             args.extend(["--env", "OMNIGENT_API_TOKEN"])
+        if github_token:
+            child_env["GH_TOKEN"] = github_token
+            child_env["GIT_TOKEN"] = github_token
+            args.extend(
+                [
+                    "--env",
+                    "GH_TOKEN",
+                    "--env",
+                    "GIT_TOKEN",
+                    "--env",
+                    "GIT_USERNAME=x-access-token",
+                    "--env",
+                    "GH_CONFIG_DIR=/workspaces/run/.config/gh",
+                    "--env",
+                    "GH_PROMPT_DISABLED=1",
+                    "--env",
+                    "GH_NO_UPDATE_NOTIFIER=1",
+                    "--env",
+                    "GH_NO_EXTENSION_UPDATE_NOTIFIER=1",
+                    "--env",
+                    "OMNIGENT_RUNNER_ENV_PASSTHROUGH="
+                    "GH_TOKEN,GH_CONFIG_DIR,GH_PROMPT_DISABLED,"
+                    "GH_NO_UPDATE_NOTIFIER,GH_NO_EXTENSION_UPDATE_NOTIFIER",
+                ]
+            )
         for key, value in labels.items():
             args.extend(["--label", f"{key}={value}"])
         args.extend(["--entrypoint", "/usr/bin/env"])
@@ -379,6 +424,54 @@ class OmnigentOAuthHostRuntime:
             "-lc",
             "test -f /opt/moonmind-tools/manifest.json "
             "&& command -v gh >/dev/null && gh --version >/dev/null",
+        )
+
+    async def _preflight_mounted_tools(
+        self,
+        *,
+        binding: OmnigentOAuthHostBinding,
+        host_lease: OmnigentHostLease,
+        required_capabilities: tuple[str, ...],
+        repository: str,
+        mutation_required: bool,
+    ) -> dict[str, Any]:
+        if "gh" not in {item.strip().lower() for item in required_capabilities}:
+            return {"status": "not_required", "boundaries": []}
+        if not binding.host_launch_profile_ref:
+            raise MountedToolPreflightError(
+                "Required gh credentials cannot be isolated on a reusable static host",
+                code="github_auth_unavailable",
+                evidence={"tool": "gh", "phase": "host_launch", "hostMode": "static"},
+            )
+        container_name = host_lease.container_name or deterministic_host_container_name(
+            host_lease.lease_id
+        )
+
+        async def host_runner(command: str) -> tuple[int, str, str]:
+            return await self._run(
+                "docker", "exec", container_name, "bash", "-lc", command, check=False
+            )
+
+        async def runner_runner(command: str) -> tuple[int, str, str]:
+            # Mirror the stock host's explicit runner passthrough allowlist.  This
+            # proves the shell/environment that the harness constructs, not the
+            # worker container that launched the host.
+            runner_command = (
+                'env -i HOME="$HOME" PATH="$PATH" GH_TOKEN="$GH_TOKEN" '
+                'GH_CONFIG_DIR="$GH_CONFIG_DIR" GH_PROMPT_DISABLED=1 '
+                'GH_NO_UPDATE_NOTIFIER=1 GH_NO_EXTENSION_UPDATE_NOTIFIER=1 '
+                f"bash -lc {shlex.quote(command)}"
+            )
+            return await self._run(
+                "docker", "exec", container_name, "bash", "-lc", runner_command, check=False
+            )
+
+        return await preflight_mounted_tools(
+            required_capabilities=required_capabilities,
+            repository=repository,
+            mutation_required=mutation_required,
+            host_runner=host_runner,
+            runner_runner=runner_runner,
         )
 
     async def _prepare_workspace(

--- a/moonmind/omnigent/oauth_host_runtime.py
+++ b/moonmind/omnigent/oauth_host_runtime.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import os
-import shlex
 from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
@@ -453,17 +452,29 @@ class OmnigentOAuthHostRuntime:
             )
 
         async def runner_runner(command: str) -> tuple[int, str, str]:
-            # Mirror the stock host's explicit runner passthrough allowlist.  This
-            # proves the shell/environment that the harness constructs, not the
-            # worker container that launched the host.
-            runner_command = (
-                'env -i HOME="$HOME" PATH="$PATH" GH_TOKEN="$GH_TOKEN" '
-                'GH_CONFIG_DIR="$GH_CONFIG_DIR" GH_PROMPT_DISABLED=1 '
-                'GH_NO_UPDATE_NOTIFIER=1 GH_NO_EXTENSION_UPDATE_NOTIFIER=1 '
-                f"bash -lc {shlex.quote(command)}"
+            # Execute with the stock host's authoritative runner environment
+            # constructor.  Importing this function from the installed Omnigent
+            # build keeps the pre-session proof on the exact path that
+            # HostConnect._handle_launch uses immediately before Popen.
+            runner_probe = (
+                "import os, subprocess, sys; "
+                "from omnigent.host.connect import _build_runner_env; "
+                "env = _build_runner_env(os.environ, server_url=os.environ.get("
+                "'OMNIGENT_SERVER_URL', ''), runner_id='preflight', "
+                "binding_token='preflight', workspace='/workspaces/run', "
+                "parent_pid=os.getpid()); "
+                "result = subprocess.run(['bash', '-lc', sys.argv[1]], env=env, "
+                "text=True); raise SystemExit(result.returncode)"
             )
             return await self._run(
-                "docker", "exec", container_name, "bash", "-lc", runner_command, check=False
+                "docker",
+                "exec",
+                container_name,
+                "python",
+                "-c",
+                runner_probe,
+                command,
+                check=False,
             )
 
         return await preflight_mounted_tools(

--- a/moonmind/omnigent/oauth_host_runtime.py
+++ b/moonmind/omnigent/oauth_host_runtime.py
@@ -365,8 +365,8 @@ class OmnigentOAuthHostRuntime:
                     "GH_NO_EXTENSION_UPDATE_NOTIFIER=1",
                     "--env",
                     "OMNIGENT_RUNNER_ENV_PASSTHROUGH=GH_TOKEN,GH_CONFIG_DIR,"
-                    "GH_PROMPT_DISABLED,GH_NO_UPDATE_NOTIFIER,"
-                    "GH_NO_EXTENSION_UPDATE_NOTIFIER",
+                    + "GH_PROMPT_DISABLED,GH_NO_UPDATE_NOTIFIER,"
+                    + "GH_NO_EXTENSION_UPDATE_NOTIFIER",
                 ]
             )
         for key, value in labels.items():

--- a/moonmind/omnigent/oauth_host_runtime.py
+++ b/moonmind/omnigent/oauth_host_runtime.py
@@ -23,6 +23,9 @@ from moonmind.schemas.agent_runtime_models import (
     OmnigentOAuthHostBinding,
     OmnigentHostLease,
 )
+from moonmind.workflows.temporal.runtime.git_auth import (
+    build_github_token_git_environment,
+)
 from moonmind.workflows.adapters.omnigent_client import OmnigentHttpClient
 
 _FORBIDDEN_ENV = (
@@ -116,8 +119,11 @@ class OmnigentOAuthHostRuntime:
         workspace_source = await self._prepare_workspace(
             workspace_key=workspace_key,
             repository_url=repository_url,
+            github_token=github_token,
         )
         if binding.host_launch_profile_ref:
+            if "gh" in {item.strip().lower() for item in required_capabilities}:
+                await self._initialize_required_tools()
             container_name = (
                 host_lease.container_name
                 or deterministic_host_container_name(host_lease.lease_id)
@@ -358,9 +364,9 @@ class OmnigentOAuthHostRuntime:
                     "--env",
                     "GH_NO_EXTENSION_UPDATE_NOTIFIER=1",
                     "--env",
-                    "OMNIGENT_RUNNER_ENV_PASSTHROUGH="
-                    "GH_TOKEN,GH_CONFIG_DIR,GH_PROMPT_DISABLED,"
-                    "GH_NO_UPDATE_NOTIFIER,GH_NO_EXTENSION_UPDATE_NOTIFIER",
+                    "OMNIGENT_RUNNER_ENV_PASSTHROUGH=GH_TOKEN,GH_CONFIG_DIR,"
+                    "GH_PROMPT_DISABLED,GH_NO_UPDATE_NOTIFIER,"
+                    "GH_NO_EXTENSION_UPDATE_NOTIFIER",
                 ]
             )
         for key, value in labels.items():
@@ -486,7 +492,11 @@ class OmnigentOAuthHostRuntime:
         )
 
     async def _prepare_workspace(
-        self, *, workspace_key: str, repository_url: str | None
+        self,
+        *,
+        workspace_key: str,
+        repository_url: str | None,
+        github_token: str | None = None,
     ) -> Path:
         self._workspace_root.mkdir(parents=True, exist_ok=True)
         digest = hashlib.sha256(workspace_key.encode("utf-8")).hexdigest()[:24]
@@ -495,8 +505,28 @@ class OmnigentOAuthHostRuntime:
             raise OmnigentOAuthHostError("workspace escaped configured root")
         workspace.mkdir(mode=0o700, parents=True, exist_ok=True)
         if repository_url and not any(workspace.iterdir()):
-            await self._run("git", "clone", "--", repository_url, str(workspace))
+            await self._run(
+                "git",
+                "clone",
+                "--",
+                repository_url,
+                str(workspace),
+                env=build_github_token_git_environment(github_token, base_env=os.environ),
+            )
         return workspace
+
+    async def _initialize_required_tools(self) -> None:
+        await self._run(
+            "docker",
+            "compose",
+            "-f",
+            "docker-compose.yaml",
+            "--profile",
+            "omnigent-host-codex",
+            "run",
+            "--rm",
+            "omnigent-tools-init",
+        )
 
     async def _compose_static_check(self) -> None:
         await self._run(

--- a/moonmind/omnigent/profile_bound_execution.py
+++ b/moonmind/omnigent/profile_bound_execution.py
@@ -20,6 +20,7 @@ from moonmind.omnigent.checkpoints import (
     validate_cold_restore_target,
 )
 from moonmind.omnigent.oauth_host_runtime import OmnigentOAuthHostRuntime
+from moonmind.omnigent.mounted_tool_preflight import MountedToolPreflightError
 from moonmind.omnigent.oauth_hosts import (
     OmnigentOAuthHostError,
     OmnigentOAuthHostRepository,
@@ -198,6 +199,12 @@ class OmnigentProfileBoundExecutionCoordinator:
                     f"{workflow_id}:{step_execution_id or request.idempotency_key}"
                 ),
                 repository_url=self._repository_url(request),
+                target_repository=str(
+                    (request.parameters or {}).get("repository") or ""
+                ).strip(),
+                required_capabilities=self._required_capabilities(request),
+                github_token=await self._github_token(request),
+                github_mutation_required="gh" in self._required_capabilities(request),
             )
             host_id = str(preflight["hostId"])
             if binding.static_host_id is None and not binding.host_launch_profile_ref:
@@ -232,6 +239,12 @@ class OmnigentProfileBoundExecutionCoordinator:
                     "omnigentHostId": host_id,
                 },
             )
+            if preflight.get("mountedTools", {}).get("status") == "ready":
+                await self._run_store.record_lifecycle_event(
+                    request.idempotency_key,
+                    event_type="mounted_tool_preflight_ready",
+                    metadata=dict(preflight["mountedTools"]),
+                )
             if host_lease.status == "ready":
                 host_lease = await self._hosts.transition_host_lease(
                     host_lease.lease_id,
@@ -269,6 +282,14 @@ class OmnigentProfileBoundExecutionCoordinator:
             return result
         except Exception as exc:
             if bridge_ready:
+                if isinstance(exc, MountedToolPreflightError):
+                    await self._run_store.record_lifecycle_event(
+                        request.idempotency_key,
+                        event_type="mounted_tool_preflight_blocked",
+                        code=exc.code,
+                        summary=str(exc),
+                        metadata=exc.evidence,
+                    )
                 await self._run_store.record_lifecycle_event(
                     request.idempotency_key,
                     event_type="cleanup_started",
@@ -465,6 +486,35 @@ class OmnigentProfileBoundExecutionCoordinator:
             build_omnigent_selection(request).session.workspace or ""
         ).strip()
         return workspace if "://" in workspace or workspace.startswith("git@") else None
+
+    @staticmethod
+    def _required_capabilities(request: AgentExecutionRequest) -> tuple[str, ...]:
+        raw = (request.parameters or {}).get("requiredCapabilities")
+        if not isinstance(raw, list):
+            return ()
+        return tuple(
+            dict.fromkeys(
+                str(value).strip().lower() for value in raw if str(value).strip()
+            )
+        )
+
+    @staticmethod
+    async def _github_token(request: AgentExecutionRequest) -> str | None:
+        if "gh" not in OmnigentProfileBoundExecutionCoordinator._required_capabilities(
+            request
+        ):
+            return None
+        from moonmind.auth.github_credentials import resolve_github_credential
+
+        repository = str((request.parameters or {}).get("repository") or "").strip()
+        resolved = await resolve_github_credential(repo=repository or None)
+        token = str(resolved.token or "").strip()
+        if not token:
+            raise OmnigentOAuthHostError(
+                "GitHub credential is required for mounted gh readiness",
+                code="github_auth_unavailable",
+            )
+        return token
 
 
 __all__ = ["OmnigentProfileBoundExecutionCoordinator"]

--- a/moonmind/omnigent/profile_bound_execution.py
+++ b/moonmind/omnigent/profile_bound_execution.py
@@ -204,7 +204,7 @@ class OmnigentProfileBoundExecutionCoordinator:
                 ).strip(),
                 required_capabilities=self._required_capabilities(request),
                 github_token=await self._github_token(request),
-                github_mutation_required="gh" in self._required_capabilities(request),
+                github_mutation_required=self._github_mutation_required(request),
             )
             host_id = str(preflight["hostId"])
             if binding.static_host_id is None and not binding.host_launch_profile_ref:
@@ -508,13 +508,31 @@ class OmnigentProfileBoundExecutionCoordinator:
 
         repository = str((request.parameters or {}).get("repository") or "").strip()
         resolved = await resolve_github_credential(repo=repository or None)
-        token = str(resolved.token or "").strip()
+        token = str(resolved.token or "").strip() if resolved else ""
         if not token:
             raise OmnigentOAuthHostError(
                 "GitHub credential is required for mounted gh readiness",
                 code="github_auth_unavailable",
             )
         return token
+
+    @staticmethod
+    def _github_mutation_required(request: AgentExecutionRequest) -> bool:
+        if "gh" not in OmnigentProfileBoundExecutionCoordinator._required_capabilities(
+            request
+        ):
+            return False
+        parameters = request.parameters or {}
+        publish_mode = str(parameters.get("publishMode") or "none").strip().lower()
+        if publish_mode not in {"", "none"}:
+            return True
+        skill = parameters.get("skill")
+        if not isinstance(skill, Mapping):
+            return False
+        side_effect = skill.get("sideEffect")
+        return isinstance(side_effect, Mapping) and bool(
+            str(side_effect.get("kind") or "").strip()
+        )
 
 
 __all__ = ["OmnigentProfileBoundExecutionCoordinator"]

--- a/services/omnigent/tools/init_omnigent_tools.py
+++ b/services/omnigent/tools/init_omnigent_tools.py
@@ -90,7 +90,7 @@ def _runtime_manifest(lock: dict, platform_key: str) -> dict:
                 "name": tool["name"],
                 "version": tool["version"],
                 "platform": platform_key,
-                "sha256": selected["sha256"],
+                "sha256": selected["executableSha256"],
                 "path": tool["path"],
                 "versionProbe": tool["versionProbe"],
             }
@@ -112,8 +112,13 @@ def _validate_completed(bundle: Path, manifest: dict) -> None:
         raise RuntimeError("completed tool bundle manifest does not match pinned manifest")
     for tool in manifest["tools"]:
         executable = bundle / _safe_relative_path(tool["path"])
-        if not executable.is_file() or not os.access(executable, os.X_OK):
+        if not executable.is_file():
+            raise RuntimeError(f"executable missing for {tool['path']}")
+        if not os.access(executable, os.X_OK):
             raise RuntimeError(f"invalid executable permissions for {tool['path']}")
+        digest = hashlib.sha256(executable.read_bytes()).hexdigest()
+        if digest != tool["sha256"]:
+            raise RuntimeError(f"SHA-256 mismatch for {tool['path']}")
         subprocess.run(
             [str(executable), *tool["versionProbe"]],
             check=True,

--- a/services/omnigent/tools/manifest.lock.json
+++ b/services/omnigent/tools/manifest.lock.json
@@ -9,11 +9,13 @@
         "linux/amd64": {
           "url": "https://github.com/cli/cli/releases/download/v2.74.2/gh_2.74.2_linux_amd64.tar.gz",
           "sha256": "c421091ae5800390e6aef1f50bfda59cc1d4f2ef2200bcd4e1a662c05c28c444",
+          "executableSha256": "abc2fd6b6411776b2843f320dc08a9e99b63b662e79c5752504ea696739ad408",
           "archivePath": "gh_2.74.2_linux_amd64/bin/gh"
         },
         "linux/arm64": {
           "url": "https://github.com/cli/cli/releases/download/v2.74.2/gh_2.74.2_linux_arm64.tar.gz",
           "sha256": "f0b07f0aeaf00f137df1bd33a76e717b1945f4b83bd6a3296b365414d3eb413f",
+          "executableSha256": "f4c95edc71e91dad4f39f4a655a37d8b9cc9ae7677a299213ab06b6dd00ab0dd",
           "archivePath": "gh_2.74.2_linux_arm64/bin/gh"
         }
       },

--- a/tests/integration/temporal/test_compose_foundation.py
+++ b/tests/integration/temporal/test_compose_foundation.py
@@ -201,9 +201,7 @@ def test_omnigent_hosts_use_versioned_read_only_tool_bundle():
         host = services[service_name]
         environment = _env_map(host["environment"])
         assert environment["PATH"].startswith("/opt/moonmind-tools/bin:")
-        assert host["depends_on"]["omnigent-tools-init"]["condition"] == (
-            "service_completed_successfully"
-        )
+        assert "omnigent-tools-init" not in host["depends_on"]
         assert "omnigent-tools:/opt/moonmind-tools:ro" in host["volumes"]
         assert (
             "./services/omnigent/profile/moonmind-tools.sh:"
@@ -579,9 +577,7 @@ def test_omnigent_claude_host_profile_uses_only_canonical_oauth_credentials():
 
     assert host_service["depends_on"] == {
         "omnigent": {"condition": "service_started"},
-        "omnigent-tools-init": {"condition": "service_completed_successfully"},
         "claude-auth-init": {"condition": "service_completed_successfully"},
-        "omnigent-tools-init": {"condition": "service_completed_successfully"},
     }
     assert _network_names(host_service) == {"local-network"}
     assert host_service["restart"] == "unless-stopped"
@@ -655,11 +651,9 @@ def test_omnigent_codex_host_profile_uses_only_canonical_oauth_credentials():
     assert "omnigent-host-codex-state" in compose["volumes"]
     assert host_service["depends_on"] == {
         "omnigent": {"condition": "service_started"},
-        "omnigent-tools-init": {"condition": "service_completed_successfully"},
         "omnigent-host-codex-init": {
             "condition": "service_completed_successfully"
         },
-        "omnigent-tools-init": {"condition": "service_completed_successfully"},
     }
     init_service = compose["services"]["omnigent-host-codex-init"]
     assert init_service["user"] == "0:0"

--- a/tests/integration/temporal/test_compose_foundation.py
+++ b/tests/integration/temporal/test_compose_foundation.py
@@ -512,7 +512,9 @@ def test_omnigent_host_profile_service_is_wired_for_mm_971():
     assert host_env["GEMINI_API_KEY"] == "${GEMINI_API_KEY:-}"
     assert host_env["GOOGLE_API_KEY"] == "${GOOGLE_API_KEY:-}"
 
-    host_volumes = set(host_service["volumes"])
+    host_volumes = {
+        volume for volume in host_service["volumes"] if isinstance(volume, str)
+    }
     assert "omnigent-host-state:/root/.omnigent" in host_volumes
     assert "./omnigent_workspaces:/workspaces" in host_volumes
     assert "codex_auth_volume:/root/.codex" not in host_volumes
@@ -563,7 +565,9 @@ def test_omnigent_claude_host_profile_uses_only_canonical_oauth_credentials():
         "GOOGLE_API_KEY": "",
     }
 
-    host_volumes = set(host_service["volumes"])
+    host_volumes = {
+        volume for volume in host_service["volumes"] if isinstance(volume, str)
+    }
     assert "omnigent-host-claude-state:/home/app/.omnigent" in host_volumes
     assert "claude_auth_volume:/home/app/.claude" in host_volumes
     assert "./omnigent_workspaces:/workspaces" in host_volumes
@@ -577,6 +581,7 @@ def test_omnigent_claude_host_profile_uses_only_canonical_oauth_credentials():
         "omnigent": {"condition": "service_started"},
         "omnigent-tools-init": {"condition": "service_completed_successfully"},
         "claude-auth-init": {"condition": "service_completed_successfully"},
+        "omnigent-tools-init": {"condition": "service_completed_successfully"},
     }
     assert _network_names(host_service) == {"local-network"}
     assert host_service["restart"] == "unless-stopped"
@@ -632,7 +637,9 @@ def test_omnigent_codex_host_profile_uses_only_canonical_oauth_credentials():
         "GOOGLE_API_KEY",
     }
     assert set(entrypoint[1::2]) == {"-u"}
-    assert set(host_service["volumes"]) == {
+    assert {
+        volume for volume in host_service["volumes"] if isinstance(volume, str)
+    } == {
         "omnigent-host-codex-state:/home/app/.omnigent",
         "codex_auth_volume:/home/app/.codex",
         "omnigent-tools:/opt/moonmind-tools:ro",
@@ -643,6 +650,7 @@ def test_omnigent_codex_host_profile_uses_only_canonical_oauth_credentials():
             "/workspaces/MoonMind:ro"
         ),
         "./services/omnigent/scripts:/opt/moonmind:ro",
+        "./services/omnigent/profile/moonmind-tools.sh:/etc/profile.d/moonmind-tools.sh:ro",
     }
     assert "omnigent-host-codex-state" in compose["volumes"]
     assert host_service["depends_on"] == {
@@ -651,6 +659,7 @@ def test_omnigent_codex_host_profile_uses_only_canonical_oauth_credentials():
         "omnigent-host-codex-init": {
             "condition": "service_completed_successfully"
         },
+        "omnigent-tools-init": {"condition": "service_completed_successfully"},
     }
     init_service = compose["services"]["omnigent-host-codex-init"]
     assert init_service["user"] == "0:0"

--- a/tests/unit/omnigent/test_host_tool_projection.py
+++ b/tests/unit/omnigent/test_host_tool_projection.py
@@ -18,9 +18,7 @@ def test_static_hosts_project_versioned_tools_without_covering_usr_local_bin() -
         else:
             assert environment["PATH"] == expected_path
         assert "omnigent-tools:/opt/moonmind-tools:ro" in service["volumes"]
-        assert service["depends_on"]["omnigent-tools-init"]["condition"] == (
-            "service_completed_successfully"
-        )
+        assert "omnigent-tools-init" not in service["depends_on"]
         assert (
             "./services/omnigent/profile/moonmind-tools.sh:"
             "/etc/profile.d/moonmind-tools.sh:ro"

--- a/tests/unit/omnigent/test_mounted_tool_preflight.py
+++ b/tests/unit/omnigent/test_mounted_tool_preflight.py
@@ -1,0 +1,85 @@
+"""MM-1215 mounted-tool capability boundary tests."""
+
+from __future__ import annotations
+
+import pytest
+
+from moonmind.omnigent.mounted_tool_preflight import (
+    MountedToolPreflightError,
+    preflight_mounted_tools,
+)
+
+
+@pytest.mark.asyncio
+async def test_optional_gh_absence_does_not_probe_or_unhealthy_host() -> None:
+    calls: list[str] = []
+
+    async def runner(command: str) -> tuple[int, str, str]:
+        calls.append(command)
+        return 127, "", "missing"
+
+    result = await preflight_mounted_tools(
+        required_capabilities=("git",),
+        repository="owner/repo",
+        mutation_required=False,
+        host_runner=runner,
+        runner_runner=runner,
+    )
+
+    assert result == {"status": "not_required", "boundaries": []}
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_gh_probes_host_and_exact_runner_with_mutation_permission() -> None:
+    calls: list[tuple[str, str]] = []
+
+    def make_runner(boundary: str):
+        async def runner(command: str) -> tuple[int, str, str]:
+            calls.append((boundary, command))
+            return 0, "ok", ""
+
+        return runner
+
+    result = await preflight_mounted_tools(
+        required_capabilities=("gh",),
+        repository="https://github.com/owner/repo.git",
+        mutation_required=True,
+        host_runner=make_runner("host"),
+        runner_runner=make_runner("runner"),
+    )
+
+    assert result["status"] == "ready"
+    assert [boundary for boundary, _ in calls] == ["host"] * 6 + ["runner"] * 6
+    assert any("command -v gh" in command for _, command in calls)
+    assert any("gh auth status" in command for _, command in calls)
+    assert any("viewerPermission" in command for _, command in calls)
+
+
+@pytest.mark.asyncio
+async def test_runner_auth_failure_is_stable_bounded_and_redacted() -> None:
+    async def host_runner(_command: str) -> tuple[int, str, str]:
+        return 0, "ok", ""
+
+    call_count = 0
+
+    async def runner_runner(_command: str) -> tuple[int, str, str]:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 4:
+            return 1, "", "Authorization: Bearer ghp_abcdefghijklmnopqrstuvwxyz123456"
+        return 0, "ok", ""
+
+    with pytest.raises(MountedToolPreflightError) as raised:
+        await preflight_mounted_tools(
+            required_capabilities=("gh",),
+            repository="owner/repo",
+            mutation_required=False,
+            host_runner=host_runner,
+            runner_runner=runner_runner,
+        )
+
+    assert raised.value.code == "github_auth_unavailable"
+    serialized = str(raised.value.evidence)
+    assert "ghp_abcdefghijklmnopqrstuvwxyz123456" not in serialized
+    assert len(serialized) < 4096

--- a/tests/unit/omnigent/test_mounted_tool_preflight.py
+++ b/tests/unit/omnigent/test_mounted_tool_preflight.py
@@ -54,6 +54,33 @@ async def test_gh_probes_host_and_exact_runner_with_mutation_permission() -> Non
     assert any("command -v gh" in command for _, command in calls)
     assert any("gh auth status" in command for _, command in calls)
     assert any("viewerPermission" in command for _, command in calls)
+    permission_commands = [command for _, command in calls if "--jq .viewerPermission" in command]
+    assert len(permission_commands) == 2
+    assert all(command.count("gh repo view") == 1 for command in permission_commands)
+
+
+@pytest.mark.parametrize(
+    "repository",
+    (
+        "https://evil.example/github.com/owner/repo",
+        "https://github.com.evil.example/owner/repo",
+    ),
+)
+@pytest.mark.asyncio
+async def test_repository_parser_rejects_embedded_github_hostname(repository: str) -> None:
+    async def runner(_command: str) -> tuple[int, str, str]:
+        return 0, "", ""
+
+    with pytest.raises(MountedToolPreflightError) as raised:
+        await preflight_mounted_tools(
+            required_capabilities=("gh",),
+            repository=repository,
+            mutation_required=False,
+            host_runner=runner,
+            runner_runner=runner,
+        )
+
+    assert raised.value.code == "github_repository_unauthorized"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/omnigent/test_oauth_profile_lifecycle.py
+++ b/tests/unit/omnigent/test_oauth_profile_lifecycle.py
@@ -30,6 +30,7 @@ from moonmind.omnigent.oauth_hosts import (
     validate_preflight_result,
 )
 from moonmind.omnigent.oauth_host_runtime import OmnigentOAuthHostRuntime
+from moonmind.omnigent.mounted_tool_preflight import MountedToolPreflightError
 from moonmind.omnigent.profile_bound_execution import (
     OmnigentProfileBoundExecutionCoordinator,
 )
@@ -138,6 +139,34 @@ def test_oauth_host_runtime_preserves_complete_image_reference(
     runtime = OmnigentOAuthHostRuntime(client=SimpleNamespace())
 
     assert runtime._image == image
+
+
+@pytest.mark.asyncio
+async def test_runtime_preflight_uses_stock_runner_environment_constructor() -> None:
+    runtime = OmnigentOAuthHostRuntime(client=SimpleNamespace())
+    calls: list[tuple[str, ...]] = []
+
+    async def run(*args, **_kwargs):
+        calls.append(args)
+        return 0, "ready", ""
+
+    runtime._run = run  # type: ignore[method-assign]
+    binding = _binding().model_copy(update={"host_launch_profile_ref": "codex"})
+    lease = _host_lease().model_copy(update={"container_name": "host-mm-1215"})
+
+    result = await runtime._preflight_mounted_tools(
+        binding=binding,
+        host_lease=lease,
+        required_capabilities=("gh",),
+        repository="owner/repo",
+        mutation_required=True,
+    )
+
+    assert result["status"] == "ready"
+    runner_calls = [call for call in calls if "python" in call]
+    assert len(runner_calls) == 6
+    assert all("from omnigent.host.connect import _build_runner_env" in call[5] for call in runner_calls)
+    assert all(call[:4] == ("docker", "exec", "host-mm-1215", "python") for call in runner_calls)
 
 
 def test_deterministic_owner_reuses_activity_retry_identity() -> None:
@@ -686,3 +715,115 @@ async def test_coordinator_releases_provider_lease_after_host_cleanup() -> None:
     )
     assert result.summary == "done"
     assert actions[-3:] == ["host_stopped", "cleanup_completed", "provider_released"]
+
+
+@pytest.mark.asyncio
+async def test_coordinator_records_runner_preflight_block_before_execution() -> None:
+    events: list[tuple[str, dict]] = []
+    execute = AsyncMock()
+    provider_lease = SimpleNamespace(
+        profile_id="codex",
+        runtime_id="codex_cli",
+        lease_id="provider-lease-1",
+        owner_id="owner-1",
+        purpose=CredentialLeasePurpose.EXECUTION_OMNIGENT,
+    )
+
+    class LeaseClient:
+        async def acquire_execution_lease(self, **_kwargs):
+            return provider_lease
+
+        async def release_lease(self, _lease):
+            return None
+
+    class Hosts:
+        def __init__(self):
+            self.lease = _host_lease().model_copy(
+                update={"status": "allocating", "omnigent_host_id": None}
+            )
+
+        async def get_binding_for_profile(self, _profile_id):
+            return _binding()
+
+        async def create_or_get_host_lease(self, **_kwargs):
+            return self.lease
+
+        async def transition_host_lease(
+            self, _lease_id, *, expected_status, new_status, fields=None
+        ):
+            assert self.lease.status == expected_status
+            self.lease = self.lease.model_copy(
+                update={"status": new_status, **dict(fields or {})}
+            )
+            return self.lease
+
+        async def mark_host_lease_stopped(self, _lease_id):
+            self.lease = self.lease.model_copy(update={"status": "stopped"})
+            return self.lease
+
+        async def mark_host_lease_failed(self, *_args, **_kwargs):
+            return None
+
+    class Runtime:
+        async def prepare_host(self, **kwargs):
+            assert kwargs["required_capabilities"] == ("gh",)
+            raise MountedToolPreflightError(
+                "Mounted gh preflight failed during runner authentication",
+                code="github_auth_unavailable",
+                evidence={
+                    "tool": "gh",
+                    "phase": "authentication",
+                    "probes": [{"boundary": "runner", "status": "failed"}],
+                },
+            )
+
+        async def stop_host(self, **_kwargs):
+            return None
+
+    class Store:
+        async def bind_profile_authorization(self, **_kwargs):
+            return SimpleNamespace(bridge_session_id="bridge-1")
+
+        async def record_lifecycle_event(self, _key, *, event_type, **kwargs):
+            events.append((event_type, kwargs))
+
+    coordinator = OmnigentProfileBoundExecutionCoordinator(
+        session_factory=lambda: None,
+        lease_client=LeaseClient(),
+        host_repository=Hosts(),
+        host_runtime=Runtime(),
+        run_store=Store(),
+        execution_runner=execute,
+        artifact_gateway=object(),
+    )
+    coordinator._resolve_profile = AsyncMock(  # type: ignore[method-assign]
+        return_value=SimpleNamespace(cooldown_after_429_seconds=900)
+    )
+    coordinator._github_token = AsyncMock(return_value="resolved-token")  # type: ignore[method-assign]
+
+    with pytest.raises(MountedToolPreflightError):
+        await coordinator.execute(
+            AgentExecutionRequest(
+                agentKind="external",
+                agentId="omnigent",
+                executionProfileRef="codex",
+                correlationId="workflow-1",
+                idempotencyKey="idem-1",
+                parameters={
+                    "repository": "owner/repo",
+                    "requiredCapabilities": ["gh"],
+                    "omnigent": {
+                        "session": {"workspace": "https://github.com/owner/repo.git"}
+                    },
+                },
+            )
+        )
+
+    execute.assert_not_awaited()
+    blocked = next(kwargs for name, kwargs in events if name == "mounted_tool_preflight_blocked")
+    assert blocked["code"] == "github_auth_unavailable"
+    assert blocked["metadata"] == {
+        "tool": "gh",
+        "phase": "authentication",
+        "probes": [{"boundary": "runner", "status": "failed"}],
+    }

--- a/tests/unit/omnigent/test_oauth_profile_lifecycle.py
+++ b/tests/unit/omnigent/test_oauth_profile_lifecycle.py
@@ -48,6 +48,7 @@ from moonmind.schemas.agent_runtime_models import (
     OmnigentOAuthHostBinding,
 )
 from moonmind.schemas.temporal_models import WorkspaceCheckpointEvidenceModel
+from moonmind.workflows.temporal.runtime.git_auth import build_github_token_git_environment
 
 
 def _binding() -> OmnigentOAuthHostBinding:
@@ -307,6 +308,28 @@ async def test_on_demand_host_initializes_state_before_unprivileged_launch(
 
 
 @pytest.mark.asyncio
+async def test_private_workspace_clone_uses_in_memory_github_credentials(tmp_path) -> None:
+    runtime = OmnigentOAuthHostRuntime(
+        client=SimpleNamespace(), workspace_root=tmp_path / "workspaces"
+    )
+    runtime._run = AsyncMock(return_value=(0, "", ""))
+
+    await runtime._prepare_workspace(
+        workspace_key="private",
+        repository_url="https://github.com/owner/private.git",
+        github_token="test-token-value",
+    )
+
+    call = runtime._run.await_args
+    assert call.args[:3] == ("git", "clone", "--")
+    expected = build_github_token_git_environment(
+        "test-token-value", base_env=call.kwargs["env"]
+    )
+    assert call.kwargs["env"]["GITHUB_TOKEN"] == "test-token-value"
+    assert call.kwargs["env"]["GIT_CONFIG_VALUE_1"] == expected["GIT_CONFIG_VALUE_1"]
+
+
+@pytest.mark.asyncio
 async def test_on_demand_host_fails_before_launch_when_profile_is_not_daemon_visible(
     tmp_path,
 ) -> None:
@@ -344,6 +367,31 @@ def test_tools_path_prepend_is_idempotent_and_preserves_upstream_path() -> None:
 
     assert OmnigentOAuthHostRuntime._prepend_tools_path(upstream) == expected
     assert OmnigentOAuthHostRuntime._prepend_tools_path(expected) == expected
+
+
+def test_github_write_probe_uses_publish_or_skill_side_effect() -> None:
+    base = AgentExecutionRequest(
+        agentKind="external",
+        agentId="omnigent",
+        idempotencyKey="idem",
+        correlationId="corr",
+        parameters={"requiredCapabilities": ["gh"], "publishMode": "none"},
+    )
+
+    assert not OmnigentProfileBoundExecutionCoordinator._github_mutation_required(base)
+    assert OmnigentProfileBoundExecutionCoordinator._github_mutation_required(
+        base.model_copy(update={"parameters": {**base.parameters, "publishMode": "pr"}})
+    )
+    assert OmnigentProfileBoundExecutionCoordinator._github_mutation_required(
+        base.model_copy(
+            update={
+                "parameters": {
+                    **base.parameters,
+                    "skill": {"sideEffect": {"kind": "merge_pull_request"}},
+                }
+            }
+        )
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/omnigent/test_tool_bundle_initializer.py
+++ b/tests/unit/omnigent/test_tool_bundle_initializer.py
@@ -32,6 +32,7 @@ def _fixture_lock(tmp_path: Path, *, sha256: str | None = None) -> Path:
                     "linux/amd64": {
                         "url": archive.as_uri(),
                         "sha256": digest,
+                        "executableSha256": hashlib.sha256(executable).hexdigest(),
                         "archivePath": "fixture/bin/fixture-tool",
                     }
                 },

--- a/tests/unit/omnigent/test_tool_initializer.py
+++ b/tests/unit/omnigent/test_tool_initializer.py
@@ -1,0 +1,50 @@
+import hashlib
+import json
+
+import pytest
+
+from services.omnigent.tools.init_omnigent_tools import _validate_completed
+
+
+def _completed_bundle(tmp_path):
+    bundle = tmp_path / "bundle"
+    executable = bundle / "bin" / "tool"
+    executable.parent.mkdir(parents=True)
+    executable.write_bytes(b"#!/bin/sh\nexit 0\n")
+    executable.chmod(0o555)
+    manifest = {
+        "schemaVersion": 1,
+        "bundleVersion": "test",
+        "tools": [
+            {
+                "name": "tool",
+                "version": "1",
+                "platform": "linux/amd64",
+                "sha256": hashlib.sha256(executable.read_bytes()).hexdigest(),
+                "path": "bin/tool",
+                "versionProbe": [],
+            }
+        ],
+    }
+    (bundle / "manifest.json").write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    return bundle, executable, manifest
+
+
+def test_completed_bundle_rechecks_executable_digest(tmp_path) -> None:
+    bundle, executable, manifest = _completed_bundle(tmp_path)
+    executable.chmod(0o755)
+    executable.write_bytes(b"#!/bin/sh\nexit 1\n")
+    executable.chmod(0o555)
+
+    with pytest.raises(RuntimeError, match="SHA-256 mismatch"):
+        _validate_completed(bundle, manifest)
+
+
+def test_completed_bundle_reports_missing_executable(tmp_path) -> None:
+    bundle, executable, manifest = _completed_bundle(tmp_path)
+    executable.unlink()
+
+    with pytest.raises(RuntimeError, match="executable missing"):
+        _validate_completed(bundle, manifest)


### PR DESCRIPTION
Issue: MM-1215
Jira: https://moonladder.atlassian.net/browse/MM-1215

## Summary
- add trusted mounted-tool preflight probes in the selected Omnigent host and authoritative runner environment
- verify gh manifest, lookup, version, authentication, repository access, and mutation permissions before execution
- return stable mounted-tool failure classes with bounded redacted host/runner evidence while keeping optional-tool absence scoped to requiring runs

## Tests run
- `MOONMIND_FORCE_LOCAL_TESTS=1 python -m pytest -q tests/unit/omnigent/test_mounted_tool_preflight.py tests/unit/omnigent/test_oauth_profile_lifecycle.py --tb=short` (20 passed)
- `MOONMIND_FORCE_LOCAL_TESTS=1 python -m pytest -q tests/integration/temporal/test_compose_foundation.py -k "omnigent_host_profile_service_is_wired_for_mm_971 or omnigent_claude_host_profile_uses_only_canonical_oauth_credentials or omnigent_codex_host_profile_uses_only_canonical_oauth_credentials" --tb=short` (3 passed, 17 deselected)

## Remaining risks
- live credentialed gh host/runner probing was not run because this verification environment does not provide a running Omnigent host plus target-repository credentials; production wiring and hermetic boundary behavior are covered by the focused tests above.