### PR TITLE
Fix app image builds after Omnigent embedding

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -45,6 +45,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v7
 
+      - name: Initialize pinned Omnigent verifier source
+        run: git submodule update --init --depth 1 -- omnigent
+
       - name: Set up Python
         if: matrix.platform == 'linux/amd64'
         uses: actions/setup-python@v6

--- a/tests/unit/test_docker_publish_workflow.py
+++ b/tests/unit/test_docker_publish_workflow.py
@@ -41,15 +41,17 @@ def test_docker_publish_generates_version_before_platform_builds() -> None:
     assert build_job["needs"] == "metadata"
 
 
-def test_docker_publish_does_not_require_submodules() -> None:
-    # MoonSpec skills are vendored real files under .agents/skills, so the
-    # image build must not depend on submodule checkout state.
+def test_docker_publish_initializes_only_required_omnigent_submodule() -> None:
+    # MoonSpec skills are vendored real files under .agents/skills, while the
+    # runtime image embeds verifier sources from the pinned Omnigent revision.
+    # Initialize that one required source without cloning unrelated submodules.
     workflow = _load_workflow()
 
+    build_steps = workflow["jobs"]["build"]["steps"]
     checkout = next(
         (
             step
-            for step in workflow["jobs"]["build"]["steps"]
+            for step in build_steps
             if step.get("uses", "").startswith("actions/checkout@")
         ),
         None,
@@ -57,6 +59,17 @@ def test_docker_publish_does_not_require_submodules() -> None:
 
     assert checkout is not None, "Checkout step not found"
     assert "submodules" not in checkout.get("with", {})
+
+    initialize = next(
+        (
+            step
+            for step in build_steps
+            if step.get("name") == "Initialize pinned Omnigent verifier source"
+        ),
+        None,
+    )
+    assert initialize is not None, "Pinned Omnigent initialization step not found"
+    assert initialize["run"] == "git submodule update --init --depth 1 -- omnigent"
 
 
 def test_app_image_ships_vendored_skills_without_moonspec_submodule() -> None:


### PR DESCRIPTION
## Summary
- initialize the pinned Omnigent submodule before app image builds
- keep unrelated submodules out of the release checkout
- add a regression assertion for the required initialization step

## Verification
- targeted Docker publish workflow unit suite passes
- local linux/amd64 api-runtime image target builds with release arguments