### PR TITLE
Fix this issue: The mounted-tools feature has been implemented and merged into `main` through a sequence of PRs: * **#3383:** pinned, immutable tool b

### DIFF
--- a/moonmind/omnigent/mounted_tool_preflight.py
+++ b/moonmind/omnigent/mounted_tool_preflight.py
@@ -64,7 +64,7 @@ def _trusted_gh_digest_checks() -> str:
     tool = next(item for item in manifest["tools"] if item["name"] == "gh")
     digests = {item["executableSha256"] for item in tool["platforms"].values()}
     executable = f'/opt/moonmind-tools/{tool["path"]}'
-    return _digest_check_command(executable, digests)
+    return _digest_check_command(executable, sorted(digests))
 
 
 def _digest_check_command(executable: str, digests: Sequence[str]) -> str:

--- a/moonmind/omnigent/mounted_tool_preflight.py
+++ b/moonmind/omnigent/mounted_tool_preflight.py
@@ -64,8 +64,13 @@ def _trusted_gh_digest_checks() -> str:
     tool = next(item for item in manifest["tools"] if item["name"] == "gh")
     digests = {item["executableSha256"] for item in tool["platforms"].values()}
     executable = f'/opt/moonmind-tools/{tool["path"]}'
+    return _digest_check_command(executable, digests)
+
+
+def _digest_check_command(executable: str, digests: Sequence[str]) -> str:
+    quoted_executable = shlex.quote(executable)
     return " || ".join(
-        f'''test "$(sha256sum {executable} | awk '{{print $1}}')" = "{digest}"'''
+        f'''test "$(sha256sum {quoted_executable} | awk '{{print $1}}')" = "{digest}"'''
         for digest in sorted(digests)
     )
 

--- a/services/omnigent/tools/manifest.lock.json
+++ b/services/omnigent/tools/manifest.lock.json
@@ -1,22 +1,22 @@
 {
   "schemaVersion": 1,
-  "bundleVersion": "gh-2.74.2-1",
+  "bundleVersion": "gh-2.76.2-1",
   "tools": [
     {
       "name": "gh",
-      "version": "2.74.2",
+      "version": "2.76.2",
       "platforms": {
         "linux/amd64": {
-          "url": "https://github.com/cli/cli/releases/download/v2.74.2/gh_2.74.2_linux_amd64.tar.gz",
-          "sha256": "c421091ae5800390e6aef1f50bfda59cc1d4f2ef2200bcd4e1a662c05c28c444",
-          "executableSha256": "abc2fd6b6411776b2843f320dc08a9e99b63b662e79c5752504ea696739ad408",
-          "archivePath": "gh_2.74.2_linux_amd64/bin/gh"
+          "url": "https://github.com/cli/cli/releases/download/v2.76.2/gh_2.76.2_linux_amd64.tar.gz",
+          "sha256": "62544b0f3759bbf1155c0ac3d75838b5fe23d66dfb75cf8368f84fff8f82b93e",
+          "executableSha256": "999cfe2e886adea0edc7919f6724a49d4bf2f35b8f2e0f72377bfb2d58f43c6e",
+          "archivePath": "gh_2.76.2_linux_amd64/bin/gh"
         },
         "linux/arm64": {
-          "url": "https://github.com/cli/cli/releases/download/v2.74.2/gh_2.74.2_linux_arm64.tar.gz",
-          "sha256": "f0b07f0aeaf00f137df1bd33a76e717b1945f4b83bd6a3296b365414d3eb413f",
-          "executableSha256": "f4c95edc71e91dad4f39f4a655a37d8b9cc9ae7677a299213ab06b6dd00ab0dd",
-          "archivePath": "gh_2.74.2_linux_arm64/bin/gh"
+          "url": "https://github.com/cli/cli/releases/download/v2.76.2/gh_2.76.2_linux_arm64.tar.gz",
+          "sha256": "a77f6d709c5100cda8e9bbb8d8b7143120121233d9102ba2f2bc254134db18dc",
+          "executableSha256": "24b717fc99e0faad28eff591c9c1aa8f97fc23b0854abcaadd4eb9dc40170fbc",
+          "archivePath": "gh_2.76.2_linux_arm64/bin/gh"
         }
       },
       "path": "bin/gh",

--- a/tests/integration/temporal/test_compose_foundation.py
+++ b/tests/integration/temporal/test_compose_foundation.py
@@ -186,6 +186,14 @@ def test_omnigent_hosts_use_versioned_read_only_tool_bundle():
     compose = _load_compose()
     services = compose["services"]
     initializer = services["omnigent-tools-init"]
+    tool_manifest = json.loads(
+        Path("services/omnigent/tools/manifest.lock.json").read_text(encoding="utf-8")
+    )
+
+    configured_version = initializer["environment"]["MOONMIND_GH_VERSION"]
+    compose_default_version = configured_version.removesuffix("}").rsplit(":-", 1)[1]
+    assert tool_manifest["bundleVersion"] == f"gh-{compose_default_version}-1"
+    assert tool_manifest["tools"][0]["version"] == compose_default_version
 
     assert initializer["image"] == (
         "${OMNIGENT_GH_IMAGE:-serversideup/github-cli:alpine-2.76.2}"

--- a/tests/integration/temporal/test_compose_foundation.py
+++ b/tests/integration/temporal/test_compose_foundation.py
@@ -187,7 +187,9 @@ def test_omnigent_hosts_use_versioned_read_only_tool_bundle():
     services = compose["services"]
     initializer = services["omnigent-tools-init"]
     tool_manifest = json.loads(
-        Path("services/omnigent/tools/manifest.lock.json").read_text(encoding="utf-8")
+        (REPO_ROOT / "services/omnigent/tools/manifest.lock.json").read_text(
+            encoding="utf-8"
+        )
     )
 
     configured_version = initializer["environment"]["MOONMIND_GH_VERSION"]

--- a/tests/unit/omnigent/test_mounted_tool_preflight.py
+++ b/tests/unit/omnigent/test_mounted_tool_preflight.py
@@ -2,12 +2,30 @@
 
 from __future__ import annotations
 
+import hashlib
+import subprocess
+from pathlib import Path
+
 import pytest
 
 from moonmind.omnigent.mounted_tool_preflight import (
+    _digest_check_command,
     MountedToolPreflightError,
     preflight_mounted_tools,
 )
+
+
+def test_digest_probe_executes_against_mounted_executable(tmp_path: Path) -> None:
+    executable = tmp_path / "mounted tools/gh"
+    executable.parent.mkdir()
+    executable.write_bytes(b"pinned gh executable fixture")
+    trusted_digest = hashlib.sha256(executable.read_bytes()).hexdigest()
+    command = _digest_check_command(str(executable), {trusted_digest})
+
+    assert subprocess.run(["bash", "-lc", command], check=False).returncode == 0
+
+    executable.write_bytes(b"different executable")
+    assert subprocess.run(["bash", "-lc", command], check=False).returncode != 0
 
 
 @pytest.mark.asyncio

--- a/tests/unit/omnigent/test_mounted_tool_preflight.py
+++ b/tests/unit/omnigent/test_mounted_tool_preflight.py
@@ -20,7 +20,7 @@ def test_digest_probe_executes_against_mounted_executable(tmp_path: Path) -> Non
     executable.parent.mkdir()
     executable.write_bytes(b"pinned gh executable fixture")
     trusted_digest = hashlib.sha256(executable.read_bytes()).hexdigest()
-    command = _digest_check_command(str(executable), {trusted_digest})
+    command = _digest_check_command(str(executable), [trusted_digest])
 
     assert subprocess.run(["bash", "-lc", command], check=False).returncode == 0
 


### PR DESCRIPTION
Fix this issue:

The mounted-tools feature has been implemented and merged into `main` through a sequence of PRs:

* **#3383:** pinned, immutable tool bundle
* **#3387:** static and on-demand host mounts
* **#3390:** host and runner preflight
* **#3391:** GitHub credential injection
* **#3392:** resolved Skill projection
* **#3395:** corrected the initializer’s GitHub CLI image
* **#3396:** fixed static hosts looping while waiting for a run-scoped Skill projection

Those PRs are merged, and #3396 is currently the newest commit on `main`.

### What is now present

Current Compose configuration:

* Runs an `omnigent-tools-init` service.
* Copies a real `gh` executable into a named volume.
* Mounts the volume read-only at `/opt/moonmind-tools`.
* Mounts the resolved Skill directory read-only at `/opt/moonmind-skills`.
* Adds `/opt/moonmind-tools/bin` to `PATH`.
* Mounts a login-shell profile script.
* Applies this to the generic, Claude, and Codex Omnigent hosts.

The on-demand host path also:

* Materializes and verifies the resolved Skill snapshot before host mutation.
* Authenticates private repository cloning.
* Mounts the tool volume and Skill snapshot.
* Supplies `GH_TOKEN` and `GIT_TOKEN`.
* Configures `GH_CONFIG_DIR` and disables prompts and update checks.
* Verifies `gh` through both the host shell and Omnigent’s constructed runner environment.

The preflight checks include:

```text
gh executable digest
command -v gh
gh --version
gh auth status
gh repo view
repository write permission when mutation is required
```

They run against both the host and expected runner environments.

## The current blocker I found

There appears to be a **version and checksum inconsistency on current `main`**.

The checked-in trusted manifest expects:

```text
gh 2.74.2
bundleVersion: gh-2.74.2-1
```

and contains executable hashes for that version.

But active Compose initialization uses:

```text
serversideup/github-cli:alpine-2.76.2
OMNIGENT_GH_VERSION=2.76.2
```

and the named volume is also versioned as `2.76.2`.

The initializer copies that 2.76.2 executable into the bundle and explicitly verifies that it reports 2.76.2.

However, the runtime preflight still reads `services/omnigent/tools/manifest.lock.json` and constructs its executable SHA-256 test from the **2.74.2 hashes**.

Therefore, as currently written:

```text
initializer installs gh 2.76.2
        ↓
preflight expects gh 2.74.2 executable hash
        ↓
tool_manifest_mismatch
```

A `gh`-requiring run such as `pr-resolver` should be rejected before its Omnigent session starts.

The focused preflight unit test does not catch this because its command runners return synthetic success without executing the generated digest command.  The preflight PR also states that a live credentialed host/runner check was not performed in its validation environment.

## One intentional limitation

Authenticated `gh` workloads currently require a **run-dedicated on-demand host**. The runtime explicitly rejects `gh` on a reusable static host:

```text
Required gh credentials cannot be isolated on a reusable static host
```

Static hosts do receive the tool and Skill mounts, but they wait for a resolved Skill projection and are not currently the supported path for an authenticated `pr-resolver` execution.

## Verdict

**The architecture and nearly all implementation work have landed, but end-to-end `pr-resolver` use through Omnigent should not yet be considered working.**

The immediate correction is simple: make the active initializer and trusted digest manifest use one `gh` version—either update the manifest and executable hashes to 2.76.2 or configure the initializer to publish 2.74.2. Then run one real on-demand Codex/Omnigent verification through the runner environment:

```bash
bash -lc 'command -v gh && gh --version && gh auth status'
gh repo view OWNER/REPO --json nameWithOwner,viewerPermission
```

After that passes, the mounted-binary implementation can reasonably be called complete.