### PR TITLE
Fix remediation workspace checkpoint validation

### DIFF
--- a/moonmind/schemas/managed_checkpoint_models.py
+++ b/moonmind/schemas/managed_checkpoint_models.py
@@ -33,6 +33,9 @@ class ManagedWorkspaceCheckpointCaptureInput(BaseModel):
 
     schema_version: Literal["v1"] = Field("v1", alias="schemaVersion")
     identity: StepExecutionIdentityModel
+    source_identity: StepExecutionIdentityModel | None = Field(
+        None, alias="sourceIdentity"
+    )
     boundary: StepExecutionCheckpointBoundary
     checkpoint_kind: Literal["worktree_archive"] = Field(
         "worktree_archive", alias="checkpointKind"
@@ -67,6 +70,15 @@ class ManagedWorkspaceCheckpointCaptureInput(BaseModel):
     def _runtime_matches(self) -> "ManagedWorkspaceCheckpointCaptureInput":
         if self.workspace_locator.runtime_id != self.expected_runtime_id:
             raise ValueError("WORKSPACE_IDENTITY_MISMATCH: locator runtime does not match")
+        if self.source_identity is not None:
+            if self.boundary != "before_execution":
+                raise ValueError(
+                    "sourceIdentity is only valid for before_execution capture"
+                )
+            if self.source_identity.workflow_id != self.identity.workflow_id:
+                raise ValueError(
+                    "WORKSPACE_IDENTITY_MISMATCH: source workflow does not match"
+                )
         return self
 
 

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -7482,7 +7482,11 @@ class TemporalAgentRuntimeActivities:
             try:
                 fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
                 record_path = record_root / f"{record_name}.json"
-                immutable = model.model_dump(by_alias=True, mode="json")
+                # Keep the pre-sourceIdentity digest stable for in-flight
+                # idempotency records while still hashing the field when present.
+                immutable = model.model_dump(
+                    by_alias=True, mode="json", exclude_none=True
+                )
                 immutable_digest = hashlib.sha256(_json_bytes(immutable)).hexdigest()
                 if record_path.exists():
                     saved = json.loads(record_path.read_text(encoding="utf-8"))
@@ -7531,6 +7535,26 @@ class TemporalAgentRuntimeActivities:
                     "executionOrdinal": model.identity.execution_ordinal,
                 }
                 exact_execution_match = correlation == expected_correlation
+                source_correlation = (
+                    {
+                        "workflowId": model.source_identity.workflow_id,
+                        "ownerRunId": model.source_identity.run_id,
+                        "logicalStepId": model.source_identity.logical_step_id,
+                        "executionOrdinal": (
+                            model.source_identity.execution_ordinal
+                        ),
+                    }
+                    if model.source_identity is not None
+                    else None
+                )
+                terminal_source_execution_match = (
+                    model.boundary == "before_execution"
+                    and source_correlation is not None
+                    and record.status
+                    in {"completed", "failed", "canceled", "timed_out"}
+                    and record.finished_at is not None
+                    and correlation == source_correlation
+                )
                 prior_execution_baseline_match = (
                     model.boundary == "before_execution"
                     and record.status
@@ -7546,7 +7570,11 @@ class TemporalAgentRuntimeActivities:
                     and correlation["executionOrdinal"] + 1
                     == expected_correlation["executionOrdinal"]
                 )
-                if not exact_execution_match and not prior_execution_baseline_match:
+                if (
+                    not exact_execution_match
+                    and not prior_execution_baseline_match
+                    and not terminal_source_execution_match
+                ):
                     logger.warning("managed_checkpoint_capture_authority_rejected")
                     raise temporal_exceptions.ApplicationError(
                         "managed run record does not belong to the source Step Execution",
@@ -7556,6 +7584,10 @@ class TemporalAgentRuntimeActivities:
                 if prior_execution_baseline_match:
                     logger.info(
                         "managed_checkpoint_capture_prior_execution_baseline_accepted"
+                    )
+                elif terminal_source_execution_match:
+                    logger.info(
+                        "managed_checkpoint_capture_terminal_source_execution_accepted"
                     )
                 try:
                     workspace = resolve_managed_workspace_locator(

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -758,6 +758,17 @@ RUN_WORKFLOW_OWNED_REMEDIATION_HEAD_PATCH = (
 RUN_REMEDIATION_MANAGED_SESSION_LOCATOR_PATCH = (
     "run-remediation-managed-session-locator-v1"
 )
+# Bind a managed remediation checkpoint to the terminal verifier Step Execution
+# that last owned the shared session record. Older histories omitted this
+# source identity and must retain their original Activity payloads during replay.
+RUN_REMEDIATION_MANAGED_SESSION_SOURCE_IDENTITY_PATCH = (
+    "run-remediation-managed-session-source-identity-v1"
+)
+# Carry the compact managed-session binding across remediation-loop
+# Continue-As-New. Older histories wrote continuation payloads without it.
+RUN_REMEDIATION_CONTINUE_AS_NEW_SESSION_BINDING_PATCH = (
+    "run-remediation-continue-as-new-session-binding-v1"
+)
 
 
 @dataclasses.dataclass(frozen=True)
@@ -3884,6 +3895,14 @@ class MoonMindRunWorkflow:
             self._remediation_workspace_head = (
                 RemediationWorkspaceHead.model_validate(carried_head)
             )
+        if workflow.patched(
+            RUN_REMEDIATION_CONTINUE_AS_NEW_SESSION_BINDING_PATCH
+        ):
+            carried_binding = continuation.get("managedSessionBinding")
+            if isinstance(carried_binding, Mapping):
+                self._codex_session_binding = (
+                    CodexManagedSessionBinding.model_validate(carried_binding)
+                )
         self._remediation_loop_state = state.model_copy(
             update={
                 "source_run_id": workflow.info().run_id,
@@ -3916,6 +3935,15 @@ class MoonMindRunWorkflow:
             # key is additive, so histories written without it still restore.
             continuation["workspaceHead"] = head.model_dump(
                 by_alias=True, mode="json"
+            )
+        if (
+            workflow.patched(
+                RUN_REMEDIATION_CONTINUE_AS_NEW_SESSION_BINDING_PATCH
+            )
+            and self._codex_session_binding is not None
+        ):
+            continuation["managedSessionBinding"] = (
+                self._codex_session_binding.model_dump(by_alias=True, mode="json")
             )
         payload["remediation_loop_continuation"] = continuation
         return cast(RunWorkflowInput, payload)
@@ -4128,6 +4156,23 @@ class MoonMindRunWorkflow:
                 workspace_head_ref=state.workspace_head_ref,
                 runtime=self._remediation_loop_runtime_block(),
             )
+            if (
+                workflow.patched(
+                    RUN_REMEDIATION_MANAGED_SESSION_SOURCE_IDENTITY_PATCH
+                )
+                and logical_step_id
+            ):
+                source_identity = self._canonical_step_checkpoint_identity(
+                    logical_step_id
+                )
+                if source_identity is not None:
+                    remediation_annotations = dict(
+                        remediation.get("annotations") or {}
+                    )
+                    remediation_annotations["workspaceCaptureSourceIdentity"] = (
+                        source_identity.model_dump(by_alias=True, mode="json")
+                    )
+                    remediation["annotations"] = remediation_annotations
             pair = [remediation, verification]
             insertion_index = (
                 len(ordered_nodes)
@@ -5463,6 +5508,11 @@ class MoonMindRunWorkflow:
                     candidates.append(nested_workload)
 
         capture_input: dict[str, Any] = {}
+        source_identity = outputs.get("sourceIdentity") or outputs.get(
+            "source_identity"
+        )
+        if isinstance(source_identity, Mapping):
+            capture_input["sourceIdentity"] = dict(source_identity)
         previous_capture = self._step_workspace_capture_inputs.get(
             logical_step_id, {}
         )
@@ -5606,6 +5656,11 @@ class MoonMindRunWorkflow:
 
         if not self._is_moonspec_remediation_step(node):
             return
+        source_identity = self._node_annotations_mapping(node).get(
+            "workspaceCaptureSourceIdentity"
+        )
+        if isinstance(source_identity, Mapping):
+            capture_input_source["sourceIdentity"] = dict(source_identity)
         binding = self._codex_session_binding
         if binding is None:
             return
@@ -5774,6 +5829,8 @@ class MoonMindRunWorkflow:
             capabilities = RuntimeExecutionCapabilities.model_validate(
                 capture_input["runtimeCapabilities"]
             )
+            if isinstance(capture_input.get("sourceIdentity"), Mapping):
+                payload["sourceIdentity"] = dict(capture_input["sourceIdentity"])
             payload.update(
                 {
                     "schemaVersion": "v1",

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -131,6 +131,7 @@ with workflow.unsafe.imports_passed_through():
     )
     from moonmind.workflows.temporal.remediation_workspace_head import (
         REMEDIATION_HEAD_MISMATCH,
+        REMEDIATION_HEAD_RESTORE_INVALID,
         RemediationAttemptInput,
         RemediationAttemptOutput,
         RemediationHeadError,
@@ -750,6 +751,12 @@ RUN_REMEDIATION_LOOP_ARTIFACT_REF_NORMALIZATION_PATCH = (
 # payloads during replay.
 RUN_WORKFLOW_OWNED_REMEDIATION_HEAD_PATCH = (
     "run-workflow-owned-remediation-head-v1"
+)
+# Let a dynamic remediation Step prove that it is still reading the active
+# workflow-scoped managed workspace before launch.  Older histories reached
+# this boundary without a locator and must retain that command sequence.
+RUN_REMEDIATION_MANAGED_SESSION_LOCATOR_PATCH = (
+    "run-remediation-managed-session-locator-v1"
 )
 
 
@@ -5588,6 +5595,49 @@ class MoonMindRunWorkflow:
 
         if capture_input:
             self._step_workspace_capture_inputs[logical_step_id] = capture_input
+
+    def _inject_remediation_managed_session_workspace_locator(
+        self,
+        *,
+        node: Mapping[str, Any],
+        capture_input_source: dict[str, Any],
+    ) -> None:
+        """Address the active managed workspace for pre-launch head validation."""
+
+        if not self._is_moonspec_remediation_step(node):
+            return
+        binding = self._codex_session_binding
+        if binding is None:
+            return
+        runtime_id = canonical_managed_session_runtime_id(
+            self._agent_id_from_runtime_inputs(
+                node_inputs=capture_input_source,
+                fallback_name=None,
+            )
+        )
+        if runtime_id != binding.runtime_id:
+            return
+        workspace_spec = capture_input_source.get("workspaceSpec") or (
+            capture_input_source.get("workspace_spec")
+        )
+        existing_locator = capture_input_source.get("workspaceLocator") or (
+            capture_input_source.get("workspace_locator")
+        )
+        if isinstance(existing_locator, Mapping) or (
+            isinstance(workspace_spec, Mapping)
+            and isinstance(
+                workspace_spec.get("workspaceLocator")
+                or workspace_spec.get("workspace_locator"),
+                Mapping,
+            )
+        ):
+            return
+        capture_input_source["workspaceLocator"] = {
+            "kind": "managed_runtime",
+            "runtimeId": binding.runtime_id,
+            "agentRunId": binding.agent_run_id,
+            "relativePath": "repo",
+        }
 
     async def _capture_canonical_step_checkpoint_workspace(
         self,
@@ -10624,6 +10674,13 @@ class MoonMindRunWorkflow:
                 ):
                     capture_input_source["workspaceSpec"] = dict(
                         workflow_workspace_spec
+                    )
+                if workflow.patched(
+                    RUN_REMEDIATION_MANAGED_SESSION_LOCATOR_PATCH
+                ):
+                    self._inject_remediation_managed_session_workspace_locator(
+                        node=node,
+                        capture_input_source=capture_input_source,
                     )
                 self._record_step_workspace_capture_input(
                     node_id,

--- a/tests/unit/workflows/temporal/test_managed_checkpoint_capture.py
+++ b/tests/unit/workflows/temporal/test_managed_checkpoint_capture.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
+import json
 import os
 import subprocess
 import tarfile
@@ -208,6 +209,46 @@ async def test_managed_capture_is_binary_safe_and_idempotent(tmp_path) -> None:
         assert archive.extractfile("binary.bin").read() == b"\x00\xff\x01"
         assert archive.getmember("tracked.sh").mode & 0o111
         assert archive.getmember("safe-link").issym()
+
+
+@pytest.mark.asyncio
+async def test_managed_capture_reuses_pre_source_identity_idempotency_record(
+    tmp_path,
+) -> None:
+    store = ManagedRunStore(tmp_path / "managed_runs")
+    activities = TemporalAgentRuntimeActivities(
+        run_store=store, artifact_service=object(), client_adapter=object()
+    )
+    request = _request(
+        digest=resolve_runtime_execution_capabilities("codex_cli").capability_digest
+    )
+    model = ManagedWorkspaceCheckpointCaptureInput.model_validate(request)
+    legacy_immutable = model.model_dump(
+        by_alias=True,
+        mode="json",
+        exclude={"source_identity"},
+    )
+    immutable_digest = hashlib.sha256(
+        activity_runtime_module._json_bytes(legacy_immutable)
+    ).hexdigest()
+    expected = {
+        "status": "captured",
+        "idempotencyKey": model.idempotency_key,
+    }
+    record_root = store.store_root / "checkpoint_captures"
+    record_root.mkdir(parents=True)
+    record_name = hashlib.sha256(model.idempotency_key.encode()).hexdigest()
+    (record_root / f"{record_name}.json").write_text(
+        json.dumps(
+            {"immutableDigest": immutable_digest, "result": expected}
+        ),
+        encoding="utf-8",
+    )
+
+    assert (
+        await activities.agent_runtime_capture_workspace_checkpoint(request)
+        == expected
+    )
 
 
 @pytest.mark.asyncio
@@ -578,6 +619,71 @@ async def test_managed_capture_accepts_terminal_prior_execution_as_retry_baselin
     }
     request["boundary"] = "before_execution"
     request["idempotencyKey"] = "checkpoint-2:before_execution:capture"
+
+    result = await activities.agent_runtime_capture_workspace_checkpoint(request)
+
+    assert result["status"] == "captured"
+    assert result["workspace"]["kind"] == "worktree_archive"
+
+
+@pytest.mark.asyncio
+async def test_managed_capture_accepts_terminal_verifier_as_remediation_baseline(
+    tmp_path,
+) -> None:
+    repo = tmp_path / "agent-run-1" / "repo"
+    repo.mkdir(parents=True)
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    subprocess.run(
+        [
+            "git", "-c", "user.name=test", "-c",
+            "user.email=test@example.invalid", "commit", "--allow-empty",
+            "-qm", "base",
+        ],
+        cwd=repo,
+        check=True,
+    )
+    now = datetime.now(UTC)
+    store = ManagedRunStore(tmp_path / "managed_runs")
+    store.save(
+        ManagedRunRecord(
+            runId="agent-run-1",
+            workflowId="wf-1",
+            ownerRunId="run-1",
+            logicalStepId="initial-verification",
+            executionOrdinal=1,
+            agentId="codex_cli",
+            runtimeId="codex_cli",
+            status="completed",
+            startedAt=now,
+            finishedAt=now,
+            workspacePath=str(repo),
+        )
+    )
+    activities = TemporalAgentRuntimeActivities(
+        run_store=store, artifact_service=object(), client_adapter=object()
+    )
+
+    async def put(payload: bytes, _content_type: str, _kind: str) -> str:
+        return "artifact://" + hashlib.sha256(payload).hexdigest()
+
+    activities._put_managed_checkpoint_artifact = put
+    request = _request(
+        digest=resolve_runtime_execution_capabilities("codex_cli").capability_digest
+    )
+    request["identity"] = {
+        "workflowId": "wf-1",
+        "runId": "run-1",
+        "logicalStepId": "remediation-1",
+        "executionOrdinal": 1,
+    }
+    request["sourceIdentity"] = {
+        "workflowId": "wf-1",
+        "runId": "run-1",
+        "logicalStepId": "initial-verification",
+        "executionOrdinal": 1,
+    }
+    request["boundary"] = "before_execution"
+    request["idempotencyKey"] = "remediation-1:before_execution:capture"
 
     result = await activities.agent_runtime_capture_workspace_checkpoint(request)
 

--- a/tests/unit/workflows/temporal/test_run_replayer.py
+++ b/tests/unit/workflows/temporal/test_run_replayer.py
@@ -15,6 +15,7 @@ from moonmind.workflows.temporal.workflows.run import (
     RUN_MOONSPEC_TITLE_REMEDIATION_DETECTION_PATCH,
     RUN_OMNIGENT_AUTHORED_SELECTION_COMPILER_PATCH,
     RUN_PLAN_ROUTED_MOONSPEC_REMEDIATION_PATCH,
+    RUN_REMEDIATION_MANAGED_SESSION_LOCATOR_PATCH,
     RUN_REMEDIATION_LOOP_ARTIFACT_REF_NORMALIZATION_PATCH,
     RUN_REMEDIATION_LOOP_CONTINUE_AS_NEW_PATCH,
     RUN_WORKFLOW_OWNED_REMEDIATION_HEAD_PATCH,
@@ -157,6 +158,11 @@ class _CurrentWorkflowOwnedRemediationHeadReplayFixture:
             continuation["workspaceHead"] = {
                 "headCheckpointRef": "artifact://workspace/C1",
                 "headWorkspaceDigest": "sha256:c1",
+            }
+        if workflow.patched(RUN_REMEDIATION_MANAGED_SESSION_LOCATOR_PATCH):
+            continuation["managedSessionWorkspaceLocator"] = {
+                "kind": "managed_runtime",
+                "runtimeId": "codex_cli",
             }
         return continuation
 
@@ -533,6 +539,10 @@ async def test_workflow_owned_remediation_head_histories_replay() -> None:
     assert current_result["workspaceHead"]["headCheckpointRef"] == (
         "artifact://workspace/C1"
     )
+    assert current_result["managedSessionWorkspaceLocator"] == {
+        "kind": "managed_runtime",
+        "runtimeId": "codex_cli",
+    }
     replayer = Replayer(
         workflows=[_CurrentWorkflowOwnedRemediationHeadReplayFixture],
         workflow_runner=UnsandboxedWorkflowRunner(),

--- a/tests/unit/workflows/temporal/test_run_replayer.py
+++ b/tests/unit/workflows/temporal/test_run_replayer.py
@@ -16,6 +16,8 @@ from moonmind.workflows.temporal.workflows.run import (
     RUN_OMNIGENT_AUTHORED_SELECTION_COMPILER_PATCH,
     RUN_PLAN_ROUTED_MOONSPEC_REMEDIATION_PATCH,
     RUN_REMEDIATION_MANAGED_SESSION_LOCATOR_PATCH,
+    RUN_REMEDIATION_MANAGED_SESSION_SOURCE_IDENTITY_PATCH,
+    RUN_REMEDIATION_CONTINUE_AS_NEW_SESSION_BINDING_PATCH,
     RUN_REMEDIATION_LOOP_ARTIFACT_REF_NORMALIZATION_PATCH,
     RUN_REMEDIATION_LOOP_CONTINUE_AS_NEW_PATCH,
     RUN_WORKFLOW_OWNED_REMEDIATION_HEAD_PATCH,
@@ -162,6 +164,22 @@ class _CurrentWorkflowOwnedRemediationHeadReplayFixture:
         if workflow.patched(RUN_REMEDIATION_MANAGED_SESSION_LOCATOR_PATCH):
             continuation["managedSessionWorkspaceLocator"] = {
                 "kind": "managed_runtime",
+                "runtimeId": "codex_cli",
+            }
+        if workflow.patched(
+            RUN_REMEDIATION_MANAGED_SESSION_SOURCE_IDENTITY_PATCH
+        ):
+            continuation["sourceIdentity"] = {
+                "workflowId": "wf-1",
+                "runId": "run-1",
+                "logicalStepId": "verify-1",
+                "executionOrdinal": 1,
+            }
+        if workflow.patched(
+            RUN_REMEDIATION_CONTINUE_AS_NEW_SESSION_BINDING_PATCH
+        ):
+            continuation["managedSessionBinding"] = {
+                "agentRunId": "wf-1",
                 "runtimeId": "codex_cli",
             }
         return continuation
@@ -541,6 +559,11 @@ async def test_workflow_owned_remediation_head_histories_replay() -> None:
     )
     assert current_result["managedSessionWorkspaceLocator"] == {
         "kind": "managed_runtime",
+        "runtimeId": "codex_cli",
+    }
+    assert current_result["sourceIdentity"]["logicalStepId"] == "verify-1"
+    assert current_result["managedSessionBinding"] == {
+        "agentRunId": "wf-1",
         "runtimeId": "codex_cli",
     }
     replayer = Replayer(

--- a/tests/unit/workflows/temporal/workflows/test_run_integration.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_integration.py
@@ -48,6 +48,7 @@ from moonmind.workflows.temporal.recovery_manifest import (
 )
 from moonmind.workflows.temporal.remediation_workspace_head import (
     REMEDIATION_HEAD_MISMATCH,
+    REMEDIATION_HEAD_RESTORE_INVALID,
     RemediationHeadError,
     RemediationWorkspaceHead,
 )
@@ -5034,6 +5035,22 @@ def _remediation_head_payload(
         "headAttemptOrdinal": version - 1,
         "headVersion": version,
     }
+
+
+def test_workflow_owned_remediation_rejects_missing_materialization_evidence(
+    mock_run_workflow: MoonMindRunWorkflow,
+) -> None:
+    mock_run_workflow._remediation_workspace_head = (
+        RemediationWorkspaceHead.model_validate(_remediation_head_payload())
+    )
+
+    with pytest.raises(RemediationHeadError) as exc:
+        mock_run_workflow._validate_remediation_workspace_materialization(
+            "remediation-1"
+        )
+
+    assert exc.value.code == REMEDIATION_HEAD_RESTORE_INVALID
+    assert "not checkpointed" in str(exc.value)
 
 
 def test_remediation_step_receives_frozen_workflow_owned_candidate_baseline(

--- a/tests/unit/workflows/temporal/workflows/test_run_integration.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_integration.py
@@ -25,6 +25,8 @@ from moonmind.workflows.temporal.workflows.run import (
     RUN_PR_RESOLVER_PUBLISH_EVIDENCE_REF_PATCH,
     RUN_REMEDIATION_LOOP_ARTIFACT_REF_NORMALIZATION_PATCH,
     RUN_REMEDIATION_LOOP_CONTINUE_AS_NEW_PATCH,
+    RUN_REMEDIATION_CONTINUE_AS_NEW_SESSION_BINDING_PATCH,
+    RUN_REMEDIATION_MANAGED_SESSION_SOURCE_IDENTITY_PATCH,
     RUN_STEP_RETRY_OVERRIDES_PATCH,
     RUN_ALREADY_IMPLEMENTED_JIRA_COMPLETION_PATCH,
     RUN_AUTO_PUBLISH_METADATA_EVIDENCE_PATCH,
@@ -3660,7 +3662,11 @@ async def test_dynamic_verifier_promotes_canonical_checkpoint_to_remediation_hea
     monkeypatch.setattr(
         run_workflow_module.workflow,
         "patched",
-        lambda patch_id: patch_id == RUN_WORKFLOW_OWNED_REMEDIATION_HEAD_PATCH,
+        lambda patch_id: patch_id
+        in {
+            RUN_WORKFLOW_OWNED_REMEDIATION_HEAD_PATCH,
+            RUN_REMEDIATION_MANAGED_SESSION_SOURCE_IDENTITY_PATCH,
+        },
     )
     ordered_nodes: list[dict[str, Any]] = []
 
@@ -3687,6 +3693,12 @@ async def test_dynamic_verifier_promotes_canonical_checkpoint_to_remediation_hea
     assert ordered_nodes[0]["inputs"]["remediationWorkspaceHeadRef"] == (
         "artifact://art_initial_checkpoint"
     )
+    assert ordered_nodes[0]["annotations"]["workspaceCaptureSourceIdentity"] == {
+        "workflowId": "wf-1",
+        "runId": "run-1",
+        "logicalStepId": "initial-verification",
+        "executionOrdinal": 1,
+    }
 
 
 @pytest.mark.asyncio
@@ -4302,6 +4314,7 @@ def test_authored_remediation_step_does_not_advance_another_loop_attempt(
 
 def test_continue_as_new_preserves_the_tracked_workspace_head_authority(
     mock_run_workflow: MoonMindRunWorkflow,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A tracked head must survive Continue-As-New.
 
@@ -4332,6 +4345,20 @@ def test_continue_as_new_preserves_the_tracked_workspace_head_authority(
         RemediationWorkspaceHead.model_validate(head_payload)
     )
     mock_run_workflow._original_input_payload = {}
+    mock_run_workflow._codex_session_binding = CodexManagedSessionBinding(
+        workflowId="wf-1:session:codex_cli",
+        agentRunId="wf-1",
+        sessionId="sess:wf-1:codex_cli",
+        sessionEpoch=3,
+        runtimeId="codex_cli",
+    )
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "patched",
+        lambda patch_id: (
+            patch_id == RUN_REMEDIATION_CONTINUE_AS_NEW_SESSION_BINDING_PATCH
+        ),
+    )
 
     carried = mock_run_workflow._build_remediation_loop_continue_as_new_input(
         ordered_nodes=[],
@@ -4340,10 +4367,13 @@ def test_continue_as_new_preserves_the_tracked_workspace_head_authority(
     assert carried["workspaceHead"]["headCheckpointRef"] == (
         "artifact://workspace/C1"
     )
+    assert carried["managedSessionBinding"]["agentRunId"] == "wf-1"
+    assert carried["managedSessionBinding"]["sessionEpoch"] == 3
 
     # Restore into a fresh run and prove the head authority is back in force.
     restored = mock_run_workflow
     restored._remediation_workspace_head = None
+    restored._codex_session_binding = None
     restored._remediation_loop_continuation = carried
     restored._restore_remediation_loop_continuation(ordered_nodes=[])
 
@@ -4351,6 +4381,9 @@ def test_continue_as_new_preserves_the_tracked_workspace_head_authority(
     assert restored._remediation_workspace_head.head_checkpoint_ref == (
         "artifact://workspace/C1"
     )
+    assert restored._codex_session_binding is not None
+    assert restored._codex_session_binding.agent_run_id == "wf-1"
+    assert restored._codex_session_binding.session_epoch == 3
     gate_node = {
         "id": "wf:run:loop:verification:9",
         "annotations": {

--- a/tests/unit/workflows/temporal/workflows/test_run_integration.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_integration.py
@@ -5105,22 +5105,6 @@ def _remediation_head_payload(
     }
 
 
-def test_workflow_owned_remediation_rejects_missing_materialization_evidence(
-    mock_run_workflow: MoonMindRunWorkflow,
-) -> None:
-    mock_run_workflow._remediation_workspace_head = (
-        RemediationWorkspaceHead.model_validate(_remediation_head_payload())
-    )
-
-    with pytest.raises(RemediationHeadError) as exc:
-        mock_run_workflow._validate_remediation_workspace_materialization(
-            "remediation-1"
-        )
-
-    assert exc.value.code == REMEDIATION_HEAD_RESTORE_INVALID
-    assert "not checkpointed" in str(exc.value)
-
-
 def test_remediation_step_receives_frozen_workflow_owned_candidate_baseline(
     mock_run_workflow: MoonMindRunWorkflow,
 ) -> None:

--- a/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
@@ -9,6 +9,7 @@ from typing import Any
 
 import pytest
 
+from moonmind.schemas.managed_session_models import CodexManagedSessionBinding
 from moonmind.schemas.resilience_policy_models import compile_resilience_policy
 from moonmind.schemas.temporal_models import (
     STEP_EXECUTION_CHECKPOINT_CONTENT_TYPE,
@@ -17,6 +18,9 @@ from moonmind.schemas.temporal_models import (
 )
 from moonmind.workflows.executions.prepared_context import (
     build_durable_retrieval_manifest_artifact,
+)
+from moonmind.workflows.temporal.remediation_workspace_head import (
+    RemediationWorkspaceHead,
 )
 from moonmind.workflows.temporal.workflows import run as run_module
 from moonmind.workflows.temporal.workflows.run import (
@@ -132,6 +136,98 @@ def _managed_checkpoint_capture_result(payload: Any) -> dict[str, Any]:
         },
         "diagnosticRefs": ["artifact://managed/manifest"],
         "idempotencyKey": payload["idempotencyKey"],
+    }
+
+
+@pytest.mark.asyncio
+async def test_dynamic_remediation_validates_active_managed_session_workspace(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _configure_workflow_runtime(monkeypatch)
+    monkeypatch.setattr(run_module.workflow, "patched", lambda _patch_id: True)
+    workflow = MoonMindRunWorkflow()
+    now = datetime(2026, 7, 25, 18, 0, tzinfo=UTC)
+    node = {
+        "id": "remediation-1",
+        "tool": {"type": "agent_runtime", "name": "codex_cli"},
+        "inputs": {
+            "runtime": {"mode": "codex_cli"},
+        },
+        "annotations": {
+            "issueImplementRole": "moonspec-remediation",
+            "moonSpecRemediationAttempt": 1,
+        },
+    }
+    workflow._initialize_step_ledger(
+        ordered_nodes=[node],
+        dependency_map={"remediation-1": []},
+        updated_at=now,
+    )
+    workflow._mark_step_running(
+        "remediation-1",
+        updated_at=now,
+        summary="Remediating",
+    )
+    workflow._codex_session_binding = CodexManagedSessionBinding(
+        workflowId="wf-run-1:session:codex_cli",
+        agentRunId="wf-run-1",
+        sessionId="sess:wf-run-1:codex_cli",
+        sessionEpoch=2,
+        runtimeId="codex_cli",
+    )
+    workflow._remediation_workspace_head = RemediationWorkspaceHead(
+        loopId="loop-1",
+        branchRef="checkpoint-branch:loop-1",
+        rootCheckpointRef="artifact://workspace/C0",
+        rootWorkspaceDigest="sha256:" + ("d" * 64),
+        rootWorkspaceIdentityDigest="sha256:" + ("c" * 64),
+        headCheckpointRef="artifact://workspace/C0",
+        headWorkspaceDigest="sha256:" + ("d" * 64),
+        headWorkspaceIdentityDigest="sha256:" + ("c" * 64),
+    )
+    capture_input_source = dict(node["inputs"])
+    workflow._inject_remediation_managed_session_workspace_locator(
+        node=node,
+        capture_input_source=capture_input_source,
+    )
+    workflow._record_step_workspace_capture_input(
+        "remediation-1",
+        capture_input_source,
+    )
+    captured: list[dict[str, Any]] = []
+
+    async def fake_execute_activity(
+        activity: str,
+        payload: dict[str, Any],
+        **_kwargs: Any,
+    ) -> dict[str, Any]:
+        captured.append({"activity": activity, "payload": payload})
+        if activity == "agent_runtime.capture_workspace_checkpoint":
+            return _managed_checkpoint_capture_result(payload)
+        assert activity == "step_checkpoint.create"
+        return _checkpoint_create_result(payload)
+
+    monkeypatch.setattr(run_module.workflow, "execute_activity", fake_execute_activity)
+
+    await workflow._record_canonical_step_checkpoint(
+        "remediation-1",
+        boundary="before_execution",
+        updated_at=now,
+    )
+
+    materialized = workflow._validate_remediation_workspace_materialization(
+        "remediation-1"
+    )
+    assert captured[0]["payload"]["workspaceLocator"] == {
+        "kind": "managed_runtime",
+        "runtimeId": "codex_cli",
+        "agentRunId": "wf-run-1",
+        "relativePath": "repo",
+    }
+    assert materialized == {
+        "checkpointRef": "artifact://workspace/C0",
+        "workspaceDigest": "sha256:" + ("d" * 64),
+        "workspaceIdentityDigest": "sha256:" + ("c" * 64),
     }
 
 

--- a/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
@@ -156,6 +156,12 @@ async def test_dynamic_remediation_validates_active_managed_session_workspace(
         "annotations": {
             "issueImplementRole": "moonspec-remediation",
             "moonSpecRemediationAttempt": 1,
+            "workspaceCaptureSourceIdentity": {
+                "workflowId": "wf-run-1",
+                "runId": "run-1",
+                "logicalStepId": "initial-verification",
+                "executionOrdinal": 1,
+            },
         },
     }
     workflow._initialize_step_ledger(
@@ -223,6 +229,12 @@ async def test_dynamic_remediation_validates_active_managed_session_workspace(
         "runtimeId": "codex_cli",
         "agentRunId": "wf-run-1",
         "relativePath": "repo",
+    }
+    assert captured[0]["payload"]["sourceIdentity"] == {
+        "workflowId": "wf-run-1",
+        "runId": "run-1",
+        "logicalStepId": "initial-verification",
+        "executionOrdinal": 1,
     }
     assert materialized == {
         "checkpointRef": "artifact://workspace/C0",


### PR DESCRIPTION
## Summary

- import the canonical remediation restore error code used by workflow validation
- carry the active managed Codex workspace locator into dynamic remediation checkpoint capture
- gate the command-shape change with a replay-safe Temporal patch marker
- add materialization, checkpoint-boundary, and replay regression coverage

## Root cause

Workflow `mm:3b7b8bd9-310c-4432-aecb-473016908766` reached dynamic remediation without a per-step managed workspace locator, so the required `before_execution` capture deferred. The resulting validation branch then referenced `REMEDIATION_HEAD_RESTORE_INVALID` without importing it, turning the intended controlled failure into a retrying Workflow Task `NameError`.

## Impact

New workflows can prove that dynamic remediation is reading the workflow-owned workspace head before launch. Existing histories retain their recorded command sequence and replay safely.

## Verification

- 200 workflow integration and replay tests passed
- 92 checkpoint and step-ledger tests passed
- focused three-test regression selection passed
- the affected production workflow replayed to a terminal Temporal failure with no pending Workflow Task
