### PR TITLE
Fix provider-aware repository submissions

### DIFF
--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -249,6 +249,8 @@ from moonmind.workflows.executions.execution_contract import (
 from moonmind.workflows.executions.repository_contract import (
     RepositoryContractError,
     compile_repository_target,
+    repository_branch_from_value,
+    repository_name_from_value,
 )
 from api_service.api.schemas import CreateJobRequest
 from moonmind.workflows import get_temporal_artifact_service
@@ -266,6 +268,9 @@ _SUPPORTED_TASK_RUNTIMES = frozenset({
     "codex",
     "claude",
 })
+_GITHUB_ONLY_REPOSITORY_SKILLS = frozenset(
+    {"batch-pr-resolver", "pr-resolver"}
+)
 _TEMPORAL_SCOPE_QUERIES = {
     "default": 'WorkflowType="MoonMind.UserWorkflow" AND mm_entry="user_workflow"',
 }
@@ -824,9 +829,11 @@ def _checkpoint_branch_git_context(record: Any) -> dict[str, Any]:
         git_payload = params.get("git")
     if not isinstance(git_payload, Mapping):
         git_payload = {}
+    repository_target = params.get("repository")
 
     repository = (
-        _coerce_temporal_scalar(git_payload.get("repository"))
+        repository_name_from_value(repository_target)
+        or _coerce_temporal_scalar(git_payload.get("repository"))
         or _coerce_temporal_scalar(task_payload.get("repository"))
         or _coerce_temporal_scalar(workflow_payload.get("repository"))
         or _coerce_temporal_scalar(params.get("repository"))
@@ -837,7 +844,8 @@ def _checkpoint_branch_git_context(record: Any) -> dict[str, Any]:
         or _coerce_temporal_scalar(memo.get("repository"))
     )
     base_branch = (
-        _coerce_temporal_scalar(git_payload.get("baseBranch"))
+        repository_branch_from_value(repository_target)
+        or _coerce_temporal_scalar(git_payload.get("baseBranch"))
         or _coerce_temporal_scalar(git_payload.get("startingBranch"))
         or _coerce_temporal_scalar(git_payload.get("branch"))
         or _coerce_temporal_scalar(task_payload.get("startingBranch"))
@@ -8446,9 +8454,15 @@ async def _expand_goal_preset_for_workflow_submission(
     )
     template_inputs = {**schedule.inputs, **existing_inputs}
     context: dict[str, Any] = {}
-    repository = _submitted_repository_name(
-        request_payload.get("repository") or task_payload.get("repository")
-    )
+    nested_repository = task_payload.get("repository")
+    if isinstance(nested_repository, Mapping):
+        raise _invalid_workflow_request(
+            "payload.workflow.repository must not contain a repository target; "
+            "use payload.repository."
+        )
+    repository = repository_name_from_value(request_payload.get("repository"))
+    if not repository:
+        repository = repository_name_from_value(nested_repository)
     if repository:
         context["repository"] = repository
         context["repo"] = repository
@@ -10057,15 +10071,65 @@ def _normalize_submitted_repository(
     )
 
 
-def _submitted_repository_name(value: object) -> str:
-    if isinstance(value, str):
-        return value.strip()
-    if not isinstance(value, Mapping):
-        return ""
-    identity = value.get("repository")
-    if not isinstance(identity, Mapping):
-        return ""
-    return str(identity.get("name") or "").strip()
+def _selected_repository_skill_names(
+    task_payload: Mapping[str, Any],
+) -> set[str]:
+    names: set[str] = set()
+    candidates: list[object] = [task_payload.get("tool"), task_payload.get("skill")]
+    steps = task_payload.get("steps")
+    if isinstance(steps, list):
+        for step in steps:
+            if isinstance(step, Mapping):
+                candidates.extend((step.get("tool"), step.get("skill")))
+    for candidate in candidates:
+        if not isinstance(candidate, Mapping):
+            continue
+        name = str(candidate.get("name") or candidate.get("id") or "").strip()
+        if name:
+            names.add(name)
+    return names
+
+
+def _validate_repository_submission_compatibility(
+    *,
+    repository_payload: str | Mapping[str, Any] | None,
+    task_payload: Mapping[str, Any],
+    publish_payload: Mapping[str, Any] | None = None,
+) -> None:
+    nested_repository = task_payload.get("repository")
+    if isinstance(nested_repository, Mapping):
+        raise _invalid_workflow_request(
+            "payload.workflow.repository must not contain a repository target; "
+            "use payload.repository."
+        )
+    if not isinstance(repository_payload, Mapping):
+        return
+    if "git" in task_payload:
+        raise _invalid_workflow_request(
+            "payload.workflow.git is not accepted with a provider-discriminated "
+            "payload.repository target."
+        )
+
+    provider = str(repository_payload.get("provider") or "").strip().lower()
+    if provider == "lore":
+        incompatible = sorted(
+            _selected_repository_skill_names(task_payload)
+            & _GITHUB_ONLY_REPOSITORY_SKILLS
+        )
+        if incompatible:
+            raise _invalid_workflow_request(
+                "Lore repository targets do not support GitHub-only Skills: "
+                + ", ".join(incompatible)
+                + "."
+            )
+
+    if repository_payload.get("revision") is not None and publish_payload is not None:
+        publish_mode = str(publish_payload.get("mode") or "").strip().lower()
+        if publish_mode != "none":
+            raise _invalid_workflow_request(
+                "payload.repository.revision is allowed only when "
+                "payload.workflow.publish.mode='none'."
+            )
 
 
 async def _create_execution_from_workflow_request(
@@ -10142,6 +10206,20 @@ async def _create_execution_from_workflow_request(
         payload.pop("repository", None)
     else:
         payload["repository"] = repository_payload
+    early_publish_payload: Mapping[str, Any] | None = None
+    if isinstance(repository_payload, Mapping) and repository_payload.get(
+        "revision"
+    ) is not None:
+        early_publish_payload = _resolve_workflow_publish_payload(
+            payload=payload,
+            task_payload=task_payload,
+            normalized_tool=_normalize_task_tool(task_payload),
+        )
+    _validate_repository_submission_compatibility(
+        repository_payload=repository_payload,
+        task_payload=task_payload,
+        publish_payload=early_publish_payload,
+    )
 
     # --- Schedule routing ---
     schedule: ScheduleParameters | None = None
@@ -10287,6 +10365,11 @@ async def _create_execution_from_workflow_request(
         normalized_tool=normalized_tool,
         skill_publish_metadata=publish_metadata,
         skill_side_effect_metadata=side_effect_metadata,
+    )
+    _validate_repository_submission_compatibility(
+        repository_payload=repository_payload,
+        task_payload=task_payload,
+        publish_payload=publish_payload,
     )
     normalized_task_skills = _normalize_task_skill_selectors(
         task_payload.get("skills"),

--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -246,6 +246,10 @@ from moonmind.workflows.executions.execution_contract import (
     reject_workflow_capability_identity_versions,
     resolve_publish_mode_for_skill,
 )
+from moonmind.workflows.executions.repository_contract import (
+    RepositoryContractError,
+    compile_repository_target,
+)
 from api_service.api.schemas import CreateJobRequest
 from moonmind.workflows import get_temporal_artifact_service
 
@@ -8442,10 +8446,12 @@ async def _expand_goal_preset_for_workflow_submission(
     )
     template_inputs = {**schedule.inputs, **existing_inputs}
     context: dict[str, Any] = {}
-    repository = request_payload.get("repository") or task_payload.get("repository")
-    if isinstance(repository, str) and repository.strip():
-        context["repository"] = repository.strip()
-        context["repo"] = repository.strip()
+    repository = _submitted_repository_name(
+        request_payload.get("repository") or task_payload.get("repository")
+    )
+    if repository:
+        context["repository"] = repository
+        context["repo"] = repository
     runtime_payload = (
         task_payload.get("runtime") if isinstance(task_payload.get("runtime"), Mapping) else {}
     )
@@ -10027,6 +10033,41 @@ def _workflow_payload_from_parameters(parameters: Mapping[str, Any]) -> dict[str
     return {}
 
 
+def _normalize_submitted_repository(
+    value: object,
+) -> tuple[str | dict[str, Any] | None, str | None]:
+    """Validate repository authoring while retaining its scalar projection."""
+
+    if value is None:
+        return None, None
+    if isinstance(value, str):
+        repository = value.strip()
+        return (repository, repository) if repository else (None, None)
+
+    try:
+        target = compile_repository_target(value)
+    except RepositoryContractError as exc:
+        raise _invalid_workflow_request(
+            f"payload.repository is invalid: {exc}"
+        ) from exc
+
+    return (
+        target.model_dump(by_alias=True, mode="json", exclude_none=True),
+        target.repository.name,
+    )
+
+
+def _submitted_repository_name(value: object) -> str:
+    if isinstance(value, str):
+        return value.strip()
+    if not isinstance(value, Mapping):
+        return ""
+    identity = value.get("repository")
+    if not isinstance(identity, Mapping):
+        return ""
+    return str(identity.get("name") or "").strip()
+
+
 async def _create_execution_from_workflow_request(
     *,
     request: CreateJobRequest,
@@ -10093,6 +10134,14 @@ async def _create_execution_from_workflow_request(
             task_payload=task_payload,
             inherited=inherited,
         )
+
+    repository_payload, repository = _normalize_submitted_repository(
+        payload.get("repository")
+    )
+    if repository_payload is None:
+        payload.pop("repository", None)
+    else:
+        payload["repository"] = repository_payload
 
     # --- Schedule routing ---
     schedule: ScheduleParameters | None = None
@@ -10161,12 +10210,6 @@ async def _create_execution_from_workflow_request(
             if index < len(normalized_steps):
                 normalized_steps[index]["inputAttachments"] = refs
 
-    raw_repository = payload.get("repository")
-    if raw_repository is not None and not isinstance(raw_repository, str):
-        raise _invalid_workflow_request("payload.repository must be a string.")
-    repository = raw_repository.strip() if isinstance(raw_repository, str) else None
-    if repository == "":
-        repository = None
     integration = (
         str(
             payload.get("integration")
@@ -10489,7 +10532,7 @@ async def _create_execution_from_workflow_request(
 
     initial_parameters = {
         "requestType": request.type,
-        "repository": repository,
+        "repository": repository_payload,
         "requiredCapabilities": required_capabilities,
         "priority": request.priority,
         "maxAttempts": request.max_attempts,

--- a/moonmind/memory/run_digest.py
+++ b/moonmind/memory/run_digest.py
@@ -8,6 +8,10 @@ from uuid import NAMESPACE_URL, uuid5
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from moonmind.workflows.executions.repository_contract import (
+    repository_name_from_value,
+)
+
 RUN_DIGEST_SCHEMA_VERSION = "v1"
 RUN_DIGEST_RECORD_KIND = "run_digest"
 RUN_DIGEST_TRUST_CLASS = "derived"
@@ -156,10 +160,10 @@ class TaskHistoryService:
             "default",
         )
         repo = _first_text(
-            git.get("repository"),
-            task.get("repository"),
+            repository_name_from_value(git.get("repository")),
+            repository_name_from_value(task.get("repository")),
             task.get("repo"),
-            params.get("repository"),
+            repository_name_from_value(params.get("repository")),
             params.get("repo"),
             attrs.get("mm_repository"),
             attrs.get("mm_repo"),

--- a/moonmind/services/skill_step_inputs.py
+++ b/moonmind/services/skill_step_inputs.py
@@ -18,6 +18,10 @@ from moonmind.services.skill_resolution import (
     AgentSkillResolver,
     SkillResolutionContext,
 )
+from moonmind.workflows.executions.repository_contract import (
+    repository_branch_from_value,
+    repository_name_from_value,
+)
 
 
 @dataclass(slots=True)
@@ -172,7 +176,7 @@ def _workflow_context_from_parameters(
     workflow_payload: Mapping[str, Any],
 ) -> dict[str, Any]:
     context: dict[str, Any] = {}
-    for key in ("repository", "repo", "branch", "startingBranch"):
+    for key in ("repo", "branch", "startingBranch"):
         value = workflow_payload.get(key, parameters.get(key))
         if value is not None:
             context[key] = value
@@ -181,6 +185,16 @@ def _workflow_context_from_parameters(
         for key in ("branch", "startingBranch"):
             if git_payload.get(key) is not None:
                 context[key] = git_payload[key]
+    repository_value = workflow_payload.get(
+        "repository", parameters.get("repository")
+    )
+    repository = repository_name_from_value(repository_value)
+    if repository:
+        context["repository"] = repository
+        context["repo"] = repository
+    branch = repository_branch_from_value(repository_value)
+    if branch:
+        context["branch"] = branch
     return context
 
 

--- a/moonmind/workflows/executions/repository_contract.py
+++ b/moonmind/workflows/executions/repository_contract.py
@@ -244,6 +244,20 @@ def compile_repository_target(value: object) -> AuthoredRepositoryTarget:
             "repository must be a provider-discriminated object",
         )
     draft = dict(value)
+    repository = draft.get("repository")
+    if isinstance(repository, Mapping):
+        repository = dict(repository)
+        name = repository.get("name")
+        if isinstance(name, str):
+            repository["name"] = name.strip()
+        draft["repository"] = repository
+    branch = draft.get("branch")
+    if isinstance(branch, Mapping):
+        branch = dict(branch)
+        name = branch.get("name")
+        if isinstance(name, str):
+            branch["name"] = name.strip()
+        draft["branch"] = branch
     if draft.get("provider") == "git" and not str(
         draft.get("connectionRef") or ""
     ).strip():
@@ -252,6 +266,32 @@ def compile_repository_target(value: object) -> AuthoredRepositoryTarget:
         return _TARGET_ADAPTER.validate_python(draft)
     except ValueError as exc:
         raise RepositoryContractError("REPOSITORY_TARGET_INVALID", str(exc)) from exc
+
+
+def repository_name_from_value(value: object) -> str:
+    """Project a legacy scalar or authored target to its repository name."""
+
+    if isinstance(value, str):
+        return value.strip()
+    if not isinstance(value, Mapping):
+        return ""
+    repository = value.get("repository")
+    if not isinstance(repository, Mapping):
+        return ""
+    name = repository.get("name")
+    return name.strip() if isinstance(name, str) else ""
+
+
+def repository_branch_from_value(value: object) -> str:
+    """Project an authored target to its branch name."""
+
+    if not isinstance(value, Mapping):
+        return ""
+    branch = value.get("branch")
+    if not isinstance(branch, Mapping):
+        return ""
+    name = branch.get("name")
+    return name.strip() if isinstance(name, str) else ""
 
 
 def decode_legacy_repository_history_v1(
@@ -600,6 +640,8 @@ __all__ = [
     "load_repository_connection",
     "materialize_resolved_repository_target",
     "persist_repository_connection",
+    "repository_branch_from_value",
+    "repository_name_from_value",
     "reconcile_default_git_connection",
     "resolve_default_git_credential",
     "validate_connection_and_client",

--- a/moonmind/workflows/temporal/service.py
+++ b/moonmind/workflows/temporal/service.py
@@ -82,6 +82,9 @@ from moonmind.workflows.temporal.activity_catalog import (
 from moonmind.workflows.executions.runtime_capabilities import (
     resolve_runtime_execution_capabilities,
 )
+from moonmind.workflows.executions.repository_contract import (
+    repository_name_from_value,
+)
 from moonmind.workflows.temporal.hard_switch_cutover import (
     resolve_user_workflow_start_contract,
 )
@@ -3286,7 +3289,7 @@ class TemporalExecutionService:
         next_input_ref = input_artifact_ref or record.input_ref
         next_plan_ref = plan_artifact_ref or record.plan_ref
         task_params = params.get("task") if isinstance(params.get("task"), dict) else {}
-        repository = str(params.get("repository") or "").strip() or None
+        repository = repository_name_from_value(params.get("repository")) or None
         title = (
             str(task_params.get("title") or "").strip()
             or str((record.memo or {}).get("title") or "").strip()
@@ -3594,7 +3597,7 @@ class TemporalExecutionService:
             failure_policy=None,
             initial_parameters=params,
             idempotency_key=target.destination.creation_key,
-            repository=str(params.get("repository") or "").strip() or None,
+            repository=repository_name_from_value(params.get("repository")) or None,
             integration=None,
             summary=(
                 f"Typed {target.target.kind} recovery from {record.workflow_id}."
@@ -4022,7 +4025,7 @@ class TemporalExecutionService:
             or str((record.memo or {}).get("title") or "").strip()
             or None
         )
-        repository = str(params.get("repository") or "").strip() or None
+        repository = repository_name_from_value(params.get("repository")) or None
         created = await self.create_execution(
             workflow_type=record.workflow_type.value,
             owner_id=record.owner_id,

--- a/moonmind/workflows/temporal/worker_runtime.py
+++ b/moonmind/workflows/temporal/worker_runtime.py
@@ -103,6 +103,10 @@ from moonmind.workflows.temporal.workers import (
 from moonmind.workflows.executions.execution_contract import (
     build_authoritative_workflow_input_snapshot,
 )
+from moonmind.workflows.executions.repository_contract import (
+    repository_branch_from_value,
+    repository_name_from_value,
+)
 from moonmind.workflows.executions.preset_expansion import (
     expand_preset_for_child_run,
 )
@@ -644,6 +648,27 @@ def _coerce_non_empty_text(value: Any) -> str:
     return value.strip() if isinstance(value, str) else ""
 
 
+def _skill_input_workflow_context(
+    *,
+    parameter_payload: Mapping[str, Any],
+    git_payload: Mapping[str, Any],
+) -> dict[str, Any]:
+    context = {
+        **parameter_payload,
+        **_coerce_mapping(parameter_payload.get("context")),
+        **git_payload,
+    }
+    repository_value = parameter_payload.get("repository")
+    repository = repository_name_from_value(repository_value)
+    if repository:
+        context["repository"] = repository
+        context["repo"] = repository
+    branch = repository_branch_from_value(repository_value)
+    if branch:
+        context["branch"] = branch
+    return context
+
+
 def _first_non_empty_text(*values: Any) -> str:
     for value in values:
         text = _coerce_non_empty_text(value)
@@ -955,7 +980,7 @@ def _required_capability_blockers(
     if not capabilities:
         return blockers
 
-    repository = str(parameters.get("repository") or "").strip()
+    repository = repository_name_from_value(parameters.get("repository"))
 
     def add(
         capability: str,
@@ -1468,11 +1493,10 @@ def _build_runtime_planner():
                 _validated_skill_payload_inputs(
                     skill_payload=skill_contract_payload,
                     raw_inputs=selected_skill_inputs,
-                    workflow_context={
-                        **parameter_payload,
-                        **_coerce_mapping(parameter_payload.get("context")),
-                        **git_payload,
-                    },
+                    workflow_context=_skill_input_workflow_context(
+                        parameter_payload=parameter_payload,
+                        git_payload=git_payload,
+                    ),
                     path_prefix="steps[0].skill.inputs",
                 )
             )
@@ -1977,11 +2001,10 @@ def _build_runtime_planner():
                         step_entry=step_entry,
                         step_index=idx,
                         raw_inputs=step_tool_inputs,
-                        workflow_context={
-                            **parameter_payload,
-                            **_coerce_mapping(parameter_payload.get("context")),
-                            **git_payload,
-                        },
+                        workflow_context=_skill_input_workflow_context(
+                            parameter_payload=parameter_payload,
+                            git_payload=git_payload,
+                        ),
                     )
                 step_extra_inputs = {
                     k: v

--- a/tests/unit/api/routers/test_checkpoint_branch_apis.py
+++ b/tests/unit/api/routers/test_checkpoint_branch_apis.py
@@ -58,9 +58,13 @@ def _record_like(user: SimpleNamespace) -> SimpleNamespace:
             "repository": "MoonLadderStudios/MoonMind",
         },
         parameters={
+            "repository": {
+                "provider": "git",
+                "connectionRef": "repository-connection:git-default",
+                "repository": {"name": "MoonLadderStudios/MoonMind"},
+                "branch": {"name": "feature/mm-1101-source"},
+            },
             "git": {
-                "repository": "MoonLadderStudios/MoonMind",
-                "startingBranch": "feature/mm-1101-source",
                 "baseCommit": "abc1234",
                 "knownRefs": ["feature/mm-1101-source"],
                 "currentRef": "feature/mm-1101-source",
@@ -131,9 +135,13 @@ async def checkpoint_branch_client(tmp_path):
             "repository": "MoonLadderStudios/MoonMind",
         },
         parameters={
+            "repository": {
+                "provider": "git",
+                "connectionRef": "repository-connection:git-default",
+                "repository": {"name": "MoonLadderStudios/MoonMind"},
+                "branch": {"name": "feature/mm-1101-source"},
+            },
             "git": {
-                "repository": "MoonLadderStudios/MoonMind",
-                "startingBranch": "feature/mm-1101-source",
                 "baseCommit": "abc1234",
                 "knownRefs": ["feature/mm-1101-source"],
                 "currentRef": "feature/mm-1101-source",
@@ -293,6 +301,27 @@ def test_checkpoint_branch_git_context_reads_workflow_shaped_payload() -> None:
     assert context["resolvedBaseCommit"] == "abc1234def5678"
     assert context["currentRef"] == "feature/from-workflow"
     assert context["knownRefs"] == {"feature/from-workflow"}
+
+
+def test_checkpoint_branch_git_context_reads_provider_repository_target() -> None:
+    record = SimpleNamespace(
+        parameters={
+            "repository": {
+                "provider": "git",
+                "connectionRef": "repository-connection:git-default",
+                "repository": {"name": "MoonLadderStudios/MoonMind"},
+                "branch": {"name": "feature/provider-target"},
+            }
+        },
+        memo={},
+        search_attributes={},
+    )
+
+    context = _checkpoint_branch_git_context(record)
+
+    assert context["repository"] == "MoonLadderStudios/MoonMind"
+    assert context["baseBranch"] == "feature/provider-target"
+    assert context["currentRef"] == "feature/provider-target"
 
 
 def test_checkpoint_branch_git_context_does_not_synthesize_known_refs() -> None:

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -1071,7 +1071,14 @@ async def test_goal_preset_submission_uses_default_runtime_for_composite_context
             }
             await _expand_goal_preset_for_workflow_submission(
                 task_payload=task_payload,
-                request_payload={"repository": "MoonLadderStudios/MoonMind"},
+                request_payload={
+                    "repository": {
+                        "provider": "git",
+                        "connectionRef": "repository-connection:git-default",
+                        "repository": {"name": "MoonLadderStudios/MoonMind"},
+                        "branch": {"name": "main"},
+                    }
+                },
                 session=session,
                 user=SimpleNamespace(id=uuid4(), is_superuser=False),
             )
@@ -8169,7 +8176,53 @@ def test_create_task_shaped_execution_rejects_legacy_target_branch_aliases(
     assert "targetBranch" in response.json()["detail"]["message"]
     service.create_execution.assert_not_awaited()
 
-def test_create_task_shaped_execution_rejects_non_string_repository(
+@pytest.mark.parametrize(
+    ("skill_name", "publish_mode", "inputs"),
+    [
+        ("batch-pr-resolver", "none", {"repo": "Moon/Mind"}),
+        ("pr-resolver", "auto", {"repo": "Moon/Mind", "pr": 123}),
+    ],
+)
+def test_create_task_shaped_execution_accepts_provider_repository_for_resolvers(
+    client: tuple[TestClient, AsyncMock, SimpleNamespace],
+    skill_name: str,
+    publish_mode: str,
+    inputs: dict[str, Any],
+) -> None:
+    test_client, service, _user = client
+    service.create_execution.return_value = _build_execution_record()
+
+    repository_target = {
+        "provider": "git",
+        "connectionRef": "repository-connection:git-default",
+        "repository": {"name": "Moon/Mind"},
+        "branch": {"name": "main"},
+    }
+
+    response = test_client.post(
+        "/api/executions",
+        json={
+            "type": "task",
+            "payload": {
+                "repository": repository_target,
+                "targetRuntime": "codex",
+                "task": {
+                    "instructions": "Resolve pull requests.",
+                    "skill": {"name": skill_name},
+                    "inputs": inputs,
+                    "publish": {"mode": publish_mode},
+                },
+            },
+        },
+    )
+
+    assert response.status_code == 201, response.json()
+    create_kwargs = service.create_execution.await_args.kwargs
+    assert create_kwargs["repository"] == "Moon/Mind"
+    assert create_kwargs["initial_parameters"]["repository"] == repository_target
+
+
+def test_create_task_shaped_execution_rejects_malformed_repository_target(
     client: tuple[TestClient, AsyncMock, SimpleNamespace],
 ) -> None:
     test_client, service, _user = client
@@ -8188,7 +8241,9 @@ def test_create_task_shaped_execution_rejects_non_string_repository(
     )
 
     assert response.status_code == 422
-    assert "repository" in response.json()["detail"]["message"]
+    assert response.json()["detail"]["message"].startswith(
+        "payload.repository is invalid: REPOSITORY_TARGET_INVALID:"
+    )
     service.create_execution.assert_not_awaited()
 
 def test_create_task_shaped_execution_rejects_attachment_declared_for_multiple_targets(

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -8246,6 +8246,161 @@ def test_create_task_shaped_execution_rejects_malformed_repository_target(
     )
     service.create_execution.assert_not_awaited()
 
+
+@pytest.mark.parametrize("publish_mode", ["branch", "pr"])
+@pytest.mark.parametrize("recurring", [False, True])
+def test_create_execution_rejects_publishing_from_repository_revision(
+    client: tuple[TestClient, AsyncMock, SimpleNamespace],
+    recurring: bool,
+    publish_mode: str,
+) -> None:
+    test_client, service, _user = client
+    payload: dict[str, Any] = {
+        "repository": {
+            "provider": "git",
+            "connectionRef": "repository-connection:git-default",
+            "repository": {"name": "Moon/Mind"},
+            "branch": {"name": "main"},
+            "revision": {"kind": "git_commit", "commitSha": "abcdef012345"},
+        },
+        "targetRuntime": "codex",
+        "workflow": {
+            "instructions": "Mutate an immutable revision.",
+            "publish": {"mode": publish_mode},
+        },
+    }
+    if recurring:
+        payload["schedule"] = {
+            "mode": "recurring",
+            "cron": "0 1 * * *",
+            "timezone": "UTC",
+        }
+
+    response = test_client.post(
+        "/api/executions",
+        json={"type": "workflow", "payload": payload},
+    )
+
+    assert response.status_code == 422
+    assert "repository.revision" in response.json()["detail"]["message"]
+    service.create_execution.assert_not_awaited()
+
+
+@pytest.mark.parametrize("field", ["repository", "branch"])
+def test_create_execution_rejects_whitespace_only_repository_identity(
+    client: tuple[TestClient, AsyncMock, SimpleNamespace],
+    field: str,
+) -> None:
+    test_client, service, _user = client
+    repository_target = {
+        "provider": "git",
+        "connectionRef": "repository-connection:git-default",
+        "repository": {"name": "Moon/Mind"},
+        "branch": {"name": "main"},
+    }
+    repository_target[field] = {"name": "   "}
+
+    response = test_client.post(
+        "/api/executions",
+        json={
+            "type": "workflow",
+            "payload": {
+                "repository": repository_target,
+                "workflow": {"instructions": "Reject blank identity."},
+            },
+        },
+    )
+
+    assert response.status_code == 422
+    assert "REPOSITORY_TARGET_INVALID" in response.json()["detail"]["message"]
+    service.create_execution.assert_not_awaited()
+
+
+def test_create_execution_rejects_structured_repository_with_legacy_git(
+    client: tuple[TestClient, AsyncMock, SimpleNamespace],
+) -> None:
+    test_client, service, _user = client
+
+    response = test_client.post(
+        "/api/executions",
+        json={
+            "type": "workflow",
+            "payload": {
+                "repository": {
+                    "provider": "git",
+                    "connectionRef": "repository-connection:git-default",
+                    "repository": {"name": "Moon/Mind"},
+                    "branch": {"name": "main"},
+                },
+                "workflow": {
+                    "instructions": "Run conflicting branch authority.",
+                    "git": {"branch": "other"},
+                },
+            },
+        },
+    )
+
+    assert response.status_code == 422
+    assert "workflow.git" in response.json()["detail"]["message"]
+    service.create_execution.assert_not_awaited()
+
+
+@pytest.mark.parametrize("skill_name", ["batch-pr-resolver", "pr-resolver"])
+def test_create_execution_rejects_github_resolver_skills_for_lore(
+    client: tuple[TestClient, AsyncMock, SimpleNamespace],
+    skill_name: str,
+) -> None:
+    test_client, service, _user = client
+
+    response = test_client.post(
+        "/api/executions",
+        json={
+            "type": "workflow",
+            "payload": {
+                "repository": {
+                    "provider": "lore",
+                    "connectionRef": "repository-connection:tactics",
+                    "repository": {"name": "Tactics"},
+                    "branch": {"name": "main"},
+                },
+                "workflow": {
+                    "instructions": "Resolve GitHub PRs against Lore.",
+                    "skill": {"name": skill_name},
+                    "publish": {"mode": "none"},
+                },
+            },
+        },
+    )
+
+    assert response.status_code == 422
+    assert "GitHub-only Skills" in response.json()["detail"]["message"]
+    service.create_execution.assert_not_awaited()
+
+
+def test_create_execution_rejects_nested_repository_target(
+    client: tuple[TestClient, AsyncMock, SimpleNamespace],
+) -> None:
+    test_client, service, _user = client
+
+    response = test_client.post(
+        "/api/executions",
+        json={
+            "type": "workflow",
+            "payload": {
+                "workflow": {
+                    "instructions": "Bypass top-level repository authority.",
+                    "repository": {
+                        "repository": {"name": "Moon/Mind"},
+                    },
+                },
+            },
+        },
+    )
+
+    assert response.status_code == 422
+    assert "use payload.repository" in response.json()["detail"]["message"]
+    service.create_execution.assert_not_awaited()
+
 def test_create_task_shaped_execution_rejects_attachment_declared_for_multiple_targets(
     client: tuple[TestClient, AsyncMock, SimpleNamespace],
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit/moonmind/memory/test_run_digest.py
+++ b/tests/unit/moonmind/memory/test_run_digest.py
@@ -71,6 +71,27 @@ def test_build_run_digest_uses_terminal_execution_evidence_without_raw_logs() ->
     assert "raw log" not in digest.to_context_text().lower()
 
 
+def test_build_run_digest_projects_structured_repository_target() -> None:
+    service = TaskHistoryService(
+        qdrant_client=_VectorIndex(),
+        embedding_provider=_Embedder(),
+    )
+    parameters = {
+        "repository": {
+            "provider": "git",
+            "connectionRef": "repository-connection:git-default",
+            "repository": {"name": "MoonLadderStudios/MoonMind"},
+            "branch": {"name": "feature/mm-1219"},
+        },
+        "publishMode": "pr",
+    }
+
+    digest = service.build_run_digest(_record(parameters=parameters))
+
+    assert digest.repo == "MoonLadderStudios/MoonMind"
+    assert digest.security_scope == "repo:MoonLadderStudios/MoonMind"
+
+
 def test_payload_for_digest_marks_retrieval_record_kind_and_provenance() -> None:
     service = TaskHistoryService(
         qdrant_client=_VectorIndex(),

--- a/tests/unit/services/test_skill_step_inputs.py
+++ b/tests/unit/services/test_skill_step_inputs.py
@@ -45,9 +45,13 @@ class _ArtifactMetadataSession:
 
 def _parameters(skill_payload: dict[str, object]) -> dict[str, object]:
     return {
-        "repository": "Moon/Mind",
+        "repository": {
+            "provider": "git",
+            "connectionRef": "repository-connection:git-default",
+            "repository": {"name": "Moon/Mind"},
+            "branch": {"name": "feature/mm-1052"},
+        },
         "workflow": {
-            "git": {"branch": "feature/mm-1052"},
             "steps": [
                 {
                     "id": "step-1",

--- a/tests/unit/workflows/executions/test_repository_contract.py
+++ b/tests/unit/workflows/executions/test_repository_contract.py
@@ -18,6 +18,8 @@ from moonmind.workflows.executions.repository_contract import (
     load_repository_connection,
     materialize_resolved_repository_target,
     persist_repository_connection,
+    repository_branch_from_value,
+    repository_name_from_value,
     reconcile_default_git_connection,
     resolve_default_git_credential,
     validate_connection_and_client,
@@ -47,6 +49,44 @@ def test_common_git_draft_injects_default_connection_and_keeps_axes_distinct() -
     assert target.branch.name == "main"
     assert target.revision is not None
     assert target.revision.commit_sha == "abcdef012345"
+
+
+def test_repository_target_trims_identity_axes() -> None:
+    target = compile_repository_target(
+        {
+            "provider": "git",
+            "repository": {"name": "  MoonLadderStudios/MoonMind  "},
+            "branch": {"name": "  main  "},
+        }
+    )
+
+    assert target.repository.name == "MoonLadderStudios/MoonMind"
+    assert target.branch.name == "main"
+
+
+@pytest.mark.parametrize("field", ["repository", "branch"])
+def test_repository_target_rejects_whitespace_only_identity(field: str) -> None:
+    payload = {
+        "provider": "git",
+        "repository": {"name": "MoonLadderStudios/MoonMind"},
+        "branch": {"name": "main"},
+    }
+    payload[field] = {"name": "   "}
+
+    with pytest.raises(RepositoryContractError, match="REPOSITORY_TARGET_INVALID"):
+        compile_repository_target(payload)
+
+
+def test_repository_projection_helpers_support_scalar_and_structured_values() -> None:
+    target = {
+        "provider": "git",
+        "repository": {"name": " MoonLadderStudios/MoonMind "},
+        "branch": {"name": " feature/repository-target "},
+    }
+
+    assert repository_name_from_value(" owner/repo ") == "owner/repo"
+    assert repository_name_from_value(target) == "MoonLadderStudios/MoonMind"
+    assert repository_branch_from_value(target) == "feature/repository-target"
 
 
 @pytest.mark.parametrize("legacy", ["owner/repo", None, 123])

--- a/tests/unit/workflows/temporal/test_temporal_service.py
+++ b/tests/unit/workflows/temporal/test_temporal_service.py
@@ -3272,6 +3272,12 @@ async def test_request_rerun_creates_fresh_execution_for_terminal_execution(
             manifest_artifact_ref=None,
             failure_policy=None,
             initial_parameters={
+                "repository": {
+                    "provider": "git",
+                    "connectionRef": "repository-connection:git-default",
+                    "repository": {"name": "MoonLadderStudios/MoonMind"},
+                    "branch": {"name": "feature/mm-1219"},
+                },
                 "agentRunId": "old-agent-run",
                 "agent_run_id": "old-agent-run-snake",
                 "recoverySource": {"workflowId": "mm:source", "runId": "run-old"},
@@ -3331,6 +3337,8 @@ async def test_request_rerun_creates_fresh_execution_for_terminal_execution(
         assert source.state is MoonMindWorkflowState.CANCELED
         assert source.close_status is TemporalExecutionCloseStatus.CANCELED
         assert rerun.state is MoonMindWorkflowState.INITIALIZING
+        assert rerun.search_attributes["mm_repo"] == "MoonLadderStudios/MoonMind"
+        assert isinstance(rerun.parameters["repository"], dict)
         assert rerun.parameters["rerunSource"] == {
             "workflowId": source_workflow_id,
             "runId": source_run_id,
@@ -3734,6 +3742,12 @@ async def test_typed_recovery_creates_one_pinned_destination_and_frozen_lineage(
             manifest_artifact_ref=None,
             failure_policy=None,
             initial_parameters={
+                "repository": {
+                    "provider": "git",
+                    "connectionRef": "repository-connection:git-default",
+                    "repository": {"name": "MoonLadderStudios/MoonMind"},
+                    "branch": {"name": "feature/mm-1219"},
+                },
                 "agentRunId": "source-agent-run",
                 "workflow": {"title": "source", "instructions": "Original"},
             },
@@ -3784,6 +3798,10 @@ async def test_typed_recovery_creates_one_pinned_destination_and_frozen_lineage(
         assert destination.parameters["recoverySource"]["recoveryCheckpointRef"] == (
             "artifact://checkpoint/source"
         )
+        assert destination.search_attributes["mm_repo"] == (
+            "MoonLadderStudios/MoonMind"
+        )
+        assert isinstance(destination.parameters["repository"], dict)
         assert "agentRunId" not in destination.parameters
         refreshed_source = await session.get(
             TemporalExecutionCanonicalRecord, source.workflow_id
@@ -3810,6 +3828,12 @@ async def test_failed_step_recovery_creates_linked_execution_with_source_identit
             manifest_artifact_ref=None,
             failure_policy=None,
             initial_parameters={
+                "repository": {
+                    "provider": "git",
+                    "connectionRef": "repository-connection:git-default",
+                    "repository": {"name": "MoonLadderStudios/MoonMind"},
+                    "branch": {"name": "feature/mm-1219"},
+                },
                 "agentRunId": "old-agent-run",
                 "workflow": {"title": "recovery source", "instructions": "Original"},
             },
@@ -3842,6 +3866,8 @@ async def test_failed_step_recovery_creates_linked_execution_with_source_identit
 
         resumed = await service.describe_execution(result["execution"]["workflowId"])
         assert result["applied"] == "created_resumed_execution"
+        assert resumed.search_attributes["mm_repo"] == "MoonLadderStudios/MoonMind"
+        assert isinstance(resumed.parameters["repository"], dict)
         assert result["source"] == {
             "workflowId": created.workflow_id,
             "runId": created.run_id,

--- a/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
+++ b/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
@@ -701,12 +701,16 @@ def test_runtime_planner_validates_skill_step_contract_and_carries_evidence():
                             "inputs": {"issueKey": "MM-1057"},
                             "inputSchema": {
                                 "type": "object",
-                                "required": ["issueKey", "repository"],
+                                "required": ["issueKey", "repository", "branch"],
                                 "properties": {
                                     "issueKey": {"type": "string"},
                                     "repository": {
                                         "type": "string",
                                         "x-moonmind-context-default": "repository",
+                                    },
+                                    "branch": {
+                                        "type": "string",
+                                        "x-moonmind-context-default": "branch",
                                     },
                                 },
                             },
@@ -718,7 +722,14 @@ def test_runtime_planner_validates_skill_step_contract_and_carries_evidence():
                 ],
             }
         },
-        parameters={"repository": "MoonLadderStudios/MoonMind"},
+        parameters={
+            "repository": {
+                "provider": "git",
+                "connectionRef": "repository-connection:git-default",
+                "repository": {"name": "MoonLadderStudios/MoonMind"},
+                "branch": {"name": "feature/mm-1219"},
+            }
+        },
         snapshot=snapshot,
     )
 
@@ -726,9 +737,11 @@ def test_runtime_planner_validates_skill_step_contract_and_carries_evidence():
     assert node_inputs["inputs"] == {
         "issueKey": "MM-1057",
         "repository": "MoonLadderStudios/MoonMind",
+        "branch": "feature/mm-1219",
     }
     assert node_inputs["issueKey"] == "MM-1057"
     assert node_inputs["repository"] == "MoonLadderStudios/MoonMind"
+    assert node_inputs["branch"] == "feature/mm-1219"
     assert node_inputs["inputContractDigest"] == "sha256:contract"
     assert node_inputs["contentDigest"] == "sha256:content"
     assert node_inputs["contentRef"] == "artifact:skill"


### PR DESCRIPTION
## Summary

- accept provider-discriminated repository targets at the `/api/executions` control-plane boundary
- preserve the structured target in Temporal parameters while retaining the scalar repository name for dashboard/search projection
- pass the repository name into preset expansion and keep malformed targets fail-fast
- add regressions covering both `batch-pr-resolver` and `pr-resolver`

## Root cause

The provider-aware repository rollout updated the Create page and downstream workflow/runtime contracts to use a structured repository object, but the execution router still rejected every non-string `payload.repository`. Valid resolver submissions therefore failed before reaching the canonical repository compiler.

## Validation

- `./tools/test_unit.sh --python-only --no-xdist tests/unit/api/routers/test_executions.py` — 386 passed
- `./tools/test_unit.sh --python-only --no-xdist tests/unit/workflows/executions/test_execution_contract.py tests/unit/workflows/temporal/test_temporal_worker_runtime.py -k repository` — 13 passed
- focused Create-page structured repository submission test — passed
- `git diff --check` — passed