### PR TITLE
MoonLadderStudios/MoonMind#3476: Add semantic remediation progress budgets

### DIFF
--- a/frontend/src/entrypoints/workflow-detail.test.tsx
+++ b/frontend/src/entrypoints/workflow-detail.test.tsx
@@ -7060,6 +7060,89 @@ describe('Workflow Detail Entrypoint', () => {
     });
   });
 
+  it('renders remediation trends, budgets, evidence, and exact stop dimension', async () => {
+    window.history.pushState({}, 'Remediation Test', '/workflows/remediation/overview?source=temporal');
+    const execution = {
+      taskId: 'remediation',
+      workflowId: 'remediation',
+      namespace: 'default',
+      runId: 'run-1',
+      source: 'temporal',
+      workflowType: 'MoonMind.UserWorkflow',
+      title: 'Remediation run',
+      summary: 'Stopped on contract repair budget',
+      status: 'failed',
+      state: 'failed',
+      rawState: 'failed',
+      temporalStatus: 'failed',
+      closeStatus: 'FAILED',
+      summaryArtifactRef: 'art-remediation-summary',
+      createdAt: '2026-03-28T00:00:00Z',
+      updatedAt: '2026-03-28T00:00:03Z',
+      actions: {},
+    };
+    fetchSpy.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/artifacts/art-remediation-summary/download')) {
+        return Promise.resolve({
+          ok: true,
+          text: async () => JSON.stringify({
+            publishContext: {
+              boundedStoryLoop: {
+                continuationDecision: {
+                  continueLoop: false,
+                  reason: 'contract_repair_budget_exhausted',
+                  budget: {
+                    maxAttempts: 6,
+                    providerBudget: 4,
+                    tokenBudget: 1000,
+                    costBudget: 50,
+                    maxElapsedSeconds: 600,
+                    consumed: {
+                      attempts: 3,
+                      consecutiveNoProgressAttempts: 1,
+                      provider: 2,
+                      tokens: 500,
+                      cost: 20,
+                      elapsedSeconds: 300,
+                    },
+                  },
+                  gate: {
+                    progressVector: {
+                      classification: 'meaningful_progress',
+                      unresolvedGapScore: 5,
+                      priorUnresolvedGapScore: 8,
+                      requiredChecks: { passed: 7, failed: 1, not_run: 2 },
+                      priorRequiredChecks: { passed: 5, failed: 2, not_run: 3 },
+                      repeatedFailureSignatures: ['sha256:failure'],
+                      relevantDiffDigest: 'sha256:diff',
+                      gaps: [{ status: 'unresolved' }, { status: 'resolved' }],
+                    },
+                  },
+                },
+              },
+            },
+          }),
+        } as Response);
+      }
+      if (url.includes('/artifacts')) {
+        return Promise.resolve({ ok: true, json: async () => ({ artifacts: [] }) } as Response);
+      }
+      return Promise.resolve({ ok: true, json: async () => execution } as Response);
+    });
+
+    renderWithClient(<WorkflowDetailPage payload={mockPayload} />);
+
+    await waitFor(() => expect(screen.getByRole('region', { name: 'Remediation progress and budgets' })).toBeTruthy());
+    const region = screen.getByRole('region', { name: 'Remediation progress and budgets' });
+    expect(within(region).getByText('1 unresolved · score 5 (-3)')).toBeTruthy();
+    expect(within(region).getByText('Passed 7 (+2) · Failed 1 · Not run 2')).toBeTruthy();
+    expect(within(region).getByText('3 / 3')).toBeTruthy();
+    expect(within(region).getByText('Repeated failure signatures').closest('div')?.textContent).toContain('1');
+    expect(within(region).getByText('sha256:diff')).toBeTruthy();
+    expect(within(region).getByText('contract repair budget exhausted')).toBeTruthy();
+  });
+
   it('renders auto publish mode and evidence with Auto labels', async () => {
     window.history.pushState({}, 'Overview Test', '/workflows/test-auto-publish/overview?source=temporal');
     const mockExecution = {

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -9384,7 +9384,7 @@ function WorkflowDetailPageContent({ payload }: { payload: BootPayload }) {
                       <Fact label="Exact stop dimension">{continuation.continueLoop ? 'None' : formatStatusLabel(continuation.reason)}</Fact>
                     </FlatFactGrid>
                     {progress?.regressions?.length ? (
-                      <p className="small">Regressions: {progress.regressions.map(formatStatusLabel).join(', ')}</p>
+                      <p className="small">Regressions: {progress.regressions.map((regression) => formatStatusLabel(regression)).join(', ')}</p>
                     ) : null}
                   </section>
                 );

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -1755,9 +1755,18 @@ const RunSummaryArtifactSchema = z
                 unresolvedGapScore: z.number().int().nonnegative(),
                 requiredChecks: z.record(z.string(), z.number().int().nonnegative()),
                 regressions: z.array(z.string()).optional(),
+                repeatedFailureSignatures: z.array(z.string()).optional(),
+                newAuthoritativeEvidenceDigest: z.string().nullable().optional(),
+                relevantDiffDigest: z.string().nullable().optional(),
+                gaps: z.array(z.object({ status: z.string() }).passthrough()).optional(),
               }).passthrough().optional(),
             }).passthrough().optional(),
             budget: z.object({
+              maxAttempts: z.number().int().positive().optional(),
+              maxElapsedSeconds: z.number().int().positive().nullable().optional(),
+              providerBudget: z.number().int().nonnegative().nullable().optional(),
+              tokenBudget: z.number().int().nonnegative().nullable().optional(),
+              costBudget: z.number().int().nonnegative().nullable().optional(),
               consumed: z.record(z.string(), z.number().int().nonnegative()),
             }).passthrough().optional(),
           }).passthrough().optional(),
@@ -9345,18 +9354,32 @@ function WorkflowDetailPageContent({ payload }: { payload: BootPayload }) {
                 const continuation = runSummary.publishContext.boundedStoryLoop.continuationDecision;
                 const progress = continuation.gate?.progressVector;
                 const consumed = continuation.budget?.consumed ?? {};
+                const attemptsUsed = consumed.attempts ?? 0;
+                const attemptsMaximum = continuation.budget?.maxAttempts;
+                const unresolvedGaps = progress?.gaps?.filter((gap) => !['passed', 'resolved', 'satisfied'].includes(gap.status)).length;
                 return (
                   <section className="stack" aria-label="Remediation progress and budgets">
                     <h4>Remediation progress</h4>
                     <FlatFactGrid>
                       <Fact label="Classification">{formatStatusLabel(progress?.classification) || '—'}</Fact>
-                      <Fact label="Unresolved gap score">{progress?.unresolvedGapScore ?? '—'}</Fact>
+                      <Fact label="Gap trend">{progress ? `${unresolvedGaps ?? '—'} unresolved · score ${progress.unresolvedGapScore}` : '—'}</Fact>
                       <Fact label="Required checks">
                         {progress ? `Passed ${progress.requiredChecks.passed ?? 0} · Failed ${progress.requiredChecks.failed ?? 0} · Not run ${progress.requiredChecks.not_run ?? 0}` : '—'}
                       </Fact>
                       <Fact label="Semantic no-progress cycles">{consumed.consecutiveNoProgressAttempts ?? 0}</Fact>
-                      <Fact label="Remediation attempts">{consumed.attempts ?? 0}</Fact>
-                      <Fact label="Continuation">{continuation.continueLoop ? 'Continue' : `Stop: ${formatStatusLabel(continuation.reason)}`}</Fact>
+                      <Fact label="Hard attempts used / remaining">
+                        {attemptsMaximum === undefined ? `${attemptsUsed} / —` : `${attemptsUsed} / ${Math.max(0, attemptsMaximum - attemptsUsed)}`}
+                      </Fact>
+                      <Fact label="Repeated failure signatures">{progress?.repeatedFailureSignatures?.length ?? 0}</Fact>
+                      <Fact label="Resource budgets">
+                        {`Provider ${consumed.provider ?? 0}/${continuation.budget?.providerBudget ?? '∞'} · Tokens ${consumed.tokens ?? 0}/${continuation.budget?.tokenBudget ?? '∞'} · Cost ${consumed.cost ?? 0}/${continuation.budget?.costBudget ?? '∞'} · Wall clock ${consumed.elapsedSeconds ?? 0}/${continuation.budget?.maxElapsedSeconds ?? '∞'}`}
+                      </Fact>
+                      <Fact label="Latest meaningful progress evidence">
+                        {progress?.classification === 'meaningful_progress'
+                          ? progress.newAuthoritativeEvidenceDigest || progress.relevantDiffDigest || 'Structured gap/check progress'
+                          : '—'}
+                      </Fact>
+                      <Fact label="Exact stop dimension">{continuation.continueLoop ? 'None' : formatStatusLabel(continuation.reason)}</Fact>
                     </FlatFactGrid>
                     {progress?.regressions?.length ? (
                       <p className="small">Regressions: {progress.regressions.map(formatStatusLabel).join(', ')}</p>

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -1744,6 +1744,24 @@ const RunSummaryArtifactSchema = z
         baseRef: z.string().nullable().optional(),
         commitCount: z.union([z.number(), z.string()]).nullable().optional(),
         pullRequestUrl: z.string().nullable().optional(),
+        boundedStoryLoop: z.object({
+          continuationDecision: z.object({
+            reason: z.string().optional(),
+            continueLoop: z.boolean().optional(),
+            progressVectorDigest: z.string().optional(),
+            gate: z.object({
+              progressVector: z.object({
+                classification: z.string(),
+                unresolvedGapScore: z.number().int().nonnegative(),
+                requiredChecks: z.record(z.string(), z.number().int().nonnegative()),
+                regressions: z.array(z.string()).optional(),
+              }).passthrough().optional(),
+            }).passthrough().optional(),
+            budget: z.object({
+              consumed: z.record(z.string(), z.number().int().nonnegative()),
+            }).passthrough().optional(),
+          }).passthrough().optional(),
+        }).passthrough().optional(),
       })
       .passthrough()
       .optional(),
@@ -9323,6 +9341,29 @@ function WorkflowDetailPageContent({ payload }: { payload: BootPayload }) {
                   ) : null}
                 </FlatFactGrid>
               ) : null}
+              {runSummary.publishContext?.boundedStoryLoop?.continuationDecision ? (() => {
+                const continuation = runSummary.publishContext.boundedStoryLoop.continuationDecision;
+                const progress = continuation.gate?.progressVector;
+                const consumed = continuation.budget?.consumed ?? {};
+                return (
+                  <section className="stack" aria-label="Remediation progress and budgets">
+                    <h4>Remediation progress</h4>
+                    <FlatFactGrid>
+                      <Fact label="Classification">{formatStatusLabel(progress?.classification) || '—'}</Fact>
+                      <Fact label="Unresolved gap score">{progress?.unresolvedGapScore ?? '—'}</Fact>
+                      <Fact label="Required checks">
+                        {progress ? `Passed ${progress.requiredChecks.passed ?? 0} · Failed ${progress.requiredChecks.failed ?? 0} · Not run ${progress.requiredChecks.not_run ?? 0}` : '—'}
+                      </Fact>
+                      <Fact label="Semantic no-progress cycles">{consumed.consecutiveNoProgressAttempts ?? 0}</Fact>
+                      <Fact label="Remediation attempts">{consumed.attempts ?? 0}</Fact>
+                      <Fact label="Continuation">{continuation.continueLoop ? 'Continue' : `Stop: ${formatStatusLabel(continuation.reason)}`}</Fact>
+                    </FlatFactGrid>
+                    {progress?.regressions?.length ? (
+                      <p className="small">Regressions: {progress.regressions.map(formatStatusLabel).join(', ')}</p>
+                    ) : null}
+                  </section>
+                );
+              })() : null}
               {runSummary.lastStep?.summary && runSummary.lastStep.summary !== displayedSummary ? (
                 <div>
                   <strong>Last Step</strong>

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -1753,7 +1753,9 @@ const RunSummaryArtifactSchema = z
               progressVector: z.object({
                 classification: z.string(),
                 unresolvedGapScore: z.number().int().nonnegative(),
+                priorUnresolvedGapScore: z.number().int().nonnegative().nullable().optional(),
                 requiredChecks: z.record(z.string(), z.number().int().nonnegative()),
+                priorRequiredChecks: z.record(z.string(), z.number().int().nonnegative()).nullable().optional(),
                 regressions: z.array(z.string()).optional(),
                 repeatedFailureSignatures: z.array(z.string()).optional(),
                 newAuthoritativeEvidenceDigest: z.string().nullable().optional(),
@@ -9362,9 +9364,9 @@ function WorkflowDetailPageContent({ payload }: { payload: BootPayload }) {
                     <h4>Remediation progress</h4>
                     <FlatFactGrid>
                       <Fact label="Classification">{formatStatusLabel(progress?.classification) || '—'}</Fact>
-                      <Fact label="Gap trend">{progress ? `${unresolvedGaps ?? '—'} unresolved · score ${progress.unresolvedGapScore}` : '—'}</Fact>
+                      <Fact label="Gap trend">{progress ? `${unresolvedGaps ?? '—'} unresolved · score ${progress.unresolvedGapScore}${progress.priorUnresolvedGapScore === undefined || progress.priorUnresolvedGapScore === null ? '' : ` (${progress.unresolvedGapScore - progress.priorUnresolvedGapScore >= 0 ? '+' : ''}${progress.unresolvedGapScore - progress.priorUnresolvedGapScore})`}` : '—'}</Fact>
                       <Fact label="Required checks">
-                        {progress ? `Passed ${progress.requiredChecks.passed ?? 0} · Failed ${progress.requiredChecks.failed ?? 0} · Not run ${progress.requiredChecks.not_run ?? 0}` : '—'}
+                        {progress ? `Passed ${progress.requiredChecks.passed ?? 0}${progress.priorRequiredChecks ? ` (${(progress.requiredChecks.passed ?? 0) - (progress.priorRequiredChecks.passed ?? 0) >= 0 ? '+' : ''}${(progress.requiredChecks.passed ?? 0) - (progress.priorRequiredChecks.passed ?? 0)})` : ''} · Failed ${progress.requiredChecks.failed ?? 0} · Not run ${progress.requiredChecks.not_run ?? 0}` : '—'}
                       </Fact>
                       <Fact label="Semantic no-progress cycles">{consumed.consecutiveNoProgressAttempts ?? 0}</Fact>
                       <Fact label="Hard attempts used / remaining">

--- a/moonmind/workflows/temporal/bounded_story_loop.py
+++ b/moonmind/workflows/temporal/bounded_story_loop.py
@@ -84,6 +84,13 @@ class LoopBudget(_ContractModel):
     max_unsafe_or_policy_denied_attempts: int = Field(
         alias="maxUnsafeOrPolicyDeniedAttempts", ge=0
     )
+    max_evidence_retries: int = Field(default=2, alias="maxEvidenceRetries", ge=0)
+    max_infrastructure_retries: int = Field(
+        default=2, alias="maxInfrastructureRetries", ge=0
+    )
+    max_contract_repair_attempts: int = Field(
+        default=1, alias="maxContractRepairAttempts", ge=0
+    )
     max_elapsed_seconds: int | None = Field(
         default=None, alias="maxElapsedSeconds", ge=1
     )
@@ -99,6 +106,78 @@ class LoopBudget(_ContractModel):
             if not isinstance(consumed, int) or consumed < 0:
                 raise ValueError(f"budget counter {key} must be a non-negative integer")
         return value
+
+
+class RemediationLoopState(_ContractModel):
+    """Versioned monotonic state carried by rollover and linked continuations."""
+
+    schema_version: Literal["remediation-loop-state/v1"] = Field(
+        "remediation-loop-state/v1", alias="schemaVersion"
+    )
+    policy: LoopBudget
+    progress_vector: "RemediationProgressVector | None" = Field(
+        default=None, alias="progressVector"
+    )
+    consumed: dict[str, int] = Field(default_factory=dict)
+    grants: dict[str, int] = Field(default_factory=dict)
+    prior_exhaustion_reason: str | None = Field(
+        default=None, alias="priorExhaustionReason"
+    )
+
+    @field_validator("consumed", "grants")
+    @classmethod
+    def _non_negative_counters(cls, value: dict[str, int]) -> dict[str, int]:
+        if any(
+            not isinstance(amount, int) or isinstance(amount, bool) or amount < 0
+            for amount in value.values()
+        ):
+            raise ValueError("loop state counters must be non-negative integers")
+        return value
+
+
+def advance_remediation_loop_state(
+    *,
+    prior: RemediationLoopState | None,
+    policy: LoopBudget,
+    progress_vector: "RemediationProgressVector | None",
+    consumed: Mapping[str, int],
+    grant: Mapping[str, int] | None = None,
+    exhaustion_reason: str | None = None,
+) -> RemediationLoopState:
+    """Merge durable consumption monotonically; grants add capacity, never erase history."""
+
+    prior_consumed = prior.consumed if prior is not None else {}
+    merged_consumed = {
+        key: max(prior_consumed.get(key, 0), int(amount))
+        for key, amount in consumed.items()
+    }
+    for key, amount in prior_consumed.items():
+        merged_consumed.setdefault(key, amount)
+    merged_grants = dict(prior.grants if prior is not None else {})
+    for key, amount in (grant or {}).items():
+        if not isinstance(amount, int) or isinstance(amount, bool) or amount < 0:
+            raise ValueError("loop state grants must be non-negative integers")
+        merged_grants[key] = merged_grants.get(key, 0) + amount
+    granted_policy = policy.model_copy(
+        update={
+            "max_attempts": policy.max_attempts + merged_grants.get("attempts", 0),
+            "max_evidence_retries": policy.max_evidence_retries
+            + merged_grants.get("evidenceRetries", 0),
+            "max_infrastructure_retries": policy.max_infrastructure_retries
+            + merged_grants.get("infrastructureRetries", 0),
+            "max_contract_repair_attempts": policy.max_contract_repair_attempts
+            + merged_grants.get("contractRepairAttempts", 0),
+            "consumed": merged_consumed,
+        }
+    )
+    return RemediationLoopState(
+        policy=granted_policy,
+        progressVector=progress_vector or (prior.progress_vector if prior else None),
+        consumed=merged_consumed,
+        grants=merged_grants,
+        priorExhaustionReason=exhaustion_reason
+        or (prior.prior_exhaustion_reason if prior else None),
+    )
 
 
 class CanonicalGap(_ContractModel):
@@ -133,8 +212,14 @@ class RemediationProgressVector(_ContractModel):
     addressed_gap_ids: tuple[str, ...] = Field(default=(), alias="addressedGapIds")
     unresolved_gap_digest: str = Field(alias="unresolvedGapDigest")
     unresolved_gap_score: int = Field(alias="unresolvedGapScore", ge=0)
+    prior_unresolved_gap_score: int | None = Field(
+        default=None, alias="priorUnresolvedGapScore", ge=0
+    )
     required_checks_digest: str = Field(alias="requiredChecksDigest")
     required_checks: dict[str, int] = Field(alias="requiredChecks")
+    prior_required_checks: dict[str, int] | None = Field(
+        default=None, alias="priorRequiredChecks"
+    )
     blocker_code: str | None = Field(default=None, alias="blockerCode")
     new_authoritative_evidence_digest: str | None = Field(
         default=None, alias="newAuthoritativeEvidenceDigest"
@@ -240,8 +325,12 @@ def build_remediation_progress_vector(
         addressedGapIds=normalized_addressed_gap_ids,
         unresolvedGapDigest=_canonical_digest([gap.model_dump(by_alias=True) for gap in unresolved]),
         unresolvedGapScore=gap_score,
+        priorUnresolvedGapScore=(
+            prior.unresolved_gap_score if prior is not None else None
+        ),
         requiredChecksDigest=_canonical_digest([check.model_dump(by_alias=True) for check in canonical_checks]),
         requiredChecks=check_counts,
+        priorRequiredChecks=(dict(prior.required_checks) if prior is not None else None),
         blockerCode=_normalize_token(blocker_code),
         newAuthoritativeEvidenceDigest=authoritative_evidence_digest,
         repeatedFailureSignatures=failure_signatures,
@@ -262,6 +351,10 @@ class BoundedStoryLoopInput(_ContractModel):
     additional_item_refs: tuple[ArtifactRef, ...] = Field(
         default=(), alias="additionalItemRefs"
     )
+    prior_loop_state: RemediationLoopState | None = Field(
+        default=None, alias="priorLoopState"
+    )
+    budget_grant: dict[str, int] = Field(default_factory=dict, alias="budgetGrant")
 
     @field_validator("selected_item_ref")
     @classmethod
@@ -897,6 +990,21 @@ def _budget_exhaustion_reason(budget: LoopBudget) -> str | None:
             ("repeatedFailedCommands", "repeated_failed_commands"),
             budget.max_repeated_failed_commands,
             "repeated_failure_signature_exhausted",
+        ),
+        (
+            ("evidenceRetries", "evidence_retries"),
+            budget.max_evidence_retries,
+            "evidence_retry_budget_exhausted",
+        ),
+        (
+            ("infrastructureRetries", "infrastructure_retries"),
+            budget.max_infrastructure_retries,
+            "infrastructure_retry_budget_exhausted",
+        ),
+        (
+            ("contractRepairAttempts", "contract_repair_attempts"),
+            budget.max_contract_repair_attempts,
+            "contract_repair_budget_exhausted",
         ),
     )
     for keys, limit, reason in checks:

--- a/moonmind/workflows/temporal/bounded_story_loop.py
+++ b/moonmind/workflows/temporal/bounded_story_loop.py
@@ -130,6 +130,7 @@ class RemediationProgressVector(_ContractModel):
         default=None, alias="candidateWorkspaceDigest"
     )
     relevant_diff_digest: str | None = Field(default=None, alias="relevantDiffDigest")
+    addressed_gap_ids: tuple[str, ...] = Field(default=(), alias="addressedGapIds")
     unresolved_gap_digest: str = Field(alias="unresolvedGapDigest")
     unresolved_gap_score: int = Field(alias="unresolvedGapScore", ge=0)
     required_checks_digest: str = Field(alias="requiredChecksDigest")
@@ -163,6 +164,7 @@ def build_remediation_progress_vector(
     base_workspace_digest: str | None = None,
     candidate_workspace_digest: str | None = None,
     relevant_diff_digest: str | None = None,
+    addressed_gap_ids: Sequence[str] = (),
     checks: Sequence[Mapping[str, Any]] = (),
     blocker_code: str | None = None,
     authoritative_evidence_digest: str | None = None,
@@ -194,6 +196,9 @@ def build_remediation_progress_vector(
         )
     )
     gap_score = sum(gap.score for gap in unresolved)
+    normalized_addressed_gap_ids = tuple(
+        sorted({_normalize_token(value) for value in addressed_gap_ids if _normalize_token(value)})
+    )
     classification: Literal["baseline", "meaningful_progress", "no_progress", "regression"] = "baseline"
     regressions: list[str] = []
     if prior is not None:
@@ -219,6 +224,11 @@ def build_remediation_progress_vector(
                 prior.candidate_disposition == "contaminated"
                 and candidate_disposition == "clean"
             )
+            or (
+                relevant_diff_digest
+                and relevant_diff_digest != prior.relevant_diff_digest
+                and bool(current_gap_ids & set(normalized_addressed_gap_ids))
+            )
         )
         classification = "regression" if regressions else ("meaningful_progress" if meaningful else "no_progress")
     return RemediationProgressVector(
@@ -227,6 +237,7 @@ def build_remediation_progress_vector(
         baseWorkspaceDigest=base_workspace_digest,
         candidateWorkspaceDigest=candidate_workspace_digest,
         relevantDiffDigest=relevant_diff_digest,
+        addressedGapIds=normalized_addressed_gap_ids,
         unresolvedGapDigest=_canonical_digest([gap.model_dump(by_alias=True) for gap in unresolved]),
         unresolvedGapScore=gap_score,
         requiredChecksDigest=_canonical_digest([check.model_dump(by_alias=True) for check in canonical_checks]),
@@ -698,6 +709,20 @@ def evaluate_attempt_continuation(
             diagnostics_ref=gate.diagnostics_ref,
         )
     if gate.verdict == "ADDITIONAL_WORK_NEEDED":
+        if (
+            attempt.attempt_ordinal >= 3
+            and (
+                gate.progress_vector is None
+                or gate.progress_vector.classification != "meaningful_progress"
+            )
+        ):
+            return _stop(
+                attempt,
+                state=LoopStopState.FAILED_WITH_REMAINING_WORK,
+                reason="required_progress_not_met",
+                remaining_work_ref=gate.remaining_work_ref,
+                diagnostics_ref=gate.diagnostics_ref,
+            )
         return LoopStopDecision(
             state=LoopStopState.FAILED_WITH_REMAINING_WORK,
             reason="verification_requested_remediation",
@@ -866,12 +891,12 @@ def _budget_exhaustion_reason(budget: LoopBudget) -> str | None:
                 "consecutive_no_progress_attempts",
             ),
             budget.max_consecutive_no_progress_attempts,
-            "no_progress_attempts_exhausted",
+            "semantic_no_progress_exhausted",
         ),
         (
             ("repeatedFailedCommands", "repeated_failed_commands"),
             budget.max_repeated_failed_commands,
-            "repeated_failed_commands_exhausted",
+            "repeated_failure_signature_exhausted",
         ),
     )
     for keys, limit, reason in checks:
@@ -890,7 +915,7 @@ def _budget_exhaustion_reason(budget: LoopBudget) -> str | None:
         )
         > 0
     ):
-        return "unsafe_policy_attempts_exhausted"
+        return "unsafe_or_policy_denied"
     optional = (
         (
             ("elapsedSeconds", "elapsed_seconds"),

--- a/moonmind/workflows/temporal/bounded_story_loop.py
+++ b/moonmind/workflows/temporal/bounded_story_loop.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from enum import StrEnum
 import hashlib
-from typing import Any, Literal
+from typing import Any, Literal, Mapping, Sequence
 
 from pydantic import (
     BaseModel,
@@ -101,6 +101,147 @@ class LoopBudget(_ContractModel):
         return value
 
 
+class CanonicalGap(_ContractModel):
+    identity: str
+    status: str
+    severity: str
+    score: int = Field(ge=0)
+    scope: str | None = None
+    required_check_id: str | None = Field(default=None, alias="requiredCheckId")
+
+
+class CanonicalCheck(_ContractModel):
+    identity: str
+    status: str
+    target: str | None = None
+    failure_signature: str | None = Field(default=None, alias="failureSignature")
+
+
+class RemediationProgressVector(_ContractModel):
+    """Compact semantic evidence used by the durable continuation policy."""
+
+    schema_version: Literal["remediation-progress/v1"] = Field(
+        "remediation-progress/v1", alias="schemaVersion"
+    )
+    loop_id: str = Field(alias="loopId", min_length=1)
+    attempt_ordinal: int = Field(alias="attemptOrdinal", ge=1)
+    base_workspace_digest: str | None = Field(default=None, alias="baseWorkspaceDigest")
+    candidate_workspace_digest: str | None = Field(
+        default=None, alias="candidateWorkspaceDigest"
+    )
+    relevant_diff_digest: str | None = Field(default=None, alias="relevantDiffDigest")
+    unresolved_gap_digest: str = Field(alias="unresolvedGapDigest")
+    unresolved_gap_score: int = Field(alias="unresolvedGapScore", ge=0)
+    required_checks_digest: str = Field(alias="requiredChecksDigest")
+    required_checks: dict[str, int] = Field(alias="requiredChecks")
+    blocker_code: str | None = Field(default=None, alias="blockerCode")
+    new_authoritative_evidence_digest: str | None = Field(
+        default=None, alias="newAuthoritativeEvidenceDigest"
+    )
+    repeated_failure_signatures: tuple[str, ...] = Field(
+        default=(), alias="repeatedFailureSignatures"
+    )
+    candidate_disposition: str | None = Field(
+        default=None, alias="candidateDisposition"
+    )
+    classification: Literal["baseline", "meaningful_progress", "no_progress", "regression"]
+    regressions: tuple[str, ...] = ()
+    gaps: tuple[CanonicalGap, ...] = ()
+    checks: tuple[CanonicalCheck, ...] = ()
+
+    @property
+    def digest(self) -> str:
+        return _canonical_digest(self.model_dump(by_alias=True, mode="json"))
+
+
+def build_remediation_progress_vector(
+    *,
+    loop_id: str,
+    attempt_ordinal: int,
+    issues: Sequence[Mapping[str, Any]],
+    prior: RemediationProgressVector | None = None,
+    base_workspace_digest: str | None = None,
+    candidate_workspace_digest: str | None = None,
+    relevant_diff_digest: str | None = None,
+    checks: Sequence[Mapping[str, Any]] = (),
+    blocker_code: str | None = None,
+    authoritative_evidence_digest: str | None = None,
+    candidate_disposition: str | None = None,
+) -> RemediationProgressVector:
+    """Normalize verifier evidence; refs, prose and runtime identity are excluded."""
+
+    canonical_gaps = tuple(
+        sorted((_canonical_gap(issue) for issue in issues), key=lambda gap: gap.identity)
+    )
+    canonical_checks = tuple(
+        sorted(
+            (_canonical_check(check) for check in checks),
+            key=lambda check: check.identity,
+        )
+    )
+    unresolved = tuple(gap for gap in canonical_gaps if gap.status not in {"passed", "resolved", "satisfied"})
+    check_counts = {
+        status: sum(check.status == status for check in canonical_checks)
+        for status in ("passed", "failed", "not_run")
+    }
+    failure_signatures = tuple(
+        sorted(
+            {
+                check.failure_signature
+                for check in canonical_checks
+                if check.status == "failed" and check.failure_signature
+            }
+        )
+    )
+    gap_score = sum(gap.score for gap in unresolved)
+    classification: Literal["baseline", "meaningful_progress", "no_progress", "regression"] = "baseline"
+    regressions: list[str] = []
+    if prior is not None:
+        previous_gap_ids = {gap.identity for gap in prior.gaps if gap.status not in {"passed", "resolved", "satisfied"}}
+        current_gap_ids = {gap.identity for gap in unresolved}
+        previous_checks = {check.identity: check.status for check in prior.checks}
+        current_checks = {check.identity: check.status for check in canonical_checks}
+        if current_gap_ids - previous_gap_ids:
+            regressions.append("new_gap_introduced")
+        if any(previous_checks.get(key) == "passed" and status == "failed" for key, status in current_checks.items()):
+            regressions.append("required_check_regressed")
+        if candidate_disposition in {"contaminated", "unsafe_side_effect", "scope_expanded"}:
+            regressions.append(candidate_disposition)
+        meaningful = bool(
+            previous_gap_ids - current_gap_ids
+            or gap_score < prior.unresolved_gap_score
+            or any(previous_checks.get(key) == "failed" and status == "passed" for key, status in current_checks.items())
+            or (
+                authoritative_evidence_digest
+                and authoritative_evidence_digest != prior.new_authoritative_evidence_digest
+            )
+            or (
+                prior.candidate_disposition == "contaminated"
+                and candidate_disposition == "clean"
+            )
+        )
+        classification = "regression" if regressions else ("meaningful_progress" if meaningful else "no_progress")
+    return RemediationProgressVector(
+        loopId=loop_id,
+        attemptOrdinal=attempt_ordinal,
+        baseWorkspaceDigest=base_workspace_digest,
+        candidateWorkspaceDigest=candidate_workspace_digest,
+        relevantDiffDigest=relevant_diff_digest,
+        unresolvedGapDigest=_canonical_digest([gap.model_dump(by_alias=True) for gap in unresolved]),
+        unresolvedGapScore=gap_score,
+        requiredChecksDigest=_canonical_digest([check.model_dump(by_alias=True) for check in canonical_checks]),
+        requiredChecks=check_counts,
+        blockerCode=_normalize_token(blocker_code),
+        newAuthoritativeEvidenceDigest=authoritative_evidence_digest,
+        repeatedFailureSignatures=failure_signatures,
+        candidateDisposition=_normalize_token(candidate_disposition),
+        classification=classification,
+        regressions=tuple(regressions),
+        gaps=canonical_gaps,
+        checks=canonical_checks,
+    )
+
+
 class BoundedStoryLoopInput(_ContractModel):
     selected_item_ref: ArtifactRef = Field(alias="selectedItemRef")
     selected_item_digest: str = Field(alias="selectedItemDigest")
@@ -157,6 +298,9 @@ class TypedGateResult(_ContractModel):
     remaining_work_ref: ArtifactRef | None = Field(default=None, alias="remainingWorkRef")
     diagnostics_ref: ArtifactRef | None = Field(default=None, alias="diagnosticsRef")
     progress_signature: str | None = Field(default=None, alias="progressSignature")
+    progress_vector: RemediationProgressVector | None = Field(
+        default=None, alias="progressVector"
+    )
     degraded: bool = False
 
     @field_validator("gate_result_ref", "remaining_work_ref", "diagnostics_ref")
@@ -816,3 +960,91 @@ def _camel_to_reason(value: str) -> str:
             chars.append("_")
         chars.append(char.lower())
     return "".join(chars).replace("-", "_")
+
+
+_SEVERITY_SCORES = {
+    "critical": 8,
+    "high": 5,
+    "medium": 3,
+    "low": 1,
+    "info": 0,
+}
+
+
+def _normalize_token(value: Any) -> str | None:
+    normalized = " ".join(str(value or "").strip().lower().split())
+    return normalized.replace(" ", "_") or None
+
+
+def _canonical_digest(value: Any) -> str:
+    encoded = json_dumps_canonical(value).encode("utf-8")
+    return f"sha256:{hashlib.sha256(encoded).hexdigest()}"
+
+
+def json_dumps_canonical(value: Any) -> str:
+    import json
+
+    return json.dumps(value, ensure_ascii=True, sort_keys=True, separators=(",", ":"))
+
+
+def _canonical_gap(issue: Mapping[str, Any]) -> CanonicalGap:
+    requirement = (
+        issue.get("requirementId")
+        or issue.get("acceptanceCriterionId")
+        or issue.get("requirement")
+        or issue.get("id")
+        or issue.get("code")
+    )
+    scope = issue.get("scope") or issue.get("component") or issue.get("file")
+    check_id = issue.get("requiredCheckId") or issue.get("checkId")
+    if not requirement:
+        # Structured bounded fields are the fallback identity. Free-form feedback,
+        # artifact refs and execution identity are intentionally never included.
+        requirement = _canonical_digest(
+            {
+                "scope": _normalize_token(scope),
+                "check": _normalize_token(check_id),
+                "category": _normalize_token(issue.get("category") or issue.get("type")),
+            }
+        )
+    severity = _normalize_token(issue.get("severity") or issue.get("priority")) or "medium"
+    score_value = issue.get("score")
+    score = (
+        int(score_value)
+        if isinstance(score_value, int) and not isinstance(score_value, bool) and score_value >= 0
+        else _SEVERITY_SCORES.get(severity, 3)
+    )
+    return CanonicalGap(
+        identity=str(requirement).strip().lower(),
+        status=_normalize_token(issue.get("status")) or "unresolved",
+        severity=severity,
+        score=score,
+        scope=_normalize_token(scope),
+        requiredCheckId=_normalize_token(check_id),
+    )
+
+
+def _canonical_check(check: Mapping[str, Any]) -> CanonicalCheck:
+    identity = check.get("checkId") or check.get("commandId") or check.get("id")
+    target = check.get("target") or check.get("scope")
+    if not identity:
+        identity = _canonical_digest(
+            {
+                "target": _normalize_token(target),
+                "kind": _normalize_token(check.get("kind") or check.get("type")),
+            }
+        )
+    status = _normalize_token(check.get("status")) or "not_run"
+    if status in {"success", "succeeded", "pass"}:
+        status = "passed"
+    elif status in {"failure", "failed", "error"}:
+        status = "failed"
+    elif status in {"notrun", "skipped", "pending"}:
+        status = "not_run"
+    failure = check.get("failureSignature") or check.get("failureClass")
+    return CanonicalCheck(
+        identity=str(identity).strip().lower(),
+        status=status,
+        target=_normalize_token(target),
+        failureSignature=_normalize_token(failure),
+    )

--- a/moonmind/workflows/temporal/bounded_story_loop.py
+++ b/moonmind/workflows/temporal/bounded_story_loop.py
@@ -802,8 +802,13 @@ def evaluate_attempt_continuation(
             diagnostics_ref=gate.diagnostics_ref,
         )
     if gate.verdict == "ADDITIONAL_WORK_NEEDED":
+        semantic_attempt_ordinal = (
+            gate.progress_vector.attempt_ordinal
+            if gate.progress_vector is not None
+            else attempt.attempt_ordinal
+        )
         if (
-            attempt.attempt_ordinal >= 3
+            semantic_attempt_ordinal >= 3
             and (
                 gate.progress_vector is None
                 or gate.progress_vector.classification != "meaningful_progress"

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -189,6 +189,7 @@ from moonmind.workflows.temporal.bounded_story_loop import (
     BoundedStoryLoopInput,
     LoopAttempt,
     LoopBudget,
+    LoopStopState,
     PublicationAction,
     RemediationLoopState,
     RemediationProgressVector,

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -14,6 +14,7 @@ from temporalio.exceptions import CancelledError
 from temporalio.workflow import ActivityCancellationType, ChildWorkflowCancellationType
 
 with workflow.unsafe.imports_passed_through():
+    from pydantic import ValidationError
     from collections.abc import Mapping as WorkflowMapping
 
     from moonmind.schemas.agent_runtime_models import (
@@ -6610,9 +6611,12 @@ class MoonMindRunWorkflow:
                     ).strip() or None
                     prior_vector_payload = prior_gate.get("progressVector")
                     if isinstance(prior_vector_payload, Mapping):
-                        prior_progress_vector = RemediationProgressVector.model_validate(
-                            prior_vector_payload
-                        )
+                        try:
+                            prior_progress_vector = RemediationProgressVector.model_validate(
+                                prior_vector_payload
+                            )
+                        except ValidationError:
+                            prior_progress_vector = None
                 prior_budget = prior_decision.get("budget")
                 if isinstance(prior_budget, Mapping):
                     prior_consumed = prior_budget.get("consumed")
@@ -6643,6 +6647,20 @@ class MoonMindRunWorkflow:
             if isinstance(gate_result.validated_refs, Mapping)
             else {}
         )
+        evidence_schema_version = structured_evidence.get("progressEvidenceSchemaVersion")
+        progress_evidence_invalid = evidence_schema_version not in {
+            None,
+            "remediation-progress-evidence/v1",
+        } or (
+            isinstance(loop_context, Mapping)
+            and isinstance(loop_context.get("continuationDecision"), Mapping)
+            and isinstance(
+                loop_context["continuationDecision"].get("gate"), Mapping
+            )
+            and loop_context["continuationDecision"]["gate"].get("progressVector")
+            is not None
+            and prior_progress_vector is None
+        )
         structured_checks: list[Mapping[str, Any]] = []
         raw_checks = structured_evidence.get("requiredChecks")
         if isinstance(raw_checks, Sequence) and not isinstance(raw_checks, (str, bytes)):
@@ -6663,6 +6681,14 @@ class MoonMindRunWorkflow:
             ),
             relevant_diff_digest=self._coerce_text(
                 structured_evidence.get("relevantDiffDigest"), max_chars=200
+            ),
+            addressed_gap_ids=(
+                structured_evidence.get("addressedGapIds")
+                if isinstance(structured_evidence.get("addressedGapIds"), Sequence)
+                and not isinstance(
+                    structured_evidence.get("addressedGapIds"), (str, bytes)
+                )
+                else ()
             ),
             blocker_code=(
                 "verification_blocked" if gate_result.verdict == "BLOCKED" else None
@@ -6787,6 +6813,15 @@ class MoonMindRunWorkflow:
             checkpoint_available=True,
             policy_allowed=True,
         )
+        if progress_evidence_invalid:
+            decision = decision.model_copy(
+                update={
+                    "continue_loop": False,
+                    "reason": "progress_evidence_invalid",
+                    "state": LoopStopState.FAILED_WITH_REMAINING_WORK,
+                    "next_attempt_kind": None,
+                }
+            )
         payload = decision.model_dump(by_alias=True, mode="json")
         payload["hasRemainingRemediationStep"] = has_remaining_remediation_step
         payload["remediationRoutingReason"] = successor_reason
@@ -11062,7 +11097,7 @@ class MoonMindRunWorkflow:
                                 or 1
                             )
                         ):
-                            transition_reason = "no_progress_attempts_exhausted"
+                            transition_reason = "semantic_no_progress_exhausted"
                         elif (
                             normalized_gate == "ADDITIONAL_WORK_NEEDED"
                             and plan_routed_moonspec_remediation_enabled
@@ -11106,7 +11141,7 @@ class MoonMindRunWorkflow:
                             "no_remediation_successor": (
                                 "Skipped because no explicit remediation successor exists."
                             ),
-                            "no_progress_attempts_exhausted": (
+                            "semantic_no_progress_exhausted": (
                                 "Skipped because consecutive remediation cycles "
                                 "produced no new progress."
                             ),

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -6691,10 +6691,19 @@ class MoonMindRunWorkflow:
             structured_checks = [
                 check for check in raw_checks if isinstance(check, Mapping)
             ]
+        progress_issues: Sequence[Mapping[str, Any]] = gate_result.issues
+        if (
+            self._patched_or_false_outside_workflow(
+                RUN_BOUNDED_STORY_LOOP_FEEDBACK_PROGRESS_PATCH
+            )
+            and not progress_issues
+            and gate_result.feedback
+        ):
+            progress_issues = ({"feedback": gate_result.feedback},)
         progress_vector = build_remediation_progress_vector(
             loop_id=workflow_id,
             attempt_ordinal=remediation_attempt or attempt.attempt_ordinal,
-            issues=gate_result.issues,
+            issues=progress_issues,
             checks=structured_checks,
             prior=prior_progress_vector,
             base_workspace_digest=self._coerce_text(

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -190,8 +190,10 @@ from moonmind.workflows.temporal.bounded_story_loop import (
     LoopAttempt,
     LoopBudget,
     PublicationAction,
+    RemediationLoopState,
     RemediationProgressVector,
     TypedGateResult,
+    advance_remediation_loop_state,
     build_remediation_progress_vector,
     compile_bounded_story_loop,
     evaluate_attempt_continuation,
@@ -6600,8 +6602,20 @@ class MoonMindRunWorkflow:
         prior_progress_signature = None
         prior_no_progress_attempts = 0
         prior_progress_vector: RemediationProgressVector | None = None
+        prior_loop_state: RemediationLoopState | None = None
         prior_consumed_counters: dict[str, int] = {}
         if isinstance(loop_context, Mapping):
+            durable_state_payload = loop_context.get("durableLoopState")
+            if isinstance(durable_state_payload, Mapping):
+                try:
+                    prior_loop_state = RemediationLoopState.model_validate(
+                        durable_state_payload
+                    )
+                except ValidationError:
+                    prior_loop_state = None
+                if prior_loop_state is not None:
+                    prior_progress_vector = prior_loop_state.progress_vector
+                    prior_consumed_counters = dict(prior_loop_state.consumed)
             prior_decision = loop_context.get("continuationDecision")
             if isinstance(prior_decision, Mapping):
                 prior_gate = prior_decision.get("gate")
@@ -6633,6 +6647,11 @@ class MoonMindRunWorkflow:
                             )
                             or 0
                         )
+            if prior_loop_state is not None:
+                for key, value in prior_loop_state.consumed.items():
+                    prior_consumed_counters[key] = max(
+                        prior_consumed_counters.get(key, 0), value
+                    )
         workflow_id, _ = self._bounded_story_loop_workflow_identity()
         progress_node = (
             ordered_nodes[current_index]
@@ -6766,6 +6785,42 @@ class MoonMindRunWorkflow:
                 ),
             }
         )
+        evidence_retries = max(
+            0, (self._step_execution_for(logical_step_id) or 1) - 1
+        )
+        infrastructure_retries = max(
+            0,
+            int(
+                (
+                    (gate_result.validated_refs or {}).get(
+                        "infrastructureRetries", 0
+                    )
+                    if isinstance(gate_result.validated_refs, Mapping)
+                    else 0
+                )
+                or 0
+            ),
+        )
+        consumed["evidenceRetries"] = max(
+            consumed.get("evidenceRetries", 0), evidence_retries
+        )
+        consumed["infrastructureRetries"] = max(
+            consumed.get("infrastructureRetries", 0), infrastructure_retries
+        )
+        retry_accounting = (
+            loop_context.get("retryAccounting")
+            if isinstance(loop_context, Mapping)
+            else None
+        )
+        if isinstance(retry_accounting, Mapping):
+            for key in (
+                "evidenceRetries",
+                "infrastructureRetries",
+                "contractRepairAttempts",
+            ):
+                amount = retry_accounting.get(key)
+                if isinstance(amount, int) and not isinstance(amount, bool):
+                    consumed[key] = max(consumed.get(key, 0), amount)
         resource_usage = (
             gate_result.validated_refs.get("resourceUsage")
             if isinstance(gate_result.validated_refs, Mapping)
@@ -6799,6 +6854,15 @@ class MoonMindRunWorkflow:
                 "maxUnsafeOrPolicyDeniedAttempts": configured_budgets.get(
                     "maxUnsafeOrPolicyDeniedAttempts", 0
                 ),
+                "maxEvidenceRetries": configured_budgets.get(
+                    "maxEvidenceRetries", 2
+                ),
+                "maxInfrastructureRetries": configured_budgets.get(
+                    "maxInfrastructureRetries", 2
+                ),
+                "maxContractRepairAttempts": configured_budgets.get(
+                    "maxContractRepairAttempts", 1
+                ),
                 "maxElapsedSeconds": configured_budgets.get("maxElapsedSeconds"),
                 "providerBudget": configured_budgets.get("providerBudget"),
                 "tokenBudget": configured_budgets.get("tokenBudget"),
@@ -6806,6 +6870,20 @@ class MoonMindRunWorkflow:
                 "consumed": consumed,
             }
         )
+        grant = (
+            loop_context.get("budgetGrant")
+            if isinstance(loop_context, Mapping)
+            and isinstance(loop_context.get("budgetGrant"), Mapping)
+            else None
+        )
+        provisional_state = advance_remediation_loop_state(
+            prior=prior_loop_state,
+            policy=budget,
+            progress_vector=progress_vector,
+            consumed=consumed,
+            grant=grant,
+        )
+        budget = provisional_state.policy
         decision = evaluate_attempt_continuation(
             attempt=attempt,
             gate=gate,
@@ -6838,6 +6916,18 @@ class MoonMindRunWorkflow:
             "progressVectorDigest": progress_vector.digest,
         }
         payload["budget"] = budget.model_dump(by_alias=True, mode="json")
+        durable_state = provisional_state.model_copy(
+            update={
+                "prior_exhaustion_reason": (
+                    provisional_state.prior_exhaustion_reason
+                    if decision.continue_loop
+                    else decision.reason
+                )
+            }
+        )
+        payload["durableLoopState"] = durable_state.model_dump(
+            by_alias=True, mode="json"
+        )
         payload["currentLogicalStepId"] = logical_step_id
         current_node = next(
             (
@@ -6854,7 +6944,7 @@ class MoonMindRunWorkflow:
         remediation_attempt, remediation_max = (
             self._moonspec_remediation_attempt_metadata(current_node)
         )
-        review_retries = max(0, (self._step_execution_for(logical_step_id) or 1) - 1)
+        review_retries = evidence_retries
         persisted_review_budget: Mapping[str, Any] | None = None
         current_row = self._step_ledger_row_for(logical_step_id) or {}
         checks = current_row.get("checks")
@@ -6879,17 +6969,7 @@ class MoonMindRunWorkflow:
         payload["nonSemanticRetryBudgets"] = {
             "reviewEvidenceRetries": review_retries,
             "infrastructureRetries": max(
-                0,
-                int(
-                    (
-                        (gate_result.validated_refs or {}).get(
-                            "infrastructureRetries", 0
-                        )
-                        if isinstance(gate_result.validated_refs, Mapping)
-                        else 0
-                    )
-                    or 0
-                ),
+                0, infrastructure_retries
             ),
             "consumesSemanticAttempt": False,
         }
@@ -6901,6 +6981,10 @@ class MoonMindRunWorkflow:
         self._publish_context.setdefault("boundedStoryLoop", {})[
             "continuationDecision"
         ] = payload
+        self._publish_context["boundedStoryLoop"]["durableLoopState"] = payload[
+            "durableLoopState"
+        ]
+        self._publish_context["boundedStoryLoop"].pop("budgetGrant", None)
         return payload
 
     def _blocking_moonspec_gate_reason(self) -> str | None:
@@ -8960,6 +9044,14 @@ class MoonMindRunWorkflow:
             "budgets": serialized_budgets,
             "scopeGuard": scope,
         }
+        if loop_input.prior_loop_state is not None:
+            self._publish_context["boundedStoryLoop"]["durableLoopState"] = (
+                loop_input.prior_loop_state.model_dump(by_alias=True, mode="json")
+            )
+        if loop_input.budget_grant:
+            self._publish_context["boundedStoryLoop"]["budgetGrant"] = dict(
+                loop_input.budget_grant
+            )
 
     def _runtime_visibility_from_parameters(
         self,
@@ -10463,6 +10555,15 @@ class MoonMindRunWorkflow:
                         < _MOONSPEC_GATE_CONTRACT_REPAIR_MAX_ATTEMPTS
                     ):
                         moonspec_contract_repair_attempts += 1
+                        loop_context = self._publish_context.setdefault(
+                            "boundedStoryLoop", {}
+                        )
+                        retry_accounting = loop_context.setdefault(
+                            "retryAccounting", {}
+                        )
+                        retry_accounting["contractRepairAttempts"] = (
+                            moonspec_contract_repair_attempts
+                        )
                         if workflow.patched(
                             RUN_MOONSPEC_GATE_CONTRACT_REPAIR_FRESH_SOURCE_PATCH
                         ):
@@ -20529,3 +20630,4 @@ class MoonMindUserWorkflow(MoonMindRunWorkflow):
     @workflow.run
     async def run(self, input_payload: RunWorkflowInput) -> RunWorkflowOutput:
         return await super().run(input_payload)
+    advance_remediation_loop_state,

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -818,14 +818,7 @@ class MoonMindRunWorkflow:
         if not hasattr(logger_to_use, "isEnabledFor"):
             logger_to_use = logging.getLogger(__name__)
 
-        try:
-            logger_to_use.isEnabledFor(logging.INFO)
-            return logging.LoggerAdapter(logger_to_use, extra=extra)
-        except Exception:
-            logging.getLogger(__name__).exception(
-                "Error checking logger capabilities in _get_logger"
-            )
-            return logging.LoggerAdapter(logging.getLogger(__name__), extra=extra)
+        return logging.LoggerAdapter(logger_to_use, extra=extra)
 
     @staticmethod
     def _operator_failure_summary(exc: BaseException) -> str:
@@ -6616,6 +6609,9 @@ class MoonMindRunWorkflow:
                 if prior_loop_state is not None:
                     prior_progress_vector = prior_loop_state.progress_vector
                     prior_consumed_counters = dict(prior_loop_state.consumed)
+                    prior_no_progress_attempts = prior_loop_state.consumed.get(
+                        "consecutiveNoProgressAttempts", 0
+                    )
             prior_decision = loop_context.get("continuationDecision")
             if isinstance(prior_decision, Mapping):
                 prior_gate = prior_decision.get("gate")
@@ -6788,18 +6784,16 @@ class MoonMindRunWorkflow:
         evidence_retries = max(
             0, (self._step_execution_for(logical_step_id) or 1) - 1
         )
-        infrastructure_retries = max(
-            0,
-            int(
-                (
-                    (gate_result.validated_refs or {}).get(
-                        "infrastructureRetries", 0
-                    )
-                    if isinstance(gate_result.validated_refs, Mapping)
-                    else 0
-                )
-                or 0
-            ),
+        raw_infrastructure_retries = (
+            (gate_result.validated_refs or {}).get("infrastructureRetries", 0)
+            if isinstance(gate_result.validated_refs, Mapping)
+            else 0
+        )
+        infrastructure_retries = (
+            max(0, int(raw_infrastructure_retries))
+            if isinstance(raw_infrastructure_retries, (int, float))
+            and not isinstance(raw_infrastructure_retries, bool)
+            else 0
         )
         consumed["evidenceRetries"] = max(
             consumed.get("evidenceRetries", 0), evidence_retries
@@ -6891,6 +6885,19 @@ class MoonMindRunWorkflow:
             checkpoint_available=True,
             policy_allowed=True,
         )
+        if (
+            gate.verdict == "ADDITIONAL_WORK_NEEDED"
+            and not has_remaining_remediation_step
+            and decision.continue_loop
+        ):
+            decision = decision.model_copy(
+                update={
+                    "continue_loop": False,
+                    "reason": "no_remediation_successor",
+                    "state": LoopStopState.FAILED_WITH_REMAINING_WORK,
+                    "next_attempt_kind": None,
+                }
+            )
         if progress_evidence_invalid:
             decision = decision.model_copy(
                 update={

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -818,6 +818,14 @@ class MoonMindRunWorkflow:
         if not hasattr(logger_to_use, "isEnabledFor"):
             logger_to_use = logging.getLogger(__name__)
 
+        try:
+            if not isinstance(logger_to_use.isEnabledFor(logging.INFO), bool):
+                logger_to_use = logging.getLogger(__name__)
+        except Exception:
+            logging.getLogger(__name__).exception(
+                "Error checking logger capabilities in _get_logger"
+            )
+            logger_to_use = logging.getLogger(__name__)
         return logging.LoggerAdapter(logger_to_use, extra=extra)
 
     @staticmethod

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -189,7 +189,9 @@ from moonmind.workflows.temporal.bounded_story_loop import (
     LoopAttempt,
     LoopBudget,
     PublicationAction,
+    RemediationProgressVector,
     TypedGateResult,
+    build_remediation_progress_vector,
     compile_bounded_story_loop,
     evaluate_attempt_continuation,
     evaluate_publication_decision,
@@ -6451,34 +6453,6 @@ class MoonMindRunWorkflow:
         terminal_disposition = (
             "accepted" if terminal == "accepted" else "failed_with_remaining_work"
         )
-        progress_payload = {
-            "verdict": gate_result.verdict,
-            "issues": [dict(issue) for issue in gate_result.issues],
-            "remainingWorkRef": gate_result.remaining_work_ref,
-            "blockingEvidenceRefs": list(gate_result.blocking_evidence_refs),
-            "recommendedNextAction": gate_result.recommended_next_action,
-            "workspacePolicyRecommendation": (
-                gate_result.workspace_policy_recommendation
-            ),
-            "recoverableInCurrentRuntime": gate_result.recoverable_in_current_runtime,
-        }
-        if self._patched_or_false_outside_workflow(
-            RUN_BOUNDED_STORY_LOOP_FEEDBACK_PROGRESS_PATCH
-        ):
-            # Verifiers may report their remaining gaps in feedback even when
-            # they omit the optional structured issues/remainingWorkRef fields.
-            # Excluding that authoritative summary makes distinct verifier
-            # reports look identical and can exhaust the no-progress budget
-            # after the first remediation attempt.
-            progress_payload["feedback"] = gate_result.feedback
-        progress_signature = hashlib.sha256(
-            json.dumps(
-                progress_payload,
-                ensure_ascii=True,
-                sort_keys=True,
-                separators=(",", ":"),
-            ).encode("utf-8")
-        ).hexdigest()
         return TypedGateResult.from_boundary_payload(
             {
                 "verdict": gate_result.verdict,
@@ -6501,7 +6475,7 @@ class MoonMindRunWorkflow:
                     next(iter(gate_result.blocking_evidence_refs), None)
                 ),
                 "progressSignature": (
-                    progress_signature if progress_budget_enabled else None
+                    None
                 ),
                 "degraded": gate_result.degraded,
             }
@@ -6624,6 +6598,8 @@ class MoonMindRunWorkflow:
         loop_context = self._publish_context.get("boundedStoryLoop")
         prior_progress_signature = None
         prior_no_progress_attempts = 0
+        prior_progress_vector: RemediationProgressVector | None = None
+        prior_consumed_counters: dict[str, int] = {}
         if isinstance(loop_context, Mapping):
             prior_decision = loop_context.get("continuationDecision")
             if isinstance(prior_decision, Mapping):
@@ -6632,25 +6608,96 @@ class MoonMindRunWorkflow:
                     prior_progress_signature = str(
                         prior_gate.get("progressSignature") or ""
                     ).strip() or None
+                    prior_vector_payload = prior_gate.get("progressVector")
+                    if isinstance(prior_vector_payload, Mapping):
+                        prior_progress_vector = RemediationProgressVector.model_validate(
+                            prior_vector_payload
+                        )
                 prior_budget = prior_decision.get("budget")
                 if isinstance(prior_budget, Mapping):
                     prior_consumed = prior_budget.get("consumed")
                     if isinstance(prior_consumed, Mapping):
+                        prior_consumed_counters = {
+                            str(key): max(0, int(value or 0))
+                            for key, value in prior_consumed.items()
+                            if isinstance(value, (int, float))
+                            and not isinstance(value, bool)
+                        }
                         prior_no_progress_attempts = int(
                             prior_consumed.get(
                                 "consecutiveNoProgressAttempts", 0
                             )
                             or 0
                         )
+        workflow_id, _ = self._bounded_story_loop_workflow_identity()
+        progress_node = (
+            ordered_nodes[current_index]
+            if 0 <= current_index < len(ordered_nodes)
+            else {}
+        )
+        remediation_attempt, remediation_max = (
+            self._moonspec_remediation_attempt_metadata(progress_node)
+        )
+        structured_evidence = (
+            gate_result.validated_refs
+            if isinstance(gate_result.validated_refs, Mapping)
+            else {}
+        )
+        structured_checks: list[Mapping[str, Any]] = []
+        raw_checks = structured_evidence.get("requiredChecks")
+        if isinstance(raw_checks, Sequence) and not isinstance(raw_checks, (str, bytes)):
+            structured_checks = [
+                check for check in raw_checks if isinstance(check, Mapping)
+            ]
+        progress_vector = build_remediation_progress_vector(
+            loop_id=workflow_id,
+            attempt_ordinal=remediation_attempt or attempt.attempt_ordinal,
+            issues=gate_result.issues,
+            checks=structured_checks,
+            prior=prior_progress_vector,
+            base_workspace_digest=self._coerce_text(
+                structured_evidence.get("baseWorkspaceDigest"), max_chars=200
+            ),
+            candidate_workspace_digest=self._coerce_text(
+                structured_evidence.get("candidateWorkspaceDigest"), max_chars=200
+            ),
+            relevant_diff_digest=self._coerce_text(
+                structured_evidence.get("relevantDiffDigest"), max_chars=200
+            ),
+            blocker_code=(
+                "verification_blocked" if gate_result.verdict == "BLOCKED" else None
+            ),
+            authoritative_evidence_digest=(
+                self._coerce_text(
+                    (gate_result.validated_refs or {}).get("authoritativeEvidenceDigest"),
+                    max_chars=200,
+                )
+                if structured_evidence
+                else None
+            ),
+            candidate_disposition=(
+                self._coerce_text(
+                    (gate_result.validated_refs or {}).get("candidateDisposition"),
+                    max_chars=100,
+                )
+                if structured_evidence
+                else None
+            ),
+        )
+        gate = gate.model_copy(
+            update={
+                "progress_vector": progress_vector,
+                "progress_signature": progress_vector.digest,
+            }
+        )
         repeated_progress = bool(
             progress_budget_enabled
-            and gate.progress_signature
-            and prior_progress_signature == gate.progress_signature
+            and progress_vector.classification in {"no_progress", "regression"}
         )
         consecutive_no_progress_attempts = (
             prior_no_progress_attempts + 1 if repeated_progress else 0
         )
-        max_no_progress_attempts = 1
+        max_no_progress_attempts = 2
         explicit_no_progress_budget = False
         if progress_budget_enabled and isinstance(loop_context, Mapping):
             loop_budgets = loop_context.get("budgets")
@@ -6661,44 +6708,76 @@ class MoonMindRunWorkflow:
                 if configured_no_progress_attempts is not None:
                     max_no_progress_attempts = configured_no_progress_attempts
                     explicit_no_progress_budget = True
-        if (
-            progress_budget_enabled
-            and not explicit_no_progress_budget
-            and self._patched_or_false_outside_workflow(
-                RUN_BOUNDED_STORY_LOOP_REMEDIATION_BUDGET_PATCH
-            )
-        ):
-            # A compiled remediation chain already has a finite, operator-visible
-            # attempt budget. When no independent no-progress policy was authored,
-            # let that declared budget govern repeated verifier results as well.
-            # Defaulting this guard to one makes the first unchanged/sparse
-            # post-remediation report shadow an explicit "attempt 1 of 6" plan.
-            declared_remediation_maxima: set[int] = set()
-            for candidate in ordered_nodes:
-                if self._moonspec_step_role(candidate) not in {
-                    "moonspec-remediation",
-                    "moonspec-verification-gate",
-                }:
-                    continue
-                _, maximum = self._moonspec_remediation_attempt_metadata(candidate)
-                if maximum is not None:
-                    declared_remediation_maxima.add(maximum)
-            if len(declared_remediation_maxima) == 1:
-                max_no_progress_attempts = next(iter(declared_remediation_maxima))
+        hard_max_attempts = remediation_max or 6
+        consumed = dict(prior_consumed_counters)
+        prior_failures = (
+            set(prior_progress_vector.repeated_failure_signatures)
+            if prior_progress_vector is not None
+            else set()
+        )
+        current_failures = set(progress_vector.repeated_failure_signatures)
+        repeated_failure_count = (
+            consumed.get("repeatedFailedCommands", 0) + 1
+            if current_failures and current_failures & prior_failures
+            else (1 if current_failures else 0)
+        )
+        consumed.update(
+            {
+                "attempts": max(
+                    consumed.get("attempts", 0),
+                    remediation_attempt or (1 if remediation_gate else 0),
+                ),
+                "consecutiveNoProgressAttempts": max(
+                    0, consecutive_no_progress_attempts
+                ),
+                "repeatedFailedCommands": repeated_failure_count,
+                "unsafeOrPolicyDeniedAttempts": max(
+                    consumed.get("unsafeOrPolicyDeniedAttempts", 0),
+                    1
+                    if progress_vector.candidate_disposition
+                    in {"unsafe_side_effect", "policy_denied"}
+                    else 0,
+                ),
+            }
+        )
+        resource_usage = (
+            gate_result.validated_refs.get("resourceUsage")
+            if isinstance(gate_result.validated_refs, Mapping)
+            else None
+        )
+        if isinstance(resource_usage, Mapping):
+            for source_key, counter_key in (
+                ("elapsedSeconds", "elapsedSeconds"),
+                ("provider", "provider"),
+                ("tokens", "tokens"),
+                ("cost", "cost"),
+            ):
+                amount = resource_usage.get(source_key)
+                if isinstance(amount, (int, float)) and not isinstance(amount, bool):
+                    consumed[counter_key] = max(
+                        consumed.get(counter_key, 0), max(0, int(amount))
+                    )
+        configured_budgets = (
+            loop_context.get("budgets") if isinstance(loop_context, Mapping) else None
+        )
+        configured_budgets = (
+            configured_budgets if isinstance(configured_budgets, Mapping) else {}
+        )
         budget = LoopBudget.model_validate(
             {
-                "maxAttempts": 1,
+                "maxAttempts": hard_max_attempts,
                 "maxConsecutiveNoProgressAttempts": max_no_progress_attempts,
-                "maxRepeatedFailedCommands": 1,
-                "maxUnsafeOrPolicyDeniedAttempts": 1,
-                "consumed": {
-                    "attempts": 0 if has_remaining_remediation_step else 1,
-                    "consecutiveNoProgressAttempts": (
-                        consecutive_no_progress_attempts
-                    ),
-                    "repeated_failed_commands": 0,
-                    "unsafe_or_policy_denied_attempts": 0,
-                },
+                "maxRepeatedFailedCommands": configured_budgets.get(
+                    "maxRepeatedFailedCommands", 2
+                ),
+                "maxUnsafeOrPolicyDeniedAttempts": configured_budgets.get(
+                    "maxUnsafeOrPolicyDeniedAttempts", 0
+                ),
+                "maxElapsedSeconds": configured_budgets.get("maxElapsedSeconds"),
+                "providerBudget": configured_budgets.get("providerBudget"),
+                "tokenBudget": configured_budgets.get("tokenBudget"),
+                "costBudget": configured_budgets.get("costBudget"),
+                "consumed": consumed,
             }
         )
         decision = evaluate_attempt_continuation(
@@ -6720,6 +6799,8 @@ class MoonMindRunWorkflow:
             "remainingWorkRef": gate.remaining_work_ref,
             "diagnosticsRef": gate.diagnostics_ref,
             "progressSignature": gate.progress_signature,
+            "progressVector": progress_vector.model_dump(by_alias=True, mode="json"),
+            "progressVectorDigest": progress_vector.digest,
         }
         payload["budget"] = budget.model_dump(by_alias=True, mode="json")
         payload["currentLogicalStepId"] = logical_step_id
@@ -6760,6 +6841,23 @@ class MoonMindRunWorkflow:
                 "remainingExecutions": 0,
             }
         )
+        payload["nonSemanticRetryBudgets"] = {
+            "reviewEvidenceRetries": review_retries,
+            "infrastructureRetries": max(
+                0,
+                int(
+                    (
+                        (gate_result.validated_refs or {}).get(
+                            "infrastructureRetries", 0
+                        )
+                        if isinstance(gate_result.validated_refs, Mapping)
+                        else 0
+                    )
+                    or 0
+                ),
+            ),
+            "consumesSemanticAttempt": False,
+        }
         payload["remediationBudget"] = self._moonspec_remediation_budget_metadata(
             ordered_nodes=ordered_nodes,
             current_attempt=remediation_attempt,

--- a/tests/unit/workflows/temporal/test_bounded_story_loop.py
+++ b/tests/unit/workflows/temporal/test_bounded_story_loop.py
@@ -18,6 +18,7 @@ from moonmind.workflows.temporal.bounded_story_loop import (
     TypedGateResult,
     VerificationWorkspaceSnapshot,
     advance_candidate_workspace_head,
+    build_remediation_progress_vector,
     compile_bounded_story_loop,
     evaluate_attempt_continuation,
     evaluate_attempt_preflight,
@@ -63,6 +64,90 @@ def _attempt(**overrides: object) -> LoopAttempt:
     }
     payload.update(overrides)
     return LoopAttempt.model_validate(payload)
+
+
+def test_progress_vector_ignores_refs_prose_and_runtime_identity() -> None:
+    issue = {
+        "requirementId": "AC-1",
+        "scope": "api/controller.py",
+        "status": "unresolved",
+        "severity": "high",
+        "summary": "first wording",
+        "artifactRef": "artifact://report/one",
+        "runId": "run-one",
+    }
+    first = build_remediation_progress_vector(
+        loop_id="loop-1", attempt_ordinal=1, issues=[issue]
+    )
+    second = build_remediation_progress_vector(
+        loop_id="loop-1",
+        attempt_ordinal=2,
+        issues=[
+            {
+                **issue,
+                "summary": "completely rewritten",
+                "artifactRef": "artifact://report/two",
+                "runId": "run-two",
+            }
+        ],
+        prior=first,
+    )
+
+    assert first.unresolved_gap_digest == second.unresolved_gap_digest
+    assert second.classification == "no_progress"
+
+
+def test_progress_vector_detects_gap_check_and_evidence_progress() -> None:
+    baseline = build_remediation_progress_vector(
+        loop_id="loop-1",
+        attempt_ordinal=1,
+        issues=[
+            {"requirementId": "AC-1", "status": "unresolved", "severity": "high"},
+            {"requirementId": "AC-2", "status": "unresolved", "severity": "medium"},
+        ],
+        checks=[{"checkId": "unit", "status": "failed", "failureClass": "assertion"}],
+    )
+    progressed = build_remediation_progress_vector(
+        loop_id="loop-1",
+        attempt_ordinal=2,
+        issues=[
+            {"requirementId": "AC-1", "status": "resolved", "severity": "high"},
+            {"requirementId": "AC-2", "status": "unresolved", "severity": "medium"},
+        ],
+        checks=[{"checkId": "unit", "status": "passed"}],
+        prior=baseline,
+    )
+
+    assert progressed.classification == "meaningful_progress"
+    assert progressed.unresolved_gap_score < baseline.unresolved_gap_score
+    assert progressed.required_checks == {"passed": 1, "failed": 0, "not_run": 0}
+
+
+def test_progress_vector_records_regressions_separately() -> None:
+    baseline = build_remediation_progress_vector(
+        loop_id="loop-1",
+        attempt_ordinal=1,
+        issues=[{"requirementId": "AC-1", "status": "unresolved"}],
+        checks=[{"checkId": "unit", "status": "passed"}],
+    )
+    regressed = build_remediation_progress_vector(
+        loop_id="loop-1",
+        attempt_ordinal=2,
+        issues=[
+            {"requirementId": "AC-1", "status": "unresolved"},
+            {"requirementId": "AC-2", "status": "unresolved"},
+        ],
+        checks=[{"checkId": "unit", "status": "failed"}],
+        prior=baseline,
+        candidate_disposition="contaminated",
+    )
+
+    assert regressed.classification == "regression"
+    assert set(regressed.regressions) == {
+        "new_gap_introduced",
+        "required_check_regressed",
+        "contaminated",
+    }
 
 
 def test_selected_item_validation_and_compilation_are_single_item_only() -> None:

--- a/tests/unit/workflows/temporal/test_bounded_story_loop.py
+++ b/tests/unit/workflows/temporal/test_bounded_story_loop.py
@@ -123,6 +123,54 @@ def test_progress_vector_detects_gap_check_and_evidence_progress() -> None:
     assert progressed.required_checks == {"passed": 1, "failed": 0, "not_run": 0}
 
 
+def test_relevant_diff_only_counts_when_it_addresses_a_named_gap() -> None:
+    issue = {"requirementId": "AC-1", "status": "unresolved", "severity": "high"}
+    baseline = build_remediation_progress_vector(
+        loop_id="loop-1",
+        attempt_ordinal=1,
+        issues=[issue],
+        relevant_diff_digest="sha256:old",
+    )
+    unrelated = build_remediation_progress_vector(
+        loop_id="loop-1",
+        attempt_ordinal=2,
+        issues=[issue],
+        prior=baseline,
+        relevant_diff_digest="sha256:new",
+        addressed_gap_ids=["AC-OTHER"],
+    )
+    relevant = build_remediation_progress_vector(
+        loop_id="loop-1",
+        attempt_ordinal=2,
+        issues=[issue],
+        prior=baseline,
+        relevant_diff_digest="sha256:new",
+        addressed_gap_ids=["ac-1"],
+    )
+
+    assert unrelated.classification == "no_progress"
+    assert relevant.classification == "meaningful_progress"
+
+
+def test_third_attempt_requires_meaningful_progress() -> None:
+    progress = build_remediation_progress_vector(
+        loop_id="loop-1",
+        attempt_ordinal=3,
+        issues=[{"requirementId": "AC-1", "status": "unresolved"}],
+    ).model_copy(update={"classification": "no_progress"})
+
+    decision = evaluate_attempt_continuation(
+        attempt=_attempt(attemptOrdinal=3, kind="remediation"),
+        gate=_gate(progressVector=progress),
+        budget=_budget(maxAttempts=6),
+        checkpoint_available=True,
+        policy_allowed=True,
+    )
+
+    assert decision.continue_loop is False
+    assert decision.reason == "required_progress_not_met"
+
+
 def test_progress_vector_records_regressions_separately() -> None:
     baseline = build_remediation_progress_vector(
         loop_id="loop-1",
@@ -384,17 +432,17 @@ def test_verification_workspace_snapshot_rejects_writable_projection() -> None:
         (
             {"maxConsecutiveNoProgressAttempts": 2},
             {"consecutive_no_progress_attempts": 2},
-            "no_progress_attempts_exhausted",
+            "semantic_no_progress_exhausted",
         ),
         (
             {"maxRepeatedFailedCommands": 2},
             {"repeated_failed_commands": 2},
-            "repeated_failed_commands_exhausted",
+            "repeated_failure_signature_exhausted",
         ),
         (
             {"maxUnsafeOrPolicyDeniedAttempts": 1},
             {"unsafe_or_policy_denied_attempts": 1},
-            "unsafe_policy_attempts_exhausted",
+            "unsafe_or_policy_denied",
         ),
         (
             {"maxElapsedSeconds": 300},
@@ -609,9 +657,9 @@ def test_publication_decision_requires_latest_accepted_step(action: PublicationA
     ("consumed", "expected_reason"),
     [
         ({"attempts": 3}, "max_attempts_exhausted"),
-        ({"consecutiveNoProgressAttempts": 2}, "no_progress_attempts_exhausted"),
-        ({"repeatedFailedCommands": 3}, "repeated_failed_commands_exhausted"),
-        ({"unsafeOrPolicyDeniedAttempts": 1}, "unsafe_policy_attempts_exhausted"),
+        ({"consecutiveNoProgressAttempts": 2}, "semantic_no_progress_exhausted"),
+        ({"repeatedFailedCommands": 3}, "repeated_failure_signature_exhausted"),
+        ({"unsafeOrPolicyDeniedAttempts": 1}, "unsafe_or_policy_denied"),
         ({"provider": 11}, "provider_budget_exhausted"),
         ({"tokens": 101}, "token_budget_exhausted"),
         ({"cost": 11}, "cost_budget_exhausted"),

--- a/tests/unit/workflows/temporal/test_bounded_story_loop.py
+++ b/tests/unit/workflows/temporal/test_bounded_story_loop.py
@@ -231,6 +231,25 @@ def test_third_attempt_requires_meaningful_progress() -> None:
     assert decision.reason == "required_progress_not_met"
 
 
+def test_semantic_third_attempt_requires_progress_for_plan_routed_gate() -> None:
+    progress = build_remediation_progress_vector(
+        loop_id="loop-1",
+        attempt_ordinal=3,
+        issues=[{"requirementId": "AC-1", "status": "unresolved"}],
+    ).model_copy(update={"classification": "no_progress"})
+
+    decision = evaluate_attempt_continuation(
+        attempt=_attempt(attemptOrdinal=1, kind="verification"),
+        gate=_gate(progressVector=progress),
+        budget=_budget(maxAttempts=6),
+        checkpoint_available=True,
+        policy_allowed=True,
+    )
+
+    assert decision.continue_loop is False
+    assert decision.reason == "required_progress_not_met"
+
+
 def test_progress_vector_records_regressions_separately() -> None:
     baseline = build_remediation_progress_vector(
         loop_id="loop-1",

--- a/tests/unit/workflows/temporal/test_bounded_story_loop.py
+++ b/tests/unit/workflows/temporal/test_bounded_story_loop.py
@@ -17,6 +17,8 @@ from moonmind.workflows.temporal.bounded_story_loop import (
     ProviderLeaseDecision,
     TypedGateResult,
     VerificationWorkspaceSnapshot,
+    RemediationLoopState,
+    advance_remediation_loop_state,
     advance_candidate_workspace_head,
     build_remediation_progress_vector,
     compile_bounded_story_loop,
@@ -49,6 +51,64 @@ def _gate(**overrides: object) -> TypedGateResult:
     }
     payload.update(overrides)
     return TypedGateResult.model_validate(payload)
+
+
+def test_loop_state_is_monotonic_and_linked_grants_add_capacity() -> None:
+    policy = _budget(
+        maxAttempts=6,
+        maxEvidenceRetries=2,
+        consumed={"attempts": 4, "evidenceRetries": 2},
+    )
+    prior = RemediationLoopState(
+        policy=policy,
+        consumed={"attempts": 4, "evidenceRetries": 2},
+        priorExhaustionReason="evidence_retry_budget_exhausted",
+    )
+
+    continued = advance_remediation_loop_state(
+        prior=prior,
+        policy=policy.model_copy(update={"consumed": {"attempts": 1}}),
+        progress_vector=None,
+        consumed={"attempts": 1},
+        grant={"attempts": 2, "evidenceRetries": 1},
+    )
+
+    assert continued.schema_version == "remediation-loop-state/v1"
+    assert continued.consumed == {"attempts": 4, "evidenceRetries": 2}
+    assert continued.policy.max_attempts == 8
+    assert continued.policy.max_evidence_retries == 3
+    assert continued.prior_exhaustion_reason == "evidence_retry_budget_exhausted"
+
+
+@pytest.mark.parametrize(
+    ("counter", "limit", "reason"),
+    [
+        ("evidenceRetries", "maxEvidenceRetries", "evidence_retry_budget_exhausted"),
+        (
+            "infrastructureRetries",
+            "maxInfrastructureRetries",
+            "infrastructure_retry_budget_exhausted",
+        ),
+        (
+            "contractRepairAttempts",
+            "maxContractRepairAttempts",
+            "contract_repair_budget_exhausted",
+        ),
+    ],
+)
+def test_non_semantic_retry_budgets_have_exact_stop_reasons(
+    counter: str, limit: str, reason: str
+) -> None:
+    decision = evaluate_attempt_continuation(
+        attempt=_attempt(),
+        gate=_gate(),
+        budget=_budget(**{limit: 1, "consumed": {counter: 1}}),
+        checkpoint_available=True,
+        policy_allowed=True,
+    )
+
+    assert decision.continue_loop is False
+    assert decision.reason == reason
 
 
 def _attempt(**overrides: object) -> LoopAttempt:

--- a/tests/unit/workflows/temporal/test_bounded_story_loop.py
+++ b/tests/unit/workflows/temporal/test_bounded_story_loop.py
@@ -239,7 +239,7 @@ def test_semantic_third_attempt_requires_progress_for_plan_routed_gate() -> None
     ).model_copy(update={"classification": "no_progress"})
 
     decision = evaluate_attempt_continuation(
-        attempt=_attempt(attemptOrdinal=1, kind="verification"),
+        attempt=_attempt(attemptOrdinal=1, kind="remediation"),
         gate=_gate(progressVector=progress),
         budget=_budget(maxAttempts=6),
         checkpoint_available=True,

--- a/tests/unit/workflows/temporal/workflows/test_run_bounded_story_loop.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_bounded_story_loop.py
@@ -206,6 +206,9 @@ def test_workflow_payload_records_compiled_bounded_story_loop_context() -> None:
             "maxConsecutiveNoProgressAttempts": 2,
             "maxRepeatedFailedCommands": 2,
             "maxUnsafeOrPolicyDeniedAttempts": 0,
+            "maxEvidenceRetries": 2,
+            "maxInfrastructureRetries": 2,
+            "maxContractRepairAttempts": 1,
             "providerBudget": None,
             "tokenBudget": None,
             "costBudget": None,
@@ -1008,7 +1011,7 @@ def test_parent_loop_stops_on_structured_gate_when_remediation_budget_exhausted(
 
     assert decision["continueLoop"] is False
     assert decision["state"] == "failed_with_remaining_work"
-    assert decision["reason"] == "max_attempts_exhausted"
+    assert decision["reason"] == "no_remediation_successor"
     assert decision["remainingWorkRef"] == "artifact://remaining-work/final"
     assert decision["hasRemainingRemediationStep"] is False
 

--- a/tests/unit/workflows/temporal/workflows/test_run_bounded_story_loop.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_bounded_story_loop.py
@@ -477,6 +477,60 @@ def test_continuation_decision_preserves_consumption_and_applies_explicit_grant(
     assert "budgetGrant" not in run._publish_context["boundedStoryLoop"]
 
 
+def test_continuation_seeds_no_progress_count_from_durable_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    run = MoonMindRunWorkflow()
+    monkeypatch.setattr(run, "_patched_or_false_outside_workflow", lambda _: True)
+    ordered_nodes = _explicit_remediation_chain(max_attempts=6)
+    gate = StepGateResult(
+        verdict="ADDITIONAL_WORK_NEEDED",
+        issues=({"requirement": "same gap", "status": "unmet"},),
+    )
+    first = run._bounded_story_loop_continuation_decision(
+        logical_step_id="verify-1",
+        gate_result=gate,
+        gate_result_ref="artifact://gate/1",
+        ordered_nodes=ordered_nodes,
+        current_index=2,
+    )
+    durable_state = first["durableLoopState"]
+    durable_state["consumed"]["consecutiveNoProgressAttempts"] = 1
+    durable_state["policy"]["consumed"]["consecutiveNoProgressAttempts"] = 1
+    run._publish_context["boundedStoryLoop"] = {
+        "budgets": {"maxConsecutiveNoProgressAttempts": 2},
+        "durableLoopState": durable_state,
+    }
+
+    decision = run._bounded_story_loop_continuation_decision(
+        logical_step_id="verify-2",
+        gate_result=gate,
+        gate_result_ref="artifact://gate/2",
+        ordered_nodes=ordered_nodes,
+        current_index=4,
+    )
+
+    assert decision["continueLoop"] is False
+    assert decision["reason"] == "semantic_no_progress_exhausted"
+    assert decision["budget"]["consumed"]["consecutiveNoProgressAttempts"] == 2
+
+
+def test_invalid_infrastructure_retry_telemetry_is_ignored() -> None:
+    run = MoonMindRunWorkflow()
+    decision = run._bounded_story_loop_continuation_decision(
+        logical_step_id="verify-initial",
+        gate_result=StepGateResult(
+            verdict="ADDITIONAL_WORK_NEEDED",
+            validated_refs={"infrastructureRetries": "unknown"},
+        ),
+        gate_result_ref="artifact://gate/1",
+        ordered_nodes=_explicit_remediation_chain(max_attempts=2),
+        current_index=0,
+    )
+
+    assert decision["budget"]["consumed"]["infrastructureRetries"] == 0
+
+
 def test_default_no_progress_policy_is_independent_of_remediation_budget_patch(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/workflows/temporal/workflows/test_run_bounded_story_loop.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_bounded_story_loop.py
@@ -425,6 +425,58 @@ def test_explicit_no_progress_policy_overrides_remediation_attempt_budget(
     assert decision["remediationBudget"]["remainingAttempts"] == 6
 
 
+def test_continuation_decision_preserves_consumption_and_applies_explicit_grant(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    run = MoonMindRunWorkflow()
+    monkeypatch.setattr(run, "_patched_or_false_outside_workflow", lambda _: True)
+    run._publish_context["boundedStoryLoop"] = {
+        "budgets": {
+            "maxAttempts": 6,
+            "maxConsecutiveNoProgressAttempts": 2,
+            "maxRepeatedFailedCommands": 2,
+            "maxUnsafeOrPolicyDeniedAttempts": 0,
+            "maxEvidenceRetries": 2,
+        },
+        "durableLoopState": {
+            "schemaVersion": "remediation-loop-state/v1",
+            "policy": {
+                "maxAttempts": 6,
+                "maxConsecutiveNoProgressAttempts": 2,
+                "maxRepeatedFailedCommands": 2,
+                "maxUnsafeOrPolicyDeniedAttempts": 0,
+                "maxEvidenceRetries": 2,
+                "consumed": {"attempts": 4, "evidenceRetries": 2},
+            },
+            "consumed": {"attempts": 4, "evidenceRetries": 2},
+            "grants": {},
+            "priorExhaustionReason": "evidence_retry_budget_exhausted",
+        },
+        "budgetGrant": {"evidenceRetries": 1},
+        "retryAccounting": {"evidenceRetries": 2},
+    }
+    gate = StepGateResult(
+        verdict="ADDITIONAL_WORK_NEEDED",
+        feedback="A bounded gap remains.",
+    )
+
+    decision = run._bounded_story_loop_continuation_decision(
+        logical_step_id="verify-1",
+        gate_result=gate,
+        gate_result_ref="artifact://gate/1",
+        ordered_nodes=_explicit_remediation_chain(max_attempts=6),
+        current_index=2,
+    )
+
+    state = decision["durableLoopState"]
+    assert state["consumed"]["attempts"] == 4
+    assert state["consumed"]["evidenceRetries"] == 2
+    assert state["policy"]["maxEvidenceRetries"] == 3
+    assert state["grants"] == {"evidenceRetries": 1}
+    assert state["priorExhaustionReason"] == "evidence_retry_budget_exhausted"
+    assert "budgetGrant" not in run._publish_context["boundedStoryLoop"]
+
+
 def test_default_no_progress_policy_is_independent_of_remediation_budget_patch(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/workflows/temporal/workflows/test_run_bounded_story_loop.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_bounded_story_loop.py
@@ -385,7 +385,7 @@ def test_semantic_no_progress_budget_stops_before_hard_attempt_maximum(
 
     assert decisions[1]["continueLoop"] is True
     assert decisions[2]["continueLoop"] is False
-    assert decisions[2]["reason"] == "no_progress_attempts_exhausted"
+    assert decisions[2]["reason"] == "semantic_no_progress_exhausted"
     assert decisions[2]["remediationBudget"]["maxAttempts"] == 6
     assert decisions[2]["remediationBudget"]["currentAttempt"] == 2
 
@@ -420,7 +420,7 @@ def test_explicit_no_progress_policy_overrides_remediation_attempt_budget(
     )
 
     assert decision["continueLoop"] is False
-    assert decision["reason"] == "no_progress_attempts_exhausted"
+    assert decision["reason"] == "semantic_no_progress_exhausted"
     assert decision["budget"]["maxConsecutiveNoProgressAttempts"] == 1
     assert decision["remediationBudget"]["remainingAttempts"] == 6
 
@@ -728,7 +728,7 @@ def test_parent_loop_honors_configured_no_progress_budget(
 
     assert second["continueLoop"] is True
     assert third["continueLoop"] is False
-    assert third["reason"] == "no_progress_attempts_exhausted"
+    assert third["reason"] == "semantic_no_progress_exhausted"
 
 
 def test_parent_loop_replay_before_progress_patch_keeps_legacy_continuation() -> None:

--- a/tests/unit/workflows/temporal/workflows/test_run_bounded_story_loop.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_bounded_story_loop.py
@@ -339,12 +339,13 @@ def test_parent_loop_stops_when_verification_makes_no_progress(
     )
 
     assert first["continueLoop"] is True
-    assert second["continueLoop"] is False
-    assert second["reason"] == "no_progress_attempts_exhausted"
+    assert second["continueLoop"] is True
+    assert second["reason"] == "verification_requested_remediation"
+    assert second["budget"]["consumed"]["consecutiveNoProgressAttempts"] == 1
     assert second["hasRemainingRemediationStep"] is True
 
 
-def test_explicit_remediation_budget_governs_repeated_verifier_results(
+def test_semantic_no_progress_budget_stops_before_hard_attempt_maximum(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Regression for mm:bd3dedc3-6cf3-4801-95b4-be177b70ef6b."""
@@ -377,16 +378,16 @@ def test_explicit_remediation_budget_governs_repeated_verifier_results(
     assert first_post_remediation["nextLogicalStepId"] == "remediate-2"
     assert first_post_remediation["budget"][
         "maxConsecutiveNoProgressAttempts"
-    ] == 6
+    ] == 2
     assert first_post_remediation["budget"]["consumed"][
         "consecutiveNoProgressAttempts"
     ] == 1
 
-    assert all(decision["continueLoop"] for decision in decisions[:-1])
-    assert decisions[-1]["continueLoop"] is False
-    assert decisions[-1]["reason"] == "max_attempts_exhausted"
-    assert decisions[-1]["remediationBudget"]["maxAttempts"] == 6
-    assert decisions[-1]["remediationBudget"]["currentAttempt"] == 6
+    assert decisions[1]["continueLoop"] is True
+    assert decisions[2]["continueLoop"] is False
+    assert decisions[2]["reason"] == "no_progress_attempts_exhausted"
+    assert decisions[2]["remediationBudget"]["maxAttempts"] == 6
+    assert decisions[2]["remediationBudget"]["currentAttempt"] == 2
 
 
 def test_explicit_no_progress_policy_overrides_remediation_attempt_budget(
@@ -424,7 +425,7 @@ def test_explicit_no_progress_policy_overrides_remediation_attempt_budget(
     assert decision["remediationBudget"]["remainingAttempts"] == 6
 
 
-def test_remediation_budget_patch_preserves_legacy_no_progress_stop(
+def test_default_no_progress_policy_is_independent_of_remediation_budget_patch(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     run = MoonMindRunWorkflow()
@@ -459,9 +460,9 @@ def test_remediation_budget_patch_preserves_legacy_no_progress_stop(
     )
 
     assert RUN_BOUNDED_STORY_LOOP_REMEDIATION_BUDGET_PATCH.endswith("-v1")
-    assert decision["continueLoop"] is False
-    assert decision["reason"] == "no_progress_attempts_exhausted"
-    assert decision["budget"]["maxConsecutiveNoProgressAttempts"] == 1
+    assert decision["continueLoop"] is True
+    assert decision["reason"] == "verification_requested_remediation"
+    assert decision["budget"]["maxConsecutiveNoProgressAttempts"] == 2
 
 
 def test_parent_loop_continues_when_verification_progress_changes(
@@ -523,7 +524,7 @@ def test_parent_loop_continues_when_verification_progress_changes(
     assert second["reason"] == "verification_requested_remediation"
 
 
-def test_parent_loop_progress_tracks_changed_verifier_feedback(
+def test_parent_loop_does_not_treat_changed_verifier_feedback_as_progress(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Sparse structured gates still carry progress in verifier feedback."""
@@ -572,7 +573,8 @@ def test_parent_loop_progress_tracks_changed_verifier_feedback(
         current_index=2,
     )
 
-    assert first["gate"]["progressSignature"] != second["gate"]["progressSignature"]
+    assert first["gate"]["progressVector"]["unresolvedGapDigest"] == second["gate"]["progressVector"]["unresolvedGapDigest"]
+    assert second["gate"]["progressVector"]["classification"] == "no_progress"
     assert second["continueLoop"] is True
     assert second["nextAttemptKind"] == "remediation"
 
@@ -610,7 +612,7 @@ def test_feedback_progress_patch_preserves_prior_history_signature(
     assert first.progress_signature == second.progress_signature
 
 
-def test_parent_loop_progress_tracks_remaining_work_refs(
+def test_parent_loop_does_not_treat_changed_remaining_work_refs_as_progress(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     workflow = MoonMindRunWorkflow()
@@ -655,7 +657,8 @@ def test_parent_loop_progress_tracks_remaining_work_refs(
         current_index=2,
     )
 
-    assert first["gate"]["progressSignature"] != second["gate"]["progressSignature"]
+    assert first["gate"]["progressVector"]["unresolvedGapDigest"] == second["gate"]["progressVector"]["unresolvedGapDigest"]
+    assert second["gate"]["progressVector"]["classification"] == "no_progress"
     assert second["continueLoop"] is True
 
 


### PR DESCRIPTION
Issue: MoonLadderStudios/MoonMind#3476

Closes MoonLadderStudios/MoonMind#3476

## Summary

- add a canonical `remediation-progress/v1` vector and evidence-based progress classification
- enforce independent semantic, failure, safety, provider, token, cost, and wall-clock stop budgets
- persist monotonic continuation state and use one continuation decision for routing and projections
- show remediation trends and the exhausted budget dimension in Workflow Detail

## Tests run

- `npm run ui:test -- frontend/src/entrypoints/workflow-detail.test.tsx` (passed: 198 tests)
- `python -m py_compile moonmind/workflows/temporal/bounded_story_loop.py moonmind/workflows/temporal/workflows/run.py` (passed)
- `git diff --check` (passed)
- `moonmind container python-tests tests/unit/workflows/temporal/test_bounded_story_loop.py tests/unit/workflows/temporal/workflows/test_run_bounded_story_loop.py` (not run: durable backend status returned HTTP 404 after submission)

## Remaining risks

- Focused Python unit and workflow-boundary tests could not complete in this runtime because the durable container job disappeared before status retrieval. The post-remediation verifier classified this as a non-blocking environment limitation after inspecting production wiring and test definitions.