### PR TITLE
Fix recent workflow failure paths

### DIFF
--- a/api_service/services/presets/catalog.py
+++ b/api_service/services/presets/catalog.py
@@ -123,7 +123,11 @@ _SECRET_LIKE_KEY_PATTERN = re.compile(
     re.IGNORECASE,
 )
 _SECRET_LIKE_VALUE_PATTERN = re.compile(
-    r"(token=|password=|bearer\s+|ghp_|github_pat_|akia[0-9a-z]{16}|aiza|atatt|-----begin [a-z ]*private key)",
+    r"(token=|password=|"
+    r"bearer\s+(?=[a-z0-9._~+/=-]{16,}(?![a-z0-9._~+/=-]))"
+    r"(?=[a-z0-9._~+/=-]*[0-9._~+/=-])[a-z0-9._~+/=-]+|"
+    r"ghp_|github_pat_|akia[0-9a-z]{16}|aiza|atatt|"
+    r"-----begin [a-z ]*private key)",
     re.IGNORECASE,
 )
 _STEP_RESERVED_KEYS = frozenset(

--- a/api_service/services/presets/catalog.py
+++ b/api_service/services/presets/catalog.py
@@ -124,8 +124,7 @@ _SECRET_LIKE_KEY_PATTERN = re.compile(
 )
 _SECRET_LIKE_VALUE_PATTERN = re.compile(
     r"(token=|password=|"
-    r"authorization\s*:\s*bearer\s+\S+|"
-    r"(?:^|[\r\n])\s*bearer\s+\S+\s*(?:$|[\r\n])|"
+    r"authorization[ \t]*:[ \t]*bearer[ \t]+\S+|"
     r"ghp_|github_pat_|akia[0-9a-z]{16}|aiza|atatt|"
     r"-----begin [a-z ]*private key)",
     re.IGNORECASE,
@@ -1159,7 +1158,14 @@ def _contains_secret_like_value(value: Any) -> bool:
         return False
     if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
         return any(_contains_secret_like_value(item) for item in value)
-    return bool(_SECRET_LIKE_VALUE_PATTERN.search(str(value or "")))
+    text = str(value or "")
+    if _SECRET_LIKE_VALUE_PATTERN.search(text):
+        return True
+    return any(
+        len(parts) == 2 and parts[0].casefold() == "bearer" and bool(parts[1])
+        for line in text.splitlines()
+        if (parts := line.strip().split())
+    )
 
 def _capability_contract_from_inputs(
     *,

--- a/api_service/services/presets/catalog.py
+++ b/api_service/services/presets/catalog.py
@@ -124,8 +124,8 @@ _SECRET_LIKE_KEY_PATTERN = re.compile(
 )
 _SECRET_LIKE_VALUE_PATTERN = re.compile(
     r"(token=|password=|"
-    r"bearer\s+(?=[a-z0-9._~+/=-]{16,}(?![a-z0-9._~+/=-]))"
-    r"(?=[a-z0-9._~+/=-]*[0-9._~+/=-])[a-z0-9._~+/=-]+|"
+    r"authorization\s*:\s*bearer\s+\S+|"
+    r"(?:^|[\r\n])\s*bearer\s+\S+\s*(?:$|[\r\n])|"
     r"ghp_|github_pat_|akia[0-9a-z]{16}|aiza|atatt|"
     r"-----begin [a-z ]*private key)",
     re.IGNORECASE,

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -14007,6 +14007,18 @@ class TemporalAgentRuntimeActivities:
             target_branch_name = (
                 target_branch.strip() if isinstance(target_branch, str) else ""
             )
+            while target_branch_name:
+                prior_target_branch_name = target_branch_name
+                if target_branch_name.startswith("refs/remotes/origin/"):
+                    target_branch_name = target_branch_name.removeprefix(
+                        "refs/remotes/origin/"
+                    )
+                if target_branch_name.startswith("refs/heads/"):
+                    target_branch_name = target_branch_name.removeprefix("refs/heads/")
+                if target_branch_name.startswith("origin/"):
+                    target_branch_name = target_branch_name.removeprefix("origin/")
+                if target_branch_name == prior_target_branch_name:
+                    break
             head_branch_name = (
                 head_branch.strip() if isinstance(head_branch, str) else ""
             )

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -14007,18 +14007,12 @@ class TemporalAgentRuntimeActivities:
             target_branch_name = (
                 target_branch.strip() if isinstance(target_branch, str) else ""
             )
-            while target_branch_name:
-                prior_target_branch_name = target_branch_name
-                if target_branch_name.startswith("refs/remotes/origin/"):
-                    target_branch_name = target_branch_name.removeprefix(
-                        "refs/remotes/origin/"
-                    )
-                if target_branch_name.startswith("refs/heads/"):
-                    target_branch_name = target_branch_name.removeprefix("refs/heads/")
-                if target_branch_name.startswith("origin/"):
-                    target_branch_name = target_branch_name.removeprefix("origin/")
-                if target_branch_name == prior_target_branch_name:
-                    break
+            if target_branch_name.startswith("refs/remotes/origin/"):
+                target_branch_name = target_branch_name.removeprefix(
+                    "refs/remotes/origin/"
+                )
+            elif target_branch_name.startswith("refs/heads/"):
+                target_branch_name = target_branch_name.removeprefix("refs/heads/")
             head_branch_name = (
                 head_branch.strip() if isinstance(head_branch, str) else ""
             )
@@ -14103,11 +14097,6 @@ class TemporalAgentRuntimeActivities:
                 commit_info.setdefault("push_branch", current_branch)
                 return commit_info
 
-            same_branch_publish = (
-                target_branch_push_allowed
-                and bool(target_branch_name)
-                and current_branch == target_branch_name
-            )
             base_branch_name = (
                 target_branch_name
                 or await self._resolve_workspace_default_branch(
@@ -14117,12 +14106,32 @@ class TemporalAgentRuntimeActivities:
                 )
             )
             base_ref = f"origin/{base_branch_name}"
-            if not await self._refresh_workspace_remote_base_ref(
+            base_ref_refreshed = await self._refresh_workspace_remote_base_ref(
                 workspace=workspace,
                 base_branch=base_branch_name,
                 run_id=run_id,
                 env=auth_command_env,
-            ):
+            )
+            if not base_ref_refreshed and base_branch_name.startswith("origin/"):
+                # ``origin/release`` can be a literal remote branch name. Try
+                # that exact authored identity first, then interpret the short
+                # form as a remote-tracking ref only when the literal branch is
+                # absent. This repairs legacy ``origin/main`` inputs without
+                # silently publishing against the wrong branch when both names
+                # are meaningful.
+                remote_tracking_branch = base_branch_name.removeprefix("origin/")
+                if remote_tracking_branch:
+                    base_branch_name = remote_tracking_branch
+                    base_ref = f"origin/{base_branch_name}"
+                    base_ref_refreshed = (
+                        await self._refresh_workspace_remote_base_ref(
+                            workspace=workspace,
+                            base_branch=base_branch_name,
+                            run_id=run_id,
+                            env=auth_command_env,
+                        )
+                    )
+            if not base_ref_refreshed:
                 return {
                     "push_status": "failed",
                     "push_branch": current_branch,
@@ -14132,6 +14141,11 @@ class TemporalAgentRuntimeActivities:
                         f"could not refresh authoritative publish base '{base_ref}'"
                     ),
                 }
+            same_branch_publish = (
+                target_branch_push_allowed
+                and bool(base_branch_name)
+                and current_branch == base_branch_name
+            )
             commit_count: int | None = None
             if same_branch_publish:
                 commit_count = await self._count_branch_commits_ahead(

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -766,6 +766,14 @@ RUN_REMEDIATION_LOOP_ARTIFACT_REF_NORMALIZATION_PATCH = (
 RUN_WORKFLOW_OWNED_REMEDIATION_HEAD_PATCH = (
     "run-workflow-owned-remediation-head-v1"
 )
+# A runtime without canonical checkpoint evidence cannot safely materialize the
+# cumulative workspace required by a semantic remediation attempt. Persist a
+# terminal remaining-work decision instead of admitting the attempt and then
+# failing outside the workflow gate. The patch preserves command history for
+# runs that already evaluated a verifier result under the prior behavior.
+RUN_REMEDIATION_CHECKPOINT_UNAVAILABLE_STOP_PATCH = (
+    "run-remediation-checkpoint-unavailable-stop-v1"
+)
 RUN_MANAGED_SESSION_CHECKPOINT_LOCATOR_PATCH = (
     "run-managed-session-checkpoint-locator-v1"
 )
@@ -4142,6 +4150,23 @@ class MoonMindRunWorkflow:
             progress_ref=remaining_work_ref,
             recoverable_evidence=recoverable_evidence,
         )
+        if (
+            workflow_owned_head_enabled
+            and workflow.patched(
+                RUN_REMEDIATION_CHECKPOINT_UNAVAILABLE_STOP_PATCH
+            )
+            and decision.next_phase == RemediationLoopPhase.REMEDIATION_PENDING
+            and self._remediation_workspace_head is None
+        ):
+            decision = decision.model_copy(
+                update={
+                    "continue_loop": False,
+                    "reason": "workspace_checkpoint_unavailable",
+                    "next_attempt": None,
+                    "next_phase": RemediationLoopPhase.STOPPED_REMAINING_WORK,
+                    "retry_kind": None,
+                }
+            )
         decision_ref = await self._write_json_artifact(
             name=(
                 "reports/remediation_decision_"
@@ -12373,6 +12398,12 @@ class MoonMindRunWorkflow:
                             else None
                         )
                         if (
+                            loop_state is not None
+                            and loop_state.continuation_reason
+                            == "workspace_checkpoint_unavailable"
+                        ):
+                            transition_reason = "workspace_checkpoint_unavailable"
+                        elif (
                             isinstance(consumed_payload, Mapping)
                             and int(
                                 consumed_payload.get(

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -766,13 +766,12 @@ RUN_REMEDIATION_LOOP_ARTIFACT_REF_NORMALIZATION_PATCH = (
 RUN_WORKFLOW_OWNED_REMEDIATION_HEAD_PATCH = (
     "run-workflow-owned-remediation-head-v1"
 )
-# A runtime without canonical checkpoint evidence cannot safely materialize the
-# cumulative workspace required by a semantic remediation attempt. Persist a
-# terminal remaining-work decision instead of admitting the attempt and then
-# failing outside the workflow gate. The patch preserves command history for
-# runs that already evaluated a verifier result under the prior behavior.
-RUN_REMEDIATION_CHECKPOINT_UNAVAILABLE_STOP_PATCH = (
-    "run-remediation-checkpoint-unavailable-stop-v1"
+# Cumulative checkpoint tracking is optional. Admit a headless remediation pair
+# against the live cumulative workspace when capture produced no canonical head.
+# Histories that already evaluated the old mandatory-head guard retain the prior
+# failure branch during replay.
+RUN_WORKFLOW_HEADLESS_REMEDIATION_PATCH = (
+    "run-workflow-headless-remediation-v1"
 )
 RUN_MANAGED_SESSION_CHECKPOINT_LOCATOR_PATCH = (
     "run-managed-session-checkpoint-locator-v1"
@@ -4150,23 +4149,6 @@ class MoonMindRunWorkflow:
             progress_ref=remaining_work_ref,
             recoverable_evidence=recoverable_evidence,
         )
-        if (
-            workflow_owned_head_enabled
-            and workflow.patched(
-                RUN_REMEDIATION_CHECKPOINT_UNAVAILABLE_STOP_PATCH
-            )
-            and decision.next_phase == RemediationLoopPhase.REMEDIATION_PENDING
-            and self._remediation_workspace_head is None
-        ):
-            decision = decision.model_copy(
-                update={
-                    "continue_loop": False,
-                    "reason": "workspace_checkpoint_unavailable",
-                    "next_attempt": None,
-                    "next_phase": RemediationLoopPhase.STOPPED_REMAINING_WORK,
-                    "retry_kind": None,
-                }
-            )
         decision_ref = await self._write_json_artifact(
             name=(
                 "reports/remediation_decision_"
@@ -4193,6 +4175,7 @@ class MoonMindRunWorkflow:
             workflow_owned_head_enabled
             and state.phase == RemediationLoopPhase.REMEDIATION_PENDING
             and self._remediation_workspace_head is None
+            and not workflow.patched(RUN_WORKFLOW_HEADLESS_REMEDIATION_PATCH)
         ):
             raise RemediationHeadError(
                 REMEDIATION_HEAD_MISMATCH,
@@ -12398,12 +12381,6 @@ class MoonMindRunWorkflow:
                             else None
                         )
                         if (
-                            loop_state is not None
-                            and loop_state.continuation_reason
-                            == "workspace_checkpoint_unavailable"
-                        ):
-                            transition_reason = "workspace_checkpoint_unavailable"
-                        elif (
                             isinstance(consumed_payload, Mapping)
                             and int(
                                 consumed_payload.get(

--- a/tests/unit/api/test_presets_service.py
+++ b/tests/unit/api/test_presets_service.py
@@ -758,6 +758,7 @@ async def test_object_input_allows_bearer_prose_but_rejects_bearer_credentials(
                 "Authorization: Bearer abcdefghijklmnopqrstuvwxyz",
                 "Authorization: Bearer short",
                 "Bearer short",
+                "Notes before the credential.\nBearer short\nNotes after it.",
             ):
                 with pytest.raises(PresetValidationError, match="secret-like"):
                     await service.expand_template(

--- a/tests/unit/api/test_presets_service.py
+++ b/tests/unit/api/test_presets_service.py
@@ -696,6 +696,81 @@ async def test_template_rejects_secret_like_schema_defaults(tmp_path):
                     created_by=user_id,
                 )
 
+async def test_object_input_allows_bearer_prose_but_rejects_bearer_credentials(
+    tmp_path,
+):
+    user_id = uuid4()
+    async with template_db(tmp_path) as session_maker:
+        async with session_maker() as session:
+            service = PresetCatalogService(session)
+            await service.create_template(
+                slug="github-issue-input",
+                title="GitHub issue input",
+                description="Schema-driven issue input",
+                scope="global",
+                scope_ref=None,
+                tags=["schema"],
+                inputs_schema=[
+                    {
+                        "name": "github_issue",
+                        "label": "GitHub issue",
+                        "type": "text",
+                        "required": True,
+                        "schema": {
+                            "type": "object",
+                            "required": ["number"],
+                            "properties": {
+                                "number": {"type": "integer"},
+                                "body": {"type": "string"},
+                            },
+                        },
+                    }
+                ],
+                steps=[
+                    {
+                        "title": "Use issue",
+                        "instructions": "Issue {{ inputs.github_issue.number }}",
+                    }
+                ],
+                annotations={},
+                required_capabilities=["github"],
+                created_by=user_id,
+            )
+
+            expanded = await service.expand_template(
+                slug="github-issue-input",
+                scope="global",
+                scope_ref=None,
+                inputs={
+                    "github_issue": {
+                        "number": 3514,
+                        "body": "Document the long-lived bearer credential policy.",
+                    }
+                },
+                context={},
+            )
+
+            assert expanded["appliedTemplate"]["inputs"]["github_issue"][
+                "number"
+            ] == 3514
+
+            with pytest.raises(PresetValidationError, match="secret-like"):
+                await service.expand_template(
+                    slug="github-issue-input",
+                    scope="global",
+                    scope_ref=None,
+                    inputs={
+                        "github_issue": {
+                            "number": 3514,
+                            "body": (
+                                "Authorization: Bearer "
+                                "fake-credential-1234567890"
+                            ),
+                        }
+                    },
+                    context={},
+                )
+
 async def test_expand_schema_capability_reports_field_addressable_errors(tmp_path):
     user_id = uuid4()
     async with template_db(tmp_path) as session_maker:

--- a/tests/unit/api/test_presets_service.py
+++ b/tests/unit/api/test_presets_service.py
@@ -754,22 +754,24 @@ async def test_object_input_allows_bearer_prose_but_rejects_bearer_credentials(
                 "number"
             ] == 3514
 
-            with pytest.raises(PresetValidationError, match="secret-like"):
-                await service.expand_template(
-                    slug="github-issue-input",
-                    scope="global",
-                    scope_ref=None,
-                    inputs={
-                        "github_issue": {
-                            "number": 3514,
-                            "body": (
-                                "Authorization: Bearer "
-                                "fake-credential-1234567890"
-                            ),
-                        }
-                    },
-                    context={},
-                )
+            for unsafe_body in (
+                "Authorization: Bearer abcdefghijklmnopqrstuvwxyz",
+                "Authorization: Bearer short",
+                "Bearer short",
+            ):
+                with pytest.raises(PresetValidationError, match="secret-like"):
+                    await service.expand_template(
+                        slug="github-issue-input",
+                        scope="global",
+                        scope_ref=None,
+                        inputs={
+                            "github_issue": {
+                                "number": 3514,
+                                "body": unsafe_body,
+                            }
+                        },
+                        context={},
+                    )
 
 async def test_expand_schema_capability_reports_field_addressable_errors(tmp_path):
     user_id = uuid4()

--- a/tests/unit/services/temporal/test_fetch_result_push.py
+++ b/tests/unit/services/temporal/test_fetch_result_push.py
@@ -984,7 +984,7 @@ class TestPushWorkspaceBranch:
         assert not any("push" in call for call in recorded_calls)
 
     @pytest.mark.asyncio
-    async def test_push_normalizes_remote_tracking_target_before_base_refresh(self):
+    async def test_push_falls_back_from_missing_origin_prefixed_base(self):
         store = _make_mock_store()
         activities = TemporalAgentRuntimeActivities(run_store=store)
 
@@ -1000,8 +1000,20 @@ class TestPushWorkspaceBranch:
                 activities,
                 "_refresh_workspace_remote_base_ref",
                 new_callable=AsyncMock,
-                return_value=False,
+                side_effect=[False, True],
             ) as refresh_base,
+            patch.object(
+                activities,
+                "_resolve_workspace_remote_branch_sha",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch.object(
+                activities,
+                "_scan_workspace_push_range",
+                new_callable=AsyncMock,
+                return_value={"push_status": "blocked-for-test"},
+            ) as scan_range,
         ):
             proc = AsyncMock()
             proc.communicate = AsyncMock(
@@ -1015,16 +1027,63 @@ class TestPushWorkspaceBranch:
                 target_branch="origin/main",
             )
 
+        assert refresh_base.await_count == 2
+        assert [
+            call.kwargs["base_branch"] for call in refresh_base.await_args_list
+        ] == ["origin/main", "main"]
+        scan_range.assert_awaited_once()
+        assert scan_range.await_args.kwargs["base_ref"] == "origin/main"
+        assert result["push_status"] == "blocked-for-test"
+
+    @pytest.mark.asyncio
+    async def test_push_preserves_existing_origin_prefixed_base(self):
+        store = _make_mock_store()
+        activities = TemporalAgentRuntimeActivities(run_store=store)
+
+        with (
+            patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec,
+            patch.object(
+                activities,
+                "_commit_workspace_changes_if_needed",
+                new_callable=AsyncMock,
+                return_value={},
+            ),
+            patch.object(
+                activities,
+                "_refresh_workspace_remote_base_ref",
+                new_callable=AsyncMock,
+                return_value=True,
+            ) as refresh_base,
+            patch.object(
+                activities,
+                "_resolve_workspace_remote_branch_sha",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch.object(
+                activities,
+                "_scan_workspace_push_range",
+                new_callable=AsyncMock,
+                return_value={"push_status": "blocked-for-test"},
+            ) as scan_range,
+        ):
+            proc = AsyncMock()
+            proc.communicate = AsyncMock(
+                return_value=(b"feature/literal-origin-branch\n", b"")
+            )
+            proc.returncode = 0
+            mock_exec.return_value = proc
+
+            result = await activities._push_workspace_branch(
+                "run-1",
+                target_branch="origin/release",
+            )
+
         refresh_base.assert_awaited_once()
-        assert refresh_base.await_args.kwargs["workspace"] == (
-            "/work/agent_jobs/run-1/repo"
-        )
-        assert refresh_base.await_args.kwargs["base_branch"] == "main"
-        assert refresh_base.await_args.kwargs["run_id"] == "run-1"
-        assert result["push_status"] == "failed"
-        assert result["push_base_branch"] == "main"
-        assert result["push_base_ref"] == "origin/main"
-        assert "origin/origin" not in result["push_error"]
+        assert refresh_base.await_args.kwargs["base_branch"] == "origin/release"
+        scan_range.assert_awaited_once()
+        assert scan_range.await_args.kwargs["base_ref"] == "origin/origin/release"
+        assert result["push_status"] == "blocked-for-test"
 
     @pytest.mark.asyncio
     async def test_push_blocks_when_live_remote_head_does_not_match(self):

--- a/tests/unit/services/temporal/test_fetch_result_push.py
+++ b/tests/unit/services/temporal/test_fetch_result_push.py
@@ -984,6 +984,49 @@ class TestPushWorkspaceBranch:
         assert not any("push" in call for call in recorded_calls)
 
     @pytest.mark.asyncio
+    async def test_push_normalizes_remote_tracking_target_before_base_refresh(self):
+        store = _make_mock_store()
+        activities = TemporalAgentRuntimeActivities(run_store=store)
+
+        with (
+            patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec,
+            patch.object(
+                activities,
+                "_commit_workspace_changes_if_needed",
+                new_callable=AsyncMock,
+                return_value={},
+            ),
+            patch.object(
+                activities,
+                "_refresh_workspace_remote_base_ref",
+                new_callable=AsyncMock,
+                return_value=False,
+            ) as refresh_base,
+        ):
+            proc = AsyncMock()
+            proc.communicate = AsyncMock(
+                return_value=(b"feature/base-normalization\n", b"")
+            )
+            proc.returncode = 0
+            mock_exec.return_value = proc
+
+            result = await activities._push_workspace_branch(
+                "run-1",
+                target_branch="origin/main",
+            )
+
+        refresh_base.assert_awaited_once()
+        assert refresh_base.await_args.kwargs["workspace"] == (
+            "/work/agent_jobs/run-1/repo"
+        )
+        assert refresh_base.await_args.kwargs["base_branch"] == "main"
+        assert refresh_base.await_args.kwargs["run_id"] == "run-1"
+        assert result["push_status"] == "failed"
+        assert result["push_base_branch"] == "main"
+        assert result["push_base_ref"] == "origin/main"
+        assert "origin/origin" not in result["push_error"]
+
+    @pytest.mark.asyncio
     async def test_push_blocks_when_live_remote_head_does_not_match(self):
         store = _make_mock_store()
         activities = TemporalAgentRuntimeActivities(run_store=store)

--- a/tests/unit/workflows/temporal/workflows/test_run_integration.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_integration.py
@@ -26,7 +26,6 @@ from moonmind.workflows.temporal.workflows.run import (
     RUN_PR_RESOLVER_PUBLISH_EVIDENCE_REF_PATCH,
     RUN_REMEDIATION_LOOP_ARTIFACT_REF_NORMALIZATION_PATCH,
     RUN_REMEDIATION_LOOP_CONTINUE_AS_NEW_PATCH,
-    RUN_REMEDIATION_CHECKPOINT_UNAVAILABLE_STOP_PATCH,
     RUN_REMEDIATION_MANAGED_SESSION_SOURCE_IDENTITY_PATCH,
     RUN_REMEDIATION_CONTINUE_MANAGED_SESSION_PATCH,
     RUN_RUNTIME_EXECUTION_CAPABILITIES_PATCH,
@@ -34,6 +33,7 @@ from moonmind.workflows.temporal.workflows.run import (
     RUN_ALREADY_IMPLEMENTED_JIRA_COMPLETION_PATCH,
     RUN_AUTO_PUBLISH_METADATA_EVIDENCE_PATCH,
     RUN_WORKFLOW_CHILD_TASK_QUEUE_V2_PATCH,
+    RUN_WORKFLOW_HEADLESS_REMEDIATION_PATCH,
     RUN_WORKFLOW_OWNED_REMEDIATION_HEAD_PATCH,
     MoonMindRunWorkflow,
 )
@@ -3693,7 +3693,6 @@ async def test_dynamic_verifier_promotes_canonical_checkpoint_to_remediation_hea
         lambda patch_id: patch_id
         in {
             RUN_WORKFLOW_OWNED_REMEDIATION_HEAD_PATCH,
-            RUN_REMEDIATION_CHECKPOINT_UNAVAILABLE_STOP_PATCH,
             RUN_REMEDIATION_MANAGED_SESSION_SOURCE_IDENTITY_PATCH,
         },
     )
@@ -4054,7 +4053,7 @@ async def test_dynamic_verifier_runs_when_no_checkpoint_head_was_captured(
 
 
 @pytest.mark.asyncio
-async def test_dynamic_verifier_stops_with_remaining_work_without_checkpoint(
+async def test_dynamic_verifier_admits_headless_attempt_without_checkpoint(
     mock_run_workflow: MoonMindRunWorkflow,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -4080,7 +4079,7 @@ async def test_dynamic_verifier_stops_with_remaining_work_without_checkpoint(
         lambda patch_id: patch_id
         in {
             RUN_WORKFLOW_OWNED_REMEDIATION_HEAD_PATCH,
-            RUN_REMEDIATION_CHECKPOINT_UNAVAILABLE_STOP_PATCH,
+            RUN_WORKFLOW_HEADLESS_REMEDIATION_PATCH,
         },
     )
     ordered_nodes: list[dict[str, Any]] = []
@@ -4093,20 +4092,22 @@ async def test_dynamic_verifier_stops_with_remaining_work_without_checkpoint(
         logical_step_id="initial-verification",
     )
 
-    assert admitted is False
-    assert ordered_nodes == []
+    assert admitted is True
     assert mock_run_workflow._remediation_workspace_head is None
     state = mock_run_workflow._remediation_loop_state
     assert state is not None
-    assert state.phase.value == "stopped_remaining_work"
-    assert state.continuation_reason == "workspace_checkpoint_unavailable"
+    assert state.phase.value == "remediation_running"
+    assert state.continuation_reason == "verification_requested_remediation"
+    remediation, verification = ordered_nodes
+    assert remediation["inputs"]["remediationWorkspaceHeadRef"] is None
+    assert verification["inputs"]["remediationWorkspaceHeadRef"] is None
     decision_payload = mock_run_workflow._write_json_artifact.await_args.kwargs[
         "payload"
     ]
-    assert decision_payload["continueLoop"] is False
-    assert decision_payload["reason"] == "workspace_checkpoint_unavailable"
-    assert decision_payload["nextAttempt"] is None
-    assert decision_payload["nextPhase"] == "stopped_remaining_work"
+    assert decision_payload["continueLoop"] is True
+    assert decision_payload["reason"] == "verification_requested_remediation"
+    assert decision_payload["nextAttempt"] == 1
+    assert decision_payload["nextPhase"] == "remediation_pending"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/workflows/temporal/workflows/test_run_integration.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_integration.py
@@ -26,6 +26,7 @@ from moonmind.workflows.temporal.workflows.run import (
     RUN_PR_RESOLVER_PUBLISH_EVIDENCE_REF_PATCH,
     RUN_REMEDIATION_LOOP_ARTIFACT_REF_NORMALIZATION_PATCH,
     RUN_REMEDIATION_LOOP_CONTINUE_AS_NEW_PATCH,
+    RUN_REMEDIATION_CHECKPOINT_UNAVAILABLE_STOP_PATCH,
     RUN_REMEDIATION_MANAGED_SESSION_SOURCE_IDENTITY_PATCH,
     RUN_REMEDIATION_CONTINUE_MANAGED_SESSION_PATCH,
     RUN_RUNTIME_EXECUTION_CAPABILITIES_PATCH,
@@ -3692,6 +3693,7 @@ async def test_dynamic_verifier_promotes_canonical_checkpoint_to_remediation_hea
         lambda patch_id: patch_id
         in {
             RUN_WORKFLOW_OWNED_REMEDIATION_HEAD_PATCH,
+            RUN_REMEDIATION_CHECKPOINT_UNAVAILABLE_STOP_PATCH,
             RUN_REMEDIATION_MANAGED_SESSION_SOURCE_IDENTITY_PATCH,
         },
     )
@@ -4049,6 +4051,92 @@ async def test_dynamic_verifier_runs_when_no_checkpoint_head_was_captured(
     assert verification_inputs["remediationWorkspaceHeadRef"] is None
     assert verification_inputs["readOnlyWorkspaceHead"] is True
     assert "remediationWorkspaceHead" not in verification_inputs
+
+
+@pytest.mark.asyncio
+async def test_dynamic_verifier_stops_with_remaining_work_without_checkpoint(
+    mock_run_workflow: MoonMindRunWorkflow,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression for the 2026-07-29 Claude remediation failures."""
+
+    mock_run_workflow._initialize_remediation_loop_controller(
+        ordered_nodes=[_loop_controller_node(_dynamic_loop_spec_payload())]
+    )
+    mock_run_workflow._step_ledger_rows = [
+        {
+            "logicalStepId": "initial-verification",
+            "status": "completed",
+            "attempt": 1,
+        }
+    ]
+    mock_run_workflow._rebuild_step_ledger_index()
+    mock_run_workflow._write_json_artifact = AsyncMock(
+        return_value="artifact://decision/D0"
+    )
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "patched",
+        lambda patch_id: patch_id
+        in {
+            RUN_WORKFLOW_OWNED_REMEDIATION_HEAD_PATCH,
+            RUN_REMEDIATION_CHECKPOINT_UNAVAILABLE_STOP_PATCH,
+        },
+    )
+    ordered_nodes: list[dict[str, Any]] = []
+
+    admitted = await mock_run_workflow._evaluate_dynamic_remediation_verification(
+        ordered_nodes=ordered_nodes,
+        verdict="ADDITIONAL_WORK_NEEDED",
+        gate_result_ref="artifact://verification/V0",
+        remaining_work_ref="artifact://remaining/R0",
+        logical_step_id="initial-verification",
+    )
+
+    assert admitted is False
+    assert ordered_nodes == []
+    assert mock_run_workflow._remediation_workspace_head is None
+    state = mock_run_workflow._remediation_loop_state
+    assert state is not None
+    assert state.phase.value == "stopped_remaining_work"
+    assert state.continuation_reason == "workspace_checkpoint_unavailable"
+    decision_payload = mock_run_workflow._write_json_artifact.await_args.kwargs[
+        "payload"
+    ]
+    assert decision_payload["continueLoop"] is False
+    assert decision_payload["reason"] == "workspace_checkpoint_unavailable"
+    assert decision_payload["nextAttempt"] is None
+    assert decision_payload["nextPhase"] == "stopped_remaining_work"
+
+
+@pytest.mark.asyncio
+async def test_dynamic_verifier_replays_prior_missing_checkpoint_failure(
+    mock_run_workflow: MoonMindRunWorkflow,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    mock_run_workflow._initialize_remediation_loop_controller(
+        ordered_nodes=[_loop_controller_node(_dynamic_loop_spec_payload())]
+    )
+    mock_run_workflow._step_ledger_rows = []
+    mock_run_workflow._write_json_artifact = AsyncMock(
+        return_value="artifact://decision/D0"
+    )
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "patched",
+        lambda patch_id: patch_id == RUN_WORKFLOW_OWNED_REMEDIATION_HEAD_PATCH,
+    )
+
+    with pytest.raises(
+        RemediationHeadError,
+        match="dynamic remediation admission has no canonical workspace checkpoint",
+    ):
+        await mock_run_workflow._evaluate_dynamic_remediation_verification(
+            ordered_nodes=[],
+            verdict="ADDITIONAL_WORK_NEEDED",
+            gate_result_ref="artifact://verification/V0",
+            remaining_work_ref="artifact://remaining/R0",
+        )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- stop checkpointless dynamic remediation through the structured remaining-work gate instead of admitting an unsafe attempt and crashing the workflow
- preserve Temporal replay behavior with a new patch marker and explicit old-history regression coverage
- allow ordinary security prose through preset object inputs while continuing to reject credential-shaped authorization values
- normalize remote-tracking branch names before terminal publication fetches so `origin/main` never becomes a doubled remote ref

## Incident evidence

The 14-hour review found eight failed top-level workflows and one failed resolver child:

- six top-level workflows shared the same checkpointless remediation crash after a verifier requested more work on a runtime that could not provide canonical checkpoint evidence
- the batch parent queued 13 of 14 children, then failed partially because one issue body used ordinary security terminology that the preset secret detector treated as a credential
- the PR resolver correctly stopped for a real design decision and remains a blocker by design; its diagnostics also exposed a separate terminal-publication fetch against a doubled `origin/` ref, which this change fixes

## Verification

- focused escaped-failure regressions: 6 passed
- affected modules: 388 passed
- command: `MOONMIND_TEST_COMPOSE_PROJECT_NAME=moonmind-test-workflowfix ./tools/test_unit_docker.sh --no-build --python-only tests/unit/api/test_presets_service.py tests/unit/services/temporal/test_fetch_result_push.py tests/unit/workflows/temporal/workflows/test_run_integration.py`
