### PR TITLE
MoonLadderStudios/MoonMind#3472: Separate Omnigent session and workspace checkpoint authority

### DIFF
--- a/docs/Omnigent/CodexCreateToHostContract.md
+++ b/docs/Omnigent/CodexCreateToHostContract.md
@@ -1,5 +1,16 @@
 # Codex via Omnigent Create-to-host contract
 
+## Frozen hybrid capability
+
+Admission records a versioned, digested snapshot for `external/omnigent` and its
+`codex-native` harness. The session plane names Omnigent/bridge
+`external_state_ref` evidence; the workspace plane names MoonMind sandbox locators
+and `worktree_archive` capture/restore; the host plane names static Compose and
+on-demand Docker realization at `/workspaces/run`. Session ids, host ids,
+credentials, and raw paths remain mutable run bindings, not descriptor identity.
+Workflow Detail reports session reattach and workspace restore independently and
+explains when only one plane has sufficient recovery evidence.
+
 **Document Class:** Canonical declarative  
 **Status:** Accepted  
 **Owners:** MoonMind Platform  

--- a/docs/Steps/StepExecutionsAndCheckpointing.md
+++ b/docs/Steps/StepExecutionsAndCheckpointing.md
@@ -1,5 +1,16 @@
 # Step Executions and Checkpointing
 
+## Plane-aware checkpoints
+
+Policy callers select session state, workspace state, or both. Session evidence
+supports reattach or cold-session decisions; workspace evidence supports repository
+continuation and must satisfy the artifact contract, digest, and boundary map in the
+frozen workspace capability. A session `external_state_ref` never represents files,
+git metadata, generated tests, or uncommitted changes. Omnigent workspace boundaries
+therefore use MoonMind `worktree_archive` checkpoints and
+`workspace.apply_checkpoint`, while replay consumes the recorded capability snapshot
+instead of performing a mutable registry lookup.
+
 Status: Desired State
 Owners: MoonMind Engineering
 Last Updated: 2026-06-13

--- a/docs/Temporal/ManagedAndExternalAgentExecutionModel.md
+++ b/docs/Temporal/ManagedAndExternalAgentExecutionModel.md
@@ -1,5 +1,16 @@
 # Managed and External Agent Execution Model
 
+## Hybrid runtime capability ownership
+
+An admitted runtime capability snapshot freezes three independent planes: canonical
+agent identity and session continuity, repository workspace ownership, and host
+realization. For profile-bound Omnigent, identity remains `external/omnigent` with
+the `codex-native` harness. Omnigent owns session reattach evidence; MoonMind owns
+the sandbox `WorkspaceLocator`, repository checkpoint capture, validation, and
+restore. An `external_state_ref` proves session continuity only and cannot satisfy
+workspace restore preflight. Recovery uses the versioned, digested snapshot admitted
+with the run rather than rewriting it after registry or credential changes.
+
 **Document Class:** Canonical declarative  
 **Status:** Current  
 **Owners:** MoonMind Platform  

--- a/docs/Workflows/WorkspaceLocators.md
+++ b/docs/Workflows/WorkspaceLocators.md
@@ -1,5 +1,15 @@
 # Workspace locators
 
+## Hybrid session and workspace authority
+
+Workspace authority comes from the workspace plane of the frozen capability,
+independently of session identity. Profile-bound Omnigent accepts a MoonMind
+`sandbox` locator and mounts it at `/workspaces/run` in both static and on-demand
+hosts. MoonMind captures repository state through `workspace.capture_checkpoint`
+and restores it through `workspace.apply_checkpoint`, retaining normal containment,
+digest, and symlink checks. Omnigent session restore never applies a local archive,
+and workspace restore does not require the original Omnigent host.
+
 The **Codex via Omnigent** product path applies this authority contract as specified by [`docs/Omnigent/CodexCreateToHostContract.md`](../Omnigent/CodexCreateToHostContract.md). Workflow Create never authors absolute paths or daemon bind sources.
 
 Durable workflow payloads identify workspaces with the discriminated

--- a/frontend/src/entrypoints/workflow-detail.test.tsx
+++ b/frontend/src/entrypoints/workflow-detail.test.tsx
@@ -2217,6 +2217,9 @@ describe('Workflow Detail Entrypoint', () => {
               checkpointRef: 'artifact://checkpoint/before',
               sourceWorkflowId: 'wf-source',
               sourceRunId: 'run-source',
+              sessionRecoverable: false,
+              workspaceRecoverable: true,
+              authoritativeWorkspaceCheckpointKind: 'worktree_archive',
               operatorGuidance: 'resume',
               evidence: [
                 {
@@ -2253,6 +2256,9 @@ describe('Workflow Detail Entrypoint', () => {
     expect(await screen.findByRole('heading', { name: 'Recovery evidence' })).toBeTruthy();
     expect(screen.getByText(/Resume from checkpoint is the default recovery action/)).toBeTruthy();
     expect(screen.getByText('artifact://checkpoint/before')).toBeTruthy();
+    expect(screen.getByText('Session reattach:').parentElement?.textContent).toContain('unavailable');
+    expect(screen.getByText('Workspace restore:').parentElement?.textContent).toContain('supported');
+    expect(screen.getByText('Authoritative workspace checkpoint:').parentElement?.textContent).toContain('worktree archive');
     expect(fetchSpy).toHaveBeenCalledWith(
       '/api/executions/test-123/steps/apply/step-executions/2?source=temporal',
       { credentials: 'include' },

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -725,6 +725,10 @@ const RecoveryEligibilitySchema = z
     promotionState: z.string().nullable().optional(),
     liveSessionId: z.string().nullable().optional(),
     supportsSameSessionContinuation: z.boolean().nullable().optional(),
+    sessionRecoverable: z.boolean().nullable().optional(),
+    workspaceRecoverable: z.boolean().nullable().optional(),
+    authoritativeWorkspaceCheckpointKind: z.string().nullable().optional(),
+    partialRecoveryReason: z.string().nullable().optional(),
     operatorGuidance: z.enum(['continue_same_session', 'resume_from_workspace_checkpoint', 'full_retry', 'fix_environment', 'manual_intervention', 'resume', 'needs_human']),
     evidence: z.array(EvidenceRefStatusSchema).default([]),
   })
@@ -6593,6 +6597,18 @@ function RecoveryEvidencePanel({
         ) : null}
         {recovery?.checkpointKind ? (
           <li><strong>Checkpoint kind:</strong> {formatStatusLabel(recovery.checkpointKind)}</li>
+        ) : null}
+        {recovery?.sessionRecoverable != null ? (
+          <li><strong>Session reattach:</strong> {recovery.sessionRecoverable ? 'supported' : 'unavailable'}</li>
+        ) : null}
+        {recovery?.workspaceRecoverable != null ? (
+          <li><strong>Workspace restore:</strong> {recovery.workspaceRecoverable ? 'supported' : 'unavailable'}</li>
+        ) : null}
+        {recovery?.authoritativeWorkspaceCheckpointKind ? (
+          <li><strong>Authoritative workspace checkpoint:</strong> {formatStatusLabel(recovery.authoritativeWorkspaceCheckpointKind)}</li>
+        ) : null}
+        {recovery?.partialRecoveryReason ? (
+          <li><strong>Partial recovery:</strong> {recovery.partialRecoveryReason}</li>
         ) : null}
         {recovery?.runtimeId ? (
           <li><strong>Runtime:</strong> {formatStatusLabel(recovery.runtimeId)}</li>

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -10119,6 +10119,14 @@ export interface components {
             restoreActivity?: string | null;
             /** Workspaceauthority */
             workspaceAuthority?: string | null;
+            /** Sessionrecoverable */
+            sessionRecoverable?: boolean | null;
+            /** Workspacerecoverable */
+            workspaceRecoverable?: boolean | null;
+            /** Authoritativeworkspacecheckpointkind */
+            authoritativeWorkspaceCheckpointKind?: string | null;
+            /** Partialrecoveryreason */
+            partialRecoveryReason?: string | null;
             /** Checkpointref */
             checkpointRef?: string | null;
             /** Sourceworkflowid */

--- a/moonmind/omnigent/profile_bound_execution.py
+++ b/moonmind/omnigent/profile_bound_execution.py
@@ -964,9 +964,19 @@ class OmnigentProfileBoundExecutionCoordinator:
     @staticmethod
     def _repository_mutation_required(request: AgentExecutionRequest) -> bool:
         parameters = request.parameters or {}
-        return bool(parameters.get("repositoryMutationRequired")) or (
-            OmnigentProfileBoundExecutionCoordinator._github_mutation_required(request)
-        )
+        if bool(parameters.get("repositoryMutationRequired")):
+            return True
+        publish_mode = str(parameters.get("publishMode") or "none").strip().lower()
+        if publish_mode not in {"", "none"}:
+            return True
+        skill = parameters.get("skill")
+        if isinstance(skill, Mapping):
+            side_effect = skill.get("sideEffect")
+            if isinstance(side_effect, Mapping) and str(
+                side_effect.get("kind") or ""
+            ).strip():
+                return True
+        return False
 
 
 __all__ = ["OmnigentProfileBoundExecutionCoordinator"]

--- a/moonmind/omnigent/profile_bound_execution.py
+++ b/moonmind/omnigent/profile_bound_execution.py
@@ -39,6 +39,10 @@ from moonmind.provider_profiles.lease_client import (
 )
 from moonmind.provider_profiles.oauth_policy import is_codex_oauth_profile
 from moonmind.schemas.agent_runtime_models import AgentExecutionRequest, AgentRunResult
+from moonmind.workflows.executions.runtime_capabilities import (
+    RuntimeCapabilityError,
+    resolve_runtime_execution_capabilities,
+)
 
 
 ExecutionRunner = Callable[..., Awaitable[AgentRunResult]]
@@ -342,6 +346,20 @@ class OmnigentProfileBoundExecutionCoordinator:
                     ),
                     provider_profile_id=profile_id,
                 )
+            try:
+                host_capabilities = resolve_runtime_execution_capabilities(
+                    "omnigent"
+                ).host_realization
+                assert host_capabilities is not None
+                host_capabilities.require_mode(
+                    str(effective_launch["hostMode"]),
+                    repository_mutation=self._repository_mutation_required(request),
+                    github_credentials=self._github_mutation_required(request),
+                )
+            except RuntimeCapabilityError as exc:
+                raise OmnigentOAuthHostError(
+                    str(exc), code="OMNIGENT_HOST_MODE_CAPABILITY_UNSUPPORTED"
+                ) from exc
             await emit(
                 "effective_launch_compiled",
                 "completed",
@@ -941,6 +959,13 @@ class OmnigentProfileBoundExecutionCoordinator:
         side_effect = skill.get("sideEffect")
         return isinstance(side_effect, Mapping) and bool(
             str(side_effect.get("kind") or "").strip()
+        )
+
+    @staticmethod
+    def _repository_mutation_required(request: AgentExecutionRequest) -> bool:
+        parameters = request.parameters or {}
+        return bool(parameters.get("repositoryMutationRequired")) or (
+            OmnigentProfileBoundExecutionCoordinator._github_mutation_required(request)
         )
 
 

--- a/moonmind/schemas/managed_checkpoint_models.py
+++ b/moonmind/schemas/managed_checkpoint_models.py
@@ -42,7 +42,9 @@ class ManagedWorkspaceCheckpointCaptureInput(BaseModel):
         "codex_cli", alias="expectedRuntimeId"
     )
     capability_set_version: Literal[
-        "runtime-execution-capabilities-v1", "runtime-execution-capabilities-v2"
+        "runtime-execution-capabilities-v1",
+        "runtime-execution-capabilities-v2",
+        "runtime-execution-capabilities-v3",
     ] = Field(
         ..., alias="capabilitySetVersion"
     )

--- a/moonmind/schemas/temporal_models.py
+++ b/moonmind/schemas/temporal_models.py
@@ -327,6 +327,14 @@ class RecoveryEligibilityDiagnosticModel(BaseModel):
     checkpoint_restore_kinds: tuple[str, ...] = Field(default=(), alias="checkpointRestoreKinds")
     restore_activity: str | None = Field(None, alias="restoreActivity", max_length=200)
     workspace_authority: str | None = Field(None, alias="workspaceAuthority", max_length=100)
+    session_recoverable: bool | None = Field(None, alias="sessionRecoverable")
+    workspace_recoverable: bool | None = Field(None, alias="workspaceRecoverable")
+    authoritative_workspace_checkpoint_kind: str | None = Field(
+        None, alias="authoritativeWorkspaceCheckpointKind", max_length=100
+    )
+    partial_recovery_reason: str | None = Field(
+        None, alias="partialRecoveryReason", max_length=240
+    )
     checkpoint_ref: str | None = Field(None, alias="checkpointRef", max_length=500)
     source_workflow_id: str | None = Field(None, alias="sourceWorkflowId", max_length=200)
     source_run_id: str | None = Field(None, alias="sourceRunId", max_length=200)

--- a/moonmind/workflows/executions/runtime_capabilities.py
+++ b/moonmind/workflows/executions/runtime_capabilities.py
@@ -21,7 +21,7 @@ WorkspaceAuthority = Literal[
 ]
 CheckpointCriticality = Literal["required", "recoverability_only", "unsupported"]
 
-CAPABILITY_SET_VERSION = "runtime-execution-capabilities-v2"
+CAPABILITY_SET_VERSION = "runtime-execution-capabilities-v3"
 CheckpointResumePhase = Literal[
     "rerun_failed_step", "continue_to_gate", "continue_after_gate",
     "resume_publication", "retry_restoration",
@@ -32,18 +32,91 @@ class RuntimeCapabilityError(ValueError):
     """Raised when a runtime or capability/workspace combination is invalid."""
 
 
+class AgentIdentityCapability(BaseModel):
+    model_config = ConfigDict(populate_by_name=True, extra="forbid", frozen=True)
+
+    agent_kind: Literal["managed", "external"] = Field(..., alias="agentKind")
+    agent_id: NonBlankStr = Field(..., alias="agentId")
+    harness: str | None = None
+
+
+class SessionStateCapability(BaseModel):
+    model_config = ConfigDict(populate_by_name=True, extra="forbid", frozen=True)
+
+    authority: WorkspaceAuthority
+    checkpoint_kinds: tuple[str, ...] = Field(default=(), alias="checkpointKinds")
+    capture_activity: str | None = Field(None, alias="captureActivity")
+    restore_owner: str | None = Field(None, alias="restoreOwner")
+    required_evidence: tuple[str, ...] = Field(default=(), alias="requiredEvidence")
+    supports_live_reattach: bool = Field(False, alias="supportsLiveReattach")
+    supports_cold_session: bool = Field(False, alias="supportsColdSession")
+
+    @model_validator(mode="after")
+    def _validate_capture(self) -> "SessionStateCapability":
+        if bool(self.checkpoint_kinds) != bool(self.capture_activity):
+            raise ValueError("session checkpoint kinds and capture activity must be declared together")
+        if self.supports_cold_session and not self.restore_owner:
+            raise ValueError("cold session support must name its restore owner")
+        return self
+
+
+class WorkspaceStateCapability(BaseModel):
+    model_config = ConfigDict(populate_by_name=True, extra="forbid", frozen=True)
+
+    authority: WorkspaceAuthority
+    locator_kinds: tuple[str, ...] = Field(default=(), alias="locatorKinds")
+    checkpoint_kinds: tuple[str, ...] = Field(default=(), alias="checkpointKinds")
+    restore_kinds: tuple[str, ...] = Field(default=(), alias="restoreKinds")
+    capture_activity: str | None = Field(None, alias="captureActivity")
+    restore_activity: str | None = Field(None, alias="restoreActivity")
+    artifact_contract_version: str | None = Field(None, alias="artifactContractVersion")
+    digest_required: bool = Field(False, alias="digestRequired")
+    boundary_support: dict[str, tuple[CheckpointResumePhase, ...]] = Field(
+        default_factory=dict, alias="boundarySupport"
+    )
+
+    @model_validator(mode="after")
+    def _validate_checkpoint_contract(self) -> "WorkspaceStateCapability":
+        if bool(self.checkpoint_kinds) != bool(self.capture_activity):
+            raise ValueError("workspace checkpoint kinds and capture activity must be declared together")
+        if bool(self.restore_kinds) != bool(self.restore_activity):
+            raise ValueError("workspace restore kinds and activity must be declared together")
+        if self.restore_kinds and (not self.artifact_contract_version or not self.boundary_support):
+            raise ValueError("workspace restore support requires artifact contract and boundaries")
+        if self.authority == "moonmind_sandbox" and self.locator_kinds != ("sandbox",):
+            raise ValueError("MoonMind sandbox workspace authority requires sandbox locators")
+        return self
+
+
+class HostRealizationCapability(BaseModel):
+    model_config = ConfigDict(populate_by_name=True, extra="forbid", frozen=True)
+
+    owner: NonBlankStr
+    modes: tuple[str, ...] = ()
+    lease_owner: str | None = Field(None, alias="leaseOwner")
+    cleanup_owner: str | None = Field(None, alias="cleanupOwner")
+    workspace_mount_target: str | None = Field(None, alias="workspaceMountTarget")
+    repository_mutation_isolated: bool = Field(False, alias="repositoryMutationIsolated")
+    github_credentials_isolated: bool = Field(False, alias="githubCredentialsIsolated")
+
+
 class RuntimeExecutionCapabilities(BaseModel):
     """Compact runtime-neutral policy snapshot recorded with an execution."""
 
     model_config = ConfigDict(populate_by_name=True, extra="forbid", frozen=True)
 
     capability_set_version: Literal[
-        "runtime-execution-capabilities-v1", "runtime-execution-capabilities-v2"
+        "runtime-execution-capabilities-v1", "runtime-execution-capabilities-v2",
+        "runtime-execution-capabilities-v3",
     ] = Field(
-        CAPABILITY_SET_VERSION, alias="capabilitySetVersion"
+        "runtime-execution-capabilities-v2", alias="capabilitySetVersion"
     )
     runtime_id: NonBlankStr = Field(..., alias="runtimeId")
     runtime_family: str | None = Field(None, alias="runtimeFamily")
+    agent_identity: AgentIdentityCapability | None = Field(None, alias="agentIdentity")
+    session_state: SessionStateCapability | None = Field(None, alias="sessionState")
+    workspace_state: WorkspaceStateCapability | None = Field(None, alias="workspaceState")
+    host_realization: HostRealizationCapability | None = Field(None, alias="hostRealization")
     workspace_authority: WorkspaceAuthority = Field(..., alias="workspaceAuthority")
     checkpoint_capture_kinds: tuple[str, ...] = Field(
         default=(), alias="checkpointCaptureKinds"
@@ -82,6 +155,20 @@ class RuntimeExecutionCapabilities(BaseModel):
 
     @model_validator(mode="after")
     def _validate_claims(self) -> "RuntimeExecutionCapabilities":
+        if self.capability_set_version == CAPABILITY_SET_VERSION:
+            if not all((self.agent_identity, self.session_state, self.workspace_state, self.host_realization)):
+                raise ValueError("v3 capability snapshots require identity, session, workspace, and host planes")
+            assert self.workspace_state is not None
+            if self.workspace_authority != self.workspace_state.authority:
+                raise ValueError("workspace authority contradicts workspace state plane")
+            if self.checkpoint_capture_kinds != self.workspace_state.checkpoint_kinds:
+                raise ValueError("checkpoint capture kinds contradict workspace state plane")
+            if self.checkpoint_restore_kinds != self.workspace_state.restore_kinds:
+                raise ValueError("checkpoint restore kinds contradict workspace state plane")
+            if self.checkpoint_capture_activity != self.workspace_state.capture_activity:
+                raise ValueError("checkpoint capture activity contradicts workspace state plane")
+            if self.checkpoint_restore_activity != self.workspace_state.restore_activity:
+                raise ValueError("checkpoint restore activity contradicts workspace state plane")
         if bool(self.checkpoint_capture_kinds) != bool(self.checkpoint_capture_activity):
             raise ValueError("checkpoint capture kinds and activity must be declared together")
         if bool(self.checkpoint_restore_kinds) != bool(self.checkpoint_restore_activity):
@@ -121,6 +208,35 @@ class RuntimeExecutionCapabilities(BaseModel):
 
 
 def _descriptor(**values: Any) -> RuntimeExecutionCapabilities:
+    values.setdefault("capabilitySetVersion", CAPABILITY_SET_VERSION)
+    runtime_id = values["runtimeId"]
+    authority = values["workspaceAuthority"]
+    capture_kinds = tuple(values.get("checkpointCaptureKinds", ()))
+    restore_kinds = tuple(values.get("checkpointRestoreKinds", ()))
+    capture_activity = values.get("checkpointCaptureActivity")
+    restore_activity = values.get("checkpointRestoreActivity")
+    contract_version = values.get("checkpointArtifactContractVersion")
+    boundaries = values.get("checkpointBoundarySupport", {})
+    values.setdefault("agentIdentity", {
+        "agentKind": "external" if values.get("runtimeFamily") == "external_provider" else "managed",
+        "agentId": runtime_id,
+    })
+    values.setdefault("sessionState", {
+        "authority": authority,
+        "supportsLiveReattach": values.get("supportsSameSessionContinuation", False),
+    })
+    values.setdefault("workspaceState", {
+        "authority": authority,
+        "locatorKinds": ({"moonmind_sandbox": ("sandbox",), "managed_runtime": ("managed_runtime",), "external_provider": ("external_state",)}.get(authority, ())),
+        "checkpointKinds": capture_kinds,
+        "restoreKinds": restore_kinds,
+        "captureActivity": capture_activity,
+        "restoreActivity": restore_activity,
+        "artifactContractVersion": contract_version,
+        "digestRequired": bool(restore_kinds),
+        "boundarySupport": boundaries or ({"before_execution": ("rerun_failed_step",)} if restore_kinds else {}),
+    })
+    values.setdefault("hostRealization", {"owner": "moonmind" if authority != "external_provider" else "external_provider"})
     return RuntimeExecutionCapabilities(**values).with_digest()
 
 
@@ -165,14 +281,46 @@ _DESCRIPTORS = (
     ),
     _descriptor(
         runtimeId="omnigent", runtimeFamily="external_provider",
-        workspaceAuthority="external_provider",
-        checkpointCaptureKinds=("external_state_ref",),
-        checkpointRestoreKinds=("external_state_ref",),
-        # This activity persists an already-produced external state reference;
-        # it never resolves or reads an external provider workspace path.
+        agentIdentity={"agentKind": "external", "agentId": "omnigent", "harness": "codex-native"},
+        sessionState={
+            "authority": "external_provider",
+            "checkpointKinds": ("external_state_ref",),
+            "captureActivity": "workspace.capture_checkpoint",
+            "restoreOwner": "integration.omnigent.profile_bound_execute",
+            "requiredEvidence": ("externalStateRef", "runtimeSessionId", "firstMessageEvidenceRef"),
+            "supportsLiveReattach": True,
+            "supportsColdSession": True,
+        },
+        workspaceAuthority="moonmind_sandbox",
+        checkpointCaptureKinds=("worktree_archive",),
+        checkpointRestoreKinds=("worktree_archive",),
         checkpointCaptureActivity="workspace.capture_checkpoint",
-        checkpointRestoreActivity="integration.omnigent.execute",
-        checkpointArtifactContractVersion="external-state-ref-v1",
+        checkpointRestoreActivity="workspace.apply_checkpoint",
+        checkpointArtifactContractVersion="workspace-checkpoint-v1",
+        checkpointBoundarySupport={
+            "after_execution": ("continue_to_gate",),
+            "after_gate": ("continue_after_gate",),
+            "before_publication": ("resume_publication",),
+            "before_execution": ("rerun_failed_step",),
+        },
+        workspaceState={
+            "authority": "moonmind_sandbox", "locatorKinds": ("sandbox",),
+            "checkpointKinds": ("worktree_archive",), "restoreKinds": ("worktree_archive",),
+            "captureActivity": "workspace.capture_checkpoint",
+            "restoreActivity": "workspace.apply_checkpoint",
+            "artifactContractVersion": "workspace-checkpoint-v1", "digestRequired": True,
+            "boundarySupport": {
+                "after_execution": ("continue_to_gate",), "after_gate": ("continue_after_gate",),
+                "before_publication": ("resume_publication",), "before_execution": ("rerun_failed_step",),
+            },
+        },
+        hostRealization={
+            "owner": "moonmind", "modes": ("static_compose", "on_demand_docker"),
+            "leaseOwner": "integration.omnigent.profile_bound_execute",
+            "cleanupOwner": "integration.omnigent.profile_bound_execute",
+            "workspaceMountTarget": "/workspaces/run",
+            "repositoryMutationIsolated": True, "githubCredentialsIsolated": True,
+        },
         supportsSameSessionContinuation=True,
         terminalContractIds=("omnigent_execution_terminal_v1",),
         postExecutionCheckpointCriticality="required",
@@ -261,6 +409,12 @@ def validate_runtime_preflight(
             f"runtime '{capabilities.runtime_id}' owns '{capabilities.workspace_authority}' "
             f"workspaces, not '{requested_authority}'"
         )
+    if workspace_locator and capabilities.workspace_state:
+        locator_kind = str(workspace_locator.get("kind") or "").strip()
+        if locator_kind not in capabilities.workspace_state.locator_kinds:
+            raise RuntimeCapabilityError(
+                f"runtime '{capabilities.runtime_id}' does not accept workspace locator kind '{locator_kind}'"
+            )
     if checkpoint_kind and checkpoint_kind not in capabilities.checkpoint_capture_kinds:
         raise RuntimeCapabilityError(
             f"runtime '{capabilities.runtime_id}' cannot capture checkpoint kind "
@@ -279,7 +433,8 @@ def validate_runtime_preflight(
 
 __all__ = [
     "CAPABILITY_SET_VERSION", "RUNTIME_EXECUTION_CAPABILITIES",
-    "RuntimeCapabilityError", "RuntimeExecutionCapabilities",
+    "AgentIdentityCapability", "HostRealizationCapability", "RuntimeCapabilityError",
+    "RuntimeExecutionCapabilities", "SessionStateCapability", "WorkspaceStateCapability",
     "RuntimeExecutionCapabilityRegistry", "resolve_runtime_execution_capabilities",
     "validate_runtime_preflight", "workspace_authority_from_locator",
 ]

--- a/moonmind/workflows/executions/runtime_capabilities.py
+++ b/moonmind/workflows/executions/runtime_capabilities.py
@@ -88,16 +88,48 @@ class WorkspaceStateCapability(BaseModel):
         return self
 
 
+class HostModeCapability(BaseModel):
+    model_config = ConfigDict(populate_by_name=True, extra="forbid", frozen=True)
+
+    mode: NonBlankStr
+    repository_mutation_isolated: bool = Field(False, alias="repositoryMutationIsolated")
+    github_credentials_isolated: bool = Field(False, alias="githubCredentialsIsolated")
+
+
 class HostRealizationCapability(BaseModel):
     model_config = ConfigDict(populate_by_name=True, extra="forbid", frozen=True)
 
     owner: NonBlankStr
-    modes: tuple[str, ...] = ()
+    mode_capabilities: tuple[HostModeCapability, ...] = Field(
+        default=(), alias="modeCapabilities"
+    )
     lease_owner: str | None = Field(None, alias="leaseOwner")
     cleanup_owner: str | None = Field(None, alias="cleanupOwner")
     workspace_mount_target: str | None = Field(None, alias="workspaceMountTarget")
-    repository_mutation_isolated: bool = Field(False, alias="repositoryMutationIsolated")
-    github_credentials_isolated: bool = Field(False, alias="githubCredentialsIsolated")
+
+    @model_validator(mode="after")
+    def _validate_modes(self) -> "HostRealizationCapability":
+        modes = tuple(item.mode for item in self.mode_capabilities)
+        if len(modes) != len(set(modes)):
+            raise ValueError("host realization modes must be unique")
+        return self
+
+    def require_mode(
+        self, mode: str, *, repository_mutation: bool = False,
+        github_credentials: bool = False,
+    ) -> HostModeCapability:
+        selected = next((item for item in self.mode_capabilities if item.mode == mode), None)
+        if selected is None:
+            raise RuntimeCapabilityError(f"unsupported host realization mode '{mode}'")
+        if repository_mutation and not selected.repository_mutation_isolated:
+            raise RuntimeCapabilityError(
+                f"host realization mode '{mode}' does not isolate repository mutation"
+            )
+        if github_credentials and not selected.github_credentials_isolated:
+            raise RuntimeCapabilityError(
+                f"host realization mode '{mode}' does not isolate GitHub credentials"
+            )
+        return selected
 
 
 class RuntimeExecutionCapabilities(BaseModel):
@@ -315,11 +347,21 @@ _DESCRIPTORS = (
             },
         },
         hostRealization={
-            "owner": "moonmind", "modes": ("static_compose", "on_demand_docker"),
+            "owner": "moonmind", "modeCapabilities": (
+                {
+                    "mode": "static_compose",
+                    "repositoryMutationIsolated": False,
+                    "githubCredentialsIsolated": False,
+                },
+                {
+                    "mode": "on_demand_docker",
+                    "repositoryMutationIsolated": True,
+                    "githubCredentialsIsolated": True,
+                },
+            ),
             "leaseOwner": "integration.omnigent.profile_bound_execute",
             "cleanupOwner": "integration.omnigent.profile_bound_execute",
             "workspaceMountTarget": "/workspaces/run",
-            "repositoryMutationIsolated": True, "githubCredentialsIsolated": True,
         },
         supportsSameSessionContinuation=True,
         terminalContractIds=("omnigent_execution_terminal_v1",),

--- a/moonmind/workflows/executions/runtime_capabilities.py
+++ b/moonmind/workflows/executions/runtime_capabilities.py
@@ -201,6 +201,13 @@ class RuntimeExecutionCapabilities(BaseModel):
                 raise ValueError("checkpoint capture activity contradicts workspace state plane")
             if self.checkpoint_restore_activity != self.workspace_state.restore_activity:
                 raise ValueError("checkpoint restore activity contradicts workspace state plane")
+            if (
+                self.checkpoint_artifact_contract_version
+                != self.workspace_state.artifact_contract_version
+            ):
+                raise ValueError("checkpoint artifact contract contradicts workspace state plane")
+            if self.checkpoint_boundary_support != self.workspace_state.boundary_support:
+                raise ValueError("checkpoint boundary support contradicts workspace state plane")
         if bool(self.checkpoint_capture_kinds) != bool(self.checkpoint_capture_activity):
             raise ValueError("checkpoint capture kinds and activity must be declared together")
         if bool(self.checkpoint_restore_kinds) != bool(self.checkpoint_restore_activity):

--- a/moonmind/workflows/temporal/activity_catalog.py
+++ b/moonmind/workflows/temporal/activity_catalog.py
@@ -621,6 +621,16 @@ def build_default_activity_catalog(
             heartbeat_required=True,
         ),
         TemporalActivityDefinition(
+            activity_type="workspace.apply_checkpoint",
+            family="workspace",
+            capability_class="sandbox",
+            task_queue=cfg.activity_sandbox_task_queue,
+            fleet=SANDBOX_FLEET,
+            timeouts=TemporalActivityTimeouts(120, 300, heartbeat_timeout_seconds=30),
+            retries=_activity_retries(max_attempts=2, max_interval_seconds=300),
+            heartbeat_required=True,
+        ),
+        TemporalActivityDefinition(
             activity_type="workspace.apply_policy",
             family="workspace",
             capability_class="sandbox",

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -1346,6 +1346,7 @@ _ACTIVITY_HANDLER_ATTRS: dict[str, tuple[str, str]] = {
     "sandbox.run_command": ("sandbox", "sandbox_run_command"),
     "sandbox.run_tests": ("sandbox", "sandbox_run_tests"),
     "workspace.capture_checkpoint": ("sandbox", "workspace_capture_checkpoint"),
+    "workspace.apply_checkpoint": ("sandbox", "workspace_apply_policy"),
     "agent_runtime.capture_workspace_checkpoint": (
         "agent_runtime",
         "agent_runtime_capture_workspace_checkpoint",

--- a/moonmind/workflows/temporal/checkpoint_policy.py
+++ b/moonmind/workflows/temporal/checkpoint_policy.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Literal
 
 from moonmind.schemas.temporal_models import WorkspacePolicy
 from moonmind.workflows.executions.runtime_capabilities import (
@@ -16,6 +16,7 @@ from moonmind.workflows.executions.runtime_capabilities import (
 )
 
 _LEGACY_SANDBOX_CAPABILITIES = RuntimeExecutionCapabilities(
+    capabilitySetVersion="runtime-execution-capabilities-v2",
     runtimeId="legacy_sandbox",
     runtimeFamily="moonmind_sandbox",
     workspaceAuthority="moonmind_sandbox",
@@ -29,6 +30,7 @@ _LEGACY_SANDBOX_CAPABILITIES = RuntimeExecutionCapabilities(
     postExecutionCheckpointCriticality="recoverability_only",
 ).with_digest()
 _LEGACY_MANAGED_CAPABILITIES = RuntimeExecutionCapabilities(
+    capabilitySetVersion="runtime-execution-capabilities-v2",
     runtimeId="legacy_managed_runtime",
     runtimeFamily="managed_cli",
     workspaceAuthority="managed_runtime",
@@ -48,6 +50,20 @@ class ResolvedCheckpointPolicy:
     capture_activity: str | None = None
     criticality: str = "unsupported"
     supported_checkpoint_kinds: tuple[str, ...] = ()
+    session: "CheckpointPlaneDecision | None" = None
+    workspace: "CheckpointPlaneDecision | None" = None
+
+
+@dataclass(frozen=True)
+class CheckpointPlaneDecision:
+    plane: Literal["session", "workspace"]
+    checkpoint_kind: str | None
+    resumable: bool
+    required_evidence: tuple[str, ...]
+    authority: WorkspaceAuthority
+    capture_activity: str | None
+    restore_activity: str | None
+    supported_checkpoint_kinds: tuple[str, ...]
 
 
 _EXTERNAL_STATE_BOUNDARIES = frozenset(
@@ -102,6 +118,7 @@ def resolve_checkpoint_policy(
     runtime_kind: str | None = None,
     external_agent_id: str | None = None,
     agent_kind: str | None = None,
+    requested_state: Literal["session", "workspace", "both"] = "workspace",
 ) -> ResolvedCheckpointPolicy:
     """Select checkpoint behavior solely from a recorded capability snapshot."""
 
@@ -128,6 +145,39 @@ def resolve_checkpoint_policy(
     validate_runtime_preflight(capabilities, workspace_authority=authority)
     token = _boundary_token(boundary)
 
+    session_capability = capabilities.session_state
+    session_kind = None
+    if session_capability and session_capability.checkpoint_kinds and token in _EXTERNAL_STATE_BOUNDARIES:
+        session_kind = session_capability.checkpoint_kinds[0]
+    session_decision = CheckpointPlaneDecision(
+        plane="session",
+        checkpoint_kind=session_kind,
+        resumable=bool(
+            session_kind and session_capability
+            and (session_capability.supports_live_reattach or session_capability.supports_cold_session)
+        ),
+        required_evidence=(
+            session_capability.required_evidence if session_kind and session_capability else ()
+        ),
+        authority=session_capability.authority if session_capability else authority,
+        capture_activity=session_capability.capture_activity if session_capability else None,
+        restore_activity=session_capability.restore_owner if session_capability else None,
+        supported_checkpoint_kinds=session_capability.checkpoint_kinds if session_capability else (),
+    )
+
+    if requested_state == "session":
+        return ResolvedCheckpointPolicy(
+            workspace_policy="continue_from_previous_execution",
+            checkpoint_kind=session_decision.checkpoint_kind,
+            resumable=session_decision.resumable,
+            required_evidence=session_decision.required_evidence,
+            capture_authority=session_decision.authority,
+            capture_activity=session_decision.capture_activity,
+            criticality=capabilities.post_execution_checkpoint_criticality,
+            supported_checkpoint_kinds=session_decision.supported_checkpoint_kinds,
+            session=session_decision,
+        )
+
     if "external_state_ref" in capabilities.checkpoint_capture_kinds:
         if token not in _EXTERNAL_STATE_BOUNDARIES:
             return ResolvedCheckpointPolicy(
@@ -138,6 +188,7 @@ def resolve_checkpoint_policy(
                 capture_authority=authority,
                 criticality="unsupported",
                 supported_checkpoint_kinds=capabilities.checkpoint_capture_kinds,
+                session=session_decision if requested_state == "both" else None,
             )
         return ResolvedCheckpointPolicy(
             workspace_policy="continue_from_previous_execution",
@@ -148,9 +199,15 @@ def resolve_checkpoint_policy(
             capture_activity=capabilities.checkpoint_capture_activity,
             criticality=capabilities.post_execution_checkpoint_criticality,
             supported_checkpoint_kinds=capabilities.checkpoint_capture_kinds,
+            session=session_decision if requested_state == "both" else None,
         )
 
     if not capabilities.checkpoint_capture_kinds:
+        workspace_decision = CheckpointPlaneDecision(
+            plane="workspace", checkpoint_kind=None, resumable=False,
+            required_evidence=(), authority=authority, capture_activity=None,
+            restore_activity=None, supported_checkpoint_kinds=(),
+        )
         return ResolvedCheckpointPolicy(
             workspace_policy=(
                 _workspace_policy_from_recovery_source(recovery_source)
@@ -163,6 +220,8 @@ def resolve_checkpoint_policy(
             capture_authority=authority,
             criticality=capabilities.post_execution_checkpoint_criticality,
             supported_checkpoint_kinds=capabilities.checkpoint_capture_kinds,
+            session=session_decision if requested_state == "both" else None,
+            workspace=workspace_decision,
         )
 
     preferred_kind = (
@@ -179,6 +238,19 @@ def resolve_checkpoint_policy(
         checkpoint_kind=kind,
         restore_required=token == "before_recovery_restoration",
     )
+    required_evidence = (
+        ("patchRef", "manifestRef")
+        if kind == "git_patch"
+        else ("archiveRef", "manifestRef")
+    )
+    workspace_decision = CheckpointPlaneDecision(
+        plane="workspace", checkpoint_kind=kind,
+        resumable=kind in capabilities.checkpoint_restore_kinds,
+        required_evidence=required_evidence, authority=authority,
+        capture_activity=capabilities.checkpoint_capture_activity,
+        restore_activity=capabilities.checkpoint_restore_activity,
+        supported_checkpoint_kinds=capabilities.checkpoint_capture_kinds,
+    )
     return ResolvedCheckpointPolicy(
         workspace_policy=(
             _workspace_policy_from_recovery_source(recovery_source)
@@ -187,13 +259,11 @@ def resolve_checkpoint_policy(
         ),
         checkpoint_kind=kind,
         resumable=kind in capabilities.checkpoint_restore_kinds,
-        required_evidence=(
-            ("patchRef", "manifestRef")
-            if kind == "git_patch"
-            else ("archiveRef", "manifestRef")
-        ),
+        required_evidence=required_evidence,
         capture_authority=authority,
         capture_activity=capabilities.checkpoint_capture_activity,
         criticality=capabilities.post_execution_checkpoint_criticality,
         supported_checkpoint_kinds=capabilities.checkpoint_capture_kinds,
+        session=session_decision if requested_state == "both" else None,
+        workspace=workspace_decision,
     )

--- a/moonmind/workflows/temporal/recovery_decision.py
+++ b/moonmind/workflows/temporal/recovery_decision.py
@@ -23,6 +23,7 @@ def decide_same_session_recovery(
     *,
     live_session_id: str | None,
     session_reachable: bool,
+    workspace_checkpoint_valid: bool = False,
     capabilities: RuntimeExecutionCapabilities | None,
     evidence: Sequence[Any] = (),
 ) -> RecoveryEligibilityDiagnosticModel:
@@ -53,14 +54,15 @@ def decide_same_session_recovery(
         capabilityDigest=capability_dump.get("capabilityDigest"),
         workspaceAuthority=capability_dump.get("workspaceAuthority"),
         sessionRecoverable=eligible,
-        workspaceRecoverable=bool(capabilities and capabilities.checkpoint_restore_kinds),
+        workspaceRecoverable=workspace_checkpoint_valid,
         authoritativeWorkspaceCheckpointKind=(
             capabilities.checkpoint_restore_kinds[0]
-            if capabilities and capabilities.checkpoint_restore_kinds else None
+            if workspace_checkpoint_valid and capabilities
+            and capabilities.checkpoint_restore_kinds else None
         ),
         partialRecoveryReason=(
             "Session continuity is unavailable; workspace recovery is independent."
-            if not eligible and capabilities and capabilities.checkpoint_restore_kinds else None
+            if not eligible and workspace_checkpoint_valid else None
         ),
         liveSessionId=live_session_id,
         supportsSameSessionContinuation=supported,
@@ -78,6 +80,8 @@ def decide_checkpoint_recovery(
     restore_route_registered: bool,
     artifact_valid: bool,
     side_effect_safe: bool,
+    live_session_id: str | None = None,
+    session_reachable: bool = False,
     source_workflow_id: str | None = None,
     source_run_id: str | None = None,
     evidence: Sequence[Any] = (),
@@ -123,7 +127,8 @@ def decide_checkpoint_recovery(
         restoreActivity=capability_dump.get("checkpointRestoreActivity"),
         workspaceAuthority=capability_dump.get("workspaceAuthority"),
         sessionRecoverable=bool(
-            capabilities and capabilities.session_state
+            live_session_id and session_reachable and capabilities
+            and capabilities.session_state
             and capabilities.session_state.supports_live_reattach
         ),
         workspaceRecoverable=eligible,
@@ -132,7 +137,8 @@ def decide_checkpoint_recovery(
         ),
         partialRecoveryReason=(
             "Session state is recoverable, but authoritative workspace checkpoint evidence is unavailable."
-            if not eligible and capabilities and capabilities.session_state
+            if not eligible and live_session_id and session_reachable
+            and capabilities and capabilities.session_state
             and capabilities.session_state.supports_live_reattach else None
         ),
         sourceWorkflowId=source_workflow_id,

--- a/moonmind/workflows/temporal/recovery_decision.py
+++ b/moonmind/workflows/temporal/recovery_decision.py
@@ -29,7 +29,10 @@ def decide_same_session_recovery(
     """Decide live continuation without using cold-checkpoint evidence."""
 
     supported = bool(
-        capabilities and capabilities.supports_same_session_continuation
+        capabilities and (
+            capabilities.session_state.supports_live_reattach
+            if capabilities.session_state else capabilities.supports_same_session_continuation
+        )
     )
     reason = None
     if not supported:
@@ -49,6 +52,16 @@ def decide_same_session_recovery(
         capabilitySetVersion=capability_dump.get("capabilitySetVersion"),
         capabilityDigest=capability_dump.get("capabilityDigest"),
         workspaceAuthority=capability_dump.get("workspaceAuthority"),
+        sessionRecoverable=eligible,
+        workspaceRecoverable=bool(capabilities and capabilities.checkpoint_restore_kinds),
+        authoritativeWorkspaceCheckpointKind=(
+            capabilities.checkpoint_restore_kinds[0]
+            if capabilities and capabilities.checkpoint_restore_kinds else None
+        ),
+        partialRecoveryReason=(
+            "Session continuity is unavailable; workspace recovery is independent."
+            if not eligible and capabilities and capabilities.checkpoint_restore_kinds else None
+        ),
         liveSessionId=live_session_id,
         supportsSameSessionContinuation=supported,
         operatorGuidance="continue_same_session" if eligible else "full_retry",
@@ -109,6 +122,19 @@ def decide_checkpoint_recovery(
         checkpointRestoreKinds=capability_dump.get("checkpointRestoreKinds", ()),
         restoreActivity=capability_dump.get("checkpointRestoreActivity"),
         workspaceAuthority=capability_dump.get("workspaceAuthority"),
+        sessionRecoverable=bool(
+            capabilities and capabilities.session_state
+            and capabilities.session_state.supports_live_reattach
+        ),
+        workspaceRecoverable=eligible,
+        authoritativeWorkspaceCheckpointKind=(
+            checkpoint_kind if checkpoint_kind in tuple(capability_dump.get("checkpointRestoreKinds", ())) else None
+        ),
+        partialRecoveryReason=(
+            "Session state is recoverable, but authoritative workspace checkpoint evidence is unavailable."
+            if not eligible and capabilities and capabilities.session_state
+            and capabilities.session_state.supports_live_reattach else None
+        ),
         sourceWorkflowId=source_workflow_id,
         sourceRunId=source_run_id,
         operatorGuidance=(

--- a/moonmind/workflows/temporal/recovery_state.py
+++ b/moonmind/workflows/temporal/recovery_state.py
@@ -82,13 +82,18 @@ class CheckpointRecoveryContract(BaseModel):
             raise RecoveryContractError(
                 CHECKPOINT_CAPABILITY_INVALID, "checkpoint kind is not restorable"
             )
-        supported_phases = self.capabilities.checkpoint_boundary_support.get(
-            self.source_checkpoint_boundary, ()
+        supported_phases = (
+            self.capabilities.checkpoint_boundary_support.get(
+                self.source_checkpoint_boundary, ()
+            )
+            if self.capabilities.capability_set_version == CAPABILITY_SET_VERSION
+            else (
+                ("rerun_failed_step",)
+                if self.source_checkpoint_boundary == "before_execution"
+                else ()
+            )
         )
-        if (
-            self.capabilities.capability_set_version == CAPABILITY_SET_VERSION
-            and self.resume_phase not in supported_phases
-        ):
+        if self.resume_phase not in supported_phases:
             raise RecoveryContractError(
                 CHECKPOINT_BOUNDARY_INCOMPATIBLE,
                 "workspace capability does not authorize the requested boundary",

--- a/moonmind/workflows/temporal/recovery_state.py
+++ b/moonmind/workflows/temporal/recovery_state.py
@@ -22,6 +22,10 @@ CHECKPOINT_RESTORATION_NOT_READY = "CHECKPOINT_RESTORATION_NOT_READY"
 
 BOUNDARY_PHASES = {
     "before_execution": "rerun_failed_step",
+    "after_execution": "continue_to_gate",
+    "after_gate": "continue_after_gate",
+    "before_publication": "resume_publication",
+    "before_recovery_restoration": "retry_restoration",
 }
 
 
@@ -63,7 +67,9 @@ class CheckpointRecoveryContract(BaseModel):
                 CHECKPOINT_BOUNDARY_INCOMPATIBLE,
                 "checkpoint boundary does not authorize the requested resume phase",
             )
-        if self.capabilities.capability_set_version != CAPABILITY_SET_VERSION:
+        if self.capabilities.capability_set_version not in {
+            "runtime-execution-capabilities-v2", CAPABILITY_SET_VERSION
+        }:
             raise RecoveryContractError(
                 CHECKPOINT_CAPABILITY_INVALID, "unsupported capability set version"
             )
@@ -75,6 +81,17 @@ class CheckpointRecoveryContract(BaseModel):
         if self.source_checkpoint_kind not in self.capabilities.checkpoint_restore_kinds:
             raise RecoveryContractError(
                 CHECKPOINT_CAPABILITY_INVALID, "checkpoint kind is not restorable"
+            )
+        supported_phases = self.capabilities.checkpoint_boundary_support.get(
+            self.source_checkpoint_boundary, ()
+        )
+        if (
+            self.capabilities.capability_set_version == CAPABILITY_SET_VERSION
+            and self.resume_phase not in supported_phases
+        ):
+            raise RecoveryContractError(
+                CHECKPOINT_BOUNDARY_INCOMPATIBLE,
+                "workspace capability does not authorize the requested boundary",
             )
         if self.restore_activity != self.capabilities.checkpoint_restore_activity:
             raise RecoveryContractError(

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -4982,6 +4982,29 @@ class MoonMindRunWorkflow:
                 capture_input["criticality"] = (
                     capabilities.post_execution_checkpoint_criticality
                 )
+                if capabilities.runtime_id == "omnigent":
+                    try:
+                        wf_info = workflow.info()
+                        identity = StepExecutionIdentityModel(
+                            workflowId=wf_info.workflow_id,
+                            runId=wf_info.run_id,
+                            logicalStepId=logical_step_id,
+                            executionOrdinal=(
+                                self._step_execution_for(logical_step_id) or 1
+                            ),
+                        )
+                        locator_identity = (
+                            f"{wf_info.workflow_id}:{build_step_execution_id(identity)}"
+                        )
+                        capture_input["workspaceLocator"] = {
+                            "kind": "sandbox",
+                            "workspaceId": hashlib.sha256(
+                                locator_identity.encode("utf-8")
+                            ).hexdigest()[:24],
+                            "relativePath": "repo",
+                        }
+                    except workflow._NotInWorkflowEventLoopError:
+                        pass
         elif (
             agent_kind == "managed"
             or previous_capture.get("captureAuthority") == "managed_runtime"

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -5004,6 +5004,8 @@ class MoonMindRunWorkflow:
                             "relativePath": "repo",
                         }
                     except workflow._NotInWorkflowEventLoopError:
+                        # Pure unit callers cannot derive a durable workflow identity;
+                        # the real workflow path always records this locator.
                         pass
         elif (
             agent_kind == "managed"

--- a/tests/unit/omnigent/test_oauth_profile_lifecycle.py
+++ b/tests/unit/omnigent/test_oauth_profile_lifecycle.py
@@ -104,6 +104,22 @@ def test_failure_evidence_falls_back_when_code_is_none() -> None:
     assert _failure_evidence(exc)[0] == "RuntimeError"
 
 
+def test_repository_mutation_requirement_is_explicit_or_implied_by_publish() -> None:
+    explicit = AgentExecutionRequest(
+        agentKind="external", agentId="omnigent", correlationId="corr-explicit",
+        idempotencyKey="explicit",
+        parameters={"repositoryMutationRequired": True},
+    )
+    read_only = AgentExecutionRequest(
+        agentKind="external", agentId="omnigent", correlationId="corr-read-only",
+        idempotencyKey="read-only",
+        parameters={},
+    )
+
+    assert OmnigentProfileBoundExecutionCoordinator._repository_mutation_required(explicit)
+    assert not OmnigentProfileBoundExecutionCoordinator._repository_mutation_required(read_only)
+
+
 def _binding() -> OmnigentOAuthHostBinding:
     return OmnigentOAuthHostBinding(
         bindingRef="omnigent-oauth:codex",

--- a/tests/unit/omnigent/test_oauth_profile_lifecycle.py
+++ b/tests/unit/omnigent/test_oauth_profile_lifecycle.py
@@ -115,8 +115,15 @@ def test_repository_mutation_requirement_is_explicit_or_implied_by_publish() -> 
         idempotencyKey="read-only",
         parameters={},
     )
+    branch_publish_without_gh = AgentExecutionRequest(
+        agentKind="external", agentId="omnigent", correlationId="corr-branch",
+        idempotencyKey="branch", parameters={"publishMode": "branch"},
+    )
 
     assert OmnigentProfileBoundExecutionCoordinator._repository_mutation_required(explicit)
+    assert OmnigentProfileBoundExecutionCoordinator._repository_mutation_required(
+        branch_publish_without_gh
+    )
     assert not OmnigentProfileBoundExecutionCoordinator._repository_mutation_required(read_only)
 
 

--- a/tests/unit/workflows/executions/test_checkpoint_resume_admission.py
+++ b/tests/unit/workflows/executions/test_checkpoint_resume_admission.py
@@ -58,7 +58,7 @@ def test_codex_capability_and_admitted_decision_are_frozen() -> None:
     decision = _decision()
     assert decision.admitted is True
     assert decision.restore_activity == "agent_runtime.restore_workspace_checkpoint"
-    assert decision.runtime_capabilities.capability_set_version.endswith("v2")
+    assert decision.runtime_capabilities.capability_set_version.endswith("v3")
     assert decision.runtime_capabilities.checkpoint_artifact_contract_version
 
 

--- a/tests/unit/workflows/executions/test_runtime_capabilities.py
+++ b/tests/unit/workflows/executions/test_runtime_capabilities.py
@@ -55,8 +55,8 @@ def test_workspace_authority_and_checkpoint_kind_are_jointly_validated() -> None
     omnigent = resolve_runtime_execution_capabilities("omnigent")
     validate_runtime_preflight(
         omnigent,
-        workspace_locator={"kind": "external_state", "artifactRef": "art_1"},
-        checkpoint_kind="external_state_ref",
+        workspace_locator={"kind": "sandbox", "workspaceId": "ws_1"},
+        checkpoint_kind="worktree_archive",
         restore_required=True,
         same_session_continuation=True,
     )
@@ -130,11 +130,34 @@ def test_recorded_capability_snapshot_is_independent_of_registry_changes() -> No
     snapshot = resolve_runtime_execution_capabilities("omnigent").model_dump(
         by_alias=True, mode="json"
     )
-    replacement = RuntimeExecutionCapabilities.model_validate(
-        {**snapshot, "checkpointCaptureKinds": ["future_kind"]}
-    )
+    replacement_payload = {**snapshot, "checkpointCaptureKinds": ["future_kind"]}
+    replacement_payload["workspaceState"] = {
+        **snapshot["workspaceState"], "checkpointKinds": ["future_kind"]
+    }
+    replacement = RuntimeExecutionCapabilities.model_validate(replacement_payload)
 
     recorded = RuntimeExecutionCapabilities.model_validate(snapshot)
 
-    assert recorded.checkpoint_capture_kinds == ("external_state_ref",)
+    assert recorded.checkpoint_capture_kinds == ("worktree_archive",)
     assert replacement.checkpoint_capture_kinds == ("future_kind",)
+
+
+def test_omnigent_freezes_three_independent_ownership_planes() -> None:
+    capability = resolve_runtime_execution_capabilities("omnigent")
+
+    assert capability.agent_identity.model_dump(by_alias=True) == {
+        "agentKind": "external", "agentId": "omnigent", "harness": "codex-native"
+    }
+    assert capability.session_state.authority == "external_provider"
+    assert capability.session_state.checkpoint_kinds == ("external_state_ref",)
+    assert capability.workspace_state.authority == "moonmind_sandbox"
+    assert capability.workspace_state.locator_kinds == ("sandbox",)
+    assert capability.workspace_state.restore_activity == "workspace.apply_checkpoint"
+    assert capability.host_realization.workspace_mount_target == "/workspaces/run"
+
+
+def test_v3_rejects_contradictory_flattened_workspace_claim() -> None:
+    snapshot = resolve_runtime_execution_capabilities("omnigent").model_dump(by_alias=True)
+    snapshot["workspaceAuthority"] = "external_provider"
+    with pytest.raises(ValidationError, match="contradicts workspace state"):
+        RuntimeExecutionCapabilities.model_validate(snapshot)

--- a/tests/unit/workflows/executions/test_runtime_capabilities.py
+++ b/tests/unit/workflows/executions/test_runtime_capabilities.py
@@ -154,6 +154,13 @@ def test_omnigent_freezes_three_independent_ownership_planes() -> None:
     assert capability.workspace_state.locator_kinds == ("sandbox",)
     assert capability.workspace_state.restore_activity == "workspace.apply_checkpoint"
     assert capability.host_realization.workspace_mount_target == "/workspaces/run"
+    assert capability.host_realization.require_mode(
+        "on_demand_docker", repository_mutation=True, github_credentials=True
+    ).mode == "on_demand_docker"
+    with pytest.raises(RuntimeCapabilityError, match="does not isolate repository mutation"):
+        capability.host_realization.require_mode(
+            "static_compose", repository_mutation=True
+        )
 
 
 def test_v3_rejects_contradictory_flattened_workspace_claim() -> None:

--- a/tests/unit/workflows/executions/test_runtime_capabilities.py
+++ b/tests/unit/workflows/executions/test_runtime_capabilities.py
@@ -168,3 +168,21 @@ def test_v3_rejects_contradictory_flattened_workspace_claim() -> None:
     snapshot["workspaceAuthority"] = "external_provider"
     with pytest.raises(ValidationError, match="contradicts workspace state"):
         RuntimeExecutionCapabilities.model_validate(snapshot)
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("checkpointArtifactContractVersion", "other-contract-v1"),
+        ("checkpointBoundarySupport", {"before_execution": ["continue_to_gate"]}),
+    ],
+)
+def test_v3_rejects_workspace_plane_contract_drift(
+    field: str, value: object
+) -> None:
+    snapshot = resolve_runtime_execution_capabilities("omnigent").model_dump(
+        by_alias=True
+    )
+    snapshot[field] = value
+    with pytest.raises(ValidationError, match="contradicts workspace state"):
+        RuntimeExecutionCapabilities.model_validate(snapshot)

--- a/tests/unit/workflows/temporal/test_checkpoint_policy.py
+++ b/tests/unit/workflows/temporal/test_checkpoint_policy.py
@@ -45,41 +45,39 @@ def test_resolve_checkpoint_policy_uses_enum_value() -> None:
     assert policy.workspace_policy == "start_from_last_passed_commit"
 
 
-def test_resolve_checkpoint_policy_uses_omnigent_external_state_after_execution() -> None:
+def test_resolve_checkpoint_policy_separates_omnigent_planes_after_execution() -> None:
     policy = resolve_checkpoint_policy(
         boundary=_Boundary.AFTER_EXECUTION,
-        capabilities=resolve_runtime_execution_capabilities("omnigent"),
+        capabilities=resolve_runtime_execution_capabilities("omnigent"), requested_state="both",
     )
 
-    assert policy.workspace_policy == "continue_from_previous_execution"
-    assert policy.checkpoint_kind == "external_state_ref"
+    assert policy.workspace_policy == "restore_pre_execution"
+    assert policy.checkpoint_kind == "worktree_archive"
     assert policy.resumable is True
-    assert policy.required_evidence == (
-        "externalStateRef",
-        "diagnosticsRef",
-        "runtimeSessionId",
-    )
+    assert policy.required_evidence == ("archiveRef", "manifestRef")
+    assert policy.session.checkpoint_kind == "external_state_ref"
+    assert policy.workspace.checkpoint_kind == "worktree_archive"
 
 
-def test_resolve_checkpoint_policy_uses_omnigent_external_state_before_execution() -> None:
+def test_resolve_checkpoint_policy_can_request_omnigent_session_state() -> None:
     policy = resolve_checkpoint_policy(
         boundary=_Boundary.BEFORE_EXECUTION,
-        capabilities=resolve_runtime_execution_capabilities("omnigent"),
+        capabilities=resolve_runtime_execution_capabilities("omnigent"), requested_state="session",
     )
 
     assert policy.workspace_policy == "continue_from_previous_execution"
     assert policy.checkpoint_kind == "external_state_ref"
     assert policy.required_evidence == (
         "externalStateRef",
-        "idempotencyKey",
         "runtimeSessionId",
+        "firstMessageEvidenceRef",
     )
 
 
 def test_resolve_checkpoint_policy_uses_canonical_external_capabilities() -> None:
     policy = resolve_checkpoint_policy(
         boundary=_Boundary.BEFORE_EXECUTION,
-        capabilities=resolve_runtime_execution_capabilities("omnigent"),
+        capabilities=resolve_runtime_execution_capabilities("omnigent"), requested_state="session",
     )
     control = resolve_checkpoint_policy(
         boundary=_Boundary.BEFORE_EXECUTION,
@@ -128,8 +126,19 @@ def test_omnigent_unsupported_recovery_boundary_does_not_invent_local_capture() 
         },
     )
 
-    assert policy.checkpoint_kind is None
-    assert policy.workspace_policy == "restore_pre_execution"
+    assert policy.checkpoint_kind == "worktree_archive"
+    assert policy.workspace_policy == "start_from_last_passed_commit"
+
+
+def test_external_state_ref_never_satisfies_workspace_restore_preflight() -> None:
+    capability = resolve_runtime_execution_capabilities("omnigent")
+    policy = resolve_checkpoint_policy(
+        boundary="before_recovery_restoration", capabilities=capability,
+        requested_state="workspace",
+    )
+
+    assert policy.checkpoint_kind == "worktree_archive"
+    assert "external_state_ref" not in policy.supported_checkpoint_kinds
 
 
 def test_external_state_checkpoint_is_continue_only() -> None:

--- a/tests/unit/workflows/temporal/test_recovery_decision.py
+++ b/tests/unit/workflows/temporal/test_recovery_decision.py
@@ -42,7 +42,7 @@ def _decision(**overrides):
     values = {
         "checkpoint_ref": "artifact://checkpoint",
         "checkpoint_boundary": "before_execution",
-        "checkpoint_kind": "external_state_ref",
+        "checkpoint_kind": "worktree_archive",
         "capabilities": resolve_runtime_execution_capabilities("omnigent"),
         "restore_route_registered": True,
         "artifact_valid": True,
@@ -65,7 +65,7 @@ def test_checkpoint_resume_requires_complete_restore_proof() -> None:
     ("overrides", "reason"),
     [
         ({"restore_route_registered": False}, "CHECKPOINT_RESTORE_ROUTE_MISSING"),
-        ({"checkpoint_kind": "worktree_archive"}, "CHECKPOINT_KIND_INCOMPATIBLE"),
+        ({"checkpoint_kind": "external_state_ref"}, "CHECKPOINT_KIND_INCOMPATIBLE"),
         ({"checkpoint_boundary": "after_prepare"}, "CHECKPOINT_BOUNDARY_INCOMPATIBLE"),
         ({"side_effect_safe": False}, "CHECKPOINT_SIDE_EFFECT_UNSAFE"),
         ({"capabilities": None}, "CHECKPOINT_CAPABILITY_SNAPSHOT_MISSING"),
@@ -90,6 +90,16 @@ def test_codex_worktree_archive_restore_is_eligible() -> None:
         decision.restore_activity
         == "agent_runtime.restore_workspace_checkpoint"
     )
+
+
+def test_omnigent_partial_evidence_distinguishes_session_from_workspace() -> None:
+    decision = _decision(checkpoint_kind="external_state_ref")
+
+    assert decision.eligible is False
+    assert decision.session_recoverable is True
+    assert decision.workspace_recoverable is False
+    assert decision.authoritative_workspace_checkpoint_kind is None
+    assert "workspace checkpoint evidence" in decision.partial_recovery_reason
 
 
 def test_restore_kinds_without_activity_are_rejected_by_capability_schema() -> None:
@@ -132,7 +142,7 @@ def test_workflow_preflight_rejects_string_restore_kinds() -> None:
         **decision,
         "recoveryAction": "resume_from_workspace_checkpoint",
         "selectedCheckpointBoundary": "before_execution",
-        "checkpointRestoreKinds": "external_state_ref",
+        "checkpointRestoreKinds": "worktree_archive",
         "checkpointRestoreActivity": decision["restoreActivity"],
         "recoveryCheckpointRef": decision["checkpointRef"],
         "selectedTargetRuntimeId": decision["targetRuntimeId"],

--- a/tests/unit/workflows/temporal/test_recovery_decision.py
+++ b/tests/unit/workflows/temporal/test_recovery_decision.py
@@ -93,13 +93,35 @@ def test_codex_worktree_archive_restore_is_eligible() -> None:
 
 
 def test_omnigent_partial_evidence_distinguishes_session_from_workspace() -> None:
-    decision = _decision(checkpoint_kind="external_state_ref")
+    decision = _decision(
+        checkpoint_kind="external_state_ref",
+        live_session_id="session-1",
+        session_reachable=True,
+    )
 
     assert decision.eligible is False
     assert decision.session_recoverable is True
     assert decision.workspace_recoverable is False
     assert decision.authoritative_workspace_checkpoint_kind is None
     assert "workspace checkpoint evidence" in decision.partial_recovery_reason
+
+
+def test_workspace_decision_does_not_infer_session_evidence_from_capability() -> None:
+    decision = _decision()
+
+    assert decision.workspace_recoverable is True
+    assert decision.session_recoverable is False
+
+
+def test_same_session_decision_does_not_infer_workspace_evidence_from_capability() -> None:
+    decision = decide_same_session_recovery(
+        live_session_id="session-1",
+        session_reachable=True,
+        capabilities=resolve_runtime_execution_capabilities("omnigent"),
+    )
+
+    assert decision.session_recoverable is True
+    assert decision.workspace_recoverable is False
 
 
 def test_restore_kinds_without_activity_are_rejected_by_capability_schema() -> None:

--- a/tests/unit/workflows/temporal/test_recovery_manifest.py
+++ b/tests/unit/workflows/temporal/test_recovery_manifest.py
@@ -67,7 +67,7 @@ def _build(**overrides):
             "run-tests": {"before_execution": "artifact://checkpoint/before"}
         },
         side_effect_records={},
-        checkpoint_kind="external_state_ref",
+        checkpoint_kind="worktree_archive",
         runtime_capabilities=resolve_runtime_execution_capabilities("omnigent"),
         restore_route_registered=True,
         failure_diagnostic={

--- a/tests/unit/workflows/temporal/test_recovery_state.py
+++ b/tests/unit/workflows/temporal/test_recovery_state.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 import pytest
 
-from moonmind.workflows.executions.runtime_capabilities import RuntimeExecutionCapabilities
+from moonmind.workflows.executions.runtime_capabilities import (
+    RuntimeExecutionCapabilities,
+    resolve_runtime_execution_capabilities,
+)
 from moonmind.workflows.temporal.recovery_state import (
     CHECKPOINT_BOUNDARY_INCOMPATIBLE,
     CHECKPOINT_CAPABILITY_INVALID,
@@ -55,6 +58,21 @@ def test_valid_contract_and_deterministic_destination_identity() -> None:
     )
     assert first == second
     assert first[0] == "wf:restore:implement:execution:1"
+
+
+def test_v3_omnigent_snapshot_authorizes_workspace_boundary_without_registry_lookup() -> None:
+    snapshot = resolve_runtime_execution_capabilities("omnigent").model_dump(by_alias=True)
+    contract = CheckpointRecoveryContract.model_validate(
+        _contract(
+            resumePhase="continue_to_gate",
+            sourceCheckpointBoundary="after_execution",
+            capabilitySnapshot=snapshot,
+            restoreActivity="workspace.apply_checkpoint",
+        )
+    )
+
+    assert contract.capabilities.workspace_state.authority == "moonmind_sandbox"
+    assert contract.source_checkpoint_kind == "worktree_archive"
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/workflows/temporal/workflows/test_run_recovery_manifest.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_recovery_manifest.py
@@ -102,7 +102,7 @@ async def test_emit_recovery_manifest_writes_artifact_and_compact_summary(
     capabilities = resolve_runtime_execution_capabilities("omnigent")
     assert capabilities is not None
     workflow._step_workspace_capture_inputs["run-tests"] = {
-        "kind": "external_state_ref",
+        "kind": "worktree_archive",
         "runtimeCapabilities": capabilities.model_dump(by_alias=True, mode="json"),
     }
 
@@ -141,7 +141,7 @@ async def test_emit_recovery_manifest_writes_artifact_and_compact_summary(
     assert payload["lastAcceptedStep"]["logicalStepId"] == "prepare"
     assert payload["validation"]["result"] == "valid"
     assert payload["resumeAllowed"] is True
-    assert payload["recoveryEligibility"]["checkpointKind"] == "external_state_ref"
+    assert payload["recoveryEligibility"]["checkpointKind"] == "worktree_archive"
     # Compact, execution-linked summary.
     assert summary["resumeAllowed"] is True
     assert summary["failedLogicalStepId"] == "run-tests"

--- a/tests/unit/workflows/temporal/workflows/test_run_recovery_manifest.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_recovery_manifest.py
@@ -151,6 +151,46 @@ async def test_emit_recovery_manifest_writes_artifact_and_compact_summary(
 
 
 @pytest.mark.asyncio
+async def test_recovery_manifest_freezes_hybrid_planes_without_inferred_session_evidence(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Exercise the workflow boundary used to project a v3 hybrid snapshot."""
+
+    _configure(monkeypatch, patched=True)
+    workflow = MoonMindRunWorkflow()
+    _seed_failed_run(workflow)
+    capabilities = resolve_runtime_execution_capabilities("omnigent")
+    workflow._step_workspace_capture_inputs["run-tests"] = {
+        "kind": "worktree_archive",
+        "runtimeCapabilities": capabilities.model_dump(by_alias=True, mode="json"),
+    }
+    writes: list[dict[str, Any]] = []
+
+    async def fake_write_json_artifact(
+        name: str,
+        payload: dict[str, Any],
+        content_type: str = "application/json",
+        metadata_json: dict[str, Any] | None = None,
+    ) -> str:
+        writes.append(payload)
+        return "artifact-hybrid-manifest"
+
+    monkeypatch.setattr(workflow, "_write_json_artifact", fake_write_json_artifact)
+
+    summary, manifest_ref = await workflow._emit_failed_run_recovery_manifest()
+
+    assert manifest_ref == "artifact-hybrid-manifest"
+    assert summary is not None and summary["resumeAllowed"] is True
+    eligibility = writes[0]["recoveryEligibility"]
+    assert eligibility["capabilitySetVersion"] == "runtime-execution-capabilities-v3"
+    assert eligibility["sessionRecoverable"] is False
+    assert eligibility["workspaceRecoverable"] is True
+    rendered = str(writes[0])
+    assert "workspacePath" not in rendered
+    assert "githubToken" not in rendered
+
+
+@pytest.mark.asyncio
 async def test_emit_recovery_manifest_is_patch_gated(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
@@ -3844,16 +3844,8 @@ async def test_run_uses_external_omnigent_identity_for_checkpoint_capture(
     ) -> dict[str, Any]:
         captured.append({"activity": activity, "payload": payload, "kwargs": kwargs})
         if activity == "workspace.capture_checkpoint":
-            assert payload["kind"] == "external_state_ref"
-            return {
-                "status": "captured",
-                "workspace": {
-                    "kind": "external_state_ref",
-                    "externalStateRef": "artifact://omnigent/state",
-                    "createdAt": "2026-06-13T12:00:00+00:00",
-                },
-                "diagnosticRefs": ["artifact://omnigent/manifest"],
-            }
+            assert payload["kind"] == "worktree_archive"
+            return _managed_checkpoint_capture_result(payload)
         assert activity == "step_checkpoint.create"
         return _checkpoint_create_result(payload)
 
@@ -3878,10 +3870,10 @@ async def test_run_uses_external_omnigent_identity_for_checkpoint_capture(
         ("workspace.capture_checkpoint", "before_execution"),
         ("step_checkpoint.create", "before_execution"),
     ]
-    assert captured[0]["payload"]["kind"] == "external_state_ref"
-    assert captured[1]["payload"]["workspace"]["kind"] == "external_state_ref"
+    assert captured[0]["payload"]["kind"] == "worktree_archive"
+    assert captured[1]["payload"]["workspace"]["kind"] == "worktree_archive"
     assert "patchRef" not in captured[1]["payload"]["workspace"]
-    assert "archiveRef" not in captured[1]["payload"]["workspace"]
+    assert "archiveRef" in captured[1]["payload"]["workspace"]
 
 
 def test_run_derives_external_omnigent_identity_from_runtime_selection() -> None:
@@ -3900,7 +3892,7 @@ def test_run_derives_external_omnigent_identity_from_runtime_selection() -> None
     capture = workflow._step_workspace_capture_inputs["implement"]
     assert capture["workspacePath"] == "/work/agent_jobs/run-1/repo"
     assert capture["baseCommit"] == "abc123"
-    assert capture["captureAuthority"] == "external_provider"
+    assert capture["captureAuthority"] == "moonmind_sandbox"
     assert capture["runtimeCapabilities"]["runtimeId"] == "omnigent"
     assert "kind" not in capture
 

--- a/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
@@ -3845,6 +3845,7 @@ async def test_run_uses_external_omnigent_identity_for_checkpoint_capture(
         captured.append({"activity": activity, "payload": payload, "kwargs": kwargs})
         if activity == "workspace.capture_checkpoint":
             assert payload["kind"] == "worktree_archive"
+            assert payload["workspaceLocator"]["kind"] == "sandbox"
             return _managed_checkpoint_capture_result(payload)
         assert activity == "step_checkpoint.create"
         return _checkpoint_create_result(payload)

--- a/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
@@ -3807,7 +3807,11 @@ async def test_run_uses_external_omnigent_identity_for_checkpoint_capture(
     monkeypatch.setattr(
         run_module.workflow,
         "patched",
-        lambda patch_id: patch_id == run_module.RUN_CANONICAL_STEP_CHECKPOINTS_PATCH,
+        lambda patch_id: patch_id in {
+            run_module.RUN_CANONICAL_STEP_CHECKPOINTS_PATCH,
+            run_module.RUN_RUNTIME_EXECUTION_CAPABILITIES_PATCH,
+            run_module.RUN_MANAGED_CHECKPOINT_AUTHORITY_PATCH,
+        },
     )
     workflow = MoonMindRunWorkflow()
     now = datetime(2026, 6, 13, 12, 0, tzinfo=UTC)


### PR DESCRIPTION
Issue: MoonLadderStudios/MoonMind#3472

Closes MoonLadderStudios/MoonMind#3472

## Summary

- introduce immutable v3 runtime capabilities that separate Omnigent session state, MoonMind workspace state, and host realization ownership
- make checkpoint and recovery decisions plane-aware and fail closed for unsupported host mutation modes
- project independent session/workspace recoverability in Workflow Detail and document the hybrid authority model
- add schema, policy, workflow-boundary, Omnigent lifecycle, and UI coverage

## Tests run

- PASS: Python compileall and focused import/assertion smoke for changed modules
- PASS: npm run ui:test -- frontend/src/entrypoints/workflow-detail.test.tsx (197 tests)
- PASS: git diff --check 4af9fb79c..HEAD
- NOT RUN: focused Python container suite; the trusted container backend returned HTTP 404 container job not found before execution

## Remaining risks

- The focused Python suite could not execute because the container-job backend was unavailable. Verification classified this as environment-only and non-gating; targeted compile/import assertions and the Workflow Detail suite passed.