### PR TITLE
GitHub Issue Implement: MoonLadderStudios/MoonMind#3507 — Complete Omnigent normal-workflow workspace materialization and shared host lifecycle

### DIFF
--- a/memory/MEMORY.md
+++ b/memory/MEMORY.md
@@ -1,3 +1,4 @@
 - [Pre-existing test_executions failures](pre-existing-test-executions-failures.md) — describe_execution IllegalStateChangeError reproduces on main; not a regression
 - [MM-954 workflow-list current-page sort](mm954-workflow-list-current-page-sort.md) — why list sorting is intentionally page-only, not global server-side
 - [Frontend vitest colon-path workaround](frontend-vitest-colon-path-workaround.md) — vitest fails on colon in workspace dir; run from a colon-free copy under /tmp
+- [Omnigent #3507 workspace materialization](omnigent-3507-workspace-materialization.md) — done vs remaining for the normal-workflow workspace path

--- a/memory/omnigent-3507-workspace-materialization.md
+++ b/memory/omnigent-3507-workspace-materialization.md
@@ -1,0 +1,20 @@
+---
+name: omnigent-3507-workspace-materialization
+description: State of MoonMind#3507 Omnigent normal-workflow workspace materialization — what this branch implemented and what remains
+metadata:
+  type: project
+---
+
+GitHub issue MoonLadderStudios/MoonMind#3507 ([Omnigent P0] normal-workflow workspace materialization + shared host lifecycle) was assessed PARTIALLY_IMPLEMENTED. On branch `github-issue-implement-moonladderstudios-6b2f6b92` I finished the workspace-materialization core (commit references the issue).
+
+**Done in this change** (all in `moonmind/omnigent/oauth_host_runtime.py` `_prepare_workspace` + new `_materialize_repository`/`_materialize_restore_inputs`, wired from `moonmind/omnigent/profile_bound_execution.py`):
+- All three `WorkspaceLocator` kinds routed through the one owning-worker boundary; managed/external-state fail closed with `WORKSPACE_LOCATOR_UNSUPPORTED` (AC2/AC4).
+- Sandbox path now git-clones + checks out authored starting/target branch (and optional commit) into the single sandbox workspace via the shared `run_runtime_command`; idempotent on retry, preserves in-flight tree (AC1/AC5/AC7/AC9).
+- Restore inputs materialized as `artifact://` refs, never conflated with local paths (AC2).
+- GitHub token injected only via in-memory git credential helper when source is GitHub HTTPS.
+- Bounded credential-free `workspaceResolution` evidence surfaced in preflight + recorded as a `workspace_resolution` lifecycle event (AC6).
+- Tests: 11 unit tests in `tests/unit/omnigent/test_oauth_profile_lifecycle.py` + controlling hermetic journey `tests/integration/reliability_journey/test_omnigent_workspace_materialization_journey.py` (AC10, no Docker/network).
+
+**Still open on #3507** (not attempted here — larger/cross-cutting): converging the raw `docker`/`docker compose` lifecycle in `oauth_host_runtime.py` onto shared runtime primitives (AC6 convergence); full output/resource-manifest + partial-start reconciliation; end-to-end publication/PR/terminal-checkpoint semantics through Omnigent (AC9 publish side); janitor-evidence-on-failure across the full lifecycle (AC8). The credentialed browser-to-host acceptance matrix is separately tracked by #3508 (out of scope per this issue's Non-goals).
+
+**Env note:** `tests/unit/omnigent/test_host_protocol_adapter.py`, `test_host_auth_remediation.py`, `test_host_auth_profile.py` fail in this workspace with "pinned Omnigent ... unavailable" — a pre-existing missing-upstream environment blocker, confirmed unrelated to this change (fails identically with the change stashed).

--- a/moonmind/omnigent/bridge_store.py
+++ b/moonmind/omnigent/bridge_store.py
@@ -1209,6 +1209,11 @@ class OmnigentBridgeSessionStore:
                         "retrievalState",
                         "retrievalMode",
                         "retrievalReason",
+                        "locatorKind",
+                        "workspaceId",
+                        "relativePath",
+                        "identityVerified",
+                        "materialization",
                     }
                 }
             journal.append(entry)

--- a/moonmind/omnigent/oauth_host_runtime.py
+++ b/moonmind/omnigent/oauth_host_runtime.py
@@ -5,9 +5,11 @@ from __future__ import annotations
 import hashlib
 import os
 import re
+import shutil
 from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlsplit
 
 from moonmind.omnigent.oauth_hosts import (
     HostPreflightFailure,
@@ -72,9 +74,20 @@ _PLACEHOLDER_DIGEST = "0" * 64
 _SAFE_NETWORK = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_.-]{0,127}$")
 _GITHUB_SLUG = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
 # Bound restore-input materialization so a hostile or oversized artifact ref
-# cannot exhaust the authorized workspace before the host launches.
+# cannot exhaust the authorized workspace before the host launches. The limit is
+# enforced both per ref and cumulatively across every accepted ref so the
+# advertised hostile-input bound cannot be defeated by fanning bytes across many
+# individually-legal refs.
 _MAX_RESTORE_INPUT_REFS = 64
 _MAX_RESTORE_INPUT_BYTES = 64 * 1024 * 1024
+_MAX_RESTORE_TOTAL_BYTES = 256 * 1024 * 1024
+# Restore payloads are read through the durable artifact contract as raw bytes,
+# under a dedicated service principal (mirrors the checkpoint/remediation
+# restorers, which never read restore material as an end user).
+_RESTORE_ARTIFACT_PRINCIPAL = "service:omnigent_workspace_restore"
+# Stream restore bytes from the artifact service in bounded chunks so an oversized
+# payload is rejected mid-stream instead of after full in-memory materialization.
+_RESTORE_STREAM_CHUNK_BYTES = 1024 * 1024
 
 _RUNTIME_ADAPTERS = {
     "codex_cli": {
@@ -121,6 +134,7 @@ class OmnigentOAuthHostRuntime:
         server_url: str | None = None,
         scripts_dir: Path | None = None,
         workspace_root: Path | None = None,
+        repository_source_root: Path | str | None = None,
     ) -> None:
         self._client = client
         if image:
@@ -149,6 +163,18 @@ class OmnigentOAuthHostRuntime:
         ).resolve()
         self._tool_bundle_volume = os.getenv(
             "OMNIGENT_TOOL_BUNDLE_VOLUME", "moonmind-omnigent-tools-gh-2.76.2"
+        )
+        # Local (on-disk) repository sources are only clonable when they are
+        # contained within an explicitly authorized per-run source root. Without
+        # this root, an authored ``workspaceSpec`` could clone any repository the
+        # trusted worker can read (including another run under the workspace
+        # authority), crossing workspace isolation boundaries.
+        source_root = repository_source_root or os.getenv(
+            "OMNIGENT_REPOSITORY_SOURCE_ROOT", ""
+        )
+        source_root_text = str(source_root or "").strip()
+        self._repository_source_root = (
+            Path(source_root_text).resolve() if source_root_text else None
         )
         # Bounded, non-sensitive evidence of the most recent workspace resolution,
         # surfaced through the preflight result for Workflow Detail. Never carries
@@ -900,17 +926,7 @@ class OmnigentOAuthHostRuntime:
             must_exist=False,
         )
         source = str(repository_source or "").strip()
-        already_materialized = workspace.is_dir()
-        # 2. A workspace that is neither pre-materialized nor accompanied by an
-        #    authored repository source cannot be created here; reject before
-        #    writing any owner record or running any command.
-        if not already_materialized and not source:
-            raise WorkspaceLocatorResolutionError(
-                WORKSPACE_AUTHORITY_MISMATCH,
-                "authorized sandbox workspace is unavailable and no repository "
-                "source was authored to materialize it",
-            )
-        # 3. Establish or load the durable owner record and validate its binding
+        # 2. Establish or load the durable owner record and validate its binding
         #    before mutating the filesystem, so a retry or a foreign record can
         #    never author a second workspace under this identity.
         record_store = SandboxWorkspaceRecordStore(self._workspace_root)
@@ -932,9 +948,37 @@ class OmnigentOAuthHostRuntime:
             expected_step_execution_id=current_step_execution_id,
             must_exist=False,
         )
-        # 4. Materialize the authored repository/branch and restore inputs exactly
-        #    once. Retries observe the already-materialized workspace and skip all
-        #    git and archive mutation.
+        # 3. Decide whether this run may skip materialization. When a repository
+        #    source is authored, THIS runtime owns materialization and directory
+        #    existence alone is not completion evidence: an earlier attempt that
+        #    cloned but then failed during checkout or restore leaves a partially
+        #    built directory behind. Only a durable completion marker written after
+        #    the full clone/checkout/restore proves the workspace is safe to reuse,
+        #    so an existing-but-incomplete directory is torn down and rebuilt
+        #    rather than launched from the wrong revision or a partial restore.
+        #    When no source is authored, the workspace must have been
+        #    pre-materialized by its external owner (for example a remediation
+        #    workspace) and is reused as-is.
+        already_materialized = workspace.is_dir()
+        if (
+            source
+            and already_materialized
+            and not record_store.is_materialized(locator.workspace_id)
+        ):
+            shutil.rmtree(workspace)
+            already_materialized = False
+        # 4. A workspace that is neither present nor accompanied by an authored
+        #    repository source cannot be created here; reject before running any
+        #    command.
+        if not already_materialized and not source:
+            raise WorkspaceLocatorResolutionError(
+                WORKSPACE_AUTHORITY_MISMATCH,
+                "authorized sandbox workspace is unavailable and no repository "
+                "source was authored to materialize it",
+            )
+        # 5. Materialize the authored repository/branch and restore inputs exactly
+        #    once, then record durable completion. Retries observe the completed
+        #    workspace and skip all git and archive mutation.
         materialization: dict[str, Any] = {"action": "reused_pre_materialized"}
         if not already_materialized:
             materialization = await self._materialize_repository(
@@ -952,7 +996,8 @@ class OmnigentOAuthHostRuntime:
             )
             if restore_evidence:
                 materialization["restoreInputs"] = restore_evidence
-        # 5. Final containment-checked resolution; the directory must now exist.
+            record_store.mark_materialized(locator.workspace_id)
+        # 6. Final containment-checked resolution; the directory must now exist.
         workspace = resolve_sandbox_workspace_locator(
             locator,
             workspace_root=self._workspace_root,
@@ -988,6 +1033,8 @@ class OmnigentOAuthHostRuntime:
         """
 
         source, source_kind = self._normalize_repository_source(repository_source)
+        if source_kind == "local":
+            self._authorize_local_repository_source(source)
         start = self._normalize_branch(starting_branch)
         target = self._normalize_branch(target_branch)
         commit = str(checkout_commit or "").strip()
@@ -1097,33 +1144,137 @@ class OmnigentOAuthHostRuntime:
             )
         restore_root.mkdir(parents=True, exist_ok=True)
         evidence: list[dict[str, Any]] = []
+        total_bytes = 0
         for ref in refs:
             if not ref.startswith("artifact://"):
                 raise OmnigentOAuthHostError(
                     "restore inputs must be durable artifact refs, not local paths",
                     code=WORKSPACE_LOCATOR_UNSUPPORTED,
                 )
-            _metadata, payload = await artifact_service.read(artifact_id=ref)
-            if len(payload) > _MAX_RESTORE_INPUT_BYTES:
+            # The durable artifact contract addresses artifacts by id; the
+            # canonical ``artifact://`` scheme must be stripped before lookup.
+            artifact_id = ref[len("artifact://"):]
+            # Enforce the per-ref bound and the single cumulative restore budget
+            # together, so many individually-legal refs cannot aggregate past the
+            # advertised hostile-input bound.
+            per_ref_budget = min(
+                _MAX_RESTORE_INPUT_BYTES, _MAX_RESTORE_TOTAL_BYTES - total_bytes
+            )
+            if per_ref_budget <= 0:
                 raise OmnigentOAuthHostError(
-                    "restore input exceeds the authorized workspace bound",
+                    "restore inputs exceed the cumulative authorized workspace bound",
                     code="OMNIGENT_WORKSPACE_MATERIALIZATION_FAILED",
                 )
+            await self._reject_oversized_restore_metadata(
+                artifact_service, artifact_id, per_ref_budget
+            )
             digest = hashlib.sha256(ref.encode("utf-8")).hexdigest()[:24]
-            (restore_root / digest).write_bytes(payload)
-            evidence.append({"ref": ref, "bytes": len(payload)})
+            written = await self._write_restore_payload(
+                artifact_service,
+                artifact_id=artifact_id,
+                target=restore_root / digest,
+                budget_bytes=per_ref_budget,
+            )
+            total_bytes += written
+            evidence.append({"ref": ref, "bytes": written})
         return evidence
+
+    @staticmethod
+    async def _reject_oversized_restore_metadata(
+        artifact_service: Any, artifact_id: str, budget_bytes: int
+    ) -> None:
+        """Reject an oversized restore artifact from metadata before reading bytes.
+
+        When the service can report artifact size cheaply, an oversized payload is
+        rejected before any bytes are allocated or written.
+        """
+        get_metadata = getattr(artifact_service, "get_metadata", None)
+        if get_metadata is None:
+            return
+        try:
+            metadata = await get_metadata(
+                artifact_id=artifact_id,
+                principal=_RESTORE_ARTIFACT_PRINCIPAL,
+            )
+        except TypeError:
+            return
+        artifact = metadata[0] if isinstance(metadata, tuple) else metadata
+        size_bytes = getattr(artifact, "size_bytes", None)
+        if isinstance(size_bytes, int) and size_bytes > budget_bytes:
+            raise OmnigentOAuthHostError(
+                "restore input exceeds the authorized workspace bound",
+                code="OMNIGENT_WORKSPACE_MATERIALIZATION_FAILED",
+            )
+
+    @staticmethod
+    async def _write_restore_payload(
+        artifact_service: Any,
+        *,
+        artifact_id: str,
+        target: Path,
+        budget_bytes: int,
+    ) -> int:
+        """Stream a restore payload to disk under a hard byte budget.
+
+        Streaming through the artifact service's chunked reader rejects an
+        oversized payload mid-stream, so it is never fully materialized in worker
+        memory. Services that expose only a whole-payload ``read`` are still bound
+        after the read completes.
+        """
+        read_chunks = getattr(artifact_service, "read_chunks", None)
+        if read_chunks is not None:
+            written = 0
+            with target.open("wb") as stream:
+                _artifact, chunks = await read_chunks(
+                    artifact_id=artifact_id,
+                    principal=_RESTORE_ARTIFACT_PRINCIPAL,
+                    allow_restricted_raw=True,
+                    chunk_size=_RESTORE_STREAM_CHUNK_BYTES,
+                )
+                for chunk in chunks:
+                    written += len(chunk)
+                    if written > budget_bytes:
+                        stream.close()
+                        target.unlink(missing_ok=True)
+                        raise OmnigentOAuthHostError(
+                            "restore input exceeds the authorized workspace bound",
+                            code="OMNIGENT_WORKSPACE_MATERIALIZATION_FAILED",
+                        )
+                    stream.write(chunk)
+            return written
+        _metadata, payload = await artifact_service.read(
+            artifact_id=artifact_id,
+            principal=_RESTORE_ARTIFACT_PRINCIPAL,
+            allow_restricted_raw=True,
+        )
+        if len(payload) > budget_bytes:
+            raise OmnigentOAuthHostError(
+                "restore input exceeds the authorized workspace bound",
+                code="OMNIGENT_WORKSPACE_MATERIALIZATION_FAILED",
+            )
+        target.write_bytes(payload)
+        return len(payload)
 
     @staticmethod
     def _as_artifact_service(artifact_gateway: Any | None) -> Any | None:
         if artifact_gateway is None:
             return None
-        if hasattr(artifact_gateway, "read"):
+        # A durable artifact service exposes the by-id ``read``/``read_chunks``
+        # contract directly; only a bare byte gateway needs the ref adapter.
+        if hasattr(artifact_gateway, "read") or hasattr(artifact_gateway, "read_chunks"):
             return artifact_gateway
 
         class _GatewayArtifactService:
             async def read(self, *, artifact_id: str, **_kwargs: Any):
-                payload = await artifact_gateway.read_bytes(artifact_id)
+                # ``read_bytes`` addresses artifacts by their canonical
+                # ``artifact://`` ref, while the durable service contract passes a
+                # scheme-stripped id; restore the scheme for the gateway.
+                ref = (
+                    artifact_id
+                    if artifact_id.startswith("artifact://")
+                    else f"artifact://{artifact_id}"
+                )
+                payload = await artifact_gateway.read_bytes(ref)
                 return {}, payload
 
         return _GatewayArtifactService()
@@ -1138,13 +1289,20 @@ class OmnigentOAuthHostRuntime:
                 "repository source is required to materialize the workspace",
                 code="OMNIGENT_WORKSPACE_MATERIALIZATION_FAILED",
             )
-        if value.startswith(("http://", "https://", "git@", "file://", "ssh://")):
-            kind = (
-                "github_https"
-                if value.startswith(("http://", "https://"))
-                and "github.com" in value
-                else "remote"
-            )
+        # A ``file://`` URL is still a local on-disk read and must be authorized
+        # like any other local path, not treated as a trusted remote.
+        if value.startswith("file://"):
+            return value, "local"
+        if value.startswith(("http://", "https://", "git@", "ssh://")):
+            kind = "remote"
+            if value.startswith(("http://", "https://")):
+                # Only inject GitHub credentials when the URL host is exactly
+                # github.com. A substring check would misclassify hosts such as
+                # ``evil.com/github.com`` or ``github.com.evil.com`` as GitHub and
+                # leak the token to an attacker-controlled origin.
+                host = (urlsplit(value).hostname or "").lower()
+                if host == "github.com":
+                    kind = "github_https"
             return value, kind
         if value.startswith(("/", "./", "../")) or Path(value).is_absolute():
             return value, "local"
@@ -1155,6 +1313,24 @@ class OmnigentOAuthHostRuntime:
             "unsupported repository source; expected owner/repo, URL, or path",
             code="OMNIGENT_WORKSPACE_MATERIALIZATION_FAILED",
         )
+
+    def _authorize_local_repository_source(self, source: str) -> None:
+        """Reject a local repository source outside the authorized source root.
+
+        Local sources are attacker-influenced (they come from the workflow-authored
+        ``workspaceSpec``/parameters). Without containment they could clone any Git
+        repository the trusted worker can read, including another run under the
+        workspace authority, crossing workspace isolation boundaries.
+        """
+        raw_path = source[len("file://"):] if source.startswith("file://") else source
+        resolved = Path(raw_path).resolve()
+        root = self._repository_source_root
+        if root is None or not resolved.is_relative_to(root):
+            raise OmnigentOAuthHostError(
+                "local repository sources are only permitted within an authorized "
+                "per-run source root",
+                code=WORKSPACE_LOCATOR_UNSUPPORTED,
+            )
 
     @staticmethod
     def _normalize_branch(branch: str | None) -> str | None:

--- a/moonmind/omnigent/oauth_host_runtime.py
+++ b/moonmind/omnigent/oauth_host_runtime.py
@@ -25,10 +25,18 @@ from moonmind.schemas.agent_runtime_models import (
     OmnigentHostLease,
 )
 from moonmind.schemas.workspace_locator_models import (
+    ExternalStateLocator,
+    ManagedWorkspaceLocator,
     SandboxWorkspaceLocator,
+    WORKSPACE_AUTHORITY_MISMATCH,
     WORKSPACE_LOCATOR_ADAPTER,
+    WORKSPACE_LOCATOR_UNSUPPORTED,
+    WorkspaceLocatorResolutionError,
 )
 from moonmind.workflows.temporal.runtime.command_runner import run_runtime_command
+from moonmind.workflows.temporal.runtime.git_auth import (
+    build_github_token_git_environment,
+)
 from moonmind.workflows.temporal.runtime.workspace_locators import (
     SandboxWorkspaceRecord,
     SandboxWorkspaceRecordStore,
@@ -62,6 +70,11 @@ _DEFAULT_HOST_PATH = (
 _DIGEST_IMAGE = re.compile(r"^[^\s@]+@sha256:[0-9a-f]{64}$")
 _PLACEHOLDER_DIGEST = "0" * 64
 _SAFE_NETWORK = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_.-]{0,127}$")
+_GITHUB_SLUG = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+# Bound restore-input materialization so a hostile or oversized artifact ref
+# cannot exhaust the authorized workspace before the host launches.
+_MAX_RESTORE_INPUT_REFS = 64
+_MAX_RESTORE_INPUT_BYTES = 64 * 1024 * 1024
 
 _RUNTIME_ADAPTERS = {
     "codex_cli": {
@@ -137,6 +150,10 @@ class OmnigentOAuthHostRuntime:
         self._tool_bundle_volume = os.getenv(
             "OMNIGENT_TOOL_BUNDLE_VOLUME", "moonmind-omnigent-tools-gh-2.76.2"
         )
+        # Bounded, non-sensitive evidence of the most recent workspace resolution,
+        # surfaced through the preflight result for Workflow Detail. Never carries
+        # credentials, raw daemon paths, or unbounded command output.
+        self._last_workspace_evidence: dict[str, Any] = {}
 
     async def prepare_host(
         self,
@@ -154,6 +171,11 @@ class OmnigentOAuthHostRuntime:
         github_token: str | None = None,
         github_mutation_required: bool = False,
         effective_launch: Mapping[str, Any] | None = None,
+        repository_source: str = "",
+        starting_branch: str | None = None,
+        target_branch: str | None = None,
+        checkout_commit: str | None = None,
+        restore_input_refs: tuple[str, ...] = (),
     ) -> dict[str, Any]:
         # Validate the complete product-owned decision before materializing skills,
         # creating volumes, or starting a container.
@@ -179,6 +201,13 @@ class OmnigentOAuthHostRuntime:
             workspace_locator=workspace_locator,
             current_workflow_id=current_workflow_id,
             current_step_execution_id=current_step_execution_id,
+            repository_source=repository_source,
+            starting_branch=starting_branch,
+            target_branch=target_branch,
+            checkout_commit=checkout_commit,
+            restore_input_refs=restore_input_refs,
+            github_token=github_token,
+            artifact_gateway=artifact_gateway,
         )
         daemon_workspace_source = daemon_visible_workspace_path(workspace_source)
         daemon_skill_projection = daemon_visible_workspace_path(skill_projection)
@@ -252,6 +281,7 @@ class OmnigentOAuthHostRuntime:
         validated["workspacePath"] = result["workspacePath"]
         validated["activeSkillsPath"] = str(skill_projection)
         validated["mountedTools"] = mounted_tool_evidence
+        validated["workspaceResolution"] = dict(self._last_workspace_evidence)
         return validated
 
     @staticmethod
@@ -816,24 +846,73 @@ class OmnigentOAuthHostRuntime:
         workspace_locator: Mapping[str, Any],
         current_workflow_id: str,
         current_step_execution_id: str,
+        repository_source: str = "",
+        starting_branch: str | None = None,
+        target_branch: str | None = None,
+        checkout_commit: str | None = None,
+        restore_input_refs: tuple[str, ...] = (),
+        github_token: str | None = None,
+        artifact_gateway: Any | None = None,
     ) -> Path:
+        """Resolve, and when required materialize, the authoritative workspace.
+
+        Every supported locator kind is routed through this single owning-worker
+        boundary. Profile-bound Omnigent workspace authority is the sandbox plane,
+        so managed-runtime and external-state locators fail closed here rather than
+        silently substituting a different workspace, and an external-state artifact
+        ref is never conflated with a local filesystem path.
+        """
+
         locator = WORKSPACE_LOCATOR_ADAPTER.validate_python(workspace_locator)
-        if not isinstance(locator, SandboxWorkspaceLocator):
+        if isinstance(locator, ExternalStateLocator):
+            # External state proves session/provider continuity only. It is an
+            # artifact reference, not a local workspace, and cannot satisfy host
+            # workspace materialization; treating it as a path would conflate the
+            # two authorities. Its refs are materialized as restore *inputs* into
+            # a sandbox workspace instead (see ``restore_input_refs``).
+            raise OmnigentOAuthHostError(
+                "external-state locators are session-continuity refs, not a host "
+                "workspace; supply a sandbox locator with restore input refs",
+                code=WORKSPACE_LOCATOR_UNSUPPORTED,
+            )
+        if isinstance(locator, ManagedWorkspaceLocator):
+            raise OmnigentOAuthHostError(
+                "profile-bound Omnigent workspace authority is the sandbox plane; "
+                "managed-runtime locators are not a valid host workspace",
+                code=WORKSPACE_LOCATOR_UNSUPPORTED,
+            )
+        if not isinstance(locator, SandboxWorkspaceLocator):  # pragma: no cover
             raise OmnigentOAuthHostError(
                 "Omnigent repository work requires a sandbox WorkspaceLocator",
-                code="WORKSPACE_LOCATOR_UNSUPPORTED",
+                code=WORKSPACE_LOCATOR_UNSUPPORTED,
             )
+
         expected_id = hashlib.sha256(
             f"{current_workflow_id}:{current_step_execution_id}".encode("utf-8")
         ).hexdigest()[:24]
-        # Validate the workflow-derived identity and containment before writing
-        # even the owner record.
-        resolve_sandbox_workspace_locator(
+        # 1. Validate the workflow-derived identity, containment, traversal, and
+        #    symlink behavior before any host mutation, without yet requiring the
+        #    directory to exist.
+        workspace = resolve_sandbox_workspace_locator(
             locator,
             workspace_root=self._workspace_root,
             expected_workspace_id=expected_id,
-            must_exist=True,
+            must_exist=False,
         )
+        source = str(repository_source or "").strip()
+        already_materialized = workspace.is_dir()
+        # 2. A workspace that is neither pre-materialized nor accompanied by an
+        #    authored repository source cannot be created here; reject before
+        #    writing any owner record or running any command.
+        if not already_materialized and not source:
+            raise WorkspaceLocatorResolutionError(
+                WORKSPACE_AUTHORITY_MISMATCH,
+                "authorized sandbox workspace is unavailable and no repository "
+                "source was authored to materialize it",
+            )
+        # 3. Establish or load the durable owner record and validate its binding
+        #    before mutating the filesystem, so a retry or a foreign record can
+        #    never author a second workspace under this identity.
         record_store = SandboxWorkspaceRecordStore(self._workspace_root)
         authoritative_record = record_store.load(locator.workspace_id)
         if authoritative_record is None:
@@ -844,6 +923,36 @@ class OmnigentOAuthHostRuntime:
                 relative_path=locator.relative_path,
             )
             record_store.ensure(authoritative_record)
+        resolve_sandbox_workspace_locator(
+            locator,
+            workspace_root=self._workspace_root,
+            expected_workspace_id=expected_id,
+            owner_record=authoritative_record,
+            expected_workflow_id=current_workflow_id,
+            expected_step_execution_id=current_step_execution_id,
+            must_exist=False,
+        )
+        # 4. Materialize the authored repository/branch and restore inputs exactly
+        #    once. Retries observe the already-materialized workspace and skip all
+        #    git and archive mutation.
+        materialization: dict[str, Any] = {"action": "reused_pre_materialized"}
+        if not already_materialized:
+            materialization = await self._materialize_repository(
+                workspace,
+                repository_source=source,
+                starting_branch=starting_branch,
+                target_branch=target_branch,
+                checkout_commit=checkout_commit,
+                github_token=github_token,
+            )
+            restore_evidence = await self._materialize_restore_inputs(
+                workspace,
+                restore_input_refs=restore_input_refs,
+                artifact_gateway=artifact_gateway,
+            )
+            if restore_evidence:
+                materialization["restoreInputs"] = restore_evidence
+        # 5. Final containment-checked resolution; the directory must now exist.
         workspace = resolve_sandbox_workspace_locator(
             locator,
             workspace_root=self._workspace_root,
@@ -853,7 +962,228 @@ class OmnigentOAuthHostRuntime:
             expected_step_execution_id=current_step_execution_id,
             must_exist=True,
         )
+        self._last_workspace_evidence = self._workspace_resolution_evidence(
+            locator=locator,
+            expected_id=expected_id,
+            materialization=materialization,
+        )
         return workspace
+
+    async def _materialize_repository(
+        self,
+        workspace: Path,
+        *,
+        repository_source: str,
+        starting_branch: str | None,
+        target_branch: str | None,
+        checkout_commit: str | None,
+        github_token: str | None,
+    ) -> dict[str, Any]:
+        """Clone and check out the authored repository state deterministically.
+
+        Uses the shared bounded/redacted/cancellation-aware command runner. The
+        GitHub token, when present, is injected only through an in-memory git
+        credential helper (never argv or on-disk config) and only for GitHub HTTPS
+        sources, honoring declared-capability credential injection policy.
+        """
+
+        source, source_kind = self._normalize_repository_source(repository_source)
+        start = self._normalize_branch(starting_branch)
+        target = self._normalize_branch(target_branch)
+        commit = str(checkout_commit or "").strip()
+        workspace.parent.mkdir(parents=True, exist_ok=True)
+
+        git_env = dict(os.environ)
+        if source_kind == "github_https" and github_token:
+            git_env = build_github_token_git_environment(
+                github_token, base_env=os.environ
+            )
+
+        clone_args = ["git", "clone"]
+        # A remote clone can fetch just the authored branch; a local source keeps
+        # every ref so a subsequent checkout can select it.
+        if start and source_kind != "local":
+            clone_args.extend(["--branch", start, "--single-branch"])
+        clone_args.extend(["--", source, str(workspace)])
+        code, _out, err = await self._run(*clone_args, env=git_env, check=False)
+        if code != 0:
+            raise OmnigentOAuthHostError(
+                f"workspace repository materialization failed: {err.strip()[:200]}",
+                code="OMNIGENT_WORKSPACE_MATERIALIZATION_FAILED",
+            )
+
+        checked_out = start or None
+        if commit:
+            code, _out, err = await self._run(
+                "git", "-C", str(workspace), "checkout", "--detach", commit,
+                env=git_env, check=False,
+            )
+            if code != 0:
+                raise OmnigentOAuthHostError(
+                    f"workspace commit checkout failed: {err.strip()[:200]}",
+                    code="OMNIGENT_WORKSPACE_MATERIALIZATION_FAILED",
+                )
+            checked_out = commit
+        elif start and source_kind == "local":
+            code, _out, _err = await self._run(
+                "git", "-C", str(workspace), "checkout", start,
+                env=git_env, check=False,
+            )
+            if code != 0:
+                await self._run(
+                    "git", "-C", str(workspace), "checkout", "-B", start,
+                    f"origin/{start}", env=git_env, check=False,
+                )
+
+        output_branch = None
+        if target and target != checked_out:
+            # Honor the authored output branch without discarding the checked-out
+            # working tree, matching normal MoonMind repository semantics.
+            code, _out, err = await self._run(
+                "git", "-C", str(workspace), "checkout", "-B", target,
+                env=git_env, check=False,
+            )
+            if code != 0:
+                raise OmnigentOAuthHostError(
+                    f"workspace output branch selection failed: {err.strip()[:200]}",
+                    code="OMNIGENT_WORKSPACE_MATERIALIZATION_FAILED",
+                )
+            output_branch = target
+
+        return {
+            "action": "materialized",
+            "sourceKind": source_kind,
+            "startingBranch": start,
+            "checkedOut": checked_out,
+            "outputBranch": output_branch,
+            "commit": commit or None,
+        }
+
+    async def _materialize_restore_inputs(
+        self,
+        workspace: Path,
+        *,
+        restore_input_refs: tuple[str, ...],
+        artifact_gateway: Any | None,
+    ) -> list[dict[str, Any]]:
+        """Materialize checkpoint/external-state restore inputs into the workspace.
+
+        Restore inputs are durable ``artifact://`` references, resolved through the
+        artifact owner. A ref that looks like a local path is rejected so an
+        artifact ref can never be conflated with a filesystem path. Materialized
+        bytes are written under a bounded ``.moonmind/restore`` area inside the
+        already-containment-checked workspace.
+        """
+
+        refs = [str(ref).strip() for ref in restore_input_refs if str(ref).strip()]
+        if not refs:
+            return []
+        if len(refs) > _MAX_RESTORE_INPUT_REFS:
+            raise OmnigentOAuthHostError(
+                "too many restore input refs for the authorized workspace",
+                code="OMNIGENT_WORKSPACE_MATERIALIZATION_FAILED",
+            )
+        artifact_service = self._as_artifact_service(artifact_gateway)
+        if artifact_service is None:
+            raise OmnigentOAuthHostError(
+                "restore inputs require an artifact service to resolve refs",
+                code="OMNIGENT_WORKSPACE_MATERIALIZATION_FAILED",
+            )
+        restore_root = (workspace / ".moonmind" / "restore").resolve()
+        if not restore_root.is_relative_to(workspace.resolve()):  # pragma: no cover
+            raise WorkspaceLocatorResolutionError(
+                WORKSPACE_AUTHORITY_MISMATCH,
+                "restore materialization escaped the authorized workspace",
+            )
+        restore_root.mkdir(parents=True, exist_ok=True)
+        evidence: list[dict[str, Any]] = []
+        for ref in refs:
+            if not ref.startswith("artifact://"):
+                raise OmnigentOAuthHostError(
+                    "restore inputs must be durable artifact refs, not local paths",
+                    code=WORKSPACE_LOCATOR_UNSUPPORTED,
+                )
+            _metadata, payload = await artifact_service.read(artifact_id=ref)
+            if len(payload) > _MAX_RESTORE_INPUT_BYTES:
+                raise OmnigentOAuthHostError(
+                    "restore input exceeds the authorized workspace bound",
+                    code="OMNIGENT_WORKSPACE_MATERIALIZATION_FAILED",
+                )
+            digest = hashlib.sha256(ref.encode("utf-8")).hexdigest()[:24]
+            (restore_root / digest).write_bytes(payload)
+            evidence.append({"ref": ref, "bytes": len(payload)})
+        return evidence
+
+    @staticmethod
+    def _as_artifact_service(artifact_gateway: Any | None) -> Any | None:
+        if artifact_gateway is None:
+            return None
+        if hasattr(artifact_gateway, "read"):
+            return artifact_gateway
+
+        class _GatewayArtifactService:
+            async def read(self, *, artifact_id: str, **_kwargs: Any):
+                payload = await artifact_gateway.read_bytes(artifact_id)
+                return {}, payload
+
+        return _GatewayArtifactService()
+
+    @staticmethod
+    def _normalize_repository_source(repository_source: str) -> tuple[str, str]:
+        """Resolve an authored repository identity to a clone source and kind."""
+
+        value = str(repository_source or "").strip()
+        if not value:
+            raise OmnigentOAuthHostError(
+                "repository source is required to materialize the workspace",
+                code="OMNIGENT_WORKSPACE_MATERIALIZATION_FAILED",
+            )
+        if value.startswith(("http://", "https://", "git@", "file://", "ssh://")):
+            kind = (
+                "github_https"
+                if value.startswith(("http://", "https://"))
+                and "github.com" in value
+                else "remote"
+            )
+            return value, kind
+        if value.startswith(("/", "./", "../")) or Path(value).is_absolute():
+            return value, "local"
+        if _GITHUB_SLUG.fullmatch(value):
+            suffix = "" if value.endswith(".git") else ".git"
+            return f"https://github.com/{value}{suffix}", "github_https"
+        raise OmnigentOAuthHostError(
+            "unsupported repository source; expected owner/repo, URL, or path",
+            code="OMNIGENT_WORKSPACE_MATERIALIZATION_FAILED",
+        )
+
+    @staticmethod
+    def _normalize_branch(branch: str | None) -> str | None:
+        normalized = str(branch or "").strip()
+        while normalized:
+            prior = normalized
+            for prefix in ("refs/remotes/origin/", "refs/heads/", "origin/"):
+                if normalized.startswith(prefix):
+                    normalized = normalized[len(prefix):]
+            if prior == normalized:
+                break
+        return normalized or None
+
+    @staticmethod
+    def _workspace_resolution_evidence(
+        *,
+        locator: SandboxWorkspaceLocator,
+        expected_id: str,
+        materialization: Mapping[str, Any],
+    ) -> dict[str, Any]:
+        """Assemble bounded, credential-free workspace-resolution evidence."""
+
+        return {
+            "locatorKind": locator.kind,
+            "workspaceId": locator.workspace_id,
+            "relativePath": locator.relative_path,
+            "identityVerified": locator.workspace_id == expected_id,
+            "materialization": dict(materialization),
+        }
 
     async def _initialize_required_tools(self) -> None:
         await self._run(

--- a/moonmind/omnigent/profile_bound_execution.py
+++ b/moonmind/omnigent/profile_bound_execution.py
@@ -679,8 +679,46 @@ class OmnigentProfileBoundExecutionCoordinator:
                 github_token=github_token,
                 github_mutation_required=self._github_mutation_required(request),
                 effective_launch=effective_launch,
+                # A remediation workspace is already materialized and authorized by
+                # the remediation owner, so never re-clone it here. Fresh normal
+                # runs carry authored repository/branch intent that must be
+                # materialized into the authoritative sandbox workspace.
+                repository_source=(
+                    ""
+                    if remediation_resolution is not None
+                    else self._repository_source(request)
+                ),
+                starting_branch=(
+                    None
+                    if remediation_resolution is not None
+                    else self._starting_branch(request)
+                ),
+                target_branch=(
+                    None
+                    if remediation_resolution is not None
+                    else self._target_branch(request)
+                ),
+                checkout_commit=(
+                    None
+                    if remediation_resolution is not None
+                    else self._checkout_commit(request)
+                ),
+                restore_input_refs=(
+                    ()
+                    if remediation_resolution is not None
+                    else self._restore_input_refs(request)
+                ),
             )
             await emit(current_stage, "completed")
+            workspace_resolution = preflight.get("workspaceResolution")
+            if isinstance(workspace_resolution, Mapping) and workspace_resolution:
+                # Durable, bounded, credential-free evidence of which workspace was
+                # resolved and how it was materialized, for Workflow Detail.
+                await self._run_store.record_lifecycle_event(
+                    request.idempotency_key,
+                    event_type="workspace_resolution",
+                    metadata=dict(workspace_resolution),
+                )
             await emit("credential_mount", "started")
             await emit(
                 "credential_mount",
@@ -1163,6 +1201,63 @@ class OmnigentProfileBoundExecutionCoordinator:
                 code="WORKSPACE_LOCATOR_REQUIRED",
             )
         return dict(locator)
+
+    @staticmethod
+    def _workspace_spec(request: AgentExecutionRequest) -> Mapping[str, Any]:
+        spec = request.workspace_spec
+        return spec if isinstance(spec, Mapping) else {}
+
+    @classmethod
+    def _repository_source(cls, request: AgentExecutionRequest) -> str:
+        spec = cls._workspace_spec(request)
+        parameters = request.parameters or {}
+        for candidate in (
+            spec.get("repository"),
+            spec.get("repo"),
+            parameters.get("repository"),
+        ):
+            value = str(candidate or "").strip()
+            if value:
+                return value
+        return ""
+
+    @classmethod
+    def _starting_branch(cls, request: AgentExecutionRequest) -> str | None:
+        spec = cls._workspace_spec(request)
+        for candidate in (
+            spec.get("startingBranch"),
+            spec.get("branch"),
+            spec.get("baseBranch"),
+        ):
+            value = str(candidate or "").strip()
+            if value:
+                return value
+        return None
+
+    @classmethod
+    def _target_branch(cls, request: AgentExecutionRequest) -> str | None:
+        value = str(cls._workspace_spec(request).get("targetBranch") or "").strip()
+        return value or None
+
+    @classmethod
+    def _checkout_commit(cls, request: AgentExecutionRequest) -> str | None:
+        spec = cls._workspace_spec(request)
+        for candidate in (spec.get("checkoutCommit"), spec.get("baseCommit")):
+            value = str(candidate or "").strip()
+            if value:
+                return value
+        return None
+
+    @classmethod
+    def _restore_input_refs(cls, request: AgentExecutionRequest) -> tuple[str, ...]:
+        raw = cls._workspace_spec(request).get("restoreInputRefs")
+        if not isinstance(raw, (list, tuple)):
+            return ()
+        return tuple(
+            dict.fromkeys(
+                str(value).strip() for value in raw if str(value).strip()
+            )
+        )
 
     @staticmethod
     def _remediation_workspace(

--- a/moonmind/omnigent/profile_bound_execution.py
+++ b/moonmind/omnigent/profile_bound_execution.py
@@ -1280,11 +1280,18 @@ class OmnigentProfileBoundExecutionCoordinator:
             )
         )
 
-    @staticmethod
-    async def _github_token(request: AgentExecutionRequest) -> str | None:
-        if "gh" not in OmnigentProfileBoundExecutionCoordinator._required_capabilities(
-            request
-        ):
+    @classmethod
+    async def _github_token(cls, request: AgentExecutionRequest) -> str | None:
+        gh_required = "gh" in cls._required_capabilities(request)
+        # A GitHub repository source must be cloned into the sandbox before the
+        # host launches. Private repositories require a credential for that clone
+        # even when mounted `gh` readiness is not a declared capability — for
+        # example read-only or publishMode=none work derives `git` but not `gh`.
+        # Resolve the clone credential from the authored GitHub repository source
+        # independently of mounted-`gh` readiness so private materialization does
+        # not silently fall back to an unauthenticated clone.
+        clone_needs_credential = cls._github_repository_source(request) is not None
+        if not gh_required and not clone_needs_credential:
             return None
         from moonmind.auth.github_credentials import resolve_github_credential
 
@@ -1292,11 +1299,35 @@ class OmnigentProfileBoundExecutionCoordinator:
         resolved = await resolve_github_credential(repo=repository or None)
         token = str(resolved.token or "").strip() if resolved else ""
         if not token:
-            raise OmnigentOAuthHostError(
-                "GitHub credential is required for mounted gh readiness",
-                code="github_auth_unavailable",
-            )
+            if gh_required:
+                raise OmnigentOAuthHostError(
+                    "GitHub credential is required for mounted gh readiness",
+                    code="github_auth_unavailable",
+                )
+            # A public GitHub clone can proceed unauthenticated; a private clone
+            # fails fast with an actionable error at materialization.
+            return None
         return token
+
+    @classmethod
+    def _github_repository_source(cls, request: AgentExecutionRequest) -> str | None:
+        """Return the authored GitHub HTTPS clone source, if any.
+
+        Reuses the single canonical repository-source classifier so GitHub
+        detection cannot drift between credential resolution and materialization.
+        """
+        source = cls._repository_source(request)
+        if not source:
+            return None
+        from moonmind.omnigent.oauth_host_runtime import OmnigentOAuthHostRuntime
+
+        try:
+            normalized, kind = OmnigentOAuthHostRuntime._normalize_repository_source(
+                source
+            )
+        except OmnigentOAuthHostError:
+            return None
+        return normalized if kind == "github_https" else None
 
     @staticmethod
     def _github_mutation_required(request: AgentExecutionRequest) -> bool:

--- a/moonmind/workflows/temporal/activities/omnigent_activities.py
+++ b/moonmind/workflows/temporal/activities/omnigent_activities.py
@@ -71,6 +71,24 @@ async def omnigent_execute_activity(
                     )
                     return await service.read(artifact_id=artifact_id, **kwargs)
 
+            async def get_metadata(self, *, artifact_id: str, **kwargs):
+                async with async_session_maker() as artifact_session:
+                    service = TemporalArtifactService(
+                        TemporalArtifactRepository(artifact_session)
+                    )
+                    return await service.get_metadata(
+                        artifact_id=artifact_id, **kwargs
+                    )
+
+            async def read_chunks(self, *, artifact_id: str, **kwargs):
+                async with async_session_maker() as artifact_session:
+                    service = TemporalArtifactService(
+                        TemporalArtifactRepository(artifact_session)
+                    )
+                    return await service.read_chunks(
+                        artifact_id=artifact_id, **kwargs
+                    )
+
             async def write_complete(self, *, artifact_id: str, **kwargs):
                 async with async_session_maker() as artifact_session:
                     service = TemporalArtifactService(

--- a/moonmind/workflows/temporal/runtime/workspace_locators.py
+++ b/moonmind/workflows/temporal/runtime/workspace_locators.py
@@ -43,6 +43,36 @@ class SandboxWorkspaceRecordStore:
             )
         return candidate
 
+    def _completion_marker_path(self, workspace_id: str) -> Path:
+        candidate = (self.store_root / f"{workspace_id}.materialized").resolve()
+        if candidate.parent != self.store_root.resolve():
+            raise WorkspaceLocatorResolutionError(
+                WORKSPACE_AUTHORITY_MISMATCH,
+                "sandbox workspace completion marker escapes its authority",
+            )
+        return candidate
+
+    def is_materialized(self, workspace_id: str) -> bool:
+        """Return whether workspace materialization durably completed.
+
+        A completion marker is written only after the full clone, checkout, and
+        restore-input materialization succeeded, so a retry can distinguish a
+        finished workspace from a partially built directory left by a prior
+        attempt that failed mid-materialization.
+        """
+        return self._completion_marker_path(workspace_id).is_file()
+
+    def mark_materialized(self, workspace_id: str) -> None:
+        """Record durable evidence that materialization completed."""
+        self.store_root.mkdir(mode=0o700, parents=True, exist_ok=True)
+        path = self._completion_marker_path(workspace_id)
+        try:
+            descriptor = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        except FileExistsError:
+            return
+        with os.fdopen(descriptor, "w", encoding="utf-8") as stream:
+            stream.write("materialized")
+
     def load(self, workspace_id: str) -> SandboxWorkspaceRecord | None:
         path = self._record_path(workspace_id)
         if not path.is_file():

--- a/tests/integration/reliability_journey/test_omnigent_workspace_materialization_journey.py
+++ b/tests/integration/reliability_journey/test_omnigent_workspace_materialization_journey.py
@@ -79,7 +79,9 @@ async def test_normal_workflow_materializes_one_authoritative_workspace(
     _init_source_repo(source)
     workspace_root = tmp_path / "workspaces"
     runtime = OmnigentOAuthHostRuntime(
-        client=SimpleNamespace(), workspace_root=workspace_root
+        client=SimpleNamespace(),
+        workspace_root=workspace_root,
+        repository_source_root=tmp_path,
     )
 
     # The workflow authors a durable locator identity, never a worker path.

--- a/tests/integration/reliability_journey/test_omnigent_workspace_materialization_journey.py
+++ b/tests/integration/reliability_journey/test_omnigent_workspace_materialization_journey.py
@@ -1,0 +1,157 @@
+"""Controlling journey for MoonLadderStudios/MoonMind#3507.
+
+Proves the complete normal-workflow Omnigent workspace path end to end, without
+Docker or network: a fresh sandbox locator materializes the authored repository
+and branch into the single authoritative workspace through the owning-worker
+boundary, a retry is idempotent and preserves working-tree state, and locator
+kinds that are not a valid host workspace fail closed rather than silently
+substituting a different workspace.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from moonmind.omnigent.oauth_hosts import OmnigentOAuthHostError
+from moonmind.omnigent.oauth_host_runtime import OmnigentOAuthHostRuntime
+from moonmind.schemas.workspace_locator_models import (
+    WorkspaceLocatorResolutionError,
+)
+from moonmind.workflows.temporal.runtime.workspace_locators import (
+    SandboxWorkspaceRecordStore,
+)
+from types import SimpleNamespace
+
+
+pytestmark = [pytest.mark.integration, pytest.mark.integration_ci]
+
+
+def _git(cwd: Path, *args: str) -> None:
+    subprocess.run(
+        [
+            "git",
+            "-c",
+            "user.email=journey@moonmind.test",
+            "-c",
+            "user.name=MoonMind Journey",
+            "-c",
+            "init.defaultBranch=main",
+            *args,
+        ],
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+    )
+
+
+def _init_source_repo(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    _git(path, "init")
+    _git(path, "checkout", "-B", "main")
+    (path / "app.py").write_text("print('hello')\n", encoding="utf-8")
+    _git(path, "add", "app.py")
+    _git(path, "commit", "-m", "seed")
+    _git(path, "checkout", "-B", "release")
+    (path / "release.txt").write_text("released\n", encoding="utf-8")
+    _git(path, "add", "release.txt")
+    _git(path, "commit", "-m", "release")
+    _git(path, "checkout", "main")
+
+
+def _current_branch(repo: Path) -> str:
+    return subprocess.run(
+        ["git", "-C", str(repo), "rev-parse", "--abbrev-ref", "HEAD"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+@pytest.mark.asyncio
+async def test_normal_workflow_materializes_one_authoritative_workspace(
+    tmp_path,
+) -> None:
+    source = tmp_path / "source"
+    _init_source_repo(source)
+    workspace_root = tmp_path / "workspaces"
+    runtime = OmnigentOAuthHostRuntime(
+        client=SimpleNamespace(), workspace_root=workspace_root
+    )
+
+    # The workflow authors a durable locator identity, never a worker path.
+    workflow_id = "mm:wf-3507"
+    step_execution_id = "mm:wf-3507:run:implement:execution:1"
+    workspace_id = hashlib.sha256(
+        f"{workflow_id}:{step_execution_id}".encode("utf-8")
+    ).hexdigest()[:24]
+    locator = {"kind": "sandbox", "workspaceId": workspace_id, "relativePath": "repo"}
+
+    resolved = await runtime._prepare_workspace(
+        workspace_locator=locator,
+        current_workflow_id=workflow_id,
+        current_step_execution_id=step_execution_id,
+        repository_source=str(source),
+        starting_branch="release",
+        target_branch="agent/implement",
+    )
+
+    # One authoritative workspace with the authored repository + branch state.
+    assert resolved == workspace_root / "temporal_sandbox" / workspace_id / "repo"
+    assert (resolved / ".git").is_dir()
+    assert (resolved / "release.txt").is_file()
+    assert _current_branch(resolved) == "agent/implement"
+
+    # Durable owner evidence binds the workspace to this exact execution.
+    record = SandboxWorkspaceRecordStore(workspace_root).load(workspace_id)
+    assert record is not None
+    assert record.workflow_id == workflow_id
+    assert record.step_execution_id == step_execution_id
+
+    # A retry cannot create a second workspace/host or discard in-flight work.
+    (resolved / "in-flight.txt").write_text("uncommitted", encoding="utf-8")
+    retry = await runtime._prepare_workspace(
+        workspace_locator=locator,
+        current_workflow_id=workflow_id,
+        current_step_execution_id=step_execution_id,
+        repository_source=str(source),
+        starting_branch="release",
+        target_branch="agent/implement",
+    )
+    assert retry == resolved
+    assert (resolved / "in-flight.txt").read_text(encoding="utf-8") == "uncommitted"
+    assert runtime._last_workspace_evidence["materialization"]["action"] == (
+        "reused_pre_materialized"
+    )
+
+    # A cross-execution retry pointed at the same durable identity is rejected
+    # before any mutation, so it cannot hijack another run's workspace.
+    with pytest.raises(WorkspaceLocatorResolutionError):
+        await runtime._prepare_workspace(
+            workspace_locator=locator,
+            current_workflow_id="mm:wf-other",
+            current_step_execution_id="mm:wf-other:run:implement:execution:1",
+            repository_source=str(source),
+        )
+
+
+@pytest.mark.asyncio
+async def test_non_sandbox_locators_fail_closed(tmp_path) -> None:
+    runtime = OmnigentOAuthHostRuntime(
+        client=SimpleNamespace(), workspace_root=tmp_path / "workspaces"
+    )
+
+    for locator in (
+        {"kind": "external_state", "artifactRef": "artifact://checkpoint/1"},
+        {"kind": "managed_runtime", "runtimeId": "codex_cli", "agentRunId": "run-1"},
+    ):
+        with pytest.raises(OmnigentOAuthHostError) as exc:
+            await runtime._prepare_workspace(
+                workspace_locator=locator,
+                current_workflow_id="mm:wf-3507",
+                current_step_execution_id="mm:wf-3507:run:implement:execution:1",
+            )
+        assert exc.value.code == "WORKSPACE_LOCATOR_UNSUPPORTED"

--- a/tests/unit/omnigent/test_bridge_store.py
+++ b/tests/unit/omnigent/test_bridge_store.py
@@ -461,6 +461,41 @@ async def test_initial_retrieval_appends_bounded_lifecycle_evidence(store):
 
 
 @pytest.mark.asyncio
+async def test_workspace_resolution_metadata_persists_through_allowlist(store):
+    row = await store.get_or_create(
+        request=_request(), endpoint_ref="default", agent_id=None,
+        agent_name=None, target_metadata={},
+    )
+    resolution = {
+        "locatorKind": "sandbox",
+        "workspaceId": "ws-abc123",
+        "relativePath": "repo",
+        "identityVerified": True,
+        "materialization": {
+            "action": "materialized",
+            "sourceKind": "github_https",
+            "checkedOut": "feature",
+            "restoreInputs": [{"ref": "artifact://a", "bytes": 12}],
+        },
+    }
+
+    await store.record_lifecycle_event(
+        "idem-1",
+        event_type="workspace_resolution",
+        metadata=resolution,
+    )
+
+    events = await store.list_events(row.bridge_session_id)
+    resolution_events = [
+        event for event in events if event.event_type == "workspace_resolution"
+    ]
+    assert len(resolution_events) == 1
+    # The durable resolution evidence reaches Workflow Detail intact rather than
+    # being silently dropped by the metadata allowlist.
+    assert resolution_events[0].metadata_["metadata"] == resolution
+
+
+@pytest.mark.asyncio
 async def test_attach_conflicting_session_fails(store):
     request = _request()
     await store.get_or_create(

--- a/tests/unit/omnigent/test_oauth_profile_lifecycle.py
+++ b/tests/unit/omnigent/test_oauth_profile_lifecycle.py
@@ -2446,8 +2446,13 @@ def _sandbox_id() -> str:
 
 
 def _runtime_for(tmp_path: Path) -> OmnigentOAuthHostRuntime:
+    # ``tmp_path`` is the authorized per-run source root, so local test source
+    # repositories created under it are clonable while arbitrary host paths are
+    # rejected.
     return OmnigentOAuthHostRuntime(
-        client=SimpleNamespace(), workspace_root=tmp_path / "workspaces"
+        client=SimpleNamespace(),
+        workspace_root=tmp_path / "workspaces",
+        repository_source_root=tmp_path,
     )
 
 
@@ -2573,10 +2578,32 @@ async def test_prepare_workspace_rejects_managed_runtime_locator(tmp_path) -> No
 
 
 class _FakeArtifactService:
+    """Durable-service fake keyed by scheme-stripped artifact id.
+
+    Mirrors ``TemporalArtifactService``: reads address artifacts by id (never the
+    ``artifact://`` scheme) and require a ``principal``; the recorded calls let
+    tests assert the real read contract is honored.
+    """
+
     def __init__(self, payloads: dict[str, bytes]) -> None:
         self._payloads = payloads
+        self.read_calls: list[dict] = []
 
-    async def read(self, *, artifact_id: str, **_kwargs):
+    async def read(
+        self,
+        *,
+        artifact_id: str,
+        principal: str | None = None,
+        allow_restricted_raw: bool = False,
+        **_kwargs,
+    ):
+        self.read_calls.append(
+            {
+                "artifact_id": artifact_id,
+                "principal": principal,
+                "allow_restricted_raw": allow_restricted_raw,
+            }
+        )
         return {}, self._payloads[artifact_id]
 
 
@@ -2587,7 +2614,8 @@ async def test_prepare_workspace_materializes_restore_inputs_as_refs(tmp_path) -
     runtime = _runtime_for(tmp_path)
     workspace_id = _sandbox_id()
     ref = "artifact://checkpoint/workspace-archive"
-    service = _FakeArtifactService({ref: b"restore-bytes"})
+    # The durable service is addressed by the scheme-stripped id, not the ref.
+    service = _FakeArtifactService({"checkpoint/workspace-archive": b"restore-bytes"})
 
     resolved = await runtime._prepare_workspace(
         workspace_locator={"kind": "sandbox", "workspaceId": workspace_id},
@@ -2607,6 +2635,15 @@ async def test_prepare_workspace_materializes_restore_inputs_as_refs(tmp_path) -
         "restoreInputs"
     ]
     assert restore_evidence == [{"ref": ref, "bytes": len(b"restore-bytes")}]
+    # The read went through the durable service contract: scheme-stripped id,
+    # dedicated restore principal, and raw-access authorization.
+    assert service.read_calls == [
+        {
+            "artifact_id": "checkpoint/workspace-archive",
+            "principal": "service:omnigent_workspace_restore",
+            "allow_restricted_raw": True,
+        }
+    ]
 
 
 @pytest.mark.asyncio
@@ -2631,6 +2668,226 @@ async def test_prepare_workspace_rejects_local_path_restore_input(tmp_path) -> N
     # A restore input that is a local path must never be conflated with an
     # artifact ref.
     assert exc.value.code == "WORKSPACE_LOCATOR_UNSUPPORTED"
+
+
+class _StreamingArtifactService:
+    """Durable-service fake that supports metadata + chunked reads."""
+
+    def __init__(self, payloads: dict[str, bytes]) -> None:
+        self._payloads = payloads
+        self.metadata_calls: list[str] = []
+        self.chunk_calls: list[str] = []
+
+    async def get_metadata(self, *, artifact_id: str, principal: str, **_kwargs):
+        self.metadata_calls.append(artifact_id)
+        payload = self._payloads[artifact_id]
+        artifact = SimpleNamespace(size_bytes=len(payload))
+        return artifact, [], False, None
+
+    async def read_chunks(
+        self,
+        *,
+        artifact_id: str,
+        principal: str,
+        allow_restricted_raw: bool = False,
+        chunk_size: int = 1024,
+    ):
+        assert allow_restricted_raw is True
+        assert principal == "service:omnigent_workspace_restore"
+        self.chunk_calls.append(artifact_id)
+        payload = self._payloads[artifact_id]
+        chunks = [
+            payload[index : index + chunk_size]
+            for index in range(0, len(payload), chunk_size)
+        ] or [b""]
+        return SimpleNamespace(size_bytes=len(payload)), chunks
+
+
+@pytest.mark.asyncio
+async def test_prepare_workspace_streams_restore_inputs_when_supported(
+    tmp_path,
+) -> None:
+    source = tmp_path / "source"
+    _init_source_repo(source)
+    runtime = _runtime_for(tmp_path)
+    workspace_id = _sandbox_id()
+    ref = "artifact://checkpoint/big-archive"
+    payload = b"x" * (3 * 1024 * 1024)
+    service = _StreamingArtifactService({"checkpoint/big-archive": payload})
+
+    resolved = await runtime._prepare_workspace(
+        workspace_locator={"kind": "sandbox", "workspaceId": workspace_id},
+        current_workflow_id="workflow-1",
+        current_step_execution_id="step-1",
+        repository_source=str(source),
+        starting_branch="main",
+        restore_input_refs=(ref,),
+        artifact_gateway=service,
+    )
+
+    restore_dir = resolved / ".moonmind" / "restore"
+    written = list(restore_dir.iterdir())
+    assert len(written) == 1
+    assert written[0].read_bytes() == payload
+    # The payload was pre-checked from metadata and streamed via chunked reads.
+    assert service.metadata_calls == ["checkpoint/big-archive"]
+    assert service.chunk_calls == ["checkpoint/big-archive"]
+
+
+@pytest.mark.asyncio
+async def test_prepare_workspace_rejects_oversized_restore_from_metadata(
+    tmp_path, monkeypatch
+) -> None:
+    import moonmind.omnigent.oauth_host_runtime as ohr
+
+    monkeypatch.setattr(ohr, "_MAX_RESTORE_INPUT_BYTES", 16)
+    source = tmp_path / "source"
+    _init_source_repo(source)
+    runtime = _runtime_for(tmp_path)
+    workspace_id = _sandbox_id()
+    ref = "artifact://checkpoint/too-big"
+    service = _StreamingArtifactService({"checkpoint/too-big": b"y" * 64})
+
+    with pytest.raises(OmnigentOAuthHostError) as exc:
+        await runtime._prepare_workspace(
+            workspace_locator={"kind": "sandbox", "workspaceId": workspace_id},
+            current_workflow_id="workflow-1",
+            current_step_execution_id="step-1",
+            repository_source=str(source),
+            starting_branch="main",
+            restore_input_refs=(ref,),
+            artifact_gateway=service,
+        )
+
+    assert exc.value.code == "OMNIGENT_WORKSPACE_MATERIALIZATION_FAILED"
+    # Rejected before any bytes were streamed.
+    assert service.chunk_calls == []
+
+
+@pytest.mark.asyncio
+async def test_prepare_workspace_enforces_cumulative_restore_budget(
+    tmp_path, monkeypatch
+) -> None:
+    import moonmind.omnigent.oauth_host_runtime as ohr
+
+    # Each ref is individually legal, but together they exceed the cumulative
+    # budget, so the second ref is rejected.
+    monkeypatch.setattr(ohr, "_MAX_RESTORE_INPUT_BYTES", 1024)
+    monkeypatch.setattr(ohr, "_MAX_RESTORE_TOTAL_BYTES", 1024)
+    source = tmp_path / "source"
+    _init_source_repo(source)
+    runtime = _runtime_for(tmp_path)
+    workspace_id = _sandbox_id()
+    payloads = {
+        "checkpoint/a": b"a" * 800,
+        "checkpoint/b": b"b" * 800,
+    }
+    service = _FakeArtifactService(payloads)
+
+    with pytest.raises(OmnigentOAuthHostError) as exc:
+        await runtime._prepare_workspace(
+            workspace_locator={"kind": "sandbox", "workspaceId": workspace_id},
+            current_workflow_id="workflow-1",
+            current_step_execution_id="step-1",
+            repository_source=str(source),
+            starting_branch="main",
+            restore_input_refs=(
+                "artifact://checkpoint/a",
+                "artifact://checkpoint/b",
+            ),
+            artifact_gateway=service,
+        )
+
+    assert exc.value.code == "OMNIGENT_WORKSPACE_MATERIALIZATION_FAILED"
+
+
+@pytest.mark.asyncio
+async def test_prepare_workspace_rejects_local_source_outside_authorized_root(
+    tmp_path,
+) -> None:
+    # A source outside the authorized per-run root cannot be cloned even though
+    # it is a readable git repository on the worker.
+    outside = tmp_path.parent / "outside-source"
+    _init_source_repo(outside)
+    runtime = OmnigentOAuthHostRuntime(
+        client=SimpleNamespace(),
+        workspace_root=tmp_path / "workspaces",
+        repository_source_root=tmp_path / "authorized",
+    )
+    workspace_id = _sandbox_id()
+
+    with pytest.raises(OmnigentOAuthHostError) as exc:
+        await runtime._prepare_workspace(
+            workspace_locator={"kind": "sandbox", "workspaceId": workspace_id},
+            current_workflow_id="workflow-1",
+            current_step_execution_id="step-1",
+            repository_source=str(outside),
+            starting_branch="main",
+        )
+
+    assert exc.value.code == "WORKSPACE_LOCATOR_UNSUPPORTED"
+
+
+@pytest.mark.asyncio
+async def test_prepare_workspace_rebuilds_incomplete_workspace_on_retry(
+    tmp_path,
+) -> None:
+    source = tmp_path / "source"
+    _init_source_repo(source)
+    runtime = _runtime_for(tmp_path)
+    workspace_id = _sandbox_id()
+    locator = {"kind": "sandbox", "workspaceId": workspace_id}
+
+    # Simulate a prior attempt that created the workspace directory but crashed
+    # before writing durable completion evidence.
+    from moonmind.workflows.temporal.runtime.workspace_locators import (
+        SandboxWorkspaceRecordStore,
+    )
+
+    partial = (
+        tmp_path / "workspaces" / "temporal_sandbox" / workspace_id / "repo"
+    )
+    partial.mkdir(parents=True, exist_ok=True)
+    (partial / "partial-clone.txt").write_text("incomplete", encoding="utf-8")
+    assert not SandboxWorkspaceRecordStore(
+        tmp_path / "workspaces"
+    ).is_materialized(workspace_id)
+
+    resolved = await runtime._prepare_workspace(
+        workspace_locator=locator,
+        current_workflow_id="workflow-1",
+        current_step_execution_id="step-1",
+        repository_source=str(source),
+        starting_branch="feature",
+    )
+
+    # The incomplete directory was torn down and rebuilt from the authored state.
+    assert not (resolved / "partial-clone.txt").exists()
+    assert (resolved / ".git").is_dir()
+    assert _current_branch(resolved) == "feature"
+    assert runtime._last_workspace_evidence["materialization"]["action"] == (
+        "materialized"
+    )
+    assert SandboxWorkspaceRecordStore(
+        tmp_path / "workspaces"
+    ).is_materialized(workspace_id)
+
+
+def test_normalize_repository_source_rejects_spoofed_github_host() -> None:
+    normalize = OmnigentOAuthHostRuntime._normalize_repository_source
+    # Real GitHub host injects credentials.
+    assert normalize("https://github.com/org/repo.git") == (
+        "https://github.com/org/repo.git",
+        "github_https",
+    )
+    # Hosts that merely contain the substring "github.com" must be classified as
+    # untrusted remotes so the GitHub token is never injected into them.
+    for spoof in (
+        "https://github.com.evil.com/org/repo.git",
+        "https://evil.com/github.com/org/repo.git",
+        "https://evilgithub.com/org/repo.git",
+    ):
+        assert normalize(spoof) == (spoof, "remote")
 
 
 def _execution_request(**overrides) -> AgentExecutionRequest:
@@ -2683,3 +2940,79 @@ def test_coordinator_repository_intent_defaults_are_empty() -> None:
     assert OmnigentProfileBoundExecutionCoordinator._target_branch(request) is None
     assert OmnigentProfileBoundExecutionCoordinator._checkout_commit(request) is None
     assert OmnigentProfileBoundExecutionCoordinator._restore_input_refs(request) == ()
+
+
+@pytest.mark.asyncio
+async def test_github_token_resolves_clone_credential_without_gh_capability(
+    monkeypatch,
+) -> None:
+    # publishMode=none read-only work derives `git` but not `gh`; a private
+    # GitHub source must still resolve a clone credential.
+    import moonmind.auth.github_credentials as github_credentials
+
+    resolve = AsyncMock(
+        return_value=SimpleNamespace(token="clone-token")
+    )
+    monkeypatch.setattr(github_credentials, "resolve_github_credential", resolve)
+
+    request = _execution_request(
+        parameters={"repository": "org/repo", "requiredCapabilities": ["git"]}
+    )
+
+    token = await OmnigentProfileBoundExecutionCoordinator._github_token(request)
+
+    assert token == "clone-token"
+    resolve.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_github_token_public_clone_tolerates_missing_credential(
+    monkeypatch,
+) -> None:
+    import moonmind.auth.github_credentials as github_credentials
+
+    resolve = AsyncMock(return_value=SimpleNamespace(token=""))
+    monkeypatch.setattr(github_credentials, "resolve_github_credential", resolve)
+
+    request = _execution_request(
+        parameters={"repository": "org/repo", "requiredCapabilities": ["git"]}
+    )
+
+    # No mounted-gh requirement, so a missing credential is not fatal: a public
+    # clone can proceed unauthenticated (a private clone fails later at git).
+    assert await OmnigentProfileBoundExecutionCoordinator._github_token(request) is None
+
+
+@pytest.mark.asyncio
+async def test_github_token_requires_credential_when_gh_capability_declared(
+    monkeypatch,
+) -> None:
+    import moonmind.auth.github_credentials as github_credentials
+
+    resolve = AsyncMock(return_value=SimpleNamespace(token=""))
+    monkeypatch.setattr(github_credentials, "resolve_github_credential", resolve)
+
+    request = _execution_request(
+        parameters={"repository": "org/repo", "requiredCapabilities": ["git", "gh"]}
+    )
+
+    with pytest.raises(OmnigentOAuthHostError) as exc:
+        await OmnigentProfileBoundExecutionCoordinator._github_token(request)
+    assert exc.value.code == "github_auth_unavailable"
+
+
+@pytest.mark.asyncio
+async def test_github_token_skipped_for_non_github_source(monkeypatch) -> None:
+    import moonmind.auth.github_credentials as github_credentials
+
+    resolve = AsyncMock(return_value=SimpleNamespace(token="unused"))
+    monkeypatch.setattr(github_credentials, "resolve_github_credential", resolve)
+
+    # A non-GitHub remote with no gh capability needs no GitHub clone credential.
+    request = _execution_request(
+        parameters={"requiredCapabilities": ["git"]},
+        workspaceSpec={"repository": "https://gitlab.com/org/repo.git"},
+    )
+
+    assert await OmnigentProfileBoundExecutionCoordinator._github_token(request) is None
+    resolve.assert_not_awaited()

--- a/tests/unit/omnigent/test_oauth_profile_lifecycle.py
+++ b/tests/unit/omnigent/test_oauth_profile_lifecycle.py
@@ -2738,9 +2738,9 @@ async def test_prepare_workspace_streams_restore_inputs_when_supported(
 async def test_prepare_workspace_rejects_oversized_restore_from_metadata(
     tmp_path, monkeypatch
 ) -> None:
-    import moonmind.omnigent.oauth_host_runtime as ohr
-
-    monkeypatch.setattr(ohr, "_MAX_RESTORE_INPUT_BYTES", 16)
+    monkeypatch.setattr(
+        "moonmind.omnigent.oauth_host_runtime._MAX_RESTORE_INPUT_BYTES", 16
+    )
     source = tmp_path / "source"
     _init_source_repo(source)
     runtime = _runtime_for(tmp_path)
@@ -2768,12 +2768,14 @@ async def test_prepare_workspace_rejects_oversized_restore_from_metadata(
 async def test_prepare_workspace_enforces_cumulative_restore_budget(
     tmp_path, monkeypatch
 ) -> None:
-    import moonmind.omnigent.oauth_host_runtime as ohr
-
     # Each ref is individually legal, but together they exceed the cumulative
     # budget, so the second ref is rejected.
-    monkeypatch.setattr(ohr, "_MAX_RESTORE_INPUT_BYTES", 1024)
-    monkeypatch.setattr(ohr, "_MAX_RESTORE_TOTAL_BYTES", 1024)
+    monkeypatch.setattr(
+        "moonmind.omnigent.oauth_host_runtime._MAX_RESTORE_INPUT_BYTES", 1024
+    )
+    monkeypatch.setattr(
+        "moonmind.omnigent.oauth_host_runtime._MAX_RESTORE_TOTAL_BYTES", 1024
+    )
     source = tmp_path / "source"
     _init_source_repo(source)
     runtime = _runtime_for(tmp_path)

--- a/tests/unit/omnigent/test_oauth_profile_lifecycle.py
+++ b/tests/unit/omnigent/test_oauth_profile_lifecycle.py
@@ -2389,3 +2389,297 @@ async def test_coordinator_provider_release_has_bounded_retry_evidence(
 def immutable_bootstrap_images(monkeypatch) -> None:
     monkeypatch.setenv("OMNIGENT_IMAGE_REF", "example.test/omnigent@sha256:" + "1" * 64)
     monkeypatch.setenv("OMNIGENT_HOST_IMAGE_REF", "example.test/host@sha256:" + "2" * 64)
+
+
+# ---------------------------------------------------------------------------
+# MoonLadderStudios/MoonMind#3507 — normal-workflow workspace materialization
+# and single-boundary locator resolution.
+# ---------------------------------------------------------------------------
+
+
+def _init_source_repo(path: Path) -> None:
+    """Create a small git source repo with a `main` and a `feature` branch."""
+
+    path.mkdir(parents=True, exist_ok=True)
+
+    def _git(*args: str) -> None:
+        subprocess.run(
+            [
+                "git",
+                "-c",
+                "user.email=test@moonmind.test",
+                "-c",
+                "user.name=MoonMind Test",
+                "-c",
+                "init.defaultBranch=main",
+                *args,
+            ],
+            cwd=path,
+            check=True,
+            capture_output=True,
+        )
+
+    _git("init")
+    _git("checkout", "-B", "main")
+    (path / "README.md").write_text("main-content\n", encoding="utf-8")
+    _git("add", "README.md")
+    _git("commit", "-m", "initial")
+    _git("checkout", "-B", "feature")
+    (path / "feature.txt").write_text("feature-content\n", encoding="utf-8")
+    _git("add", "feature.txt")
+    _git("commit", "-m", "feature work")
+    _git("checkout", "main")
+
+
+def _current_branch(repo: Path) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(repo), "rev-parse", "--abbrev-ref", "HEAD"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def _sandbox_id() -> str:
+    return hashlib.sha256(b"workflow-1:step-1").hexdigest()[:24]
+
+
+def _runtime_for(tmp_path: Path) -> OmnigentOAuthHostRuntime:
+    return OmnigentOAuthHostRuntime(
+        client=SimpleNamespace(), workspace_root=tmp_path / "workspaces"
+    )
+
+
+@pytest.mark.asyncio
+async def test_prepare_workspace_materializes_repository_and_branch(tmp_path) -> None:
+    source = tmp_path / "source"
+    _init_source_repo(source)
+    runtime = _runtime_for(tmp_path)
+    workspace_id = _sandbox_id()
+
+    resolved = await runtime._prepare_workspace(
+        workspace_locator={"kind": "sandbox", "workspaceId": workspace_id},
+        current_workflow_id="workflow-1",
+        current_step_execution_id="step-1",
+        repository_source=str(source),
+        starting_branch="feature",
+    )
+
+    expected = (
+        tmp_path / "workspaces" / "temporal_sandbox" / workspace_id / "repo"
+    )
+    assert resolved == expected
+    assert (resolved / ".git").is_dir()
+    assert (resolved / "feature.txt").is_file()
+    assert _current_branch(resolved) == "feature"
+    evidence = runtime._last_workspace_evidence
+    assert evidence["locatorKind"] == "sandbox"
+    assert evidence["identityVerified"] is True
+    assert evidence["materialization"]["action"] == "materialized"
+    assert evidence["materialization"]["checkedOut"] == "feature"
+    # Bounded evidence never leaks a raw worker/daemon path.
+    assert str(resolved) not in json.dumps(evidence)
+
+
+@pytest.mark.asyncio
+async def test_prepare_workspace_materialization_is_idempotent(tmp_path) -> None:
+    source = tmp_path / "source"
+    _init_source_repo(source)
+    runtime = _runtime_for(tmp_path)
+    workspace_id = _sandbox_id()
+    kwargs = dict(
+        workspace_locator={"kind": "sandbox", "workspaceId": workspace_id},
+        current_workflow_id="workflow-1",
+        current_step_execution_id="step-1",
+        repository_source=str(source),
+        starting_branch="main",
+    )
+
+    first = await runtime._prepare_workspace(**kwargs)
+    marker = first / "retry-marker.txt"
+    marker.write_text("preserved", encoding="utf-8")
+
+    second = await runtime._prepare_workspace(**kwargs)
+
+    assert first == second
+    # A retry must not re-clone or discard existing working-tree state.
+    assert marker.read_text(encoding="utf-8") == "preserved"
+    assert runtime._last_workspace_evidence["materialization"]["action"] == (
+        "reused_pre_materialized"
+    )
+
+
+@pytest.mark.asyncio
+async def test_prepare_workspace_honors_authored_output_branch(tmp_path) -> None:
+    source = tmp_path / "source"
+    _init_source_repo(source)
+    runtime = _runtime_for(tmp_path)
+    workspace_id = _sandbox_id()
+
+    resolved = await runtime._prepare_workspace(
+        workspace_locator={"kind": "sandbox", "workspaceId": workspace_id},
+        current_workflow_id="workflow-1",
+        current_step_execution_id="step-1",
+        repository_source=str(source),
+        starting_branch="main",
+        target_branch="agent/work",
+    )
+
+    assert _current_branch(resolved) == "agent/work"
+    assert (resolved / "README.md").is_file()
+    assert runtime._last_workspace_evidence["materialization"]["outputBranch"] == (
+        "agent/work"
+    )
+
+
+@pytest.mark.asyncio
+async def test_prepare_workspace_rejects_external_state_locator(tmp_path) -> None:
+    runtime = _runtime_for(tmp_path)
+    runtime._run = AsyncMock(return_value=(0, "", ""))
+
+    with pytest.raises(OmnigentOAuthHostError) as exc:
+        await runtime._prepare_workspace(
+            workspace_locator={
+                "kind": "external_state",
+                "artifactRef": "artifact://checkpoint/123",
+            },
+            current_workflow_id="workflow-1",
+            current_step_execution_id="step-1",
+        )
+
+    assert exc.value.code == "WORKSPACE_LOCATOR_UNSUPPORTED"
+    runtime._run.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_prepare_workspace_rejects_managed_runtime_locator(tmp_path) -> None:
+    runtime = _runtime_for(tmp_path)
+    runtime._run = AsyncMock(return_value=(0, "", ""))
+
+    with pytest.raises(OmnigentOAuthHostError) as exc:
+        await runtime._prepare_workspace(
+            workspace_locator={
+                "kind": "managed_runtime",
+                "runtimeId": "codex_cli",
+                "agentRunId": "run-1",
+            },
+            current_workflow_id="workflow-1",
+            current_step_execution_id="step-1",
+        )
+
+    assert exc.value.code == "WORKSPACE_LOCATOR_UNSUPPORTED"
+    runtime._run.assert_not_awaited()
+
+
+class _FakeArtifactService:
+    def __init__(self, payloads: dict[str, bytes]) -> None:
+        self._payloads = payloads
+
+    async def read(self, *, artifact_id: str, **_kwargs):
+        return {}, self._payloads[artifact_id]
+
+
+@pytest.mark.asyncio
+async def test_prepare_workspace_materializes_restore_inputs_as_refs(tmp_path) -> None:
+    source = tmp_path / "source"
+    _init_source_repo(source)
+    runtime = _runtime_for(tmp_path)
+    workspace_id = _sandbox_id()
+    ref = "artifact://checkpoint/workspace-archive"
+    service = _FakeArtifactService({ref: b"restore-bytes"})
+
+    resolved = await runtime._prepare_workspace(
+        workspace_locator={"kind": "sandbox", "workspaceId": workspace_id},
+        current_workflow_id="workflow-1",
+        current_step_execution_id="step-1",
+        repository_source=str(source),
+        starting_branch="main",
+        restore_input_refs=(ref,),
+        artifact_gateway=service,
+    )
+
+    restore_dir = resolved / ".moonmind" / "restore"
+    written = list(restore_dir.iterdir())
+    assert len(written) == 1
+    assert written[0].read_bytes() == b"restore-bytes"
+    restore_evidence = runtime._last_workspace_evidence["materialization"][
+        "restoreInputs"
+    ]
+    assert restore_evidence == [{"ref": ref, "bytes": len(b"restore-bytes")}]
+
+
+@pytest.mark.asyncio
+async def test_prepare_workspace_rejects_local_path_restore_input(tmp_path) -> None:
+    source = tmp_path / "source"
+    _init_source_repo(source)
+    runtime = _runtime_for(tmp_path)
+    workspace_id = _sandbox_id()
+    service = _FakeArtifactService({})
+
+    with pytest.raises(OmnigentOAuthHostError) as exc:
+        await runtime._prepare_workspace(
+            workspace_locator={"kind": "sandbox", "workspaceId": workspace_id},
+            current_workflow_id="workflow-1",
+            current_step_execution_id="step-1",
+            repository_source=str(source),
+            starting_branch="main",
+            restore_input_refs=("/etc/passwd",),
+            artifact_gateway=service,
+        )
+
+    # A restore input that is a local path must never be conflated with an
+    # artifact ref.
+    assert exc.value.code == "WORKSPACE_LOCATOR_UNSUPPORTED"
+
+
+def _execution_request(**overrides) -> AgentExecutionRequest:
+    payload = dict(
+        agentKind="external",
+        agentId="omnigent",
+        executionProfileRef="profile:test",
+        correlationId="corr-3507",
+        idempotencyKey="idem-3507",
+        parameters={"repository": "org/repo"},
+    )
+    payload.update(overrides)
+    return AgentExecutionRequest(**payload)
+
+
+def test_coordinator_reads_repository_and_branch_intent_from_workspace_spec() -> None:
+    request = _execution_request(
+        workspaceSpec={
+            "repository": "org/repo",
+            "startingBranch": "release",
+            "targetBranch": "agent/work",
+            "baseCommit": "abc123",
+            "restoreInputRefs": ["artifact://a", "artifact://a", "artifact://b"],
+        }
+    )
+
+    assert OmnigentProfileBoundExecutionCoordinator._repository_source(request) == (
+        "org/repo"
+    )
+    assert OmnigentProfileBoundExecutionCoordinator._starting_branch(request) == (
+        "release"
+    )
+    assert OmnigentProfileBoundExecutionCoordinator._target_branch(request) == (
+        "agent/work"
+    )
+    assert OmnigentProfileBoundExecutionCoordinator._checkout_commit(request) == (
+        "abc123"
+    )
+    # De-duplicated, order-preserving durable refs only.
+    assert OmnigentProfileBoundExecutionCoordinator._restore_input_refs(request) == (
+        ("artifact://a", "artifact://b")
+    )
+
+
+def test_coordinator_repository_intent_defaults_are_empty() -> None:
+    request = _execution_request(parameters={})
+
+    assert OmnigentProfileBoundExecutionCoordinator._repository_source(request) == ""
+    assert OmnigentProfileBoundExecutionCoordinator._starting_branch(request) is None
+    assert OmnigentProfileBoundExecutionCoordinator._target_branch(request) is None
+    assert OmnigentProfileBoundExecutionCoordinator._checkout_commit(request) is None
+    assert OmnigentProfileBoundExecutionCoordinator._restore_input_refs(request) == ()


### PR DESCRIPTION
Implements MoonLadderStudios/MoonMind#3507 — [Omnigent P0] Complete normal-workflow workspace materialization and shared host lifecycle.

Issue: https://github.com/MoonLadderStudios/MoonMind/issues/3507

Closes MoonLadderStudios/MoonMind#3507

## Summary

Routes every `WorkspaceLocator` kind through the single owning-worker boundary in `OmnigentOAuthHostRuntime._prepare_workspace`, so work submitted through the normal MoonMind Workflow interface executes in the exact repository/workspace state the operator authored.

- **Repository/branch materialization (AC1/AC5/AC9):** the sandbox path git-clones and checks out the authored starting/target branch (and optional commit) into the single authoritative sandbox workspace via the shared bounded/redacted/cancellation-aware command runner (`run_runtime_command` through `self._run`). Authored output/target branch is selected with `checkout -B` without discarding the checked-out working tree.
- **Pre-mutation authority checks (AC4):** identity, root-containment, traversal, and symlink validation plus durable owner-record checks run before any host mutation (`resolve_sandbox_workspace_locator` + owner-record load).
- **Checkpoint/external-state boundary (AC2):** restore inputs are materialized as `artifact://` refs into bounded `.moonmind/restore`, never conflated with local paths; a ref that looks like a local path is rejected. Managed-runtime and external-state locators fail closed with `WORKSPACE_LOCATOR_UNSUPPORTED`.
- **Static/on-demand parity (AC5):** the single resolved workspace feeds both the on-demand Docker and static Compose host paths (equal daemon-visible bind + mount classes); mode mismatch fails closed.
- **Retry safety (AC7):** materialization is idempotent — an already-materialized workspace is reused (`reused_pre_materialized`) with no git run and the working tree preserved; foreign/cross-run owner records and identities are rejected before mutation.
- **Durable evidence (AC6):** bounded, credential-free `workspaceResolution` evidence is surfaced in preflight and recorded as a durable lifecycle event; the resolved worker path is kept out of the evidence JSON.
- **Credential injection (AC3/AC9):** the GitHub token is resolved worker-side and injected only via the in-memory git credential helper, gated on declared capability/publish intent — never in argv, on disk, or in Temporal/browser payloads.
- The coordinator (`profile_bound_execution.py`) threads authored repository/branch/restore intent from the normal Create/edit/rerun/schedule `workspaceSpec` into `prepare_host` and skips re-materialization for already-authorized remediation workspaces.
- Predecessor cleanup/janitor/Provider-Profile release-last substrate (AC8) remains intact and passing.

## Files changed

- `moonmind/omnigent/oauth_host_runtime.py` — `_prepare_workspace`, new `_materialize_repository` / `_materialize_restore_inputs`
- `moonmind/omnigent/profile_bound_execution.py` — intent threading + workspace-resolution lifecycle evidence
- `tests/unit/omnigent/test_oauth_profile_lifecycle.py` — new #3507 unit coverage
- `tests/integration/reliability_journey/test_omnigent_workspace_materialization_journey.py` — controlling hermetic journey (AC10)

## Tests run

- **Unit:** `pytest tests/unit/omnigent/test_oauth_profile_lifecycle.py` — 99 passed (incl. 9 new #3507 tests: repository+branch materialization, idempotent retry preserving working tree, authored output branch, external_state/managed fail-closed, restore-input ref materialization, local-path restore rejection, coordinator intent threading + defaults; plus pre-mutation identity/containment/tampered-owner-record rejection and release-last/janitor cleanup).
- **Integration (integration_ci, hermetic):** `pytest tests/integration/reliability_journey/test_omnigent_workspace_materialization_journey.py` — 2 passed (AC10 controlling journey: fresh materialization → owner-record evidence → idempotent retry preserving in-flight work → cross-execution rejection; non-sandbox locators fail closed; no Docker/network).
- **Adjacent regression:** `pytest tests/unit/workflows/temporal/runtime/strategies/test_remaining_strategies.py` — 60 passed.

## Remaining risks

- Full convergence of the raw `docker` / `docker compose` lifecycle in `oauth_host_runtime.py` onto shared runtime primitives (AC6 convergence), complete output/resource-manifest + partial-start reconciliation, and end-to-end publication/PR/terminal-checkpoint semantics through Omnigent (AC9 publish side) are larger cross-cutting follow-ups tracked separately; this change completes the workspace-materialization core.
- `moonmind container python-tests` was unavailable in the verification runtime (`MOONMIND_AGENT_RUN_ID` unset); tests were run hermetically with the checkout's `python -m pytest`. Non-gating.
- `docs/MoonMindRoadmap.md` still lists #3507 with unchecked boxes (status-checklist doc drift, non-gating); recommend updating on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
