### PR TITLE
Run Jira Implement for MM-1217: Compose the existing resolved Skill snapshot with Omnigent mounted CLI capabilities

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -859,7 +859,6 @@ services:
       MOONMIND_ACTIVE_SKILLS_DIR: /opt/moonmind-skills
       OMNIGENT_SERVER_URL: http://omnigent:8000
       HOME: /home/app
-      PATH: /opt/moonmind-tools/bin:${OMNIGENT_HOST_BASE_PATH:-/opt/venv/bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin}
       CLAUDE_HOME: /home/app/.claude
       CLAUDE_VOLUME_PATH: /home/app/.claude
       CLAUDE_CONFIG_DIR: /home/app/.claude
@@ -926,7 +925,6 @@ services:
       PATH: /opt/moonmind-tools/bin:${OMNIGENT_HOST_BASE_PATH:-/opt/venv/bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin}
       MOONMIND_ACTIVE_SKILLS_DIR: /opt/moonmind-skills
       HOME: /home/app
-      PATH: /opt/moonmind-tools/bin:${OMNIGENT_HOST_BASE_PATH:-/opt/venv/bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin}
       CODEX_HOME: /home/app/.codex
       CODEX_CONFIG_HOME: /home/app/.codex
       CODEX_CONFIG_PATH: /home/app/.codex/config.toml

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -820,7 +820,7 @@ services:
     entrypoint: ["/opt/moonmind/start-host-with-projections.sh"]
     environment:
       PATH: /opt/moonmind-tools/bin:${OMNIGENT_HOST_BASE_PATH:-/opt/venv/bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin}
-      MOONMIND_ACTIVE_SKILLS_DIR: /workspaces/MoonMind/.agents/skills
+      MOONMIND_ACTIVE_SKILLS_DIR: /opt/moonmind-skills
       OMNIGENT_SERVER_URL: http://omnigent:8000
       OPENAI_API_KEY: ${OPENAI_API_KEY:-}
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
@@ -832,6 +832,7 @@ services:
     volumes:
       - omnigent-host-state:/root/.omnigent
       - omnigent-tools:/opt/moonmind-tools:ro
+      - ${OMNIGENT_ACTIVE_SKILLS_DIR:-./omnigent_workspaces/.moonmind/skills_active}:/opt/moonmind-skills:ro
       - ./services/omnigent/scripts/moonmind-tools.sh:/etc/profile.d/moonmind-tools.sh:ro
       - ./services/omnigent/scripts:/opt/moonmind:ro
       - ./omnigent_workspaces:/workspaces
@@ -855,7 +856,7 @@ services:
     entrypoint: ["/opt/moonmind/start-host-with-projections.sh"]
     environment:
       PATH: /opt/moonmind-tools/bin:${OMNIGENT_HOST_BASE_PATH:-/opt/venv/bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin}
-      MOONMIND_ACTIVE_SKILLS_DIR: /workspaces/MoonMind/.agents/skills
+      MOONMIND_ACTIVE_SKILLS_DIR: /opt/moonmind-skills
       OMNIGENT_SERVER_URL: http://omnigent:8000
       HOME: /home/app
       CLAUDE_HOME: /home/app/.claude
@@ -871,6 +872,7 @@ services:
     volumes:
       - omnigent-host-claude-state:/home/app/.omnigent
       - omnigent-tools:/opt/moonmind-tools:ro
+      - ${OMNIGENT_ACTIVE_SKILLS_DIR:-./omnigent_workspaces/.moonmind/skills_active}:/opt/moonmind-skills:ro
       - ./services/omnigent/scripts/moonmind-tools.sh:/etc/profile.d/moonmind-tools.sh:ro
       - ./services/omnigent/scripts:/opt/moonmind:ro
       - claude_auth_volume:/home/app/.claude
@@ -921,7 +923,7 @@ services:
     command: ["/opt/moonmind/start-codex-oauth-host.sh"]
     environment:
       PATH: /opt/moonmind-tools/bin:${OMNIGENT_HOST_BASE_PATH:-/opt/venv/bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin}
-      MOONMIND_ACTIVE_SKILLS_DIR: /workspaces/MoonMind/.agents/skills
+      MOONMIND_ACTIVE_SKILLS_DIR: /opt/moonmind-skills
       HOME: /home/app
       CODEX_HOME: /home/app/.codex
       CODEX_CONFIG_HOME: /home/app/.codex
@@ -932,6 +934,7 @@ services:
     volumes:
       - omnigent-host-codex-state:/home/app/.omnigent
       - omnigent-tools:/opt/moonmind-tools:ro
+      - ${OMNIGENT_ACTIVE_SKILLS_DIR:-./omnigent_workspaces/.moonmind/skills_active}:/opt/moonmind-skills:ro
       - ./services/omnigent/scripts/moonmind-tools.sh:/etc/profile.d/moonmind-tools.sh:ro
       - codex_auth_volume:/home/app/.codex
       - ./services/omnigent/scripts:/opt/moonmind:ro

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -802,26 +802,46 @@ services:
     networks:
       - local-network
 
+  omnigent-tools-init:
+    profiles: ["omnigent-host", "omnigent-host-claude", "omnigent-host-codex"]
+    image: ${OMNIGENT_GH_IMAGE:-cli/cli:2.76.2}
+    user: "0:0"
+    entrypoint: ["/opt/moonmind/init-mounted-tools.sh"]
+    environment:
+      MOONMIND_GH_VERSION: ${OMNIGENT_GH_VERSION:-2.76.2}
+    volumes:
+      - omnigent-tools:/output
+      - ./services/omnigent/scripts:/opt/moonmind:ro
+    restart: "no"
+
   omnigent-host:
     profiles: ["omnigent-host"]
     image: ${OMNIGENT_HOST_IMAGE:-ghcr.io/omnigent-ai/omnigent-host}:${OMNIGENT_HOST_IMAGE_TAG:-latest}
-    command: ["omnigent", "host", "--server", "http://omnigent:8000", "--non-interactive"]
+    entrypoint: ["/opt/moonmind/start-host-with-projections.sh"]
     environment:
-      - OPENAI_API_KEY=${OPENAI_API_KEY:-}
-      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
-      - GEMINI_API_KEY=${GEMINI_API_KEY:-}
-      - GOOGLE_API_KEY=${GOOGLE_API_KEY:-}
+      PATH: /opt/moonmind-tools/bin:${OMNIGENT_HOST_BASE_PATH:-/opt/venv/bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin}
+      MOONMIND_ACTIVE_SKILLS_DIR: /workspaces/MoonMind/.agents/skills
+      OMNIGENT_SERVER_URL: http://omnigent:8000
+      OPENAI_API_KEY: ${OPENAI_API_KEY:-}
+      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
+      GEMINI_API_KEY: ${GEMINI_API_KEY:-}
+      GOOGLE_API_KEY: ${GOOGLE_API_KEY:-}
     env_file:
       - path: .env
         required: false
     volumes:
       - omnigent-host-state:/root/.omnigent
+      - omnigent-tools:/opt/moonmind-tools:ro
+      - ./services/omnigent/scripts/moonmind-tools.sh:/etc/profile.d/moonmind-tools.sh:ro
+      - ./services/omnigent/scripts:/opt/moonmind:ro
       - ./omnigent_workspaces:/workspaces
       # Mount an operator-managed sanitized workspace, not the repo root with local secrets.
       - ${OMNIGENT_MOONMIND_WORKSPACE:-./omnigent_workspaces/MoonMind}:/workspaces/MoonMind:ro
     depends_on:
       omnigent:
         condition: service_started
+      omnigent-tools-init:
+        condition: service_completed_successfully
     networks:
       - local-network
     restart: unless-stopped
@@ -832,8 +852,11 @@ services:
     hostname: omnigent-host-claude
     user: "1000:1000"
     working_dir: /home/app
-    command: ["omnigent", "host", "--server", "http://omnigent:8000", "--non-interactive"]
+    entrypoint: ["/opt/moonmind/start-host-with-projections.sh"]
     environment:
+      PATH: /opt/moonmind-tools/bin:${OMNIGENT_HOST_BASE_PATH:-/opt/venv/bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin}
+      MOONMIND_ACTIVE_SKILLS_DIR: /workspaces/MoonMind/.agents/skills
+      OMNIGENT_SERVER_URL: http://omnigent:8000
       HOME: /home/app
       CLAUDE_HOME: /home/app/.claude
       CLAUDE_VOLUME_PATH: /home/app/.claude
@@ -847,6 +870,9 @@ services:
       GOOGLE_API_KEY: ""
     volumes:
       - omnigent-host-claude-state:/home/app/.omnigent
+      - omnigent-tools:/opt/moonmind-tools:ro
+      - ./services/omnigent/scripts/moonmind-tools.sh:/etc/profile.d/moonmind-tools.sh:ro
+      - ./services/omnigent/scripts:/opt/moonmind:ro
       - claude_auth_volume:/home/app/.claude
       - ./omnigent_workspaces:/workspaces
       # Mount an operator-managed sanitized workspace, not the repo root with local secrets.
@@ -855,6 +881,8 @@ services:
       omnigent:
         condition: service_started
       claude-auth-init:
+        condition: service_completed_successfully
+      omnigent-tools-init:
         condition: service_completed_successfully
     networks:
       - local-network
@@ -892,6 +920,8 @@ services:
     entrypoint: ["/usr/bin/env", "-u", "OPENAI_API_KEY", "-u", "CODEX_ACCESS_TOKEN", "-u", "OPENAI_BASE_URL", "-u", "MINIMAX_API_KEY", "-u", "ANTHROPIC_API_KEY", "-u", "ANTHROPIC_AUTH_TOKEN", "-u", "CLAUDE_API_KEY", "-u", "CLAUDE_CODE_OAUTH_TOKEN", "-u", "GEMINI_API_KEY", "-u", "GOOGLE_API_KEY"]
     command: ["/opt/moonmind/start-codex-oauth-host.sh"]
     environment:
+      PATH: /opt/moonmind-tools/bin:${OMNIGENT_HOST_BASE_PATH:-/opt/venv/bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin}
+      MOONMIND_ACTIVE_SKILLS_DIR: /workspaces/MoonMind/.agents/skills
       HOME: /home/app
       CODEX_HOME: /home/app/.codex
       CODEX_CONFIG_HOME: /home/app/.codex
@@ -901,6 +931,8 @@ services:
       OMNIGENT_SERVER_URL: http://omnigent:8000
     volumes:
       - omnigent-host-codex-state:/home/app/.omnigent
+      - omnigent-tools:/opt/moonmind-tools:ro
+      - ./services/omnigent/scripts/moonmind-tools.sh:/etc/profile.d/moonmind-tools.sh:ro
       - codex_auth_volume:/home/app/.codex
       - ./services/omnigent/scripts:/opt/moonmind:ro
       - ./omnigent_workspaces:/workspaces
@@ -910,6 +942,8 @@ services:
       omnigent:
         condition: service_started
       omnigent-host-codex-init:
+        condition: service_completed_successfully
+      omnigent-tools-init:
         condition: service_completed_successfully
     networks:
       - local-network
@@ -1108,6 +1142,8 @@ volumes:
   omnigent-host-state:
   omnigent-host-claude-state:
   omnigent-host-codex-state:
+  omnigent-tools:
+    name: moonmind-omnigent-tools-gh-${OMNIGENT_GH_VERSION:-2.76.2}
   postgres-data:
   minio-data:
   workflow_workspaces:

--- a/moonmind/omnigent/bridge_artifacts.py
+++ b/moonmind/omnigent/bridge_artifacts.py
@@ -86,6 +86,9 @@ class OmnigentArtifactGateway:
     async def read_text(self, artifact_ref: str) -> str:
         raise NotImplementedError
 
+    async def read_bytes(self, artifact_ref: str) -> bytes:
+        return (await self.read_text(artifact_ref)).encode("utf-8")
+
 
 class LocalOmnigentArtifactGateway(OmnigentArtifactGateway):
     """Local MoonMind artifact gateway for Omnigent evidence capture."""
@@ -189,6 +192,17 @@ class LocalOmnigentArtifactGateway(OmnigentArtifactGateway):
                 )
             if path.is_file():
                 return path.read_text(encoding="utf-8")
+        raise OmnigentArtifactError(f"Unable to dereference artifact ref: {artifact_ref}")
+
+    async def read_bytes(self, artifact_ref: str) -> bytes:
+        if artifact_ref in self._readable_refs:
+            return self._readable_refs[artifact_ref].encode("utf-8")
+        prefix = "artifact://omnigent/"
+        if artifact_ref.startswith(prefix):
+            relative = artifact_ref[len(prefix) :]
+            path = (self._root / relative).resolve()
+            if path.is_relative_to(self._root) and path.is_file():
+                return path.read_bytes()
         raise OmnigentArtifactError(f"Unable to dereference artifact ref: {artifact_ref}")
 
 

--- a/moonmind/omnigent/oauth_host_runtime.py
+++ b/moonmind/omnigent/oauth_host_runtime.py
@@ -73,6 +73,9 @@ class OmnigentOAuthHostRuntime:
             workspace_root
             or Path(os.getenv("OMNIGENT_WORKSPACE_ROOT", "omnigent_workspaces"))
         ).resolve()
+        self._tool_bundle_volume = os.getenv(
+            "OMNIGENT_TOOL_BUNDLE_VOLUME", "moonmind-omnigent-tools-gh-2.76.2"
+        )
 
     async def prepare_host(
         self,
@@ -263,6 +266,8 @@ class OmnigentOAuthHostRuntime:
             "--mount",
             f"type=bind,src={self._scripts_dir},dst=/opt/moonmind,readonly",
             "--mount",
+            f"type=volume,src={self._tool_bundle_volume},dst=/opt/moonmind-tools,readonly",
+            "--mount",
             f"type=bind,src={workspace_source},dst=/workspaces/run",
             "--env",
             "HOME=/home/app",
@@ -278,6 +283,10 @@ class OmnigentOAuthHostRuntime:
             f"CODEX_CREDENTIAL_GENERATION={host_lease.credential_generation}",
             "--env",
             f"OMNIGENT_SERVER_URL={self._server_url}",
+            "--env",
+            "MOONMIND_ACTIVE_SKILLS_DIR=/workspaces/run/.agents/skills",
+            "--env",
+            "PATH=/opt/moonmind-tools/bin:/opt/venv/bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin",
         ]
         token = os.getenv("OMNIGENT_HOST_TOKEN", "")
         child_env = dict(os.environ)
@@ -327,12 +336,12 @@ class OmnigentOAuthHostRuntime:
             "exec",
             "-T",
             "omnigent-host-codex",
-            "/opt/moonmind/check-codex-oauth-host.sh",
+            "/opt/moonmind/check-runner-projections.sh",
         )
 
     async def _exec_check(self, container_name: str) -> None:
         await self._run(
-            "docker", "exec", container_name, "/opt/moonmind/check-codex-oauth-host.sh"
+            "docker", "exec", container_name, "/opt/moonmind/check-runner-projections.sh"
         )
 
     async def _resolve_exact_host(

--- a/moonmind/omnigent/oauth_host_runtime.py
+++ b/moonmind/omnigent/oauth_host_runtime.py
@@ -208,7 +208,7 @@ class OmnigentOAuthHostRuntime:
             class _GatewayArtifactService:
                 async def read(self, *, artifact_id: str, **_kwargs: Any):
                     payload = await artifact_gateway.read_bytes(artifact_id)
-                    return None, payload
+                    return {}, payload
 
             artifact_service = _GatewayArtifactService()
         resolved_skillset = await load_resolved_skillset(

--- a/moonmind/omnigent/oauth_host_runtime.py
+++ b/moonmind/omnigent/oauth_host_runtime.py
@@ -20,6 +20,11 @@ from moonmind.schemas.agent_runtime_models import (
     OmnigentHostLease,
 )
 from moonmind.workflows.adapters.omnigent_client import OmnigentHttpClient
+from moonmind.workflows.skills.run_projection import (
+    load_resolved_skillset,
+    materialize_run_skill_snapshot,
+    verify_skill_projection,
+)
 
 _FORBIDDEN_ENV = (
     "OPENAI_API_KEY",
@@ -84,7 +89,14 @@ class OmnigentOAuthHostRuntime:
         host_lease: OmnigentHostLease,
         workspace_key: str,
         repository_url: str | None = None,
+        resolved_skillset_ref: str | None = None,
+        artifact_gateway: Any | None = None,
     ) -> dict[str, Any]:
+        skill_projection = await self._prepare_skill_projection(
+            workspace_key=workspace_key,
+            resolved_skillset_ref=resolved_skillset_ref,
+            artifact_gateway=artifact_gateway,
+        )
         workspace_source = await self._prepare_workspace(
             workspace_key=workspace_key,
             repository_url=repository_url,
@@ -99,10 +111,11 @@ class OmnigentOAuthHostRuntime:
                 host_lease=host_lease,
                 container_name=container_name,
                 workspace_source=workspace_source,
+                skill_projection=skill_projection,
             )
             await self._exec_check(container_name)
         else:
-            await self._compose_static_check()
+            await self._compose_static_check(skill_projection=skill_projection)
 
         host = await self._resolve_exact_host(binding=binding, host_lease=host_lease)
         host_id = str(host.get("id") or host.get("host_id") or host.get("hostId") or "")
@@ -139,7 +152,52 @@ class OmnigentOAuthHostRuntime:
             host_lease=host_lease.model_copy(update={"omnigent_host_id": host_id}),
         )
         validated["workspacePath"] = result["workspacePath"]
+        validated["activeSkillsPath"] = str(skill_projection)
         return validated
+
+    async def _prepare_skill_projection(
+        self,
+        *,
+        workspace_key: str,
+        resolved_skillset_ref: str | None,
+        artifact_gateway: Any | None,
+    ) -> Path:
+        """Materialize and verify the run snapshot before workspace/host mutation."""
+
+        skillset_ref = str(resolved_skillset_ref or "").strip()
+        if not skillset_ref or artifact_gateway is None:
+            raise OmnigentOAuthHostError(
+                "resolved Skill projection is required before Omnigent host mutation",
+                code="OMNIGENT_SKILL_PROJECTION_UNAVAILABLE",
+            )
+
+        if hasattr(artifact_gateway, "read"):
+            artifact_service = artifact_gateway
+        else:
+            class _GatewayArtifactService:
+                async def read(self, *, artifact_id: str, **_kwargs: Any):
+                    payload = await artifact_gateway.read_bytes(artifact_id)
+                    return None, payload
+
+            artifact_service = _GatewayArtifactService()
+        resolved_skillset = await load_resolved_skillset(
+            artifact_service, skillset_ref
+        )
+        digest = hashlib.sha256(workspace_key.encode("utf-8")).hexdigest()[:24]
+        projection_root = (self._workspace_root / ".skill-projections" / digest).resolve()
+        metadata = await materialize_run_skill_snapshot(
+            workspace_path=projection_root,
+            run_root=projection_root,
+            runtime_id="omnigent",
+            resolved_skillset=resolved_skillset,
+            artifact_service=artifact_service,
+            project_adapter_aliases=False,
+        )
+        await verify_skill_projection(
+            materialization_metadata=metadata,
+            resolved_skillset=resolved_skillset,
+        )
+        return Path(str(metadata["visiblePath"])).resolve()
 
     async def stop_host(
         self, *, binding: OmnigentOAuthHostBinding, host_lease: OmnigentHostLease
@@ -210,6 +268,7 @@ class OmnigentOAuthHostRuntime:
         host_lease: OmnigentHostLease,
         container_name: str,
         workspace_source: Path,
+        skill_projection: Path,
     ) -> None:
         if await self.container_exists(container_name):
             return
@@ -269,6 +328,8 @@ class OmnigentOAuthHostRuntime:
             f"type=volume,src={self._tool_bundle_volume},dst=/opt/moonmind-tools,readonly",
             "--mount",
             f"type=bind,src={workspace_source},dst=/workspaces/run",
+            "--mount",
+            f"type=bind,src={skill_projection},dst=/opt/moonmind-skills,readonly",
             "--env",
             "HOME=/home/app",
             "--env",
@@ -284,7 +345,7 @@ class OmnigentOAuthHostRuntime:
             "--env",
             f"OMNIGENT_SERVER_URL={self._server_url}",
             "--env",
-            "MOONMIND_ACTIVE_SKILLS_DIR=/workspaces/run/.agents/skills",
+            "MOONMIND_ACTIVE_SKILLS_DIR=/opt/moonmind-skills",
             "--env",
             "PATH=/opt/moonmind-tools/bin:/opt/venv/bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin",
         ]
@@ -314,7 +375,10 @@ class OmnigentOAuthHostRuntime:
             await self._run("git", "clone", "--", repository_url, str(workspace))
         return workspace
 
-    async def _compose_static_check(self) -> None:
+    async def _compose_static_check(self, *, skill_projection: Path | None = None) -> None:
+        child_env = dict(os.environ)
+        if skill_projection is not None:
+            child_env["OMNIGENT_ACTIVE_SKILLS_DIR"] = str(skill_projection)
         await self._run(
             "docker",
             "compose",
@@ -325,6 +389,7 @@ class OmnigentOAuthHostRuntime:
             "up",
             "-d",
             "omnigent-host-codex",
+            env=child_env,
         )
         await self._run(
             "docker",
@@ -337,6 +402,7 @@ class OmnigentOAuthHostRuntime:
             "-T",
             "omnigent-host-codex",
             "/opt/moonmind/check-runner-projections.sh",
+            env=child_env,
         )
 
     async def _exec_check(self, container_name: str) -> None:

--- a/moonmind/omnigent/profile_bound_execution.py
+++ b/moonmind/omnigent/profile_bound_execution.py
@@ -100,6 +100,7 @@ class OmnigentProfileBoundExecutionCoordinator:
         run_store: OmnigentBridgeSessionStore,
         execution_runner: ExecutionRunner,
         artifact_gateway: Any,
+        artifact_service: Any | None = None,
     ) -> None:
         self._session_factory = session_factory
         self._lease_client = lease_client
@@ -108,6 +109,7 @@ class OmnigentProfileBoundExecutionCoordinator:
         self._run_store = run_store
         self._execute = execution_runner
         self._artifact_gateway = artifact_gateway
+        self._artifact_service = artifact_service or artifact_gateway
 
     async def execute(self, request: AgentExecutionRequest) -> AgentRunResult:
         profile_id = str(request.execution_profile_ref or "").strip()
@@ -198,6 +200,8 @@ class OmnigentProfileBoundExecutionCoordinator:
                     f"{workflow_id}:{step_execution_id or request.idempotency_key}"
                 ),
                 repository_url=self._repository_url(request),
+                resolved_skillset_ref=request.resolved_skillset_ref,
+                artifact_gateway=self._artifact_service,
             )
             host_id = str(preflight["hostId"])
             if binding.static_host_id is None and not binding.host_launch_profile_ref:

--- a/moonmind/workflows/temporal/activities/omnigent_activities.py
+++ b/moonmind/workflows/temporal/activities/omnigent_activities.py
@@ -53,20 +53,25 @@ async def omnigent_execute_activity(
             client=http_client,
             upstream_header_allowlist=resolved_proxy_forward_headers(),
         )
-        async with async_session_maker() as artifact_session:
-            coordinator = OmnigentProfileBoundExecutionCoordinator(
-                session_factory=async_session_maker,
-                lease_client=ProviderProfileLeaseClient(TemporalClientAdapter()),
-                host_repository=OmnigentOAuthHostRepository(async_session_maker),
-                host_runtime=OmnigentOAuthHostRuntime(client=omnigent_client),
-                run_store=run_store,
-                execution_runner=run_omnigent_execution,
-                artifact_gateway=artifact_gateway,
-                artifact_service=TemporalArtifactService(
-                    TemporalArtifactRepository(artifact_session)
-                ),
-            )
-            return await coordinator.execute(request)
+        class OnDemandTemporalArtifactService:
+            async def read(self, *, artifact_id: str, **kwargs):
+                async with async_session_maker() as artifact_session:
+                    service = TemporalArtifactService(
+                        TemporalArtifactRepository(artifact_session)
+                    )
+                    return await service.read(artifact_id=artifact_id, **kwargs)
+
+        coordinator = OmnigentProfileBoundExecutionCoordinator(
+            session_factory=async_session_maker,
+            lease_client=ProviderProfileLeaseClient(TemporalClientAdapter()),
+            host_repository=OmnigentOAuthHostRepository(async_session_maker),
+            host_runtime=OmnigentOAuthHostRuntime(client=omnigent_client),
+            run_store=run_store,
+            execution_runner=run_omnigent_execution,
+            artifact_gateway=artifact_gateway,
+            artifact_service=OnDemandTemporalArtifactService(),
+        )
+        return await coordinator.execute(request)
 
 
 @activity.defn(name="integration.omnigent.profile_bound_execute")

--- a/moonmind/workflows/temporal/activities/omnigent_activities.py
+++ b/moonmind/workflows/temporal/activities/omnigent_activities.py
@@ -32,6 +32,10 @@ async def omnigent_execute_activity(
     from moonmind.provider_profiles.lease_client import ProviderProfileLeaseClient
     from moonmind.workflows.adapters.omnigent_client import OmnigentHttpClient
     from moonmind.workflows.temporal.client import TemporalClientAdapter
+    from moonmind.workflows.temporal.artifacts import (
+        TemporalArtifactRepository,
+        TemporalArtifactService,
+    )
 
     artifact_gateway = LocalOmnigentArtifactGateway()
     run_store = OmnigentBridgeSessionStore(async_session_maker)
@@ -49,16 +53,20 @@ async def omnigent_execute_activity(
             client=http_client,
             upstream_header_allowlist=resolved_proxy_forward_headers(),
         )
-        coordinator = OmnigentProfileBoundExecutionCoordinator(
-            session_factory=async_session_maker,
-            lease_client=ProviderProfileLeaseClient(TemporalClientAdapter()),
-            host_repository=OmnigentOAuthHostRepository(async_session_maker),
-            host_runtime=OmnigentOAuthHostRuntime(client=omnigent_client),
-            run_store=run_store,
-            execution_runner=run_omnigent_execution,
-            artifact_gateway=artifact_gateway,
-        )
-        return await coordinator.execute(request)
+        async with async_session_maker() as artifact_session:
+            coordinator = OmnigentProfileBoundExecutionCoordinator(
+                session_factory=async_session_maker,
+                lease_client=ProviderProfileLeaseClient(TemporalClientAdapter()),
+                host_repository=OmnigentOAuthHostRepository(async_session_maker),
+                host_runtime=OmnigentOAuthHostRuntime(client=omnigent_client),
+                run_store=run_store,
+                execution_runner=run_omnigent_execution,
+                artifact_gateway=artifact_gateway,
+                artifact_service=TemporalArtifactService(
+                    TemporalArtifactRepository(artifact_session)
+                ),
+            )
+            return await coordinator.execute(request)
 
 
 @activity.defn(name="integration.omnigent.profile_bound_execute")

--- a/services/omnigent/scripts/check-runner-projections.sh
+++ b/services/omnigent/scripts/check-runner-projections.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -eu
+
+skills=${MOONMIND_ACTIVE_SKILLS_DIR:?MOONMIND_ACTIVE_SKILLS_DIR is required}
+test -d "$skills"
+test -r "$skills/_manifest.json"
+test ! -w "$skills"
+test -r /opt/moonmind-tools/manifest.json
+test -x /opt/moonmind-tools/bin/gh
+command -v gh >/dev/null
+gh --version >/dev/null

--- a/services/omnigent/scripts/check-runner-projections.sh
+++ b/services/omnigent/scripts/check-runner-projections.sh
@@ -10,4 +10,4 @@ test -r /opt/moonmind-tools/manifest.json
 test -x /opt/moonmind-tools/bin/gh
 command -v gh >/dev/null
 gh --version >/dev/null
-bash -lc 'command -v gh >/dev/null && gh --version >/dev/null'
+sh -lc 'command -v gh >/dev/null && gh --version >/dev/null'

--- a/services/omnigent/scripts/check-runner-projections.sh
+++ b/services/omnigent/scripts/check-runner-projections.sh
@@ -5,7 +5,9 @@ skills=${MOONMIND_ACTIVE_SKILLS_DIR:?MOONMIND_ACTIVE_SKILLS_DIR is required}
 test -d "$skills"
 test -r "$skills/_manifest.json"
 test ! -w "$skills"
+grep -q '"snapshot_id"' "$skills/_manifest.json"
 test -r /opt/moonmind-tools/manifest.json
 test -x /opt/moonmind-tools/bin/gh
 command -v gh >/dev/null
 gh --version >/dev/null
+bash -lc 'command -v gh >/dev/null && gh --version >/dev/null'

--- a/services/omnigent/scripts/init-mounted-tools.sh
+++ b/services/omnigent/scripts/init-mounted-tools.sh
@@ -10,7 +10,12 @@ if [ -x "$output/bin/gh" ] && [ -r "$output/manifest.json" ]; then
   reported=$($output/bin/gh --version | sed -n '1p')
   case "$reported" in
     *" $version "*) exit 0 ;;
-    *) echo "existing tool bundle does not match requested gh $version" >&2; exit 65 ;;
+    *)
+      echo "existing tool bundle does not match requested gh $version, recreating" >&2
+      chmod u+w "$output" "$output/bin" 2>/dev/null || true
+      chmod -R u+w "$output" 2>/dev/null || true
+      rm -rf "$output/bin" "$output/manifest.json"
+      ;;
   esac
 fi
 mkdir -p "$output/bin"

--- a/services/omnigent/scripts/init-mounted-tools.sh
+++ b/services/omnigent/scripts/init-mounted-tools.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+set -eu
+
+source_gh=${MOONMIND_GH_SOURCE:-/usr/bin/gh}
+output=${MOONMIND_TOOL_BUNDLE_OUTPUT:-/output}
+version=${MOONMIND_GH_VERSION:?MOONMIND_GH_VERSION is required}
+
+test -x "$source_gh"
+if [ -x "$output/bin/gh" ] && [ -r "$output/manifest.json" ]; then
+  reported=$($output/bin/gh --version | sed -n '1p')
+  case "$reported" in
+    *" $version "*) exit 0 ;;
+    *) echo "existing tool bundle does not match requested gh $version" >&2; exit 65 ;;
+  esac
+fi
+mkdir -p "$output/bin"
+install -m 0555 "$source_gh" "$output/bin/gh"
+reported=$($output/bin/gh --version | sed -n '1p')
+case "$reported" in
+  *" $version "*) ;;
+  *) echo "gh version mismatch: expected $version" >&2; exit 65 ;;
+esac
+printf '{"schemaVersion":1,"bundleVersion":"gh-%s","tools":[{"name":"gh","version":"%s","path":"bin/gh","versionProbe":["--version"]}]}\n' \
+  "$version" "$version" > "$output/manifest.json"
+chmod -R a-w "$output"

--- a/services/omnigent/scripts/moonmind-tools.sh
+++ b/services/omnigent/scripts/moonmind-tools.sh
@@ -1,0 +1,4 @@
+case ":${PATH:-}:" in
+  *:/opt/moonmind-tools/bin:*) ;;
+  *) export PATH="/opt/moonmind-tools/bin${PATH:+:$PATH}" ;;
+esac

--- a/services/omnigent/scripts/start-codex-oauth-host.sh
+++ b/services/omnigent/scripts/start-codex-oauth-host.sh
@@ -13,4 +13,6 @@ until /opt/moonmind/check-codex-oauth-host.sh; do
   sleep 5
 done
 
+/opt/moonmind/check-runner-projections.sh
+
 exec omnigent host --server "$server" --non-interactive

--- a/services/omnigent/scripts/start-host-with-projections.sh
+++ b/services/omnigent/scripts/start-host-with-projections.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -eu
+
+/opt/moonmind/check-runner-projections.sh
+exec omnigent host --server "${OMNIGENT_SERVER_URL:-http://omnigent:8000}" --non-interactive

--- a/tests/integration/temporal/test_compose_foundation.py
+++ b/tests/integration/temporal/test_compose_foundation.py
@@ -191,20 +191,22 @@ def test_omnigent_hosts_use_versioned_read_only_tool_bundle():
     assert initializer["restart"] == "no"
     assert initializer["volumes"] == [
         "omnigent-tools:/output",
-        "./services/omnigent/tools:/opt/moonmind-tools-init:ro",
+        "./services/omnigent/scripts:/opt/moonmind:ro",
     ]
     assert compose["volumes"]["omnigent-tools"]["name"] == (
-        "moonmind-omnigent-tools-${OMNIGENT_TOOL_BUNDLE_VERSION:-gh-2.74.2-1}"
+        "moonmind-omnigent-tools-gh-${OMNIGENT_GH_VERSION:-2.76.2}"
     )
 
     for service_name in ("omnigent-host", "omnigent-host-claude", "omnigent-host-codex"):
         host = services[service_name]
         environment = _env_map(host["environment"])
         assert environment["PATH"].startswith("/opt/moonmind-tools/bin:")
-        assert "omnigent-tools-init" not in host["depends_on"]
+        assert host["depends_on"]["omnigent-tools-init"] == {
+            "condition": "service_completed_successfully"
+        }
         assert "omnigent-tools:/opt/moonmind-tools:ro" in host["volumes"]
         assert (
-            "./services/omnigent/profile/moonmind-tools.sh:"
+            "./services/omnigent/scripts/moonmind-tools.sh:"
             "/etc/profile.d/moonmind-tools.sh:ro"
         ) in host["volumes"]
 
@@ -636,7 +638,6 @@ def test_omnigent_codex_host_profile_uses_only_canonical_oauth_credentials():
         "omnigent-host-codex-state:/home/app/.omnigent",
         "codex_auth_volume:/home/app/.codex",
         "omnigent-tools:/opt/moonmind-tools:ro",
-        "./services/omnigent/profile/moonmind-tools.sh:/etc/profile.d/moonmind-tools.sh:ro",
         "./omnigent_workspaces:/workspaces",
         (
             "${OMNIGENT_MOONMIND_WORKSPACE:-./omnigent_workspaces/MoonMind}:"

--- a/tests/integration/temporal/test_compose_foundation.py
+++ b/tests/integration/temporal/test_compose_foundation.py
@@ -461,13 +461,7 @@ def test_omnigent_host_profile_service_is_wired_for_mm_971():
         "${OMNIGENT_HOST_IMAGE:-ghcr.io/omnigent-ai/omnigent-host}:"
         "${OMNIGENT_HOST_IMAGE_TAG:-latest}"
     )
-    assert host_service["command"] == [
-        "omnigent",
-        "host",
-        "--server",
-        "http://omnigent:8000",
-        "--non-interactive",
-    ]
+    assert host_service["entrypoint"] == ["/opt/moonmind/start-host-with-projections.sh"]
     assert host_service["depends_on"]["omnigent"]["condition"] == "service_started"
     assert _network_names(host_service) == {"local-network"}
 
@@ -502,19 +496,16 @@ def test_omnigent_claude_host_profile_uses_only_canonical_oauth_credentials():
         "${OMNIGENT_HOST_IMAGE:-ghcr.io/omnigent-ai/omnigent-host}:"
         "${OMNIGENT_HOST_IMAGE_TAG:-latest}"
     )
-    assert host_service["command"] == [
-        "omnigent",
-        "host",
-        "--server",
-        "http://omnigent:8000",
-        "--non-interactive",
-    ]
+    assert host_service["entrypoint"] == ["/opt/moonmind/start-host-with-projections.sh"]
     assert host_service["user"] == "1000:1000"
     assert host_service["working_dir"] == "/home/app"
     assert "env_file" not in host_service
 
     host_env = _env_map(host_service["environment"])
     assert host_env == {
+        "PATH": "/opt/moonmind-tools/bin:${OMNIGENT_HOST_BASE_PATH:-/opt/venv/bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin}",
+        "MOONMIND_ACTIVE_SKILLS_DIR": "/opt/moonmind-skills",
+        "OMNIGENT_SERVER_URL": "http://omnigent:8000",
         "HOME": "/home/app",
         "CLAUDE_HOME": "/home/app/.claude",
         "CLAUDE_VOLUME_PATH": "/home/app/.claude",
@@ -532,6 +523,11 @@ def test_omnigent_claude_host_profile_uses_only_canonical_oauth_credentials():
     assert "omnigent-host-claude-state:/home/app/.omnigent" in host_volumes
     assert "claude_auth_volume:/home/app/.claude" in host_volumes
     assert "./omnigent_workspaces:/workspaces" in host_volumes
+    assert "omnigent-tools:/opt/moonmind-tools:ro" in host_volumes
+    assert (
+        "${OMNIGENT_ACTIVE_SKILLS_DIR:-./omnigent_workspaces/.moonmind/skills_active}:"
+        "/opt/moonmind-skills:ro"
+    ) in host_volumes
     assert (
         "${OMNIGENT_MOONMIND_WORKSPACE:-./omnigent_workspaces/MoonMind}:"
         "/workspaces/MoonMind:ro"
@@ -541,6 +537,7 @@ def test_omnigent_claude_host_profile_uses_only_canonical_oauth_credentials():
     assert host_service["depends_on"] == {
         "omnigent": {"condition": "service_started"},
         "claude-auth-init": {"condition": "service_completed_successfully"},
+        "omnigent-tools-init": {"condition": "service_completed_successfully"},
     }
     assert _network_names(host_service) == {"local-network"}
     assert host_service["restart"] == "unless-stopped"
@@ -572,6 +569,8 @@ def test_omnigent_codex_host_profile_uses_only_canonical_oauth_credentials():
     assert host_service["working_dir"] == "/home/app"
     assert "env_file" not in host_service
     assert _env_map(host_service["environment"]) == {
+        "PATH": "/opt/moonmind-tools/bin:${OMNIGENT_HOST_BASE_PATH:-/opt/venv/bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin}",
+        "MOONMIND_ACTIVE_SKILLS_DIR": "/opt/moonmind-skills",
         "HOME": "/home/app",
         "CODEX_HOME": "/home/app/.codex",
         "CODEX_CONFIG_HOME": "/home/app/.codex",
@@ -604,6 +603,12 @@ def test_omnigent_codex_host_profile_uses_only_canonical_oauth_credentials():
             "/workspaces/MoonMind:ro"
         ),
         "./services/omnigent/scripts:/opt/moonmind:ro",
+        "./services/omnigent/scripts/moonmind-tools.sh:/etc/profile.d/moonmind-tools.sh:ro",
+        "omnigent-tools:/opt/moonmind-tools:ro",
+        (
+            "${OMNIGENT_ACTIVE_SKILLS_DIR:-./omnigent_workspaces/.moonmind/skills_active}:"
+            "/opt/moonmind-skills:ro"
+        ),
     }
     assert "omnigent-host-codex-state" in compose["volumes"]
     assert host_service["depends_on"] == {
@@ -611,6 +616,7 @@ def test_omnigent_codex_host_profile_uses_only_canonical_oauth_credentials():
         "omnigent-host-codex-init": {
             "condition": "service_completed_successfully"
         },
+        "omnigent-tools-init": {"condition": "service_completed_successfully"},
     }
     init_service = compose["services"]["omnigent-host-codex-init"]
     assert init_service["user"] == "0:0"

--- a/tests/integration/temporal/test_compose_foundation.py
+++ b/tests/integration/temporal/test_compose_foundation.py
@@ -537,7 +537,6 @@ def test_omnigent_claude_host_profile_uses_only_canonical_oauth_credentials():
 
     host_env = _env_map(host_service["environment"])
     assert host_env == {
-        "PATH": "/opt/moonmind-tools/bin:${OMNIGENT_HOST_BASE_PATH:-/opt/venv/bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin}",
         "MOONMIND_ACTIVE_SKILLS_DIR": "/opt/moonmind-skills",
         "OMNIGENT_SERVER_URL": "http://omnigent:8000",
         "HOME": "/home/app",
@@ -606,7 +605,6 @@ def test_omnigent_codex_host_profile_uses_only_canonical_oauth_credentials():
     assert host_service["working_dir"] == "/home/app"
     assert "env_file" not in host_service
     assert _env_map(host_service["environment"]) == {
-        "PATH": "/opt/moonmind-tools/bin:${OMNIGENT_HOST_BASE_PATH:-/opt/venv/bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin}",
         "MOONMIND_ACTIVE_SKILLS_DIR": "/opt/moonmind-skills",
         "HOME": "/home/app",
         "PATH": MOUNTED_TOOL_PATH,

--- a/tests/unit/omnigent/test_host_tool_projection.py
+++ b/tests/unit/omnigent/test_host_tool_projection.py
@@ -18,20 +18,22 @@ def test_static_hosts_project_versioned_tools_without_covering_usr_local_bin() -
         else:
             assert environment["PATH"] == expected_path
         assert "omnigent-tools:/opt/moonmind-tools:ro" in service["volumes"]
-        assert "omnigent-tools-init" not in service["depends_on"]
+        assert service["depends_on"]["omnigent-tools-init"] == {
+            "condition": "service_completed_successfully"
+        }
         assert (
-            "./services/omnigent/profile/moonmind-tools.sh:"
+            "./services/omnigent/scripts/moonmind-tools.sh:"
             "/etc/profile.d/moonmind-tools.sh:ro"
         ) in service["volumes"]
         assert all("/usr/local/bin" not in volume for volume in service["volumes"])
 
     assert compose["volumes"]["omnigent-tools"]["name"] == (
-        "moonmind-omnigent-tools-${OMNIGENT_TOOL_BUNDLE_VERSION:-gh-2.74.2-1}"
+        "moonmind-omnigent-tools-gh-${OMNIGENT_GH_VERSION:-2.76.2}"
     )
 
 
 def test_login_profile_prepends_tools_path_idempotently() -> None:
-    profile = Path("services/omnigent/profile/moonmind-tools.sh").read_text()
+    profile = Path("services/omnigent/scripts/moonmind-tools.sh").read_text()
 
     assert "*:/opt/moonmind-tools/bin:*)" in profile
     assert 'export PATH="/opt/moonmind-tools/bin:${PATH}"' in profile

--- a/tests/unit/omnigent/test_host_tool_projection.py
+++ b/tests/unit/omnigent/test_host_tool_projection.py
@@ -36,4 +36,4 @@ def test_login_profile_prepends_tools_path_idempotently() -> None:
     profile = Path("services/omnigent/scripts/moonmind-tools.sh").read_text()
 
     assert "*:/opt/moonmind-tools/bin:*)" in profile
-    assert 'export PATH="/opt/moonmind-tools/bin:${PATH}"' in profile
+    assert 'export PATH="/opt/moonmind-tools/bin${PATH:+:$PATH}"' in profile

--- a/tests/unit/omnigent/test_oauth_profile_lifecycle.py
+++ b/tests/unit/omnigent/test_oauth_profile_lifecycle.py
@@ -1,4 +1,9 @@
 from datetime import UTC, datetime, timedelta
+import json
+import os
+from pathlib import Path
+import runpy
+import subprocess
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
@@ -246,6 +251,7 @@ async def test_on_demand_host_initializes_state_before_unprivileged_launch(
         host_lease=lease,
         container_name="mm-host-lease-1",
         workspace_source=tmp_path,
+        skill_projection=tmp_path / "skills",
     )
 
     commands = [call.args for call in runtime._run.await_args_list]
@@ -258,7 +264,10 @@ async def test_on_demand_host_initializes_state_before_unprivileged_launch(
         "type=volume,src=moonmind-omnigent-tools-gh-2.76.2,"
         "dst=/opt/moonmind-tools,readonly"
     ) in commands[2]
-    assert "MOONMIND_ACTIVE_SKILLS_DIR=/workspaces/run/.agents/skills" in commands[2]
+    assert "MOONMIND_ACTIVE_SKILLS_DIR=/opt/moonmind-skills" in commands[2]
+    assert (
+        f"type=bind,src={tmp_path / 'skills'},dst=/opt/moonmind-skills,readonly"
+    ) in commands[2]
     assert (
         "PATH=/opt/moonmind-tools/bin:/opt/venv/bin:/usr/local/bin:"
         "/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin"
@@ -337,6 +346,85 @@ def test_exact_host_preflight_rejects_generation_mismatch() -> None:
             result=result, binding=_binding(), host_lease=_host_lease()
         )
     assert exc_info.value.code == "CODEX_OAUTH_GENERATION_STALE"
+
+
+@pytest.mark.asyncio
+async def test_host_rejects_missing_skill_projection_before_workspace_mutation(
+    tmp_path,
+) -> None:
+    runtime = OmnigentOAuthHostRuntime(
+        client=SimpleNamespace(), workspace_root=tmp_path / "workspaces"
+    )
+    runtime._prepare_workspace = AsyncMock()  # type: ignore[method-assign]
+
+    with pytest.raises(OmnigentOAuthHostError) as exc_info:
+        await runtime.prepare_host(
+            binding=_binding(),
+            host_lease=_host_lease(),
+            workspace_key="run-1",
+        )
+
+    assert exc_info.value.code == "OMNIGENT_SKILL_PROJECTION_UNAVAILABLE"
+    runtime._prepare_workspace.assert_not_awaited()
+
+
+def test_projection_scripts_install_real_gh_and_resolve_login_shell(tmp_path) -> None:
+    scripts = Path(__file__).resolve().parents[3] / "services" / "omnigent" / "scripts"
+    fake_bin = tmp_path / "source"
+    fake_bin.mkdir()
+    fake_gh = fake_bin / "gh"
+    fake_gh.write_text("#!/bin/sh\necho 'gh version 2.76.2 (fixture)'\n", encoding="utf-8")
+    fake_gh.chmod(0o755)
+    output = tmp_path / "bundle"
+    env = {
+        **os.environ,
+        "MOONMIND_GH_SOURCE": str(fake_gh),
+        "MOONMIND_GH_VERSION": "2.76.2",
+        "MOONMIND_TOOL_BUNDLE_OUTPUT": str(output),
+    }
+
+    installed = subprocess.run(
+        ["sh", str(scripts / "init-mounted-tools.sh")],
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert installed.returncode == 0, installed.stderr
+    assert json.loads((output / "manifest.json").read_text())["tools"][0]["name"] == "gh"
+    assert (output / "bin" / "gh").stat().st_mode & 0o222 == 0
+    login_home = tmp_path / "home"
+    login_home.mkdir()
+    (login_home / ".bash_profile").write_text(
+        f"export PATH={output / 'bin'}:$PATH\n", encoding="utf-8"
+    )
+    login = subprocess.run(
+        ["bash", "-lc", "command -v gh && gh --version"],
+        env={
+            **os.environ,
+            "HOME": str(login_home),
+            "PATH": f"{output / 'bin'}:{os.environ.get('PATH', '')}",
+        },
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert login.returncode == 0, login.stderr
+    assert "2.76.2" in login.stdout
+
+
+def test_omnigent_projects_portable_pr_resolver_semantics_without_copying_them() -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    helper = runpy.run_path(
+        str(repo_root / ".agents/skills/pr-resolver/bin/pr_resolve_snapshot.py")
+    )
+    actionable, reason = helper["_classify_comment_actionability"](
+        {"type": "review_comment", "body": "Please fix this", "user": "reviewer"}
+    )
+    assert (actionable, reason) == (True, "actionable")
+    adapter_source = (repo_root / "moonmind/omnigent/oauth_host_runtime.py").read_text()
+    assert "_classify_comment_actionability" not in adapter_source
+    assert "MOONMIND_ACTIVE_SKILLS_DIR" in adapter_source
 
 
 def test_checkpoint_live_reattach_requires_every_original_authority() -> None:

--- a/tests/unit/omnigent/test_oauth_profile_lifecycle.py
+++ b/tests/unit/omnigent/test_oauth_profile_lifecycle.py
@@ -254,6 +254,15 @@ async def test_on_demand_host_initializes_state_before_unprivileged_launch(
     assert commands[2][:3] == ("docker", "run", "-d")
     assert commands[1][commands[1].index("--user") + 1] == "0:0"
     assert commands[2][commands[2].index("--workdir") + 1] == "/home/app"
+    assert (
+        "type=volume,src=moonmind-omnigent-tools-gh-2.76.2,"
+        "dst=/opt/moonmind-tools,readonly"
+    ) in commands[2]
+    assert "MOONMIND_ACTIVE_SKILLS_DIR=/workspaces/run/.agents/skills" in commands[2]
+    assert (
+        "PATH=/opt/moonmind-tools/bin:/opt/venv/bin:/usr/local/bin:"
+        "/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin"
+    ) in commands[2]
 
 
 @pytest.mark.asyncio
@@ -291,7 +300,7 @@ async def test_static_host_runtime_uses_only_canonical_compose_file(tmp_path) ->
             "exec",
             "-T",
             "omnigent-host-codex",
-            "/opt/moonmind/check-codex-oauth-host.sh",
+            "/opt/moonmind/check-runner-projections.sh",
         ),
         (
             "docker",

--- a/tests/unit/omnigent/test_oauth_profile_lifecycle.py
+++ b/tests/unit/omnigent/test_oauth_profile_lifecycle.py
@@ -579,6 +579,17 @@ def test_projection_scripts_install_real_gh_and_resolve_login_shell(tmp_path) ->
     assert installed.returncode == 0, installed.stderr
     assert json.loads((output / "manifest.json").read_text())["tools"][0]["name"] == "gh"
     assert (output / "bin" / "gh").stat().st_mode & 0o222 == 0
+    fake_gh.write_text("#!/bin/sh\necho 'gh version 2.77.0 (fixture)'\n", encoding="utf-8")
+    env["MOONMIND_GH_VERSION"] = "2.77.0"
+    upgraded = subprocess.run(
+        ["sh", str(scripts / "init-mounted-tools.sh")],
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert upgraded.returncode == 0, upgraded.stderr
+    assert json.loads((output / "manifest.json").read_text())["tools"][0]["version"] == "2.77.0"
     login_home = tmp_path / "home"
     login_home.mkdir()
     (login_home / ".bash_profile").write_text(
@@ -596,7 +607,7 @@ def test_projection_scripts_install_real_gh_and_resolve_login_shell(tmp_path) ->
         text=True,
     )
     assert login.returncode == 0, login.stderr
-    assert "2.76.2" in login.stdout
+    assert "2.77.0" in login.stdout
 
 
 def test_omnigent_projects_portable_pr_resolver_semantics_without_copying_them() -> None:


### PR DESCRIPTION
Run Jira Implement for MM-1217.

Source story: STORY-005.
Source summary: Compose the existing resolved Skill snapshot with Omnigent mounted CLI capabilities.
Source Jira issue: unknown.
Source design document: docs/Omnigent/OmnigentHostMountedTools.md.
Source canonical claim IDs: OMHMT-decisions-01, OMHMT-skill-01.
Original brief reference: not provided.

Use the existing Jira Implement workflow for this Jira issue. Do not run implementation inline inside the breakdown workflow.

## MoonSpec verification incomplete

This pull request was opened as a **draft** because MoonSpec verification did not approve publication (verdict ADDITIONAL_WORK_NEEDED) and the bounded remediation budget was exhausted with remaining implementation work.

- Gate outcome: MoonSpec verification did not approve publication. verdict ADDITIONAL_WORK_NEEDED. The remediation correctly materializes and mounts the resolved immutable Skill snapshot, supplies a pinned real gh executable, and retains portable Skill semantics. One acceptance-critical gap remains: the required tool projection is first validated by check-runner-projections.sh after docker compose up or docker run has already created/started host resources, so a missing or unusable tool projection does not fail before mutation. verification report art_01KXQX9B1EH17FT26XHFBHK0XF.
- Verification report: art_01KXQX9B1EH17FT26XHFBHK0XF
- Verification gate result: art_01KXQX9AZYRJ6MYZ2Q1W20GZCJ

Review the verification evidence before marking this pull request ready for review.