### PR TITLE
Complete control-stop continuation recovery

### DIFF
--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -225,6 +225,7 @@ from moonmind.services.control_stop_continuation import (
     admit_control_stop_continuation,
 )
 from moonmind.workflows.executions.control_stop_continuation import (
+    ContinuationBudgetGrant,
     ControlStopContinuationContract,
     ControlStopContinuationError,
 )
@@ -7102,12 +7103,33 @@ def _build_action_capabilities(record) -> ExecutionActionCapabilityModel:
                 )
             continue
         disabled_reasons[alias] = "state_not_eligible"
+    common_control_stop_evidence = {
+        "candidateRef": control_stop.get("workspaceHeadRef"),
+        "remainingWorkRef": control_stop.get("remainingWorkRef"),
+    }
+    continuation_evidence = {
+        **common_control_stop_evidence,
+        **{
+            destination: control_stop[source]
+            for source, destination in (
+                ("controlStopId", "controlStopId"),
+                ("sourceBudget", "sourceBudget"),
+                ("continuationBudgetGrant", "continuationBudget"),
+                ("destinationWorkflowId", "destinationWorkflowId"),
+                ("restorationEvidenceRef", "restorationEvidenceRef"),
+                ("restorationEvidenceDigest", "restorationEvidenceDigest"),
+                ("hostSessionLifecycle", "hostSessionLifecycle"),
+            )
+            if source in control_stop
+        },
+    }
     action_evidence = {
         **{
-            action: {
-                "candidateRef": control_stop.get("workspaceHeadRef"),
-                "remainingWorkRef": control_stop.get("remainingWorkRef"),
-            }
+            action: (
+                continuation_evidence
+                if action == "continueRemediation"
+                else common_control_stop_evidence
+            )
             for action in (
                 "editForRerun",
                 "fullRetry",
@@ -14240,11 +14262,25 @@ async def describe_execution(
     return execution
 
 
+class ContinueRemediationBudgetProposal(BaseModel):
+    """Operator-selected limits bounded by the server-owned grant."""
+
+    model_config = {"populate_by_name": True, "extra": "forbid"}
+
+    max_attempts: int = Field(alias="maxAttempts", ge=1)
+    max_consecutive_no_progress_attempts: int = Field(
+        alias="maxConsecutiveNoProgressAttempts", ge=1
+    )
+
+
 class ContinueRemediationRequest(BaseModel):
     """Select the frozen control-stop evidence owned by the source execution."""
 
     model_config = {"populate_by_name": True, "extra": "forbid"}
 
+    proposed_continuation_budget: ContinueRemediationBudgetProposal | None = Field(
+        None, alias="proposedContinuationBudget"
+    )
     instruction_changes_ref: str | None = Field(
         None, alias="instructionChangesRef", min_length=1
     )
@@ -14296,6 +14332,11 @@ async def continue_remediation(
 ) -> ContinueRemediationResponse:
     """Admit one deterministic continuation from authoritative frozen evidence."""
 
+    continuation_metrics = get_metrics_emitter()
+    continuation_metrics.increment(
+        "control_stop_continuation.admission_total",
+        tags={"outcome": "attempt"},
+    )
     source = await _get_owned_execution(
         service=service,
         workflow_id=workflow_id,
@@ -14320,17 +14361,31 @@ async def continue_remediation(
         contract = ControlStopContinuationContract.model_validate(
             dict(evidence.contract_payload)
         )
+        selected_budget = contract.continuation_budget
+        if payload.proposed_continuation_budget is not None:
+            selected_budget = ContinuationBudgetGrant(
+                grantId=contract.continuation_budget.grant_id,
+                maxAttempts=payload.proposed_continuation_budget.max_attempts,
+                maxConsecutiveNoProgressAttempts=(
+                    payload.proposed_continuation_budget
+                    .max_consecutive_no_progress_attempts
+                ),
+            )
         reservation = await admit_control_stop_continuation(
             source_workflow_id=source.workflow_id,
             source_run_id=source_run_id,
             control_stop_id=control_stop_id,
-            continuation_budget=contract.continuation_budget,
+            continuation_budget=selected_budget,
             instruction_changes_ref=payload.instruction_changes_ref,
             instruction_changes_digest=payload.instruction_changes_digest,
             repository=repository,
             starter=starter,
         )
     except (ControlStopContinuationError, ValidationError) as exc:
+        continuation_metrics.increment(
+            "control_stop_continuation.admission_total",
+            tags={"outcome": "rejected"},
+        )
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
             detail={
@@ -14339,6 +14394,10 @@ async def continue_remediation(
             },
         ) from exc
 
+    continuation_metrics.increment(
+        "control_stop_continuation.admission_total",
+        tags={"outcome": "created" if reservation.created else "reconciled"},
+    )
     return ContinueRemediationResponse(
         sourceWorkflowId=reservation.source_workflow_id,
         sourceRunId=reservation.source_run_id,

--- a/api_service/services/control_stop_continuation.py
+++ b/api_service/services/control_stop_continuation.py
@@ -11,6 +11,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from temporalio.common import WorkflowIDReusePolicy
 
 from api_service.db.models import ControlStopContinuationRecord
+from moonmind.config.settings import settings
 from moonmind.services.control_stop_continuation import (
     ControlStopContinuationReservation,
     ControlStopSourceEvidence,
@@ -18,6 +19,7 @@ from moonmind.services.control_stop_continuation import (
 from moonmind.workflows.executions.control_stop_continuation import (
     ControlStopContinuationContract,
     ControlStopContinuationError,
+    ControlStopContinuationWorkflowInput,
 )
 from moonmind.workflows.temporal.client import TemporalClientAdapter
 from moonmind.workflows.temporal.workflows.control_stop_continuation import (
@@ -34,20 +36,24 @@ class TemporalControlStopContinuationStarter:
     async def start_or_reconcile(
         self, *, workflow_id: str, input_payload: Mapping[str, Any]
     ) -> str:
+        workflow_input = ControlStopContinuationWorkflowInput.model_validate(
+            dict(input_payload)
+        )
+        contract = workflow_input.contract
         result = await self._adapter.start_workflow(
             workflow_type=WORKFLOW_NAME,
             workflow_id=workflow_id,
             input_args=dict(input_payload),
             id_reuse_policy=WorkflowIDReusePolicy.REJECT_DUPLICATE,
             memo={
-                "owner_id": str(input_payload["ownerId"]),
-                "owner_type": str(input_payload["ownerType"]),
-                "source_workflow_id": str(input_payload["sourceWorkflowId"]),
-                "source_run_id": str(input_payload["sourceRunId"]),
+                "owner_id": contract.owner_id,
+                "owner_type": contract.owner_type,
+                "source_workflow_id": contract.source_workflow_id,
+                "source_run_id": contract.source_run_id,
             },
             search_attributes={
-                "mm_owner_id": str(input_payload["ownerId"]),
-                "mm_owner_type": str(input_payload["ownerType"]),
+                "mm_owner_id": contract.owner_id,
+                "mm_owner_type": contract.owner_type,
             },
         )
         if result.workflow_id != workflow_id:
@@ -117,13 +123,53 @@ class SqlControlStopContinuationRepository:
             source_run_id=source_run_id,
             control_stop_id=control_stop_id,
         )
+        contract = ControlStopContinuationContract.model_validate(
+            dict(row.contract_payload)
+        )
+        flags = settings.feature_flags
+        canary_owners = {
+            item.strip()
+            for item in flags.control_stop_continuation_canary_owner_ids.split(",")
+            if item.strip()
+        }
+        allowed_provider_profiles = {
+            item.strip()
+            for item in (
+                flags.control_stop_continuation_allowed_provider_profile_ids.split(",")
+            )
+            if item.strip()
+        }
+        allowed_execution_profiles = {
+            item.strip()
+            for item in (
+                flags.control_stop_continuation_allowed_execution_profile_refs.split(
+                    ","
+                )
+            )
+            if item.strip()
+        }
+        allowed_launch_policies = {
+            item.strip()
+            for item in (
+                flags.control_stop_continuation_allowed_launch_policy_refs.split(",")
+            )
+            if item.strip()
+        }
+        deployment_promoted = (
+            flags.control_stop_continuation_enabled
+            and not flags.control_stop_continuation_shadow
+            and (not canary_owners or contract.owner_id in canary_owners)
+            and contract.lane.provider_profile_id in allowed_provider_profiles
+            and contract.lane.execution_profile_id in allowed_execution_profiles
+            and contract.lane.launch_policy_ref in allowed_launch_policies
+        )
         return ControlStopSourceEvidence(
             contract_payload=dict(row.contract_payload),
             artifact_digests={
                 str(key): str(value) for key, value in row.artifact_digests.items()
             },
-            current_deployment_generation=row.deployment_generation,
-            deployment_promoted=row.deployment_promoted,
+            current_deployment_generation=(flags.control_stop_continuation_generation),
+            deployment_promoted=deployment_promoted,
         )
 
     async def reserve_destination(
@@ -141,12 +187,15 @@ class SqlControlStopContinuationRepository:
                 row.destination_workflow_id = contract.destination_workflow_id
                 row.workspace_head_ref = contract.workspace_head_ref
                 row.remaining_work_ref = contract.remaining_work_ref
+                row.contract_payload = contract.model_dump(by_alias=True, mode="json")
                 row.reserved_at = datetime.now(UTC)
                 await self._session.flush()
             elif (
                 row.destination_workflow_id != contract.destination_workflow_id
                 or row.workspace_head_ref != contract.workspace_head_ref
                 or row.remaining_work_ref != contract.remaining_work_ref
+                or dict(row.contract_payload)
+                != contract.model_dump(by_alias=True, mode="json")
             ):
                 raise ControlStopContinuationError(
                     "existing control-stop reservation conflicts with frozen contract"

--- a/docs/Omnigent/ConformanceAndLiveSmoke.md
+++ b/docs/Omnigent/ConformanceAndLiveSmoke.md
@@ -120,6 +120,16 @@ disable-new-selection, rollback, historical-read, and worker-version replay
 outcomes. A missing or false assertion fails publication; there is no
 fresh-root, alternate-profile, direct-Codex, or lower-level fallback.
 
+New control-stop destinations are disabled unless
+`FEATURE_FLAGS__CONTROL_STOP_CONTINUATION_ENABLED=true`, shadow mode is false,
+and `FEATURE_FLAGS__CONTROL_STOP_CONTINUATION_GENERATION` matches the frozen
+contract generation. The comma-separated `CANARY_OWNER_IDS`,
+`ALLOWED_PROVIDER_PROFILE_IDS`, `ALLOWED_EXECUTION_PROFILE_REFS`, and
+`ALLOWED_LAUNCH_POLICY_REFS` values under the same
+`FEATURE_FLAGS__CONTROL_STOP_CONTINUATION_` prefix are exact allowlists.
+Disabling the feature or changing its generation blocks new admissions without
+changing replay or historical reads for already-started destinations.
+
 ## Credentialed CI publication
 
 `.github/workflows/omnigent-live-conformance.yml` is the scheduled and manually

--- a/frontend/src/entrypoints/workflow-detail.test.tsx
+++ b/frontend/src/entrypoints/workflow-detail.test.tsx
@@ -697,6 +697,119 @@ describe('Workflow Detail Entrypoint', () => {
     expect(screen.getByText(/No failed Step Execution was fabricated/)).toBeTruthy();
   });
 
+  it('submits an explicit operator-selected budget from the authorized grant', async () => {
+    window.history.pushState(
+      {},
+      'Continuation budget test',
+      '/workflows/test-123/overview?source=temporal',
+    );
+    const execution = {
+      taskId: 'test-123',
+      workflowId: 'test-123',
+      namespace: 'default',
+      runId: '02-run',
+      source: 'temporal',
+      workflowType: 'MoonMind.UserWorkflow',
+      title: 'Quality gate stopped run',
+      summary: 'Remaining work is preserved.',
+      status: 'failed',
+      state: 'failed',
+      rawState: 'failed',
+      temporalStatus: 'failed',
+      createdAt: '2026-04-09T00:00:00Z',
+      updatedAt: '2026-04-09T00:00:04Z',
+      actions: {
+        canContinueRemediation: true,
+        actionEvidence: {
+          continueRemediation: {
+            controlStopId: 'verify:control-stop:6',
+            candidateRef: 'artifact://workspace/final',
+            remainingWorkRef: 'artifact://remaining/final',
+            sourceBudget: {
+              maxAttempts: 6,
+              consumedAttempts: 6,
+              exhaustedDimension: 'remediation_attempts',
+            },
+            continuationBudget: {
+              grantId: 'grant-authorized',
+              maxAttempts: 4,
+              maxConsecutiveNoProgressAttempts: 2,
+            },
+            destinationWorkflowId: 'control-stop-continuation-linked',
+            restorationEvidenceRef: 'artifact://restore/evidence',
+            hostSessionLifecycle: {
+              activityCleanupCompleted: true,
+              omnigentSessionId: 'session-7',
+            },
+          },
+        },
+      },
+      finishSummary: {
+        finishOutcome: { code: 'FAILED', stage: 'finalizing' },
+        controlStop: {
+          kind: 'workflow_gate',
+          controlStopId: 'verify:control-stop:6',
+          verdict: 'ADDITIONAL_WORK_NEEDED',
+          reasonCode: 'remediation_budget_exhausted',
+          remainingWorkRef: 'artifact://remaining/final',
+          workspaceHeadRef: 'artifact://workspace/final',
+          publicationFeasible: false,
+          publicationAttempted: false,
+        },
+      },
+    };
+    fetchSpy.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.endsWith('/actions/continue-remediation') && init?.method === 'POST') {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            destinationWorkflowId: 'control-stop-continuation-linked',
+          }),
+        } as Response);
+      }
+      return Promise.resolve({
+        ok: true,
+        json: async () => execution,
+      } as Response);
+    });
+
+    renderWithClient(<WorkflowDetailPage payload={actionsPayload} />);
+
+    expect(await screen.findByText('4 attempts · 2 consecutive no-progress')).toBeTruthy();
+    expect(screen.getByText('6 / 6 · remediation attempts')).toBeTruthy();
+    expect(screen.getByText('artifact://restore/evidence')).toBeTruthy();
+    fireEvent.change(
+      screen.getByRole('spinbutton', { name: 'Continuation maximum attempts' }),
+      { target: { value: '3' } },
+    );
+    fireEvent.change(
+      screen.getByRole('spinbutton', {
+        name: 'Continuation consecutive no-progress attempts',
+      }),
+      { target: { value: '1' } },
+    );
+    const menu = await openWorkflowActionsMenu('Continue remediation');
+    fireEvent.click(
+      within(menu).getByRole('menuitem', { name: 'Continue remediation' }),
+    );
+
+    await waitFor(() => {
+      const post = fetchSpy.mock.calls.find(
+        ([url, init]) =>
+          String(url).endsWith('/actions/continue-remediation') &&
+          init?.method === 'POST',
+      );
+      expect(post).toBeTruthy();
+      expect(JSON.parse(String(post?.[1]?.body))).toEqual({
+        proposedContinuationBudget: {
+          maxAttempts: 3,
+          maxConsecutiveNoProgressAttempts: 1,
+        },
+      });
+    });
+  });
+
   function mockWorkflowWorkspaceFetchesWithSelectedOutsideList() {
     const selectedExecution = {
       taskId: 'test-123',

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -8055,6 +8055,11 @@ function WorkflowDetailPageContent({ payload }: { payload: BootPayload }) {
   );
   const [selectedRecoveryStepId, setSelectedRecoveryStepId] = useState('');
   const [selectedBranchId, setSelectedBranchId] = useState('');
+  const [continuationMaxAttempts, setContinuationMaxAttempts] = useState(1);
+  const [
+    continuationMaxConsecutiveNoProgressAttempts,
+    setContinuationMaxConsecutiveNoProgressAttempts,
+  ] = useState(1);
   const [latestBranchCompare, setLatestBranchCompare] = useState<z.infer<typeof CheckpointBranchCompareSchema> | null>(null);
 
   const detailQuery = useQuery(
@@ -8211,6 +8216,21 @@ function WorkflowDetailPageContent({ payload }: { payload: BootPayload }) {
     staleTime: evidenceStaleTime,
   });
   const latestRunId = stepsQuery.data?.runId || runId;
+  const continueRemediationEvidence =
+    execution?.actions?.actionEvidence?.continueRemediation;
+  const authorizedContinuationBudget =
+    continueRemediationEvidence?.continuationBudget;
+  useEffect(() => {
+    if (!authorizedContinuationBudget) return;
+    setContinuationMaxAttempts(authorizedContinuationBudget.maxAttempts);
+    setContinuationMaxConsecutiveNoProgressAttempts(
+      authorizedContinuationBudget.maxConsecutiveNoProgressAttempts,
+    );
+  }, [
+    authorizedContinuationBudget?.grantId,
+    authorizedContinuationBudget?.maxAttempts,
+    authorizedContinuationBudget?.maxConsecutiveNoProgressAttempts,
+  ]);
   const artifactRunId = execution?.stepsHref ? stepsQuery.data?.runId : runId;
   const selectedRecoveryOptions = useMemo(() => {
     const failedStepId = execution?.resume?.failedStepId || '';
@@ -8556,13 +8576,24 @@ function WorkflowDetailPageContent({ payload }: { payload: BootPayload }) {
 
   const continueRemediationMutation = useMutation({
     mutationFn: async () => {
+      if (!authorizedContinuationBudget?.grantId) {
+        throw new Error(
+          'Continue remediation requires an authorized continuation budget.',
+        );
+      }
       const response = await fetch(
         `${payload.apiBase}/executions/${encodeURIComponent(workflowId)}/actions/continue-remediation`,
         {
           method: 'POST',
           credentials: 'include',
           headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
-          body: JSON.stringify({}),
+          body: JSON.stringify({
+            proposedContinuationBudget: {
+              maxAttempts: continuationMaxAttempts,
+              maxConsecutiveNoProgressAttempts:
+                continuationMaxConsecutiveNoProgressAttempts,
+            },
+          }),
         },
       );
       if (!response.ok) {
@@ -9441,7 +9472,107 @@ function WorkflowDetailPageContent({ payload }: { payload: BootPayload }) {
                     <Fact label="Authoritative remaining work">
                       <code className="text-xs break-all">{runSummary.controlStop.remainingWorkRef || '—'}</code>
                     </Fact>
+                    {continueRemediationEvidence?.sourceBudget ? (
+                      <Fact label="Exhausted source budget">
+                        {continueRemediationEvidence.sourceBudget.consumedAttempts}
+                        {' / '}
+                        {continueRemediationEvidence.sourceBudget.maxAttempts}
+                        {' · '}
+                        {formatStatusLabel(
+                          continueRemediationEvidence.sourceBudget.exhaustedDimension,
+                        )}
+                      </Fact>
+                    ) : null}
+                    {authorizedContinuationBudget ? (
+                      <Fact label="Authorized continuation grant">
+                        {authorizedContinuationBudget.maxAttempts} attempts
+                        {' · '}
+                        {authorizedContinuationBudget.maxConsecutiveNoProgressAttempts}
+                        {' consecutive no-progress'}
+                      </Fact>
+                    ) : null}
+                    {continueRemediationEvidence?.destinationWorkflowId ? (
+                      <Fact label="Linked continuation">
+                        <a
+                          href={`/workflows/${encodeURIComponent(
+                            continueRemediationEvidence.destinationWorkflowId,
+                          )}/overview?source=temporal`}
+                        >
+                          <code className="text-xs break-all">
+                            {continueRemediationEvidence.destinationWorkflowId}
+                          </code>
+                        </a>
+                      </Fact>
+                    ) : null}
+                    {continueRemediationEvidence?.restorationEvidenceRef ? (
+                      <Fact label="Restoration provenance">
+                        <code className="text-xs break-all">
+                          {continueRemediationEvidence.restorationEvidenceRef}
+                        </code>
+                      </Fact>
+                    ) : null}
                   </FlatFactGrid>
+                  {authorizedContinuationBudget ? (
+                    <fieldset className="stack td-continuation-budget">
+                      <legend>Proposed continuation budget</legend>
+                      <label>
+                        Maximum attempts
+                        <input
+                          aria-label="Continuation maximum attempts"
+                          type="number"
+                          min={1}
+                          max={authorizedContinuationBudget.maxAttempts}
+                          value={continuationMaxAttempts}
+                          onChange={(event) =>
+                            setContinuationMaxAttempts(
+                              Math.max(
+                                1,
+                                Math.min(
+                                  authorizedContinuationBudget.maxAttempts,
+                                  Number(event.target.value) || 1,
+                                ),
+                              ),
+                            )}
+                        />
+                      </label>
+                      <label>
+                        Consecutive no-progress attempts
+                        <input
+                          aria-label="Continuation consecutive no-progress attempts"
+                          type="number"
+                          min={1}
+                          max={
+                            authorizedContinuationBudget
+                              .maxConsecutiveNoProgressAttempts
+                          }
+                          value={continuationMaxConsecutiveNoProgressAttempts}
+                          onChange={(event) =>
+                            setContinuationMaxConsecutiveNoProgressAttempts(
+                              Math.max(
+                                1,
+                                Math.min(
+                                  authorizedContinuationBudget
+                                    .maxConsecutiveNoProgressAttempts,
+                                  Number(event.target.value) || 1,
+                                ),
+                              ),
+                            )}
+                        />
+                      </label>
+                    </fieldset>
+                  ) : null}
+                  {continueRemediationEvidence?.hostSessionLifecycle ? (
+                    <details>
+                      <summary>Host/session lifecycle evidence</summary>
+                      <pre className="text-xs break-all">
+                        {JSON.stringify(
+                          continueRemediationEvidence.hostSessionLifecycle,
+                          null,
+                          2,
+                        )}
+                      </pre>
+                    </details>
+                  ) : null}
                   <p className="small">
                     Edit for rerun and Full retry reuse the original task input. Continue remediation,
                     when admitted, consumes the preserved candidate and remaining-work evidence.

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -6099,10 +6099,21 @@ export interface components {
             };
         };
         /**
+         * ContinueRemediationBudgetProposal
+         * @description Operator-selected limits bounded by the server-owned grant.
+         */
+        ContinueRemediationBudgetProposal: {
+            /** Maxattempts */
+            maxAttempts: number;
+            /** Maxconsecutivenoprogressattempts */
+            maxConsecutiveNoProgressAttempts: number;
+        };
+        /**
          * ContinueRemediationRequest
          * @description Select the frozen control-stop evidence owned by the source execution.
          */
         ContinueRemediationRequest: {
+            proposedContinuationBudget?: components["schemas"]["ContinueRemediationBudgetProposal"] | null;
             /** Instructionchangesref */
             instructionChangesRef?: string | null;
             /** Instructionchangesdigest */

--- a/frontend/src/lib/workflowActions.ts
+++ b/frontend/src/lib/workflowActions.ts
@@ -25,6 +25,23 @@ export const ExecutionActionsSchema = z
       z.object({
         candidateRef: z.string().nullable().optional(),
         remainingWorkRef: z.string().nullable().optional(),
+        controlStopId: z.string().nullable().optional(),
+        sourceBudget: z.object({
+          maxAttempts: z.number().int().positive(),
+          consumedAttempts: z.number().int().nonnegative(),
+          exhaustedDimension: z.string(),
+        }).passthrough().optional(),
+        continuationBudget: z.object({
+          grantId: z.string(),
+          maxAttempts: z.number().int().positive(),
+          maxConsecutiveNoProgressAttempts: z.number().int().positive(),
+          consumedAttempts: z.number().int().nonnegative().optional(),
+          consecutiveNoProgressAttempts: z.number().int().nonnegative().optional(),
+        }).passthrough().optional(),
+        destinationWorkflowId: z.string().nullable().optional(),
+        restorationEvidenceRef: z.string().nullable().optional(),
+        restorationEvidenceDigest: z.string().nullable().optional(),
+        hostSessionLifecycle: z.record(z.string(), z.unknown()).nullable().optional(),
       }).passthrough(),
     ).optional(),
     canCancel: z.boolean().optional(),

--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -8735,6 +8735,30 @@ button.workflow-workspace-sidebar-row:active {
   overflow-wrap: anywhere;
 }
 
+.td-continuation-budget {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.75rem 1rem;
+  min-inline-size: 0;
+  margin: 0;
+  padding: 0.9rem;
+  border: 1px solid rgb(var(--mm-border) / 0.72);
+  border-radius: 0.75rem;
+  background: rgb(var(--mm-panel) / 0.42);
+}
+
+.td-continuation-budget legend {
+  padding-inline: 0.35rem;
+  color: rgb(var(--mm-ink));
+  font-size: 0.88rem;
+  font-weight: 700;
+}
+
+.td-continuation-budget input {
+  width: 100%;
+  min-width: 0;
+}
+
 .td-remediation-list {
   display: grid;
   gap: 0.75rem;
@@ -9238,6 +9262,10 @@ button.workflow-workspace-sidebar-row:active {
 @media (max-width: 720px) {
   .td-remediation-region {
     padding: 0.7rem;
+  }
+
+  .td-continuation-budget {
+    grid-template-columns: minmax(0, 1fr);
   }
 
   .td-remediation-list {

--- a/moonmind/config/settings.py
+++ b/moonmind/config/settings.py
@@ -2339,6 +2339,55 @@ class FeatureFlagsSettings(BaseSettings):
             "PUBLICATION_RECOVERY_GENERATION",
         ),
     )
+    control_stop_continuation_enabled: bool = Field(
+        False,
+        validation_alias=AliasChoices(
+            "FEATURE_FLAGS__CONTROL_STOP_CONTINUATION_ENABLED",
+            "CONTROL_STOP_CONTINUATION_ENABLED",
+        ),
+    )
+    control_stop_continuation_shadow: bool = Field(
+        False,
+        validation_alias=AliasChoices(
+            "FEATURE_FLAGS__CONTROL_STOP_CONTINUATION_SHADOW",
+            "CONTROL_STOP_CONTINUATION_SHADOW",
+        ),
+    )
+    control_stop_continuation_canary_owner_ids: str = Field(
+        "",
+        validation_alias=AliasChoices(
+            "FEATURE_FLAGS__CONTROL_STOP_CONTINUATION_CANARY_OWNER_IDS",
+            "CONTROL_STOP_CONTINUATION_CANARY_OWNER_IDS",
+        ),
+    )
+    control_stop_continuation_allowed_provider_profile_ids: str = Field(
+        "",
+        validation_alias=AliasChoices(
+            "FEATURE_FLAGS__CONTROL_STOP_CONTINUATION_ALLOWED_PROVIDER_PROFILE_IDS",
+            "CONTROL_STOP_CONTINUATION_ALLOWED_PROVIDER_PROFILE_IDS",
+        ),
+    )
+    control_stop_continuation_allowed_execution_profile_refs: str = Field(
+        "",
+        validation_alias=AliasChoices(
+            "FEATURE_FLAGS__CONTROL_STOP_CONTINUATION_ALLOWED_EXECUTION_PROFILE_REFS",
+            "CONTROL_STOP_CONTINUATION_ALLOWED_EXECUTION_PROFILE_REFS",
+        ),
+    )
+    control_stop_continuation_allowed_launch_policy_refs: str = Field(
+        "",
+        validation_alias=AliasChoices(
+            "FEATURE_FLAGS__CONTROL_STOP_CONTINUATION_ALLOWED_LAUNCH_POLICY_REFS",
+            "CONTROL_STOP_CONTINUATION_ALLOWED_LAUNCH_POLICY_REFS",
+        ),
+    )
+    control_stop_continuation_generation: str = Field(
+        "disabled",
+        validation_alias=AliasChoices(
+            "FEATURE_FLAGS__CONTROL_STOP_CONTINUATION_GENERATION",
+            "CONTROL_STOP_CONTINUATION_GENERATION",
+        ),
+    )
     live_logs_session_timeline_rollout: Literal[
         "off",
         "internal",

--- a/moonmind/services/control_stop_continuation.py
+++ b/moonmind/services/control_stop_continuation.py
@@ -8,13 +8,15 @@ the same reserved destination.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import Any, Mapping, Protocol
+from typing import Any, Protocol
 
 from moonmind.workflows.executions.control_stop_continuation import (
     ContinuationBudgetGrant,
     ControlStopContinuationContract,
     ControlStopContinuationError,
+    ControlStopContinuationWorkflowInput,
 )
 
 
@@ -65,6 +67,7 @@ def _assert_authoritative_evidence(
     required = {
         contract.gate_result_ref: contract.gate_result_digest,
         contract.remaining_work_ref: contract.remaining_work_digest,
+        contract.checkpoint_ref: contract.checkpoint_digest,
         contract.workspace_head_ref: contract.workspace_head_digest,
         contract.workspace_manifest_ref: contract.workspace_manifest_digest,
         contract.task_input_snapshot_ref: contract.task_input_snapshot_digest,
@@ -74,7 +77,12 @@ def _assert_authoritative_evidence(
         contract.lane.effective_launch_snapshot_ref: (
             contract.lane.effective_launch_snapshot_digest
         ),
+        contract.verification_instruction_ref: (
+            contract.verification_instruction_digest
+        ),
     }
+    if contract.instruction_changes_ref and contract.instruction_changes_digest:
+        required[contract.instruction_changes_ref] = contract.instruction_changes_digest
     stale = [
         ref
         for ref, expected_digest in required.items()
@@ -92,6 +100,35 @@ def _assert_authoritative_evidence(
         raise ControlStopContinuationError(
             "control-stop continuation deployment is not currently promoted"
         )
+
+
+def _select_continuation_budget(
+    *,
+    authorized: ContinuationBudgetGrant,
+    requested: ContinuationBudgetGrant,
+) -> ContinuationBudgetGrant:
+    """Validate an explicit operator selection within the frozen grant ceiling."""
+
+    if requested.grant_id != authorized.grant_id:
+        raise ControlStopContinuationError(
+            "requested continuation budget uses a different grant identity"
+        )
+    if (
+        requested.consumed_attempts != 0
+        or requested.consecutive_no_progress_attempts != 0
+    ):
+        raise ControlStopContinuationError(
+            "a new continuation budget must begin with zero consumption"
+        )
+    if (
+        requested.max_attempts > authorized.max_attempts
+        or requested.max_consecutive_no_progress_attempts
+        > authorized.max_consecutive_no_progress_attempts
+    ):
+        raise ControlStopContinuationError(
+            "requested continuation budget exceeds the authorized frozen grant"
+        )
+    return requested
 
 
 async def admit_control_stop_continuation(
@@ -127,10 +164,10 @@ async def admit_control_stop_continuation(
         raise ControlStopContinuationError(
             "requested source identity does not match authoritative evidence"
         )
-    if contract.continuation_budget != continuation_budget:
-        raise ControlStopContinuationError(
-            "requested continuation budget does not match the authorized frozen grant"
-        )
+    selected_budget = _select_continuation_budget(
+        authorized=contract.continuation_budget,
+        requested=continuation_budget,
+    )
     if (
         contract.instruction_changes_ref != instruction_changes_ref
         or contract.instruction_changes_digest != instruction_changes_digest
@@ -138,6 +175,7 @@ async def admit_control_stop_continuation(
         raise ControlStopContinuationError(
             "requested instruction changes do not match authoritative evidence"
         )
+    contract = contract.model_copy(update={"continuation_budget": selected_budget})
     _assert_authoritative_evidence(contract, evidence)
 
     reservation = await repository.reserve_destination(contract=contract)
@@ -154,6 +192,8 @@ async def admit_control_stop_continuation(
         )
     await starter.start_or_reconcile(
         workflow_id=contract.destination_workflow_id,
-        input_payload=contract.model_dump(by_alias=True, mode="json"),
+        input_payload=ControlStopContinuationWorkflowInput.initial(contract).model_dump(
+            by_alias=True, mode="json"
+        ),
     )
     return reservation

--- a/moonmind/workflows/executions/control_stop_continuation.py
+++ b/moonmind/workflows/executions/control_stop_continuation.py
@@ -13,6 +13,8 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
+from moonmind.security.outbound_scan import scan_outbound_text
+
 
 class ControlStopContinuationError(ValueError):
     """A control-stop continuation contract is unsafe or incomplete."""
@@ -32,7 +34,7 @@ class ContinuationBudgetGrant(BaseModel):
     )
 
     @model_validator(mode="after")
-    def _bounded_consumption(self) -> "ContinuationBudgetGrant":
+    def _bounded_consumption(self) -> ContinuationBudgetGrant:
         if self.consumed_attempts > self.max_attempts:
             raise ValueError("consumedAttempts exceeds the continuation grant")
         if (
@@ -42,12 +44,14 @@ class ContinuationBudgetGrant(BaseModel):
             raise ValueError("no-progress consumption exceeds the continuation grant")
         return self
 
-    def consume(self, *, progress: bool) -> "ContinuationBudgetGrant":
+    def consume(self, *, progress: bool) -> ContinuationBudgetGrant:
         if self.consumed_attempts >= self.max_attempts:
             raise ControlStopContinuationError("continuation_attempt_budget_exhausted")
         no_progress = 0 if progress else self.consecutive_no_progress_attempts + 1
         if no_progress > self.max_consecutive_no_progress_attempts:
-            raise ControlStopContinuationError("continuation_no_progress_budget_exhausted")
+            raise ControlStopContinuationError(
+                "continuation_no_progress_budget_exhausted"
+            )
         return self.model_copy(
             update={
                 "consumed_attempts": self.consumed_attempts + 1,
@@ -64,6 +68,38 @@ class SourceBudgetEvidence(BaseModel):
     exhausted_dimension: Literal[
         "remediation_attempts", "consecutive_no_progress_attempts"
     ] = Field(alias="exhaustedDimension")
+
+
+class ControlStopRolloutPolicy(BaseModel):
+    """Frozen admission policy for one continuation destination.
+
+    Current deployment policy is evaluated before destination creation.  This
+    compact snapshot is then the replay authority, so disabling new admissions
+    never changes an already-linked workflow.
+    """
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    mode: Literal["shadow", "canary", "enabled"]
+    canary_owner_ids: list[str] = Field(default_factory=list, alias="canaryOwnerIds")
+    allowed_provider_profile_ids: list[str] = Field(
+        alias="allowedProviderProfileIds", min_length=1
+    )
+    allowed_execution_profile_refs: list[str] = Field(
+        alias="allowedExecutionProfileRefs", min_length=1
+    )
+    allowed_launch_policy_refs: list[str] = Field(
+        alias="allowedLaunchPolicyRefs", min_length=1
+    )
+    allowed_runtime: Literal["external/omnigent"] = Field(
+        "external/omnigent", alias="allowedRuntime"
+    )
+    allowed_product: Literal["codex-native"] = Field(
+        "codex-native", alias="allowedProduct"
+    )
+    allowed_host_profile: Literal["omnigent-host-codex"] = Field(
+        "omnigent-host-codex", alias="allowedHostProfile"
+    )
 
 
 class FrozenProfileBoundLane(BaseModel):
@@ -97,9 +133,7 @@ class FrozenProfileBoundLane(BaseModel):
 class PreservedControlStopStep(BaseModel):
     model_config = ConfigDict(populate_by_name=True, extra="forbid")
 
-    source_step_execution_id: str = Field(
-        alias="sourceStepExecutionId", min_length=1
-    )
+    source_step_execution_id: str = Field(alias="sourceStepExecutionId", min_length=1)
     logical_step_id: str = Field(alias="logicalStepId", min_length=1)
     execution_ordinal: int = Field(alias="executionOrdinal", ge=1)
     terminal_disposition: Literal["accepted", "accepted_control_result"] = Field(
@@ -113,7 +147,7 @@ class PreservedControlStopStep(BaseModel):
     semantic_verdict: str | None = Field(None, alias="semanticVerdict")
 
     @model_validator(mode="after")
-    def _negative_verifier_is_control_evidence(self) -> "PreservedControlStopStep":
+    def _negative_verifier_is_control_evidence(self) -> PreservedControlStopStep:
         if (
             self.semantic_verdict == "ADDITIONAL_WORK_NEEDED"
             and self.terminal_disposition != "accepted_control_result"
@@ -129,17 +163,75 @@ class PreservedSideEffect(BaseModel):
 
     operation: str = Field(min_length=1)
     evidence_ref: str = Field(alias="evidenceRef", min_length=1)
-    disposition: Literal["already_performed", "reconcile", "reapply", "blocked"]
-    idempotency_key: str | None = Field(None, alias="idempotencyKey")
-    authorization_ref: str | None = Field(None, alias="authorizationRef")
+    disposition: Literal["already_performed"]
+
+
+class ContinuationVerificationResult(BaseModel):
+    """Typed semantic evidence returned by the authoritative verifier."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    verdict: Literal[
+        "FULLY_IMPLEMENTED",
+        "ADDITIONAL_WORK_NEEDED",
+        "BLOCKED",
+        "FAILED_UNRECOVERABLE",
+        "ENVIRONMENT_CONTAMINATED_BY_SKILL_PROJECTION",
+    ]
+    verification_ref: str = Field(alias="verificationRef", min_length=1)
+    remaining_work_ref: str | None = Field(None, alias="remainingWorkRef")
+    progress: bool
+    progress_evidence_ref: str | None = Field(None, alias="progressEvidenceRef")
 
     @model_validator(mode="after")
-    def _safe_disposition(self) -> "PreservedSideEffect":
-        if self.disposition == "reconcile" and not self.idempotency_key:
-            raise ValueError("reconciliation requires a stable idempotencyKey")
-        if self.disposition == "reapply" and not self.authorization_ref:
-            raise ValueError("reapplication requires an authorizationRef")
+    def _remaining_work_is_authoritative(self) -> ContinuationVerificationResult:
+        if self.verdict == "ADDITIONAL_WORK_NEEDED" and not self.remaining_work_ref:
+            raise ValueError("ADDITIONAL_WORK_NEEDED requires remainingWorkRef")
         return self
+
+
+class ContinuationAttemptEvidence(BaseModel):
+    """Compact, replay-safe evidence for one remediation/verification pair."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    attempt_ordinal: int = Field(alias="attemptOrdinal", ge=1)
+    remediation_step_execution_id: str = Field(
+        alias="remediationStepExecutionId", min_length=1
+    )
+    verification_step_execution_id: str = Field(
+        alias="verificationStepExecutionId", min_length=1
+    )
+    candidate_ref: str = Field(alias="candidateRef", min_length=1)
+    candidate_digest: str = Field(alias="candidateDigest", min_length=1)
+    progress: bool
+    semantic_verdict: str = Field(alias="semanticVerdict", min_length=1)
+    verification_ref: str = Field(alias="verificationRef", min_length=1)
+    remaining_work_ref: str | None = Field(None, alias="remainingWorkRef")
+    lifecycle: dict[str, str | bool | int | None] = Field(default_factory=dict)
+
+
+class ControlStopContinuationState(BaseModel):
+    """State transferred verbatim across Continue-As-New boundaries."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    destination_workspace_locator: dict[str, Any] = Field(
+        alias="destinationWorkspaceLocator"
+    )
+    restoration_evidence_ref: str = Field(alias="restorationEvidenceRef", min_length=1)
+    restoration_evidence_digest: str = Field(
+        alias="restorationEvidenceDigest", min_length=1
+    )
+    latest_workspace_head_ref: str = Field(alias="latestWorkspaceHeadRef", min_length=1)
+    latest_workspace_head_digest: str = Field(
+        alias="latestWorkspaceHeadDigest", min_length=1
+    )
+    latest_verification_ref: str = Field(alias="latestVerificationRef", min_length=1)
+    remaining_work_ref: str = Field(alias="remainingWorkRef", min_length=1)
+    continuation_budget: ContinuationBudgetGrant = Field(alias="continuationBudget")
+    attempts: list[ContinuationAttemptEvidence] = Field(default_factory=list)
+    continue_as_new_count: int = Field(0, alias="continueAsNewCount", ge=0)
 
 
 class ControlStopContinuationContract(BaseModel):
@@ -147,8 +239,8 @@ class ControlStopContinuationContract(BaseModel):
 
     model_config = ConfigDict(populate_by_name=True, extra="forbid")
 
-    schema_version: Literal["control-stop-continuation/v1"] = Field(
-        "control-stop-continuation/v1", alias="schemaVersion"
+    schema_version: Literal["control-stop-continuation/v2"] = Field(
+        "control-stop-continuation/v2", alias="schemaVersion"
     )
     target_kind: Literal["control_stop"] = Field(alias="targetKind")
     phase: Literal["continue_to_remediation"]
@@ -158,9 +250,7 @@ class ControlStopContinuationContract(BaseModel):
     owner_type: Literal["user", "service", "system"] = Field(alias="ownerType")
     owner_id: str = Field(alias="ownerId", min_length=1)
     control_stop_id: str = Field(alias="controlStopId", min_length=1)
-    semantic_verdict: Literal["ADDITIONAL_WORK_NEEDED"] = Field(
-        alias="semanticVerdict"
-    )
+    semantic_verdict: Literal["ADDITIONAL_WORK_NEEDED"] = Field(alias="semanticVerdict")
     stop_reason: Literal[
         "remediation_budget_exhausted",
         "no_progress_attempts_exhausted",
@@ -170,6 +260,8 @@ class ControlStopContinuationContract(BaseModel):
     gate_result_digest: str = Field(alias="gateResultDigest", min_length=1)
     remaining_work_ref: str = Field(alias="remainingWorkRef", min_length=1)
     remaining_work_digest: str = Field(alias="remainingWorkDigest", min_length=1)
+    checkpoint_ref: str = Field(alias="checkpointRef", min_length=1)
+    checkpoint_digest: str = Field(alias="checkpointDigest", min_length=1)
     workspace_head_ref: str = Field(alias="workspaceHeadRef", min_length=1)
     workspace_head_digest: str = Field(
         alias="workspaceHeadDigest", pattern=r"^sha256:[0-9a-f]{64}$"
@@ -198,11 +290,29 @@ class ControlStopContinuationContract(BaseModel):
     continuation_budget: ContinuationBudgetGrant = Field(alias="continuationBudget")
     deployment_generation: str = Field(alias="deploymentGeneration", min_length=1)
     deployment_promoted: bool = Field(alias="deploymentPromoted")
+    rollout: ControlStopRolloutPolicy
     restore_capability_set_version: str = Field(
         alias="restoreCapabilitySetVersion", min_length=1
     )
     restore_capability_digest: str = Field(
         alias="restoreCapabilityDigest", min_length=1
+    )
+    capture_capability_set_version: Literal[
+        "runtime-execution-capabilities-v1",
+        "runtime-execution-capabilities-v2",
+        "runtime-execution-capabilities-v3",
+    ] = Field(alias="captureCapabilitySetVersion")
+    capture_capability_digest: str = Field(
+        alias="captureCapabilityDigest", min_length=1
+    )
+    verification_instruction_ref: str = Field(
+        alias="verificationInstructionRef", min_length=1
+    )
+    verification_instruction_digest: str = Field(
+        alias="verificationInstructionDigest", min_length=1
+    )
+    continue_as_new_after_attempts: int = Field(
+        10, alias="continueAsNewAfterAttempts", ge=1, le=100
     )
     idempotency_key: str = Field(alias="idempotencyKey", min_length=1, max_length=200)
     instruction_changes_ref: str | None = Field(None, alias="instructionChangesRef")
@@ -211,13 +321,30 @@ class ControlStopContinuationContract(BaseModel):
     )
 
     @model_validator(mode="after")
-    def _fail_closed_admission(self) -> "ControlStopContinuationContract":
+    def _fail_closed_admission(self) -> ControlStopContinuationContract:
         if not self.terminal_head:
             raise ValueError("selected checkpoint is not the source terminal head")
         if not self.deployment_promoted:
             raise ValueError("control-stop continuation deployment is not promoted")
-        if any(effect.disposition == "blocked" for effect in self.side_effects):
-            raise ValueError("source side effects block continuation")
+        if self.rollout.mode == "shadow":
+            raise ValueError("control-stop continuation is shadow diagnostics only")
+        if (
+            self.rollout.mode == "canary"
+            and self.owner_id not in self.rollout.canary_owner_ids
+        ):
+            raise ValueError("owner is not selected for the control-stop canary")
+        if (
+            self.lane.provider_profile_id
+            not in self.rollout.allowed_provider_profile_ids
+        ):
+            raise ValueError("selected Provider Profile is not rollout-allowlisted")
+        if (
+            self.lane.execution_profile_id
+            not in self.rollout.allowed_execution_profile_refs
+        ):
+            raise ValueError("selected execution profile is not rollout-allowlisted")
+        if self.lane.launch_policy_ref not in self.rollout.allowed_launch_policy_refs:
+            raise ValueError("selected launch policy is not rollout-allowlisted")
         if bool(self.instruction_changes_ref) != bool(self.instruction_changes_digest):
             raise ValueError("instruction changes require both ref and digest")
         if not any(
@@ -233,6 +360,16 @@ class ControlStopContinuationContract(BaseModel):
                 "frozen runtime capabilities do not authorize the checkpoint "
                 "boundary and continuation phase"
             )
+        scan_payload = self.model_dump(by_alias=True, mode="json")
+        scan = scan_outbound_text(
+            json.dumps(scan_payload, sort_keys=True, separators=(",", ":")),
+            location="control_stop_continuation.contract",
+            high_security_mode=True,
+        )
+        if not scan.allowed:
+            raise ValueError(
+                "control-stop continuation contract failed secret scanning"
+            )
         return self
 
     @property
@@ -241,6 +378,8 @@ class ControlStopContinuationContract(BaseModel):
             "sourceWorkflowId": self.source_workflow_id,
             "sourceRunId": self.source_run_id,
             "controlStopId": self.control_stop_id,
+            "checkpointRef": self.checkpoint_ref,
+            "checkpointDigest": self.checkpoint_digest,
             "workspaceHeadRef": self.workspace_head_ref,
             "workspaceHeadDigest": self.workspace_head_digest,
             "idempotencyKey": self.idempotency_key,
@@ -277,6 +416,11 @@ class ControlStopContinuationContract(BaseModel):
             "product": "codex-native",
             "providerProfileId": self.lane.provider_profile_id,
             "hostProfile": "omnigent-host-codex",
+            "sourceBudget": self.source_budget.model_dump(by_alias=True, mode="json"),
+            "proposedGrant": self.continuation_budget.model_dump(
+                by_alias=True, mode="json"
+            ),
+            "rolloutGeneration": self.deployment_generation,
         }
 
     def restore_request(self, *, destination_run_id: str) -> dict[str, Any]:
@@ -305,7 +449,7 @@ class ControlStopContinuationContract(BaseModel):
                 "runId": self.source_run_id,
                 "logicalStepId": terminal_verifier.logical_step_id,
                 "executionOrdinal": terminal_verifier.execution_ordinal,
-                "checkpointRef": self.workspace_head_ref,
+                "checkpointRef": self.checkpoint_ref,
                 "checkpointBoundary": self.checkpoint_boundary,
             },
             "checkpoint": {
@@ -408,8 +552,8 @@ class ControlStopContinuationContract(BaseModel):
             "checkpointKind": "worktree_archive",
             "workspaceLocator": destination_workspace_locator,
             "expectedRuntimeId": "codex_cli",
-            "capabilitySetVersion": self.restore_capability_set_version,
-            "capabilityDigest": self.restore_capability_digest,
+            "capabilitySetVersion": self.capture_capability_set_version,
+            "capabilityDigest": self.capture_capability_digest,
             "artifactNamespace": (
                 f"control-stop-continuations/{self.destination_workflow_id}/"
                 f"attempts/{attempt}"
@@ -452,7 +596,7 @@ class ControlStopContinuationContract(BaseModel):
             "parameters": {
                 "omnigent": {
                     "prompt": {
-                        "instructionRef": self.gate_result_ref,
+                        "instructionRef": self.verification_instruction_ref,
                     }
                 },
                 "workflowId": self.destination_workflow_id,
@@ -469,12 +613,27 @@ class ControlStopContinuationContract(BaseModel):
                 "controlStopId": self.control_stop_id,
                 "candidateRef": workspace_head_ref,
                 "expectedResultContract": {
-                    "metadata.semanticVerdict": [
-                        "FULLY_IMPLEMENTED",
-                        "ADDITIONAL_WORK_NEEDED",
-                        "BLOCKED",
-                    ],
-                    "metadata.remainingWorkRef": "required_for_additional_work",
+                    "metadata.controlStopVerification": (
+                        "ContinuationVerificationResult"
+                    ),
                 },
             },
         }
+
+
+class ControlStopContinuationWorkflowInput(BaseModel):
+    """Stable workflow input for initial execution and Continue-As-New."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    schema_version: Literal["control-stop-continuation-workflow/v1"] = Field(
+        "control-stop-continuation-workflow/v1", alias="schemaVersion"
+    )
+    contract: ControlStopContinuationContract
+    state: ControlStopContinuationState | None = None
+
+    @classmethod
+    def initial(
+        cls, contract: ControlStopContinuationContract
+    ) -> ControlStopContinuationWorkflowInput:
+        return cls(contract=contract)

--- a/moonmind/workflows/temporal/workflows/control_stop_continuation.py
+++ b/moonmind/workflows/temporal/workflows/control_stop_continuation.py
@@ -1,4 +1,4 @@
-"""Temporal entrypoint for a control-stop remediation continuation."""
+"""Temporal controller for a profile-bound control-stop continuation."""
 
 from __future__ import annotations
 
@@ -7,23 +7,26 @@ from typing import Any
 
 from temporalio import exceptions, workflow
 from temporalio.common import RetryPolicy
+from temporalio.exceptions import CancelledError
 
+from moonmind.schemas.agent_runtime_models import AgentRunResult
+from moonmind.schemas.checkpoint_restore_models import ManagedWorkspaceRestoreResult
 from moonmind.schemas.managed_checkpoint_models import (
     ManagedWorkspaceCheckpointCaptureResult,
 )
-from moonmind.schemas.checkpoint_restore_models import ManagedWorkspaceRestoreResult
-from moonmind.schemas.agent_runtime_models import AgentRunResult
 from moonmind.workflows.executions.control_stop_continuation import (
+    ContinuationAttemptEvidence,
+    ContinuationVerificationResult,
     ControlStopContinuationContract,
-    ControlStopContinuationError,
+    ControlStopContinuationState,
+    ControlStopContinuationWorkflowInput,
 )
 from moonmind.workflows.temporal.activity_catalog import build_default_activity_catalog
 
 WORKFLOW_NAME = "MoonMind.ControlStopContinuation"
 _RESTORE_ACTIVITY = "agent_runtime.restore_workspace_checkpoint"
-_REMEDIATE_ACTIVITY = "integration.omnigent.profile_bound_execute"
+_PROFILE_ACTIVITY = "integration.omnigent.profile_bound_execute"
 _CAPTURE_ACTIVITY = "agent_runtime.capture_workspace_checkpoint"
-_VERIFY_ACTIVITY = "integration.omnigent.profile_bound_execute"
 
 
 async def _execute(activity_type: str, payload: dict[str, Any]) -> Any:
@@ -34,44 +37,225 @@ async def _execute(activity_type: str, payload: dict[str, Any]) -> Any:
         activity_type,
         payload,
         task_queue=route.task_queue,
-        start_to_close_timeout=timedelta(
-            seconds=route.timeouts.start_to_close_seconds
-        ),
+        start_to_close_timeout=timedelta(seconds=route.timeouts.start_to_close_seconds),
         schedule_to_close_timeout=timedelta(
             seconds=route.timeouts.schedule_to_close_seconds
         ),
-        heartbeat_timeout=timedelta(
-            seconds=route.timeouts.heartbeat_timeout_seconds
-        ),
+        heartbeat_timeout=timedelta(seconds=route.timeouts.heartbeat_timeout_seconds),
         retry_policy=RetryPolicy(
             initial_interval=timedelta(seconds=5),
             backoff_coefficient=2.0,
-            maximum_interval=timedelta(
-                seconds=route.retries.max_interval_seconds
-            ),
+            maximum_interval=timedelta(seconds=route.retries.max_interval_seconds),
             maximum_attempts=route.retries.max_attempts,
-            non_retryable_error_types=list(
-                route.retries.non_retryable_error_codes
-            ),
+            non_retryable_error_types=list(route.retries.non_retryable_error_codes),
         ),
     )
 
 
+def _safe_lifecycle(result: AgentRunResult) -> dict[str, str | bool | int | None]:
+    """Project only bounded Omnigent lifecycle evidence returned by the Activity."""
+
+    metadata = result.metadata or {}
+    projected: dict[str, str | bool | int | None] = {
+        "normalizedStatus": str(metadata.get("normalizedStatus") or "completed"),
+        "cleanupOwner": "profile_bound_activity",
+        # The profile-bound Activity returns only after its finally block has
+        # stopped/drained the host and released the Provider Profile last.
+        "activityCleanupCompleted": True,
+    }
+    for key in (
+        "omnigentSessionId",
+        "externalStateRef",
+        "captureManifestRef",
+        "stateCheckpointRef",
+        "checkpointKind",
+        "providerName",
+    ):
+        value = metadata.get(key)
+        if isinstance(value, (str, bool, int)) or value is None:
+            projected[key] = value
+    if result.diagnostics_ref:
+        projected["diagnosticsRef"] = result.diagnostics_ref
+    return projected
+
+
+def _attempt_lifecycle(
+    *,
+    remediation: AgentRunResult,
+    verification: AgentRunResult,
+) -> dict[str, str | bool | int | None]:
+    """Join both profile-bound host lifecycles without carrying provider payloads."""
+
+    remediation_lifecycle = _safe_lifecycle(remediation)
+    verification_lifecycle = _safe_lifecycle(verification)
+    lifecycle: dict[str, str | bool | int | None] = {
+        "cleanupOwner": "profile_bound_activity",
+        "activityCleanupCompleted": bool(
+            remediation_lifecycle["activityCleanupCompleted"]
+            and verification_lifecycle["activityCleanupCompleted"]
+        ),
+    }
+    for prefix, source in (
+        ("remediation", remediation_lifecycle),
+        ("verification", verification_lifecycle),
+    ):
+        for key, value in source.items():
+            if key in {"cleanupOwner", "activityCleanupCompleted"}:
+                continue
+            lifecycle[f"{prefix}{key[0].upper()}{key[1:]}"] = value
+    return lifecycle
+
+
 @workflow.defn(name=WORKFLOW_NAME)
 class MoonMindControlStopContinuationWorkflow:
-    """Restore the frozen cumulative head before any new semantic operation."""
+    """Restore Cn, then repeat remediation -> capture -> verification."""
+
+    def __init__(self) -> None:
+        self._projection: dict[str, Any] = {"status": "validating_contract"}
+
+    @workflow.query
+    def continuation_state(self) -> dict[str, Any]:
+        """Return the destination lifecycle without consulting mutable source state."""
+
+        return self._projection
+
+    def _project(
+        self,
+        *,
+        contract: ControlStopContinuationContract,
+        state: ControlStopContinuationState,
+        status: str,
+        failure_phase: str | None = None,
+        reason_code: str | None = None,
+    ) -> dict[str, Any]:
+        attempts = [
+            attempt.model_dump(by_alias=True, mode="json") for attempt in state.attempts
+        ]
+        latest_lifecycle = attempts[-1].get("lifecycle") if attempts else None
+        projection: dict[str, Any] = {
+            **contract.workflow_entry(),
+            "status": status,
+            "sourceOutcome": {
+                "workflowId": contract.source_workflow_id,
+                "runId": contract.source_run_id,
+                "status": "failed",
+                "kind": "workflow_gate",
+                "immutable": True,
+            },
+            "destinationOutcome": {
+                "workflowId": contract.destination_workflow_id,
+                "status": status,
+            },
+            "restorationEvidenceRef": state.restoration_evidence_ref,
+            "restorationEvidenceDigest": state.restoration_evidence_digest,
+            "destinationWorkspaceLocator": state.destination_workspace_locator,
+            "candidateState": (
+                "accepted_complete" if status == "accepted" else "recovered_candidate"
+            ),
+            "latestWorkspaceHeadRef": state.latest_workspace_head_ref,
+            "latestWorkspaceHeadDigest": state.latest_workspace_head_digest,
+            "latestVerificationRef": state.latest_verification_ref,
+            "remainingWorkRef": state.remaining_work_ref,
+            "sourceBudget": contract.source_budget.model_dump(
+                by_alias=True, mode="json"
+            ),
+            "continuationBudget": state.continuation_budget.model_dump(
+                by_alias=True, mode="json"
+            ),
+            "preservedSteps": [
+                step.model_dump(by_alias=True, mode="json")
+                for step in contract.preserved_steps
+            ],
+            "skippedSideEffects": [
+                effect.model_dump(by_alias=True, mode="json")
+                for effect in contract.side_effects
+            ],
+            "attempts": attempts,
+            "hostSessionLifecycle": latest_lifecycle,
+            "continueAsNewCount": state.continue_as_new_count,
+            "metrics": {
+                "restoreSucceeded": 1,
+                "attemptsCompleted": len(attempts),
+                "converged": status == "accepted",
+                "sideEffectsSkipped": sum(
+                    effect.disposition == "already_performed"
+                    for effect in contract.side_effects
+                ),
+            },
+        }
+        if failure_phase:
+            projection["failurePhase"] = failure_phase
+        if reason_code:
+            projection["reasonCode"] = reason_code
+        self._projection = projection
+        return projection
+
+    def _pre_restore_terminal(
+        self,
+        *,
+        contract: ControlStopContinuationContract,
+        status: str,
+        failure_phase: str,
+        reason_code: str,
+    ) -> dict[str, Any]:
+        projection = {
+            **contract.workflow_entry(),
+            "status": status,
+            "failurePhase": failure_phase,
+            "reasonCode": reason_code,
+            "sourceOutcome": {
+                "workflowId": contract.source_workflow_id,
+                "runId": contract.source_run_id,
+                "status": "failed",
+                "kind": "workflow_gate",
+                "immutable": True,
+            },
+            "destinationOutcome": {
+                "workflowId": contract.destination_workflow_id,
+                "status": status,
+            },
+            "latestWorkspaceHeadRef": contract.workspace_head_ref,
+            "latestWorkspaceHeadDigest": contract.workspace_head_digest,
+            "latestVerificationRef": contract.gate_result_ref,
+            "remainingWorkRef": contract.remaining_work_ref,
+            "sourceBudget": contract.source_budget.model_dump(
+                by_alias=True, mode="json"
+            ),
+            "continuationBudget": contract.continuation_budget.model_dump(
+                by_alias=True, mode="json"
+            ),
+            "preservedSteps": [
+                step.model_dump(by_alias=True, mode="json")
+                for step in contract.preserved_steps
+            ],
+            "skippedSideEffects": [
+                effect.model_dump(by_alias=True, mode="json")
+                for effect in contract.side_effects
+            ],
+            "attempts": [],
+            "metrics": {
+                "restoreSucceeded": 0,
+                "attemptsCompleted": 0,
+                "converged": False,
+            },
+        }
+        self._projection = projection
+        return projection
 
     @workflow.run
     async def run(self, input_payload: dict[str, Any]) -> dict[str, Any]:
         try:
-            contract = ControlStopContinuationContract.model_validate(input_payload)
+            workflow_input = ControlStopContinuationWorkflowInput.model_validate(
+                input_payload
+            )
         except Exception as exc:
             raise exceptions.ApplicationError(
-                "invalid control-stop continuation contract",
+                "invalid control-stop continuation workflow input",
                 type="CONTROL_STOP_CONTINUATION_INVALID",
                 non_retryable=True,
             ) from exc
 
+        contract = workflow_input.contract
         info = workflow.info()
         if info.workflow_id != contract.destination_workflow_id:
             raise exceptions.ApplicationError(
@@ -80,256 +264,347 @@ class MoonMindControlStopContinuationWorkflow:
                 non_retryable=True,
             )
 
-        restored_payload = await _execute(
-            _RESTORE_ACTIVITY,
-            contract.restore_request(destination_run_id=info.run_id),
-        )
-        restored = ManagedWorkspaceRestoreResult.model_validate(restored_payload)
-        expected_key = f"{contract.destination_workflow_id}:restore"
-        if (
-            restored.checkpoint_ref != contract.workspace_head_ref
-            or restored.base_commit != contract.workspace_base_commit
-            or restored.idempotency_key != expected_key
-            or restored.destination_workspace_locator.agent_run_id
-            != contract.destination_workspace_id
-        ):
-            raise exceptions.ApplicationError(
-                "workspace restoration result does not match frozen contract",
-                type="CONTROL_STOP_RESTORE_EVIDENCE_MISMATCH",
-                non_retryable=True,
-            )
+        state = workflow_input.state
+        if state is None:
+            self._projection = {
+                **contract.workflow_entry(),
+                "status": "restoring",
+                "sourceOutcome": {
+                    "workflowId": contract.source_workflow_id,
+                    "runId": contract.source_run_id,
+                    "status": "failed",
+                    "kind": "workflow_gate",
+                    "immutable": True,
+                },
+            }
+            try:
+                restored_payload = await _execute(
+                    _RESTORE_ACTIVITY,
+                    contract.restore_request(destination_run_id=info.run_id),
+                )
+                restored = ManagedWorkspaceRestoreResult.model_validate(
+                    restored_payload
+                )
+            except CancelledError:
+                self._pre_restore_terminal(
+                    contract=contract,
+                    status="canceled",
+                    failure_phase="restoration",
+                    reason_code="continuation_canceled",
+                )
+                raise
+            except Exception as exc:  # noqa: BLE001 - phase becomes terminal evidence
+                return self._pre_restore_terminal(
+                    contract=contract,
+                    status="failed",
+                    failure_phase="restoration",
+                    reason_code=type(exc).__name__,
+                )
 
-        workspace_locator = restored.destination_workspace_locator.model_dump(
-            by_alias=True, mode="json"
-        )
-        state: dict[str, Any] = {
-            **contract.workflow_entry(),
-            "restorationEvidenceRef": restored.restoration_evidence_ref,
-            "restorationEvidenceDigest": restored.restoration_evidence_digest,
-            "destinationWorkspaceLocator": workspace_locator,
-            "preservedSteps": [
-                step.model_dump(by_alias=True, mode="json")
-                for step in contract.preserved_steps
-            ],
-            "sideEffects": [
-                effect.model_dump(by_alias=True, mode="json")
-                for effect in contract.side_effects
-            ],
-            "sourceBudget": contract.source_budget.model_dump(
-                by_alias=True, mode="json"
-            ),
-            "attempts": [],
-        }
-        budget = contract.continuation_budget
-        workspace_head_ref = contract.workspace_head_ref
-        workspace_head_digest = contract.workspace_head_digest
-        remaining_work_ref = contract.remaining_work_ref
-        latest_verification_ref = contract.gate_result_ref
-
-        while budget.consumed_attempts < budget.max_attempts:
+            expected_key = f"{contract.destination_workflow_id}:restore"
             if (
-                budget.consecutive_no_progress_attempts
-                >= budget.max_consecutive_no_progress_attempts
+                restored.checkpoint_ref != contract.checkpoint_ref
+                or restored.base_commit != contract.workspace_base_commit
+                or restored.idempotency_key != expected_key
+                or restored.destination_workspace_locator.agent_run_id
+                != contract.destination_workspace_id
             ):
-                return {
-                    **state,
-                    "status": "control_stop",
-                    "outcomeKind": "workflow_gate",
-                    "reasonCode": "continuation_no_progress_budget_exhausted",
-                    "latestWorkspaceHeadRef": workspace_head_ref,
-                    "latestWorkspaceHeadDigest": workspace_head_digest,
-                    "remainingWorkRef": remaining_work_ref,
-                    "continuationBudget": budget.model_dump(
-                        by_alias=True, mode="json"
-                    ),
-                }
-            attempt = (
-                contract.source_budget.consumed_attempts
-                + budget.consumed_attempts
-                + 1
-            )
-            remediation = AgentRunResult.model_validate(
-                await _execute(
-                    _REMEDIATE_ACTIVITY,
-                    contract.remediation_request(
-                        destination_run_id=info.run_id,
-                        destination_workspace_locator=workspace_locator,
-                        attempt=attempt,
-                        workspace_head_ref=workspace_head_ref,
-                        latest_verification_ref=latest_verification_ref,
-                        remaining_work_ref=remaining_work_ref,
-                        continuation_budget=budget,
-                    ),
+                return self._pre_restore_terminal(
+                    contract=contract,
+                    status="failed",
+                    failure_phase="restoration",
+                    reason_code="CONTROL_STOP_RESTORE_EVIDENCE_MISMATCH",
                 )
-            )
-            if remediation.failure_class:
-                return {
-                    **state,
-                    "status": "failed",
-                    "failurePhase": "remediation",
-                    "latestWorkspaceHeadRef": workspace_head_ref,
-                    "latestWorkspaceHeadDigest": workspace_head_digest,
-                    "continuationBudget": budget.model_dump(
-                        by_alias=True, mode="json"
-                    ),
-                    "remediationResult": remediation.model_dump(
-                        by_alias=True, mode="json", exclude_none=True
-                    ),
-                }
 
-            captured = ManagedWorkspaceCheckpointCaptureResult.model_validate(
-                await _execute(
-                    _CAPTURE_ACTIVITY,
-                    contract.capture_request(
-                        destination_run_id=info.run_id,
-                        destination_workspace_locator=workspace_locator,
-                        attempt=attempt,
-                    ),
-                )
-            )
-            if captured.status != "captured" or captured.workspace is None:
-                return {
-                    **state,
-                    "status": "failed",
-                    "failurePhase": "candidate_capture",
-                    "latestWorkspaceHeadRef": workspace_head_ref,
-                    "latestWorkspaceHeadDigest": workspace_head_digest,
-                    "continuationBudget": budget.model_dump(
+            state = ControlStopContinuationState(
+                destinationWorkspaceLocator=(
+                    restored.destination_workspace_locator.model_dump(
                         by_alias=True, mode="json"
-                    ),
-                    "captureResult": captured.model_dump(
-                        by_alias=True, mode="json", exclude_none=True
-                    ),
-                }
+                    )
+                ),
+                restorationEvidenceRef=restored.restoration_evidence_ref,
+                restorationEvidenceDigest=restored.restoration_evidence_digest,
+                latestWorkspaceHeadRef=contract.workspace_head_ref,
+                latestWorkspaceHeadDigest=contract.workspace_head_digest,
+                latestVerificationRef=contract.gate_result_ref,
+                remainingWorkRef=contract.remaining_work_ref,
+                continuationBudget=contract.continuation_budget,
+            )
+
+        self._project(contract=contract, state=state, status="restored")
+
+        while state.continuation_budget.consumed_attempts < (
+            state.continuation_budget.max_attempts
+        ):
+            budget = state.continuation_budget
+            attempt = (
+                contract.source_budget.consumed_attempts + budget.consumed_attempts + 1
+            )
+            self._project(contract=contract, state=state, status="remediating")
+            try:
+                remediation = AgentRunResult.model_validate(
+                    await _execute(
+                        _PROFILE_ACTIVITY,
+                        contract.remediation_request(
+                            destination_run_id=info.run_id,
+                            destination_workspace_locator=(
+                                state.destination_workspace_locator
+                            ),
+                            attempt=attempt,
+                            workspace_head_ref=state.latest_workspace_head_ref,
+                            latest_verification_ref=state.latest_verification_ref,
+                            remaining_work_ref=state.remaining_work_ref,
+                            continuation_budget=budget,
+                        ),
+                    )
+                )
+            except CancelledError:
+                self._project(
+                    contract=contract,
+                    state=state,
+                    status="canceled",
+                    failure_phase="remediation",
+                    reason_code="continuation_canceled",
+                )
+                raise
+            except Exception as exc:  # noqa: BLE001 - phase becomes terminal evidence
+                return self._project(
+                    contract=contract,
+                    state=state,
+                    status="failed",
+                    failure_phase="remediation",
+                    reason_code=type(exc).__name__,
+                )
+            if remediation.failure_class:
+                return self._project(
+                    contract=contract,
+                    state=state,
+                    status="failed",
+                    failure_phase="remediation",
+                    reason_code=str(remediation.failure_class),
+                )
+
+            self._project(contract=contract, state=state, status="capturing_candidate")
+            try:
+                captured = ManagedWorkspaceCheckpointCaptureResult.model_validate(
+                    await _execute(
+                        _CAPTURE_ACTIVITY,
+                        contract.capture_request(
+                            destination_run_id=info.run_id,
+                            destination_workspace_locator=(
+                                state.destination_workspace_locator
+                            ),
+                            attempt=attempt,
+                        ),
+                    )
+                )
+            except CancelledError:
+                self._project(
+                    contract=contract,
+                    state=state,
+                    status="canceled",
+                    failure_phase="candidate_capture",
+                    reason_code="continuation_canceled",
+                )
+                raise
+            except Exception as exc:  # noqa: BLE001 - phase becomes terminal evidence
+                return self._project(
+                    contract=contract,
+                    state=state,
+                    status="failed",
+                    failure_phase="candidate_capture",
+                    reason_code=type(exc).__name__,
+                )
+
+            expected_capture_key = (
+                f"{contract.destination_workflow_id}:remediation:{attempt}:capture"
+            )
+            if (
+                captured.status != "captured"
+                or captured.workspace is None
+                or not captured.workspace.archive_ref
+                or not captured.workspace.archive_digest
+                or captured.idempotency_key != expected_capture_key
+                or captured.source_workspace_locator.model_dump(
+                    by_alias=True, mode="json"
+                )
+                != state.destination_workspace_locator
+            ):
+                return self._project(
+                    contract=contract,
+                    state=state,
+                    status="failed",
+                    failure_phase="candidate_capture",
+                    reason_code="CONTROL_STOP_CAPTURE_EVIDENCE_MISMATCH",
+                )
+
             candidate_ref = captured.workspace.archive_ref
             candidate_digest = captured.workspace.archive_digest
-            if not candidate_ref or not candidate_digest:
-                raise exceptions.ApplicationError(
-                    "captured candidate lacks restorable archive evidence",
-                    type="CONTROL_STOP_CAPTURE_EVIDENCE_MISSING",
-                    non_retryable=True,
-                )
-            progress = candidate_digest != workspace_head_digest
-            try:
-                budget = budget.consume(progress=progress)
-            except ControlStopContinuationError as exc:
-                return {
-                    **state,
-                    "status": "control_stop",
-                    "outcomeKind": "workflow_gate",
-                    "reasonCode": str(exc),
-                    "latestWorkspaceHeadRef": candidate_ref,
-                    "latestWorkspaceHeadDigest": candidate_digest,
-                    "remainingWorkRef": remaining_work_ref,
-                    "continuationBudget": budget.model_dump(
-                        by_alias=True, mode="json"
-                    ),
+            capture_state = state.model_copy(
+                update={
+                    "latest_workspace_head_ref": candidate_ref,
+                    "latest_workspace_head_digest": candidate_digest,
                 }
-
-            verification = AgentRunResult.model_validate(
-                await _execute(
-                    _VERIFY_ACTIVITY,
-                    contract.verification_request(
-                        destination_run_id=info.run_id,
-                        destination_workspace_locator=workspace_locator,
-                        attempt=attempt,
-                        workspace_head_ref=candidate_ref,
-                        remaining_work_ref=remaining_work_ref,
-                    ),
-                )
             )
-            gate = verification.metadata.get("moonSpecVerify")
-            gate = gate if isinstance(gate, dict) else verification.metadata
-            verdict = str(
-                gate.get("semanticVerdict")
-                or gate.get("verdict")
-                or gate.get("gateVerdict")
-                or gate.get("moonSpecVerdict")
-                or gate.get("verificationVerdict")
-                or ""
-            ).strip().upper()
-            verification_ref = str(
-                gate.get("gateResultRef")
-                or (verification.output_refs[0] if verification.output_refs else "")
-            ).strip()
-            attempt_result = {
-                "attemptOrdinal": attempt,
-                "remediationStepExecutionId": (
+            self._project(contract=contract, state=capture_state, status="verifying")
+            try:
+                verification = AgentRunResult.model_validate(
+                    await _execute(
+                        _PROFILE_ACTIVITY,
+                        contract.verification_request(
+                            destination_run_id=info.run_id,
+                            destination_workspace_locator=(
+                                state.destination_workspace_locator
+                            ),
+                            attempt=attempt,
+                            workspace_head_ref=candidate_ref,
+                            remaining_work_ref=state.remaining_work_ref,
+                        ),
+                    )
+                )
+            except CancelledError:
+                self._project(
+                    contract=contract,
+                    state=capture_state,
+                    status="canceled",
+                    failure_phase="verification",
+                    reason_code="continuation_canceled",
+                )
+                raise
+            except Exception as exc:  # noqa: BLE001 - phase becomes terminal evidence
+                return self._project(
+                    contract=contract,
+                    state=capture_state,
+                    status="failed",
+                    failure_phase="verification",
+                    reason_code=type(exc).__name__,
+                )
+            if verification.failure_class:
+                return self._project(
+                    contract=contract,
+                    state=capture_state,
+                    status="failed",
+                    failure_phase="verification",
+                    reason_code=str(verification.failure_class),
+                )
+
+            try:
+                gate = ContinuationVerificationResult.model_validate(
+                    verification.metadata.get("controlStopVerification")
+                )
+            except Exception:  # noqa: BLE001 - malformed provider evidence fails closed
+                return self._project(
+                    contract=contract,
+                    state=capture_state,
+                    status="failed",
+                    failure_phase="verification",
+                    reason_code="CONTROL_STOP_VERIFICATION_EVIDENCE_INVALID",
+                )
+            if gate.verification_ref not in verification.output_refs:
+                return self._project(
+                    contract=contract,
+                    state=capture_state,
+                    status="failed",
+                    failure_phase="verification",
+                    reason_code="CONTROL_STOP_VERIFICATION_REF_MISMATCH",
+                )
+
+            budget = budget.consume(progress=gate.progress)
+            attempt_evidence = ContinuationAttemptEvidence(
+                attemptOrdinal=attempt,
+                remediationStepExecutionId=(
                     f"{contract.destination_workflow_id}:remediation:"
                     f"execution:{attempt}"
                 ),
-                "verificationStepExecutionId": (
+                verificationStepExecutionId=(
                     f"{contract.destination_workflow_id}:verification:"
                     f"execution:{attempt}"
                 ),
-                "candidateRef": candidate_ref,
-                "candidateDigest": candidate_digest,
-                "progress": progress,
-                "semanticVerdict": verdict,
-                "verificationRef": verification_ref or None,
-            }
-            state["attempts"].append(attempt_result)
-            workspace_head_ref = candidate_ref
-            workspace_head_digest = candidate_digest
-            latest_verification_ref = verification_ref or latest_verification_ref
+                candidateRef=candidate_ref,
+                candidateDigest=candidate_digest,
+                progress=gate.progress,
+                semanticVerdict=gate.verdict,
+                verificationRef=gate.verification_ref,
+                remainingWorkRef=gate.remaining_work_ref,
+                lifecycle=_attempt_lifecycle(
+                    remediation=remediation,
+                    verification=verification,
+                ),
+            )
+            next_remaining_work_ref = (
+                gate.remaining_work_ref or state.remaining_work_ref
+            )
+            state = capture_state.model_copy(
+                update={
+                    "latest_verification_ref": gate.verification_ref,
+                    "remaining_work_ref": next_remaining_work_ref,
+                    "continuation_budget": budget,
+                    "attempts": [*state.attempts, attempt_evidence],
+                }
+            )
 
-            if verification.failure_class or verdict in {
+            if gate.verdict == "FULLY_IMPLEMENTED":
+                result = self._project(
+                    contract=contract, state=state, status="accepted"
+                )
+                result["nextSemanticOperation"] = "publication_gate"
+                return result
+            if gate.verdict in {
                 "BLOCKED",
-                "FAILED_UNRECOVERABLE",
+                "ENVIRONMENT_CONTAMINATED_BY_SKILL_PROJECTION",
             }:
-                return {
-                    **state,
-                    "status": "blocked" if verdict == "BLOCKED" else "failed",
-                    "failurePhase": "verification",
-                    "latestWorkspaceHeadRef": workspace_head_ref,
-                    "latestWorkspaceHeadDigest": workspace_head_digest,
-                    "continuationBudget": budget.model_dump(
-                        by_alias=True, mode="json"
-                    ),
-                    "verificationResult": verification.model_dump(
-                        by_alias=True, mode="json", exclude_none=True
-                    ),
-                }
-            if verdict == "FULLY_IMPLEMENTED":
-                return {
-                    **state,
-                    "status": "accepted",
-                    "candidateState": "accepted_complete",
-                    "nextSemanticOperation": "publication_gate",
-                    "latestWorkspaceHeadRef": workspace_head_ref,
-                    "latestWorkspaceHeadDigest": workspace_head_digest,
-                    "latestVerificationRef": latest_verification_ref,
-                    "continuationBudget": budget.model_dump(
-                        by_alias=True, mode="json"
-                    ),
-                }
-            if verdict != "ADDITIONAL_WORK_NEEDED":
-                raise exceptions.ApplicationError(
-                    "authoritative verifier returned an unsupported verdict",
-                    type="CONTROL_STOP_VERDICT_INVALID",
-                    non_retryable=True,
+                return self._project(
+                    contract=contract,
+                    state=state,
+                    status="blocked",
+                    failure_phase="verification",
+                    reason_code=gate.verdict,
                 )
-            next_remaining = str(
-                gate.get("remainingWorkRef")
-                or gate.get("remaining_work_ref")
-                or ""
-            ).strip()
-            if not next_remaining:
-                raise exceptions.ApplicationError(
-                    "additional work verdict lacks remaining-work evidence",
-                    type="CONTROL_STOP_REMAINING_WORK_MISSING",
-                    non_retryable=True,
+            if gate.verdict == "FAILED_UNRECOVERABLE":
+                return self._project(
+                    contract=contract,
+                    state=state,
+                    status="failed",
+                    failure_phase="verification",
+                    reason_code=gate.verdict,
                 )
-            remaining_work_ref = next_remaining
 
-        return {
-            **state,
-            "status": "control_stop",
-            "outcomeKind": "workflow_gate",
-            "reasonCode": "continuation_attempt_budget_exhausted",
-            "latestWorkspaceHeadRef": workspace_head_ref,
-            "latestWorkspaceHeadDigest": workspace_head_digest,
-            "latestVerificationRef": latest_verification_ref,
-            "remainingWorkRef": remaining_work_ref,
-            "continuationBudget": budget.model_dump(by_alias=True, mode="json"),
-        }
+            attempts_exhausted = budget.consumed_attempts >= budget.max_attempts
+            no_progress_exhausted = (
+                budget.consecutive_no_progress_attempts
+                >= budget.max_consecutive_no_progress_attempts
+            )
+            if attempts_exhausted or no_progress_exhausted:
+                return self._project(
+                    contract=contract,
+                    state=state,
+                    status="control_stop",
+                    reason_code=(
+                        "continuation_attempt_budget_exhausted"
+                        if attempts_exhausted
+                        else "continuation_no_progress_budget_exhausted"
+                    ),
+                )
+
+            if budget.consumed_attempts % contract.continue_as_new_after_attempts == 0:
+                continued_state = state.model_copy(
+                    update={"continue_as_new_count": state.continue_as_new_count + 1}
+                )
+                self._project(
+                    contract=contract,
+                    state=continued_state,
+                    status="continuing_as_new",
+                )
+                workflow.continue_as_new(
+                    ControlStopContinuationWorkflowInput(
+                        contract=contract,
+                        state=continued_state,
+                    ).model_dump(by_alias=True, mode="json")
+                )
+
+        return self._project(
+            contract=contract,
+            state=state,
+            status="control_stop",
+            reason_code="continuation_attempt_budget_exhausted",
+        )

--- a/tests/integration/reliability/test_checkpoint_cold_resume.py
+++ b/tests/integration/reliability/test_checkpoint_cold_resume.py
@@ -10,6 +10,9 @@ from pathlib import Path
 import pytest
 
 from moonmind.schemas.agent_runtime_models import ManagedRunRecord
+from moonmind.workflows.executions.control_stop_continuation import (
+    ControlStopContinuationContract,
+)
 from moonmind.workflows.executions.runtime_capabilities import (
     resolve_runtime_execution_capabilities,
 )
@@ -25,7 +28,9 @@ from moonmind.workflows.temporal.step_ledger import (
     refresh_ready_steps,
 )
 from moonmind.workflows.temporal.workflows.run import MoonMindRunWorkflow
-
+from tests.unit.workflows.executions.test_control_stop_continuation import (
+    _payload as control_stop_payload,
+)
 
 pytestmark = [
     pytest.mark.asyncio,
@@ -38,6 +43,7 @@ def _git(*args: str, cwd: Path) -> str:
     return subprocess.check_output(["git", *args], cwd=cwd, text=True).strip()
 
 
+@pytest.mark.integration_ci
 async def test_managed_codex_checkpoint_cold_resume_uses_only_durable_state(
     tmp_path: Path,
 ) -> None:
@@ -255,3 +261,61 @@ async def test_managed_codex_checkpoint_cold_resume_uses_only_durable_state(
     assert rows["implement"]["status"] == "ready"
     assert rows["verify"]["status"] == "pending"
     assert restored["restorationEvidenceRef"]
+
+    # The control-stop continuation contract consumes the same durable archive
+    # after the source workspace and ManagedRun record have been destroyed. Its
+    # deterministic destination and idempotency identity must survive a cold
+    # process boundary without any source-path fallback.
+    control_stop_checkpoint_ref = artifact_store.put_bytes(
+        json.dumps(
+            {
+                "contentType": (
+                    "application/vnd.moonmind.step-execution-checkpoint+json;version=1"
+                ),
+                "source": {
+                    "workflowId": "source",
+                    "runId": "source-run",
+                    "logicalStepId": "verify",
+                    "executionOrdinal": 6,
+                },
+                "boundary": "after_gate",
+                "workspace": workspace,
+            }
+        ).encode(),
+        content_type=(
+            "application/vnd.moonmind.step-execution-checkpoint+json;version=1"
+        ),
+    ).artifact_ref
+    payload = control_stop_payload()
+    payload.update(
+        {
+            "sourceWorkflowId": "source",
+            "checkpointRef": control_stop_checkpoint_ref,
+            "checkpointDigest": "checkpoint-envelope-digest",
+            "workspaceHeadRef": workspace["archiveRef"],
+            "workspaceHeadDigest": workspace["archiveDigest"],
+            "workspaceBaseCommit": base_commit,
+            "workspaceManifestRef": workspace["manifestRef"],
+            "workspaceManifestDigest": workspace["manifestDigest"],
+            "restoreCapabilitySetVersion": capabilities.capability_set_version,
+            "restoreCapabilityDigest": capabilities.capability_digest,
+            "captureCapabilitySetVersion": capabilities.capability_set_version,
+            "captureCapabilityDigest": capabilities.capability_digest,
+        }
+    )
+    contract = ControlStopContinuationContract.model_validate(payload)
+    control_stop_request = contract.restore_request(
+        destination_run_id="control-stop-run"
+    )
+    control_stop_restored = await restore_service.restore(control_stop_request)
+
+    assert control_stop_restored == await restore_service.restore(control_stop_request)
+    assert control_stop_restored["checkpointRef"] == control_stop_checkpoint_ref
+    assert control_stop_restored["destinationWorkspaceLocator"] == {
+        "kind": "managed_runtime",
+        "runtimeId": "codex_cli",
+        "agentRunId": contract.destination_workspace_id,
+        "relativePath": "repo",
+    }
+    assert not source_run_root.exists()
+    assert run_store.load("source-agent-run") is None

--- a/tests/integration/security/test_outbound_scan_contract.py
+++ b/tests/integration/security/test_outbound_scan_contract.py
@@ -1,11 +1,18 @@
 from __future__ import annotations
 
 import pytest
+from pydantic import ValidationError
 
 from moonmind.security.outbound_scan import (
     OutboundBundleItem,
     scan_outbound_bundle,
     scan_outbound_text,
+)
+from moonmind.workflows.executions.control_stop_continuation import (
+    ControlStopContinuationContract,
+)
+from tests.unit.workflows.executions.test_control_stop_continuation import (
+    _payload as control_stop_payload,
 )
 
 pytestmark = [pytest.mark.integration, pytest.mark.integration_ci]
@@ -92,4 +99,19 @@ def test_disabled_mode_preserves_exact_outbound_payloads() -> None:
 
     assert text_result.model_dump(by_alias=True)["originalContent"] == raw_text
     assert bundle_result.original_bundle == bundle
-    assert bundle_result.model_dump(by_alias=True)["originalBundle"][0]["content"] == raw_text
+    assert (
+        bundle_result.model_dump(by_alias=True)["originalBundle"][0]["content"]
+        == raw_text
+    )
+
+
+def test_control_stop_contract_blocks_secret_before_admission() -> None:
+    payload = control_stop_payload()
+    payload["remainingWorkRef"] = "artifact://" + "github_" + "pat_" + ("1" * 30)
+    admitted: list[str] = []
+
+    with pytest.raises(ValidationError, match="secret scanning"):
+        ControlStopContinuationContract.model_validate(payload)
+        admitted.append("started")
+
+    assert admitted == []

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -14737,8 +14737,22 @@ def test_workflow_gate_actions_expose_distinct_capabilities_and_consumed_refs(
     record.finish_summary_json = {
         "controlStop": {
             "kind": "workflow_gate",
+            "controlStopId": "verify:control-stop:6",
             "remainingWorkRef": "artifact://remaining/final",
             "workspaceHeadRef": "artifact://workspace/final",
+            "sourceBudget": {
+                "maxAttempts": 6,
+                "consumedAttempts": 6,
+                "exhaustedDimension": "remediation_attempts",
+            },
+            "continuationBudgetGrant": {
+                "grantId": "grant-1",
+                "maxAttempts": 3,
+                "maxConsecutiveNoProgressAttempts": 2,
+            },
+            "destinationWorkflowId": "control-stop-continuation-digest",
+            "restorationEvidenceRef": "artifact://restore/evidence",
+            "hostSessionLifecycle": {"activityCleanupCompleted": True},
             "metrics": {"remediationAdmitted": True},
             "auxiliaryOutcomes": {
                 "gitPublication": {
@@ -14804,6 +14818,20 @@ def test_workflow_gate_actions_expose_distinct_capabilities_and_consumed_refs(
     assert actions["actionEvidence"]["continueRemediation"] == {
         "candidateRef": "artifact://workspace/final",
         "remainingWorkRef": "artifact://remaining/final",
+        "controlStopId": "verify:control-stop:6",
+        "sourceBudget": {
+            "maxAttempts": 6,
+            "consumedAttempts": 6,
+            "exhaustedDimension": "remediation_attempts",
+        },
+        "continuationBudget": {
+            "grantId": "grant-1",
+            "maxAttempts": 3,
+            "maxConsecutiveNoProgressAttempts": 2,
+        },
+        "destinationWorkflowId": "control-stop-continuation-digest",
+        "restorationEvidenceRef": "artifact://restore/evidence",
+        "hostSessionLifecycle": {"activityCleanupCompleted": True},
     }
 
 
@@ -15330,11 +15358,21 @@ def test_continue_remediation_returns_same_destination_for_duplicate_requests(
 
     first = test_client.post(
         "/api/executions/mm:wf-1/actions/continue-remediation",
-        json={},
+        json={
+            "proposedContinuationBudget": {
+                "maxAttempts": 1,
+                "maxConsecutiveNoProgressAttempts": 1,
+            }
+        },
     )
     duplicate = test_client.post(
         "/api/executions/mm:wf-1/actions/continue-remediation",
-        json={},
+        json={
+            "proposedContinuationBudget": {
+                "maxAttempts": 1,
+                "maxConsecutiveNoProgressAttempts": 1,
+            }
+        },
     )
 
     assert first.status_code == 202
@@ -15351,6 +15389,7 @@ def test_continue_remediation_returns_same_destination_for_duplicate_requests(
         assert invocation.kwargs["source_run_id"] == "run-2"
         assert invocation.kwargs["control_stop_id"] == "verify:control-stop:6"
         assert invocation.kwargs["continuation_budget"].grant_id == "grant-1"
+        assert invocation.kwargs["continuation_budget"].max_attempts == 1
         assert invocation.kwargs["instruction_changes_ref"] is None
 
 

--- a/tests/unit/services/test_control_stop_continuation.py
+++ b/tests/unit/services/test_control_stop_continuation.py
@@ -18,6 +18,7 @@ def _evidence(payload: dict) -> ControlStopSourceEvidence:
     refs = {
         payload["gateResultRef"]: payload["gateResultDigest"],
         payload["remainingWorkRef"]: payload["remainingWorkDigest"],
+        payload["checkpointRef"]: payload["checkpointDigest"],
         payload["workspaceHeadRef"]: payload["workspaceHeadDigest"],
         payload["workspaceManifestRef"]: payload["workspaceManifestDigest"],
         payload["taskInputSnapshotRef"]: payload["taskInputSnapshotDigest"],
@@ -29,6 +30,7 @@ def _evidence(payload: dict) -> ControlStopSourceEvidence:
         payload["lane"]["effectiveLaunchSnapshotRef"]: payload["lane"][
             "effectiveLaunchSnapshotDigest"
         ],
+        payload["verificationInstructionRef"]: payload["verificationInstructionDigest"],
     }
     return ControlStopSourceEvidence(
         contract_payload=payload,
@@ -68,7 +70,8 @@ class _Starter:
         self.workflow_ids = []
 
     async def start_or_reconcile(self, *, workflow_id, input_payload):
-        assert input_payload["deploymentPromoted"] is True
+        assert input_payload["contract"]["deploymentPromoted"] is True
+        assert input_payload["state"] is None
         self.workflow_ids.append(workflow_id)
         return "existing-or-new-run"
 
@@ -159,6 +162,25 @@ async def test_budget_mismatch_fails_before_reservation_or_start() -> None:
 
     assert repository.reserve_calls == 0
     assert starter.workflow_ids == []
+
+
+@pytest.mark.asyncio
+async def test_operator_may_select_smaller_budget_within_frozen_grant() -> None:
+    payload = _payload()
+    repository = _Repository(_evidence(payload))
+    starter = _Starter()
+    requested = deepcopy(payload)
+    requested["continuationBudget"]["maxAttempts"] = 1
+
+    reservation = await _admit(
+        repository=repository,
+        starter=starter,
+        payload=requested,
+    )
+
+    assert reservation.created is True
+    assert repository.reserve_calls == 1
+    assert starter.workflow_ids == [reservation.destination_workflow_id]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/test_control_stop_continuation_repository.py
+++ b/tests/unit/services/test_control_stop_continuation_repository.py
@@ -10,9 +10,11 @@ from api_service.services.control_stop_continuation import (
     SqlControlStopContinuationRepository,
     TemporalControlStopContinuationStarter,
 )
+from moonmind.config.settings import settings
 from moonmind.workflows.executions.control_stop_continuation import (
     ControlStopContinuationContract,
     ControlStopContinuationError,
+    ControlStopContinuationWorkflowInput,
 )
 from moonmind.workflows.temporal.client import WorkflowStartResult
 from moonmind.workflows.temporal.workflows.control_stop_continuation import (
@@ -54,9 +56,9 @@ async def test_sql_repository_persists_one_reservation_across_sessions() -> None
 
     contract = ControlStopContinuationContract.model_validate(payload)
     async with sessions() as session:
-        first = await SqlControlStopContinuationRepository(
-            session
-        ).reserve_destination(contract=contract)
+        first = await SqlControlStopContinuationRepository(session).reserve_destination(
+            contract=contract
+        )
         await session.commit()
     async with sessions() as session:
         second = await SqlControlStopContinuationRepository(
@@ -93,9 +95,7 @@ async def test_sql_repository_rejects_conflicting_frozen_destination() -> None:
         )
         await session.commit()
         with pytest.raises(ControlStopContinuationError, match="conflicts"):
-            await SqlControlStopContinuationRepository(
-                session
-            ).reserve_destination(
+            await SqlControlStopContinuationRepository(session).reserve_destination(
                 contract=ControlStopContinuationContract.model_validate(payload)
             )
 
@@ -137,6 +137,80 @@ async def test_sql_repository_commits_reservation_before_returning() -> None:
     await engine.dispose()
 
 
+@pytest.mark.asyncio
+async def test_sql_repository_uses_current_exact_rollout_policy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    engine, sessions = await _database()
+    payload = _payload()
+    evidence = _evidence(payload)
+    async with sessions() as session:
+        session.add(
+            ControlStopContinuationRecord(
+                source_workflow_id=payload["sourceWorkflowId"],
+                source_run_id=payload["sourceRunId"],
+                control_stop_id=payload["controlStopId"],
+                contract_payload=deepcopy(payload),
+                artifact_digests=dict(evidence.artifact_digests),
+                deployment_generation=payload["deploymentGeneration"],
+                deployment_promoted=True,
+            )
+        )
+        await session.commit()
+
+    flags = settings.feature_flags
+    monkeypatch.setattr(flags, "control_stop_continuation_enabled", True)
+    monkeypatch.setattr(flags, "control_stop_continuation_shadow", False)
+    monkeypatch.setattr(
+        flags,
+        "control_stop_continuation_generation",
+        payload["deploymentGeneration"],
+    )
+    monkeypatch.setattr(
+        flags,
+        "control_stop_continuation_canary_owner_ids",
+        payload["ownerId"],
+    )
+    monkeypatch.setattr(
+        flags,
+        "control_stop_continuation_allowed_provider_profile_ids",
+        payload["lane"]["providerProfileId"],
+    )
+    monkeypatch.setattr(
+        flags,
+        "control_stop_continuation_allowed_execution_profile_refs",
+        payload["lane"]["executionProfileId"],
+    )
+    monkeypatch.setattr(
+        flags,
+        "control_stop_continuation_allowed_launch_policy_refs",
+        payload["lane"]["launchPolicyRef"],
+    )
+
+    async with sessions() as session:
+        current = await SqlControlStopContinuationRepository(
+            session
+        ).load_source_evidence(
+            source_workflow_id=payload["sourceWorkflowId"],
+            source_run_id=payload["sourceRunId"],
+            control_stop_id=payload["controlStopId"],
+        )
+    assert current.deployment_promoted is True
+    assert current.current_deployment_generation == payload["deploymentGeneration"]
+
+    monkeypatch.setattr(flags, "control_stop_continuation_enabled", False)
+    async with sessions() as session:
+        rolled_back = await SqlControlStopContinuationRepository(
+            session
+        ).load_source_evidence(
+            source_workflow_id=payload["sourceWorkflowId"],
+            source_run_id=payload["sourceRunId"],
+            control_stop_id=payload["controlStopId"],
+        )
+    assert rolled_back.deployment_promoted is False
+    await engine.dispose()
+
+
 class _TemporalAdapter:
     def __init__(self, result: WorkflowStartResult) -> None:
         self.result = result
@@ -150,23 +224,25 @@ class _TemporalAdapter:
 @pytest.mark.asyncio
 async def test_temporal_starter_uses_registered_type_and_reconciles_duplicate() -> None:
     payload = _payload()
-    workflow_id = ControlStopContinuationContract.model_validate(
-        payload
-    ).destination_workflow_id
+    contract = ControlStopContinuationContract.model_validate(payload)
+    workflow_id = contract.destination_workflow_id
+    workflow_input = ControlStopContinuationWorkflowInput.initial(contract).model_dump(
+        by_alias=True, mode="json"
+    )
     adapter = _TemporalAdapter(
         WorkflowStartResult(workflow_id=workflow_id, run_id="existing-run")
     )
 
     run_id = await TemporalControlStopContinuationStarter(
         adapter=adapter  # type: ignore[arg-type]
-    ).start_or_reconcile(workflow_id=workflow_id, input_payload=payload)
+    ).start_or_reconcile(workflow_id=workflow_id, input_payload=workflow_input)
 
     assert run_id == "existing-run"
     assert adapter.calls == [
         {
             "workflow_type": WORKFLOW_NAME,
             "workflow_id": workflow_id,
-            "input_args": payload,
+            "input_args": workflow_input,
             "id_reuse_policy": WorkflowIDReusePolicy.REJECT_DUPLICATE,
             "memo": {
                 "owner_id": payload["ownerId"],
@@ -189,9 +265,12 @@ async def test_temporal_starter_rejects_mismatched_reconciled_identity() -> None
     )
 
     with pytest.raises(ControlStopContinuationError, match="different"):
+        contract = ControlStopContinuationContract.model_validate(_payload())
         await TemporalControlStopContinuationStarter(
             adapter=adapter  # type: ignore[arg-type]
         ).start_or_reconcile(
             workflow_id="expected",
-            input_payload=_payload(),
+            input_payload=ControlStopContinuationWorkflowInput.initial(
+                contract
+            ).model_dump(by_alias=True, mode="json"),
         )

--- a/tests/unit/workflows/executions/test_control_stop_continuation.py
+++ b/tests/unit/workflows/executions/test_control_stop_continuation.py
@@ -26,6 +26,8 @@ def _payload() -> dict:
         "gateResultDigest": "gate-digest",
         "remainingWorkRef": "artifact://remaining/6",
         "remainingWorkDigest": "remaining-digest",
+        "checkpointRef": "artifact://checkpoint/C6",
+        "checkpointDigest": "checkpoint-digest",
         "workspaceHeadRef": "artifact://workspace/C6",
         "workspaceHeadDigest": f"sha256:{'a' * 64}",
         "workspaceBaseCommit": "abc123",
@@ -52,9 +54,7 @@ def _payload() -> dict:
             "capabilitySnapshotDigest": "capability-digest",
             "effectiveLaunchSnapshotRef": "artifact://effective-launch",
             "effectiveLaunchSnapshotDigest": "effective-launch-digest",
-            "checkpointBoundarySupport": {
-                "after_gate": ["continue_to_remediation"]
-            },
+            "checkpointBoundarySupport": {"after_gate": ["continue_to_remediation"]},
         },
         "preservedSteps": [
             {
@@ -96,8 +96,19 @@ def _payload() -> dict:
         },
         "deploymentGeneration": "control-stop-2026-07",
         "deploymentPromoted": True,
+        "rollout": {
+            "mode": "enabled",
+            "canaryOwnerIds": [],
+            "allowedProviderProfileIds": ["codex-oauth-primary"],
+            "allowedExecutionProfileRefs": ["codex-default"],
+            "allowedLaunchPolicyRefs": ["artifact://launch-policy"],
+        },
         "restoreCapabilitySetVersion": "runtime-execution-capabilities-v3",
         "restoreCapabilityDigest": "capability-digest",
+        "captureCapabilitySetVersion": "runtime-execution-capabilities-v3",
+        "captureCapabilityDigest": "capture-capability-digest",
+        "verificationInstructionRef": "artifact://verify/instructions",
+        "verificationInstructionDigest": "verification-instruction-digest",
         "idempotencyKey": "operator-request-1",
     }
 
@@ -134,16 +145,20 @@ def test_restore_request_uses_distinct_deterministic_destination() -> None:
     request = contract.restore_request(destination_run_id="destination-run")
 
     assert request["source"]["workflowId"] == "source-workflow"
+    assert request["source"]["checkpointRef"] == contract.checkpoint_ref
     assert request["recoveryIdentity"]["workflowId"] == contract.destination_workflow_id
     assert request["recoveryIdentity"]["runId"] == "destination-run"
     assert request["destination"]["agentRunId"] == contract.destination_workspace_id
     assert request["checkpoint"]["archiveDigest"] == f"sha256:{'a' * 64}"
     assert request["checkpoint"]["manifestDigest"] == f"sha256:{'b' * 64}"
     assert request["resumePhase"] == "continue_to_remediation"
+    assert request["capabilitySetVersion"] == (contract.restore_capability_set_version)
     assert request["idempotencyKey"] == f"{contract.destination_workflow_id}:restore"
 
 
-def test_attempt_requests_freeze_profile_and_have_distinct_retry_safe_identities() -> None:
+def test_attempt_requests_freeze_profile_and_have_distinct_retry_safe_identities() -> (
+    None
+):
     contract = ControlStopContinuationContract.model_validate(_payload())
     locator = {
         "kind": "managed_runtime",
@@ -178,9 +193,10 @@ def test_attempt_requests_freeze_profile_and_have_distinct_retry_safe_identities
     assert "instructionRef" not in verification
     assert (
         verification["parameters"]["omnigent"]["prompt"]["instructionRef"]
-        == contract.gate_result_ref
+        == contract.verification_instruction_ref
     )
     assert capture["workspaceLocator"] == locator
+    assert capture["capabilitySetVersion"] == (contract.capture_capability_set_version)
 
 
 def test_previous_restore_capability_value_remains_accepted() -> None:
@@ -202,6 +218,8 @@ def test_previous_restore_capability_value_remains_accepted() -> None:
         (("lane", "providerProfileId"), ""),
         (("continuationBudget", "maxAttempts"), 0),
         (("checkpointBoundary",), "before_execution"),
+        (("rollout", "mode"), "shadow"),
+        (("rollout", "allowedProviderProfileIds"), ["other-profile"]),
     ],
 )
 def test_incomplete_or_unsupported_contract_fails_closed(path, value) -> None:
@@ -218,7 +236,7 @@ def test_incomplete_or_unsupported_contract_fails_closed(path, value) -> None:
 def test_blocked_side_effect_denies_admission() -> None:
     payload = _payload()
     payload["sideEffects"][0]["disposition"] = "blocked"
-    with pytest.raises(ValidationError, match="side effects block"):
+    with pytest.raises(ValidationError):
         ControlStopContinuationContract.model_validate(payload)
 
 
@@ -227,7 +245,9 @@ def test_negative_verifier_is_preserved_without_failed_step() -> None:
     assert all(
         step.terminal_disposition != "failed" for step in contract.preserved_steps
     )
-    assert contract.preserved_steps[-1].terminal_disposition == "accepted_control_result"
+    assert (
+        contract.preserved_steps[-1].terminal_disposition == "accepted_control_result"
+    )
 
 
 def test_continuation_budget_is_monotonic_and_bounded() -> None:
@@ -244,3 +264,16 @@ def test_continuation_budget_is_monotonic_and_bounded() -> None:
         ControlStopContinuationError, match="continuation_attempt_budget_exhausted"
     ):
         after_no_progress.consume(progress=True)
+
+
+def test_canary_and_secret_scanning_fail_closed() -> None:
+    canary = _payload()
+    canary["rollout"]["mode"] = "canary"
+    canary["rollout"]["canaryOwnerIds"] = ["different-owner"]
+    with pytest.raises(ValidationError, match="not selected"):
+        ControlStopContinuationContract.model_validate(canary)
+
+    secret = _payload()
+    secret["remainingWorkRef"] = "artifact://" + "g" + "hp_" + ("1" * 30)
+    with pytest.raises(ValidationError, match="secret scanning"):
+        ControlStopContinuationContract.model_validate(secret)

--- a/tests/unit/workflows/temporal/test_control_stop_continuation_workflow.py
+++ b/tests/unit/workflows/temporal/test_control_stop_continuation_workflow.py
@@ -1,9 +1,12 @@
+from copy import deepcopy
 from unittest.mock import AsyncMock
 
 import pytest
+from temporalio.exceptions import CancelledError
 
 from moonmind.workflows.executions.control_stop_continuation import (
     ControlStopContinuationContract,
+    ControlStopContinuationWorkflowInput,
 )
 from moonmind.workflows.temporal.workflows.control_stop_continuation import (
     MoonMindControlStopContinuationWorkflow,
@@ -11,72 +14,110 @@ from moonmind.workflows.temporal.workflows.control_stop_continuation import (
 from tests.unit.workflows.executions.test_control_stop_continuation import _payload
 
 
-@pytest.mark.asyncio
-async def test_workflow_restores_before_exposing_remediation_state(monkeypatch) -> None:
-    contract = ControlStopContinuationContract.model_validate(_payload())
+def _contract(**budget_overrides: int) -> ControlStopContinuationContract:
+    payload = _payload()
+    payload["continuationBudget"].update(budget_overrides)
+    return ControlStopContinuationContract.model_validate(payload)
+
+
+def _workflow_input(contract: ControlStopContinuationContract) -> dict:
+    return ControlStopContinuationWorkflowInput.initial(contract).model_dump(
+        by_alias=True,
+        mode="json",
+    )
+
+
+def _locator(contract: ControlStopContinuationContract) -> dict:
+    return {
+        "kind": "managed_runtime",
+        "runtimeId": "codex_cli",
+        "agentRunId": contract.destination_workspace_id,
+        "relativePath": "repo",
+    }
+
+
+def _restore(contract: ControlStopContinuationContract) -> dict:
+    return {
+        "schemaVersion": "v1",
+        "status": "succeeded",
+        "checkpointRef": contract.checkpoint_ref,
+        "destinationWorkspaceLocator": _locator(contract),
+        "restorationEvidenceRef": "artifact://restore/evidence",
+        "restorationEvidenceDigest": f"sha256:{'e' * 64}",
+        "baseCommit": contract.workspace_base_commit,
+        "restoredEntryCount": 2,
+        "restoredBytes": 20,
+        "gitStatusDigest": f"sha256:{'f' * 64}",
+        "idempotencyKey": f"{contract.destination_workflow_id}:restore",
+    }
+
+
+def _remediation(*, failed: bool = False) -> dict:
+    return {
+        "outputRefs": ["artifact://remediation/result"],
+        "summary": "Remediation attempt completed.",
+        "failureClass": "execution_error" if failed else None,
+        "metadata": {
+            "omnigentSessionId": "session-7",
+            "externalStateRef": "artifact://omnigent/state",
+        },
+    }
+
+
+def _capture(contract: ControlStopContinuationContract, attempt: int) -> dict:
+    return {
+        "schemaVersion": "v1",
+        "status": "captured",
+        "checkpointKind": "worktree_archive",
+        "workspace": {
+            "kind": "worktree_archive",
+            "baseCommit": contract.workspace_base_commit,
+            "archiveRef": f"artifact://workspace/C{attempt}",
+            "archiveDigest": f"sha256:{str(attempt % 10) * 64}",
+            "manifestRef": f"artifact://workspace/C{attempt}/manifest",
+            "manifestDigest": f"sha256:{str((attempt + 1) % 10) * 64}",
+        },
+        "sourceWorkspaceLocator": _locator(contract),
+        "idempotencyKey": (
+            f"{contract.destination_workflow_id}:remediation:{attempt}:capture"
+        ),
+    }
+
+
+def _verification(
+    attempt: int,
+    *,
+    verdict: str,
+    progress: bool,
+    remaining_work: bool = True,
+) -> dict:
+    return {
+        "outputRefs": [f"artifact://gate/{attempt}"],
+        "summary": f"Verifier returned {verdict}.",
+        "metadata": {
+            "normalizedStatus": "completed",
+            "omnigentSessionId": f"verify-session-{attempt}",
+            "controlStopVerification": {
+                "verdict": verdict,
+                "verificationRef": f"artifact://gate/{attempt}",
+                "remainingWorkRef": (
+                    f"artifact://remaining/{attempt}" if remaining_work else None
+                ),
+                "progress": progress,
+                "progressEvidenceRef": (
+                    f"artifact://progress/{attempt}" if progress else None
+                ),
+            },
+        },
+    }
+
+
+def _patch_runtime(monkeypatch, contract, execute) -> None:
     info = type(
         "Info",
         (),
         {"workflow_id": contract.destination_workflow_id, "run_id": "destination-run"},
     )()
-    restore_result = {
-            "schemaVersion": "v1",
-            "status": "succeeded",
-            "checkpointRef": contract.workspace_head_ref,
-            "destinationWorkspaceLocator": {
-                "kind": "managed_runtime",
-                "runtimeId": "codex_cli",
-                "agentRunId": contract.destination_workspace_id,
-                "relativePath": "repo",
-            },
-            "restorationEvidenceRef": "artifact://restore/evidence",
-            "restorationEvidenceDigest": "sha256:restore",
-            "baseCommit": contract.workspace_base_commit,
-            "restoredEntryCount": 2,
-            "restoredBytes": 20,
-            "gitStatusDigest": "sha256:status",
-            "idempotencyKey": f"{contract.destination_workflow_id}:restore",
-        }
-    execute = AsyncMock(
-        side_effect=[
-            restore_result,
-            {
-                "outputRefs": ["artifact://remediation/result"],
-                "summary": "Remediation attempt completed.",
-                "metrics": {"attemptOrdinal": 7},
-            },
-            {
-                "schemaVersion": "v1",
-                "status": "captured",
-                "checkpointKind": "worktree_archive",
-                "workspace": {
-                    "kind": "worktree_archive",
-                    "baseCommit": contract.workspace_base_commit,
-                    "archiveRef": "artifact://workspace/C7",
-                    "archiveDigest": f"sha256:{'c' * 64}",
-                    "manifestRef": "artifact://workspace/C7/manifest",
-                    "manifestDigest": f"sha256:{'d' * 64}",
-                },
-                "sourceWorkspaceLocator": {
-                    "kind": "managed_runtime",
-                    "runtimeId": "codex_cli",
-                    "agentRunId": contract.destination_workspace_id,
-                    "relativePath": "repo",
-                },
-                "idempotencyKey": (
-                    f"{contract.destination_workflow_id}:remediation:7:capture"
-                ),
-            },
-            {
-                "outputRefs": ["artifact://gate/7"],
-                "summary": "Candidate accepted.",
-                "metadata": {
-                    "semanticVerdict": "FULLY_IMPLEMENTED",
-                    "gateResultRef": "artifact://gate/7",
-                },
-            },
-        ]
-    )
     monkeypatch.setattr(
         "moonmind.workflows.temporal.workflows.control_stop_continuation.workflow.info",
         lambda: info,
@@ -86,117 +127,361 @@ async def test_workflow_restores_before_exposing_remediation_state(monkeypatch) 
         execute,
     )
 
-    result = await MoonMindControlStopContinuationWorkflow().run(_payload())
+
+@pytest.mark.asyncio
+async def test_workflow_restores_then_runs_profile_bound_loop_to_acceptance(
+    monkeypatch,
+) -> None:
+    contract = _contract()
+    execute = AsyncMock(
+        side_effect=[
+            _restore(contract),
+            _remediation(),
+            _capture(contract, 7),
+            _verification(
+                7,
+                verdict="FULLY_IMPLEMENTED",
+                progress=True,
+                remaining_work=False,
+            ),
+        ]
+    )
+    _patch_runtime(monkeypatch, contract, execute)
+
+    result = await MoonMindControlStopContinuationWorkflow().run(
+        _workflow_input(contract)
+    )
 
     assert result["status"] == "accepted"
     assert result["nextSemanticOperation"] == "publication_gate"
     assert result["candidateState"] == "accepted_complete"
     assert result["latestWorkspaceHeadRef"] == "artifact://workspace/C7"
     assert result["continuationBudget"]["consumedAttempts"] == 1
-    assert result["sideEffects"][0]["disposition"] == "already_performed"
-    assert execute.await_args_list[0].args[0] == (
-        "agent_runtime.restore_workspace_checkpoint"
+    assert result["skippedSideEffects"][0]["disposition"] == "already_performed"
+    assert result["hostSessionLifecycle"]["activityCleanupCompleted"] is True
+    assert result["hostSessionLifecycle"]["remediationOmnigentSessionId"] == (
+        "session-7"
     )
-    assert execute.await_args_list[1].args[0] == (
-        "integration.omnigent.profile_bound_execute"
+    assert result["hostSessionLifecycle"]["verificationOmnigentSessionId"] == (
+        "verify-session-7"
     )
-    assert execute.await_args_list[2].args[0] == (
-        "agent_runtime.capture_workspace_checkpoint"
+    assert [call.args[0] for call in execute.await_args_list] == [
+        "agent_runtime.restore_workspace_checkpoint",
+        "integration.omnigent.profile_bound_execute",
+        "agent_runtime.capture_workspace_checkpoint",
+        "integration.omnigent.profile_bound_execute",
+    ]
+    assert execute.await_args_list[1].args[1]["instructionRef"] == (
+        contract.remaining_work_ref
     )
-    assert execute.await_args_list[3].args[0] == (
-        "integration.omnigent.profile_bound_execute"
-    )
-    remediation_request = execute.await_args_list[1].args[1]
-    assert remediation_request["instructionRef"] == contract.remaining_work_ref
-    assert remediation_request["executionProfileRef"] == (
-        contract.lane.provider_profile_id
-    )
-    assert remediation_request["idempotencyKey"].endswith(
-        ":remediation:execution:7"
-    )
-    verification_request = execute.await_args_list[3].args[1]
-    assert verification_request["idempotencyKey"].endswith(
-        ":verification:execution:7"
-    )
-    assert verification_request["executionProfileRef"] == (
-        contract.lane.provider_profile_id
+    assert (
+        execute.await_args_list[3].args[1]["parameters"]["omnigent"]["prompt"][
+            "instructionRef"
+        ]
+        == contract.verification_instruction_ref
     )
 
 
 @pytest.mark.asyncio
-async def test_workflow_reads_published_moonspec_verifier_contract(monkeypatch) -> None:
-    contract = ControlStopContinuationContract.model_validate(_payload())
-    info = type(
-        "Info",
-        (),
-        {"workflow_id": contract.destination_workflow_id, "run_id": "destination-run"},
-    )()
-    restore_result = {
-        "schemaVersion": "v1",
-        "status": "succeeded",
-        "checkpointRef": contract.workspace_head_ref,
-        "destinationWorkspaceLocator": {
-            "kind": "managed_runtime",
-            "runtimeId": "codex_cli",
-            "agentRunId": contract.destination_workspace_id,
-            "relativePath": "repo",
-        },
-        "restorationEvidenceRef": "artifact://restore/evidence",
-        "restorationEvidenceDigest": "sha256:restore",
-        "baseCommit": contract.workspace_base_commit,
-        "restoredEntryCount": 2,
-        "restoredBytes": 20,
-        "gitStatusDigest": "sha256:status",
-        "idempotencyKey": f"{contract.destination_workflow_id}:restore",
-    }
+async def test_additional_work_retries_from_latest_candidate_without_replaying_restore(
+    monkeypatch,
+) -> None:
+    contract = _contract(maxAttempts=3, maxConsecutiveNoProgressAttempts=2)
     execute = AsyncMock(
         side_effect=[
-            restore_result,
-            {"outputRefs": ["artifact://remediation/result"], "summary": "done"},
-            {
-                "schemaVersion": "v1",
-                "status": "captured",
-                "checkpointKind": "worktree_archive",
-                "workspace": {
-                    "kind": "worktree_archive",
-                    "baseCommit": contract.workspace_base_commit,
-                    "archiveRef": "artifact://workspace/C7",
-                    "archiveDigest": f"sha256:{'c' * 64}",
-                    "manifestRef": "artifact://workspace/C7/manifest",
-                    "manifestDigest": f"sha256:{'d' * 64}",
-                },
-                "sourceWorkspaceLocator": {
-                    "kind": "managed_runtime",
-                    "runtimeId": "codex_cli",
-                    "agentRunId": contract.destination_workspace_id,
-                    "relativePath": "repo",
-                },
-                "idempotencyKey": (
-                    f"{contract.destination_workflow_id}:remediation:7:capture"
-                ),
-            },
-            {
-                "outputRefs": ["artifact://gate/7"],
-                "summary": "Candidate accepted.",
-                "metadata": {
-                    "moonSpecVerify": {
-                        "verdict": "FULLY_IMPLEMENTED",
-                        "gateResultRef": "artifact://gate/7",
-                    }
-                },
-            },
+            _restore(contract),
+            _remediation(),
+            _capture(contract, 7),
+            _verification(7, verdict="ADDITIONAL_WORK_NEEDED", progress=True),
+            _remediation(),
+            _capture(contract, 8),
+            _verification(
+                8,
+                verdict="FULLY_IMPLEMENTED",
+                progress=True,
+                remaining_work=False,
+            ),
         ]
     )
-    monkeypatch.setattr(
-        "moonmind.workflows.temporal.workflows.control_stop_continuation.workflow.info",
-        lambda: info,
-    )
-    monkeypatch.setattr(
-        "moonmind.workflows.temporal.workflows.control_stop_continuation.workflow.execute_activity",
-        execute,
-    )
+    _patch_runtime(monkeypatch, contract, execute)
 
-    result = await MoonMindControlStopContinuationWorkflow().run(_payload())
+    result = await MoonMindControlStopContinuationWorkflow().run(
+        _workflow_input(contract)
+    )
 
     assert result["status"] == "accepted"
-    assert result["latestVerificationRef"] == "artifact://gate/7"
+    assert result["continuationBudget"]["consumedAttempts"] == 2
+    assert [attempt["attemptOrdinal"] for attempt in result["attempts"]] == [7, 8]
+    second_remediation = execute.await_args_list[4].args[1]
+    assert second_remediation["instructionRef"] == "artifact://remaining/7"
+    assert "artifact://workspace/C7" in second_remediation["inputRefs"]
+    assert (
+        sum(
+            call.args[0] == "agent_runtime.restore_workspace_checkpoint"
+            for call in execute.await_args_list
+        )
+        == 1
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("max_attempts", "max_no_progress", "progress", "reason"),
+    [
+        (1, 1, True, "continuation_attempt_budget_exhausted"),
+        (3, 1, False, "continuation_no_progress_budget_exhausted"),
+    ],
+)
+async def test_workflow_stops_at_frozen_budget_boundary(
+    monkeypatch,
+    max_attempts,
+    max_no_progress,
+    progress,
+    reason,
+) -> None:
+    contract = _contract(
+        maxAttempts=max_attempts,
+        maxConsecutiveNoProgressAttempts=max_no_progress,
+    )
+    execute = AsyncMock(
+        side_effect=[
+            _restore(contract),
+            _remediation(),
+            _capture(contract, 7),
+            _verification(
+                7,
+                verdict="ADDITIONAL_WORK_NEEDED",
+                progress=progress,
+            ),
+        ]
+    )
+    _patch_runtime(monkeypatch, contract, execute)
+
+    result = await MoonMindControlStopContinuationWorkflow().run(
+        _workflow_input(contract)
+    )
+
+    assert result["status"] == "control_stop"
+    assert result["reasonCode"] == reason
+    assert result["latestWorkspaceHeadRef"] == "artifact://workspace/C7"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("verdict", "status"),
+    [
+        ("BLOCKED", "blocked"),
+        ("ENVIRONMENT_CONTAMINATED_BY_SKILL_PROJECTION", "blocked"),
+        ("FAILED_UNRECOVERABLE", "failed"),
+    ],
+)
+async def test_terminal_verifier_outcomes_preserve_candidate(
+    monkeypatch,
+    verdict,
+    status,
+) -> None:
+    contract = _contract()
+    execute = AsyncMock(
+        side_effect=[
+            _restore(contract),
+            _remediation(),
+            _capture(contract, 7),
+            _verification(7, verdict=verdict, progress=False),
+        ]
+    )
+    _patch_runtime(monkeypatch, contract, execute)
+
+    result = await MoonMindControlStopContinuationWorkflow().run(
+        _workflow_input(contract)
+    )
+
+    assert result["status"] == status
+    assert result["reasonCode"] == verdict
+    assert result["latestWorkspaceHeadRef"] == "artifact://workspace/C7"
+    assert result["attempts"][0]["verificationRef"] == "artifact://gate/7"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("side_effect", "failure_phase"),
+    [
+        ([RuntimeError("restore")], "restoration"),
+        (
+            [
+                "RESTORE",
+                RuntimeError("remediation"),
+            ],
+            "remediation",
+        ),
+        (
+            [
+                "RESTORE",
+                "REMEDIATION",
+                RuntimeError("capture"),
+            ],
+            "candidate_capture",
+        ),
+        (
+            [
+                "RESTORE",
+                "REMEDIATION",
+                "CAPTURE",
+                RuntimeError("verification"),
+            ],
+            "verification",
+        ),
+    ],
+)
+async def test_activity_failures_are_phase_specific_and_do_not_fallback(
+    monkeypatch,
+    side_effect,
+    failure_phase,
+) -> None:
+    contract = _contract()
+    replacements = {
+        "RESTORE": _restore(contract),
+        "REMEDIATION": _remediation(),
+        "CAPTURE": _capture(contract, 7),
+    }
+    effects = [replacements.get(item, item) for item in side_effect]
+    execute = AsyncMock(side_effect=effects)
+    _patch_runtime(monkeypatch, contract, execute)
+
+    result = await MoonMindControlStopContinuationWorkflow().run(
+        _workflow_input(contract)
+    )
+
+    assert result["status"] == "failed"
+    assert result["failurePhase"] == failure_phase
+    activity_types = [call.args[0] for call in execute.await_args_list]
+    assert set(activity_types) <= {
+        "agent_runtime.restore_workspace_checkpoint",
+        "integration.omnigent.profile_bound_execute",
+        "agent_runtime.capture_workspace_checkpoint",
+    }
+
+
+@pytest.mark.asyncio
+async def test_cancellation_after_capture_preserves_latest_candidate(
+    monkeypatch,
+) -> None:
+    contract = _contract()
+    execute = AsyncMock(
+        side_effect=[
+            _restore(contract),
+            _remediation(),
+            _capture(contract, 7),
+            CancelledError(),
+        ]
+    )
+    _patch_runtime(monkeypatch, contract, execute)
+
+    continuation = MoonMindControlStopContinuationWorkflow()
+    with pytest.raises(CancelledError):
+        await continuation.run(_workflow_input(contract))
+    result = continuation.continuation_state()
+
+    assert result["status"] == "canceled"
+    assert result["failurePhase"] == "verification"
+    assert result["latestWorkspaceHeadRef"] == "artifact://workspace/C7"
+    assert result["continuationBudget"]["consumedAttempts"] == 0
+
+
+@pytest.mark.asyncio
+async def test_profile_failure_and_unbound_verifier_ref_fail_closed(
+    monkeypatch,
+) -> None:
+    contract = _contract()
+    remediation_failure = AsyncMock(
+        side_effect=[_restore(contract), _remediation(failed=True)]
+    )
+    _patch_runtime(monkeypatch, contract, remediation_failure)
+    failed = await MoonMindControlStopContinuationWorkflow().run(
+        _workflow_input(contract)
+    )
+    assert failed["status"] == "failed"
+    assert failed["failurePhase"] == "remediation"
+    assert failed["reasonCode"] == "execution_error"
+
+    unbound_verification = _verification(
+        7,
+        verdict="FULLY_IMPLEMENTED",
+        progress=True,
+        remaining_work=False,
+    )
+    unbound_verification["outputRefs"] = ["artifact://different-verifier"]
+    execute = AsyncMock(
+        side_effect=[
+            _restore(contract),
+            _remediation(),
+            _capture(contract, 7),
+            unbound_verification,
+        ]
+    )
+    _patch_runtime(monkeypatch, contract, execute)
+    rejected = await MoonMindControlStopContinuationWorkflow().run(
+        _workflow_input(contract)
+    )
+    assert rejected["status"] == "failed"
+    assert rejected["failurePhase"] == "verification"
+    assert rejected["reasonCode"] == "CONTROL_STOP_VERIFICATION_REF_MISMATCH"
+    assert rejected["latestWorkspaceHeadRef"] == "artifact://workspace/C7"
+
+
+@pytest.mark.asyncio
+async def test_continue_as_new_transfers_full_state_and_does_not_restore_again(
+    monkeypatch,
+) -> None:
+    contract_payload = _payload()
+    contract_payload["continuationBudget"]["maxAttempts"] = 2
+    contract_payload["continuationBudget"]["maxConsecutiveNoProgressAttempts"] = 2
+    contract_payload["continueAsNewAfterAttempts"] = 1
+    contract = ControlStopContinuationContract.model_validate(contract_payload)
+    execute = AsyncMock(
+        side_effect=[
+            _restore(contract),
+            _remediation(),
+            _capture(contract, 7),
+            _verification(7, verdict="ADDITIONAL_WORK_NEEDED", progress=True),
+        ]
+    )
+    _patch_runtime(monkeypatch, contract, execute)
+    carried: dict = {}
+
+    def _capture_continue_as_new(payload):
+        carried.update(deepcopy(payload))
+        raise RuntimeError("continue-as-new-issued")
+
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.workflows.control_stop_continuation.workflow.continue_as_new",
+        _capture_continue_as_new,
+    )
+    with pytest.raises(RuntimeError, match="continue-as-new-issued"):
+        await MoonMindControlStopContinuationWorkflow().run(_workflow_input(contract))
+
+    state = carried["state"]
+    assert state["continueAsNewCount"] == 1
+    assert state["continuationBudget"]["consumedAttempts"] == 1
+    assert state["latestWorkspaceHeadRef"] == "artifact://workspace/C7"
+
+    resumed_execute = AsyncMock(
+        side_effect=[
+            _remediation(),
+            _capture(contract, 8),
+            _verification(
+                8,
+                verdict="FULLY_IMPLEMENTED",
+                progress=True,
+                remaining_work=False,
+            ),
+        ]
+    )
+    _patch_runtime(monkeypatch, contract, resumed_execute)
+    result = await MoonMindControlStopContinuationWorkflow().run(carried)
+
+    assert result["status"] == "accepted"
+    assert result["continueAsNewCount"] == 1
+    assert result["continuationBudget"]["consumedAttempts"] == 2
+    assert resumed_execute.await_args_list[0].args[0] == (
+        "integration.omnigent.profile_bound_execute"
+    )


### PR DESCRIPTION
## Summary

- complete deterministic restore → remediate → capture → verify continuation with Continue-As-New state transfer, cancellation preservation, and typed terminal evidence
- add exact rollout allowlists, canary/shadow/rollback controls, bounded metrics, and fail-closed secret scanning
- project source/granted budgets, destination lifecycle, and restoration provenance in the Workflow Detail UI
- let operators propose smaller limits while keeping control-stop and grant identity server-authoritative
- add retry, exhaustion, cancellation, cold-restore, rollout, and security regression coverage

## Failed workflow investigated

Workflow `mm:97bda32b-afe8-4e13-8aa9-c370af55b225` failed after all three child agent runs completed. Temporal scheduling and workers were healthy; the final MoonSpec verifier returned `ADDITIONAL_WORK_NEEDED`, and the plan had no remediation successor. The original `no_remediation_successor` control stop is not continuation-eligible and remains immutable.

## Verification

- 52 targeted unit/integration tests passed
- Workflow Detail: 200 tests passed
- frontend typecheck and lint passed
- OpenAPI types regenerated
- light/dark desktop visual QA passed without horizontal overflow

Closes #3479.
