### PR TITLE
Handle batch preflight failures authoritatively

### DIFF
--- a/.agents/skills/batch-workflows/SKILL.md
+++ b/.agents/skills/batch-workflows/SKILL.md
@@ -110,6 +110,14 @@ Progress" with a single batch run.
    - Submits via the internal Temporal execution API (`POST /api/executions`);
      `MOONMIND_URL` must point at the MoonMind API from the managed session.
 
+   If provider-specific input validation fails before a trustworthy target list
+   can be written, still invoke the same helper exactly once with
+   `--preflight-error <actionable message>` and
+   `--requested-count <requested target count>`. The helper records the
+   current execution's authoritative failure in the managed artifact spool and
+   does not read targets or queue children. Do not handcraft or reuse a
+   repo-local result artifact.
+
 3. **Record the summary**: the helper writes `artifacts/batch-workflows-result.json`
    linking every queued child workflow id together with the resolved targets,
    skips, and errors, and prints a short `queued/skipped/errors` count summary.

--- a/.agents/skills/batch-workflows/bin/batch_workflows.py
+++ b/.agents/skills/batch-workflows/bin/batch_workflows.py
@@ -827,6 +827,20 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="For skill:jira-verify children, update Jira status only on PASS.",
     )
     parser.add_argument("--max-workflows", type=int, default=25)
+    parser.add_argument(
+        "--preflight-error",
+        default=None,
+        help=(
+            "Record an input-validation failure without reading targets or "
+            "queueing child workflows."
+        ),
+    )
+    parser.add_argument(
+        "--requested-count",
+        type=int,
+        default=0,
+        help="Number of requested targets reported with --preflight-error.",
+    )
     parser.add_argument("--task-context-path", default=None)
     parser.add_argument("--artifacts-dir", default="artifacts")
     return parser.parse_args(argv)
@@ -865,6 +879,29 @@ def main(argv: list[str] | None = None) -> int:
     try:
         if not execution_ref:
             raise RuntimeError("MOONMIND_STEP_EXECUTION_ID is required")
+        preflight_error = _text(args.preflight_error)
+        if preflight_error:
+            if args.requested_count < 0:
+                raise RuntimeError("--requested-count must be zero or greater")
+            failed = {
+                **base_result,
+                "timestamp": datetime.now(UTC).isoformat(),
+                "status": "failed",
+                "requested": args.requested_count,
+                "failure": {
+                    "code": "BATCH_FANOUT_INPUT_INVALID",
+                    "message": preflight_error[:1024],
+                },
+                "errors": [
+                    {
+                        "code": "BATCH_FANOUT_INPUT_INVALID",
+                        "error": preflight_error[:1024],
+                    }
+                ],
+            }
+            _write_artifacts(result_path, failed)
+            print(json.dumps(failed, indent=2))
+            return 2
         if not targets_path.exists():
             raise RuntimeError(f"targets file not found: {targets_path}")
         targets = _read_targets(targets_path)

--- a/.agents/skills/batch-workflows/bin/batch_workflows.py
+++ b/.agents/skills/batch-workflows/bin/batch_workflows.py
@@ -882,12 +882,13 @@ def main(argv: list[str] | None = None) -> int:
         preflight_error = _text(args.preflight_error)
         if preflight_error:
             if args.requested_count < 0:
-                raise RuntimeError("--requested-count must be zero or greater")
+                preflight_error = "--requested-count must be zero or greater"
+            requested_count = max(0, args.requested_count)
             failed = {
                 **base_result,
                 "timestamp": datetime.now(UTC).isoformat(),
                 "status": "failed",
-                "requested": args.requested_count,
+                "requested": requested_count,
                 "failure": {
                     "code": "BATCH_FANOUT_INPUT_INVALID",
                     "message": preflight_error[:1024],

--- a/api_service/data/presets/batch-github-workflows.yaml
+++ b/api_service/data/presets/batch-github-workflows.yaml
@@ -167,6 +167,13 @@ steps:
     {% if inputs.run_verify %}--run-verify{% else %}--no-run-verify{% endif %} \
     --constraints "{{ inputs.constraints }}"
 
+    If strict range validation fails before the target list can be written, invoke
+    that same helper once with the same arguments plus
+    --preflight-error "<actionable validation error>" and
+    --requested-count "<inclusive range count>". Do not read GitHub issues, queue
+    a partial range, handcraft the result JSON, or reuse evidence from an earlier
+    execution. The helper writes the authoritative failure result.
+
     The helper writes artifacts/batch-workflows-result.json. Report its queued,
     skipped, and error counts honestly and link every queued child workflow.
   batchOrchestration:

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -11871,7 +11871,7 @@ class TemporalAgentRuntimeActivities:
         terminal_failure_code = str(
             metadata.get("terminalFailureCode") or evaluation.failure_code or ""
         ).strip()
-        if terminal_failure_code == "BATCH_FANOUT_INPUT_INVALID":
+        if evaluation.failure_code == "BATCH_FANOUT_INPUT_INVALID":
             return result.model_copy(
                 update={
                     "summary": terminal_failure_message

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -11865,6 +11865,22 @@ class TemporalAgentRuntimeActivities:
             }
         )
         missing = ", ".join(evaluation.missing_evidence) or "valid terminal evidence"
+        terminal_failure_message = str(
+            metadata.get("terminalFailureMessage") or ""
+        ).strip()
+        terminal_failure_code = str(
+            metadata.get("terminalFailureCode") or evaluation.failure_code or ""
+        ).strip()
+        if terminal_failure_code == "BATCH_FANOUT_INPUT_INVALID":
+            return result.model_copy(
+                update={
+                    "summary": terminal_failure_message
+                    or "Batch fan-out input validation failed.",
+                    "failure_class": "user_error",
+                    "provider_error_code": terminal_failure_code,
+                    "metadata": metadata,
+                }
+            )
         if result.failure_class is not None:
             return result.model_copy(
                 update={

--- a/moonmind/workflows/terminal_evidence.py
+++ b/moonmind/workflows/terminal_evidence.py
@@ -156,6 +156,46 @@ def evaluate_terminal_evidence(
         return TerminalEvidenceEvaluation(False, "INVALID_TERMINAL_EVIDENCE")
     if not expected_execution or payload.get("executionRef") != expected_execution:
         return TerminalEvidenceEvaluation(False, "STALE_TERMINAL_EVIDENCE")
+    status = payload.get("status")
+    queued = payload.get("queued")
+    requested, created = payload.get("requested"), payload.get("created")
+    skipped = payload.get("skipped")
+    errors = payload.get("errors")
+    failure = payload.get("failure")
+    failure_payload = dict(failure) if isinstance(failure, Mapping) else {}
+    failure_code = str(failure_payload.get("code") or "").strip()
+    failure_message = str(failure_payload.get("message") or "").strip()
+    metadata = {
+        "terminalContractId": contract_id,
+        "terminalContractEvidencePath": relative,
+        "terminalContractExecutionRef": expected_execution,
+        "queuedChildCount": created if isinstance(created, int) else 0,
+        "queuedChildren": queued if isinstance(queued, list) else [],
+    }
+    if failure_code:
+        metadata["terminalFailureCode"] = failure_code
+    if failure_message:
+        metadata["terminalFailureMessage"] = failure_message
+
+    # Input validation can fail before a trustworthy target list exists. The
+    # portable helper still binds that terminal failure to this execution and
+    # guarantees that no child side effect occurred.
+    if status == "failed" and failure_code == "BATCH_FANOUT_INPUT_INVALID":
+        if (
+            not isinstance(requested, int)
+            or requested < 0
+            or created != 0
+            or queued != []
+            or skipped != []
+            or not isinstance(errors, list)
+            or not errors
+            or not failure_message
+        ):
+            return TerminalEvidenceEvaluation(
+                False, "INVALID_TERMINAL_EVIDENCE", metadata=metadata
+            )
+        return _failure("BATCH_FANOUT_INPUT_INVALID", metadata=metadata)
+
     targets_relative = str(contract.get("targetsRelativePath") or "artifacts/batch-workflows-targets.json").replace("\\", "/")
     targets_path = (workspace / targets_relative).resolve()
     try:
@@ -165,17 +205,6 @@ def evaluate_terminal_evidence(
         return TerminalEvidenceEvaluation(False, "INVALID_TERMINAL_EVIDENCE")
     if payload.get("targetsSha256") != expected_digest:
         return TerminalEvidenceEvaluation(False, "STALE_TERMINAL_EVIDENCE")
-    status = payload.get("status")
-    queued = payload.get("queued")
-    requested, created = payload.get("requested"), payload.get("created")
-    skipped = payload.get("skipped")
-    errors = payload.get("errors")
-    metadata = {
-        "terminalContractId": contract_id,
-        "terminalContractEvidencePath": relative,
-        "queuedChildCount": created if isinstance(created, int) else 0,
-        "queuedChildren": queued if isinstance(queued, list) else [],
-    }
     if status == "running":
         return TerminalEvidenceEvaluation(
             False, "INCOMPLETE_TERMINAL_CONTRACT", metadata=metadata

--- a/tests/integration/reliability/replays/batch-workflows-invalid-range/expected-outcome.json
+++ b/tests/integration/reliability/replays/batch-workflows-invalid-range/expected-outcome.json
@@ -1,0 +1,7 @@
+{
+  "parentState": "failed",
+  "failureClass": "user_error",
+  "failureCode": "BATCH_FANOUT_INPUT_INVALID",
+  "retryable": false,
+  "missingEvidence": []
+}

--- a/tests/integration/reliability/replays/batch-workflows-invalid-range/manifest.json
+++ b/tests/integration/reliability/replays/batch-workflows-invalid-range/manifest.json
@@ -1,0 +1,34 @@
+{
+  "failureShapeId": "batch-workflows-invalid-range",
+  "incidentWorkflowId": "mm:3df0b867-a25a-4560-b21d-fad3689f5fd8",
+  "issueRange": "3370-3425",
+  "maxWorkflows": 25,
+  "requestedCount": 56,
+  "terminalContract": {
+    "contractId": "batch_workflows_fanout.v1",
+    "relativePath": "artifacts/batch-workflows-result.json",
+    "expectedSchemaVersion": "moonmind.batch-workflows-result.v1",
+    "executionRef": "workflow:run:step:execution:1"
+  },
+  "terminalEvidence": {
+    "schemaVersion": "moonmind.batch-workflows-result.v1",
+    "contractId": "batch_workflows_fanout.v1",
+    "executionRef": "workflow:run:step:execution:1",
+    "targetsSha256": null,
+    "status": "failed",
+    "requested": 56,
+    "created": 0,
+    "queued": [],
+    "skipped": [],
+    "errors": [
+      {
+        "code": "BATCH_FANOUT_INPUT_INVALID",
+        "error": "Range 3370-3425 contains 56 issues; maximum is 25."
+      }
+    ],
+    "failure": {
+      "code": "BATCH_FANOUT_INPUT_INVALID",
+      "message": "Range 3370-3425 contains 56 issues; maximum is 25."
+    }
+  }
+}

--- a/tests/integration/reliability/test_escaped_failure_journeys.py
+++ b/tests/integration/reliability/test_escaped_failure_journeys.py
@@ -243,6 +243,47 @@ async def test_completed_batch_turn_is_rejected_at_agent_run_boundary(
     ]
 
 
+async def test_invalid_batch_range_records_terminal_failure_without_retry(
+    tmp_path: Path,
+) -> None:
+    """Replay mm:3df0b867 through the terminal and parent retry boundaries."""
+    manifest = load_replay("batch-workflows-invalid-range", "manifest.json")
+    expected = load_replay(
+        "batch-workflows-invalid-range", "expected-outcome.json"
+    )
+    workspace = tmp_path / "repo"
+    spool = tmp_path / "spool"
+    workspace.mkdir()
+    spool.mkdir()
+    (spool / "batch-workflows-result.json").write_text(
+        json.dumps(manifest["terminalEvidence"]), encoding="utf-8"
+    )
+
+    result = await TemporalAgentRuntimeActivities().agent_runtime_evaluate_terminal_evidence(
+        {
+            "workspacePath": str(workspace),
+            "artifactSpoolPath": str(spool),
+            "terminalContract": manifest["terminalContract"],
+            "result": {"summary": "Batch range validation failed."},
+        }
+    )
+
+    assert result.failure_class == expected["failureClass"]
+    assert result.provider_error_code == expected["failureCode"]
+    assert result.metadata["terminalContractMissingEvidence"] == expected[
+        "missingEvidence"
+    ]
+
+    parent = MoonMindRunWorkflow()
+    retryable = parent._activity_result_retryable(
+        {"outputs": result.model_dump(mode="json", by_alias=True)},
+        failure_message="execution_error",
+        tool_type="agent_runtime",
+    )
+    assert retryable is expected["retryable"]
+    assert expected["parentState"] == "failed"
+
+
 async def test_completed_batch_no_op_replays_through_production_activity_route(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/unit/api/test_batch_github_workflows_preset.py
+++ b/tests/unit/api/test_batch_github_workflows_preset.py
@@ -83,6 +83,8 @@ async def test_batch_github_workflows_seed_and_expansion_contract(tmp_path):
     assert orchestration["publish"]["mode"] == "pr_with_merge_automation"
     assert orchestration["runtime"]["inherit"] == "caller"
     assert "--run-verify" in step["instructions"]
+    assert "--preflight-error" in step["instructions"]
+    assert "--requested-count" in step["instructions"]
 
 
 async def test_batch_github_workflows_uses_repository_context(tmp_path):

--- a/tests/unit/test_batch_workflows.py
+++ b/tests/unit/test_batch_workflows.py
@@ -732,6 +732,38 @@ def test_helper_records_preflight_failure_without_targets_or_queueing(
     assert evidence["failure"]["code"] == "BATCH_FANOUT_INPUT_INVALID"
 
 
+def test_helper_preserves_preflight_classification_for_negative_requested_count(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module = _load_module()
+    spool = tmp_path / "spool"
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("MOONMIND_STEP_EXECUTION_ID", "step-negative-count")
+    monkeypatch.setenv("MOONMIND_SESSION_ARTIFACT_SPOOL_PATH", str(spool))
+
+    return_code = module["main"](
+        [
+            "--targets",
+            "artifacts/batch-workflows-targets.json",
+            "--run-ref",
+            "preset:github-issue-implement",
+            "--preflight-error",
+            "Invalid range.",
+            "--requested-count",
+            "-1",
+        ]
+    )
+
+    evidence = json.loads((spool / "batch-workflows-result.json").read_text())
+    assert return_code == 2
+    assert evidence["status"] == "failed"
+    assert evidence["requested"] == 0
+    assert evidence["failure"] == {
+        "code": "BATCH_FANOUT_INPUT_INVALID",
+        "message": "--requested-count must be zero or greater",
+    }
+
+
 def test_materialized_helper_failure_matrix_preserves_authoritative_evidence(tmp_path):
     """Every preflight/transport failure replaces stale evidence and retains children."""
     repo_root = Path(__file__).resolve().parents[2]

--- a/tests/unit/test_batch_workflows.py
+++ b/tests/unit/test_batch_workflows.py
@@ -698,6 +698,40 @@ def test_materialized_snapshot_queues_five_targets_from_external_repo(tmp_path):
     assert [item["ref"] for item in evidence["queued"]] == [f"THOR-{n}" for n in range(705, 710)]
 
 
+def test_helper_records_preflight_failure_without_targets_or_queueing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module = _load_module()
+    spool = tmp_path / "spool"
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("MOONMIND_STEP_EXECUTION_ID", "step-invalid-range")
+    monkeypatch.setenv("MOONMIND_SESSION_ARTIFACT_SPOOL_PATH", str(spool))
+    monkeypatch.delenv("MOONMIND_URL", raising=False)
+
+    return_code = module["main"](
+        [
+            "--targets",
+            "artifacts/batch-workflows-targets.json",
+            "--run-ref",
+            "preset:github-issue-implement",
+            "--preflight-error",
+            "Range 3370-3425 contains 56 issues; maximum is 25.",
+            "--requested-count",
+            "56",
+        ]
+    )
+
+    assert return_code == 2
+    assert not (tmp_path / "artifacts/batch-workflows-targets.json").exists()
+    evidence = json.loads((spool / "batch-workflows-result.json").read_text())
+    assert evidence["executionRef"] == "step-invalid-range"
+    assert evidence["status"] == "failed"
+    assert evidence["requested"] == 56
+    assert evidence["created"] == 0
+    assert evidence["queued"] == []
+    assert evidence["failure"]["code"] == "BATCH_FANOUT_INPUT_INVALID"
+
+
 def test_materialized_helper_failure_matrix_preserves_authoritative_evidence(tmp_path):
     """Every preflight/transport failure replaces stale evidence and retains children."""
     repo_root = Path(__file__).resolve().parents[2]

--- a/tests/unit/workflows/temporal/test_agent_runtime_activities.py
+++ b/tests/unit/workflows/temporal/test_agent_runtime_activities.py
@@ -6276,3 +6276,57 @@ async def test_terminal_evidence_activity_classifies_batch_input_failure_as_user
     assert result.provider_error_code == "BATCH_FANOUT_INPUT_INVALID"
     assert result.summary == message
     assert result.metadata["terminalContractMissingEvidence"] == []
+
+
+@pytest.mark.asyncio
+async def test_terminal_evidence_activity_does_not_trust_rejected_failure_metadata(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "repo"
+    spool = tmp_path / "spool"
+    workspace.mkdir()
+    spool.mkdir()
+    (spool / "batch-workflows-result.json").write_text(
+        json.dumps(
+            {
+                "schemaVersion": "moonmind.batch-workflows-result.v1",
+                "contractId": "batch_workflows_fanout.v1",
+                "executionRef": "step-malformed-input-failure",
+                "targetsSha256": None,
+                "status": "failed",
+                "requested": 1,
+                "created": 1,
+                "queued": [{"executionId": "unexpected-child"}],
+                "skipped": [],
+                "errors": [
+                    {
+                        "code": "BATCH_FANOUT_INPUT_INVALID",
+                        "error": "Invalid range.",
+                    }
+                ],
+                "failure": {
+                    "code": "BATCH_FANOUT_INPUT_INVALID",
+                    "message": "Invalid range.",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = await TemporalAgentRuntimeActivities().agent_runtime_evaluate_terminal_evidence(
+        {
+            "workspacePath": str(workspace),
+            "artifactSpoolPath": str(spool),
+            "terminalContract": {
+                "contractId": "batch_workflows_fanout.v1",
+                "relativePath": "artifacts/batch-workflows-result.json",
+                "expectedSchemaVersion": "moonmind.batch-workflows-result.v1",
+                "executionRef": "step-malformed-input-failure",
+            },
+            "result": {"summary": "Malformed terminal result."},
+        }
+    )
+
+    assert result.failure_class == "execution_error"
+    assert result.provider_error_code == "INVALID_TERMINAL_EVIDENCE"
+    assert result.metadata["failureCode"] == "INVALID_TERMINAL_EVIDENCE"

--- a/tests/unit/workflows/temporal/test_agent_runtime_activities.py
+++ b/tests/unit/workflows/temporal/test_agent_runtime_activities.py
@@ -6218,3 +6218,61 @@ async def test_terminal_evidence_activity_enriches_existing_helper_failure(
     assert result.provider_error_code == "process_exit_1"
     assert result.metadata["failureCode"] == "BATCH_FANOUT_PARTIAL_FAILURE"
     assert result.metadata["queuedChildren"] == [{"executionId": "child-1"}]
+
+
+@pytest.mark.asyncio
+async def test_terminal_evidence_activity_classifies_batch_input_failure_as_user_error(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "repo"
+    spool = tmp_path / "spool"
+    workspace.mkdir()
+    spool.mkdir()
+    message = "Range 3370-3425 contains 56 issues; maximum is 25."
+    (spool / "batch-workflows-result.json").write_text(
+        json.dumps(
+            {
+                "schemaVersion": "moonmind.batch-workflows-result.v1",
+                "contractId": "batch_workflows_fanout.v1",
+                "executionRef": "step-invalid-range",
+                "targetsSha256": None,
+                "status": "failed",
+                "requested": 56,
+                "created": 0,
+                "queued": [],
+                "skipped": [],
+                "errors": [
+                    {"code": "BATCH_FANOUT_INPUT_INVALID", "error": message}
+                ],
+                "failure": {
+                    "code": "BATCH_FANOUT_INPUT_INVALID",
+                    "message": message,
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    activities = TemporalAgentRuntimeActivities()
+    result = await activities.agent_runtime_evaluate_terminal_evidence(
+        {
+            "workspacePath": str(workspace),
+            "artifactSpoolPath": str(spool),
+            "terminalContract": {
+                "contractId": "batch_workflows_fanout.v1",
+                "relativePath": "artifacts/batch-workflows-result.json",
+                "expectedSchemaVersion": "moonmind.batch-workflows-result.v1",
+                "executionRef": "step-invalid-range",
+            },
+            "result": {
+                "summary": "helper exited 2",
+                "failureClass": "execution_error",
+                "providerErrorCode": "process_exit_2",
+            },
+        }
+    )
+
+    assert result.failure_class == "user_error"
+    assert result.provider_error_code == "BATCH_FANOUT_INPUT_INVALID"
+    assert result.summary == message
+    assert result.metadata["terminalContractMissingEvidence"] == []

--- a/tests/unit/workflows/test_terminal_evidence.py
+++ b/tests/unit/workflows/test_terminal_evidence.py
@@ -90,6 +90,56 @@ def test_batch_terminal_reads_result_from_artifact_spool(tmp_path: Path) -> None
     assert result.metadata["queuedChildren"] == [{"executionId": "child-1"}]
 
 
+def test_batch_terminal_accepts_preflight_failure_without_target_list(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "repo"
+    spool = tmp_path / "spool"
+    workspace.mkdir()
+    spool.mkdir()
+    (spool / "batch-workflows-result.json").write_text(
+        json.dumps(
+            {
+                "schemaVersion": "moonmind.batch-workflows-result.v1",
+                "contractId": "batch_workflows_fanout.v1",
+                "executionRef": "step:1",
+                "targetsSha256": None,
+                "status": "failed",
+                "requested": 56,
+                "created": 0,
+                "queued": [],
+                "skipped": [],
+                "errors": [
+                    {
+                        "code": "BATCH_FANOUT_INPUT_INVALID",
+                        "error": "Range contains 56 issues; maximum is 25.",
+                    }
+                ],
+                "failure": {
+                    "code": "BATCH_FANOUT_INPUT_INVALID",
+                    "message": "Range contains 56 issues; maximum is 25.",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = evaluate_terminal_evidence(
+        _contract(),
+        workspace_path=str(workspace),
+        artifact_spool_path=str(spool),
+    )
+
+    assert result.satisfied is False
+    assert result.failure_code == "BATCH_FANOUT_INPUT_INVALID"
+    assert result.missing_evidence == ()
+    assert result.metadata["terminalContractExecutionRef"] == "step:1"
+    assert (
+        result.metadata["terminalFailureMessage"]
+        == "Range contains 56 issues; maximum is 25."
+    )
+
+
 def test_pr_resolver_terminal_requires_result_and_publish_evidence(tmp_path: Path) -> None:
     contract = {
         "contractId": "pr_resolver_terminal.v1",


### PR DESCRIPTION
## Summary

- record batch input-validation failures through the portable helper and authoritative artifact spool
- accept current-execution preflight failure evidence without a target list
- classify invalid batch input as a non-retryable user error
- add a minimized replay for workflow mm:3df0b867-a25a-4560-b21d-fad3689f5fd8

## Root cause

The requested GitHub range contained 56 issues while the configured cap was 25. The agent correctly stopped before reading issues, but that path bypassed the helper that writes terminal evidence. Follow-up turns hand-authored repo-local evidence tied to an older execution, while MoonMind expected current-execution evidence in the managed artifact spool. The parent therefore reported an incomplete terminal contract and retried the deterministic validation failure.

## Impact

Invalid batch inputs now produce an authoritative, actionable terminal result without reading provider data, queueing partial children, or consuming repeated agent retries.

## Validation

- 50 focused helper, preset, terminal-evidence, activity-boundary, and reliability replay tests passed in the repository Linux Python-test image
- git diff --check