### PR TITLE
Forward validated skill inputs to agents

### DIFF
--- a/moonmind/workflows/temporal/worker_runtime.py
+++ b/moonmind/workflows/temporal/worker_runtime.py
@@ -1160,6 +1160,40 @@ def _validated_skill_payload_inputs(
     return _coerce_mapping(result.get("values")), evidence
 
 
+def _append_selected_skill_inputs(
+    instructions: str,
+    skill_inputs: Mapping[str, Any],
+) -> str:
+    if not skill_inputs:
+        return instructions
+    return (
+        f"{instructions.rstrip()}\n\n"
+        "Selected skill inputs:\n"
+        + json.dumps(skill_inputs, indent=2, sort_keys=True)
+    )
+
+
+def _normalized_agent_skill_payload(
+    skill_payload: Mapping[str, Any],
+    *,
+    selected_skill_name: str,
+    selected_skill_inputs: Mapping[str, Any],
+) -> dict[str, Any]:
+    compact_payload = {
+        key: deepcopy(skill_payload[key])
+        for key in (
+            "contentRef",
+            "contentDigest",
+            "inputContractDigest",
+        )
+        if key in skill_payload
+    }
+    compact_payload["name"] = selected_skill_name
+    if selected_skill_inputs:
+        compact_payload["inputs"] = deepcopy(dict(selected_skill_inputs))
+    return compact_payload
+
+
 def _merge_story_output_inputs(
     existing: Mapping[str, Any] | None,
     override: Any,
@@ -1404,9 +1438,10 @@ def _build_runtime_planner():
             task_payload=task_payload,
         )
         git_payload = _coerce_mapping(task_payload.get("git"))
-        selected_skill_payload = _coerce_mapping(task_payload.get("tool")) or _coerce_mapping(
-            task_payload.get("skill")
-        )
+        task_skill_payload = _coerce_mapping(task_payload.get("skill"))
+        selected_skill_payload = _coerce_mapping(
+            task_payload.get("tool")
+        ) or task_skill_payload
         selected_skill_name = str(
             selected_skill_payload.get("name")
             or selected_skill_payload.get("id")
@@ -1418,11 +1453,16 @@ def _build_runtime_planner():
                 selected_skill_payload.get("inputs")
                 or selected_skill_payload.get("args")
             )
+        if not selected_skill_inputs and task_skill_payload:
+            selected_skill_inputs = _coerce_mapping(
+                task_skill_payload.get("inputs") or task_skill_payload.get("args")
+            )
         selected_skill_evidence: dict[str, Any] = {}
-        if selected_skill_payload:
+        skill_contract_payload = task_skill_payload or selected_skill_payload
+        if skill_contract_payload:
             selected_skill_inputs, selected_skill_evidence = (
                 _validated_skill_payload_inputs(
-                    skill_payload=selected_skill_payload,
+                    skill_payload=skill_contract_payload,
                     raw_inputs=selected_skill_inputs,
                     workflow_context={
                         **parameter_payload,
@@ -1479,27 +1519,16 @@ def _build_runtime_planner():
                 )
                 merged_inputs["pr"] = effective_selector
                 selected_skill_inputs = merged_inputs
-                if has_explicit_instructions:
-                    instructions = (
-                        f"{str(instructions).strip()}\n\n"
-                        f"Selected skill inputs:\n"
-                        + json.dumps(merged_inputs, indent=2, sort_keys=True)
-                    )
-                else:
+                if not has_explicit_instructions:
                     instructions = (
                         f"Execute skill '{selected_skill_name}' with inputs:\n"
                         + json.dumps(merged_inputs, indent=2, sort_keys=True)
                     )
 
-        if (
-            has_explicit_instructions
-            and selected_skill_inputs
-            and "Selected skill inputs:\n" not in str(instructions)
-        ):
-            instructions = (
-                f"{str(instructions).strip()}\n\n"
-                "Selected skill inputs:\n"
-                + json.dumps(selected_skill_inputs, indent=2, sort_keys=True)
+        if has_explicit_instructions and selected_skill_inputs:
+            instructions = _append_selected_skill_inputs(
+                str(instructions),
+                selected_skill_inputs,
             )
 
         # --- Resolve runtime mode ---
@@ -1598,22 +1627,11 @@ def _build_runtime_planner():
             node_inputs["repo"] = repository.strip()
         if selected_skill_name:
             node_inputs["selectedSkill"] = selected_skill_name
-            selected_skill_payload = _coerce_mapping(task_payload.get("skill"))
-            compact_skill_payload = {
-                key: deepcopy(selected_skill_payload[key])
-                for key in (
-                    "name",
-                    "contentRef",
-                    "contentDigest",
-                    "inputContractDigest",
-                    "inputs",
-                )
-                if key in selected_skill_payload
-            }
-            compact_skill_payload.setdefault("name", selected_skill_name)
-            if selected_skill_inputs:
-                compact_skill_payload["inputs"] = deepcopy(selected_skill_inputs)
-            node_inputs["skill"] = compact_skill_payload
+            node_inputs["skill"] = _normalized_agent_skill_payload(
+                skill_contract_payload,
+                selected_skill_name=selected_skill_name,
+                selected_skill_inputs=selected_skill_inputs,
+            )
 
         raw_steps = task_payload.get("steps")
         if (
@@ -2025,6 +2043,13 @@ def _build_runtime_planner():
                 )
                 if is_agent_runtime_step and has_explicit_step_skill:
                     step_node_inputs["selectedSkill"] = step_tool_name
+                    step_skill_payload = _coerce_mapping(step_entry.get("skill"))
+                    if step_skill_payload:
+                        step_node_inputs["skill"] = _normalized_agent_skill_payload(
+                            step_skill_payload,
+                            selected_skill_name=step_tool_name,
+                            selected_skill_inputs=step_tool_inputs,
+                        )
                     if (
                         _jira_agent_skill_selected(step_tool_name)
                         and step_tool_name.lower() not in _MOONSPEC_BREAKDOWN_TOOLS
@@ -2034,6 +2059,10 @@ def _build_runtime_planner():
                     step_node_inputs["instructions"] = _append_agent_skill_instructions(
                         step_node_inputs["instructions"],
                         selected_skill=effective_step_skill_name,
+                    )
+                    step_node_inputs["instructions"] = _append_selected_skill_inputs(
+                        step_node_inputs["instructions"],
+                        step_tool_inputs,
                     )
                 if step_tool_name.lower() in _MOONSPEC_BREAKDOWN_TOOLS:
                     if (

--- a/moonmind/workflows/temporal/worker_runtime.py
+++ b/moonmind/workflows/temporal/worker_runtime.py
@@ -1491,6 +1491,17 @@ def _build_runtime_planner():
                         + json.dumps(merged_inputs, indent=2, sort_keys=True)
                     )
 
+        if (
+            has_explicit_instructions
+            and selected_skill_inputs
+            and "Selected skill inputs:\n" not in str(instructions)
+        ):
+            instructions = (
+                f"{str(instructions).strip()}\n\n"
+                "Selected skill inputs:\n"
+                + json.dumps(selected_skill_inputs, indent=2, sort_keys=True)
+            )
+
         # --- Resolve runtime mode ---
         runtime_payload = _coerce_mapping(task_payload.get("runtime"))
         runtime_mode = _normalize_runtime_mode(
@@ -1599,8 +1610,10 @@ def _build_runtime_planner():
                 )
                 if key in selected_skill_payload
             }
-            if compact_skill_payload:
-                node_inputs["skill"] = compact_skill_payload
+            compact_skill_payload.setdefault("name", selected_skill_name)
+            if selected_skill_inputs:
+                compact_skill_payload["inputs"] = deepcopy(selected_skill_inputs)
+            node_inputs["skill"] = compact_skill_payload
 
         raw_steps = task_payload.get("steps")
         if (

--- a/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
+++ b/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
@@ -2641,6 +2641,43 @@ def test_runtime_planner_does_not_require_pr_branch_for_jira_verify():
     assert "targetBranch" not in node["inputs"]
     assert "commit your work" not in node["inputs"]["instructions"]
 
+def test_runtime_planner_exposes_jira_verify_inputs_with_explicit_instructions():
+    planner = _build_runtime_planner()
+    snapshot = SimpleNamespace(
+        digest="reg:sha256:test",
+        artifact_ref="art_registry_123",
+    )
+
+    plan = planner(
+        inputs={
+            "task": {
+                "instructions": "Verify Jira issue THOR-709.",
+                "tool": {"type": "skill", "name": "jira-verify"},
+                "skill": {"name": "jira-verify"},
+                "inputs": {
+                    "jira_issue_key": "THOR-709",
+                    "update_status": True,
+                },
+                "runtime": {"mode": "codex_cli"},
+                "publish": {"mode": "none"},
+            }
+        },
+        parameters={},
+        snapshot=snapshot,
+    )
+
+    node_inputs = plan["nodes"][0]["inputs"]
+    assert node_inputs["instructions"].startswith("Use $jira-verify.")
+    assert "Selected skill inputs:" in node_inputs["instructions"]
+    assert '"update_status": true' in node_inputs["instructions"]
+    assert node_inputs["skill"] == {
+        "name": "jira-verify",
+        "inputs": {
+            "jira_issue_key": "THOR-709",
+            "update_status": True,
+        },
+    }
+
 def test_runtime_planner_does_not_require_pr_branch_for_jira_pr_verify():
     planner = _build_runtime_planner()
     snapshot = SimpleNamespace(

--- a/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
+++ b/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
@@ -2678,6 +2678,118 @@ def test_runtime_planner_exposes_jira_verify_inputs_with_explicit_instructions()
         },
     }
 
+def test_runtime_planner_reads_inputs_from_nested_skill_with_tool_discriminator():
+    planner = _build_runtime_planner()
+    snapshot = SimpleNamespace(
+        digest="reg:sha256:test",
+        artifact_ref="art_registry_123",
+    )
+
+    plan = planner(
+        inputs={
+            "task": {
+                "instructions": "Verify Jira issue THOR-709.",
+                "tool": {"type": "skill", "name": "jira-verify"},
+                "skill": {
+                    "name": "jira-verify",
+                    "inputs": {
+                        "jira_issue_key": "THOR-709",
+                        "update_status": True,
+                    },
+                },
+                "runtime": {"mode": "codex_cli"},
+                "publish": {"mode": "none"},
+            }
+        },
+        parameters={},
+        snapshot=snapshot,
+    )
+
+    node_inputs = plan["nodes"][0]["inputs"]
+    assert '"update_status": true' in node_inputs["instructions"]
+    assert node_inputs["skill"]["inputs"]["update_status"] is True
+
+def test_runtime_planner_appends_inputs_despite_authored_heading_collision():
+    planner = _build_runtime_planner()
+    snapshot = SimpleNamespace(
+        digest="reg:sha256:test",
+        artifact_ref="art_registry_123",
+    )
+
+    plan = planner(
+        inputs={
+            "task": {
+                "instructions": (
+                    "Discuss the phrase Selected skill inputs:\n"
+                    "without treating it as runtime data."
+                ),
+                "tool": {"type": "skill", "name": "jira-verify"},
+                "inputs": {"update_status": True},
+                "runtime": {"mode": "codex_cli"},
+                "publish": {"mode": "none"},
+            }
+        },
+        parameters={},
+        snapshot=snapshot,
+    )
+
+    instructions = plan["nodes"][0]["inputs"]["instructions"]
+    assert instructions.count("Selected skill inputs:\n") == 2
+    assert 'Selected skill inputs:\n{\n  "update_status": true\n}' in instructions
+
+def test_runtime_planner_exposes_inputs_for_expanded_agent_skill_step():
+    planner = _build_runtime_planner()
+    snapshot = SimpleNamespace(
+        digest="reg:sha256:test",
+        artifact_ref="art_registry_123",
+    )
+
+    plan = planner(
+        inputs={
+            "task": {
+                "instructions": "Process the Jira verification steps.",
+                "runtime": {"mode": "codex_cli"},
+                "publish": {"mode": "none"},
+                "steps": [
+                    {
+                        "id": "verify-one",
+                        "type": "skill",
+                        "instructions": "Verify THOR-709.",
+                        "skill": {
+                            "name": "jira-verify",
+                            "inputs": {
+                                "jira_issue_key": "THOR-709",
+                                "update_status": True,
+                            },
+                        },
+                    },
+                    {
+                        "id": "verify-two",
+                        "type": "skill",
+                        "instructions": "Verify THOR-710.",
+                        "skill": {
+                            "name": "jira-verify",
+                            "inputs": {"jira_issue_key": "THOR-710"},
+                        },
+                    },
+                ],
+            }
+        },
+        parameters={},
+        snapshot=snapshot,
+    )
+
+    node_inputs = plan["nodes"][0]["inputs"]
+    assert node_inputs["selectedSkill"] == "jira-verify"
+    assert '"update_status": true' in node_inputs["instructions"]
+    assert node_inputs["skill"] == {
+        "name": "jira-verify",
+        "inputs": {
+            "jira_issue_key": "THOR-709",
+            "update_status": True,
+        },
+    }
+
 def test_runtime_planner_does_not_require_pr_branch_for_jira_pr_verify():
     planner = _build_runtime_planner()
     snapshot = SimpleNamespace(


### PR DESCRIPTION
## Summary

- include validated skill inputs in agent-visible instructions even when the workflow has explicit authored instructions
- preserve the validated values under the structured `skill.inputs` request payload
- add regression coverage for `jira-verify` with `update_status: true`

## Root cause

The runtime planner retained top-level skill values under `node.inputs.inputs`, but explicit authored instructions suppressed the existing input rendering path. The downstream agent request therefore received the verification instruction and skill name without the requested status-update flag, causing `jira-verify` to apply its default `update_status: false`.

## Validation

- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_temporal_worker_runtime.py` — 111 passed
- selector-triggered frontend suite — 65 files passed; 1,094 passed and 239 skipped
- `uvx ruff check moonmind/workflows/temporal/worker_runtime.py tests/unit/workflows/temporal/test_temporal_worker_runtime.py` — passed
- `git diff --check` — passed

Black reports that both touched files would be reformatted under the current repository baseline; no bulk formatting changes are included.