### PR TITLE
Preserve MoonSpec remediation evidence

### DIFF
--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -9485,15 +9485,7 @@ class TemporalAgentRuntimeActivities:
                 )
                 validated_refs.setdefault(
                     "authoritativeEvidenceDigest",
-                    "sha256:"
-                    + hashlib.sha256(
-                        json.dumps(
-                            remaining_work,
-                            ensure_ascii=False,
-                            separators=(",", ":"),
-                            sort_keys=True,
-                        ).encode("utf-8")
-                    ).hexdigest(),
+                    _unordered_json_list_digest(remaining_work),
                 )
                 gate_payload["validatedRefs"] = validated_refs
                 gate_payload.pop("validated_refs", None)
@@ -15556,6 +15548,22 @@ def _compact_artifact_ref_text(artifact: Any) -> str:
 
 def _json_bytes(payload: Mapping[str, Any] | list[Any]) -> bytes:
     return json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def _unordered_json_list_digest(values: Sequence[Any]) -> str:
+    """Hash a JSON list as a multiset while preserving each item's semantics."""
+
+    canonical_items = sorted(
+        json.dumps(
+            value,
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+        for value in values
+    )
+    canonical_list = "[" + ",".join(canonical_items) + "]"
+    return "sha256:" + hashlib.sha256(canonical_list.encode("utf-8")).hexdigest()
 
 
 class TemporalCheckpointActivities:

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -9450,6 +9450,53 @@ class TemporalAgentRuntimeActivities:
                 )
                 return {}
             gate_payload = _canonicalize_moonspec_verify_gate_payload(payload)
+            declared_verdict = _first_non_empty_text(
+                gate_payload,
+                "verdict",
+                "gateVerdict",
+                "gate_verdict",
+                "moonSpecVerdict",
+                "moonspecVerdict",
+                "verificationVerdict",
+                "verification_verdict",
+            )
+            additional_work_declared = (
+                recommended_next_action_for_verdict(declared_verdict)
+                == "reattempt_current_step"
+            )
+            remaining_work = gate_payload.get("remainingWork")
+            if additional_work_declared and isinstance(remaining_work, list):
+                # Workflow history carries only a stable semantic digest; the
+                # resolved verifier's full structured gaps remain in its
+                # artifact. This lets the progress gate compare attempts
+                # without duplicating Skill semantics or large payloads.
+                validated_refs_value = gate_payload.get(
+                    "validatedRefs",
+                    gate_payload.get("validated_refs"),
+                )
+                validated_refs = (
+                    dict(validated_refs_value)
+                    if isinstance(validated_refs_value, Mapping)
+                    else {}
+                )
+                validated_refs.setdefault(
+                    "progressEvidenceSchemaVersion",
+                    "remediation-progress-evidence/v1",
+                )
+                validated_refs.setdefault(
+                    "authoritativeEvidenceDigest",
+                    "sha256:"
+                    + hashlib.sha256(
+                        json.dumps(
+                            remaining_work,
+                            ensure_ascii=False,
+                            separators=(",", ":"),
+                            sort_keys=True,
+                        ).encode("utf-8")
+                    ).hexdigest(),
+                )
+                gate_payload["validatedRefs"] = validated_refs
+                gate_payload.pop("validated_refs", None)
             contract_violations = step_gate_contract_violations(gate_payload)
             if contract_violations:
                 # Surface violations at the boundary where the verifier JSON
@@ -9481,6 +9528,16 @@ class TemporalAgentRuntimeActivities:
                 },
             )
             gate_payload["gateResultRef"] = verify_ref.artifact_id
+            if not _first_non_empty_text(
+                gate_payload,
+                "remainingWorkRef",
+                "remaining_work_ref",
+            ) and additional_work_declared:
+                # The resolved verifier bundle owns the remaining-work
+                # semantics. Its published JSON is therefore the durable
+                # evidence when the portable contract emits structured
+                # remainingWork inline but no separate artifact ref.
+                gate_payload["remainingWorkRef"] = verify_ref.artifact_id
             authoritative_ref = verify_ref.artifact_id
             remediation_verify_ref = (
                 await _publish_moonspec_remediation_verification_artifact(

--- a/moonmind/workflows/temporal/remediation_loop.py
+++ b/moonmind/workflows/temporal/remediation_loop.py
@@ -10,12 +10,16 @@ Implementation reference: MoonLadderStudios/MoonMind#3475.
 
 from __future__ import annotations
 
+import re
 from enum import StrEnum
 from typing import Literal, Mapping
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from moonmind.schemas.agent_runtime_models import AUTO_RUNTIME_SENTINEL
+
+
+_SHA256_DIGEST = re.compile(r"^sha256:[0-9a-f]{64}$")
 
 
 class _Contract(BaseModel):
@@ -164,6 +168,11 @@ class RemediationLoopState(_Contract):
     capability_digest: str | None = Field(default=None, alias="capabilityDigest")
     latest_verdict: str | None = Field(default=None, alias="latestVerdict")
     latest_progress_ref: str | None = Field(default=None, alias="latestProgressRef")
+    latest_progress_signature: str | None = Field(
+        default=None,
+        alias="latestProgressSignature",
+        pattern=r"^sha256:[0-9a-f]{64}$",
+    )
     continuation_reason: str | None = Field(
         default=None, alias="continuationReason"
     )
@@ -301,13 +310,24 @@ def record_verification_evidence(
 
 
 def record_semantic_progress(
-    state: RemediationLoopState, *, progress_ref: str | None
+    state: RemediationLoopState,
+    *,
+    progress_ref: str | None,
+    progress_signature: str | None = None,
 ) -> RemediationLoopState:
     """Update bounded no-progress counters from authoritative verifier evidence."""
 
     if not progress_ref:
         return state
-    repeated = progress_ref == state.latest_progress_ref
+    if progress_signature is not None and not _SHA256_DIGEST.fullmatch(
+        progress_signature
+    ):
+        raise ValueError("progressSignature must be a sha256 digest")
+    progress_identity = progress_signature or progress_ref
+    previous_identity = (
+        state.latest_progress_signature or state.latest_progress_ref
+    )
+    repeated = progress_identity == previous_identity
     consumed = state.consumed_budgets.model_copy(
         update={
             "consecutive_semantic_no_progress": (
@@ -325,6 +345,7 @@ def record_semantic_progress(
     return state.model_copy(
         update={
             "latest_progress_ref": progress_ref,
+            "latest_progress_signature": progress_signature,
             "consumed_budgets": consumed,
         }
     )

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -766,6 +766,14 @@ RUN_REMEDIATION_LOOP_CONTINUE_AS_NEW_PATCH = (
 RUN_REMEDIATION_LOOP_ARTIFACT_REF_NORMALIZATION_PATCH = (
     "run-remediation-loop-artifact-ref-normalization-v1"
 )
+# Verifier bundles author the structured remaining-work semantics, while the
+# runtime publishes their JSON as durable evidence. Preserve that artifact as
+# remainingWorkRef when an older verifier payload omits a separate ref, and do
+# not replace it with an empty terminal handoff. Replay-gate the workflow-side
+# fallback because it changes remediation inputs and terminal side effects.
+RUN_MOONSPEC_VERIFY_REMAINING_WORK_EVIDENCE_PATCH = (
+    "run-moonspec-verify-remaining-work-evidence-v1"
+)
 # Promote canonical checkpoint Activity evidence into cumulative remediation
 # authority and carry that compact head through Continue-As-New. Histories that
 # already admitted remediation without this evidence retain their prior command
@@ -1779,6 +1787,19 @@ class MoonMindRunWorkflow:
                 "terminal incomplete finalization requires gate and workspace head refs"
             )
         issues = [dict(issue) for issue in gate.issues]
+        if (
+            not issues
+            and self._patched_or_false_outside_workflow(
+                RUN_MOONSPEC_VERIFY_REMAINING_WORK_EVIDENCE_PATCH
+            )
+        ):
+            # Compact workflow history intentionally omits the verifier's
+            # structured remainingWork array. Reuse its authoritative artifact
+            # instead of publishing an apparently valid but empty handoff.
+            return (
+                self._bounded_story_loop_artifact_ref(gate.remaining_work_ref)
+                or gate_ref
+            )
 
         def items(key: str) -> tuple[str, ...]:
             return tuple(
@@ -4085,8 +4106,12 @@ class MoonMindRunWorkflow:
         state = self._remediation_loop_state
         if spec is None or state is None:
             return False
-        normalize_artifact_refs = workflow.patched(
-            RUN_REMEDIATION_LOOP_ARTIFACT_REF_NORMALIZATION_PATCH
+        verifier_evidence_fallback = workflow.patched(
+            RUN_MOONSPEC_VERIFY_REMAINING_WORK_EVIDENCE_PATCH
+        )
+        normalize_artifact_refs = (
+            workflow.patched(RUN_REMEDIATION_LOOP_ARTIFACT_REF_NORMALIZATION_PATCH)
+            or verifier_evidence_fallback
         )
         if normalize_artifact_refs:
             normalized_gate_result_ref = self._bounded_story_loop_artifact_ref(
@@ -4107,6 +4132,15 @@ class MoonMindRunWorkflow:
                         "remaining-work result"
                     )
                 remaining_work_ref = normalized_remaining_work_ref
+        if (
+            verifier_evidence_fallback
+            and verdict.strip().upper() == "ADDITIONAL_WORK_NEEDED"
+            and not remaining_work_ref
+        ):
+            # Compatibility path for compact verifier payloads produced before
+            # the publication activity stamped remainingWorkRef. The gate
+            # artifact itself contains the resolved Skill's structured gaps.
+            remaining_work_ref = gate_result_ref
         workflow_owned_head_enabled = workflow.patched(
             RUN_WORKFLOW_OWNED_REMEDIATION_HEAD_PATCH
         )
@@ -7406,6 +7440,18 @@ class MoonMindRunWorkflow:
             )
             if declared_verdict:
                 break
+        gate_result_ref = self._moonspec_verify_gate_result_ref(outputs)
+        remaining_work_ref = gate_result.remaining_work_ref
+        if self._patched_or_false_outside_workflow(
+            RUN_MOONSPEC_VERIFY_REMAINING_WORK_EVIDENCE_PATCH
+        ):
+            remaining_work_ref = self._bounded_story_loop_artifact_ref(
+                remaining_work_ref
+            ) or (
+                self._bounded_story_loop_artifact_ref(gate_result_ref)
+                if verdict == "ADDITIONAL_WORK_NEEDED"
+                else None
+            )
         gate_context: dict[str, Any] = {
             "logicalStepId": node_id,
             "verdict": verdict,
@@ -7413,7 +7459,7 @@ class MoonMindRunWorkflow:
             "confidence": gate_result.confidence,
             "validatedRefs": dict(gate_result.validated_refs or {}),
             "invalidatedRefs": list(gate_result.invalidated_refs),
-            "remainingWorkRef": gate_result.remaining_work_ref,
+            "remainingWorkRef": remaining_work_ref,
             "recommendedNextAction": gate_result.recommended_next_action,
             "targetLogicalStepId": gate_result.target_logical_step_id,
             "workspacePolicyRecommendation": (
@@ -7427,7 +7473,6 @@ class MoonMindRunWorkflow:
         }
         if gate_result.downgrade_reason:
             gate_context["downgradeReason"] = gate_result.downgrade_reason
-        gate_result_ref = self._moonspec_verify_gate_result_ref(outputs)
         if gate_result_ref:
             gate_context["gateResultRef"] = gate_result_ref
         if reason:

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -774,6 +774,13 @@ RUN_REMEDIATION_LOOP_ARTIFACT_REF_NORMALIZATION_PATCH = (
 RUN_MOONSPEC_VERIFY_REMAINING_WORK_EVIDENCE_PATCH = (
     "run-moonspec-verify-remaining-work-evidence-v1"
 )
+# A verifier artifact receives a new opaque ref on every publication, even
+# when its structured remaining-work payload is unchanged. Compare the stable
+# content digest while retaining the artifact ref as durable handoff evidence.
+# Gate the state and Continue-As-New payload change for replay safety.
+RUN_REMEDIATION_STABLE_PROGRESS_IDENTITY_PATCH = (
+    "run-remediation-stable-progress-identity-v1"
+)
 # Promote canonical checkpoint Activity evidence into cumulative remediation
 # authority and carry that compact head through Continue-As-New. Histories that
 # already admitted remediation without this evidence retain their prior command
@@ -3995,9 +4002,12 @@ class MoonMindRunWorkflow:
         if state is None:
             raise ValueError("remediation loop is not initialized")
         payload = dict(self._original_input_payload)
+        state_payload = state.model_dump(by_alias=True, mode="json")
+        if not workflow.patched(RUN_REMEDIATION_STABLE_PROGRESS_IDENTITY_PATCH):
+            state_payload.pop("latestProgressSignature", None)
         continuation: dict[str, Any] = {
             "schemaVersion": 1,
-            "state": state.model_dump(by_alias=True, mode="json"),
+            "state": state_payload,
             "orderedNodes": [dict(node) for node in ordered_nodes],
             "stepLedgerRows": [dict(row) for row in self._step_ledger_rows],
         }
@@ -4090,6 +4100,7 @@ class MoonMindRunWorkflow:
         verdict: str,
         gate_result_ref: str | None,
         remaining_work_ref: str | None,
+        progress_signature: str | None = None,
         current_index: int | None = None,
         logical_step_id: str | None = None,
         recoverable_evidence: bool = False,
@@ -4187,6 +4198,13 @@ class MoonMindRunWorkflow:
         state = record_semantic_progress(
             state,
             progress_ref=remaining_work_ref,
+            progress_signature=(
+                progress_signature
+                if workflow.patched(
+                    RUN_REMEDIATION_STABLE_PROGRESS_IDENTITY_PATCH
+                )
+                else None
+            ),
         )
         decision = decide_remediation_continuation(
             spec=spec,
@@ -12384,6 +12402,12 @@ class MoonMindRunWorkflow:
                                 gate_result_ref=step_gate_result_ref,
                                 remaining_work_ref=(
                                     step_gate_result.remaining_work_ref
+                                ),
+                                progress_signature=self._coerce_text(
+                                    (
+                                        step_gate_result.validated_refs or {}
+                                    ).get("authoritativeEvidenceDigest"),
+                                    max_chars=200,
                                 ),
                                 current_index=index,
                                 logical_step_id=node_id,

--- a/tests/unit/workflows/temporal/test_activity_runtime.py
+++ b/tests/unit/workflows/temporal/test_activity_runtime.py
@@ -5726,6 +5726,14 @@ async def test_agent_runtime_publish_artifacts_links_remediation_verification_at
             assert result.metadata["gateResultRef"] == verification_ref
             assert result.metadata["moonSpecVerifyArtifactRef"] == verification_ref
             assert result.metadata["sourceMoonSpecVerifyArtifactRef"] != verification_ref
+            assert result.metadata["moonSpecVerify"]["remainingWorkRef"] == (
+                result.metadata["sourceMoonSpecVerifyArtifactRef"]
+            )
+            evidence = result.metadata["moonSpecVerify"]["validatedRefs"]
+            assert evidence["progressEvidenceSchemaVersion"] == (
+                "remediation-progress-evidence/v1"
+            )
+            assert evidence["authoritativeEvidenceDigest"].startswith("sha256:")
             artifact, artifact_path = await service.read_path(
                 artifact_id=verification_ref,
                 principal="system:agent_runtime",
@@ -5744,6 +5752,9 @@ async def test_agent_runtime_publish_artifacts_links_remediation_verification_at
             ] == result.metadata["sourceMoonSpecVerifyArtifactRef"]
             assert persisted_payload["remainingGaps"][0]["requirement"] == (
                 "artifact linkage"
+            )
+            assert persisted_payload["moonSpecVerify"]["remainingWorkRef"] == (
+                result.metadata["sourceMoonSpecVerifyArtifactRef"]
             )
 
 

--- a/tests/unit/workflows/temporal/test_activity_runtime.py
+++ b/tests/unit/workflows/temporal/test_activity_runtime.py
@@ -5629,6 +5629,26 @@ async def test_agent_runtime_publish_artifacts_publishes_remediation_attempt_jso
             assert persisted_payload["nextVerificationRequired"] is True
 
 
+async def test_remaining_work_digest_is_independent_of_entry_order() -> None:
+    first = {
+        "requirement": "artifact linkage",
+        "gapType": "implementation",
+    }
+    second = {
+        "requirement": "workflow routing",
+        "gapType": "behavior",
+    }
+
+    assert activity_runtime_module._unordered_json_list_digest(
+        [first, second]
+    ) == activity_runtime_module._unordered_json_list_digest([second, first])
+    assert activity_runtime_module._unordered_json_list_digest(
+        [first, second]
+    ) != activity_runtime_module._unordered_json_list_digest(
+        [first, {**second, "gapType": "contract"}]
+    )
+
+
 async def test_agent_runtime_publish_artifacts_links_remediation_verification_attempt(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit/workflows/temporal/test_remediation_loop.py
+++ b/tests/unit/workflows/temporal/test_remediation_loop.py
@@ -147,15 +147,36 @@ def test_environment_contamination_is_a_terminal_block() -> None:
 
 
 def test_repeated_progress_evidence_updates_no_progress_budgets() -> None:
+    signature = "sha256:" + ("a" * 64)
     first = record_semantic_progress(
-        _state(), progress_ref="artifact://remaining/R1"
+        _state(),
+        progress_ref="artifact://remaining/R1",
+        progress_signature=signature,
     )
-    repeated = record_semantic_progress(
-        first, progress_ref="artifact://remaining/R1"
+    repeated_once = record_semantic_progress(
+        first,
+        progress_ref="artifact://remaining/R2",
+        progress_signature=signature,
+    )
+    repeated_twice = record_semantic_progress(
+        repeated_once,
+        progress_ref="artifact://remaining/R3",
+        progress_signature=signature,
+    )
+    decision = decide_remediation_continuation(
+        spec=_spec(),
+        state=repeated_twice,
+        verdict="ADDITIONAL_WORK_NEEDED",
+        gate_result_ref="artifact://gate/latest",
+        remaining_work_ref=repeated_twice.latest_progress_ref,
     )
 
-    assert repeated.consumed_budgets.consecutive_semantic_no_progress == 1
-    assert repeated.consumed_budgets.repeated_failure_signature == 1
+    assert repeated_twice.consumed_budgets.consecutive_semantic_no_progress == 2
+    assert repeated_twice.consumed_budgets.repeated_failure_signature == 2
+    assert repeated_twice.latest_progress_ref == "artifact://remaining/R3"
+    assert repeated_twice.latest_progress_signature == signature
+    assert decision.continue_loop is False
+    assert decision.reason == "remediation_budget_or_progress_exhausted"
 
 
 def test_semantic_step_execution_id_is_attempt_scoped() -> None:

--- a/tests/unit/workflows/temporal/workflows/test_run_bounded_story_loop.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_bounded_story_loop.py
@@ -95,6 +95,35 @@ async def test_terminal_remaining_work_persistence_failure_fails_closed(
         )
 
 
+@pytest.mark.asyncio
+async def test_terminal_remaining_work_reuses_authoritative_verifier_artifact(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workflow = MoonMindRunWorkflow()
+
+    async def unexpected_write(**_kwargs: Any) -> str:
+        raise AssertionError("authoritative verifier evidence must be reused")
+
+    monkeypatch.setattr(workflow, "_write_json_artifact", unexpected_write)
+    monkeypatch.setattr(
+        workflow,
+        "_patched_or_false_outside_workflow",
+        lambda _patch_id: True,
+    )
+
+    ref = await workflow._materialize_remaining_work_artifact(
+        gate=StepGateResult(
+            verdict="ADDITIONAL_WORK_NEEDED",
+            confidence="high",
+            remaining_work_ref="artifact://verification/final",
+        ),
+        gate_result_ref="artifact://gate/final",
+        workspace_head_ref="artifact://workspace/final",
+    )
+
+    assert ref == "artifact://verification/final"
+
+
 def test_terminal_handoff_side_effects_have_replay_patch_boundary() -> None:
     instructions = tuple(dis.get_instructions(MoonMindRunWorkflow._run_execution_stage))
 
@@ -1349,3 +1378,28 @@ def test_moonspec_gate_context_records_invalidated_refs_as_typed_data() -> None:
     assert context["remainingWorkRef"] == "artifact://remaining-work/attempt-1"
     assert context["recommendedNextAction"] == "reattempt_current_step"
     assert context["targetLogicalStepId"] == "remediate-1"
+
+
+def test_moonspec_gate_context_uses_gate_artifact_for_legacy_remaining_work(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workflow = MoonMindRunWorkflow()
+    monkeypatch.setattr(
+        workflow,
+        "_patched_or_false_outside_workflow",
+        lambda _patch_id: True,
+    )
+
+    workflow._record_moonspec_verify_gate(
+        node_id="verify-legacy",
+        outputs={
+            "moonSpecVerify": {
+                "verdict": "ADDITIONAL_WORK_NEEDED",
+                "confidence": "medium",
+                "gateResultRef": "art_verify_legacy",
+            }
+        },
+    )
+
+    context = workflow._publish_context["moonSpecGate"]
+    assert context["remainingWorkRef"] == "artifact://art_verify_legacy"

--- a/tests/unit/workflows/temporal/workflows/test_run_integration.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_integration.py
@@ -30,6 +30,7 @@ from moonmind.workflows.temporal.workflows.run import (
     RUN_REMEDIATION_LOOP_CONTINUE_AS_NEW_PATCH,
     RUN_REMEDIATION_MANAGED_SESSION_SOURCE_IDENTITY_PATCH,
     RUN_REMEDIATION_CONTINUE_MANAGED_SESSION_PATCH,
+    RUN_REMEDIATION_STABLE_PROGRESS_IDENTITY_PATCH,
     RUN_RUNTIME_EXECUTION_CAPABILITIES_PATCH,
     RUN_STEP_RETRY_OVERRIDES_PATCH,
     RUN_ALREADY_IMPLEMENTED_JIRA_COMPLETION_PATCH,
@@ -3589,6 +3590,7 @@ def test_loop_attempt_materialization_requires_a_resolved_controller_runtime(
 @pytest.mark.asyncio
 async def test_dynamic_verifier_persists_decision_and_appends_only_admitted_pair(
     mock_run_workflow: MoonMindRunWorkflow,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     loop = {
         "kind": "remediation_loop",
@@ -3614,7 +3616,15 @@ async def test_dynamic_verifier_persists_decision_and_appends_only_admitted_pair
     mock_run_workflow._write_json_artifact = AsyncMock(
         return_value="artifact://decision/D0"
     )
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "patched",
+        lambda patch_id: (
+            patch_id == RUN_REMEDIATION_STABLE_PROGRESS_IDENTITY_PATCH
+        ),
+    )
     ordered_nodes: list[dict[str, Any]] = []
+    progress_signature = "sha256:" + ("a" * 64)
 
     admitted = await (
         mock_run_workflow._evaluate_dynamic_remediation_verification(
@@ -3622,6 +3632,7 @@ async def test_dynamic_verifier_persists_decision_and_appends_only_admitted_pair
             verdict="ADDITIONAL_WORK_NEEDED",
             gate_result_ref="artifact://verification/V0",
             remaining_work_ref="artifact://remaining/R0",
+            progress_signature=progress_signature,
         )
     )
 
@@ -3639,6 +3650,9 @@ async def test_dynamic_verifier_persists_decision_and_appends_only_admitted_pair
     assert projection["status"] == "remediation_running"
     assert projection["latestVerdict"] == "ADDITIONAL_WORK_NEEDED"
     assert projection["continuationDecisionRef"] == "artifact://decision/D0"
+    assert mock_run_workflow._remediation_loop_state.latest_progress_signature == (
+        progress_signature
+    )
     mock_run_workflow._write_json_artifact.assert_awaited_once()
 
 
@@ -4653,6 +4667,55 @@ def test_continue_as_new_preserves_the_workflow_scoped_managed_session(
     mock_run_workflow._restore_remediation_loop_continuation(ordered_nodes=[])
 
     assert mock_run_workflow._codex_session_binding == binding
+
+
+def test_continue_as_new_preserves_stable_progress_identity_only_after_patch(
+    mock_run_workflow: MoonMindRunWorkflow,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from moonmind.workflows.temporal.remediation_loop import (
+        ConsumedRemediationBudgets,
+        RemediationLoopPhase,
+        RemediationLoopSpec,
+        RemediationLoopState,
+    )
+
+    spec = RemediationLoopSpec.model_validate(_dynamic_loop_spec_payload())
+    signature = "sha256:" + ("b" * 64)
+    mock_run_workflow._remediation_loop_spec = spec
+    mock_run_workflow._remediation_loop_state = RemediationLoopState(
+        loopId=spec.loop_id,
+        attemptOrdinal=1,
+        phase=RemediationLoopPhase.VERIFICATION_PENDING,
+        latestProgressRef="artifact://remaining/R1",
+        latestProgressSignature=signature,
+        consumedBudgets=ConsumedRemediationBudgets(attempts=1),
+    )
+    mock_run_workflow._original_input_payload = {}
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "patched",
+        lambda patch_id: (
+            patch_id == RUN_REMEDIATION_STABLE_PROGRESS_IDENTITY_PATCH
+        ),
+    )
+
+    carried = mock_run_workflow._build_remediation_loop_continue_as_new_input(
+        ordered_nodes=[]
+    )["remediation_loop_continuation"]
+
+    assert carried["state"]["latestProgressSignature"] == signature
+
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "patched",
+        lambda _patch_id: False,
+    )
+    legacy = mock_run_workflow._build_remediation_loop_continue_as_new_input(
+        ordered_nodes=[]
+    )["remediation_loop_continuation"]
+
+    assert "latestProgressSignature" not in legacy["state"]
 
 
 def test_continuation_written_without_a_head_still_restores(

--- a/tests/unit/workflows/temporal/workflows/test_run_integration.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_integration.py
@@ -22,6 +22,7 @@ from moonmind.workflows.temporal.workflows.run import (
     RUN_HEADLESS_REMEDIATION_EXECUTION_PATCH,
     RUN_MANAGED_SESSION_CHECKPOINT_LOCATOR_PATCH,
     RUN_MOONSPEC_GATE_PREVIOUS_OUTPUTS_HANDOFF_PATCH,
+    RUN_MOONSPEC_VERIFY_REMAINING_WORK_EVIDENCE_PATCH,
     RUN_PAUSE_SAFE_BOUNDARIES_PATCH,
     RUN_PUBLISH_REPAIR_FEEDBACK_PATCH,
     RUN_PR_RESOLVER_PUBLISH_EVIDENCE_REF_PATCH,
@@ -3781,6 +3782,46 @@ async def test_dynamic_verifier_normalizes_runtime_artifact_ids(
     assert state.latest_verification_ref == "artifact://art_verification_V0"
     assert state.latest_progress_ref == "artifact://art_remaining_R0"
     assert state.continuation_decision_ref == "artifact://art_decision_D0"
+
+
+@pytest.mark.asyncio
+async def test_dynamic_verifier_uses_gate_artifact_for_legacy_remaining_work(
+    mock_run_workflow: MoonMindRunWorkflow,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    mock_run_workflow._initialize_remediation_loop_controller(
+        ordered_nodes=[_loop_controller_node(_dynamic_loop_spec_payload())]
+    )
+    mock_run_workflow._step_ledger_rows = []
+    mock_run_workflow._write_json_artifact = AsyncMock(
+        return_value="art_decision_legacy"
+    )
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "patched",
+        lambda patch_id: (
+            patch_id == RUN_MOONSPEC_VERIFY_REMAINING_WORK_EVIDENCE_PATCH
+        ),
+    )
+    ordered_nodes: list[dict[str, Any]] = []
+
+    admitted = await mock_run_workflow._evaluate_dynamic_remediation_verification(
+        ordered_nodes=ordered_nodes,
+        verdict="ADDITIONAL_WORK_NEEDED",
+        gate_result_ref="art_verification_legacy",
+        remaining_work_ref=None,
+    )
+
+    assert admitted is True
+    state = mock_run_workflow._remediation_loop_state
+    assert state is not None
+    assert state.latest_progress_ref == "artifact://art_verification_legacy"
+    decision_payload = mock_run_workflow._write_json_artifact.await_args.kwargs[
+        "payload"
+    ]
+    assert decision_payload["remainingWorkRef"] == (
+        "artifact://art_verification_legacy"
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- preserve a durable verifier artifact reference when MoonSpec reports additional work
- carry a stable remaining-work digest through compact workflow history for semantic progress checks
- reuse authoritative verifier evidence for replay-compatible remediation and terminal handoff instead of synthesizing an empty artifact
- add activity, workflow-boundary, replay-compatibility, and terminal-handoff regressions

## Root cause

MoonSpec verifier output contained structured `remainingWork`, but the publication boundary did not provide `remainingWorkRef`. Remediation attempts therefore lacked an authorized durable evidence reference, and terminal finalization generated an empty remaining-work artifact after compact history omitted the inline gap list.

## Impact

Future remediation attempts consume the exact verifier artifact without relying on retrieval configuration. Changed gap evidence counts as progress, unchanged evidence remains bounded by the no-progress gate, and older compact payloads receive a replay-gated fallback.

## Validation

- `./tools/test_unit.sh --python-only tests/unit/workflows/temporal/test_activity_runtime.py tests/unit/workflows/temporal/workflows/test_run_bounded_story_loop.py tests/unit/workflows/temporal/workflows/test_run_integration.py` — 387 passed
- focused post-adjustment regressions — 4 passed, 1 passed, and 2 passed
- `git diff --check`
- workflow and agent-runtime workers restarted healthy against the bind-mounted fix