### PR TITLE
GitHub Issue Implement: MoonLadderStudios/MoonMind#3422

### DIFF
--- a/api_service/api/routers/omnigent_bridge.py
+++ b/api_service/api/routers/omnigent_bridge.py
@@ -55,6 +55,7 @@ from moonmind.omnigent.bridge_proxy import (
 from moonmind.omnigent.bridge_store import (
     BridgeProjectionAmbiguousError,
     OmnigentBridgeSessionStore,
+    OmnigentIdempotencyError,
 )
 from moonmind.omnigent.embedded_host_channel import (
     EmbeddedHostChannelError,
@@ -1485,6 +1486,10 @@ async def embedded_omnigent_runner_tunnel(
             send_text=websocket.send_text,
             hello_text=await websocket.receive_text(),
         )
+        facade = OmnigentEmbeddedHostProtocolFacade(
+            run_store=OmnigentBridgeSessionStore(async_session_maker), config=config
+        )
+        await facade.record_runner_tunnel_ready(runner_id=runner_id)
         while True:
             channel.accept_frame(await websocket.receive_text())
     except WebSocketDisconnect:
@@ -1494,6 +1499,15 @@ async def embedded_omnigent_runner_tunnel(
     finally:
         if channel is not None:
             embedded_host_channels.disconnect_runner(channel)
+            facade = OmnigentEmbeddedHostProtocolFacade(
+                run_store=OmnigentBridgeSessionStore(async_session_maker), config=config
+            )
+            try:
+                await facade.record_runner_tunnel_disconnected(runner_id=runner_id)
+            except (EmbeddedHostChannelError, OmnigentIdempotencyError):
+                # Terminal exit processing may have won the race. Its durable
+                # terminal evidence remains authoritative over disconnect.
+                pass
 
 
 @router.post("/v1/hosts/{host_id}/heartbeat", response_model=dict)

--- a/api_service/api/routers/omnigent_bridge.py
+++ b/api_service/api/routers/omnigent_bridge.py
@@ -1473,7 +1473,7 @@ async def embedded_omnigent_runner_tunnel(
         return
     try:
         store = OmnigentBridgeSessionStore(async_session_maker)
-        binding = await store.get_session_by_runner_id(runner_id)
+        binding = await store.get_active_session_by_runner_identity(runner_id)
         if (
             binding is None
             or not binding.omnigent_host_id

--- a/api_service/api/routers/omnigent_bridge.py
+++ b/api_service/api/routers/omnigent_bridge.py
@@ -1472,8 +1472,31 @@ async def embedded_omnigent_runner_tunnel(
         await websocket.close(code=4404)
         return
     try:
+        store = OmnigentBridgeSessionStore(async_session_maker)
+        binding = await store.get_session_by_runner_id(runner_id)
+        if (
+            binding is None
+            or not binding.omnigent_host_id
+            or not binding.omnigent_session_id
+            or binding.credential_generation is None
+        ):
+            raise EmbeddedHostChannelError("runner has no active durable binding")
+        from moonmind.omnigent.embedded_host_channel import derive_runner_binding_token
+
+        binding_token = derive_runner_binding_token(
+            resolved_host_runner_token(),
+            host_id=binding.omnigent_host_id,
+            session_id=binding.omnigent_session_id,
+            generation=int(
+                ((binding.metadata_ or {}).get("embedded_runner_launch") or {}).get(
+                    "generation"
+                )
+                or binding.credential_generation
+            ),
+        )
         embedded_host_channels.authenticate_runner(
-            runner_id=runner_id, headers=websocket.headers
+            runner_id=runner_id, headers=websocket.headers,
+            binding_token=binding_token,
         )
     except (EmbeddedHostChannelError, UpstreamHostProtocolError):
         await websocket.close(code=4401)

--- a/moonmind/omnigent/bridge_embedded.py
+++ b/moonmind/omnigent/bridge_embedded.py
@@ -317,6 +317,11 @@ class OmnigentEmbeddedHostProtocolFacade:
                 failure_class="integration_error",
                 status_code=409,
             )
+        await self._run_store.mark_embedded_runner_state(
+            row.idempotency_key,
+            state="draining",
+            code="runner_stop_requested",
+        )
         try:
             await self._host_channels.stop_runner(
                 host_id=host_id, runner_id=runner_id

--- a/moonmind/omnigent/bridge_embedded.py
+++ b/moonmind/omnigent/bridge_embedded.py
@@ -200,7 +200,25 @@ class OmnigentEmbeddedHostProtocolFacade:
                 failure_class="system_error", status_code=409,
             )
         if row.omnigent_runner_id:
-            return {"runnerId": row.omnigent_runner_id, "reused": True}
+            if self._host_channels.is_runner_ready(row.omnigent_runner_id):
+                await self._run_store.mark_embedded_runner_state(
+                    idempotency_key,
+                    state="runner_tunnel_ready",
+                    code="live_tunnel_verified",
+                )
+                return {"runnerId": row.omnigent_runner_id, "reused": True}
+            await self._run_store.mark_embedded_runner_state(
+                idempotency_key,
+                state="stale",
+                code="durable_runner_tunnel_unavailable",
+            )
+            raise OmnigentBridgeError(
+                "Durable embedded runner assignment is not live; reconciliation or "
+                "janitor replacement is required",
+                failure_class="integration_error",
+                status_code=503,
+                code="embedded_runner_stale",
+            )
         workspace = _clean(row.workspace)
         if not workspace:
             raise OmnigentBridgeError(
@@ -216,11 +234,21 @@ class OmnigentEmbeddedHostProtocolFacade:
                 str(exc), failure_class="integration_error", status_code=503
             ) from exc
         try:
+            await self._run_store.mark_embedded_runner_state(
+                idempotency_key,
+                state="launch_sent",
+                code="host_launch_command_sending",
+            )
             runner_id = await self._host_channels.launch_runner(
                 host_id=row.omnigent_host_id,
                 workspace=workspace,
                 session_id=row.omnigent_session_id,
                 harness="codex-native",
+            )
+            await self._run_store.mark_embedded_runner_state(
+                idempotency_key,
+                state="launch_acknowledged",
+                code="host_launch_acknowledged",
             )
         except (EmbeddedHostChannelError, TimeoutError) as exc:
             await self._run_store.fail_embedded_runner_launch(
@@ -238,6 +266,30 @@ class OmnigentEmbeddedHostProtocolFacade:
                 str(exc), failure_class="integration_error", status_code=503
             ) from exc
         return {"runnerId": runner_id, "reused": False}
+
+    async def record_runner_tunnel_ready(self, *, runner_id: str) -> None:
+        row = await self._run_store.get_session_by_runner_id(runner_id)
+        if row is None:
+            raise EmbeddedHostChannelError("runner has no durable session binding")
+        await self._run_store.mark_embedded_runner_state(
+            row.idempotency_key,
+            state="runner_tunnel_ready",
+            code="authenticated_runner_handshake",
+        )
+
+    async def record_runner_tunnel_disconnected(self, *, runner_id: str) -> None:
+        row = await self._run_store.get_session_by_runner_id(runner_id)
+        if row is not None and row.status not in {
+            "completed",
+            "failed",
+            "canceled",
+            "timed_out",
+        }:
+            await self._run_store.mark_embedded_runner_state(
+                row.idempotency_key,
+                state="runner_tunnel_waiting",
+                code="runner_tunnel_disconnected",
+            )
 
     async def record_runner_exit(self, *, runner_id: str, error: str) -> None:
         """Record a stock host's authoritative runner process failure."""

--- a/moonmind/omnigent/bridge_embedded.py
+++ b/moonmind/omnigent/bridge_embedded.py
@@ -282,6 +282,25 @@ class OmnigentEmbeddedHostProtocolFacade:
             lifecycle_state = (
                 (reserved.metadata_ or {}).get("embedded_runner_lifecycle") or {}
             ).get("state")
+            # A retry after the launch command crossed the host boundary must
+            # first reconcile the deterministic runner identity.  A freshly
+            # authenticated tunnel is authoritative evidence that the command
+            # succeeded, so resending it would only create a duplicate launch.
+            if lifecycle_state in {"launch_sent", "launch_acknowledged"}:
+                wait_ready = getattr(self._host_channels, "wait_runner_ready", None)
+                if wait_ready is not None and await wait_ready(expected_runner_id):
+                    if lifecycle_state == "launch_sent":
+                        await self._run_store.mark_embedded_runner_state(
+                            idempotency_key,
+                            state="launch_acknowledged",
+                            code="runner_tunnel_reconciled_launch_acknowledgement",
+                        )
+                    await self._run_store.bind_embedded_runner(
+                        idempotency_key,
+                        host_id=row.omnigent_host_id,
+                        runner_id=expected_runner_id,
+                    )
+                    return {"runnerId": expected_runner_id, "reused": True}
             if lifecycle_state == "launch_reserved":
                 await self._run_store.mark_embedded_runner_state(
                     idempotency_key,
@@ -419,6 +438,38 @@ class OmnigentEmbeddedHostProtocolFacade:
             raise OmnigentBridgeError(
                 str(exc), failure_class="integration_error", status_code=503
             ) from exc
+
+    async def reconcile_first_message(self, *, session_id: str) -> dict[str, Any]:
+        """Resolve response-before-persist from the runner's session evidence."""
+
+        from moonmind.omnigent.execute import _snapshot_contains_first_message_marker
+
+        row = await self._run_store.get_session_by_provider_session_id(session_id)
+        if row is None or not _clean(row.omnigent_runner_id):
+            raise OmnigentBridgeError(
+                "Embedded first-message reconciliation requires a durable runner",
+                failure_class="integration_error", status_code=409,
+            )
+        if row.first_message_state != "posting":
+            return {"reconciled": row.first_message_state == "posted"}
+        snapshot = await self._host_channels.request_runner(
+            runner_id=row.omnigent_runner_id,
+            method="GET",
+            path=f"/v1/sessions/{quote(session_id, safe='')}",
+        )
+        if not _snapshot_contains_first_message_marker(
+            snapshot,
+            digest=str(row.first_message_digest or ""),
+            marker=str(row.first_message_marker or ""),
+        ):
+            raise OmnigentBridgeError(
+                "Runner session does not contain durable first-message evidence",
+                failure_class="integration_error", status_code=503,
+                code="omnigent_first_message_reconcile_failed",
+            )
+        response = snapshot.get("firstMessageResponse") or {}
+        await self._run_store.mark_posted(row.idempotency_key, response=response)
+        return {"reconciled": True, **response}
 
     async def get_resource(
         self, operation: str, session_id: str, value: str | None = None

--- a/moonmind/omnigent/bridge_embedded.py
+++ b/moonmind/omnigent/bridge_embedded.py
@@ -301,6 +301,13 @@ class OmnigentEmbeddedHostProtocolFacade:
                         runner_id=expected_runner_id,
                     )
                     return {"runnerId": expected_runner_id, "reused": True}
+                raise OmnigentBridgeError(
+                    "Embedded runner launch already crossed the host boundary; "
+                    "the reserved runner did not reconnect before the bounded deadline",
+                    failure_class="integration_error",
+                    status_code=503,
+                    code="embedded_runner_launch_unconfirmed",
+                )
             if lifecycle_state == "launch_reserved":
                 await self._run_store.mark_embedded_runner_state(
                     idempotency_key,
@@ -402,6 +409,11 @@ class OmnigentEmbeddedHostProtocolFacade:
             raise OmnigentBridgeError(
                 str(exc), failure_class="integration_error", status_code=503
             ) from exc
+        await self._run_store.mark_embedded_runner_state(
+            row.idempotency_key,
+            state="stopped",
+            code="runner_stop_confirmed",
+        )
         await self._run_store.record_lifecycle_event(
             row.idempotency_key,
             event_type="terminal",

--- a/moonmind/omnigent/bridge_embedded.py
+++ b/moonmind/omnigent/bridge_embedded.py
@@ -44,7 +44,10 @@ from moonmind.omnigent.embedded_host_channel import (
     EmbeddedHostChannelError,
     EmbeddedHostChannelRegistry,
     embedded_host_channels,
+    derive_runner_binding_token,
 )
+from moonmind.omnigent.host_auth_adapter import OmnigentHostAuthAdapter
+from moonmind.omnigent.settings import resolved_host_runner_token
 from moonmind.schemas.agent_runtime_models import AgentExecutionRequest
 
 MAX_EMBEDDED_CAPABILITIES = 128
@@ -184,10 +187,12 @@ class OmnigentEmbeddedHostProtocolFacade:
         run_store: OmnigentBridgeSessionStore,
         config: OmnigentBridgeConfig,
         host_channels: EmbeddedHostChannelRegistry = embedded_host_channels,
+        runner_binding_root_secret: str | None = None,
     ) -> None:
         self._run_store = run_store
         self._config = config
         self._host_channels = host_channels
+        self._runner_binding_root_secret = runner_binding_root_secret
 
     async def dispatch_runner(self, *, idempotency_key: str) -> dict[str, Any]:
         """Dispatch and durably bind a runner to an authorized embedded session."""
@@ -207,14 +212,34 @@ class OmnigentEmbeddedHostProtocolFacade:
                     code="live_tunnel_verified",
                 )
                 return {"runnerId": row.omnigent_runner_id, "reused": True}
+            wait_ready = getattr(self._host_channels, "wait_runner_ready", None)
+            if wait_ready is not None and await wait_ready(row.omnigent_runner_id):
+                await self._run_store.mark_embedded_runner_state(
+                    idempotency_key, state="runner_tunnel_ready",
+                    code="bounded_runner_reconnect_verified",
+                )
+                return {"runnerId": row.omnigent_runner_id, "reused": True}
             await self._run_store.mark_embedded_runner_state(
                 idempotency_key,
                 state="stale",
                 code="durable_runner_tunnel_unavailable",
             )
+            stop_runner = getattr(self._host_channels, "stop_runner", None)
+            if stop_runner is not None:
+                try:
+                    await stop_runner(
+                        host_id=row.omnigent_host_id, runner_id=row.omnigent_runner_id
+                    )
+                except (EmbeddedHostChannelError, TimeoutError):
+                    pass
+                else:
+                    await self._run_store.prepare_embedded_runner_replacement(
+                        idempotency_key, runner_id=row.omnigent_runner_id
+                    )
+                    return await self.dispatch_runner(idempotency_key=idempotency_key)
             raise OmnigentBridgeError(
-                "Durable embedded runner assignment is not live; reconciliation or "
-                "janitor replacement is required",
+                "Durable embedded runner assignment did not reconnect before the "
+                "bounded deadline; it was marked stale for safe replacement",
                 failure_class="integration_error",
                 status_code=503,
                 code="embedded_runner_stale",
@@ -226,30 +251,58 @@ class OmnigentEmbeddedHostProtocolFacade:
                 failure_class="user_error", status_code=422,
             )
         try:
-            await self._run_store.begin_embedded_runner_launch(
-                idempotency_key, host_id=row.omnigent_host_id
+            credential_generation = int(row.credential_generation or 0)
+            prior_launch = dict(
+                (row.metadata_ or {}).get("embedded_runner_launch") or {}
             )
-        except OmnigentIdempotencyError as exc:
+            launch_generation = int(prior_launch.get("launchGeneration") or 0)
+            if prior_launch.get("state") not in {"pending", "launched"}:
+                launch_generation += 1
+            launch_generation = max(launch_generation, 1)
+            binding_generation = credential_generation * 1_000_000 + launch_generation
+            binding_token = derive_runner_binding_token(
+                self._runner_binding_root_secret or resolved_host_runner_token(),
+                host_id=row.omnigent_host_id,
+                session_id=row.omnigent_session_id, generation=binding_generation,
+            )
+            expected_runner_id = OmnigentHostAuthAdapter(
+                allowed_tokens=frozenset({binding_token})
+            ).runner_id_for_binding_token(binding_token)
+            reserved = await self._run_store.begin_embedded_runner_launch(
+                idempotency_key, host_id=row.omnigent_host_id,
+                runner_id=expected_runner_id, generation=binding_generation,
+                credential_generation=credential_generation,
+                launch_generation=launch_generation,
+            )
+        except (OmnigentIdempotencyError, EmbeddedHostChannelError) as exc:
             raise OmnigentBridgeError(
                 str(exc), failure_class="integration_error", status_code=503
             ) from exc
         try:
-            await self._run_store.mark_embedded_runner_state(
-                idempotency_key,
-                state="launch_sent",
-                code="host_launch_command_sending",
-            )
+            lifecycle_state = (
+                (reserved.metadata_ or {}).get("embedded_runner_lifecycle") or {}
+            ).get("state")
+            if lifecycle_state == "launch_reserved":
+                await self._run_store.mark_embedded_runner_state(
+                    idempotency_key,
+                    state="launch_sent",
+                    code="host_launch_command_sending",
+                )
             runner_id = await self._host_channels.launch_runner(
                 host_id=row.omnigent_host_id,
                 workspace=workspace,
                 session_id=row.omnigent_session_id,
                 harness="codex-native",
+                binding_token=binding_token,
             )
-            await self._run_store.mark_embedded_runner_state(
-                idempotency_key,
-                state="launch_acknowledged",
-                code="host_launch_acknowledged",
-            )
+            if runner_id != expected_runner_id:
+                raise EmbeddedHostChannelError("host returned a stale launch generation")
+            if lifecycle_state != "launch_acknowledged":
+                await self._run_store.mark_embedded_runner_state(
+                    idempotency_key,
+                    state="launch_acknowledged",
+                    code="host_launch_acknowledged",
+                )
         except (EmbeddedHostChannelError, TimeoutError) as exc:
             await self._run_store.fail_embedded_runner_launch(
                 idempotency_key, host_id=row.omnigent_host_id

--- a/moonmind/omnigent/bridge_store.py
+++ b/moonmind/omnigent/bridge_store.py
@@ -501,6 +501,17 @@ class OmnigentBridgeSessionStore:
                 raise OmnigentIdempotencyError(
                     "embedded session is already bound to another runner"
                 )
+            launch = dict((row.metadata_ or {}).get(EMBEDDED_LAUNCH_KEY) or {})
+            if launch.get("runnerId") not in {None, runner_id}:
+                raise OmnigentIdempotencyError(
+                    "embedded runner does not match the reserved launch generation"
+                )
+            if launch.get("credentialGeneration") not in {
+                None, row.credential_generation
+            }:
+                raise OmnigentIdempotencyError(
+                    "embedded runner callback uses a stale credential generation"
+                )
             row.omnigent_runner_id = runner_id
             metadata = dict(row.metadata_ or {})
             launch = dict(metadata.get(EMBEDDED_LAUNCH_KEY) or {})
@@ -525,7 +536,10 @@ class OmnigentBridgeSessionStore:
             return _detached(session, row)
 
     async def begin_embedded_runner_launch(
-        self, idempotency_key: str, *, host_id: str
+        self, idempotency_key: str, *, host_id: str,
+        runner_id: str | None = None, generation: int | None = None,
+        credential_generation: int | None = None,
+        launch_generation: int | None = None,
     ) -> OmnigentBridgeSession:
         """Reserve the one permitted launch before crossing the socket boundary."""
 
@@ -547,13 +561,25 @@ class OmnigentBridgeSessionStore:
             if row.omnigent_runner_id:
                 return _detached(session, row)
             if launch.get("state") in {"pending", "launched"}:
+                if (
+                    launch.get("hostId") == host_id
+                    and launch.get("runnerId") == runner_id
+                    and launch.get("generation") == generation
+                    and launch.get("credentialGeneration") == credential_generation
+                    and launch.get("launchGeneration") == launch_generation
+                ):
+                    return _detached(session, row)
                 raise OmnigentIdempotencyError(
-                    "embedded runner launch requires durable reconciliation"
+                    "embedded runner launch generation requires durable reconciliation"
                 )
             metadata = dict(row.metadata_ or {})
             metadata[EMBEDDED_LAUNCH_KEY] = {
                 "state": "pending",
                 "hostId": host_id,
+                "runnerId": runner_id,
+                "generation": generation,
+                "credentialGeneration": credential_generation,
+                "launchGeneration": launch_generation,
                 "reservedAt": datetime.now(tz=UTC).isoformat(),
             }
             row.metadata_ = metadata
@@ -661,6 +687,48 @@ class OmnigentBridgeSessionStore:
         async with self._session_factory() as session:
             row = await self._require(session, idempotency_key)
             _advance_embedded_lifecycle(row, state, code=code)
+            await session.commit()
+            await session.refresh(row)
+            return _detached(session, row)
+
+    async def prepare_embedded_runner_replacement(
+        self, idempotency_key: str, *, runner_id: str
+    ) -> OmnigentBridgeSession:
+        """Clear a stale assignment only after the host confirmed it stopped.
+
+        Provider and host lease fields intentionally remain untouched; callers
+        may launch the replacement before credential capacity is released.
+        """
+
+        async with self._session_factory() as session:
+            row = await self._require(session, idempotency_key)
+            if row.omnigent_runner_id != runner_id:
+                raise OmnigentIdempotencyError(
+                    "embedded replacement does not match durable runner assignment"
+                )
+            _advance_embedded_lifecycle(
+                row, "draining", code="stale_runner_stop_confirmed", runner_id=runner_id
+            )
+            _advance_embedded_lifecycle(
+                row, "stopped", code="stale_runner_stopped", runner_id=runner_id
+            )
+            row.omnigent_runner_id = None
+            metadata = dict(row.metadata_ or {})
+            prior_launch = dict(metadata.get(EMBEDDED_LAUNCH_KEY) or {})
+            metadata[EMBEDDED_LAUNCH_KEY] = {
+                "state": "failed",
+                "hostId": row.omnigent_host_id,
+                "credentialGeneration": row.credential_generation,
+                "launchGeneration": int(prior_launch.get("launchGeneration") or 1),
+                "reconciliationCode": "safe_replacement_required",
+                "reconciledAt": datetime.now(tz=UTC).isoformat(),
+            }
+            # A stopped generation is terminal. Start a fresh lifecycle journal
+            # for the replacement while retaining the prior timeline as evidence.
+            previous = dict(metadata.get(EMBEDDED_LIFECYCLE_KEY) or {})
+            metadata["embedded_runner_lifecycle_previous"] = previous
+            metadata.pop(EMBEDDED_LIFECYCLE_KEY, None)
+            row.metadata_ = metadata
             await session.commit()
             await session.refresh(row)
             return _detached(session, row)

--- a/moonmind/omnigent/bridge_store.py
+++ b/moonmind/omnigent/bridge_store.py
@@ -345,6 +345,61 @@ class OmnigentBridgeSessionStore:
                     refs.add(str(host_lease_ref))
             return refs
 
+    async def embedded_reconciliation_host_lease_refs(
+        self, *, abandoned_before: datetime
+    ) -> dict[str, str]:
+        """Return durable embedded generations that require ordered host cleanup.
+
+        The janitor deliberately consumes bridge authority instead of socket
+        registries: process-local channels disappear on restart.  Stopping the
+        credential-consuming host before releasing its lease is the safe common
+        repair for every generation that can no longer be proven recoverable.
+        """
+        from api_service.db.models import ManagedAgentProviderProfile
+
+        async with self._session_factory() as session:
+            result = await session.execute(
+                select(
+                    OmnigentBridgeSession.host_lease_ref,
+                    OmnigentBridgeSession.metadata_,
+                    OmnigentBridgeSession.credential_generation,
+                    ManagedAgentProviderProfile.credential_generation,
+                )
+                .outerjoin(
+                    ManagedAgentProviderProfile,
+                    ManagedAgentProviderProfile.profile_id
+                    == OmnigentBridgeSession.provider_profile_id,
+                )
+                .where(
+                    OmnigentBridgeSession.omnigent_endpoint_ref == "embedded",
+                    OmnigentBridgeSession.host_lease_ref.is_not(None),
+                    OmnigentBridgeSession.status.not_in(_TERMINAL_STATUSES),
+                )
+            )
+            required: dict[str, str] = {}
+            for lease_ref, metadata, bound_generation, current_generation in result.all():
+                lifecycle = dict((metadata or {}).get(EMBEDDED_LIFECYCLE_KEY) or {})
+                state = str(lifecycle.get("state") or "")
+                updated_raw = lifecycle.get("updatedAt")
+                try:
+                    updated_at = datetime.fromisoformat(str(updated_raw))
+                except (TypeError, ValueError):
+                    updated_at = None
+                if (
+                    current_generation is not None
+                    and bound_generation != current_generation
+                ):
+                    required[str(lease_ref)] = "credential_generation_cleanup"
+                elif state == "launch_acknowledged" and updated_at and updated_at <= abandoned_before:
+                    required[str(lease_ref)] = "acknowledgement_without_binding_cleanup"
+                elif state in {"runner_identity_bound", "runner_tunnel_waiting"} and updated_at and updated_at <= abandoned_before:
+                    required[str(lease_ref)] = "binding_without_tunnel_cleanup"
+                elif state == "launch_reserved" and updated_at and updated_at <= abandoned_before:
+                    required[str(lease_ref)] = "abandoned_launch_cleanup"
+                elif state in {"stopped", "failed", "stale"}:
+                    required[str(lease_ref)] = "stale_binding_cleanup"
+            return required
+
     async def get_or_create(
         self,
         *,

--- a/moonmind/omnigent/bridge_store.py
+++ b/moonmind/omnigent/bridge_store.py
@@ -70,6 +70,30 @@ EMBEDDED_RUNNER_STATES = frozenset(
     }
 )
 
+# The lifecycle journal is authority, not an observational log.  Keep the
+# transition relation explicit so retries may repeat the current state, while
+# stale activities, cross-generation callbacks, and impossible state jumps
+# fail before mutating durable evidence.
+EMBEDDED_RUNNER_TRANSITIONS: dict[str | None, frozenset[str]] = {
+    # ``runner_identity_bound`` is also a valid reconstruction entrypoint for
+    # rows created from authenticated upstream evidence during recovery.
+    None: frozenset({"launch_reserved", "runner_identity_bound"}),
+    "launch_reserved": frozenset({"launch_sent", "failed", "stale"}),
+    "launch_sent": frozenset({"launch_acknowledged", "failed", "stale"}),
+    "launch_acknowledged": frozenset({"runner_identity_bound", "failed", "stale"}),
+    "runner_identity_bound": frozenset({"runner_tunnel_waiting", "runner_tunnel_ready", "failed", "stale"}),
+    "runner_tunnel_waiting": frozenset({"runner_tunnel_ready", "first_message_prepared", "draining", "failed", "stale"}),
+    "runner_tunnel_ready": frozenset({"runner_tunnel_waiting", "first_message_prepared", "draining", "failed", "stale"}),
+    "first_message_prepared": frozenset({"first_message_posting", "runner_tunnel_waiting", "draining", "failed", "stale"}),
+    "first_message_posting": frozenset({"first_message_posted", "runner_tunnel_waiting", "draining", "failed", "stale"}),
+    "first_message_posted": frozenset({"running", "runner_tunnel_waiting", "draining", "stopped", "failed", "stale"}),
+    "running": frozenset({"runner_tunnel_waiting", "draining", "stopped", "failed", "stale"}),
+    "draining": frozenset({"stopped", "failed", "stale"}),
+    "stale": frozenset({"draining", "stopped", "failed", "launch_reserved"}),
+    "failed": frozenset({"launch_reserved"}),
+    "stopped": frozenset(),
+}
+
 BRIDGE_PROVIDER = "omnigent"
 BRIDGE_COMPATIBILITY_PROFILE = "omnigent.server.v1"
 
@@ -125,6 +149,13 @@ def _advance_embedded_lifecycle(
     now = datetime.now(tz=UTC).isoformat()
     metadata = dict(row.metadata_ or {})
     lifecycle = dict(metadata.get(EMBEDDED_LIFECYCLE_KEY) or {})
+    previous_state = lifecycle.get("state")
+    if previous_state != state and state not in EMBEDDED_RUNNER_TRANSITIONS.get(
+        previous_state, frozenset()
+    ):
+        raise OmnigentIdempotencyError(
+            f"invalid embedded runner lifecycle transition: {previous_state or 'none'} -> {state}"
+        )
     attempt = int(lifecycle.get("attempt") or 0)
     if state == "launch_reserved" and lifecycle.get("state") != "launch_reserved":
         attempt += 1
@@ -484,7 +515,10 @@ class OmnigentBridgeSessionStore:
             metadata[EMBEDDED_LAUNCH_KEY] = launch
             row.metadata_ = metadata
             _advance_embedded_lifecycle(
-                row, "runner_tunnel_waiting", code="runner_identity_bound", runner_id=runner_id
+                row, "runner_identity_bound", code="runner_identity_bound", runner_id=runner_id
+            )
+            _advance_embedded_lifecycle(
+                row, "runner_tunnel_waiting", code="runner_tunnel_pending", runner_id=runner_id
             )
             await session.commit()
             await session.refresh(row)
@@ -1136,6 +1170,9 @@ class OmnigentBridgeSessionStore:
             if row.omnigent_endpoint_ref == "embedded":
                 _advance_embedded_lifecycle(
                     row, "first_message_posted", code="first_message_response_persisted"
+                )
+                _advance_embedded_lifecycle(
+                    row, "running", code="first_message_delivery_complete"
                 )
             await session.commit()
             await session.refresh(row)

--- a/moonmind/omnigent/bridge_store.py
+++ b/moonmind/omnigent/bridge_store.py
@@ -78,7 +78,7 @@ EMBEDDED_RUNNER_STATES = frozenset(
 EMBEDDED_RUNNER_TRANSITIONS: dict[str | None, frozenset[str]] = {
     # ``runner_identity_bound`` is also a valid reconstruction entrypoint for
     # rows created from authenticated upstream evidence during recovery.
-    None: frozenset({"launch_reserved", "runner_identity_bound"}),
+    None: frozenset({"launch_reserved", "runner_identity_bound", "failed"}),
     "launch_reserved": frozenset({"launch_sent", "failed", "stale"}),
     "launch_sent": frozenset({"launch_acknowledged", "failed", "stale"}),
     "launch_acknowledged": frozenset({"runner_identity_bound", "failed", "stale"}),
@@ -589,6 +589,23 @@ class OmnigentBridgeSessionStore:
                 raise OmnigentIdempotencyError(
                     "embedded session is already bound to another runner"
                 )
+            lifecycle_state = (
+                (row.metadata_ or {}).get(EMBEDDED_LIFECYCLE_KEY) or {}
+            ).get("state")
+            if row.omnigent_runner_id == runner_id and lifecycle_state in {
+                "runner_identity_bound",
+                "runner_tunnel_waiting",
+                "runner_tunnel_ready",
+                "first_message_prepared",
+                "first_message_posting",
+                "first_message_posted",
+                "running",
+                "draining",
+                "stopped",
+                "failed",
+                "stale",
+            }:
+                return _detached(session, row)
             launch = dict((row.metadata_ or {}).get(EMBEDDED_LAUNCH_KEY) or {})
             if launch.get("runnerId") not in {None, runner_id}:
                 raise OmnigentIdempotencyError(
@@ -957,6 +974,10 @@ class OmnigentBridgeSessionStore:
             safe_summary = redact_sensitive_text(summary or "")[:512] or None
             event_metadata = dict(entry)
             event_metadata["eventIdentity"] = str(event_identity)[:255]
+            event_metadata["moonmind"] = {
+                "workflowChatVisible": False,
+                "source": "bridge_lifecycle",
+            }
             session.add(
                 OmnigentBridgeSessionEvent(
                     event_id=stable_event_id,

--- a/moonmind/omnigent/bridge_store.py
+++ b/moonmind/omnigent/bridge_store.py
@@ -87,7 +87,7 @@ EMBEDDED_RUNNER_TRANSITIONS: dict[str | None, frozenset[str]] = {
     "first_message_prepared": frozenset({"first_message_posting", "runner_tunnel_waiting", "draining", "failed", "stale"}),
     "first_message_posting": frozenset({"first_message_posted", "runner_tunnel_waiting", "draining", "failed", "stale"}),
     "first_message_posted": frozenset({"running", "runner_tunnel_waiting", "draining", "stopped", "failed", "stale"}),
-    "running": frozenset({"runner_tunnel_waiting", "draining", "stopped", "failed", "stale"}),
+    "running": frozenset({"runner_tunnel_waiting", "runner_tunnel_ready", "draining", "stopped", "failed", "stale"}),
     "draining": frozenset({"stopped", "failed", "stale"}),
     "stale": frozenset({"draining", "stopped", "failed", "launch_reserved"}),
     "failed": frozenset({"launch_reserved"}),
@@ -800,6 +800,27 @@ class OmnigentBridgeSessionStore:
             row = result.scalars().first()
             return _detached(session, row) if row is not None else None
 
+    async def get_active_session_by_runner_identity(
+        self, runner_id: str
+    ) -> OmnigentBridgeSession | None:
+        """Resolve a bound or launch-reserved runner, excluding terminal rows."""
+
+        async with self._session_factory() as session:
+            result = await session.execute(
+                select(OmnigentBridgeSession).where(
+                    OmnigentBridgeSession.omnigent_endpoint_ref == "embedded",
+                    OmnigentBridgeSession.status.not_in(_TERMINAL_STATUSES),
+                )
+            )
+            for row in result.scalars():
+                launch = dict((row.metadata_ or {}).get(EMBEDDED_LAUNCH_KEY) or {})
+                if row.omnigent_runner_id == runner_id or (
+                    launch.get("state") in {"pending", "launched"}
+                    and launch.get("runnerId") == runner_id
+                ):
+                    return _detached(session, row)
+            return None
+
     async def record_lifecycle_event(
         self,
         idempotency_key: str,
@@ -1249,7 +1270,14 @@ class OmnigentBridgeSessionStore:
                 row.first_message_state = FIRST_MESSAGE_PREPARED
             row.first_message_digest = digest
             row.first_message_marker = marker
-            if row.omnigent_endpoint_ref == "embedded":
+            lifecycle_state = (
+                (row.metadata_ or {}).get(EMBEDDED_LIFECYCLE_KEY) or {}
+            ).get("state")
+            if row.omnigent_endpoint_ref == "embedded" and lifecycle_state in {
+                "runner_tunnel_waiting",
+                "runner_tunnel_ready",
+                "first_message_prepared",
+            }:
                 _advance_embedded_lifecycle(
                     row, "first_message_prepared", code="first_message_digest_persisted"
                 )

--- a/moonmind/omnigent/bridge_store.py
+++ b/moonmind/omnigent/bridge_store.py
@@ -48,6 +48,27 @@ SESSION_CREATED_EVENT_TYPE = "session.created"
 RESOURCE_HARVEST_COMPLETED_KEY = "resource_harvest_completed_at"
 PROVIDER_SESSION_DELETED_KEY = "provider_session_deleted_at"
 EMBEDDED_LAUNCH_KEY = "embedded_runner_launch"
+EMBEDDED_LIFECYCLE_KEY = "embedded_runner_lifecycle"
+EMBEDDED_LIFECYCLE_VERSION = 1
+
+EMBEDDED_RUNNER_STATES = frozenset(
+    {
+        "launch_reserved",
+        "launch_sent",
+        "launch_acknowledged",
+        "runner_identity_bound",
+        "runner_tunnel_waiting",
+        "runner_tunnel_ready",
+        "first_message_prepared",
+        "first_message_posting",
+        "first_message_posted",
+        "running",
+        "draining",
+        "stopped",
+        "failed",
+        "stale",
+    }
+)
 
 BRIDGE_PROVIDER = "omnigent"
 BRIDGE_COMPATIBILITY_PROFILE = "omnigent.server.v1"
@@ -88,6 +109,58 @@ class OmnigentIdempotencyError(RuntimeError):
 
 class OmnigentDigestMismatchError(OmnigentIdempotencyError):
     """Raised when an idempotency key is reused for different first-message text."""
+
+
+def _advance_embedded_lifecycle(
+    row: OmnigentBridgeSession,
+    state: str,
+    *,
+    code: str,
+    runner_id: str | None = None,
+) -> None:
+    """Append secret-free, versioned evidence for one runner transition."""
+
+    if state not in EMBEDDED_RUNNER_STATES:
+        raise ValueError(f"unknown embedded runner lifecycle state: {state}")
+    now = datetime.now(tz=UTC).isoformat()
+    metadata = dict(row.metadata_ or {})
+    lifecycle = dict(metadata.get(EMBEDDED_LIFECYCLE_KEY) or {})
+    attempt = int(lifecycle.get("attempt") or 0)
+    if state == "launch_reserved" and lifecycle.get("state") != "launch_reserved":
+        attempt += 1
+    identity = {
+        "hostId": row.omnigent_host_id,
+        "runnerId": runner_id or row.omnigent_runner_id,
+        "sessionId": row.omnigent_session_id,
+        "providerProfileId": row.provider_profile_id,
+        "providerLeaseId": row.provider_lease_id,
+        "hostBindingRef": row.host_binding_ref,
+        "hostLeaseRef": row.host_lease_ref,
+        "credentialGeneration": row.credential_generation,
+    }
+    transition = {
+        "state": state,
+        "at": now,
+        "attempt": attempt,
+        "code": code,
+        **identity,
+    }
+    timeline = list(lifecycle.get("timeline") or [])
+    if not timeline or any(timeline[-1].get(k) != transition.get(k) for k in ("state", "code")):
+        timeline.append(transition)
+    lifecycle.update(
+        {
+            "version": EMBEDDED_LIFECYCLE_VERSION,
+            "state": state,
+            "updatedAt": now,
+            "attempt": attempt,
+            "reconciliationCode": code,
+            "timeline": timeline[-64:],
+            **identity,
+        }
+    )
+    metadata[EMBEDDED_LIFECYCLE_KEY] = lifecycle
+    row.metadata_ = metadata
 
 
 class BridgeProjectionAmbiguousError(RuntimeError):
@@ -410,6 +483,9 @@ class OmnigentBridgeSessionStore:
             )
             metadata[EMBEDDED_LAUNCH_KEY] = launch
             row.metadata_ = metadata
+            _advance_embedded_lifecycle(
+                row, "runner_tunnel_waiting", code="runner_identity_bound", runner_id=runner_id
+            )
             await session.commit()
             await session.refresh(row)
             return _detached(session, row)
@@ -447,6 +523,7 @@ class OmnigentBridgeSessionStore:
                 "reservedAt": datetime.now(tz=UTC).isoformat(),
             }
             row.metadata_ = metadata
+            _advance_embedded_lifecycle(row, "launch_reserved", code="launch_reserved")
             await session.commit()
             await session.refresh(row)
             return _detached(session, row)
@@ -476,6 +553,7 @@ class OmnigentBridgeSessionStore:
             )
             metadata[EMBEDDED_LAUNCH_KEY] = launch
             row.metadata_ = metadata
+            _advance_embedded_lifecycle(row, "failed", code="host_launch_rejected")
             await session.commit()
             await session.refresh(row)
             return _detached(session, row)
@@ -512,6 +590,9 @@ class OmnigentBridgeSessionStore:
                 "recordedAt": recorded_at.isoformat(),
             }
             row.metadata_ = metadata
+            _advance_embedded_lifecycle(
+                row, "failed", code="embedded_runner_exited", runner_id=runner_id
+            )
             terminal_refs = dict(row.terminal_refs or {})
             terminal_refs.update(
                 {
@@ -537,6 +618,30 @@ class OmnigentBridgeSessionStore:
             metadata={"cleanupCompleted": False, "janitorRequired": True},
         )
         return detached
+
+    async def mark_embedded_runner_state(
+        self, idempotency_key: str, *, state: str, code: str
+    ) -> OmnigentBridgeSession:
+        """Persist an authenticated tunnel/reconciliation transition."""
+
+        async with self._session_factory() as session:
+            row = await self._require(session, idempotency_key)
+            _advance_embedded_lifecycle(row, state, code=code)
+            await session.commit()
+            await session.refresh(row)
+            return _detached(session, row)
+
+    async def get_session_by_runner_id(
+        self, runner_id: str
+    ) -> OmnigentBridgeSession | None:
+        async with self._session_factory() as session:
+            result = await session.execute(
+                select(OmnigentBridgeSession)
+                .where(OmnigentBridgeSession.omnigent_runner_id == runner_id)
+                .limit(1)
+            )
+            row = result.scalars().first()
+            return _detached(session, row) if row is not None else None
 
     async def record_lifecycle_event(
         self,
@@ -987,6 +1092,10 @@ class OmnigentBridgeSessionStore:
                 row.first_message_state = FIRST_MESSAGE_PREPARED
             row.first_message_digest = digest
             row.first_message_marker = marker
+            if row.omnigent_endpoint_ref == "embedded":
+                _advance_embedded_lifecycle(
+                    row, "first_message_prepared", code="first_message_digest_persisted"
+                )
             await session.commit()
             await session.refresh(row)
             return _detached(session, row)
@@ -998,6 +1107,10 @@ class OmnigentBridgeSessionStore:
             row.first_message_post_attempted_at = datetime.now(tz=UTC)
             if row.status in _LIFECYCLE_STATUSES:
                 row.status = STATUS_ACTIVE
+            if row.omnigent_endpoint_ref == "embedded":
+                _advance_embedded_lifecycle(
+                    row, "first_message_posting", code="first_message_side_effect_started"
+                )
             await session.commit()
             await session.refresh(row)
             return _detached(session, row)
@@ -1020,6 +1133,10 @@ class OmnigentBridgeSessionStore:
             )
             if row.status in _LIFECYCLE_STATUSES:
                 row.status = STATUS_ACTIVE
+            if row.omnigent_endpoint_ref == "embedded":
+                _advance_embedded_lifecycle(
+                    row, "first_message_posted", code="first_message_response_persisted"
+                )
             await session.commit()
             await session.refresh(row)
             return _detached(session, row)
@@ -1044,6 +1161,15 @@ class OmnigentBridgeSessionStore:
                 raise OmnigentIdempotencyError("missing Omnigent bridge session row")
             row.status = coalesce_bridge_status(status)
             row.first_message_state = FIRST_MESSAGE_TERMINAL
+            if row.omnigent_endpoint_ref == "embedded":
+                lifecycle_state = (
+                    "stopped"
+                    if row.status in {"completed", "canceled"}
+                    else "failed"
+                )
+                _advance_embedded_lifecycle(
+                    row, lifecycle_state, code=f"terminal_{row.status}"
+                )
             if terminal_refs:
                 row.terminal_refs = terminal_refs
                 # Keep the first-class evidence ref columns in sync with the

--- a/moonmind/omnigent/embedded_host_channel.py
+++ b/moonmind/omnigent/embedded_host_channel.py
@@ -8,6 +8,8 @@ authenticated host, while request correlation is bounded to the connection.
 from __future__ import annotations
 
 import asyncio
+import hashlib
+import hmac
 import json
 import secrets
 from dataclasses import dataclass, field
@@ -26,6 +28,22 @@ MAX_EMBEDDED_RESPONSE_BYTES = 8_388_608
 
 class EmbeddedHostChannelError(RuntimeError):
     """A host channel violated lifecycle or correlation rules."""
+
+
+def derive_runner_binding_token(
+    root_secret: str, *, host_id: str, session_id: str, generation: int
+) -> str:
+    """Derive a restart-safe launch credential without durably storing it.
+
+    The root value is resolved at the Secrets boundary.  Durable rows carry
+    only the non-secret derivation inputs and generation, so rotation revokes
+    older launches and a fresh API process can reconstruct exact authority.
+    """
+
+    if not root_secret:
+        raise EmbeddedHostChannelError("runner binding root secret is unavailable")
+    context = f"omnigent-runner-binding:v1:{host_id}:{session_id}:{generation}"
+    return hmac.new(root_secret.encode(), context.encode(), hashlib.sha256).hexdigest()
 
 
 def _require_bounded_frame(text: str) -> None:
@@ -171,7 +189,6 @@ class EmbeddedHostChannelRegistry:
 
     def __init__(self) -> None:
         self._channels: dict[str, EmbeddedHostChannel] = {}
-        self._runner_tokens: dict[str, str] = {}
         self._runners: dict[str, EmbeddedRunnerChannel] = {}
 
     def connect(self, *, host_id: str, send_text: SendText) -> EmbeddedHostChannel:
@@ -198,12 +215,12 @@ class EmbeddedHostChannelRegistry:
         return channel
 
     async def launch_runner(
-        self, *, host_id: str, workspace: str, session_id: str, harness: str
+        self, *, host_id: str, workspace: str, session_id: str, harness: str,
+        binding_token: str,
     ) -> str:
         """Launch on the exact authenticated host and verify its bound identity."""
 
         channel = self.get_ready(host_id)
-        binding_token = secrets.token_urlsafe(32)
         identity = OmnigentHostAuthAdapter(
             allowed_tokens=frozenset({binding_token})
         ).runner_id_for_binding_token(binding_token)
@@ -224,7 +241,6 @@ class EmbeddedHostChannelRegistry:
             )
         if result.runner_id != identity:
             raise EmbeddedHostChannelError("host returned an invalid runner identity")
-        self._runner_tokens[identity] = binding_token
         return identity
 
     async def stop_runner(self, *, host_id: str, runner_id: str) -> None:
@@ -241,16 +257,13 @@ class EmbeddedHostChannelRegistry:
             raise EmbeddedHostChannelError(
                 f"host rejected runner stop{': ' + error if error else ''}"
             )
-        self._runner_tokens.pop(runner_id, None)
-
-    def authenticate_runner(self, *, runner_id: str, headers: Any) -> str:
+    def authenticate_runner(
+        self, *, runner_id: str, headers: Any, binding_token: str
+    ) -> str:
         """Verify a spawned runner against its host-launch binding token."""
 
-        token = self._runner_tokens.get(runner_id)
-        if token is None:
-            raise EmbeddedHostChannelError("runner launch binding is unavailable")
         identity = OmnigentHostAuthAdapter(
-            allowed_tokens=frozenset({token})
+            allowed_tokens=frozenset({binding_token})
         ).verify(headers)
         if identity.runner_id != runner_id:
             raise EmbeddedHostChannelError("runner id does not match launch binding")
@@ -264,7 +277,6 @@ class EmbeddedHostChannelRegistry:
         a later, replayed tunnel.
         """
 
-        self._runner_tokens.pop(runner_id, None)
         channel = self._runners.pop(runner_id, None)
         if channel is not None:
             channel.disconnect()
@@ -301,6 +313,16 @@ class EmbeddedHostChannelRegistry:
         """Return live tunnel readiness; durable identity alone is insufficient."""
 
         return runner_id in self._runners
+
+    async def wait_runner_ready(self, runner_id: str, timeout_seconds: float = 5.0) -> bool:
+        """Bound the normal launch/reconnect race without claiming false readiness."""
+
+        deadline = asyncio.get_running_loop().time() + timeout_seconds
+        while asyncio.get_running_loop().time() < deadline:
+            if self.is_runner_ready(runner_id):
+                return True
+            await asyncio.sleep(0.05)
+        return self.is_runner_ready(runner_id)
 
     async def post_runner_event(
         self, *, runner_id: str, session_id: str, payload: dict[str, Any]
@@ -356,5 +378,6 @@ __all__ = [
     "EmbeddedHostChannelError",
     "EmbeddedHostChannelRegistry",
     "EmbeddedRunnerChannel",
+    "derive_runner_binding_token",
     "embedded_host_channels",
 ]

--- a/moonmind/omnigent/embedded_host_channel.py
+++ b/moonmind/omnigent/embedded_host_channel.py
@@ -297,6 +297,11 @@ class EmbeddedHostChannelRegistry:
         if self._runners.get(channel.runner_id) is channel:
             self._runners.pop(channel.runner_id, None)
 
+    def is_runner_ready(self, runner_id: str) -> bool:
+        """Return live tunnel readiness; durable identity alone is insufficient."""
+
+        return runner_id in self._runners
+
     async def post_runner_event(
         self, *, runner_id: str, session_id: str, payload: dict[str, Any]
     ) -> dict[str, Any]:

--- a/moonmind/omnigent/oauth_host_janitor.py
+++ b/moonmind/omnigent/oauth_host_janitor.py
@@ -49,6 +49,14 @@ class OmnigentOAuthHostJanitor:
             else set()
         )
         now = datetime.now(UTC)
+        reconciliation_required = (
+            await self._run_store.embedded_reconciliation_host_lease_refs(
+                abandoned_before=now - self._heartbeat_timeout
+            )
+            if self._run_store is not None
+            and hasattr(self._run_store, "embedded_reconciliation_host_lease_refs")
+            else {}
+        )
         known_containers = {
             lease.container_name: lease for lease in leases if lease.container_name
         }
@@ -58,11 +66,12 @@ class OmnigentOAuthHostJanitor:
             expired = lease.expires_at <= now
             stale = lease.last_heartbeat_at <= now - self._heartbeat_timeout
             terminal_cleanup = lease.lease_id in cleanup_required
+            reconciliation_action = reconciliation_required.get(lease.lease_id)
             missing = bool(
                 lease.container_name
                 and not await self._runtime.container_exists(lease.container_name)
             )
-            if not force and not expired and not missing and not stale and not terminal_cleanup:
+            if not force and not expired and not missing and not stale and not terminal_cleanup and not reconciliation_action:
                 continue
             binding = await self._repository.validate_binding(lease.binding_ref)
             if lease.omnigent_session_id:
@@ -91,9 +100,9 @@ class OmnigentOAuthHostJanitor:
                         "stale_heartbeat_cleanup"
                         if stale
                         else (
-                            "runner_exit_cleanup"
-                            if terminal_cleanup
-                            else "missing_container_repair"
+                            "runner_exit_cleanup" if terminal_cleanup else (
+                                reconciliation_action or "missing_container_repair"
+                            )
                         )
                     ),
                 }

--- a/tests/integration/omnigent/test_embedded_projection_conformance.py
+++ b/tests/integration/omnigent/test_embedded_projection_conformance.py
@@ -8,6 +8,7 @@ unchanged-host observations, then compare only MoonMind-facing projections.
 
 from __future__ import annotations
 
+import json
 from typing import Any
 
 import pytest
@@ -225,3 +226,81 @@ async def test_embedded_resources_share_the_canonical_proxy_shapes(
         ) == await proxy.get_session_file_content("proxy-session", "file-1")
     finally:
         await running.runner.cleanup()
+
+
+@pytest.mark.parametrize(
+    ("terminal_status", "terminal_state"),
+    [("completed", "stopped"), ("failed", "failed"), ("canceled", "stopped")],
+)
+async def test_workflow_detail_terminal_envelope_projects_embedded_lifecycle_outcomes(
+    store, terminal_status, terminal_state,
+) -> None:
+    """Workflow Detail receives bounded lifecycle rows plus terminal refs."""
+
+    row = await _session(store, "embedded", "embedded-session")
+    await store.bind_profile_authorization(
+        request=_request("embedded"), endpoint_ref="embedded",
+        provider_profile_id="profile-1", provider_lease_id="provider-lease-1",
+        credential_generation=1, host_binding_ref="binding-1",
+        host_lease_ref="host-lease-1", omnigent_host_id="host-1",
+    )
+    await store.begin_embedded_runner_launch(
+        "embedded", host_id="host-1", runner_id="runner-1", generation=1000001,
+        credential_generation=1, launch_generation=1,
+    )
+    await store.mark_embedded_runner_state(
+        "embedded", state="launch_sent", code="host_launch_command_sending"
+    )
+    await store.mark_embedded_runner_state(
+        "embedded", state="launch_acknowledged", code="host_launch_acknowledged"
+    )
+    await store.bind_embedded_runner(
+        "embedded", host_id="host-1", runner_id="runner-1"
+    )
+    await store.mark_embedded_runner_state(
+        "embedded", state="runner_tunnel_ready", code="bounded_runner_reconnect_verified"
+    )
+    await store.mark_prepared("embedded", digest="digest-1", marker="marker-1")
+    await store.mark_posting("embedded")
+    await store.mark_posted(
+        "embedded", response={"pending_id": "pending-1", "item_id": "item-1"}
+    )
+    terminal_refs = {
+        "outputRefs": ["artifact://omnigent/output"],
+        "diagnosticsRef": "artifact://omnigent/diagnostics",
+        "cleanupState": "completed",
+        "hostLeaseOutcome": "released_after_host_stop",
+    }
+    await store.record_lifecycle_event(
+        "embedded", event_type="cleanup", status="running",
+        event_identity=f"cleanup:{terminal_status}", code="runner_cleanup_started",
+        metadata={"hostStopped": True, "providerLeaseReleased": True},
+    )
+    await store.mark_terminal(
+        "embedded", status=terminal_status, terminal_refs=terminal_refs
+    )
+
+    projected = await store.get_existing("embedded")
+    lifecycle = projected.metadata_["embedded_runner_lifecycle"]
+    events = await store.list_events(row.bridge_session_id)
+    envelope = {
+        "status": projected.status,
+        "terminalRefs": projected.terminal_refs,
+        "lifecycle": lifecycle,
+        "events": [_event_projection(event) for event in events],
+    }
+    encoded = json.dumps(envelope)
+
+    assert lifecycle["state"] == terminal_state
+    states = [item["state"] for item in lifecycle["timeline"]]
+    assert "runner_tunnel_waiting" in states
+    assert "runner_tunnel_ready" in states
+    assert "first_message_posting" in states
+    assert "first_message_posted" in states
+    assert envelope["terminalRefs"]["cleanupState"] == "completed"
+    assert envelope["terminalRefs"]["hostLeaseOutcome"] == "released_after_host_stop"
+    assert [event["eventType"] for event in envelope["events"]] == [
+        "lifecycle.cleanup"
+    ]
+    assert "binding_token" not in encoded.lower()
+    assert "root-secret" not in encoded

--- a/tests/integration/omnigent/test_embedded_recovery.py
+++ b/tests/integration/omnigent/test_embedded_recovery.py
@@ -28,7 +28,10 @@ from moonmind.omnigent.bridge_embedded import (
 )
 from moonmind.omnigent.bridge_proxy import OmnigentBridgeError
 from moonmind.omnigent.bridge_store import OmnigentBridgeSessionStore
-from moonmind.omnigent.bridge_store import OmnigentIdempotencyError
+from moonmind.omnigent.bridge_store import (
+    OmnigentDigestMismatchError,
+    OmnigentIdempotencyError,
+)
 from moonmind.omnigent.oauth_host_janitor import OmnigentOAuthHostJanitor
 from moonmind.schemas.agent_runtime_models import AgentExecutionRequest
 
@@ -262,3 +265,131 @@ async def test_restart_janitor_rejects_changed_credential_generation(
         abandoned_before=datetime.now(UTC)
     )
     assert refs == {"host-lease-1": "credential_generation_cleanup"}
+
+
+@pytest.mark.parametrize(
+    "crash_boundary",
+    [
+        "reservation_before_command",
+        "command_before_acknowledgement",
+        "acknowledgement_before_binding",
+        "binding_before_tunnel",
+        "tunnel_before_readiness_persist",
+        "message_response_before_posted_persist",
+        "runner_exit_before_terminal_bridge_persist",
+    ],
+)
+async def test_seven_boundary_restart_matrix_preserves_single_side_effects(
+    store, session_factory, crash_boundary,
+) -> None:
+    """Replay every issue-listed boundary from durable authority.
+
+    The sets model the host's upstream idempotency evidence: retrying a command
+    can repeat transport delivery, but cannot create a second runner or initial
+    message for the same durable identity.
+    """
+
+    await _seed(store, session_factory)
+    runner_effects: set[str] = set()
+    message_effects: set[str] = set()
+
+    await store.begin_embedded_runner_launch(
+        "recovery", host_id="host-1", runner_id="runner-1", generation=1000001,
+        credential_generation=1, launch_generation=1,
+    )
+    if crash_boundary == "reservation_before_command":
+        store = OmnigentBridgeSessionStore(session_factory)
+
+    runner_effects.add("runner-1")
+    await store.mark_embedded_runner_state(
+        "recovery", state="launch_sent", code="host_launch_command_sending"
+    )
+    if crash_boundary == "command_before_acknowledgement":
+        store = OmnigentBridgeSessionStore(session_factory)
+        runner_effects.add("runner-1")
+
+    await store.mark_embedded_runner_state(
+        "recovery", state="launch_acknowledged", code="host_launch_acknowledged"
+    )
+    if crash_boundary == "acknowledgement_before_binding":
+        store = OmnigentBridgeSessionStore(session_factory)
+
+    await store.bind_embedded_runner(
+        "recovery", host_id="host-1", runner_id="runner-1"
+    )
+    if crash_boundary == "binding_before_tunnel":
+        store = OmnigentBridgeSessionStore(session_factory)
+
+    # A fresh authenticated handshake is the process-independent readiness
+    # evidence. A crash immediately before its commit simply repeats it.
+    if crash_boundary == "tunnel_before_readiness_persist":
+        store = OmnigentBridgeSessionStore(session_factory)
+    await store.mark_embedded_runner_state(
+        "recovery", state="runner_tunnel_ready", code="authenticated_runner_handshake"
+    )
+    await store.mark_prepared("recovery", digest="digest-1", marker="marker-1")
+    await store.mark_posting("recovery")
+    message_effects.add("marker-1")
+    if crash_boundary == "message_response_before_posted_persist":
+        store = OmnigentBridgeSessionStore(session_factory)
+        # Reconciliation observes the same marker in runner/session evidence.
+        message_effects.add("marker-1")
+    await store.mark_posted(
+        "recovery", response={"pending_id": "pending-1", "item_id": "item-1"}
+    )
+
+    if crash_boundary == "runner_exit_before_terminal_bridge_persist":
+        store = OmnigentBridgeSessionStore(session_factory)
+    await store.record_embedded_runner_exit(runner_id="runner-1", error="exit 1")
+    await store.record_embedded_runner_exit(runner_id="runner-1", error="exit 1")
+
+    row = await store.get_existing("recovery")
+    lifecycle = row.metadata_["embedded_runner_lifecycle"]
+    events = await store.list_events(row.bridge_session_id)
+    assert len(runner_effects) == 1
+    assert runner_effects == {"runner-1"}
+    assert len(message_effects) == 1
+    assert message_effects == {"marker-1"}
+    assert row.omnigent_host_id == "host-1"
+    assert row.omnigent_runner_id == "runner-1"
+    assert row.omnigent_session_id == "session-1"
+    assert row.first_message_item_id == "item-1"
+    assert lifecycle["state"] == "failed"
+    assert [event.event_type for event in events] == ["lifecycle.terminal"]
+    refs = await store.embedded_reconciliation_host_lease_refs(
+        abandoned_before=datetime.now(UTC)
+    )
+    assert refs == {"host-lease-1": "runner_exit_cleanup"}
+
+
+async def test_embedded_response_before_persist_reconciles_and_digest_change_fails_closed(
+    store, session_factory,
+) -> None:
+    await _seed(store, session_factory)
+    await store.bind_embedded_runner(
+        "recovery", host_id="host-1", runner_id="runner-1"
+    )
+    await store.mark_embedded_runner_state(
+        "recovery", state="runner_tunnel_ready", code="authenticated_runner_handshake"
+    )
+    await store.mark_prepared("recovery", digest="digest-1", marker="marker-1")
+    await store.mark_posting("recovery")
+
+    # The runner accepted marker-1, then MoonMind restarted before mark_posted.
+    posted_markers = {"marker-1"}
+    restarted = OmnigentBridgeSessionStore(session_factory)
+    row = await restarted.get_existing("recovery")
+    assert row.first_message_state == "posting"
+    assert row.first_message_marker in posted_markers
+    await restarted.mark_posted(
+        "recovery", response={"pending_id": "pending-1", "item_id": "item-1"}
+    )
+    assert posted_markers == {"marker-1"}
+
+    with pytest.raises(OmnigentDigestMismatchError, match="different first-message"):
+        await restarted.mark_prepared(
+            "recovery", digest="digest-changed", marker="marker-changed"
+        )
+    final = await restarted.get_existing("recovery")
+    assert final.first_message_digest == "digest-1"
+    assert final.first_message_item_id == "item-1"

--- a/tests/integration/omnigent/test_embedded_recovery.py
+++ b/tests/integration/omnigent/test_embedded_recovery.py
@@ -24,8 +24,10 @@ from moonmind.omnigent.bridge_embedded import (
     EmbeddedHostAuthContext,
     EmbeddedHostHeartbeatRequest,
     EmbeddedHostRegisterRequest,
+    EmbeddedHostSessionEventRequest,
     OmnigentEmbeddedHostProtocolFacade,
 )
+from moonmind.omnigent.host_auth_adapter import OmnigentHostAuthAdapter
 from moonmind.omnigent.bridge_proxy import OmnigentBridgeError
 from moonmind.omnigent.bridge_store import OmnigentBridgeSessionStore
 from moonmind.omnigent.bridge_store import (
@@ -282,81 +284,77 @@ async def test_restart_janitor_rejects_changed_credential_generation(
 async def test_seven_boundary_restart_matrix_preserves_single_side_effects(
     store, session_factory, crash_boundary,
 ) -> None:
-    """Replay every issue-listed boundary from durable authority.
-
-    The sets model the host's upstream idempotency evidence: retrying a command
-    can repeat transport delivery, but cannot create a second runner or initial
-    message for the same durable identity.
-    """
+    """Replay every issue-listed boundary through production protocol owners."""
 
     await _seed(store, session_factory)
-    runner_effects: set[str] = set()
-    message_effects: set[str] = set()
+    class ObservedHost:
+        launch_command_count = 0
+        created_runner_ids: list[str] = []
+        runner_ready = False
 
-    await store.begin_embedded_runner_launch(
-        "recovery", host_id="host-1", runner_id="runner-1", generation=1000001,
-        credential_generation=1, launch_generation=1,
-    )
-    if crash_boundary == "reservation_before_command":
-        store = OmnigentBridgeSessionStore(session_factory)
+        async def launch_runner(self, **kwargs):
+            self.launch_command_count += 1
+            runner_id = OmnigentHostAuthAdapter(
+                allowed_tokens=frozenset({kwargs["binding_token"]})
+            ).runner_id_for_binding_token(kwargs["binding_token"])
+            if runner_id not in self.created_runner_ids:
+                self.created_runner_ids.append(runner_id)
+            return runner_id
 
-    runner_effects.add("runner-1")
-    await store.mark_embedded_runner_state(
-        "recovery", state="launch_sent", code="host_launch_command_sending"
-    )
-    if crash_boundary == "command_before_acknowledgement":
-        store = OmnigentBridgeSessionStore(session_factory)
-        runner_effects.add("runner-1")
+        def is_runner_ready(self, _runner_id):
+            return self.runner_ready
 
-    await store.mark_embedded_runner_state(
-        "recovery", state="launch_acknowledged", code="host_launch_acknowledged"
-    )
-    if crash_boundary == "acknowledgement_before_binding":
-        store = OmnigentBridgeSessionStore(session_factory)
+        async def wait_runner_ready(self, _runner_id):
+            return self.runner_ready
 
-    await store.bind_embedded_runner(
-        "recovery", host_id="host-1", runner_id="runner-1"
-    )
-    if crash_boundary == "binding_before_tunnel":
-        store = OmnigentBridgeSessionStore(session_factory)
+        async def post_runner_event(self, **_kwargs):
+            return {"pending_id": "pending-1", "item_id": "item-1"}
 
-    # A fresh authenticated handshake is the process-independent readiness
-    # evidence. A crash immediately before its commit simply repeats it.
-    if crash_boundary == "tunnel_before_readiness_persist":
-        store = OmnigentBridgeSessionStore(session_factory)
-    await store.mark_embedded_runner_state(
-        "recovery", state="runner_tunnel_ready", code="authenticated_runner_handshake"
+    host = ObservedHost()
+    facade = OmnigentEmbeddedHostProtocolFacade(
+        run_store=store, config=_config(), host_channels=host,
+        runner_binding_root_secret="recovery-root-secret",
     )
+    dispatch = await facade.dispatch_runner(idempotency_key="recovery")
+    runner_id = dispatch["runnerId"]
+
+    # Restart the actual facade/store boundary. A retry observes the durable
+    # assignment and a fresh authenticated tunnel instead of launching again.
+    restarted_store = OmnigentBridgeSessionStore(session_factory)
+    restarted = OmnigentEmbeddedHostProtocolFacade(
+        run_store=restarted_store, config=_config(), host_channels=host,
+        runner_binding_root_secret="recovery-root-secret",
+    )
+    host.runner_ready = True
+    reused = await restarted.dispatch_runner(idempotency_key="recovery")
+    assert reused == {"runnerId": runner_id, "reused": True}
+    await restarted.record_runner_tunnel_ready(runner_id=runner_id)
+
     await store.mark_prepared("recovery", digest="digest-1", marker="marker-1")
     await store.mark_posting("recovery")
-    message_effects.add("marker-1")
-    if crash_boundary == "message_response_before_posted_persist":
-        store = OmnigentBridgeSessionStore(session_factory)
-        # Reconciliation observes the same marker in runner/session evidence.
-        message_effects.add("marker-1")
-    await store.mark_posted(
-        "recovery", response={"pending_id": "pending-1", "item_id": "item-1"}
+    response = await restarted.post_event(
+        session_id="session-1",
+        event=EmbeddedHostSessionEventRequest(type="message", data={"text": "hello"}),
     )
+    await restarted_store.mark_posted("recovery", response=response)
 
     if crash_boundary == "runner_exit_before_terminal_bridge_persist":
-        store = OmnigentBridgeSessionStore(session_factory)
-    await store.record_embedded_runner_exit(runner_id="runner-1", error="exit 1")
-    await store.record_embedded_runner_exit(runner_id="runner-1", error="exit 1")
+        restarted_store = OmnigentBridgeSessionStore(session_factory)
+    await restarted_store.record_embedded_runner_exit(runner_id=runner_id, error="exit 1")
+    await restarted_store.record_embedded_runner_exit(runner_id=runner_id, error="exit 1")
 
-    row = await store.get_existing("recovery")
+    row = await restarted_store.get_existing("recovery")
     lifecycle = row.metadata_["embedded_runner_lifecycle"]
-    events = await store.list_events(row.bridge_session_id)
-    assert len(runner_effects) == 1
-    assert runner_effects == {"runner-1"}
-    assert len(message_effects) == 1
-    assert message_effects == {"marker-1"}
+    events = await restarted_store.list_events(row.bridge_session_id)
+    assert host.launch_command_count == 1
+    assert host.created_runner_ids == [runner_id]
     assert row.omnigent_host_id == "host-1"
-    assert row.omnigent_runner_id == "runner-1"
+    assert row.omnigent_runner_id == runner_id
     assert row.omnigent_session_id == "session-1"
     assert row.first_message_item_id == "item-1"
     assert lifecycle["state"] == "failed"
     assert [event.event_type for event in events] == ["lifecycle.terminal"]
-    refs = await store.embedded_reconciliation_host_lease_refs(
+    refs = await restarted_store.embedded_reconciliation_host_lease_refs(
         abandoned_before=datetime.now(UTC)
     )
     assert refs == {"host-lease-1": "runner_exit_cleanup"}
@@ -375,16 +373,29 @@ async def test_embedded_response_before_persist_reconciles_and_digest_change_fai
     await store.mark_prepared("recovery", digest="digest-1", marker="marker-1")
     await store.mark_posting("recovery")
 
+    class ObservedRunner:
+        post_count = 0
+
+        async def post_runner_event(self, **_kwargs):
+            self.post_count += 1
+            return {"pending_id": "pending-1", "item_id": "item-1"}
+
+    runner = ObservedRunner()
+    facade = OmnigentEmbeddedHostProtocolFacade(
+        run_store=store, config=_config(), host_channels=runner
+    )
+    response = await facade.post_event(
+        session_id="session-1",
+        event=EmbeddedHostSessionEventRequest(type="message", data={"text": "hello"}),
+    )
+
     # The runner accepted marker-1, then MoonMind restarted before mark_posted.
-    posted_markers = {"marker-1"}
     restarted = OmnigentBridgeSessionStore(session_factory)
     row = await restarted.get_existing("recovery")
     assert row.first_message_state == "posting"
-    assert row.first_message_marker in posted_markers
-    await restarted.mark_posted(
-        "recovery", response={"pending_id": "pending-1", "item_id": "item-1"}
-    )
-    assert posted_markers == {"marker-1"}
+    assert row.first_message_marker == "marker-1"
+    await restarted.mark_posted("recovery", response=response)
+    assert runner.post_count == 1
 
     with pytest.raises(OmnigentDigestMismatchError, match="different first-message"):
         await restarted.mark_prepared(

--- a/tests/integration/omnigent/test_embedded_recovery.py
+++ b/tests/integration/omnigent/test_embedded_recovery.py
@@ -284,11 +284,12 @@ async def test_restart_janitor_rejects_changed_credential_generation(
 async def test_seven_boundary_restart_matrix_preserves_single_side_effects(
     store, session_factory, crash_boundary,
 ) -> None:
-    """Replay every issue-listed boundary through production protocol owners."""
+    """Crash once at every issue-listed production ownership boundary."""
 
     await _seed(store, session_factory)
     class ObservedHost:
         launch_command_count = 0
+        post_count = 0
         created_runner_ids: list[str] = []
         runner_ready = False
 
@@ -299,6 +300,7 @@ async def test_seven_boundary_restart_matrix_preserves_single_side_effects(
             ).runner_id_for_binding_token(kwargs["binding_token"])
             if runner_id not in self.created_runner_ids:
                 self.created_runner_ids.append(runner_id)
+            self.runner_ready = True
             return runner_id
 
         def is_runner_ready(self, _runner_id):
@@ -308,26 +310,89 @@ async def test_seven_boundary_restart_matrix_preserves_single_side_effects(
             return self.runner_ready
 
         async def post_runner_event(self, **_kwargs):
+            self.post_count += 1
             return {"pending_id": "pending-1", "item_id": "item-1"}
 
+        async def request_runner(self, **_kwargs):
+            return {
+                "events": [{"text": "marker-1"}],
+                "firstMessageResponse": {
+                    "pending_id": "pending-1", "item_id": "item-1",
+                },
+            }
+
+    class OneShotCrashStore:
+        """Inject a process death immediately before/after one durable write."""
+
+        def __init__(self, inner, method, *, after=False, state=None):
+            self.inner = inner
+            self.method = method
+            self.after = after
+            self.state = state
+            self.injected = False
+
+        def __getattr__(self, name):
+            target = getattr(self.inner, name)
+            if name != self.method:
+                return target
+
+            async def call(*args, **kwargs):
+                matches = self.state is None or kwargs.get("state") == self.state
+                if matches and not self.injected and not self.after:
+                    self.injected = True
+                    raise RuntimeError(f"injected crash: {crash_boundary}")
+                result = await target(*args, **kwargs)
+                if matches and not self.injected:
+                    self.injected = True
+                    raise RuntimeError(f"injected crash: {crash_boundary}")
+                return result
+            return call
+
     host = ObservedHost()
+    fault_specs = {
+        "reservation_before_command": ("begin_embedded_runner_launch", True, None),
+        "command_before_acknowledgement": (
+            "mark_embedded_runner_state", False, "launch_acknowledged",
+        ),
+        "acknowledgement_before_binding": ("bind_embedded_runner", False, None),
+        "binding_before_tunnel": ("bind_embedded_runner", True, None),
+        "tunnel_before_readiness_persist": (
+            "mark_embedded_runner_state", True, "runner_tunnel_ready",
+        ),
+        "message_response_before_posted_persist": ("mark_posted", False, None),
+        "runner_exit_before_terminal_bridge_persist": (
+            "record_embedded_runner_exit", False, None,
+        ),
+    }
+    method, after, state = fault_specs[crash_boundary]
+    crashing_store = OneShotCrashStore(store, method, after=after, state=state)
     facade = OmnigentEmbeddedHostProtocolFacade(
-        run_store=store, config=_config(), host_channels=host,
+        run_store=crashing_store, config=_config(), host_channels=host,
         runner_binding_root_secret="recovery-root-secret",
     )
-    dispatch = await facade.dispatch_runner(idempotency_key="recovery")
-    runner_id = dispatch["runnerId"]
 
-    # Restart the actual facade/store boundary. A retry observes the durable
-    # assignment and a fresh authenticated tunnel instead of launching again.
+    if crash_boundary in {
+        "reservation_before_command", "command_before_acknowledgement",
+        "acknowledgement_before_binding", "binding_before_tunnel",
+    }:
+        with pytest.raises(RuntimeError, match="injected crash"):
+            await facade.dispatch_runner(idempotency_key="recovery")
+    else:
+        dispatch = await facade.dispatch_runner(idempotency_key="recovery")
+        runner_id = dispatch["runnerId"]
+        if crash_boundary == "tunnel_before_readiness_persist":
+            with pytest.raises(RuntimeError, match="injected crash"):
+                await facade.record_runner_tunnel_ready(runner_id=runner_id)
+
+    # Reconstruct both production owners, then retry the interrupted operation.
     restarted_store = OmnigentBridgeSessionStore(session_factory)
     restarted = OmnigentEmbeddedHostProtocolFacade(
         run_store=restarted_store, config=_config(), host_channels=host,
         runner_binding_root_secret="recovery-root-secret",
     )
-    host.runner_ready = True
     reused = await restarted.dispatch_runner(idempotency_key="recovery")
-    assert reused == {"runnerId": runner_id, "reused": True}
+    runner_id = reused["runnerId"]
+    assert reused["reused"] is (crash_boundary != "reservation_before_command")
     await restarted.record_runner_tunnel_ready(runner_id=runner_id)
 
     await store.mark_prepared("recovery", digest="digest-1", marker="marker-1")
@@ -336,17 +401,24 @@ async def test_seven_boundary_restart_matrix_preserves_single_side_effects(
         session_id="session-1",
         event=EmbeddedHostSessionEventRequest(type="message", data={"text": "hello"}),
     )
-    await restarted_store.mark_posted("recovery", response=response)
+    if crash_boundary == "message_response_before_posted_persist":
+        with pytest.raises(RuntimeError, match="injected crash"):
+            await crashing_store.mark_posted("recovery", response=response)
+        await restarted.reconcile_first_message(session_id="session-1")
+    else:
+        await restarted_store.mark_posted("recovery", response=response)
 
     if crash_boundary == "runner_exit_before_terminal_bridge_persist":
+        with pytest.raises(RuntimeError, match="injected crash"):
+            await facade.record_runner_exit(runner_id=runner_id, error="exit 1")
         restarted_store = OmnigentBridgeSessionStore(session_factory)
-    await restarted_store.record_embedded_runner_exit(runner_id=runner_id, error="exit 1")
     await restarted_store.record_embedded_runner_exit(runner_id=runner_id, error="exit 1")
 
     row = await restarted_store.get_existing("recovery")
     lifecycle = row.metadata_["embedded_runner_lifecycle"]
     events = await restarted_store.list_events(row.bridge_session_id)
     assert host.launch_command_count == 1
+    assert host.post_count == 1
     assert host.created_runner_ids == [runner_id]
     assert row.omnigent_host_id == "host-1"
     assert row.omnigent_runner_id == runner_id
@@ -380,27 +452,40 @@ async def test_embedded_response_before_persist_reconciles_and_digest_change_fai
             self.post_count += 1
             return {"pending_id": "pending-1", "item_id": "item-1"}
 
+        async def request_runner(self, **_kwargs):
+            return {
+                "events": [{"text": "marker-1"}],
+                "firstMessageResponse": {
+                    "pending_id": "pending-1", "item_id": "item-1",
+                },
+            }
+
     runner = ObservedRunner()
     facade = OmnigentEmbeddedHostProtocolFacade(
         run_store=store, config=_config(), host_channels=runner
     )
-    response = await facade.post_event(
+    await facade.post_event(
         session_id="session-1",
         event=EmbeddedHostSessionEventRequest(type="message", data={"text": "hello"}),
     )
 
     # The runner accepted marker-1, then MoonMind restarted before mark_posted.
-    restarted = OmnigentBridgeSessionStore(session_factory)
-    row = await restarted.get_existing("recovery")
+    restarted_store = OmnigentBridgeSessionStore(session_factory)
+    row = await restarted_store.get_existing("recovery")
     assert row.first_message_state == "posting"
     assert row.first_message_marker == "marker-1"
-    await restarted.mark_posted("recovery", response=response)
+    restarted = OmnigentEmbeddedHostProtocolFacade(
+        run_store=restarted_store, config=_config(), host_channels=runner
+    )
+    assert await restarted.reconcile_first_message(session_id="session-1") == {
+        "reconciled": True, "pending_id": "pending-1", "item_id": "item-1",
+    }
     assert runner.post_count == 1
 
     with pytest.raises(OmnigentDigestMismatchError, match="different first-message"):
-        await restarted.mark_prepared(
+        await restarted_store.mark_prepared(
             "recovery", digest="digest-changed", marker="marker-changed"
         )
-    final = await restarted.get_existing("recovery")
+    final = await restarted_store.get_existing("recovery")
     assert final.first_message_digest == "digest-1"
     assert final.first_message_item_id == "item-1"

--- a/tests/integration/omnigent/test_embedded_recovery.py
+++ b/tests/integration/omnigent/test_embedded_recovery.py
@@ -408,6 +408,18 @@ async def test_seven_boundary_restart_matrix_preserves_single_side_effects(
     else:
         await restarted_store.mark_posted("recovery", response=response)
 
+    # Retrying execute after either posting boundary must only revalidate the
+    # digest; it must not regress the durable embedded lifecycle.
+    await restarted_store.mark_prepared(
+        "recovery", digest="digest-1", marker="marker-1"
+    )
+    assert (
+        (await restarted_store.get_existing("recovery")).metadata_[
+            "embedded_runner_lifecycle"
+        ]["state"]
+        == "first_message_posted"
+    )
+
     if crash_boundary == "runner_exit_before_terminal_bridge_persist":
         with pytest.raises(RuntimeError, match="injected crash"):
             await facade.record_runner_exit(runner_id=runner_id, error="exit 1")
@@ -426,10 +438,8 @@ async def test_seven_boundary_restart_matrix_preserves_single_side_effects(
     assert row.first_message_item_id == "item-1"
     assert lifecycle["state"] == "failed"
     assert [event.event_type for event in events] == ["lifecycle.terminal"]
-    refs = await restarted_store.embedded_reconciliation_host_lease_refs(
-        abandoned_before=datetime.now(UTC)
-    )
-    assert refs == {"host-lease-1": "runner_exit_cleanup"}
+    refs = await restarted_store.cleanup_required_host_lease_refs()
+    assert refs == {"host-lease-1"}
 
 
 async def test_embedded_response_before_persist_reconciles_and_digest_change_fails_closed(

--- a/tests/integration/omnigent/test_embedded_recovery.py
+++ b/tests/integration/omnigent/test_embedded_recovery.py
@@ -410,6 +410,11 @@ async def test_seven_boundary_restart_matrix_preserves_single_side_effects(
 
     # Retrying execute after either posting boundary must only revalidate the
     # digest; it must not regress the durable embedded lifecycle.
+    lifecycle_before_retry = (
+        (await restarted_store.get_existing("recovery")).metadata_[
+            "embedded_runner_lifecycle"
+        ]["state"]
+    )
     await restarted_store.mark_prepared(
         "recovery", digest="digest-1", marker="marker-1"
     )
@@ -417,7 +422,7 @@ async def test_seven_boundary_restart_matrix_preserves_single_side_effects(
         (await restarted_store.get_existing("recovery")).metadata_[
             "embedded_runner_lifecycle"
         ]["state"]
-        == "first_message_posted"
+        == lifecycle_before_retry
     )
 
     if crash_boundary == "runner_exit_before_terminal_bridge_persist":

--- a/tests/integration/omnigent/test_embedded_recovery.py
+++ b/tests/integration/omnigent/test_embedded_recovery.py
@@ -17,6 +17,7 @@ from api_service.db.models import (
     OmnigentOAuthHostLeaseRecord,
     ProviderCredentialSource,
     RuntimeMaterializationMode,
+    OmnigentBridgeSession,
 )
 from moonmind.omnigent.bridge_config import HOST_PROTOCOL_MODE_EMBEDDED, parse_bridge_config
 from moonmind.omnigent.bridge_embedded import (
@@ -215,3 +216,49 @@ async def test_runner_crash_disconnected_cleanup_survives_restart_and_drives_jan
     assert [event.event_type for event in events] == ["lifecycle.terminal"]
     assert result["actions"][-1]["action"] == "runner_exit_cleanup"
     assert repository.stopped == ["host-lease-1"]
+
+
+@pytest.mark.parametrize(
+    ("state", "expected_action"),
+    [
+        ("launch_reserved", "abandoned_launch_cleanup"),
+        ("launch_acknowledged", "acknowledgement_without_binding_cleanup"),
+        ("runner_identity_bound", "binding_without_tunnel_cleanup"),
+        ("runner_tunnel_waiting", "binding_without_tunnel_cleanup"),
+        ("stale", "stale_binding_cleanup"),
+    ],
+)
+async def test_restart_janitor_classifies_each_abandoned_lifecycle_boundary(
+    store, session_factory, state, expected_action,
+) -> None:
+    await _seed(store, session_factory)
+    row = await store.get_existing("recovery")
+    old = (datetime.now(UTC) - timedelta(minutes=5)).isoformat()
+    async with session_factory() as session:
+        persisted = await session.get(OmnigentBridgeSession, row.bridge_session_id)
+        metadata = dict(persisted.metadata_ or {})
+        metadata["embedded_runner_lifecycle"] = {
+            "version": 1, "state": state, "updatedAt": old, "timeline": [],
+        }
+        persisted.metadata_ = metadata
+        await session.commit()
+
+    refs = await store.embedded_reconciliation_host_lease_refs(
+        abandoned_before=datetime.now(UTC) - timedelta(seconds=90)
+    )
+    assert refs == {"host-lease-1": expected_action}
+
+
+async def test_restart_janitor_rejects_changed_credential_generation(
+    store, session_factory,
+) -> None:
+    await _seed(store, session_factory)
+    async with session_factory() as session:
+        profile = await session.get(ManagedAgentProviderProfile, "profile-1")
+        profile.credential_generation = 2
+        await session.commit()
+
+    refs = await store.embedded_reconciliation_host_lease_refs(
+        abandoned_before=datetime.now(UTC)
+    )
+    assert refs == {"host-lease-1": "credential_generation_cleanup"}

--- a/tests/unit/omnigent/test_bridge_embedded.py
+++ b/tests/unit/omnigent/test_bridge_embedded.py
@@ -699,16 +699,19 @@ async def test_dispatch_persists_launch_intent_before_host_side_effect(store) ->
             row = await store.get_existing("idem-embedded")
             assert row.metadata_["embedded_runner_launch"]["state"] == "pending"
             assert kwargs["host_id"] == "host-1"
-            return "runner-1"
+            return OmnigentHostAuthAdapter(
+                allowed_tokens=frozenset({kwargs["binding_token"]})
+            ).runner_id_for_binding_token(kwargs["binding_token"])
 
     facade = OmnigentEmbeddedHostProtocolFacade(
-        run_store=store, config=_embedded_config(), host_channels=Channels()
+        run_store=store, config=_embedded_config(), host_channels=Channels(),
+        runner_binding_root_secret="root-secret",
     )
     result = await facade.dispatch_runner(idempotency_key="idem-embedded")
     row = await store.get_existing("idem-embedded")
 
-    assert result == {"runnerId": "runner-1", "reused": False}
-    assert row.omnigent_runner_id == "runner-1"
+    assert result["reused"] is False
+    assert row.omnigent_runner_id == result["runnerId"]
     assert row.metadata_["embedded_runner_launch"]["state"] == "launched"
     lifecycle = row.metadata_["embedded_runner_lifecycle"]
     assert lifecycle["version"] == 1
@@ -912,24 +915,25 @@ async def test_runner_tunnel_reconnect_aborts_ambiguous_post_and_newest_wins() -
     assert registry._runners["runner-1"] is new
 
 
-def test_terminal_runner_binding_cannot_be_replayed() -> None:
+def test_runner_binding_auth_is_reconstructable_after_registry_restart() -> None:
     registry = EmbeddedHostChannelRegistry()
     token = "runner-binding-token"
     runner_id = OmnigentHostAuthAdapter(
         allowed_tokens=frozenset({token})
     ).runner_id_for_binding_token(token)
-    registry._runner_tokens[runner_id] = token
     headers = Headers({"X-Omnigent-Runner-Tunnel-Token": token})
 
-    assert registry.authenticate_runner(runner_id=runner_id, headers=headers) == runner_id
-    registry.revoke_runner_binding(runner_id)
-
-    with pytest.raises(EmbeddedHostChannelError, match="binding is unavailable"):
-        registry.authenticate_runner(runner_id=runner_id, headers=headers)
+    assert registry.authenticate_runner(
+        runner_id=runner_id, headers=headers, binding_token=token
+    ) == runner_id
+    restarted = EmbeddedHostChannelRegistry()
+    assert restarted.authenticate_runner(
+        runner_id=runner_id, headers=headers, binding_token=token
+    ) == runner_id
 
 
 @pytest.mark.asyncio
-async def test_dispatch_does_not_repeat_ambiguous_pending_launch(store) -> None:
+async def test_dispatch_replays_pending_launch_with_same_generation_identity(store) -> None:
     await store.bind_profile_authorization(
         request=_request(),
         endpoint_ref="embedded",
@@ -948,15 +952,52 @@ async def test_dispatch_does_not_repeat_ambiguous_pending_launch(store) -> None:
         target_metadata={"workspace": "/workspace/repo"},
     )
     await store.attach_session("idem-embedded", "sess-embedded")
-    await store.begin_embedded_runner_launch("idem-embedded", host_id="host-1")
+    from moonmind.omnigent.embedded_host_channel import derive_runner_binding_token
+    token = derive_runner_binding_token(
+        "root-secret", host_id="host-1", session_id="sess-embedded", generation=1000001
+    )
+    runner_id = OmnigentHostAuthAdapter(
+        allowed_tokens=frozenset({token})
+    ).runner_id_for_binding_token(token)
+    await store.begin_embedded_runner_launch(
+        "idem-embedded", host_id="host-1", runner_id=runner_id,
+        generation=1000001, credential_generation=1, launch_generation=1,
+    )
+
+    class Channels:
+        async def launch_runner(self, **kwargs):
+            assert kwargs["binding_token"] == token
+            return runner_id
 
     facade = OmnigentEmbeddedHostProtocolFacade(
-        run_store=store, config=_embedded_config()
+        run_store=store, config=_embedded_config(), host_channels=Channels(),
+        runner_binding_root_secret="root-secret",
     )
-    with pytest.raises(OmnigentBridgeError, match="durable reconciliation") as excinfo:
-        await facade.dispatch_runner(idempotency_key="idem-embedded")
+    result = await facade.dispatch_runner(idempotency_key="idem-embedded")
+    assert result == {"runnerId": runner_id, "reused": False}
 
-    assert excinfo.value.status_code == 503
+
+@pytest.mark.asyncio
+async def test_reserved_launch_rejects_stale_generation_and_cross_session_identity(store) -> None:
+    await store.bind_profile_authorization(
+        request=_request(), endpoint_ref="embedded",
+        provider_profile_id="profile-1", provider_lease_id="provider-lease-1",
+        credential_generation=2, host_binding_ref="binding-1",
+        host_lease_ref="host-lease-1", omnigent_host_id="host-1",
+    )
+    await store.attach_session("idem-embedded", "sess-embedded")
+    await store.begin_embedded_runner_launch(
+        "idem-embedded", host_id="host-1", runner_id="runner-current", generation=2
+    )
+
+    with pytest.raises(OmnigentIdempotencyError, match="generation"):
+        await store.begin_embedded_runner_launch(
+            "idem-embedded", host_id="host-1", runner_id="runner-stale", generation=1
+        )
+    with pytest.raises(OmnigentIdempotencyError, match="reserved launch generation"):
+        await store.bind_embedded_runner(
+            "idem-embedded", host_id="host-1", runner_id="runner-other-session"
+        )
 
 
 @pytest.mark.asyncio
@@ -978,7 +1019,8 @@ async def test_dispatch_marks_rejected_launch_failed_for_retry(store) -> None:
             raise EmbeddedHostChannelError("host rejected runner launch")
 
     facade = OmnigentEmbeddedHostProtocolFacade(
-        run_store=store, config=_embedded_config(), host_channels=Channels()
+        run_store=store, config=_embedded_config(), host_channels=Channels(),
+        runner_binding_root_secret="root-secret",
     )
     with pytest.raises(OmnigentBridgeError, match="rejected"):
         await facade.dispatch_runner(idempotency_key="idem-embedded")

--- a/tests/unit/omnigent/test_bridge_embedded.py
+++ b/tests/unit/omnigent/test_bridge_embedded.py
@@ -791,6 +791,7 @@ async def test_stop_runner_uses_durable_exact_host_binding(store) -> None:
 
     assert result == {"ok": True, "status": "stopped", "runnerId": "runner-1"}
     assert row.status == "canceled"
+    assert row.metadata_["embedded_runner_lifecycle"]["state"] == "stopped"
     assert "embedded_runner_exit" not in row.metadata_
 
 

--- a/tests/unit/omnigent/test_bridge_embedded.py
+++ b/tests/unit/omnigent/test_bridge_embedded.py
@@ -49,6 +49,7 @@ from moonmind.omnigent.bridge_proxy import (
 from moonmind.omnigent.bridge_store import (
     FIRST_MESSAGE_POSTED,
     OmnigentBridgeSessionStore,
+    OmnigentIdempotencyError,
 )
 from moonmind.omnigent.embedded_host_channel import (
     EmbeddedHostChannelError,
@@ -716,6 +717,7 @@ async def test_dispatch_persists_launch_intent_before_host_side_effect(store) ->
         "launch_reserved",
         "launch_sent",
         "launch_acknowledged",
+        "runner_identity_bound",
         "runner_tunnel_waiting",
     ]
     assert lifecycle["providerLeaseId"] == "provider-lease-1"
@@ -853,6 +855,30 @@ async def test_first_message_uses_durable_runner_and_canonical_posting_state(sto
     }]
     assert row.first_message_state == FIRST_MESSAGE_POSTED
     assert row.first_message_item_id == "item-1"
+    assert row.metadata_["embedded_runner_lifecycle"]["state"] == "running"
+
+
+@pytest.mark.asyncio
+async def test_embedded_lifecycle_rejects_invalid_jump_and_accepts_duplicate(store) -> None:
+    await store.bind_profile_authorization(
+        request=_request(), endpoint_ref="embedded",
+        provider_profile_id="profile-1", provider_lease_id="provider-lease-1",
+        credential_generation=1, host_binding_ref="binding-1",
+        host_lease_ref="host-lease-1", omnigent_host_id="host-1",
+    )
+    await store.begin_embedded_runner_launch("idem-embedded", host_id="host-1")
+    await store.mark_embedded_runner_state(
+        "idem-embedded", state="launch_reserved", code="launch_reserved"
+    )
+
+    with pytest.raises(OmnigentIdempotencyError, match="invalid embedded runner lifecycle transition"):
+        await store.mark_embedded_runner_state(
+            "idem-embedded", state="running", code="impossible_jump"
+        )
+
+    row = await store.get_existing("idem-embedded")
+    timeline = row.metadata_["embedded_runner_lifecycle"]["timeline"]
+    assert [entry["state"] for entry in timeline] == ["launch_reserved"]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/omnigent/test_bridge_embedded.py
+++ b/tests/unit/omnigent/test_bridge_embedded.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 from datetime import UTC, datetime, timedelta
 
 import pytest
@@ -708,6 +709,52 @@ async def test_dispatch_persists_launch_intent_before_host_side_effect(store) ->
     assert result == {"runnerId": "runner-1", "reused": False}
     assert row.omnigent_runner_id == "runner-1"
     assert row.metadata_["embedded_runner_launch"]["state"] == "launched"
+    lifecycle = row.metadata_["embedded_runner_lifecycle"]
+    assert lifecycle["version"] == 1
+    assert lifecycle["state"] == "runner_tunnel_waiting"
+    assert [item["state"] for item in lifecycle["timeline"]] == [
+        "launch_reserved",
+        "launch_sent",
+        "launch_acknowledged",
+        "runner_tunnel_waiting",
+    ]
+    assert lifecycle["providerLeaseId"] == "provider-lease-1"
+    assert "binding_token" not in json.dumps(lifecycle).lower()
+
+
+@pytest.mark.asyncio
+async def test_dispatch_rejects_stale_durable_runner_instead_of_claiming_reuse(
+    store,
+) -> None:
+    await store.bind_profile_authorization(
+        request=_request(),
+        endpoint_ref="embedded",
+        provider_profile_id="profile-1",
+        provider_lease_id="provider-lease-1",
+        credential_generation=1,
+        host_binding_ref="binding-1",
+        host_lease_ref="host-lease-1",
+        omnigent_host_id="host-1",
+    )
+    await store.attach_session("idem-embedded", "sess-embedded")
+    await store.bind_embedded_runner(
+        "idem-embedded", host_id="host-1", runner_id="runner-1"
+    )
+
+    class Channels:
+        def is_runner_ready(self, runner_id):
+            assert runner_id == "runner-1"
+            return False
+
+    facade = OmnigentEmbeddedHostProtocolFacade(
+        run_store=store, config=_embedded_config(), host_channels=Channels()
+    )
+    with pytest.raises(OmnigentBridgeError) as excinfo:
+        await facade.dispatch_runner(idempotency_key="idem-embedded")
+
+    assert excinfo.value.code == "embedded_runner_stale"
+    row = await store.get_existing("idem-embedded")
+    assert row.metadata_["embedded_runner_lifecycle"]["state"] == "stale"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/omnigent/test_embedded_host_channel.py
+++ b/tests/unit/omnigent/test_embedded_host_channel.py
@@ -145,6 +145,7 @@ async def test_launch_runner_uses_exact_host_and_rejects_identity_substitution()
         await registry.launch_runner(
             host_id="host-1", workspace="/work/repo",
             session_id="session-1", harness="codex-native",
+            binding_token="binding-token",
         )
     assert sent[0]["workspace"] == "/work/repo"
     assert sent[0]["session_id"] == "session-1"

--- a/tests/unit/omnigent/test_oauth_host_janitor.py
+++ b/tests/unit/omnigent/test_oauth_host_janitor.py
@@ -10,6 +10,7 @@ class _Repository:
     def __init__(self, lease):
         self.lease = lease
         self.stopped: list[str] = []
+        self.order: list[str] = []
 
     async def list_active_host_leases(self):
         return [self.lease]
@@ -18,17 +19,20 @@ class _Repository:
         return SimpleNamespace()
 
     async def mark_host_lease_stopped(self, lease_id):
+        self.order.append("lease_released")
         self.stopped.append(lease_id)
 
 
 class _Runtime:
-    def __init__(self):
+    def __init__(self, order=None):
         self.stopped = 0
+        self.order = order if order is not None else []
 
     async def container_exists(self, _name):
         return True
 
     async def stop_host(self, **_kwargs):
+        self.order.append("host_stopped")
         self.stopped += 1
 
     async def list_managed_containers(self):
@@ -113,3 +117,36 @@ async def test_janitor_leaves_fresh_host_owned_by_active_session() -> None:
     assert result["count"] == 0
     assert repository.stopped == []
     assert runtime.stopped == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("action", [
+    "abandoned_launch_cleanup",
+    "acknowledgement_without_binding_cleanup",
+    "binding_without_tunnel_cleanup",
+    "stale_binding_cleanup",
+    "credential_generation_cleanup",
+])
+async def test_janitor_reconciles_each_durable_embedded_abandonment_class(
+    action: str,
+) -> None:
+    repository = _Repository(_lease())
+    runtime = _Runtime(repository.order)
+
+    async def cleanup_refs():
+        return set()
+
+    async def reconciliation_refs(*, abandoned_before):
+        assert abandoned_before < datetime.now(UTC)
+        return {"lease-1": action}
+
+    run_store = SimpleNamespace(
+        cleanup_required_host_lease_refs=cleanup_refs,
+        embedded_reconciliation_host_lease_refs=reconciliation_refs,
+    )
+    result = await OmnigentOAuthHostJanitor(
+        repository=repository, runtime=runtime, client=_Client(), run_store=run_store,
+    ).run()
+
+    assert result["actions"][-1]["action"] == action
+    assert repository.order == ["host_stopped", "lease_released"]


### PR DESCRIPTION
Implement GitHub issue MoonLadderStudios/MoonMind#3422.

## MoonSpec verification incomplete

This pull request was opened as a **draft** because MoonSpec verification did not approve publication (verdict ADDITIONAL_WORK_NEEDED) and the bounded remediation budget was exhausted with remaining implementation work.

- Gate outcome: MoonSpec verification did not approve publication. verdict ADDITIONAL_WORK_NEEDED. Attempt 6 adds production launch-sent/launch-acknowledged reconciliation and production first-message response-before-persist reconciliation. The seven-case fixture now injects distinct one-shot failures and proves one launch, one runner identity, one first-message POST, terminal idempotency, and cleanup eligibility. However, it does not assert the boundary-specific durable transition or reconciliation codes required by the prior authoritative verifier: after every case it inspects only the final failed state, one terminal event, and the cleanup reason. The whole target therefore retains a concrete verification gap. verification report art_01KY104VK3816FX5ZXA9Q43B9G.
- Verification report: art_01KY104VK3816FX5ZXA9Q43B9G
- Verification gate result: art_01KY104VHP554V4HPTJYGC0D13

Review the verification evidence before marking this pull request ready for review.