### PR TITLE
Fix remediation workspace checkpoint capture

### DIFF
--- a/moonmind/schemas/workspace_locator_models.py
+++ b/moonmind/schemas/workspace_locator_models.py
@@ -25,6 +25,13 @@ def _relative_subpath(value: str) -> str:
     return str(path)
 
 
+def _managed_relative_subpath(value: str) -> str:
+    candidate = str(value).strip().replace("\\", "/")
+    if candidate == ".":
+        return candidate
+    return _relative_subpath(candidate)
+
+
 class SandboxWorkspaceLocator(BaseModel):
     model_config = ConfigDict(populate_by_name=True, extra="forbid")
 
@@ -43,7 +50,9 @@ class ManagedWorkspaceLocator(BaseModel):
     agent_run_id: str = Field(..., alias="agentRunId", min_length=1, max_length=300)
     relative_path: str = Field("repo", alias="relativePath", max_length=1000)
 
-    _validate_relative_path = field_validator("relative_path", mode="before")(_relative_subpath)
+    _validate_relative_path = field_validator("relative_path", mode="before")(
+        _managed_relative_subpath
+    )
 
 
 class ExternalStateLocator(BaseModel):

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -7546,7 +7546,25 @@ class TemporalAgentRuntimeActivities:
                     and correlation["executionOrdinal"] + 1
                     == expected_correlation["executionOrdinal"]
                 )
-                if not exact_execution_match and not prior_execution_baseline_match:
+                workflow_scoped_session_baseline_match = (
+                    model.boundary == "before_execution"
+                    and record.session_id is not None
+                    and record.status
+                    in {"completed", "failed", "canceled", "timed_out"}
+                    and record.finished_at is not None
+                    and record.run_id == locator.agent_run_id
+                    and record.runtime_id == locator.runtime_id
+                    and correlation["workflowId"]
+                    == expected_correlation["workflowId"]
+                    and correlation["logicalStepId"]
+                    != expected_correlation["logicalStepId"]
+                    and expected_correlation["executionOrdinal"] == 1
+                )
+                if (
+                    not exact_execution_match
+                    and not prior_execution_baseline_match
+                    and not workflow_scoped_session_baseline_match
+                ):
                     logger.warning("managed_checkpoint_capture_authority_rejected")
                     raise temporal_exceptions.ApplicationError(
                         "managed run record does not belong to the source Step Execution",
@@ -7556,6 +7574,10 @@ class TemporalAgentRuntimeActivities:
                 if prior_execution_baseline_match:
                     logger.info(
                         "managed_checkpoint_capture_prior_execution_baseline_accepted"
+                    )
+                elif workflow_scoped_session_baseline_match:
+                    logger.info(
+                        "managed_checkpoint_capture_workflow_session_baseline_accepted"
                     )
                 try:
                     workspace = resolve_managed_workspace_locator(

--- a/moonmind/workflows/temporal/runtime/workspace_locators.py
+++ b/moonmind/workflows/temporal/runtime/workspace_locators.py
@@ -189,7 +189,8 @@ def resolve_managed_workspace_locator(
         )
     workspace = (
         workspace_root
-        if locator.relative_path == "repo" and workspace_root.name == "repo"
+        if locator.relative_path == "."
+        or (locator.relative_path == "repo" and workspace_root.name == "repo")
         else (workspace_root / locator.relative_path).resolve()
     )
     if not workspace.is_relative_to(workspace_root):

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -131,6 +131,7 @@ with workflow.unsafe.imports_passed_through():
     )
     from moonmind.workflows.temporal.remediation_workspace_head import (
         REMEDIATION_HEAD_MISMATCH,
+        REMEDIATION_HEAD_RESTORE_INVALID,
         RemediationAttemptInput,
         RemediationAttemptOutput,
         RemediationHeadError,
@@ -750,6 +751,9 @@ RUN_REMEDIATION_LOOP_ARTIFACT_REF_NORMALIZATION_PATCH = (
 # payloads during replay.
 RUN_WORKFLOW_OWNED_REMEDIATION_HEAD_PATCH = (
     "run-workflow-owned-remediation-head-v1"
+)
+RUN_MANAGED_SESSION_CHECKPOINT_LOCATOR_PATCH = (
+    "run-managed-session-checkpoint-locator-v1"
 )
 
 
@@ -5485,7 +5489,26 @@ class MoonMindRunWorkflow:
                 capture_input["criticality"] = (
                     capabilities.post_execution_checkpoint_criticality
                 )
-                if capabilities.runtime_id == "omnigent":
+                binding = self._codex_session_binding
+                if (
+                    capabilities.workspace_authority == "managed_runtime"
+                    and binding is not None
+                    and binding.runtime_id == capabilities.runtime_id
+                    and workflow.patched(
+                        RUN_MANAGED_SESSION_CHECKPOINT_LOCATOR_PATCH
+                    )
+                ):
+                    # A workflow-scoped managed session keeps one stable
+                    # workspace across plan steps. Reuse its typed identity so
+                    # a dynamic remediation step can capture and validate the
+                    # current loop head before launching its next AgentRun.
+                    capture_input["workspaceLocator"] = {
+                        "kind": "managed_runtime",
+                        "runtimeId": binding.runtime_id,
+                        "agentRunId": binding.agent_run_id,
+                        "relativePath": "repo",
+                    }
+                elif capabilities.runtime_id == "omnigent":
                     try:
                         wf_info = workflow.info()
                         identity = StepExecutionIdentityModel(

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -755,6 +755,9 @@ RUN_WORKFLOW_OWNED_REMEDIATION_HEAD_PATCH = (
 RUN_MANAGED_SESSION_CHECKPOINT_LOCATOR_PATCH = (
     "run-managed-session-checkpoint-locator-v1"
 )
+RUN_REMEDIATION_CONTINUE_MANAGED_SESSION_PATCH = (
+    "run-remediation-continue-managed-session-v1"
+)
 
 
 @dataclasses.dataclass(frozen=True)
@@ -3881,6 +3884,24 @@ class MoonMindRunWorkflow:
             self._remediation_workspace_head = (
                 RemediationWorkspaceHead.model_validate(carried_head)
             )
+        carried_session = continuation.get("managedSessionBinding")
+        if isinstance(carried_session, Mapping) and workflow.patched(
+            RUN_REMEDIATION_CONTINUE_MANAGED_SESSION_PATCH
+        ):
+            binding = CodexManagedSessionBinding.model_validate(carried_session)
+            expected_agent_run_id = workflow.info().workflow_id
+            expected_session_workflow_id = self._workflow_scoped_session_workflow_id(
+                binding.runtime_id
+            )
+            if (
+                binding.agent_run_id != expected_agent_run_id
+                or binding.workflow_id != expected_session_workflow_id
+            ):
+                raise ValueError(
+                    "remediation loop continuation managed session belongs to "
+                    "another workflow"
+                )
+            self._codex_session_binding = binding
         self._remediation_loop_state = state.model_copy(
             update={
                 "source_run_id": workflow.info().run_id,
@@ -3913,6 +3934,15 @@ class MoonMindRunWorkflow:
             # key is additive, so histories written without it still restore.
             continuation["workspaceHead"] = head.model_dump(
                 by_alias=True, mode="json"
+            )
+        binding = self._codex_session_binding
+        if binding is not None and workflow.patched(
+            RUN_REMEDIATION_CONTINUE_MANAGED_SESSION_PATCH
+        ):
+            continuation["managedSessionBinding"] = binding.model_dump(
+                by_alias=True,
+                mode="json",
+                exclude_none=True,
             )
         payload["remediation_loop_continuation"] = continuation
         return cast(RunWorkflowInput, payload)
@@ -5506,7 +5536,7 @@ class MoonMindRunWorkflow:
                         "kind": "managed_runtime",
                         "runtimeId": binding.runtime_id,
                         "agentRunId": binding.agent_run_id,
-                        "relativePath": "repo",
+                        "relativePath": ".",
                     }
                 elif capabilities.runtime_id == "omnigent":
                     try:

--- a/tests/unit/schemas/test_workspace_locator_models.py
+++ b/tests/unit/schemas/test_workspace_locator_models.py
@@ -228,6 +228,27 @@ def test_managed_locator_requires_current_identity_and_store_record(tmp_path):
     assert exc.value.code == "WORKSPACE_IDENTITY_MISMATCH"
 
 
+def test_managed_locator_dot_resolves_the_recorded_workspace_root(tmp_path):
+    workspace = tmp_path / "workspaces" / "run-1" / "custom-checkout"
+    workspace.mkdir(parents=True)
+    record = SimpleNamespace(
+        run_id="run-1", runtime_id="codex", workspace_path=str(workspace)
+    )
+    store = SimpleNamespace(
+        store_root=tmp_path / "managed_runs", load=lambda run_id: record
+    )
+    locator = ManagedWorkspaceLocator(
+        runtimeId="codex", agentRunId="run-1", relativePath="."
+    )
+
+    assert resolve_managed_workspace_locator(
+        locator,
+        store=store,
+        current_agent_run_id="run-1",
+        current_runtime_id="codex",
+    ) == workspace.resolve()
+
+
 def test_managed_locator_rejects_current_runtime_mismatch(tmp_path):
     workspace = tmp_path / "workspaces" / "run-1" / "repo"
     workspace.mkdir(parents=True)

--- a/tests/unit/workflows/temporal/test_managed_checkpoint_capture.py
+++ b/tests/unit/workflows/temporal/test_managed_checkpoint_capture.py
@@ -525,6 +525,74 @@ async def test_managed_capture_accepts_session_record_bound_to_parent_workflow(
 
 
 @pytest.mark.asyncio
+async def test_managed_capture_accepts_cross_step_workflow_session_baseline(
+    tmp_path,
+) -> None:
+    repo = tmp_path / "managed_runs" / "wf-1" / "custom-checkout"
+    repo.mkdir(parents=True)
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    subprocess.run(
+        [
+            "git", "-c", "user.name=test", "-c",
+            "user.email=test@example.invalid", "commit", "--allow-empty",
+            "-qm", "base",
+        ],
+        cwd=repo,
+        check=True,
+    )
+    now = datetime.now(UTC)
+    store = ManagedRunStore(tmp_path / "managed_runs")
+    store.save(
+        ManagedRunRecord(
+            runId="wf-1",
+            workflowId="wf-1:agent:verify",
+            sessionId="sess:wf-1:codex_cli",
+            ownerRunId="source-run",
+            logicalStepId="verify",
+            executionOrdinal=1,
+            agentId="codex_cli",
+            runtimeId="codex_cli",
+            status="completed",
+            startedAt=now,
+            finishedAt=now,
+            workspacePath=str(repo),
+        )
+    )
+    activities = TemporalAgentRuntimeActivities(
+        run_store=store, artifact_service=object(), client_adapter=object()
+    )
+
+    async def put(payload: bytes, _content_type: str, _kind: str) -> str:
+        return "artifact://" + hashlib.sha256(payload).hexdigest()
+
+    activities._put_managed_checkpoint_artifact = put
+    request = _request(
+        digest=resolve_runtime_execution_capabilities(
+            "codex_cli"
+        ).capability_digest
+    )
+    request["identity"] = {
+        "workflowId": "wf-1",
+        "runId": "continued-run",
+        "logicalStepId": "remediation-1",
+        "executionOrdinal": 1,
+    }
+    request["boundary"] = "before_execution"
+    request["workspaceLocator"] = {
+        "kind": "managed_runtime",
+        "runtimeId": "codex_cli",
+        "agentRunId": "wf-1",
+        "relativePath": ".",
+    }
+    request["idempotencyKey"] = "remediation-1:before_execution:capture"
+
+    result = await activities.agent_runtime_capture_workspace_checkpoint(request)
+
+    assert result["status"] == "captured"
+    assert result["sourceWorkspaceLocator"]["relativePath"] == "."
+
+
+@pytest.mark.asyncio
 async def test_managed_capture_accepts_terminal_prior_execution_as_retry_baseline(
     tmp_path,
 ) -> None:

--- a/tests/unit/workflows/temporal/test_run_replayer.py
+++ b/tests/unit/workflows/temporal/test_run_replayer.py
@@ -12,6 +12,7 @@ from moonmind.workflows.temporal.workflows.run import (
     RUN_BOUNDED_STORY_LOOP_FEEDBACK_PROGRESS_PATCH,
     RUN_BOUNDED_STORY_LOOP_PROGRESS_BUDGET_PATCH,
     RUN_CANONICAL_NO_COMMIT_OUTCOME_PATCH,
+    RUN_MANAGED_SESSION_CHECKPOINT_LOCATOR_PATCH,
     RUN_MOONSPEC_TITLE_REMEDIATION_DETECTION_PATCH,
     RUN_OMNIGENT_AUTHORED_SELECTION_COMPILER_PATCH,
     RUN_PLAN_ROUTED_MOONSPEC_REMEDIATION_PATCH,
@@ -159,6 +160,22 @@ class _CurrentWorkflowOwnedRemediationHeadReplayFixture:
                 "headWorkspaceDigest": "sha256:c1",
             }
         return continuation
+
+
+@workflow.defn(name="MMManagedSessionCheckpointLocatorReplayFixture")
+class _LegacyManagedSessionCheckpointLocatorReplayFixture:
+    @workflow.run
+    async def run(self) -> str:
+        return "locator_deferred"
+
+
+@workflow.defn(name="MMManagedSessionCheckpointLocatorReplayFixture")
+class _CurrentManagedSessionCheckpointLocatorReplayFixture:
+    @workflow.run
+    async def run(self) -> str:
+        if workflow.patched(RUN_MANAGED_SESSION_CHECKPOINT_LOCATOR_PATCH):
+            return "binding_locator"
+        return "locator_deferred"
 
 
 def _mm3379_remediation_nodes() -> list[dict[str, Any]]:
@@ -535,6 +552,45 @@ async def test_workflow_owned_remediation_head_histories_replay() -> None:
     )
     replayer = Replayer(
         workflows=[_CurrentWorkflowOwnedRemediationHeadReplayFixture],
+        workflow_runner=UnsandboxedWorkflowRunner(),
+    )
+    await replayer.replay_workflow(legacy_history)
+    await replayer.replay_workflow(current_history)
+
+
+@pytest.mark.asyncio
+async def test_managed_session_checkpoint_locator_histories_replay() -> None:
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        async with Worker(
+            env.client,
+            task_queue="test-managed-session-locator-legacy-replay",
+            workflows=[_LegacyManagedSessionCheckpointLocatorReplayFixture],
+            workflow_runner=UnsandboxedWorkflowRunner(),
+        ):
+            legacy_handle = await env.client.start_workflow(
+                _LegacyManagedSessionCheckpointLocatorReplayFixture.run,
+                id="test-managed-session-locator-legacy",
+                task_queue="test-managed-session-locator-legacy-replay",
+            )
+            assert await legacy_handle.result() == "locator_deferred"
+            legacy_history = await legacy_handle.fetch_history()
+
+        async with Worker(
+            env.client,
+            task_queue="test-managed-session-locator-current-replay",
+            workflows=[_CurrentManagedSessionCheckpointLocatorReplayFixture],
+            workflow_runner=UnsandboxedWorkflowRunner(),
+        ):
+            current_handle = await env.client.start_workflow(
+                _CurrentManagedSessionCheckpointLocatorReplayFixture.run,
+                id="test-managed-session-locator-current",
+                task_queue="test-managed-session-locator-current-replay",
+            )
+            assert await current_handle.result() == "binding_locator"
+            current_history = await current_handle.fetch_history()
+
+    replayer = Replayer(
+        workflows=[_CurrentManagedSessionCheckpointLocatorReplayFixture],
         workflow_runner=UnsandboxedWorkflowRunner(),
     )
     await replayer.replay_workflow(legacy_history)

--- a/tests/unit/workflows/temporal/test_run_replayer.py
+++ b/tests/unit/workflows/temporal/test_run_replayer.py
@@ -16,6 +16,7 @@ from moonmind.workflows.temporal.workflows.run import (
     RUN_MOONSPEC_TITLE_REMEDIATION_DETECTION_PATCH,
     RUN_OMNIGENT_AUTHORED_SELECTION_COMPILER_PATCH,
     RUN_PLAN_ROUTED_MOONSPEC_REMEDIATION_PATCH,
+    RUN_REMEDIATION_CONTINUE_MANAGED_SESSION_PATCH,
     RUN_REMEDIATION_LOOP_ARTIFACT_REF_NORMALIZATION_PATCH,
     RUN_REMEDIATION_LOOP_CONTINUE_AS_NEW_PATCH,
     RUN_WORKFLOW_OWNED_REMEDIATION_HEAD_PATCH,
@@ -165,17 +166,23 @@ class _CurrentWorkflowOwnedRemediationHeadReplayFixture:
 @workflow.defn(name="MMManagedSessionCheckpointLocatorReplayFixture")
 class _LegacyManagedSessionCheckpointLocatorReplayFixture:
     @workflow.run
-    async def run(self) -> str:
-        return "locator_deferred"
+    async def run(self) -> dict[str, Any]:
+        return {"locator": "locator_deferred", "bindingCarried": False}
 
 
 @workflow.defn(name="MMManagedSessionCheckpointLocatorReplayFixture")
 class _CurrentManagedSessionCheckpointLocatorReplayFixture:
     @workflow.run
-    async def run(self) -> str:
-        if workflow.patched(RUN_MANAGED_SESSION_CHECKPOINT_LOCATOR_PATCH):
-            return "binding_locator"
-        return "locator_deferred"
+    async def run(self) -> dict[str, Any]:
+        locator = (
+            "binding_locator"
+            if workflow.patched(RUN_MANAGED_SESSION_CHECKPOINT_LOCATOR_PATCH)
+            else "locator_deferred"
+        )
+        binding_carried = workflow.patched(
+            RUN_REMEDIATION_CONTINUE_MANAGED_SESSION_PATCH
+        )
+        return {"locator": locator, "bindingCarried": binding_carried}
 
 
 def _mm3379_remediation_nodes() -> list[dict[str, Any]]:
@@ -559,7 +566,7 @@ async def test_workflow_owned_remediation_head_histories_replay() -> None:
 
 
 @pytest.mark.asyncio
-async def test_managed_session_checkpoint_locator_histories_replay() -> None:
+async def test_managed_session_checkpoint_histories_replay() -> None:
     async with await WorkflowEnvironment.start_time_skipping() as env:
         async with Worker(
             env.client,
@@ -572,7 +579,10 @@ async def test_managed_session_checkpoint_locator_histories_replay() -> None:
                 id="test-managed-session-locator-legacy",
                 task_queue="test-managed-session-locator-legacy-replay",
             )
-            assert await legacy_handle.result() == "locator_deferred"
+            assert await legacy_handle.result() == {
+                "locator": "locator_deferred",
+                "bindingCarried": False,
+            }
             legacy_history = await legacy_handle.fetch_history()
 
         async with Worker(
@@ -586,7 +596,10 @@ async def test_managed_session_checkpoint_locator_histories_replay() -> None:
                 id="test-managed-session-locator-current",
                 task_queue="test-managed-session-locator-current-replay",
             )
-            assert await current_handle.result() == "binding_locator"
+            assert await current_handle.result() == {
+                "locator": "binding_locator",
+                "bindingCarried": True,
+            }
             current_history = await current_handle.fetch_history()
 
     replayer = Replayer(

--- a/tests/unit/workflows/temporal/workflows/test_run_integration.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_integration.py
@@ -19,12 +19,14 @@ from moonmind.workflows.temporal.workflows.run import (
     RUN_DURABLE_PUBLISH_CONTEXT_MERGE_HANDOFF_PATCH,
     RUN_FAILED_RUN_RECOVERY_MANIFEST_PATCH,
     RUN_HANDOFF_ACCEPTED_DISPOSITION_GATE_PATCH,
+    RUN_MANAGED_SESSION_CHECKPOINT_LOCATOR_PATCH,
     RUN_MOONSPEC_GATE_PREVIOUS_OUTPUTS_HANDOFF_PATCH,
     RUN_PAUSE_SAFE_BOUNDARIES_PATCH,
     RUN_PUBLISH_REPAIR_FEEDBACK_PATCH,
     RUN_PR_RESOLVER_PUBLISH_EVIDENCE_REF_PATCH,
     RUN_REMEDIATION_LOOP_ARTIFACT_REF_NORMALIZATION_PATCH,
     RUN_REMEDIATION_LOOP_CONTINUE_AS_NEW_PATCH,
+    RUN_RUNTIME_EXECUTION_CAPABILITIES_PATCH,
     RUN_STEP_RETRY_OVERRIDES_PATCH,
     RUN_ALREADY_IMPLEMENTED_JIRA_COMPLETION_PATCH,
     RUN_AUTO_PUBLISH_METADATA_EVIDENCE_PATCH,
@@ -48,6 +50,7 @@ from moonmind.workflows.temporal.recovery_manifest import (
 )
 from moonmind.workflows.temporal.remediation_workspace_head import (
     REMEDIATION_HEAD_MISMATCH,
+    REMEDIATION_HEAD_RESTORE_INVALID,
     RemediationHeadError,
     RemediationWorkspaceHead,
 )
@@ -5258,6 +5261,94 @@ def test_workflow_owned_remediation_rejects_different_captured_workspace(
 
     assert exc.value.code == REMEDIATION_HEAD_MISMATCH
     assert "workspace identity" in str(exc.value)
+
+
+def test_workflow_owned_remediation_rejects_missing_materialization_evidence(
+    mock_run_workflow: MoonMindRunWorkflow,
+) -> None:
+    """Regression for workflow mm:e231ca44-2322-40a0-9142-13420f2591ee."""
+
+    mock_run_workflow._remediation_workspace_head = (
+        RemediationWorkspaceHead.model_validate(_remediation_head_payload())
+    )
+
+    with pytest.raises(RemediationHeadError) as exc:
+        mock_run_workflow._validate_remediation_workspace_materialization(
+            "remediation-1"
+        )
+
+    assert exc.value.code == REMEDIATION_HEAD_RESTORE_INVALID
+    assert "not checkpointed before execution" in str(exc.value)
+
+
+def test_existing_managed_session_supplies_remediation_checkpoint_locator(
+    mock_run_workflow: MoonMindRunWorkflow,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A later managed step can checkpoint the workflow-scoped workspace."""
+
+    mock_run_workflow._codex_session_binding = CodexManagedSessionBinding(
+        workflowId="session-workflow",
+        agentRunId="wf-1",
+        sessionId="sess:wf-1:codex_cli",
+        sessionEpoch=2,
+        runtimeId="codex_cli",
+        executionProfileRef="codex_openai_oauth",
+    )
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "patched",
+        lambda patch_id: patch_id
+        in {
+            RUN_RUNTIME_EXECUTION_CAPABILITIES_PATCH,
+            RUN_MANAGED_SESSION_CHECKPOINT_LOCATOR_PATCH,
+        },
+    )
+
+    mock_run_workflow._record_step_workspace_capture_input(
+        "remediation-1",
+        {"runtime": {"mode": "codex_cli"}},
+    )
+
+    capture_input = mock_run_workflow._step_workspace_capture_inputs[
+        "remediation-1"
+    ]
+    assert capture_input["workspaceLocator"] == {
+        "kind": "managed_runtime",
+        "runtimeId": "codex_cli",
+        "agentRunId": "wf-1",
+        "relativePath": "repo",
+    }
+    assert capture_input["captureAuthority"] == "managed_runtime"
+
+
+def test_existing_managed_session_keeps_prior_checkpoint_shape_during_replay(
+    mock_run_workflow: MoonMindRunWorkflow,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Histories without the locator patch retain their recorded commands."""
+
+    mock_run_workflow._codex_session_binding = CodexManagedSessionBinding(
+        workflowId="session-workflow",
+        agentRunId="wf-1",
+        sessionId="sess:wf-1:codex_cli",
+        runtimeId="codex_cli",
+    )
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "patched",
+        lambda patch_id: patch_id == RUN_RUNTIME_EXECUTION_CAPABILITIES_PATCH,
+    )
+
+    mock_run_workflow._record_step_workspace_capture_input(
+        "remediation-1",
+        {"runtime": {"mode": "codex_cli"}},
+    )
+
+    capture_input = mock_run_workflow._step_workspace_capture_inputs[
+        "remediation-1"
+    ]
+    assert "workspaceLocator" not in capture_input
 
 
 def test_remediation_head_uses_archive_not_git_patch_checkpoint(

--- a/tests/unit/workflows/temporal/workflows/test_run_integration.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_integration.py
@@ -26,6 +26,7 @@ from moonmind.workflows.temporal.workflows.run import (
     RUN_PR_RESOLVER_PUBLISH_EVIDENCE_REF_PATCH,
     RUN_REMEDIATION_LOOP_ARTIFACT_REF_NORMALIZATION_PATCH,
     RUN_REMEDIATION_LOOP_CONTINUE_AS_NEW_PATCH,
+    RUN_REMEDIATION_CONTINUE_MANAGED_SESSION_PATCH,
     RUN_RUNTIME_EXECUTION_CAPABILITIES_PATCH,
     RUN_STEP_RETRY_OVERRIDES_PATCH,
     RUN_ALREADY_IMPLEMENTED_JIRA_COMPLETION_PATCH,
@@ -4370,6 +4371,60 @@ def test_continue_as_new_preserves_the_tracked_workspace_head_authority(
     assert "remediationWorkspaceHead" in inputs
 
 
+def test_continue_as_new_preserves_the_workflow_scoped_managed_session(
+    mock_run_workflow: MoonMindRunWorkflow,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from moonmind.workflows.temporal.remediation_loop import (
+        ConsumedRemediationBudgets,
+        RemediationLoopPhase,
+        RemediationLoopSpec,
+        RemediationLoopState,
+    )
+
+    spec = RemediationLoopSpec.model_validate(_dynamic_loop_spec_payload())
+    mock_run_workflow._remediation_loop_spec = spec
+    mock_run_workflow._remediation_loop_state = RemediationLoopState(
+        loopId=spec.loop_id,
+        attemptOrdinal=3,
+        phase=RemediationLoopPhase.REMEDIATION_PENDING,
+        consumedBudgets=ConsumedRemediationBudgets(attempts=3),
+    )
+    mock_run_workflow._original_input_payload = {}
+    binding = CodexManagedSessionBinding(
+        workflowId="wf-1:session:codex_cli",
+        agentRunId="wf-1",
+        sessionId="sess:wf-1:codex_cli",
+        sessionEpoch=4,
+        runtimeId="codex_cli",
+        executionProfileRef="codex_openai_oauth",
+    )
+    mock_run_workflow._codex_session_binding = binding
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "patched",
+        lambda patch_id: (
+            patch_id == RUN_REMEDIATION_CONTINUE_MANAGED_SESSION_PATCH
+        ),
+    )
+
+    carried = mock_run_workflow._build_remediation_loop_continue_as_new_input(
+        ordered_nodes=[]
+    )["remediation_loop_continuation"]
+
+    assert carried["managedSessionBinding"] == binding.model_dump(
+        by_alias=True,
+        mode="json",
+        exclude_none=True,
+    )
+
+    mock_run_workflow._codex_session_binding = None
+    mock_run_workflow._remediation_loop_continuation = carried
+    mock_run_workflow._restore_remediation_loop_continuation(ordered_nodes=[])
+
+    assert mock_run_workflow._codex_session_binding == binding
+
+
 def test_continuation_written_without_a_head_still_restores(
     mock_run_workflow: MoonMindRunWorkflow,
 ) -> None:
@@ -5317,7 +5372,7 @@ def test_existing_managed_session_supplies_remediation_checkpoint_locator(
         "kind": "managed_runtime",
         "runtimeId": "codex_cli",
         "agentRunId": "wf-1",
-        "relativePath": "repo",
+        "relativePath": ".",
     }
     assert capture_input["captureAuthority"] == "managed_runtime"
 


### PR DESCRIPTION
## Summary

- import the typed remediation restore error used by the workflow
- reuse the workflow-scoped managed-session locator for pre-execution remediation checkpoint capture
- gate the new Temporal command shape behind a replay-safe patch marker
- add regression and pre/post-patch replay coverage

## Root cause

Workflow `mm:e231ca44-2322-40a0-9142-13420f2591ee` reached dynamic remediation without pre-execution workspace evidence. The error path then referenced `REMEDIATION_HEAD_RESTORE_INVALID` without importing it, leaving the workflow task in a retrying `NameError`. Even with the import corrected, the existing locator guard would defer checkpoint capture although the workflow-scoped managed session already provided a stable typed workspace identity.

## Validation

- `./tools/test_unit.sh --python-only tests/unit/workflows/temporal/workflows/test_run_integration.py tests/unit/workflows/temporal/test_managed_checkpoint_capture.py tests/unit/workflows/temporal/test_run_replayer.py -q`
- `git diff --check`
- restarted the workflow worker and verified readiness on `mm.workflow.merge_automation`
