### PR TITLE
GitHub Issue Implement: MoonLadderStudios/MoonMind#3561 — Omnigent repository publication semantics + durable authority-chain evidence

### DIFF
--- a/memory/MEMORY.md
+++ b/memory/MEMORY.md
@@ -2,3 +2,4 @@
 - [MM-954 workflow-list current-page sort](mm954-workflow-list-current-page-sort.md) — why list sorting is intentionally page-only, not global server-side
 - [Frontend vitest colon-path workaround](frontend-vitest-colon-path-workaround.md) — vitest fails on colon in workspace dir; run from a colon-free copy under /tmp
 - [Omnigent #3507 workspace materialization](omnigent-3507-workspace-materialization.md) — done vs remaining for the normal-workflow workspace path
+- [Omnigent #3561 publication semantics](omnigent-3561-publication-semantics.md) — publication/saved-work/recovery proof + unified authority-chain evidence through the Omnigent path

--- a/memory/omnigent-3561-publication-semantics.md
+++ b/memory/omnigent-3561-publication-semantics.md
@@ -1,0 +1,20 @@
+---
+name: omnigent-3561-publication-semantics
+description: State of MoonMind#3561 Omnigent repository publication semantics + durable authority-chain evidence — what this branch added
+metadata:
+  type: project
+---
+
+GitHub issue MoonLadderStudios/MoonMind#3561 ([Omnigent M1 4/8] Preserve repository publication semantics and durable workspace evidence) was assessed PARTIALLY_IMPLEMENTED: the shared substrate from parent [[omnigent-3507-workspace-materialization]] (#3507) exists, but #3561's own deliverable — proof that publication/saved-work/recovery obey canonical contracts through the Omnigent path, plus a unified bounded authority-chain projection — was absent. Finished on branch `github-issue-implement-moonladderstudios-63cbaf04`.
+
+**Architecture note (confirmed):** the Omnigent coordinator (`moonmind/omnigent/profile_bound_execution.py`) does NOT publish; it returns an `AgentRunResult`. Publication flows through the shared `agent_run.py` workflow → `agent_runtime_fetch_result` / `_push_workspace_branch` and `agent_runtime_publish_terminal_checkpoint` (in `activity_runtime.py`). publishMode short forms are `none`/`branch`/`pr`/`auto`. `PublishService.publish` (`moonmind/publish/service.py`) is a self-contained canonical publisher (branch/commit/push/PR + outbound scan). `publication_recovery.py` is provider-agnostic (no Omnigent coupling by design).
+
+**Done in this change:**
+- New `moonmind/omnigent/authority_chain.py`: pure, total, secret-scanned `build_omnigent_authority_chain_evidence(...)` assembling the unified workspace→runtime→publication→terminal→cleanup→lease projection (AC5/AC3/AC6). Runs through `redact_sensitive_payload`; never raises.
+- Coordinator wiring: emits one `authority_chain` lifecycle event (nested under a single `authorityChain` metadata key) before `terminal`, on both success and failure paths. Added `authorityChain` to the bridge-store metadata allowlist (`bridge_store.py` ~line 1217).
+- Controlling journey `tests/integration/reliability_journey/test_omnigent_publication_semantics_journey.py` (integration_ci, hermetic — real git + bare remote + real `PublishService` + real `_prepare_workspace` + real coordinator): branch publish + idempotent publication-only recovery, canonical PR publish, no-publish terminal saved-work checkpoint with distinct source/output branches, and coordinator materialization→cleanup→replay for static (read-only) and on-demand (mutation) modes.
+- Unit tests: `tests/unit/omnigent/test_authority_chain_evidence.py` (6), `test_bridge_store.py::test_authority_chain_metadata_persists_through_allowlist`, `test_oauth_profile_lifecycle.py::test_coordinator_emits_bounded_authority_chain_before_terminal`.
+
+**Still open on #3561:** AC8 (update parent #3507 with resolvable evidence before closure) is an external issue-tracking action, not a repo change. A frontend Workflow-Detail renderer specifically for the `lifecycle.authority_chain` event was not added (the event + bounded metadata reach the existing events projection intact; dedicated UI is optional polish).
+
+**Env note:** `tests/unit/omnigent/test_host_protocol_adapter.py`, `test_host_auth_profile.py`, `test_host_auth_remediation.py`, `test_embedded_host_channel.py` fail with "pinned Omnigent ... unavailable" — the same pre-existing missing-upstream environment blocker noted for #3507; confirmed identical with this change stashed, unrelated.

--- a/moonmind/omnigent/authority_chain.py
+++ b/moonmind/omnigent/authority_chain.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
 from typing import Any
+from urllib.parse import urlsplit, urlunsplit
 
 from moonmind.utils.logging import redact_sensitive_payload
 
@@ -44,12 +45,58 @@ _PUBLICATION_REF_KEYS = (
     "captureManifestRef",
 )
 
+# The subset of publication refs that constitute realized terminal evidence the
+# publication owner produces after the run: a recorded commit, a verified push,
+# or a created pull request. Their presence reconciles the authorized
+# pre-publication snapshot into a published disposition.
+_TERMINAL_PUBLICATION_EVIDENCE_KEYS = (
+    "commitRef",
+    "pushRef",
+    "pullRequestRef",
+    "pullRequestUrl",
+)
+
 
 def _text(value: Any) -> str | None:
     text = str(value).strip() if value is not None else ""
     if not text:
         return None
     return text[:_MAX_STRING_CHARS]
+
+
+def _repository_identity(value: Any) -> str | None:
+    """Project a credential-free canonical repository identity.
+
+    An authored repository source may embed URL userinfo, for example
+    ``https://alice:token@github.com/org/repo.git`` or an scp-style
+    ``user:token@github.com:org/repo.git``. ``redact_sensitive_payload`` does not
+    recognize userinfo under the ``repository`` key, so the username/password
+    would otherwise persist verbatim in the durable lifecycle journal. Strip the
+    userinfo here so only the credential-free host/path identity is recorded.
+    """
+
+    text = _text(value)
+    if text is None:
+        return None
+    # scheme://[userinfo@]host/path — drop the userinfo component entirely.
+    split = urlsplit(text)
+    if split.scheme and split.netloc and "@" in split.netloc:
+        host = split.hostname or ""
+        if split.port:
+            host = f"{host}:{split.port}"
+        return _text(
+            urlunsplit(
+                (split.scheme, host, split.path, split.query, split.fragment)
+            )
+        )
+    # scp-style ``[user[:pass]@]host:path`` (no scheme). Only strip userinfo that
+    # carries an embedded credential (``user:pass@``); a bare ``git@`` username is
+    # a conventional, non-sensitive identity and is preserved.
+    if "://" not in text and "@" in text:
+        userinfo, _, remainder = text.partition("@")
+        if ":" in userinfo and "/" not in userinfo:
+            return _text(remainder)
+    return text
 
 
 def _ref_list(values: Any) -> list[str]:
@@ -70,14 +117,22 @@ def _class_list(values: Any) -> list[str]:
 
 
 def _publication_state(
-    *, publish_mode: str, repository_mutation: bool, terminal_status: str
+    *,
+    publish_mode: str,
+    repository_mutation: bool,
+    terminal_status: str,
+    publication_evidence_present: bool = False,
 ) -> str:
     """Classify the publication disposition MoonMind owns for this run.
 
     The coordinator does not itself push; the actual commit/push/PR side effects
     are performed by the shared publication path after the run result returns.
-    This records the disposition the Omnigent execution boundary authorized so the
-    downstream side-effect evidence can be reconciled against it.
+    Until that owner produces terminal evidence, the projection records the
+    disposition the Omnigent execution boundary *authorized*
+    (``authorized_pending_publication``). Once realized commit/push/PR evidence is
+    present in the result metadata, the state is reconciled to ``published`` so the
+    chain reflects the publication owner's terminal outcome rather than a stale
+    pre-publication snapshot.
     """
 
     normalized = (publish_mode or "none").strip().lower()
@@ -89,6 +144,8 @@ def _publication_state(
             if repository_mutation
             else "read_only_no_publication"
         )
+    if publication_evidence_present:
+        return "published"
     return "authorized_pending_publication"
 
 
@@ -144,9 +201,16 @@ def build_omnigent_authority_chain_evidence(
         "identityVerified": bool(workspace.get("identityVerified"))
         if workspace.get("identityVerified") is not None
         else None,
-        "repository": _text(repository),
+        "repository": _repository_identity(repository),
         "sourceBranch": _text(source_branch or materialization.get("startingBranch")),
-        "sourceCommit": _text(materialization.get("checkedOut")),
+        # Prefer the immutable resolved revision (``git rev-parse HEAD`` captured at
+        # materialization) so the authority evidence proves which source state ran,
+        # not a movable branch ref. Fall back to ``checkedOut`` only when a resolved
+        # commit is unavailable (for example an explicit detached-commit checkout).
+        "sourceCommit": _text(
+            materialization.get("resolvedCommit")
+            or materialization.get("checkedOut")
+        ),
         "candidateHead": _text(
             materialization.get("outputBranch") or output_branch
         ),
@@ -196,6 +260,9 @@ def build_omnigent_authority_chain_evidence(
         ref = _text(metadata.get(key))
         if ref is not None:
             publication_refs[key] = ref
+    publication_evidence_present = any(
+        key in publication_refs for key in _TERMINAL_PUBLICATION_EVIDENCE_KEYS
+    )
 
     publication_section = {
         "publishMode": (publish_mode or "none").strip().lower() or "none",
@@ -210,6 +277,7 @@ def build_omnigent_authority_chain_evidence(
             publish_mode=publish_mode or "none",
             repository_mutation=bool(repository_mutation_required),
             terminal_status=terminal_status,
+            publication_evidence_present=publication_evidence_present,
         ),
         "declaredOutputRefs": _ref_list(result_output_refs),
         "evidenceRefs": publication_refs,

--- a/moonmind/omnigent/authority_chain.py
+++ b/moonmind/omnigent/authority_chain.py
@@ -1,0 +1,260 @@
+"""Bounded, credential-free authority-chain evidence for the Omnigent path.
+
+Tracks MoonLadderStudios/MoonMind#3561. The profile-bound Omnigent coordinator
+already emits per-stage lifecycle events (workspace resolution, credential mount,
+host registration, resource harvest, host cleanup, provider-lease release,
+terminal). Those are individually useful but do not, on their own, expose the
+single unified workspace -> runtime -> publication -> terminal -> cleanup ->
+lease authority chain that Workflow Detail and the protected release matrix need.
+
+This module assembles that one bounded projection from evidence the coordinator
+already holds. It is intentionally a pure, total function: it never raises, never
+carries credentials or raw daemon paths, and never reaches back into provider
+internals. The result is nested under a single ``authorityChain`` lifecycle key so
+it survives the bridge-store metadata allowlist intact.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from moonmind.utils.logging import redact_sensitive_payload
+
+AUTHORITY_CHAIN_SCHEMA_VERSION = "omnigent-authority-chain-v1"
+
+# Keep the projection compact so a large launch snapshot or output-ref list cannot
+# inflate the lifecycle journal past the compact-history policy.
+_MAX_STRING_CHARS = 512
+_MAX_REF_LIST = 32
+_MAX_REASONS = 20
+_MAX_CLASSES = 32
+
+# Result metadata keys that carry durable, non-sensitive publication/saved-work
+# evidence references produced downstream. They are surfaced as refs only.
+_PUBLICATION_REF_KEYS = (
+    "commitRef",
+    "pushRef",
+    "pullRequestRef",
+    "pullRequestUrl",
+    "savedWorkRef",
+    "terminalCheckpointRef",
+    "publicationRecoveryRef",
+    "resourceManifestRef",
+    "captureManifestRef",
+)
+
+
+def _text(value: Any) -> str | None:
+    text = str(value).strip() if value is not None else ""
+    if not text:
+        return None
+    return text[:_MAX_STRING_CHARS]
+
+
+def _ref_list(values: Any) -> list[str]:
+    if not isinstance(values, Sequence) or isinstance(values, (str, bytes)):
+        return []
+    out: list[str] = []
+    for value in values:
+        text = _text(value)
+        if text is not None and text not in out:
+            out.append(text)
+        if len(out) >= _MAX_REF_LIST:
+            break
+    return out
+
+
+def _class_list(values: Any) -> list[str]:
+    return _ref_list(values)[:_MAX_CLASSES]
+
+
+def _publication_state(
+    *, publish_mode: str, repository_mutation: bool, terminal_status: str
+) -> str:
+    """Classify the publication disposition MoonMind owns for this run.
+
+    The coordinator does not itself push; the actual commit/push/PR side effects
+    are performed by the shared publication path after the run result returns.
+    This records the disposition the Omnigent execution boundary authorized so the
+    downstream side-effect evidence can be reconciled against it.
+    """
+
+    normalized = (publish_mode or "none").strip().lower()
+    if terminal_status == "failed":
+        return "not_published_failed_run"
+    if normalized in {"", "none"}:
+        return (
+            "unpublished_saved_work_eligible"
+            if repository_mutation
+            else "read_only_no_publication"
+        )
+    return "authorized_pending_publication"
+
+
+def build_omnigent_authority_chain_evidence(
+    *,
+    effective_launch: Mapping[str, Any] | None,
+    workspace_resolution: Mapping[str, Any] | None,
+    repository: str | None,
+    source_branch: str | None,
+    output_branch: str | None,
+    publish_mode: str | None,
+    required_capabilities: Sequence[str] = (),
+    repository_mutation_required: bool = False,
+    github_mutation_required: bool = False,
+    profile_authorization: Mapping[str, Any] | None = None,
+    result_output_refs: Sequence[str] = (),
+    result_metadata: Mapping[str, Any] | None = None,
+    terminal_status: str = "completed",
+    cleanup_mode: str | None = None,
+    cleanup_completed: bool = False,
+    lease_released: bool = False,
+    janitor_required: bool = False,
+    release_ordering: Sequence[str] = (),
+    reasons: Sequence[Mapping[str, Any]] = (),
+) -> dict[str, Any]:
+    """Assemble the unified bounded authority-chain projection.
+
+    Every field is a compact scalar, ref, or ref-list; the entire payload is run
+    through :func:`redact_sensitive_payload` before returning so a token, header,
+    or auth path that slipped into any upstream evidence value is scrubbed rather
+    than published. The function is total: missing inputs yield partial evidence,
+    never an exception, so best-effort evidence emission can never break a run.
+    """
+
+    launch = effective_launch if isinstance(effective_launch, Mapping) else {}
+    workspace = (
+        workspace_resolution if isinstance(workspace_resolution, Mapping) else {}
+    )
+    authorization = (
+        profile_authorization if isinstance(profile_authorization, Mapping) else {}
+    )
+    metadata = result_metadata if isinstance(result_metadata, Mapping) else {}
+    materialization = (
+        workspace.get("materialization")
+        if isinstance(workspace.get("materialization"), Mapping)
+        else {}
+    )
+
+    workspace_section = {
+        "locatorKind": _text(workspace.get("locatorKind")),
+        "workspaceId": _text(workspace.get("workspaceId")),
+        "relativePath": _text(workspace.get("relativePath")),
+        "identityVerified": bool(workspace.get("identityVerified"))
+        if workspace.get("identityVerified") is not None
+        else None,
+        "repository": _text(repository),
+        "sourceBranch": _text(source_branch or materialization.get("startingBranch")),
+        "sourceCommit": _text(materialization.get("checkedOut")),
+        "candidateHead": _text(
+            materialization.get("outputBranch") or output_branch
+        ),
+        "materializationAction": _text(materialization.get("action")),
+        "sourceKind": _text(materialization.get("sourceKind")),
+        "restoreInputRefs": _ref_list(
+            [
+                entry.get("ref") if isinstance(entry, Mapping) else entry
+                for entry in (materialization.get("restoreInputs") or [])
+            ]
+        ),
+    }
+
+    runtime_section = {
+        "hostMode": _text(launch.get("hostMode")),
+        "effectiveLaunchRef": _text(launch.get("snapshotRef"))
+        or _text(authorization.get("effectiveLaunchRef")),
+        "executionProfileRef": _text(launch.get("executionProfileRef")),
+        "launchPolicyRef": _text(launch.get("launchPolicyRef")),
+        "policyRef": _text(
+            (launch.get("policyAuthority") or {}).get("policyRef")
+            if isinstance(launch.get("policyAuthority"), Mapping)
+            else None
+        ),
+        "endpointRef": _text(
+            launch.get("endpointRef") or authorization.get("endpointRef")
+        ),
+        "providerProfileId": _text(
+            launch.get("providerProfileId")
+            or authorization.get("providerProfileId")
+        ),
+        "credentialGeneration": authorization.get("credentialGeneration")
+        if isinstance(authorization.get("credentialGeneration"), int)
+        else None,
+        "providerLeaseRef": _text(authorization.get("providerLeaseRef")),
+        "hostBindingRef": _text(authorization.get("hostBindingRef")),
+        "hostLeaseRef": _text(authorization.get("hostLeaseRef")),
+        "omnigentHostId": _text(authorization.get("omnigentHostId")),
+        "bridgeSessionId": _text(authorization.get("bridgeSessionId")),
+        "mountClasses": _class_list(launch.get("mountClasses")),
+        "capabilityClasses": _class_list(required_capabilities),
+        "controlCapabilities": _class_list(launch.get("controlCapabilities")),
+    }
+
+    publication_refs: dict[str, Any] = {}
+    for key in _PUBLICATION_REF_KEYS:
+        ref = _text(metadata.get(key))
+        if ref is not None:
+            publication_refs[key] = ref
+
+    publication_section = {
+        "publishMode": (publish_mode or "none").strip().lower() or "none",
+        "outputBranch": _text(output_branch),
+        "repositoryMutationAuthorized": bool(
+            repository_mutation_required
+            or (isinstance(launch.get("repositoryMutation"), bool)
+                and launch.get("repositoryMutation"))
+        ),
+        "githubMutationRequired": bool(github_mutation_required),
+        "publicationState": _publication_state(
+            publish_mode=publish_mode or "none",
+            repository_mutation=bool(repository_mutation_required),
+            terminal_status=terminal_status,
+        ),
+        "declaredOutputRefs": _ref_list(result_output_refs),
+        "evidenceRefs": publication_refs,
+    }
+
+    terminal_section = {
+        "harvestState": terminal_status,
+        "cleanupMode": _text(cleanup_mode),
+        "cleanupCompleted": bool(cleanup_completed),
+        "leaseReleased": bool(lease_released),
+        "janitorRequired": bool(janitor_required),
+        "releaseOrdering": _ref_list(release_ordering),
+    }
+
+    bounded_reasons: list[dict[str, Any]] = []
+    for reason in reasons:
+        if not isinstance(reason, Mapping):
+            continue
+        bounded_reasons.append(
+            {
+                "stage": _text(reason.get("stage")),
+                "code": _text(reason.get("code")),
+                "failureClass": _text(reason.get("failureClass")),
+                "remediationAction": _text(reason.get("remediationAction")),
+            }
+        )
+        if len(bounded_reasons) >= _MAX_REASONS:
+            break
+
+    evidence = {
+        "schemaVersion": AUTHORITY_CHAIN_SCHEMA_VERSION,
+        "workspace": workspace_section,
+        "runtime": runtime_section,
+        "publication": publication_section,
+        "terminal": terminal_section,
+        "reasons": bounded_reasons,
+    }
+    # Fail-closed secret hygiene: scrub the whole projection so any credential,
+    # authorization header, or auth path that leaked into an upstream evidence
+    # value is redacted rather than surfaced through Workflow Detail.
+    scrubbed = redact_sensitive_payload(evidence)
+    return scrubbed if isinstance(scrubbed, dict) else dict(evidence)
+
+
+__all__ = [
+    "AUTHORITY_CHAIN_SCHEMA_VERSION",
+    "build_omnigent_authority_chain_evidence",
+]

--- a/moonmind/omnigent/bridge_store.py
+++ b/moonmind/omnigent/bridge_store.py
@@ -1214,6 +1214,12 @@ class OmnigentBridgeSessionStore:
                         "relativePath",
                         "identityVerified",
                         "materialization",
+                        # Unified bounded workspace -> runtime -> publication ->
+                        # terminal -> cleanup -> lease authority-chain projection
+                        # (MoonLadderStudios/MoonMind#3561). Nested under one key so
+                        # the whole compact, secret-scanned structure survives this
+                        # top-level allowlist intact.
+                        "authorityChain",
                     }
                 }
             journal.append(entry)

--- a/moonmind/omnigent/oauth_host_runtime.py
+++ b/moonmind/omnigent/oauth_host_runtime.py
@@ -1134,11 +1134,24 @@ class OmnigentOAuthHostRuntime:
                 )
             output_branch = target
 
+        # ``checkedOut`` records the authored selection (a branch name for the
+        # normal path), which is a movable ref. Resolve the immutable revision that
+        # was actually checked out so durable authority evidence proves which source
+        # state executed and cannot drift after the branch advances.
+        resolved_commit: str | None = None
+        code, out, _err = await self._run(
+            "git", "-C", str(workspace), "rev-parse", "HEAD",
+            env=git_env, check=False,
+        )
+        if code == 0:
+            resolved_commit = str(out or "").strip() or None
+
         return {
             "action": "materialized",
             "sourceKind": source_kind,
             "startingBranch": start,
             "checkedOut": checked_out,
+            "resolvedCommit": resolved_commit,
             "outputBranch": output_branch,
             "commit": commit or None,
         }

--- a/moonmind/omnigent/profile_bound_execution.py
+++ b/moonmind/omnigent/profile_bound_execution.py
@@ -20,6 +20,9 @@ from api_service.services.omnigent_policies import (
     OmnigentPolicyService,
     PolicyConflict,
 )
+from moonmind.omnigent.authority_chain import (
+    build_omnigent_authority_chain_evidence,
+)
 from moonmind.omnigent.bridge_store import OmnigentBridgeSessionStore
 from moonmind.omnigent.checkpoints import (
     CandidateWorkspaceAuthority,
@@ -363,6 +366,14 @@ class OmnigentProfileBoundExecutionCoordinator:
         effective_launch: dict[str, Any] | None = None
         remediation_resolution: Mapping[str, Any] | None = None
         terminal_status = "completed"
+        # Bounded, credential-free evidence accumulated across the run so the
+        # unified authority chain (MoonLadderStudios/MoonMind#3561) can be emitted
+        # once at terminal, covering both success and every failure path.
+        authority_workspace_resolution: Mapping[str, Any] | None = None
+        authority_result: AgentRunResult | None = None
+        authority_bridge_session_id: str | None = None
+        authority_cleanup_mode: str | None = None
+        authority_reasons: list[dict[str, Any]] = []
         try:
             await emit("request_validated", "started")
             if not profile_id:
@@ -646,6 +657,9 @@ class OmnigentProfileBoundExecutionCoordinator:
                 omnigent_host_id=binding.static_host_id,
                 effective_launch_snapshot=effective_launch,
             )
+            authority_bridge_session_id = str(
+                getattr(bridge, "bridge_session_id", "") or ""
+            ) or None
             if host_lease.status == "allocating":
                 host_lease = await self._hosts.transition_host_lease(
                     host_lease.lease_id,
@@ -711,6 +725,11 @@ class OmnigentProfileBoundExecutionCoordinator:
             )
             await emit(current_stage, "completed")
             workspace_resolution = preflight.get("workspaceResolution")
+            authority_workspace_resolution = (
+                dict(workspace_resolution)
+                if isinstance(workspace_resolution, Mapping)
+                else None
+            )
             if isinstance(workspace_resolution, Mapping) and workspace_resolution:
                 # Durable, bounded, credential-free evidence of which workspace was
                 # resolved and how it was materialized, for Workflow Detail.
@@ -818,6 +837,7 @@ class OmnigentProfileBoundExecutionCoordinator:
                 artifact_gateway=self._artifact_gateway,
                 run_store=self._run_store,
             )
+            authority_result = result
             result_failed = bool(result.failure_class or result.provider_error_code)
             result_status = "failed" if result_failed else "completed"
             terminal_status = result_status
@@ -856,6 +876,14 @@ class OmnigentProfileBoundExecutionCoordinator:
             terminal_status = "failed"
             if bridge_ready:
                 code, failure_class, remediation = _failure_evidence(exc)
+                authority_reasons.append(
+                    {
+                        "stage": current_stage,
+                        "code": code,
+                        "failureClass": failure_class,
+                        "remediationAction": remediation,
+                    }
+                )
                 if isinstance(exc, MountedToolPreflightError):
                     await self._run_store.record_lifecycle_event(
                         request.idempotency_key,
@@ -892,6 +920,7 @@ class OmnigentProfileBoundExecutionCoordinator:
                         if binding.host_launch_profile_ref
                         else "static_drain"
                     )
+                    authority_cleanup_mode = cleanup_mode
                     await emit(
                         "host_cleanup",
                         "started",
@@ -935,6 +964,14 @@ class OmnigentProfileBoundExecutionCoordinator:
                         # Preserve the primary cleanup failure when best-effort
                         # persistence of that failure also becomes unavailable.
                         pass
+                    authority_reasons.append(
+                        {
+                            "stage": "host_cleanup",
+                            "code": type(cleanup_exc).__name__,
+                            "failureClass": "system_error",
+                            "remediationAction": "inspect_cleanup_diagnostics",
+                        }
+                    )
                     await emit(
                         "host_cleanup",
                         "failed",
@@ -991,15 +1028,110 @@ class OmnigentProfileBoundExecutionCoordinator:
                         metadata={"leaseReleased": False, "janitorRequired": True},
                         ignore_errors=True,
                     )
+            janitor_required = provider_lease is not None and not lease_released
+            # Emit the single unified, bounded, credential-free authority chain
+            # (MoonLadderStudios/MoonMind#3561) before terminal so Workflow Detail
+            # exposes one workspace -> runtime -> publication -> terminal ->
+            # cleanup -> lease projection for both success and failure paths.
+            try:
+                release_ordering: list[str] = []
+                if host_lease is not None:
+                    release_ordering.append(
+                        "host_cleanup_completed"
+                        if safe_to_release_provider
+                        else "host_cleanup_incomplete"
+                    )
+                if provider_lease is not None:
+                    release_ordering.append(
+                        "provider_lease_released"
+                        if lease_released
+                        else "provider_lease_release_deferred"
+                    )
+                release_ordering.append("terminal")
+                if janitor_required:
+                    authority_reasons.append(
+                        {
+                            "stage": "profile_lease_release",
+                            "code": "credential_cleanup_incomplete",
+                            "failureClass": "system_error",
+                            "remediationAction": "inspect_cleanup_diagnostics",
+                        }
+                    )
+                authorization_evidence: dict[str, Any] = {}
+                if profile_id:
+                    authorization_evidence["providerProfileId"] = profile_id
+                if provider_lease is not None:
+                    authorization_evidence["providerLeaseRef"] = provider_lease.lease_id
+                if binding is not None:
+                    authorization_evidence["hostBindingRef"] = binding.binding_ref
+                    authorization_evidence["endpointRef"] = binding.endpoint_ref
+                if host_lease is not None:
+                    authorization_evidence["hostLeaseRef"] = host_lease.lease_id
+                    authorization_evidence["credentialGeneration"] = (
+                        host_lease.credential_generation
+                    )
+                    if host_lease.omnigent_host_id:
+                        authorization_evidence["omnigentHostId"] = (
+                            host_lease.omnigent_host_id
+                        )
+                if effective_launch is not None:
+                    authorization_evidence["effectiveLaunchRef"] = str(
+                        effective_launch.get("snapshotRef") or ""
+                    )
+                if authority_bridge_session_id:
+                    authorization_evidence["bridgeSessionId"] = (
+                        authority_bridge_session_id
+                    )
+                authority_chain = build_omnigent_authority_chain_evidence(
+                    effective_launch=effective_launch,
+                    workspace_resolution=authority_workspace_resolution,
+                    repository=self._repository_source(request) or None,
+                    source_branch=self._starting_branch(request),
+                    output_branch=self._target_branch(request),
+                    publish_mode=str(
+                        (request.parameters or {}).get("publishMode") or "none"
+                    ),
+                    required_capabilities=self._required_capabilities(request),
+                    repository_mutation_required=self._repository_mutation_required(
+                        request
+                    ),
+                    github_mutation_required=self._github_mutation_required(request),
+                    profile_authorization=authorization_evidence,
+                    result_output_refs=(
+                        authority_result.output_refs
+                        if authority_result is not None
+                        else ()
+                    ),
+                    result_metadata=(
+                        authority_result.metadata
+                        if authority_result is not None
+                        else None
+                    ),
+                    terminal_status=terminal_status,
+                    cleanup_mode=authority_cleanup_mode,
+                    cleanup_completed=safe_to_release_provider,
+                    lease_released=lease_released,
+                    janitor_required=janitor_required,
+                    release_ordering=release_ordering,
+                    reasons=authority_reasons,
+                )
+                await emit(
+                    "authority_chain",
+                    "completed",
+                    metadata={"authorityChain": authority_chain},
+                    ignore_errors=True,
+                )
+            except Exception:
+                # Bounded evidence is best-effort and must never mask the primary
+                # run outcome or its terminal record.
+                pass
             await emit(
                 "terminal",
                 terminal_status,
                 metadata={
                     "cleanupCompleted": safe_to_release_provider,
                     "leaseReleased": lease_released,
-                    "janitorRequired": (
-                        provider_lease is not None and not lease_released
-                    ),
+                    "janitorRequired": janitor_required,
                 },
                 ignore_errors=True,
             )

--- a/moonmind/omnigent/profile_bound_execution.py
+++ b/moonmind/omnigent/profile_bound_execution.py
@@ -919,6 +919,31 @@ class OmnigentProfileBoundExecutionCoordinator:
             result_failed = bool(result.failure_class or result.provider_error_code)
             result_status = "failed" if result_failed else "completed"
             terminal_status = result_status
+            if result_failed:
+                # The runner returned a failed ``AgentRunResult`` instead of
+                # raising, so the exception path never runs. Carry the provider
+                # failure code, class, and remediation into the unified authority
+                # chain; otherwise ``harvestState="failed"`` would surface with an
+                # empty reasons list, dropping evidence already on the result.
+                authority_reasons.append(
+                    {
+                        "stage": "resource_harvest",
+                        "code": (
+                            result.provider_error_code
+                            or (
+                                str(result.failure_class)
+                                if result.failure_class
+                                else "provider_run_failed"
+                            )
+                        ),
+                        "failureClass": (
+                            str(result.failure_class)
+                            if result.failure_class
+                            else None
+                        ),
+                        "remediationAction": result.retry_recommendation or None,
+                    }
+                )
             await emit("first_message_prepare", result_status)
             await emit("first_message_post", result_status)
             await emit(

--- a/tests/integration/reliability_journey/test_omnigent_publication_semantics_journey.py
+++ b/tests/integration/reliability_journey/test_omnigent_publication_semantics_journey.py
@@ -1,0 +1,709 @@
+"""Controlling journey for MoonLadderStudios/MoonMind#3561.
+
+Extends the #3507 materialization journey through the parts #3561 owns:
+repository work executed through the Omnigent path must obey the same authored
+branch, mutation, publication, saved-work, publication-only recovery, retry, and
+bounded-evidence contracts as normal MoonMind workflows.
+
+Everything here is hermetic (no Docker, no network): a real Git source and a real
+bare remote back the canonical ``PublishService`` publisher, the real
+``OmnigentOAuthHostRuntime`` materializes the authoritative workspace, and the
+real profile-bound coordinator is driven through materialization -> repository
+mutation -> publication/saved-work -> terminal harvest -> cleanup -> replay for
+both the static and on-demand host modes.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import subprocess
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from uuid import UUID
+
+import pytest
+
+from moonmind.omnigent.checkpoints import OmnigentCheckpointIdentity
+from moonmind.omnigent.oauth_host_runtime import OmnigentOAuthHostRuntime
+from moonmind.omnigent.policies import compile_policy_snapshot
+from moonmind.omnigent.profile_bound_execution import (
+    OmnigentProfileBoundExecutionCoordinator,
+)
+from moonmind.provider_profiles.lease_client import CredentialLeasePurpose
+from moonmind.publish.service import PublishService
+from moonmind.schemas.agent_runtime_models import (
+    AgentExecutionRequest,
+    AgentRunResult,
+    AuthVolumeRef,
+    CredentialMountRef,
+    OmnigentHostLease,
+    OmnigentOAuthHostBinding,
+)
+from api_service.db.models import (
+    ProviderCredentialSource,
+    ProviderProfileAuthState,
+    RuntimeMaterializationMode,
+)
+from tests.unit.omnigent.test_policy_authority import policy_document
+
+
+pytestmark = [pytest.mark.integration, pytest.mark.integration_ci]
+
+
+# --- Git helpers ------------------------------------------------------------
+
+
+def _git(cwd: Path, *args: str) -> None:
+    subprocess.run(
+        [
+            "git",
+            "-c",
+            "user.email=journey@moonmind.test",
+            "-c",
+            "user.name=MoonMind Journey",
+            "-c",
+            "init.defaultBranch=main",
+            *args,
+        ],
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+    )
+
+
+def _git_out(cwd: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", "-C", str(cwd), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+def _init_bare_remote_with_seed(tmp_path: Path) -> Path:
+    """Create a bare remote holding a seeded ``main`` branch; return the remote."""
+
+    remote = tmp_path / "remote.git"
+    remote.mkdir(parents=True)
+    _git(remote, "init", "--bare")
+    seed = tmp_path / "seed"
+    seed.mkdir()
+    _git(seed, "init")
+    _git(seed, "checkout", "-B", "main")
+    (seed / "app.py").write_text("print('hello')\n", encoding="utf-8")
+    _git(seed, "add", "app.py")
+    _git(seed, "commit", "-m", "seed")
+    _git(seed, "remote", "add", "origin", str(remote))
+    _git(seed, "push", "-u", "origin", "main")
+    return remote
+
+
+def _configure_identity(repo: Path) -> None:
+    _git(repo, "config", "user.email", "journey@moonmind.test")
+    _git(repo, "config", "user.name", "MoonMind Journey")
+
+
+async def _run_command(cmd, *, cwd=None, check=True, env=None, **_kwargs):
+    """Minimal async command runner matching the PublishService contract."""
+
+    process = await asyncio.create_subprocess_exec(
+        *[str(part) for part in cmd],
+        cwd=str(cwd) if cwd else None,
+        env=env,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    stdout, stderr = await process.communicate()
+    if check and process.returncode != 0:
+        raise RuntimeError(
+            f"command {cmd!r} failed: {stderr.decode('utf-8', 'replace')[:200]}"
+        )
+    return SimpleNamespace(
+        stdout=stdout.decode("utf-8", "replace"),
+        stderr=stderr.decode("utf-8", "replace"),
+        returncode=process.returncode,
+    )
+
+
+async def _materialize_workspace(
+    tmp_path: Path,
+    *,
+    workflow_id: str,
+    step_execution_id: str,
+    source: Path,
+    starting_branch: str,
+    target_branch: str,
+) -> tuple[OmnigentOAuthHostRuntime, Path]:
+    workspace_root = tmp_path / "workspaces"
+    runtime = OmnigentOAuthHostRuntime(
+        client=SimpleNamespace(),
+        workspace_root=workspace_root,
+        repository_source_root=tmp_path,
+    )
+    workspace_id = hashlib.sha256(
+        f"{workflow_id}:{step_execution_id}".encode("utf-8")
+    ).hexdigest()[:24]
+    locator = {"kind": "sandbox", "workspaceId": workspace_id, "relativePath": "repo"}
+    workspace = await runtime._prepare_workspace(
+        workspace_locator=locator,
+        current_workflow_id=workflow_id,
+        current_step_execution_id=step_execution_id,
+        repository_source=str(source),
+        starting_branch=starting_branch,
+        target_branch=target_branch,
+    )
+    _configure_identity(workspace)
+    return runtime, workspace
+
+
+# --- Journey 1: mutation -> branch publication -> publication-only recovery -
+
+
+@pytest.mark.asyncio
+async def test_materialized_workspace_publishes_branch_and_recovery_is_idempotent(
+    tmp_path, monkeypatch
+) -> None:
+    # The outbound secret scan is the publication layer's own concern and is
+    # covered elsewhere; disable it so this journey is deterministic and offline.
+    monkeypatch.setattr(
+        "moonmind.publish.service.resolve_high_security_mode", lambda *a, **k: False
+    )
+    remote = _init_bare_remote_with_seed(tmp_path)
+
+    _runtime, workspace = await _materialize_workspace(
+        tmp_path,
+        workflow_id="mm:wf-3561",
+        step_execution_id="mm:wf-3561:run:implement:execution:1",
+        source=remote,
+        starting_branch="main",
+        target_branch="agent/implement",
+    )
+
+    # Authored source, output, and publication branches stay distinct (AC1).
+    assert _git_out(workspace, "rev-parse", "--abbrev-ref", "HEAD") == (
+        "agent/implement"
+    )
+    assert (workspace / "app.py").is_file()
+
+    # Simulate the Omnigent agent mutating the repository (uncommitted work that
+    # canonical publication owns the commit/branch/push for).
+    (workspace / "feature.py").write_text("print('feature')\n", encoding="utf-8")
+
+    publisher = PublishService()
+    job_id = UUID("00000000-0000-0000-0000-000000003561")
+    result = await publisher.publish(
+        job_id=job_id,
+        instruction="Add the feature module",
+        publish_mode="branch",
+        publish_base_branch="main",
+        runtime_mode="codex",
+        repo_dir=workspace,
+        run_command=_run_command,
+    )
+
+    assert result is not None
+    assert result.status == "published"
+    assert result.commit_created is True
+    assert result.branch_pushed is True
+    publication_branch = result.branch_name
+    assert publication_branch and publication_branch.startswith("moonmind-job-")
+    # Source (main), output (agent/implement), and publication branch are three
+    # distinct refs; none was silently reset onto another (AC1/AC3).
+    assert publication_branch not in {"main", "agent/implement"}
+
+    # The push reached the real remote with the mutation.
+    remote_branches = _git_out(remote, "branch", "--list", publication_branch)
+    assert publication_branch in remote_branches
+    remote_head = _git_out(remote, "rev-parse", publication_branch)
+
+    # Publication-only recovery from the already-qualified candidate is
+    # idempotent: the accepted work is already committed and pushed, so a retry
+    # neither creates a second commit nor a divergent remote head (AC4).
+    recovery = await publisher.publish(
+        job_id=job_id,
+        instruction="Add the feature module",
+        publish_mode="branch",
+        publish_base_branch="main",
+        runtime_mode="codex",
+        repo_dir=workspace,
+        run_command=_run_command,
+    )
+    assert recovery is not None
+    assert recovery.status == "skipped"
+    assert recovery.reason_code == "no_commit"
+    assert _git_out(remote, "rev-parse", publication_branch) == remote_head
+
+
+# --- Journey 2: pull-request publication through canonical contract ---------
+
+
+@pytest.mark.asyncio
+async def test_materialized_workspace_publishes_pull_request_through_canonical_contract(
+    tmp_path, monkeypatch
+) -> None:
+    monkeypatch.setattr(
+        "moonmind.publish.service.resolve_high_security_mode", lambda *a, **k: False
+    )
+    # Managed publishing resolves an explicit token; ambient gh state is never a
+    # publishing authority. Stub the resolver so the PR path stays offline.
+    monkeypatch.setattr(
+        "moonmind.auth.github_credentials.resolve_github_credential",
+        AsyncMock(return_value=SimpleNamespace(token="ghp_journeytoken", safe_summary="stub")),
+    )
+    remote = _init_bare_remote_with_seed(tmp_path)
+    _runtime, workspace = await _materialize_workspace(
+        tmp_path,
+        workflow_id="mm:wf-3561-pr",
+        step_execution_id="mm:wf-3561-pr:run:implement:execution:1",
+        source=remote,
+        starting_branch="main",
+        target_branch="agent/implement",
+    )
+    (workspace / "feature.py").write_text("print('feature')\n", encoding="utf-8")
+
+    created_calls: list[dict] = []
+
+    async def _create_pull_request(**kwargs):
+        created_calls.append(kwargs)
+        return SimpleNamespace(
+            created=True, url="https://github.com/owner/repo/pull/7"
+        )
+
+    publisher = PublishService(github_create_pull_request=_create_pull_request)
+    result = await publisher.publish(
+        job_id=UUID("00000000-0000-0000-0000-000000003562"),
+        instruction="Add the feature module",
+        publish_mode="pr",
+        publish_base_branch="main",
+        runtime_mode="codex",
+        repo_dir=workspace,
+        run_command=_run_command,
+        repo="owner/repo",
+    )
+
+    assert result is not None
+    assert result.status == "published"
+    assert result.pr_url == "https://github.com/owner/repo/pull/7"
+    # The canonical PR contract targets base=main from the moonmind head branch.
+    assert len(created_calls) == 1
+    assert created_calls[0]["base"] == "main"
+    assert created_calls[0]["head"] == result.branch_name
+    assert created_calls[0]["repo"] == "owner/repo"
+
+
+# --- Journey 3: no-publish preserves the terminal saved-work contract -------
+
+
+@pytest.mark.asyncio
+async def test_no_publish_preserves_distinct_branch_saved_work_contract(
+    tmp_path,
+) -> None:
+    remote = _init_bare_remote_with_seed(tmp_path)
+    _runtime, workspace = await _materialize_workspace(
+        tmp_path,
+        workflow_id="mm:wf-3561-none",
+        step_execution_id="mm:wf-3561-none:run:implement:execution:1",
+        source=remote,
+        starting_branch="main",
+        target_branch="agent/implement",
+    )
+    (workspace / "feature.py").write_text("print('feature')\n", encoding="utf-8")
+    _git(workspace, "add", "-A")
+    _git(workspace, "commit", "-m", "wip")
+    head_commit = _git_out(workspace, "rev-parse", "HEAD")
+    baseline_commit = _git_out(workspace, "rev-parse", "main")
+
+    # publishMode=none performs no external publication.
+    publisher = PublishService()
+    assert (
+        await publisher.publish(
+            job_id=UUID("00000000-0000-0000-0000-000000003563"),
+            instruction="Add the feature module",
+            publish_mode="none",
+            publish_base_branch="main",
+            runtime_mode="codex",
+            repo_dir=workspace,
+            run_command=_run_command,
+        )
+        is None
+    )
+
+    # The work is preserved as a durable terminal saved-work checkpoint whose
+    # identity keeps source and output branches distinct and records that it was
+    # never published (AC1/AC3 terminal saved-work capture).
+    checkpoint = OmnigentCheckpointIdentity(
+        workflowId="mm:wf-3561-none",
+        runId="run-1",
+        logicalStepId="implement",
+        stepExecutionId="mm:wf-3561-none:run:implement:execution:1",
+        attemptOrdinal=1,
+        boundary="after_execution",
+        providerProfileId="codex",
+        credentialRef="credential://codex",
+        credentialGeneration=3,
+        hostBindingRef="omnigent-oauth:codex",
+        endpointRef="default",
+        bridgeSessionId="bridge-1",
+        externalStateRef="artifact://external-state",
+        externalStateDigest="sha256:" + "0" * 64,
+        idempotencyKey="idem-none",
+        effectiveLaunchRef="omnigent-launch:sha256:" + "0" * 64,
+        executionProfileRef="omnigent-codex@1",
+        launchPolicyRef="codex-on-demand@1",
+        workspaceLocator={
+            "kind": "sandbox",
+            "workspaceId": "workspace-none",
+            "relativePath": "repo",
+        },
+        baselineCommit=baseline_commit,
+        headCommit=head_commit,
+        headRef="artifact://head",
+        headDigest="sha256:" + "2" * 64,
+        workspaceCheckpointRef="artifact://workspace-checkpoint",
+        workspaceCheckpointDigest="sha256:" + "3" * 64,
+        sourceBranch="main",
+        outputBranch="agent/implement",
+        publicationState="unpublished",
+        capturedAt=datetime(2026, 7, 31, tzinfo=UTC),
+        producerVersion="moonmind-journey",
+        validation={
+            "valid": True,
+            "liveReattachAvailable": False,
+            "workspaceColdRestoreAvailable": True,
+            "branchCreationAvailable": True,
+        },
+    )
+    assert checkpoint.publication_state == "unpublished"
+    assert checkpoint.source_branch == "main"
+    assert checkpoint.output_branch == "agent/implement"
+    assert checkpoint.source_branch != checkpoint.output_branch
+    assert checkpoint.baseline_commit != checkpoint.head_commit
+
+
+# --- Journey 4: coordinator materialization -> cleanup for both host modes --
+
+
+def _profile() -> SimpleNamespace:
+    return SimpleNamespace(
+        enabled=True,
+        auth_state=ProviderProfileAuthState.CONNECTED,
+        disabled_reason=None,
+        max_parallel_runs=1,
+        cooldown_after_429_seconds=900,
+        runtime_id="codex_cli",
+        credential_source=ProviderCredentialSource.OAUTH_VOLUME,
+        runtime_materialization_mode=RuntimeMaterializationMode.OAUTH_HOME,
+        volume_ref="codex_auth_volume",
+        volume_mount_path="/home/app/.codex",
+        secret_refs={},
+        command_behavior={},
+    )
+
+
+def _binding(*, on_demand: bool) -> OmnigentOAuthHostBinding:
+    return OmnigentOAuthHostBinding(
+        bindingRef="omnigent-oauth:codex",
+        providerProfileId="codex",
+        endpointRef="default",
+        harness="codex-native",
+        credentialMountRef=CredentialMountRef(
+            authVolumeRef=AuthVolumeRef(
+                providerProfileId="codex",
+                runtimeId="codex_cli",
+                providerId="openai",
+                volumeRef="codex_auth_volume",
+                credentialGeneration=3,
+                ownerUserId="user-1",
+            ),
+            targetPath="/home/app/.codex",
+            runtimeUid=1000,
+            runtimeGid=1000,
+        ),
+        staticHostId=None if on_demand else "host-1",
+        hostLaunchProfileRef="codex-on-demand@1" if on_demand else None,
+    )
+
+
+def _host_lease() -> OmnigentHostLease:
+    now = datetime(2026, 7, 31, tzinfo=UTC)
+    return OmnigentHostLease(
+        leaseId="host-lease-1",
+        providerProfileId="codex",
+        providerLeaseId="provider-lease-1",
+        bindingRef="omnigent-oauth:codex",
+        credentialGeneration=3,
+        omnigentHostId=None,
+        status="allocating",
+        acquiredAt=now,
+        lastHeartbeatAt=now,
+        expiresAt=now + timedelta(hours=1),
+    )
+
+
+async def _resolve_policy(_self, policy_ref):
+    document = policy_document()
+    if policy_ref.startswith("codex-on-demand@"):
+        document["host"]["mode"] = "on_demand_docker"
+        document["host"]["backendRef"] = "container-backend"
+        document["session"]["cleanup"] = "remove"
+    return compile_policy_snapshot(
+        policy_id=policy_ref.rsplit("@", 1)[0],
+        version=int(policy_ref.rsplit("@", 1)[1]),
+        document=document,
+        validation={"valid": True, "diagnostics": []},
+    )
+
+
+async def _drive_coordinator_materialization_to_cleanup(
+    tmp_path: Path,
+    *,
+    on_demand: bool,
+    publish_mode: str,
+) -> list[dict]:
+    """Run the real coordinator across a real workspace materialization.
+
+    Returns the ordered list of ``(event_type, status, metadata)`` records so the
+    caller can assert cleanup ordering, replay idempotency, and bounded evidence.
+    """
+
+    remote = _init_bare_remote_with_seed(tmp_path)
+    workspace_root = tmp_path / "workspaces"
+    real_runtime = OmnigentOAuthHostRuntime(
+        client=SimpleNamespace(),
+        workspace_root=workspace_root,
+        repository_source_root=tmp_path,
+    )
+    ordered: list[dict] = []
+
+    provider_lease = SimpleNamespace(
+        profile_id="codex",
+        runtime_id="codex_cli",
+        lease_id="provider-lease-1",
+        owner_id="owner-1",
+        purpose=CredentialLeasePurpose.EXECUTION_OMNIGENT,
+    )
+    binding = _binding(on_demand=on_demand)
+
+    class LeaseClient:
+        async def acquire_execution_lease(self, **_kwargs):
+            return provider_lease
+
+        async def release_lease(self, _lease):
+            ordered.append({"type": "provider_released", "status": "completed"})
+
+        async def record_cooldown(self, **_kwargs):
+            return None
+
+    class Hosts:
+        def __init__(self):
+            self.lease = _host_lease()
+
+        async def get_binding_for_profile(self, _profile_id):
+            return binding
+
+        async def create_or_update_static_binding(self, **kwargs):
+            if "effective_launch_snapshot" not in kwargs:
+                return binding
+            return binding.model_copy(
+                update={
+                    "host_launch_profile_ref": kwargs.get("host_launch_profile_ref")
+                    or binding.host_launch_profile_ref,
+                    "execution_profile_ref": kwargs["execution_profile_ref"],
+                    "launch_policy_ref": kwargs["launch_policy_ref"],
+                    "effective_launch_snapshot": kwargs["effective_launch_snapshot"],
+                }
+            )
+
+        async def create_or_get_host_lease(self, **_kwargs):
+            return self.lease
+
+        async def restart_host_lease(self, _lease_id):
+            self.lease = self.lease.model_copy(update={"status": "allocating"})
+            return self.lease
+
+        async def transition_host_lease(
+            self, _lease_id, *, expected_status, new_status, fields=None
+        ):
+            self.lease = self.lease.model_copy(
+                update={"status": new_status, **dict(fields or {})}
+            )
+            return self.lease
+
+        async def mark_host_lease_stopped(self, _lease_id):
+            ordered.append({"type": "host_stopped", "status": "completed"})
+            self.lease = self.lease.model_copy(update={"status": "stopped"})
+            return self.lease
+
+        async def mark_host_lease_failed(self, *_args, **_kwargs):
+            return None
+
+    class Runtime:
+        async def prepare_host(
+            self,
+            *,
+            workspace_locator,
+            current_workflow_id,
+            current_step_execution_id,
+            repository_source,
+            starting_branch=None,
+            target_branch=None,
+            **_kwargs,
+        ):
+            # Delegate to the REAL materialization boundary so the coordinator is
+            # proven end to end over an authoritative on-disk workspace.
+            workspace = await real_runtime._prepare_workspace(
+                workspace_locator=workspace_locator,
+                current_workflow_id=current_workflow_id,
+                current_step_execution_id=current_step_execution_id,
+                repository_source=repository_source,
+                starting_branch=starting_branch,
+                target_branch=target_branch,
+            )
+            assert workspace.is_dir()
+            return {
+                "hostId": "host-1",
+                "workspacePath": "/workspaces/run",
+                "workspaceResolution": dict(real_runtime._last_workspace_evidence),
+            }
+
+        async def stop_host(self, **_kwargs):
+            ordered.append({"type": "host_cleanup", "status": "completed"})
+
+    class Store:
+        async def get_or_create(self, **_kwargs):
+            return SimpleNamespace(bridge_session_id="bridge-1")
+
+        async def bind_profile_authorization(self, **_kwargs):
+            return SimpleNamespace(bridge_session_id="bridge-1")
+
+        async def record_lifecycle_event(self, _key, *, event_type, **kwargs):
+            ordered.append(
+                {
+                    "type": event_type,
+                    "status": kwargs.get("status"),
+                    "metadata": kwargs.get("metadata") or {},
+                }
+            )
+
+    async def execute(request, **_kwargs):
+        return AgentRunResult(summary="done", outputRefs=["artifact://out-1"])
+
+    coordinator = OmnigentProfileBoundExecutionCoordinator(
+        session_factory=lambda: None,
+        lease_client=LeaseClient(),
+        host_repository=Hosts(),
+        host_runtime=Runtime(),
+        run_store=Store(),
+        execution_runner=execute,
+        artifact_gateway=object(),
+    )
+    coordinator._resolve_profile = AsyncMock(return_value=_profile())
+    coordinator._resolve_policy_snapshot = _resolve_policy.__get__(coordinator)
+
+    workflow_id = f"mm:wf-3561-coord-{'ondemand' if on_demand else 'static'}"
+    step_execution_id = f"{workflow_id}:run:implement:execution:1"
+    request = AgentExecutionRequest(
+        agentKind="external",
+        agentId="omnigent",
+        executionProfileRef="codex",
+        correlationId=workflow_id,
+        idempotencyKey=f"idem-{workflow_id}",
+        workspaceSpec={
+            "workspaceLocator": {
+                "kind": "sandbox",
+                "workspaceId": hashlib.sha256(
+                    f"{workflow_id}:{step_execution_id}".encode("utf-8")
+                ).hexdigest()[:24],
+            },
+            "repository": str(remote),
+            "startingBranch": "main",
+            "targetBranch": "agent/implement",
+        },
+        parameters={
+            "stepExecution": {
+                "workflowId": workflow_id,
+                "stepExecutionId": step_execution_id,
+            },
+            "publishMode": publish_mode,
+            "omnigent": {"session": {"workspace": str(remote)}},
+        },
+    )
+
+    await coordinator.execute(request)
+    # Replay: the identical durable identity must not clone a second workspace or
+    # duplicate the host/session; materialization is observed as reuse (AC4).
+    await coordinator.execute(request)
+    return ordered
+
+
+@pytest.mark.asyncio
+async def test_coordinator_materialization_to_cleanup_on_demand_mutation(
+    tmp_path,
+) -> None:
+    ordered = await _drive_coordinator_materialization_to_cleanup(
+        tmp_path, on_demand=True, publish_mode="branch"
+    )
+    types = [entry["type"] for entry in ordered]
+
+    # Full authority handoff ordering: host stop -> provider lease release ->
+    # terminal, for the first run.
+    assert types.index("host_stopped") < types.index("profile_lease_release")
+    assert types.index("provider_released") < types.index(
+        "profile_lease_release", types.index("provider_released")
+    )
+    assert "authority_chain" in types
+    assert types.index("authority_chain") < types.index("terminal")
+
+    chains = [
+        entry["metadata"]["authorityChain"]
+        for entry in ordered
+        if entry["type"] == "authority_chain"
+    ]
+    assert len(chains) == 2
+    first, second = chains
+    # First run materialized; the replay reused the same authoritative workspace.
+    assert first["workspace"]["materializationAction"] == "materialized"
+    assert second["workspace"]["materializationAction"] == "reused_pre_materialized"
+    assert first["runtime"]["hostMode"] == "on_demand_docker"
+    assert first["publication"]["publishMode"] == "branch"
+    assert (
+        first["publication"]["publicationState"] == "authorized_pending_publication"
+    )
+    assert first["workspace"]["candidateHead"] == "agent/implement"
+    assert first["terminal"]["releaseOrdering"][-1] == "terminal"
+    # Bounded + credential-free: the internal daemon/sandbox workspace paths
+    # never leak (the authored repository identity is echoed as-is; here it is a
+    # local test path, but the container/host workspace path is not).
+    flat = repr(first)
+    assert "/workspaces/run" not in flat
+    assert "temporal_sandbox" not in flat
+    assert str(tmp_path / "workspaces") not in flat
+    assert "token" not in flat.lower()
+
+
+@pytest.mark.asyncio
+async def test_coordinator_materialization_to_cleanup_static_read_only(
+    tmp_path,
+) -> None:
+    ordered = await _drive_coordinator_materialization_to_cleanup(
+        tmp_path, on_demand=False, publish_mode="none"
+    )
+    types = [entry["type"] for entry in ordered]
+    assert types.index("host_stopped") < types.index("profile_lease_release")
+
+    chains = [
+        entry["metadata"]["authorityChain"]
+        for entry in ordered
+        if entry["type"] == "authority_chain"
+    ]
+    assert len(chains) == 2
+    first, second = chains
+    assert first["runtime"]["hostMode"] == "static_compose"
+    # Static read-only work performs no repository mutation or publication.
+    assert first["publication"]["publishMode"] == "none"
+    assert first["publication"]["publicationState"] == "read_only_no_publication"
+    assert first["terminal"]["cleanupMode"] == "static_drain"
+    assert second["workspace"]["materializationAction"] == "reused_pre_materialized"

--- a/tests/unit/omnigent/test_authority_chain_evidence.py
+++ b/tests/unit/omnigent/test_authority_chain_evidence.py
@@ -1,0 +1,231 @@
+"""Unit tests for the bounded Omnigent authority-chain evidence projection.
+
+Tracks MoonLadderStudios/MoonMind#3561: the unified workspace -> runtime ->
+publication -> terminal -> cleanup -> lease authority chain must be complete,
+compact, credential-free, and total (never raising on partial input).
+"""
+
+from __future__ import annotations
+
+from moonmind.omnigent.authority_chain import (
+    AUTHORITY_CHAIN_SCHEMA_VERSION,
+    build_omnigent_authority_chain_evidence,
+)
+
+
+def _effective_launch() -> dict:
+    return {
+        "hostMode": "on_demand_docker",
+        "snapshotRef": "omnigent-launch:sha256:" + "0" * 64,
+        "executionProfileRef": "omnigent-codex@1",
+        "launchPolicyRef": "codex-on-demand@1",
+        "endpointRef": "default",
+        "providerProfileId": "codex",
+        "mountClasses": ["workspace", "oauth_home", "skills_tools"],
+        "controlCapabilities": ["interrupt", "terminate", "clear_context"],
+        "repositoryMutation": True,
+        "policyAuthority": {"policyRef": "codex-on-demand@1"},
+    }
+
+
+def _workspace_resolution() -> dict:
+    return {
+        "locatorKind": "sandbox",
+        "workspaceId": "ws-abc123",
+        "relativePath": "repo",
+        "identityVerified": True,
+        "materialization": {
+            "action": "materialized",
+            "sourceKind": "github_https",
+            "startingBranch": "main",
+            "checkedOut": "main",
+            "outputBranch": "agent/impl",
+            "restoreInputs": [{"ref": "artifact://restore-1", "bytes": 12}],
+        },
+    }
+
+
+def test_authority_chain_assembles_complete_bounded_projection() -> None:
+    evidence = build_omnigent_authority_chain_evidence(
+        effective_launch=_effective_launch(),
+        workspace_resolution=_workspace_resolution(),
+        repository="owner/repo",
+        source_branch="main",
+        output_branch="agent/impl",
+        publish_mode="branch",
+        required_capabilities=["gh", "git"],
+        repository_mutation_required=True,
+        github_mutation_required=True,
+        profile_authorization={
+            "providerProfileId": "codex",
+            "providerLeaseRef": "provider-lease-1",
+            "hostBindingRef": "omnigent-oauth:codex",
+            "hostLeaseRef": "host-lease-1",
+            "endpointRef": "default",
+            "omnigentHostId": "host-1",
+            "credentialGeneration": 3,
+            "bridgeSessionId": "bridge-1",
+        },
+        result_output_refs=["artifact://out-1", "artifact://out-2"],
+        result_metadata={
+            "pushRef": "artifact://push-1",
+            "pullRequestUrl": "https://github.com/owner/repo/pull/7",
+            "resourceManifestRef": "artifact://resources",
+        },
+        terminal_status="completed",
+        cleanup_mode="on_demand_remove",
+        cleanup_completed=True,
+        lease_released=True,
+        janitor_required=False,
+        release_ordering=[
+            "host_cleanup_completed",
+            "provider_lease_released",
+            "terminal",
+        ],
+        reasons=[],
+    )
+
+    assert evidence["schemaVersion"] == AUTHORITY_CHAIN_SCHEMA_VERSION
+    # Workspace intent + materialization survive.
+    ws = evidence["workspace"]
+    assert ws["locatorKind"] == "sandbox"
+    assert ws["repository"] == "owner/repo"
+    assert ws["sourceBranch"] == "main"
+    assert ws["sourceCommit"] == "main"
+    assert ws["candidateHead"] == "agent/impl"
+    assert ws["materializationAction"] == "materialized"
+    assert ws["restoreInputRefs"] == ["artifact://restore-1"]
+    # Runtime authority refs + mount/capability classes.
+    rt = evidence["runtime"]
+    assert rt["hostMode"] == "on_demand_docker"
+    assert rt["effectiveLaunchRef"].startswith("omnigent-launch:sha256:")
+    assert rt["hostLeaseRef"] == "host-lease-1"
+    assert rt["bridgeSessionId"] == "bridge-1"
+    assert rt["mountClasses"] == ["workspace", "oauth_home", "skills_tools"]
+    assert rt["capabilityClasses"] == ["gh", "git"]
+    # Publication policy + declared outputs + downstream evidence refs.
+    pub = evidence["publication"]
+    assert pub["publishMode"] == "branch"
+    assert pub["outputBranch"] == "agent/impl"
+    assert pub["repositoryMutationAuthorized"] is True
+    assert pub["publicationState"] == "authorized_pending_publication"
+    assert pub["declaredOutputRefs"] == ["artifact://out-1", "artifact://out-2"]
+    assert pub["evidenceRefs"]["pushRef"] == "artifact://push-1"
+    assert pub["evidenceRefs"]["resourceManifestRef"] == "artifact://resources"
+    # Terminal harvest + cleanup + release ordering.
+    term = evidence["terminal"]
+    assert term["harvestState"] == "completed"
+    assert term["cleanupMode"] == "on_demand_remove"
+    assert term["cleanupCompleted"] is True
+    assert term["leaseReleased"] is True
+    assert term["janitorRequired"] is False
+    assert term["releaseOrdering"][-1] == "terminal"
+
+
+def test_authority_chain_classifies_no_publish_saved_work() -> None:
+    evidence = build_omnigent_authority_chain_evidence(
+        effective_launch=_effective_launch(),
+        workspace_resolution=_workspace_resolution(),
+        repository="owner/repo",
+        source_branch="main",
+        output_branch="agent/impl",
+        publish_mode="none",
+        required_capabilities=[],
+        repository_mutation_required=True,
+        terminal_status="completed",
+    )
+    assert (
+        evidence["publication"]["publicationState"]
+        == "unpublished_saved_work_eligible"
+    )
+
+
+def test_authority_chain_classifies_read_only_run() -> None:
+    evidence = build_omnigent_authority_chain_evidence(
+        effective_launch=_effective_launch(),
+        workspace_resolution=_workspace_resolution(),
+        repository="owner/repo",
+        source_branch="main",
+        output_branch=None,
+        publish_mode="none",
+        required_capabilities=[],
+        repository_mutation_required=False,
+        terminal_status="completed",
+    )
+    assert evidence["publication"]["publicationState"] == "read_only_no_publication"
+
+
+def test_authority_chain_records_typed_failure_reasons() -> None:
+    evidence = build_omnigent_authority_chain_evidence(
+        effective_launch=_effective_launch(),
+        workspace_resolution=None,
+        repository="owner/repo",
+        source_branch="main",
+        output_branch="agent/impl",
+        publish_mode="branch",
+        repository_mutation_required=True,
+        terminal_status="failed",
+        cleanup_completed=False,
+        lease_released=False,
+        janitor_required=True,
+        release_ordering=["host_cleanup_incomplete", "terminal"],
+        reasons=[
+            {
+                "stage": "container_start",
+                "code": "OMNIGENT_WORKSPACE_MATERIALIZATION_FAILED",
+                "failureClass": "configuration_error",
+                "remediationAction": "repair_host_image",
+            }
+        ],
+    )
+    assert evidence["publication"]["publicationState"] == "not_published_failed_run"
+    assert evidence["terminal"]["janitorRequired"] is True
+    assert evidence["reasons"][0]["code"] == (
+        "OMNIGENT_WORKSPACE_MATERIALIZATION_FAILED"
+    )
+    assert evidence["reasons"][0]["failureClass"] == "configuration_error"
+
+
+def test_authority_chain_scrubs_credential_like_leaks() -> None:
+    """A credential that leaked into an upstream evidence value is scrubbed.
+
+    The projection is credential-free by contract; the secret scan is the
+    fail-closed backstop when an upstream value is not.
+    """
+
+    evidence = build_omnigent_authority_chain_evidence(
+        effective_launch=_effective_launch(),
+        workspace_resolution=_workspace_resolution(),
+        repository="owner/repo",
+        source_branch="main",
+        output_branch="agent/impl",
+        publish_mode="branch",
+        repository_mutation_required=True,
+        result_metadata={
+            # A non-ref key is not surfaced at all, and the recursive scrub
+            # ensures no bearer/token material appears anywhere in the output.
+            "authorization": "Bearer sk-supersecrettoken",
+            "ghToken": "ghp_" + "a" * 36,
+        },
+        terminal_status="completed",
+    )
+    flattened = repr(evidence)
+    assert "supersecrettoken" not in flattened
+    assert "ghp_" not in flattened
+    # None of the non-allowlisted credential keys leak into evidence refs.
+    assert evidence["publication"]["evidenceRefs"] == {}
+
+
+def test_authority_chain_is_total_on_empty_input() -> None:
+    evidence = build_omnigent_authority_chain_evidence(
+        effective_launch=None,
+        workspace_resolution=None,
+        repository=None,
+        source_branch=None,
+        output_branch=None,
+        publish_mode=None,
+    )
+    assert evidence["schemaVersion"] == AUTHORITY_CHAIN_SCHEMA_VERSION
+    assert evidence["publication"]["publishMode"] == "none"
+    assert evidence["workspace"]["locatorKind"] is None
+    assert evidence["reasons"] == []

--- a/tests/unit/omnigent/test_authority_chain_evidence.py
+++ b/tests/unit/omnigent/test_authority_chain_evidence.py
@@ -39,6 +39,7 @@ def _workspace_resolution() -> dict:
             "sourceKind": "github_https",
             "startingBranch": "main",
             "checkedOut": "main",
+            "resolvedCommit": "a" * 40,
             "outputBranch": "agent/impl",
             "restoreInputs": [{"ref": "artifact://restore-1", "bytes": 12}],
         },
@@ -91,7 +92,8 @@ def test_authority_chain_assembles_complete_bounded_projection() -> None:
     assert ws["locatorKind"] == "sandbox"
     assert ws["repository"] == "owner/repo"
     assert ws["sourceBranch"] == "main"
-    assert ws["sourceCommit"] == "main"
+    # The immutable resolved revision is projected, not the movable branch ref.
+    assert ws["sourceCommit"] == "a" * 40
     assert ws["candidateHead"] == "agent/impl"
     assert ws["materializationAction"] == "materialized"
     assert ws["restoreInputRefs"] == ["artifact://restore-1"]
@@ -108,7 +110,9 @@ def test_authority_chain_assembles_complete_bounded_projection() -> None:
     assert pub["publishMode"] == "branch"
     assert pub["outputBranch"] == "agent/impl"
     assert pub["repositoryMutationAuthorized"] is True
-    assert pub["publicationState"] == "authorized_pending_publication"
+    # Realized push evidence in the result metadata reconciles the pre-publication
+    # snapshot into a published disposition.
+    assert pub["publicationState"] == "published"
     assert pub["declaredOutputRefs"] == ["artifact://out-1", "artifact://out-2"]
     assert pub["evidenceRefs"]["pushRef"] == "artifact://push-1"
     assert pub["evidenceRefs"]["resourceManifestRef"] == "artifact://resources"
@@ -120,6 +124,99 @@ def test_authority_chain_assembles_complete_bounded_projection() -> None:
     assert term["leaseReleased"] is True
     assert term["janitorRequired"] is False
     assert term["releaseOrdering"][-1] == "terminal"
+
+
+def test_authority_chain_pending_publication_without_terminal_evidence() -> None:
+    """A branch/pr run stays pending until realized publication evidence exists."""
+
+    evidence = build_omnigent_authority_chain_evidence(
+        effective_launch=_effective_launch(),
+        workspace_resolution=_workspace_resolution(),
+        repository="owner/repo",
+        source_branch="main",
+        output_branch="agent/impl",
+        publish_mode="branch",
+        repository_mutation_required=True,
+        # A non-terminal ref (resource manifest) is not commit/push/PR evidence.
+        result_metadata={"resourceManifestRef": "artifact://resources"},
+        terminal_status="completed",
+    )
+    assert (
+        evidence["publication"]["publicationState"]
+        == "authorized_pending_publication"
+    )
+
+
+def test_authority_chain_reconciles_published_from_pull_request_evidence() -> None:
+    evidence = build_omnigent_authority_chain_evidence(
+        effective_launch=_effective_launch(),
+        workspace_resolution=_workspace_resolution(),
+        repository="owner/repo",
+        source_branch="main",
+        output_branch="agent/impl",
+        publish_mode="pr",
+        repository_mutation_required=True,
+        result_metadata={
+            "pullRequestRef": "artifact://pr-1",
+            "pullRequestUrl": "https://github.com/owner/repo/pull/9",
+        },
+        terminal_status="completed",
+    )
+    assert evidence["publication"]["publicationState"] == "published"
+
+
+def test_authority_chain_strips_repository_url_credentials() -> None:
+    """URL userinfo never persists into the durable repository identity."""
+
+    evidence = build_omnigent_authority_chain_evidence(
+        effective_launch=_effective_launch(),
+        workspace_resolution=_workspace_resolution(),
+        repository="https://alice:s3cr3t-token@github.com/org/repo.git",
+        source_branch="main",
+        output_branch="agent/impl",
+        publish_mode="branch",
+        repository_mutation_required=True,
+        terminal_status="completed",
+    )
+    repository = evidence["workspace"]["repository"]
+    assert repository == "https://github.com/org/repo.git"
+    assert "alice" not in repr(evidence)
+    assert "s3cr3t-token" not in repr(evidence)
+
+
+def test_authority_chain_strips_scp_style_repository_credentials() -> None:
+    evidence = build_omnigent_authority_chain_evidence(
+        effective_launch=_effective_launch(),
+        workspace_resolution=_workspace_resolution(),
+        repository="x-access-token:ghp_secretvalue@github.com:org/repo.git",
+        source_branch="main",
+        output_branch="agent/impl",
+        publish_mode="branch",
+        repository_mutation_required=True,
+        terminal_status="completed",
+    )
+    repository = evidence["workspace"]["repository"]
+    assert repository == "github.com:org/repo.git"
+    assert "ghp_secretvalue" not in repr(evidence)
+
+
+def test_authority_chain_falls_back_to_checked_out_commit() -> None:
+    """When no resolved SHA is captured, the checked-out selection is projected."""
+
+    workspace = _workspace_resolution()
+    workspace["materialization"].pop("resolvedCommit", None)
+    workspace["materialization"]["checkedOut"] = "d" * 40
+    evidence = build_omnigent_authority_chain_evidence(
+        effective_launch=_effective_launch(),
+        workspace_resolution=workspace,
+        repository="owner/repo",
+        source_branch="main",
+        output_branch="agent/impl",
+        publish_mode="branch",
+        repository_mutation_required=True,
+        terminal_status="completed",
+    )
+    assert evidence["workspace"]["sourceCommit"] == "d" * 40
 
 
 def test_authority_chain_classifies_no_publish_saved_work() -> None:

--- a/tests/unit/omnigent/test_bridge_store.py
+++ b/tests/unit/omnigent/test_bridge_store.py
@@ -496,6 +496,60 @@ async def test_workspace_resolution_metadata_persists_through_allowlist(store):
 
 
 @pytest.mark.asyncio
+async def test_authority_chain_metadata_persists_through_allowlist(store):
+    """The unified #3561 authority-chain projection survives the allowlist intact.
+
+    It is nested under the single ``authorityChain`` key so the whole compact
+    workspace -> runtime -> publication -> terminal -> cleanup -> lease structure
+    reaches Workflow Detail without the top-level allowlist pruning its subtree.
+    """
+
+    row = await store.get_or_create(
+        request=_request(), endpoint_ref="default", agent_id=None,
+        agent_name=None, target_metadata={},
+    )
+    authority_chain = {
+        "schemaVersion": "omnigent-authority-chain-v1",
+        "workspace": {"locatorKind": "sandbox", "workspaceId": "ws-1"},
+        "runtime": {"hostMode": "static_compose", "mountClasses": ["workspace"]},
+        "publication": {
+            "publishMode": "branch",
+            "outputBranch": "agent/impl",
+            "publicationState": "authorized_pending_publication",
+        },
+        "terminal": {
+            "cleanupCompleted": True,
+            "leaseReleased": True,
+            "releaseOrdering": [
+                "host_cleanup_completed",
+                "provider_lease_released",
+                "terminal",
+            ],
+        },
+        "reasons": [],
+    }
+
+    await store.record_lifecycle_event(
+        "idem-1",
+        event_type="authority_chain",
+        event_identity="idem-1:attempt:1:authority_chain:completed",
+        status="completed",
+        metadata={"authorityChain": authority_chain},
+    )
+
+    events = await store.list_events(row.bridge_session_id)
+    authority_events = [
+        event
+        for event in events
+        if event.event_type == "lifecycle.authority_chain"
+    ]
+    assert len(authority_events) == 1
+    assert authority_events[0].metadata_["metadata"] == {
+        "authorityChain": authority_chain
+    }
+
+
+@pytest.mark.asyncio
 async def test_attach_conflicting_session_fails(store):
     request = _request()
     await store.get_or_create(

--- a/tests/unit/omnigent/test_oauth_profile_lifecycle.py
+++ b/tests/unit/omnigent/test_oauth_profile_lifecycle.py
@@ -1804,6 +1804,206 @@ async def test_coordinator_releases_provider_lease_after_host_cleanup() -> None:
 
 
 @pytest.mark.asyncio
+async def test_coordinator_emits_bounded_authority_chain_before_terminal() -> None:
+    """The coordinator emits the unified #3561 authority chain once, credential-free.
+
+    It must appear before the terminal event, carry the workspace/runtime/
+    publication/terminal sections nested under ``authorityChain`` so the bridge
+    store allowlist preserves them, and leak no GitHub token or raw daemon path.
+    """
+
+    ordered: list[str] = []
+    authority_metadata: list[dict] = []
+
+    provider_lease = SimpleNamespace(
+        profile_id="codex",
+        runtime_id="codex_cli",
+        lease_id="provider-lease-1",
+        owner_id="owner-1",
+        purpose=CredentialLeasePurpose.EXECUTION_OMNIGENT,
+    )
+
+    class LeaseClient:
+        async def acquire_execution_lease(self, **_kwargs):
+            return provider_lease
+
+        async def release_lease(self, _lease):
+            ordered.append("provider_released")
+
+        async def record_cooldown(self, **_kwargs):
+            return None
+
+    # An on-demand binding: repository mutation (publishMode=branch) is only
+    # realizable on an isolated on-demand host, so authored publication requires it.
+    def _on_demand_binding():
+        return _binding().model_copy(
+            update={
+                "static_host_id": None,
+                "host_launch_profile_ref": "codex-on-demand@1",
+            }
+        )
+
+    class Hosts:
+        def __init__(self):
+            self.lease = _host_lease().model_copy(
+                update={"status": "allocating", "omnigent_host_id": None}
+            )
+
+        async def get_binding_for_profile(self, _profile_id):
+            return _on_demand_binding()
+
+        async def create_or_update_static_binding(self, **kwargs):
+            binding = _on_demand_binding()
+            if "effective_launch_snapshot" not in kwargs:
+                return binding
+            return binding.model_copy(update={
+                "host_launch_profile_ref": kwargs.get("host_launch_profile_ref")
+                or binding.host_launch_profile_ref,
+                "execution_profile_ref": kwargs["execution_profile_ref"],
+                "launch_policy_ref": kwargs["launch_policy_ref"],
+                "effective_launch_snapshot": kwargs["effective_launch_snapshot"],
+            })
+
+        async def create_or_get_host_lease(self, **_kwargs):
+            return self.lease
+
+        async def transition_host_lease(
+            self, _lease_id, *, expected_status, new_status, fields=None
+        ):
+            self.lease = self.lease.model_copy(
+                update={"status": new_status, **dict(fields or {})}
+            )
+            return self.lease
+
+        async def mark_host_lease_stopped(self, _lease_id):
+            ordered.append("host_stopped")
+            self.lease = self.lease.model_copy(update={"status": "stopped"})
+            return self.lease
+
+        async def mark_host_lease_failed(self, *_args, **_kwargs):
+            return None
+
+    class Runtime:
+        async def prepare_host(self, **_kwargs):
+            return {
+                "hostId": "host-1",
+                "workspacePath": "/workspaces/run",
+                # Bounded, credential-free resolution evidence as produced by the
+                # real runtime; the coordinator folds this into the authority chain.
+                "workspaceResolution": {
+                    "locatorKind": "sandbox",
+                    "workspaceId": "ws-1",
+                    "relativePath": "repo",
+                    "identityVerified": True,
+                    "materialization": {
+                        "action": "materialized",
+                        "sourceKind": "github_https",
+                        "startingBranch": "main",
+                        "checkedOut": "main",
+                        "outputBranch": "agent/impl",
+                    },
+                },
+            }
+
+        async def stop_host(self, **_kwargs):
+            ordered.append("host_cleanup")
+
+    class Store:
+        async def get_or_create(self, **_kwargs):
+            return SimpleNamespace(bridge_session_id="bridge-1")
+
+        async def bind_profile_authorization(self, **_kwargs):
+            return SimpleNamespace(bridge_session_id="bridge-1")
+
+        async def record_lifecycle_event(self, _key, *, event_type, **kwargs):
+            ordered.append(event_type)
+            metadata = kwargs.get("metadata") or {}
+            if "authorityChain" in metadata:
+                authority_metadata.append(metadata["authorityChain"])
+
+    async def execute(request, **_kwargs):
+        return AgentRunResult(
+            summary="done",
+            outputRefs=["artifact://out-1"],
+            metadata={"pushRef": "artifact://push-1"},
+        )
+
+    coordinator = OmnigentProfileBoundExecutionCoordinator(
+        session_factory=lambda: None,
+        lease_client=LeaseClient(),
+        host_repository=Hosts(),
+        host_runtime=Runtime(),
+        run_store=Store(),
+        execution_runner=execute,
+        artifact_gateway=object(),
+    )
+    coordinator._resolve_profile = AsyncMock(  # type: ignore[method-assign]
+        return_value=SimpleNamespace(
+            enabled=True,
+            auth_state=ProviderProfileAuthState.CONNECTED,
+            disabled_reason=None,
+            max_parallel_runs=1,
+            cooldown_after_429_seconds=900,
+            runtime_id="codex_cli",
+            credential_source=ProviderCredentialSource.OAUTH_VOLUME,
+            runtime_materialization_mode=RuntimeMaterializationMode.OAUTH_HOME,
+            volume_ref="codex_auth_volume",
+            volume_mount_path="/home/app/.codex",
+            secret_refs={},
+            command_behavior={},
+        )
+    )
+    await coordinator.execute(
+        AgentExecutionRequest(
+            agentKind="external",
+            agentId="omnigent",
+            executionProfileRef="codex",
+            correlationId="workflow-1",
+            idempotencyKey="idem-1",
+            workspaceSpec={
+                "workspaceLocator": {
+                    "kind": "sandbox",
+                    "workspaceId": hashlib.sha256(
+                        b"workflow-1:idem-1"
+                    ).hexdigest()[:24],
+                },
+                "repository": "owner/repo",
+                "startingBranch": "main",
+                "targetBranch": "agent/impl",
+            },
+            parameters={
+                "publishMode": "branch",
+                "repository": "owner/repo",
+                "omnigent": {"session": {"workspace": "owner/repo"}},
+            },
+        )
+    )
+
+    assert "authority_chain" in ordered
+    assert ordered.index("authority_chain") < ordered.index("terminal")
+    assert ordered.index("host_stopped") < ordered.index("authority_chain")
+    assert len(authority_metadata) == 1
+    chain = authority_metadata[0]
+    assert chain["schemaVersion"] == "omnigent-authority-chain-v1"
+    assert chain["workspace"]["candidateHead"] == "agent/impl"
+    assert chain["publication"]["publishMode"] == "branch"
+    assert chain["publication"]["outputBranch"] == "agent/impl"
+    assert (
+        chain["publication"]["publicationState"] == "authorized_pending_publication"
+    )
+    assert chain["publication"]["declaredOutputRefs"] == ["artifact://out-1"]
+    assert chain["publication"]["evidenceRefs"]["pushRef"] == "artifact://push-1"
+    assert chain["terminal"]["releaseOrdering"][-1] == "terminal"
+    assert chain["terminal"]["cleanupCompleted"] is True
+    assert chain["runtime"]["hostMode"] == "on_demand_docker"
+    assert chain["terminal"]["cleanupMode"] == "on_demand_remove"
+    # No credential material or raw daemon path anywhere in the projection.
+    flat = repr(chain)
+    assert "/workspaces/run" not in flat
+    assert "token" not in flat.lower()
+
+
+@pytest.mark.asyncio
 async def test_coordinator_records_runner_preflight_block_before_execution() -> None:
     events: list[tuple[str, dict]] = []
     execute = AsyncMock()

--- a/tests/unit/omnigent/test_oauth_profile_lifecycle.py
+++ b/tests/unit/omnigent/test_oauth_profile_lifecycle.py
@@ -1803,13 +1803,12 @@ async def test_coordinator_releases_provider_lease_after_host_cleanup() -> None:
         )
 
 
-@pytest.mark.asyncio
-async def test_coordinator_emits_bounded_authority_chain_before_terminal() -> None:
-    """The coordinator emits the unified #3561 authority chain once, credential-free.
+async def _drive_authority_chain_coordinator(execute) -> tuple[list[str], list[dict]]:
+    """Drive a fully-stubbed on-demand coordinator run with the given runner.
 
-    It must appear before the terminal event, carry the workspace/runtime/
-    publication/terminal sections nested under ``authorityChain`` so the bridge
-    store allowlist preserves them, and leak no GitHub token or raw daemon path.
+    Returns the ordered lifecycle event-type stream and every emitted
+    ``authorityChain`` projection so tests can assert both the success and the
+    returned-failure remediation-evidence paths against one harness.
     """
 
     ordered: list[str] = []
@@ -1921,13 +1920,6 @@ async def test_coordinator_emits_bounded_authority_chain_before_terminal() -> No
             if "authorityChain" in metadata:
                 authority_metadata.append(metadata["authorityChain"])
 
-    async def execute(request, **_kwargs):
-        return AgentRunResult(
-            summary="done",
-            outputRefs=["artifact://out-1"],
-            metadata={"pushRef": "artifact://push-1"},
-        )
-
     coordinator = OmnigentProfileBoundExecutionCoordinator(
         session_factory=lambda: None,
         lease_client=LeaseClient(),
@@ -1978,6 +1970,26 @@ async def test_coordinator_emits_bounded_authority_chain_before_terminal() -> No
             },
         )
     )
+    return ordered, authority_metadata
+
+
+@pytest.mark.asyncio
+async def test_coordinator_emits_bounded_authority_chain_before_terminal() -> None:
+    """The coordinator emits the unified #3561 authority chain once, credential-free.
+
+    It must appear before the terminal event, carry the workspace/runtime/
+    publication/terminal sections nested under ``authorityChain`` so the bridge
+    store allowlist preserves them, and leak no GitHub token or raw daemon path.
+    """
+
+    async def execute(request, **_kwargs):
+        return AgentRunResult(
+            summary="done",
+            outputRefs=["artifact://out-1"],
+            metadata={"pushRef": "artifact://push-1"},
+        )
+
+    ordered, authority_metadata = await _drive_authority_chain_coordinator(execute)
 
     assert "authority_chain" in ordered
     assert ordered.index("authority_chain") < ordered.index("terminal")
@@ -1988,9 +2000,9 @@ async def test_coordinator_emits_bounded_authority_chain_before_terminal() -> No
     assert chain["workspace"]["candidateHead"] == "agent/impl"
     assert chain["publication"]["publishMode"] == "branch"
     assert chain["publication"]["outputBranch"] == "agent/impl"
-    assert (
-        chain["publication"]["publicationState"] == "authorized_pending_publication"
-    )
+    # The returned result carried realized push evidence, so the pre-publication
+    # snapshot is reconciled to a published disposition.
+    assert chain["publication"]["publicationState"] == "published"
     assert chain["publication"]["declaredOutputRefs"] == ["artifact://out-1"]
     assert chain["publication"]["evidenceRefs"]["pushRef"] == "artifact://push-1"
     assert chain["terminal"]["releaseOrdering"][-1] == "terminal"
@@ -2001,6 +2013,39 @@ async def test_coordinator_emits_bounded_authority_chain_before_terminal() -> No
     flat = repr(chain)
     assert "/workspaces/run" not in flat
     assert "token" not in flat.lower()
+
+
+@pytest.mark.asyncio
+async def test_coordinator_records_returned_runner_failure_in_authority_chain() -> None:
+    """A runner that returns a failed result (not raising) still records evidence.
+
+    The exception path never runs, so the returned provider failure code, class,
+    and remediation must be folded into the authority-chain reasons; otherwise
+    ``harvestState="failed"`` would surface with an empty reasons list.
+    """
+
+    async def execute(request, **_kwargs):
+        return AgentRunResult(
+            summary="provider failed",
+            outputRefs=["artifact://out-1"],
+            failureClass="integration_error",
+            providerErrorCode="429",
+            retryRecommendation="retry_after_provider_cooldown",
+        )
+
+    ordered, authority_metadata = await _drive_authority_chain_coordinator(execute)
+
+    assert len(authority_metadata) == 1
+    chain = authority_metadata[0]
+    assert chain["terminal"]["harvestState"] == "failed"
+    assert chain["publication"]["publicationState"] == "not_published_failed_run"
+    reasons = chain["reasons"]
+    harvest_reasons = [r for r in reasons if r["stage"] == "resource_harvest"]
+    assert harvest_reasons, "returned provider failure must appear in the chain"
+    reason = harvest_reasons[0]
+    assert reason["code"] == "429"
+    assert reason["failureClass"] == "integration_error"
+    assert reason["remediationAction"] == "retry_after_provider_cooldown"
 
 
 @pytest.mark.asyncio
@@ -2968,6 +3013,17 @@ async def test_prepare_workspace_materializes_repository_and_branch(tmp_path) ->
     assert evidence["identityVerified"] is True
     assert evidence["materialization"]["action"] == "materialized"
     assert evidence["materialization"]["checkedOut"] == "feature"
+    # The immutable resolved revision is captured alongside the movable branch ref
+    # so authority evidence proves which source state executed.
+    resolved_commit = evidence["materialization"]["resolvedCommit"]
+    expected_commit = subprocess.run(
+        ["git", "-C", str(resolved), "rev-parse", "HEAD"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    assert resolved_commit == expected_commit
+    assert len(resolved_commit) == 40
     # Bounded evidence never leaks a raw worker/daemon path.
     assert str(resolved) not in json.dumps(evidence)
 


### PR DESCRIPTION
## Issue

Implements MoonLadderStudios/MoonMind#3561 — [Omnigent M1 4/8] Preserve repository publication semantics and durable workspace evidence (parent #3507).

Closes MoonLadderStudios/MoonMind#3561

## Summary

Finishes #3561's own deliverables on top of the existing #3507 Omnigent workspace-materialization substrate, proving that repository work executed through the Codex-through-Omnigent path obeys the same canonical branch, mutation, saved-work, publication, publication-only-recovery, retry, and evidence contracts as normal MoonMind workflows.

- **Unified authority-chain projection** — new `moonmind/omnigent/authority_chain.py` provides a pure, total, secret-scanned `build_omnigent_authority_chain_evidence(...)` that assembles one bounded workspace → runtime → publication → terminal → cleanup → lease evidence structure (repo/source-branch/source-commit/candidate-head, output branch + publish mode, launch/policy/profile/host/session/first-message refs, mount + capability classes, declared outputs, harvest/cleanup/janitor release ordering, typed denial/degraded/retry reasons). It runs through `redact_sensitive_payload` and never raises (AC1, AC3, AC5, AC6).
- **Coordinator wiring** — `moonmind/omnigent/profile_bound_execution.py` emits exactly one `authority_chain` lifecycle event before `terminal`, on both success and every failure path, accumulating typed `{stage, code, failureClass, remediationAction}` reasons and release ordering.
- **Bridge-store allowlist** — `moonmind/omnigent/bridge_store.py` extends the metadata allowlist with `authorityChain` so the nested projection persists intact and credential-free.
- **Controlling integration journey** — new hermetic `tests/integration/reliability_journey/test_omnigent_publication_semantics_journey.py` drives real git + a real bare remote + the real `PublishService` + real workspace materialization + the real coordinator through branch publish, idempotent publication-only recovery, canonical PR publish, no-publish terminal saved-work (with distinct source/output branches), and materialization → cleanup → replay for static (read-only) and on-demand (mutation) host modes (AC4, AC7).

The live Omnigent session is not publication authority: MoonMind owns publish policy; the coordinator returns an `AgentRunResult` and publication flows through the shared canonical `PublishService` path. Credentials remain capability-scoped and fail-closed (AC2, unchanged from #3507).

## Tests run

- `python -m pytest tests/unit/omnigent/test_authority_chain_evidence.py tests/unit/omnigent/test_bridge_store.py -q` → **54 passed** (bounded assembly, publication-state classification, typed failure reasons, credential-like leak scrubbing, totality on empty input, allowlist persistence).
- `python -m pytest tests/unit/omnigent/test_oauth_profile_lifecycle.py -q` → **110 passed** (includes `test_coordinator_emits_bounded_authority_chain_before_terminal` — single emission, ordered after host cleanup and before terminal, credential-free, no raw daemon path).
- `python -m pytest tests/integration/reliability_journey/test_omnigent_publication_semantics_journey.py -q` → **5 passed** (hermetic: real git + bare remote, no Docker/network).

## Remaining risks

- **AC8 (external):** updating parent #3507 with independently resolvable implementation/test evidence before closure is a GitHub issue-tracking action, not a repo change — it happens outside this PR.
- A dedicated Workflow-Detail frontend renderer for the `lifecycle.authority_chain` event was not added; the event and its bounded metadata reach the existing events projection intact, so a dedicated UI is optional polish.
- Workflow-boundary evidence emission is best-effort and cannot mask the primary terminal outcome.
- The credentialed browser-to-stock-host live release matrix is an explicit non-goal tracked by #3508; this journey is the repository-verifiable substrate, not a substitute for it.
- Pre-existing environment blocker: some `tests/unit/omnigent/test_host_*` suites fail with "pinned Omnigent ... unavailable" (missing upstream), confirmed identical with this change stashed and unrelated to it.
