### PR TITLE
Fix AgentRun publish metadata overflow

### DIFF
--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -117,6 +117,10 @@ from moonmind.workflows.executions.prepared_context import (
     build_prepared_input_manifest,
     select_step_prepared_context,
 )
+from moonmind.workflows.temporal.agent_result_payloads import (
+    compact_agent_run_result_payload_for_workflow_history,
+    compact_published_agent_run_result_payload,
+)
 from moonmind.workflows.temporal.completion_summary import (
     is_generic_completion_summary,
 )
@@ -9855,48 +9859,55 @@ class TemporalAgentRuntimeActivities:
                     ).strip()
                     if primary_report_id:
                         published_refs["primaryReportRef"] = primary_report_id
-            # Enrich result with the diagnostics ref
-            if isinstance(result, Mapping):
-                enriched = dict(result)
-                if "diagnosticsRef" in enriched:
-                    enriched["diagnosticsRef"] = agent_result_ref.artifact_id
-                else:
-                    enriched["diagnostics_ref"] = agent_result_ref.artifact_id
-                enriched_metadata = (
-                    dict(enriched.get("metadata") or {})
-                    if isinstance(enriched.get("metadata"), Mapping)
-                    else {}
+            # Enrich and revalidate the real Activity output. Publication can
+            # push a valid near-limit input over the compact metadata boundary.
+            # The full pre-enrichment result is already durable at
+            # outputAgentResultRef, so oversized inline annotations may be
+            # projected out while all authoritative refs remain linkable.
+            if not isinstance(result, (Mapping, BaseModel)):
+                if hasattr(result, "diagnostics_ref"):
+                    result.diagnostics_ref = agent_result_ref.artifact_id
+                if hasattr(result, "metadata"):
+                    metadata_obj = getattr(result, "metadata", None)
+                    enriched_metadata = (
+                        dict(metadata_obj)
+                        if isinstance(metadata_obj, Mapping)
+                        else {}
+                    )
+                    enriched_metadata.update(
+                        {
+                            **published_refs,
+                            "outputSummaryRef": summary_ref.artifact_id,
+                            "outputAgentResultRef": agent_result_ref.artifact_id,
+                        }
+                    )
+                    result.metadata = enriched_metadata
+                await _notify_terminal_result(result)
+                return result
+            enriched = dict(result_dict)
+            enriched["diagnosticsRef"] = agent_result_ref.artifact_id
+            enriched.pop("diagnostics_ref", None)
+            enriched_metadata = (
+                dict(enriched.get("metadata") or {})
+                if isinstance(enriched.get("metadata"), Mapping)
+                else {}
+            )
+            enriched_metadata.update(
+                {
+                    **published_refs,
+                    "outputSummaryRef": summary_ref.artifact_id,
+                    "outputAgentResultRef": agent_result_ref.artifact_id,
+                }
+            )
+            enriched["metadata"] = enriched_metadata
+            try:
+                published_result = AgentRunResult.model_validate(enriched)
+            except ValueError:
+                published_result = AgentRunResult.model_validate(
+                    compact_published_agent_run_result_payload(enriched)
                 )
-                enriched_metadata.update(
-                    {
-                        **published_refs,
-                        "outputSummaryRef": summary_ref.artifact_id,
-                        "outputAgentResultRef": agent_result_ref.artifact_id,
-                    }
-                )
-                enriched["metadata"] = enriched_metadata
-                # Remove snake_case if alias is present to avoid Pydantic validation errors
-                if "diagnosticsRef" in enriched and "diagnostics_ref" in enriched:
-                    del enriched["diagnostics_ref"]
-                await _notify_terminal_result(enriched)
-                return enriched
-            if hasattr(result, "diagnostics_ref"):
-                result.diagnostics_ref = agent_result_ref.artifact_id
-            if hasattr(result, "metadata"):
-                metadata_obj = getattr(result, "metadata", None)
-                enriched_metadata = (
-                    dict(metadata_obj) if isinstance(metadata_obj, Mapping) else {}
-                )
-                enriched_metadata.update(
-                    {
-                        **published_refs,
-                        "outputSummaryRef": summary_ref.artifact_id,
-                        "outputAgentResultRef": agent_result_ref.artifact_id,
-                    }
-                )
-                result.metadata = enriched_metadata
-            await _notify_terminal_result(result)
-            return result
+            await _notify_terminal_result(published_result)
+            return published_result
         except Exception as exc:
             logger.warning(
                 "agent_runtime.publish_artifacts failed to publish managed-session artifacts",
@@ -12745,7 +12756,10 @@ class TemporalAgentRuntimeActivities:
         /,
     ) -> AgentRunResult:
         """Apply an execution-bound terminal contract above provider adapters."""
-        from moonmind.workflows.terminal_evidence import evaluate_terminal_evidence
+        from moonmind.workflows.terminal_evidence import (
+            evaluate_terminal_evidence,
+            resolve_terminal_evidence_source,
+        )
 
         result = AgentRunResult.model_validate(request.get("result") or {})
         contract = request.get("terminalContract")
@@ -12760,10 +12774,12 @@ class TemporalAgentRuntimeActivities:
             record = self._run_store.load(run_id)
             workspace_path = str(getattr(record, "workspace_path", "") or "").strip()
 
+        artifact_spool_path = str(request.get("artifactSpoolPath") or "").strip()
+        contract_payload = dict(contract)
         evaluation = evaluate_terminal_evidence(
-            dict(contract),
+            contract_payload,
             workspace_path=workspace_path,
-            artifact_spool_path=str(request.get("artifactSpoolPath") or "").strip(),
+            artifact_spool_path=artifact_spool_path,
         )
         metadata = {**dict(result.metadata or {}), **dict(evaluation.metadata)}
         metadata["terminalContractId"] = str(contract.get("contractId") or "")
@@ -12771,9 +12787,74 @@ class TemporalAgentRuntimeActivities:
         metadata["terminalContractOutcome"] = evaluation.outcome
         if evaluation.failure_code:
             metadata["failureCode"] = evaluation.failure_code
+
+        # Terminal evidence is the authoritative full result for fan-out and
+        # merge automation. Publish the validated run-scoped file here, before
+        # the workflow projects large child records out of its result metadata.
+        if evaluation.metadata.get("terminalContractEvidencePath"):
+            source = resolve_terminal_evidence_source(
+                contract_payload,
+                workspace_path=workspace_path,
+                artifact_spool_path=artifact_spool_path,
+            )
+            if source.path is not None and self._artifact_service is not None:
+                payload = source.path.read_bytes()
+                try:
+                    info = temporal_activity.info()
+                except RuntimeError:
+                    info = None
+                execution_ref = (
+                    ExecutionRef(
+                        namespace=info.namespace,
+                        workflow_id=info.workflow_id,
+                        run_id=info.workflow_run_id,
+                        link_type="output.terminal_evidence",
+                    )
+                    if info is not None
+                    else None
+                )
+                artifact, _upload = await self._artifact_service.create(
+                    principal="system:agent_runtime",
+                    content_type="application/json",
+                    size_bytes=len(payload),
+                    link=execution_ref,
+                    metadata_json={
+                        "name": source.path.name,
+                        "path": source.relative_path,
+                        "producer": (
+                            "activity:agent_runtime.evaluate_terminal_evidence"
+                        ),
+                        "labels": ["agent_runtime", "output.terminal_evidence"],
+                        "terminalContractId": metadata["terminalContractId"],
+                    },
+                )
+                completed = await self._artifact_service.write_complete(
+                    artifact_id=artifact.artifact_id,
+                    principal="system:agent_runtime",
+                    payload=payload,
+                    content_type="application/json",
+                )
+                metadata["terminalContractEvidenceRef"] = completed.artifact_id
+            elif source.path is not None:
+                logger.warning(
+                    "Terminal evidence artifact service is unavailable; evidence "
+                    "remains run-scoped at %s",
+                    source.relative_path,
+                )
+
+        def _validated_result(update: Mapping[str, Any]) -> AgentRunResult:
+            updated = result.model_copy(update=dict(update))
+            payload = updated.model_dump(mode="json", by_alias=True)
+            try:
+                return AgentRunResult.model_validate(payload)
+            except ValueError:
+                return AgentRunResult.model_validate(
+                    compact_agent_run_result_payload_for_workflow_history(payload)
+                )
+
         if evaluation.satisfied:
             metadata["terminalContractSatisfied"] = True
-            return result.model_copy(update={"metadata": metadata})
+            return _validated_result({"metadata": metadata})
 
         if evaluation.outcome == "continuation_requested":
             metadata.update(
@@ -12784,9 +12865,9 @@ class TemporalAgentRuntimeActivities:
                 }
             )
             if result.failure_class is not None:
-                return result.model_copy(update={"metadata": metadata})
-            return result.model_copy(
-                update={
+                return _validated_result({"metadata": metadata})
+            return _validated_result(
+                {
                     "summary": "Agent completed an authoritative durable continuation handoff.",
                     "failure_class": "execution_error",
                     "provider_error_code": "PR_RESOLVER_REENTER_GATE",
@@ -12809,8 +12890,8 @@ class TemporalAgentRuntimeActivities:
             metadata.get("terminalFailureCode") or evaluation.failure_code or ""
         ).strip()
         if evaluation.failure_code == "BATCH_FANOUT_INPUT_INVALID":
-            return result.model_copy(
-                update={
+            return _validated_result(
+                {
                     "summary": terminal_failure_message
                     or "Batch fan-out input validation failed.",
                     "failure_class": "user_error",
@@ -12819,16 +12900,16 @@ class TemporalAgentRuntimeActivities:
                 }
             )
         if result.failure_class is not None:
-            return result.model_copy(
-                update={
+            return _validated_result(
+                {
                     "provider_error_code": result.provider_error_code
                     or evaluation.failure_code
                     or "missing_terminal_evidence",
                     "metadata": metadata,
                 }
             )
-        return result.model_copy(
-            update={
+        return _validated_result(
+            {
                 "summary": f"Agent completed without required terminal evidence: {missing}",
                 "failure_class": "execution_error",
                 "provider_error_code": evaluation.failure_code
@@ -12836,6 +12917,7 @@ class TemporalAgentRuntimeActivities:
                 "metadata": metadata,
             }
         )
+
     async def _managed_session_summary_metadata(
         self,
         record: ManagedRunRecord,

--- a/moonmind/workflows/temporal/agent_result_payloads.py
+++ b/moonmind/workflows/temporal/agent_result_payloads.py
@@ -1,0 +1,310 @@
+"""Compact agent results at Temporal workflow-history boundaries."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from typing import Any
+
+from moonmind.schemas.temporal_payload_policy import MAX_TEMPORAL_METADATA_BYTES
+
+
+def _compact_workflow_text(value: Any, *, max_chars: int = 700) -> str | None:
+    if not isinstance(value, str):
+        return None
+    text = value.strip()
+    if not text:
+        return None
+    if len(text) > max_chars:
+        return text[: max_chars - 3].rstrip() + "..."
+    return text
+
+
+def _compact_workflow_scalar(value: Any) -> Any:
+    if isinstance(value, str):
+        return _compact_workflow_text(value)
+    if value is None or isinstance(value, (bool, int, float)):
+        return value
+    return None
+
+
+def _compact_workflow_text_list(
+    value: Any,
+    *,
+    max_items: int = 20,
+    max_chars: int = 400,
+) -> list[str]:
+    if not isinstance(value, (list, tuple)):
+        return []
+    compact: list[str] = []
+    for item in value:
+        text = _compact_workflow_text(item, max_chars=max_chars)
+        if text:
+            compact.append(text)
+        if len(compact) >= max_items:
+            break
+    return compact
+
+
+def _compact_workflow_text_mapping(value: Any) -> dict[str, str]:
+    if not isinstance(value, Mapping):
+        return {}
+    compact: dict[str, str] = {}
+    for raw_key, raw_value in value.items():
+        key = _compact_workflow_text(str(raw_key), max_chars=120)
+        text = _compact_workflow_text(raw_value, max_chars=400)
+        if key and text:
+            compact[key] = text
+        if len(compact) >= 20:
+            break
+    return compact
+
+
+def _compact_moonspec_verify_for_workflow_history(
+    value: Mapping[str, Any],
+) -> dict[str, Any]:
+    compact: dict[str, Any] = {}
+    scalar_keys = (
+        "schemaVersion",
+        "verdict",
+        "gateVerdict",
+        "gate_verdict",
+        "moonSpecVerdict",
+        "moonspecVerdict",
+        "verificationVerdict",
+        "verification_verdict",
+        "confidence",
+        "recommendedNextAction",
+        "recommended_next_action",
+        "targetLogicalStepId",
+        "target_logical_step_id",
+        "workspacePolicyRecommendation",
+        "workspace_policy_recommendation",
+        "recoverableInCurrentRuntime",
+        "recoverable_in_current_runtime",
+        "invalid",
+        "degraded",
+        "remainingWorkRef",
+        "remaining_work_ref",
+        "diagnosticsRef",
+        "diagnostics_ref",
+        "verificationReportRef",
+        "verification_report_ref",
+        "reportRef",
+        "report_ref",
+        "gateResultRef",
+        "gate_result_ref",
+        "artifactRef",
+        "artifact_ref",
+    )
+    for key in scalar_keys:
+        field_value = _compact_workflow_scalar(value.get(key))
+        if field_value is not None:
+            compact[key] = field_value
+
+    for key in ("feedback", "summary", "message", "downgradeReason"):
+        text = _compact_workflow_text(value.get(key), max_chars=900)
+        if text:
+            compact[key] = text
+
+    for key in ("invalidatedRefs", "invalidated_refs"):
+        refs = _compact_workflow_text_list(value.get(key))
+        if refs:
+            compact[key] = refs
+            break
+    for key in ("blockingEvidenceRefs", "blocking_evidence_refs"):
+        refs = _compact_workflow_text_list(value.get(key))
+        if refs:
+            compact[key] = refs
+            break
+
+    validated_refs = _compact_workflow_text_mapping(
+        value.get("validatedRefs") or value.get("validated_refs")
+    )
+    if validated_refs:
+        compact["validatedRefs"] = validated_refs
+
+    contract_violations = _compact_workflow_text_list(
+        value.get("contractViolations") or value.get("contract_violations"),
+        max_items=10,
+        max_chars=700,
+    )
+    if contract_violations:
+        compact["contractViolations"] = contract_violations
+
+    return compact
+
+
+def compact_agent_run_result_payload_for_workflow_history(
+    payload: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Project known large result metadata to compact workflow-safe evidence."""
+
+    compact_payload = dict(payload)
+    metadata = compact_payload.get("metadata")
+    if not isinstance(metadata, Mapping):
+        return compact_payload
+
+    compact_metadata = dict(metadata)
+    for key in (
+        "moonSpecVerify",
+        "moonspecVerify",
+        "moonspec_verify",
+        "verificationResult",
+        "verification_result",
+    ):
+        value = compact_metadata.get(key)
+        if isinstance(value, Mapping):
+            compact_metadata[key] = _compact_moonspec_verify_for_workflow_history(
+                value
+            )
+
+    queued_children = compact_metadata.get("queuedChildren")
+    if isinstance(queued_children, (list, tuple)):
+        compact_children: list[dict[str, str]] = []
+        for child in queued_children:
+            if not isinstance(child, Mapping):
+                continue
+            compact_child: dict[str, str] = {}
+            workflow_id = _compact_workflow_text(
+                child.get("workflowId"), max_chars=400
+            )
+            execution_id = _compact_workflow_text(
+                child.get("executionId"), max_chars=400
+            )
+            if workflow_id:
+                compact_child["workflowId"] = workflow_id
+            if execution_id and execution_id != workflow_id:
+                compact_child["executionId"] = execution_id
+            reference = _compact_workflow_text(
+                child.get("ref") or child.get("targetRef"), max_chars=400
+            )
+            if reference:
+                compact_child["ref"] = reference
+            if compact_child:
+                compact_children.append(compact_child)
+        compact_metadata["queuedChildren"] = compact_children
+    compact_payload["metadata"] = compact_metadata
+    return compact_payload
+
+
+def _serialized_metadata_size(metadata: Mapping[str, Any]) -> int:
+    return len(
+        json.dumps(
+            metadata,
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        ).encode("utf-8")
+    )
+
+
+_INLINE_METADATA_BODIES = (
+    "lastAssistantText",
+    "assistantText",
+    "operator_summary",
+)
+
+_ESSENTIAL_PUBLISHED_METADATA_KEYS = frozenset(
+    {
+        "agentId",
+        "agentKind",
+        "agentRunId",
+        "childRunId",
+        "childWorkflowId",
+        "failureCode",
+        "mergeAutomationDisposition",
+        "providerErrorCode",
+        "providerFailure",
+        "queuedChildCount",
+        "queuedChildren",
+        "status",
+        "terminalContractAuthority",
+        "terminalContractEvidencePath",
+        "terminalContractEvidenceRef",
+        "terminalContractExecutionRef",
+        "terminalContractId",
+        "terminalContractMissingEvidence",
+        "terminalContractOutcome",
+        "terminalContractRecoveryOutcome",
+        "terminalContractSatisfied",
+    }
+)
+
+_PUBLISHED_ARTIFACT_REF_KEYS = frozenset(
+    {
+        "inputInstructionsRef",
+        "inputSkillSnapshotRef",
+        "outputAgentResultRef",
+        "outputSummaryRef",
+        "primaryReportRef",
+        "reportBundle",
+    }
+)
+
+
+def _published_metadata_key_is_durable(key: str) -> bool:
+    normalized = key.lower()
+    return (
+        key in _ESSENTIAL_PUBLISHED_METADATA_KEYS
+        or normalized.endswith("ref")
+        or normalized.endswith("refs")
+    )
+
+
+def compact_published_agent_run_result_payload(
+    payload: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Bound an artifact-backed result after publication adds metadata refs.
+
+    ``outputAgentResultRef`` points to the full pre-enrichment result. Once that
+    artifact exists, inline prose and other non-authoritative annotations may be
+    omitted from workflow history while terminal evidence and durable refs stay
+    directly linkable.
+    """
+
+    compact_payload = compact_agent_run_result_payload_for_workflow_history(payload)
+    metadata = compact_payload.get("metadata")
+    if not isinstance(metadata, Mapping):
+        return compact_payload
+    compact_metadata = dict(metadata)
+    compact_metadata["workflowHistoryMetadataCompacted"] = True
+    for key in _INLINE_METADATA_BODIES:
+        if _serialized_metadata_size(compact_metadata) <= MAX_TEMPORAL_METADATA_BYTES:
+            break
+        compact_metadata.pop(key, None)
+
+    if _serialized_metadata_size(compact_metadata) > MAX_TEMPORAL_METADATA_BYTES:
+        removable = sorted(
+            (
+                (_serialized_metadata_size({key: value}), key)
+                for key, value in compact_metadata.items()
+                if not _published_metadata_key_is_durable(key)
+                and key != "workflowHistoryMetadataCompacted"
+            ),
+            reverse=True,
+        )
+        for _size, key in removable:
+            compact_metadata.pop(key, None)
+            if (
+                _serialized_metadata_size(compact_metadata)
+                <= MAX_TEMPORAL_METADATA_BYTES
+            ):
+                break
+
+    if _serialized_metadata_size(compact_metadata) > MAX_TEMPORAL_METADATA_BYTES:
+        compact_metadata = {
+            key: value
+            for key, value in compact_metadata.items()
+            if key in _ESSENTIAL_PUBLISHED_METADATA_KEYS
+            or key in _PUBLISHED_ARTIFACT_REF_KEYS
+        }
+        compact_metadata["workflowHistoryMetadataCompacted"] = True
+
+    if _serialized_metadata_size(compact_metadata) > MAX_TEMPORAL_METADATA_BYTES:
+        compact_metadata.pop("queuedChildren", None)
+        compact_metadata.pop("providerFailure", None)
+        compact_metadata.pop("terminalContractMissingEvidence", None)
+
+    compact_payload["metadata"] = compact_metadata
+    return compact_payload

--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -37,6 +37,9 @@ with workflow.unsafe.imports_passed_through():
         ExternalAgentRunInput,
     )
     from moonmind.schemas.temporal_payload_policy import compact_temporal_ref_metadata
+    from moonmind.workflows.temporal.agent_result_payloads import (
+        compact_agent_run_result_payload_for_workflow_history,
+    )
     from moonmind.workflows.adapters.agent_adapter import AgentAdapter
     from moonmind.workflows.adapters.managed_agent_adapter import (
         ManagedAgentAdapter,
@@ -150,183 +153,6 @@ def _setdefault_compact_ref_metadata(
 ) -> None:
     for key, compact_value in compact_temporal_ref_metadata(field_name, value).items():
         metadata.setdefault(key, compact_value)
-
-
-def _compact_workflow_text(value: Any, *, max_chars: int = 700) -> str | None:
-    if not isinstance(value, str):
-        return None
-    text = value.strip()
-    if not text:
-        return None
-    if len(text) > max_chars:
-        return text[: max_chars - 3].rstrip() + "..."
-    return text
-
-
-def _compact_workflow_scalar(value: Any) -> Any:
-    if isinstance(value, str):
-        return _compact_workflow_text(value)
-    if value is None or isinstance(value, (bool, int, float)):
-        return value
-    return None
-
-
-def _compact_workflow_text_list(
-    value: Any,
-    *,
-    max_items: int = 20,
-    max_chars: int = 400,
-) -> list[str]:
-    if not isinstance(value, (list, tuple)):
-        return []
-    compact: list[str] = []
-    for item in value:
-        text = _compact_workflow_text(item, max_chars=max_chars)
-        if text:
-            compact.append(text)
-        if len(compact) >= max_items:
-            break
-    return compact
-
-
-def _compact_workflow_text_mapping(value: Any) -> dict[str, str]:
-    if not isinstance(value, Mapping):
-        return {}
-    compact: dict[str, str] = {}
-    for raw_key, raw_value in value.items():
-        key = _compact_workflow_text(str(raw_key), max_chars=120)
-        text = _compact_workflow_text(raw_value, max_chars=400)
-        if key and text:
-            compact[key] = text
-        if len(compact) >= 20:
-            break
-    return compact
-
-
-def _compact_moonspec_verify_for_workflow_history(
-    value: Mapping[str, Any],
-) -> dict[str, Any]:
-    compact: dict[str, Any] = {}
-    scalar_keys = (
-        "schemaVersion",
-        "verdict",
-        "gateVerdict",
-        "gate_verdict",
-        "moonSpecVerdict",
-        "moonspecVerdict",
-        "verificationVerdict",
-        "verification_verdict",
-        "confidence",
-        "recommendedNextAction",
-        "recommended_next_action",
-        "targetLogicalStepId",
-        "target_logical_step_id",
-        "workspacePolicyRecommendation",
-        "workspace_policy_recommendation",
-        "recoverableInCurrentRuntime",
-        "recoverable_in_current_runtime",
-        "invalid",
-        "degraded",
-        "remainingWorkRef",
-        "remaining_work_ref",
-        "diagnosticsRef",
-        "diagnostics_ref",
-        "verificationReportRef",
-        "verification_report_ref",
-        "reportRef",
-        "report_ref",
-        "gateResultRef",
-        "gate_result_ref",
-        "artifactRef",
-        "artifact_ref",
-    )
-    for key in scalar_keys:
-        field_value = _compact_workflow_scalar(value.get(key))
-        if field_value is not None:
-            compact[key] = field_value
-
-    for key in ("feedback", "summary", "message", "downgradeReason"):
-        text = _compact_workflow_text(value.get(key), max_chars=900)
-        if text:
-            compact[key] = text
-
-    for key in ("invalidatedRefs", "invalidated_refs"):
-        refs = _compact_workflow_text_list(value.get(key))
-        if refs:
-            compact[key] = refs
-            break
-    for key in ("blockingEvidenceRefs", "blocking_evidence_refs"):
-        refs = _compact_workflow_text_list(value.get(key))
-        if refs:
-            compact[key] = refs
-            break
-
-    validated_refs = _compact_workflow_text_mapping(
-        value.get("validatedRefs") or value.get("validated_refs")
-    )
-    if validated_refs:
-        compact["validatedRefs"] = validated_refs
-
-    contract_violations = _compact_workflow_text_list(
-        value.get("contractViolations") or value.get("contract_violations"),
-        max_items=10,
-        max_chars=700,
-    )
-    if contract_violations:
-        compact["contractViolations"] = contract_violations
-
-    return compact
-
-
-def _compact_agent_run_result_payload_for_workflow_history(
-    payload: Mapping[str, Any],
-) -> dict[str, Any]:
-    compact_payload = dict(payload)
-    metadata = compact_payload.get("metadata")
-    if not isinstance(metadata, Mapping):
-        return compact_payload
-
-    compact_metadata = dict(metadata)
-    for key in (
-        "moonSpecVerify",
-        "moonspecVerify",
-        "moonspec_verify",
-        "verificationResult",
-        "verification_result",
-    ):
-        value = compact_metadata.get(key)
-        if isinstance(value, Mapping):
-            compact_metadata[key] = _compact_moonspec_verify_for_workflow_history(
-                value
-            )
-
-    queued_children = compact_metadata.get("queuedChildren")
-    if isinstance(queued_children, (list, tuple)):
-        compact_children: list[dict[str, str]] = []
-        for child in queued_children:
-            if not isinstance(child, Mapping):
-                continue
-            compact_child: dict[str, str] = {}
-            workflow_id = _compact_workflow_text(
-                child.get("workflowId"), max_chars=400
-            )
-            execution_id = _compact_workflow_text(
-                child.get("executionId"), max_chars=400
-            )
-            if workflow_id:
-                compact_child["workflowId"] = workflow_id
-            if execution_id and execution_id != workflow_id:
-                compact_child["executionId"] = execution_id
-            reference = _compact_workflow_text(
-                child.get("ref") or child.get("targetRef"), max_chars=400
-            )
-            if reference:
-                compact_child["ref"] = reference
-            if compact_child:
-                compact_children.append(compact_child)
-        compact_metadata["queuedChildren"] = compact_children
-    compact_payload["metadata"] = compact_metadata
-    return compact_payload
 
 
 # Default workflow-level execution timeouts
@@ -1649,7 +1475,7 @@ class MoonMindAgentRun:
             self.final_result = AgentRunResult(**publish_payload)
         except ValueError:
             compacted_payload = (
-                _compact_agent_run_result_payload_for_workflow_history(
+                compact_agent_run_result_payload_for_workflow_history(
                     publish_payload
                 )
             )
@@ -1678,7 +1504,7 @@ class MoonMindAgentRun:
                 self.final_result = AgentRunResult(**enriched_result)
             except ValueError:
                 compacted_result = (
-                    _compact_agent_run_result_payload_for_workflow_history(
+                    compact_agent_run_result_payload_for_workflow_history(
                         enriched_result
                     )
                 )

--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -299,6 +299,32 @@ def _compact_agent_run_result_payload_for_workflow_history(
             compact_metadata[key] = _compact_moonspec_verify_for_workflow_history(
                 value
             )
+
+    queued_children = compact_metadata.get("queuedChildren")
+    if isinstance(queued_children, (list, tuple)):
+        compact_children: list[dict[str, str]] = []
+        for child in queued_children:
+            if not isinstance(child, Mapping):
+                continue
+            compact_child: dict[str, str] = {}
+            workflow_id = _compact_workflow_text(
+                child.get("workflowId"), max_chars=400
+            )
+            execution_id = _compact_workflow_text(
+                child.get("executionId"), max_chars=400
+            )
+            if workflow_id:
+                compact_child["workflowId"] = workflow_id
+            if execution_id and execution_id != workflow_id:
+                compact_child["executionId"] = execution_id
+            reference = _compact_workflow_text(
+                child.get("ref") or child.get("targetRef"), max_chars=400
+            )
+            if reference:
+                compact_child["ref"] = reference
+            if compact_child:
+                compact_children.append(compact_child)
+        compact_metadata["queuedChildren"] = compact_children
     compact_payload["metadata"] = compact_metadata
     return compact_payload
 
@@ -1618,6 +1644,23 @@ class MoonMindAgentRun:
             request=request,
             result=result,
         )
+        publish_payload = self.final_result.model_dump(mode="json", by_alias=True)
+        try:
+            self.final_result = AgentRunResult(**publish_payload)
+        except ValueError:
+            compacted_payload = (
+                _compact_agent_run_result_payload_for_workflow_history(
+                    publish_payload
+                )
+            )
+            if compacted_payload == publish_payload:
+                raise
+            # Validate before scheduling the typed activity. Pydantic model_copy
+            # intentionally skips validation, so metadata accumulated across
+            # fetch-result, terminal-evidence, and workflow enrichment can exceed
+            # the AgentRunResult boundary even though every individual producer
+            # returned a valid result.
+            self.final_result = AgentRunResult(**compacted_payload)
         enriched_result = await self._execute_routed_activity(
             "agent_runtime.publish_artifacts",
             self.final_result,

--- a/moonmind/workflows/terminal_evidence.py
+++ b/moonmind/workflows/terminal_evidence.py
@@ -23,6 +23,16 @@ class TerminalEvidenceEvaluation:
     outcome: TerminalEvidenceOutcome = "terminal_failure"
 
 
+@dataclass(frozen=True)
+class TerminalEvidenceSource:
+    """Resolved, workspace-confined source for terminal contract evidence."""
+
+    relative_path: str
+    path: Path | None = None
+    failure_code: str | None = None
+    missing_evidence: tuple[str, ...] = ()
+
+
 def _failure(
     failure_code: str,
     missing_evidence: tuple[str, ...] = (),
@@ -36,6 +46,48 @@ def _failure(
 def _success(metadata: dict[str, Any] | None = None) -> TerminalEvidenceEvaluation:
     return TerminalEvidenceEvaluation(
         True, metadata=metadata or {}, outcome="terminal_success"
+    )
+
+
+def resolve_terminal_evidence_source(
+    contract: Mapping[str, Any],
+    *,
+    workspace_path: str,
+    artifact_spool_path: str = "",
+) -> TerminalEvidenceSource:
+    """Resolve the declared evidence file without escaping trusted run roots."""
+
+    relative = str(contract.get("relativePath") or contract.get("relative_path") or "")
+    normalized_relative = relative.replace("\\", "/")
+    relative_path = Path(normalized_relative)
+    workspace = Path(workspace_path).resolve()
+    if not relative or relative_path.is_absolute() or ".." in relative_path.parts:
+        return TerminalEvidenceSource(
+            relative_path=normalized_relative,
+            failure_code="INVALID_TERMINAL_EVIDENCE_PATH",
+        )
+    evidence_root = workspace
+    evidence_relative = relative_path
+    if artifact_spool_path and relative_path.parts[:1] == ("artifacts",):
+        evidence_root = Path(artifact_spool_path).resolve()
+        evidence_relative = Path(*relative_path.parts[1:])
+    evidence_path = (evidence_root / evidence_relative).resolve()
+    try:
+        evidence_path.relative_to(evidence_root)
+    except ValueError:
+        return TerminalEvidenceSource(
+            relative_path=normalized_relative,
+            failure_code="INVALID_TERMINAL_EVIDENCE_PATH",
+        )
+    if not evidence_path.is_file():
+        return TerminalEvidenceSource(
+            relative_path=normalized_relative,
+            failure_code="INCOMPLETE_TERMINAL_CONTRACT",
+            missing_evidence=(relative,),
+        )
+    return TerminalEvidenceSource(
+        relative_path=normalized_relative,
+        path=evidence_path,
     )
 
 
@@ -129,25 +181,19 @@ def evaluate_terminal_evidence(
     }:
         return _failure("UNSUPPORTED_TERMINAL_CONTRACT")
     relative = str(contract.get("relativePath") or contract.get("relative_path") or "")
-    normalized_relative = relative.replace("\\", "/")
-    relative_path = Path(normalized_relative)
-    workspace = Path(workspace_path).resolve()
-    if not relative or relative_path.is_absolute() or ".." in relative_path.parts:
-        return _failure("INVALID_TERMINAL_EVIDENCE_PATH")
-    evidence_root = workspace
-    evidence_relative = relative_path
-    if artifact_spool_path and relative_path.parts[:1] == ("artifacts",):
-        evidence_root = Path(artifact_spool_path).resolve()
-        evidence_relative = Path(*relative_path.parts[1:])
-    evidence_path = (evidence_root / evidence_relative).resolve()
-    try:
-        evidence_path.relative_to(evidence_root)
-    except ValueError:
-        return _failure("INVALID_TERMINAL_EVIDENCE_PATH")
-    if not evidence_path.is_file():
+    source = resolve_terminal_evidence_source(
+        contract,
+        workspace_path=workspace_path,
+        artifact_spool_path=artifact_spool_path,
+    )
+    normalized_relative = source.relative_path
+    if source.failure_code:
+        return _failure(source.failure_code, source.missing_evidence)
+    if source.path is None:
         return _failure("INCOMPLETE_TERMINAL_CONTRACT", (relative,))
+    workspace = Path(workspace_path).resolve()
     try:
-        payload = json.loads(evidence_path.read_text(encoding="utf-8"))
+        payload = json.loads(source.path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError):
         return _failure("MALFORMED_TERMINAL_EVIDENCE")
     if not isinstance(payload, dict):

--- a/tests/integration/reliability/replays/agent-run-publish-metadata-overflow/expected-outcome.json
+++ b/tests/integration/reliability/replays/agent-run-publish-metadata-overflow/expected-outcome.json
@@ -1,0 +1,16 @@
+{
+  "terminalOutcome": "terminal_success",
+  "parentState": "succeeded",
+  "queuedChildCount": 23,
+  "preservedQueuedChildFields": [
+    "workflowId",
+    "ref"
+  ],
+  "artifactOnlyQueuedChildFields": [
+    "provider",
+    "executionId",
+    "targetRef",
+    "idempotencyKey"
+  ],
+  "maxMetadataBytes": 16384
+}

--- a/tests/integration/reliability/replays/agent-run-publish-metadata-overflow/manifest.json
+++ b/tests/integration/reliability/replays/agent-run-publish-metadata-overflow/manifest.json
@@ -1,0 +1,83 @@
+{
+  "failureShapeId": "agent-run-publish-metadata-overflow",
+  "incidentWorkflowId": "mm:dc7271dd-64b5-4f98-8da5-081d12f13442",
+  "runtime": {
+    "runtimeId": "codex_cli",
+    "protocol": "codex_app_server",
+    "executionLane": "direct_managed_session"
+  },
+  "activityName": "agent_runtime.publish_artifacts",
+  "expectedTaskQueue": "mm.activity.agent_runtime",
+  "eventScript": [
+    {
+      "event": "agent_runtime.fetch_result",
+      "metadataBytes": 4894,
+      "outcome": "completed"
+    },
+    {
+      "event": "agent_runtime.evaluate_terminal_evidence",
+      "metadataBytes": 13668,
+      "outcome": "terminal_success",
+      "queuedChildCount": 23
+    },
+    {
+      "event": "MoonMind.AgentRun.enrich_result_metadata",
+      "metadataBytes": 16656,
+      "outcome": "activity_input_rejected_before_fix"
+    }
+  ],
+  "workspaceArtifactManifest": {
+    "terminalEvidencePath": "artifacts/batch-workflows-result.json",
+    "schemaVersion": "moonmind.batch-workflows-result.v1",
+    "contractId": "batch_workflows_fanout.v1",
+    "status": "queued",
+    "requested": 23,
+    "created": 23,
+    "skipped": 0,
+    "errors": 0
+  },
+  "request": {
+    "agentKind": "managed",
+    "agentId": "codex_cli",
+    "executionProfileRef": "codex-openai-oauth",
+    "correlationId": "replay-agent-run-publish-metadata-overflow",
+    "idempotencyKey": "replay-agent-run-publish-metadata-overflow:1",
+    "instructionRef": "artifact:replay-instructions",
+    "resolvedSkillsetRef": "art_01REPLAYRESOLVEDSKILLSET000",
+    "managedSession": {
+      "workflowId": "mm:replay-parent:session:codex_cli",
+      "agentRunId": "mm:00000000-0000-0000-0000-000000000002",
+      "sessionId": "sess:mm:replay-parent:codex_cli",
+      "sessionEpoch": 1,
+      "runtimeId": "codex_cli",
+      "executionProfileRef": "codex-openai-oauth"
+    },
+    "workspaceSpec": {
+      "repository": "MoonLadderStudios/Tactics",
+      "repo": "MoonLadderStudios/Tactics",
+      "branch": "main"
+    },
+    "parameters": {
+      "publishMode": "none",
+      "metadata": {
+        "moonmind": {
+          "selectedSkill": "batch-workflows",
+          "stepLedger": {
+            "logicalStepId": "tpl:batch-github-workflows:01:replay",
+            "scope": "step",
+            "executionOrdinal": 1
+          }
+        }
+      }
+    }
+  },
+  "resultShape": {
+    "summary": "Completed with status completed",
+    "lastAssistantTextChars": 3112,
+    "operatorSummaryChars": 1414,
+    "queuedChildCount": 23,
+    "firstIssueNumber": 2347,
+    "repository": "MoonLadderStudios/Tactics",
+    "idempotencyDigestChars": 64
+  }
+}

--- a/tests/integration/reliability/test_escaped_failure_journeys.py
+++ b/tests/integration/reliability/test_escaped_failure_journeys.py
@@ -280,6 +280,144 @@ async def test_completed_batch_turn_is_rejected_at_agent_run_boundary(
     ]
 
 
+async def test_successful_batch_fanout_is_compacted_before_publish_activity_decode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Replay mm:dc7271dd at the AgentRun-to-publish activity boundary."""
+
+    replay_id = "agent-run-publish-metadata-overflow"
+    manifest = load_replay(replay_id, "manifest.json")
+    expected = load_replay(replay_id, "expected-outcome.json")
+    shape = manifest["resultShape"]
+    request = AgentExecutionRequest.model_validate(manifest["request"])
+    assert request.managed_session is not None
+    queued_children = []
+    for index in range(shape["queuedChildCount"]):
+        issue_number = shape["firstIssueNumber"] + index
+        execution_id = f"mm:00000000-0000-0000-0000-{index:012d}"
+        target_ref = f"{shape['repository']}#{issue_number}"
+        queued_children.append(
+            {
+                "provider": "github",
+                "ref": target_ref,
+                "workflowId": execution_id,
+                "executionId": execution_id,
+                "targetRef": target_ref,
+                "idempotencyKey": (
+                    f"batch-workflows:github:{target_ref}:sha256:"
+                    + "a" * shape["idempotencyDigestChars"]
+                ),
+            }
+        )
+
+    provider_result = AgentRunResult(
+        summary=shape["summary"],
+        metadata={
+            "agentRunId": request.managed_session.agent_run_id,
+            "diagnosticsRef": "sess:" + "d" * 66,
+            "lastAssistantText": "A" * shape["lastAssistantTextChars"],
+            "operator_summary": "B" * shape["operatorSummaryChars"],
+            "queuedChildCount": len(queued_children),
+            "queuedChildren": queued_children,
+            "stderrArtifactRef": "sess:" + "e" * 60,
+            "stdoutArtifactRef": "sess:" + "o" * 60,
+            "instructionRefOmitted": True,
+            "instructionRefSha256": "f" * 64,
+            "instructionRefLengthChars": 2247,
+            "terminalContractAuthority": "MoonMind.AgentRun",
+            "terminalContractEvidencePath": manifest[
+                "workspaceArtifactManifest"
+            ]["terminalEvidencePath"],
+            "terminalContractExecutionRef": "execution:" + "e" * 118,
+            "terminalContractId": manifest["workspaceArtifactManifest"][
+                "contractId"
+            ],
+            "terminalContractOutcome": expected["terminalOutcome"],
+            "terminalContractSatisfied": True,
+        },
+    )
+    agent_run = MoonMindAgentRun()
+    workflow_info = type(
+        "WorkflowInfo",
+        (),
+        {
+            "namespace": "default",
+            "workflow_id": (
+                "mm:replay-parent:agent:tpl:batch-github-workflows:01:replay"
+            ),
+            "run_id": "00000000-0000-0000-0000-000000000001",
+            "search_attributes": {},
+            "parent": None,
+        },
+    )
+    monkeypatch.setattr(agent_run_module.workflow, "info", workflow_info)
+    monkeypatch.setattr(agent_run_module.workflow, "patched", lambda _patch: True)
+
+    prepublication_result = agent_run._enrich_result_metadata(
+        request=request,
+        result=provider_result,
+    )
+    assert prepublication_result is not None
+    prepublication_metadata = dict(prepublication_result.metadata)
+    prepublication_metadata["resiliencyPolicy"] = {
+        "noProgressTimeoutSeconds": 1800,
+        "retryPolicy": {},
+        "runtime": "codex_cli",
+        "stuckAction": "request_intervention",
+    }
+    prepublication_result = prepublication_result.model_copy(
+        update={"metadata": prepublication_metadata}
+    )
+    with pytest.raises(ValueError, match="metadata must serialize"):
+        AgentRunResult.model_validate(
+            prepublication_result.model_dump(mode="json", by_alias=True)
+        )
+
+    published_payloads: list[AgentRunResult] = []
+
+    async def execute_activity(
+        name: str,
+        payload: AgentRunResult,
+        **kwargs: object,
+    ) -> dict:
+        assert name == manifest["activityName"]
+        assert kwargs["task_queue"] == manifest["expectedTaskQueue"]
+        validated = AgentRunResult.model_validate(
+            payload.model_dump(mode="json", by_alias=True)
+        )
+        metadata_bytes = len(
+            json.dumps(
+                validated.metadata,
+                sort_keys=True,
+                separators=(",", ":"),
+            ).encode("utf-8")
+        )
+        assert metadata_bytes <= expected["maxMetadataBytes"]
+        published_payloads.append(validated)
+        return validated.model_dump(mode="json", by_alias=True)
+
+    # Patch only the Temporal SDK handoff so production activity routing remains
+    # part of the escaped-failure replay.
+    monkeypatch.setattr(agent_run_module, "execute_typed_activity", execute_activity)
+
+    result = await agent_run._publish_terminal_result(
+        request=request,
+        result=prepublication_result,
+    )
+
+    assert result.failure_class is None
+    assert expected["parentState"] == "succeeded"
+    assert result.metadata["terminalContractOutcome"] == expected["terminalOutcome"]
+    assert result.metadata["queuedChildCount"] == expected["queuedChildCount"]
+    assert len(published_payloads) == 1
+    projected_children = published_payloads[0].metadata["queuedChildren"]
+    assert len(projected_children) == expected["queuedChildCount"]
+    assert set(projected_children[0]) == set(expected["preservedQueuedChildFields"])
+    assert not set(projected_children[0]).intersection(
+        expected["artifactOnlyQueuedChildFields"]
+    )
+
+
 async def test_dependabot_build_titles_replay_through_portable_skill_classifier() -> (
     None
 ):

--- a/tests/unit/services/temporal/test_agent_runtime_activities.py
+++ b/tests/unit/services/temporal/test_agent_runtime_activities.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from types import SimpleNamespace
 from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
@@ -169,6 +170,58 @@ async def test_publish_artifacts_writes_managed_session_input_reference_artifact
         "output.summary",
         "output.agent_result",
     ]
+
+
+@pytest.mark.asyncio
+async def test_publish_artifacts_compacts_metadata_added_after_near_limit_input():
+    metadata = {
+        "lastAssistantText": "A" * 8000,
+        "operator_summary": "",
+        "terminalContractSatisfied": True,
+    }
+    base_size = len(
+        json.dumps(metadata, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    )
+    metadata["operator_summary"] = "B" * (16_250 - base_size)
+    encoded_size = len(
+        json.dumps(metadata, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    )
+    assert encoded_size == 16_250
+    input_result = AgentRunResult(summary="done", metadata=metadata)
+    captured_payloads: list[object] = []
+
+    async def fake_write_json_artifact(
+        _service,
+        *,
+        principal,
+        payload,
+        execution_ref=None,
+        metadata_json=None,
+    ):
+        del principal, execution_ref, metadata_json
+        captured_payloads.append(payload)
+        artifact_id = (
+            "art_summary_" + "s" * 64
+            if len(captured_payloads) == 1
+            else "art_result_" + "r" * 64
+        )
+        return SimpleNamespace(artifact_id=artifact_id)
+
+    activities = TemporalAgentRuntimeActivities(artifact_service=object())
+    with patch(
+        "moonmind.workflows.temporal.activity_runtime._write_json_artifact",
+        new=fake_write_json_artifact,
+    ):
+        result = await activities.agent_runtime_publish_artifacts(input_result)
+
+    assert isinstance(result, AgentRunResult)
+    assert result.metadata["outputSummaryRef"] == "art_summary_" + "s" * 64
+    assert result.metadata["outputAgentResultRef"] == "art_result_" + "r" * 64
+    assert result.metadata["workflowHistoryMetadataCompacted"] is True
+    assert "lastAssistantText" not in result.metadata
+    assert result.metadata["operator_summary"].startswith("B")
+    assert captured_payloads[1]["metadata"]["lastAssistantText"] == "A" * 8000
+    AgentRunResult.model_validate(result.model_dump(mode="json", by_alias=True))
 
 @pytest.mark.asyncio
 async def test_publish_artifacts_captures_story_breakdown_handoff(tmp_path):

--- a/tests/unit/workflows/temporal/test_agent_runtime_activities.py
+++ b/tests/unit/workflows/temporal/test_agent_runtime_activities.py
@@ -15,7 +15,7 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from pydantic import BaseModel
@@ -6358,6 +6358,74 @@ async def test_terminal_evidence_activity_enriches_existing_helper_failure(
     assert result.provider_error_code == "process_exit_1"
     assert result.metadata["failureCode"] == "BATCH_FANOUT_PARTIAL_FAILURE"
     assert result.metadata["queuedChildren"] == [{"executionId": "child-1"}]
+
+
+@pytest.mark.asyncio
+async def test_terminal_evidence_activity_publishes_full_fanout_manifest(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "repo"
+    spool = tmp_path / "spool"
+    targets = workspace / "artifacts/batch-workflows-targets.json"
+    targets.parent.mkdir(parents=True)
+    targets.write_text('[{"ref":"MoonMind#1"}]', encoding="utf-8")
+    spool.mkdir()
+    queued_child = {
+        "provider": "github",
+        "ref": "MoonMind#1",
+        "workflowId": "mm:child-1",
+        "executionId": "mm:child-1",
+        "idempotencyKey": "batch-workflows:github:MoonMind#1:sha256:abc",
+    }
+    manifest = {
+        "schemaVersion": "moonmind.batch-workflows-result.v1",
+        "contractId": "batch_workflows_fanout.v1",
+        "executionRef": "step-1",
+        "targetsSha256": hashlib.sha256(targets.read_bytes()).hexdigest(),
+        "status": "queued",
+        "requested": 1,
+        "created": 1,
+        "queued": [queued_child],
+        "skipped": [],
+        "errors": [],
+    }
+    evidence_path = spool / "batch-workflows-result.json"
+    evidence_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    artifact_service = MagicMock()
+    artifact_service.create = AsyncMock(
+        return_value=(SimpleNamespace(artifact_id="art-terminal-evidence"), None)
+    )
+    artifact_service.write_complete = AsyncMock(
+        return_value=SimpleNamespace(artifact_id="art-terminal-evidence")
+    )
+    activities = TemporalAgentRuntimeActivities(artifact_service=artifact_service)
+
+    result = await activities.agent_runtime_evaluate_terminal_evidence(
+        {
+            "workspacePath": str(workspace),
+            "artifactSpoolPath": str(spool),
+            "terminalContract": {
+                "contractId": "batch_workflows_fanout.v1",
+                "relativePath": "artifacts/batch-workflows-result.json",
+                "expectedSchemaVersion": "moonmind.batch-workflows-result.v1",
+                "executionRef": "step-1",
+            },
+            "result": {"summary": "Queued one child."},
+        }
+    )
+
+    assert result.metadata["terminalContractSatisfied"] is True
+    assert result.metadata["terminalContractEvidenceRef"] == "art-terminal-evidence"
+    assert result.metadata["queuedChildren"] == [queued_child]
+    published = json.loads(
+        artifact_service.write_complete.await_args.kwargs["payload"].decode("utf-8")
+    )
+    assert published["queued"][0]["provider"] == "github"
+    assert published["queued"][0]["idempotencyKey"] == queued_child["idempotencyKey"]
+    assert artifact_service.create.await_args.kwargs["metadata_json"]["path"] == (
+        "artifacts/batch-workflows-result.json"
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py
@@ -574,6 +574,79 @@ async def test_publish_terminal_result_compacts_replayed_moonspec_verify_metadat
     AgentRunResult(**result.model_dump(mode="json", by_alias=True))
 
 
+async def test_publish_terminal_result_compacts_large_fanout_before_activity_decode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Keep a successful fan-out result inside the typed activity boundary."""
+
+    _configure_workflow_runtime(monkeypatch)
+    run = MoonMindAgentRun()
+    request = _managed_session_request()
+    queued_children = []
+    for index in range(23):
+        issue_number = 2347 + index
+        execution_id = f"mm:00000000-0000-0000-0000-{index:012d}"
+        target_ref = f"MoonLadderStudios/Tactics#{issue_number}"
+        queued_children.append(
+            {
+                "provider": "github",
+                "ref": target_ref,
+                "workflowId": execution_id,
+                "executionId": execution_id,
+                "targetRef": target_ref,
+                "idempotencyKey": (
+                    f"batch-workflows:github:{target_ref}:sha256:" + "a" * 64
+                ),
+            }
+        )
+    provider_result = AgentRunResult(
+        summary="Completed with status completed",
+        metadata={
+            "lastAssistantText": "A" * 5000,
+            "operator_summary": "B" * 1410,
+            "queuedChildCount": len(queued_children),
+            "queuedChildren": queued_children,
+            "terminalContractId": "batch_workflows_fanout.v1",
+            "terminalContractSatisfied": True,
+            "terminalContractOutcome": "terminal_success",
+        },
+    )
+    unbounded = run._enrich_result_metadata(request=request, result=provider_result)
+    assert unbounded is not None
+    with pytest.raises(ValueError, match="metadata must serialize"):
+        AgentRunResult(**unbounded.model_dump(mode="json", by_alias=True))
+
+    published_payloads: list[AgentRunResult] = []
+
+    async def fake_publish_activity(
+        name: str,
+        payload: AgentRunResult,
+        **_kwargs: Any,
+    ) -> AgentRunResult:
+        assert name == "agent_runtime.publish_artifacts"
+        AgentRunResult(**payload.model_dump(mode="json", by_alias=True))
+        published_payloads.append(payload)
+        return payload
+
+    run._execute_routed_activity = fake_publish_activity  # type: ignore[method-assign]
+
+    result = await run._publish_terminal_result(
+        request=request,
+        result=provider_result,
+    )
+
+    assert len(published_payloads) == 1
+    compact_children = published_payloads[0].metadata["queuedChildren"]
+    assert len(compact_children) == len(queued_children)
+    assert compact_children[0] == {
+        "workflowId": queued_children[0]["workflowId"],
+        "ref": queued_children[0]["ref"],
+    }
+    assert result.metadata["queuedChildCount"] == len(queued_children)
+    assert result.metadata["terminalContractSatisfied"] is True
+    assert run._terminal_result_payload_compacted_for_history is False
+
+
 async def test_publish_terminal_result_releases_slot_after_compacted_replay_cleanup(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py
@@ -607,6 +607,7 @@ async def test_publish_terminal_result_compacts_large_fanout_before_activity_dec
             "queuedChildCount": len(queued_children),
             "queuedChildren": queued_children,
             "terminalContractId": "batch_workflows_fanout.v1",
+            "terminalContractEvidenceRef": "art_terminal_evidence",
             "terminalContractSatisfied": True,
             "terminalContractOutcome": "terminal_success",
         },
@@ -643,6 +644,7 @@ async def test_publish_terminal_result_compacts_large_fanout_before_activity_dec
         "ref": queued_children[0]["ref"],
     }
     assert result.metadata["queuedChildCount"] == len(queued_children)
+    assert result.metadata["terminalContractEvidenceRef"] == "art_terminal_evidence"
     assert result.metadata["terminalContractSatisfied"] is True
     assert run._terminal_result_payload_compacted_for_history is False
 


### PR DESCRIPTION
## Summary

- validate the enriched `AgentRunResult` before scheduling `agent_runtime.publish_artifacts`
- compact large batch fan-out child metadata to linkable workflow identities and references while keeping full details in the authoritative result artifact
- add focused unit coverage and a redacted escaped-failure reliability replay

## Root cause

Workflow `mm:dc7271dd-64b5-4f98-8da5-081d12f13442` successfully queued 23 child workflows with terminal-contract success. Subsequent AgentRun runtime/session enrichment grew metadata beyond the 16 KiB contract limit. Because Pydantic `model_copy` skips validation, the oversized payload reached the activity boundary and failed during worker argument decoding before artifact publication ran.

## Impact

Successful batch fan-out runs no longer register as failures solely because accumulated terminal metadata crosses the Temporal payload limit. Child workflow links and terminal outcome evidence remain available in the compact result.

## Validation

- `./tools/test_unit.sh --python-only tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py` — 49 passed
- targeted `reliability_journey` replay — passed
- exact incident payload validation — compacted from 16,791 bytes to 10,673 bytes while preserving all 23 child links and terminal success
- `git diff --check` — passed
