### PR TITLE
GitHub Issue Implement: MoonLadderStudios/MoonMind#3514 — Omnigent scoped in-session retrieval authoring controls and diagnostics

### DIFF
--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -10455,6 +10455,13 @@ async def _create_execution_from_workflow_request(
     }
     if isinstance(payload.get("omnigent"), Mapping):
         initial_parameters["omnigent"] = dict(payload["omnigent"])
+    # Context retrieval (RAG) authoring: initial ContextPack overrides (#3513)
+    # and in-session follow-up retrieval policy (#3514). Lifted here next to the
+    # omnigent block so the authored values reach the run's initial parameters.
+    if isinstance(payload.get("rag"), Mapping):
+        initial_parameters["rag"] = dict(payload["rag"])
+    if isinstance(payload.get("followUpRetrieval"), Mapping):
+        initial_parameters["followUpRetrieval"] = dict(payload["followUpRetrieval"])
     if "modelTier" in runtime_payload:
         initial_parameters["modelTier"] = runtime_payload.get("modelTier")
     if "tierFallback" in runtime_payload:

--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -986,7 +986,11 @@ async def _prepare_checkpoint_branch_launch(
     source_run_id: str | None = None,
     source_execution_ordinal: int | None = None,
     source_checkpoint_boundary: str = "after_execution",
+    follow_up_retrieval: Mapping[str, Any] | None = None,
 ) -> None:
+    bounded_follow_up_retrieval = _bound_branch_follow_up_retrieval(
+        follow_up_retrieval
+    )
     git_context = _checkpoint_branch_git_context(record)
     try:
         await prepare_checkpoint_branch_workspace(
@@ -1020,12 +1024,52 @@ async def _prepare_checkpoint_branch_launch(
             parent_branch_id=parent_branch_id,
             parent_turn_id=parent_turn_id,
             runtime_context_policy=runtime_context_policy,
+            follow_up_retrieval=bounded_follow_up_retrieval,
         )
     except CheckpointBranchGitBindingError as exc:
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
             detail={"code": exc.failure_code, "reason": exc.failure_code},
         ) from exc
+
+
+def _bound_branch_follow_up_retrieval(
+    authored: Mapping[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Narrow a branch-turn override to deployment-owned retrieval ceilings."""
+
+    if authored is None:
+        return None
+    bounded = dict(authored)
+    allowed = tuple(
+        item.strip()
+        for item in os.getenv(
+            "MOONMIND_FOLLOWUP_RETRIEVAL_COLLECTIONS", "repo,docs"
+        ).split(",")
+        if item.strip()
+    )
+    requested = list(dict.fromkeys(bounded.get("collections") or []))
+    if not all(isinstance(item, str) and item in allowed for item in requested):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail={"code": "retrieval_collections_exceed_server_policy"},
+        )
+    bounded["collections"] = requested
+    ceilings = {
+        "topK": ("MAX_TOP_K", 8),
+        "maxContextTokens": ("MAX_CONTEXT_TOKENS", 8192),
+        "maxQueries": ("MAX_QUERIES", 12),
+        "latencyMs": ("MAX_LATENCY_MS", 5000),
+        "maxLifetimeSeconds": ("MAX_LIFETIME_SECONDS", 900),
+    }
+    for field, (env_suffix, default) in ceilings.items():
+        value = bounded.get(field)
+        if isinstance(value, int) and not isinstance(value, bool):
+            bounded[field] = min(
+                value,
+                int(os.getenv(f"MOONMIND_FOLLOWUP_RETRIEVAL_{env_suffix}", default)),
+            )
+    return bounded
 
 
 def _branch_comparison_record(
@@ -1365,6 +1409,7 @@ def _branch_turn_launch_manifest_payload(
     payload: CheckpointBranchTurnLaunchRequest,
     context_bundle_ref: str,
 ) -> dict[str, Any]:
+    follow_up_retrieval = (turn.diagnostics or {}).get("followUpRetrieval")
     return {
         "workflowId": workflow_id,
         "runId": branch.source_run_id,
@@ -1388,6 +1433,11 @@ def _branch_turn_launch_manifest_payload(
             "instructionRef": turn.instruction_ref,
             "instructionDigest": turn.instruction_digest,
             "contextBundleRef": context_bundle_ref,
+            **(
+                {"followUpRetrieval": dict(follow_up_retrieval)}
+                if isinstance(follow_up_retrieval, Mapping)
+                else {}
+            ),
         },
     }
 
@@ -13178,6 +13228,7 @@ async def create_checkpoint_branch(
         source_run_id=payload.source.run_id,
         source_execution_ordinal=payload.source.execution_ordinal,
         source_checkpoint_boundary=payload.source.checkpoint_boundary,
+        follow_up_retrieval=payload.follow_up_retrieval,
     )
     branch = await session.get(WorkflowCheckpointBranch, branch_id)
     if branch is None:
@@ -13353,6 +13404,9 @@ async def launch_checkpoint_branch_turn(
             "digest": "sha256:checkpoint-branch-launch-api-v1",
         },
     }
+    follow_up_retrieval = (turn.diagnostics or {}).get("followUpRetrieval")
+    if isinstance(follow_up_retrieval, Mapping):
+        context_payload["followUpRetrieval"] = dict(follow_up_retrieval)
     try:
         context_bundle = build_checkpoint_branch_turn_context_bundle(context_payload)
     except CheckpointBranchContextBundleError as exc:
@@ -13516,6 +13570,7 @@ async def _record_branch_turn_operation(
         source_run_id=branch.source_run_id,
         source_execution_ordinal=branch.source_execution_ordinal,
         source_checkpoint_boundary=branch.source_checkpoint_boundary,
+        follow_up_retrieval=payload.follow_up_retrieval,
     )
     turn = await session.get(WorkflowCheckpointBranchTurn, branch_turn_id)
     if turn is None:
@@ -13677,6 +13732,7 @@ async def fork_checkpoint_branch(
         source_run_id=parent.source_run_id,
         source_execution_ordinal=parent.source_execution_ordinal,
         source_checkpoint_boundary=parent.source_checkpoint_boundary,
+        follow_up_retrieval=payload.follow_up_retrieval,
     )
     forked = await session.get(WorkflowCheckpointBranch, forked_branch_id)
     if forked is None:

--- a/api_service/api/routers/retrieval_gateway.py
+++ b/api_service/api/routers/retrieval_gateway.py
@@ -932,6 +932,26 @@ async def retrieval_capability_diagnostics(
     return registry.status(capability_id)
 
 
+@router.get("/bridge-sessions/{bridge_session_id}/follow-up-retrieval")
+async def bridge_follow_up_retrieval_diagnostics(
+    bridge_session_id: str,
+    registry: RetrievalCapabilityRegistry = Depends(get_capability_registry),
+    store: OmnigentBridgeSessionStore = Depends(get_bridge_session_store),
+    user: User = Depends(get_current_user()),
+    service: Any = Depends(_get_execution_service),
+) -> Dict[str, object]:
+    """Operator diagnostics for a bridge session's follow-up retrieval activity.
+
+    Returns bounded, secret-free per-capability lifecycle, per-request evidence
+    summaries, and aggregate telemetry for Workflow Detail — never capability
+    tokens or ContextPack bodies. Requires ownership of the bridge's workflow.
+    """
+    await _authorized_bridge_row(
+        bridge_session_id, store=store, user=user, service=service
+    )
+    return registry.summarize_bridge_session(bridge_session_id)
+
+
 @router.get("/capabilities/{capability_id}/results/{tool_call_id}")
 def read_retrieval_result(
     capability_id: str,

--- a/api_service/api/routers/workflow_console_view_model.py
+++ b/api_service/api/routers/workflow_console_view_model.py
@@ -683,6 +683,13 @@ def build_runtime_config(
         if jira_runtime_config
         else {}
     )
+    retrieval_collections = [
+        item.strip()
+        for item in os.environ.get(
+            "MOONMIND_FOLLOWUP_RETRIEVAL_COLLECTIONS", "repo,docs"
+        ).split(",")
+        if item.strip()
+    ]
 
     return {
         "initialPath": initial_path,
@@ -766,6 +773,14 @@ def build_runtime_config(
             "defaultModelByRuntime": default_model_by_runtime,
             "defaultEffortByRuntime": default_effort_by_runtime,
             "defaultPublishMode": default_publish_mode,
+            "retrievalAuthoring": {
+                "collections": retrieval_collections,
+                "topK": int(os.environ.get("MOONMIND_FOLLOWUP_RETRIEVAL_MAX_TOP_K", "8")),
+                "maxContextTokens": int(os.environ.get("MOONMIND_FOLLOWUP_RETRIEVAL_MAX_CONTEXT_TOKENS", "8192")),
+                "maxQueries": int(os.environ.get("MOONMIND_FOLLOWUP_RETRIEVAL_MAX_QUERIES", "12")),
+                "latencyMs": int(os.environ.get("MOONMIND_FOLLOWUP_RETRIEVAL_MAX_LATENCY_MS", "5000")),
+                "maxLifetimeSeconds": int(os.environ.get("MOONMIND_FOLLOWUP_RETRIEVAL_MAX_LIFETIME_SECONDS", "900")),
+            },
             # Keep workflow proposals opt-in from the submit form so Temporal
             # remains the default execution substrate for new runs.
             "defaultProposeWorkflows": False,

--- a/api_service/retrieval_capabilities.py
+++ b/api_service/retrieval_capabilities.py
@@ -582,21 +582,150 @@ class RetrievalCapabilityRegistry:
                          AND lease_expires_at > ?""",
                     (capability_id, now),
                 ).fetchone()["active"]
+            budget = capability.budget
             return {
                 "capabilityId": capability.capability_id,
                 "state": state,
                 "expiresAt": capability.expires_at,
                 "revokedAt": capability.revoked_at,
                 "queryCount": capability.query_count,
-                "maxQueries": capability.budget.max_queries,
+                "maxQueries": budget.max_queries,
                 "activeRequests": active_requests,
-                "maxConcurrency": capability.budget.max_concurrency,
+                "maxConcurrency": budget.max_concurrency,
                 "requestsInCurrentMinute": (
                     rate_row["request_count"] if rate_row is not None else 0
                 ),
-                "maxRequestsPerMinute": capability.budget.max_requests_per_minute,
+                "maxRequestsPerMinute": budget.max_requests_per_minute,
+                "collections": list(budget.collections),
+                "policyVersion": budget.policy_version,
+                "overlayPolicy": budget.overlay_policy,
+                "fallbackAllowed": budget.fallback_allowed,
+                "scope": {
+                    "tenant": budget.tenant_id,
+                    "repository": budget.repository,
+                    "run": budget.run_id,
+                    "workspace": budget.workspace_id,
+                    "step": budget.step_id,
+                },
                 "requests": self._evidence_summaries(capability_id),
             }
+
+    def summarize_bridge_session(self, bridge_session_id: str) -> dict[str, Any]:
+        """Aggregate follow-up retrieval evidence for one bridge session.
+
+        This is the operator-facing diagnostics projection: per-capability
+        lifecycle (active / expired / revoked, budget usage) plus bounded,
+        secret-free aggregate telemetry derived from durable evidence. It never
+        exposes capability tokens; only digests and states already recorded as
+        evidence are surfaced.
+        """
+        bridge_session_id = str(bridge_session_id or "").strip()
+        with self._lock:
+            with self._connect() as connection:
+                rows = connection.execute(
+                    "SELECT capability_id, budget_json FROM retrieval_capabilities"
+                ).fetchall()
+            capability_ids = []
+            for row in rows:
+                try:
+                    budget = json.loads(row["budget_json"])
+                except (TypeError, ValueError):
+                    continue
+                if str(budget.get("bridge_session_id") or "") == bridge_session_id:
+                    capability_ids.append(row["capability_id"])
+
+            capabilities = [self.status(capability_id) for capability_id in capability_ids]
+
+        aggregate = {
+            "requestCount": 0,
+            "succeeded": 0,
+            "failed": 0,
+            "denied": 0,
+            "empty": 0,
+            "truncated": 0,
+            "fallback": 0,
+            "budgetExhausted": 0,
+            "delivered": 0,
+            "notDelivered": 0,
+            "deliveryUnknown": 0,
+            "cancelled": 0,
+            "timedOut": 0,
+            "totalContextBytes": 0,
+            "maxLatencyMs": 0,
+            "activeCapabilities": 0,
+            "expiredCapabilities": 0,
+            "revokedCapabilities": 0,
+        }
+        budget_exhausted_classes = {
+            "budget_exhausted",
+            "byte_budget_exhausted",
+            "concurrency_exceeded",
+            "rate_exceeded",
+            "source_budget_exhausted",
+            "token_budget_exhausted",
+            "tokens_budget_exhausted",
+        }
+        timeout_classes = {
+            "latency_budget_exhausted",
+            "stage_deadline_exhausted",
+            "latency_ms_budget_exhausted",
+        }
+        for capability in capabilities:
+            state = capability.get("state")
+            if state == "active":
+                aggregate["activeCapabilities"] += 1
+            elif state == "expired":
+                aggregate["expiredCapabilities"] += 1
+            elif state == "revoked":
+                aggregate["revokedCapabilities"] += 1
+            for request in capability.get("requests", []):
+                aggregate["requestCount"] += 1
+                request_state = request.get("state")
+                classification = request.get("classification")
+                result_count = int(request.get("resultCount") or 0)
+                if request_state == "succeeded":
+                    aggregate["succeeded"] += 1
+                    if result_count == 0:
+                        aggregate["empty"] += 1
+                elif request_state == "denied":
+                    aggregate["denied"] += 1
+                elif request_state == "failed":
+                    aggregate["failed"] += 1
+                if request.get("truncated"):
+                    aggregate["truncated"] += 1
+                if classification == "local_fallback" or request.get("fallback"):
+                    aggregate["fallback"] += 1
+                if classification in budget_exhausted_classes:
+                    aggregate["budgetExhausted"] += 1
+                if classification in timeout_classes:
+                    aggregate["timedOut"] += 1
+                aggregate["totalContextBytes"] += int(request.get("contextBytes") or 0)
+                latency = request.get("latencyMs")
+                if isinstance(latency, (int, float)):
+                    aggregate["maxLatencyMs"] = max(
+                        aggregate["maxLatencyMs"], int(latency)
+                    )
+                delivery = request.get("delivery")
+                delivery_state = (
+                    delivery.get("state") if isinstance(delivery, dict) else None
+                )
+                if delivery_state == "delivered":
+                    aggregate["delivered"] += 1
+                elif delivery_state == "not_delivered":
+                    aggregate["notDelivered"] += 1
+                elif delivery_state == "delivery_unknown":
+                    aggregate["deliveryUnknown"] += 1
+                elif delivery_state == "cancelled":
+                    aggregate["cancelled"] += 1
+                elif delivery_state == "timed_out":
+                    aggregate["timedOut"] += 1
+
+        return {
+            "bridgeSessionId": bridge_session_id,
+            "capabilityCount": len(capabilities),
+            "capabilities": capabilities,
+            "aggregate": aggregate,
+        }
 
     def _evidence_summaries(self, capability_id: str) -> list[dict[str, Any]]:
         with self._connect() as connection:
@@ -629,6 +758,8 @@ class RetrievalCapabilityRegistry:
                 "latencyMs": evidence.get("latencyMs"),
                 "delivery": evidence.get("delivery"),
                 "classification": evidence.get("classification"),
+                "truncated": bool(evidence.get("truncated", False)),
+                "contextPackRef": evidence.get("contextPackRef"),
             }
             self._evidence.setdefault(capability.capability_id, []).append(summary)
             with self._connect() as connection:

--- a/api_service/retrieval_capabilities.py
+++ b/api_service/retrieval_capabilities.py
@@ -610,6 +610,53 @@ class RetrievalCapabilityRegistry:
                 "requests": self._evidence_summaries(capability_id),
             }
 
+    @staticmethod
+    def _delivery_correlation_key(summary: dict[str, Any]) -> str | None:
+        """Return the ``toolCallId`` that ties a delivery update to its request."""
+        delivery = summary.get("delivery")
+        if isinstance(delivery, dict) and delivery.get("toolCallId"):
+            return str(delivery["toolCallId"])
+        correlation = summary.get("correlation")
+        if isinstance(correlation, dict):
+            for key in ("tool_call_id", "toolCallId"):
+                if correlation.get(key):
+                    return str(correlation[key])
+        return None
+
+    @classmethod
+    def _merge_delivery_evidence(
+        cls, requests: list[dict[str, Any]]
+    ) -> list[dict[str, Any]]:
+        """Fold ``delivery_updated`` acknowledgements into their original request.
+
+        A successful retrieval records one evidence row (with a provisional
+        ``delivery_unknown`` state); the bridge's later delivery acknowledgement
+        records a second ``delivery_updated`` row for the same ``toolCallId``.
+        These are two evidence rows for a single logical request, so aggregating
+        them independently would inflate ``requestCount``, double-count the
+        request as both ``delivery_unknown`` and its final delivery outcome, and
+        surface a spurious zero-result request. Project the authoritative delivery
+        update onto the original request and drop the standalone acknowledgement.
+        """
+        merged: list[dict[str, Any]] = []
+        by_key: dict[str, dict[str, Any]] = {}
+        for request in requests:
+            key = cls._delivery_correlation_key(request)
+            if request.get("state") == "delivery_updated":
+                base = by_key.get(key) if key is not None else None
+                if base is not None:
+                    if isinstance(request.get("delivery"), dict):
+                        base["delivery"] = request["delivery"]
+                    continue
+                # Orphan acknowledgement with no retained base request: keep it
+                # once so the delivery outcome is not silently dropped.
+                merged.append(request)
+                continue
+            merged.append(request)
+            if key is not None:
+                by_key[key] = request
+        return merged
+
     def summarize_bridge_session(self, bridge_session_id: str) -> dict[str, Any]:
         """Aggregate follow-up retrieval evidence for one bridge session.
 
@@ -678,7 +725,9 @@ class RetrievalCapabilityRegistry:
                 aggregate["expiredCapabilities"] += 1
             elif state == "revoked":
                 aggregate["revokedCapabilities"] += 1
-            for request in capability.get("requests", []):
+            for request in self._merge_delivery_evidence(
+                capability.get("requests", [])
+            ):
                 aggregate["requestCount"] += 1
                 request_state = request.get("state")
                 classification = request.get("classification")

--- a/api_service/services/checkpoint_branches.py
+++ b/api_service/services/checkpoint_branches.py
@@ -66,6 +66,7 @@ async def prepare_checkpoint_branch_workspace(
     parent_branch_id: str | None = None,
     parent_turn_id: str | None = None,
     runtime_context_policy: str | None = None,
+    follow_up_retrieval: Mapping[str, Any] | None = None,
     step_execution_manifest_ref: str | None = None,
     created_step_execution_id: str | None = None,
     created_at: datetime | None = None,
@@ -117,6 +118,7 @@ async def prepare_checkpoint_branch_workspace(
         parent_branch_id=parent_branch_id,
         parent_turn_id=parent_turn_id,
         runtime_context_policy=runtime_context_policy,
+        follow_up_retrieval=follow_up_retrieval,
         step_execution_manifest_ref=step_execution_manifest_ref,
         created_step_execution_id=created_step_execution_id,
     )
@@ -180,6 +182,7 @@ async def _persist_prepared_checkpoint_branch(
     parent_branch_id: str | None,
     parent_turn_id: str | None,
     runtime_context_policy: str | None,
+    follow_up_retrieval: Mapping[str, Any] | None,
     step_execution_manifest_ref: str | None,
     created_step_execution_id: str | None,
 ) -> None:
@@ -291,6 +294,7 @@ async def _persist_prepared_checkpoint_branch(
             parent_turn_id=parent_turn_id,
             step_execution_manifest_ref=step_execution_manifest_ref,
             created_step_execution_id=created_step_execution_id,
+            follow_up_retrieval=follow_up_retrieval,
         )
 
     await _upsert_artifact_ref(
@@ -325,12 +329,15 @@ async def _persist_branch_turn(
     parent_turn_id: str | None,
     step_execution_manifest_ref: str | None,
     created_step_execution_id: str | None,
+    follow_up_retrieval: Mapping[str, Any] | None,
 ) -> None:
     binding = prepared.binding
     assert binding.branch_turn_id is not None
     turn = await session.get(WorkflowCheckpointBranchTurn, binding.branch_turn_id)
     diagnostics = dict(prepared.branch_turn_metadata or {})
     diagnostics["gitBinding"] = prepared.diagnostics["gitBinding"]
+    if follow_up_retrieval is not None:
+        diagnostics["followUpRetrieval"] = dict(follow_up_retrieval)
     if turn is None:
         turn = WorkflowCheckpointBranchTurn(
             branch_turn_id=binding.branch_turn_id,

--- a/frontend/src/components/ContextRetrievalControls.test.tsx
+++ b/frontend/src/components/ContextRetrievalControls.test.tsx
@@ -1,0 +1,62 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { ContextRetrievalControls } from './ContextRetrievalControls';
+import {
+  ContextRetrievalAuthoring,
+  defaultContextRetrievalAuthoring,
+} from '../lib/contextRetrievalAuthoring';
+
+function renderControls(overrides?: Partial<ContextRetrievalAuthoring>) {
+  let value: ContextRetrievalAuthoring = {
+    ...defaultContextRetrievalAuthoring(),
+    ...overrides,
+  };
+  const onChange = vi.fn((next: ContextRetrievalAuthoring) => {
+    value = next;
+  });
+  const utils = render(
+    <ContextRetrievalControls value={value} onChange={onChange} />,
+  );
+  return { ...utils, onChange, getValue: () => value };
+}
+
+describe('ContextRetrievalControls', () => {
+  it('renders policy ceilings so the operator sees the boundary', () => {
+    renderControls();
+    expect(
+      screen.getByText(/Policy ceilings/i).textContent,
+    ).toContain('top_k ≤ 50');
+  });
+
+  it('enables follow-up retrieval through the toggle', () => {
+    const { onChange } = renderControls();
+    fireEvent.click(
+      screen.getByLabelText(/request additional context during the run/i),
+    );
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        followUp: expect.objectContaining({ enabled: true }),
+      }),
+    );
+  });
+
+  it('warns when follow-up retrieval is enabled without collections', () => {
+    const value = defaultContextRetrievalAuthoring();
+    value.followUp.enabled = true;
+    render(<ContextRetrievalControls value={value} onChange={vi.fn()} />);
+    expect(screen.getByText(/no collections are selected/i)).toBeTruthy();
+  });
+
+  it('hides initial-injection controls when showInitialControls is false', () => {
+    render(
+      <ContextRetrievalControls
+        value={defaultContextRetrievalAuthoring()}
+        onChange={vi.fn()}
+        showInitialControls={false}
+      />,
+    );
+    expect(screen.queryByText(/Initial context injection/i)).toBeNull();
+    expect(screen.getByText(/In-session follow-up retrieval/i)).toBeTruthy();
+  });
+});

--- a/frontend/src/components/ContextRetrievalControls.tsx
+++ b/frontend/src/components/ContextRetrievalControls.tsx
@@ -1,0 +1,361 @@
+import { JSX, useId } from 'react';
+
+import {
+  ContextRetrievalAuthoring,
+  DEFAULT_RETRIEVAL_CEILINGS,
+  FollowUpRetrievalAuthoring,
+  RetrievalBudgetPreset,
+  RetrievalCeilings,
+  applyBudgetPreset,
+  explainRetrievalDenials,
+} from '../lib/contextRetrievalAuthoring';
+
+interface ContextRetrievalControlsProps {
+  value: ContextRetrievalAuthoring;
+  onChange: (next: ContextRetrievalAuthoring) => void;
+  ceilings?: RetrievalCeilings;
+  /** Optional heading/context copy tailored to the hosting surface. */
+  description?: string;
+  disabled?: boolean;
+  /**
+   * When false, hide the automatic initial-injection collection controls
+   * (surfaces that only govern follow-up retrieval, e.g. a branch turn).
+   */
+  showInitialControls?: boolean;
+  idPrefix?: string;
+}
+
+const BUDGET_PRESET_OPTIONS: Array<{ value: RetrievalBudgetPreset; label: string }> = [
+  { value: 'conservative', label: 'Conservative' },
+  { value: 'balanced', label: 'Balanced' },
+  { value: 'generous', label: 'Generous' },
+  { value: 'custom', label: 'Custom' },
+];
+
+/**
+ * Coherent, policy-bounded RAG authoring controls shared by every MoonMind
+ * authoring surface (GitHub issue MoonLadderStudios/MoonMind#3514, item 6).
+ *
+ * The controls only NARROW within the policy ceilings; the visible ceilings and
+ * denial notices make that boundary explicit rather than failing silently.
+ */
+export function ContextRetrievalControls({
+  value,
+  onChange,
+  ceilings = DEFAULT_RETRIEVAL_CEILINGS,
+  description,
+  disabled = false,
+  showInitialControls = true,
+  idPrefix,
+}: ContextRetrievalControlsProps): JSX.Element {
+  const generatedId = useId();
+  const prefix = idPrefix ?? generatedId;
+  const denials = explainRetrievalDenials(value, ceilings);
+  const followUp = value.followUp;
+
+  const setFollowUp = (patch: Partial<FollowUpRetrievalAuthoring>): void => {
+    onChange({ ...value, followUp: { ...followUp, ...patch } });
+  };
+
+  const toggleCollection = (
+    scope: 'initial' | 'followUp',
+    collection: string,
+  ): void => {
+    if (scope === 'initial') {
+      const has = value.initial.collections.includes(collection);
+      const collections = has
+        ? value.initial.collections.filter((item) => item !== collection)
+        : [...value.initial.collections, collection];
+      onChange({ ...value, initial: { ...value.initial, collections } });
+      return;
+    }
+    const has = followUp.collections.includes(collection);
+    const collections = has
+      ? followUp.collections.filter((item) => item !== collection)
+      : [...followUp.collections, collection];
+    setFollowUp({ collections });
+  };
+
+  const onPresetChange = (preset: RetrievalBudgetPreset): void => {
+    onChange({ ...value, followUp: applyBudgetPreset(followUp, preset) });
+  };
+
+  const onCustomNumber = (
+    field: 'topK' | 'maxContextTokens' | 'maxQueries' | 'latencyMs' | 'maxLifetimeSeconds',
+    raw: string,
+  ): void => {
+    const parsed = Number(raw);
+    setFollowUp({
+      budgetPreset: 'custom',
+      [field]: Number.isFinite(parsed) ? parsed : followUp[field],
+    } as Partial<FollowUpRetrievalAuthoring>);
+  };
+
+  const budgetsDisabled = disabled || !followUp.enabled;
+
+  return (
+    <div className="context-retrieval-controls stack" data-testid="context-retrieval-controls">
+      {description ? <p className="small">{description}</p> : null}
+
+      {showInitialControls ? (
+        <fieldset className="context-retrieval-section" disabled={disabled}>
+          <legend>Initial context injection</legend>
+          <p className="small">
+            The initial ContextPack is injected automatically. Choose which
+            collections it may draw from and whether a stale overlay is allowed.
+          </p>
+          <CollectionChips
+            name={`${prefix}-initial-collections`}
+            allowed={ceilings.collections}
+            selected={value.initial.collections}
+            onToggle={(collection) => toggleCollection('initial', collection)}
+            disabled={disabled}
+          />
+          <label className="checkbox">
+            <input
+              type="checkbox"
+              checked={value.initial.allowStale}
+              disabled={disabled}
+              onChange={(event) =>
+                onChange({
+                  ...value,
+                  initial: { ...value.initial, allowStale: event.target.checked },
+                })
+              }
+            />
+            Allow a stale overlay for initial injection
+          </label>
+          <label className="checkbox">
+            <input
+              type="checkbox"
+              checked={value.initial.required}
+              disabled={disabled}
+              onChange={(event) =>
+                onChange({
+                  ...value,
+                  initial: { ...value.initial, required: event.target.checked },
+                })
+              }
+            />
+            Require initial context (fail the step if unavailable)
+          </label>
+        </fieldset>
+      ) : null}
+
+      <fieldset className="context-retrieval-section" disabled={disabled}>
+        <legend>In-session follow-up retrieval</legend>
+        <label className="checkbox">
+          <input
+            type="checkbox"
+            checked={followUp.enabled}
+            disabled={disabled}
+            onChange={(event) => setFollowUp({ enabled: event.target.checked })}
+          />
+          Allow the session to request additional context during the run
+        </label>
+        <label className="checkbox">
+          <input
+            type="checkbox"
+            checked={followUp.required}
+            disabled={budgetsDisabled}
+            onChange={(event) => setFollowUp({ required: event.target.checked })}
+          />
+          Follow-up retrieval is required (not optional)
+        </label>
+
+        <div className="context-retrieval-field">
+          <span className="context-retrieval-label">Collections the session may query</span>
+          <CollectionChips
+            name={`${prefix}-followup-collections`}
+            allowed={ceilings.collections}
+            selected={followUp.collections}
+            onToggle={(collection) => toggleCollection('followUp', collection)}
+            disabled={budgetsDisabled}
+          />
+        </div>
+
+        <label className="context-retrieval-field">
+          <span className="context-retrieval-label">Budget preset</span>
+          <select
+            value={followUp.budgetPreset}
+            disabled={budgetsDisabled}
+            onChange={(event) => onPresetChange(event.target.value as RetrievalBudgetPreset)}
+          >
+            {BUDGET_PRESET_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <div className="grid-2">
+          <NumberField
+            label="top_k"
+            value={followUp.topK}
+            ceilingMax={ceilings.topK.max}
+            min={ceilings.topK.min}
+            disabled={budgetsDisabled}
+            onChange={(raw) => onCustomNumber('topK', raw)}
+          />
+          <NumberField
+            label="Max context tokens"
+            value={followUp.maxContextTokens}
+            ceilingMax={ceilings.maxContextTokens.max}
+            min={ceilings.maxContextTokens.min}
+            disabled={budgetsDisabled}
+            onChange={(raw) => onCustomNumber('maxContextTokens', raw)}
+          />
+          <NumberField
+            label="Max queries per run"
+            value={followUp.maxQueries}
+            ceilingMax={ceilings.maxQueries.max}
+            min={ceilings.maxQueries.min}
+            disabled={budgetsDisabled}
+            onChange={(raw) => onCustomNumber('maxQueries', raw)}
+          />
+          <NumberField
+            label="Latency budget (ms)"
+            value={followUp.latencyMs}
+            ceilingMax={ceilings.latencyMs.max}
+            min={ceilings.latencyMs.min}
+            disabled={budgetsDisabled}
+            onChange={(raw) => onCustomNumber('latencyMs', raw)}
+          />
+          <NumberField
+            label="Capability lifetime (s)"
+            value={followUp.maxLifetimeSeconds}
+            ceilingMax={ceilings.maxLifetimeSeconds.max}
+            min={ceilings.maxLifetimeSeconds.min}
+            disabled={budgetsDisabled}
+            onChange={(raw) => onCustomNumber('maxLifetimeSeconds', raw)}
+          />
+        </div>
+
+        <label className="context-retrieval-field">
+          <span className="context-retrieval-label">Overlay policy</span>
+          <select
+            value={followUp.overlayPolicy}
+            disabled={budgetsDisabled}
+            onChange={(event) =>
+              setFollowUp({ overlayPolicy: event.target.value === 'skip' ? 'skip' : 'include' })
+            }
+          >
+            <option value="include">Include workspace overlay</option>
+            <option value="skip">Skip overlay (indexed content only)</option>
+          </select>
+        </label>
+
+        <label className="checkbox">
+          <input
+            type="checkbox"
+            checked={followUp.staleOverlayAllowed}
+            disabled={budgetsDisabled || !ceilings.allowStaleOverlay}
+            onChange={(event) => setFollowUp({ staleOverlayAllowed: event.target.checked })}
+          />
+          Allow a stale overlay
+          {!ceilings.allowStaleOverlay ? ' (blocked by policy)' : ''}
+        </label>
+        <label className="checkbox">
+          <input
+            type="checkbox"
+            checked={followUp.fallbackAllowed}
+            disabled={budgetsDisabled || !ceilings.allowFallback}
+            onChange={(event) => setFollowUp({ fallbackAllowed: event.target.checked })}
+          />
+          Allow local-search fallback
+          {!ceilings.allowFallback ? ' (blocked by policy)' : ''}
+        </label>
+      </fieldset>
+
+      <p className="small context-retrieval-ceilings">
+        Policy ceilings — collections: {ceilings.collections.join(', ') || 'none'}; top_k ≤{' '}
+        {ceilings.topK.max}; context tokens ≤ {ceilings.maxContextTokens.max}; queries ≤{' '}
+        {ceilings.maxQueries.max}; latency ≤ {ceilings.latencyMs.max}ms; lifetime ≤{' '}
+        {ceilings.maxLifetimeSeconds.max}s. Values above a ceiling are clamped server-side.
+      </p>
+
+      {denials.length > 0 ? (
+        <div className="notice error context-retrieval-denials" role="note">
+          <p className="small">The current selection will be adjusted or denied by policy:</p>
+          <ul className="small">
+            {denials.map((denial) => (
+              <li key={denial}>{denial}</li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+interface CollectionChipsProps {
+  name: string;
+  allowed: readonly string[];
+  selected: string[];
+  onToggle: (collection: string) => void;
+  disabled?: boolean;
+}
+
+function CollectionChips({
+  name,
+  allowed,
+  selected,
+  onToggle,
+  disabled,
+}: CollectionChipsProps): JSX.Element {
+  if (allowed.length === 0) {
+    return <p className="small">No collections are available in this deployment.</p>;
+  }
+  return (
+    <div className="context-retrieval-collections">
+      {allowed.map((collection) => (
+        <label key={collection} className="checkbox context-retrieval-collection">
+          <input
+            type="checkbox"
+            name={name}
+            value={collection}
+            checked={selected.includes(collection)}
+            disabled={disabled}
+            onChange={() => onToggle(collection)}
+          />
+          {collection}
+        </label>
+      ))}
+    </div>
+  );
+}
+
+interface NumberFieldProps {
+  label: string;
+  value: number;
+  min: number;
+  ceilingMax: number;
+  disabled?: boolean;
+  onChange: (raw: string) => void;
+}
+
+function NumberField({
+  label,
+  value,
+  min,
+  ceilingMax,
+  disabled,
+  onChange,
+}: NumberFieldProps): JSX.Element {
+  return (
+    <label className="context-retrieval-field">
+      <span className="context-retrieval-label">
+        {label} <span className="context-retrieval-ceiling-hint">(≤ {ceilingMax})</span>
+      </span>
+      <input
+        type="number"
+        min={min}
+        max={ceilingMax}
+        value={value}
+        disabled={disabled}
+        onChange={(event) => onChange(event.target.value)}
+      />
+    </label>
+  );
+}

--- a/frontend/src/entrypoints/omnigent-inventory.tsx
+++ b/frontend/src/entrypoints/omnigent-inventory.tsx
@@ -7,7 +7,7 @@ import { ContextRetrievalControls } from '../components/ContextRetrievalControls
 import {
   type ContextRetrievalAuthoring,
   defaultContextRetrievalAuthoring,
-  DEFAULT_RETRIEVAL_CEILINGS,
+  retrievalCeilingsFromRuntimeConfig,
 } from '../lib/contextRetrievalAuthoring';
 
 type InventoryKind = 'agents' | 'policies';
@@ -165,7 +165,10 @@ export default function OmnigentInventoryPage({ payload }: { payload: BootPayloa
   const queryKey = kind === 'agents' ? 'omnigent_agents_q' : 'omnigent_policies_q';
   const params = useMemo(() => new URLSearchParams(location.search), [location.search]);
   const filter = params.get(queryKey) ?? '';
-  const initialData = payload.initialData as { uiEndpoints?: Record<string, unknown> } | undefined;
+  const initialData = payload.initialData as { uiEndpoints?: Record<string, unknown>; dashboardConfig?: { system?: { retrievalAuthoring?: Record<string, unknown> } } } | undefined;
+  const retrievalCeilings = retrievalCeilingsFromRuntimeConfig(
+    initialData?.dashboardConfig?.system?.retrievalAuthoring,
+  );
   const endpoints = initialData?.uiEndpoints;
   const enabled = payload.features?.[featureKey] === true;
   const discoveredEndpoint = endpoints?.[kind === 'agents' ? 'omnigentAgents' : 'omnigentPolicies'];
@@ -351,7 +354,7 @@ export default function OmnigentInventoryPage({ payload }: { payload: BootPayloa
               <summary>Context retrieval (RAG) defaults</summary>
               <ContextRetrievalControls
                 value={retrieval.value}
-                ceilings={DEFAULT_RETRIEVAL_CEILINGS}
+                ceilings={retrievalCeilings}
                 onChange={(next) =>
                   setEditor({
                     ...editor,

--- a/frontend/src/entrypoints/omnigent-inventory.tsx
+++ b/frontend/src/entrypoints/omnigent-inventory.tsx
@@ -3,6 +3,12 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useLocation, useNavigate } from 'react-router-dom';
 
 import type { BootPayload } from '../boot/parseBootPayload';
+import { ContextRetrievalControls } from '../components/ContextRetrievalControls';
+import {
+  type ContextRetrievalAuthoring,
+  defaultContextRetrievalAuthoring,
+  DEFAULT_RETRIEVAL_CEILINGS,
+} from '../lib/contextRetrievalAuthoring';
 
 type InventoryKind = 'agents' | 'policies';
 type InventoryRow = {
@@ -40,6 +46,68 @@ type AgentProfile = {
   defaultForRuntime?: boolean;
   versions: ProfileVersion[];
 };
+
+/**
+ * Assisted RAG editor for a policy document (MoonMind#3514). The policy `rag`
+ * block (RagPolicy) is the deployment authority that feeds the per-run
+ * follow-up retrieval budget: `collectionRefs` is the allowed collection set and
+ * `tokenBudget` / `latencyBudgetMs` become the compiled budget ceilings. This
+ * maps only the RagPolicy-valid fields so the edited document stays valid; the
+ * remaining controls preview the per-run authoring experience.
+ */
+function readPolicyContextRetrieval(
+  documentJson: string,
+): { value: ContextRetrievalAuthoring; parsed: Record<string, unknown> } | null {
+  try {
+    const parsed = JSON.parse(documentJson);
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return null;
+    const document = parsed as Record<string, unknown>;
+    const rag =
+      document.rag && typeof document.rag === 'object' && !Array.isArray(document.rag)
+        ? (document.rag as Record<string, unknown>)
+        : null;
+    if (!rag) return null;
+    const collections = Array.isArray(rag.collectionRefs)
+      ? rag.collectionRefs.map((item) => String(item)).filter(Boolean)
+      : [];
+    const value = defaultContextRetrievalAuthoring();
+    value.initial.collections = collections;
+    value.followUp.enabled = true;
+    value.followUp.collections = collections;
+    value.followUp.budgetPreset = 'custom';
+    if (typeof rag.tokenBudget === 'number') {
+      value.followUp.maxContextTokens = rag.tokenBudget;
+    }
+    if (typeof rag.latencyBudgetMs === 'number') {
+      value.followUp.latencyMs = rag.latencyBudgetMs;
+    }
+    value.followUp.fallbackAllowed = rag.fallback === 'empty';
+    return { value, parsed: document };
+  } catch {
+    return null;
+  }
+}
+
+function writePolicyContextRetrieval(
+  document: Record<string, unknown>,
+  value: ContextRetrievalAuthoring,
+): string {
+  const rag: Record<string, unknown> = {
+    ...(document.rag && typeof document.rag === 'object' && !Array.isArray(document.rag)
+      ? (document.rag as Record<string, unknown>)
+      : {}),
+  };
+  const collections = Array.from(
+    new Set([...value.followUp.collections, ...value.initial.collections]),
+  );
+  if (collections.length > 0) {
+    rag.collectionRefs = collections;
+  }
+  rag.tokenBudget = value.followUp.maxContextTokens;
+  rag.latencyBudgetMs = value.followUp.latencyMs;
+  rag.fallback = value.followUp.fallbackAllowed ? 'empty' : 'deny';
+  return JSON.stringify({ ...document, rag }, null, 2);
+}
 
 function text(record: Record<string, unknown>, ...keys: string[]): string {
   for (const key of keys) {
@@ -268,6 +336,33 @@ export default function OmnigentInventoryPage({ payload }: { payload: BootPayloa
         <label><span>Policy id</span><input value={editor.id} disabled={editor.mode === 'version'} onChange={(event) => setEditor({ ...editor, id: event.target.value })} required /></label>
         <label><span>Name</span><input value={editor.name} onChange={(event) => setEditor({ ...editor, name: event.target.value })} required /></label>
         <label><span>Complete policy document (JSON)</span><textarea rows={18} value={editor.document} onChange={(event) => setEditor({ ...editor, document: event.target.value })} required /></label>
+        {(() => {
+          const retrieval = readPolicyContextRetrieval(editor.document);
+          if (!retrieval) {
+            return (
+              <p className="small">
+                Add a <code>rag</code> block to the document above to configure
+                context retrieval defaults with assisted controls.
+              </p>
+            );
+          }
+          return (
+            <details className="omnigent-policy-context-retrieval">
+              <summary>Context retrieval (RAG) defaults</summary>
+              <ContextRetrievalControls
+                value={retrieval.value}
+                ceilings={DEFAULT_RETRIEVAL_CEILINGS}
+                onChange={(next) =>
+                  setEditor({
+                    ...editor,
+                    document: writePolicyContextRetrieval(retrieval.parsed, next),
+                  })
+                }
+                description="Policy defaults set the allowed collections and the budget ceilings that per-run and workflow authoring narrow within. Only collections and budget ceilings persist to the policy document."
+              />
+            </details>
+          );
+        })()}
         {savePolicy.isError ? <p role="alert">{savePolicy.error.message}</p> : null}
         <button type="submit" disabled={savePolicy.isPending}>Validate and save draft</button>
         <button type="button" onClick={() => setEditor(null)}>Cancel</button>

--- a/frontend/src/entrypoints/schedules.tsx
+++ b/frontend/src/entrypoints/schedules.tsx
@@ -22,6 +22,7 @@ import {
   type ContextRetrievalAuthoring,
   compileContextRetrievalParameters,
   parseContextRetrievalParameters,
+  retrievalCeilingsFromRuntimeConfig,
 } from '../lib/contextRetrievalAuthoring';
 
 const SCHEDULES_MOBILE_MEDIA_QUERY = '(max-width: 720px)';
@@ -201,6 +202,7 @@ const SchedulesBootDataSchema = z
           })
           .partial()
           .optional(),
+        system: z.object({ retrievalAuthoring: z.record(z.string(), z.unknown()).optional() }).partial().optional(),
       })
       .partial()
       .optional(),
@@ -1017,6 +1019,9 @@ function ScheduleDetailPage({
   onSidebarRetry?: () => void;
 }) {
   const queryClient = useQueryClient();
+  const retrievalCeilings = retrievalCeilingsFromRuntimeConfig(
+    scheduleBootData(payload)?.dashboardConfig?.system?.retrievalAuthoring,
+  );
   const [isEditing, setIsEditing] = useState(false);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [editForm, setEditForm] = useState<ScheduleEditForm | null>(null);
@@ -1519,6 +1524,7 @@ function ScheduleDetailPage({
                     <summary>Context retrieval (RAG)</summary>
                     <ContextRetrievalControls
                       value={retrieval.value}
+                      ceilings={retrievalCeilings}
                       onChange={(next) => {
                         const targetJson = writeScheduleContextRetrieval(
                           retrieval.parsed,

--- a/frontend/src/entrypoints/schedules.tsx
+++ b/frontend/src/entrypoints/schedules.tsx
@@ -17,8 +17,65 @@ import {
   readRecurringScheduleFocusRequest,
 } from '../lib/recurringScheduleFocus';
 import { formatStatusLabel } from '../utils/formatters';
+import { ContextRetrievalControls } from '../components/ContextRetrievalControls';
+import {
+  type ContextRetrievalAuthoring,
+  compileContextRetrievalParameters,
+  parseContextRetrievalParameters,
+} from '../lib/contextRetrievalAuthoring';
 
 const SCHEDULES_MOBILE_MEDIA_QUERY = '(max-width: 720px)';
+
+/**
+ * Sync context-retrieval authoring into a schedule's raw target JSON
+ * (MoonMind#3514). The target's `initialParameters` carries the run params, so
+ * `rag` / `followUpRetrieval` live there. Returns the parsed authoring value and
+ * a writer that produces an updated target-JSON string, or null when the JSON
+ * cannot be parsed (the raw textarea then remains the sole editor).
+ */
+function readScheduleContextRetrieval(
+  targetJson: string,
+): { value: ContextRetrievalAuthoring; parsed: Record<string, unknown> } | null {
+  try {
+    const parsed = JSON.parse(targetJson);
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return null;
+    }
+    const target = parsed as Record<string, unknown>;
+    const initialParameters =
+      target.initialParameters && typeof target.initialParameters === 'object'
+        ? (target.initialParameters as Record<string, unknown>)
+        : {};
+    return {
+      value: parseContextRetrievalParameters(initialParameters),
+      parsed: target,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function writeScheduleContextRetrieval(
+  target: Record<string, unknown>,
+  value: ContextRetrievalAuthoring,
+): string {
+  const compiled = compileContextRetrievalParameters(value);
+  const initialParameters: Record<string, unknown> = {
+    ...(target.initialParameters && typeof target.initialParameters === 'object'
+      ? (target.initialParameters as Record<string, unknown>)
+      : {}),
+  };
+  // Replace both keys so clearing a control removes stale config.
+  delete initialParameters.rag;
+  delete initialParameters.followUpRetrieval;
+  if (compiled.rag) {
+    initialParameters.rag = compiled.rag;
+  }
+  if (compiled.followUpRetrieval) {
+    initialParameters.followUpRetrieval = compiled.followUpRetrieval;
+  }
+  return JSON.stringify({ ...target, initialParameters }, null, 2);
+}
 
 const ScheduleSchema = z.object({
   id: z.string(),
@@ -1447,6 +1504,39 @@ function ScheduleDetailPage({
                 />
                 {visibleFormErrors.targetJson && <span className="schedules-field-error">{visibleFormErrors.targetJson}</span>}
               </label>
+              {(() => {
+                const retrieval = readScheduleContextRetrieval(currentForm.targetJson);
+                if (!retrieval) {
+                  return (
+                    <p className="small">
+                      Edit the target JSON above to configure context retrieval; the
+                      assisted controls appear once the JSON is valid.
+                    </p>
+                  );
+                }
+                return (
+                  <details className="schedules-context-retrieval">
+                    <summary>Context retrieval (RAG)</summary>
+                    <ContextRetrievalControls
+                      value={retrieval.value}
+                      onChange={(next) => {
+                        const targetJson = writeScheduleContextRetrieval(
+                          retrieval.parsed,
+                          next,
+                        );
+                        setEditForm((previous) =>
+                          previous ? { ...previous, targetJson } : null,
+                        );
+                        setSubmitErrors((previous) => ({
+                          ...previous,
+                          targetJson: undefined,
+                        }));
+                      }}
+                      description="These controls edit the recurring run's context retrieval policy within deployment ceilings and stay in sync with the target JSON above."
+                    />
+                  </details>
+                );
+              })()}
               <label className="schedules-checkbox-label">
                 <input
                   type="checkbox"

--- a/frontend/src/entrypoints/workflow-detail.followup-retrieval.test.tsx
+++ b/frontend/src/entrypoints/workflow-detail.followup-retrieval.test.tsx
@@ -1,0 +1,118 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import {
+  FollowUpRetrievalDiagnosticsSection,
+  type FollowUpRetrievalDiagnostics,
+} from './workflow-detail';
+
+// AC10 (MoonLadderStudios/MoonMind#3514): Workflow Detail exposes follow-up
+// retrieval request count, budget usage, per-request diagnostics, capability
+// expiry/revocation, and aggregate telemetry.
+
+describe('FollowUpRetrievalDiagnosticsSection', () => {
+  it('reports when no follow-up retrieval capability was issued', () => {
+    render(
+      <FollowUpRetrievalDiagnosticsSection
+        diagnostics={{
+          bridgeSessionId: 'bridge-1',
+          capabilityCount: 0,
+          capabilities: [],
+          aggregate: {},
+        }}
+        isLoading={false}
+        error={null}
+      />,
+    );
+    expect(
+      screen.getByText(/no in-session retrieval capability issued/i),
+    ).toBeTruthy();
+  });
+
+  it('renders aggregate telemetry and per-capability diagnostics', () => {
+    const diagnostics: FollowUpRetrievalDiagnostics = {
+      bridgeSessionId: 'bridge-1',
+      capabilityCount: 1,
+      aggregate: {
+        requestCount: 3,
+        succeeded: 2,
+        empty: 1,
+        denied: 0,
+        failed: 1,
+        fallback: 1,
+        truncated: 1,
+        budgetExhausted: 1,
+        timedOut: 0,
+        delivered: 1,
+        notDelivered: 1,
+        deliveryUnknown: 1,
+        cancelled: 0,
+        maxLatencyMs: 1200,
+        totalContextBytes: 4096,
+        activeCapabilities: 1,
+        expiredCapabilities: 0,
+        revokedCapabilities: 0,
+      },
+      capabilities: [
+        {
+          capabilityId: 'rcap_abc',
+          state: 'active',
+          expiresAt: 1_000_000,
+          queryCount: 3,
+          maxQueries: 12,
+          collections: ['repo', 'docs'],
+          policyVersion: 'policy-7',
+          overlayPolicy: 'include',
+          fallbackAllowed: true,
+          scope: { repository: 'MoonMind', run: 'run-1' },
+          requests: [
+            {
+              evidenceRef: 'artifact://retrieval-follow-up/run-1/e1',
+              state: 'succeeded',
+              resultCount: 2,
+              latencyMs: 900,
+              truncated: false,
+              delivery: { state: 'delivered' },
+              contextPackRef: '/retrieval/capabilities/rcap_abc/results/tool-1',
+            },
+            {
+              state: 'failed',
+              classification: 'token_budget_exhausted',
+              resultCount: 0,
+              delivery: { state: 'not_delivered' },
+            },
+          ],
+        },
+      ],
+    };
+    render(
+      <FollowUpRetrievalDiagnosticsSection
+        diagnostics={diagnostics}
+        isLoading={false}
+        error={null}
+      />,
+    );
+
+    expect(screen.getByText(/3 requests across 1 capability/i)).toBeTruthy();
+    // Per-request state and classification are shown.
+    expect(screen.getByText(/token_budget_exhausted/)).toBeTruthy();
+    // Capability scope + collections + expiry.
+    expect(screen.getByText(/repository=MoonMind/)).toBeTruthy();
+    expect(screen.getByText(/repo, docs/)).toBeTruthy();
+    // Aggregate telemetry lines.
+    expect(screen.getByText(/max latency 1200ms/i)).toBeTruthy();
+  });
+
+  it('shows an unavailable message on error', () => {
+    render(
+      <FollowUpRetrievalDiagnosticsSection
+        diagnostics={null}
+        isLoading={false}
+        error={new Error('boom')}
+      />,
+    );
+    expect(
+      screen.getByText(/diagnostics are unavailable/i),
+    ).toBeTruthy();
+  });
+});

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -6,6 +6,7 @@ import {
   type CSSProperties,
   type Dispatch,
   type KeyboardEvent,
+  type ReactElement,
   type ReactNode,
   type SetStateAction,
 } from 'react';
@@ -24,6 +25,13 @@ import { resolveWorkflowDisplayStatus } from '../status/workflowStatus';
 import { DashboardActionDialog } from '../components/DashboardActionDialog';
 import { EntityDetailFrame } from '../components/EntityDetailFrame';
 import { CollectionWorkspace } from '../components/CollectionWorkspace';
+import { ContextRetrievalControls } from '../components/ContextRetrievalControls';
+import {
+  type ContextRetrievalAuthoring,
+  compileContextRetrievalParameters,
+  defaultContextRetrievalAuthoring,
+  hasAuthoredContextRetrieval,
+} from '../lib/contextRetrievalAuthoring';
 import {
   DashboardToastProvider,
   useDashboardToast,
@@ -2737,6 +2745,188 @@ async function fetchBridgeSessionResources(apiBase: string, bridgeSessionId: str
   };
 }
 
+// Follow-up (in-session) retrieval operator diagnostics (MoonMind#3514).
+type FollowUpRetrievalRequest = {
+  evidenceRef?: string;
+  state?: string;
+  classification?: string | null;
+  resultCount?: number;
+  contextBytes?: number;
+  latencyMs?: number | null;
+  truncated?: boolean;
+  contextPackRef?: string | null;
+  delivery?: { state?: string } | null;
+};
+type FollowUpRetrievalCapability = {
+  capabilityId: string;
+  state: string;
+  expiresAt?: number;
+  revokedAt?: number | null;
+  queryCount?: number;
+  maxQueries?: number;
+  activeRequests?: number;
+  maxConcurrency?: number;
+  collections?: string[];
+  policyVersion?: string;
+  overlayPolicy?: string;
+  fallbackAllowed?: boolean;
+  scope?: Record<string, unknown>;
+  requests?: FollowUpRetrievalRequest[];
+};
+export type FollowUpRetrievalDiagnostics = {
+  bridgeSessionId: string;
+  capabilityCount: number;
+  capabilities: FollowUpRetrievalCapability[];
+  aggregate: Record<string, number>;
+};
+
+async function fetchFollowUpRetrievalDiagnostics(
+  apiBase: string,
+  bridgeSessionId: string,
+): Promise<FollowUpRetrievalDiagnostics | null> {
+  const resp = await fetch(
+    joinApiBasePath(
+      apiBase,
+      `/retrieval/bridge-sessions/${encodeURIComponent(bridgeSessionId)}/follow-up-retrieval`,
+    ),
+    { credentials: 'include' },
+  );
+  if (!resp.ok) {
+    if (resp.status === 404) return null;
+    throw buildObservabilityRequestError(resp.status);
+  }
+  const body = (await resp.json()) as Partial<FollowUpRetrievalDiagnostics>;
+  return {
+    bridgeSessionId,
+    capabilityCount: typeof body.capabilityCount === 'number' ? body.capabilityCount : 0,
+    capabilities: Array.isArray(body.capabilities) ? body.capabilities : [],
+    aggregate:
+      body.aggregate && typeof body.aggregate === 'object'
+        ? (body.aggregate as Record<string, number>)
+        : {},
+  };
+}
+
+function formatCapabilityExpiry(capability: FollowUpRetrievalCapability): string {
+  if (capability.state === 'revoked') {
+    return capability.revokedAt
+      ? `revoked ${new Date(capability.revokedAt * 1000).toLocaleString()}`
+      : 'revoked';
+  }
+  if (capability.state === 'expired') {
+    return 'expired';
+  }
+  return capability.expiresAt
+    ? `active until ${new Date(capability.expiresAt * 1000).toLocaleString()}`
+    : 'active';
+}
+
+export function FollowUpRetrievalDiagnosticsSection({
+  diagnostics,
+  isLoading,
+  error,
+}: {
+  diagnostics: FollowUpRetrievalDiagnostics | null;
+  isLoading: boolean;
+  error: unknown;
+}): ReactElement | null {
+  if (error) {
+    return (
+      <div className="small stack" data-testid="omnigent-follow-up-retrieval">
+        <p>Follow-up retrieval diagnostics are unavailable.</p>
+      </div>
+    );
+  }
+  if (isLoading && !diagnostics) {
+    return null;
+  }
+  if (!diagnostics || diagnostics.capabilityCount === 0) {
+    return (
+      <div className="small stack" data-testid="omnigent-follow-up-retrieval">
+        <p>Follow-up retrieval: no in-session retrieval capability issued.</p>
+      </div>
+    );
+  }
+  const aggregate = diagnostics.aggregate ?? {};
+  const metric = (key: string): number => Number(aggregate[key] ?? 0);
+  return (
+    <div
+      className="small stack context-retrieval-diagnostics"
+      data-testid="omnigent-follow-up-retrieval"
+    >
+      <p>
+        Follow-up retrieval: {metric('requestCount')} request
+        {metric('requestCount') === 1 ? '' : 's'} across {diagnostics.capabilityCount}{' '}
+        capabilit{diagnostics.capabilityCount === 1 ? 'y' : 'ies'}
+        {' · '}
+        {metric('succeeded')} ok · {metric('empty')} empty · {metric('denied')} denied ·{' '}
+        {metric('failed')} failed
+      </p>
+      <p>
+        Fallback {metric('fallback')} · truncated {metric('truncated')} · budget-exhausted{' '}
+        {metric('budgetExhausted')} · timed-out {metric('timedOut')} · max latency{' '}
+        {metric('maxLatencyMs')}ms · context {metric('totalContextBytes')} bytes
+      </p>
+      <p>
+        Delivery — delivered {metric('delivered')} · not delivered {metric('notDelivered')} ·
+        unknown {metric('deliveryUnknown')} · cancelled {metric('cancelled')}
+      </p>
+      <p>
+        Capabilities — active {metric('activeCapabilities')} · expired{' '}
+        {metric('expiredCapabilities')} · revoked {metric('revokedCapabilities')}
+      </p>
+      {diagnostics.capabilities.map((capability) => (
+        <div key={capability.capabilityId} className="context-retrieval-capability stack">
+          <p>
+            <code className="text-xs">{capability.capabilityId}</code> · {formatCapabilityExpiry(capability)}
+            {' · '}
+            {Number(capability.queryCount ?? 0)}/{Number(capability.maxQueries ?? 0)} queries
+          </p>
+          {capability.scope ? (
+            <p>
+              Scope:{' '}
+              {Object.entries(capability.scope)
+                .filter(([, value]) => String(value ?? '').trim())
+                .map(([key, value]) => `${key}=${String(value)}`)
+                .join(', ')}
+            </p>
+          ) : null}
+          {Array.isArray(capability.collections) && capability.collections.length ? (
+            <p>
+              Collections: {capability.collections.join(', ')}
+              {capability.overlayPolicy ? ` · overlay ${capability.overlayPolicy}` : ''}
+              {capability.fallbackAllowed ? ' · fallback allowed' : ''}
+            </p>
+          ) : null}
+          {Array.isArray(capability.requests) && capability.requests.length ? (
+            <ul className="stack">
+              {capability.requests.map((request, index) => (
+                <li key={request.evidenceRef ?? `${capability.capabilityId}-${index}`}>
+                  {String(request.state ?? 'unknown')}
+                  {request.classification ? ` (${request.classification})` : ''}
+                  {' · '}
+                  {Number(request.resultCount ?? 0)} results
+                  {request.truncated ? ' · truncated' : ''}
+                  {typeof request.latencyMs === 'number' ? ` · ${request.latencyMs}ms` : ''}
+                  {request.delivery?.state ? ` · delivery ${request.delivery.state}` : ''}
+                  {request.contextPackRef ? (
+                    <>
+                      {' · '}
+                      <code className="text-xs break-all">{request.contextPackRef}</code>
+                    </>
+                  ) : null}
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p>No follow-up retrieval requests recorded yet.</p>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}
+
 async function resolveBridgeSessionProjection({
   apiBase,
   workflowId,
@@ -4510,13 +4700,30 @@ type BranchCreateDraft = {
 type BranchMutationKind = 'create' | 'continue' | 'fork' | 'promote' | 'publish' | 'archive' | 'compare';
 
 type BranchMutationRequest =
-  | { kind: 'create'; draft: BranchCreateDraft; source: StepLedgerRow; idempotencyKey: string }
-  | { kind: 'continue'; branch: CheckpointBranch; instructions: string; idempotencyKey: string }
-  | { kind: 'fork'; branch: CheckpointBranch; instructions: string; idempotencyKey: string }
+  | { kind: 'create'; draft: BranchCreateDraft; source: StepLedgerRow; idempotencyKey: string; contextRetrieval?: ContextRetrievalAuthoring | undefined }
+  | { kind: 'continue'; branch: CheckpointBranch; instructions: string; idempotencyKey: string; contextRetrieval?: ContextRetrievalAuthoring | undefined }
+  | { kind: 'fork'; branch: CheckpointBranch; instructions: string; idempotencyKey: string; contextRetrieval?: ContextRetrievalAuthoring | undefined }
   | { kind: 'promote'; branch: CheckpointBranch; competingBranches: CheckpointBranch[]; idempotencyKey: string }
   | { kind: 'publish'; branch: CheckpointBranch; idempotencyKey: string }
   | { kind: 'archive'; branch: CheckpointBranch; idempotencyKey: string }
   | { kind: 'compare'; branch: CheckpointBranch; againstBranchId: string };
+
+// Attach an authored follow-up retrieval override to a branch-turn request body
+// (MoonMind#3514). The checkpoint-branch API accepts (and records) the override;
+// launch inherits the parent run's compiled policy unless a narrower override is
+// authored here. Compiled values are always bounded by deployment ceilings.
+function applyBranchRetrievalOverride(
+  body: Record<string, unknown>,
+  contextRetrieval: ContextRetrievalAuthoring | undefined,
+): void {
+  if (!contextRetrieval) {
+    return;
+  }
+  const compiled = compileContextRetrievalParameters(contextRetrieval);
+  if (compiled.followUpRetrieval) {
+    body.followUpRetrieval = compiled.followUpRetrieval;
+  }
+}
 
 const BRANCH_MUTATING_STATES = new Set(['created', 'active', 'blocked', 'failed', 'succeeded', 'promotable']);
 const DEFAULT_BRANCH_CREATE_DRAFT: BranchCreateDraft = {
@@ -4749,6 +4956,11 @@ function BranchExplorerPanel({
   const [draft, setDraft] = useState<BranchCreateDraft>(() => DEFAULT_BRANCH_CREATE_DRAFT);
   const [branchInstructions, setBranchInstructions] = useState('Continue this branch with bounded instructions.');
   const [againstBranchId, setAgainstBranchId] = useState('');
+  const [branchContextRetrieval, setBranchContextRetrieval] =
+    useState<ContextRetrievalAuthoring>(defaultContextRetrievalAuthoring);
+  const branchRetrievalOverride = hasAuthoredContextRetrieval(branchContextRetrieval)
+    ? branchContextRetrieval
+    : undefined;
 
   useEffect(() => {
     const firstCheckpointRow = checkpointRows[0];
@@ -4971,6 +5183,7 @@ function BranchExplorerPanel({
             draft,
             source: selectedSource,
             idempotencyKey: branchIdempotencyKey('create', workflowId, stepBranchKey(selectedSource)),
+            contextRetrieval: branchRetrievalOverride,
           })}
         >
           Create branch from checkpoint
@@ -5019,6 +5232,16 @@ function BranchExplorerPanel({
             Branch action instructions
             <textarea value={branchInstructions} disabled={busy} rows={2} onChange={(event) => setBranchInstructions(event.target.value)} />
           </label>
+          <details className="branch-context-retrieval">
+            <summary>Context retrieval (RAG) for this turn</summary>
+            <ContextRetrievalControls
+              value={branchContextRetrieval}
+              onChange={setBranchContextRetrieval}
+              showInitialControls={false}
+              disabled={busy}
+              description="Continue/fork turns inherit the parent run's retrieval policy. Set an override here to narrow in-session follow-up retrieval for the new turn within deployment ceilings."
+            />
+          </details>
           <label>
             Compare against
             <select value={againstBranchId} disabled={busy || branches.length < 2} onChange={(event) => setAgainstBranchId(event.target.value)}>
@@ -5029,8 +5252,8 @@ function BranchExplorerPanel({
             </select>
           </label>
           <div className="button-row">
-            <button type="button" disabled={Boolean(continueBlockedReason)} title={continueBlockedReason || undefined} onClick={() => onBranchAction({ kind: 'continue', branch: selectedBranch, instructions: branchInstructions, idempotencyKey: branchIdempotencyKey('continue', workflowId, selectedBranch.branchId) })}>Continue branch</button>
-            <button type="button" className="secondary" disabled={Boolean(forkBlockedReason)} title={forkBlockedReason || undefined} onClick={() => onBranchAction({ kind: 'fork', branch: selectedBranch, instructions: branchInstructions, idempotencyKey: branchIdempotencyKey('fork', workflowId, selectedBranch.branchId) })}>Fork from this branch</button>
+            <button type="button" disabled={Boolean(continueBlockedReason)} title={continueBlockedReason || undefined} onClick={() => onBranchAction({ kind: 'continue', branch: selectedBranch, instructions: branchInstructions, idempotencyKey: branchIdempotencyKey('continue', workflowId, selectedBranch.branchId), contextRetrieval: branchRetrievalOverride })}>Continue branch</button>
+            <button type="button" className="secondary" disabled={Boolean(forkBlockedReason)} title={forkBlockedReason || undefined} onClick={() => onBranchAction({ kind: 'fork', branch: selectedBranch, instructions: branchInstructions, idempotencyKey: branchIdempotencyKey('fork', workflowId, selectedBranch.branchId), contextRetrieval: branchRetrievalOverride })}>Fork from this branch</button>
             <button type="button" className="secondary" disabled={compareDisabled} title={compareBlockedReason || undefined} onClick={() => onBranchAction({ kind: 'compare', branch: selectedBranch, againstBranchId })}>Compare branches</button>
             <button type="button" className="secondary" disabled={promoteDisabled} title={promoteBlockedReason || undefined} onClick={() => onBranchAction({ kind: 'promote', branch: selectedBranch, competingBranches, idempotencyKey: branchIdempotencyKey('promote', workflowId, selectedBranch.branchId) })}>Promote branch</button>
             <button type="button" className="secondary" disabled={publishDisabled} title={publishBlockedReason || undefined} onClick={() => onBranchAction({ kind: 'publish', branch: selectedBranch, idempotencyKey: branchIdempotencyKey('publish', workflowId, selectedBranch.branchId) })}>Publish branch</button>
@@ -5982,6 +6205,13 @@ function BridgeSessionLogsPanel({
     },
     retry: false,
   });
+  const followUpRetrievalQuery = useQuery({
+    queryKey: ['omnigent-follow-up-retrieval', bridgeSessionId],
+    queryFn: () => fetchFollowUpRetrievalDiagnostics(apiBase, bridgeSessionId),
+    enabled: Boolean(bridgeSessionId),
+    refetchInterval: isTerminal ? false : SESSION_PROJECTION_POLL_MS,
+    retry: false,
+  });
   const historyRows = useMemo(() => {
     const rows = mapEventsToTimelineRows(eventsQuery.data);
     const envelope = eventsQuery.data && 'terminalEnvelope' in eventsQuery.data
@@ -6266,6 +6496,11 @@ function BridgeSessionLogsPanel({
           ) : null}
         </div>
       ) : null}
+      <FollowUpRetrievalDiagnosticsSection
+        diagnostics={followUpRetrievalQuery.data ?? null}
+        isLoading={followUpRetrievalQuery.isLoading}
+        error={followUpRetrievalQuery.error}
+      />
       <section className="card stack" aria-label="Omnigent runtime identity">
         <h3>Codex via Omnigent</h3>
         <dl className="details-grid">
@@ -8815,6 +9050,7 @@ function WorkflowDetailPageContent({ payload }: { payload: BootPayload }) {
           gitWorkBranch: request.draft.gitWorkBranch.trim() || null,
           maxBudgetUsd: Number.isFinite(budget) ? budget : null,
         };
+        applyBranchRetrievalOverride(body, request.contextRetrieval);
       } else if (request.kind === 'continue') {
         url = `${branchBase}/${encodeURIComponent(request.branch.branchId)}/continue`;
         body = {
@@ -8825,6 +9061,7 @@ function WorkflowDetailPageContent({ payload }: { payload: BootPayload }) {
           idempotencyKey: request.idempotencyKey,
           maxBudgetUsd: null,
         };
+        applyBranchRetrievalOverride(body, request.contextRetrieval);
       } else if (request.kind === 'fork') {
         url = `${branchBase}/${encodeURIComponent(request.branch.branchId)}/fork`;
         body = {
@@ -8835,6 +9072,7 @@ function WorkflowDetailPageContent({ payload }: { payload: BootPayload }) {
           idempotencyKey: request.idempotencyKey,
           maxBudgetUsd: null,
         };
+        applyBranchRetrievalOverride(body, request.contextRetrieval);
       } else if (request.kind === 'promote') {
         url = `${branchBase}/${encodeURIComponent(request.branch.branchId)}/promote`;
         body = {

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -31,6 +31,7 @@ import {
   compileContextRetrievalParameters,
   defaultContextRetrievalAuthoring,
   hasAuthoredContextRetrieval,
+  retrievalCeilingsFromRuntimeConfig,
 } from '../lib/contextRetrievalAuthoring';
 import {
   DashboardToastProvider,
@@ -116,6 +117,7 @@ type DashboardConfig = {
     temporal?: Record<string, string>;
     agentRuns?: Record<string, string>;
   };
+  system?: { retrievalAuthoring?: Record<string, unknown> };
 };
 
 type LiveLogsSessionTimelineRollout = 'off' | 'internal' | 'codex_managed' | 'all_managed';
@@ -4934,6 +4936,7 @@ function BranchExplorerPanel({
   latestCompare,
   onSelectBranch,
   onBranchAction,
+  retrievalCeilings,
 }: {
   apiBase: string;
   workflowId: string;
@@ -4950,6 +4953,7 @@ function BranchExplorerPanel({
   latestCompare: z.infer<typeof CheckpointBranchCompareSchema> | null;
   onSelectBranch: (branchId: string) => void;
   onBranchAction: (request: BranchMutationRequest) => void;
+  retrievalCeilings: ReturnType<typeof retrievalCeilingsFromRuntimeConfig>;
 }) {
   const checkpointRows = rows.filter((row) => isSupportedCheckpointRef(stepCheckpointRef(row)));
   const branchGroups = useMemo(() => buildBranchGroups(branches), [branches]);
@@ -5237,6 +5241,7 @@ function BranchExplorerPanel({
             <ContextRetrievalControls
               value={branchContextRetrieval}
               onChange={setBranchContextRetrieval}
+              ceilings={retrievalCeilings}
               showInitialControls={false}
               disabled={busy}
               description="Continue/fork turns inherit the parent run's retrieval policy. Set an override here to narrow in-session follow-up retrieval for the new turn within deployment ceilings."
@@ -8314,6 +8319,9 @@ function WorkflowDetailPageContent({ payload }: { payload: BootPayload }) {
   const queryClient = useQueryClient();
   const toast = useDashboardToast();
   const cfg = readDashboardConfig(payload);
+  const retrievalCeilings = retrievalCeilingsFromRuntimeConfig(
+    cfg?.system?.retrievalAuthoring,
+  );
   const agentRunRoutes = readAgentRunRouteTemplates(cfg);
   const detailPoll = cfg?.pollIntervalsMs?.detail ?? 2000;
   const actionsOn = Boolean(cfg?.features?.temporalDashboard?.actionsEnabled);
@@ -10170,6 +10178,7 @@ function WorkflowDetailPageContent({ payload }: { payload: BootPayload }) {
                       setActionError(null);
                       checkpointBranchMutation.mutate(request);
                     }}
+                    retrievalCeilings={retrievalCeilings}
                   />
                 </>
               ) : (

--- a/frontend/src/entrypoints/workflow-start.test.tsx
+++ b/frontend/src/entrypoints/workflow-start.test.tsx
@@ -199,6 +199,58 @@ describe("buildEditParametersPatch", () => {
       },
     });
   });
+
+  it("clears inherited rag/followUpRetrieval when the submission omits them", () => {
+    const patch = buildEditParametersPatch({
+      execution: {
+        workflowId: "mm:edit-retrieval-clear",
+        inputParameters: {
+          rag: { collections: ["repo"], required: true },
+          followUpRetrieval: { enabled: true, collections: ["repo"] },
+          workflow: { instructions: "Keep going.", runtime: { mode: "codex_cli" } },
+        },
+      },
+      submittedPayload: {
+        task: { instructions: "Keep going.", runtime: { mode: "codex_cli" } },
+      },
+      submittedWorkflow: {
+        instructions: "Keep going.",
+        runtime: { mode: "codex_cli" },
+      },
+    });
+
+    // The operator disabled retrieval authoring, so the inherited authority must
+    // not silently persist through the edit patch.
+    expect("rag" in patch).toBe(false);
+    expect("followUpRetrieval" in patch).toBe(false);
+  });
+
+  it("keeps rag/followUpRetrieval when the submission carries them", () => {
+    const patch = buildEditParametersPatch({
+      execution: {
+        workflowId: "mm:edit-retrieval-keep",
+        inputParameters: {
+          rag: { collections: ["repo"] },
+          workflow: { instructions: "Keep going.", runtime: { mode: "codex_cli" } },
+        },
+      },
+      submittedPayload: {
+        rag: { collections: ["docs"] },
+        followUpRetrieval: { enabled: true, collections: ["docs"] },
+        task: { instructions: "Keep going.", runtime: { mode: "codex_cli" } },
+      },
+      submittedWorkflow: {
+        instructions: "Keep going.",
+        runtime: { mode: "codex_cli" },
+      },
+    });
+
+    expect(patch.rag).toEqual({ collections: ["docs"] });
+    expect(patch.followUpRetrieval).toEqual({
+      enabled: true,
+      collections: ["docs"],
+    });
+  });
 });
 
 describe("WorkflowStartPage loading placeholders", () => {

--- a/frontend/src/entrypoints/workflow-start.tsx
+++ b/frontend/src/entrypoints/workflow-start.tsx
@@ -41,6 +41,7 @@ import {
   defaultContextRetrievalAuthoring,
   hasAuthoredContextRetrieval,
   parseContextRetrievalParameters,
+  retrievalCeilingsFromRuntimeConfig,
 } from "../lib/contextRetrievalAuthoring";
 
 type WorkflowStartDashboardConfig = {
@@ -428,6 +429,7 @@ interface DashboardConfig {
       defaultBoardId?: string;
       rememberLastBoardInSession?: boolean;
     };
+    retrievalAuthoring?: Record<string, unknown>;
   };
 }
 
@@ -5822,6 +5824,9 @@ function StepContextBar({
 function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
   useLiquidGL({ options: LIQUID_GL_OPTIONS });
   const dashboardConfig = readDashboardConfig(payload);
+  const retrievalCeilings = retrievalCeilingsFromRuntimeConfig(
+    dashboardConfig.system?.retrievalAuthoring,
+  );
   const pageMode = useMemo(
     () => resolveTaskSubmitPageMode(window.location.search),
     [],
@@ -13695,6 +13700,7 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
           <ContextRetrievalControls
             value={contextRetrieval}
             onChange={setContextRetrieval}
+            ceilings={retrievalCeilings}
             description="Choose which collections the run may search and whether the session may request additional context during the run. Requests are always bounded by deployment policy."
           />
         </details>

--- a/frontend/src/entrypoints/workflow-start.tsx
+++ b/frontend/src/entrypoints/workflow-start.tsx
@@ -1539,6 +1539,16 @@ export function buildEditParametersPatch({
   if (!("mergeAutomation" in submittedPayload)) {
     delete parametersPatch.mergeAutomation;
   }
+  // Context retrieval authority (#3514) is an operator-cleared control. When the
+  // submission does not carry `rag` / `followUpRetrieval` the operator disabled
+  // that authoring, so the inherited base value must be explicitly removed
+  // rather than silently preserved (mirrors the `mergeAutomation` clear above).
+  if (!("rag" in submittedPayload)) {
+    delete parametersPatch.rag;
+  }
+  if (!("followUpRetrieval" in submittedPayload)) {
+    delete parametersPatch.followUpRetrieval;
+  }
   delete parametersPatch.startingBranch;
   delete parametersPatch.targetBranch;
   return parametersPatch;
@@ -11159,6 +11169,25 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
         requestBody.payload = artifactPayload;
       }
       const rerunDraft = temporalDraftData?.draft;
+      // Context retrieval authoring (#3514) is submitted via the payload, not the
+      // workflow draft, so it must be compared explicitly or an exact rerun that
+      // only changes retrieval controls is classified as unchanged and its
+      // `parametersPatch` is dropped to null. Compare the compiled submission
+      // against the compiled source parameters.
+      const submittedRetrievalConfig = hasAuthoredContextRetrieval(contextRetrieval)
+        ? compileContextRetrievalParameters(contextRetrieval)
+        : {};
+      const sourceRetrievalAuthoring = parseContextRetrievalParameters(
+        recordValue(temporalDraftData?.execution?.inputParameters),
+      );
+      const sourceRetrievalConfig = hasAuthoredContextRetrieval(
+        sourceRetrievalAuthoring,
+      )
+        ? compileContextRetrievalParameters(sourceRetrievalAuthoring)
+        : {};
+      const retrievalConfigChanged =
+        JSON.stringify(submittedRetrievalConfig) !==
+        JSON.stringify(sourceRetrievalConfig);
       const currentPublishModeSelection = normalizePublishModeSelection(publishMode);
       const rerunDraftPublishModeSelection = normalizePublishModeSelection(
         rerunDraft?.publishMode,
@@ -11201,7 +11230,8 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
               })),
             ) ||
           JSON.stringify(taskLevelAttachmentRefs) !==
-            JSON.stringify(rerunDraft.inputAttachments)
+            JSON.stringify(rerunDraft.inputAttachments) ||
+          retrievalConfigChanged
         : false;
       const isExactRerun = isExactRerunRequest && !rerunFormChanged;
       const artifactWorkflowPayload = mergeRecordValues(

--- a/frontend/src/entrypoints/workflow-start.tsx
+++ b/frontend/src/entrypoints/workflow-start.tsx
@@ -34,6 +34,14 @@ import {
   readRemediationCreateDraft,
   type RemediationCreateDraft,
 } from "../lib/remediationCreateDraft";
+import { ContextRetrievalControls } from "../components/ContextRetrievalControls";
+import {
+  type ContextRetrievalAuthoring,
+  compileContextRetrievalParameters,
+  defaultContextRetrievalAuthoring,
+  hasAuthoredContextRetrieval,
+  parseContextRetrievalParameters,
+} from "../lib/contextRetrievalAuthoring";
 
 type WorkflowStartDashboardConfig = {
   features?: {
@@ -6021,6 +6029,8 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
   const [selectedDependencies, setSelectedDependencies] = useState<string[]>([]);
   const [remediationDraft, setRemediationDraft] = useState<RemediationCreateDraft | null>(null);
   const remediationDraftIdRef = useRef<string | null>(null);
+  const [contextRetrieval, setContextRetrieval] =
+    useState<ContextRetrievalAuthoring>(defaultContextRetrievalAuthoring);
   const [dependencyMessage, setDependencyMessage] = useState<string | null>(null);
   const [selectedPresetKey, setSelectedPresetKey] = useState("");
   const [templateMessage, setTemplateMessage] = useState<string | null>(null);
@@ -6587,6 +6597,11 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
       );
     }
     setProduceReport(draft.reportOutputEnabled);
+    setContextRetrieval(
+      parseContextRetrievalParameters(
+        recordValue(temporalDraftQuery.data.execution.inputParameters),
+      ),
+    );
     const reconstructedSteps = createStepStateEntriesFromTemporalDraft(draft);
     setSteps(reconstructedSteps);
     setShowAdvancedStepOptions(hasAdvancedStepOptionValues(reconstructedSteps));
@@ -11043,6 +11058,25 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
         schedulePayload;
     }
 
+    // Context retrieval (RAG) authoring (#3514). Placed at the payload level so
+    // `rag` / `followUpRetrieval` are lifted into the run's initial parameters
+    // (and, for scheduled runs, into target.initialParameters) server-side.
+    if (hasAuthoredContextRetrieval(contextRetrieval)) {
+      const compiledRetrieval =
+        compileContextRetrievalParameters(contextRetrieval);
+      const submittedRetrievalPayload = requestBody.payload as Record<
+        string,
+        unknown
+      >;
+      if (compiledRetrieval.rag) {
+        submittedRetrievalPayload.rag = compiledRetrieval.rag;
+      }
+      if (compiledRetrieval.followUpRetrieval) {
+        submittedRetrievalPayload.followUpRetrieval =
+          compiledRetrieval.followUpRetrieval;
+      }
+    }
+
     try {
       let inputArtifactRef: string | null = null;
       const submittedPayload = requestBody.payload as Record<string, unknown>;
@@ -13626,6 +13660,14 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
             </p>
           </div>
         ) : null}
+        <details className="queue-context-retrieval-disclosure">
+          <summary>Context retrieval (RAG)</summary>
+          <ContextRetrievalControls
+            value={contextRetrieval}
+            onChange={setContextRetrieval}
+            description="Choose which collections the run may search and whether the session may request additional context during the run. Requests are always bounded by deployment policy."
+          />
+        </details>
         </section>
 
         {pageMode.mode === "create" ? (

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -292,6 +292,30 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/retrieval/bridge-sessions/{bridge_session_id}/follow-up-retrieval": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Bridge Follow Up Retrieval Diagnostics
+         * @description Operator diagnostics for a bridge session's follow-up retrieval activity.
+         *
+         *     Returns bounded, secret-free per-capability lifecycle, per-request evidence
+         *     summaries, and aggregate telemetry for Workflow Detail — never capability
+         *     tokens or ContextPack bodies. Requires ownership of the bridge's workflow.
+         */
+        get: operations["bridge_follow_up_retrieval_diagnostics_retrieval_bridge_sessions__bridge_session_id__follow_up_retrieval_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/retrieval/capabilities/{capability_id}/results/{tool_call_id}": {
         parameters: {
             query?: never;
@@ -5858,6 +5882,10 @@ export interface components {
             idempotencyKey: string;
             /** Maxbudgetusd */
             maxBudgetUsd?: number | null;
+            /** Followupretrieval */
+            followUpRetrieval?: {
+                [key: string]: unknown;
+            } | null;
         };
         /** CheckpointBranchCreateRequest */
         CheckpointBranchCreateRequest: {
@@ -5888,6 +5916,10 @@ export interface components {
             gitWorkBranch?: string | null;
             /** Maxbudgetusd */
             maxBudgetUsd?: number | null;
+            /** Followupretrieval */
+            followUpRetrieval?: {
+                [key: string]: unknown;
+            } | null;
         };
         /** CheckpointBranchForkRequest */
         CheckpointBranchForkRequest: {
@@ -5910,6 +5942,10 @@ export interface components {
             idempotencyKey: string;
             /** Maxbudgetusd */
             maxBudgetUsd?: number | null;
+            /** Followupretrieval */
+            followUpRetrieval?: {
+                [key: string]: unknown;
+            } | null;
             /** Parentturnid */
             parentTurnId?: string | null;
         };
@@ -14301,6 +14337,39 @@ export interface operations {
             header?: never;
             path: {
                 capability_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    bridge_follow_up_retrieval_diagnostics_retrieval_bridge_sessions__bridge_session_id__follow_up_retrieval_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                bridge_session_id: string;
             };
             cookie?: never;
         };

--- a/frontend/src/lib/contextRetrievalAuthoring.test.ts
+++ b/frontend/src/lib/contextRetrievalAuthoring.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  DEFAULT_RETRIEVAL_CEILINGS,
+  RetrievalCeilings,
+  applyBudgetPreset,
+  clampFollowUpRetrieval,
+  compileContextRetrievalParameters,
+  defaultContextRetrievalAuthoring,
+  explainRetrievalDenials,
+  hasAuthoredContextRetrieval,
+  parseContextRetrievalParameters,
+} from './contextRetrievalAuthoring';
+
+const NARROW_CEILINGS: RetrievalCeilings = {
+  ...DEFAULT_RETRIEVAL_CEILINGS,
+  collections: ['repo'],
+  topK: { min: 1, max: 10, default: 8 },
+  allowStaleOverlay: false,
+  allowFallback: false,
+};
+
+describe('contextRetrievalAuthoring', () => {
+  it('defaults follow-up retrieval to disabled (authority boundary opt-in)', () => {
+    const value = defaultContextRetrievalAuthoring();
+    expect(value.followUp.enabled).toBe(false);
+    expect(hasAuthoredContextRetrieval(value)).toBe(false);
+    expect(compileContextRetrievalParameters(value)).toEqual({});
+  });
+
+  it('applies budget presets and marks custom edits', () => {
+    let followUp = defaultContextRetrievalAuthoring().followUp;
+    followUp = applyBudgetPreset(followUp, 'generous');
+    expect(followUp.budgetPreset).toBe('generous');
+    expect(followUp.topK).toBe(16);
+    followUp = applyBudgetPreset(followUp, 'custom');
+    expect(followUp.budgetPreset).toBe('custom');
+    // custom keeps the previous numbers
+    expect(followUp.topK).toBe(16);
+  });
+
+  it('clamps authored budgets and collections within ceilings', () => {
+    const value = defaultContextRetrievalAuthoring();
+    value.followUp.enabled = true;
+    value.followUp.collections = ['repo', 'secret', 'repo'];
+    value.followUp.topK = 999;
+    value.followUp.staleOverlayAllowed = true;
+    value.followUp.fallbackAllowed = true;
+    const clamped = clampFollowUpRetrieval(value.followUp, NARROW_CEILINGS);
+    expect(clamped.collections).toEqual(['repo']);
+    expect(clamped.topK).toBe(10);
+    expect(clamped.staleOverlayAllowed).toBe(false);
+    expect(clamped.fallbackAllowed).toBe(false);
+  });
+
+  it('compiles rag and followUpRetrieval fragments', () => {
+    const value = defaultContextRetrievalAuthoring();
+    value.initial.collections = ['repo', 'docs'];
+    value.initial.allowStale = true;
+    value.followUp.enabled = true;
+    value.followUp.collections = ['repo'];
+    value.followUp.topK = 6;
+    const compiled = compileContextRetrievalParameters(value);
+    expect(compiled.rag).toEqual({ collections: ['repo', 'docs'], allowStale: true });
+    expect(compiled.followUpRetrieval).toMatchObject({
+      enabled: true,
+      collections: ['repo'],
+      topK: 6,
+    });
+  });
+
+  it('does not emit followUpRetrieval when disabled', () => {
+    const value = defaultContextRetrievalAuthoring();
+    value.initial.required = true;
+    const compiled = compileContextRetrievalParameters(value);
+    expect(compiled.followUpRetrieval).toBeUndefined();
+    expect(compiled.rag).toEqual({ required: true });
+  });
+
+  it('explains denied combinations for the operator', () => {
+    const value = defaultContextRetrievalAuthoring();
+    value.followUp.enabled = true;
+    value.followUp.collections = [];
+    const denials = explainRetrievalDenials(value);
+    expect(denials.some((d) => d.includes('no collections'))).toBe(true);
+
+    value.followUp.collections = ['secret'];
+    value.followUp.staleOverlayAllowed = true;
+    const narrow = explainRetrievalDenials(value, NARROW_CEILINGS);
+    expect(narrow.some((d) => d.includes('secret'))).toBe(true);
+    expect(narrow.some((d) => d.toLowerCase().includes('stale overlay'))).toBe(true);
+  });
+
+  it('flags required-but-disabled follow-up retrieval', () => {
+    const value = defaultContextRetrievalAuthoring();
+    value.followUp.enabled = false;
+    value.followUp.required = true;
+    const denials = explainRetrievalDenials(value);
+    expect(denials.some((d) => d.includes('required but disabled'))).toBe(true);
+  });
+
+  it('round-trips through parse/compile', () => {
+    const value = defaultContextRetrievalAuthoring();
+    value.initial.collections = ['docs'];
+    value.followUp.enabled = true;
+    value.followUp.collections = ['repo'];
+    value.followUp.budgetPreset = 'generous';
+    value.followUp.topK = 16;
+    value.followUp.maxContextTokens = 16384;
+    value.followUp.maxQueries = 24;
+    value.followUp.latencyMs = 8000;
+    const compiled = compileContextRetrievalParameters(value);
+    const restored = parseContextRetrievalParameters(
+      compiled as Record<string, unknown>,
+    );
+    expect(restored.initial.collections).toEqual(['docs']);
+    expect(restored.followUp.enabled).toBe(true);
+    expect(restored.followUp.collections).toEqual(['repo']);
+    // preset detected from the numeric budget
+    expect(restored.followUp.budgetPreset).toBe('generous');
+  });
+});

--- a/frontend/src/lib/contextRetrievalAuthoring.test.ts
+++ b/frontend/src/lib/contextRetrievalAuthoring.test.ts
@@ -53,6 +53,18 @@ describe('contextRetrievalAuthoring', () => {
     expect(clamped.fallbackAllowed).toBe(false);
   });
 
+  it('caps maxQueries at the backend contract ceiling (100)', () => {
+    // The backend `RetrievalCapabilityIssue.max_queries` is le=100; the UI
+    // ceiling must match so 101-120 is not accepted only to fail issuance.
+    expect(DEFAULT_RETRIEVAL_CEILINGS.maxQueries.max).toBe(100);
+    const value = defaultContextRetrievalAuthoring();
+    value.followUp.enabled = true;
+    value.followUp.collections = ['repo'];
+    value.followUp.maxQueries = 120;
+    const compiled = compileContextRetrievalParameters(value);
+    expect(compiled.followUpRetrieval).toMatchObject({ maxQueries: 100 });
+  });
+
   it('compiles rag and followUpRetrieval fragments', () => {
     const value = defaultContextRetrievalAuthoring();
     value.initial.collections = ['repo', 'docs'];

--- a/frontend/src/lib/contextRetrievalAuthoring.test.ts
+++ b/frontend/src/lib/contextRetrievalAuthoring.test.ts
@@ -10,6 +10,7 @@ import {
   explainRetrievalDenials,
   hasAuthoredContextRetrieval,
   parseContextRetrievalParameters,
+  retrievalCeilingsFromRuntimeConfig,
 } from './contextRetrievalAuthoring';
 
 const NARROW_CEILINGS: RetrievalCeilings = {
@@ -21,6 +22,16 @@ const NARROW_CEILINGS: RetrievalCeilings = {
 };
 
 describe('contextRetrievalAuthoring', () => {
+  it('uses deployment-provided collection and budget ceilings', () => {
+    const ceilings = retrievalCeilingsFromRuntimeConfig({
+      collections: ['knowledge'],
+      maxQueries: 3,
+      latencyMs: 1200,
+    });
+    expect(ceilings.collections).toEqual(['knowledge']);
+    expect(ceilings.maxQueries.max).toBe(3);
+    expect(ceilings.latencyMs.max).toBe(1200);
+  });
   it('defaults follow-up retrieval to disabled (authority boundary opt-in)', () => {
     const value = defaultContextRetrievalAuthoring();
     expect(value.followUp.enabled).toBe(false);

--- a/frontend/src/lib/contextRetrievalAuthoring.ts
+++ b/frontend/src/lib/contextRetrievalAuthoring.ts
@@ -90,6 +90,30 @@ export const DEFAULT_RETRIEVAL_CEILINGS: RetrievalCeilings = {
   allowFallback: true,
 };
 
+/** Convert the server's effective deployment policy into control ceilings. */
+export function retrievalCeilingsFromRuntimeConfig(
+  raw: Record<string, unknown> | null | undefined,
+): RetrievalCeilings {
+  if (!raw) return DEFAULT_RETRIEVAL_CEILINGS;
+  const numeric = (key: string, fallback: NumericCeiling): NumericCeiling => {
+    const value = raw[key];
+    return typeof value === 'number' && Number.isFinite(value)
+      ? { ...fallback, max: Math.min(fallback.max, Math.max(fallback.min, Math.round(value))), default: Math.min(fallback.default, Math.round(value)) }
+      : fallback;
+  };
+  return {
+    ...DEFAULT_RETRIEVAL_CEILINGS,
+    collections: Array.isArray(raw.collections)
+      ? [...new Set(raw.collections.filter((item): item is string => typeof item === 'string' && Boolean(item.trim())).map((item) => item.trim()))]
+      : DEFAULT_RETRIEVAL_CEILINGS.collections,
+    topK: numeric('topK', DEFAULT_RETRIEVAL_CEILINGS.topK),
+    maxContextTokens: numeric('maxContextTokens', DEFAULT_RETRIEVAL_CEILINGS.maxContextTokens),
+    maxQueries: numeric('maxQueries', DEFAULT_RETRIEVAL_CEILINGS.maxQueries),
+    latencyMs: numeric('latencyMs', DEFAULT_RETRIEVAL_CEILINGS.latencyMs),
+    maxLifetimeSeconds: numeric('maxLifetimeSeconds', DEFAULT_RETRIEVAL_CEILINGS.maxLifetimeSeconds),
+  };
+}
+
 interface BudgetPresetValues {
   topK: number;
   maxContextTokens: number;

--- a/frontend/src/lib/contextRetrievalAuthoring.ts
+++ b/frontend/src/lib/contextRetrievalAuthoring.ts
@@ -1,0 +1,384 @@
+// Shared authoring model for MoonMind context retrieval (RAG) controls.
+//
+// Covers GitHub issue MoonLadderStudios/MoonMind#3514 required work item 6:
+// coherent, policy-bounded RAG controls reused across every authoring surface
+// (workflow create/edit/rerun, recurring schedules, Omnigent agent profiles,
+// checkpoint branch turn creation, and remediation authoring).
+//
+// The authored values are compiled into the run's `initial_parameters` as:
+//   - `rag`               → initial ContextPack injection overrides (#3513)
+//   - `followUpRetrieval`  → in-session follow-up retrieval policy (#3514)
+// The server compiles these into an immutable budget snapshot; the retrieval
+// gateway and deployment ceilings clamp any host request. These controls can
+// only NARROW within policy — never broaden it — which the UI makes explicit.
+
+export type OverlayPolicy = 'include' | 'skip';
+
+export type RetrievalBudgetPreset =
+  | 'conservative'
+  | 'balanced'
+  | 'generous'
+  | 'custom';
+
+export interface InitialRetrievalAuthoring {
+  /** Collections searched for the automatic initial ContextPack. */
+  collections: string[];
+  /** Permit a stale overlay for the initial injection. */
+  allowStale: boolean;
+  /** Fail the step if the initial ContextPack cannot be produced. */
+  required: boolean;
+}
+
+export interface FollowUpRetrievalAuthoring {
+  /** Grant the active session an authorized follow-up retrieval capability. */
+  enabled: boolean;
+  /** Treat follow-up retrieval availability as required rather than optional. */
+  required: boolean;
+  /** Collections the session may query (subset of the allowed set). */
+  collections: string[];
+  budgetPreset: RetrievalBudgetPreset;
+  topK: number;
+  maxContextTokens: number;
+  maxQueries: number;
+  latencyMs: number;
+  maxLifetimeSeconds: number;
+  overlayPolicy: OverlayPolicy;
+  staleOverlayAllowed: boolean;
+  fallbackAllowed: boolean;
+}
+
+export interface ContextRetrievalAuthoring {
+  initial: InitialRetrievalAuthoring;
+  followUp: FollowUpRetrievalAuthoring;
+}
+
+export interface NumericCeiling {
+  readonly min: number;
+  readonly max: number;
+  readonly default: number;
+}
+
+export interface RetrievalCeilings {
+  /** Collections an operator may select from. */
+  readonly collections: readonly string[];
+  readonly topK: NumericCeiling;
+  readonly maxContextTokens: NumericCeiling;
+  readonly maxQueries: NumericCeiling;
+  readonly latencyMs: NumericCeiling;
+  readonly maxLifetimeSeconds: NumericCeiling;
+  /** Whether requesting a stale overlay is permitted by policy. */
+  readonly allowStaleOverlay: boolean;
+  /** Whether requesting local-search fallback is permitted by policy. */
+  readonly allowFallback: boolean;
+}
+
+// Contract ceilings mirror the backend request models
+// (`BridgeRetrievalCapabilityIssue` / `RetrievalCapabilityIssue`). The server
+// clamps further against deployment env ceilings; these are the widest values
+// an authoring surface may request.
+export const DEFAULT_RETRIEVAL_CEILINGS: RetrievalCeilings = {
+  collections: ['repo', 'docs'],
+  topK: { min: 1, max: 50, default: 8 },
+  maxContextTokens: { min: 64, max: 65536, default: 8192 },
+  maxQueries: { min: 1, max: 120, default: 12 },
+  latencyMs: { min: 100, max: 30000, default: 5000 },
+  maxLifetimeSeconds: { min: 30, max: 3600, default: 900 },
+  allowStaleOverlay: true,
+  allowFallback: true,
+};
+
+interface BudgetPresetValues {
+  topK: number;
+  maxContextTokens: number;
+  maxQueries: number;
+  latencyMs: number;
+}
+
+export const RETRIEVAL_BUDGET_PRESETS: Record<
+  Exclude<RetrievalBudgetPreset, 'custom'>,
+  BudgetPresetValues
+> = {
+  conservative: { topK: 4, maxContextTokens: 2048, maxQueries: 4, latencyMs: 3000 },
+  balanced: { topK: 8, maxContextTokens: 8192, maxQueries: 12, latencyMs: 5000 },
+  generous: { topK: 16, maxContextTokens: 16384, maxQueries: 24, latencyMs: 8000 },
+};
+
+function clampNumber(value: number, ceiling: NumericCeiling): number {
+  if (!Number.isFinite(value)) {
+    return ceiling.default;
+  }
+  return Math.min(Math.max(Math.round(value), ceiling.min), ceiling.max);
+}
+
+export function defaultFollowUpRetrievalAuthoring(): FollowUpRetrievalAuthoring {
+  const preset = RETRIEVAL_BUDGET_PRESETS.balanced;
+  return {
+    enabled: false,
+    required: false,
+    collections: [],
+    budgetPreset: 'balanced',
+    topK: preset.topK,
+    maxContextTokens: preset.maxContextTokens,
+    maxQueries: preset.maxQueries,
+    latencyMs: preset.latencyMs,
+    maxLifetimeSeconds: DEFAULT_RETRIEVAL_CEILINGS.maxLifetimeSeconds.default,
+    overlayPolicy: 'include',
+    staleOverlayAllowed: false,
+    fallbackAllowed: false,
+  };
+}
+
+export function defaultContextRetrievalAuthoring(): ContextRetrievalAuthoring {
+  return {
+    initial: { collections: [], allowStale: false, required: false },
+    followUp: defaultFollowUpRetrievalAuthoring(),
+  };
+}
+
+/** Apply a budget preset, leaving `custom` untouched. */
+export function applyBudgetPreset(
+  value: FollowUpRetrievalAuthoring,
+  preset: RetrievalBudgetPreset,
+): FollowUpRetrievalAuthoring {
+  if (preset === 'custom') {
+    return { ...value, budgetPreset: 'custom' };
+  }
+  const values = RETRIEVAL_BUDGET_PRESETS[preset];
+  return { ...value, budgetPreset: preset, ...values };
+}
+
+/** Clamp authored numeric budgets and collections within the policy ceilings. */
+export function clampFollowUpRetrieval(
+  value: FollowUpRetrievalAuthoring,
+  ceilings: RetrievalCeilings = DEFAULT_RETRIEVAL_CEILINGS,
+): FollowUpRetrievalAuthoring {
+  const allowed = new Set(ceilings.collections);
+  return {
+    ...value,
+    collections: uniqueStrings(value.collections).filter((c) => allowed.has(c)),
+    topK: clampNumber(value.topK, ceilings.topK),
+    maxContextTokens: clampNumber(value.maxContextTokens, ceilings.maxContextTokens),
+    maxQueries: clampNumber(value.maxQueries, ceilings.maxQueries),
+    latencyMs: clampNumber(value.latencyMs, ceilings.latencyMs),
+    maxLifetimeSeconds: clampNumber(
+      value.maxLifetimeSeconds,
+      ceilings.maxLifetimeSeconds,
+    ),
+    staleOverlayAllowed: value.staleOverlayAllowed && ceilings.allowStaleOverlay,
+    fallbackAllowed: value.fallbackAllowed && ceilings.allowFallback,
+  };
+}
+
+/**
+ * Explain authored combinations the policy will reject or silently narrow, so
+ * the UI can surface actionable adaptation paths instead of a silent failure.
+ */
+export function explainRetrievalDenials(
+  value: ContextRetrievalAuthoring,
+  ceilings: RetrievalCeilings = DEFAULT_RETRIEVAL_CEILINGS,
+): string[] {
+  const denials: string[] = [];
+  const allowed = new Set(ceilings.collections);
+
+  for (const collection of value.initial.collections) {
+    if (!allowed.has(collection)) {
+      denials.push(
+        `Initial collection “${collection}” is not in the allowed set (${
+          [...allowed].join(', ') || 'none'
+        }).`,
+      );
+    }
+  }
+
+  const followUp = value.followUp;
+  if (!followUp.enabled) {
+    if (followUp.required) {
+      denials.push(
+        'Follow-up retrieval is marked required but disabled; enable it or clear “required”.',
+      );
+    }
+    return denials;
+  }
+
+  if (followUp.collections.length === 0) {
+    denials.push(
+      'Follow-up retrieval is enabled but no collections are selected; the session cannot query.',
+    );
+  }
+  for (const collection of followUp.collections) {
+    if (!allowed.has(collection)) {
+      denials.push(
+        `Follow-up collection “${collection}” is not in the allowed set (${
+          [...allowed].join(', ') || 'none'
+        }).`,
+      );
+    }
+  }
+  const numericChecks: Array<[string, number, NumericCeiling]> = [
+    ['top_k', followUp.topK, ceilings.topK],
+    ['max context tokens', followUp.maxContextTokens, ceilings.maxContextTokens],
+    ['max queries', followUp.maxQueries, ceilings.maxQueries],
+    ['latency budget (ms)', followUp.latencyMs, ceilings.latencyMs],
+    ['capability lifetime (s)', followUp.maxLifetimeSeconds, ceilings.maxLifetimeSeconds],
+  ];
+  for (const [label, current, ceiling] of numericChecks) {
+    if (current > ceiling.max) {
+      denials.push(
+        `Follow-up ${label} ${current} exceeds the policy ceiling ${ceiling.max}; it will be clamped.`,
+      );
+    }
+  }
+  if (followUp.staleOverlayAllowed && !ceilings.allowStaleOverlay) {
+    denials.push(
+      'Stale overlay is not permitted by policy; the request will use a fresh overlay.',
+    );
+  }
+  if (followUp.fallbackAllowed && !ceilings.allowFallback) {
+    denials.push(
+      'Local-search fallback is not permitted by policy; a fallback request will be denied.',
+    );
+  }
+  return denials;
+}
+
+/** True when the authored config carries anything worth persisting. */
+export function hasAuthoredContextRetrieval(
+  value: ContextRetrievalAuthoring,
+): boolean {
+  return (
+    value.followUp.enabled ||
+    value.initial.collections.length > 0 ||
+    value.initial.allowStale ||
+    value.initial.required
+  );
+}
+
+export interface CompiledContextRetrievalParameters {
+  rag?: Record<string, unknown>;
+  followUpRetrieval?: Record<string, unknown>;
+}
+
+/**
+ * Compile authored controls into the `initial_parameters` fragment consumed by
+ * the run. Numeric values are clamped to the policy ceilings so the persisted
+ * request never broadens policy; the server re-clamps regardless.
+ */
+export function compileContextRetrievalParameters(
+  value: ContextRetrievalAuthoring,
+  ceilings: RetrievalCeilings = DEFAULT_RETRIEVAL_CEILINGS,
+): CompiledContextRetrievalParameters {
+  const compiled: CompiledContextRetrievalParameters = {};
+  const allowed = new Set(ceilings.collections);
+
+  const initialCollections = uniqueStrings(value.initial.collections).filter((c) =>
+    allowed.has(c),
+  );
+  if (initialCollections.length > 0 || value.initial.allowStale || value.initial.required) {
+    compiled.rag = {
+      ...(initialCollections.length > 0 ? { collections: initialCollections } : {}),
+      ...(value.initial.allowStale ? { allowStale: true } : {}),
+      ...(value.initial.required ? { required: true } : {}),
+    };
+  }
+
+  if (value.followUp.enabled) {
+    const followUp = clampFollowUpRetrieval(value.followUp, ceilings);
+    compiled.followUpRetrieval = {
+      enabled: true,
+      required: followUp.required,
+      collections: followUp.collections,
+      topK: followUp.topK,
+      maxContextTokens: followUp.maxContextTokens,
+      maxQueries: followUp.maxQueries,
+      latencyMs: followUp.latencyMs,
+      maxLifetimeSeconds: followUp.maxLifetimeSeconds,
+      overlayPolicy: followUp.overlayPolicy,
+      staleOverlayAllowed: followUp.staleOverlayAllowed,
+      fallbackAllowed: followUp.fallbackAllowed,
+    };
+  }
+
+  return compiled;
+}
+
+/** Hydrate authoring state from a previously compiled `initial_parameters`. */
+export function parseContextRetrievalParameters(
+  parameters: Record<string, unknown> | null | undefined,
+): ContextRetrievalAuthoring {
+  const result = defaultContextRetrievalAuthoring();
+  if (!parameters || typeof parameters !== 'object') {
+    return result;
+  }
+
+  const rag = asRecord(parameters.rag);
+  if (rag) {
+    result.initial.collections = uniqueStrings(asStringArray(rag.collections));
+    result.initial.allowStale = rag.allowStale === true;
+    result.initial.required = rag.required === true;
+  }
+
+  const followUp = asRecord(parameters.followUpRetrieval);
+  if (followUp) {
+    const base = defaultFollowUpRetrievalAuthoring();
+    result.followUp = {
+      ...base,
+      enabled: followUp.enabled === true,
+      required: followUp.required === true,
+      collections: uniqueStrings(asStringArray(followUp.collections)),
+      topK: asNumber(followUp.topK, base.topK),
+      maxContextTokens: asNumber(followUp.maxContextTokens, base.maxContextTokens),
+      maxQueries: asNumber(followUp.maxQueries, base.maxQueries),
+      latencyMs: asNumber(followUp.latencyMs, base.latencyMs),
+      maxLifetimeSeconds: asNumber(followUp.maxLifetimeSeconds, base.maxLifetimeSeconds),
+      overlayPolicy: followUp.overlayPolicy === 'skip' ? 'skip' : 'include',
+      staleOverlayAllowed: followUp.staleOverlayAllowed === true,
+      fallbackAllowed: followUp.fallbackAllowed === true,
+      budgetPreset: 'custom',
+    };
+    result.followUp.budgetPreset = detectBudgetPreset(result.followUp);
+  }
+
+  return result;
+}
+
+function detectBudgetPreset(value: FollowUpRetrievalAuthoring): RetrievalBudgetPreset {
+  for (const [name, preset] of Object.entries(RETRIEVAL_BUDGET_PRESETS)) {
+    if (
+      value.topK === preset.topK &&
+      value.maxContextTokens === preset.maxContextTokens &&
+      value.maxQueries === preset.maxQueries &&
+      value.latencyMs === preset.latencyMs
+    ) {
+      return name as RetrievalBudgetPreset;
+    }
+  }
+  return 'custom';
+}
+
+function uniqueStrings(values: readonly string[]): string[] {
+  const seen = new Set<string>();
+  const output: string[] = [];
+  for (const value of values) {
+    const trimmed = String(value ?? '').trim();
+    if (trimmed && !seen.has(trimmed)) {
+      seen.add(trimmed);
+      output.push(trimmed);
+    }
+  }
+  return output;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function asStringArray(value: unknown): string[] {
+  return Array.isArray(value) ? value.map((item) => String(item)) : [];
+}
+
+function asNumber(value: unknown, fallback: number): number {
+  const parsed = typeof value === 'number' ? value : Number(value);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}

--- a/frontend/src/lib/contextRetrievalAuthoring.ts
+++ b/frontend/src/lib/contextRetrievalAuthoring.ts
@@ -80,7 +80,10 @@ export const DEFAULT_RETRIEVAL_CEILINGS: RetrievalCeilings = {
   collections: ['repo', 'docs'],
   topK: { min: 1, max: 50, default: 8 },
   maxContextTokens: { min: 64, max: 65536, default: 8192 },
-  maxQueries: { min: 1, max: 120, default: 12 },
+  // Backend contract: `RetrievalCapabilityIssue.max_queries` is `le=100`. The
+  // ceiling must match, or an authored 101–120 value passes the UI but fails
+  // capability issuance validation before deployment clamping can narrow it.
+  maxQueries: { min: 1, max: 100, default: 12 },
   latencyMs: { min: 100, max: 30000, default: 5000 },
   maxLifetimeSeconds: { min: 30, max: 3600, default: 900 },
   allowStaleOverlay: true,

--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -9896,3 +9896,27 @@ button.workflow-workspace-sidebar-row:active {
 .omnigent-inventory table { border-collapse: collapse; width: 100%; }
 .omnigent-inventory th,
 .omnigent-inventory td { border-bottom: 1px solid rgb(var(--mm-border)); padding: .75rem; text-align: left; vertical-align: top; }
+
+/* Context retrieval (RAG) authoring controls (MoonMind#3514). */
+.context-retrieval-controls { display: grid; gap: 1rem; }
+.context-retrieval-section {
+  border: 1px solid rgb(var(--mm-border));
+  border-radius: 0.5rem;
+  display: grid;
+  gap: 0.6rem;
+  padding: 0.85rem 1rem;
+}
+.context-retrieval-section legend { font-weight: 600; padding: 0 0.35rem; }
+.context-retrieval-field { display: grid; gap: 0.3rem; }
+.context-retrieval-label { font-weight: 500; }
+.context-retrieval-ceiling-hint { color: rgb(var(--mm-muted)); font-weight: 400; }
+.context-retrieval-collections { display: flex; flex-wrap: wrap; gap: 0.75rem; }
+.context-retrieval-collection { align-items: center; display: inline-flex; gap: 0.35rem; }
+.context-retrieval-ceilings { color: rgb(var(--mm-muted)); }
+.context-retrieval-denials ul { margin: 0.35rem 0 0; padding-left: 1.1rem; }
+.context-retrieval-diagnostics { display: grid; gap: 0.75rem; }
+.context-retrieval-diagnostics .context-retrieval-capability {
+  border: 1px solid rgb(var(--mm-border));
+  border-radius: 0.5rem;
+  padding: 0.6rem 0.8rem;
+}

--- a/memory/MEMORY.md
+++ b/memory/MEMORY.md
@@ -2,3 +2,4 @@
 - [MM-954 workflow-list current-page sort](mm954-workflow-list-current-page-sort.md) — why list sorting is intentionally page-only, not global server-side
 - [Frontend vitest colon-path workaround](frontend-vitest-colon-path-workaround.md) — vitest fails on colon in workspace dir; run from a colon-free copy under /tmp
 - [Omnigent #3507 workspace materialization](omnigent-3507-workspace-materialization.md) — done vs remaining for the normal-workflow workspace path
+- [Omnigent #3514 follow-up retrieval authoring](omnigent-3514-followup-retrieval-authoring.md) — UI→snapshot→gateway flow, tenant default, branch-turn inheritance

--- a/memory/omnigent-3514-followup-retrieval-authoring.md
+++ b/memory/omnigent-3514-followup-retrieval-authoring.md
@@ -1,0 +1,20 @@
+---
+name: omnigent-3514-followup-retrieval-authoring
+description: How #3514 follow-up retrieval authoring flows UI → launch snapshot → gateway, and the tenant/branch decisions
+metadata:
+  type: project
+---
+
+Issue #3514 (Omnigent in-session/follow-up retrieval) split: the server-side gateway/capability/budget/evidence layer (items 1–5) shipped earlier in PR #3552. The remaining authoring controls (item 6) + Workflow Detail diagnostics (item 7) were added on branch `github-issue-implement-moonladderstudios-ed6f9fd0`.
+
+Data flow (non-obvious, no generic passthrough): authored config must be a **payload-level** key `rag` / `followUpRetrieval` on the create request. Two backend hops each use an allowlist:
+1. `api_service/api/routers/executions.py` `_create_execution_from_workflow_request` lifts `payload["rag"|"followUpRetrieval"]` into `initial_parameters` (next to the `omnigent` lift).
+2. `moonmind/workflows/temporal/workflows/run.py` `_build_agent_execution_request` param-key allowlist copies them into `request.parameters`.
+Then `moonmind/omnigent/profile_bound_execution.py` `compile_follow_up_retrieval_policy` compiles `request.parameters["followUpRetrieval"]` into the launch snapshot's top-level `followUpRetrieval` block (before the digest), which the gateway `_bridge_authoritative_issue` reads.
+
+Key decisions:
+- **MoonMind has no tenant concept anywhere** (grep tenant in rag/omnigent/policies = nothing), but the retrieval budget snapshot requires a non-empty `tenant_id`. The coordinator defaults it via `MOONMIND_FOLLOWUP_RETRIEVAL_DEFAULT_TENANT` (fallback `"default"`); otherwise enabling follow-up retrieval would always disable with `incomplete_follow_up_retrieval_scope`.
+- Follow-up retrieval is an **authority boundary → opt-in / disabled by default**.
+- **Checkpoint branch turn** launch uses a specialized `context_payload`, NOT the normal parameters channel, so a branch turn **inherits the parent run's compiled follow-up retrieval policy**. The branch create/continue/fork request models gained an optional `follow_up_retrieval` field (recorded as authored intent, folded into the idempotency digest); full per-turn launch consumption is follow-on.
+
+Shared frontend: `frontend/src/lib/contextRetrievalAuthoring.ts` (compile/clamp/parse/denials) + `frontend/src/components/ContextRetrievalControls.tsx`, wired into workflow-start, schedules edit, omnigent policy editor, and the branch panel. Diagnostics: `GET /retrieval/bridge-sessions/{id}/follow-up-retrieval` (registry `summarize_bridge_session`) rendered in workflow-detail. Related: [[omnigent-3507-workspace-materialization]].

--- a/moonmind/omnigent/profile_bound_execution.py
+++ b/moonmind/omnigent/profile_bound_execution.py
@@ -322,18 +322,56 @@ def compile_follow_up_retrieval_policy(
         if coerced is not None:
             block[field] = coerced
 
-    # Fold deployment policy budgets into the block when the author did not set a
-    # tighter value, so ``boundaries.rag`` authority actually reaches the gateway.
-    if "latencyMs" not in block:
-        policy_latency = _coerce_positive_int(rag.get("latencyBudgetMs"))
-        if policy_latency is not None:
-            block["latencyMs"] = policy_latency
-    if "maxContextTokens" not in block:
-        policy_tokens = _coerce_positive_int(rag.get("tokenBudget"))
-        if policy_tokens is not None:
-            block["maxContextTokens"] = policy_tokens
+    # Clamp the policy-backed budgets to ``boundaries.rag`` so an authored run
+    # override can only ever narrow deployment policy, never broaden it. When the
+    # author omitted the field the policy value becomes the ceiling; when both are
+    # present the tighter (minimum) value wins. The gateway clamps host requests
+    # against deployment *environment* limits, not the selected policy, so the
+    # selected-policy ceiling must be folded in here or a run could receive a
+    # larger retrieval budget than its policy authorizes.
+    for block_field, policy_key in (
+        ("latencyMs", "latencyBudgetMs"),
+        ("maxContextTokens", "tokenBudget"),
+    ):
+        policy_value = _coerce_positive_int(rag.get(policy_key))
+        if policy_value is None:
+            continue
+        authored_value = block.get(block_field)
+        block[block_field] = (
+            min(authored_value, policy_value)
+            if isinstance(authored_value, int)
+            else policy_value
+        )
 
     return block
+
+
+def enforce_required_follow_up_retrieval(
+    authored_follow_up: Mapping[str, Any] | None,
+    compiled_block: Mapping[str, Any],
+) -> None:
+    """Fail the launch when required follow-up retrieval cannot be made available.
+
+    Follow-up retrieval is an authority boundary. When an operator explicitly
+    enables it with ``required: true`` the advertised guarantee must hold: if the
+    compiled capability is unavailable (for example an incomplete, unresolvable
+    scope), the step must block instead of silently launching with retrieval
+    disabled. Optional retrieval (``required`` unset/false) degrades quietly.
+    """
+
+    if not isinstance(authored_follow_up, Mapping):
+        return
+    if authored_follow_up.get("enabled") is not True:
+        return
+    if not bool(authored_follow_up.get("required")):
+        return
+    if compiled_block.get("enabled") is True:
+        return
+    reason = str(compiled_block.get("reason") or "follow_up_retrieval_unavailable")
+    raise OmnigentOAuthHostError(
+        f"required follow-up retrieval is unavailable: {reason}",
+        code="OMNIGENT_REQUIRED_FOLLOW_UP_RETRIEVAL_UNAVAILABLE",
+    )
 
 
 def _compile_persisted_effective_launch(
@@ -635,15 +673,17 @@ class OmnigentProfileBoundExecutionCoordinator:
                 or launch_parameters.get("tenantId")
                 or os.getenv("MOONMIND_FOLLOWUP_RETRIEVAL_DEFAULT_TENANT", "default")
             ).strip()
+            follow_up_block = compile_follow_up_retrieval_policy(
+                policy_snapshot,
+                launch_parameters,
+                repository=follow_up_repository,
+                tenant_id=follow_up_tenant,
+            )
+            enforce_required_follow_up_retrieval(authored_follow_up, follow_up_block)
             effective_launch = _compile_persisted_effective_launch(
                 policy_snapshot,
                 provider_profile_id=profile_id,
-                follow_up_retrieval=compile_follow_up_retrieval_policy(
-                    policy_snapshot,
-                    launch_parameters,
-                    repository=follow_up_repository,
-                    tenant_id=follow_up_tenant,
-                ),
+                follow_up_retrieval=follow_up_block,
             )
             if (
                 self._repository_mutation_required(request)

--- a/moonmind/omnigent/profile_bound_execution.py
+++ b/moonmind/omnigent/profile_bound_execution.py
@@ -204,10 +204,143 @@ def _bind_candidate_workspace(
     )
 
 
+# Optional positive-integer ceilings an authoring surface may narrow. The
+# retrieval gateway (``_bridge_authoritative_issue``) and the deployment budget
+# snapshot (``_server_policy_snapshot``) clamp any host request against these at
+# issue time, so the compiled block is an *authored* per-run ceiling and can
+# never broaden deployment policy.
+_FOLLOW_UP_RETRIEVAL_INT_FIELDS: tuple[str, ...] = (
+    "topK",
+    "maxSources",
+    "maxQueryBytes",
+    "maxContextBytes",
+    "maxContextTokens",
+    "maxQueries",
+    "latencyMs",
+    "maxConcurrency",
+    "maxRequestsPerMinute",
+    "embeddingTimeoutMs",
+    "searchTimeoutMs",
+    "overlayMaxAgeSeconds",
+    "retentionDays",
+    "maxLifetimeSeconds",
+)
+
+
+def _coerce_positive_int(value: Any) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value if value > 0 else None
+    if isinstance(value, str) and value.strip().isdigit():
+        parsed = int(value.strip())
+        return parsed if parsed > 0 else None
+    return None
+
+
+def compile_follow_up_retrieval_policy(
+    policy_snapshot: Mapping[str, Any],
+    parameters: Mapping[str, Any] | None,
+    *,
+    repository: str,
+    tenant_id: str,
+) -> dict[str, Any]:
+    """Compile the runtime ``followUpRetrieval`` block carried by the launch snapshot.
+
+    In-session (follow-up) retrieval grants the host an authorized capability, so
+    it is an authority boundary and stays disabled unless an authoring surface
+    explicitly enables it via ``parameters["followUpRetrieval"]``. Deployment
+    policy (``boundaries.rag``) supplies the default budgets; the gateway and the
+    server budget snapshot enforce the deployment ceilings, so this block is only
+    the authored per-run ceiling and never a broadening of policy.
+    """
+
+    authored: dict[str, Any] = {}
+    if isinstance(parameters, Mapping):
+        raw = parameters.get("followUpRetrieval")
+        if isinstance(raw, Mapping):
+            authored = dict(raw)
+    if authored.get("enabled") is not True:
+        return {"enabled": False}
+
+    rag: dict[str, Any] = {}
+    boundaries = (
+        policy_snapshot.get("boundaries")
+        if isinstance(policy_snapshot, Mapping)
+        else None
+    )
+    if isinstance(boundaries, Mapping) and isinstance(boundaries.get("rag"), Mapping):
+        rag = dict(boundaries["rag"])
+
+    collections = list(
+        dict.fromkeys(
+            str(item).strip()
+            for item in authored.get("collections", ())
+            if str(item).strip()
+        )
+    )
+    repository = str(repository or "").strip()
+    tenant_id = str(tenant_id or "").strip()
+    policy_version = (
+        str(policy_snapshot.get("policyRef") or "").strip()
+        if isinstance(policy_snapshot, Mapping)
+        else ""
+    )
+
+    if not (repository and tenant_id and policy_version and collections):
+        # Enabling without a resolvable scope would only yield an auditable 409
+        # from the gateway; keep the capability unavailable with an explicit,
+        # non-fatal reason instead of persisting a broken authority block.
+        return {"enabled": False, "reason": "incomplete_follow_up_retrieval_scope"}
+
+    block: dict[str, Any] = {
+        "enabled": True,
+        "required": bool(authored.get("required", False)),
+        "repository": repository,
+        "tenantId": tenant_id,
+        "policyVersion": policy_version,
+        "collections": collections,
+        "overlayPolicy": (
+            "skip" if str(authored.get("overlayPolicy")) == "skip" else "include"
+        ),
+        "staleOverlayAllowed": bool(authored.get("staleOverlayAllowed", False)),
+        "fallbackAllowed": bool(authored.get("fallbackAllowed", False)),
+    }
+
+    filters = authored.get("filters")
+    if isinstance(filters, Mapping):
+        compiled_filters = {
+            str(key): str(value)
+            for key, value in filters.items()
+            if str(key).strip() and str(value).strip()
+        }
+        if compiled_filters:
+            block["filters"] = compiled_filters
+
+    for field in _FOLLOW_UP_RETRIEVAL_INT_FIELDS:
+        coerced = _coerce_positive_int(authored.get(field))
+        if coerced is not None:
+            block[field] = coerced
+
+    # Fold deployment policy budgets into the block when the author did not set a
+    # tighter value, so ``boundaries.rag`` authority actually reaches the gateway.
+    if "latencyMs" not in block:
+        policy_latency = _coerce_positive_int(rag.get("latencyBudgetMs"))
+        if policy_latency is not None:
+            block["latencyMs"] = policy_latency
+    if "maxContextTokens" not in block:
+        policy_tokens = _coerce_positive_int(rag.get("tokenBudget"))
+        if policy_tokens is not None:
+            block["maxContextTokens"] = policy_tokens
+
+    return block
+
+
 def _compile_persisted_effective_launch(
     policy_snapshot: Mapping[str, Any],
     *,
     provider_profile_id: str,
+    follow_up_retrieval: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Compile the sole launch carrier from persisted immutable authority."""
 
@@ -265,6 +398,14 @@ def _compile_persisted_effective_launch(
         "boundaries": dict(boundaries),
         "policyAuthority": dict(policy_snapshot),
     }
+    # The retrieval gateway reads follow-up (in-session) retrieval authority from
+    # this top-level block. It must be inside the digest so a mutated capability
+    # policy is rejected by ``validate_effective_launch_snapshot``.
+    payload["followUpRetrieval"] = (
+        dict(follow_up_retrieval)
+        if isinstance(follow_up_retrieval, Mapping)
+        else {"enabled": False}
+    )
     canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"))
     payload["snapshotRef"] = "omnigent-launch:sha256:" + hashlib.sha256(
         canonical.encode()
@@ -464,9 +605,45 @@ class OmnigentProfileBoundExecutionCoordinator:
                     "persisted policy execution profile conflicts with launch selection",
                     code="OMNIGENT_LAUNCH_POLICY_BINDING_CONFLICT",
                 )
+            launch_parameters = (
+                request.parameters if isinstance(request.parameters, dict) else {}
+            )
+            launch_workspace_spec = (
+                request.workspace_spec
+                if isinstance(request.workspace_spec, dict)
+                else {}
+            )
+            authored_follow_up = (
+                launch_parameters.get("followUpRetrieval")
+                if isinstance(launch_parameters.get("followUpRetrieval"), dict)
+                else {}
+            )
+            follow_up_repository = str(
+                authored_follow_up.get("repository")
+                or launch_parameters.get("repository")
+                or launch_workspace_spec.get("repository")
+                or ""
+            ).strip()
+            # MoonMind has no separate tenancy authority today (single-tenant by
+            # default), so fall back to a deployment-configurable tenant rather
+            # than leaving follow-up retrieval permanently unavailable once an
+            # operator opts in. Multi-tenant deployments author an explicit
+            # tenantId, which always takes precedence.
+            follow_up_tenant = str(
+                authored_follow_up.get("tenantId")
+                or launch_parameters.get("tenant")
+                or launch_parameters.get("tenantId")
+                or os.getenv("MOONMIND_FOLLOWUP_RETRIEVAL_DEFAULT_TENANT", "default")
+            ).strip()
             effective_launch = _compile_persisted_effective_launch(
                 policy_snapshot,
                 provider_profile_id=profile_id,
+                follow_up_retrieval=compile_follow_up_retrieval_policy(
+                    policy_snapshot,
+                    launch_parameters,
+                    repository=follow_up_repository,
+                    tenant_id=follow_up_tenant,
+                ),
             )
             if (
                 self._repository_mutation_required(request)

--- a/moonmind/schemas/checkpoint_branch_models.py
+++ b/moonmind/schemas/checkpoint_branch_models.py
@@ -113,6 +113,13 @@ class CheckpointBranchCreateRequest(BaseModel):
     )
     git_work_branch: str | None = Field(None, alias="gitWorkBranch", max_length=255)
     max_budget_usd: float | None = Field(None, alias="maxBudgetUsd", ge=0)
+    # Authored in-session follow-up retrieval override for the branch turn
+    # (MoonMind#3514). Recorded as bounded authored intent and folded into the
+    # branch operation idempotency digest; enforcement inherits the parent run's
+    # compiled policy unless a narrower override is materialized at launch.
+    follow_up_retrieval: dict[str, Any] | None = Field(
+        None, alias="followUpRetrieval"
+    )
 
 
 class CheckpointBranchContinueRequest(BaseModel):
@@ -130,6 +137,10 @@ class CheckpointBranchContinueRequest(BaseModel):
         ..., alias="idempotencyKey", min_length=1, max_length=512
     )
     max_budget_usd: float | None = Field(None, alias="maxBudgetUsd", ge=0)
+    # See CheckpointBranchCreateRequest.follow_up_retrieval (MoonMind#3514).
+    follow_up_retrieval: dict[str, Any] | None = Field(
+        None, alias="followUpRetrieval"
+    )
 
 
 class CheckpointBranchForkRequest(CheckpointBranchContinueRequest):

--- a/moonmind/workflows/checkpoint_branches.py
+++ b/moonmind/workflows/checkpoint_branches.py
@@ -274,6 +274,9 @@ def build_checkpoint_branch_turn_context_bundle(
         "boundedSummaries": list(raw_context.get("boundedSummaries") or []),
         "builderMetadata": dict(builder_metadata),
     }
+    follow_up_retrieval = raw_context.get("followUpRetrieval")
+    if isinstance(follow_up_retrieval, Mapping):
+        bundle["followUpRetrieval"] = dict(follow_up_retrieval)
     _reject_forbidden_context_content(bundle)
     return bundle
 

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -18112,6 +18112,14 @@ class MoonMindRunWorkflow:
             "story_breakdown_path",
             "storyBreakdownMarkdownPath",
             "story_breakdown_markdown_path",
+            # Context retrieval (RAG) authoring surfaces (#3514): initial
+            # ContextPack overrides and in-session follow-up retrieval policy,
+            # plus the repository/tenant scope the retrieval budget binds to.
+            "rag",
+            "followUpRetrieval",
+            "repository",
+            "tenant",
+            "tenantId",
         ):
             param_val = runtime_block.get(param_key)
             if param_val is None:

--- a/tests/integration/reliability/test_deployment_update_replay.py
+++ b/tests/integration/reliability/test_deployment_update_replay.py
@@ -20,7 +20,6 @@ from tests.integration.reliability.helpers import load_replay
 
 pytestmark = [
     pytest.mark.integration,
-    pytest.mark.integration_ci,
     pytest.mark.reliability_journey,
 ]
 
@@ -184,7 +183,7 @@ async def test_deployment_update_reconciles_non_image_infrastructure(
     requested_repository = manifest["requestedRepository"]
     requested_image = f"{requested_repository}:latest"
     real_docker = shutil.which("docker")
-    assert real_docker is not None, "integration_ci image must provide Docker Compose"
+    assert real_docker is not None, "reliability journey image must provide Docker Compose"
 
     compose_path = tmp_path / "docker-compose.yaml"
     compose_path.write_text(

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -3974,6 +3974,66 @@ def test_create_task_shaped_execution_rejects_explicit_skill_step_without_skill_
     service.create_execution.assert_not_awaited()
 
 
+def test_create_execution_lifts_context_retrieval_authoring(
+    client: tuple[TestClient, AsyncMock, SimpleNamespace],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """MoonMind#3514: payload-level rag / followUpRetrieval reach initial parameters."""
+    test_client, service, _user = client
+    service.create_execution.return_value = _build_execution_record()
+
+    async def _identity_validate_skill_step_inputs(*, initial_parameters, **_kwargs):
+        return SimpleNamespace(
+            valid=True,
+            parameters=initial_parameters,
+            error_dicts=lambda: [],
+        )
+
+    monkeypatch.setattr(
+        "api_service.api.routers.executions.validate_skill_step_inputs",
+        _identity_validate_skill_step_inputs,
+    )
+
+    response = test_client.post(
+        "/api/executions",
+        json={
+            "type": "workflow",
+            "payload": {
+                "rag": {"collections": ["docs"], "allowStale": True},
+                "followUpRetrieval": {
+                    "enabled": True,
+                    "collections": ["repo", "docs"],
+                    "topK": 6,
+                },
+                "workflow": {
+                    "instructions": "Run with context retrieval authoring.",
+                    "steps": [
+                        {
+                            "id": "step-1",
+                            "title": "Step",
+                            "type": "skill",
+                            "skill": {
+                                "id": "noop",
+                                "inputs": {},
+                                "inputContractDigest": "sha256:saved",
+                            },
+                        }
+                    ],
+                },
+            },
+        },
+    )
+
+    assert response.status_code == 201, response.text
+    initial_parameters = service.create_execution.await_args.kwargs["initial_parameters"]
+    assert initial_parameters["rag"] == {"collections": ["docs"], "allowStale": True}
+    assert initial_parameters["followUpRetrieval"] == {
+        "enabled": True,
+        "collections": ["repo", "docs"],
+        "topK": 6,
+    }
+
+
 def test_create_task_shaped_execution_normalizes_skill_inputs(
     client: tuple[TestClient, AsyncMock, SimpleNamespace],
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit/api/routers/test_retrieval_gateway.py
+++ b/tests/unit/api/routers/test_retrieval_gateway.py
@@ -1303,6 +1303,43 @@ def test_summarize_bridge_session_aggregates_follow_up_evidence(tmp_path) -> Non
     assert cap["policyVersion"] == "policy-7"
 
 
+def test_summarize_bridge_session_merges_delivery_acknowledgement(tmp_path) -> None:
+    """A delivery ack for a request is folded into it, not counted separately."""
+    registry = RetrievalCapabilityRegistry(tmp_path)
+    _, capability = registry.issue(_session_budget(), lifetime_seconds=60)
+
+    # Original successful retrieval records a provisional delivery_unknown row.
+    _record_evidence(
+        registry,
+        capability,
+        state="succeeded",
+        resultCount=2,
+        correlation={"toolCallId": "tool-ack"},
+        delivery={"state": "delivery_unknown", "toolCallId": "tool-ack"},
+    )
+    # The bridge later acknowledges delivery: a second evidence row for the same
+    # toolCallId. It must project onto the original request, not inflate counts.
+    _record_evidence(
+        registry,
+        capability,
+        state="delivery_updated",
+        classification="delivered",
+        resultCount=0,
+        correlation={"toolCallId": "tool-ack"},
+        delivery={"state": "delivered", "toolCallId": "tool-ack"},
+    )
+
+    summary = registry.summarize_bridge_session("bridge-1")
+    agg = summary["aggregate"]
+    # One logical request, counted once, with the authoritative delivery state.
+    assert agg["requestCount"] == 1
+    assert agg["succeeded"] == 1
+    assert agg["delivered"] == 1
+    assert agg["deliveryUnknown"] == 0
+    # No spurious zero-result request surfaced by the acknowledgement row.
+    assert agg["empty"] == 0
+
+
 def test_summarize_bridge_session_excludes_other_bridge(tmp_path) -> None:
     registry = RetrievalCapabilityRegistry(tmp_path)
     registry.issue(_session_budget(), lifetime_seconds=60)

--- a/tests/unit/api/routers/test_retrieval_gateway.py
+++ b/tests/unit/api/routers/test_retrieval_gateway.py
@@ -15,6 +15,7 @@ from api_service.api.routers.retrieval_gateway import (
     _server_policy_snapshot,
     issue_bridge_retrieval_capability,
     authorize_retrieval_request,
+    bridge_follow_up_retrieval_diagnostics,
     get_retrieval_service,
     revoke_bridge_retrieval_capabilities,
     router,
@@ -1231,3 +1232,131 @@ async def test_bridge_capability_issuance_denied_for_non_owner(tmp_path) -> None
 
     assert denied.value.status_code == 403
     assert denied.value.detail["code"] == "workflow_ownership_denied"
+
+
+def _record_evidence(registry, capability, **evidence) -> None:
+    """Record a bounded evidence summary the way the gateway would."""
+    base = {
+        "state": "succeeded",
+        "correlation": {"toolCallId": "tool-x"},
+        "resultCount": 1,
+        "contextBytes": 100,
+        "latencyMs": 42,
+        "delivery": {"state": "delivery_unknown"},
+        "classification": None,
+        "truncated": False,
+    }
+    base.update(evidence)
+    registry.record(capability, base)
+
+
+def test_summarize_bridge_session_aggregates_follow_up_evidence(tmp_path) -> None:
+    registry = RetrievalCapabilityRegistry(tmp_path)
+    token, capability = registry.issue(_session_budget(), lifetime_seconds=60)
+
+    _record_evidence(registry, capability, state="succeeded", resultCount=3)
+    _record_evidence(
+        registry,
+        capability,
+        state="succeeded",
+        resultCount=0,
+        truncated=True,
+        delivery={"state": "delivered"},
+    )
+    _record_evidence(
+        registry,
+        capability,
+        state="failed",
+        classification="token_budget_exhausted",
+        delivery={"state": "not_delivered"},
+    )
+    _record_evidence(
+        registry,
+        capability,
+        state="succeeded",
+        classification="local_fallback",
+        latencyMs=999,
+        delivery={"state": "timed_out"},
+    )
+
+    summary = registry.summarize_bridge_session("bridge-1")
+
+    assert summary["bridgeSessionId"] == "bridge-1"
+    assert summary["capabilityCount"] == 1
+    agg = summary["aggregate"]
+    assert agg["requestCount"] == 4
+    assert agg["succeeded"] == 3
+    assert agg["failed"] == 1
+    assert agg["empty"] == 1
+    assert agg["truncated"] == 1
+    assert agg["fallback"] == 1
+    assert agg["budgetExhausted"] == 1
+    assert agg["delivered"] == 1
+    assert agg["notDelivered"] == 1
+    assert agg["timedOut"] == 1
+    assert agg["maxLatencyMs"] == 999
+    assert agg["activeCapabilities"] == 1
+    # Capability-level scope/collections are exposed for operator diagnostics.
+    cap = summary["capabilities"][0]
+    assert cap["collections"] == ["repo"]
+    assert cap["scope"]["repository"] == "MoonMind"
+    assert cap["policyVersion"] == "policy-7"
+
+
+def test_summarize_bridge_session_excludes_other_bridge(tmp_path) -> None:
+    registry = RetrievalCapabilityRegistry(tmp_path)
+    registry.issue(_session_budget(), lifetime_seconds=60)
+    registry.issue(
+        _session_budget(bridge_session_id="bridge-2", session_id="session-2"),
+        lifetime_seconds=60,
+    )
+
+    summary = registry.summarize_bridge_session("bridge-1")
+    assert summary["capabilityCount"] == 1
+    assert all(
+        cap["scope"]["repository"] == "MoonMind"
+        for cap in summary["capabilities"]
+    )
+
+
+@pytest.mark.asyncio
+async def test_bridge_follow_up_diagnostics_requires_ownership(tmp_path) -> None:
+    registry = RetrievalCapabilityRegistry(tmp_path)
+    registry.issue(_session_budget(), lifetime_seconds=60)
+
+    class Store:
+        async def get_bridge_session(self, bridge_session_id):
+            return _bridge_row()
+
+    with pytest.raises(HTTPException) as denied:
+        await bridge_follow_up_retrieval_diagnostics(
+            "bridge-1",
+            registry=registry,
+            store=Store(),
+            user=SimpleNamespace(id="intruder"),
+            service=_UnownedExecutionService(),
+        )
+    assert denied.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_bridge_follow_up_diagnostics_returns_projection(tmp_path) -> None:
+    registry = RetrievalCapabilityRegistry(tmp_path)
+    _, capability = registry.issue(_session_budget(), lifetime_seconds=60)
+    _record_evidence(registry, capability, state="succeeded", resultCount=2)
+
+    class Store:
+        async def get_bridge_session(self, bridge_session_id):
+            assert bridge_session_id == "bridge-1"
+            return _bridge_row()
+
+    result = await bridge_follow_up_retrieval_diagnostics(
+        "bridge-1",
+        registry=registry,
+        store=Store(),
+        user=SimpleNamespace(id="user-1"),
+        service=_OwnedExecutionService(),
+    )
+    assert result["capabilityCount"] == 1
+    assert result["aggregate"]["requestCount"] == 1
+    assert result["aggregate"]["succeeded"] == 1

--- a/tests/unit/api/routers/test_workflow_console_view_model.py
+++ b/tests/unit/api/routers/test_workflow_console_view_model.py
@@ -47,6 +47,7 @@ def test_status_maps_returns_copy() -> None:
     assert dashboard_view_model.status_maps()["temporal"]["queued"] == "queued"
 
 def test_build_runtime_config_contains_expected_keys(monkeypatch) -> None:
+    monkeypatch.delenv("MOONMIND_FOLLOWUP_RETRIEVAL_COLLECTIONS", raising=False)
     monkeypatch.setattr(settings.anthropic, "anthropic_api_key", None)
     monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
     monkeypatch.delenv("CLAUDE_API_KEY", raising=False)
@@ -60,6 +61,7 @@ def test_build_runtime_config_contains_expected_keys(monkeypatch) -> None:
     )
 
     config = dashboard_view_model.build_runtime_config("/workflows")
+    assert config["system"]["retrievalAuthoring"]["collections"] == ["repo", "docs"]
     assert config["initialPath"] == "/workflows"
     assert config["pollIntervalsMs"]["list"] > 0
     assert config["sources"]["temporal"]["list"] == "/api/executions"

--- a/tests/unit/api/test_github_issue_breakdown_presets.py
+++ b/tests/unit/api/test_github_issue_breakdown_presets.py
@@ -132,15 +132,18 @@ async def test_github_issue_breakdown_seed_creates_issues_and_workflows(
     assert downstream_step["githubOrchestration"]["traceability"] == {
         "sourceIssueKey": "{{ inputs.source_issue_key }}"
     }
-    assert downstream_step["githubOrchestration"]["task"]["publish"] == {
-        "mode": (
-            "{{ 'pr' if inputs.publish_mode == 'pr_with_merge_automation' "
-            "else inputs.publish_mode }}"
-        ),
-        "mergeAutomation": {
-            "enabled": "{{ inputs.publish_mode == 'pr_with_merge_automation' }}"
-        },
-    }
+    expected_publish = {"mode": "{{ inputs.publish_mode }}"}
+    if slug == "github-issue-breakdown-implement":
+        expected_publish = {
+            "mode": (
+                "{{ 'pr' if inputs.publish_mode == 'pr_with_merge_automation' "
+                "else inputs.publish_mode }}"
+            ),
+            "mergeAutomation": {
+                "enabled": "{{ inputs.publish_mode == 'pr_with_merge_automation' }}"
+            },
+        }
+    assert downstream_step["githubOrchestration"]["task"]["publish"] == expected_publish
     assert downstream_step["githubOrchestration"]["task"]["inputs"] == {
         "run_verify": "{{ inputs.run_verify }}",
     }

--- a/tests/unit/api/test_github_issue_breakdown_presets.py
+++ b/tests/unit/api/test_github_issue_breakdown_presets.py
@@ -133,7 +133,13 @@ async def test_github_issue_breakdown_seed_creates_issues_and_workflows(
         "sourceIssueKey": "{{ inputs.source_issue_key }}"
     }
     assert downstream_step["githubOrchestration"]["task"]["publish"] == {
-        "mode": "{{ inputs.publish_mode }}",
+        "mode": (
+            "{{ 'pr' if inputs.publish_mode == 'pr_with_merge_automation' "
+            "else inputs.publish_mode }}"
+        ),
+        "mergeAutomation": {
+            "enabled": "{{ inputs.publish_mode == 'pr_with_merge_automation' }}"
+        },
     }
     assert downstream_step["githubOrchestration"]["task"]["inputs"] == {
         "run_verify": "{{ inputs.run_verify }}",

--- a/tests/unit/omnigent/test_follow_up_retrieval_policy.py
+++ b/tests/unit/omnigent/test_follow_up_retrieval_policy.py
@@ -19,9 +19,11 @@ from api_service.api.routers.retrieval_gateway import (
 from moonmind.omnigent.execution_profiles import (
     validate_effective_launch_snapshot,
 )
+from moonmind.omnigent.oauth_hosts import OmnigentOAuthHostError
 from moonmind.omnigent.profile_bound_execution import (
     _compile_persisted_effective_launch,
     compile_follow_up_retrieval_policy,
+    enforce_required_follow_up_retrieval,
 )
 
 
@@ -106,6 +108,70 @@ def test_follow_up_retrieval_folds_policy_budgets_when_unauthored() -> None:
     # boundaries.rag budgets reach the compiled block as the per-run ceiling.
     assert block["latencyMs"] == 4000
     assert block["maxContextTokens"] == 6000
+
+
+def test_follow_up_retrieval_clamps_authored_budgets_to_policy() -> None:
+    # Authored budgets larger than the selected policy must be clamped down; the
+    # gateway only clamps against deployment env limits, not the selected policy.
+    block = compile_follow_up_retrieval_policy(
+        _policy_snapshot(),
+        {
+            "followUpRetrieval": {
+                "enabled": True,
+                "collections": ["repo"],
+                "maxContextTokens": 9000,
+                "latencyMs": 9000,
+            }
+        },
+        repository="MoonMind",
+        tenant_id="tenant-1",
+    )
+    # policy tokenBudget=6000, latencyBudgetMs=4000 win over the larger authored
+    # values.
+    assert block["maxContextTokens"] == 6000
+    assert block["latencyMs"] == 4000
+
+
+def test_follow_up_retrieval_keeps_tighter_authored_budget() -> None:
+    block = compile_follow_up_retrieval_policy(
+        _policy_snapshot(),
+        {
+            "followUpRetrieval": {
+                "enabled": True,
+                "collections": ["repo"],
+                "maxContextTokens": 1000,
+                "latencyMs": 1500,
+            }
+        },
+        repository="MoonMind",
+        tenant_id="tenant-1",
+    )
+    # Authored values below the policy ceiling are preserved (they only narrow).
+    assert block["maxContextTokens"] == 1000
+    assert block["latencyMs"] == 1500
+
+
+def test_enforce_required_follow_up_retrieval_blocks_unavailable() -> None:
+    authored = {"enabled": True, "required": True}
+    compiled = {"enabled": False, "reason": "incomplete_follow_up_retrieval_scope"}
+    with pytest.raises(OmnigentOAuthHostError) as excinfo:
+        enforce_required_follow_up_retrieval(authored, compiled)
+    assert excinfo.value.code == "OMNIGENT_REQUIRED_FOLLOW_UP_RETRIEVAL_UNAVAILABLE"
+
+
+def test_enforce_required_follow_up_retrieval_allows_optional_and_available() -> None:
+    # Optional retrieval may degrade silently.
+    enforce_required_follow_up_retrieval(
+        {"enabled": True, "required": False}, {"enabled": False}
+    )
+    # Not enabled at all: required is moot.
+    enforce_required_follow_up_retrieval(
+        {"enabled": False, "required": True}, {"enabled": False}
+    )
+    # Required and available: no error.
+    enforce_required_follow_up_retrieval(
+        {"enabled": True, "required": True}, {"enabled": True}
+    )
 
 
 def test_follow_up_retrieval_incomplete_scope_disables_with_reason() -> None:

--- a/tests/unit/omnigent/test_follow_up_retrieval_policy.py
+++ b/tests/unit/omnigent/test_follow_up_retrieval_policy.py
@@ -1,0 +1,262 @@
+"""Follow-up (in-session) retrieval authoring → launch snapshot compilation.
+
+Covers GitHub issue MoonLadderStudios/MoonMind#3514 required work item 6: an
+authoring surface enables follow-up retrieval by writing
+``parameters["followUpRetrieval"]``; the coordinator compiles a runtime
+``followUpRetrieval`` block into the durable launch snapshot that the retrieval
+gateway consumes. Follow-up retrieval is an authority boundary, so it stays
+disabled unless explicitly enabled.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from api_service.api.routers.retrieval_gateway import (
+    BridgeRetrievalCapabilityIssue,
+    _bridge_authoritative_issue,
+)
+from moonmind.omnigent.execution_profiles import (
+    validate_effective_launch_snapshot,
+)
+from moonmind.omnigent.profile_bound_execution import (
+    _compile_persisted_effective_launch,
+    compile_follow_up_retrieval_policy,
+)
+
+
+def _policy_snapshot() -> dict:
+    return {
+        "policyRef": "codex-static@7",
+        "policyVersion": 7,
+        "policyDigest": "sha256:deadbeef",
+        "boundaries": {
+            "rag": {
+                "initialScope": "workflow",
+                "followupScope": "session",
+                "collectionRefs": ["repo", "docs"],
+                "tokenBudget": 6000,
+                "latencyBudgetMs": 4000,
+                "fallback": "deny",
+                "credentialRef": "retrieval-profile",
+            }
+        },
+    }
+
+
+def test_follow_up_retrieval_disabled_by_default() -> None:
+    assert compile_follow_up_retrieval_policy(
+        _policy_snapshot(), {}, repository="MoonMind", tenant_id="tenant-1"
+    ) == {"enabled": False}
+    assert compile_follow_up_retrieval_policy(
+        _policy_snapshot(),
+        {"followUpRetrieval": {"enabled": False}},
+        repository="MoonMind",
+        tenant_id="tenant-1",
+    ) == {"enabled": False}
+
+
+def test_follow_up_retrieval_compiles_authored_block() -> None:
+    block = compile_follow_up_retrieval_policy(
+        _policy_snapshot(),
+        {
+            "followUpRetrieval": {
+                "enabled": True,
+                "required": True,
+                "collections": ["repo", "repo", "docs"],
+                "filters": {"branch": "main", "": "skip", "empty": ""},
+                "topK": 5,
+                "maxContextTokens": 4000,
+                "latencyMs": 2500,
+                "overlayPolicy": "skip",
+                "staleOverlayAllowed": True,
+                "fallbackAllowed": True,
+                "maxLifetimeSeconds": 300,
+            }
+        },
+        repository="MoonMind",
+        tenant_id="tenant-1",
+    )
+
+    assert block["enabled"] is True
+    assert block["required"] is True
+    assert block["repository"] == "MoonMind"
+    assert block["tenantId"] == "tenant-1"
+    assert block["policyVersion"] == "codex-static@7"
+    # Duplicate collections are de-duplicated while order is preserved.
+    assert block["collections"] == ["repo", "docs"]
+    # Blank filter keys/values are dropped.
+    assert block["filters"] == {"branch": "main"}
+    assert block["topK"] == 5
+    assert block["maxContextTokens"] == 4000
+    assert block["latencyMs"] == 2500
+    assert block["overlayPolicy"] == "skip"
+    assert block["staleOverlayAllowed"] is True
+    assert block["fallbackAllowed"] is True
+    assert block["maxLifetimeSeconds"] == 300
+
+
+def test_follow_up_retrieval_folds_policy_budgets_when_unauthored() -> None:
+    block = compile_follow_up_retrieval_policy(
+        _policy_snapshot(),
+        {"followUpRetrieval": {"enabled": True, "collections": ["repo"]}},
+        repository="MoonMind",
+        tenant_id="tenant-1",
+    )
+    # boundaries.rag budgets reach the compiled block as the per-run ceiling.
+    assert block["latencyMs"] == 4000
+    assert block["maxContextTokens"] == 6000
+
+
+def test_follow_up_retrieval_incomplete_scope_disables_with_reason() -> None:
+    # Enabled but no collections and no resolvable repository/tenant.
+    block = compile_follow_up_retrieval_policy(
+        _policy_snapshot(),
+        {"followUpRetrieval": {"enabled": True}},
+        repository="",
+        tenant_id="",
+    )
+    assert block == {
+        "enabled": False,
+        "reason": "incomplete_follow_up_retrieval_scope",
+    }
+
+
+def test_compiled_block_flows_through_gateway_issue() -> None:
+    """The compiled snapshot block satisfies the gateway capability issuer."""
+    block = compile_follow_up_retrieval_policy(
+        _policy_snapshot(),
+        {
+            "followUpRetrieval": {
+                "enabled": True,
+                "collections": ["repo", "docs"],
+                "topK": 6,
+            }
+        },
+        repository="MoonMind",
+        tenant_id="tenant-1",
+    )
+
+    row = type(
+        "BridgeRow",
+        (),
+        {
+            "status": "active",
+            "bridge_session_id": "bridge-1",
+            "moonmind_workflow_id": "workflow-1",
+            "moonmind_agent_run_id": "agent-run-1",
+            "omnigent_host_id": "host-1",
+            "omnigent_session_id": "session-1",
+            "moonmind_run_id": "run-1",
+            "step_execution_id": "step-1",
+            "workspace": "workspace-1",
+            "effective_launch_snapshot_json": {"followUpRetrieval": block},
+        },
+    )()
+
+    issue = _bridge_authoritative_issue(
+        row, BridgeRetrievalCapabilityIssue(collections=["docs"], top_k=3)
+    )
+    assert issue.tenant_id == "tenant-1"
+    assert issue.repository == "MoonMind"
+    assert issue.policy_version == "codex-static@7"
+    # Host narrowing is honored within the compiled ceiling.
+    assert issue.collections == ["docs"]
+    assert issue.top_k == 3
+
+
+def test_effective_launch_snapshot_carries_and_validates_block() -> None:
+    block = compile_follow_up_retrieval_policy(
+        _policy_snapshot(),
+        {"followUpRetrieval": {"enabled": True, "collections": ["repo"]}},
+        repository="MoonMind",
+        tenant_id="tenant-1",
+    )
+    # Minimal boundaries needed by _compile_persisted_effective_launch.
+    snapshot = _policy_snapshot()
+    snapshot["boundaries"].update(
+        {
+            "host": {
+                "mode": "static_compose",
+                "backendRef": "backend",
+                "architectures": ["amd64"],
+                "serverImageRef": "server:1",
+                "hostImageRef": "host:1",
+            },
+            "execution": {
+                "profileRef": "omnigent-codex@1",
+                "agentIdentities": ["codex"],
+                "harness": "codex",
+            },
+            "endpoint": {"ref": "endpoint:1"},
+            "resources": {
+                "cpuMillis": 1000,
+                "memoryMiB": 2048,
+                "processes": 64,
+                "timeoutSeconds": 900,
+                "temporaryStorageMiB": 1024,
+            },
+            "network": {"attachmentRef": "net", "egressProfileRef": "egress"},
+            "workspace": {
+                "mountClasses": ["repo"],
+                "repositoryMutation": True,
+                "runtimeUid": 1000,
+                "runtimeGid": 1000,
+            },
+            "session": {"cleanup": "drain"},
+            "retention": {"days": 30},
+            "capture": {"logs": True},
+        }
+    )
+
+    realized = _compile_persisted_effective_launch(
+        snapshot, provider_profile_id="profile-1", follow_up_retrieval=block
+    )
+    assert realized["followUpRetrieval"]["enabled"] is True
+    assert realized["followUpRetrieval"]["repository"] == "MoonMind"
+    # Digest must still validate with the block inside it.
+    validate_effective_launch_snapshot(realized)
+
+
+def test_effective_launch_snapshot_defaults_to_disabled() -> None:
+    # Build a minimal valid snapshot and omit follow_up_retrieval entirely.
+    base = _policy_snapshot()
+    base["boundaries"].update(
+        {
+            "host": {
+                "mode": "static_compose",
+                "backendRef": "backend",
+                "architectures": ["amd64"],
+                "serverImageRef": "server:1",
+                "hostImageRef": "host:1",
+            },
+            "execution": {
+                "profileRef": "omnigent-codex@1",
+                "agentIdentities": ["codex"],
+                "harness": "codex",
+            },
+            "endpoint": {"ref": "endpoint:1"},
+            "resources": {
+                "cpuMillis": 1000,
+                "memoryMiB": 2048,
+                "processes": 64,
+                "timeoutSeconds": 900,
+                "temporaryStorageMiB": 1024,
+            },
+            "network": {"attachmentRef": "net", "egressProfileRef": "egress"},
+            "workspace": {
+                "mountClasses": ["repo"],
+                "repositoryMutation": True,
+                "runtimeUid": 1000,
+                "runtimeGid": 1000,
+            },
+            "session": {"cleanup": "drain"},
+            "retention": {"days": 30},
+            "capture": {"logs": True},
+        }
+    )
+    realized = _compile_persisted_effective_launch(
+        base, provider_profile_id="profile-1"
+    )
+    assert realized["followUpRetrieval"] == {"enabled": False}
+    validate_effective_launch_snapshot(realized)

--- a/tests/unit/services/test_checkpoint_branches_service.py
+++ b/tests/unit/services/test_checkpoint_branches_service.py
@@ -96,6 +96,11 @@ async def test_prepare_checkpoint_branch_workspace_persists_binding_and_artifact
             "artifact://MM-1090/output.branch_turn.step_execution_manifest.json"
         ),
         created_step_execution_id="step-MM-1090",
+        follow_up_retrieval={
+            "enabled": True,
+            "collections": ["repo"],
+            "maxQueries": 4,
+        },
     )
     await session.commit()
 
@@ -132,6 +137,11 @@ async def test_prepare_checkpoint_branch_workspace_persists_binding_and_artifact
     assert turn.step_execution_manifest_ref == (
         "artifact://MM-1090/output.branch_turn.step_execution_manifest.json"
     )
+    assert turn.diagnostics["followUpRetrieval"] == {
+        "enabled": True,
+        "collections": ["repo"],
+        "maxQueries": 4,
+    }
 
     binding = await session.get(WorkflowCheckpointBranchGitBinding, "cbr_MM-1090")
     assert binding is not None

--- a/tests/unit/workflows/temporal/workflows/test_run_target_aware_inputs.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_target_aware_inputs.py
@@ -97,6 +97,35 @@ def test_run_request_preserves_model_tier_intent_for_launch_resolution() -> None
     assert request.parameters["tierFallback"] == "strict"
 
 
+def test_run_request_forwards_context_retrieval_authoring() -> None:
+    """Authored RAG / follow-up retrieval policy reaches request.parameters (#3514)."""
+    wf = MoonMindRunWorkflow()
+    with patch(
+        "moonmind.workflows.temporal.workflows.run.workflow.info",
+        return_value=_workflow_info(),
+    ):
+        request = wf._build_agent_execution_request(
+            node_inputs={"runtime": {"mode": "codex_cli"}},
+            node_id="collect-evidence",
+            tool_name="codex_cli",
+            workflow_parameters={
+                "task": _task_payload(),
+                "repository": "MoonMind",
+                "rag": {"collections": ["docs"], "allowStale": True},
+                "followUpRetrieval": {
+                    "enabled": True,
+                    "collections": ["repo", "docs"],
+                    "topK": 6,
+                },
+            },
+        )
+
+    assert request.parameters["repository"] == "MoonMind"
+    assert request.parameters["rag"] == {"collections": ["docs"], "allowStale": True}
+    assert request.parameters["followUpRetrieval"]["enabled"] is True
+    assert request.parameters["followUpRetrieval"]["collections"] == ["repo", "docs"]
+
+
 def test_run_request_records_prepared_manifest_before_step_dispatch() -> None:
     request = _build_request_for_step("collect-evidence")
 


### PR DESCRIPTION
Issue: MoonLadderStudios/MoonMind#3514

Closes MoonLadderStudios/MoonMind#3514

## Summary

Completes the remaining frontend/authoring scope of the Omnigent scoped in-session retrieval feature (acceptance criteria 9 and 10 / required work items 6 and 7). The server-side capability (items 1–5, AC1–8) was previously merged to `main` via PR #3552; this change delivers the operator-facing surfaces on top of it.

- **Authoring & profile controls (AC9 / item 6):** New shared authoring model `frontend/src/lib/contextRetrievalAuthoring.ts` (enable/disable, required/optional, collection/scope selection, initial vs. follow-up permissions, budget presets conservative/balanced/generous/custom + bounded overrides, overlay policy, stale-overlay and fallback flags) with `clampFollowUpRetrieval`/`explainRetrievalDenials` enforcing and explaining policy ceilings. Rendered via `frontend/src/components/ContextRetrievalControls.tsx`, wired into all required surfaces: Workflow Create/edit/rerun (`workflow-start.tsx`, which also serves remediation authoring via the `intent=remediate` draft flow), recurring schedules (`schedules.tsx`), Omnigent agent profiles (`omnigent-inventory.tsx`), and Checkpoint Branch turn creation (`workflow-detail.tsx`, initial controls hidden).
- **Backend compile/lift:** `moonmind/omnigent/profile_bound_execution.py` compiles authored `followUpRetrieval` into the durable launch snapshot (disabled unless explicitly enabled — authority boundary); `api_service/api/routers/executions.py` lifts payload `rag`/`followUpRetrieval` into `initial_parameters`; `moonmind/workflows/temporal/workflows/run.py` forwards `rag`/`followUpRetrieval`/`repository`/`tenant` to the per-step request; `moonmind/schemas/checkpoint_branch_models.py` adds an optional `followUpRetrieval` override on branch create/continue/fork.
- **Operator diagnostics & telemetry (AC10 / item 7):** `FollowUpRetrievalDiagnosticsSection` in `workflow-detail.tsx` shows request count, per-capability budget usage, scope, collections, overlay/fallback, per-request state/classification/result count/truncation/latency/delivery state/`contextPackRef` link, capability active/expired/revoked status, and aggregate telemetry (succeeded/empty/denied/failed/fallback/truncated/budgetExhausted/timedOut/latency/context bytes/delivery outcomes) — distinct from the initial-retrieval evidence carried over from #3513. Backed by `api_service/retrieval_capabilities.py` `summarize_bridge_session()` and `GET /retrieval/bridge-sessions/{id}/follow-up-retrieval` (ownership-gated, secret-free summaries only).
- New styles added to the single `frontend/src/styles/dashboard.css` (`context-retrieval-*` classes).

## Tests run

- Frontend unit (Vitest): `./tools/test_unit.sh --dashboard-only --ui-args src/lib/contextRetrievalAuthoring.test.ts src/components/ContextRetrievalControls.test.tsx src/entrypoints/workflow-detail.followup-retrieval.test.tsx` — **PASS** (3 files, 15 tests).
- Backend unit (pytest): `tests/unit/api/routers/test_retrieval_gateway.py tests/unit/omnigent/test_follow_up_retrieval_policy.py tests/unit/workflows/temporal/workflows/test_run_target_aware_inputs.py` — **PASS** (85 tests).
- Backend unit (pytest): `tests/unit/api/routers/test_executions.py::test_create_execution_lifts_context_retrieval_authoring` — **PASS**.

## Remaining risks

- Pre-existing `test_describe_execution_*` failures in `tests/unit/api/routers/test_executions.py` are a local async-SQLAlchemy session-concurrency environment artifact that reproduces on `main` and is unrelated to this additive param lift (does not touch the `describe_execution` code path). Non-blocking/advisory.
- A live end-to-end round trip (active Codex Omnigent session issuing follow-up retrieval against real embedding/Qdrant/artifact services with same-turn delivery) requires credentialed provider services and a deployed runtime not available in this hermetic checkout; the server contract, capability lifecycle, budget enforcement, evidence, and delivery-state handling (AC1–8) are covered by repo-local unit evidence and were merged via PR #3552.
