### PR TITLE
Fix provider profile timeout amplification

### DIFF
--- a/moonmind/workflows/temporal/artifacts.py
+++ b/moonmind/workflows/temporal/artifacts.py
@@ -39,6 +39,7 @@ _PREVIEW_MAX_BYTES = 16 * 1024
 _STREAM_CHUNK_BYTES = 64 * 1024
 _MULTIPART_WRITE_CHUNK_BYTES = 8 * 1024 * 1024
 _RUN_DIGEST_INDEXING_TIMEOUT_SECONDS = 10
+_PROVIDER_PROFILE_MANAGER_QUERY_TIMEOUT_SECONDS = 2.0
 _SINGLE_PUT_READ_RETRY_DELAYS_SECONDS = (0.1, 0.2, 0.4, 0.8, 1.6)
 _SINGLE_PUT_READ_RETRYABLE_S3_ERROR_CODES = {"404", "NoSuchKey", "NotFound"}
 _TASK_INPUT_ATTACHMENT_SOURCES = frozenset(
@@ -3651,6 +3652,7 @@ class TemporalArtifactActivities:
                 "running": False,
                 "workflow_id": workflow_id,
                 "status": f"RPC_ERROR_{exc.status.name}",
+                "inspection_succeeded": False,
                 "error_type": type(exc).__name__,
                 "error": str(exc),
             }
@@ -3661,24 +3663,40 @@ class TemporalArtifactActivities:
                 "running": False,
                 "workflow_id": workflow_id,
                 "status": status_name,
+                "inspection_succeeded": True,
             }
 
         try:
-            state = await handle.query("get_state")
+            state = await asyncio.wait_for(
+                handle.query("get_state"),
+                timeout=_PROVIDER_PROFILE_MANAGER_QUERY_TIMEOUT_SECONDS,
+            )
+        except TimeoutError:
+            return {
+                "running": True,
+                "workflow_id": workflow_id,
+                "status": status_name,
+                "inspection_succeeded": False,
+                "inspection_status": "QUERY_TIMEOUT",
+            }
         except RPCError as exc:
             return {
-                "running": False,
+                "running": True,
                 "workflow_id": workflow_id,
-                "status": f"RPC_ERROR_{exc.status.name}",
+                "status": status_name,
+                "inspection_succeeded": False,
+                "inspection_status": f"RPC_ERROR_{exc.status.name}",
                 "error_type": type(exc).__name__,
                 "error": str(exc),
             }
 
         if not isinstance(state, dict):
             return {
-                "running": False,
+                "running": True,
                 "workflow_id": workflow_id,
                 "status": status_name,
+                "inspection_succeeded": False,
+                "inspection_status": "INVALID_QUERY_PAYLOAD",
                 "error_type": "InvalidQueryPayload",
             }
 
@@ -3769,6 +3787,7 @@ class TemporalArtifactActivities:
             "running": True,
             "workflow_id": workflow_id,
             "status": status_name,
+            "inspection_succeeded": True,
             "profile_count": len(profiles) if isinstance(profiles, dict) else 0,
             "pending_requests_count": (
                 len(pending_requests) if isinstance(pending_requests, list) else 0

--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -331,6 +331,9 @@ PR_RESOLVER_MERGE_GATE_OWNERSHIP_PATCH_ID = (
     "agent-run-pr-resolver-merge-gate-ownership-v1"
 )
 MANAGER_SLOT_WAIT_INSPECTION_PATCH_ID = "agent-run-slot-wait-manager-inspection-v1"
+PRESERVE_DURABLE_SLOT_REQUEST_ON_AMBIGUOUS_INSPECTION_PATCH_ID = (
+    "agent-run-preserve-slot-request-on-ambiguous-inspection-v1"
+)
 NON_DESTRUCTIVE_SLOT_WAIT_RECOVERY_PATCH_ID = (
     "agent-run-non-destructive-slot-wait-recovery-v1"
 )
@@ -4109,6 +4112,9 @@ class MoonMindAgentRun:
                                     by_alias=True,
                                     exclude_none=True,
                                 )
+                                preserve_durable_slot_request = workflow.patched(
+                                    PRESERVE_DURABLE_SLOT_REQUEST_ON_AMBIGUOUS_INSPECTION_PATCH_ID
+                                )
                                 if workflow.patched(MANAGER_SLOT_WAIT_INSPECTION_PATCH_ID):
                                     try:
                                         manager_state = await self._manager_state_for_slot_wait(
@@ -4119,12 +4125,25 @@ class MoonMindAgentRun:
                                         raise
                                     except Exception as exc:
                                         self._get_logger().warning(
-                                            "Auth profile manager %s state inspection failed while %s waits for a slot; using non-destructive recovery: %s",
+                                            "Auth profile manager %s state inspection failed while %s waits for a slot; preserving the durable slot request: %s",
                                             manager_id,
                                             workflow.info().workflow_id,
                                             exc,
                                         )
+                                        if preserve_durable_slot_request:
+                                            continue
                                         manager_state = {"running": False}
+                                    if (
+                                        preserve_durable_slot_request
+                                        and manager_state.get("inspection_succeeded")
+                                        is False
+                                    ):
+                                        self._get_logger().warning(
+                                            "Auth profile manager %s inspection was inconclusive while %s waits for a slot; preserving the durable slot request without ensure or duplicate signal",
+                                            manager_id,
+                                            workflow.info().workflow_id,
+                                        )
+                                        continue
                                     if manager_state.get("running") is True:
                                         if manager_state.get("requester_pending") is True:
                                             self._get_logger().warning(

--- a/tests/integration/services/temporal/workflows/test_agent_run.py
+++ b/tests/integration/services/temporal/workflows/test_agent_run.py
@@ -8,14 +8,17 @@ from typing import Any
 
 from temporalio import workflow
 from temporalio.testing import WorkflowEnvironment
-from temporalio.worker import Worker, UnsandboxedWorkflowRunner
+from temporalio.worker import Replayer, Worker, UnsandboxedWorkflowRunner
 from temporalio.client import WorkflowFailureError
 from temporalio.service import RPCError
 from moonmind.schemas.agent_runtime_models import AgentExecutionRequest, AgentRunResult, AgentRunStatus, ProfileSelector
 from moonmind.schemas.workload_models import WorkloadRequest
 from moonmind.workloads.docker_launcher import DockerWorkloadLauncher
 from moonmind.workloads.registry import RunnerProfileRegistry
-from moonmind.workflows.temporal.workflows.agent_run import MoonMindAgentRun
+from moonmind.workflows.temporal.workflows.agent_run import (
+    MoonMindAgentRun,
+    _SLOT_WAIT_TIMEOUT_SECONDS,
+)
 
 # NOTE: This test file is NOT marked integration_ci because the Temporal
 # time-skipping workflow tests consistently exceed CI timeout thresholds.
@@ -169,11 +172,41 @@ async def mock_provider_profile_list(request: dict) -> dict:
 
 @_activity.defn(name="provider_profile.ensure_manager")
 async def mock_provider_profile_ensure_manager(request: dict) -> dict:
+    global _provider_profile_ensure_manager_count
+    _provider_profile_ensure_manager_count += 1
     return {"started": True, "workflow_id": f"provider-profile-manager:{request.get('runtime_id', 'test')}"}
 
 @_activity.defn(name="provider_profile.reset_manager")
 async def mock_provider_profile_reset_manager(request: dict) -> dict:
     return {"reset": True, "workflow_id": f"provider-profile-manager:{request.get('runtime_id', 'test')}"}
+
+
+_provider_profile_ensure_manager_count = 0
+_provider_profile_manager_state_count = 0
+_provider_profile_manager_state_mode = "running"
+
+
+@_activity.defn(name="provider_profile.manager_state")
+async def mock_provider_profile_manager_state(request: dict) -> dict:
+    global _provider_profile_manager_state_count
+    _provider_profile_manager_state_count += 1
+    workflow_id = f"provider-profile-manager:{request.get('runtime_id', 'test')}"
+    if _provider_profile_manager_state_mode == "ambiguous":
+        return {
+            "running": True,
+            "workflow_id": workflow_id,
+            "status": "RUNNING",
+            "inspection_succeeded": False,
+            "inspection_status": "QUERY_TIMEOUT",
+        }
+    return {
+        "running": True,
+        "workflow_id": workflow_id,
+        "status": "RUNNING",
+        "inspection_succeeded": True,
+        "requester_pending": True,
+    }
+
 
 # Collect all activities that need to be registered on the main task queue.
 _COMMON_AGENT_RUN_ACTIVITIES = [
@@ -182,6 +215,7 @@ _COMMON_AGENT_RUN_ACTIVITIES = [
     mock_provider_profile_list,
     mock_provider_profile_ensure_manager,
     mock_provider_profile_reset_manager,
+    mock_provider_profile_manager_state,
 ]
 
 _managed_launch_requests: list[dict] = []
@@ -717,6 +751,106 @@ async def test_agent_run_workflow_cancellation():
                 assert "cancel" in exc_str or "cancel" in cause_str or isinstance(
                     exc_info.value.__cause__, asyncio.CancelledError
                 )
+
+
+async def test_slot_wait_preserves_durable_request_when_manager_inspection_is_ambiguous(
+):
+    """A busy manager query must not trigger ensure/re-request amplification."""
+    global _provider_profile_ensure_manager_count
+    global _provider_profile_manager_state_count
+    global _provider_profile_manager_state_mode
+
+    _provider_profile_ensure_manager_count = 0
+    _provider_profile_manager_state_count = 0
+    _provider_profile_manager_state_mode = "ambiguous"
+    history = None
+    try:
+        async with await WorkflowEnvironment.start_time_skipping() as env:
+            async with (
+                Worker(
+                    env.client,
+                    task_queue="agent-run-task-queue-ambiguous-manager",
+                    workflows=[
+                        MoonMindAgentRun,
+                        RuntimeUpdateProviderProfileManager,
+                    ],
+                    workflow_runner=UnsandboxedWorkflowRunner(),
+                ),
+                Worker(
+                    env.client,
+                    task_queue="mm.activity.artifacts",
+                    activities=[
+                        mock_provider_profile_list,
+                        mock_provider_profile_ensure_manager,
+                        mock_provider_profile_reset_manager,
+                        mock_provider_profile_manager_state,
+                    ],
+                ),
+            ):
+                manager_id = "provider-profile-manager:codex_cli"
+                await env.client.start_workflow(
+                    RuntimeUpdateProviderProfileManager.run,
+                    {
+                        "runtime_id": "codex_cli",
+                        "assignable_profile_id": "never-assign",
+                    },
+                    id=manager_id,
+                    task_queue="agent-run-task-queue-ambiguous-manager",
+                )
+                manager_handle = env.client.get_workflow_handle(manager_id)
+                child_handle = await env.client.start_workflow(
+                    MoonMindAgentRun.run,
+                    AgentExecutionRequest(
+                        agent_kind="managed",
+                        agent_id="codex_cli",
+                        execution_profile_ref="default-managed",
+                        correlation_id="ambiguous-manager:corr",
+                        idempotency_key="ambiguous-manager:idem",
+                    ),
+                    id="test-agent-run-ambiguous-manager",
+                    task_queue="agent-run-task-queue-ambiguous-manager",
+                )
+
+                manager_state = {}
+                for _ in range(40):
+                    manager_state = await manager_handle.query(
+                        RuntimeUpdateProviderProfileManager.get_state
+                    )
+                    if (
+                        manager_state.get("request_payloads")
+                        and _provider_profile_manager_state_count >= 1
+                    ):
+                        break
+                    await asyncio.sleep(0.05)
+
+                assert len(manager_state.get("request_payloads", [])) == 1
+                await env.sleep(_SLOT_WAIT_TIMEOUT_SECONDS + 5)
+
+                for _ in range(40):
+                    if _provider_profile_manager_state_count >= 2:
+                        break
+                    await asyncio.sleep(0.05)
+
+                manager_state = await manager_handle.query(
+                    RuntimeUpdateProviderProfileManager.get_state
+                )
+                assert _provider_profile_manager_state_count >= 2
+                assert _provider_profile_ensure_manager_count == 0
+                assert len(manager_state["request_payloads"]) == 1
+
+                await child_handle.cancel()
+                with pytest.raises(WorkflowFailureError):
+                    await child_handle.result()
+                history = await child_handle.fetch_history()
+
+        assert history is not None
+        await Replayer(
+            workflows=[MoonMindAgentRun],
+            workflow_runner=UnsandboxedWorkflowRunner(),
+        ).replay_workflow(history)
+    finally:
+        _provider_profile_manager_state_mode = "running"
+
 
 @pytest.mark.asyncio
 async def test_agent_run_reports_managed_429_retry_summary_to_parent():

--- a/tests/unit/workflows/temporal/test_provider_profile_manager.py
+++ b/tests/unit/workflows/temporal/test_provider_profile_manager.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
@@ -3071,6 +3072,7 @@ async def test_provider_profile_manager_state_returns_compact_running_snapshot(
         "running": True,
         "workflow_id": "provider-profile-manager:claude_code",
         "status": "RUNNING",
+        "inspection_succeeded": True,
         "profile_count": 2,
         "pending_requests_count": 2,
         "event_count": 7,
@@ -3211,5 +3213,62 @@ async def test_provider_profile_manager_state_checks_status_before_query(
         "running": False,
         "workflow_id": "provider-profile-manager:claude_code",
         "status": "COMPLETED",
+        "inspection_succeeded": True,
     }
     assert handle.queried is False
+
+
+@pytest.mark.asyncio
+async def test_provider_profile_manager_state_bounds_busy_workflow_query(
+    monkeypatch,
+):
+    from moonmind.workflows.temporal import artifacts as artifacts_module
+    from moonmind.workflows.temporal.artifacts import TemporalArtifactActivities
+
+    query_cancelled = asyncio.Event()
+
+    class FakeHandle:
+        async def describe(self):
+            return SimpleNamespace(status=SimpleNamespace(name="RUNNING"))
+
+        async def query(self, query_name):
+            assert query_name == "get_state"
+            try:
+                await asyncio.Event().wait()
+            finally:
+                query_cancelled.set()
+
+    class FakeClient:
+        def get_workflow_handle(self, workflow_id):
+            assert workflow_id == "provider-profile-manager:codex_cli"
+            return FakeHandle()
+
+    class FakeAdapter:
+        async def get_client(self):
+            return FakeClient()
+
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.client.TemporalClientAdapter",
+        FakeAdapter,
+    )
+    monkeypatch.setattr(
+        artifacts_module,
+        "_PROVIDER_PROFILE_MANAGER_QUERY_TIMEOUT_SECONDS",
+        0.01,
+    )
+
+    result = await TemporalArtifactActivities(
+        object()
+    ).provider_profile_manager_state(
+        runtime_id="codex_cli",
+        requester_workflow_id="agent-run-1",
+    )
+
+    assert result == {
+        "running": True,
+        "workflow_id": "provider-profile-manager:codex_cli",
+        "status": "RUNNING",
+        "inspection_succeeded": False,
+        "inspection_status": "QUERY_TIMEOUT",
+    }
+    assert query_cancelled.is_set()

--- a/tests/unit/workflows/temporal/workflows/test_agent_run_slot_wait_timeout.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_run_slot_wait_timeout.py
@@ -16,6 +16,7 @@ from moonmind.workflows.temporal.workflows.agent_run import (
     ACCURATE_SLOT_WAIT_REASON_PATCH_ID,
     MANAGER_SLOT_WAIT_INSPECTION_PATCH_ID,
     NON_DESTRUCTIVE_SLOT_WAIT_RECOVERY_PATCH_ID,
+    PRESERVE_DURABLE_SLOT_REQUEST_ON_AMBIGUOUS_INSPECTION_PATCH_ID,
     MoonMindAgentRun,
     RunStatus,
     _SLOT_WAIT_TIMEOUT_SECONDS,
@@ -208,12 +209,21 @@ class TestSlotWaitRetryBehavior:
         assert "manager_handle.signal(\"request_slot\"" not in source
         assert "provider_profile.reset_manager" not in source
 
-    def test_slot_timeout_probe_failure_falls_back_to_safe_recovery(self):
-        """Inspection ambiguity must not authorize destructive manager reset."""
+    def test_slot_timeout_probe_failure_preserves_durable_request(self):
+        """Inspection ambiguity must not amplify load with ensure/re-request work."""
         source = inspect.getsource(MoonMindAgentRun.run)
 
         assert "except CancelledError:" in source
-        assert "using non-destructive recovery" in source
+        assert (
+            PRESERVE_DURABLE_SLOT_REQUEST_ON_AMBIGUOUS_INSPECTION_PATCH_ID
+            == "agent-run-preserve-slot-request-on-ambiguous-inspection-v1"
+        )
+        assert "preserving the durable slot request" in source
+        assert 'manager_state.get("inspection_succeeded")' in source
+        assert "if preserve_durable_slot_request:" in source
+        assert "continue" in source
+        # The old replay path remains available for histories that already
+        # recorded manager recovery commands before this patch marker.
         assert 'manager_state = {"running": False}' in source
         assert "_recover_and_request_slot" in source
 


### PR DESCRIPTION
## Summary

- Bound provider-profile manager state queries to two seconds so busy consistent queries cannot occupy artifact-worker slots indefinitely.
- Preserve an AgentRun's already-durable slot request when manager inspection is inconclusive, avoiding redundant `ensure_manager` and re-request load.
- Add unit, real Temporal boundary, and replay coverage for the timeout path.

## Root cause

A burst of AgentRuns waiting on one provider profile issued concurrent consistent manager-state queries. Temporal returned `BusyWorkflow` / query-buffer exhaustion, and client retries saturated the eight-slot artifact worker. The recovery path then treated inconclusive inspection as a missing manager and scheduled `provider_profile.ensure_manager`; those activities starved until their StartToClose or ScheduleToClose timeout. This produced the failure summaries observed in workflows `mm:720f8241-fd48-403f-b2f0-a3ede96a05db` and `mm:b49848fa-e134-48d4-91a8-9af770fc4e11`.

## Impact

Queued AgentRuns now keep waiting on their authoritative durable request under manager-query pressure. A confirmed non-running manager can still trigger recovery. A Temporal patch marker preserves deterministic replay for histories that may already have recorded the previous recovery commands.

## Validation

- `./tools/test_unit.sh --python-only --no-xdist tests/unit/workflows/temporal/test_provider_profile_manager.py tests/unit/workflows/temporal/workflows/test_agent_run_slot_wait_timeout.py` — 144 passed
- `.venv/bin/python -m pytest -q tests/integration/services/temporal/workflows/test_agent_run.py::test_slot_wait_preserves_durable_request_when_manager_inspection_is_ambiguous` — passed, including deterministic history replay
- Restarted the affected local workers; both reported healthy, and post-restart logs showed no recurrence of the timeout/query-buffer pattern