### PR TITLE
Preserve draft publication after remediation stops

### DIFF
--- a/docs/Workflows/WorkflowPublishing.md
+++ b/docs/Workflows/WorkflowPublishing.md
@@ -198,6 +198,16 @@ before the push. The push command receives `GITHUB_TOKEN`, `GH_TOKEN`, and
 `GIT_TERMINAL_PROMPT=0` in its subprocess environment when a token is available,
 so managed publishing does not depend on machine-level git credential caches.
 
+The managed push activity is the authority for whether a publishable repository
+candidate exists. After a successful push (including an already-current remote
+branch), it emits `acceptedRepositoryEvidence` with the work branch, base branch,
+head commit, commits-ahead count, authorization/contamination disposition, and
+remote-verification result. Verification Steps and terminal workflow gates
+consume that typed envelope instead of reconstructing publication feasibility
+from raw `push_*` metadata or agent prose. If the activity cannot produce a
+complete, internally consistent envelope, draft and ready-for-review publication
+remain blocked with an explicit artifact-backed handoff.
+
 ### Safety Guard
 
 Before pushing, the runtime resolves the current branch name (`git rev-parse --abbrev-ref HEAD`) and **refuses to push** if the branch is:

--- a/docs/Workflows/WorkflowPublishing.md
+++ b/docs/Workflows/WorkflowPublishing.md
@@ -208,6 +208,13 @@ from raw `push_*` metadata or agent prose. If the activity cannot produce a
 complete, internally consistent envelope, draft and ready-for-review publication
 remain blocked with an explicit artifact-backed handoff.
 
+Before measuring commits, the activity refreshes the exact `origin/<base>`
+tracking ref used as the publication base. After pushing, it queries the live
+remote branch and requires its head to equal the local candidate head. A base
+refresh failure, remote-head mismatch, or indeterminate commits-ahead count
+downgrades the raw push result to a failed publication result; it never emits
+accepted evidence or permits native PR creation from that incomplete state.
+
 ### Safety Guard
 
 Before pushing, the runtime resolves the current branch name (`git rev-parse --abbrev-ref HEAD`) and **refuses to push** if the branch is:

--- a/moonmind/schemas/temporal_activity_models.py
+++ b/moonmind/schemas/temporal_activity_models.py
@@ -386,7 +386,7 @@ class AcceptedRepositoryEvidence(BaseModel):
     candidate_contaminated: Literal[False] = Field(
         False, alias="candidateContaminated"
     )
-    remote_verified: Literal[True] = Field(True, alias="remoteVerified")
+    remote_verified: Literal[True] = Field(..., alias="remoteVerified")
     authority: Literal["agent_runtime.fetch_result"] = "agent_runtime.fetch_result"
 
     @model_validator(mode="after")

--- a/moonmind/schemas/temporal_activity_models.py
+++ b/moonmind/schemas/temporal_activity_models.py
@@ -366,6 +366,46 @@ class AgentRuntimeTerminalCheckpointResult(BaseModel):
     error: str | None = None
 
 
+class AcceptedRepositoryEvidence(BaseModel):
+    """Authoritative repository state emitted by the managed push boundary."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    schema_version: Literal["accepted-repository-evidence/v1"] = Field(
+        "accepted-repository-evidence/v1", alias="schemaVersion"
+    )
+    push_status: Literal["pushed", "no_commits"] = Field(..., alias="pushStatus")
+    branch: str = Field(..., min_length=1)
+    base_branch: str = Field(..., alias="baseBranch", min_length=1)
+    head_sha: str = Field(..., alias="headSha", min_length=1)
+    commits_ahead_of_base: int = Field(..., alias="commitsAheadOfBase", ge=0)
+    repository_changed: bool = Field(..., alias="repositoryChanged")
+    publication_authorized: Literal[True] = Field(
+        True, alias="publicationAuthorized"
+    )
+    candidate_contaminated: Literal[False] = Field(
+        False, alias="candidateContaminated"
+    )
+    remote_verified: Literal[True] = Field(True, alias="remoteVerified")
+    authority: Literal["agent_runtime.fetch_result"] = "agent_runtime.fetch_result"
+
+    @model_validator(mode="after")
+    def _validate_push_evidence(self) -> "AcceptedRepositoryEvidence":
+        self.branch = self.branch.strip()
+        self.base_branch = self.base_branch.strip()
+        self.head_sha = self.head_sha.strip()
+        if not self.branch or not self.base_branch or not self.head_sha:
+            raise ValueError("accepted repository evidence requires git identities")
+        expected_changed = self.push_status == "pushed"
+        if self.repository_changed != expected_changed:
+            raise ValueError("push status and repositoryChanged disagree")
+        if expected_changed and self.commits_ahead_of_base < 1:
+            raise ValueError("pushed repository evidence requires commits over base")
+        if not expected_changed and self.commits_ahead_of_base != 0:
+            raise ValueError("no-commit repository evidence cannot be ahead of base")
+        return self
+
+
 class ResiliencePolicyCompileInput(BaseModel):
     """Input for the ``resilience.compile_policy`` activity (MM-880).
 

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -12037,6 +12037,7 @@ class TemporalAgentRuntimeActivities:
                 headSha=push_info.get("push_head_sha"),
                 commitsAheadOfBase=push_info.get("push_commit_count"),
                 repositoryChanged=push_status == "pushed",
+                remoteVerified=push_info.get("remote_verified"),
             )
         except ValidationError:
             logger.warning(
@@ -12518,6 +12519,16 @@ class TemporalAgentRuntimeActivities:
                     meta["acceptedRepositoryEvidence"] = (
                         accepted_repository_evidence
                     )
+                elif push_info.get("push_status") in {"pushed", "no_commits"}:
+                    push_info = {
+                        **push_info,
+                        "push_original_status": push_info["push_status"],
+                        "push_status": "failed",
+                        "push_error": (
+                            "managed push did not produce authoritative "
+                            "repository evidence"
+                        ),
+                    }
                 meta.update(push_info)
 
             # Enrich result with pull_request_url detected from workspace git
@@ -13903,6 +13914,21 @@ class TemporalAgentRuntimeActivities:
                 )
             )
             base_ref = f"origin/{base_branch_name}"
+            if not await self._refresh_workspace_remote_base_ref(
+                workspace=workspace,
+                base_branch=base_branch_name,
+                run_id=run_id,
+                env=auth_command_env,
+            ):
+                return {
+                    "push_status": "failed",
+                    "push_branch": current_branch,
+                    "push_base_branch": base_branch_name,
+                    "push_base_ref": base_ref,
+                    "push_error": (
+                        f"could not refresh authoritative publish base '{base_ref}'"
+                    ),
+                }
             commit_count: int | None = None
             if same_branch_publish:
                 commit_count = await self._count_branch_commits_ahead(
@@ -13923,6 +13949,31 @@ class TemporalAgentRuntimeActivities:
                     run_id=run_id,
                     env=command_env,
                 )
+                remote_verified = await self._verify_workspace_remote_branch_head(
+                    workspace=workspace,
+                    branch=current_branch,
+                    expected_head_sha=head_sha,
+                    run_id=run_id,
+                    env=auth_command_env,
+                )
+                if not remote_verified:
+                    logger.warning(
+                        "Post-agent git push for run %s did not verify the "
+                        "exact remote head for branch %s.",
+                        run_id,
+                        current_branch,
+                    )
+                    return {
+                        "push_status": "failed",
+                        "push_branch": current_branch,
+                        "push_base_branch": base_branch_name,
+                        "push_base_ref": base_ref,
+                        "push_head_sha": head_sha,
+                        "remote_verified": False,
+                        "push_error": (
+                            "post-push remote head did not match the local head"
+                        ),
+                    }
 
                 final_commit_count = precomputed_commit_count
                 # Verify the branch actually has commits over the publish base.
@@ -13937,6 +13988,19 @@ class TemporalAgentRuntimeActivities:
                         run_id=run_id,
                         env=command_env,
                     )
+                if final_commit_count < 0:
+                    return {
+                        "push_status": "failed",
+                        "push_branch": current_branch,
+                        "push_base_branch": base_branch_name,
+                        "push_base_ref": base_ref,
+                        "push_head_sha": head_sha,
+                        "remote_verified": True,
+                        "push_error": (
+                            "could not measure commits over the authoritative "
+                            "publish base"
+                        ),
+                    }
 
                 if final_commit_count == 0:
                     logger.warning(
@@ -13952,6 +14016,7 @@ class TemporalAgentRuntimeActivities:
                         "push_base_branch": base_branch_name,
                         "push_base_ref": base_ref,
                         "push_commit_count": 0,
+                        "remote_verified": True,
                     }
                     if head_sha:
                         result["push_head_sha"] = head_sha
@@ -13969,6 +14034,7 @@ class TemporalAgentRuntimeActivities:
                     "push_branch": current_branch,
                     "push_base_branch": base_branch_name,
                     "push_base_ref": base_ref,
+                    "remote_verified": True,
                 }
                 result.update(commit_info)
                 if extra:
@@ -14218,6 +14284,62 @@ class TemporalAgentRuntimeActivities:
                 "push_error": str(exc),
             }
 
+    async def _refresh_workspace_remote_base_ref(
+        self,
+        *,
+        workspace: str,
+        base_branch: str,
+        run_id: str,
+        env: Mapping[str, str],
+    ) -> bool:
+        """Refresh the exact remote base used for publication measurements."""
+
+        branch_name = str(base_branch or "").strip()
+        if not branch_name:
+            return False
+        remote_ref = f"refs/remotes/origin/{branch_name}"
+        try:
+            proc = await _create_managed_agent_subprocess(
+                *self._workspace_git_command(
+                    workspace,
+                    "fetch",
+                    "--no-tags",
+                    "origin",
+                    f"+refs/heads/{branch_name}:{remote_ref}",
+                ),
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                env=env,
+            )
+            try:
+                await asyncio.wait_for(proc.communicate(), timeout=60)
+            except asyncio.TimeoutError:
+                proc.kill()
+                await proc.wait()
+                logger.warning(
+                    "Timed out refreshing publish base %s for run %s.",
+                    branch_name,
+                    run_id,
+                )
+                return False
+            if proc.returncode == 0:
+                return True
+            logger.warning(
+                "Could not refresh publish base %s for run %s (rc=%s).",
+                branch_name,
+                run_id,
+                proc.returncode,
+            )
+            return False
+        except Exception:
+            logger.warning(
+                "Failed to refresh publish base %s for run %s.",
+                branch_name,
+                run_id,
+                exc_info=True,
+            )
+            return False
+
     async def _resolve_workspace_remote_branch_sha(
         self,
         *,
@@ -14247,6 +14369,26 @@ class TemporalAgentRuntimeActivities:
         if remote_sha:
             return remote_sha
 
+        return await self._query_workspace_remote_branch_sha(
+            workspace=workspace,
+            branch=branch_name,
+            run_id=run_id,
+            env=env,
+        )
+
+    async def _query_workspace_remote_branch_sha(
+        self,
+        *,
+        workspace: str,
+        branch: str,
+        run_id: str,
+        env: Mapping[str, str],
+    ) -> str | None:
+        """Read the live remote branch head without trusting a tracking ref."""
+
+        branch_name = str(branch or "").strip()
+        if not branch_name:
+            return None
         try:
             proc = await _create_managed_agent_subprocess(
                 *self._workspace_git_command(
@@ -14289,6 +14431,28 @@ class TemporalAgentRuntimeActivities:
                 exc_info=True,
             )
             return None
+
+    async def _verify_workspace_remote_branch_head(
+        self,
+        *,
+        workspace: str,
+        branch: str,
+        expected_head_sha: str | None,
+        run_id: str,
+        env: Mapping[str, str],
+    ) -> bool:
+        """Verify the live remote branch points at the exact local candidate."""
+
+        expected = str(expected_head_sha or "").strip()
+        if not expected:
+            return False
+        remote_head_sha = await self._query_workspace_remote_branch_sha(
+            workspace=workspace,
+            branch=branch,
+            run_id=run_id,
+            env=env,
+        )
+        return remote_head_sha == expected
 
     async def _resolve_workspace_ref_sha(
         self,

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -76,6 +76,7 @@ from moonmind.schemas.managed_checkpoint_models import (
     ManagedWorkspaceCheckpointCaptureResult,
 )
 from moonmind.schemas.temporal_activity_models import (
+    AcceptedRepositoryEvidence,
     AgentRuntimeCancelInput,
     AgentRuntimeFetchResultInput,
     AgentRuntimeStatusInput,
@@ -12019,6 +12020,34 @@ class TemporalAgentRuntimeActivities:
         await self._cleanup_run_support_best_effort(run_id)
         self._cleanup_deferred_run_files_best_effort(run_id)
 
+    @staticmethod
+    def _accepted_repository_evidence(
+        push_info: Mapping[str, Any],
+    ) -> dict[str, Any] | None:
+        """Promote a successful managed push into the workflow gate contract."""
+
+        push_status = str(push_info.get("push_status") or "").strip()
+        if push_status not in {"pushed", "no_commits"}:
+            return None
+        try:
+            evidence = AcceptedRepositoryEvidence(
+                pushStatus=push_status,
+                branch=push_info.get("push_branch"),
+                baseBranch=push_info.get("push_base_branch"),
+                headSha=push_info.get("push_head_sha"),
+                commitsAheadOfBase=push_info.get("push_commit_count"),
+                repositoryChanged=push_status == "pushed",
+            )
+        except ValidationError:
+            logger.warning(
+                "Managed git push completed with status %s but lacked the "
+                "bounded identity/count fields required for accepted "
+                "repository evidence.",
+                push_status,
+            )
+            return None
+        return evidence.model_dump(mode="json", by_alias=True)
+
     async def agent_runtime_status(
         self,
         request: Any = None,
@@ -12348,6 +12377,11 @@ class TemporalAgentRuntimeActivities:
             # Build merged metadata from the typed result, then enrich with
             # push/PR URL info using model_copy to preserve the typed contract.
             meta = dict(result.metadata or {})
+            # Provider/agent metadata is untrusted at this authority handoff.
+            # Only the managed git-push boundary below may emit accepted
+            # repository evidence.
+            meta.pop("acceptedRepositoryEvidence", None)
+            meta.pop("accepted_repository_evidence", None)
             if record is not None:
                 meta.setdefault("agentRunId", record.run_id)
                 if record.stdout_artifact_ref:
@@ -12477,6 +12511,13 @@ class TemporalAgentRuntimeActivities:
                     )
                 except Exception:
                     raise
+                accepted_repository_evidence = self._accepted_repository_evidence(
+                    push_info
+                )
+                if accepted_repository_evidence is not None:
+                    meta["acceptedRepositoryEvidence"] = (
+                        accepted_repository_evidence
+                    )
                 meta.update(push_info)
 
             # Enrich result with pull_request_url detected from workspace git

--- a/tests/integration/reliability/replays/draft-publication-authority-gap/expected-outcome.json
+++ b/tests/integration/reliability/replays/draft-publication-authority-gap/expected-outcome.json
@@ -1,0 +1,7 @@
+{
+  "acceptedEvidenceSchemaVersion": "accepted-repository-evidence/v1",
+  "acceptedEvidenceAuthority": "agent_runtime.fetch_result",
+  "publicationFeasible": true,
+  "publicationFeasibilityReason": "verified_remote_head",
+  "terminalHandoff": "draft_publication"
+}

--- a/tests/integration/reliability/replays/draft-publication-authority-gap/manifest.json
+++ b/tests/integration/reliability/replays/draft-publication-authority-gap/manifest.json
@@ -11,7 +11,8 @@
         "push_branch": "github-issue-implement-moonladderstudios-fdea5b2e",
         "push_base_branch": "main",
         "push_head_sha": "0e21b2035300a8d62fc25153ad1d6ac45741dcbf",
-        "push_commit_count": 3
+        "push_commit_count": 3,
+        "remote_verified": true
       }
     },
     {
@@ -21,7 +22,8 @@
         "push_branch": "github-issue-implement-moonladderstudios-1c91487a",
         "push_base_branch": "main",
         "push_head_sha": "669cc50ce4b2aba63f0d68ecf1abf4daa793f9b8",
-        "push_commit_count": 3
+        "push_commit_count": 3,
+        "remote_verified": true
       }
     }
   ]

--- a/tests/integration/reliability/replays/draft-publication-authority-gap/manifest.json
+++ b/tests/integration/reliability/replays/draft-publication-authority-gap/manifest.json
@@ -1,0 +1,28 @@
+{
+  "schemaVersion": "escaped-failure-replay/v1",
+  "incident": "verified pushed branches were orphaned after MoonSpec remediation exhaustion",
+  "publishMode": "pr",
+  "draftPublicationPolicy": "draft_pr_on_additional_work_needed",
+  "cases": [
+    {
+      "workflowId": "mm:9d9c591c-274e-4deb-8a69-2f0d5526c7ca",
+      "pushResult": {
+        "push_status": "pushed",
+        "push_branch": "github-issue-implement-moonladderstudios-fdea5b2e",
+        "push_base_branch": "main",
+        "push_head_sha": "0e21b2035300a8d62fc25153ad1d6ac45741dcbf",
+        "push_commit_count": 3
+      }
+    },
+    {
+      "workflowId": "mm:40e2387a-5e26-47be-a6e5-43635efca755",
+      "pushResult": {
+        "push_status": "pushed",
+        "push_branch": "github-issue-implement-moonladderstudios-1c91487a",
+        "push_base_branch": "main",
+        "push_head_sha": "669cc50ce4b2aba63f0d68ecf1abf4daa793f9b8",
+        "push_commit_count": 3
+      }
+    }
+  ]
+}

--- a/tests/integration/reliability/test_escaped_failure_journeys.py
+++ b/tests/integration/reliability/test_escaped_failure_journeys.py
@@ -166,6 +166,42 @@ async def test_completed_batch_turn_without_fanout_evidence_fails() -> None:
     assert expected["parentState"] == "failed"
 
 
+async def test_verified_remediation_push_reaches_draft_publication_handoff() -> None:
+    """Replay the two orphaned branches through the production authority seam."""
+    replay_id = "draft-publication-authority-gap"
+    manifest = load_replay(replay_id, "manifest.json")
+    expected = load_replay(replay_id, "expected-outcome.json")
+
+    for case in manifest["cases"]:
+        workflow_run = MoonMindRunWorkflow()
+        raw_result = {"outputs": case["pushResult"]}
+        assert workflow_run._publication_feasibility(raw_result)["reason"] == (
+            "publication_state_ambiguous"
+        )
+
+        accepted = TemporalAgentRuntimeActivities._accepted_repository_evidence(
+            case["pushResult"]
+        )
+        assert accepted is not None
+        assert accepted["schemaVersion"] == expected[
+            "acceptedEvidenceSchemaVersion"
+        ]
+        assert accepted["authority"] == expected["acceptedEvidenceAuthority"]
+
+        feasibility = workflow_run._publication_feasibility(
+            {"outputs": {"acceptedRepositoryEvidence": accepted}}
+        )
+        assert feasibility["feasible"] is expected["publicationFeasible"]
+        assert feasibility["reason"] == expected[
+            "publicationFeasibilityReason"
+        ]
+        assert workflow_run._terminal_gate_handoff_kind(
+            publish_mode=manifest["publishMode"],
+            draft_publication_policy=manifest["draftPublicationPolicy"],
+            publication_feasible=feasibility["feasible"],
+        ) == expected["terminalHandoff"]
+
+
 async def test_completed_batch_turn_is_rejected_at_agent_run_boundary(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/services/temporal/test_fetch_result_push.py
+++ b/tests/unit/services/temporal/test_fetch_result_push.py
@@ -58,6 +58,20 @@ def _make_subprocess_result(
         args=[], returncode=returncode, stdout=stdout, stderr=stderr,
     )
 
+def _verified_push_info(
+    *,
+    branch: str = "my-branch",
+    base_branch: str = "main",
+) -> dict[str, object]:
+    return {
+        "push_status": "pushed",
+        "push_branch": branch,
+        "push_base_branch": base_branch,
+        "push_head_sha": "verified-head-sha",
+        "push_commit_count": 1,
+        "remote_verified": True,
+    }
+
 def test_detect_pr_url_uses_workspace_command_shims_and_resolved_token(tmp_path):
     store = _make_mock_store(workspace_path=str(tmp_path / "run-1" / "repo"))
     activities = TemporalAgentRuntimeActivities(run_store=store)
@@ -115,6 +129,32 @@ def test_parse_git_status_paths_rejects_truncated_rename_record() -> None:
 
 class TestPushWorkspaceBranch:
     """Tests for TemporalAgentRuntimeActivities._push_workspace_branch."""
+
+    @pytest.fixture(autouse=True)
+    def _stub_unrelated_publication_authority_calls(self, request):
+        if request.node.name in {
+            "test_push_refreshes_authoritative_base_before_remote_write",
+            "test_push_blocks_when_authoritative_base_cannot_refresh",
+            "test_push_blocks_when_live_remote_head_does_not_match",
+            "test_live_remote_head_verification_requires_exact_sha",
+        }:
+            yield
+            return
+        with (
+            patch.object(
+                TemporalAgentRuntimeActivities,
+                "_refresh_workspace_remote_base_ref",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch.object(
+                TemporalAgentRuntimeActivities,
+                "_verify_workspace_remote_branch_head",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+        ):
+            yield
 
     @pytest.mark.asyncio
     async def test_push_skipped_no_store(self):
@@ -868,6 +908,183 @@ class TestPushWorkspaceBranch:
         assert result["push_base_ref"] == "origin/trunk"
         assert result["push_head_sha"] == "pushed-head-sha"
         assert "push_error" not in result
+
+    @pytest.mark.asyncio
+    async def test_push_refreshes_authoritative_base_before_remote_write(self):
+        store = _make_mock_store()
+        activities = TemporalAgentRuntimeActivities(run_store=store)
+        recorded_calls: list[tuple[object, ...]] = []
+
+        async def _mock_exec(*args, **kwargs):
+            del kwargs
+            recorded_calls.append(args)
+            proc = AsyncMock()
+            proc.communicate = AsyncMock(return_value=(b"", b""))
+            proc.returncode = 0
+            return proc
+
+        with patch("asyncio.create_subprocess_exec", side_effect=_mock_exec):
+            refreshed = await activities._refresh_workspace_remote_base_ref(
+                workspace="/work/agent_jobs/run-1/repo",
+                base_branch="main",
+                run_id="run-1",
+                env={},
+            )
+
+        assert refreshed is True
+        assert list(recorded_calls[0][-4:]) == [
+            "fetch",
+            "--no-tags",
+            "origin",
+            "+refs/heads/main:refs/remotes/origin/main",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_push_blocks_when_authoritative_base_cannot_refresh(self):
+        store = _make_mock_store()
+        activities = TemporalAgentRuntimeActivities(run_store=store)
+        recorded_calls: list[tuple[object, ...]] = []
+
+        async def _mock_exec(*args, **kwargs):
+            del kwargs
+            recorded_calls.append(args)
+            proc = AsyncMock()
+            proc.communicate = AsyncMock(
+                return_value=(b"feature/base-refresh\n", b"")
+            )
+            proc.returncode = 0
+            return proc
+
+        with (
+            patch("asyncio.create_subprocess_exec", side_effect=_mock_exec),
+            patch.object(
+                activities,
+                "_commit_workspace_changes_if_needed",
+                new_callable=AsyncMock,
+                return_value={},
+            ),
+            patch.object(
+                activities,
+                "_resolve_workspace_default_branch",
+                new_callable=AsyncMock,
+                return_value="main",
+            ),
+            patch.object(
+                activities,
+                "_refresh_workspace_remote_base_ref",
+                new_callable=AsyncMock,
+                return_value=False,
+            ) as refresh_base,
+        ):
+            result = await activities._push_workspace_branch("run-1")
+
+        refresh_base.assert_awaited_once()
+        assert result["push_status"] == "failed"
+        assert "authoritative publish base" in result["push_error"]
+        assert not any("push" in call for call in recorded_calls)
+
+    @pytest.mark.asyncio
+    async def test_push_blocks_when_live_remote_head_does_not_match(self):
+        store = _make_mock_store()
+        activities = TemporalAgentRuntimeActivities(run_store=store)
+        recorded_calls: list[tuple[object, ...]] = []
+
+        async def _mock_exec(*args, **kwargs):
+            del kwargs
+            recorded_calls.append(args)
+            proc = AsyncMock()
+            if len(recorded_calls) == 1:
+                proc.communicate = AsyncMock(
+                    return_value=(b"feature/remote-mismatch\n", b"")
+                )
+            else:
+                proc.communicate = AsyncMock(return_value=(b"", b""))
+            proc.returncode = 0
+            return proc
+
+        with (
+            patch("asyncio.create_subprocess_exec", side_effect=_mock_exec),
+            patch.object(
+                activities,
+                "_commit_workspace_changes_if_needed",
+                new_callable=AsyncMock,
+                return_value={},
+            ),
+            patch.object(
+                activities,
+                "_resolve_workspace_default_branch",
+                new_callable=AsyncMock,
+                return_value="main",
+            ),
+            patch.object(
+                activities,
+                "_refresh_workspace_remote_base_ref",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch.object(
+                activities,
+                "_resolve_workspace_remote_branch_sha",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch.object(
+                activities,
+                "_scan_workspace_push_range",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch.object(
+                activities,
+                "_resolve_workspace_head_sha",
+                new_callable=AsyncMock,
+                return_value="local-head",
+            ),
+            patch.object(
+                activities,
+                "_verify_workspace_remote_branch_head",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+        ):
+            result = await activities._push_workspace_branch("run-1")
+
+        assert result["push_status"] == "failed"
+        assert result["remote_verified"] is False
+        assert "remote head did not match" in result["push_error"]
+        assert any("push" in call for call in recorded_calls)
+
+    @pytest.mark.asyncio
+    async def test_live_remote_head_verification_requires_exact_sha(self):
+        activities = TemporalAgentRuntimeActivities(run_store=_make_mock_store())
+
+        with patch.object(
+            activities,
+            "_query_workspace_remote_branch_sha",
+            new_callable=AsyncMock,
+            side_effect=["expected-head", "different-head", None],
+        ):
+            assert await activities._verify_workspace_remote_branch_head(
+                workspace="/work/agent_jobs/run-1/repo",
+                branch="feature/exact-head",
+                expected_head_sha="expected-head",
+                run_id="run-1",
+                env={},
+            )
+            assert not await activities._verify_workspace_remote_branch_head(
+                workspace="/work/agent_jobs/run-1/repo",
+                branch="feature/exact-head",
+                expected_head_sha="expected-head",
+                run_id="run-1",
+                env={},
+            )
+            assert not await activities._verify_workspace_remote_branch_head(
+                workspace="/work/agent_jobs/run-1/repo",
+                branch="feature/exact-head",
+                expected_head_sha="expected-head",
+                run_id="run-1",
+                env={},
+            )
 
     @pytest.mark.asyncio
     async def test_push_blocks_high_security_scan_before_git_push(self, monkeypatch):
@@ -1849,8 +2066,8 @@ class TestPushWorkspaceBranch:
         assert warning_mock.call_args.args[1] == str(workspace)
 
     @pytest.mark.asyncio
-    async def test_push_revlist_failure_falls_through(self):
-        """When rev-list --count raises, we fall through to 'pushed' (safe default)."""
+    async def test_push_revlist_failure_blocks_publication(self):
+        """An indeterminate commits-ahead count cannot authorize publication."""
         store = _make_mock_store()
         activities = TemporalAgentRuntimeActivities(run_store=store)
         call_count = 0
@@ -1883,9 +2100,10 @@ class TestPushWorkspaceBranch:
 
         with patch("asyncio.create_subprocess_exec", side_effect=_mock_exec):
             result = await activities._push_workspace_branch("run-1")
-        assert result["push_status"] == "pushed"
+        assert result["push_status"] == "failed"
         assert result["push_branch"] == "auto-abc123"
         assert "push_commit_count" not in result
+        assert "could not measure commits" in result["push_error"]
 
     @pytest.mark.asyncio
     async def test_push_resolves_github_token_and_injects_push_env(self):
@@ -2029,8 +2247,8 @@ class TestPushWorkspaceBranch:
         assert captured_push_env["GH_TOKEN"] == "resolved-push-token"
 
     @pytest.mark.asyncio
-    async def test_push_revlist_nonzero_returncode_falls_through(self):
-        """Non-zero rev-list returncode falls through to 'pushed' instead of false no_commits."""
+    async def test_push_revlist_nonzero_returncode_blocks_publication(self):
+        """A failed rev-list cannot be treated as a publishable candidate."""
         store = _make_mock_store()
         activities = TemporalAgentRuntimeActivities(run_store=store)
         call_count = 0
@@ -2064,10 +2282,10 @@ class TestPushWorkspaceBranch:
 
         with patch("asyncio.create_subprocess_exec", side_effect=_mock_exec):
             result = await activities._push_workspace_branch("run-1")
-        # Should NOT be no_commits; should fall through to pushed
-        assert result["push_status"] == "pushed"
+        assert result["push_status"] == "failed"
         assert result["push_branch"] == "auto-abc123"
         assert "push_commit_count" not in result
+        assert "could not measure commits" in result["push_error"]
 
     @pytest.mark.asyncio
     async def test_push_revlist_uses_target_branch(self):
@@ -2138,6 +2356,7 @@ class TestFetchResultPushIntegration:
                     "push_base_branch": "main",
                     "push_head_sha": "abc123",
                     "push_commit_count": 2,
+                    "remote_verified": True,
                 },
             ),
             patch.object(
@@ -2176,6 +2395,71 @@ class TestFetchResultPushIntegration:
             "remoteVerified": True,
             "authority": "agent_runtime.fetch_result",
         }
+
+    def test_accepted_evidence_requires_remote_head_verification(self):
+        """A local push result cannot claim an accepted remote candidate."""
+        activities = TemporalAgentRuntimeActivities(run_store=_make_mock_store())
+
+        accepted = activities._accepted_repository_evidence(
+            {
+                "push_status": "pushed",
+                "push_branch": "partial-work",
+                "push_base_branch": "main",
+                "push_head_sha": "abc123",
+                "push_commit_count": 2,
+                "remote_verified": False,
+            }
+        )
+
+        assert accepted is None
+
+    @pytest.mark.asyncio
+    async def test_fetch_result_blocks_incomplete_managed_push_evidence(self):
+        """Raw pushed status cannot bypass the typed publication boundary."""
+        store = _make_mock_store()
+        activities = TemporalAgentRuntimeActivities(run_store=store)
+
+        with (
+            patch.object(
+                activities,
+                "_push_workspace_branch",
+                new_callable=AsyncMock,
+                return_value={
+                    "push_status": "pushed",
+                    "push_branch": "partial-work",
+                    "push_base_branch": "main",
+                    "push_head_sha": "abc123",
+                    "push_commit_count": 2,
+                    "remote_verified": False,
+                },
+            ),
+            patch.object(
+                activities,
+                "_detect_pr_url_from_workspace",
+                return_value=None,
+            ),
+            patch.object(
+                activities,
+                "_resolve_workspace_push_github_token",
+                new_callable=AsyncMock,
+                return_value="resolved-token",
+            ),
+            patch(
+                "moonmind.workflows.temporal.activity_runtime.ManagedAgentAdapter",
+            ) as MockAdapter,
+        ):
+            MockAdapter.return_value.fetch_result = AsyncMock(
+                return_value=AgentRunResult(summary="done", failure_class=None)
+            )
+
+            result = await activities.agent_runtime_fetch_result(
+                {"run_id": "run-1", "agent_id": "claude", "publish_mode": "pr"},
+            )
+
+        assert "acceptedRepositoryEvidence" not in result.metadata
+        assert result.metadata["push_status"] == "failed"
+        assert result.metadata["push_original_status"] == "pushed"
+        assert "authoritative repository evidence" in result.metadata["push_error"]
 
     @pytest.mark.asyncio
     async def test_fetch_result_rejects_provider_authored_repository_evidence(self):
@@ -2238,7 +2522,7 @@ class TestFetchResultPushIntegration:
             patch.object(
                 activities, "_push_workspace_branch",
                 new_callable=AsyncMock,
-                return_value={"push_status": "pushed", "push_branch": "my-branch"},
+                return_value=_verified_push_info(),
             ) as mock_push,
             patch.object(
                 activities, "_detect_pr_url_from_workspace",
@@ -2283,8 +2567,10 @@ class TestFetchResultPushIntegration:
                 "_push_workspace_branch",
                 new_callable=AsyncMock,
                 return_value={
-                    "push_status": "pushed",
-                    "push_branch": "feature/existing",
+                    **_verified_push_info(
+                        branch="feature/existing",
+                        base_branch="feature/existing",
+                    ),
                 },
             ) as mock_push,
             patch.object(
@@ -2717,7 +3003,7 @@ class TestFetchResultPushIntegration:
                 activities,
                 "_push_workspace_branch",
                 new_callable=AsyncMock,
-                return_value={"push_status": "pushed", "push_branch": "my-branch"},
+                return_value=_verified_push_info(),
             ) as mock_push,
             patch.object(
                 activities, "_detect_pr_url_from_workspace",
@@ -2810,7 +3096,7 @@ class TestFetchResultPushIntegration:
             patch.object(
                 activities, "_push_workspace_branch",
                 new_callable=AsyncMock,
-                return_value={"push_status": "pushed", "push_branch": "my-branch"},
+                return_value=_verified_push_info(),
             ),
             patch.object(
                 activities, "_detect_pr_url_from_workspace",
@@ -2859,7 +3145,7 @@ class TestFetchResultPushIntegration:
         async def _push_side_effect(*_args, **_kwargs):
             launcher.cleanup_run_support.assert_not_awaited()
             supervisor.cleanup_deferred_run_files.assert_not_called()
-            return {"push_status": "pushed", "push_branch": "my-branch"}
+            return _verified_push_info()
 
         with (
             patch.object(
@@ -2909,7 +3195,7 @@ class TestFetchResultPushIntegration:
             patch.object(
                 activities, "_push_workspace_branch",
                 new_callable=AsyncMock,
-                return_value={"push_status": "pushed", "push_branch": "my-branch"},
+                return_value=_verified_push_info(),
             ),
             patch.object(
                 activities,

--- a/tests/unit/services/temporal/test_fetch_result_push.py
+++ b/tests/unit/services/temporal/test_fetch_result_push.py
@@ -2122,6 +2122,113 @@ class TestFetchResultPushIntegration:
     """Tests for publish_mode-aware git push inside fetch_result."""
 
     @pytest.mark.asyncio
+    async def test_fetch_result_promotes_verified_push_to_accepted_evidence(self):
+        """The workflow gate receives typed evidence from the push authority."""
+        store = _make_mock_store()
+        activities = TemporalAgentRuntimeActivities(run_store=store)
+
+        with (
+            patch.object(
+                activities,
+                "_push_workspace_branch",
+                new_callable=AsyncMock,
+                return_value={
+                    "push_status": "pushed",
+                    "push_branch": "partial-work",
+                    "push_base_branch": "main",
+                    "push_head_sha": "abc123",
+                    "push_commit_count": 2,
+                },
+            ),
+            patch.object(
+                activities,
+                "_detect_pr_url_from_workspace",
+                return_value=None,
+            ),
+            patch.object(
+                activities,
+                "_resolve_workspace_push_github_token",
+                new_callable=AsyncMock,
+                return_value="resolved-token",
+            ),
+            patch(
+                "moonmind.workflows.temporal.activity_runtime.ManagedAgentAdapter",
+            ) as MockAdapter,
+        ):
+            MockAdapter.return_value.fetch_result = AsyncMock(
+                return_value=AgentRunResult(summary="done", failure_class=None)
+            )
+
+            result = await activities.agent_runtime_fetch_result(
+                {"run_id": "run-1", "agent_id": "claude", "publish_mode": "pr"},
+            )
+
+        assert result.metadata["acceptedRepositoryEvidence"] == {
+            "schemaVersion": "accepted-repository-evidence/v1",
+            "pushStatus": "pushed",
+            "branch": "partial-work",
+            "baseBranch": "main",
+            "headSha": "abc123",
+            "commitsAheadOfBase": 2,
+            "repositoryChanged": True,
+            "publicationAuthorized": True,
+            "candidateContaminated": False,
+            "remoteVerified": True,
+            "authority": "agent_runtime.fetch_result",
+        }
+
+    @pytest.mark.asyncio
+    async def test_fetch_result_rejects_provider_authored_repository_evidence(self):
+        """Untrusted metadata cannot authorize the terminal publish gate."""
+        store = _make_mock_store()
+        activities = TemporalAgentRuntimeActivities(run_store=store)
+
+        with (
+            patch.object(
+                activities,
+                "_push_workspace_branch",
+                new_callable=AsyncMock,
+                return_value={
+                    "push_status": "failed",
+                    "push_error": "remote head verification failed",
+                },
+            ),
+            patch.object(
+                activities,
+                "_detect_pr_url_from_workspace",
+                return_value=None,
+            ),
+            patch.object(
+                activities,
+                "_resolve_workspace_push_github_token",
+                new_callable=AsyncMock,
+                return_value="resolved-token",
+            ),
+            patch(
+                "moonmind.workflows.temporal.activity_runtime.ManagedAgentAdapter",
+            ) as MockAdapter,
+        ):
+            MockAdapter.return_value.fetch_result = AsyncMock(
+                return_value=AgentRunResult(
+                    summary="done",
+                    failure_class=None,
+                    metadata={
+                        "acceptedRepositoryEvidence": {
+                            "pushStatus": "pushed",
+                            "commitsAheadOfBase": 99,
+                        }
+                    },
+                )
+            )
+
+            result = await activities.agent_runtime_fetch_result(
+                {"run_id": "run-1", "agent_id": "claude", "publish_mode": "pr"},
+            )
+
+        assert "acceptedRepositoryEvidence" not in result.metadata
+        assert result.metadata["push_status"] == "failed"
+
+    @pytest.mark.asyncio
     async def test_fetch_result_pushes_when_publish_mode_pr(self):
         """Push attempted when publish_mode=pr and agent succeeded."""
         store = _make_mock_store()

--- a/tests/unit/workflows/temporal/test_run_artifacts.py
+++ b/tests/unit/workflows/temporal/test_run_artifacts.py
@@ -5345,6 +5345,7 @@ async def test_run_execution_stage_additional_work_publishes_pushed_branch_as_dr
             "push_base_ref": "origin/main",
             "push_commit_count": 2,
             "push_head_sha": "abc123",
+            "remote_verified": True,
         }
         accepted_repository_evidence = (
             TemporalAgentRuntimeActivities._accepted_repository_evidence(push_info)

--- a/tests/unit/workflows/temporal/test_run_artifacts.py
+++ b/tests/unit/workflows/temporal/test_run_artifacts.py
@@ -13,6 +13,9 @@ from moonmind.workflows.temporal.activity_catalog import (
     TemporalActivityRoute,
     TemporalActivityTimeouts,
 )
+from moonmind.workflows.temporal.activity_runtime import (
+    TemporalAgentRuntimeActivities,
+)
 from moonmind.workflows.temporal.workflows.run import MoonMindRunWorkflow
 
 
@@ -5335,6 +5338,18 @@ async def test_run_execution_stage_additional_work_publishes_pushed_branch_as_dr
         _request: object,
         **_kwargs: object,
     ) -> object:
+        push_info = {
+            "push_status": "pushed",
+            "push_branch": "partial-work",
+            "push_base_branch": "main",
+            "push_base_ref": "origin/main",
+            "push_commit_count": 2,
+            "push_head_sha": "abc123",
+        }
+        accepted_repository_evidence = (
+            TemporalAgentRuntimeActivities._accepted_repository_evidence(push_info)
+        )
+        assert accepted_repository_evidence is not None
         return {
             "summary": "Verdict: ADDITIONAL_WORK_NEEDED",
             "metadata": {
@@ -5342,15 +5357,8 @@ async def test_run_execution_stage_additional_work_publishes_pushed_branch_as_dr
                 "recommendedNextAction": "reattempt_current_step",
                 "operator_summary": "One retry-stability gap remains.",
                 "diagnostics_ref": "art_verify_remaining_work",
-                "push_status": "pushed",
-                "push_branch": "partial-work",
-                "push_base_ref": "origin/main",
-                "push_commit_count": 2,
-                "push_head_sha": "abc123",
-                "acceptedRepositoryEvidence": {
-                    "pushStatus": "pushed",
-                    "evidenceRef": "artifact://repository/published",
-                },
+                **push_info,
+                "acceptedRepositoryEvidence": accepted_repository_evidence,
             },
             "output_refs": [],
         }

--- a/tests/unit/workflows/temporal/test_typed_activity_boundaries.py
+++ b/tests/unit/workflows/temporal/test_typed_activity_boundaries.py
@@ -81,6 +81,7 @@ def test_accepted_repository_evidence_rejects_inconsistent_push_state() -> None:
             headSha="abc123",
             commitsAheadOfBase=0,
             repositoryChanged=True,
+            remoteVerified=True,
         )
 
     with pytest.raises(ValidationError, match="repositoryChanged disagree"):
@@ -90,6 +91,17 @@ def test_accepted_repository_evidence_rejects_inconsistent_push_state() -> None:
             baseBranch="main",
             headSha="abc123",
             commitsAheadOfBase=0,
+            repositoryChanged=True,
+            remoteVerified=True,
+        )
+
+    with pytest.raises(ValidationError, match="remoteVerified"):
+        AcceptedRepositoryEvidence(
+            pushStatus="pushed",
+            branch="partial-work",
+            baseBranch="main",
+            headSha="abc123",
+            commitsAheadOfBase=1,
             repositoryChanged=True,
         )
 

--- a/tests/unit/workflows/temporal/test_typed_activity_boundaries.py
+++ b/tests/unit/workflows/temporal/test_typed_activity_boundaries.py
@@ -16,6 +16,7 @@ from moonmind.schemas.agent_runtime_models import (
     AgentRunStatus,
 )
 from moonmind.schemas.temporal_activity_models import (
+    AcceptedRepositoryEvidence,
     AgentRuntimeFetchResultInput,
     ExternalAgentRunInput,
 )
@@ -69,6 +70,29 @@ def test_agent_runtime_fetch_result_input_normalizes_parent_and_fetch_fields() -
     assert request.commit_message == "Use typed payloads"
     assert request.target_branch == "main"
     assert request.head_branch is None
+
+
+def test_accepted_repository_evidence_rejects_inconsistent_push_state() -> None:
+    with pytest.raises(ValidationError, match="requires commits over base"):
+        AcceptedRepositoryEvidence(
+            pushStatus="pushed",
+            branch="partial-work",
+            baseBranch="main",
+            headSha="abc123",
+            commitsAheadOfBase=0,
+            repositoryChanged=True,
+        )
+
+    with pytest.raises(ValidationError, match="repositoryChanged disagree"):
+        AcceptedRepositoryEvidence(
+            pushStatus="no_commits",
+            branch="partial-work",
+            baseBranch="main",
+            headSha="abc123",
+            commitsAheadOfBase=0,
+            repositoryChanged=True,
+        )
+
 
 @pytest.mark.asyncio
 async def test_external_lifecycle_helper_accepts_provider_neutral_activity_name(


### PR DESCRIPTION
## Summary

- make the managed post-agent push boundary emit the typed `acceptedRepositoryEvidence` consumed by terminal publication gates
- strip provider-authored repository evidence so only MoonMind's managed push result can authorize publication
- fail closed when the push result lacks a consistent branch, base, head, or commits-ahead count
- add an escaped-failure replay for workflows `mm:9d9c591c-274e-4deb-8a69-2f0d5526c7ca` and `mm:40e2387a-5e26-47be-a6e5-43635efca755`

## Incident analysis

The workflow histories are not present in the currently running local Temporal/API instance, so that instance cannot provide authoritative event history for these IDs. Durable GitHub evidence shows that both executions completed implementation and pushed three commits to their workflow branches, but neither branch received a pull request or checks.

The common failure was an authority-handoff gap introduced when terminal gates began requiring typed `acceptedRepositoryEvidence`. The workflow gate correctly stopped trusting raw `push_status` and `push_commit_count` fields, but the managed push activity never produced the new accepted envelope. Consequently, a successfully pushed remediation branch was classified as `publication_state_ambiguous`, and exhausted remediation routed to an artifact-backed handoff instead of the configured draft-PR handoff.

This change connects the existing managed push authority to the existing terminal gate contract. It is additive to activity result metadata and does not change an activity signature or workflow payload shape; already-recorded histories retain their recorded result, while new activity results include the evidence.

## Validation

After syncing the adjacent terminal-evidence fix from `main`:

- `.venv/bin/pytest tests/unit/services/temporal/test_fetch_result_push.py tests/unit/workflows/temporal/test_typed_activity_boundaries.py tests/unit/workflows/temporal/test_run_artifacts.py tests/unit/workflows/temporal/workflows/test_run_bounded_story_loop.py tests/integration/reliability/test_escaped_failure_journeys.py -q --tb=short` — 245 passed
- `git diff origin/main...HEAD --check`