### PR TITLE
Fix checkpoint and GitHub status workflow failures

### DIFF
--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -7571,7 +7571,7 @@ class TemporalAgentRuntimeActivities:
                     == expected_correlation["executionOrdinal"]
                 )
                 workflow_scoped_session_baseline_match = (
-                    model.boundary == "before_execution"
+                    model.boundary in {"after_prepare", "before_execution"}
                     and model.source_identity is None
                     and record.session_id is not None
                     and record.status

--- a/moonmind/workflows/temporal/story_output_tools.py
+++ b/moonmind/workflows/temporal/story_output_tools.py
@@ -5230,7 +5230,9 @@ async def update_github_issue_status(
     if actions.get("closeIssue"):
         patch_payload["state"] = "closed"
     applied: list[str] = []
-    async with httpx.AsyncClient(timeout=10.0) as client:
+    warnings: list[str] = []
+    comment_body = ""
+    async with httpx.AsyncClient(timeout=30.0) as client:
         try:
             response = await client.patch(
                 f"https://api.github.com/repos/{repository}/issues/{issue_number}",
@@ -5240,13 +5242,36 @@ async def update_github_issue_status(
             response.raise_for_status()
             updated = response.json()
             applied.append("patch_issue")
-            comment_body = ""
-            pr_url = pull_request_url
-            if actions.get("commentPullRequestUrl") and pr_url:
-                comment_body = f"Implementation pull request: {pr_url}"
-            elif actions.get("comment"):
-                comment_body = f"MoonMind started implementation for {issue_ref}."
-            if comment_body:
+        except httpx.HTTPStatusError as exc:
+            summary = service._github_permission_summary(exc.response)
+            return ToolResult(
+                status="FAILED",
+                outputs={
+                    "issueRef": issue_ref,
+                    "summary": (
+                        "GitHub issue update failed with HTTP "
+                        f"{exc.response.status_code}. {summary}"
+                    ).strip(),
+                },
+            )
+        except (httpx.TransportError, httpx.TimeoutException) as exc:
+            return ToolResult(
+                status="FAILED",
+                outputs={
+                    "issueRef": issue_ref,
+                    "summary": (
+                        f"GitHub issue update failed: {exc.__class__.__name__}"
+                    ),
+                },
+            )
+
+        pr_url = pull_request_url
+        if actions.get("commentPullRequestUrl") and pr_url:
+            comment_body = f"Implementation pull request: {pr_url}"
+        elif actions.get("comment"):
+            comment_body = f"MoonMind started implementation for {issue_ref}."
+        if comment_body:
+            try:
                 comment_response = await client.post(
                     f"https://api.github.com/repos/{repository}/issues/{issue_number}/comments",
                     headers=headers,
@@ -5254,37 +5279,48 @@ async def update_github_issue_status(
                 )
                 comment_response.raise_for_status()
                 applied.append("comment")
-        except httpx.HTTPStatusError as exc:
-            summary = service._github_permission_summary(exc.response)
-            return ToolResult(
-                status="FAILED",
-                outputs={"issueRef": issue_ref, "summary": f"GitHub issue update failed with HTTP {exc.response.status_code}. {summary}".strip()},
-            )
-        except (httpx.TransportError, httpx.TimeoutException) as exc:
-            return ToolResult(status="FAILED", outputs={"issueRef": issue_ref, "summary": f"GitHub issue update failed: {exc.__class__.__name__}"})
+            except httpx.HTTPStatusError as exc:
+                summary = service._github_permission_summary(exc.response)
+                warnings.append(
+                    (
+                        "GitHub issue status was updated, but the automation "
+                        f"comment failed with HTTP {exc.response.status_code}. "
+                        f"{summary}"
+                    ).strip()
+                )
+            except (httpx.TransportError, httpx.TimeoutException) as exc:
+                warnings.append(
+                    "GitHub issue status was updated, but the automation comment "
+                    f"result could not be confirmed after {exc.__class__.__name__}; "
+                    "the comment was not retried to avoid a duplicate."
+                )
     updated_issue = _github_issue_payload(updated, repository)
     issue_url = updated_issue.get("url") or issue.get("url")
     summary = f"Updated GitHub issue {issue_ref} with mode {mode}."
+    outputs: dict[str, Any] = {
+        "issueUrl": issue_url,
+        "appliedActions": applied,
+        "confirmedState": updated_issue.get("state"),
+        "confirmedLabels": updated_issue.get("labels"),
+        "summary": summary,
+        "sideEffect": {
+            "effectClass": "external_non_idempotent",
+            "kind": "github",
+            "operation": (
+                "github.issue.close"
+                if actions.get("closeIssue")
+                else "github.issue.update"
+            ),
+            "target": issue_url,
+            "summary": summary,
+        },
+    }
+    if warnings:
+        outputs["warnings"] = warnings
+        outputs["commentStatus"] = "unconfirmed"
     return ToolResult(
         status="COMPLETED",
-        outputs={
-            "issueUrl": issue_url,
-            "appliedActions": applied,
-            "confirmedState": updated_issue.get("state"),
-            "confirmedLabels": updated_issue.get("labels"),
-            "summary": summary,
-            "sideEffect": {
-                "effectClass": "external_non_idempotent",
-                "kind": "github",
-                "operation": (
-                    "github.issue.close"
-                    if actions.get("closeIssue")
-                    else "github.issue.update"
-                ),
-                "target": issue_url,
-                "summary": summary,
-            },
-        },
+        outputs=outputs,
     )
 
 

--- a/moonmind/workflows/temporal/story_output_tools.py
+++ b/moonmind/workflows/temporal/story_output_tools.py
@@ -44,6 +44,10 @@ JIRA_UPDATE_ISSUE_STATUS_TOOL_NAME = "jira.update_issue_status"
 GITHUB_LOAD_ISSUE_PRESET_BRIEF_TOOL_NAME = "github.load_issue_preset_brief"
 GITHUB_CHECK_ISSUE_BLOCKERS_TOOL_NAME = "github.check_issue_blockers"
 GITHUB_UPDATE_ISSUE_STATUS_TOOL_NAME = "github.update_issue_status"
+# The status tool runs inside a 60-second activity. One fetch plus the PATCH and
+# optional comment must leave enough time for the activity to classify results.
+_GITHUB_ISSUE_FETCH_TIMEOUT_SECONDS = 10.0
+_GITHUB_ISSUE_MUTATION_TIMEOUT_SECONDS = 15.0
 JIRA_STORY_TOOL_NAMES = frozenset(
     {
         JIRA_CREATE_ISSUES_TOOL_NAME,
@@ -4421,7 +4425,7 @@ async def _fetch_github_issue(
     if not token:
         return None, resolution_error or "GitHub issue lookup is unavailable."
     headers = service._github_headers(token)
-    async with httpx.AsyncClient(timeout=10.0) as client:
+    async with httpx.AsyncClient(timeout=_GITHUB_ISSUE_FETCH_TIMEOUT_SECONDS) as client:
         try:
             response = await client.get(
                 f"https://api.github.com/repos/{repository}/issues/{issue_number}",
@@ -5232,7 +5236,9 @@ async def update_github_issue_status(
     applied: list[str] = []
     warnings: list[str] = []
     comment_body = ""
-    async with httpx.AsyncClient(timeout=30.0) as client:
+    async with httpx.AsyncClient(
+        timeout=_GITHUB_ISSUE_MUTATION_TIMEOUT_SECONDS
+    ) as client:
         try:
             response = await client.patch(
                 f"https://api.github.com/repos/{repository}/issues/{issue_number}",
@@ -5242,6 +5248,8 @@ async def update_github_issue_status(
             response.raise_for_status()
             updated = response.json()
             applied.append("patch_issue")
+            updated_issue = _github_issue_payload(updated, repository)
+            issue_url = updated_issue.get("url") or issue.get("url")
         except httpx.HTTPStatusError as exc:
             summary = service._github_permission_summary(exc.response)
             return ToolResult(
@@ -5281,12 +5289,21 @@ async def update_github_issue_status(
                 applied.append("comment")
             except httpx.HTTPStatusError as exc:
                 summary = service._github_permission_summary(exc.response)
-                warnings.append(
-                    (
-                        "GitHub issue status was updated, but the automation "
-                        f"comment failed with HTTP {exc.response.status_code}. "
-                        f"{summary}"
-                    ).strip()
+                return ToolResult(
+                    status="FAILED",
+                    outputs={
+                        "issueRef": issue_ref,
+                        "issueUrl": issue_url,
+                        "appliedActions": applied,
+                        "confirmedState": updated_issue.get("state"),
+                        "confirmedLabels": updated_issue.get("labels"),
+                        "commentStatus": "rejected",
+                        "summary": (
+                            "GitHub issue status was updated, but the automation "
+                            f"comment failed with HTTP {exc.response.status_code}. "
+                            f"{summary}"
+                        ).strip(),
+                    },
                 )
             except (httpx.TransportError, httpx.TimeoutException) as exc:
                 warnings.append(
@@ -5294,8 +5311,6 @@ async def update_github_issue_status(
                     f"result could not be confirmed after {exc.__class__.__name__}; "
                     "the comment was not retried to avoid a duplicate."
                 )
-    updated_issue = _github_issue_payload(updated, repository)
-    issue_url = updated_issue.get("url") or issue.get("url")
     summary = f"Updated GitHub issue {issue_ref} with mode {mode}."
     outputs: dict[str, Any] = {
         "issueUrl": issue_url,

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -5821,7 +5821,9 @@ class MoonMindRunWorkflow:
             capabilities = RuntimeExecutionCapabilities.model_validate(
                 capture_input["runtimeCapabilities"]
             )
-            if isinstance(capture_input.get("sourceIdentity"), Mapping):
+            if boundary == "before_execution" and isinstance(
+                capture_input.get("sourceIdentity"), Mapping
+            ):
                 payload["sourceIdentity"] = dict(capture_input["sourceIdentity"])
             payload.update(
                 {

--- a/tests/unit/workflows/temporal/test_managed_checkpoint_capture.py
+++ b/tests/unit/workflows/temporal/test_managed_checkpoint_capture.py
@@ -566,8 +566,9 @@ async def test_managed_capture_accepts_session_record_bound_to_parent_workflow(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("boundary", ["after_prepare", "before_execution"])
 async def test_managed_capture_accepts_cross_step_workflow_session_baseline(
-    tmp_path,
+    tmp_path, boundary: str,
 ) -> None:
     repo = tmp_path / "managed_runs" / "wf-1" / "custom-checkout"
     repo.mkdir(parents=True)
@@ -618,14 +619,14 @@ async def test_managed_capture_accepts_cross_step_workflow_session_baseline(
         "logicalStepId": "remediation-1",
         "executionOrdinal": 1,
     }
-    request["boundary"] = "before_execution"
+    request["boundary"] = boundary
     request["workspaceLocator"] = {
         "kind": "managed_runtime",
         "runtimeId": "codex_cli",
         "agentRunId": "wf-1",
         "relativePath": ".",
     }
-    request["idempotencyKey"] = "remediation-1:before_execution:capture"
+    request["idempotencyKey"] = f"remediation-1:{boundary}:capture"
 
     result = await activities.agent_runtime_capture_workspace_checkpoint(request)
 

--- a/tests/unit/workflows/temporal/test_story_output_tools.py
+++ b/tests/unit/workflows/temporal/test_story_output_tools.py
@@ -231,11 +231,27 @@ class _FakeHttpClient:
 
 
 class _CommentReadTimeoutHttpClient(_FakeHttpClient):
+    timeouts: list[float] = []
+
+    def __init__(self, *args, timeout: float, **kwargs) -> None:
+        super().__init__(*args, timeout=timeout, **kwargs)
+        self.__class__.timeouts.append(timeout)
+
     async def post(self, url: str, **kwargs):
         self.requests.append(("POST", url, kwargs))
         raise story_tools.httpx.ReadTimeout(
             "response timed out after GitHub accepted the comment",
             request=story_tools.httpx.Request("POST", url),
+        )
+
+
+class _CommentHttpRejectedClient(_FakeHttpClient):
+    async def post(self, url: str, **kwargs):
+        self.requests.append(("POST", url, kwargs))
+        return story_tools.httpx.Response(
+            403,
+            request=story_tools.httpx.Request("POST", url),
+            json={"message": "secondary rate limit"},
         )
 
 
@@ -433,6 +449,7 @@ async def test_update_github_issue_status_declares_completed_close_side_effect(
 async def test_update_github_issue_status_preserves_patch_when_comment_times_out(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    _CommentReadTimeoutHttpClient.timeouts = []
     monkeypatch.setattr(
         story_tools.httpx,
         "AsyncClient",
@@ -458,6 +475,42 @@ async def test_update_github_issue_status_preserves_patch_when_comment_times_out
         "could not be confirmed after ReadTimeout; the comment was not retried "
         "to avoid a duplicate."
     ]
+    assert _CommentReadTimeoutHttpClient.timeouts == [10.0, 15.0]
+    assert (
+        _CommentReadTimeoutHttpClient.timeouts[0]
+        + (2 * _CommentReadTimeoutHttpClient.timeouts[1])
+        < 60.0
+    )
+
+
+@pytest.mark.asyncio
+async def test_update_github_issue_status_retries_confirmed_comment_rejection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        story_tools.httpx,
+        "AsyncClient",
+        _CommentHttpRejectedClient,
+    )
+    service = _FakeGitHubService()
+
+    result = await update_github_issue_status(
+        {
+            "repository": "MoonLadderStudios/Tactics",
+            "issueNumber": 2355,
+            "mode": "start",
+        },
+        github_service_factory=lambda: service,
+    )
+
+    assert result.status == "FAILED"
+    assert result.outputs["appliedActions"] == ["patch_issue"]
+    assert result.outputs["commentStatus"] == "rejected"
+    assert result.outputs["confirmedLabels"] == ["status: in-progress"]
+    assert result.outputs["summary"] == (
+        "GitHub issue status was updated, but the automation comment failed "
+        "with HTTP 403. github status 403"
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/workflows/temporal/test_story_output_tools.py
+++ b/tests/unit/workflows/temporal/test_story_output_tools.py
@@ -230,6 +230,15 @@ class _FakeHttpClient:
         return _FakeHttpResponse({"id": 1})
 
 
+class _CommentReadTimeoutHttpClient(_FakeHttpClient):
+    async def post(self, url: str, **kwargs):
+        self.requests.append(("POST", url, kwargs))
+        raise story_tools.httpx.ReadTimeout(
+            "response timed out after GitHub accepted the comment",
+            request=story_tools.httpx.Request("POST", url),
+        )
+
+
 @pytest.mark.asyncio
 async def test_load_github_issue_preset_brief_uses_requested_artifact_path(
     monkeypatch: pytest.MonkeyPatch,
@@ -418,6 +427,37 @@ async def test_update_github_issue_status_declares_completed_close_side_effect(
             "Updated GitHub issue MoonLadderStudios/MoonMind#1067 with mode done."
         ),
     }
+
+
+@pytest.mark.asyncio
+async def test_update_github_issue_status_preserves_patch_when_comment_times_out(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        story_tools.httpx,
+        "AsyncClient",
+        _CommentReadTimeoutHttpClient,
+    )
+    service = _FakeGitHubService()
+
+    result = await update_github_issue_status(
+        {
+            "repository": "MoonLadderStudios/Tactics",
+            "issueNumber": 2355,
+            "mode": "start",
+        },
+        github_service_factory=lambda: service,
+    )
+
+    assert result.status == "COMPLETED"
+    assert result.outputs["appliedActions"] == ["patch_issue"]
+    assert result.outputs["commentStatus"] == "unconfirmed"
+    assert result.outputs["confirmedLabels"] == ["status: in-progress"]
+    assert result.outputs["warnings"] == [
+        "GitHub issue status was updated, but the automation comment result "
+        "could not be confirmed after ReadTimeout; the comment was not retried "
+        "to avoid a duplicate."
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
@@ -215,6 +215,16 @@ async def test_dynamic_remediation_validates_active_managed_session_workspace(
 
     monkeypatch.setattr(run_module.workflow, "execute_activity", fake_execute_activity)
 
+    identity = workflow._canonical_step_checkpoint_identity("remediation-1")
+    assert identity is not None
+    await workflow._capture_canonical_step_checkpoint_workspace(
+        "remediation-1",
+        identity=identity,
+        boundary="after_prepare",
+    )
+    assert "sourceIdentity" not in captured[0]["payload"]
+    captured.clear()
+
     await workflow._record_canonical_step_checkpoint(
         "remediation-1",
         boundary="before_execution",


### PR DESCRIPTION
## Summary

- Accept workflow-scoped managed-session baselines at the canonical `after_prepare` checkpoint.
- Preserve a confirmed GitHub issue state update when the auxiliary comment response times out.
- Add regression coverage modeled on the production failures.

## Root cause

Fourteen recent issue workflows failed because checkpoint validation only accepted a cross-step workflow session at `before_execution`, while the production plan captures the same valid baseline at `after_prepare`.

One issue workflow failed after GitHub had already accepted its label update and automation comment. A subsequent comment-response `ReadTimeout` was handled together with the primary issue mutation, so the whole tool step was reported as failed despite the authoritative state change succeeding.

## Impact

Managed-session workflows can now advance through preparation without weakening the existing workflow, runtime, session, ordinal, or source-identity checks. GitHub issue updates remain authoritative after a successful patch; an unconfirmed auxiliary comment is reported as a warning and is not retried, avoiding duplicate comments.

## Validation

- `.venv/bin/python -m pytest tests/unit/workflows/temporal/test_managed_checkpoint_capture.py tests/unit/workflows/temporal/test_story_output_tools.py -n 2 --dist loadfile -q --tb=short` — 201 passed
- Ruff checks for the changed story-output implementation and both test files — passed
- `py_compile` for the checkpoint runtime implementation — passed
- `git diff --cached --check` — passed

The repository test wrapper's global status audit was blocked by pre-existing findings in the ignored `.claude/worktrees/ui-regressions` tree, so the selected test files were executed directly.