### PR TITLE
MoonLadderStudios/MoonMind#3425: add final embedded acceptance gate

### DIFF
--- a/.github/workflows/omnigent-embedded-acceptance.yml
+++ b/.github/workflows/omnigent-embedded-acceptance.yml
@@ -1,0 +1,73 @@
+name: Provider / Omnigent Embedded Acceptance
+
+on:
+  workflow_dispatch:
+    inputs:
+      evidence_artifact:
+        description: "Artifact containing embedded-acceptance-input.json from the complete matrix"
+        required: true
+        type: string
+      evidence_run_id:
+        description: "Workflow run that produced the matrix artifact"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: omnigent-embedded-acceptance
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Validate and publish the final embedded gate
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+      issues: write
+    steps:
+      - name: Checkout exact candidate commit
+        uses: actions/checkout@v7
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: Download complete matrix evidence
+        uses: actions/download-artifact@v8
+        with:
+          name: ${{ inputs.evidence_artifact }}
+          run-id: ${{ inputs.evidence_run_id }}
+          github-token: ${{ github.token }}
+          path: artifacts/omnigent-embedded-acceptance/input
+      - name: Build protected acceptance report
+        run: |
+          python tools/build_omnigent_embedded_acceptance.py \
+            artifacts/omnigent-embedded-acceptance/input/embedded-acceptance-input.json \
+            artifacts/omnigent-embedded-acceptance/report.json
+      - name: Upload passing report
+        uses: actions/upload-artifact@v7
+        with:
+          name: omnigent-embedded-acceptance-${{ github.run_id }}-${{ github.run_attempt }}
+          path: artifacts/omnigent-embedded-acceptance/report.json
+          if-no-files-found: error
+          retention-days: 90
+      - name: Link passing report from issue 3425
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          report_artifact="omnigent-embedded-acceptance-${{ github.run_id }}-${{ github.run_attempt }}"
+          run_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          comment_file="${RUNNER_TEMP}/omnigent-embedded-acceptance.md"
+          {
+            echo "Embedded Omnigent acceptance gate: PASS"
+            echo
+            echo "- Run: ${run_url} (attempt ${{ github.run_attempt }})"
+            echo "- Commit: \`${{ github.sha }}\`"
+            echo "- Durable report: \`${report_artifact}\`"
+            echo "- Source matrix: \`${{ inputs.evidence_artifact }}\` from run \`${{ inputs.evidence_run_id }}\`"
+          } > "$comment_file"
+          gh issue comment 3425 --repo "${{ github.repository }}" --body-file "$comment_file"
+

--- a/.github/workflows/omnigent-embedded-acceptance.yml
+++ b/.github/workflows/omnigent-embedded-acceptance.yml
@@ -46,7 +46,9 @@ jobs:
         run: |
           python tools/build_omnigent_embedded_acceptance.py \
             artifacts/omnigent-embedded-acceptance/input/embedded-acceptance-input.json \
-            artifacts/omnigent-embedded-acceptance/report.json
+            artifacts/omnigent-embedded-acceptance/report.json \
+            --evidence-root artifacts/omnigent-embedded-acceptance/input/evidence \
+            --expected-commit "${{ github.sha }}"
       - name: Upload passing report
         uses: actions/upload-artifact@v7
         with:
@@ -70,4 +72,3 @@ jobs:
             echo "- Source matrix: \`${{ inputs.evidence_artifact }}\` from run \`${{ inputs.evidence_run_id }}\`"
           } > "$comment_file"
           gh issue comment 3425 --repo "${{ github.repository }}" --body-file "$comment_file"
-

--- a/api_service/api/routers/omnigent_bridge.py
+++ b/api_service/api/routers/omnigent_bridge.py
@@ -56,6 +56,10 @@ from moonmind.omnigent.bridge_store import (
     BridgeProjectionAmbiguousError,
     OmnigentBridgeSessionStore,
 )
+from moonmind.omnigent.embedded_evidence import (
+    EmbeddedEvidenceError,
+    validate_embedded_evidence,
+)
 from moonmind.omnigent.embedded_host_channel import (
     EmbeddedHostChannelError,
     embedded_host_channels,
@@ -69,6 +73,11 @@ from moonmind.omnigent.settings import (
     resolved_host_runner_token,
     resolved_proxy_forward_headers,
     resolved_server_url,
+)
+from moonmind.utils.build_info import resolve_moonmind_build_id
+from moonmind.workflows.temporal.artifacts import (
+    TemporalArtifactRepository,
+    TemporalArtifactService,
 )
 from moonmind.workflows.adapters.omnigent_client import OmnigentHttpClient
 
@@ -199,7 +208,77 @@ async def get_omnigent_bridge_readiness(
 ) -> dict[str, Any]:
     """Expose selected protocol and conformance gates without secret material."""
 
-    return config.readiness()
+    if config.host_protocol_mode != HOST_PROTOCOL_MODE_EMBEDDED:
+        return config.readiness()
+    return config.readiness(
+        evidence_validation=await _resolve_embedded_evidence(config)
+    )
+
+
+_EMBEDDED_EVIDENCE_SLOTS = {
+    "proxyConformance": ("proxy_conformance", "proxy_conformance_evidence_ref"),
+    "liveSmoke": ("live_smoke", "live_smoke_evidence_ref"),
+    "hostAuthConformance": (
+        "host_auth_conformance",
+        "host_auth_conformance_evidence_ref",
+    ),
+}
+
+
+def _artifact_id_from_evidence_ref(value: str | None) -> str:
+    candidate = str(value or "").strip()
+    if candidate.startswith("artifact://"):
+        candidate = candidate[len("artifact://") :]
+    if not candidate or "/" in candidate or "?" in candidate or "#" in candidate:
+        raise EmbeddedEvidenceError("evidence ref must identify one MoonMind artifact")
+    return candidate
+
+
+async def _resolve_embedded_evidence(
+    config: OmnigentBridgeConfig,
+) -> dict[str, dict[str, Any]]:
+    """Resolve claims with the artifact service's trusted service principal."""
+
+    results: dict[str, dict[str, Any]] = {}
+    embedded = config.host_connection.embedded
+    build_identity = resolve_moonmind_build_id()
+    if not build_identity:
+        return {
+            key: {"status": "failed", "reason": "moonmind_build_identity_missing"}
+            for key in _EMBEDDED_EVIDENCE_SLOTS
+        }
+    async with async_session_maker() as session:
+        service = TemporalArtifactService(TemporalArtifactRepository(session))
+        for key, (claim_type, attribute) in _EMBEDDED_EVIDENCE_SLOTS.items():
+            try:
+                artifact_id = _artifact_id_from_evidence_ref(
+                    getattr(embedded, attribute)
+                )
+                _artifact, body = await service.read(
+                    artifact_id=artifact_id,
+                    principal="service:omnigent-embedded-evidence-gate",
+                )
+                claim = validate_embedded_evidence(
+                    body,
+                    expected_claim_type=claim_type,
+                    moonmind_build_identity=build_identity,
+                    bridge_config_sha256=config.evidence_policy_sha256(),
+                )
+                results[key] = {
+                    "status": "passed",
+                    "schemaVersion": claim.schema_version,
+                    "generatedAt": claim.generated_at.isoformat(),
+                    "expiresAt": claim.expires_at.isoformat(),
+                    "producer": claim.producer,
+                }
+            except Exception:  # noqa: BLE001 - every resolver failure gates mode
+                # Read/auth/schema failures intentionally share one bounded,
+                # non-enumerating public result.
+                results[key] = {
+                    "status": "failed",
+                    "reason": "evidence_unavailable_or_invalid",
+                }
+    return results
 
 
 def _require_proxy_mode(
@@ -221,13 +300,24 @@ def _require_proxy_mode(
     return config
 
 
-def _require_embedded_mode(
+async def _require_embedded_mode(
     config: OmnigentBridgeConfig = Depends(_require_bridge_enabled),
 ) -> OmnigentBridgeConfig:
     """Fail fast when an embedded-host route is called outside embedded mode."""
 
     if config.host_protocol_mode == HOST_PROTOCOL_MODE_EMBEDDED:
-        return config
+        validation = await _resolve_embedded_evidence(config)
+        readiness = config.readiness(evidence_validation=validation)
+        if readiness["conformanceState"] == "ready":
+            return config
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail={
+                "code": "omnigent_embedded_evidence_gated",
+                "message": "Embedded mode requires authorized, current passing evidence.",
+                "evidenceValidation": validation,
+            },
+        )
     raise HTTPException(
         status_code=status.HTTP_501_NOT_IMPLEMENTED,
         detail={

--- a/api_service/api/routers/omnigent_bridge.py
+++ b/api_service/api/routers/omnigent_bridge.py
@@ -269,7 +269,6 @@ async def _resolve_embedded_evidence(
                     "schemaVersion": claim.schema_version,
                     "generatedAt": claim.generated_at.isoformat(),
                     "expiresAt": claim.expires_at.isoformat(),
-                    "producer": claim.producer,
                 }
             except Exception:  # noqa: BLE001 - every resolver failure gates mode
                 # Read/auth/schema failures intentionally share one bounded,
@@ -419,11 +418,12 @@ def _get_embedded_host_facade(
     )
 
 
-def _get_create_embedded_facade(
+async def _get_create_embedded_facade(
     _config: OmnigentBridgeConfig = Depends(_require_bridge_enabled),
 ) -> OmnigentEmbeddedHostProtocolFacade | None:
     if _config.host_protocol_mode != HOST_PROTOCOL_MODE_EMBEDDED:
         return None
+    await _require_embedded_mode(_config)
     return OmnigentEmbeddedHostProtocolFacade(
         run_store=OmnigentBridgeSessionStore(async_session_maker),
         config=_config,
@@ -1704,6 +1704,11 @@ async def embedded_omnigent_host_tunnel(websocket: WebSocket, host_id: str) -> N
         if not config.enabled or config.host_protocol_mode != HOST_PROTOCOL_MODE_EMBEDDED:
             await websocket.close(code=4404)
             return
+        try:
+            await _require_embedded_mode(config)
+        except HTTPException:
+            await websocket.close(code=4403)
+            return
         auth = verify_embedded_host_auth(
             headers=websocket.headers,
             config=config,
@@ -1753,6 +1758,11 @@ async def embedded_omnigent_runner_tunnel(
     config = get_bridge_config()
     if not config.enabled or config.host_protocol_mode != HOST_PROTOCOL_MODE_EMBEDDED:
         await websocket.close(code=4404)
+        return
+    try:
+        await _require_embedded_mode(config)
+    except HTTPException:
+        await websocket.close(code=4403)
         return
     try:
         embedded_host_channels.authenticate_runner(

--- a/moonmind/omnigent/bridge_config.py
+++ b/moonmind/omnigent/bridge_config.py
@@ -34,6 +34,8 @@ errors.
 
 from __future__ import annotations
 
+import hashlib
+import json
 import os
 from collections.abc import Mapping
 from pathlib import Path
@@ -601,7 +603,23 @@ class OmnigentBridgeConfig(BaseModel):
             "liveExecution": self.authority.live_execution,
         }
 
-    def readiness(self) -> dict[str, Any]:
+    def evidence_policy_sha256(self) -> str:
+        """Bind evidence to execution-relevant config without self-referential refs."""
+
+        payload = self.model_dump(mode="json", by_alias=True)
+        embedded = payload["hostConnection"]["embedded"]
+        for key in (
+            "proxyConformanceEvidenceRef",
+            "liveSmokeEvidenceRef",
+            "hostAuthConformanceEvidenceRef",
+        ):
+            embedded[key] = None
+        encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+        return hashlib.sha256(encoded).hexdigest()
+
+    def readiness(
+        self, *, evidence_validation: Mapping[str, Mapping[str, Any]] | None = None
+    ) -> dict[str, Any]:
         """Return non-secret, operator-visible mode/conformance readiness."""
 
         embedded = self.host_connection.embedded
@@ -612,7 +630,11 @@ class OmnigentBridgeConfig(BaseModel):
         }
         selected_embedded = self.host_protocol_mode == HOST_PROTOCOL_MODE_EMBEDDED
         proxy_ready = build_omnigent_gate().enabled
-        return {
+        validation = dict(evidence_validation or {})
+        evidence_ready = bool(validation) and all(
+            validation.get(key, {}).get("status") == "passed" for key in evidence
+        )
+        result = {
             "enabled": self.enabled,
             "selectedMode": self.host_protocol_mode,
             "protocolProfile": (
@@ -629,12 +651,17 @@ class OmnigentBridgeConfig(BaseModel):
                 "ready"
                 if self.enabled
                 and (
-                    all(evidence.values()) if selected_embedded else proxy_ready
+                    evidence_ready if selected_embedded else proxy_ready
                 )
                 else "disabled" if not self.enabled else "gated"
             ),
             "evidenceRefs": evidence if selected_embedded else {},
         }
+        if selected_embedded:
+            result["evidenceValidation"] = validation
+            if not evidence_ready:
+                result["gateReason"] = "validated_embedded_evidence_required"
+        return result
 
 
 # ---------------------------------------------------------------------------

--- a/moonmind/omnigent/embedded_acceptance.py
+++ b/moonmind/omnigent/embedded_acceptance.py
@@ -10,6 +10,7 @@ from moonmind.omnigent.conformance import ConformanceContractError, assert_secre
 
 SCHEMA_VERSION = "moonmind.omnigent.embedded-acceptance/v1"
 EVIDENCE_SCHEMA_VERSION = "moonmind.omnigent.embedded-acceptance-evidence/v1"
+CASE_EVIDENCE_SCHEMA_VERSION = "moonmind.omnigent.embedded-acceptance-case-evidence/v1"
 REQUIRED_PREREQUISITES = ("3417", "3420", "3421", "3422", "3423", "3424")
 REQUIRED_SECTIONS = (
     "evidence-validation",
@@ -26,6 +27,56 @@ REQUIRED_SECTIONS = (
 _DIGEST_REF = re.compile(r"^.+@sha256:[0-9a-f]{64}$")
 
 
+def _active_evidence(item: Mapping[str, Any], *, label: str, now: datetime) -> None:
+    try:
+        generated_at = datetime.fromisoformat(str(item["generatedAt"]).replace("Z", "+00:00"))
+        expires_at = datetime.fromisoformat(str(item["expiresAt"]).replace("Z", "+00:00"))
+    except (KeyError, TypeError, ValueError) as exc:
+        raise ConformanceContractError(f"{label} has invalid generation or expiry time") from exc
+    if generated_at.tzinfo is None or expires_at.tzinfo is None:
+        raise ConformanceContractError(f"{label} timestamps must include a timezone")
+    if generated_at > now or expires_at <= generated_at or expires_at <= now:
+        raise ConformanceContractError(f"{label} is not within its validity period")
+    if item.get("revokedAt") is not None:
+        raise ConformanceContractError(f"{label} is revoked")
+    if item.get("supersededBy") is not None:
+        raise ConformanceContractError(f"{label} is superseded")
+
+
+def _passed_case_evidence(
+    evidence: Any,
+    *,
+    label: str,
+    claim: str,
+    case_name: str,
+    identities: Mapping[str, Any],
+    now: datetime,
+) -> None:
+    if not isinstance(evidence, Mapping):
+        raise ConformanceContractError(f"{label} evidence ref is unresolved")
+    if evidence.get("schemaVersion") != CASE_EVIDENCE_SCHEMA_VERSION:
+        raise ConformanceContractError(f"{label} evidence has an unsupported schema")
+    if (
+        evidence.get("claim") != claim
+        or evidence.get("case") != case_name
+        or evidence.get("status") != "passed"
+    ):
+        raise ConformanceContractError(f"{label} evidence does not prove its case")
+    if evidence.get("identities") != identities:
+        raise ConformanceContractError(f"{label} evidence is for different identities")
+    if evidence.get("secretScan") != "passed" or evidence.get("cleanup") != "passed":
+        raise ConformanceContractError(f"{label} evidence failed safety checks")
+    channel_refs = evidence.get("evidenceRefs")
+    if not isinstance(channel_refs, list) or not channel_refs or not all(
+        isinstance(ref, str) and ref.strip() for ref in channel_refs
+    ):
+        raise ConformanceContractError(f"{label} evidence lacks channel refs")
+    if not isinstance(evidence.get("producer"), str) or not evidence["producer"].strip():
+        raise ConformanceContractError(f"{label} evidence lacks provenance")
+    _active_evidence(evidence, label=f"{label} evidence", now=now)
+    assert_secret_free(evidence)
+
+
 def _passed_evidence(
     item: Any,
     *,
@@ -33,6 +84,7 @@ def _passed_evidence(
     claim: str,
     evidence_objects: Mapping[str, Any],
     identities: Mapping[str, Any],
+    now: datetime,
 ) -> dict[str, Any]:
     if not isinstance(item, Mapping) or item.get("status") != "passed":
         raise ConformanceContractError(f"{label} did not pass")
@@ -51,6 +103,7 @@ def _passed_evidence(
             raise ConformanceContractError(f"{label} evidence does not prove its claim")
         if evidence.get("identities") != identities:
             raise ConformanceContractError(f"{label} evidence is for different identities")
+        _active_evidence(evidence, label=f"{label} evidence", now=now)
         cases = evidence.get("cases")
         if not isinstance(cases, Mapping) or not cases or any(
             not isinstance(case, Mapping)
@@ -64,6 +117,16 @@ def _passed_evidence(
             for case in cases.values()
         ):
             raise ConformanceContractError(f"{label} evidence cases are incomplete")
+        for case_name, case in cases.items():
+            for case_ref in case["evidenceRefs"]:
+                _passed_case_evidence(
+                    evidence_objects.get(case_ref),
+                    label=f"{label} case {case_name}",
+                    claim=claim,
+                    case_name=case_name,
+                    identities=identities,
+                    now=now,
+                )
         if evidence.get("secretScan") != "passed" or evidence.get("cleanup") != "passed":
             raise ConformanceContractError(f"{label} evidence failed safety checks")
         if (
@@ -77,13 +140,18 @@ def _passed_evidence(
     return dict(item)
 
 
-def build_embedded_acceptance_report(source: Mapping[str, Any]) -> dict[str, Any]:
+def build_embedded_acceptance_report(
+    source: Mapping[str, Any], *, now: datetime | None = None
+) -> dict[str, Any]:
     """Validate all controlling lanes and return the publishable report.
 
     Live/provider execution may produce the input in separate jobs, but no
     partial, skipped, mutable-image, or unattested result can become the final
     support gate.
     """
+    now = now or datetime.now(timezone.utc)
+    if now.tzinfo is None:
+        raise ConformanceContractError("acceptance validation time must include a timezone")
     identities = source.get("identities")
     if not isinstance(identities, Mapping):
         raise ConformanceContractError("acceptance identities are required")
@@ -122,6 +190,7 @@ def build_embedded_acceptance_report(source: Mapping[str, Any]) -> dict[str, Any
             claim=f"prerequisite:{issue}",
             evidence_objects=evidence_objects,
             identities=identities,
+            now=now,
         )
         for issue in REQUIRED_PREREQUISITES
     }
@@ -136,6 +205,7 @@ def build_embedded_acceptance_report(source: Mapping[str, Any]) -> dict[str, Any
             claim=f"section:{section}",
             evidence_objects=evidence_objects,
             identities=identities,
+            now=now,
         )
         for section in REQUIRED_SECTIONS
     }
@@ -146,6 +216,7 @@ def build_embedded_acceptance_report(source: Mapping[str, Any]) -> dict[str, Any
         claim="cleanup",
         evidence_objects=evidence_objects,
         identities=identities,
+        now=now,
     )
     if (
         cleanup.get("historicalEvidencePreserved") is not True
@@ -157,7 +228,7 @@ def build_embedded_acceptance_report(source: Mapping[str, Any]) -> dict[str, Any
         "schemaVersion": SCHEMA_VERSION,
         "issue": "MoonLadderStudios/MoonMind#3425",
         "status": "passed",
-        "generatedAt": datetime.now(timezone.utc).isoformat(),
+        "generatedAt": now.isoformat(),
         "producer": source.get("producer"),
         "identities": dict(identities),
         "prerequisites": accepted_prerequisites,

--- a/moonmind/omnigent/embedded_acceptance.py
+++ b/moonmind/omnigent/embedded_acceptance.py
@@ -1,0 +1,94 @@
+"""Final embedded-mode acceptance report contract for issue #3425."""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime, timezone
+from typing import Any, Mapping
+
+from moonmind.omnigent.conformance import ConformanceContractError, assert_secret_free
+
+SCHEMA_VERSION = "moonmind.omnigent.embedded-acceptance/v1"
+REQUIRED_PREREQUISITES = ("3417", "3420", "3421", "3422", "3423", "3424")
+REQUIRED_SECTIONS = (
+    "evidence-validation",
+    "mode-transition-rollback",
+    "mixed-mode-history",
+    "stock-host-codex-oauth",
+    "restart-failure-recovery",
+    "proxy-embedded-parity",
+    "security-isolation",
+    "hostile-input-bounds",
+    "secret-scan",
+    "cleanup-post-removal-replay",
+)
+_DIGEST_REF = re.compile(r"^.+@sha256:[0-9a-f]{64}$")
+
+
+def _passed_evidence(item: Any, *, label: str) -> dict[str, Any]:
+    if not isinstance(item, Mapping) or item.get("status") != "passed":
+        raise ConformanceContractError(f"{label} did not pass")
+    refs = item.get("evidenceRefs")
+    if not isinstance(refs, list) or not refs or not all(
+        isinstance(ref, str) and ref.strip() for ref in refs
+    ):
+        raise ConformanceContractError(f"{label} requires durable evidence refs")
+    return dict(item)
+
+
+def build_embedded_acceptance_report(source: Mapping[str, Any]) -> dict[str, Any]:
+    """Validate all controlling lanes and return the publishable report.
+
+    Live/provider execution may produce the input in separate jobs, but no
+    partial, skipped, mutable-image, or unattested result can become the final
+    support gate.
+    """
+    prerequisites = source.get("prerequisites")
+    if not isinstance(prerequisites, Mapping):
+        raise ConformanceContractError("embedded prerequisites are required")
+    accepted_prerequisites = {
+        issue: _passed_evidence(prerequisites.get(issue), label=f"prerequisite #{issue}")
+        for issue in REQUIRED_PREREQUISITES
+    }
+
+    sections = source.get("sections")
+    if not isinstance(sections, Mapping):
+        raise ConformanceContractError("embedded acceptance sections are required")
+    accepted_sections = {
+        section: _passed_evidence(sections.get(section), label=f"section {section}")
+        for section in REQUIRED_SECTIONS
+    }
+
+    identities = source.get("identities")
+    if not isinstance(identities, Mapping):
+        raise ConformanceContractError("acceptance identities are required")
+    required_strings = ("moonmindCommit", "moonmindBuild", "profileVersion", "protocolVersion")
+    if any(not isinstance(identities.get(key), str) or not identities[key].strip() for key in required_strings):
+        raise ConformanceContractError("complete build, profile, and protocol identities are required")
+    images = identities.get("images")
+    if not isinstance(images, Mapping) or any(
+        not isinstance(images.get(role), str) or not _DIGEST_REF.fullmatch(images[role])
+        for role in ("server", "host")
+    ):
+        raise ConformanceContractError("published server and unchanged host images must be digest-pinned")
+
+    cleanup = _passed_evidence(source.get("cleanup"), label="cleanup")
+    if cleanup.get("historicalEvidencePreserved") is not True or cleanup.get("leasesReleased") is not True:
+        raise ConformanceContractError("cleanup must preserve history and release leases")
+
+    report = {
+        "schemaVersion": SCHEMA_VERSION,
+        "issue": "MoonLadderStudios/MoonMind#3425",
+        "status": "passed",
+        "generatedAt": datetime.now(timezone.utc).isoformat(),
+        "producer": source.get("producer"),
+        "identities": dict(identities),
+        "prerequisites": accepted_prerequisites,
+        "sections": accepted_sections,
+        "cleanup": cleanup,
+    }
+    if not isinstance(report["producer"], str) or not report["producer"].strip():
+        raise ConformanceContractError("trusted workflow producer identity is required")
+    assert_secret_free(report)
+    return report
+

--- a/moonmind/omnigent/embedded_acceptance.py
+++ b/moonmind/omnigent/embedded_acceptance.py
@@ -9,6 +9,7 @@ from typing import Any, Mapping
 from moonmind.omnigent.conformance import ConformanceContractError, assert_secret_free
 
 SCHEMA_VERSION = "moonmind.omnigent.embedded-acceptance/v1"
+EVIDENCE_SCHEMA_VERSION = "moonmind.omnigent.embedded-acceptance-evidence/v1"
 REQUIRED_PREREQUISITES = ("3417", "3420", "3421", "3422", "3423", "3424")
 REQUIRED_SECTIONS = (
     "evidence-validation",
@@ -25,7 +26,14 @@ REQUIRED_SECTIONS = (
 _DIGEST_REF = re.compile(r"^.+@sha256:[0-9a-f]{64}$")
 
 
-def _passed_evidence(item: Any, *, label: str) -> dict[str, Any]:
+def _passed_evidence(
+    item: Any,
+    *,
+    label: str,
+    claim: str,
+    evidence_objects: Mapping[str, Any],
+    identities: Mapping[str, Any],
+) -> dict[str, Any]:
     if not isinstance(item, Mapping) or item.get("status") != "passed":
         raise ConformanceContractError(f"{label} did not pass")
     refs = item.get("evidenceRefs")
@@ -33,6 +41,39 @@ def _passed_evidence(item: Any, *, label: str) -> dict[str, Any]:
         isinstance(ref, str) and ref.strip() for ref in refs
     ):
         raise ConformanceContractError(f"{label} requires durable evidence refs")
+    for ref in refs:
+        evidence = evidence_objects.get(ref)
+        if not isinstance(evidence, Mapping):
+            raise ConformanceContractError(f"{label} evidence ref is unresolved: {ref}")
+        if evidence.get("schemaVersion") != EVIDENCE_SCHEMA_VERSION:
+            raise ConformanceContractError(f"{label} evidence has an unsupported schema")
+        if evidence.get("claim") != claim or evidence.get("status") != "passed":
+            raise ConformanceContractError(f"{label} evidence does not prove its claim")
+        if evidence.get("identities") != identities:
+            raise ConformanceContractError(f"{label} evidence is for different identities")
+        cases = evidence.get("cases")
+        if not isinstance(cases, Mapping) or not cases or any(
+            not isinstance(case, Mapping)
+            or case.get("status") != "passed"
+            or not isinstance(case.get("evidenceRefs"), list)
+            or not case["evidenceRefs"]
+            or not all(
+                isinstance(case_ref, str) and case_ref.strip()
+                for case_ref in case["evidenceRefs"]
+            )
+            for case in cases.values()
+        ):
+            raise ConformanceContractError(f"{label} evidence cases are incomplete")
+        if evidence.get("secretScan") != "passed" or evidence.get("cleanup") != "passed":
+            raise ConformanceContractError(f"{label} evidence failed safety checks")
+        if (
+            not isinstance(evidence.get("generatedAt"), str)
+            or not evidence["generatedAt"].strip()
+            or not isinstance(evidence.get("producer"), str)
+            or not evidence["producer"].strip()
+        ):
+            raise ConformanceContractError(f"{label} evidence lacks provenance")
+        assert_secret_free(evidence)
     return dict(item)
 
 
@@ -43,11 +84,45 @@ def build_embedded_acceptance_report(source: Mapping[str, Any]) -> dict[str, Any
     partial, skipped, mutable-image, or unattested result can become the final
     support gate.
     """
+    identities = source.get("identities")
+    if not isinstance(identities, Mapping):
+        raise ConformanceContractError("acceptance identities are required")
+    required_strings = (
+        "moonmindCommit",
+        "moonmindBuild",
+        "profileVersion",
+        "protocolVersion",
+    )
+    if any(
+        not isinstance(identities.get(key), str) or not identities[key].strip()
+        for key in required_strings
+    ):
+        raise ConformanceContractError(
+            "complete build, profile, and protocol identities are required"
+        )
+    images = identities.get("images")
+    if not isinstance(images, Mapping) or any(
+        not isinstance(images.get(role), str) or not _DIGEST_REF.fullmatch(images[role])
+        for role in ("server", "host")
+    ):
+        raise ConformanceContractError(
+            "published server and unchanged host images must be digest-pinned"
+        )
+
+    evidence_objects = source.get("evidenceObjects")
+    if not isinstance(evidence_objects, Mapping):
+        raise ConformanceContractError("resolved acceptance evidence objects are required")
     prerequisites = source.get("prerequisites")
     if not isinstance(prerequisites, Mapping):
         raise ConformanceContractError("embedded prerequisites are required")
     accepted_prerequisites = {
-        issue: _passed_evidence(prerequisites.get(issue), label=f"prerequisite #{issue}")
+        issue: _passed_evidence(
+            prerequisites.get(issue),
+            label=f"prerequisite #{issue}",
+            claim=f"prerequisite:{issue}",
+            evidence_objects=evidence_objects,
+            identities=identities,
+        )
         for issue in REQUIRED_PREREQUISITES
     }
 
@@ -55,25 +130,27 @@ def build_embedded_acceptance_report(source: Mapping[str, Any]) -> dict[str, Any
     if not isinstance(sections, Mapping):
         raise ConformanceContractError("embedded acceptance sections are required")
     accepted_sections = {
-        section: _passed_evidence(sections.get(section), label=f"section {section}")
+        section: _passed_evidence(
+            sections.get(section),
+            label=f"section {section}",
+            claim=f"section:{section}",
+            evidence_objects=evidence_objects,
+            identities=identities,
+        )
         for section in REQUIRED_SECTIONS
     }
 
-    identities = source.get("identities")
-    if not isinstance(identities, Mapping):
-        raise ConformanceContractError("acceptance identities are required")
-    required_strings = ("moonmindCommit", "moonmindBuild", "profileVersion", "protocolVersion")
-    if any(not isinstance(identities.get(key), str) or not identities[key].strip() for key in required_strings):
-        raise ConformanceContractError("complete build, profile, and protocol identities are required")
-    images = identities.get("images")
-    if not isinstance(images, Mapping) or any(
-        not isinstance(images.get(role), str) or not _DIGEST_REF.fullmatch(images[role])
-        for role in ("server", "host")
+    cleanup = _passed_evidence(
+        source.get("cleanup"),
+        label="cleanup",
+        claim="cleanup",
+        evidence_objects=evidence_objects,
+        identities=identities,
+    )
+    if (
+        cleanup.get("historicalEvidencePreserved") is not True
+        or cleanup.get("leasesReleased") is not True
     ):
-        raise ConformanceContractError("published server and unchanged host images must be digest-pinned")
-
-    cleanup = _passed_evidence(source.get("cleanup"), label="cleanup")
-    if cleanup.get("historicalEvidencePreserved") is not True or cleanup.get("leasesReleased") is not True:
         raise ConformanceContractError("cleanup must preserve history and release leases")
 
     report = {
@@ -91,4 +168,3 @@ def build_embedded_acceptance_report(source: Mapping[str, Any]) -> dict[str, Any
         raise ConformanceContractError("trusted workflow producer identity is required")
     assert_secret_free(report)
     return report
-

--- a/moonmind/omnigent/embedded_acceptance.py
+++ b/moonmind/omnigent/embedded_acceptance.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import re
 from datetime import datetime, timezone
-from typing import Any, Mapping
+from typing import Any, Callable, Mapping
 
 from moonmind.omnigent.conformance import ConformanceContractError, assert_secret_free
 
@@ -141,7 +141,11 @@ def _passed_evidence(
 
 
 def build_embedded_acceptance_report(
-    source: Mapping[str, Any], *, now: datetime | None = None
+    source: Mapping[str, Any],
+    *,
+    now: datetime | None = None,
+    expected_commit: str | None = None,
+    evidence_resolver: Callable[[str], Mapping[str, Any]] | None = None,
 ) -> dict[str, Any]:
     """Validate all controlling lanes and return the publishable report.
 
@@ -168,6 +172,8 @@ def build_embedded_acceptance_report(
         raise ConformanceContractError(
             "complete build, profile, and protocol identities are required"
         )
+    if expected_commit is not None and identities["moonmindCommit"] != expected_commit:
+        raise ConformanceContractError("acceptance evidence is for a different commit")
     images = identities.get("images")
     if not isinstance(images, Mapping) or any(
         not isinstance(images.get(role), str) or not _DIGEST_REF.fullmatch(images[role])
@@ -177,9 +183,33 @@ def build_embedded_acceptance_report(
             "published server and unchanged host images must be digest-pinned"
         )
 
-    evidence_objects = source.get("evidenceObjects")
-    if not isinstance(evidence_objects, Mapping):
-        raise ConformanceContractError("resolved acceptance evidence objects are required")
+    if evidence_resolver is None:
+        evidence_objects = source.get("evidenceObjects")
+        if not isinstance(evidence_objects, Mapping):
+            raise ConformanceContractError("resolved acceptance evidence objects are required")
+    else:
+        refs: set[str] = set()
+        for collection in (source.get("prerequisites"), source.get("sections")):
+            if isinstance(collection, Mapping):
+                for item in collection.values():
+                    if isinstance(item, Mapping):
+                        refs.update(item.get("evidenceRefs") or [])
+        cleanup_source = source.get("cleanup")
+        if isinstance(cleanup_source, Mapping):
+            refs.update(cleanup_source.get("evidenceRefs") or [])
+        evidence_objects = {}
+        pending = list(refs)
+        while pending:
+            ref = pending.pop()
+            if ref in evidence_objects:
+                continue
+            resolved = dict(evidence_resolver(ref))
+            evidence_objects[ref] = resolved
+            cases = resolved.get("cases")
+            if isinstance(cases, Mapping):
+                for case in cases.values():
+                    if isinstance(case, Mapping):
+                        pending.extend(case.get("evidenceRefs") or [])
     prerequisites = source.get("prerequisites")
     if not isinstance(prerequisites, Mapping):
         raise ConformanceContractError("embedded prerequisites are required")

--- a/moonmind/omnigent/embedded_evidence.py
+++ b/moonmind/omnigent/embedded_evidence.py
@@ -1,0 +1,144 @@
+"""Validated embedded-mode enablement evidence.
+
+Source issue: MoonLadderStudios/MoonMind#3425.
+
+Configuration carries artifact identifiers only.  This module validates the
+versioned claim stored in each artifact; authorization and byte retrieval stay
+at the API/service boundary.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from datetime import datetime, timezone
+from typing import Any, Literal, Mapping
+
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    ValidationError,
+    field_validator,
+    model_validator,
+)
+
+from moonmind.omnigent.host_auth_adapter import PINNED_OMNIGENT_COMMIT
+
+EMBEDDED_EVIDENCE_SCHEMA_VERSION = "moonmind.omnigent.embedded-evidence/v1"
+EMBEDDED_PROTOCOL_PROFILE = "omnigent.runner_tunnel.7da32637"
+_PINNED_IMAGE = re.compile(r"^.+@sha256:[0-9a-f]{64}$")
+
+EmbeddedClaimType = Literal[
+    "proxy_conformance", "live_smoke", "host_auth_conformance"
+]
+
+
+class EmbeddedEvidenceError(ValueError):
+    """Evidence is unsafe, incompatible, or does not prove enablement."""
+
+
+class EvidenceOutcome(BaseModel):
+    model_config = ConfigDict(populate_by_name=True, extra="forbid", frozen=True)
+
+    status: Literal["passed"]
+    evidence_refs: tuple[str, ...] = Field(..., alias="evidenceRefs", min_length=1)
+
+    @field_validator("evidence_refs")
+    @classmethod
+    def _refs_are_non_blank(cls, value: tuple[str, ...]) -> tuple[str, ...]:
+        if any(not ref.strip() for ref in value):
+            raise ValueError("evidenceRefs must not contain blank values")
+        return value
+
+
+class EmbeddedEnablementEvidence(BaseModel):
+    """One immutable, expiring embedded enablement claim."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid", frozen=True)
+
+    schema_version: Literal[EMBEDDED_EVIDENCE_SCHEMA_VERSION] = Field(
+        ..., alias="schemaVersion"
+    )
+    claim_type: EmbeddedClaimType = Field(..., alias="claimType")
+    status: Literal["passed"]
+    moonmind_build_identity: str = Field(..., alias="moonmindBuildIdentity")
+    bridge_config_sha256: str = Field(
+        ..., alias="bridgeConfigSha256", pattern=r"^[0-9a-f]{64}$"
+    )
+    omnigent_source_commit: Literal[PINNED_OMNIGENT_COMMIT] = Field(
+        ..., alias="omnigentSourceCommit"
+    )
+    protocol_profile: Literal[EMBEDDED_PROTOCOL_PROFILE] = Field(
+        ..., alias="protocolProfile"
+    )
+    images: dict[str, str]
+    test_matrix: dict[str, EvidenceOutcome] = Field(..., alias="testMatrix")
+    generated_at: datetime = Field(..., alias="generatedAt")
+    expires_at: datetime = Field(..., alias="expiresAt")
+    superseded_by: str | None = Field(None, alias="supersededBy")
+    revoked_at: datetime | None = Field(None, alias="revokedAt")
+    secret_scan: Literal["passed"] = Field(..., alias="secretScan")
+    cleanup: Literal["passed"]
+    producer: str
+
+    @model_validator(mode="after")
+    def _is_usable(self) -> "EmbeddedEnablementEvidence":
+        if not self.moonmind_build_identity.strip() or not self.producer.strip():
+            raise ValueError("build identity and producer are required")
+        if self.generated_at.tzinfo is None or self.expires_at.tzinfo is None:
+            raise ValueError("generatedAt and expiresAt must include a timezone")
+        if self.expires_at <= self.generated_at:
+            raise ValueError("expiresAt must be later than generatedAt")
+        if self.revoked_at is not None or self.superseded_by is not None:
+            raise ValueError("revoked or superseded evidence cannot unlock embedded mode")
+        if not self.test_matrix:
+            raise ValueError("testMatrix must contain passing cases")
+        if not self.images:
+            raise ValueError("immutable server/host images are required")
+        for role in ("server", "host"):
+            image = self.images.get(role, "")
+            if not _PINNED_IMAGE.fullmatch(image):
+                raise ValueError(f"{role} image must use an immutable sha256 digest")
+        return self
+
+
+def validate_embedded_evidence(
+    payload: bytes | str | Mapping[str, Any],
+    *,
+    expected_claim_type: EmbeddedClaimType,
+    moonmind_build_identity: str,
+    bridge_config_sha256: str,
+    now: datetime | None = None,
+) -> EmbeddedEnablementEvidence:
+    """Parse and policy-bind one artifact claim to the running deployment."""
+
+    try:
+        raw: Any = payload
+        if isinstance(payload, bytes):
+            raw = json.loads(payload.decode("utf-8"))
+        elif isinstance(payload, str):
+            raw = json.loads(payload)
+        claim = EmbeddedEnablementEvidence.model_validate(raw)
+    except (UnicodeDecodeError, json.JSONDecodeError, ValidationError) as exc:
+        raise EmbeddedEvidenceError(f"malformed embedded evidence: {exc}") from exc
+    if claim.claim_type != expected_claim_type:
+        raise EmbeddedEvidenceError("evidence claim type does not match configured slot")
+    if claim.moonmind_build_identity != moonmind_build_identity:
+        raise EmbeddedEvidenceError("evidence is for a different MoonMind build")
+    if claim.bridge_config_sha256 != bridge_config_sha256:
+        raise EmbeddedEvidenceError("evidence is for a different bridge configuration")
+    current = now or datetime.now(timezone.utc)
+    if current >= claim.expires_at:
+        raise EmbeddedEvidenceError("embedded evidence has expired")
+    return claim
+
+
+__all__ = [
+    "EMBEDDED_EVIDENCE_SCHEMA_VERSION",
+    "EMBEDDED_PROTOCOL_PROFILE",
+    "EmbeddedEnablementEvidence",
+    "EmbeddedEvidenceError",
+    "EmbeddedClaimType",
+    "validate_embedded_evidence",
+]

--- a/moonmind/omnigent/embedded_evidence.py
+++ b/moonmind/omnigent/embedded_evidence.py
@@ -129,6 +129,8 @@ def validate_embedded_evidence(
     if claim.bridge_config_sha256 != bridge_config_sha256:
         raise EmbeddedEvidenceError("evidence is for a different bridge configuration")
     current = now or datetime.now(timezone.utc)
+    if current < claim.generated_at:
+        raise EmbeddedEvidenceError("embedded evidence is not yet valid")
     if current >= claim.expires_at:
         raise EmbeddedEvidenceError("embedded evidence has expired")
     return claim

--- a/tests/unit/api/routers/test_omnigent_bridge.py
+++ b/tests/unit/api/routers/test_omnigent_bridge.py
@@ -7,6 +7,7 @@ workflow ownership, and bridge failure classes map onto HTTP status codes.
 
 from __future__ import annotations
 
+import importlib
 from types import SimpleNamespace
 from typing import Any
 from uuid import uuid4
@@ -50,6 +51,21 @@ _ELICITATION_RESOLVE_PATH = (
 _UNSET = object()
 
 
+@pytest.fixture(autouse=True)
+def _validated_embedded_evidence(monkeypatch):
+    """Existing embedded-route tests exercise behavior beyond the #3425 gate."""
+
+    module = importlib.import_module("api_service.api.routers.omnigent_bridge")
+
+    async def resolved(_config):
+        return {
+            key: {"status": "passed"}
+            for key in ("proxyConformance", "liveSmoke", "hostAuthConformance")
+        }
+
+    monkeypatch.setattr(module, "_resolve_embedded_evidence", resolved)
+
+
 def test_readiness_reports_selected_mode_and_conformance_state(monkeypatch) -> None:
     monkeypatch.setenv("OMNIGENT_ENABLED", "true")
     monkeypatch.setenv("OMNIGENT_SERVER_URL", "https://omnigent.example.test")
@@ -64,6 +80,43 @@ def test_readiness_reports_selected_mode_and_conformance_state(monkeypatch) -> N
     assert response.json()["selectedMode"] == "upstream_omnigent_server_proxy"
     assert response.json()["protocolProfile"] == "omnigent.server.v1"
     assert response.json()["conformanceState"] == "ready"
+
+
+def test_embedded_readiness_stays_gated_when_artifacts_are_invalid(monkeypatch) -> None:
+    module = importlib.import_module("api_service.api.routers.omnigent_bridge")
+    config = parse_bridge_config(
+        {
+            "compatibility": {"hostProtocolMode": HOST_PROTOCOL_MODE_EMBEDDED},
+            "hostConnection": {
+                "embedded": {
+                    "proxyConformanceEvidenceRef": "arbitrary",
+                    "liveSmokeEvidenceRef": "missing",
+                    "hostAuthConformanceEvidenceRef": "unauthorized",
+                }
+            },
+        }
+    )
+
+    async def invalid(_config):
+        return {
+            key: {
+                "status": "failed",
+                "reason": "evidence_unavailable_or_invalid",
+            }
+            for key in ("proxyConformance", "liveSmoke", "hostAuthConformance")
+        }
+
+    monkeypatch.setattr(module, "_resolve_embedded_evidence", invalid)
+    app = FastAPI()
+    app.include_router(router, prefix=OMNIGENT_BRIDGE_MOUNT_PATH)
+    app.dependency_overrides[get_current_user()] = _mock_user
+    app.dependency_overrides[_require_bridge_enabled] = lambda: config
+
+    response = TestClient(app).get(_READINESS_PATH)
+
+    assert response.status_code == 200
+    assert response.json()["conformanceState"] == "gated"
+    assert response.json()["gateReason"] == "validated_embedded_evidence_required"
 
 
 def _mock_user():

--- a/tests/unit/omnigent/test_bridge_config.py
+++ b/tests/unit/omnigent/test_bridge_config.py
@@ -233,13 +233,23 @@ def test_host_protocol_mode_accepts_embedded() -> None:
         "selectedMode": HOST_PROTOCOL_MODE_EMBEDDED,
         "protocolProfile": "omnigent.runner_tunnel.7da32637",
         "upstreamComponentVersion": "7da32637",
-        "conformanceState": "ready",
+        "conformanceState": "gated",
         "evidenceRefs": {
             "proxyConformance": "artifact://omnigent/proxy-conformance",
             "liveSmoke": "artifact://omnigent/live-smoke",
             "hostAuthConformance": "artifact://omnigent/host-auth",
         },
+        "evidenceValidation": {},
+        "gateReason": "validated_embedded_evidence_required",
     }
+
+    validation = {
+        key: {"status": "passed"}
+        for key in ("proxyConformance", "liveSmoke", "hostAuthConformance")
+    }
+    assert (
+        config.readiness(evidence_validation=validation)["conformanceState"] == "ready"
+    )
 
 
 def test_proxy_readiness_exposes_supported_fallback_without_embedded_evidence(

--- a/tests/unit/omnigent/test_embedded_acceptance.py
+++ b/tests/unit/omnigent/test_embedded_acceptance.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 import copy
+from datetime import datetime, timezone
 
 import pytest
 
 from moonmind.omnigent.conformance import ConformanceContractError
 from moonmind.omnigent.embedded_acceptance import (
+    CASE_EVIDENCE_SCHEMA_VERSION,
     EVIDENCE_SCHEMA_VERSION,
     REQUIRED_PREREQUISITES,
     REQUIRED_SECTIONS,
@@ -49,19 +51,39 @@ def _source() -> dict:
         "cleanup": "cleanup",
     }
     for name, claim in claims.items():
+        case_ref = f"artifact://case/{name}"
         evidence_objects[f"artifact://{name}"] = {
             "schemaVersion": EVIDENCE_SCHEMA_VERSION,
             "claim": claim,
             "status": "passed",
             "identities": copy.deepcopy(source["identities"]),
+            "evidenceRefs": [f"artifact://channel/{name}"],
             "cases": {
                 "controlling-case": {
                     "status": "passed",
-                    "evidenceRefs": [f"artifact://case/{name}"],
+                    "evidenceRefs": [case_ref],
                 }
             },
             "generatedAt": "2026-07-21T00:00:00Z",
+            "expiresAt": "2026-07-22T00:00:00Z",
+            "revokedAt": None,
+            "supersededBy": None,
             "producer": "github-actions:matrix",
+            "secretScan": "passed",
+            "cleanup": "passed",
+        }
+        evidence_objects[case_ref] = {
+            "schemaVersion": CASE_EVIDENCE_SCHEMA_VERSION,
+            "claim": claim,
+            "case": "controlling-case",
+            "status": "passed",
+            "identities": copy.deepcopy(source["identities"]),
+            "evidenceRefs": [f"artifact://channel/case/{name}"],
+            "generatedAt": "2026-07-21T00:00:00Z",
+            "expiresAt": "2026-07-22T00:00:00Z",
+            "revokedAt": None,
+            "supersededBy": None,
+            "producer": "github-actions:case-runner",
             "secretScan": "passed",
             "cleanup": "passed",
         }
@@ -70,7 +92,9 @@ def _source() -> dict:
 
 
 def test_complete_matrix_builds_publishable_issue_3425_report() -> None:
-    report = build_embedded_acceptance_report(_source())
+    report = build_embedded_acceptance_report(
+        _source(), now=datetime(2026, 7, 21, 12, tzinfo=timezone.utc)
+    )
     assert report["status"] == "passed"
     assert report["issue"] == "MoonLadderStudios/MoonMind#3425"
     assert set(report["sections"]) == set(REQUIRED_SECTIONS)
@@ -123,3 +147,43 @@ def test_failed_or_incomplete_resolved_case_refuses_publication() -> None:
     evidence["cases"]["controlling-case"]["status"] = "skipped"
     with pytest.raises(ConformanceContractError, match="cases are incomplete"):
         build_embedded_acceptance_report(source)
+
+
+def test_unresolved_or_mismatched_leaf_case_refuses_publication() -> None:
+    unresolved = _source()
+    del unresolved["evidenceObjects"]["artifact://case/mixed-mode-history"]
+    with pytest.raises(
+        ConformanceContractError,
+        match="case controlling-case evidence ref is unresolved",
+    ):
+        build_embedded_acceptance_report(
+            unresolved, now=datetime(2026, 7, 21, 12, tzinfo=timezone.utc)
+        )
+
+    mismatched = _source()
+    leaf = mismatched["evidenceObjects"]["artifact://case/mixed-mode-history"]
+    leaf["case"] = "another-case"
+    with pytest.raises(ConformanceContractError, match="does not prove its case"):
+        build_embedded_acceptance_report(
+            mismatched, now=datetime(2026, 7, 21, 12, tzinfo=timezone.utc)
+        )
+
+
+@pytest.mark.parametrize(
+    "override,match",
+    [
+        ({"expiresAt": "2026-07-21T11:59:59Z"}, "validity period"),
+        ({"revokedAt": "2026-07-21T11:00:00Z"}, "revoked"),
+        ({"supersededBy": "artifact://replacement"}, "superseded"),
+        ({"generatedAt": "not-a-time"}, "invalid generation"),
+    ],
+)
+def test_stale_revoked_superseded_or_malformed_evidence_refuses_publication(
+    override: dict, match: str
+) -> None:
+    source = _source()
+    source["evidenceObjects"]["artifact://mode-transition-rollback"].update(override)
+    with pytest.raises(ConformanceContractError, match=match):
+        build_embedded_acceptance_report(
+            source, now=datetime(2026, 7, 21, 12, tzinfo=timezone.utc)
+        )

--- a/tests/unit/omnigent/test_embedded_acceptance.py
+++ b/tests/unit/omnigent/test_embedded_acceptance.py
@@ -100,6 +100,11 @@ def test_complete_matrix_builds_publishable_issue_3425_report() -> None:
     assert set(report["sections"]) == set(REQUIRED_SECTIONS)
 
 
+def test_expected_commit_must_match_evidence_identity() -> None:
+    with pytest.raises(ConformanceContractError, match="different commit"):
+        build_embedded_acceptance_report(_source(), expected_commit="def456")
+
+
 @pytest.mark.parametrize("kind,key", [("prerequisites", "3422"), ("sections", "mode-transition-rollback")])
 def test_missing_or_failed_controlling_lane_refuses_publication(kind: str, key: str) -> None:
     source = _source()

--- a/tests/unit/omnigent/test_embedded_acceptance.py
+++ b/tests/unit/omnigent/test_embedded_acceptance.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import copy
+
+import pytest
+
+from moonmind.omnigent.conformance import ConformanceContractError
+from moonmind.omnigent.embedded_acceptance import (
+    REQUIRED_PREREQUISITES,
+    REQUIRED_SECTIONS,
+    build_embedded_acceptance_report,
+)
+
+
+def _source() -> dict:
+    passed = lambda name: {"status": "passed", "evidenceRefs": [f"artifact://{name}"]}
+    digest = "a" * 64
+    return {
+        "producer": "github-actions:omnigent-embedded-acceptance",
+        "identities": {
+            "moonmindCommit": "abc123",
+            "moonmindBuild": "build-7",
+            "profileVersion": "omnigent-stock/v1",
+            "protocolVersion": "omnigent/v1",
+            "images": {"server": f"server@sha256:{digest}", "host": f"host@sha256:{digest}"},
+        },
+        "prerequisites": {issue: passed(f"issue-{issue}") for issue in REQUIRED_PREREQUISITES},
+        "sections": {section: passed(section) for section in REQUIRED_SECTIONS},
+        "cleanup": {**passed("cleanup"), "historicalEvidencePreserved": True, "leasesReleased": True},
+    }
+
+
+def test_complete_matrix_builds_publishable_issue_3425_report() -> None:
+    report = build_embedded_acceptance_report(_source())
+    assert report["status"] == "passed"
+    assert report["issue"] == "MoonLadderStudios/MoonMind#3425"
+    assert set(report["sections"]) == set(REQUIRED_SECTIONS)
+
+
+@pytest.mark.parametrize("kind,key", [("prerequisites", "3422"), ("sections", "mode-transition-rollback")])
+def test_missing_or_failed_controlling_lane_refuses_publication(kind: str, key: str) -> None:
+    source = _source()
+    source[kind][key] = {"status": "failed", "evidenceRefs": ["artifact://failure"]}
+    with pytest.raises(ConformanceContractError, match="did not pass"):
+        build_embedded_acceptance_report(source)
+
+
+def test_mutable_stock_host_and_incomplete_cleanup_refuse_publication() -> None:
+    mutable = _source()
+    mutable["identities"]["images"]["host"] = "host:latest"
+    with pytest.raises(ConformanceContractError, match="digest-pinned"):
+        build_embedded_acceptance_report(mutable)
+    incomplete = copy.deepcopy(_source())
+    incomplete["cleanup"]["leasesReleased"] = False
+    with pytest.raises(ConformanceContractError, match="release leases"):
+        build_embedded_acceptance_report(incomplete)
+
+
+def test_secret_like_material_refuses_publication() -> None:
+    source = _source()
+    source["sections"]["secret-scan"]["note"] = "authorization=unsafe"
+    with pytest.raises(ConformanceContractError, match="secret-like"):
+        build_embedded_acceptance_report(source)

--- a/tests/unit/omnigent/test_embedded_acceptance.py
+++ b/tests/unit/omnigent/test_embedded_acceptance.py
@@ -6,6 +6,7 @@ import pytest
 
 from moonmind.omnigent.conformance import ConformanceContractError
 from moonmind.omnigent.embedded_acceptance import (
+    EVIDENCE_SCHEMA_VERSION,
     REQUIRED_PREREQUISITES,
     REQUIRED_SECTIONS,
     build_embedded_acceptance_report,
@@ -13,21 +14,59 @@ from moonmind.omnigent.embedded_acceptance import (
 
 
 def _source() -> dict:
-    passed = lambda name: {"status": "passed", "evidenceRefs": [f"artifact://{name}"]}
+    passed = lambda name: {
+        "status": "passed",
+        "evidenceRefs": [f"artifact://{name}"],
+    }
     digest = "a" * 64
-    return {
+    source = {
         "producer": "github-actions:omnigent-embedded-acceptance",
         "identities": {
             "moonmindCommit": "abc123",
             "moonmindBuild": "build-7",
             "profileVersion": "omnigent-stock/v1",
             "protocolVersion": "omnigent/v1",
-            "images": {"server": f"server@sha256:{digest}", "host": f"host@sha256:{digest}"},
+            "images": {
+                "server": f"server@sha256:{digest}",
+                "host": f"host@sha256:{digest}",
+            },
         },
         "prerequisites": {issue: passed(f"issue-{issue}") for issue in REQUIRED_PREREQUISITES},
         "sections": {section: passed(section) for section in REQUIRED_SECTIONS},
-        "cleanup": {**passed("cleanup"), "historicalEvidencePreserved": True, "leasesReleased": True},
+        "cleanup": {
+            **passed("cleanup"),
+            "historicalEvidencePreserved": True,
+            "leasesReleased": True,
+        },
     }
+    evidence_objects = {}
+    claims = {
+        **{
+            f"issue-{issue}": f"prerequisite:{issue}"
+            for issue in REQUIRED_PREREQUISITES
+        },
+        **{section: f"section:{section}" for section in REQUIRED_SECTIONS},
+        "cleanup": "cleanup",
+    }
+    for name, claim in claims.items():
+        evidence_objects[f"artifact://{name}"] = {
+            "schemaVersion": EVIDENCE_SCHEMA_VERSION,
+            "claim": claim,
+            "status": "passed",
+            "identities": copy.deepcopy(source["identities"]),
+            "cases": {
+                "controlling-case": {
+                    "status": "passed",
+                    "evidenceRefs": [f"artifact://case/{name}"],
+                }
+            },
+            "generatedAt": "2026-07-21T00:00:00Z",
+            "producer": "github-actions:matrix",
+            "secretScan": "passed",
+            "cleanup": "passed",
+        }
+    source["evidenceObjects"] = evidence_objects
+    return source
 
 
 def test_complete_matrix_builds_publishable_issue_3425_report() -> None:
@@ -60,4 +99,27 @@ def test_secret_like_material_refuses_publication() -> None:
     source = _source()
     source["sections"]["secret-scan"]["note"] = "authorization=unsafe"
     with pytest.raises(ConformanceContractError, match="secret-like"):
+        build_embedded_acceptance_report(source)
+
+
+def test_unresolved_or_identity_mismatched_evidence_refuses_publication() -> None:
+    unresolved = _source()
+    unresolved["sections"]["mixed-mode-history"]["evidenceRefs"] = [
+        "artifact://missing"
+    ]
+    with pytest.raises(ConformanceContractError, match="unresolved"):
+        build_embedded_acceptance_report(unresolved)
+
+    mismatched = _source()
+    evidence = mismatched["evidenceObjects"]["artifact://mixed-mode-history"]
+    evidence["identities"]["moonmindCommit"] = "different"
+    with pytest.raises(ConformanceContractError, match="different identities"):
+        build_embedded_acceptance_report(mismatched)
+
+
+def test_failed_or_incomplete_resolved_case_refuses_publication() -> None:
+    source = _source()
+    evidence = source["evidenceObjects"]["artifact://hostile-input-bounds"]
+    evidence["cases"]["controlling-case"]["status"] = "skipped"
+    with pytest.raises(ConformanceContractError, match="cases are incomplete"):
         build_embedded_acceptance_report(source)

--- a/tests/unit/omnigent/test_embedded_evidence.py
+++ b/tests/unit/omnigent/test_embedded_evidence.py
@@ -1,0 +1,105 @@
+"""Acceptance-gate evidence tests for MoonLadderStudios/MoonMind#3425."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from moonmind.omnigent.embedded_evidence import (
+    EMBEDDED_EVIDENCE_SCHEMA_VERSION,
+    EMBEDDED_PROTOCOL_PROFILE,
+    EmbeddedEvidenceError,
+    validate_embedded_evidence,
+)
+from moonmind.omnigent.host_auth_adapter import PINNED_OMNIGENT_COMMIT
+
+
+NOW = datetime(2026, 7, 21, tzinfo=timezone.utc)
+SHA = "a" * 64
+
+
+def _claim(**overrides):
+    claim = {
+        "schemaVersion": EMBEDDED_EVIDENCE_SCHEMA_VERSION,
+        "claimType": "live_smoke",
+        "status": "passed",
+        "moonmindBuildIdentity": "build-3425",
+        "bridgeConfigSha256": SHA,
+        "omnigentSourceCommit": PINNED_OMNIGENT_COMMIT,
+        "protocolProfile": EMBEDDED_PROTOCOL_PROFILE,
+        "images": {
+            "server": f"ghcr.io/omnigent/server@sha256:{'1' * 64}",
+            "host": f"ghcr.io/omnigent/host@sha256:{'2' * 64}",
+        },
+        "testMatrix": {
+            "stock-host-codex": {
+                "status": "passed",
+                "evidenceRefs": ["artifact-id"],
+            }
+        },
+        "generatedAt": NOW.isoformat(),
+        "expiresAt": (NOW + timedelta(days=1)).isoformat(),
+        "supersededBy": None,
+        "revokedAt": None,
+        "secretScan": "passed",
+        "cleanup": "passed",
+        "producer": "workflow:omnigent-embedded-conformance",
+    }
+    claim.update(overrides)
+    return claim
+
+
+def test_accepts_current_passing_policy_bound_claim() -> None:
+    result = validate_embedded_evidence(
+        _claim(),
+        expected_claim_type="live_smoke",
+        moonmind_build_identity="build-3425",
+        bridge_config_sha256=SHA,
+        now=NOW,
+    )
+
+    assert result.status == "passed"
+
+
+@pytest.mark.parametrize(
+    ("override", "match"),
+    [
+        ({"status": "failed"}, "malformed"),
+        ({"revokedAt": NOW.isoformat()}, "revoked"),
+        ({"supersededBy": "new-artifact"}, "superseded"),
+        ({"secretScan": "failed"}, "malformed"),
+        ({"cleanup": "failed"}, "malformed"),
+        ({"images": {}}, "images"),
+    ],
+)
+def test_rejects_failed_revoked_or_incomplete_claims(override, match) -> None:
+    with pytest.raises(EmbeddedEvidenceError, match=match):
+        validate_embedded_evidence(
+            _claim(**override),
+            expected_claim_type="live_smoke",
+            moonmind_build_identity="build-3425",
+            bridge_config_sha256=SHA,
+            now=NOW,
+        )
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "match"),
+    [
+        ({"expected_claim_type": "proxy_conformance"}, "claim type"),
+        ({"moonmind_build_identity": "other-build"}, "different MoonMind"),
+        ({"bridge_config_sha256": "b" * 64}, "different bridge"),
+        ({"now": NOW + timedelta(days=2)}, "expired"),
+    ],
+)
+def test_rejects_stale_or_incompatible_policy(kwargs, match) -> None:
+    arguments = {
+        "expected_claim_type": "live_smoke",
+        "moonmind_build_identity": "build-3425",
+        "bridge_config_sha256": SHA,
+        "now": NOW,
+    }
+    arguments.update(kwargs)
+    with pytest.raises(EmbeddedEvidenceError, match=match):
+        validate_embedded_evidence(_claim(), **arguments)

--- a/tests/unit/omnigent/test_embedded_evidence.py
+++ b/tests/unit/omnigent/test_embedded_evidence.py
@@ -103,3 +103,17 @@ def test_rejects_stale_or_incompatible_policy(kwargs, match) -> None:
     arguments.update(kwargs)
     with pytest.raises(EmbeddedEvidenceError, match=match):
         validate_embedded_evidence(_claim(), **arguments)
+
+
+def test_rejects_not_yet_valid_claim() -> None:
+    with pytest.raises(EmbeddedEvidenceError, match="not yet valid"):
+        validate_embedded_evidence(
+            _claim(
+                generatedAt=(NOW + timedelta(minutes=1)).isoformat(),
+                expiresAt=(NOW + timedelta(days=1)).isoformat(),
+            ),
+            expected_claim_type="live_smoke",
+            moonmind_build_identity="build-3425",
+            bridge_config_sha256=SHA,
+            now=NOW,
+        )

--- a/tests/unit/test_omnigent_embedded_acceptance_workflow.py
+++ b/tests/unit/test_omnigent_embedded_acceptance_workflow.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+
+import yaml
+
+
+WORKFLOW = Path(".github/workflows/omnigent-embedded-acceptance.yml")
+
+
+def test_embedded_acceptance_workflow_uses_prior_durable_matrix_and_fail_closed_builder() -> None:
+    workflow = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    steps = workflow["jobs"]["publish"]["steps"]
+    download = next(step for step in steps if step["name"] == "Download complete matrix evidence")
+    assert download["with"]["run-id"] == "${{ inputs.evidence_run_id }}"
+    build = next(step for step in steps if step["name"] == "Build protected acceptance report")
+    assert "build_omnigent_embedded_acceptance.py" in build["run"]
+    assert "--allow-partial" not in build["run"]
+
+
+def test_issue_link_can_only_run_after_report_upload() -> None:
+    workflow = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    names = [step["name"] for step in workflow["jobs"]["publish"]["steps"]]
+    assert names.index("Upload passing report") < names.index("Link passing report from issue 3425")

--- a/tests/unit/test_omnigent_embedded_acceptance_workflow.py
+++ b/tests/unit/test_omnigent_embedded_acceptance_workflow.py
@@ -13,6 +13,8 @@ def test_embedded_acceptance_workflow_uses_prior_durable_matrix_and_fail_closed_
     assert download["with"]["run-id"] == "${{ inputs.evidence_run_id }}"
     build = next(step for step in steps if step["name"] == "Build protected acceptance report")
     assert "build_omnigent_embedded_acceptance.py" in build["run"]
+    assert "--expected-commit \"${{ github.sha }}\"" in build["run"]
+    assert "--evidence-root" in build["run"]
     assert "--allow-partial" not in build["run"]
 
 

--- a/tests/unit/tools/test_check_github_workflow_names.py
+++ b/tests/unit/tools/test_check_github_workflow_names.py
@@ -32,6 +32,7 @@ def test_current_workflows_have_stable_names() -> None:
         "codex-conformance-canary.yml": "Provider / Codex Conformance Canary",
         "docker-publish.yml": "Release / Build App Image",
         "omnigent-live-conformance.yml": "Provider / Omnigent Live Conformance",
+        "omnigent-embedded-acceptance.yml": "Provider / Omnigent Embedded Acceptance",
         "pentestgpt-runner.yml": "Security / Build PentestGPT Runner",
         "promote-ghcr-stable.yml": "Release / Promote Stable",
         "pytest-unit-tests.yml": "CI / Test Suite",

--- a/tools/build_omnigent_embedded_acceptance.py
+++ b/tools/build_omnigent_embedded_acceptance.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+"""Build the fail-closed #3425 embedded acceptance publication."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from moonmind.omnigent.embedded_acceptance import build_embedded_acceptance_report
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("evidence", type=Path)
+    parser.add_argument("output", type=Path)
+    args = parser.parse_args()
+    source = json.loads(args.evidence.read_text(encoding="utf-8"))
+    report = build_embedded_acceptance_report(source)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+

--- a/tools/build_omnigent_embedded_acceptance.py
+++ b/tools/build_omnigent_embedded_acceptance.py
@@ -19,9 +19,24 @@ def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("evidence", type=Path)
     parser.add_argument("output", type=Path)
+    parser.add_argument("--evidence-root", type=Path)
+    parser.add_argument("--expected-commit")
     args = parser.parse_args()
     source = json.loads(args.evidence.read_text(encoding="utf-8"))
-    report = build_embedded_acceptance_report(source)
+    resolver = None
+    if args.evidence_root is not None:
+        root = args.evidence_root.resolve()
+
+        def resolver(ref: str):
+            if not ref.startswith("artifact://"):
+                raise ValueError("evidence refs must use artifact://")
+            path = (root / (ref.removeprefix("artifact://") + ".json")).resolve()
+            if root not in path.parents:
+                raise ValueError("evidence ref escapes evidence root")
+            return json.loads(path.read_text(encoding="utf-8"))
+    report = build_embedded_acceptance_report(
+        source, expected_commit=args.expected_commit, evidence_resolver=resolver
+    )
     args.output.parent.mkdir(parents=True, exist_ok=True)
     args.output.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     return 0
@@ -29,4 +44,3 @@ def main() -> int:
 
 if __name__ == "__main__":
     raise SystemExit(main())
-


### PR DESCRIPTION
Issue: MoonLadderStudios/MoonMind#3425

Closes MoonLadderStudios/MoonMind#3425

## Summary
- validate authorized, schema-bound embedded enablement evidence instead of accepting arbitrary references
- add the fail-closed final embedded acceptance matrix and report builder
- add the embedded acceptance publication workflow and focused unit coverage

## Tests run
- `python tools/check_github_workflow_names.py` (pass)
- `python -m compileall -q moonmind/omnigent/embedded_acceptance.py tools/build_omnigent_embedded_acceptance.py tests/unit/omnigent/test_embedded_acceptance.py` (pass)
- `git diff --check` (pass)
- focused Python container suite was attempted but not run because the container-job service returned HTTP 503 (disabled in this environment)

## Remaining risks
- the credentialed unchanged-stock-host live matrix and GitHub publication workflow still require external images, credentials, and services; repository verification confirms the gate fails closed until valid passing evidence exists
