### PR TITLE
GitHub Issue Implement: MoonLadderStudios/MoonMind#3510

### DIFF
--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -1410,6 +1410,7 @@ def _branch_turn_launch_manifest_payload(
     context_bundle_ref: str,
 ) -> dict[str, Any]:
     follow_up_retrieval = (turn.diagnostics or {}).get("followUpRetrieval")
+    runtime_selection = (branch.diagnostics or {}).get("runtimeSelection")
     return {
         "workflowId": workflow_id,
         "runId": branch.source_run_id,
@@ -1418,6 +1419,11 @@ def _branch_turn_launch_manifest_payload(
         "stepExecutionId": payload.created_step_execution_id,
         "reason": "checkpoint_branch",
         "status": "running",
+        "runtimeSelection": (
+            dict(runtime_selection)
+            if isinstance(runtime_selection, Mapping)
+            else {}
+        ),
         "branch": {
             "branchId": branch.branch_id,
             "branchTurnId": turn.branch_turn_id,
@@ -13404,6 +13410,9 @@ async def launch_checkpoint_branch_turn(
             "gitWorkBranch": branch.git_work_branch or turn.git_work_branch,
         },
         "workspacePolicy": turn.workspace_policy,
+        "runtimeSelection": dict(
+            (branch.diagnostics or {}).get("runtimeSelection") or {}
+        ),
         "workspaceBaseline": payload.workspace_baseline
         or {
             "kind": "checkpoint_ref",

--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -13242,6 +13242,21 @@ async def create_checkpoint_branch(
     branch.publish_status = "unpublished"
     branch.idempotency_key = payload.idempotency_key
     branch.created_by = getattr(user, "email", None) or _owner_id(user)
+    # Runtime selectors are authored branch input. Persist the exact effective
+    # selection with the branch so launch/retry never has to trust transient UI
+    # state or mutate the source workflow's immutable runtime selection.
+    branch.diagnostics = {
+        **(branch.diagnostics or {}),
+        "runtimeSelection": {
+            "providerProfileRef": payload.provider_profile_ref,
+            "executionProfileRef": payload.execution_profile_ref,
+            "model": payload.model,
+            "effort": payload.effort,
+            "runtimeContextPolicy": payload.runtime_context_policy,
+            "publishMode": payload.publish_mode,
+            "gitWorkBranch": payload.git_work_branch,
+        },
+    }
     session.add(
         WorkflowCheckpointBranchOperation(
             workflow_id=workflow_id,

--- a/frontend/src/entrypoints/workflow-detail.test.tsx
+++ b/frontend/src/entrypoints/workflow-detail.test.tsx
@@ -2005,6 +2005,10 @@ describe('Workflow Detail Entrypoint', () => {
 
     renderWithClient(<WorkflowDetailPage payload={actionsPayload} />);
 
+    fireEvent.change(await screen.findByLabelText('Provider profile'), { target: { value: 'profile-oauth-2' } });
+    fireEvent.change(screen.getByLabelText('Execution profile / launch policy'), { target: { value: 'omnigent-isolated' } });
+    fireEvent.change(screen.getByLabelText('Model'), { target: { value: 'gpt-5.6-sol' } });
+    fireEvent.change(screen.getByLabelText('Effort'), { target: { value: 'high' } });
     fireEvent.click(await screen.findByRole('button', { name: 'Create branch from checkpoint' }));
 
     await waitFor(() => {
@@ -2018,6 +2022,10 @@ describe('Workflow Detail Entrypoint', () => {
       expect(body.workspacePolicy).toBe('apply_previous_execution_diff_to_clean_baseline');
       expect(body.runtimeContextPolicy).toBe('fresh_agent_run');
       expect(body.publishMode).toBe('none');
+      expect(body.providerProfileRef).toBe('profile-oauth-2');
+      expect(body.executionProfileRef).toBe('omnigent-isolated');
+      expect(body.model).toBe('gpt-5.6-sol');
+      expect(body.effort).toBe('high');
       expect(body.instructions.text).toContain('bounded alternative implementation');
       expect(body.idempotencyKey).toMatch(/^dashboard:create:test-123:apply:1:/);
     });

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -4697,6 +4697,10 @@ type BranchCreateDraft = {
   publishMode: string;
   gitWorkBranch: string;
   maxBudgetUsd: string;
+  providerProfileRef: string;
+  executionProfileRef: string;
+  model: string;
+  effort: string;
 };
 
 type BranchMutationKind = 'create' | 'continue' | 'fork' | 'promote' | 'publish' | 'archive' | 'compare';
@@ -4737,6 +4741,10 @@ const DEFAULT_BRANCH_CREATE_DRAFT: BranchCreateDraft = {
   publishMode: 'none',
   gitWorkBranch: '',
   maxBudgetUsd: '',
+  providerProfileRef: '',
+  executionProfileRef: '',
+  model: '',
+  effort: '',
 };
 
 function stepCheckpointRef(row: StepLedgerRow): string | null {
@@ -5149,6 +5157,28 @@ function BranchExplorerPanel({
               <option value="fresh_agent_run">Fresh agent run</option>
               <option value="reuse_session_new_epoch">Reuse session new epoch</option>
               <option value="reuse_session_same_epoch">Reuse session same epoch</option>
+            </select>
+          </label>
+          <label>
+            Provider profile
+            <input value={draft.providerProfileRef} disabled={busy} placeholder="Automatic authorized profile" onChange={(event) => setDraft((current) => ({ ...current, providerProfileRef: event.target.value }))} />
+          </label>
+          <label>
+            Execution profile / launch policy
+            <input value={draft.executionProfileRef} disabled={busy} placeholder="Inherited launch policy" onChange={(event) => setDraft((current) => ({ ...current, executionProfileRef: event.target.value }))} />
+          </label>
+          <label>
+            Model
+            <input value={draft.model} disabled={busy} placeholder="Runtime default" onChange={(event) => setDraft((current) => ({ ...current, model: event.target.value }))} />
+          </label>
+          <label>
+            Effort
+            <select value={draft.effort} disabled={busy} onChange={(event) => setDraft((current) => ({ ...current, effort: event.target.value }))}>
+              <option value="">Runtime default</option>
+              <option value="low">Low</option>
+              <option value="medium">Medium</option>
+              <option value="high">High</option>
+              <option value="xhigh">Extra high</option>
             </select>
           </label>
           <label>
@@ -9057,6 +9087,10 @@ function WorkflowDetailPageContent({ payload }: { payload: BootPayload }) {
           idempotencyKey: request.idempotencyKey,
           gitWorkBranch: request.draft.gitWorkBranch.trim() || null,
           maxBudgetUsd: Number.isFinite(budget) ? budget : null,
+          providerProfileRef: request.draft.providerProfileRef.trim() || null,
+          executionProfileRef: request.draft.executionProfileRef.trim() || null,
+          model: request.draft.model.trim() || null,
+          effort: request.draft.effort || null,
         };
         applyBranchRetrievalOverride(body, request.contextRetrieval);
       } else if (request.kind === 'continue') {

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -5916,6 +5916,14 @@ export interface components {
             gitWorkBranch?: string | null;
             /** Maxbudgetusd */
             maxBudgetUsd?: number | null;
+            /** Providerprofileref */
+            providerProfileRef?: string | null;
+            /** Executionprofileref */
+            executionProfileRef?: string | null;
+            /** Model */
+            model?: string | null;
+            /** Effort */
+            effort?: string | null;
             /** Followupretrieval */
             followUpRetrieval?: {
                 [key: string]: unknown;

--- a/moonmind/omnigent/checkpoints.py
+++ b/moonmind/omnigent/checkpoints.py
@@ -414,6 +414,8 @@ def recovery_mode(
     )
     if all(
         (
+            checkpoint.validation.valid,
+            checkpoint.validation.live_reattach_available,
             provider_active,
             provider_ref_matches,
             host_active,

--- a/moonmind/schemas/agent_runtime_models.py
+++ b/moonmind/schemas/agent_runtime_models.py
@@ -642,6 +642,9 @@ class AgentExecutionRequest(BaseModel):
     remediation_workspace: dict[str, Any] | None = Field(
         None, alias="remediationWorkspace"
     )
+    checkpoint_recovery: dict[str, Any] | None = Field(
+        None, alias="checkpointRecovery"
+    )
     terminal_contract: AgentTerminalContract | None = Field(
         None, alias="terminalContract"
     )
@@ -728,6 +731,11 @@ class AgentExecutionRequest(BaseModel):
             )
             self.remediation_workspace = binding.model_dump(
                 by_alias=True, mode="json", exclude_none=True
+            )
+        if self.checkpoint_recovery is not None:
+            self.checkpoint_recovery = validate_compact_temporal_mapping(
+                self.checkpoint_recovery,
+                field_name="checkpointRecovery",
             )
         self.input_refs = [
             require_non_blank(item, field_name="inputRefs[]")

--- a/moonmind/schemas/checkpoint_branch_models.py
+++ b/moonmind/schemas/checkpoint_branch_models.py
@@ -113,6 +113,14 @@ class CheckpointBranchCreateRequest(BaseModel):
     )
     git_work_branch: str | None = Field(None, alias="gitWorkBranch", max_length=255)
     max_budget_usd: float | None = Field(None, alias="maxBudgetUsd", ge=0)
+    provider_profile_ref: str | None = Field(
+        None, alias="providerProfileRef", min_length=1, max_length=255
+    )
+    execution_profile_ref: str | None = Field(
+        None, alias="executionProfileRef", min_length=1, max_length=255
+    )
+    model: str | None = Field(None, min_length=1, max_length=255)
+    effort: str | None = Field(None, min_length=1, max_length=64)
     # Authored in-session follow-up retrieval override for the branch turn
     # (MoonMind#3514). Recorded as bounded authored intent and folded into the
     # branch operation idempotency digest; enforcement inherits the parent run's

--- a/moonmind/workflows/temporal/activities/omnigent_activities.py
+++ b/moonmind/workflows/temporal/activities/omnigent_activities.py
@@ -111,7 +111,7 @@ def _checkpoint_recovery_from_request(request: AgentExecutionRequest):
         OmnigentCheckpointIdentity,
     )
 
-    recovery = (request.parameters or {}).get("checkpointRecovery")
+    recovery = request.checkpoint_recovery
     if not isinstance(recovery, dict):
         return None
     checkpoint_payload = recovery.get("omnigentCheckpoint")
@@ -138,7 +138,7 @@ def _checkpoint_branch_from_request(request: AgentExecutionRequest):
     Activity a typed call site for ``branch_from_checkpoint``.
     """
 
-    recovery = (request.parameters or {}).get("checkpointRecovery")
+    recovery = request.checkpoint_recovery
     if not isinstance(recovery, dict):
         return None
     if "immutableSource" in recovery or "immutableRequested" in recovery:
@@ -414,7 +414,7 @@ async def omnigent_execute_activity(
         )
         recovery_inputs = _checkpoint_recovery_from_request(request)
         branch_inputs = _checkpoint_branch_from_request(request)
-        recovery_payload = (request.parameters or {}).get("checkpointRecovery")
+        recovery_payload = request.checkpoint_recovery
         if branch_inputs is not None:
             checkpoint, candidate_workspace = branch_inputs
             authority = await _resolve_live_recovery_authority(

--- a/moonmind/workflows/temporal/activities/omnigent_activities.py
+++ b/moonmind/workflows/temporal/activities/omnigent_activities.py
@@ -38,6 +38,30 @@ def _checkpoint_recovery_from_request(request: AgentExecutionRequest):
     return checkpoint, candidate_workspace
 
 
+def _checkpoint_branch_from_request(request: AgentExecutionRequest):
+    """Return branch inputs only for an explicit, immutable-input-changing turn.
+
+    Recovery and branch execution intentionally share checkpoint validation, but
+    they do not share lease/session identity.  The explicit action keeps a normal
+    resume from accidentally creating a new branch and gives the production
+    Activity a typed call site for ``branch_from_checkpoint``.
+    """
+
+    recovery = (request.parameters or {}).get("checkpointRecovery")
+    if (
+        not isinstance(recovery, dict)
+        or recovery.get("recoveryAction") != "branch_required"
+    ):
+        return None
+    parsed = _checkpoint_recovery_from_request(request)
+    if parsed is None:
+        raise ValueError("checkpoint branch requires validated checkpoint evidence")
+    checkpoint, candidate_workspace = parsed
+    if request.idempotency_key == checkpoint.idempotency_key:
+        raise ValueError("checkpoint branch requires a new idempotency key")
+    return checkpoint, candidate_workspace
+
+
 async def _resolve_live_recovery_authority(
     *, checkpoint: Any, session_factory: Any, host_repository: Any, run_store: Any
 ) -> dict[str, Any]:
@@ -294,6 +318,23 @@ async def omnigent_execute_activity(
             ),
         )
         recovery_inputs = _checkpoint_recovery_from_request(request)
+        branch_inputs = _checkpoint_branch_from_request(request)
+        if branch_inputs is not None:
+            checkpoint, candidate_workspace = branch_inputs
+            authority = await _resolve_live_recovery_authority(
+                checkpoint=checkpoint,
+                session_factory=async_session_maker,
+                host_repository=host_repository,
+                run_store=run_store,
+            )
+            return await coordinator.branch_from_checkpoint(
+                request=request,
+                checkpoint=checkpoint,
+                current_credential_generation=authority[
+                    "current_credential_generation"
+                ],
+                candidate_workspace=candidate_workspace,
+            )
         if recovery_inputs is not None:
             checkpoint, candidate_workspace = recovery_inputs
             authority = await _resolve_live_recovery_authority(

--- a/moonmind/workflows/temporal/activities/omnigent_activities.py
+++ b/moonmind/workflows/temporal/activities/omnigent_activities.py
@@ -10,6 +10,32 @@ from temporalio import activity
 from moonmind.schemas.agent_runtime_models import AgentExecutionRequest, AgentRunResult
 
 
+def _checkpoint_recovery_from_request(request: AgentExecutionRequest):
+    """Return validated coordinator inputs for an evidence-gated resume."""
+
+    from moonmind.omnigent.checkpoints import (
+        CandidateWorkspaceAuthority,
+        OmnigentCheckpointIdentity,
+    )
+
+    recovery = (request.parameters or {}).get("checkpointRecovery")
+    if not isinstance(recovery, dict):
+        return None
+    checkpoint_payload = recovery.get("omnigentCheckpoint")
+    if checkpoint_payload is None:
+        return None
+    checkpoint = OmnigentCheckpointIdentity.model_validate(checkpoint_payload)
+    candidate_workspace = CandidateWorkspaceAuthority(
+        loopId=f"{checkpoint.workflow_id}:{checkpoint.logical_step_id}",
+        attemptOrdinal=checkpoint.attempt_ordinal,
+        headRef=checkpoint.head_ref,
+        headDigest=checkpoint.head_digest,
+        checkpointRef=checkpoint.workspace_checkpoint_ref,
+        checkpointDigest=checkpoint.workspace_checkpoint_digest,
+    )
+    return checkpoint, candidate_workspace
+
+
 @activity.defn(name="integration.omnigent.execute")
 async def omnigent_execute_activity(
     request: AgentExecutionRequest,
@@ -138,6 +164,25 @@ async def omnigent_execute_activity(
                 head_loader=ArtifactRemediationHeadLoader(artifact_service),
             ),
         )
+        recovery_inputs = _checkpoint_recovery_from_request(request)
+        if recovery_inputs is not None:
+            checkpoint, candidate_workspace = recovery_inputs
+            # Live reattachment is intentionally fail-closed here. The
+            # Activity has validated durable restore evidence, but no
+            # authoritative proof that every original live lease/session
+            # is still current; recover_from_checkpoint therefore selects
+            # cold restore and reacquires capacity through the coordinator.
+            return await coordinator.recover_from_checkpoint(
+                request=request,
+                checkpoint=checkpoint,
+                provider_lease=None,
+                host_lease=None,
+                host_registered=False,
+                session_valid=False,
+                first_message_consistent=False,
+                current_credential_generation=checkpoint.credential_generation,
+                candidate_workspace=candidate_workspace,
+            )
         return await coordinator.execute(request)
 
 
@@ -204,6 +249,7 @@ async def omnigent_oauth_host_janitor_activity(
 
 
 __all__ = [
+    "_checkpoint_recovery_from_request",
     "omnigent_execute_activity",
     "omnigent_profile_bound_execute_activity",
     "omnigent_oauth_host_janitor_activity",

--- a/moonmind/workflows/temporal/activities/omnigent_activities.py
+++ b/moonmind/workflows/temporal/activities/omnigent_activities.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import os
+from datetime import UTC, datetime
 from pathlib import Path
+from typing import Any
 
 from temporalio import activity
 
@@ -34,6 +36,119 @@ def _checkpoint_recovery_from_request(request: AgentExecutionRequest):
         checkpointDigest=checkpoint.workspace_checkpoint_digest,
     )
     return checkpoint, candidate_workspace
+
+
+async def _resolve_live_recovery_authority(
+    *, checkpoint: Any, session_factory: Any, host_repository: Any, run_store: Any
+) -> dict[str, Any]:
+    """Resolve every mutable authority used by the live-reattach gate.
+
+    Missing, expired, ambiguous, or mismatched state is represented as false
+    evidence so ``recovery_mode`` fails closed to cold restore.  Credential
+    generation is always loaded from the current Provider Profile and is never
+    copied from checkpoint evidence.
+    """
+
+    from sqlalchemy import func, select
+
+    from api_service.db.models import (
+        ManagedAgentProviderProfile,
+        OmnigentBridgeSessionEvent,
+        ProviderProfileSlotLease,
+    )
+
+    now = datetime.now(UTC)
+    async with session_factory() as session:
+        profile = await session.get(
+            ManagedAgentProviderProfile, checkpoint.provider_profile_id
+        )
+        current_generation = int(profile.credential_generation) if profile else 0
+        provider_row = None
+        if checkpoint.provider_lease_ref:
+            provider_row = (
+                await session.execute(
+                    select(ProviderProfileSlotLease).where(
+                        ProviderProfileSlotLease.lease_id
+                        == checkpoint.provider_lease_ref,
+                        ProviderProfileSlotLease.profile_id
+                        == checkpoint.provider_profile_id,
+                    )
+                )
+            ).scalar_one_or_none()
+        latest_sequence = int(
+            (
+                await session.execute(
+                    select(func.max(OmnigentBridgeSessionEvent.sequence)).where(
+                        OmnigentBridgeSessionEvent.bridge_session_id
+                        == checkpoint.bridge_session_id
+                    )
+                )
+            ).scalar()
+            or 0
+        )
+
+    provider_lease = None
+    if provider_row is not None:
+        expires_at = provider_row.expires_at
+        if expires_at is not None and expires_at.tzinfo is None:
+            expires_at = expires_at.replace(tzinfo=UTC)
+        provider_lease = {
+            "leaseId": provider_row.lease_id,
+            "active": expires_at is None or expires_at > now,
+        }
+
+    host = (
+        await host_repository.get_host_lease(checkpoint.host_lease_ref)
+        if checkpoint.host_lease_ref
+        else None
+    )
+    host_lease = (
+        host.model_dump(by_alias=True, mode="json", exclude_none=True)
+        if host is not None
+        else None
+    )
+    bridge = await run_store.get_bridge_session(checkpoint.bridge_session_id)
+    host_expires_at = host.expires_at if host is not None else None
+    if host_expires_at is not None and host_expires_at.tzinfo is None:
+        host_expires_at = host_expires_at.replace(tzinfo=UTC)
+    host_registered = bool(
+        host
+        and host.omnigent_host_id == checkpoint.omnigent_host_id
+        and host.omnigent_session_id == checkpoint.omnigent_session_id
+        and host.bridge_session_id == checkpoint.bridge_session_id
+        and host.status in {"ready", "assigned"}
+        and host_expires_at
+        and host_expires_at > now
+    )
+    session_valid = bool(
+        bridge
+        and bridge.omnigent_host_id == checkpoint.omnigent_host_id
+        and bridge.omnigent_session_id == checkpoint.omnigent_session_id
+        and bridge.status == "active"
+        and (
+            checkpoint.last_bridge_event_cursor is None
+            or (
+                checkpoint.last_bridge_event_cursor.isdecimal()
+                and latest_sequence >= int(checkpoint.last_bridge_event_cursor)
+            )
+        )
+    )
+    first_message_consistent = bool(
+        bridge
+        and checkpoint.first_message_digest
+        and bridge.first_message_digest == checkpoint.first_message_digest
+        and checkpoint.first_message_id
+        in {bridge.first_message_item_id, bridge.first_message_pending_id}
+        and bridge.first_message_state in {"posted", "terminal"}
+    )
+    return {
+        "provider_lease": provider_lease,
+        "host_lease": host_lease,
+        "host_registered": host_registered,
+        "session_valid": session_valid,
+        "first_message_consistent": first_message_consistent,
+        "current_credential_generation": current_generation,
+    }
 
 
 @activity.defn(name="integration.omnigent.execute")
@@ -146,10 +261,11 @@ async def omnigent_execute_activity(
         )
 
         lore_repository_adapter = build_lore_repository_adapter_from_environment()
+        host_repository = OmnigentOAuthHostRepository(async_session_maker)
         coordinator = OmnigentProfileBoundExecutionCoordinator(
             session_factory=async_session_maker,
             lease_client=ProviderProfileLeaseClient(TemporalClientAdapter()),
-            host_repository=OmnigentOAuthHostRepository(async_session_maker),
+            host_repository=host_repository,
             host_runtime=OmnigentOAuthHostRuntime(
                 client=omnigent_client,
                 lore_repository_adapter=lore_repository_adapter,
@@ -167,21 +283,17 @@ async def omnigent_execute_activity(
         recovery_inputs = _checkpoint_recovery_from_request(request)
         if recovery_inputs is not None:
             checkpoint, candidate_workspace = recovery_inputs
-            # Live reattachment is intentionally fail-closed here. The
-            # Activity has validated durable restore evidence, but no
-            # authoritative proof that every original live lease/session
-            # is still current; recover_from_checkpoint therefore selects
-            # cold restore and reacquires capacity through the coordinator.
+            authority = await _resolve_live_recovery_authority(
+                checkpoint=checkpoint,
+                session_factory=async_session_maker,
+                host_repository=host_repository,
+                run_store=run_store,
+            )
             return await coordinator.recover_from_checkpoint(
                 request=request,
                 checkpoint=checkpoint,
-                provider_lease=None,
-                host_lease=None,
-                host_registered=False,
-                session_valid=False,
-                first_message_consistent=False,
-                current_credential_generation=checkpoint.credential_generation,
                 candidate_workspace=candidate_workspace,
+                **authority,
             )
         return await coordinator.execute(request)
 
@@ -250,6 +362,7 @@ async def omnigent_oauth_host_janitor_activity(
 
 __all__ = [
     "_checkpoint_recovery_from_request",
+    "_resolve_live_recovery_authority",
     "omnigent_execute_activity",
     "omnigent_profile_bound_execute_activity",
     "omnigent_oauth_host_janitor_activity",

--- a/moonmind/workflows/temporal/activities/omnigent_activities.py
+++ b/moonmind/workflows/temporal/activities/omnigent_activities.py
@@ -65,16 +65,24 @@ async def _resolve_live_recovery_authority(
         current_generation = int(profile.credential_generation) if profile else 0
         provider_row = None
         if checkpoint.provider_lease_ref:
-            provider_row = (
-                await session.execute(
-                    select(ProviderProfileSlotLease).where(
-                        ProviderProfileSlotLease.lease_id
-                        == checkpoint.provider_lease_ref,
-                        ProviderProfileSlotLease.profile_id
-                        == checkpoint.provider_profile_id,
+            provider_rows = list(
+                (
+                    await session.execute(
+                        select(ProviderProfileSlotLease).where(
+                            ProviderProfileSlotLease.lease_id
+                            == checkpoint.provider_lease_ref,
+                            ProviderProfileSlotLease.profile_id
+                            == checkpoint.provider_profile_id,
+                        )
                     )
                 )
-            ).scalar_one_or_none()
+                .scalars()
+                .all()
+            )
+            # A duplicated lease identity is ambiguous authority even if both
+            # rows otherwise look current.  Fail closed instead of allowing a
+            # live session to keep consuming the OAuth profile.
+            provider_row = provider_rows[0] if len(provider_rows) == 1 else None
         latest_sequence = int(
             (
                 await session.execute(
@@ -94,7 +102,12 @@ async def _resolve_live_recovery_authority(
             expires_at = expires_at.replace(tzinfo=UTC)
         provider_lease = {
             "leaseId": provider_row.lease_id,
-            "active": expires_at is None or expires_at > now,
+            "active": bool(
+                expires_at
+                and expires_at > now
+                and provider_row.owner_id
+                and provider_row.idempotency_key == checkpoint.idempotency_key
+            ),
         }
 
     host = (

--- a/moonmind/workflows/temporal/activities/omnigent_activities.py
+++ b/moonmind/workflows/temporal/activities/omnigent_activities.py
@@ -29,6 +29,7 @@ def _checkpoint_recovery_decision(
     *,
     live_authority: dict[str, Any] | None = None,
     cold_restore_authorized: bool | None = None,
+    live_reattach_authorized: bool | None = None,
 ) -> dict[str, Any]:
     """Classify recovery from bounded, caller-independent authority evidence.
 
@@ -73,7 +74,8 @@ def _checkpoint_recovery_decision(
     # cursor, and first-message state.  Payload booleans are deliberately
     # ignored: callers may request recovery, but cannot attest authority.
     live_valid = bool(
-        live_authority
+        live_reattach_authorized is True
+        and live_authority
         and live_authority.get("provider_lease")
         and live_authority["provider_lease"].get("active") is True
         and live_authority.get("host_registered") is True
@@ -442,6 +444,10 @@ async def omnigent_execute_activity(
             decision = _checkpoint_recovery_decision(
                 recovery_payload,
                 live_authority=authority,
+                live_reattach_authorized=bool(
+                    checkpoint.validation.valid
+                    and checkpoint.validation.live_reattach_available
+                ),
                 cold_restore_authorized=bool(
                     checkpoint.validation.valid
                     and checkpoint.validation.workspace_cold_restore_available
@@ -460,6 +466,11 @@ async def omnigent_execute_activity(
                 raise ValueError(
                     "checkpoint resume unavailable: "
                     + ",".join(map(str, reasons[:20]))
+                )
+            if decision["recoveryAction"] == "cold_restore":
+                raise ValueError(
+                    "checkpoint cold restore requires an owned workspace restoration "
+                    "boundary before Omnigent launch"
                 )
             return await coordinator.recover_from_checkpoint(
                 request=request,

--- a/moonmind/workflows/temporal/activities/omnigent_activities.py
+++ b/moonmind/workflows/temporal/activities/omnigent_activities.py
@@ -24,7 +24,12 @@ _IMMUTABLE_RECOVERY_DIMENSIONS = (
 )
 
 
-def _checkpoint_recovery_decision(recovery: dict[str, Any]) -> dict[str, Any]:
+def _checkpoint_recovery_decision(
+    recovery: dict[str, Any],
+    *,
+    live_authority: dict[str, Any] | None = None,
+    cold_restore_authorized: bool | None = None,
+) -> dict[str, Any]:
     """Classify recovery from bounded, caller-independent authority evidence.
 
     The decision is intentionally compact so the request/history can retain the
@@ -63,12 +68,26 @@ def _checkpoint_recovery_decision(recovery: dict[str, Any]) -> dict[str, Any]:
                 f"immutable_{dimension}_changed" for dimension in changed[:20]
             ],
         }
-    if recovery.get("liveReattachAvailable") is True:
+    # Availability is authority-sensitive and must be supplied by the trusted
+    # Activity after it has re-resolved current profile, lease, host, session,
+    # cursor, and first-message state.  Payload booleans are deliberately
+    # ignored: callers may request recovery, but cannot attest authority.
+    live_valid = bool(
+        live_authority
+        and live_authority.get("provider_lease")
+        and live_authority["provider_lease"].get("active") is True
+        and live_authority.get("host_registered") is True
+        and live_authority.get("session_valid") is True
+        and live_authority.get("first_message_consistent") is True
+        and live_authority.get("current_credential_generation")
+        == live_authority.get("checkpoint_credential_generation")
+    )
+    if live_valid:
         return {
             "recoveryAction": "live_reattach",
             "reasonCodes": ["all_authority_valid"],
         }
-    if recovery.get("coldRestoreAvailable") is True:
+    if cold_restore_authorized is True:
         return {
             "recoveryAction": "cold_restore",
             "reasonCodes": ["live_authority_unavailable"],
@@ -258,6 +277,7 @@ async def _resolve_live_recovery_authority(
         "session_valid": session_valid,
         "first_message_consistent": first_message_consistent,
         "current_credential_generation": current_generation,
+        "checkpoint_credential_generation": checkpoint.credential_generation,
     }
 
 
@@ -393,21 +413,6 @@ async def omnigent_execute_activity(
         recovery_inputs = _checkpoint_recovery_from_request(request)
         branch_inputs = _checkpoint_branch_from_request(request)
         recovery_payload = (request.parameters or {}).get("checkpointRecovery")
-        recovery_decision = (
-            recovery_payload.get("recoveryDecision")
-            if isinstance(recovery_payload, dict)
-            else None
-        )
-        if (
-            isinstance(recovery_decision, dict)
-            and recovery_decision.get("recoveryAction") == "resume_unavailable"
-        ):
-            reasons = recovery_decision.get("reasonCodes") or [
-                "checkpoint_authority_unavailable"
-            ]
-            raise ValueError(
-                "checkpoint resume unavailable: " + ",".join(map(str, reasons[:20]))
-            )
         if branch_inputs is not None:
             checkpoint, candidate_workspace = branch_inputs
             authority = await _resolve_live_recovery_authority(
@@ -432,6 +437,30 @@ async def omnigent_execute_activity(
                 host_repository=host_repository,
                 run_store=run_store,
             )
+            if not isinstance(recovery_payload, dict):
+                raise ValueError("checkpoint recovery payload is invalid")
+            decision = _checkpoint_recovery_decision(
+                recovery_payload,
+                live_authority=authority,
+                cold_restore_authorized=bool(
+                    checkpoint.validation.valid
+                    and checkpoint.validation.workspace_cold_restore_available
+                    and authority["current_credential_generation"]
+                    == checkpoint.credential_generation
+                    and request.execution_profile_ref
+                    == checkpoint.provider_profile_id
+                ),
+            )
+            recovery_payload["recoveryDecision"] = decision
+            recovery_payload["recoveryAction"] = decision["recoveryAction"]
+            if decision["recoveryAction"] == "resume_unavailable":
+                reasons = decision.get("reasonCodes") or [
+                    "checkpoint_authority_unavailable"
+                ]
+                raise ValueError(
+                    "checkpoint resume unavailable: "
+                    + ",".join(map(str, reasons[:20]))
+                )
             return await coordinator.recover_from_checkpoint(
                 request=request,
                 checkpoint=checkpoint,

--- a/moonmind/workflows/temporal/activities/omnigent_activities.py
+++ b/moonmind/workflows/temporal/activities/omnigent_activities.py
@@ -12,6 +12,76 @@ from temporalio import activity
 from moonmind.schemas.agent_runtime_models import AgentExecutionRequest, AgentRunResult
 
 
+_IMMUTABLE_RECOVERY_DIMENSIONS = (
+    "instructionDigest",
+    "runtimeId",
+    "model",
+    "effort",
+    "providerProfileId",
+    "launchPolicyRef",
+    "repositoryBranch",
+    "publishMode",
+)
+
+
+def _checkpoint_recovery_decision(recovery: dict[str, Any]) -> dict[str, Any]:
+    """Classify recovery from bounded, caller-independent authority evidence.
+
+    The decision is intentionally compact so the request/history can retain the
+    exact terminal rationale without persisting mutable host details. Immutable
+    input changes always win over live/cold availability.
+    """
+
+    source = recovery.get("immutableSource")
+    requested = recovery.get("immutableRequested")
+    if not isinstance(source, dict) or not isinstance(requested, dict):
+        return {
+            "recoveryAction": "resume_unavailable",
+            "reasonCodes": ["immutable_authority_missing"],
+        }
+    missing = [
+        dimension
+        for dimension in _IMMUTABLE_RECOVERY_DIMENSIONS
+        if dimension not in source or dimension not in requested
+    ]
+    if missing:
+        return {
+            "recoveryAction": "resume_unavailable",
+            "reasonCodes": [
+                f"immutable_{dimension}_missing" for dimension in missing[:20]
+            ],
+        }
+    changed = [
+        dimension
+        for dimension in _IMMUTABLE_RECOVERY_DIMENSIONS
+        if source[dimension] != requested[dimension]
+    ]
+    if changed:
+        return {
+            "recoveryAction": "branch_required",
+            "reasonCodes": [
+                f"immutable_{dimension}_changed" for dimension in changed[:20]
+            ],
+        }
+    if recovery.get("liveReattachAvailable") is True:
+        return {
+            "recoveryAction": "live_reattach",
+            "reasonCodes": ["all_authority_valid"],
+        }
+    if recovery.get("coldRestoreAvailable") is True:
+        return {
+            "recoveryAction": "cold_restore",
+            "reasonCodes": ["live_authority_unavailable"],
+        }
+    reasons = recovery.get("unavailableReasonCodes")
+    bounded_reasons = (
+        [str(reason)[:120] for reason in reasons[:20]]
+        if isinstance(reasons, list) and reasons
+        else ["checkpoint_authority_unavailable"]
+    )
+    return {"recoveryAction": "resume_unavailable", "reasonCodes": bounded_reasons}
+
+
 def _checkpoint_recovery_from_request(request: AgentExecutionRequest):
     """Return validated coordinator inputs for an evidence-gated resume."""
 
@@ -48,10 +118,13 @@ def _checkpoint_branch_from_request(request: AgentExecutionRequest):
     """
 
     recovery = (request.parameters or {}).get("checkpointRecovery")
-    if (
-        not isinstance(recovery, dict)
-        or recovery.get("recoveryAction") != "branch_required"
-    ):
+    if not isinstance(recovery, dict):
+        return None
+    if "immutableSource" in recovery or "immutableRequested" in recovery:
+        decision = _checkpoint_recovery_decision(recovery)
+        recovery["recoveryDecision"] = decision
+        recovery["recoveryAction"] = decision["recoveryAction"]
+    if recovery.get("recoveryAction") != "branch_required":
         return None
     parsed = _checkpoint_recovery_from_request(request)
     if parsed is None:
@@ -319,6 +392,22 @@ async def omnigent_execute_activity(
         )
         recovery_inputs = _checkpoint_recovery_from_request(request)
         branch_inputs = _checkpoint_branch_from_request(request)
+        recovery_payload = (request.parameters or {}).get("checkpointRecovery")
+        recovery_decision = (
+            recovery_payload.get("recoveryDecision")
+            if isinstance(recovery_payload, dict)
+            else None
+        )
+        if (
+            isinstance(recovery_decision, dict)
+            and recovery_decision.get("recoveryAction") == "resume_unavailable"
+        ):
+            reasons = recovery_decision.get("reasonCodes") or [
+                "checkpoint_authority_unavailable"
+            ]
+            raise ValueError(
+                "checkpoint resume unavailable: " + ",".join(map(str, reasons[:20]))
+            )
         if branch_inputs is not None:
             checkpoint, candidate_workspace = branch_inputs
             authority = await _resolve_live_recovery_authority(

--- a/moonmind/workflows/temporal/service.py
+++ b/moonmind/workflows/temporal/service.py
@@ -3942,6 +3942,25 @@ class TemporalExecutionService:
                 ],
             }
         recovery_source_payload["failedRunRecoveryManifestRef"] = manifest_ref
+        # Preserve the validated Omnigent authority snapshot at the Activity
+        # boundary.  The resumed workflow must not silently turn an Omnigent
+        # checkpoint into a fresh profile-bound execution.
+        omnigent_checkpoint = checkpoint_payload.get("omnigentCheckpoint")
+        if omnigent_checkpoint is None:
+            omnigent_checkpoint = checkpoint_payload.get("omnigent_checkpoint")
+        if omnigent_checkpoint is not None:
+            try:
+                from moonmind.omnigent.checkpoints import OmnigentCheckpointIdentity
+
+                recovery_source_payload["omnigentCheckpoint"] = (
+                    OmnigentCheckpointIdentity.model_validate(
+                        omnigent_checkpoint
+                    ).model_dump(by_alias=True, mode="json", exclude_none=True)
+                )
+            except ValidationError as exc:
+                raise TemporalExecutionRecoveryCheckpointError(
+                    "Omnigent recovery checkpoint identity is invalid."
+                ) from exc
         recovery_source_payload["selectedCheckpointBoundary"] = (
             recovery_manifest.validation.boundary
         )

--- a/moonmind/workflows/temporal/service.py
+++ b/moonmind/workflows/temporal/service.py
@@ -3955,6 +3955,13 @@ class TemporalExecutionService:
                 validated_omnigent = OmnigentCheckpointIdentity.model_validate(
                     omnigent_checkpoint
                 )
+                if (
+                    recovery_mode == "selected_step"
+                    and validated_omnigent.logical_step_id != failed_step_id
+                ):
+                    raise TemporalExecutionRecoveryCheckpointError(
+                        "Selected start step has no matching Omnigent checkpoint evidence."
+                    )
                 recovery_source_payload["omnigentCheckpoint"] = (
                     validated_omnigent.model_dump(
                         by_alias=True, mode="json", exclude_none=True
@@ -3989,6 +3996,19 @@ class TemporalExecutionService:
                         or "none"
                     ),
                 }
+                # Pin the checkpoint's validated selection into the authored
+                # launch. A later profile/default lookup must not silently alter
+                # a recovery after the immutable comparison has admitted it.
+                pinned_runtime_payload = dict(runtime_payload)
+                pinned_runtime_payload["model"] = immutable_snapshot["model"]
+                pinned_runtime_payload["effort"] = immutable_snapshot["effort"]
+                task_payload["runtime"] = pinned_runtime_payload
+                task_payload["model"] = immutable_snapshot["model"]
+                task_payload["effort"] = immutable_snapshot["effort"]
+                task_payload["publishMode"] = immutable_snapshot["publishMode"]
+                params[
+                    "workflow" if _mapping_payload(params.get("workflow")) else "task"
+                ] = task_payload
                 # This command preserves the source workflow inputs. Branch
                 # APIs construct a distinct requested snapshot when an operator
                 # changes any immutable dimension.

--- a/moonmind/workflows/temporal/service.py
+++ b/moonmind/workflows/temporal/service.py
@@ -3952,10 +3952,49 @@ class TemporalExecutionService:
             try:
                 from moonmind.omnigent.checkpoints import OmnigentCheckpointIdentity
 
+                validated_omnigent = OmnigentCheckpointIdentity.model_validate(
+                    omnigent_checkpoint
+                )
                 recovery_source_payload["omnigentCheckpoint"] = (
-                    OmnigentCheckpointIdentity.model_validate(
-                        omnigent_checkpoint
-                    ).model_dump(by_alias=True, mode="json", exclude_none=True)
+                    validated_omnigent.model_dump(
+                        by_alias=True, mode="json", exclude_none=True
+                    )
+                )
+                task_payload = _workflow_payload(params)
+                runtime_payload = _mapping_payload(task_payload.get("runtime"))
+                instruction_identity = hashlib.sha256(
+                    source_snapshot_ref.encode("utf-8")
+                ).hexdigest()
+                immutable_snapshot = {
+                    "instructionDigest": f"sha256:{instruction_identity}",
+                    "runtimeId": eligibility.target_runtime_id,
+                    "model": str(
+                        runtime_payload.get("model")
+                        or task_payload.get("model")
+                        or params.get("model")
+                        or "default"
+                    ),
+                    "effort": str(
+                        runtime_payload.get("effort")
+                        or task_payload.get("effort")
+                        or params.get("effort")
+                        or "default"
+                    ),
+                    "providerProfileId": validated_omnigent.provider_profile_id,
+                    "launchPolicyRef": validated_omnigent.launch_policy_ref,
+                    "repositoryBranch": validated_omnigent.source_branch,
+                    "publishMode": str(
+                        task_payload.get("publishMode")
+                        or params.get("publishMode")
+                        or "none"
+                    ),
+                }
+                # This command preserves the source workflow inputs. Branch
+                # APIs construct a distinct requested snapshot when an operator
+                # changes any immutable dimension.
+                recovery_source_payload["immutableSource"] = immutable_snapshot
+                recovery_source_payload["immutableRequested"] = dict(
+                    immutable_snapshot
                 )
             except ValidationError as exc:
                 raise TemporalExecutionRecoveryCheckpointError(

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -18165,6 +18165,9 @@ class MoonMindRunWorkflow:
         if (
             self._recovery_failed_step_id == node_id
             and isinstance(self._recovery_source, Mapping)
+            and self._workflow_patch_enabled(
+                RUN_CHECKPOINT_RECOVERY_STATE_MACHINE_PATCH
+            )
         ):
             # This is trusted workflow-owned recovery state created by the API
             # after artifact validation. Keep it out of ordinary plan inputs.

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -18163,6 +18163,13 @@ class MoonMindRunWorkflow:
             if param_val is not None:
                 parameters[param_key] = param_val
         if (
+            self._recovery_failed_step_id == node_id
+            and isinstance(self._recovery_source, Mapping)
+        ):
+            # This is trusted workflow-owned recovery state created by the API
+            # after artifact validation. Keep it out of ordinary plan inputs.
+            parameters["checkpointRecovery"] = dict(self._recovery_source)
+        if (
             self._workflow_patch_enabled(
                 RUN_PR_RESOLVER_CONTINUATION_IDENTITY_PATCH
             )

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -18231,6 +18231,7 @@ class MoonMindRunWorkflow:
                 param_val = workflow_parameters.get(param_key)
             if param_val is not None:
                 parameters[param_key] = param_val
+        checkpoint_recovery = None
         if (
             self._recovery_failed_step_id == node_id
             and isinstance(self._recovery_source, Mapping)
@@ -18240,7 +18241,7 @@ class MoonMindRunWorkflow:
         ):
             # This is trusted workflow-owned recovery state created by the API
             # after artifact validation. Keep it out of ordinary plan inputs.
-            parameters["checkpointRecovery"] = dict(self._recovery_source)
+            checkpoint_recovery = dict(self._recovery_source)
         if (
             self._workflow_patch_enabled(
                 RUN_PR_RESOLVER_CONTINUATION_IDENTITY_PATCH
@@ -19127,6 +19128,7 @@ class MoonMindRunWorkflow:
                 if isinstance(remediation_workspace, Mapping)
                 else None
             ),
+            checkpoint_recovery=checkpoint_recovery,
             terminal_contract=terminal_contract_payload,
             terminal_continuation_authority=terminal_continuation_authority,
             input_refs=input_refs,

--- a/tests/unit/workflows/temporal/test_omnigent_activities.py
+++ b/tests/unit/workflows/temporal/test_omnigent_activities.py
@@ -15,10 +15,98 @@ from moonmind.workflows.temporal.activities import (
 )
 from moonmind.workflows.temporal.activities.omnigent_activities import (
     _checkpoint_branch_from_request,
+    _checkpoint_recovery_decision,
     _checkpoint_recovery_from_request,
     _resolve_live_recovery_authority,
     omnigent_execute_activity,
 )
+
+
+@pytest.mark.parametrize(
+    ("dimension", "changed"),
+    [
+        ("instructionDigest", "sha256:changed-instructions"),
+        ("runtimeId", "codex"),
+        ("model", "gpt-5.6"),
+        ("effort", "high"),
+        ("providerProfileId", "profile-2"),
+        ("launchPolicyRef", "artifact://policy/2"),
+        ("repositoryBranch", "feature/changed"),
+        ("publishMode", "pull_request"),
+    ],
+)
+def test_checkpoint_recovery_decision_requires_branch_for_immutable_change(
+    dimension, changed
+) -> None:
+    immutable_source = {
+        "instructionDigest": "sha256:instructions",
+        "runtimeId": "omnigent",
+        "model": "default",
+        "effort": "medium",
+        "providerProfileId": "profile-1",
+        "launchPolicyRef": "artifact://policy/1",
+        "repositoryBranch": "main",
+        "publishMode": "none",
+    }
+    requested = {**immutable_source, dimension: changed}
+
+    decision = _checkpoint_recovery_decision(
+        {
+            "immutableSource": immutable_source,
+            "immutableRequested": requested,
+            "liveReattachAvailable": True,
+            "coldRestoreAvailable": True,
+        }
+    )
+
+    assert decision == {
+        "recoveryAction": "branch_required",
+        "reasonCodes": [f"immutable_{dimension}_changed"],
+    }
+
+
+def test_checkpoint_recovery_decision_fails_closed_without_authoritative_snapshot() -> None:
+    decision = _checkpoint_recovery_decision(
+        {"liveReattachAvailable": True, "coldRestoreAvailable": True}
+    )
+
+    assert decision == {
+        "recoveryAction": "resume_unavailable",
+        "reasonCodes": ["immutable_authority_missing"],
+    }
+
+
+def test_checkpoint_recovery_decision_selects_live_or_cold_with_bounded_rationale() -> None:
+    immutable = {
+        "instructionDigest": "sha256:instructions",
+        "runtimeId": "omnigent",
+        "model": "default",
+        "effort": "medium",
+        "providerProfileId": "profile-1",
+        "launchPolicyRef": "artifact://policy/1",
+        "repositoryBranch": "main",
+        "publishMode": "none",
+    }
+
+    assert _checkpoint_recovery_decision(
+        {
+            "immutableSource": immutable,
+            "immutableRequested": immutable,
+            "liveReattachAvailable": True,
+            "coldRestoreAvailable": True,
+        }
+    ) == {"recoveryAction": "live_reattach", "reasonCodes": ["all_authority_valid"]}
+    assert _checkpoint_recovery_decision(
+        {
+            "immutableSource": immutable,
+            "immutableRequested": immutable,
+            "liveReattachAvailable": False,
+            "coldRestoreAvailable": True,
+        }
+    ) == {
+        "recoveryAction": "cold_restore",
+        "reasonCodes": ["live_authority_unavailable"],
+    }
 
 
 @pytest.mark.asyncio
@@ -123,6 +211,49 @@ def test_checkpoint_branch_request_requires_explicit_action_and_new_boundary() -
     parsed_checkpoint, candidate = parsed
     assert parsed_checkpoint == checkpoint
     assert candidate.checkpoint_ref == checkpoint.workspace_checkpoint_ref
+
+
+def test_checkpoint_branch_request_is_derived_from_immutable_input_change() -> None:
+    from tests.unit.omnigent.test_oauth_profile_lifecycle import _checkpoint
+
+    checkpoint = _checkpoint()
+    source = {
+        "instructionDigest": "sha256:old",
+        "runtimeId": "omnigent",
+        "model": "default",
+        "effort": "medium",
+        "providerProfileId": checkpoint.provider_profile_id,
+        "launchPolicyRef": checkpoint.launch_policy_ref,
+        "repositoryBranch": "main",
+        "publishMode": "none",
+    }
+    request = AgentExecutionRequest(
+        agentKind="external",
+        agentId="omnigent",
+        executionProfileRef=checkpoint.provider_profile_id,
+        correlationId="branch-workflow",
+        idempotencyKey="branch-turn-derived",
+        parameters={
+            "checkpointRecovery": {
+                "omnigentCheckpoint": checkpoint.model_dump(
+                    by_alias=True, mode="json", exclude_none=True
+                ),
+                "immutableSource": source,
+                "immutableRequested": {
+                    **source,
+                    "instructionDigest": "sha256:new",
+                },
+                "liveReattachAvailable": True,
+                "coldRestoreAvailable": True,
+            }
+        },
+    )
+
+    assert _checkpoint_branch_from_request(request) is not None
+    assert request.parameters["checkpointRecovery"]["recoveryDecision"] == {
+        "recoveryAction": "branch_required",
+        "reasonCodes": ["immutable_instructionDigest_changed"],
+    }
 
 
 def test_checkpoint_branch_request_rejects_source_idempotency_boundary() -> None:

--- a/tests/unit/workflows/temporal/test_omnigent_activities.py
+++ b/tests/unit/workflows/temporal/test_omnigent_activities.py
@@ -114,6 +114,8 @@ async def test_live_recovery_authority_requires_matching_current_records() -> No
     provider = SimpleNamespace(credential_generation=checkpoint.credential_generation)
     provider_lease = SimpleNamespace(
         lease_id="provider-lease",
+        owner_id="owner-1",
+        idempotency_key=checkpoint.idempotency_key,
         expires_at=datetime.now(UTC) + timedelta(minutes=5),
     )
 
@@ -123,6 +125,10 @@ async def test_live_recovery_authority_requires_matching_current_records() -> No
 
         def scalar_one_or_none(self):
             return self.value
+
+        def scalars(self):
+            value = self.value if isinstance(self.value, list) else [self.value]
+            return SimpleNamespace(all=lambda: value)
 
         def scalar(self):
             return self.value
@@ -183,6 +189,93 @@ async def test_live_recovery_authority_requires_matching_current_records() -> No
         authority["current_credential_generation"]
         == checkpoint.credential_generation
     )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "lease_rows",
+    [
+        [],
+        [
+            SimpleNamespace(
+                lease_id="provider-lease",
+                owner_id="owner-1",
+                idempotency_key="wrong-boundary",
+                expires_at=datetime.now(UTC) + timedelta(minutes=5),
+            )
+        ],
+        [
+            SimpleNamespace(
+                lease_id="provider-lease",
+                owner_id="owner-1",
+                idempotency_key="checkpoint-key",
+                expires_at=datetime.now(UTC) + timedelta(minutes=5),
+            ),
+            SimpleNamespace(
+                lease_id="provider-lease",
+                owner_id="owner-2",
+                idempotency_key="checkpoint-key",
+                expires_at=datetime.now(UTC) + timedelta(minutes=5),
+            ),
+        ],
+    ],
+)
+async def test_live_recovery_authority_fails_closed_for_ambiguous_or_mismatched_lease(
+    lease_rows,
+) -> None:
+    from tests.unit.omnigent.test_oauth_profile_lifecycle import _checkpoint
+
+    checkpoint = _checkpoint().model_copy(
+        update={
+            "idempotency_key": "checkpoint-key",
+            "provider_lease_ref": "provider-lease",
+            "host_lease_ref": "host-lease",
+            "omnigent_host_id": "host-1",
+            "omnigent_session_id": "session-1",
+            "last_bridge_event_cursor": "4",
+            "first_message_id": "message-1",
+            "first_message_digest": "sha256:" + "a" * 64,
+        }
+    )
+
+    class Result:
+        def __init__(self, value):
+            self.value = value
+
+        def scalars(self):
+            return SimpleNamespace(all=lambda: self.value)
+
+        def scalar(self):
+            return self.value
+
+    class Session:
+        calls = 0
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return None
+
+        async def get(self, *_args):
+            return SimpleNamespace(
+                credential_generation=checkpoint.credential_generation
+            )
+
+        async def execute(self, _query):
+            self.calls += 1
+            return Result(lease_rows if self.calls == 1 else 7)
+
+    authority = await _resolve_live_recovery_authority(
+        checkpoint=checkpoint,
+        session_factory=Session,
+        host_repository=SimpleNamespace(get_host_lease=lambda _ref: _async_value(None)),
+        run_store=SimpleNamespace(get_bridge_session=lambda _ref: _async_value(None)),
+    )
+
+    assert authority["provider_lease"] is None or not authority["provider_lease"][
+        "active"
+    ]
 
 
 async def _async_value(value):

--- a/tests/unit/workflows/temporal/test_omnigent_activities.py
+++ b/tests/unit/workflows/temporal/test_omnigent_activities.py
@@ -92,20 +92,63 @@ def test_checkpoint_recovery_decision_selects_live_or_cold_with_bounded_rational
         {
             "immutableSource": immutable,
             "immutableRequested": immutable,
-            "liveReattachAvailable": True,
-            "coldRestoreAvailable": True,
-        }
+            "liveReattachAvailable": False,
+            "coldRestoreAvailable": False,
+        },
+        live_authority={
+            "provider_lease": {"active": True},
+            "host_registered": True,
+            "session_valid": True,
+            "first_message_consistent": True,
+            "current_credential_generation": 4,
+            "checkpoint_credential_generation": 4,
+        },
+        cold_restore_authorized=True,
     ) == {"recoveryAction": "live_reattach", "reasonCodes": ["all_authority_valid"]}
     assert _checkpoint_recovery_decision(
         {
             "immutableSource": immutable,
             "immutableRequested": immutable,
-            "liveReattachAvailable": False,
-            "coldRestoreAvailable": True,
-        }
+            "liveReattachAvailable": True,
+            "coldRestoreAvailable": False,
+        },
+        live_authority={
+            "provider_lease": None,
+            "host_registered": False,
+            "session_valid": False,
+            "first_message_consistent": False,
+            "current_credential_generation": 4,
+            "checkpoint_credential_generation": 4,
+        },
+        cold_restore_authorized=True,
     ) == {
         "recoveryAction": "cold_restore",
         "reasonCodes": ["live_authority_unavailable"],
+    }
+
+
+def test_checkpoint_recovery_decision_ignores_caller_availability_assertions() -> None:
+    immutable = {
+        "instructionDigest": "sha256:instructions",
+        "runtimeId": "omnigent",
+        "model": "default",
+        "effort": "medium",
+        "providerProfileId": "profile-1",
+        "launchPolicyRef": "artifact://policy/1",
+        "repositoryBranch": "main",
+        "publishMode": "none",
+    }
+
+    assert _checkpoint_recovery_decision(
+        {
+            "immutableSource": immutable,
+            "immutableRequested": immutable,
+            "liveReattachAvailable": True,
+            "coldRestoreAvailable": True,
+        }
+    ) == {
+        "recoveryAction": "resume_unavailable",
+        "reasonCodes": ["checkpoint_authority_unavailable"],
     }
 
 

--- a/tests/unit/workflows/temporal/test_omnigent_activities.py
+++ b/tests/unit/workflows/temporal/test_omnigent_activities.py
@@ -14,6 +14,7 @@ from moonmind.workflows.temporal.activities import (
     omnigent_activities as omnigent_activities_module,
 )
 from moonmind.workflows.temporal.activities.omnigent_activities import (
+    _checkpoint_branch_from_request,
     _checkpoint_recovery_from_request,
     _resolve_live_recovery_authority,
     omnigent_execute_activity,
@@ -94,6 +95,58 @@ def test_checkpoint_recovery_request_builds_validated_candidate_workspace() -> N
     )
     assert candidate.head_ref == checkpoint.head_ref
     assert candidate.checkpoint_ref == checkpoint.workspace_checkpoint_ref
+
+
+def test_checkpoint_branch_request_requires_explicit_action_and_new_boundary() -> None:
+    from tests.unit.omnigent.test_oauth_profile_lifecycle import _checkpoint
+
+    checkpoint = _checkpoint()
+    request = AgentExecutionRequest(
+        agentKind="external",
+        agentId="omnigent",
+        executionProfileRef=checkpoint.provider_profile_id,
+        correlationId="branch-workflow",
+        idempotencyKey="branch-turn-1",
+        parameters={
+            "checkpointRecovery": {
+                "recoveryAction": "branch_required",
+                "omnigentCheckpoint": checkpoint.model_dump(
+                    by_alias=True, mode="json", exclude_none=True
+                ),
+            }
+        },
+    )
+
+    parsed = _checkpoint_branch_from_request(request)
+
+    assert parsed is not None
+    parsed_checkpoint, candidate = parsed
+    assert parsed_checkpoint == checkpoint
+    assert candidate.checkpoint_ref == checkpoint.workspace_checkpoint_ref
+
+
+def test_checkpoint_branch_request_rejects_source_idempotency_boundary() -> None:
+    from tests.unit.omnigent.test_oauth_profile_lifecycle import _checkpoint
+
+    checkpoint = _checkpoint()
+    request = AgentExecutionRequest(
+        agentKind="external",
+        agentId="omnigent",
+        executionProfileRef=checkpoint.provider_profile_id,
+        correlationId="branch-workflow",
+        idempotencyKey=checkpoint.idempotency_key,
+        parameters={
+            "checkpointRecovery": {
+                "recoveryAction": "branch_required",
+                "omnigentCheckpoint": checkpoint.model_dump(
+                    by_alias=True, mode="json", exclude_none=True
+                ),
+            }
+        },
+    )
+
+    with pytest.raises(ValueError, match="new idempotency key"):
+        _checkpoint_branch_from_request(request)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/workflows/temporal/test_omnigent_activities.py
+++ b/tests/unit/workflows/temporal/test_omnigent_activities.py
@@ -1,4 +1,6 @@
 import inspect
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -13,6 +15,7 @@ from moonmind.workflows.temporal.activities import (
 )
 from moonmind.workflows.temporal.activities.omnigent_activities import (
     _checkpoint_recovery_from_request,
+    _resolve_live_recovery_authority,
     omnigent_execute_activity,
 )
 
@@ -91,3 +94,96 @@ def test_checkpoint_recovery_request_builds_validated_candidate_workspace() -> N
     )
     assert candidate.head_ref == checkpoint.head_ref
     assert candidate.checkpoint_ref == checkpoint.workspace_checkpoint_ref
+
+
+@pytest.mark.asyncio
+async def test_live_recovery_authority_requires_matching_current_records() -> None:
+    from tests.unit.omnigent.test_oauth_profile_lifecycle import _checkpoint
+
+    checkpoint = _checkpoint().model_copy(
+        update={
+            "provider_lease_ref": "provider-lease",
+            "host_lease_ref": "host-lease",
+            "omnigent_host_id": "host-1",
+            "omnigent_session_id": "session-1",
+            "last_bridge_event_cursor": "4",
+            "first_message_id": "message-1",
+            "first_message_digest": "sha256:" + "a" * 64,
+        }
+    )
+    provider = SimpleNamespace(credential_generation=checkpoint.credential_generation)
+    provider_lease = SimpleNamespace(
+        lease_id="provider-lease",
+        expires_at=datetime.now(UTC) + timedelta(minutes=5),
+    )
+
+    class Result:
+        def __init__(self, value):
+            self.value = value
+
+        def scalar_one_or_none(self):
+            return self.value
+
+        def scalar(self):
+            return self.value
+
+    class Session:
+        calls = 0
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return None
+
+        async def get(self, *_args):
+            return provider
+
+        async def execute(self, _query):
+            self.calls += 1
+            return Result(provider_lease if self.calls == 1 else 7)
+
+    host = SimpleNamespace(
+        omnigent_host_id="host-1",
+        omnigent_session_id="session-1",
+        bridge_session_id=checkpoint.bridge_session_id,
+        status="assigned",
+        expires_at=datetime.now(UTC) + timedelta(minutes=5),
+        model_dump=lambda **_kwargs: {
+            "leaseId": "host-lease",
+            "status": "assigned",
+            "credentialGeneration": checkpoint.credential_generation,
+        },
+    )
+    bridge = SimpleNamespace(
+        omnigent_host_id="host-1",
+        omnigent_session_id="session-1",
+        status="active",
+        first_message_digest=checkpoint.first_message_digest,
+        first_message_item_id="message-1",
+        first_message_pending_id=None,
+        first_message_state="posted",
+    )
+    authority = await _resolve_live_recovery_authority(
+        checkpoint=checkpoint,
+        session_factory=Session,
+        host_repository=SimpleNamespace(
+            get_host_lease=lambda _lease_id: _async_value(host)
+        ),
+        run_store=SimpleNamespace(
+            get_bridge_session=lambda _bridge_id: _async_value(bridge)
+        ),
+    )
+
+    assert authority["provider_lease"]["active"] is True
+    assert authority["host_registered"] is True
+    assert authority["session_valid"] is True
+    assert authority["first_message_consistent"] is True
+    assert (
+        authority["current_credential_generation"]
+        == checkpoint.credential_generation
+    )
+
+
+async def _async_value(value):
+    return value

--- a/tests/unit/workflows/temporal/test_omnigent_activities.py
+++ b/tests/unit/workflows/temporal/test_omnigent_activities.py
@@ -104,6 +104,7 @@ def test_checkpoint_recovery_decision_selects_live_or_cold_with_bounded_rational
             "checkpoint_credential_generation": 4,
         },
         cold_restore_authorized=True,
+        live_reattach_authorized=True,
     ) == {"recoveryAction": "live_reattach", "reasonCodes": ["all_authority_valid"]}
     assert _checkpoint_recovery_decision(
         {

--- a/tests/unit/workflows/temporal/test_omnigent_activities.py
+++ b/tests/unit/workflows/temporal/test_omnigent_activities.py
@@ -12,6 +12,7 @@ from moonmind.workflows.temporal.activities import (
     omnigent_activities as omnigent_activities_module,
 )
 from moonmind.workflows.temporal.activities.omnigent_activities import (
+    _checkpoint_recovery_from_request,
     omnigent_execute_activity,
 )
 
@@ -59,3 +60,34 @@ def test_omnigent_execution_path_does_not_use_managed_github_broker() -> None:
         "GITHUB_TOKEN",
     ):
         assert disallowed not in source
+
+
+def test_checkpoint_recovery_request_builds_validated_candidate_workspace() -> None:
+    from tests.unit.omnigent.test_oauth_profile_lifecycle import _checkpoint
+
+    checkpoint = _checkpoint()
+    request = AgentExecutionRequest(
+        agentKind="external",
+        agentId="omnigent",
+        executionProfileRef=checkpoint.provider_profile_id,
+        correlationId="recovery-workflow",
+        idempotencyKey="recovery-step",
+        parameters={
+            "checkpointRecovery": {
+                "omnigentCheckpoint": checkpoint.model_dump(
+                    by_alias=True, mode="json", exclude_none=True
+                )
+            }
+        },
+    )
+
+    parsed = _checkpoint_recovery_from_request(request)
+
+    assert parsed is not None
+    parsed_checkpoint, candidate = parsed
+    assert parsed_checkpoint == checkpoint
+    assert candidate.loop_id == (
+        f"{checkpoint.workflow_id}:{checkpoint.logical_step_id}"
+    )
+    assert candidate.head_ref == checkpoint.head_ref
+    assert candidate.checkpoint_ref == checkpoint.workspace_checkpoint_ref

--- a/tests/unit/workflows/temporal/test_omnigent_activities.py
+++ b/tests/unit/workflows/temporal/test_omnigent_activities.py
@@ -208,12 +208,10 @@ def test_checkpoint_recovery_request_builds_validated_candidate_workspace() -> N
         executionProfileRef=checkpoint.provider_profile_id,
         correlationId="recovery-workflow",
         idempotencyKey="recovery-step",
-        parameters={
-            "checkpointRecovery": {
-                "omnigentCheckpoint": checkpoint.model_dump(
-                    by_alias=True, mode="json", exclude_none=True
-                )
-            }
+        checkpointRecovery={
+            "omnigentCheckpoint": checkpoint.model_dump(
+                by_alias=True, mode="json", exclude_none=True
+            )
         },
     )
 
@@ -239,13 +237,11 @@ def test_checkpoint_branch_request_requires_explicit_action_and_new_boundary() -
         executionProfileRef=checkpoint.provider_profile_id,
         correlationId="branch-workflow",
         idempotencyKey="branch-turn-1",
-        parameters={
-            "checkpointRecovery": {
-                "recoveryAction": "branch_required",
-                "omnigentCheckpoint": checkpoint.model_dump(
-                    by_alias=True, mode="json", exclude_none=True
-                ),
-            }
+        checkpointRecovery={
+            "recoveryAction": "branch_required",
+            "omnigentCheckpoint": checkpoint.model_dump(
+                by_alias=True, mode="json", exclude_none=True
+            ),
         },
     )
 
@@ -277,24 +273,22 @@ def test_checkpoint_branch_request_is_derived_from_immutable_input_change() -> N
         executionProfileRef=checkpoint.provider_profile_id,
         correlationId="branch-workflow",
         idempotencyKey="branch-turn-derived",
-        parameters={
-            "checkpointRecovery": {
-                "omnigentCheckpoint": checkpoint.model_dump(
-                    by_alias=True, mode="json", exclude_none=True
-                ),
-                "immutableSource": source,
-                "immutableRequested": {
-                    **source,
-                    "instructionDigest": "sha256:new",
-                },
-                "liveReattachAvailable": True,
-                "coldRestoreAvailable": True,
-            }
+        checkpointRecovery={
+            "omnigentCheckpoint": checkpoint.model_dump(
+                by_alias=True, mode="json", exclude_none=True
+            ),
+            "immutableSource": source,
+            "immutableRequested": {
+                **source,
+                "instructionDigest": "sha256:new",
+            },
+            "liveReattachAvailable": True,
+            "coldRestoreAvailable": True,
         },
     )
 
     assert _checkpoint_branch_from_request(request) is not None
-    assert request.parameters["checkpointRecovery"]["recoveryDecision"] == {
+    assert request.checkpoint_recovery["recoveryDecision"] == {
         "recoveryAction": "branch_required",
         "reasonCodes": ["immutable_instructionDigest_changed"],
     }
@@ -310,13 +304,11 @@ def test_checkpoint_branch_request_rejects_source_idempotency_boundary() -> None
         executionProfileRef=checkpoint.provider_profile_id,
         correlationId="branch-workflow",
         idempotencyKey=checkpoint.idempotency_key,
-        parameters={
-            "checkpointRecovery": {
-                "recoveryAction": "branch_required",
-                "omnigentCheckpoint": checkpoint.model_dump(
-                    by_alias=True, mode="json", exclude_none=True
-                ),
-            }
+        checkpointRecovery={
+            "recoveryAction": "branch_required",
+            "omnigentCheckpoint": checkpoint.model_dump(
+                by_alias=True, mode="json", exclude_none=True
+            ),
         },
     )
 

--- a/tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py
@@ -152,7 +152,7 @@ class TestSlotContinuityMetadata(unittest.TestCase):
             "RUN_CHECKPOINT_RECOVERY_STATE_MACHINE_PATCH"
         )
         injection_index = source.index(
-            'parameters["checkpointRecovery"]', guard_index
+            "checkpoint_recovery = dict(self._recovery_source)", guard_index
         )
 
         self.assertLess(guard_index, injection_index)

--- a/tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py
@@ -26,6 +26,7 @@ from moonmind.schemas.agent_skill_models import (
 )
 from moonmind.workflows.temporal.workflows.run import (
     RUN_ASSESSMENT_PARAMETER_INJECTION_PATCH,
+    RUN_CHECKPOINT_RECOVERY_STATE_MACHINE_PATCH,
     RUN_CHECKPOINT_BRANCH_TURN_CONTEXT_PATCH,
     RUN_EXISTING_SKILLSET_TERMINAL_CONTRACT_PATCH,
     RUN_JSON_ARTIFACT_WRITE_COMPLETE_PATCH,
@@ -136,6 +137,22 @@ class TestSlotContinuityMetadata(unittest.TestCase):
         injection_index = source.index(
             "self._ensure_assessment_parameters(",
             guard_index,
+        )
+
+        self.assertLess(guard_index, injection_index)
+
+    def test_checkpoint_recovery_request_shape_is_replay_patch_guarded(self) -> None:
+        source = inspect.getsource(MoonMindRunWorkflow._build_agent_execution_request)
+        self.assertEqual(
+            RUN_CHECKPOINT_RECOVERY_STATE_MACHINE_PATCH,
+            "run-checkpoint-recovery-state-machine-v1",
+        )
+
+        guard_index = source.index(
+            "RUN_CHECKPOINT_RECOVERY_STATE_MACHINE_PATCH"
+        )
+        injection_index = source.index(
+            'parameters["checkpointRecovery"]', guard_index
         )
 
         self.assertLess(guard_index, injection_index)


### PR DESCRIPTION
Implement GitHub issue MoonLadderStudios/MoonMind#3510.

## MoonSpec verification incomplete

This pull request was opened as a **draft** because MoonSpec verification did not approve publication (verdict ADDITIONAL_WORK_NEEDED) and the bounded remediation budget was exhausted with remaining implementation work.

- Gate outcome: MoonSpec verification did not approve publication. verdict ADDITIONAL_WORK_NEEDED. At remediation head b083f8ed3286dd691cf972f2b4470365c0fc87b5, normal failed-step recovery reaches the existing evidence-gated Omnigent coordinator paths, and the newest commit adds create-branch Provider Profile, execution-profile, model, and effort inputs with API persistence. Issue #3510 remains incomplete because the product branch-turn launch endpoint still requires and records caller-supplied Step Execution and session identities without dispatching real Omnigent execution, durable host decision rationale remains incomplete, and production-boundary lifecycle and Temporal replay evidence is absent. verification report art_01KZ18E3WCCA1B5VEPS7XJWBJW.
- Verification report: art_01KZ18E3WCCA1B5VEPS7XJWBJW
- Verification gate result: art_01KZ18E3TPGTV0728DMNYJJ4PF

Review the verification evidence before marking this pull request ready for review.