### PR TITLE
Run Jira Implement for MM-1219: Compile provider-aware repository targets and readiness

### DIFF
--- a/frontend/src/entrypoints/workflow-start.test.tsx
+++ b/frontend/src/entrypoints/workflow-start.test.tsx
@@ -14695,7 +14695,13 @@ describe("Task Create MM-641 authoring validation", () => {
     expect(task.instructions).toBe(
       "Move repository branch publish controls into Steps.",
     );
-    expect(task.git).toEqual({ branch: "feature/mm-641-create-page" });
+    expect(task.git).toBeUndefined();
+    expect((request.payload as Record<string, unknown>).repository).toEqual({
+      provider: "git",
+      connectionRef: "repository-connection:git-default",
+      repository: { name: "MoonLadderStudios/MoonMind" },
+      branch: { name: "feature/mm-641-create-page" },
+    });
     expect(task.publish).toEqual({ mode: "branch" });
     expect(task.dependsOn).toEqual(["mm:dep-641"]);
     expect((task.steps as Array<Record<string, unknown>>)[0]).toMatchObject({
@@ -14752,7 +14758,13 @@ describe("Task Create MM-641 authoring validation", () => {
 
     const request = latestCreateRequest();
     const task = (request.payload as { task: Record<string, unknown> }).task;
-    expect(task.git).toEqual({ branch: "feature/pasted-while-loading" });
+    expect(task.git).toBeUndefined();
+    expect((request.payload as Record<string, unknown>).repository).toEqual({
+      provider: "git",
+      connectionRef: "repository-connection:git-default",
+      repository: { name: "MoonLadderStudios/MoonMind" },
+      branch: { name: "feature/pasted-while-loading" },
+    });
   });
 
   it("remembers the Propose Tasks selection across Create page mounts", async () => {

--- a/frontend/src/entrypoints/workflow-start.tsx
+++ b/frontend/src/entrypoints/workflow-start.tsx
@@ -10975,13 +10975,6 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
             },
           }
         : {}),
-      ...(normalizedRepository && effectiveBranch
-        ? {
-            git: {
-              branch: effectiveBranch,
-            },
-          }
-        : {}),
       ...(normalizedSteps.length > 0 ? { steps: normalizedSteps } : {}),
       ...(submissionAppliedTemplates.length > 0
         ? { appliedStepTemplates: submissionAppliedTemplates }
@@ -11002,7 +10995,16 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
       priority: effectivePriority,
       maxAttempts: effectiveMaxAttempts,
       payload: {
-        ...(normalizedRepository ? { repository: normalizedRepository } : {}),
+        ...(normalizedRepository && effectiveBranch
+          ? {
+              repository: {
+                provider: "git",
+                connectionRef: "repository-connection:git-default",
+                repository: { name: normalizedRepository },
+                branch: { name: effectiveBranch },
+              },
+            }
+          : {}),
         ...(mergedCapabilities.length > 0
           ? { requiredCapabilities: mergedCapabilities }
           : {}),

--- a/moonmind/agents/codex_worker/worker.py
+++ b/moonmind/agents/codex_worker/worker.py
@@ -235,6 +235,29 @@ def _canonical_workflow_node(canonical_payload: Mapping[str, Any]) -> Mapping[st
         return task_node
     return {}
 
+
+def _canonical_repository_name(canonical_payload: Mapping[str, Any]) -> str:
+    """Return the canonical provider target's portable repository name."""
+
+    target = canonical_payload.get("repository")
+    if isinstance(target, Mapping):
+        identity = target.get("repository")
+        if isinstance(identity, Mapping):
+            return str(identity.get("name") or "").strip()
+        return ""
+    return str(target or "").strip()
+
+
+def _canonical_repository_branch(canonical_payload: Mapping[str, Any]) -> str:
+    """Return the canonical provider target's authored branch name."""
+
+    target = canonical_payload.get("repository")
+    if isinstance(target, Mapping):
+        branch = target.get("branch")
+        if isinstance(branch, Mapping):
+            return str(branch.get("name") or "").strip()
+    return ""
+
 _PROPOSAL_INSTRUCTIONS_PLACEHOLDER = "<OBJECTIVE>"
 _DEFAULT_PREPARE_GIT_USER_NAME = "MoonMind Worker"
 _DEFAULT_PREPARE_GIT_USER_EMAIL = "moonmind-worker@users.noreply.github.com"
@@ -2932,7 +2955,7 @@ class CodexWorker:
                 canonical_payload=canonical_payload,
                 runtime_mode=runtime_mode,
             )
-            repository = str(canonical_payload.get("repository") or "").strip()
+            repository = _canonical_repository_name(canonical_payload)
             runtime_meta: dict[str, Any] = {
                 "source": "moonmind",
                 "stage": "moonmind.task.execute",
@@ -3479,7 +3502,7 @@ class CodexWorker:
         jules_runtime_records: Sequence[JulesRuntimeTaskRecord] = (),
         run_quality_reason: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
-        repository = str(canonical_payload.get("repository") or "").strip()
+        repository = _canonical_repository_name(canonical_payload)
         patch_path = "patches/changes.patch"
         patch_exists = False
         if prepared is not None:
@@ -3954,7 +3977,7 @@ class CodexWorker:
         publish = publish_node if isinstance(publish_node, Mapping) else {}
 
         payload: dict[str, Any] = {
-            "repository": canonical_payload.get("repository"),
+            "repository": _canonical_repository_name(canonical_payload),
             "instruction": (
                 instruction_override
                 if instruction_override is not None
@@ -3972,7 +3995,10 @@ class CodexWorker:
             },
         }
         selected_ref = (
-            ref_override if ref_override is not None else git.get("startingBranch")
+            ref_override
+            if ref_override is not None
+            else _canonical_repository_branch(canonical_payload)
+            or git.get("startingBranch")
         )
         if include_ref and selected_ref:
             payload["ref"] = selected_ref
@@ -4115,7 +4141,7 @@ class CodexWorker:
                 or runtime_provider_profile
             )
 
-            repository = str(canonical_payload.get("repository") or "").strip()
+            repository = _canonical_repository_name(canonical_payload)
             if not repository:
                 raise ValueError("repository is required for prepare stage")
             auth_context = await self._resolve_task_auth_context(
@@ -4179,9 +4205,13 @@ class CodexWorker:
                 fallback="main",
                 env=auth_context.repo_command_env,
             )
-            authored_branch_input = str(git.get("branch") or "").strip() or None
+            canonical_branch = _canonical_repository_branch(canonical_payload)
+            authored_branch_input = (
+                canonical_branch or str(git.get("branch") or "").strip() or None
+            )
             starting_branch_input = (
-                str(git.get("startingBranch") or "").strip()
+                canonical_branch
+                or str(git.get("startingBranch") or "").strip()
                 or authored_branch_input
                 or None
             )
@@ -6058,7 +6088,7 @@ class CodexWorker:
             if publish_mode == "pr" and pr_base is not None:
                 publish_env = prepared.publish_command_env or {}
                 github_token = str(publish_env.get("GITHUB_TOKEN") or "").strip()
-                repository = str(canonical_payload.get("repository") or "").strip()
+                repository = _canonical_repository_name(canonical_payload)
                 if repository and github_token:
                     pr_result = await GitHubService().create_pull_request(
                         repo=repository,
@@ -8336,13 +8366,15 @@ class CodexWorker:
         else:
             args = self._skill_inputs_from_node(skill)
 
-        repository = str(canonical_payload.get("repository") or "").strip()
+        repository = _canonical_repository_name(canonical_payload)
         instructions = (
             str(instruction_override).strip()
             if instruction_override is not None
             else str(task.get("instructions") or "").strip()
         )
-        starting_branch = str(git.get("startingBranch") or "").strip()
+        starting_branch = _canonical_repository_branch(canonical_payload) or str(
+            git.get("startingBranch") or ""
+        ).strip()
         selected_ref = (
             str(ref_override).strip() if ref_override is not None else starting_branch
         )
@@ -8425,7 +8457,11 @@ class CodexWorker:
         git_node = task.get("git")
         git = git_node if isinstance(git_node, Mapping) else {}
 
-        starting_branch = str(git.get("startingBranch") or "").strip() or None
+        starting_branch = (
+            _canonical_repository_branch(canonical_payload)
+            or str(git.get("startingBranch") or "").strip()
+            or None
+        )
         publish_mode = "pr"
 
         return {
@@ -8433,7 +8469,7 @@ class CodexWorker:
             "priority": 0,
             "maxAttempts": 3,
             "payload": {
-                "repository": str(canonical_payload.get("repository") or "").strip(),
+                "repository": _canonical_repository_name(canonical_payload),
                 "workflow": {
                     "instructions": _PROPOSAL_INSTRUCTIONS_PLACEHOLDER,
                     "skill": {"id": "auto", "args": {}},
@@ -8681,7 +8717,7 @@ class CodexWorker:
         evidence = self._redact_text(
             str(evidence_source)
         )[:500]
-        repository = str(canonical_payload.get("repository") or "").strip().lower()
+        repository = _canonical_repository_name(canonical_payload).lower()
         is_moonmind_repository = repository == "moonladderstudios/moonmind"
         if is_moonmind_repository:
             instructions = (
@@ -8869,7 +8905,7 @@ class CodexWorker:
             )
             skill_args = {
                 "jobId": str(job.id),
-                "repository": str(canonical_payload.get("repository") or "").strip(),
+                "repository": _canonical_repository_name(canonical_payload),
                 "runtimeMode": runtime_mode,
                 "taskStatus": "completed" if task_result.succeeded else "failed",
                 "taskSummary": str(task_result.summary or ""),
@@ -10589,7 +10625,7 @@ class CodexWorker:
         prepared: PreparedTaskWorkspace,
         container_spec: ContainerTaskSpec,
     ) -> WorkerExecutionResult:
-        repository = str(canonical_payload.get("repository") or "").strip()
+        repository = _canonical_repository_name(canonical_payload)
         if not repository:
             raise ValueError("repository is required for task.container execution")
 
@@ -11251,7 +11287,7 @@ class CodexWorker:
         """Submit instruction to Jules and poll until completion/failure."""
 
         self._ensure_jules_runtime_enabled()
-        repository = str(canonical_payload.get("repository") or "").strip()
+        repository = _canonical_repository_name(canonical_payload)
         runtime_meta: dict[str, Any] = {
             "source": "moonmind",
             "stage": stage,
@@ -11501,7 +11537,7 @@ class CodexWorker:
         }
         if not required:
             return "requiredCapabilities must include at least one capability"
-        repository = str(canonical_payload.get("repository") or "").strip()
+        repository = _canonical_repository_name(canonical_payload)
         if "git" in required and not repository:
             return "repository is required for git task execution"
 
@@ -11535,7 +11571,7 @@ class CodexWorker:
         repo_token, repo_source = await self._resolve_github_token(
             auth_ref=repo_auth_ref,
             purpose="repository",
-            repo=str(canonical_payload.get("repository") or "").strip() or None,
+            repo=_canonical_repository_name(canonical_payload) or None,
         )
         repo_env = self._build_command_env(
             repo_token,
@@ -11550,7 +11586,7 @@ class CodexWorker:
             publish_token, publish_source = await self._resolve_github_token(
                 auth_ref=publish_ref,
                 purpose="publish",
-                repo=str(canonical_payload.get("repository") or "").strip() or None,
+                repo=_canonical_repository_name(canonical_payload) or None,
             )
             publish_env = self._build_command_env(
                 publish_token,
@@ -11862,7 +11898,7 @@ class CodexWorker:
             [proposal for proposal in proposals if isinstance(proposal, dict)]
         )
         canonical_payload = job.payload if isinstance(job.payload, Mapping) else {}
-        project_repository = str(canonical_payload.get("repository") or "").strip()
+        project_repository = _canonical_repository_name(canonical_payload)
         if not project_repository:
             logger.warning(
                 "Skipping workflow proposal submission for job %s: canonical repository missing",

--- a/moonmind/agents/codex_worker/worker.py
+++ b/moonmind/agents/codex_worker/worker.py
@@ -47,6 +47,7 @@ from moonmind.workflows.executions.execution_contract import (
     WorkflowContractError,
     WorkflowProposalPolicy,
     build_canonical_workflow_view,
+    decode_recorded_legacy_workflow_history_v1,
     build_effective_proposal_policy,
     build_workflow_stage_plan,
     is_self_managed_publish_skill,
@@ -1637,9 +1638,15 @@ class CodexWorker:
             return None
 
         try:
-            canonical_payload = build_canonical_workflow_view(
-                job_type=job.type,
-                payload=job.payload,
+            canonical_payload = (
+                decode_recorded_legacy_workflow_history_v1(
+                    job_type=job.type, payload=job.payload
+                )
+                if job.type in LEGACY_WORKFLOW_JOB_TYPES
+                else build_canonical_workflow_view(
+                    job_type=job.type,
+                    payload=job.payload,
+                )
             )
         except WorkflowContractError as exc:
             await self._emit_event(

--- a/moonmind/omnigent/workspace_intent.py
+++ b/moonmind/omnigent/workspace_intent.py
@@ -344,6 +344,12 @@ def compile_workspace_intent(
         )
 
     repository = authored_repository_source(request) or None
+    resolved_repository = _spec(request).get("resolvedRepositoryTarget")
+    if resolved_repository is not None and not isinstance(resolved_repository, Mapping):
+        raise WorkspaceIntentCompilationError(
+            WORKSPACE_INTENT_UNSAFE_INPUT,
+            "workspaceSpec.resolvedRepositoryTarget must be an object",
+        )
     restore_refs = authored_restore_input_refs(request)
     restore_input_refs, external_state_refs = _partition_restore_refs(restore_refs)
 
@@ -360,6 +366,9 @@ def compile_workspace_intent(
             checkoutCommit=authored_checkout_commit(request),
             revisionKind=authored_revision_kind(request),
             remoteTipExpectation=(
+                resolved_repository.get("remoteTipExpectation")
+                if resolved_repository
+                else
                 {"kind": "read_only"}
                 if authored_revision_kind(request)
                 else {
@@ -376,6 +385,9 @@ def compile_workspace_intent(
                 }
                 if repository
                 else None
+            ),
+            resolvedRepositoryTarget=(
+                dict(resolved_repository) if resolved_repository else None
             ),
             startingBranch=authored_starting_branch(request),
             targetBranch=authored_target_branch(request),

--- a/moonmind/omnigent/workspace_intent.py
+++ b/moonmind/omnigent/workspace_intent.py
@@ -52,6 +52,12 @@ def authored_repository_source(request: AgentExecutionRequest) -> str:
         spec.get("repo"),
         parameters.get("repository"),
     ):
+        if isinstance(candidate, Mapping):
+            nested = candidate.get("repository")
+            if isinstance(nested, Mapping):
+                value = str(nested.get("name") or "").strip()
+                if value:
+                    return value
         value = str(candidate or "").strip()
         if value:
             return value
@@ -60,6 +66,13 @@ def authored_repository_source(request: AgentExecutionRequest) -> str:
 
 def authored_starting_branch(request: AgentExecutionRequest) -> str | None:
     spec = _spec(request)
+    repository = spec.get("repository")
+    if isinstance(repository, Mapping):
+        branch = repository.get("branch")
+        if isinstance(branch, Mapping):
+            value = str(branch.get("name") or "").strip()
+            if value:
+                return value
     for candidate in (
         spec.get("startingBranch"),
         spec.get("branch"),
@@ -78,11 +91,38 @@ def authored_target_branch(request: AgentExecutionRequest) -> str | None:
 
 def authored_checkout_commit(request: AgentExecutionRequest) -> str | None:
     spec = _spec(request)
+    repository = spec.get("repository")
+    if isinstance(repository, Mapping):
+        revision = repository.get("revision")
+        if isinstance(revision, Mapping):
+            for key in ("commitSha", "revisionSignature"):
+                value = str(revision.get(key) or "").strip()
+                if value:
+                    return value
     for candidate in (spec.get("checkoutCommit"), spec.get("baseCommit")):
         value = str(candidate or "").strip()
         if value:
             return value
     return None
+
+
+def authored_connection_ref(request: AgentExecutionRequest) -> str | None:
+    repository = _spec(request).get("repository")
+    if not isinstance(repository, Mapping):
+        return None
+    value = str(repository.get("connectionRef") or "").strip()
+    return value or None
+
+
+def authored_revision_kind(request: AgentExecutionRequest) -> str | None:
+    repository = _spec(request).get("repository")
+    if not isinstance(repository, Mapping):
+        return None
+    revision = repository.get("revision")
+    if not isinstance(revision, Mapping):
+        return None
+    value = str(revision.get("kind") or "").strip()
+    return value or None
 
 
 def authored_restore_input_refs(request: AgentExecutionRequest) -> tuple[str, ...]:
@@ -316,7 +356,16 @@ def compile_workspace_intent(
             stepExecutionId=step_execution_id,
             repository=repository,
             repositoryKind=_classify_repository(repository or ""),
+            connectionRef=authored_connection_ref(request),
             checkoutCommit=authored_checkout_commit(request),
+            revisionKind=authored_revision_kind(request),
+            remoteTipExpectation=(
+                "read_only"
+                if authored_revision_kind(request)
+                else "must_equal"
+                if repository
+                else None
+            ),
             startingBranch=authored_starting_branch(request),
             targetBranch=authored_target_branch(request),
             inputRefs=list(request.input_refs),

--- a/moonmind/omnigent/workspace_intent.py
+++ b/moonmind/omnigent/workspace_intent.py
@@ -360,9 +360,20 @@ def compile_workspace_intent(
             checkoutCommit=authored_checkout_commit(request),
             revisionKind=authored_revision_kind(request),
             remoteTipExpectation=(
-                "read_only"
+                {"kind": "read_only"}
                 if authored_revision_kind(request)
-                else "must_equal"
+                else {
+                    "kind": "must_equal",
+                    "revision": {
+                        "provider": (
+                            "lore"
+                            if authored_revision_kind(request) == "lore_revision"
+                            else "git"
+                        ),
+                        "repositoryId": repository,
+                        "commitSha": authored_checkout_commit(request),
+                    },
+                }
                 if repository
                 else None
             ),

--- a/moonmind/omnigent/workspace_intent.py
+++ b/moonmind/omnigent/workspace_intent.py
@@ -345,10 +345,11 @@ def compile_workspace_intent(
 
     repository = authored_repository_source(request) or None
     resolved_repository = _spec(request).get("resolvedRepositoryTarget")
-    if resolved_repository is not None and not isinstance(resolved_repository, Mapping):
+    if resolved_repository is not None:
         raise WorkspaceIntentCompilationError(
             WORKSPACE_INTENT_UNSAFE_INPUT,
-            "workspaceSpec.resolvedRepositoryTarget must be an object",
+            "workspaceSpec.resolvedRepositoryTarget is runtime-owned and cannot "
+            "be authored",
         )
     restore_refs = authored_restore_input_refs(request)
     restore_input_refs, external_state_refs = _partition_restore_refs(restore_refs)

--- a/moonmind/schemas/agent_runtime_models.py
+++ b/moonmind/schemas/agent_runtime_models.py
@@ -2034,6 +2034,9 @@ class ManagedRunRecord(BaseModel):
     finished_at: datetime | None = Field(None, alias="finishedAt")
     last_heartbeat_at: datetime | None = Field(None, alias="lastHeartbeatAt")
     workspace_path: str | None = Field(None, alias="workspacePath")
+    resolved_repository_target: dict[str, Any] | None = Field(
+        None, alias="resolvedRepositoryTarget"
+    )
     # deprecated: use stdout_artifact_ref and stderr_artifact_ref instead
     log_artifact_ref: str | None = Field(None, alias="logArtifactRef")
     stdout_artifact_ref: str | None = Field(None, alias="stdoutArtifactRef")

--- a/moonmind/schemas/workspace_intent.py
+++ b/moonmind/schemas/workspace_intent.py
@@ -157,7 +157,12 @@ class WorkspaceIntentRecord(BaseModel):
     # Repository identity and immutable source evidence.
     repository: str | None = Field(None, alias="repository", max_length=2000)
     repository_kind: str | None = Field(None, alias="repositoryKind", max_length=50)
+    connection_ref: str | None = Field(None, alias="connectionRef", max_length=500)
     checkout_commit: str | None = Field(None, alias="checkoutCommit", max_length=200)
+    revision_kind: str | None = Field(None, alias="revisionKind", max_length=50)
+    remote_tip_expectation: str | None = Field(
+        None, alias="remoteTipExpectation", max_length=50
+    )
 
     # Requested branch intent.
     starting_branch: str | None = Field(None, alias="startingBranch", max_length=400)
@@ -306,7 +311,10 @@ class WorkspaceIntentRecord(BaseModel):
             "stepExecutionId": self.step_execution_id,
             "repository": repository_evidence,
             "repositoryKind": self.repository_kind,
+            "connectionRef": self.connection_ref,
             "sourceCommit": self.checkout_commit,
+            "revisionKind": self.revision_kind,
+            "remoteTipExpectation": self.remote_tip_expectation,
             "startingBranch": self.starting_branch,
             "targetBranch": self.target_branch,
             "publishMode": self.publish_mode,

--- a/moonmind/schemas/workspace_intent.py
+++ b/moonmind/schemas/workspace_intent.py
@@ -163,6 +163,9 @@ class WorkspaceIntentRecord(BaseModel):
     remote_tip_expectation: dict[str, Any] | None = Field(
         None, alias="remoteTipExpectation"
     )
+    resolved_repository_target: dict[str, Any] | None = Field(
+        None, alias="resolvedRepositoryTarget"
+    )
 
     # Requested branch intent.
     starting_branch: str | None = Field(None, alias="startingBranch", max_length=400)
@@ -315,6 +318,7 @@ class WorkspaceIntentRecord(BaseModel):
             "sourceCommit": self.checkout_commit,
             "revisionKind": self.revision_kind,
             "remoteTipExpectation": self.remote_tip_expectation,
+            "resolvedRepositoryTarget": self.resolved_repository_target,
             "startingBranch": self.starting_branch,
             "targetBranch": self.target_branch,
             "publishMode": self.publish_mode,

--- a/moonmind/schemas/workspace_intent.py
+++ b/moonmind/schemas/workspace_intent.py
@@ -160,8 +160,8 @@ class WorkspaceIntentRecord(BaseModel):
     connection_ref: str | None = Field(None, alias="connectionRef", max_length=500)
     checkout_commit: str | None = Field(None, alias="checkoutCommit", max_length=200)
     revision_kind: str | None = Field(None, alias="revisionKind", max_length=50)
-    remote_tip_expectation: str | None = Field(
-        None, alias="remoteTipExpectation", max_length=50
+    remote_tip_expectation: dict[str, Any] | None = Field(
+        None, alias="remoteTipExpectation"
     )
 
     # Requested branch intent.

--- a/moonmind/workflows/executions/execution_contract.py
+++ b/moonmind/workflows/executions/execution_contract.py
@@ -2440,7 +2440,7 @@ class CanonicalWorkflowExecutionPayload(BaseModel):
 
     model_config = ConfigDict(populate_by_name=True, extra="allow")
 
-    repository: AuthoredRepositoryTarget = Field(alias="repository")
+    repository: AuthoredRepositoryTarget | None = Field(None, alias="repository")
     required_capabilities: list[str] | None = Field(
         None,
         alias="requiredCapabilities",
@@ -2462,7 +2462,9 @@ class CanonicalWorkflowExecutionPayload(BaseModel):
 
     @field_validator("repository", mode="before")
     @classmethod
-    def _normalize_repository(cls, value: object) -> AuthoredRepositoryTarget:
+    def _normalize_repository(cls, value: object) -> AuthoredRepositoryTarget | None:
+        if value is None:
+            return None
         return compile_repository_target(value)
 
     @field_validator("target_runtime", mode="before")
@@ -2484,7 +2486,11 @@ class CanonicalWorkflowExecutionPayload(BaseModel):
     def _validate_repository_revision_publish_mode(
         self,
     ) -> "CanonicalWorkflowExecutionPayload":
-        if self.repository.revision is not None and self.task.publish.mode != "none":
+        if (
+            self.repository is not None
+            and self.repository.revision is not None
+            and self.task.publish.mode != "none"
+        ):
             raise WorkflowContractError(
                 "repository.revision is allowed only when workflow.publish.mode='none'"
             )
@@ -2766,7 +2772,12 @@ def build_canonical_workflow_view(
         required.extend(canonical_existing)
 
     required.append(target_runtime)
-    repository_target = compile_repository_target(canonical.get("repository"))
+    repository_raw = canonical.get("repository")
+    repository_target = (
+        compile_repository_target(repository_raw)
+        if repository_raw is not None
+        else None
+    )
 
     source_publish_mode = None
     if normalized_type == CANONICAL_WORKFLOW_JOB_TYPE:
@@ -2846,14 +2857,17 @@ def build_canonical_workflow_view(
                 repository_tool_caps.extend(step_tool_caps)
                 required.extend(step_tool_caps)
 
-    required.extend(
-        derive_repository_capabilities(
-            repository_target,
-            publish_mode=publish_mode,
-            skill_capabilities=repository_skill_caps,
-            tool_capabilities=repository_tool_caps,
+    if repository_target is not None:
+        required.extend(
+            derive_repository_capabilities(
+                repository_target,
+                publish_mode=publish_mode,
+                skill_capabilities=repository_skill_caps,
+                tool_capabilities=repository_tool_caps,
+            )
         )
-    )
+    elif publish_mode == "pr":
+        required.append("gh")
 
     container_node = (canonical.get("workflow") or {}).get("container")
     container = container_node if isinstance(container_node, Mapping) else {}

--- a/moonmind/workflows/executions/execution_contract.py
+++ b/moonmind/workflows/executions/execution_contract.py
@@ -2440,7 +2440,7 @@ class CanonicalWorkflowExecutionPayload(BaseModel):
 
     model_config = ConfigDict(populate_by_name=True, extra="allow")
 
-    repository: AuthoredRepositoryTarget | None = Field(None, alias="repository")
+    repository: AuthoredRepositoryTarget | str | None = Field(None, alias="repository")
     required_capabilities: list[str] | None = Field(
         None,
         alias="requiredCapabilities",
@@ -2462,9 +2462,16 @@ class CanonicalWorkflowExecutionPayload(BaseModel):
 
     @field_validator("repository", mode="before")
     @classmethod
-    def _normalize_repository(cls, value: object) -> AuthoredRepositoryTarget | None:
+    def _normalize_repository(
+        cls, value: object
+    ) -> AuthoredRepositoryTarget | str | None:
         if value is None:
             return None
+        if isinstance(value, str):
+            cleaned = value.strip()
+            if not cleaned:
+                raise WorkflowContractError("repository must be non-empty")
+            return cleaned
         return compile_repository_target(value)
 
     @field_validator("target_runtime", mode="before")
@@ -2488,6 +2495,7 @@ class CanonicalWorkflowExecutionPayload(BaseModel):
     ) -> "CanonicalWorkflowExecutionPayload":
         if (
             self.repository is not None
+            and not isinstance(self.repository, str)
             and self.repository.revision is not None
             and self.task.publish.mode != "none"
         ):
@@ -2708,11 +2716,33 @@ def build_canonical_workflow_view(
         except (ValidationError, WorkflowContractError) as exc:
             raise WorkflowContractError(str(exc)) from exc
         canonical = model.model_dump(by_alias=True, exclude_none=False)
-    elif normalized_type in LEGACY_WORKFLOW_JOB_TYPES:
-        raise WorkflowContractError(
-            "legacy codex_exec/codex_skill submissions are no longer accepted; "
-            "recorded histories must use decode_legacy_repository_history_v1"
+    elif normalized_type == "codex_exec":
+        repository = _clean_optional_str(source.get("repository")) or ""
+        if not repository:
+            raise WorkflowContractError("repository is required")
+        canonical = {
+            "repository": repository,
+            "targetRuntime": "codex",
+            "auth": _build_auth_from_payload(source),
+            "workflow": _build_spec_from_codex_exec_payload(source),
+        }
+    elif normalized_type == "codex_skill":
+        inputs = source.get("inputs")
+        input_mapping = inputs if isinstance(inputs, Mapping) else {}
+        repository = (
+            _clean_optional_str(source.get("repository"))
+            or _clean_optional_str(input_mapping.get("repo"))
+            or _clean_optional_str(input_mapping.get("repository"))
+            or ""
         )
+        if not repository:
+            raise WorkflowContractError("repository is required")
+        canonical = {
+            "repository": repository,
+            "targetRuntime": "codex",
+            "auth": _build_auth_from_payload(source),
+            "workflow": _build_spec_from_codex_skill_payload(source),
+        }
     else:
         canonical = {
             "repository": _clean_optional_str(source.get("repository")) or "",
@@ -2773,11 +2803,19 @@ def build_canonical_workflow_view(
 
     required.append(target_runtime)
     repository_raw = canonical.get("repository")
-    repository_target = (
-        compile_repository_target(repository_raw)
-        if repository_raw is not None
-        else None
-    )
+    if isinstance(repository_raw, str):
+        git_node = workflow_node.get("git")
+        git_mapping = git_node if isinstance(git_node, Mapping) else {}
+        repository_target = decode_legacy_repository_history_v1(
+            repository_raw,
+            _clean_optional_str(git_mapping.get("startingBranch")),
+        )
+    else:
+        repository_target = (
+            compile_repository_target(repository_raw)
+            if repository_raw is not None
+            else None
+        )
 
     source_publish_mode = None
     if normalized_type == CANONICAL_WORKFLOW_JOB_TYPE:
@@ -2857,7 +2895,11 @@ def build_canonical_workflow_view(
                 repository_tool_caps.extend(step_tool_caps)
                 required.extend(step_tool_caps)
 
-    if repository_target is not None:
+    if isinstance(repository_raw, str):
+        required.append("git")
+        if publish_mode == "pr":
+            required.append("gh")
+    elif repository_target is not None:
         required.extend(
             derive_repository_capabilities(
                 repository_target,

--- a/moonmind/workflows/executions/execution_contract.py
+++ b/moonmind/workflows/executions/execution_contract.py
@@ -29,6 +29,11 @@ from moonmind.workflows.skills.resolver import (
 )
 
 from .job_types import CANONICAL_WORKFLOW_JOB_TYPE, LEGACY_WORKFLOW_JOB_TYPES
+from .repository_contract import (
+    AuthoredRepositoryTarget,
+    compile_repository_target,
+    derive_repository_capabilities,
+)
 
 DEFAULT_WORKFLOW_RUNTIME = "codex"
 SUPPORTED_RUNTIME_MODES = {
@@ -2425,11 +2430,7 @@ class CanonicalWorkflowExecutionPayload(BaseModel):
 
     model_config = ConfigDict(populate_by_name=True, extra="allow")
 
-    repository: str | None = Field(
-        None,
-        alias="repository",
-        validation_alias=AliasChoices("repository", "repo"),
-    )
+    repository: AuthoredRepositoryTarget = Field(alias="repository")
     required_capabilities: list[str] | None = Field(
         None,
         alias="requiredCapabilities",
@@ -2451,11 +2452,8 @@ class CanonicalWorkflowExecutionPayload(BaseModel):
 
     @field_validator("repository", mode="before")
     @classmethod
-    def _normalize_repository(cls, value: object) -> str:
-        cleaned = _clean_optional_str(value)
-        if not cleaned:
-            raise WorkflowContractError("repository is required")
-        return cleaned
+    def _normalize_repository(cls, value: object) -> AuthoredRepositoryTarget:
+        return compile_repository_target(value)
 
     @field_validator("target_runtime", mode="before")
     @classmethod
@@ -2471,6 +2469,16 @@ class CanonicalWorkflowExecutionPayload(BaseModel):
             raise WorkflowContractError("requiredCapabilities must be a list")
         normalized = _normalize_capabilities(value)
         return normalized or None
+
+    @model_validator(mode="after")
+    def _validate_repository_revision_publish_mode(
+        self,
+    ) -> "CanonicalWorkflowExecutionPayload":
+        if self.repository.revision is not None and self.task.publish.mode != "none":
+            raise WorkflowContractError(
+                "repository.revision is allowed only when workflow.publish.mode='none'"
+            )
+        return self
 
     @model_validator(mode="before")
     @classmethod
@@ -2684,39 +2692,11 @@ def build_canonical_workflow_view(
         except (ValidationError, WorkflowContractError) as exc:
             raise WorkflowContractError(str(exc)) from exc
         canonical = model.model_dump(by_alias=True, exclude_none=False)
-    elif normalized_type == "codex_exec":
-        repository = _clean_optional_str(source.get("repository")) or ""
-        if not repository:
-            raise WorkflowContractError("repository is required")
-        canonical = {
-            "repository": repository,
-            "targetRuntime": "codex",
-            "auth": _build_auth_from_payload(source),
-            "workflow": _build_spec_from_codex_exec_payload(source),
-        }
-    elif normalized_type == "codex_skill":
-        repository = (
-            _clean_optional_str(source.get("repository"))
-            or _clean_optional_str(
-                (source.get("inputs") or {}).get("repo")
-                if isinstance(source.get("inputs"), Mapping)
-                else None
-            )
-            or _clean_optional_str(
-                (source.get("inputs") or {}).get("repository")
-                if isinstance(source.get("inputs"), Mapping)
-                else None
-            )
-            or ""
+    elif normalized_type in LEGACY_WORKFLOW_JOB_TYPES:
+        raise WorkflowContractError(
+            "legacy codex_exec/codex_skill submissions are no longer accepted; "
+            "recorded histories must use decode_legacy_repository_history_v1"
         )
-        if not repository:
-            raise WorkflowContractError("repository is required")
-        canonical = {
-            "repository": repository,
-            "targetRuntime": "codex",
-            "auth": _build_auth_from_payload(source),
-            "workflow": _build_spec_from_codex_skill_payload(source),
-        }
     else:
         canonical = {
             "repository": _clean_optional_str(source.get("repository")) or "",
@@ -2776,23 +2756,7 @@ def build_canonical_workflow_view(
         required.extend(canonical_existing)
 
     required.append(target_runtime)
-    workflow_git_node = (
-        workflow_node.get("git") if isinstance(workflow_node, Mapping) else None
-    )
-    workflow_git = workflow_git_node if isinstance(workflow_git_node, Mapping) else {}
-    has_git_checkout_context = any(
-        _clean_optional_str(workflow_git.get(key))
-        for key in (
-            "repository",
-            "repo",
-            "branch",
-            "startingBranch",
-            "targetBranch",
-            "ref",
-        )
-    )
-    if _clean_optional_str(canonical.get("repository")) or has_git_checkout_context:
-        required.append("git")
+    repository_target = compile_repository_target(canonical.get("repository"))
 
     source_publish_mode = None
     if normalized_type == CANONICAL_WORKFLOW_JOB_TYPE:
@@ -2833,11 +2797,9 @@ def build_canonical_workflow_view(
         side_effect_metadata=skill_side_effect_metadata,
     )
     publish_node["mode"] = publish_mode
-    if publish_mode == "pr":
-        required.append("gh")
-
     skill_caps = skill_node.get("requiredCapabilities")
-    required.extend(_skill_metadata_required_capabilities(skill_id))
+    repository_skill_caps = list(_skill_metadata_required_capabilities(skill_id))
+    required.extend(repository_skill_caps)
     if isinstance(skill_caps, list):
         required.extend(skill_caps)
 
@@ -2850,7 +2812,11 @@ def build_canonical_workflow_view(
             step_skill_raw = step_raw.get("skill")
             step_skill = step_skill_raw if isinstance(step_skill_raw, Mapping) else {}
             step_skill_id = step_skill.get("id") or step_skill.get("name")
-            required.extend(_skill_metadata_required_capabilities(step_skill_id))
+            step_metadata_caps = list(
+                _skill_metadata_required_capabilities(step_skill_id)
+            )
+            repository_skill_caps.extend(step_metadata_caps)
+            required.extend(step_metadata_caps)
             step_skill_caps = step_skill.get("requiredCapabilities")
             if isinstance(step_skill_caps, list):
                 required.extend(step_skill_caps)
@@ -2859,6 +2825,14 @@ def build_canonical_workflow_view(
             step_tool_caps = step_tool.get("requiredCapabilities")
             if isinstance(step_tool_caps, list):
                 required.extend(step_tool_caps)
+
+    required.extend(
+        derive_repository_capabilities(
+            repository_target,
+            publish_mode=publish_mode,
+            skill_capabilities=repository_skill_caps,
+        )
+    )
 
     container_node = (canonical.get("workflow") or {}).get("container")
     container = container_node if isinstance(container_node, Mapping) else {}

--- a/moonmind/workflows/executions/execution_contract.py
+++ b/moonmind/workflows/executions/execution_contract.py
@@ -2151,7 +2151,6 @@ class WorkflowExecutionSpec(BaseModel):
     runtime: WorkflowRuntimeSelection = Field(
         default_factory=WorkflowRuntimeSelection, alias="runtime"
     )
-    git: WorkflowGitSelection = Field(default_factory=WorkflowGitSelection, alias="git")
     publish: WorkflowPublishSelection = Field(
         default_factory=WorkflowPublishSelection, alias="publish"
     )
@@ -2170,6 +2169,16 @@ class WorkflowExecutionSpec(BaseModel):
     recovery: WorkflowRecoveryProvenance | None = Field(None, alias="recovery")
     resume: ResumeFromFailedStepRef | None = Field(None, alias="resume")
     depends_on: list[str] | None = Field(None, alias="dependsOn")
+
+    @model_validator(mode="before")
+    @classmethod
+    def _reject_legacy_git_authoring(cls, value: object) -> object:
+        if isinstance(value, Mapping) and "git" in value:
+            raise WorkflowContractError(
+                "workflow.git is not accepted for new submissions; use the "
+                "top-level provider-discriminated repository target"
+            )
+        return value
 
     @field_validator("instructions", mode="before")
     @classmethod
@@ -2799,9 +2808,18 @@ def build_canonical_workflow_view(
     publish_node["mode"] = publish_mode
     skill_caps = skill_node.get("requiredCapabilities")
     repository_skill_caps = list(_skill_metadata_required_capabilities(skill_id))
+    repository_tool_caps: list[object] = []
     required.extend(repository_skill_caps)
     if isinstance(skill_caps, list):
         required.extend(skill_caps)
+    workflow_tool_raw = workflow_payload.get("tool")
+    workflow_tool = (
+        workflow_tool_raw if isinstance(workflow_tool_raw, Mapping) else {}
+    )
+    workflow_tool_caps = workflow_tool.get("requiredCapabilities")
+    if isinstance(workflow_tool_caps, list):
+        repository_tool_caps.extend(workflow_tool_caps)
+        required.extend(workflow_tool_caps)
 
     steps_node = (canonical.get("workflow") or {}).get("steps")
     if isinstance(steps_node, list):
@@ -2824,6 +2842,7 @@ def build_canonical_workflow_view(
             step_tool = step_tool_raw if isinstance(step_tool_raw, Mapping) else {}
             step_tool_caps = step_tool.get("requiredCapabilities")
             if isinstance(step_tool_caps, list):
+                repository_tool_caps.extend(step_tool_caps)
                 required.extend(step_tool_caps)
 
     required.extend(
@@ -2831,6 +2850,7 @@ def build_canonical_workflow_view(
             repository_target,
             publish_mode=publish_mode,
             skill_capabilities=repository_skill_caps,
+            tool_capabilities=repository_tool_caps,
         )
     )
 

--- a/moonmind/workflows/executions/execution_contract.py
+++ b/moonmind/workflows/executions/execution_contract.py
@@ -2171,16 +2171,6 @@ class WorkflowExecutionSpec(BaseModel):
     resume: ResumeFromFailedStepRef | None = Field(None, alias="resume")
     depends_on: list[str] | None = Field(None, alias="dependsOn")
 
-    @model_validator(mode="before")
-    @classmethod
-    def _reject_legacy_git_authoring(cls, value: object) -> object:
-        if isinstance(value, Mapping) and "git" in value:
-            raise WorkflowContractError(
-                "workflow.git is not accepted for new submissions; use the "
-                "top-level provider-discriminated repository target"
-            )
-        return value
-
     @field_validator("instructions", mode="before")
     @classmethod
     def _normalize_instructions(cls, value: object) -> str | None:
@@ -2513,6 +2503,16 @@ class CanonicalWorkflowExecutionPayload(BaseModel):
         workflow_node = payload.get("workflow")
         task_node = payload.get("task")
         body_node = workflow_node if isinstance(workflow_node, Mapping) else task_node
+        repository_node = payload.get("repository")
+        if (
+            isinstance(repository_node, Mapping)
+            and isinstance(body_node, Mapping)
+            and "git" in body_node
+        ):
+            raise WorkflowContractError(
+                "workflow.git is not accepted with a provider-discriminated "
+                "repository target"
+            )
         if not isinstance(body_node, Mapping):
             legacy_instruction = (
                 payload.get("instructions") or payload.get("instruction") or ""
@@ -2716,33 +2716,11 @@ def build_canonical_workflow_view(
         except (ValidationError, WorkflowContractError) as exc:
             raise WorkflowContractError(str(exc)) from exc
         canonical = model.model_dump(by_alias=True, exclude_none=False)
-    elif normalized_type == "codex_exec":
-        repository = _clean_optional_str(source.get("repository")) or ""
-        if not repository:
-            raise WorkflowContractError("repository is required")
-        canonical = {
-            "repository": repository,
-            "targetRuntime": "codex",
-            "auth": _build_auth_from_payload(source),
-            "workflow": _build_spec_from_codex_exec_payload(source),
-        }
-    elif normalized_type == "codex_skill":
-        inputs = source.get("inputs")
-        input_mapping = inputs if isinstance(inputs, Mapping) else {}
-        repository = (
-            _clean_optional_str(source.get("repository"))
-            or _clean_optional_str(input_mapping.get("repo"))
-            or _clean_optional_str(input_mapping.get("repository"))
-            or ""
+    elif normalized_type in LEGACY_WORKFLOW_JOB_TYPES:
+        raise WorkflowContractError(
+            "legacy codex_exec/codex_skill submissions are no longer accepted; "
+            "recorded histories must use decode_legacy_repository_history_v1"
         )
-        if not repository:
-            raise WorkflowContractError("repository is required")
-        canonical = {
-            "repository": repository,
-            "targetRuntime": "codex",
-            "auth": _build_auth_from_payload(source),
-            "workflow": _build_spec_from_codex_skill_payload(source),
-        }
     else:
         canonical = {
             "repository": _clean_optional_str(source.get("repository")) or "",
@@ -2947,9 +2925,14 @@ def decode_recorded_legacy_workflow_history_v1(
         canonical_source["repository"] = decode_legacy_repository_history_v1(
             repository, branch
         ).model_dump(by_alias=True, mode="json")
-    return build_canonical_workflow_view(
+    canonical = build_canonical_workflow_view(
         job_type=CANONICAL_WORKFLOW_JOB_TYPE, payload=canonical_source
     )
+    legacy_required = ["codex", "git"]
+    if task.get("publish", {}).get("mode") == "pr":
+        legacy_required.append("gh")
+    canonical["requiredCapabilities"] = legacy_required
+    return canonical
 
 def build_effective_proposal_policy(
     *,

--- a/moonmind/workflows/executions/execution_contract.py
+++ b/moonmind/workflows/executions/execution_contract.py
@@ -33,6 +33,7 @@ from .repository_contract import (
     AuthoredRepositoryTarget,
     compile_repository_target,
     derive_repository_capabilities,
+    decode_legacy_repository_history_v1,
 )
 
 DEFAULT_WORKFLOW_RUNTIME = "codex"
@@ -2862,6 +2863,38 @@ def build_canonical_workflow_view(
     canonical["requiredCapabilities"] = _normalize_capabilities(tuple(required))
     return canonical
 
+
+def decode_recorded_legacy_workflow_history_v1(
+    *, job_type: str, payload: Mapping[str, Any] | None
+) -> dict[str, Any]:
+    """Frozen adapter used only when executing already-recorded queue history."""
+
+    source = dict(payload or {})
+    if job_type not in LEGACY_WORKFLOW_JOB_TYPES:
+        raise WorkflowContractError("recorded legacy decoder requires a legacy job type")
+    task = (
+        _build_spec_from_codex_exec_payload(source)
+        if job_type == "codex_exec"
+        else _build_spec_from_codex_skill_payload(source)
+    )
+    repository = _clean_optional_str(source.get("repository")) or _clean_optional_str(
+        (task.get("skill") or {}).get("args", {}).get("repo")
+    )
+    legacy_git = task.pop("git", {})
+    canonical_source: dict[str, Any] = {
+        "targetRuntime": "codex",
+        "auth": _build_auth_from_payload(source),
+        "workflow": task,
+    }
+    if repository:
+        branch = _clean_optional_str(legacy_git.get("startingBranch"))
+        canonical_source["repository"] = decode_legacy_repository_history_v1(
+            repository, branch
+        ).model_dump(by_alias=True, mode="json")
+    return build_canonical_workflow_view(
+        job_type=CANONICAL_WORKFLOW_JOB_TYPE, payload=canonical_source
+    )
+
 def build_effective_proposal_policy(
     *,
     policy: WorkflowProposalPolicy | None,
@@ -3279,6 +3312,7 @@ __all__ = [
     "build_runtime_command_preview_config",
     "build_workflow_stage_plan",
     "build_canonical_workflow_view",
+    "decode_recorded_legacy_workflow_history_v1",
     "allows_repository_publish_for_skill_context",
     "has_attachment_mutation_fields",
     "is_non_repository_side_effect_skill",

--- a/moonmind/workflows/executions/execution_contract.py
+++ b/moonmind/workflows/executions/execution_contract.py
@@ -2654,19 +2654,17 @@ def _build_spec_from_codex_skill_payload(payload: Mapping[str, Any]) -> dict[str
         payload.get("ref")
     )
     publish_payload = {
-        # Preserve an omitted publish mode as ``None`` so the auto-publish-capable
-        # skill resolver applies the per-skill default from
-        # docs/Workflows/WorkflowPublishing.md. Materializing the default ``pr``
-        # here would make ``resolve_publish_mode_for_skill`` treat the absent mode
-        # as an explicit forbidden mode and reject the request.
-        "mode": _normalize_publish_mode(publish_mode)
-        if publish_mode is not None
-        else None,
         "prBaseBranch": publish_base,
         "commitMessage": None,
         "prTitle": None,
         "prBody": None,
     }
+    # Preserve omission by leaving ``mode`` out entirely. Supplying ``None``
+    # marks the Pydantic field as explicitly set after its field validator
+    # normalizes it to the global ``pr`` default, which prevents the selected
+    # skill resolver from applying an auto-publish skill's ``auto`` default.
+    if publish_mode is not None:
+        publish_payload["mode"] = _normalize_publish_mode(publish_mode)
     if "verificationSkipReason" in skill_publish_node:
         publish_payload["verificationSkipReason"] = skill_publish_node.get(
             "verificationSkipReason"

--- a/moonmind/workflows/executions/repository_contract.py
+++ b/moonmind/workflows/executions/repository_contract.py
@@ -1,0 +1,299 @@
+"""Provider-aware repository compilation and readiness boundary.
+
+MM-1219 replaces repository-shaped authoring aliases with one discriminated
+target.  This module owns compilation, connection reconciliation, capability
+derivation, and the pre-mutation readiness check so those decisions cannot
+drift across authoring and runtime code.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable, Mapping, Sequence
+from typing import Annotated, Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, TypeAdapter, model_validator
+
+DEFAULT_GIT_CONNECTION_REF = "repository-connection:git-default"
+LEGACY_REPOSITORY_DECODER_VERSION = "moonmind.repository-legacy-history.v1"
+REPOSITORY_CAPABILITY_UNKNOWN = "REPOSITORY_CAPABILITY_UNKNOWN"
+REPOSITORY_CONNECTION_MISMATCH = "REPOSITORY_CONNECTION_MISMATCH"
+REPOSITORY_CLIENT_MISMATCH = "REPOSITORY_CLIENT_MISMATCH"
+
+
+class RepositoryContractError(ValueError):
+    def __init__(self, code: str, message: str) -> None:
+        self.code = code
+        super().__init__(f"{code}: {message}")
+
+
+class RepositoryName(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    name: str = Field(min_length=1, max_length=2000)
+
+
+class RepositoryBranch(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    name: str = Field(min_length=1, max_length=400)
+
+
+class GitRevision(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    kind: Literal["git_commit"]
+    commit_sha: str = Field(alias="commitSha", min_length=7, max_length=200)
+
+
+class LoreRevision(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    kind: Literal["lore_revision"]
+    revision_signature: str = Field(
+        alias="revisionSignature", min_length=1, max_length=1000
+    )
+
+
+class AuthoredGitRepositoryTarget(BaseModel):
+    model_config = ConfigDict(populate_by_name=True, extra="forbid", frozen=True)
+    provider: Literal["git"]
+    connection_ref: str = Field(alias="connectionRef", min_length=1)
+    repository: RepositoryName
+    branch: RepositoryBranch
+    revision: GitRevision | None = None
+
+
+class AuthoredLoreRepositoryTarget(BaseModel):
+    model_config = ConfigDict(populate_by_name=True, extra="forbid", frozen=True)
+    provider: Literal["lore"]
+    connection_ref: str = Field(alias="connectionRef", min_length=1)
+    repository: RepositoryName
+    branch: RepositoryBranch
+    revision: LoreRevision | None = None
+
+
+AuthoredRepositoryTarget = Annotated[
+    AuthoredGitRepositoryTarget | AuthoredLoreRepositoryTarget,
+    Field(discriminator="provider"),
+]
+_TARGET_ADAPTER = TypeAdapter(AuthoredRepositoryTarget)
+
+
+class RepositoryClientPolicy(BaseModel):
+    model_config = ConfigDict(populate_by_name=True, extra="forbid", frozen=True)
+    pinned_version: str = Field(alias="pinnedVersion", min_length=1)
+    compatible_server_versions: tuple[str, ...] = Field(
+        default=(), alias="compatibleServerVersions"
+    )
+    tool_bundle_ref: str = Field(alias="toolBundleRef", min_length=1)
+    executable_sha256: str = Field(alias="executableSha256", min_length=1)
+
+
+class RepositoryClientEvidence(BaseModel):
+    model_config = ConfigDict(populate_by_name=True, extra="forbid", frozen=True)
+    tool_bundle_ref: str = Field(alias="toolBundleRef", min_length=1)
+    client_version: str = Field(alias="clientVersion", min_length=1)
+    executable_sha256: str = Field(alias="executableSha256", min_length=1)
+    server_version: str | None = Field(None, alias="serverVersion")
+
+
+class RepositoryConnection(BaseModel):
+    model_config = ConfigDict(populate_by_name=True, extra="forbid", frozen=True)
+    schema_version: Literal["moonmind.repository-connection.v1"] = Field(
+        alias="schemaVersion"
+    )
+    id: str = Field(min_length=1)
+    provider: Literal["git", "lore"]
+    display_name: str = Field(alias="displayName", min_length=1)
+    endpoint_ref: str = Field(alias="endpointRef", min_length=1)
+    allowed_repository_ids: tuple[str, ...] = Field(
+        default=(), alias="allowedRepositoryIds"
+    )
+    allowed_operations: tuple[
+        Literal[
+            "read",
+            "write",
+            "branch_write",
+            "lock",
+            "review_request",
+            "merge_request",
+        ],
+        ...,
+    ] = Field(alias="allowedOperations")
+    client_policy: RepositoryClientPolicy = Field(alias="clientPolicy")
+    credential_source: Literal[
+        "github_resolver", "secret_ref", "trusted_network_development"
+    ] = Field(alias="credentialSource")
+
+
+def compile_repository_target(value: object) -> AuthoredRepositoryTarget:
+    """Compile a UI draft, injecting only the well-known common Git connection."""
+
+    if not isinstance(value, Mapping):
+        raise RepositoryContractError(
+            "REPOSITORY_TARGET_INVALID",
+            "repository must be a provider-discriminated object",
+        )
+    draft = dict(value)
+    if draft.get("provider") == "git" and not str(
+        draft.get("connectionRef") or ""
+    ).strip():
+        draft["connectionRef"] = DEFAULT_GIT_CONNECTION_REF
+    try:
+        return _TARGET_ADAPTER.validate_python(draft)
+    except ValueError as exc:
+        raise RepositoryContractError("REPOSITORY_TARGET_INVALID", str(exc)) from exc
+
+
+def decode_legacy_repository_history_v1(
+    repository: str, branch: str | None = None
+) -> AuthoredGitRepositoryTarget:
+    """Frozen decoder for already-recorded histories; never call for authoring."""
+
+    return AuthoredGitRepositoryTarget(
+        provider="git",
+        connectionRef=DEFAULT_GIT_CONNECTION_REF,
+        repository={"name": repository},
+        branch={"name": branch or "main"},
+    )
+
+
+def derive_repository_capabilities(
+    target: AuthoredRepositoryTarget,
+    *,
+    publish_mode: str,
+    skill_capabilities: Sequence[object] = (),
+    tool_capabilities: Sequence[object] = (),
+) -> list[str]:
+    required = ["lore" if target.provider == "lore" else "git", "repo.read"]
+    if publish_mode == "branch":
+        required.extend(("repo.write", "repo.branch.write"))
+    elif publish_mode == "pr":
+        required.extend(("repo.write", "repo.branch.write"))
+        required.append("repo.review.request" if target.provider == "lore" else "gh")
+    required.extend(str(item).strip().lower() for item in skill_capabilities)
+    required.extend(str(item).strip().lower() for item in tool_capabilities)
+    return list(dict.fromkeys(item for item in required if item))
+
+
+def reconcile_default_git_connection(
+    *,
+    client_policy: RepositoryClientPolicy,
+) -> RepositoryConnection:
+    """Return the deployment-owned connection selecting the existing resolver."""
+
+    return RepositoryConnection(
+        schemaVersion="moonmind.repository-connection.v1",
+        id=DEFAULT_GIT_CONNECTION_REF,
+        provider="git",
+        displayName="Default GitHub connection",
+        endpointRef="https://github.com",
+        allowedOperations=("read", "write", "branch_write", "review_request"),
+        clientPolicy=client_policy,
+        credentialSource="github_resolver",
+    )
+
+
+def validate_connection_and_client(
+    target: AuthoredRepositoryTarget,
+    connection: RepositoryConnection,
+    evidence: RepositoryClientEvidence,
+    *,
+    operation: str,
+) -> None:
+    """Fail before mutation unless target, policy, allowlists and evidence agree."""
+
+    if connection.id != target.connection_ref or connection.provider != target.provider:
+        raise RepositoryContractError(
+            REPOSITORY_CONNECTION_MISMATCH,
+            "repository target and connection identity/provider do not match",
+        )
+    if operation not in connection.allowed_operations:
+        raise RepositoryContractError(
+            REPOSITORY_CONNECTION_MISMATCH,
+            f"connection does not allow operation {operation!r}",
+        )
+    if (
+        connection.allowed_repository_ids
+        and target.repository.name not in connection.allowed_repository_ids
+    ):
+        raise RepositoryContractError(
+            REPOSITORY_CONNECTION_MISMATCH, "repository is not allowed by connection"
+        )
+    policy = connection.client_policy
+    if (
+        evidence.tool_bundle_ref != policy.tool_bundle_ref
+        or evidence.client_version != policy.pinned_version
+        or evidence.executable_sha256 != policy.executable_sha256
+        or (
+            policy.compatible_server_versions
+            and evidence.server_version not in policy.compatible_server_versions
+        )
+    ):
+        raise RepositoryContractError(
+            REPOSITORY_CLIENT_MISMATCH,
+            "observed repository client evidence does not match connection policy",
+        )
+
+
+ReadinessCheck = Callable[[Mapping[str, Any]], bool | Awaitable[bool]]
+
+
+class CapabilityReadinessRegistry:
+    """Fail-closed registry used immediately before repository mutation."""
+
+    def __init__(self, runtime_owned_tokens: Sequence[str] = ()) -> None:
+        self._checks: dict[str, ReadinessCheck] = {}
+        self._runtime_owned = frozenset(runtime_owned_tokens)
+
+    def register(self, token: str, check: ReadinessCheck) -> None:
+        normalized = token.strip().lower()
+        if not normalized or normalized in self._checks:
+            raise ValueError(f"invalid or duplicate capability token {token!r}")
+        self._checks[normalized] = check
+
+    async def check(
+        self, tokens: Sequence[str], context: Mapping[str, Any]
+    ) -> None:
+        for raw in tokens:
+            token = str(raw).strip().lower()
+            if token in self._runtime_owned:
+                continue
+            check = self._checks.get(token)
+            if check is None:
+                raise RepositoryContractError(
+                    REPOSITORY_CAPABILITY_UNKNOWN,
+                    f"required capability {token!r} has no readiness provider",
+                )
+            result = check(context)
+            if hasattr(result, "__await__"):
+                result = await result  # type: ignore[misc]
+            if not result:
+                raise RepositoryContractError(
+                    "REPOSITORY_CAPABILITY_UNREADY",
+                    f"required capability {token!r} is not ready",
+                )
+
+
+async def resolve_default_git_credential(repository: str) -> object:
+    """Invoke the canonical GitHub resolver selected by the default connection."""
+
+    from moonmind.auth.github_credentials import resolve_github_credential
+
+    return await resolve_github_credential(repo=repository)
+
+
+__all__ = [
+    "AuthoredGitRepositoryTarget",
+    "AuthoredLoreRepositoryTarget",
+    "AuthoredRepositoryTarget",
+    "CapabilityReadinessRegistry",
+    "DEFAULT_GIT_CONNECTION_REF",
+    "LEGACY_REPOSITORY_DECODER_VERSION",
+    "RepositoryClientEvidence",
+    "RepositoryClientPolicy",
+    "RepositoryConnection",
+    "RepositoryContractError",
+    "compile_repository_target",
+    "decode_legacy_repository_history_v1",
+    "derive_repository_capabilities",
+    "reconcile_default_git_connection",
+    "resolve_default_git_credential",
+    "validate_connection_and_client",
+]

--- a/moonmind/workflows/executions/repository_contract.py
+++ b/moonmind/workflows/executions/repository_contract.py
@@ -39,6 +39,23 @@ class RepositoryBranch(BaseModel):
     name: str = Field(min_length=1, max_length=400)
 
 
+class ResolvedRepositoryRef(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    id: str = Field(min_length=1, max_length=2000)
+    name: str = Field(min_length=1, max_length=2000)
+
+
+class ResolvedRepositoryBranchRef(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    repository_id: str = Field(alias="repositoryId", min_length=1, max_length=2000)
+    id: str = Field(min_length=1, max_length=1000)
+    name: str = Field(min_length=1, max_length=400)
+
+
+class ResolvedWorkBranchRef(ResolvedRepositoryBranchRef):
+    origin: Literal["generated", "selected", "review_mapping", "historical_branch"]
+
+
 class GitRevision(BaseModel):
     model_config = ConfigDict(extra="forbid", frozen=True)
     kind: Literal["git_commit"]
@@ -96,6 +113,23 @@ class RepositoryClientEvidence(BaseModel):
     server_version: str | None = Field(None, alias="serverVersion")
 
 
+class RepositoryProjectionPolicy(BaseModel):
+    model_config = ConfigDict(populate_by_name=True, extra="forbid", frozen=True)
+    provider: Literal["github"]
+    repository: str = Field(min_length=1, max_length=2000)
+    authority: Literal["review_only"]
+    status_source_ref: str = Field(alias="statusSourceRef", min_length=1)
+
+
+class RepositoryMergeCoordinatorPolicy(BaseModel):
+    model_config = ConfigDict(populate_by_name=True, extra="forbid", frozen=True)
+    endpoint_ref: str = Field(alias="endpointRef", min_length=1)
+    policy_ref: str = Field(alias="policyRef", min_length=1)
+    supported_protocol_version: str = Field(
+        alias="supportedProtocolVersion", min_length=1
+    )
+
+
 class ResolvedRepositoryTarget(BaseModel):
     """Immutable repository identity observed at the pre-mutation boundary."""
 
@@ -105,13 +139,18 @@ class ResolvedRepositoryTarget(BaseModel):
     )
     provider: Literal["git", "lore"]
     connection_ref: str = Field(alias="connectionRef", min_length=1)
-    repository: RepositoryName
+    repository: ResolvedRepositoryRef
     prepared_revision: GitRevision | LoreRevision = Field(alias="preparedRevision")
-    prepared_branch: RepositoryBranch = Field(alias="preparedBranch")
-    base_branch: RepositoryBranch = Field(alias="baseBranch")
-    work_branch: RepositoryBranch = Field(alias="workBranch")
+    prepared_branch: ResolvedRepositoryBranchRef = Field(alias="preparedBranch")
+    base_branch: ResolvedRepositoryBranchRef = Field(alias="baseBranch")
+    work_branch: ResolvedWorkBranchRef | None = Field(None, alias="workBranch")
     remote_tip_expectation: dict[str, Any] = Field(alias="remoteTipExpectation")
     client_evidence: RepositoryClientEvidence = Field(alias="clientEvidence")
+    compatible_server_versions: tuple[str, ...] = Field(
+        default=(), alias="compatibleServerVersions"
+    )
+    authority: Literal["authoritative"] = "authoritative"
+    projection: RepositoryProjectionPolicy | None = None
 
 
 class RepositoryConnection(BaseModel):
@@ -123,6 +162,7 @@ class RepositoryConnection(BaseModel):
     provider: Literal["git", "lore"]
     display_name: str = Field(alias="displayName", min_length=1)
     endpoint_ref: str = Field(alias="endpointRef", min_length=1)
+    trust_bundle_ref: str | None = Field(None, alias="trustBundleRef", min_length=1)
     allowed_repository_ids: tuple[str, ...] = Field(
         default=(), alias="allowedRepositoryIds"
     )
@@ -138,9 +178,28 @@ class RepositoryConnection(BaseModel):
         ...,
     ] = Field(alias="allowedOperations")
     client_policy: RepositoryClientPolicy = Field(alias="clientPolicy")
+    projection: RepositoryProjectionPolicy | None = None
+    merge_coordinator: RepositoryMergeCoordinatorPolicy | None = Field(
+        None, alias="mergeCoordinator"
+    )
     credential_source: Literal[
         "github_resolver", "secret_ref", "trusted_network_development"
     ] = Field(alias="credentialSource")
+
+    @model_validator(mode="after")
+    def _validate_provider_policy(self) -> "RepositoryConnection":
+        if self.provider == "git" and (
+            self.projection is not None or self.merge_coordinator is not None
+        ):
+            raise ValueError("Lore projection and merge policy require provider=lore")
+        if (
+            self.merge_coordinator is not None
+            and "merge_request" not in self.allowed_operations
+        ):
+            raise ValueError(
+                "mergeCoordinator requires the merge_request operation"
+            )
+        return self
 
 
 def compile_repository_target(value: object) -> AuthoredRepositoryTarget:
@@ -246,7 +305,16 @@ def materialize_resolved_repository_target(
     *,
     observed_revision: str,
     evidence: RepositoryClientEvidence,
+    client_policy: RepositoryClientPolicy | None = None,
+    publish_mode: str = "none",
+    repository_id: str | None = None,
+    branch_id: str | None = None,
     work_branch: str | None = None,
+    work_branch_id: str | None = None,
+    work_branch_origin: Literal[
+        "generated", "selected", "review_mapping", "historical_branch"
+    ] | None = None,
+    projection: RepositoryProjectionPolicy | None = None,
 ) -> ResolvedRepositoryTarget:
     """Freeze exact repository and client observations for durable metadata."""
 
@@ -255,26 +323,66 @@ def materialize_resolved_repository_target(
         revision = GitRevision(kind="git_commit", commitSha=observed_revision)
     else:
         revision = LoreRevision(kind="lore_revision", revisionSignature=observed_revision)
+    resolved_repository_id = repository_id or target.repository.name
+    resolved_branch_id = branch_id or (
+        f"refs/heads/{target.branch.name}"
+        if target.provider == "git"
+        else target.branch.name
+    )
     expected_revision: dict[str, Any] = {
         "provider": target.provider,
-        "repositoryId": target.repository.name,
+        "repositoryId": resolved_repository_id,
     }
     if target.provider == "git":
         expected_revision["commitSha"] = observed_revision
     else:
         expected_revision["revisionSignature"] = observed_revision
-    expected = {"kind": "must_equal", "revision": expected_revision}
+    if target.revision is not None:
+        expected: dict[str, Any] = {"kind": "read_only"}
+        resolved_work_branch = None
+    elif work_branch_origin == "generated":
+        expected = {"kind": "must_not_exist"}
+        resolved_work_branch = ResolvedWorkBranchRef(
+            repositoryId=resolved_repository_id,
+            id=work_branch_id or work_branch or "",
+            name=work_branch or "",
+            origin="generated",
+        )
+    else:
+        expected = {"kind": "must_equal", "revision": expected_revision}
+        selected_work_branch = work_branch or (
+            target.branch.name if publish_mode in {"branch", "pr"} else None
+        )
+        resolved_work_branch = (
+            ResolvedWorkBranchRef(
+                repositoryId=resolved_repository_id,
+                id=work_branch_id or resolved_branch_id,
+                name=selected_work_branch,
+                origin=work_branch_origin or "selected",
+            )
+            if selected_work_branch
+            else None
+        )
+    resolved_branch = ResolvedRepositoryBranchRef(
+        repositoryId=resolved_repository_id,
+        id=resolved_branch_id,
+        name=target.branch.name,
+    )
     return ResolvedRepositoryTarget(
         schemaVersion="moonmind.resolved-repository-target.v1",
         provider=target.provider,
         connectionRef=target.connection_ref,
-        repository=target.repository,
+        repository={"id": resolved_repository_id, "name": target.repository.name},
         preparedRevision=revision,
-        preparedBranch=target.branch,
-        baseBranch=target.branch,
-        workBranch={"name": work_branch or target.branch.name},
+        preparedBranch=resolved_branch,
+        baseBranch=resolved_branch,
+        workBranch=resolved_work_branch,
         remoteTipExpectation=expected,
         clientEvidence=evidence,
+        compatibleServerVersions=(
+            client_policy.compatible_server_versions if client_policy else ()
+        ),
+        projection=projection,
     )
 
 

--- a/moonmind/workflows/executions/repository_contract.py
+++ b/moonmind/workflows/executions/repository_contract.py
@@ -18,6 +18,7 @@ LEGACY_REPOSITORY_DECODER_VERSION = "moonmind.repository-legacy-history.v1"
 REPOSITORY_CAPABILITY_UNKNOWN = "REPOSITORY_CAPABILITY_UNKNOWN"
 REPOSITORY_CONNECTION_MISMATCH = "REPOSITORY_CONNECTION_MISMATCH"
 REPOSITORY_CLIENT_MISMATCH = "REPOSITORY_CLIENT_MISMATCH"
+REPOSITORY_REMOTE_TIP_MISMATCH = "REPOSITORY_REMOTE_TIP_MISMATCH"
 
 
 class RepositoryContractError(ValueError):
@@ -233,6 +234,16 @@ def validate_connection_and_client(
 
 
 ReadinessCheck = Callable[[Mapping[str, Any]], bool | Awaitable[bool]]
+ConnectionResolver = Callable[
+    [AuthoredRepositoryTarget], RepositoryConnection | Awaitable[RepositoryConnection]
+]
+ClientEvidenceResolver = Callable[
+    [RepositoryConnection], RepositoryClientEvidence | Awaitable[RepositoryClientEvidence]
+]
+CredentialResolver = Callable[[str], object | Awaitable[object]]
+RemoteTipVerifier = Callable[
+    [AuthoredRepositoryTarget], bool | Awaitable[bool]
+]
 
 
 class CapabilityReadinessRegistry:
@@ -279,6 +290,67 @@ async def resolve_default_git_credential(repository: str) -> object:
     return await resolve_github_credential(repo=repository)
 
 
+async def _await_if_needed(value: Any) -> Any:
+    if hasattr(value, "__await__"):
+        return await value
+    return value
+
+
+async def ensure_repository_ready(
+    target: AuthoredRepositoryTarget,
+    *,
+    publish_mode: str,
+    operation: str,
+    skill_capabilities: Sequence[object] = (),
+    tool_capabilities: Sequence[object] = (),
+    connection_resolver: ConnectionResolver,
+    evidence_resolver: ClientEvidenceResolver,
+    readiness_registry: CapabilityReadinessRegistry,
+    credential_resolver: CredentialResolver = resolve_default_git_credential,
+    remote_tip_verifier: RemoteTipVerifier | None = None,
+) -> RepositoryConnection:
+    """Resolve and validate all repository authority before any side effect.
+
+    Callers must complete this composition boundary before workspace
+    preparation, runtime launch, or repository Tool execution.
+    """
+
+    connection = await _await_if_needed(connection_resolver(target))
+    evidence = await _await_if_needed(evidence_resolver(connection))
+    validate_connection_and_client(target, connection, evidence, operation=operation)
+
+    context = {
+        "target": target,
+        "connection": connection,
+        "clientEvidence": evidence,
+        "operation": operation,
+        "publishMode": publish_mode,
+    }
+    required = derive_repository_capabilities(
+        target,
+        publish_mode=publish_mode,
+        skill_capabilities=skill_capabilities,
+        tool_capabilities=tool_capabilities,
+    )
+    await readiness_registry.check(required, context)
+
+    if connection.credential_source == "github_resolver":
+        await _await_if_needed(credential_resolver(target.repository.name))
+
+    if operation != "read":
+        if remote_tip_verifier is None:
+            raise RepositoryContractError(
+                REPOSITORY_REMOTE_TIP_MISMATCH,
+                "repository mutation requires an observed remote-tip comparison",
+            )
+        if not await _await_if_needed(remote_tip_verifier(target)):
+            raise RepositoryContractError(
+                REPOSITORY_REMOTE_TIP_MISMATCH,
+                "observed remote tip does not match the expected provider revision",
+            )
+    return connection
+
+
 __all__ = [
     "AuthoredGitRepositoryTarget",
     "AuthoredLoreRepositoryTarget",
@@ -293,6 +365,7 @@ __all__ = [
     "compile_repository_target",
     "decode_legacy_repository_history_v1",
     "derive_repository_capabilities",
+    "ensure_repository_ready",
     "reconcile_default_git_connection",
     "resolve_default_git_credential",
     "validate_connection_and_client",

--- a/moonmind/workflows/executions/repository_contract.py
+++ b/moonmind/workflows/executions/repository_contract.py
@@ -15,6 +15,8 @@ from typing import Annotated, Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, TypeAdapter, model_validator
 
+from moonmind.schemas.manifest_models import SecretRef
+
 DEFAULT_GIT_CONNECTION_REF = "repository-connection:git-default"
 LEGACY_REPOSITORY_DECODER_VERSION = "moonmind.repository-legacy-history.v1"
 REPOSITORY_CAPABILITY_UNKNOWN = "REPOSITORY_CAPABILITY_UNKNOWN"
@@ -130,6 +132,30 @@ class RepositoryMergeCoordinatorPolicy(BaseModel):
     )
 
 
+class GitHubResolverCredential(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    source: Literal["github_resolver"]
+
+
+class SecretRefCredential(BaseModel):
+    model_config = ConfigDict(populate_by_name=True, extra="forbid", frozen=True)
+    source: Literal["secret_ref"]
+    credential_ref: SecretRef = Field(alias="credentialRef")
+
+
+class TrustedNetworkDevelopmentCredential(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    source: Literal["trusted_network_development"]
+
+
+RepositoryCredential = Annotated[
+    GitHubResolverCredential
+    | SecretRefCredential
+    | TrustedNetworkDevelopmentCredential,
+    Field(discriminator="source"),
+]
+
+
 class ResolvedRepositoryTarget(BaseModel):
     """Immutable repository identity observed at the pre-mutation boundary."""
 
@@ -182,12 +208,19 @@ class RepositoryConnection(BaseModel):
     merge_coordinator: RepositoryMergeCoordinatorPolicy | None = Field(
         None, alias="mergeCoordinator"
     )
-    credential_source: Literal[
-        "github_resolver", "secret_ref", "trusted_network_development"
-    ] = Field(alias="credentialSource")
+    credential: RepositoryCredential
 
     @model_validator(mode="after")
     def _validate_provider_policy(self) -> "RepositoryConnection":
+        if (
+            self.provider == "git"
+            and self.credential.source == "trusted_network_development"
+        ):
+            raise ValueError("Git connections do not support trusted-network credentials")
+        if self.provider == "lore" and self.credential.source == "github_resolver":
+            raise ValueError(
+                "Lore connections do not support GitHub resolver credentials"
+            )
         if self.provider == "git" and (
             self.projection is not None or self.merge_coordinator is not None
         ):
@@ -266,7 +299,7 @@ def reconcile_default_git_connection(
         endpointRef="https://github.com",
         allowedOperations=("read", "write", "branch_write", "review_request"),
         clientPolicy=client_policy,
-        credentialSource="github_resolver",
+        credential={"source": "github_resolver"},
     )
 
 
@@ -529,7 +562,7 @@ async def ensure_repository_ready(
     )
     await readiness_registry.check(required, context)
 
-    if connection.credential_source == "github_resolver":
+    if connection.credential.source == "github_resolver":
         await _await_if_needed(credential_resolver(target.repository.name))
 
     if operation != "read":
@@ -555,6 +588,7 @@ __all__ = [
     "LEGACY_REPOSITORY_DECODER_VERSION",
     "RepositoryClientEvidence",
     "RepositoryClientPolicy",
+    "RepositoryCredential",
     "RepositoryConnection",
     "RepositoryContractError",
     "ResolvedRepositoryTarget",

--- a/moonmind/workflows/executions/repository_contract.py
+++ b/moonmind/workflows/executions/repository_contract.py
@@ -9,6 +9,8 @@ drift across authoring and runtime code.
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable, Mapping, Sequence
+import json
+from pathlib import Path
 from typing import Annotated, Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, TypeAdapter, model_validator
@@ -92,6 +94,24 @@ class RepositoryClientEvidence(BaseModel):
     client_version: str = Field(alias="clientVersion", min_length=1)
     executable_sha256: str = Field(alias="executableSha256", min_length=1)
     server_version: str | None = Field(None, alias="serverVersion")
+
+
+class ResolvedRepositoryTarget(BaseModel):
+    """Immutable repository identity observed at the pre-mutation boundary."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid", frozen=True)
+    schema_version: Literal["moonmind.resolved-repository-target.v1"] = Field(
+        alias="schemaVersion"
+    )
+    provider: Literal["git", "lore"]
+    connection_ref: str = Field(alias="connectionRef", min_length=1)
+    repository: RepositoryName
+    prepared_revision: GitRevision | LoreRevision = Field(alias="preparedRevision")
+    prepared_branch: RepositoryBranch = Field(alias="preparedBranch")
+    base_branch: RepositoryBranch = Field(alias="baseBranch")
+    work_branch: RepositoryBranch = Field(alias="workBranch")
+    remote_tip_expectation: dict[str, Any] = Field(alias="remoteTipExpectation")
+    client_evidence: RepositoryClientEvidence = Field(alias="clientEvidence")
 
 
 class RepositoryConnection(BaseModel):
@@ -188,6 +208,73 @@ def reconcile_default_git_connection(
         allowedOperations=("read", "write", "branch_write", "review_request"),
         clientPolicy=client_policy,
         credentialSource="github_resolver",
+    )
+
+
+def persist_repository_connection(connection: RepositoryConnection, path: Path) -> None:
+    """Atomically reconcile one deployment-owned connection record."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    temporary.write_text(
+        json.dumps(connection.model_dump(by_alias=True, mode="json"), sort_keys=True),
+        encoding="utf-8",
+    )
+    temporary.replace(path)
+
+
+def load_repository_connection(path: Path, connection_ref: str) -> RepositoryConnection:
+    """Resolve a previously reconciled connection; never synthesize at launch."""
+
+    try:
+        connection = RepositoryConnection.model_validate_json(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        raise RepositoryContractError(
+            "REPOSITORY_CONNECTION_UNAVAILABLE",
+            f"deployment-owned repository connection {connection_ref!r} is unavailable",
+        ) from exc
+    if connection.id != connection_ref:
+        raise RepositoryContractError(
+            "REPOSITORY_CONNECTION_UNAVAILABLE",
+            f"stored repository connection does not match {connection_ref!r}",
+        )
+    return connection
+
+
+def materialize_resolved_repository_target(
+    target: AuthoredRepositoryTarget,
+    *,
+    observed_revision: str,
+    evidence: RepositoryClientEvidence,
+    work_branch: str | None = None,
+) -> ResolvedRepositoryTarget:
+    """Freeze exact repository and client observations for durable metadata."""
+
+    revision: GitRevision | LoreRevision
+    if target.provider == "git":
+        revision = GitRevision(kind="git_commit", commitSha=observed_revision)
+    else:
+        revision = LoreRevision(kind="lore_revision", revisionSignature=observed_revision)
+    expected_revision: dict[str, Any] = {
+        "provider": target.provider,
+        "repositoryId": target.repository.name,
+    }
+    if target.provider == "git":
+        expected_revision["commitSha"] = observed_revision
+    else:
+        expected_revision["revisionSignature"] = observed_revision
+    expected = {"kind": "must_equal", "revision": expected_revision}
+    return ResolvedRepositoryTarget(
+        schemaVersion="moonmind.resolved-repository-target.v1",
+        provider=target.provider,
+        connectionRef=target.connection_ref,
+        repository=target.repository,
+        preparedRevision=revision,
+        preparedBranch=target.branch,
+        baseBranch=target.branch,
+        workBranch={"name": work_branch or target.branch.name},
+        remoteTipExpectation=expected,
+        clientEvidence=evidence,
     )
 
 
@@ -362,10 +449,14 @@ __all__ = [
     "RepositoryClientPolicy",
     "RepositoryConnection",
     "RepositoryContractError",
+    "ResolvedRepositoryTarget",
     "compile_repository_target",
     "decode_legacy_repository_history_v1",
     "derive_repository_capabilities",
     "ensure_repository_ready",
+    "load_repository_connection",
+    "materialize_resolved_repository_target",
+    "persist_repository_connection",
     "reconcile_default_git_connection",
     "resolve_default_git_credential",
     "validate_connection_and_client",

--- a/moonmind/workflows/executions/repository_contract.py
+++ b/moonmind/workflows/executions/repository_contract.py
@@ -439,7 +439,8 @@ def validate_connection_and_client(
             f"connection does not allow operation {operation!r}",
         )
     if (
-        connection.allowed_repository_ids
+        target.provider == "git"
+        and connection.allowed_repository_ids
         and target.repository.name not in connection.allowed_repository_ids
     ):
         raise RepositoryContractError(

--- a/moonmind/workflows/temporal/runtime/launcher.py
+++ b/moonmind/workflows/temporal/runtime/launcher.py
@@ -77,17 +77,6 @@ LoreRepositoryReadinessAdapter = Callable[
     Awaitable[ResolvedRepositoryTarget],
 ]
 
-_DEFAULT_REPOSITORY_CONNECTION_PATH = Path(
-    os.environ.get(
-        "MOONMIND_REPOSITORY_CONNECTION_PATH",
-        os.path.join(
-            os.environ.get("MOONMIND_AGENT_RUNTIME_STORE", "/work/agent_jobs"),
-            "repository_connections",
-            "git-default.json",
-        ),
-    )
-)
-
 _LIVE_LOG_SPOOL_FILENAME = "live_streams.spool"
 _MODEL_TIER_DIAGNOSTIC_STRING_LIMIT = 1024
 _MODEL_TIER_DIAGNOSTIC_FIELDS = (

--- a/moonmind/workflows/temporal/runtime/launcher.py
+++ b/moonmind/workflows/temporal/runtime/launcher.py
@@ -26,12 +26,17 @@ from moonmind.schemas.agent_runtime_models import (
 from moonmind.workflows.executions.repository_contract import (
     CapabilityReadinessRegistry,
     DEFAULT_GIT_CONNECTION_REF,
+    REPOSITORY_REMOTE_TIP_MISMATCH,
     RepositoryClientEvidence,
     RepositoryClientPolicy,
     RepositoryConnection,
     RepositoryContractError,
+    ResolvedRepositoryTarget,
     compile_repository_target,
     ensure_repository_ready,
+    load_repository_connection,
+    materialize_resolved_repository_target,
+    persist_repository_connection,
     reconcile_default_git_connection,
 )
 from moonmind.utils.logging import SecretRedactor, redact_sensitive_text
@@ -62,6 +67,17 @@ _MANAGED_RUNTIME_ATLASSIAN_ENV_PREFIX_BLOCKLIST: frozenset[str] = frozenset(
 )
 
 logger = logging.getLogger(__name__)
+
+_DEFAULT_REPOSITORY_CONNECTION_PATH = Path(
+    os.environ.get(
+        "MOONMIND_REPOSITORY_CONNECTION_PATH",
+        os.path.join(
+            os.environ.get("MOONMIND_AGENT_RUNTIME_STORE", "/work/agent_jobs"),
+            "repository_connections",
+            "git-default.json",
+        ),
+    )
+)
 
 _LIVE_LOG_SPOOL_FILENAME = "live_streams.spool"
 _MODEL_TIER_DIAGNOSTIC_STRING_LIMIT = 1024
@@ -166,6 +182,22 @@ def resolve_deployment_git_client_policy() -> RepositoryClientPolicy:
     )
 
 
+def reconcile_deployment_git_connection(
+    path: Path = _DEFAULT_REPOSITORY_CONNECTION_PATH,
+) -> RepositoryConnection:
+    """Persist the worker deployment's default Git connection at startup."""
+
+    connection = reconcile_default_git_connection(
+        client_policy=resolve_deployment_git_client_policy()
+    )
+    persist_repository_connection(connection, path)
+    return connection
+
+
+def default_repository_connection_path() -> Path:
+    return _DEFAULT_REPOSITORY_CONNECTION_PATH
+
+
 def _compact_string(value: Any) -> str:
     normalized = str(value or "").strip()
     if not normalized:
@@ -263,17 +295,28 @@ class ManagedRuntimeLauncher:
         log_streamer: RuntimeLogStreamer | None = None,
         artifact_service: Any | None = None,
         repository_readiness_boundary: Callable[
-            [AgentExecutionRequest, Mapping[str, str] | None], Awaitable[None]
+            [AgentExecutionRequest, Mapping[str, str] | None],
+            Awaitable[ResolvedRepositoryTarget | None],
         ]
         | None = None,
         repository_client_policy: RepositoryClientPolicy | None = None,
-    ) -> None:
+    ) -> ResolvedRepositoryTarget | None:
         self._store = store
         self._logger = logging.getLogger(__name__)
         self._github_auth_brokers = GitHubAuthBrokerManager()
         self._log_streamer = log_streamer
         self._artifact_service = artifact_service
         self._repository_client_policy = repository_client_policy
+        if repository_client_policy is not None:
+            # Worker construction is a deployment startup boundary. Reconcile
+            # durably here as well as in the worker factory so alternate worker
+            # entrypoints cannot launch against an ephemeral connection object.
+            persist_repository_connection(
+                reconcile_default_git_connection(
+                    client_policy=repository_client_policy
+                ),
+                _DEFAULT_REPOSITORY_CONNECTION_PATH,
+            )
         self._repository_readiness_boundary = (
             repository_readiness_boundary or self._ensure_repository_ready_for_launch
         )
@@ -343,7 +386,7 @@ class ManagedRuntimeLauncher:
         raw_target = workspace_spec.get("repositoryTarget")
         if raw_target is None:
             # Recorded legacy requests continue through their frozen history path.
-            return
+            return None
         target = compile_repository_target(raw_target)
         if (
             target.provider != "git"
@@ -355,14 +398,9 @@ class ManagedRuntimeLauncher:
                 "the selected connection",
             )
 
-        if self._repository_client_policy is None:
-            raise RepositoryContractError(
-                "REPOSITORY_CONNECTION_UNAVAILABLE",
-                "the default Git connection has no deployment-owned client policy",
-            )
         observed = await self._observe_git_client()
-        connection = reconcile_default_git_connection(
-            client_policy=self._repository_client_policy
+        connection = load_repository_connection(
+            _DEFAULT_REPOSITORY_CONNECTION_PATH, target.connection_ref
         )
         registry = CapabilityReadinessRegistry(
             runtime_owned_tokens=(
@@ -461,6 +499,27 @@ class ManagedRuntimeLauncher:
             evidence_resolver=resolve_evidence,
             readiness_registry=registry,
             remote_tip_verifier=verify_remote_tip,
+        )
+        observed_revision = (
+            target.revision.commit_sha
+            if target.revision is not None
+            else expected_remote_tip
+        )
+        if not observed_revision:
+            observed_revision = await self._observe_git_remote_tip(
+                repository=target.repository.name,
+                branch=target.branch.name,
+                git_env=git_env,
+            )
+        if not observed_revision:
+            raise RepositoryContractError(
+                REPOSITORY_REMOTE_TIP_MISMATCH,
+                "repository readiness did not observe an immutable prepared revision",
+            )
+        return materialize_resolved_repository_target(
+            target,
+            observed_revision=observed_revision,
+            evidence=observed,
         )
 
     @staticmethod
@@ -1581,7 +1640,13 @@ class ManagedRuntimeLauncher:
             if launch_github_token
             else None
         )
-        await self._repository_readiness_boundary(request, git_host_env)
+        resolved_repository = await self._repository_readiness_boundary(
+            request, git_host_env
+        )
+        if resolved_repository is not None:
+            request.workspace_spec["resolvedRepositoryTarget"] = (
+                resolved_repository.model_dump(by_alias=True, mode="json")
+            )
         resolved_workspace_path = await self._prepare_workspace_path(
             run_id=run_id,
             request=request,
@@ -1991,6 +2056,11 @@ class ManagedRuntimeLauncher:
             pid=process.pid,
             started_at=datetime.now(tz=UTC),
             workspace_path=resolved_workspace_path,
+            resolvedRepositoryTarget=(
+                resolved_repository.model_dump(by_alias=True, mode="json")
+                if resolved_repository is not None
+                else None
+            ),
             live_stream_capable=bool(resolved_workspace_path),
         )
         self._store.save(record)

--- a/moonmind/workflows/temporal/runtime/launcher.py
+++ b/moonmind/workflows/temporal/runtime/launcher.py
@@ -10,7 +10,7 @@ import re
 import shlex
 import shutil
 import stat
-from collections.abc import Mapping
+from collections.abc import Awaitable, Callable, Mapping
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -21,6 +21,17 @@ from moonmind.schemas.agent_runtime_models import (
     ManagedRunRecord,
     ManagedRuntimeProfile,
     TERMINAL_AGENT_RUN_STATES,
+)
+from moonmind.workflows.executions.repository_contract import (
+    CapabilityReadinessRegistry,
+    DEFAULT_GIT_CONNECTION_REF,
+    RepositoryClientEvidence,
+    RepositoryClientPolicy,
+    RepositoryConnection,
+    RepositoryContractError,
+    compile_repository_target,
+    ensure_repository_ready,
+    reconcile_default_git_connection,
 )
 from moonmind.utils.logging import SecretRedactor, redact_sensitive_text
 from moonmind.workflows.skills.run_projection import (
@@ -220,12 +231,176 @@ class ManagedRuntimeLauncher:
         store: ManagedRunStore,
         log_streamer: RuntimeLogStreamer | None = None,
         artifact_service: Any | None = None,
+        repository_readiness_boundary: Callable[
+            [AgentExecutionRequest, Mapping[str, str] | None], Awaitable[None]
+        ]
+        | None = None,
     ) -> None:
         self._store = store
         self._logger = logging.getLogger(__name__)
         self._github_auth_brokers = GitHubAuthBrokerManager()
         self._log_streamer = log_streamer
         self._artifact_service = artifact_service
+        self._repository_client_policy: RepositoryClientPolicy | None = None
+        self._repository_readiness_boundary = (
+            repository_readiness_boundary or self._ensure_repository_ready_for_launch
+        )
+
+    async def _observe_git_client(self) -> RepositoryClientEvidence:
+        executable = shutil.which("git")
+        if not executable:
+            raise RepositoryContractError(
+                "REPOSITORY_CLIENT_UNAVAILABLE",
+                "the Git executable is unavailable at the runtime launch boundary",
+            )
+        executable_path = Path(executable).resolve()
+        digest = hashlib.sha256(executable_path.read_bytes()).hexdigest()
+        returncode, stdout_text, stderr_text = await self._run_command(
+            str(executable_path), "--version"
+        )
+        if returncode != 0:
+            raise RepositoryContractError(
+                "REPOSITORY_CLIENT_UNAVAILABLE",
+                (stderr_text or stdout_text or "git --version failed").strip(),
+            )
+        version_text = stdout_text.strip()
+        version = version_text.removeprefix("git version ").strip()
+        if not version:
+            raise RepositoryContractError(
+                "REPOSITORY_CLIENT_UNAVAILABLE",
+                "git --version returned no version identity",
+            )
+        return RepositoryClientEvidence(
+            toolBundleRef="repository-client:git-system",
+            clientVersion=version,
+            executableSha256=f"sha256:{digest}",
+        )
+
+    async def _observe_git_remote_tip(
+        self,
+        *,
+        repository: str,
+        branch: str,
+        git_env: Mapping[str, str] | None,
+    ) -> str | None:
+        source = self._resolve_repository_source(repository)
+        if source is None:
+            return None
+        returncode, stdout_text, _stderr_text = await self._run_command(
+            "git",
+            "ls-remote",
+            source,
+            f"refs/heads/{self._normalize_clone_branch(branch) or branch}",
+            env=dict(git_env) if git_env is not None else None,
+        )
+        if returncode != 0:
+            return None
+        first_line = next(
+            (line for line in stdout_text.splitlines() if line.strip()), ""
+        )
+        return first_line.split(maxsplit=1)[0] if first_line else None
+
+    async def _ensure_repository_ready_for_launch(
+        self,
+        request: AgentExecutionRequest,
+        git_env: Mapping[str, str] | None,
+    ) -> None:
+        """Enforce the provider readiness contract before checkout or launch."""
+
+        workspace_spec = request.workspace_spec
+        raw_target = workspace_spec.get("repositoryTarget")
+        if raw_target is None:
+            # Recorded legacy requests continue through their frozen history path.
+            return
+        target = compile_repository_target(raw_target)
+        if (
+            target.provider != "git"
+            or target.connection_ref != DEFAULT_GIT_CONNECTION_REF
+        ):
+            raise RepositoryContractError(
+                "REPOSITORY_CONNECTION_UNAVAILABLE",
+                "the managed-runtime launch boundary has no ready adapter for "
+                "the selected connection",
+            )
+
+        observed = await self._observe_git_client()
+        if self._repository_client_policy is None:
+            self._repository_client_policy = RepositoryClientPolicy(
+                pinnedVersion=observed.client_version,
+                toolBundleRef=observed.tool_bundle_ref,
+                executableSha256=observed.executable_sha256,
+            )
+        connection = reconcile_default_git_connection(
+            client_policy=self._repository_client_policy
+        )
+        registry = CapabilityReadinessRegistry()
+        for token in (
+            "git",
+            "gh",
+            "repo.read",
+            "repo.write",
+            "repo.branch.write",
+            "repo.review.request",
+            "repo.lock",
+            "artifact.read",
+            "artifact.write",
+            "jira",
+            "docker",
+            "container.run",
+        ):
+            registry.register(token, lambda _context: True)
+
+        parameters = (
+            request.parameters if isinstance(request.parameters, Mapping) else {}
+        )
+        publish_mode = str(parameters.get("publishMode") or "none").strip().lower()
+        operation = "write" if publish_mode in {"branch", "pr"} else "read"
+        skill_caps = (
+            request.skill.get("requiredCapabilities", ())
+            if isinstance(request.skill, Mapping)
+            else ()
+        )
+        tool_caps = parameters.get("repositoryToolCapabilities", ())
+        if not isinstance(skill_caps, (list, tuple)):
+            skill_caps = ()
+        if not isinstance(tool_caps, (list, tuple)):
+            tool_caps = ()
+
+        expected_remote_tip: str | None = None
+        if operation != "read":
+            expected_remote_tip = await self._observe_git_remote_tip(
+                repository=target.repository.name,
+                branch=target.branch.name,
+                git_env=git_env,
+            )
+
+        async def resolve_connection(_target: object) -> RepositoryConnection:
+            return connection
+
+        async def resolve_evidence(_connection: object) -> RepositoryClientEvidence:
+            return observed
+
+        async def verify_remote_tip(_target: object) -> bool:
+            if expected_remote_tip is None:
+                return False
+            current = await self._observe_git_remote_tip(
+                repository=target.repository.name,
+                branch=target.branch.name,
+                git_env=git_env,
+            )
+            return current == expected_remote_tip
+
+        await ensure_repository_ready(
+            target,
+            publish_mode=publish_mode,
+            operation=operation,
+            skill_capabilities=skill_caps,
+            tool_capabilities=tool_caps,
+            connection_resolver=resolve_connection,
+            evidence_resolver=resolve_evidence,
+            readiness_registry=registry,
+            remote_tip_verifier=verify_remote_tip,
+        )
 
     @staticmethod
     def _build_managed_runtime_base_env() -> dict[str, str]:
@@ -1345,6 +1520,7 @@ class ManagedRuntimeLauncher:
             if launch_github_token
             else None
         )
+        await self._repository_readiness_boundary(request, git_host_env)
         resolved_workspace_path = await self._prepare_workspace_path(
             run_id=run_id,
             request=request,

--- a/moonmind/workflows/temporal/runtime/launcher.py
+++ b/moonmind/workflows/temporal/runtime/launcher.py
@@ -475,7 +475,7 @@ class ManagedRuntimeLauncher:
             "gh",
             lambda context: (
                 context["target"].provider == "git"
-                and context["connection"].credential_source == "github_resolver"
+                and context["connection"].credential.source == "github_resolver"
                 and context["publishMode"] == "pr"
             ),
         )

--- a/moonmind/workflows/temporal/runtime/launcher.py
+++ b/moonmind/workflows/temporal/runtime/launcher.py
@@ -14,7 +14,7 @@ import subprocess
 from collections.abc import Awaitable, Callable, Mapping
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal, cast
 
 from moonmind.schemas.agent_runtime_models import (
     AgentExecutionRequest,
@@ -24,6 +24,7 @@ from moonmind.schemas.agent_runtime_models import (
     TERMINAL_AGENT_RUN_STATES,
 )
 from moonmind.workflows.executions.repository_contract import (
+    AuthoredLoreRepositoryTarget,
     CapabilityReadinessRegistry,
     DEFAULT_GIT_CONNECTION_REF,
     REPOSITORY_REMOTE_TIP_MISMATCH,
@@ -67,6 +68,11 @@ _MANAGED_RUNTIME_ATLASSIAN_ENV_PREFIX_BLOCKLIST: frozenset[str] = frozenset(
 )
 
 logger = logging.getLogger(__name__)
+
+LoreRepositoryReadinessAdapter = Callable[
+    [AuthoredLoreRepositoryTarget, AgentExecutionRequest],
+    Awaitable[ResolvedRepositoryTarget],
+]
 
 _DEFAULT_REPOSITORY_CONNECTION_PATH = Path(
     os.environ.get(
@@ -300,13 +306,15 @@ class ManagedRuntimeLauncher:
         ]
         | None = None,
         repository_client_policy: RepositoryClientPolicy | None = None,
-    ) -> ResolvedRepositoryTarget | None:
+        lore_repository_adapter: LoreRepositoryReadinessAdapter | None = None,
+    ) -> None:
         self._store = store
         self._logger = logging.getLogger(__name__)
         self._github_auth_brokers = GitHubAuthBrokerManager()
         self._log_streamer = log_streamer
         self._artifact_service = artifact_service
         self._repository_client_policy = repository_client_policy
+        self._lore_repository_adapter = lore_repository_adapter
         if repository_client_policy is not None:
             # Worker construction is a deployment startup boundary. Reconcile
             # durably here as well as in the worker factory so alternate worker
@@ -388,10 +396,33 @@ class ManagedRuntimeLauncher:
             # Recorded legacy requests continue through their frozen history path.
             return None
         target = compile_repository_target(raw_target)
-        if (
-            target.provider != "git"
-            or target.connection_ref != DEFAULT_GIT_CONNECTION_REF
-        ):
+        if target.provider == "lore":
+            if self._lore_repository_adapter is None:
+                raise RepositoryContractError(
+                    "LORE_CONNECTION_NOT_READY",
+                    "the selected Lore connection has no configured managed-runtime "
+                    "readiness adapter",
+                )
+            resolved = await self._lore_repository_adapter(target, request)
+            if (
+                resolved.provider != "lore"
+                or resolved.connection_ref != target.connection_ref
+                or resolved.repository.name != target.repository.name
+                or (
+                    target.revision is not None
+                    and getattr(
+                        resolved.prepared_revision, "revision_signature", None
+                    )
+                    != target.revision.revision_signature
+                )
+            ):
+                raise RepositoryContractError(
+                    "LORE_CONNECTION_NOT_READY",
+                    "the Lore adapter returned repository authority that does not "
+                    "match the authored target",
+                )
+            return resolved
+        if target.connection_ref != DEFAULT_GIT_CONNECTION_REF:
             raise RepositoryContractError(
                 "REPOSITORY_CONNECTION_UNAVAILABLE",
                 "the managed-runtime launch boundary has no ready adapter for "
@@ -464,6 +495,29 @@ class ManagedRuntimeLauncher:
             skill_caps = ()
         if not isinstance(tool_caps, (list, tuple)):
             tool_caps = ()
+        work_branch_origin_raw = str(
+            parameters.get("workBranchOrigin") or ""
+        ).strip().lower()
+        allowed_work_branch_origins = {
+            "generated",
+            "selected",
+            "review_mapping",
+            "historical_branch",
+        }
+        if work_branch_origin_raw and (
+            work_branch_origin_raw not in allowed_work_branch_origins
+        ):
+            raise RepositoryContractError(
+                "REPOSITORY_TARGET_INVALID",
+                f"unsupported work branch origin {work_branch_origin_raw!r}",
+            )
+        work_branch_origin = cast(
+            Literal[
+                "generated", "selected", "review_mapping", "historical_branch"
+            ]
+            | None,
+            work_branch_origin_raw or None,
+        )
 
         expected_remote_tip: str | None = None
         if operation != "read":
@@ -520,6 +574,16 @@ class ManagedRuntimeLauncher:
             target,
             observed_revision=observed_revision,
             evidence=observed,
+            client_policy=connection.client_policy,
+            publish_mode=publish_mode,
+            work_branch=(
+                str(parameters.get("workBranch") or "").strip() or None
+            ),
+            work_branch_id=(
+                str(parameters.get("workBranchId") or "").strip() or None
+            ),
+            work_branch_origin=work_branch_origin,
+            projection=connection.projection,
         )
 
     @staticmethod

--- a/moonmind/workflows/temporal/runtime/launcher.py
+++ b/moonmind/workflows/temporal/runtime/launcher.py
@@ -10,6 +10,7 @@ import re
 import shlex
 import shutil
 import stat
+import subprocess
 from collections.abc import Awaitable, Callable, Mapping
 from datetime import UTC, datetime
 from pathlib import Path
@@ -135,6 +136,36 @@ _SECRET_LIKE_PATTERN = re.compile(
 )
 
 
+def resolve_deployment_git_client_policy() -> RepositoryClientPolicy:
+    """Pin the worker deployment's Git client independently of launch evidence."""
+
+    executable = shutil.which("git")
+    if not executable:
+        raise RepositoryContractError(
+            "REPOSITORY_CLIENT_UNAVAILABLE",
+            "the Git executable is unavailable during worker reconciliation",
+        )
+    executable_path = Path(executable).resolve()
+    completed = subprocess.run(
+        (str(executable_path), "--version"),
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    version = completed.stdout.strip().removeprefix("git version ").strip()
+    if completed.returncode != 0 or not version:
+        raise RepositoryContractError(
+            "REPOSITORY_CLIENT_UNAVAILABLE",
+            "the worker could not reconcile its deployment Git client policy",
+        )
+    digest = hashlib.sha256(executable_path.read_bytes()).hexdigest()
+    return RepositoryClientPolicy(
+        pinnedVersion=version,
+        toolBundleRef="repository-client:git-system",
+        executableSha256=f"sha256:{digest}",
+    )
+
+
 def _compact_string(value: Any) -> str:
     normalized = str(value or "").strip()
     if not normalized:
@@ -235,13 +266,14 @@ class ManagedRuntimeLauncher:
             [AgentExecutionRequest, Mapping[str, str] | None], Awaitable[None]
         ]
         | None = None,
+        repository_client_policy: RepositoryClientPolicy | None = None,
     ) -> None:
         self._store = store
         self._logger = logging.getLogger(__name__)
         self._github_auth_brokers = GitHubAuthBrokerManager()
         self._log_streamer = log_streamer
         self._artifact_service = artifact_service
-        self._repository_client_policy: RepositoryClientPolicy | None = None
+        self._repository_client_policy = repository_client_policy
         self._repository_readiness_boundary = (
             repository_readiness_boundary or self._ensure_repository_ready_for_launch
         )
@@ -323,32 +355,61 @@ class ManagedRuntimeLauncher:
                 "the selected connection",
             )
 
-        observed = await self._observe_git_client()
         if self._repository_client_policy is None:
-            self._repository_client_policy = RepositoryClientPolicy(
-                pinnedVersion=observed.client_version,
-                toolBundleRef=observed.tool_bundle_ref,
-                executableSha256=observed.executable_sha256,
+            raise RepositoryContractError(
+                "REPOSITORY_CONNECTION_UNAVAILABLE",
+                "the default Git connection has no deployment-owned client policy",
             )
+        observed = await self._observe_git_client()
         connection = reconcile_default_git_connection(
             client_policy=self._repository_client_policy
         )
-        registry = CapabilityReadinessRegistry()
-        for token in (
-            "git",
-            "gh",
+        registry = CapabilityReadinessRegistry(
+            runtime_owned_tokens=(
+                "artifact.read",
+                "artifact.write",
+                "jira",
+                "docker",
+                "container.run",
+            )
+        )
+
+        def git_ready(context: Mapping[str, Any]) -> bool:
+            selected = context["target"]
+            client = context["clientEvidence"]
+            return (
+                selected.provider == "git"
+                and client.tool_bundle_ref == connection.client_policy.tool_bundle_ref
+                and client.client_version == connection.client_policy.pinned_version
+                and client.executable_sha256
+                == connection.client_policy.executable_sha256
+            )
+
+        def operation_ready(operation_name: str) -> Callable[[Mapping[str, Any]], bool]:
+            return lambda context: (
+                context["operation"] == "write"
+                and operation_name in context["connection"].allowed_operations
+            )
+
+        registry.register("git", git_ready)
+        registry.register(
             "repo.read",
-            "repo.write",
-            "repo.branch.write",
-            "repo.review.request",
-            "repo.lock",
-            "artifact.read",
-            "artifact.write",
-            "jira",
-            "docker",
-            "container.run",
-        ):
-            registry.register(token, lambda _context: True)
+            lambda context: "read" in context["connection"].allowed_operations,
+        )
+        registry.register("repo.write", operation_ready("write"))
+        registry.register("repo.branch.write", operation_ready("branch_write"))
+        registry.register("repo.lock", operation_ready("lock"))
+        registry.register(
+            "repo.review.request", operation_ready("review_request")
+        )
+        registry.register(
+            "gh",
+            lambda context: (
+                context["target"].provider == "git"
+                and context["connection"].credential_source == "github_resolver"
+                and context["publishMode"] == "pr"
+            ),
+        )
 
         parameters = (
             request.parameters if isinstance(request.parameters, Mapping) else {}

--- a/moonmind/workflows/temporal/runtime/launcher.py
+++ b/moonmind/workflows/temporal/runtime/launcher.py
@@ -191,20 +191,35 @@ def resolve_deployment_git_client_policy() -> RepositoryClientPolicy:
     )
 
 
+def _current_default_repository_connection_path() -> Path:
+    return Path(
+        os.environ.get(
+            "MOONMIND_REPOSITORY_CONNECTION_PATH",
+            os.path.join(
+                os.environ.get("MOONMIND_AGENT_RUNTIME_STORE", "/work/agent_jobs"),
+                "repository_connections",
+                "git-default.json",
+            ),
+        )
+    )
+
+
 def reconcile_deployment_git_connection(
-    path: Path = _DEFAULT_REPOSITORY_CONNECTION_PATH,
+    path: Path | None = None,
 ) -> RepositoryConnection:
     """Persist the worker deployment's default Git connection at startup."""
 
     connection = reconcile_default_git_connection(
         client_policy=resolve_deployment_git_client_policy()
     )
-    persist_repository_connection(connection, path)
+    persist_repository_connection(
+        connection, path or _current_default_repository_connection_path()
+    )
     return connection
 
 
 def default_repository_connection_path() -> Path:
-    return _DEFAULT_REPOSITORY_CONNECTION_PATH
+    return _current_default_repository_connection_path()
 
 
 def _compact_string(value: Any) -> str:
@@ -339,7 +354,7 @@ class ManagedRuntimeLauncher:
                 reconcile_default_git_connection(
                     client_policy=repository_client_policy
                 ),
-                _DEFAULT_REPOSITORY_CONNECTION_PATH,
+                _current_default_repository_connection_path(),
             )
         self._repository_readiness_boundary = (
             repository_readiness_boundary or self._ensure_repository_ready_for_launch
@@ -445,12 +460,12 @@ class ManagedRuntimeLauncher:
                     "REPOSITORY_CONNECTION_UNAVAILABLE",
                     "the current deployment Git client policy was not supplied",
                 )
-            connection_path = _DEFAULT_REPOSITORY_CONNECTION_PATH
+            connection_path = _current_default_repository_connection_path()
         else:
             connections_dir = Path(
                 os.environ.get(
                     "MOONMIND_REPOSITORY_CONNECTIONS_DIR",
-                    str(_DEFAULT_REPOSITORY_CONNECTION_PATH.parent),
+                    str(_current_default_repository_connection_path().parent),
                 )
             )
             connection_path = next(

--- a/moonmind/workflows/temporal/runtime/launcher.py
+++ b/moonmind/workflows/temporal/runtime/launcher.py
@@ -354,7 +354,9 @@ class ManagedRuntimeLauncher:
                 reconcile_default_git_connection(
                     client_policy=repository_client_policy
                 ),
-                _current_default_repository_connection_path(),
+                self._store.store_root.parent
+                / "repository_connections"
+                / "git-default.json",
             )
         self._repository_readiness_boundary = (
             repository_readiness_boundary or self._ensure_repository_ready_for_launch
@@ -460,12 +462,16 @@ class ManagedRuntimeLauncher:
                     "REPOSITORY_CONNECTION_UNAVAILABLE",
                     "the current deployment Git client policy was not supplied",
                 )
-            connection_path = _current_default_repository_connection_path()
+            connection_path = (
+                self._store.store_root.parent
+                / "repository_connections"
+                / "git-default.json"
+            )
         else:
             connections_dir = Path(
                 os.environ.get(
                     "MOONMIND_REPOSITORY_CONNECTIONS_DIR",
-                    str(_current_default_repository_connection_path().parent),
+                    str(self._store.store_root.parent / "repository_connections"),
                 )
             )
             connection_path = next(

--- a/moonmind/workflows/temporal/runtime/launcher.py
+++ b/moonmind/workflows/temporal/runtime/launcher.py
@@ -422,16 +422,38 @@ class ManagedRuntimeLauncher:
                     "match the authored target",
                 )
             return resolved
-        if target.connection_ref != DEFAULT_GIT_CONNECTION_REF:
+
+        if target.connection_ref == DEFAULT_GIT_CONNECTION_REF:
+            if self._repository_client_policy is None:
+                raise RepositoryContractError(
+                    "REPOSITORY_CONNECTION_UNAVAILABLE",
+                    "the current deployment Git client policy was not supplied",
+                )
+            connection_path = _DEFAULT_REPOSITORY_CONNECTION_PATH
+        else:
+            connections_dir = Path(
+                os.environ.get(
+                    "MOONMIND_REPOSITORY_CONNECTIONS_DIR",
+                    str(_DEFAULT_REPOSITORY_CONNECTION_PATH.parent),
+                )
+            )
+            connection_path = next(
+                (
+                    path
+                    for path in sorted(connections_dir.glob("*.json"))
+                    if self._connection_file_matches(path, target.connection_ref)
+                ),
+                None,
+            )
+        if connection_path is None:
             raise RepositoryContractError(
                 "REPOSITORY_CONNECTION_UNAVAILABLE",
-                "the managed-runtime launch boundary has no ready adapter for "
-                "the selected connection",
+                "the selected Git connection is absent from the deployment registry",
             )
 
         observed = await self._observe_git_client()
         connection = load_repository_connection(
-            _DEFAULT_REPOSITORY_CONNECTION_PATH, target.connection_ref
+            connection_path, target.connection_ref
         )
         registry = CapabilityReadinessRegistry(
             runtime_owned_tokens=(
@@ -585,6 +607,14 @@ class ManagedRuntimeLauncher:
             work_branch_origin=work_branch_origin,
             projection=connection.projection,
         )
+
+    @staticmethod
+    def _connection_file_matches(path: Path, connection_ref: str) -> bool:
+        try:
+            connection = load_repository_connection(path, connection_ref)
+        except RepositoryContractError:
+            return False
+        return connection.provider == "git"
 
     @staticmethod
     def _build_managed_runtime_base_env() -> dict[str, str]:
@@ -1148,6 +1178,11 @@ class ManagedRuntimeLauncher:
         repo_path = (workspace_root / "repo").resolve()
         workspace_root.mkdir(parents=True, exist_ok=True)
         if repo_path.exists():
+            await self._checkout_resolved_read_only_revision(
+                repo_path=repo_path,
+                workspace_spec=workspace_spec,
+                git_env=git_env,
+            )
             return str(repo_path)
 
         source = self._resolve_repository_source(repository)
@@ -1167,6 +1202,12 @@ class ManagedRuntimeLauncher:
             *clone_cmd,
             cwd=str(workspace_root),
             env=command_env,
+        )
+
+        await self._checkout_resolved_read_only_revision(
+            repo_path=repo_path,
+            workspace_spec=workspace_spec,
+            git_env=git_env,
         )
 
         new_branch = str(workspace_spec.get("targetBranch") or "").strip()
@@ -1217,6 +1258,48 @@ class ManagedRuntimeLauncher:
                 )
 
         return str(repo_path)
+
+    async def _checkout_resolved_read_only_revision(
+        self,
+        *,
+        repo_path: Path,
+        workspace_spec: Mapping[str, Any],
+        git_env: Mapping[str, str] | None,
+    ) -> None:
+        resolved = workspace_spec.get("resolvedRepositoryTarget")
+        if not isinstance(resolved, Mapping):
+            return
+        expectation = resolved.get("remoteTipExpectation")
+        revision = resolved.get("preparedRevision")
+        if (
+            not isinstance(expectation, Mapping)
+            or expectation.get("kind") != "read_only"
+            or not isinstance(revision, Mapping)
+        ):
+            return
+        commit_sha = str(revision.get("commitSha") or "").strip()
+        if not commit_sha:
+            return
+        await self._run_checked_command(
+            "git",
+            "-C",
+            str(repo_path),
+            "checkout",
+            "--detach",
+            commit_sha,
+            env=dict(git_env) if git_env is not None else None,
+        )
+        returncode, stdout_text, _stderr_text = await self._run_command(
+            "git", "-C", str(repo_path), "rev-parse", "HEAD"
+        )
+        observed_sha = stdout_text.strip()
+        if returncode != 0 or not observed_sha.startswith(commit_sha):
+            raise RepositoryContractError(
+                REPOSITORY_REMOTE_TIP_MISMATCH,
+                "prepared workspace does not match the resolved pinned revision",
+            )
+        if isinstance(revision, dict):
+            revision["commitSha"] = observed_sha
 
     @staticmethod
     def _runtime_requires_direct_github_env(runtime_id: str | None) -> bool:
@@ -1711,6 +1794,12 @@ class ManagedRuntimeLauncher:
             request.workspace_spec["resolvedRepositoryTarget"] = (
                 resolved_repository.model_dump(by_alias=True, mode="json")
             )
+            if resolved_repository.provider == "lore" and workspace_path is None:
+                raise RepositoryContractError(
+                    "LORE_WORKSPACE_MATERIALIZATION_UNAVAILABLE",
+                    "the configured Lore adapter resolves authority but does not "
+                    "materialize a managed workspace",
+                )
         resolved_workspace_path = await self._prepare_workspace_path(
             run_id=run_id,
             request=request,

--- a/moonmind/workflows/temporal/runtime/lore_repository_adapter.py
+++ b/moonmind/workflows/temporal/runtime/lore_repository_adapter.py
@@ -1,0 +1,272 @@
+"""Portable, machine-readable Lore repository readiness adapter."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import os
+import shutil
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from moonmind.schemas.agent_runtime_models import AgentExecutionRequest
+from moonmind.workflows.executions.repository_contract import (
+    AuthoredLoreRepositoryTarget,
+    CapabilityReadinessRegistry,
+    RepositoryClientEvidence,
+    RepositoryConnection,
+    RepositoryContractError,
+    ResolvedRepositoryTarget,
+    derive_repository_capabilities,
+    load_repository_connection,
+    materialize_resolved_repository_target,
+    validate_connection_and_client,
+)
+
+
+class _LoreResolvedIdentity(BaseModel):
+    model_config = ConfigDict(populate_by_name=True, extra="forbid", frozen=True)
+    repository_id: str = Field(alias="repositoryId", min_length=1)
+    repository_name: str = Field(alias="repositoryName", min_length=1)
+    branch_id: str = Field(alias="branchId", min_length=1)
+    branch_name: str = Field(alias="branchName", min_length=1)
+    revision_signature: str = Field(alias="revisionSignature", min_length=1)
+    server_version: str = Field(alias="serverVersion", min_length=1)
+
+
+class LoreCliReadinessAdapter:
+    """Resolve Lore authority through a pinned CLI that emits strict JSON."""
+
+    def __init__(
+        self,
+        *,
+        connections_dir: Path,
+        executable: str | None,
+        tool_bundle_ref: str | None,
+        allow_trusted_network_development: bool = False,
+    ) -> None:
+        self._connections_dir = connections_dir
+        self._executable = executable
+        self._tool_bundle_ref = tool_bundle_ref
+        self._allow_trusted_network_development = allow_trusted_network_development
+
+    @classmethod
+    def from_environment(cls) -> "LoreCliReadinessAdapter":
+        runtime_root = Path(
+            os.environ.get("MOONMIND_AGENT_RUNTIME_STORE", "/work/agent_jobs")
+        )
+        return cls(
+            connections_dir=Path(
+                os.environ.get(
+                    "MOONMIND_REPOSITORY_CONNECTIONS_DIR",
+                    str(runtime_root / "repository_connections"),
+                )
+            ),
+            executable=os.environ.get("MOONMIND_LORE_CLIENT_EXECUTABLE"),
+            tool_bundle_ref=os.environ.get("MOONMIND_LORE_TOOL_BUNDLE_REF"),
+            allow_trusted_network_development=os.environ.get(
+                "MOONMIND_LORE_ALLOW_TRUSTED_NETWORK_DEVELOPMENT", ""
+            ).strip().lower()
+            in {"1", "true", "yes"},
+        )
+
+    def _load_connection(self, connection_ref: str) -> RepositoryConnection:
+        try:
+            candidates = sorted(self._connections_dir.glob("*.json"))
+        except OSError as exc:
+            raise RepositoryContractError(
+                "LORE_CONNECTION_NOT_READY", "Lore connection registry is unavailable"
+            ) from exc
+        for path in candidates:
+            try:
+                connection = load_repository_connection(path, connection_ref)
+            except RepositoryContractError:
+                continue
+            if connection.provider == "lore":
+                return connection
+        raise RepositoryContractError(
+            "LORE_CONNECTION_NOT_READY",
+            f"deployment-owned Lore connection {connection_ref!r} is unavailable",
+        )
+
+    def _resolve_executable(self) -> Path:
+        candidate = self._executable or shutil.which("lore")
+        if not candidate:
+            raise RepositoryContractError(
+                "LORE_CLIENT_UNAVAILABLE", "no Lore client executable is configured"
+            )
+        path = Path(candidate).resolve()
+        if not path.is_file():
+            raise RepositoryContractError(
+                "LORE_CLIENT_UNAVAILABLE", "configured Lore client does not exist"
+            )
+        return path
+
+    async def _run(self, executable: Path, *args: str) -> tuple[int, str, str]:
+        process = await asyncio.create_subprocess_exec(
+            str(executable),
+            *args,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, stderr = await process.communicate()
+        return (
+            process.returncode or 0,
+            stdout.decode("utf-8", errors="replace"),
+            stderr.decode("utf-8", errors="replace"),
+        )
+
+    async def __call__(
+        self, target: AuthoredLoreRepositoryTarget, request: AgentExecutionRequest
+    ) -> ResolvedRepositoryTarget:
+        connection = self._load_connection(target.connection_ref)
+        if (
+            connection.credential.source == "trusted_network_development"
+            and not self._allow_trusted_network_development
+        ):
+            raise RepositoryContractError(
+                "LORE_CONNECTION_NOT_READY",
+                "trusted-network Lore credentials require explicit development policy",
+            )
+        executable = self._resolve_executable()
+        if not self._tool_bundle_ref:
+            raise RepositoryContractError(
+                "LORE_CLIENT_UNAVAILABLE", "Lore tool-bundle identity is not configured"
+            )
+        version_code, version_stdout, _version_stderr = await self._run(
+            executable, "--version"
+        )
+        if version_code != 0 or not version_stdout.strip():
+            raise RepositoryContractError(
+                "LORE_CLIENT_UNAVAILABLE",
+                "Lore client version probe failed",
+            )
+        client_version = version_stdout.strip().removeprefix("lore ").strip()
+        arguments = [
+            "repository",
+            "resolve",
+            "--endpoint-ref",
+            connection.endpoint_ref,
+            "--repository",
+            target.repository.name,
+            "--branch",
+            target.branch.name,
+            "--output",
+            "json",
+        ]
+        if connection.trust_bundle_ref is not None:
+            arguments.extend(["--trust-bundle-ref", connection.trust_bundle_ref])
+        if connection.credential.source == "secret_ref":
+            arguments.extend(
+                [
+                    "--credential-ref-json",
+                    json.dumps(
+                        connection.credential.credential_ref.model_dump(mode="json"),
+                        sort_keys=True,
+                        separators=(",", ":"),
+                    ),
+                ]
+            )
+        else:
+            arguments.append("--trusted-network-development")
+        if target.revision is not None:
+            arguments.extend(
+                ["--revision-signature", target.revision.revision_signature]
+            )
+        code, stdout, _stderr = await self._run(executable, *arguments)
+        if code != 0:
+            raise RepositoryContractError(
+                "LORE_CONNECTION_NOT_READY",
+                "Lore target resolution failed",
+            )
+        try:
+            identity = _LoreResolvedIdentity.model_validate_json(stdout)
+        except ValueError as exc:
+            raise RepositoryContractError(
+                "LORE_CONNECTION_NOT_READY",
+                "Lore client returned invalid machine-readable authority evidence",
+            ) from exc
+        if (
+            identity.repository_name != target.repository.name
+            or identity.branch_name != target.branch.name
+            or (
+                target.revision is not None
+                and identity.revision_signature
+                != target.revision.revision_signature
+            )
+        ):
+            raise RepositoryContractError(
+                "LORE_CONNECTION_NOT_READY",
+                "Lore client authority does not match the authored target",
+            )
+        evidence = RepositoryClientEvidence(
+            toolBundleRef=self._tool_bundle_ref,
+            clientVersion=client_version,
+            executableSha256=f"sha256:{hashlib.sha256(executable.read_bytes()).hexdigest()}",
+            serverVersion=identity.server_version,
+        )
+        parameters: Mapping[str, Any] = (
+            request.parameters if isinstance(request.parameters, Mapping) else {}
+        )
+        publish_mode = str(parameters.get("publishMode") or "none").lower()
+        operation = "write" if publish_mode in {"branch", "pr"} else "read"
+        validate_connection_and_client(
+            target, connection, evidence, operation=operation
+        )
+        registry = CapabilityReadinessRegistry(
+            runtime_owned_tokens=(
+                "artifact.read",
+                "artifact.write",
+                "jira",
+                "docker",
+                "container.run",
+            )
+        )
+        registry.register("lore", lambda _context: True)
+        operation_tokens = {
+            "repo.read": "read",
+            "repo.write": "write",
+            "repo.branch.write": "branch_write",
+            "repo.lock": "lock",
+            "repo.review.request": "review_request",
+        }
+        for token, allowed_operation in operation_tokens.items():
+            registry.register(
+                token,
+                lambda _context, required=allowed_operation: required
+                in connection.allowed_operations,
+            )
+        skill_caps = (
+            request.skill.get("requiredCapabilities", ())
+            if isinstance(request.skill, Mapping)
+            else ()
+        )
+        tool_caps = parameters.get("repositoryToolCapabilities", ())
+        if not isinstance(skill_caps, (list, tuple)):
+            skill_caps = ()
+        if not isinstance(tool_caps, (list, tuple)):
+            tool_caps = ()
+        required = derive_repository_capabilities(
+            target,
+            publish_mode=publish_mode,
+            skill_capabilities=skill_caps,
+            tool_capabilities=tool_caps,
+        )
+        await registry.check(required, {"connection": connection, "target": target})
+        return materialize_resolved_repository_target(
+            target,
+            observed_revision=identity.revision_signature,
+            evidence=evidence,
+            client_policy=connection.client_policy,
+            publish_mode=publish_mode,
+            repository_id=identity.repository_id,
+            branch_id=identity.branch_id,
+            projection=connection.projection,
+        )
+
+
+__all__ = ["LoreCliReadinessAdapter"]

--- a/moonmind/workflows/temporal/runtime/lore_repository_adapter.py
+++ b/moonmind/workflows/temporal/runtime/lore_repository_adapter.py
@@ -203,6 +203,14 @@ class LoreCliReadinessAdapter:
                 "LORE_CONNECTION_NOT_READY",
                 "Lore client authority does not match the authored target",
             )
+        if (
+            connection.allowed_repository_ids
+            and identity.repository_id not in connection.allowed_repository_ids
+        ):
+            raise RepositoryContractError(
+                "REPOSITORY_CONNECTION_MISMATCH",
+                "resolved Lore repository is not allowed by connection",
+            )
         evidence = RepositoryClientEvidence(
             toolBundleRef=self._tool_bundle_ref,
             clientVersion=client_version,

--- a/moonmind/workflows/temporal/worker_runtime.py
+++ b/moonmind/workflows/temporal/worker_runtime.py
@@ -1188,6 +1188,7 @@ def _normalized_agent_skill_payload(
             "contentRef",
             "contentDigest",
             "inputContractDigest",
+            "requiredCapabilities",
         )
         if key in skill_payload
     }
@@ -1627,7 +1628,21 @@ def _build_runtime_planner():
             or selected_skill_inputs.get("repository")
             or selected_skill_inputs.get("repo")
         )
-        if isinstance(repository, str) and repository.strip():
+        if isinstance(repository, Mapping):
+            repository_target = dict(repository)
+            repository_identity = _coerce_mapping(
+                repository_target.get("repository")
+            )
+            repository_name = _coerce_non_empty_text(repository_identity.get("name"))
+            branch_identity = _coerce_mapping(repository_target.get("branch"))
+            branch_name = _coerce_non_empty_text(branch_identity.get("name"))
+            if repository_name:
+                node_inputs["repositoryTarget"] = repository_target
+                node_inputs["repository"] = repository_name
+                node_inputs["repo"] = repository_name
+            if branch_name:
+                node_inputs["branch"] = branch_name
+        elif isinstance(repository, str) and repository.strip():
             node_inputs["repository"] = repository.strip()
             node_inputs["repo"] = repository.strip()
         if selected_skill_name:

--- a/moonmind/workflows/temporal/worker_runtime.py
+++ b/moonmind/workflows/temporal/worker_runtime.py
@@ -130,7 +130,10 @@ from moonmind.workflows.temporal.workflow_registry import (
     workflow_fleet_workflow_classes,
 )
 from moonmind.workflows.temporal.runtime.store import ManagedRunStore
-from moonmind.workflows.temporal.runtime.launcher import ManagedRuntimeLauncher
+from moonmind.workflows.temporal.runtime.launcher import (
+    ManagedRuntimeLauncher,
+    resolve_deployment_git_client_policy,
+)
 from moonmind.workflows.temporal.runtime.log_streamer import RuntimeLogStreamer
 from moonmind.workflows.temporal.runtime.managed_session_controller import (
     DockerCodexManagedSessionController,
@@ -2546,6 +2549,7 @@ def _build_agent_runtime_deps(
         store,
         log_streamer=log_streamer,
         artifact_service=artifact_service,
+        repository_client_policy=resolve_deployment_git_client_policy(),
     )
     session_store = ManagedSessionStore(
         os.path.join(

--- a/moonmind/workflows/temporal/worker_runtime.py
+++ b/moonmind/workflows/temporal/worker_runtime.py
@@ -1623,9 +1623,9 @@ def _build_runtime_planner():
             node_inputs["publishBaseBranch"] = publish_base_branch
 
         repository = (
-            task_payload.get("repository")
+            parameter_payload.get("repository")
             or input_payload.get("repository")
-            or parameter_payload.get("repository")
+            or task_payload.get("repository")
             or parameter_payload.get("repo")
             or selected_skill_inputs.get("repository")
             or selected_skill_inputs.get("repo")

--- a/moonmind/workflows/temporal/worker_runtime.py
+++ b/moonmind/workflows/temporal/worker_runtime.py
@@ -2547,6 +2547,9 @@ def _build_agent_runtime_deps(
     from moonmind.workflows.temporal.runtime.launcher import (
         reconcile_deployment_git_connection,
     )
+    from moonmind.workflows.temporal.runtime.lore_repository_adapter import (
+        LoreCliReadinessAdapter,
+    )
 
     reconciled_git_connection = reconcile_deployment_git_connection()
     launcher = ManagedRuntimeLauncher(
@@ -2554,6 +2557,7 @@ def _build_agent_runtime_deps(
         log_streamer=log_streamer,
         artifact_service=artifact_service,
         repository_client_policy=reconciled_git_connection.client_policy,
+        lore_repository_adapter=LoreCliReadinessAdapter.from_environment(),
     )
     session_store = ManagedSessionStore(
         os.path.join(

--- a/moonmind/workflows/temporal/worker_runtime.py
+++ b/moonmind/workflows/temporal/worker_runtime.py
@@ -132,7 +132,6 @@ from moonmind.workflows.temporal.workflow_registry import (
 from moonmind.workflows.temporal.runtime.store import ManagedRunStore
 from moonmind.workflows.temporal.runtime.launcher import (
     ManagedRuntimeLauncher,
-    resolve_deployment_git_client_policy,
 )
 from moonmind.workflows.temporal.runtime.log_streamer import RuntimeLogStreamer
 from moonmind.workflows.temporal.runtime.managed_session_controller import (
@@ -2545,11 +2544,16 @@ def _build_agent_runtime_deps(
     artifact_storage = LocalRuntimeArtifactStorage(artifact_root)
     log_streamer = RuntimeLogStreamer(artifact_storage)
     supervisor = ManagedRunSupervisor(store, log_streamer)
+    from moonmind.workflows.temporal.runtime.launcher import (
+        reconcile_deployment_git_connection,
+    )
+
+    reconciled_git_connection = reconcile_deployment_git_connection()
     launcher = ManagedRuntimeLauncher(
         store,
         log_streamer=log_streamer,
         artifact_service=artifact_service,
-        repository_client_policy=resolve_deployment_git_client_policy(),
+        repository_client_policy=reconciled_git_connection.client_policy,
     )
     session_store = ManagedSessionStore(
         os.path.join(

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -18281,6 +18281,7 @@ class MoonMindRunWorkflow:
                     "contentRef",
                     "contentDigest",
                     "inputContractDigest",
+                    "requiredCapabilities",
                     "inputs",
                     "sideEffect",
                 ):

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -18096,6 +18096,7 @@ class MoonMindRunWorkflow:
                 )
         for ws_key in (
             "repository",
+            "repositoryTarget",
             "repo",
             "startingBranch",
             "targetBranch",

--- a/tests/unit/omnigent/test_workspace_intent_compiler.py
+++ b/tests/unit/omnigent/test_workspace_intent_compiler.py
@@ -107,6 +107,33 @@ def test_compiles_full_authored_intent() -> None:
     ]
 
 
+def test_provider_target_persists_connection_revision_and_remote_tip_axes() -> None:
+    request = _request(
+        workspace_spec={
+            "workspaceLocator": _locator(),
+            "repository": {
+                "provider": "git",
+                "connectionRef": "repository-connection:git-default",
+                "repository": {"name": "acme/widgets"},
+                "branch": {"name": "main"},
+                "revision": {
+                    "kind": "git_commit",
+                    "commitSha": "abcdef012345",
+                },
+            },
+        },
+        parameters={"publishMode": "none", "requiredCapabilities": ["git"]},
+    )
+    intent = _compile(request)
+
+    assert intent.repository == "acme/widgets"
+    assert intent.connection_ref == "repository-connection:git-default"
+    assert intent.starting_branch == "main"
+    assert intent.checkout_commit == "abcdef012345"
+    assert intent.revision_kind == "git_commit"
+    assert intent.remote_tip_expectation == "read_only"
+
+
 def test_owner_repo_shorthand_is_classified_as_github_not_local() -> None:
     # The canonical materialization classifier resolves ``owner/repo`` to a
     # GitHub clone, so durable evidence must not redact it as ``[local-source]``.

--- a/tests/unit/omnigent/test_workspace_intent_compiler.py
+++ b/tests/unit/omnigent/test_workspace_intent_compiler.py
@@ -131,7 +131,7 @@ def test_provider_target_persists_connection_revision_and_remote_tip_axes() -> N
     assert intent.starting_branch == "main"
     assert intent.checkout_commit == "abcdef012345"
     assert intent.revision_kind == "git_commit"
-    assert intent.remote_tip_expectation == "read_only"
+    assert intent.remote_tip_expectation == {"kind": "read_only"}
 
 
 def test_owner_repo_shorthand_is_classified_as_github_not_local() -> None:

--- a/tests/unit/omnigent/test_workspace_intent_compiler.py
+++ b/tests/unit/omnigent/test_workspace_intent_compiler.py
@@ -134,6 +134,22 @@ def test_provider_target_persists_connection_revision_and_remote_tip_axes() -> N
     assert intent.remote_tip_expectation == {"kind": "read_only"}
 
 
+def test_rejects_caller_authored_resolved_repository_evidence() -> None:
+    request = _request(
+        workspace_spec={
+            "workspaceLocator": _locator(),
+            "repository": "acme/widgets",
+            "resolvedRepositoryTarget": {"authority": "authoritative"},
+        }
+    )
+
+    with pytest.raises(
+        WorkspaceIntentCompilationError,
+        match="resolvedRepositoryTarget is runtime-owned",
+    ):
+        _compile(request)
+
+
 def test_owner_repo_shorthand_is_classified_as_github_not_local() -> None:
     # The canonical materialization classifier resolves ``owner/repo`` to a
     # GitHub clone, so durable evidence must not redact it as ``[local-source]``.

--- a/tests/unit/services/temporal/runtime/test_launcher.py
+++ b/tests/unit/services/temporal/runtime/test_launcher.py
@@ -14,6 +14,8 @@ from moonmind.workflows.executions.repository_contract import (
     RepositoryClientEvidence,
     RepositoryClientPolicy,
     RepositoryContractError,
+    compile_repository_target,
+    materialize_resolved_repository_target,
 )
 from moonmind.workflows.temporal.runtime.launcher import (
     ManagedRuntimeLauncher,
@@ -197,6 +199,86 @@ async def test_default_repository_readiness_returns_exact_resolved_metadata(tmp_
     assert resolved.prepared_revision.commit_sha == "abcdef0123456789"
     assert resolved.remote_tip_expectation["revision"]["commitSha"] == "abcdef0123456789"
     assert resolved.client_evidence == evidence
+    assert resolved.compatible_server_versions == ()
+
+
+@pytest.mark.asyncio
+async def test_lore_readiness_uses_policy_owned_adapter_and_preserves_exact_identity(
+    tmp_path,
+):
+    evidence = RepositoryClientEvidence(
+        toolBundleRef="tool-bundle:lore-1.2.3",
+        clientVersion="1.2.3",
+        executableSha256="sha256:lore",
+        serverVersion="2026.08",
+    )
+    target_payload = {
+        "provider": "lore",
+        "connectionRef": "repository-connection:tactics",
+        "repository": {"name": "tactics-id"},
+        "branch": {"name": "Main"},
+        "revision": {
+            "kind": "lore_revision",
+            "revisionSignature": "lore-revision-123",
+        },
+    }
+    adapter = AsyncMock(
+        return_value=materialize_resolved_repository_target(
+            compile_repository_target(target_payload),
+            observed_revision="lore-revision-123",
+            evidence=evidence,
+            client_policy=RepositoryClientPolicy(
+                pinnedVersion="1.2.3",
+                compatibleServerVersions=("2026.08",),
+                toolBundleRef="tool-bundle:lore-1.2.3",
+                executableSha256="sha256:lore",
+            ),
+            repository_id="lore-repository-uuid",
+            branch_id="branch-id-main",
+        )
+    )
+    launcher = ManagedRuntimeLauncher(
+        ManagedRunStore(tmp_path / "managed_runs"),
+        lore_repository_adapter=adapter,
+    )
+    request = _make_request(
+        workspace_spec={
+            "repository": "tactics-id",
+            "repositoryTarget": target_payload,
+        },
+        parameters={"publishMode": "none"},
+    )
+
+    resolved = await launcher._ensure_repository_ready_for_launch(request, None)
+
+    assert resolved is not None
+    assert resolved.repository.id == "lore-repository-uuid"
+    assert resolved.prepared_revision.revision_signature == "lore-revision-123"
+    assert resolved.remote_tip_expectation == {"kind": "read_only"}
+    assert resolved.compatible_server_versions == ("2026.08",)
+    adapter.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_lore_without_configured_adapter_has_structured_readiness_failure(
+    tmp_path,
+):
+    launcher = ManagedRuntimeLauncher(ManagedRunStore(tmp_path / "managed_runs"))
+    request = _make_request(
+        workspace_spec={
+            "repository": "tactics-id",
+            "repositoryTarget": {
+                "provider": "lore",
+                "connectionRef": "repository-connection:tactics",
+                "repository": {"name": "tactics-id"},
+                "branch": {"name": "Main"},
+            },
+        },
+        parameters={"publishMode": "none"},
+    )
+
+    with pytest.raises(RepositoryContractError, match="LORE_CONNECTION_NOT_READY"):
+        await launcher._ensure_repository_ready_for_launch(request, None)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/temporal/runtime/test_launcher.py
+++ b/tests/unit/services/temporal/runtime/test_launcher.py
@@ -10,6 +10,11 @@ import pytest
 from moonmind.schemas.agent_runtime_models import AgentExecutionRequest
 from moonmind.schemas.agent_runtime_models import ManagedRuntimeProfile
 from moonmind.schemas.agent_runtime_models import RuntimeCommandRenderResult
+from moonmind.workflows.executions.repository_contract import (
+    RepositoryClientEvidence,
+    RepositoryClientPolicy,
+    RepositoryContractError,
+)
 from moonmind.workflows.temporal.runtime.launcher import (
     ManagedRuntimeLauncher,
 )
@@ -38,6 +43,133 @@ def _make_request(**overrides) -> AgentExecutionRequest:
     )
     defaults.update(overrides)
     return AgentExecutionRequest(**defaults)
+
+
+@pytest.mark.asyncio
+async def test_repository_readiness_blocks_before_workspace_mutation(tmp_path):
+    store = ManagedRunStore(tmp_path / "managed_runs")
+    readiness = AsyncMock(
+        side_effect=RepositoryContractError(
+            "REPOSITORY_CLIENT_MISMATCH",
+            "observed client does not match deployment policy",
+        )
+    )
+    launcher = ManagedRuntimeLauncher(
+        store,
+        repository_readiness_boundary=readiness,
+    )
+    request = _make_request(
+        workspace_spec={
+            "repository": "file:///tmp/readiness-test-repository",
+            "repositoryTarget": {
+                "provider": "git",
+                "connectionRef": "repository-connection:git-default",
+                "repository": {"name": "MoonLadderStudios/MoonMind"},
+                "branch": {"name": "main"},
+            },
+        },
+        parameters={"publishMode": "pr"},
+    )
+
+    with pytest.raises(RepositoryContractError, match="REPOSITORY_CLIENT_MISMATCH"):
+        await launcher.launch(
+            run_id="readiness-blocked",
+            request=request,
+            profile=_make_profile(command_template=["echo", "hello"]),
+        )
+
+    readiness.assert_awaited_once()
+    assert not (tmp_path / "workspaces").exists()
+
+
+def _repository_readiness_request(
+    *, publish_mode: str = "pr", skill_capabilities: list[str] | None = None
+) -> AgentExecutionRequest:
+    return _make_request(
+        workspace_spec={
+            "repository": "MoonLadderStudios/MoonMind",
+            "repositoryTarget": {
+                "provider": "git",
+                "connectionRef": "repository-connection:git-default",
+                "repository": {"name": "MoonLadderStudios/MoonMind"},
+                "branch": {"name": "main"},
+            },
+        },
+        parameters={"publishMode": publish_mode},
+        skill={"requiredCapabilities": skill_capabilities or []},
+    )
+
+
+@pytest.mark.asyncio
+async def test_default_repository_readiness_rejects_observed_client_policy_mismatch(
+    tmp_path,
+):
+    store = ManagedRunStore(tmp_path / "managed_runs")
+    launcher = ManagedRuntimeLauncher(store)
+    launcher._repository_client_policy = RepositoryClientPolicy(
+        pinnedVersion="2.46.0",
+        toolBundleRef="repository-client:git-system",
+        executableSha256="sha256:expected",
+    )
+    launcher._observe_git_client = AsyncMock(
+        return_value=RepositoryClientEvidence(
+            toolBundleRef="repository-client:git-system",
+            clientVersion="2.47.0",
+            executableSha256="sha256:observed",
+        )
+    )
+
+    with pytest.raises(RepositoryContractError, match="REPOSITORY_CLIENT_MISMATCH"):
+        await launcher._ensure_repository_ready_for_launch(
+            _repository_readiness_request(publish_mode="none"), None
+        )
+
+
+@pytest.mark.asyncio
+async def test_default_repository_readiness_rejects_unknown_skill_capability(tmp_path):
+    store = ManagedRunStore(tmp_path / "managed_runs")
+    launcher = ManagedRuntimeLauncher(store)
+    evidence = RepositoryClientEvidence(
+        toolBundleRef="repository-client:git-system",
+        clientVersion="2.46.0",
+        executableSha256="sha256:git",
+    )
+    launcher._observe_git_client = AsyncMock(return_value=evidence)
+
+    with pytest.raises(RepositoryContractError, match="REPOSITORY_CAPABILITY_UNKNOWN"):
+        await launcher._ensure_repository_ready_for_launch(
+            _repository_readiness_request(
+                publish_mode="none", skill_capabilities=["unknown.repository.tool"]
+            ),
+            None,
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("tips", [[None], ["aaaa", "bbbb"]])
+async def test_default_repository_readiness_rejects_missing_or_changed_remote_tip(
+    tmp_path, tips
+):
+    store = ManagedRunStore(tmp_path / "managed_runs")
+    launcher = ManagedRuntimeLauncher(store)
+    evidence = RepositoryClientEvidence(
+        toolBundleRef="repository-client:git-system",
+        clientVersion="2.46.0",
+        executableSha256="sha256:git",
+    )
+    launcher._observe_git_client = AsyncMock(return_value=evidence)
+    launcher._observe_git_remote_tip = AsyncMock(side_effect=tips)
+
+    with patch(
+        "moonmind.auth.github_credentials.resolve_github_credential",
+        AsyncMock(return_value=object()),
+    ):
+        with pytest.raises(
+            RepositoryContractError, match="REPOSITORY_REMOTE_TIP_MISMATCH"
+        ):
+            await launcher._ensure_repository_ready_for_launch(
+                _repository_readiness_request(), None
+            )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/temporal/runtime/test_launcher.py
+++ b/tests/unit/services/temporal/runtime/test_launcher.py
@@ -101,15 +101,32 @@ def _repository_readiness_request(
 
 
 @pytest.mark.asyncio
+async def test_default_repository_readiness_requires_deployment_client_policy(tmp_path):
+    launcher = ManagedRuntimeLauncher(ManagedRunStore(tmp_path / "managed_runs"))
+    launcher._observe_git_client = AsyncMock()
+
+    with pytest.raises(
+        RepositoryContractError, match="REPOSITORY_CONNECTION_UNAVAILABLE"
+    ):
+        await launcher._ensure_repository_ready_for_launch(
+            _repository_readiness_request(publish_mode="none"), None
+        )
+
+    launcher._observe_git_client.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_default_repository_readiness_rejects_observed_client_policy_mismatch(
     tmp_path,
 ):
     store = ManagedRunStore(tmp_path / "managed_runs")
-    launcher = ManagedRuntimeLauncher(store)
-    launcher._repository_client_policy = RepositoryClientPolicy(
-        pinnedVersion="2.46.0",
-        toolBundleRef="repository-client:git-system",
-        executableSha256="sha256:expected",
+    launcher = ManagedRuntimeLauncher(
+        store,
+        repository_client_policy=RepositoryClientPolicy(
+            pinnedVersion="2.46.0",
+            toolBundleRef="repository-client:git-system",
+            executableSha256="sha256:expected",
+        ),
     )
     launcher._observe_git_client = AsyncMock(
         return_value=RepositoryClientEvidence(
@@ -128,11 +145,18 @@ async def test_default_repository_readiness_rejects_observed_client_policy_misma
 @pytest.mark.asyncio
 async def test_default_repository_readiness_rejects_unknown_skill_capability(tmp_path):
     store = ManagedRunStore(tmp_path / "managed_runs")
-    launcher = ManagedRuntimeLauncher(store)
     evidence = RepositoryClientEvidence(
         toolBundleRef="repository-client:git-system",
         clientVersion="2.46.0",
         executableSha256="sha256:git",
+    )
+    launcher = ManagedRuntimeLauncher(
+        store,
+        repository_client_policy=RepositoryClientPolicy(
+            pinnedVersion=evidence.client_version,
+            toolBundleRef=evidence.tool_bundle_ref,
+            executableSha256=evidence.executable_sha256,
+        ),
     )
     launcher._observe_git_client = AsyncMock(return_value=evidence)
 
@@ -146,16 +170,49 @@ async def test_default_repository_readiness_rejects_unknown_skill_capability(tmp
 
 
 @pytest.mark.asyncio
+async def test_default_repository_readiness_rejects_unready_known_capability(tmp_path):
+    evidence = RepositoryClientEvidence(
+        toolBundleRef="repository-client:git-system",
+        clientVersion="2.46.0",
+        executableSha256="sha256:git",
+    )
+    launcher = ManagedRuntimeLauncher(
+        ManagedRunStore(tmp_path / "managed_runs"),
+        repository_client_policy=RepositoryClientPolicy(
+            pinnedVersion=evidence.client_version,
+            toolBundleRef=evidence.tool_bundle_ref,
+            executableSha256=evidence.executable_sha256,
+        ),
+    )
+    launcher._observe_git_client = AsyncMock(return_value=evidence)
+
+    with pytest.raises(RepositoryContractError, match="REPOSITORY_CAPABILITY_UNREADY"):
+        await launcher._ensure_repository_ready_for_launch(
+            _repository_readiness_request(
+                publish_mode="none", skill_capabilities=["repo.write"]
+            ),
+            None,
+        )
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("tips", [[None], ["aaaa", "bbbb"]])
 async def test_default_repository_readiness_rejects_missing_or_changed_remote_tip(
     tmp_path, tips
 ):
     store = ManagedRunStore(tmp_path / "managed_runs")
-    launcher = ManagedRuntimeLauncher(store)
     evidence = RepositoryClientEvidence(
         toolBundleRef="repository-client:git-system",
         clientVersion="2.46.0",
         executableSha256="sha256:git",
+    )
+    launcher = ManagedRuntimeLauncher(
+        store,
+        repository_client_policy=RepositoryClientPolicy(
+            pinnedVersion=evidence.client_version,
+            toolBundleRef=evidence.tool_bundle_ref,
+            executableSha256=evidence.executable_sha256,
+        ),
     )
     launcher._observe_git_client = AsyncMock(return_value=evidence)
     launcher._observe_git_remote_tip = AsyncMock(side_effect=tips)

--- a/tests/unit/services/temporal/runtime/test_launcher.py
+++ b/tests/unit/services/temporal/runtime/test_launcher.py
@@ -170,6 +170,36 @@ async def test_default_repository_readiness_rejects_unknown_skill_capability(tmp
 
 
 @pytest.mark.asyncio
+async def test_default_repository_readiness_returns_exact_resolved_metadata(tmp_path):
+    evidence = RepositoryClientEvidence(
+        toolBundleRef="repository-client:git-system",
+        clientVersion="2.46.0",
+        executableSha256="sha256:git",
+    )
+    launcher = ManagedRuntimeLauncher(
+        ManagedRunStore(tmp_path / "managed_runs"),
+        repository_client_policy=RepositoryClientPolicy(
+            pinnedVersion=evidence.client_version,
+            toolBundleRef=evidence.tool_bundle_ref,
+            executableSha256=evidence.executable_sha256,
+        ),
+    )
+    launcher._observe_git_client = AsyncMock(return_value=evidence)
+    launcher._observe_git_remote_tip = AsyncMock(return_value="abcdef0123456789")
+    with patch(
+        "moonmind.auth.github_credentials.resolve_github_credential",
+        AsyncMock(return_value=object()),
+    ):
+        resolved = await launcher._ensure_repository_ready_for_launch(
+            _repository_readiness_request(publish_mode="none"), None
+        )
+    assert resolved is not None
+    assert resolved.prepared_revision.commit_sha == "abcdef0123456789"
+    assert resolved.remote_tip_expectation["revision"]["commitSha"] == "abcdef0123456789"
+    assert resolved.client_evidence == evidence
+
+
+@pytest.mark.asyncio
 async def test_default_repository_readiness_rejects_unready_known_capability(tmp_path):
     evidence = RepositoryClientEvidence(
         toolBundleRef="repository-client:git-system",

--- a/tests/unit/services/temporal/runtime/test_launcher.py
+++ b/tests/unit/services/temporal/runtime/test_launcher.py
@@ -1,4 +1,5 @@
 import asyncio
+import hashlib
 import json
 import os
 import subprocess
@@ -13,14 +14,19 @@ from moonmind.schemas.agent_runtime_models import RuntimeCommandRenderResult
 from moonmind.workflows.executions.repository_contract import (
     RepositoryClientEvidence,
     RepositoryClientPolicy,
+    RepositoryConnection,
     RepositoryContractError,
     compile_repository_target,
     materialize_resolved_repository_target,
+    persist_repository_connection,
 )
 from moonmind.workflows.temporal.runtime.launcher import (
     ManagedRuntimeLauncher,
 )
 from moonmind.workflows.temporal.runtime.store import ManagedRunStore
+from moonmind.workflows.temporal.runtime.lore_repository_adapter import (
+    LoreCliReadinessAdapter,
+)
 
 def _make_profile(**overrides) -> ManagedRuntimeProfile:
     defaults = dict(
@@ -257,6 +263,81 @@ async def test_lore_readiness_uses_policy_owned_adapter_and_preserves_exact_iden
     assert resolved.remote_tip_expectation == {"kind": "read_only"}
     assert resolved.compatible_server_versions == ("2026.08",)
     adapter.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_portable_lore_adapter_validates_connection_and_exact_cli_evidence(
+    tmp_path,
+):
+    executable = tmp_path / "lore"
+    executable.write_bytes(b"fake-lore-client")
+    executable.chmod(0o755)
+    digest = hashlib.sha256(executable.read_bytes()).hexdigest()
+    connection = RepositoryConnection.model_validate(
+        {
+            "schemaVersion": "moonmind.repository-connection.v1",
+            "id": "repository-connection:tactics",
+            "provider": "lore",
+            "displayName": "Tactics Lore",
+            "endpointRef": "lore-endpoint:tactics",
+            "allowedRepositoryIds": ["tactics"],
+            "allowedOperations": ["read"],
+            "clientPolicy": {
+                "pinnedVersion": "1.2.3",
+                "compatibleServerVersions": ["2026.08"],
+                "toolBundleRef": "tool-bundle:lore-1.2.3",
+                "executableSha256": f"sha256:{digest}",
+            },
+            "credential": {
+                "source": "secret_ref",
+                "credentialRef": {"provider": "env", "key": "LORE_TOKEN"},
+            },
+        }
+    )
+    connections_dir = tmp_path / "connections"
+    persist_repository_connection(connection, connections_dir / "tactics.json")
+    adapter = LoreCliReadinessAdapter(
+        connections_dir=connections_dir,
+        executable=str(executable),
+        tool_bundle_ref="tool-bundle:lore-1.2.3",
+    )
+    adapter._run = AsyncMock(
+        side_effect=[
+            (0, "lore 1.2.3\n", ""),
+            (
+                0,
+                json.dumps(
+                    {
+                        "repositoryId": "lore-repository-uuid",
+                        "repositoryName": "tactics",
+                        "branchId": "branch-main-id",
+                        "branchName": "Main",
+                        "revisionSignature": "lore-revision-123",
+                        "serverVersion": "2026.08",
+                    }
+                ),
+                "",
+            ),
+        ]
+    )
+    target = compile_repository_target(
+        {
+            "provider": "lore",
+            "connectionRef": connection.id,
+            "repository": {"name": "tactics"},
+            "branch": {"name": "Main"},
+        }
+    )
+
+    resolved = await adapter(
+        target,
+        _make_request(parameters={"publishMode": "none"}),
+    )
+
+    assert resolved.repository.id == "lore-repository-uuid"
+    assert resolved.prepared_branch.id == "branch-main-id"
+    assert resolved.prepared_revision.revision_signature == "lore-revision-123"
+    assert resolved.client_evidence.server_version == "2026.08"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/temporal/runtime/test_launcher.py
+++ b/tests/unit/services/temporal/runtime/test_launcher.py
@@ -280,7 +280,7 @@ async def test_portable_lore_adapter_validates_connection_and_exact_cli_evidence
             "provider": "lore",
             "displayName": "Tactics Lore",
             "endpointRef": "lore-endpoint:tactics",
-            "allowedRepositoryIds": ["tactics"],
+            "allowedRepositoryIds": ["lore-repository-uuid"],
             "allowedOperations": ["read"],
             "clientPolicy": {
                 "pinnedVersion": "1.2.3",

--- a/tests/unit/workflows/executions/test_execution_contract.py
+++ b/tests/unit/workflows/executions/test_execution_contract.py
@@ -1990,7 +1990,12 @@ _VALID_RESUME_BLOCK = {
 }
 
 _BASE_TASK_PAYLOAD = {
-    "repository": "test/repo",
+    "repository": {
+        "provider": "git",
+        "connectionRef": "repository-connection:git-default",
+        "repository": {"name": "test/repo"},
+        "branch": {"name": "main"},
+    },
     "workflow": {"instructions": "Do work"},
 }
 

--- a/tests/unit/workflows/executions/test_execution_contract.py
+++ b/tests/unit/workflows/executions/test_execution_contract.py
@@ -1209,11 +1209,15 @@ def test_pr_publish_derives_gh_without_implicit_git_for_non_repository_workflow(
     assert "git" not in result["requiredCapabilities"]
 
 
-def test_required_capabilities_derive_git_from_repository_or_git_context() -> None:
+def test_required_capabilities_derive_git_from_provider_target() -> None:
     repository_result = build_canonical_workflow_view(
         job_type="task",
         payload={
-            "repository": "MoonLadderStudios/MoonMind",
+            "repository": {
+                "provider": "git",
+                "repository": {"name": "MoonLadderStudios/MoonMind"},
+                "branch": {"name": "main"},
+            },
             "targetRuntime": "codex_cli",
             "task": {
                 "instructions": "Run repository-backed work.",
@@ -1221,20 +1225,12 @@ def test_required_capabilities_derive_git_from_repository_or_git_context() -> No
             },
         },
     )
-    git_context_result = build_canonical_workflow_view(
-        job_type="task",
-        payload={
-            "targetRuntime": "codex_cli",
-            "task": {
-                "instructions": "Run branch-backed work.",
-                "git": {"branch": "feature/mm-945"},
-                "publish": {"mode": "none"},
-            },
-        },
-    )
 
     assert "git" in repository_result["requiredCapabilities"]
-    assert "git" in git_context_result["requiredCapabilities"]
+    assert (
+        repository_result["repository"]["connectionRef"]
+        == "repository-connection:git-default"
+    )
 
 
 def test_explicit_git_required_capability_is_preserved_without_repository_context() -> None:
@@ -2256,27 +2252,35 @@ def test_fr009_empty_depends_on_normalized_to_none() -> None:
     assert spec.depends_on is None
 
 
-# FR-010/011: task.git.branch is the canonical field; targetBranch is stripped.
+# MM-1219 atomic cutover: workflow.git is history-only, never new authoring.
 
-def test_fr010_branch_is_canonical_authored_field() -> None:
-    """MM-638 FR-010: task.git.branch is accepted and present in canonical output."""
+@pytest.mark.parametrize("git", [{"branch": "feature/my-branch"}, {"targetBranch": "legacy"}])
+def test_workflow_git_is_rejected_for_new_authoring(git: dict[str, str]) -> None:
+    with pytest.raises(WorkflowContractError, match="workflow.git is not accepted"):
+        build_canonical_workflow_view(
+            job_type="task",
+            payload=_canonical_task_payload({"git": git}),
+        )
+
+
+def test_step_tool_capabilities_feed_repository_derivation() -> None:
     result = build_canonical_workflow_view(
         job_type="task",
-        payload=_canonical_task_payload({"git": {"branch": "feature/my-branch"}}),
+        payload=_canonical_task_payload(
+            {
+                "steps": [
+                    {
+                        "instructions": "Inspect repository",
+                        "tool": {
+                            "name": "repository-inspector",
+                            "requiredCapabilities": ["repo.lock"],
+                        },
+                    }
+                ]
+            }
+        ),
     )
-    assert result["workflow"]["git"]["branch"] == "feature/my-branch"
-
-
-def test_mm668_target_branch_is_not_active_authored_branch_input() -> None:
-    """MM-668: targetBranch must not be normalized into active authored branch."""
-    result = build_canonical_workflow_view(
-        job_type="task",
-        payload=_canonical_task_payload({
-            "git": {"targetBranch": "feature/legacy"},
-        }),
-    )
-    assert result["workflow"]["git"]["branch"] is None
-    assert "targetBranch" not in result["workflow"]["git"]
+    assert "repo.lock" in result["requiredCapabilities"]
 
 
 # SC-001: Full recover_from_failed_step acceptance scenario
@@ -2432,14 +2436,10 @@ def test_edge_case_recovery_checkpoint_ref_empty_is_rejected() -> None:
         ResumeFromFailedStepRef.model_validate(bad_resume)
 
 
-def test_edge_case_branch_and_starting_branch_both_preserved() -> None:
-    """MM-638 edge case: branch and startingBranch are distinct fields and both preserved."""
+def test_edge_case_repository_branch_is_preserved_without_workflow_git() -> None:
     result = build_canonical_workflow_view(
         job_type="task",
-        payload=_canonical_task_payload({
-            "git": {"branch": "main", "startingBranch": "sha-abc123"},
-        }),
+        payload=_canonical_task_payload({}),
     )
-    git = result["workflow"]["git"]
-    assert git["branch"] == "main"
-    assert git["startingBranch"] == "sha-abc123"
+    assert result["repository"]["branch"] == {"name": "main"}
+    assert "git" not in result["workflow"]

--- a/tests/unit/workflows/executions/test_execution_contract.py
+++ b/tests/unit/workflows/executions/test_execution_contract.py
@@ -1505,16 +1505,16 @@ def test_workflow_skill_side_effect_metadata_forces_none_for_unknown_skill() -> 
     "skill_id",
     ["fix-comments", "fix-ci", "fix-merge-conflicts"],
 )
-def test_codex_skill_payload_defaults_auto_publish_capable_skill_to_auto(
+def test_recorded_codex_skill_defaults_auto_publish_capable_skill_to_auto(
     skill_id: str,
 ) -> None:
-    """codex_skill submissions that omit publishMode must default to ``auto``.
+    """Recorded codex_skill payloads that omit publishMode default to ``auto``.
 
     The legacy payload path must preserve omitted publish mode until the
     selected-skill resolver can apply the auto publishing contract.
     """
 
-    result = build_canonical_workflow_view(
+    result = decode_recorded_legacy_workflow_history_v1(
         job_type="codex_skill",
         payload={
             "skillId": skill_id,

--- a/tests/unit/workflows/executions/test_execution_contract.py
+++ b/tests/unit/workflows/executions/test_execution_contract.py
@@ -9,6 +9,7 @@ from moonmind.workflows.executions.execution_contract import (
     build_authoritative_workflow_input_snapshot,
     build_effective_workflow_skill_selectors,
     build_runtime_command_preview_config,
+    decode_recorded_legacy_workflow_history_v1,
     CanonicalWorkflowExecutionPayload,
     ResumeFromFailedStepRef,
     SUPPORTED_PUBLISH_MODES,
@@ -21,6 +22,21 @@ from moonmind.workflows.executions.execution_contract import (
     WorkflowRecoveryProvenance,
     WorkflowStepSpec,
 )
+
+
+def test_recorded_legacy_decoder_is_separate_from_new_submission_validation() -> None:
+    legacy = {
+        "repository": "owner/repo",
+        "ref": "release",
+        "instruction": "Continue recorded work",
+    }
+    decoded = decode_recorded_legacy_workflow_history_v1(
+        job_type="codex_exec", payload=legacy
+    )
+    assert decoded["repository"]["repository"]["name"] == "owner/repo"
+    assert decoded["repository"]["branch"]["name"] == "release"
+    with pytest.raises(WorkflowContractError, match="no longer accepted"):
+        build_canonical_workflow_view(job_type="codex_exec", payload=legacy)
 from tests.helpers.step_type_payloads import (
     mixed_tool_skill_step,
     preset_step,

--- a/tests/unit/workflows/executions/test_repository_contract.py
+++ b/tests/unit/workflows/executions/test_repository_contract.py
@@ -160,7 +160,10 @@ def test_lore_connection_persists_trust_projection_and_merge_policy(tmp_path) ->
             "toolBundleRef": "tool-bundle:lore-1.2.3",
             "executableSha256": "sha256:lore",
         },
-        "credentialSource": "secret_ref",
+        "credential": {
+            "source": "secret_ref",
+            "credentialRef": {"provider": "env", "key": "LORE_TOKEN"},
+        },
         "projection": {
             "provider": "github",
             "repository": "owner/tactics-projection",
@@ -176,6 +179,75 @@ def test_lore_connection_persists_trust_projection_and_merge_policy(tmp_path) ->
     modeled = RepositoryConnection.model_validate(connection)
     persist_repository_connection(modeled, path)
     assert load_repository_connection(path, modeled.id) == modeled
+
+
+@pytest.mark.parametrize(
+    ("provider", "credential"),
+    [
+        ("git", {"source": "github_resolver"}),
+        (
+            "git",
+            {
+                "source": "secret_ref",
+                "credentialRef": {"provider": "env", "key": "GIT_TOKEN"},
+            },
+        ),
+        (
+            "lore",
+            {
+                "source": "secret_ref",
+                "credentialRef": {"provider": "env", "key": "LORE_TOKEN"},
+            },
+        ),
+        ("lore", {"source": "trusted_network_development"}),
+    ],
+)
+def test_repository_connection_credential_variants_round_trip(
+    provider, credential
+) -> None:
+    payload = {
+        "schemaVersion": "moonmind.repository-connection.v1",
+        "id": f"repository-connection:{provider}",
+        "provider": provider,
+        "displayName": f"{provider} connection",
+        "endpointRef": f"{provider}-endpoint:default",
+        "allowedOperations": ["read"],
+        "clientPolicy": _policy().model_dump(by_alias=True),
+        "credential": credential,
+    }
+    modeled = RepositoryConnection.model_validate(payload)
+    assert modeled.model_dump(by_alias=True, mode="json")["credential"] == credential
+
+
+@pytest.mark.parametrize(
+    "credential",
+    [
+        {"source": "secret_ref"},
+        {
+            "source": "github_resolver",
+            "credentialRef": {"provider": "env", "key": "TOKEN"},
+        },
+        {
+            "source": "trusted_network_development",
+            "credentialRef": {"provider": "env", "key": "TOKEN"},
+        },
+    ],
+)
+def test_repository_connection_rejects_invalid_credential_reference_rules(
+    credential,
+) -> None:
+    payload = {
+        "schemaVersion": "moonmind.repository-connection.v1",
+        "id": "repository-connection:test",
+        "provider": "lore",
+        "displayName": "Lore connection",
+        "endpointRef": "lore-endpoint:test",
+        "allowedOperations": ["read"],
+        "clientPolicy": _policy().model_dump(by_alias=True),
+        "credential": credential,
+    }
+    with pytest.raises(ValueError):
+        RepositoryConnection.model_validate(payload)
 
 
 def test_resolved_target_freezes_remote_tip_and_client_evidence() -> None:

--- a/tests/unit/workflows/executions/test_repository_contract.py
+++ b/tests/unit/workflows/executions/test_repository_contract.py
@@ -216,7 +216,13 @@ def test_repository_connection_credential_variants_round_trip(
         "credential": credential,
     }
     modeled = RepositoryConnection.model_validate(payload)
-    assert modeled.model_dump(by_alias=True, mode="json")["credential"] == credential
+    expected = credential
+    if credential["source"] == "secret_ref":
+        expected = {
+            **credential,
+            "credentialRef": {**credential["credentialRef"], "extra": {}},
+        }
+    assert modeled.model_dump(by_alias=True, mode="json")["credential"] == expected
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/workflows/executions/test_repository_contract.py
+++ b/tests/unit/workflows/executions/test_repository_contract.py
@@ -13,6 +13,7 @@ from moonmind.workflows.executions.repository_contract import (
     compile_repository_target,
     decode_legacy_repository_history_v1,
     derive_repository_capabilities,
+    ensure_repository_ready,
     reconcile_default_git_connection,
     resolve_default_git_credential,
     validate_connection_and_client,
@@ -129,3 +130,73 @@ def test_frozen_legacy_decoder_is_explicitly_history_only() -> None:
     target = decode_legacy_repository_history_v1("owner/repo", "release")
     assert target.connection_ref == DEFAULT_GIT_CONNECTION_REF
     assert target.branch.name == "release"
+
+
+@pytest.mark.asyncio
+async def test_coherent_readiness_boundary_completes_before_mutation() -> None:
+    target = compile_repository_target(
+        {
+            "provider": "git",
+            "repository": {"name": "MoonLadderStudios/MoonMind"},
+            "branch": {"name": "main"},
+        }
+    )
+    connection = reconcile_default_git_connection(client_policy=_policy())
+    evidence = RepositoryClientEvidence(
+        toolBundleRef="tool-bundle:git-2.46",
+        clientVersion="2.46.0",
+        executableSha256="sha256:git",
+    )
+    registry = CapabilityReadinessRegistry()
+    for token in ("git", "repo.read", "repo.write", "repo.branch.write", "gh"):
+        registry.register(token, lambda _context: True)
+    credential = AsyncMock(return_value=object())
+    remote_tip = AsyncMock(return_value=True)
+
+    resolved = await ensure_repository_ready(
+        target,
+        publish_mode="pr",
+        operation="write",
+        connection_resolver=lambda _target: connection,
+        evidence_resolver=lambda _connection: evidence,
+        readiness_registry=registry,
+        credential_resolver=credential,
+        remote_tip_verifier=remote_tip,
+    )
+
+    assert resolved == connection
+    credential.assert_awaited_once_with("MoonLadderStudios/MoonMind")
+    remote_tip.assert_awaited_once_with(target)
+
+
+@pytest.mark.asyncio
+async def test_readiness_boundary_fails_before_resolver_for_unknown_token() -> None:
+    target = compile_repository_target(
+        {
+            "provider": "git",
+            "repository": {"name": "owner/repo"},
+            "branch": {"name": "main"},
+        }
+    )
+    connection = reconcile_default_git_connection(client_policy=_policy())
+    evidence = RepositoryClientEvidence(
+        toolBundleRef="tool-bundle:git-2.46",
+        clientVersion="2.46.0",
+        executableSha256="sha256:git",
+    )
+    registry = CapabilityReadinessRegistry()
+    registry.register("git", lambda _context: True)
+    credential = AsyncMock()
+
+    with pytest.raises(RepositoryContractError, match="REPOSITORY_CAPABILITY_UNKNOWN"):
+        await ensure_repository_ready(
+            target,
+            publish_mode="none",
+            operation="read",
+            tool_capabilities=("unknown.tool",),
+            connection_resolver=lambda _target: connection,
+            evidence_resolver=lambda _connection: evidence,
+            readiness_registry=registry,
+            credential_resolver=credential,
+        )
+    credential.assert_not_awaited()

--- a/tests/unit/workflows/executions/test_repository_contract.py
+++ b/tests/unit/workflows/executions/test_repository_contract.py
@@ -9,6 +9,7 @@ from moonmind.workflows.executions.repository_contract import (
     DEFAULT_GIT_CONNECTION_REF,
     RepositoryClientEvidence,
     RepositoryClientPolicy,
+    RepositoryConnection,
     RepositoryContractError,
     compile_repository_target,
     decode_legacy_repository_history_v1,
@@ -142,6 +143,41 @@ def test_reconciled_connection_is_persisted_and_resolved(tmp_path) -> None:
     assert load_repository_connection(path, DEFAULT_GIT_CONNECTION_REF) == connection
 
 
+def test_lore_connection_persists_trust_projection_and_merge_policy(tmp_path) -> None:
+    path = tmp_path / "connections" / "lore.json"
+    connection = {
+        "schemaVersion": "moonmind.repository-connection.v1",
+        "id": "repository-connection:tactics",
+        "provider": "lore",
+        "displayName": "Tactics Lore",
+        "endpointRef": "lore-endpoint:tactics",
+        "trustBundleRef": "trust-bundle:tactics-ca",
+        "allowedRepositoryIds": ["tactics-id"],
+        "allowedOperations": ["read", "merge_request"],
+        "clientPolicy": {
+            "pinnedVersion": "1.2.3",
+            "compatibleServerVersions": ["2026.08"],
+            "toolBundleRef": "tool-bundle:lore-1.2.3",
+            "executableSha256": "sha256:lore",
+        },
+        "credentialSource": "secret_ref",
+        "projection": {
+            "provider": "github",
+            "repository": "owner/tactics-projection",
+            "authority": "review_only",
+            "statusSourceRef": "projection-status:tactics",
+        },
+        "mergeCoordinator": {
+            "endpointRef": "merge-coordinator:tactics",
+            "policyRef": "merge-policy:protected-main",
+            "supportedProtocolVersion": "v1",
+        },
+    }
+    modeled = RepositoryConnection.model_validate(connection)
+    persist_repository_connection(modeled, path)
+    assert load_repository_connection(path, modeled.id) == modeled
+
+
 def test_resolved_target_freezes_remote_tip_and_client_evidence() -> None:
     target = compile_repository_target(
         {
@@ -155,12 +191,85 @@ def test_resolved_target_freezes_remote_tip_and_client_evidence() -> None:
         clientVersion="2.46.0",
         executableSha256="sha256:git",
     )
+    policy = RepositoryClientPolicy(
+        pinnedVersion="2.46.0",
+        compatibleServerVersions=("2.46",),
+        toolBundleRef="tool-bundle:git-2.46",
+        executableSha256="sha256:git",
+    )
     resolved = materialize_resolved_repository_target(
-        target, observed_revision="abcdef0123456789", evidence=evidence
+        target,
+        observed_revision="abcdef0123456789",
+        evidence=evidence,
+        client_policy=policy,
+        publish_mode="branch",
     )
     assert resolved.prepared_revision.commit_sha == "abcdef0123456789"
     assert resolved.remote_tip_expectation["revision"]["commitSha"] == "abcdef0123456789"
     assert resolved.client_evidence == evidence
+    assert resolved.compatible_server_versions == ("2.46",)
+    assert resolved.base_branch.id == "refs/heads/main"
+    assert resolved.work_branch is not None
+    assert resolved.work_branch.origin == "selected"
+
+
+def test_resolved_exact_revision_is_read_only_without_work_branch() -> None:
+    target = compile_repository_target(
+        {
+            "provider": "lore",
+            "connectionRef": "repository-connection:tactics",
+            "repository": {"name": "tactics-id"},
+            "branch": {"name": "Main"},
+            "revision": {
+                "kind": "lore_revision",
+                "revisionSignature": "lore-revision-123",
+            },
+        }
+    )
+    evidence = RepositoryClientEvidence(
+        toolBundleRef="tool-bundle:lore",
+        clientVersion="1.2.3",
+        executableSha256="sha256:lore",
+    )
+    resolved = materialize_resolved_repository_target(
+        target,
+        observed_revision="lore-revision-123",
+        evidence=evidence,
+        branch_id="branch-id-main",
+    )
+    assert resolved.remote_tip_expectation == {"kind": "read_only"}
+    assert resolved.work_branch is None
+    assert resolved.repository.id == "tactics-id"
+    assert resolved.base_branch.id == "branch-id-main"
+    assert resolved.compatible_server_versions == ()
+
+
+def test_resolved_generated_branch_must_not_exist() -> None:
+    target = compile_repository_target(
+        {
+            "provider": "git",
+            "repository": {"name": "owner/repo"},
+            "branch": {"name": "main"},
+        }
+    )
+    evidence = RepositoryClientEvidence(
+        toolBundleRef="tool-bundle:git",
+        clientVersion="2.46.0",
+        executableSha256="sha256:git",
+    )
+    resolved = materialize_resolved_repository_target(
+        target,
+        observed_revision="abcdef0123456789",
+        evidence=evidence,
+        publish_mode="pr",
+        work_branch="feature/mm-1219",
+        work_branch_id="refs/heads/feature/mm-1219",
+        work_branch_origin="generated",
+    )
+    assert resolved.remote_tip_expectation == {"kind": "must_not_exist"}
+    assert resolved.work_branch is not None
+    assert resolved.work_branch.id == "refs/heads/feature/mm-1219"
+    assert resolved.work_branch.origin == "generated"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/workflows/executions/test_repository_contract.py
+++ b/tests/unit/workflows/executions/test_repository_contract.py
@@ -14,6 +14,9 @@ from moonmind.workflows.executions.repository_contract import (
     decode_legacy_repository_history_v1,
     derive_repository_capabilities,
     ensure_repository_ready,
+    load_repository_connection,
+    materialize_resolved_repository_target,
+    persist_repository_connection,
     reconcile_default_git_connection,
     resolve_default_git_credential,
     validate_connection_and_client,
@@ -130,6 +133,34 @@ def test_frozen_legacy_decoder_is_explicitly_history_only() -> None:
     target = decode_legacy_repository_history_v1("owner/repo", "release")
     assert target.connection_ref == DEFAULT_GIT_CONNECTION_REF
     assert target.branch.name == "release"
+
+
+def test_reconciled_connection_is_persisted_and_resolved(tmp_path) -> None:
+    path = tmp_path / "connections" / "git-default.json"
+    connection = reconcile_default_git_connection(client_policy=_policy())
+    persist_repository_connection(connection, path)
+    assert load_repository_connection(path, DEFAULT_GIT_CONNECTION_REF) == connection
+
+
+def test_resolved_target_freezes_remote_tip_and_client_evidence() -> None:
+    target = compile_repository_target(
+        {
+            "provider": "git",
+            "repository": {"name": "owner/repo"},
+            "branch": {"name": "main"},
+        }
+    )
+    evidence = RepositoryClientEvidence(
+        toolBundleRef="tool-bundle:git-2.46",
+        clientVersion="2.46.0",
+        executableSha256="sha256:git",
+    )
+    resolved = materialize_resolved_repository_target(
+        target, observed_revision="abcdef0123456789", evidence=evidence
+    )
+    assert resolved.prepared_revision.commit_sha == "abcdef0123456789"
+    assert resolved.remote_tip_expectation["revision"]["commitSha"] == "abcdef0123456789"
+    assert resolved.client_evidence == evidence
 
 
 @pytest.mark.asyncio

--- a/tests/unit/workflows/executions/test_repository_contract.py
+++ b/tests/unit/workflows/executions/test_repository_contract.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from moonmind.workflows.executions.repository_contract import (
+    CapabilityReadinessRegistry,
+    DEFAULT_GIT_CONNECTION_REF,
+    RepositoryClientEvidence,
+    RepositoryClientPolicy,
+    RepositoryContractError,
+    compile_repository_target,
+    decode_legacy_repository_history_v1,
+    derive_repository_capabilities,
+    reconcile_default_git_connection,
+    resolve_default_git_credential,
+    validate_connection_and_client,
+)
+
+
+def _policy() -> RepositoryClientPolicy:
+    return RepositoryClientPolicy(
+        pinnedVersion="2.46.0",
+        toolBundleRef="tool-bundle:git-2.46",
+        executableSha256="sha256:git",
+    )
+
+
+def test_common_git_draft_injects_default_connection_and_keeps_axes_distinct() -> None:
+    target = compile_repository_target(
+        {
+            "provider": "git",
+            "repository": {"name": "MoonLadderStudios/MoonMind"},
+            "branch": {"name": "main"},
+            "revision": {"kind": "git_commit", "commitSha": "abcdef012345"},
+        }
+    )
+
+    assert target.connection_ref == DEFAULT_GIT_CONNECTION_REF
+    assert target.repository.name == "MoonLadderStudios/MoonMind"
+    assert target.branch.name == "main"
+    assert target.revision is not None
+    assert target.revision.commit_sha == "abcdef012345"
+
+
+@pytest.mark.parametrize("legacy", ["owner/repo", None, 123])
+def test_new_compiler_rejects_legacy_or_missing_repository_shape(legacy: object) -> None:
+    with pytest.raises(RepositoryContractError, match="provider-discriminated"):
+        compile_repository_target(legacy)
+
+
+def test_lore_requires_explicit_connection_and_matching_revision_kind() -> None:
+    with pytest.raises(RepositoryContractError, match="REPOSITORY_TARGET_INVALID"):
+        compile_repository_target(
+            {
+                "provider": "lore",
+                "repository": {"name": "Tactics"},
+                "branch": {"name": "main"},
+                "revision": {"kind": "git_commit", "commitSha": "abcdef0"},
+            }
+        )
+
+
+def test_provider_publish_skill_tool_capabilities_are_additive() -> None:
+    target = compile_repository_target(
+        {
+            "provider": "lore",
+            "connectionRef": "repository-connection:tactics",
+            "repository": {"name": "Tactics"},
+            "branch": {"name": "main"},
+        }
+    )
+    assert derive_repository_capabilities(
+        target,
+        publish_mode="pr",
+        skill_capabilities=["repo.lock"],
+        tool_capabilities=["artifact.read"],
+    ) == [
+        "lore",
+        "repo.read",
+        "repo.write",
+        "repo.branch.write",
+        "repo.review.request",
+        "repo.lock",
+        "artifact.read",
+    ]
+
+
+def test_policy_and_observed_client_must_match_before_mutation() -> None:
+    target = compile_repository_target(
+        {
+            "provider": "git",
+            "repository": {"name": "MoonLadderStudios/MoonMind"},
+            "branch": {"name": "main"},
+        }
+    )
+    connection = reconcile_default_git_connection(client_policy=_policy())
+    evidence = RepositoryClientEvidence(
+        toolBundleRef="tool-bundle:git-2.46",
+        clientVersion="wrong",
+        executableSha256="sha256:git",
+    )
+    with pytest.raises(RepositoryContractError, match="REPOSITORY_CLIENT_MISMATCH"):
+        validate_connection_and_client(
+            target, connection, evidence, operation="write"
+        )
+
+
+@pytest.mark.asyncio
+async def test_unknown_capability_fails_closed() -> None:
+    registry = CapabilityReadinessRegistry(runtime_owned_tokens=("codex",))
+    registry.register("repo.read", lambda _context: True)
+    with pytest.raises(RepositoryContractError, match="REPOSITORY_CAPABILITY_UNKNOWN"):
+        await registry.check(["codex", "repo.read", "mystery"], {})
+
+
+@pytest.mark.asyncio
+async def test_default_git_connection_invokes_existing_github_resolver() -> None:
+    resolver = AsyncMock(return_value=object())
+    with patch(
+        "moonmind.auth.github_credentials.resolve_github_credential", resolver
+    ):
+        await resolve_default_git_credential("MoonLadderStudios/MoonMind")
+    resolver.assert_awaited_once_with(repo="MoonLadderStudios/MoonMind")
+
+
+def test_frozen_legacy_decoder_is_explicitly_history_only() -> None:
+    target = decode_legacy_repository_history_v1("owner/repo", "release")
+    assert target.connection_ref == DEFAULT_GIT_CONNECTION_REF
+    assert target.branch.name == "release"

--- a/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
+++ b/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
@@ -324,6 +324,41 @@ def test_runtime_planner_preserves_execution_profile_ref():
     assert runtime_node["mode"] == "claude"
     assert runtime_node["executionProfileRef"] == "claude-minimax-oauth"
 
+
+def test_runtime_planner_preserves_canonical_repository_target_for_launch_readiness():
+    planner = _build_runtime_planner()
+    snapshot = SimpleNamespace(
+        digest="reg:sha256:test",
+        artifact_ref="art_registry_123",
+    )
+    repository = {
+        "provider": "git",
+        "connectionRef": "repository-connection:git-default",
+        "repository": {"name": "MoonLadderStudios/MoonMind"},
+        "branch": {"name": "main"},
+    }
+
+    plan = planner(
+        inputs={
+            "workflow": {
+                "instructions": "Inspect the repository",
+                "runtime": {"mode": "codex_cli"},
+                "publish": {"mode": "none"},
+            }
+        },
+        parameters={
+            "repository": repository,
+            "targetRuntime": "codex_cli",
+            "requiredCapabilities": ["codex_cli", "git", "repo.read"],
+        },
+        snapshot=snapshot,
+    )
+
+    node_inputs = plan["nodes"][0]["inputs"]
+    assert node_inputs["repositoryTarget"] == repository
+    assert node_inputs["repository"] == "MoonLadderStudios/MoonMind"
+    assert node_inputs["branch"] == "main"
+
 def test_runtime_planner_preserves_execution_profile_ref_snake_case():
     planner = _build_runtime_planner()
     snapshot = SimpleNamespace(

--- a/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
+++ b/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
@@ -3271,7 +3271,6 @@ def test_build_agent_runtime_deps_wires_production_lore_readiness_adapter(
     dependencies = _build_agent_runtime_deps()
     launcher = dependencies[2]
 
-    assert launcher._lore_repository_adapter is not None
     assert launcher._lore_repository_readiness_adapter is not None
 
 

--- a/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
+++ b/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
@@ -3259,6 +3259,21 @@ def test_build_agent_runtime_deps_uses_artifacts_env_without_double_nesting(
     assert artifacts_root.is_dir()
     assert not (artifacts_root / "artifacts").exists()
 
+
+def test_build_agent_runtime_deps_wires_production_lore_readiness_adapter(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.setenv("MOONMIND_AGENT_RUNTIME_STORE", str(tmp_path))
+    monkeypatch.setenv(
+        "MOONMIND_AGENT_RUNTIME_ARTIFACTS", str(tmp_path / "artifacts")
+    )
+
+    dependencies = _build_agent_runtime_deps()
+    launcher = dependencies[2]
+
+    assert launcher._lore_repository_adapter is not None
+
+
 def test_build_agent_runtime_deps_reuses_global_session_network(
     tmp_path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py
@@ -2370,6 +2370,7 @@ class TestBuildAgentExecutionRequest(unittest.TestCase):
                         "contentRef": "art_skill",
                         "contentDigest": "sha256:skill",
                         "inputContractDigest": "sha256:contract",
+                        "requiredCapabilities": ["repo.lock"],
                         "inputs": {"issue": "MM-1052"},
                     },
                 },
@@ -2385,6 +2386,7 @@ class TestBuildAgentExecutionRequest(unittest.TestCase):
                 "contentRef": "art_skill",
                 "contentDigest": "sha256:skill",
                 "inputContractDigest": "sha256:contract",
+                "requiredCapabilities": ["repo.lock"],
                 "inputs": {"issue": "MM-1052"},
             },
         )


### PR DESCRIPTION
MoonSpec verification incomplete; publishing draft pull request for operator review. MoonSpec verification did not approve publication. verdict BLOCKED. Direct inspection at the latest remediation workspace head finds all seven MM-1219 requirements implemented, including production Lore adapter wiring and typed credential-reference rules. Trustworthy final verification is blocked because the required MoonMind container test backend deleted or lost the job container before pytest started. Syntax compilation and diff hygiene pass, but they do not replace the required targeted unit and runtime-boundary suite. verification report art_01KYYFMJE3PQ5WN8K3PAF6FQRZ.

## MoonSpec verification incomplete

This pull request was opened as a **draft** because MoonSpec verification did not approve publication (verdict BLOCKED) and the operator policy `workflow.moonspec_environment_blocked_publish_action` is `draft_pr`.

- Gate outcome: MoonSpec verification did not approve publication. verdict BLOCKED. Direct inspection at the latest remediation workspace head finds all seven MM-1219 requirements implemented, including production Lore adapter wiring and typed credential-reference rules. Trustworthy final verification is blocked because the required MoonMind container test backend deleted or lost the job container before pytest started. Syntax compilation and diff hygiene pass, but they do not replace the required targeted unit and runtime-boundary suite. verification report art_01KYYFMJE3PQ5WN8K3PAF6FQRZ.
- Verification report: art_01KYYFMJE3PQ5WN8K3PAF6FQRZ
- Verification gate result: art_01KYYFMJBZRF2RA6R2EWEDPW7Y

Review the verification evidence before marking this pull request ready for review.