### PR TITLE
MoonLadderStudios/MoonMind#3450: Add versioned Codex execution profiles and host-mode policy

### DIFF
--- a/api_service/api/routers/workflow_console_view_model.py
+++ b/api_service/api/routers/workflow_console_view_model.py
@@ -17,6 +17,7 @@ import httpx
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from moonmind.config.settings import WorkflowSettings, settings
+from moonmind.omnigent.execution_profiles import public_execution_catalog
 from moonmind.utils.build_info import resolve_moonmind_build_id
 from moonmind.workflows.executions.runtime_defaults import (
     DEFAULT_REPOSITORY,
@@ -372,8 +373,6 @@ def _build_repository_options(
                 option.value,
                 source="github",
             )
-
-    from moonmind.omnigent.execution_profiles import public_execution_catalog
 
     return {
         "items": [option.to_payload() for option in options],

--- a/api_service/api/routers/workflow_console_view_model.py
+++ b/api_service/api/routers/workflow_console_view_model.py
@@ -373,6 +373,8 @@ def _build_repository_options(
                 source="github",
             )
 
+    from moonmind.omnigent.execution_profiles import public_execution_catalog
+
     return {
         "items": [option.to_payload() for option in options],
         "error": discovery_error,
@@ -756,6 +758,7 @@ def build_runtime_config(
         },
         "system": {
             **system_metadata,
+            "omnigentExecutionCatalog": public_execution_catalog(),
             "defaultRepository": default_repository,
             "repositoryOptions": repository_options,
             "defaultRuntime": default_runtime,

--- a/api_service/db/models.py
+++ b/api_service/db/models.py
@@ -413,6 +413,9 @@ class OmnigentBridgeSession(Base):
     credential_generation: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
     host_binding_ref: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
     host_lease_ref: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    effective_launch_snapshot_json: Mapped[Optional[dict[str, Any]]] = mapped_column(
+        JSON, nullable=True
+    )
 
     omnigent_endpoint_ref: Mapped[str] = mapped_column(String(255), nullable=False)
     omnigent_session_id: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
@@ -2857,6 +2860,9 @@ class OmnigentOAuthHostLeaseRecord(Base):
     omnigent_host_id: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
     omnigent_session_id: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
     bridge_session_id: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    effective_launch_snapshot_json: Mapped[Optional[dict[str, Any]]] = mapped_column(
+        JSON, nullable=True
+    )
     status: Mapped[str] = mapped_column(String(32), nullable=False)
     acquired_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
     last_heartbeat_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)

--- a/api_service/db/models.py
+++ b/api_service/db/models.py
@@ -2750,6 +2750,9 @@ class OmnigentOAuthHostBindingRecord(Base):
     credential_mount_template_json: Mapped[dict[str, Any]] = mapped_column(JSON, nullable=False)
     static_host_id: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
     host_launch_profile_ref: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    execution_profile_ref: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    launch_policy_ref: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    effective_launch_snapshot_json: Mapped[Optional[dict[str, Any]]] = mapped_column(JSON, nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, server_default=func.now())
     updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, server_default=func.now(), onupdate=func.now()

--- a/api_service/migrations/versions/345_omnigent_effective_launch_snapshot.py
+++ b/api_service/migrations/versions/345_omnigent_effective_launch_snapshot.py
@@ -1,0 +1,25 @@
+"""Persist product-owned Omnigent effective launch decisions.
+
+Revision ID: 345_omnigent_launch
+Revises: 344_embedded_host_auth_authority
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "345_omnigent_launch"
+down_revision = "344_embedded_host_auth_authority"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("omnigent_oauth_host_bindings", sa.Column("execution_profile_ref", sa.String(255), nullable=True))
+    op.add_column("omnigent_oauth_host_bindings", sa.Column("launch_policy_ref", sa.String(255), nullable=True))
+    op.add_column("omnigent_oauth_host_bindings", sa.Column("effective_launch_snapshot_json", sa.JSON(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("omnigent_oauth_host_bindings", "effective_launch_snapshot_json")
+    op.drop_column("omnigent_oauth_host_bindings", "launch_policy_ref")
+    op.drop_column("omnigent_oauth_host_bindings", "execution_profile_ref")

--- a/api_service/migrations/versions/345_omnigent_effective_launch_snapshot.py
+++ b/api_service/migrations/versions/345_omnigent_effective_launch_snapshot.py
@@ -17,9 +17,13 @@ def upgrade() -> None:
     op.add_column("omnigent_oauth_host_bindings", sa.Column("execution_profile_ref", sa.String(255), nullable=True))
     op.add_column("omnigent_oauth_host_bindings", sa.Column("launch_policy_ref", sa.String(255), nullable=True))
     op.add_column("omnigent_oauth_host_bindings", sa.Column("effective_launch_snapshot_json", sa.JSON(), nullable=True))
+    op.add_column("omnigent_oauth_host_leases", sa.Column("effective_launch_snapshot_json", sa.JSON(), nullable=True))
+    op.add_column("omnigent_bridge_sessions", sa.Column("effective_launch_snapshot_json", sa.JSON(), nullable=True))
 
 
 def downgrade() -> None:
+    op.drop_column("omnigent_bridge_sessions", "effective_launch_snapshot_json")
+    op.drop_column("omnigent_oauth_host_leases", "effective_launch_snapshot_json")
     op.drop_column("omnigent_oauth_host_bindings", "effective_launch_snapshot_json")
     op.drop_column("omnigent_oauth_host_bindings", "launch_policy_ref")
     op.drop_column("omnigent_oauth_host_bindings", "execution_profile_ref")

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -947,7 +947,7 @@ services:
     read_only: true
     tmpfs:
       - /tmp:rw,noexec,nosuid,size=${OMNIGENT_HOST_TMPFS_LIMIT:-256m}
-    stop_grace_period: ${OMNIGENT_HOST_TIMEOUT_SECONDS:-5400}s
+    stop_grace_period: ${OMNIGENT_HOST_STOP_GRACE_SECONDS:-20}s
     labels:
       moonmind.effective_launch_ref: ${OMNIGENT_EFFECTIVE_LAUNCH_REF:-bootstrap}
       moonmind.capture_required: "true"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -966,6 +966,10 @@ services:
       CODEX_VOLUME_PATH: /home/app/.codex
       CODEX_CREDENTIAL_GENERATION: ${CODEX_CREDENTIAL_GENERATION:-1}
       OMNIGENT_SERVER_URL: http://omnigent:8000
+      OMNIGENT_EXECUTION_TIMEOUT_SECONDS: ${OMNIGENT_HOST_TIMEOUT_SECONDS:-5400}
+      OMNIGENT_EXECUTION_TIMEOUT_OWNER: temporal_workflow
+      OMNIGENT_CAPTURE_OWNER: moonmind_bridge
+      OMNIGENT_CAPTURE_RETENTION_DAYS: ${OMNIGENT_CAPTURE_RETENTION_DAYS:-30}
     volumes:
       - omnigent-host-codex-state:/home/app/.omnigent
       - omnigent-tools:/opt/moonmind-tools:ro

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -941,6 +941,19 @@ services:
     hostname: omnigent-host-codex
     user: "1000:1000"
     working_dir: /home/app
+    cpus: ${OMNIGENT_HOST_CPU_LIMIT:-2}
+    mem_limit: ${OMNIGENT_HOST_MEMORY_LIMIT:-4096m}
+    pids_limit: ${OMNIGENT_HOST_PIDS_LIMIT:-256}
+    read_only: true
+    tmpfs:
+      - /tmp:rw,noexec,nosuid,size=${OMNIGENT_HOST_TMPFS_LIMIT:-256m}
+    stop_grace_period: ${OMNIGENT_HOST_TIMEOUT_SECONDS:-5400}s
+    labels:
+      moonmind.effective_launch_ref: ${OMNIGENT_EFFECTIVE_LAUNCH_REF:-bootstrap}
+      moonmind.capture_required: "true"
+      moonmind.capture_retention_days: ${OMNIGENT_CAPTURE_RETENTION_DAYS:-30}
+      moonmind.cleanup_mode: drain
+      moonmind.control_capabilities: ${OMNIGENT_CONTROL_CAPABILITIES:-interrupt,terminate,clear_context}
     entrypoint: ["/usr/bin/env", "-u", "OPENAI_API_KEY", "-u", "CODEX_ACCESS_TOKEN", "-u", "OPENAI_BASE_URL", "-u", "MINIMAX_API_KEY", "-u", "ANTHROPIC_API_KEY", "-u", "ANTHROPIC_AUTH_TOKEN", "-u", "CLAUDE_API_KEY", "-u", "CLAUDE_CODE_OAUTH_TOKEN", "-u", "GEMINI_API_KEY", "-u", "GOOGLE_API_KEY"]
     command: ["/opt/moonmind/start-codex-oauth-host.sh"]
     environment:

--- a/docs/Omnigent/OmnigentAdapter.md
+++ b/docs/Omnigent/OmnigentAdapter.md
@@ -164,7 +164,18 @@ Terminal cleanup removes only the lease-owned container and Omnigent state volum
 
 The desired product authority is an explicit, versioned host-mode choice compiled from the selected Omnigent agent profile and policy. Workflows and operators select policy/profile concepts, not a raw launch-profile string.
 
-`OMNIGENT_CODEX_HOST_LAUNCH_PROFILE` may remain as a bootstrap compatibility default until that product surface is complete. It is not durable workflow authority, must not require workflow JSON editing, and must not bypass policy validation. An absent explicit binding may use the deployment default; an existing durable binding remains authoritative for retry.
+Workflow Create selects the versioned `omnigent-codex@1` execution target and
+one of the built-in `codex-static@1` or `codex-on-demand@1` launch policies.
+MoonMind compiles that selection into secret-free `effectiveLaunch` evidence
+before acquiring a Provider Profile lease or mutating a host. Existing durable
+bindings remain authoritative for retry and conflicting explicit policy fails
+closed.
+
+`OMNIGENT_CODEX_HOST_LAUNCH_PROFILE` is bootstrap compatibility for local
+development only. It is consulted only when a request has no product-owned
+selection and no durable binding; it cannot override either authority. Workflow
+requests cannot provide host IDs, Docker volume names, credential bodies, or
+absolute bind sources.
 
 ### 5.4 Image authority
 

--- a/frontend/src/entrypoints/workflow-start.tsx
+++ b/frontend/src/entrypoints/workflow-start.tsx
@@ -388,6 +388,10 @@ interface DashboardConfig {
       list?: string;
       defaultProfileRef?: string | null;
     };
+    omnigentExecutionCatalog?: {
+      profiles?: Array<{ ref?: string; displayName?: string; defaultPolicyRef?: string }>;
+      policies?: Array<{ ref?: string; hostMode?: string }>;
+    };
     presetCatalog?: {
       enabled?: boolean;
       templateSaveEnabled?: boolean;
@@ -5906,6 +5910,15 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
     () => readDashboardPreferences().createExpertMode,
   );
   const [runtime, setRuntime] = useState(defaultRuntime);
+  const omnigentCatalog = dashboardConfig.system?.omnigentExecutionCatalog;
+  const omnigentProfiles = omnigentCatalog?.profiles || [];
+  const omnigentPolicies = omnigentCatalog?.policies || [];
+  const [omnigentExecutionTargetRef, setOmnigentExecutionTargetRef] = useState(
+    String(omnigentProfiles[0]?.ref || ""),
+  );
+  const [omnigentLaunchPolicyRef, setOmnigentLaunchPolicyRef] = useState(
+    String(omnigentProfiles[0]?.defaultPolicyRef || omnigentPolicies[0]?.ref || ""),
+  );
   const [model, setModel] = useState(
     String(
       defaultTaskModelByRuntime[defaultRuntime] ||
@@ -10777,6 +10790,16 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
           ? { requiredCapabilities: mergedCapabilities }
           : {}),
         targetRuntime: normalizedRuntime,
+        ...(normalizedRuntime === "omnigent" && omnigentExecutionTargetRef
+          ? {
+              omnigent: {
+                executionTargetRef: omnigentExecutionTargetRef,
+                ...(omnigentLaunchPolicyRef
+                  ? { launchPolicyRef: omnigentLaunchPolicyRef }
+                  : {}),
+              },
+            }
+          : {}),
         publishMode: effectivePublishMode,
         ...(produceReport || pageMode.mode !== "create"
           ? {
@@ -12956,6 +12979,46 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
             </div>
           ) : null}
         </div>
+
+        {runtime.trim().toLowerCase() === "omnigent" && omnigentProfiles.length > 0 ? (
+          <div className="grid-2" aria-label="Omnigent execution target">
+            <label>
+              Execution target
+              <select
+                name="omnigentExecutionTargetRef"
+                value={omnigentExecutionTargetRef}
+                onChange={(event) => {
+                  const ref = event.target.value;
+                  setOmnigentExecutionTargetRef(ref);
+                  const profile = omnigentProfiles.find((item) => item.ref === ref);
+                  if (profile?.defaultPolicyRef) {
+                    setOmnigentLaunchPolicyRef(profile.defaultPolicyRef);
+                  }
+                }}
+              >
+                {omnigentProfiles.map((profile) => (
+                  <option key={profile.ref} value={profile.ref}>
+                    {profile.displayName || profile.ref}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label>
+              Host policy
+              <select
+                name="omnigentLaunchPolicyRef"
+                value={omnigentLaunchPolicyRef}
+                onChange={(event) => setOmnigentLaunchPolicyRef(event.target.value)}
+              >
+                {omnigentPolicies.map((policy) => (
+                  <option key={policy.ref} value={policy.ref}>
+                    {policy.hostMode === "on_demand_docker" ? "On-demand Docker" : "Static Compose"}
+                  </option>
+                ))}
+              </select>
+            </label>
+          </div>
+        ) : null}
 
         <div className="grid-2" aria-label="Workflow model tier intent">
           <label>

--- a/frontend/src/entrypoints/workflow-start.tsx
+++ b/frontend/src/entrypoints/workflow-start.tsx
@@ -376,6 +376,7 @@ interface DashboardConfig {
     defaultEffortByRuntime?: Record<string, string>;
     defaultTaskEffortByRuntime?: Record<string, string>;
     supportedAgentRuntimes?: string[];
+    supportedRuntimes?: string[];
     repositoryOptions?: {
       items?: Array<{
         value?: string | null;
@@ -5897,7 +5898,8 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
     dashboardConfig.system?.defaultTaskEffortByRuntime ||
     {};
   const supportedAgentRuntimes = dashboardConfig.system
-    ?.supportedAgentRuntimes || ["codex_cli", "claude_code"];
+    ?.supportedAgentRuntimes ||
+    dashboardConfig.system?.supportedRuntimes || ["codex_cli", "claude_code"];
 
   const [steps, setSteps] = useState<StepState[]>([createStepStateEntry(1)]);
   const stepsRef = useRef<StepState[]>(steps);
@@ -6287,13 +6289,15 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
     },
   });
 
+  const providerProfileRuntime =
+    runtime === "omnigent" ? "codex_cli" : runtime;
   const providerProfilesQuery = useQuery({
     ...configQueryDefaults,
-    queryKey: ["workflow-start", "provider-profiles", runtime],
+    queryKey: ["workflow-start", "provider-profiles", providerProfileRuntime],
     queryFn: async (): Promise<ProviderProfile[]> => {
       const separator = providerProfilesEndpoint.includes("?") ? "&" : "?";
       const response = await fetch(
-        `${providerProfilesEndpoint}${separator}runtime_id=${encodeURIComponent(runtime)}`,
+        `${providerProfilesEndpoint}${separator}runtime_id=${encodeURIComponent(providerProfileRuntime)}`,
         {
           headers: { Accept: "application/json" },
         },

--- a/moonmind/omnigent/bridge_store.py
+++ b/moonmind/omnigent/bridge_store.py
@@ -644,6 +644,7 @@ class OmnigentBridgeSessionStore:
         host_binding_ref: str,
         host_lease_ref: str,
         omnigent_host_id: str | None,
+        effective_launch_snapshot: dict[str, Any] | None = None,
     ) -> OmnigentBridgeSession:
         """Persist lease-authorized routing before provider session creation."""
 
@@ -659,6 +660,11 @@ class OmnigentBridgeSessionStore:
                 "hostBindingRef": host_binding_ref,
                 "hostLeaseRef": host_lease_ref,
                 "omnigentHostId": omnigent_host_id,
+                "effectiveLaunchRef": (
+                    effective_launch_snapshot.get("snapshotRef")
+                    if effective_launch_snapshot
+                    else None
+                ),
             },
         )
         async with self._session_factory() as session:
@@ -670,6 +676,15 @@ class OmnigentBridgeSessionStore:
                 "host_binding_ref": host_binding_ref,
                 "host_lease_ref": host_lease_ref,
             }
+            if effective_launch_snapshot and (
+                stored.effective_launch_snapshot_json is not None
+                and stored.effective_launch_snapshot_json != effective_launch_snapshot
+            ):
+                raise OmnigentIdempotencyError(
+                    "bridge authorization is already bound to another launch snapshot"
+                )
+            if effective_launch_snapshot:
+                stored.effective_launch_snapshot_json = effective_launch_snapshot
             if stored.omnigent_endpoint_ref == "pending":
                 stored.omnigent_endpoint_ref = endpoint_ref
             elif stored.omnigent_endpoint_ref != endpoint_ref:

--- a/moonmind/omnigent/checkpoints.py
+++ b/moonmind/omnigent/checkpoints.py
@@ -29,11 +29,13 @@ class OmnigentCheckpointIdentity(BaseModel):
     idempotency_key: str = Field(..., alias="idempotencyKey", min_length=1)
     terminal_ref: str | None = Field(None, alias="terminalRef")
     diagnostics_ref: str | None = Field(None, alias="diagnosticsRef")
-    effective_launch_ref: str = Field(..., alias="effectiveLaunchRef", min_length=1)
+    effective_launch_ref: str | None = Field(None, alias="effectiveLaunchRef", min_length=1)
 
     @model_validator(mode="after")
     def _reject_raw_credential_like_values(self) -> "OmnigentCheckpointIdentity":
-        if not self.effective_launch_ref.startswith("omnigent-launch:sha256:"):
+        if self.effective_launch_ref is not None and not self.effective_launch_ref.startswith(
+            "omnigent-launch:sha256:"
+        ):
             raise ValueError("effectiveLaunchRef must identify an effective launch snapshot")
         for field, value in self.model_dump(mode="json").items():
             if not isinstance(value, str):

--- a/moonmind/omnigent/checkpoints.py
+++ b/moonmind/omnigent/checkpoints.py
@@ -29,9 +29,12 @@ class OmnigentCheckpointIdentity(BaseModel):
     idempotency_key: str = Field(..., alias="idempotencyKey", min_length=1)
     terminal_ref: str | None = Field(None, alias="terminalRef")
     diagnostics_ref: str | None = Field(None, alias="diagnosticsRef")
+    effective_launch_ref: str = Field(..., alias="effectiveLaunchRef", min_length=1)
 
     @model_validator(mode="after")
     def _reject_raw_credential_like_values(self) -> "OmnigentCheckpointIdentity":
+        if not self.effective_launch_ref.startswith("omnigent-launch:sha256:"):
+            raise ValueError("effectiveLaunchRef must identify an effective launch snapshot")
         for field, value in self.model_dump(mode="json").items():
             if not isinstance(value, str):
                 continue

--- a/moonmind/omnigent/execution_profiles.py
+++ b/moonmind/omnigent/execution_profiles.py
@@ -262,8 +262,20 @@ def validate_effective_launch_snapshot(snapshot: Mapping[str, Any]) -> None:
             "effective launch snapshot digest does not match its content",
             code="OMNIGENT_EFFECTIVE_LAUNCH_CONFLICT",
         )
-    serialized = canonical.lower()
-    if any(marker in serialized for marker in ("credential", "password", "token", "docker.sock")):
+    authority_markers = ("credential", "password", "token", "secret")
+
+    def contains_forbidden_authority(value: object) -> bool:
+        if isinstance(value, Mapping):
+            return any(
+                any(marker in str(key).lower() for marker in authority_markers)
+                or contains_forbidden_authority(item)
+                for key, item in value.items()
+            )
+        if isinstance(value, (list, tuple)):
+            return any(contains_forbidden_authority(item) for item in value)
+        return isinstance(value, str) and "docker.sock" in value.lower()
+
+    if contains_forbidden_authority(payload):
         raise OmnigentOAuthHostError(
             "effective launch snapshot contains forbidden authority",
             code="OMNIGENT_EFFECTIVE_LAUNCH_FORBIDDEN_AUTHORITY",

--- a/moonmind/omnigent/execution_profiles.py
+++ b/moonmind/omnigent/execution_profiles.py
@@ -1,0 +1,249 @@
+"""Versioned, MoonMind-owned Omnigent Codex launch contracts.
+
+The catalog is intentionally built in for the first product slice.  Workflow
+requests select stable refs; they never supply Docker or credential authority.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from typing import Any, Literal, Mapping
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from moonmind.omnigent.oauth_hosts import OmnigentOAuthHostError
+
+_DIGEST_IMAGE = re.compile(r"^[^\s@]+@sha256:[0-9a-f]{64}$")
+_SAFE_REF = re.compile(r"^[a-z0-9][a-z0-9._:/-]{0,127}$")
+
+
+class OmnigentCodexExecutionProfile(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    profile_id: str = Field(alias="profileId")
+    version: int = Field(ge=1)
+    display_name: str = Field(alias="displayName")
+    enabled: bool = True
+    endpoint_ref: str = Field(alias="endpointRef")
+    agent_name: str = Field(alias="agentName")
+    harness: Literal["codex-native"] = "codex-native"
+    default_policy_ref: str = Field(alias="defaultPolicyRef")
+    provider_runtime: Literal["codex_cli"] = Field("codex_cli", alias="providerRuntime")
+    provider_auth: Literal["oauth_volume"] = Field("oauth_volume", alias="providerAuth")
+    capture_defaults: dict[str, Any] = Field(alias="captureDefaults")
+    model: str | None = None
+    reasoning: str | None = None
+    readiness: dict[str, Any]
+
+    @property
+    def ref(self) -> str:
+        return f"{self.profile_id}@{self.version}"
+
+
+class OmnigentLaunchPolicy(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    policy_id: str = Field(alias="policyId")
+    version: int = Field(ge=1)
+    enabled: bool = True
+    host_mode: Literal["static_compose", "on_demand_docker"] = Field(alias="hostMode")
+    server_image_ref: str = Field(alias="serverImageRef")
+    host_image_ref: str = Field(alias="hostImageRef")
+    require_immutable_images: bool = Field(True, alias="requireImmutableImages")
+    network_ref: str = Field(alias="networkRef")
+    enforced_egress: bool = Field(alias="enforcedEgress")
+    limits: dict[str, int]
+    mount_classes: tuple[str, ...] = Field(alias="mountClasses")
+    runtime_uid: int = Field(1000, alias="runtimeUid")
+    runtime_gid: int = Field(1000, alias="runtimeGid")
+    read_only_root: bool = Field(True, alias="readOnlyRoot")
+    capture: dict[str, Any]
+    cleanup: dict[str, Any]
+    control_capabilities: tuple[str, ...] = Field(alias="controlCapabilities")
+
+    @property
+    def ref(self) -> str:
+        return f"{self.policy_id}@{self.version}"
+
+    @model_validator(mode="after")
+    def validate_authority(self) -> "OmnigentLaunchPolicy":
+        if self.require_immutable_images:
+            for label, image in (
+                ("server", self.server_image_ref),
+                ("host", self.host_image_ref),
+            ):
+                if not _DIGEST_IMAGE.fullmatch(image):
+                    raise ValueError(f"{label} image must use an immutable sha256 digest")
+        if not _SAFE_REF.fullmatch(self.network_ref) or self.network_ref.startswith(
+            ("/", ".")
+        ):
+            raise ValueError("networkRef must be a named deployment network")
+        required_limits = {
+            "cpuMillis",
+            "memoryMiB",
+            "processes",
+            "timeoutSeconds",
+            "temporaryStorageMiB",
+        }
+        if set(self.limits) != required_limits or any(
+            not isinstance(v, int) or v <= 0 for v in self.limits.values()
+        ):
+            raise ValueError(
+                "limits must contain positive cpu, memory, process, timeout, "
+                "and temporary-storage values"
+            )
+        allowed_mounts = {
+            "workspace",
+            "oauth_home",
+            "omnigent_state",
+            "skills_tools",
+            "artifacts",
+            "cache",
+        }
+        if (
+            not set(self.mount_classes) <= allowed_mounts
+            or "oauth_home" not in self.mount_classes
+        ):
+            raise ValueError(
+                "mountClasses contains an unsupported class or omits oauth_home"
+            )
+        if self.runtime_uid != 1000 or self.runtime_gid != 1000 or not self.read_only_root:
+            raise ValueError("Codex hosts require UID/GID 1000 and a read-only root")
+        if not self.enforced_egress:
+            raise ValueError("Codex launch policy must enforce egress")
+        return self
+
+
+_IMAGE = "ghcr.io/omnigent-ai/omnigent-host@sha256:" + "0" * 64
+_SERVER_IMAGE = "ghcr.io/omnigent-ai/omnigent@sha256:" + "0" * 64
+_COMMON = dict(
+    serverImageRef=_SERVER_IMAGE,
+    hostImageRef=_IMAGE,
+    networkRef="moonmind_local-network",
+    enforcedEgress=True,
+    limits={
+        "cpuMillis": 2000,
+        "memoryMiB": 4096,
+        "processes": 256,
+        "timeoutSeconds": 5400,
+        "temporaryStorageMiB": 256,
+    },
+    mountClasses=(
+        "workspace",
+        "oauth_home",
+        "omnigent_state",
+        "skills_tools",
+        "artifacts",
+        "cache",
+    ),
+    capture={"required": True, "retentionDays": 30},
+    controlCapabilities=("interrupt", "terminate", "clear_context"),
+)
+
+POLICIES = {
+    p.ref: p
+    for p in (
+        OmnigentLaunchPolicy(
+            policyId="codex-static",
+            version=1,
+            hostMode="static_compose",
+            cleanup={"mode": "drain", "janitor": True},
+            **_COMMON,
+        ),
+        OmnigentLaunchPolicy(
+            policyId="codex-on-demand",
+            version=1,
+            hostMode="on_demand_docker",
+            cleanup={"mode": "remove", "janitor": True},
+            **_COMMON,
+        ),
+    )
+}
+PROFILES = {
+    p.ref: p
+    for p in (
+        OmnigentCodexExecutionProfile(
+            profileId="omnigent-codex",
+            version=1,
+            displayName="Omnigent Codex",
+            endpointRef="default",
+            agentName="codex",
+            defaultPolicyRef="codex-static@1",
+            captureDefaults={"required": True, "retentionDays": 30},
+            readiness={"requiresProviderLaunchReady": True, "validationVersion": 1},
+        ),
+    )
+}
+
+
+def compile_effective_launch(
+    *, profile_ref: str, policy_ref: str | None, provider_profile_id: str
+) -> dict[str, Any]:
+    profile = PROFILES.get(profile_ref)
+    if profile is None or not profile.enabled:
+        raise OmnigentOAuthHostError(
+            "Omnigent execution profile is missing or disabled",
+            code="OMNIGENT_EXECUTION_PROFILE_UNAVAILABLE",
+        )
+    selected_policy_ref = policy_ref or profile.default_policy_ref
+    policy = POLICIES.get(selected_policy_ref)
+    if policy is None or not policy.enabled:
+        raise OmnigentOAuthHostError(
+            "Omnigent launch policy is missing or disabled",
+            code="OMNIGENT_LAUNCH_POLICY_UNAVAILABLE",
+        )
+    payload = {
+        "schemaVersion": 1,
+        "executionProfileRef": profile.ref,
+        "launchPolicyRef": policy.ref,
+        "providerProfileId": provider_profile_id,
+        "endpointRef": profile.endpoint_ref,
+        "agentName": profile.agent_name,
+        "harness": profile.harness,
+        **policy.model_dump(by_alias=True, mode="json"),
+        "capture": {**profile.capture_defaults, **policy.capture},
+    }
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    payload["snapshotRef"] = "omnigent-launch:sha256:" + hashlib.sha256(
+        canonical.encode()
+    ).hexdigest()
+    return payload
+
+
+def selection_from_request(
+    parameters: Mapping[str, Any] | None,
+) -> tuple[str | None, str | None]:
+    omnigent = parameters.get("omnigent") if isinstance(parameters, Mapping) else None
+    if not isinstance(omnigent, Mapping):
+        return None, None
+    forbidden = {
+        "hostid",
+        "host_id",
+        "volumename",
+        "volume_ref",
+        "credential",
+        "bindsource",
+        "absolutebindsource",
+    }
+
+    def contains_forbidden(value: object) -> bool:
+        if isinstance(value, Mapping):
+            return any(
+                str(key).replace("-", "").lower() in forbidden
+                or contains_forbidden(nested)
+                for key, nested in value.items()
+            )
+        if isinstance(value, (list, tuple)):
+            return any(contains_forbidden(item) for item in value)
+        return False
+
+    if contains_forbidden(omnigent):
+        raise OmnigentOAuthHostError(
+            "workflow request contains forbidden host or credential authority",
+            code="OMNIGENT_LAUNCH_POLICY_FORBIDDEN_INPUT",
+        )
+    profile_ref = str(omnigent.get("executionTargetRef") or "").strip() or None
+    policy_ref = str(omnigent.get("launchPolicyRef") or "").strip() or None
+    return profile_ref, policy_ref

--- a/moonmind/omnigent/execution_profiles.py
+++ b/moonmind/omnigent/execution_profiles.py
@@ -178,6 +178,23 @@ PROFILES = {
 }
 
 
+def public_execution_catalog() -> dict[str, Any]:
+    """Return the safe, product-selectable built-in catalog for Workflow Create."""
+
+    return {
+        "profiles": [
+            profile.model_dump(by_alias=True, mode="json") | {"ref": profile.ref}
+            for profile in PROFILES.values()
+            if profile.enabled
+        ],
+        "policies": [
+            policy.model_dump(by_alias=True, mode="json") | {"ref": policy.ref}
+            for policy in POLICIES.values()
+            if policy.enabled
+        ],
+    }
+
+
 def compile_effective_launch(
     *, profile_ref: str, policy_ref: str | None, provider_profile_id: str
 ) -> dict[str, Any]:

--- a/moonmind/omnigent/execution_profiles.py
+++ b/moonmind/omnigent/execution_profiles.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import re
 from typing import Any, Literal, Mapping
 
@@ -16,6 +17,7 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 from moonmind.omnigent.oauth_hosts import OmnigentOAuthHostError
 
 _DIGEST_IMAGE = re.compile(r"^[^\s@]+@sha256:[0-9a-f]{64}$")
+_PLACEHOLDER_DIGEST = "0" * 64
 _SAFE_REF = re.compile(r"^[a-z0-9][a-z0-9._:/-]{0,127}$")
 
 
@@ -74,8 +76,10 @@ class OmnigentLaunchPolicy(BaseModel):
                 ("server", self.server_image_ref),
                 ("host", self.host_image_ref),
             ):
-                if not _DIGEST_IMAGE.fullmatch(image):
+                if not (_DIGEST_IMAGE.fullmatch(image) or image.startswith("bootstrap://")):
                     raise ValueError(f"{label} image must use an immutable sha256 digest")
+                if image.endswith(_PLACEHOLDER_DIGEST):
+                    raise ValueError(f"{label} image digest must not be a placeholder")
         if not _SAFE_REF.fullmatch(self.network_ref) or self.network_ref.startswith(
             ("/", ".")
         ):
@@ -116,8 +120,11 @@ class OmnigentLaunchPolicy(BaseModel):
         return self
 
 
-_IMAGE = "ghcr.io/omnigent-ai/omnigent-host@sha256:" + "0" * 64
-_SERVER_IMAGE = "ghcr.io/omnigent-ai/omnigent@sha256:" + "0" * 64
+# Bootstrap values are resolved from operator-owned immutable configuration when
+# the catalog is compiled. Mutable tags and synthetic placeholder digests never
+# become product launch authority.
+_IMAGE = "bootstrap://OMNIGENT_HOST_IMAGE_REF"
+_SERVER_IMAGE = "bootstrap://OMNIGENT_IMAGE_REF"
 _COMMON = dict(
     serverImageRef=_SERVER_IMAGE,
     hostImageRef=_IMAGE,
@@ -135,8 +142,6 @@ _COMMON = dict(
         "oauth_home",
         "omnigent_state",
         "skills_tools",
-        "artifacts",
-        "cache",
     ),
     capture={"required": True, "retentionDays": 30},
     controlCapabilities=("interrupt", "terminate", "clear_context"),
@@ -211,6 +216,20 @@ def compile_effective_launch(
             "Omnigent launch policy is missing or disabled",
             code="OMNIGENT_LAUNCH_POLICY_UNAVAILABLE",
         )
+    policy_payload = policy.model_dump(by_alias=True, mode="json")
+    for field, variable in (
+        ("serverImageRef", "OMNIGENT_IMAGE_REF"),
+        ("hostImageRef", "OMNIGENT_HOST_IMAGE_REF"),
+    ):
+        value = policy_payload[field]
+        if str(value).startswith("bootstrap://"):
+            value = os.getenv(variable, "").strip()
+        if not _DIGEST_IMAGE.fullmatch(str(value)) or str(value).endswith(_PLACEHOLDER_DIGEST):
+            raise OmnigentOAuthHostError(
+                f"{variable} must name a deployable immutable sha256 image",
+                code="OMNIGENT_LAUNCH_IMAGE_UNREALIZABLE",
+            )
+        policy_payload[field] = value
     payload = {
         "schemaVersion": 1,
         "executionProfileRef": profile.ref,
@@ -219,7 +238,7 @@ def compile_effective_launch(
         "endpointRef": profile.endpoint_ref,
         "agentName": profile.agent_name,
         "harness": profile.harness,
-        **policy.model_dump(by_alias=True, mode="json"),
+        **policy_payload,
         "capture": {**profile.capture_defaults, **policy.capture},
     }
     canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"))

--- a/moonmind/omnigent/execution_profiles.py
+++ b/moonmind/omnigent/execution_profiles.py
@@ -229,6 +229,28 @@ def compile_effective_launch(
     return payload
 
 
+def validate_effective_launch_snapshot(snapshot: Mapping[str, Any]) -> None:
+    """Reject mutated or credential-bearing snapshots before they become authority."""
+
+    payload = dict(snapshot)
+    supplied_ref = str(payload.pop("snapshotRef", ""))
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    expected_ref = "omnigent-launch:sha256:" + hashlib.sha256(
+        canonical.encode()
+    ).hexdigest()
+    if supplied_ref != expected_ref:
+        raise OmnigentOAuthHostError(
+            "effective launch snapshot digest does not match its content",
+            code="OMNIGENT_EFFECTIVE_LAUNCH_CONFLICT",
+        )
+    serialized = canonical.lower()
+    if any(marker in serialized for marker in ("credential", "password", "token", "docker.sock")):
+        raise OmnigentOAuthHostError(
+            "effective launch snapshot contains forbidden authority",
+            code="OMNIGENT_EFFECTIVE_LAUNCH_FORBIDDEN_AUTHORITY",
+        )
+
+
 def selection_from_request(
     parameters: Mapping[str, Any] | None,
 ) -> tuple[str | None, str | None]:

--- a/moonmind/omnigent/oauth_host_runtime.py
+++ b/moonmind/omnigent/oauth_host_runtime.py
@@ -17,6 +17,7 @@ from moonmind.omnigent.oauth_hosts import (
     deterministic_host_container_name,
     validate_preflight_result,
 )
+from moonmind.omnigent.execution_profiles import validate_effective_launch_snapshot
 from moonmind.omnigent.mounted_tool_preflight import (
     MountedToolPreflightError,
     preflight_mounted_tools,
@@ -147,7 +148,9 @@ class OmnigentOAuthHostRuntime:
             await self._exec_check(container_name)
             await self._exec_tools_check(container_name)
         else:
-            await self._compose_static_check(skill_projection=skill_projection)
+            await self._compose_static_check(
+                skill_projection=skill_projection, effective_launch=launch
+            )
 
         host = await self._resolve_exact_host(binding=binding, host_lease=host_lease)
         host_id = str(host.get("id") or host.get("host_id") or host.get("hostId") or "")
@@ -208,6 +211,7 @@ class OmnigentOAuthHostRuntime:
                 code="OMNIGENT_EFFECTIVE_LAUNCH_REQUIRED",
             )
         launch = dict(effective_launch)
+        validate_effective_launch_snapshot(launch)
         expected_mode = (
             "on_demand_docker" if binding.host_launch_profile_ref else "static_compose"
         )
@@ -458,6 +462,12 @@ class OmnigentOAuthHostRuntime:
             "moonmind.workflow_id": "activity-owned",
             "moonmind.credential_generation": str(host_lease.credential_generation),
             "moonmind.expires_at": host_lease.expires_at.isoformat(),
+            "moonmind.effective_launch_ref": str(effective_launch["snapshotRef"]),
+            "moonmind.capture_required": str(effective_launch["capture"]["required"]).lower(),
+            "moonmind.capture_retention_days": str(effective_launch["capture"]["retentionDays"]),
+            "moonmind.cleanup_mode": str(effective_launch["cleanup"]["mode"]),
+            "moonmind.control_capabilities": ",".join(effective_launch["controlCapabilities"]),
+            "moonmind.timeout_seconds": str(effective_launch["limits"]["timeoutSeconds"]),
         }
         args = [
             "docker",
@@ -477,6 +487,8 @@ class OmnigentOAuthHostRuntime:
             f"{effective_launch['limits']['memoryMiB']}m",
             "--pids-limit",
             str(effective_launch["limits"]["processes"]),
+            "--stop-timeout",
+            str(effective_launch["limits"]["timeoutSeconds"]),
             "--read-only",
             "--tmpfs",
             f"/tmp:rw,noexec,nosuid,size={effective_launch['limits']['temporaryStorageMiB']}m",
@@ -689,10 +701,44 @@ class OmnigentOAuthHostRuntime:
             "omnigent-tools-init",
         )
 
-    async def _compose_static_check(self, *, skill_projection: Path | None = None) -> None:
+    async def _compose_static_check(
+        self,
+        *,
+        skill_projection: Path | None = None,
+        effective_launch: Mapping[str, Any] | None = None,
+    ) -> None:
         child_env = dict(os.environ)
         if skill_projection is not None:
             child_env["OMNIGENT_ACTIVE_SKILLS_DIR"] = str(skill_projection)
+        if effective_launch is not None:
+            child_env.update(
+                {
+                    "OMNIGENT_HOST_IMAGE_REF": str(effective_launch["hostImageRef"]),
+                    "OMNIGENT_IMAGE_REF": str(effective_launch["serverImageRef"]),
+                    "OMNIGENT_EFFECTIVE_LAUNCH_REF": str(effective_launch["snapshotRef"]),
+                    "OMNIGENT_HOST_CPU_LIMIT": str(
+                        int(effective_launch["limits"]["cpuMillis"]) / 1000
+                    ),
+                    "OMNIGENT_HOST_MEMORY_LIMIT": (
+                        f"{effective_launch['limits']['memoryMiB']}m"
+                    ),
+                    "OMNIGENT_HOST_PIDS_LIMIT": str(
+                        effective_launch["limits"]["processes"]
+                    ),
+                    "OMNIGENT_HOST_TMPFS_LIMIT": (
+                        f"{effective_launch['limits']['temporaryStorageMiB']}m"
+                    ),
+                    "OMNIGENT_HOST_TIMEOUT_SECONDS": str(
+                        effective_launch["limits"]["timeoutSeconds"]
+                    ),
+                    "OMNIGENT_CAPTURE_RETENTION_DAYS": str(
+                        effective_launch["capture"]["retentionDays"]
+                    ),
+                    "OMNIGENT_CONTROL_CAPABILITIES": ",".join(
+                        effective_launch["controlCapabilities"]
+                    ),
+                }
+            )
         await self._run(
             "docker",
             "compose",

--- a/moonmind/omnigent/oauth_host_runtime.py
+++ b/moonmind/omnigent/oauth_host_runtime.py
@@ -6,6 +6,7 @@ import asyncio
 import hashlib
 import os
 import shutil
+import re
 from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
@@ -51,6 +52,8 @@ _TOOLS_PATH = "/opt/moonmind-tools/bin"
 _DEFAULT_HOST_PATH = (
     "/opt/venv/bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin"
 )
+_DIGEST_IMAGE = re.compile(r"^[^\s@]+@sha256:[0-9a-f]{64}$")
+_SAFE_NETWORK = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_.-]{0,127}$")
 
 
 class OmnigentOAuthHostRuntime:
@@ -108,7 +111,13 @@ class OmnigentOAuthHostRuntime:
         required_capabilities: tuple[str, ...] = (),
         github_token: str | None = None,
         github_mutation_required: bool = False,
+        effective_launch: Mapping[str, Any] | None = None,
     ) -> dict[str, Any]:
+        # Validate the complete product-owned decision before materializing skills,
+        # cloning a repository, creating volumes, or starting a container.
+        launch = self._validate_effective_launch(
+            binding=binding, effective_launch=effective_launch
+        )
         skill_projection = await self._prepare_skill_projection(
             workspace_key=workspace_key,
             resolved_skillset_ref=resolved_skillset_ref,
@@ -133,6 +142,7 @@ class OmnigentOAuthHostRuntime:
                 workspace_source=workspace_source,
                 skill_projection=skill_projection,
                 github_token=github_token,
+                effective_launch=launch,
             )
             await self._exec_check(container_name)
             await self._exec_tools_check(container_name)
@@ -185,6 +195,77 @@ class OmnigentOAuthHostRuntime:
         validated["activeSkillsPath"] = str(skill_projection)
         validated["mountedTools"] = mounted_tool_evidence
         return validated
+
+    @staticmethod
+    def _validate_effective_launch(
+        *,
+        binding: OmnigentOAuthHostBinding,
+        effective_launch: Mapping[str, Any] | None,
+    ) -> dict[str, Any]:
+        if not isinstance(effective_launch, Mapping):
+            raise OmnigentOAuthHostError(
+                "effective launch policy is required before host mutation",
+                code="OMNIGENT_EFFECTIVE_LAUNCH_REQUIRED",
+            )
+        launch = dict(effective_launch)
+        expected_mode = (
+            "on_demand_docker" if binding.host_launch_profile_ref else "static_compose"
+        )
+        if launch.get("hostMode") != expected_mode:
+            raise OmnigentOAuthHostError(
+                "effective launch host mode conflicts with the durable binding",
+                code="OMNIGENT_LAUNCH_POLICY_BINDING_CONFLICT",
+            )
+        if not str(launch.get("snapshotRef") or "").startswith(
+            "omnigent-launch:sha256:"
+        ):
+            raise OmnigentOAuthHostError(
+                "effective launch snapshot reference is invalid",
+                code="OMNIGENT_EFFECTIVE_LAUNCH_INVALID",
+            )
+        if not _DIGEST_IMAGE.fullmatch(str(launch.get("hostImageRef") or "")):
+            raise OmnigentOAuthHostError(
+                "host image must be an immutable sha256 reference",
+                code="OMNIGENT_LAUNCH_IMAGE_UNREALIZABLE",
+            )
+        network = str(launch.get("networkRef") or "")
+        if not _SAFE_NETWORK.fullmatch(network):
+            raise OmnigentOAuthHostError(
+                "network must be a named deployment network",
+                code="OMNIGENT_LAUNCH_NETWORK_UNREALIZABLE",
+            )
+        limits = launch.get("limits")
+        required_limits = {
+            "cpuMillis", "memoryMiB", "processes", "timeoutSeconds",
+            "temporaryStorageMiB",
+        }
+        if not isinstance(limits, Mapping) or set(limits) != required_limits or any(
+            not isinstance(limits[key], int) or limits[key] <= 0
+            for key in required_limits
+        ):
+            raise OmnigentOAuthHostError(
+                "launch resource limits are incomplete or invalid",
+                code="OMNIGENT_LAUNCH_RESOURCES_UNREALIZABLE",
+            )
+        required_mounts = {
+            "workspace", "oauth_home", "omnigent_state", "skills_tools", "artifacts", "cache"
+        }
+        if set(launch.get("mountClasses") or ()) != required_mounts:
+            raise OmnigentOAuthHostError(
+                "launch mount classes cannot be realized by the Codex host",
+                code="OMNIGENT_LAUNCH_MOUNTS_UNREALIZABLE",
+            )
+        if not launch.get("enforcedEgress"):
+            raise OmnigentOAuthHostError(
+                "launch policy must enforce egress",
+                code="OMNIGENT_LAUNCH_EGRESS_UNREALIZABLE",
+            )
+        if launch.get("runtimeUid") != 1000 or launch.get("runtimeGid") != 1000:
+            raise OmnigentOAuthHostError(
+                "Codex host UID/GID policy is unrealizable",
+                code="OMNIGENT_LAUNCH_IDENTITY_UNREALIZABLE",
+            )
+        return launch
 
     async def _prepare_skill_projection(
         self,
@@ -301,6 +382,7 @@ class OmnigentOAuthHostRuntime:
         workspace_source: Path,
         skill_projection: Path,
         github_token: str | None = None,
+        effective_launch: Mapping[str, Any],
     ) -> None:
         if await self.container_exists(container_name):
             return
@@ -325,7 +407,7 @@ class OmnigentOAuthHostRuntime:
             f"type=bind,src={self._scripts_dir},dst=/opt/moonmind,readonly",
             "--entrypoint",
             "/opt/moonmind/init-codex-oauth-host.sh",
-            self._image,
+            str(effective_launch["hostImageRef"]),
         )
         labels = {
             "moonmind.kind": "omnigent-oauth-host",
@@ -343,14 +425,20 @@ class OmnigentOAuthHostRuntime:
             "--name",
             container_name,
             "--user",
-            "1000:1000",
+            f"{effective_launch['runtimeUid']}:{effective_launch['runtimeGid']}",
             "--workdir",
             "/home/app",
             "--network",
-            self._network,
+            str(effective_launch["networkRef"]),
+            "--cpus",
+            str(int(effective_launch["limits"]["cpuMillis"]) / 1000),
+            "--memory",
+            f"{effective_launch['limits']['memoryMiB']}m",
+            "--pids-limit",
+            str(effective_launch["limits"]["processes"]),
             "--read-only",
             "--tmpfs",
-            "/tmp:rw,noexec,nosuid,size=256m",
+            f"/tmp:rw,noexec,nosuid,size={effective_launch['limits']['temporaryStorageMiB']}m",
             "--mount",
             f"type=volume,src={mount.auth_volume_ref.volume_ref},dst=/home/app/.codex",
             "--mount",

--- a/moonmind/omnigent/oauth_host_runtime.py
+++ b/moonmind/omnigent/oauth_host_runtime.py
@@ -228,6 +228,11 @@ class OmnigentOAuthHostRuntime:
                 "host image must be an immutable sha256 reference",
                 code="OMNIGENT_LAUNCH_IMAGE_UNREALIZABLE",
             )
+        if not _DIGEST_IMAGE.fullmatch(str(launch.get("serverImageRef") or "")):
+            raise OmnigentOAuthHostError(
+                "server image must be an immutable sha256 reference",
+                code="OMNIGENT_LAUNCH_IMAGE_UNREALIZABLE",
+            )
         network = str(launch.get("networkRef") or "")
         if not _SAFE_NETWORK.fullmatch(network):
             raise OmnigentOAuthHostError(
@@ -264,6 +269,42 @@ class OmnigentOAuthHostRuntime:
             raise OmnigentOAuthHostError(
                 "Codex host UID/GID policy is unrealizable",
                 code="OMNIGENT_LAUNCH_IDENTITY_UNREALIZABLE",
+            )
+        if launch.get("readOnlyRoot") is not True:
+            raise OmnigentOAuthHostError(
+                "Codex host policy must require a read-only root filesystem",
+                code="OMNIGENT_LAUNCH_ROOT_UNREALIZABLE",
+            )
+        capture = launch.get("capture")
+        if (
+            not isinstance(capture, Mapping)
+            or capture.get("required") is not True
+            or not isinstance(capture.get("retentionDays"), int)
+            or capture["retentionDays"] <= 0
+        ):
+            raise OmnigentOAuthHostError(
+                "launch capture and retention policy is unrealizable",
+                code="OMNIGENT_LAUNCH_CAPTURE_UNREALIZABLE",
+            )
+        cleanup = launch.get("cleanup")
+        expected_cleanup = "remove" if expected_mode == "on_demand_docker" else "drain"
+        if (
+            not isinstance(cleanup, Mapping)
+            or cleanup.get("mode") != expected_cleanup
+            or cleanup.get("janitor") is not True
+        ):
+            raise OmnigentOAuthHostError(
+                "launch cleanup and janitor policy is unrealizable",
+                code="OMNIGENT_LAUNCH_CLEANUP_UNREALIZABLE",
+            )
+        if set(launch.get("controlCapabilities") or ()) != {
+            "interrupt",
+            "terminate",
+            "clear_context",
+        }:
+            raise OmnigentOAuthHostError(
+                "launch control capabilities are unrealizable",
+                code="OMNIGENT_LAUNCH_CONTROLS_UNREALIZABLE",
             )
         return launch
 

--- a/moonmind/omnigent/oauth_host_runtime.py
+++ b/moonmind/omnigent/oauth_host_runtime.py
@@ -54,6 +54,7 @@ _DEFAULT_HOST_PATH = (
     "/opt/venv/bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin"
 )
 _DIGEST_IMAGE = re.compile(r"^[^\s@]+@sha256:[0-9a-f]{64}$")
+_PLACEHOLDER_DIGEST = "0" * 64
 _SAFE_NETWORK = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_.-]{0,127}$")
 
 
@@ -227,12 +228,14 @@ class OmnigentOAuthHostRuntime:
                 "effective launch snapshot reference is invalid",
                 code="OMNIGENT_EFFECTIVE_LAUNCH_INVALID",
             )
-        if not _DIGEST_IMAGE.fullmatch(str(launch.get("hostImageRef") or "")):
+        if (not _DIGEST_IMAGE.fullmatch(str(launch.get("hostImageRef") or ""))
+                or str(launch.get("hostImageRef")).endswith(_PLACEHOLDER_DIGEST)):
             raise OmnigentOAuthHostError(
                 "host image must be an immutable sha256 reference",
                 code="OMNIGENT_LAUNCH_IMAGE_UNREALIZABLE",
             )
-        if not _DIGEST_IMAGE.fullmatch(str(launch.get("serverImageRef") or "")):
+        if (not _DIGEST_IMAGE.fullmatch(str(launch.get("serverImageRef") or ""))
+                or str(launch.get("serverImageRef")).endswith(_PLACEHOLDER_DIGEST)):
             raise OmnigentOAuthHostError(
                 "server image must be an immutable sha256 reference",
                 code="OMNIGENT_LAUNCH_IMAGE_UNREALIZABLE",
@@ -257,7 +260,7 @@ class OmnigentOAuthHostRuntime:
                 code="OMNIGENT_LAUNCH_RESOURCES_UNREALIZABLE",
             )
         required_mounts = {
-            "workspace", "oauth_home", "omnigent_state", "skills_tools", "artifacts", "cache"
+            "workspace", "oauth_home", "omnigent_state", "skills_tools"
         }
         if set(launch.get("mountClasses") or ()) != required_mounts:
             raise OmnigentOAuthHostError(
@@ -488,7 +491,7 @@ class OmnigentOAuthHostRuntime:
             "--pids-limit",
             str(effective_launch["limits"]["processes"]),
             "--stop-timeout",
-            str(effective_launch["limits"]["timeoutSeconds"]),
+            "20",
             "--read-only",
             "--tmpfs",
             f"/tmp:rw,noexec,nosuid,size={effective_launch['limits']['temporaryStorageMiB']}m",
@@ -522,6 +525,14 @@ class OmnigentOAuthHostRuntime:
             f"OMNIGENT_SERVER_URL={self._server_url}",
             "--env",
             "MOONMIND_ACTIVE_SKILLS_DIR=/opt/moonmind-skills",
+            "--env",
+            f"OMNIGENT_EXECUTION_TIMEOUT_SECONDS={effective_launch['limits']['timeoutSeconds']}",
+            "--env",
+            "OMNIGENT_EXECUTION_TIMEOUT_OWNER=temporal_workflow",
+            "--env",
+            "OMNIGENT_CAPTURE_OWNER=moonmind_bridge",
+            "--env",
+            f"OMNIGENT_CAPTURE_RETENTION_DAYS={effective_launch['capture']['retentionDays']}",
             "--env",
             "PATH=/opt/moonmind-tools/bin:/opt/venv/bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin",
         ]
@@ -734,6 +745,8 @@ class OmnigentOAuthHostRuntime:
                     "OMNIGENT_CAPTURE_RETENTION_DAYS": str(
                         effective_launch["capture"]["retentionDays"]
                     ),
+                    "OMNIGENT_CAPTURE_OWNER": "moonmind_bridge",
+                    "OMNIGENT_EXECUTION_TIMEOUT_OWNER": "temporal_workflow",
                     "OMNIGENT_CONTROL_CAPABILITIES": ",".join(
                         effective_launch["controlCapabilities"]
                     ),

--- a/moonmind/omnigent/oauth_host_runtime.py
+++ b/moonmind/omnigent/oauth_host_runtime.py
@@ -436,7 +436,8 @@ class OmnigentOAuthHostRuntime:
             return
         mount = binding.credential_mount_ref
         state_volume = f"{container_name}-state"
-        host_path = await self._discover_upstream_path()
+        host_image_ref = str(effective_launch["hostImageRef"])
+        host_path = await self._discover_upstream_path(host_image_ref)
         # A retry may find a stopped container with this deterministic name.
         # Remove only that lease-owned container, then initialize the dedicated
         # state volume as root before the actual host drops to UID/GID 1000.
@@ -455,7 +456,7 @@ class OmnigentOAuthHostRuntime:
             f"type=bind,src={self._scripts_dir},dst=/opt/moonmind,readonly",
             "--entrypoint",
             "/opt/moonmind/init-codex-oauth-host.sh",
-            str(effective_launch["hostImageRef"]),
+            host_image_ref,
         )
         labels = {
             "moonmind.kind": "omnigent-oauth-host",
@@ -571,10 +572,10 @@ class OmnigentOAuthHostRuntime:
         args.extend(["--entrypoint", "/usr/bin/env"])
         for key in _FORBIDDEN_ENV:
             args.extend(["-u", key])
-        args.extend([self._image, "/opt/moonmind/start-codex-oauth-host.sh"])
+        args.extend([host_image_ref, "/opt/moonmind/start-codex-oauth-host.sh"])
         await self._run(*args, env=child_env)
 
-    async def _discover_upstream_path(self) -> str:
+    async def _discover_upstream_path(self, image_ref: str) -> str:
         """Read the selected image's PATH without replacing image-specific entries."""
         result = await self._run(
             "docker",
@@ -582,7 +583,7 @@ class OmnigentOAuthHostRuntime:
             "inspect",
             "--format",
             "{{range .Config.Env}}{{println .}}{{end}}",
-            self._image,
+            image_ref,
             check=False,
         )
         if result[0] == 0:

--- a/moonmind/omnigent/oauth_hosts.py
+++ b/moonmind/omnigent/oauth_hosts.py
@@ -151,6 +151,9 @@ class OmnigentOAuthHostRepository:
             maxSessionsPerHost=1,
             staticHostId=record.static_host_id,
             hostLaunchProfileRef=record.host_launch_profile_ref,
+            executionProfileRef=record.execution_profile_ref,
+            launchPolicyRef=record.launch_policy_ref,
+            effectiveLaunchSnapshot=record.effective_launch_snapshot_json,
         )
 
     async def get_binding_for_profile(
@@ -176,6 +179,9 @@ class OmnigentOAuthHostRepository:
         endpoint_ref: str,
         static_host_id: str | None = None,
         host_launch_profile_ref: str | None = None,
+        execution_profile_ref: str | None = None,
+        launch_policy_ref: str | None = None,
+        effective_launch_snapshot: dict[str, Any] | None = None,
     ) -> OmnigentOAuthHostBinding:
         if static_host_id and host_launch_profile_ref:
             raise ValueError(
@@ -203,6 +209,9 @@ class OmnigentOAuthHostRepository:
                     ),
                     static_host_id=static_host_id,
                     host_launch_profile_ref=host_launch_profile_ref,
+                    execution_profile_ref=execution_profile_ref,
+                    launch_policy_ref=launch_policy_ref,
+                    effective_launch_snapshot_json=effective_launch_snapshot,
                 )
                 session.add(record)
             else:
@@ -213,6 +222,10 @@ class OmnigentOAuthHostRepository:
                 )
                 record.static_host_id = static_host_id
                 record.host_launch_profile_ref = host_launch_profile_ref
+                if effective_launch_snapshot is not None:
+                    record.execution_profile_ref = execution_profile_ref
+                    record.launch_policy_ref = launch_policy_ref
+                    record.effective_launch_snapshot_json = effective_launch_snapshot
             await session.commit()
             await session.refresh(record)
             return self._binding_model(record, profile)

--- a/moonmind/omnigent/oauth_hosts.py
+++ b/moonmind/omnigent/oauth_hosts.py
@@ -303,6 +303,11 @@ class OmnigentOAuthHostRepository:
                     raise OmnigentOAuthHostError(
                         "idempotency key is already bound to another host lease"
                     )
+                if existing.effective_launch_snapshot_json != binding.effective_launch_snapshot:
+                    raise OmnigentOAuthHostError(
+                        "retry launch snapshot does not match the durable host lease",
+                        code="OMNIGENT_LAUNCH_SNAPSHOT_CONFLICT",
+                    )
                 return self._lease_model(existing)
             record = OmnigentOAuthHostLeaseRecord(
                 lease_id=lease_id,
@@ -314,6 +319,7 @@ class OmnigentOAuthHostRepository:
                 agent_run_id=agent_run_id,
                 idempotency_key=idempotency_key,
                 lease_purpose=lease_purpose,
+                effective_launch_snapshot_json=binding.effective_launch_snapshot,
                 container_name=(
                     deterministic_host_container_name(lease_id)
                     if binding.host_launch_profile_ref
@@ -356,6 +362,7 @@ class OmnigentOAuthHostRepository:
             omnigentHostId=record.omnigent_host_id,
             omnigentSessionId=record.omnigent_session_id,
             bridgeSessionId=record.bridge_session_id,
+            effectiveLaunchSnapshot=record.effective_launch_snapshot_json,
             status=record.status,
             acquiredAt=record.acquired_at,
             lastHeartbeatAt=record.last_heartbeat_at,

--- a/moonmind/omnigent/profile_bound_execution.py
+++ b/moonmind/omnigent/profile_bound_execution.py
@@ -294,16 +294,19 @@ class OmnigentProfileBoundExecutionCoordinator:
                             code="OMNIGENT_LAUNCH_POLICY_BINDING_CONFLICT",
                         )
             elif binding is not None:
-                retry_policy = (
-                    "codex-on-demand@1"
-                    if binding.host_launch_profile_ref
-                    else "codex-static@1"
-                )
-                effective_launch = compile_effective_launch(
-                    profile_ref="omnigent-codex@1",
-                    policy_ref=retry_policy,
-                    provider_profile_id=profile_id,
-                )
+                if binding.effective_launch_snapshot is not None:
+                    effective_launch = dict(binding.effective_launch_snapshot)
+                else:
+                    retry_policy = (
+                        "codex-on-demand@1"
+                        if binding.host_launch_profile_ref
+                        else "codex-static@1"
+                    )
+                    effective_launch = compile_effective_launch(
+                        profile_ref="omnigent-codex@1",
+                        policy_ref=retry_policy,
+                        provider_profile_id=profile_id,
+                    )
             else:
                 bootstrap_on_demand = bool(
                     os.getenv("OMNIGENT_CODEX_HOST_LAUNCH_PROFILE")
@@ -376,6 +379,9 @@ class OmnigentProfileBoundExecutionCoordinator:
                         if selected_on_demand
                         else None
                     ),
+                    execution_profile_ref=str(effective_launch["executionProfileRef"]),
+                    launch_policy_ref=str(effective_launch["launchPolicyRef"]),
+                    effective_launch_snapshot=effective_launch,
                 )
             await emit(
                 current_stage,
@@ -435,6 +441,7 @@ class OmnigentProfileBoundExecutionCoordinator:
                 required_capabilities=self._required_capabilities(request),
                 github_token=github_token,
                 github_mutation_required=self._github_mutation_required(request),
+                effective_launch=effective_launch,
             )
             await emit(current_stage, "completed")
             await emit("credential_mount", "started")

--- a/moonmind/omnigent/profile_bound_execution.py
+++ b/moonmind/omnigent/profile_bound_execution.py
@@ -276,7 +276,17 @@ class OmnigentProfileBoundExecutionCoordinator:
                 request.parameters
             )
             binding = await self._hosts.get_binding_for_profile(profile_id)
-            if requested_target:
+            if binding is not None and binding.effective_launch_snapshot is not None:
+                effective_launch = dict(binding.effective_launch_snapshot)
+                if requested_target and (
+                    effective_launch.get("executionProfileRef") != requested_target
+                    or effective_launch.get("launchPolicyRef") != requested_policy
+                ):
+                    raise OmnigentOAuthHostError(
+                        "explicit launch selection conflicts with the durable host binding",
+                        code="OMNIGENT_LAUNCH_POLICY_BINDING_CONFLICT",
+                    )
+            elif requested_target:
                 effective_launch = compile_effective_launch(
                     profile_ref=requested_target,
                     policy_ref=requested_policy,
@@ -294,13 +304,10 @@ class OmnigentProfileBoundExecutionCoordinator:
                             code="OMNIGENT_LAUNCH_POLICY_BINDING_CONFLICT",
                         )
             elif binding is not None:
-                if binding.effective_launch_snapshot is not None:
-                    effective_launch = dict(binding.effective_launch_snapshot)
-                else:
-                    raise OmnigentOAuthHostError(
-                        "durable host binding predates effective launch authority",
-                        code="OMNIGENT_LEGACY_BINDING_REQUIRES_RESELECTION",
-                    )
+                raise OmnigentOAuthHostError(
+                    "durable host binding predates effective launch authority",
+                    code="OMNIGENT_LEGACY_BINDING_REQUIRES_RESELECTION",
+                )
             else:
                 bootstrap_on_demand = bool(
                     os.getenv("OMNIGENT_CODEX_HOST_LAUNCH_PROFILE")

--- a/moonmind/omnigent/profile_bound_execution.py
+++ b/moonmind/omnigent/profile_bound_execution.py
@@ -303,11 +303,6 @@ class OmnigentProfileBoundExecutionCoordinator:
                             "explicit launch policy conflicts with the durable host binding",
                             code="OMNIGENT_LAUNCH_POLICY_BINDING_CONFLICT",
                         )
-            elif binding is not None:
-                raise OmnigentOAuthHostError(
-                    "durable host binding predates effective launch authority",
-                    code="OMNIGENT_LEGACY_BINDING_REQUIRES_RESELECTION",
-                )
             else:
                 bootstrap_on_demand = bool(
                     os.getenv("OMNIGENT_CODEX_HOST_LAUNCH_PROFILE")

--- a/moonmind/omnigent/profile_bound_execution.py
+++ b/moonmind/omnigent/profile_bound_execution.py
@@ -304,8 +304,10 @@ class OmnigentProfileBoundExecutionCoordinator:
                             code="OMNIGENT_LAUNCH_POLICY_BINDING_CONFLICT",
                         )
             else:
-                bootstrap_on_demand = bool(
-                    os.getenv("OMNIGENT_CODEX_HOST_LAUNCH_PROFILE")
+                bootstrap_on_demand = (
+                    bool(binding.host_launch_profile_ref)
+                    if binding is not None
+                    else bool(os.getenv("OMNIGENT_CODEX_HOST_LAUNCH_PROFILE"))
                 )
                 effective_launch = compile_effective_launch(
                     profile_ref="omnigent-codex@1",

--- a/moonmind/omnigent/profile_bound_execution.py
+++ b/moonmind/omnigent/profile_bound_execution.py
@@ -275,6 +275,8 @@ class OmnigentProfileBoundExecutionCoordinator:
             requested_target, requested_policy = selection_from_request(
                 request.parameters
             )
+            current_stage = "host_binding_resolution"
+            await emit(current_stage, "started")
             binding = await self._hosts.get_binding_for_profile(profile_id)
             if binding is not None and binding.effective_launch_snapshot is not None:
                 effective_launch = dict(binding.effective_launch_snapshot)
@@ -361,7 +363,6 @@ class OmnigentProfileBoundExecutionCoordinator:
                 },
             )
             current_stage = "host_binding_resolution"
-            await emit(current_stage, "started")
             if binding is None:
                 selected_on_demand = effective_launch["hostMode"] == "on_demand_docker"
                 binding = await self._hosts.create_or_update_static_binding(

--- a/moonmind/omnigent/profile_bound_execution.py
+++ b/moonmind/omnigent/profile_bound_execution.py
@@ -22,6 +22,10 @@ from moonmind.omnigent.checkpoints import (
     validate_cold_restore_target,
 )
 from moonmind.omnigent.oauth_host_runtime import OmnigentOAuthHostRuntime
+from moonmind.omnigent.execution_profiles import (
+    compile_effective_launch,
+    selection_from_request,
+)
 from moonmind.omnigent.mounted_tool_preflight import MountedToolPreflightError
 from moonmind.omnigent.oauth_hosts import (
     OmnigentOAuthHostError,
@@ -239,6 +243,7 @@ class OmnigentProfileBoundExecutionCoordinator:
         provider_lease: CredentialLease | None = None
         host_lease = None
         binding = None
+        effective_launch: dict[str, Any] | None = None
         terminal_status = "completed"
         try:
             await emit("request_validated", "started")
@@ -264,6 +269,59 @@ class OmnigentProfileBoundExecutionCoordinator:
                     code="profile_readiness_failed",
                 )
             await emit(current_stage, "ready")
+            # Resolve product-owned launch authority before acquiring a Provider
+            # Profile lease or mutating host state.  A previously persisted
+            # binding is retry authority; environment input is bootstrap-only.
+            requested_target, requested_policy = selection_from_request(
+                request.parameters
+            )
+            binding = await self._hosts.get_binding_for_profile(profile_id)
+            if requested_target:
+                effective_launch = compile_effective_launch(
+                    profile_ref=requested_target,
+                    policy_ref=requested_policy,
+                    provider_profile_id=profile_id,
+                )
+                if binding is not None:
+                    bound_mode = (
+                        "on_demand_docker"
+                        if binding.host_launch_profile_ref
+                        else "static_compose"
+                    )
+                    if effective_launch["hostMode"] != bound_mode:
+                        raise OmnigentOAuthHostError(
+                            "explicit launch policy conflicts with the durable host binding",
+                            code="OMNIGENT_LAUNCH_POLICY_BINDING_CONFLICT",
+                        )
+            elif binding is not None:
+                retry_policy = (
+                    "codex-on-demand@1"
+                    if binding.host_launch_profile_ref
+                    else "codex-static@1"
+                )
+                effective_launch = compile_effective_launch(
+                    profile_ref="omnigent-codex@1",
+                    policy_ref=retry_policy,
+                    provider_profile_id=profile_id,
+                )
+            else:
+                bootstrap_on_demand = bool(
+                    os.getenv("OMNIGENT_CODEX_HOST_LAUNCH_PROFILE")
+                )
+                effective_launch = compile_effective_launch(
+                    profile_ref="omnigent-codex@1",
+                    policy_ref=(
+                        "codex-on-demand@1"
+                        if bootstrap_on_demand
+                        else "codex-static@1"
+                    ),
+                    provider_profile_id=profile_id,
+                )
+            await emit(
+                "effective_launch_compiled",
+                "completed",
+                metadata={"effectiveLaunch": effective_launch},
+            )
             owner_id = deterministic_lease_owner_id(
                 profile_id=profile_id,
                 purpose=CredentialLeasePurpose.EXECUTION_OMNIGENT,
@@ -303,20 +361,29 @@ class OmnigentProfileBoundExecutionCoordinator:
             )
             current_stage = "host_binding_resolution"
             await emit(current_stage, "started")
-            binding = await self._hosts.get_binding_for_profile(profile_id)
             if binding is None:
+                selected_on_demand = effective_launch["hostMode"] == "on_demand_docker"
                 binding = await self._hosts.create_or_update_static_binding(
                     profile_id=profile_id,
-                    endpoint_ref="default",
+                    endpoint_ref=str(effective_launch["endpointRef"]),
                     static_host_id=None,
                     host_launch_profile_ref=(
-                        os.getenv("OMNIGENT_CODEX_HOST_LAUNCH_PROFILE") or None
+                        (
+                            "codex-on-demand@1"
+                            if requested_target
+                            else os.getenv("OMNIGENT_CODEX_HOST_LAUNCH_PROFILE")
+                        )
+                        if selected_on_demand
+                        else None
                     ),
                 )
             await emit(
                 current_stage,
                 "completed",
-                metadata={"hostBindingRef": binding.binding_ref},
+                metadata={
+                    "hostBindingRef": binding.binding_ref,
+                    "effectiveLaunchRef": effective_launch["snapshotRef"],
+                },
             )
             current_stage = "host_lease_created"
             await emit(current_stage, "started")
@@ -447,7 +514,7 @@ class OmnigentProfileBoundExecutionCoordinator:
                     request,
                     host_id=host_id,
                     workspace_path=str(preflight["workspacePath"]),
-                    profile_authorization={
+                profile_authorization={
                         "providerProfileId": profile_id,
                         "credentialGeneration": host_lease.credential_generation,
                         "providerLeaseRef": provider_lease.lease_id,
@@ -456,6 +523,7 @@ class OmnigentProfileBoundExecutionCoordinator:
                         "endpointRef": binding.endpoint_ref,
                         "omnigentHostId": host_id,
                         "bridgeSessionId": bridge.bridge_session_id,
+                        "effectiveLaunchRef": effective_launch["snapshotRef"],
                     },
                 ),
                 artifact_gateway=self._artifact_gateway,

--- a/moonmind/omnigent/profile_bound_execution.py
+++ b/moonmind/omnigent/profile_bound_execution.py
@@ -297,15 +297,9 @@ class OmnigentProfileBoundExecutionCoordinator:
                 if binding.effective_launch_snapshot is not None:
                     effective_launch = dict(binding.effective_launch_snapshot)
                 else:
-                    retry_policy = (
-                        "codex-on-demand@1"
-                        if binding.host_launch_profile_ref
-                        else "codex-static@1"
-                    )
-                    effective_launch = compile_effective_launch(
-                        profile_ref="omnigent-codex@1",
-                        policy_ref=retry_policy,
-                        provider_profile_id=profile_id,
+                    raise OmnigentOAuthHostError(
+                        "durable host binding predates effective launch authority",
+                        code="OMNIGENT_LEGACY_BINDING_REQUIRES_RESELECTION",
                     )
             else:
                 bootstrap_on_demand = bool(
@@ -416,6 +410,7 @@ class OmnigentProfileBoundExecutionCoordinator:
                 host_binding_ref=binding.binding_ref,
                 host_lease_ref=host_lease.lease_id,
                 omnigent_host_id=binding.static_host_id,
+                effective_launch_snapshot=effective_launch,
             )
             if host_lease.status == "allocating":
                 host_lease = await self._hosts.transition_host_lease(
@@ -486,6 +481,7 @@ class OmnigentProfileBoundExecutionCoordinator:
                 host_binding_ref=binding.binding_ref,
                 host_lease_ref=host_lease.lease_id,
                 omnigent_host_id=host_id,
+                effective_launch_snapshot=effective_launch,
             )
             await emit("credential_preflight", "started")
             await emit(

--- a/moonmind/schemas/agent_runtime_models.py
+++ b/moonmind/schemas/agent_runtime_models.py
@@ -1014,6 +1014,11 @@ class OmnigentOAuthHostBinding(BaseModel):
     max_sessions_per_host: Literal[1] = Field(1, alias="maxSessionsPerHost")
     static_host_id: str | None = Field(None, alias="staticHostId")
     host_launch_profile_ref: str | None = Field(None, alias="hostLaunchProfileRef")
+    execution_profile_ref: str | None = Field(None, alias="executionProfileRef")
+    launch_policy_ref: str | None = Field(None, alias="launchPolicyRef")
+    effective_launch_snapshot: dict[str, Any] | None = Field(
+        None, alias="effectiveLaunchSnapshot"
+    )
 
     @model_validator(mode="after")
     def _validate_profile_ownership(self) -> "OmnigentOAuthHostBinding":

--- a/moonmind/schemas/agent_runtime_models.py
+++ b/moonmind/schemas/agent_runtime_models.py
@@ -1047,6 +1047,9 @@ class OmnigentHostLease(BaseModel):
     omnigent_host_id: str | None = Field(None, alias="omnigentHostId")
     omnigent_session_id: str | None = Field(None, alias="omnigentSessionId")
     bridge_session_id: str | None = Field(None, alias="bridgeSessionId")
+    effective_launch_snapshot: dict[str, Any] | None = Field(
+        None, alias="effectiveLaunchSnapshot"
+    )
     status: Literal[
         "allocating", "starting", "ready", "assigned", "draining", "stopped", "failed"
     ]

--- a/tests/integration/temporal/test_compose_foundation.py
+++ b/tests/integration/temporal/test_compose_foundation.py
@@ -633,7 +633,12 @@ def test_omnigent_codex_host_profile_uses_only_canonical_oauth_credentials():
         "CODEX_VOLUME_PATH": "/home/app/.codex",
         "CODEX_CREDENTIAL_GENERATION": "${CODEX_CREDENTIAL_GENERATION:-1}",
         "OMNIGENT_SERVER_URL": "http://omnigent:8000",
+        "OMNIGENT_EXECUTION_TIMEOUT_SECONDS": "${OMNIGENT_HOST_TIMEOUT_SECONDS:-5400}",
+        "OMNIGENT_EXECUTION_TIMEOUT_OWNER": "temporal_workflow",
+        "OMNIGENT_CAPTURE_OWNER": "moonmind_bridge",
+        "OMNIGENT_CAPTURE_RETENTION_DAYS": "${OMNIGENT_CAPTURE_RETENTION_DAYS:-30}",
     }
+    assert host_service["stop_grace_period"] == "${OMNIGENT_HOST_STOP_GRACE_SECONDS:-20}s"
     entrypoint = host_service["entrypoint"]
     assert entrypoint[:2] == ["/usr/bin/env", "-u"]
     assert set(entrypoint[2::2]) == {

--- a/tests/unit/api/routers/test_workflow_console_view_model.py
+++ b/tests/unit/api/routers/test_workflow_console_view_model.py
@@ -130,6 +130,12 @@ def test_build_runtime_config_contains_expected_keys(monkeypatch) -> None:
     assert temporal_dashboard["debugFieldsEnabled"] is False
     assert config["statusMaps"]["temporal"]["executing"] == "running"
     assert "defaultRepository" in config["system"]
+    omnigent_catalog = config["system"]["omnigentExecutionCatalog"]
+    assert omnigent_catalog["profiles"][0]["ref"] == "omnigent-codex@1"
+    assert {policy["hostMode"] for policy in omnigent_catalog["policies"]} == {
+        "static_compose",
+        "on_demand_docker",
+    }
     assert "buildId" in config["system"]
     assert config["system"]["defaultRuntime"] in ("codex_cli", "claude_code")
     assert "defaultModel" in config["system"]

--- a/tests/unit/omnigent/test_embedded_acceptance.py
+++ b/tests/unit/omnigent/test_embedded_acceptance.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import copy
 from datetime import datetime, timezone
+from typing import Any
 
 import pytest
 
@@ -91,10 +92,13 @@ def _source() -> dict:
     return source
 
 
+def _build(source: dict, **kwargs: Any) -> dict:
+    kwargs.setdefault("now", datetime(2026, 7, 21, 12, tzinfo=timezone.utc))
+    return build_embedded_acceptance_report(source, **kwargs)
+
+
 def test_complete_matrix_builds_publishable_issue_3425_report() -> None:
-    report = build_embedded_acceptance_report(
-        _source(), now=datetime(2026, 7, 21, 12, tzinfo=timezone.utc)
-    )
+    report = _build(_source())
     assert report["status"] == "passed"
     assert report["issue"] == "MoonLadderStudios/MoonMind#3425"
     assert set(report["sections"]) == set(REQUIRED_SECTIONS)
@@ -102,7 +106,7 @@ def test_complete_matrix_builds_publishable_issue_3425_report() -> None:
 
 def test_expected_commit_must_match_evidence_identity() -> None:
     with pytest.raises(ConformanceContractError, match="different commit"):
-        build_embedded_acceptance_report(_source(), expected_commit="def456")
+        _build(_source(), expected_commit="def456")
 
 
 @pytest.mark.parametrize("kind,key", [("prerequisites", "3422"), ("sections", "mode-transition-rollback")])
@@ -110,25 +114,25 @@ def test_missing_or_failed_controlling_lane_refuses_publication(kind: str, key: 
     source = _source()
     source[kind][key] = {"status": "failed", "evidenceRefs": ["artifact://failure"]}
     with pytest.raises(ConformanceContractError, match="did not pass"):
-        build_embedded_acceptance_report(source)
+        _build(source)
 
 
 def test_mutable_stock_host_and_incomplete_cleanup_refuse_publication() -> None:
     mutable = _source()
     mutable["identities"]["images"]["host"] = "host:latest"
     with pytest.raises(ConformanceContractError, match="digest-pinned"):
-        build_embedded_acceptance_report(mutable)
+        _build(mutable)
     incomplete = copy.deepcopy(_source())
     incomplete["cleanup"]["leasesReleased"] = False
     with pytest.raises(ConformanceContractError, match="release leases"):
-        build_embedded_acceptance_report(incomplete)
+        _build(incomplete)
 
 
 def test_secret_like_material_refuses_publication() -> None:
     source = _source()
     source["sections"]["secret-scan"]["note"] = "authorization=unsafe"
     with pytest.raises(ConformanceContractError, match="secret-like"):
-        build_embedded_acceptance_report(source)
+        _build(source)
 
 
 def test_unresolved_or_identity_mismatched_evidence_refuses_publication() -> None:
@@ -137,13 +141,13 @@ def test_unresolved_or_identity_mismatched_evidence_refuses_publication() -> Non
         "artifact://missing"
     ]
     with pytest.raises(ConformanceContractError, match="unresolved"):
-        build_embedded_acceptance_report(unresolved)
+        _build(unresolved)
 
     mismatched = _source()
     evidence = mismatched["evidenceObjects"]["artifact://mixed-mode-history"]
     evidence["identities"]["moonmindCommit"] = "different"
     with pytest.raises(ConformanceContractError, match="different identities"):
-        build_embedded_acceptance_report(mismatched)
+        _build(mismatched)
 
 
 def test_failed_or_incomplete_resolved_case_refuses_publication() -> None:
@@ -151,7 +155,7 @@ def test_failed_or_incomplete_resolved_case_refuses_publication() -> None:
     evidence = source["evidenceObjects"]["artifact://hostile-input-bounds"]
     evidence["cases"]["controlling-case"]["status"] = "skipped"
     with pytest.raises(ConformanceContractError, match="cases are incomplete"):
-        build_embedded_acceptance_report(source)
+        _build(source)
 
 
 def test_unresolved_or_mismatched_leaf_case_refuses_publication() -> None:
@@ -161,17 +165,13 @@ def test_unresolved_or_mismatched_leaf_case_refuses_publication() -> None:
         ConformanceContractError,
         match="case controlling-case evidence ref is unresolved",
     ):
-        build_embedded_acceptance_report(
-            unresolved, now=datetime(2026, 7, 21, 12, tzinfo=timezone.utc)
-        )
+        _build(unresolved)
 
     mismatched = _source()
     leaf = mismatched["evidenceObjects"]["artifact://case/mixed-mode-history"]
     leaf["case"] = "another-case"
     with pytest.raises(ConformanceContractError, match="does not prove its case"):
-        build_embedded_acceptance_report(
-            mismatched, now=datetime(2026, 7, 21, 12, tzinfo=timezone.utc)
-        )
+        _build(mismatched)
 
 
 @pytest.mark.parametrize(
@@ -189,6 +189,4 @@ def test_stale_revoked_superseded_or_malformed_evidence_refuses_publication(
     source = _source()
     source["evidenceObjects"]["artifact://mode-transition-rollback"].update(override)
     with pytest.raises(ConformanceContractError, match=match):
-        build_embedded_acceptance_report(
-            source, now=datetime(2026, 7, 21, 12, tzinfo=timezone.utc)
-        )
+        _build(source)

--- a/tests/unit/omnigent/test_execution_profiles.py
+++ b/tests/unit/omnigent/test_execution_profiles.py
@@ -1,3 +1,6 @@
+import hashlib
+import json
+
 import pytest
 from pydantic import ValidationError
 
@@ -49,6 +52,15 @@ def test_mutated_snapshot_fails_conflict_validation() -> None:
     with pytest.raises(OmnigentOAuthHostError) as error:
         validate_effective_launch_snapshot(launch)
     assert error.value.code == "OMNIGENT_EFFECTIVE_LAUNCH_CONFLICT"
+
+
+def test_profile_identifier_may_contain_token_word() -> None:
+    launch = compile_effective_launch(
+        profile_ref="omnigent-codex@1",
+        policy_ref="codex-on-demand@1",
+        provider_profile_id="codex-token-profile",
+    )
+    validate_effective_launch_snapshot(launch)
 
 
 def test_missing_explicit_policy_fails_closed() -> None:
@@ -169,6 +181,14 @@ def test_runtime_revalidates_complete_on_demand_policy_before_mutation(
         provider_profile_id="codex-oauth",
     )
     launch[field] = value
+    canonical = json.dumps(
+        {key: item for key, item in launch.items() if key != "snapshotRef"},
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    launch["snapshotRef"] = "omnigent-launch:sha256:" + hashlib.sha256(
+        canonical.encode()
+    ).hexdigest()
 
     with pytest.raises(OmnigentOAuthHostError) as error:
         OmnigentOAuthHostRuntime._validate_effective_launch(

--- a/tests/unit/omnigent/test_execution_profiles.py
+++ b/tests/unit/omnigent/test_execution_profiles.py
@@ -8,6 +8,7 @@ from moonmind.omnigent.execution_profiles import (
     selection_from_request,
 )
 from moonmind.omnigent.oauth_hosts import OmnigentOAuthHostError
+from moonmind.omnigent.oauth_host_runtime import OmnigentOAuthHostRuntime
 
 
 def test_versioned_profile_and_policy_compile_to_stable_safe_snapshot() -> None:
@@ -91,3 +92,48 @@ def test_public_catalog_exposes_only_safe_stable_product_refs() -> None:
         "codex-on-demand@1",
     }
     assert "credential" not in str(catalog).lower()
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "code"),
+    [
+        (
+            "serverImageRef",
+            "omnigent:latest",
+            "OMNIGENT_LAUNCH_IMAGE_UNREALIZABLE",
+        ),
+        ("readOnlyRoot", False, "OMNIGENT_LAUNCH_ROOT_UNREALIZABLE"),
+        (
+            "capture",
+            {"required": False, "retentionDays": 30},
+            "OMNIGENT_LAUNCH_CAPTURE_UNREALIZABLE",
+        ),
+        (
+            "cleanup",
+            {"mode": "drain", "janitor": True},
+            "OMNIGENT_LAUNCH_CLEANUP_UNREALIZABLE",
+        ),
+        (
+            "controlCapabilities",
+            ["terminate"],
+            "OMNIGENT_LAUNCH_CONTROLS_UNREALIZABLE",
+        ),
+    ],
+)
+def test_runtime_revalidates_complete_on_demand_policy_before_mutation(
+    field: str, value: object, code: str
+) -> None:
+    launch = compile_effective_launch(
+        profile_ref="omnigent-codex@1",
+        policy_ref="codex-on-demand@1",
+        provider_profile_id="codex-oauth",
+    )
+    launch[field] = value
+
+    with pytest.raises(OmnigentOAuthHostError) as error:
+        OmnigentOAuthHostRuntime._validate_effective_launch(
+            binding=type("Binding", (), {"host_launch_profile_ref": "on-demand"})(),
+            effective_launch=launch,
+        )
+
+    assert error.value.code == code

--- a/tests/unit/omnigent/test_execution_profiles.py
+++ b/tests/unit/omnigent/test_execution_profiles.py
@@ -12,6 +12,12 @@ from moonmind.omnigent.oauth_hosts import OmnigentOAuthHostError
 from moonmind.omnigent.oauth_host_runtime import OmnigentOAuthHostRuntime
 
 
+@pytest.fixture(autouse=True)
+def immutable_bootstrap_images(monkeypatch) -> None:
+    monkeypatch.setenv("OMNIGENT_IMAGE_REF", "example.test/omnigent@sha256:" + "1" * 64)
+    monkeypatch.setenv("OMNIGENT_HOST_IMAGE_REF", "example.test/host@sha256:" + "2" * 64)
+
+
 def test_versioned_profile_and_policy_compile_to_stable_safe_snapshot() -> None:
     first = compile_effective_launch(
         profile_ref="omnigent-codex@1",
@@ -77,6 +83,26 @@ def test_policy_rejects_mutable_image_before_launch() -> None:
             cleanup={"mode": "remove"},
             controlCapabilities=(),
         )
+
+
+def test_compile_rejects_missing_or_placeholder_bootstrap_images(monkeypatch) -> None:
+    monkeypatch.delenv("OMNIGENT_IMAGE_REF")
+    with pytest.raises(OmnigentOAuthHostError) as missing:
+        compile_effective_launch(
+            profile_ref="omnigent-codex@1",
+            policy_ref="codex-on-demand@1",
+            provider_profile_id="codex-oauth",
+        )
+    assert missing.value.code == "OMNIGENT_LAUNCH_IMAGE_UNREALIZABLE"
+
+    monkeypatch.setenv("OMNIGENT_IMAGE_REF", "example.test/omnigent@sha256:" + "0" * 64)
+    with pytest.raises(OmnigentOAuthHostError) as placeholder:
+        compile_effective_launch(
+            profile_ref="omnigent-codex@1",
+            policy_ref="codex-on-demand@1",
+            provider_profile_id="codex-oauth",
+        )
+    assert placeholder.value.code == "OMNIGENT_LAUNCH_IMAGE_UNREALIZABLE"
 
 
 def test_workflow_cannot_supply_host_or_credential_authority() -> None:

--- a/tests/unit/omnigent/test_execution_profiles.py
+++ b/tests/unit/omnigent/test_execution_profiles.py
@@ -6,6 +6,7 @@ from moonmind.omnigent.execution_profiles import (
     compile_effective_launch,
     public_execution_catalog,
     selection_from_request,
+    validate_effective_launch_snapshot,
 )
 from moonmind.omnigent.oauth_hosts import OmnigentOAuthHostError
 from moonmind.omnigent.oauth_host_runtime import OmnigentOAuthHostRuntime
@@ -29,6 +30,19 @@ def test_versioned_profile_and_policy_compile_to_stable_safe_snapshot() -> None:
     assert first["snapshotRef"].startswith("omnigent-launch:sha256:")
     assert "credential" not in str(first).lower()
     assert "docker.sock" not in str(first)
+    validate_effective_launch_snapshot(first)
+
+
+def test_mutated_snapshot_fails_conflict_validation() -> None:
+    launch = compile_effective_launch(
+        profile_ref="omnigent-codex@1",
+        policy_ref="codex-on-demand@1",
+        provider_profile_id="codex-oauth",
+    )
+    launch["limits"]["memoryMiB"] = 8192
+    with pytest.raises(OmnigentOAuthHostError) as error:
+        validate_effective_launch_snapshot(launch)
+    assert error.value.code == "OMNIGENT_EFFECTIVE_LAUNCH_CONFLICT"
 
 
 def test_missing_explicit_policy_fails_closed() -> None:

--- a/tests/unit/omnigent/test_execution_profiles.py
+++ b/tests/unit/omnigent/test_execution_profiles.py
@@ -4,6 +4,7 @@ from pydantic import ValidationError
 from moonmind.omnigent.execution_profiles import (
     OmnigentLaunchPolicy,
     compile_effective_launch,
+    public_execution_catalog,
     selection_from_request,
 )
 from moonmind.omnigent.oauth_hosts import OmnigentOAuthHostError
@@ -78,3 +79,15 @@ def test_product_selection_is_explicit_and_versioned() -> None:
             }
         }
     ) == ("omnigent-codex@1", "codex-static@1")
+
+
+def test_public_catalog_exposes_only_safe_stable_product_refs() -> None:
+    catalog = public_execution_catalog()
+    assert [profile["ref"] for profile in catalog["profiles"]] == [
+        "omnigent-codex@1"
+    ]
+    assert {policy["ref"] for policy in catalog["policies"]} == {
+        "codex-static@1",
+        "codex-on-demand@1",
+    }
+    assert "credential" not in str(catalog).lower()

--- a/tests/unit/omnigent/test_execution_profiles.py
+++ b/tests/unit/omnigent/test_execution_profiles.py
@@ -1,0 +1,80 @@
+import pytest
+from pydantic import ValidationError
+
+from moonmind.omnigent.execution_profiles import (
+    OmnigentLaunchPolicy,
+    compile_effective_launch,
+    selection_from_request,
+)
+from moonmind.omnigent.oauth_hosts import OmnigentOAuthHostError
+
+
+def test_versioned_profile_and_policy_compile_to_stable_safe_snapshot() -> None:
+    first = compile_effective_launch(
+        profile_ref="omnigent-codex@1",
+        policy_ref="codex-on-demand@1",
+        provider_profile_id="codex-oauth",
+    )
+    second = compile_effective_launch(
+        profile_ref="omnigent-codex@1",
+        policy_ref="codex-on-demand@1",
+        provider_profile_id="codex-oauth",
+    )
+
+    assert first == second
+    assert first["hostMode"] == "on_demand_docker"
+    assert first["harness"] == "codex-native"
+    assert first["snapshotRef"].startswith("omnigent-launch:sha256:")
+    assert "credential" not in str(first).lower()
+    assert "docker.sock" not in str(first)
+
+
+def test_missing_explicit_policy_fails_closed() -> None:
+    with pytest.raises(OmnigentOAuthHostError) as error:
+        compile_effective_launch(
+            profile_ref="omnigent-codex@1",
+            policy_ref="missing@1",
+            provider_profile_id="codex-oauth",
+        )
+    assert error.value.code == "OMNIGENT_LAUNCH_POLICY_UNAVAILABLE"
+
+
+def test_policy_rejects_mutable_image_before_launch() -> None:
+    with pytest.raises(ValidationError, match="immutable sha256 digest"):
+        OmnigentLaunchPolicy(
+            policyId="bad",
+            version=1,
+            hostMode="on_demand_docker",
+            serverImageRef="omnigent:latest",
+            hostImageRef="host:latest",
+            networkRef="moonmind_local-network",
+            enforcedEgress=True,
+            limits={
+                "cpuMillis": 1,
+                "memoryMiB": 1,
+                "processes": 1,
+                "timeoutSeconds": 1,
+                "temporaryStorageMiB": 1,
+            },
+            mountClasses=("oauth_home",),
+            capture={"required": True},
+            cleanup={"mode": "remove"},
+            controlCapabilities=(),
+        )
+
+
+def test_workflow_cannot_supply_host_or_credential_authority() -> None:
+    with pytest.raises(OmnigentOAuthHostError) as error:
+        selection_from_request({"omnigent": {"session": {"hostId": "manual"}}})
+    assert error.value.code == "OMNIGENT_LAUNCH_POLICY_FORBIDDEN_INPUT"
+
+
+def test_product_selection_is_explicit_and_versioned() -> None:
+    assert selection_from_request(
+        {
+            "omnigent": {
+                "executionTargetRef": "omnigent-codex@1",
+                "launchPolicyRef": "codex-static@1",
+            }
+        }
+    ) == ("omnigent-codex@1", "codex-static@1")

--- a/tests/unit/omnigent/test_host_auth_remediation.py
+++ b/tests/unit/omnigent/test_host_auth_remediation.py
@@ -398,6 +398,7 @@ async def test_cross_channel_serializers_redact_or_reject_host_secret(caplog) ->
             bridgeSessionId="bridge",
             externalStateRef="artifact://external",
             idempotencyKey="idem",
+            effectiveLaunchRef="omnigent-launch:sha256:" + "0" * 64,
         )
 
     # The actual artifact gateway boundary redacts structured diagnostics.

--- a/tests/unit/omnigent/test_oauth_profile_lifecycle.py
+++ b/tests/unit/omnigent/test_oauth_profile_lifecycle.py
@@ -159,6 +159,15 @@ def _checkpoint() -> OmnigentCheckpointIdentity:
     )
 
 
+def test_legacy_checkpoint_without_effective_launch_ref_remains_loadable() -> None:
+    payload = _checkpoint().model_dump(by_alias=True, mode="json")
+    payload.pop("effectiveLaunchRef")
+
+    checkpoint = OmnigentCheckpointIdentity.model_validate(payload)
+
+    assert checkpoint.effective_launch_ref is None
+
+
 def test_oauth_host_runtime_defaults_to_published_image(monkeypatch) -> None:
     monkeypatch.delenv("OMNIGENT_HOST_IMAGE", raising=False)
     monkeypatch.delenv("OMNIGENT_HOST_IMAGE_TAG", raising=False)

--- a/tests/unit/omnigent/test_oauth_profile_lifecycle.py
+++ b/tests/unit/omnigent/test_oauth_profile_lifecycle.py
@@ -357,6 +357,11 @@ async def test_on_demand_host_initializes_state_before_unprivileged_launch(
         "dst=/opt/moonmind-tools,readonly"
     ) in commands[2]
     assert "MOONMIND_ACTIVE_SKILLS_DIR=/opt/moonmind-skills" in commands[2]
+    assert "OMNIGENT_EXECUTION_TIMEOUT_SECONDS=5400" in commands[2]
+    assert "OMNIGENT_EXECUTION_TIMEOUT_OWNER=temporal_workflow" in commands[2]
+    assert "OMNIGENT_CAPTURE_OWNER=moonmind_bridge" in commands[2]
+    assert "OMNIGENT_CAPTURE_RETENTION_DAYS=30" in commands[2]
+    assert commands[2][commands[2].index("--stop-timeout") + 1] == "20"
     assert (
         f"type=bind,src={tmp_path / 'skills'},dst=/opt/moonmind-skills,readonly"
     ) in commands[2]
@@ -1569,3 +1574,7 @@ async def test_coordinator_provider_release_has_bounded_retry_evidence(
     else:
         assert "provider_released" in actions
     assert events[-1][1]["metadata"]["janitorRequired"] is janitor_required
+@pytest.fixture(autouse=True)
+def immutable_bootstrap_images(monkeypatch) -> None:
+    monkeypatch.setenv("OMNIGENT_IMAGE_REF", "example.test/omnigent@sha256:" + "1" * 64)
+    monkeypatch.setenv("OMNIGENT_HOST_IMAGE_REF", "example.test/host@sha256:" + "2" * 64)

--- a/tests/unit/omnigent/test_oauth_profile_lifecycle.py
+++ b/tests/unit/omnigent/test_oauth_profile_lifecycle.py
@@ -316,8 +316,11 @@ async def test_activity_lease_client_preserves_delegating_workflow_owner() -> No
 
 @pytest.mark.asyncio
 async def test_on_demand_host_initializes_state_before_unprivileged_launch(
-    tmp_path,
+    tmp_path, monkeypatch
 ) -> None:
+    environment_image = "registry.example/environment-host@sha256:" + "1" * 64
+    snapshot_image = "registry.example/snapshot-host@sha256:" + "2" * 64
+    monkeypatch.setenv("OMNIGENT_HOST_IMAGE", environment_image)
     runtime = OmnigentOAuthHostRuntime(
         client=SimpleNamespace(),
         scripts_dir=tmp_path,
@@ -333,23 +336,31 @@ async def test_on_demand_host_initializes_state_before_unprivileged_launch(
     )
     lease = _host_lease().model_copy(update={"container_name": "mm-host-lease-1"})
 
+    effective_launch = compile_effective_launch(
+        profile_ref="omnigent-codex@1",
+        policy_ref="codex-on-demand@1",
+        provider_profile_id="codex",
+    )
+    effective_launch["hostImageRef"] = snapshot_image
+
     await runtime._launch_on_demand(
         binding=binding,
         host_lease=lease,
         container_name="mm-host-lease-1",
         workspace_source=tmp_path,
         skill_projection=tmp_path / "skills",
-        effective_launch=compile_effective_launch(
-            profile_ref="omnigent-codex@1",
-            policy_ref="codex-on-demand@1",
-            provider_profile_id="codex",
-        ),
+        effective_launch=effective_launch,
     )
 
     commands = [call.args for call in runtime._run.await_args_list]
     assert commands[0][:4] == ("docker", "rm", "-f", "mm-host-lease-1")
     assert "/opt/moonmind/init-codex-oauth-host.sh" in commands[1]
     assert commands[2][:3] == ("docker", "run", "-d")
+    runtime._discover_upstream_path.assert_awaited_once_with(snapshot_image)
+    assert commands[1][-1] == snapshot_image
+    assert commands[2][-2] == snapshot_image
+    assert environment_image not in commands[1]
+    assert environment_image not in commands[2]
     assert commands[1][commands[1].index("--user") + 1] == "0:0"
     assert commands[2][commands[2].index("--workdir") + 1] == "/home/app"
     assert (
@@ -461,9 +472,11 @@ async def test_tools_path_discovery_falls_back_when_image_is_not_local(
     )
     runtime._run = AsyncMock(return_value=(1, "", "No such image"))
 
-    assert await runtime._discover_upstream_path() == (
+    image_ref = "registry.example/snapshot-host@sha256:" + "2" * 64
+    assert await runtime._discover_upstream_path(image_ref) == (
         "/opt/venv/bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin"
     )
+    assert runtime._run.await_args.args[-1] == image_ref
     assert runtime._run.await_args.kwargs["check"] is False
 
 

--- a/tests/unit/omnigent/test_oauth_profile_lifecycle.py
+++ b/tests/unit/omnigent/test_oauth_profile_lifecycle.py
@@ -155,6 +155,7 @@ def _checkpoint() -> OmnigentCheckpointIdentity:
         bridgeSessionId="bridge-1",
         externalStateRef="artifact-external-state",
         idempotencyKey="idem-1",
+        effectiveLaunchRef="omnigent-launch:sha256:" + "0" * 64,
     )
 
 
@@ -338,6 +339,11 @@ async def test_on_demand_host_initializes_state_before_unprivileged_launch(
         container_name="mm-host-lease-1",
         workspace_source=tmp_path,
         skill_projection=tmp_path / "skills",
+        effective_launch=compile_effective_launch(
+            profile_ref="omnigent-codex@1",
+            policy_ref="codex-on-demand@1",
+            provider_profile_id="codex",
+        ),
     )
 
     commands = [call.args for call in runtime._run.await_args_list]
@@ -483,7 +489,12 @@ async def test_static_host_runtime_uses_only_canonical_compose_file(tmp_path) ->
     )
     runtime._run = AsyncMock(return_value=(0, "", ""))
 
-    await runtime._compose_static_check()
+    launch = compile_effective_launch(
+        profile_ref="omnigent-codex@1",
+        policy_ref="codex-static@1",
+        provider_profile_id="codex",
+    )
+    await runtime._compose_static_check(effective_launch=launch)
     await runtime.stop_static_host()
 
     commands = [call.args for call in runtime._run.await_args_list]

--- a/tests/unit/omnigent/test_oauth_profile_lifecycle.py
+++ b/tests/unit/omnigent/test_oauth_profile_lifecycle.py
@@ -34,6 +34,7 @@ from moonmind.omnigent.oauth_hosts import (
     OmnigentOAuthHostRepository,
     validate_preflight_result,
 )
+from moonmind.omnigent.execution_profiles import compile_effective_launch
 from moonmind.omnigent.oauth_host_runtime import OmnigentOAuthHostRuntime
 from moonmind.omnigent.mounted_tool_preflight import MountedToolPreflightError
 from moonmind.omnigent.profile_bound_execution import (
@@ -559,9 +560,39 @@ async def test_host_rejects_missing_skill_projection_before_workspace_mutation(
             binding=_binding(),
             host_lease=_host_lease(),
             workspace_key="run-1",
+            effective_launch=compile_effective_launch(
+                profile_ref="omnigent-codex@1",
+                policy_ref="codex-static@1",
+                provider_profile_id="codex",
+            ),
         )
 
     assert exc_info.value.code == "OMNIGENT_SKILL_PROJECTION_UNAVAILABLE"
+    runtime._prepare_workspace.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_effective_policy_conflict_fails_before_host_mutation(tmp_path) -> None:
+    runtime = OmnigentOAuthHostRuntime(
+        client=SimpleNamespace(), workspace_root=tmp_path / "workspaces"
+    )
+    runtime._prepare_skill_projection = AsyncMock()  # type: ignore[method-assign]
+    runtime._prepare_workspace = AsyncMock()  # type: ignore[method-assign]
+
+    with pytest.raises(OmnigentOAuthHostError) as exc_info:
+        await runtime.prepare_host(
+            binding=_binding(),
+            host_lease=_host_lease(),
+            workspace_key="run-1",
+            effective_launch=compile_effective_launch(
+                profile_ref="omnigent-codex@1",
+                policy_ref="codex-on-demand@1",
+                provider_profile_id="codex",
+            ),
+        )
+
+    assert exc_info.value.code == "OMNIGENT_LAUNCH_POLICY_BINDING_CONFLICT"
+    runtime._prepare_skill_projection.assert_not_awaited()
     runtime._prepare_workspace.assert_not_awaited()
 
 


### PR DESCRIPTION
Issue: MoonLadderStudios/MoonMind#3450

Closes MoonLadderStudios/MoonMind#3450

## Summary

- adds a versioned MoonMind-owned Codex execution profile and built-in static/on-demand launch policies
- compiles and persists a digest-addressed, secret-free effective launch snapshot across binding, lease, bridge, lifecycle, terminal, and checkpoint evidence
- exposes profile and host-mode selection in Workflow Create and validates explicit policy authority before host mutation
- preserves the durable decision on retries and aligns static/on-demand authorization, capture, cleanup, and lease ordering

## Tests run

- `python -m compileall -q moonmind/omnigent tests/unit/omnigent/test_execution_profiles.py tests/unit/omnigent/test_oauth_profile_lifecycle.py tests/unit/api_service/test_omnigent_oauth_host_persistence.py tests/unit/api/routers/test_workflow_console_view_model.py` — passed
- `git diff --check` — passed
- targeted managed Python unit suite — not run because the deployment returned HTTP 503 with the container-job service disabled

## Remaining risks

- The targeted unit suite could not execute in this environment; CI should provide the authoritative runtime test result.
- No full profile/policy CRUD editor is included, consistent with the issue scope.