### PR TITLE
Fix Temporal repository readiness

### DIFF
--- a/moonmind/workflows/executions/repository_contract.py
+++ b/moonmind/workflows/executions/repository_contract.py
@@ -22,6 +22,7 @@ LEGACY_REPOSITORY_DECODER_VERSION = "moonmind.repository-legacy-history.v1"
 REPOSITORY_CAPABILITY_UNKNOWN = "REPOSITORY_CAPABILITY_UNKNOWN"
 REPOSITORY_CONNECTION_MISMATCH = "REPOSITORY_CONNECTION_MISMATCH"
 REPOSITORY_CLIENT_MISMATCH = "REPOSITORY_CLIENT_MISMATCH"
+REPOSITORY_CREDENTIAL_UNAVAILABLE = "REPOSITORY_CREDENTIAL_UNAVAILABLE"
 REPOSITORY_REMOTE_TIP_MISMATCH = "REPOSITORY_REMOTE_TIP_MISMATCH"
 
 
@@ -268,12 +269,18 @@ def compile_repository_target(value: object) -> AuthoredRepositoryTarget:
         raise RepositoryContractError("REPOSITORY_TARGET_INVALID", str(exc)) from exc
 
 
-def repository_name_from_value(value: object) -> str:
+def repository_name_from_value(
+    value: object,
+    *,
+    provider: Literal["git", "lore"] | None = None,
+) -> str:
     """Project a legacy scalar or authored target to its repository name."""
 
     if isinstance(value, str):
         return value.strip()
     if not isinstance(value, Mapping):
+        return ""
+    if provider is not None and value.get("provider") != provider:
         return ""
     repository = value.get("repository")
     if not isinstance(repository, Mapping):
@@ -604,7 +611,18 @@ async def ensure_repository_ready(
     await readiness_registry.check(required, context)
 
     if connection.credential.source == "github_resolver":
-        await _await_if_needed(credential_resolver(target.repository.name))
+        credential = await _await_if_needed(
+            credential_resolver(target.repository.name)
+        )
+        if not bool(getattr(credential, "resolved", False)):
+            safe_summary = str(
+                getattr(credential, "safe_summary", "")
+                or "GitHub credential resolution returned no usable credential."
+            )
+            raise RepositoryContractError(
+                REPOSITORY_CREDENTIAL_UNAVAILABLE,
+                safe_summary,
+            )
 
     if operation != "read":
         if remote_tip_verifier is None:

--- a/moonmind/workflows/temporal/runtime/launcher.py
+++ b/moonmind/workflows/temporal/runtime/launcher.py
@@ -519,12 +519,13 @@ class ManagedRuntimeLauncher:
         registry.register(
             "repo.review.request", operation_ready("review_request")
         )
+        # Skills may require authenticated read-only GitHub operations even
+        # when the workflow itself does not publish a pull request.
         registry.register(
             "gh",
             lambda context: (
                 context["target"].provider == "git"
                 and context["connection"].credential.source == "github_resolver"
-                and context["publishMode"] == "pr"
             ),
         )
 

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -551,6 +551,9 @@ RUN_UPDATE_INPUTS_VISIBILITY_REFRESH_PATCH = (
     "run-update-inputs-visibility-refresh-v1"
 )
 RUN_RECURRING_SCHEDULED_START_PATCH = "run-recurring-scheduled-start-v1"
+RUN_CANONICAL_GIT_REPOSITORY_PROJECTION_PATCH = (
+    "run-canonical-git-repository-projection-v1"
+)
 RUN_MEMO_RUNTIME_INHERITANCE_PATCH = "run-memo-runtime-inheritance-v1"
 DEPENDENCY_GATE_PATCH = "dependency-gate-v1"
 # Replay-stable patch id for unified wait-through-rerun dependency behavior.
@@ -1370,6 +1373,7 @@ class MoonMindRunWorkflow:
         self._publish_status: Optional[str] = None
         self._publish_reason: Optional[str] = None
         self._publish_context: dict[str, Any] = {}
+        self._canonical_git_repository_projection_enabled: bool = False
         self._canonical_no_commit_outcome_enabled: bool = False
         self._authoritative_publish_outcome_enabled: bool = False
         self._publish_repair_attempts: int = 0
@@ -9623,6 +9627,9 @@ class MoonMindRunWorkflow:
 
     @workflow.run
     async def run(self, input_payload: RunWorkflowInput) -> RunWorkflowOutput:
+        self._canonical_git_repository_projection_enabled = workflow.patched(
+            RUN_CANONICAL_GIT_REPOSITORY_PROJECTION_PATCH
+        )
         try:
             workflow_type, parameters, input_ref, plan_ref, scheduled_for = (
                 self._initialize_from_payload(input_payload)
@@ -10071,12 +10078,37 @@ class MoonMindRunWorkflow:
             task_parameters.get("dependsOn")
         )
         ws = self._mapping_value(parameters, "workspaceSpec", "workspace_spec") or {}
-        self._repo = (
-            self._string_from_mapping(parameters, "repo")
-            or repository_name_from_value(parameters.get("repository"))
-            or self._string_from_mapping(ws, "repo")
-            or repository_name_from_value(ws.get("repository"))
+        repository_values = (
+            parameters.get("repository"),
+            ws.get("repository"),
         )
+        lore_target_selected = any(
+            isinstance(value, Mapping) and value.get("provider") == "lore"
+            for value in repository_values
+        )
+        if (
+            self._canonical_git_repository_projection_enabled
+            and not lore_target_selected
+        ):
+            self._repo = (
+                self._string_from_mapping(parameters, "repo")
+                or repository_name_from_value(
+                    parameters.get("repository"), provider="git"
+                )
+                or self._string_from_mapping(ws, "repo")
+                or repository_name_from_value(
+                    ws.get("repository"), provider="git"
+                )
+            )
+        elif self._canonical_git_repository_projection_enabled:
+            self._repo = None
+        else:
+            self._repo = (
+                self._string_from_mapping(parameters, "repo")
+                or self._string_from_mapping(parameters, "repository")
+                or self._string_from_mapping(ws, "repo")
+                or self._string_from_mapping(ws, "repository")
+            )
         self._record_integration_from_parameters(parameters)
 
         input_ref = self._optional_string(

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -91,6 +91,9 @@ with workflow.unsafe.imports_passed_through():
     from moonmind.workflows.executions.execution_contract import (
         build_effective_workflow_skill_selectors,
     )
+    from moonmind.workflows.executions.repository_contract import (
+        repository_name_from_value,
+    )
     from moonmind.workflows.temporal.workflows.provider_profile_manager import (
         workflow_id_for_runtime,
     )
@@ -10070,9 +10073,9 @@ class MoonMindRunWorkflow:
         ws = self._mapping_value(parameters, "workspaceSpec", "workspace_spec") or {}
         self._repo = (
             self._string_from_mapping(parameters, "repo")
-            or self._string_from_mapping(parameters, "repository")
+            or repository_name_from_value(parameters.get("repository"))
             or self._string_from_mapping(ws, "repo")
-            or self._string_from_mapping(ws, "repository")
+            or repository_name_from_value(ws.get("repository"))
         )
         self._record_integration_from_parameters(parameters)
 

--- a/tests/unit/services/temporal/runtime/test_launcher.py
+++ b/tests/unit/services/temporal/runtime/test_launcher.py
@@ -209,6 +209,41 @@ async def test_default_repository_readiness_returns_exact_resolved_metadata(tmp_
 
 
 @pytest.mark.asyncio
+async def test_default_repository_readiness_allows_gh_for_read_only_skill(tmp_path):
+    evidence = RepositoryClientEvidence(
+        toolBundleRef="repository-client:git-system",
+        clientVersion="2.46.0",
+        executableSha256="sha256:git",
+    )
+    launcher = ManagedRuntimeLauncher(
+        ManagedRunStore(tmp_path / "managed_runs"),
+        repository_client_policy=RepositoryClientPolicy(
+            pinnedVersion=evidence.client_version,
+            toolBundleRef=evidence.tool_bundle_ref,
+            executableSha256=evidence.executable_sha256,
+        ),
+    )
+    launcher._observe_git_client = AsyncMock(return_value=evidence)
+    launcher._observe_git_remote_tip = AsyncMock(return_value="abcdef0123456789")
+
+    with patch(
+        "moonmind.auth.github_credentials.resolve_github_credential",
+        AsyncMock(return_value=object()),
+    ):
+        resolved = await launcher._ensure_repository_ready_for_launch(
+            _repository_readiness_request(
+                publish_mode="none",
+                skill_capabilities=["gh"],
+            ),
+            None,
+        )
+
+    assert resolved is not None
+    assert resolved.prepared_revision.commit_sha == "abcdef0123456789"
+    assert resolved.remote_tip_expectation["kind"] == "must_equal"
+
+
+@pytest.mark.asyncio
 async def test_lore_readiness_uses_policy_owned_adapter_and_preserves_exact_identity(
     tmp_path,
 ):

--- a/tests/unit/services/temporal/runtime/test_launcher.py
+++ b/tests/unit/services/temporal/runtime/test_launcher.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from moonmind.auth.github_credentials import ResolvedGitHubCredential
 from moonmind.schemas.agent_runtime_models import AgentExecutionRequest
 from moonmind.schemas.agent_runtime_models import ManagedRuntimeProfile
 from moonmind.schemas.agent_runtime_models import RuntimeCommandRenderResult
@@ -196,7 +197,7 @@ async def test_default_repository_readiness_returns_exact_resolved_metadata(tmp_
     launcher._observe_git_remote_tip = AsyncMock(return_value="abcdef0123456789")
     with patch(
         "moonmind.auth.github_credentials.resolve_github_credential",
-        AsyncMock(return_value=object()),
+        AsyncMock(return_value=ResolvedGitHubCredential(token="test-token")),
     ):
         resolved = await launcher._ensure_repository_ready_for_launch(
             _repository_readiness_request(publish_mode="none"), None
@@ -228,7 +229,7 @@ async def test_default_repository_readiness_allows_gh_for_read_only_skill(tmp_pa
 
     with patch(
         "moonmind.auth.github_credentials.resolve_github_credential",
-        AsyncMock(return_value=object()),
+        AsyncMock(return_value=ResolvedGitHubCredential(token="test-token")),
     ):
         resolved = await launcher._ensure_repository_ready_for_launch(
             _repository_readiness_request(
@@ -241,6 +242,48 @@ async def test_default_repository_readiness_allows_gh_for_read_only_skill(tmp_pa
     assert resolved is not None
     assert resolved.prepared_revision.commit_sha == "abcdef0123456789"
     assert resolved.remote_tip_expectation["kind"] == "must_equal"
+
+
+@pytest.mark.asyncio
+async def test_default_repository_readiness_rejects_unresolved_gh_credential(
+    tmp_path,
+):
+    evidence = RepositoryClientEvidence(
+        toolBundleRef="repository-client:git-system",
+        clientVersion="2.46.0",
+        executableSha256="sha256:git",
+    )
+    launcher = ManagedRuntimeLauncher(
+        ManagedRunStore(tmp_path / "managed_runs"),
+        repository_client_policy=RepositoryClientPolicy(
+            pinnedVersion=evidence.client_version,
+            toolBundleRef=evidence.tool_bundle_ref,
+            executableSha256=evidence.executable_sha256,
+        ),
+    )
+    launcher._observe_git_client = AsyncMock(return_value=evidence)
+    launcher._observe_git_remote_tip = AsyncMock(return_value="abcdef0123456789")
+
+    with patch(
+        "moonmind.auth.github_credentials.resolve_github_credential",
+        AsyncMock(
+            return_value=ResolvedGitHubCredential(
+                diagnostic="GitHub auth is unavailable for the repository."
+            )
+        ),
+    ):
+        with pytest.raises(
+            RepositoryContractError, match="REPOSITORY_CREDENTIAL_UNAVAILABLE"
+        ):
+            await launcher._ensure_repository_ready_for_launch(
+                _repository_readiness_request(
+                    publish_mode="none",
+                    skill_capabilities=["gh"],
+                ),
+                None,
+            )
+
+    launcher._observe_git_remote_tip.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -447,7 +490,7 @@ async def test_default_repository_readiness_rejects_missing_or_changed_remote_ti
 
     with patch(
         "moonmind.auth.github_credentials.resolve_github_credential",
-        AsyncMock(return_value=object()),
+        AsyncMock(return_value=ResolvedGitHubCredential(token="test-token")),
     ):
         with pytest.raises(
             RepositoryContractError, match="REPOSITORY_REMOTE_TIP_MISMATCH"

--- a/tests/unit/workflows/executions/test_repository_contract.py
+++ b/tests/unit/workflows/executions/test_repository_contract.py
@@ -4,9 +4,10 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from moonmind.auth.github_credentials import ResolvedGitHubCredential
 from moonmind.workflows.executions.repository_contract import (
-    CapabilityReadinessRegistry,
     DEFAULT_GIT_CONNECTION_REF,
+    CapabilityReadinessRegistry,
     RepositoryClientEvidence,
     RepositoryClientPolicy,
     RepositoryConnection,
@@ -18,9 +19,9 @@ from moonmind.workflows.executions.repository_contract import (
     load_repository_connection,
     materialize_resolved_repository_target,
     persist_repository_connection,
+    reconcile_default_git_connection,
     repository_branch_from_value,
     repository_name_from_value,
-    reconcile_default_git_connection,
     resolve_default_git_credential,
     validate_connection_and_client,
 )
@@ -86,6 +87,11 @@ def test_repository_projection_helpers_support_scalar_and_structured_values() ->
 
     assert repository_name_from_value(" owner/repo ") == "owner/repo"
     assert repository_name_from_value(target) == "MoonLadderStudios/MoonMind"
+    assert (
+        repository_name_from_value(target, provider="git")
+        == "MoonLadderStudios/MoonMind"
+    )
+    assert repository_name_from_value(target, provider="lore") == ""
     assert repository_branch_from_value(target) == "feature/repository-target"
 
 
@@ -408,7 +414,7 @@ async def test_coherent_readiness_boundary_completes_before_mutation() -> None:
     registry = CapabilityReadinessRegistry()
     for token in ("git", "repo.read", "repo.write", "repo.branch.write", "gh"):
         registry.register(token, lambda _context: True)
-    credential = AsyncMock(return_value=object())
+    credential = AsyncMock(return_value=ResolvedGitHubCredential(token="test-token"))
     remote_tip = AsyncMock(return_value=True)
 
     resolved = await ensure_repository_ready(
@@ -458,3 +464,46 @@ async def test_readiness_boundary_fails_before_resolver_for_unknown_token() -> N
             credential_resolver=credential,
         )
     credential.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_readiness_boundary_rejects_unresolved_github_credential() -> None:
+    target = compile_repository_target(
+        {
+            "provider": "git",
+            "repository": {"name": "owner/repo"},
+            "branch": {"name": "main"},
+        }
+    )
+    connection = reconcile_default_git_connection(client_policy=_policy())
+    evidence = RepositoryClientEvidence(
+        toolBundleRef="tool-bundle:git-2.46",
+        clientVersion="2.46.0",
+        executableSha256="sha256:git",
+    )
+    registry = CapabilityReadinessRegistry()
+    registry.register("git", lambda _context: True)
+    registry.register("repo.read", lambda _context: True)
+    registry.register("gh", lambda _context: True)
+    remote_tip = AsyncMock(return_value=True)
+
+    with pytest.raises(
+        RepositoryContractError, match="REPOSITORY_CREDENTIAL_UNAVAILABLE"
+    ):
+        await ensure_repository_ready(
+            target,
+            publish_mode="none",
+            operation="read",
+            skill_capabilities=("gh",),
+            connection_resolver=lambda _target: connection,
+            evidence_resolver=lambda _connection: evidence,
+            readiness_registry=registry,
+            credential_resolver=AsyncMock(
+                return_value=ResolvedGitHubCredential(
+                    diagnostic="GitHub auth is unavailable for the repository."
+                )
+            ),
+            remote_tip_verifier=remote_tip,
+        )
+
+    remote_tip.assert_not_awaited()

--- a/tests/unit/workflows/temporal/test_run_artifacts.py
+++ b/tests/unit/workflows/temporal/test_run_artifacts.py
@@ -173,6 +173,7 @@ def test_initialize_from_payload_projects_canonical_repository_target(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     workflow = MoonMindRunWorkflow()
+    workflow._canonical_git_repository_projection_enabled = True
     monkeypatch.setattr(run_workflow_module.workflow, "memo", lambda: {})
     monkeypatch.setattr(
         MoonMindRunWorkflow,
@@ -196,6 +197,37 @@ def test_initialize_from_payload_projects_canonical_repository_target(
     )
 
     assert workflow._repo == "MoonLadderStudios/Tactics"
+
+
+def test_initialize_from_payload_does_not_project_lore_target_to_github_repo(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workflow = MoonMindRunWorkflow()
+    workflow._canonical_git_repository_projection_enabled = True
+    monkeypatch.setattr(run_workflow_module.workflow, "memo", lambda: {})
+    monkeypatch.setattr(
+        MoonMindRunWorkflow,
+        "_trusted_owner_metadata",
+        lambda self: ("user", "owner-1"),
+    )
+
+    workflow._initialize_from_payload(
+        {
+            "workflowType": "MoonMind.UserWorkflow",
+            "initialParameters": {
+                "repo": "must-not-be-used-as-a-github-repository",
+                "repository": {
+                    "provider": "lore",
+                    "connectionRef": "repository-connection:tactics",
+                    "repository": {"name": "tactics-id"},
+                    "branch": {"name": "Main"},
+                },
+                "workflow": {"instructions": "Prepare a Lore review request."},
+            },
+        }
+    )
+
+    assert workflow._repo is None
 
 
 def test_initialize_from_payload_tracks_declared_dependencies(

--- a/tests/unit/workflows/temporal/test_run_artifacts.py
+++ b/tests/unit/workflows/temporal/test_run_artifacts.py
@@ -166,6 +166,37 @@ def test_initialize_from_payload_captures_input_and_plan_refs(
     assert plan_ref == "art_plan_1"
     assert workflow._input_ref == "art_input_1"
     assert workflow._plan_ref == "art_plan_1"
+    assert workflow._repo == "MoonLadderStudios/MoonMind"
+
+
+def test_initialize_from_payload_projects_canonical_repository_target(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workflow = MoonMindRunWorkflow()
+    monkeypatch.setattr(run_workflow_module.workflow, "memo", lambda: {})
+    monkeypatch.setattr(
+        MoonMindRunWorkflow,
+        "_trusted_owner_metadata",
+        lambda self: ("user", "owner-1"),
+    )
+
+    workflow._initialize_from_payload(
+        {
+            "workflowType": "MoonMind.UserWorkflow",
+            "initialParameters": {
+                "repository": {
+                    "provider": "git",
+                    "connectionRef": "repository-connection:git-default",
+                    "repository": {"name": "MoonLadderStudios/Tactics"},
+                    "branch": {"name": "main"},
+                },
+                "workflow": {"instructions": "Resolve GitHub issues."},
+            },
+        }
+    )
+
+    assert workflow._repo == "MoonLadderStudios/Tactics"
+
 
 def test_initialize_from_payload_tracks_declared_dependencies(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit/workflows/temporal/test_run_replayer.py
+++ b/tests/unit/workflows/temporal/test_run_replayer.py
@@ -505,6 +505,55 @@ async def test_workflow_determinism_replay(mock_run_environment):  # noqa: F811
             await replayer.replay_workflow(history)
 
 
+@pytest.mark.asyncio
+async def test_repository_target_input_shapes_execute_and_replay(
+    mock_run_environment,  # noqa: F811
+) -> None:
+    """Canonical repository targets run while legacy scalar histories still replay."""
+
+    repository_parameters = [
+        {"repository": "MoonLadderStudios/Tactics"},
+        {
+            "repository": {
+                "provider": "git",
+                "connectionRef": "repository-connection:git-default",
+                "repository": {"name": "MoonLadderStudios/Tactics"},
+                "branch": {"name": "main"},
+            }
+        },
+    ]
+    histories = []
+
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        for index, initial_parameters in enumerate(repository_parameters):
+            task_queue = f"test-repository-target-replay-{index}"
+            async with Worker(
+                env.client,
+                task_queue=task_queue,
+                workflows=[MoonMindUserWorkflow],
+                workflow_runner=UnsandboxedWorkflowRunner(),
+            ):
+                handle = await env.client.start_workflow(
+                    MoonMindUserWorkflow.run,
+                    {
+                        "workflow_type": "MoonMind.UserWorkflow",
+                        "initial_parameters": initial_parameters,
+                        "plan_artifact_ref": "ref-123",
+                    },
+                    id=f"test-repository-target-history-{index}",
+                    task_queue=task_queue,
+                )
+                assert (await handle.result())["status"] == "success"
+                histories.append(await handle.fetch_history())
+
+    replayer = Replayer(
+        workflows=[MoonMindUserWorkflow],
+        workflow_runner=UnsandboxedWorkflowRunner(),
+    )
+    for history in histories:
+        await replayer.replay_workflow(history)
+
+
 def test_plan_routed_moonspec_patch_is_snapshotted_before_node_execution() -> None:
     """MoonLadderStudios/MoonMind#3238 keeps the cutover replay-stable."""
 

--- a/tests/unit/workflows/temporal/test_run_replayer.py
+++ b/tests/unit/workflows/temporal/test_run_replayer.py
@@ -5,9 +5,12 @@ from typing import Any
 import pytest
 from temporalio import activity, workflow
 from temporalio.testing import WorkflowEnvironment
-from temporalio.worker import Worker, UnsandboxedWorkflowRunner, Replayer
+from temporalio.worker import Replayer, UnsandboxedWorkflowRunner, Worker
 
 from moonmind.omnigent.cutover import CutoverPhase, select_runtime
+from moonmind.workflows.executions.repository_contract import (
+    repository_name_from_value,
+)
 from moonmind.workflows.skills.approval_policy import StepGateResult
 from moonmind.workflows.temporal.remediation_loop import (
     ConsumedRemediationBudgets,
@@ -18,21 +21,22 @@ from moonmind.workflows.temporal.remediation_loop import (
 )
 from moonmind.workflows.temporal.workflows.agent_run import MoonMindAgentRun
 from moonmind.workflows.temporal.workflows.run import (
-    GateTransitionDecision,
     RUN_BOUNDED_STORY_LOOP_FEEDBACK_PROGRESS_PATCH,
     RUN_BOUNDED_STORY_LOOP_PROGRESS_BUDGET_PATCH,
+    RUN_CANONICAL_GIT_REPOSITORY_PROJECTION_PATCH,
     RUN_CANONICAL_NO_COMMIT_OUTCOME_PATCH,
     RUN_MANAGED_SESSION_CHECKPOINT_LOCATOR_PATCH,
     RUN_MOONSPEC_TITLE_REMEDIATION_DETECTION_PATCH,
     RUN_OMNIGENT_AUTHORED_SELECTION_COMPILER_PATCH,
     RUN_PLAN_ROUTED_MOONSPEC_REMEDIATION_PATCH,
-    RUN_REMEDIATION_MANAGED_SESSION_SOURCE_IDENTITY_PATCH,
     RUN_REMEDIATION_CONTINUE_MANAGED_SESSION_PATCH,
     RUN_REMEDIATION_LOOP_ARTIFACT_REF_NORMALIZATION_PATCH,
     RUN_REMEDIATION_LOOP_CONTINUE_AS_NEW_PATCH,
+    RUN_REMEDIATION_MANAGED_SESSION_SOURCE_IDENTITY_PATCH,
     RUN_REFRESH_MOONSPEC_BLOCK_AFTER_REMEDIATION_DECISION_PATCH,
     RUN_WORKFLOW_HEADLESS_REMEDIATION_PATCH,
     RUN_WORKFLOW_OWNED_REMEDIATION_HEAD_PATCH,
+    GateTransitionDecision,
     MoonMindRunWorkflow,
     MoonMindUserWorkflow,
 )
@@ -383,6 +387,22 @@ class _CurrentCanonicalNoCommitReplayFixture:
         return [run_workflow._publish_status, status, publish_failure]
 
 
+@workflow.defn(name="MMCanonicalGitRepositoryProjectionReplayFixture")
+class _LegacyCanonicalGitRepositoryProjectionReplayFixture:
+    @workflow.run
+    async def run(self, _repository: dict[str, Any]) -> str:
+        return ""
+
+
+@workflow.defn(name="MMCanonicalGitRepositoryProjectionReplayFixture")
+class _CurrentCanonicalGitRepositoryProjectionReplayFixture:
+    @workflow.run
+    async def run(self, repository: dict[str, Any]) -> str:
+        if not workflow.patched(RUN_CANONICAL_GIT_REPOSITORY_PROJECTION_PATCH):
+            return ""
+        return repository_name_from_value(repository, provider="git")
+
+
 @workflow.defn(name="MM3453OmnigentCompilerReplayFixture")
 class _LegacyOmnigentCompilerReplayFixture:
     @workflow.run
@@ -552,6 +572,64 @@ async def test_repository_target_input_shapes_execute_and_replay(
     )
     for history in histories:
         await replayer.replay_workflow(history)
+
+
+@pytest.mark.asyncio
+async def test_canonical_repository_projection_pre_and_post_patch_histories_replay(
+) -> None:
+    repository = {
+        "provider": "git",
+        "connectionRef": "repository-connection:git-default",
+        "repository": {"name": "MoonLadderStudios/Tactics"},
+        "branch": {"name": "main"},
+    }
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        async with Worker(
+            env.client,
+            task_queue="test-canonical-repository-projection-legacy",
+            workflows=[_LegacyCanonicalGitRepositoryProjectionReplayFixture],
+            workflow_runner=UnsandboxedWorkflowRunner(),
+        ):
+            legacy = await env.client.start_workflow(
+                _LegacyCanonicalGitRepositoryProjectionReplayFixture.run,
+                repository,
+                id="test-canonical-repository-projection-legacy",
+                task_queue="test-canonical-repository-projection-legacy",
+            )
+            assert await legacy.result() == ""
+            legacy_history = await legacy.fetch_history()
+
+        async with Worker(
+            env.client,
+            task_queue="test-canonical-repository-projection-current",
+            workflows=[_CurrentCanonicalGitRepositoryProjectionReplayFixture],
+            workflow_runner=UnsandboxedWorkflowRunner(),
+        ):
+            current = await env.client.start_workflow(
+                _CurrentCanonicalGitRepositoryProjectionReplayFixture.run,
+                repository,
+                id="test-canonical-repository-projection-current",
+                task_queue="test-canonical-repository-projection-current",
+            )
+            assert await current.result() == "MoonLadderStudios/Tactics"
+            current_history = await current.fetch_history()
+
+    replayer = Replayer(
+        workflows=[_CurrentCanonicalGitRepositoryProjectionReplayFixture],
+        workflow_runner=UnsandboxedWorkflowRunner(),
+    )
+    await replayer.replay_workflow(legacy_history)
+    await replayer.replay_workflow(current_history)
+
+
+def test_canonical_repository_projection_patch_is_snapshotted_before_input_parse(
+) -> None:
+    source = inspect.getsource(MoonMindRunWorkflow.run)
+    patch_name = "RUN_CANONICAL_GIT_REPOSITORY_PROJECTION_PATCH"
+
+    assert RUN_CANONICAL_GIT_REPOSITORY_PROJECTION_PATCH.endswith("-v1")
+    assert source.count(patch_name) == 1
+    assert source.index(patch_name) < source.index("_initialize_from_payload")
 
 
 def test_plan_routed_moonspec_patch_is_snapshotted_before_node_execution() -> None:


### PR DESCRIPTION
## What changed

- Normalize canonical provider-scoped repository targets before launching Temporal user workflows.
- Allow Skills that declare `gh` to pass runtime readiness independently of pull-request publish mode.
- Add workflow-boundary, replay, API, and launcher regression coverage.

## Why

A batch workflow failed immediately because its canonical repository object reached a scalar-only parser. After correcting that boundary, the same run exposed an independent readiness gate that rejected a read-only GitHub CLI dependency unless PR publishing was enabled.

## Verification

- `./tools/test_unit.sh tests/unit/services/temporal/runtime/test_launcher.py tests/unit/workflows/temporal/test_run_artifacts.py tests/unit/workflows/temporal/test_run_replayer.py::test_repository_target_input_shapes_execute_and_replay tests/unit/api/routers/test_executions.py::test_create_task_shaped_execution_accepts_provider_repository_for_resolvers --python-only`
- 186 tests passed on the latest `origin/main`.
- A production-shaped rerun completed and queued all 17 expected child workflows.