### PR TITLE
Fix Dependabot batch resolver dispatch

### DIFF
--- a/.agents/skills/batch-dependabot-resolver/SKILL.md
+++ b/.agents/skills/batch-dependabot-resolver/SKILL.md
@@ -80,16 +80,6 @@ inputSchema:
 uiSchema:
   titleRegex:
     widget: textarea
-defaults:
-  state: open
-  mergeMethod: squash
-  maxIterations: 5
-  maxAttempts: 3
-  priority: 0
-  packageManagers: []
-  titleRegex: '^(?:Bump|[Cc]hore\(deps\): bump) .+ from \S+ to \S+(?: in /.+)?$'
-  includeSecurityUpdates: true
-  dryRun: false
 ---
 
 # Batch Dependabot Resolver Skill

--- a/.agents/skills/batch-dependabot-resolver/SKILL.md
+++ b/.agents/skills/batch-dependabot-resolver/SKILL.md
@@ -6,8 +6,90 @@ metadata:
     kind: enqueue_children
     owner: agent
     outcomeArtifact: artifacts/batch_dependabot_resolver_result.json
+    terminalContractId: batch_dependabot_resolver_fanout.v1
+    terminalSchemaVersion: moonmind.batch-dependabot-resolver-result.v1
   required-capabilities:
     - gh
+inputSchema:
+  type: object
+  properties:
+    repo:
+      type: string
+      title: Repository
+      description: >-
+        Target repository in owner/repo form; inferred from task context when omitted.
+      x-moonmind-context-default: repository
+    state:
+      type: string
+      title: Pull request state
+      enum: [open, closed, merged, all]
+      default: open
+    mergeMethod:
+      type: string
+      title: Merge method
+      enum: [squash, merge, rebase]
+      default: squash
+    maxIterations:
+      type: integer
+      title: Resolver iteration limit
+      minimum: 1
+      default: 5
+    maxAttempts:
+      type: integer
+      title: Queue attempt limit
+      minimum: 1
+      default: 3
+    priority:
+      type: integer
+      title: Queue priority
+      default: 0
+    packageManagers:
+      type: array
+      title: Package managers
+      items:
+        type: string
+      default: []
+    titleRegex:
+      type: string
+      title: Version-bump title regex
+      default: '^(?:Bump|[Cc]hore\(deps\): bump) .+ from \S+ to \S+(?: in /.+)?$'
+    includeSecurityUpdates:
+      type: boolean
+      title: Include security updates
+      default: true
+    maxPrs:
+      type: integer
+      title: Maximum PRs per run
+      minimum: 1
+    dryRun:
+      type: boolean
+      title: Dry run
+      default: false
+    runtimeMode:
+      type: string
+      title: Child runtime override
+    runtimeModel:
+      type: string
+      title: Child model override
+    runtimeEffort:
+      type: string
+      title: Child effort override
+    runtimeProviderProfile:
+      type: string
+      title: Child provider profile override
+uiSchema:
+  titleRegex:
+    widget: textarea
+defaults:
+  state: open
+  mergeMethod: squash
+  maxIterations: 5
+  maxAttempts: 3
+  priority: 0
+  packageManagers: []
+  titleRegex: '^(?:Bump|[Cc]hore\(deps\): bump) .+ from \S+ to \S+(?: in /.+)?$'
+  includeSecurityUpdates: true
+  dryRun: false
 ---
 
 # Batch Dependabot Resolver Skill
@@ -41,7 +123,10 @@ each queued `pr-resolver` child owns its repository publishing outcome.
   `github-actions`. Matched against the Dependabot branch ecosystem segment with alias
   normalization (`npm`↔`npm_and_yarn`, `github-actions`↔`github_actions`). Omit to allow all.
 - `titleRegex` (string, optional): Override for the version-bump title matcher.
-  Default `^Bump .+ from \S+ to \S+(?: in /.+)?$` (matches e.g. `Bump anthropic from 0.105.2 to 0.107.1` and subdirectory suffixes like `in /frontend`).
+  Default `^(?:Bump|[Cc]hore\(deps\): bump) .+ from \S+ to \S+(?: in /.+)?$`
+  (matches both Dependabot's legacy `Bump anthropic from 0.105.2 to 0.107.1`
+  titles and conventional-commit titles such as `Chore(deps): bump anthropic from
+  0.105.2 to 0.107.1`, including subdirectory suffixes like `in /frontend`).
 - `includeSecurityUpdates` (boolean, optional): Default `true`. When `false`, PRs labeled
   `security` are skipped.
 - `maxPrs` (number, optional): Safety cap on the number of resolver workflows queued per run.
@@ -99,8 +184,11 @@ python3 .agents/skills/batch-dependabot-resolver/bin/batch_dependabot_resolver.p
 5. Write a summary artifact `batch_dependabot_resolver_result.json` (under the managed
    session artifact spool when available, otherwise the configured `--artifacts-dir`) listing
    discovered PRs, matched count, queued / would-queue resolver workflows, skipped PRs with
-   reasons, and submission errors. A deliberate zero-match run also writes
-   `skill_outcome.json` with `status: "no_op"`.
+   reasons, runtime-inheritance mode, and submission errors. A deliberate zero-match run also
+   writes `skill_outcome.json` with `status: "no_op"`. When the default title contract rejects
+   a Dependabot title that still has the shape of a single version bump (`bump ... from ... to
+   ...`), the helper records title-contract drift and fails instead of silently reporting a
+   successful no-op.
 
 6. Print a short summary to stdout (`matched`, `queued`, `would_queue`, `skipped`, `errors`).
 

--- a/.agents/skills/batch-dependabot-resolver/bin/batch_dependabot_resolver.py
+++ b/.agents/skills/batch-dependabot-resolver/bin/batch_dependabot_resolver.py
@@ -906,9 +906,12 @@ def _would_queue_records(queue_requests: list[JobSubmission]) -> list[dict[str, 
 
 def _write_artifacts(path: Path, payload: dict[str, Any]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    temporary = path.with_name(f".{path.name}.{os.getpid()}.tmp")
-    temporary.write_text(json.dumps(payload, indent=2), encoding="utf-8")
-    os.replace(temporary, path)
+    temporary = path.with_name(f".{path.name}.{os.urandom(6).hex()}.tmp")
+    try:
+        temporary.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+        os.replace(temporary, path)
+    finally:
+        temporary.unlink(missing_ok=True)
 
 
 def _write_run_artifacts(artifacts_dir: Path, payload: dict[str, Any]) -> None:
@@ -1093,14 +1096,14 @@ async def main(argv: list[str] | None = None) -> int:
         and item.get("likelyVersionBump") is True
     ]
     failure_code: str | None = None
-    if args.dry_run:
-        status = "dry_run"
-    elif errors:
+    if errors:
         status = "partial_failure" if created else "failed"
         failure_code = "CHILD_WORKFLOW_QUEUE_FAILED"
     elif title_contract_drift_prs:
         status = "partial_failure" if created else "failed"
         failure_code = "DEPENDABOT_TITLE_CONTRACT_DRIFT"
+    elif args.dry_run:
+        status = "dry_run"
     elif created:
         status = "queued"
     else:

--- a/.agents/skills/batch-dependabot-resolver/bin/batch_dependabot_resolver.py
+++ b/.agents/skills/batch-dependabot-resolver/bin/batch_dependabot_resolver.py
@@ -35,7 +35,12 @@ logger = logging.getLogger(__name__)
 API_EXECUTIONS_ENDPOINT = "/api/executions"
 IDEMPOTENCY_KEY_MAX_LENGTH = 128
 TERMINAL_FAILURE_STATES = {"failed", "canceled", "terminated"}
-DEFAULT_TITLE_REGEX = r"^Bump .+ from \S+ to \S+(?: in /.+)?$"
+DEFAULT_TITLE_REGEX = (
+    r"^(?:Bump|[Cc]hore\(deps\): bump) .+ from \S+ to \S+(?: in /.+)?$"
+)
+LIKELY_VERSION_BUMP_TITLE_REGEX = re.compile(
+    r"\bbump\s+.+\s+from\s+\S+\s+to\s+\S+", re.IGNORECASE
+)
 DEPENDABOT_BRANCH_PREFIX = "dependabot/"
 
 # Friendly package-manager names (as an operator would type them) mapped to the
@@ -286,6 +291,12 @@ def _title_matches(title: str | None, pattern: str) -> bool:
         return re.search(pattern, str(title or "").strip()) is not None
     except re.error as exc:
         raise RuntimeError(f"invalid titleRegex {pattern!r}: {exc}") from exc
+
+
+def _looks_like_version_bump_title(title: Any) -> bool:
+    """Return whether a rejected title still resembles one version bump."""
+
+    return bool(LIKELY_VERSION_BUMP_TITLE_REGEX.search(str(title or "").strip()))
 
 
 def _branch_package_manager(branch: str | None) -> str | None:
@@ -684,7 +695,15 @@ def _build_request_records(
             include_security_updates=args.include_security_updates,
         )
         if reason is not None:
-            skipped.append({"pr": number, "branch": branch, "reason": reason})
+            skipped_entry = {"pr": number, "branch": branch, "reason": reason}
+            if (
+                reason == "title-mismatch"
+                and args.title_regex == DEFAULT_TITLE_REGEX
+                and _looks_like_version_bump_title(pr.get("title"))
+            ):
+                skipped_entry["title"] = str(pr.get("title") or "").strip()
+                skipped_entry["likelyVersionBump"] = True
+            skipped.append(skipped_entry)
             continue
         matched.append((number, branch, _extract_head_sha(pr)))
 
@@ -887,7 +906,9 @@ def _would_queue_records(queue_requests: list[JobSubmission]) -> list[dict[str, 
 
 def _write_artifacts(path: Path, payload: dict[str, Any]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(payload, indent=2))
+    temporary = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    temporary.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    os.replace(temporary, path)
 
 
 def _write_run_artifacts(artifacts_dir: Path, payload: dict[str, Any]) -> None:
@@ -895,12 +916,16 @@ def _write_run_artifacts(artifacts_dir: Path, payload: dict[str, Any]) -> None:
 
     ``skill_outcome.json`` with ``status: "no_op"`` is written only when the run
     queued zero executions, hit no submission errors, and was not a dry run —
-    i.e. a deliberate "no matching Dependabot PRs" outcome.
+    i.e. a deliberate "no matching Dependabot PRs" outcome. A likely version-bump
+    title rejected by the default matcher is filter-contract drift, not a no-op.
     """
 
     _write_artifacts(artifacts_dir / "batch_dependabot_resolver_result.json", payload)
     errors = payload.get("errors") or []
     created = int(payload.get("created") or 0)
+    title_contract_drift_prs = (
+        (payload.get("diagnostics") or {}).get("titleContractDriftPrs") or []
+    )
     if errors:
         _write_artifacts(
             artifacts_dir / "skill_outcome.json",
@@ -912,6 +937,20 @@ def _write_run_artifacts(artifacts_dir: Path, payload: dict[str, Any]) -> None:
                     "requested": payload.get("requested"),
                     "created": created,
                     "errors": errors,
+                },
+            },
+        )
+    elif title_contract_drift_prs:
+        _write_artifacts(
+            artifacts_dir / "skill_outcome.json",
+            {
+                "schema_version": 1,
+                "status": "partial" if created else "failed",
+                "reason": "dependabot_title_contract_drift",
+                "evidence": {
+                    "requested": payload.get("requested"),
+                    "created": created,
+                    "titleContractDriftPrs": title_contract_drift_prs,
                 },
             },
         )
@@ -972,7 +1011,10 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument(
         "--title-regex",
         default=DEFAULT_TITLE_REGEX,
-        help="Version-bump title matcher (default: Bump <dep> from <old> to <new>).",
+        help=(
+            "Version-bump title matcher (default: Bump <dep> from <old> to <new> "
+            "or Chore(deps): bump <dep> from <old> to <new>)."
+        ),
     )
     parser.add_argument(
         "--include-security-updates",
@@ -1011,6 +1053,25 @@ async def main(argv: list[str] | None = None) -> int:
     if args.state.strip() != "open":
         print(f"warning: non-open state requested: {args.state}")
     runtime = _resolve_runtime_selection(args)
+    artifacts_dir = _resolve_artifacts_dir(args.artifacts_dir, args.task_context_path)
+    execution_ref = _runtime_text(os.getenv("MOONMIND_STEP_EXECUTION_ID"))
+    if execution_ref is None:
+        execution_ref = f"local:batch-dependabot-resolver:{repo}"
+    _write_artifacts(
+        artifacts_dir / "batch_dependabot_resolver_result.json",
+        {
+            "schemaVersion": "moonmind.batch-dependabot-resolver-result.v1",
+            "contractId": "batch_dependabot_resolver_fanout.v1",
+            "executionRef": execution_ref,
+            "status": "running",
+            "requested": 0,
+            "created": 0,
+            "queued": [],
+            "wouldQueue": [],
+            "skipped": [],
+            "errors": [],
+        },
+    )
 
     open_prs = _run_pr_list(repo=repo, state=args.state)
     queue_requests, skipped, matched_count = _build_request_records(
@@ -1025,7 +1086,32 @@ async def main(argv: list[str] | None = None) -> int:
         created, errors = await _submit_jobs(queue_requests)
         would_queue = []
 
+    title_contract_drift_prs = [
+        item.get("pr")
+        for item in skipped
+        if item.get("reason") == "title-mismatch"
+        and item.get("likelyVersionBump") is True
+    ]
+    failure_code: str | None = None
+    if args.dry_run:
+        status = "dry_run"
+    elif errors:
+        status = "partial_failure" if created else "failed"
+        failure_code = "CHILD_WORKFLOW_QUEUE_FAILED"
+    elif title_contract_drift_prs:
+        status = "partial_failure" if created else "failed"
+        failure_code = "DEPENDABOT_TITLE_CONTRACT_DRIFT"
+    elif created:
+        status = "queued"
+    else:
+        status = "no_op"
+
     payload = {
+        "schemaVersion": "moonmind.batch-dependabot-resolver-result.v1",
+        "contractId": "batch_dependabot_resolver_fanout.v1",
+        "executionRef": execution_ref,
+        "status": status,
+        "failureCode": failure_code,
         "timestamp": datetime.now(UTC).isoformat(),
         "actor": os.getenv("GITHUB_ACTOR") or os.getenv("USER") or "unknown",
         "repository": repo,
@@ -1042,6 +1128,9 @@ async def main(argv: list[str] | None = None) -> int:
             "model": runtime.model,
             "effort": runtime.effort,
             "executionProfileRef": runtime.provider_profile,
+            "inheritance": (
+                "caller" if _task_workflow_id_from_env() is not None else None
+            ),
         },
         "requested": len(open_prs),
         "matched": matched_count,
@@ -1051,10 +1140,16 @@ async def main(argv: list[str] | None = None) -> int:
         "skipped": skipped,
         "errors": errors,
     }
-    if not args.dry_run and payload["created"] == 0:
+    payload["diagnostics"] = {
+        "titleContractDriftPrs": title_contract_drift_prs,
+    }
+    if title_contract_drift_prs:
+        payload["message"] = (
+            "Dependabot version-bump titles did not match the default title contract."
+        )
+    elif not args.dry_run and payload["created"] == 0:
         payload["message"] = "No matching Dependabot PRs were queued."
 
-    artifacts_dir = _resolve_artifacts_dir(args.artifacts_dir, args.task_context_path)
     _write_run_artifacts(artifacts_dir, payload)
 
     print(json.dumps(payload, indent=2))
@@ -1063,7 +1158,7 @@ async def main(argv: list[str] | None = None) -> int:
         f"would_queue={len(would_queue)} skipped={len(skipped)} "
         f"errors={len(errors)} repo={repo} dry_run={bool(args.dry_run)}"
     )
-    if errors:
+    if errors or title_contract_drift_prs:
         return 1
     return 0
 

--- a/moonmind/services/skill_resolution.py
+++ b/moonmind/services/skill_resolution.py
@@ -247,6 +247,9 @@ def _terminal_contract_from_side_effect(
     if not contract_id:
         return None
     known = {
+        "batch_dependabot_resolver_fanout.v1": (
+            "moonmind.batch-dependabot-resolver-result.v1"
+        ),
         "batch_workflows_fanout.v1": "moonmind.batch-workflows-result.v1",
         "pr_resolver_terminal.v1": "moonmind.pr-resolver-result.v1",
     }

--- a/moonmind/workflows/adapters/managed_agent_adapter.py
+++ b/moonmind/workflows/adapters/managed_agent_adapter.py
@@ -1234,19 +1234,19 @@ class ManagedAgentAdapter:
                         output_refs.append(ref)
                 summary = record.error_message or f"Completed with status {record.status}"
                 failure_class = record.failure_class
-                metadata = _derive_pr_resolver_metadata(
-                    record.workspace_path,
-                    merge_gate_owned=pr_resolver_merge_gate_owned,
-                    supports_same_session_continuation=(
-                        resolve_runtime_execution_capabilities(record.runtime_id)
-                        .supports_same_session_continuation
-                    ),
-                    run_id=record.run_id,
-                    workflow_id=record.workflow_id,
-                    not_before=record.started_at,
-                )
-                if not pr_resolver_expected:
-                    metadata.pop("retryRecommendation", None)
+                metadata: dict[str, Any] = {}
+                if pr_resolver_expected:
+                    metadata = _derive_pr_resolver_metadata(
+                        record.workspace_path,
+                        merge_gate_owned=pr_resolver_merge_gate_owned,
+                        supports_same_session_continuation=(
+                            resolve_runtime_execution_capabilities(record.runtime_id)
+                            .supports_same_session_continuation
+                        ),
+                        run_id=record.run_id,
+                        workflow_id=record.workflow_id,
+                        not_before=record.started_at,
+                    )
                 if (
                     include_workspace_auto_publish_evidence
                     and "publishResult" not in metadata

--- a/moonmind/workflows/terminal_evidence.py
+++ b/moonmind/workflows/terminal_evidence.py
@@ -39,11 +39,94 @@ def _success(metadata: dict[str, Any] | None = None) -> TerminalEvidenceEvaluati
     )
 
 
+def _evaluate_batch_dependabot_resolver_evidence(
+    payload: Mapping[str, Any],
+    *,
+    contract_id: str,
+    relative_path: str,
+) -> TerminalEvidenceEvaluation:
+    """Validate the authoritative discovery and child-enqueue result."""
+
+    requested = payload.get("requested")
+    created = payload.get("created")
+    queued = payload.get("queued")
+    would_queue = payload.get("wouldQueue")
+    skipped = payload.get("skipped")
+    errors = payload.get("errors")
+    metadata = {
+        "terminalContractId": contract_id,
+        "terminalContractEvidencePath": relative_path,
+        "queuedChildCount": created if isinstance(created, int) else 0,
+        "queuedChildren": queued if isinstance(queued, list) else [],
+    }
+    status = payload.get("status")
+    if status == "running":
+        return _failure("INCOMPLETE_TERMINAL_CONTRACT", metadata=metadata)
+    accounted = (
+        len(would_queue)
+        if status == "dry_run" and isinstance(would_queue, list)
+        else created
+    )
+    if (
+        not isinstance(requested, int)
+        or requested < 0
+        or not isinstance(created, int)
+        or created < 0
+        or not isinstance(queued, list)
+        or not isinstance(would_queue, list)
+        or not isinstance(skipped, list)
+        or not isinstance(errors, list)
+        or len(queued) != created
+        or not isinstance(accounted, int)
+        or accounted + len(skipped) + len(errors) != requested
+    ):
+        return _failure("INVALID_TERMINAL_EVIDENCE", metadata=metadata)
+
+    failure_code = str(payload.get("failureCode") or "").strip()
+    if status == "partial_failure":
+        return _failure(
+            failure_code or "BATCH_FANOUT_PARTIAL_FAILURE", metadata=metadata
+        )
+    if status == "failed":
+        return _failure(failure_code or "BATCH_FANOUT_FAILED", metadata=metadata)
+    if status == "dry_run":
+        if (
+            payload.get("dryRun") is True
+            and created == 0
+            and not errors
+            and len(would_queue) + len(skipped) == requested
+        ):
+            return _success(metadata)
+        return _failure("INVALID_TERMINAL_EVIDENCE", metadata=metadata)
+    if status == "no_op":
+        if created == 0 and not errors and len(skipped) == requested:
+            return _success(metadata)
+        return _failure("INVALID_TERMINAL_EVIDENCE", metadata=metadata)
+    if status == "queued":
+        if (
+            created > 0
+            and not errors
+            and created + len(skipped) == requested
+            and all(
+                isinstance(item, Mapping)
+                and str(item.get("workflowId") or "").strip()
+                for item in queued
+            )
+        ):
+            return _success(metadata)
+        return _failure("INVALID_TERMINAL_EVIDENCE", metadata=metadata)
+    return _failure("INCOMPLETE_TERMINAL_CONTRACT", metadata=metadata)
+
+
 def evaluate_terminal_evidence(
     contract: Mapping[str, Any], *, workspace_path: str, artifact_spool_path: str = ""
 ) -> TerminalEvidenceEvaluation:
     contract_id = str(contract.get("contractId") or contract.get("contract_id") or "")
-    if contract_id not in {"batch_workflows_fanout.v1", "pr_resolver_terminal.v1"}:
+    if contract_id not in {
+        "batch_dependabot_resolver_fanout.v1",
+        "batch_workflows_fanout.v1",
+        "pr_resolver_terminal.v1",
+    }:
         return _failure("UNSUPPORTED_TERMINAL_CONTRACT")
     relative = str(contract.get("relativePath") or contract.get("relative_path") or "")
     normalized_relative = relative.replace("\\", "/")
@@ -156,6 +239,12 @@ def evaluate_terminal_evidence(
         return TerminalEvidenceEvaluation(False, "INVALID_TERMINAL_EVIDENCE")
     if not expected_execution or payload.get("executionRef") != expected_execution:
         return TerminalEvidenceEvaluation(False, "STALE_TERMINAL_EVIDENCE")
+    if contract_id == "batch_dependabot_resolver_fanout.v1":
+        return _evaluate_batch_dependabot_resolver_evidence(
+            payload,
+            contract_id=contract_id,
+            relative_path=relative,
+        )
     targets_relative = str(contract.get("targetsRelativePath") or "artifacts/batch-workflows-targets.json").replace("\\", "/")
     targets_path = (workspace / targets_relative).resolve()
     try:

--- a/tests/integration/skills/test_batch_dependabot_resolver_e2e.py
+++ b/tests/integration/skills/test_batch_dependabot_resolver_e2e.py
@@ -338,6 +338,36 @@ def test_end_to_end_fails_when_default_title_contract_drifts(
     assert outcome["reason"] == "dependabot_title_contract_drift"
 
 
+def test_end_to_end_dry_run_fails_when_default_title_contract_drifts(
+    monkeypatch: Any,
+    tmp_path: Path,
+) -> None:
+    module = _load_module()
+    drifted_pr = {
+        **_mixed_pr_set()[0],
+        "number": 9,
+        "title": "Deps: bump anthropic from 0.105.2 to 0.107.1",
+    }
+    summary = _run_main(
+        module,
+        ["--repo", "MoonLadderStudios/MoonMind", "--dry-run"],
+        monkeypatch,
+        tmp_path,
+        pr_set=[drifted_pr],
+    )
+
+    assert summary["_exit_code"] == 1
+    assert summary["dryRun"] is True
+    assert summary["status"] == "failed"
+    assert summary["failureCode"] == "DEPENDABOT_TITLE_CONTRACT_DRIFT"
+    assert summary["diagnostics"]["titleContractDriftPrs"] == [9]
+    outcome = json.loads(
+        (tmp_path / "artifacts" / "skill_outcome.json").read_text()
+    )
+    assert outcome["status"] == "failed"
+    assert outcome["reason"] == "dependabot_title_contract_drift"
+
+
 def test_end_to_end_package_manager_filter(monkeypatch: Any, tmp_path: Path) -> None:
     module = _load_module()
     summary = _run_main(

--- a/tests/integration/skills/test_batch_dependabot_resolver_e2e.py
+++ b/tests/integration/skills/test_batch_dependabot_resolver_e2e.py
@@ -84,7 +84,7 @@ def _mixed_pr_set() -> list[dict[str, Any]]:
         },
         {  # second genuine Dependabot match (npm)
             "number": 5,
-            "title": "Bump eslint from 8.0.0 to 9.0.0",
+            "title": "Chore(deps): bump eslint from 8.0.0 to 9.0.0",
             "author": {"login": "dependabot[bot]"},
             "headRefName": "dependabot/npm_and_yarn/eslint-9.0.0",
             "headRefOid": "sha-5",
@@ -145,6 +145,7 @@ def _run_main(
     tmp_path: Path,
     *,
     extra_env: dict[str, str] | None = None,
+    pr_set: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     _FakeAsyncClient.submissions = []
     _FakeAsyncClient.workflow_ids = set()
@@ -163,13 +164,17 @@ def _run_main(
         "MOONMIND_AGENT_RUN_ID",
         "MOONMIND_RUN_ID",
         "AGENT_RUN_ID",
+        "MOONMIND_STEP_EXECUTION_ID",
     ):
         monkeypatch.delenv(env_key, raising=False)
     for key, value in (extra_env or {}).items():
         monkeypatch.setenv(key, value)
 
     completed = subprocess.CompletedProcess(
-        args=["gh"], returncode=0, stdout=json.dumps(_mixed_pr_set()), stderr=""
+        args=["gh"],
+        returncode=0,
+        stdout=json.dumps(_mixed_pr_set() if pr_set is None else pr_set),
+        stderr="",
     )
 
     artifacts_dir = tmp_path / "artifacts"
@@ -198,6 +203,7 @@ def test_end_to_end_mixed_pr_set(monkeypatch: Any, tmp_path: Path) -> None:
     assert summary["requested"] == 5
     assert summary["matched"] == 2
     assert summary["created"] == 2
+    assert summary["status"] == "queued"
     assert sorted(item["pr"] for item in summary["queued"]) == [1, 5]
     reasons = {entry["pr"]: entry["reason"] for entry in summary["skipped"]}
     assert reasons == {2: "fork-pr", 3: "not-dependabot-author", 4: "title-mismatch"}
@@ -251,6 +257,7 @@ def test_end_to_end_inherits_runtime_selection_from_parent_context(
             "MOONMIND_TASK_CONTEXT_PATH": str(task_context_path),
             "MOONMIND_TASK_WORKFLOW_ID": "mm:parent-workflow",
             "MOONMIND_AGENT_RUN_ID": "agent-run-1",
+            "MOONMIND_STEP_EXECUTION_ID": "step:batch-dependabot",
         },
     )
 
@@ -259,7 +266,14 @@ def test_end_to_end_inherits_runtime_selection_from_parent_context(
         "model": "gpt-5.3-codex-spark",
         "effort": "xhigh",
         "executionProfileRef": "codex-profile",
+        "inheritance": "caller",
     }
+    assert summary["schemaVersion"] == (
+        "moonmind.batch-dependabot-resolver-result.v1"
+    )
+    assert summary["contractId"] == "batch_dependabot_resolver_fanout.v1"
+    assert summary["executionRef"] == "step:batch-dependabot"
+    assert summary["status"] == "queued"
     assert summary["created"] == 1
     assert len(_FakeAsyncClient.submissions) == 1
 
@@ -284,6 +298,7 @@ def test_end_to_end_dry_run_submits_nothing(monkeypatch: Any, tmp_path: Path) ->
     )
 
     assert summary["dryRun"] is True
+    assert summary["status"] == "dry_run"
     assert summary["created"] == 0
     assert summary["queued"] == []
     assert sorted(item["pr"] for item in summary["wouldQueue"]) == [1, 5]
@@ -291,6 +306,36 @@ def test_end_to_end_dry_run_submits_nothing(monkeypatch: Any, tmp_path: Path) ->
     assert summary["_exit_code"] == 0
     # No no-op signal on a dry run even though created==0.
     assert not (tmp_path / "artifacts" / "skill_outcome.json").exists()
+
+
+def test_end_to_end_fails_when_default_title_contract_drifts(
+    monkeypatch: Any,
+    tmp_path: Path,
+) -> None:
+    module = _load_module()
+    drifted_pr = {
+        **_mixed_pr_set()[0],
+        "number": 9,
+        "title": "Deps: bump anthropic from 0.105.2 to 0.107.1",
+    }
+    summary = _run_main(
+        module,
+        ["--repo", "MoonLadderStudios/MoonMind"],
+        monkeypatch,
+        tmp_path,
+        pr_set=[drifted_pr],
+    )
+
+    assert summary["_exit_code"] == 1
+    assert summary["matched"] == 0
+    assert summary["status"] == "failed"
+    assert summary["failureCode"] == "DEPENDABOT_TITLE_CONTRACT_DRIFT"
+    assert summary["diagnostics"]["titleContractDriftPrs"] == [9]
+    outcome = json.loads(
+        (tmp_path / "artifacts" / "skill_outcome.json").read_text()
+    )
+    assert outcome["status"] == "failed"
+    assert outcome["reason"] == "dependabot_title_contract_drift"
 
 
 def test_end_to_end_package_manager_filter(monkeypatch: Any, tmp_path: Path) -> None:

--- a/tests/unit/capabilities/test_batch_dependabot_resolver_skill.py
+++ b/tests/unit/capabilities/test_batch_dependabot_resolver_skill.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from moonmind.capabilities.input_contracts import (
+    parse_skill_capability_input_contract,
+)
+
+
+def test_batch_dependabot_resolver_exposes_structured_inputs() -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    skill_path = (
+        repo_root
+        / ".agents"
+        / "skills"
+        / "batch-dependabot-resolver"
+        / "SKILL.md"
+    )
+    contract = parse_skill_capability_input_contract(
+        skill_id="batch-dependabot-resolver",
+        label="batch-dependabot-resolver",
+        markdown=skill_path.read_text(encoding="utf-8"),
+        strict=True,
+    )
+
+    assert contract["hasInputSchema"] is True
+    assert contract["inputSchema"]["properties"]["titleRegex"]["default"] == (
+        r"^(?:Bump|[Cc]hore\(deps\): bump) .+ from \S+ to \S+(?: in /.+)?$"
+    )
+    assert contract["defaults"]["mergeMethod"] == "squash"
+    assert contract["defaults"]["dryRun"] is False
+    assert contract["diagnostics"] == []

--- a/tests/unit/capabilities/test_batch_dependabot_resolver_skill.py
+++ b/tests/unit/capabilities/test_batch_dependabot_resolver_skill.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 from moonmind.capabilities.input_contracts import (
     parse_skill_capability_input_contract,
+    validate_capability_inputs,
 )
 
 
@@ -27,6 +28,8 @@ def test_batch_dependabot_resolver_exposes_structured_inputs() -> None:
     assert contract["inputSchema"]["properties"]["titleRegex"]["default"] == (
         r"^(?:Bump|[Cc]hore\(deps\): bump) .+ from \S+ to \S+(?: in /.+)?$"
     )
-    assert contract["defaults"]["mergeMethod"] == "squash"
-    assert contract["defaults"]["dryRun"] is False
+    assert contract["defaults"] == {}
+    validated = validate_capability_inputs(contract=contract, values={})
+    assert validated["values"]["mergeMethod"] == "squash"
+    assert validated["values"]["dryRun"] is False
     assert contract["diagnostics"] == []

--- a/tests/unit/services/test_skill_resolution.py
+++ b/tests/unit/services/test_skill_resolution.py
@@ -144,6 +144,26 @@ async def test_built_in_loader_resolves_batch_dependabot_resolver_by_name(tmp_pa
     # Parity: the general-purpose batch resolver is guaranteed by the same path.
     assert "batch-pr-resolver" in resolved_names
 
+
+async def test_built_in_batch_dependabot_resolver_declares_terminal_contract():
+    results = await BuiltInSkillLoader().load_skills(
+        SkillSelector(include=[{"name": "batch-dependabot-resolver"}]),
+        SkillResolutionContext(snapshot_id="snap-batch-dependabot-resolver"),
+    )
+
+    entry = next(
+        item for item in results if item.skill_name == "batch-dependabot-resolver"
+    )
+    assert entry.terminal_contract is not None
+    assert (
+        entry.terminal_contract.contract_id
+        == "batch_dependabot_resolver_fanout.v1"
+    )
+    assert (
+        entry.terminal_contract.relative_path
+        == "artifacts/batch_dependabot_resolver_result.json"
+    )
+
 async def test_builtin_loader_ignores_cwd_agents_skills_projection(
     monkeypatch,
     tmp_path,

--- a/tests/unit/test_batch_dependabot_resolver.py
+++ b/tests/unit/test_batch_dependabot_resolver.py
@@ -519,6 +519,35 @@ def test_would_queue_records_carry_idempotency_keys() -> None:
     assert records[0]["idempotencyKey"].startswith("batch-dependabot-resolver:")
 
 
+def test_write_artifacts_uses_unique_temporary_names(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    module = _load_module()
+    entropy = iter([b"first1", b"second"])
+    temporary_names: list[str] = []
+    original_replace = module["os"].replace
+
+    monkeypatch.setattr(module["os"], "urandom", lambda _size: next(entropy))
+
+    def capture_replace(source: str | Path, destination: str | Path) -> None:
+        temporary_names.append(Path(source).name)
+        original_replace(source, destination)
+
+    monkeypatch.setattr(module["os"], "replace", capture_replace)
+    result_path = tmp_path / "result.json"
+
+    module["_write_artifacts"](result_path, {"attempt": 1})
+    module["_write_artifacts"](result_path, {"attempt": 2})
+
+    assert temporary_names == [
+        ".result.json.666972737431.tmp",
+        ".result.json.7365636f6e64.tmp",
+    ]
+    assert json.loads(result_path.read_text(encoding="utf-8")) == {"attempt": 2}
+    assert list(tmp_path.glob(".result.json.*.tmp")) == []
+
+
 def test_write_run_artifacts_emits_no_op_on_zero_match(tmp_path: Path) -> None:
     module = _load_module()
     payload = {

--- a/tests/unit/test_batch_dependabot_resolver.py
+++ b/tests/unit/test_batch_dependabot_resolver.py
@@ -49,7 +49,9 @@ def _args(**overrides: Any) -> Any:
         "max_attempts": 3,
         "priority": 0,
         "package_managers": [],
-        "title_regex": r"^Bump .+ from \S+ to \S+$",
+        "title_regex": (
+            r"^(?:Bump|[Cc]hore\(deps\): bump) .+ from \S+ to \S+(?: in /.+)?$"
+        ),
         "include_security_updates": True,
         "max_prs": None,
         "dry_run": False,
@@ -116,8 +118,24 @@ def test_title_matches_default_regex() -> None:
     assert module["_title_matches"](
         "Bump eslint from 8.0.0 to 9.0.0 in /frontend", pattern
     )
+    assert module["_title_matches"](
+        "Chore(deps): bump actions/setup-node from 6 to 7", pattern
+    )
+    assert module["_title_matches"](
+        "chore(deps): bump boto3 from 1.43.46 to 1.43.51", pattern
+    )
     assert not module["_title_matches"]("Bump the pip group with 2 updates", pattern)
     assert not module["_title_matches"]("Refactor things", pattern)
+
+
+def test_likely_version_bump_title_detects_filter_contract_drift() -> None:
+    module = _load_module()
+    assert module["_looks_like_version_bump_title"](
+        "Deps: bump package from 1.0.0 to 2.0.0"
+    )
+    assert not module["_looks_like_version_bump_title"](
+        "Bump the pip group with 2 updates"
+    )
 
 
 def test_infer_repo_from_remote_returns_none_when_git_remote_unavailable(
@@ -448,6 +466,30 @@ def test_partition_package_manager_filter() -> None:
     assert (skipped[0]["pr"], skipped[0]["reason"]) == (2, "package-manager-filtered")
 
 
+def test_partition_respects_intentionally_narrow_title_override() -> None:
+    module = _load_module()
+    prs = [
+        _dependabot_pr(
+            number=1,
+            title="Deps: bump anthropic from 1.0.0 to 2.0.0",
+            headRefOid="s1",
+        )
+    ]
+    queue_requests, skipped, _ = _partition(
+        module,
+        prs,
+        title_regex=r"^Bump .+ from \S+ to \S+$",
+    )
+    assert queue_requests == []
+    assert skipped == [
+        {
+            "pr": 1,
+            "branch": "dependabot/pip/anthropic-0.107.1",
+            "reason": "title-mismatch",
+        }
+    ]
+
+
 def test_partition_security_update_excluded_when_disabled() -> None:
     module = _load_module()
     prs = [
@@ -526,6 +568,34 @@ def test_write_run_artifacts_skips_no_op_on_errors(tmp_path: Path) -> None:
     outcome = json.loads((tmp_path / "skill_outcome.json").read_text())
     assert outcome["status"] == "failed"
     assert outcome["reason"] == "child_workflow_queue_failed"
+
+
+def test_write_run_artifacts_fails_on_default_title_contract_drift(
+    tmp_path: Path,
+) -> None:
+    module = _load_module()
+    payload = {
+        "dryRun": False,
+        "requested": 1,
+        "created": 0,
+        "queued": [],
+        "wouldQueue": [],
+        "skipped": [
+            {
+                "pr": 9,
+                "branch": "dependabot/pip/x",
+                "reason": "title-mismatch",
+                "likelyVersionBump": True,
+            }
+        ],
+        "errors": [],
+        "diagnostics": {"titleContractDriftPrs": [9]},
+    }
+    module["_write_run_artifacts"](tmp_path, payload)
+    outcome = json.loads((tmp_path / "skill_outcome.json").read_text())
+    assert outcome["status"] == "failed"
+    assert outcome["reason"] == "dependabot_title_contract_drift"
+    assert outcome["evidence"]["titleContractDriftPrs"] == [9]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/workflows/adapters/test_managed_agent_adapter.py
+++ b/tests/unit/workflows/adapters/test_managed_agent_adapter.py
@@ -2907,6 +2907,45 @@ async def test_fetch_result_fails_when_expected_pr_resolver_artifact_missing(
     assert "mergeAutomationDisposition" not in result.metadata
 
 
+async def test_fetch_result_omits_pr_resolver_metadata_when_not_expected(
+    tmp_path: Path,
+):
+    from datetime import UTC, datetime
+
+    from moonmind.schemas.agent_runtime_models import ManagedRunRecord
+    from moonmind.workflows.temporal.runtime.store import ManagedRunStore
+
+    workspace_path = tmp_path / "workspace"
+    workspace_path.mkdir()
+    store = ManagedRunStore(tmp_path / "run_store")
+    store.save(
+        ManagedRunRecord(
+            run_id="run-result-batch-skill",
+            agent_id="codex_cli",
+            runtime_id="codex_cli",
+            status="completed",
+            started_at=datetime.now(tz=UTC),
+            workspace_path=str(workspace_path),
+        )
+    )
+    adapter = ManagedAgentAdapter(
+        profile_fetcher=_fake_profiles([]),
+        slot_requester=_async_noop,
+        slot_releaser=_async_noop,
+        cooldown_reporter=_async_noop,
+        workflow_id="wf-result-batch-skill",
+        run_store=store,
+    )
+
+    result = await adapter.fetch_result("run-result-batch-skill")
+
+    assert result.failure_class is None
+    assert "contractId" not in result.metadata
+    assert "failureCode" not in result.metadata
+    assert "terminalResultPresent" not in result.metadata
+    assert "missingEvidence" not in result.metadata
+
+
 async def test_fetch_result_fails_when_pr_resolver_artifact_and_attempts_missing(
     tmp_path: Path,
 ):

--- a/tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py
@@ -441,6 +441,82 @@ class TestAgentSkillSnapshotResolution(unittest.IsolatedAsyncioTestCase):
             parent.run_id,
         )
 
+    async def test_batch_dependabot_terminal_contract_reaches_agent_run(
+        self,
+    ) -> None:
+        wf = MoonMindRunWorkflow()
+        wf._owner_id = "owner-1"
+        resolved = ResolvedSkillSet(
+            snapshot_id="skillset-batch-dependabot",
+            resolved_at=datetime.now(UTC),
+            manifest_ref="artifact://skillsets/batch-dependabot",
+            skills=[
+                ResolvedSkillEntry(
+                    skill_name="batch-dependabot-resolver",
+                    provenance=AgentSkillProvenance(
+                        source_kind=AgentSkillSourceKind.BUILT_IN
+                    ),
+                    terminal_contract=SkillTerminalContract(
+                        contract_id="batch_dependabot_resolver_fanout.v1",
+                        relative_path=(
+                            "artifacts/batch_dependabot_resolver_result.json"
+                        ),
+                        expected_schema_version=(
+                            "moonmind.batch-dependabot-resolver-result.v1"
+                        ),
+                    ),
+                )
+            ],
+        )
+        info = SimpleNamespace(
+            namespace="default",
+            workflow_id="batch:dependabot",
+            run_id="batch-run-1",
+            parent=None,
+        )
+
+        with (
+            patch(
+                "moonmind.workflows.temporal.workflows.run.workflow.execute_activity",
+                new=AsyncMock(return_value=resolved),
+            ),
+            patch(
+                "moonmind.workflows.temporal.workflows.run.workflow.patched",
+                return_value=True,
+            ),
+            patch(
+                "moonmind.workflows.temporal.workflows.run.workflow.info",
+                return_value=info,
+            ),
+        ):
+            resolved_ref = await wf._resolve_agent_node_skillset_ref(
+                task_skills=None,
+                node_inputs={"selectedSkill": "batch-dependabot-resolver"},
+                node_id="node-1",
+                existing_skillset_ref=None,
+            )
+            request = wf._build_agent_execution_request(
+                node_inputs={
+                    "targetRuntime": "codex_cli",
+                    "selectedSkill": "batch-dependabot-resolver",
+                },
+                node_id="node-1",
+                tool_name="codex_cli",
+                resolved_skillset_ref=resolved_ref,
+                workflow_parameters={},
+            )
+
+        self.assertIsNotNone(request.terminal_contract)
+        self.assertEqual(
+            request.terminal_contract.contract_id,
+            "batch_dependabot_resolver_fanout.v1",
+        )
+        self.assertEqual(
+            request.terminal_contract.execution_ref,
+            "batch:dependabot:batch-run-1:node-1:execution:1",
+        )
+        self.assertIsNone(request.terminal_continuation_authority)
+
     async def test_existing_history_does_not_change_agent_request_shape(self) -> None:
         wf = MoonMindRunWorkflow()
         wf._owner_id = "owner-1"

--- a/tests/unit/workflows/test_terminal_evidence.py
+++ b/tests/unit/workflows/test_terminal_evidence.py
@@ -109,6 +109,7 @@ def _write_dependabot_result(
     errors: list[dict] | None = None,
     would_queue: list[dict] | None = None,
     failure_code: str | None = None,
+    dry_run: bool | None = None,
 ) -> None:
     artifacts = workspace / "artifacts"
     artifacts.mkdir(parents=True, exist_ok=True)
@@ -118,7 +119,7 @@ def _write_dependabot_result(
         "executionRef": "step:dependabot",
         "status": status,
         "failureCode": failure_code,
-        "dryRun": status == "dry_run",
+        "dryRun": status == "dry_run" if dry_run is None else dry_run,
         "requested": requested,
         "created": len(queued),
         "queued": queued,
@@ -187,6 +188,7 @@ def test_batch_dependabot_terminal_rejects_drift_stale_and_bad_accounting(
         queued=[],
         skipped=skipped,
         failure_code="DEPENDABOT_TITLE_CONTRACT_DRIFT",
+        dry_run=True,
     )
     drift = evaluate_terminal_evidence(
         _dependabot_contract(), workspace_path=str(tmp_path)

--- a/tests/unit/workflows/test_terminal_evidence.py
+++ b/tests/unit/workflows/test_terminal_evidence.py
@@ -90,6 +90,126 @@ def test_batch_terminal_reads_result_from_artifact_spool(tmp_path: Path) -> None
     assert result.metadata["queuedChildren"] == [{"executionId": "child-1"}]
 
 
+def _dependabot_contract(execution_ref: str = "step:dependabot") -> dict[str, str]:
+    return {
+        "contractId": "batch_dependabot_resolver_fanout.v1",
+        "relativePath": "artifacts/batch_dependabot_resolver_result.json",
+        "expectedSchemaVersion": "moonmind.batch-dependabot-resolver-result.v1",
+        "executionRef": execution_ref,
+    }
+
+
+def _write_dependabot_result(
+    workspace: Path,
+    *,
+    status: str,
+    requested: int,
+    queued: list[dict],
+    skipped: list[dict] | None = None,
+    errors: list[dict] | None = None,
+    would_queue: list[dict] | None = None,
+    failure_code: str | None = None,
+) -> None:
+    artifacts = workspace / "artifacts"
+    artifacts.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "schemaVersion": "moonmind.batch-dependabot-resolver-result.v1",
+        "contractId": "batch_dependabot_resolver_fanout.v1",
+        "executionRef": "step:dependabot",
+        "status": status,
+        "failureCode": failure_code,
+        "dryRun": status == "dry_run",
+        "requested": requested,
+        "created": len(queued),
+        "queued": queued,
+        "wouldQueue": would_queue or [],
+        "skipped": skipped or [],
+        "errors": errors or [],
+    }
+    (artifacts / "batch_dependabot_resolver_result.json").write_text(
+        json.dumps(payload), encoding="utf-8"
+    )
+
+
+def test_batch_dependabot_terminal_accepts_queued_and_no_op_results(
+    tmp_path: Path,
+) -> None:
+    queued = [{"pr": 1, "workflowId": "mm:child-1"}]
+    skipped = [{"pr": 2, "reason": "not-dependabot-author"}]
+    _write_dependabot_result(
+        tmp_path,
+        status="queued",
+        requested=2,
+        queued=queued,
+        skipped=skipped,
+    )
+    queued_result = evaluate_terminal_evidence(
+        _dependabot_contract(), workspace_path=str(tmp_path)
+    )
+    assert queued_result.satisfied is True
+    assert queued_result.metadata["queuedChildren"] == queued
+
+    _write_dependabot_result(
+        tmp_path,
+        status="no_op",
+        requested=1,
+        queued=[],
+        skipped=skipped,
+    )
+    no_op_result = evaluate_terminal_evidence(
+        _dependabot_contract(), workspace_path=str(tmp_path)
+    )
+    assert no_op_result.satisfied is True
+
+
+def test_batch_dependabot_terminal_accepts_dry_run(tmp_path: Path) -> None:
+    _write_dependabot_result(
+        tmp_path,
+        status="dry_run",
+        requested=1,
+        queued=[],
+        would_queue=[{"pr": 1, "idempotencyKey": "key"}],
+    )
+    result = evaluate_terminal_evidence(
+        _dependabot_contract(), workspace_path=str(tmp_path)
+    )
+    assert result.satisfied is True
+
+
+def test_batch_dependabot_terminal_rejects_drift_stale_and_bad_accounting(
+    tmp_path: Path,
+) -> None:
+    skipped = [{"pr": 1, "reason": "title-mismatch"}]
+    _write_dependabot_result(
+        tmp_path,
+        status="failed",
+        requested=1,
+        queued=[],
+        skipped=skipped,
+        failure_code="DEPENDABOT_TITLE_CONTRACT_DRIFT",
+    )
+    drift = evaluate_terminal_evidence(
+        _dependabot_contract(), workspace_path=str(tmp_path)
+    )
+    assert drift.failure_code == "DEPENDABOT_TITLE_CONTRACT_DRIFT"
+
+    stale = evaluate_terminal_evidence(
+        _dependabot_contract("other-step"), workspace_path=str(tmp_path)
+    )
+    assert stale.failure_code == "STALE_TERMINAL_EVIDENCE"
+
+    _write_dependabot_result(
+        tmp_path,
+        status="queued",
+        requested=2,
+        queued=[{"pr": 1, "workflowId": "mm:child-1"}],
+    )
+    invalid = evaluate_terminal_evidence(
+        _dependabot_contract(), workspace_path=str(tmp_path)
+    )
+    assert invalid.failure_code == "INVALID_TERMINAL_EVIDENCE"
+
+
 def test_pr_resolver_terminal_requires_result_and_publish_evidence(tmp_path: Path) -> None:
     contract = {
         "contractId": "pr_resolver_terminal.v1",


### PR DESCRIPTION
## Summary

- accept both legacy `Bump …` and conventional `Chore(deps): bump …` Dependabot version-bump titles
- expose structured batch resolver inputs and report caller-runtime inheritance explicitly
- fail on likely version-bump title-contract drift instead of silently completing as a no-op
- bind batch fan-out completion to an identity-checked terminal artifact
- stop adding PR-resolver-only terminal diagnostics to unrelated managed agent runs

## Root cause

The batch resolver's anchored default matcher only accepted titles beginning with `Bump`. Dependabot's current PRs use `Chore(deps): bump`, so every candidate was classified as `title-mismatch` and no child workflow was queued. Zero created children with no submission errors was then treated as a successful no-op, while the shared result adapter added unrelated `pr-resolver.v1` diagnostics.

## Validation

- targeted unit suites: 182 passed
- managed adapter unit suite: 86 passed
- frontend unit suite: 1,103 passed, 239 skipped
- hermetic integration suite: 434 passed, 1 skipped
- live GitHub dry-run: all 9 current Dependabot version-bump PRs matched and would queue, including #3416
