### PR TITLE
Fix remediation artifact reference normalization

### DIFF
--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -734,6 +734,13 @@ RUN_DYNAMIC_REMEDIATION_LOOP_CONTROLLER_PATCH = (
 RUN_REMEDIATION_LOOP_CONTINUE_AS_NEW_PATCH = (
     "run-remediation-loop-continue-as-new-v1"
 )
+# Agent/runtime artifact activities return opaque ``art_`` IDs, while the
+# deterministic remediation state stores canonical ``artifact://`` refs.
+# Version the boundary normalization so histories that already evaluated a gate
+# retain their original command sequence during replay.
+RUN_REMEDIATION_LOOP_ARTIFACT_REF_NORMALIZATION_PATCH = (
+    "run-remediation-loop-artifact-ref-normalization-v1"
+)
 
 
 @dataclasses.dataclass(frozen=True)
@@ -3941,6 +3948,28 @@ class MoonMindRunWorkflow:
         state = self._remediation_loop_state
         if spec is None or state is None:
             return False
+        normalize_artifact_refs = workflow.patched(
+            RUN_REMEDIATION_LOOP_ARTIFACT_REF_NORMALIZATION_PATCH
+        )
+        if normalize_artifact_refs:
+            normalized_gate_result_ref = self._bounded_story_loop_artifact_ref(
+                gate_result_ref
+            )
+            if normalized_gate_result_ref is None:
+                raise ValueError(
+                    "dynamic remediation verification requires an artifact gate result"
+                )
+            gate_result_ref = normalized_gate_result_ref
+            if remaining_work_ref:
+                normalized_remaining_work_ref = (
+                    self._bounded_story_loop_artifact_ref(remaining_work_ref)
+                )
+                if normalized_remaining_work_ref is None:
+                    raise ValueError(
+                        "dynamic remediation verification requires an artifact "
+                        "remaining-work result"
+                    )
+                remaining_work_ref = normalized_remaining_work_ref
         if self._remediation_workspace_head is None and workspace_head is not None:
             self._remediation_workspace_head = RemediationWorkspaceHead.model_validate(
                 workspace_head
@@ -3985,6 +4014,16 @@ class MoonMindRunWorkflow:
             ),
             payload=decision.model_dump(by_alias=True, mode="json"),
         )
+        if normalize_artifact_refs:
+            normalized_decision_ref = self._bounded_story_loop_artifact_ref(
+                decision_ref
+            )
+            if normalized_decision_ref is None:
+                raise ValueError(
+                    "dynamic remediation verification requires an artifact "
+                    "continuation decision"
+                )
+            decision_ref = normalized_decision_ref
         state = apply_continuation_decision(
             state,
             decision=decision,

--- a/tests/unit/workflows/temporal/test_run_replayer.py
+++ b/tests/unit/workflows/temporal/test_run_replayer.py
@@ -15,6 +15,7 @@ from moonmind.workflows.temporal.workflows.run import (
     RUN_MOONSPEC_TITLE_REMEDIATION_DETECTION_PATCH,
     RUN_OMNIGENT_AUTHORED_SELECTION_COMPILER_PATCH,
     RUN_PLAN_ROUTED_MOONSPEC_REMEDIATION_PATCH,
+    RUN_REMEDIATION_LOOP_ARTIFACT_REF_NORMALIZATION_PATCH,
     RUN_REMEDIATION_LOOP_CONTINUE_AS_NEW_PATCH,
     MoonMindRunWorkflow,
     MoonMindUserWorkflow,
@@ -113,6 +114,28 @@ class _CurrentStaticLoopCutoverReplayFixture:
         if workflow.patched(RUN_REMEDIATION_LOOP_CONTINUE_AS_NEW_PATCH):
             return ["controller", "remediation:1", "verification:1"]
         return commands
+
+
+@workflow.defn(name="MMRemediationArtifactRefReplayFixture")
+class _LegacyRemediationArtifactRefReplayFixture:
+    @workflow.run
+    async def run(self) -> str:
+        return "art_gate_result"
+
+
+@workflow.defn(name="MMRemediationArtifactRefReplayFixture")
+class _CurrentRemediationArtifactRefReplayFixture:
+    @workflow.run
+    async def run(self) -> str:
+        artifact_ref = "art_gate_result"
+        if workflow.patched(
+            RUN_REMEDIATION_LOOP_ARTIFACT_REF_NORMALIZATION_PATCH
+        ):
+            return (
+                MoonMindRunWorkflow._bounded_story_loop_artifact_ref(artifact_ref)
+                or ""
+            )
+        return artifact_ref
 
 
 def _mm3379_remediation_nodes() -> list[dict[str, Any]]:
@@ -407,6 +430,45 @@ async def test_static_remediation_history_replays_across_loop_schema_cutover() -
 
     replayer = Replayer(
         workflows=[_CurrentStaticLoopCutoverReplayFixture],
+        workflow_runner=UnsandboxedWorkflowRunner(),
+    )
+    await replayer.replay_workflow(legacy_history)
+    await replayer.replay_workflow(current_history)
+
+
+@pytest.mark.asyncio
+async def test_remediation_artifact_ref_normalization_histories_replay() -> None:
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        async with Worker(
+            env.client,
+            task_queue="test-remediation-artifact-ref-legacy-replay",
+            workflows=[_LegacyRemediationArtifactRefReplayFixture],
+            workflow_runner=UnsandboxedWorkflowRunner(),
+        ):
+            legacy_handle = await env.client.start_workflow(
+                _LegacyRemediationArtifactRefReplayFixture.run,
+                id="test-remediation-artifact-ref-legacy",
+                task_queue="test-remediation-artifact-ref-legacy-replay",
+            )
+            assert await legacy_handle.result() == "art_gate_result"
+            legacy_history = await legacy_handle.fetch_history()
+
+        async with Worker(
+            env.client,
+            task_queue="test-remediation-artifact-ref-current-replay",
+            workflows=[_CurrentRemediationArtifactRefReplayFixture],
+            workflow_runner=UnsandboxedWorkflowRunner(),
+        ):
+            current_handle = await env.client.start_workflow(
+                _CurrentRemediationArtifactRefReplayFixture.run,
+                id="test-remediation-artifact-ref-current",
+                task_queue="test-remediation-artifact-ref-current-replay",
+            )
+            assert await current_handle.result() == "artifact://art_gate_result"
+            current_history = await current_handle.fetch_history()
+
+    replayer = Replayer(
+        workflows=[_CurrentRemediationArtifactRefReplayFixture],
         workflow_runner=UnsandboxedWorkflowRunner(),
     )
     await replayer.replay_workflow(legacy_history)

--- a/tests/unit/workflows/temporal/workflows/test_run_integration.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_integration.py
@@ -22,6 +22,7 @@ from moonmind.workflows.temporal.workflows.run import (
     RUN_PAUSE_SAFE_BOUNDARIES_PATCH,
     RUN_PUBLISH_REPAIR_FEEDBACK_PATCH,
     RUN_PR_RESOLVER_PUBLISH_EVIDENCE_REF_PATCH,
+    RUN_REMEDIATION_LOOP_ARTIFACT_REF_NORMALIZATION_PATCH,
     RUN_REMEDIATION_LOOP_CONTINUE_AS_NEW_PATCH,
     RUN_STEP_RETRY_OVERRIDES_PATCH,
     RUN_ALREADY_IMPLEMENTED_JIRA_COMPLETION_PATCH,
@@ -3501,6 +3502,61 @@ async def test_dynamic_verifier_persists_decision_and_appends_only_admitted_pair
     assert projection["latestVerdict"] == "ADDITIONAL_WORK_NEEDED"
     assert projection["continuationDecisionRef"] == "artifact://decision/D0"
     mock_run_workflow._write_json_artifact.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_dynamic_verifier_normalizes_runtime_artifact_ids(
+    mock_run_workflow: MoonMindRunWorkflow,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    loop = {
+        "kind": "remediation_loop",
+        "loopId": "issue-implementation-remediation",
+        "remediationTool": {"type": "skill", "name": "auto"},
+        "verificationTool": {"type": "skill", "name": "moonspec-verify"},
+        "workspacePolicy": "continue_from_loop_head",
+        "budgets": {"hardMaxAttempts": 6},
+        "terminalPolicy": {
+            "fullyImplemented": "advance",
+            "additionalWorkNeeded": "continue_when_allowed",
+            "blocked": "stop",
+            "noDetermination": "retry_evidence_or_stop",
+            "failedUnrecoverable": "stop",
+        },
+        "sideEffectPolicy": "workflow_owned",
+        "publicationPolicy": "evaluate_after_terminal",
+    }
+    mock_run_workflow._initialize_remediation_loop_controller(
+        ordered_nodes=[
+            {"id": "controller", "annotations": {"remediationLoop": loop}}
+        ]
+    )
+    mock_run_workflow._step_ledger_rows = []
+    mock_run_workflow._write_json_artifact = AsyncMock(
+        return_value="art_decision_D0"
+    )
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "patched",
+        lambda patch_id: (
+            patch_id == RUN_REMEDIATION_LOOP_ARTIFACT_REF_NORMALIZATION_PATCH
+        ),
+    )
+    ordered_nodes: list[dict[str, Any]] = []
+
+    admitted = await mock_run_workflow._evaluate_dynamic_remediation_verification(
+        ordered_nodes=ordered_nodes,
+        verdict="ADDITIONAL_WORK_NEEDED",
+        gate_result_ref="art_verification_V0",
+        remaining_work_ref="art_remaining_R0",
+    )
+
+    assert admitted is True
+    state = mock_run_workflow._remediation_loop_state
+    assert state is not None
+    assert state.latest_verification_ref == "artifact://art_verification_V0"
+    assert state.latest_progress_ref == "artifact://art_remaining_R0"
+    assert state.continuation_decision_ref == "artifact://art_decision_D0"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Normalize runtime `art_…` artifact IDs into canonical `artifact://…` references before the dynamic remediation controller records verifier evidence.
- Apply the same normalization to remaining-work evidence and workflow-authored continuation decisions.
- Version the behavior with a Temporal patch marker so pre-change histories retain their original deterministic command sequence.
- Add production-shaped boundary coverage and pre/post-change replay coverage.

## Root cause

The six most recent issue-implementation workflows all reached a successfully completed verifier child. The child returned its gate artifact using MoonMind's normal opaque `art_…` ID, but the newly introduced remediation-loop state accepted only `artifact://…` references. The parent therefore failed with `dynamic remediation verification requires an artifact gate result` instead of applying the verifier verdict.

The workflow's own decision artifact is emitted in the same opaque-ID form, so it is normalized at the same authority boundary to avoid a second failure after accepting the gate.

## Impact

New remediation-loop workflows can consume the artifact references produced by managed agent and artifact activities while continuing to store canonical URI-form references in deterministic state. Invalid or missing references still fail closed.

## Validation

```text
./tools/test_unit.sh --python-only --no-xdist \
  tests/unit/workflows/temporal/workflows/test_run_integration.py \
  tests/unit/workflows/temporal/test_run_replayer.py

181 passed
```
