### PR TITLE
MoonLadderStudios/MoonMind#3420: link credentialed conformance evidence

### DIFF
--- a/.github/workflows/omnigent-live-conformance.yml
+++ b/.github/workflows/omnigent-live-conformance.yml
@@ -112,6 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      issues: write
     steps:
       - name: Download passing case evidence
         uses: actions/download-artifact@v8
@@ -131,9 +132,18 @@ jobs:
               raise SystemExit(f"expected four passing reports, found {len(reports)}")
           manifest = {
               "schemaVersion": "moonmind.omnigent.published-matrix/v1",
-              "issue": "MoonLadderStudios/MoonMind#3368",
+              "issue": "MoonLadderStudios/MoonMind#3420",
               "runId": os.environ["GITHUB_RUN_ID"],
               "runAttempt": os.environ["GITHUB_RUN_ATTEMPT"],
+              "commit": os.environ["GITHUB_SHA"],
+              "runUrl": (
+                  f"{os.environ['GITHUB_SERVER_URL']}/{os.environ['GITHUB_REPOSITORY']}"
+                  f"/actions/runs/{os.environ['GITHUB_RUN_ID']}"
+              ),
+              "artifactName": (
+                  f"omnigent-live-published-matrix-{os.environ['GITHUB_RUN_ID']}-"
+                  f"{os.environ['GITHUB_RUN_ATTEMPT']}"
+              ),
               "reports": [str(path) for path in reports],
               "modes": ["stock", "static", "ondemand", "failures"],
               "status": "passed",
@@ -155,7 +165,25 @@ jobs:
           {
             echo "### Omnigent credentialed conformance matrix"
             echo ""
-            echo "- Issue: \`MoonLadderStudios/MoonMind#3368\`"
+            echo "- Issue: \`MoonLadderStudios/MoonMind#3420\`"
             echo "- Result: all stock, static, on-demand, and failure cases passed"
             echo "- Durable evidence: \`omnigent-live-published-matrix-${{ github.run_id }}-${{ github.run_attempt }}\`"
           } >> "$GITHUB_STEP_SUMMARY"
+      - name: Link passing matrix from issue 3420
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          artifact="omnigent-live-published-matrix-${{ github.run_id }}-${{ github.run_attempt }}"
+          run_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          comment_file="${RUNNER_TEMP}/omnigent-matrix-comment.md"
+          {
+            echo "Credentialed Codex–Omnigent conformance matrix: PASS"
+            echo
+            echo "- Run: ${run_url} (attempt ${{ github.run_attempt }})"
+            echo "- Commit: \`${{ github.sha }}\`"
+            echo "- Modes: \`stock\`, \`static\`, \`ondemand\`, \`failures\`"
+            echo "- Durable artifact: \`${artifact}\`"
+            echo "- Evidence refs and immutable image digests: the four \`report.json\` trees in \`${artifact}\`"
+          } > "$comment_file"
+          gh issue comment 3420 --repo "${{ github.repository }}" --body-file "$comment_file"

--- a/tests/unit/test_omnigent_live_conformance_workflow.py
+++ b/tests/unit/test_omnigent_live_conformance_workflow.py
@@ -87,7 +87,8 @@ def test_publication_requires_every_matrix_case_to_pass() -> None:
         if step.get("name") == "Write publication manifest"
     )
     assert "expected four passing reports" in manifest["run"]
-    assert "MoonLadderStudios/MoonMind#3368" in manifest["run"]
+    assert "MoonLadderStudios/MoonMind#3420" in manifest["run"]
+    assert '"commit": os.environ["GITHUB_SHA"]' in manifest["run"]
     upload = next(
         step
         for step in job["steps"]
@@ -101,3 +102,13 @@ def test_publication_requires_every_matrix_case_to_pass() -> None:
     assert "github.run_attempt" in download["with"]["pattern"]
     assert "github.run_attempt" in upload["with"]["name"]
     assert upload["with"]["retention-days"] == 90
+    assert job["permissions"]["issues"] == "write"
+    link = next(
+        step
+        for step in job["steps"]
+        if step.get("name") == "Link passing matrix from issue 3420"
+    )
+    assert "gh issue comment 3420" in link["run"]
+    assert "github.run_id" in link["run"]
+    assert "github.run_attempt" in link["run"]
+    assert "github.sha" in link["run"]


### PR DESCRIPTION
Issue: MoonLadderStudios/MoonMind#3420

Closes MoonLadderStudios/MoonMind#3420

## Summary

- Target the guarded Omnigent credentialed matrix publication at issue #3420.
- Include run URL, attempt, commit, artifact name, modes, evidence references, and immutable image digest references in durable publication metadata.
- Link the passing four-mode matrix artifact from issue #3420 only after the full matrix succeeds.
- Add unit assertions for the issue linkage and publication metadata.

## Tests run

- Managed focused unit tests were attempted with `moonmind container python-tests tests/unit/test_omnigent_live_conformance_workflow.py tests/unit/test_run_omnigent_live_conformance.py`, but the container-job service returned HTTP 503 because it is disabled in this environment.
- Workflow YAML parsed successfully during verification.
- `git diff --check origin/main...HEAD`
- Secret-like pattern scan of the branch diff.

## Remaining risks

- The credentialed provider matrix was not run here because the protected environment, self-hosted runner, enrolled OAuth profile, live adapter, published digest-pinned images, and service credentials are external to this runtime.
- Publication remains gated by all four real matrix modes passing in one accepted run.