### PR TITLE
Fix managed-session recovery for failed workflows

### DIFF
--- a/moonmind/schemas/managed_session_models.py
+++ b/moonmind/schemas/managed_session_models.py
@@ -1212,6 +1212,7 @@ class LaunchCodexManagedSessionRequest(_CodexManagedSessionRemoteContract):
     session_id: NonBlankStr = Field(..., alias="sessionId")
     session_epoch: int = Field(1, alias="sessionEpoch", ge=1)
     thread_id: NonBlankStr = Field(..., alias="threadId")
+    replace_existing: bool = Field(False, alias="replaceExisting")
     workspace_path: NonBlankStr = Field(..., alias="workspacePath")
     session_workspace_path: NonBlankStr = Field(
         ..., alias="sessionWorkspacePath"

--- a/moonmind/workflows/adapters/codex_session_adapter.py
+++ b/moonmind/workflows/adapters/codex_session_adapter.py
@@ -573,6 +573,7 @@ class CodexSessionAdapter(ManagedAgentAdapter):
         session_image_ref: str,
         task_workflow_id: str | None = None,
         defer_turn_instructions_until_session_launch: bool = True,
+        replace_existing_on_resume_mismatch: bool = False,
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
@@ -594,6 +595,9 @@ class CodexSessionAdapter(ManagedAgentAdapter):
         self._task_workflow_id = str(task_workflow_id or "").strip() or None
         self._defer_turn_instructions_until_session_launch = bool(
             defer_turn_instructions_until_session_launch
+        )
+        self._replace_existing_on_resume_mismatch = bool(
+            replace_existing_on_resume_mismatch
         )
         self._run_states: dict[str, CodexSessionExecutionState] = {}
 
@@ -1777,6 +1781,7 @@ class CodexSessionAdapter(ManagedAgentAdapter):
         profile: ManagedRuntimeProfile,
     ) -> CodexManagedSessionHandle:
         snapshot = await self._load_snapshot(binding.workflow_id)
+        replace_existing = False
         if snapshot.container_id and snapshot.thread_id:
             locator = self._locator_from_snapshot(snapshot)
             try:
@@ -1793,6 +1798,7 @@ class CodexSessionAdapter(ManagedAgentAdapter):
                         binding.session_id,
                     )
                     snapshot = refreshed_snapshot
+                    replace_existing = self._replace_existing_on_resume_mismatch
                 else:
                     refreshed_locator = self._locator_from_snapshot(refreshed_snapshot)
                     logger.warning(
@@ -1814,6 +1820,7 @@ class CodexSessionAdapter(ManagedAgentAdapter):
                             refreshed_locator.session_id,
                         )
                         snapshot = refreshed_snapshot
+                        replace_existing = self._replace_existing_on_resume_mismatch
                     else:
                         await self._signal_control_action(
                             action="resume_session",
@@ -1861,6 +1868,7 @@ class CodexSessionAdapter(ManagedAgentAdapter):
             sessionId=active_binding.session_id,
             sessionEpoch=active_binding.session_epoch,
             threadId=self._default_thread_id(active_binding),
+            replaceExisting=replace_existing,
             workspacePath=workspace_path,
             sessionWorkspacePath=str(self._session_root(binding) / "session"),
             artifactSpoolPath=str(self._session_root(binding) / "artifacts"),
@@ -1875,8 +1883,12 @@ class CodexSessionAdapter(ManagedAgentAdapter):
                 else {}
             ),
         )
+        launch_request_payload = launch_request.model_dump(mode="json", by_alias=True)
+        if not replace_existing:
+            # Preserve the pre-replacement activity payload for Temporal replay.
+            launch_request_payload.pop("replaceExisting", None)
         launch_payload = {
-            "request": launch_request.model_dump(mode="json", by_alias=True),
+            "request": launch_request_payload,
             "profile": profile.model_dump(mode="json", by_alias=True),
         }
         handle = await self._coerce_handle(self._launch_session(launch_payload))

--- a/moonmind/workflows/temporal/runtime/managed_session_controller.py
+++ b/moonmind/workflows/temporal/runtime/managed_session_controller.py
@@ -2966,7 +2966,8 @@ class DockerCodexManagedSessionController:
         if self._session_store is not None:
             existing_record = self._session_store.load(request.session_id)
             if (
-                existing_record is not None
+                not request.replace_existing
+                and existing_record is not None
                 and self._request_matches_record(request, existing_record)
                 and await self._container_exists(existing_record.container_id)
                 and await self._container_uses_current_image(

--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -24,6 +24,7 @@ with workflow.unsafe.imports_passed_through():
     )
     from moonmind.schemas.managed_session_models import (
         CodexManagedSessionBinding,
+        CodexManagedSessionSnapshot,
         CodexManagedSessionWorkflowInput,
         SendCodexManagedSessionTurnRequest,
         build_codex_managed_session_turn_environment,
@@ -75,6 +76,9 @@ with workflow.unsafe.imports_passed_through():
     )
 
 TERMINAL_CONTRACT_CONTINUATION_PATCH_ID = "agent-run-terminal-contract-continuation-v1"
+TERMINAL_CONTRACT_RUNTIME_FAILURE_AUTHORITY_PATCH_ID = (
+    "agent-run-terminal-contract-runtime-failure-authority-v1"
+)
 PR_RESOLVER_OWNED_CONTINUATION_PATCH_ID = "agent-run-pr-resolver-owned-continuation-v1"
 PR_RESOLVER_CONTINUATION_OBSERVABILITY_PATCH_ID = (
     "agent-run-pr-resolver-continuation-observability-v1"
@@ -401,6 +405,9 @@ MANAGED_SESSION_PR_PUBLISH_BASE_BRANCH_PATCH_ID = (
 )
 MANAGED_SESSION_BRIDGE_EVENTS_ACTIVITY_PATCH_ID = (
     "agent-run-managed-session-bridge-events-activity-v1"
+)
+MANAGED_SESSION_REPLACE_ON_LOCATOR_MISMATCH_PATCH_ID = (
+    "agent-run-managed-session-replace-on-locator-mismatch-v1"
 )
 
 # Module-level activity catalog — deterministic, safe for Temporal replay.
@@ -2116,6 +2123,16 @@ class MoonMindAgentRun:
         """Enforce terminal evidence at the runtime-neutral AgentRun boundary."""
         if request.terminal_contract is None:
             return result
+        try:
+            runtime_failure_authority_enabled = workflow.patched(
+                TERMINAL_CONTRACT_RUNTIME_FAILURE_AUTHORITY_PATCH_ID
+            )
+        except Exception as exc:
+            if type(exc).__name__ != "_NotInWorkflowEventLoopError":
+                raise
+            runtime_failure_authority_enabled = True
+        if runtime_failure_authority_enabled and result.failure_class is not None:
+            return result
         workspace_path = str(
             (result.metadata or {}).get("workspacePath")
             or (request.workspace_spec or {}).get("workspacePath")
@@ -2319,16 +2336,29 @@ class MoonMindAgentRun:
                 snapshot_request,
                 cancellation_type=ActivityCancellationType.TRY_CANCEL,
             )
-            epoch_value = snapshot.get("sessionEpoch")
-            turn_request = SendCodexManagedSessionTurnRequest(
-                sessionId=request.managed_session.session_id,
-                sessionEpoch=int(
+            if runtime_failure_authority_enabled:
+                authoritative_snapshot = CodexManagedSessionSnapshot.model_validate(
+                    snapshot
+                )
+                session_id = authoritative_snapshot.binding.session_id
+                session_epoch = authoritative_snapshot.binding.session_epoch
+                container_id = authoritative_snapshot.container_id
+                thread_id = authoritative_snapshot.thread_id
+            else:
+                epoch_value = snapshot.get("sessionEpoch")
+                session_id = request.managed_session.session_id
+                session_epoch = int(
                     epoch_value
                     if epoch_value is not None
                     else request.managed_session.session_epoch
-                ),
-                containerId=snapshot.get("containerId"),
-                threadId=snapshot.get("threadId"),
+                )
+                container_id = snapshot.get("containerId")
+                thread_id = snapshot.get("threadId")
+            turn_request = SendCodexManagedSessionTurnRequest(
+                sessionId=session_id,
+                sessionEpoch=session_epoch,
+                containerId=container_id,
+                threadId=thread_id,
                 instructions=_terminal_contract_continuation_instruction(missing),
                 reason="incomplete_terminal_contract",
                 requestId=(
@@ -4399,6 +4429,9 @@ class MoonMindAgentRun:
                         use_publish_bridge_events_activity = workflow.patched(
                             MANAGED_SESSION_BRIDGE_EVENTS_ACTIVITY_PATCH_ID
                         )
+                        replace_existing_on_resume_mismatch = workflow.patched(
+                            MANAGED_SESSION_REPLACE_ON_LOCATOR_MISMATCH_PATCH_ID
+                        )
                         if request.managed_session is None:
                             raise ApplicationError(
                                 "managedSession is required for Codex session-backed runs",
@@ -4547,6 +4580,9 @@ class MoonMindAgentRun:
                             launch_context_builder=_launch_context_builder,
                             defer_turn_instructions_until_session_launch=(
                                 defer_turn_instructions_until_session_launch
+                            ),
+                            replace_existing_on_resume_mismatch=(
+                                replace_existing_on_resume_mismatch
                             ),
                         )
                     else:

--- a/tests/integration/reliability/test_escaped_failure_journeys.py
+++ b/tests/integration/reliability/test_escaped_failure_journeys.py
@@ -582,8 +582,8 @@ async def test_nested_yield_continuation_replays_through_production_agent_run_ro
             return evaluated.model_dump(mode="json", by_alias=True)
         if name == "agent_runtime.load_session_snapshot":
             return {
-                "sessionId": binding.session_id,
-                "sessionEpoch": binding.session_epoch,
+                "binding": binding.model_dump(mode="json", by_alias=True),
+                "status": "active",
                 "containerId": container_id,
                 "threadId": thread_id,
             }

--- a/tests/unit/schemas/test_managed_session_models.py
+++ b/tests/unit/schemas/test_managed_session_models.py
@@ -188,6 +188,23 @@ def test_launch_codex_managed_session_request_freezes_remote_container_defaults(
     assert request.control_mode == "remote_container"
     assert request.protocol == "codex_app_server"
     assert request.session_epoch == 1
+    assert request.replace_existing is False
+
+
+def test_launch_codex_managed_session_request_serializes_explicit_replacement() -> None:
+    request = LaunchCodexManagedSessionRequest(
+        agentRunId="task-123",
+        sessionId="sess-123",
+        threadId="thread-1",
+        replaceExisting=True,
+        workspacePath="/work/task/repo",
+        sessionWorkspacePath="/work/task/session",
+        artifactSpoolPath="/work/task/artifacts",
+        codexHomePath="/work/task/codex-home",
+        imageRef="moonmind:latest",
+    )
+
+    assert request.model_dump(by_alias=True)["replaceExisting"] is True
 
 def test_launch_managed_session_request_rejects_claude_code_runtime_family() -> None:
     with pytest.raises(ValidationError, match="Input should be 'codex'"):

--- a/tests/unit/services/temporal/runtime/test_managed_session_controller.py
+++ b/tests/unit/services/temporal/runtime/test_managed_session_controller.py
@@ -4580,6 +4580,58 @@ async def test_controller_duplicate_launch_reuses_existing_live_record(
 
 
 @pytest.mark.asyncio
+async def test_controller_explicit_replacement_bypasses_live_record_reuse(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = ManagedSessionStore(tmp_path / "session-store")
+    request = LaunchCodexManagedSessionRequest(
+        agentRunId="task-1",
+        sessionId="sess-1",
+        threadId="logical-thread-1",
+        replaceExisting=True,
+        workspacePath="/tmp/agent_jobs/task-1/repo",
+        sessionWorkspacePath="/tmp/agent_jobs/task-1/session",
+        artifactSpoolPath="/tmp/agent_jobs/task-1/artifacts",
+        codexHomePath="/tmp/codex-home",
+        imageRef="img",
+    )
+    store.save(
+        CodexManagedSessionRecord(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            agentRunId="task-1",
+            containerId="ctr-broken",
+            threadId="logical-thread-1",
+            runtimeId="codex_cli",
+            imageRef="img",
+            controlUrl="docker-exec://ctr-broken",
+            status="ready",
+            workspacePath=request.workspace_path,
+            sessionWorkspacePath=request.session_workspace_path,
+            artifactSpoolPath=request.artifact_spool_path,
+            startedAt="2026-04-06T12:00:00Z",
+        )
+    )
+    runner = AsyncMock(side_effect=AssertionError("live record was inspected"))
+    controller = DockerCodexManagedSessionController(
+        workspace_volume_name="agent_workspaces",
+        codex_volume_name="codex_auth_volume",
+        workspace_root="/tmp/agent_jobs",
+        session_store=store,
+        command_runner=runner,
+    )
+    replacement = AsyncMock(side_effect=RuntimeError("replacement launch reached"))
+    monkeypatch.setattr(controller, "_ensure_workspace_paths", replacement)
+
+    with pytest.raises(RuntimeError, match="replacement launch reached"):
+        await controller.launch_session(request)
+
+    replacement.assert_awaited_once_with(request)
+    runner.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_controller_duplicate_launch_recreates_stale_mutable_image(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit/workflows/adapters/test_codex_session_adapter.py
+++ b/tests/unit/workflows/adapters/test_codex_session_adapter.py
@@ -4034,8 +4034,10 @@ async def test_start_retries_existing_session_status_after_locator_mismatch(
         "threadId": "thread-cleared",
     }
 
+@pytest.mark.parametrize("replacement_enabled", [False, True])
 async def test_start_relaunches_session_when_refreshed_locator_still_mismatches(
     tmp_path: Path,
+    replacement_enabled: bool,
 ) -> None:
     binding = _binding().model_copy(update={"session_epoch": 7})
     stale_snapshot_binding = binding.model_copy(update={"session_epoch": 6})
@@ -4135,6 +4137,7 @@ async def test_start_relaunches_session_when_refreshed_locator_still_mismatches(
         apply_session_control_action=_apply_control_action,
         workspace_root=str(tmp_path / "agent_jobs"),
         session_image_ref="ghcr.io/moonladderstudios/moonmind:latest",
+        replace_existing_on_resume_mismatch=replacement_enabled,
     )
 
     handle = await adapter.start(_request(binding))
@@ -4150,6 +4153,10 @@ async def test_start_relaunches_session_when_refreshed_locator_still_mismatches(
     launch_request = launch_calls[0]["request"]
     assert launch_request["sessionEpoch"] == 7
     assert launch_request["threadId"] == f"thread:{binding.session_id}:7"
+    if replacement_enabled:
+        assert launch_request["replaceExisting"] is True
+    else:
+        assert "replaceExisting" not in launch_request
     assert send_turn_calls[0].container_id == "container-fresh"
     assert send_turn_calls[0].thread_id == "thread-fresh"
     assert attach_calls == [

--- a/tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py
@@ -98,6 +98,24 @@ def _request_with_terminal_contract() -> AgentExecutionRequest:
     )
 
 
+def _terminal_contract_snapshot(
+    *,
+    session_epoch: int,
+    container_id: str = "ctr-1",
+    thread_id: str = "thr-1",
+) -> dict[str, Any]:
+    binding = _managed_session_request().managed_session
+    assert binding is not None
+    return {
+        "binding": binding.model_copy(
+            update={"session_epoch": session_epoch}
+        ).model_dump(mode="json", by_alias=True),
+        "status": "active",
+        "containerId": container_id,
+        "threadId": thread_id,
+    }
+
+
 async def test_terminal_contract_continuation_is_agent_run_owned_and_bounded(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -135,7 +153,11 @@ async def test_terminal_contract_continuation_is_agent_run_owned_and_bounded(
                 }
             return {"summary": "recovered", "metadata": {}}
         if name == "agent_runtime.load_session_snapshot":
-            return {"sessionEpoch": 0, "containerId": "ctr-1", "threadId": "thr-1"}
+            return _terminal_contract_snapshot(
+                session_epoch=3,
+                container_id="ctr-reset",
+                thread_id="thr-reset",
+            )
         if name == "agent_runtime.send_turn":
             return {"status": "completed"}
         if name == "agent_runtime.fetch_result":
@@ -160,13 +182,92 @@ async def test_terminal_contract_continuation_is_agent_run_owned_and_bounded(
     ]
     turn = calls[2][1]
     assert turn.request_id == "idem-managed-1:terminal-contract:1"
-    assert turn.session_epoch == 0
+    assert turn.session_epoch == 3
+    assert turn.container_id == "ctr-reset"
+    assert turn.thread_id == "thr-reset"
     assert turn.environment == {
         "MOONMIND_ACTIVE_SKILLS_DIR": "/work/runtime/skills_active/snapshot-retry",
         "MOONMIND_STEP_EXECUTION_ID": (
             "wf-task-1:run-1:batch-workflows:execution:2"
         ),
     }
+
+
+async def test_terminal_contract_preserves_primary_runtime_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _configure_workflow_runtime(monkeypatch)
+    run = MoonMindAgentRun()
+    calls: list[str] = []
+
+    async def fake_activity(name: str, _payload: Any, **_kwargs: Any) -> Any:
+        calls.append(name)
+        raise AssertionError(name)
+
+    run._execute_routed_activity = fake_activity  # type: ignore[method-assign]
+    primary_failure = AgentRunResult(
+        summary="codex app-server turn/completed produced no assistant output",
+        failureClass="execution_error",
+        providerErrorCode="CODEX_EMPTY_ASSISTANT_OUTPUT",
+    )
+
+    result = await run._evaluate_terminal_contract(
+        request=_request_with_terminal_contract(),
+        result=primary_failure,
+    )
+
+    assert result == primary_failure
+    assert calls == []
+
+
+async def test_terminal_contract_replays_pre_authority_snapshot_behavior(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _configure_workflow_runtime(monkeypatch)
+    monkeypatch.setattr(
+        agent_run_module.workflow,
+        "patched",
+        lambda patch_id: (
+            patch_id
+            != agent_run_module.TERMINAL_CONTRACT_RUNTIME_FAILURE_AUTHORITY_PATCH_ID
+        ),
+    )
+    run = MoonMindAgentRun()
+    calls: list[tuple[str, Any]] = []
+    evaluations = 0
+
+    async def fake_activity(name: str, payload: Any, **_kwargs: Any) -> Any:
+        nonlocal evaluations
+        calls.append((name, payload))
+        if name == "agent_runtime.evaluate_terminal_evidence":
+            evaluations += 1
+            if evaluations == 1:
+                return {
+                    "summary": "missing",
+                    "failureClass": "execution_error",
+                    "metadata": {
+                        "terminalContractMissingEvidence": ["reports/result.json"]
+                    },
+                }
+            return {"summary": "recovered", "metadata": {}}
+        if name == "agent_runtime.load_session_snapshot":
+            return _terminal_contract_snapshot(session_epoch=3)
+        if name == "agent_runtime.send_turn":
+            return {"status": "completed"}
+        if name == "agent_runtime.fetch_result":
+            return {"summary": "continued", "metadata": {}}
+        raise AssertionError(name)
+
+    run._execute_routed_activity = fake_activity  # type: ignore[method-assign]
+
+    result = await run._evaluate_terminal_contract(
+        request=_request_with_terminal_contract(),
+        result=AgentRunResult(summary="initial"),
+    )
+
+    assert result.failure_class is None
+    turn = next(payload for name, payload in calls if name == "agent_runtime.send_turn")
+    assert turn.session_epoch == 1
 
 
 async def test_terminal_contract_fails_immediately_when_runtime_cannot_continue(
@@ -334,7 +435,7 @@ async def test_terminal_contract_continuation_exhaustion_is_agent_run_owned(
                 "metadata": {"terminalContractMissingEvidence": ["reports/result.json"]},
             }
         if name == "agent_runtime.load_session_snapshot":
-            return {"sessionEpoch": 1, "containerId": "ctr-1", "threadId": "thr-1"}
+            return _terminal_contract_snapshot(session_epoch=1)
         if name == "agent_runtime.send_turn":
             return {"status": "completed"}
         if name == "agent_runtime.fetch_result":
@@ -375,7 +476,7 @@ async def test_terminal_contract_provider_failure_retains_contract_context(
                 "metadata": {"terminalContractMissingEvidence": ["reports/result.json"]},
             }
         if name == "agent_runtime.load_session_snapshot":
-            return {"sessionEpoch": 1, "containerId": "ctr-1", "threadId": "thr-1"}
+            return _terminal_contract_snapshot(session_epoch=1)
         if name == "agent_runtime.send_turn":
             raise RuntimeError("provider transport unavailable")
         raise AssertionError(name)
@@ -408,7 +509,7 @@ async def test_terminal_contract_continuation_propagates_cancellation(
                 "metadata": {"terminalContractMissingEvidence": ["reports/result.json"]},
             }
         if name == "agent_runtime.load_session_snapshot":
-            return {"sessionEpoch": 1, "containerId": "ctr-1", "threadId": "thr-1"}
+            return _terminal_contract_snapshot(session_epoch=1)
         if name == "agent_runtime.send_turn":
             raise asyncio.CancelledError
         raise AssertionError(name)


### PR DESCRIPTION
## Summary

- preserve the authoritative managed-runtime failure instead of replacing it with a terminal-evidence recovery error
- consume the canonical nested managed-session snapshot when continuing a successful turn with incomplete terminal evidence
- explicitly replace a managed-session container after repeated authoritative locator mismatches instead of reusing the broken durable record
- patch-gate both workflow behavior changes so in-flight Temporal histories keep their previous command shapes
- update unit and escaped-failure replay coverage to use the real session snapshot contract

## Incident evidence

The review window contained three failed `MoonMind.UserWorkflow` executions. All three first encountered a 30-minute managed turn activity timeout and then failed during managed-session recovery:

- two retries repeatedly reported `sessionEpoch does not match the active managed session`; the adapter announced a fresh launch, but the controller idempotently returned the still-broken container
- one empty-assistant-output self-heal advanced the session from epoch 2 to epoch 3, while terminal-contract recovery paired the epoch-3 thread with the stale epoch-2 request and masked the primary provider failure as `STALE_TERMINAL_EVIDENCE`

A fresh Temporal visibility check found no additional failed workflow signatures in the window.

## Validation

- focused schema/controller/adapter/workflow suite: 258 passed
- updated adapter/workflow compatibility suite: 112 passed
- Temporal boundary selector: 3,237 passed; the one bind-mount Git-admin-path failure reran with the correct worktree mount and passed
- reliability journey selector: 27 passed
- AgentSession deployment safety validation passed
- terminology and status-domain audits passed
- `git diff --check` passed