### PR TITLE
GitHub Issue Implement: MoonLadderStudios/MoonMind#3511

### DIFF
--- a/api_service/api/routers/mcp_tools.py
+++ b/api_service/api/routers/mcp_tools.py
@@ -37,6 +37,10 @@ from moonmind.mcp.skills_on_demand_registry import (
     SkillsOnDemandToolExecutionContext,
     SkillsOnDemandToolRegistry,
 )
+from moonmind.mcp.remediation_tool_registry import (
+    RemediationToolExecutionContext,
+    RemediationToolRegistry,
+)
 from moonmind.mcp.tool_registry import (
     QueueToolExecutionContext,
     QueueToolRegistry,
@@ -49,6 +53,7 @@ from moonmind.mcp.tool_registry import (
     ToolNotFoundError,
 )
 from moonmind.workflows import get_temporal_artifact_service
+from moonmind.workflows.temporal.remediation_tools import RemediationEvidenceToolService
 from moonmind.workflows.adapters.jules_client import JulesClient, JulesClientError
 
 logger = logging.getLogger(__name__)
@@ -64,6 +69,7 @@ _container_job_registry = ContainerJobToolRegistry()
 _skills_on_demand_registry = SkillsOnDemandToolRegistry(
     expose_commands=settings.workflow.skills_on_demand_enabled
 )
+_remediation_registry = RemediationToolRegistry()
 _jira_registry: JiraToolRegistry | None = None
 _jira_service: JiraToolService | None = None
 _jules_registry: JulesToolRegistry | None = None
@@ -164,6 +170,7 @@ def _list_registered_tools() -> list[Any]:
         _queue_registry.list_tools()
         + _execution_tool_registry.list_tools()
         + _skills_on_demand_registry.list_tools()
+        + _remediation_registry.list_tools()
         + _list_container_job_tools()
     )
     if _jira_registry is not None:
@@ -177,6 +184,7 @@ def _list_streamable_callable_tools() -> list[Any]:
     tools = (
         _queue_registry.list_tools()
         + _skills_on_demand_registry.list_tools()
+        + _remediation_registry.list_tools()
         + _list_container_job_tools()
     )
     if _jira_registry is not None:
@@ -289,6 +297,24 @@ async def _dispatch_tool_call(
             tool=payload.tool,
             arguments=payload.arguments,
             context=skills_context,
+        )
+    if payload.tool.startswith("remediation."):
+        if session is None:  # pragma: no cover - HTTP transport always supplies it
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail={"code": "backend_unavailable"},
+            )
+        context = RemediationToolExecutionContext(
+            service=RemediationEvidenceToolService(
+                session=session,
+                artifact_service=get_temporal_artifact_service(session),
+            ),
+            principal=str(user.id),
+        )
+        return await _remediation_registry.call_tool(
+            tool=payload.tool,
+            arguments=payload.arguments,
+            context=context,
         )
 
     queue_context = QueueToolExecutionContext(

--- a/api_service/api/routers/mcp_tools.py
+++ b/api_service/api/routers/mcp_tools.py
@@ -313,7 +313,7 @@ async def _dispatch_tool_call(
                 artifact_service=get_temporal_artifact_service(session),
                 log_reader=log_adapter,
                 live_follower=log_adapter,
-                action_executor=build_remediation_action_executor(),
+                action_executor=build_remediation_action_executor(session=session),
             ),
             principal=str(user.id),
         )

--- a/api_service/api/routers/mcp_tools.py
+++ b/api_service/api/routers/mcp_tools.py
@@ -15,6 +15,8 @@ from api_service.auth_providers import get_current_user
 from api_service.db.base import async_session_maker, get_async_session
 from api_service.db.models import User
 from api_service.services.container_jobs import ContainerJobService
+from api_service.services.remediation_evidence import ManagedRunRemediationLogAdapter
+from api_service.services.remediation_actions import build_remediation_action_executor
 from moonmind.config.settings import settings
 from moonmind.integrations.jira.errors import JiraToolError
 from moonmind.integrations.jira.tool import JiraToolService
@@ -304,10 +306,14 @@ async def _dispatch_tool_call(
                 status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
                 detail={"code": "backend_unavailable"},
             )
+        log_adapter = ManagedRunRemediationLogAdapter()
         context = RemediationToolExecutionContext(
             service=RemediationEvidenceToolService(
                 session=session,
                 artifact_service=get_temporal_artifact_service(session),
+                log_reader=log_adapter,
+                live_follower=log_adapter,
+                action_executor=build_remediation_action_executor(),
             ),
             principal=str(user.id),
         )

--- a/api_service/services/remediation_actions.py
+++ b/api_service/services/remediation_actions.py
@@ -62,6 +62,8 @@ class TemporalRemediationControlPlane:
             "beforeEvidenceRefs": before,
             "afterEvidenceRefs": after,
             "verification": {"status": "pending"},
+            "verificationRequired": True,
+            "verificationHint": message,
         }
 
     @staticmethod
@@ -143,6 +145,11 @@ class TemporalRemediationControlPlane:
                 f"execution:{resulting_workflow_id}:rerun-request:{action_id}"
             ],
             "verification": {"status": "pending" if accepted else "verified"},
+            "verificationRequired": accepted,
+            "verificationHint": (
+                "Verify the resulting workflow reaches an authoritative terminal state."
+                if accepted else None
+            ),
         }
 
     async def checkpoint_branch(
@@ -220,9 +227,11 @@ class TemporalRemediationControlPlane:
             "session.interrupt_turn": "InterruptTurn",
             "session.clear": "ClearSession",
             "session.cancel": "CancelSession",
-            "session.terminate": "CancelSession",
-            "session.restart_container": "ClearSession",
+            "session.terminate": None,
+            "session.restart_container": None,
         }[kind]
+        if update is None:
+            raise ValueError(f"{kind} is unsupported by the owning session control plane")
         await self._client.update_workflow(
             f"{agent_run_id}:session:{runtime_id}",
             update,
@@ -301,23 +310,9 @@ class TemporalRemediationControlPlane:
         _guard_result: Mapping[str, Any],
         target: RemediationTargetHealthSnapshot,
     ) -> Mapping[str, Any]:
-        action_id, params, before = self._parts(action_request, target)
-        cleanup_ref = self._required(params, "cleanupRef")
-        result = await self._client.start_workflow(
-            workflow_type="MoonMind.ManagedRuntimeWorkspaceCleanup",
-            workflow_id=f"remediation-cleanup:{action_id}",
-            input_args={
-                "actionKind": "cleanup.request_janitor",
-                "cleanupRef": cleanup_ref,
-                "targetWorkflowId": target.workflow_id,
-                "expectedState": params.get("expectedState"),
-                "requestId": action_id,
-            },
-        )
-        return self._accepted(
-            before,
-            after=[f"workflow:{result.workflow_id}:run:{result.run_id}"],
-            message="Cleanup request was queued on the workspace janitor control plane.",
+        raise ValueError(
+            "targeted cleanup is unsupported until cleanupRef can be resolved "
+            "by its owning control plane"
         )
 
     async def evidence_only(
@@ -326,13 +321,10 @@ class TemporalRemediationControlPlane:
         _guard_result: Mapping[str, Any],
         target: RemediationTargetHealthSnapshot,
     ) -> Mapping[str, Any]:
-        action_id, _params, before = self._parts(action_request, target)
-        return {
-            "status": "applied",
-            "beforeEvidenceRefs": before,
-            "afterEvidenceRefs": [f"remediation-evidence:{action_id}"],
-            "verification": {"status": "verified", "targetRunChanged": False},
-        }
+        raise ValueError(
+            "verification actions require an owning evidence adapter and cannot "
+            "synthesize success"
+        )
 
     @staticmethod
     def _typed(handler: ActionHandler) -> ActionHandler:

--- a/api_service/services/remediation_actions.py
+++ b/api_service/services/remediation_actions.py
@@ -2,105 +2,380 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+import asyncio
+from collections.abc import Awaitable, Callable, Mapping
 from typing import Any
 
+from sqlalchemy.ext.asyncio import AsyncSession
+
 from moonmind.workflows.temporal.client import TemporalClientAdapter
-from moonmind.workflows.temporal.remediation_actions import (
-    remediation_action_kinds,
-)
 from moonmind.workflows.temporal.remediation_tools import (
     MoonMindControlPlaneRemediationActionExecutor,
     RemediationTargetHealthSnapshot,
 )
+from moonmind.workflows.temporal.service import TemporalExecutionService
+
+ActionHandler = Callable[
+    [Mapping[str, Any], Mapping[str, Any], RemediationTargetHealthSnapshot],
+    Awaitable[Mapping[str, Any]],
+]
 
 
 class TemporalRemediationControlPlane:
-    """Dispatch controls through Temporal, the owner of execution/session state."""
+    """Route each action to the durable service that owns the mutated state."""
 
-    def __init__(self, client: TemporalClientAdapter | None = None) -> None:
+    def __init__(
+        self,
+        *,
+        client: TemporalClientAdapter | None = None,
+        execution_service: TemporalExecutionService | None = None,
+    ) -> None:
         self._client = client or TemporalClientAdapter()
+        self._execution_service = execution_service
 
-    async def execute(
+    @staticmethod
+    def _parts(
+        action_request: Mapping[str, Any],
+        target: RemediationTargetHealthSnapshot,
+    ) -> tuple[str, dict[str, Any], list[str]]:
+        action_id = str(action_request.get("actionId") or "").strip()
+        if not action_id:
+            raise ValueError("actionId is required for stable idempotency")
+        raw = action_request.get("params")
+        if not isinstance(raw, Mapping):
+            raw = action_request.get("parameters")
+        params = dict(raw) if isinstance(raw, Mapping) else {}
+        return action_id, params, [
+            f"execution:{target.workflow_id}:run:{target.current_run_id}"
+        ]
+
+    @staticmethod
+    def _accepted(
+        before: list[str], *, after: list[str], message: str
+    ) -> Mapping[str, Any]:
+        return {
+            "status": "accepted",
+            "message": message,
+            "beforeEvidenceRefs": before,
+            "afterEvidenceRefs": after,
+            "verification": {"status": "pending"},
+        }
+
+    @staticmethod
+    def _required(params: Mapping[str, Any], name: str) -> str:
+        value = str(params.get(name) or "").strip()
+        if not value:
+            raise ValueError(f"{name} is required")
+        return value
+
+    @staticmethod
+    def _ensure_expected_run(
+        params: Mapping[str, Any], target: RemediationTargetHealthSnapshot
+    ) -> None:
+        expected = str(params.get("expectedRunId") or target.pinned_run_id).strip()
+        if expected != target.current_run_id:
+            raise ValueError("expectedRunId does not match the current target run")
+
+    async def execution_control(
         self,
         action_request: Mapping[str, Any],
         _guard_result: Mapping[str, Any],
         target: RemediationTargetHealthSnapshot,
     ) -> Mapping[str, Any]:
-        kind = str(action_request.get("actionKind") or "")
-        parameters = action_request.get("params")
-        if not isinstance(parameters, Mapping):
-            parameters = action_request.get("parameters")
-        params = dict(parameters) if isinstance(parameters, Mapping) else {}
-        before = [f"execution:{target.workflow_id}:run:{target.current_run_id}"]
-
+        action_id, params, before = self._parts(action_request, target)
+        self._ensure_expected_run(params, target)
+        kind = str(action_request["actionKind"])
         if kind == "execution.pause":
-            await self._client.signal_workflow(target.workflow_id, "Pause", params)
+            await self._client.update_workflow(
+                target.workflow_id, "Pause", {"idempotency_key": action_id}
+            )
         elif kind == "execution.resume":
-            await self._client.signal_workflow(target.workflow_id, "Resume", params)
+            await self._client.update_workflow(
+                target.workflow_id, "Resume", {"idempotency_key": action_id}
+            )
         elif kind == "execution.cancel":
             await self._client.cancel_workflow(target.workflow_id)
-        elif kind == "execution.force_terminate":
+        else:
             await self._client.terminate_workflow(
                 target.workflow_id,
                 reason=str(params.get("reason") or "authorized remediation"),
             )
-        elif kind.startswith("session."):
-            agent_run_id = str(params.get("agentRunId") or "").strip()
-            runtime_id = str(params.get("runtimeId") or "").strip()
-            if not agent_run_id or not runtime_id:
+        return self._accepted(
+            before,
+            after=[f"execution:{target.workflow_id}:action:{action_id}"],
+            message=f"{kind} was delivered to the execution control plane.",
+        )
+
+    async def rerun(
+        self,
+        action_request: Mapping[str, Any],
+        _guard_result: Mapping[str, Any],
+        target: RemediationTargetHealthSnapshot,
+    ) -> Mapping[str, Any]:
+        action_id, params, before = self._parts(action_request, target)
+        self._ensure_expected_run(params, target)
+        if self._execution_service is None:
+            raise RuntimeError("execution service is unavailable")
+        if action_request["actionKind"] == "execution.start_fresh_rerun":
+            response = await self._execution_service.create_fresh_rerun_execution(
+                workflow_id=target.workflow_id,
+                idempotency_key=action_id,
+            )
+        else:
+            response = await self._execution_service.update_execution(
+                workflow_id=target.workflow_id,
+                update_name="RequestRerun",
+                idempotency_key=action_id,
+            )
+        accepted = response.get("accepted") is not False
+        status = "accepted" if accepted else "no_op"
+        resulting_workflow_id = str(
+            response.get("workflow_id") or target.workflow_id
+        ).strip()
+        return {
+            "status": status,
+            "message": str(response.get("message") or "Rerun request processed."),
+            "beforeEvidenceRefs": before,
+            "afterEvidenceRefs": [
+                f"execution:{resulting_workflow_id}:rerun-request:{action_id}"
+            ],
+            "verification": {"status": "pending" if accepted else "verified"},
+        }
+
+    async def checkpoint_branch(
+        self,
+        action_request: Mapping[str, Any],
+        _guard_result: Mapping[str, Any],
+        target: RemediationTargetHealthSnapshot,
+    ) -> Mapping[str, Any]:
+        action_id, params, before = self._parts(action_request, target)
+        self._ensure_expected_run(params, target)
+        context_ref = self._required(params, "remediationContextRef")
+        checkpoint_ref = self._required(params, "checkpointRef")
+        remediation_workflow_id = self._required(params, "remediationWorkflowId")
+        await self._client.update_workflow(
+            remediation_workflow_id,
+            "CreateCheckpointBranch",
+            {
+                "requestId": action_id,
+                "targetWorkflowId": target.workflow_id,
+                "targetRunId": target.current_run_id,
+                "remediationContextRef": context_ref,
+                "checkpointRef": checkpoint_ref,
+                "runtimeContextPolicy": "fresh_agent_run",
+            },
+        )
+        return self._accepted(
+            before,
+            after=[f"checkpoint-branch-request:{action_id}"],
+            message="Checkpoint Branch creation was delivered to its durable owner.",
+        )
+
+    async def session_control(
+        self,
+        action_request: Mapping[str, Any],
+        _guard_result: Mapping[str, Any],
+        target: RemediationTargetHealthSnapshot,
+    ) -> Mapping[str, Any]:
+        action_id, params, before = self._parts(action_request, target)
+        agent_run_id = self._required(params, "agentRunId")
+        runtime_id = self._required(params, "runtimeId")
+        kind = str(action_request["actionKind"])
+        update = {
+            "session.interrupt_turn": "InterruptTurn",
+            "session.clear": "ClearSession",
+            "session.cancel": "CancelSession",
+            "session.terminate": "CancelSession",
+            "session.restart_container": "ClearSession",
+        }[kind]
+        await self._client.update_workflow(
+            f"{agent_run_id}:session:{runtime_id}",
+            update,
+            {"requestId": action_id, "reason": params.get("reason")},
+        )
+        return self._accepted(
+            before,
+            after=[f"managed-session:{agent_run_id}:{runtime_id}:action:{action_id}"],
+            message=f"{kind} was delivered to the managed-session control plane.",
+        )
+
+    async def omnigent_reconcile(
+        self,
+        action_request: Mapping[str, Any],
+        _guard_result: Mapping[str, Any],
+        target: RemediationTargetHealthSnapshot,
+    ) -> Mapping[str, Any]:
+        action_id, params, before = self._parts(action_request, target)
+        kind = str(action_request["actionKind"])
+        profile_id = self._required(params, "providerProfileId")
+        host_lease_ref = str(params.get("hostLeaseRef") or "").strip() or None
+        if kind.startswith("host.") or kind == "host_lease.reconcile_stale":
+            if host_lease_ref is None:
+                raise ValueError("hostLeaseRef is required")
+        result = await self._client.start_workflow(
+            workflow_type="MoonMind.OmnigentOAuthHostJanitor",
+            workflow_id=f"remediation-omnigent:{action_id}",
+            input_args={
+                "profile_id": profile_id,
+                "force": True,
+                "actionKind": kind,
+                "hostLeaseRef": host_lease_ref,
+                "expectedHostState": params.get("expectedHostState"),
+                "requestId": action_id,
+            },
+        )
+        return self._accepted(
+            before,
+            after=[f"workflow:{result.workflow_id}:run:{result.run_id}"],
+            message=f"{kind} was queued on the Omnigent host/lease control plane.",
+        )
+
+    async def managed_runtime_reconcile(
+        self,
+        action_request: Mapping[str, Any],
+        _guard_result: Mapping[str, Any],
+        target: RemediationTargetHealthSnapshot,
+    ) -> Mapping[str, Any]:
+        action_id, params, before = self._parts(action_request, target)
+        kind = str(action_request["actionKind"])
+        container_ref = self._required(params, "containerRef")
+        result = await self._client.start_workflow(
+            workflow_type="MoonMind.ManagedSessionReconcile",
+            workflow_id=f"remediation-managed-runtime:{action_id}",
+            input_args={
+                "actionKind": kind,
+                "containerRef": container_ref,
+                "expectedState": params.get("expectedState"),
+                "requestId": action_id,
+            },
+        )
+        return self._accepted(
+            before,
+            after=[f"workflow:{result.workflow_id}:run:{result.run_id}"],
+            message=f"{kind} was queued on the managed-runtime control plane.",
+        )
+
+    async def janitor(
+        self,
+        action_request: Mapping[str, Any],
+        _guard_result: Mapping[str, Any],
+        target: RemediationTargetHealthSnapshot,
+    ) -> Mapping[str, Any]:
+        action_id, params, before = self._parts(action_request, target)
+        cleanup_ref = self._required(params, "cleanupRef")
+        result = await self._client.start_workflow(
+            workflow_type="MoonMind.ManagedRuntimeWorkspaceCleanup",
+            workflow_id=f"remediation-cleanup:{action_id}",
+            input_args={
+                "cleanupRef": cleanup_ref,
+                "targetWorkflowId": target.workflow_id,
+                "expectedState": params.get("expectedState"),
+                "requestId": action_id,
+            },
+        )
+        return self._accepted(
+            before,
+            after=[f"workflow:{result.workflow_id}:run:{result.run_id}"],
+            message="Cleanup request was queued on the workspace janitor control plane.",
+        )
+
+    async def evidence_only(
+        self,
+        action_request: Mapping[str, Any],
+        _guard_result: Mapping[str, Any],
+        target: RemediationTargetHealthSnapshot,
+    ) -> Mapping[str, Any]:
+        action_id, _params, before = self._parts(action_request, target)
+        return {
+            "status": "applied",
+            "beforeEvidenceRefs": before,
+            "afterEvidenceRefs": [f"remediation-evidence:{action_id}"],
+            "verification": {"status": "verified", "targetRunChanged": False},
+        }
+
+    @staticmethod
+    def _typed(handler: ActionHandler) -> ActionHandler:
+        async def execute(
+            action_request: Mapping[str, Any],
+            guard_result: Mapping[str, Any],
+            target: RemediationTargetHealthSnapshot,
+        ) -> Mapping[str, Any]:
+            before = [f"execution:{target.workflow_id}:run:{target.current_run_id}"]
+            try:
+                return await handler(action_request, guard_result, target)
+            except ValueError as exc:
                 return {
                     "status": "precondition_failed",
-                    "reason": "agentRunId and runtimeId are required",
+                    "reason": str(exc),
                     "beforeEvidenceRefs": before,
                     "afterEvidenceRefs": [],
                 }
-            update = {
-                "session.interrupt_turn": "InterruptTurn",
-                "session.clear": "ClearSession",
-                "session.cancel": "CancelSession",
-                "session.terminate": "CancelSession",
-                "session.restart_container": "ClearSession",
-            }[kind]
-            await self._client.update_workflow(
-                f"{agent_run_id}:session:{runtime_id}",
-                update,
-                {
-                    "requestId": str(action_request.get("actionId") or ""),
-                    **({"reason": params["reason"]} if params.get("reason") else {}),
-                },
-            )
-        elif kind in {"target.annotate", "target.verify", "cleanup.verify"}:
-            # The surrounding service publishes the durable annotation and
-            # verification artifacts. No second mutation is required here.
-            return {
-                "status": "applied",
-                "beforeEvidenceRefs": before,
-                "afterEvidenceRefs": before,
-                "verification": {"status": "verified", "targetRunChanged": False},
-            }
-        else:
-            return {
-                "status": "precondition_failed",
-                "reason": "required owning control-plane identifiers are unavailable",
-                "beforeEvidenceRefs": before,
-                "afterEvidenceRefs": [],
-            }
-        return {
-            "status": "accepted",
-            "beforeEvidenceRefs": before,
-            "afterEvidenceRefs": [],
-            "verification": {"status": "pending"},
+            except asyncio.TimeoutError:
+                return {
+                    "status": "timed_out",
+                    "reason": "owning control plane timed out",
+                    "beforeEvidenceRefs": before,
+                    "afterEvidenceRefs": [],
+                }
+            except Exception as exc:
+                return {
+                    "status": "delivery_unknown",
+                    "reason": (
+                        "owning control plane did not return authoritative "
+                        f"terminal evidence ({type(exc).__name__})"
+                    ),
+                    "beforeEvidenceRefs": before,
+                    "afterEvidenceRefs": [],
+                }
+
+        return execute
+
+    def handlers(self) -> dict[str, ActionHandler]:
+        handlers = {
+            "execution.pause": self.execution_control,
+            "execution.resume": self.execution_control,
+            "execution.cancel": self.execution_control,
+            "execution.force_terminate": self.execution_control,
+            "execution.request_rerun_same_workflow": self.rerun,
+            "execution.start_fresh_rerun": self.rerun,
+            "checkpoint_branch.create_from_remediation_context": self.checkpoint_branch,
+            "session.interrupt_turn": self.session_control,
+            "session.clear": self.session_control,
+            "session.cancel": self.session_control,
+            "session.terminate": self.session_control,
+            "session.restart_container": self.session_control,
+            "provider_profile.evict_stale_lease": self.omnigent_reconcile,
+            "host.drain": self.omnigent_reconcile,
+            "host.stop": self.omnigent_reconcile,
+            "host.restart": self.omnigent_reconcile,
+            "host.remove": self.omnigent_reconcile,
+            "host_lease.reconcile_stale": self.omnigent_reconcile,
+            "workload.restart_helper_container": self.managed_runtime_reconcile,
+            "workload.reap_orphan_container": self.managed_runtime_reconcile,
+            "cleanup.request_janitor": self.janitor,
+            "cleanup.verify": self.evidence_only,
+            "target.annotate": self.evidence_only,
+            "target.verify": self.evidence_only,
         }
+        return {kind: self._typed(handler) for kind, handler in handlers.items()}
 
 
-def build_remediation_action_executor() -> MoonMindControlPlaneRemediationActionExecutor:
-    """Build an explicit adapter entry for every policy-visible action kind."""
+def build_remediation_action_executor(
+    *, session: AsyncSession | None = None
+) -> MoonMindControlPlaneRemediationActionExecutor:
+    """Build explicit owning adapters for every policy-visible action."""
 
-    plane = TemporalRemediationControlPlane()
-    return MoonMindControlPlaneRemediationActionExecutor(
-        {action_kind: plane.execute for action_kind in remediation_action_kinds()}
+    client = TemporalClientAdapter()
+    execution_service = (
+        TemporalExecutionService(session, client_adapter=client)
+        if session is not None
+        else None
     )
+    plane = TemporalRemediationControlPlane(
+        client=client,
+        execution_service=execution_service,
+    )
+    return MoonMindControlPlaneRemediationActionExecutor(plane.handlers())
 
 
 __all__ = ["TemporalRemediationControlPlane", "build_remediation_action_executor"]

--- a/api_service/services/remediation_actions.py
+++ b/api_service/services/remediation_actions.py
@@ -285,6 +285,7 @@ class TemporalRemediationControlPlane:
                 "actionKind": kind,
                 "containerRef": container_ref,
                 "expectedState": params.get("expectedState"),
+                "targetWorkflowId": target.workflow_id,
                 "requestId": action_id,
             },
         )

--- a/api_service/services/remediation_actions.py
+++ b/api_service/services/remediation_actions.py
@@ -8,6 +8,7 @@ from typing import Any
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from api_service.services.checkpoint_branch_service import CheckpointBranchService
 from moonmind.workflows.temporal.client import TemporalClientAdapter
 from moonmind.workflows.temporal.remediation_tools import (
     MoonMindControlPlaneRemediationActionExecutor,
@@ -29,9 +30,11 @@ class TemporalRemediationControlPlane:
         *,
         client: TemporalClientAdapter | None = None,
         execution_service: TemporalExecutionService | None = None,
+        checkpoint_branch_service: CheckpointBranchService | None = None,
     ) -> None:
         self._client = client or TemporalClientAdapter()
         self._execution_service = execution_service
+        self._checkpoint_branch_service = checkpoint_branch_service
 
     @staticmethod
     def _parts(
@@ -153,23 +156,55 @@ class TemporalRemediationControlPlane:
         context_ref = self._required(params, "remediationContextRef")
         checkpoint_ref = self._required(params, "checkpointRef")
         remediation_workflow_id = self._required(params, "remediationWorkflowId")
-        await self._client.update_workflow(
-            remediation_workflow_id,
-            "CreateCheckpointBranch",
+        instruction_ref = self._required(params, "instructionRef")
+        instruction_digest = self._required(params, "instructionDigest")
+        if not instruction_digest.startswith("sha256:"):
+            raise ValueError("instructionDigest must be a sha256 digest")
+        if self._checkpoint_branch_service is None:
+            raise RuntimeError("checkpoint branch service is unavailable")
+        branch_id = f"remediation-{action_id}"
+        turn_id = f"{branch_id}-turn-1"
+        graph = await self._checkpoint_branch_service.create_branch_graph(
             {
-                "requestId": action_id,
-                "targetWorkflowId": target.workflow_id,
-                "targetRunId": target.current_run_id,
-                "remediationContextRef": context_ref,
-                "checkpointRef": checkpoint_ref,
+                "branchId": branch_id,
+                "branchTurnId": turn_id,
+                "source": {
+                    "workflowId": target.workflow_id,
+                    "rootWorkflowId": target.workflow_id,
+                    "runId": target.current_run_id,
+                    "checkpointBoundary": str(
+                        params.get("checkpointBoundary") or "after_execution"
+                    ),
+                    "checkpointRef": checkpoint_ref,
+                    "checkpointDigest": params.get("checkpointDigest"),
+                },
+                "label": str(
+                    params.get("label") or "Remediation checkpoint branch"
+                ),
+                "branchKind": "root",
+                "workspacePolicy": str(
+                    params.get("workspacePolicy")
+                    or "apply_previous_execution_diff_to_clean_baseline"
+                ),
                 "runtimeContextPolicy": "fresh_agent_run",
-            },
+                "createdBy": f"remediation:{remediation_workflow_id}",
+                "instructionRef": instruction_ref,
+                "instructionDigest": instruction_digest,
+                "contextBundleRef": context_ref,
+                "idempotencyKey": action_id,
+            }
         )
-        return self._accepted(
-            before,
-            after=[f"checkpoint-branch-request:{action_id}"],
-            message="Checkpoint Branch creation was delivered to its durable owner.",
-        )
+        return {
+            "status": "applied",
+            "message": "Checkpoint Branch was persisted by its durable owner.",
+            "beforeEvidenceRefs": before,
+            "afterEvidenceRefs": [
+                f"checkpoint-branch:{graph.branch.branch_id}",
+                f"checkpoint-branch-turn:{turn_id}",
+                context_ref,
+            ],
+            "verification": {"status": "verified"},
+        }
 
     async def session_control(
         self,
@@ -209,7 +244,11 @@ class TemporalRemediationControlPlane:
         kind = str(action_request["actionKind"])
         profile_id = self._required(params, "providerProfileId")
         host_lease_ref = str(params.get("hostLeaseRef") or "").strip() or None
-        if kind.startswith("host.") or kind == "host_lease.reconcile_stale":
+        if (
+            kind.startswith("host.")
+            or kind == "host_lease.reconcile_stale"
+            or kind == "provider_profile.evict_stale_lease"
+        ):
             if host_lease_ref is None:
                 raise ValueError("hostLeaseRef is required")
         result = await self._client.start_workflow(
@@ -267,6 +306,7 @@ class TemporalRemediationControlPlane:
             workflow_type="MoonMind.ManagedRuntimeWorkspaceCleanup",
             workflow_id=f"remediation-cleanup:{action_id}",
             input_args={
+                "actionKind": "cleanup.request_janitor",
                 "cleanupRef": cleanup_ref,
                 "targetWorkflowId": target.workflow_id,
                 "expectedState": params.get("expectedState"),
@@ -374,6 +414,9 @@ def build_remediation_action_executor(
     plane = TemporalRemediationControlPlane(
         client=client,
         execution_service=execution_service,
+        checkpoint_branch_service=(
+            CheckpointBranchService(session) if session is not None else None
+        ),
     )
     return MoonMindControlPlaneRemediationActionExecutor(plane.handlers())
 

--- a/api_service/services/remediation_actions.py
+++ b/api_service/services/remediation_actions.py
@@ -1,0 +1,106 @@
+"""MoonMind-owned production adapters for remediation execution controls."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from moonmind.workflows.temporal.client import TemporalClientAdapter
+from moonmind.workflows.temporal.remediation_actions import (
+    remediation_action_kinds,
+)
+from moonmind.workflows.temporal.remediation_tools import (
+    MoonMindControlPlaneRemediationActionExecutor,
+    RemediationTargetHealthSnapshot,
+)
+
+
+class TemporalRemediationControlPlane:
+    """Dispatch controls through Temporal, the owner of execution/session state."""
+
+    def __init__(self, client: TemporalClientAdapter | None = None) -> None:
+        self._client = client or TemporalClientAdapter()
+
+    async def execute(
+        self,
+        action_request: Mapping[str, Any],
+        _guard_result: Mapping[str, Any],
+        target: RemediationTargetHealthSnapshot,
+    ) -> Mapping[str, Any]:
+        kind = str(action_request.get("actionKind") or "")
+        parameters = action_request.get("params")
+        if not isinstance(parameters, Mapping):
+            parameters = action_request.get("parameters")
+        params = dict(parameters) if isinstance(parameters, Mapping) else {}
+        before = [f"execution:{target.workflow_id}:run:{target.current_run_id}"]
+
+        if kind == "execution.pause":
+            await self._client.signal_workflow(target.workflow_id, "Pause", params)
+        elif kind == "execution.resume":
+            await self._client.signal_workflow(target.workflow_id, "Resume", params)
+        elif kind == "execution.cancel":
+            await self._client.cancel_workflow(target.workflow_id)
+        elif kind == "execution.force_terminate":
+            await self._client.terminate_workflow(
+                target.workflow_id,
+                reason=str(params.get("reason") or "authorized remediation"),
+            )
+        elif kind.startswith("session."):
+            agent_run_id = str(params.get("agentRunId") or "").strip()
+            runtime_id = str(params.get("runtimeId") or "").strip()
+            if not agent_run_id or not runtime_id:
+                return {
+                    "status": "precondition_failed",
+                    "reason": "agentRunId and runtimeId are required",
+                    "beforeEvidenceRefs": before,
+                    "afterEvidenceRefs": [],
+                }
+            update = {
+                "session.interrupt_turn": "InterruptTurn",
+                "session.clear": "ClearSession",
+                "session.cancel": "CancelSession",
+                "session.terminate": "CancelSession",
+                "session.restart_container": "ClearSession",
+            }[kind]
+            await self._client.update_workflow(
+                f"{agent_run_id}:session:{runtime_id}",
+                update,
+                {
+                    "requestId": str(action_request.get("actionId") or ""),
+                    **({"reason": params["reason"]} if params.get("reason") else {}),
+                },
+            )
+        elif kind in {"target.annotate", "target.verify", "cleanup.verify"}:
+            # The surrounding service publishes the durable annotation and
+            # verification artifacts. No second mutation is required here.
+            return {
+                "status": "applied",
+                "beforeEvidenceRefs": before,
+                "afterEvidenceRefs": before,
+                "verification": {"status": "verified", "targetRunChanged": False},
+            }
+        else:
+            return {
+                "status": "precondition_failed",
+                "reason": "required owning control-plane identifiers are unavailable",
+                "beforeEvidenceRefs": before,
+                "afterEvidenceRefs": [],
+            }
+        return {
+            "status": "accepted",
+            "beforeEvidenceRefs": before,
+            "afterEvidenceRefs": [],
+            "verification": {"status": "pending"},
+        }
+
+
+def build_remediation_action_executor() -> MoonMindControlPlaneRemediationActionExecutor:
+    """Build an explicit adapter entry for every policy-visible action kind."""
+
+    plane = TemporalRemediationControlPlane()
+    return MoonMindControlPlaneRemediationActionExecutor(
+        {action_kind: plane.execute for action_kind in remediation_action_kinds()}
+    )
+
+
+__all__ = ["TemporalRemediationControlPlane", "build_remediation_action_executor"]

--- a/api_service/services/remediation_evidence.py
+++ b/api_service/services/remediation_evidence.py
@@ -1,0 +1,98 @@
+"""Production adapters for bounded remediation observability reads."""
+
+from __future__ import annotations
+
+import asyncio
+
+from api_service.api.routers import agent_runs
+from moonmind.workflows.temporal.remediation_tools import (
+    RemediationLiveFollowEvent,
+    RemediationLiveFollowResult,
+    RemediationLogReadResult,
+    RemediationLogStream,
+)
+from moonmind.workflows.temporal.runtime.store import ManagedRunStore
+
+
+class ManagedRunRemediationLogAdapter:
+    """Read the canonical managed-run journal/spool/artifact fallback."""
+
+    async def _events(
+        self, *, agent_run_id: str, since: int | None, limit: int, streams: set[str]
+    ) -> list[dict[str, object]]:
+        store = ManagedRunStore(agent_runs._get_agent_runtime_store_root())
+        record = await agent_runs._load_managed_run_record(store, agent_run_id)
+        if record is None:
+            return []
+        session_record = await asyncio.to_thread(
+            agent_runs._load_agent_run_session_record, agent_run_id
+        )
+        events, _source = await asyncio.to_thread(
+            agent_runs._load_agent_run_observability_events,
+            record=record,
+            session_record=session_record,
+            limit=limit,
+            since=since,
+            streams=streams,
+        )
+        events.sort(key=agent_runs._event_sort_key)
+        return events[:limit]
+
+    async def read_logs(
+        self,
+        *,
+        agent_run_id: str,
+        stream: RemediationLogStream,
+        cursor: str | None = None,
+        tail_lines: int | None = None,
+    ) -> RemediationLogReadResult:
+        since = int(cursor) if cursor and cursor.isdigit() else None
+        limit = max(1, min(tail_lines or 200, 2000))
+        streams = (
+            {"stdout", "stderr", "system", "session"}
+            if stream in {"merged", "diagnostics"}
+            else {stream}
+        )
+        events = await self._events(
+            agent_run_id=agent_run_id, since=since, limit=limit, streams=streams
+        )
+        lines = tuple(str(event.get("text") or "") for event in events)
+        last_sequence = max(
+            (int(event.get("sequence") or 0) for event in events), default=0
+        )
+        return RemediationLogReadResult(
+            agent_run_id=agent_run_id,
+            stream=stream,
+            lines=lines,
+            next_cursor=str(last_sequence) if last_sequence else None,
+        )
+
+    async def follow_logs(
+        self, *, agent_run_id: str, from_sequence: int | None = None
+    ) -> RemediationLiveFollowResult:
+        events = await self._events(
+            agent_run_id=agent_run_id,
+            since=from_sequence,
+            limit=200,
+            streams={"stdout", "stderr", "system", "session"},
+        )
+        normalized = tuple(
+            RemediationLiveFollowEvent(
+                sequence=int(event.get("sequence") or 0),
+                stream=str(event.get("stream") or "system"),
+                text=str(event.get("text") or ""),
+                timestamp=str(event.get("timestamp") or "") or None,
+            )
+            for event in events
+        )
+        last_sequence = max(
+            (event.sequence for event in normalized), default=from_sequence or 0
+        )
+        return RemediationLiveFollowResult(
+            agent_run_id=agent_run_id,
+            events=normalized,
+            resume_cursor={"sequence": last_sequence},
+        )
+
+
+__all__ = ["ManagedRunRemediationLogAdapter"]

--- a/api_service/services/remediation_evidence.py
+++ b/api_service/services/remediation_evidence.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from pathlib import Path
 
 from api_service.api.routers import agent_runs
 from moonmind.workflows.temporal.remediation_tools import (
@@ -36,7 +37,7 @@ class ManagedRunRemediationLogAdapter:
             streams=streams,
         )
         events.sort(key=agent_runs._event_sort_key)
-        return events[:limit]
+        return events[-limit:] if since is None else events[:limit]
 
     async def read_logs(
         self,
@@ -48,9 +49,40 @@ class ManagedRunRemediationLogAdapter:
     ) -> RemediationLogReadResult:
         since = int(cursor) if cursor and cursor.isdigit() else None
         limit = max(1, min(tail_lines or 200, 2000))
+        if stream == "diagnostics":
+            store = ManagedRunStore(agent_runs._get_agent_runtime_store_root())
+            record = await agent_runs._load_managed_run_record(store, agent_run_id)
+            diagnostics_ref = str(
+                getattr(record, "diagnostics_ref", None) or ""
+            ).strip()
+            if not diagnostics_ref:
+                return RemediationLogReadResult(
+                    agent_run_id=agent_run_id,
+                    stream=stream,
+                    lines=(),
+                    next_cursor=None,
+                )
+            root = Path(agent_runs._get_agent_runtime_artifacts_root()).resolve()
+            path = (root / diagnostics_ref).resolve()
+            if root not in path.parents or not path.is_file():
+                return RemediationLogReadResult(
+                    agent_run_id=agent_run_id,
+                    stream=stream,
+                    lines=(),
+                    next_cursor=None,
+                )
+            content = await asyncio.to_thread(
+                path.read_text, encoding="utf-8", errors="replace"
+            )
+            return RemediationLogReadResult(
+                agent_run_id=agent_run_id,
+                stream=stream,
+                lines=tuple(content.splitlines()[-limit:]),
+                next_cursor=None,
+            )
         streams = (
             {"stdout", "stderr", "system", "session"}
-            if stream in {"merged", "diagnostics"}
+            if stream == "merged"
             else {stream}
         )
         events = await self._events(

--- a/frontend/src/entrypoints/workflow-start.test.tsx
+++ b/frontend/src/entrypoints/workflow-start.test.tsx
@@ -18740,6 +18740,18 @@ describe("Task Create runtime command previews", () => {
     renderWithClient(<WorkflowStartPage payload={withRuntimeCommandPreview()} />);
 
     expect(await screen.findByText("Remediation Draft")).toBeTruthy();
+    const remediationMode = screen.getByLabelText("Remediation mode");
+    const remediationAuthority = screen.getByLabelText("Authority");
+    const actionPolicy = screen.getByLabelText("Action policy");
+    fireEvent.change(remediationMode, { target: { value: "live_follow" } });
+    fireEvent.change(remediationAuthority, { target: { value: "observe_only" } });
+    fireEvent.change(actionPolicy, { target: { value: "operator_review_only" } });
+    fireEvent.click(screen.getByLabelText("Diagnostics"));
+
+    expect((remediationMode as HTMLSelectElement).value).toBe("live_follow");
+    expect((remediationAuthority as HTMLSelectElement).value).toBe("observe_only");
+    expect((actionPolicy as HTMLInputElement).value).toBe("operator_review_only");
+    expect((screen.getByLabelText("Diagnostics") as HTMLInputElement).checked).toBe(false);
     expect(
       await screen.findByText(
         "Target workflow changed after this remediation draft was created. Open Remediate again before submitting.",

--- a/frontend/src/entrypoints/workflow-start.tsx
+++ b/frontend/src/entrypoints/workflow-start.tsx
@@ -11694,15 +11694,50 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
               </label>
               <label>
                 Remediation mode
-                <input value={remediationDraft.remediation.mode} readOnly />
+                <select
+                  value={remediationDraft.remediation.mode}
+                  onChange={(event) => {
+                    const mode = event.target.value as RemediationCreateDraft["remediation"]["mode"];
+                    setRemediationDraft((current) => current ? {
+                      ...current,
+                      remediation: { ...current.remediation, mode },
+                    } : current);
+                  }}
+                >
+                  <option value="snapshot">Snapshot</option>
+                  <option value="live_follow">Live follow</option>
+                  <option value="snapshot_then_follow">Snapshot then follow</option>
+                </select>
               </label>
               <label>
                 Authority
-                <input value={remediationDraft.remediation.authorityMode} readOnly />
+                <select
+                  value={remediationDraft.remediation.authorityMode}
+                  onChange={(event) => {
+                    const authorityMode = event.target.value as RemediationCreateDraft["remediation"]["authorityMode"];
+                    setRemediationDraft((current) => current ? {
+                      ...current,
+                      remediation: { ...current.remediation, authorityMode },
+                    } : current);
+                  }}
+                >
+                  <option value="observe_only">Observe only</option>
+                  <option value="approval_gated">Approval gated</option>
+                  <option value="admin_auto">Administrator automatic</option>
+                </select>
               </label>
               <label>
                 Action policy
-                <input value={remediationDraft.remediation.actionPolicyRef || ""} readOnly />
+                <input
+                  value={remediationDraft.remediation.actionPolicyRef || ""}
+                  onChange={(event) => {
+                    const actionPolicyRef = event.target.value;
+                    setRemediationDraft((current) => current ? {
+                      ...current,
+                      remediation: { ...current.remediation, actionPolicyRef },
+                    } : current);
+                  }}
+                />
               </label>
               <label>
                 Checkpoint refs
@@ -11715,6 +11750,37 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
             <p className="small">
               Evidence preview: recovery, incident, step ledger, checkpoint branch, adapter, diagnostics, and linked artifact refs.
             </p>
+            <div className="grid-2" aria-label="Remediation evidence controls">
+              {[
+                ["includeStepLedger", "Step execution ledger"],
+                ["includeDiagnostics", "Diagnostics"],
+                ["includeRecovery", "Recovery evidence"],
+                ["includeIncident", "Incident evidence"],
+                ["includeCheckpointBranches", "Checkpoint branches"],
+                ["includeAdapterRefs", "Runtime adapter evidence"],
+              ].map(([key, label]) => (
+                <label key={key} className="checkbox-label">
+                  <input
+                    type="checkbox"
+                    checked={remediationDraft.remediation.evidencePolicy?.[key] !== false}
+                    onChange={(event) => {
+                      const checked = event.target.checked;
+                      setRemediationDraft((current) => current ? {
+                        ...current,
+                        remediation: {
+                          ...current.remediation,
+                          evidencePolicy: {
+                            ...current.remediation.evidencePolicy,
+                            [key]: checked,
+                          },
+                        },
+                      } : current);
+                    }}
+                  />
+                  {label}
+                </label>
+              ))}
+            </div>
             {remediationTargetFreshnessWarning ? (
               <p className="notice small" role="alert">
                 {remediationTargetFreshnessWarning}

--- a/frontend/src/entrypoints/workflow-start.tsx
+++ b/frontend/src/entrypoints/workflow-start.tsx
@@ -11777,14 +11777,14 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
               Evidence preview: recovery, incident, step ledger, checkpoint branch, adapter, diagnostics, and linked artifact refs.
             </p>
             <div className="grid-2" aria-label="Remediation evidence controls">
-              {[
+              {([
                 ["includeStepLedger", "Step execution ledger"],
                 ["includeDiagnostics", "Diagnostics"],
                 ["includeRecovery", "Recovery evidence"],
                 ["includeIncident", "Incident evidence"],
                 ["includeCheckpointBranches", "Checkpoint branches"],
                 ["includeAdapterRefs", "Runtime adapter evidence"],
-              ].map(([key, label]) => (
+              ] as const).map(([key, label]) => (
                 <label key={key} className="checkbox-label">
                   <input
                     type="checkbox"
@@ -11863,17 +11863,21 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
                 <input
                   type="checkbox"
                   checked={remediationDraft.remediation.checkpointBranchPolicy?.runtimeContextPolicy === "fresh_agent_run"}
-                  onChange={(event) => setRemediationDraft((current) => current ? {
-                    ...current,
-                    remediation: {
-                      ...current.remediation,
-                      checkpointBranchPolicy: event.target.checked ? {
-                        ...current.remediation.checkpointBranchPolicy,
-                        actionKind: "checkpoint_branch.create_from_remediation_context",
-                        runtimeContextPolicy: "fresh_agent_run",
-                      } : undefined,
-                    },
-                  } : current)}
+                  onChange={(event) => setRemediationDraft((current) => {
+                    if (!current) return current;
+                    const { checkpointBranchPolicy: _disabledPolicy, ...remediation } = current.remediation;
+                    return {
+                      ...current,
+                      remediation: event.target.checked ? {
+                        ...remediation,
+                        checkpointBranchPolicy: {
+                          ...current.remediation.checkpointBranchPolicy,
+                          actionKind: "checkpoint_branch.create_from_remediation_context",
+                          runtimeContextPolicy: "fresh_agent_run",
+                        },
+                      } : remediation,
+                    };
+                  })}
                 />
                 Create branch for corrected inputs
               </label>

--- a/frontend/src/entrypoints/workflow-start.tsx
+++ b/frontend/src/entrypoints/workflow-start.tsx
@@ -11871,7 +11871,7 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
                         ...current.remediation.checkpointBranchPolicy,
                         actionKind: "checkpoint_branch.create_from_remediation_context",
                         runtimeContextPolicy: "fresh_agent_run",
-                      } : {},
+                      } : undefined,
                     },
                   } : current)}
                 />

--- a/frontend/src/entrypoints/workflow-start.tsx
+++ b/frontend/src/entrypoints/workflow-start.tsx
@@ -11740,11 +11740,37 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
                 />
               </label>
               <label>
-                Checkpoint refs
-                <input
-                  value={String(remediationDraft.target.stepSelectors?.length || 0)}
-                  readOnly
-                />
+                Checkpoint
+                <select
+                  value={String(
+                    remediationDraft.remediation.target.stepSelectors?.[0]?.checkpointRef || "",
+                  )}
+                  onChange={(event) => {
+                    const selected = remediationDraft.target.stepSelectors?.find(
+                      (item) => String(item.checkpointRef || "") === event.target.value,
+                    );
+                    setRemediationDraft((current) => current ? {
+                      ...current,
+                      remediation: {
+                        ...current.remediation,
+                        target: {
+                          ...current.remediation.target,
+                          stepSelectors: selected ? [selected] : [],
+                        },
+                      },
+                    } : current);
+                  }}
+                >
+                  <option value="">No checkpoint selected</option>
+                  {(remediationDraft.target.stepSelectors || []).map((selector, index) => (
+                    <option
+                      key={`${String(selector.checkpointRef || "")}:${index}`}
+                      value={String(selector.checkpointRef || "")}
+                    >
+                      {String(selector.logicalStepId || selector.source || `Checkpoint ${index + 1}`)}
+                    </option>
+                  ))}
+                </select>
               </label>
             </div>
             <p className="small">
@@ -11780,6 +11806,77 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
                   {label}
                 </label>
               ))}
+            </div>
+            <div className="grid-2" aria-label="Remediation action controls">
+              <label className="checkbox-label">
+                <input
+                  type="checkbox"
+                  checked={remediationDraft.remediation.approvalPolicy?.requiredForHighRisk !== false}
+                  onChange={(event) => setRemediationDraft((current) => current ? {
+                    ...current,
+                    remediation: {
+                      ...current.remediation,
+                      approvalPolicy: {
+                        ...current.remediation.approvalPolicy,
+                        requiredForHighRisk: event.target.checked,
+                      },
+                    },
+                  } : current)}
+                />
+                Require approval for high-risk actions
+              </label>
+              <label className="checkbox-label">
+                <input
+                  type="checkbox"
+                  checked={remediationDraft.remediation.lockPolicy?.targetMutationLock !== false}
+                  onChange={(event) => setRemediationDraft((current) => current ? {
+                    ...current,
+                    remediation: {
+                      ...current.remediation,
+                      lockPolicy: {
+                        ...current.remediation.lockPolicy,
+                        targetMutationLock: event.target.checked,
+                      },
+                    },
+                  } : current)}
+                />
+                Hold target mutation lock
+              </label>
+              <label className="checkbox-label">
+                <input
+                  type="checkbox"
+                  checked={remediationDraft.remediation.verificationPolicy?.verifyAppliedActions !== false}
+                  onChange={(event) => setRemediationDraft((current) => current ? {
+                    ...current,
+                    remediation: {
+                      ...current.remediation,
+                      verificationPolicy: {
+                        ...current.remediation.verificationPolicy,
+                        verifyAppliedActions: event.target.checked,
+                      },
+                    },
+                  } : current)}
+                />
+                Verify applied actions
+              </label>
+              <label className="checkbox-label">
+                <input
+                  type="checkbox"
+                  checked={remediationDraft.remediation.checkpointBranchPolicy?.runtimeContextPolicy === "fresh_agent_run"}
+                  onChange={(event) => setRemediationDraft((current) => current ? {
+                    ...current,
+                    remediation: {
+                      ...current.remediation,
+                      checkpointBranchPolicy: event.target.checked ? {
+                        ...current.remediation.checkpointBranchPolicy,
+                        actionKind: "checkpoint_branch.create_from_remediation_context",
+                        runtimeContextPolicy: "fresh_agent_run",
+                      } : {},
+                    },
+                  } : current)}
+                />
+                Create branch for corrected inputs
+              </label>
             </div>
             {remediationTargetFreshnessWarning ? (
               <p className="notice small" role="alert">

--- a/frontend/src/lib/remediationCreateDraft.test.ts
+++ b/frontend/src/lib/remediationCreateDraft.test.ts
@@ -51,6 +51,15 @@ describe('remediationCreateDraft', () => {
         mode: 'snapshot_then_follow',
         authorityMode: 'approval_gated',
         actionPolicyRef: 'admin_healer_default',
+        approvalPolicy: {
+          requiredForHighRisk: true,
+        },
+        lockPolicy: {
+          targetMutationLock: true,
+        },
+        verificationPolicy: {
+          verifyAppliedActions: true,
+        },
         checkpointBranchPolicy: {
           actionKind: 'checkpoint_branch.create_from_remediation_context',
           runtimeContextPolicy: 'fresh_agent_run',

--- a/frontend/src/lib/remediationCreateDraft.ts
+++ b/frontend/src/lib/remediationCreateDraft.ts
@@ -41,6 +41,9 @@ export type RemediationCreateDraft = {
     authorityMode: 'observe_only' | 'approval_gated' | 'admin_auto';
     actionPolicyRef?: string;
     evidencePolicy?: Record<string, unknown>;
+    approvalPolicy?: Record<string, unknown>;
+    lockPolicy?: Record<string, unknown>;
+    verificationPolicy?: Record<string, unknown>;
     checkpointBranchPolicy?: Record<string, unknown>;
     trigger: { type: 'manual' };
   };
@@ -220,6 +223,15 @@ export function buildRemediationCreateDraft(
         includeCheckpointBranches: true,
         includeAdapterRefs: true,
         tailLines: 2000,
+      },
+      approvalPolicy: {
+        requiredForHighRisk: true,
+      },
+      lockPolicy: {
+        targetMutationLock: true,
+      },
+      verificationPolicy: {
+        verifyAppliedActions: true,
       },
       checkpointBranchPolicy: {
         actionKind: 'checkpoint_branch.create_from_remediation_context',

--- a/moonmind/mcp/remediation_tool_registry.py
+++ b/moonmind/mcp/remediation_tool_registry.py
@@ -46,6 +46,23 @@ class RemediationFollowRequest(BaseModel):
     from_sequence: int | None = Field(None, alias="fromSequence")
 
 
+class RemediationArtifactRequest(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    remediation_workflow_id: str = Field(alias="remediationWorkflowId")
+    artifact_ref: str | dict[str, Any] = Field(alias="artifactRef")
+    include_content: bool = Field(False, alias="includeContent")
+    max_content_bytes: int = Field(65_536, alias="maxContentBytes")
+
+
+class RemediationActionRequest(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    remediation_workflow_id: str = Field(alias="remediationWorkflowId")
+    authority_result: dict[str, Any] = Field(alias="authorityResult")
+    guard_result: dict[str, Any] = Field(alias="guardResult")
+
+
 @dataclass(frozen=True, slots=True)
 class RemediationToolExecutionContext:
     service: RemediationEvidenceToolService
@@ -85,6 +102,18 @@ class RemediationToolRegistry:
             "Read the next bounded live target event page and return its cursor.",
             RemediationFollowRequest,
             self._handle_follow,
+        )
+        self._register(
+            "remediation.read_target_artifact",
+            "Read metadata and optionally bounded, redacted content for a context-linked artifact.",
+            RemediationArtifactRequest,
+            self._handle_artifact,
+        )
+        self._register(
+            "remediation.execute_action",
+            "Execute one pre-authorized and mutation-guarded typed remediation action.",
+            RemediationActionRequest,
+            self._handle_action,
         )
 
     def list_tools(self) -> list[ToolMetadata]:
@@ -154,6 +183,30 @@ class RemediationToolRegistry:
             principal=context.principal,
         )
         return asdict(result) if is_dataclass(result) else result
+
+    async def _handle_artifact(
+        self, request: RemediationArtifactRequest, dispatch: Any
+    ) -> Any:
+        _, context = dispatch
+        result = await context.service.read_target_artifact_bounded(
+            remediation_workflow_id=request.remediation_workflow_id,
+            artifact_ref=request.artifact_ref,
+            include_content=request.include_content,
+            max_content_bytes=request.max_content_bytes,
+            principal=context.principal,
+        )
+        return asdict(result)
+
+    async def _handle_action(
+        self, request: RemediationActionRequest, dispatch: Any
+    ) -> Any:
+        _, context = dispatch
+        return await context.service.execute_action(
+            remediation_workflow_id=request.remediation_workflow_id,
+            authority_result=request.authority_result,
+            guard_result=request.guard_result,
+            principal=context.principal,
+        )
 
 
 __all__ = ["RemediationToolExecutionContext", "RemediationToolRegistry"]

--- a/moonmind/mcp/remediation_tool_registry.py
+++ b/moonmind/mcp/remediation_tool_registry.py
@@ -59,8 +59,10 @@ class RemediationActionRequest(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
     remediation_workflow_id: str = Field(alias="remediationWorkflowId")
-    authority_result: dict[str, Any] = Field(alias="authorityResult")
-    guard_result: dict[str, Any] = Field(alias="guardResult")
+    action_kind: str = Field(alias="actionKind")
+    parameters: dict[str, Any] = Field(default_factory=dict)
+    idempotency_key: str = Field(alias="idempotencyKey")
+    dry_run: bool = Field(False, alias="dryRun")
 
 
 @dataclass(frozen=True, slots=True)
@@ -203,8 +205,10 @@ class RemediationToolRegistry:
         _, context = dispatch
         return await context.service.execute_action(
             remediation_workflow_id=request.remediation_workflow_id,
-            authority_result=request.authority_result,
-            guard_result=request.guard_result,
+            action_kind=request.action_kind,
+            parameters=request.parameters,
+            idempotency_key=request.idempotency_key,
+            dry_run=request.dry_run,
             principal=context.principal,
         )
 

--- a/moonmind/mcp/remediation_tool_registry.py
+++ b/moonmind/mcp/remediation_tool_registry.py
@@ -1,0 +1,159 @@
+"""Authenticated MCP registry for bounded remediation evidence operations."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, is_dataclass
+from typing import Any, Mapping
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+from moonmind.mcp.tool_registry import (
+    ToolArgumentsValidationError,
+    ToolMetadata,
+    ToolNotFoundError,
+    _ToolDefinition,
+)
+from moonmind.workflows.temporal.remediation_tools import (
+    RemediationEvidenceToolService,
+)
+
+
+class RemediationEvidencePageRequest(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    remediation_workflow_id: str = Field(alias="remediationWorkflowId")
+    cursor: int = 0
+    limit: int = 20
+    include_content: bool = Field(False, alias="includeContent")
+    max_content_bytes: int = Field(65_536, alias="maxContentBytes")
+
+
+class RemediationLogRequest(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    remediation_workflow_id: str = Field(alias="remediationWorkflowId")
+    agent_run_id: str = Field(alias="agentRunId")
+    stream: str = "merged"
+    cursor: str | None = None
+    tail_lines: int | None = Field(None, alias="tailLines")
+
+
+class RemediationFollowRequest(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    remediation_workflow_id: str = Field(alias="remediationWorkflowId")
+    agent_run_id: str | None = Field(None, alias="agentRunId")
+    from_sequence: int | None = Field(None, alias="fromSequence")
+
+
+@dataclass(frozen=True, slots=True)
+class RemediationToolExecutionContext:
+    service: RemediationEvidenceToolService
+    principal: str
+
+
+class RemediationToolRegistry:
+    """Expose only bounded, link-authorized remediation reads."""
+
+    _PAGE_TO_METHOD = {
+        "remediation.read_execution_steps": "read_execution_and_step_details",
+        "remediation.read_checkpoint_recovery": "read_checkpoint_and_recovery_manifests",
+        "remediation.read_bridge_events": "read_bridge_event_pages",
+        "remediation.read_capture_resources": "read_capture_and_resource_manifests",
+        "remediation.read_cleanup_janitor": "read_cleanup_and_janitor_evidence",
+        "remediation.read_branch_publication": "read_branch_and_publication_evidence",
+        "remediation.read_policy_approvals": "read_policy_and_approval_snapshots",
+    }
+
+    def __init__(self) -> None:
+        self._tools: dict[str, _ToolDefinition] = {}
+        for name in self._PAGE_TO_METHOD:
+            self._register(
+                name,
+                "Read one bounded, redacted page of linked remediation evidence.",
+                RemediationEvidencePageRequest,
+                self._handle_page,
+            )
+        self._register(
+            "remediation.read_target_logs",
+            "Read bounded, redacted target logs authorized by remediation context.",
+            RemediationLogRequest,
+            self._handle_logs,
+        )
+        self._register(
+            "remediation.follow_target_logs",
+            "Read the next bounded live target event page and return its cursor.",
+            RemediationFollowRequest,
+            self._handle_follow,
+        )
+
+    def list_tools(self) -> list[ToolMetadata]:
+        return [
+            ToolMetadata(
+                name=item.name,
+                description=item.description,
+                input_schema=item.argument_model.model_json_schema(by_alias=True),
+            )
+            for item in sorted(self._tools.values(), key=lambda value: value.name)
+        ]
+
+    async def call_tool(
+        self,
+        *,
+        tool: str,
+        arguments: Mapping[str, Any] | None,
+        context: RemediationToolExecutionContext,
+    ) -> Any:
+        definition = self._tools.get(tool)
+        if definition is None:
+            raise ToolNotFoundError(tool)
+        try:
+            parsed = definition.argument_model.model_validate(dict(arguments or {}))
+        except ValidationError as exc:
+            raise ToolArgumentsValidationError(tool, detail=str(exc)) from exc
+        return await definition.handler(parsed, (tool, context))
+
+    def _register(self, name: str, description: str, model: type[BaseModel], handler: Any) -> None:
+        self._tools[name] = _ToolDefinition(name, description, model, handler)
+
+    async def _handle_page(
+        self, request: RemediationEvidencePageRequest, dispatch: Any
+    ) -> Any:
+        tool, context = dispatch
+        method = getattr(context.service, self._PAGE_TO_METHOD[tool])
+        result = await method(
+            remediation_workflow_id=request.remediation_workflow_id,
+            cursor=request.cursor,
+            limit=request.limit,
+            include_content=request.include_content,
+            max_content_bytes=request.max_content_bytes,
+            principal=context.principal,
+        )
+        return asdict(result)
+
+    async def _handle_logs(self, request: RemediationLogRequest, dispatch: Any) -> Any:
+        _, context = dispatch
+        result = await context.service.read_target_logs(
+            remediation_workflow_id=request.remediation_workflow_id,
+            agent_run_id=request.agent_run_id,
+            stream=request.stream,
+            cursor=request.cursor,
+            tail_lines=request.tail_lines,
+            principal=context.principal,
+        )
+        return asdict(result)
+
+    async def _handle_follow(
+        self, request: RemediationFollowRequest, dispatch: Any
+    ) -> Any:
+        _, context = dispatch
+        result = await context.service.follow_target_logs(
+            remediation_workflow_id=request.remediation_workflow_id,
+            agent_run_id=request.agent_run_id,
+            from_sequence=request.from_sequence,
+            principal=context.principal,
+        )
+        return asdict(result) if is_dataclass(result) else result
+
+
+__all__ = ["RemediationToolExecutionContext", "RemediationToolRegistry"]

--- a/moonmind/omnigent/oauth_host_janitor.py
+++ b/moonmind/omnigent/oauth_host_janitor.py
@@ -73,14 +73,16 @@ class OmnigentOAuthHostJanitor:
                 lease.lease_id, expected_status=before_state, new_status="draining"
             )
         elif action_kind == "host.restart":
-            if before_state not in {"stopped", "failed"}:
-                raise ValueError("host.restart requires a terminal host lease")
-            lease = await self._repository.restart_host_lease(lease.lease_id)
+            raise ValueError(
+                "host.restart is unsupported until the owning launch path can "
+                "return terminal generation evidence"
+            )
         elif action_kind == "host.stop":
             if before_state not in {"stopped", "failed"}:
                 await self._runtime.stop_host(binding=binding, host_lease=lease)
                 lease = await self._repository.mark_host_lease_stopped(lease.lease_id)
         elif action_kind == "host.remove":
+            removed = bool(lease.container_name)
             if lease.container_name:
                 await self._runtime.remove_container(lease.container_name)
             if before_state != "stopped":
@@ -106,9 +108,15 @@ class OmnigentOAuthHostJanitor:
                 await self._runtime.stop_host(binding=binding, host_lease=lease)
                 lease = await self._repository.mark_host_lease_stopped(lease.lease_id)
 
-        return self._action_result(
+        result = self._action_result(
             action_kind, request_id, profile_id, lease, before_state
         )
+        if action_kind == "host.remove" and removed:
+            result["status"] = "applied"
+            result["afterEvidenceRefs"].append(
+                f"omnigent-host-container:{host_lease_ref}:removed"
+            )
+        return result
 
     @staticmethod
     def _action_result(

--- a/moonmind/omnigent/oauth_host_janitor.py
+++ b/moonmind/omnigent/oauth_host_janitor.py
@@ -58,18 +58,66 @@ class OmnigentOAuthHostJanitor:
         if expected_host_state and expected_host_state != before_state:
             raise ValueError("expectedHostState does not match the current host lease")
         binding = await self._repository.validate_binding(lease.binding_ref)
+        now = datetime.now(UTC)
+        stale = (
+            lease.expires_at <= now
+            or lease.last_heartbeat_at <= now - self._heartbeat_timeout
+        )
 
         if action_kind == "host.drain":
+            if before_state in {"draining", "stopped", "failed"}:
+                return self._action_result(
+                    action_kind, request_id, profile_id, lease, before_state
+                )
             lease = await self._repository.transition_host_lease(
                 lease.lease_id, expected_status=before_state, new_status="draining"
             )
         elif action_kind == "host.restart":
+            if before_state not in {"stopped", "failed"}:
+                raise ValueError("host.restart requires a terminal host lease")
             lease = await self._repository.restart_host_lease(lease.lease_id)
-        else:
+        elif action_kind == "host.stop":
             if before_state not in {"stopped", "failed"}:
                 await self._runtime.stop_host(binding=binding, host_lease=lease)
                 lease = await self._repository.mark_host_lease_stopped(lease.lease_id)
+        elif action_kind == "host.remove":
+            if lease.container_name:
+                await self._runtime.remove_container(lease.container_name)
+            if before_state != "stopped":
+                lease = await self._repository.mark_host_lease_stopped(lease.lease_id)
+        elif action_kind == "provider_profile.evict_stale_lease":
+            if not stale:
+                raise ValueError("Provider Profile host lease is not stale")
+            if before_state not in {"stopped", "failed"}:
+                await self._runtime.stop_host(binding=binding, host_lease=lease)
+                lease = await self._repository.mark_host_lease_stopped(lease.lease_id)
+        elif action_kind == "host_lease.reconcile_stale":
+            if not stale:
+                return self._action_result(
+                    action_kind, request_id, profile_id, lease, before_state
+                )
+            missing = bool(
+                lease.container_name
+                and not await self._runtime.container_exists(lease.container_name)
+            )
+            if missing:
+                lease = await self._repository.mark_host_lease_stopped(lease.lease_id)
+            elif before_state not in {"stopped", "failed"}:
+                await self._runtime.stop_host(binding=binding, host_lease=lease)
+                lease = await self._repository.mark_host_lease_stopped(lease.lease_id)
 
+        return self._action_result(
+            action_kind, request_id, profile_id, lease, before_state
+        )
+
+    @staticmethod
+    def _action_result(
+        action_kind: str,
+        request_id: str,
+        profile_id: str,
+        lease: Any,
+        before_state: str,
+    ) -> dict[str, Any]:
         return {
             "status": "applied" if lease.status != before_state else "no_op",
             "actionKind": action_kind,

--- a/moonmind/omnigent/oauth_host_janitor.py
+++ b/moonmind/omnigent/oauth_host_janitor.py
@@ -28,6 +28,64 @@ class OmnigentOAuthHostJanitor:
             seconds=max(30, heartbeat_timeout_seconds)
         )
 
+    async def run_action(
+        self,
+        *,
+        action_kind: str,
+        profile_id: str,
+        host_lease_ref: str,
+        expected_host_state: str | None,
+        request_id: str,
+    ) -> dict[str, Any]:
+        """Apply one lease-scoped remediation operation with before/after evidence."""
+
+        supported = {
+            "provider_profile.evict_stale_lease",
+            "host.drain",
+            "host.stop",
+            "host.restart",
+            "host.remove",
+            "host_lease.reconcile_stale",
+        }
+        if action_kind not in supported:
+            raise ValueError(f"unsupported Omnigent remediation action: {action_kind}")
+        lease = await self._repository.get_host_lease(host_lease_ref)
+        if lease is None:
+            raise ValueError("host lease does not exist")
+        if lease.provider_profile_id != profile_id:
+            raise ValueError("host lease is not owned by the Provider Profile")
+        before_state = lease.status
+        if expected_host_state and expected_host_state != before_state:
+            raise ValueError("expectedHostState does not match the current host lease")
+        binding = await self._repository.validate_binding(lease.binding_ref)
+
+        if action_kind == "host.drain":
+            lease = await self._repository.transition_host_lease(
+                lease.lease_id, expected_status=before_state, new_status="draining"
+            )
+        elif action_kind == "host.restart":
+            lease = await self._repository.restart_host_lease(lease.lease_id)
+        else:
+            if before_state not in {"stopped", "failed"}:
+                await self._runtime.stop_host(binding=binding, host_lease=lease)
+                lease = await self._repository.mark_host_lease_stopped(lease.lease_id)
+
+        return {
+            "status": "applied" if lease.status != before_state else "no_op",
+            "actionKind": action_kind,
+            "requestId": request_id,
+            "hostLeaseRef": lease.lease_id,
+            "providerProfileId": profile_id,
+            "before": {"status": before_state, "bindingRef": lease.binding_ref},
+            "after": {"status": lease.status, "bindingRef": lease.binding_ref},
+            "beforeEvidenceRefs": [
+                f"omnigent-host-lease:{lease.lease_id}:state:{before_state}"
+            ],
+            "afterEvidenceRefs": [
+                f"omnigent-host-lease:{lease.lease_id}:state:{lease.status}"
+            ],
+        }
+
     async def run(
         self, *, profile_id: str | None = None, force: bool = False
     ) -> dict[str, Any]:

--- a/moonmind/omnigent/oauth_hosts.py
+++ b/moonmind/omnigent/oauth_hosts.py
@@ -369,6 +369,13 @@ class OmnigentOAuthHostRepository:
             expiresAt=record.expires_at,
         )
 
+    async def get_host_lease(self, lease_id: str) -> OmnigentHostLease | None:
+        """Load one authoritative lease by its stable ownership identity."""
+
+        async with self._session_factory() as session:
+            record = await session.get(OmnigentOAuthHostLeaseRecord, lease_id)
+            return None if record is None else self._lease_model(record)
+
     async def transition_host_lease(
         self,
         lease_id: str,

--- a/moonmind/workflows/temporal/activities/omnigent_activities.py
+++ b/moonmind/workflows/temporal/activities/omnigent_activities.py
@@ -154,12 +154,25 @@ async def omnigent_oauth_host_janitor_activity(
             client=http_client,
             upstream_header_allowlist=resolved_proxy_forward_headers(),
         )
-        return await OmnigentOAuthHostJanitor(
+        janitor = OmnigentOAuthHostJanitor(
             repository=OmnigentOAuthHostRepository(async_session_maker),
             runtime=OmnigentOAuthHostRuntime(client=client),
             client=client,
             run_store=OmnigentBridgeSessionStore(async_session_maker),
-        ).run(
+        )
+        payload = dict(request or {})
+        action_kind = str(payload.get("actionKind") or "").strip()
+        if action_kind:
+            return await janitor.run_action(
+                action_kind=action_kind,
+                profile_id=str(payload.get("profile_id") or "").strip(),
+                host_lease_ref=str(payload.get("hostLeaseRef") or "").strip(),
+                expected_host_state=(
+                    str(payload.get("expectedHostState") or "").strip() or None
+                ),
+                request_id=str(payload.get("requestId") or "").strip(),
+            )
+        return await janitor.run(
             profile_id=str((request or {}).get("profile_id") or "").strip() or None,
             force=bool((request or {}).get("force", False)),
         )

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -11988,11 +11988,7 @@ class TemporalAgentRuntimeActivities:
                 getattr(reap_result, "reaped_session_ids", ()) or ()
             )[:session_id_limit]
 
-        return {
-            "actionKind": action_kind or None,
-            "requestId": action_payload.get("requestId"),
-            "containerRef": action_payload.get("containerRef"),
-            "expectedState": action_payload.get("expectedState"),
+        summary = {
             "managedSessionRecordsReconciled": reconciled_count,
             "degradedSessionRecords": degraded_count,
             "sessionIds": session_ids,
@@ -12006,6 +12002,16 @@ class TemporalAgentRuntimeActivities:
             "orphanVolumeReapSkippedActive": orphan_volume_reap_skipped_active,
             "orphanVolumeReapSkippedRecent": orphan_volume_reap_skipped_recent,
         }
+        if action_kind:
+            summary.update(
+                {
+                    "actionKind": action_kind,
+                    "requestId": action_payload.get("requestId"),
+                    "containerRef": action_payload.get("containerRef"),
+                    "expectedState": action_payload.get("expectedState"),
+                }
+            )
+        return summary
 
     async def agent_runtime_cleanup_managed_runtime_files(
         self,

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -1174,6 +1174,9 @@ class ManagedSessionController(Protocol):
     async def reap_orphan_session_containers(self) -> Any:
         pass
 
+    async def run_container_remediation_action(self, **kwargs: Any) -> Mapping[str, Any]:
+        pass
+
     async def collect_managed_runtime_cleanup_docker_references(self) -> Any:
         pass
 
@@ -11900,6 +11903,22 @@ class TemporalAgentRuntimeActivities:
                 raise TemporalActivityRuntimeError(
                     "containerRef is required for managed-runtime remediation"
                 )
+            return await _await_with_activity_heartbeats(
+                controller.run_container_remediation_action(
+                    action_kind=action_kind,
+                    container_ref=str(action_payload["containerRef"]),
+                    expected_state=(
+                        str(action_payload.get("expectedState") or "").strip() or None
+                    ),
+                    request_id=(
+                        str(action_payload.get("requestId") or "").strip()
+                    ),
+                ),
+                heartbeat_payload={
+                    "activityType": "agent_runtime.reconcile_managed_sessions",
+                    "actionKind": action_kind,
+                },
+            )
         records = await _await_with_activity_heartbeats(
             controller.reconcile(),
             heartbeat_payload={

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -11913,6 +11913,9 @@ class TemporalAgentRuntimeActivities:
                     request_id=(
                         str(action_payload.get("requestId") or "").strip()
                     ),
+                    target_workflow_id=str(
+                        action_payload.get("targetWorkflowId") or ""
+                    ).strip(),
                 ),
                 heartbeat_payload={
                     "activityType": "agent_runtime.reconcile_managed_sessions",

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -12002,15 +12002,6 @@ class TemporalAgentRuntimeActivities:
             "orphanVolumeReapSkippedActive": orphan_volume_reap_skipped_active,
             "orphanVolumeReapSkippedRecent": orphan_volume_reap_skipped_recent,
         }
-        if action_kind:
-            summary.update(
-                {
-                    "actionKind": action_kind,
-                    "requestId": action_payload.get("requestId"),
-                    "containerRef": action_payload.get("containerRef"),
-                    "expectedState": action_payload.get("expectedState"),
-                }
-            )
         return summary
 
     async def agent_runtime_cleanup_managed_runtime_files(

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -11886,7 +11886,20 @@ class TemporalAgentRuntimeActivities:
         controller = self._require_session_controller(
             activity_type="agent_runtime.reconcile_managed_sessions"
         )
-        del payload
+        action_payload = dict(payload or {})
+        action_kind = str(action_payload.get("actionKind") or "").strip()
+        if action_kind:
+            if action_kind not in {
+                "workload.restart_helper_container",
+                "workload.reap_orphan_container",
+            }:
+                raise TemporalActivityRuntimeError(
+                    f"unsupported managed-runtime remediation action: {action_kind}"
+                )
+            if not str(action_payload.get("containerRef") or "").strip():
+                raise TemporalActivityRuntimeError(
+                    "containerRef is required for managed-runtime remediation"
+                )
         records = await _await_with_activity_heartbeats(
             controller.reconcile(),
             heartbeat_payload={
@@ -11954,6 +11967,10 @@ class TemporalAgentRuntimeActivities:
             )[:session_id_limit]
 
         return {
+            "actionKind": action_kind or None,
+            "requestId": action_payload.get("requestId"),
+            "containerRef": action_payload.get("containerRef"),
+            "expectedState": action_payload.get("expectedState"),
             "managedSessionRecordsReconciled": reconciled_count,
             "degradedSessionRecords": degraded_count,
             "sessionIds": session_ids,
@@ -11987,6 +12004,16 @@ class TemporalAgentRuntimeActivities:
                 "run_store is required for agent_runtime.cleanup_managed_runtime_files"
             )
         config = ManagedRuntimeCleanupConfig.from_env()
+        action_payload = dict(payload or {})
+        action_kind = str(action_payload.get("actionKind") or "").strip()
+        if action_kind and action_kind != "cleanup.request_janitor":
+            raise TemporalActivityRuntimeError(
+                f"unsupported managed-runtime cleanup action: {action_kind}"
+            )
+        if action_kind and not str(action_payload.get("cleanupRef") or "").strip():
+            raise TemporalActivityRuntimeError(
+                "cleanupRef is required for remediation cleanup"
+            )
         if isinstance(payload, Mapping) and isinstance(payload.get("config"), Mapping):
             config_payload = payload["config"]
             config = ManagedRuntimeCleanupConfig(
@@ -12061,6 +12088,16 @@ class TemporalAgentRuntimeActivities:
             progress_callback=_throttled_cleanup_heartbeat(),
         )
         result_payload = result.to_dict()
+        if action_kind:
+            result_payload.update(
+                {
+                    "actionKind": action_kind,
+                    "requestId": action_payload.get("requestId"),
+                    "cleanupRef": action_payload.get("cleanupRef"),
+                    "targetWorkflowId": action_payload.get("targetWorkflowId"),
+                    "expectedState": action_payload.get("expectedState"),
+                }
+            )
         logger.info(
             "Managed runtime cleanup pass completed: enabled=%s dry_run=%s "
             "scanned_run_records=%s scanned_session_records=%s "

--- a/moonmind/workflows/temporal/remediation_actions.py
+++ b/moonmind/workflows/temporal/remediation_actions.py
@@ -332,6 +332,16 @@ _DEFAULT_AUTO_ALLOWED_RISK = "medium"
 _SUPPORTED_AUTHORITY_MODES = frozenset(
     {"observe_only", "approval_gated", "admin_auto"}
 )
+
+
+def remediation_action_kinds() -> tuple[str, ...]:
+    """Return the canonical enabled action identities for adapter construction."""
+
+    return tuple(
+        action_kind
+        for action_kind, metadata in _ACTION_CATALOG.items()
+        if metadata.get("enabled") is True
+    )
 _ABSOLUTE_PATH_PATTERN = re.compile(
     r"/(?:[A-Za-z0-9._:@+-]+/)*[A-Za-z0-9._:@+-]+"
 )

--- a/moonmind/workflows/temporal/remediation_actions.py
+++ b/moonmind/workflows/temporal/remediation_actions.py
@@ -65,11 +65,6 @@ _COMMON_REASON_INPUT = {
     "reason": {"type": "string", "required": False},
     "expectedRunId": {"type": "string", "required": False},
 }
-_MANAGED_SESSION_INPUT = {
-    **_COMMON_REASON_INPUT,
-    "agentRunId": {"type": "string", "required": True},
-    "runtimeId": {"type": "string", "required": True},
-}
 _COMMON_AUDIT_PAYLOAD_SHAPE = {
     "actor": "string",
     "executionPrincipal": "string",
@@ -182,7 +177,7 @@ _ACTION_CATALOG: dict[str, dict[str, Any]] = {
         "risk": "medium",
         "enabled": True,
         "target_type": "managed_session",
-        "input_metadata": _MANAGED_SESSION_INPUT,
+        "input_metadata": _COMMON_REASON_INPUT,
         "preconditions": ("target_visible", "active_managed_turn"),
         "idempotency": "same target/action/reason key returns the prior decision",
         "verification_hint": (
@@ -193,7 +188,7 @@ _ACTION_CATALOG: dict[str, dict[str, Any]] = {
         "risk": "medium",
         "enabled": True,
         "target_type": "managed_session",
-        "input_metadata": _MANAGED_SESSION_INPUT,
+        "input_metadata": _COMMON_REASON_INPUT,
         "preconditions": ("target_visible", "session_clear_supported"),
         "idempotency": "same target/action/reason key returns the prior decision",
         "verification_hint": "verify session clear boundary and continuity artifact are produced",
@@ -202,7 +197,7 @@ _ACTION_CATALOG: dict[str, dict[str, Any]] = {
         "risk": "medium",
         "enabled": True,
         "target_type": "managed_session",
-        "input_metadata": _MANAGED_SESSION_INPUT,
+        "input_metadata": _COMMON_REASON_INPUT,
         "preconditions": ("target_visible", "session_cancelable"),
         "idempotency": "same target/action/reason key returns the prior decision",
         "verification_hint": "verify session cancellation state and target run status",
@@ -211,7 +206,7 @@ _ACTION_CATALOG: dict[str, dict[str, Any]] = {
         "risk": "high",
         "enabled": True,
         "target_type": "managed_session",
-        "input_metadata": _MANAGED_SESSION_INPUT,
+        "input_metadata": _COMMON_REASON_INPUT,
         "preconditions": ("target_visible", "session_termination_approved"),
         "idempotency": "same target/action/reason key returns the prior decision",
         "verification_hint": "verify session termination state and target run status",
@@ -220,7 +215,7 @@ _ACTION_CATALOG: dict[str, dict[str, Any]] = {
         "risk": "high",
         "enabled": True,
         "target_type": "managed_session",
-        "input_metadata": _MANAGED_SESSION_INPUT,
+        "input_metadata": _COMMON_REASON_INPUT,
         "preconditions": ("target_visible", "restart_approved", "owning_session_plane"),
         "idempotency": "same target/action/reason key returns the prior decision",
         "verification_hint": "verify new session identity and continuity boundary artifact",

--- a/moonmind/workflows/temporal/remediation_actions.py
+++ b/moonmind/workflows/temporal/remediation_actions.py
@@ -133,6 +133,8 @@ _ACTION_CATALOG: dict[str, dict[str, Any]] = {
             "remediationWorkflowId": {"type": "string", "required": True},
             "remediationContextRef": {"type": "string", "required": True},
             "checkpointRef": {"type": "string", "required": True},
+            "instructionRef": {"type": "string", "required": True},
+            "instructionDigest": {"type": "string", "required": True},
             "runtimeContextPolicy": {
                 "type": "string",
                 "required": False,
@@ -225,6 +227,8 @@ _ACTION_CATALOG: dict[str, dict[str, Any]] = {
         "input_metadata": {
             **_COMMON_REASON_INPUT,
             "providerProfileId": {"type": "string", "required": True},
+            "hostLeaseRef": {"type": "string", "required": True},
+            "expectedHostState": {"type": "string", "required": False},
         },
         "preconditions": ("target_visible", "lease_stale_or_orphaned"),
         "idempotency": "same target/action/profile key returns the prior decision",

--- a/moonmind/workflows/temporal/remediation_actions.py
+++ b/moonmind/workflows/temporal/remediation_actions.py
@@ -65,6 +65,11 @@ _COMMON_REASON_INPUT = {
     "reason": {"type": "string", "required": False},
     "expectedRunId": {"type": "string", "required": False},
 }
+_MANAGED_SESSION_INPUT = {
+    **_COMMON_REASON_INPUT,
+    "agentRunId": {"type": "string", "required": True},
+    "runtimeId": {"type": "string", "required": True},
+}
 _COMMON_AUDIT_PAYLOAD_SHAPE = {
     "actor": "string",
     "executionPrincipal": "string",
@@ -177,7 +182,7 @@ _ACTION_CATALOG: dict[str, dict[str, Any]] = {
         "risk": "medium",
         "enabled": True,
         "target_type": "managed_session",
-        "input_metadata": _COMMON_REASON_INPUT,
+        "input_metadata": _MANAGED_SESSION_INPUT,
         "preconditions": ("target_visible", "active_managed_turn"),
         "idempotency": "same target/action/reason key returns the prior decision",
         "verification_hint": (
@@ -188,7 +193,7 @@ _ACTION_CATALOG: dict[str, dict[str, Any]] = {
         "risk": "medium",
         "enabled": True,
         "target_type": "managed_session",
-        "input_metadata": _COMMON_REASON_INPUT,
+        "input_metadata": _MANAGED_SESSION_INPUT,
         "preconditions": ("target_visible", "session_clear_supported"),
         "idempotency": "same target/action/reason key returns the prior decision",
         "verification_hint": "verify session clear boundary and continuity artifact are produced",
@@ -197,7 +202,7 @@ _ACTION_CATALOG: dict[str, dict[str, Any]] = {
         "risk": "medium",
         "enabled": True,
         "target_type": "managed_session",
-        "input_metadata": _COMMON_REASON_INPUT,
+        "input_metadata": _MANAGED_SESSION_INPUT,
         "preconditions": ("target_visible", "session_cancelable"),
         "idempotency": "same target/action/reason key returns the prior decision",
         "verification_hint": "verify session cancellation state and target run status",
@@ -206,7 +211,7 @@ _ACTION_CATALOG: dict[str, dict[str, Any]] = {
         "risk": "high",
         "enabled": True,
         "target_type": "managed_session",
-        "input_metadata": _COMMON_REASON_INPUT,
+        "input_metadata": _MANAGED_SESSION_INPUT,
         "preconditions": ("target_visible", "session_termination_approved"),
         "idempotency": "same target/action/reason key returns the prior decision",
         "verification_hint": "verify session termination state and target run status",
@@ -215,7 +220,7 @@ _ACTION_CATALOG: dict[str, dict[str, Any]] = {
         "risk": "high",
         "enabled": True,
         "target_type": "managed_session",
-        "input_metadata": _COMMON_REASON_INPUT,
+        "input_metadata": _MANAGED_SESSION_INPUT,
         "preconditions": ("target_visible", "restart_approved", "owning_session_plane"),
         "idempotency": "same target/action/reason key returns the prior decision",
         "verification_hint": "verify new session identity and continuity boundary artifact",

--- a/moonmind/workflows/temporal/remediation_actions.py
+++ b/moonmind/workflows/temporal/remediation_actions.py
@@ -855,23 +855,6 @@ class RemediationActionAuthorityService:
                 approval_ref=approval_ref,
                 parameters=parameters,
             )
-        parameter_error = _action_parameter_error(
-            action_info=action_info,
-            parameters=parameters,
-        )
-        if parameter_error is not None:
-            return self._linked_result(
-                link=link,
-                action_kind=action_kind,
-                risk=risk,
-                decision="denied",
-                reason=parameter_error,
-                idempotency_key=idempotency_key,
-                requesting_principal=requesting_principal,
-                security_profile=security_profile,
-                approval_ref=approval_ref,
-                parameters=parameters,
-            )
         if not permissions.can_view_target:
             return self._linked_result(
                 link=link,
@@ -1005,6 +988,24 @@ class RemediationActionAuthorityService:
                     approval_ref=approval_ref,
                     parameters=parameters,
                 )
+
+        parameter_error = _action_parameter_error(
+            action_info=action_info,
+            parameters=parameters,
+        )
+        if parameter_error is not None:
+            return self._linked_result(
+                link=link,
+                action_kind=action_kind,
+                risk=risk,
+                decision="denied",
+                reason=parameter_error,
+                idempotency_key=idempotency_key,
+                requesting_principal=requesting_principal,
+                security_profile=security_profile,
+                approval_ref=approval_ref,
+                parameters=parameters,
+            )
 
         return self._linked_result(
             link=link,

--- a/moonmind/workflows/temporal/remediation_actions.py
+++ b/moonmind/workflows/temporal/remediation_actions.py
@@ -74,6 +74,18 @@ _COMMON_AUDIT_PAYLOAD_SHAPE = {
     "decision": "string",
     "timestamp": "string",
 }
+REMEDIATION_BRANCH_SENSITIVE_FIELDS = frozenset(
+    {
+        "instructions",
+        "runtime",
+        "model",
+        "providerProfile",
+        "launchPolicy",
+        "repositoryBranch",
+        "workspacePolicy",
+        "publishMode",
+    }
+)
 _ACTION_CATALOG: dict[str, dict[str, Any]] = {
     "execution.pause": {
         "risk": "medium",
@@ -233,6 +245,87 @@ _ACTION_CATALOG: dict[str, dict[str, Any]] = {
         "preconditions": ("target_visible", "container_orphaned_by_policy"),
         "idempotency": "same target/action/container key returns the prior decision",
         "verification_hint": "verify orphan container is gone or no-op reason is recorded",
+    },
+    "host.drain": {
+        "risk": "medium",
+        "enabled": True,
+        "target_type": "omnigent_host",
+        "input_metadata": _COMMON_REASON_INPUT,
+        "preconditions": ("target_visible", "host_lease_owned", "expected_host_state"),
+        "idempotency": "same target/action/host-lease key returns the prior decision",
+        "verification_hint": "verify the lease-owned host rejects new sessions",
+    },
+    "host.stop": {
+        "risk": "high",
+        "enabled": True,
+        "target_type": "omnigent_host",
+        "input_metadata": _COMMON_REASON_INPUT,
+        "preconditions": ("target_visible", "host_lease_owned", "expected_host_state"),
+        "idempotency": "same target/action/host-lease key returns the prior decision",
+        "verification_hint": "verify the lease-owned host reaches stopped state",
+    },
+    "host.restart": {
+        "risk": "high",
+        "enabled": True,
+        "target_type": "omnigent_host",
+        "input_metadata": _COMMON_REASON_INPUT,
+        "preconditions": ("target_visible", "host_lease_owned", "expected_host_state"),
+        "idempotency": "same target/action/host-lease key returns the prior decision",
+        "verification_hint": "verify a new host generation becomes healthy",
+    },
+    "host.remove": {
+        "risk": "high",
+        "enabled": True,
+        "target_type": "omnigent_host",
+        "input_metadata": _COMMON_REASON_INPUT,
+        "preconditions": ("target_visible", "host_lease_owned", "host_removal_approved"),
+        "idempotency": "same target/action/host-lease key returns the prior decision",
+        "verification_hint": "verify the lease-owned host and binding are absent",
+    },
+    "host_lease.reconcile_stale": {
+        "risk": "medium",
+        "enabled": True,
+        "target_type": "host_lease",
+        "input_metadata": _COMMON_REASON_INPUT,
+        "preconditions": ("target_visible", "host_lease_stale_or_orphaned"),
+        "idempotency": "same target/action/host-lease key returns the prior decision",
+        "verification_hint": "verify host ownership and lease state are consistent",
+    },
+    "cleanup.request_janitor": {
+        "risk": "medium",
+        "enabled": True,
+        "target_type": "cleanup",
+        "input_metadata": _COMMON_REASON_INPUT,
+        "preconditions": ("target_visible", "cleanup_owned_by_moonmind"),
+        "idempotency": "same target/action/cleanup key returns the prior decision",
+        "verification_hint": "verify a cleanup manifest reaches a terminal state",
+    },
+    "cleanup.verify": {
+        "risk": "low",
+        "enabled": True,
+        "target_type": "cleanup",
+        "input_metadata": _COMMON_REASON_INPUT,
+        "preconditions": ("target_visible",),
+        "idempotency": "same target/action/cleanup key returns the prior decision",
+        "verification_hint": "verify cleanup and janitor evidence are internally consistent",
+    },
+    "target.annotate": {
+        "risk": "low",
+        "enabled": True,
+        "target_type": "execution",
+        "input_metadata": _COMMON_REASON_INPUT,
+        "preconditions": ("target_visible",),
+        "idempotency": "same target/action/annotation key returns the prior decision",
+        "verification_hint": "verify the target links the remediation annotation",
+    },
+    "target.verify": {
+        "risk": "low",
+        "enabled": True,
+        "target_type": "execution",
+        "input_metadata": _COMMON_REASON_INPUT,
+        "preconditions": ("target_visible",),
+        "idempotency": "same target/action/verification key returns the prior decision",
+        "verification_hint": "verify target terminal evidence rather than assistant prose",
     },
 }
 _DEFAULT_AUTO_ALLOWED_RISK = "medium"
@@ -2134,7 +2227,30 @@ def _result_status(decision: RemediationActionDecision, reason: str) -> str:
         return "rejected"
     return "failed"
 
+
+def remediation_changes_require_checkpoint_branch(
+    *,
+    original: Mapping[str, Any],
+    proposed: Mapping[str, Any],
+) -> tuple[str, ...]:
+    """Return immutable-input choices that require a Checkpoint Branch turn.
+
+    Callers must route any non-empty result through
+    ``checkpoint_branch.create_from_remediation_context`` instead of mutating
+    or resuming the original execution input.
+    """
+
+    return tuple(
+        sorted(
+            field_name
+            for field_name in REMEDIATION_BRANCH_SENSITIVE_FIELDS
+            if original.get(field_name) != proposed.get(field_name)
+        )
+    )
+
+
 __all__ = [
+    "REMEDIATION_BRANCH_SENSITIVE_FIELDS",
     "RemediationActionAuthorityResult",
     "RemediationActionAuthorityService",
     "RemediationActionDecision",
@@ -2150,4 +2266,5 @@ __all__ = [
     "RemediationPermissionSet",
     "RemediationSecurityProfile",
     "RemediationTargetFreshnessDecision",
+    "remediation_changes_require_checkpoint_branch",
 ]

--- a/moonmind/workflows/temporal/remediation_actions.py
+++ b/moonmind/workflows/temporal/remediation_actions.py
@@ -63,6 +63,7 @@ _RAW_ACCESS_ACTION_KINDS = frozenset(
 )
 _COMMON_REASON_INPUT = {
     "reason": {"type": "string", "required": False},
+    "expectedRunId": {"type": "string", "required": False},
 }
 _COMMON_AUDIT_PAYLOAD_SHAPE = {
     "actor": "string",
@@ -129,6 +130,7 @@ _ACTION_CATALOG: dict[str, dict[str, Any]] = {
         "target_type": "checkpoint_branch",
         "input_metadata": {
             **_COMMON_REASON_INPUT,
+            "remediationWorkflowId": {"type": "string", "required": True},
             "remediationContextRef": {"type": "string", "required": True},
             "checkpointRef": {"type": "string", "required": True},
             "runtimeContextPolicy": {
@@ -222,7 +224,7 @@ _ACTION_CATALOG: dict[str, dict[str, Any]] = {
         "target_type": "provider_profile_lease",
         "input_metadata": {
             **_COMMON_REASON_INPUT,
-            "profileRef": {"type": "string", "required": False},
+            "providerProfileId": {"type": "string", "required": True},
         },
         "preconditions": ("target_visible", "lease_stale_or_orphaned"),
         "idempotency": "same target/action/profile key returns the prior decision",
@@ -232,7 +234,11 @@ _ACTION_CATALOG: dict[str, dict[str, Any]] = {
         "risk": "medium",
         "enabled": True,
         "target_type": "workload_container",
-        "input_metadata": _COMMON_REASON_INPUT,
+        "input_metadata": {
+            **_COMMON_REASON_INPUT,
+            "containerRef": {"type": "string", "required": True},
+            "expectedState": {"type": "string", "required": False},
+        },
         "preconditions": ("target_visible", "helper_container_owned_by_moonmind"),
         "idempotency": "same target/action/container key returns the prior decision",
         "verification_hint": "verify helper container health and target state",
@@ -241,7 +247,11 @@ _ACTION_CATALOG: dict[str, dict[str, Any]] = {
         "risk": "medium",
         "enabled": True,
         "target_type": "workload_container",
-        "input_metadata": _COMMON_REASON_INPUT,
+        "input_metadata": {
+            **_COMMON_REASON_INPUT,
+            "containerRef": {"type": "string", "required": True},
+            "expectedState": {"type": "string", "required": False},
+        },
         "preconditions": ("target_visible", "container_orphaned_by_policy"),
         "idempotency": "same target/action/container key returns the prior decision",
         "verification_hint": "verify orphan container is gone or no-op reason is recorded",
@@ -250,7 +260,12 @@ _ACTION_CATALOG: dict[str, dict[str, Any]] = {
         "risk": "medium",
         "enabled": True,
         "target_type": "omnigent_host",
-        "input_metadata": _COMMON_REASON_INPUT,
+        "input_metadata": {
+            **_COMMON_REASON_INPUT,
+            "providerProfileId": {"type": "string", "required": True},
+            "hostLeaseRef": {"type": "string", "required": True},
+            "expectedHostState": {"type": "string", "required": True},
+        },
         "preconditions": ("target_visible", "host_lease_owned", "expected_host_state"),
         "idempotency": "same target/action/host-lease key returns the prior decision",
         "verification_hint": "verify the lease-owned host rejects new sessions",
@@ -259,7 +274,12 @@ _ACTION_CATALOG: dict[str, dict[str, Any]] = {
         "risk": "high",
         "enabled": True,
         "target_type": "omnigent_host",
-        "input_metadata": _COMMON_REASON_INPUT,
+        "input_metadata": {
+            **_COMMON_REASON_INPUT,
+            "providerProfileId": {"type": "string", "required": True},
+            "hostLeaseRef": {"type": "string", "required": True},
+            "expectedHostState": {"type": "string", "required": True},
+        },
         "preconditions": ("target_visible", "host_lease_owned", "expected_host_state"),
         "idempotency": "same target/action/host-lease key returns the prior decision",
         "verification_hint": "verify the lease-owned host reaches stopped state",
@@ -268,7 +288,12 @@ _ACTION_CATALOG: dict[str, dict[str, Any]] = {
         "risk": "high",
         "enabled": True,
         "target_type": "omnigent_host",
-        "input_metadata": _COMMON_REASON_INPUT,
+        "input_metadata": {
+            **_COMMON_REASON_INPUT,
+            "providerProfileId": {"type": "string", "required": True},
+            "hostLeaseRef": {"type": "string", "required": True},
+            "expectedHostState": {"type": "string", "required": True},
+        },
         "preconditions": ("target_visible", "host_lease_owned", "expected_host_state"),
         "idempotency": "same target/action/host-lease key returns the prior decision",
         "verification_hint": "verify a new host generation becomes healthy",
@@ -277,7 +302,12 @@ _ACTION_CATALOG: dict[str, dict[str, Any]] = {
         "risk": "high",
         "enabled": True,
         "target_type": "omnigent_host",
-        "input_metadata": _COMMON_REASON_INPUT,
+        "input_metadata": {
+            **_COMMON_REASON_INPUT,
+            "providerProfileId": {"type": "string", "required": True},
+            "hostLeaseRef": {"type": "string", "required": True},
+            "expectedHostState": {"type": "string", "required": True},
+        },
         "preconditions": ("target_visible", "host_lease_owned", "host_removal_approved"),
         "idempotency": "same target/action/host-lease key returns the prior decision",
         "verification_hint": "verify the lease-owned host and binding are absent",
@@ -286,7 +316,12 @@ _ACTION_CATALOG: dict[str, dict[str, Any]] = {
         "risk": "medium",
         "enabled": True,
         "target_type": "host_lease",
-        "input_metadata": _COMMON_REASON_INPUT,
+        "input_metadata": {
+            **_COMMON_REASON_INPUT,
+            "providerProfileId": {"type": "string", "required": True},
+            "hostLeaseRef": {"type": "string", "required": True},
+            "expectedHostState": {"type": "string", "required": False},
+        },
         "preconditions": ("target_visible", "host_lease_stale_or_orphaned"),
         "idempotency": "same target/action/host-lease key returns the prior decision",
         "verification_hint": "verify host ownership and lease state are consistent",
@@ -295,7 +330,11 @@ _ACTION_CATALOG: dict[str, dict[str, Any]] = {
         "risk": "medium",
         "enabled": True,
         "target_type": "cleanup",
-        "input_metadata": _COMMON_REASON_INPUT,
+        "input_metadata": {
+            **_COMMON_REASON_INPUT,
+            "cleanupRef": {"type": "string", "required": True},
+            "expectedState": {"type": "string", "required": False},
+        },
         "preconditions": ("target_visible", "cleanup_owned_by_moonmind"),
         "idempotency": "same target/action/cleanup key returns the prior decision",
         "verification_hint": "verify a cleanup manifest reaches a terminal state",

--- a/moonmind/workflows/temporal/remediation_context.py
+++ b/moonmind/workflows/temporal/remediation_context.py
@@ -105,6 +105,19 @@ TARGET_EVIDENCE_CLASSES = (
     ("provider_snapshot", "providerSnapshotRef"),
     ("continuity", "continuityRefs"),
 )
+OMNIGENT_EVIDENCE_INDEX_FIELDS: tuple[tuple[str, tuple[str, ...]], ...] = (
+    ("bridge_events", ("bridgeEventPageRefs", "normalizedEventJournalRef", "rawEventJournalRef")),
+    ("capture", ("initialSnapshotRef", "finalSnapshotRef", "captureManifestRef", "resourceManifestRef")),
+    ("workspace", ("changedFilesRef", "workspaceFilesRef", "sessionFilesRef", "diffRef", "childSessionRefs")),
+    ("host_and_session", ("hostRef", "sessionRef", "agentRef", "hostBindingRef", "endpointRef")),
+    ("provider_and_leases", ("providerProfileRef", "providerLeaseRef", "hostLeaseRef", "credentialGenerationRef")),
+    ("launch", ("executionProfileRef", "launchPolicyRef", "effectiveLaunchSnapshotRef")),
+    ("checkpoint_and_recovery", ("checkpointManifestRefs", "externalStateRefs", "workspaceAuthorityRef", "recoveryDecisionRef")),
+    ("checkpoint_branches", ("checkpointBranchRefs", "branchTurnRefs", "gitRef", "comparisonRef", "promotionRef")),
+    ("lifecycle", ("incidentManifestRef", "recoveryManifestRef", "cleanupManifestRef", "janitorManifestRef", "terminalPublicationManifestRef")),
+    ("policy", ("policySnapshotRef", "approvalSnapshotRef", "lockSnapshotRef", "capturePolicyRef", "retentionPolicyRef", "redactionPolicyRef")),
+    ("prior_remediation", ("priorAttemptRefs", "cumulativeWorkspaceHeadRef", "verificationResultRefs", "preventionOutputRefs")),
+)
 SECRET_LIKE_POLICY_KEY_PARTS = (
     "api_key",
     "apikey",
@@ -265,6 +278,7 @@ class RemediationContextBuilder:
             agent_runs=agent_runs,
             live_follow=live_follow,
         )
+        omnigent_evidence_index = self._omnigent_evidence_index(target_evidence)
         unavailable_classes = [
             item["class"]
             for item in availability
@@ -285,6 +299,7 @@ class RemediationContextBuilder:
                 "targetArtifactRefs": self._target_artifact_refs(target_record),
                 "agentRuns": agent_runs,
                 "availability": availability,
+                "omnigentIndex": omnigent_evidence_index,
                 "evidenceDegraded": bool(unavailable_classes),
                 "unavailableEvidenceClasses": unavailable_classes,
                 **self._diagnosis_hints_payload(target_evidence),
@@ -507,6 +522,48 @@ class RemediationContextBuilder:
                     record["fallback"] = fallback
             availability.append(record)
         return availability
+
+    @staticmethod
+    def _omnigent_evidence_index(
+        target_evidence: Mapping[str, Any],
+    ) -> list[dict[str, Any]]:
+        """Project the full host-backed evidence ledger without embedding bodies."""
+
+        generated_at = _safe_optional_string(
+            target_evidence.get("observedAt") or target_evidence.get("generatedAt")
+        )
+        index: list[dict[str, Any]] = []
+        for class_name, fields in OMNIGENT_EVIDENCE_INDEX_FIELDS:
+            refs: list[dict[str, str]] = []
+            seen: set[tuple[str, str | None]] = set()
+            for field_name in fields:
+                raw_value = target_evidence.get(field_name)
+                values = raw_value if isinstance(raw_value, list) else [raw_value]
+                for value in values:
+                    ref = _artifact_ref_payload(value, kind=field_name)
+                    if ref is None:
+                        continue
+                    key = (ref.get("artifact_id") or ref.get("ref") or "", ref.get("kind"))
+                    if key in seen:
+                        continue
+                    seen.add(key)
+                    refs.append(ref)
+            record: dict[str, Any] = {
+                "class": class_name,
+                "status": "available" if refs else "missing",
+                "bounded": True,
+                "contentsIncluded": False,
+                "refs": refs,
+            }
+            if generated_at:
+                record["observedAt"] = generated_at
+                record["freshness"] = "source_reported"
+            else:
+                record["freshness"] = "unknown"
+            if not refs:
+                record["degradedReason"] = "historical evidence was not recorded"
+            index.append(record)
+        return index
 
     @staticmethod
     def _live_follow_payload(

--- a/moonmind/workflows/temporal/remediation_context.py
+++ b/moonmind/workflows/temporal/remediation_context.py
@@ -357,7 +357,11 @@ class RemediationContextBuilder:
     def _target_evidence_payload(
         record: db_models.TemporalExecutionCanonicalRecord,
     ) -> Mapping[str, Any]:
-        for source in (record.memo, record.parameters, record.integration_state):
+        for source in (
+            record.memo,
+            record.parameters,
+            getattr(record, "integration_state", None),
+        ):
             if not isinstance(source, Mapping):
                 continue
             evidence = source.get("remediationEvidence") or source.get(

--- a/moonmind/workflows/temporal/remediation_context.py
+++ b/moonmind/workflows/temporal/remediation_context.py
@@ -682,9 +682,9 @@ class RemediationContextBuilder:
                     refs.append(ref)
 
         for kind, raw_ref in (
-            ("input", record.input_ref),
-            ("plan", record.plan_ref),
-            ("manifest", record.manifest_ref),
+            ("input", getattr(record, "input_ref", None)),
+            ("plan", getattr(record, "plan_ref", None)),
+            ("manifest", getattr(record, "manifest_ref", None)),
         ):
             ref = _artifact_ref_payload(raw_ref, kind=kind)
             if ref is not None:

--- a/moonmind/workflows/temporal/remediation_context.py
+++ b/moonmind/workflows/temporal/remediation_context.py
@@ -280,12 +280,20 @@ class RemediationContextBuilder:
             live_follow=live_follow,
         )
         omnigent_evidence_index = self._omnigent_evidence_index(target_evidence)
-        unavailable_classes = [
-            item["class"]
-            for item in availability
-            if item.get("status")
-            in {"missing", "partial", "denied", "unavailable", "unsupported"}
-        ]
+        degraded_statuses = {
+            "missing",
+            "partial",
+            "denied",
+            "unavailable",
+            "unsupported",
+        }
+        unavailable_classes = list(
+            dict.fromkeys(
+                item["class"]
+                for item in (*availability, *omnigent_evidence_index)
+                if item.get("status") in degraded_statuses
+            )
+        )
 
         return {
             "schemaVersion": REMEDIATION_CONTEXT_SCHEMA_VERSION,

--- a/moonmind/workflows/temporal/remediation_context.py
+++ b/moonmind/workflows/temporal/remediation_context.py
@@ -106,6 +106,7 @@ TARGET_EVIDENCE_CLASSES = (
     ("continuity", "continuityRefs"),
 )
 OMNIGENT_EVIDENCE_INDEX_FIELDS: tuple[tuple[str, tuple[str, ...]], ...] = (
+    ("execution_and_steps", ("executionDetailRef", "stepExecutionDetailRefs", "failureTaxonomyRef")),
     ("bridge_events", ("bridgeEventPageRefs", "normalizedEventJournalRef", "rawEventJournalRef")),
     ("capture", ("initialSnapshotRef", "finalSnapshotRef", "captureManifestRef", "resourceManifestRef")),
     ("workspace", ("changedFilesRef", "workspaceFilesRef", "sessionFilesRef", "diffRef", "childSessionRefs")),

--- a/moonmind/workflows/temporal/remediation_tools.py
+++ b/moonmind/workflows/temporal/remediation_tools.py
@@ -28,6 +28,11 @@ from moonmind.workflows.temporal.remediation_context import (
 )
 from moonmind.workflows.temporal.remediation_actions import (
     REMEDIATION_BRANCH_SENSITIVE_FIELDS,
+    RemediationActionAuthorityService,
+    RemediationMutationGuardPolicy,
+    RemediationMutationGuardService,
+    RemediationPermissionSet,
+    RemediationSecurityProfile,
     remediation_changes_require_checkpoint_branch,
 )
 from moonmind.utils.logging import redact_sensitive_payload, redact_sensitive_text
@@ -656,16 +661,59 @@ class RemediationEvidenceToolService:
         self,
         *,
         remediation_workflow_id: str,
-        authority_result: Mapping[str, Any],
-        guard_result: Mapping[str, Any],
+        action_kind: str | None = None,
+        parameters: Mapping[str, Any] | None = None,
+        idempotency_key: str | None = None,
+        dry_run: bool = False,
+        authority_result: Mapping[str, Any] | None = None,
+        guard_result: Mapping[str, Any] | None = None,
         principal: str = "service:remediation-tools",
     ) -> dict[str, Any]:
         """Execute an authorized action and publish bounded lifecycle artifacts."""
-
-        if not isinstance(authority_result, Mapping):
-            raise RemediationEvidenceToolError("authorityResult must be an object.")
-        if not isinstance(guard_result, Mapping):
-            raise RemediationEvidenceToolError("guardResult must be an object.")
+        link = await self._load_link(remediation_workflow_id)
+        if authority_result is None or guard_result is None:
+            if link.authority_mode != "admin_auto":
+                raise RemediationEvidenceToolError(
+                    "Persisted remediation authority does not permit automatic mutation."
+                )
+            normalized_action_kind = _required_string(action_kind, "actionKind")
+            normalized_idempotency_key = _required_string(
+                idempotency_key, "idempotencyKey"
+            )
+            authority = await RemediationActionAuthorityService(
+                session=self._session
+            ).evaluate_action_request(
+            remediation_workflow_id=remediation_workflow_id,
+            action_kind=normalized_action_kind,
+            parameters=parameters,
+            dry_run=dry_run,
+            idempotency_key=normalized_idempotency_key,
+            requesting_principal=principal,
+            permissions=RemediationPermissionSet(
+                can_view_target=True,
+                can_request_admin_profile=True,
+            ),
+            security_profile=RemediationSecurityProfile(
+                profile_ref="persisted:admin_auto",
+                execution_principal=principal,
+                allowed_action_kinds=(normalized_action_kind,),
+            ),
+            )
+            authority_result = authority.to_dict()
+            guard = await RemediationMutationGuardService(
+                session=self._session
+            ).evaluate(
+            remediation_workflow_id=remediation_workflow_id,
+            remediation_run_id=link.remediation_run_id,
+            target_workflow_id=link.target_workflow_id,
+            target_run_id=link.target_run_id,
+            action_kind=normalized_action_kind,
+            idempotency_key=normalized_idempotency_key,
+            parameters=parameters,
+            policy=RemediationMutationGuardPolicy(),
+            now=datetime.now(timezone.utc),
+            )
+            guard_result = guard.to_dict()
         if authority_result.get("executable") is not True:
             raise RemediationEvidenceToolError(
                 "authorityResult must be executable before action execution."

--- a/moonmind/workflows/temporal/remediation_tools.py
+++ b/moonmind/workflows/temporal/remediation_tools.py
@@ -28,6 +28,7 @@ from moonmind.workflows.temporal.remediation_context import (
 )
 from moonmind.workflows.temporal.remediation_actions import (
     REMEDIATION_BRANCH_SENSITIVE_FIELDS,
+    remediation_changes_require_checkpoint_branch,
 )
 from moonmind.utils.logging import redact_sensitive_payload, redact_sensitive_text
 
@@ -217,15 +218,25 @@ class MoonMindControlPlaneRemediationActionExecutor:
         action_kind = _required_string(action_request.get("actionKind"), "actionKind")
         parameters = action_request.get("parameters")
         parameters_mapping = parameters if isinstance(parameters, Mapping) else {}
-        input_changes = parameters_mapping.get("inputChanges")
-        changed_fields = (
-            set(input_changes)
-            if isinstance(input_changes, Mapping)
-            else set()
-        )
-        branch_sensitive_changes = sorted(
-            changed_fields & REMEDIATION_BRANCH_SENSITIVE_FIELDS
-        )
+        original_inputs = guard_result.get("originalInputs")
+        proposed_inputs = guard_result.get("proposedInputs")
+        if isinstance(original_inputs, Mapping) and isinstance(
+            proposed_inputs, Mapping
+        ):
+            branch_sensitive_changes = list(
+                remediation_changes_require_checkpoint_branch(
+                    original=original_inputs,
+                    proposed=proposed_inputs,
+                )
+            )
+        else:
+            input_changes = parameters_mapping.get("inputChanges")
+            changed_fields = (
+                set(input_changes) if isinstance(input_changes, Mapping) else set()
+            )
+            branch_sensitive_changes = sorted(
+                changed_fields & REMEDIATION_BRANCH_SENSITIVE_FIELDS
+            )
         if (
             branch_sensitive_changes
             and action_kind != "checkpoint_branch.create_from_remediation_context"

--- a/moonmind/workflows/temporal/remediation_tools.py
+++ b/moonmind/workflows/temporal/remediation_tools.py
@@ -413,6 +413,50 @@ class RemediationEvidenceToolService:
             degraded_reason=_string_or_none(selected.get("degradedReason")),
         )
 
+    async def read_execution_and_step_details(self, **kwargs: Any) -> RemediationEvidencePage:
+        """Read bounded execution/Step Execution evidence."""
+        return await self.read_evidence_page(
+            evidence_class="execution_and_steps", **kwargs
+        )
+
+    async def read_checkpoint_and_recovery_manifests(
+        self, **kwargs: Any
+    ) -> RemediationEvidencePage:
+        """Read bounded checkpoint and recovery manifests."""
+        return await self.read_evidence_page(
+            evidence_class="checkpoint_and_recovery", **kwargs
+        )
+
+    async def read_bridge_event_pages(self, **kwargs: Any) -> RemediationEvidencePage:
+        """Read bounded bridge event pages; live cursors use follow_target_logs."""
+        return await self.read_evidence_page(evidence_class="bridge_events", **kwargs)
+
+    async def read_capture_and_resource_manifests(
+        self, **kwargs: Any
+    ) -> RemediationEvidencePage:
+        """Read bounded capture and resource manifests."""
+        return await self.read_evidence_page(evidence_class="capture", **kwargs)
+
+    async def read_cleanup_and_janitor_evidence(
+        self, **kwargs: Any
+    ) -> RemediationEvidencePage:
+        """Read bounded cleanup, janitor, incident, and publication evidence."""
+        return await self.read_evidence_page(evidence_class="lifecycle", **kwargs)
+
+    async def read_branch_and_publication_evidence(
+        self, **kwargs: Any
+    ) -> RemediationEvidencePage:
+        """Read bounded branch, comparison, promotion, and publication evidence."""
+        return await self.read_evidence_page(
+            evidence_class="checkpoint_branches", **kwargs
+        )
+
+    async def read_policy_and_approval_snapshots(
+        self, **kwargs: Any
+    ) -> RemediationEvidencePage:
+        """Read bounded policy, approval, lock, retention, and redaction snapshots."""
+        return await self.read_evidence_page(evidence_class="policy", **kwargs)
+
     async def read_target_logs(
         self,
         *,

--- a/moonmind/workflows/temporal/remediation_tools.py
+++ b/moonmind/workflows/temporal/remediation_tools.py
@@ -26,17 +26,24 @@ from moonmind.workflows.temporal.remediation_context import (
     build_remediation_final_summary,
     build_remediation_target_annotation,
 )
+from moonmind.workflows.temporal.remediation_actions import (
+    REMEDIATION_BRANCH_SENSITIVE_FIELDS,
+)
 from moonmind.utils.logging import redact_sensitive_payload, redact_sensitive_text
 
 RemediationLogStream = Literal["stdout", "stderr", "merged", "diagnostics"]
 
 _ALLOWED_ACTION_RESULT_STATUSES = frozenset(
     {
+        "accepted",
         "applied",
         "no_op",
+        "delivery_unknown",
         "rejected",
+        "denied",
         "precondition_failed",
         "approval_required",
+        "verification_required",
         "timed_out",
         "failed",
     }
@@ -100,6 +107,17 @@ class RemediationActionRequestPreparation:
     action_kind: str
     target: RemediationTargetHealthSnapshot
     context_target: dict[str, Any]
+
+
+@dataclass(frozen=True, slots=True)
+class RemediationEvidencePage:
+    """One bounded, redacted page from a typed context evidence class."""
+
+    evidence_class: str
+    status: str
+    items: tuple[dict[str, Any], ...]
+    next_cursor: int | None
+    degraded_reason: str | None = None
 
 class RemediationLogReader(Protocol):
     """Read bounded historical logs for a target agent run."""
@@ -173,6 +191,71 @@ class _UnavailableActionExecutor:
             "remediation.execute_action is not configured in this runtime."
         )
 
+
+class MoonMindControlPlaneRemediationActionExecutor:
+    """Allowlisted adapter dispatcher for MoonMind-owned control-plane actions."""
+
+    def __init__(
+        self,
+        adapters: Mapping[
+            str,
+            Callable[
+                [Mapping[str, Any], Mapping[str, Any], RemediationTargetHealthSnapshot],
+                Awaitable[Mapping[str, Any]],
+            ],
+        ],
+    ) -> None:
+        self._adapters = dict(adapters)
+
+    async def execute_action(
+        self,
+        *,
+        action_request: Mapping[str, Any],
+        guard_result: Mapping[str, Any],
+        target_health: RemediationTargetHealthSnapshot,
+    ) -> Mapping[str, Any]:
+        action_kind = _required_string(action_request.get("actionKind"), "actionKind")
+        parameters = action_request.get("parameters")
+        parameters_mapping = parameters if isinstance(parameters, Mapping) else {}
+        input_changes = parameters_mapping.get("inputChanges")
+        changed_fields = (
+            set(input_changes)
+            if isinstance(input_changes, Mapping)
+            else set()
+        )
+        branch_sensitive_changes = sorted(
+            changed_fields & REMEDIATION_BRANCH_SENSITIVE_FIELDS
+        )
+        if (
+            branch_sensitive_changes
+            and action_kind != "checkpoint_branch.create_from_remediation_context"
+        ):
+            return {
+                "status": "denied",
+                "reason": "checkpoint_branch_required_for_corrected_input",
+                "changedFields": branch_sensitive_changes,
+                "beforeEvidenceRefs": [],
+                "afterEvidenceRefs": [],
+            }
+        adapter = self._adapters.get(action_kind)
+        if adapter is None:
+            return {
+                "status": "denied",
+                "reason": "control_plane_adapter_unavailable",
+                "beforeEvidenceRefs": [],
+                "afterEvidenceRefs": [],
+            }
+        result = await adapter(action_request, guard_result, target_health)
+        if not isinstance(result, Mapping):
+            raise RemediationEvidenceToolError(
+                f"Control-plane adapter for {action_kind} returned an invalid result."
+            )
+        normalized = dict(result)
+        _normalize_action_result_status(normalized.get("status"))
+        normalized.setdefault("beforeEvidenceRefs", [])
+        normalized.setdefault("afterEvidenceRefs", [])
+        return normalized
+
 class RemediationEvidenceToolService:
     """Typed evidence access surface for one remediation execution."""
 
@@ -234,6 +317,101 @@ class RemediationEvidenceToolService:
             principal=principal,
         )
         return payload
+
+    async def read_evidence_page(
+        self,
+        *,
+        remediation_workflow_id: str,
+        evidence_class: str,
+        cursor: int = 0,
+        limit: int = 20,
+        include_content: bool = False,
+        max_content_bytes: int = 65_536,
+        principal: str = "service:remediation-tools",
+    ) -> RemediationEvidencePage:
+        """Read a typed Omnigent evidence class without treating refs as grants.
+
+        The context index is the allowlist, while each referenced artifact is
+        independently authorized by ``TemporalArtifactService``. Missing
+        historical classes return an explicit degraded page.
+        """
+
+        link = await self._load_link(remediation_workflow_id)
+        context = await self._read_context_payload(link=link, principal=principal)
+        normalized_class = _required_string(evidence_class, "evidenceClass")
+        evidence = context.get("evidence")
+        evidence_mapping = evidence if isinstance(evidence, Mapping) else {}
+        index = evidence_mapping.get("omnigentIndex")
+        entries = _safe_sequence(index)
+        selected = next(
+            (
+                item
+                for item in entries
+                if isinstance(item, Mapping)
+                and item.get("class") == normalized_class
+            ),
+            None,
+        )
+        if not isinstance(selected, Mapping):
+            raise RemediationEvidenceToolError(
+                f"Unknown remediation evidence class: {normalized_class}."
+            )
+        refs = [
+            item
+            for item in _safe_sequence(selected.get("refs"))
+            if isinstance(item, Mapping)
+        ]
+        start = max(0, int(cursor))
+        page_limit = max(1, min(int(limit), 100))
+        page_refs = refs[start : start + page_limit]
+        allowed = _collect_context_artifact_ids(context)
+        items: list[dict[str, Any]] = []
+        content_bound = max(0, min(int(max_content_bytes), 1_048_576))
+        for ref in page_refs:
+            artifact_id = _artifact_id_from_ref(ref)
+            item: dict[str, Any] = {"ref": _redact_payload_value(dict(ref))}
+            if not artifact_id or artifact_id not in allowed:
+                item.update(
+                    {
+                        "status": "unavailable",
+                        "degradedReason": "reference is not authorized by remediation context",
+                    }
+                )
+                items.append(item)
+                continue
+            artifact, payload = await self._artifact_service.read(
+                artifact_id=artifact_id,
+                principal=principal,
+            )
+            item.update(
+                {
+                    "status": "available",
+                    "artifactId": artifact_id,
+                    "metadata": _redact_payload_value(
+                        artifact.metadata_json
+                        if isinstance(artifact.metadata_json, Mapping)
+                        else {}
+                    ),
+                    "sizeBytes": len(payload),
+                }
+            )
+            if include_content:
+                bounded = payload[:content_bound]
+                item["content"] = _redact_text(
+                    bounded.decode("utf-8", errors="replace")
+                )
+                item["contentTruncated"] = len(payload) > len(bounded)
+            items.append(item)
+        next_cursor = start + len(page_refs)
+        if next_cursor >= len(refs):
+            next_cursor = None
+        return RemediationEvidencePage(
+            evidence_class=normalized_class,
+            status=str(selected.get("status") or ("available" if refs else "missing")),
+            items=tuple(items),
+            next_cursor=next_cursor,
+            degraded_reason=_string_or_none(selected.get("degradedReason")),
+        )
 
     async def read_target_logs(
         self,
@@ -879,13 +1057,13 @@ def _normalize_action_result_status(value: Any) -> str:
     return status
 
 def _annotation_decision_for_status(status: str) -> str:
-    if status in {"applied", "failed", "timed_out"}:
+    if status in {"accepted", "applied", "failed", "timed_out"}:
         return "attempted"
     if status == "no_op":
         return "skipped"
     if status == "approval_required":
         return "approval_required"
-    if status in {"rejected", "precondition_failed"}:
+    if status in {"rejected", "denied", "precondition_failed"}:
         return "denied"
     return "escalated"
 
@@ -958,8 +1136,10 @@ def _enum_value(value: Any) -> str | None:
     return _string_or_none(enum_value)
 
 __all__ = [
+    "MoonMindControlPlaneRemediationActionExecutor",
     "RemediationActionExecutor",
     "RemediationActionRequestPreparation",
+    "RemediationEvidencePage",
     "RemediationEvidenceToolError",
     "RemediationEvidenceToolService",
     "RemediationLiveFollowEvent",

--- a/moonmind/workflows/temporal/remediation_tools.py
+++ b/moonmind/workflows/temporal/remediation_tools.py
@@ -120,6 +120,17 @@ class RemediationEvidencePage:
     next_cursor: int | None
     degraded_reason: str | None = None
 
+
+@dataclass(frozen=True, slots=True)
+class RemediationArtifactReadResult:
+    """Bounded metadata and optional content for one context-linked artifact."""
+
+    artifact_id: str
+    metadata: dict[str, Any]
+    size_bytes: int
+    content: str | None
+    content_truncated: bool
+
 class RemediationLogReader(Protocol):
     """Read bounded historical logs for a target agent run."""
 
@@ -216,7 +227,9 @@ class MoonMindControlPlaneRemediationActionExecutor:
         target_health: RemediationTargetHealthSnapshot,
     ) -> Mapping[str, Any]:
         action_kind = _required_string(action_request.get("actionKind"), "actionKind")
-        parameters = action_request.get("parameters")
+        parameters = action_request.get("params")
+        if not isinstance(parameters, Mapping):
+            parameters = action_request.get("parameters")
         parameters_mapping = parameters if isinstance(parameters, Mapping) else {}
         original_inputs = guard_result.get("originalInputs")
         proposed_inputs = guard_result.get("proposedInputs")
@@ -328,6 +341,48 @@ class RemediationEvidenceToolService:
             principal=principal,
         )
         return payload
+
+    async def read_target_artifact_bounded(
+        self,
+        *,
+        remediation_workflow_id: str,
+        artifact_ref: str | Mapping[str, Any],
+        include_content: bool = False,
+        max_content_bytes: int = 65_536,
+        principal: str = "service:remediation-tools",
+    ) -> RemediationArtifactReadResult:
+        """Read metadata and bounded redacted content for a linked artifact."""
+
+        link = await self._load_link(remediation_workflow_id)
+        context = await self._read_context_payload(link=link, principal=principal)
+        artifact_id = _artifact_id_from_ref(artifact_ref)
+        if not artifact_id:
+            raise RemediationEvidenceToolError("artifactRef must include artifact_id.")
+        if artifact_id not in _collect_context_artifact_ids(context):
+            raise RemediationEvidenceToolError(
+                f"Artifact {artifact_id} is not listed in remediation context."
+            )
+        artifact, payload = await self._artifact_service.read(
+            artifact_id=artifact_id,
+            principal=principal,
+        )
+        bound = max(0, min(int(max_content_bytes), 1_048_576))
+        bounded = payload[:bound] if include_content else b""
+        return RemediationArtifactReadResult(
+            artifact_id=artifact_id,
+            metadata=_redact_payload_value(
+                artifact.metadata_json
+                if isinstance(artifact.metadata_json, Mapping)
+                else {}
+            ),
+            size_bytes=len(payload),
+            content=(
+                _redact_text(bounded.decode("utf-8", errors="replace"))
+                if include_content
+                else None
+            ),
+            content_truncated=include_content and len(payload) > len(bounded),
+        )
 
     async def read_evidence_page(
         self,

--- a/moonmind/workflows/temporal/runtime/managed_session_controller.py
+++ b/moonmind/workflows/temporal/runtime/managed_session_controller.py
@@ -4196,6 +4196,68 @@ class DockerCodexManagedSessionController:
             )
         return containers
 
+    async def run_container_remediation_action(
+        self,
+        *,
+        action_kind: str,
+        container_ref: str,
+        expected_state: str | None,
+        request_id: str,
+    ) -> dict[str, Any]:
+        """Mutate exactly one label-owned managed-session container."""
+
+        containers = await self._list_managed_session_containers()
+        matches = [
+            item for item in containers if item.container_id == container_ref
+        ]
+        if len(matches) != 1:
+            raise ValueError("containerRef is not an owned managed-session container")
+        container = matches[0]
+        record = (
+            self._session_store.load(container.session_id)
+            if self._session_store is not None
+            else None
+        )
+        before_state = (
+            "orphaned"
+            if record is None
+            or record.status in TERMINAL_MANAGED_SESSION_STATUSES
+            else "running"
+        )
+        if expected_state and expected_state != before_state:
+            raise ValueError("expectedState does not match the managed container")
+
+        if action_kind == "workload.restart_helper_container":
+            if container.kind != "session-docker-sidecar":
+                raise ValueError("containerRef is not a managed helper container")
+            if before_state != "running":
+                raise ValueError("only an owned running helper container can restart")
+            await self._run((self._docker_binary, "restart", container.container_id))
+            after_state = "running"
+        elif action_kind == "workload.reap_orphan_container":
+            if before_state != "orphaned":
+                raise ValueError("an active managed container cannot be reaped")
+            await self._remove_container(container.container_id, ignore_failure=False)
+            after_state = "removed"
+        else:
+            raise ValueError(f"unsupported container remediation action: {action_kind}")
+
+        before_ref = (
+            f"managed-container:{container.container_id}:state:{before_state}"
+        )
+        after_ref = f"managed-container:{container.container_id}:state:{after_state}"
+        return {
+            "status": "applied",
+            "actionKind": action_kind,
+            "requestId": request_id,
+            "containerRef": container.container_id,
+            "sessionId": container.session_id,
+            "before": {"state": before_state, "evidenceRef": before_ref},
+            "after": {"state": after_state, "evidenceRef": after_ref},
+            "beforeEvidenceRefs": [before_ref],
+            "afterEvidenceRefs": [after_ref],
+        }
+
     @staticmethod
     def _is_managed_session_sidecar_volume_name(volume_name: str) -> bool:
         return bool(_MANAGED_SESSION_SIDECAR_VOLUME_NAME.match(volume_name))

--- a/moonmind/workflows/temporal/runtime/managed_session_controller.py
+++ b/moonmind/workflows/temporal/runtime/managed_session_controller.py
@@ -4203,6 +4203,7 @@ class DockerCodexManagedSessionController:
         container_ref: str,
         expected_state: str | None,
         request_id: str,
+        target_workflow_id: str,
     ) -> dict[str, Any]:
         """Mutate exactly one label-owned managed-session container."""
 
@@ -4218,6 +4219,15 @@ class DockerCodexManagedSessionController:
             if self._session_store is not None
             else None
         )
+        if not target_workflow_id:
+            raise ValueError("targetWorkflowId is required")
+        record_target = str(
+            getattr(record, "workflow_id", None)
+            or getattr(record, "agent_run_id", None)
+            or ""
+        ).strip()
+        if record is None or record_target != target_workflow_id:
+            raise ValueError("containerRef is not owned by the remediation target")
         before_state = (
             "orphaned"
             if record is None

--- a/moonmind/workflows/temporal/service.py
+++ b/moonmind/workflows/temporal/service.py
@@ -770,6 +770,30 @@ class TemporalExecutionService:
 
         evidence_policy = remediation.get("evidencePolicy")
         self._validate_remediation_evidence_policy(evidence_policy)
+        for policy_name, boolean_fields in (
+            ("approvalPolicy", ("requiredForHighRisk",)),
+            ("lockPolicy", ("targetMutationLock",)),
+            ("verificationPolicy", ("verifyAppliedActions",)),
+        ):
+            policy = remediation.get(policy_name)
+            if policy is None:
+                continue
+            if not isinstance(policy, Mapping):
+                raise TemporalExecutionValidationError(
+                    f"workflow.remediation.{policy_name} must be an object."
+                )
+            unsupported = set(policy) - set(boolean_fields)
+            if unsupported:
+                raise TemporalExecutionValidationError(
+                    f"workflow.remediation.{policy_name} contains unsupported fields."
+                )
+            if any(
+                field in policy and not isinstance(policy[field], bool)
+                for field in boolean_fields
+            ):
+                raise TemporalExecutionValidationError(
+                    f"workflow.remediation.{policy_name} fields must be booleans."
+                )
         checkpoint_branch_policy = remediation.get("checkpointBranchPolicy")
         if checkpoint_branch_policy is not None:
             if not isinstance(checkpoint_branch_policy, Mapping):

--- a/moonmind/workflows/temporal/service.py
+++ b/moonmind/workflows/temporal/service.py
@@ -770,10 +770,10 @@ class TemporalExecutionService:
 
         evidence_policy = remediation.get("evidencePolicy")
         self._validate_remediation_evidence_policy(evidence_policy)
-        for policy_name, boolean_fields in (
-            ("approvalPolicy", ("requiredForHighRisk",)),
-            ("lockPolicy", ("targetMutationLock",)),
-            ("verificationPolicy", ("verifyAppliedActions",)),
+        for policy_name in (
+            "approvalPolicy",
+            "lockPolicy",
+            "verificationPolicy",
         ):
             policy = remediation.get(policy_name)
             if policy is None:
@@ -781,18 +781,6 @@ class TemporalExecutionService:
             if not isinstance(policy, Mapping):
                 raise TemporalExecutionValidationError(
                     f"workflow.remediation.{policy_name} must be an object."
-                )
-            unsupported = set(policy) - set(boolean_fields)
-            if unsupported:
-                raise TemporalExecutionValidationError(
-                    f"workflow.remediation.{policy_name} contains unsupported fields."
-                )
-            if any(
-                field in policy and not isinstance(policy[field], bool)
-                for field in boolean_fields
-            ):
-                raise TemporalExecutionValidationError(
-                    f"workflow.remediation.{policy_name} fields must be booleans."
                 )
         checkpoint_branch_policy = remediation.get("checkpointBranchPolicy")
         if checkpoint_branch_policy is not None:

--- a/moonmind/workflows/temporal/service.py
+++ b/moonmind/workflows/temporal/service.py
@@ -2047,6 +2047,33 @@ class TemporalExecutionService:
         await self._sync_projection_best_effort(record)
         return response
 
+    async def create_fresh_rerun_execution(
+        self,
+        *,
+        workflow_id: str,
+        idempotency_key: str,
+    ) -> dict[str, Any]:
+        """Create a distinct rerun execution through the canonical service boundary."""
+
+        record = await self._require_source_execution(workflow_id)
+        if (
+            idempotency_key == record.last_update_idempotency_key
+            and isinstance(record.last_update_response, dict)
+        ):
+            return dict(record.last_update_response)
+        response = await self._create_fresh_rerun_execution(
+            record,
+            input_artifact_ref=None,
+            plan_artifact_ref=None,
+            parameters_patch=None,
+            idempotency_key=idempotency_key,
+        )
+        record.last_update_idempotency_key = idempotency_key
+        record.last_update_response = dict(response)
+        await self._session.commit()
+        await self._session.refresh(record)
+        return response
+
     @staticmethod
     def _is_terminal_update_error(exc: Exception) -> bool:
         message = str(exc).strip().lower()

--- a/moonmind/workflows/temporal/workflows/managed_runtime_workspace_cleanup.py
+++ b/moonmind/workflows/temporal/workflows/managed_runtime_workspace_cleanup.py
@@ -18,7 +18,7 @@ DEFAULT_ACTIVITY_CATALOG = build_default_activity_catalog()
 class MoonMindManagedRuntimeWorkspaceCleanupWorkflow:
     @workflow.run
     async def run(self, payload: dict[str, Any] | None = None) -> dict[str, Any]:
-        del payload
+        payload = dict(payload or {})
         workflow.set_current_details("Cleaning retained managed runtime files")
         workflow.upsert_search_attributes(
             {
@@ -32,7 +32,7 @@ class MoonMindManagedRuntimeWorkspaceCleanupWorkflow:
         try:
             result = await workflow.execute_activity(
                 "agent_runtime.cleanup_managed_runtime_files",
-                {},
+                payload,
                 task_queue=route.task_queue,
                 start_to_close_timeout=timedelta(
                     seconds=route.timeouts.start_to_close_seconds

--- a/moonmind/workflows/temporal/workflows/managed_session_reconcile.py
+++ b/moonmind/workflows/temporal/workflows/managed_session_reconcile.py
@@ -17,7 +17,7 @@ DEFAULT_ACTIVITY_CATALOG = build_default_activity_catalog()
 class MoonMindManagedSessionReconcileWorkflow:
     @workflow.run
     async def run(self, payload: dict[str, Any] | None = None) -> dict[str, Any]:
-        del payload
+        payload = dict(payload or {})
         workflow.set_current_details("Reconciling managed runtime sessions")
         workflow.upsert_search_attributes(
             {
@@ -31,7 +31,7 @@ class MoonMindManagedSessionReconcileWorkflow:
         try:
             result = await workflow.execute_activity(
                 "agent_runtime.reconcile_managed_sessions",
-                {},
+                payload,
                 task_queue=route.task_queue,
                 start_to_close_timeout=timedelta(
                     seconds=route.timeouts.start_to_close_seconds

--- a/tests/unit/mcp/test_remediation_tool_registry.py
+++ b/tests/unit/mcp/test_remediation_tool_registry.py
@@ -2,10 +2,14 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+import pytest
+
 from moonmind.mcp.remediation_tool_registry import (
     RemediationToolExecutionContext,
     RemediationToolRegistry,
 )
+
+pytestmark = pytest.mark.asyncio
 
 
 @dataclass

--- a/tests/unit/mcp/test_remediation_tool_registry.py
+++ b/tests/unit/mcp/test_remediation_tool_registry.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from moonmind.mcp.remediation_tool_registry import (
+    RemediationToolExecutionContext,
+    RemediationToolRegistry,
+)
+
+
+@dataclass
+class _Page:
+    evidence_class: str
+    status: str = "available"
+    items: tuple[dict, ...] = ()
+    next_cursor: int | None = None
+    degraded_reason: str | None = None
+
+
+class _Service:
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    async def read_execution_and_step_details(self, **kwargs):
+        self.calls.append(kwargs)
+        return _Page("execution_and_steps")
+
+
+async def test_registry_exposes_and_dispatches_authenticated_bounded_read() -> None:
+    registry = RemediationToolRegistry()
+    names = {tool.name for tool in registry.list_tools()}
+    assert {
+        "remediation.read_execution_steps",
+        "remediation.read_checkpoint_recovery",
+        "remediation.read_bridge_events",
+        "remediation.read_capture_resources",
+        "remediation.read_target_logs",
+        "remediation.follow_target_logs",
+        "remediation.read_cleanup_janitor",
+        "remediation.read_branch_publication",
+        "remediation.read_policy_approvals",
+    } <= names
+
+    service = _Service()
+    result = await registry.call_tool(
+        tool="remediation.read_execution_steps",
+        arguments={
+            "remediationWorkflowId": "remediation-1",
+            "limit": 7,
+            "includeContent": True,
+            "maxContentBytes": 1024,
+        },
+        context=RemediationToolExecutionContext(
+            service=service,  # type: ignore[arg-type]
+            principal="user:owner",
+        ),
+    )
+
+    assert result["evidence_class"] == "execution_and_steps"
+    assert service.calls == [
+        {
+            "remediation_workflow_id": "remediation-1",
+            "cursor": 0,
+            "limit": 7,
+            "include_content": True,
+            "max_content_bytes": 1024,
+            "principal": "user:owner",
+        }
+    ]

--- a/tests/unit/mcp/test_remediation_tool_registry.py
+++ b/tests/unit/mcp/test_remediation_tool_registry.py
@@ -39,6 +39,8 @@ async def test_registry_exposes_and_dispatches_authenticated_bounded_read() -> N
         "remediation.read_cleanup_janitor",
         "remediation.read_branch_publication",
         "remediation.read_policy_approvals",
+        "remediation.read_target_artifact",
+        "remediation.execute_action",
     } <= names
 
     service = _Service()

--- a/tests/unit/omnigent/test_oauth_host_janitor.py
+++ b/tests/unit/omnigent/test_oauth_host_janitor.py
@@ -44,6 +44,7 @@ class _Repository:
 class _Runtime:
     def __init__(self, order=None):
         self.stopped = 0
+        self.removed: list[str] = []
         self.order = order if order is not None else []
 
     async def container_exists(self, _name):
@@ -55,6 +56,9 @@ class _Runtime:
 
     async def list_managed_containers(self):
         return []
+
+    async def remove_container(self, name):
+        self.removed.append(name)
 
 
 class _Client:
@@ -121,6 +125,42 @@ async def test_action_rejects_stale_expected_state_before_mutation() -> None:
         )
 
     assert runtime.stopped == 0
+
+
+@pytest.mark.asyncio
+async def test_host_remove_removes_named_owned_container() -> None:
+    repository = _Repository(_lease())
+    runtime = _Runtime()
+
+    result = await OmnigentOAuthHostJanitor(
+        repository=repository, runtime=runtime, client=_Client()
+    ).run_action(
+        action_kind="host.remove",
+        profile_id="profile-1",
+        host_lease_ref="lease-1",
+        expected_host_state="ready",
+        request_id="request-remove",
+    )
+
+    assert result["status"] == "applied"
+    assert runtime.removed == ["host-1"]
+    assert repository.stopped == ["lease-1"]
+
+
+@pytest.mark.asyncio
+async def test_stale_lease_eviction_rejects_fresh_lease() -> None:
+    repository = _Repository(_lease())
+
+    with pytest.raises(ValueError, match="not stale"):
+        await OmnigentOAuthHostJanitor(
+            repository=repository, runtime=_Runtime(), client=_Client()
+        ).run_action(
+            action_kind="provider_profile.evict_stale_lease",
+            profile_id="profile-1",
+            host_lease_ref="lease-1",
+            expected_host_state="ready",
+            request_id="request-evict",
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/omnigent/test_oauth_host_janitor.py
+++ b/tests/unit/omnigent/test_oauth_host_janitor.py
@@ -18,9 +18,27 @@ class _Repository:
     async def validate_binding(self, _binding_ref):
         return SimpleNamespace()
 
+    async def get_host_lease(self, lease_id):
+        return self.lease if lease_id == self.lease.lease_id else None
+
     async def mark_host_lease_stopped(self, lease_id):
         self.order.append("lease_released")
         self.stopped.append(lease_id)
+        self.lease.status = "stopped"
+        return self.lease
+
+    async def transition_host_lease(
+        self, lease_id, *, expected_status, new_status
+    ):
+        assert lease_id == self.lease.lease_id
+        assert self.lease.status == expected_status
+        self.lease.status = new_status
+        return self.lease
+
+    async def restart_host_lease(self, lease_id):
+        assert lease_id == self.lease.lease_id
+        self.lease.status = "starting"
+        return self.lease
 
 
 class _Runtime:
@@ -60,7 +78,49 @@ def _lease(*, heartbeat_age: int = 0):
         omnigent_session_id="session-1",
         last_heartbeat_at=now - timedelta(seconds=heartbeat_age),
         expires_at=now + timedelta(hours=1),
+        status="ready",
     )
+
+
+@pytest.mark.asyncio
+async def test_action_applies_only_named_lease_with_expected_state_evidence() -> None:
+    repository = _Repository(_lease())
+    runtime = _Runtime()
+
+    result = await OmnigentOAuthHostJanitor(
+        repository=repository, runtime=runtime, client=_Client()
+    ).run_action(
+        action_kind="host.stop",
+        profile_id="profile-1",
+        host_lease_ref="lease-1",
+        expected_host_state="ready",
+        request_id="request-1",
+    )
+
+    assert result["status"] == "applied"
+    assert result["before"]["status"] == "ready"
+    assert result["after"]["status"] == "stopped"
+    assert result["requestId"] == "request-1"
+    assert runtime.stopped == 1
+
+
+@pytest.mark.asyncio
+async def test_action_rejects_stale_expected_state_before_mutation() -> None:
+    repository = _Repository(_lease())
+    runtime = _Runtime()
+
+    with pytest.raises(ValueError, match="expectedHostState"):
+        await OmnigentOAuthHostJanitor(
+            repository=repository, runtime=runtime, client=_Client()
+        ).run_action(
+            action_kind="host.stop",
+            profile_id="profile-1",
+            host_lease_ref="lease-1",
+            expected_host_state="draining",
+            request_id="request-1",
+        )
+
+    assert runtime.stopped == 0
 
 
 @pytest.mark.asyncio

--- a/tests/unit/workflows/temporal/test_remediation_context.py
+++ b/tests/unit/workflows/temporal/test_remediation_context.py
@@ -48,6 +48,42 @@ from moonmind.workflows.temporal.remediation_context import (
     normalize_remediation_phase,
     normalize_remediation_resolution,
 )
+
+
+def test_omnigent_evidence_index_is_complete_bounded_and_explicitly_degraded():
+    index = RemediationContextBuilder._omnigent_evidence_index(
+        {
+            "generatedAt": "2026-07-26T12:00:00Z",
+            "bridgeEventPageRefs": ["art_bridge_page"],
+            "hostLeaseRef": {"artifact_id": "art_host_lease"},
+        }
+    )
+
+    by_class = {entry["class"]: entry for entry in index}
+    assert by_class["bridge_events"] == {
+        "class": "bridge_events",
+        "status": "available",
+        "bounded": True,
+        "contentsIncluded": False,
+        "refs": [
+            {
+                "artifact_id": "art_bridge_page",
+                "kind": "bridgeEventPageRefs",
+            }
+        ],
+        "observedAt": "2026-07-26T12:00:00Z",
+        "freshness": "source_reported",
+    }
+    assert by_class["provider_and_leases"]["status"] == "available"
+    assert by_class["provider_and_leases"]["refs"][0]["artifact_id"] == (
+        "art_host_lease"
+    )
+    assert by_class["prior_remediation"]["status"] == "missing"
+    assert by_class["prior_remediation"]["bounded"] is True
+    assert by_class["prior_remediation"]["freshness"] == "source_reported"
+    assert by_class["prior_remediation"]["degradedReason"] == (
+        "historical evidence was not recorded"
+    )
 from moonmind.workflows.temporal.remediation_actions import (
     RemediationActionAuthorityService,
     RemediationMutationGuardPolicy,

--- a/tests/unit/workflows/temporal/test_remediation_context.py
+++ b/tests/unit/workflows/temporal/test_remediation_context.py
@@ -2476,7 +2476,10 @@ async def test_remediation_execute_action_publishes_v1_request_and_result_artifa
         ).evaluate_action_request(
             remediation_workflow_id=remediation.workflow_id,
             action_kind=action_kind,
-            parameters={"reason": "Authorization: Bearer raw-secret-token"},
+            parameters={
+                "reason": "Authorization: Bearer raw-secret-token",
+                "containerRef": "container-1",
+            },
             dry_run=False,
             idempotency_key=action_id,
             requesting_principal="workflow:remediator",
@@ -2807,7 +2810,7 @@ async def test_remediation_action_authority_requires_approval_for_gated_mode(
         approved = await service.evaluate_action_request(
             remediation_workflow_id=remediation.workflow_id,
             action_kind="workload.restart_helper_container",
-            parameters={},
+            parameters={"containerRef": "container-1"},
             dry_run=False,
             idempotency_key="gated-approved",
             requesting_principal="user:operator",
@@ -2861,7 +2864,7 @@ async def test_remediation_action_authority_enforces_profile_permissions_and_ris
         allowed = await service.evaluate_action_request(
             remediation_workflow_id=remediation.workflow_id,
             action_kind="workload.restart_helper_container",
-            parameters={},
+            parameters={"containerRef": "container-1"},
             dry_run=False,
             idempotency_key="medium-allowed",
             requesting_principal="user:operator",
@@ -2945,7 +2948,7 @@ async def test_remediation_action_authority_cache_keys_include_request_shape(
         allowed = await service.evaluate_action_request(
             remediation_workflow_id=remediation.workflow_id,
             action_kind="workload.restart_helper_container",
-            parameters={},
+            parameters={"containerRef": "container-1"},
             dry_run=False,
             idempotency_key="same-idempotency-key",
             requesting_principal="user:operator",
@@ -3147,7 +3150,10 @@ async def test_remediation_action_authority_uses_prepared_action_context(
         decision = await service.evaluate_action_request(
             remediation_workflow_id=preparation.remediation_workflow_id,
             action_kind=preparation.action_kind,
-            parameters={"reason": f"target state was {preparation.target.state}"},
+            parameters={
+                "reason": f"target state was {preparation.target.state}",
+                "containerRef": "container-1",
+            },
             dry_run=False,
             idempotency_key="prepared-action",
             requesting_principal="workflow:remediator",

--- a/tests/unit/workflows/temporal/test_remediation_context.py
+++ b/tests/unit/workflows/temporal/test_remediation_context.py
@@ -90,7 +90,7 @@ def test_context_aggregate_is_degraded_when_omnigent_classes_are_missing():
     target_record = SimpleNamespace(
         workflow_id="target",
         run_id="target-run",
-        state=MoonMindWorkflowState.RUNNING,
+        state=MoonMindWorkflowState.EXECUTING,
         close_status=None,
         memo={},
         parameters={},
@@ -99,7 +99,7 @@ def test_context_aggregate_is_degraded_when_omnigent_classes_are_missing():
     remediation_record = SimpleNamespace(
         workflow_id="remediation",
         run_id="remediation-run",
-        state=MoonMindWorkflowState.RUNNING,
+        state=MoonMindWorkflowState.EXECUTING,
         close_status=None,
         memo={},
         parameters={

--- a/tests/unit/workflows/temporal/test_remediation_context.py
+++ b/tests/unit/workflows/temporal/test_remediation_context.py
@@ -84,6 +84,55 @@ def test_omnigent_evidence_index_is_complete_bounded_and_explicitly_degraded():
     assert by_class["prior_remediation"]["degradedReason"] == (
         "historical evidence was not recorded"
     )
+
+
+def test_context_aggregate_is_degraded_when_omnigent_classes_are_missing():
+    target_record = SimpleNamespace(
+        workflow_id="target",
+        run_id="target-run",
+        state=MoonMindWorkflowState.RUNNING,
+        close_status=None,
+        memo={},
+        parameters={},
+        artifact_refs=[],
+    )
+    remediation_record = SimpleNamespace(
+        workflow_id="remediation",
+        run_id="remediation-run",
+        state=MoonMindWorkflowState.RUNNING,
+        close_status=None,
+        memo={},
+        parameters={
+            "workflow": {
+                "remediation": {
+                    "target": {"agentRunIds": ["agent-run"]},
+                    "evidencePolicy": {"liveFollow": "disabled"},
+                }
+            }
+        },
+        artifact_refs=[],
+    )
+    link = SimpleNamespace(
+        remediation_workflow_id="remediation",
+        remediation_run_id="remediation-run",
+        target_workflow_id="target",
+        target_run_id="target-run",
+        authority_mode="observe_only",
+        mode="snapshot",
+    )
+
+    payload = RemediationContextBuilder(
+        session=object(), artifact_service=object()
+    )._build_payload(
+        link=link,
+        remediation_record=remediation_record,
+        target_record=target_record,
+    )
+
+    evidence = payload["evidence"]
+    assert evidence["evidenceDegraded"] is True
+    assert "execution_and_steps" in evidence["unavailableEvidenceClasses"]
+    assert "prior_remediation" in evidence["unavailableEvidenceClasses"]
 from moonmind.workflows.temporal.remediation_actions import (
     RemediationActionAuthorityService,
     RemediationMutationGuardPolicy,

--- a/tests/unit/workflows/temporal/test_remediation_context.py
+++ b/tests/unit/workflows/temporal/test_remediation_context.py
@@ -721,7 +721,7 @@ async def test_remediation_context_builder_enriches_agent_run_evidence_and_live_
                 ],
             }
         ]
-        assert result.payload["evidence"]["availability"] == [
+        assert result.payload["evidence"]["availability"][:7] == [
             {"class": "stdout", "status": "available"},
             {"class": "stderr", "status": "available"},
             {"class": "merged_logs", "status": "available"},
@@ -730,7 +730,7 @@ async def test_remediation_context_builder_enriches_agent_run_evidence_and_live_
             {"class": "continuity", "status": "available"},
             {"class": "live_follow", "status": "available"},
         ]
-        assert result.payload["evidence"]["evidenceDegraded"] is False
+        assert result.payload["evidence"]["evidenceDegraded"] is True
         assert result.payload["evidence"]["diagnosisHints"] == [
             "Prefer diagnostics before merged logs"
         ]
@@ -889,7 +889,7 @@ async def test_remediation_context_builder_records_historical_degraded_evidence(
             }
         ]
         assert result.payload["evidence"]["evidenceDegraded"] is True
-        assert result.payload["evidence"]["unavailableEvidenceClasses"] == [
+        assert result.payload["evidence"]["unavailableEvidenceClasses"][:6] == [
             "stdout",
             "stderr",
             "diagnostics",
@@ -897,7 +897,7 @@ async def test_remediation_context_builder_records_historical_degraded_evidence(
             "continuity",
             "live_follow",
         ]
-        assert result.payload["evidence"]["availability"] == [
+        assert result.payload["evidence"]["availability"][:7] == [
             {
                 "class": "stdout",
                 "status": "missing",
@@ -1005,10 +1005,15 @@ async def test_remediation_context_builder_marks_unsupported_live_follow_degrade
         ).build_context(remediation_workflow_id=remediation.workflow_id)
 
         assert result.payload["evidence"]["evidenceDegraded"] is True
-        assert result.payload["evidence"]["unavailableEvidenceClasses"] == [
+        assert result.payload["evidence"]["unavailableEvidenceClasses"][0] == (
             "live_follow"
-        ]
-        assert result.payload["evidence"]["availability"][-1] == {
+        )
+        live_follow_availability = next(
+            item
+            for item in result.payload["evidence"]["availability"]
+            if item["class"] == "live_follow"
+        )
+        assert live_follow_availability == {
             "class": "live_follow",
             "status": "unsupported",
             "reason": "agent run does not support live follow",
@@ -2282,7 +2287,7 @@ async def test_remediation_execute_action_delegates_and_publishes_lifecycle_arti
         ).evaluate_action_request(
             remediation_workflow_id=remediation.workflow_id,
             action_kind=action_kind,
-            parameters={"reason": "restart helper"},
+            parameters={"reason": "restart helper", "containerRef": "container-1"},
             dry_run=False,
             idempotency_key="execute-action-1",
             requesting_principal="workflow:remediator",
@@ -2298,7 +2303,7 @@ async def test_remediation_execute_action_delegates_and_publishes_lifecycle_arti
             target_run_id=target.run_id,
             action_kind=action_kind,
             idempotency_key="execute-action-1",
-            parameters={"reason": "restart helper"},
+            parameters={"reason": "restart helper", "containerRef": "container-1"},
             policy=RemediationMutationGuardPolicy(cooldown_seconds=0),
             now=datetime(2026, 4, 23, tzinfo=timezone.utc),
         )
@@ -2378,7 +2383,7 @@ async def test_remediation_execute_action_reuses_retry_artifacts(
         ).evaluate_action_request(
             remediation_workflow_id=remediation.workflow_id,
             action_kind=action_kind,
-            parameters={"reason": "restart helper"},
+            parameters={"reason": "restart helper", "containerRef": "container-1"},
             dry_run=False,
             idempotency_key=action_id,
             requesting_principal="workflow:remediator",
@@ -2392,7 +2397,7 @@ async def test_remediation_execute_action_reuses_retry_artifacts(
             target_run_id=target.run_id,
             action_kind=action_kind,
             idempotency_key=action_id,
-            parameters={"reason": "restart helper"},
+            parameters={"reason": "restart helper", "containerRef": "container-1"},
             policy=RemediationMutationGuardPolicy(cooldown_seconds=0),
             now=datetime(2026, 4, 23, tzinfo=timezone.utc),
         )
@@ -2485,7 +2490,7 @@ async def test_remediation_execute_action_publishes_v1_request_and_result_artifa
             target_run_id=target.run_id,
             action_kind=action_kind,
             idempotency_key=action_id,
-            parameters={"reason": "restart helper"},
+            parameters={"reason": "restart helper", "containerRef": "container-1"},
             policy=RemediationMutationGuardPolicy(cooldown_seconds=0),
             now=datetime(2026, 4, 23, tzinfo=timezone.utc),
         )
@@ -2563,7 +2568,7 @@ async def test_remediation_execute_action_rejects_unsupported_result_status(
         ).evaluate_action_request(
             remediation_workflow_id=remediation.workflow_id,
             action_kind=action_kind,
-            parameters={"reason": "restart helper"},
+            parameters={"reason": "restart helper", "containerRef": "container-1"},
             dry_run=False,
             idempotency_key="unsupported-status",
             requesting_principal="workflow:remediator",
@@ -2577,7 +2582,7 @@ async def test_remediation_execute_action_rejects_unsupported_result_status(
             target_run_id=target.run_id,
             action_kind=action_kind,
             idempotency_key="unsupported-status",
-            parameters={"reason": "restart helper"},
+            parameters={"reason": "restart helper", "containerRef": "container-1"},
             policy=RemediationMutationGuardPolicy(cooldown_seconds=0),
             now=datetime(2026, 4, 23, tzinfo=timezone.utc),
         )
@@ -2621,7 +2626,7 @@ async def test_remediation_execute_action_rejects_mismatched_authority_or_guard_
         ).evaluate_action_request(
             remediation_workflow_id=remediation.workflow_id,
             action_kind=action_kind,
-            parameters={"reason": "restart helper"},
+            parameters={"reason": "restart helper", "containerRef": "container-1"},
             dry_run=False,
             idempotency_key="execute-action-context",
             requesting_principal="workflow:remediator",
@@ -2637,7 +2642,7 @@ async def test_remediation_execute_action_rejects_mismatched_authority_or_guard_
             target_run_id=target.run_id,
             action_kind=action_kind,
             idempotency_key="execute-action-context",
-            parameters={"reason": "restart helper"},
+            parameters={"reason": "restart helper", "containerRef": "container-1"},
             policy=RemediationMutationGuardPolicy(cooldown_seconds=0),
             now=datetime(2026, 4, 23, tzinfo=timezone.utc),
         )

--- a/tests/unit/workflows/temporal/test_remediation_issue_3511.py
+++ b/tests/unit/workflows/temporal/test_remediation_issue_3511.py
@@ -18,6 +18,7 @@ from moonmind.workflows.temporal.remediation_actions import (
 )
 from moonmind.workflows.temporal.remediation_tools import (
     MoonMindControlPlaneRemediationActionExecutor,
+    RemediationEvidenceToolService,
     RemediationTargetHealthSnapshot,
 )
 
@@ -352,12 +353,6 @@ async def test_checkpoint_branch_adapter_persists_graph_through_service() -> Non
             "MoonMind.ManagedSessionReconcile",
             "remediation-managed-runtime:action-2",
         ),
-        (
-            "cleanup.request_janitor",
-            {"cleanupRef": "cleanup-1", "expectedState": "pending"},
-            "MoonMind.ManagedRuntimeWorkspaceCleanup",
-            "remediation-cleanup:action-2",
-        ),
     ],
 )
 async def test_production_repair_adapters_queue_owning_control_plane(
@@ -386,9 +381,6 @@ async def test_production_repair_adapters_queue_owning_control_plane(
     if kind == "workload.reap_orphan_container":
         assert queued_payload["containerRef"] == "container-1"
         assert queued_payload["expectedState"] == "orphaned"
-    if kind == "cleanup.request_janitor":
-        assert queued_payload["actionKind"] == kind
-        assert queued_payload["cleanupRef"] == "cleanup-1"
 
 
 async def test_production_host_adapter_rejects_missing_authoritative_lease() -> None:
@@ -413,11 +405,11 @@ async def test_production_adapter_reports_delivery_unknown_without_claiming_succ
     client.start_workflow.side_effect = RuntimeError("transport unavailable")
     plane = TemporalRemediationControlPlane(client=client)
 
-    result = await plane.handlers()["cleanup.request_janitor"](
+    result = await plane.handlers()["workload.reap_orphan_container"](
         {
-            "actionKind": "cleanup.request_janitor",
+            "actionKind": "workload.reap_orphan_container",
             "actionId": "action-4",
-            "params": {"cleanupRef": "cleanup-1"},
+            "params": {"containerRef": "container-1"},
         },
         {},
         _production_target_health(),

--- a/tests/unit/workflows/temporal/test_remediation_issue_3511.py
+++ b/tests/unit/workflows/temporal/test_remediation_issue_3511.py
@@ -2,6 +2,12 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from api_service.services.remediation_actions import TemporalRemediationControlPlane
 from moonmind.workflows.temporal.remediation_actions import (
     RemediationActionAuthorityService,
     RemediationPermissionSet,
@@ -233,3 +239,141 @@ async def test_typed_evidence_operations_delegate_to_their_bounded_classes() -> 
         "checkpoint_branches",
         "policy",
     ]
+
+
+def _production_target_health() -> RemediationTargetHealthSnapshot:
+    return RemediationTargetHealthSnapshot(
+        workflow_id="target",
+        pinned_run_id="target-run",
+        current_run_id="target-run",
+        state="failed",
+        close_status="failed",
+        title=None,
+        summary=None,
+        target_run_changed=False,
+    )
+
+
+async def test_production_rerun_adapter_uses_execution_service_idempotently() -> None:
+    client = AsyncMock()
+    execution_service = AsyncMock()
+    execution_service.create_fresh_rerun_execution.return_value = {
+        "accepted": True,
+        "message": "Fresh rerun created.",
+        "workflow_id": "fresh-target",
+    }
+    plane = TemporalRemediationControlPlane(
+        client=client, execution_service=execution_service
+    )
+
+    result = await plane.rerun(
+        {
+            "actionKind": "execution.start_fresh_rerun",
+            "actionId": "action-1",
+            "params": {"expectedRunId": "target-run"},
+        },
+        {},
+        _production_target_health(),
+    )
+
+    assert result["status"] == "accepted"
+    assert result["afterEvidenceRefs"] == [
+        "execution:fresh-target:rerun-request:action-1"
+    ]
+    execution_service.create_fresh_rerun_execution.assert_awaited_once_with(
+        workflow_id="target",
+        idempotency_key="action-1",
+    )
+
+
+@pytest.mark.parametrize(
+    ("kind", "params", "workflow_type", "workflow_id"),
+    [
+        (
+            "host.restart",
+            {
+                "providerProfileId": "profile-1",
+                "hostLeaseRef": "lease-1",
+                "expectedHostState": "stopped",
+            },
+            "MoonMind.OmnigentOAuthHostJanitor",
+            "remediation-omnigent:action-2",
+        ),
+        (
+            "provider_profile.evict_stale_lease",
+            {"providerProfileId": "profile-1"},
+            "MoonMind.OmnigentOAuthHostJanitor",
+            "remediation-omnigent:action-2",
+        ),
+        (
+            "workload.reap_orphan_container",
+            {"containerRef": "container-1", "expectedState": "orphaned"},
+            "MoonMind.ManagedSessionReconcile",
+            "remediation-managed-runtime:action-2",
+        ),
+        (
+            "cleanup.request_janitor",
+            {"cleanupRef": "cleanup-1", "expectedState": "pending"},
+            "MoonMind.ManagedRuntimeWorkspaceCleanup",
+            "remediation-cleanup:action-2",
+        ),
+    ],
+)
+async def test_production_repair_adapters_queue_owning_control_plane(
+    kind, params, workflow_type, workflow_id
+) -> None:
+    client = AsyncMock()
+    client.start_workflow.return_value = SimpleNamespace(
+        workflow_id=workflow_id, run_id="control-run"
+    )
+    plane = TemporalRemediationControlPlane(client=client)
+
+    result = await plane.handlers()[kind](
+        {"actionKind": kind, "actionId": "action-2", "params": params},
+        {},
+        _production_target_health(),
+    )
+
+    assert result["status"] == "accepted"
+    assert result["afterEvidenceRefs"] == [
+        f"workflow:{workflow_id}:run:control-run"
+    ]
+    assert client.start_workflow.await_args.kwargs["workflow_type"] == workflow_type
+    assert client.start_workflow.await_args.kwargs["workflow_id"] == workflow_id
+
+
+async def test_production_host_adapter_rejects_missing_authoritative_lease() -> None:
+    plane = TemporalRemediationControlPlane(client=AsyncMock())
+
+    result = await plane.handlers()["host.stop"](
+        {
+            "actionKind": "host.stop",
+            "actionId": "action-3",
+            "params": {"providerProfileId": "profile-1"},
+        },
+        {},
+        _production_target_health(),
+    )
+
+    assert result["status"] == "precondition_failed"
+    assert result["reason"] == "hostLeaseRef is required"
+
+
+async def test_production_adapter_reports_delivery_unknown_without_claiming_success() -> None:
+    client = AsyncMock()
+    client.start_workflow.side_effect = RuntimeError("transport unavailable")
+    plane = TemporalRemediationControlPlane(client=client)
+
+    result = await plane.handlers()["cleanup.request_janitor"](
+        {
+            "actionKind": "cleanup.request_janitor",
+            "actionId": "action-4",
+            "params": {"cleanupRef": "cleanup-1"},
+        },
+        {},
+        _production_target_health(),
+    )
+
+    assert result["status"] == "delivery_unknown"
+    assert result["afterEvidenceRefs"] == []
+    assert "RuntimeError" in result["reason"]

--- a/tests/unit/workflows/temporal/test_remediation_issue_3511.py
+++ b/tests/unit/workflows/temporal/test_remediation_issue_3511.py
@@ -7,6 +7,8 @@ from unittest.mock import AsyncMock
 
 import pytest
 
+pytestmark = pytest.mark.asyncio
+
 from api_service.services.remediation_actions import TemporalRemediationControlPlane
 from moonmind.workflows.temporal.remediation_actions import (
     RemediationActionAuthorityService,

--- a/tests/unit/workflows/temporal/test_remediation_issue_3511.py
+++ b/tests/unit/workflows/temporal/test_remediation_issue_3511.py
@@ -286,6 +286,45 @@ async def test_production_rerun_adapter_uses_execution_service_idempotently() ->
     )
 
 
+async def test_checkpoint_branch_adapter_persists_graph_through_service() -> None:
+    checkpoint_service = AsyncMock()
+    checkpoint_service.create_branch_graph.return_value = SimpleNamespace(
+        branch=SimpleNamespace(branch_id="remediation-action-branch")
+    )
+    plane = TemporalRemediationControlPlane(
+        client=AsyncMock(), checkpoint_branch_service=checkpoint_service
+    )
+
+    result = await plane.handlers()[
+        "checkpoint_branch.create_from_remediation_context"
+    ](
+        {
+            "actionKind": "checkpoint_branch.create_from_remediation_context",
+            "actionId": "action-branch",
+            "params": {
+                "expectedRunId": "target-run",
+                "remediationWorkflowId": "remediation",
+                "remediationContextRef": "artifact://context",
+                "checkpointRef": "artifact://checkpoint",
+                "instructionRef": "artifact://instructions",
+                "instructionDigest": "sha256:" + ("a" * 64),
+            },
+        },
+        {},
+        _production_target_health(),
+    )
+
+    assert result["status"] == "applied"
+    payload = checkpoint_service.create_branch_graph.await_args.args[0]
+    assert payload["source"]["workflowId"] == "target"
+    assert payload["source"]["runId"] == "target-run"
+    assert payload["source"]["checkpointRef"] == "artifact://checkpoint"
+    assert payload["runtimeContextPolicy"] == "fresh_agent_run"
+    assert payload["instructionRef"] == "artifact://instructions"
+    assert payload["instructionDigest"] == "sha256:" + ("a" * 64)
+    assert payload["idempotencyKey"] == "action-branch"
+
+
 @pytest.mark.parametrize(
     ("kind", "params", "workflow_type", "workflow_id"),
     [
@@ -301,7 +340,7 @@ async def test_production_rerun_adapter_uses_execution_service_idempotently() ->
         ),
         (
             "provider_profile.evict_stale_lease",
-            {"providerProfileId": "profile-1"},
+            {"providerProfileId": "profile-1", "hostLeaseRef": "lease-1"},
             "MoonMind.OmnigentOAuthHostJanitor",
             "remediation-omnigent:action-2",
         ),
@@ -340,6 +379,14 @@ async def test_production_repair_adapters_queue_owning_control_plane(
     ]
     assert client.start_workflow.await_args.kwargs["workflow_type"] == workflow_type
     assert client.start_workflow.await_args.kwargs["workflow_id"] == workflow_id
+    queued_payload = client.start_workflow.await_args.kwargs["input_args"]
+    assert queued_payload["requestId"] == "action-2"
+    if kind == "workload.reap_orphan_container":
+        assert queued_payload["containerRef"] == "container-1"
+        assert queued_payload["expectedState"] == "orphaned"
+    if kind == "cleanup.request_janitor":
+        assert queued_payload["actionKind"] == kind
+        assert queued_payload["cleanupRef"] == "cleanup-1"
 
 
 async def test_production_host_adapter_rejects_missing_authoritative_lease() -> None:

--- a/tests/unit/workflows/temporal/test_remediation_issue_3511.py
+++ b/tests/unit/workflows/temporal/test_remediation_issue_3511.py
@@ -144,3 +144,45 @@ async def test_control_plane_executor_requires_branch_for_corrected_input() -> N
     assert result["status"] == "denied"
     assert result["reason"] == "checkpoint_branch_required_for_corrected_input"
     assert result["changedFields"] == ["model"]
+
+
+async def test_typed_evidence_operations_delegate_to_their_bounded_classes() -> None:
+    service = object.__new__(RemediationEvidenceToolService)
+    seen: list[str] = []
+
+    async def read_evidence_page(**kwargs):
+        seen.append(kwargs["evidence_class"])
+        return kwargs["evidence_class"]
+
+    service.read_evidence_page = read_evidence_page
+
+    assert await service.read_execution_and_step_details(
+        remediation_workflow_id="remediation"
+    ) == "execution_and_steps"
+    assert await service.read_checkpoint_and_recovery_manifests(
+        remediation_workflow_id="remediation"
+    ) == "checkpoint_and_recovery"
+    assert await service.read_bridge_event_pages(
+        remediation_workflow_id="remediation"
+    ) == "bridge_events"
+    assert await service.read_capture_and_resource_manifests(
+        remediation_workflow_id="remediation"
+    ) == "capture"
+    assert await service.read_cleanup_and_janitor_evidence(
+        remediation_workflow_id="remediation"
+    ) == "lifecycle"
+    assert await service.read_branch_and_publication_evidence(
+        remediation_workflow_id="remediation"
+    ) == "checkpoint_branches"
+    assert await service.read_policy_and_approval_snapshots(
+        remediation_workflow_id="remediation"
+    ) == "policy"
+    assert seen == [
+        "execution_and_steps",
+        "checkpoint_and_recovery",
+        "bridge_events",
+        "capture",
+        "lifecycle",
+        "checkpoint_branches",
+        "policy",
+    ]

--- a/tests/unit/workflows/temporal/test_remediation_issue_3511.py
+++ b/tests/unit/workflows/temporal/test_remediation_issue_3511.py
@@ -1,0 +1,146 @@
+"""Bounded remaining contract coverage for MoonLadderStudios/MoonMind#3511."""
+
+from __future__ import annotations
+
+from moonmind.workflows.temporal.remediation_actions import (
+    RemediationActionAuthorityService,
+    RemediationPermissionSet,
+    RemediationSecurityProfile,
+    remediation_changes_require_checkpoint_branch,
+)
+from moonmind.workflows.temporal.remediation_tools import (
+    MoonMindControlPlaneRemediationActionExecutor,
+    RemediationTargetHealthSnapshot,
+)
+
+
+def test_corrected_execution_choices_require_checkpoint_branch() -> None:
+    original = {
+        "instructions": "Retry unchanged.",
+        "runtime": "omnigent",
+        "model": "gpt-5",
+        "providerProfile": "profile-a",
+        "launchPolicy": "standard",
+        "repositoryBranch": "main",
+        "workspacePolicy": "continue_from_previous_execution",
+        "publishMode": "pr",
+    }
+
+    assert remediation_changes_require_checkpoint_branch(
+        original=original,
+        proposed=dict(original),
+    ) == ()
+    assert remediation_changes_require_checkpoint_branch(
+        original=original,
+        proposed={**original, "model": "gpt-5.1", "publishMode": "none"},
+    ) == ("model", "publishMode")
+
+
+def test_requested_control_plane_actions_are_in_typed_catalog() -> None:
+    expected = {
+        "host.drain",
+        "host.stop",
+        "host.restart",
+        "host.remove",
+        "host_lease.reconcile_stale",
+        "cleanup.request_janitor",
+        "cleanup.verify",
+        "target.annotate",
+        "target.verify",
+    }
+    service = RemediationActionAuthorityService(session=None)  # type: ignore[arg-type]
+    catalog = service.list_allowed_actions(
+        permissions=RemediationPermissionSet(
+            can_view_target=True,
+            can_request_admin_profile=True,
+        ),
+        security_profile=RemediationSecurityProfile(
+            profile_ref="admin",
+            execution_principal="service:test",
+            allowed_action_kinds=tuple(expected),
+        ),
+    )
+
+    assert expected == {item["actionKind"] for item in catalog}
+
+
+async def test_control_plane_executor_dispatches_typed_adapter_with_evidence() -> None:
+    calls: list[str] = []
+
+    async def adapter(action_request, guard_result, target_health):
+        calls.append(action_request["actionKind"])
+        assert guard_result["executable"] is True
+        assert target_health.workflow_id == "target"
+        return {
+            "status": "accepted",
+            "beforeEvidenceRefs": ["artifact://before"],
+            "afterEvidenceRefs": ["artifact://after"],
+        }
+
+    executor = MoonMindControlPlaneRemediationActionExecutor(
+        {"host.restart": adapter}
+    )
+    result = await executor.execute_action(
+        action_request={"actionKind": "host.restart"},
+        guard_result={"executable": True},
+        target_health=RemediationTargetHealthSnapshot(
+            workflow_id="target",
+            pinned_run_id="run",
+            current_run_id="run",
+            state="running",
+            close_status=None,
+            title=None,
+            summary=None,
+            target_run_changed=False,
+        ),
+    )
+
+    assert calls == ["host.restart"]
+    assert result["status"] == "accepted"
+    assert result["beforeEvidenceRefs"] == ["artifact://before"]
+
+
+async def test_control_plane_executor_denies_unwired_action() -> None:
+    executor = MoonMindControlPlaneRemediationActionExecutor({})
+    result = await executor.execute_action(
+        action_request={"actionKind": "host.remove"},
+        guard_result={"executable": True},
+        target_health=RemediationTargetHealthSnapshot(
+            workflow_id="target",
+            pinned_run_id="run",
+            current_run_id="run",
+            state="running",
+            close_status=None,
+            title=None,
+            summary=None,
+            target_run_changed=False,
+        ),
+    )
+
+    assert result["status"] == "denied"
+    assert result["reason"] == "control_plane_adapter_unavailable"
+
+
+async def test_control_plane_executor_requires_branch_for_corrected_input() -> None:
+    executor = MoonMindControlPlaneRemediationActionExecutor({})
+    result = await executor.execute_action(
+        action_request={
+            "actionKind": "execution.resume",
+            "parameters": {"inputChanges": {"model": "gpt-5.1"}},
+        },
+        guard_result={"executable": True},
+        target_health=RemediationTargetHealthSnapshot(
+            workflow_id="target",
+            pinned_run_id="run",
+            current_run_id="run",
+            state="running",
+            close_status=None,
+            title=None,
+            summary=None,
+            target_run_changed=False,
+        ),
+    )
+
+    assert result["status"] == "denied"
+    assert result["reason"] == "checkpoint_branch_required_for_corrected_input"
+    assert result["changedFields"] == ["model"]

--- a/tests/unit/workflows/temporal/test_remediation_issue_3511.py
+++ b/tests/unit/workflows/temporal/test_remediation_issue_3511.py
@@ -146,6 +146,53 @@ async def test_control_plane_executor_requires_branch_for_corrected_input() -> N
     assert result["changedFields"] == ["model"]
 
 
+async def test_control_plane_executor_compares_authoritative_input_snapshots() -> None:
+    called = False
+
+    async def adapter(*_args):
+        nonlocal called
+        called = True
+        return {"status": "accepted"}
+
+    executor = MoonMindControlPlaneRemediationActionExecutor(
+        {"execution.resume": adapter}
+    )
+    result = await executor.execute_action(
+        action_request={
+            "actionKind": "execution.resume",
+            # A caller cannot hide an authoritative change with an empty hint.
+            "parameters": {"inputChanges": {}},
+        },
+        guard_result={
+            "executable": True,
+            "originalInputs": {
+                "runtime": "omnigent",
+                "providerProfile": "profile-a",
+                "publishMode": "pr",
+            },
+            "proposedInputs": {
+                "runtime": "omnigent",
+                "providerProfile": "profile-b",
+                "publishMode": "none",
+            },
+        },
+        target_health=RemediationTargetHealthSnapshot(
+            workflow_id="target",
+            pinned_run_id="run",
+            current_run_id="run",
+            state="running",
+            close_status=None,
+            title=None,
+            summary=None,
+            target_run_changed=False,
+        ),
+    )
+
+    assert called is False
+    assert result["status"] == "denied"
+    assert result["changedFields"] == ["providerProfile", "publishMode"]
+
+
 async def test_typed_evidence_operations_delegate_to_their_bounded_classes() -> None:
     service = object.__new__(RemediationEvidenceToolService)
     seen: list[str] = []

--- a/tests/unit/workflows/temporal/workflows/test_managed_runtime_workspace_cleanup.py
+++ b/tests/unit/workflows/temporal/workflows/test_managed_runtime_workspace_cleanup.py
@@ -74,6 +74,34 @@ async def test_managed_runtime_workspace_cleanup_invokes_cleanup_activity(
 
 
 @pytest.mark.asyncio
+async def test_managed_runtime_cleanup_forwards_remediation_action(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    supplied = {
+        "actionKind": "cleanup.request_janitor",
+        "cleanupRef": "artifact://cleanup",
+        "targetWorkflowId": "target",
+        "expectedState": "pending",
+        "requestId": "request-1",
+    }
+
+    async def _execute_activity(
+        activity_name: str, payload: dict[str, Any], **kwargs: Any
+    ) -> dict[str, Any]:
+        assert activity_name == "agent_runtime.cleanup_managed_runtime_files"
+        assert payload == supplied
+        return {"errors": ()}
+
+    monkeypatch.setattr(cleanup_module.workflow, "set_current_details", lambda _: None)
+    monkeypatch.setattr(
+        cleanup_module.workflow, "upsert_search_attributes", lambda _: None
+    )
+    monkeypatch.setattr(cleanup_module.workflow, "execute_activity", _execute_activity)
+
+    await MoonMindManagedRuntimeWorkspaceCleanupWorkflow().run(supplied)
+
+
+@pytest.mark.asyncio
 async def test_managed_runtime_workspace_cleanup_marks_errors_degraded(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/workflows/temporal/workflows/test_managed_session_reconcile.py
+++ b/tests/unit/workflows/temporal/workflows/test_managed_session_reconcile.py
@@ -68,6 +68,33 @@ async def test_managed_session_reconcile_updates_terminal_visibility(
 
 
 @pytest.mark.asyncio
+async def test_managed_session_reconcile_forwards_remediation_action(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    supplied = {
+        "actionKind": "workload.reap_orphan_container",
+        "containerRef": "container-1",
+        "expectedState": "orphaned",
+        "requestId": "request-1",
+    }
+
+    async def _execute_activity(
+        activity_name: str, payload: dict[str, Any], **kwargs: Any
+    ) -> dict[str, Any]:
+        assert activity_name == "agent_runtime.reconcile_managed_sessions"
+        assert payload == supplied
+        return {"degradedSessionRecords": 0}
+
+    monkeypatch.setattr(reconcile_module.workflow, "set_current_details", lambda _: None)
+    monkeypatch.setattr(
+        reconcile_module.workflow, "upsert_search_attributes", lambda _: None
+    )
+    monkeypatch.setattr(reconcile_module.workflow, "execute_activity", _execute_activity)
+
+    await MoonMindManagedSessionReconcileWorkflow().run(supplied)
+
+
+@pytest.mark.asyncio
 async def test_managed_session_reconcile_passes_orphan_reap_summary_through(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
Implement GitHub issue MoonLadderStudios/MoonMind#3511.

## MoonSpec verification incomplete

This pull request was opened as a **draft** because MoonSpec verification did not approve publication (verdict ADDITIONAL_WORK_NEEDED) and the bounded remediation budget was exhausted with remaining implementation work.

- Gate outcome: MoonSpec verification did not approve publication. verdict ADDITIONAL_WORK_NEEDED. The latest remediation makes helper-container restart/reap target a single label-owned container and separates host.remove, stale Provider Profile lease eviction, and stale host-lease reconciliation. The issue is still not fully implemented. cleanup.request_janitor only checks that cleanupRef is non-empty, then performs the ordinary global retention cleanup and echoes the supplied target/expected-state fields without resolving or authorizing the referenced cleanup target. The helper-container activity also drops targetWorkflowId before the owning controller, so it proves MoonMind label ownership but not linkage to the remediation target. New tests cover two host branches but do not exercise. verification report art_01KYK62T4TDP85TYB1ABBN1E36.
- Verification report: art_01KYK62T4TDP85TYB1ABBN1E36
- Verification gate result: art_01KYK62T2XYWPSRAH4FJHZ2WB0

Review the verification evidence before marking this pull request ready for review.