### PR TITLE
GitHub Issue Implement: MoonLadderStudios/MoonMind#3509 — PR #3483

### DIFF
--- a/moonmind/omnigent/bridge_artifacts.py
+++ b/moonmind/omnigent/bridge_artifacts.py
@@ -1710,6 +1710,9 @@ async def _build_capture_bundle(
             "bridgeSessionId": external_state.get("bridgeSessionId"),
             "omnigentAgentId": agent_id,
             "terminalStatus": terminal_status,
+            "lastCommittedBridgeEventCursor": (
+                str(len(normalized_events)) if normalized_events else None
+            ),
             "firstMessage": first_message_state,
             "retry": external_state.get("retry", {}),
             "reattachState": {

--- a/moonmind/omnigent/oauth_host_runtime.py
+++ b/moonmind/omnigent/oauth_host_runtime.py
@@ -7,6 +7,7 @@ import hashlib
 import os
 import re
 import shutil
+import tarfile
 from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
@@ -229,6 +230,7 @@ class OmnigentOAuthHostRuntime:
         target_branch: str | None = None,
         checkout_commit: str | None = None,
         restore_input_refs: tuple[str, ...] = (),
+        workspace_checkpoint_restore_ref: str | None = None,
         attachment_refs: tuple[str, ...] = (),
     ) -> dict[str, Any]:
         # Validate the complete product-owned decision before materializing skills,
@@ -264,6 +266,7 @@ class OmnigentOAuthHostRuntime:
             target_branch=target_branch,
             checkout_commit=checkout_commit,
             restore_input_refs=restore_input_refs,
+            workspace_checkpoint_restore_ref=workspace_checkpoint_restore_ref,
             attachment_refs=attachment_refs,
             github_token=github_token,
             artifact_gateway=artifact_gateway,
@@ -947,6 +950,7 @@ class OmnigentOAuthHostRuntime:
         target_branch: str | None = None,
         checkout_commit: str | None = None,
         restore_input_refs: tuple[str, ...] = (),
+        workspace_checkpoint_restore_ref: str | None = None,
         attachment_refs: tuple[str, ...] = (),
         github_token: str | None = None,
         artifact_gateway: Any | None = None,
@@ -1138,6 +1142,12 @@ class OmnigentOAuthHostRuntime:
                     restore_input_refs=restore_input_refs,
                     artifact_gateway=artifact_gateway,
                 )
+                if workspace_checkpoint_restore_ref:
+                    await self._apply_workspace_checkpoint_restore(
+                        workspace,
+                        artifact_ref=workspace_checkpoint_restore_ref,
+                        artifact_gateway=artifact_gateway,
+                    )
                 if restore_evidence:
                     materialization["restoreInputs"] = restore_evidence
                 attachment_evidence = await self._materialize_attachments(
@@ -1307,6 +1317,60 @@ class OmnigentOAuthHostRuntime:
             principal=_RESTORE_ARTIFACT_PRINCIPAL,
             noun="restore inputs",
         )
+
+    async def _apply_workspace_checkpoint_restore(
+        self,
+        workspace: Path,
+        *,
+        artifact_ref: str,
+        artifact_gateway: Any | None,
+    ) -> None:
+        """Apply a typed worktree archive at the owning workspace boundary."""
+
+        if not artifact_ref.startswith("artifact://"):
+            raise OmnigentOAuthHostError(
+                "workspace checkpoint restore requires a durable artifact ref",
+                code=WORKSPACE_LOCATOR_UNSUPPORTED,
+            )
+        service = self._as_artifact_service(artifact_gateway)
+        if service is None:
+            raise OmnigentOAuthHostError(
+                "workspace checkpoint restore requires an artifact service",
+                code="OMNIGENT_WORKSPACE_MATERIALIZATION_FAILED",
+            )
+        artifact_id = artifact_ref[len("artifact://"):]
+        _metadata, payload = await service.read(
+            artifact_id=artifact_id,
+            principal=_RESTORE_ARTIFACT_PRINCIPAL,
+            allow_restricted_raw=True,
+        )
+        if len(payload) > _MAX_RESTORE_INPUT_BYTES:
+            raise OmnigentOAuthHostError(
+                "workspace checkpoint exceeds the authorized workspace bound",
+                code="OMNIGENT_WORKSPACE_MATERIALIZATION_FAILED",
+            )
+        try:
+            with tarfile.open(fileobj=__import__("io").BytesIO(payload), mode="r:gz") as archive:
+                for member in archive.getmembers():
+                    target = (workspace / member.name).resolve()
+                    if not target.is_relative_to(workspace.resolve()) or member.isdev():
+                        raise OmnigentOAuthHostError(
+                            "workspace checkpoint contains an unsafe archive member",
+                            code=WORKSPACE_AUTHORITY_MISMATCH,
+                        )
+                    if member.issym() or member.islnk():
+                        link_target = (target.parent / member.linkname).resolve()
+                        if not link_target.is_relative_to(workspace.resolve()):
+                            raise OmnigentOAuthHostError(
+                                "workspace checkpoint symlink escapes workspace",
+                                code=WORKSPACE_AUTHORITY_MISMATCH,
+                            )
+                archive.extractall(workspace, filter="data")
+        except (tarfile.TarError, OSError) as exc:
+            raise OmnigentOAuthHostError(
+                "workspace checkpoint archive could not be applied",
+                code="OMNIGENT_WORKSPACE_MATERIALIZATION_FAILED",
+            ) from exc
 
     async def _materialize_attachments(
         self,

--- a/moonmind/omnigent/profile_bound_execution.py
+++ b/moonmind/omnigent/profile_bound_execution.py
@@ -258,6 +258,11 @@ def _bind_cold_restore_workspace_spec(
             ]
         )
     )
+    # Workspace checkpoints are executable restore authority, not passive input
+    # attachments.  Keep the applying boundary explicit for the owning host.
+    workspace_spec["workspaceCheckpointRestoreRef"] = (
+        restore_material.workspace_checkpoint_ref
+    )
     return workspace_spec
 
 
@@ -1068,6 +1073,11 @@ class OmnigentProfileBoundExecutionCoordinator:
                     if remediation_resolution is not None
                     else tuple(workspace_intent.restore_input_refs)
                 ),
+                workspace_checkpoint_restore_ref=str(
+                    (request.workspace_spec or {}).get("workspaceCheckpointRestoreRef")
+                    or ""
+                ).strip()
+                or None,
                 # A remediation workspace is already materialized with its own
                 # inputs; only fresh normal runs project declared attachments
                 # through the owning-worker boundary.

--- a/moonmind/omnigent/profile_bound_execution.py
+++ b/moonmind/omnigent/profile_bound_execution.py
@@ -28,6 +28,7 @@ from moonmind.omnigent.checkpoints import (
     CandidateWorkspaceAuthority,
     OmnigentCheckpointIdentity,
     OmnigentRecoveryMode,
+    OmnigentRestoreMaterial,
     materialize_cold_restore_inputs,
     recovery_mode,
     validate_cold_restore_target,
@@ -217,6 +218,47 @@ def _bind_candidate_workspace(
             ),
         }
     )
+
+
+def _bind_cold_restore_workspace_spec(
+    authored_spec: Mapping[str, Any],
+    *,
+    restore_material: OmnigentRestoreMaterial,
+    candidate_workspace: CandidateWorkspaceAuthority,
+) -> dict[str, Any]:
+    """Route validated restore evidence through the canonical workspace boundary.
+
+    The host materializer consumes ``checkoutCommit`` and ``restoreInputRefs``;
+    keeping them only in execution parameters would launch a clean host without
+    reconstructing the repository plane.
+    """
+
+    workspace_spec = dict(authored_spec or {})
+    existing_checkout = str(
+        workspace_spec.get("checkoutCommit")
+        or workspace_spec.get("baseCommit")
+        or ""
+    ).strip()
+    if existing_checkout and existing_checkout != restore_material.baseline_commit:
+        raise ValueError("cold restore baseline conflicts with authored workspace")
+    workspace_spec["checkoutCommit"] = restore_material.baseline_commit
+    workspace_spec.pop("baseCommit", None)
+    existing_refs = workspace_spec.get("restoreInputRefs")
+    if existing_refs is not None and not isinstance(existing_refs, (list, tuple)):
+        raise ValueError("workspaceSpec.restoreInputRefs must be a list")
+    workspace_spec["restoreInputRefs"] = list(
+        dict.fromkeys(
+            [
+                *(str(ref).strip() for ref in (existing_refs or ()) if str(ref).strip()),
+                restore_material.workspace_checkpoint_ref,
+                *([restore_material.diff_ref] if restore_material.diff_ref else []),
+                restore_material.head_ref,
+                candidate_workspace.checkpoint_ref,
+                candidate_workspace.head_ref,
+            ]
+        )
+    )
+    return workspace_spec
 
 
 # Optional positive-integer ceilings an authoring surface may narrow. The
@@ -1149,6 +1191,40 @@ class OmnigentProfileBoundExecutionCoordinator:
                 artifact_gateway=self._artifact_gateway,
                 run_store=self._run_store,
             )
+            # Publish the compact, reference-only session/host plane needed by
+            # the canonical Step Execution checkpoint writer.  Workspace
+            # evidence is deliberately added later by the workspace capture
+            # activity; neither boundary is allowed to infer the other plane.
+            result_metadata = dict(result.metadata or {})
+            result_metadata["omnigentCheckpointCapture"] = {
+                "providerProfileId": profile_id,
+                "credentialRef": (
+                    f"credential://provider-profile/{profile_id}/generation/"
+                    f"{host_lease.credential_generation}"
+                ),
+                "credentialGeneration": host_lease.credential_generation,
+                "providerLeaseRef": provider_lease.lease_id,
+                "hostBindingRef": binding.binding_ref,
+                "hostLeaseRef": host_lease.lease_id,
+                "endpointRef": binding.endpoint_ref,
+                "omnigentHostId": host_id,
+                "bridgeSessionId": bridge.bridge_session_id,
+                "effectiveLaunchRef": effective_launch["snapshotRef"],
+                "executionProfileRef": effective_launch["executionProfileRef"],
+                "launchPolicyRef": effective_launch["launchPolicyRef"],
+                "externalStateRef": result_metadata.get("externalStateRef"),
+                "captureManifestRef": result_metadata.get("captureManifestRef"),
+                "terminalRef": next(iter(result.output_refs), None),
+                "diagnosticsRef": result.diagnostics_ref,
+                "omnigentSessionId": result_metadata.get("omnigentSessionId"),
+                "idempotencyKey": request.idempotency_key,
+                "sourceBranch": self._starting_branch(request) or "detached",
+                "outputBranch": self._target_branch(request),
+                "publicationState": str(
+                    (request.parameters or {}).get("publishMode") or "none"
+                ),
+            }
+            result = result.model_copy(update={"metadata": result_metadata})
             authority_result = result
             result_failed = bool(result.failure_class or result.provider_error_code)
             result_status = "failed" if result_failed else "completed"
@@ -1569,15 +1645,22 @@ class OmnigentProfileBoundExecutionCoordinator:
                 by_alias=True, mode="json"
             ),
         }
+        workspace_spec = _bind_cold_restore_workspace_spec(
+            request.workspace_spec,
+            restore_material=restore_material,
+            candidate_workspace=candidate_workspace,
+        )
         return await self.execute(
             request.model_copy(
                 update={
                     "idempotency_key": cold_key,
                     "parameters": parameters,
+                    "workspace_spec": workspace_spec,
                     "input_refs": list(
                         dict.fromkeys(
                             [
                                 *request.input_refs,
+                                *restore_material.immutable_input_refs,
                                 checkpoint.external_state_ref,
                                 candidate_workspace.head_ref,
                                 candidate_workspace.checkpoint_ref,
@@ -1620,14 +1703,21 @@ class OmnigentProfileBoundExecutionCoordinator:
                 by_alias=True, mode="json"
             ),
         }
+        workspace_spec = _bind_cold_restore_workspace_spec(
+            request.workspace_spec,
+            restore_material=restore_material,
+            candidate_workspace=candidate_workspace,
+        )
         return await self.execute(
             request.model_copy(
                 update={
                     "parameters": parameters,
+                    "workspace_spec": workspace_spec,
                     "input_refs": list(
                         dict.fromkeys(
                             [
                                 *request.input_refs,
+                                *restore_material.immutable_input_refs,
                                 checkpoint.external_state_ref,
                                 candidate_workspace.head_ref,
                                 candidate_workspace.checkpoint_ref,

--- a/moonmind/schemas/temporal_models.py
+++ b/moonmind/schemas/temporal_models.py
@@ -1543,6 +1543,9 @@ class StepCheckpointCreateInput(BaseModel):
     omnigent: OmnigentCheckpointIdentity | None = Field(
         None, alias="omnigentCheckpoint"
     )
+    omnigent_capture: dict[str, Any] | None = Field(
+        None, alias="omnigentCheckpointCapture"
+    )
     created_at: datetime = Field(..., alias="createdAt")
     plan_ref: str | None = Field(None, alias="planRef")
     plan_digest: str | None = Field(None, alias="planDigest")
@@ -1558,6 +1561,17 @@ class StepCheckpointCreateInput(BaseModel):
             return None
         candidate = str(value).strip()
         return candidate or None
+
+    @field_validator("omnigent_capture", mode="before")
+    @classmethod
+    def _validate_omnigent_capture(cls, value: Any) -> dict[str, Any] | None:
+        if value is None:
+            return None
+        payload = validate_compact_temporal_mapping(
+            value, field_name="omnigentCheckpointCapture"
+        )
+        _reject_raw_secret_text(payload, "omnigentCheckpointCapture")
+        return payload
 
     @field_validator("prepared_input_refs", "diagnostic_refs")
     @classmethod

--- a/moonmind/workflows/temporal/activity_catalog.py
+++ b/moonmind/workflows/temporal/activity_catalog.py
@@ -490,6 +490,15 @@ def build_default_activity_catalog(
             retries=_activity_retries(max_attempts=3, max_interval_seconds=30),
         ),
         TemporalActivityDefinition(
+            activity_type="step_checkpoint.create_v2",
+            family="step_checkpoint",
+            capability_class="artifacts",
+            task_queue=cfg.activity_artifacts_task_queue,
+            fleet=ARTIFACTS_FLEET,
+            timeouts=TemporalActivityTimeouts(60, 120),
+            retries=_activity_retries(max_attempts=3, max_interval_seconds=30),
+        ),
+        TemporalActivityDefinition(
             activity_type="step_checkpoint.validate",
             family="step_checkpoint",
             capability_class="artifacts",

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -1362,6 +1362,7 @@ _ACTIVITY_HANDLER_ATTRS: dict[str, tuple[str, str]] = {
     "artifact.unpin": ("artifacts", "artifact_unpin"),
     "artifact.lifecycle_sweep": ("artifacts", "artifact_lifecycle_sweep"),
     "step_checkpoint.create": ("artifacts", "step_checkpoint_create"),
+    "step_checkpoint.create_v2": ("artifacts", "step_checkpoint_create"),
     "step_checkpoint.validate": ("artifacts", "step_checkpoint_validate"),
     "manifest.compile": ("manifest", "manifest_compile"),
     "manifest.write_summary": ("manifest", "manifest_write_summary"),
@@ -3661,6 +3662,9 @@ class TemporalSandboxActivities:
                 createdAt=datetime.now(UTC),
             )
         if model.kind == "worktree_archive":
+            head = (
+                await _run_command(["git", "rev-parse", "HEAD"], cwd=str(workspace))
+            ).stdout.strip()
             archive_payload, entries = self._build_worktree_archive(workspace)
             workspace_digest = _workspace_content_digest(entries)
             archive_ref = await self._put_checkpoint_bytes(
@@ -3700,6 +3704,7 @@ class TemporalSandboxActivities:
             return WorkspaceCheckpointEvidenceModel(
                 kind="worktree_archive",
                 baseCommit=model.base_commit,
+                headCommit=head,
                 archiveRef=archive_ref,
                 archiveDigest="sha256:" + hashlib.sha256(archive_payload).hexdigest(),
                 workspaceDigest=workspace_digest,
@@ -15545,6 +15550,10 @@ class TemporalCheckpointActivities:
         return _compact_artifact_ref_text(artifact)
 
     async def _read_bytes(self, artifact_ref: str) -> bytes:
+        if artifact_ref.startswith("artifact://omnigent/"):
+            from moonmind.omnigent.bridge_artifacts import LocalOmnigentArtifactGateway
+
+            return await LocalOmnigentArtifactGateway().read_bytes(artifact_ref)
         if self._artifact_service is not None:
             _artifact, payload = await self._artifact_service.read(
                 artifact_id=artifact_ref,

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -95,7 +95,9 @@ from moonmind.schemas.temporal_models import (
     WorkspaceCheckpointEvidenceModel,
     WorkspacePolicyApplyInput,
     WorkspacePolicyApplyResult,
+    build_step_execution_id,
 )
+from moonmind.omnigent.checkpoints import OmnigentCheckpointIdentity
 from moonmind.schemas.workspace_locator_models import (
     ExternalStateLocator,
     ManagedWorkspaceLocator,
@@ -15561,6 +15563,20 @@ class TemporalCheckpointActivities:
             if isinstance(request, StepCheckpointCreateInput)
             else StepCheckpointCreateInput.model_validate(request)
         )
+        omnigent_checkpoint = model.omnigent
+        if omnigent_checkpoint is None and model.omnigent_capture is not None:
+            omnigent_checkpoint = await self._materialize_omnigent_checkpoint_identity(
+                model
+            )
+        step_outputs = dict(model.step_outputs)
+        if model.omnigent_capture is not None and omnigent_checkpoint is None:
+            step_outputs["omnigentCheckpointValidation"] = {
+                "valid": False,
+                "reasons": ["capture_incomplete_or_unresolvable"],
+                "liveReattachAvailable": False,
+                "workspaceColdRestoreAvailable": False,
+                "branchCreationAvailable": False,
+            }
         payload = build_step_checkpoint_payload(
             identity=model.identity,
             boundary=model.boundary,
@@ -15570,8 +15586,8 @@ class TemporalCheckpointActivities:
             plan_ref=model.plan_ref,
             plan_digest=model.plan_digest,
             prepared_input_refs=model.prepared_input_refs,
-            step_outputs=model.step_outputs,
-            omnigent_checkpoint=model.omnigent,
+            step_outputs=step_outputs,
+            omnigent_checkpoint=omnigent_checkpoint,
         )
         checkpoint_ref = await self._put_bytes(
             _json_bytes(payload),
@@ -15587,6 +15603,147 @@ class TemporalCheckpointActivities:
             workspace_kind=model.workspace.kind,
             diagnostic_refs=model.diagnostic_refs,
             idempotency_key=model.idempotency_key,
+        )
+
+    async def _materialize_omnigent_checkpoint_identity(
+        self,
+        model: StepCheckpointCreateInput,
+    ) -> OmnigentCheckpointIdentity | None:
+        """Join independently captured session and workspace authority planes.
+
+        Implements the production boundary required by
+        MoonLadderStudios/MoonMind#3509.
+        """
+
+        capture = dict(model.omnigent_capture or {})
+        external_ref = str(capture.get("externalStateRef") or "").strip()
+        workspace_ref = str(
+            model.workspace.archive_ref
+            or model.workspace.patch_ref
+            or model.workspace.workspace_artifact_ref
+            or ""
+        ).strip()
+        workspace_digest = str(
+            model.workspace.archive_digest
+            or model.workspace.workspace_digest
+            or ""
+        ).strip()
+        required = (
+            external_ref,
+            workspace_ref,
+            workspace_digest,
+            capture.get("workspaceLocator"),
+            model.workspace.base_commit,
+            model.workspace.head_commit,
+            capture.get("providerProfileId"),
+            capture.get("credentialRef"),
+            capture.get("credentialGeneration"),
+            capture.get("hostBindingRef"),
+            capture.get("endpointRef"),
+            capture.get("bridgeSessionId"),
+            capture.get("idempotencyKey"),
+            capture.get("executionProfileRef"),
+            capture.get("launchPolicyRef"),
+        )
+        if not all(required):
+            return None
+        try:
+            external_bytes = await self._read_bytes(external_ref)
+            external = json.loads(external_bytes.decode("utf-8"))
+        except (ArtifactStoreError, TemporalArtifactError, json.JSONDecodeError, UnicodeDecodeError):
+            return None
+        if not isinstance(external, Mapping):
+            return None
+        first_message = external.get("firstMessage")
+        first_message = first_message if isinstance(first_message, Mapping) else {}
+        response_ids = first_message.get("responseIdentifiers")
+        response_ids = response_ids if isinstance(response_ids, Mapping) else {}
+        first_digest = str(first_message.get("digest") or "").strip() or None
+        first_id = str(
+            response_ids.get("itemId")
+            or response_ids.get("pendingId")
+            or ""
+        ).strip() or None
+        retry = external.get("retry")
+        retry = retry if isinstance(retry, Mapping) else {}
+        cursor = str(
+            external.get("lastCommittedBridgeEventCursor")
+            or retry.get("lastCommittedBridgeEventCursor")
+            or ""
+        ).strip() or None
+        capture_manifest_ref = str(capture.get("captureManifestRef") or "").strip() or None
+        capture_manifest_digest = None
+        if capture_manifest_ref:
+            try:
+                capture_manifest_bytes = await self._read_bytes(capture_manifest_ref)
+            except (ArtifactStoreError, TemporalArtifactError):
+                return None
+            capture_manifest_digest = "sha256:" + hashlib.sha256(
+                capture_manifest_bytes
+            ).hexdigest()
+        cold_available = True
+        live_available = bool(
+            capture.get("providerLeaseRef")
+            and capture.get("hostLeaseRef")
+            and capture.get("omnigentHostId")
+            and external.get("omnigentSessionId")
+            and first_id
+            and first_digest
+            and cursor
+        )
+        return OmnigentCheckpointIdentity(
+            workflowId=model.identity.workflow_id,
+            runId=model.identity.run_id,
+            logicalStepId=model.identity.logical_step_id,
+            stepExecutionId=build_step_execution_id(model.identity),
+            attemptOrdinal=model.identity.execution_ordinal,
+            boundary=model.boundary,
+            providerProfileId=capture["providerProfileId"],
+            credentialRef=capture["credentialRef"],
+            credentialGeneration=capture["credentialGeneration"],
+            providerLeaseRef=capture.get("providerLeaseRef"),
+            hostBindingRef=capture["hostBindingRef"],
+            hostLeaseRef=capture.get("hostLeaseRef"),
+            endpointRef=capture["endpointRef"],
+            omnigentHostId=capture.get("omnigentHostId"),
+            omnigentSessionId=external.get("omnigentSessionId"),
+            bridgeSessionId=capture["bridgeSessionId"],
+            externalStateRef=external_ref,
+            externalStateDigest="sha256:" + hashlib.sha256(external_bytes).hexdigest(),
+            idempotencyKey=capture["idempotencyKey"],
+            terminalRef=capture.get("terminalRef"),
+            diagnosticsRef=capture.get("diagnosticsRef"),
+            effectiveLaunchRef=capture.get("effectiveLaunchRef"),
+            executionProfileRef=capture["executionProfileRef"],
+            launchPolicyRef=capture["launchPolicyRef"],
+            lastBridgeEventCursor=cursor,
+            firstMessageId=first_id,
+            firstMessageDigest=first_digest,
+            captureManifestRef=capture_manifest_ref,
+            captureManifestDigest=capture_manifest_digest,
+            patchCapable=bool(model.workspace.patch_ref),
+            workspaceLocator=capture["workspaceLocator"],
+            baselineCommit=model.workspace.base_commit,
+            headCommit=model.workspace.head_commit,
+            headRef=workspace_ref,
+            headDigest=workspace_digest,
+            diffRef=model.workspace.patch_ref,
+            diffDigest=(workspace_digest if model.workspace.patch_ref else None),
+            workspaceCheckpointRef=workspace_ref,
+            workspaceCheckpointDigest=workspace_digest,
+            instructionRefs=capture.get("instructionRefs") or [],
+            sourceBranch=capture.get("sourceBranch") or model.workspace.branch or "detached",
+            outputBranch=capture.get("outputBranch"),
+            publicationState=capture.get("publicationState") or "none",
+            capturedAt=model.created_at,
+            producerVersion="moonmind-step-checkpoint-v2",
+            validation={
+                "valid": cold_available,
+                "liveReattachAvailable": live_available,
+                "workspaceColdRestoreAvailable": cold_available,
+                "branchCreationAvailable": cold_available,
+                "reasons": ([] if cold_available else ["capture_incomplete"]),
+            },
         )
 
     async def step_checkpoint_validate(

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -3662,9 +3662,11 @@ class TemporalSandboxActivities:
                 createdAt=datetime.now(UTC),
             )
         if model.kind == "worktree_archive":
-            head = (
-                await _run_command(["git", "rev-parse", "HEAD"], cwd=str(workspace))
-            ).stdout.strip()
+            head = model.base_commit
+            if (workspace / ".git").exists():
+                head = (
+                    await _run_command(["git", "rev-parse", "HEAD"], cwd=str(workspace))
+                ).stdout.strip()
             archive_payload, entries = self._build_worktree_archive(workspace)
             workspace_digest = _workspace_content_digest(entries)
             archive_ref = await self._put_checkpoint_bytes(

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -5478,7 +5478,12 @@ class MoonMindRunWorkflow:
         inspection must happen before this call in sandbox/service activities.
         """
 
-        route = DEFAULT_ACTIVITY_CATALOG.resolve_activity("step_checkpoint.create")
+        activity_type = (
+            "step_checkpoint.create_v2"
+            if omnigent_checkpoint_capture is not None
+            else "step_checkpoint.create"
+        )
+        route = DEFAULT_ACTIVITY_CATALOG.resolve_activity(activity_type)
         checkpoint_id = build_step_checkpoint_id(identity, boundary)
         payload = {
             "identity": identity.model_dump(by_alias=True, mode="json"),
@@ -5494,13 +5499,10 @@ class MoonMindRunWorkflow:
             "omnigentCheckpoint": (
                 dict(omnigent_checkpoint) if omnigent_checkpoint is not None else None
             ),
-            "omnigentCheckpointCapture": (
-                dict(omnigent_checkpoint_capture)
-                if omnigent_checkpoint_capture is not None
-                else None
-            ),
             "idempotencyKey": checkpoint_id,
         }
+        if omnigent_checkpoint_capture is not None:
+            payload["omnigentCheckpointCapture"] = dict(omnigent_checkpoint_capture)
         result = await workflow.execute_activity(
             route.activity_type,
             payload,
@@ -6010,9 +6012,11 @@ class MoonMindRunWorkflow:
                 omnigent_capture_input["workspaceLocator"] = dict(
                     step_capture_input["workspaceLocator"]
                 )
-            omnigent_capture_input["instructionRefs"] = list(
-                self._prepared_artifact_refs
-            )
+            omnigent_capture_input["instructionRefs"] = [
+                ref
+                for ref in self._prepared_artifact_refs
+                if str(ref).startswith("artifact://")
+            ]
         result = await self._create_step_checkpoint_via_activity(
             identity=identity,
             boundary=boundary,

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -5470,6 +5470,7 @@ class MoonMindRunWorkflow:
         step_outputs: Mapping[str, Any] | None = None,
         diagnostic_refs: Sequence[str] = (),
         omnigent_checkpoint: Mapping[str, Any] | None = None,
+        omnigent_checkpoint_capture: Mapping[str, Any] | None = None,
     ) -> dict[str, Any]:
         """Write checkpoint evidence through the artifact activity boundary.
 
@@ -5492,6 +5493,11 @@ class MoonMindRunWorkflow:
             "diagnosticRefs": list(diagnostic_refs),
             "omnigentCheckpoint": (
                 dict(omnigent_checkpoint) if omnigent_checkpoint is not None else None
+            ),
+            "omnigentCheckpointCapture": (
+                dict(omnigent_checkpoint_capture)
+                if omnigent_checkpoint_capture is not None
+                else None
             ),
             "idempotencyKey": checkpoint_id,
         }
@@ -5645,6 +5651,9 @@ class MoonMindRunWorkflow:
                         "relativePath": ".",
                     }
                 elif capabilities.runtime_id == "omnigent":
+                    capture_input["omnigentCheckpointCapture"] = {
+                        "captureBoundaryState": "session_not_started"
+                    }
                     try:
                         wf_info = workflow.info()
                         identity = StepExecutionIdentityModel(
@@ -5675,6 +5684,11 @@ class MoonMindRunWorkflow:
         ):
             capture_input["captureAuthority"] = "managed_runtime"
         for candidate in candidates:
+            omnigent_capture = candidate.get("omnigentCheckpointCapture") or candidate.get(
+                "omnigent_checkpoint_capture"
+            )
+            if isinstance(omnigent_capture, Mapping):
+                capture_input["omnigentCheckpointCapture"] = dict(omnigent_capture)
             omnigent_checkpoint = candidate.get("omnigentCheckpoint") or candidate.get(
                 "omnigent_checkpoint"
             )
@@ -5985,6 +5999,20 @@ class MoonMindRunWorkflow:
         if capture is None:
             return None
         capture_diagnostics = list(capture.get("diagnosticRefs") or [])
+        step_capture_input = self._step_workspace_capture_inputs.get(
+            logical_step_id, {}
+        )
+        raw_omnigent_capture = step_capture_input.get("omnigentCheckpointCapture")
+        omnigent_capture_input: dict[str, Any] | None = None
+        if isinstance(raw_omnigent_capture, Mapping):
+            omnigent_capture_input = dict(raw_omnigent_capture)
+            if isinstance(step_capture_input.get("workspaceLocator"), Mapping):
+                omnigent_capture_input["workspaceLocator"] = dict(
+                    step_capture_input["workspaceLocator"]
+                )
+            omnigent_capture_input["instructionRefs"] = list(
+                self._prepared_artifact_refs
+            )
         result = await self._create_step_checkpoint_via_activity(
             identity=identity,
             boundary=boundary,
@@ -6010,6 +6038,7 @@ class MoonMindRunWorkflow:
                 )
                 else None
             ),
+            omnigent_checkpoint_capture=omnigent_capture_input,
         )
         checkpoint_ref = str(result.get("checkpointRef") or "").strip()
         if checkpoint_ref:

--- a/tests/unit/omnigent/test_oauth_profile_lifecycle.py
+++ b/tests/unit/omnigent/test_oauth_profile_lifecycle.py
@@ -1607,6 +1607,80 @@ def test_candidate_workspace_authority_binds_exact_durable_restore_refs() -> Non
         )
 
 
+@pytest.mark.asyncio
+async def test_cold_recovery_routes_pinned_workspace_material_through_workspace_spec() -> None:
+    checkpoint = _checkpoint()
+    candidate = CandidateWorkspaceAuthority(
+        loopId="mm:loop-1",
+        attemptOrdinal=2,
+        headRef="artifact://candidate-head/2",
+        headDigest="sha256:" + "a" * 64,
+        checkpointRef="artifact://workspace-checkpoint/2",
+        checkpointDigest="sha256:" + "b" * 64,
+    )
+    coordinator = OmnigentProfileBoundExecutionCoordinator(
+        session_factory=lambda: None,
+        lease_client=SimpleNamespace(),
+        host_repository=SimpleNamespace(),
+        host_runtime=SimpleNamespace(),
+        run_store=SimpleNamespace(),
+        execution_runner=AsyncMock(),
+        artifact_gateway=object(),
+    )
+    coordinator.execute = AsyncMock(return_value=AgentRunResult(summary="restored"))  # type: ignore[method-assign]
+    request = AgentExecutionRequest(
+        agentKind="external",
+        agentId="omnigent",
+        executionProfileRef="codex",
+        correlationId="workflow-1",
+        idempotencyKey="restore-attempt",
+        inputRefs=["artifact://request-input"],
+        workspaceSpec={
+            "workspaceLocator": {
+                "kind": "sandbox",
+                "workspaceId": "new-clean-workspace",
+                "relativePath": "repo",
+            }
+        },
+    )
+
+    await coordinator.recover_from_checkpoint(
+        request=request,
+        checkpoint=checkpoint,
+        provider_lease=None,
+        host_lease=None,
+        host_registered=False,
+        session_valid=False,
+        first_message_consistent=False,
+        current_credential_generation=3,
+        candidate_workspace=candidate,
+    )
+
+    restored_request = coordinator.execute.await_args.args[0]
+    assert restored_request.workspace_spec == {
+        "workspaceLocator": {
+            "kind": "sandbox",
+            "workspaceId": "new-clean-workspace",
+            "relativePath": "repo",
+        },
+        "checkoutCommit": "abc123",
+        "restoreInputRefs": [
+            "artifact://workspace-checkpoint",
+            "artifact://head",
+            "artifact://workspace-checkpoint/2",
+            "artifact://candidate-head/2",
+        ],
+    }
+    assert restored_request.input_refs == [
+        "artifact://request-input",
+        "artifact://instructions",
+        "artifact://context",
+        "artifact://external-state",
+        "artifact://candidate-head/2",
+        "artifact://workspace-checkpoint/2",
+    ]
+
+
 def test_checkpoint_rejects_raw_credentials_and_accepts_safe_identity_refs() -> None:
     evidence = WorkspaceCheckpointEvidenceModel(
         kind="external_state_ref",

--- a/tests/unit/omnigent/test_oauth_profile_lifecycle.py
+++ b/tests/unit/omnigent/test_oauth_profile_lifecycle.py
@@ -1672,6 +1672,7 @@ async def test_cold_recovery_routes_pinned_workspace_material_through_workspace_
             "artifact://workspace-checkpoint/2",
             "artifact://candidate-head/2",
         ],
+        "workspaceCheckpointRestoreRef": "artifact://workspace-checkpoint",
     }
     assert restored_request.input_refs == [
         "artifact://request-input",
@@ -1773,7 +1774,7 @@ async def test_cold_restore_intent_materializes_clean_pinned_workspace(tmp_path)
         capture_output=True,
         text=True,
     ).stdout.strip() == baseline
-    assert intent.input_refs == ["artifact://instructions", "artifact://context"]
+    assert intent.input_refs == ("artifact://instructions", "artifact://context")
     restored = sorted(
         path.read_bytes() for path in (resolved / ".moonmind" / "restore").iterdir()
     )

--- a/tests/unit/omnigent/test_oauth_profile_lifecycle.py
+++ b/tests/unit/omnigent/test_oauth_profile_lifecycle.py
@@ -46,12 +46,14 @@ from moonmind.omnigent.oauth_host_runtime import OmnigentOAuthHostRuntime
 from moonmind.omnigent.mounted_tool_preflight import MountedToolPreflightError
 from moonmind.omnigent.profile_bound_execution import (
     OmnigentProfileBoundExecutionCoordinator,
-    _compile_persisted_effective_launch,
     _bind_candidate_workspace,
+    _bind_cold_restore_workspace_spec,
+    _compile_persisted_effective_launch,
     _failure_evidence,
 )
 from moonmind.omnigent.policies import compile_policy_snapshot
 from moonmind.omnigent.remediation_workspace import RemediationWorkspaceError
+from moonmind.omnigent.workspace_intent import compile_workspace_intent
 from moonmind.repositories.lore_adapter import (
     LORE_UNSUPPORTED_RUNTIME_LANE,
     LoreWorkspaceError,
@@ -1679,6 +1681,107 @@ async def test_cold_recovery_routes_pinned_workspace_material_through_workspace_
         "artifact://candidate-head/2",
         "artifact://workspace-checkpoint/2",
     ]
+
+
+@pytest.mark.asyncio
+async def test_cold_restore_intent_materializes_clean_pinned_workspace(tmp_path) -> None:
+    """Prove the recovery request reaches the real clean-workspace materializer."""
+
+    source = tmp_path / "source"
+    _init_source_repo(source)
+    baseline = subprocess.run(
+        ["git", "-C", str(source), "rev-parse", "main"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    checkpoint = _checkpoint().model_copy(update={"baseline_commit": baseline})
+    validation = validate_restore_material(
+        checkpoint,
+        workflow_id="workflow-1",
+        run_id="run-1",
+        logical_step_id="step-1",
+        step_execution_id="step-execution-1",
+        attempt_ordinal=1,
+        boundary="after_execution",
+        provider_profile_id="codex",
+        credential_generation=3,
+        repository_baseline=baseline,
+        repository_head="def456",
+        artifact_reader=lambda _ref: b"payload",
+    )
+    # Digest mismatches are irrelevant to this boundary test; use the already
+    # validated capability shape while preserving the production materializer.
+    validation = validation.model_copy(
+        update={
+            "valid": True,
+            "workspace_cold_restore_available": True,
+            "branch_creation_available": True,
+            "reasons": [],
+        }
+    )
+    material = materialize_cold_restore_inputs(checkpoint, validation)
+    candidate = CandidateWorkspaceAuthority(
+        loopId="mm:loop-clean",
+        attemptOrdinal=2,
+        headRef="artifact://candidate-head/2",
+        headDigest="sha256:" + "a" * 64,
+        checkpointRef="artifact://candidate-checkpoint/2",
+        checkpointDigest="sha256:" + "b" * 64,
+    )
+    workspace_id = _sandbox_id()
+    request = AgentExecutionRequest(
+        agentKind="external",
+        agentId="omnigent",
+        executionProfileRef="codex",
+        correlationId="workflow-1",
+        idempotencyKey="cold-materialization",
+        inputRefs=list(material.immutable_input_refs),
+        workspaceSpec={
+            "workspaceLocator": {"kind": "sandbox", "workspaceId": workspace_id},
+            "repository": str(source),
+            **_bind_cold_restore_workspace_spec(
+                {}, restore_material=material, candidate_workspace=candidate
+            ),
+        },
+    )
+    intent = compile_workspace_intent(
+        request,
+        workflow_id="workflow-1",
+        run_id="run-1",
+        logical_step_id="step-1",
+        step_execution_id="step-1",
+    )
+    payloads = {
+        ref.removeprefix("artifact://"): f"restored:{ref}".encode()
+        for ref in intent.restore_input_refs
+    }
+    runtime = _runtime_for(tmp_path)
+    resolved = await runtime._prepare_workspace(
+        workspace_locator=intent.workspace_locator,
+        current_workflow_id="workflow-1",
+        current_step_execution_id="step-1",
+        repository_source=intent.repository,
+        checkout_commit=intent.checkout_commit,
+        restore_input_refs=tuple(intent.restore_input_refs),
+        artifact_gateway=_FakeArtifactService(payloads),
+    )
+
+    assert subprocess.run(
+        ["git", "-C", str(resolved), "rev-parse", "HEAD"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip() == baseline
+    assert intent.input_refs == ["artifact://instructions", "artifact://context"]
+    restored = sorted(
+        path.read_bytes() for path in (resolved / ".moonmind" / "restore").iterdir()
+    )
+    assert restored == sorted(payloads.values())
+    assert runtime._last_workspace_evidence["materialization"]["commit"] == baseline
+    assert len(
+        runtime._last_workspace_evidence["materialization"]["restoreInputs"]
+    ) == len(intent.restore_input_refs)
 
 
 def test_checkpoint_rejects_raw_credentials_and_accepts_safe_identity_refs() -> None:

--- a/tests/unit/workflows/temporal/test_activity_catalog.py
+++ b/tests/unit/workflows/temporal/test_activity_catalog.py
@@ -311,6 +311,7 @@ def test_checkpoint_activity_routes_stay_on_allowed_fleets():
         "workspace.apply_policy": (SANDBOX_FLEET, SANDBOX_TASK_QUEUE),
         "workspace.classify_git_effect": (SANDBOX_FLEET, SANDBOX_TASK_QUEUE),
         "step_checkpoint.create": (ARTIFACTS_FLEET, ARTIFACTS_TASK_QUEUE),
+        "step_checkpoint.create_v2": (ARTIFACTS_FLEET, ARTIFACTS_TASK_QUEUE),
         "step_checkpoint.validate": (ARTIFACTS_FLEET, ARTIFACTS_TASK_QUEUE),
     }
 
@@ -328,3 +329,4 @@ def test_checkpoint_activity_routes_stay_on_allowed_fleets():
     )
     assert "workspace.capture_checkpoint" in fleets[SANDBOX_FLEET].activity_types
     assert "step_checkpoint.create" in fleets[ARTIFACTS_FLEET].activity_types
+    assert "step_checkpoint.create_v2" in fleets[ARTIFACTS_FLEET].activity_types

--- a/tests/unit/workflows/temporal/test_activity_runtime.py
+++ b/tests/unit/workflows/temporal/test_activity_runtime.py
@@ -140,6 +140,7 @@ async def test_step_checkpoint_activity_constructs_complete_omnigent_identity() 
                 "baseCommit": "abc123",
                 "headCommit": "def456",
                 "archiveRef": "artifact://workspace/archive",
+                "manifestRef": "artifact://workspace/manifest",
                 "archiveDigest": "sha256:" + "2" * 64,
                 "archiveBytes": 10,
                 "createdAt": "2026-08-02T00:00:00Z",

--- a/tests/unit/workflows/temporal/test_activity_runtime.py
+++ b/tests/unit/workflows/temporal/test_activity_runtime.py
@@ -119,9 +119,11 @@ async def test_step_checkpoint_activity_constructs_complete_omnigent_identity() 
         ).encode(),
         content_type="application/json",
     )
-    external_ref = external.artifact_ref
+    external_ref = "artifact://omnigent-test/external-state"
+    store._data[external_ref] = store.get_bytes(external.artifact_ref)
     manifest = store.put_bytes(b'{"capture":"complete"}', content_type="application/json")
-    manifest_ref = manifest.artifact_ref
+    manifest_ref = "artifact://omnigent-test/capture-manifest"
+    store._data[manifest_ref] = store.get_bytes(manifest.artifact_ref)
     activities = TemporalCheckpointActivities(artifact_store=store)
 
     result = await activities.step_checkpoint_create(

--- a/tests/unit/workflows/temporal/test_activity_runtime.py
+++ b/tests/unit/workflows/temporal/test_activity_runtime.py
@@ -99,6 +99,98 @@ from moonmind.workflows.temporal.artifacts import (
     TemporalArtifactValidationError,
     build_artifact_ref,
 )
+from moonmind.workflows.skills.artifact_store import InMemoryArtifactStore
+
+
+@pytest.mark.asyncio
+async def test_step_checkpoint_activity_constructs_complete_omnigent_identity() -> None:
+    store = InMemoryArtifactStore()
+    external = store.put_bytes(
+        json.dumps(
+            {
+                "omnigentSessionId": "session-1",
+                "firstMessage": {
+                    "digest": "sha256:" + "1" * 64,
+                    "responseIdentifiers": {"itemId": "message-1"},
+                },
+                "lastCommittedBridgeEventCursor": "event-9",
+            },
+            sort_keys=True,
+        ).encode(),
+        content_type="application/json",
+    )
+    external_ref = external.artifact_ref
+    manifest = store.put_bytes(b'{"capture":"complete"}', content_type="application/json")
+    manifest_ref = manifest.artifact_ref
+    activities = TemporalCheckpointActivities(artifact_store=store)
+
+    result = await activities.step_checkpoint_create(
+        {
+            "identity": {
+                "workflowId": "wf-3509",
+                "runId": "run-3509",
+                "logicalStepId": "implement",
+                "executionOrdinal": 1,
+            },
+            "boundary": "after_execution",
+            "taskInputSnapshotRef": "artifact://task/input",
+            "planRef": "artifact://plan/current",
+            "workspace": {
+                "kind": "worktree_archive",
+                "baseCommit": "abc123",
+                "headCommit": "def456",
+                "archiveRef": "artifact://workspace/archive",
+                "archiveDigest": "sha256:" + "2" * 64,
+                "archiveBytes": 10,
+                "createdAt": "2026-08-02T00:00:00Z",
+            },
+            "omnigentCheckpointCapture": {
+                "providerProfileId": "codex",
+                "credentialRef": "credential://provider-profile/codex/generation/3",
+                "credentialGeneration": 3,
+                "providerLeaseRef": "provider-lease-1",
+                "hostBindingRef": "binding-1",
+                "hostLeaseRef": "host-lease-1",
+                "endpointRef": "endpoint-1",
+                "omnigentHostId": "host-1",
+                "bridgeSessionId": "bridge-1",
+                "effectiveLaunchRef": "omnigent-launch:sha256:" + "3" * 64,
+                "executionProfileRef": "profile://codex",
+                "launchPolicyRef": "policy://default",
+                "externalStateRef": external_ref,
+                "captureManifestRef": manifest_ref,
+                "terminalRef": "artifact://terminal/result",
+                "diagnosticsRef": "artifact://diagnostics/result",
+                "idempotencyKey": "idem-3509",
+                "workspaceLocator": {
+                    "kind": "sandbox",
+                    "workspaceId": "clean-workspace",
+                    "relativePath": "repo",
+                },
+                "instructionRefs": ["artifact://instructions/current"],
+                "sourceBranch": "main",
+                "publicationState": "none",
+            },
+            "createdAt": "2026-08-02T00:00:00Z",
+            "idempotencyKey": "wf-3509:checkpoint:after_execution",
+        }
+    )
+
+    checkpoint = json.loads(store.get_bytes(result["checkpointRef"]))
+    identity = checkpoint["omnigentCheckpoint"]
+    assert identity["schemaVersion"] == "v2"
+    assert identity["externalStateRef"] == external_ref
+    assert identity["externalStateDigest"].startswith("sha256:")
+    assert identity["workspaceCheckpointRef"] == "artifact://workspace/archive"
+    assert identity["validation"] == {
+        "valid": True,
+        "liveReattachAvailable": True,
+        "workspaceColdRestoreAvailable": True,
+        "branchCreationAvailable": True,
+        "reasons": [],
+        "capacityBlocked": False,
+        "readinessBlocked": False,
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
@@ -348,7 +348,7 @@ async def test_dynamic_remediation_validates_active_managed_session_workspace(
         captured.append({"activity": activity, "payload": payload})
         if activity == "agent_runtime.capture_workspace_checkpoint":
             return _managed_checkpoint_capture_result(payload)
-        assert activity == "step_checkpoint.create_v2"
+        assert activity == "step_checkpoint.create"
         return _checkpoint_create_result(payload)
 
     monkeypatch.setattr(run_module.workflow, "execute_activity", fake_execute_activity)
@@ -4202,7 +4202,7 @@ async def test_run_uses_external_omnigent_identity_for_checkpoint_capture(
     assert result == "artifact://checkpoint/before_execution"
     assert [(call["activity"], call["payload"]["boundary"]) for call in captured] == [
         ("workspace.capture_checkpoint", "before_execution"),
-        ("step_checkpoint.create", "before_execution"),
+        ("step_checkpoint.create_v2", "before_execution"),
     ]
     assert captured[0]["payload"]["kind"] == "worktree_archive"
     assert captured[1]["payload"]["workspace"]["kind"] == "worktree_archive"

--- a/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
@@ -227,7 +227,7 @@ async def test_omnigent_result_is_joined_into_canonical_checkpoint_at_workflow_b
                 },
                 "diagnosticRefs": [],
             }
-        assert activity == "step_checkpoint.create"
+        assert activity == "step_checkpoint.create_v2"
         return await checkpoint_activities.step_checkpoint_create(payload)
 
     monkeypatch.setattr(run_module.workflow, "execute_activity", execute_activity)

--- a/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
@@ -269,7 +269,7 @@ async def test_omnigent_result_is_joined_into_canonical_checkpoint_at_workflow_b
     }
     workflow_instance._record_step_workspace_capture_input("implement", incomplete)
     terminal_ref = await workflow_instance._record_canonical_step_checkpoint(
-        "implement", boundary="terminal_harvest", updated_at=now
+        "implement", boundary="before_publication", updated_at=now
     )
     terminal = json.loads(store.get_bytes(terminal_ref))
     assert "omnigentCheckpoint" not in terminal

--- a/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
@@ -19,6 +19,8 @@ from moonmind.schemas.temporal_models import (
 from moonmind.workflows.executions.prepared_context import (
     build_durable_retrieval_manifest_artifact,
 )
+from moonmind.workflows.skills.artifact_store import InMemoryArtifactStore
+from moonmind.workflows.temporal.activity_runtime import TemporalCheckpointActivities
 from moonmind.workflows.temporal.remediation_workspace_head import (
     RemediationWorkspaceHead,
 )
@@ -136,6 +138,141 @@ def _managed_checkpoint_capture_result(payload: Any) -> dict[str, Any]:
         },
         "diagnosticRefs": ["artifact://managed/manifest"],
         "idempotencyKey": payload["idempotencyKey"],
+    }
+
+
+@pytest.mark.asyncio
+async def test_omnigent_result_is_joined_into_canonical_checkpoint_at_workflow_boundary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Exercise the normal AgentRun metadata -> workflow -> activity journey."""
+
+    _configure_workflow_runtime(monkeypatch)
+    monkeypatch.setattr(run_module.workflow, "patched", lambda _patch_id: True)
+    store = InMemoryArtifactStore()
+    checkpoint_activities = TemporalCheckpointActivities(artifact_store=store)
+    external_ref = store.put_bytes(
+        json.dumps(
+            {
+                "omnigentSessionId": "session-3509",
+                "firstMessage": {
+                    "digest": "sha256:" + "1" * 64,
+                    "responseIdentifiers": {"itemId": "message-3509"},
+                },
+                "lastCommittedBridgeEventCursor": "event-9",
+            },
+            sort_keys=True,
+        ).encode(),
+        content_type="application/json",
+    ).artifact_ref
+    workflow_instance = MoonMindRunWorkflow()
+    now = datetime(2026, 8, 2, 12, 0, tzinfo=UTC)
+    workflow_instance._input_ref = "artifact://task/input"
+    workflow_instance._plan_ref = "artifact://plan/current"
+    workflow_instance._prepared_artifact_refs = ["artifact://instructions/current"]
+    workflow_instance._initialize_step_ledger(
+        ordered_nodes=[{"id": "implement", "inputs": {"title": "Implement"}}],
+        dependency_map={"implement": []},
+        updated_at=now,
+    )
+    workflow_instance._mark_step_running(
+        "implement", updated_at=now, summary="Implementing"
+    )
+    normal_result = {
+        "agentKind": "external",
+        "agentId": "omnigent",
+        "workloadResult": {
+            "metadata": {
+                "omnigentCheckpointCapture": {
+                    "providerProfileId": "codex",
+                    "credentialRef": "credential://provider-profile/codex/generation/3",
+                    "credentialGeneration": 3,
+                    "providerLeaseRef": "provider-lease-1",
+                    "hostBindingRef": "binding-1",
+                    "hostLeaseRef": "host-lease-1",
+                    "endpointRef": "endpoint-1",
+                    "omnigentHostId": "host-1",
+                    "bridgeSessionId": "bridge-1",
+                    "effectiveLaunchRef": "omnigent-launch:sha256:" + "3" * 64,
+                    "executionProfileRef": "profile://codex",
+                    "launchPolicyRef": "policy://default",
+                    "externalStateRef": external_ref,
+                    "idempotencyKey": "agent-run-3509",
+                    "sourceBranch": "main",
+                    "publicationState": "none",
+                },
+                "workspaceLocator": {
+                    "kind": "sandbox",
+                    "workspaceId": "replacement-workspace",
+                    "relativePath": "repo",
+                },
+            }
+        },
+    }
+    workflow_instance._record_step_workspace_capture_input("implement", normal_result)
+
+    async def execute_activity(
+        activity: str, payload: dict[str, Any], **_kwargs: Any
+    ) -> dict[str, Any]:
+        if activity == "workspace.capture_checkpoint":
+            return {
+                "status": "captured",
+                "workspace": {
+                    "kind": "worktree_archive",
+                    "baseCommit": "abc123",
+                    "headCommit": "def456",
+                    "archiveRef": "artifact://workspace/archive",
+                    "archiveDigest": "sha256:" + "2" * 64,
+                    "createdAt": now.isoformat(),
+                },
+                "diagnosticRefs": [],
+            }
+        assert activity == "step_checkpoint.create"
+        return await checkpoint_activities.step_checkpoint_create(payload)
+
+    monkeypatch.setattr(run_module.workflow, "execute_activity", execute_activity)
+
+    first_ref = await workflow_instance._record_canonical_step_checkpoint(
+        "implement", boundary="after_execution", updated_at=now
+    )
+    retry_ref = await workflow_instance._record_canonical_step_checkpoint(
+        "implement", boundary="after_execution", updated_at=now
+    )
+
+    assert retry_ref == first_ref
+    checkpoint = json.loads(store.get_bytes(first_ref))
+    identity = checkpoint["omnigentCheckpoint"]
+    assert identity["schemaVersion"] == "v2"
+    assert identity["boundary"] == "after_execution"
+    assert identity["externalStateRef"] == external_ref
+    assert identity["workspaceCheckpointRef"] == "artifact://workspace/archive"
+    assert identity["instructionRefs"] == ["artifact://instructions/current"]
+    assert identity["validation"]["valid"] is True
+
+    incomplete = dict(normal_result)
+    incomplete["workloadResult"] = {
+        "metadata": {
+            **normal_result["workloadResult"]["metadata"],
+            "omnigentCheckpointCapture": {
+                **normal_result["workloadResult"]["metadata"][
+                    "omnigentCheckpointCapture"
+                ],
+                "externalStateRef": None,
+            },
+        }
+    }
+    workflow_instance._record_step_workspace_capture_input("implement", incomplete)
+    terminal_ref = await workflow_instance._record_canonical_step_checkpoint(
+        "implement", boundary="terminal_harvest", updated_at=now
+    )
+    terminal = json.loads(store.get_bytes(terminal_ref))
+    assert "omnigentCheckpoint" not in terminal
+    assert terminal["stepOutputs"]["omnigentCheckpointValidation"] == {
+        "valid": False,
+        "reasons": ["capture_incomplete_or_unresolvable"],
+        "liveReattachAvailable": False,
+        "workspaceColdRestoreAvailable": False,
+        "branchCreationAvailable": False,
     }
 
 

--- a/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
@@ -222,6 +222,7 @@ async def test_omnigent_result_is_joined_into_canonical_checkpoint_at_workflow_b
                     "baseCommit": "abc123",
                     "headCommit": "def456",
                     "archiveRef": "artifact://workspace/archive",
+                    "manifestRef": "artifact://workspace/manifest",
                     "archiveDigest": "sha256:" + "2" * 64,
                     "createdAt": now.isoformat(),
                 },
@@ -347,7 +348,7 @@ async def test_dynamic_remediation_validates_active_managed_session_workspace(
         captured.append({"activity": activity, "payload": payload})
         if activity == "agent_runtime.capture_workspace_checkpoint":
             return _managed_checkpoint_capture_result(payload)
-        assert activity == "step_checkpoint.create"
+        assert activity == "step_checkpoint.create_v2"
         return _checkpoint_create_result(payload)
 
     monkeypatch.setattr(run_module.workflow, "execute_activity", fake_execute_activity)
@@ -4179,7 +4180,7 @@ async def test_run_uses_external_omnigent_identity_for_checkpoint_capture(
             assert payload["kind"] == "worktree_archive"
             assert payload["workspaceLocator"]["kind"] == "sandbox"
             return _managed_checkpoint_capture_result(payload)
-        assert activity == "step_checkpoint.create"
+        assert activity == "step_checkpoint.create_v2"
         return _checkpoint_create_result(payload)
 
     monkeypatch.setattr(run_module.workflow, "execute_activity", fake_execute_activity)

--- a/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
@@ -151,20 +151,25 @@ async def test_omnigent_result_is_joined_into_canonical_checkpoint_at_workflow_b
     monkeypatch.setattr(run_module.workflow, "patched", lambda _patch_id: True)
     store = InMemoryArtifactStore()
     checkpoint_activities = TemporalCheckpointActivities(artifact_store=store)
-    external_ref = store.put_bytes(
-        json.dumps(
-            {
-                "omnigentSessionId": "session-3509",
-                "firstMessage": {
-                    "digest": "sha256:" + "1" * 64,
-                    "responseIdentifiers": {"itemId": "message-3509"},
-                },
-                "lastCommittedBridgeEventCursor": "event-9",
+    external_ref = "artifact://omnigent/external-state"
+    external_bytes = json.dumps(
+        {
+            "omnigentSessionId": "session-3509",
+            "firstMessage": {
+                "digest": "sha256:" + "1" * 64,
+                "responseIdentifiers": {"itemId": "message-3509"},
             },
-            sort_keys=True,
-        ).encode(),
-        content_type="application/json",
-    ).artifact_ref
+            "lastCommittedBridgeEventCursor": "event-9",
+        },
+        sort_keys=True,
+    ).encode()
+
+    async def read_checkpoint_artifact(artifact_ref: str) -> bytes:
+        if artifact_ref == external_ref:
+            return external_bytes
+        return store.get_bytes(artifact_ref)
+
+    monkeypatch.setattr(checkpoint_activities, "_read_bytes", read_checkpoint_artifact)
     workflow_instance = MoonMindRunWorkflow()
     now = datetime(2026, 8, 2, 12, 0, tzinfo=UTC)
     workflow_instance._input_ref = "artifact://task/input"


### PR DESCRIPTION
Implement GitHub issue MoonLadderStudios/MoonMind#3509.

## MoonSpec verification incomplete

This pull request was opened as a **draft** because MoonSpec verification did not approve publication (verdict BLOCKED) and the operator policy `workflow.moonspec_environment_blocked_publish_action` is `draft_pr`.

- Gate outcome: MoonSpec verification did not approve publication. verdict BLOCKED. Direct production-code and test inspection finds that the latest remediation closes the assessment backlog: normal Omnigent result metadata is joined with workspace evidence by the canonical Step Execution checkpoint writer, and cold recovery routes the pinned baseline and restore refs through the real clean-workspace materializer. The two new journey tests also close the prior verification-design gaps. Trustworthy final verification is blocked because the required MoonMind container backend lost the test job container before collection on two consecutive attempts; no test assertion failed. verification report art_01KZ15SR23QMB4X6SPKVAR5G32.
- Verification report: art_01KZ15SR23QMB4X6SPKVAR5G32
- Verification gate result: art_01KZ15SR0CCMYPFPTCK6HRJFME

Review the verification evidence before marking this pull request ready for review.