### PR TITLE
Fix workflow verification gate and container handoff

### DIFF
--- a/api_service/services/container_jobs.py
+++ b/api_service/services/container_jobs.py
@@ -218,6 +218,7 @@ class ContainerJobService:
         artifacts: ContainerJobArtifactReader | None = None,
         backend_settings: ContainerBackendSettings | None = None,
     ) -> None:
+        self._session = session
         self.repository = ContainerJobRepository(session)
         self._temporal = temporal or TemporalClientAdapter()
         self._artifacts = artifacts
@@ -250,13 +251,19 @@ class ContainerJobService:
                 raise ValueError("container image source is not configured") from exc
         existing = await self.repository.find_exact_replay(owner=owner, request=request)
         if existing is not None:
-            created_at = existing.created_at or datetime.now(timezone.utc)
-            return ContainerJobAccepted(
-                jobId=existing.job_id, replayed=True, createdAt=created_at
+            record, replayed = existing, True
+        else:
+            record, replayed = await self.repository.create_or_replay(
+                owner=owner, request=request, authorization=authorization
             )
-        record, replayed = await self.repository.create_or_replay(
-            owner=owner, request=request, authorization=authorization
-        )
+
+        # The API-owned job identity is authoritative for every later status
+        # read and for worker projection Activities. Commit it before handing
+        # execution to Temporal; a request-scoped AsyncSession otherwise rolls
+        # back the flushed row when the transport returns. Exact replays also
+        # reissue the deterministic Temporal start so a prior start failure can
+        # recover without creating another job identity.
+        await self._session.commit()
         await self._temporal.start_container_job(
             ContainerJobWorkflowInput(
                 jobId=record.job_id,

--- a/api_service/services/container_jobs.py
+++ b/api_service/services/container_jobs.py
@@ -37,6 +37,7 @@ from moonmind.schemas.container_job_models import (
     ContainerJobArtifactPage,
     ContainerJobCancelRequest,
     ContainerJobCancelResult,
+    ContainerJobFailureClass,
     ContainerJobLogEntry,
     ContainerJobLogPage,
     ContainerJobLogQuery,
@@ -52,6 +53,9 @@ from moonmind.schemas.container_job_models import (
 from moonmind.workflows.temporal.client import TemporalClientAdapter
 
 _STDERR_MARKER = "[stderr]"
+_TEMPORAL_START_FAILURE_MESSAGE = (
+    "Temporal workflow start failed before the durable handoff completed."
+)
 
 
 class ContainerJobNotFoundError(RuntimeError):
@@ -257,6 +261,30 @@ class ContainerJobService:
                 owner=owner, request=request, authorization=authorization
             )
 
+        terminal = record.terminal_outcome_json
+        recovering_start_failure = bool(
+            record.state == ContainerJobState.FAILED.value
+            and isinstance(terminal, dict)
+            and terminal.get("failureClass")
+            == ContainerJobFailureClass.TEMPORAL_START.value
+        )
+        preserve_existing_terminal = bool(
+            existing is not None
+            and not recovering_start_failure
+            and record.state
+            in {
+                ContainerJobState.SUCCEEDED.value,
+                ContainerJobState.FAILED.value,
+                ContainerJobState.CANCELED.value,
+                ContainerJobState.TIMED_OUT.value,
+                ContainerJobState.REJECTED.value,
+            }
+        )
+        if recovering_start_failure:
+            record.state = ContainerJobState.QUEUED.value
+            record.terminal_outcome_json = None
+            record.updated_at = datetime.now(timezone.utc)
+
         # The API-owned job identity is authoritative for every later status
         # read and for worker projection Activities. Commit it before handing
         # execution to Temporal; a request-scoped AsyncSession otherwise rolls
@@ -264,14 +292,25 @@ class ContainerJobService:
         # reissue the deterministic Temporal start so a prior start failure can
         # recover without creating another job identity.
         await self._session.commit()
-        await self._temporal.start_container_job(
-            ContainerJobWorkflowInput(
-                jobId=record.job_id,
-                owner=owner,
-                request=request,
-                registryAuthorization=authorization,
+        try:
+            await self._temporal.start_container_job(
+                ContainerJobWorkflowInput(
+                    jobId=record.job_id,
+                    owner=owner,
+                    request=request,
+                    registryAuthorization=authorization,
+                )
             )
-        )
+        except Exception:
+            if not preserve_existing_terminal:
+                record.state = ContainerJobState.FAILED.value
+                record.terminal_outcome_json = TerminalOutcome(
+                    failureClass=ContainerJobFailureClass.TEMPORAL_START,
+                    message=_TEMPORAL_START_FAILURE_MESSAGE,
+                ).model_dump(mode="json", by_alias=True, exclude_none=True)
+                record.updated_at = datetime.now(timezone.utc)
+                await self._session.commit()
+            raise
         created_at = record.created_at or datetime.now(timezone.utc)
         return ContainerJobAccepted(jobId=record.job_id, replayed=replayed, createdAt=created_at)
 

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -5932,7 +5932,7 @@ export interface components {
          * ContainerJobFailureClass
          * @enum {string}
          */
-        ContainerJobFailureClass: "validation" | "authorization" | "workspace" | "image" | "image_not_found" | "image_pull_timeout" | "image_pull_auth_failed" | "image_build_not_configured" | "image_build_inputs_unavailable" | "image_build_timeout" | "image_build_failed" | "image_validation_failed" | "image_platform_mismatch" | "image_backend_unavailable" | "launch" | "execution" | "timeout" | "canceled" | "infrastructure" | "image_use_denied" | "credential_unresolved" | "repository_scope_mismatch" | "registry_auth_failed" | "credential_cleanup_failed";
+        ContainerJobFailureClass: "validation" | "authorization" | "workspace" | "image" | "image_not_found" | "image_pull_timeout" | "image_pull_auth_failed" | "image_build_not_configured" | "image_build_inputs_unavailable" | "image_build_timeout" | "image_build_failed" | "image_validation_failed" | "image_platform_mismatch" | "image_backend_unavailable" | "launch" | "execution" | "timeout" | "canceled" | "infrastructure" | "temporal_start" | "image_use_denied" | "credential_unresolved" | "repository_scope_mismatch" | "registry_auth_failed" | "credential_cleanup_failed";
         /** ContainerJobLogEntry */
         ContainerJobLogEntry: {
             /** Sequence */

--- a/moonmind/schemas/container_job_models.py
+++ b/moonmind/schemas/container_job_models.py
@@ -115,6 +115,7 @@ class ContainerJobFailureClass(StrEnum):
     TIMEOUT = "timeout"
     CANCELED = "canceled"
     INFRASTRUCTURE = "infrastructure"
+    TEMPORAL_START = "temporal_start"
     # Private-image authorization with ephemeral registry credentials (#3257).
     IMAGE_USE_DENIED = "image_use_denied"
     CREDENTIAL_UNRESOLVED = "credential_unresolved"

--- a/moonmind/workflows/temporal/client.py
+++ b/moonmind/workflows/temporal/client.py
@@ -440,6 +440,7 @@ class TemporalClientAdapter:
             workflow_type="MoonMind.ContainerJob",
             workflow_id=container_job_workflow_id(model.job_id),
             input_args=model.model_dump(mode="json", by_alias=True),
+            id_reuse_policy=WorkflowIDReusePolicy.REJECT_DUPLICATE,
         )
 
     async def signal_container_job_cancel(self, job_id: str) -> None:

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -732,6 +732,13 @@ RUN_PLAN_ROUTED_MOONSPEC_REMEDIATION_PATCH = (
 RUN_DYNAMIC_REMEDIATION_LOOP_CONTROLLER_PATCH = (
     "run-dynamic-remediation-loop-controller-v1"
 )
+# The dynamic controller replaces its durable decision while processing the
+# current verifier result. Re-read the blocking projection after that update so
+# a passing verdict cannot inherit the prior attempt's blocking reason. Keep
+# the ordering change replay-gated for histories that already evaluated a gate.
+RUN_REFRESH_MOONSPEC_BLOCK_AFTER_REMEDIATION_DECISION_PATCH = (
+    "run-refresh-moonspec-block-after-remediation-decision-v1"
+)
 # New controller admissions require executable instructions on both agent steps.
 # Gate the workflow-side validation so histories admitted before this invariant
 # keep replaying their recorded command sequence.
@@ -12252,6 +12259,12 @@ class MoonMindRunWorkflow:
                                 ),
                             )
                         )
+                        if workflow.patched(
+                            RUN_REFRESH_MOONSPEC_BLOCK_AFTER_REMEDIATION_DECISION_PATCH
+                        ):
+                            blocking_gate_reason = (
+                                self._blocking_moonspec_gate_reason()
+                            )
                         if dynamic_attempt_admitted:
                             blocking_gate_reason = None
                     remaining_remediation_index = (

--- a/tests/integration/workflows/temporal/test_container_job_workflow.py
+++ b/tests/integration/workflows/temporal/test_container_job_workflow.py
@@ -12,6 +12,7 @@ from temporalio.testing import WorkflowEnvironment
 from temporalio.worker import Replayer, UnsandboxedWorkflowRunner, Worker
 
 from moonmind.config.settings import settings
+from moonmind.workflows.temporal.client import TemporalClientAdapter
 from moonmind.workflows.temporal.workflows.container_job import (
     MoonMindContainerJobWorkflow,
 )
@@ -131,3 +132,42 @@ async def test_container_job_executes_on_test_server_and_replays() -> None:
         workflows=[MoonMindContainerJobWorkflow],
         workflow_runner=UnsandboxedWorkflowRunner(),
     ).replay_workflow(history)
+
+
+async def test_closed_container_job_replay_attaches_without_new_execution() -> None:
+    adapter_job_id = "container-job:" + uuid4().hex
+    payload = _input()
+    payload["jobId"] = adapter_job_id
+    payload["request"]["idempotencyKey"] = f"closed-replay:{adapter_job_id}"
+
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        adapter = TemporalClientAdapter(client=env.client)
+        workflow_queue = adapter.resolve_workflow_task_queue("MoonMind.ContainerJob")
+        activity_queue = settings.temporal.activity_agent_runtime_task_queue
+        async with AsyncExitStack() as stack:
+            await stack.enter_async_context(
+                Worker(
+                    env.client,
+                    task_queue=workflow_queue,
+                    workflows=[MoonMindContainerJobWorkflow],
+                    workflow_runner=UnsandboxedWorkflowRunner(),
+                )
+            )
+            await stack.enter_async_context(
+                Worker(
+                    env.client,
+                    task_queue=activity_queue,
+                    activities=_activities(),
+                )
+            )
+            first = await adapter.start_container_job(payload)
+            first_handle = env.client.get_workflow_handle(
+                first.workflow_id,
+                run_id=first.run_id,
+            )
+            assert (await first_handle.result())["state"] == "succeeded"
+
+            replay = await adapter.start_container_job(payload)
+
+    assert replay.workflow_id == first.workflow_id
+    assert replay.run_id == first.run_id

--- a/tests/unit/services/test_container_jobs.py
+++ b/tests/unit/services/test_container_jobs.py
@@ -130,7 +130,7 @@ async def test_create_or_replay_conflict_and_owner_scoped_reads(session_factory,
         first = await service.submit(owner=owner, request=submission())
         second = await service.submit(owner=owner, request=submission())
         assert first.job_id == second.job_id and second.replayed
-        assert temporal.start_container_job.await_count == 1
+        assert temporal.start_container_job.await_count == 2
         started = temporal.start_container_job.await_args_list[0].args[0]
         assert started.job_id == first.job_id
         assert started.owner == owner
@@ -139,6 +139,77 @@ async def test_create_or_replay_conflict_and_owner_scoped_reads(session_factory,
         assert (await service.status(owner=owner, job_id=first.job_id)).state == "queued"
         with pytest.raises(ContainerJobNotFoundError):
             await service.status(owner=OwnerIdentity(principalId="user-2", principalType="user"), job_id=first.job_id)
+
+
+@pytest.mark.asyncio
+async def test_submit_commits_identity_before_temporal_handoff(
+    session_factory,
+) -> None:
+    owner = OwnerIdentity(principalId="durable-owner", principalType="user")
+    observed_job_ids: list[str] = []
+    temporal = AsyncMock()
+
+    async def start_after_observing_committed_identity(workflow_input):
+        async with session_factory() as observer_session:
+            status = await ContainerJobService(
+                observer_session,
+                temporal=AsyncMock(),
+            ).status(owner=owner, job_id=workflow_input.job_id)
+        observed_job_ids.append(status.job_id)
+
+    temporal.start_container_job.side_effect = (
+        start_after_observing_committed_identity
+    )
+
+    async with session_factory() as session:
+        accepted = await ContainerJobService(
+            session,
+            temporal=temporal,
+        ).submit(owner=owner, request=submission())
+
+    assert observed_job_ids == [accepted.job_id]
+
+    async with session_factory() as status_session:
+        persisted = await ContainerJobService(
+            status_session,
+            temporal=AsyncMock(),
+        ).status(owner=owner, job_id=accepted.job_id)
+    assert persisted.state == "queued"
+
+
+@pytest.mark.asyncio
+async def test_exact_replay_recovers_temporal_start_failure(
+    session_factory,
+) -> None:
+    owner = OwnerIdentity(principalId="retry-owner", principalType="user")
+    temporal = AsyncMock()
+    temporal.start_container_job.side_effect = [
+        RuntimeError("temporal unavailable"),
+        None,
+    ]
+
+    with pytest.raises(RuntimeError, match="temporal unavailable"):
+        async with session_factory() as first_session:
+            await ContainerJobService(
+                first_session,
+                temporal=temporal,
+            ).submit(owner=owner, request=submission())
+
+    async with session_factory() as retry_session:
+        accepted = await ContainerJobService(
+            retry_session,
+            temporal=temporal,
+        ).submit(owner=owner, request=submission())
+
+    assert accepted.replayed is True
+    assert temporal.start_container_job.await_count == 2
+
+    async with session_factory() as status_session:
+        persisted = await ContainerJobService(
+            status_session,
+            temporal=AsyncMock(),
+        ).status(owner=owner, job_id=accepted.job_id)
+    assert persisted.state == "queued"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/test_container_jobs.py
+++ b/tests/unit/services/test_container_jobs.py
@@ -195,6 +195,21 @@ async def test_exact_replay_recovers_temporal_start_failure(
                 temporal=temporal,
             ).submit(owner=owner, request=submission())
 
+    async with session_factory() as failed_session:
+        failed_service = ContainerJobService(
+            failed_session,
+            temporal=AsyncMock(),
+        )
+        failed_record = await failed_service.repository.find_exact_replay(
+            owner=owner,
+            request=submission(),
+        )
+        assert failed_record is not None
+        failed = await failed_service.status(owner=owner, job_id=failed_record.job_id)
+    assert failed.state == "failed"
+    assert failed.terminal is not None
+    assert failed.terminal.failure_class == ContainerJobFailureClass.TEMPORAL_START
+
     async with session_factory() as retry_session:
         accepted = await ContainerJobService(
             retry_session,
@@ -210,6 +225,35 @@ async def test_exact_replay_recovers_temporal_start_failure(
             temporal=AsyncMock(),
         ).status(owner=owner, job_id=accepted.job_id)
     assert persisted.state == "queued"
+    assert persisted.terminal is None
+
+
+@pytest.mark.asyncio
+async def test_terminal_replay_start_error_preserves_terminal_projection(
+    session_factory,
+    temporal,
+) -> None:
+    owner = OwnerIdentity(principalId="terminal-owner", principalType="user")
+    async with session_factory() as session:
+        service = ContainerJobService(session, temporal=temporal)
+        accepted = await service.submit(owner=owner, request=submission())
+        await service.repository.record_observation(
+            owner=owner,
+            job_id=accepted.job_id,
+            state=ContainerJobState.SUCCEEDED,
+            terminal=TerminalOutcome(exitCode=0),
+        )
+        await session.commit()
+        temporal.start_container_job.side_effect = RuntimeError("temporal unavailable")
+
+        with pytest.raises(RuntimeError, match="temporal unavailable"):
+            await service.submit(owner=owner, request=submission())
+
+        preserved = await service.status(owner=owner, job_id=accepted.job_id)
+
+    assert preserved.state == "succeeded"
+    assert preserved.terminal is not None
+    assert preserved.terminal.exit_code == 0
 
 
 @pytest.mark.asyncio

--- a/tests/unit/workflows/temporal/test_container_job_workflow.py
+++ b/tests/unit/workflows/temporal/test_container_job_workflow.py
@@ -6,6 +6,7 @@ from datetime import timedelta
 from unittest.mock import AsyncMock
 
 import pytest
+from temporalio.common import WorkflowIDReusePolicy
 from temporalio.exceptions import ApplicationError
 
 from moonmind.config.settings import settings
@@ -99,6 +100,10 @@ async def test_start_container_job_is_asynchronous_start_or_attach() -> None:
     assert (
         adapter.start_workflow.await_args.kwargs["workflow_type"]
         == "MoonMind.ContainerJob"
+    )
+    assert (
+        adapter.start_workflow.await_args.kwargs["id_reuse_policy"]
+        == WorkflowIDReusePolicy.REJECT_DUPLICATE
     )
 
 

--- a/tests/unit/workflows/temporal/test_run_artifacts.py
+++ b/tests/unit/workflows/temporal/test_run_artifacts.py
@@ -5689,6 +5689,264 @@ async def test_run_execution_stage_moonspec_verify_uses_remaining_remediation_bu
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("refresh_enabled", "expect_published"),
+    [(False, False), (True, True)],
+)
+async def test_dynamic_remediation_final_pass_replaces_prior_blocking_verdict(
+    monkeypatch: pytest.MonkeyPatch,
+    refresh_enabled: bool,
+    expect_published: bool,
+) -> None:
+    """A passing verifier decision must supersede the prior loop decision.
+
+    Regression for workflow mm:bd309558-4b8c-4883-b4aa-d60ea7494698: the
+    final verifier returned FULLY_IMPLEMENTED, but the execution stage retained
+    the preceding ADDITIONAL_WORK_NEEDED blocking reason and failed instead of
+    publishing.
+    """
+
+    workflow = MoonMindRunWorkflow()
+    workflow._owner_id = "owner-1"
+    workflow._repo = "MoonLadderStudios/MoonMind"
+    executed_steps: list[str] = []
+    create_pr_called = False
+
+    def request_step_id(request: object) -> str:
+        parameters = getattr(request, "parameters", {})
+        metadata = parameters.get("metadata") if isinstance(parameters, dict) else {}
+        moonmind = metadata.get("moonmind") if isinstance(metadata, dict) else {}
+        step_ledger = moonmind.get("stepLedger") if isinstance(moonmind, dict) else {}
+        return str(step_ledger.get("logicalStepId") or "")
+
+    async def fake_execute_activity(
+        activity_type: str,
+        payload: dict[str, object] | None = None,
+        **_kwargs: object,
+    ) -> object:
+        nonlocal create_pr_called
+        if activity_type == "repo.create_pr":
+            create_pr_called = True
+            return {
+                "url": "https://github.com/MoonLadderStudios/MoonMind/pull/999",
+            }
+        if activity_type == "agent_skill.resolve":
+            return {
+                "manifestRef": "art_skill_snapshot_1",
+                "skills": [
+                    {"name": "moonspec-implement"},
+                    {"name": "moonspec-verify"},
+                ],
+            }
+        if activity_type == "artifact.read":
+            artifact_ref = (
+                payload.get("artifact_ref")
+                if isinstance(payload, dict)
+                else getattr(payload, "artifact_ref", None)
+            ) if payload is not None else None
+            if artifact_ref == "artifact://registry/1":
+                return json.dumps({"skills": []}).encode("utf-8")
+            loop = {
+                "kind": "remediation_loop",
+                "loopId": "issue-implementation-remediation",
+                "remediationTool": {
+                    "type": "agent_runtime",
+                    "name": "auto",
+                    "inputs": {
+                        "selectedSkill": "moonspec-implement",
+                        "instructions": "Fix the remaining verified gaps.",
+                    },
+                },
+                "verificationTool": {
+                    "type": "agent_runtime",
+                    "name": "auto",
+                    "inputs": {
+                        "selectedSkill": "moonspec-verify",
+                        "instructions": "Verify the remediated candidate.",
+                    },
+                },
+                "workspacePolicy": "continue_from_loop_head",
+                "budgets": {
+                    "hardMaxAttempts": 6,
+                    "maxConsecutiveSemanticNoProgress": 2,
+                },
+                "terminalPolicy": {
+                    "fullyImplemented": "advance",
+                    "additionalWorkNeeded": "continue_when_allowed",
+                    "blocked": "stop",
+                    "noDetermination": "retry_evidence_or_stop",
+                    "failedUnrecoverable": "stop",
+                },
+                "sideEffectPolicy": "workflow_owned",
+                "publicationPolicy": "evaluate_after_terminal",
+            }
+            return json.dumps(
+                {
+                    "plan_version": "1.0",
+                    "metadata": {
+                        "title": "Dynamic remediation final pass",
+                        "created_at": "2026-07-27T00:00:00Z",
+                        "registry_snapshot": {
+                            "digest": "reg:sha256:" + ("a" * 64),
+                            "artifact_ref": "artifact://registry/1",
+                        },
+                    },
+                    "policy": {"failure_mode": "FAIL_FAST", "max_concurrency": 1},
+                    "nodes": [
+                        {
+                            "id": "verify-initial",
+                            "tool": {"type": "agent_runtime", "name": "auto"},
+                            "inputs": {
+                                "runtime": {"mode": "codex"},
+                                "selectedSkill": "moonspec-verify",
+                                "instructions": "Verify the implementation.",
+                                "annotations": {"remediationLoop": loop},
+                            },
+                            "options": {},
+                        }
+                    ],
+                    "edges": [],
+                }
+            ).encode("utf-8")
+        return {"status": "COMPLETED", "outputs": {}}
+
+    async def fake_execute_child_workflow(
+        _workflow_type: str,
+        request: object,
+        **_kwargs: object,
+    ) -> object:
+        step_id = request_step_id(request)
+        executed_steps.append(step_id)
+        if step_id == "verify-initial":
+            return {
+                "summary": "Verdict: ADDITIONAL_WORK_NEEDED",
+                "metadata": {
+                    "verdict": "ADDITIONAL_WORK_NEEDED",
+                    "recommendedNextAction": "reattempt_current_step",
+                    "remainingWorkRef": "art_remaining_initial",
+                    "recoverableInCurrentRuntime": True,
+                    "operator_summary": "One implementation gap remains.",
+                    "diagnostics_ref": "art_verify_initial",
+                },
+                "output_refs": [],
+            }
+        if step_id.endswith(":verification:1"):
+            return {
+                "summary": "Verdict: FULLY_IMPLEMENTED",
+                "metadata": {
+                    "verdict": "FULLY_IMPLEMENTED",
+                    "recommendedNextAction": "advance",
+                    "recoverableInCurrentRuntime": True,
+                    "operator_summary": "All requirements are implemented.",
+                    "diagnostics_ref": "art_verify_final",
+                    "push_status": "pushed",
+                    "push_branch": "fixed-workflow-gate",
+                    "push_base_ref": "origin/main",
+                },
+                "output_refs": [],
+            }
+        return {
+            "summary": "Remediation completed.",
+            "metadata": {
+                "operator_summary": "Remediation completed.",
+                "push_status": "pushed",
+                "push_branch": "fixed-workflow-gate",
+                "push_base_ref": "origin/main",
+            },
+            "output_refs": [],
+        }
+
+    async def fake_bind_workflow_scoped_session(
+        self: MoonMindRunWorkflow,
+        request: object,
+    ) -> object:
+        return request
+
+    artifact_ordinal = count(1)
+
+    async def fake_write_json_artifact(**_kwargs: object) -> str:
+        return f"artifact://test/{next(artifact_ordinal)}"
+
+    monkeypatch.setattr(
+        run_workflow_module.workflow, "execute_activity", fake_execute_activity
+    )
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "execute_child_workflow",
+        fake_execute_child_workflow,
+    )
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "wait_condition",
+        _immediate_wait_condition,
+    )
+    monkeypatch.setattr(
+        MoonMindRunWorkflow,
+        "_maybe_bind_workflow_scoped_session",
+        fake_bind_workflow_scoped_session,
+    )
+    monkeypatch.setattr(workflow, "_write_json_artifact", fake_write_json_artifact)
+    monkeypatch.setattr(run_workflow_module.workflow, "upsert_memo", lambda _memo: None)
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "upsert_search_attributes",
+        lambda _attributes: None,
+    )
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "now",
+        lambda: datetime.now(timezone.utc),
+    )
+    workflow_info = type(
+        "WorkflowInfo",
+        (),
+        {"namespace": "default", "workflow_id": "wf-1", "run_id": "run-1"},
+    )
+    monkeypatch.setattr(run_workflow_module.workflow, "info", workflow_info)
+    enabled_patches = {
+        run_workflow_module.RUN_CONDITIONAL_REGISTRY_READ_PATCH,
+        run_workflow_module.NATIVE_PR_BRANCH_DEFAULTS_PATCH,
+        run_workflow_module.RUN_MOONSPEC_VERIFY_PUBLICATION_GATE_PATCH,
+        run_workflow_module.RUN_MOONSPEC_VERIFY_REMEDIATION_INDEX_PATCH,
+        run_workflow_module.RUN_DYNAMIC_REMEDIATION_LOOP_CONTROLLER_PATCH,
+        run_workflow_module.RUN_REMEDIATION_LOOP_ARTIFACT_REF_NORMALIZATION_PATCH,
+    }
+    if refresh_enabled:
+        enabled_patches.add(
+            run_workflow_module.RUN_REFRESH_MOONSPEC_BLOCK_AFTER_REMEDIATION_DECISION_PATCH
+        )
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "patched",
+        lambda patch_id: patch_id in enabled_patches,
+    )
+
+    await workflow._run_execution_stage(
+        parameters={"repo": "MoonLadderStudios/MoonMind", "publishMode": "pr"},
+        plan_ref="art_plan_1",
+    )
+
+    assert executed_steps == [
+        "verify-initial",
+        "wf-1:run-1:issue-implementation-remediation:remediation:1",
+        "wf-1:run-1:issue-implementation-remediation:verification:1",
+    ]
+    assert workflow._publish_context["moonSpecGate"]["verdict"] == (
+        "FULLY_IMPLEMENTED"
+    )
+    assert workflow._publish_context["remediationLoop"]["latestVerdict"] == (
+        "FULLY_IMPLEMENTED"
+    )
+    assert create_pr_called is expect_published
+    if expect_published:
+        assert "publicationBlockedBy" not in workflow._publish_context
+    else:
+        assert workflow._publish_context["publicationBlockedBy"] == (
+            "moonspec_verify"
+        )
+
+
+@pytest.mark.asyncio
 async def test_run_execution_stage_publish_mode_pr_jules_skips_native_pr(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/workflows/temporal/test_run_replayer.py
+++ b/tests/unit/workflows/temporal/test_run_replayer.py
@@ -7,6 +7,13 @@ from temporalio.testing import WorkflowEnvironment
 from temporalio.worker import Worker, UnsandboxedWorkflowRunner, Replayer
 
 from moonmind.workflows.skills.approval_policy import StepGateResult
+from moonmind.workflows.temporal.remediation_loop import (
+    ConsumedRemediationBudgets,
+    RemediationContinuationDecision,
+    RemediationLoopPhase,
+    RemediationLoopState,
+    apply_continuation_decision,
+)
 from moonmind.workflows.temporal.workflows.run import (
     GateTransitionDecision,
     RUN_BOUNDED_STORY_LOOP_FEEDBACK_PROGRESS_PATCH,
@@ -20,6 +27,7 @@ from moonmind.workflows.temporal.workflows.run import (
     RUN_REMEDIATION_CONTINUE_MANAGED_SESSION_PATCH,
     RUN_REMEDIATION_LOOP_ARTIFACT_REF_NORMALIZATION_PATCH,
     RUN_REMEDIATION_LOOP_CONTINUE_AS_NEW_PATCH,
+    RUN_REFRESH_MOONSPEC_BLOCK_AFTER_REMEDIATION_DECISION_PATCH,
     RUN_WORKFLOW_OWNED_REMEDIATION_HEAD_PATCH,
     MoonMindRunWorkflow,
     MoonMindUserWorkflow,
@@ -349,6 +357,67 @@ class _CurrentOmnigentCompilerReplayFixture:
             authored,
             path="workflow.omnigent",
         )
+
+
+def _mm3542_apply_final_verifier_decision(
+    run_workflow: MoonMindRunWorkflow,
+) -> str | None:
+    """Apply the final verifier while retaining the pre-decision block."""
+
+    run_workflow._moonspec_gate_verdict = "FULLY_IMPLEMENTED"
+    run_workflow._remediation_loop_state = RemediationLoopState(
+        loopId="issue-implementation-remediation",
+        attemptOrdinal=1,
+        phase=RemediationLoopPhase.CONTINUATION_DECIDING,
+        consumedBudgets=ConsumedRemediationBudgets(attempts=1),
+        continuationDecisionRef="artifact://decision/previous",
+        latestVerdict="ADDITIONAL_WORK_NEEDED",
+    )
+    blocking_reason = run_workflow._blocking_moonspec_gate_reason()
+    decision = RemediationContinuationDecision(
+        loopId="issue-implementation-remediation",
+        currentAttempt=1,
+        verdict="FULLY_IMPLEMENTED",
+        continueLoop=False,
+        reason="The final verifier approved publication.",
+        nextPhase=RemediationLoopPhase.ACCEPTED,
+        gateResultRef="artifact://verification/final",
+    )
+    run_workflow._remediation_loop_state = apply_continuation_decision(
+        run_workflow._remediation_loop_state,
+        decision=decision,
+        decision_ref="artifact://decision/final",
+    )
+    return blocking_reason
+
+
+@workflow.defn(name="MM3542FinalVerifierGateReplayFixture")
+class _LegacyFinalVerifierGateReplayFixture:
+    @workflow.run
+    async def run(self) -> dict[str, Any]:
+        run_workflow = MoonMindRunWorkflow()
+        blocking_reason = _mm3542_apply_final_verifier_decision(run_workflow)
+        return {
+            "latestVerdict": run_workflow._remediation_loop_state.latest_verdict,
+            "publicationBlocked": bool(blocking_reason),
+        }
+
+
+@workflow.defn(name="MM3542FinalVerifierGateReplayFixture")
+class _CurrentFinalVerifierGateReplayFixture:
+    @workflow.run
+    async def run(self) -> dict[str, Any]:
+        run_workflow = MoonMindRunWorkflow()
+        blocking_reason = _mm3542_apply_final_verifier_decision(run_workflow)
+        if workflow.patched(
+            RUN_REFRESH_MOONSPEC_BLOCK_AFTER_REMEDIATION_DECISION_PATCH
+        ):
+            blocking_reason = run_workflow._blocking_moonspec_gate_reason()
+        return {
+            "latestVerdict": run_workflow._remediation_loop_state.latest_verdict,
+            "publicationBlocked": bool(blocking_reason),
+        }
+
 
 @pytest.mark.asyncio
 async def test_workflow_determinism_replay(mock_run_environment):  # noqa: F811
@@ -740,6 +809,53 @@ async def test_github_3453_pre_change_omnigent_history_replays() -> None:
 
     replayer = Replayer(
         workflows=[_CurrentOmnigentCompilerReplayFixture],
+        workflow_runner=UnsandboxedWorkflowRunner(),
+    )
+    await replayer.replay_workflow(legacy_history)
+    await replayer.replay_workflow(current_history)
+
+
+@pytest.mark.asyncio
+async def test_final_verifier_gate_pre_and_post_patch_histories_replay() -> None:
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        async with Worker(
+            env.client,
+            task_queue="test-mm3542-final-verifier-legacy",
+            workflows=[_LegacyFinalVerifierGateReplayFixture],
+            workflow_runner=UnsandboxedWorkflowRunner(),
+        ):
+            legacy_handle = await env.client.start_workflow(
+                _LegacyFinalVerifierGateReplayFixture.run,
+                id="test-mm3542-final-verifier-legacy",
+                task_queue="test-mm3542-final-verifier-legacy",
+            )
+            legacy_result = await legacy_handle.result()
+            legacy_history = await legacy_handle.fetch_history()
+
+        async with Worker(
+            env.client,
+            task_queue="test-mm3542-final-verifier-current",
+            workflows=[_CurrentFinalVerifierGateReplayFixture],
+            workflow_runner=UnsandboxedWorkflowRunner(),
+        ):
+            current_handle = await env.client.start_workflow(
+                _CurrentFinalVerifierGateReplayFixture.run,
+                id="test-mm3542-final-verifier-current",
+                task_queue="test-mm3542-final-verifier-current",
+            )
+            current_result = await current_handle.result()
+            current_history = await current_handle.fetch_history()
+
+    assert legacy_result == {
+        "latestVerdict": "FULLY_IMPLEMENTED",
+        "publicationBlocked": True,
+    }
+    assert current_result == {
+        "latestVerdict": "FULLY_IMPLEMENTED",
+        "publicationBlocked": False,
+    }
+    replayer = Replayer(
+        workflows=[_CurrentFinalVerifierGateReplayFixture],
         workflow_runner=UnsandboxedWorkflowRunner(),
     )
     await replayer.replay_workflow(legacy_history)


### PR DESCRIPTION
## Summary

- refresh the MoonSpec publication gate after the current remediation verdict replaces durable loop state
- preserve Temporal replay safety with a versioned workflow patch marker
- commit container-job identities before starting their Temporal workflows
- make exact idempotent replays recover an earlier Temporal start failure

## Root cause

Workflow `mm:bd309558-4b8c-4883-b4aa-d60ea7494698` received a final `FULLY_IMPLEMENTED` verifier result, but publication still used the preceding `semantic_no_progress_exhausted` decision. Managed container test submissions also disappeared because their database rows were only flushed and were rolled back when the request-scoped session closed.

## Validation

- `./tools/test_unit.sh tests/unit/services/test_container_jobs.py tests/unit/workflows/temporal/test_run_artifacts.py --python-only` — 104 passed
- `./tools/test_unit.sh tests/unit/api/test_container_jobs_transport.py tests/unit/services/test_container_jobs.py --python-only` — 28 passed
- `./tools/test_integration.sh` — 481 passed, 1 skipped; 7 unrelated Omnigent embedded-recovery cases failed because `/app/omnigent/omnigent/runner/identity.py` was absent from the local test image
- `git diff --check`
