### PR TITLE
Fix headless remediation and worker rollout failures

### DIFF
--- a/moonmind/workflows/temporal/activity_catalog.py
+++ b/moonmind/workflows/temporal/activity_catalog.py
@@ -1314,7 +1314,9 @@ def build_default_activity_catalog(
             capability_class="agent_runtime",
             task_queue=cfg.activity_agent_runtime_task_queue,
             fleet=AGENT_RUNTIME_FLEET,
-            timeouts=TemporalActivityTimeouts(60, 180, heartbeat_timeout_seconds=30),
+            # Status is short once started, but the queue budget must cover a
+            # complete agent-runtime fleet restart and cold initialization.
+            timeouts=TemporalActivityTimeouts(60, 600, heartbeat_timeout_seconds=30),
             retries=_activity_retries(max_attempts=2, max_interval_seconds=30),
             heartbeat_required=True,
         ),

--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -2425,12 +2425,15 @@ class MoonMindAgentRun:
         adapter: AgentAdapter,
         uses_codex_session_adapter: bool,
         use_managed_status_activity: bool,
+        remaining_budget_seconds: float | None = None,
     ) -> AgentRunStatusModel:
         if uses_codex_session_adapter:
             return await adapter.status(self.run_id)
         if use_managed_status_activity:
             schedule_to_close_override = (
-                self._managed_status_schedule_to_close_override()
+                self._managed_status_schedule_to_close_override(
+                    remaining_budget_seconds=remaining_budget_seconds,
+                )
             )
             status_payload = await self._execute_routed_activity(
                 "agent_runtime.status",
@@ -2461,12 +2464,25 @@ class MoonMindAgentRun:
         )
 
     @staticmethod
-    def _managed_status_schedule_to_close_override() -> timedelta | None:
-        """Preserve the former timeout for histories without the rollout patch."""
+    def _managed_status_schedule_to_close_override(
+        *,
+        remaining_budget_seconds: float | None = None,
+    ) -> timedelta | None:
+        """Bound status queueing without changing legacy activity commands."""
 
-        if workflow.patched(MANAGED_STATUS_ROLLOUT_TOLERANCE_PATCH_ID):
+        if not workflow.patched(MANAGED_STATUS_ROLLOUT_TOLERANCE_PATCH_ID):
+            return timedelta(seconds=180)
+        if remaining_budget_seconds is None:
             return None
-        return timedelta(seconds=180)
+        configured_seconds = DEFAULT_ACTIVITY_CATALOG.resolve_activity(
+            "agent_runtime.status"
+        ).timeouts.schedule_to_close_seconds
+        return timedelta(
+            seconds=min(
+                float(configured_seconds),
+                max(0.001, float(remaining_budget_seconds)),
+            )
+        )
 
     async def _reconcile_managed_no_progress(
         self,
@@ -2527,11 +2543,24 @@ class MoonMindAgentRun:
             if completed or self.completion_event.is_set():
                 return self.final_result
 
+            remaining_status_budget = min(
+                (deadline - workflow.now()).total_seconds(),
+                timeout_seconds
+                - (workflow.now() - overall_start).total_seconds(),
+            )
+            if (
+                use_managed_status_activity
+                and not uses_codex_session_adapter
+                and workflow.patched(MANAGED_STATUS_ROLLOUT_TOLERANCE_PATCH_ID)
+                and remaining_status_budget <= 0
+            ):
+                return None
             status_obj = await self._poll_managed_status(
                 request=request,
                 adapter=adapter,
                 uses_codex_session_adapter=uses_codex_session_adapter,
                 use_managed_status_activity=use_managed_status_activity,
+                remaining_budget_seconds=remaining_status_budget,
             )
 
     async def _cancel_managed_no_progress_and_fetch_cooldown_result(
@@ -2599,11 +2628,20 @@ class MoonMindAgentRun:
                     return self.final_result
                 return None
 
+            remaining_status_budget = (deadline - workflow.now()).total_seconds()
+            if (
+                use_managed_status_activity
+                and not uses_codex_session_adapter
+                and workflow.patched(MANAGED_STATUS_ROLLOUT_TOLERANCE_PATCH_ID)
+                and remaining_status_budget <= 0
+            ):
+                return None
             status_obj = await self._poll_managed_status(
                 request=request,
                 adapter=adapter,
                 uses_codex_session_adapter=uses_codex_session_adapter,
                 use_managed_status_activity=use_managed_status_activity,
+                remaining_budget_seconds=remaining_status_budget,
             )
             self.run_status = status_obj.status
             if status_obj.status in _TERMINAL_RUN_STATUSES:
@@ -4812,11 +4850,24 @@ class MoonMindAgentRun:
                                 fallback_agent_id=request.agent_id,
                             )
                         else:
+                            remaining_status_budget = timeout_seconds - (
+                                workflow.now() - overall_start
+                            ).total_seconds()
+                            if (
+                                use_managed_status_activity
+                                and not uses_codex_session_adapter
+                                and workflow.patched(
+                                    MANAGED_STATUS_ROLLOUT_TOLERANCE_PATCH_ID
+                                )
+                                and remaining_status_budget <= 0
+                            ):
+                                break
                             status_obj = await self._poll_managed_status(
                                 request=request,
                                 adapter=adapter,
                                 uses_codex_session_adapter=uses_codex_session_adapter,
                                 use_managed_status_activity=use_managed_status_activity,
+                                remaining_budget_seconds=remaining_status_budget,
                             )
 
                         self.run_status = status_obj.status

--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -313,6 +313,9 @@ OMNIGENT_PROFILE_BOUND_EXECUTION_PATCH_ID = (
     "agent-run-omnigent-profile-bound-execution-v1"
 )
 MANAGED_STATUS_ACTIVITY_PATCH_ID = "agent-run-managed-status-activity-v1"
+MANAGED_STATUS_ROLLOUT_TOLERANCE_PATCH_ID = (
+    "agent-run-managed-status-rollout-tolerance-v1"
+)
 PROVIDER_PROFILE_MANAGER_ID_PATCH = "provider-profile-manager-id-v1"
 MANAGED_TASK_WORKFLOW_BINDING_PATCH_ID = "agent-run-managed-task-workflow-binding-v1"
 MANAGED_SESSION_FETCH_RESULT_ACTIVITY_PATCH_ID = (
@@ -2426,6 +2429,9 @@ class MoonMindAgentRun:
         if uses_codex_session_adapter:
             return await adapter.status(self.run_id)
         if use_managed_status_activity:
+            schedule_to_close_override = (
+                self._managed_status_schedule_to_close_override()
+            )
             status_payload = await self._execute_routed_activity(
                 "agent_runtime.status",
                 AgentRuntimeStatusInput(
@@ -2433,6 +2439,11 @@ class MoonMindAgentRun:
                     agentId=request.agent_id,
                 ),
                 cancellation_type=ActivityCancellationType.TRY_CANCEL,
+                **(
+                    {"schedule_to_close_timeout": schedule_to_close_override}
+                    if schedule_to_close_override is not None
+                    else {}
+                ),
             )
             return self._coerce_managed_status_payload(
                 status_payload=status_payload,
@@ -2448,6 +2459,14 @@ class MoonMindAgentRun:
             agentId=request.agent_id,
             status=RunStatus.running,
         )
+
+    @staticmethod
+    def _managed_status_schedule_to_close_override() -> timedelta | None:
+        """Preserve the former timeout for histories without the rollout patch."""
+
+        if workflow.patched(MANAGED_STATUS_ROLLOUT_TOLERANCE_PATCH_ID):
+            return None
+        return timedelta(seconds=180)
 
     async def _reconcile_managed_no_progress(
         self,

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -773,6 +773,13 @@ RUN_WORKFLOW_OWNED_REMEDIATION_HEAD_PATCH = (
 RUN_WORKFLOW_HEADLESS_REMEDIATION_PATCH = (
     "run-workflow-headless-remediation-v1"
 )
+# Complete the headless-remediation cutover at the execution boundary. The
+# admission patch above allows a remediation attempt without a canonical
+# checkpoint; older histories that already failed the later materialization
+# guard must retain that failure when replayed.
+RUN_HEADLESS_REMEDIATION_EXECUTION_PATCH = (
+    "run-headless-remediation-execution-v1"
+)
 RUN_MANAGED_SESSION_CHECKPOINT_LOCATOR_PATCH = (
     "run-managed-session-checkpoint-locator-v1"
 )
@@ -6639,6 +6646,21 @@ class MoonMindRunWorkflow:
             "workspaceIdentityDigest": workspace_identity_digest,
         }
 
+    def _remediation_workspace_materialization_required(
+        self,
+        node: Mapping[str, Any],
+    ) -> bool:
+        """Return whether this execution must prove a restored checkpoint head."""
+
+        if not workflow.patched(RUN_WORKFLOW_OWNED_REMEDIATION_HEAD_PATCH):
+            return False
+        if not self._is_moonspec_remediation_step(node):
+            return False
+        return not (
+            workflow.patched(RUN_HEADLESS_REMEDIATION_EXECUTION_PATCH)
+            and self._remediation_workspace_head is None
+        )
+
     def _inject_remediation_workspace_baseline(
         self,
         *,
@@ -10853,12 +10875,7 @@ class MoonMindRunWorkflow:
                         boundary="before_execution",
                         updated_at=workflow.now(),
                     )
-                    if (
-                        workflow.patched(
-                            RUN_WORKFLOW_OWNED_REMEDIATION_HEAD_PATCH
-                        )
-                        and self._is_moonspec_remediation_step(node)
-                    ):
+                    if self._remediation_workspace_materialization_required(node):
                         self._validate_remediation_workspace_materialization(
                             node_id
                         )

--- a/tests/unit/workflows/temporal/test_activity_catalog.py
+++ b/tests/unit/workflows/temporal/test_activity_catalog.py
@@ -176,6 +176,17 @@ def test_launch_session_timeout_budget_covers_cold_sidecar_startup():
     assert route.heartbeat_required is True
     assert route.retries.max_attempts == 3
 
+def test_managed_status_timeout_budget_covers_worker_fleet_rollout():
+    catalog = build_default_activity_catalog()
+
+    route = catalog.resolve_activity("agent_runtime.status")
+
+    assert route.timeouts.start_to_close_seconds == 60
+    assert route.timeouts.schedule_to_close_seconds == 600
+    assert route.timeouts.heartbeat_timeout_seconds == 30
+    assert route.heartbeat_required is True
+    assert route.retries.max_attempts == 2
+
 def test_resolve_skill_uses_capability_routing_for_mm_skill_execute():
     catalog = build_default_activity_catalog()
 

--- a/tests/unit/workflows/temporal/test_run_replayer.py
+++ b/tests/unit/workflows/temporal/test_run_replayer.py
@@ -14,6 +14,7 @@ from moonmind.workflows.temporal.remediation_loop import (
     RemediationLoopState,
     apply_continuation_decision,
 )
+from moonmind.workflows.temporal.workflows.agent_run import MoonMindAgentRun
 from moonmind.workflows.temporal.workflows.run import (
     GateTransitionDecision,
     RUN_BOUNDED_STORY_LOOP_FEEDBACK_PROGRESS_PATCH,
@@ -28,6 +29,7 @@ from moonmind.workflows.temporal.workflows.run import (
     RUN_REMEDIATION_LOOP_ARTIFACT_REF_NORMALIZATION_PATCH,
     RUN_REMEDIATION_LOOP_CONTINUE_AS_NEW_PATCH,
     RUN_REFRESH_MOONSPEC_BLOCK_AFTER_REMEDIATION_DECISION_PATCH,
+    RUN_WORKFLOW_HEADLESS_REMEDIATION_PATCH,
     RUN_WORKFLOW_OWNED_REMEDIATION_HEAD_PATCH,
     MoonMindRunWorkflow,
     MoonMindUserWorkflow,
@@ -170,6 +172,48 @@ class _CurrentWorkflowOwnedRemediationHeadReplayFixture:
                 "headWorkspaceDigest": "sha256:c1",
             }
         return continuation
+
+
+@workflow.defn(name="MMHeadlessRemediationExecutionReplayFixture")
+class _LegacyHeadlessRemediationExecutionReplayFixture:
+    @workflow.run
+    async def run(self) -> bool:
+        workflow.patched(RUN_WORKFLOW_OWNED_REMEDIATION_HEAD_PATCH)
+        workflow.patched(RUN_WORKFLOW_HEADLESS_REMEDIATION_PATCH)
+        return True
+
+
+@workflow.defn(name="MMHeadlessRemediationExecutionReplayFixture")
+class _CurrentHeadlessRemediationExecutionReplayFixture:
+    @workflow.run
+    async def run(self) -> bool:
+        workflow.patched(RUN_WORKFLOW_OWNED_REMEDIATION_HEAD_PATCH)
+        workflow.patched(RUN_WORKFLOW_HEADLESS_REMEDIATION_PATCH)
+        workflow_instance = MoonMindRunWorkflow()
+        workflow_instance._remediation_workspace_head = None
+        return workflow_instance._remediation_workspace_materialization_required(
+            {
+                "id": "remediation-1",
+                "annotations": {
+                    "issueImplementRole": "moonspec-remediation",
+                },
+            }
+        )
+
+
+@workflow.defn(name="MMManagedStatusRolloutTimeoutReplayFixture")
+class _LegacyManagedStatusRolloutTimeoutReplayFixture:
+    @workflow.run
+    async def run(self) -> int:
+        return 180
+
+
+@workflow.defn(name="MMManagedStatusRolloutTimeoutReplayFixture")
+class _CurrentManagedStatusRolloutTimeoutReplayFixture:
+    @workflow.run
+    async def run(self) -> int:
+        override = MoonMindAgentRun._managed_status_schedule_to_close_override()
+        return int(override.total_seconds()) if override is not None else 600
 
 
 @workflow.defn(name="MMManagedSessionCheckpointLocatorReplayFixture")
@@ -640,6 +684,84 @@ async def test_workflow_owned_remediation_head_histories_replay() -> None:
     )
     replayer = Replayer(
         workflows=[_CurrentWorkflowOwnedRemediationHeadReplayFixture],
+        workflow_runner=UnsandboxedWorkflowRunner(),
+    )
+    await replayer.replay_workflow(legacy_history)
+    await replayer.replay_workflow(current_history)
+
+
+@pytest.mark.asyncio
+async def test_headless_remediation_execution_histories_replay() -> None:
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        async with Worker(
+            env.client,
+            task_queue="test-headless-remediation-legacy-replay",
+            workflows=[_LegacyHeadlessRemediationExecutionReplayFixture],
+            workflow_runner=UnsandboxedWorkflowRunner(),
+        ):
+            legacy = await env.client.start_workflow(
+                _LegacyHeadlessRemediationExecutionReplayFixture.run,
+                id="test-headless-remediation-legacy",
+                task_queue="test-headless-remediation-legacy-replay",
+            )
+            assert await legacy.result() is True
+            legacy_history = await legacy.fetch_history()
+
+        async with Worker(
+            env.client,
+            task_queue="test-headless-remediation-current-replay",
+            workflows=[_CurrentHeadlessRemediationExecutionReplayFixture],
+            workflow_runner=UnsandboxedWorkflowRunner(),
+        ):
+            current = await env.client.start_workflow(
+                _CurrentHeadlessRemediationExecutionReplayFixture.run,
+                id="test-headless-remediation-current",
+                task_queue="test-headless-remediation-current-replay",
+            )
+            assert await current.result() is False
+            current_history = await current.fetch_history()
+
+    replayer = Replayer(
+        workflows=[_CurrentHeadlessRemediationExecutionReplayFixture],
+        workflow_runner=UnsandboxedWorkflowRunner(),
+    )
+    await replayer.replay_workflow(legacy_history)
+    await replayer.replay_workflow(current_history)
+
+
+@pytest.mark.asyncio
+async def test_managed_status_rollout_timeout_histories_replay() -> None:
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        async with Worker(
+            env.client,
+            task_queue="test-managed-status-timeout-legacy-replay",
+            workflows=[_LegacyManagedStatusRolloutTimeoutReplayFixture],
+            workflow_runner=UnsandboxedWorkflowRunner(),
+        ):
+            legacy = await env.client.start_workflow(
+                _LegacyManagedStatusRolloutTimeoutReplayFixture.run,
+                id="test-managed-status-timeout-legacy",
+                task_queue="test-managed-status-timeout-legacy-replay",
+            )
+            assert await legacy.result() == 180
+            legacy_history = await legacy.fetch_history()
+
+        async with Worker(
+            env.client,
+            task_queue="test-managed-status-timeout-current-replay",
+            workflows=[_CurrentManagedStatusRolloutTimeoutReplayFixture],
+            workflow_runner=UnsandboxedWorkflowRunner(),
+        ):
+            current = await env.client.start_workflow(
+                _CurrentManagedStatusRolloutTimeoutReplayFixture.run,
+                id="test-managed-status-timeout-current",
+                task_queue="test-managed-status-timeout-current-replay",
+            )
+            assert await current.result() == 600
+            current_history = await current.fetch_history()
+
+    replayer = Replayer(
+        workflows=[_CurrentManagedStatusRolloutTimeoutReplayFixture],
         workflow_runner=UnsandboxedWorkflowRunner(),
     )
     await replayer.replay_workflow(legacy_history)

--- a/tests/unit/workflows/temporal/test_run_replayer.py
+++ b/tests/unit/workflows/temporal/test_run_replayer.py
@@ -204,16 +204,22 @@ class _CurrentHeadlessRemediationExecutionReplayFixture:
 @workflow.defn(name="MMManagedStatusRolloutTimeoutReplayFixture")
 class _LegacyManagedStatusRolloutTimeoutReplayFixture:
     @workflow.run
-    async def run(self) -> int:
-        return 180
+    async def run(self) -> list[int]:
+        return [180, 180]
 
 
 @workflow.defn(name="MMManagedStatusRolloutTimeoutReplayFixture")
 class _CurrentManagedStatusRolloutTimeoutReplayFixture:
     @workflow.run
-    async def run(self) -> int:
-        override = MoonMindAgentRun._managed_status_schedule_to_close_override()
-        return int(override.total_seconds()) if override is not None else 600
+    async def run(self) -> list[int]:
+        uncapped = MoonMindAgentRun._managed_status_schedule_to_close_override()
+        capped = MoonMindAgentRun._managed_status_schedule_to_close_override(
+            remaining_budget_seconds=45,
+        )
+        return [
+            int(uncapped.total_seconds()) if uncapped is not None else 600,
+            int(capped.total_seconds()) if capped is not None else 600,
+        ]
 
 
 @workflow.defn(name="MMManagedSessionCheckpointLocatorReplayFixture")
@@ -743,7 +749,7 @@ async def test_managed_status_rollout_timeout_histories_replay() -> None:
                 id="test-managed-status-timeout-legacy",
                 task_queue="test-managed-status-timeout-legacy-replay",
             )
-            assert await legacy.result() == 180
+            assert await legacy.result() == [180, 180]
             legacy_history = await legacy.fetch_history()
 
         async with Worker(
@@ -757,7 +763,7 @@ async def test_managed_status_rollout_timeout_histories_replay() -> None:
                 id="test-managed-status-timeout-current",
                 task_queue="test-managed-status-timeout-current-replay",
             )
-            assert await current.result() == 600
+            assert await current.result() == [600, 45]
             current_history = await current.fetch_history()
 
     replayer = Replayer(

--- a/tests/unit/workflows/temporal/workflows/test_agent_run_status_payloads.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_run_status_payloads.py
@@ -1,9 +1,76 @@
+from datetime import timedelta
+
+import pytest
+
 from moonmind.schemas.agent_runtime_models import AgentExecutionRequest, AgentRunStatus
+from moonmind.workflows.temporal.workflows import agent_run as agent_run_module
 from moonmind.workflows.temporal.workflows.agent_run import (
+    MANAGED_STATUS_ROLLOUT_TOLERANCE_PATCH_ID,
     MoonMindAgentRun,
     RunStatus,
     _request_reserves_slot_for_immediate_followup,
 )
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("rollout_patch_enabled", "expected_schedule_to_close"),
+    [(False, timedelta(seconds=180)), (True, timedelta(seconds=600))],
+)
+async def test_managed_status_poll_timeout_is_replay_safe_and_rollout_tolerant(
+    monkeypatch: pytest.MonkeyPatch,
+    rollout_patch_enabled: bool,
+    expected_schedule_to_close: timedelta,
+) -> None:
+    """Regression for the 2026-07-30 PR resolver worker-rollout failure."""
+
+    monkeypatch.setattr(
+        agent_run_module.workflow,
+        "patched",
+        lambda patch_id: (
+            rollout_patch_enabled
+            and patch_id == MANAGED_STATUS_ROLLOUT_TOLERANCE_PATCH_ID
+        ),
+    )
+    captured: dict[str, object] = {}
+
+    async def fake_execute_typed_activity(
+        activity_name: str,
+        payload: object,
+        **kwargs: object,
+    ) -> dict[str, object]:
+        captured.update(kwargs)
+        assert activity_name == "agent_runtime.status"
+        return {
+            "runId": "managed-run-1",
+            "agentKind": "managed",
+            "agentId": "claude_code",
+            "status": "running",
+        }
+
+    monkeypatch.setattr(
+        agent_run_module,
+        "execute_typed_activity",
+        fake_execute_typed_activity,
+    )
+    workflow_instance = MoonMindAgentRun()
+    workflow_instance.run_id = "managed-run-1"
+    request = AgentExecutionRequest(
+        agentKind="managed",
+        agentId="claude_code",
+        correlationId="resolver-run-1",
+        idempotencyKey="resolver-run-1:node-1",
+    )
+
+    status = await workflow_instance._poll_managed_status(
+        request=request,
+        adapter=object(),
+        uses_codex_session_adapter=False,
+        use_managed_status_activity=True,
+    )
+
+    assert status.status == RunStatus.running
+    assert captured["start_to_close_timeout"] == timedelta(seconds=60)
+    assert captured["schedule_to_close_timeout"] == expected_schedule_to_close
 
 def test_coerce_external_status_payload_accepts_canonical_shape() -> None:
     workflow_instance = MoonMindAgentRun()

--- a/tests/unit/workflows/temporal/workflows/test_agent_run_status_payloads.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_run_status_payloads.py
@@ -13,12 +13,22 @@ from moonmind.workflows.temporal.workflows.agent_run import (
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("rollout_patch_enabled", "expected_schedule_to_close"),
-    [(False, timedelta(seconds=180)), (True, timedelta(seconds=600))],
+    (
+        "rollout_patch_enabled",
+        "remaining_budget_seconds",
+        "expected_schedule_to_close",
+    ),
+    [
+        (False, 45.0, timedelta(seconds=180)),
+        (True, None, timedelta(seconds=600)),
+        (True, 900.0, timedelta(seconds=600)),
+        (True, 45.0, timedelta(seconds=45)),
+    ],
 )
 async def test_managed_status_poll_timeout_is_replay_safe_and_rollout_tolerant(
     monkeypatch: pytest.MonkeyPatch,
     rollout_patch_enabled: bool,
+    remaining_budget_seconds: float | None,
     expected_schedule_to_close: timedelta,
 ) -> None:
     """Regression for the 2026-07-30 PR resolver worker-rollout failure."""
@@ -66,6 +76,7 @@ async def test_managed_status_poll_timeout_is_replay_safe_and_rollout_tolerant(
         adapter=object(),
         uses_codex_session_adapter=False,
         use_managed_status_activity=True,
+        remaining_budget_seconds=remaining_budget_seconds,
     )
 
     assert status.status == RunStatus.running

--- a/tests/unit/workflows/temporal/workflows/test_run_integration.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_integration.py
@@ -19,6 +19,7 @@ from moonmind.workflows.temporal.workflows.run import (
     RUN_DURABLE_PUBLISH_CONTEXT_MERGE_HANDOFF_PATCH,
     RUN_FAILED_RUN_RECOVERY_MANIFEST_PATCH,
     RUN_HANDOFF_ACCEPTED_DISPOSITION_GATE_PATCH,
+    RUN_HEADLESS_REMEDIATION_EXECUTION_PATCH,
     RUN_MANAGED_SESSION_CHECKPOINT_LOCATOR_PATCH,
     RUN_MOONSPEC_GATE_PREVIOUS_OUTPUTS_HANDOFF_PATCH,
     RUN_PAUSE_SAFE_BOUNDARIES_PATCH,
@@ -4108,6 +4109,62 @@ async def test_dynamic_verifier_admits_headless_attempt_without_checkpoint(
     assert decision_payload["reason"] == "verification_requested_remediation"
     assert decision_payload["nextAttempt"] == 1
     assert decision_payload["nextPhase"] == "remediation_pending"
+
+
+def test_headless_remediation_execution_skips_checkpoint_materialization_guard(
+    mock_run_workflow: MoonMindRunWorkflow,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression for the five headless remediation failures on 2026-07-30."""
+
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "patched",
+        lambda patch_id: patch_id
+        in {
+            RUN_WORKFLOW_OWNED_REMEDIATION_HEAD_PATCH,
+            RUN_WORKFLOW_HEADLESS_REMEDIATION_PATCH,
+            RUN_HEADLESS_REMEDIATION_EXECUTION_PATCH,
+        },
+    )
+    mock_run_workflow._remediation_workspace_head = None
+    node = {
+        "id": "remediation-1",
+        "annotations": {"issueImplementRole": "moonspec-remediation"},
+    }
+
+    assert not mock_run_workflow._remediation_workspace_materialization_required(
+        node
+    )
+
+
+def test_headless_remediation_execution_replays_prior_guard_failure(
+    mock_run_workflow: MoonMindRunWorkflow,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "patched",
+        lambda patch_id: patch_id
+        in {
+            RUN_WORKFLOW_OWNED_REMEDIATION_HEAD_PATCH,
+            RUN_WORKFLOW_HEADLESS_REMEDIATION_PATCH,
+        },
+    )
+    mock_run_workflow._remediation_workspace_head = None
+    node = {
+        "id": "remediation-1",
+        "annotations": {"issueImplementRole": "moonspec-remediation"},
+    }
+
+    assert mock_run_workflow._remediation_workspace_materialization_required(node)
+    with pytest.raises(
+        RemediationHeadError,
+        match="remediation workspace was not checkpointed before execution",
+    ):
+        mock_run_workflow._validate_remediation_workspace_materialization(
+            "remediation-1"
+        )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- allow admitted headless remediation steps to execute without requiring a checkpoint that does not exist, while retaining materialization validation for head-backed remediation
- expand the agent_runtime.status queue budget from 180 to 600 seconds so a full worker-fleet restart and cold initialization can complete
- version both workflow changes so legacy Temporal histories retain their original decisions and replay deterministically
- add production-path regressions and legacy/current Temporal replay fixtures

## Incident coverage

The 12-hour investigation window contained six root incidents and eight failed executions.

- Five roots (mm:4466422a-c86d-434d-8e90-75845fb1e48c, mm:0a1cbbab-d11c-4f00-82c6-17680d52efec, mm:391e7437-d43e-47bc-a376-1d873cda47df, mm:baaa0ff2-819e-4a84-8bf5-35476b0b0c8e, and mm:add6f07d-40a5-46b2-80f8-a78978297d01) failed because headless remediation was admitted and then rejected by the later workspace materialization guard.
- Root mm:a654e2f9-d99e-4c47-ba35-2cc33c4f8f94 and its resolver/AgentRun descendants failed when agent_runtime.status remained queued for 180 seconds during a complete agent-runtime fleet recreation; the replacement poller became ready about three seconds after the activity timed out.
- No investigated failure was attributable to quota or a purely external provider condition.

## Verification

- ./tools/test_unit.sh --python-only tests/unit/workflows/temporal/test_activity_catalog.py tests/unit/workflows/temporal/test_run_replayer.py tests/unit/workflows/temporal/workflows/test_agent_run_status_payloads.py tests/unit/workflows/temporal/workflows/test_run_integration.py
- Result: 242 passed
- Focused Python phase: 7 passed
- An automatically included frontend run exposed an unrelated timezone-sensitive Omnigent expectation (expected 12:00Z, received 20:00Z) in an untouched test; the Python-only affected suite above is green.