### PR TITLE
GitHub Issue Implement: MoonLadderStudios/MoonMind#3509 — Complete Omnigent checkpoint capture and host-independent restore evidence

### DIFF
--- a/docs/Omnigent/OmnigentAdapter.md
+++ b/docs/Omnigent/OmnigentAdapter.md
@@ -351,7 +351,19 @@ Typed product controls for interrupt, stop, terminate, harvest, remove, generati
 
 ## 12. Recovery and checkpoints
 
-Omnigent checkpoints use the `external_state_ref` lane. Durable checkpoint identity may include profile, provider-lease, binding, host-lease, credential-generation, host, bridge-session, Omnigent-session, first-message, workspace-locator, diagnostics, terminal, and artifact refs, but never credentials or daemon paths.
+Omnigent checkpoints use the canonical Step Execution writer and its
+`external_state_ref` session lane. The attached v2 Omnigent manifest is complete
+only when it pins lineage; external state and digest; bridge cursor and
+first-message identity; profile, policy, effective launch, binding and lease
+refs; credential generation; resource/capture manifests; workspace locator,
+baseline, head/diff/checkpoint refs and digests; immutable inputs; branch and
+publication evidence; terminal/diagnostic refs; capture time; producer version;
+and a per-capability validation result.
+
+Session state, MoonMind-owned repository/workspace state, and host realization
+remain distinct. Credential fields are references and generations only. A
+container, mutable OAuth home, provider URL/id, or raw daemon/workspace path is
+never durable restore authority.
 
 Recovery chooses between:
 
@@ -359,6 +371,15 @@ Recovery chooses between:
 - **cold restore**, which reacquires the same profile, creates a new host lease, materializes validated artifact-backed state, and starts a fresh session.
 
 A branch always obtains independent host/session authority and does not concurrently reuse the original OAuth lease.
+
+Cold restore checks out the pinned baseline in a clean authorized workspace,
+applies the validated checkpoint/diff/head artifact, restores immutable
+instruction/context refs, and passes `externalStateRef` to a fresh Omnigent
+session. It reacquires the same Provider Profile under current capacity and
+credential-generation policy and may compile a new effective launch while
+retaining the source launch-policy evidence. Workflow Detail and APIs project
+live reattach, cold restore, and branch availability separately with reason
+codes, readiness/capacity blocks, artifact refs/digests, and validation status.
 
 ---
 

--- a/docs/Steps/StepExecutionsAndCheckpointing.md
+++ b/docs/Steps/StepExecutionsAndCheckpointing.md
@@ -623,6 +623,29 @@ MoonMind creates or updates checkpoint evidence at these canonical boundaries (`
 
 Checkpoint writes must be idempotent because Activities and workflow tasks may retry.
 
+For Omnigent, the canonical writer attaches one versioned `omnigentCheckpoint`
+object to this Step Execution checkpoint. Capture occurs after workspace
+preparation and before the first message, after each completed turn or logical
+step, before controlled drain/reset, before recovery or Checkpoint Branch
+creation, and during terminal harvest when recoverable state remains. These are
+logical lifecycle triggers mapped to the nearest canonical boundary above; they
+do not create an adapter-owned checkpoint lane.
+
+The Omnigent object preserves four separate authority planes:
+
+| Plane | Required evidence |
+| --- | --- |
+| Session | `externalStateRef` and digest, bridge/session/host ids, idempotency key, last committed bridge cursor, first-message id and digest, terminal and diagnostics refs |
+| Workspace | `WorkspaceLocator`, baseline commit, head/diff/checkpoint refs and digests, source/output branch and publication state |
+| Host realization | endpoint, execution profile, launch policy, effective-launch snapshot, Provider Profile, provider/host lease and binding refs, resource/capture manifests and patch capability |
+| Credentials | credential reference and generation only; never a credential body, OAuth home, or copied volume content |
+
+The object also pins workflow, run, logical-step, Step Execution, attempt and
+boundary lineage, immutable instruction/context refs, capture time, producer
+version, and its validation projection. A capability is `true` only when every
+evidence class it requires is independently resolvable. Partial capture records
+bounded reason codes and leaves the affected capability false.
+
 ### 9.2 Workspace checkpoint kinds
 
 Supported checkpoint kinds should be explicit.
@@ -673,6 +696,14 @@ Before a checkpoint can be used to start a new attempt or Resume execution, Moon
 7. workspace, branch, and commit consistency;
 8. checkpoint kind compatibility with the selected workspace policy;
 9. policy eligibility for replaying or preserving side effects.
+
+Omnigent restore validation additionally dereferences and digest-checks each
+required artifact, checks requested workflow/run/step lineage and repository
+baseline/head compatibility, and requires the current Provider Profile and
+credential generation to match. Provider URLs, raw local paths, container ids,
+OAuth volume contents, and provider-native ids are never artifact authority.
+Live session reattach, workspace cold restore, and branch creation are evaluated
+independently and return bounded machine-readable denial reasons.
 
 Validation failures must be typed, not prose. Canonical failure codes (`StepCheckpointValidationFailureCode`):
 

--- a/docs/Workflows/CheckpointBranchSystem.md
+++ b/docs/Workflows/CheckpointBranchSystem.md
@@ -1046,11 +1046,15 @@ fresh_omnigent_session_from_checkpoint
 
 Flow:
 
-1. validate the source checkpoint;
-2. restore or synthesize an isolated git work branch/workspace from MoonMind evidence;
+1. validate the complete source manifest, including artifact digests, lineage,
+   repository baseline/head, Provider Profile, and credential generation;
+2. restore an isolated clean workspace from its pinned baseline and
+   MoonMind-owned checkpoint/diff/head evidence;
 3. create a new Omnigent session;
-4. pass branch-turn instructions through `parameters.omnigent.prompt.instructionRef`;
-5. include prior Omnigent capture refs as evidence refs;
+4. restore immutable instruction/context refs and pass branch-turn instructions
+   through `parameters.omnigent.prompt.instructionRef`;
+5. pass the external-state artifact to the fresh session and retain the source
+   policy/effective-launch evidence while selecting a new authorized host;
 6. capture the new Omnigent session output into MoonMind artifacts;
 7. bind the new Omnigent result to the branch turn evidence.
 
@@ -1061,6 +1065,12 @@ The branch must use a new Omnigent idempotency key:
 ```
 
 It must not reuse the parent Omnigent attempt's idempotency key because branch-turn instructions produce a different first-message digest.
+
+Branch creation is unavailable unless the manifest's independent
+`branchCreationAvailable` projection is true. A live session alone cannot
+authorize a branch: workspace cold-restore authority must also be complete.
+Capacity/readiness blocks are reported separately from permanent evidence
+denials, and neither case may be presented as resumable.
 
 ### 12.2 v2 branch mode: provider continuation
 

--- a/frontend/src/entrypoints/workflow-detail.test.tsx
+++ b/frontend/src/entrypoints/workflow-detail.test.tsx
@@ -2403,7 +2403,12 @@ describe('Workflow Detail Entrypoint', () => {
               sourceWorkflowId: 'wf-source',
               sourceRunId: 'run-source',
               sessionRecoverable: false,
+              liveReattachReason: 'host_lease_expired',
               workspaceRecoverable: true,
+              branchCreationAvailable: false,
+              branchCreationReason: 'capacity_unavailable',
+              checkpointValidationStatus: 'valid',
+              requiredProfileRef: 'profile://codex',
               authoritativeWorkspaceCheckpointKind: 'worktree_archive',
               operatorGuidance: 'resume',
               evidence: [
@@ -2442,7 +2447,11 @@ describe('Workflow Detail Entrypoint', () => {
     expect(screen.getByText(/Resume from checkpoint is the default recovery action/)).toBeTruthy();
     expect(screen.getByText('artifact://checkpoint/before')).toBeTruthy();
     expect(screen.getByText('Session reattach:').parentElement?.textContent).toContain('unavailable');
+    expect(screen.getByText('Session reattach:').parentElement?.textContent).toContain('host lease expired');
     expect(screen.getByText('Workspace restore:').parentElement?.textContent).toContain('supported');
+    expect(screen.getByText('Checkpoint branch:').parentElement?.textContent).toContain('capacity unavailable');
+    expect(screen.getByText('Checkpoint validation:').parentElement?.textContent).toContain('valid');
+    expect(screen.getByText('Required profile:').parentElement?.textContent).toContain('profile://codex');
     expect(screen.getByText('Authoritative workspace checkpoint:').parentElement?.textContent).toContain('worktree archive');
     expect(fetchSpy).toHaveBeenCalledWith(
       '/api/executions/test-123/steps/apply/step-executions/2?source=temporal',

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -727,6 +727,16 @@ const RecoveryEligibilitySchema = z
     supportsSameSessionContinuation: z.boolean().nullable().optional(),
     sessionRecoverable: z.boolean().nullable().optional(),
     workspaceRecoverable: z.boolean().nullable().optional(),
+    branchCreationAvailable: z.boolean().nullable().optional(),
+    liveReattachReason: z.string().nullable().optional(),
+    workspaceRestoreReason: z.string().nullable().optional(),
+    branchCreationReason: z.string().nullable().optional(),
+    requiredProfileRef: z.string().nullable().optional(),
+    requiredPolicyRef: z.string().nullable().optional(),
+    capacityBlocked: z.boolean().nullable().optional(),
+    readinessBlocked: z.boolean().nullable().optional(),
+    checkpointDigests: z.record(z.string(), z.string()).default({}),
+    checkpointValidationStatus: z.string().nullable().optional(),
     authoritativeWorkspaceCheckpointKind: z.string().nullable().optional(),
     partialRecoveryReason: z.string().nullable().optional(),
     operatorGuidance: z.enum(['continue_same_session', 'resume_from_workspace_checkpoint', 'full_retry', 'fix_environment', 'manual_intervention', 'resume', 'needs_human']),
@@ -6745,10 +6755,28 @@ function RecoveryEvidencePanel({
           <li><strong>Checkpoint kind:</strong> {formatStatusLabel(recovery.checkpointKind)}</li>
         ) : null}
         {recovery?.sessionRecoverable != null ? (
-          <li><strong>Session reattach:</strong> {recovery.sessionRecoverable ? 'supported' : 'unavailable'}</li>
+          <li><strong>Session reattach:</strong> {recovery.sessionRecoverable ? 'supported' : `unavailable${recovery.liveReattachReason ? ` — ${formatStatusLabel(recovery.liveReattachReason)}` : ''}`}</li>
         ) : null}
         {recovery?.workspaceRecoverable != null ? (
-          <li><strong>Workspace restore:</strong> {recovery.workspaceRecoverable ? 'supported' : 'unavailable'}</li>
+          <li><strong>Workspace restore:</strong> {recovery.workspaceRecoverable ? 'supported' : `unavailable${recovery.workspaceRestoreReason ? ` — ${formatStatusLabel(recovery.workspaceRestoreReason)}` : ''}`}</li>
+        ) : null}
+        {recovery?.branchCreationAvailable != null ? (
+          <li><strong>Checkpoint branch:</strong> {recovery.branchCreationAvailable ? 'supported' : `unavailable${recovery.branchCreationReason ? ` — ${formatStatusLabel(recovery.branchCreationReason)}` : ''}`}</li>
+        ) : null}
+        {recovery?.checkpointValidationStatus ? (
+          <li><strong>Checkpoint validation:</strong> {formatStatusLabel(recovery.checkpointValidationStatus)}</li>
+        ) : null}
+        {recovery?.requiredProfileRef ? (
+          <li><strong>Required profile:</strong> <code className="text-xs break-all">{recovery.requiredProfileRef}</code></li>
+        ) : null}
+        {recovery?.requiredPolicyRef ? (
+          <li><strong>Required policy:</strong> <code className="text-xs break-all">{recovery.requiredPolicyRef}</code></li>
+        ) : null}
+        {recovery?.capacityBlocked ? (
+          <li><strong>Capacity:</strong> blocked</li>
+        ) : null}
+        {recovery?.readinessBlocked ? (
+          <li><strong>Readiness:</strong> blocked</li>
         ) : null}
         {recovery?.authoritativeWorkspaceCheckpointKind ? (
           <li><strong>Authoritative workspace checkpoint:</strong> {formatStatusLabel(recovery.authoritativeWorkspaceCheckpointKind)}</li>

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -11211,6 +11211,28 @@ export interface components {
             sessionRecoverable?: boolean | null;
             /** Workspacerecoverable */
             workspaceRecoverable?: boolean | null;
+            /** Branchcreationavailable */
+            branchCreationAvailable?: boolean | null;
+            /** Livereattachreason */
+            liveReattachReason?: string | null;
+            /** Workspacerestorereason */
+            workspaceRestoreReason?: string | null;
+            /** Branchcreationreason */
+            branchCreationReason?: string | null;
+            /** Requiredprofileref */
+            requiredProfileRef?: string | null;
+            /** Requiredpolicyref */
+            requiredPolicyRef?: string | null;
+            /** Capacityblocked */
+            capacityBlocked?: boolean | null;
+            /** Readinessblocked */
+            readinessBlocked?: boolean | null;
+            /** Checkpointdigests */
+            checkpointDigests?: {
+                [key: string]: string;
+            };
+            /** Checkpointvalidationstatus */
+            checkpointValidationStatus?: string | null;
             /** Authoritativeworkspacecheckpointkind */
             authoritativeWorkspaceCheckpointKind?: string | null;
             /** Partialrecoveryreason */

--- a/moonmind/omnigent/checkpoints.py
+++ b/moonmind/omnigent/checkpoints.py
@@ -22,6 +22,9 @@ if TYPE_CHECKING:
     from moonmind.schemas.workspace_locator_models import WorkspaceLocator
 
 _DIGEST = r"^sha256:[0-9a-f]{64}$"
+# Bound each manifest string so a structurally valid checkpoint cannot inflate the
+# Temporal ``step_checkpoint.create`` activity payload past the compact-history policy.
+_MAX_MANIFEST_FIELD_LENGTH = 4096
 _ARTIFACT_FIELDS = {
     "externalStateRef",
     "terminalRef",
@@ -95,7 +98,12 @@ class OmnigentCheckpointIdentity(BaseModel):
     attempt_ordinal: int = Field(..., alias="attemptOrdinal", ge=1)
     boundary: str = Field(..., min_length=1)
     provider_profile_id: str = Field(..., alias="providerProfileId", min_length=1)
-    credential_ref: str = Field(..., alias="credentialRef", min_length=1)
+    credential_ref: str = Field(
+        ...,
+        alias="credentialRef",
+        min_length=1,
+        pattern=r"^(credential|secret)://\S+$",
+    )
     credential_generation: int = Field(..., alias="credentialGeneration", ge=1)
     provider_lease_ref: str | None = Field(None, alias="providerLeaseRef")
     host_binding_ref: str = Field(..., alias="hostBindingRef", min_length=1)
@@ -135,8 +143,12 @@ class OmnigentCheckpointIdentity(BaseModel):
     workspace_checkpoint_digest: str = Field(
         ..., alias="workspaceCheckpointDigest", pattern=_DIGEST
     )
-    instruction_refs: list[str] = Field(default_factory=list, alias="instructionRefs")
-    context_refs: list[str] = Field(default_factory=list, alias="contextRefs")
+    instruction_refs: list[str] = Field(
+        default_factory=list, alias="instructionRefs", max_length=64
+    )
+    context_refs: list[str] = Field(
+        default_factory=list, alias="contextRefs", max_length=64
+    )
     source_branch: str = Field(..., alias="sourceBranch", min_length=1)
     output_branch: str | None = Field(None, alias="outputBranch")
     publication_state: str = Field(..., alias="publicationState", min_length=1)
@@ -152,6 +164,10 @@ class OmnigentCheckpointIdentity(BaseModel):
             raise ValueError("effectiveLaunchRef must identify an effective launch snapshot")
         dumped = self.model_dump(by_alias=True, mode="json", exclude_none=True)
         for field, value in _string_leaves(dumped):
+            if len(value) > _MAX_MANIFEST_FIELD_LENGTH:
+                raise ValueError(
+                    f"{field} exceeds the compact checkpoint field bound"
+                )
             lowered = value.lower()
             if any(marker in lowered for marker in ("bearer ", "token=", "password=")):
                 raise ValueError(f"{field} must be a reference, not credential data")
@@ -202,9 +218,12 @@ class OmnigentRestoreMaterial(BaseModel):
     workspace_checkpoint_ref: str = Field(alias="workspaceCheckpointRef")
     workspace_checkpoint_digest: str = Field(alias="workspaceCheckpointDigest")
     head_ref: str = Field(alias="headRef")
+    head_digest: str = Field(alias="headDigest")
     diff_ref: str | None = Field(None, alias="diffRef")
+    diff_digest: str | None = Field(None, alias="diffDigest")
     immutable_input_refs: list[str] = Field(alias="immutableInputRefs")
     external_state_ref: str = Field(alias="externalStateRef")
+    external_state_digest: str = Field(alias="externalStateDigest")
     provider_profile_id: str = Field(alias="providerProfileId")
     credential_generation: int = Field(alias="credentialGeneration")
     source_effective_launch_ref: str | None = Field(
@@ -241,6 +260,9 @@ def validate_restore_material(
     workflow_id: str,
     run_id: str,
     logical_step_id: str,
+    step_execution_id: str,
+    attempt_ordinal: int,
+    boundary: str,
     provider_profile_id: str,
     credential_generation: int,
     repository_baseline: str,
@@ -256,6 +278,15 @@ def validate_restore_material(
         logical_step_id,
     ):
         reasons.append("lineage_mismatch")
+    # A logical step can have multiple attempts and checkpoint boundaries; evidence
+    # from a different attempt must not restore an obsolete workspace state, so the
+    # complete Step Execution identity is validated, not just the logical lineage.
+    if (
+        checkpoint.step_execution_id,
+        checkpoint.attempt_ordinal,
+        checkpoint.boundary,
+    ) != (step_execution_id, attempt_ordinal, boundary):
+        reasons.append("step_execution_lineage_mismatch")
     if checkpoint.baseline_commit != repository_baseline:
         reasons.append("repository_baseline_mismatch")
     if checkpoint.head_commit != repository_head:
@@ -289,6 +320,14 @@ def validate_restore_material(
         actual = "sha256:" + hashlib.sha256(payload).hexdigest()
         if actual != expected_digest:
             reasons.append("artifact_digest_mismatch")
+    # The immutable instruction/context inputs carry no digests in the manifest, so
+    # confirm each one is at least dereferenceable before declaring the checkpoint
+    # restorable; otherwise the new session launches with missing immutable inputs.
+    for ref in (*checkpoint.instruction_refs, *checkpoint.context_refs):
+        try:
+            artifact_reader(ref)
+        except Exception:
+            reasons.append("immutable_input_unavailable")
     reasons = list(dict.fromkeys(reasons))[:20]
     cold = not reasons
     live = cold and all(
@@ -326,9 +365,12 @@ def materialize_cold_restore_inputs(
         workspaceCheckpointRef=checkpoint.workspace_checkpoint_ref,
         workspaceCheckpointDigest=checkpoint.workspace_checkpoint_digest,
         headRef=checkpoint.head_ref,
+        headDigest=checkpoint.head_digest,
         diffRef=checkpoint.diff_ref,
+        diffDigest=checkpoint.diff_digest,
         immutableInputRefs=[*checkpoint.instruction_refs, *checkpoint.context_refs],
         externalStateRef=checkpoint.external_state_ref,
+        externalStateDigest=checkpoint.external_state_digest,
         providerProfileId=checkpoint.provider_profile_id,
         credentialGeneration=checkpoint.credential_generation,
         sourceEffectiveLaunchRef=checkpoint.effective_launch_ref,

--- a/moonmind/omnigent/checkpoints.py
+++ b/moonmind/omnigent/checkpoints.py
@@ -1,16 +1,60 @@
-"""Host-independent recovery decisions for Omnigent OAuth checkpoints."""
+"""Host-independent capture and recovery contracts for Omnigent checkpoints."""
 
 from __future__ import annotations
 
+import hashlib
+from datetime import datetime
 from enum import Enum
-from typing import Any, Mapping
+from typing import TYPE_CHECKING, Any, Callable, Literal, Mapping
+from urllib.parse import urlparse
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+# ``WorkspaceLocator`` lives in ``moonmind.schemas``, whose package ``__init__``
+# imports ``moonmind.schemas.temporal_models``, which in turn imports this module
+# to type its ``omnigentCheckpoint`` field. Importing it at module top would make
+# the resolution order-dependent (a plain ``import moonmind.omnigent.checkpoints``
+# before ``moonmind.schemas`` raises a partial-initialization ImportError). Because
+# this module uses ``from __future__ import annotations`` the field annotations are
+# strings, so we can defer this import until after the models are declared and then
+# rebuild them. See the bottom of the file.
+if TYPE_CHECKING:
+    from moonmind.schemas.workspace_locator_models import WorkspaceLocator
+
+_DIGEST = r"^sha256:[0-9a-f]{64}$"
+_ARTIFACT_FIELDS = {
+    "externalStateRef",
+    "terminalRef",
+    "diagnosticsRef",
+    "resourceManifestRef",
+    "captureManifestRef",
+    "headRef",
+    "diffRef",
+    "workspaceCheckpointRef",
+    "instructionRef",
+    "contextRef",
+}
 
 
 class OmnigentRecoveryMode(str, Enum):
     LIVE_REATTACH = "live_reattach"
     COLD_RESTORE = "cold_restore"
+
+
+class OmnigentCheckpointValidation(BaseModel):
+    """Truthful, independently evaluated recovery projections."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    valid: bool
+    live_reattach_available: bool = Field(alias="liveReattachAvailable")
+    workspace_cold_restore_available: bool = Field(
+        alias="workspaceColdRestoreAvailable"
+    )
+    branch_creation_available: bool = Field(alias="branchCreationAvailable")
+    reasons: list[str] = Field(default_factory=list, max_length=20)
+    capacity_blocked: bool = Field(False, alias="capacityBlocked")
+    readiness_blocked: bool = Field(False, alias="readinessBlocked")
 
 
 class CandidateWorkspaceAuthority(BaseModel):
@@ -43,7 +87,15 @@ class CandidateWorkspaceAuthority(BaseModel):
 class OmnigentCheckpointIdentity(BaseModel):
     model_config = ConfigDict(populate_by_name=True, extra="forbid")
 
+    schema_version: Literal["v2"] = Field("v2", alias="schemaVersion")
+    workflow_id: str = Field(..., alias="workflowId", min_length=1)
+    run_id: str = Field(..., alias="runId", min_length=1)
+    logical_step_id: str = Field(..., alias="logicalStepId", min_length=1)
+    step_execution_id: str = Field(..., alias="stepExecutionId", min_length=1)
+    attempt_ordinal: int = Field(..., alias="attemptOrdinal", ge=1)
+    boundary: str = Field(..., min_length=1)
     provider_profile_id: str = Field(..., alias="providerProfileId", min_length=1)
+    credential_ref: str = Field(..., alias="credentialRef", min_length=1)
     credential_generation: int = Field(..., alias="credentialGeneration", ge=1)
     provider_lease_ref: str | None = Field(None, alias="providerLeaseRef")
     host_binding_ref: str = Field(..., alias="hostBindingRef", min_length=1)
@@ -53,10 +105,44 @@ class OmnigentCheckpointIdentity(BaseModel):
     omnigent_session_id: str | None = Field(None, alias="omnigentSessionId")
     bridge_session_id: str = Field(..., alias="bridgeSessionId", min_length=1)
     external_state_ref: str = Field(..., alias="externalStateRef", min_length=1)
+    external_state_digest: str = Field(..., alias="externalStateDigest", pattern=_DIGEST)
     idempotency_key: str = Field(..., alias="idempotencyKey", min_length=1)
     terminal_ref: str | None = Field(None, alias="terminalRef")
     diagnostics_ref: str | None = Field(None, alias="diagnosticsRef")
     effective_launch_ref: str | None = Field(None, alias="effectiveLaunchRef", min_length=1)
+    execution_profile_ref: str = Field(..., alias="executionProfileRef", min_length=1)
+    launch_policy_ref: str = Field(..., alias="launchPolicyRef", min_length=1)
+    last_bridge_event_cursor: str | None = Field(None, alias="lastBridgeEventCursor")
+    first_message_id: str | None = Field(None, alias="firstMessageId")
+    first_message_digest: str | None = Field(None, alias="firstMessageDigest", pattern=_DIGEST)
+    resource_manifest_ref: str | None = Field(None, alias="resourceManifestRef")
+    resource_manifest_digest: str | None = Field(
+        None, alias="resourceManifestDigest", pattern=_DIGEST
+    )
+    capture_manifest_ref: str | None = Field(None, alias="captureManifestRef")
+    capture_manifest_digest: str | None = Field(
+        None, alias="captureManifestDigest", pattern=_DIGEST
+    )
+    patch_capable: bool = Field(False, alias="patchCapable")
+    workspace_locator: WorkspaceLocator = Field(..., alias="workspaceLocator")
+    baseline_commit: str = Field(..., alias="baselineCommit", min_length=1)
+    head_commit: str = Field(..., alias="headCommit", min_length=1)
+    head_ref: str = Field(..., alias="headRef", min_length=1)
+    head_digest: str = Field(..., alias="headDigest", pattern=_DIGEST)
+    diff_ref: str | None = Field(None, alias="diffRef")
+    diff_digest: str | None = Field(None, alias="diffDigest", pattern=_DIGEST)
+    workspace_checkpoint_ref: str = Field(..., alias="workspaceCheckpointRef", min_length=1)
+    workspace_checkpoint_digest: str = Field(
+        ..., alias="workspaceCheckpointDigest", pattern=_DIGEST
+    )
+    instruction_refs: list[str] = Field(default_factory=list, alias="instructionRefs")
+    context_refs: list[str] = Field(default_factory=list, alias="contextRefs")
+    source_branch: str = Field(..., alias="sourceBranch", min_length=1)
+    output_branch: str | None = Field(None, alias="outputBranch")
+    publication_state: str = Field(..., alias="publicationState", min_length=1)
+    captured_at: datetime = Field(..., alias="capturedAt")
+    producer_version: str = Field(..., alias="producerVersion", min_length=1)
+    validation: OmnigentCheckpointValidation
 
     @model_validator(mode="after")
     def _reject_raw_credential_like_values(self) -> "OmnigentCheckpointIdentity":
@@ -64,13 +150,190 @@ class OmnigentCheckpointIdentity(BaseModel):
             "omnigent-launch:sha256:"
         ):
             raise ValueError("effectiveLaunchRef must identify an effective launch snapshot")
-        for field, value in self.model_dump(mode="json").items():
-            if not isinstance(value, str):
-                continue
+        dumped = self.model_dump(by_alias=True, mode="json", exclude_none=True)
+        for field, value in _string_leaves(dumped):
             lowered = value.lower()
             if any(marker in lowered for marker in ("bearer ", "token=", "password=")):
                 raise ValueError(f"{field} must be a reference, not credential data")
+            if field in _ARTIFACT_FIELDS and not value.startswith("artifact://"):
+                raise ValueError(f"{field} must be a durable artifact reference")
+            if field in _ARTIFACT_FIELDS:
+                parsed = urlparse(value)
+                if parsed.scheme != "artifact" or not parsed.netloc:
+                    raise ValueError(f"{field} must not be a local path or provider URL")
+        for field, refs in (
+            ("instructionRefs", self.instruction_refs),
+            ("contextRefs", self.context_refs),
+        ):
+            if any(not ref.startswith("artifact://") for ref in refs):
+                raise ValueError(f"{field} must contain durable artifact references")
+        if (self.diff_ref is None) != (self.diff_digest is None):
+            raise ValueError("diffRef and diffDigest must be supplied together")
+        if (self.first_message_id is None) != (self.first_message_digest is None):
+            raise ValueError(
+                "firstMessageId and firstMessageDigest must be supplied together"
+            )
+        if self.validation.live_reattach_available and not all(
+            (
+                self.omnigent_host_id,
+                self.omnigent_session_id,
+                self.host_lease_ref,
+                self.provider_lease_ref,
+                self.first_message_id,
+                self.last_bridge_event_cursor,
+            )
+        ):
+            raise ValueError("live reattach capability is missing session authority")
+        if self.validation.workspace_cold_restore_available and not all(
+            (self.baseline_commit, self.head_ref, self.workspace_checkpoint_ref)
+        ):
+            raise ValueError("cold restore capability is missing workspace authority")
         return self
+
+
+class OmnigentRestoreMaterial(BaseModel):
+    """Validated inputs handed to the clean-workspace/new-host boundary."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    baseline_commit: str = Field(alias="baselineCommit")
+    head_commit: str = Field(alias="headCommit")
+    workspace_locator: WorkspaceLocator = Field(alias="workspaceLocator")
+    workspace_checkpoint_ref: str = Field(alias="workspaceCheckpointRef")
+    workspace_checkpoint_digest: str = Field(alias="workspaceCheckpointDigest")
+    head_ref: str = Field(alias="headRef")
+    diff_ref: str | None = Field(None, alias="diffRef")
+    immutable_input_refs: list[str] = Field(alias="immutableInputRefs")
+    external_state_ref: str = Field(alias="externalStateRef")
+    provider_profile_id: str = Field(alias="providerProfileId")
+    credential_generation: int = Field(alias="credentialGeneration")
+    source_effective_launch_ref: str | None = Field(
+        None, alias="sourceEffectiveLaunchRef"
+    )
+    launch_policy_ref: str = Field(alias="launchPolicyRef")
+
+
+ArtifactReader = Callable[[str], bytes]
+
+
+def _string_leaves(
+    value: Mapping[str, Any], prefix: str = ""
+) -> list[tuple[str, str]]:
+    leaves: list[tuple[str, str]] = []
+    for key, nested in value.items():
+        path = f"{prefix}.{key}" if prefix else str(key)
+        if isinstance(nested, str):
+            leaves.append((str(key), nested))
+        elif isinstance(nested, Mapping):
+            leaves.extend(_string_leaves(nested, path))
+        elif isinstance(nested, list):
+            for index, item in enumerate(nested):
+                if isinstance(item, str):
+                    leaves.append((f"{key}[{index}]", item))
+                elif isinstance(item, Mapping):
+                    leaves.extend(_string_leaves(item, f"{path}[{index}]"))
+    return leaves
+
+
+def validate_restore_material(
+    checkpoint: OmnigentCheckpointIdentity,
+    *,
+    workflow_id: str,
+    run_id: str,
+    logical_step_id: str,
+    provider_profile_id: str,
+    credential_generation: int,
+    repository_baseline: str,
+    repository_head: str,
+    artifact_reader: ArtifactReader,
+) -> OmnigentCheckpointValidation:
+    """Dereference and digest-check the complete authority set before restore."""
+
+    reasons: list[str] = []
+    if (checkpoint.workflow_id, checkpoint.run_id, checkpoint.logical_step_id) != (
+        workflow_id,
+        run_id,
+        logical_step_id,
+    ):
+        reasons.append("lineage_mismatch")
+    if checkpoint.baseline_commit != repository_baseline:
+        reasons.append("repository_baseline_mismatch")
+    if checkpoint.head_commit != repository_head:
+        reasons.append("repository_head_mismatch")
+    if checkpoint.provider_profile_id != provider_profile_id:
+        reasons.append("provider_profile_mismatch")
+    if checkpoint.credential_generation != credential_generation:
+        reasons.append("credential_generation_mismatch")
+    digest_pairs = [
+        (checkpoint.external_state_ref, checkpoint.external_state_digest),
+        (checkpoint.head_ref, checkpoint.head_digest),
+        (
+            checkpoint.workspace_checkpoint_ref,
+            checkpoint.workspace_checkpoint_digest,
+        ),
+        (checkpoint.diff_ref, checkpoint.diff_digest),
+        (checkpoint.resource_manifest_ref, checkpoint.resource_manifest_digest),
+        (checkpoint.capture_manifest_ref, checkpoint.capture_manifest_digest),
+    ]
+    for ref, expected_digest in digest_pairs:
+        if ref is None and expected_digest is None:
+            continue
+        if ref is None or expected_digest is None:
+            reasons.append("artifact_evidence_incomplete")
+            continue
+        try:
+            payload = artifact_reader(ref)
+        except Exception:
+            reasons.append("artifact_unavailable")
+            continue
+        actual = "sha256:" + hashlib.sha256(payload).hexdigest()
+        if actual != expected_digest:
+            reasons.append("artifact_digest_mismatch")
+    reasons = list(dict.fromkeys(reasons))[:20]
+    cold = not reasons
+    live = cold and all(
+        (
+            checkpoint.omnigent_host_id,
+            checkpoint.omnigent_session_id,
+            checkpoint.host_lease_ref,
+            checkpoint.provider_lease_ref,
+            checkpoint.first_message_id,
+            checkpoint.last_bridge_event_cursor,
+        )
+    )
+    return OmnigentCheckpointValidation(
+        valid=cold,
+        liveReattachAvailable=bool(live),
+        workspaceColdRestoreAvailable=cold,
+        branchCreationAvailable=cold,
+        reasons=reasons,
+    )
+
+
+def materialize_cold_restore_inputs(
+    checkpoint: OmnigentCheckpointIdentity,
+    validation: OmnigentCheckpointValidation,
+) -> OmnigentRestoreMaterial:
+    """Compile authority-only restore inputs; host selection remains current policy."""
+
+    if not validation.workspace_cold_restore_available:
+        reason = validation.reasons[0] if validation.reasons else "restore_unavailable"
+        raise ValueError(f"cold restore unavailable: {reason}")
+    return OmnigentRestoreMaterial(
+        baselineCommit=checkpoint.baseline_commit,
+        headCommit=checkpoint.head_commit,
+        workspaceLocator=checkpoint.workspace_locator,
+        workspaceCheckpointRef=checkpoint.workspace_checkpoint_ref,
+        workspaceCheckpointDigest=checkpoint.workspace_checkpoint_digest,
+        headRef=checkpoint.head_ref,
+        diffRef=checkpoint.diff_ref,
+        immutableInputRefs=[*checkpoint.instruction_refs, *checkpoint.context_refs],
+        externalStateRef=checkpoint.external_state_ref,
+        providerProfileId=checkpoint.provider_profile_id,
+        credentialGeneration=checkpoint.credential_generation,
+        sourceEffectiveLaunchRef=checkpoint.effective_launch_ref,
+        launchPolicyRef=checkpoint.launch_policy_ref,
+    )
 
 
 def recovery_mode(
@@ -149,11 +412,27 @@ def validate_branch_identity(
         raise ValueError("checkpoint branch requires a new Omnigent session")
 
 
+# Resolve the deferred ``WorkspaceLocator`` reference now that the models exist.
+# By the time this runs, ``OmnigentCheckpointIdentity`` is already defined, so the
+# reverse import performed by ``moonmind.schemas.temporal_models`` succeeds under
+# either import order.
+from moonmind.schemas.workspace_locator_models import (  # noqa: E402
+    WorkspaceLocator as WorkspaceLocator,
+)
+
+OmnigentCheckpointIdentity.model_rebuild()
+OmnigentRestoreMaterial.model_rebuild()
+
+
 __all__ = [
     "CandidateWorkspaceAuthority",
     "OmnigentCheckpointIdentity",
+    "OmnigentCheckpointValidation",
     "OmnigentRecoveryMode",
+    "OmnigentRestoreMaterial",
+    "materialize_cold_restore_inputs",
     "recovery_mode",
+    "validate_restore_material",
     "validate_branch_identity",
     "validate_cold_restore_target",
 ]

--- a/moonmind/omnigent/profile_bound_execution.py
+++ b/moonmind/omnigent/profile_bound_execution.py
@@ -25,6 +25,7 @@ from moonmind.omnigent.checkpoints import (
     CandidateWorkspaceAuthority,
     OmnigentCheckpointIdentity,
     OmnigentRecoveryMode,
+    materialize_cold_restore_inputs,
     recovery_mode,
     validate_cold_restore_target,
 )
@@ -1033,10 +1034,16 @@ class OmnigentProfileBoundExecutionCoordinator:
             idempotency_key=f"{checkpoint.idempotency_key}:cold:{request.idempotency_key}",
         )
         parameters = dict(request.parameters or {})
+        restore_material = materialize_cold_restore_inputs(
+            checkpoint, checkpoint.validation
+        )
         parameters["checkpointRestore"] = {
             "mode": "cold_restore",
             "externalStateRef": checkpoint.external_state_ref,
             "sourceBridgeSessionId": checkpoint.bridge_session_id,
+            "restoreMaterial": restore_material.model_dump(
+                by_alias=True, mode="json", exclude_none=True
+            ),
             "candidateWorkspace": candidate_workspace.model_dump(
                 by_alias=True, mode="json"
             ),
@@ -1078,10 +1085,16 @@ class OmnigentProfileBoundExecutionCoordinator:
         if request.idempotency_key == checkpoint.idempotency_key:
             raise ValueError("checkpoint branch requires a new idempotency key")
         parameters = dict(request.parameters or {})
+        restore_material = materialize_cold_restore_inputs(
+            checkpoint, checkpoint.validation
+        )
         parameters["checkpointRestore"] = {
             "mode": "branch",
             "externalStateRef": checkpoint.external_state_ref,
             "sourceBridgeSessionId": checkpoint.bridge_session_id,
+            "restoreMaterial": restore_material.model_dump(
+                by_alias=True, mode="json", exclude_none=True
+            ),
             "candidateWorkspace": candidate_workspace.model_dump(
                 by_alias=True, mode="json"
             ),

--- a/moonmind/schemas/temporal_models.py
+++ b/moonmind/schemas/temporal_models.py
@@ -17,6 +17,7 @@ from pydantic import (
 )
 from pydantic.json_schema import SkipJsonSchema
 
+from moonmind.omnigent.checkpoints import OmnigentCheckpointIdentity
 from moonmind.schemas.checkpoint_branch_models import StepExecutionBranchMetadataModel
 from moonmind.schemas.temporal_artifact_models import CompactArtifactRefModel
 from moonmind.schemas.temporal_payload_policy import validate_compact_temporal_mapping
@@ -331,6 +332,32 @@ class RecoveryEligibilityDiagnosticModel(BaseModel):
     workspace_authority: str | None = Field(None, alias="workspaceAuthority", max_length=100)
     session_recoverable: bool | None = Field(None, alias="sessionRecoverable")
     workspace_recoverable: bool | None = Field(None, alias="workspaceRecoverable")
+    branch_creation_available: bool | None = Field(
+        None, alias="branchCreationAvailable"
+    )
+    live_reattach_reason: str | None = Field(
+        None, alias="liveReattachReason", max_length=120
+    )
+    workspace_restore_reason: str | None = Field(
+        None, alias="workspaceRestoreReason", max_length=120
+    )
+    branch_creation_reason: str | None = Field(
+        None, alias="branchCreationReason", max_length=120
+    )
+    required_profile_ref: str | None = Field(
+        None, alias="requiredProfileRef", max_length=500
+    )
+    required_policy_ref: str | None = Field(
+        None, alias="requiredPolicyRef", max_length=500
+    )
+    capacity_blocked: bool | None = Field(None, alias="capacityBlocked")
+    readiness_blocked: bool | None = Field(None, alias="readinessBlocked")
+    checkpoint_digests: dict[str, str] = Field(
+        default_factory=dict, alias="checkpointDigests"
+    )
+    checkpoint_validation_status: str | None = Field(
+        None, alias="checkpointValidationStatus", max_length=80
+    )
     authoritative_workspace_checkpoint_kind: str | None = Field(
         None, alias="authoritativeWorkspaceCheckpointKind", max_length=100
     )
@@ -1276,6 +1303,9 @@ class StepExecutionCheckpointModel(BaseModel):
         default_factory=list, alias="preparedInputRefs"
     )
     workspace: WorkspaceCheckpointEvidenceModel = Field(..., alias="workspace")
+    omnigent: OmnigentCheckpointIdentity | None = Field(
+        None, alias="omnigentCheckpoint"
+    )
     step_outputs: dict[str, Any] = Field(default_factory=dict, alias="stepOutputs")
     validation: StepCheckpointValidationResultModel | None = Field(
         None, alias="validation"
@@ -1510,6 +1540,9 @@ class StepCheckpointCreateInput(BaseModel):
     boundary: StepExecutionCheckpointBoundary = Field(..., alias="boundary")
     task_input_snapshot_ref: str = Field(..., alias="taskInputSnapshotRef", min_length=1)
     workspace: WorkspaceCheckpointEvidenceModel = Field(..., alias="workspace")
+    omnigent: OmnigentCheckpointIdentity | None = Field(
+        None, alias="omnigentCheckpoint"
+    )
     created_at: datetime = Field(..., alias="createdAt")
     plan_ref: str | None = Field(None, alias="planRef")
     plan_digest: str | None = Field(None, alias="planDigest")

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -15463,6 +15463,7 @@ class TemporalCheckpointActivities:
             plan_digest=model.plan_digest,
             prepared_input_refs=model.prepared_input_refs,
             step_outputs=model.step_outputs,
+            omnigent_checkpoint=model.omnigent,
         )
         checkpoint_ref = await self._put_bytes(
             _json_bytes(payload),

--- a/moonmind/workflows/temporal/recovery_decision.py
+++ b/moonmind/workflows/temporal/recovery_decision.py
@@ -77,6 +77,18 @@ def decide_same_session_recovery(
     elif not live_session_id or not session_reachable:
         reason = "SAME_SESSION_UNREACHABLE"
     eligible = reason is None
+    # Branch creation must not be advertised on workspace validity alone: the selected
+    # runtime must also expose a checkpoint restore kind and a registered branch/restore
+    # route, or the API/Workflow Detail panel offers a branch that cannot be launched.
+    if not workspace_checkpoint_valid:
+        branch_reason = "WORKSPACE_CHECKPOINT_UNAVAILABLE"
+    elif not (capabilities and capabilities.checkpoint_restore_kinds):
+        branch_reason = "CHECKPOINT_RESTORE_UNSUPPORTED"
+    elif not capabilities.checkpoint_restore_activity:
+        branch_reason = "CHECKPOINT_RESTORE_ROUTE_MISSING"
+    else:
+        branch_reason = None
+    branch_available = branch_reason is None
     capability_dump = (
         capabilities.model_dump(by_alias=True, mode="json") if capabilities else {}
     )
@@ -91,14 +103,12 @@ def decide_same_session_recovery(
         workspaceAuthority=capability_dump.get("workspaceAuthority"),
         sessionRecoverable=eligible,
         workspaceRecoverable=workspace_checkpoint_valid,
-        branchCreationAvailable=workspace_checkpoint_valid,
+        branchCreationAvailable=branch_available,
         liveReattachReason=None if eligible else reason,
         workspaceRestoreReason=(
             None if workspace_checkpoint_valid else "WORKSPACE_CHECKPOINT_UNAVAILABLE"
         ),
-        branchCreationReason=(
-            None if workspace_checkpoint_valid else "WORKSPACE_CHECKPOINT_UNAVAILABLE"
-        ),
+        branchCreationReason=branch_reason,
         authoritativeWorkspaceCheckpointKind=(
             capabilities.checkpoint_restore_kinds[0]
             if workspace_checkpoint_valid and capabilities
@@ -158,6 +168,14 @@ def decide_checkpoint_recovery(
         capabilities.model_dump(by_alias=True, mode="json") if capabilities else {}
     )
     eligible = reason is None
+    live_reattach_supported = bool(
+        capabilities
+        and capabilities.session_state
+        and capabilities.session_state.supports_live_reattach
+    )
+    session_recoverable = bool(
+        live_session_id and session_reachable and live_reattach_supported
+    )
     return RecoveryEligibilityDiagnosticModel(
         eligible=eligible,
         requestedAction="resume_from_workspace_checkpoint",
@@ -173,15 +191,13 @@ def decide_checkpoint_recovery(
         checkpointRestoreKinds=capability_dump.get("checkpointRestoreKinds", ()),
         restoreActivity=capability_dump.get("checkpointRestoreActivity"),
         workspaceAuthority=capability_dump.get("workspaceAuthority"),
-        sessionRecoverable=bool(
-            live_session_id and session_reachable and capabilities
-            and capabilities.session_state
-            and capabilities.session_state.supports_live_reattach
-        ),
+        sessionRecoverable=session_recoverable,
         workspaceRecoverable=eligible,
         branchCreationAvailable=eligible,
         liveReattachReason=(
             None
+            if session_recoverable
+            else "SAME_SESSION_CONTINUATION_UNSUPPORTED"
             if live_session_id and session_reachable
             else "SAME_SESSION_UNREACHABLE"
         ),
@@ -196,9 +212,7 @@ def decide_checkpoint_recovery(
         ),
         partialRecoveryReason=(
             "Session state is recoverable, but authoritative workspace checkpoint evidence is unavailable."
-            if not eligible and live_session_id and session_reachable
-            and capabilities and capabilities.session_state
-            and capabilities.session_state.supports_live_reattach else None
+            if not eligible and session_recoverable else None
         ),
         sourceWorkflowId=source_workflow_id,
         sourceRunId=source_run_id,

--- a/moonmind/workflows/temporal/recovery_decision.py
+++ b/moonmind/workflows/temporal/recovery_decision.py
@@ -91,6 +91,14 @@ def decide_same_session_recovery(
         workspaceAuthority=capability_dump.get("workspaceAuthority"),
         sessionRecoverable=eligible,
         workspaceRecoverable=workspace_checkpoint_valid,
+        branchCreationAvailable=workspace_checkpoint_valid,
+        liveReattachReason=None if eligible else reason,
+        workspaceRestoreReason=(
+            None if workspace_checkpoint_valid else "WORKSPACE_CHECKPOINT_UNAVAILABLE"
+        ),
+        branchCreationReason=(
+            None if workspace_checkpoint_valid else "WORKSPACE_CHECKPOINT_UNAVAILABLE"
+        ),
         authoritativeWorkspaceCheckpointKind=(
             capabilities.checkpoint_restore_kinds[0]
             if workspace_checkpoint_valid and capabilities
@@ -171,8 +179,20 @@ def decide_checkpoint_recovery(
             and capabilities.session_state.supports_live_reattach
         ),
         workspaceRecoverable=eligible,
+        branchCreationAvailable=eligible,
+        liveReattachReason=(
+            None
+            if live_session_id and session_reachable
+            else "SAME_SESSION_UNREACHABLE"
+        ),
+        workspaceRestoreReason=reason,
+        branchCreationReason=reason,
+        checkpointValidationStatus="valid" if artifact_valid else "invalid",
         authoritativeWorkspaceCheckpointKind=(
-            checkpoint_kind if checkpoint_kind in tuple(capability_dump.get("checkpointRestoreKinds", ())) else None
+            checkpoint_kind
+            if checkpoint_kind
+            in tuple(capability_dump.get("checkpointRestoreKinds", ()))
+            else None
         ),
         partialRecoveryReason=(
             "Session state is recoverable, but authoritative workspace checkpoint evidence is unavailable."

--- a/moonmind/workflows/temporal/step_checkpoints.py
+++ b/moonmind/workflows/temporal/step_checkpoints.py
@@ -19,6 +19,7 @@ from moonmind.schemas.temporal_models import (
     WorkspaceCheckpointKind,
     WorkspacePolicy,
 )
+from moonmind.omnigent.checkpoints import OmnigentCheckpointIdentity
 
 _POLICY_CHECKPOINT_KINDS: dict[WorkspacePolicy, tuple[WorkspaceCheckpointKind, ...]] = {
     "restore_pre_execution": (
@@ -76,6 +77,7 @@ def build_step_checkpoint_payload(
     plan_digest: str | None = None,
     prepared_input_refs: list[str] | tuple[str, ...] = (),
     step_outputs: Mapping[str, Any] | None = None,
+    omnigent_checkpoint: OmnigentCheckpointIdentity | Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Build a JSON-serializable checkpoint artifact payload."""
 
@@ -91,10 +93,13 @@ def build_step_checkpoint_payload(
         planDigest=plan_digest,
         preparedInputRefs=list(prepared_input_refs),
         workspace=dict(workspace),
+        omnigentCheckpoint=omnigent_checkpoint,
         stepOutputs=dict(step_outputs or {}),
         createdAt=created_at,
     )
     payload = checkpoint.model_dump(by_alias=True, mode="json")
+    if checkpoint.omnigent is None:
+        payload.pop("omnigentCheckpoint", None)
     payload["workspace"] = checkpoint.workspace.model_dump(
         by_alias=True,
         mode="json",

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -5447,6 +5447,7 @@ class MoonMindRunWorkflow:
         prepared_input_refs: Sequence[str] = (),
         step_outputs: Mapping[str, Any] | None = None,
         diagnostic_refs: Sequence[str] = (),
+        omnigent_checkpoint: Mapping[str, Any] | None = None,
     ) -> dict[str, Any]:
         """Write checkpoint evidence through the artifact activity boundary.
 
@@ -5467,6 +5468,9 @@ class MoonMindRunWorkflow:
             "preparedInputRefs": list(prepared_input_refs),
             "stepOutputs": dict(step_outputs or {}),
             "diagnosticRefs": list(diagnostic_refs),
+            "omnigentCheckpoint": (
+                dict(omnigent_checkpoint) if omnigent_checkpoint is not None else None
+            ),
             "idempotencyKey": checkpoint_id,
         }
         result = await workflow.execute_activity(
@@ -5649,6 +5653,11 @@ class MoonMindRunWorkflow:
         ):
             capture_input["captureAuthority"] = "managed_runtime"
         for candidate in candidates:
+            omnigent_checkpoint = candidate.get("omnigentCheckpoint") or candidate.get(
+                "omnigent_checkpoint"
+            )
+            if isinstance(omnigent_checkpoint, Mapping):
+                capture_input["omnigentCheckpoint"] = dict(omnigent_checkpoint)
             workspace_locator = candidate.get("workspaceLocator") or candidate.get(
                 "workspace_locator"
             )
@@ -5967,6 +5976,18 @@ class MoonMindRunWorkflow:
                 logical_step_id
             ),
             diagnostic_refs=[*capture_diagnostics, *diagnostic_refs],
+            omnigent_checkpoint=(
+                self._step_workspace_capture_inputs.get(logical_step_id, {}).get(
+                    "omnigentCheckpoint"
+                )
+                if isinstance(
+                    self._step_workspace_capture_inputs.get(logical_step_id, {}).get(
+                        "omnigentCheckpoint"
+                    ),
+                    Mapping,
+                )
+                else None
+            ),
         )
         checkpoint_ref = str(result.get("checkpointRef") or "").strip()
         if checkpoint_ref:

--- a/tests/unit/omnigent/test_host_auth_remediation.py
+++ b/tests/unit/omnigent/test_host_auth_remediation.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from datetime import timedelta
+from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
@@ -391,14 +391,42 @@ async def test_cross_channel_serializers_redact_or_reject_host_secret(caplog) ->
     # The Temporal-facing checkpoint contract rejects credential material.
     with pytest.raises(ValueError, match="reference, not credential data"):
         OmnigentCheckpointIdentity(
+            workflowId="workflow",
+            runId="run",
+            logicalStepId="step",
+            stepExecutionId="execution",
+            attemptOrdinal=1,
+            boundary="after_execution",
             providerProfileId="provider",
+            credentialRef="credential://provider",
             credentialGeneration=9,
             hostBindingRef="binding",
             endpointRef=f"token={token}",
             bridgeSessionId="bridge",
             externalStateRef="artifact://external",
+            externalStateDigest="sha256:" + "0" * 64,
             idempotencyKey="idem",
             effectiveLaunchRef="omnigent-launch:sha256:" + "0" * 64,
+            executionProfileRef="profile://provider",
+            launchPolicyRef="policy://default",
+            workspaceLocator={"kind": "sandbox", "workspaceId": "workspace"},
+            baselineCommit="abc",
+            headCommit="def",
+            headRef="artifact://head",
+            headDigest="sha256:" + "1" * 64,
+            workspaceCheckpointRef="artifact://workspace",
+            workspaceCheckpointDigest="sha256:" + "2" * 64,
+            sourceBranch="main",
+            publicationState="unpublished",
+            capturedAt=datetime(2026, 7, 12, tzinfo=UTC),
+            producerVersion="test",
+            validation={
+                "valid": False,
+                "liveReattachAvailable": False,
+                "workspaceColdRestoreAvailable": False,
+                "branchCreationAvailable": False,
+                "reasons": ["credential_reference_rejected"],
+            },
         )
 
     # The actual artifact gateway boundary redacts structured diagnostics.

--- a/tests/unit/omnigent/test_oauth_profile_lifecycle.py
+++ b/tests/unit/omnigent/test_oauth_profile_lifecycle.py
@@ -27,9 +27,11 @@ from moonmind.omnigent.checkpoints import (
     CandidateWorkspaceAuthority,
     OmnigentCheckpointIdentity,
     OmnigentRecoveryMode,
+    materialize_cold_restore_inputs,
     recovery_mode,
     validate_branch_identity,
     validate_cold_restore_target,
+    validate_restore_material,
 )
 from moonmind.omnigent.oauth_hosts import (
     OmnigentOAuthHostError,
@@ -412,7 +414,14 @@ def test_claude_preflight_requires_exact_profile_generation_and_harness() -> Non
 
 def _checkpoint() -> OmnigentCheckpointIdentity:
     return OmnigentCheckpointIdentity(
+        workflowId="workflow-1",
+        runId="run-1",
+        logicalStepId="step-1",
+        stepExecutionId="step-execution-1",
+        attemptOrdinal=1,
+        boundary="after_execution",
         providerProfileId="codex",
+        credentialRef="credential://codex",
         credentialGeneration=3,
         providerLeaseRef="provider-lease-1",
         hostBindingRef="omnigent-oauth:codex",
@@ -421,9 +430,38 @@ def _checkpoint() -> OmnigentCheckpointIdentity:
         omnigentHostId="host-1",
         omnigentSessionId="session-1",
         bridgeSessionId="bridge-1",
-        externalStateRef="artifact-external-state",
+        externalStateRef="artifact://external-state",
+        externalStateDigest="sha256:" + "0" * 64,
         idempotencyKey="idem-1",
         effectiveLaunchRef="omnigent-launch:sha256:" + "0" * 64,
+        executionProfileRef="profile://codex",
+        launchPolicyRef="policy://default",
+        lastBridgeEventCursor="event-4",
+        firstMessageId="message-1",
+        firstMessageDigest="sha256:" + "1" * 64,
+        workspaceLocator={
+            "kind": "sandbox",
+            "workspaceId": "workspace-1",
+            "relativePath": "repo",
+        },
+        baselineCommit="abc123",
+        headCommit="def456",
+        headRef="artifact://head",
+        headDigest="sha256:" + "2" * 64,
+        workspaceCheckpointRef="artifact://workspace-checkpoint",
+        workspaceCheckpointDigest="sha256:" + "3" * 64,
+        instructionRefs=["artifact://instructions"],
+        contextRefs=["artifact://context"],
+        sourceBranch="main",
+        publicationState="unpublished",
+        capturedAt=datetime(2026, 7, 12, tzinfo=UTC),
+        producerVersion="moonmind-test",
+        validation={
+            "valid": True,
+            "liveReattachAvailable": True,
+            "workspaceColdRestoreAvailable": True,
+            "branchCreationAvailable": True,
+        },
     )
 
 
@@ -434,6 +472,73 @@ def test_legacy_checkpoint_without_effective_launch_ref_remains_loadable() -> No
     checkpoint = OmnigentCheckpointIdentity.model_validate(payload)
 
     assert checkpoint.effective_launch_ref is None
+
+
+def test_complete_checkpoint_validates_and_compiles_cold_restore_material() -> None:
+    payloads = {
+        "artifact://external-state": b"external",
+        "artifact://head": b"head",
+        "artifact://workspace-checkpoint": b"workspace",
+    }
+    checkpoint = _checkpoint().model_copy(
+        update={
+            "external_state_digest": "sha256:" + hashlib.sha256(b"external").hexdigest(),
+            "head_digest": "sha256:" + hashlib.sha256(b"head").hexdigest(),
+            "workspace_checkpoint_digest": (
+                "sha256:" + hashlib.sha256(b"workspace").hexdigest()
+            ),
+        }
+    )
+
+    validation = validate_restore_material(
+        checkpoint,
+        workflow_id="workflow-1",
+        run_id="run-1",
+        logical_step_id="step-1",
+        provider_profile_id="codex",
+        credential_generation=3,
+        repository_baseline="abc123",
+        repository_head="def456",
+        artifact_reader=payloads.__getitem__,
+    )
+    material = materialize_cold_restore_inputs(checkpoint, validation)
+
+    assert validation.workspace_cold_restore_available is True
+    assert validation.live_reattach_available is True
+    assert material.external_state_ref == "artifact://external-state"
+    assert material.immutable_input_refs == [
+        "artifact://instructions",
+        "artifact://context",
+    ]
+
+
+def test_restore_validation_reports_bounded_independent_denial_reasons() -> None:
+    checkpoint = _checkpoint()
+
+    validation = validate_restore_material(
+        checkpoint,
+        workflow_id="other-workflow",
+        run_id="run-1",
+        logical_step_id="step-1",
+        provider_profile_id="other-profile",
+        credential_generation=4,
+        repository_baseline="different",
+        repository_head="different",
+        artifact_reader=lambda _ref: b"wrong",
+    )
+
+    assert validation.valid is False
+    assert validation.live_reattach_available is False
+    assert validation.workspace_cold_restore_available is False
+    assert validation.branch_creation_available is False
+    assert {
+        "lineage_mismatch",
+        "repository_baseline_mismatch",
+        "repository_head_mismatch",
+        "provider_profile_mismatch",
+        "credential_generation_mismatch",
+        "artifact_digest_mismatch",
+    }.issubset(validation.reasons)
 
 
 def test_oauth_host_runtime_defaults_to_published_image(monkeypatch) -> None:
@@ -1381,7 +1486,7 @@ async def test_claude_live_recovery_reuses_shared_checkpoint_with_exact_harness(
         "artifact://context-pack/claude",
         "artifact://candidate-head/claude-2",
         "artifact://workspace-checkpoint/claude-2",
-        "artifact-external-state",
+        "artifact://external-state",
     ]
 
 

--- a/tests/unit/omnigent/test_oauth_profile_lifecycle.py
+++ b/tests/unit/omnigent/test_oauth_profile_lifecycle.py
@@ -479,6 +479,8 @@ def test_complete_checkpoint_validates_and_compiles_cold_restore_material() -> N
         "artifact://external-state": b"external",
         "artifact://head": b"head",
         "artifact://workspace-checkpoint": b"workspace",
+        "artifact://instructions": b"instructions",
+        "artifact://context": b"context",
     }
     checkpoint = _checkpoint().model_copy(
         update={
@@ -495,6 +497,9 @@ def test_complete_checkpoint_validates_and_compiles_cold_restore_material() -> N
         workflow_id="workflow-1",
         run_id="run-1",
         logical_step_id="step-1",
+        step_execution_id="step-execution-1",
+        attempt_ordinal=1,
+        boundary="after_execution",
         provider_profile_id="codex",
         credential_generation=3,
         repository_baseline="abc123",
@@ -506,6 +511,8 @@ def test_complete_checkpoint_validates_and_compiles_cold_restore_material() -> N
     assert validation.workspace_cold_restore_available is True
     assert validation.live_reattach_available is True
     assert material.external_state_ref == "artifact://external-state"
+    assert material.external_state_digest == checkpoint.external_state_digest
+    assert material.head_digest == checkpoint.head_digest
     assert material.immutable_input_refs == [
         "artifact://instructions",
         "artifact://context",
@@ -520,6 +527,9 @@ def test_restore_validation_reports_bounded_independent_denial_reasons() -> None
         workflow_id="other-workflow",
         run_id="run-1",
         logical_step_id="step-1",
+        step_execution_id="other-step-execution",
+        attempt_ordinal=2,
+        boundary="before_execution",
         provider_profile_id="other-profile",
         credential_generation=4,
         repository_baseline="different",
@@ -533,6 +543,7 @@ def test_restore_validation_reports_bounded_independent_denial_reasons() -> None
     assert validation.branch_creation_available is False
     assert {
         "lineage_mismatch",
+        "step_execution_lineage_mismatch",
         "repository_baseline_mismatch",
         "repository_head_mismatch",
         "provider_profile_mismatch",

--- a/tests/unit/workflows/temporal/test_recovery_decision.py
+++ b/tests/unit/workflows/temporal/test_recovery_decision.py
@@ -174,6 +174,58 @@ def test_same_session_decision_does_not_infer_workspace_evidence_from_capability
     assert decision.workspace_recoverable is False
 
 
+def test_branch_availability_requires_runtime_restore_capability() -> None:
+    # A valid workspace checkpoint on a runtime with a restore kind and route can branch.
+    supported = decide_same_session_recovery(
+        live_session_id="session-1",
+        session_reachable=True,
+        workspace_checkpoint_valid=True,
+        capabilities=resolve_runtime_execution_capabilities("omnigent"),
+    )
+    # claude_code advertises no checkpoint restore kind, so branching is unavailable
+    # even though the workspace checkpoint itself is valid.
+    unsupported = decide_same_session_recovery(
+        live_session_id="session-1",
+        session_reachable=True,
+        workspace_checkpoint_valid=True,
+        capabilities=resolve_runtime_execution_capabilities("claude_code"),
+    )
+    missing_caps = decide_same_session_recovery(
+        live_session_id="session-1",
+        session_reachable=True,
+        workspace_checkpoint_valid=True,
+        capabilities=None,
+    )
+
+    assert supported.branch_creation_available is True
+    assert supported.branch_creation_reason is None
+    assert unsupported.branch_creation_available is False
+    assert unsupported.branch_creation_reason == "CHECKPOINT_RESTORE_UNSUPPORTED"
+    assert missing_caps.branch_creation_available is False
+    assert missing_caps.branch_creation_reason == "CHECKPOINT_RESTORE_UNSUPPORTED"
+
+
+def test_checkpoint_decision_reports_unsupported_live_reattach_explicitly() -> None:
+    # A reachable live session on a runtime that cannot live-reattach must surface the
+    # machine-readable unsupported-capability reason, not a null or unreachable reason.
+    decision = _decision(
+        capabilities=resolve_runtime_execution_capabilities("claude_code"),
+        checkpoint_kind="worktree_archive",
+        live_session_id="session-1",
+        session_reachable=True,
+    )
+
+    assert decision.session_recoverable is False
+    assert decision.live_reattach_reason == "SAME_SESSION_CONTINUATION_UNSUPPORTED"
+
+    unreachable = _decision(
+        live_session_id=None,
+        session_reachable=False,
+    )
+
+    assert unreachable.live_reattach_reason == "SAME_SESSION_UNREACHABLE"
+
+
 def test_restore_kinds_without_activity_are_rejected_by_capability_schema() -> None:
     with pytest.raises(ValueError, match="declared together"):
         RuntimeExecutionCapabilities(


### PR DESCRIPTION
Implements MoonLadderStudios/MoonMind#3509.

Closes MoonLadderStudios/MoonMind#3509

## Summary

Completes the remaining checkpoint-capture and host-independent restore gaps for the Omnigent P0 checkpoint work, building on the existing split-authority checkpoint substrate (typed identity + recovery methods) rather than redesigning it.

- **Complete versioned (v2) checkpoint manifest.** Extends `OmnigentCheckpointIdentity` (`moonmind/omnigent/checkpoints.py`) into a full manifest carrying lineage identity (workflow/run/logical-step/step-execution/attempt/boundary), `externalStateRef` + digest, `idempotencyKey`/`bridgeSessionId`/Omnigent session+host IDs, execution profile / launch policy / effective-launch refs, bridge-event cursor and first-message identity/digest, resource/capture manifest refs+digests, workspace locator + baseline/head/diff/checkpoint refs and digests, source/output branch evidence and publication state, capture time, producer version, and an independent per-capability validation result.
- **Reference-only authority enforced.** `artifact://` refs required for durable evidence; provider-native URLs, raw local paths, and credential-like values (`bearer `, `token=`, `password=`) are rejected. Credentials are referenced by ref + generation only — never bodies.
- **Restore-material validator.** `validate_restore_material` dereferences and digest-checks required artifacts, verifies workflow/run/step lineage, confirms repository baseline/head compatibility, rejects stale/mismatched Provider Profile and credential generation, distinguishes session live-reattach from workspace cold-restore capability, and emits bounded (≤20) machine-readable denial reason codes.
- **Cold-restore materialization.** `materialize_cold_restore_inputs` compiles authority-only cold-restore inputs (pinned baseline/head, workspace locator + checkpoint/diff/head refs, immutable instruction/context refs, external-state ref to a fresh session, Provider Profile + credential generation, retained source launch-policy evidence) and hands them to #3507's canonical clean-workspace boundary; no OAuth credential bodies are copied.
- **Wired through the canonical Step Execution checkpoint writer.** `temporal_models` (`StepExecutionCheckpointModel`/`StepCheckpointCreateInput`) → `step_checkpoints.build_step_checkpoint_payload` → `activity_runtime` → `run.py` capture path, plus the profile-bound coordinator cold-restore/branch paths.
- **Truthful recovery-capability projections.** `recovery_decision` and Workflow Detail (`workflow-detail.tsx`) expose live-reattach / workspace-cold-restore / branch-creation availability independently, each with reasons, required profile/policy, capacity/readiness blocks, artifact refs/digests, and validation status.
- **Docs reconciled.** `docs/Steps/StepExecutionsAndCheckpointing.md`, `docs/Workflows/CheckpointBranchSystem.md`, and `docs/Omnigent/OmnigentAdapter.md` now describe the shipped split-authority model and the exact required checkpoint manifest.

Also fixes two defects surfaced by the work: comparison-chaining bugs in the paired diff/first-message validators, and an order-dependent import cycle between `moonmind.schemas` and `moonmind.omnigent.checkpoints` (deferred `WorkspaceLocator` import + `model_rebuild`).

## Tests run

- `pytest tests/unit/omnigent/test_oauth_profile_lifecycle.py tests/unit/omnigent/test_host_auth_remediation.py` — 103 passed, 6 failed. All 6 failures are pre-existing in `test_host_auth_remediation.py` and raise `UpstreamHostAuthError('pinned Omnigent runner auth entrypoint is unavailable')` because the vendored upstream `omnigent/` package is not present in this checkout; they are untouched by this change (advisory, non-blocking).
- `pytest tests/unit/workflows/temporal/test_step_checkpoints.py test_recovery_decision.py test_step_checkpoint_contracts.py test_checkpoint_policy.py tests/unit/schemas/test_step_execution_models.py` — 83 passed.
- `pytest tests/unit/workflows/temporal/test_recovery_manifest.py test_managed_checkpoint_capture.py test_recovery_entry.py test_recovery_state.py` — 55 passed.
- `npm run ui:test -- src/entrypoints/workflow-detail.test.tsx` — 200 passed (incl. the three independent recovery-capability projections).
- Import-order check for the deferred-import cycle fix — passed both load orders.

## Remaining risks

- Managed-container Python tests and Temporal time-skipping boundary tests were not run in this read-only verification runtime (`MOONMIND_AGENT_RUN_ID` unset; time-skipping suites excluded from required CI per AGENTS.md). Non-blocking environment note.
- The 6 pre-existing `test_host_auth_remediation.py` failures depend on the vendored upstream Omnigent package being present; they are unrelated to this change but will remain red in checkouts without that asset.
