### PR TITLE
fix(compose): use pullable GitHub CLI image

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -804,10 +804,11 @@ services:
 
   omnigent-tools-init:
     profiles: ["omnigent-host", "omnigent-host-claude", "omnigent-host-codex"]
-    image: ${OMNIGENT_GH_IMAGE:-cli/cli:2.76.2}
+    image: ${OMNIGENT_GH_IMAGE:-serversideup/github-cli:alpine-2.76.2}
     user: "0:0"
     entrypoint: ["/opt/moonmind/init-mounted-tools.sh"]
     environment:
+      MOONMIND_GH_SOURCE: /usr/local/bin/gh
       MOONMIND_GH_VERSION: ${OMNIGENT_GH_VERSION:-2.76.2}
     volumes:
       - omnigent-tools:/output

--- a/tests/integration/temporal/test_compose_foundation.py
+++ b/tests/integration/temporal/test_compose_foundation.py
@@ -187,8 +187,15 @@ def test_omnigent_hosts_use_versioned_read_only_tool_bundle():
     services = compose["services"]
     initializer = services["omnigent-tools-init"]
 
+    assert initializer["image"] == (
+        "${OMNIGENT_GH_IMAGE:-serversideup/github-cli:alpine-2.76.2}"
+    )
     assert initializer["user"] == "0:0"
     assert initializer["restart"] == "no"
+    assert initializer["environment"] == {
+        "MOONMIND_GH_SOURCE": "/usr/local/bin/gh",
+        "MOONMIND_GH_VERSION": "${OMNIGENT_GH_VERSION:-2.76.2}",
+    }
     assert initializer["volumes"] == [
         "omnigent-tools:/output",
         "./services/omnigent/scripts:/opt/moonmind:ro",


### PR DESCRIPTION
Root cause: the Omnigent tools initializer referenced cli/cli:2.76.2, but that Docker Hub repository does not exist.

This change uses the version-pinned multi-architecture serversideup/github-cli Alpine image and configures the initializer with its actual gh binary path. The Compose foundation test now locks both assumptions.

Validation:
- Compose configuration validation passed
- Omnigent host projection unit tests passed
- Focused Compose foundation regression test passed