### PR TITLE
Make Codex managed-session state writes atomic

### DIFF
--- a/moonmind/workflows/temporal/runtime/codex_session_runtime.py
+++ b/moonmind/workflows/temporal/runtime/codex_session_runtime.py
@@ -853,10 +853,7 @@ class CodexManagedSessionRuntime:
         finally:
             if temp_fd >= 0:
                 os.close(temp_fd)
-            try:
-                temp_path.unlink()
-            except FileNotFoundError:
-                pass
+            temp_path.unlink(missing_ok=True)
 
     def _session_state(self, state: CodexSessionRuntimeState) -> CodexManagedSessionState:
         return CodexManagedSessionState(

--- a/moonmind/workflows/temporal/runtime/codex_session_runtime.py
+++ b/moonmind/workflows/temporal/runtime/codex_session_runtime.py
@@ -836,10 +836,27 @@ class CodexManagedSessionRuntime:
 
     def _save_state(self, state: CodexSessionRuntimeState) -> None:
         self._ensure_directories()
-        self._state_path.write_text(
-            state.model_dump_json(by_alias=True, exclude_none=True, indent=2) + "\n",
-            encoding="utf-8",
+        payload = (
+            state.model_dump_json(by_alias=True, exclude_none=True, indent=2) + "\n"
         )
+        temp_fd, temp_name = tempfile.mkstemp(
+            prefix=f"{_STATE_FILENAME}.",
+            suffix=".tmp",
+            dir=str(self._state_path.parent),
+        )
+        temp_path = Path(temp_name)
+        try:
+            with os.fdopen(temp_fd, "w", encoding="utf-8") as handle:
+                temp_fd = -1
+                handle.write(payload)
+            os.replace(temp_path, self._state_path)
+        finally:
+            if temp_fd >= 0:
+                os.close(temp_fd)
+            try:
+                temp_path.unlink()
+            except FileNotFoundError:
+                pass
 
     def _session_state(self, state: CodexSessionRuntimeState) -> CodexManagedSessionState:
         return CodexManagedSessionState(

--- a/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
+++ b/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
@@ -233,6 +233,60 @@ def test_runtime_launch_session_persists_logical_thread_mapping(tmp_path: Path) 
     assert state_payload["vendorThreadPath"] == "/tmp/vendor-thread-1.jsonl"
 
 
+def test_runtime_state_save_failure_preserves_last_valid_state(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    script = write_fake_app_server(tmp_path)
+    request = launch_request(tmp_path)
+    runtime = CodexManagedSessionRuntime(
+        workspace_path=request.workspace_path,
+        session_workspace_path=request.session_workspace_path,
+        artifact_spool_path=request.artifact_spool_path,
+        codex_home_path=request.codex_home_path,
+        image_ref=request.image_ref,
+        control_url="docker-exec://mm-codex-session-sess-1",
+        container_id="ctr-1",
+        app_server_command=("python3", str(script)),
+    )
+    runtime.launch_session(request)
+    state_path = (
+        Path(request.session_workspace_path) / ".moonmind-codex-session-state.json"
+    )
+    previous_payload = state_path.read_text(encoding="utf-8")
+    state = runtime._load_state()
+    state.last_control_action = "send_turn"
+
+    def _fail_replace(_source: str | Path, _target: str | Path) -> None:
+        raise OSError("simulated atomic replace failure")
+
+    with monkeypatch.context() as replace_failure:
+        replace_failure.setattr(os, "replace", _fail_replace)
+
+        with pytest.raises(OSError, match="simulated atomic replace failure"):
+            runtime._save_state(state)
+
+    assert state_path.read_text(encoding="utf-8") == previous_payload
+    assert (
+        CodexSessionRuntimeState.model_validate_json(previous_payload).session_epoch
+        == 1
+    )
+    assert not list(state_path.parent.glob(f"{state_path.name}.*.tmp"))
+
+    handle = runtime.clear_session(
+        CodexManagedSessionClearRequest(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            containerId="ctr-1",
+            threadId="logical-thread-1",
+            newThreadId="logical-thread-2",
+        )
+    )
+
+    assert handle.status == "ready"
+    assert handle.session_state.session_epoch == 2
+
+
 def test_runtime_clear_session_recovers_sqlite_state_runtime_init_failure(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary
- persist Codex managed-session runtime state through a same-directory temporary file and atomic replacement
- preserve the last valid session state when an update is interrupted or the final replacement fails
- add a regression test proving a failed save leaves state readable and a later session clear succeeds

## Root cause
Both reported workflows left `.moonmind-codex-session-state.json` as a zero-byte file at the first long-running `send_turn` failure. The runtime wrote directly to the canonical file with `Path.write_text`, which truncates the file before the new JSON is written. Once interrupted, every retry and the final clear operation parsed an empty string and failed validation.

## Validation
- `3 passed, 91 deselected` for focused Codex session runtime state-save and clear-session tests
- `ruff check moonmind/workflows/temporal/runtime/codex_session_runtime.py`
- `git diff --check`

The repository test wrapper did not reach pytest because its global status-domain audit found pre-existing violations under `.claude/worktrees/ui-regressions`; the focused runtime tests were therefore rerun directly and passed.