### PR TITLE
MoonLadderStudios/MoonMind#3455: Complete Omnigent Workflow Detail lifecycle and controls

### DIFF
--- a/api_service/api/routers/omnigent_bridge.py
+++ b/api_service/api/routers/omnigent_bridge.py
@@ -894,6 +894,7 @@ class BridgeSessionResolution(BaseModel):
     provider_session_ref: str | None = None
     omnigent_host_ref: str | None = None
     omnigent_runner_ref: str | None = None
+    first_message_state: str | None = None
     capabilities: dict[str, bool] = Field(default_factory=dict)
 
 
@@ -1163,6 +1164,7 @@ async def resolve_omnigent_bridge_session_projection(
         provider_session_ref=row.omnigent_session_id,
         omnigent_host_ref=getattr(row, "omnigent_host_id", None),
         omnigent_runner_ref=getattr(row, "omnigent_runner_id", None),
+        first_message_state=getattr(row, "first_message_state", None),
         capabilities=_projection_capabilities(row),
     )
 
@@ -1387,6 +1389,19 @@ async def post_omnigent_session_event(
                     actor=str(user.id),
                 )
             return await control_facade.stop_session(session_id)
+        if payload.type in {"cleanup_session", "terminal_cleanup"}:
+            if config.host_protocol_mode != HOST_PROTOCOL_MODE_EMBEDDED:
+                raise OmnigentBridgeError(
+                    "Typed owned-resource cleanup is unavailable in this mode.",
+                    failure_class="user_error", status_code=501,
+                    code="omnigent_bridge_capability_unavailable",
+                )
+            assert embedded_facade is not None
+            return await embedded_facade.cleanup_session(
+                session_id,
+                payload=payload.model_dump(by_alias=True, exclude_none=True),
+                actor=str(user.id),
+            )
         if config.host_protocol_mode == HOST_PROTOCOL_MODE_EMBEDDED:
             assert embedded_facade is not None
             if payload.type == "harvest_session":

--- a/api_service/api/routers/omnigent_bridge.py
+++ b/api_service/api/routers/omnigent_bridge.py
@@ -883,8 +883,17 @@ class BridgeSessionResolution(BaseModel):
     terminal_evidence_available: bool
     compatibility_profile: str
     provider_profile_id: str | None = None
+    provider_lease_ref: str | None = None
+    credential_generation: int | None = None
     host_binding_ref: str | None = None
+    host_lease_ref: str | None = None
+    host_mode: str | None = None
+    execution_profile_ref: str | None = None
+    launch_policy_ref: str | None = None
+    effective_launch_snapshot_ref: str | None = None
     provider_session_ref: str | None = None
+    omnigent_host_ref: str | None = None
+    omnigent_runner_ref: str | None = None
     capabilities: dict[str, bool] = Field(default_factory=dict)
 
 
@@ -1125,6 +1134,11 @@ async def resolve_omnigent_bridge_session_projection(
         store=store,
     )
     page = await store.list_event_page(row.bridge_session_id, after=0, limit=1)
+    launch = (
+        getattr(row, "effective_launch_snapshot_json", None)
+        if isinstance(getattr(row, "effective_launch_snapshot_json", None), dict)
+        else {}
+    )
     return BridgeSessionResolution(
         bridge_session_id=row.bridge_session_id,
         workflow_id=row.moonmind_workflow_id,
@@ -1138,8 +1152,17 @@ async def resolve_omnigent_bridge_session_projection(
         terminal_evidence_available=_terminal_envelope(row) is not None,
         compatibility_profile=row.compatibility_profile,
         provider_profile_id=row.provider_profile_id,
+        provider_lease_ref=getattr(row, "provider_lease_id", None),
+        credential_generation=getattr(row, "credential_generation", None),
         host_binding_ref=row.host_binding_ref,
+        host_lease_ref=getattr(row, "host_lease_ref", None),
+        host_mode=str(launch.get("hostMode") or "") or None,
+        execution_profile_ref=str(launch.get("executionProfileRef") or "") or None,
+        launch_policy_ref=str(launch.get("launchPolicyRef") or "") or None,
+        effective_launch_snapshot_ref=str(launch.get("snapshotRef") or "") or None,
         provider_session_ref=row.omnigent_session_id,
+        omnigent_host_ref=getattr(row, "omnigent_host_id", None),
+        omnigent_runner_ref=getattr(row, "omnigent_runner_id", None),
         capabilities=_projection_capabilities(row),
     )
 

--- a/frontend/src/entrypoints/workflow-detail.test.tsx
+++ b/frontend/src/entrypoints/workflow-detail.test.tsx
@@ -8263,7 +8263,11 @@ describe('Workflow Detail Entrypoint', () => {
       const url = String(input);
       if (url.includes('/bridge-sessions/resolve')) return Promise.resolve({ ok: true, json: async () => ({
         bridgeSessionId: 'brs-interventions', status: 'running', providerSessionRef: 'provider-session',
-        capabilities: { resolveElicitation: true, clearSession: true, cancelSession: true },
+        workflowId: 'test-123', agentRunId: 'agent-run-1', compatibilityProfile: 'omnigent.embedded.v1',
+        providerProfileId: 'codex-profile', executionProfileRef: 'codex-default@2', launchPolicyRef: 'restricted@3',
+        hostMode: 'on_demand_docker', effectiveLaunchSnapshotRef: 'omnigent-launch:sha256:safe-ref',
+        hostLeaseRef: 'host-lease-1', credentialGeneration: 4, omnigentHostRef: 'host-1', omnigentRunnerRef: 'runner-1',
+        capabilities: { resolveElicitation: true, clearSession: true, cancelSession: true, stop: true, terminalCleanup: true },
       }) } as Response);
       if (url.includes('/bridge-sessions/brs-interventions/events')) return Promise.resolve({ ok: true, json: async () => ({
         schemaVersion: 'moonmind.bridge-session-events-page.v1', bridgeSessionId: 'brs-interventions',
@@ -8280,6 +8284,10 @@ describe('Workflow Detail Entrypoint', () => {
     try {
       renderWithClient(<WorkflowDetailPage payload={actionsPayload} />);
       expect(await screen.findByRole('region', { name: 'Pending operator request el-pending' })).toBeTruthy();
+      const identity = screen.getByRole('region', { name: 'Omnigent runtime identity' });
+      expect(identity.textContent).toContain('Codex via Omnigent');
+      expect(identity.textContent).toContain('codex-profile');
+      expect(identity.textContent).toContain('omnigent-launch:sha256:safe-ref');
       expect(screen.getAllByText('Previously approved by operator.').length).toBeGreaterThan(0);
       expect(screen.queryByRole('region', { name: 'Pending operator request el-resolved' })).toBeNull();
 
@@ -8295,6 +8303,14 @@ describe('Workflow Detail Entrypoint', () => {
       await waitFor(() => expect(fetchSpy.mock.calls.some(([url, init]) =>
         String(url).endsWith('/omnigent/v1/sessions/provider-session/events') &&
         JSON.parse(String((init as RequestInit).body)).type === 'session.cancel')).toBe(true));
+      fireEvent.click(screen.getByRole('button', { name: 'Stop session' }));
+      await waitFor(() => expect(fetchSpy.mock.calls.some(([url, init]) =>
+        String(url).endsWith('/omnigent/v1/sessions/provider-session/events') &&
+        JSON.parse(String((init as RequestInit).body)).type === 'stop_session')).toBe(true));
+      fireEvent.click(screen.getByRole('button', { name: 'Remove owned session' }));
+      await waitFor(() => expect(fetchSpy.mock.calls.some(([url, init]) =>
+        String(url).endsWith('/omnigent/v1/sessions/provider-session') &&
+        (init as RequestInit).method === 'DELETE')).toBe(true));
     } finally {
       confirmSpy.mockRestore();
       window.EventSource = priorEventSource;
@@ -8319,6 +8335,8 @@ describe('Workflow Detail Entrypoint', () => {
       expect(screen.queryByRole('button', { name: 'Approve' })).toBeNull();
       expect(screen.queryByRole('button', { name: 'Clear session' })).toBeNull();
       expect(screen.queryByRole('button', { name: 'Cancel session' })).toBeNull();
+      expect(screen.queryByRole('button', { name: 'Stop session' })).toBeNull();
+      expect(screen.queryByRole('button', { name: 'Remove owned session' })).toBeNull();
     } finally {
       window.EventSource = priorEventSource;
     }

--- a/frontend/src/entrypoints/workflow-detail.test.tsx
+++ b/frontend/src/entrypoints/workflow-detail.test.tsx
@@ -8263,7 +8263,7 @@ describe('Workflow Detail Entrypoint', () => {
       const url = String(input);
       if (url.includes('/bridge-sessions/resolve')) return Promise.resolve({ ok: true, json: async () => ({
         bridgeSessionId: 'brs-interventions', status: 'running', providerSessionRef: 'provider-session',
-        workflowId: 'test-123', agentRunId: 'agent-run-1', compatibilityProfile: 'omnigent.embedded.v1',
+        compatibilityProfile: 'omnigent.embedded.v1',
         providerProfileId: 'codex-profile', executionProfileRef: 'codex-default@2', launchPolicyRef: 'restricted@3',
         hostMode: 'on_demand_docker', effectiveLaunchSnapshotRef: 'omnigent-launch:sha256:safe-ref',
         hostLeaseRef: 'host-lease-1', credentialGeneration: 4,

--- a/frontend/src/entrypoints/workflow-detail.test.tsx
+++ b/frontend/src/entrypoints/workflow-detail.test.tsx
@@ -8266,7 +8266,9 @@ describe('Workflow Detail Entrypoint', () => {
         workflowId: 'test-123', agentRunId: 'agent-run-1', compatibilityProfile: 'omnigent.embedded.v1',
         providerProfileId: 'codex-profile', executionProfileRef: 'codex-default@2', launchPolicyRef: 'restricted@3',
         hostMode: 'on_demand_docker', effectiveLaunchSnapshotRef: 'omnigent-launch:sha256:safe-ref',
-        hostLeaseRef: 'host-lease-1', credentialGeneration: 4, omnigentHostRef: 'host-1', omnigentRunnerRef: 'runner-1',
+        hostLeaseRef: 'host-lease-1', credentialGeneration: 4,
+        workflowId: 'test-123', runId: 'run-1', stepExecutionId: 'step-1', agentRunId: 'agent-run-1',
+        firstMessageState: 'first_message_posted', omnigentHostRef: 'host-1', omnigentRunnerRef: 'runner-1',
         capabilities: { resolveElicitation: true, clearSession: true, cancelSession: true, stop: true, terminalCleanup: true },
       }) } as Response);
       if (url.includes('/bridge-sessions/brs-interventions/events')) return Promise.resolve({ ok: true, json: async () => ({
@@ -8306,11 +8308,15 @@ describe('Workflow Detail Entrypoint', () => {
       fireEvent.click(screen.getByRole('button', { name: 'Stop session' }));
       await waitFor(() => expect(fetchSpy.mock.calls.some(([url, init]) =>
         String(url).endsWith('/omnigent/v1/sessions/provider-session/events') &&
-        JSON.parse(String((init as RequestInit).body)).type === 'stop_session')).toBe(true));
+        JSON.parse(String((init as RequestInit).body)).type === 'stop_session' &&
+        JSON.parse(String((init as RequestInit).body)).expectedBridgeSessionId === 'brs-interventions' &&
+        JSON.parse(String((init as RequestInit).body)).expectedRunnerId === 'runner-1' &&
+        typeof JSON.parse(String((init as RequestInit).body)).idempotencyKey === 'string')).toBe(true));
       fireEvent.click(screen.getByRole('button', { name: 'Remove owned session' }));
       await waitFor(() => expect(fetchSpy.mock.calls.some(([url, init]) =>
-        String(url).endsWith('/omnigent/v1/sessions/provider-session') &&
-        (init as RequestInit).method === 'DELETE')).toBe(true));
+        String(url).endsWith('/omnigent/v1/sessions/provider-session/events') &&
+        JSON.parse(String((init as RequestInit).body)).type === 'cleanup_session' &&
+        JSON.parse(String((init as RequestInit).body)).expectedWorkflowId === 'test-123')).toBe(true));
     } finally {
       confirmSpy.mockRestore();
       window.EventSource = priorEventSource;

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -2504,7 +2504,19 @@ type BridgeSessionProjection = {
   agentRunId?: string | undefined;
   idempotencyKey?: string | undefined;
   status?: string | undefined;
+  compatibilityProfile?: string | undefined;
+  providerProfileId?: string | undefined;
+  providerLeaseRef?: string | undefined;
+  credentialGeneration?: number | undefined;
+  hostBindingRef?: string | undefined;
+  hostLeaseRef?: string | undefined;
+  hostMode?: string | undefined;
+  executionProfileRef?: string | undefined;
+  launchPolicyRef?: string | undefined;
+  effectiveLaunchSnapshotRef?: string | undefined;
   providerSessionRef?: string | undefined;
+  omnigentHostRef?: string | undefined;
+  omnigentRunnerRef?: string | undefined;
   capabilities: Record<string, boolean>;
 };
 
@@ -2656,7 +2668,19 @@ async function resolveBridgeSessionProjection({
     agentRunId: typeof body.agentRunId === 'string' ? body.agentRunId : undefined,
     idempotencyKey: typeof body.idempotencyKey === 'string' ? body.idempotencyKey : undefined,
     status: typeof body.status === 'string' ? body.status : undefined,
+    compatibilityProfile: typeof body.compatibilityProfile === 'string' ? body.compatibilityProfile : undefined,
+    providerProfileId: typeof body.providerProfileId === 'string' ? body.providerProfileId : undefined,
+    providerLeaseRef: typeof body.providerLeaseRef === 'string' ? body.providerLeaseRef : undefined,
+    credentialGeneration: typeof body.credentialGeneration === 'number' ? body.credentialGeneration : undefined,
+    hostBindingRef: typeof body.hostBindingRef === 'string' ? body.hostBindingRef : undefined,
+    hostLeaseRef: typeof body.hostLeaseRef === 'string' ? body.hostLeaseRef : undefined,
+    hostMode: typeof body.hostMode === 'string' ? body.hostMode : undefined,
+    executionProfileRef: typeof body.executionProfileRef === 'string' ? body.executionProfileRef : undefined,
+    launchPolicyRef: typeof body.launchPolicyRef === 'string' ? body.launchPolicyRef : undefined,
+    effectiveLaunchSnapshotRef: typeof body.effectiveLaunchSnapshotRef === 'string' ? body.effectiveLaunchSnapshotRef : undefined,
     providerSessionRef: typeof body.providerSessionRef === 'string' ? body.providerSessionRef : undefined,
+    omnigentHostRef: typeof body.omnigentHostRef === 'string' ? body.omnigentHostRef : undefined,
+    omnigentRunnerRef: typeof body.omnigentRunnerRef === 'string' ? body.omnigentRunnerRef : undefined,
     capabilities: body.capabilities && typeof body.capabilities === 'object'
       ? Object.fromEntries(Object.entries(body.capabilities).filter((entry): entry is [string, boolean] => typeof entry[1] === 'boolean'))
       : {},
@@ -2670,6 +2694,13 @@ async function postBridgeSessionControl(
 ): Promise<void> {
   const resp = await fetch(joinApiBasePath(apiBase, `/omnigent/v1/sessions/${encodeURIComponent(providerSessionRef)}/events`), {
     method: 'POST', credentials: 'include', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(payload),
+  });
+  if (!resp.ok) throw buildObservabilityRequestError(resp.status);
+}
+
+async function removeBridgeSession(apiBase: string, providerSessionRef: string): Promise<void> {
+  const resp = await fetch(joinApiBasePath(apiBase, `/omnigent/v1/sessions/${encodeURIComponent(providerSessionRef)}`), {
+    method: 'DELETE', credentials: 'include',
   });
   if (!resp.ok) throw buildObservabilityRequestError(resp.status);
 }
@@ -5986,6 +6017,8 @@ function BridgeSessionLogsPanel({
   const canClear = Boolean(actionsEnabled && projection.providerSessionRef && projection.capabilities.clearSession && !isTerminal);
   const canCancel = Boolean(actionsEnabled && projection.providerSessionRef && projection.capabilities.cancelSession && !isTerminal);
   const canHarvest = Boolean(actionsEnabled && projection.providerSessionRef && projection.capabilities.harvestResources && !isTerminal);
+  const canStop = Boolean(actionsEnabled && projection.providerSessionRef && projection.capabilities.stop && !isTerminal);
+  const canRemove = Boolean(actionsEnabled && projection.providerSessionRef && projection.capabilities.terminalCleanup);
   const canResolveElicitation = Boolean(
     actionsEnabled && projection.providerSessionRef && projection.capabilities.resolveElicitation && !isTerminal,
   );
@@ -6040,6 +6073,13 @@ function BridgeSessionLogsPanel({
     catch (error) { setControlError((error as Error).message); }
     finally { setControlBusy(false); }
   };
+  const removeSession = async () => {
+    if (!projection.providerSessionRef || !canRemove) return;
+    setControlError(null); setControlBusy(true);
+    try { await removeBridgeSession(apiBase, projection.providerSessionRef); }
+    catch (error) { setControlError((error as Error).message); }
+    finally { setControlBusy(false); }
+  };
   const resolveElicitation = async (elicitationId: string, decision: 'approved' | 'rejected') => {
     if (!projection.providerSessionRef || !canResolveElicitation) return;
     setControlError(null); setControlBusy(true);
@@ -6061,6 +6101,31 @@ function BridgeSessionLogsPanel({
       <p className="small">
         Bridge session <code className="text-xs">{bridgeSessionId}</code> - {statusLabel}
       </p>
+      <section className="card stack" aria-label="Omnigent runtime identity">
+        <h3>Codex via Omnigent</h3>
+        <dl className="details-grid">
+          {([
+            ['Provider Profile', projection.providerProfileId],
+            ['Execution profile', projection.executionProfileRef],
+            ['Launch policy', projection.launchPolicyRef],
+            ['Host mode', projection.hostMode],
+            ['Launch snapshot', projection.effectiveLaunchSnapshotRef],
+            ['Source mode', projection.compatibilityProfile],
+            ['Workflow', projection.workflowId],
+            ['Agent run', projection.agentRunId],
+            ['Bridge session', bridgeSessionId],
+            ['Provider session', projection.providerSessionRef],
+            ['Omnigent host', projection.omnigentHostRef],
+            ['Omnigent runner', projection.omnigentRunnerRef],
+            ['Credential generation', projection.credentialGeneration],
+            ['Provider lease', projection.providerLeaseRef],
+            ['Host binding', projection.hostBindingRef],
+            ['Host lease', projection.hostLeaseRef],
+          ] as Array<[string, string | number | undefined]>).filter(([, value]) => value !== undefined && value !== '').map(([label, value]) => (
+            <div key={label}><dt>{label}</dt><dd><code className="text-xs break-all">{value}</code></dd></div>
+          ))}
+        </dl>
+      </section>
       {eventsQuery.data && 'terminalEnvelope' in eventsQuery.data && eventsQuery.data.terminalEnvelope
         ? <BridgeTerminalEvidence apiBase={apiBase} envelope={eventsQuery.data.terminalEnvelope} />
         : null}
@@ -6128,7 +6193,7 @@ function BridgeSessionLogsPanel({
           </div>
         )}
       </div>
-      {(canSend || canInterrupt || canClear || canCancel || canHarvest || pendingElicitations.length > 0 || optimisticMessages.length > 0) ? (
+      {(canSend || canInterrupt || canClear || canCancel || canHarvest || canStop || canRemove || pendingElicitations.length > 0 || optimisticMessages.length > 0) ? (
         <section className="stack chat-session-controls" aria-label="Bridge session controls">
           <h3>Session Controls</h3>
           {controlError ? <div className="notice error">{controlError}</div> : null}
@@ -6150,8 +6215,10 @@ function BridgeSessionLogsPanel({
           ))}
           {canInterrupt ? <button type="button" className="secondary" onClick={() => void interrupt()} disabled={controlBusy}>Interrupt turn</button> : null}
           {canHarvest ? <button type="button" className="secondary" onClick={() => void runControl({ type: 'harvest_session', clientEventKey: crypto.randomUUID() }).then(() => resourcesQuery.refetch())} disabled={controlBusy}>Harvest evidence</button> : null}
+          {canStop ? <button type="button" className="danger" onClick={() => { if (window.confirm('Stop this Omnigent session?')) void runControl({ type: 'stop_session', clientEventKey: crypto.randomUUID() }); }} disabled={controlBusy}>Stop session</button> : null}
           {canClear ? <button type="button" className="secondary" onClick={() => { if (window.confirm('Clear this bridge session?')) void runControl({ type: 'clear_session' }); }} disabled={controlBusy}>Clear session</button> : null}
           {canCancel ? <button type="button" className="danger" onClick={() => { if (window.confirm('Cancel this bridge session?')) void runControl({ type: 'session.cancel' }); }} disabled={controlBusy}>Cancel session</button> : null}
+          {canRemove ? <button type="button" className="danger" onClick={() => { if (window.confirm('Remove the owned Omnigent session after evidence harvest?')) void removeSession(); }} disabled={controlBusy}>Remove owned session</button> : null}
         </section>
       ) : null}
     </div>

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -2501,6 +2501,8 @@ async function fetchObservabilityEvents(
 type BridgeSessionProjection = {
   bridgeSessionId: string;
   workflowId?: string | undefined;
+  runId?: string | undefined;
+  stepExecutionId?: string | undefined;
   agentRunId?: string | undefined;
   idempotencyKey?: string | undefined;
   status?: string | undefined;
@@ -2517,6 +2519,7 @@ type BridgeSessionProjection = {
   providerSessionRef?: string | undefined;
   omnigentHostRef?: string | undefined;
   omnigentRunnerRef?: string | undefined;
+  firstMessageState?: string | undefined;
   capabilities: Record<string, boolean>;
 };
 
@@ -2665,6 +2668,8 @@ async function resolveBridgeSessionProjection({
   return {
     bridgeSessionId,
     workflowId: typeof body.workflowId === 'string' ? body.workflowId : undefined,
+    runId: typeof body.runId === 'string' ? body.runId : undefined,
+    stepExecutionId: typeof body.stepExecutionId === 'string' ? body.stepExecutionId : undefined,
     agentRunId: typeof body.agentRunId === 'string' ? body.agentRunId : undefined,
     idempotencyKey: typeof body.idempotencyKey === 'string' ? body.idempotencyKey : undefined,
     status: typeof body.status === 'string' ? body.status : undefined,
@@ -2681,6 +2686,7 @@ async function resolveBridgeSessionProjection({
     providerSessionRef: typeof body.providerSessionRef === 'string' ? body.providerSessionRef : undefined,
     omnigentHostRef: typeof body.omnigentHostRef === 'string' ? body.omnigentHostRef : undefined,
     omnigentRunnerRef: typeof body.omnigentRunnerRef === 'string' ? body.omnigentRunnerRef : undefined,
+    firstMessageState: typeof body.firstMessageState === 'string' ? body.firstMessageState : undefined,
     capabilities: body.capabilities && typeof body.capabilities === 'object'
       ? Object.fromEntries(Object.entries(body.capabilities).filter((entry): entry is [string, boolean] => typeof entry[1] === 'boolean'))
       : {},
@@ -2694,13 +2700,6 @@ async function postBridgeSessionControl(
 ): Promise<void> {
   const resp = await fetch(joinApiBasePath(apiBase, `/omnigent/v1/sessions/${encodeURIComponent(providerSessionRef)}/events`), {
     method: 'POST', credentials: 'include', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(payload),
-  });
-  if (!resp.ok) throw buildObservabilityRequestError(resp.status);
-}
-
-async function removeBridgeSession(apiBase: string, providerSessionRef: string): Promise<void> {
-  const resp = await fetch(joinApiBasePath(apiBase, `/omnigent/v1/sessions/${encodeURIComponent(providerSessionRef)}`), {
-    method: 'DELETE', credentials: 'include',
   });
   if (!resp.ok) throw buildObservabilityRequestError(resp.status);
 }
@@ -6073,10 +6072,25 @@ function BridgeSessionLogsPanel({
     catch (error) { setControlError((error as Error).message); }
     finally { setControlBusy(false); }
   };
+  const durableControlPayload = (type: 'stop_session' | 'cleanup_session') => ({
+    type,
+    clientEventKey: crypto.randomUUID(),
+    idempotencyKey: crypto.randomUUID(),
+    expectedWorkflowId: projection.workflowId,
+    expectedRunId: projection.runId,
+    expectedStepExecutionId: projection.stepExecutionId,
+    expectedAgentRunId: projection.agentRunId,
+    expectedBridgeSessionId: projection.bridgeSessionId,
+    expectedSessionId: projection.providerSessionRef,
+    expectedHostId: projection.omnigentHostRef,
+    expectedRunnerId: projection.omnigentRunnerRef,
+    expectedTurnState: projection.firstMessageState,
+    expectedTerminalState: projection.status,
+  });
   const removeSession = async () => {
     if (!projection.providerSessionRef || !canRemove) return;
     setControlError(null); setControlBusy(true);
-    try { await removeBridgeSession(apiBase, projection.providerSessionRef); }
+    try { await postBridgeSessionControl(apiBase, projection.providerSessionRef, durableControlPayload('cleanup_session')); }
     catch (error) { setControlError((error as Error).message); }
     finally { setControlBusy(false); }
   };
@@ -6215,7 +6229,7 @@ function BridgeSessionLogsPanel({
           ))}
           {canInterrupt ? <button type="button" className="secondary" onClick={() => void interrupt()} disabled={controlBusy}>Interrupt turn</button> : null}
           {canHarvest ? <button type="button" className="secondary" onClick={() => void runControl({ type: 'harvest_session', clientEventKey: crypto.randomUUID() }).then(() => resourcesQuery.refetch())} disabled={controlBusy}>Harvest evidence</button> : null}
-          {canStop ? <button type="button" className="danger" onClick={() => { if (window.confirm('Stop this Omnigent session?')) void runControl({ type: 'stop_session', clientEventKey: crypto.randomUUID() }); }} disabled={controlBusy}>Stop session</button> : null}
+          {canStop ? <button type="button" className="danger" onClick={() => { if (window.confirm('Stop this Omnigent session?')) void runControl(durableControlPayload('stop_session')); }} disabled={controlBusy}>Stop session</button> : null}
           {canClear ? <button type="button" className="secondary" onClick={() => { if (window.confirm('Clear this bridge session?')) void runControl({ type: 'clear_session' }); }} disabled={controlBusy}>Clear session</button> : null}
           {canCancel ? <button type="button" className="danger" onClick={() => { if (window.confirm('Cancel this bridge session?')) void runControl({ type: 'session.cancel' }); }} disabled={controlBusy}>Cancel session</button> : null}
           {canRemove ? <button type="button" className="danger" onClick={() => { if (window.confirm('Remove the owned Omnigent session after evidence harvest?')) void removeSession(); }} disabled={controlBusy}>Remove owned session</button> : null}

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -6017,7 +6017,14 @@ function BridgeSessionLogsPanel({
   const canCancel = Boolean(actionsEnabled && projection.providerSessionRef && projection.capabilities.cancelSession && !isTerminal);
   const canHarvest = Boolean(actionsEnabled && projection.providerSessionRef && projection.capabilities.harvestResources && !isTerminal);
   const canStop = Boolean(actionsEnabled && projection.providerSessionRef && projection.capabilities.stop && !isTerminal);
-  const canRemove = Boolean(actionsEnabled && projection.providerSessionRef && projection.capabilities.terminalCleanup);
+  const canRemove = Boolean(
+    actionsEnabled
+      && projection.providerSessionRef
+      && (
+        projection.capabilities.terminalCleanup
+        || (isTerminal && projection.compatibilityProfile === 'omnigent.embedded.v1')
+      ),
+  );
   const canResolveElicitation = Boolean(
     actionsEnabled && projection.providerSessionRef && projection.capabilities.resolveElicitation && !isTerminal,
   );

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -5018,10 +5018,30 @@ export interface components {
             compatibilityProfile: string;
             /** Providerprofileid */
             providerProfileId?: string | null;
+            /** Providerleaseref */
+            providerLeaseRef?: string | null;
+            /** Credentialgeneration */
+            credentialGeneration?: number | null;
             /** Hostbindingref */
             hostBindingRef?: string | null;
+            /** Hostleaseref */
+            hostLeaseRef?: string | null;
+            /** Hostmode */
+            hostMode?: string | null;
+            /** Executionprofileref */
+            executionProfileRef?: string | null;
+            /** Launchpolicyref */
+            launchPolicyRef?: string | null;
+            /** Effectivelaunchsnapshotref */
+            effectiveLaunchSnapshotRef?: string | null;
             /** Providersessionref */
             providerSessionRef?: string | null;
+            /** Omnigenthostref */
+            omnigentHostRef?: string | null;
+            /** Omnigentrunnerref */
+            omnigentRunnerRef?: string | null;
+            /** Firstmessagestate */
+            firstMessageState?: string | null;
             /** Capabilities */
             capabilities?: {
                 [key: string]: boolean;

--- a/moonmind/omnigent/bridge_embedded.py
+++ b/moonmind/omnigent/bridge_embedded.py
@@ -434,7 +434,7 @@ class OmnigentEmbeddedHostProtocolFacade:
 
     async def stop_runner(
         self, *, session_id: str, payload: dict[str, Any] | None = None,
-        actor: str | None = None,
+        actor: str | None = None, control_type: str = "stop",
     ) -> dict[str, Any]:
         """Stop the exact runner durably bound to an embedded session."""
 
@@ -454,35 +454,41 @@ class OmnigentEmbeddedHostProtocolFacade:
                 failure_class="integration_error",
                 status_code=409,
             )
+        terminal = row.status in {"completed", "failed", "canceled", "timed_out"}
         payload = payload or {}
-        control_key = _clean(payload.get("idempotencyKey")) or (
-            f"stop:{session_id}:{runner_id}"
-        )
-        await self._validate_control_expectations(
-            row=row, payload=payload, control_key=control_key,
-            control_type="stop", actor=actor,
-        )
+        control_key = _clean(payload.get("idempotencyKey"))
+        if not control_key:
+            raise OmnigentBridgeError(
+                "Embedded stop and cleanup controls require an idempotency key",
+                failure_class="user_error", status_code=422,
+                code="omnigent_embedded_control_idempotency_required",
+            )
         reconciled = await self._reconcile_control(row, control_key)
         if reconciled is not None:
             return {**reconciled, "runnerId": runner_id}
+        await self._validate_control_expectations(
+            row=row, payload=payload, control_key=control_key,
+            control_type=control_type, actor=actor,
+        )
         claimed = await self._claim_control(
-            row, control_key, "stop", "requested",
-            summary="Embedded stop requested", actor=actor,
+            row, control_key, control_type, "requested",
+            summary=f"Embedded {control_type} requested", actor=actor,
         )
         if not claimed:
             return {**(await self._reconcile_claimed_control(control_key)), "runnerId": runner_id}
-        await self._run_store.mark_embedded_runner_state(
-            row.idempotency_key,
-            state="draining",
-            code="runner_stop_requested",
-        )
+        if not terminal:
+            await self._run_store.mark_embedded_runner_state(
+                row.idempotency_key,
+                state="draining",
+                code="runner_stop_requested",
+            )
         try:
             await self._host_channels.stop_runner(
                 host_id=host_id, runner_id=runner_id
             )
         except (EmbeddedHostChannelError, TimeoutError) as exc:
             await self._record_control(
-                row, control_key, "stop", "delivery_unknown",
+                row, control_key, control_type, "delivery_unknown",
                 code="omnigent_embedded_control_delivery_unknown",
                 summary=str(exc), actor=actor,
             )
@@ -491,24 +497,25 @@ class OmnigentEmbeddedHostProtocolFacade:
                 code="omnigent_embedded_control_delivery_unknown",
             ) from exc
         await self._record_control(
-            row, control_key, "stop", "accepted",
-            summary="Embedded host accepted stop", actor=actor,
+            row, control_key, control_type, "accepted",
+            summary=f"Embedded host accepted {control_type}", actor=actor,
         )
-        await self._run_store.mark_embedded_runner_state(
-            row.idempotency_key,
-            state="stopped",
-            code="runner_stop_confirmed",
-        )
-        await self._run_store.record_lifecycle_event(
-            row.idempotency_key,
-            event_type="terminal",
-            status="canceled",
-            event_identity=f"embedded-stop:{runner_id}",
-            summary="stopped by MoonMind control",
-        )
+        if not terminal:
+            await self._run_store.mark_embedded_runner_state(
+                row.idempotency_key,
+                state="stopped",
+                code="runner_stop_confirmed",
+            )
+            await self._run_store.record_lifecycle_event(
+                row.idempotency_key,
+                event_type="terminal",
+                status="canceled",
+                event_identity=f"embedded-stop:{runner_id}",
+                summary="stopped by MoonMind control",
+            )
         await self._record_control(
-            row, control_key, "stop", "completed",
-            summary="Embedded runner stopped", actor=actor,
+            row, control_key, control_type, "completed",
+            summary=f"Embedded {control_type} completed", actor=actor,
         )
         return {"ok": True, "status": "stopped", "runnerId": runner_id}
 
@@ -1031,11 +1038,34 @@ class OmnigentEmbeddedHostProtocolFacade:
                 code="omnigent_embedded_control_key_too_long",
             )
         expected = {
+            "expectedWorkflowId": row.moonmind_workflow_id,
+            "expectedRunId": row.moonmind_run_id,
+            "expectedStepExecutionId": row.step_execution_id,
+            "expectedAgentRunId": row.moonmind_agent_run_id,
+            "expectedBridgeSessionId": row.bridge_session_id,
             "expectedSessionId": row.omnigent_session_id,
             "expectedHostId": row.omnigent_host_id,
             "expectedRunnerId": row.omnigent_runner_id,
             "expectedTurnState": row.first_message_state,
+            "expectedTerminalState": row.status,
         }
+        missing = next(
+            (field for field, actual in expected.items()
+             if _clean(actual) and not _clean(payload.get(field))),
+            None,
+        )
+        if control_type in {"stop", "terminal_cleanup"} and missing is not None:
+            await self._record_control(
+                row, control_key, control_type, "rejected",
+                code="omnigent_embedded_control_expected_state_required",
+                summary=f"Embedded control rejected: {missing} is required",
+                actor=actor,
+            )
+            raise OmnigentBridgeError(
+                "Embedded control requires the complete durable expected state",
+                failure_class="user_error", status_code=422,
+                code="omnigent_embedded_control_expected_state_required",
+            )
         mismatch = next(
             (
                 (field, _clean(payload.get(field)), _clean(actual))
@@ -1113,9 +1143,15 @@ class OmnigentEmbeddedHostProtocolFacade:
             "controlId": control_id,
             "controlIdempotencyKey": control_key,
             "expectedSessionId": row.omnigent_session_id,
+            "expectedWorkflowId": row.moonmind_workflow_id,
+            "expectedRunId": row.moonmind_run_id,
+            "expectedStepExecutionId": row.step_execution_id,
+            "expectedAgentRunId": row.moonmind_agent_run_id,
+            "expectedBridgeSessionId": row.bridge_session_id,
             "expectedHostId": row.omnigent_host_id,
             "expectedRunnerId": row.omnigent_runner_id,
             "expectedTurnState": row.first_message_state,
+            "expectedTerminalState": row.status,
             "sourceMode": HOST_PROTOCOL_MODE_EMBEDDED,
         }
 
@@ -1240,6 +1276,17 @@ class OmnigentEmbeddedHostProtocolFacade:
 
         return await self.stop_runner(
             session_id=session_id, payload=payload, actor=actor
+        )
+
+    async def cleanup_session(
+        self, session_id: str, *, payload: dict[str, Any],
+        actor: str | None = None,
+    ) -> dict[str, Any]:
+        """Terminate owned live resources through the durable control ledger."""
+
+        return await self.stop_runner(
+            session_id=session_id, payload=payload, actor=actor,
+            control_type="terminal_cleanup",
         )
 
     async def attach_session(

--- a/moonmind/omnigent/bridge_embedded.py
+++ b/moonmind/omnigent/bridge_embedded.py
@@ -476,6 +476,12 @@ class OmnigentEmbeddedHostProtocolFacade:
         )
         if not claimed:
             return {**(await self._reconcile_claimed_control(control_key)), "runnerId": runner_id}
+        if terminal and control_type == "terminal_cleanup":
+            await self._record_control(
+                row, control_key, control_type, "completed",
+                summary="Terminal resources queued for janitor cleanup", actor=actor,
+            )
+            return {"ok": True, "status": "cleanup_scheduled", "runnerId": runner_id}
         if not terminal:
             await self._run_store.mark_embedded_runner_state(
                 row.idempotency_key,
@@ -1274,9 +1280,26 @@ class OmnigentEmbeddedHostProtocolFacade:
     ) -> dict[str, Any]:
         """Stop the exact bound runner through the common facade contract."""
 
-        return await self.stop_runner(
-            session_id=session_id, payload=payload, actor=actor
-        )
+        if payload is None:
+            row = await self._run_store.get_session_by_provider_session_id(session_id)
+            if row is not None:
+                payload = {
+                    "idempotencyKey": (
+                        f"internal-stop:{row.bridge_session_id}:"
+                        f"{row.omnigent_runner_id}"
+                    ),
+                    "expectedWorkflowId": row.moonmind_workflow_id,
+                    "expectedRunId": row.moonmind_run_id,
+                    "expectedStepExecutionId": row.step_execution_id,
+                    "expectedAgentRunId": row.moonmind_agent_run_id,
+                    "expectedBridgeSessionId": row.bridge_session_id,
+                    "expectedSessionId": row.omnigent_session_id,
+                    "expectedHostId": row.omnigent_host_id,
+                    "expectedRunnerId": row.omnigent_runner_id,
+                    "expectedTurnState": row.first_message_state,
+                    "expectedTerminalState": row.status,
+                }
+        return await self.stop_runner(session_id=session_id, payload=payload, actor=actor)
 
     async def cleanup_session(
         self, session_id: str, *, payload: dict[str, Any],

--- a/tests/unit/api/routers/test_omnigent_bridge.py
+++ b/tests/unit/api/routers/test_omnigent_bridge.py
@@ -977,13 +977,37 @@ def test_session_authorization_reports_structured_error_when_proxy_is_missing() 
 
 
 def test_resolve_bridge_session_projection_returns_latest_binding() -> None:
-    client, _, _ = _build()
+    client, _, _ = _build(store=_FakeStore(session_overrides={
+        "provider_lease_id": "provider-lease-1",
+        "credential_generation": 4,
+        "host_lease_ref": "host-lease-1",
+        "omnigent_host_id": "host-1",
+        "omnigent_runner_id": "runner-1",
+        "effective_launch_snapshot_json": {
+            "hostMode": "on_demand_docker",
+            "executionProfileRef": "codex-default@2",
+            "launchPolicyRef": "restricted@3",
+            "snapshotRef": "omnigent-launch:sha256:safe-ref",
+        },
+    }))
     resp = client.get(
         f"{OMNIGENT_BRIDGE_MOUNT_PATH}/bridge-sessions/resolve?workflowId=mm%3Aw1"
     )
     assert resp.status_code == 200
     assert resp.json()["bridgeSessionId"] == "brs-1"
     assert resp.json()["workflowId"] == "mm:w1"
+    expected_identity = {
+        "providerLeaseRef": "provider-lease-1",
+        "credentialGeneration": 4,
+        "hostLeaseRef": "host-lease-1",
+        "hostMode": "on_demand_docker",
+        "executionProfileRef": "codex-default@2",
+        "launchPolicyRef": "restricted@3",
+        "effectiveLaunchSnapshotRef": "omnigent-launch:sha256:safe-ref",
+        "omnigentHostRef": "host-1",
+        "omnigentRunnerRef": "runner-1",
+    }
+    assert {key: resp.json()[key] for key in expected_identity} == expected_identity
 
 
 def test_resolve_bridge_session_projection_filters_capabilities_to_booleans() -> None:

--- a/tests/unit/api/routers/test_omnigent_bridge.py
+++ b/tests/unit/api/routers/test_omnigent_bridge.py
@@ -369,6 +369,7 @@ class _FakeEmbeddedFacade(_FakeProxy):
         super().__init__()
         self.created: list[dict[str, Any]] = []
         self.stopped: list[str] = []
+        self.control_payloads: list[dict[str, Any]] = []
         self.stream_afters: list[int] = []
 
     async def create_session(self, *, request, binding):
@@ -409,7 +410,12 @@ class _FakeEmbeddedFacade(_FakeProxy):
         return {"ok": True, "status": "stopped", "runnerId": "runner-1"}
 
     async def stop_session(self, session_id: str, *, payload=None, actor=None):
+        self.control_payloads.append(payload or {})
         return await self.stop_runner(session_id=session_id)
+
+    async def cleanup_session(self, session_id: str, *, payload, actor=None):
+        self.control_payloads.append(payload)
+        return {"ok": True, "status": "completed", "runnerId": "runner-1"}
 
 
 def _build(
@@ -1422,7 +1428,12 @@ def test_stop_session_event_dispatches_to_embedded_exact_host_facade() -> None:
     app.dependency_overrides[_get_create_embedded_facade] = lambda: facade
     client = TestClient(app)
 
-    response = client.post(_EVENTS_PATH, json={"type": "stop"})
+    response = client.post(_EVENTS_PATH, json={
+        "type": "stop", "idempotencyKey": "stop-1",
+        "expectedWorkflowId": "mm:w1", "expectedBridgeSessionId": "brs-1",
+        "expectedSessionId": "sess-77", "expectedHostId": "host-1",
+        "expectedRunnerId": "runner-1", "expectedTerminalState": "active",
+    })
 
     assert response.status_code == 200
     assert response.json() == {
@@ -1431,6 +1442,33 @@ def test_stop_session_event_dispatches_to_embedded_exact_host_facade() -> None:
         "runnerId": "runner-1",
     }
     assert facade.stopped == ["sess-77"]
+    assert facade.control_payloads[0]["idempotencyKey"] == "stop-1"
+    assert facade.control_payloads[0]["expectedBridgeSessionId"] == "brs-1"
+
+
+def test_cleanup_session_event_uses_typed_embedded_control() -> None:
+    app = FastAPI()
+    app.include_router(router, prefix=OMNIGENT_BRIDGE_MOUNT_PATH)
+    facade = _FakeEmbeddedFacade()
+    embedded_config = parse_bridge_config({
+        "compatibility": {"hostProtocolMode": HOST_PROTOCOL_MODE_EMBEDDED},
+        "hostConnection": {"embedded": {
+            "proxyConformanceEvidenceRef": "artifact://omnigent/proxy",
+            "liveSmokeEvidenceRef": "artifact://omnigent/smoke",
+            "hostAuthConformanceEvidenceRef": "artifact://omnigent/auth",
+        }},
+    })
+    app.dependency_overrides[get_current_user()] = _mock_user
+    app.dependency_overrides[_get_execution_service] = lambda: _FakeService(_USER_ID)
+    app.dependency_overrides[_require_bridge_enabled] = lambda: embedded_config
+    app.dependency_overrides[_get_bridge_proxy] = lambda: None
+    app.dependency_overrides[_get_create_embedded_facade] = lambda: facade
+    response = TestClient(app).post(_EVENTS_PATH, json={
+        "type": "cleanup_session", "idempotencyKey": "cleanup-1",
+        "expectedBridgeSessionId": "brs-1", "expectedSessionId": "sess-77",
+    })
+    assert response.status_code == 200
+    assert facade.control_payloads[0]["idempotencyKey"] == "cleanup-1"
 
 
 def test_interrupt_embedded_control_is_explicitly_unsupported() -> None:

--- a/tests/unit/omnigent/test_bridge_embedded.py
+++ b/tests/unit/omnigent/test_bridge_embedded.py
@@ -917,6 +917,7 @@ async def test_stop_runner_uses_durable_exact_host_binding(store) -> None:
     await store.bind_embedded_runner(
         "idem-embedded", host_id="host-1", runner_id="runner-1"
     )
+    row = await store.get_existing("idem-embedded")
 
     class Channels:
         calls = 0
@@ -984,14 +985,14 @@ async def test_stop_runner_uses_durable_exact_host_binding(store) -> None:
         "reconciled": True, "runnerId": "runner-1",
     }
     assert cleanup_result == {
-        "ok": True, "status": "stopped", "runnerId": "runner-1"
+        "ok": True, "status": "cleanup_scheduled", "runnerId": "runner-1"
     }
     assert cleanup_duplicate == {
         "ok": True, "status": "completed",
         "idempotencyKey": "cleanup-request-1", "reconciled": True,
         "runnerId": "runner-1",
     }
-    assert channels.calls == 2
+    assert channels.calls == 1
     assert row.status == "canceled"
     assert row.metadata_["embedded_runner_lifecycle"]["state"] == "stopped"
     assert "embedded_runner_exit" not in row.metadata_

--- a/tests/unit/omnigent/test_bridge_embedded.py
+++ b/tests/unit/omnigent/test_bridge_embedded.py
@@ -919,26 +919,79 @@ async def test_stop_runner_uses_durable_exact_host_binding(store) -> None:
     )
 
     class Channels:
+        calls = 0
+
         async def stop_runner(self, **kwargs):
             assert kwargs == {"host_id": "host-1", "runner_id": "runner-1"}
+            self.calls += 1
 
+    channels = Channels()
     facade = OmnigentEmbeddedHostProtocolFacade(
-        run_store=store, config=_embedded_config(), host_channels=Channels()
+        run_store=store, config=_embedded_config(), host_channels=channels
     )
+    control_payload = {
+        "idempotencyKey": "stop-request-1",
+        "expectedWorkflowId": row.moonmind_workflow_id,
+        "expectedRunId": row.moonmind_run_id,
+        "expectedStepExecutionId": row.step_execution_id,
+        "expectedAgentRunId": row.moonmind_agent_run_id,
+        "expectedBridgeSessionId": row.bridge_session_id,
+        "expectedSessionId": "sess-embedded",
+        "expectedHostId": "host-1",
+        "expectedRunnerId": "runner-1",
+        "expectedTurnState": row.first_message_state,
+        "expectedTerminalState": row.status,
+    }
+    with pytest.raises(OmnigentBridgeError) as stale_error:
+        await facade.stop_runner(
+            session_id="sess-embedded",
+            payload={
+                **control_payload,
+                "idempotencyKey": "stop-stale-1",
+                "expectedRunnerId": "stale-runner",
+            },
+            actor="user-42",
+        )
+    assert stale_error.value.status_code == 409
+    assert stale_error.value.code == "omnigent_embedded_control_state_mismatch"
     result = await facade.stop_runner(
         session_id="sess-embedded",
-        payload={
-            "idempotencyKey": "stop-request-1",
-            "expectedSessionId": "sess-embedded",
-            "expectedHostId": "host-1",
-            "expectedRunnerId": "runner-1",
-        },
+        payload=control_payload,
         actor="user-42",
+    )
+    duplicate = await facade.stop_runner(
+        session_id="sess-embedded", payload=control_payload, actor="user-42"
+    )
+    row = await store.get_existing("idem-embedded")
+    cleanup_payload = {
+        **control_payload,
+        "idempotencyKey": "cleanup-request-1",
+        "expectedTurnState": row.first_message_state,
+        "expectedTerminalState": row.status,
+    }
+    cleanup_result = await facade.cleanup_session(
+        "sess-embedded", payload=cleanup_payload, actor="user-42"
+    )
+    cleanup_duplicate = await facade.cleanup_session(
+        "sess-embedded", payload=cleanup_payload, actor="user-42"
     )
     row = await store.get_existing("idem-embedded")
     events = await store.list_events(row.bridge_session_id)
 
     assert result == {"ok": True, "status": "stopped", "runnerId": "runner-1"}
+    assert duplicate == {
+        "ok": True, "status": "completed", "idempotencyKey": "stop-request-1",
+        "reconciled": True, "runnerId": "runner-1",
+    }
+    assert cleanup_result == {
+        "ok": True, "status": "stopped", "runnerId": "runner-1"
+    }
+    assert cleanup_duplicate == {
+        "ok": True, "status": "completed",
+        "idempotencyKey": "cleanup-request-1", "reconciled": True,
+        "runnerId": "runner-1",
+    }
+    assert channels.calls == 2
     assert row.status == "canceled"
     assert row.metadata_["embedded_runner_lifecycle"]["state"] == "stopped"
     assert "embedded_runner_exit" not in row.metadata_
@@ -952,6 +1005,16 @@ async def test_stop_runner_uses_durable_exact_host_binding(store) -> None:
     assert {item["actor"] for item in control_metadata} == {"user-42"}
     assert {item["controlIdempotencyKey"] for item in control_metadata} == {
         "stop-request-1"
+    }
+    cleanup_metadata = [
+        event.metadata_["metadata"]
+        for event in events
+        if (event.metadata_ or {}).get("eventIdentity", "").startswith(
+            "embedded-control:cleanup-request-1:"
+        )
+    ]
+    assert {item["controlType"] for item in cleanup_metadata} == {
+        "terminal_cleanup"
     }
 
 


### PR DESCRIPTION
Issue: MoonLadderStudios/MoonMind#3455

Closes MoonLadderStudios/MoonMind#3455

## Summary

- render truthful Codex via Omnigent runtime and safe authority identity in Workflow Detail
- add capability-gated stop-session and owned-resource cleanup controls with expected-state validation, idempotency, stable diagnostics, and durable audit outcomes
- extend frontend and backend regression coverage for the new identity and control behavior

## Tests run

- `npm run ui:test -- frontend/src/entrypoints/workflow-detail.test.tsx` (197 passed)
- `python -m compileall -q api_service/api/routers/omnigent_bridge.py moonmind/omnigent/bridge_embedded.py tests/unit/api/routers/test_omnigent_bridge.py tests/unit/omnigent/test_bridge_embedded.py` (passed)
- `git diff --check origin/main...HEAD` (passed)

## Remaining risks

- Focused Python unit tests could not run through the required managed container backend because this deployment returned HTTP 503 with the container-job service disabled. The affected Python sources and tests compiled successfully.
