### PR TITLE
Fix batch GitHub issue range discovery

### DIFF
--- a/.agents/skills/batch-workflows/SKILL.md
+++ b/.agents/skills/batch-workflows/SKILL.md
@@ -47,6 +47,8 @@ Progress" with a single batch run.
   implement presets. Default `true`.
 - `additional_jql` (string, optional): advanced JQL AND-clause appended to the
   project/status query.
+- `issue_range` (string, GitHub preset only): inclusive `START-END` search
+  criteria. Numeric members are not targets unless GitHub returns an Issue.
 - `repository` (string, optional): repository override when workflow context
   cannot infer it.
 - `publish_mode` (string, optional): advanced child publish override, `none`,
@@ -54,9 +56,10 @@ Progress" with a single batch run.
 
 ## Workflow
 
-1. **Resolve Jira targets** into the canonical resolved-target shape and write
-   them to `artifacts/batch-workflows-targets.json`, then preview the list before
-   queueing. Use the trusted Jira tool surface to search:
+1. **Resolve provider targets** into the canonical resolved-target shape and
+   write them to `artifacts/batch-workflows-targets.json` before queueing.
+
+   For Jira, use the trusted Jira tool surface to search and preview the list:
 
    ```text
    project = "<jira_project_key>" AND status = "<jira_status>"
@@ -77,6 +80,13 @@ Progress" with a single batch run.
    Never use raw Jira credentials, web scraping, or guessed issue content to
    build the target list.
 
+   For GitHub, the inclusive number range is search criteria, not a target list.
+   GitHub issues and pull requests share numbers, and numbers may be absent. Use
+   the helper's `--github-issue-range` plus `--github-repository` inputs so its
+   trusted GraphQL `issue(number:)` lookup returns only real Issue objects.
+   Pull requests and absent numbers are omitted normally and never become
+   targets. The helper writes the resolved target artifact before queueing.
+
 2. **Queue child workflows** by running the helper:
 
    ```bash
@@ -88,6 +98,13 @@ Progress" with a single batch run.
      --run-verify | --no-run-verify \
      --update-status | --no-update-status \
      --max-workflows <cap>
+   ```
+
+   For the GitHub preset, replace `--targets` with:
+
+   ```bash
+   --github-issue-range <START-END> \
+   --github-repository <owner/repository>
    ```
 
    For each resolved target the helper:
@@ -128,6 +145,7 @@ Progress" with a single batch run.
   not supported.
 - Never re-select provider/model/effort in the batch form; children inherit the
   caller runtime.
-- Cap the resolved list at `max_workflows`.
+- Cap the resolved target list at `max_workflows`; a GitHub range's numeric
+  width is not the target count.
 - Targets whose selected run capability is not auto-bindable are skipped with a
   clear `unsupported_target` reason rather than queued blindly.

--- a/.agents/skills/batch-workflows/SKILL.md
+++ b/.agents/skills/batch-workflows/SKILL.md
@@ -85,7 +85,8 @@ Progress" with a single batch run.
    the helper's `--github-issue-range` plus `--github-repository` inputs so its
    trusted GraphQL `issue(number:)` lookup returns only real Issue objects.
    Pull requests and absent numbers are omitted normally and never become
-   targets. The helper writes the resolved target artifact before queueing.
+   targets. The helper rejects numeric spans wider than 1,000 numbers before
+   querying GitHub and writes the resolved target artifact before queueing.
 
 2. **Queue child workflows** by running the helper:
 
@@ -146,6 +147,7 @@ Progress" with a single batch run.
 - Never re-select provider/model/effort in the batch form; children inherit the
   caller runtime.
 - Cap the resolved target list at `max_workflows`; a GitHub range's numeric
-  width is not the target count.
+  width is not the target count. Bound GitHub discovery independently to a
+  maximum numeric span of 1,000.
 - Targets whose selected run capability is not auto-bindable are skipped with a
   clear `unsupported_target` reason rather than queued blindly.

--- a/.agents/skills/batch-workflows/bin/batch_workflows.py
+++ b/.agents/skills/batch-workflows/bin/batch_workflows.py
@@ -60,6 +60,7 @@ SUPPORTED_RUN_REFS = frozenset(
 )
 _GITHUB_RANGE_PATTERN = re.compile(r"^(?P<start>\d+)-(?P<end>\d+)$")
 _GITHUB_GRAPHQL_CHUNK_SIZE = 50
+_GITHUB_MAX_SEARCH_WIDTH = 1000
 
 
 class BatchInputError(ValueError):
@@ -191,6 +192,12 @@ def resolve_github_issue_range(
     owner, name = _github_repository_parts(repository)
     normalized_repository = f"{owner}/{name}"
     start, end = parse_github_issue_range(issue_range)
+    search_width = end - start + 1
+    if search_width > _GITHUB_MAX_SEARCH_WIDTH:
+        raise BatchInputError(
+            "GitHub issue range may span no more than "
+            f"{_GITHUB_MAX_SEARCH_WIDTH} numbers"
+        )
     targets: list[dict[str, Any]] = []
 
     for chunk_start in range(start, end + 1, _GITHUB_GRAPHQL_CHUNK_SIZE):
@@ -205,9 +212,9 @@ def resolve_github_issue_range(
                 "graphql",
                 "-f",
                 f"query={query}",
-                "-F",
+                "-f",
                 f"owner={owner}",
-                "-F",
+                "-f",
                 f"name={name}",
             ],
             capture_output=True,

--- a/.agents/skills/batch-workflows/bin/batch_workflows.py
+++ b/.agents/skills/batch-workflows/bin/batch_workflows.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python3
-"""Queue one child MoonMind workflow per resolved issue target.
+"""Resolve issue targets and queue one child MoonMind workflow per target.
 
-The agent resolves Jira status or other issue targets into the canonical
-resolved-target shape (see SKILL.md) and writes them to a JSON file. This helper
-reads that file plus the selected child run capability / publish policy and
-submits one child execution per target through the internal Temporal execution
-API. Every child inherits the parent runtime via ``runtimeInheritance="caller"``
+The agent resolves Jira status targets into the canonical resolved-target shape
+(see SKILL.md) and writes them to a JSON file. GitHub issue-number ranges are
+resolved directly by this portable helper so a numeric range remains search
+criteria rather than being mistaken for a target list. The helper submits one
+child execution per resolved target through the internal Temporal execution API.
+Every child inherits the parent runtime via ``runtimeInheritance="caller"``
 (with a fallback copy of the effective runtime fields) and shares a single
 publish policy. A summary artifact links every queued child workflow.
 """
@@ -18,6 +19,8 @@ import importlib.util
 import json
 import logging
 import os
+import re
+import subprocess
 import sys
 import traceback
 import urllib.error
@@ -55,6 +58,12 @@ SUPPORTED_RUN_REFS = frozenset(
         ("github", "preset", "github-issue-orchestrate"),
     }
 )
+_GITHUB_RANGE_PATTERN = re.compile(r"^(?P<start>\d+)-(?P<end>\d+)$")
+_GITHUB_GRAPHQL_CHUNK_SIZE = 50
+
+
+class BatchInputError(ValueError):
+    """Raised when provider-specific batch search input is invalid."""
 
 
 @dataclass
@@ -116,6 +125,171 @@ def _normalize_repo(value: Any) -> str | None:
     if candidate.endswith(".git"):
         candidate = candidate[:-4]
     return candidate or None
+
+
+def parse_github_issue_range(value: str) -> tuple[int, int]:
+    """Parse an inclusive GitHub issue-number search range."""
+
+    candidate = str(value or "").strip()
+    match = _GITHUB_RANGE_PATTERN.fullmatch(candidate)
+    if match is None:
+        raise BatchInputError("GitHub issue range must use START-END")
+    start = int(match.group("start"))
+    end = int(match.group("end"))
+    if start <= 0 or end <= 0:
+        raise BatchInputError("GitHub issue range numbers must be positive integers")
+    if start > end:
+        raise BatchInputError(
+            "GitHub issue range START must be less than or equal to END"
+        )
+    return start, end
+
+
+def _github_repository_parts(repository: str) -> tuple[str, str]:
+    normalized = _normalize_repo(repository)
+    parts = normalized.split("/") if normalized else []
+    if len(parts) != 2 or not all(parts):
+        raise BatchInputError("GitHub repository must use owner/repository")
+    return parts[0], parts[1]
+
+
+def _github_issue_range_query(numbers: list[int]) -> str:
+    issue_fields = """
+      number
+      title
+      body
+      url
+      state
+      labels(first: 100) { nodes { name } }
+    """.strip()
+    selections = "\n".join(
+        f"issue{number}: issue(number: {number}) {{ {issue_fields} }}"
+        for number in numbers
+    )
+    return (
+        "query($owner: String!, $name: String!) {\n"
+        "  repository(owner: $owner, name: $name) {\n"
+        f"{selections}\n"
+        "  }\n"
+        "}"
+    )
+
+
+def resolve_github_issue_range(
+    repository: str,
+    issue_range: str,
+    *,
+    run_command: Any = subprocess.run,
+) -> list[dict[str, Any]]:
+    """Return only GitHub Issue objects whose numbers fall in ``issue_range``.
+
+    GitHub's shared issue/PR numbering means numeric members of the range may be
+    pull requests or may not exist. Querying the GraphQL ``issue(number:)`` field
+    makes those entries resolve to null, so neither can become a workflow target.
+    """
+
+    owner, name = _github_repository_parts(repository)
+    normalized_repository = f"{owner}/{name}"
+    start, end = parse_github_issue_range(issue_range)
+    targets: list[dict[str, Any]] = []
+
+    for chunk_start in range(start, end + 1, _GITHUB_GRAPHQL_CHUNK_SIZE):
+        numbers = list(
+            range(chunk_start, min(end + 1, chunk_start + _GITHUB_GRAPHQL_CHUNK_SIZE))
+        )
+        query = _github_issue_range_query(numbers)
+        completed = run_command(
+            [
+                "gh",
+                "api",
+                "graphql",
+                "-f",
+                f"query={query}",
+                "-F",
+                f"owner={owner}",
+                "-F",
+                f"name={name}",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=60,
+            check=False,
+        )
+        try:
+            response = json.loads(completed.stdout)
+        except json.JSONDecodeError as exc:
+            detail = _text(completed.stderr) or "invalid JSON"
+            raise RuntimeError(
+                f"GitHub issue discovery failed: {detail[:1024]}"
+            ) from exc
+        if not isinstance(response, dict):
+            raise RuntimeError("GitHub issue discovery returned an invalid response")
+        errors = (
+            response.get("errors")
+            if isinstance(response.get("errors"), list)
+            else []
+        )
+        expected_missing_aliases = {f"issue{number}" for number in numbers}
+        unexpected_errors = [
+            error
+            for error in errors
+            if not (
+                isinstance(error, dict)
+                and error.get("type") == "NOT_FOUND"
+                and isinstance(error.get("path"), list)
+                and len(error["path"]) == 2
+                and error["path"][0] == "repository"
+                and error["path"][1] in expected_missing_aliases
+                and str(error.get("message") or "").startswith(
+                    "Could not resolve to an Issue with the number of "
+                )
+            )
+        ]
+        if unexpected_errors:
+            raise RuntimeError(
+                f"GitHub issue discovery failed: {json.dumps(unexpected_errors)[:1024]}"
+            )
+        if completed.returncode != 0 and not errors:
+            detail = _text(completed.stderr) or "unknown error"
+            raise RuntimeError(f"GitHub issue discovery failed: {detail[:1024]}")
+        data = response.get("data") if isinstance(response.get("data"), dict) else {}
+        repository_data = data.get("repository")
+        if not isinstance(repository_data, dict):
+            raise RuntimeError(
+                f"GitHub repository was not found or is not readable: {normalized_repository}"
+            )
+
+        for number in numbers:
+            issue = repository_data.get(f"issue{number}")
+            if not isinstance(issue, dict):
+                continue
+            labels_node = (
+                issue.get("labels") if isinstance(issue.get("labels"), dict) else {}
+            )
+            labels = [
+                str(node.get("name"))
+                for node in labels_node.get("nodes", [])
+                if isinstance(node, dict) and _text(node.get("name"))
+            ]
+            resolved_number = int(issue.get("number"))
+            targets.append(
+                {
+                    "provider": "github",
+                    "ref": f"{normalized_repository}#{resolved_number}",
+                    "githubIssue": {
+                        "repository": normalized_repository,
+                        "number": resolved_number,
+                        "title": str(issue.get("title") or ""),
+                        "body": str(issue.get("body") or ""),
+                        "url": str(issue.get("url") or ""),
+                        "state": str(issue.get("state") or "").lower(),
+                        "labels": labels,
+                    },
+                    "repository": normalized_repository,
+                }
+            )
+
+    return targets
 
 
 def parse_run_ref(value: str | None) -> tuple[str, str]:
@@ -804,10 +978,18 @@ def _write_artifacts(path: Path, payload: dict[str, Any]) -> None:
 
 def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description="Queue one child MoonMind workflow per resolved issue target."
+        description="Resolve issue targets and queue one child MoonMind workflow per target."
     )
     parser.add_argument(
-        "--targets", required=True, help="Path to resolved targets JSON."
+        "--targets", help="Path to resolved targets JSON."
+    )
+    parser.add_argument(
+        "--github-issue-range",
+        help="Inclusive GitHub issue-number search range in START-END form.",
+    )
+    parser.add_argument(
+        "--github-repository",
+        help="GitHub owner/repository; defaults to the parent task repository.",
     )
     parser.add_argument("--run-ref", required=True)
     parser.add_argument("--publish-mode", default="pr")
@@ -848,7 +1030,7 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 
 def main(argv: list[str] | None = None) -> int:
     args = _parse_args(argv)
-    targets_path = Path(args.targets)
+    targets_path = Path(args.targets) if args.targets else None
     artifacts_dir = _resolve_artifacts_dir(args.artifacts_dir)
     result_path = artifacts_dir / "batch-workflows-result.json"
     try:
@@ -858,7 +1040,7 @@ def main(argv: list[str] | None = None) -> int:
     execution_ref = _text(os.getenv("MOONMIND_STEP_EXECUTION_ID"))
     targets_digest = (
         hashlib.sha256(targets_path.read_bytes()).hexdigest()
-        if targets_path.exists() and targets_path.is_file()
+        if targets_path is not None and targets_path.exists() and targets_path.is_file()
         else None
     )
     base_result: dict[str, Any] = {
@@ -903,12 +1085,36 @@ def main(argv: list[str] | None = None) -> int:
             _write_artifacts(result_path, failed)
             print(json.dumps(failed, indent=2))
             return 2
-        if not targets_path.exists():
-            raise RuntimeError(f"targets file not found: {targets_path}")
-        targets = _read_targets(targets_path)
+        if args.github_issue_range and targets_path is not None:
+            raise BatchInputError(
+                "use either --targets or --github-issue-range, not both"
+            )
+        batch_repository = _load_parent_repository(args.task_context_path)
+        if args.github_issue_range:
+            github_repository = (
+                _normalize_repo(args.github_repository) or batch_repository
+            )
+            if not github_repository:
+                raise BatchInputError(
+                    "--github-repository is required when parent repository context is unavailable"
+                )
+            targets = resolve_github_issue_range(
+                github_repository,
+                args.github_issue_range,
+            )
+            targets_path = artifacts_dir / "batch-workflows-targets.json"
+            _write_artifacts(targets_path, {"targets": targets})
+            base_result["targetsSha256"] = hashlib.sha256(
+                targets_path.read_bytes()
+            ).hexdigest()
+        else:
+            if targets_path is None:
+                raise BatchInputError("--targets or --github-issue-range is required")
+            if not targets_path.exists():
+                raise RuntimeError(f"targets file not found: {targets_path}")
+            targets = _read_targets(targets_path)
         constraints = _read_constraints(args)
         runtime = _resolve_runtime_selection(args.task_context_path)
-        batch_repository = _load_parent_repository(args.task_context_path)
         batch_scope = _parent_run_scope(args.task_context_path) or execution_ref
         inherit_from_caller = _task_workflow_id_from_env() is not None
         target_kind, target_slug = parse_run_ref(args.run_ref)
@@ -933,15 +1139,20 @@ def main(argv: list[str] | None = None) -> int:
     )
         created, errors = _submit_jobs(submissions)
     except Exception as exc:  # evidence must survive every reachable preflight failure
+        failure_code = (
+            "BATCH_FANOUT_INPUT_INVALID"
+            if isinstance(exc, BatchInputError)
+            else "BATCH_FANOUT_FAILED"
+        )
         failed = {
             **base_result,
             "status": "failed",
-            "failure": {"code": "BATCH_FANOUT_FAILED", "message": str(exc)[:1024]},
-            "errors": [{"error": str(exc)[:1024]}],
+            "failure": {"code": failure_code, "message": str(exc)[:1024]},
+            "errors": [{"code": failure_code, "error": str(exc)[:1024]}],
         }
         _write_artifacts(result_path, failed)
         print(json.dumps(failed, indent=2))
-        return 1
+        return 2 if isinstance(exc, BatchInputError) else 1
 
     payload = {
         **base_result,

--- a/api_service/data/presets/batch-github-workflows.yaml
+++ b/api_service/data/presets/batch-github-workflows.yaml
@@ -152,8 +152,9 @@ steps:
     Resolve the range and queue each matched issue with "{{ inputs.run_ref }}" and
     publish override "{{ inputs.publish_mode }}" using one helper invocation. The
     portable helper performs the trusted GitHub query, excludes pull requests and
-    absent numbers, writes artifacts/batch-workflows-targets.json, applies
-    max_workflows to the resolved Issue objects, and queues the children:
+    absent numbers, rejects numeric spans wider than 1,000 before querying, writes
+    artifacts/batch-workflows-targets.json, applies max_workflows to the resolved
+    Issue objects, and queues the children:
     python3 "$MOONMIND_ACTIVE_SKILLS_DIR/batch-workflows/bin/batch_workflows.py" \
     --github-issue-range "{{ inputs.issue_range }}" \
     --github-repository "{{ inputs.repository }}" \

--- a/api_service/data/presets/batch-github-workflows.yaml
+++ b/api_service/data/presets/batch-github-workflows.yaml
@@ -1,8 +1,8 @@
 slug: batch-github-workflows
 title: Batch GitHub Workflows
 description: Resolve an inclusive GitHub issue-number range and queue one GitHub
-  Issue Implement or GitHub Issue Orchestrate workflow per issue with inherited
-  runtime settings and a shared publish override.
+  Issue Implement or GitHub Issue Orchestrate workflow per existing issue in the
+  range with inherited runtime settings and a shared publish override.
 scope: global
 tags:
 - batch
@@ -140,39 +140,28 @@ steps:
   annotations:
     batchWorkflowsRole: resolve-and-queue
   instructions: |-
-    Resolve the inclusive GitHub issue-number range "{{ inputs.issue_range }}"
-    for repository "{{ inputs.repository }}" and queue one child MoonMind workflow
-    per issue. When the repository input is empty, use the repository from workflow
-    context. Do not re-select provider, model, or effort: every child inherits the
-    parent runtime via runtimeInheritance="caller".
+    Treat the inclusive GitHub issue-number range "{{ inputs.issue_range }}" as
+    search criteria for repository "{{ inputs.repository }}", not as a list of
+    targets. GitHub issues and pull requests share numbering, and some numbers may
+    not exist. Queue children only for Issue objects returned by GitHub; never queue
+    a pull request or fabricate a target for an absent number. When the repository
+    input is empty, use the repository from workflow context. Do not re-select
+    provider, model, or effort: every child inherits the parent runtime via
+    runtimeInheritance="caller".
 
-    Parse the range strictly as START-END. Require positive integers, START <= END,
-    and no more than {{ inputs.max_workflows }} issue numbers. Use the trusted `gh`
-    CLI to read each issue. Fail with an actionable error if an issue does not exist
-    or cannot be read; do not guess or silently omit it. Resolve every issue to:
-    {"provider":"github","ref":"<owner/repo>#<number>","githubIssue":
-    {"repository":"<owner/repo>","number":<number>,"title":"<title>",
-    "body":"<body>","url":"<url>","state":"<state>",
-    "labels":["<label>"]},
-    "repository":"<owner/repo>"}. Write the complete list to
-    artifacts/batch-workflows-targets.json before queueing.
-
-    Queue each target with "{{ inputs.run_ref }}" and publish override
-    "{{ inputs.publish_mode }}" using one helper invocation:
+    Resolve the range and queue each matched issue with "{{ inputs.run_ref }}" and
+    publish override "{{ inputs.publish_mode }}" using one helper invocation. The
+    portable helper performs the trusted GitHub query, excludes pull requests and
+    absent numbers, writes artifacts/batch-workflows-targets.json, applies
+    max_workflows to the resolved Issue objects, and queues the children:
     python3 "$MOONMIND_ACTIVE_SKILLS_DIR/batch-workflows/bin/batch_workflows.py" \
-    --targets artifacts/batch-workflows-targets.json \
+    --github-issue-range "{{ inputs.issue_range }}" \
+    --github-repository "{{ inputs.repository }}" \
     --run-ref "{{ inputs.run_ref }}" \
     --publish-mode "{{ inputs.publish_mode }}" \
     --max-workflows "{{ inputs.max_workflows }}" \
     {% if inputs.run_verify %}--run-verify{% else %}--no-run-verify{% endif %} \
     --constraints "{{ inputs.constraints }}"
-
-    If strict range validation fails before the target list can be written, invoke
-    that same helper once with the same arguments plus
-    --preflight-error "<actionable validation error>" and
-    --requested-count "<inclusive range count>". Do not read GitHub issues, queue
-    a partial range, handcraft the result JSON, or reuse evidence from an earlier
-    execution. The helper writes the authoritative failure result.
 
     The helper writes artifacts/batch-workflows-result.json. Report its queued,
     skipped, and error counts honestly and link every queued child workflow.

--- a/tests/unit/api/test_batch_github_workflows_preset.py
+++ b/tests/unit/api/test_batch_github_workflows_preset.py
@@ -83,8 +83,16 @@ async def test_batch_github_workflows_seed_and_expansion_contract(tmp_path):
     assert orchestration["publish"]["mode"] == "pr_with_merge_automation"
     assert orchestration["runtime"]["inherit"] == "caller"
     assert "--run-verify" in step["instructions"]
-    assert "--preflight-error" in step["instructions"]
-    assert "--requested-count" in step["instructions"]
+    assert '--github-issue-range "3142-3150"' in step["instructions"]
+    assert (
+        '--github-repository "MoonLadderStudios/MoonMind"'
+        in step["instructions"]
+    )
+    assert "only for Issue objects returned by GitHub" in step["instructions"]
+    assert (
+        "--targets artifacts/batch-workflows-targets.json"
+        not in step["instructions"]
+    )
 
 
 async def test_batch_github_workflows_uses_repository_context(tmp_path):

--- a/tests/unit/test_batch_workflows.py
+++ b/tests/unit/test_batch_workflows.py
@@ -199,6 +199,32 @@ def test_resolve_github_issue_range_excludes_pull_requests_and_absent_numbers():
     assert "issue40: issue(number: 40)" in query_arg
     assert "issue41: issue(number: 41)" in query_arg
     assert "issue42: issue(number: 42)" in query_arg
+    assert "-F" not in calls[0]
+    assert calls[0].count("-f") == 3
+    assert "owner=acme" in calls[0]
+    assert "name=widgets" in calls[0]
+
+
+def test_resolve_github_issue_range_rejects_unbounded_scan_before_querying():
+    module = _load_module()
+    called = False
+
+    def unexpected_run(*_args, **_kwargs):
+        nonlocal called
+        called = True
+        raise AssertionError("GitHub must not be queried for an oversized range")
+
+    with pytest.raises(
+        module["BatchInputError"],
+        match="may span no more than 1000 numbers",
+    ):
+        module["resolve_github_issue_range"](
+            "acme/widgets",
+            "1-1001",
+            run_command=unexpected_run,
+        )
+
+    assert called is False
 
 
 def test_parse_args_accepts_github_range_without_targets():

--- a/tests/unit/test_batch_workflows.py
+++ b/tests/unit/test_batch_workflows.py
@@ -7,9 +7,9 @@ and unsupported-target skips.
 
 from __future__ import annotations
 
-import runpy
 import json
 import os
+import runpy
 import shutil
 import subprocess
 import sys
@@ -101,6 +101,123 @@ _GITHUB_TARGET: dict[str, Any] = {
     },
     "repository": "MoonLadderStudios/MoonMind",
 }
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("1-1", (1, 1)),
+        ("3370-3425", (3370, 3425)),
+    ],
+)
+def test_parse_github_issue_range(value, expected):
+    module = _load_module()
+
+    assert module["parse_github_issue_range"](value) == expected
+
+
+@pytest.mark.parametrize("value", ["", "1", "1..2", "0-2", "3-2"])
+def test_parse_github_issue_range_rejects_invalid_search_criteria(value):
+    module = _load_module()
+
+    with pytest.raises(ValueError):
+        module["parse_github_issue_range"](value)
+
+
+def test_resolve_github_issue_range_excludes_pull_requests_and_absent_numbers():
+    module = _load_module()
+    calls: list[list[str]] = []
+
+    def fake_run(command, **kwargs):
+        calls.append(command)
+        assert kwargs == {
+            "capture_output": True,
+            "text": True,
+            "timeout": 60,
+            "check": False,
+        }
+        return subprocess.CompletedProcess(
+            command,
+            1,
+            stdout=json.dumps(
+                {
+                    "data": {
+                        "repository": {
+                            "issue40": {
+                                "number": 40,
+                                "title": "Existing issue",
+                                "body": "Body",
+                                "url": "https://github.com/acme/widgets/issues/40",
+                                "state": "OPEN",
+                                "labels": {"nodes": [{"name": "bug"}]},
+                            },
+                            # GraphQL issue(number:) returns null for both a pull
+                            # request number and a number that does not exist.
+                            "issue41": None,
+                            "issue42": None,
+                        }
+                    },
+                    "errors": [
+                        {
+                            "type": "NOT_FOUND",
+                            "path": ["repository", "issue41"],
+                            "message": (
+                                "Could not resolve to an Issue with the number of 41."
+                            ),
+                        },
+                        {
+                            "type": "NOT_FOUND",
+                            "path": ["repository", "issue42"],
+                            "message": (
+                                "Could not resolve to an Issue with the number of 42."
+                            ),
+                        },
+                    ],
+                }
+            ),
+            stderr="gh: some issues were not found",
+        )
+
+    targets = module["resolve_github_issue_range"](
+        "acme/widgets",
+        "40-42",
+        run_command=fake_run,
+    )
+
+    assert [target["ref"] for target in targets] == ["acme/widgets#40"]
+    assert targets[0]["githubIssue"] == {
+        "repository": "acme/widgets",
+        "number": 40,
+        "title": "Existing issue",
+        "body": "Body",
+        "url": "https://github.com/acme/widgets/issues/40",
+        "state": "open",
+        "labels": ["bug"],
+    }
+    assert len(calls) == 1
+    query_arg = next(arg for arg in calls[0] if arg.startswith("query="))
+    assert "issue40: issue(number: 40)" in query_arg
+    assert "issue41: issue(number: 41)" in query_arg
+    assert "issue42: issue(number: 42)" in query_arg
+
+
+def test_parse_args_accepts_github_range_without_targets():
+    module = _load_module()
+
+    args = module["_parse_args"](
+        [
+            "--github-issue-range",
+            "3370-3425",
+            "--github-repository",
+            "MoonLadderStudios/MoonMind",
+            "--run-ref",
+            "preset:github-issue-implement",
+        ]
+    )
+
+    assert args.targets is None
+    assert args.github_issue_range == "3370-3425"
+    assert args.github_repository == "MoonLadderStudios/MoonMind"
 
 
 def _jira_config(module, **overrides):


### PR DESCRIPTION
## Summary

- treat a GitHub issue-number range as search criteria instead of a target list
- resolve targets deterministically through GitHub's issue-only GraphQL field
- exclude pull requests and absent numbers before workflow fan-out
- update the portable batch skill contract and preset instructions
- add regression coverage for shared issue/PR numbering and missing numbers

## Root cause

GitHub issues and pull requests share one numbering sequence. The previous preset iterated every number in the range and treated it as a target, so pull request numbers could be submitted as GitHub Issue Implement workflows.

## Validation

- `43 passed` for the targeted batch workflow and preset unit tests
- live resolver check for `3370-3425` returned only `3370, 3417-3425`
- `git diff --check`
- Python compilation of the portable helper

The selector-equivalent wrapper's repository audit was blocked by unrelated stale files under `.claude/worktrees/ui-regressions`; the targeted pytest files passed independently in the Python test container.