### PR TITLE
The hard override model and hard override effort input fields should default to the default for the selected provider profile until they're manually c

### DIFF
--- a/frontend/src/entrypoints/workflow-start.test.tsx
+++ b/frontend/src/entrypoints/workflow-start.test.tsx
@@ -19064,6 +19064,7 @@ describe("Task Create runtime switch layout stability", () => {
                 profile_id: "profile:codex-default",
                 account_label: "Codex Default",
                 is_default: true,
+                default_model: "gpt-profile-default",
                 default_effort: "high",
               },
               {
@@ -19234,6 +19235,41 @@ describe("Task Create runtime switch layout stability", () => {
     expect(request.payload.task.runtime).not.toHaveProperty("tierFallback");
     expect(request.payload.task.runtime).not.toHaveProperty("model");
     expect(request.payload.task.runtime).not.toHaveProperty("effort");
+  });
+
+  it("defaults hard overrides from the selected profile until manually changed", async () => {
+    renderWithClient(<WorkflowStartPage payload={mockPayload} />);
+
+    await waitFor(() => {
+      expect((screen.getByLabelText("Provider profile") as HTMLSelectElement).value).toBe(
+        "profile:codex-default",
+      );
+      expect((screen.getByLabelText("Hard override model") as HTMLInputElement).value).toBe(
+        "gpt-profile-default",
+      );
+      expect((screen.getByLabelText("Hard override effort") as HTMLInputElement).value).toBe(
+        "high",
+      );
+    });
+
+    fireEvent.change(screen.getByLabelText("Hard override model"), {
+      target: { value: "gpt-manual" },
+    });
+    fireEvent.change(screen.getByLabelText("Hard override effort"), {
+      target: { value: "xhigh" },
+    });
+    fireEvent.change(screen.getByLabelText("Instructions"), {
+      target: { value: "Trigger an unrelated form render." },
+    });
+
+    await waitFor(() => {
+      expect((screen.getByLabelText("Hard override model") as HTMLInputElement).value).toBe(
+        "gpt-manual",
+      );
+      expect((screen.getByLabelText("Hard override effort") as HTMLInputElement).value).toBe(
+        "xhigh",
+      );
+    });
   });
 });
 

--- a/frontend/src/entrypoints/workflow-start.test.tsx
+++ b/frontend/src/entrypoints/workflow-start.test.tsx
@@ -19064,8 +19064,13 @@ describe("Task Create runtime switch layout stability", () => {
                 profile_id: "profile:codex-default",
                 account_label: "Codex Default",
                 is_default: true,
-                default_model: "gpt-profile-default",
-                default_effort: "high",
+                default_model: null,
+                default_effort: null,
+                model_tiers: [
+                  { label: "Plan", model: "gpt-plan", effort: "medium" },
+                  { label: "Default", model: "gpt-profile-default", effort: "high" },
+                ],
+                default_model_tier: 2,
               },
               {
                 profile_id: "profile:codex-secondary",

--- a/frontend/src/entrypoints/workflow-start.tsx
+++ b/frontend/src/entrypoints/workflow-start.tsx
@@ -6474,32 +6474,29 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
       return;
     }
 
-    setEffort(
-      String(
-        defaultTaskEffortByRuntime[runtime] ||
-          dashboardConfig.system?.defaultEffort ||
-          dashboardConfig.system?.defaultTaskEffort ||
-          "",
-      ),
-    );
-
-    if (modelManualOverride && !runtimeChanged && !profileChanged) {
-      return;
-    }
-
-    const profileIdForModel = runtimeChanged ? "" : providerProfile;
+    const profileIdForDefaults = runtimeChanged ? "" : providerProfile;
     const profiles = providerProfilesQuery.data || [];
     const selectedProfile = profiles.find(
-      (p) => p.profile_id === profileIdForModel,
+      (p) => p.profile_id === profileIdForDefaults,
     );
-    if (selectedProfile?.default_model) {
-      setModel(selectedProfile.default_model);
-    } else {
+    if (!modelManualOverride || runtimeChanged || profileChanged) {
       setModel(
         String(
-          defaultTaskModelByRuntime[runtime] ||
+          selectedProfile?.default_model ||
+            defaultTaskModelByRuntime[runtime] ||
             dashboardConfig.system?.defaultModel ||
             dashboardConfig.system?.defaultTaskModel ||
+            "",
+        ),
+      );
+    }
+    if (!effortManualOverride || runtimeChanged || profileChanged) {
+      setEffort(
+        String(
+          selectedProfile?.default_effort ||
+            defaultTaskEffortByRuntime[runtime] ||
+            dashboardConfig.system?.defaultEffort ||
+            dashboardConfig.system?.defaultTaskEffort ||
             "",
         ),
       );
@@ -6511,6 +6508,7 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
     dashboardConfig.system?.defaultModel,
     defaultTaskEffortByRuntime,
     defaultTaskModelByRuntime,
+    effortManualOverride,
     modelManualOverride,
     pageMode.mode,
     providerProfilesQuery.data,

--- a/frontend/src/entrypoints/workflow-start.tsx
+++ b/frontend/src/entrypoints/workflow-start.tsx
@@ -664,6 +664,18 @@ function modelTiersForProfile(profile: ProviderProfile | undefined): ProviderMod
   ];
 }
 
+function defaultModelTierForProfile(
+  profile: ProviderProfile | undefined,
+): ProviderModelEffortTier | undefined {
+  if (!profile || !Array.isArray(profile.model_tiers)) {
+    return undefined;
+  }
+  const defaultTier = profile.default_model_tier ?? 1;
+  return Number.isInteger(defaultTier) && defaultTier >= 1
+    ? profile.model_tiers[defaultTier - 1]
+    : undefined;
+}
+
 export function previewModelTier(
   profile: ProviderProfile | undefined,
   requestedTierValue: string,
@@ -6479,10 +6491,12 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
     const selectedProfile = profiles.find(
       (p) => p.profile_id === profileIdForDefaults,
     );
+    const selectedDefaultTier = defaultModelTierForProfile(selectedProfile);
     if (!modelManualOverride || runtimeChanged || profileChanged) {
       setModel(
         String(
-          selectedProfile?.default_model ||
+          selectedDefaultTier?.model ||
+            selectedProfile?.default_model ||
             defaultTaskModelByRuntime[runtime] ||
             dashboardConfig.system?.defaultModel ||
             dashboardConfig.system?.defaultTaskModel ||
@@ -6493,7 +6507,8 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
     if (!effortManualOverride || runtimeChanged || profileChanged) {
       setEffort(
         String(
-          selectedProfile?.default_effort ||
+          selectedDefaultTier?.effort ||
+            selectedProfile?.default_effort ||
             defaultTaskEffortByRuntime[runtime] ||
             dashboardConfig.system?.defaultEffort ||
             dashboardConfig.system?.defaultTaskEffort ||


### PR DESCRIPTION
The hard override model and hard override effort input fields should default to the default for the selected provider profile until they're manually changed.