### PR TITLE
MoonLadderStudios/MoonMind#3365: Surface harvested resources in Workflow Detail

### DIFF
--- a/api_service/api/routers/agent_runs.py
+++ b/api_service/api/routers/agent_runs.py
@@ -395,6 +395,8 @@ def _build_session_resource_list(
                 or None
             )
             resource_id = artifact.artifact_id
+            unavailable_reason = str(metadata.get("unavailableReason") or "").strip() or None
+            source_sequence = metadata.get("sourceEventSequence")
             resources.append(
                 SessionResourceModel(
                     resource_id=resource_id,
@@ -409,6 +411,24 @@ def _build_session_resource_list(
                     default_read_ref=artifact.default_read_ref,
                     preview_artifact_ref=artifact.preview_artifact_ref,
                     metadata=metadata,
+                    preview_available=bool(
+                        artifact.default_read_ref or artifact.preview_artifact_ref
+                    ),
+                    download_available=artifact.status == "available",
+                    completeness_status=(
+                        "degraded" if unavailable_reason else "complete"
+                    ),
+                    unavailable_reason=unavailable_reason,
+                    source_event_sequence=(
+                        int(source_sequence)
+                        if isinstance(source_sequence, int)
+                        else None
+                    ),
+                    related_resource_ids=[
+                        str(value)
+                        for value in metadata.get("relatedResourceIds", [])
+                        if isinstance(value, str) and value.strip()
+                    ] if isinstance(metadata.get("relatedResourceIds"), list) else [],
                     content_url=_session_resource_url(
                         projection.session_id,
                         artifact.artifact_id,

--- a/api_service/api/routers/agent_runs.py
+++ b/api_service/api/routers/agent_runs.py
@@ -414,7 +414,7 @@ def _build_session_resource_list(
                     preview_available=bool(
                         artifact.default_read_ref or artifact.preview_artifact_ref
                     ),
-                    download_available=artifact.status == "available",
+                    download_available=artifact.status == "complete",
                     completeness_status=(
                         "degraded" if unavailable_reason else "complete"
                     ),

--- a/api_service/api/routers/omnigent_bridge.py
+++ b/api_service/api/routers/omnigent_bridge.py
@@ -861,9 +861,12 @@ async def get_omnigent_bridge_session_resources(
     return {
         "schemaVersion": "moonmind.omnigent.resource_projection.v1",
         "completeness": (
-            "pending" if row.status not in _BRIDGE_TERMINAL_STATUSES else "unavailable"
+            "pending" if row.status not in _BRIDGE_TERMINAL_STATUSES else "degraded"
         ),
-        "unavailableReasons": {},
+        "unavailableReasons": (
+            {} if row.status not in _BRIDGE_TERMINAL_STATUSES else
+            {"resourceProjection": "Terminal resource evidence was not published."}
+        ),
         "groups": [],
     }
 

--- a/api_service/api/routers/omnigent_bridge.py
+++ b/api_service/api/routers/omnigent_bridge.py
@@ -836,6 +836,38 @@ async def list_omnigent_bridge_session_events(
     )
 
 
+@router.get("/bridge-sessions/{bridge_session_id}/resources", response_model=dict)
+async def get_omnigent_bridge_session_resources(
+    bridge_session_id: str,
+    _enabled: OmnigentBridgeConfig = Depends(_require_bridge_enabled),
+    user: User = Depends(get_current_user()),
+    service: Any = Depends(_get_execution_service),
+    store: OmnigentBridgeSessionStore = Depends(_get_bridge_store),
+) -> dict[str, Any]:
+    """Return owner-authorized artifact evidence for one bridge session."""
+
+    await _authorize_bridge_session_projection(
+        bridge_session_id=bridge_session_id,
+        user=user,
+        service=service,
+        store=store,
+    )
+    row = await store.get_bridge_session(bridge_session_id)
+    if row is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
+    projection = dict((row.terminal_refs or {}).get("resourceProjection") or {})
+    if projection:
+        return projection
+    return {
+        "schemaVersion": "moonmind.omnigent.resource_projection.v1",
+        "completeness": (
+            "pending" if row.status not in _BRIDGE_TERMINAL_STATUSES else "unavailable"
+        ),
+        "unavailableReasons": {},
+        "groups": [],
+    }
+
+
 @router.get("/bridge-sessions/{bridge_session_id}/stream")
 async def stream_omnigent_bridge_session_events(
     bridge_session_id: str,

--- a/frontend/src/entrypoints/workflow-detail.test.tsx
+++ b/frontend/src/entrypoints/workflow-detail.test.tsx
@@ -7924,14 +7924,14 @@ describe('Workflow Detail Entrypoint', () => {
             groups: [{
               groupKey: 'changed_files',
               title: 'Changed files',
-              resources: [{
-                label: 'src/app.py',
-                artifactRef: '0198f0f0-1111-7222-8333-abcdefabcdef',
+              resources: Array.from({ length: 30 }, (_, index) => ({
+                label: index === 0 ? 'src/app.py' : `src/file-${index}.py`,
+                artifactRef: `0198f0f0-1111-7222-8333-${String(index).padStart(12, '0')}`,
                 status: 'available',
-                sourceEventSequence: 1,
+                sourceEventSequence: index + 1,
                 previewAvailable: true,
                 downloadAvailable: true,
-              }],
+              })),
             }],
           }),
         } as Response);
@@ -7953,9 +7953,52 @@ describe('Workflow Detail Entrypoint', () => {
     expect(screen.getByLabelText('Terminal outcome evidence')).toBeTruthy();
     expect(screen.getByLabelText('Open terminal final snapshot')).toBeTruthy();
     expect(screen.getByLabelText('Open terminal capture manifest')).toBeTruthy();
+    expect(screen.getByText('Showing 25 of 30 resources. Use the capture manifest for the complete bounded index.')).toBeTruthy();
+    const firstResourceAction = screen.getByLabelText('Open src/app.py');
+    firstResourceAction.focus();
+    expect(document.activeElement).toBe(firstResourceAction);
+    expect(screen.queryByLabelText('Open src/file-25.py')).toBeNull();
     expect(
       fetchSpy.mock.calls.some(([url]) => String(url).includes('/agent-runs/')),
     ).toBe(false);
+  });
+
+  it('shows an authorization error instead of resource preview or download actions', async () => {
+    window.history.pushState({}, 'Bridge Authorization Test', '/workflows/test-123/chat?source=temporal');
+    const execution = {
+      taskId: 'test-123', workflowId: 'test-123', namespace: 'default',
+      temporalRunId: 'auth-run', runId: 'auth-run', source: 'temporal',
+      title: 'Protected bridge task', summary: 'Protected evidence',
+      status: 'completed', state: 'completed', rawState: 'completed',
+      closedAt: '2026-07-09T00:00:30Z', createdAt: '2026-07-09T00:00:00Z',
+      updatedAt: '2026-07-09T00:00:30Z', actions: {},
+    };
+    fetchSpy.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/omnigent/bridge-sessions/resolve')) {
+        return Promise.resolve({ ok: true, json: async () => ({ bridgeSessionId: 'brs-auth', workflowId: 'test-123', status: 'completed' }) } as Response);
+      }
+      if (url.includes('/omnigent/bridge-sessions/brs-auth/events')) {
+        return Promise.resolve({ ok: true, json: async () => ({
+          schemaVersion: 'moonmind.bridge-session-events-page.v1', bridgeSessionId: 'brs-auth',
+          items: [], after: 0, nextCursor: null, hasMore: false, terminal: true,
+          latestSequence: 0, retentionGap: null, terminalEnvelope: null,
+        }) } as Response);
+      }
+      if (url.includes('/omnigent/bridge-sessions/brs-auth/resources')) {
+        return Promise.resolve({ ok: false, status: 403 } as Response);
+      }
+      if (url.includes('/artifacts')) {
+        return Promise.resolve({ ok: true, json: async () => ({ artifacts: [] }) } as Response);
+      }
+      return Promise.resolve({ ok: true, json: async () => execution } as Response);
+    });
+
+    renderWithClient(<WorkflowDetailPage payload={mockPayload} />);
+
+    expect(await screen.findByText('You do not have permission to view observability for this run.')).toBeTruthy();
+    expect(screen.queryByRole('link', { name: /^Open .*\.py$/ })).toBeNull();
+    expect(screen.queryByRole('link', { name: /^Download .*\.py$/ })).toBeNull();
   });
 
   it('renders artifact download link using explicit downloadUrl when present', async () => {

--- a/frontend/src/entrypoints/workflow-detail.test.tsx
+++ b/frontend/src/entrypoints/workflow-detail.test.tsx
@@ -7909,6 +7909,9 @@ describe('Workflow Detail Entrypoint', () => {
             terminalEnvelope: {
               schemaVersion: 'moonmind.bridge-session-terminal.v1',
               status: 'completed',
+              summary: 'Terminal capture completed',
+              finalSnapshotRef: '0198f0f0-2222-7333-8444-abcdefabcdef',
+              captureManifestRef: '0198f0f0-3333-7444-8555-abcdefabcdef',
             },
           }),
         } as Response);
@@ -7947,6 +7950,9 @@ describe('Workflow Detail Entrypoint', () => {
     expect(screen.queryByText(/managed runtime observability record was created/i)).toBeNull();
     expect(await screen.findByLabelText('Open src/app.py')).toBeTruthy();
     expect(screen.getByLabelText('Download src/app.py')).toBeTruthy();
+    expect(screen.getByLabelText('Terminal outcome evidence')).toBeTruthy();
+    expect(screen.getByLabelText('Open terminal final snapshot')).toBeTruthy();
+    expect(screen.getByLabelText('Open terminal capture manifest')).toBeTruthy();
     expect(
       fetchSpy.mock.calls.some(([url]) => String(url).includes('/agent-runs/')),
     ).toBe(false);

--- a/frontend/src/entrypoints/workflow-detail.test.tsx
+++ b/frontend/src/entrypoints/workflow-detail.test.tsx
@@ -7913,6 +7913,26 @@ describe('Workflow Detail Entrypoint', () => {
           }),
         } as Response);
       }
+      if (url.includes('/omnigent/bridge-sessions/brs-1/resources')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            completeness: 'complete',
+            groups: [{
+              groupKey: 'changed_files',
+              title: 'Changed files',
+              resources: [{
+                label: 'src/app.py',
+                artifactRef: '0198f0f0-1111-7222-8333-abcdefabcdef',
+                status: 'available',
+                sourceEventSequence: 1,
+                previewAvailable: true,
+                downloadAvailable: true,
+              }],
+            }],
+          }),
+        } as Response);
+      }
       if (url.includes('/artifacts')) {
         return Promise.resolve({ ok: true, json: async () => ({ artifacts: [] }) } as Response);
       }
@@ -7925,6 +7945,8 @@ describe('Workflow Detail Entrypoint', () => {
       expect(screen.getAllByText('Bridge assistant output').length).toBeGreaterThan(0);
     });
     expect(screen.queryByText(/managed runtime observability record was created/i)).toBeNull();
+    expect(await screen.findByLabelText('Open src/app.py')).toBeTruthy();
+    expect(screen.getByLabelText('Download src/app.py')).toBeTruthy();
     expect(
       fetchSpy.mock.calls.some(([url]) => String(url).includes('/agent-runs/')),
     ).toBe(false);

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -1255,6 +1255,14 @@ const SessionResourceSchema = z
     contentUrl: z.string().optional(),
     download_url: z.string().optional(),
     downloadUrl: z.string().optional(),
+    preview_available: z.boolean().optional(),
+    previewAvailable: z.boolean().optional(),
+    download_available: z.boolean().optional(),
+    downloadAvailable: z.boolean().optional(),
+    completeness_status: z.enum(['complete', 'degraded', 'pending']).optional(),
+    completenessStatus: z.enum(['complete', 'degraded', 'pending']).optional(),
+    unavailable_reason: z.string().nullable().optional(),
+    unavailableReason: z.string().nullable().optional(),
     metadata: z.record(z.string(), z.unknown()).default({}),
   })
   .passthrough()
@@ -1268,6 +1276,10 @@ const SessionResourceSchema = z
     sizeBytes: resource.sizeBytes ?? resource.size_bytes ?? null,
     contentUrl: resource.contentUrl ?? resource.content_url ?? null,
     downloadUrl: resource.downloadUrl ?? resource.download_url ?? null,
+    previewAvailable: resource.previewAvailable ?? resource.preview_available ?? false,
+    downloadAvailable: resource.downloadAvailable ?? resource.download_available ?? true,
+    completenessStatus: resource.completenessStatus ?? resource.completeness_status ?? 'complete',
+    unavailableReason: resource.unavailableReason ?? resource.unavailable_reason ?? null,
     metadata: resource.metadata ?? {},
   }));
 
@@ -6298,6 +6310,15 @@ function SessionContinuityPanel({
 
   const projection = projectionQuery.data;
   const sessionResources = resourcesQuery.data?.resources ?? [];
+  const sessionResourceGroups = Array.from(
+    sessionResources.reduce((groups, resource) => {
+      const key = resource.groupKey || 'resources';
+      const existing = groups.get(key) ?? { title: resource.groupTitle, resources: [] as typeof sessionResources };
+      existing.resources.push(resource);
+      groups.set(key, existing);
+      return groups;
+    }, new Map<string, { title: string; resources: typeof sessionResources }>()),
+  );
   const latestBadges = [
     ['Latest Summary', projection.latest_summary_ref?.artifact_id ?? null],
     ['Latest Checkpoint', projection.latest_checkpoint_ref?.artifact_id ?? null],
@@ -6476,8 +6497,11 @@ function SessionContinuityPanel({
       {!compact && sessionResources.length > 0 ? (
         <div className="stack">
           <h4>Resource Evidence</h4>
-          <div className="grid-2">
-            {sessionResources.map((resource) => {
+          {sessionResourceGroups.map(([groupKey, group]) => (
+          <details key={groupKey} className="card" open={group.resources.length <= 8}>
+            <summary>{group.title} ({group.resources.length})</summary>
+            <div className="grid-2" style={{ marginTop: '0.5rem' }}>
+            {group.resources.map((resource) => {
               const label = resource.label || resource.artifactId;
               const contentHref = resource.contentUrl
                 ? resolveApiBaseTemplate(apiBase, resource.contentUrl)
@@ -6488,20 +6512,23 @@ function SessionContinuityPanel({
               return (
                 <div key={resource.resourceId || resource.artifactId} className="card">
                   <strong>{label}</strong>
-                  <div className="small">{resource.groupTitle}</div>
+                  <div className="small">{resource.completenessStatus === 'pending' ? 'Harvesting…' : resource.completenessStatus}</div>
                   <code className="text-xs break-all">{resource.artifactId}</code>
+                  {resource.unavailableReason ? <p className="small notice warning">{resource.unavailableReason}</p> : null}
                   <div className="actions" style={{ marginTop: '0.5rem' }}>
-                    <a className="button secondary small" href={contentHref} target="_blank" rel="noreferrer">
+                    {resource.previewAvailable ? <a aria-label={`Open ${label}`} className="button secondary small" href={contentHref} target="_blank" rel="noreferrer">
                       Open
-                    </a>
-                    <a className="button secondary small" href={downloadHref} target="_blank" rel="noreferrer">
+                    </a> : null}
+                    {resource.downloadAvailable ? <a aria-label={`Download ${label}`} className="button secondary small" href={downloadHref} target="_blank" rel="noreferrer">
                       Download
-                    </a>
+                    </a> : null}
                   </div>
                 </div>
               );
             })}
-          </div>
+            </div>
+          </details>
+          ))}
         </div>
       ) : null}
 

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -2485,11 +2485,36 @@ type BridgeSessionProjection = {
   status?: string | undefined;
 };
 
-function bridgeSessionRoute(apiBase: string, bridgeSessionId: string, suffix: 'events' | 'stream'): string {
+function bridgeSessionRoute(apiBase: string, bridgeSessionId: string, suffix: 'events' | 'stream' | 'resources'): string {
   return joinApiBasePath(
     apiBase,
     `/omnigent/bridge-sessions/${encodeURIComponent(bridgeSessionId)}/${suffix}`,
   );
+}
+
+type BridgeResourceProjection = {
+  completeness: string;
+  groups: Array<{ groupKey: string; title: string; resources: Array<{
+    label: string;
+    artifactRef?: string;
+    relatedArtifactRefs?: string[];
+    path?: string;
+    status: string;
+    unavailableReason?: string;
+    sourceEventSequence?: number;
+    previewAvailable?: boolean;
+    downloadAvailable?: boolean;
+  }> }>;
+};
+
+async function fetchBridgeSessionResources(apiBase: string, bridgeSessionId: string): Promise<BridgeResourceProjection> {
+  const resp = await fetch(bridgeSessionRoute(apiBase, bridgeSessionId, 'resources'), { credentials: 'include' });
+  if (!resp.ok) throw buildObservabilityRequestError(resp.status);
+  const body = (await resp.json()) as Partial<BridgeResourceProjection>;
+  return {
+    completeness: body.completeness || 'pending',
+    groups: Array.isArray(body.groups) ? body.groups : [],
+  };
 }
 
 async function resolveBridgeSessionProjection({
@@ -5599,6 +5624,13 @@ function BridgeSessionLogsPanel({
     staleTime: Infinity,
     retry: false,
   });
+  const resourcesQuery = useQuery({
+    queryKey: ['omnigent-bridge-session-resources', bridgeSessionId],
+    queryFn: () => fetchBridgeSessionResources(apiBase, bridgeSessionId),
+    enabled: Boolean(bridgeSessionId),
+    refetchInterval: isTerminal ? false : SESSION_PROJECTION_POLL_MS,
+    retry: false,
+  });
   const historyRows = useMemo(() => {
     const rows = mapEventsToTimelineRows(eventsQuery.data);
     if (!eventsQuery.data?.truncated) return rows;
@@ -5714,6 +5746,38 @@ function BridgeSessionLogsPanel({
       <p className="small">
         Bridge session <code className="text-xs">{bridgeSessionId}</code> - {statusLabel}
       </p>
+      <details className="card bridge-resource-evidence" open={isTerminal}>
+        <summary>Resource evidence — {resourcesQuery.data?.completeness || 'harvesting'}</summary>
+        {resourcesQuery.data?.groups.some((group) => group.resources.length > 0) ? (
+          <div className="stack" style={{ marginTop: '0.75rem' }}>
+            {resourcesQuery.data.groups.filter((group) => group.resources.length > 0).map((group) => (
+              <section key={group.groupKey} aria-label={group.title}>
+                <h4>{group.title}</h4>
+                <ul className="stack gap-1">
+                  {group.resources.map((resource, index) => {
+                    const href = resource.artifactRef ? artifactRefHref(apiBase, resource.artifactRef) : null;
+                    return (
+                      <li key={`${group.groupKey}-${resource.label}-${index}`}>
+                        <span>{resource.label}</span>
+                        {resource.path ? <code className="text-xs break-all"> — {resource.path}</code> : null}
+                        {resource.sourceEventSequence != null ? <span className="small"> (event {resource.sourceEventSequence})</span> : null}
+                        {href && resource.previewAvailable ? (
+                          <a className="button secondary small" href={href} target="_blank" rel="noreferrer" aria-label={`Open ${resource.label}`}>Open</a>
+                        ) : null}
+                        {resource.relatedArtifactRefs?.map((ref, relatedIndex) => {
+                          const relatedHref = artifactRefHref(apiBase, ref);
+                          return relatedHref ? <a key={ref} className="button secondary small" href={relatedHref} target="_blank" rel="noreferrer" aria-label={`Open related evidence ${relatedIndex + 1} for ${resource.label}`}>Related evidence</a> : null;
+                        })}
+                        {resource.unavailableReason ? <div className="small">Unavailable: {resource.unavailableReason}</div> : null}
+                      </li>
+                    );
+                  })}
+                </ul>
+              </section>
+            ))}
+          </div>
+        ) : <p className="small">{isTerminal ? 'No harvested resource evidence is available.' : 'Harvesting resource evidence…'}</p>}
+      </details>
       <div className={`live-logs-viewer-shell ${wrapLines ? 'is-wrapped' : 'is-unwrapped'}`}>
         {logContent.length === 0 ? (
           <div className="live-logs-empty">(waiting for bridge session events...)</div>

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -2529,8 +2529,9 @@ type BridgeResource = BridgeResourceProjection['groups'][number]['resources'][nu
 function chatBlockEventSequences(block: ProjectedChatBlock): Set<number> {
   const sequences = new Set<number>();
   for (const eventId of block.sourceEventIds) {
-    const match = eventId.match(/(?::seq:|:)(\d+)(?::|$)/);
-    if (match?.[1]) sequences.add(Number(match[1]));
+    const match = eventId.match(/^(\d+)-|(?::seq:|:)(\d+)(?::|$)/);
+    const sequence = match?.[1] ?? match?.[2];
+    if (sequence) sequences.add(Number(sequence));
   }
   return sequences;
 }

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -5849,6 +5849,7 @@ function BridgeSessionLogsPanel({
         : null}
       <details className="card bridge-resource-evidence" open={isTerminal}>
         <summary>Resource evidence — {resourcesQuery.data?.completeness || 'harvesting'}</summary>
+        {resourcesQuery.isError ? <div className="notice error">{(resourcesQuery.error as Error).message}</div> : null}
         {resourcesQuery.data?.groups.some((group) => group.resources.length > 0) ? (
           <div className="stack" style={{ marginTop: '0.75rem' }}>
             {resourcesQuery.data.groups.filter((group) => group.resources.length > 0).map((group) => (

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -2563,17 +2563,17 @@ function ContextualBridgeResourceLinks({
 
 type BridgeTerminalEnvelope = {
   status: 'completed' | 'failed' | 'canceled' | 'timed_out';
-  failureClass?: string | null;
-  failureCode?: string | null;
-  summary?: string | null;
-  diagnosticsRef?: string | null;
-  captureManifestRef?: string | null;
-  initialSnapshotRef?: string | null;
-  finalSnapshotRef?: string | null;
-  rawEventsRef?: string | null;
-  normalizedEventsRef?: string | null;
-  externalStateRef?: string | null;
-  evidenceIncompleteReason?: string | null;
+  failureClass?: string | null | undefined;
+  failureCode?: string | null | undefined;
+  summary?: string | null | undefined;
+  diagnosticsRef?: string | null | undefined;
+  captureManifestRef?: string | null | undefined;
+  initialSnapshotRef?: string | null | undefined;
+  finalSnapshotRef?: string | null | undefined;
+  rawEventsRef?: string | null | undefined;
+  normalizedEventsRef?: string | null | undefined;
+  externalStateRef?: string | null | undefined;
+  evidenceIncompleteReason?: string | null | undefined;
 };
 
 function BridgeTerminalEvidence({ apiBase, envelope }: { apiBase: string; envelope: BridgeTerminalEnvelope }) {

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -2507,6 +2507,42 @@ type BridgeResourceProjection = {
   }> }>;
 };
 
+type BridgeResource = BridgeResourceProjection['groups'][number]['resources'][number];
+
+function chatBlockEventSequences(block: ProjectedChatBlock): Set<number> {
+  const sequences = new Set<number>();
+  for (const eventId of block.sourceEventIds) {
+    const match = eventId.match(/(?::seq:|:)(\d+)(?::|$)/);
+    if (match?.[1]) sequences.add(Number(match[1]));
+  }
+  return sequences;
+}
+
+function ContextualBridgeResourceLinks({
+  apiBase,
+  block,
+  resources,
+}: {
+  apiBase: string;
+  block: ProjectedChatBlock;
+  resources: BridgeResource[];
+}) {
+  const sequences = chatBlockEventSequences(block);
+  const contextual = resources.filter((resource) =>
+    resource.sourceEventSequence != null && sequences.has(resource.sourceEventSequence));
+  if (contextual.length === 0) return null;
+  return <div className="timeline-artifact-links" aria-label="Resources announced by this event">
+    {contextual.map((resource, index) => {
+      const href = resource.artifactRef ? artifactRefHref(apiBase, resource.artifactRef) : null;
+      return <span key={`${resource.label}-${index}`}>
+        {href && resource.previewAvailable
+          ? <a href={href} target="_blank" rel="noreferrer" aria-label={`Open ${resource.label}`}>Open {resource.label}</a>
+          : <span>{resource.label}: {resource.status === 'pending' ? 'Harvesting…' : resource.unavailableReason || resource.status}</span>}
+      </span>;
+    })}
+  </div>;
+}
+
 async function fetchBridgeSessionResources(apiBase: string, bridgeSessionId: string): Promise<BridgeResourceProjection> {
   const resp = await fetch(bridgeSessionRoute(apiBase, bridgeSessionId, 'resources'), { credentials: 'include' });
   if (!resp.ok) throw buildObservabilityRequestError(resp.status);
@@ -3562,7 +3598,7 @@ function chatBlockArtifactLinks(block: ProjectedChatBlock, apiBase: string): Tim
   return links;
 }
 
-function renderChatBlock(block: ProjectedChatBlock, wrapLines: boolean, apiBase: string): ReactNode {
+function renderChatBlock(block: ProjectedChatBlock, wrapLines: boolean, apiBase: string, resources: BridgeResource[] = []): ReactNode {
   const className = [
     'chat-session-block',
     `chat-session-block-${block.kind}`,
@@ -3594,6 +3630,7 @@ function renderChatBlock(block: ProjectedChatBlock, wrapLines: boolean, apiBase:
           {block.text || block.toolName || 'Tool call'}
         </div>
         <TimelineArtifactLinks links={artifactLinks} />
+        <ContextualBridgeResourceLinks apiBase={apiBase} block={block} resources={resources} />
       </div>
     );
   }
@@ -3635,6 +3672,7 @@ function renderChatBlock(block: ProjectedChatBlock, wrapLines: boolean, apiBase:
         {block.text}
       </div>
       <TimelineArtifactLinks links={artifactLinks} />
+      <ContextualBridgeResourceLinks apiBase={apiBase} block={block} resources={resources} />
     </div>
   );
 }
@@ -3644,11 +3682,13 @@ function ChatSessionView({
   chatBlocks,
   rows,
   wrapLines,
+  resources = [],
 }: {
   apiBase: string;
   chatBlocks: ProjectedChatBlock[];
   rows: TimelineRow[];
   wrapLines: boolean;
+  resources?: BridgeResource[];
 }) {
   const hasFallbackRows = rows.some((row) => row.rowType === 'fallback' || row.rowType === 'output');
   return (
@@ -3676,7 +3716,7 @@ function ChatSessionView({
             data={chatBlocks}
             followOutput={(atBottom) => atBottom ? 'smooth' : false}
             computeItemKey={(index, block) => `${block.id}:${index}`}
-            itemContent={(index, block) => renderChatBlock({ ...block, id: `${block.id}:${index}` }, wrapLines, apiBase)}
+            itemContent={(index, block) => renderChatBlock({ ...block, id: `${block.id}:${index}` }, wrapLines, apiBase, resources)}
           />
         </div>
       )}
@@ -5628,7 +5668,12 @@ function BridgeSessionLogsPanel({
     queryKey: ['omnigent-bridge-session-resources', bridgeSessionId],
     queryFn: () => fetchBridgeSessionResources(apiBase, bridgeSessionId),
     enabled: Boolean(bridgeSessionId),
-    refetchInterval: isTerminal ? false : SESSION_PROJECTION_POLL_MS,
+    refetchInterval: (query) => {
+      const completeness = (query.state.data as BridgeResourceProjection | undefined)?.completeness;
+      return isTerminal && completeness && completeness !== 'pending'
+        ? false
+        : SESSION_PROJECTION_POLL_MS;
+    },
     retry: false,
   });
   const historyRows = useMemo(() => {
@@ -5754,7 +5799,7 @@ function BridgeSessionLogsPanel({
               <section key={group.groupKey} aria-label={group.title}>
                 <h4>{group.title}</h4>
                 <ul className="stack gap-1">
-                  {group.resources.map((resource, index) => {
+                  {group.resources.slice(0, 25).map((resource, index) => {
                     const href = resource.artifactRef ? artifactRefHref(apiBase, resource.artifactRef) : null;
                     return (
                       <li key={`${group.groupKey}-${resource.label}-${index}`}>
@@ -5764,6 +5809,9 @@ function BridgeSessionLogsPanel({
                         {href && resource.previewAvailable ? (
                           <a className="button secondary small" href={href} target="_blank" rel="noreferrer" aria-label={`Open ${resource.label}`}>Open</a>
                         ) : null}
+                        {href && resource.downloadAvailable ? (
+                          <a className="button secondary small" href={href} download aria-label={`Download ${resource.label}`}>Download</a>
+                        ) : null}
                         {resource.relatedArtifactRefs?.map((ref, relatedIndex) => {
                           const relatedHref = artifactRefHref(apiBase, ref);
                           return relatedHref ? <a key={ref} className="button secondary small" href={relatedHref} target="_blank" rel="noreferrer" aria-label={`Open related evidence ${relatedIndex + 1} for ${resource.label}`}>Related evidence</a> : null;
@@ -5772,6 +5820,7 @@ function BridgeSessionLogsPanel({
                       </li>
                     );
                   })}
+                  {group.resources.length > 25 ? <li className="small">Showing 25 of {group.resources.length} resources. Use the capture manifest for the complete bounded index.</li> : null}
                 </ul>
               </section>
             ))}
@@ -5783,7 +5832,13 @@ function BridgeSessionLogsPanel({
           <div className="live-logs-empty">(waiting for bridge session events...)</div>
         ) : (
           <div data-testid="chat-session-viewer" className="chat-session-viewer">
-            <ChatSessionView apiBase={apiBase} chatBlocks={chatBlocks} rows={logContent} wrapLines={wrapLines} />
+            <ChatSessionView
+              apiBase={apiBase}
+              chatBlocks={chatBlocks}
+              rows={logContent}
+              wrapLines={wrapLines}
+              resources={resourcesQuery.data?.groups.flatMap((group) => group.resources) || []}
+            />
             <details className="raw-timeline-escape-hatch">
               <summary>Raw Timeline</summary>
               <div data-testid="live-logs-timeline-viewer" className="live-logs-viewer">

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -1424,6 +1424,17 @@ const BridgeSessionEventsPageSchema = z
       .object({
         schemaVersion: z.literal('moonmind.bridge-session-terminal.v1'),
         status: z.enum(['completed', 'failed', 'canceled', 'timed_out']),
+        failureClass: z.string().nullable().optional(),
+        failureCode: z.string().nullable().optional(),
+        summary: z.string().nullable().optional(),
+        diagnosticsRef: z.string().nullable().optional(),
+        captureManifestRef: z.string().nullable().optional(),
+        initialSnapshotRef: z.string().nullable().optional(),
+        finalSnapshotRef: z.string().nullable().optional(),
+        rawEventsRef: z.string().nullable().optional(),
+        normalizedEventsRef: z.string().nullable().optional(),
+        externalStateRef: z.string().nullable().optional(),
+        evidenceIncompleteReason: z.string().nullable().optional(),
       })
       .passthrough()
       .nullable()
@@ -1435,6 +1446,7 @@ const BridgeSessionEventsPageSchema = z
     sessionSnapshot: undefined,
     nextCursor: page.nextCursor,
     hasMore: page.hasMore,
+    terminalEnvelope: page.terminalEnvelope ?? null,
   }));
 
 const ObservabilityEventsResponseSchema = z.union([
@@ -2543,6 +2555,45 @@ function ContextualBridgeResourceLinks({
   </div>;
 }
 
+type BridgeTerminalEnvelope = {
+  status: 'completed' | 'failed' | 'canceled' | 'timed_out';
+  failureClass?: string | null;
+  failureCode?: string | null;
+  summary?: string | null;
+  diagnosticsRef?: string | null;
+  captureManifestRef?: string | null;
+  initialSnapshotRef?: string | null;
+  finalSnapshotRef?: string | null;
+  rawEventsRef?: string | null;
+  normalizedEventsRef?: string | null;
+  externalStateRef?: string | null;
+  evidenceIncompleteReason?: string | null;
+};
+
+function BridgeTerminalEvidence({ apiBase, envelope }: { apiBase: string; envelope: BridgeTerminalEnvelope }) {
+  const evidence = [
+    ['Final snapshot', envelope.finalSnapshotRef],
+    ['Capture manifest', envelope.captureManifestRef],
+    ['Diagnostics', envelope.diagnosticsRef],
+    ['Raw event journal', envelope.rawEventsRef],
+    ['Normalized event journal', envelope.normalizedEventsRef],
+    ['External-state evidence', envelope.externalStateRef],
+  ] as const;
+  const links = evidence.flatMap(([label, ref]) => {
+    const href = ref ? artifactRefHref(apiBase, ref) : null;
+    return href ? [{ label, href }] : [];
+  });
+  return <section className={`notice ${envelope.status === 'completed' ? '' : 'warning'}`} aria-label="Terminal outcome evidence">
+    <strong>Terminal outcome: {formatStatusLabel(envelope.status)}</strong>
+    {envelope.summary ? <p>{envelope.summary}</p> : null}
+    {links.length > 0 ? <div className="button-group">
+      {links.map(({ label, href }) => <a key={label} className="button secondary small" href={href} target="_blank" rel="noreferrer" aria-label={`Open terminal ${label.toLowerCase()}`}>{label}</a>)}
+    </div> : null}
+    {envelope.evidenceIncompleteReason ? <p className="small">Evidence incomplete: {envelope.evidenceIncompleteReason}</p> : null}
+    {envelope.failureClass || envelope.failureCode ? <p className="small">Failure: {[envelope.failureClass, envelope.failureCode].filter(Boolean).join(' — ')}</p> : null}
+  </section>;
+}
+
 async function fetchBridgeSessionResources(apiBase: string, bridgeSessionId: string): Promise<BridgeResourceProjection> {
   const resp = await fetch(bridgeSessionRoute(apiBase, bridgeSessionId, 'resources'), { credentials: 'include' });
   if (!resp.ok) throw buildObservabilityRequestError(resp.status);
@@ -2597,6 +2648,7 @@ async function fetchBridgeSessionEvents(
   const events: z.infer<typeof ObservabilityEventSchema>[] = [];
   let cursor: string | null = null;
   let truncated = false;
+  let terminalEnvelope: BridgeTerminalEnvelope | null = null;
   do {
     const route = bridgeSessionRoute(apiBase, bridgeSessionId, 'events');
     const url = cursor ? `${route}?cursor=${encodeURIComponent(cursor)}` : route;
@@ -2608,12 +2660,13 @@ async function fetchBridgeSessionEvents(
     const page = BridgeSessionEventsPageSchema.parse(await resp.json());
     events.push(...page.events);
     truncated ||= page.truncated;
+    terminalEnvelope = page.terminalEnvelope ?? terminalEnvelope;
     cursor = page.hasMore ? page.nextCursor : null;
     if (page.hasMore && cursor == null) {
       throw new Error('Bridge event page hasMore without nextCursor');
     }
   } while (cursor != null);
-  return { events, truncated, sessionSnapshot: undefined };
+  return { events, truncated, sessionSnapshot: undefined, terminalEnvelope };
 }
 
 async function fetchStepLedger(stepsHref: string): Promise<z.infer<typeof StepLedgerSnapshotSchema>> {
@@ -5791,6 +5844,9 @@ function BridgeSessionLogsPanel({
       <p className="small">
         Bridge session <code className="text-xs">{bridgeSessionId}</code> - {statusLabel}
       </p>
+      {eventsQuery.data && 'terminalEnvelope' in eventsQuery.data && eventsQuery.data.terminalEnvelope
+        ? <BridgeTerminalEvidence apiBase={apiBase} envelope={eventsQuery.data.terminalEnvelope} />
+        : null}
       <details className="card bridge-resource-evidence" open={isTerminal}>
         <summary>Resource evidence — {resourcesQuery.data?.completeness || 'harvesting'}</summary>
         {resourcesQuery.data?.groups.some((group) => group.resources.length > 0) ? (

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -2843,6 +2843,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/omnigent/bridge-sessions/{bridge_session_id}/resources": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Omnigent Bridge Session Resources
+         * @description Return owner-authorized artifact evidence for one bridge session.
+         */
+        get: operations["get_omnigent_bridge_session_resources_api_omnigent_bridge_sessions__bridge_session_id__resources_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/omnigent/bridge-sessions/{bridge_session_id}/stream": {
         parameters: {
             query?: never;
@@ -10604,6 +10624,28 @@ export interface components {
             metadata?: {
                 [key: string]: unknown;
             };
+            /**
+             * Preview Available
+             * @default false
+             */
+            preview_available: boolean;
+            /**
+             * Download Available
+             * @default true
+             */
+            download_available: boolean;
+            /**
+             * Completeness Status
+             * @default complete
+             * @enum {string}
+             */
+            completeness_status: "complete" | "degraded" | "pending";
+            /** Unavailable Reason */
+            unavailable_reason?: string | null;
+            /** Source Event Sequence */
+            source_event_sequence?: number | null;
+            /** Related Resource Ids */
+            related_resource_ids?: string[];
             /** Content Url */
             content_url: string;
             /** Download Url */
@@ -17978,6 +18020,39 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["BridgeEventPageResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_omnigent_bridge_session_resources_api_omnigent_bridge_sessions__bridge_session_id__resources_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                bridge_session_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
                 };
             };
             /** @description Validation Error */

--- a/moonmind/omnigent/bridge_artifacts.py
+++ b/moonmind/omnigent/bridge_artifacts.py
@@ -25,6 +25,7 @@ from moonmind.schemas.agent_runtime_models import AgentExecutionRequest, AgentRu
 from moonmind.workflows.adapters.omnigent_client import OmnigentHttpClient
 
 _MAX_OMNIGENT_HARVEST_ITEMS = 100
+_CAPTURE_MANIFEST_SCHEMA_VERSION = 1
 
 
 class OmnigentContractError(RuntimeError):
@@ -1126,6 +1127,72 @@ def _patch_evidence(manifest: dict[str, Any]) -> dict[str, Any]:
     return evidence
 
 
+def _reconcile_changed_file_evidence(manifest: dict[str, Any]) -> None:
+    """Durably associate each changed file with its harvested diff outcome."""
+
+    diffs_by_path = {
+        str(item.get("path") or ""): str(item.get("artifactRef") or "")
+        for item in manifest.get("workspaceDiffs", [])
+        if isinstance(item, dict) and item.get("path") and item.get("artifactRef")
+    }
+    unavailable = str(
+        manifest.get("workspaceDiffsUnavailable")
+        or "No diff artifact was published for this changed file."
+    )
+    for changed_file in manifest.get("changedFiles", []):
+        if not isinstance(changed_file, dict) or not changed_file.get("path"):
+            continue
+        diff_ref = diffs_by_path.get(str(changed_file["path"]))
+        if diff_ref:
+            changed_file["diffArtifactRef"] = diff_ref
+            changed_file.pop("diffUnavailable", None)
+        else:
+            changed_file["diffUnavailable"] = unavailable
+
+
+def _associate_resource_events(
+    manifest: dict[str, Any], normalized_events: list[dict[str, Any]]
+) -> None:
+    """Attach harvested changed files to the durable announcing event sequence."""
+
+    sequence_by_path: dict[str, int] = {}
+    for event in normalized_events:
+        event_type = str(event.get("type") or event.get("eventType") or "")
+        if event_type != "resource.changed_file":
+            continue
+        path = _resource_path(event)
+        sequence = event.get("sequence")
+        if path and isinstance(sequence, int):
+            sequence_by_path.setdefault(path, sequence)
+    for changed_file in manifest.get("changedFiles", []):
+        if not isinstance(changed_file, dict):
+            continue
+        sequence = sequence_by_path.get(str(changed_file.get("path") or ""))
+        if sequence is not None:
+            changed_file["sourceEventSequence"] = sequence
+
+
+def _capture_resource_groups(manifest: dict[str, Any]) -> list[dict[str, Any]]:
+    """Project the manifest into stable UI-oriented evidence groups."""
+
+    definitions = (
+        ("changed_files", "Changed files", "changedFiles"),
+        ("diffs", "Diffs", "workspaceDiffs"),
+        ("workspace_files", "Workspace files", "workspaceFiles"),
+        ("session_files", "Session files", "sessionFiles"),
+        ("snapshots", "Snapshots", "snapshotEvidence"),
+        ("logs_and_journals", "Logs and event journals", "journalEvidence"),
+        ("diagnostics", "Diagnostics", "diagnosticEvidence"),
+        ("manifests", "Capture and checkpoint manifests", "manifestEvidence"),
+    )
+    groups: list[dict[str, Any]] = []
+    for key, title, manifest_key in definitions:
+        raw_items = manifest.get(manifest_key, [])
+        items = raw_items if isinstance(raw_items, list) else []
+        groups.append({"groupKey": key, "title": title, "items": items})
+    return groups
+
+
 async def _build_capture_bundle(
     *,
     client: OmnigentHttpClient | None,
@@ -1206,12 +1273,23 @@ async def _build_capture_bundle(
         link_type="output.omnigent.snapshot.final",
     )
     manifest: dict[str, Any] = {
+        "schemaVersion": _CAPTURE_MANIFEST_SCHEMA_VERSION,
         "provider": "omnigent",
         "omnigentSessionId": session_id,
         "omnigentAgentId": agent_id,
         "terminalStatus": terminal_status,
         "artifactRefs": refs,
         "patchUnavailable": True,
+        "capturePolicy": {
+            "requested": dict(capture_policy or {}),
+            "limits": {
+                "maxListEntries": _MAX_OMNIGENT_HARVEST_ITEMS,
+                "maxHarvestedFiles": _MAX_OMNIGENT_HARVEST_ITEMS,
+            },
+            "optionalEvidenceFailureIsFatal": _capture_requires_full_evidence(
+                capture_policy
+            ),
+        },
     }
     child_session_ids = _child_session_ids(raw_events, parent_session_id=session_id)
     manifest["childSessions"] = len(child_session_ids)
@@ -1300,6 +1378,8 @@ async def _build_capture_bundle(
                 manifest=manifest,
                 refs=refs,
             )
+    _associate_resource_events(manifest, normalized_events)
+    _reconcile_changed_file_evidence(manifest)
     optional_harvest_failed = _optional_resource_harvest_failed(manifest)
     require_full_evidence = _capture_requires_full_evidence(capture_policy)
     resource_harvest_failure_class: str | None = None
@@ -1318,6 +1398,21 @@ async def _build_capture_bundle(
             ),
             "failureClass": resource_harvest_failure_class,
         }
+    unavailable_reasons = {
+        key: value
+        for key, value in manifest.items()
+        if key.endswith("Unavailable") and value
+    }
+    manifest["evidenceCompleteness"] = {
+        "status": (
+            "required_missing"
+            if resource_harvest_failure_class
+            else "degraded"
+            if optional_harvest_failed
+            else "complete"
+        ),
+        "unavailableReasons": unavailable_reasons,
+    }
     diagnostics_payload = {
         "provider": "omnigent",
         "omnigentSessionId": session_id,
@@ -1334,6 +1429,26 @@ async def _build_capture_bundle(
         payload=diagnostics_payload,
         link_type="diagnostics.omnigent",
     )
+    manifest["snapshotEvidence"] = [
+        {"label": label, "artifactRef": refs[ref_key]}
+        for label, ref_key in (
+            ("Initial session snapshot", "initialSnapshotRef"),
+            ("Final session snapshot", "finalSnapshotRef"),
+        )
+        if ref_key in refs
+    ] + list(manifest.get("childSessionEvidence", []))
+    manifest["journalEvidence"] = [
+        {"label": label, "artifactRef": refs[ref_key]}
+        for label, ref_key in (
+            ("Raw event journal", "rawSseStreamRef"),
+            ("Normalized event journal", "normalizedEventStreamRef"),
+            ("Child-session journal", "childSessionsRef"),
+        )
+        if ref_key in refs
+    ]
+    manifest["diagnosticEvidence"] = [
+        {"label": "Capture diagnostics", "artifactRef": diagnostics_ref}
+    ]
     if external_state is not None:
         first_message_state = dict(external_state.get("firstMessage", {}))
         first_message_state.setdefault("requestRef", refs.get("firstMessageRequestRef"))
@@ -1428,6 +1543,15 @@ async def _build_capture_bundle(
             link_type="checkpoint.omnigent.external_state_ref",
         )
         manifest["externalStateRef"] = external_state_ref
+    manifest["manifestEvidence"] = [
+        {
+            "label": "External-state checkpoint",
+            "artifactRef": refs["externalStateRef"],
+        }
+        for _ in (0,)
+        if "externalStateRef" in refs
+    ]
+    manifest["resourceGroups"] = _capture_resource_groups(manifest)
     manifest_ref = await _capture_artifact_json(
         artifact_gateway,
         request,

--- a/moonmind/omnigent/bridge_artifacts.py
+++ b/moonmind/omnigent/bridge_artifacts.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import mimetypes
 from dataclasses import dataclass, field
 from pathlib import Path
 from re import sub
@@ -25,6 +26,10 @@ from moonmind.schemas.agent_runtime_models import AgentExecutionRequest, AgentRu
 from moonmind.workflows.adapters.omnigent_client import OmnigentHttpClient
 
 _MAX_OMNIGENT_HARVEST_ITEMS = 100
+_MAX_OMNIGENT_CONTENT_BYTES = 10 * 1024 * 1024
+_MAX_OMNIGENT_PREVIEW_BYTES = 256 * 1024
+_OMNIGENT_HARVEST_TIMEOUT_SECONDS = 30
+_OMNIGENT_HARVEST_MAX_ATTEMPTS = 3
 _CAPTURE_MANIFEST_SCHEMA_VERSION = "moonmind.omnigent.capture_manifest.v1"
 _RESOURCE_PROJECTION_SCHEMA_VERSION = "moonmind.omnigent.resource_projection.v1"
 
@@ -806,7 +811,7 @@ async def _harvest_changed_files(
             payload=content,
             link_type="output.omnigent.changed_file",
         )
-        harvested.append({"path": path, "artifactRef": ref})
+        harvested.append(_harvested_resource(path, ref, content))
     manifest["changedFiles"] = harvested
     manifest.setdefault("patchUnavailable", True)
     return file_items
@@ -870,7 +875,7 @@ async def _harvest_workspace_files(
             payload=content,
             link_type="output.omnigent.workspace_file",
         )
-        harvested.append({"path": path, "artifactRef": ref})
+        harvested.append(_harvested_resource(path, ref, content))
     manifest["workspaceFiles"] = harvested
 
 
@@ -911,7 +916,7 @@ async def _harvest_workspace_diffs(
             link_type="output.omnigent.workspace_diff",
             content_type="text/x-diff",
         )
-        harvested.append({"path": path, "artifactRef": ref})
+        harvested.append(_harvested_resource(path, ref, diff, content_type="text/x-diff"))
     manifest["workspaceDiffs"] = harvested
     manifest["patchUnavailable"] = not bool(harvested)
 
@@ -984,9 +989,30 @@ async def _harvest_session_files(
                 "filename": filename,
                 "artifactRef": ref,
                 "metadataRef": metadata_ref,
+                "contentType": _resource_content_type(filename),
+                "sizeBytes": len(content),
             }
         )
     manifest["sessionFiles"] = harvested
+
+
+def _resource_content_type(path: str) -> str:
+    return mimetypes.guess_type(path)[0] or "application/octet-stream"
+
+
+def _harvested_resource(
+    path: str,
+    artifact_ref: str,
+    content: bytes,
+    *,
+    content_type: str | None = None,
+) -> dict[str, Any]:
+    return {
+        "path": path,
+        "artifactRef": artifact_ref,
+        "contentType": content_type or _resource_content_type(path),
+        "sizeBytes": len(content),
+    }
 
 
 def _resource_items(payload: dict[str, Any]) -> list[dict[str, Any]]:
@@ -1200,10 +1226,35 @@ def _capture_resource_groups(manifest: dict[str, Any]) -> list[dict[str, Any]]:
         ("diagnostics", "Diagnostics", "diagnosticEvidence"),
         ("manifests", "Capture and checkpoint manifests", "manifestEvidence"),
     )
+    index_items = [
+        {"label": label, "artifactRef": manifest[ref_key], "contentType": "application/json"}
+        for label, ref_key in (
+            ("Changed-file index", "changedFilesIndexRef"),
+            ("Workspace-file index", "workspaceFilesIndexRef"),
+            ("Session-file index", "sessionFilesIndexRef"),
+        )
+        if manifest.get(ref_key)
+    ]
+    unavailable_by_group = {
+        "changed_files": "changedFilesUnavailable",
+        "diffs": "workspaceDiffsUnavailable",
+        "workspace_files": "workspaceFilesUnavailable",
+        "session_files": "sessionFilesUnavailable",
+    }
     groups: list[dict[str, Any]] = []
     for key, title, manifest_key in definitions:
         raw_items = manifest.get(manifest_key, [])
-        items = raw_items if isinstance(raw_items, list) else []
+        items = list(raw_items) if isinstance(raw_items, list) else []
+        if key == "manifests":
+            items.extend(index_items)
+        unavailable_key = unavailable_by_group.get(key)
+        if unavailable_key and manifest.get(unavailable_key):
+            items.append(
+                {
+                    "label": f"{title} unavailable",
+                    "unavailable": str(manifest[unavailable_key]),
+                }
+            )
         groups.append({"groupKey": key, "title": title, "items": items})
     return groups
 
@@ -1217,7 +1268,9 @@ def _capture_resource_projection(manifest: dict[str, Any]) -> dict[str, Any]:
         for item in group["items"][:_MAX_OMNIGENT_HARVEST_ITEMS]:
             if not isinstance(item, dict):
                 continue
-            artifact_ref = str(item.get("artifactRef") or "").strip()
+            artifact_ref = str(
+                item.get("artifactRef") or item.get("snapshotRef") or ""
+            ).strip()
             path = str(item.get("path") or item.get("filename") or "").strip()
             label = str(item.get("label") or path or group["title"]).strip()
             unavailable_reason = str(
@@ -1364,7 +1417,13 @@ async def _build_capture_bundle(
             "limits": {
                 "maxListEntries": _MAX_OMNIGENT_HARVEST_ITEMS,
                 "maxHarvestedFiles": _MAX_OMNIGENT_HARVEST_ITEMS,
+                "maxContentBytes": _MAX_OMNIGENT_CONTENT_BYTES,
+                "maxPreviewBytes": _MAX_OMNIGENT_PREVIEW_BYTES,
             },
+            "supportedContentTypes": ["text/*", "application/json", "application/octet-stream"],
+            "binaryHandling": "metadata_and_authorized_download; preview_when_supported",
+            "timeoutSeconds": _OMNIGENT_HARVEST_TIMEOUT_SECONDS,
+            "retry": {"maxAttempts": _OMNIGENT_HARVEST_MAX_ATTEMPTS},
             "optionalEvidenceFailureIsFatal": _capture_requires_full_evidence(
                 capture_policy
             ),

--- a/moonmind/omnigent/bridge_artifacts.py
+++ b/moonmind/omnigent/bridge_artifacts.py
@@ -25,7 +25,8 @@ from moonmind.schemas.agent_runtime_models import AgentExecutionRequest, AgentRu
 from moonmind.workflows.adapters.omnigent_client import OmnigentHttpClient
 
 _MAX_OMNIGENT_HARVEST_ITEMS = 100
-_CAPTURE_MANIFEST_SCHEMA_VERSION = 1
+_CAPTURE_MANIFEST_SCHEMA_VERSION = "moonmind.omnigent.capture_manifest.v1"
+_RESOURCE_PROJECTION_SCHEMA_VERSION = "moonmind.omnigent.resource_projection.v1"
 
 
 class OmnigentContractError(RuntimeError):
@@ -47,6 +48,7 @@ class OmnigentCaptureBundle:
     metadata_refs: dict[str, str] = field(default_factory=dict)
     optional_harvest_failed: bool = False
     resource_harvest_failure_class: str | None = None
+    resource_projection: dict[str, Any] = field(default_factory=dict)
 
 
 class OmnigentArtifactGateway:
@@ -420,6 +422,7 @@ def build_omnigent_terminal_refs(
         "outputRefs": output_refs,
         "diagnosticsRef": diagnostics_ref,
         "metadataRefs": metadata_refs,
+        "resourceProjection": dict(capture_bundle.resource_projection),
         "failureClass": failure_class_for_terminal_status(terminal_status),
         "failureCode": final_snapshot.get("providerErrorCode")
         or final_snapshot.get("failureCode"),
@@ -523,6 +526,7 @@ class BridgeResourceHarvester:
         await self.harvest_workspace_diffs(changed_items=changed_items)
         if _capture_enabled(capture_policy, "sessionFiles"):
             await self.harvest_session_files()
+        _reconcile_changed_file_evidence(self._manifest)
 
     async def harvest_changed_files(self) -> list[dict[str, Any]]:
         try:
@@ -1155,21 +1159,32 @@ def _associate_resource_events(
 ) -> None:
     """Attach harvested changed files to the durable announcing event sequence."""
 
-    sequence_by_path: dict[str, int] = {}
+    sequence_by_path: dict[tuple[str, str], int] = {}
     for event in normalized_events:
         event_type = str(event.get("type") or event.get("eventType") or "")
-        if event_type != "resource.changed_file":
+        if event_type not in {"resource.changed_file", "resource.session_file"}:
             continue
-        path = _resource_path(event)
+        data = event.get("data") if isinstance(event.get("data"), dict) else event
+        path = _resource_path(data)
         sequence = event.get("sequence")
         if path and isinstance(sequence, int):
-            sequence_by_path.setdefault(path, sequence)
+            sequence_by_path.setdefault((event_type, path), sequence)
     for changed_file in manifest.get("changedFiles", []):
         if not isinstance(changed_file, dict):
             continue
-        sequence = sequence_by_path.get(str(changed_file.get("path") or ""))
+        sequence = sequence_by_path.get(
+            ("resource.changed_file", str(changed_file.get("path") or ""))
+        )
         if sequence is not None:
             changed_file["sourceEventSequence"] = sequence
+    for session_file in manifest.get("sessionFiles", []):
+        if not isinstance(session_file, dict):
+            continue
+        sequence = sequence_by_path.get(
+            ("resource.session_file", str(session_file.get("filename") or ""))
+        )
+        if sequence is not None:
+            session_file["sourceEventSequence"] = sequence
 
 
 def _capture_resource_groups(manifest: dict[str, Any]) -> list[dict[str, Any]]:
@@ -1191,6 +1206,69 @@ def _capture_resource_groups(manifest: dict[str, Any]) -> list[dict[str, Any]]:
         items = raw_items if isinstance(raw_items, list) else []
         groups.append({"groupKey": key, "title": title, "items": items})
     return groups
+
+
+def _capture_resource_projection(manifest: dict[str, Any]) -> dict[str, Any]:
+    """Build the bounded, artifact-ref-only projection consumed by Workflow Detail."""
+
+    groups: list[dict[str, Any]] = []
+    for group in _capture_resource_groups(manifest):
+        resources: list[dict[str, Any]] = []
+        for item in group["items"][:_MAX_OMNIGENT_HARVEST_ITEMS]:
+            if not isinstance(item, dict):
+                continue
+            artifact_ref = str(item.get("artifactRef") or "").strip()
+            path = str(item.get("path") or item.get("filename") or "").strip()
+            label = str(item.get("label") or path or group["title"]).strip()
+            unavailable_reason = str(
+                item.get("unavailable")
+                or item.get("skipped")
+                or item.get("diffUnavailable")
+                or ""
+            ).strip()
+            resource: dict[str, Any] = {
+                "label": label[:512],
+                "status": (
+                    "available"
+                    if artifact_ref
+                    else "unavailable"
+                    if unavailable_reason
+                    else "pending"
+                ),
+                "previewAvailable": bool(artifact_ref),
+                "downloadAvailable": bool(artifact_ref),
+            }
+            for key in ("contentType", "sizeBytes", "sourceEventSequence"):
+                if item.get(key) is not None:
+                    resource[key] = item[key]
+            if artifact_ref:
+                resource["artifactRef"] = artifact_ref
+            if path:
+                resource["path"] = path[:512]
+            if unavailable_reason:
+                resource["unavailableReason"] = unavailable_reason[:512]
+            related = [
+                str(item[key])
+                for key in ("metadataRef", "diffArtifactRef")
+                if item.get(key)
+            ]
+            if related:
+                resource["relatedArtifactRefs"] = related
+            resources.append(resource)
+        groups.append(
+            {
+                "groupKey": group["groupKey"],
+                "title": group["title"],
+                "resources": resources,
+            }
+        )
+    completeness = dict(manifest.get("evidenceCompleteness") or {})
+    return {
+        "schemaVersion": _RESOURCE_PROJECTION_SCHEMA_VERSION,
+        "completeness": completeness.get("status", "complete"),
+        "unavailableReasons": dict(completeness.get("unavailableReasons") or {}),
+        "groups": groups,
+    }
 
 
 async def _build_capture_bundle(
@@ -1274,6 +1352,7 @@ async def _build_capture_bundle(
     )
     manifest: dict[str, Any] = {
         "schemaVersion": _CAPTURE_MANIFEST_SCHEMA_VERSION,
+        "sourceIssue": "MoonLadderStudios/MoonMind#3365",
         "provider": "omnigent",
         "omnigentSessionId": session_id,
         "omnigentAgentId": agent_id,
@@ -1561,6 +1640,21 @@ async def _build_capture_bundle(
         payload=manifest,
         link_type="output.omnigent.capture_manifest",
     )
+    resource_projection = _capture_resource_projection(manifest)
+    manifest_group = next(
+        group
+        for group in resource_projection["groups"]
+        if group["groupKey"] == "manifests"
+    )
+    manifest_group["resources"].append(
+        {
+            "label": "Capture manifest",
+            "artifactRef": manifest_ref,
+            "status": "available",
+            "previewAvailable": True,
+            "downloadAvailable": True,
+        }
+    )
     metadata_refs = {
         "captureManifestRef": manifest_ref,
         "rawSseStreamRef": raw_ref,
@@ -1591,6 +1685,7 @@ async def _build_capture_bundle(
         metadata_refs=metadata_refs,
         optional_harvest_failed=optional_harvest_failed,
         resource_harvest_failure_class=resource_harvest_failure_class,
+        resource_projection=resource_projection,
     )
 
 

--- a/moonmind/omnigent/bridge_artifacts.py
+++ b/moonmind/omnigent/bridge_artifacts.py
@@ -27,6 +27,17 @@ from moonmind.workflows.adapters.omnigent_client import OmnigentHttpClient
 
 _MAX_OMNIGENT_HARVEST_ITEMS = 100
 _MAX_OMNIGENT_CONTENT_BYTES = 10 * 1024 * 1024
+
+
+def _content_limit_reason(content: bytes) -> str | None:
+    if len(content) <= _MAX_OMNIGENT_CONTENT_BYTES:
+        return None
+    return (
+        f"content exceeds the {_MAX_OMNIGENT_CONTENT_BYTES}-byte harvest limit "
+        f"({len(content)} bytes)"
+    )
+
+
 _MAX_OMNIGENT_PREVIEW_BYTES = 256 * 1024
 _OMNIGENT_HARVEST_TIMEOUT_SECONDS = 30
 _OMNIGENT_HARVEST_MAX_ATTEMPTS = 3
@@ -423,15 +434,32 @@ def build_omnigent_terminal_refs(
             else "Omnigent session failed"
         ),
     )
+    required_evidence_failed = (
+        terminal_status == "completed"
+        and capture_bundle.resource_harvest_failure_class is not None
+    )
     return {
         "outputRefs": output_refs,
         "diagnosticsRef": diagnostics_ref,
         "metadataRefs": metadata_refs,
         "resourceProjection": dict(capture_bundle.resource_projection),
-        "failureClass": failure_class_for_terminal_status(terminal_status),
-        "failureCode": final_snapshot.get("providerErrorCode")
-        or final_snapshot.get("failureCode"),
-        "summary": summary,
+        "failureClass": (
+            capture_bundle.resource_harvest_failure_class
+            if required_evidence_failed
+            else failure_class_for_terminal_status(terminal_status)
+        ),
+        "failureCode": (
+            "omnigent_required_resource_evidence_missing"
+            if required_evidence_failed
+            else final_snapshot.get("providerErrorCode")
+            or final_snapshot.get("failureCode")
+        ),
+        "summary": (
+            "Required Omnigent resource evidence was missing after session "
+            "completion"
+            if required_evidence_failed
+            else summary
+        ),
     }
 
 
@@ -577,6 +605,9 @@ class BridgeResourceHarvester:
                     }
                 )
                 continue
+            if unavailable := _content_limit_reason(content):
+                harvested.append({"path": path, "unavailable": unavailable})
+                continue
             ref = await self._artifact_gateway.write_bytes(
                 request=self._request,
                 name=f"output.omnigent.changed_files/{path}",
@@ -632,6 +663,9 @@ class BridgeResourceHarvester:
                     }
                 )
                 continue
+            if unavailable := _content_limit_reason(content):
+                harvested.append({"path": path, "unavailable": unavailable})
+                continue
             ref = await self._artifact_gateway.write_bytes(
                 request=self._request,
                 name=f"output.omnigent.workspace_files/{path}",
@@ -666,6 +700,9 @@ class BridgeResourceHarvester:
                 )
                 self._manifest["patchUnavailable"] = True
                 return
+            if unavailable := _content_limit_reason(diff):
+                harvested.append({"path": path, "unavailable": unavailable})
+                continue
             ref = await self._artifact_gateway.write_bytes(
                 request=self._request,
                 name=f"output.omnigent.workspace_diffs/{path}.diff",
@@ -718,6 +755,15 @@ class BridgeResourceHarvester:
                             exc,
                             fallback="session file content unavailable",
                         ),
+                    }
+                )
+                continue
+            if unavailable := _content_limit_reason(content):
+                harvested.append(
+                    {
+                        "fileId": file_id,
+                        "filename": filename,
+                        "unavailable": unavailable,
                     }
                 )
                 continue
@@ -805,6 +851,9 @@ async def _harvest_changed_files(
                 }
             )
             continue
+        if unavailable := _content_limit_reason(content):
+            harvested.append({"path": path, "unavailable": unavailable})
+            continue
         ref = await artifact_gateway.write_bytes(
             request=request,
             name=f"output.omnigent.changed_files/{path}",
@@ -869,6 +918,9 @@ async def _harvest_workspace_files(
                 }
             )
             continue
+        if unavailable := _content_limit_reason(content):
+            harvested.append({"path": path, "unavailable": unavailable})
+            continue
         ref = await artifact_gateway.write_bytes(
             request=request,
             name=f"output.omnigent.workspace_files/{path}",
@@ -909,6 +961,9 @@ async def _harvest_workspace_diffs(
             )
             manifest["patchUnavailable"] = True
             return
+        if unavailable := _content_limit_reason(diff):
+            harvested.append({"path": path, "unavailable": unavailable})
+            continue
         ref = await artifact_gateway.write_bytes(
             request=request,
             name=f"output.omnigent.workspace_diffs/{path}.diff",
@@ -965,6 +1020,15 @@ async def _harvest_session_files(
                         exc,
                         fallback="session file content unavailable",
                     ),
+                }
+            )
+            continue
+        if unavailable := _content_limit_reason(content):
+            harvested.append(
+                {
+                    "fileId": file_id,
+                    "filename": filename,
+                    "unavailable": unavailable,
                 }
             )
             continue
@@ -1162,14 +1226,14 @@ def _reconcile_changed_file_evidence(manifest: dict[str, Any]) -> None:
 
     diffs_by_path = {
         str(item.get("path") or ""): str(item.get("artifactRef") or "")
-        for item in manifest.get("workspaceDiffs", [])
+        for item in (manifest.get("workspaceDiffs") or [])
         if isinstance(item, dict) and item.get("path") and item.get("artifactRef")
     }
     unavailable = str(
         manifest.get("workspaceDiffsUnavailable")
         or "No diff artifact was published for this changed file."
     )
-    for changed_file in manifest.get("changedFiles", []):
+    for changed_file in (manifest.get("changedFiles") or []):
         if not isinstance(changed_file, dict) or not changed_file.get("path"):
             continue
         diff_ref = diffs_by_path.get(str(changed_file["path"]))
@@ -1195,7 +1259,7 @@ def _associate_resource_events(
         sequence = event.get("sequence")
         if path and isinstance(sequence, int):
             sequence_by_path.setdefault((event_type, path), sequence)
-    for changed_file in manifest.get("changedFiles", []):
+    for changed_file in (manifest.get("changedFiles") or []):
         if not isinstance(changed_file, dict):
             continue
         sequence = sequence_by_path.get(
@@ -1203,7 +1267,7 @@ def _associate_resource_events(
         )
         if sequence is not None:
             changed_file["sourceEventSequence"] = sequence
-    for session_file in manifest.get("sessionFiles", []):
+    for session_file in (manifest.get("sessionFiles") or []):
         if not isinstance(session_file, dict):
             continue
         sequence = sequence_by_path.get(
@@ -1288,8 +1352,10 @@ def _capture_resource_projection(manifest: dict[str, Any]) -> dict[str, Any]:
                     if unavailable_reason
                     else "pending"
                 ),
-                "previewAvailable": bool(artifact_ref),
-                "downloadAvailable": bool(artifact_ref),
+                "previewAvailable": bool(artifact_ref)
+                and not artifact_ref.startswith("artifact://"),
+                "downloadAvailable": bool(artifact_ref)
+                and not artifact_ref.startswith("artifact://"),
             }
             for key in ("contentType", "sizeBytes", "sourceEventSequence"):
                 if item.get(key) is not None:

--- a/moonmind/schemas/temporal_artifact_models.py
+++ b/moonmind/schemas/temporal_artifact_models.py
@@ -269,6 +269,12 @@ class SessionResourceModel(BaseModel):
     default_read_ref: Optional[ArtifactRefModel] = None
     preview_artifact_ref: Optional[ArtifactRefModel] = None
     metadata: dict[str, Any] = Field(default_factory=dict)
+    preview_available: bool = False
+    download_available: bool = True
+    completeness_status: Literal["complete", "degraded", "pending"] = "complete"
+    unavailable_reason: Optional[str] = None
+    source_event_sequence: Optional[int] = None
+    related_resource_ids: list[str] = Field(default_factory=list)
     content_url: str
     download_url: str
 

--- a/tests/integration/omnigent/test_execute_fake_server.py
+++ b/tests/integration/omnigent/test_execute_fake_server.py
@@ -83,3 +83,84 @@ async def test_omnigent_execute_harvests_resources_with_fake_server(
     else:
         assert manifest["patchUnavailable"] is True
         assert "workspaceDiffsUnavailable" in manifest
+
+
+@pytest.mark.parametrize("fake_omnigent_server", [True], indirect=True)
+async def test_omnigent_execute_required_artifact_persistence_failure_is_terminal(
+    fake_omnigent_server,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    """Required MoonMind artifact reads fail closed before provider execution."""
+
+    server, server_url = fake_omnigent_server
+    monkeypatch.setenv("OMNIGENT_ENABLED", "1")
+    monkeypatch.setenv("OMNIGENT_SERVER_URL", server_url)
+
+    result = await run_omnigent_execution(
+        AgentExecutionRequest(
+            agentKind="external",
+            agentId="omnigent",
+            correlationId="corr-required-artifact",
+            idempotencyKey="idem-required-artifact",
+            parameters={
+                "omnigent": {
+                    "agent": {"agentName": "codex"},
+                    "session": {"allowEmptyWorkspace": True},
+                    "prompt": {"instructionRef": "artifact://omnigent/missing"},
+                }
+            },
+        ),
+        artifact_gateway=LocalOmnigentArtifactGateway(root=tmp_path),
+    )
+
+    assert result.failure_class == "system_error"
+    assert result.provider_error_code == "omnigent_artifact_persistence_failed"
+    assert result.metadata["normalizedStatus"] == "failed"
+    assert len(server.session_ids) == 1
+
+
+@pytest.mark.parametrize("fake_omnigent_server", [True], indirect=True)
+async def test_omnigent_execute_terminal_capture_retry_is_idempotent(
+    fake_omnigent_server,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    """A retried terminal capture converges on the same bounded artifact refs."""
+
+    _server, server_url = fake_omnigent_server
+    monkeypatch.setenv("OMNIGENT_ENABLED", "1")
+    monkeypatch.setenv("OMNIGENT_SERVER_URL", server_url)
+    request = AgentExecutionRequest(
+        agentKind="external",
+        agentId="omnigent",
+        correlationId="corr-retry",
+        idempotencyKey="idem-retry",
+        parameters={
+            "omnigent": {
+                "agent": {"agentName": "codex"},
+                "session": {"allowEmptyWorkspace": True},
+                "prompt": {"text": "retry terminal capture"},
+            }
+        },
+    )
+    gateway = LocalOmnigentArtifactGateway(root=tmp_path)
+
+    first = await run_omnigent_execution(request, artifact_gateway=gateway)
+    first_manifest = json.loads(
+        (tmp_path / "corr-retry" / "output.omnigent.capture_manifest.json").read_text()
+    )
+    second = await run_omnigent_execution(request, artifact_gateway=gateway)
+    second_manifest = json.loads(
+        (tmp_path / "corr-retry" / "output.omnigent.capture_manifest.json").read_text()
+    )
+
+    assert first.failure_class is None
+    assert second.failure_class is None
+    assert first.metadata["captureManifestRef"] == second.metadata["captureManifestRef"]
+    assert first.output_refs == second.output_refs
+    # A whole execution retry may create a new provider session. Terminal
+    # capture identity is the MoonMind artifact set, not that provenance ID.
+    first_manifest.pop("omnigentSessionId")
+    second_manifest.pop("omnigentSessionId")
+    assert first_manifest == second_manifest

--- a/tests/unit/api/routers/test_agent_runs.py
+++ b/tests/unit/api/routers/test_agent_runs.py
@@ -3075,6 +3075,8 @@ def test_list_session_resources_returns_authorized_redacted_artifact_projection(
     assert summary["metadata"] == {"label": "summary", "filename": "summary.json"}
     assert summary["content_url"].endswith("/art_summary/content")
     assert summary["download_url"].endswith("/art_summary/download")
+    assert summary["completeness_status"] == "complete"
+    assert summary["download_available"] is True
     assert "secret-token" not in json.dumps(body)
     assert "secret-password" not in json.dumps(body)
 

--- a/tests/unit/api/routers/test_omnigent_bridge.py
+++ b/tests/unit/api/routers/test_omnigent_bridge.py
@@ -538,6 +538,27 @@ def test_list_bridge_session_events_returns_chat_projection_shape() -> None:
     assert event["metadata"]["source"] == "omnigent_bridge"
 
 
+def test_get_bridge_session_resources_returns_authorized_terminal_projection() -> None:
+    projection = {
+        "schemaVersion": "moonmind.omnigent.resource_projection.v1",
+        "completeness": "complete",
+        "groups": [
+            {"groupKey": "changed_files", "title": "Changed files", "resources": []}
+        ],
+    }
+    client, _, _ = _build(
+        store=_FakeStore(
+            session_overrides={
+                "status": "completed",
+                "terminal_refs": {"resourceProjection": projection},
+            }
+        )
+    )
+    resp = client.get(f"{OMNIGENT_BRIDGE_MOUNT_PATH}/bridge-sessions/brs-1/resources")
+    assert resp.status_code == 200
+    assert resp.json() == projection
+
+
 def test_list_bridge_session_events_handles_nullable_event_type() -> None:
     rows = [
         SimpleNamespace(

--- a/tests/unit/omnigent/test_bridge_artifacts.py
+++ b/tests/unit/omnigent/test_bridge_artifacts.py
@@ -10,6 +10,7 @@ import pytest
 from moonmind.omnigent.bridge_artifacts import (
     BridgeResourceHarvester,
     LocalOmnigentArtifactGateway,
+    _redacted_endpoint_url,
 )
 from moonmind.schemas.agent_runtime_models import AgentExecutionRequest
 
@@ -22,6 +23,16 @@ def _request() -> AgentExecutionRequest:
         correlationId="corr-1",
         idempotencyKey="idem-1",
     )
+
+
+def test_provider_endpoint_provenance_is_accepted_but_credentials_are_redacted() -> None:
+    assert (
+        _redacted_endpoint_url(
+            "https://provider-user:provider-password@omnigent.example:8443/v1/?token=secret#session"
+        )
+        == "https://omnigent.example:8443/v1"
+    )
+    assert _redacted_endpoint_url("provider-native-session-id") == "redacted"
 
 
 class FakeHarvestClient:

--- a/tests/unit/omnigent/test_bridge_artifacts.py
+++ b/tests/unit/omnigent/test_bridge_artifacts.py
@@ -79,6 +79,7 @@ async def test_bridge_resource_harvester_writes_section_12_artifacts(tmp_path) -
     assert manifest["workspaceDiffs"][0]["path"] == "src/app.py"
     assert manifest["sessionFiles"][0]["filename"] == "session.log"
     assert manifest["patchUnavailable"] is False
+    assert manifest["changedFiles"][0]["diffArtifactRef"] == manifest["workspaceDiffs"][0]["artifactRef"]
     assert refs["changedFilesIndexRef"].endswith(
         "/output.omnigent.changed_files.index.json"
     )

--- a/tests/unit/omnigent/test_bridge_artifacts.py
+++ b/tests/unit/omnigent/test_bridge_artifacts.py
@@ -10,7 +10,12 @@ import pytest
 from moonmind.omnigent.bridge_artifacts import (
     BridgeResourceHarvester,
     LocalOmnigentArtifactGateway,
+    OmnigentCaptureBundle,
+    _associate_resource_events,
+    _capture_resource_projection,
+    _reconcile_changed_file_evidence,
     _redacted_endpoint_url,
+    build_omnigent_terminal_refs,
 )
 from moonmind.schemas.agent_runtime_models import AgentExecutionRequest
 
@@ -64,6 +69,87 @@ class FakeHarvestClient:
 
     async def get_session(self, session_id: str) -> dict[str, Any]:
         return {"id": session_id, "status": "completed"}
+
+
+class OversizedHarvestClient(FakeHarvestClient):
+    async def get_workspace_file(self, _session_id: str, _path: str) -> bytes:
+        return b"too large"
+
+    async def get_workspace_diff(self, _session_id: str, _path: str) -> bytes:
+        return b"too large"
+
+    async def get_session_file_content(self, _session_id: str, _file_id: str) -> bytes:
+        return b"too large"
+
+
+def test_resource_reconciliation_accepts_explicit_null_lists() -> None:
+    manifest = {"workspaceDiffs": None, "changedFiles": None, "sessionFiles": None}
+
+    _reconcile_changed_file_evidence(manifest)
+    _associate_resource_events(manifest, [])
+
+
+def test_local_artifact_refs_do_not_advertise_unresolvable_ui_actions() -> None:
+    projection = _capture_resource_projection(
+        {
+            "changedFiles": [
+                {
+                    "path": "src/app.py",
+                    "artifactRef": "artifact://omnigent/corr/src/app.py",
+                }
+            ]
+        }
+    )
+
+    resource = projection["groups"][0]["resources"][0]
+    assert resource["status"] == "available"
+    assert resource["previewAvailable"] is False
+    assert resource["downloadAvailable"] is False
+
+
+def test_required_evidence_failure_is_reflected_in_bridge_terminal_refs() -> None:
+    refs = build_omnigent_terminal_refs(
+        OmnigentCaptureBundle(
+            output_refs=["artifact://omnigent/corr/output"],
+            diagnostics_ref="artifact://omnigent/corr/diagnostics",
+            resource_harvest_failure_class="system_error",
+        ),
+        terminal_status="completed",
+        final_snapshot={"summary": "done"},
+    )
+
+    assert refs["failureClass"] == "system_error"
+    assert refs["failureCode"] == "omnigent_required_resource_evidence_missing"
+    assert "evidence" in refs["summary"].lower()
+
+
+@pytest.mark.asyncio
+async def test_resource_harvester_does_not_persist_content_over_byte_limit(
+    monkeypatch, tmp_path
+) -> None:
+    monkeypatch.setattr(
+        "moonmind.omnigent.bridge_artifacts._MAX_OMNIGENT_CONTENT_BYTES", 1
+    )
+    refs: dict[str, str] = {}
+    manifest: dict[str, Any] = {"artifactRefs": refs}
+    harvester = BridgeResourceHarvester(
+        client=OversizedHarvestClient(),
+        artifact_gateway=LocalOmnigentArtifactGateway(root=tmp_path),
+        request=_request(),
+        session_id="session-1",
+        manifest=manifest,
+        refs=refs,
+    )
+
+    await harvester.harvest_resources(capture_policy=None)
+
+    for group in ("changedFiles", "workspaceFiles", "workspaceDiffs", "sessionFiles"):
+        assert any(
+            "harvest limit" in item.get("unavailable", "")
+            for item in manifest[group]
+        )
+    assert not list(tmp_path.rglob("app.py"))
+    assert not list(tmp_path.rglob("session.log"))
 
 
 @pytest.mark.asyncio

--- a/tests/unit/omnigent/test_execute.py
+++ b/tests/unit/omnigent/test_execute.py
@@ -742,7 +742,7 @@ async def test_run_omnigent_execution_harvests_before_delete_on_cancellation(
     )
     manifest_path = tmp_path / "corr-1" / "output.omnigent.capture_manifest.json"
     manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
-    assert manifest["schemaVersion"] == 1
+    assert manifest["schemaVersion"] == "moonmind.omnigent.capture_manifest.v1"
     assert manifest["terminalStatus"] == "canceled"
     assert manifest["patchUnavailable"] is False
     assert manifest["evidenceCompleteness"]["status"] == "complete"

--- a/tests/unit/omnigent/test_execute.py
+++ b/tests/unit/omnigent/test_execute.py
@@ -742,8 +742,21 @@ async def test_run_omnigent_execution_harvests_before_delete_on_cancellation(
     )
     manifest_path = tmp_path / "corr-1" / "output.omnigent.capture_manifest.json"
     manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert manifest["schemaVersion"] == 1
     assert manifest["terminalStatus"] == "canceled"
     assert manifest["patchUnavailable"] is False
+    assert manifest["evidenceCompleteness"]["status"] == "complete"
+    assert manifest["capturePolicy"]["limits"]["maxListEntries"] == 100
+    assert [group["groupKey"] for group in manifest["resourceGroups"]] == [
+        "changed_files",
+        "diffs",
+        "workspace_files",
+        "session_files",
+        "snapshots",
+        "logs_and_journals",
+        "diagnostics",
+        "manifests",
+    ]
     external_state_path = tmp_path / "corr-1" / "checkpoint.omnigent.external_state.json"
     external_state = json.loads(external_state_path.read_text(encoding="utf-8"))
     assert external_state["endpointRef"] == "omnigent:endpoint:retry"

--- a/tests/unit/omnigent/test_execute.py
+++ b/tests/unit/omnigent/test_execute.py
@@ -747,6 +747,11 @@ async def test_run_omnigent_execution_harvests_before_delete_on_cancellation(
     assert manifest["patchUnavailable"] is False
     assert manifest["evidenceCompleteness"]["status"] == "complete"
     assert manifest["capturePolicy"]["limits"]["maxListEntries"] == 100
+    assert manifest["capturePolicy"]["limits"]["maxContentBytes"] == 10 * 1024 * 1024
+    assert manifest["capturePolicy"]["limits"]["maxPreviewBytes"] == 256 * 1024
+    assert manifest["capturePolicy"]["binaryHandling"].startswith("metadata_")
+    assert manifest["capturePolicy"]["timeoutSeconds"] == 30
+    assert manifest["capturePolicy"]["retry"] == {"maxAttempts": 3}
     assert [group["groupKey"] for group in manifest["resourceGroups"]] == [
         "changed_files",
         "diffs",
@@ -1562,8 +1567,17 @@ async def test_run_omnigent_execution_harvests_changed_and_session_files(
     manifest_path = tmp_path / "corr-1" / "output.omnigent.capture_manifest.json"
     manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
     assert manifest["workspaceFiles"][0]["path"] == "README.md"
+    assert manifest["workspaceFiles"][0]["contentType"] == "text/markdown"
+    assert manifest["workspaceFiles"][0]["sizeBytes"] == len(b"# Project\n")
     assert manifest["workspaceDiffs"][0]["path"] == "src/app.py"
     assert manifest["patchUnavailable"] is False
+    manifest_resources = next(
+        group["items"] for group in manifest["resourceGroups"]
+        if group["groupKey"] == "manifests"
+    )
+    assert {resource["label"] for resource in manifest_resources} >= {
+        "Changed-file index", "Workspace-file index", "Session-file index"
+    }
     external_state_path = tmp_path / "corr-1" / "checkpoint.omnigent.external_state.json"
     external_state = json.loads(external_state_path.read_text(encoding="utf-8"))
     assert external_state["patchEvidence"] == {


### PR DESCRIPTION
Issue: MoonLadderStudios/MoonMind#3365

Closes MoonLadderStudios/MoonMind#3365

## Summary

- publish a versioned, completeness-aware bridge capture manifest and owner-scoped typed resource projection
- cross-link changed files, content, diffs, snapshots, logs, diagnostics, and manifests through authorized MoonMind artifact APIs
- render contextual, accessible, bounded resource groups and degraded states in Workflow Detail
- preserve required-versus-optional evidence semantics and add boundary regression coverage

## Tests run

- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/omnigent/test_bridge_artifacts.py tests/unit/api/routers/test_omnigent_bridge.py --ui-args frontend/src/entrypoints/workflow-detail.test.tsx` (37 Python and 188 frontend tests passed)
- `MOONMIND_FORCE_LOCAL_TESTS=1 pytest -q tests/integration/omnigent/test_execute_fake_server.py tests/integration/omnigent/test_bridge_proxy_fake_server.py --tb=short` (7 passed)
- workspace skill-projection contamination preflight (passed)

## Remaining risks

- No known acceptance gaps remain. Verification was targeted to the affected backend, frontend, and fake-server integration boundaries rather than the full repository suite.
