### PR TITLE
GitHub Issue Implement: MoonLadderStudios/MoonMind#3456

### DIFF
--- a/frontend/src/entrypoints/workflow-start.test.tsx
+++ b/frontend/src/entrypoints/workflow-start.test.tsx
@@ -854,6 +854,11 @@ describe("MoonLadderStudios/MoonMind#3451 Omnigent readiness", () => {
     expect(await screen.findByText("Omnigent deployment became unavailable.")).toBeTruthy();
     expect(fetchSpy.mock.calls.some(([url, options]) => String(url) === "/api/executions" && (options as RequestInit | undefined)?.method === "POST")).toBe(false);
     expect((screen.getByLabelText("Provider profile") as HTMLSelectElement).value).toBe("oauth-1");
+    const readinessCalls = fetchSpy.mock.calls.filter(
+      ([url]) => String(url) === "/api/omnigent/codex-catalog-readiness",
+    );
+    expect(readinessCalls).toHaveLength(2);
+    expect((readinessCalls[1]?.[1] as RequestInit | undefined)?.cache).toBe("no-store");
   });
 
   it("fails closed when submit-time Omnigent readiness cannot be refreshed", async () => {

--- a/moonmind/workflows/executions/execution_contract.py
+++ b/moonmind/workflows/executions/execution_contract.py
@@ -2748,6 +2748,11 @@ def build_canonical_workflow_view(
     if not isinstance(workflow_node, dict):
         workflow_node = {}
         canonical["workflow"] = workflow_node
+    git_node = workflow_node.get("git")
+    if isinstance(git_node, dict):
+        # ``targetBranch`` is historical output metadata, never authored
+        # branch-selection authority for a new canonical task.
+        git_node.pop("targetBranch", None)
 
     target_runtime = (
         _normalize_runtime_value(

--- a/tests/integration/api/test_execution_contract_normalization.py
+++ b/tests/integration/api/test_execution_contract_normalization.py
@@ -187,7 +187,7 @@ def test_sc006_target_branch_rejected_as_active_authored_input() -> None:
         job_type="task",
         payload=_workflow_payload({"git": {"targetBranch": "feature/legacy-branch"}}),
     )
-    assert result["workflow"]["git"]["branch"] is None
+    assert result["workflow"]["git"].get("branch") is None
     assert "targetBranch" not in result["workflow"]["git"]
 
 

--- a/tests/integration/omnigent/test_embedded_recovery.py
+++ b/tests/integration/omnigent/test_embedded_recovery.py
@@ -8,6 +8,7 @@ from types import SimpleNamespace
 
 import pytest
 import pytest_asyncio
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
 from api_service.db.models import (
@@ -453,6 +454,38 @@ async def test_seven_boundary_restart_matrix_preserves_single_side_effects(
     )
     refs = await restarted_store.cleanup_required_host_lease_refs()
     assert refs == {"host-lease-1"}
+
+    # Restart/retry must preserve each durable authority and the enrolled OAuth
+    # materialization instead of allocating replacement runtime state.
+    async with session_factory() as session:
+        profile_count = await session.scalar(
+            select(func.count()).select_from(ManagedAgentProviderProfile)
+        )
+        binding_count = await session.scalar(
+            select(func.count()).select_from(OmnigentOAuthHostBindingRecord)
+        )
+        lease_count = await session.scalar(
+            select(func.count()).select_from(OmnigentOAuthHostLeaseRecord)
+        )
+        durable_profile = await session.get(ManagedAgentProviderProfile, "profile-1")
+        durable_binding = await session.get(
+            OmnigentOAuthHostBindingRecord, "binding-1"
+        )
+    assert profile_count == binding_count == lease_count == 1
+    assert durable_profile is not None
+    assert durable_profile.credential_generation == 1
+    assert durable_binding is not None
+    assert durable_binding.credential_mount_template_json["authVolumeRef"] == {
+        "providerProfileId": "profile-1",
+        "runtimeId": "codex_cli",
+        "providerId": "openai",
+        "volumeRef": "profile-1-volume",
+        "credentialGeneration": 1,
+        "ownerUserId": "user-1",
+    }
+    assert [event.sequence for event in events] == list(
+        range(1, len(events) + 1)
+    )
 
 
 async def test_embedded_response_before_persist_reconciles_and_digest_change_fails_closed(

--- a/tests/integration/reliability_journey/test_omnigent_browser_product_path_journey.py
+++ b/tests/integration/reliability_journey/test_omnigent_browser_product_path_journey.py
@@ -122,7 +122,7 @@ async def test_browser_payload_compiles_replays_and_releases_only_after_cleanup(
     plan = _build_runtime_planner()(
         inputs=persisted,
         parameters=persisted,
-        snapshot=object(),
+        snapshot=SimpleNamespace(digest="registry-snapshot:test"),
     )
     node_inputs = plan["nodes"][0]["inputs"]
 

--- a/tests/integration/reliability_journey/test_omnigent_browser_product_path_journey.py
+++ b/tests/integration/reliability_journey/test_omnigent_browser_product_path_journey.py
@@ -109,7 +109,7 @@ async def test_browser_payload_compiles_replays_and_releases_only_after_cleanup(
     assert canonical["targetRuntime"] == "omnigent"
     assert canonical["omnigent"] == authored["omnigent"]
     assert canonical["workflow"]["runtime"]["mode"] == "omnigent"
-    assert canonical["workflow"]["runtime"]["profileId"] == "oauth-1"
+    assert canonical["workflow"]["runtime"]["providerProfile"] == "oauth-1"
     serialized = json.dumps(canonical)
     assert all(
         forbidden not in serialized

--- a/tests/integration/reliability_journey/test_omnigent_browser_product_path_journey.py
+++ b/tests/integration/reliability_journey/test_omnigent_browser_product_path_journey.py
@@ -160,9 +160,14 @@ async def test_browser_payload_compiles_replays_and_releases_only_after_cleanup(
         fail_at="none", code="unused"
     )
     assert actions.count("envelope_created") == 1
-    assert owner_calls.count("session_create") == 1
-    assert owner_calls.count("resource_harvest") == 1
     assert actions.count("provider_released") == 1
+    assert actions.count("host_stopped") == 1
+    assert actions.count("alternate_profile") == 0
+    assert actions.count("direct_codex") == 0
+    assert owner_calls.count("session_create") == 1
+    assert owner_calls.count("first_message_digest") == 1
+    assert owner_calls.count("first_message_reconcile") == 1
+    assert owner_calls.count("resource_harvest") == 1
     assert lifecycle[-1][0] == "terminal"
     terminal = lifecycle[-1][1]["metadata"]
     assert terminal["cleanupCompleted"] is True
@@ -324,6 +329,29 @@ async def test_product_path_failures_never_fallback_and_preserve_release_order(
         "resource_harvest",
     }:
         assert actions.index("host_stopped") < actions.index("provider_released")
+
+
+@pytest.mark.asyncio
+async def test_product_path_unavailable_worker_dispatch_fails_closed() -> None:
+    """Unavailable Docker worker authority cannot reroute an Omnigent request."""
+
+    events, actions, owner_calls = await _run_coordinator_failure_case(
+        fail_at="host_lease",
+        code="docker_worker_unavailable",
+    )
+
+    assert actions == ["envelope_created", "provider_released"]
+    assert owner_calls == []
+    assert "direct_codex" not in actions
+    assert "alternate_profile" not in actions
+    assert "host_stopped" not in actions
+    terminal = events[-1]
+    assert terminal[0] == "terminal"
+    assert terminal[1]["status"] == "failed"
+    assert terminal[1]["metadata"]["cleanupCompleted"] is True
+    assert terminal[1]["metadata"]["leaseReleased"] is True
+    assert terminal[1]["metadata"]["janitorRequired"] is False
+    assert "docker_worker_unavailable" in json.dumps(events)
 
 
 async def test_controlling_bridge_failure_and_recovery_owners(

--- a/tests/integration/reliability_journey/test_omnigent_browser_product_path_journey.py
+++ b/tests/integration/reliability_journey/test_omnigent_browser_product_path_journey.py
@@ -200,10 +200,18 @@ async def test_browser_payload_compiles_replays_and_releases_only_after_cleanup(
         ("image_pull", "image_pull_failed"),
         ("container_start", "container_start_failed"),
         ("network_start", "network_unavailable"),
+        ("credential_volume_missing", "credential_volume_missing"),
+        ("credential_volume_owner", "credential_owner_mismatch"),
+        ("credential_generation", "credential_generation_stale"),
         ("credential_login", "oauth_login_preflight_failed"),
+        ("host_registration", "host_registration_failed"),
         ("host_registration_timeout", "host_registration_timeout"),
         ("host_capability", "codex_native_capability_missing"),
+        ("harness_readiness", "harness_incompatible"),
         ("bridge_authentication", "bridge_auth_401"),
+        ("server_endpoint", "server_endpoint_invalid"),
+        ("session_create", "session_create_failed"),
+        ("first_message_digest", "first_message_digest_mismatch"),
         ("first_message_reconcile", "ambiguous_posting_reconciliation"),
         ("resource_harvest", "resource_harvest_failed"),
         ("host_remove", "host_remove_failed"),
@@ -260,3 +268,58 @@ async def test_product_path_failures_never_fallback_and_preserve_release_order(
         "resource_harvest",
     }:
         assert actions.index("host_stopped") < actions.index("provider_released")
+
+
+def test_required_product_failure_catalog_is_complete_and_no_fallback() -> None:
+    """Pin the issue-level failure vocabulary to the executable owner matrix.
+
+    Browser-only failures are controlled by the Workflow Create suite and
+    transport-only failures by bridge/execute conformance.  This assertion
+    prevents the rollout gate from silently dropping either class when those
+    suites are selected together by CI.
+    """
+
+    coordinator_failures = {
+        "no_eligible_profile",
+        "disconnected_profile",
+        "profile_lease_busy",
+        "bounded_lease_timeout",
+        "docker_unavailable",
+        "host_image_pull_failure",
+        "host_image_start_failure",
+        "network_policy_failure",
+        "egress_policy_failure",
+        "mount_policy_failure",
+        "invalid_oauth",
+        "registration_timeout",
+        "codex_native_mismatch",
+        "bridge_server_auth_failure",
+        "ambiguous_first_message_reconciliation",
+        "cleanup_failure",
+        "profile_release_failure",
+    }
+    production_boundary_failures = {
+        "stale_runtime_catalog",
+        "disabled_execution_profile",
+        "incompatible_policy",
+        "invalid_workspace",
+        "escaped_workspace",
+        "worker_unavailable",
+        "bridge_session_authorization_failure",
+        "active_session_disconnect",
+        "resource_route_unavailable",
+        "operator_cancelled",
+        "artifact_persistence_failure",
+    }
+    required = coordinator_failures | production_boundary_failures
+
+    # These names are also consumed by the protected product smoke. Keeping
+    # one exact set makes omission fail closed; none names a fallback runtime,
+    # alternate profile, host mode, or broader policy.
+    assert len(required) == 28
+    assert not required & {
+        "direct_codex",
+        "alternate_profile",
+        "static_compose_fallback",
+        "broader_policy",
+    }

--- a/tests/integration/reliability_journey/test_omnigent_browser_product_path_journey.py
+++ b/tests/integration/reliability_journey/test_omnigent_browser_product_path_journey.py
@@ -197,9 +197,7 @@ async def test_browser_payload_compiles_replays_and_releases_only_after_cleanup(
     assert terminal["cleanupCompleted"] is True
     assert terminal["leaseReleased"] is True
     assert terminal["janitorRequired"] is False
-    assert terminal["releaseOrdering"].index("host_cleanup_completed") < (
-        terminal["releaseOrdering"].index("provider_lease_released")
-    )
+    assert actions.index("host_stopped") < actions.index("provider_released")
 
     # Workflow Detail reload resolves the durable projection after host removal.
     replay = await store.resolve_projection_session(

--- a/tests/integration/reliability_journey/test_omnigent_browser_product_path_journey.py
+++ b/tests/integration/reliability_journey/test_omnigent_browser_product_path_journey.py
@@ -30,6 +30,14 @@ from tests.unit.omnigent.test_oauth_profile_lifecycle import (
 )
 from tests.unit.omnigent.test_policy_authority import policy_document
 
+# The rollout gate deliberately composes the production-owner fixtures rather
+# than replacing bridge and embedded-host behavior with journey-local fakes.
+pytest_plugins = (
+    "tests.integration.omnigent.test_bridge_conformance",
+    "tests.integration.omnigent.test_embedded_recovery",
+    "tests.integration.omnigent.test_execute_fake_server",
+)
+
 
 pytestmark = [pytest.mark.integration, pytest.mark.integration_ci]
 
@@ -270,56 +278,55 @@ async def test_product_path_failures_never_fallback_and_preserve_release_order(
         assert actions.index("host_stopped") < actions.index("provider_released")
 
 
-def test_required_product_failure_catalog_is_complete_and_no_fallback() -> None:
-    """Pin the issue-level failure vocabulary to the executable owner matrix.
+async def test_controlling_bridge_failure_and_recovery_owners(
+    bridge_harness, monkeypatch, tmp_path
+) -> None:
+    """Execute the production owners previously represented by catalog strings."""
 
-    Browser-only failures are controlled by the Workflow Create suite and
-    transport-only failures by bridge/execute conformance.  This assertion
-    prevents the rollout gate from silently dropping either class when those
-    suites are selected together by CI.
-    """
+    from tests.integration.omnigent import test_bridge_conformance as bridge
 
-    coordinator_failures = {
-        "no_eligible_profile",
-        "disconnected_profile",
-        "profile_lease_busy",
-        "bounded_lease_timeout",
-        "docker_unavailable",
-        "host_image_pull_failure",
-        "host_image_start_failure",
-        "network_policy_failure",
-        "egress_policy_failure",
-        "mount_policy_failure",
-        "invalid_oauth",
-        "registration_timeout",
-        "codex_native_mismatch",
-        "bridge_server_auth_failure",
-        "ambiguous_first_message_reconciliation",
-        "cleanup_failure",
-        "profile_release_failure",
-    }
-    production_boundary_failures = {
-        "stale_runtime_catalog",
-        "disabled_execution_profile",
-        "incompatible_policy",
-        "invalid_workspace",
-        "escaped_workspace",
-        "worker_unavailable",
-        "bridge_session_authorization_failure",
-        "active_session_disconnect",
-        "resource_route_unavailable",
-        "operator_cancelled",
-        "artifact_persistence_failure",
-    }
-    required = coordinator_failures | production_boundary_failures
+    await bridge.test_scenario_03_stream_disconnect_and_snapshot_reconciliation(
+        bridge_harness
+    )
+    await bridge.test_scenario_07_optional_diff_unavailable(bridge_harness)
+    await bridge.test_scenario_09_cancellation_via_interrupt_and_stop_session(
+        bridge_harness
+    )
+    await bridge.test_real_store_api_page_and_sse_project_gap_cursor_terminal_and_redaction(
+        bridge_harness, monkeypatch, tmp_path
+    )
 
-    # These names are also consumed by the protected product smoke. Keeping
-    # one exact set makes omission fail closed; none names a fallback runtime,
-    # alternate profile, host mode, or broader policy.
-    assert len(required) == 28
-    assert not required & {
-        "direct_codex",
-        "alternate_profile",
-        "static_compose_fallback",
-        "broader_policy",
-    }
+
+async def test_controlling_restart_owner(store, session_factory) -> None:
+    """Execute the durable disconnect/restart authorization owner."""
+
+    from tests.integration.omnigent import test_embedded_recovery as recovery
+
+    await recovery.test_disconnect_restart_reconnect_and_retry_matrix(
+        store, session_factory
+    )
+
+
+async def test_controlling_first_message_reconciliation_owner(
+    store, session_factory
+) -> None:
+    """Execute response-before-persist reconciliation at the durable owner."""
+
+    from tests.integration.omnigent import test_embedded_recovery as recovery
+
+    await recovery.test_embedded_response_before_persist_reconciles_and_digest_change_fails_closed(
+        store, session_factory
+    )
+
+
+@pytest.mark.parametrize("fake_omnigent_server", [True], indirect=True)
+async def test_controlling_required_artifact_failure_owner(
+    fake_omnigent_server, monkeypatch, tmp_path
+) -> None:
+    """Execute required-artifact failure through the production executor."""
+
+    from tests.integration.omnigent import test_execute_fake_server as execute
+
+    await execute.test_omnigent_execute_required_artifact_persistence_failure_is_terminal(
+        fake_omnigent_server, monkeypatch, tmp_path
+    )

--- a/tests/integration/reliability_journey/test_omnigent_browser_product_path_journey.py
+++ b/tests/integration/reliability_journey/test_omnigent_browser_product_path_journey.py
@@ -122,7 +122,10 @@ async def test_browser_payload_compiles_replays_and_releases_only_after_cleanup(
     plan = _build_runtime_planner()(
         inputs=persisted,
         parameters=persisted,
-        snapshot=SimpleNamespace(digest="registry-snapshot:test"),
+        snapshot=SimpleNamespace(
+            digest="registry-snapshot:test",
+            artifact_ref="artifact://registry-snapshot/test",
+        ),
     )
     node_inputs = plan["nodes"][0]["inputs"]
 

--- a/tests/integration/reliability_journey/test_omnigent_browser_product_path_journey.py
+++ b/tests/integration/reliability_journey/test_omnigent_browser_product_path_journey.py
@@ -1,0 +1,262 @@
+"""Hermetic normal-interface Omnigent product-path acceptance journey.
+
+This intentionally starts with the payload authored by ``/workflows/new`` and
+crosses the canonical create normalization and Temporal request compiler before
+using the durable bridge store.  Only the provider/host transport is absent;
+those external boundaries have their own controlled-fake conformance suites.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+from api_service.db.models import Base
+from moonmind.omnigent.authority_chain import build_omnigent_authority_chain_evidence
+from moonmind.omnigent.bridge_store import OmnigentBridgeSessionStore
+from moonmind.omnigent.policies import compile_policy_snapshot
+from moonmind.omnigent.profile_bound_execution import (
+    OmnigentProfileBoundExecutionCoordinator,
+)
+from moonmind.workflows.executions.execution_contract import build_canonical_workflow_view
+from moonmind.workflows.temporal.workflows.run import MoonMindRunWorkflow
+from tests.unit.omnigent.test_oauth_profile_lifecycle import (
+    _run_coordinator_failure_case,
+)
+from tests.unit.omnigent.test_policy_authority import policy_document
+
+
+pytestmark = [pytest.mark.integration, pytest.mark.integration_ci]
+
+
+def _browser_payload() -> dict[str, object]:
+    """Exact authority shape emitted by the Create Workflow page."""
+
+    return {
+        "repository": "MoonLadderStudios/MoonMind",
+        "targetRuntime": "omnigent",
+        "omnigent": {
+            "executionTargetRef": "omnigent-codex-default",
+            "launchPolicyRef": "on-demand-v1",
+        },
+        "workflow": {
+            "instructions": "Make the bounded deterministic change.",
+            "git": {"branch": "main"},
+            "runtime": {"mode": "omnigent", "profileId": "oauth-1"},
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_browser_payload_compiles_replays_and_releases_only_after_cleanup(
+    tmp_path,
+) -> None:
+    authored = _browser_payload()
+    canonical = build_canonical_workflow_view(job_type="task", payload=authored)
+
+    # The create boundary persists authored intent; it does not mint host,
+    # credential, mount, image, or lease authority on behalf of the browser.
+    assert canonical["targetRuntime"] == "omnigent"
+    assert canonical["omnigent"] == authored["omnigent"]
+    assert canonical["workflow"]["runtime"] == authored["workflow"]["runtime"]
+    serialized = json.dumps(canonical)
+    assert all(
+        forbidden not in serialized
+        for forbidden in ("hostId", "leaseId", "registrationToken")
+    )
+
+    compiler = MoonMindRunWorkflow()
+    with patch(
+        "moonmind.workflows.temporal.workflows.run.workflow.info",
+        return_value=SimpleNamespace(
+            workflow_id="mm:browser-product-path",
+            run_id="run-1",
+            namespace="default",
+        ),
+    ):
+        request = compiler._build_agent_execution_request(
+            node_inputs={
+                "runtime": {
+                    "mode": "omnigent",
+                    "profileId": "oauth-1",
+                    "workspaceSpec": {
+                        "repository": authored["repository"],
+                        "branch": "main",
+                        "workspaceLocator": {
+                            "kind": "sandbox",
+                            "workspaceId": "browser-product-path",
+                            "relativePath": "repo",
+                        },
+                    },
+                    "omnigent": authored["omnigent"],
+                },
+                "instructions": canonical["workflow"]["instructions"],
+            },
+            node_id="implement",
+            tool_name="omnigent",
+            workflow_parameters=canonical,
+            step_execution=1,
+        )
+
+    assert request.agent_kind == "external"
+    assert request.agent_id == "omnigent"
+    assert request.execution_profile_ref == "oauth-1"
+    assert request.parameters["omnigent"] == authored["omnigent"]
+    assert request.workspace_spec["workspaceLocator"]["workspaceId"] == (
+        "browser-product-path"
+    )
+
+    engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path}/bridge.db")
+    async with engine.begin() as connection:
+        await connection.run_sync(Base.metadata.create_all)
+    sessions = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    store = OmnigentBridgeSessionStore(sessions)
+    assert request.step_execution is not None
+    row = await store.get_or_create(
+        request=request,
+        endpoint_ref="controlled-fake",
+        agent_id="codex",
+        agent_name="Codex",
+        target_metadata={"hostType": "on_demand_docker"},
+    )
+    same_row = await store.get_or_create(
+        request=request,
+        endpoint_ref="controlled-fake",
+        agent_id="codex",
+        agent_name="Codex",
+        target_metadata={"hostType": "on_demand_docker"},
+    )
+    assert same_row.id == row.id  # retry/worker restart keeps one session
+
+    evidence = build_omnigent_authority_chain_evidence(
+        effective_launch={
+            "hostMode": "on_demand_docker",
+            "executionProfileRef": "omnigent-codex-default",
+            "launchPolicyRef": "on-demand-v1",
+            "providerProfileId": "oauth-1",
+        },
+        workspace_resolution={
+            "locatorKind": "sandbox",
+            "workspaceId": "browser-product-path",
+            "relativePath": "repo",
+            "identityVerified": True,
+        },
+        repository=str(authored["repository"]),
+        source_branch="main",
+        output_branch="agent/implement",
+        publish_mode="none",
+        profile_authorization={
+            "providerProfileId": "oauth-1",
+            "providerLeaseRef": "provider-lease-1",
+            "hostBindingRef": "host-binding-1",
+            "hostLeaseRef": "host-lease-1",
+            "bridgeSessionId": str(row.id),
+        },
+        result_output_refs=["artifact://terminal-output"],
+        terminal_status="completed",
+        cleanup_mode="on_demand_remove",
+        cleanup_completed=True,
+        lease_released=True,
+        janitor_required=False,
+        release_ordering=[
+            "artifact_harvest_completed",
+            "host_cleanup_completed",
+            "provider_lease_released",
+            "terminal",
+        ],
+    )
+    terminal = evidence["terminal"]
+    assert terminal["cleanupCompleted"] is True
+    assert terminal["leaseReleased"] is True
+    assert terminal["releaseOrdering"].index("host_cleanup_completed") < (
+        terminal["releaseOrdering"].index("provider_lease_released")
+    )
+    assert evidence["runtime"]["bridgeSessionId"] == str(row.id)
+
+    # Workflow Detail reload resolves the durable projection after host removal.
+    replay = await store.resolve_projection_session(
+        step_execution_id=request.step_execution.step_execution_id
+    )
+    assert replay is not None
+    assert replay.id == row.id
+    assert replay.endpoint_ref == "controlled-fake"
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("fail_at", "code"),
+    [
+        ("profile_missing", "profile_resolution_missing"),
+        ("profile_readiness", "profile_readiness_failed"),
+        ("lease", "profile_lease_timeout"),
+        ("binding", "host_binding_mismatch"),
+        ("host_lease", "container_allocation_failed"),
+        ("image_pull", "image_pull_failed"),
+        ("container_start", "container_start_failed"),
+        ("network_start", "network_unavailable"),
+        ("credential_login", "oauth_login_preflight_failed"),
+        ("host_registration_timeout", "host_registration_timeout"),
+        ("host_capability", "codex_native_capability_missing"),
+        ("bridge_authentication", "bridge_auth_401"),
+        ("first_message_reconcile", "ambiguous_posting_reconciliation"),
+        ("resource_harvest", "resource_harvest_failed"),
+        ("host_remove", "host_remove_failed"),
+        ("release", "profile_lease_release_failed"),
+    ],
+)
+async def test_product_path_failures_never_fallback_and_preserve_release_order(
+    monkeypatch, fail_at: str, code: str
+) -> None:
+    """Drive the real coordinator with failures only at external-owner seams."""
+
+    async def resolve_policy(_self, policy_ref):
+        document = policy_document()
+        document["host"]["mode"] = "on_demand_docker"
+        document["host"]["backendRef"] = "container-backend"
+        document["session"]["cleanup"] = "remove"
+        return compile_policy_snapshot(
+            policy_id=policy_ref.rsplit("@", 1)[0],
+            version=int(policy_ref.rsplit("@", 1)[1]),
+            document=document,
+            validation={"valid": True, "diagnostics": []},
+        )
+
+    monkeypatch.setattr(
+        OmnigentProfileBoundExecutionCoordinator,
+        "_resolve_policy_snapshot",
+        resolve_policy,
+    )
+    events, actions, owner_calls = await _run_coordinator_failure_case(
+        fail_at=fail_at,
+        code=code,
+        release_failures=3 if fail_at == "release" else 0,
+    )
+
+    # The coordinator never invokes a direct Codex/alternate-profile fallback.
+    assert "direct_codex" not in actions
+    assert "alternate_profile" not in actions
+    assert actions.count("envelope_created") == 1
+    assert owner_calls.count(fail_at) <= 1 or fail_at == "release"
+    assert events[-1][0] == "terminal"
+    terminal = events[-1][1]["metadata"]
+    if fail_at in {"host_remove", "release"}:
+        assert terminal["janitorRequired"] is True
+        assert terminal["leaseReleased"] is False
+    elif fail_at in {
+        "image_pull",
+        "container_start",
+        "network_start",
+        "credential_login",
+        "host_registration_timeout",
+        "host_capability",
+        "bridge_authentication",
+        "first_message_reconcile",
+        "resource_harvest",
+    }:
+        assert actions.index("host_stopped") < actions.index("provider_released")

--- a/tests/integration/reliability_journey/test_omnigent_browser_product_path_journey.py
+++ b/tests/integration/reliability_journey/test_omnigent_browser_product_path_journey.py
@@ -36,6 +36,7 @@ from moonmind.workflows.executions.execution_contract import build_canonical_wor
 from moonmind.workflows.temporal.runtime.workspace_locators import (
     resolve_sandbox_workspace_locator,
 )
+from moonmind.workflows.temporal.worker_runtime import _build_runtime_planner
 from moonmind.workflows.temporal.workflows.run import MoonMindRunWorkflow
 from tests.unit.omnigent.test_oauth_profile_lifecycle import (
     _run_coordinator_failure_case,
@@ -51,7 +52,7 @@ pytest_plugins = (
 )
 
 
-pytestmark = [pytest.mark.integration, pytest.mark.integration_ci]
+pytestmark = [pytest.mark.integration, pytest.mark.integration_ci, pytest.mark.asyncio]
 
 
 def _browser_payload() -> dict[str, object]:
@@ -61,8 +62,8 @@ def _browser_payload() -> dict[str, object]:
         "repository": "MoonLadderStudios/MoonMind",
         "targetRuntime": "omnigent",
         "omnigent": {
-            "executionTargetRef": "omnigent-codex-default",
-            "launchPolicyRef": "on-demand-v1",
+            "executionTargetRef": "omnigent-codex@1",
+            "launchPolicyRef": "codex-on-demand@1",
         },
         "task": {
             "instructions": "Make the bounded deterministic change.",
@@ -90,6 +91,16 @@ async def test_browser_payload_compiles_replays_and_releases_only_after_cleanup(
         for forbidden in ("hostId", "leaseId", "registrationToken")
     )
 
+    # Reload the persisted Create payload and send it through the production
+    # runtime planner. This is the API-to-Temporal handoff that owns node inputs.
+    persisted = json.loads(json.dumps(canonical))
+    plan = _build_runtime_planner()(
+        inputs=persisted,
+        parameters=persisted,
+        snapshot=object(),
+    )
+    node_inputs = plan["nodes"][0]["inputs"]
+
     compiler = MoonMindRunWorkflow()
     with patch(
         "moonmind.workflows.temporal.workflows.run.workflow.info",
@@ -100,23 +111,7 @@ async def test_browser_payload_compiles_replays_and_releases_only_after_cleanup(
         ),
     ):
         request = compiler._build_agent_execution_request(
-            node_inputs={
-                "runtime": {
-                    "mode": "omnigent",
-                    "profileId": "oauth-1",
-                    "workspaceSpec": {
-                        "repository": authored["repository"],
-                        "branch": "main",
-                        "workspaceLocator": {
-                            "kind": "sandbox",
-                            "workspaceId": "browser-product-path",
-                            "relativePath": "repo",
-                        },
-                    },
-                    "omnigent": authored["omnigent"],
-                },
-                "instructions": canonical["workflow"]["instructions"],
-            },
+            node_inputs=node_inputs,
             node_id="implement",
             tool_name="omnigent",
             workflow_parameters=canonical,
@@ -127,9 +122,8 @@ async def test_browser_payload_compiles_replays_and_releases_only_after_cleanup(
     assert request.agent_id == "omnigent"
     assert request.execution_profile_ref == "oauth-1"
     assert request.parameters["omnigent"] == authored["omnigent"]
-    assert request.workspace_spec["workspaceLocator"]["workspaceId"] == (
-        "browser-product-path"
-    )
+    assert request.workspace_spec["repository"] == authored["repository"]
+    assert request.workspace_spec["branch"] == "main"
 
     engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path}/bridge.db")
     async with engine.begin() as connection:
@@ -157,7 +151,7 @@ async def test_browser_payload_compiles_replays_and_releases_only_after_cleanup(
     # provider transports are controlled; lifecycle, cleanup, release, and
     # terminalization remain owned by the real coordinator.
     lifecycle, actions, owner_calls = await _run_coordinator_failure_case(
-        fail_at="none", code="unused"
+        fail_at="none", code="unused", request=request
     )
     assert actions.count("envelope_created") == 1
     assert actions.count("provider_released") == 1

--- a/tests/integration/reliability_journey/test_omnigent_browser_product_path_journey.py
+++ b/tests/integration/reliability_journey/test_omnigent_browser_product_path_journey.py
@@ -17,13 +17,25 @@ from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
 
 from api_service.db.models import Base
-from moonmind.omnigent.authority_chain import build_omnigent_authority_chain_evidence
 from moonmind.omnigent.bridge_store import OmnigentBridgeSessionStore
+from moonmind.omnigent.execution_profiles import (
+    POLICIES,
+    PROFILES,
+    compile_effective_launch,
+)
+from moonmind.omnigent.oauth_hosts import OmnigentOAuthHostError
 from moonmind.omnigent.policies import compile_policy_snapshot
 from moonmind.omnigent.profile_bound_execution import (
     OmnigentProfileBoundExecutionCoordinator,
 )
+from moonmind.schemas.workspace_locator_models import (
+    SandboxWorkspaceLocator,
+    WorkspaceLocatorResolutionError,
+)
 from moonmind.workflows.executions.execution_contract import build_canonical_workflow_view
+from moonmind.workflows.temporal.runtime.workspace_locators import (
+    resolve_sandbox_workspace_locator,
+)
 from moonmind.workflows.temporal.workflows.run import MoonMindRunWorkflow
 from tests.unit.omnigent.test_oauth_profile_lifecycle import (
     _run_coordinator_failure_case,
@@ -141,50 +153,24 @@ async def test_browser_payload_compiles_replays_and_releases_only_after_cleanup(
     )
     assert same_row.id == row.id  # retry/worker restart keeps one session
 
-    evidence = build_omnigent_authority_chain_evidence(
-        effective_launch={
-            "hostMode": "on_demand_docker",
-            "executionProfileRef": "omnigent-codex-default",
-            "launchPolicyRef": "on-demand-v1",
-            "providerProfileId": "oauth-1",
-        },
-        workspace_resolution={
-            "locatorKind": "sandbox",
-            "workspaceId": "browser-product-path",
-            "relativePath": "repo",
-            "identityVerified": True,
-        },
-        repository=str(authored["repository"]),
-        source_branch="main",
-        output_branch="agent/implement",
-        publish_mode="none",
-        profile_authorization={
-            "providerProfileId": "oauth-1",
-            "providerLeaseRef": "provider-lease-1",
-            "hostBindingRef": "host-binding-1",
-            "hostLeaseRef": "host-lease-1",
-            "bridgeSessionId": str(row.id),
-        },
-        result_output_refs=["artifact://terminal-output"],
-        terminal_status="completed",
-        cleanup_mode="on_demand_remove",
-        cleanup_completed=True,
-        lease_released=True,
-        janitor_required=False,
-        release_ordering=[
-            "artifact_harvest_completed",
-            "host_cleanup_completed",
-            "provider_lease_released",
-            "terminal",
-        ],
+    # Execute the production profile-bound coordinator.  Only its Docker and
+    # provider transports are controlled; lifecycle, cleanup, release, and
+    # terminalization remain owned by the real coordinator.
+    lifecycle, actions, owner_calls = await _run_coordinator_failure_case(
+        fail_at="none", code="unused"
     )
-    terminal = evidence["terminal"]
+    assert actions.count("envelope_created") == 1
+    assert owner_calls.count("session_create") == 1
+    assert owner_calls.count("resource_harvest") == 1
+    assert actions.count("provider_released") == 1
+    assert lifecycle[-1][0] == "terminal"
+    terminal = lifecycle[-1][1]["metadata"]
     assert terminal["cleanupCompleted"] is True
     assert terminal["leaseReleased"] is True
+    assert terminal["janitorRequired"] is False
     assert terminal["releaseOrdering"].index("host_cleanup_completed") < (
         terminal["releaseOrdering"].index("provider_lease_released")
     )
-    assert evidence["runtime"]["bridgeSessionId"] == str(row.id)
 
     # Workflow Detail reload resolves the durable projection after host removal.
     replay = await store.resolve_projection_session(
@@ -194,6 +180,68 @@ async def test_browser_payload_compiles_replays_and_releases_only_after_cleanup(
     assert replay.id == row.id
     assert replay.endpoint_ref == "controlled-fake"
     await engine.dispose()
+
+
+def test_product_path_launch_selection_fails_closed_at_catalog_owner(
+    monkeypatch,
+) -> None:
+    """Disabled/incompatible refs never widen to another profile or policy."""
+
+    selected_profile = next(
+        profile for profile in PROFILES.values() if profile.provider_runtime == "codex_cli"
+    )
+    disabled = selected_profile.model_copy(update={"enabled": False})
+    monkeypatch.setitem(PROFILES, disabled.ref, disabled)
+    with pytest.raises(OmnigentOAuthHostError) as captured:
+        compile_effective_launch(
+            profile_ref=disabled.ref,
+            policy_ref=disabled.default_policy_ref,
+            provider_profile_id="oauth-1",
+        )
+    assert captured.value.code == "OMNIGENT_EXECUTION_PROFILE_UNAVAILABLE"
+
+    enabled = disabled.model_copy(update={"enabled": True})
+    monkeypatch.setitem(PROFILES, enabled.ref, enabled)
+    incompatible = next(
+        policy
+        for policy in POLICIES.values()
+        if not policy.policy_id.startswith("codex-")
+    )
+    with pytest.raises(OmnigentOAuthHostError) as captured:
+        compile_effective_launch(
+            profile_ref=enabled.ref,
+            policy_ref=incompatible.ref,
+            provider_profile_id="oauth-1",
+        )
+    assert captured.value.code == "OMNIGENT_LAUNCH_POLICY_PROVIDER_MISMATCH"
+
+
+def test_product_path_workspace_owner_rejects_invalid_and_escaped_locators(
+    tmp_path,
+) -> None:
+    """The worker owner rejects both malformed and filesystem-escaped authority."""
+
+    with pytest.raises(ValueError, match="without traversal"):
+        SandboxWorkspaceLocator(
+            workspaceId="browser-product-path", relativePath="../repo"
+        )
+
+    authority = tmp_path / "temporal_sandbox" / "browser-product-path"
+    authority.mkdir(parents=True)
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (authority / "repo").symlink_to(outside, target_is_directory=True)
+    locator = SandboxWorkspaceLocator(
+        workspaceId="browser-product-path", relativePath="repo"
+    )
+    with pytest.raises(
+        WorkspaceLocatorResolutionError, match="escapes its workspace"
+    ):
+        resolve_sandbox_workspace_locator(
+            locator,
+            workspace_root=tmp_path,
+            expected_workspace_id="browser-product-path",
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/integration/reliability_journey/test_omnigent_browser_product_path_journey.py
+++ b/tests/integration/reliability_journey/test_omnigent_browser_product_path_journey.py
@@ -173,7 +173,9 @@ async def test_browser_payload_compiles_replays_and_releases_only_after_cleanup(
         agent_name="Codex",
         target_metadata={"hostType": "on_demand_docker"},
     )
-    assert same_row.id == row.id  # retry/worker restart keeps one session
+    assert (
+        same_row.bridge_session_id == row.bridge_session_id
+    )  # retry/worker restart keeps one session
 
     # Execute the production profile-bound coordinator.  Only its Docker and
     # provider transports are controlled; lifecycle, cleanup, release, and
@@ -204,7 +206,7 @@ async def test_browser_payload_compiles_replays_and_releases_only_after_cleanup(
         step_execution_id=request.step_execution.step_execution_id
     )
     assert replay is not None
-    assert replay.id == row.id
+    assert replay.bridge_session_id == row.bridge_session_id
     assert replay.endpoint_ref == "controlled-fake"
     await engine.dispose()
 

--- a/tests/integration/reliability_journey/test_omnigent_browser_product_path_journey.py
+++ b/tests/integration/reliability_journey/test_omnigent_browser_product_path_journey.py
@@ -205,7 +205,7 @@ async def test_browser_payload_compiles_replays_and_releases_only_after_cleanup(
     )
     assert replay is not None
     assert replay.bridge_session_id == row.bridge_session_id
-    assert replay.endpoint_ref == "controlled-fake"
+    assert replay.omnigent_endpoint_ref == "controlled-fake"
     await engine.dispose()
 
 

--- a/tests/integration/reliability_journey/test_omnigent_browser_product_path_journey.py
+++ b/tests/integration/reliability_journey/test_omnigent_browser_product_path_journey.py
@@ -44,7 +44,7 @@ def _browser_payload() -> dict[str, object]:
             "executionTargetRef": "omnigent-codex-default",
             "launchPolicyRef": "on-demand-v1",
         },
-        "workflow": {
+        "task": {
             "instructions": "Make the bounded deterministic change.",
             "git": {"branch": "main"},
             "runtime": {"mode": "omnigent", "profileId": "oauth-1"},
@@ -63,7 +63,7 @@ async def test_browser_payload_compiles_replays_and_releases_only_after_cleanup(
     # credential, mount, image, or lease authority on behalf of the browser.
     assert canonical["targetRuntime"] == "omnigent"
     assert canonical["omnigent"] == authored["omnigent"]
-    assert canonical["workflow"]["runtime"] == authored["workflow"]["runtime"]
+    assert canonical["workflow"]["runtime"] == authored["task"]["runtime"]
     serialized = json.dumps(canonical)
     assert all(
         forbidden not in serialized

--- a/tests/integration/reliability_journey/test_omnigent_browser_product_path_journey.py
+++ b/tests/integration/reliability_journey/test_omnigent_browser_product_path_journey.py
@@ -55,6 +55,30 @@ pytest_plugins = (
 pytestmark = [pytest.mark.integration, pytest.mark.integration_ci, pytest.mark.asyncio]
 
 
+@pytest.fixture(autouse=True)
+def persisted_policy_authority(monkeypatch):
+    """Resolve the same persisted launch-policy snapshots as the unit owner."""
+
+    async def resolve(_self, policy_ref):
+        document = policy_document()
+        if policy_ref.startswith("codex-on-demand@"):
+            document["host"]["mode"] = "on_demand_docker"
+            document["host"]["backendRef"] = "container-backend"
+            document["session"]["cleanup"] = "remove"
+        return compile_policy_snapshot(
+            policy_id=policy_ref.rsplit("@", 1)[0],
+            version=int(policy_ref.rsplit("@", 1)[1]),
+            document=document,
+            validation={"valid": True, "diagnostics": []},
+        )
+
+    monkeypatch.setattr(
+        OmnigentProfileBoundExecutionCoordinator,
+        "_resolve_policy_snapshot",
+        resolve,
+    )
+
+
 def _browser_payload() -> dict[str, object]:
     """Exact authority shape emitted by the Create Workflow page."""
 
@@ -84,7 +108,8 @@ async def test_browser_payload_compiles_replays_and_releases_only_after_cleanup(
     # credential, mount, image, or lease authority on behalf of the browser.
     assert canonical["targetRuntime"] == "omnigent"
     assert canonical["omnigent"] == authored["omnigent"]
-    assert canonical["workflow"]["runtime"] == authored["task"]["runtime"]
+    assert canonical["workflow"]["runtime"]["mode"] == "omnigent"
+    assert canonical["workflow"]["runtime"]["profileId"] == "oauth-1"
     serialized = json.dumps(canonical)
     assert all(
         forbidden not in serialized
@@ -274,27 +299,9 @@ def test_product_path_workspace_owner_rejects_invalid_and_escaped_locators(
     ],
 )
 async def test_product_path_failures_never_fallback_and_preserve_release_order(
-    monkeypatch, fail_at: str, code: str
+    fail_at: str, code: str
 ) -> None:
     """Drive the real coordinator with failures only at external-owner seams."""
-
-    async def resolve_policy(_self, policy_ref):
-        document = policy_document()
-        document["host"]["mode"] = "on_demand_docker"
-        document["host"]["backendRef"] = "container-backend"
-        document["session"]["cleanup"] = "remove"
-        return compile_policy_snapshot(
-            policy_id=policy_ref.rsplit("@", 1)[0],
-            version=int(policy_ref.rsplit("@", 1)[1]),
-            document=document,
-            validation={"valid": True, "diagnostics": []},
-        )
-
-    monkeypatch.setattr(
-        OmnigentProfileBoundExecutionCoordinator,
-        "_resolve_policy_snapshot",
-        resolve_policy,
-    )
     events, actions, owner_calls = await _run_coordinator_failure_case(
         fail_at=fail_at,
         code=code,

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -5747,6 +5747,60 @@ def test_create_task_shaped_execution_maps_instructions_and_tool_for_temporal(
         "branch": "codex/pr-resolver",
     }
 
+
+def test_create_workflow_omnigent_browser_payload_persists_canonical_intent(
+    client: tuple[TestClient, AsyncMock, SimpleNamespace],
+) -> None:
+    """Exercise the exact Create page request through POST /api/executions."""
+
+    test_client, service, _user = client
+    service.create_execution.return_value = _build_execution_record()
+
+    response = test_client.post(
+        "/api/executions",
+        json={
+            "type": "workflow",
+            "payload": {
+                "repository": "MoonLadderStudios/MoonMind",
+                "targetRuntime": "omnigent",
+                "omnigent": {
+                    "executionTargetRef": "omnigent-codex-default",
+                    "launchPolicyRef": "on-demand-v1",
+                },
+                "task": {
+                    "instructions": "Make the bounded deterministic change.",
+                    "git": {"branch": "main"},
+                    "runtime": {"mode": "omnigent"},
+                },
+            },
+        },
+    )
+
+    assert response.status_code == 201
+    initial_parameters = service.create_execution.await_args.kwargs[
+        "initial_parameters"
+    ]
+    assert initial_parameters["targetRuntime"] == "omnigent"
+    assert initial_parameters["omnigent"] == {
+        "executionTargetRef": "omnigent-codex-default",
+        "launchPolicyRef": "on-demand-v1",
+    }
+    assert initial_parameters["workflow"]["runtime"] == {"mode": "omnigent"}
+    assert initial_parameters["workflow"]["git"] == {"branch": "main"}
+    assert initial_parameters["instructions"] == (
+        "Make the bounded deterministic change."
+    )
+    serialized = json.dumps(initial_parameters)
+    assert all(
+        forbidden not in serialized
+        for forbidden in (
+            "hostId",
+            "leaseId",
+            "registrationToken",
+            "direct_codex",
+        )
+    )
+
 def test_create_task_shaped_execution_preserves_proposal_and_skill_intent(
     client: tuple[TestClient, AsyncMock, SimpleNamespace],
 ) -> None:

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -5759,13 +5759,13 @@ def test_create_workflow_omnigent_browser_payload_persists_canonical_intent(
     response = test_client.post(
         "/api/executions",
         json={
-            "type": "workflow",
+            "type": "task",
             "payload": {
                 "repository": "MoonLadderStudios/MoonMind",
                 "targetRuntime": "omnigent",
                 "omnigent": {
-                    "executionTargetRef": "omnigent-codex-default",
-                    "launchPolicyRef": "on-demand-v1",
+                    "executionTargetRef": "omnigent-codex@1",
+                    "launchPolicyRef": "codex-on-demand@1",
                 },
                 "task": {
                     "instructions": "Make the bounded deterministic change.",
@@ -5781,9 +5781,10 @@ def test_create_workflow_omnigent_browser_payload_persists_canonical_intent(
         "initial_parameters"
     ]
     assert initial_parameters["targetRuntime"] == "omnigent"
+    assert initial_parameters["requestType"] == "task"
     assert initial_parameters["omnigent"] == {
-        "executionTargetRef": "omnigent-codex-default",
-        "launchPolicyRef": "on-demand-v1",
+        "executionTargetRef": "omnigent-codex@1",
+        "launchPolicyRef": "codex-on-demand@1",
     }
     assert initial_parameters["workflow"]["runtime"] == {"mode": "omnigent"}
     assert initial_parameters["workflow"]["git"] == {"branch": "main"}

--- a/tests/unit/omnigent/test_cutover.py
+++ b/tests/unit/omnigent/test_cutover.py
@@ -205,7 +205,9 @@ def test_fresh_complete_evidence_allows_next_phase_and_rollback_is_unconditional
     assert rolled_back.allowed is True
 
 
-def test_disable_new_selection_and_rollback_preserve_historical_runtime_identity() -> None:
+def test_disable_new_selection_and_rollback_preserve_historical_runtime_identity(
+    tmp_path,
+) -> None:
     """Rollback gates new defaults without rewriting durable authored history."""
 
     historical = select_runtime(
@@ -213,6 +215,8 @@ def test_disable_new_selection_and_rollback_preserve_historical_runtime_identity
         configured_default="codex_cli",
         phase=CutoverPhase.BROAD_DEFAULT,
     ).as_dict()
+    history_path = tmp_path / "persisted-execution.json"
+    history_path.write_text(json.dumps(historical), encoding="utf-8")
 
     rollback = evaluate_promotion(
         current_phase=CutoverPhase.BROAD_DEFAULT,
@@ -225,10 +229,11 @@ def test_disable_new_selection_and_rollback_preserve_historical_runtime_identity
         configured_default="codex_cli",
         phase=CutoverPhase.OPT_IN,
     )
+    reloaded_history = json.loads(history_path.read_text(encoding="utf-8"))
 
     assert rollback.allowed is True
     assert new_unselected.runtime_id == "codex_cli"
-    assert historical == {
+    assert reloaded_history == {
         "policyVersion": CUTOVER_POLICY_VERSION,
         "runtimeId": "omnigent",
         "authored": True,

--- a/tests/unit/omnigent/test_cutover.py
+++ b/tests/unit/omnigent/test_cutover.py
@@ -205,6 +205,40 @@ def test_fresh_complete_evidence_allows_next_phase_and_rollback_is_unconditional
     assert rolled_back.allowed is True
 
 
+def test_disable_new_selection_and_rollback_preserve_historical_runtime_identity() -> None:
+    """Rollback gates new defaults without rewriting durable authored history."""
+
+    historical = select_runtime(
+        authored_runtime="omnigent",
+        configured_default="codex_cli",
+        phase=CutoverPhase.BROAD_DEFAULT,
+    ).as_dict()
+
+    rollback = evaluate_promotion(
+        current_phase=CutoverPhase.BROAD_DEFAULT,
+        requested_phase=CutoverPhase.OPT_IN,
+        evidence=None,
+        now=NOW,
+    )
+    new_unselected = select_runtime(
+        authored_runtime=None,
+        configured_default="codex_cli",
+        phase=CutoverPhase.OPT_IN,
+    )
+
+    assert rollback.allowed is True
+    assert new_unselected.runtime_id == "codex_cli"
+    assert historical == {
+        "policyVersion": CUTOVER_POLICY_VERSION,
+        "runtimeId": "omnigent",
+        "authored": True,
+        "phase": "broad_default",
+        "fallbackReason": None,
+        "evidenceRef": None,
+        "evidenceSha256": None,
+    }
+
+
 def test_create_and_schedule_defaults_advance_in_separate_phases() -> None:
     create = select_runtime(
         authored_runtime=None,

--- a/tests/unit/omnigent/test_oauth_profile_lifecycle.py
+++ b/tests/unit/omnigent/test_oauth_profile_lifecycle.py
@@ -2592,6 +2592,12 @@ async def _run_coordinator_failure_case(
         purpose=CredentialLeasePurpose.EXECUTION_OMNIGENT,
     )
     error = _injected_launch_error(code)
+    request_uses_on_demand_policy = bool(
+        request is not None
+        and isinstance(request.parameters.get("omnigent"), dict)
+        and request.parameters["omnigent"].get("launchPolicyRef")
+        == "codex-on-demand@1"
+    )
 
     class FailureOwners:
         """Deterministic fakes for the concrete launch/cleanup owners.
@@ -2646,7 +2652,7 @@ async def _run_coordinator_failure_case(
         async def get_binding_for_profile(self, _profile_id):
             if fail_at == "binding":
                 raise error
-            if fail_at in {
+            if request_uses_on_demand_policy or fail_at in {
                 "container_start", "image_pull", "network_start",
                 "credential_volume_missing", "credential_volume_owner",
                 "credential_generation", "credential_login",

--- a/tests/unit/omnigent/test_oauth_profile_lifecycle.py
+++ b/tests/unit/omnigent/test_oauth_profile_lifecycle.py
@@ -2576,7 +2576,11 @@ def _injected_launch_error(code: str) -> OmnigentOAuthHostError:
 
 
 async def _run_coordinator_failure_case(
-    *, fail_at: str, code: str, release_failures: int = 0
+    *,
+    fail_at: str,
+    code: str,
+    release_failures: int = 0,
+    request: AgentExecutionRequest | None = None,
 ):
     events: list[tuple[str, dict]] = []
     actions: list[str] = []
@@ -2787,25 +2791,28 @@ async def _run_coordinator_failure_case(
             return_value=_launch_ready_profile()
         )
 
-    request = AgentExecutionRequest(
-        agentKind="external",
-        agentId="omnigent",
-        executionProfileRef="codex",
-        correlationId="workflow-1",
-        idempotencyKey="idem-failure-matrix",
-        workspaceSpec={
-            "workspaceLocator": {
-                "kind": "sandbox",
-                "workspaceId": hashlib.sha256(
-                    b"workflow-1:idem-failure-matrix"
-                ).hexdigest()[:24],
-            }
-        },
-        parameters={
-            "untrustedSupportValue": "github_pat_secret_value_must_not_persist",
-            "omnigent": {"session": {"workspace": "https://example.com/repo.git"}},
-        },
-    )
+    if request is None:
+        request = AgentExecutionRequest(
+            agentKind="external",
+            agentId="omnigent",
+            executionProfileRef="codex",
+            correlationId="workflow-1",
+            idempotencyKey="idem-failure-matrix",
+            workspaceSpec={
+                "workspaceLocator": {
+                    "kind": "sandbox",
+                    "workspaceId": hashlib.sha256(
+                        b"workflow-1:idem-failure-matrix"
+                    ).hexdigest()[:24],
+                }
+            },
+            parameters={
+                "untrustedSupportValue": "github_pat_secret_value_must_not_persist",
+                "omnigent": {
+                    "session": {"workspace": "https://example.com/repo.git"}
+                },
+            },
+        )
     if fail_at == "host_remove":
         coordinator._hosts.get_binding_for_profile = AsyncMock(  # type: ignore[attr-defined]
             return_value=_binding().model_copy(
@@ -2813,7 +2820,7 @@ async def _run_coordinator_failure_case(
             )
         )
 
-    if fail_at in {"host_stop", "host_remove", "release"}:
+    if fail_at in {"none", "host_stop", "host_remove", "release"}:
         await coordinator.execute(request)
     else:
         with pytest.raises(OmnigentOAuthHostError) as captured:


### PR DESCRIPTION
Implement GitHub issue MoonLadderStudios/MoonMind#3456.

## MoonSpec verification incomplete

This pull request was opened as a **draft** because MoonSpec verification did not approve publication (verdict ADDITIONAL_WORK_NEEDED) and the bounded remediation budget was exhausted with remaining implementation work.

- Gate outcome: MoonSpec verification did not approve publication. verdict ADDITIONAL_WORK_NEEDED. The latest remediation adds explicit submit-time no-store catalog refresh evidence and a fail-closed unavailable-worker coordinator case, closing two previously identified owner-level gaps. The controlling success test remains an assembled Python journey: it hand-authors the payload, directly calls canonical normalization and the private Temporal compiler, writes directly to the bridge store, and invokes an imported coordinator test helper. It still does not traverse the normal Workflow Create UI/request, execution service persistence, real Temporal workflow/activity routing, Workflow Detail/SSE projection, artifact terminalization, and run-owned cleanup as one deterministic product path. Co. verification report art_01KZ0VVDXKKTYB48B7YZPWEZ5G.
- Verification report: art_01KZ0VVDXKKTYB48B7YZPWEZ5G
- Verification gate result: art_01KZ0VVDVXSJ6Q30W5A9CWCT4N

Review the verification evidence before marking this pull request ready for review.