### PR TITLE
Complete Workflow Detail chat projection for MoonLadderStudios/MoonMind#3364

### DIFF
--- a/api_service/api/routers/omnigent_bridge.py
+++ b/api_service/api/routers/omnigent_bridge.py
@@ -654,8 +654,12 @@ def _terminal_envelope(row: Any) -> BridgeTerminalEnvelope | None:
 
 
 def _projection_capabilities(row: Any) -> dict[str, bool]:
-    metadata = dict(getattr(row, "metadata_", None) or {})
-    raw = metadata.get("interventionCapabilities", metadata.get("capabilities", {}))
+    metadata = getattr(row, "metadata_", None)
+    if not isinstance(metadata, dict):
+        return {}
+    raw = metadata.get("interventionCapabilities")
+    if not isinstance(raw, dict):
+        raw = metadata.get("capabilities")
     if not isinstance(raw, dict):
         return {}
     return {

--- a/api_service/api/routers/omnigent_bridge.py
+++ b/api_service/api/routers/omnigent_bridge.py
@@ -19,7 +19,7 @@ from typing import Any
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Query, Request, status
 from fastapi.responses import Response, StreamingResponse
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 from api_service.api.execution_principal import (
     execution_principal_dependency,
@@ -547,6 +547,7 @@ class BridgeSessionResolution(BaseModel):
     provider_profile_id: str | None = None
     host_binding_ref: str | None = None
     provider_session_ref: str | None = None
+    capabilities: dict[str, bool] = Field(default_factory=dict)
 
 
 class BridgeRetentionGap(BaseModel):
@@ -650,6 +651,18 @@ def _terminal_envelope(row: Any) -> BridgeTerminalEnvelope | None:
             None if has_evidence else "No terminal artifacts were captured."
         ),
     )
+
+
+def _projection_capabilities(row: Any) -> dict[str, bool]:
+    metadata = dict(getattr(row, "metadata_", None) or {})
+    raw = metadata.get("interventionCapabilities", metadata.get("capabilities", {}))
+    if not isinstance(raw, dict):
+        return {}
+    return {
+        str(key): value
+        for key, value in raw.items()
+        if isinstance(key, str) and isinstance(value, bool)
+    }
 
 
 def _bridge_event_kind(event_type: str | None) -> str:
@@ -780,6 +793,7 @@ async def resolve_omnigent_bridge_session_projection(
         provider_profile_id=row.provider_profile_id,
         host_binding_ref=row.host_binding_ref,
         provider_session_ref=row.omnigent_session_id,
+        capabilities=_projection_capabilities(row),
     )
 
 

--- a/frontend/src/entrypoints/workflow-detail.test.tsx
+++ b/frontend/src/entrypoints/workflow-detail.test.tsx
@@ -8030,7 +8030,7 @@ describe('Workflow Detail Entrypoint', () => {
     });
 
     try {
-      renderWithClient(<WorkflowDetailPage payload={mockPayload} />);
+      renderWithClient(<WorkflowDetailPage payload={actionsPayload} />);
       const input = await screen.findByLabelText('Follow-up message');
       fireEvent.change(input, { target: { value: 'Continue with the fix.' } });
       fireEvent.click(screen.getByRole('button', { name: 'Send follow-up' }));
@@ -8058,7 +8058,7 @@ describe('Workflow Detail Entrypoint', () => {
       return Promise.resolve({ ok: true, json: async () => mockExecution } as Response);
     });
     try {
-      renderWithClient(<WorkflowDetailPage payload={mockPayload} />);
+      renderWithClient(<WorkflowDetailPage payload={actionsPayload} />);
       fireEvent.change(await screen.findByLabelText('Follow-up message'), { target: { value: 'Continue.' } });
       fireEvent.click(screen.getByRole('button', { name: 'Send follow-up' }));
       await waitFor(() => expect(screen.getByText(/Operator message · Failed/)).toBeTruthy());
@@ -8072,6 +8072,7 @@ describe('Workflow Detail Entrypoint', () => {
   it('executes advertised bridge elicitation, clear, and cancel controls and preserves durable outcomes', async () => {
     window.history.pushState({}, 'Bridge Intervention Test', '/workflows/test-123/chat?source=temporal');
     const priorEventSource = window.EventSource;
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
     window.EventSource = MockEventSource as unknown as typeof EventSource;
     const mockExecution = { taskId: 'test-123', workflowId: 'test-123', source: 'temporal', namespace: 'default', title: 'Bridge interventions', summary: 'Running', createdAt: '2026-07-09T00:00:00Z', updatedAt: '2026-07-09T00:00:30Z', status: 'running', state: 'executing', rawState: 'running', actions: {} };
     fetchSpy.mockImplementation((input: RequestInfo | URL) => {
@@ -8093,7 +8094,7 @@ describe('Workflow Detail Entrypoint', () => {
       return Promise.resolve({ ok: true, json: async () => mockExecution } as Response);
     });
     try {
-      renderWithClient(<WorkflowDetailPage payload={mockPayload} />);
+      renderWithClient(<WorkflowDetailPage payload={actionsPayload} />);
       expect(await screen.findByRole('region', { name: 'Pending operator request el-pending' })).toBeTruthy();
       expect(screen.getAllByText('Previously approved by operator.').length).toBeGreaterThan(0);
       expect(screen.queryByRole('region', { name: 'Pending operator request el-resolved' })).toBeNull();
@@ -8111,6 +8112,7 @@ describe('Workflow Detail Entrypoint', () => {
         String(url).endsWith('/omnigent/v1/sessions/provider-session/events') &&
         JSON.parse(String((init as RequestInit).body)).type === 'session.cancel')).toBe(true));
     } finally {
+      confirmSpy.mockRestore();
       window.EventSource = priorEventSource;
     }
   });

--- a/frontend/src/entrypoints/workflow-detail.test.tsx
+++ b/frontend/src/entrypoints/workflow-detail.test.tsx
@@ -7981,7 +7981,9 @@ describe('Workflow Detail Entrypoint', () => {
             schemaVersion: 'moonmind.bridge-session-terminal.v1', status: 'failed',
             failureClass: 'configuration_error', failureCode: 'profile_missing',
             summary: 'Provider profile is unavailable.', diagnosticsRef: 'artifact:diagnostics',
-            cleanupState: 'completed', evidenceIncompleteReason: null,
+            initialSnapshotRef: 'artifact:initial', rawEventsRef: 'artifact:raw',
+            externalStateRef: 'artifact:external', cleanupState: 'completed',
+            leaseReleaseState: 'released', evidenceIncompleteReason: null,
           },
         }) } as Response);
       }
@@ -7995,6 +7997,11 @@ describe('Workflow Detail Entrypoint', () => {
     expect(screen.getAllByText(/Failure class: configuration_error/).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/Reason: profile_missing/).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/Cleanup: completed/).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Lease release: released/).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/verify the provider profile, credentials, and execution authorization/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByRole('link', { name: 'Open initial snapshot' }).length).toBeGreaterThan(0);
+    expect(screen.getAllByRole('link', { name: 'Open raw events' }).length).toBeGreaterThan(0);
+    expect(screen.getAllByRole('link', { name: 'Open external state' }).length).toBeGreaterThan(0);
     expect(screen.getByTestId('chat-session-blocks')).toBeTruthy();
   });
 
@@ -8032,6 +8039,31 @@ describe('Workflow Detail Entrypoint', () => {
       expect(fetchSpy.mock.calls.some(([url, init]) =>
         String(url).includes('/omnigent/v1/sessions/provider-session/events') &&
         String((init as RequestInit | undefined)?.body).includes('clientEventKey'))).toBe(true);
+    } finally {
+      window.EventSource = priorEventSource;
+    }
+  });
+
+  it('shows failed bridge delivery and denies controls not advertised by the server', async () => {
+    window.history.pushState({}, 'Bridge Failed Controls Test', '/workflows/test-123/chat?source=temporal');
+    const priorEventSource = window.EventSource;
+    window.EventSource = MockEventSource as unknown as typeof EventSource;
+    const mockExecution = { taskId: 'test-123', workflowId: 'test-123', source: 'temporal', namespace: 'default', title: 'Bridge controls', summary: 'Running', createdAt: '2026-07-09T00:00:00Z', updatedAt: '2026-07-09T00:00:30Z', status: 'running', state: 'executing', rawState: 'running', actions: {} };
+    fetchSpy.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/bridge-sessions/resolve')) return Promise.resolve({ ok: true, json: async () => ({ bridgeSessionId: 'brs-fail', status: 'running', providerSessionRef: 'provider-session', capabilities: { sendFollowUp: true, interruptTurn: false } }) } as Response);
+      if (url.includes('/bridge-sessions/brs-fail/events')) return Promise.resolve({ ok: true, json: async () => ({ schemaVersion: 'moonmind.bridge-session-events-page.v1', bridgeSessionId: 'brs-fail', items: [], after: 0, nextCursor: null, hasMore: false, terminal: false, latestSequence: 0 }) } as Response);
+      if (url.includes('/omnigent/v1/sessions/provider-session/events')) return Promise.resolve({ ok: false, status: 403, json: async () => ({ detail: 'not authorized' }) } as Response);
+      if (url.includes('/artifacts')) return Promise.resolve({ ok: true, json: async () => ({ artifacts: [] }) } as Response);
+      return Promise.resolve({ ok: true, json: async () => mockExecution } as Response);
+    });
+    try {
+      renderWithClient(<WorkflowDetailPage payload={mockPayload} />);
+      fireEvent.change(await screen.findByLabelText('Follow-up message'), { target: { value: 'Continue.' } });
+      fireEvent.click(screen.getByRole('button', { name: 'Send follow-up' }));
+      await waitFor(() => expect(screen.getByText(/Operator message · Failed/)).toBeTruthy());
+      expect(screen.queryByRole('button', { name: 'Interrupt turn' })).toBeNull();
+      expect(screen.getByRole('region', { name: 'Bridge session controls' })).toBeTruthy();
     } finally {
       window.EventSource = priorEventSource;
     }

--- a/frontend/src/entrypoints/workflow-detail.test.tsx
+++ b/frontend/src/entrypoints/workflow-detail.test.tsx
@@ -47,6 +47,36 @@ describe('bridge projection response contract', () => {
       }),
     ).toMatchObject({ nextCursor: '100', hasMore: true });
   });
+
+  it('preserves the authoritative terminal envelope', () => {
+    expect(parseObservabilityEventsResponse({
+      schemaVersion: 'moonmind.bridge-session-events-page.v1',
+      bridgeSessionId: 'brs-failed',
+      items: [],
+      after: 0,
+      nextCursor: null,
+      hasMore: false,
+      terminal: true,
+      latestSequence: 0,
+      terminalEnvelope: {
+        schemaVersion: 'moonmind.bridge-session-terminal.v1',
+        status: 'failed',
+        failureClass: 'configuration_error',
+        failureCode: 'profile_missing',
+        summary: 'Provider profile is unavailable.',
+        diagnosticsRef: 'artifact:diagnostics',
+        cleanupState: 'completed',
+      },
+    })).toMatchObject({
+      terminal: true,
+      terminalEnvelope: {
+        status: 'failed',
+        failureClass: 'configuration_error',
+        failureCode: 'profile_missing',
+        diagnosticsRef: 'artifact:diagnostics',
+      },
+    });
+  });
 });
 import {
   taskCompareHref,
@@ -7928,6 +7958,83 @@ describe('Workflow Detail Entrypoint', () => {
     expect(
       fetchSpy.mock.calls.some(([url]) => String(url).includes('/agent-runs/')),
     ).toBe(false);
+  });
+
+  it('renders bridge terminal failure evidence even without provider deltas', async () => {
+    window.history.pushState({}, 'Bridge Failure Test', '/workflows/test-123/chat?source=temporal');
+    const mockExecution = {
+      taskId: 'test-123', workflowId: 'test-123', source: 'temporal', namespace: 'default',
+      title: 'Bridge failure', summary: 'Failed before streaming',
+      createdAt: '2026-07-09T00:00:00Z', updatedAt: '2026-07-09T00:00:30Z',
+      status: 'failed', state: 'failed', rawState: 'failed', actions: {},
+    };
+    fetchSpy.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/omnigent/bridge-sessions/resolve')) {
+        return Promise.resolve({ ok: true, json: async () => ({ bridgeSessionId: 'brs-failed', status: 'failed' }) } as Response);
+      }
+      if (url.includes('/omnigent/bridge-sessions/brs-failed/events')) {
+        return Promise.resolve({ ok: true, json: async () => ({
+          schemaVersion: 'moonmind.bridge-session-events-page.v1', bridgeSessionId: 'brs-failed',
+          items: [], after: 0, nextCursor: null, hasMore: false, terminal: true, latestSequence: 0,
+          terminalEnvelope: {
+            schemaVersion: 'moonmind.bridge-session-terminal.v1', status: 'failed',
+            failureClass: 'configuration_error', failureCode: 'profile_missing',
+            summary: 'Provider profile is unavailable.', diagnosticsRef: 'artifact:diagnostics',
+            cleanupState: 'completed', evidenceIncompleteReason: null,
+          },
+        }) } as Response);
+      }
+      if (url.includes('/artifacts')) return Promise.resolve({ ok: true, json: async () => ({ artifacts: [] }) } as Response);
+      return Promise.resolve({ ok: true, json: async () => mockExecution } as Response);
+    });
+
+    renderWithClient(<WorkflowDetailPage payload={mockPayload} />);
+
+    await waitFor(() => expect(screen.getAllByText(/Provider profile is unavailable/).length).toBeGreaterThan(0));
+    expect(screen.getAllByText(/Failure class: configuration_error/).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Reason: profile_missing/).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Cleanup: completed/).length).toBeGreaterThan(0);
+    expect(screen.getByTestId('chat-session-blocks')).toBeTruthy();
+  });
+
+  it('uses advertised bridge capabilities and exposes delivery-unknown messages', async () => {
+    window.history.pushState({}, 'Bridge Controls Test', '/workflows/test-123/chat?source=temporal');
+    const priorEventSource = window.EventSource;
+    window.EventSource = MockEventSource as unknown as typeof EventSource;
+    const mockExecution = {
+      taskId: 'test-123', workflowId: 'test-123', source: 'temporal', namespace: 'default',
+      title: 'Bridge controls', summary: 'Running', createdAt: '2026-07-09T00:00:00Z',
+      updatedAt: '2026-07-09T00:00:30Z', status: 'running', state: 'executing', rawState: 'running', actions: {},
+    };
+    fetchSpy.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/omnigent/bridge-sessions/resolve')) return Promise.resolve({ ok: true, json: async () => ({
+        bridgeSessionId: 'brs-controls', status: 'running', providerSessionRef: 'provider-session',
+        capabilities: { sendFollowUp: true, interruptTurn: true },
+      }) } as Response);
+      if (url.includes('/omnigent/bridge-sessions/brs-controls/events')) return Promise.resolve({ ok: true, json: async () => ({
+        schemaVersion: 'moonmind.bridge-session-events-page.v1', bridgeSessionId: 'brs-controls', items: [],
+        after: 0, nextCursor: null, hasMore: false, terminal: false, latestSequence: 0,
+      }) } as Response);
+      if (url.includes('/omnigent/v1/sessions/provider-session/events')) return Promise.resolve({ ok: true, json: async () => ({}) } as Response);
+      if (url.includes('/artifacts')) return Promise.resolve({ ok: true, json: async () => ({ artifacts: [] }) } as Response);
+      return Promise.resolve({ ok: true, json: async () => mockExecution } as Response);
+    });
+
+    try {
+      renderWithClient(<WorkflowDetailPage payload={mockPayload} />);
+      const input = await screen.findByLabelText('Follow-up message');
+      fireEvent.change(input, { target: { value: 'Continue with the fix.' } });
+      fireEvent.click(screen.getByRole('button', { name: 'Send follow-up' }));
+      await waitFor(() => expect(screen.getByText(/Delivery confirmation pending/)).toBeTruthy());
+      expect(screen.getByRole('button', { name: 'Interrupt turn' })).toBeTruthy();
+      expect(fetchSpy.mock.calls.some(([url, init]) =>
+        String(url).includes('/omnigent/v1/sessions/provider-session/events') &&
+        String((init as RequestInit | undefined)?.body).includes('clientEventKey'))).toBe(true);
+    } finally {
+      window.EventSource = priorEventSource;
+    }
   });
 
   it('renders artifact download link using explicit downloadUrl when present', async () => {

--- a/frontend/src/entrypoints/workflow-detail.test.tsx
+++ b/frontend/src/entrypoints/workflow-detail.test.tsx
@@ -8069,6 +8069,75 @@ describe('Workflow Detail Entrypoint', () => {
     }
   });
 
+  it('executes advertised bridge elicitation, clear, and cancel controls and preserves durable outcomes', async () => {
+    window.history.pushState({}, 'Bridge Intervention Test', '/workflows/test-123/chat?source=temporal');
+    const priorEventSource = window.EventSource;
+    window.EventSource = MockEventSource as unknown as typeof EventSource;
+    const mockExecution = { taskId: 'test-123', workflowId: 'test-123', source: 'temporal', namespace: 'default', title: 'Bridge interventions', summary: 'Running', createdAt: '2026-07-09T00:00:00Z', updatedAt: '2026-07-09T00:00:30Z', status: 'running', state: 'executing', rawState: 'running', actions: {} };
+    fetchSpy.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/bridge-sessions/resolve')) return Promise.resolve({ ok: true, json: async () => ({
+        bridgeSessionId: 'brs-interventions', status: 'running', providerSessionRef: 'provider-session',
+        capabilities: { resolveElicitation: true, clearSession: true, cancelSession: true },
+      }) } as Response);
+      if (url.includes('/bridge-sessions/brs-interventions/events')) return Promise.resolve({ ok: true, json: async () => ({
+        schemaVersion: 'moonmind.bridge-session-events-page.v1', bridgeSessionId: 'brs-interventions',
+        items: [
+          { sequence: 1, timestamp: '2026-07-09T00:00:01Z', stream: 'session', kind: 'approval_requested', text: 'Allow the provider action?', metadata: { elicitationId: 'el-pending' } },
+          { sequence: 2, timestamp: '2026-07-09T00:00:02Z', stream: 'session', kind: 'approval_requested', text: 'Previously resolved request.', metadata: { elicitationId: 'el-resolved' } },
+          { sequence: 3, timestamp: '2026-07-09T00:00:03Z', stream: 'session', kind: 'approval_resolved', text: 'Previously approved by operator.', metadata: { elicitationId: 'el-resolved' } },
+        ], after: 0, nextCursor: '3', hasMore: false, terminal: false, latestSequence: 3,
+      }) } as Response);
+      if (url.includes('/omnigent/v1/sessions/provider-session/')) return Promise.resolve({ ok: true, json: async () => ({ ok: true }) } as Response);
+      if (url.includes('/artifacts')) return Promise.resolve({ ok: true, json: async () => ({ artifacts: [] }) } as Response);
+      return Promise.resolve({ ok: true, json: async () => mockExecution } as Response);
+    });
+    try {
+      renderWithClient(<WorkflowDetailPage payload={mockPayload} />);
+      expect(await screen.findByRole('region', { name: 'Pending operator request el-pending' })).toBeTruthy();
+      expect(screen.getAllByText('Previously approved by operator.').length).toBeGreaterThan(0);
+      expect(screen.queryByRole('region', { name: 'Pending operator request el-resolved' })).toBeNull();
+
+      fireEvent.click(screen.getByRole('button', { name: 'Approve' }));
+      await waitFor(() => expect(fetchSpy.mock.calls.some(([url, init]) =>
+        String(url).endsWith('/omnigent/v1/sessions/provider-session/elicitations/el-pending/resolve') &&
+        JSON.parse(String((init as RequestInit).body)).decision === 'approved')).toBe(true));
+      fireEvent.click(screen.getByRole('button', { name: 'Clear session' }));
+      await waitFor(() => expect(fetchSpy.mock.calls.some(([url, init]) =>
+        String(url).endsWith('/omnigent/v1/sessions/provider-session/events') &&
+        JSON.parse(String((init as RequestInit).body)).type === 'clear_session')).toBe(true));
+      fireEvent.click(screen.getByRole('button', { name: 'Cancel session' }));
+      await waitFor(() => expect(fetchSpy.mock.calls.some(([url, init]) =>
+        String(url).endsWith('/omnigent/v1/sessions/provider-session/events') &&
+        JSON.parse(String((init as RequestInit).body)).type === 'session.cancel')).toBe(true));
+    } finally {
+      window.EventSource = priorEventSource;
+    }
+  });
+
+  it('does not expose bridge elicitation, clear, or cancel actions unless advertised', async () => {
+    window.history.pushState({}, 'Bridge Denied Intervention Test', '/workflows/test-123/chat?source=temporal');
+    const priorEventSource = window.EventSource;
+    window.EventSource = MockEventSource as unknown as typeof EventSource;
+    const mockExecution = { taskId: 'test-123', workflowId: 'test-123', source: 'temporal', namespace: 'default', title: 'Bridge interventions', summary: 'Running', createdAt: '2026-07-09T00:00:00Z', updatedAt: '2026-07-09T00:00:30Z', status: 'running', state: 'executing', rawState: 'running', actions: {} };
+    fetchSpy.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/bridge-sessions/resolve')) return Promise.resolve({ ok: true, json: async () => ({ bridgeSessionId: 'brs-denied', status: 'running', providerSessionRef: 'provider-session', capabilities: {} }) } as Response);
+      if (url.includes('/bridge-sessions/brs-denied/events')) return Promise.resolve({ ok: true, json: async () => ({ schemaVersion: 'moonmind.bridge-session-events-page.v1', bridgeSessionId: 'brs-denied', items: [{ sequence: 1, timestamp: '2026-07-09T00:00:01Z', stream: 'session', kind: 'approval_requested', text: 'Request without capability.', metadata: { elicitationId: 'el-denied' } }], after: 0, nextCursor: '1', hasMore: false, terminal: false, latestSequence: 1 }) } as Response);
+      if (url.includes('/artifacts')) return Promise.resolve({ ok: true, json: async () => ({ artifacts: [] }) } as Response);
+      return Promise.resolve({ ok: true, json: async () => mockExecution } as Response);
+    });
+    try {
+      renderWithClient(<WorkflowDetailPage payload={mockPayload} />);
+      expect((await screen.findAllByText('Request without capability.')).length).toBeGreaterThan(0);
+      expect(screen.queryByRole('button', { name: 'Approve' })).toBeNull();
+      expect(screen.queryByRole('button', { name: 'Clear session' })).toBeNull();
+      expect(screen.queryByRole('button', { name: 'Cancel session' })).toBeNull();
+    } finally {
+      window.EventSource = priorEventSource;
+    }
+  });
+
   it('renders artifact download link using explicit downloadUrl when present', async () => {
     window.history.pushState({}, 'Artifacts Test', '/workflows/test-123/artifacts?source=temporal');
     const mockExecution = {

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -3416,8 +3416,11 @@ function buildTimelineArtifactLinks(row: TimelineRow, apiBase: string): Timeline
   if (row.metadata.terminalStatus) {
     addLink('Open diagnostics', row.metadata.diagnosticsRef);
     addLink('Open capture manifest', row.metadata.captureManifestRef);
+    addLink('Open initial snapshot', row.metadata.initialSnapshotRef);
     addLink('Open final snapshot', row.metadata.finalSnapshotRef);
+    addLink('Open raw events', row.metadata.rawEventsRef);
     addLink('Open normalized events', row.metadata.normalizedEventsRef);
+    addLink('Open external state', row.metadata.externalStateRef);
   }
 
   return links;
@@ -3566,8 +3569,11 @@ function chatBlockArtifactLinks(block: ProjectedChatBlock, apiBase: string): Tim
   if (metadata.terminalStatus) {
     addLink('Open diagnostics', metadata.diagnosticsRef);
     addLink('Open capture manifest', metadata.captureManifestRef);
+    addLink('Open initial snapshot', metadata.initialSnapshotRef);
     addLink('Open final snapshot', metadata.finalSnapshotRef);
+    addLink('Open raw events', metadata.rawEventsRef);
     addLink('Open normalized events', metadata.normalizedEventsRef);
+    addLink('Open external state', metadata.externalStateRef);
   }
 
   return links;
@@ -5672,6 +5678,10 @@ function BridgeSessionLogsPanel({
         envelope.failureCode ? `Reason: ${envelope.failureCode}.` : '',
         envelope.evidenceIncompleteReason ? `Evidence incomplete: ${envelope.evidenceIncompleteReason}` : '',
         envelope.cleanupState ? `Cleanup: ${envelope.cleanupState}.` : '',
+        envelope.leaseReleaseState ? `Lease release: ${envelope.leaseReleaseState}.` : '',
+        /configuration|profile|authori[sz]ation/i.test(`${envelope.failureClass ?? ''} ${envelope.failureCode ?? ''}`)
+          ? 'Remediation: verify the provider profile, credentials, and execution authorization, then retry.'
+          : '',
       ].filter(Boolean).join(' ');
       rows.push({
         id: `${bridgeSessionId}-terminal-envelope`,

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -3416,29 +3416,29 @@ function buildTimelineArtifactLinks(row: TimelineRow, apiBase: string): Timeline
   };
 
   if (row.kind === 'summary_published') {
-    addLink('Open summary artifact', row.metadata.summaryRef ?? row.metadata.artifactRef);
+    addLink('Open summary artifact', row.metadata?.summaryRef ?? row.metadata?.artifactRef);
   }
   if (row.kind === 'checkpoint_published') {
-    addLink('Open checkpoint artifact', row.metadata.checkpointRef ?? row.metadata.artifactRef);
+    addLink('Open checkpoint artifact', row.metadata?.checkpointRef ?? row.metadata?.artifactRef);
   }
   if (row.kind === 'session_cleared' || row.kind === 'session_reset_boundary') {
     addLink(
       'Open control event artifact',
-      row.metadata.controlEventRef ?? (row.kind === 'session_cleared' ? row.metadata.artifactRef : null),
+      row.metadata?.controlEventRef ?? (row.kind === 'session_cleared' ? row.metadata?.artifactRef : null),
     );
     addLink(
       'Open reset boundary artifact',
-      row.metadata.resetBoundaryRef ?? (row.kind === 'session_reset_boundary' ? row.metadata.artifactRef : null),
+      row.metadata?.resetBoundaryRef ?? (row.kind === 'session_reset_boundary' ? row.metadata?.artifactRef : null),
     );
   }
-  if (row.metadata.terminalStatus) {
-    addLink('Open diagnostics', row.metadata.diagnosticsRef);
-    addLink('Open capture manifest', row.metadata.captureManifestRef);
-    addLink('Open initial snapshot', row.metadata.initialSnapshotRef);
-    addLink('Open final snapshot', row.metadata.finalSnapshotRef);
-    addLink('Open raw events', row.metadata.rawEventsRef);
-    addLink('Open normalized events', row.metadata.normalizedEventsRef);
-    addLink('Open external state', row.metadata.externalStateRef);
+  if (row.metadata?.terminalStatus) {
+    addLink('Open diagnostics', row.metadata?.diagnosticsRef);
+    addLink('Open capture manifest', row.metadata?.captureManifestRef);
+    addLink('Open initial snapshot', row.metadata?.initialSnapshotRef);
+    addLink('Open final snapshot', row.metadata?.finalSnapshotRef);
+    addLink('Open raw events', row.metadata?.rawEventsRef);
+    addLink('Open normalized events', row.metadata?.normalizedEventsRef);
+    addLink('Open external state', row.metadata?.externalStateRef);
   }
 
   return links;
@@ -5646,6 +5646,7 @@ function BridgeSessionLogsPanel({
   projection,
   optimisticMessages,
   setOptimisticMessages,
+  actionsEnabled = false,
 }: {
   apiBase: string;
   bridgeSessionId: string;
@@ -5653,6 +5654,7 @@ function BridgeSessionLogsPanel({
   projection: BridgeSessionProjection;
   optimisticMessages: OptimisticChatSessionMessage[];
   setOptimisticMessages: Dispatch<SetStateAction<OptimisticChatSessionMessage[]>>;
+  actionsEnabled?: boolean;
 }) {
   const [logContent, setLogContent] = useState<TimelineRow[]>([]);
   const [viewerState, setViewerState] = useState<LogViewerState>('starting');
@@ -5793,6 +5795,11 @@ function BridgeSessionLogsPanel({
     };
     es.onmessage = handleBridgeEvent;
     es.addEventListener('bridge_event', handleBridgeEvent);
+    es.addEventListener('terminal', () => {
+      if (cancelled) return;
+      setViewerState('ended');
+      void eventsQuery.refetch();
+    });
     es.onerror = () => {
       es.close();
       esRef.current = null;
@@ -5820,23 +5827,23 @@ function BridgeSessionLogsPanel({
     if (logContent.length === 0) return;
     copyTextToClipboard(logContent.map((line) => getCopyableRowText(line)).join('\n'));
   };
-  const canSend = Boolean(projection.providerSessionRef && projection.capabilities.sendFollowUp && !isTerminal);
-  const canInterrupt = Boolean(projection.providerSessionRef && projection.capabilities.interruptTurn && !isTerminal);
-  const canClear = Boolean(projection.providerSessionRef && projection.capabilities.clearSession && !isTerminal);
-  const canCancel = Boolean(projection.providerSessionRef && projection.capabilities.cancelSession && !isTerminal);
+  const canSend = Boolean(actionsEnabled && projection.providerSessionRef && projection.capabilities.sendFollowUp && !isTerminal);
+  const canInterrupt = Boolean(actionsEnabled && projection.providerSessionRef && projection.capabilities.interruptTurn && !isTerminal);
+  const canClear = Boolean(actionsEnabled && projection.providerSessionRef && projection.capabilities.clearSession && !isTerminal);
+  const canCancel = Boolean(actionsEnabled && projection.providerSessionRef && projection.capabilities.cancelSession && !isTerminal);
   const canResolveElicitation = Boolean(
-    projection.providerSessionRef && projection.capabilities.resolveElicitation && !isTerminal,
+    actionsEnabled && projection.providerSessionRef && projection.capabilities.resolveElicitation && !isTerminal,
   );
   const pendingElicitations = useMemo(() => {
     if (!canResolveElicitation) return [];
     const resolvedIds = new Set(logContent
       .filter((row) => ['approval_resolved', 'approval_granted', 'approval_denied', 'intervention_resolved'].includes(row.kind ?? ''))
-      .map((row) => String(row.metadata.elicitationId ?? row.metadata.requestId ?? '').trim())
+      .map((row) => String(row.metadata?.elicitationId ?? row.metadata?.requestId ?? '').trim())
       .filter(Boolean));
     const pending = new Map<string, string>();
     for (const row of logContent) {
       if (!['approval_requested', 'intervention_requested'].includes(row.kind ?? '')) continue;
-      const id = String(row.metadata.elicitationId ?? row.metadata.requestId ?? '').trim();
+      const id = String(row.metadata?.elicitationId ?? row.metadata?.requestId ?? '').trim();
       if (id && !resolvedIds.has(id)) pending.set(id, row.text || 'Operator decision requested.');
     }
     return Array.from(pending, ([id, text]) => ({ id, text }));
@@ -5853,7 +5860,7 @@ function BridgeSessionLogsPanel({
     setMessage(''); setControlError(null); setControlBusy(true);
     try {
       await postBridgeSessionControl(apiBase, projection.providerSessionRef, {
-        type: 'session.input', message: text, clientEventKey,
+        type: 'message', message: text, clientEventKey,
       });
       setOptimisticMessages((items) => items.map((item) => item.clientEventKey === clientEventKey
         ? { ...item, status: 'delivery_unknown' } : item));
@@ -5940,8 +5947,8 @@ function BridgeSessionLogsPanel({
             </section>
           ))}
           {canInterrupt ? <button type="button" className="secondary" onClick={() => void interrupt()} disabled={controlBusy}>Interrupt turn</button> : null}
-          {canClear ? <button type="button" className="secondary" onClick={() => void runControl({ type: 'clear_session' })} disabled={controlBusy}>Clear session</button> : null}
-          {canCancel ? <button type="button" className="danger" onClick={() => void runControl({ type: 'session.cancel' })} disabled={controlBusy}>Cancel session</button> : null}
+          {canClear ? <button type="button" className="secondary" onClick={() => { if (window.confirm('Clear this bridge session?')) void runControl({ type: 'clear_session' }); }} disabled={controlBusy}>Clear session</button> : null}
+          {canCancel ? <button type="button" className="danger" onClick={() => { if (window.confirm('Cancel this bridge session?')) void runControl({ type: 'session.cancel' }); }} disabled={controlBusy}>Cancel session</button> : null}
         </section>
       ) : null}
     </div>
@@ -7653,6 +7660,7 @@ function WorkflowDetailPageContent({ payload }: { payload: BootPayload }) {
     execution &&
       detailSubroute === 'chat' &&
       !resolvedAgentRunId &&
+      !explicitBridgeSessionId &&
       workflowId,
   );
   const bridgeResolutionQuery = useQuery({
@@ -7669,7 +7677,11 @@ function WorkflowDetailPageContent({ payload }: { payload: BootPayload }) {
   });
   const resolvedBridgeSessionId =
     explicitBridgeSessionId || bridgeResolutionQuery.data?.bridgeSessionId || '';
-  const resolvedBridgeProjection: BridgeSessionProjection = bridgeResolutionQuery.data ?? {
+  const resolvedBridgeProjection: BridgeSessionProjection = (
+    bridgeResolutionQuery.data?.bridgeSessionId === resolvedBridgeSessionId
+      ? bridgeResolutionQuery.data
+      : undefined
+  ) ?? {
     bridgeSessionId: resolvedBridgeSessionId,
     status: execution?.status ?? undefined,
     capabilities: {},
@@ -8726,6 +8738,7 @@ function WorkflowDetailPageContent({ payload }: { payload: BootPayload }) {
                     projection={resolvedBridgeProjection}
                     optimisticMessages={chatOptimisticMessages}
                     setOptimisticMessages={setChatOptimisticMessages}
+                    actionsEnabled={actionsOn}
                   />
                 ) : bridgeResolutionQuery.isLoading ? (
                   <p className="small">Checking bridge session evidence.</p>

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -2549,6 +2549,24 @@ async function postBridgeSessionControl(
   if (!resp.ok) throw buildObservabilityRequestError(resp.status);
 }
 
+async function resolveBridgeElicitation(
+  apiBase: string,
+  providerSessionRef: string,
+  elicitationId: string,
+  decision: 'approved' | 'rejected',
+): Promise<void> {
+  const resp = await fetch(joinApiBasePath(
+    apiBase,
+    `/omnigent/v1/sessions/${encodeURIComponent(providerSessionRef)}/elicitations/${encodeURIComponent(elicitationId)}/resolve`,
+  ), {
+    method: 'POST',
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ decision }),
+  });
+  if (!resp.ok) throw buildObservabilityRequestError(resp.status);
+}
+
 async function fetchBridgeSessionEvents(
   apiBase: string,
   bridgeSessionId: string,
@@ -5804,6 +5822,25 @@ function BridgeSessionLogsPanel({
   };
   const canSend = Boolean(projection.providerSessionRef && projection.capabilities.sendFollowUp && !isTerminal);
   const canInterrupt = Boolean(projection.providerSessionRef && projection.capabilities.interruptTurn && !isTerminal);
+  const canClear = Boolean(projection.providerSessionRef && projection.capabilities.clearSession && !isTerminal);
+  const canCancel = Boolean(projection.providerSessionRef && projection.capabilities.cancelSession && !isTerminal);
+  const canResolveElicitation = Boolean(
+    projection.providerSessionRef && projection.capabilities.resolveElicitation && !isTerminal,
+  );
+  const pendingElicitations = useMemo(() => {
+    if (!canResolveElicitation) return [];
+    const resolvedIds = new Set(logContent
+      .filter((row) => ['approval_resolved', 'approval_granted', 'approval_denied', 'intervention_resolved'].includes(row.kind ?? ''))
+      .map((row) => String(row.metadata.elicitationId ?? row.metadata.requestId ?? '').trim())
+      .filter(Boolean));
+    const pending = new Map<string, string>();
+    for (const row of logContent) {
+      if (!['approval_requested', 'intervention_requested'].includes(row.kind ?? '')) continue;
+      const id = String(row.metadata.elicitationId ?? row.metadata.requestId ?? '').trim();
+      if (id && !resolvedIds.has(id)) pending.set(id, row.text || 'Operator decision requested.');
+    }
+    return Array.from(pending, ([id, text]) => ({ id, text }));
+  }, [canResolveElicitation, logContent]);
   const submitMessage = async () => {
     const text = message.trim();
     if (!text || !projection.providerSessionRef || !canSend) return;
@@ -5831,6 +5868,20 @@ function BridgeSessionLogsPanel({
     if (!projection.providerSessionRef || !canInterrupt) return;
     setControlError(null); setControlBusy(true);
     try { await postBridgeSessionControl(apiBase, projection.providerSessionRef, { type: 'session.interrupt' }); }
+    catch (error) { setControlError((error as Error).message); }
+    finally { setControlBusy(false); }
+  };
+  const runControl = async (payload: Record<string, unknown>) => {
+    if (!projection.providerSessionRef) return;
+    setControlError(null); setControlBusy(true);
+    try { await postBridgeSessionControl(apiBase, projection.providerSessionRef, payload); }
+    catch (error) { setControlError((error as Error).message); }
+    finally { setControlBusy(false); }
+  };
+  const resolveElicitation = async (elicitationId: string, decision: 'approved' | 'rejected') => {
+    if (!projection.providerSessionRef || !canResolveElicitation) return;
+    setControlError(null); setControlBusy(true);
+    try { await resolveBridgeElicitation(apiBase, projection.providerSessionRef, elicitationId, decision); }
     catch (error) { setControlError((error as Error).message); }
     finally { setControlBusy(false); }
   };
@@ -5868,7 +5919,7 @@ function BridgeSessionLogsPanel({
           </div>
         )}
       </div>
-      {(canSend || canInterrupt || optimisticMessages.length > 0) ? (
+      {(canSend || canInterrupt || canClear || canCancel || pendingElicitations.length > 0 || optimisticMessages.length > 0) ? (
         <section className="stack chat-session-controls" aria-label="Bridge session controls">
           <h3>Session Controls</h3>
           {controlError ? <div className="notice error">{controlError}</div> : null}
@@ -5879,7 +5930,18 @@ function BridgeSessionLogsPanel({
             </div>
           ))}
           {canSend ? <><label htmlFor="bridge-follow-up">Follow-up message</label><textarea id="bridge-follow-up" value={message} onChange={(event) => setMessage(event.target.value)} disabled={controlBusy} rows={3} /><button type="button" onClick={() => void submitMessage()} disabled={controlBusy || !message.trim()}>Send follow-up</button></> : null}
+          {pendingElicitations.map((elicitation) => (
+            <section key={elicitation.id} className="stack" aria-label={`Pending operator request ${elicitation.id}`}>
+              <p>{elicitation.text}</p>
+              <div className="button-group">
+                <button type="button" onClick={() => void resolveElicitation(elicitation.id, 'approved')} disabled={controlBusy}>Approve</button>
+                <button type="button" className="secondary" onClick={() => void resolveElicitation(elicitation.id, 'rejected')} disabled={controlBusy}>Reject</button>
+              </div>
+            </section>
+          ))}
           {canInterrupt ? <button type="button" className="secondary" onClick={() => void interrupt()} disabled={controlBusy}>Interrupt turn</button> : null}
+          {canClear ? <button type="button" className="secondary" onClick={() => void runControl({ type: 'clear_session' })} disabled={controlBusy}>Clear session</button> : null}
+          {canCancel ? <button type="button" className="danger" onClick={() => void runControl({ type: 'session.cancel' })} disabled={controlBusy}>Cancel session</button> : null}
         </section>
       ) : null}
     </div>

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -1300,7 +1300,7 @@ type ChatSessionMessageEvent = {
 };
 
 type OptimisticChatSessionMessage = ChatSessionMessageEvent & {
-  status: 'pending' | 'failed';
+  status: 'pending' | 'delivery_unknown' | 'failed';
   error?: string;
 };
 
@@ -1412,6 +1412,19 @@ const BridgeSessionEventsPageSchema = z
       .object({
         schemaVersion: z.literal('moonmind.bridge-session-terminal.v1'),
         status: z.enum(['completed', 'failed', 'canceled', 'timed_out']),
+        failureClass: z.string().nullable().optional(),
+        failureCode: z.string().nullable().optional(),
+        summary: z.string().nullable().optional(),
+        diagnosticsRef: z.string().nullable().optional(),
+        captureManifestRef: z.string().nullable().optional(),
+        initialSnapshotRef: z.string().nullable().optional(),
+        finalSnapshotRef: z.string().nullable().optional(),
+        rawEventsRef: z.string().nullable().optional(),
+        normalizedEventsRef: z.string().nullable().optional(),
+        externalStateRef: z.string().nullable().optional(),
+        cleanupState: z.string().nullable().optional(),
+        leaseReleaseState: z.string().nullable().optional(),
+        evidenceIncompleteReason: z.string().nullable().optional(),
       })
       .passthrough()
       .nullable()
@@ -1423,6 +1436,8 @@ const BridgeSessionEventsPageSchema = z
     sessionSnapshot: undefined,
     nextCursor: page.nextCursor,
     hasMore: page.hasMore,
+    terminal: page.terminal,
+    terminalEnvelope: page.terminalEnvelope ?? null,
   }));
 
 const ObservabilityEventsResponseSchema = z.union([
@@ -2471,6 +2486,8 @@ type BridgeSessionProjection = {
   agentRunId?: string | undefined;
   idempotencyKey?: string | undefined;
   status?: string | undefined;
+  providerSessionRef?: string | undefined;
+  capabilities: Record<string, boolean>;
 };
 
 function bridgeSessionRoute(apiBase: string, bridgeSessionId: string, suffix: 'events' | 'stream'): string {
@@ -2514,7 +2531,22 @@ async function resolveBridgeSessionProjection({
     agentRunId: typeof body.agentRunId === 'string' ? body.agentRunId : undefined,
     idempotencyKey: typeof body.idempotencyKey === 'string' ? body.idempotencyKey : undefined,
     status: typeof body.status === 'string' ? body.status : undefined,
+    providerSessionRef: typeof body.providerSessionRef === 'string' ? body.providerSessionRef : undefined,
+    capabilities: body.capabilities && typeof body.capabilities === 'object'
+      ? Object.fromEntries(Object.entries(body.capabilities).filter((entry): entry is [string, boolean] => typeof entry[1] === 'boolean'))
+      : {},
   };
+}
+
+async function postBridgeSessionControl(
+  apiBase: string,
+  providerSessionRef: string,
+  payload: Record<string, unknown>,
+): Promise<void> {
+  const resp = await fetch(joinApiBasePath(apiBase, `/omnigent/v1/sessions/${encodeURIComponent(providerSessionRef)}/events`), {
+    method: 'POST', credentials: 'include', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(payload),
+  });
+  if (!resp.ok) throw buildObservabilityRequestError(resp.status);
 }
 
 async function fetchBridgeSessionEvents(
@@ -2524,6 +2556,8 @@ async function fetchBridgeSessionEvents(
   const events: z.infer<typeof ObservabilityEventSchema>[] = [];
   let cursor: string | null = null;
   let truncated = false;
+  let terminalEnvelope: z.infer<typeof BridgeSessionEventsPageSchema>['terminalEnvelope'] = null;
+  let terminal = false;
   do {
     const route = bridgeSessionRoute(apiBase, bridgeSessionId, 'events');
     const url = cursor ? `${route}?cursor=${encodeURIComponent(cursor)}` : route;
@@ -2535,12 +2569,14 @@ async function fetchBridgeSessionEvents(
     const page = BridgeSessionEventsPageSchema.parse(await resp.json());
     events.push(...page.events);
     truncated ||= page.truncated;
+    terminal ||= page.terminal;
+    terminalEnvelope = page.terminalEnvelope ?? terminalEnvelope;
     cursor = page.hasMore ? page.nextCursor : null;
     if (page.hasMore && cursor == null) {
       throw new Error('Bridge event page hasMore without nextCursor');
     }
   } while (cursor != null);
-  return { events, truncated, sessionSnapshot: undefined };
+  return { events, truncated, sessionSnapshot: undefined, terminal, terminalEnvelope };
 }
 
 async function fetchStepLedger(stepsHref: string): Promise<z.infer<typeof StepLedgerSnapshotSchema>> {
@@ -3377,6 +3413,12 @@ function buildTimelineArtifactLinks(row: TimelineRow, apiBase: string): Timeline
       row.metadata.resetBoundaryRef ?? (row.kind === 'session_reset_boundary' ? row.metadata.artifactRef : null),
     );
   }
+  if (row.metadata.terminalStatus) {
+    addLink('Open diagnostics', row.metadata.diagnosticsRef);
+    addLink('Open capture manifest', row.metadata.captureManifestRef);
+    addLink('Open final snapshot', row.metadata.finalSnapshotRef);
+    addLink('Open normalized events', row.metadata.normalizedEventsRef);
+  }
 
   return links;
 }
@@ -3521,6 +3563,12 @@ function chatBlockArtifactLinks(block: ProjectedChatBlock, apiBase: string): Tim
       metadata.resetBoundaryRef ?? (sourceKind === 'session_reset_boundary' ? metadata.artifactRef : null),
     );
   }
+  if (metadata.terminalStatus) {
+    addLink('Open diagnostics', metadata.diagnosticsRef);
+    addLink('Open capture manifest', metadata.captureManifestRef);
+    addLink('Open final snapshot', metadata.finalSnapshotRef);
+    addLink('Open normalized events', metadata.normalizedEventsRef);
+  }
 
   return links;
 }
@@ -3607,15 +3655,18 @@ function ChatSessionView({
   chatBlocks,
   rows,
   wrapLines,
+  liveAnnouncement,
 }: {
   apiBase: string;
   chatBlocks: ProjectedChatBlock[];
   rows: TimelineRow[];
   wrapLines: boolean;
+  liveAnnouncement?: string | undefined;
 }) {
   const hasFallbackRows = rows.some((row) => row.rowType === 'fallback' || row.rowType === 'output');
   return (
     <div className="chat-session-view" aria-label="Chat session projection">
+      {liveAnnouncement ? <div className="sr-only" aria-live="polite" aria-atomic="true">{liveAnnouncement}</div> : null}
       <div className="chat-session-header">
         <div>
           <h3>Chat Session</h3>
@@ -3959,6 +4010,7 @@ function StepObservabilityGroup({
   workflowId: string;
   routes: AgentRunRouteTemplates;
 }) {
+  const [bridgeOptimisticMessages, setBridgeOptimisticMessages] = useState<OptimisticChatSessionMessage[]>([]);
   const agentRunId = row.refs.agentRunId;
   const explicitBridgeSessionId =
     row.refs.bridgeSessionId ||
@@ -4008,6 +4060,9 @@ function StepObservabilityGroup({
           apiBase={apiBase}
           bridgeSessionId={bridgeSessionId}
           isTerminal={stepTerminal(row.status)}
+          projection={bridgeResolutionQuery.data ?? { bridgeSessionId, capabilities: {} }}
+          optimisticMessages={bridgeOptimisticMessages}
+          setOptimisticMessages={setBridgeOptimisticMessages}
         />
       );
     }
@@ -5564,20 +5619,30 @@ function BridgeSessionLogsPanel({
   apiBase,
   bridgeSessionId,
   isTerminal,
+  projection,
+  optimisticMessages,
+  setOptimisticMessages,
 }: {
   apiBase: string;
   bridgeSessionId: string;
   isTerminal: boolean;
+  projection: BridgeSessionProjection;
+  optimisticMessages: OptimisticChatSessionMessage[];
+  setOptimisticMessages: Dispatch<SetStateAction<OptimisticChatSessionMessage[]>>;
 }) {
   const [logContent, setLogContent] = useState<TimelineRow[]>([]);
   const [viewerState, setViewerState] = useState<LogViewerState>('starting');
   const [wrapLines, setWrapLines] = useState(true);
+  const [liveAnnouncement, setLiveAnnouncement] = useState('');
+  const [message, setMessage] = useState('');
+  const [controlError, setControlError] = useState<string | null>(null);
+  const [controlBusy, setControlBusy] = useState(false);
   const lastSeqRef = useRef<number | null>(null);
   const esRef = useRef<EventSource | null>(null);
   const isVisible = usePageVisibility();
   const chatBlocks = useMemo(
-    () => reduceTimelineRowsToChatBlocks(logContent, bridgeSessionId),
-    [bridgeSessionId, logContent],
+    () => reduceTimelineRowsToChatBlocks(logContent, bridgeSessionId, optimisticMessages),
+    [bridgeSessionId, logContent, optimisticMessages],
   );
 
   const eventsQuery = useQuery({
@@ -5589,6 +5654,42 @@ function BridgeSessionLogsPanel({
   });
   const historyRows = useMemo(() => {
     const rows = mapEventsToTimelineRows(eventsQuery.data);
+    const envelope = eventsQuery.data && 'terminalEnvelope' in eventsQuery.data
+      ? eventsQuery.data.terminalEnvelope
+      : null;
+    if (envelope) {
+      const refs = [
+        envelope.diagnosticsRef,
+        envelope.captureManifestRef,
+        envelope.initialSnapshotRef,
+        envelope.finalSnapshotRef,
+        envelope.rawEventsRef,
+        envelope.normalizedEventsRef,
+        envelope.externalStateRef,
+      ].filter((ref): ref is string => Boolean(ref));
+      const details = [
+        envelope.failureClass ? `Failure class: ${envelope.failureClass}.` : '',
+        envelope.failureCode ? `Reason: ${envelope.failureCode}.` : '',
+        envelope.evidenceIncompleteReason ? `Evidence incomplete: ${envelope.evidenceIncompleteReason}` : '',
+        envelope.cleanupState ? `Cleanup: ${envelope.cleanupState}.` : '',
+      ].filter(Boolean).join(' ');
+      rows.push({
+        id: `${bridgeSessionId}-terminal-envelope`,
+        text: [envelope.summary || `Session ${envelope.status}.`, details].filter(Boolean).join(' '),
+        stream: 'system',
+        kind: envelope.status === 'completed' ? 'response_completed' : 'response_failed',
+        sequence: Math.max(0, ...rows.map((row) => row.sequence ?? 0)) + 1,
+        timestamp: null,
+        sessionId: bridgeSessionId,
+        sessionEpoch: null,
+        containerId: null,
+        threadId: null,
+        turnId: null,
+        activeTurnId: null,
+        metadata: { terminalStatus: envelope.status, artifactRefs: refs, ...envelope },
+        rowType: 'boundary',
+      });
+    }
     if (!eventsQuery.data?.truncated) return rows;
     return [{
       id: `${bridgeSessionId}-retention-gap`,
@@ -5651,6 +5752,9 @@ function BridgeSessionLogsPanel({
         const data = ObservabilityEventSchema.parse(JSON.parse(event.data));
         lastSeqRef.current = data.sequence;
         setLogContent((prev) => [...prev, ...eventToTimelineRows(data)]);
+        if (data.kind !== 'assistant_message_delta') {
+          setLiveAnnouncement('New session activity is available.');
+        }
       } catch {
         // Ignore malformed bridge events; the fetched event index remains visible.
       }
@@ -5688,6 +5792,38 @@ function BridgeSessionLogsPanel({
     if (logContent.length === 0) return;
     copyTextToClipboard(logContent.map((line) => getCopyableRowText(line)).join('\n'));
   };
+  const canSend = Boolean(projection.providerSessionRef && projection.capabilities.sendFollowUp && !isTerminal);
+  const canInterrupt = Boolean(projection.providerSessionRef && projection.capabilities.interruptTurn && !isTerminal);
+  const submitMessage = async () => {
+    const text = message.trim();
+    if (!text || !projection.providerSessionRef || !canSend) return;
+    const clientEventKey = crypto.randomUUID();
+    const optimistic: OptimisticChatSessionMessage = {
+      type: 'chat_session.message_submitted', clientEventKey, sessionId: bridgeSessionId,
+      sessionEpoch: 0, message: text, status: 'pending',
+    };
+    setOptimisticMessages((items) => [...items, optimistic]);
+    setMessage(''); setControlError(null); setControlBusy(true);
+    try {
+      await postBridgeSessionControl(apiBase, projection.providerSessionRef, {
+        type: 'session.input', message: text, clientEventKey,
+      });
+      setOptimisticMessages((items) => items.map((item) => item.clientEventKey === clientEventKey
+        ? { ...item, status: 'delivery_unknown' } : item));
+    } catch (error) {
+      const detail = (error as Error).message;
+      setControlError(detail);
+      setOptimisticMessages((items) => items.map((item) => item.clientEventKey === clientEventKey
+        ? { ...item, status: 'failed', error: detail } : item));
+    } finally { setControlBusy(false); }
+  };
+  const interrupt = async () => {
+    if (!projection.providerSessionRef || !canInterrupt) return;
+    setControlError(null); setControlBusy(true);
+    try { await postBridgeSessionControl(apiBase, projection.providerSessionRef, { type: 'session.interrupt' }); }
+    catch (error) { setControlError((error as Error).message); }
+    finally { setControlBusy(false); }
+  };
 
   return (
     <div className="stack live-logs-panel">
@@ -5707,7 +5843,7 @@ function BridgeSessionLogsPanel({
           <div className="live-logs-empty">(waiting for bridge session events...)</div>
         ) : (
           <div data-testid="chat-session-viewer" className="chat-session-viewer">
-            <ChatSessionView apiBase={apiBase} chatBlocks={chatBlocks} rows={logContent} wrapLines={wrapLines} />
+            <ChatSessionView apiBase={apiBase} chatBlocks={chatBlocks} rows={logContent} wrapLines={wrapLines} liveAnnouncement={liveAnnouncement} />
             <details className="raw-timeline-escape-hatch">
               <summary>Raw Timeline</summary>
               <div data-testid="live-logs-timeline-viewer" className="live-logs-viewer">
@@ -5722,6 +5858,20 @@ function BridgeSessionLogsPanel({
           </div>
         )}
       </div>
+      {(canSend || canInterrupt || optimisticMessages.length > 0) ? (
+        <section className="stack chat-session-controls" aria-label="Bridge session controls">
+          <h3>Session Controls</h3>
+          {controlError ? <div className="notice error">{controlError}</div> : null}
+          {optimisticMessages.map((item) => (
+            <div key={item.clientEventKey} role="status" className={`chat-session-message chat-session-message-${item.status}`}>
+              Operator message · {item.status === 'pending' ? 'Sending' : item.status === 'failed' ? 'Failed' : 'Delivery confirmation pending'}
+              {item.error ? `: ${item.error}` : null}
+            </div>
+          ))}
+          {canSend ? <><label htmlFor="bridge-follow-up">Follow-up message</label><textarea id="bridge-follow-up" value={message} onChange={(event) => setMessage(event.target.value)} disabled={controlBusy} rows={3} /><button type="button" onClick={() => void submitMessage()} disabled={controlBusy || !message.trim()}>Send follow-up</button></> : null}
+          {canInterrupt ? <button type="button" className="secondary" onClick={() => void interrupt()} disabled={controlBusy}>Interrupt turn</button> : null}
+        </section>
+      ) : null}
     </div>
   );
 }
@@ -7431,7 +7581,6 @@ function WorkflowDetailPageContent({ payload }: { payload: BootPayload }) {
     execution &&
       detailSubroute === 'chat' &&
       !resolvedAgentRunId &&
-      !explicitBridgeSessionId &&
       workflowId,
   );
   const bridgeResolutionQuery = useQuery({
@@ -7448,6 +7597,11 @@ function WorkflowDetailPageContent({ payload }: { payload: BootPayload }) {
   });
   const resolvedBridgeSessionId =
     explicitBridgeSessionId || bridgeResolutionQuery.data?.bridgeSessionId || '';
+  const resolvedBridgeProjection: BridgeSessionProjection = bridgeResolutionQuery.data ?? {
+    bridgeSessionId: resolvedBridgeSessionId,
+    status: execution?.status ?? undefined,
+    capabilities: {},
+  };
   const shouldFetchRemediationLinks = Boolean(execution && workflowId);
   const sessionTimelineEnabled = shouldEnableSessionTimelineViewer({
     config: cfg,
@@ -8497,6 +8651,9 @@ function WorkflowDetailPageContent({ payload }: { payload: BootPayload }) {
                     apiBase={payload.apiBase}
                     bridgeSessionId={resolvedBridgeSessionId}
                     isTerminal={isTerminalExecution}
+                    projection={resolvedBridgeProjection}
+                    optimisticMessages={chatOptimisticMessages}
+                    setOptimisticMessages={setChatOptimisticMessages}
                   />
                 ) : bridgeResolutionQuery.isLoading ? (
                   <p className="small">Checking bridge session evidence.</p>

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -4905,6 +4905,10 @@ export interface components {
             hostBindingRef?: string | null;
             /** Providersessionref */
             providerSessionRef?: string | null;
+            /** Capabilities */
+            capabilities?: {
+                [key: string]: boolean;
+            };
         };
         /** BridgeTerminalEnvelope */
         BridgeTerminalEnvelope: {

--- a/moonmind/omnigent/bridge_proxy.py
+++ b/moonmind/omnigent/bridge_proxy.py
@@ -301,14 +301,26 @@ class OmnigentBridgeSessionProxy:
         # before the journal write landed, a retry finds the session already
         # attached; re-emitting here (the store append is idempotent) prevents the
         # session.created event from being permanently lost on partial failure.
+        snapshot = await self._best_effort_snapshot(session_id)
+        raw_capabilities = snapshot.get("interventionCapabilities")
+        if not isinstance(raw_capabilities, dict):
+            raw_capabilities = snapshot.get("capabilities")
+        capabilities = (
+            {
+                key: value
+                for key, value in raw_capabilities.items()
+                if isinstance(key, str) and isinstance(value, bool)
+            }
+            if isinstance(raw_capabilities, dict)
+            else None
+        )
         await self._run_store.record_session_created(
             exec_request.idempotency_key,
             session_id=session_id,
             agent_id=target.agent_id,
             endpoint_ref=endpoint_ref,
+            capabilities=capabilities,
         )
-
-        snapshot = await self._best_effort_snapshot(session_id)
         return self._session_response(
             snapshot=snapshot,
             session_id=session_id,
@@ -335,13 +347,26 @@ class OmnigentBridgeSessionProxy:
 
         endpoint_ref = str(getattr(row, "omnigent_endpoint_ref", None) or "default")
         agent_id = getattr(row, "omnigent_agent_id", None)
+        snapshot = await self._best_effort_snapshot(session_id)
+        raw_capabilities = snapshot.get("interventionCapabilities")
+        if not isinstance(raw_capabilities, dict):
+            raw_capabilities = snapshot.get("capabilities")
+        capabilities = (
+            {
+                key: value
+                for key, value in raw_capabilities.items()
+                if isinstance(key, str) and isinstance(value, bool)
+            }
+            if isinstance(raw_capabilities, dict)
+            else None
+        )
         await self._run_store.record_session_created(
             exec_request.idempotency_key,
             session_id=session_id,
             agent_id=agent_id,
             endpoint_ref=endpoint_ref,
+            capabilities=capabilities,
         )
-        snapshot = await self._best_effort_snapshot(session_id)
         return self._session_response(
             snapshot=snapshot,
             session_id=session_id,

--- a/moonmind/omnigent/bridge_store.py
+++ b/moonmind/omnigent/bridge_store.py
@@ -622,6 +622,7 @@ class OmnigentBridgeSessionStore:
         session_id: str,
         agent_id: str | None = None,
         endpoint_ref: str | None = None,
+        capabilities: dict[str, bool] | None = None,
     ) -> OmnigentBridgeSession:
         """Emit ``session.created`` into the durable bridge event journal.
 
@@ -643,6 +644,10 @@ class OmnigentBridgeSessionStore:
             already_recorded = any(
                 entry.get("type") == SESSION_CREATED_EVENT_TYPE for entry in journal
             )
+            changed = False
+            if capabilities is not None:
+                metadata["interventionCapabilities"] = capabilities
+                changed = True
             if not already_recorded:
                 journal.append(
                     {
@@ -655,6 +660,8 @@ class OmnigentBridgeSessionStore:
                     }
                 )
                 metadata[BRIDGE_EVENT_JOURNAL_KEY] = journal
+                changed = True
+            if changed:
                 row.metadata_ = metadata
                 await session.commit()
                 await session.refresh(row)

--- a/tests/unit/api/routers/test_omnigent_bridge.py
+++ b/tests/unit/api/routers/test_omnigent_bridge.py
@@ -521,6 +521,27 @@ def test_resolve_bridge_session_projection_returns_latest_binding() -> None:
     assert resp.json()["workflowId"] == "mm:w1"
 
 
+def test_resolve_bridge_session_projection_filters_capabilities_to_booleans() -> None:
+    store = _FakeStore(session_overrides={"metadata_": {"interventionCapabilities": {
+        "sendFollowUp": True, "interruptTurn": False, "malformed": "yes", 7: True,
+    }}})
+    client, _, _ = _build(store=store)
+    resp = client.get(
+        f"{OMNIGENT_BRIDGE_MOUNT_PATH}/bridge-sessions/resolve?workflowId=mm%3Aw1"
+    )
+    assert resp.status_code == 200
+    assert resp.json()["capabilities"] == {"sendFollowUp": True, "interruptTurn": False}
+
+
+def test_resolve_bridge_session_projection_denies_absent_capabilities() -> None:
+    client, _, _ = _build(store=_FakeStore(session_overrides={"metadata_": {}}))
+    resp = client.get(
+        f"{OMNIGENT_BRIDGE_MOUNT_PATH}/bridge-sessions/resolve?workflowId=mm%3Aw1"
+    )
+    assert resp.status_code == 200
+    assert resp.json()["capabilities"] == {}
+
+
 def test_list_bridge_session_events_returns_chat_projection_shape() -> None:
     client, _, _ = _build()
     resp = client.get(f"{OMNIGENT_BRIDGE_MOUNT_PATH}/bridge-sessions/brs-1/events")

--- a/tests/unit/omnigent/test_bridge_proxy.py
+++ b/tests/unit/omnigent/test_bridge_proxy.py
@@ -119,19 +119,26 @@ class _FakeStore:
         return self.rows[key]
 
     async def record_session_created(
-        self, key: str, *, session_id: str, agent_id=None, endpoint_ref=None
+        self,
+        key: str,
+        *,
+        session_id: str,
+        agent_id=None,
+        endpoint_ref=None,
+        capabilities=None,
     ) -> _FakeRow:
         # Mirror the real store: session.created is recorded once per session
         # (idempotent), so create/reuse retries never duplicate the event.
         if not any(evt["key"] == key for evt in self.created_events):
-            self.created_events.append(
-                {
+            event = {
                     "key": key,
                     "session_id": session_id,
                     "agent_id": agent_id,
                     "endpoint_ref": endpoint_ref,
                 }
-            )
+            if capabilities is not None:
+                event["capabilities"] = capabilities
+            self.created_events.append(event)
         return self.rows.get(key)
 
 


### PR DESCRIPTION
Issue: MoonLadderStudios/MoonMind#3364

Closes MoonLadderStudios/MoonMind#3364

## Summary
- complete bridge-backed Workflow Chat projection with terminal-envelope diagnostics and durable evidence handling
- add capability-gated session controls and elicitation resolution using server-advertised state
- reconcile optimistic messages, improve accessibility and large-session behavior, and expand focused coverage

## Tests run
- `npm run ui:test -- frontend/src/entrypoints/workflow-detail.test.tsx frontend/src/lib/chatSession.test.ts` (207 passed)
- `git diff --check` (passed)
- backend pytest was not available in the managed image (`No module named pytest`); backend test definitions were inspected by the verifier

## Remaining risks
- combined-stack smoke testing with a live stock Omnigent host was not available in this runtime
- backend tests were not executed because pytest is absent from the managed image