### PR TITLE
Run Jira Implement for MM-1220: Complete remaining behavior for Prepare and bind exact Lore workspaces

### DIFF
--- a/moonmind/omnigent/oauth_host_runtime.py
+++ b/moonmind/omnigent/oauth_host_runtime.py
@@ -219,6 +219,8 @@ class OmnigentOAuthHostRuntime:
         effective_launch: Mapping[str, Any] | None = None,
         repository_source: str = "",
         repository_provider: str = "",
+        repository_connection_ref: str = "",
+        repository_client_evidence: Mapping[str, str] | None = None,
         starting_branch: str | None = None,
         target_branch: str | None = None,
         checkout_commit: str | None = None,
@@ -252,6 +254,8 @@ class OmnigentOAuthHostRuntime:
             current_step_execution_id=current_step_execution_id,
             repository_source=repository_source,
             repository_provider=repository_provider,
+            repository_connection_ref=repository_connection_ref,
+            repository_client_evidence=repository_client_evidence,
             starting_branch=starting_branch,
             target_branch=target_branch,
             checkout_commit=checkout_commit,
@@ -933,6 +937,8 @@ class OmnigentOAuthHostRuntime:
         current_step_execution_id: str,
         repository_source: str = "",
         repository_provider: str = "",
+        repository_connection_ref: str = "",
+        repository_client_evidence: Mapping[str, str] | None = None,
         starting_branch: str | None = None,
         target_branch: str | None = None,
         checkout_commit: str | None = None,
@@ -993,9 +999,40 @@ class OmnigentOAuthHostRuntime:
                     "Lore repository work requires the configured provider adapter",
                     code=WORKSPACE_LOCATOR_UNSUPPORTED,
                 )
-            prepared = self._lore_repository_adapter.load_prepared_workspace(
-                locator=locator, authority_path=workspace
-            )
+            repository = str(repository_source or "").strip()
+            branch = str(starting_branch or target_branch or "").strip()
+            revision = str(checkout_commit or "").strip()
+            if workspace.exists():
+                prepared = await asyncio.to_thread(
+                    self._lore_repository_adapter.load_prepared_workspace,
+                    locator=locator,
+                    authority_path=workspace,
+                )
+                if repository and (
+                    prepared.repository,
+                    prepared.branch,
+                    prepared.revision_signature,
+                ) != (repository, branch, revision):
+                    raise OmnigentOAuthHostError(
+                        "existing Lore workspace does not match the authored target",
+                        code=WORKSPACE_AUTHORITY_MISMATCH,
+                    )
+            else:
+                if not repository or not branch or not revision:
+                    raise OmnigentOAuthHostError(
+                        "fresh Lore workspaces require repository, branch, and revision",
+                        code=WORKSPACE_LOCATOR_UNSUPPORTED,
+                    )
+                prepared = await asyncio.to_thread(
+                    self._lore_repository_adapter.prepare_workspace,
+                    repository=repository,
+                    branch=branch,
+                    revision_signature=revision,
+                    locator=locator,
+                    authority_path=workspace,
+                    connection_ref=repository_connection_ref,
+                    client_evidence=dict(repository_client_evidence or {}),
+                )
             binding = self._lore_repository_adapter.bind_workspace(
                 prepared,
                 runtime_lane="omnigent",

--- a/moonmind/omnigent/oauth_host_runtime.py
+++ b/moonmind/omnigent/oauth_host_runtime.py
@@ -246,6 +246,10 @@ class OmnigentOAuthHostRuntime:
             restore_input_refs=restore_input_refs,
             github_token=github_token,
             artifact_gateway=artifact_gateway,
+            omnigent_isolation_verified=(
+                launch.get("hostMode") == "on_demand_docker"
+                and "workspace" in set(launch.get("mountClasses") or ())
+            ),
         )
         daemon_workspace_source = daemon_visible_workspace_path(workspace_source)
         daemon_skill_projection = daemon_visible_workspace_path(skill_projection)
@@ -922,6 +926,7 @@ class OmnigentOAuthHostRuntime:
         restore_input_refs: tuple[str, ...] = (),
         github_token: str | None = None,
         artifact_gateway: Any | None = None,
+        omnigent_isolation_verified: bool = False,
     ) -> Path:
         """Resolve, and when required materialize, the authoritative workspace.
 
@@ -981,7 +986,7 @@ class OmnigentOAuthHostRuntime:
                 prepared,
                 runtime_lane="omnigent",
                 omnigent_mount_path="/workspaces/run",
-                omnigent_isolation_verified=True,
+                omnigent_isolation_verified=omnigent_isolation_verified,
             )
             if binding.authority_locator != locator:
                 raise OmnigentOAuthHostError(

--- a/moonmind/omnigent/oauth_host_runtime.py
+++ b/moonmind/omnigent/oauth_host_runtime.py
@@ -18,7 +18,11 @@ from moonmind.omnigent.oauth_hosts import (
     deterministic_host_container_name,
     validate_preflight_result,
 )
-from moonmind.repositories.lore_adapter import LoreRepositoryProviderAdapter
+from moonmind.repositories.lore_adapter import (
+    LORE_UNSUPPORTED_RUNTIME_LANE,
+    LoreRepositoryProviderAdapter,
+    LoreWorkspaceError,
+)
 from moonmind.omnigent.execution_profiles import validate_effective_launch_snapshot
 from moonmind.security.egress import (
     OMNIGENT_EGRESS_PROFILE,
@@ -998,6 +1002,11 @@ class OmnigentOAuthHostRuntime:
                 raise OmnigentOAuthHostError(
                     "Lore repository work requires the configured provider adapter",
                     code=WORKSPACE_LOCATOR_UNSUPPORTED,
+                )
+            if not omnigent_isolation_verified:
+                raise LoreWorkspaceError(
+                    LORE_UNSUPPORTED_RUNTIME_LANE,
+                    "Lore workspace isolation is not verified for this runtime lane",
                 )
             repository = str(repository_source or "").strip()
             branch = str(starting_branch or target_branch or "").strip()

--- a/moonmind/omnigent/oauth_host_runtime.py
+++ b/moonmind/omnigent/oauth_host_runtime.py
@@ -17,6 +17,7 @@ from moonmind.omnigent.oauth_hosts import (
     deterministic_host_container_name,
     validate_preflight_result,
 )
+from moonmind.repositories.lore_adapter import LoreRepositoryProviderAdapter
 from moonmind.omnigent.execution_profiles import validate_effective_launch_snapshot
 from moonmind.security.egress import (
     OMNIGENT_EGRESS_PROFILE,
@@ -141,6 +142,7 @@ class OmnigentOAuthHostRuntime:
         scripts_dir: Path | None = None,
         workspace_root: Path | None = None,
         repository_source_root: Path | str | None = None,
+        lore_repository_adapter: LoreRepositoryProviderAdapter | None = None,
     ) -> None:
         self._client = client
         if image:
@@ -182,6 +184,7 @@ class OmnigentOAuthHostRuntime:
         self._repository_source_root = (
             Path(source_root_text).resolve() if source_root_text else None
         )
+        self._lore_repository_adapter = lore_repository_adapter
         # Bounded, non-sensitive evidence of the most recent workspace resolution,
         # surfaced through the preflight result for Workflow Detail. Never carries
         # credentials, raw daemon paths, or unbounded command output.
@@ -204,6 +207,7 @@ class OmnigentOAuthHostRuntime:
         github_mutation_required: bool = False,
         effective_launch: Mapping[str, Any] | None = None,
         repository_source: str = "",
+        repository_provider: str = "",
         starting_branch: str | None = None,
         target_branch: str | None = None,
         checkout_commit: str | None = None,
@@ -235,6 +239,7 @@ class OmnigentOAuthHostRuntime:
             current_workflow_id=current_workflow_id,
             current_step_execution_id=current_step_execution_id,
             repository_source=repository_source,
+            repository_provider=repository_provider,
             starting_branch=starting_branch,
             target_branch=target_branch,
             checkout_commit=checkout_commit,
@@ -910,6 +915,7 @@ class OmnigentOAuthHostRuntime:
         current_workflow_id: str,
         current_step_execution_id: str,
         repository_source: str = "",
+        repository_provider: str = "",
         starting_branch: str | None = None,
         target_branch: str | None = None,
         checkout_commit: str | None = None,
@@ -962,6 +968,35 @@ class OmnigentOAuthHostRuntime:
             expected_workspace_id=expected_id,
             must_exist=False,
         )
+        if str(repository_provider or "").strip().lower() == "lore":
+            if self._lore_repository_adapter is None:
+                raise OmnigentOAuthHostError(
+                    "Lore repository work requires the configured provider adapter",
+                    code=WORKSPACE_LOCATOR_UNSUPPORTED,
+                )
+            prepared = self._lore_repository_adapter.load_prepared_workspace(
+                locator=locator, authority_path=workspace
+            )
+            binding = self._lore_repository_adapter.bind_workspace(
+                prepared,
+                runtime_lane="omnigent",
+                omnigent_mount_path="/workspaces/run",
+                omnigent_isolation_verified=True,
+            )
+            if binding.authority_locator != locator:
+                raise OmnigentOAuthHostError(
+                    "Lore workspace binding changed sandbox authority",
+                    code=WORKSPACE_AUTHORITY_MISMATCH,
+                )
+            self._last_workspace_evidence = self._workspace_resolution_evidence(
+                locator=locator,
+                expected_id=expected_id,
+                materialization={
+                    "action": "reused_lore_authority",
+                    "revisionSignature": prepared.revision_signature,
+                },
+            )
+            return workspace
         source = str(repository_source or "").strip()
         # 2. Establish or load the durable owner record and validate its binding
         #    before mutating the filesystem, so a retry or a foreign record can

--- a/moonmind/omnigent/profile_bound_execution.py
+++ b/moonmind/omnigent/profile_bound_execution.py
@@ -995,6 +995,12 @@ class OmnigentProfileBoundExecutionCoordinator:
                 repository_provider=str(
                     (request.workspace_spec or {}).get("provider") or ""
                 ).strip(),
+                repository_connection_ref=str(
+                    (request.workspace_spec or {}).get("connectionRef") or ""
+                ).strip(),
+                repository_client_evidence=dict(
+                    (request.workspace_spec or {}).get("clientEvidence") or {}
+                ),
                 starting_branch=(
                     None
                     if remediation_resolution is not None

--- a/moonmind/omnigent/profile_bound_execution.py
+++ b/moonmind/omnigent/profile_bound_execution.py
@@ -775,6 +775,9 @@ class OmnigentProfileBoundExecutionCoordinator:
                     if remediation_resolution is not None
                     else (workspace_intent.repository or "")
                 ),
+                repository_provider=str(
+                    (request.workspace_spec or {}).get("provider") or ""
+                ).strip(),
                 starting_branch=(
                     None
                     if remediation_resolution is not None

--- a/moonmind/repositories/__init__.py
+++ b/moonmind/repositories/__init__.py
@@ -1,5 +1,8 @@
 """Repository-provider boundaries."""
 
-from moonmind.repositories.lore_adapter import LoreRepositoryProviderAdapter
+from moonmind.repositories.lore_adapter import (
+    LoreImmutableObjectCache,
+    LoreRepositoryProviderAdapter,
+)
 
-__all__ = ["LoreRepositoryProviderAdapter"]
+__all__ = ["LoreImmutableObjectCache", "LoreRepositoryProviderAdapter"]

--- a/moonmind/repositories/__init__.py
+++ b/moonmind/repositories/__init__.py
@@ -1,0 +1,5 @@
+"""Repository-provider boundaries."""
+
+from moonmind.repositories.lore_adapter import LoreRepositoryProviderAdapter
+
+__all__ = ["LoreRepositoryProviderAdapter"]

--- a/moonmind/repositories/lore_adapter.py
+++ b/moonmind/repositories/lore_adapter.py
@@ -8,10 +8,11 @@ Implements the remaining workspace-boundary scope of Jira MM-1220.
 
 from __future__ import annotations
 
-import hashlib
 import base64
+import hashlib
 import json
 import os
+import shutil
 import stat
 import tempfile
 from dataclasses import dataclass
@@ -38,11 +39,24 @@ class LoreClient(Protocol):
     """Machine-readable operations supplied by the pinned Lore tool bundle."""
 
     def materialize(
-        self, *, repository: str, revision: str, destination: Path
-    ) -> Mapping[str, object]: ...
-    def scan_external_changes(self, *, workspace: Path) -> Mapping[str, object]: ...
-    def status(self, *, workspace: Path) -> Mapping[str, object]: ...
-    def stage_paths(self, *, workspace: Path, paths: Sequence[str]) -> None: ...
+        self,
+        *,
+        repository: str,
+        revision: str,
+        destination: Path,
+        connection_ref: str,
+        client_evidence: Mapping[str, str],
+    ) -> Mapping[str, object]:
+        ...
+
+    def scan_external_changes(self, *, workspace: Path) -> Mapping[str, object]:
+        ...
+
+    def status(self, *, workspace: Path) -> Mapping[str, object]:
+        ...
+
+    def stage_paths(self, *, workspace: Path, paths: Sequence[str]) -> None:
+        ...
 
 
 @dataclass(frozen=True)
@@ -331,19 +345,33 @@ class LoreRepositoryProviderAdapter:
             raise LoreWorkspaceError(
                 LORE_WORKSPACE_INVALID, "workspace must be empty before preparation"
             )
-        root.mkdir(parents=True, exist_ok=True)
-        result = self._client.materialize(
-            repository=repository, revision=revision_signature, destination=root
+        root.parent.mkdir(parents=True, exist_ok=True)
+        temporary = Path(
+            tempfile.mkdtemp(prefix=f".{root.name}.materializing-", dir=root.parent)
         )
-        if (
-            result.get("revisionSignature") != revision_signature
-            or result.get("completeTree") is not True
-        ):
-            raise LoreWorkspaceError(
-                LORE_WORKSPACE_INVALID,
-                "client did not prove the exact complete revision",
+        try:
+            result = self._client.materialize(
+                repository=repository,
+                revision=revision_signature,
+                destination=temporary,
+                connection_ref=connection_ref,
+                client_evidence=client_evidence,
             )
-        self._validate_tree(root)
+            if (
+                result.get("revisionSignature") != revision_signature
+                or result.get("completeTree") is not True
+            ):
+                raise LoreWorkspaceError(
+                    LORE_WORKSPACE_INVALID,
+                    "client did not prove the exact complete revision",
+                )
+            self._validate_tree(temporary)
+            if root.exists():
+                root.rmdir()
+            os.replace(temporary, root)
+        except Exception:
+            shutil.rmtree(temporary, ignore_errors=True)
+            raise
         metadata = {
             "schemaVersion": "moonmind.lore-workspace.v1",
             "repository": repository,

--- a/moonmind/repositories/lore_adapter.py
+++ b/moonmind/repositories/lore_adapter.py
@@ -9,9 +9,11 @@ Implements the remaining workspace-boundary scope of Jira MM-1220.
 from __future__ import annotations
 
 import hashlib
+import base64
 import json
 import os
 import stat
+import tempfile
 from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
 from typing import Literal, Mapping, Protocol, Sequence
@@ -73,16 +75,245 @@ class LoreDeltaCheckpoint:
     lock_state: Literal["not_captured"] = "not_captured"
 
 
+class LoreImmutableObjectCache:
+    """Trusted, content-addressed Lore object cache; never workspace state."""
+
+    def __init__(self, root: Path) -> None:
+        self._root = root.resolve()
+        if self._root == Path(self._root.anchor):
+            raise ValueError("cache root cannot be the filesystem root")
+
+    @staticmethod
+    def _digest(content: bytes) -> str:
+        return f"sha256:{hashlib.sha256(content).hexdigest()}"
+
+    @staticmethod
+    def _validate_identity(*values: str) -> None:
+        for value in values:
+            parts = PurePosixPath(str(value).replace("\\", "/")).parts
+            if not value or any(part in _PRIVATE_PARTS for part in parts):
+                raise LoreWorkspaceError(
+                    LORE_WORKSPACE_INVALID, "private cache identity is forbidden"
+                )
+
+    def _path(
+        self,
+        *,
+        endpoint: str,
+        repository: str,
+        client_compatibility: str,
+        object_digest: str,
+    ) -> Path:
+        self._validate_identity(endpoint, repository, client_compatibility)
+        if not object_digest.startswith("sha256:") or len(object_digest) != 71:
+            raise LoreWorkspaceError(LORE_WORKSPACE_INVALID, "invalid cache digest")
+        try:
+            int(object_digest[7:], 16)
+        except ValueError as exc:
+            raise LoreWorkspaceError(
+                LORE_WORKSPACE_INVALID, "invalid cache digest"
+            ) from exc
+        namespace = hashlib.sha256(
+            "\0".join((endpoint, repository, client_compatibility)).encode()
+        ).hexdigest()
+        return (
+            self._root / "objects" / namespace / object_digest[7:9] / object_digest[7:]
+        )
+
+    def publish(
+        self,
+        *,
+        endpoint: str,
+        repository: str,
+        client_compatibility: str,
+        object_digest: str,
+        content: bytes,
+    ) -> Path:
+        """Atomically publish a verified immutable object from a trusted boundary."""
+
+        if self._digest(content) != object_digest:
+            raise LoreWorkspaceError(
+                LORE_WORKSPACE_INVALID, "cache object digest mismatch"
+            )
+        target = self._path(
+            endpoint=endpoint,
+            repository=repository,
+            client_compatibility=client_compatibility,
+            object_digest=object_digest,
+        )
+        target.parent.mkdir(parents=True, exist_ok=True)
+        if target.exists():
+            self.read(
+                endpoint=endpoint,
+                repository=repository,
+                client_compatibility=client_compatibility,
+                object_digest=object_digest,
+            )
+            return target
+        fd, temporary_name = tempfile.mkstemp(prefix=".publish-", dir=target.parent)
+        temporary = Path(temporary_name)
+        try:
+            with os.fdopen(fd, "wb") as handle:
+                handle.write(content)
+                handle.flush()
+                os.fsync(handle.fileno())
+            temporary.chmod(0o444)
+            os.replace(temporary, target)
+        finally:
+            temporary.unlink(missing_ok=True)
+        return target
+
+    def read(
+        self,
+        *,
+        endpoint: str,
+        repository: str,
+        client_compatibility: str,
+        object_digest: str,
+    ) -> bytes:
+        target = self._path(
+            endpoint=endpoint,
+            repository=repository,
+            client_compatibility=client_compatibility,
+            object_digest=object_digest,
+        )
+        try:
+            content = target.read_bytes()
+        except FileNotFoundError as exc:
+            raise LoreWorkspaceError(
+                LORE_WORKSPACE_INVALID, "cache object is unavailable"
+            ) from exc
+        if self._digest(content) != object_digest:
+            target.unlink(missing_ok=True)
+            raise LoreWorkspaceError(
+                LORE_WORKSPACE_INVALID,
+                "cache object failed digest verification and was evicted",
+            )
+        return content
+
+
 class LoreRepositoryProviderAdapter:
     """Prepare exactly one authoritative workspace and bind it to runtimes."""
 
     def __init__(
-        self, client: LoreClient, *, checkpoint_limit_bytes: int = 64 * 1024 * 1024
+        self,
+        client: LoreClient,
+        *,
+        checkpoint_limit_bytes: int = 64 * 1024 * 1024,
+        immutable_cache: LoreImmutableObjectCache | None = None,
     ) -> None:
         if checkpoint_limit_bytes <= 0:
             raise ValueError("checkpoint_limit_bytes must be positive")
         self._client = client
         self._checkpoint_limit = checkpoint_limit_bytes
+        self._immutable_cache = immutable_cache
+
+    def publish_cache_object(self, **kwargs: object) -> Path:
+        if self._immutable_cache is None:
+            raise LoreWorkspaceError(
+                LORE_WORKSPACE_INVALID, "immutable Lore cache is not configured"
+            )
+        return self._immutable_cache.publish(**kwargs)  # type: ignore[arg-type]
+
+    def read_cache_object(self, **kwargs: str) -> bytes:
+        if self._immutable_cache is None:
+            raise LoreWorkspaceError(
+                LORE_WORKSPACE_INVALID, "immutable Lore cache is not configured"
+            )
+        return self._immutable_cache.read(**kwargs)
+
+    def encode_checkpoint(self, checkpoint: LoreDeltaCheckpoint) -> bytes:
+        """Encode the provider checkpoint for the durable artifact boundary."""
+
+        self._validate_checkpoint(checkpoint)
+        payload = {
+            "schemaVersion": "moonmind.repository-checkpoint.v1",
+            "provider": "lore",
+            "checkpointKind": "repository_delta",
+            "baseRevision": checkpoint.base_revision,
+            "changedPaths": list(checkpoint.changed_paths),
+            "stagedPaths": list(checkpoint.staged_paths),
+            "files": {
+                path: None if data is None else base64.b64encode(data).decode("ascii")
+                for path, data in checkpoint.files.items()
+            },
+            "totalBytes": checkpoint.total_bytes,
+            "digest": checkpoint.digest,
+            "lockState": checkpoint.lock_state,
+        }
+        return json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+
+    def decode_checkpoint(self, payload: bytes) -> LoreDeltaCheckpoint:
+        """Decode and validate an untrusted durable checkpoint artifact."""
+
+        try:
+            data = json.loads(payload)
+            if (
+                data.get("schemaVersion") != "moonmind.repository-checkpoint.v1"
+                or data.get("provider") != "lore"
+                or data.get("checkpointKind") != "repository_delta"
+                or data.get("lockState") != "not_captured"
+                or not isinstance(data.get("files"), dict)
+            ):
+                raise ValueError("invalid contract")
+            files = {
+                str(path): (
+                    None if value is None else base64.b64decode(value, validate=True)
+                )
+                for path, value in data["files"].items()
+            }
+            checkpoint = LoreDeltaCheckpoint(
+                base_revision=str(data["baseRevision"]),
+                changed_paths=tuple(data["changedPaths"]),
+                staged_paths=tuple(data["stagedPaths"]),
+                files=files,
+                total_bytes=int(data["totalBytes"]),
+                digest=str(data["digest"]),
+            )
+        except (KeyError, TypeError, ValueError, json.JSONDecodeError) as exc:
+            raise LoreWorkspaceError(
+                LORE_WORKSPACE_INVALID, "invalid durable Lore checkpoint"
+            ) from exc
+        self._validate_checkpoint(checkpoint)
+        return checkpoint
+
+    def load_prepared_workspace(
+        self,
+        *,
+        locator: SandboxWorkspaceLocator,
+        authority_path: Path,
+    ) -> LorePreparedWorkspace:
+        """Rebind an already-prepared authority without a second materialization."""
+
+        root = self._validate_authority_path(authority_path, must_exist=True)
+        self._validate_tree(root)
+        metadata_path = root.parent / f".{root.name}.lore-workspace.json"
+        try:
+            metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            raise LoreWorkspaceError(
+                LORE_WORKSPACE_INVALID, "Lore workspace metadata is unavailable"
+            ) from exc
+        if metadata.get("schemaVersion") != "moonmind.lore-workspace.v1":
+            raise LoreWorkspaceError(
+                LORE_WORKSPACE_INVALID, "Lore workspace metadata is invalid"
+            )
+        required = ("repository", "branch", "revisionSignature")
+        if any(
+            not isinstance(metadata.get(key), str) or not metadata[key]
+            for key in required
+        ):
+            raise LoreWorkspaceError(
+                LORE_WORKSPACE_INVALID, "Lore workspace metadata is incomplete"
+            )
+        return LorePreparedWorkspace(
+            locator,
+            root,
+            metadata["repository"],
+            metadata["branch"],
+            metadata["revisionSignature"],
+            metadata_path,
+        )
 
     def prepare_workspace(
         self,
@@ -215,10 +446,7 @@ class LoreRepositoryProviderAdapter:
         connection_ref: str,
         client_evidence: Mapping[str, str],
     ) -> LorePreparedWorkspace:
-        if checkpoint.total_bytes > self._checkpoint_limit:
-            raise LoreWorkspaceError(
-                LORE_CHECKPOINT_TOO_LARGE, "checkpoint exceeds restore policy"
-            )
+        self._validate_checkpoint(checkpoint)
         prepared = self.prepare_workspace(
             repository=repository,
             branch=branch,
@@ -242,6 +470,45 @@ class LoreRepositoryProviderAdapter:
             workspace=prepared.authority_path, paths=checkpoint.staged_paths
         )
         return prepared
+
+    def _validate_checkpoint(self, checkpoint: LoreDeltaCheckpoint) -> None:
+        changed = self._paths(checkpoint.changed_paths)
+        staged = self._paths(checkpoint.staged_paths)
+        file_paths = self._paths(tuple(checkpoint.files))
+        if set(file_paths) != set(changed) or not set(staged).issubset(changed):
+            raise LoreWorkspaceError(
+                LORE_WORKSPACE_INVALID,
+                "checkpoint paths, files, and staged paths are inconsistent",
+            )
+        actual_total, actual_digest = self._checkpoint_integrity(
+            changed, checkpoint.files
+        )
+        if actual_total > self._checkpoint_limit:
+            raise LoreWorkspaceError(
+                LORE_CHECKPOINT_TOO_LARGE, "checkpoint exceeds restore policy"
+            )
+        if checkpoint.total_bytes != actual_total or checkpoint.digest != actual_digest:
+            raise LoreWorkspaceError(
+                LORE_WORKSPACE_INVALID, "checkpoint size or digest is invalid"
+            )
+
+    @staticmethod
+    def _checkpoint_integrity(
+        changed: Sequence[str], files: Mapping[str, bytes | None]
+    ) -> tuple[int, str]:
+        total = 0
+        digest = hashlib.sha256()
+        for relative in changed:
+            data = files[relative]
+            if data is not None and not isinstance(data, bytes):
+                raise LoreWorkspaceError(
+                    LORE_WORKSPACE_INVALID, "checkpoint file payload must be bytes"
+                )
+            total += len(data or b"")
+            digest.update(relative.encode())
+            digest.update(b"\0")
+            digest.update(data or b"<deleted>")
+        return total, f"sha256:{digest.hexdigest()}"
 
     def _scan(self, root: Path) -> None:
         result = self._client.scan_external_changes(workspace=root)

--- a/moonmind/repositories/lore_adapter.py
+++ b/moonmind/repositories/lore_adapter.py
@@ -1,0 +1,328 @@
+"""Lore workspace preparation, binding, inspection, and checkpoint boundaries.
+
+The adapter owns provider semantics while callers supply the pinned Lore client
+implementation.  Workflow state carries only typed metadata and sandbox locators.
+
+Implements the remaining workspace-boundary scope of Jira MM-1220.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import stat
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Literal, Mapping, Protocol, Sequence
+
+from moonmind.schemas.workspace_locator_models import SandboxWorkspaceLocator
+
+LORE_CHECKPOINT_TOO_LARGE = "LORE_CHECKPOINT_TOO_LARGE"
+LORE_EXTERNAL_SCAN_FAILED = "LORE_EXTERNAL_SCAN_FAILED"
+LORE_UNSUPPORTED_RUNTIME_LANE = "LORE_UNSUPPORTED_RUNTIME_LANE"
+LORE_WORKSPACE_INVALID = "LORE_WORKSPACE_INVALID"
+
+_PRIVATE_PARTS = frozenset({".lore", ".credentials", ".locks", ".journals"})
+
+
+class LoreWorkspaceError(RuntimeError):
+    def __init__(self, code: str, message: str) -> None:
+        self.code = code
+        super().__init__(f"{code}: {message}")
+
+
+class LoreClient(Protocol):
+    """Machine-readable operations supplied by the pinned Lore tool bundle."""
+
+    def materialize(
+        self, *, repository: str, revision: str, destination: Path
+    ) -> Mapping[str, object]: ...
+    def scan_external_changes(self, *, workspace: Path) -> Mapping[str, object]: ...
+    def status(self, *, workspace: Path) -> Mapping[str, object]: ...
+    def stage_paths(self, *, workspace: Path, paths: Sequence[str]) -> None: ...
+
+
+@dataclass(frozen=True)
+class LorePreparedWorkspace:
+    authority_locator: SandboxWorkspaceLocator
+    authority_path: Path
+    repository: str
+    branch: str
+    revision_signature: str
+    metadata_path: Path
+
+
+@dataclass(frozen=True)
+class LoreWorkspaceBinding:
+    authority_locator: SandboxWorkspaceLocator
+    runtime_lane: Literal["managed_runtime", "omnigent"]
+    runtime_visible_path: str
+    mount_mode: Literal["direct_path", "bind_mount"]
+    read_only: bool
+
+
+@dataclass(frozen=True)
+class LoreDeltaCheckpoint:
+    base_revision: str
+    changed_paths: tuple[str, ...]
+    staged_paths: tuple[str, ...]
+    files: Mapping[str, bytes | None]
+    total_bytes: int
+    digest: str
+    lock_state: Literal["not_captured"] = "not_captured"
+
+
+class LoreRepositoryProviderAdapter:
+    """Prepare exactly one authoritative workspace and bind it to runtimes."""
+
+    def __init__(
+        self, client: LoreClient, *, checkpoint_limit_bytes: int = 64 * 1024 * 1024
+    ) -> None:
+        if checkpoint_limit_bytes <= 0:
+            raise ValueError("checkpoint_limit_bytes must be positive")
+        self._client = client
+        self._checkpoint_limit = checkpoint_limit_bytes
+
+    def prepare_workspace(
+        self,
+        *,
+        repository: str,
+        branch: str,
+        revision_signature: str,
+        locator: SandboxWorkspaceLocator,
+        authority_path: Path,
+        connection_ref: str,
+        client_evidence: Mapping[str, str],
+    ) -> LorePreparedWorkspace:
+        root = self._validate_authority_path(authority_path, must_exist=False)
+        if root.exists() and any(root.iterdir()):
+            raise LoreWorkspaceError(
+                LORE_WORKSPACE_INVALID, "workspace must be empty before preparation"
+            )
+        root.mkdir(parents=True, exist_ok=True)
+        result = self._client.materialize(
+            repository=repository, revision=revision_signature, destination=root
+        )
+        if (
+            result.get("revisionSignature") != revision_signature
+            or result.get("completeTree") is not True
+        ):
+            raise LoreWorkspaceError(
+                LORE_WORKSPACE_INVALID,
+                "client did not prove the exact complete revision",
+            )
+        self._validate_tree(root)
+        metadata = {
+            "schemaVersion": "moonmind.lore-workspace.v1",
+            "repository": repository,
+            "branch": branch,
+            "revisionSignature": revision_signature,
+            "connectionRef": connection_ref,
+            "clientEvidence": dict(client_evidence),
+        }
+        metadata_path = root.parent / f".{root.name}.lore-workspace.json"
+        metadata_path.write_text(json.dumps(metadata, sort_keys=True), encoding="utf-8")
+        return LorePreparedWorkspace(
+            locator, root, repository, branch, revision_signature, metadata_path
+        )
+
+    def bind_workspace(
+        self,
+        prepared: LorePreparedWorkspace,
+        *,
+        runtime_lane: str,
+        omnigent_mount_path: str = "/workspaces/run",
+        read_only: bool = False,
+        omnigent_isolation_verified: bool = True,
+    ) -> LoreWorkspaceBinding:
+        self._validate_tree(prepared.authority_path)
+        if runtime_lane == "managed_runtime":
+            return LoreWorkspaceBinding(
+                prepared.authority_locator,
+                runtime_lane,
+                str(prepared.authority_path),
+                "direct_path",
+                read_only,
+            )
+        if (
+            runtime_lane == "omnigent"
+            and omnigent_isolation_verified
+            and PurePosixPath(omnigent_mount_path).is_absolute()
+        ):
+            return LoreWorkspaceBinding(
+                prepared.authority_locator,
+                runtime_lane,
+                omnigent_mount_path,
+                "bind_mount",
+                read_only,
+            )
+        raise LoreWorkspaceError(
+            LORE_UNSUPPORTED_RUNTIME_LANE,
+            f"cannot bind authoritative Lore workspace to {runtime_lane!r}",
+        )
+
+    def inspect_workspace(
+        self, prepared: LorePreparedWorkspace
+    ) -> Mapping[str, object]:
+        self._scan(prepared.authority_path)
+        return self._client.status(workspace=prepared.authority_path)
+
+    def capture_checkpoint(
+        self, prepared: LorePreparedWorkspace
+    ) -> LoreDeltaCheckpoint:
+        self._scan(prepared.authority_path)
+        status = self._client.status(workspace=prepared.authority_path)
+        changed = self._paths(status.get("changedPaths", ()))
+        staged = self._paths(status.get("stagedPaths", ()))
+        if not set(staged).issubset(changed):
+            raise LoreWorkspaceError(
+                LORE_WORKSPACE_INVALID, "staged paths must be changed paths"
+            )
+        files: dict[str, bytes | None] = {}
+        total = 0
+        digest = hashlib.sha256()
+        for relative in changed:
+            path = self._checked_path(prepared.authority_path, relative)
+            data = None if not path.exists() else path.read_bytes()
+            total += len(data or b"")
+            if total > self._checkpoint_limit:
+                raise LoreWorkspaceError(
+                    LORE_CHECKPOINT_TOO_LARGE,
+                    f"dirty delta exceeds {self._checkpoint_limit} bytes",
+                )
+            files[relative] = data
+            digest.update(relative.encode())
+            digest.update(b"\0")
+            digest.update(data or b"<deleted>")
+        return LoreDeltaCheckpoint(
+            prepared.revision_signature,
+            changed,
+            staged,
+            files,
+            total,
+            f"sha256:{digest.hexdigest()}",
+        )
+
+    def restore_checkpoint(
+        self,
+        checkpoint: LoreDeltaCheckpoint,
+        *,
+        repository: str,
+        branch: str,
+        locator: SandboxWorkspaceLocator,
+        authority_path: Path,
+        connection_ref: str,
+        client_evidence: Mapping[str, str],
+    ) -> LorePreparedWorkspace:
+        if checkpoint.total_bytes > self._checkpoint_limit:
+            raise LoreWorkspaceError(
+                LORE_CHECKPOINT_TOO_LARGE, "checkpoint exceeds restore policy"
+            )
+        prepared = self.prepare_workspace(
+            repository=repository,
+            branch=branch,
+            revision_signature=checkpoint.base_revision,
+            locator=locator,
+            authority_path=authority_path,
+            connection_ref=connection_ref,
+            client_evidence=client_evidence,
+        )
+        for relative, data in checkpoint.files.items():
+            path = self._checked_path(prepared.authority_path, relative)
+            if data is None:
+                if path.exists():
+                    path.unlink()
+            else:
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_bytes(data)
+        self._validate_tree(prepared.authority_path)
+        self._scan(prepared.authority_path)
+        self._client.stage_paths(
+            workspace=prepared.authority_path, paths=checkpoint.staged_paths
+        )
+        return prepared
+
+    def _scan(self, root: Path) -> None:
+        result = self._client.scan_external_changes(workspace=root)
+        if result.get("success") is not True:
+            raise LoreWorkspaceError(
+                LORE_EXTERNAL_SCAN_FAILED, "external-change scan did not succeed"
+            )
+
+    @staticmethod
+    def _paths(values: object) -> tuple[str, ...]:
+        if not isinstance(values, (list, tuple)):
+            raise LoreWorkspaceError(
+                LORE_WORKSPACE_INVALID, "client paths must be a list"
+            )
+        result = tuple(dict.fromkeys(str(value).replace("\\", "/") for value in values))
+        for value in result:
+            LoreRepositoryProviderAdapter._validate_relative(value)
+        return result
+
+    @staticmethod
+    def _validate_relative(value: str) -> None:
+        path = PurePosixPath(value)
+        if (
+            not value
+            or path.is_absolute()
+            or any(
+                part in {"", ".", ".."} or part in _PRIVATE_PARTS for part in path.parts
+            )
+        ):
+            raise LoreWorkspaceError(
+                LORE_WORKSPACE_INVALID, f"unsafe or private checkpoint path: {value!r}"
+            )
+
+    @classmethod
+    def _checked_path(cls, root: Path, relative: str) -> Path:
+        cls._validate_relative(relative)
+        candidate = root.joinpath(*PurePosixPath(relative).parts)
+        current = root
+        for part in PurePosixPath(relative).parts:
+            current = current / part
+            if current.is_symlink():
+                raise LoreWorkspaceError(
+                    LORE_WORKSPACE_INVALID, f"symlink in checkpoint path: {relative}"
+                )
+        resolved_root, resolved = root.resolve(), candidate.resolve(strict=False)
+        if not resolved.is_relative_to(resolved_root):
+            raise LoreWorkspaceError(
+                LORE_WORKSPACE_INVALID, "checkpoint path escapes workspace"
+            )
+        return candidate
+
+    @staticmethod
+    def _validate_authority_path(path: Path, *, must_exist: bool) -> Path:
+        if not path.is_absolute():
+            raise LoreWorkspaceError(
+                LORE_WORKSPACE_INVALID, "authority path must be absolute"
+            )
+        root = path.resolve(strict=must_exist)
+        if root == Path(root.anchor):
+            raise LoreWorkspaceError(
+                LORE_WORKSPACE_INVALID, "filesystem root cannot be workspace authority"
+            )
+        return root
+
+    @classmethod
+    def _validate_tree(cls, root: Path) -> None:
+        root = cls._validate_authority_path(root, must_exist=True)
+        for directory, names, files in os.walk(root, followlinks=False):
+            base = Path(directory)
+            for name in names + files:
+                path = base / name
+                if path.is_symlink():
+                    target = path.resolve(strict=False)
+                    if not target.is_relative_to(root):
+                        raise LoreWorkspaceError(
+                            LORE_WORKSPACE_INVALID,
+                            f"workspace symlink escapes authority: {path.relative_to(root)}",
+                        )
+                elif path.exists() and not (path.is_file() or path.is_dir()):
+                    mode = stat.S_IFMT(path.stat().st_mode)
+                    raise LoreWorkspaceError(
+                        LORE_WORKSPACE_INVALID,
+                        f"unsupported workspace entry mode {mode}",
+                    )

--- a/moonmind/repositories/lore_adapter.py
+++ b/moonmind/repositories/lore_adapter.py
@@ -47,16 +47,16 @@ class LoreClient(Protocol):
         connection_ref: str,
         client_evidence: Mapping[str, str],
     ) -> Mapping[str, object]:
-        ...
+        pass
 
     def scan_external_changes(self, *, workspace: Path) -> Mapping[str, object]:
-        ...
+        pass
 
     def status(self, *, workspace: Path) -> Mapping[str, object]:
-        ...
+        pass
 
     def stage_paths(self, *, workspace: Path, paths: Sequence[str]) -> None:
-        ...
+        pass
 
 
 @dataclass(frozen=True)

--- a/moonmind/repositories/lore_checkpoints.py
+++ b/moonmind/repositories/lore_checkpoints.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
 from typing import Any, Mapping
 
@@ -24,18 +25,21 @@ class LoreDurableCheckpointService:
 
     async def capture(self, prepared: LorePreparedWorkspace) -> str:
         # capture_checkpoint performs the mandatory external scan before status.
-        payload = self._adapter.encode_checkpoint(
-            self._adapter.capture_checkpoint(prepared)
+        payload = await asyncio.to_thread(
+            lambda: self._adapter.encode_checkpoint(
+                self._adapter.capture_checkpoint(prepared)
+            )
         )
         artifact, _ = await self._artifacts.create(
             principal=_PRINCIPAL,
             content_type=LORE_CHECKPOINT_CONTENT_TYPE,
+            size_bytes=len(payload),
             metadata_json={
                 "artifact_kind": "repository_checkpoint",
                 "provider": "lore",
             },
         )
-        completed = await self._artifacts.write_complete(
+        completed = await self._artifacts.write_payload_complete(
             artifact_id=artifact.artifact_id,
             principal=_PRINCIPAL,
             payload=payload,
@@ -63,13 +67,14 @@ class LoreDurableCheckpointService:
             raise ValueError(
                 "Lore checkpoint artifact has an incompatible content type"
             )
-        checkpoint = self._adapter.decode_checkpoint(payload)
-        return self._adapter.restore_checkpoint(
-            checkpoint,
-            repository=repository,
-            branch=branch,
-            locator=locator,
-            authority_path=authority_path,
-            connection_ref=connection_ref,
-            client_evidence=client_evidence,
+        return await asyncio.to_thread(
+            lambda: self._adapter.restore_checkpoint(
+                self._adapter.decode_checkpoint(payload),
+                repository=repository,
+                branch=branch,
+                locator=locator,
+                authority_path=authority_path,
+                connection_ref=connection_ref,
+                client_evidence=client_evidence,
+            )
         )

--- a/moonmind/repositories/lore_checkpoints.py
+++ b/moonmind/repositories/lore_checkpoints.py
@@ -1,0 +1,75 @@
+"""Durable artifact boundary for Lore delta checkpoints."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Mapping
+
+from moonmind.schemas.workspace_locator_models import SandboxWorkspaceLocator
+
+from .lore_adapter import LorePreparedWorkspace, LoreRepositoryProviderAdapter
+
+LORE_CHECKPOINT_CONTENT_TYPE = (
+    "application/vnd.moonmind.repository-checkpoint+json;version=1"
+)
+_PRINCIPAL = "service:lore_checkpoint"
+
+
+class LoreDurableCheckpointService:
+    def __init__(
+        self, *, adapter: LoreRepositoryProviderAdapter, artifact_service: Any
+    ) -> None:
+        self._adapter = adapter
+        self._artifacts = artifact_service
+
+    async def capture(self, prepared: LorePreparedWorkspace) -> str:
+        # capture_checkpoint performs the mandatory external scan before status.
+        payload = self._adapter.encode_checkpoint(
+            self._adapter.capture_checkpoint(prepared)
+        )
+        artifact, _ = await self._artifacts.create(
+            principal=_PRINCIPAL,
+            content_type=LORE_CHECKPOINT_CONTENT_TYPE,
+            metadata_json={
+                "artifact_kind": "repository_checkpoint",
+                "provider": "lore",
+            },
+        )
+        completed = await self._artifacts.write_complete(
+            artifact_id=artifact.artifact_id,
+            principal=_PRINCIPAL,
+            payload=payload,
+            content_type=LORE_CHECKPOINT_CONTENT_TYPE,
+        )
+        return completed.artifact_id
+
+    async def restore(
+        self,
+        checkpoint_ref: str,
+        *,
+        repository: str,
+        branch: str,
+        locator: SandboxWorkspaceLocator,
+        authority_path: Path,
+        connection_ref: str,
+        client_evidence: Mapping[str, str],
+    ) -> LorePreparedWorkspace:
+        artifact, payload = await self._artifacts.read(
+            artifact_id=checkpoint_ref,
+            principal=_PRINCIPAL,
+            allow_restricted_raw=True,
+        )
+        if str(artifact.content_type) != LORE_CHECKPOINT_CONTENT_TYPE:
+            raise ValueError(
+                "Lore checkpoint artifact has an incompatible content type"
+            )
+        checkpoint = self._adapter.decode_checkpoint(payload)
+        return self._adapter.restore_checkpoint(
+            checkpoint,
+            repository=repository,
+            branch=branch,
+            locator=locator,
+            authority_path=authority_path,
+            connection_ref=connection_ref,
+            client_evidence=client_evidence,
+        )

--- a/moonmind/repositories/lore_runtime.py
+++ b/moonmind/repositories/lore_runtime.py
@@ -1,0 +1,138 @@
+"""Production construction for the pinned Lore repository adapter.
+
+The executable is supplied by the resolved tool bundle.  This boundary verifies
+the configured pin before every invocation and accepts machine-readable JSON
+only; it never places credentials on the command line.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import subprocess
+from pathlib import Path
+from typing import Mapping, Sequence
+
+from .lore_adapter import (
+    LORE_WORKSPACE_INVALID,
+    LoreImmutableObjectCache,
+    LoreRepositoryProviderAdapter,
+    LoreWorkspaceError,
+)
+
+
+class PinnedLoreCliClient:
+    def __init__(self, *, executable: Path, executable_sha256: str) -> None:
+        self._executable = executable.resolve(strict=True)
+        self._expected_digest = executable_sha256.removeprefix("sha256:").lower()
+        if len(self._expected_digest) != 64:
+            raise LoreWorkspaceError(
+                LORE_WORKSPACE_INVALID, "invalid Lore executable pin"
+            )
+
+    def _invoke(self, arguments: Sequence[str]) -> Mapping[str, object]:
+        actual = hashlib.sha256(self._executable.read_bytes()).hexdigest()
+        if actual != self._expected_digest:
+            raise LoreWorkspaceError(
+                LORE_WORKSPACE_INVALID, "pinned Lore executable digest does not match"
+            )
+        completed = subprocess.run(
+            [str(self._executable), *arguments, "--output", "json"],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=300,
+            env={
+                key: value
+                for key, value in os.environ.items()
+                if key not in {"LORE_TOKEN", "LORE_PASSWORD"}
+            },
+        )
+        if completed.returncode != 0:
+            raise LoreWorkspaceError(
+                LORE_WORKSPACE_INVALID,
+                f"Lore client operation failed with exit code {completed.returncode}",
+            )
+        try:
+            result = json.loads(completed.stdout)
+        except json.JSONDecodeError as exc:
+            raise LoreWorkspaceError(
+                LORE_WORKSPACE_INVALID,
+                "Lore client did not return machine-readable JSON",
+            ) from exc
+        if not isinstance(result, dict):
+            raise LoreWorkspaceError(
+                LORE_WORKSPACE_INVALID, "invalid Lore client result"
+            )
+        return result
+
+    def materialize(self, *, repository: str, revision: str, destination: Path):
+        return self._invoke(
+            (
+                "workspace",
+                "materialize",
+                "--repository",
+                repository,
+                "--revision",
+                revision,
+                "--destination",
+                str(destination),
+                "--complete-tree",
+            )
+        )
+
+    def scan_external_changes(self, *, workspace: Path):
+        return self._invoke(
+            ("workspace", "scan-external", "--workspace", str(workspace))
+        )
+
+    def status(self, *, workspace: Path):
+        return self._invoke(("workspace", "status", "--workspace", str(workspace)))
+
+    def stage_paths(self, *, workspace: Path, paths: Sequence[str]) -> None:
+        result = self._invoke(
+            (
+                "workspace",
+                "stage",
+                "--workspace",
+                str(workspace),
+                "--paths-json",
+                json.dumps(list(paths)),
+            )
+        )
+        if result.get("success") is not True:
+            raise LoreWorkspaceError(
+                LORE_WORKSPACE_INVALID, "Lore staging did not succeed"
+            )
+
+
+def build_lore_repository_adapter_from_environment() -> (
+    LoreRepositoryProviderAdapter | None
+):
+    """Build the single production adapter, or advertise no Lore support.
+
+    Partial configuration fails at worker startup instead of allowing a Lore run
+    to reach launch with an unpinned client.
+    """
+
+    executable = os.getenv("MOONMIND_LORE_EXECUTABLE", "").strip()
+    digest = os.getenv("MOONMIND_LORE_EXECUTABLE_SHA256", "").strip()
+    if not executable and not digest:
+        return None
+    if not executable or not digest:
+        raise LoreWorkspaceError(
+            LORE_WORKSPACE_INVALID,
+            "MOONMIND_LORE_EXECUTABLE and MOONMIND_LORE_EXECUTABLE_SHA256 are both required",
+        )
+    cache_root = Path(
+        os.getenv("MOONMIND_LORE_IMMUTABLE_CACHE_ROOT", "/var/cache/moonmind/lore")
+    )
+    limit = int(
+        os.getenv("MOONMIND_LORE_CHECKPOINT_LIMIT_BYTES", str(64 * 1024 * 1024))
+    )
+    return LoreRepositoryProviderAdapter(
+        PinnedLoreCliClient(executable=Path(executable), executable_sha256=digest),
+        checkpoint_limit_bytes=limit,
+        immutable_cache=LoreImmutableObjectCache(cache_root),
+    )

--- a/moonmind/repositories/lore_runtime.py
+++ b/moonmind/repositories/lore_runtime.py
@@ -67,13 +67,27 @@ class PinnedLoreCliClient:
             )
         return result
 
-    def materialize(self, *, repository: str, revision: str, destination: Path):
+    def materialize(
+        self,
+        *,
+        repository: str,
+        revision: str,
+        destination: Path,
+        connection_ref: str,
+        client_evidence: Mapping[str, str],
+    ):
+        if not connection_ref:
+            raise LoreWorkspaceError(
+                LORE_WORKSPACE_INVALID, "Lore connectionRef is required"
+            )
         return self._invoke(
             (
                 "workspace",
                 "materialize",
                 "--repository",
                 repository,
+                "--connection-ref",
+                connection_ref,
                 "--revision",
                 revision,
                 "--destination",

--- a/moonmind/workflows/temporal/activities/oauth_session_activities.py
+++ b/moonmind/workflows/temporal/activities/oauth_session_activities.py
@@ -54,6 +54,9 @@ async def oauth_session_prepare_credential_maintenance(
         resolved_proxy_forward_headers,
         resolved_server_url,
     )
+    from moonmind.repositories.lore_runtime import (
+        build_lore_repository_adapter_from_environment,
+    )
     from moonmind.workflows.adapters.omnigent_client import OmnigentHttpClient
 
     profile_id = str(request.get("profile_id") or "").strip()
@@ -71,7 +74,10 @@ async def oauth_session_prepare_credential_maintenance(
             client=http_client,
             upstream_header_allowlist=resolved_proxy_forward_headers(),
         )
-        runtime = OmnigentOAuthHostRuntime(client=client)
+        runtime = OmnigentOAuthHostRuntime(
+            client=client,
+            lore_repository_adapter=build_lore_repository_adapter_from_environment(),
+        )
         drained = 0
         if not binding.host_launch_profile_ref:
             # The static host can remain intentionally idle after its prior
@@ -111,6 +117,9 @@ async def oauth_session_revalidate_bound_host(
         resolved_proxy_forward_headers,
         resolved_server_url,
     )
+    from moonmind.repositories.lore_runtime import (
+        build_lore_repository_adapter_from_environment,
+    )
     from moonmind.workflows.adapters.omnigent_client import OmnigentHttpClient
 
     profile_id = str(request.get("profile_id") or "").strip()
@@ -147,7 +156,10 @@ async def oauth_session_revalidate_bound_host(
                 client=http_client,
                 upstream_header_allowlist=resolved_proxy_forward_headers(),
             )
-            runtime = OmnigentOAuthHostRuntime(client=client)
+            runtime = OmnigentOAuthHostRuntime(
+                client=client,
+                lore_repository_adapter=build_lore_repository_adapter_from_environment(),
+            )
             preflight = await runtime.prepare_host(
                 binding=binding,
                 host_lease=lease,

--- a/moonmind/workflows/temporal/activities/omnigent_activities.py
+++ b/moonmind/workflows/temporal/activities/omnigent_activities.py
@@ -33,6 +33,9 @@ async def omnigent_execute_activity(
         resolved_server_url,
     )
     from moonmind.provider_profiles.lease_client import ProviderProfileLeaseClient
+    from moonmind.repositories.lore_runtime import (
+        build_lore_repository_adapter_from_environment,
+    )
     from moonmind.workflows.adapters.omnigent_client import OmnigentHttpClient
     from moonmind.workflows.temporal.client import TemporalClientAdapter
     from moonmind.workflows.temporal.artifacts import (
@@ -116,11 +119,15 @@ async def omnigent_execute_activity(
             artifact_service=artifact_service,
         )
 
+        lore_repository_adapter = build_lore_repository_adapter_from_environment()
         coordinator = OmnigentProfileBoundExecutionCoordinator(
             session_factory=async_session_maker,
             lease_client=ProviderProfileLeaseClient(TemporalClientAdapter()),
             host_repository=OmnigentOAuthHostRepository(async_session_maker),
-            host_runtime=OmnigentOAuthHostRuntime(client=omnigent_client),
+            host_runtime=OmnigentOAuthHostRuntime(
+                client=omnigent_client,
+                lore_repository_adapter=lore_repository_adapter,
+            ),
             run_store=run_store,
             execution_runner=run_omnigent_execution,
             artifact_gateway=artifact_gateway,

--- a/moonmind/workflows/temporal/runtime/launcher.py
+++ b/moonmind/workflows/temporal/runtime/launcher.py
@@ -822,6 +822,13 @@ class ManagedRuntimeLauncher:
                 workspace_spec.get("workspaceLocator")
                 or {"kind": "sandbox", "workspaceId": workspace_key, "relativePath": "repo"}
             )
+            omnigent_workspace_key = hashlib.sha256(
+                f"{request.correlation_id}:{request.idempotency_key}".encode("utf-8")
+            ).hexdigest()[:24]
+            if locator.workspace_id not in {workspace_key, omnigent_workspace_key}:
+                raise RuntimeError(
+                    "Lore sandbox locator does not belong to the current run"
+                )
             # Resolve the same sandbox-authority path used by the Omnigent owner.
             # The managed lane must not create a parallel checkout under its
             # managed-run store when an authored locator already names authority.
@@ -841,8 +848,10 @@ class ManagedRuntimeLauncher:
                     "Lore workspaceSpec requires repository, branch, and revisionSignature"
                 )
             if authority_path.exists():
-                prepared = self._lore_repository_adapter.load_prepared_workspace(
-                    locator=locator, authority_path=authority_path
+                prepared = await asyncio.to_thread(
+                    self._lore_repository_adapter.load_prepared_workspace,
+                    locator=locator,
+                    authority_path=authority_path,
                 )
                 if (prepared.repository, prepared.branch, prepared.revision_signature) != (
                     repository, branch, revision
@@ -851,7 +860,8 @@ class ManagedRuntimeLauncher:
                         "existing Lore workspace does not match the authored target"
                     )
             else:
-                prepared = self._lore_repository_adapter.prepare_workspace(
+                prepared = await asyncio.to_thread(
+                    self._lore_repository_adapter.prepare_workspace,
                     repository=repository,
                     branch=branch,
                     revision_signature=revision,

--- a/moonmind/workflows/temporal/runtime/launcher.py
+++ b/moonmind/workflows/temporal/runtime/launcher.py
@@ -12,7 +12,7 @@ import shutil
 import stat
 from collections.abc import Mapping
 from datetime import UTC, datetime
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any
 
 from moonmind.repositories.lore_adapter import LoreRepositoryProviderAdapter
@@ -231,6 +231,38 @@ class ManagedRuntimeLauncher:
         self._log_streamer = log_streamer
         self._artifact_service = artifact_service
         self._lore_repository_adapter = lore_repository_adapter
+        self._lore_checkpoint_service = None
+        if lore_repository_adapter is not None and artifact_service is not None:
+            from moonmind.repositories.lore_checkpoints import (
+                LoreDurableCheckpointService,
+            )
+
+            self._lore_checkpoint_service = LoreDurableCheckpointService(
+                adapter=lore_repository_adapter,
+                artifact_service=artifact_service,
+            )
+
+    async def capture_lore_workspace_checkpoint(
+        self, *, locator: SandboxWorkspaceLocator, authority_path: Path
+    ) -> str:
+        """Persist provider state from the authoritative sandbox workspace."""
+        if (
+            self._lore_repository_adapter is None
+            or self._lore_checkpoint_service is None
+        ):
+            raise RuntimeError("Lore durable checkpoint support is not configured")
+        prepared = self._lore_repository_adapter.load_prepared_workspace(
+            locator=locator, authority_path=authority_path
+        )
+        return await self._lore_checkpoint_service.capture(prepared)
+
+    async def restore_lore_workspace_checkpoint(
+        self, checkpoint_ref: str, **kwargs: Any
+    ):
+        """Cold-restore a Lore delta before a managed runtime is launched."""
+        if self._lore_checkpoint_service is None:
+            raise RuntimeError("Lore durable checkpoint support is not configured")
+        return await self._lore_checkpoint_service.restore(checkpoint_ref, **kwargs)
 
     @staticmethod
     def _build_managed_runtime_base_env() -> dict[str, str]:
@@ -786,14 +818,21 @@ class ManagedRuntimeLauncher:
                     "Lore repository work requires the configured provider adapter"
                 )
             workspace_key = self._workspace_key_for_request(run_id=run_id, request=request)
-            workspace_root = (
-                self._store.store_root.parent / "workspaces" / workspace_key
-            ).resolve()
-            authority_path = (workspace_root / "repo").resolve()
             locator = SandboxWorkspaceLocator.model_validate(
                 workspace_spec.get("workspaceLocator")
                 or {"kind": "sandbox", "workspaceId": workspace_key, "relativePath": "repo"}
             )
+            # Resolve the same sandbox-authority path used by the Omnigent owner.
+            # The managed lane must not create a parallel checkout under its
+            # managed-run store when an authored locator already names authority.
+            workspace_root = (
+                self._store.store_root.parent / locator.workspace_id
+            ).resolve()
+            authority_path = workspace_root.joinpath(
+                *PurePosixPath(locator.relative_path).parts
+            ).resolve()
+            if not authority_path.is_relative_to(workspace_root):
+                raise RuntimeError("Lore sandbox locator escapes workspace authority")
             repository = str(workspace_spec.get("repository") or workspace_spec.get("repo") or "").strip()
             branch = str(workspace_spec.get("startingBranch") or workspace_spec.get("branch") or "").strip()
             revision = str(workspace_spec.get("revisionSignature") or workspace_spec.get("preparedRevision") or "").strip()

--- a/moonmind/workflows/temporal/runtime/launcher.py
+++ b/moonmind/workflows/temporal/runtime/launcher.py
@@ -833,7 +833,9 @@ class ManagedRuntimeLauncher:
             # The managed lane must not create a parallel checkout under its
             # managed-run store when an authored locator already names authority.
             workspace_root = (
-                self._store.store_root.parent / locator.workspace_id
+                self._store.store_root.parent
+                / "temporal_sandbox"
+                / locator.workspace_id
             ).resolve()
             authority_path = workspace_root.joinpath(
                 *PurePosixPath(locator.relative_path).parts

--- a/moonmind/workflows/temporal/runtime/launcher.py
+++ b/moonmind/workflows/temporal/runtime/launcher.py
@@ -15,6 +15,9 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
+from moonmind.repositories.lore_adapter import LoreRepositoryProviderAdapter
+from moonmind.schemas.workspace_locator_models import SandboxWorkspaceLocator
+
 from moonmind.schemas.agent_runtime_models import (
     AgentExecutionRequest,
     AgentTerminalContract,
@@ -220,12 +223,14 @@ class ManagedRuntimeLauncher:
         store: ManagedRunStore,
         log_streamer: RuntimeLogStreamer | None = None,
         artifact_service: Any | None = None,
+        lore_repository_adapter: LoreRepositoryProviderAdapter | None = None,
     ) -> None:
         self._store = store
         self._logger = logging.getLogger(__name__)
         self._github_auth_brokers = GitHubAuthBrokerManager()
         self._log_streamer = log_streamer
         self._artifact_service = artifact_service
+        self._lore_repository_adapter = lore_repository_adapter
 
     @staticmethod
     def _build_managed_runtime_base_env() -> dict[str, str]:
@@ -774,6 +779,51 @@ class ManagedRuntimeLauncher:
             if isinstance(request.workspace_spec, dict)
             else {}
         )
+        provider = str(workspace_spec.get("provider") or "").strip().lower()
+        if provider == "lore":
+            if self._lore_repository_adapter is None:
+                raise RuntimeError(
+                    "Lore repository work requires the configured provider adapter"
+                )
+            workspace_key = self._workspace_key_for_request(run_id=run_id, request=request)
+            workspace_root = (
+                self._store.store_root.parent / "workspaces" / workspace_key
+            ).resolve()
+            authority_path = (workspace_root / "repo").resolve()
+            locator = SandboxWorkspaceLocator.model_validate(
+                workspace_spec.get("workspaceLocator")
+                or {"kind": "sandbox", "workspaceId": workspace_key, "relativePath": "repo"}
+            )
+            repository = str(workspace_spec.get("repository") or workspace_spec.get("repo") or "").strip()
+            branch = str(workspace_spec.get("startingBranch") or workspace_spec.get("branch") or "").strip()
+            revision = str(workspace_spec.get("revisionSignature") or workspace_spec.get("preparedRevision") or "").strip()
+            if not repository or not branch or not revision:
+                raise RuntimeError(
+                    "Lore workspaceSpec requires repository, branch, and revisionSignature"
+                )
+            if authority_path.exists():
+                prepared = self._lore_repository_adapter.load_prepared_workspace(
+                    locator=locator, authority_path=authority_path
+                )
+                if (prepared.repository, prepared.branch, prepared.revision_signature) != (
+                    repository, branch, revision
+                ):
+                    raise RuntimeError(
+                        "existing Lore workspace does not match the authored target"
+                    )
+            else:
+                prepared = self._lore_repository_adapter.prepare_workspace(
+                    repository=repository,
+                    branch=branch,
+                    revision_signature=revision,
+                    locator=locator,
+                    authority_path=authority_path,
+                    connection_ref=str(workspace_spec.get("connectionRef") or ""),
+                    client_evidence=dict(workspace_spec.get("clientEvidence") or {}),
+                )
+            return self._lore_repository_adapter.bind_workspace(
+                prepared, runtime_lane="managed_runtime"
+            ).runtime_visible_path
         repository = str(
             workspace_spec.get("repository")
             or workspace_spec.get("repo")

--- a/moonmind/workflows/temporal/worker_runtime.py
+++ b/moonmind/workflows/temporal/worker_runtime.py
@@ -2498,6 +2498,9 @@ def _build_agent_runtime_deps(
         DockerWorkloadLauncher,
         RunnerProfileRegistry,
     )
+    from moonmind.repositories.lore_runtime import (
+        build_lore_repository_adapter_from_environment,
+    )
 
     class LocalRuntimeArtifactStorage:
         def __init__(self, root: str) -> None:
@@ -2531,6 +2534,7 @@ def _build_agent_runtime_deps(
         store,
         log_streamer=log_streamer,
         artifact_service=artifact_service,
+        lore_repository_adapter=build_lore_repository_adapter_from_environment(),
     )
     session_store = ManagedSessionStore(
         os.path.join(

--- a/tests/unit/omnigent/test_oauth_profile_lifecycle.py
+++ b/tests/unit/omnigent/test_oauth_profile_lifecycle.py
@@ -52,6 +52,10 @@ from moonmind.omnigent.profile_bound_execution import (
 )
 from moonmind.omnigent.policies import compile_policy_snapshot
 from moonmind.omnigent.remediation_workspace import RemediationWorkspaceError
+from moonmind.repositories.lore_adapter import (
+    LORE_UNSUPPORTED_RUNTIME_LANE,
+    LoreWorkspaceError,
+)
 from moonmind.provider_profiles.lease_client import (
     CredentialLeasePurpose,
     ProviderProfileLeaseClient,
@@ -66,7 +70,10 @@ from moonmind.schemas.agent_runtime_models import (
     OmnigentOAuthHostBinding,
 )
 from moonmind.schemas.temporal_models import WorkspaceCheckpointEvidenceModel
-from moonmind.schemas.workspace_locator_models import WorkspaceLocatorResolutionError
+from moonmind.schemas.workspace_locator_models import (
+    SandboxWorkspaceLocator,
+    WorkspaceLocatorResolutionError,
+)
 from moonmind.workflows.temporal.runtime.workspace_locators import (
     SandboxWorkspaceRecord,
     SandboxWorkspaceRecordStore,
@@ -1257,6 +1264,64 @@ async def test_effective_policy_conflict_fails_before_host_mutation(tmp_path) ->
     assert exc_info.value.code == "OMNIGENT_LAUNCH_POLICY_BINDING_CONFLICT"
     runtime._prepare_skill_projection.assert_not_awaited()
     runtime._prepare_workspace.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_static_host_rejects_lore_workspace_before_host_mutation(tmp_path) -> None:
+    workflow_id, step_id = "workflow-1", "step-1"
+    workspace_id = hashlib.sha256(
+        f"{workflow_id}:{step_id}".encode("utf-8")
+    ).hexdigest()[:24]
+    locator = {
+        "kind": "sandbox",
+        "workspaceId": workspace_id,
+        "relativePath": "repo",
+    }
+    authority = tmp_path / "workspaces" / "temporal_sandbox" / workspace_id / "repo"
+    authority_locator = SandboxWorkspaceLocator.model_validate(locator)
+    prepared = SimpleNamespace(
+        authority_locator=authority_locator, authority_path=authority
+    )
+    lore_adapter = MagicMock()
+    lore_adapter.load_prepared_workspace.return_value = prepared
+
+    def bind_workspace(_prepared, *, omnigent_isolation_verified, **_kwargs):
+        if not omnigent_isolation_verified:
+            raise LoreWorkspaceError(
+                LORE_UNSUPPORTED_RUNTIME_LANE,
+                "Lore workspace isolation is not verified for this runtime lane",
+            )
+        return SimpleNamespace(authority_locator=authority_locator)
+
+    lore_adapter.bind_workspace.side_effect = bind_workspace
+    runtime = OmnigentOAuthHostRuntime(
+        client=SimpleNamespace(),
+        workspace_root=tmp_path / "workspaces",
+        lore_repository_adapter=lore_adapter,
+    )
+    runtime._prepare_skill_projection = AsyncMock(return_value=tmp_path / "skills")
+    runtime._attest_egress = AsyncMock()
+    runtime._compose_static_check = AsyncMock(
+        side_effect=AssertionError("host mutation must not be reached")
+    )
+
+    with pytest.raises(LoreWorkspaceError, match=LORE_UNSUPPORTED_RUNTIME_LANE):
+        await runtime.prepare_host(
+            binding=_binding(),
+            host_lease=_host_lease(),
+            workspace_key="run-1",
+            workspace_locator=locator,
+            current_workflow_id=workflow_id,
+            current_step_execution_id=step_id,
+            repository_provider="lore",
+            effective_launch=compile_effective_launch(
+                profile_ref="omnigent-codex@1",
+                policy_ref="codex-static@1",
+                provider_profile_id="codex",
+            ),
+        )
+
+    runtime._compose_static_check.assert_not_awaited()
 
 
 def test_projection_scripts_install_real_gh_and_resolve_login_shell(tmp_path) -> None:

--- a/tests/unit/repositories/test_lore_adapter.py
+++ b/tests/unit/repositories/test_lore_adapter.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import hashlib
 
 import pytest
 
@@ -7,9 +8,15 @@ from moonmind.repositories.lore_adapter import (
     LORE_EXTERNAL_SCAN_FAILED,
     LORE_UNSUPPORTED_RUNTIME_LANE,
     LoreRepositoryProviderAdapter,
+    LoreImmutableObjectCache,
+    LoreDeltaCheckpoint,
     LoreWorkspaceError,
 )
 from moonmind.schemas.workspace_locator_models import SandboxWorkspaceLocator
+from moonmind.schemas.agent_runtime_models import AgentExecutionRequest
+from moonmind.workflows.temporal.runtime.launcher import ManagedRuntimeLauncher
+from moonmind.workflows.temporal.runtime.store import ManagedRunStore
+from moonmind.omnigent.oauth_host_runtime import OmnigentOAuthHostRuntime
 
 
 class FakeLoreClient:
@@ -100,6 +107,9 @@ def test_dirty_restore_is_bounded_scanned_and_restages_only_intended_paths(tmp_p
     client.staged = ["Content/root.uasset"]
     (workspace.authority_path / "Plugins/P/Content/plugin.uasset").unlink()
     checkpoint = adapter.capture_checkpoint(workspace)
+    assert (
+        adapter.decode_checkpoint(adapter.encode_checkpoint(checkpoint)) == checkpoint
+    )
     restored = adapter.restore_checkpoint(
         checkpoint,
         repository="Tactics",
@@ -149,3 +159,161 @@ def test_restore_rechecks_symlink_containment(tmp_path):
             connection_ref="repository-connection:lore",
             client_evidence={},
         )
+
+
+@pytest.mark.parametrize("tamper", ["size", "digest", "paths"])
+def test_restore_rejects_tampered_checkpoint_before_materialization(tmp_path, tamper):
+    client, adapter, locator, workspace = prepared(tmp_path)
+    client.changed = ["Content/root.uasset"]
+    checkpoint = adapter.capture_checkpoint(workspace)
+    values = dict(checkpoint.__dict__)
+    if tamper == "size":
+        values["total_bytes"] += 1
+    elif tamper == "digest":
+        values["digest"] = "sha256:" + "0" * 64
+    else:
+        values["changed_paths"] = ("Content/other.uasset",)
+    invalid = LoreDeltaCheckpoint(**values)
+
+    with pytest.raises(LoreWorkspaceError, match=LORE_WORKSPACE_INVALID):
+        adapter.restore_checkpoint(
+            invalid,
+            repository="Tactics",
+            branch="main",
+            locator=locator,
+            authority_path=tmp_path / f"invalid-{tamper}",
+            connection_ref="repository-connection:lore",
+            client_evidence={},
+        )
+    assert [call[0] for call in client.calls].count("materialize") == 1
+
+
+def test_restore_rejects_actual_oversize_when_metadata_claims_small(tmp_path):
+    client, _, locator, _ = prepared(tmp_path)
+    adapter = LoreRepositoryProviderAdapter(client, checkpoint_limit_bytes=2)
+    checkpoint = LoreDeltaCheckpoint(
+        base_revision="rev-1",
+        changed_paths=("Content/root.uasset",),
+        staged_paths=(),
+        files={"Content/root.uasset": b"large"},
+        total_bytes=1,
+        digest="sha256:" + "0" * 64,
+    )
+    with pytest.raises(LoreWorkspaceError, match=LORE_CHECKPOINT_TOO_LARGE):
+        adapter.restore_checkpoint(
+            checkpoint,
+            repository="Tactics",
+            branch="main",
+            locator=locator,
+            authority_path=tmp_path / "oversize",
+            connection_ref="repository-connection:lore",
+            client_evidence={},
+        )
+    assert [call[0] for call in client.calls].count("materialize") == 1
+
+
+def test_immutable_cache_verifies_content_and_excludes_private_state(tmp_path):
+    cache = LoreImmutableObjectCache(tmp_path / "cache")
+    adapter = LoreRepositoryProviderAdapter(FakeLoreClient(), immutable_cache=cache)
+    digest = "sha256:" + __import__("hashlib").sha256(b"object").hexdigest()
+    cached = adapter.publish_cache_object(
+        endpoint="lore.example",
+        repository="Tactics",
+        client_compatibility="1",
+        object_digest=digest,
+        content=b"object",
+    )
+    identity = {
+        "endpoint": "lore.example",
+        "repository": "Tactics",
+        "client_compatibility": "1",
+        "object_digest": digest,
+    }
+    assert adapter.read_cache_object(**identity) == b"object"
+    assert cached.stat().st_mode & 0o222 == 0
+
+    cached.chmod(0o600)
+    cached.write_bytes(b"tampered")
+    with pytest.raises(LoreWorkspaceError, match=LORE_WORKSPACE_INVALID):
+        adapter.read_cache_object(**identity)
+    assert not cached.exists()
+
+    with pytest.raises(LoreWorkspaceError, match="private cache identity"):
+        adapter.publish_cache_object(
+            endpoint="lore.example",
+            repository=".lore/journals",
+            client_compatibility="1",
+            object_digest=digest,
+            content=b"object",
+        )
+
+
+@pytest.mark.asyncio
+async def test_managed_launcher_delegates_lore_preparation_and_reuses_revision(
+    tmp_path,
+):
+    client = FakeLoreClient()
+    adapter = LoreRepositoryProviderAdapter(client)
+    launcher = ManagedRuntimeLauncher(
+        ManagedRunStore(tmp_path / "managed_runs"),
+        lore_repository_adapter=adapter,
+    )
+    request = AgentExecutionRequest(
+        agentKind="managed",
+        agentId="agent",
+        correlationId="corr",
+        idempotencyKey="key",
+        workspaceSpec={
+            "provider": "lore",
+            "repository": "Tactics",
+            "branch": "main",
+            "revisionSignature": "rev-1",
+            "connectionRef": "repository-connection:lore",
+            "clientEvidence": {"clientVersion": "1"},
+        },
+    )
+    first = await launcher._prepare_workspace_path(
+        run_id="run-1", request=request, workspace_path=None
+    )
+    second = await launcher._prepare_workspace_path(
+        run_id="run-1", request=request, workspace_path=None
+    )
+    assert first == second
+    assert [call[0] for call in client.calls].count("materialize") == 1
+
+
+@pytest.mark.asyncio
+async def test_omnigent_launcher_binds_prepared_lore_sandbox_without_checkout(tmp_path):
+    workflow_id, step_id = "workflow", "step"
+    workspace_id = hashlib.sha256(
+        f"{workflow_id}:{step_id}".encode("utf-8")
+    ).hexdigest()[:24]
+    locator = SandboxWorkspaceLocator(workspaceId=workspace_id, relativePath="repo")
+    authority = tmp_path / workspace_id / "repo"
+    client = FakeLoreClient()
+    adapter = LoreRepositoryProviderAdapter(client)
+    adapter.prepare_workspace(
+        repository="Tactics",
+        branch="main",
+        revision_signature="rev-1",
+        locator=locator,
+        authority_path=authority,
+        connection_ref="repository-connection:lore",
+        client_evidence={},
+    )
+    runtime = OmnigentOAuthHostRuntime(
+        client=object(),
+        workspace_root=tmp_path,
+        lore_repository_adapter=adapter,
+    )
+    resolved = await runtime._prepare_workspace(
+        workspace_locator=locator.model_dump(by_alias=True),
+        current_workflow_id=workflow_id,
+        current_step_execution_id=step_id,
+        repository_provider="lore",
+    )
+    assert resolved == authority
+    assert [call[0] for call in client.calls].count("materialize") == 1
+    assert runtime._last_workspace_evidence["materialization"]["action"] == (
+        "reused_lore_authority"
+    )

--- a/tests/unit/repositories/test_lore_adapter.py
+++ b/tests/unit/repositories/test_lore_adapter.py
@@ -12,6 +12,10 @@ from moonmind.repositories.lore_adapter import (
     LoreDeltaCheckpoint,
     LoreWorkspaceError,
 )
+from moonmind.repositories.lore_checkpoints import LORE_CHECKPOINT_CONTENT_TYPE
+from moonmind.repositories.lore_runtime import (
+    build_lore_repository_adapter_from_environment,
+)
 from moonmind.schemas.workspace_locator_models import SandboxWorkspaceLocator
 from moonmind.schemas.agent_runtime_models import AgentExecutionRequest
 from moonmind.workflows.temporal.runtime.launcher import ManagedRuntimeLauncher
@@ -292,15 +296,29 @@ async def test_omnigent_launcher_binds_prepared_lore_sandbox_without_checkout(tm
     authority = tmp_path / workspace_id / "repo"
     client = FakeLoreClient()
     adapter = LoreRepositoryProviderAdapter(client)
-    adapter.prepare_workspace(
-        repository="Tactics",
-        branch="main",
-        revision_signature="rev-1",
-        locator=locator,
-        authority_path=authority,
-        connection_ref="repository-connection:lore",
-        client_evidence={},
+    launcher = ManagedRuntimeLauncher(
+        ManagedRunStore(tmp_path / "managed_runs"),
+        lore_repository_adapter=adapter,
     )
+    managed_path = await launcher._prepare_workspace_path(
+        run_id="managed-run",
+        workspace_path=None,
+        request=AgentExecutionRequest(
+            agentKind="managed",
+            agentId="agent",
+            correlationId="corr",
+            idempotencyKey="key",
+            workspaceSpec={
+                "provider": "lore",
+                "repository": "Tactics",
+                "branch": "main",
+                "revisionSignature": "rev-1",
+                "connectionRef": "repository-connection:lore",
+                "workspaceLocator": locator.model_dump(by_alias=True),
+            },
+        ),
+    )
+    assert managed_path == str(authority)
     runtime = OmnigentOAuthHostRuntime(
         client=object(),
         workspace_root=tmp_path,
@@ -316,4 +334,82 @@ async def test_omnigent_launcher_binds_prepared_lore_sandbox_without_checkout(tm
     assert [call[0] for call in client.calls].count("materialize") == 1
     assert runtime._last_workspace_evidence["materialization"]["action"] == (
         "reused_lore_authority"
+    )
+
+
+class FakeArtifactService:
+    def __init__(self):
+        self.payloads = {}
+        self.content_types = {}
+
+    async def create(self, *, content_type, **kwargs):
+        artifact = type(
+            "Artifact",
+            (),
+            {"artifact_id": "art_lore", "content_type": content_type},
+        )()
+        self.content_types[artifact.artifact_id] = content_type
+        return artifact, object()
+
+    async def write_complete(self, *, artifact_id, payload, content_type, **kwargs):
+        self.payloads[artifact_id] = payload
+        return type("Artifact", (), {"artifact_id": artifact_id})()
+
+    async def read(self, *, artifact_id, **kwargs):
+        artifact = type(
+            "Artifact",
+            (),
+            {"artifact_id": artifact_id, "content_type": self.content_types[artifact_id]},
+        )()
+        return artifact, self.payloads[artifact_id]
+
+
+@pytest.mark.asyncio
+async def test_durable_lore_checkpoint_round_trip_scans_and_restages(tmp_path):
+    client, adapter, locator, workspace = prepared(tmp_path)
+    client.changed = ["Content/root.uasset"]
+    client.staged = ["Content/root.uasset"]
+    (workspace.authority_path / "Content/root.uasset").write_bytes(b"dirty")
+    artifacts = FakeArtifactService()
+    launcher = ManagedRuntimeLauncher(
+        ManagedRunStore(tmp_path / "managed_runs"),
+        artifact_service=artifacts,
+        lore_repository_adapter=adapter,
+    )
+
+    checkpoint_ref = await launcher.capture_lore_workspace_checkpoint(
+        locator=locator, authority_path=workspace.authority_path
+    )
+    assert artifacts.content_types[checkpoint_ref] == LORE_CHECKPOINT_CONTENT_TYPE
+    restored = await launcher.restore_lore_workspace_checkpoint(
+        checkpoint_ref,
+        repository="Tactics",
+        branch="main",
+        locator=locator,
+        authority_path=tmp_path / "cold-restored",
+        connection_ref="repository-connection:lore",
+        client_evidence={},
+    )
+
+    assert (restored.authority_path / "Content/root.uasset").read_bytes() == b"dirty"
+    assert [call[0] for call in client.calls].count("materialize") == 2
+    assert client.calls[-2][0] == "scan"
+    assert client.calls[-1] == ("stage", ("Content/root.uasset",))
+
+
+def test_production_lore_factory_requires_complete_pin(monkeypatch, tmp_path):
+    executable = tmp_path / "lore"
+    executable.write_bytes(b"binary")
+    monkeypatch.setenv("MOONMIND_LORE_EXECUTABLE", str(executable))
+    monkeypatch.delenv("MOONMIND_LORE_EXECUTABLE_SHA256", raising=False)
+    with pytest.raises(LoreWorkspaceError, match="both required"):
+        build_lore_repository_adapter_from_environment()
+
+    monkeypatch.setenv(
+        "MOONMIND_LORE_EXECUTABLE_SHA256", hashlib.sha256(b"binary").hexdigest()
+    )
+    monkeypatch.setenv("MOONMIND_LORE_IMMUTABLE_CACHE_ROOT", str(tmp_path / "cache"))
+    assert isinstance(
+        build_lore_repository_adapter_from_environment(),
+        LoreRepositoryProviderAdapter,
     )

--- a/tests/unit/repositories/test_lore_adapter.py
+++ b/tests/unit/repositories/test_lore_adapter.py
@@ -6,6 +6,7 @@ from moonmind.repositories.lore_adapter import (
     LORE_CHECKPOINT_TOO_LARGE,
     LORE_EXTERNAL_SCAN_FAILED,
     LORE_UNSUPPORTED_RUNTIME_LANE,
+    LORE_WORKSPACE_INVALID,
     LoreRepositoryProviderAdapter,
     LoreImmutableObjectCache,
     LoreDeltaCheckpoint,
@@ -368,7 +369,7 @@ async def test_omnigent_launcher_binds_prepared_lore_sandbox_without_checkout(tm
         f"{workflow_id}:{step_id}".encode("utf-8")
     ).hexdigest()[:24]
     locator = SandboxWorkspaceLocator(workspaceId=workspace_id, relativePath="repo")
-    authority = tmp_path / workspace_id / "repo"
+    authority = tmp_path / "temporal_sandbox" / workspace_id / "repo"
     client = FakeLoreClient()
     adapter = LoreRepositoryProviderAdapter(client)
     launcher = ManagedRuntimeLauncher(
@@ -440,7 +441,7 @@ async def test_omnigent_launcher_materializes_fresh_lore_sandbox(tmp_path):
         omnigent_isolation_verified=True,
     )
 
-    assert resolved == tmp_path / workspace_id / "repo"
+    assert resolved == tmp_path / "temporal_sandbox" / workspace_id / "repo"
     assert [call[0] for call in client.calls].count("materialize") == 1
 
 

--- a/tests/unit/repositories/test_lore_adapter.py
+++ b/tests/unit/repositories/test_lore_adapter.py
@@ -1,4 +1,3 @@
-from pathlib import Path
 import hashlib
 
 import pytest
@@ -30,7 +29,16 @@ class FakeLoreClient:
         self.staged = []
         self.scan_ok = True
 
-    def materialize(self, *, repository, revision, destination):
+    def materialize(
+        self,
+        *,
+        repository,
+        revision,
+        destination,
+        connection_ref,
+        client_evidence,
+    ):
+        self.calls.append(("connection", connection_ref, dict(client_evidence)))
         self.calls.append(("materialize", revision))
         (destination / "Content").mkdir()
         (destination / "Content/root.uasset").write_bytes(b"root")
@@ -70,7 +78,7 @@ def test_prepares_complete_revision_once_and_binds_same_authority(tmp_path):
     client, adapter, _, workspace = prepared(tmp_path)
     assert (workspace.authority_path / "Content/root.uasset").is_file()
     assert (workspace.authority_path / "Plugins/P/Content/plugin.uasset").is_file()
-    assert [call[0] for call in client.calls] == ["materialize"]
+    assert [call[0] for call in client.calls] == ["connection", "materialize"]
     managed = adapter.bind_workspace(workspace, runtime_lane="managed_runtime")
     omnigent = adapter.bind_workspace(workspace, runtime_lane="omnigent")
     assert (
@@ -79,6 +87,44 @@ def test_prepares_complete_revision_once_and_binds_same_authority(tmp_path):
         == workspace.authority_locator
     )
     assert managed.mount_mode == "direct_path" and omnigent.mount_mode == "bind_mount"
+
+
+def test_failed_materialization_leaves_authority_retryable(tmp_path):
+    client = FakeLoreClient()
+    adapter = LoreRepositoryProviderAdapter(client)
+    locator = SandboxWorkspaceLocator(workspaceId="run-1", relativePath="repo")
+    original = client.materialize
+
+    def fail_after_writing(**kwargs):
+        original(**kwargs)
+        raise RuntimeError("transient failure")
+
+    client.materialize = fail_after_writing
+    authority = tmp_path / "repo"
+    with pytest.raises(RuntimeError, match="transient failure"):
+        adapter.prepare_workspace(
+            repository="Tactics",
+            branch="main",
+            revision_signature="rev-1",
+            locator=locator,
+            authority_path=authority,
+            connection_ref="repository-connection:lore",
+            client_evidence={},
+        )
+    assert not authority.exists()
+    assert not list(tmp_path.glob(".repo.materializing-*"))
+
+    client.materialize = original
+    adapter.prepare_workspace(
+        repository="Tactics",
+        branch="main",
+        revision_signature="rev-1",
+        locator=locator,
+        authority_path=authority,
+        connection_ref="repository-connection:lore",
+        client_evidence={},
+    )
+    assert authority.is_dir()
 
 
 def test_rejects_unsupported_lane_before_launch(tmp_path):
@@ -287,6 +333,35 @@ async def test_managed_launcher_delegates_lore_preparation_and_reuses_revision(
 
 
 @pytest.mark.asyncio
+async def test_managed_launcher_rejects_foreign_lore_locator(tmp_path):
+    launcher = ManagedRuntimeLauncher(
+        ManagedRunStore(tmp_path / "managed_runs"),
+        lore_repository_adapter=LoreRepositoryProviderAdapter(FakeLoreClient()),
+    )
+    request = AgentExecutionRequest(
+        agentKind="managed",
+        agentId="agent",
+        correlationId="corr",
+        idempotencyKey="key",
+        workspaceSpec={
+            "provider": "lore",
+            "repository": "Tactics",
+            "branch": "main",
+            "revisionSignature": "rev-1",
+            "workspaceLocator": {
+                "kind": "sandbox",
+                "workspaceId": "another-run",
+                "relativePath": "repo",
+            },
+        },
+    )
+    with pytest.raises(RuntimeError, match="does not belong to the current run"):
+        await launcher._prepare_workspace_path(
+            run_id="run-1", request=request, workspace_path=None
+        )
+
+
+@pytest.mark.asyncio
 async def test_omnigent_launcher_binds_prepared_lore_sandbox_without_checkout(tmp_path):
     workflow_id, step_id = "workflow", "step"
     workspace_id = hashlib.sha256(
@@ -306,8 +381,8 @@ async def test_omnigent_launcher_binds_prepared_lore_sandbox_without_checkout(tm
         request=AgentExecutionRequest(
             agentKind="managed",
             agentId="agent",
-            correlationId="corr",
-            idempotencyKey="key",
+            correlationId=workflow_id,
+            idempotencyKey=step_id,
             workspaceSpec={
                 "provider": "lore",
                 "repository": "Tactics",
@@ -338,6 +413,37 @@ async def test_omnigent_launcher_binds_prepared_lore_sandbox_without_checkout(tm
     )
 
 
+@pytest.mark.asyncio
+async def test_omnigent_launcher_materializes_fresh_lore_sandbox(tmp_path):
+    workflow_id, step_id = "workflow", "fresh-step"
+    workspace_id = hashlib.sha256(
+        f"{workflow_id}:{step_id}".encode("utf-8")
+    ).hexdigest()[:24]
+    locator = SandboxWorkspaceLocator(workspaceId=workspace_id, relativePath="repo")
+    client = FakeLoreClient()
+    runtime = OmnigentOAuthHostRuntime(
+        client=object(),
+        workspace_root=tmp_path,
+        lore_repository_adapter=LoreRepositoryProviderAdapter(client),
+    )
+
+    resolved = await runtime._prepare_workspace(
+        workspace_locator=locator.model_dump(by_alias=True),
+        current_workflow_id=workflow_id,
+        current_step_execution_id=step_id,
+        repository_source="Tactics",
+        repository_provider="lore",
+        repository_connection_ref="repository-connection:lore",
+        repository_client_evidence={"clientVersion": "1"},
+        starting_branch="main",
+        checkout_commit="rev-1",
+        omnigent_isolation_verified=True,
+    )
+
+    assert resolved == tmp_path / workspace_id / "repo"
+    assert [call[0] for call in client.calls].count("materialize") == 1
+
+
 class FakeArtifactService:
     def __init__(self):
         self.payloads = {}
@@ -352,7 +458,9 @@ class FakeArtifactService:
         self.content_types[artifact.artifact_id] = content_type
         return artifact, object()
 
-    async def write_complete(self, *, artifact_id, payload, content_type, **kwargs):
+    async def write_payload_complete(
+        self, *, artifact_id, payload, content_type, **kwargs
+    ):
         self.payloads[artifact_id] = payload
         return type("Artifact", (), {"artifact_id": artifact_id})()
 

--- a/tests/unit/repositories/test_lore_adapter.py
+++ b/tests/unit/repositories/test_lore_adapter.py
@@ -1,0 +1,151 @@
+from pathlib import Path
+
+import pytest
+
+from moonmind.repositories.lore_adapter import (
+    LORE_CHECKPOINT_TOO_LARGE,
+    LORE_EXTERNAL_SCAN_FAILED,
+    LORE_UNSUPPORTED_RUNTIME_LANE,
+    LoreRepositoryProviderAdapter,
+    LoreWorkspaceError,
+)
+from moonmind.schemas.workspace_locator_models import SandboxWorkspaceLocator
+
+
+class FakeLoreClient:
+    def __init__(self):
+        self.calls = []
+        self.changed = []
+        self.staged = []
+        self.scan_ok = True
+
+    def materialize(self, *, repository, revision, destination):
+        self.calls.append(("materialize", revision))
+        (destination / "Content").mkdir()
+        (destination / "Content/root.uasset").write_bytes(b"root")
+        (destination / "Plugins/P/Content").mkdir(parents=True)
+        (destination / "Plugins/P/Content/plugin.uasset").write_bytes(b"plugin")
+        return {"revisionSignature": revision, "completeTree": True}
+
+    def scan_external_changes(self, *, workspace):
+        self.calls.append(("scan", workspace))
+        return {"success": self.scan_ok}
+
+    def status(self, *, workspace):
+        self.calls.append(("status", workspace))
+        return {"changedPaths": self.changed, "stagedPaths": self.staged}
+
+    def stage_paths(self, *, workspace, paths):
+        self.calls.append(("stage", tuple(paths)))
+
+
+def prepared(tmp_path):
+    client = FakeLoreClient()
+    adapter = LoreRepositoryProviderAdapter(client, checkpoint_limit_bytes=32)
+    locator = SandboxWorkspaceLocator(workspaceId="run-1", relativePath="repo")
+    workspace = adapter.prepare_workspace(
+        repository="Tactics",
+        branch="main",
+        revision_signature="rev-1",
+        locator=locator,
+        authority_path=tmp_path / "repo",
+        connection_ref="repository-connection:lore",
+        client_evidence={"clientVersion": "1", "executableSha256": "a" * 64},
+    )
+    return client, adapter, locator, workspace
+
+
+def test_prepares_complete_revision_once_and_binds_same_authority(tmp_path):
+    client, adapter, _, workspace = prepared(tmp_path)
+    assert (workspace.authority_path / "Content/root.uasset").is_file()
+    assert (workspace.authority_path / "Plugins/P/Content/plugin.uasset").is_file()
+    assert [call[0] for call in client.calls] == ["materialize"]
+    managed = adapter.bind_workspace(workspace, runtime_lane="managed_runtime")
+    omnigent = adapter.bind_workspace(workspace, runtime_lane="omnigent")
+    assert (
+        managed.authority_locator
+        == omnigent.authority_locator
+        == workspace.authority_locator
+    )
+    assert managed.mount_mode == "direct_path" and omnigent.mount_mode == "bind_mount"
+
+
+def test_rejects_unsupported_lane_before_launch(tmp_path):
+    _, adapter, _, workspace = prepared(tmp_path)
+    with pytest.raises(LoreWorkspaceError, match=LORE_UNSUPPORTED_RUNTIME_LANE):
+        adapter.bind_workspace(
+            workspace, runtime_lane="omnigent", omnigent_isolation_verified=False
+        )
+
+
+def test_scan_precedes_status_and_checkpoint_and_private_state_is_rejected(tmp_path):
+    client, adapter, _, workspace = prepared(tmp_path)
+    adapter.inspect_workspace(workspace)
+    assert [c[0] for c in client.calls[-2:]] == ["scan", "status"]
+    client.changed = [".lore/journal"]
+    with pytest.raises(LoreWorkspaceError, match="private checkpoint path"):
+        adapter.capture_checkpoint(workspace)
+    assert [c[0] for c in client.calls[-2:]] == ["scan", "status"]
+    client.scan_ok = False
+    with pytest.raises(LoreWorkspaceError, match=LORE_EXTERNAL_SCAN_FAILED):
+        adapter.inspect_workspace(workspace)
+    assert client.calls[-1][0] == "scan"
+
+
+def test_dirty_restore_is_bounded_scanned_and_restages_only_intended_paths(tmp_path):
+    client, adapter, locator, workspace = prepared(tmp_path)
+    changed = workspace.authority_path / "Content/root.uasset"
+    changed.write_bytes(b"changed")
+    client.changed = ["Content/root.uasset", "Plugins/P/Content/plugin.uasset"]
+    client.staged = ["Content/root.uasset"]
+    (workspace.authority_path / "Plugins/P/Content/plugin.uasset").unlink()
+    checkpoint = adapter.capture_checkpoint(workspace)
+    restored = adapter.restore_checkpoint(
+        checkpoint,
+        repository="Tactics",
+        branch="main",
+        locator=locator,
+        authority_path=tmp_path / "restored",
+        connection_ref="repository-connection:lore",
+        client_evidence={},
+    )
+    assert (restored.authority_path / "Content/root.uasset").read_bytes() == b"changed"
+    assert not (restored.authority_path / "Plugins/P/Content/plugin.uasset").exists()
+    assert client.calls[-2][0] == "scan" and client.calls[-1] == (
+        "stage",
+        ("Content/root.uasset",),
+    )
+
+
+def test_oversized_checkpoint_fails_before_artifact_creation(tmp_path):
+    client, _, _, workspace = prepared(tmp_path)
+    adapter = LoreRepositoryProviderAdapter(client, checkpoint_limit_bytes=2)
+    client.changed = ["Content/root.uasset"]
+    with pytest.raises(LoreWorkspaceError, match=LORE_CHECKPOINT_TOO_LARGE):
+        adapter.capture_checkpoint(workspace)
+
+
+def test_restore_rechecks_symlink_containment(tmp_path):
+    client, adapter, locator, workspace = prepared(tmp_path)
+    client.changed = ["Content/root.uasset"]
+    client.staged = []
+    checkpoint = adapter.capture_checkpoint(workspace)
+    original = client.materialize
+
+    def unsafe(**kwargs):
+        result = original(**kwargs)
+        (kwargs["destination"] / "Content/root.uasset").unlink()
+        (kwargs["destination"] / "Content/root.uasset").symlink_to("/etc/passwd")
+        return result
+
+    client.materialize = unsafe
+    with pytest.raises(LoreWorkspaceError, match="symlink escapes"):
+        adapter.restore_checkpoint(
+            checkpoint,
+            repository="Tactics",
+            branch="main",
+            locator=locator,
+            authority_path=tmp_path / "unsafe",
+            connection_ref="repository-connection:lore",
+            client_evidence={},
+        )

--- a/tests/unit/repositories/test_lore_adapter.py
+++ b/tests/unit/repositories/test_lore_adapter.py
@@ -329,6 +329,7 @@ async def test_omnigent_launcher_binds_prepared_lore_sandbox_without_checkout(tm
         current_workflow_id=workflow_id,
         current_step_execution_id=step_id,
         repository_provider="lore",
+        omnigent_isolation_verified=True,
     )
     assert resolved == authority
     assert [call[0] for call in client.calls].count("materialize") == 1


### PR DESCRIPTION
Run Jira Implement for MM-1220.

Source story: STORY-002.
Source summary: Complete remaining behavior for Prepare and bind exact Lore workspaces.
Source Jira issue: unknown.
Source design document: docs/Workflows/LoreVcsIntegrationDesign.md.
Source canonical claim IDs: WORKSPACE-001, WORKSPACE-002, WORKSPACE-003, WORKSPACE-004, NON-GOAL-005, QUALITY-005.
Original brief reference: not provided.

Use the existing Jira Implement workflow for this Jira issue. Do not run implementation inline inside the breakdown workflow.

## MoonSpec verification incomplete

This pull request was opened as a **draft** because MoonSpec verification did not approve publication (verdict BLOCKED) and the operator policy `workflow.moonspec_environment_blocked_publish_action` is `draft_pr`.

- Gate outcome: MoonSpec verification did not approve publication. verdict BLOCKED. Direct production and test inspection supports all bounded MM-1220 requirements at the latest remediation HEAD. Python compilation and patch hygiene pass. Trustworthy completion cannot be declared because the required controlling unit tests could not start: two independent MoonMind container jobs disappeared before pytest execution, including a reduced single-file retry. verification report art_01KYYEVRSN70TSGVGQ6PVG14K3.
- Verification report: art_01KYYEVRSN70TSGVGQ6PVG14K3
- Verification gate result: art_01KYYEVRPP5JE5WF9T4CNFRKGA

Review the verification evidence before marking this pull request ready for review.