### PR TITLE
Reconcile infrastructure during deployment updates

### DIFF
--- a/moonmind/workflows/skills/deployment_execution.py
+++ b/moonmind/workflows/skills/deployment_execution.py
@@ -1230,7 +1230,7 @@ class DeploymentUpdateExecutor:
                 before_state = await self.runner.capture_state(
                     stack=parsed["stack"], phase="before"
                 )
-                command_plan = _command_plan_targeting_services(
+                command_plan = _command_plan_targeting_stack_services(
                     command_plan,
                     before_state=before_state,
                     requested_repository=str(parsed["image"]["repository"]),
@@ -1562,7 +1562,7 @@ def _compose_up_target_services(args: Sequence[str]) -> tuple[str, ...]:
     return tuple(services)
 
 
-def _command_plan_targeting_services(
+def _command_plan_targeting_stack_services(
     command_plan: ComposeCommandPlan,
     *,
     before_state: Mapping[str, Any],
@@ -1570,21 +1570,22 @@ def _command_plan_targeting_services(
     excluded_services: Sequence[str],
 ) -> ComposeCommandPlan:
     excluded = _normalized_service_names(excluded_services)
-    target_candidates = _target_service_names_from_state(
+    # Pull only services governed by the requested MoonMind image target.
+    pull_candidates = _target_service_names_from_state(
         before_state,
         requested_repository=requested_repository,
     )
-    if not target_candidates and not excluded and not isinstance(
+    if not pull_candidates and not excluded and not isinstance(
         before_state.get("configuredServiceImages"),
         Mapping,
     ):
         return command_plan
-    services = tuple(
+    pull_services = tuple(
         service_name
-        for service_name in target_candidates
+        for service_name in pull_candidates
         if not _service_is_excluded(service_name, excluded)
     )
-    if not services:
+    if not pull_services:
         raise ToolFailure(
             error_code="DEPLOYMENT_RUNNER_UNSAFE",
             message=(
@@ -1598,10 +1599,34 @@ def _command_plan_targeting_services(
                 "failureClass": "runner_self_recreation_unsafe",
             },
         )
+    # Compose up must still reconcile the active stack so infrastructure-only
+    # configuration, networks, and dependencies required by the new image exist.
+    reconciliation_services = tuple(
+        service_name
+        for service_name in _configured_service_names_from_state(before_state)
+        if not _service_is_excluded(service_name, excluded)
+    )
+    if not reconciliation_services:
+        raise ToolFailure(
+            error_code="DEPLOYMENT_RUNNER_UNSAFE",
+            message=(
+                "Deployment update has no configured services to reconcile "
+                "after applying service exclusions."
+            ),
+            retryable=False,
+            details={
+                "excludedServices": sorted(excluded),
+                "failureClass": "runner_self_recreation_unsafe",
+            },
+        )
     return ComposeCommandPlan(
         runner_mode=command_plan.runner_mode,
-        pull_args=(*command_plan.pull_args, *services),
-        up_args=(*command_plan.up_args, "--no-deps", *services),
+        pull_args=(*command_plan.pull_args, *pull_services),
+        up_args=(
+            *command_plan.up_args,
+            "--no-deps",
+            *reconciliation_services,
+        ),
     )
 
 
@@ -1762,6 +1787,20 @@ def _target_service_names_from_state(
             seen.add(key)
             names.append(name)
     return tuple(names)
+
+
+def _configured_service_names_from_state(
+    before_state: Mapping[str, Any],
+) -> tuple[str, ...]:
+    configured_services = _service_names_from_state(
+        before_state.get("configuredServices")
+    )
+    if configured_services:
+        return configured_services
+    configured_images = before_state.get("configuredServiceImages")
+    if isinstance(configured_images, Mapping):
+        return _service_names_from_state(tuple(configured_images))
+    return _service_names_from_state(before_state.get("services"))
 
 
 def _target_service_names_from_configured_images(

--- a/tests/integration/reliability/replays/deployment-update-infrastructure-reconciliation/expected-outcome.json
+++ b/tests/integration/reliability/replays/deployment-update-infrastructure-reconciliation/expected-outcome.json
@@ -1,0 +1,12 @@
+{
+  "pullServices": [
+    "temporal-worker-agent-runtime"
+  ],
+  "reconciliationServices": [
+    "temporal-worker-agent-runtime",
+    "sandbox-egress-proxy"
+  ],
+  "excludedServices": [
+    "temporal-worker-deployment-control"
+  ]
+}

--- a/tests/integration/reliability/replays/deployment-update-infrastructure-reconciliation/manifest.json
+++ b/tests/integration/reliability/replays/deployment-update-infrastructure-reconciliation/manifest.json
@@ -1,0 +1,43 @@
+{
+  "failureShapeId": "deployment-update-infrastructure-reconciliation",
+  "incidentWorkflowId": "mm:d7803775-e018-45c4-a17e-47aa303245d8",
+  "activityType": "mm.tool.execute",
+  "toolName": "deployment.update_compose_stack",
+  "requestedRepository": "ghcr.io/moonladderstudios/moonmind",
+  "excludedServices": [
+    "temporal-worker-deployment-control"
+  ],
+  "commandPlan": {
+    "runnerMode": "privileged_worker",
+    "pullArgs": [
+      "docker",
+      "compose",
+      "pull",
+      "--policy",
+      "always",
+      "--ignore-buildable"
+    ],
+    "upArgs": [
+      "docker",
+      "compose",
+      "up",
+      "-d",
+      "--remove-orphans",
+      "--wait"
+    ]
+  },
+  "beforeState": {
+    "configuredServices": [
+      "temporal-worker-agent-runtime",
+      "sandbox-egress-proxy",
+      "temporal-worker-deployment-control"
+    ],
+    "configuredServiceImages": {
+      "temporal-worker-agent-runtime": "ghcr.io/moonladderstudios/moonmind:latest",
+      "sandbox-egress-proxy": "ubuntu/squid:latest",
+      "temporal-worker-deployment-control": "ghcr.io/moonladderstudios/moonmind:latest"
+    }
+  },
+  "observedFailure": "The update recreated the agent-runtime worker but skipped sandbox-egress-proxy, so the required restricted-egress network was absent and the worker restarted with exit code 1.",
+  "invariant": "Compose up reconciles every configured stack service except the deployment-control runner, even when infrastructure services use a different image repository."
+}

--- a/tests/integration/reliability/test_deployment_update_replay.py
+++ b/tests/integration/reliability/test_deployment_update_replay.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import pytest
+
+from moonmind.workflows.skills.deployment_execution import (
+    ComposeCommandPlan,
+    _command_plan_targeting_stack_services,
+)
+from tests.integration.reliability.helpers import load_replay
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.integration_ci,
+    pytest.mark.reliability_journey,
+]
+
+
+def test_deployment_update_reconciles_non_image_infrastructure() -> None:
+    replay_id = "deployment-update-infrastructure-reconciliation"
+    manifest = load_replay(replay_id, "manifest.json")
+    expected = load_replay(replay_id, "expected-outcome.json")
+    source_plan = manifest["commandPlan"]
+
+    plan = _command_plan_targeting_stack_services(
+        ComposeCommandPlan(
+            runner_mode=source_plan["runnerMode"],
+            pull_args=tuple(source_plan["pullArgs"]),
+            up_args=tuple(source_plan["upArgs"]),
+        ),
+        before_state=manifest["beforeState"],
+        requested_repository=manifest["requestedRepository"],
+        excluded_services=manifest["excludedServices"],
+    )
+
+    expected_pull_args = (
+        *tuple(source_plan["pullArgs"]),
+        *tuple(expected["pullServices"]),
+    )
+    expected_up_args = (
+        *tuple(source_plan["upArgs"]),
+        "--no-deps",
+        *tuple(expected["reconciliationServices"]),
+    )
+    assert plan.pull_args == expected_pull_args
+    assert plan.up_args == expected_up_args
+    assert all(
+        service not in plan.pull_args and service not in plan.up_args
+        for service in expected["excludedServices"]
+    )

--- a/tests/integration/reliability/test_deployment_update_replay.py
+++ b/tests/integration/reliability/test_deployment_update_replay.py
@@ -1,10 +1,20 @@
 from __future__ import annotations
 
+import json
+import os
+import shutil
+import stat
+import textwrap
+from pathlib import Path
+
 import pytest
 
 from moonmind.workflows.skills.deployment_execution import (
-    ComposeCommandPlan,
-    _command_plan_targeting_stack_services,
+    DeploymentUpdateExecutor,
+    DeploymentUpdateLockManager,
+    HostDockerComposeRunner,
+    InMemoryDesiredStateStore,
+    InMemoryEvidenceWriter,
 )
 from tests.integration.reliability.helpers import load_replay
 
@@ -15,35 +25,267 @@ pytestmark = [
 ]
 
 
-def test_deployment_update_reconciles_non_image_infrastructure() -> None:
+_FAKE_DOCKER_ENGINE = r"""
+#!/usr/bin/env python3
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+STATE_PATH = Path(os.environ["MM_DEPLOYMENT_REPLAY_STATE"])
+REAL_DOCKER = os.environ["MM_DEPLOYMENT_REPLAY_REAL_DOCKER"]
+TARGET_ID = "sha256:" + "a" * 64
+AGENT_SERVICE = "temporal-worker-agent-runtime"
+PROXY_SERVICE = "sandbox-egress-proxy"
+RUNNER_SERVICE = "temporal-worker-deployment-control"
+NETWORK = "restricted-egress-network"
+KNOWN_SERVICES = (AGENT_SERVICE, PROXY_SERVICE, RUNNER_SERVICE)
+
+
+def load_state():
+    return json.loads(STATE_PATH.read_text(encoding="utf-8"))
+
+
+def save_state(state):
+    STATE_PATH.write_text(json.dumps(state, sort_keys=True), encoding="utf-8")
+
+
+def selected_services(parts):
+    return [service for service in KNOWN_SERVICES if service in parts]
+
+
+args = sys.argv[1:]
+state = load_state()
+
+if args[:2] == ["image", "inspect"]:
+    requested_image = args[2]
+    print(
+        json.dumps(
+            [
+                {
+                    "Id": TARGET_ID,
+                    "RepoTags": [requested_image],
+                    "RepoDigests": [
+                        requested_image.split(":", 1)[0] + "@sha256:" + "b" * 64
+                    ],
+                }
+            ]
+        )
+    )
+    raise SystemExit(0)
+
+if not args or args[0] != "compose":
+    print("unsupported fake Docker command", file=sys.stderr)
+    raise SystemExit(2)
+
+command_index = next(
+    (index for index, part in enumerate(args) if part in {"config", "ps", "images", "pull", "up"}),
+    None,
+)
+if command_index is None:
+    print("missing Compose command", file=sys.stderr)
+    raise SystemExit(2)
+
+command = args[command_index]
+tail = args[command_index + 1 :]
+
+if command == "config":
+    completed = subprocess.run(
+        [REAL_DOCKER, *args],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    state["composeConfigCalls"] = state.get("composeConfigCalls", 0) + 1
+    save_state(state)
+    sys.stdout.write(completed.stdout)
+    sys.stderr.write(completed.stderr)
+    raise SystemExit(completed.returncode)
+
+if command == "ps":
+    print(json.dumps(state["containers"]))
+    raise SystemExit(0)
+
+if command == "images":
+    print(json.dumps(state["images"]))
+    raise SystemExit(0)
+
+if command == "pull":
+    state["pullServices"] = selected_services(tail)
+    save_state(state)
+    raise SystemExit(0)
+
+up_services = selected_services(tail)
+state["upServices"] = up_services
+if AGENT_SERVICE in up_services and PROXY_SERVICE not in up_services:
+    state["networkError"] = f"network {NETWORK} is unavailable"
+    save_state(state)
+    print(state["networkError"], file=sys.stderr)
+    raise SystemExit(1)
+
+state["networks"] = {NETWORK: {"services": up_services}}
+state["containers"] = [
+    {
+        "ID": "agent-runtime-new",
+        "Name": "replay-temporal-worker-agent-runtime-1",
+        "Service": AGENT_SERVICE,
+        "State": "running",
+        "Health": "healthy",
+    },
+    {
+        "ID": "sandbox-proxy-new",
+        "Name": "replay-sandbox-egress-proxy-1",
+        "Service": PROXY_SERVICE,
+        "State": "running",
+        "Health": "healthy",
+    },
+    {
+        "ID": "deployment-runner-existing",
+        "Name": "replay-temporal-worker-deployment-control-1",
+        "Service": RUNNER_SERVICE,
+        "State": "running",
+        "Health": "healthy",
+    },
+]
+state["images"] = [
+    {
+        "ID": TARGET_ID,
+        "Repository": "ghcr.io/moonladderstudios/moonmind",
+        "Service": AGENT_SERVICE,
+        "Tag": "latest",
+    },
+    {
+        "ID": "sha256:" + "c" * 64,
+        "Repository": "ubuntu/squid",
+        "Service": PROXY_SERVICE,
+        "Tag": "latest",
+    },
+    {
+        "ID": "sha256:" + "d" * 64,
+        "Repository": "ghcr.io/moonladderstudios/moonmind",
+        "Service": RUNNER_SERVICE,
+        "Tag": "latest",
+    },
+]
+save_state(state)
+raise SystemExit(0)
+"""
+
+
+@pytest.mark.asyncio
+async def test_deployment_update_reconciles_non_image_infrastructure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     replay_id = "deployment-update-infrastructure-reconciliation"
     manifest = load_replay(replay_id, "manifest.json")
     expected = load_replay(replay_id, "expected-outcome.json")
-    source_plan = manifest["commandPlan"]
+    requested_repository = manifest["requestedRepository"]
+    requested_image = f"{requested_repository}:latest"
+    real_docker = shutil.which("docker")
+    assert real_docker is not None, "integration_ci image must provide Docker Compose"
 
-    plan = _command_plan_targeting_stack_services(
-        ComposeCommandPlan(
-            runner_mode=source_plan["runnerMode"],
-            pull_args=tuple(source_plan["pullArgs"]),
-            up_args=tuple(source_plan["upArgs"]),
+    compose_path = tmp_path / "docker-compose.yaml"
+    compose_path.write_text(
+        textwrap.dedent(
+            f"""
+            services:
+              temporal-worker-agent-runtime:
+                image: {requested_image}
+                networks:
+                  - restricted-egress-network
+              sandbox-egress-proxy:
+                image: ubuntu/squid:latest
+                networks:
+                  - restricted-egress-network
+              temporal-worker-deployment-control:
+                image: {requested_image}
+            networks:
+              restricted-egress-network:
+                internal: true
+            """
+        ).lstrip(),
+        encoding="utf-8",
+    )
+    state_path = tmp_path / "engine-state.json"
+    state_path.write_text(
+        json.dumps(
+            {
+                "composeConfigCalls": 0,
+                "containers": [
+                    {
+                        "ID": "agent-runtime-old",
+                        "Service": "temporal-worker-agent-runtime",
+                        "State": "running",
+                    },
+                    {
+                        "ID": "deployment-runner-existing",
+                        "Service": "temporal-worker-deployment-control",
+                        "State": "running",
+                    },
+                ],
+                "images": [],
+                "networks": {},
+            }
         ),
-        before_state=manifest["beforeState"],
-        requested_repository=manifest["requestedRepository"],
-        excluded_services=manifest["excludedServices"],
+        encoding="utf-8",
+    )
+    fake_docker = tmp_path / "docker"
+    fake_docker.write_text(
+        textwrap.dedent(_FAKE_DOCKER_ENGINE).lstrip(),
+        encoding="utf-8",
+    )
+    fake_docker.chmod(
+        fake_docker.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
+    )
+    monkeypatch.setenv("MM_DEPLOYMENT_REPLAY_STATE", str(state_path))
+    monkeypatch.setenv("MM_DEPLOYMENT_REPLAY_REAL_DOCKER", real_docker)
+    monkeypatch.setenv("PATH", f"{tmp_path}{os.pathsep}{os.environ['PATH']}")
+
+    runner = HostDockerComposeRunner(
+        project_dir=str(tmp_path),
+        project_name="deployment-replay",
+        excluded_services=tuple(manifest["excludedServices"]),
+    )
+    executor = DeploymentUpdateExecutor(
+        lock_manager=DeploymentUpdateLockManager(),
+        desired_state_store=InMemoryDesiredStateStore(),
+        evidence_writer=InMemoryEvidenceWriter(),
+        runner=runner,
+        excluded_services=tuple(manifest["excludedServices"]),
     )
 
-    expected_pull_args = (
-        *tuple(source_plan["pullArgs"]),
-        *tuple(expected["pullServices"]),
+    result = await executor.execute(
+        {
+            "stack": "moonmind",
+            "image": {
+                "repository": requested_repository,
+                "reference": "latest",
+            },
+            "mode": "changed_services",
+            "removeOrphans": True,
+            "wait": True,
+            "reason": "Replay production infrastructure reconciliation failure",
+        },
+        context={"deployment_runner_mode": "privileged_worker"},
     )
-    expected_up_args = (
-        *tuple(source_plan["upArgs"]),
-        "--no-deps",
-        *tuple(expected["reconciliationServices"]),
+
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    assert result.status == "COMPLETED"
+    assert result.outputs["status"] == "SUCCEEDED"
+    assert state["composeConfigCalls"] >= 4
+    assert state["pullServices"] == expected["pullServices"]
+    assert state["upServices"] == expected["reconciliationServices"]
+    assert set(state["networks"]["restricted-egress-network"]["services"]) == set(
+        expected["reconciliationServices"]
     )
-    assert plan.pull_args == expected_pull_args
-    assert plan.up_args == expected_up_args
+    assert {
+        container["Service"]
+        for container in state["containers"]
+        if container["State"] == "running"
+    } >= set(expected["reconciliationServices"])
     assert all(
-        service not in plan.pull_args and service not in plan.up_args
+        service not in state["pullServices"] and service not in state["upServices"]
         for service in expected["excludedServices"]
     )

--- a/tests/unit/workflows/skills/test_deployment_update_execution.py
+++ b/tests/unit/workflows/skills/test_deployment_update_execution.py
@@ -20,7 +20,7 @@ from moonmind.workflows.skills.deployment_execution import (
     HostDockerComposeRunner,
     InMemoryDesiredStateStore,
     TemporalDeploymentEvidenceWriter,
-    _command_plan_targeting_services,
+    _command_plan_targeting_stack_services,
     _compose_up_args_for_services,
     _ensure_command_succeeded,
     _ensure_runner_survives_update,
@@ -914,12 +914,19 @@ async def test_deployment_control_runner_targets_services_except_itself(monkeypa
         "new-worker",
     )
     assert one_shot_command[-1:] == ("init-db",)
-    assert up_command[-3:] == ("temporal-worker-agent-runtime", "api", "new-worker")
+    assert up_command[-6:] == (
+        "postgres",
+        "docker-proxy",
+        "temporal",
+        "temporal-worker-agent-runtime",
+        "api",
+        "new-worker",
+    )
     assert "temporal-worker-deployment-control" not in up_command
     assert "init-db" not in up_command
-    assert "postgres" not in up_command
-    assert "docker-proxy" not in up_command
-    assert "temporal" not in up_command
+    assert "postgres" in up_command
+    assert "docker-proxy" in up_command
+    assert "temporal" in up_command
     assert "-d" not in one_shot_command
     assert "--wait" not in one_shot_command
     assert "--exit-code-from" in one_shot_command
@@ -1120,25 +1127,36 @@ def test_remove_services_from_command_args_preserves_option_values() -> None:
     )
 
 
-def test_targeted_update_plan_skips_compose_dependencies() -> None:
+def test_update_plan_reconciles_configured_infrastructure_without_pulling_it() -> None:
     plan = ComposeCommandPlan(
         runner_mode="privileged_worker",
         pull_args=("docker", "compose", "pull"),
         up_args=("docker", "compose", "up", "-d", "--remove-orphans", "--wait"),
     )
-    targeted = _command_plan_targeting_services(
+    targeted = _command_plan_targeting_stack_services(
         plan,
         before_state={
+            "configuredServices": [
+                "temporal-worker-agent-runtime",
+                "sandbox-egress-proxy",
+            ],
             "configuredServiceImages": {
-                "api": "ghcr.io/moonladderstudios/moonmind:latest",
-                "docker-proxy": "tecnativa/docker-socket-proxy:0.1.1",
+                "temporal-worker-agent-runtime": (
+                    "ghcr.io/moonladderstudios/moonmind:latest"
+                ),
+                "sandbox-egress-proxy": "ubuntu/squid:latest",
             }
         },
         requested_repository="ghcr.io/moonladderstudios/moonmind",
         excluded_services=(),
     )
 
-    assert targeted.pull_args == ("docker", "compose", "pull", "api")
+    assert targeted.pull_args == (
+        "docker",
+        "compose",
+        "pull",
+        "temporal-worker-agent-runtime",
+    )
     assert targeted.up_args == (
         "docker",
         "compose",
@@ -1147,7 +1165,8 @@ def test_targeted_update_plan_skips_compose_dependencies() -> None:
         "--remove-orphans",
         "--wait",
         "--no-deps",
-        "api",
+        "temporal-worker-agent-runtime",
+        "sandbox-egress-proxy",
     )
 
 


### PR DESCRIPTION
## Summary

- keep image pulls scoped to services using the requested MoonMind repository
- reconcile every active Compose service except the deployment-control runner during `up`, so new infrastructure configuration and networks are created
- add a minimized reliability replay for workflow `mm:d7803775-e018-45c4-a17e-47aa303245d8`

## Root cause

The changed-services update path appended only services whose image matched the requested MoonMind repository and invoked Compose with `--no-deps`. The new agent-runtime image requires the restricted-egress network at startup, but the `sandbox-egress-proxy` service that declares that network uses a different image repository and was skipped. The worker therefore failed its startup egress attestation, exited with code 1, and restarted until a later full-stack reconciliation created the missing network.

## Validation

- `./tools/test_unit.sh --python-only tests/unit/workflows/skills/test_deployment_update_execution.py` — 82 passed
- focused production replay — 1 passed
- `./tools/test_integration.sh` — 497 passed, 1 skipped
