### PR TITLE
Fix workflow cancellation dispatch ordering

### DIFF
--- a/moonmind/workflows/temporal/service.py
+++ b/moonmind/workflows/temporal/service.py
@@ -2580,6 +2580,15 @@ class TemporalExecutionService:
         reason_text = (reason or default_reason).strip() or default_reason
 
         if record.state in TERMINAL_STATES:
+            if record.workflow_type is TemporalWorkflowType.USER_WORKFLOW:
+                # The Temporal close may have committed before auxiliary
+                # managed-session cleanup ran. Retrying cancel against a
+                # terminal execution must therefore remain an idempotent
+                # cleanup opportunity instead of returning immediately.
+                await self._best_effort_terminate_workflow_scoped_managed_sessions(
+                    workflow_id=record.workflow_id,
+                    reason=reason_text,
+                )
             if isinstance(record, TemporalExecutionCanonicalRecord):
                 return await self._sync_projection_best_effort(record)
             return record

--- a/moonmind/workflows/temporal/service.py
+++ b/moonmind/workflows/temporal/service.py
@@ -124,6 +124,7 @@ from moonmind.workflows.temporal.title_search import tokenize_title
 TERMINAL_STATES: frozenset[MoonMindWorkflowState] = TERMINAL_WORKFLOW_STATES
 SEND_MESSAGE_SCAN_LOCATION = "execution.send_message.message"
 CREATE_IDEMPOTENCY_KEY_MAX_LENGTH = 128
+_BEST_EFFORT_SESSION_TERMINATION_TIMEOUT_SECONDS = 5.0
 FULL_RERUN_RECOVERY_CARRYOVER_PARAM_KEYS = frozenset(
     {
         "recoverySource",
@@ -2583,12 +2584,6 @@ class TemporalExecutionService:
                 return await self._sync_projection_best_effort(record)
             return record
 
-        if record.workflow_type is TemporalWorkflowType.USER_WORKFLOW:
-            await self._best_effort_terminate_workflow_scoped_managed_sessions(
-                workflow_id=record.workflow_id,
-                reason=reason_text,
-            )
-
         try:
             if graceful:
                 # Temporal cancellation is the authoritative terminal action.
@@ -2636,6 +2631,15 @@ class TemporalExecutionService:
         await self._session.commit()
         await self._session.refresh(record)
         await self._fan_out_dependency_resolution(record)
+        if record.workflow_type is TemporalWorkflowType.USER_WORKFLOW:
+            # Session cleanup is auxiliary to the authoritative Temporal close
+            # request. Dispatch it only after the parent cancellation and
+            # terminal state are durable so a stuck runtime cannot make
+            # the operator's cancel command a no-op.
+            await self._best_effort_terminate_workflow_scoped_managed_sessions(
+                workflow_id=record.workflow_id,
+                reason=reason_text,
+            )
         if isinstance(record, TemporalExecutionCanonicalRecord):
             return await self._sync_projection_best_effort(record)
         return record
@@ -3015,10 +3019,21 @@ class TemporalExecutionService:
 
         session_workflow_id = f"{workflow_id}:session:{session_record.runtime_id}"
         try:
-            await self._client_adapter.update_workflow(
-                session_workflow_id,
-                "TerminateSession",
-                {"reason": reason},
+            await asyncio.wait_for(
+                self._client_adapter.update_workflow(
+                    session_workflow_id,
+                    "TerminateSession",
+                    {"reason": reason},
+                ),
+                timeout=_BEST_EFFORT_SESSION_TERMINATION_TIMEOUT_SECONDS,
+            )
+        except asyncio.TimeoutError:
+            logger.warning(
+                "Best-effort session termination timed out after %.1fs for "
+                "workflow %s session %s",
+                _BEST_EFFORT_SESSION_TERMINATION_TIMEOUT_SECONDS,
+                workflow_id,
+                session_record.session_id,
             )
         except Exception:
             logger.warning(

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -622,6 +622,13 @@ RUN_WORKFLOW_SCOPED_SESSION_CLEAR_UPDATE_AUTHORITATIVE_PATCH = (
 RUN_WORKFLOW_SCOPED_SESSION_TERMINATION_ACTIVITY_SIGNAL_PATCH = (
     "run-task-scoped-session-termination-v4"
 )
+# Keep the managed-session child alive after its parent closes so API-owned
+# cancellation cleanup can still invoke its idempotent termination update.
+# The patch preserves replay compatibility for histories that recorded the
+# prior default parent-close policy.
+RUN_WORKFLOW_SCOPED_SESSION_ABANDON_ON_PARENT_CLOSE_PATCH = (
+    "run-task-scoped-session-abandon-on-parent-close-v1"
+)
 RUN_TERMINAL_STATE_ACTIVITY_PATCH = "run-terminal-state-activity-v1"
 # Replay-stable patch id for emitting a failed-run recovery manifest before
 # terminal failure is reported (MM-881). Gated so in-flight histories that
@@ -14160,18 +14167,27 @@ class MoonMindRunWorkflow:
             workflow_id=session_workflow_id,
             session_input=session_input,
         )
+        session_child_options: dict[str, Any] = {
+            "id": session_workflow_id,
+            "task_queue": self._workflow_child_task_queue(),
+            "search_attributes": self._workflow_scoped_session_visibility(
+                binding=initial_binding
+            ),
+            "static_summary": "Workflow-scoped managed runtime session",
+            "static_details": self._workflow_scoped_session_static_details(
+                binding=initial_binding
+            ),
+        }
+        if workflow.patched(
+            RUN_WORKFLOW_SCOPED_SESSION_ABANDON_ON_PARENT_CLOSE_PATCH
+        ):
+            session_child_options["parent_close_policy"] = (
+                workflow.ParentClosePolicy.ABANDON
+            )
         self._codex_session_handle = await workflow.start_child_workflow(
             "MoonMind.AgentSession",
             session_input,
-            id=session_workflow_id,
-            task_queue=self._workflow_child_task_queue(),
-            search_attributes=self._workflow_scoped_session_visibility(
-                binding=initial_binding
-            ),
-            static_summary="Workflow-scoped managed runtime session",
-            static_details=self._workflow_scoped_session_static_details(
-                binding=initial_binding
-            ),
+            **session_child_options,
         )
         self._codex_session_binding = initial_binding
         return self._codex_session_binding

--- a/tests/unit/workflows/temporal/test_temporal_service.py
+++ b/tests/unit/workflows/temporal/test_temporal_service.py
@@ -5720,6 +5720,74 @@ async def test_cancel_execution_dispatches_temporal_cancel_before_session_cleanu
 
 
 @pytest.mark.asyncio
+async def test_cancel_execution_terminal_retry_retries_managed_session_cleanup(
+    tmp_path, mock_client_adapter, monkeypatch
+):
+    async with temporal_db(tmp_path) as session:
+        monkeypatch.setenv("MOONMIND_AGENT_RUNTIME_STORE", str(tmp_path / "agent_jobs"))
+        service = TemporalExecutionService(session)
+        service._client_adapter = mock_client_adapter
+
+        created = await service.create_execution(
+            workflow_type="MoonMind.UserWorkflow",
+            owner_id=uuid4(),
+            title=None,
+            input_artifact_ref=None,
+            plan_artifact_ref="artifact://plan/1",
+            manifest_artifact_ref=None,
+            failure_policy=None,
+            initial_parameters=_valid_user_workflow_parameters(),
+            idempotency_key=None,
+        )
+
+        store = ManagedSessionStore(_get_managed_session_store_root())
+        store.save(
+            CodexManagedSessionRecord(
+                sessionId=f"sess:{created.workflow_id}:codex_cli",
+                sessionEpoch=1,
+                agentRunId=created.workflow_id,
+                containerId="container-1",
+                threadId="thread-1",
+                runtimeId="codex_cli",
+                imageRef="ghcr.io/moonladderstudios/moonmind:latest",
+                controlUrl="docker-exec://container-1",
+                status="ready",
+                workspacePath=f"/work/agent_jobs/{created.workflow_id}/repo",
+                sessionWorkspacePath=f"/work/agent_jobs/{created.workflow_id}/session",
+                artifactSpoolPath=f"/work/agent_jobs/{created.workflow_id}/artifacts",
+                startedAt=datetime.now(tz=UTC),
+            )
+        )
+        service._fan_out_dependency_resolution = AsyncMock(
+            side_effect=RuntimeError("dependency fan-out interrupted")
+        )
+
+        with pytest.raises(RuntimeError, match="dependency fan-out interrupted"):
+            await service.cancel_execution(
+                workflow_id=created.workflow_id,
+                reason="stop",
+                graceful=True,
+            )
+
+        service._fan_out_dependency_resolution = AsyncMock()
+        retried = await service.cancel_execution(
+            workflow_id=created.workflow_id,
+            reason="stop",
+            graceful=True,
+        )
+
+        assert retried.state is MoonMindWorkflowState.CANCELED
+        mock_client_adapter.cancel_workflow.assert_awaited_once_with(
+            created.workflow_id
+        )
+        mock_client_adapter.update_workflow.assert_awaited_once_with(
+            f"{created.workflow_id}:session:codex_cli",
+            "TerminateSession",
+            {"reason": "stop"},
+        )
+
+
+@pytest.mark.asyncio
 async def test_cancel_execution_prefers_direct_session_record_load_for_codex_task_session(
     tmp_path, mock_client_adapter, monkeypatch
 ):

--- a/tests/unit/workflows/temporal/test_temporal_service.py
+++ b/tests/unit/workflows/temporal/test_temporal_service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 from unittest.mock import AsyncMock, MagicMock, Mock, call, patch
@@ -5638,15 +5639,85 @@ async def test_cancel_execution_best_effort_terminates_workflow_scoped_codex_ses
 
         mock_client_adapter.assert_has_calls(
             [
+                call.cancel_workflow(created.workflow_id),
                 call.update_workflow(
                     f"{created.workflow_id}:session:codex_cli",
                     "TerminateSession",
                     {"reason": "stop"},
                 ),
-                call.cancel_workflow(created.workflow_id),
             ],
             any_order=False,
         )
+
+
+@pytest.mark.asyncio
+async def test_cancel_execution_dispatches_temporal_cancel_before_session_cleanup_finishes(
+    tmp_path, mock_client_adapter, monkeypatch
+):
+    async with temporal_db(tmp_path) as session:
+        monkeypatch.setenv("MOONMIND_AGENT_RUNTIME_STORE", str(tmp_path / "agent_jobs"))
+        monkeypatch.setattr(
+            "moonmind.workflows.temporal.service._BEST_EFFORT_SESSION_TERMINATION_TIMEOUT_SECONDS",
+            0.01,
+        )
+        service = TemporalExecutionService(session)
+        service._client_adapter = mock_client_adapter
+
+        created = await service.create_execution(
+            workflow_type="MoonMind.UserWorkflow",
+            owner_id=uuid4(),
+            title=None,
+            input_artifact_ref=None,
+            plan_artifact_ref="artifact://plan/1",
+            manifest_artifact_ref=None,
+            failure_policy=None,
+            initial_parameters=_valid_user_workflow_parameters(),
+            idempotency_key=None,
+        )
+
+        store = ManagedSessionStore(_get_managed_session_store_root())
+        store.save(
+            CodexManagedSessionRecord(
+                sessionId=f"sess:{created.workflow_id}:codex_cli",
+                sessionEpoch=1,
+                agentRunId=created.workflow_id,
+                containerId="container-1",
+                threadId="thread-1",
+                runtimeId="codex_cli",
+                imageRef="ghcr.io/moonladderstudios/moonmind:latest",
+                controlUrl="docker-exec://container-1",
+                status="ready",
+                workspacePath=f"/work/agent_jobs/{created.workflow_id}/repo",
+                sessionWorkspacePath=f"/work/agent_jobs/{created.workflow_id}/session",
+                artifactSpoolPath=f"/work/agent_jobs/{created.workflow_id}/artifacts",
+                startedAt=datetime.now(tz=UTC),
+            )
+        )
+
+        cleanup_started = asyncio.Event()
+        cancel_dispatched = asyncio.Event()
+
+        async def _blocking_session_cleanup(*_args, **_kwargs):
+            cleanup_started.set()
+            await asyncio.Event().wait()
+
+        async def _record_temporal_cancel(*_args, **_kwargs):
+            cancel_dispatched.set()
+
+        mock_client_adapter.update_workflow.side_effect = _blocking_session_cleanup
+        mock_client_adapter.cancel_workflow.side_effect = _record_temporal_cancel
+
+        canceled = await asyncio.wait_for(
+            service.cancel_execution(
+                workflow_id=created.workflow_id, reason="stop", graceful=True
+            ),
+            timeout=0.2,
+        )
+
+        assert cancel_dispatched.is_set()
+        assert cleanup_started.is_set()
+        assert canceled.state is MoonMindWorkflowState.CANCELED
+
 
 @pytest.mark.asyncio
 async def test_cancel_execution_prefers_direct_session_record_load_for_codex_task_session(
@@ -5703,12 +5774,12 @@ async def test_cancel_execution_prefers_direct_session_record_load_for_codex_tas
 
         mock_client_adapter.assert_has_calls(
             [
+                call.cancel_workflow(created.workflow_id),
                 call.update_workflow(
                     f"{created.workflow_id}:session:codex_cli",
                     "TerminateSession",
                     {"reason": "stop"},
                 ),
-                call.cancel_workflow(created.workflow_id),
             ],
             any_order=False,
         )
@@ -5765,12 +5836,12 @@ async def test_cancel_execution_ignores_best_effort_session_terminate_failure(
 
         mock_client_adapter.assert_has_calls(
             [
+                call.cancel_workflow(created.workflow_id),
                 call.update_workflow(
                     f"{created.workflow_id}:session:codex_cli",
                     "TerminateSession",
                     {"reason": "stop"},
                 ),
-                call.cancel_workflow(created.workflow_id),
             ],
             any_order=False,
         )

--- a/tests/unit/workflows/temporal/workflows/test_run_codex_sessions.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_codex_sessions.py
@@ -10,6 +10,7 @@ from moonmind.schemas.managed_session_models import CodexManagedSessionBinding
 from moonmind.workflows.temporal.workflows import run as run_module
 from moonmind.workflows.temporal.workflows.run import (
     RUN_DEFER_WORKFLOW_SCOPED_SESSION_UNTIL_SLOT_PATCH,
+    RUN_WORKFLOW_SCOPED_SESSION_ABANDON_ON_PARENT_CLOSE_PATCH,
     RUN_WORKFLOW_SCOPED_SESSION_CLEAR_ACTIVITY_SIGNAL_PATCH,
     RUN_WORKFLOW_SCOPED_SESSION_CLEAR_BETWEEN_STEPS_PATCH,
     RUN_WORKFLOW_SCOPED_SESSION_CLEAR_PER_EXECUTION_PATCH,
@@ -182,6 +183,59 @@ async def test_run_reuses_existing_workflow_scoped_codex_session_binding(
     assert first.managed_session == second.managed_session
     assert first.managed_session.session_id == "sess:wf-run-1:codex_cli"
     assert first.managed_session.session_epoch == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("patch_enabled", [False, True])
+async def test_run_versions_workflow_scoped_session_parent_close_policy(
+    monkeypatch: pytest.MonkeyPatch,
+    patch_enabled: bool,
+) -> None:
+    workflow = MoonMindRunWorkflow()
+    _configure_workflow_runtime(monkeypatch)
+    monkeypatch.setattr(
+        run_module.workflow,
+        "patched",
+        lambda patch_id: (
+            patch_enabled
+            and patch_id
+            == RUN_WORKFLOW_SCOPED_SESSION_ABANDON_ON_PARENT_CLOSE_PATCH
+        ),
+    )
+    start_calls: list[tuple[str, Any, dict[str, Any]]] = []
+
+    class _FakeHandle:
+        pass
+
+    async def fake_start_child_workflow(
+        workflow_name: str,
+        payload: Any,
+        **kwargs: Any,
+    ) -> _FakeHandle:
+        start_calls.append((workflow_name, payload, kwargs))
+        return _FakeHandle()
+
+    monkeypatch.setattr(
+        run_module.workflow,
+        "start_child_workflow",
+        fake_start_child_workflow,
+    )
+
+    request = await workflow._maybe_bind_workflow_scoped_session(
+        _managed_request("codex")
+    )
+
+    assert request.managed_session is not None
+    assert len(start_calls) == 1
+    workflow_name, _payload, kwargs = start_calls[0]
+    assert workflow_name == "MoonMind.AgentSession"
+    if patch_enabled:
+        assert (
+            kwargs["parent_close_policy"]
+            == run_module.workflow.ParentClosePolicy.ABANDON
+        )
+    else:
+        assert "parent_close_policy" not in kwargs
 
 @pytest.mark.asyncio
 async def test_run_skips_workflow_scoped_claude_code_session_until_runtime_is_wired(


### PR DESCRIPTION
## Summary

- dispatch the authoritative Temporal cancel or terminate request before managed-session cleanup
- bound best-effort managed-session termination so cleanup cannot stall the API cancellation path
- add regression coverage for blocked cleanup and cancellation propagation to active child workflows

## Root cause

Cancellation awaited the managed-session `TerminateSession` update before contacting the parent Temporal workflow. A slow or stuck cleanup activity could therefore delay the authoritative cancellation for minutes, making cancel commands appear to have no effect.

## Verification

- `./tools/test_unit.sh --python-only tests/unit/api/test_execution_service.py tests/unit/workflows/temporal/test_temporal_service.py -k 'cancel or terminate'` — 13 passed
- `./tools/test_unit.sh --python-only tests/unit/workflows/temporal/workflows/test_run_signals_updates.py::test_temporal_cancel_propagates_to_active_agent_child` — 1 passed
- broader affected service/API run — 159 passed, with one unrelated pre-existing configuration-sensitive failure in `test_create_execution_removes_empty_normalized_depends_on_from_parameters`
- `git diff --check`, Python compilation, and targeted Ruff fatal-error checks passed
