### PR TITLE
MoonLadderStudios/MoonMind#3452: Add Codex via Omnigent workflow authoring

### DIFF
--- a/frontend/src/entrypoints/workflow-start.test.tsx
+++ b/frontend/src/entrypoints/workflow-start.test.tsx
@@ -541,7 +541,6 @@ describe("MoonLadderStudios/MoonMind#3451 Omnigent readiness", () => {
     return {
       ...mockPayload,
       initialData: {
-        ...mockPayload.initialData,
         dashboardConfig: {
           ...mockDashboardConfig,
           system: {
@@ -588,7 +587,6 @@ describe("MoonLadderStudios/MoonMind#3451 Omnigent readiness", () => {
     const payload = {
       ...mockPayload,
       initialData: {
-        ...mockPayload.initialData,
         dashboardConfig: {
           ...mockDashboardConfig,
           system: {
@@ -722,7 +720,7 @@ describe("MoonLadderStudios/MoonMind#3451 Omnigent readiness", () => {
   });
 
   it("rejects a selection revoked by no-cache submit-time readiness without substitution", async () => {
-    fetchSpy.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+    fetchSpy.mockImplementation((input: RequestInfo | URL) => {
       const url = String(input);
       if (url === "/api/omnigent/codex-catalog-readiness") {
         readinessRequests += 1;

--- a/frontend/src/entrypoints/workflow-start.test.tsx
+++ b/frontend/src/entrypoints/workflow-start.test.tsx
@@ -745,6 +745,65 @@ describe("MoonLadderStudios/MoonMind#3451 Omnigent readiness", () => {
     expect(fetchSpy.mock.calls.some(([url, options]) => String(url) === "/api/executions" && (options as RequestInit | undefined)?.method === "POST")).toBe(false);
     expect((screen.getByLabelText("Provider profile") as HTMLSelectElement).value).toBe("oauth-1");
   });
+
+  it("fails closed when submit-time Omnigent readiness cannot be refreshed", async () => {
+    fetchSpy.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === "/api/omnigent/codex-catalog-readiness") {
+        readinessRequests += 1;
+        if (readinessRequests > 1) {
+          return Promise.resolve({
+            ok: false,
+            status: 503,
+            json: async () => ({ detail: "readiness unavailable" }),
+          } as Response);
+        }
+        return Promise.resolve({
+          ok: true,
+          json: async () => readyOmnigentCatalog,
+        } as Response);
+      }
+      if (url.startsWith("/api/v1/provider-profiles")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => [
+            {
+              profile_id: "oauth-1",
+              account_label: "Codex OAuth",
+              provider_id: "openai",
+            },
+          ],
+        } as Response);
+      }
+      return Promise.resolve({
+        ok: true,
+        json: async () => ({ items: [] }),
+      } as Response);
+    });
+
+    renderWorkflowStartPage(omnigentPayload());
+    fireEvent.change(await screen.findByLabelText("Runtime"), {
+      target: { value: "omnigent" },
+    });
+    fireEvent.change(await screen.findByLabelText("Provider profile"), {
+      target: { value: "oauth-1" },
+    });
+    fireEvent.change(screen.getByLabelText("Instructions"), {
+      target: { value: "Do not launch when readiness cannot be checked." },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Start Workflow" }));
+
+    expect(
+      await screen.findByText("Codex via Omnigent readiness could not be verified."),
+    ).toBeTruthy();
+    expect(
+      fetchSpy.mock.calls.some(
+        ([url, options]) =>
+          String(url) === "/api/executions" &&
+          (options as RequestInit | undefined)?.method === "POST",
+      ),
+    ).toBe(false);
+  });
 });
 
 const historicalRuntimeCommand = {

--- a/frontend/src/entrypoints/workflow-start.test.tsx
+++ b/frontend/src/entrypoints/workflow-start.test.tsx
@@ -12,6 +12,7 @@ import { act, fireEvent, screen, waitFor, within } from "@testing-library/react"
 import { MemoryRouter } from "react-router-dom";
 
 import type { BootPayload } from "../boot/parseBootPayload";
+import type { components } from "../generated/openapi";
 import { navigateTo } from "../lib/navigation";
 import { requestWorkflowStartRouteChange } from "../lib/workflowStartRouteGuard";
 import {
@@ -545,6 +546,7 @@ describe("MoonLadderStudios/MoonMind#3451 Omnigent readiness", () => {
           ...mockDashboardConfig,
           system: {
             ...mockDashboardConfig.system,
+            supportedAgentRuntimes: ["codex_cli", "claude_code", "jules"],
             omnigentExecutionCatalog: {
               profiles: [{ ref: "omnigent-codex-default", displayName: "Codex default", defaultPolicyRef: "on-demand-v1" }],
               policies: [{ ref: "on-demand-v1", displayName: "On-demand v1", hostMode: "on_demand_docker" }],
@@ -559,13 +561,17 @@ describe("MoonLadderStudios/MoonMind#3451 Omnigent readiness", () => {
     schemaVersion: "moonmind.omnigent-codex-readiness.v1",
     runtimeId: "omnigent",
     displayName: "Codex via Omnigent",
+    agentKind: "external",
+    agentId: "omnigent",
+    harness: "codex-native",
     available: true,
     defaultExecutionProfileRef: "omnigent-codex-default",
     executionProfiles: [{ ref: "omnigent-codex-default", displayName: "Codex default", available: true, policyRefs: ["on-demand-v1"], gateReasons: [] }],
     eligibleProviderProfiles: [{ profileId: "oauth-1", label: "Codex OAuth", providerId: "openai", busy: false, queueWhenBusy: true }],
     ineligibleProviderProfiles: [],
+    hostModes: ["on_demand_docker"],
     gateReasons: [],
-  };
+  } satisfies components["schemas"]["OmnigentCodexCatalogReadiness"];
 
   it("keeps an unavailable runtime unselectable and explicitly revalidates stale readiness", async () => {
     renderWorkflowStartPage(mockPayload);
@@ -650,14 +656,18 @@ describe("MoonLadderStudios/MoonMind#3451 Omnigent readiness", () => {
     const runtime = await screen.findByLabelText("Runtime");
     expect(within(runtime).getByRole("option", { name: "Codex CLI" })).toBeTruthy();
     expect(within(runtime).getByRole("option", { name: "Claude Code" })).toBeTruthy();
+    expect(within(runtime).getByRole("option", { name: "Jules" })).toBeTruthy();
+    runtime.focus();
+    expect(document.activeElement).toBe(runtime);
     fireEvent.change(runtime, { target: { value: "omnigent" } });
+    expect((runtime as HTMLSelectElement).value).toBe("omnigent");
     fireEvent.change(await screen.findByLabelText("Provider profile"), { target: { value: "oauth-1" } });
     fireEvent.change(screen.getByLabelText("Instructions"), { target: { value: "Exercise the Omnigent submit boundary." } });
 
     expect(await screen.findByText("Runtime: Codex via Omnigent")).toBeTruthy();
     expect(screen.getByText("Host mode: On-demand Docker")).toBeTruthy();
     expect(screen.getByLabelText("Execution target").getAttribute("name")).toBe("omnigentExecutionTargetRef");
-    fireEvent.keyDown(runtime, { key: "ArrowDown" });
+    expect(screen.getByLabelText("Execution target").closest(".grid-2")).toBeTruthy();
     fireEvent.click(screen.getByRole("button", { name: "Start Workflow" }));
 
     await waitFor(() => expect(navigateTo).toHaveBeenCalledWith("/workflows/mm%3Aomnigent-created?source=temporal"));
@@ -670,6 +680,45 @@ describe("MoonLadderStudios/MoonMind#3451 Omnigent readiness", () => {
       task: { runtime: { mode: "omnigent", profileId: "oauth-1" } },
     });
     expect(JSON.stringify(request)).not.toMatch(/hostId|volume|credential|registrationToken|image|network|mount/i);
+  });
+
+  it.each([
+    ["deferred", "deferred_minutes", "Minutes from now", "5", { mode: "once" }],
+    ["once", "once", "Scheduled For", "2099-01-01T12:00", { mode: "once", scheduledFor: "2099-01-01T12:00:00.000Z" }],
+    ["recurring", "recurring", "Cron Expression", "0 4 * * *", { mode: "recurring", cron: "0 4 * * *", timezone: "UTC" }],
+  ])("preserves canonical Omnigent refs in %s schedule submissions", async (_label, mode, fieldLabel, fieldValue, expectedSchedule) => {
+    fetchSpy.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url === "/api/omnigent/codex-catalog-readiness") {
+        readinessRequests += 1;
+        return Promise.resolve({ ok: true, json: async () => readyOmnigentCatalog } as Response);
+      }
+      if (url.startsWith("/api/v1/provider-profiles")) {
+        return Promise.resolve({ ok: true, json: async () => [{ profile_id: "oauth-1", account_label: "Codex OAuth", provider_id: "openai" }] } as Response);
+      }
+      if (url === "/api/executions" && init?.method === "POST") {
+        return Promise.resolve({ ok: true, json: async () => ({ workflowId: `mm:omnigent-${mode}` }) } as Response);
+      }
+      return Promise.resolve({ ok: true, json: async () => ({ items: [] }) } as Response);
+    });
+
+    renderWorkflowStartPage(omnigentPayload());
+    fireEvent.change(await screen.findByLabelText("Runtime"), { target: { value: "omnigent" } });
+    fireEvent.change(await screen.findByLabelText("Provider profile"), { target: { value: "oauth-1" } });
+    fireEvent.change(screen.getByLabelText("Instructions"), { target: { value: `Exercise ${mode} scheduling.` } });
+    fireEvent.change(screen.getByLabelText("Schedule Mode"), { target: { value: mode } });
+    fireEvent.change(screen.getByLabelText(fieldLabel), { target: { value: fieldValue } });
+    fireEvent.click(screen.getByRole("button", { name: "Start Workflow" }));
+
+    await waitFor(() => expect(fetchSpy.mock.calls.some(([url, options]) => String(url) === "/api/executions" && (options as RequestInit | undefined)?.method === "POST")).toBe(true));
+    const createCall = fetchSpy.mock.calls.find(([url, options]) => String(url) === "/api/executions" && (options as RequestInit | undefined)?.method === "POST");
+    const request = JSON.parse(String((createCall?.[1] as RequestInit | undefined)?.body));
+    expect(request.payload).toMatchObject({
+      targetRuntime: "omnigent",
+      omnigent: { executionTargetRef: "omnigent-codex-default", launchPolicyRef: "on-demand-v1" },
+      task: { runtime: { mode: "omnigent", profileId: "oauth-1" } },
+      schedule: expectedSchedule,
+    });
   });
 
   it("rejects a selection revoked by no-cache submit-time readiness without substitution", async () => {
@@ -1224,6 +1273,11 @@ describe("WorkflowStart CSS Layout", () => {
     );
     expect(dashboardCss).toMatch(
       /@media \(max-width:\s*924px\) and \(min-width:\s*641px\)\s*\{[^}]*\.workflow-start-workspace \.queue-floating-bar-row\s*\{[^}]*grid-template-columns:\s*minmax\(0,\s*1fr\)\s*minmax\(9\.5rem,\s*0\.8fr\)\s*auto;/s,
+    );
+    // The execution target/policy pair used by Omnigent is a canonical grid-2
+    // row, which collapses to one keyboard-ordered column on narrow screens.
+    expect(dashboardCss).toMatch(
+      /@media \(max-width:\s*900px\)\s*\{[^}]*\.grid-2\s*\{[^}]*grid-template-columns:\s*1fr;/s,
     );
   });
 });

--- a/frontend/src/entrypoints/workflow-start.test.tsx
+++ b/frontend/src/entrypoints/workflow-start.test.tsx
@@ -546,6 +546,58 @@ describe("MoonLadderStudios/MoonMind#3451 Omnigent readiness", () => {
     fireEvent.click(screen.getByRole("button", { name: "Refresh readiness" }));
     await waitFor(() => expect(readinessRequests).toBe(2));
   });
+
+  it("gates a busy Omnigent selection and hides unsupported model authority", async () => {
+    const payload = {
+      ...mockPayload,
+      initialData: {
+        ...mockPayload.initialData,
+        dashboardConfig: {
+          ...mockDashboardConfig,
+          system: {
+            ...mockDashboardConfig.system,
+            omnigentExecutionCatalog: {
+              profiles: [{ ref: "omnigent-codex-default", displayName: "Codex default", defaultPolicyRef: "on-demand-v1" }],
+              policies: [{ ref: "on-demand-v1", hostMode: "on_demand_docker" }],
+            },
+          },
+        },
+      },
+    } as BootPayload;
+    fetchSpy.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === "/api/omnigent/codex-catalog-readiness") {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            schemaVersion: "moonmind.omnigent-codex-readiness.v1",
+            runtimeId: "omnigent",
+            displayName: "Codex via Omnigent",
+            available: true,
+            defaultExecutionProfileRef: "omnigent-codex-default",
+            executionProfiles: [{ ref: "omnigent-codex-default", displayName: "Codex default", available: true, policyRefs: ["on-demand-v1"], gateReasons: [] }],
+            eligibleProviderProfiles: [{ profileId: "oauth-1", label: "Codex OAuth", providerId: "openai", busy: true, queueWhenBusy: false }],
+            ineligibleProviderProfiles: [],
+            gateReasons: [],
+          }),
+        } as Response);
+      }
+      if (url.startsWith("/api/v1/provider-profiles")) {
+        return Promise.resolve({ ok: true, json: async () => [{ profile_id: "oauth-1", account_label: "Codex OAuth", provider_id: "openai" }] } as Response);
+      }
+      return Promise.resolve({ ok: true, json: async () => ({ items: [] }) } as Response);
+    });
+
+    renderWorkflowStartPage(payload);
+    fireEvent.change(await screen.findByLabelText("Runtime"), { target: { value: "omnigent" } });
+    fireEvent.change(await screen.findByLabelText("Provider profile"), { target: { value: "oauth-1" } });
+
+    expect(await screen.findByText(/busy and does not support queued waiting/)).toBeTruthy();
+    expect((screen.getByRole("button", { name: "Start Workflow" }) as HTMLButtonElement).disabled).toBe(true);
+    expect(screen.queryByLabelText("Workflow model tier intent")).toBeNull();
+    expect(screen.queryByLabelText("Hard override model")).toBeNull();
+    expect(document.querySelector('[name="hostId"], [name*="volume"], [name*="token"]')).toBeNull();
+  });
 });
 
 const historicalRuntimeCommand = {

--- a/frontend/src/entrypoints/workflow-start.test.tsx
+++ b/frontend/src/entrypoints/workflow-start.test.tsx
@@ -536,6 +536,37 @@ describe("MoonLadderStudios/MoonMind#3451 Omnigent readiness", () => {
 
   afterEach(() => fetchSpy.mockRestore());
 
+  function omnigentPayload(): BootPayload {
+    return {
+      ...mockPayload,
+      initialData: {
+        ...mockPayload.initialData,
+        dashboardConfig: {
+          ...mockDashboardConfig,
+          system: {
+            ...mockDashboardConfig.system,
+            omnigentExecutionCatalog: {
+              profiles: [{ ref: "omnigent-codex-default", displayName: "Codex default", defaultPolicyRef: "on-demand-v1" }],
+              policies: [{ ref: "on-demand-v1", displayName: "On-demand v1", hostMode: "on_demand_docker" }],
+            },
+          },
+        },
+      },
+    } as BootPayload;
+  }
+
+  const readyOmnigentCatalog = {
+    schemaVersion: "moonmind.omnigent-codex-readiness.v1",
+    runtimeId: "omnigent",
+    displayName: "Codex via Omnigent",
+    available: true,
+    defaultExecutionProfileRef: "omnigent-codex-default",
+    executionProfiles: [{ ref: "omnigent-codex-default", displayName: "Codex default", available: true, policyRefs: ["on-demand-v1"], gateReasons: [] }],
+    eligibleProviderProfiles: [{ profileId: "oauth-1", label: "Codex OAuth", providerId: "openai", busy: false, queueWhenBusy: true }],
+    ineligibleProviderProfiles: [],
+    gateReasons: [],
+  };
+
   it("keeps an unavailable runtime unselectable and explicitly revalidates stale readiness", async () => {
     renderWorkflowStartPage(mockPayload);
 
@@ -597,6 +628,75 @@ describe("MoonLadderStudios/MoonMind#3451 Omnigent readiness", () => {
     expect(screen.queryByLabelText("Workflow model tier intent")).toBeNull();
     expect(screen.queryByLabelText("Hard override model")).toBeNull();
     expect(document.querySelector('[name="hostId"], [name*="volume"], [name*="token"]')).toBeNull();
+  });
+
+  it("revalidates and submits only canonical Omnigent intent before opening Workflow Detail", async () => {
+    fetchSpy.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url === "/api/omnigent/codex-catalog-readiness") {
+        readinessRequests += 1;
+        return Promise.resolve({ ok: true, json: async () => readyOmnigentCatalog } as Response);
+      }
+      if (url.startsWith("/api/v1/provider-profiles")) {
+        return Promise.resolve({ ok: true, json: async () => [{ profile_id: "oauth-1", account_label: "Codex OAuth", provider_id: "openai" }] } as Response);
+      }
+      if (url === "/api/executions" && init?.method === "POST") {
+        return Promise.resolve({ ok: true, json: async () => ({ workflowId: "mm:omnigent-created" }) } as Response);
+      }
+      return Promise.resolve({ ok: true, json: async () => ({ items: [] }) } as Response);
+    });
+
+    renderWorkflowStartPage(omnigentPayload());
+    const runtime = await screen.findByLabelText("Runtime");
+    expect(within(runtime).getByRole("option", { name: "Codex CLI" })).toBeTruthy();
+    expect(within(runtime).getByRole("option", { name: "Claude Code" })).toBeTruthy();
+    fireEvent.change(runtime, { target: { value: "omnigent" } });
+    fireEvent.change(await screen.findByLabelText("Provider profile"), { target: { value: "oauth-1" } });
+    fireEvent.change(screen.getByLabelText("Instructions"), { target: { value: "Exercise the Omnigent submit boundary." } });
+
+    expect(await screen.findByText("Runtime: Codex via Omnigent")).toBeTruthy();
+    expect(screen.getByText("Host mode: On-demand Docker")).toBeTruthy();
+    expect(screen.getByLabelText("Execution target").getAttribute("name")).toBe("omnigentExecutionTargetRef");
+    fireEvent.keyDown(runtime, { key: "ArrowDown" });
+    fireEvent.click(screen.getByRole("button", { name: "Start Workflow" }));
+
+    await waitFor(() => expect(navigateTo).toHaveBeenCalledWith("/workflows/mm%3Aomnigent-created?source=temporal"));
+    expect(readinessRequests).toBeGreaterThanOrEqual(2);
+    const createCall = fetchSpy.mock.calls.find(([url, options]) => String(url) === "/api/executions" && (options as RequestInit | undefined)?.method === "POST");
+    const request = JSON.parse(String((createCall?.[1] as RequestInit | undefined)?.body));
+    expect(request.payload).toMatchObject({
+      targetRuntime: "omnigent",
+      omnigent: { executionTargetRef: "omnigent-codex-default", launchPolicyRef: "on-demand-v1" },
+      task: { runtime: { mode: "omnigent", profileId: "oauth-1" } },
+    });
+    expect(JSON.stringify(request)).not.toMatch(/hostId|volume|credential|registrationToken|image|network|mount/i);
+  });
+
+  it("rejects a selection revoked by no-cache submit-time readiness without substitution", async () => {
+    fetchSpy.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url === "/api/omnigent/codex-catalog-readiness") {
+        readinessRequests += 1;
+        const body = readinessRequests === 1
+          ? readyOmnigentCatalog
+          : { ...readyOmnigentCatalog, available: false, gateReasons: [{ code: "deployment_unready", message: "Omnigent deployment became unavailable." }] };
+        return Promise.resolve({ ok: true, json: async () => body } as Response);
+      }
+      if (url.startsWith("/api/v1/provider-profiles")) {
+        return Promise.resolve({ ok: true, json: async () => [{ profile_id: "oauth-1", account_label: "Codex OAuth", provider_id: "openai" }] } as Response);
+      }
+      return Promise.resolve({ ok: true, json: async () => ({ items: [] }) } as Response);
+    });
+
+    renderWorkflowStartPage(omnigentPayload());
+    fireEvent.change(await screen.findByLabelText("Runtime"), { target: { value: "omnigent" } });
+    fireEvent.change(await screen.findByLabelText("Provider profile"), { target: { value: "oauth-1" } });
+    fireEvent.change(screen.getByLabelText("Instructions"), { target: { value: "Do not launch stale authority." } });
+    fireEvent.click(screen.getByRole("button", { name: "Start Workflow" }));
+
+    expect(await screen.findByText("Omnigent deployment became unavailable.")).toBeTruthy();
+    expect(fetchSpy.mock.calls.some(([url, options]) => String(url) === "/api/executions" && (options as RequestInit | undefined)?.method === "POST")).toBe(false);
+    expect((screen.getByLabelText("Provider profile") as HTMLSelectElement).value).toBe("oauth-1");
   });
 });
 

--- a/frontend/src/entrypoints/workflow-start.tsx
+++ b/frontend/src/entrypoints/workflow-start.tsx
@@ -611,6 +611,11 @@ interface OmnigentCodexCatalogReadiness {
     busy: boolean;
     queueWhenBusy: boolean;
   }>;
+  ineligibleProviderProfiles: Array<{
+    profileId: string;
+    label: string;
+    gateReasons: OmnigentCatalogGateReason[];
+  }>;
   gateReasons: OmnigentCatalogGateReason[];
 }
 
@@ -6344,7 +6349,10 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
       }
       return (await response.json()) as ProviderProfile[];
     },
-    enabled: Boolean(runtime) && runtime !== "omnigent",
+    // Omnigent eligibility comes exclusively from the readiness catalog, but
+    // the normal profile response remains the authority for model/effort
+    // capabilities. Load it for Codex and intersect the two below.
+    enabled: Boolean(runtime),
     // Keep the previously loaded profiles visible while a runtime switch
     // refetches. Without this, the query key change empties `data`, which
     // collapses the Runtime/Provider-profile row from `grid-2` to `stack`
@@ -6369,13 +6377,19 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
   });
 
   const activeProviderProfiles: ProviderProfile[] = runtime === "omnigent"
-    ? (omnigentCatalogQuery.data?.eligibleProviderProfiles || []).map((profile) => ({
-        profile_id: profile.profileId,
-        account_label: profile.label,
-        provider_id: profile.providerId,
-        enabled: true,
-        launch_ready: true,
-      }))
+    ? (omnigentCatalogQuery.data?.eligibleProviderProfiles || []).map((profile) => {
+        const capabilityProfile = (providerProfilesQuery.data || []).find(
+          (candidate) => candidate.profile_id === profile.profileId,
+        );
+        return {
+          ...capabilityProfile,
+          profile_id: profile.profileId,
+          account_label: profile.label,
+          provider_id: profile.providerId,
+          enabled: true,
+          launch_ready: true,
+        };
+      })
     : (providerProfilesQuery.data || []);
 
   useEffect(() => {
@@ -7929,12 +7943,47 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
   const selectableOmnigentPolicies = omnigentPolicies.filter((policy) =>
     selectedOmnigentReadiness?.policyRefs.includes(String(policy.ref || "")),
   );
+  const selectedEligibleOmnigentProfile = (omnigentCatalogQuery.data?.eligibleProviderProfiles || []).find(
+    (profile) => profile.profileId === providerProfile,
+  );
+  const historicalOmnigentProviderProfile = (omnigentCatalogQuery.data?.ineligibleProviderProfiles || []).find(
+    (profile) => profile.profileId === providerProfile,
+  );
+  const selectedOmnigentPolicyAvailable = selectableOmnigentPolicies.some(
+    (policy) => policy.ref === omnigentLaunchPolicyRef,
+  );
+  const omnigentSelectionGateReason =
+    selectedOmnigentReadiness?.gateReasons?.[0]?.message ||
+    historicalOmnigentProviderProfile?.gateReasons?.[0]?.message ||
+    omnigentCatalogQuery.data?.gateReasons?.[0]?.message ||
+    (!selectedEligibleOmnigentProfile
+      ? "Choose an eligible Codex OAuth Provider Profile."
+      : selectedEligibleOmnigentProfile.busy && !selectedEligibleOmnigentProfile.queueWhenBusy
+          ? "The selected Provider Profile is busy and does not support queued waiting."
+          : !selectedOmnigentPolicyAvailable
+            ? "Choose a compatible Omnigent host policy."
+            : null);
+  const omnigentSelectionEligible =
+    runtime !== "omnigent" ||
+    (omnigentCatalogQuery.data?.available === true &&
+      selectedOmnigentReadiness?.available === true &&
+      Boolean(selectedEligibleOmnigentProfile) &&
+      selectedOmnigentPolicyAvailable &&
+      !(selectedEligibleOmnigentProfile?.busy && !selectedEligibleOmnigentProfile.queueWhenBusy));
 
   const selectedProviderProfileForPreview = providerProfilesQuery.isPlaceholderData
     ? undefined
     : activeProviderProfiles.find(
         (profile) => profile.profile_id === providerProfile,
       );
+  const selectedProfileSupportsModelControls =
+    runtime !== "omnigent" ||
+    Boolean(
+      selectedProviderProfileForPreview &&
+        ((selectedProviderProfileForPreview.model_tiers?.length || 0) > 0 ||
+          selectedProviderProfileForPreview.default_model ||
+          selectedProviderProfileForPreview.default_effort),
+    );
   const workflowTierPreview = previewModelTier(
     selectedProviderProfileForPreview,
     modelTier,
@@ -9861,7 +9910,7 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
         return;
       }
     }
-    const submittedModelTierValue = modelTier.trim();
+    const submittedModelTierValue = selectedProfileSupportsModelControls ? modelTier.trim() : "";
     const submittedModelTier = Number.parseInt(submittedModelTierValue, 10);
     const hasSubmittedModelTier = submittedModelTierValue !== "";
     if (
@@ -10845,8 +10894,8 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
           (profile) => profile.profile_id === providerProfile,
         );
     const selectedProviderId = selectedProviderProfile?.provider_id?.trim?.() || "";
-    const submittedModel = modelManualOverride ? model.trim() : "";
-    const submittedEffort = effortManualOverride ? effort.trim() : "";
+    const submittedModel = selectedProfileSupportsModelControls && modelManualOverride ? model.trim() : "";
+    const submittedEffort = selectedProfileSupportsModelControls && effortManualOverride ? effort.trim() : "";
 
     const taskPayload: Record<string, unknown> = {
       instructions: objectiveInstructionsForSubmit,
@@ -11279,6 +11328,8 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
   const isTemporalFormBlocked =
     pageMode.mode !== "create" &&
     (temporalDraftQuery.isLoading || Boolean(modeLoadError));
+  const isSubmitBlocked =
+    isTemporalFormBlocked || (runtime === "omnigent" && !omnigentSelectionEligible);
 
   useEffect(() => {
     if (!showPrimaryCtaArrow || isTemporalFormBlocked) {
@@ -13103,13 +13154,20 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
                   {runtime !== "omnigent" && providerProfilesQuery.isPlaceholderData ? (
                     <option value="">Loading profiles…</option>
                   ) : (
-                    providerOptions.map((option) => (
-                      <option key={option.id} value={option.id}>
-                        {option.isDefault
-                          ? `${option.label} (Default)`
-                          : option.label}
-                      </option>
-                    ))
+                    <>
+                      {runtime === "omnigent" && providerProfile && !providerOptions.some((option) => option.id === providerProfile) ? (
+                        <option value={providerProfile} disabled>
+                          {historicalOmnigentProviderProfile?.label || providerProfile} (Unavailable — replacement required)
+                        </option>
+                      ) : null}
+                      {providerOptions.map((option) => (
+                        <option key={option.id} value={option.id}>
+                          {option.isDefault
+                            ? `${option.label} (Default)`
+                            : option.label}
+                        </option>
+                      ))}
+                    </>
                   )}
                 </select>
               </label>
@@ -13173,16 +13231,24 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
         ) : null}
 
         {runtime.trim().toLowerCase() === "omnigent" ? (
-          <div className="notice small" aria-label="Effective Omnigent selection">
-            <div>Runtime: Codex via Omnigent</div>
-            <div>Provider Profile: {providerOptions.find((option) => option.id === providerProfile)?.label || providerProfile || "Not selected"}</div>
-            <div>Host mode: {omnigentPolicies.find((policy) => policy.ref === omnigentLaunchPolicyRef)?.hostMode === "on_demand_docker" ? "On-demand Docker" : "Static Compose"}</div>
-            <div>Policy: {omnigentLaunchPolicyRef || "Not selected"}</div>
-            <div>Repository: {repository.trim() || "Not selected"}</div>
-          </div>
+          <>
+            {!omnigentSelectionEligible && omnigentSelectionGateReason ? (
+              <div className="notice error small" role="alert">
+                Codex via Omnigent cannot be submitted: {omnigentSelectionGateReason}
+              </div>
+            ) : null}
+            <div className="notice small" aria-label="Effective Omnigent selection">
+              <div>Runtime: Codex via Omnigent</div>
+              <div>Provider Profile: {providerOptions.find((option) => option.id === providerProfile)?.label || historicalOmnigentProviderProfile?.label || providerProfile || "Not selected"}</div>
+              <div>Host mode: {omnigentPolicies.find((policy) => policy.ref === omnigentLaunchPolicyRef)?.hostMode === "on_demand_docker" ? "On-demand Docker" : "Static Compose"}</div>
+              <div>Policy: {omnigentLaunchPolicyRef || "Not selected"}</div>
+              <div>Repository: {repository.trim() || "Not selected"}</div>
+            </div>
+          </>
         ) : null}
 
-        <div className="grid-2" aria-label="Workflow model tier intent">
+        {selectedProfileSupportsModelControls ? (
+        <><div className="grid-2" aria-label="Workflow model tier intent">
           <label>
             Model tier intent
             <input
@@ -13221,9 +13287,10 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
               </span>
             ) : null}
           </div>
+        ) : null}</>
         ) : null}
 
-        <div className="grid-2">
+        {selectedProfileSupportsModelControls ? (<div className="grid-2">
           <label>
             Hard override model
             <input
@@ -13252,7 +13319,7 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
               }}
             />
           </label>
-        </div>
+        </div>) : null}
 
         </section>
 
@@ -13688,14 +13755,14 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
                     }`
                   : "queue-submit-primary queue-submit-primary--with-arrow"
               }
-              disabled={isTemporalFormBlocked}
-              aria-disabled={isSubmitting || isTemporalFormBlocked}
+              disabled={isSubmitBlocked}
+              aria-disabled={isSubmitting || isSubmitBlocked}
               aria-busy={isSubmitting}
               aria-label={primaryCta}
               title={primaryCtaTooltip}
               onPointerDown={(event) => {
                 if (event.button !== 0) return;
-                if (isTemporalFormBlocked) return;
+                if (isSubmitBlocked) return;
                 const rect =
                   submitButtonRef.current?.getBoundingClientRect() ?? null;
                 setSubmitRippleRect(rect);

--- a/frontend/src/entrypoints/workflow-start.tsx
+++ b/frontend/src/entrypoints/workflow-start.tsx
@@ -9874,6 +9874,11 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
     }
     if (normalizedRuntime === "omnigent") {
       const refreshed = await omnigentCatalogQuery.refetch();
+      if (refreshed.isError) {
+        setSubmitMessage("Codex via Omnigent readiness could not be verified.");
+        clearSubmitBusy();
+        return;
+      }
       const catalog = refreshed.data;
       const executionProfile = (catalog?.executionProfiles || []).find(
         (profile) => profile.ref === omnigentExecutionTargetRef,
@@ -9923,12 +9928,17 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
     }
     const invalidStepRuntime = submissionSteps.find((step) => {
       const stepRuntime = (step.runtimeMode || "").trim().toLowerCase();
-      return stepRuntime && !supportedAgentRuntimeIds.includes(stepRuntime);
+      return (
+        stepRuntime === "omnigent" ||
+        (stepRuntime && !supportedAgentRuntimeIds.includes(stepRuntime))
+      );
     });
     if (invalidStepRuntime) {
       const stepIndex = submissionSteps.indexOf(invalidStepRuntime) + 1;
       setSubmitMessage(
-        `Step ${stepIndex} runtime must be one of: ${supportedAgentRuntimes.join(", ")}.`,
+        (invalidStepRuntime.runtimeMode || "").trim().toLowerCase() === "omnigent"
+          ? `Step ${stepIndex} cannot use Codex via Omnigent; select it as the workflow runtime instead.`
+          : `Step ${stepIndex} runtime must be one of: ${supportedAgentRuntimes.join(", ")}.`,
       );
       clearSubmitBusy();
       return;
@@ -10913,7 +10923,10 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
       runtime: {
         mode: normalizedRuntime,
         ...(hasSubmittedModelTier ? { modelTier: submittedModelTier } : {}),
-        ...(hasSubmittedModelTier || tierFallback === "strict" ? { tierFallback } : {}),
+        ...(selectedProfileSupportsModelControls &&
+        (hasSubmittedModelTier || tierFallback === "strict")
+          ? { tierFallback }
+          : {}),
         ...(submittedModel ? { model: submittedModel } : {}),
         ...(submittedEffort ? { effort: submittedEffort } : {}),
         ...(providerProfile ? { profileId: providerProfile } : {}),
@@ -11099,6 +11112,10 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
           selectedAttachmentFiles.length > 0 ||
           normalizedRepository !== String(rerunDraft.repository || "").trim() ||
           normalizedRuntime !== String(rerunDraft.runtime || "").trim() ||
+          omnigentExecutionTargetRef.trim() !==
+            String(rerunDraft.omnigentExecutionTargetRef || "").trim() ||
+          omnigentLaunchPolicyRef.trim() !==
+            String(rerunDraft.omnigentLaunchPolicyRef || "").trim() ||
           model.trim() !== String(rerunDraft.model || "").trim() ||
           effort.trim() !== String(rerunDraft.effort || "").trim() ||
           effectivePublishMode !== rerunDraftEffectivePublishMode ||

--- a/frontend/src/entrypoints/workflow-start.tsx
+++ b/frontend/src/entrypoints/workflow-start.tsx
@@ -596,6 +596,14 @@ interface OmnigentCodexCatalogReadiness {
   runtimeId: "omnigent";
   displayName: string;
   available: boolean;
+  defaultExecutionProfileRef: string;
+  executionProfiles: Array<{
+    ref: string;
+    displayName: string;
+    available: boolean;
+    policyRefs: string[];
+    gateReasons: OmnigentCatalogGateReason[];
+  }>;
   eligibleProviderProfiles: Array<{
     profileId: string;
     label: string;
@@ -6371,6 +6379,13 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
     : (providerProfilesQuery.data || []);
 
   useEffect(() => {
+    if (runtime !== "omnigent" || !omnigentCatalogQuery.data) return;
+    if (!omnigentExecutionTargetRef) {
+      setOmnigentExecutionTargetRef(omnigentCatalogQuery.data.defaultExecutionProfileRef);
+    }
+  }, [runtime, omnigentCatalogQuery.data, omnigentExecutionTargetRef]);
+
+  useEffect(() => {
     const profiles = activeProviderProfiles;
     if (
       (runtime === "omnigent" && omnigentCatalogQuery.isFetching) ||
@@ -6499,6 +6514,12 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
     if (draft.providerProfile) {
       prevProviderProfileRef.current = draft.providerProfile;
       setProviderProfile(draft.providerProfile);
+    }
+    if (draft.omnigentExecutionTargetRef) {
+      setOmnigentExecutionTargetRef(draft.omnigentExecutionTargetRef);
+    }
+    if (draft.omnigentLaunchPolicyRef) {
+      setOmnigentLaunchPolicyRef(draft.omnigentLaunchPolicyRef);
     }
     if (draft.model) {
       setModel(draft.model);
@@ -7897,6 +7918,17 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
           : profile.account_label || profile.profile_id,
       isDefault: Boolean(profile.is_default),
     }));
+  const selectedOmnigentReadiness = (omnigentCatalogQuery.data?.executionProfiles || []).find(
+    (profile) => profile.ref === omnigentExecutionTargetRef,
+  );
+  const selectableOmnigentProfiles = omnigentProfiles.filter((profile) =>
+    (omnigentCatalogQuery.data?.executionProfiles || []).some(
+      (readiness) => readiness.ref === profile.ref && readiness.available,
+    ),
+  );
+  const selectableOmnigentPolicies = omnigentPolicies.filter((policy) =>
+    selectedOmnigentReadiness?.policyRefs.includes(String(policy.ref || "")),
+  );
 
   const selectedProviderProfileForPreview = providerProfilesQuery.isPlaceholderData
     ? undefined
@@ -9781,15 +9813,53 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
     setAttachmentTargetErrors({});
 
     const normalizedRuntime = runtime.trim().toLowerCase();
-    const supportedAgentRuntimeIds = supportedAgentRuntimes.map((item) =>
+    const supportedAgentRuntimeIds = runtimeOptions.map((item) =>
       item.trim().toLowerCase(),
     );
     if (!supportedAgentRuntimeIds.includes(normalizedRuntime)) {
       setSubmitMessage(
-        `Runtime must be one of: ${supportedAgentRuntimes.join(", ")}.`,
+        `Runtime must be one of: ${runtimeOptions.join(", ")}.`,
       );
       clearSubmitBusy();
       return;
+    }
+    if (normalizedRuntime === "omnigent") {
+      const refreshed = await omnigentCatalogQuery.refetch();
+      const catalog = refreshed.data;
+      const executionProfile = (catalog?.executionProfiles || []).find(
+        (profile) => profile.ref === omnigentExecutionTargetRef,
+      );
+      const eligibleProfile = catalog?.eligibleProviderProfiles.find(
+        (profile) => profile.profileId === providerProfile,
+      );
+      if (!catalog?.available || !executionProfile?.available) {
+        setSubmitMessage(
+          executionProfile?.gateReasons[0]?.message ||
+            catalog?.gateReasons[0]?.message ||
+            "Codex via Omnigent readiness could not be verified.",
+        );
+        clearSubmitBusy();
+        return;
+      }
+      if (!eligibleProfile) {
+        setSubmitMessage(
+          "The selected Codex OAuth Provider Profile is no longer eligible. Choose an eligible profile explicitly.",
+        );
+        clearSubmitBusy();
+        return;
+      }
+      if (!executionProfile.policyRefs.includes(omnigentLaunchPolicyRef)) {
+        setSubmitMessage(
+          "The selected Omnigent host policy is no longer compatible. Choose an available policy explicitly.",
+        );
+        clearSubmitBusy();
+        return;
+      }
+      if (eligibleProfile.busy && !eligibleProfile.queueWhenBusy) {
+        setSubmitMessage("The selected Provider Profile is busy and does not support queued waiting.");
+        clearSubmitBusy();
+        return;
+      }
     }
     const submittedModelTierValue = modelTier.trim();
     const submittedModelTier = Number.parseInt(submittedModelTierValue, 10);
@@ -10769,9 +10839,9 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
     // Never resolve a provider profile from placeholder data: during a runtime
     // switch refetch `data` still holds the previous runtime's profiles, which
     // must not be submitted under the newly selected runtime.
-    const selectedProviderProfile = providerProfilesQuery.isPlaceholderData
+    const selectedProviderProfile = runtime !== "omnigent" && providerProfilesQuery.isPlaceholderData
       ? undefined
-      : (providerProfilesQuery.data || []).find(
+      : activeProviderProfiles.find(
           (profile) => profile.profile_id === providerProfile,
         );
     const selectedProviderId = selectedProviderProfile?.provider_id?.trim?.() || "";
@@ -13028,9 +13098,9 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
                   // layout stays stable. Those profiles do not belong to the newly
                   // selected runtime, so the control is disabled and the stale
                   // options are withheld to prevent selecting/submitting them.
-                  disabled={providerProfilesQuery.isPlaceholderData}
+                  disabled={runtime === "omnigent" ? omnigentCatalogQuery.isFetching : providerProfilesQuery.isPlaceholderData}
                 >
-                  {providerProfilesQuery.isPlaceholderData ? (
+                  {runtime !== "omnigent" && providerProfilesQuery.isPlaceholderData ? (
                     <option value="">Loading profiles…</option>
                   ) : (
                     providerOptions.map((option) => (
@@ -13068,7 +13138,12 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
                   }
                 }}
               >
-                {omnigentProfiles.map((profile) => (
+                {!selectableOmnigentProfiles.some((profile) => profile.ref === omnigentExecutionTargetRef) && omnigentExecutionTargetRef ? (
+                  <option value={omnigentExecutionTargetRef} disabled>
+                    {omnigentExecutionTargetRef} (Unavailable — replacement required)
+                  </option>
+                ) : null}
+                {selectableOmnigentProfiles.map((profile) => (
                   <option key={profile.ref} value={profile.ref}>
                     {profile.displayName || profile.ref}
                   </option>
@@ -13082,13 +13157,28 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
                 value={omnigentLaunchPolicyRef}
                 onChange={(event) => setOmnigentLaunchPolicyRef(event.target.value)}
               >
-                {omnigentPolicies.map((policy) => (
+                {!selectableOmnigentPolicies.some((policy) => policy.ref === omnigentLaunchPolicyRef) && omnigentLaunchPolicyRef ? (
+                  <option value={omnigentLaunchPolicyRef} disabled>
+                    {omnigentLaunchPolicyRef} (Unavailable — replacement required)
+                  </option>
+                ) : null}
+                {selectableOmnigentPolicies.map((policy) => (
                   <option key={policy.ref} value={policy.ref}>
                     {policy.hostMode === "on_demand_docker" ? "On-demand Docker" : "Static Compose"}
                   </option>
                 ))}
               </select>
             </label>
+          </div>
+        ) : null}
+
+        {runtime.trim().toLowerCase() === "omnigent" ? (
+          <div className="notice small" aria-label="Effective Omnigent selection">
+            <div>Runtime: Codex via Omnigent</div>
+            <div>Provider Profile: {providerOptions.find((option) => option.id === providerProfile)?.label || providerProfile || "Not selected"}</div>
+            <div>Host mode: {omnigentPolicies.find((policy) => policy.ref === omnigentLaunchPolicyRef)?.hostMode === "on_demand_docker" ? "On-demand Docker" : "Static Compose"}</div>
+            <div>Policy: {omnigentLaunchPolicyRef || "Not selected"}</div>
+            <div>Repository: {repository.trim() || "Not selected"}</div>
           </div>
         ) : null}
 

--- a/frontend/src/lib/temporalTaskEditing.test.ts
+++ b/frontend/src/lib/temporalTaskEditing.test.ts
@@ -29,6 +29,32 @@ describe("MoonLadderStudios/MoonMind#3452 Omnigent draft round-trip", () => {
       omnigentLaunchPolicyRef: "omnigent-codex-on-demand-v1",
     });
   });
+
+  it.each([
+    ["edit", { draft: { runtime: "omnigent", providerProfile: "oauth-history", omnigentExecutionTargetRef: "target-history", omnigentLaunchPolicyRef: "policy-history", model: "gpt-history", effort: "high" } }],
+    ["edit-for-rerun", { workflow: { runtime: { mode: "omnigent", profileId: "oauth-history", model: "gpt-history", effort: "high" } }, omnigent: { executionTargetRef: "target-history", launchPolicyRef: "policy-history" } }],
+    ["rerun", { draft: { runtime: "omnigent", providerProfile: "oauth-history", omnigentExecutionTargetRef: "target-history", omnigentLaunchPolicyRef: "policy-history", model: "gpt-history", effort: "high" } }],
+    ["comparison", { workflow: { runtime: { mode: "omnigent", profileId: "oauth-history", model: "gpt-history", effort: "high" } }, omnigent: { executionTargetRef: "target-history", launchPolicyRef: "policy-history" } }],
+  ])("preserves the unavailable historical selection for %s reconstruction", (_mode, artifactInput) => {
+    const draft = buildTemporalSubmissionDraftFromExecution(
+      {
+        workflowId: "mm:omnigent-history",
+        workflowType: "MoonMind.UserWorkflow",
+        targetRuntime: "omnigent",
+        inputParameters: { workflow: { instructions: "Inspect historical selection." } },
+      },
+      artifactInput,
+    );
+
+    expect(draft).toMatchObject({
+      runtime: "omnigent",
+      providerProfile: "oauth-history",
+      omnigentExecutionTargetRef: "target-history",
+      omnigentLaunchPolicyRef: "policy-history",
+      model: "gpt-history",
+      effort: "high",
+    });
+  });
 });
 
 describe("buildTemporalSubmissionDraftFromExecution runtime command metadata", () => {

--- a/frontend/src/lib/temporalTaskEditing.test.ts
+++ b/frontend/src/lib/temporalTaskEditing.test.ts
@@ -2,6 +2,35 @@ import { describe, expect, it } from "vitest";
 
 import { buildTemporalSubmissionDraftFromExecution } from "./temporalTaskEditing";
 
+describe("MoonLadderStudios/MoonMind#3452 Omnigent draft round-trip", () => {
+  it("preserves canonical execution target and launch policy refs", () => {
+    const draft = buildTemporalSubmissionDraftFromExecution({
+      workflowId: "mm:omnigent-edit",
+      workflowType: "MoonMind.UserWorkflow",
+      targetRuntime: "omnigent",
+      inputParameters: {
+        targetRuntime: "omnigent",
+        profileId: "codex-oauth-team",
+        omnigent: {
+          executionTargetRef: "omnigent-codex-default",
+          launchPolicyRef: "omnigent-codex-on-demand-v1",
+        },
+        workflow: {
+          instructions: "Implement the requested change.",
+          runtime: { mode: "omnigent", profileId: "codex-oauth-team" },
+        },
+      },
+    });
+
+    expect(draft).toMatchObject({
+      runtime: "omnigent",
+      providerProfile: "codex-oauth-team",
+      omnigentExecutionTargetRef: "omnigent-codex-default",
+      omnigentLaunchPolicyRef: "omnigent-codex-on-demand-v1",
+    });
+  });
+});
+
 describe("buildTemporalSubmissionDraftFromExecution runtime command metadata", () => {
   const objectiveRuntimeCommand = {
     kind: "slash_command",

--- a/frontend/src/lib/temporalTaskEditing.ts
+++ b/frontend/src/lib/temporalTaskEditing.ts
@@ -107,6 +107,8 @@ export type TemporalSubmissionDraftPresetPayload = {
 export type TemporalSubmissionDraft = {
   runtime: string | null;
   providerProfile: string | null;
+  omnigentExecutionTargetRef: string | null;
+  omnigentLaunchPolicyRef: string | null;
   model: string | null;
   effort: string | null;
   modelTier: number | null;
@@ -896,6 +898,8 @@ export function buildTemporalSubmissionDraftFromExecution(
     : workflowRecord(artifactParams);
   const runtime = objectValue(task.runtime);
   const artifactRuntime = objectValue(artifactTask.runtime);
+  const omnigent = objectValue(params.omnigent);
+  const artifactOmnigent = objectValue(artifactParams.omnigent);
   const git = objectValue(task.git);
   const artifactGit = objectValue(artifactTask.git);
   const publish = objectValue(task.publish);
@@ -985,6 +989,16 @@ export function buildTemporalSubmissionDraftFromExecution(
       params.profileId,
       runtime.profileId,
       artifactRuntime.profileId,
+    ),
+    omnigentExecutionTargetRef: nullableStringValue(
+      snapshotDraft.omnigentExecutionTargetRef,
+      omnigent.executionTargetRef,
+      artifactOmnigent.executionTargetRef,
+    ),
+    omnigentLaunchPolicyRef: nullableStringValue(
+      snapshotDraft.omnigentLaunchPolicyRef,
+      omnigent.launchPolicyRef,
+      artifactOmnigent.launchPolicyRef,
     ),
     model: nullableStringValue(
       snapshotDraft.model,


### PR DESCRIPTION
Issue: MoonLadderStudios/MoonMind#3452

Closes MoonLadderStudios/MoonMind#3452

## Summary
- add Codex via Omnigent as a catalog-driven runtime in normal workflow authoring
- enforce profile, execution-profile, policy, readiness, and stale-selection gates without exposing host/container authority
- preserve canonical Omnigent runtime intent through create, edit, rerun, comparison, and schedule flows
- add confirmation UI and focused regression, accessibility, responsive, payload, and round-trip coverage

## Tests run
- `npm run ui:test -- frontend/src/entrypoints/workflow-start.test.tsx frontend/src/lib/temporalTaskEditing.test.ts` (127 passed)
- `node node_modules/typescript/bin/tsc --noEmit -p frontend/tsconfig.json`
- `git diff --check`

## Remaining risks
- no known issue-scope gaps; backend compilation, Settings management, and Workflow Detail runtime rendering remain owned by their separate follow-up issues