### PR TITLE
Accept Dependabot conventional title prefixes

### DIFF
--- a/.agents/skills/batch-dependabot-resolver/SKILL.md
+++ b/.agents/skills/batch-dependabot-resolver/SKILL.md
@@ -52,7 +52,7 @@ inputSchema:
     titleRegex:
       type: string
       title: Version-bump title regex
-      default: '^(?:Bump|[Cc]hore\(deps\): bump) .+ from \S+ to \S+(?: in /.+)?$'
+      default: '^(?:Bump|[A-Za-z][A-Za-z0-9_-]*\(deps(?:-dev)?\): bump) .+ from \S+ to \S+(?: in /.+)?$'
     includeSecurityUpdates:
       type: boolean
       title: Include security updates
@@ -113,10 +113,11 @@ each queued `pr-resolver` child owns its repository publishing outcome.
   `github-actions`. Matched against the Dependabot branch ecosystem segment with alias
   normalization (`npm`↔`npm_and_yarn`, `github-actions`↔`github_actions`). Omit to allow all.
 - `titleRegex` (string, optional): Override for the version-bump title matcher.
-  Default `^(?:Bump|[Cc]hore\(deps\): bump) .+ from \S+ to \S+(?: in /.+)?$`
+  Default `^(?:Bump|[A-Za-z][A-Za-z0-9_-]*\(deps(?:-dev)?\): bump) .+ from \S+ to \S+(?: in /.+)?$`
   (matches both Dependabot's legacy `Bump anthropic from 0.105.2 to 0.107.1`
-  titles and conventional-commit titles such as `Chore(deps): bump anthropic from
-  0.105.2 to 0.107.1`, including subdirectory suffixes like `in /frontend`).
+  titles and conventional-commit titles whose type is scoped to `deps` or `deps-dev`,
+  such as `Build(deps): bump anthropic from 0.105.2 to 0.107.1`, including
+  subdirectory suffixes like `in /frontend`).
 - `includeSecurityUpdates` (boolean, optional): Default `true`. When `false`, PRs labeled
   `security` are skipped.
 - `maxPrs` (number, optional): Safety cap on the number of resolver workflows queued per run.

--- a/.agents/skills/batch-dependabot-resolver/SKILL.md
+++ b/.agents/skills/batch-dependabot-resolver/SKILL.md
@@ -52,7 +52,7 @@ inputSchema:
     titleRegex:
       type: string
       title: Version-bump title regex
-      default: '^(?:Bump|[A-Za-z][A-Za-z0-9_-]*\(deps(?:-dev)?\): bump) .+ from \S+ to \S+(?: in /.+)?$'
+      default: '^(?!.* from .* from )(?!.* to .* to )(?:Bump|[A-Za-z][A-Za-z0-9_-]*\(deps(?:-dev)?\): bump) .+ from \S+ to \S+(?: in /.+)?$'
     includeSecurityUpdates:
       type: boolean
       title: Include security updates
@@ -113,11 +113,12 @@ each queued `pr-resolver` child owns its repository publishing outcome.
   `github-actions`. Matched against the Dependabot branch ecosystem segment with alias
   normalization (`npm`↔`npm_and_yarn`, `github-actions`↔`github_actions`). Omit to allow all.
 - `titleRegex` (string, optional): Override for the version-bump title matcher.
-  Default `^(?:Bump|[A-Za-z][A-Za-z0-9_-]*\(deps(?:-dev)?\): bump) .+ from \S+ to \S+(?: in /.+)?$`
+  Default `^(?!.* from .* from )(?!.* to .* to )(?:Bump|[A-Za-z][A-Za-z0-9_-]*\(deps(?:-dev)?\): bump) .+ from \S+ to \S+(?: in /.+)?$`
   (matches both Dependabot's legacy `Bump anthropic from 0.105.2 to 0.107.1`
   titles and conventional-commit titles whose type is scoped to `deps` or `deps-dev`,
   such as `Build(deps): bump anthropic from 0.105.2 to 0.107.1`, including
-  subdirectory suffixes like `in /frontend`).
+  subdirectory suffixes like `in /frontend`, while rejecting grouped or edited titles
+  that contain multiple `from ... to ...` update segments).
 - `includeSecurityUpdates` (boolean, optional): Default `true`. When `false`, PRs labeled
   `security` are skipped.
 - `maxPrs` (number, optional): Safety cap on the number of resolver workflows queued per run.

--- a/.agents/skills/batch-dependabot-resolver/bin/batch_dependabot_resolver.py
+++ b/.agents/skills/batch-dependabot-resolver/bin/batch_dependabot_resolver.py
@@ -36,7 +36,8 @@ API_EXECUTIONS_ENDPOINT = "/api/executions"
 IDEMPOTENCY_KEY_MAX_LENGTH = 128
 TERMINAL_FAILURE_STATES = {"failed", "canceled", "terminated"}
 DEFAULT_TITLE_REGEX = (
-    r"^(?:Bump|[A-Za-z][A-Za-z0-9_-]*\(deps(?:-dev)?\): bump) "
+    r"^(?!.* from .* from )(?!.* to .* to )"
+    r"(?:Bump|[A-Za-z][A-Za-z0-9_-]*\(deps(?:-dev)?\): bump) "
     r".+ from \S+ to \S+(?: in /.+)?$"
 )
 LIKELY_VERSION_BUMP_TITLE_REGEX = re.compile(

--- a/.agents/skills/batch-dependabot-resolver/bin/batch_dependabot_resolver.py
+++ b/.agents/skills/batch-dependabot-resolver/bin/batch_dependabot_resolver.py
@@ -36,7 +36,8 @@ API_EXECUTIONS_ENDPOINT = "/api/executions"
 IDEMPOTENCY_KEY_MAX_LENGTH = 128
 TERMINAL_FAILURE_STATES = {"failed", "canceled", "terminated"}
 DEFAULT_TITLE_REGEX = (
-    r"^(?:Bump|[Cc]hore\(deps\): bump) .+ from \S+ to \S+(?: in /.+)?$"
+    r"^(?:Bump|[A-Za-z][A-Za-z0-9_-]*\(deps(?:-dev)?\): bump) "
+    r".+ from \S+ to \S+(?: in /.+)?$"
 )
 LIKELY_VERSION_BUMP_TITLE_REGEX = re.compile(
     r"\bbump\s+.+\s+from\s+\S+\s+to\s+\S+", re.IGNORECASE
@@ -1016,7 +1017,7 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         default=DEFAULT_TITLE_REGEX,
         help=(
             "Version-bump title matcher (default: Bump <dep> from <old> to <new> "
-            "or Chore(deps): bump <dep> from <old> to <new>)."
+            "or <type>(deps[-dev]): bump <dep> from <old> to <new>)."
         ),
     )
     parser.add_argument(

--- a/tests/integration/reliability/replays/dependabot-build-title-contract/expected-outcome.json
+++ b/tests/integration/reliability/replays/dependabot-build-title-contract/expected-outcome.json
@@ -1,0 +1,6 @@
+{
+  "matchedCount": 4,
+  "matchedPrNumbers": [2419, 2420, 2421, 2422],
+  "skipped": [],
+  "titleContractDriftPrs": []
+}

--- a/tests/integration/reliability/replays/dependabot-build-title-contract/manifest.json
+++ b/tests/integration/reliability/replays/dependabot-build-title-contract/manifest.json
@@ -1,0 +1,52 @@
+{
+  "schemaVersion": "escaped-failure-replay/v1",
+  "failureShapeId": "dependabot-build-title-contract",
+  "incidentWorkflowId": "mm:c837ff3b-9967-4e46-b476-4462a2c0cf54",
+  "repository": "MoonLadderStudios/Tactics",
+  "pullRequests": [
+    {
+      "number": 2419,
+      "title": "Build(deps): bump ubuntu from 24.04 to 26.04 in /docker/actions-runner-control",
+      "author": {"login": "dependabot[bot]"},
+      "headRefName": "dependabot/docker/docker/actions-runner-control/ubuntu-26.04",
+      "headRefOid": "replay-head-2419",
+      "headRepository": {"name": "Tactics"},
+      "headRepositoryOwner": {"login": "MoonLadderStudios"},
+      "isCrossRepository": false,
+      "labels": [{"name": "dependencies"}]
+    },
+    {
+      "number": 2420,
+      "title": "Build(deps): bump actions/checkout from 4.4.0 to 7.0.1",
+      "author": {"login": "dependabot[bot]"},
+      "headRefName": "dependabot/github_actions/actions/checkout-7.0.1",
+      "headRefOid": "replay-head-2420",
+      "headRepository": {"name": "Tactics"},
+      "headRepositoryOwner": {"login": "MoonLadderStudios"},
+      "isCrossRepository": false,
+      "labels": [{"name": "dependencies"}]
+    },
+    {
+      "number": 2421,
+      "title": "Build(deps): bump actions/upload-artifact from 4.6.2 to 7.0.1",
+      "author": {"login": "dependabot[bot]"},
+      "headRefName": "dependabot/github_actions/actions/upload-artifact-7.0.1",
+      "headRefOid": "replay-head-2421",
+      "headRepository": {"name": "Tactics"},
+      "headRepositoryOwner": {"login": "MoonLadderStudios"},
+      "isCrossRepository": false,
+      "labels": [{"name": "dependencies"}]
+    },
+    {
+      "number": 2422,
+      "title": "Build(deps): bump actions/github-script from 7.1.0 to 9.0.0",
+      "author": {"login": "dependabot[bot]"},
+      "headRefName": "dependabot/github_actions/actions/github-script-9.0.0",
+      "headRefOid": "replay-head-2422",
+      "headRepository": {"name": "Tactics"},
+      "headRepositoryOwner": {"login": "MoonLadderStudios"},
+      "isCrossRepository": false,
+      "labels": [{"name": "dependencies"}]
+    }
+  ]
+}

--- a/tests/integration/reliability/test_escaped_failure_journeys.py
+++ b/tests/integration/reliability/test_escaped_failure_journeys.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import json
+import runpy
 import sqlite3
 import subprocess
 import threading
@@ -277,6 +278,56 @@ async def test_completed_batch_turn_is_rejected_at_agent_run_boundary(
     assert summary["failure"]["terminalContractMissingEvidence"] == expected[
         "missingEvidence"
     ]
+
+
+async def test_dependabot_build_titles_replay_through_portable_skill_classifier() -> (
+    None
+):
+    """Replay mm:c837ff3b through the resolved Skill's classification boundary."""
+    replay_id = "dependabot-build-title-contract"
+    manifest = load_replay(replay_id, "manifest.json")
+    expected = load_replay(replay_id, "expected-outcome.json")
+    repo_root = Path(__file__).resolve().parents[3]
+    skill = runpy.run_path(
+        str(
+            repo_root
+            / ".agents"
+            / "skills"
+            / "batch-dependabot-resolver"
+            / "bin"
+            / "batch_dependabot_resolver.py"
+        )
+    )
+    args = SimpleNamespace(
+        title_regex=skill["DEFAULT_TITLE_REGEX"],
+        package_managers=[],
+        include_security_updates=True,
+        max_prs=None,
+        merge_method="squash",
+        max_iterations=5,
+        priority=0,
+        max_attempts=3,
+    )
+
+    queue_requests, skipped, matched_count = skill["_build_request_records"](
+        manifest["repository"],
+        manifest["pullRequests"],
+        args,
+        skill["RuntimeSelection"](),
+    )
+    drift_prs = [
+        item["pr"]
+        for item in skipped
+        if item.get("reason") == "title-mismatch"
+        and item.get("likelyVersionBump") is True
+    ]
+
+    assert matched_count == expected["matchedCount"]
+    assert [item.pr_number for item in queue_requests] == expected[
+        "matchedPrNumbers"
+    ]
+    assert skipped == expected["skipped"]
+    assert drift_prs == expected["titleContractDriftPrs"]
 
 
 async def test_invalid_batch_range_records_terminal_failure_without_retry(

--- a/tests/integration/skills/test_batch_dependabot_resolver_e2e.py
+++ b/tests/integration/skills/test_batch_dependabot_resolver_e2e.py
@@ -308,6 +308,38 @@ def test_end_to_end_dry_run_submits_nothing(monkeypatch: Any, tmp_path: Path) ->
     assert not (tmp_path / "artifacts" / "skill_outcome.json").exists()
 
 
+def test_end_to_end_accepts_dependabot_build_scope_title(
+    monkeypatch: Any,
+    tmp_path: Path,
+) -> None:
+    module = _load_module()
+    build_scoped_pr = {
+        **_mixed_pr_set()[0],
+        "number": 2419,
+        "title": (
+            "Build(deps): bump ubuntu from 24.04 to 26.04 "
+            "in /docker/actions-runner-control"
+        ),
+        "headRefName": (
+            "dependabot/docker/docker/actions-runner-control/ubuntu-26.04"
+        ),
+        "headRefOid": "build-scope-head-sha",
+    }
+    summary = _run_main(
+        module,
+        ["--repo", "MoonLadderStudios/MoonMind"],
+        monkeypatch,
+        tmp_path,
+        pr_set=[build_scoped_pr],
+    )
+
+    assert summary["_exit_code"] == 0
+    assert summary["matched"] == 1
+    assert summary["status"] == "queued"
+    assert [item["pr"] for item in summary["queued"]] == [2419]
+    assert summary["diagnostics"]["titleContractDriftPrs"] == []
+
+
 def test_end_to_end_fails_when_default_title_contract_drifts(
     monkeypatch: Any,
     tmp_path: Path,

--- a/tests/unit/capabilities/test_batch_dependabot_resolver_skill.py
+++ b/tests/unit/capabilities/test_batch_dependabot_resolver_skill.py
@@ -26,7 +26,8 @@ def test_batch_dependabot_resolver_exposes_structured_inputs() -> None:
 
     assert contract["hasInputSchema"] is True
     assert contract["inputSchema"]["properties"]["titleRegex"]["default"] == (
-        r"^(?:Bump|[Cc]hore\(deps\): bump) .+ from \S+ to \S+(?: in /.+)?$"
+        r"^(?:Bump|[A-Za-z][A-Za-z0-9_-]*\(deps(?:-dev)?\): bump) "
+        r".+ from \S+ to \S+(?: in /.+)?$"
     )
     assert contract["defaults"] == {}
     validated = validate_capability_inputs(contract=contract, values={})

--- a/tests/unit/capabilities/test_batch_dependabot_resolver_skill.py
+++ b/tests/unit/capabilities/test_batch_dependabot_resolver_skill.py
@@ -26,7 +26,8 @@ def test_batch_dependabot_resolver_exposes_structured_inputs() -> None:
 
     assert contract["hasInputSchema"] is True
     assert contract["inputSchema"]["properties"]["titleRegex"]["default"] == (
-        r"^(?:Bump|[A-Za-z][A-Za-z0-9_-]*\(deps(?:-dev)?\): bump) "
+        r"^(?!.* from .* from )(?!.* to .* to )"
+        r"(?:Bump|[A-Za-z][A-Za-z0-9_-]*\(deps(?:-dev)?\): bump) "
         r".+ from \S+ to \S+(?: in /.+)?$"
     )
     assert contract["defaults"] == {}

--- a/tests/unit/test_batch_dependabot_resolver.py
+++ b/tests/unit/test_batch_dependabot_resolver.py
@@ -50,7 +50,8 @@ def _args(**overrides: Any) -> Any:
         "priority": 0,
         "package_managers": [],
         "title_regex": (
-            r"^(?:Bump|[A-Za-z][A-Za-z0-9_-]*\(deps(?:-dev)?\): bump) "
+            r"^(?!.* from .* from )(?!.* to .* to )"
+            r"(?:Bump|[A-Za-z][A-Za-z0-9_-]*\(deps(?:-dev)?\): bump) "
             r".+ from \S+ to \S+(?: in /.+)?$"
         ),
         "include_security_updates": True,
@@ -136,6 +137,9 @@ def test_title_matches_default_regex() -> None:
     assert not module["_title_matches"]("Bump the pip group with 2 updates", pattern)
     assert not module["_title_matches"](
         "Deps: bump anthropic from 0.105.2 to 0.107.1", pattern
+    )
+    assert not module["_title_matches"](
+        "Build(deps): bump foo from 1 to 2 and bar from 3 to 4", pattern
     )
     assert not module["_title_matches"]("Refactor things", pattern)
 

--- a/tests/unit/test_batch_dependabot_resolver.py
+++ b/tests/unit/test_batch_dependabot_resolver.py
@@ -50,7 +50,8 @@ def _args(**overrides: Any) -> Any:
         "priority": 0,
         "package_managers": [],
         "title_regex": (
-            r"^(?:Bump|[Cc]hore\(deps\): bump) .+ from \S+ to \S+(?: in /.+)?$"
+            r"^(?:Bump|[A-Za-z][A-Za-z0-9_-]*\(deps(?:-dev)?\): bump) "
+            r".+ from \S+ to \S+(?: in /.+)?$"
         ),
         "include_security_updates": True,
         "max_prs": None,
@@ -124,7 +125,18 @@ def test_title_matches_default_regex() -> None:
     assert module["_title_matches"](
         "chore(deps): bump boto3 from 1.43.46 to 1.43.51", pattern
     )
+    assert module["_title_matches"](
+        "Build(deps): bump ubuntu from 24.04 to 26.04 "
+        "in /docker/actions-runner-control",
+        pattern,
+    )
+    assert module["_title_matches"](
+        "build(deps-dev): bump pytest from 8.0.0 to 9.0.0", pattern
+    )
     assert not module["_title_matches"]("Bump the pip group with 2 updates", pattern)
+    assert not module["_title_matches"](
+        "Deps: bump anthropic from 0.105.2 to 0.107.1", pattern
+    )
     assert not module["_title_matches"]("Refactor things", pattern)
 
 


### PR DESCRIPTION
## Summary

- expand the batch Dependabot resolver's default title contract to accept conventional commit types scoped to `deps` or `deps-dev`, while preserving legacy `Bump ...` titles
- keep the existing Dependabot author, branch, single-version-bump, and title-contract-drift safety gates
- add a minimized `integration_ci` replay for the escaped `Build(deps): bump ...` production title

## Root cause

Workflow `mm:c837ff3b-9967-4e46-b476-4462a2c0cf54` discovered four genuine Dependabot PRs in `MoonLadderStudios/Tactics`, but all used `Build(deps): bump ...` titles. The built-in skill default only allowed `Bump ...` and `Chore(deps): bump ...`, so it classified every Dependabot PR as title-contract drift and failed before enqueueing child resolvers.

## Impact

Dependabot PRs using conventional commit types such as `Build(deps)` now reach the existing child resolver fan-out. Unsupported likely-version-bump forms still trigger the deliberate drift failure instead of silently producing a no-op.

## Validation

- `./tools/test_unit.sh --python-only tests/unit/test_batch_dependabot_resolver.py tests/unit/capabilities/test_batch_dependabot_resolver_skill.py` — 46 passed
- `./.venv/bin/python -m pytest -q tests/integration/skills/test_batch_dependabot_resolver_e2e.py -m integration_ci --tb=short` — 7 passed
- `./tools/test_integration.sh` — 497 passed, 1 skipped
