### PR TITLE
Prevent skill resolver skew during updates

### DIFF
--- a/.agents/skills/update-moonmind/SKILL.md
+++ b/.agents/skills/update-moonmind/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: update-moonmind
-description: Refresh MoonMind services from git by checking out a branch, pulling updates, pulling compose images, then restarting changed containers with optional orchestrator inclusion.
+description: Refresh MoonMind services from git by fetching and pinning a branch snapshot, pulling compose images, then restarting changed containers with optional orchestrator inclusion.
 metadata:
   required-capabilities:
     - git
@@ -27,9 +27,11 @@ metadata:
    - `git fetch` `<branch>` from `origin`
    - quiesce and coherently recreate the agent-runtime worker across changes to
      the live-mounted Skill catalog or its resolver code
-   - checkout/reset local `<branch>` from `origin/<branch>` and run
-     `git pull --ff-only origin <branch>`
-   - optionally `docker compose pull` (unless `noComposePull` is set)
+   - checkout/reset local `<branch>` to the exact commit captured by that fetch
+   - optionally `docker compose pull` while the resolver worker remains quiesced
+     (unless `noComposePull` is set)
+   - recreate the resolver worker only when it still exists in the post-checkout
+     Compose topology
    - detect files changed between pre-pull and post-pull commits, force-recreate only application processes affected by bind-mounted runtime source, and use normal Compose reconciliation for other selected services
    - restart services with image drift or stopped service state so runtime stays healthy
    - exclude the deployment-control worker from update targets so it can finish and verify the operation

--- a/.agents/skills/update-moonmind/SKILL.md
+++ b/.agents/skills/update-moonmind/SKILL.md
@@ -24,10 +24,13 @@ metadata:
    - Pass `--restart-orchestrator` if you need the orchestrator container restarted as well.
 3. The script will:
    - validate `branch` as a safe git branch value
-   - `git fetch` from `origin` and checkout/reset local `<branch>` from `origin/<branch>`
-   - `git pull --ff-only origin <branch>`
+   - `git fetch` `<branch>` from `origin`
+   - quiesce and coherently recreate the agent-runtime worker across changes to
+     the live-mounted Skill catalog or its resolver code
+   - checkout/reset local `<branch>` from `origin/<branch>` and run
+     `git pull --ff-only origin <branch>`
    - optionally `docker compose pull` (unless `noComposePull` is set)
-  - detect files changed between pre-pull and post-pull commits, force-recreate only application processes affected by bind-mounted runtime source, and use normal Compose reconciliation for other selected services
-  - restart services with image drift or stopped service state so runtime stays healthy
-  - exclude the deployment-control worker from update targets so it can finish and verify the operation
+   - detect files changed between pre-pull and post-pull commits, force-recreate only application processes affected by bind-mounted runtime source, and use normal Compose reconciliation for other selected services
+   - restart services with image drift or stopped service state so runtime stays healthy
+   - exclude the deployment-control worker from update targets so it can finish and verify the operation
 4. By default, do not restart the `orchestrator` container, even when it changed.

--- a/.agents/skills/update-moonmind/scripts/run-update-moonmind.sh
+++ b/.agents/skills/update-moonmind/scripts/run-update-moonmind.sh
@@ -449,6 +449,48 @@ if ! git rev-parse --verify "origin/$BRANCH" >/dev/null 2>&1; then
   die "Remote branch 'origin/$BRANCH' does not exist."
 fi
 
+REMOTE_COMMIT="$(git rev-parse "origin/$BRANCH")"
+mapfile -t CHANGED_FILES < <(
+  if [[ "$PRE_PULL_COMMIT" == "$REMOTE_COMMIT" ]]; then
+    printf ''
+  else
+    git diff --name-only "${PRE_PULL_COMMIT}..${REMOTE_COMMIT}" --
+  fi
+)
+
+SKILL_RESOLUTION_BARRIER_REQUIRED="false"
+for changed_file in "${CHANGED_FILES[@]}"; do
+  case "$changed_file" in
+    .agents/* | moonmind/services/skill_resolution.py | moonmind/workflows/agent_skills/*)
+      SKILL_RESOLUTION_BARRIER_REQUIRED="true"
+      break
+      ;;
+  esac
+done
+
+SKILL_RESOLUTION_SERVICE="temporal-worker-agent-runtime"
+SKILL_RESOLUTION_BARRIER_ACTIVE="false"
+
+resume_skill_resolution_worker() {
+  if [[ "$SKILL_RESOLUTION_BARRIER_ACTIVE" != "true" ]]; then
+    return
+  fi
+  warn "Update exited while the Skill resolution barrier was active; restarting $SKILL_RESOLUTION_SERVICE."
+  "${COMPOSE_CMD[@]}" up -d --no-deps --force-recreate "$SKILL_RESOLUTION_SERVICE" || true
+}
+
+if [[ "$SKILL_RESOLUTION_BARRIER_REQUIRED" == "true" ]]; then
+  if ! "${COMPOSE_CMD[@]}" config --services | grep -Fxq "$SKILL_RESOLUTION_SERVICE"; then
+    die "Skill resolution source changed but $SKILL_RESOLUTION_SERVICE is unavailable."
+  fi
+  say "Quiescing $SKILL_RESOLUTION_SERVICE before updating live-mounted Skill resolution source"
+  if [[ "$DRY_RUN" != "true" ]]; then
+    SKILL_RESOLUTION_BARRIER_ACTIVE="true"
+    trap resume_skill_resolution_worker EXIT
+  fi
+  run_cmd "${COMPOSE_CMD[@]}" stop "$SKILL_RESOLUTION_SERVICE"
+fi
+
 say "Checking out local branch '$BRANCH' tracking origin/$BRANCH"
 run_cmd git checkout -B "$BRANCH" "origin/$BRANCH"
 
@@ -456,6 +498,13 @@ say "Pulling latest git changes"
 run_cmd git pull --ff-only origin "$BRANCH"
 
 POST_PULL_COMMIT="$(git rev-parse HEAD)"
+
+if [[ "$SKILL_RESOLUTION_BARRIER_REQUIRED" == "true" ]]; then
+  say "Recreating $SKILL_RESOLUTION_SERVICE with coherent Skill resolver and catalog source"
+  run_cmd "${COMPOSE_CMD[@]}" up -d --no-deps --force-recreate "$SKILL_RESOLUTION_SERVICE"
+  SKILL_RESOLUTION_BARRIER_ACTIVE="false"
+  trap - EXIT
+fi
 
 if [[ "$SKIP_COMPOSE_PULL" != "true" ]]; then
   say "Pulling updated compose images"
@@ -476,14 +525,6 @@ fi
 if [[ "$PRE_PULL_COMMIT" == "$POST_PULL_COMMIT" ]]; then
   say "No new commit received from origin/$BRANCH; skipping file-based restart detection."
 fi
-
-mapfile -t CHANGED_FILES < <(
-  if [[ "$PRE_PULL_COMMIT" == "$POST_PULL_COMMIT" ]]; then
-    printf ''
-  else
-    git diff --name-only "${PRE_PULL_COMMIT}..${POST_PULL_COMMIT}" --
-  fi
-)
 
 if [[ "$PRE_PULL_COMMIT" == "$POST_PULL_COMMIT" ]]; then
   if [[ "$SKIP_COMPOSE_PULL" == "true" ]]; then
@@ -563,11 +604,11 @@ for changed_file in "${CHANGED_FILES[@]}"; do
     docker-compose*.y*ml | .env* | AGENTS.md | .env-template* | .env.vllm-template* | .gitmodules )
       add_all_services
       ;;
-    moonmind/* | api_service/* | services/*)
+    moonmind/* | api_service/* | services/* | .agents/*)
       add_all_services
       add_runtime_source_services_for_recreate
       ;;
-    tools/* | .agents/* | .gemini/* | specs/* | .specify/* | docs/* | README* | LICENSE | .gitignore)
+    tools/* | .gemini/* | specs/* | .specify/* | docs/* | README* | LICENSE | .gitignore)
       add_all_services
       ;;
     init_db/*)

--- a/.agents/skills/update-moonmind/scripts/run-update-moonmind.sh
+++ b/.agents/skills/update-moonmind/scripts/run-update-moonmind.sh
@@ -475,6 +475,10 @@ resume_skill_resolution_worker() {
   if [[ "$SKILL_RESOLUTION_BARRIER_ACTIVE" != "true" ]]; then
     return
   fi
+  if ! "${COMPOSE_CMD[@]}" config --services | grep -Fxq "$SKILL_RESOLUTION_SERVICE"; then
+    warn "Cannot restart removed Skill resolution service $SKILL_RESOLUTION_SERVICE; normal Compose reconciliation must start its replacement."
+    return
+  fi
   warn "Update exited while the Skill resolution barrier was active; restarting $SKILL_RESOLUTION_SERVICE."
   "${COMPOSE_CMD[@]}" up -d --no-deps --force-recreate "$SKILL_RESOLUTION_SERVICE" || true
 }
@@ -491,19 +495,12 @@ if [[ "$SKILL_RESOLUTION_BARRIER_REQUIRED" == "true" ]]; then
   run_cmd "${COMPOSE_CMD[@]}" stop "$SKILL_RESOLUTION_SERVICE"
 fi
 
-say "Checking out local branch '$BRANCH' tracking origin/$BRANCH"
-run_cmd git checkout -B "$BRANCH" "origin/$BRANCH"
-
-say "Pulling latest git changes"
-run_cmd git pull --ff-only origin "$BRANCH"
+say "Checking out local branch '$BRANCH' at fetched commit $REMOTE_COMMIT"
+run_cmd git checkout -B "$BRANCH" "$REMOTE_COMMIT"
 
 POST_PULL_COMMIT="$(git rev-parse HEAD)"
-
-if [[ "$SKILL_RESOLUTION_BARRIER_REQUIRED" == "true" ]]; then
-  say "Recreating $SKILL_RESOLUTION_SERVICE with coherent Skill resolver and catalog source"
-  run_cmd "${COMPOSE_CMD[@]}" up -d --no-deps --force-recreate "$SKILL_RESOLUTION_SERVICE"
-  SKILL_RESOLUTION_BARRIER_ACTIVE="false"
-  trap - EXIT
+if [[ "$POST_PULL_COMMIT" != "$REMOTE_COMMIT" ]]; then
+  die "Checked-out commit $POST_PULL_COMMIT does not match fetched commit $REMOTE_COMMIT."
 fi
 
 if [[ "$SKIP_COMPOSE_PULL" != "true" ]]; then
@@ -520,6 +517,17 @@ if [[ "$SKIP_COMPOSE_PULL" != "true" ]]; then
       die "Command failed with exit code $compose_pull_exit: ${COMPOSE_CMD[*]} pull"
     fi
   fi
+fi
+
+if [[ "$SKILL_RESOLUTION_BARRIER_REQUIRED" == "true" ]]; then
+  if "${COMPOSE_CMD[@]}" config --services | grep -Fxq "$SKILL_RESOLUTION_SERVICE"; then
+    say "Recreating $SKILL_RESOLUTION_SERVICE with coherent Skill resolver, catalog, and image source"
+    run_cmd "${COMPOSE_CMD[@]}" up -d --no-deps --force-recreate "$SKILL_RESOLUTION_SERVICE"
+  else
+    say "Skill resolution service $SKILL_RESOLUTION_SERVICE was removed by the update; normal Compose reconciliation will start the replacement topology"
+  fi
+  SKILL_RESOLUTION_BARRIER_ACTIVE="false"
+  trap - EXIT
 fi
 
 if [[ "$PRE_PULL_COMMIT" == "$POST_PULL_COMMIT" ]]; then

--- a/.agents/skills/update-moonmind/scripts/run-update-moonmind.sh
+++ b/.agents/skills/update-moonmind/scripts/run-update-moonmind.sh
@@ -607,6 +607,9 @@ for changed_file in "${CHANGED_FILES[@]}"; do
     moonmind/* | api_service/* | services/* | .agents/*)
       add_all_services
       add_runtime_source_services_for_recreate
+      if [[ "$SKILL_RESOLUTION_BARRIER_REQUIRED" == "true" ]]; then
+        unset "force_recreate_services[$SKILL_RESOLUTION_SERVICE]"
+      fi
       ;;
     tools/* | .gemini/* | specs/* | .specify/* | docs/* | README* | LICENSE | .gitignore)
       add_all_services

--- a/tests/integration/reliability/replays/skill-resolution-update-skew/expected-outcome.json
+++ b/tests/integration/reliability/replays/skill-resolution-update-skew/expected-outcome.json
@@ -1,0 +1,6 @@
+{
+  "barrierService": "temporal-worker-agent-runtime",
+  "stopCommand": "compose stop temporal-worker-agent-runtime",
+  "recreateCommand": "compose up -d --no-deps --force-recreate temporal-worker-agent-runtime",
+  "composePullCommand": "compose pull"
+}

--- a/tests/integration/reliability/replays/skill-resolution-update-skew/expected-outcome.json
+++ b/tests/integration/reliability/replays/skill-resolution-update-skew/expected-outcome.json
@@ -2,5 +2,6 @@
   "barrierService": "temporal-worker-agent-runtime",
   "stopCommand": "compose stop temporal-worker-agent-runtime",
   "recreateCommand": "compose up -d --no-deps --force-recreate temporal-worker-agent-runtime",
-  "composePullCommand": "compose pull"
+  "composePullCommand": "compose pull",
+  "ordering": "stop_then_pull_then_recreate"
 }

--- a/tests/integration/reliability/replays/skill-resolution-update-skew/manifest.json
+++ b/tests/integration/reliability/replays/skill-resolution-update-skew/manifest.json
@@ -1,0 +1,10 @@
+{
+  "failureShapeId": "skill-resolution-update-skew",
+  "incidentWorkflowId": "mm:95f76aea-06f2-4e3b-9317-2dcc46f22c2a",
+  "activityType": "agent_skill.resolve",
+  "activityTaskQueue": "mm.activity.agent_runtime",
+  "changedFile": ".agents/skills/batch-dependabot-resolver/SKILL.md",
+  "selectedSkill": "moonspec-verify",
+  "observedFailure": "skill 'batch-dependabot-resolver' selects unknown terminal contract 'batch_dependabot_resolver_fanout.v1'",
+  "invariant": "The worker that resolves live-mounted Skill metadata must not execute between checkout mutation and recreation with resolver code from the same revision"
+}

--- a/tests/unit/test_update_moonmind_skill.py
+++ b/tests/unit/test_update_moonmind_skill.py
@@ -58,6 +58,7 @@ def _run_update_scenario(
     *,
     changed_file: str,
     include_all_commands: bool = False,
+    remove_agent_runtime_after_update: bool = False,
 ) -> list[str]:
     bash = _modern_bash()
     seed = tmp_path / "seed"
@@ -108,10 +109,20 @@ case "${1:-} ${2:-}" in
     exit 0
     ;;
   "config --services")
-    printf '%s\\n' api postgres temporal-worker-agent-runtime temporal-worker-deployment-control temporal-worker-workflow
+    if [[ "${REMOVE_AGENT_RUNTIME_AFTER_UPDATE:-false}" == "true" ]] \
+      && [[ "$(git -C "$UPDATE_CHECKOUT" rev-parse HEAD)" == "$UPDATE_EXPECTED_HEAD" ]]; then
+      printf '%s\\n' api postgres temporal-worker-deployment-control temporal-worker-workflow
+    else
+      printf '%s\\n' api postgres temporal-worker-agent-runtime temporal-worker-deployment-control temporal-worker-workflow
+    fi
     ;;
   "config --format")
-    printf '%s\\n' '{"services":{"api":{"image":"moonmind:test"},"postgres":{"image":"postgres:test"},"temporal-worker-agent-runtime":{"image":"moonmind:test"},"temporal-worker-deployment-control":{"image":"moonmind:test"},"temporal-worker-workflow":{"image":"moonmind:test"}}}'
+    if [[ "${REMOVE_AGENT_RUNTIME_AFTER_UPDATE:-false}" == "true" ]] \
+      && [[ "$(git -C "$UPDATE_CHECKOUT" rev-parse HEAD)" == "$UPDATE_EXPECTED_HEAD" ]]; then
+      printf '%s\\n' '{"services":{"api":{"image":"moonmind:test"},"postgres":{"image":"postgres:test"},"temporal-worker-deployment-control":{"image":"moonmind:test"},"temporal-worker-workflow":{"image":"moonmind:test"}}}'
+    else
+      printf '%s\\n' '{"services":{"api":{"image":"moonmind:test"},"postgres":{"image":"postgres:test"},"temporal-worker-agent-runtime":{"image":"moonmind:test"},"temporal-worker-deployment-control":{"image":"moonmind:test"},"temporal-worker-workflow":{"image":"moonmind:test"}}}'
+    fi
     ;;
   "pull ")
     exit 0
@@ -131,6 +142,11 @@ esac
     env = dict(os.environ)
     env["PATH"] = f"{fake_bin}{os.pathsep}{env['PATH']}"
     env["DOCKER_LOG"] = str(docker_log)
+    env["UPDATE_CHECKOUT"] = str(checkout)
+    env["UPDATE_EXPECTED_HEAD"] = expected_head
+    env["REMOVE_AGENT_RUNTIME_AFTER_UPDATE"] = str(
+        remove_agent_runtime_after_update
+    ).lower()
     subprocess.run(
         [bash, str(UPDATE_SCRIPT), "--repo", str(checkout), "--branch", "main"],
         cwd=ROOT,
@@ -205,16 +221,44 @@ def test_skill_source_update_quiesces_resolver_before_checkout_mutation(
     assert stop_command in commands
     assert barrier_recreate in commands
     assert commands.count(barrier_recreate) == 1
-    assert commands.index(stop_command) < commands.index(barrier_recreate)
-    assert commands.index(barrier_recreate) < commands.index(
+    assert commands.index(stop_command) < commands.index(
         expected["composePullCommand"]
+    )
+    assert commands.index(expected["composePullCommand"]) < commands.index(
+        barrier_recreate
     )
     final_force_recreates = [
         command
-        for command in commands[commands.index(expected["composePullCommand"]) + 1 :]
+        for command in commands[commands.index(barrier_recreate) + 1 :]
         if command.startswith("compose up ") and "--force-recreate" in command
     ]
     assert all(
         expected["barrierService"] not in command
         for command in final_force_recreates
     )
+
+
+def test_update_uses_one_fetched_commit_without_a_second_fetching_pull() -> None:
+    script = UPDATE_SCRIPT.read_text(encoding="utf-8")
+
+    assert 'git checkout -B "$BRANCH" "$REMOTE_COMMIT"' in script
+    assert 'git pull --ff-only origin "$BRANCH"' not in script
+    assert '"$POST_PULL_COMMIT" != "$REMOTE_COMMIT"' in script
+
+
+def test_skill_barrier_does_not_restart_service_removed_by_update(
+    tmp_path: Path,
+) -> None:
+    expected = json.loads(
+        (REPLAY_ROOT / "expected-outcome.json").read_text(encoding="utf-8")
+    )
+    commands = _run_update_scenario(
+        tmp_path,
+        changed_file=".agents/skills/example/SKILL.md",
+        include_all_commands=True,
+        remove_agent_runtime_after_update=True,
+    )
+
+    assert expected["stopCommand"] in commands
+    assert expected["composePullCommand"] in commands
+    assert expected["recreateCommand"] not in commands

--- a/tests/unit/test_update_moonmind_skill.py
+++ b/tests/unit/test_update_moonmind_skill.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import os
 import shutil
 import subprocess
@@ -16,6 +17,14 @@ UPDATE_SCRIPT = (
     / "update-moonmind"
     / "scripts"
     / "run-update-moonmind.sh"
+)
+REPLAY_ROOT = (
+    ROOT
+    / "tests"
+    / "integration"
+    / "reliability"
+    / "replays"
+    / "skill-resolution-update-skew"
 )
 
 
@@ -44,7 +53,12 @@ def _modern_bash() -> str:
     return bash
 
 
-def _run_update_scenario(tmp_path: Path, *, changed_file: str) -> list[str]:
+def _run_update_scenario(
+    tmp_path: Path,
+    *,
+    changed_file: str,
+    include_all_commands: bool = False,
+) -> list[str]:
     bash = _modern_bash()
     seed = tmp_path / "seed"
     remote = tmp_path / "origin.git"
@@ -94,10 +108,10 @@ case "${1:-} ${2:-}" in
     exit 0
     ;;
   "config --services")
-    printf '%s\\n' api postgres temporal-worker-deployment-control temporal-worker-workflow
+    printf '%s\\n' api postgres temporal-worker-agent-runtime temporal-worker-deployment-control temporal-worker-workflow
     ;;
   "config --format")
-    printf '%s\\n' '{"services":{"api":{"image":"moonmind:test"},"postgres":{"image":"postgres:test"},"temporal-worker-deployment-control":{"image":"moonmind:test"},"temporal-worker-workflow":{"image":"moonmind:test"}}}'
+    printf '%s\\n' '{"services":{"api":{"image":"moonmind:test"},"postgres":{"image":"postgres:test"},"temporal-worker-agent-runtime":{"image":"moonmind:test"},"temporal-worker-deployment-control":{"image":"moonmind:test"},"temporal-worker-workflow":{"image":"moonmind:test"}}}'
     ;;
   "pull ")
     exit 0
@@ -127,11 +141,10 @@ esac
     )
 
     assert _run_git("rev-parse", "HEAD", cwd=checkout).stdout.strip() == expected_head
-    return [
-        line
-        for line in docker_log.read_text(encoding="utf-8").splitlines()
-        if line.startswith("compose up ")
-    ]
+    commands = docker_log.read_text(encoding="utf-8").splitlines()
+    if include_all_commands:
+        return commands
+    return [line for line in commands if line.startswith("compose up ")]
 
 
 def test_runtime_source_update_force_recreates_only_application_services(
@@ -170,3 +183,28 @@ def test_documentation_update_does_not_force_recreate_services(
     assert "postgres" in up_commands[0]
     assert "temporal-worker-workflow" in up_commands[0]
     assert "temporal-worker-deployment-control" not in up_commands[0]
+
+
+def test_skill_source_update_quiesces_resolver_before_checkout_mutation(
+    tmp_path: Path,
+) -> None:
+    manifest = json.loads(
+        (REPLAY_ROOT / "manifest.json").read_text(encoding="utf-8")
+    )
+    expected = json.loads(
+        (REPLAY_ROOT / "expected-outcome.json").read_text(encoding="utf-8")
+    )
+    commands = _run_update_scenario(
+        tmp_path,
+        changed_file=manifest["changedFile"],
+        include_all_commands=True,
+    )
+
+    stop_command = expected["stopCommand"]
+    barrier_recreate = expected["recreateCommand"]
+    assert stop_command in commands
+    assert barrier_recreate in commands
+    assert commands.index(stop_command) < commands.index(barrier_recreate)
+    assert commands.index(barrier_recreate) < commands.index(
+        expected["composePullCommand"]
+    )

--- a/tests/unit/test_update_moonmind_skill.py
+++ b/tests/unit/test_update_moonmind_skill.py
@@ -204,7 +204,17 @@ def test_skill_source_update_quiesces_resolver_before_checkout_mutation(
     barrier_recreate = expected["recreateCommand"]
     assert stop_command in commands
     assert barrier_recreate in commands
+    assert commands.count(barrier_recreate) == 1
     assert commands.index(stop_command) < commands.index(barrier_recreate)
     assert commands.index(barrier_recreate) < commands.index(
         expected["composePullCommand"]
+    )
+    final_force_recreates = [
+        command
+        for command in commands[commands.index(expected["composePullCommand"]) + 1 :]
+        if command.startswith("compose up ") and "--force-recreate" in command
+    ]
+    assert all(
+        expected["barrierService"] not in command
+        for command in final_force_recreates
     )


### PR DESCRIPTION
## Summary

- quiesce `temporal-worker-agent-runtime` before checkout changes mutate the live-mounted Skill catalog or resolver source
- force-recreate the worker from the coherent checkout before the potentially slow Compose image pull
- force-recreate application services for `.agents` changes and recover the resolver worker if the update exits while the barrier is active
- add a minimized replay fixture for workflow `mm:95f76aea-06f2-4e3b-9317-2dcc46f22c2a`

## Root cause

`agent_skill.resolve` was running in an already-started agent-runtime process. During an update, its bind-mounted `.agents` catalog changed live while the imported Python resolver registry remained from the previous revision. The next catalog scan therefore saw `batch_dependabot_resolver_fanout.v1` in the new Skill metadata while the running resolver still considered that contract unknown.

The contract registration itself is already present on `main` through #3429. This change closes the update race that allowed code and Skill metadata from different revisions to execute together.

## Impact

Temporal queues agent-runtime work during the short update barrier. The worker resumes from a coherent checkout before image pulling continues, and an exit trap recreates it if checkout or pull preparation fails.

## Validation

- Linux/Bash 5 update and skill-resolution suites: `37 passed`
- update script syntax validation under Bash 5
- JSON replay fixture validation
- staged diff whitespace validation
