### PR TITLE
Expose actionable PR selector for pr-resolver

### DIFF
--- a/.agents/skills/pr-resolver/SKILL.md
+++ b/.agents/skills/pr-resolver/SKILL.md
@@ -22,6 +22,19 @@ metadata:
     supportedHosts:
       - cli
     nativeHostEligible: false
+inputSchema:
+  type: object
+  required:
+    - pr
+  properties:
+    pr:
+      type: string
+      title: Pull request
+      description: >-
+        PR number, PR URL, or head branch. MoonMind requires an explicit
+        selector so the resolver cannot target the wrong PR.
+uiSchema: {}
+defaults: {}
 ---
 
 # PR Resolver Skill

--- a/.agents/skills/pr-resolver/SKILL.md
+++ b/.agents/skills/pr-resolver/SKILL.md
@@ -24,15 +24,24 @@ metadata:
     nativeHostEligible: false
 inputSchema:
   type: object
-  required:
-    - pr
   properties:
     pr:
       type: string
       title: Pull request
       description: >-
-        PR number, PR URL, or head branch. MoonMind requires an explicit
-        selector so the resolver cannot target the wrong PR.
+        PR number or PR URL. MoonMind requires either this value or a head
+        branch so the resolver cannot target the wrong PR.
+    branch:
+      type: string
+      title: Head branch
+      description: >-
+        PR head branch. MoonMind requires either this value or a PR number or
+        URL so the resolver cannot target the wrong PR.
+  anyOf:
+    - required:
+        - pr
+    - required:
+        - branch
 uiSchema: {}
 defaults: {}
 ---

--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -9076,11 +9076,12 @@ def _validate_pentest_submission_boundary(
             )
 
 _PR_RESOLVER_SELECTOR_ERROR = (
-    "pr-resolver workflow requires a structured PR selector: "
-    "payload.workflow.inputs.pr, payload.workflow.inputs.branch, "
-    "payload.workflow.tool.inputs.pr/branch, or "
-    "payload.workflow.git.startingBranch, or a non-default "
-    "payload.workflow.git.branch."
+    "pr-resolver requires an explicit pull request selector. In the dashboard, "
+    "select the pr-resolver Skill and fill in Pull request with a PR number, PR "
+    "URL, or head branch. API callers can set payload.task.inputs.pr (or "
+    "payload.workflow.inputs.pr); Skill/Tool inputs named pr or branch, "
+    "git.startingBranch, and a non-default git.branch are also accepted. A "
+    "default checkout branch such as main does not identify a PR."
 )
 _PR_RESOLVER_DEFAULT_BRANCH_NAMES = frozenset(
     {"main", "master", "develop", "development", "trunk"}

--- a/docs/Steps/SkillGithubPrResolver.md
+++ b/docs/Steps/SkillGithubPrResolver.md
@@ -95,9 +95,9 @@ reimplements resolver behavior.
 ### 4.1 Inputs (Skill Args)
 
 MoonMind workflow submissions require an explicit structured PR selector. The
-dashboard renders the Skill's required **Pull request** field from the
-`SKILL.md` input schema; enter a PR number, PR URL, or head branch. API callers
-may provide the same value through Skill/Tool `pr` or `branch` inputs,
+dashboard renders the Skill's **Pull request** and **Head branch** fields from
+the `SKILL.md` input schema and requires either a PR number/URL or a head branch.
+API callers may provide the selector through Skill/Tool `pr` or `branch` inputs,
 top-level task inputs, `git.startingBranch`, or a non-default `git.branch`.
 The repository's default checkout branch (for example, `main`) is not a PR
 selector. This boundary deliberately avoids inferring merge authority from

--- a/docs/Steps/SkillGithubPrResolver.md
+++ b/docs/Steps/SkillGithubPrResolver.md
@@ -94,6 +94,15 @@ reimplements resolver behavior.
 
 ### 4.1 Inputs (Skill Args)
 
+MoonMind workflow submissions require an explicit structured PR selector. The
+dashboard renders the Skill's required **Pull request** field from the
+`SKILL.md` input schema; enter a PR number, PR URL, or head branch. API callers
+may provide the same value through Skill/Tool `pr` or `branch` inputs,
+top-level task inputs, `git.startingBranch`, or a non-default `git.branch`.
+The repository's default checkout branch (for example, `main`) is not a PR
+selector. This boundary deliberately avoids inferring merge authority from
+free-form instructions.
+
 | Arg                   | Type        |  Default | Meaning                                                                                                              |
 | --------------------- | ----------- | -------: | -------------------------------------------------------------------------------------------------------------------- |
 | `repo`                | string|null |     null | `owner/repo`. If null, infer from git remote.                                                                        |

--- a/frontend/src/entrypoints/workflow-start.test.tsx
+++ b/frontend/src/entrypoints/workflow-start.test.tsx
@@ -16658,7 +16658,14 @@ describe("Task Create schema-driven capability inputs", () => {
       return Promise.resolve({
         ok: true,
         json: async () => ({
-          items: { worker: ["schema.skill", "schema.other", "no-schema.skill"] },
+          items: {
+            worker: [
+              "schema.skill",
+              "schema.other",
+              "no-schema.skill",
+              "pr-resolver",
+            ],
+          },
           legacyItems: [
             {
               id: "schema.skill",
@@ -16777,6 +16784,24 @@ describe("Task Create schema-driven capability inputs", () => {
               id: "no-schema.skill",
               description: "Instruction-driven Skill fixture.",
               inputSchema: {},
+              uiSchema: {},
+              defaults: {},
+            },
+            {
+              id: "pr-resolver",
+              description: "Resolve a pull request.",
+              inputSchema: {
+                type: "object",
+                required: ["pr"],
+                properties: {
+                  pr: {
+                    type: "string",
+                    title: "Pull request",
+                    description:
+                      "PR number, PR URL, or head branch. MoonMind requires an explicit selector so the resolver cannot target the wrong PR.",
+                  },
+                },
+              },
               uiSchema: {},
               defaults: {},
             },
@@ -17410,6 +17435,50 @@ describe("Task Create schema-driven capability inputs", () => {
         "Widget external.lookup is unavailable; using a text field.",
       ),
     ).toBeTruthy();
+  });
+
+  it("gives pr-resolver an actionable required PR selector and submits it structurally", async () => {
+    renderWithClient(<WorkflowStartPage payload={mockPayload} />);
+    const step = (await screen.findByText("Step 1")).closest("section") as HTMLElement;
+    selectStepType(step, "Skill");
+    fireEvent.change(within(step).getByLabelText("Skill (optional)"), {
+      target: { value: "pr-resolver" },
+    });
+
+    const selector = await within(step).findByLabelText("Pull request");
+    expect(
+      within(step).getByText(
+        "PR number, PR URL, or head branch. MoonMind requires an explicit selector so the resolver cannot target the wrong PR.",
+      ),
+    ).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Start Workflow" }));
+
+    expect(await within(step).findByText("Pull request is required.")).toBeTruthy();
+    expect(
+      fetchSpy.mock.calls.some(([url]) => String(url) === "/api/executions"),
+    ).toBe(false);
+
+    fireEvent.change(selector, { target: { value: "2733" } });
+    fireEvent.click(screen.getByRole("button", { name: "Start Workflow" }));
+
+    await waitFor(() => {
+      expect(
+        fetchSpy.mock.calls.some(([url]) => String(url) === "/api/executions"),
+      ).toBe(true);
+    });
+    const request = latestSchemaCreateRequest() as {
+      payload: {
+        task: {
+          inputs?: Record<string, unknown>;
+          skill?: { inputs?: Record<string, unknown> };
+          tool?: { inputs?: Record<string, unknown> };
+        };
+      };
+    };
+    expect(request.payload.task.inputs?.pr).toBe("2733");
+    expect(request.payload.task.skill?.inputs?.pr).toBe("2733");
+    expect(request.payload.task.tool?.inputs?.pr).toBe("2733");
   });
 
   it("preserves MM-1056 Skill fallback values under step.skill.inputs for MM-1047 traceability", async () => {

--- a/frontend/src/entrypoints/workflow-start.test.tsx
+++ b/frontend/src/entrypoints/workflow-start.test.tsx
@@ -16792,15 +16792,21 @@ describe("Task Create schema-driven capability inputs", () => {
               description: "Resolve a pull request.",
               inputSchema: {
                 type: "object",
-                required: ["pr"],
                 properties: {
                   pr: {
                     type: "string",
                     title: "Pull request",
                     description:
-                      "PR number, PR URL, or head branch. MoonMind requires an explicit selector so the resolver cannot target the wrong PR.",
+                      "PR number or PR URL. MoonMind requires either this value or a head branch so the resolver cannot target the wrong PR.",
+                  },
+                  branch: {
+                    type: "string",
+                    title: "Head branch",
+                    description:
+                      "PR head branch. MoonMind requires either this value or a PR number or URL so the resolver cannot target the wrong PR.",
                   },
                 },
+                anyOf: [{ required: ["pr"] }, { required: ["branch"] }],
               },
               uiSchema: {},
               defaults: {},
@@ -17437,49 +17443,58 @@ describe("Task Create schema-driven capability inputs", () => {
     ).toBeTruthy();
   });
 
-  it("gives pr-resolver an actionable required PR selector and submits it structurally", async () => {
-    renderWithClient(<WorkflowStartPage payload={mockPayload} />);
-    const step = (await screen.findByText("Step 1")).closest("section") as HTMLElement;
-    selectStepType(step, "Skill");
-    fireEvent.change(within(step).getByLabelText("Skill (optional)"), {
-      target: { value: "pr-resolver" },
-    });
+  it.each([
+    ["Pull request", "2733", "pr"],
+    ["Head branch", "agent/fix-selector", "branch"],
+  ])(
+    "requires a pr-resolver selector and submits %s structurally",
+    async (fieldLabel, selectorValue, inputKey) => {
+      renderWithClient(<WorkflowStartPage payload={mockPayload} />);
+      const step = (await screen.findByText("Step 1")).closest(
+        "section",
+      ) as HTMLElement;
+      selectStepType(step, "Skill");
+      fireEvent.change(within(step).getByLabelText("Skill (optional)"), {
+        target: { value: "pr-resolver" },
+      });
 
-    const selector = await within(step).findByLabelText("Pull request");
-    expect(
-      within(step).getByText(
-        "PR number, PR URL, or head branch. MoonMind requires an explicit selector so the resolver cannot target the wrong PR.",
-      ),
-    ).toBeTruthy();
+      const selector = await within(step).findByLabelText(fieldLabel);
+      expect(await within(step).findByLabelText("Pull request")).toBeTruthy();
+      expect(within(step).getByLabelText("Head branch")).toBeTruthy();
 
-    fireEvent.click(screen.getByRole("button", { name: "Start Workflow" }));
+      fireEvent.click(screen.getByRole("button", { name: "Start Workflow" }));
 
-    expect(await within(step).findByText("Pull request is required.")).toBeTruthy();
-    expect(
-      fetchSpy.mock.calls.some(([url]) => String(url) === "/api/executions"),
-    ).toBe(false);
-
-    fireEvent.change(selector, { target: { value: "2733" } });
-    fireEvent.click(screen.getByRole("button", { name: "Start Workflow" }));
-
-    await waitFor(() => {
+      expect(
+        await within(step).findByText(
+          "Pull request or Head branch is required.",
+        ),
+      ).toBeTruthy();
       expect(
         fetchSpy.mock.calls.some(([url]) => String(url) === "/api/executions"),
-      ).toBe(true);
-    });
-    const request = latestSchemaCreateRequest() as {
-      payload: {
-        task: {
-          inputs?: Record<string, unknown>;
-          skill?: { inputs?: Record<string, unknown> };
-          tool?: { inputs?: Record<string, unknown> };
+      ).toBe(false);
+
+      fireEvent.change(selector, { target: { value: selectorValue } });
+      fireEvent.click(screen.getByRole("button", { name: "Start Workflow" }));
+
+      await waitFor(() => {
+        expect(
+          fetchSpy.mock.calls.some(([url]) => String(url) === "/api/executions"),
+        ).toBe(true);
+      });
+      const request = latestSchemaCreateRequest() as {
+        payload: {
+          task: {
+            inputs?: Record<string, unknown>;
+            skill?: { inputs?: Record<string, unknown> };
+            tool?: { inputs?: Record<string, unknown> };
+          };
         };
       };
-    };
-    expect(request.payload.task.inputs?.pr).toBe("2733");
-    expect(request.payload.task.skill?.inputs?.pr).toBe("2733");
-    expect(request.payload.task.tool?.inputs?.pr).toBe("2733");
-  });
+      expect(request.payload.task.inputs?.[inputKey]).toBe(selectorValue);
+      expect(request.payload.task.skill?.inputs?.[inputKey]).toBe(selectorValue);
+      expect(request.payload.task.tool?.inputs?.[inputKey]).toBe(selectorValue);
+    },
+  );
 
   it("preserves MM-1056 Skill fallback values under step.skill.inputs for MM-1047 traceability", async () => {
     renderWithClient(<WorkflowStartPage payload={mockPayload} />);

--- a/frontend/src/entrypoints/workflow-start.tsx
+++ b/frontend/src/entrypoints/workflow-start.tsx
@@ -3416,6 +3416,21 @@ function schemaRequired(schema: Record<string, unknown> | undefined): Set<string
   );
 }
 
+function schemaAlternativeRequiredGroups(
+  schema: Record<string, unknown> | undefined,
+): string[][] {
+  const alternatives = Array.isArray(schema?.anyOf)
+    ? schema.anyOf
+    : Array.isArray(schema?.oneOf)
+      ? schema.oneOf
+      : [];
+  return alternatives
+    .map((alternative) =>
+      Array.from(schemaRequired(recordValue(alternative))),
+    )
+    .filter((group) => group.length > 0);
+}
+
 function capabilityFieldLabel(name: string, schema: Record<string, unknown>): string {
   return String(schema.title || name)
     .trim()
@@ -3843,6 +3858,30 @@ function validateSchemaCapabilityValues(
       (typeof value !== "object" || Array.isArray(value))
     ) {
       errors[name] = `${capabilityFieldLabel(name, fieldSchema)} must be a JSON object.`;
+    }
+  }
+  const alternativeRequiredGroups = schemaAlternativeRequiredGroups(
+    detail.inputSchema,
+  );
+  if (
+    alternativeRequiredGroups.length > 0 &&
+    !alternativeRequiredGroups.some((group) =>
+      group.every((name) => {
+        const value = values[name];
+        return value !== undefined && value !== null && value !== "";
+      }),
+    )
+  ) {
+    const labels = alternativeRequiredGroups.map((group) =>
+      group
+        .map((name) =>
+          capabilityFieldLabel(name, recordValue(properties[name])),
+        )
+        .join(" and "),
+    );
+    const errorField = alternativeRequiredGroups[0]?.[0];
+    if (errorField) {
+      errors[errorField] = `${labels.join(" or ")} is required.`;
     }
   }
   return errors;

--- a/moonmind/workflows/temporal/worker_runtime.py
+++ b/moonmind/workflows/temporal/worker_runtime.py
@@ -785,9 +785,10 @@ def _derive_pr_branch_prefix(
 
 
 _PR_RESOLVER_SELECTOR_ERROR = (
-    "pr-resolver workflow requires workflow.tool.inputs.pr, "
-    "workflow.tool.inputs.branch, workflow.git.startingBranch, "
-    "or a non-default workflow.git.branch"
+    "pr-resolver requires an explicit pull request selector. Set inputs.pr (or "
+    "Skill/Tool inputs named pr or branch) to a PR number, PR URL, or head "
+    "branch; git.startingBranch and a non-default git.branch are also accepted. "
+    "A default checkout branch such as main does not identify a PR."
 )
 _PR_RESOLVER_DEFAULT_BRANCH_NAMES = frozenset(
     {"main", "master", "develop", "development", "trunk"}

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -7199,11 +7199,13 @@ def test_create_task_shaped_execution_rejects_pr_resolver_without_structured_sel
     assert response.status_code == 422
     assert (
         response.json()["detail"]["message"]
-        == "pr-resolver workflow requires a structured PR selector: "
-        "payload.workflow.inputs.pr, payload.workflow.inputs.branch, "
-        "payload.workflow.tool.inputs.pr/branch, or "
-        "payload.workflow.git.startingBranch, or a non-default "
-        "payload.workflow.git.branch."
+        == "pr-resolver requires an explicit pull request selector. In the "
+        "dashboard, select the pr-resolver Skill and fill in Pull request with a "
+        "PR number, PR URL, or head branch. API callers can set "
+        "payload.task.inputs.pr (or payload.workflow.inputs.pr); Skill/Tool "
+        "inputs named pr or branch, git.startingBranch, and a non-default "
+        "git.branch are also accepted. A default checkout branch such as main "
+        "does not identify a PR."
     )
     service.create_execution.assert_not_awaited()
 

--- a/tests/unit/api/routers/test_workflow_console.py
+++ b/tests/unit/api/routers/test_workflow_console.py
@@ -929,6 +929,40 @@ defaults:
     assert item["inputContractRef"] is None
 
 
+def test_skills_api_exposes_pr_resolver_selector_contract(
+    client: TestClient, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repository_root = Path(__file__).resolve().parents[4]
+    monkeypatch.setattr(
+        "api_service.api.routers.workflow_console.settings.workflow.skills_local_mirror_root",
+        str(tmp_path / "local"),
+    )
+    monkeypatch.setattr(
+        "api_service.api.routers.workflow_console.settings.workflow.skills_legacy_mirror_root",
+        str(repository_root / ".agents" / "skills"),
+    )
+    monkeypatch.setattr(
+        "api_service.api.routers.workflow_console.list_available_skill_names",
+        lambda: ("pr-resolver",),
+    )
+
+    response = client.get("/api/workflows/skills")
+
+    assert response.status_code == 200
+    item = response.json()["legacyItems"][0]
+    assert item["id"] == "pr-resolver"
+    assert item["hasInputSchema"] is True
+    assert item["inputSchema"]["required"] == ["pr"]
+    assert item["inputSchema"]["properties"]["pr"] == {
+        "type": "string",
+        "title": "Pull request",
+        "description": (
+            "PR number, PR URL, or head branch. MoonMind requires an explicit "
+            "selector so the resolver cannot target the wrong PR."
+        ),
+    }
+
+
 def test_skills_api_large_schema_uses_input_contract_ref(
     client: TestClient, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/unit/api/routers/test_workflow_console.py
+++ b/tests/unit/api/routers/test_workflow_console.py
@@ -952,13 +952,24 @@ def test_skills_api_exposes_pr_resolver_selector_contract(
     item = response.json()["legacyItems"][0]
     assert item["id"] == "pr-resolver"
     assert item["hasInputSchema"] is True
-    assert item["inputSchema"]["required"] == ["pr"]
+    assert item["inputSchema"]["anyOf"] == [
+        {"required": ["pr"]},
+        {"required": ["branch"]},
+    ]
     assert item["inputSchema"]["properties"]["pr"] == {
         "type": "string",
         "title": "Pull request",
         "description": (
-            "PR number, PR URL, or head branch. MoonMind requires an explicit "
-            "selector so the resolver cannot target the wrong PR."
+            "PR number or PR URL. MoonMind requires either this value or a head "
+            "branch so the resolver cannot target the wrong PR."
+        ),
+    }
+    assert item["inputSchema"]["properties"]["branch"] == {
+        "type": "string",
+        "title": "Head branch",
+        "description": (
+            "PR head branch. MoonMind requires either this value or a PR number "
+            "or URL so the resolver cannot target the wrong PR."
         ),
     }
 

--- a/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
+++ b/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
@@ -3227,9 +3227,8 @@ def test_runtime_planner_requires_selector_for_pr_resolver_without_instructions(
     with pytest.raises(
         RuntimeError,
         match=(
-            "pr-resolver workflow requires workflow.tool.inputs.pr, "
-            "workflow.tool.inputs.branch, workflow.git.startingBranch, "
-            "or a non-default workflow.git.branch"
+            "pr-resolver requires an explicit pull request selector.*"
+            "A default checkout branch such as main does not identify a PR"
         ),
     ):
         planner(
@@ -3983,9 +3982,8 @@ def test_runtime_planner_rejects_pr_resolver_with_only_jira_instructions_and_bas
     with pytest.raises(
         RuntimeError,
         match=(
-            "pr-resolver workflow requires workflow.tool.inputs.pr, "
-            "workflow.tool.inputs.branch, workflow.git.startingBranch, "
-            "or a non-default workflow.git.branch"
+            "pr-resolver requires an explicit pull request selector.*"
+            "A default checkout branch such as main does not identify a PR"
         ),
     ):
         planner(


### PR DESCRIPTION
## Summary

- declare a required `Pull request` input in the authoritative `pr-resolver` Skill contract so the dashboard renders an actionable PR number, URL, or head-branch field
- keep the safety boundary that rejects ambiguous default checkout branches while replacing JSON-only diagnostics with dashboard and task-shaped API recovery guidance
- add API catalog, submission, planner, and workflow-start regression coverage, and document the explicit-selector contract

## Root cause

The structured-selector guard intentionally stopped inferring merge authority from free-form instructions. However, `pr-resolver/SKILL.md` did not declare an input schema, so the dashboard rendered no PR selector and submitted only its default checkout branch (usually `main`). The guard correctly rejected that branch, but its error referenced only workflow-shaped JSON paths rather than the normal dashboard action or task-shaped request.

## User impact

Selecting `pr-resolver` now shows a required **Pull request** field. Blank submissions are blocked in the form, and valid values are serialized into task, Skill, and Tool inputs before the request reaches the API. API/runtime fallback errors now explain that default branches do not identify a PR and list the accepted recovery paths.

## Validation

Passed:

- focused selector/catalog/planner Python regressions: 4 passed
- PR-resolver backend selection coverage: 16 passed
- schema-driven workflow-start coverage: 16 passed
- focused PR-resolver dashboard journey: 1 passed
- reliability journeys: 30 passed
- frontend CI: typecheck, lint, 1,148 tests passed (239 skipped), production build, manifest verification
- Chromium browser suite: 13 passed
- staged diff check

Broader selector-equivalent local shards also ran. They remained non-green only on unrelated existing local state/platform cases: the dirty/out-of-sync MoonSpec submodule and macOS filesystem path/permission assertions in fast-unit; three Omnigent policy fixture validations in API component; and one local default-setting expectation in the Temporal boundary shard. Focused tests covering every changed boundary are green.