### PR TITLE
Restore container image builds in worker runtime

### DIFF
--- a/api_service/Dockerfile
+++ b/api_service/Dockerfile
@@ -171,6 +171,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
       tee /etc/apt/sources.list.d/docker.list > /dev/null && \
     apt-get update && \
     apt-get install -y --no-install-recommends \
+        docker-buildx-plugin \
         docker-ce-cli \
         docker-compose-plugin
 
@@ -192,7 +193,7 @@ RUN useradd --create-home --home-dir /home/app --shell /bin/bash app && \
 RUN runuser -u app -- env -u NODE_OPTIONS -u npm_config_node_options \
     HOME=/home/app \
     PATH="/usr/local/bin:/usr/local/sbin:/usr/bin:/bin" \
-    sh -c 'codex --version && claude --version && npm --version && rg --version'
+    sh -c 'codex --version && claude --version && npm --version && rg --version && docker buildx version && docker compose version'
 
 # Provide a managed Codex configuration template that enforces non-interactive
 # approvals and managed sandbox defaults. The template is merged into the

--- a/tests/integration/temporal/test_compose_foundation.py
+++ b/tests/integration/temporal/test_compose_foundation.py
@@ -808,6 +808,8 @@ def test_python_test_runtime_is_provisioned_on_demand_outside_compose_startup():
 
     assert test_stage < production_stage < omnigent_copy
     assert "USER app" in dockerfile[test_stage:production_stage]
+    assert "docker-buildx-plugin" in dockerfile[:test_stage]
+    assert "docker buildx version" in dockerfile[:test_stage]
 
     compose = _load_compose()
     services = compose["services"]


### PR DESCRIPTION
## What changed

- install the Docker Buildx plugin in the shared API/worker runtime image
- verify Buildx and Compose are callable by the non-root worker user during image construction
- pin the requirement in the hermetic compose-foundation regression suite

## Root cause

The agent-runtime worker enables BuildKit and builds Python test images on demand, but its image installed `docker-ce-cli` with `--no-install-recommends` and omitted the separately packaged Buildx plugin. Every image acquisition therefore failed before a workload container could start. The audited failure interval contained 53 affected container jobs and 159 identical build attempts; this also blocked the MM-1219 and MM-1220 workflows.

The remaining failed user workflow was the Dependabot batch title-contract drift. That independent cause is already fixed on `main` by #3578, so this PR does not duplicate it.

## Validation

- `./tools/test_unit.sh --python-only -- tests/unit/tools/test_select_test_suites.py` — 38 passed
- `.venv/bin/python -m pytest tests/integration/temporal/test_compose_foundation.py::test_python_test_runtime_is_provisioned_on_demand_outside_compose_startup -q --tb=short` — 1 passed
- built the `runtime-dependencies` stage and invoked `docker buildx version` and `docker compose version` as the non-root `app` user
- `./tools/test_integration.sh` — 497 passed, 1 skipped
