### PR TITLE
Fix provider profile manager lease recovery

### DIFF
--- a/docs/Temporal/ActivityCatalogAndWorkerTopology.md
+++ b/docs/Temporal/ActivityCatalogAndWorkerTopology.md
@@ -386,6 +386,9 @@ Current implemented activities:
 Worker queue: `mm.activity.artifacts`
 
 These are support activities used by workflow and manager orchestration. They are not part of the end-user skill or agent contract surface.
+`provider_profile.reset_manager` remains registered only for replay compatibility
+and performs non-destructive ensure/recovery; it never terminates the lease
+authority workflow.
 
 ## 8.6 OAuth session activities (`oauth_session.*`)
 

--- a/docs/Temporal/ErrorTaxonomy.md
+++ b/docs/Temporal/ErrorTaxonomy.md
@@ -218,11 +218,11 @@ Use when:
 
 - managed execution waits too long for provider-profile slot assignment
 - the manager appears stuck or unavailable after bounded recovery attempts
-- the orchestration path has exhausted its manager-reset or reacquisition strategy
+- the orchestration path has exhausted its non-destructive manager recovery or reacquisition strategy
 
 Examples:
 
-- `MoonMind.AgentRun` times out after repeated manager reset attempts
+- `MoonMind.AgentRun` times out after repeated manager ensure/reacquisition attempts
 - slot assignment never occurs despite a valid request and bounded retries
 
 Classification: **non-retryable** for the current attempt

--- a/moonmind/workflows/temporal/artifacts.py
+++ b/moonmind/workflows/temporal/artifacts.py
@@ -3284,6 +3284,7 @@ class TemporalArtifactActivities:
 
         from api_service.db.models import (
             ManagedAgentProviderProfile,
+            ProviderProfileSlotLease,
         )
         from api_service.db.base import get_async_session_context
         from api_service.services.provider_profile_readiness import (
@@ -3299,7 +3300,6 @@ class TemporalArtifactActivities:
         async with get_async_session_context() as session:
             stmt = select(ManagedAgentProviderProfile).where(
                 ManagedAgentProviderProfile.runtime_id == runtime_id,
-                ManagedAgentProviderProfile.enabled.is_(True),
             ).order_by(
                 ManagedAgentProviderProfile.is_default.desc(),
                 ManagedAgentProviderProfile.priority.desc(),
@@ -3307,6 +3307,12 @@ class TemporalArtifactActivities:
             )
             result = await session.execute(stmt)
             rows = list(result.scalars().all())
+            leased_profile_result = await session.execute(
+                select(ProviderProfileSlotLease.profile_id).where(
+                    ProviderProfileSlotLease.runtime_id == runtime_id
+                )
+            )
+            leased_profile_ids = set(leased_profile_result.scalars().all())
             managed_secret_statuses = await _managed_secret_statuses_for_profiles(
                 session=session,
                 rows=rows,
@@ -3314,10 +3320,11 @@ class TemporalArtifactActivities:
 
         profiles = []
         for row in rows:
-            if not provider_profile_launch_ready(
+            launch_ready = provider_profile_launch_ready(
                 row,
                 managed_secret_statuses=managed_secret_statuses,
-            ):
+            )
+            if not launch_ready and row.profile_id not in leased_profile_ids:
                 continue
             command_behavior = row.command_behavior or {}
             billing_metadata = (
@@ -3370,7 +3377,7 @@ class TemporalArtifactActivities:
                     "rate_limit_policy": row.rate_limit_policy.value,
                     "max_lease_duration_seconds": row.max_lease_duration_seconds,
                     "enabled": row.enabled,
-                    "launch_ready": True,
+                    "launch_ready": launch_ready,
                     "auth_state": row.auth_state.value if row.auth_state else None,
                     "disabled_reason": (
                         row.disabled_reason.value if row.disabled_reason else None

--- a/moonmind/workflows/temporal/artifacts.py
+++ b/moonmind/workflows/temporal/artifacts.py
@@ -3491,51 +3491,23 @@ class TemporalArtifactActivities:
         *,
         runtime_id: str,
     ) -> dict[str, Any]:
-        """Terminate and restart the ProviderProfileManager for *runtime_id*.
+        """Replay-safe legacy recovery that never revokes lease authority.
 
-        Used by AgentRun when the manager appears stuck (e.g. nondeterminism
-        error causing workflow task failures). Terminates the existing manager
-        if running, then starts a fresh one.
+        Older AgentRun histories may already contain this activity type, so it
+        remains registered. Its destructive implementation is intentionally
+        removed: ambiguous manager health cannot authorize termination while a
+        credential consumer may still be active.
         """
-        from temporalio.service import RPCError
-
-        from moonmind.workflows.temporal.client import TemporalClientAdapter
-        from moonmind.workflows.temporal.activity_catalog import get_workflow_task_queue
-        from moonmind.workflows.temporal.workflows.provider_profile_manager import (
-            WORKFLOW_NAME as PROVIDER_PROFILE_MANAGER_WF,
-            workflow_id_for_runtime,
-        )
-
-        workflow_id = workflow_id_for_runtime(runtime_id)
-        adapter = TemporalClientAdapter()
-        client = await adapter.get_client()
-
-        # Terminate the existing manager if it exists.
-        try:
-            handle = client.get_workflow_handle(workflow_id)
-            await handle.terminate(reason="Reset by AgentRun: manager appeared stuck")
-            logger.info(
-                "provider_profile.reset_manager terminated stale manager for runtime=%s",
-                runtime_id,
-            )
-        except RPCError:
-            logger.debug(
-                "provider_profile.reset_manager no running manager to terminate for runtime=%s",
-                runtime_id,
-            )
-
-        # Start a fresh manager.
-        await client.start_workflow(
-            PROVIDER_PROFILE_MANAGER_WF,
-            {"runtime_id": runtime_id},
-            id=workflow_id,
-            task_queue=get_workflow_task_queue(),
-        )
+        result = await self.provider_profile_ensure_manager(runtime_id=runtime_id)
         logger.info(
-            "provider_profile.reset_manager started fresh manager for runtime=%s",
+            "provider_profile.reset_manager performed non-destructive recovery for runtime=%s",
             runtime_id,
         )
-        return {"reset": True, "workflow_id": workflow_id}
+        return {
+            "reset": False,
+            "started": bool(result.get("started")),
+            "workflow_id": result["workflow_id"],
+        }
 
     async def provider_profile_manager_state(
         self,

--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -330,6 +330,9 @@ PR_RESOLVER_MERGE_GATE_OWNERSHIP_PATCH_ID = (
     "agent-run-pr-resolver-merge-gate-ownership-v1"
 )
 MANAGER_SLOT_WAIT_INSPECTION_PATCH_ID = "agent-run-slot-wait-manager-inspection-v1"
+NON_DESTRUCTIVE_SLOT_WAIT_RECOVERY_PATCH_ID = (
+    "agent-run-non-destructive-slot-wait-recovery-v1"
+)
 ACCURATE_SLOT_WAIT_REASON_PATCH_ID = "agent-run-accurate-slot-wait-reason-v1"
 SLOT_HANDOFF_PATCH_ID = "agent-run-slot-handoff-v1"
 SYNC_PROFILES_BEFORE_SLOT_REQUEST_PATCH_ID = (
@@ -398,10 +401,10 @@ MANAGED_SESSION_BRIDGE_EVENTS_ACTIVITY_PATCH_ID = (
 # Mirrors the pattern used by MoonMind.UserWorkflow (run.py:50).
 DEFAULT_ACTIVITY_CATALOG = build_default_activity_catalog()
 
-# How long to wait for a slot_assigned signal before assuming the manager is
-# stuck (e.g. nondeterminism error) and resetting it.
+# How long to wait for a slot_assigned signal before inspecting manager health
+# and performing bounded, non-destructive recovery.
 _SLOT_WAIT_TIMEOUT_SECONDS = 120
-_SLOT_WAIT_MAX_RESETS = 3
+_SLOT_WAIT_MAX_RECOVERY_ATTEMPTS = 3
 _DEFAULT_NO_PROGRESS_TIMEOUT_SECONDS = 1800
 _CLAUDE_CODE_NO_PROGRESS_TIMEOUT_SECONDS = 2400
 _CLAUDE_CODE_NO_PROGRESS_GRACE_SECONDS = 900
@@ -2727,17 +2730,47 @@ class MoonMindAgentRun:
         request_priority: int | None = None,
         request_queue_metadata: dict[str, Any] | None = None,
     ) -> workflow.ExternalWorkflowHandle:
-        """Terminate a stuck manager, start a fresh one, and re-request a slot.
+        """Run the replay-only legacy recovery command and re-request a slot.
 
-        Called when the slot wait times out, indicating the manager may have a
-        nondeterminism error or other unrecoverable workflow task failure.
+        The activity type is retained for histories that already scheduled it,
+        but its implementation is non-destructive.
         """
         self._get_logger().warning(
-            "Slot wait timed out — resetting ProviderProfileManager %s",
+            "Slot wait timed out — invoking legacy non-destructive ProviderProfileManager recovery for %s",
             manager_id,
         )
         await self._execute_routed_activity(
             "provider_profile.reset_manager",
+            {"runtime_id": runtime_id},
+            cancellation_type=ActivityCancellationType.TRY_CANCEL,
+        )
+        return await self._ensure_manager_and_signal(
+            manager_id,
+            runtime_id,
+            request_slot=True,
+            execution_profile_ref=execution_profile_ref,
+            profile_selector=profile_selector,
+            request_priority=request_priority,
+            request_queue_metadata=request_queue_metadata,
+        )
+
+    async def _recover_and_request_slot(
+        self,
+        manager_id: str,
+        runtime_id: str,
+        *,
+        execution_profile_ref: str | None = None,
+        profile_selector: dict | None = None,
+        request_priority: int | None = None,
+        request_queue_metadata: dict[str, Any] | None = None,
+    ) -> workflow.ExternalWorkflowHandle:
+        """Ensure the singleton exists and re-request without revoking leases."""
+        self._get_logger().warning(
+            "Slot wait timed out — ensuring ProviderProfileManager %s without resetting lease authority",
+            manager_id,
+        )
+        await self._execute_routed_activity(
+            "provider_profile.ensure_manager",
             {"runtime_id": runtime_id},
             cancellation_type=ActivityCancellationType.TRY_CANCEL,
         )
@@ -3938,8 +3971,8 @@ class MoonMindAgentRun:
                     # Wait for a provider-profile slot.
                     # Awaiting time does not count against the execution timeout;
                     # overall_start is reset once the slot is acquired.
-                    # If the manager is stuck (e.g. nondeterminism error), the
-                    # wait will time out and we reset the manager automatically.
+                    # If the manager appears unavailable, bounded recovery
+                    # ensures/re-requests it without terminating lease authority.
                     #
                     # NOTE: The slot_assigned signal may have arrived during
                     # _sync_manager_profiles (the activity gives the manager
@@ -3981,7 +4014,7 @@ class MoonMindAgentRun:
                             )
 
                     if workflow.patched("agent_run_slot_wait_retry_v1"):
-                        slot_resets = 0
+                        slot_recovery_attempts = 0
                         refresh_waiting_reason = False
                         while (
                             not self.slot_assigned_event.is_set()
@@ -4052,9 +4085,12 @@ class MoonMindAgentRun:
                                     refresh_waiting_reason = True
                                     continue
                             except TimeoutError:
-                                if slot_resets >= _SLOT_WAIT_MAX_RESETS:
+                                if (
+                                    slot_recovery_attempts
+                                    >= _SLOT_WAIT_MAX_RECOVERY_ATTEMPTS
+                                ):
                                     raise ApplicationError(
-                                        f"Auth profile slot not assigned after {_SLOT_WAIT_MAX_RESETS} manager resets for runtime_id='{runtime_id}'",
+                                        f"Auth profile slot not assigned after {_SLOT_WAIT_MAX_RECOVERY_ATTEMPTS} manager recovery attempts for runtime_id='{runtime_id}'",
                                         type="SlotAcquisitionTimeout",
                                         non_retryable=True,
                                     )
@@ -4072,7 +4108,7 @@ class MoonMindAgentRun:
                                         raise
                                     except Exception as exc:
                                         self._get_logger().warning(
-                                            "Auth profile manager %s state inspection failed while %s waits for a slot; falling back to reset path: %s",
+                                            "Auth profile manager %s state inspection failed while %s waits for a slot; using non-destructive recovery: %s",
                                             manager_id,
                                             workflow.info().workflow_id,
                                             exc,
@@ -4115,20 +4151,36 @@ class MoonMindAgentRun:
                                         )
                                         continue
                                 self.slot_assigned_event.clear()
-                                manager_handle = await self._reset_and_request_slot(
-                                    manager_id,
-                                    runtime_id,
-                                    execution_profile_ref=request.execution_profile_ref,
-                                    profile_selector=selector_payload,
-                                    request_priority=self._request_priority(request),
-                                    request_queue_metadata=self._request_queue_metadata(request),
-                                )
+                                if workflow.patched(
+                                    NON_DESTRUCTIVE_SLOT_WAIT_RECOVERY_PATCH_ID
+                                ):
+                                    manager_handle = (
+                                        await self._recover_and_request_slot(
+                                            manager_id,
+                                            runtime_id,
+                                            execution_profile_ref=request.execution_profile_ref,
+                                            profile_selector=selector_payload,
+                                            request_priority=self._request_priority(request),
+                                            request_queue_metadata=self._request_queue_metadata(request),
+                                        )
+                                    )
+                                else:
+                                    # Replay compatibility for histories that
+                                    # already scheduled the legacy activity.
+                                    manager_handle = await self._reset_and_request_slot(
+                                        manager_id,
+                                        runtime_id,
+                                        execution_profile_ref=request.execution_profile_ref,
+                                        profile_selector=selector_payload,
+                                        request_priority=self._request_priority(request),
+                                        request_queue_metadata=self._request_queue_metadata(request),
+                                    )
                                 await self._sync_manager_profiles(
                                     manager_id=manager_id,
                                     manager_handle=manager_handle,
                                     runtime_id=runtime_id,
                                 )
-                                slot_resets += 1
+                                slot_recovery_attempts += 1
                     else:
                         while not self.slot_assigned_event.is_set():
                             await workflow.wait_condition(

--- a/moonmind/workflows/temporal/workflows/provider_profile_manager.py
+++ b/moonmind/workflows/temporal/workflows/provider_profile_manager.py
@@ -69,6 +69,10 @@ CODEX_OAUTH_LEGACY_RESTORE_PATCH = (
 PURPOSE_AWARE_CREDENTIAL_LEASE_PATCH = (
     "provider-profile-manager-purpose-aware-credential-lease-v1"
 )
+FRESH_START_DB_LEASE_RESTORE_PATCH = (
+    "provider-profile-manager-fresh-start-db-lease-restore-v1"
+)
+DURABLE_LEASE_GRANT_PATCH = "provider-profile-manager-durable-lease-grant-v1"
 
 # Deterministic sort sentinel for pending requests whose scheduled queue order
 # cannot be resolved (missing scheduled_for / created_at). ISO-8601 strings sort
@@ -686,7 +690,16 @@ class MoonMindProviderProfileManagerWorkflow:
                 metadata=lease_metadata,
             ):
                 if workflow.patched(DB_LEASE_PERSISTENCE_PATCH):
-                    await self._sync_leases_to_db()
+                    persisted = await self._sync_leases_to_db()
+                    if (
+                        workflow.patched(DURABLE_LEASE_GRANT_PATCH)
+                        and not persisted
+                    ):
+                        profile.release(requester_id)
+                        raise exceptions.ApplicationError(
+                            "Provider profile lease persistence failed before direct grant",
+                            type="ProviderProfileLeasePersistenceFailed",
+                        )
                 self._has_new_events = True
                 return {
                     "profile_id": profile.profile_id,
@@ -776,7 +789,16 @@ class MoonMindProviderProfileManagerWorkflow:
                 allow_unready=True,
             ):
                 if workflow.patched(DB_LEASE_PERSISTENCE_PATCH):
-                    await self._sync_leases_to_db()
+                    persisted = await self._sync_leases_to_db()
+                    if (
+                        workflow.patched(DURABLE_LEASE_GRANT_PATCH)
+                        and not persisted
+                    ):
+                        profile.release(requester_id)
+                        raise exceptions.ApplicationError(
+                            "Provider profile lease persistence failed before maintenance grant",
+                            type="ProviderProfileLeasePersistenceFailed",
+                        )
                 return {
                     "profile_id": profile_id,
                     "lease_id": requester_id,
@@ -876,15 +898,25 @@ class MoonMindProviderProfileManagerWorkflow:
         if not self._profiles:
             await self._load_profiles_from_db()
 
-        # If we restored state from a crash (not continue-as-new), the
-        # pending_requests and current_leases would be empty in the input.
-        # In that case, try to restore leases from the database.
+        # A fresh singleton execution must restore the durable lease ledger
+        # before it drains requests. Signal handlers can populate the pending
+        # queue while the profile-list activity is in flight, so pending state
+        # is not evidence that startup lease recovery already happened.
         if workflow.patched(DB_LEASE_PERSISTENCE_PATCH):
-            has_leases = any(p.current_leases for p in self._profiles.values())
-            has_pending = bool(self._pending_requests)
-            if not has_leases and not has_pending:
-                # This looks like a fresh start after a crash - try to restore leases from DB
-                await self._load_leases_from_db()
+            if workflow.patched(FRESH_START_DB_LEASE_RESTORE_PATCH):
+                if workflow.info().continued_run_id is None:
+                    leases_restored = await self._load_leases_from_db()
+                    if not leases_restored:
+                        raise exceptions.ApplicationError(
+                            "Provider profile lease recovery failed; refusing to grant capacity without the authoritative lease ledger",
+                            type="ProviderProfileLeaseRecoveryFailed",
+                            non_retryable=True,
+                        )
+            else:
+                has_leases = any(p.current_leases for p in self._profiles.values())
+                has_pending = bool(self._pending_requests)
+                if not has_leases and not has_pending:
+                    await self._load_leases_from_db()
 
         # Refresh restored state from the authoritative DB snapshot. This keeps
         # continued-as-new managers from routing to profiles deleted or changed
@@ -1307,6 +1339,7 @@ class MoonMindProviderProfileManagerWorkflow:
     async def _drain_queue(self) -> None:
         """Try to assign slots to pending requests in priority order."""
         now = workflow.now()
+        durable_grants = workflow.patched(DURABLE_LEASE_GRANT_PATCH)
         self._clear_expired_handoff_reservations(now)
         remaining: list[PendingRequest] = []
         leases_changed = False
@@ -1332,6 +1365,9 @@ class MoonMindProviderProfileManagerWorkflow:
                     break
 
             if existing_profile_id:
+                if durable_grants and not await self._sync_leases_to_db():
+                    remaining.append(req)
+                    continue
                 try:
                     await self._signal_slot_assigned(
                         req.requester_workflow_id, existing_profile_id
@@ -1342,10 +1378,17 @@ class MoonMindProviderProfileManagerWorkflow:
                         req.requester_workflow_id,
                         e,
                     )
-                    self._profiles[existing_profile_id].release(
-                        req.requester_workflow_id
-                    )
-                    leases_changed = True
+                    if durable_grants:
+                        # Signal failure is ambiguous. Keep the durable lease
+                        # until workflow-status verification proves the owner
+                        # terminal; releasing here could authorize a second
+                        # credential consumer while the first is still alive.
+                        remaining.append(req)
+                    else:
+                        self._profiles[existing_profile_id].release(
+                            req.requester_workflow_id
+                        )
+                        leases_changed = True
                 continue
 
             profile = self._find_available_profile(
@@ -1360,6 +1403,12 @@ class MoonMindProviderProfileManagerWorkflow:
                 metadata=req.lease_metadata,
             ):
                 leases_changed = True
+                if durable_grants and not await self._sync_leases_to_db():
+                    # Hold the in-memory reservation and retry persistence on
+                    # the next loop. Never signal a consumer before its lease
+                    # is durable.
+                    remaining.append(req)
+                    continue
                 try:
                     await self._signal_slot_assigned(
                         req.requester_workflow_id, profile.profile_id
@@ -1370,15 +1419,22 @@ class MoonMindProviderProfileManagerWorkflow:
                         req.requester_workflow_id,
                         e,
                     )
-                    profile.release(req.requester_workflow_id)
-                    leases_changed = True
+                    if durable_grants:
+                        remaining.append(req)
+                    else:
+                        profile.release(req.requester_workflow_id)
+                        leases_changed = True
             else:
                 remaining.append(req)
         self._pending_requests = remaining
         self._pending_requests_ordered = True
 
         # Persist lease changes to DB for crash recovery
-        if leases_changed and workflow.patched(DB_LEASE_PERSISTENCE_PATCH):
+        if (
+            leases_changed
+            and not durable_grants
+            and workflow.patched(DB_LEASE_PERSISTENCE_PATCH)
+        ):
             await self._sync_leases_to_db()
 
     @staticmethod
@@ -1965,7 +2021,7 @@ class MoonMindProviderProfileManagerWorkflow:
             )
             return False
 
-    async def _sync_leases_to_db(self) -> None:
+    async def _sync_leases_to_db(self) -> bool:
         """Persist current lease state to the database for crash recovery."""
         try:
             leases = []
@@ -1993,12 +2049,12 @@ class MoonMindProviderProfileManagerWorkflow:
                     maximum_attempts=3,
                 ),
             )
+            return True
         except Exception:
-            # If we can't persist leases, log but don't fail.
-            # The manager will still function, just without DB persistence.
             self._get_logger().warning(
-                "Failed to persist leases to DB, continuing without persistence"
+                "Failed to persist leases to DB; provider capacity remains blocked"
             )
+            return False
 
     async def _remove_lease_from_db(self, workflow_id: str) -> None:
         """Remove a single lease from the database."""
@@ -2024,7 +2080,7 @@ class MoonMindProviderProfileManagerWorkflow:
                 "Failed to remove lease for %s from DB", workflow_id
             )
 
-    async def _load_leases_from_db(self) -> None:
+    async def _load_leases_from_db(self) -> bool:
         """Load persisted leases from DB and reconnect to running workflows.
 
         On manager startup (after a crash), we load leases from the DB and
@@ -2052,7 +2108,7 @@ class MoonMindProviderProfileManagerWorkflow:
                 self._get_logger().info(
                     "No persisted leases found in DB for runtime %s", self._runtime_id
                 )
-                return
+                return True
 
             self._get_logger().info(
                 "Restoring %d persisted leases from DB for runtime %s",
@@ -2072,16 +2128,29 @@ class MoonMindProviderProfileManagerWorkflow:
                 if not wf_id or not profile_id:
                     continue
 
-                # Check if this profile still exists and is enabled
+                # Check if this profile still exists. A disabled profile must
+                # still retain an existing lease; disabled only prevents new
+                # grants. If the profile is missing entirely, the manager
+                # cannot safely establish the credential authority boundary.
                 profile = self._profiles.get(profile_id)
                 purpose = str(lease.get("purpose") or "execution_direct")
                 is_maintenance = purpose not in {
                     CredentialLeasePurpose.EXECUTION_DIRECT.value,
                     CredentialLeasePurpose.EXECUTION_OMNIGENT.value,
                 }
-                if not profile or (not profile.enabled and not is_maintenance):
+                durable_grants = workflow.patched(DURABLE_LEASE_GRANT_PATCH)
+                if not profile:
                     self._get_logger().warning(
-                        "Persisted lease for %s references unknown or disabled profile %s, skipping",
+                        "Persisted lease for %s references unknown profile %s",
+                        wf_id,
+                        profile_id,
+                    )
+                    if durable_grants:
+                        return False
+                    continue
+                if not durable_grants and not profile.enabled and not is_maintenance:
+                    self._get_logger().warning(
+                        "Persisted lease for %s references disabled profile %s, skipping",
                         wf_id,
                         profile_id,
                     )
@@ -2122,11 +2191,17 @@ class MoonMindProviderProfileManagerWorkflow:
                     self._get_logger().warning(
                         "Failed to reconnect to workflow %s: %s", wf_id, e
                     )
-                    # Release the lease since the workflow is likely dead
-                    profile.release(wf_id)
-                    await self._remove_lease_from_db(wf_id)
+                    if not durable_grants:
+                        # Preserve the old behavior for replaying histories
+                        # recorded before ambiguous reconnect failures became
+                        # fail-closed.
+                        profile.release(wf_id)
+                        await self._remove_lease_from_db(wf_id)
+
+            return True
 
         except Exception:
             self._get_logger().warning(
-                "Failed to load leases from DB, continuing without persisted state"
+                "Failed to load leases from DB; refusing unverified capacity"
             )
+            return False

--- a/tests/integration/temporal/test_provider_profile_manager_recovery.py
+++ b/tests/integration/temporal/test_provider_profile_manager_recovery.py
@@ -41,7 +41,8 @@ class _ProviderProfileActivities:
                     "credential_source": "oauth_volume",
                     "runtime_materialization_mode": "oauth_home",
                     "max_parallel_runs": 1,
-                    "enabled": True,
+                    "enabled": False,
+                    "launch_ready": False,
                     "is_default": True,
                 }
             ]

--- a/tests/integration/temporal/test_provider_profile_manager_recovery.py
+++ b/tests/integration/temporal/test_provider_profile_manager_recovery.py
@@ -1,0 +1,169 @@
+"""Temporal boundary regression tests for provider-profile lease recovery."""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from typing import Any
+
+import pytest
+from temporalio import activity, workflow
+from temporalio.testing import WorkflowEnvironment
+from temporalio.worker import UnsandboxedWorkflowRunner, Worker
+
+from moonmind.workflows.temporal.workflows.provider_profile_manager import (
+    ACTIVITY_TASK_QUEUE,
+    MoonMindProviderProfileManagerWorkflow,
+)
+
+pytestmark = [
+    pytest.mark.asyncio,
+    pytest.mark.integration,
+    pytest.mark.temporal_boundary,
+]
+
+
+class _ProviderProfileActivities:
+    def __init__(self) -> None:
+        self.list_started = asyncio.Event()
+        self.release_list = asyncio.Event()
+
+    @activity.defn(name="provider_profile.list")
+    async def list_profiles(self, request: dict[str, Any]) -> dict[str, Any]:
+        assert request == {"runtime_id": "codex_cli"}
+        self.list_started.set()
+        await self.release_list.wait()
+        return {
+            "profiles": [
+                {
+                    "profile_id": "codex-oauth",
+                    "runtime_id": "codex_cli",
+                    "credential_source": "oauth_volume",
+                    "runtime_materialization_mode": "oauth_home",
+                    "max_parallel_runs": 1,
+                    "enabled": True,
+                    "is_default": True,
+                }
+            ]
+        }
+
+    @activity.defn(name="provider_profile.sync_slot_leases")
+    async def sync_slot_leases(self, request: dict[str, Any]) -> dict[str, Any]:
+        if request["action"] == "load":
+            return {
+                "leases": [
+                    {
+                        "workflow_id": "active-agent-run",
+                        "profile_id": "codex-oauth",
+                    }
+                ]
+            }
+        return {"synced": len(request.get("leases", []))}
+
+    @activity.defn(name="provider_profile.pending_request_order")
+    async def pending_request_order(self, request: dict[str, Any]) -> dict[str, Any]:
+        return {"orders": {workflow_id: {} for workflow_id in request["workflow_ids"]}}
+
+    @activity.defn(name="provider_profile.verify_lease_holders")
+    async def verify_lease_holders(self, request: dict[str, Any]) -> dict[str, Any]:
+        return {
+            workflow_id: {"running": True, "status": "RUNNING"}
+            for workflow_id in request["workflow_ids"]
+        }
+
+
+@workflow.defn(name="Test.ProviderProfileLeaseHolder")
+class _LeaseHolderWorkflow:
+    def __init__(self) -> None:
+        self._assigned_profiles: list[str] = []
+        self._shutdown = False
+
+    @workflow.signal(name="slot_assigned")
+    def slot_assigned(self, payload: dict[str, Any]) -> None:
+        self._assigned_profiles.append(payload["profile_id"])
+
+    @workflow.query(name="assignment_count")
+    def assignment_count(self) -> int:
+        return len(self._assigned_profiles)
+
+    @workflow.signal(name="shutdown")
+    def shutdown(self) -> None:
+        self._shutdown = True
+
+    @workflow.run
+    async def run(self) -> None:
+        await workflow.wait_condition(lambda: self._shutdown)
+
+
+async def _query_until_recovered(manager_handle: Any) -> dict[str, Any]:
+    for _ in range(100):
+        state = await manager_handle.query("get_state")
+        profile = state.get("profiles", {}).get("codex-oauth", {})
+        pending = {
+            request["requester_workflow_id"]
+            for request in state.get("pending_requests", [])
+        }
+        if profile.get("current_leases") == ["active-agent-run"] and pending == {
+            "waiting-agent-run"
+        }:
+            return state
+        await asyncio.sleep(0.01)
+    raise AssertionError(
+        "manager did not recover the durable lease and pending request"
+    )
+
+
+async def test_request_during_startup_cannot_bypass_recovered_oauth_lease() -> None:
+    """A request signaled during profile loading must remain queued at capacity."""
+    activities = _ProviderProfileActivities()
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        task_queue = f"provider-profile-recovery-{uuid.uuid4()}"
+        async with Worker(
+            env.client,
+            task_queue=task_queue,
+            workflows=[
+                MoonMindProviderProfileManagerWorkflow,
+                _LeaseHolderWorkflow,
+            ],
+            workflow_runner=UnsandboxedWorkflowRunner(),
+        ), Worker(
+            env.client,
+            task_queue=ACTIVITY_TASK_QUEUE,
+            activities=[
+                activities.list_profiles,
+                activities.sync_slot_leases,
+                activities.pending_request_order,
+                activities.verify_lease_holders,
+            ],
+        ):
+            holder = await env.client.start_workflow(
+                _LeaseHolderWorkflow.run,
+                id="active-agent-run",
+                task_queue=task_queue,
+            )
+            manager = await env.client.start_workflow(
+                MoonMindProviderProfileManagerWorkflow.run,
+                {"runtime_id": "codex_cli"},
+                id=f"provider-profile-manager-test-{uuid.uuid4()}",
+                task_queue=task_queue,
+            )
+
+            await asyncio.wait_for(activities.list_started.wait(), timeout=10)
+            await manager.signal(
+                "request_slot",
+                {
+                    "requester_workflow_id": "waiting-agent-run",
+                    "runtime_id": "codex_cli",
+                },
+            )
+            activities.release_list.set()
+
+            await asyncio.wait_for(_query_until_recovered(manager), timeout=15)
+            assert await holder.query("assignment_count") == 1
+
+            await manager.signal("shutdown")
+            await holder.signal("shutdown")
+            manager_result = await asyncio.wait_for(manager.result(), timeout=15)
+            await asyncio.wait_for(holder.result(), timeout=15)
+
+    assert manager_result["status"] == "shutdown"

--- a/tests/unit/workflows/adapters/test_managed_agent_adapter.py
+++ b/tests/unit/workflows/adapters/test_managed_agent_adapter.py
@@ -28,6 +28,7 @@ from api_service.db.models import (
     ProviderCredentialSource,
     ProviderProfileAuthMethod,
     ProviderProfileAuthState,
+    ProviderProfileSlotLease,
     RuntimeMaterializationMode,
 )
 from moonmind.auth.env_shaping import (
@@ -1443,6 +1444,79 @@ async def test_provider_profile_list_filters_to_launch_ready_profiles(
         assert [profile["profile_id"] for profile in result["profiles"]] == [
             "ready-secret"
         ]
+
+
+async def test_provider_profile_list_includes_unavailable_profiles_with_leases(
+    tmp_path: Path,
+):
+    """Lease recovery retains disabled/unready owners without routing to them."""
+    async with _in_memory_db(tmp_path) as session_factory:
+        async with session_factory() as session:
+            session.add_all(
+                [
+                    ManagedAgentProviderProfile(
+                        profile_id="disabled-leased",
+                        runtime_id="codex_cli",
+                        credential_source=ProviderCredentialSource.OAUTH_VOLUME,
+                        runtime_materialization_mode=RuntimeMaterializationMode.OAUTH_HOME,
+                        max_parallel_runs=1,
+                        cooldown_after_429_seconds=300,
+                        rate_limit_policy=ManagedAgentRateLimitPolicy.BACKOFF,
+                        enabled=False,
+                        auth_state=ProviderProfileAuthState.CONNECTED,
+                        last_auth_method=ProviderProfileAuthMethod.OAUTH_VOLUME,
+                    ),
+                    ManagedAgentProviderProfile(
+                        profile_id="unready-leased",
+                        runtime_id="codex_cli",
+                        credential_source=ProviderCredentialSource.OAUTH_VOLUME,
+                        runtime_materialization_mode=RuntimeMaterializationMode.OAUTH_HOME,
+                        max_parallel_runs=1,
+                        cooldown_after_429_seconds=300,
+                        rate_limit_policy=ManagedAgentRateLimitPolicy.BACKOFF,
+                        enabled=True,
+                        auth_state=ProviderProfileAuthState.CONNECTED,
+                        last_auth_method=ProviderProfileAuthMethod.OAUTH_VOLUME,
+                    ),
+                    ProviderProfileSlotLease(
+                        runtime_id="codex_cli",
+                        workflow_id="disabled-owner",
+                        profile_id="disabled-leased",
+                    ),
+                    ProviderProfileSlotLease(
+                        runtime_id="codex_cli",
+                        workflow_id="unready-owner",
+                        profile_id="unready-leased",
+                    ),
+                ]
+            )
+            await session.commit()
+
+        service = TemporalArtifactService(
+            TemporalArtifactRepository(session),
+            store=LocalTemporalArtifactStore(tmp_path / "artifacts"),
+        )
+        activities = TemporalArtifactActivities(service)
+
+        import api_service.db.base as _db_base_mod
+
+        orig = _db_base_mod.get_async_session_context
+        _db_base_mod.get_async_session_context = lambda: _patched_session_context(
+            session_factory
+        )
+        try:
+            result = await activities.provider_profile_list(runtime_id="codex_cli")
+        finally:
+            _db_base_mod.get_async_session_context = orig
+
+        profiles = {
+            profile["profile_id"]: profile for profile in result["profiles"]
+        }
+        assert set(profiles) == {"disabled-leased", "unready-leased"}
+        assert profiles["disabled-leased"]["enabled"] is False
+        assert profiles["disabled-leased"]["launch_ready"] is False
+        assert profiles["unready-leased"]["enabled"] is True
+        assert profiles["unready-leased"]["launch_ready"] is False
 
 async def test_provider_profile_list_preserves_secret_ref_materialization_fields(
     tmp_path: Path,

--- a/tests/unit/workflows/temporal/test_provider_profile_manager.py
+++ b/tests/unit/workflows/temporal/test_provider_profile_manager.py
@@ -13,6 +13,8 @@ from moonmind.workflows.temporal.workflows.provider_profile_manager import (
     CODEX_OAUTH_LEGACY_RESTORE_PATCH,
     DB_AUTHORITATIVE_PROFILE_SYNC_PATCH,
     DEFAULT_PROFILE_EXCLUSIVE_SELECTION_PATCH,
+    DURABLE_LEASE_GRANT_PATCH,
+    FRESH_START_DB_LEASE_RESTORE_PATCH,
     HandoffReservation,
     PendingRequest,
     PRIORITY_PENDING_REQUESTS_PATCH,
@@ -2169,6 +2171,299 @@ class TestProviderProfileManagerHelpers:
 
         assert drain_index < verify_index
 
+    def test_fresh_start_restores_db_leases_even_when_requests_are_pending(self):
+        """A reset-time request must not suppress authoritative lease recovery."""
+        import inspect
+
+        source = inspect.getsource(MoonMindProviderProfileManagerWorkflow.run)
+
+        assert "FRESH_START_DB_LEASE_RESTORE_PATCH" in source
+        assert "workflow.info().continued_run_id is None" in source
+        assert "await self._load_leases_from_db()" in source
+        assert source.index(
+            "leases_restored = await self._load_leases_from_db()"
+        ) < source.index("has_pending")
+
+    @pytest.mark.asyncio
+    async def test_run_restores_durable_lease_when_request_arrives_during_startup(
+        self,
+    ):
+        """Replay the startup race that previously granted duplicate capacity."""
+        wf = MoonMindProviderProfileManagerWorkflow()
+
+        async def load_profiles(*_args, **_kwargs) -> bool:
+            if not wf._profiles:
+                wf._profiles["p1"] = ProfileSlotState(
+                    profile_id="p1",
+                    max_parallel_runs=1,
+                    cooldown_after_429_seconds=300,
+                    rate_limit_policy="backoff",
+                    enabled=True,
+                    is_default=True,
+                )
+                wf.request_slot(
+                    {
+                        "requester_workflow_id": "waiting-agent-run",
+                        "runtime_id": "codex_cli",
+                    }
+                )
+            return True
+
+        async def load_leases() -> bool:
+            assert [
+                request.requester_workflow_id for request in wf._pending_requests
+            ] == ["waiting-agent-run"]
+            wf._profiles["p1"].current_leases.append("active-agent-run")
+            wf._shutdown_requested = True
+            return True
+
+        wf._load_profiles_from_db = AsyncMock(side_effect=load_profiles)
+        wf._load_leases_from_db = AsyncMock(side_effect=load_leases)
+
+        with patch(
+            "moonmind.workflows.temporal.workflows.provider_profile_manager.workflow"
+        ) as mock_wf:
+            mock_wf.patched.return_value = True
+            mock_wf.info.return_value = SimpleNamespace(continued_run_id=None)
+            result = await wf.run({"runtime_id": "codex_cli"})
+
+        assert result["status"] == "shutdown"
+        assert wf._profiles["p1"].current_leases == ["active-agent-run"]
+        assert [
+            request.requester_workflow_id for request in wf._pending_requests
+        ] == ["waiting-agent-run"]
+        wf._load_leases_from_db.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_run_preserves_continue_as_new_lease_snapshot(self):
+        """Existing histories keep using their compact continuation snapshot."""
+        wf = MoonMindProviderProfileManagerWorkflow()
+        wf._shutdown_requested = True
+        wf._load_profiles_from_db = AsyncMock(return_value=True)
+        wf._load_leases_from_db = AsyncMock()
+
+        with patch(
+            "moonmind.workflows.temporal.workflows.provider_profile_manager.workflow"
+        ) as mock_wf:
+            mock_wf.patched.return_value = True
+            mock_wf.info.return_value = SimpleNamespace(
+                continued_run_id="previous-manager-run"
+            )
+            result = await wf.run(
+                {
+                    "runtime_id": "codex_cli",
+                    "profiles": [
+                        {
+                            "profile_id": "p1",
+                            "max_parallel_runs": 1,
+                            "enabled": True,
+                        }
+                    ],
+                    "leases": {"p1": ["active-agent-run"]},
+                }
+            )
+
+        assert result["status"] == "shutdown"
+        assert wf._profiles["p1"].current_leases == ["active-agent-run"]
+        wf._load_leases_from_db.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_durable_restore_keeps_lease_after_ambiguous_signal_failure(self):
+        wf = self._make_workflow()
+        wf._profiles["p1"] = ProfileSlotState(
+            profile_id="p1",
+            max_parallel_runs=1,
+            cooldown_after_429_seconds=300,
+            rate_limit_policy="backoff",
+            enabled=True,
+            is_default=True,
+        )
+        wf._signal_slot_assigned = AsyncMock(side_effect=RuntimeError("unavailable"))
+        wf._remove_lease_from_db = AsyncMock()
+
+        with patch(
+            "moonmind.workflows.temporal.workflows.provider_profile_manager.workflow"
+        ) as mock_wf:
+            mock_wf.patched.side_effect = (
+                lambda patch_id: patch_id == DURABLE_LEASE_GRANT_PATCH
+            )
+            mock_wf.execute_activity = AsyncMock(
+                return_value={
+                    "leases": [
+                        {
+                            "workflow_id": "active-agent-run",
+                            "profile_id": "p1",
+                        }
+                    ]
+                }
+            )
+            restored = await wf._load_leases_from_db()
+
+        assert restored is True
+        assert wf._profiles["p1"].current_leases == ["active-agent-run"]
+        wf._remove_lease_from_db.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_durable_restore_fails_closed_for_unknown_profile(self):
+        wf = self._make_workflow()
+
+        with patch(
+            "moonmind.workflows.temporal.workflows.provider_profile_manager.workflow"
+        ) as mock_wf:
+            mock_wf.patched.side_effect = (
+                lambda patch_id: patch_id == DURABLE_LEASE_GRANT_PATCH
+            )
+            mock_wf.execute_activity = AsyncMock(
+                return_value={
+                    "leases": [
+                        {
+                            "workflow_id": "active-agent-run",
+                            "profile_id": "missing-profile",
+                        }
+                    ]
+                }
+            )
+            restored = await wf._load_leases_from_db()
+
+        assert restored is False
+
+    @pytest.mark.asyncio
+    async def test_durable_grant_persists_before_signaling_consumer(self):
+        wf = self._make_workflow()
+        wf._profiles["p1"] = ProfileSlotState(
+            profile_id="p1",
+            max_parallel_runs=1,
+            cooldown_after_429_seconds=300,
+            rate_limit_policy="backoff",
+            enabled=True,
+            is_default=True,
+        )
+        wf._pending_requests = [
+            PendingRequest(
+                requester_workflow_id="agent-run-1",
+                runtime_id="claude_code",
+                execution_profile_ref="p1",
+            )
+        ]
+        calls: list[str] = []
+
+        async def persist() -> bool:
+            calls.append("persist")
+            return True
+
+        async def signal(_workflow_id: str, _profile_id: str) -> None:
+            calls.append("signal")
+
+        wf._sync_leases_to_db = AsyncMock(side_effect=persist)
+        wf._signal_slot_assigned = AsyncMock(side_effect=signal)
+
+        with patch(
+            "moonmind.workflows.temporal.workflows.provider_profile_manager.workflow"
+        ) as mock_wf:
+            mock_wf.now.return_value = datetime.now(timezone.utc)
+            mock_wf.patched.side_effect = (
+                lambda patch_id: patch_id == DURABLE_LEASE_GRANT_PATCH
+            )
+            await wf._drain_queue()
+
+        assert calls == ["persist", "signal"]
+        assert wf._profiles["p1"].current_leases == ["agent-run-1"]
+        assert wf._pending_requests == []
+
+    @pytest.mark.asyncio
+    async def test_durable_grant_blocks_when_lease_persistence_is_unavailable(self):
+        wf = self._make_workflow()
+        wf._profiles["p1"] = ProfileSlotState(
+            profile_id="p1",
+            max_parallel_runs=1,
+            cooldown_after_429_seconds=300,
+            rate_limit_policy="backoff",
+            enabled=True,
+            is_default=True,
+        )
+        request = PendingRequest(
+            requester_workflow_id="agent-run-1",
+            runtime_id="claude_code",
+            execution_profile_ref="p1",
+        )
+        wf._pending_requests = [request]
+        wf._sync_leases_to_db = AsyncMock(return_value=False)
+        wf._signal_slot_assigned = AsyncMock()
+
+        with patch(
+            "moonmind.workflows.temporal.workflows.provider_profile_manager.workflow"
+        ) as mock_wf:
+            mock_wf.now.return_value = datetime.now(timezone.utc)
+            mock_wf.patched.side_effect = (
+                lambda patch_id: patch_id == DURABLE_LEASE_GRANT_PATCH
+            )
+            await wf._drain_queue()
+
+        wf._signal_slot_assigned.assert_not_awaited()
+        assert wf._profiles["p1"].current_leases == ["agent-run-1"]
+        assert wf._pending_requests == [request]
+
+    @pytest.mark.asyncio
+    async def test_direct_update_does_not_return_unpersisted_lease(self):
+        wf = self._make_workflow()
+        wf._profiles["p1"] = ProfileSlotState(
+            profile_id="p1",
+            max_parallel_runs=1,
+            cooldown_after_429_seconds=300,
+            rate_limit_policy="backoff",
+            enabled=True,
+            is_default=True,
+        )
+        wf._sync_leases_to_db = AsyncMock(return_value=False)
+
+        with patch(
+            "moonmind.workflows.temporal.workflows.provider_profile_manager.workflow"
+        ) as mock_wf:
+            mock_wf.patched.return_value = True
+            mock_wf.now.return_value = datetime.now(timezone.utc)
+            with pytest.raises(Exception, match="persistence failed before direct grant"):
+                await wf.acquire_slot(
+                    {
+                        "requester_workflow_id": "container-job-1",
+                        "runtime_id": "claude_code",
+                    }
+                )
+
+        assert wf._profiles["p1"].current_leases == []
+
+    @pytest.mark.asyncio
+    async def test_maintenance_update_does_not_return_unpersisted_lease(self):
+        wf = self._make_workflow()
+        wf._profiles["p1"] = ProfileSlotState(
+            profile_id="p1",
+            max_parallel_runs=1,
+            cooldown_after_429_seconds=300,
+            rate_limit_policy="backoff",
+            enabled=False,
+            is_default=True,
+        )
+        wf._sync_leases_to_db = AsyncMock(return_value=False)
+
+        with patch(
+            "moonmind.workflows.temporal.workflows.provider_profile_manager.workflow"
+        ) as mock_wf:
+            mock_wf.patched.return_value = True
+            mock_wf.now.return_value = datetime.now(timezone.utc)
+            with pytest.raises(
+                Exception,
+                match="persistence failed before maintenance grant",
+            ):
+                await wf.acquire_credential_maintenance_lease(
+                    {
+                        "requester_workflow_id": "oauth-session-1",
+                        "runtime_id": "claude_code",
+                        "execution_profile_ref": "p1",
+                        "purpose": "credential_validation",
+                    }
+                )
+
+        assert wf._profiles["p1"].current_leases == []
+
     def test_handoff_reservation_blocks_only_one_slot(self):
         wf = self._make_workflow()
         wf._profiles["p1"] = ProfileSlotState(
@@ -2274,6 +2569,13 @@ def test_verify_pending_requests_patch_id():
         VERIFY_PENDING_REQUESTS_PATCH
         == "provider-profile-manager-verify-pending-requests-v1"
     )
+
+
+def test_profile_manager_reliability_patch_ids():
+    assert FRESH_START_DB_LEASE_RESTORE_PATCH.endswith(
+        "fresh-start-db-lease-restore-v1"
+    )
+    assert DURABLE_LEASE_GRANT_PATCH.endswith("durable-lease-grant-v1")
 
 def test_registered_workflow_types():
     from moonmind.workflows.temporal.workers import list_registered_workflow_types
@@ -2672,6 +2974,42 @@ def test_provider_profile_manager_state_activity_exists():
     from moonmind.workflows.temporal.artifacts import TemporalArtifactActivities
 
     assert hasattr(TemporalArtifactActivities, "provider_profile_manager_state")
+
+
+def test_legacy_reset_activity_never_terminates_manager():
+    import inspect
+
+    from moonmind.workflows.temporal.artifacts import TemporalArtifactActivities
+
+    source = inspect.getsource(
+        TemporalArtifactActivities.provider_profile_reset_manager
+    )
+    assert "provider_profile_ensure_manager" in source
+    assert ".terminate(" not in source
+
+
+@pytest.mark.asyncio
+async def test_legacy_reset_activity_uses_non_destructive_ensure_contract():
+    from moonmind.workflows.temporal.artifacts import TemporalArtifactActivities
+
+    activities = TemporalArtifactActivities(AsyncMock())
+    activities.provider_profile_ensure_manager = AsyncMock(
+        return_value={
+            "started": False,
+            "workflow_id": "provider-profile-manager:codex_cli",
+        }
+    )
+
+    result = await activities.provider_profile_reset_manager(runtime_id="codex_cli")
+
+    activities.provider_profile_ensure_manager.assert_awaited_once_with(
+        runtime_id="codex_cli"
+    )
+    assert result == {
+        "reset": False,
+        "started": False,
+        "workflow_id": "provider-profile-manager:codex_cli",
+    }
 
 @pytest.mark.asyncio
 async def test_provider_profile_manager_state_returns_compact_running_snapshot(

--- a/tests/unit/workflows/temporal/workflows/test_agent_run_slot_wait_timeout.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_run_slot_wait_timeout.py
@@ -4,8 +4,9 @@ The awaiting state (waiting for a provider-profile slot) must not consume the
 execution timeout budget.  ``overall_start`` is reset after slot acquisition
 so the full timeout is available for actual execution.
 
-The slot wait uses a timeout+retry loop: if the manager doesn't respond within
-``_SLOT_WAIT_TIMEOUT_SECONDS``, the AgentRun resets the manager and re-requests.
+The slot wait uses a timeout+retry loop. Recovery may ensure and re-request the
+manager, but it must never terminate the singleton while credential consumers
+may still be active.
 """
 
 import inspect
@@ -14,10 +15,11 @@ import textwrap
 from moonmind.workflows.temporal.workflows.agent_run import (
     ACCURATE_SLOT_WAIT_REASON_PATCH_ID,
     MANAGER_SLOT_WAIT_INSPECTION_PATCH_ID,
+    NON_DESTRUCTIVE_SLOT_WAIT_RECOVERY_PATCH_ID,
     MoonMindAgentRun,
     RunStatus,
     _SLOT_WAIT_TIMEOUT_SECONDS,
-    _SLOT_WAIT_MAX_RESETS,
+    _SLOT_WAIT_MAX_RECOVERY_ATTEMPTS,
 )
 
 class TestSlotWaitRetryBehavior:
@@ -25,7 +27,7 @@ class TestSlotWaitRetryBehavior:
 
     def test_slot_wait_has_timeout_in_patched_path(self):
         """The patched ``wait_condition`` call for slot assignment must have
-        a timeout so that a stuck manager triggers a reset."""
+        a timeout so that a stuck manager triggers bounded recovery."""
         import ast
 
         source = textwrap.dedent(inspect.getsource(MoonMindAgentRun.run))
@@ -63,7 +65,7 @@ class TestSlotWaitRetryBehavior:
 
         assert found_with_timeout, (
             "The patched slot-wait path must use wait_condition with a timeout "
-            "to detect and recover from a stuck manager"
+            "to detect and recover from an unavailable manager"
         )
         # The legacy (unpatched) path should still have no timeout
         assert found_without_timeout, (
@@ -142,22 +144,25 @@ class TestSlotWaitRetryBehavior:
 
     def test_slot_wait_constants_are_sane(self):
         """Verify the slot wait constants have reasonable values."""
+        assert NON_DESTRUCTIVE_SLOT_WAIT_RECOVERY_PATCH_ID.endswith(
+            "non-destructive-slot-wait-recovery-v1"
+        )
         assert _SLOT_WAIT_TIMEOUT_SECONDS >= 60, (
             "Slot wait timeout should be at least 60 seconds to allow for "
             "normal manager processing delays"
         )
-        assert _SLOT_WAIT_MAX_RESETS >= 1, (
-            "Must allow at least one manager reset attempt"
+        assert _SLOT_WAIT_MAX_RECOVERY_ATTEMPTS >= 1, (
+            "Must allow at least one manager recovery attempt"
         )
-        assert _SLOT_WAIT_MAX_RESETS <= 10, (
-            "Too many reset attempts would delay failure detection"
+        assert _SLOT_WAIT_MAX_RECOVERY_ATTEMPTS <= 10, (
+            "Too many recovery attempts would delay failure detection"
         )
 
-    def test_reset_and_request_slot_method_exists(self):
-        """The _reset_and_request_slot helper must exist for the retry loop."""
-        assert hasattr(MoonMindAgentRun, "_reset_and_request_slot"), (
-            "MoonMindAgentRun must have _reset_and_request_slot method "
-            "for resetting a stuck manager during slot acquisition"
+    def test_recover_and_request_slot_method_exists(self):
+        """The recovery helper must preserve singleton lease authority."""
+        assert hasattr(MoonMindAgentRun, "_recover_and_request_slot"), (
+            "MoonMindAgentRun must have _recover_and_request_slot for bounded "
+            "non-destructive slot recovery"
         )
 
     def test_slot_timeout_inspects_manager_before_reset(self):
@@ -173,9 +178,10 @@ class TestSlotWaitRetryBehavior:
             MoonMindAgentRun._manager_state_for_slot_wait
         )
         assert source.index("_manager_state_for_slot_wait") < source.index(
-            "_reset_and_request_slot"
+            "_recover_and_request_slot"
         )
         assert "re-requesting without reset" in source
+        assert "NON_DESTRUCTIVE_SLOT_WAIT_RECOVERY_PATCH_ID" in source
 
     def test_accurate_initial_wait_reason_is_replay_gated(self):
         source = inspect.getsource(MoonMindAgentRun.run)
@@ -194,20 +200,22 @@ class TestSlotWaitRetryBehavior:
         assert "not self.runtime_selection_updated_event.is_set()" in source
         assert "_inspected_provider_slot_waiting_reason" in source
 
-    def test_reset_and_request_slot_uses_ensure_signal_fallback(self):
-        """The reset path must tolerate the fresh-manager signal race."""
-        source = inspect.getsource(MoonMindAgentRun._reset_and_request_slot)
+    def test_recover_and_request_slot_uses_ensure_signal_fallback(self):
+        """Recovery must tolerate the fresh-manager signal race without reset."""
+        source = inspect.getsource(MoonMindAgentRun._recover_and_request_slot)
 
         assert "_ensure_manager_and_signal" in source
         assert "manager_handle.signal(\"request_slot\"" not in source
+        assert "provider_profile.reset_manager" not in source
 
-    def test_slot_timeout_probe_failure_falls_back_to_reset(self):
-        """Manager inspection errors must not fail the AgentRun timeout path."""
+    def test_slot_timeout_probe_failure_falls_back_to_safe_recovery(self):
+        """Inspection ambiguity must not authorize destructive manager reset."""
         source = inspect.getsource(MoonMindAgentRun.run)
 
         assert "except CancelledError:" in source
-        assert "falling back to reset path" in source
+        assert "using non-destructive recovery" in source
         assert 'manager_state = {"running": False}' in source
+        assert "_recover_and_request_slot" in source
 
     def test_healthy_manager_does_not_duplicate_pending_request(self):
         """If this workflow is already pending, timeout recovery must not re-signal."""


### PR DESCRIPTION
## Summary

- restore the authoritative provider-profile lease ledger on every fresh manager execution, even when slot-request signals arrive during startup
- persist lease grants before notifying any AgentRun, direct update caller, or credential-maintenance caller
- keep leases on ambiguous signal/reconnect failures until workflow-status verification proves the owner terminal
- replace destructive AgentRun timeout recovery with idempotent manager ensure/re-request behavior while retaining the legacy activity name for Temporal replay compatibility
- add a real Temporal boundary regression for the startup race that allowed multiple Codex OAuth consumers

## Root cause

The singleton manager skipped database lease recovery whenever its pending queue was non-empty. During a manager restart, waiting AgentRuns could signal while the initial profile-list activity was still running, making the queue non-empty before recovery. The manager then granted a replacement lease and its full-snapshot persistence removed the prior lease even though that provider process could still be alive.

AgentRun timeout recovery amplified the race by terminating and recreating the manager when health was ambiguous.

## Verification

- `143 passed`: provider-profile manager and AgentRun slot-wait unit suites
- `172 passed`: provider-profile manager, AgentRun slot-wait, and manager-start adjacency suite
- `1 passed`: real Temporal startup-race boundary test
- `git diff --check`
- focused Ruff checks passed; the new boundary test passes Black check

All Docker-backed verification used the explicit `moonmind-test-profile-manager` Compose project. Teardown removed only that project's MinIO container and network. The live `moonmind` API, Temporal, Postgres, and worker containers remained running and healthy after testing.
