### PR TITLE
Enforce restricted egress for host and workload policies (MoonLadderStudios/MoonMind#3516)

### DIFF
--- a/config/workloads/default-runner-profiles.yaml
+++ b/config/workloads/default-runner-profiles.yaml
@@ -25,7 +25,7 @@ profiles:
       - CLAUDE_HOME
       - MM_PENTEST_CLAUDE_OAUTH_SOURCE
       - MM_PENTEST_SEED_CLAUDE_HOME
-    networkPolicy: bridge
+    networkPolicy: pentest_approved_lab
     resources:
       cpu: "4"
       memory: 8g
@@ -57,7 +57,7 @@ profiles:
       - CI
       - DOCKER_HOST
       - MOONMIND_DOCKER_NETWORK
-    networkPolicy: bridge
+    networkPolicy: docker_proxy
     resources:
       cpu: "4"
       memory: 8g

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -875,12 +875,22 @@ services:
     cpus: ${OMNIGENT_HOST_CPU_LIMIT:-2}
     mem_limit: ${OMNIGENT_HOST_MEMORY_LIMIT:-4096m}
     pids_limit: ${OMNIGENT_HOST_PIDS_LIMIT:-256}
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
     read_only: true
     tmpfs:
       - /tmp:rw,noexec,nosuid,size=${OMNIGENT_HOST_TMPFS_LIMIT:-256m}
     stop_grace_period: ${OMNIGENT_HOST_STOP_GRACE_SECONDS:-20}s
     entrypoint: ["/opt/moonmind/start-claude-oauth-host.sh"]
     environment:
+      HTTP_PROXY: http://omnigent-egress-proxy:3129
+      HTTPS_PROXY: http://omnigent-egress-proxy:3129
+      http_proxy: http://omnigent-egress-proxy:3129
+      https_proxy: http://omnigent-egress-proxy:3129
+      NO_PROXY: ""
+      no_proxy: ""
       PATH: /opt/moonmind-tools/bin:${OMNIGENT_HOST_BASE_PATH:-/opt/venv/bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin}
       MOONMIND_ACTIVE_SKILLS_DIR: /opt/moonmind-skills
       OMNIGENT_SERVER_URL: http://omnigent:8000
@@ -914,6 +924,8 @@ services:
         condition: service_completed_successfully
       omnigent-tools-init:
         condition: service_completed_successfully
+      sandbox-egress-proxy:
+        condition: service_healthy
     healthcheck:
       test:
         [
@@ -925,7 +937,7 @@ services:
       retries: 12
       start_period: 30s
     networks:
-      - local-network
+      - omnigent-egress-network
     restart: unless-stopped
   omnigent-host-claude-init:
     profiles: ["omnigent-host-claude"]
@@ -989,10 +1001,10 @@ services:
     entrypoint: ["/usr/bin/env", "-u", "OPENAI_API_KEY", "-u", "CODEX_ACCESS_TOKEN", "-u", "OPENAI_BASE_URL", "-u", "MINIMAX_API_KEY", "-u", "ANTHROPIC_API_KEY", "-u", "ANTHROPIC_AUTH_TOKEN", "-u", "CLAUDE_API_KEY", "-u", "CLAUDE_CODE_OAUTH_TOKEN", "-u", "GEMINI_API_KEY", "-u", "GOOGLE_API_KEY"]
     command: ["/opt/moonmind/start-codex-oauth-host.sh"]
     environment:
-      HTTP_PROXY: http://sandbox-egress-proxy:3128
-      HTTPS_PROXY: http://sandbox-egress-proxy:3128
-      http_proxy: http://sandbox-egress-proxy:3128
-      https_proxy: http://sandbox-egress-proxy:3128
+      HTTP_PROXY: http://omnigent-egress-proxy:3129
+      HTTPS_PROXY: http://omnigent-egress-proxy:3129
+      http_proxy: http://omnigent-egress-proxy:3129
+      https_proxy: http://omnigent-egress-proxy:3129
       NO_PROXY: ""
       no_proxy: ""
       PATH: /opt/moonmind-tools/bin:${OMNIGENT_HOST_BASE_PATH:-/opt/venv/bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin}
@@ -1025,8 +1037,10 @@ services:
         condition: service_completed_successfully
       omnigent-tools-init:
         condition: service_completed_successfully
+      sandbox-egress-proxy:
+        condition: service_healthy
     networks:
-      - restricted-egress-network
+      - omnigent-egress-network
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "/opt/moonmind/check-codex-oauth-host.sh"]
@@ -1212,19 +1226,23 @@ services:
     container_name: moonmind-sandbox-egress-proxy
     image: ubuntu/squid:latest
     labels:
-      moonmind.egress.profile: moonmind-provider-egress@1
+      moonmind.egress.profile-set-digest: sha256:210bb382a9738300138bca5e4f6885c2e472c725816504040a559a22a7909e82
       moonmind.egress.enforcer: docker-internal-proxy/v1
-      moonmind.egress.config-digest: sha256:c3ad0d533dab70608bbbbcb0a5e82b94f67364cfcb2f4d670d0c944b2e945faa
+      moonmind.egress.config-digest: sha256:1a14f90f01f7926080e37300ef977a4347b44ad93b2a30d86951eeb76b730191
     volumes:
       - ./docker/sandbox-egress-proxy/squid.conf:/etc/squid/squid.conf:ro
     expose:
       - "3128"
+      - "3129"
     networks:
-      - local-network
-      - sandbox-egress-network
-      - restricted-egress-network
+      local-network: {}
+      sandbox-egress-network: {}
+      restricted-egress-network: {}
+      omnigent-egress-network:
+        aliases:
+          - omnigent-egress-proxy
     healthcheck:
-      test: ["CMD-SHELL", "squid -k parse && test \"$$(sha256sum /etc/squid/squid.conf | cut -d' ' -f1)\" = c3ad0d533dab70608bbbbcb0a5e82b94f67364cfcb2f4d670d0c944b2e945faa"]
+      test: ["CMD-SHELL", "squid -k parse && test \"$$(sha256sum /etc/squid/squid.conf | cut -d' ' -f1)\" = 1a14f90f01f7926080e37300ef977a4347b44ad93b2a30d86951eeb76b730191"]
       interval: 10s
       timeout: 5s
       retries: 3
@@ -1271,4 +1289,7 @@ networks:
     internal: true
   restricted-egress-network:
     name: ${MOONMIND_RESTRICTED_EGRESS_NETWORK:-moonmind_restricted-egress-network}
+    internal: true
+  omnigent-egress-network:
+    name: ${MOONMIND_OMNIGENT_EGRESS_NETWORK:-moonmind_omnigent-egress-network}
     internal: true

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1214,6 +1214,7 @@ services:
     labels:
       moonmind.egress.profile: moonmind-provider-egress@1
       moonmind.egress.enforcer: docker-internal-proxy/v1
+      moonmind.egress.config-digest: sha256:c3ad0d533dab70608bbbbcb0a5e82b94f67364cfcb2f4d670d0c944b2e945faa
     volumes:
       - ./docker/sandbox-egress-proxy/squid.conf:/etc/squid/squid.conf:ro
     expose:
@@ -1222,6 +1223,12 @@ services:
       - local-network
       - sandbox-egress-network
       - restricted-egress-network
+    healthcheck:
+      test: ["CMD-SHELL", "squid -k parse && test \"$$(sha256sum /etc/squid/squid.conf | cut -d' ' -f1)\" = c3ad0d533dab70608bbbbcb0a5e82b94f67364cfcb2f4d670d0c944b2e945faa"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
     restart: unless-stopped
 
 volumes:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -972,6 +972,10 @@ services:
     cpus: ${OMNIGENT_HOST_CPU_LIMIT:-2}
     mem_limit: ${OMNIGENT_HOST_MEMORY_LIMIT:-4096m}
     pids_limit: ${OMNIGENT_HOST_PIDS_LIMIT:-256}
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
     read_only: true
     tmpfs:
       - /tmp:rw,noexec,nosuid,size=${OMNIGENT_HOST_TMPFS_LIMIT:-256m}
@@ -985,6 +989,12 @@ services:
     entrypoint: ["/usr/bin/env", "-u", "OPENAI_API_KEY", "-u", "CODEX_ACCESS_TOKEN", "-u", "OPENAI_BASE_URL", "-u", "MINIMAX_API_KEY", "-u", "ANTHROPIC_API_KEY", "-u", "ANTHROPIC_AUTH_TOKEN", "-u", "CLAUDE_API_KEY", "-u", "CLAUDE_CODE_OAUTH_TOKEN", "-u", "GEMINI_API_KEY", "-u", "GOOGLE_API_KEY"]
     command: ["/opt/moonmind/start-codex-oauth-host.sh"]
     environment:
+      HTTP_PROXY: http://sandbox-egress-proxy:3128
+      HTTPS_PROXY: http://sandbox-egress-proxy:3128
+      http_proxy: http://sandbox-egress-proxy:3128
+      https_proxy: http://sandbox-egress-proxy:3128
+      NO_PROXY: ""
+      no_proxy: ""
       PATH: /opt/moonmind-tools/bin:${OMNIGENT_HOST_BASE_PATH:-/opt/venv/bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin}
       MOONMIND_ACTIVE_SKILLS_DIR: /opt/moonmind-skills
       HOME: /home/app
@@ -1016,7 +1026,7 @@ services:
       omnigent-tools-init:
         condition: service_completed_successfully
     networks:
-      - local-network
+      - restricted-egress-network
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "/opt/moonmind/check-codex-oauth-host.sh"]
@@ -1199,7 +1209,11 @@ services:
     restart: unless-stopped
 
   sandbox-egress-proxy:
+    container_name: moonmind-sandbox-egress-proxy
     image: ubuntu/squid:latest
+    labels:
+      moonmind.egress.profile: moonmind-provider-egress@1
+      moonmind.egress.enforcer: docker-internal-proxy/v1
     volumes:
       - ./docker/sandbox-egress-proxy/squid.conf:/etc/squid/squid.conf:ro
     expose:
@@ -1207,6 +1221,7 @@ services:
     networks:
       - local-network
       - sandbox-egress-network
+      - restricted-egress-network
     restart: unless-stopped
 
 volumes:
@@ -1246,4 +1261,7 @@ networks:
     internal: true
   sandbox-egress-network:
     name: ${MOONMIND_SANDBOX_EGRESS_NETWORK:-moonmind_sandbox-egress-network}
+    internal: true
+  restricted-egress-network:
+    name: ${MOONMIND_RESTRICTED_EGRESS_NETWORK:-moonmind_restricted-egress-network}
     internal: true

--- a/docker/pentestgpt-runner/Dockerfile
+++ b/docker/pentestgpt-runner/Dockerfile
@@ -10,7 +10,7 @@ RUN npm install -g "@anthropic-ai/claude-code@${CLAUDE_CODE_NPM_VERSION}" \
     && cp "$(readlink -f "$(command -v claude)")" /tmp/claude \
     && chmod 0755 /tmp/claude
 
-FROM python:3.12-slim AS runtime
+FROM python:3.12-slim-bookworm AS runtime
 
 ARG PENTESTGPT_REF=b9869307d028f26660f4615455d3b14b7d976b2e
 
@@ -34,7 +34,8 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 RUN python -m pip install --upgrade pip \
-    && python -m pip install "git+https://github.com/GreyDGL/PentestGPT.git@${PENTESTGPT_REF}"
+    && python -m pip install "git+https://github.com/GreyDGL/PentestGPT.git@${PENTESTGPT_REF}" \
+    && python -m pip uninstall --yes pip
 
 COPY --from=claude-cli /tmp/claude /usr/local/bin/claude
 COPY docker/pentestgpt-runner/moonmind-pentestgpt-run /usr/local/bin/moonmind-pentestgpt-run

--- a/docker/sandbox-egress-proxy/squid.conf
+++ b/docker/sandbox-egress-proxy/squid.conf
@@ -2,6 +2,24 @@ http_port 3128
 
 acl SSL_ports port 443
 acl CONNECT method CONNECT
+acl omnigent_control dstdomain omnigent
+acl omnigent_control_port port 8000
+acl forbidden_destination dst \
+    0.0.0.0/8 \
+    10.0.0.0/8 \
+    100.64.0.0/10 \
+    127.0.0.0/8 \
+    169.254.0.0/16 \
+    172.16.0.0/12 \
+    192.0.0.0/24 \
+    192.168.0.0/16 \
+    224.0.0.0/4 \
+    240.0.0.0/4 \
+    ::/128 \
+    ::1/128 \
+    fc00::/7 \
+    fe80::/10 \
+    ff00::/8
 acl allowed_sandbox_domains dstdomain \
     .anthropic.com \
     .chatgpt.com \
@@ -13,6 +31,8 @@ acl allowed_sandbox_domains dstdomain \
     .googleapis.com \
     .openai.com
 
+http_access allow omnigent_control omnigent_control_port
+http_access deny forbidden_destination
 http_access deny !CONNECT
 http_access deny CONNECT !SSL_ports
 http_access allow allowed_sandbox_domains

--- a/docker/sandbox-egress-proxy/squid.conf
+++ b/docker/sandbox-egress-proxy/squid.conf
@@ -1,10 +1,13 @@
-http_port 3128
-dns_nameservers 1.1.1.1 8.8.8.8
+http_port 3128 name=restricted_egress
+http_port omnigent-egress-proxy:3129 name=omnigent_control
+dns_nameservers 127.0.0.11
 request_timeout 300 seconds
+read_timeout 300 seconds
 
 acl SSL_ports port 443
 acl CONNECT method CONNECT
 acl connection_limit maxconn 128
+acl omnigent_listener myportname omnigent_control
 acl omnigent_control dstdomain omnigent
 acl omnigent_control_port port 8000
 acl forbidden_destination dst \
@@ -18,11 +21,7 @@ acl forbidden_destination dst \
     192.168.0.0/16 \
     224.0.0.0/4 \
     240.0.0.0/4 \
-    ::/128 \
-    ::1/128 \
-    fc00::/7 \
-    fe80::/10 \
-    ff00::/8
+    ::/0
 acl allowed_sandbox_domains dstdomain \
     .anthropic.com \
     .chatgpt.com \
@@ -34,8 +33,9 @@ acl allowed_sandbox_domains dstdomain \
     .googleapis.com \
     .openai.com
 
-http_access allow omnigent_control omnigent_control_port
 http_access deny connection_limit
+http_access allow omnigent_listener omnigent_control omnigent_control_port
+http_access deny omnigent_control
 http_access deny forbidden_destination
 http_access deny !CONNECT
 http_access deny CONNECT !SSL_ports

--- a/docker/sandbox-egress-proxy/squid.conf
+++ b/docker/sandbox-egress-proxy/squid.conf
@@ -1,7 +1,10 @@
 http_port 3128
+dns_nameservers 1.1.1.1 8.8.8.8
+request_timeout 300 seconds
 
 acl SSL_ports port 443
 acl CONNECT method CONNECT
+acl connection_limit maxconn 128
 acl omnigent_control dstdomain omnigent
 acl omnigent_control_port port 8000
 acl forbidden_destination dst \
@@ -32,6 +35,7 @@ acl allowed_sandbox_domains dstdomain \
     .openai.com
 
 http_access allow omnigent_control omnigent_control_port
+http_access deny connection_limit
 http_access deny forbidden_destination
 http_access deny !CONNECT
 http_access deny CONNECT !SSL_ports

--- a/docs/Security/PentestOperations.md
+++ b/docs/Security/PentestOperations.md
@@ -135,11 +135,11 @@ production-rollout gates that **fail the build** when:
 
 ## Network Enforcement
 
-**`pentestgpt-claude-oauth` runs on the Docker `bridge` network. This is NOT a
-network-enforced "restricted egress" boundary.** The runner can, at the OS
-level, reach any network the Docker host can reach. The first production-safe
-posture therefore relies on **approved-scope validation**, not on network
-enforcement:
+`pentestgpt-claude-oauth` declares `pentest_approved_lab`, which requires the
+approved target scope to resolve to a target-specific reviewed egress profile.
+The generic workload launcher rejects the run before Docker process creation
+when that mapping is unavailable; it never substitutes the provider-only
+restricted-egress profile or raw Docker `bridge` networking.
 
 - `MOONMIND_PENTEST_ALLOW_EXTERNAL_TARGETS=true` allows
   `external_authorized` scopes by default, but
@@ -147,15 +147,17 @@ enforcement:
   recorded manual approval for external targets.
 - Set `MOONMIND_PENTEST_ALLOW_EXTERNAL_TARGETS=false` to confine targets to
   lab/internal-authorized classes recorded in the approved scope artifact.
-- The `pentestgpt-claude-oauth` profile is intended for **approved targets only**.
+- The `pentestgpt-claude-oauth` profile is intended for **approved targets only**
+  and fails closed until the target-specific network route is reviewed and
+  available.
 - Operator docs, launch-plan metadata, runner profile names, and UI copy must
-  describe this profile as Docker `bridge` for approved lab targets — never as
-  an enforced egress firewall.
+  describe this profile as requiring approved lab egress, never as raw Docker
+  `bridge` or as the general provider profile.
 
-Real restricted egress (a dedicated Docker network, egress proxy, or firewall
-sidecar that can only reach approved lab/provider endpoints) is **future work**
-and gated behind a separate security review. Until that exists, do not enable
-external targets and do not represent the Claude OAuth profile as network-enforced.
+The shared restricted-egress substrate does not itself authorize a lab or
+external target. Do not enable external targets until an exact reviewed target
+profile is available, and do not represent the Claude OAuth runner as
+network-enforced when launch was rejected for missing target authority.
 
 ## Task Inputs
 

--- a/docs/Security/RestrictedEgress.md
+++ b/docs/Security/RestrictedEgress.md
@@ -6,13 +6,17 @@ on-demand Omnigent hosts.
 
 ## Architecture and authority
 
-The supported design is one dedicated Docker network with `internal: true` and
-IPv6 disabled. A workload is attached only to that network. Its sole
-internet-capable peer is a trusted, dual-homed Squid gateway. The trusted
-agent-runtime worker selects the immutable egress profile, attests the live
-network and gateway, and launches the workload. Public API, workflow, browser,
-and host-process contracts cannot select a Docker network, gateway, route,
-firewall command, extra host, device, namespace, or capability.
+The supported design uses deployment-owned Docker networks with `internal:
+true` and IPv6 disabled. A workload is attached only to the network selected by
+its immutable profile. Its sole internet-capable peer is one trusted Squid
+gateway with exactly one external attachment. Provider workloads and Omnigent
+hosts use separate internal networks and separate proxy listeners. The
+Omnigent listener is bound only to an alias on the Omnigent network, so generic
+Container Jobs and helpers have no route to the narrow control-plane exception.
+The trusted agent-runtime worker selects the immutable egress profile, attests
+the live network and gateway, and launches the workload. Public API, workflow,
+browser, and host-process contracts cannot select a Docker network, gateway,
+route, firewall command, extra host, device, namespace, or capability.
 
 An internal Docker network has no host-provided external route. Proxy
 environment variables provide compatibility, but are not the security
@@ -20,11 +24,14 @@ boundary: deleting or overriding them removes connectivity rather than
 restoring direct egress. Workloads run without privileges or capabilities,
 with `no-new-privileges`, without the Docker socket, and cannot attach a
 secondary network or launch a helper outside the trusted backend. Static
-Compose and on-demand hosts use the same internal network and gateway;
-Container Jobs and deployment-owned helper profiles resolve `bridge` policy to
-that same enforcing state. Plain Docker `bridge`, `local-network`, and local
-application URL allowlists are non-enforcing development mechanisms and must
-never be reported in `enforcedNetworkRefs`.
+Compose and on-demand hosts use the same Omnigent profile, internal network,
+isolated listener, and gateway. Deployment-owned runner profiles select an
+explicit network policy: `restricted_egress` uses the provider profile,
+`docker_proxy` reaches only the trusted Docker proxy, and a PentestGPT lab run
+fails before launch until its approved target maps to a reviewed lab egress
+profile. Plain Docker `bridge`, `local-network`, and local application URL
+allowlists are non-enforcing development mechanisms and must never be reported
+in `enforcedNetworkRefs`.
 
 The current implementation supports the deployment-selected daemon reached
 through MoonMind's restricted Docker proxy. Arbitrary remote daemon endpoints
@@ -45,21 +52,25 @@ unique-local ranges are rejected.
 The proxy permits only HTTPS `CONNECT` to port 443 for approved provider,
 source-control, artifact, and retrieval domains. All other methods, ports, IP
 literals, redirects to unapproved names, and alternate CONNECT targets fail.
-Squid resolves the requested name for each connection and applies the
-prohibited-address ACL after resolution, so CNAME chains, mixed answers,
-rebinding to a private address, metadata services, Docker/host gateways, and
-internal service DNS are denied. IPv6 is disabled on the workload network and
-IPv6 destination ranges are denied at the proxy. The single narrow exception
-is HTTP access from Omnigent hosts through the gateway to the `omnigent:8000`
-control endpoint; no other control-plane destination is allowed.
+Squid resolves through Docker's embedded DNS for each connection and applies
+the prohibited-address ACL after resolution, so Compose service discovery works
+without weakening CNAME, mixed-answer, rebinding, metadata, Docker/host gateway,
+or internal-service protections. IPv6 is disabled on workload networks and the
+gateway denies the entire IPv6 destination space on its external hop. The
+reviewed 300-second peer read timeout bounds idle CONNECT tunnels and is part of
+the attested profile/config digests. The single narrow exception is HTTP access
+through the Omnigent-only listener to the `omnigent:8000` control endpoint; no
+other workload network can reach that listener and no other control-plane
+destination is allowed.
 
 ## Lifecycle and evidence
 
 Before readiness or a networked launch, the worker verifies:
 
 1. the exact network exists, is internal, and has IPv6 disabled;
-2. the exact gateway exists, has the expected profile and enforcer labels, is
-   attached to the internal network, and has exactly one external attachment;
+2. the exact gateway exists, has the expected approved-profile-set and enforcer
+   labels, is attached to every declared internal network, and has exactly one
+   external attachment;
 3. the live profile version matches the immutable profile selected by policy.
 
 A passing attestation records the profile ref and digest, backend and enforcer

--- a/docs/Security/RestrictedEgress.md
+++ b/docs/Security/RestrictedEgress.md
@@ -1,0 +1,79 @@
+# Restricted egress
+
+MoonLadderStudios/MoonMind#3516 defines the production restricted-egress
+boundary shared by Container Jobs, managed helper workloads, and static and
+on-demand Omnigent hosts.
+
+## Architecture and authority
+
+The supported design is one dedicated Docker network with `internal: true` and
+IPv6 disabled. A workload is attached only to that network. Its sole
+internet-capable peer is a trusted, dual-homed Squid gateway. The trusted
+agent-runtime worker selects the immutable egress profile, attests the live
+network and gateway, and launches the workload. Public API, workflow, browser,
+and host-process contracts cannot select a Docker network, gateway, route,
+firewall command, extra host, device, namespace, or capability.
+
+An internal Docker network has no host-provided external route. Proxy
+environment variables provide compatibility, but are not the security
+boundary: deleting or overriding them removes connectivity rather than
+restoring direct egress. Workloads run without privileges or capabilities,
+with `no-new-privileges`, without the Docker socket, and cannot attach a
+secondary network or launch a helper outside the trusted backend. Static
+Compose and on-demand hosts use the same internal network and gateway;
+Container Jobs and deployment-owned helper profiles resolve `bridge` policy to
+that same enforcing state. Plain Docker `bridge`, `local-network`, and local
+application URL allowlists are non-enforcing development mechanisms and must
+never be reported in `enforcedNetworkRefs`.
+
+The current implementation supports the deployment-selected daemon reached
+through MoonMind's restricted Docker proxy. Arbitrary remote daemon endpoints
+are not profile authority: the backend must find and attest the exact
+deployment-owned network and gateway on its selected daemon or startup fails.
+
+## Profile and request controls
+
+`moonmind.security.egress.EgressProfile` is frozen, versioned, digestible, and
+rejects extra fields. It contains only destinations, TCP ports, DNS/resolution
+policy, IPv6 policy, bounds, ownership, workload classes, validation state, and
+a security-review reference. It cannot contain credentials or executable
+commands. Names are exact/suffix proxy destinations; direct IP literals are
+not accepted by name-only rules. CIDRs overlapping unspecified, private,
+loopback, carrier NAT, link-local, multicast, reserved, IPv4-mapped IPv6, or
+unique-local ranges are rejected.
+
+The proxy permits only HTTPS `CONNECT` to port 443 for approved provider,
+source-control, artifact, and retrieval domains. All other methods, ports, IP
+literals, redirects to unapproved names, and alternate CONNECT targets fail.
+Squid resolves the requested name for each connection and applies the
+prohibited-address ACL after resolution, so CNAME chains, mixed answers,
+rebinding to a private address, metadata services, Docker/host gateways, and
+internal service DNS are denied. IPv6 is disabled on the workload network and
+IPv6 destination ranges are denied at the proxy. The single narrow exception
+is HTTP access from Omnigent hosts through the gateway to the `omnigent:8000`
+control endpoint; no other control-plane destination is allowed.
+
+## Lifecycle and evidence
+
+Before readiness or a networked launch, the worker verifies:
+
+1. the exact network exists, is internal, and has IPv6 disabled;
+2. the exact gateway exists, has the expected profile and enforcer labels, is
+   attached to the internal network, and has exactly one external attachment;
+3. the live profile version matches the immutable profile selected by policy.
+
+A passing attestation records the profile ref and digest, backend and enforcer
+implementation, network and gateway identities, applied-rule digest,
+validation result and time, bounded denial counters, and bounded diagnostics.
+Only a passing attestation contributes to `enforcedNetworkRefs`. Workload
+labels bind the attachment to the profile/rule digest. Stale profile versions,
+partial setup, missing labels, extra gateway networks, missing cleanup state,
+or an unavailable backend fail closed before workload start. Reconciliation
+and cleanup remain label/ownership scoped; they never remove an unowned
+network, gateway, container, or volume. Diagnostics contain bounded redacted
+destination metadata, never credentials, request bodies, or packet payloads.
+
+External PentestGPT targets remain gated. Enabling one additionally requires an
+exact reviewed egress profile, approved target scope, and durable approval
+evidence; the general provider profile in this document is not authority for
+external penetration-test targets.

--- a/moonmind/config/settings.py
+++ b/moonmind/config/settings.py
@@ -1603,8 +1603,12 @@ class PentestSettings(BaseSettings):
         ),
     )
     allow_external_targets: bool = Field(
-        True,
+        False,
         validation_alias=AliasChoices("MOONMIND_PENTEST_ALLOW_EXTERNAL_TARGETS"),
+        description=(
+            "Permit approved external targets. Disabled by default until the "
+            "deployment explicitly accepts the restricted-egress boundary."
+        ),
     )
     telemetry_enabled: bool = Field(
         False,

--- a/moonmind/integrations/pentest/models.py
+++ b/moonmind/integrations/pentest/models.py
@@ -474,6 +474,8 @@ class PentestApprovedScope(PentestBaseModel):
     requires_manual_approval: bool = False
     approval_ticket: str | None = None
     approval_recorded: bool = False
+    egress_profile_ref: str | None = None
+    security_review_ref: str | None = None
     allowed_runner_profiles: tuple[str, ...] = Field(..., min_length=1)
     required_network_attachment_type: PentestNetworkAttachmentType | None = None
     authorized_principals: tuple[str, ...] = ()
@@ -482,6 +484,8 @@ class PentestApprovedScope(PentestBaseModel):
     @field_validator(
         "owner_user_id",
         "approval_ticket",
+        "egress_profile_ref",
+        "security_review_ref",
         "required_network_attachment_type",
         mode="before",
     )
@@ -2347,6 +2351,46 @@ def validate_authorized_scope_for_request(
         _raise_scope_error(
             request, scope, "UNAPPROVED_TARGET", "manual_approval_required"
         )
+
+    if scope.target_class == "external_authorized":
+        from moonmind.config.settings import settings
+        from moonmind.security.egress import DEFAULT_EGRESS_PROFILE
+
+        if not settings.pentest.allow_external_targets:
+            _raise_scope_error(
+                request, scope, "UNAPPROVED_TARGET", "external_targets_disabled"
+            )
+        if (
+            not scope.approval_recorded
+            or not scope.approval_ticket
+            or not scope.security_review_ref
+        ):
+            _raise_scope_error(
+                request,
+                scope,
+                "UNAPPROVED_TARGET",
+                "external_security_approval_required",
+            )
+        if scope.egress_profile_ref != DEFAULT_EGRESS_PROFILE.ref:
+            _raise_scope_error(
+                request,
+                scope,
+                "UNSUPPORTED_PROFILE",
+                "external_egress_profile_mismatch",
+            )
+        target_host = _target_host_candidate(_normalize_target(request.target))
+        approved_names = {
+            destination.dns_name
+            for destination in DEFAULT_EGRESS_PROFILE.destinations
+            if destination.dns_name is not None
+        }
+        if target_host not in approved_names:
+            _raise_scope_error(
+                request,
+                scope,
+                "UNAPPROVED_TARGET",
+                "external_target_not_in_egress_profile",
+            )
 
     ambiguity_markers = {
         str((scope.metadata or {}).get(key) or "").strip().lower()

--- a/moonmind/integrations/pentest/models.py
+++ b/moonmind/integrations/pentest/models.py
@@ -2378,6 +2378,17 @@ def validate_authorized_scope_for_request(
                 "UNSUPPORTED_PROFILE",
                 "external_egress_profile_mismatch",
             )
+        if scope.security_review_ref != DEFAULT_EGRESS_PROFILE.security_review_ref:
+            # A nonempty review reference is not enough: it must be the exact
+            # review attached to the selected egress profile, or a placeholder
+            # such as "reviewed" would be indistinguishable from the approved
+            # review in downstream evidence. Match it as strictly as the profile.
+            _raise_scope_error(
+                request,
+                scope,
+                "UNAPPROVED_TARGET",
+                "external_security_review_mismatch",
+            )
         target_host = _target_host_candidate(_normalize_target(request.target))
         approved_names = {
             destination.dns_name

--- a/moonmind/omnigent/execution_profiles.py
+++ b/moonmind/omnigent/execution_profiles.py
@@ -15,6 +15,7 @@ from typing import Any, Literal, Mapping
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from moonmind.omnigent.oauth_hosts import OmnigentOAuthHostError
+from moonmind.security.egress import DEFAULT_EGRESS_PROFILE
 
 _DIGEST_IMAGE = re.compile(r"^[^\s@]+@sha256:[0-9a-f]{64}$")
 _PLACEHOLDER_DIGEST = "0" * 64
@@ -128,7 +129,7 @@ _SERVER_IMAGE = "bootstrap://OMNIGENT_IMAGE_REF"
 _COMMON = dict(
     serverImageRef=_SERVER_IMAGE,
     hostImageRef=_IMAGE,
-    networkRef="local-network",
+    networkRef=DEFAULT_EGRESS_PROFILE.network_ref,
     enforcedEgress=True,
     limits={
         "cpuMillis": 2000,

--- a/moonmind/omnigent/execution_profiles.py
+++ b/moonmind/omnigent/execution_profiles.py
@@ -15,7 +15,7 @@ from typing import Any, Literal, Mapping
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from moonmind.omnigent.oauth_hosts import OmnigentOAuthHostError
-from moonmind.security.egress import DEFAULT_EGRESS_PROFILE
+from moonmind.security.egress import OMNIGENT_EGRESS_PROFILE
 
 _DIGEST_IMAGE = re.compile(r"^[^\s@]+@sha256:[0-9a-f]{64}$")
 _PLACEHOLDER_DIGEST = "0" * 64
@@ -129,7 +129,7 @@ _SERVER_IMAGE = "bootstrap://OMNIGENT_IMAGE_REF"
 _COMMON = dict(
     serverImageRef=_SERVER_IMAGE,
     hostImageRef=_IMAGE,
-    networkRef=DEFAULT_EGRESS_PROFILE.network_ref,
+    networkRef=OMNIGENT_EGRESS_PROFILE.network_ref,
     enforcedEgress=True,
     limits={
         "cpuMillis": 2000,

--- a/moonmind/omnigent/oauth_host_runtime.py
+++ b/moonmind/omnigent/oauth_host_runtime.py
@@ -16,6 +16,12 @@ from moonmind.omnigent.oauth_hosts import (
     validate_preflight_result,
 )
 from moonmind.omnigent.execution_profiles import validate_effective_launch_snapshot
+from moonmind.security.egress import (
+    DEFAULT_EGRESS_PROFILE,
+    attest_docker_egress,
+    restricted_proxy_env,
+)
+from moonmind.workloads.docker_launcher import structured_container_security_args
 from moonmind.omnigent.mounted_tool_preflight import (
     MountedToolPreflightError,
     preflight_mounted_tools,
@@ -175,6 +181,7 @@ class OmnigentOAuthHostRuntime:
             resolved_skillset_ref=resolved_skillset_ref,
             artifact_gateway=artifact_gateway,
         )
+        egress_attestation = await self._attest_egress(launch)
         workspace_source = await self._prepare_workspace(
             workspace_locator=workspace_locator,
             current_workflow_id=current_workflow_id,
@@ -238,6 +245,9 @@ class OmnigentOAuthHostRuntime:
             "harness": adapter["harness"],
             "competingCredentialsPresent": False,
             "mountedTools": mounted_tool_evidence,
+            "egressAttestation": egress_attestation.model_dump(
+                by_alias=True, mode="json"
+            ),
             "workspacePath": (
                 "/workspaces/run"
                 if binding.host_launch_profile_ref
@@ -252,7 +262,31 @@ class OmnigentOAuthHostRuntime:
         validated["workspacePath"] = result["workspacePath"]
         validated["activeSkillsPath"] = str(skill_projection)
         validated["mountedTools"] = mounted_tool_evidence
+        validated["egressAttestation"] = result["egressAttestation"]
         return validated
+
+    async def _attest_egress(self, launch: Mapping[str, Any]):
+        if launch.get("networkRef") != DEFAULT_EGRESS_PROFILE.network_ref:
+            raise OmnigentOAuthHostError(
+                "launch egress profile does not map to supported backend state",
+                code="OMNIGENT_LAUNCH_EGRESS_UNATTESTED",
+            )
+
+        async def runner(args):
+            code, stdout, stderr = await self._run(*args, check=False)
+            return code, stdout.encode(), stderr.encode()
+
+        try:
+            return await attest_docker_egress(
+                runner=runner,
+                profile=DEFAULT_EGRESS_PROFILE,
+                backend_ref="omnigent-host-runtime",
+            )
+        except RuntimeError as exc:
+            raise OmnigentOAuthHostError(
+                "launch egress backend attestation failed",
+                code="OMNIGENT_LAUNCH_EGRESS_UNATTESTED",
+            ) from exc
 
     @staticmethod
     def _runtime_adapter(binding: OmnigentOAuthHostBinding) -> Mapping[str, Any]:
@@ -615,6 +649,7 @@ class OmnigentOAuthHostRuntime:
             "/home/app",
             "--network",
             str(effective_launch["networkRef"]),
+            *structured_container_security_args(),
             "--cpus",
             str(int(effective_launch["limits"]["cpuMillis"]) / 1000),
             "--memory",
@@ -665,6 +700,8 @@ class OmnigentOAuthHostRuntime:
         ]
         for runtime_env in adapter["env"]:
             args.extend(["--env", runtime_env])
+        for proxy_env in restricted_proxy_env():
+            args.extend(["--env", proxy_env])
         token = os.getenv("OMNIGENT_HOST_TOKEN", "")
         child_env = dict(os.environ)
         if token:

--- a/moonmind/omnigent/oauth_host_runtime.py
+++ b/moonmind/omnigent/oauth_host_runtime.py
@@ -17,9 +17,9 @@ from moonmind.omnigent.oauth_hosts import (
 )
 from moonmind.omnigent.execution_profiles import validate_effective_launch_snapshot
 from moonmind.security.egress import (
-    DEFAULT_EGRESS_PROFILE,
+    OMNIGENT_EGRESS_PROFILE,
     attest_docker_egress,
-    restricted_proxy_env,
+    omnigent_proxy_env,
 )
 from moonmind.workloads.docker_launcher import structured_container_security_args
 from moonmind.omnigent.mounted_tool_preflight import (
@@ -266,7 +266,7 @@ class OmnigentOAuthHostRuntime:
         return validated
 
     async def _attest_egress(self, launch: Mapping[str, Any]):
-        if launch.get("networkRef") != DEFAULT_EGRESS_PROFILE.network_ref:
+        if launch.get("networkRef") != OMNIGENT_EGRESS_PROFILE.network_ref:
             raise OmnigentOAuthHostError(
                 "launch egress profile does not map to supported backend state",
                 code="OMNIGENT_LAUNCH_EGRESS_UNATTESTED",
@@ -279,7 +279,7 @@ class OmnigentOAuthHostRuntime:
         try:
             return await attest_docker_egress(
                 runner=runner,
-                profile=DEFAULT_EGRESS_PROFILE,
+                profile=OMNIGENT_EGRESS_PROFILE,
                 backend_ref="omnigent-host-runtime",
             )
         except RuntimeError as exc:
@@ -700,7 +700,7 @@ class OmnigentOAuthHostRuntime:
         ]
         for runtime_env in adapter["env"]:
             args.extend(["--env", runtime_env])
-        for proxy_env in restricted_proxy_env():
+        for proxy_env in omnigent_proxy_env():
             args.extend(["--env", proxy_env])
         token = os.getenv("OMNIGENT_HOST_TOKEN", "")
         child_env = dict(os.environ)

--- a/moonmind/schemas/workload_models.py
+++ b/moonmind/schemas/workload_models.py
@@ -52,6 +52,12 @@ WorkloadStatus = Literal[
 WorkloadKind = Literal["one_shot", "bounded_service"]
 WorkloadOwnershipKind = Literal["workload", "bounded_service"]
 WorkloadNetworkPolicy = Literal["none", "bridge"]
+RunnerNetworkPolicy = Literal[
+    "none",
+    "restricted_egress",
+    "docker_proxy",
+    "pentest_approved_lab",
+]
 WorkflowDockerMode = Literal["disabled", "profiles", "unrestricted"]
 WorkloadAccessKind = Literal["profile", "unrestricted_container", "unrestricted_docker_cli"]
 WorkloadDeviceMode = Literal["none"]
@@ -372,7 +378,7 @@ class RunnerProfile(BaseModel):
         alias="credentialMounts",
     )
     env_allowlist: tuple[str, ...] = Field(default_factory=tuple, alias="envAllowlist")
-    network_policy: WorkloadNetworkPolicy = Field("none", alias="networkPolicy")
+    network_policy: RunnerNetworkPolicy = Field("none", alias="networkPolicy")
     resources: RunnerResourceProfile = Field(
         default_factory=RunnerResourceProfile,
         alias="resources",

--- a/moonmind/security/egress.py
+++ b/moonmind/security/egress.py
@@ -1,0 +1,275 @@
+"""Trusted restricted-egress profiles and Docker network attestation.
+
+MoonLadderStudios/MoonMind#3516.  Workloads never receive these objects.  They
+select a higher-level workload/launch policy and the trusted backend resolves
+that policy to this immutable deployment-owned profile.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import ipaddress
+import json
+from datetime import UTC, datetime
+from typing import Awaitable, Callable, Literal, Sequence
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+CommandRunner = Callable[[Sequence[str]], Awaitable[tuple[int, bytes, bytes]]]
+
+ENFORCER_IMPLEMENTATION = "docker-internal-proxy/v1"
+EGRESS_NETWORK_REF = "moonmind_restricted-egress-network"
+EGRESS_GATEWAY_REF = "moonmind-sandbox-egress-proxy"
+PROXY_URL = "http://sandbox-egress-proxy:3128"
+_EXPECTED_GATEWAY_NETWORKS = frozenset(
+    {
+        EGRESS_NETWORK_REF,
+        "moonmind_sandbox-egress-network",
+        "local-network",
+    }
+)
+
+_FORBIDDEN_NETWORKS = tuple(
+    ipaddress.ip_network(value)
+    for value in (
+        "0.0.0.0/8",
+        "10.0.0.0/8",
+        "100.64.0.0/10",
+        "127.0.0.0/8",
+        "169.254.0.0/16",
+        "172.16.0.0/12",
+        "192.0.0.0/24",
+        "192.168.0.0/16",
+        "224.0.0.0/4",
+        "240.0.0.0/4",
+        "::/128",
+        "::1/128",
+        "fc00::/7",
+        "fe80::/10",
+        "ff00::/8",
+        "::ffff:0:0/96",
+    )
+)
+
+
+class EgressDestination(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    dns_name: str | None = Field(None, alias="dnsName")
+    cidr: str | None = None
+    ports: tuple[int, ...] = Field(min_length=1)
+    protocol: Literal["tcp"] = "tcp"
+
+    @model_validator(mode="after")
+    def validate_destination(self) -> "EgressDestination":
+        if (self.dns_name is None) == (self.cidr is None):
+            raise ValueError("exactly one of dnsName or cidr is required")
+        if self.dns_name is not None:
+            name = self.dns_name.lower().rstrip(".")
+            try:
+                ipaddress.ip_address(name)
+            except ValueError:
+                pass
+            else:
+                raise ValueError("dnsName cannot be an IP literal")
+            if (
+                not name
+                or "*" in name
+                or "/" in name
+                or name == "localhost"
+                or name.endswith((".local", ".internal"))
+            ):
+                raise ValueError("dnsName must be an exact or suffix public DNS name")
+            object.__setattr__(self, "dns_name", name)
+        if self.cidr is not None:
+            network = ipaddress.ip_network(self.cidr, strict=True)
+            if any(network.overlaps(forbidden) for forbidden in _FORBIDDEN_NETWORKS):
+                raise ValueError("destination overlaps a prohibited address range")
+            object.__setattr__(self, "cidr", str(network))
+        if any(port < 1 or port > 65535 for port in self.ports):
+            raise ValueError("ports must be valid TCP ports")
+        return self
+
+
+class EgressProfile(BaseModel):
+    """Immutable, declarative profile; commands and credentials are impossible."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    profile_id: str = Field(alias="profileId", pattern=r"^[a-z0-9][a-z0-9-]{0,62}$")
+    version: int = Field(ge=1)
+    owner: str = Field(min_length=1, max_length=128)
+    destinations: tuple[EgressDestination, ...] = Field(min_length=1)
+    resolution: Literal["continuous_proxy_validation"] = Field(
+        "continuous_proxy_validation"
+    )
+    ipv6: Literal["deny"] = "deny"
+    dns_servers: tuple[str, ...] = Field(alias="dnsServers", min_length=1)
+    permitted_workload_classes: tuple[str, ...] = Field(
+        alias="permittedWorkloadClasses", min_length=1
+    )
+    max_connections: int = Field(ge=1, alias="maxConnections")
+    idle_seconds: int = Field(ge=1, alias="idleSeconds")
+    diagnostics_retention_days: int = Field(
+        ge=1, le=90, alias="diagnosticsRetentionDays"
+    )
+    security_review_ref: str = Field(alias="securityReviewRef", min_length=1)
+    validation_state: Literal["approved"] = Field("approved", alias="validationState")
+    network_ref: str = Field(alias="networkRef")
+    gateway_ref: str = Field(alias="gatewayRef")
+
+    @field_validator("dns_servers")
+    @classmethod
+    def public_resolvers_only(cls, values: tuple[str, ...]) -> tuple[str, ...]:
+        for value in values:
+            address = ipaddress.ip_address(value)
+            if not address.is_global:
+                raise ValueError("DNS resolvers must use global addresses")
+        return values
+
+    @property
+    def ref(self) -> str:
+        return f"{self.profile_id}@{self.version}"
+
+    @property
+    def digest(self) -> str:
+        payload = self.model_dump(by_alias=True, mode="json")
+        canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+        return f"sha256:{hashlib.sha256(canonical.encode()).hexdigest()}"
+
+
+class EgressAttestation(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    profile_ref: str = Field(alias="profileRef")
+    profile_digest: str = Field(alias="profileDigest")
+    enforcer_implementation: str = Field(alias="enforcerImplementation")
+    backend_ref: str = Field(alias="backendRef")
+    network_ref: str = Field(alias="networkRef")
+    gateway_ref: str = Field(alias="gatewayRef")
+    applied_rule_digest: str = Field(alias="appliedRuleDigest")
+    validated_at: datetime = Field(alias="validatedAt")
+    validation_result: Literal["passed"] = Field("passed", alias="validationResult")
+    denied_connection_count: int = Field(0, alias="deniedConnectionCount", ge=0)
+    diagnostics: tuple[str, ...] = Field(default_factory=tuple, max_length=20)
+
+
+DEFAULT_EGRESS_PROFILE = EgressProfile.model_validate(
+    {
+        "profileId": "moonmind-provider-egress",
+        "version": 1,
+        "owner": "MoonMind security",
+        "destinations": [
+            {"dnsName": name, "ports": [443]}
+            for name in (
+                "anthropic.com",
+                "chatgpt.com",
+                "ghcr.io",
+                "github.com",
+                "githubassets.com",
+                "githubusercontent.com",
+                "google.com",
+                "googleapis.com",
+                "openai.com",
+            )
+        ],
+        "dnsServers": ["1.1.1.1", "8.8.8.8"],
+        "permittedWorkloadClasses": [
+            "container_job",
+            "managed_helper",
+            "omnigent_static",
+            "omnigent_on_demand",
+            "rag_gateway",
+            "remediation",
+        ],
+        "maxConnections": 128,
+        "idleSeconds": 300,
+        "diagnosticsRetentionDays": 30,
+        "securityReviewRef": "MoonLadderStudios/MoonMind#3516",
+        "networkRef": EGRESS_NETWORK_REF,
+        "gatewayRef": EGRESS_GATEWAY_REF,
+    }
+)
+
+
+async def attest_docker_egress(
+    *,
+    runner: CommandRunner,
+    profile: EgressProfile,
+    backend_ref: str,
+) -> EgressAttestation:
+    """Prove the internal network and sole dual-homed gateway exist.
+
+    Docker's ``internal`` flag removes a default external route at the network
+    layer.  The gateway is trusted deployment state and must carry the exact
+    profile and implementation labels.  A stale gateway/profile therefore
+    fails closed rather than being reused.
+    """
+
+    code, stdout, _ = await runner(
+        ("network", "inspect", "--format", "{{json .}}", profile.network_ref)
+    )
+    if code:
+        raise RuntimeError("restricted-egress network is unavailable")
+    try:
+        network = json.loads(stdout)
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        raise RuntimeError("restricted-egress network attestation is malformed") from exc
+    if network.get("Internal") is not True or network.get("EnableIPv6") is True:
+        raise RuntimeError("restricted-egress network is not internal IPv4-only state")
+
+    format_value = (
+        '{"labels":{{json .Config.Labels}},"networks":'
+        '{{json .NetworkSettings.Networks}}}'
+    )
+    code, stdout, _ = await runner(
+        ("inspect", "--format", format_value, profile.gateway_ref)
+    )
+    if code:
+        raise RuntimeError("restricted-egress gateway is unavailable")
+    try:
+        gateway = json.loads(stdout)
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        raise RuntimeError("restricted-egress gateway attestation is malformed") from exc
+    labels = gateway.get("labels") or {}
+    networks = gateway.get("networks") or {}
+    if labels.get("moonmind.egress.profile") != profile.ref:
+        raise RuntimeError("restricted-egress gateway profile is stale or mismatched")
+    if labels.get("moonmind.egress.enforcer") != ENFORCER_IMPLEMENTATION:
+        raise RuntimeError("restricted-egress gateway implementation is unattested")
+    if set(networks) != _EXPECTED_GATEWAY_NETWORKS:
+        raise RuntimeError("restricted-egress gateway attachment is invalid")
+
+    applied = {
+        "profileDigest": profile.digest,
+        "internal": True,
+        "ipv6": False,
+        "gatewayNetworks": sorted(networks),
+        "enforcer": ENFORCER_IMPLEMENTATION,
+    }
+    applied_digest = "sha256:" + hashlib.sha256(
+        json.dumps(applied, sort_keys=True, separators=(",", ":")).encode()
+    ).hexdigest()
+    return EgressAttestation(
+        profileRef=profile.ref,
+        profileDigest=profile.digest,
+        enforcerImplementation=ENFORCER_IMPLEMENTATION,
+        backendRef=backend_ref,
+        networkRef=profile.network_ref,
+        gatewayRef=profile.gateway_ref,
+        appliedRuleDigest=applied_digest,
+        validatedAt=datetime.now(UTC),
+    )
+
+
+def restricted_proxy_env() -> tuple[str, ...]:
+    """Non-overridable proxy environment for an internally routed workload."""
+
+    return (
+        f"HTTP_PROXY={PROXY_URL}",
+        f"HTTPS_PROXY={PROXY_URL}",
+        f"http_proxy={PROXY_URL}",
+        f"https_proxy={PROXY_URL}",
+        "NO_PROXY=",
+        "no_proxy=",
+    )

--- a/moonmind/security/egress.py
+++ b/moonmind/security/egress.py
@@ -21,7 +21,7 @@ CommandRunner = Callable[[Sequence[str]], Awaitable[tuple[int, bytes, bytes]]]
 ENFORCER_IMPLEMENTATION = "docker-internal-proxy/v1"
 # Digest of the reviewed, mounted Squid policy. Attestation compares this
 # deployment-owned value with both the container label and the live file.
-EGRESS_CONFIG_DIGEST = "sha256:c3ad0d533dab70608bbbbcb0a5e82b94f67364cfcb2f4d670d0c944b2e945faa"
+EGRESS_CONFIG_DIGEST = "sha256:1a14f90f01f7926080e37300ef977a4347b44ad93b2a30d86951eeb76b730191"
 # Deployment-owned network names. Compose resolves these same overrides when it
 # creates the networks (``restricted-egress-network`` /
 # ``sandbox-egress-network``), so an operator that sets the documented override
@@ -33,12 +33,17 @@ EGRESS_NETWORK_REF = os.environ.get(
 _SANDBOX_EGRESS_NETWORK_REF = os.environ.get(
     "MOONMIND_SANDBOX_EGRESS_NETWORK", "moonmind_sandbox-egress-network"
 )
+OMNIGENT_EGRESS_NETWORK_REF = os.environ.get(
+    "MOONMIND_OMNIGENT_EGRESS_NETWORK", "moonmind_omnigent-egress-network"
+)
 EGRESS_GATEWAY_REF = "moonmind-sandbox-egress-proxy"
 PROXY_URL = "http://sandbox-egress-proxy:3128"
+OMNIGENT_PROXY_URL = "http://omnigent-egress-proxy:3129"
 _EXPECTED_GATEWAY_NETWORKS = frozenset(
     {
         EGRESS_NETWORK_REF,
         _SANDBOX_EGRESS_NETWORK_REF,
+        OMNIGENT_EGRESS_NETWORK_REF,
         "local-network",
     }
 )
@@ -134,11 +139,13 @@ class EgressProfile(BaseModel):
 
     @field_validator("dns_servers")
     @classmethod
-    def public_resolvers_only(cls, values: tuple[str, ...]) -> tuple[str, ...]:
+    def approved_resolvers_only(cls, values: tuple[str, ...]) -> tuple[str, ...]:
         for value in values:
             address = ipaddress.ip_address(value)
-            if not address.is_global:
-                raise ValueError("DNS resolvers must use global addresses")
+            if not address.is_global and value != "127.0.0.11":
+                raise ValueError(
+                    "DNS resolvers must be global or Docker's embedded resolver"
+                )
         return values
 
     @property
@@ -190,12 +197,10 @@ DEFAULT_EGRESS_PROFILE = EgressProfile.model_validate(
                 "openai.com",
             )
         ],
-        "dnsServers": ["1.1.1.1", "8.8.8.8"],
+        "dnsServers": ["127.0.0.11"],
         "permittedWorkloadClasses": [
             "container_job",
             "managed_helper",
-            "omnigent_static",
-            "omnigent_on_demand",
             "rag_gateway",
             "remediation",
         ],
@@ -208,6 +213,46 @@ DEFAULT_EGRESS_PROFILE = EgressProfile.model_validate(
     }
 )
 
+OMNIGENT_EGRESS_PROFILE = EgressProfile.model_validate(
+    {
+        **DEFAULT_EGRESS_PROFILE.model_dump(by_alias=True, mode="json"),
+        "profileId": "moonmind-omnigent-egress",
+        "dnsServers": ["127.0.0.11"],
+        "permittedWorkloadClasses": [
+            "omnigent_static",
+            "omnigent_on_demand",
+        ],
+        "networkRef": OMNIGENT_EGRESS_NETWORK_REF,
+    }
+)
+
+EGRESS_PROFILE_DIGESTS = {
+    profile.ref: profile.digest
+    for profile in (DEFAULT_EGRESS_PROFILE, OMNIGENT_EGRESS_PROFILE)
+}
+
+
+def _gateway_policy_digest(profile: EgressProfile) -> str:
+    """Digest proxy-enforced policy without deployment-specific identities."""
+
+    payload = profile.model_dump(by_alias=True, mode="json")
+    payload.pop("networkRef")
+    payload.pop("gatewayRef")
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return "sha256:" + hashlib.sha256(canonical.encode()).hexdigest()
+
+
+EGRESS_PROFILE_SET_DIGEST = "sha256:" + hashlib.sha256(
+    json.dumps(
+        {
+            profile.ref: _gateway_policy_digest(profile)
+            for profile in (DEFAULT_EGRESS_PROFILE, OMNIGENT_EGRESS_PROFILE)
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode()
+).hexdigest()
+
 
 async def attest_docker_egress(
     *,
@@ -218,10 +263,13 @@ async def attest_docker_egress(
     """Prove the internal network and sole dual-homed gateway exist.
 
     Docker's ``internal`` flag removes a default external route at the network
-    layer.  The gateway is trusted deployment state and must carry the exact
-    profile and implementation labels.  A stale gateway/profile therefore
-    fails closed rather than being reused.
+    layer. The gateway is trusted deployment state and must carry the exact
+    approved profile-set and implementation labels. A stale gateway/profile
+    therefore fails closed rather than being reused.
     """
+
+    if EGRESS_PROFILE_DIGESTS.get(profile.ref) != profile.digest:
+        raise RuntimeError("restricted-egress profile is not approved")
 
     code, stdout, _ = await runner(
         ("network", "inspect", "--format", "{{json .}}", profile.network_ref)
@@ -251,8 +299,8 @@ async def attest_docker_egress(
         raise RuntimeError("restricted-egress gateway attestation is malformed") from exc
     labels = gateway.get("labels") or {}
     networks = gateway.get("networks") or {}
-    if labels.get("moonmind.egress.profile") != profile.ref:
-        raise RuntimeError("restricted-egress gateway profile is stale or mismatched")
+    if labels.get("moonmind.egress.profile-set-digest") != EGRESS_PROFILE_SET_DIGEST:
+        raise RuntimeError("restricted-egress gateway profile set is stale")
     if labels.get("moonmind.egress.enforcer") != ENFORCER_IMPLEMENTATION:
         raise RuntimeError("restricted-egress gateway implementation is unattested")
     if labels.get("moonmind.egress.config-digest") != EGRESS_CONFIG_DIGEST:
@@ -286,6 +334,7 @@ async def attest_docker_egress(
         "gatewayImageDigest": image_digest,
         "internal": True,
         "ipv6": False,
+        "idleSeconds": profile.idle_seconds,
         "gatewayNetworks": sorted(networks),
         "enforcer": ENFORCER_IMPLEMENTATION,
     }
@@ -315,6 +364,19 @@ def restricted_proxy_env() -> tuple[str, ...]:
         f"HTTPS_PROXY={PROXY_URL}",
         f"http_proxy={PROXY_URL}",
         f"https_proxy={PROXY_URL}",
+        "NO_PROXY=",
+        "no_proxy=",
+    )
+
+
+def omnigent_proxy_env() -> tuple[str, ...]:
+    """Proxy environment for the isolated Omnigent control-plane ingress."""
+
+    return (
+        f"HTTP_PROXY={OMNIGENT_PROXY_URL}",
+        f"HTTPS_PROXY={OMNIGENT_PROXY_URL}",
+        f"http_proxy={OMNIGENT_PROXY_URL}",
+        f"https_proxy={OMNIGENT_PROXY_URL}",
         "NO_PROXY=",
         "no_proxy=",
     )

--- a/moonmind/security/egress.py
+++ b/moonmind/security/egress.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import hashlib
 import ipaddress
 import json
+import os
 from datetime import UTC, datetime
 from typing import Awaitable, Callable, Literal, Sequence
 
@@ -21,13 +22,23 @@ ENFORCER_IMPLEMENTATION = "docker-internal-proxy/v1"
 # Digest of the reviewed, mounted Squid policy. Attestation compares this
 # deployment-owned value with both the container label and the live file.
 EGRESS_CONFIG_DIGEST = "sha256:c3ad0d533dab70608bbbbcb0a5e82b94f67364cfcb2f4d670d0c944b2e945faa"
-EGRESS_NETWORK_REF = "moonmind_restricted-egress-network"
+# Deployment-owned network names. Compose resolves these same overrides when it
+# creates the networks (``restricted-egress-network`` /
+# ``sandbox-egress-network``), so an operator that sets the documented override
+# gets the resolved name fed into the immutable profile and every attestation
+# rather than a hard-coded default the backend would then fail closed against.
+EGRESS_NETWORK_REF = os.environ.get(
+    "MOONMIND_RESTRICTED_EGRESS_NETWORK", "moonmind_restricted-egress-network"
+)
+_SANDBOX_EGRESS_NETWORK_REF = os.environ.get(
+    "MOONMIND_SANDBOX_EGRESS_NETWORK", "moonmind_sandbox-egress-network"
+)
 EGRESS_GATEWAY_REF = "moonmind-sandbox-egress-proxy"
 PROXY_URL = "http://sandbox-egress-proxy:3128"
 _EXPECTED_GATEWAY_NETWORKS = frozenset(
     {
         EGRESS_NETWORK_REF,
-        "moonmind_sandbox-egress-network",
+        _SANDBOX_EGRESS_NETWORK_REF,
         "local-network",
     }
 )

--- a/moonmind/security/egress.py
+++ b/moonmind/security/egress.py
@@ -18,6 +18,9 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator, model_valida
 CommandRunner = Callable[[Sequence[str]], Awaitable[tuple[int, bytes, bytes]]]
 
 ENFORCER_IMPLEMENTATION = "docker-internal-proxy/v1"
+# Digest of the reviewed, mounted Squid policy. Attestation compares this
+# deployment-owned value with both the container label and the live file.
+EGRESS_CONFIG_DIGEST = "sha256:c3ad0d533dab70608bbbbcb0a5e82b94f67364cfcb2f4d670d0c944b2e945faa"
 EGRESS_NETWORK_REF = "moonmind_restricted-egress-network"
 EGRESS_GATEWAY_REF = "moonmind-sandbox-egress-proxy"
 PROXY_URL = "http://sandbox-egress-proxy:3128"
@@ -148,6 +151,9 @@ class EgressAttestation(BaseModel):
     network_ref: str = Field(alias="networkRef")
     gateway_ref: str = Field(alias="gatewayRef")
     applied_rule_digest: str = Field(alias="appliedRuleDigest")
+    config_digest: str = Field(alias="configDigest")
+    gateway_image_digest: str = Field(alias="gatewayImageDigest")
+    health_result: Literal["healthy"] = Field("healthy", alias="healthResult")
     validated_at: datetime = Field(alias="validatedAt")
     validation_result: Literal["passed"] = Field("passed", alias="validationResult")
     denied_connection_count: int = Field(0, alias="deniedConnectionCount", ge=0)
@@ -220,7 +226,8 @@ async def attest_docker_egress(
 
     format_value = (
         '{"labels":{{json .Config.Labels}},"networks":'
-        '{{json .NetworkSettings.Networks}}}'
+        '{{json .NetworkSettings.Networks}},"image":{{json .Image}},'
+        '"health":{{json .State.Health.Status}}}'
     )
     code, stdout, _ = await runner(
         ("inspect", "--format", format_value, profile.gateway_ref)
@@ -237,11 +244,35 @@ async def attest_docker_egress(
         raise RuntimeError("restricted-egress gateway profile is stale or mismatched")
     if labels.get("moonmind.egress.enforcer") != ENFORCER_IMPLEMENTATION:
         raise RuntimeError("restricted-egress gateway implementation is unattested")
+    if labels.get("moonmind.egress.config-digest") != EGRESS_CONFIG_DIGEST:
+        raise RuntimeError("restricted-egress gateway config label is stale")
     if set(networks) != _EXPECTED_GATEWAY_NETWORKS:
         raise RuntimeError("restricted-egress gateway attachment is invalid")
+    image_digest = str(gateway.get("image") or "")
+    if not image_digest.startswith("sha256:"):
+        raise RuntimeError("restricted-egress gateway image is unattested")
+    health = str(gateway.get("health") or "")
+    if health != "healthy":
+        raise RuntimeError("restricted-egress gateway is not healthy")
+
+    code, stdout, _ = await runner(
+        (
+            "exec",
+            profile.gateway_ref,
+            "sha256sum",
+            "/etc/squid/squid.conf",
+        )
+    )
+    if code:
+        raise RuntimeError("restricted-egress live config cannot be observed")
+    observed_config_digest = "sha256:" + stdout.decode(errors="replace").split()[0]
+    if observed_config_digest != EGRESS_CONFIG_DIGEST:
+        raise RuntimeError("restricted-egress live config is stale or mismatched")
 
     applied = {
         "profileDigest": profile.digest,
+        "configDigest": observed_config_digest,
+        "gatewayImageDigest": image_digest,
         "internal": True,
         "ipv6": False,
         "gatewayNetworks": sorted(networks),
@@ -258,6 +289,9 @@ async def attest_docker_egress(
         networkRef=profile.network_ref,
         gatewayRef=profile.gateway_ref,
         appliedRuleDigest=applied_digest,
+        configDigest=observed_config_digest,
+        gatewayImageDigest=image_digest,
+        healthResult="healthy",
         validatedAt=datetime.now(UTC),
     )
 

--- a/moonmind/workflows/temporal/container_job_backend.py
+++ b/moonmind/workflows/temporal/container_job_backend.py
@@ -1395,9 +1395,10 @@ class DockerContainerJobBackend:
         self._enforce_resource_ceilings(request)
         spec = request.request.spec
         name = self._name(request)
-        await self._reject_ownership_collision(request, name)
         if spec.network_mode not in {"none", "bridge"}:
             raise RuntimeError("network mode must be 'none' or policy-approved 'bridge'")
+        # Prove network-layer egress enforcement before probing container state
+        # or reserving a name; an unattested launch must fail closed first.
         egress_attestation = None
         network_mode = spec.network_mode
         if spec.network_mode == "bridge":
@@ -1407,6 +1408,7 @@ class DockerContainerJobBackend:
                 backend_ref=self._backend_ref,
             )
             network_mode = egress_attestation.network_ref
+        await self._reject_ownership_collision(request, name)
         volume_name = request.resolved_workspace_volume_name
         volume_subpath = request.resolved_workspace_volume_subpath
         if (

--- a/moonmind/workflows/temporal/container_job_backend.py
+++ b/moonmind/workflows/temporal/container_job_backend.py
@@ -1517,7 +1517,38 @@ class DockerContainerJobBackend:
             # Docker mount errors echo the trusted host source. Keep it out of
             # workflow history and caller-visible terminal diagnostics.
             raise RuntimeError("docker create failed for the resolved workspace")
-        return ContainerJobActivityResult(containerRef=name)
+        egress_evidence_ref = None
+        if egress_attestation is not None and self._publish is not None:
+            evidence = {
+                "schemaVersion": 1,
+                "kind": "restricted-egress-launch-attestation",
+                "attachmentIdentity": name,
+                "attestation": egress_attestation.model_dump(
+                    by_alias=True, mode="json"
+                ),
+                "deniedConnectionCount": 0,
+                "denialDiagnostics": [],
+                "cleanupResult": "pending",
+                "reconciliationResult": "not-required",
+            }
+            try:
+                egress_evidence_ref = await self._publish(
+                    request,
+                    f"{request.job_id}-egress-attestation.json",
+                    json.dumps(
+                        evidence, sort_keys=True, separators=(",", ":")
+                    ).encode(),
+                )
+            except Exception as exc:
+                # Evidence is part of readiness at this authority boundary. A
+                # container that cannot publish it must never be started.
+                await self._runner(("rm", "--force", name))
+                raise RuntimeError(
+                    "restricted-egress launch evidence could not be persisted"
+                ) from exc
+        return ContainerJobActivityResult(
+            containerRef=name, diagnosticsRef=egress_evidence_ref
+        )
 
     async def start_container(self, request: ContainerJobActivityRequest):
         await self._checked("start", request.container_ref or self._name(request))

--- a/moonmind/workflows/temporal/container_job_backend.py
+++ b/moonmind/workflows/temporal/container_job_backend.py
@@ -78,6 +78,11 @@ from moonmind.workflows.temporal.runtime.registry_auth_resolve import (
     resolve_registry_pull_credentials,
 )
 from moonmind.workloads.docker_launcher import structured_container_security_args
+from moonmind.security.egress import (
+    DEFAULT_EGRESS_PROFILE,
+    attest_docker_egress,
+    restricted_proxy_env,
+)
 from moonmind.schemas.workspace_locator_models import (
     ExternalStateLocator,
     ManagedWorkspaceLocator,
@@ -535,6 +540,12 @@ class DockerContainerJobBackend:
 
         code, _, _ = await self._runner(("network", "inspect", network_ref))
         return code == 0
+
+    @property
+    def command_runner(self) -> CommandRunner:
+        """Expose only the normalized trusted runner for backend attestation."""
+
+        return self._runner
 
     async def resolve_workspace(self, request: ContainerJobActivityRequest):
         locator = request.request.spec.workspace_ref
@@ -1387,6 +1398,15 @@ class DockerContainerJobBackend:
         await self._reject_ownership_collision(request, name)
         if spec.network_mode not in {"none", "bridge"}:
             raise RuntimeError("network mode must be 'none' or policy-approved 'bridge'")
+        egress_attestation = None
+        network_mode = spec.network_mode
+        if spec.network_mode == "bridge":
+            egress_attestation = await attest_docker_egress(
+                runner=self._runner,
+                profile=DEFAULT_EGRESS_PROFILE,
+                backend_ref=self._backend_ref,
+            )
+            network_mode = egress_attestation.network_ref
         volume_name = request.resolved_workspace_volume_name
         volume_subpath = request.resolved_workspace_volume_subpath
         if (
@@ -1450,7 +1470,7 @@ class DockerContainerJobBackend:
             "--label",
             f"{LABEL_OWNERSHIP_SCHEMA}={OWNERSHIP_SCHEMA_VERSION}",
             "--network",
-            spec.network_mode,
+            network_mode,
             *structured_container_security_args(),
             "--cpus",
             str(spec.resources.cpu_millis / 1000),
@@ -1471,6 +1491,21 @@ class DockerContainerJobBackend:
                 "resolve it to an approved volume"
             )
         args.extend(await self._materialized_env(request))
+        if egress_attestation is not None:
+            args.extend(
+                (
+                    "--label",
+                    f"moonmind.egress.profile={egress_attestation.profile_ref}",
+                    "--label",
+                    "moonmind.egress.profile_digest="
+                    f"{egress_attestation.profile_digest}",
+                    "--label",
+                    "moonmind.egress.applied_rule_digest="
+                    f"{egress_attestation.applied_rule_digest}",
+                )
+            )
+            for proxy_env in restricted_proxy_env():
+                args.extend(("--env", proxy_env))
         if spec.entrypoint:
             args.extend(("--entrypoint", spec.entrypoint[0]))
         self._reject_forbidden_launch_args(args)

--- a/moonmind/workflows/temporal/worker_runtime.py
+++ b/moonmind/workflows/temporal/worker_runtime.py
@@ -2761,15 +2761,25 @@ async def _build_runtime_activities(topology) -> tuple[AsyncExitStack, list[obje
                 # missing or unreachable rather than at first job launch.
                 await container_job_backend.check_readiness()
                 from moonmind.omnigent.execution_profiles import POLICIES
+                from moonmind.security.egress import (
+                    DEFAULT_EGRESS_PROFILE,
+                    attest_docker_egress,
+                )
 
                 enforced_network_refs = []
+                egress_attestation = await attest_docker_egress(
+                    runner=container_job_backend.command_runner,
+                    profile=DEFAULT_EGRESS_PROFILE,
+                    backend_ref=container_backend_settings.default_backend_ref,
+                )
                 for policy in POLICIES.values():
                     if (
                         policy.enabled
                         and policy.enforced_egress
-                        and await container_job_backend.network_ready(policy.network_ref)
+                        and policy.network_ref == egress_attestation.network_ref
                     ):
                         enforced_network_refs.append(policy.network_ref)
+                resources.egress_attestation = egress_attestation  # type: ignore[attr-defined]
             else:
                 container_job_backend = None
                 enforced_network_refs = []
@@ -3003,6 +3013,13 @@ async def main_async() -> None:
                 "ready": container_job_backend is not None,
                 "enforcedNetworkRefs": sorted(set(enforced_network_refs)),
             }
+            egress_attestation = getattr(
+                runtime_resources, "egress_attestation", None
+            )
+            if egress_attestation is not None:
+                health_state.readiness_metadata["containerBackend"][
+                    "egressAttestation"
+                ] = egress_attestation.model_dump(by_alias=True, mode="json")
 
         logger.info(
             "Temporal executable worker specification: %s",

--- a/moonmind/workloads/docker_launcher.py
+++ b/moonmind/workloads/docker_launcher.py
@@ -235,17 +235,30 @@ def _workload_command_args(
 def _profile_network_args(network_policy: str) -> tuple[str, list[str]]:
     if network_policy == "none":
         return "none", []
-    if network_policy != "bridge":
-        raise DockerWorkloadLauncherError("unsupported workload network policy")
-    args = [
-        "--label",
-        f"moonmind.egress.profile={DEFAULT_EGRESS_PROFILE.ref}",
-        "--label",
-        f"moonmind.egress.profile_digest={DEFAULT_EGRESS_PROFILE.digest}",
-    ]
-    for value in restricted_proxy_env():
-        args.extend(("--env", value))
-    return EGRESS_NETWORK_REF, args
+    if network_policy == "restricted_egress":
+        args = [
+            "--label",
+            f"moonmind.egress.profile={DEFAULT_EGRESS_PROFILE.ref}",
+            "--label",
+            f"moonmind.egress.profile_digest={DEFAULT_EGRESS_PROFILE.digest}",
+        ]
+        for value in restricted_proxy_env():
+            args.extend(("--env", value))
+        return EGRESS_NETWORK_REF, args
+    if network_policy == "docker_proxy":
+        return (
+            os.environ.get(
+                "MOONMIND_DOCKER_PROXY_NETWORK",
+                "moonmind_docker-proxy-network",
+            ),
+            [],
+        )
+    if network_policy == "pentest_approved_lab":
+        raise DockerWorkloadLauncherError(
+            "pentest_approved_lab requires a target-specific reviewed egress "
+            "profile before launch"
+        )
+    raise DockerWorkloadLauncherError("unsupported workload network policy")
 
 def _path_is_under_mount(path: str, mounts: Sequence[WorkloadMount]) -> bool:
     normalized = posixpath.normpath(path)
@@ -804,16 +817,20 @@ class DockerWorkloadLauncher:
     ) -> EgressAttestation | None:
         """Fail closed at the shared process-creation boundary.
 
-        Argument construction is deliberately side-effect free, but a bridge
-        profile must not become a Docker process based on declared network
-        metadata alone. Both one-shot and helper launches pass this boundary.
+        Argument construction is deliberately side-effect free, but a
+        restricted-egress profile must not become a Docker process based on
+        declared network metadata alone. Both one-shot and helper launches
+        pass this boundary.
 
         The proven attestation is returned to the caller so each workload
         lifecycle can publish its durable evidence (profile/applied-rule digest
         and validation time) instead of discarding it.
         """
 
-        if request.profile is None or request.profile.network_policy != "bridge":
+        if (
+            request.profile is None
+            or request.profile.network_policy != "restricted_egress"
+        ):
             return None
 
         async def runner(args: Sequence[str]) -> tuple[int, bytes, bytes]:

--- a/moonmind/workloads/docker_launcher.py
+++ b/moonmind/workloads/docker_launcher.py
@@ -20,12 +20,13 @@ from moonmind.schemas.workload_models import (
     WorkloadResourceOverrides,
     WorkloadResult,
 )
-from moonmind.utils.logging import redact_sensitive_payload, redact_sensitive_text
 from moonmind.security.egress import (
     DEFAULT_EGRESS_PROFILE,
     EGRESS_NETWORK_REF,
+    attest_docker_egress,
     restricted_proxy_env,
 )
+from moonmind.utils.logging import redact_sensitive_payload, redact_sensitive_text
 
 _MAX_CAPTURED_STREAM_CHARS = 64_000
 _MAX_CAPTURED_STREAM_BYTES = 64_000
@@ -797,6 +798,29 @@ class DockerWorkloadLauncher:
         )
         self._helper_leases: dict[str, _ConcurrencyLease] = {}
 
+    async def _attest_egress_before_launch(
+        self, request: ValidatedWorkloadRequest
+    ) -> None:
+        """Fail closed at the shared process-creation boundary.
+
+        Argument construction is deliberately side-effect free, but a bridge
+        profile must not become a Docker process based on declared network
+        metadata alone. Both one-shot and helper launches pass this boundary.
+        """
+
+        if request.profile is None or request.profile.network_policy != "bridge":
+            return
+
+        async def runner(args: Sequence[str]) -> tuple[int, bytes, bytes]:
+            stdout, stderr, code = await self._janitor._run_control(args)
+            return code, stdout, stderr
+
+        await attest_docker_egress(
+            runner=runner,
+            profile=DEFAULT_EGRESS_PROFILE,
+            backend_ref="docker-workload-launcher",
+        )
+
     def build_run_args(self, request: ValidatedWorkloadRequest) -> list[str]:
         _ensure_paths_are_mounted(request)
         profile = request.profile
@@ -921,6 +945,7 @@ class DockerWorkloadLauncher:
         lease = await self._concurrency_limiter.acquire(request)
 
         try:
+            await self._attest_egress_before_launch(request)
             process = await asyncio.create_subprocess_exec(
                 *self.build_run_args(request),
                 stdout=asyncio.subprocess.PIPE,
@@ -1071,6 +1096,7 @@ class DockerWorkloadLauncher:
         started_at = datetime.now(UTC)
         lease = await self._concurrency_limiter.acquire(request)
         try:
+            await self._attest_egress_before_launch(request)
             process = await asyncio.create_subprocess_exec(
                 *self.build_helper_run_args(request),
                 stdout=asyncio.subprocess.PIPE,

--- a/moonmind/workloads/docker_launcher.py
+++ b/moonmind/workloads/docker_launcher.py
@@ -23,6 +23,7 @@ from moonmind.schemas.workload_models import (
 from moonmind.security.egress import (
     DEFAULT_EGRESS_PROFILE,
     EGRESS_NETWORK_REF,
+    EgressAttestation,
     attest_docker_egress,
     restricted_proxy_env,
 )
@@ -800,26 +801,38 @@ class DockerWorkloadLauncher:
 
     async def _attest_egress_before_launch(
         self, request: ValidatedWorkloadRequest
-    ) -> None:
+    ) -> EgressAttestation | None:
         """Fail closed at the shared process-creation boundary.
 
         Argument construction is deliberately side-effect free, but a bridge
         profile must not become a Docker process based on declared network
         metadata alone. Both one-shot and helper launches pass this boundary.
+
+        The proven attestation is returned to the caller so each workload
+        lifecycle can publish its durable evidence (profile/applied-rule digest
+        and validation time) instead of discarding it.
         """
 
         if request.profile is None or request.profile.network_policy != "bridge":
-            return
+            return None
 
         async def runner(args: Sequence[str]) -> tuple[int, bytes, bytes]:
             stdout, stderr, code = await self._janitor._run_control(args)
             return code, stdout, stderr
 
-        await attest_docker_egress(
+        return await attest_docker_egress(
             runner=runner,
             profile=DEFAULT_EGRESS_PROFILE,
             backend_ref="docker-workload-launcher",
         )
+
+    @staticmethod
+    def _egress_attestation_evidence(
+        egress_attestation: EgressAttestation | None,
+    ) -> dict[str, object] | None:
+        if egress_attestation is None:
+            return None
+        return egress_attestation.model_dump(by_alias=True, mode="json")
 
     def build_run_args(self, request: ValidatedWorkloadRequest) -> list[str]:
         _ensure_paths_are_mounted(request)
@@ -943,9 +956,10 @@ class DockerWorkloadLauncher:
             else _request_timeout_seconds(request)
         )
         lease = await self._concurrency_limiter.acquire(request)
+        egress_attestation: EgressAttestation | None = None
 
         try:
-            await self._attest_egress_before_launch(request)
+            egress_attestation = await self._attest_egress_before_launch(request)
             process = await asyncio.create_subprocess_exec(
                 *self.build_run_args(request),
                 stdout=asyncio.subprocess.PIPE,
@@ -1048,6 +1062,9 @@ class DockerWorkloadLauncher:
         diagnostics["collectedOutputRefs"] = dict(collected_refs)
         diagnostics["collectedOutputs"] = collected_outputs
         diagnostics["reportPublication"] = report_publication
+        egress_evidence = self._egress_attestation_evidence(egress_attestation)
+        diagnostics["egressAttestation"] = egress_evidence
+        workload_metadata["egressAttestation"] = egress_evidence
         stdout_ref, stderr_ref, diagnostics_ref, output_refs, artifact_publication = (
             _publish_workload_artifacts(
                 request,
@@ -1095,8 +1112,9 @@ class DockerWorkloadLauncher:
     ) -> WorkloadResult:
         started_at = datetime.now(UTC)
         lease = await self._concurrency_limiter.acquire(request)
+        egress_attestation: EgressAttestation | None = None
         try:
-            await self._attest_egress_before_launch(request)
+            egress_attestation = await self._attest_egress_before_launch(request)
             process = await asyncio.create_subprocess_exec(
                 *self.build_helper_run_args(request),
                 stdout=asyncio.subprocess.PIPE,
@@ -1117,6 +1135,7 @@ class DockerWorkloadLauncher:
                         "status": "not_started",
                         "reason": "docker run failed",
                     },
+                    egress_attestation=egress_attestation,
                 )
             self._helper_leases[request.container_name] = lease
             lease = None
@@ -1135,6 +1154,7 @@ class DockerWorkloadLauncher:
             stdout=_decode_stream(stdout),
             stderr=_decode_stream(stderr),
             readiness=readiness,
+            egress_attestation=egress_attestation,
         )
 
     async def stop_helper(
@@ -1243,6 +1263,7 @@ class DockerWorkloadLauncher:
         stderr: str,
         readiness: Mapping[str, object],
         teardown: Mapping[str, object] | None = None,
+        egress_attestation: EgressAttestation | None = None,
     ) -> WorkloadResult:
         duration_seconds = (completed_at - started_at).total_seconds()
         helper_metadata = _helper_metadata(
@@ -1278,6 +1299,9 @@ class DockerWorkloadLauncher:
         diagnostics["collectedOutputRefs"] = dict(collected_refs)
         diagnostics["collectedOutputs"] = collected_outputs
         diagnostics["reportPublication"] = report_publication
+        egress_evidence = self._egress_attestation_evidence(egress_attestation)
+        diagnostics["egressAttestation"] = egress_evidence
+        helper_metadata["egressAttestation"] = egress_evidence
         stdout_ref, stderr_ref, diagnostics_ref, output_refs, artifact_publication = (
             _publish_workload_artifacts(
                 request,

--- a/moonmind/workloads/docker_launcher.py
+++ b/moonmind/workloads/docker_launcher.py
@@ -21,6 +21,11 @@ from moonmind.schemas.workload_models import (
     WorkloadResult,
 )
 from moonmind.utils.logging import redact_sensitive_payload, redact_sensitive_text
+from moonmind.security.egress import (
+    DEFAULT_EGRESS_PROFILE,
+    EGRESS_NETWORK_REF,
+    restricted_proxy_env,
+)
 
 _MAX_CAPTURED_STREAM_CHARS = 64_000
 _MAX_CAPTURED_STREAM_BYTES = 64_000
@@ -223,6 +228,22 @@ def _workload_command_args(
             return [workload_command[0]]
         return [shlex.join(workload_command)]
     return list(workload_command)
+
+
+def _profile_network_args(network_policy: str) -> tuple[str, list[str]]:
+    if network_policy == "none":
+        return "none", []
+    if network_policy != "bridge":
+        raise DockerWorkloadLauncherError("unsupported workload network policy")
+    args = [
+        "--label",
+        f"moonmind.egress.profile={DEFAULT_EGRESS_PROFILE.ref}",
+        "--label",
+        f"moonmind.egress.profile_digest={DEFAULT_EGRESS_PROFILE.digest}",
+    ]
+    for value in restricted_proxy_env():
+        args.extend(("--env", value))
+    return EGRESS_NETWORK_REF, args
 
 def _path_is_under_mount(path: str, mounts: Sequence[WorkloadMount]) -> bool:
     normalized = posixpath.normpath(path)
@@ -785,6 +806,7 @@ class DockerWorkloadLauncher:
                 docker_binary=self._docker_binary,
                 request=request,
             )
+        network_ref, egress_args = _profile_network_args(profile.network_policy)
         args = [
             self._docker_binary,
             "run",
@@ -793,8 +815,9 @@ class DockerWorkloadLauncher:
             "--workdir",
             workload.repo_dir,
             "--network",
-            profile.network_policy,
+            network_ref,
             *structured_container_security_args(),
+            *egress_args,
         ]
 
         for key, value in _operational_labels(request).items():
@@ -838,6 +861,7 @@ class DockerWorkloadLauncher:
                 "start_helper requires a bounded_service runner profile"
             )
         _ensure_paths_are_mounted(request)
+        network_ref, egress_args = _profile_network_args(profile.network_policy)
         args = [
             self._docker_binary,
             "run",
@@ -847,8 +871,9 @@ class DockerWorkloadLauncher:
             "--workdir",
             workload.repo_dir,
             "--network",
-            profile.network_policy,
+            network_ref,
             *structured_container_security_args(),
+            *egress_args,
         ]
         for key, value in _operational_labels(request).items():
             args.extend(["--label", f"{key}={value}"])

--- a/tests/integration/temporal/test_compose_foundation.py
+++ b/tests/integration/temporal/test_compose_foundation.py
@@ -634,6 +634,15 @@ def test_omnigent_codex_host_profile_uses_only_canonical_oauth_credentials():
     assert host_service["working_dir"] == "/home/app"
     assert "env_file" not in host_service
     assert _env_map(host_service["environment"]) == {
+        # Restricted-egress enforcement (MoonLadderStudios/MoonMind#3516): the
+        # static Codex host is routed through the trusted proxy on the internal
+        # network. NO_PROXY is pinned empty so no destination bypasses it.
+        "HTTP_PROXY": "http://sandbox-egress-proxy:3128",
+        "HTTPS_PROXY": "http://sandbox-egress-proxy:3128",
+        "http_proxy": "http://sandbox-egress-proxy:3128",
+        "https_proxy": "http://sandbox-egress-proxy:3128",
+        "NO_PROXY": "",
+        "no_proxy": "",
         "MOONMIND_ACTIVE_SKILLS_DIR": "/opt/moonmind-skills",
         "HOME": "/home/app",
         "PATH": MOUNTED_TOOL_PATH,
@@ -697,7 +706,10 @@ def test_omnigent_codex_host_profile_uses_only_canonical_oauth_credentials():
     assert init_service["entrypoint"] == [
         "/opt/moonmind/init-codex-oauth-host.sh"
     ]
-    assert _network_names(host_service) == {"local-network"}
+    # Restricted egress: the host attaches only to the internal enforcing
+    # network (MoonLadderStudios/MoonMind#3516), never the routable
+    # local-network.
+    assert _network_names(host_service) == {"restricted-egress-network"}
 
 
 def test_canonical_omnigent_codex_host_uses_base_owned_oauth_volume():

--- a/tests/integration/temporal/test_compose_foundation.py
+++ b/tests/integration/temporal/test_compose_foundation.py
@@ -399,6 +399,7 @@ def test_sandbox_worker_compose_egress_is_restricted_for_mm_785():
     networks = compose["networks"]
 
     assert networks["sandbox-egress-network"]["internal"] is True
+    assert networks["omnigent-egress-network"]["internal"] is True
     assert _network_names(services["temporal-worker-sandbox"]) == {
         "sandbox-egress-network"
     }
@@ -420,8 +421,16 @@ def test_sandbox_worker_compose_egress_is_restricted_for_mm_785():
         "local-network",
         "sandbox-egress-network",
         "restricted-egress-network",
+        "omnigent-egress-network",
     }
-    assert proxy_service["expose"] == ["3128"]
+    assert proxy_service["expose"] == ["3128", "3129"]
+    assert "omnigent-egress-proxy" in _network_aliases(
+        proxy_service,
+        "omnigent-egress-network",
+    )
+    assert proxy_service["labels"][
+        "moonmind.egress.profile-set-digest"
+    ].startswith("sha256:")
     assert proxy_service["labels"]["moonmind.egress.config-digest"].startswith(
         "sha256:"
     )
@@ -450,8 +459,12 @@ def test_sandbox_worker_compose_egress_is_restricted_for_mm_785():
         ]
     }
     assert "http_access deny all" in squid_config
-    assert "dns_nameservers 1.1.1.1 8.8.8.8" in squid_config
+    assert "dns_nameservers 127.0.0.11" in squid_config
     assert "request_timeout 300 seconds" in squid_config
+    assert "read_timeout 300 seconds" in squid_config
+    assert "http_port omnigent-egress-proxy:3129 name=omnigent_control" in squid_config
+    assert "http_access allow omnigent_listener omnigent_control omnigent_control_port" in squid_config
+    assert "::/0" in squid_config
     assert "acl connection_limit maxconn 128" in squid_config
     assert expected_proxy_domains <= set(squid_config.split())
 
@@ -564,6 +577,12 @@ def test_omnigent_claude_host_profile_uses_only_canonical_oauth_credentials():
 
     host_env = _env_map(host_service["environment"])
     assert host_env == {
+        "HTTP_PROXY": "http://omnigent-egress-proxy:3129",
+        "HTTPS_PROXY": "http://omnigent-egress-proxy:3129",
+        "http_proxy": "http://omnigent-egress-proxy:3129",
+        "https_proxy": "http://omnigent-egress-proxy:3129",
+        "NO_PROXY": "",
+        "no_proxy": "",
         "MOONMIND_ACTIVE_SKILLS_DIR": "/opt/moonmind-skills",
         "OMNIGENT_SERVER_URL": "http://omnigent:8000",
         "HOME": "/home/app",
@@ -603,8 +622,11 @@ def test_omnigent_claude_host_profile_uses_only_canonical_oauth_credentials():
         "omnigent": {"condition": "service_started"},
         "omnigent-host-claude-init": {"condition": "service_completed_successfully"},
         "omnigent-tools-init": {"condition": "service_completed_successfully"},
+        "sandbox-egress-proxy": {"condition": "service_healthy"},
     }
-    assert _network_names(host_service) == {"local-network"}
+    assert _network_names(host_service) == {"omnigent-egress-network"}
+    assert host_service["cap_drop"] == ["ALL"]
+    assert host_service["security_opt"] == ["no-new-privileges:true"]
     assert host_service["restart"] == "unless-stopped"
     assert host_service["healthcheck"] == {
         "test": [
@@ -637,10 +659,10 @@ def test_omnigent_codex_host_profile_uses_only_canonical_oauth_credentials():
         # Restricted-egress enforcement (MoonLadderStudios/MoonMind#3516): the
         # static Codex host is routed through the trusted proxy on the internal
         # network. NO_PROXY is pinned empty so no destination bypasses it.
-        "HTTP_PROXY": "http://sandbox-egress-proxy:3128",
-        "HTTPS_PROXY": "http://sandbox-egress-proxy:3128",
-        "http_proxy": "http://sandbox-egress-proxy:3128",
-        "https_proxy": "http://sandbox-egress-proxy:3128",
+        "HTTP_PROXY": "http://omnigent-egress-proxy:3129",
+        "HTTPS_PROXY": "http://omnigent-egress-proxy:3129",
+        "http_proxy": "http://omnigent-egress-proxy:3129",
+        "https_proxy": "http://omnigent-egress-proxy:3129",
         "NO_PROXY": "",
         "no_proxy": "",
         "MOONMIND_ACTIVE_SKILLS_DIR": "/opt/moonmind-skills",
@@ -697,6 +719,7 @@ def test_omnigent_codex_host_profile_uses_only_canonical_oauth_credentials():
             "condition": "service_completed_successfully"
         },
         "omnigent-tools-init": {"condition": "service_completed_successfully"},
+        "sandbox-egress-proxy": {"condition": "service_healthy"},
     }
     init_service = compose["services"]["omnigent-host-codex-init"]
     assert init_service["user"] == "0:0"
@@ -709,7 +732,7 @@ def test_omnigent_codex_host_profile_uses_only_canonical_oauth_credentials():
     # Restricted egress: the host attaches only to the internal enforcing
     # network (MoonLadderStudios/MoonMind#3516), never the routable
     # local-network.
-    assert _network_names(host_service) == {"restricted-egress-network"}
+    assert _network_names(host_service) == {"omnigent-egress-network"}
 
 
 def test_canonical_omnigent_codex_host_uses_base_owned_oauth_volume():

--- a/tests/integration/temporal/test_compose_foundation.py
+++ b/tests/integration/temporal/test_compose_foundation.py
@@ -419,8 +419,13 @@ def test_sandbox_worker_compose_egress_is_restricted_for_mm_785():
     assert _network_names(proxy_service) == {
         "local-network",
         "sandbox-egress-network",
+        "restricted-egress-network",
     }
     assert proxy_service["expose"] == ["3128"]
+    assert proxy_service["labels"]["moonmind.egress.config-digest"].startswith(
+        "sha256:"
+    )
+    assert "squid -k parse" in proxy_service["healthcheck"]["test"][1]
 
     sandbox_env = _env_map(services["temporal-worker-sandbox"]["environment"])
     assert sandbox_env["HTTPS_PROXY"] == (
@@ -445,6 +450,9 @@ def test_sandbox_worker_compose_egress_is_restricted_for_mm_785():
         ]
     }
     assert "http_access deny all" in squid_config
+    assert "dns_nameservers 1.1.1.1 8.8.8.8" in squid_config
+    assert "request_timeout 300 seconds" in squid_config
+    assert "acl connection_limit maxconn 128" in squid_config
     assert expected_proxy_domains <= set(squid_config.split())
 
 def test_temporal_persistence_and_visibility_environment_defaults():

--- a/tests/integration/temporal/test_pentest_runner_profile_registry.py
+++ b/tests/integration/temporal/test_pentest_runner_profile_registry.py
@@ -1,12 +1,10 @@
-"""Hermetic checks that the deployment runner-profile registry maps the Claude
-OAuth PentestGPT runner to the approved image and Docker ``bridge`` network policy.
+"""Hermetic checks for the deployment-owned PentestGPT runner profile.
 
 These are required-CI hermetic tests: they only parse the checked-in
-``config/workloads/default-runner-profiles.yaml`` and assert the generic Docker
-launcher's actual network policy, complementing the application-level pentest
-metadata (``network_policy="bridge_approved_lab"``) defined in the pentest
-models. The two are distinct: one is MoonMind pentest metadata, the other is the
-generic Docker launcher's enforced network policy.
+``config/workloads/default-runner-profiles.yaml`` and assert that the generic
+Docker launcher requires a target-specific approved lab profile, complementing
+the application-level ``bridge_approved_lab`` pentest metadata. The launcher
+must not collapse that authority into provider-only restricted egress.
 """
 
 from __future__ import annotations
@@ -37,7 +35,7 @@ def test_default_runner_profiles_expose_pentestgpt_claude_oauth() -> None:
 
 @pytest.mark.integration
 @pytest.mark.integration_ci
-def test_pentestgpt_claude_oauth_uses_docker_bridge_network_policy() -> None:
+def test_pentestgpt_claude_oauth_requires_target_specific_lab_egress() -> None:
     registry = RunnerProfileRegistry.load_file(
         _PROFILES_PATH,
         workspace_root="/work/agent_jobs",
@@ -45,4 +43,4 @@ def test_pentestgpt_claude_oauth_uses_docker_bridge_network_policy() -> None:
     profile = registry.get("pentestgpt-claude-oauth")
 
     assert profile is not None
-    assert profile.network_policy == "bridge"
+    assert profile.network_policy == "pentest_approved_lab"

--- a/tests/test_local_dev.py
+++ b/tests/test_local_dev.py
@@ -210,6 +210,9 @@ def test_sandbox_worker_uses_internal_egress_network_for_mm_785():
         "sandbox-egress-network must be an internal Docker network so sandbox "
         "workers do not have default outbound internet egress"
     )
+    restricted_network = networks.get("restricted-egress-network")
+    assert isinstance(restricted_network, dict)
+    assert restricted_network.get("internal") is True
 
     sandbox_worker = services.get("temporal-worker-sandbox")
     assert isinstance(
@@ -243,8 +246,16 @@ def test_sandbox_worker_uses_internal_egress_network_for_mm_785():
     assert _network_names(proxy_service) == {
         "local-network",
         "sandbox-egress-network",
+        "restricted-egress-network",
     }
     assert proxy_service.get("expose") == ["3128"]
+    assert proxy_service["container_name"] == "moonmind-sandbox-egress-proxy"
+    assert proxy_service["labels"]["moonmind.egress.profile"] == (
+        "moonmind-provider-egress@1"
+    )
+    assert proxy_service["labels"]["moonmind.egress.enforcer"] == (
+        "docker-internal-proxy/v1"
+    )
 
     sandbox_env = _env_map(sandbox_worker.get("environment"))
     assert sandbox_env["HTTPS_PROXY"] == (
@@ -266,7 +277,17 @@ def test_sandbox_worker_uses_internal_egress_network_for_mm_785():
         ]
     }
     assert "http_access deny all" in squid_config
+    assert "169.254.0.0/16" in squid_config
+    assert "http_access deny forbidden_destination" in squid_config
     assert expected_proxy_domains <= set(squid_config.split())
+
+    codex_host = services["omnigent-host-codex"]
+    assert _network_names(codex_host) == {"restricted-egress-network"}
+    assert codex_host["cap_drop"] == ["ALL"]
+    assert codex_host["security_opt"] == ["no-new-privileges:true"]
+    codex_env = _env_map(codex_host["environment"])
+    assert codex_env["HTTPS_PROXY"] == "http://sandbox-egress-proxy:3128"
+    assert codex_env["NO_PROXY"] == ""
 
 
 def test_api_service_runs_with_container_init():

--- a/tests/test_local_dev.py
+++ b/tests/test_local_dev.py
@@ -213,6 +213,9 @@ def test_sandbox_worker_uses_internal_egress_network_for_mm_785():
     restricted_network = networks.get("restricted-egress-network")
     assert isinstance(restricted_network, dict)
     assert restricted_network.get("internal") is True
+    omnigent_network = networks.get("omnigent-egress-network")
+    assert isinstance(omnigent_network, dict)
+    assert omnigent_network.get("internal") is True
 
     sandbox_worker = services.get("temporal-worker-sandbox")
     assert isinstance(
@@ -247,12 +250,13 @@ def test_sandbox_worker_uses_internal_egress_network_for_mm_785():
         "local-network",
         "sandbox-egress-network",
         "restricted-egress-network",
+        "omnigent-egress-network",
     }
-    assert proxy_service.get("expose") == ["3128"]
+    assert proxy_service.get("expose") == ["3128", "3129"]
     assert proxy_service["container_name"] == "moonmind-sandbox-egress-proxy"
-    assert proxy_service["labels"]["moonmind.egress.profile"] == (
-        "moonmind-provider-egress@1"
-    )
+    assert proxy_service["labels"][
+        "moonmind.egress.profile-set-digest"
+    ].startswith("sha256:")
     assert proxy_service["labels"]["moonmind.egress.enforcer"] == (
         "docker-internal-proxy/v1"
     )
@@ -279,14 +283,17 @@ def test_sandbox_worker_uses_internal_egress_network_for_mm_785():
     assert "http_access deny all" in squid_config
     assert "169.254.0.0/16" in squid_config
     assert "http_access deny forbidden_destination" in squid_config
+    assert "dns_nameservers 127.0.0.11" in squid_config
+    assert "read_timeout 300 seconds" in squid_config
+    assert "::/0" in squid_config
     assert expected_proxy_domains <= set(squid_config.split())
 
     codex_host = services["omnigent-host-codex"]
-    assert _network_names(codex_host) == {"restricted-egress-network"}
+    assert _network_names(codex_host) == {"omnigent-egress-network"}
     assert codex_host["cap_drop"] == ["ALL"]
     assert codex_host["security_opt"] == ["no-new-privileges:true"]
     codex_env = _env_map(codex_host["environment"])
-    assert codex_env["HTTPS_PROXY"] == "http://sandbox-egress-proxy:3128"
+    assert codex_env["HTTPS_PROXY"] == "http://omnigent-egress-proxy:3129"
     assert codex_env["NO_PROXY"] == ""
 
 

--- a/tests/unit/api/routers/test_omnigent_catalog.py
+++ b/tests/unit/api/routers/test_omnigent_catalog.py
@@ -6,6 +6,7 @@ from types import SimpleNamespace
 import pytest
 from fastapi import FastAPI, HTTPException
 from fastapi.testclient import TestClient
+from moonmind.security.egress import EGRESS_NETWORK_REF
 
 from api_service.api.routers import omnigent_catalog as catalog
 from api_service.auth_providers import get_current_user
@@ -105,7 +106,7 @@ def _app(monkeypatch, *, session, enabled=True, readiness=None, superuser=True):
         lambda: SimpleNamespace(enabled=True),
     )
     async def live_readiness():
-        return True, {"local-network"}
+        return True, {EGRESS_NETWORK_REF}
 
     monkeypatch.setattr(catalog, "_live_deployment_readiness", live_readiness)
     monkeypatch.setenv("OMNIGENT_IMAGE_REF", "registry.test/server@sha256:" + "1" * 64)
@@ -426,7 +427,7 @@ def test_catalog_filters_profiles_not_visible_to_caller(monkeypatch):
 @pytest.mark.parametrize(
     ("live_readiness", "expected"),
     [
-        ((False, {"local-network"}), "bridge_endpoint_unavailable"),
+        ((False, {EGRESS_NETWORK_REF}), "bridge_endpoint_unavailable"),
         ((True, set()), "network_policy_unavailable"),
     ],
 )
@@ -454,7 +455,7 @@ async def test_live_readiness_requires_worker_route_backend_and_network(monkeypa
             "taskQueues": ["mm.activity.agent_runtime"],
             "containerBackend": {
                 "ready": True,
-                "enforcedNetworkRefs": ["local-network"],
+                "enforcedNetworkRefs": [EGRESS_NETWORK_REF],
             },
         }),
     ])
@@ -477,7 +478,7 @@ async def test_live_readiness_requires_worker_route_backend_and_network(monkeypa
 
     assert await catalog._live_deployment_readiness() == (
         True,
-        {"local-network"},
+        {EGRESS_NETWORK_REF},
     )
 
 

--- a/tests/unit/api/routers/test_omnigent_catalog.py
+++ b/tests/unit/api/routers/test_omnigent_catalog.py
@@ -6,7 +6,7 @@ from types import SimpleNamespace
 import pytest
 from fastapi import FastAPI, HTTPException
 from fastapi.testclient import TestClient
-from moonmind.security.egress import EGRESS_NETWORK_REF
+from moonmind.security.egress import OMNIGENT_EGRESS_NETWORK_REF
 
 from api_service.api.routers import omnigent_catalog as catalog
 from api_service.auth_providers import get_current_user
@@ -106,7 +106,7 @@ def _app(monkeypatch, *, session, enabled=True, readiness=None, superuser=True):
         lambda: SimpleNamespace(enabled=True),
     )
     async def live_readiness():
-        return True, {EGRESS_NETWORK_REF}
+        return True, {OMNIGENT_EGRESS_NETWORK_REF}
 
     monkeypatch.setattr(catalog, "_live_deployment_readiness", live_readiness)
     monkeypatch.setenv("OMNIGENT_IMAGE_REF", "registry.test/server@sha256:" + "1" * 64)
@@ -427,7 +427,7 @@ def test_catalog_filters_profiles_not_visible_to_caller(monkeypatch):
 @pytest.mark.parametrize(
     ("live_readiness", "expected"),
     [
-        ((False, {EGRESS_NETWORK_REF}), "bridge_endpoint_unavailable"),
+        ((False, {OMNIGENT_EGRESS_NETWORK_REF}), "bridge_endpoint_unavailable"),
         ((True, set()), "network_policy_unavailable"),
     ],
 )
@@ -455,7 +455,7 @@ async def test_live_readiness_requires_worker_route_backend_and_network(monkeypa
             "taskQueues": ["mm.activity.agent_runtime"],
             "containerBackend": {
                 "ready": True,
-                "enforcedNetworkRefs": [EGRESS_NETWORK_REF],
+                "enforcedNetworkRefs": [OMNIGENT_EGRESS_NETWORK_REF],
             },
         }),
     ])
@@ -478,7 +478,7 @@ async def test_live_readiness_requires_worker_route_backend_and_network(monkeypa
 
     assert await catalog._live_deployment_readiness() == (
         True,
-        {EGRESS_NETWORK_REF},
+        {OMNIGENT_EGRESS_NETWORK_REF},
     )
 
 

--- a/tests/unit/integrations/pentest/test_pentest_models.py
+++ b/tests/unit/integrations/pentest/test_pentest_models.py
@@ -254,6 +254,45 @@ def test_pentest_scope_validation_accepts_authorized_scope() -> None:
         request, now=datetime(2026, 4, 22, 12, tzinfo=UTC)
     )
 
+
+def test_external_pentest_scope_requires_exact_egress_profile_and_review(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from moonmind.config.settings import settings
+    from moonmind.security.egress import DEFAULT_EGRESS_PROFILE
+
+    monkeypatch.setattr(settings.pentest, "allow_external_targets", True)
+    payload = _valid_request_payload()
+    payload["target"] = "https://github.com"
+    payload["approved_scope"] = _approved_scope_payload(
+        target_class="external_authorized",
+        targets=[{"kind": "url", "value": "https://github.com"}],
+        requires_manual_approval=True,
+        approval_recorded=True,
+        approval_ticket="SEC-3516",
+        security_review_ref="review:SEC-3516",
+        egress_profile_ref=DEFAULT_EGRESS_PROFILE.ref,
+    )
+    payload["trusted_internal_execution"] = True
+    request = PentestWorkloadRequest.model_validate(payload)
+
+    validate_authorized_scope_for_request(
+        request, now=datetime(2026, 4, 22, 12, tzinfo=UTC)
+    )
+
+    request = request.model_copy(
+        update={
+            "approved_scope": request.approved_scope.model_copy(
+                update={"egress_profile_ref": "stale@1"}
+            )
+        }
+    )
+    with pytest.raises(PentestScopeValidationError) as exc_info:
+        validate_authorized_scope_for_request(
+            request, now=datetime(2026, 4, 22, 12, tzinfo=UTC)
+        )
+    assert "external_egress_profile_mismatch" in exc_info.value.reasons
+
 def test_pentest_workload_request_rejects_user_controlled_docker_launch_fields() -> None:
     payload = _valid_request_payload()
     payload.update(

--- a/tests/unit/integrations/pentest/test_pentest_models.py
+++ b/tests/unit/integrations/pentest/test_pentest_models.py
@@ -270,7 +270,7 @@ def test_external_pentest_scope_requires_exact_egress_profile_and_review(
         requires_manual_approval=True,
         approval_recorded=True,
         approval_ticket="SEC-3516",
-        security_review_ref="review:SEC-3516",
+        security_review_ref=DEFAULT_EGRESS_PROFILE.security_review_ref,
         egress_profile_ref=DEFAULT_EGRESS_PROFILE.ref,
     )
     payload["trusted_internal_execution"] = True
@@ -280,7 +280,7 @@ def test_external_pentest_scope_requires_exact_egress_profile_and_review(
         request, now=datetime(2026, 4, 22, 12, tzinfo=UTC)
     )
 
-    request = request.model_copy(
+    mismatched_profile = request.model_copy(
         update={
             "approved_scope": request.approved_scope.model_copy(
                 update={"egress_profile_ref": "stale@1"}
@@ -289,9 +289,24 @@ def test_external_pentest_scope_requires_exact_egress_profile_and_review(
     )
     with pytest.raises(PentestScopeValidationError) as exc_info:
         validate_authorized_scope_for_request(
-            request, now=datetime(2026, 4, 22, 12, tzinfo=UTC)
+            mismatched_profile, now=datetime(2026, 4, 22, 12, tzinfo=UTC)
         )
     assert "external_egress_profile_mismatch" in exc_info.value.reasons
+
+    # A nonempty but non-matching review reference (e.g. a placeholder) must be
+    # rejected just as strictly as the egress profile reference itself.
+    mismatched_review = request.model_copy(
+        update={
+            "approved_scope": request.approved_scope.model_copy(
+                update={"security_review_ref": "reviewed"}
+            )
+        }
+    )
+    with pytest.raises(PentestScopeValidationError) as exc_info:
+        validate_authorized_scope_for_request(
+            mismatched_review, now=datetime(2026, 4, 22, 12, tzinfo=UTC)
+        )
+    assert "external_security_review_mismatch" in exc_info.value.reasons
 
 def test_pentest_workload_request_rejects_user_controlled_docker_launch_fields() -> None:
     payload = _valid_request_payload()

--- a/tests/unit/integrations/pentest/test_pentest_models.py
+++ b/tests/unit/integrations/pentest/test_pentest_models.py
@@ -209,7 +209,7 @@ def test_pentest_settings_default_enables_tool_with_disable_override(
     defaults = PentestSettings(_env_file=None)
 
     assert defaults.enabled is True
-    assert defaults.allow_external_targets is True
+    assert defaults.allow_external_targets is False
     assert defaults.require_manual_approval_for_external is True
     assert PentestSettings(MOONMIND_PENTEST_ENABLED="false").enabled is False
     assert PentestSettings(MOONMIND_PENTEST_ENABLED="true").enabled is True

--- a/tests/unit/omnigent/test_oauth_profile_lifecycle.py
+++ b/tests/unit/omnigent/test_oauth_profile_lifecycle.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import runpy
 import subprocess
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from pydantic import ValidationError
@@ -2100,6 +2100,10 @@ async def _run_coordinator_failure_case(
         return_value=Path("/tmp/workspace")
     )
     runtime._launch_on_demand = AsyncMock()  # type: ignore[method-assign]
+    # Egress attestation is an orthogonal trusted-backend gate; this matrix
+    # exercises coordinator failure/cleanup evidence, so treat enforcement as
+    # already attested and let the intended failure stages surface.
+    runtime._attest_egress = AsyncMock(return_value=MagicMock())  # type: ignore[method-assign]
     runtime._exec_check = AsyncMock()  # type: ignore[method-assign]
     runtime._exec_tools_check = AsyncMock()  # type: ignore[method-assign]
     runtime._resolve_exact_host = AsyncMock(  # type: ignore[method-assign]

--- a/tests/unit/security/test_egress.py
+++ b/tests/unit/security/test_egress.py
@@ -49,9 +49,13 @@ def test_profile_rejects_internal_wildcard_and_direct_ip_names(name):
 
 
 def test_profile_is_immutable_digest_stable_and_has_no_execution_fields():
-    assert DEFAULT_EGRESS_PROFILE.digest == DEFAULT_EGRESS_PROFILE.digest
-    assert "command" not in DEFAULT_EGRESS_PROFILE.model_fields
-    assert "credential" not in DEFAULT_EGRESS_PROFILE.model_fields
+    # Rebuild the profile from its own serialized content and confirm the digest
+    # is content-stable. Comparing the property to itself would be a tautology
+    # (identical operands) and would not prove stability across construction.
+    rebuilt = _profile()
+    assert rebuilt.digest == DEFAULT_EGRESS_PROFILE.digest
+    assert "command" not in type(DEFAULT_EGRESS_PROFILE).model_fields
+    assert "credential" not in type(DEFAULT_EGRESS_PROFILE).model_fields
     with pytest.raises(ValidationError):
         _profile(firewallCommands=["iptables -F"])
 
@@ -218,3 +222,29 @@ def test_proxy_environment_clears_bypass_variables():
     assert "NO_PROXY=" in values
     assert "no_proxy=" in values
     assert all("169.254.169.254" not in value for value in values)
+
+
+def test_network_ref_resolves_configured_override(monkeypatch):
+    """The documented compose override feeds the immutable profile/attestation.
+
+    Setting ``MOONMIND_RESTRICTED_EGRESS_NETWORK`` must change the network the
+    profile declares and the attestation inspects, instead of leaving a hard
+    coded default the backend would fail closed against.
+    """
+
+    import importlib
+
+    from moonmind.security import egress as egress_module
+
+    monkeypatch.setenv("MOONMIND_RESTRICTED_EGRESS_NETWORK", "custom_restricted_net")
+    monkeypatch.setenv("MOONMIND_SANDBOX_EGRESS_NETWORK", "custom_sandbox_net")
+    try:
+        reloaded = importlib.reload(egress_module)
+        assert reloaded.EGRESS_NETWORK_REF == "custom_restricted_net"
+        assert reloaded.DEFAULT_EGRESS_PROFILE.network_ref == "custom_restricted_net"
+        assert "custom_restricted_net" in reloaded._EXPECTED_GATEWAY_NETWORKS
+        assert "custom_sandbox_net" in reloaded._EXPECTED_GATEWAY_NETWORKS
+    finally:
+        # Restore module-level defaults so later tests see the shipped values.
+        monkeypatch.undo()
+        importlib.reload(egress_module)

--- a/tests/unit/security/test_egress.py
+++ b/tests/unit/security/test_egress.py
@@ -1,0 +1,158 @@
+"""Restricted-egress policy and attestation coverage for #3516."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from pydantic import ValidationError
+
+from moonmind.security.egress import (
+    DEFAULT_EGRESS_PROFILE,
+    EGRESS_NETWORK_REF,
+    ENFORCER_IMPLEMENTATION,
+    attest_docker_egress,
+    restricted_proxy_env,
+)
+
+
+def _profile(**updates):
+    payload = DEFAULT_EGRESS_PROFILE.model_dump(by_alias=True, mode="json")
+    payload.update(updates)
+    return type(DEFAULT_EGRESS_PROFILE).model_validate(payload)
+
+
+@pytest.mark.parametrize(
+    "cidr",
+    [
+        "127.0.0.1/32",
+        "169.254.169.254/32",
+        "172.17.0.0/16",
+        "192.168.1.0/24",
+        "::1/128",
+        "fc00::/7",
+        "::ffff:127.0.0.1/128",
+    ],
+)
+def test_profile_rejects_local_metadata_docker_and_mapped_ranges(cidr):
+    with pytest.raises(ValidationError, match="prohibited address range"):
+        _profile(destinations=[{"cidr": cidr, "ports": [443]}])
+
+
+@pytest.mark.parametrize(
+    "name", ["localhost", "service.internal", "*.openai.com", "10.0.0.1"]
+)
+def test_profile_rejects_internal_wildcard_and_direct_ip_names(name):
+    with pytest.raises(ValidationError):
+        _profile(destinations=[{"dnsName": name, "ports": [443]}])
+
+
+def test_profile_is_immutable_digest_stable_and_has_no_execution_fields():
+    assert DEFAULT_EGRESS_PROFILE.digest == DEFAULT_EGRESS_PROFILE.digest
+    assert "command" not in DEFAULT_EGRESS_PROFILE.model_fields
+    assert "credential" not in DEFAULT_EGRESS_PROFILE.model_fields
+    with pytest.raises(ValidationError):
+        _profile(firewallCommands=["iptables -F"])
+
+
+@pytest.mark.asyncio
+async def test_attestation_proves_internal_ipv4_network_and_exact_gateway():
+    calls = []
+
+    async def runner(args):
+        calls.append(tuple(args))
+        if args[0] == "network":
+            return 0, json.dumps(
+                {"Internal": True, "EnableIPv6": False}
+            ).encode(), b""
+        return 0, json.dumps(
+            {
+                "labels": {
+                    "moonmind.egress.profile": DEFAULT_EGRESS_PROFILE.ref,
+                    "moonmind.egress.enforcer": ENFORCER_IMPLEMENTATION,
+                },
+                "networks": {
+                    EGRESS_NETWORK_REF: {},
+                    "moonmind_sandbox-egress-network": {},
+                    "local-network": {},
+                },
+            }
+        ).encode(), b""
+
+    evidence = await attest_docker_egress(
+        runner=runner,
+        profile=DEFAULT_EGRESS_PROFILE,
+        backend_ref="local",
+    )
+
+    assert evidence.validation_result == "passed"
+    assert evidence.profile_digest == DEFAULT_EGRESS_PROFILE.digest
+    assert evidence.applied_rule_digest.startswith("sha256:")
+    assert calls[0][0:2] == ("network", "inspect")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("network", "labels", "networks", "message"),
+    [
+        (
+            {"Internal": False, "EnableIPv6": False},
+            {},
+            {},
+            "not internal",
+        ),
+        (
+            {"Internal": True, "EnableIPv6": True},
+            {},
+            {},
+            "not internal",
+        ),
+        (
+            {"Internal": True, "EnableIPv6": False},
+            {"moonmind.egress.profile": "stale@1"},
+            {
+                EGRESS_NETWORK_REF: {},
+                "moonmind_sandbox-egress-network": {},
+                "local-network": {},
+            },
+            "stale",
+        ),
+        (
+            {"Internal": True, "EnableIPv6": False},
+            {
+                "moonmind.egress.profile": DEFAULT_EGRESS_PROFILE.ref,
+                "moonmind.egress.enforcer": ENFORCER_IMPLEMENTATION,
+            },
+            {
+                EGRESS_NETWORK_REF: {},
+                "moonmind_sandbox-egress-network": {},
+                "local-network": {},
+                "bypass": {},
+            },
+            "attachment",
+        ),
+    ],
+)
+async def test_attestation_fails_closed_on_unproven_or_stale_state(
+    network, labels, networks, message
+):
+    async def runner(args):
+        payload = network if args[0] == "network" else {
+            "labels": labels,
+            "networks": networks,
+        }
+        return 0, json.dumps(payload).encode(), b""
+
+    with pytest.raises(RuntimeError, match=message):
+        await attest_docker_egress(
+            runner=runner,
+            profile=DEFAULT_EGRESS_PROFILE,
+            backend_ref="local",
+        )
+
+
+def test_proxy_environment_clears_bypass_variables():
+    values = restricted_proxy_env()
+    assert "NO_PROXY=" in values
+    assert "no_proxy=" in values
+    assert all("169.254.169.254" not in value for value in values)

--- a/tests/unit/security/test_egress.py
+++ b/tests/unit/security/test_egress.py
@@ -9,6 +9,7 @@ from pydantic import ValidationError
 
 from moonmind.security.egress import (
     DEFAULT_EGRESS_PROFILE,
+    EGRESS_CONFIG_DIGEST,
     EGRESS_NETWORK_REF,
     ENFORCER_IMPLEMENTATION,
     attest_docker_egress,
@@ -65,18 +66,26 @@ async def test_attestation_proves_internal_ipv4_network_and_exact_gateway():
             return 0, json.dumps(
                 {"Internal": True, "EnableIPv6": False}
             ).encode(), b""
-        return 0, json.dumps(
-            {
-                "labels": {
-                    "moonmind.egress.profile": DEFAULT_EGRESS_PROFILE.ref,
-                    "moonmind.egress.enforcer": ENFORCER_IMPLEMENTATION,
-                },
-                "networks": {
-                    EGRESS_NETWORK_REF: {},
-                    "moonmind_sandbox-egress-network": {},
-                    "local-network": {},
-                },
-            }
+        if args[0] == "inspect":
+            return 0, json.dumps(
+                {
+                    "labels": {
+                        "moonmind.egress.profile": DEFAULT_EGRESS_PROFILE.ref,
+                        "moonmind.egress.enforcer": ENFORCER_IMPLEMENTATION,
+                        "moonmind.egress.config-digest": EGRESS_CONFIG_DIGEST,
+                    },
+                    "networks": {
+                        EGRESS_NETWORK_REF: {},
+                        "moonmind_sandbox-egress-network": {},
+                        "local-network": {},
+                    },
+                    "image": "sha256:gateway-image",
+                    "health": "healthy",
+                }
+            ).encode(), b""
+        return 0, (
+            f"{EGRESS_CONFIG_DIGEST.removeprefix('sha256:')}  "
+            "/etc/squid/squid.conf\n"
         ).encode(), b""
 
     evidence = await attest_docker_egress(
@@ -88,7 +97,11 @@ async def test_attestation_proves_internal_ipv4_network_and_exact_gateway():
     assert evidence.validation_result == "passed"
     assert evidence.profile_digest == DEFAULT_EGRESS_PROFILE.digest
     assert evidence.applied_rule_digest.startswith("sha256:")
+    assert evidence.config_digest == EGRESS_CONFIG_DIGEST
+    assert evidence.gateway_image_digest == "sha256:gateway-image"
+    assert evidence.health_result == "healthy"
     assert calls[0][0:2] == ("network", "inspect")
+    assert calls[-1][0:2] == ("exec", DEFAULT_EGRESS_PROFILE.gateway_ref)
 
 
 @pytest.mark.asyncio
@@ -122,6 +135,7 @@ async def test_attestation_proves_internal_ipv4_network_and_exact_gateway():
             {
                 "moonmind.egress.profile": DEFAULT_EGRESS_PROFILE.ref,
                 "moonmind.egress.enforcer": ENFORCER_IMPLEMENTATION,
+                "moonmind.egress.config-digest": EGRESS_CONFIG_DIGEST,
             },
             {
                 EGRESS_NETWORK_REF: {},
@@ -140,8 +154,56 @@ async def test_attestation_fails_closed_on_unproven_or_stale_state(
         payload = network if args[0] == "network" else {
             "labels": labels,
             "networks": networks,
+            "image": "sha256:gateway-image",
+            "health": "healthy",
         }
         return 0, json.dumps(payload).encode(), b""
+
+    with pytest.raises(RuntimeError, match=message):
+        await attest_docker_egress(
+            runner=runner,
+            profile=DEFAULT_EGRESS_PROFILE,
+            backend_ref="local",
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("config_digest", "health", "message"),
+    [
+        ("sha256:" + "0" * 64, "healthy", "config"),
+        (EGRESS_CONFIG_DIGEST, "unhealthy", "healthy"),
+    ],
+)
+async def test_attestation_rejects_unobserved_rules_or_unhealthy_gateway(
+    config_digest, health, message
+):
+    async def runner(args):
+        if args[0] == "network":
+            return 0, json.dumps(
+                {"Internal": True, "EnableIPv6": False}
+            ).encode(), b""
+        if args[0] == "inspect":
+            return 0, json.dumps(
+                {
+                    "labels": {
+                        "moonmind.egress.profile": DEFAULT_EGRESS_PROFILE.ref,
+                        "moonmind.egress.enforcer": ENFORCER_IMPLEMENTATION,
+                        "moonmind.egress.config-digest": EGRESS_CONFIG_DIGEST,
+                    },
+                    "networks": {
+                        EGRESS_NETWORK_REF: {},
+                        "moonmind_sandbox-egress-network": {},
+                        "local-network": {},
+                    },
+                    "image": "sha256:gateway-image",
+                    "health": health,
+                }
+            ).encode(), b""
+        return 0, (
+            f"{config_digest.removeprefix('sha256:')}  "
+            "/etc/squid/squid.conf\n"
+        ).encode(), b""
 
     with pytest.raises(RuntimeError, match=message):
         await attest_docker_egress(

--- a/tests/unit/security/test_egress.py
+++ b/tests/unit/security/test_egress.py
@@ -11,8 +11,11 @@ from moonmind.security.egress import (
     DEFAULT_EGRESS_PROFILE,
     EGRESS_CONFIG_DIGEST,
     EGRESS_NETWORK_REF,
+    EGRESS_PROFILE_SET_DIGEST,
     ENFORCER_IMPLEMENTATION,
+    OMNIGENT_EGRESS_NETWORK_REF,
     attest_docker_egress,
+    omnigent_proxy_env,
     restricted_proxy_env,
 )
 
@@ -74,13 +77,14 @@ async def test_attestation_proves_internal_ipv4_network_and_exact_gateway():
             return 0, json.dumps(
                 {
                     "labels": {
-                        "moonmind.egress.profile": DEFAULT_EGRESS_PROFILE.ref,
+                        "moonmind.egress.profile-set-digest": EGRESS_PROFILE_SET_DIGEST,
                         "moonmind.egress.enforcer": ENFORCER_IMPLEMENTATION,
                         "moonmind.egress.config-digest": EGRESS_CONFIG_DIGEST,
                     },
                     "networks": {
                         EGRESS_NETWORK_REF: {},
                         "moonmind_sandbox-egress-network": {},
+                        OMNIGENT_EGRESS_NETWORK_REF: {},
                         "local-network": {},
                     },
                     "image": "sha256:gateway-image",
@@ -126,10 +130,11 @@ async def test_attestation_proves_internal_ipv4_network_and_exact_gateway():
         ),
         (
             {"Internal": True, "EnableIPv6": False},
-            {"moonmind.egress.profile": "stale@1"},
+            {"moonmind.egress.profile-set-digest": "sha256:stale"},
             {
                 EGRESS_NETWORK_REF: {},
                 "moonmind_sandbox-egress-network": {},
+                OMNIGENT_EGRESS_NETWORK_REF: {},
                 "local-network": {},
             },
             "stale",
@@ -137,13 +142,14 @@ async def test_attestation_proves_internal_ipv4_network_and_exact_gateway():
         (
             {"Internal": True, "EnableIPv6": False},
             {
-                "moonmind.egress.profile": DEFAULT_EGRESS_PROFILE.ref,
+                "moonmind.egress.profile-set-digest": EGRESS_PROFILE_SET_DIGEST,
                 "moonmind.egress.enforcer": ENFORCER_IMPLEMENTATION,
                 "moonmind.egress.config-digest": EGRESS_CONFIG_DIGEST,
             },
             {
                 EGRESS_NETWORK_REF: {},
                 "moonmind_sandbox-egress-network": {},
+                OMNIGENT_EGRESS_NETWORK_REF: {},
                 "local-network": {},
                 "bypass": {},
             },
@@ -191,13 +197,14 @@ async def test_attestation_rejects_unobserved_rules_or_unhealthy_gateway(
             return 0, json.dumps(
                 {
                     "labels": {
-                        "moonmind.egress.profile": DEFAULT_EGRESS_PROFILE.ref,
+                        "moonmind.egress.profile-set-digest": EGRESS_PROFILE_SET_DIGEST,
                         "moonmind.egress.enforcer": ENFORCER_IMPLEMENTATION,
                         "moonmind.egress.config-digest": EGRESS_CONFIG_DIGEST,
                     },
                     "networks": {
                         EGRESS_NETWORK_REF: {},
                         "moonmind_sandbox-egress-network": {},
+                        OMNIGENT_EGRESS_NETWORK_REF: {},
                         "local-network": {},
                     },
                     "image": "sha256:gateway-image",
@@ -223,6 +230,30 @@ def test_proxy_environment_clears_bypass_variables():
     assert "no_proxy=" in values
     assert all("169.254.169.254" not in value for value in values)
 
+    omnigent_values = omnigent_proxy_env()
+    assert "HTTP_PROXY=http://omnigent-egress-proxy:3129" in omnigent_values
+    assert "NO_PROXY=" in omnigent_values
+
+
+@pytest.mark.asyncio
+async def test_attestation_rejects_unapproved_profile_bounds_before_docker_calls():
+    profile = _profile(idleSeconds=301)
+    called = False
+
+    async def runner(_args):
+        nonlocal called
+        called = True
+        return 0, b"", b""
+
+    with pytest.raises(RuntimeError, match="profile is not approved"):
+        await attest_docker_egress(
+            runner=runner,
+            profile=profile,
+            backend_ref="local",
+        )
+
+    assert called is False
+
 
 def test_network_ref_resolves_configured_override(monkeypatch):
     """The documented compose override feeds the immutable profile/attestation.
@@ -236,14 +267,21 @@ def test_network_ref_resolves_configured_override(monkeypatch):
 
     from moonmind.security import egress as egress_module
 
+    original_profile_set_digest = egress_module.EGRESS_PROFILE_SET_DIGEST
+    original_provider_digest = egress_module.DEFAULT_EGRESS_PROFILE.digest
     monkeypatch.setenv("MOONMIND_RESTRICTED_EGRESS_NETWORK", "custom_restricted_net")
     monkeypatch.setenv("MOONMIND_SANDBOX_EGRESS_NETWORK", "custom_sandbox_net")
+    monkeypatch.setenv("MOONMIND_OMNIGENT_EGRESS_NETWORK", "custom_omnigent_net")
     try:
         reloaded = importlib.reload(egress_module)
         assert reloaded.EGRESS_NETWORK_REF == "custom_restricted_net"
         assert reloaded.DEFAULT_EGRESS_PROFILE.network_ref == "custom_restricted_net"
+        assert reloaded.OMNIGENT_EGRESS_PROFILE.network_ref == "custom_omnigent_net"
+        assert reloaded.DEFAULT_EGRESS_PROFILE.digest != original_provider_digest
+        assert reloaded.EGRESS_PROFILE_SET_DIGEST == original_profile_set_digest
         assert "custom_restricted_net" in reloaded._EXPECTED_GATEWAY_NETWORKS
         assert "custom_sandbox_net" in reloaded._EXPECTED_GATEWAY_NETWORKS
+        assert "custom_omnigent_net" in reloaded._EXPECTED_GATEWAY_NETWORKS
     finally:
         # Restore module-level defaults so later tests see the shipped values.
         monkeypatch.undo()

--- a/tests/unit/test_pentestgpt_runner_workflow.py
+++ b/tests/unit/test_pentestgpt_runner_workflow.py
@@ -108,6 +108,13 @@ def test_runner_publish_scans_image_with_configured_vulnerability_threshold() ->
     assert "moonmind-pentestgpt-smoke" in run
 
 
+def test_runner_image_pins_scanned_python_distribution() -> None:
+    dockerfile = DOCKERFILE_PATH.read_text(encoding="utf-8")
+
+    assert "FROM python:3.12-slim-bookworm AS runtime" in dockerfile
+    assert "python -m pip uninstall --yes pip" in dockerfile
+
+
 def test_runner_publish_validates_selftest_report_output() -> None:
     # MM-839: CI must fail on invalid self-test report-output content, not just
     # on the runner exit code.

--- a/tests/unit/workflows/temporal/test_activity_runtime.py
+++ b/tests/unit/workflows/temporal/test_activity_runtime.py
@@ -3579,7 +3579,7 @@ async def test_pentest_workload_profile_registry_includes_claude_oauth_runner():
     profile = registry.get(PENTEST_CLAUDE_OAUTH_RUNNER_PROFILE_ID)
     assert profile is not None
     assert profile.image == PENTEST_RUNNER_IMAGE
-    assert profile.network_policy == "bridge"
+    assert profile.network_policy == "pentest_approved_lab"
     assert "ANTHROPIC_API_KEY" not in profile.env_allowlist
     assert "CLAUDE_HOME" in profile.env_allowlist
 
@@ -3633,7 +3633,7 @@ async def test_security_pentest_execute_rejects_registered_runner_image_drift(
                             }
                         ],
                         "envAllowlist": ["ANTHROPIC_API_KEY"],
-                        "networkPolicy": "bridge",
+                        "networkPolicy": "pentest_approved_lab",
                         "resources": {
                             "cpu": "4",
                             "memory": "8g",

--- a/tests/unit/workflows/temporal/test_container_job_backend.py
+++ b/tests/unit/workflows/temporal/test_container_job_backend.py
@@ -11,7 +11,9 @@ from moonmind.security.egress import (
     DEFAULT_EGRESS_PROFILE,
     EGRESS_CONFIG_DIGEST,
     EGRESS_NETWORK_REF,
+    EGRESS_PROFILE_SET_DIGEST,
     ENFORCER_IMPLEMENTATION,
+    OMNIGENT_EGRESS_NETWORK_REF,
     PROXY_URL,
 )
 from moonmind.config.container_backend_settings import (
@@ -175,13 +177,14 @@ async def test_bridge_launch_requires_attestation_and_uses_restricted_network(
         if args[0] == "inspect" and "NetworkSettings.Networks" in args[2]:
             payload = {
                 "labels": {
-                    "moonmind.egress.profile": DEFAULT_EGRESS_PROFILE.ref,
+                    "moonmind.egress.profile-set-digest": EGRESS_PROFILE_SET_DIGEST,
                     "moonmind.egress.enforcer": ENFORCER_IMPLEMENTATION,
                     "moonmind.egress.config-digest": EGRESS_CONFIG_DIGEST,
                 },
                 "networks": {
                     EGRESS_NETWORK_REF: {},
                     "moonmind_sandbox-egress-network": {},
+                    OMNIGENT_EGRESS_NETWORK_REF: {},
                     "local-network": {},
                 },
                 "image": "sha256:gateway-image",

--- a/tests/unit/workflows/temporal/test_container_job_backend.py
+++ b/tests/unit/workflows/temporal/test_container_job_backend.py
@@ -9,6 +9,7 @@ import pytest
 
 from moonmind.security.egress import (
     DEFAULT_EGRESS_PROFILE,
+    EGRESS_CONFIG_DIGEST,
     EGRESS_NETWORK_REF,
     ENFORCER_IMPLEMENTATION,
     PROXY_URL,
@@ -176,14 +177,22 @@ async def test_bridge_launch_requires_attestation_and_uses_restricted_network(
                 "labels": {
                     "moonmind.egress.profile": DEFAULT_EGRESS_PROFILE.ref,
                     "moonmind.egress.enforcer": ENFORCER_IMPLEMENTATION,
+                    "moonmind.egress.config-digest": EGRESS_CONFIG_DIGEST,
                 },
                 "networks": {
                     EGRESS_NETWORK_REF: {},
                     "moonmind_sandbox-egress-network": {},
                     "local-network": {},
                 },
+                "image": "sha256:gateway-image",
+                "health": "healthy",
             }
             return 0, json.dumps(payload).encode(), b""
+        if args[:2] == ("exec", DEFAULT_EGRESS_PROFILE.gateway_ref):
+            return 0, (
+                EGRESS_CONFIG_DIGEST.removeprefix("sha256:")
+                + "  /etc/squid/squid.conf\n"
+            ).encode(), b""
         return await _recording_runner(commands)(args)
 
     backend = DockerContainerJobBackend(

--- a/tests/unit/workflows/temporal/test_container_job_backend.py
+++ b/tests/unit/workflows/temporal/test_container_job_backend.py
@@ -7,6 +7,12 @@ from unittest.mock import AsyncMock
 
 import pytest
 
+from moonmind.security.egress import (
+    DEFAULT_EGRESS_PROFILE,
+    EGRESS_NETWORK_REF,
+    ENFORCER_IMPLEMENTATION,
+    PROXY_URL,
+)
 from moonmind.config.container_backend_settings import (
     ContainerBackendReadinessError,
     resolve_container_backend_settings,
@@ -151,6 +157,66 @@ async def test_create_applies_hardening_shm_pids_and_labels(tmp_path) -> None:
     assert f"{LABEL_OBJECT_KIND}=container" in joined
     assert f"{LABEL_BACKEND_REF}=system" in joined
     assert f"{LABEL_OWNERSHIP_SCHEMA}={OWNERSHIP_SCHEMA_VERSION}" in joined
+
+
+@pytest.mark.asyncio
+async def test_bridge_launch_requires_attestation_and_uses_restricted_network(
+    tmp_path,
+) -> None:
+    (tmp_path / "art_workspace").mkdir()
+    commands: list[tuple[str, ...]] = []
+
+    async def runner(args):
+        args = tuple(args)
+        commands.append(args)
+        if args[:2] == ("network", "inspect"):
+            return 0, b'{"Internal":true,"EnableIPv6":false}', b""
+        if args[0] == "inspect" and "NetworkSettings.Networks" in args[2]:
+            payload = {
+                "labels": {
+                    "moonmind.egress.profile": DEFAULT_EGRESS_PROFILE.ref,
+                    "moonmind.egress.enforcer": ENFORCER_IMPLEMENTATION,
+                },
+                "networks": {
+                    EGRESS_NETWORK_REF: {},
+                    "moonmind_sandbox-egress-network": {},
+                    "local-network": {},
+                },
+            }
+            return 0, json.dumps(payload).encode(), b""
+        return await _recording_runner(commands)(args)
+
+    backend = DockerContainerJobBackend(
+        workspace_root=tmp_path, command_runner=runner
+    )
+    await backend.create_container(_request(tmp_path, networkMode="bridge"))
+
+    create = next(command for command in commands if command[0] == "create")
+    assert create[create.index("--network") + 1] == EGRESS_NETWORK_REF
+    assert f"HTTPS_PROXY={PROXY_URL}" in create
+    assert "NO_PROXY=" in create
+    assert f"moonmind.egress.profile={DEFAULT_EGRESS_PROFILE.ref}" in create
+
+
+@pytest.mark.asyncio
+async def test_bridge_launch_fails_before_create_when_network_is_not_internal(
+    tmp_path,
+) -> None:
+    (tmp_path / "art_workspace").mkdir()
+    commands: list[tuple[str, ...]] = []
+
+    async def runner(args):
+        commands.append(tuple(args))
+        if args[:2] == ("network", "inspect"):
+            return 0, b'{"Internal":false,"EnableIPv6":false}', b""
+        return 0, b"", b""
+
+    backend = DockerContainerJobBackend(
+        workspace_root=tmp_path, command_runner=runner
+    )
+    with pytest.raises(RuntimeError, match="not internal"):
+        await backend.create_container(_request(tmp_path, networkMode="bridge"))
+    assert not any(command[0] == "create" for command in commands)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
+++ b/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
@@ -4463,10 +4463,13 @@ async def test_build_runtime_activities_reconciles_managed_sessions_only_on_agen
         patch(
             "moonmind.workflows.temporal.worker_runtime.DockerContainerJobBackend"
         ) as mock_backend_cls,
+        patch(
+            "moonmind.security.egress.attest_docker_egress",
+            new=AsyncMock(return_value=MagicMock()),
+        ),
     ):
         mock_settings.workflow.workflow_docker_mode = "profiles"
         mock_backend_cls.return_value.check_readiness = AsyncMock()
-        mock_backend_cls.return_value.network_ready = AsyncMock(return_value=True)
         resources, handlers = await _build_runtime_activities(topology)
 
     mock_backend_cls.return_value.check_readiness.assert_awaited_once()
@@ -4650,9 +4653,12 @@ async def test_build_runtime_activities_registers_unrestricted_mode(
         patch(
             "moonmind.workflows.temporal.worker_runtime.DockerContainerJobBackend"
         ) as mock_backend_cls,
+        patch(
+            "moonmind.security.egress.attest_docker_egress",
+            new=AsyncMock(return_value=MagicMock()),
+        ),
     ):
         mock_backend_cls.return_value.check_readiness = AsyncMock()
-        mock_backend_cls.return_value.network_ready = AsyncMock(return_value=True)
         resources, _handlers = await _build_runtime_activities(topology)
 
     mock_agent_runtime_activities_cls.assert_called_once()

--- a/tests/unit/workflows/temporal/test_workload_run_activity.py
+++ b/tests/unit/workflows/temporal/test_workload_run_activity.py
@@ -48,7 +48,7 @@ def _helper_profile_payload() -> dict[str, object]:
             }
         ],
         "env_allowlist": ["CI"],
-        "network_policy": "bridge",
+        "network_policy": "restricted_egress",
         "timeout_seconds": 60,
         "max_timeout_seconds": 120,
         "helper_ttl_seconds": 300,

--- a/tests/unit/workloads/test_docker_workload_launcher.py
+++ b/tests/unit/workloads/test_docker_workload_launcher.py
@@ -1840,10 +1840,10 @@ async def test_container_janitor_sweeps_expired_bounded_helpers(
         "--format",
         '{{.ID}}\t{{.Names}}\t{{.Label "moonmind.expires_at"}}',
     ]
-def test_bridge_profile_resolves_to_restricted_attested_network(tmp_path: Path) -> None:
+def test_restricted_profile_resolves_to_attested_network(tmp_path: Path) -> None:
     request = _validated_request(
         tmp_path,
-        profiles=[_profile_payload(network_policy="bridge")],
+        profiles=[_profile_payload(network_policy="restricted_egress")],
     )
 
     args = DockerWorkloadLauncher().build_run_args(request)
@@ -1857,14 +1857,46 @@ def test_bridge_profile_resolves_to_restricted_attested_network(tmp_path: Path) 
     assert args[args.index("--cap-drop") + 1] == "ALL"
 
 
+def test_docker_proxy_profile_preserves_its_target_specific_route(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MOONMIND_DOCKER_PROXY_NETWORK", "custom_docker_proxy")
+    request = _validated_request(
+        tmp_path,
+        profiles=[_profile_payload(network_policy="docker_proxy")],
+    )
+
+    args = DockerWorkloadLauncher().build_run_args(request)
+
+    assert args[args.index("--network") + 1] == "custom_docker_proxy"
+    assert not any(value.startswith("HTTPS_PROXY=") for value in args)
+    assert not any("moonmind.egress.profile=" in value for value in args)
+
+
+def test_pentest_lab_profile_fails_before_a_target_profile_exists(
+    tmp_path: Path,
+) -> None:
+    request = _validated_request(
+        tmp_path,
+        profiles=[_profile_payload(network_policy="pentest_approved_lab")],
+    )
+
+    with pytest.raises(
+        DockerWorkloadLauncherError,
+        match="target-specific reviewed egress profile",
+    ):
+        DockerWorkloadLauncher().build_run_args(request)
+
+
 @pytest.mark.asyncio
-async def test_bridge_launch_fails_before_process_when_egress_is_unattested(
+async def test_restricted_launch_fails_before_process_when_egress_is_unattested(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     request = _validated_request(
         tmp_path,
-        profiles=[_profile_payload(network_policy="bridge")],
+        profiles=[_profile_payload(network_policy="restricted_egress")],
     )
     process_started = False
 
@@ -1897,7 +1929,9 @@ def _healthy_egress_run_process(args: list[str]) -> _Process:
         DEFAULT_EGRESS_PROFILE,
         EGRESS_CONFIG_DIGEST,
         EGRESS_NETWORK_REF,
+        EGRESS_PROFILE_SET_DIGEST,
         ENFORCER_IMPLEMENTATION,
+        OMNIGENT_EGRESS_NETWORK_REF,
     )
 
     subcommand = args[1] if len(args) > 1 else ""
@@ -1910,13 +1944,14 @@ def _healthy_egress_run_process(args: list[str]) -> _Process:
             stdout=json.dumps(
                 {
                     "labels": {
-                        "moonmind.egress.profile": DEFAULT_EGRESS_PROFILE.ref,
+                        "moonmind.egress.profile-set-digest": EGRESS_PROFILE_SET_DIGEST,
                         "moonmind.egress.enforcer": ENFORCER_IMPLEMENTATION,
                         "moonmind.egress.config-digest": EGRESS_CONFIG_DIGEST,
                     },
                     "networks": {
                         EGRESS_NETWORK_REF: {},
                         "moonmind_sandbox-egress-network": {},
+                        OMNIGENT_EGRESS_NETWORK_REF: {},
                         "local-network": {},
                     },
                     "image": "sha256:gateway-image",
@@ -1932,12 +1967,12 @@ def _healthy_egress_run_process(args: list[str]) -> _Process:
             ).encode()
         )
     if subcommand == "run":
-        return _Process(returncode=0, stdout=b"bridge workload ok\n")
+        return _Process(returncode=0, stdout=b"restricted workload ok\n")
     return _Process(returncode=0)
 
 
 @pytest.mark.asyncio
-async def test_bridge_launch_publishes_egress_attestation_evidence(
+async def test_restricted_launch_publishes_egress_attestation_evidence(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1962,7 +1997,8 @@ async def test_bridge_launch_publishes_egress_attestation_evidence(
             artifactsDir=str(artifact_dir),
             profiles=[
                 _profile_payload(
-                    workspace_root=workspace_root, network_policy="bridge"
+                    workspace_root=workspace_root,
+                    network_policy="restricted_egress",
                 )
             ],
         )

--- a/tests/unit/workloads/test_docker_workload_launcher.py
+++ b/tests/unit/workloads/test_docker_workload_launcher.py
@@ -1888,3 +1888,128 @@ async def test_bridge_launch_fails_before_process_when_egress_is_unattested(
         await launcher.run(request)
 
     assert process_started is False
+
+
+def _healthy_egress_run_process(args: list[str]) -> _Process:
+    """Fake docker responses that satisfy attest_docker_egress plus the run."""
+
+    from moonmind.security.egress import (
+        DEFAULT_EGRESS_PROFILE,
+        EGRESS_CONFIG_DIGEST,
+        EGRESS_NETWORK_REF,
+        ENFORCER_IMPLEMENTATION,
+    )
+
+    subcommand = args[1] if len(args) > 1 else ""
+    if subcommand == "network":
+        return _Process(
+            stdout=json.dumps({"Internal": True, "EnableIPv6": False}).encode()
+        )
+    if subcommand == "inspect":
+        return _Process(
+            stdout=json.dumps(
+                {
+                    "labels": {
+                        "moonmind.egress.profile": DEFAULT_EGRESS_PROFILE.ref,
+                        "moonmind.egress.enforcer": ENFORCER_IMPLEMENTATION,
+                        "moonmind.egress.config-digest": EGRESS_CONFIG_DIGEST,
+                    },
+                    "networks": {
+                        EGRESS_NETWORK_REF: {},
+                        "moonmind_sandbox-egress-network": {},
+                        "local-network": {},
+                    },
+                    "image": "sha256:gateway-image",
+                    "health": "healthy",
+                }
+            ).encode()
+        )
+    if subcommand == "exec":
+        return _Process(
+            stdout=(
+                f"{EGRESS_CONFIG_DIGEST.removeprefix('sha256:')}  "
+                "/etc/squid/squid.conf\n"
+            ).encode()
+        )
+    if subcommand == "run":
+        return _Process(returncode=0, stdout=b"bridge workload ok\n")
+    return _Process(returncode=0)
+
+
+@pytest.mark.asyncio
+async def test_bridge_launch_publishes_egress_attestation_evidence(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace_root = tmp_path / "workspace"
+    artifact_dir = workspace_root / "task-egress" / "artifacts" / "step-test"
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+
+    async def _fake_create_subprocess_exec(*args: str, **_kwargs: Any) -> _Process:
+        return _healthy_egress_run_process(list(args))
+
+    monkeypatch.setattr(
+        "moonmind.workloads.docker_launcher.asyncio.create_subprocess_exec",
+        _fake_create_subprocess_exec,
+    )
+
+    result = await DockerWorkloadLauncher().run(
+        _validated_request(
+            tmp_path,
+            workspace_root=workspace_root,
+            agentRunId="task-egress",
+            repoDir=str(workspace_root / "task-egress" / "repo"),
+            artifactsDir=str(artifact_dir),
+            profiles=[
+                _profile_payload(
+                    workspace_root=workspace_root, network_policy="bridge"
+                )
+            ],
+        )
+    )
+
+    assert result.status == "succeeded"
+    attestation = result.metadata["workload"]["egressAttestation"]
+    assert attestation is not None
+    assert attestation["profileRef"] == DEFAULT_EGRESS_PROFILE.ref
+    assert attestation["profileDigest"] == DEFAULT_EGRESS_PROFILE.digest
+    assert attestation["appliedRuleDigest"].startswith("sha256:")
+    assert attestation["validationResult"] == "passed"
+    assert "validatedAt" in attestation
+
+    diagnostics = json.loads(Path(result.diagnostics_ref or "").read_text("utf-8"))
+    assert diagnostics["egressAttestation"] == attestation
+
+
+@pytest.mark.asyncio
+async def test_none_network_launch_records_no_egress_attestation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace_root = tmp_path / "workspace"
+    artifact_dir = workspace_root / "task-none-egress" / "artifacts" / "step-test"
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+
+    async def _fake_create_subprocess_exec(*args: str, **_kwargs: Any) -> _Process:
+        if args[1] == "run":
+            return _Process(returncode=0, stdout=b"ok\n")
+        return _Process(returncode=0)
+
+    monkeypatch.setattr(
+        "moonmind.workloads.docker_launcher.asyncio.create_subprocess_exec",
+        _fake_create_subprocess_exec,
+    )
+
+    result = await DockerWorkloadLauncher().run(
+        _validated_request(
+            tmp_path,
+            workspace_root=workspace_root,
+            agentRunId="task-none-egress",
+            repoDir=str(workspace_root / "task-none-egress" / "repo"),
+            artifactsDir=str(artifact_dir),
+        )
+    )
+
+    assert result.metadata["workload"]["egressAttestation"] is None
+    diagnostics = json.loads(Path(result.diagnostics_ref or "").read_text("utf-8"))
+    assert diagnostics["egressAttestation"] is None

--- a/tests/unit/workloads/test_docker_workload_launcher.py
+++ b/tests/unit/workloads/test_docker_workload_launcher.py
@@ -7,6 +7,11 @@ from typing import Any
 
 import pytest
 
+from moonmind.security.egress import (
+    DEFAULT_EGRESS_PROFILE,
+    EGRESS_NETWORK_REF,
+    PROXY_URL,
+)
 from moonmind.schemas.workload_models import UnrestrictedDockerRequest, WorkloadRequest
 from moonmind.workloads.docker_launcher import (
     DockerContainerJanitor,
@@ -1835,3 +1840,18 @@ async def test_container_janitor_sweeps_expired_bounded_helpers(
         "--format",
         '{{.ID}}\t{{.Names}}\t{{.Label "moonmind.expires_at"}}',
     ]
+def test_bridge_profile_resolves_to_restricted_attested_network(tmp_path: Path) -> None:
+    request = _validated_request(
+        tmp_path,
+        profiles=[_profile_payload(network_policy="bridge")],
+    )
+
+    args = DockerWorkloadLauncher().build_run_args(request)
+
+    assert args[args.index("--network") + 1] == EGRESS_NETWORK_REF
+    assert f"moonmind.egress.profile={DEFAULT_EGRESS_PROFILE.ref}" in args
+    assert f"moonmind.egress.profile_digest={DEFAULT_EGRESS_PROFILE.digest}" in args
+    assert f"HTTPS_PROXY={PROXY_URL}" in args
+    assert "NO_PROXY=" in args
+    assert "--privileged=false" in args
+    assert args[args.index("--cap-drop") + 1] == "ALL"

--- a/tests/unit/workloads/test_docker_workload_launcher.py
+++ b/tests/unit/workloads/test_docker_workload_launcher.py
@@ -1855,3 +1855,36 @@ def test_bridge_profile_resolves_to_restricted_attested_network(tmp_path: Path) 
     assert "NO_PROXY=" in args
     assert "--privileged=false" in args
     assert args[args.index("--cap-drop") + 1] == "ALL"
+
+
+@pytest.mark.asyncio
+async def test_bridge_launch_fails_before_process_when_egress_is_unattested(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    request = _validated_request(
+        tmp_path,
+        profiles=[_profile_payload(network_policy="bridge")],
+    )
+    process_started = False
+
+    async def _fake_create_subprocess_exec(*_args: str, **_kwargs: Any) -> _Process:
+        nonlocal process_started
+        process_started = True
+        return _Process()
+
+    monkeypatch.setattr(
+        "moonmind.workloads.docker_launcher.asyncio.create_subprocess_exec",
+        _fake_create_subprocess_exec,
+    )
+    launcher = DockerWorkloadLauncher()
+
+    async def _unavailable(_args: list[str]) -> tuple[bytes, bytes, int]:
+        return b"", b"not found", 1
+
+    monkeypatch.setattr(launcher._janitor, "_run_control", _unavailable)
+
+    with pytest.raises(RuntimeError, match="network is unavailable"):
+        await launcher.run(request)
+
+    assert process_started is False


### PR DESCRIPTION
Implements restricted egress enforcement for host and workload policies.

Issue: MoonLadderStudios/MoonMind#3516

Closes MoonLadderStudios/MoonMind#3516

## Summary

Replaces declarative-only egress plumbing with a concrete, testable, policy-selected egress enforcement substrate that fails closed when enforcement cannot be proven.

- **Canonical architecture** (`docs/Security/RestrictedEgress.md`, `docker-compose.yaml`): dedicated `internal: true` Docker network plus a trusted dual-homed Squid gateway (`docker/sandbox-egress-proxy/squid.conf`). Local-dev bridge/local-network is explicitly classified as non-enforcing.
- **Immutable egress profiles** (`moonmind/security/egress.py`): frozen `EgressProfile`/`EgressDestination` with `extra="forbid"` (no executable firewall commands or credentials possible), forbidden-range rejection (private/loopback/link-local/multicast/metadata/bridge/host-gateway/control-plane), IPv6 policy, resolver policy, bounded connection/rate/byte/idle limits, owner/version/digest/validation state. `DEFAULT_EGRESS_PROFILE` ships as the shared default.
- **Trusted-backend enforcement**: `attest_docker_egress()` fails closed unless the live network is internal/IPv4-only and the gateway carries the exact profile/enforcer/config-digest labels, expected attachment set, healthy state, and a live `squid.conf` whose sha256 matches the reviewed digest. Attestation runs before container create (`container_job_backend.py`), before subprocess launch (`docker_launcher.py`), before host readiness (`oauth_host_runtime.py`), and before `enforcedNetworkRefs` is reported (`worker_runtime.py`).
- **Bypass handling**: per-connection resolution + post-resolution forbidden-destination ACL, IPv6 disabled and denied, direct-IP name rejection, `NO_PROXY` pinned empty, stale/mismatched profile fails attestation.
- **Evidence-backed readiness**: `enforcedNetworkRefs` gated on a passing attestation; bounded per-launch evidence persisted (profile ref/digest, applied-rule digest, attachment identity, validation result/time, bounded denied-connection counters/diagnostics, cleanup/reconciliation result); evidence-publish failure removes the container.
- **Shared capability** across static/on-demand Omnigent hosts, Container Jobs, managed helper containers, and worker runtime.
- **PentestGPT external targets fail closed** (`allow_external_targets=False` by default) and require an exact reviewed egress profile ref, security-review ref, recorded approval, and an in-profile target host.

## Tests run

Hermetic suites (via `python -m pytest`; 300 focused tests pass):

- `tests/unit/security/test_egress.py`, `tests/unit/integrations/pentest/test_pentest_models.py` — 98 passed
- `tests/test_local_dev.py`, `tests/unit/workflows/temporal/test_container_job_backend.py`, `tests/unit/workloads/test_docker_workload_launcher.py`, `tests/unit/api/routers/test_omnigent_catalog.py` — 108 passed
- `tests/unit/workflows/temporal/test_temporal_worker_runtime.py` (targeted) + `tests/unit/omnigent/test_oauth_profile_lifecycle.py` — 92 passed
- `tests/integration/temporal/test_compose_foundation.py` (restricted-egress topology, parse-only) — 2 passed
- Config digest integrity: `sha256sum docker/sandbox-egress-proxy/squid.conf` matches `EGRESS_CONFIG_DIGEST` and the compose gateway label/healthcheck

## Remaining risks

- **Live network-layer conformance run** (containers driving real allowed/forbidden connections through the running internal network + Squid gateway) and **live `docker compose` bring-up** were NOT RUN: they require a Docker daemon, which is not available in the managed-agent runtime (no Docker socket). These are disclosed as advisory. Hermetic negative-conformance coverage (Squid ACL assertions, profile forbidden-range rejection, attestation fail-closed) is present and passing, but end-to-end network-layer enforcement should be validated in an environment with Docker before relying on it in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
