### PR TITLE
Complete Omnigent agent profiles — MoonLadderStudios/MoonMind#3517

### DIFF
--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -11953,6 +11953,24 @@ async def create_remediation_checkpoint_branch(
     instruction_ref, instruction_digest = _instruction_identity(payload.instructions)
     branch_id = _new_checkpoint_branch_id()
     branch_turn_id = _new_checkpoint_branch_turn_id()
+    agent_profile_snapshot = None
+    if payload.agent_profile is not None:
+        selection = dict(payload.agent_profile)
+        if payload.provider_profile_ref:
+            selected_ref = selection.get("providerProfileRef")
+            if selected_ref and selected_ref != payload.provider_profile_ref:
+                raise HTTPException(
+                    status_code=status.HTTP_409_CONFLICT,
+                    detail="agent profile and branch Provider Profile selections conflict",
+                )
+            selection["providerProfileRef"] = payload.provider_profile_ref
+        agent_profile_snapshot = await resolve_agent_profile_snapshot(
+            session,
+            selection=selection,
+            consumer_type="checkpoint",
+            consumer_id=branch_id,
+            user=user,
+        )
     await _prepare_checkpoint_branch_launch(
         session=session,
         record=target_record,
@@ -13447,6 +13465,15 @@ async def create_checkpoint_branch(
             "runtimeContextPolicy": payload.runtime_context_policy,
             "publishMode": payload.publish_mode,
             "gitWorkBranch": payload.git_work_branch,
+            "agentProfile": (
+                {
+                    "profileId": agent_profile_snapshot["profileId"],
+                    "version": agent_profile_snapshot["version"],
+                    "digest": agent_profile_snapshot["digest"],
+                }
+                if agent_profile_snapshot else None
+            ),
+            "agentProfileSnapshot": agent_profile_snapshot,
         },
     }
     session.add(

--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -24,6 +24,7 @@ from functools import lru_cache
 from fastapi import APIRouter, Body, Depends, HTTPException, Query, Request, Response, status
 from pydantic import (
     BaseModel,
+    ConfigDict,
     Field,
     ValidationError,
     field_validator,

--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -58,6 +58,9 @@ from api_service.db.models import (
     WorkflowCheckpointBranchTurn,
 )
 from api_service.services.checkpoint_branches import prepare_checkpoint_branch_workspace
+from api_service.services.omnigent_agent_profile_selection import (
+    resolve_agent_profile_snapshot,
+)
 from api_service.services.control_stop_continuation import (
     SqlControlStopContinuationRepository,
     TemporalControlStopContinuationStarter,
@@ -7810,6 +7813,7 @@ def _normalize_task_steps(task_payload: dict[str, Any]) -> list[dict[str, Any]]:
         "model",
         "effort",
         "providerProfile",
+        "agentProfile",
         "profileId",
         "repository",
         "repo",
@@ -10685,6 +10689,52 @@ async def _create_execution_from_workflow_request(
         )
     initial_parameters = skill_validation.parameters
 
+    # Reserve the canonical identity before launch so profile readiness and the
+    # immutable effective snapshot are persisted in the same transaction as the
+    # execution record.  A failed resolution never starts Temporal work.
+    reserved_workflow_id = f"mm:{uuid4()}"
+    agent_profile_selection = payload.get("agentProfile")
+    if agent_profile_selection is None and isinstance(runtime_payload, Mapping):
+        agent_profile_selection = runtime_payload.get("agentProfile")
+    if agent_profile_selection is not None:
+        if canonical_target_runtime != "omnigent":
+            raise _invalid_workflow_request(
+                "agentProfile is supported only for targetRuntime='omnigent'."
+            )
+        if not isinstance(agent_profile_selection, Mapping):
+            raise _invalid_workflow_request("agentProfile must be an object.")
+        profile_snapshot = await resolve_agent_profile_snapshot(
+            session,
+            selection=agent_profile_selection,
+            consumer_type=("remediation" if task_payload.get("remediation") else "workflow"),
+            consumer_id=reserved_workflow_id,
+            user=user,
+        )
+        initial_parameters["agentProfileSnapshot"] = profile_snapshot
+        initial_parameters["agentProfile"] = {
+            "profileId": profile_snapshot["profileId"],
+            "version": profile_snapshot["version"],
+            "digest": profile_snapshot["digest"],
+        }
+        effective_profile = profile_snapshot["document"]
+        effective_model = effective_profile.get("model") or {}
+        initial_parameters["profileId"] = profile_snapshot["providerProfileRef"]
+        if effective_model.get("model") is not None:
+            initial_parameters["model"] = effective_model["model"]
+        if effective_model.get("effort") is not None:
+            initial_parameters["effort"] = effective_model["effort"]
+        initial_parameters["omnigent"] = {
+            **dict(initial_parameters.get("omnigent") or {}),
+            "agentProfileRef": (
+                f"{profile_snapshot['profileId']}@{profile_snapshot['version']}"
+            ),
+            "executionProfileRef": profile_snapshot["executionProfileRef"],
+            "launchPolicyRef": profile_snapshot["policyRef"],
+        }
+        initial_parameters["rag"] = effective_profile.get("rag") or {}
+        initial_parameters["capture"] = effective_profile.get("capture") or {}
+        initial_parameters["workspace"] = effective_profile.get("workspace") or {}
+
     try:
         start_contract = resolve_user_workflow_start_contract(settings.temporal)
         record = await service.create_execution(
@@ -10703,6 +10753,7 @@ async def _create_execution_from_workflow_request(
             summary=_derive_workflow_summary(task_payload, input_artifact_ref),
             start_delay=start_delay,
             scheduled_for=scheduled_for_dt,
+            _workflow_id=reserved_workflow_id,
         )
     except TemporalExecutionValidationError as exc:
         message = str(exc)
@@ -11270,6 +11321,11 @@ async def _handle_recurring_schedule(
         request_payload,
         runtime_metadata=runtime_metadata,
     )
+    agent_profile_selection = request_payload.get("agentProfile")
+    if agent_profile_selection is not None and not isinstance(
+        agent_profile_selection, Mapping
+    ):
+        raise _invalid_workflow_request("agentProfile must be an object.")
     try:
         definition = await svc.create_definition(
             name=schedule.name or "Inline schedule",
@@ -11283,6 +11339,8 @@ async def _handle_recurring_schedule(
             owner_user_id=user.id,
             target=target,
             policy=schedule.policy,
+            agent_profile_selection=agent_profile_selection,
+            actor=user,
         )
     except RecurringWorkflowValidationError as exc:
         raise HTTPException(
@@ -11437,6 +11495,7 @@ async def create_remediation_execution(
         "publish_mode",
         "profileId",
         "providerProfile",
+        "agentProfile",
         "idempotencyKey",
         "schedule",
         "runtimeInheritance",

--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -11931,6 +11931,8 @@ async def create_remediation_checkpoint_branch(
             "runtimeContextPolicy": runtime_context_policy,
             "gitWorkBranch": payload.gitWorkBranch,
             "maxBudgetUsd": payload.maxBudgetUsd,
+            "providerProfileRef": payload.provider_profile_ref,
+            "agentProfile": payload.agent_profile,
         }
     )
     existing_op = await session.execute(

--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -15,7 +15,7 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any, Literal, Optional
 from urllib.parse import quote, urlsplit
-from uuid import uuid4
+from uuid import NAMESPACE_URL, uuid4, uuid5
 
 logger = logging.getLogger(__name__)
 
@@ -10699,7 +10699,14 @@ async def _create_execution_from_workflow_request(
     # Reserve the canonical identity before launch so profile readiness and the
     # immutable effective snapshot are persisted in the same transaction as the
     # execution record.  A failed resolution never starts Temporal work.
-    reserved_workflow_id = f"mm:{uuid4()}"
+    create_idempotency_key = str(
+        task_payload.get("idempotencyKey") or payload.get("idempotencyKey") or ""
+    ).strip()
+    reserved_workflow_id = (
+        f"mm:{uuid5(NAMESPACE_URL, f'{user.id}:user-workflow:{create_idempotency_key}')}"
+        if create_idempotency_key
+        else f"mm:{uuid4()}"
+    )
     agent_profile_selection = payload.get("agentProfile")
     if agent_profile_selection is None and isinstance(runtime_payload, Mapping):
         agent_profile_selection = runtime_payload.get("agentProfile")
@@ -10736,7 +10743,8 @@ async def _create_execution_from_workflow_request(
                 f"{profile_snapshot['profileId']}@{profile_snapshot['version']}"
             ),
             "executionProfileRef": profile_snapshot["executionProfileRef"],
-            "launchPolicyRef": profile_snapshot["policyRef"],
+            "launchPolicyRef": profile_snapshot["launchPolicyRef"],
+            "agent": {"agentId": profile_snapshot["agentId"]},
         }
         initial_parameters["rag"] = effective_profile.get("rag") or {}
         initial_parameters["capture"] = effective_profile.get("capture") or {}

--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -678,6 +678,8 @@ class PublicationRecoveryResponse(BaseModel):
     rolloutGeneration: str
 
 class RemediationCheckpointBranchRepairRequest(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
     checkpointRef: str
     instructions: CheckpointBranchInstructionsModel
     idempotencyKey: str = Field(..., min_length=1, max_length=512)
@@ -690,6 +692,10 @@ class RemediationCheckpointBranchRepairRequest(BaseModel):
     runtimeContextPolicy: Literal["fresh_agent_run"] = "fresh_agent_run"
     gitWorkBranch: str | None = None
     maxBudgetUsd: float | None = None
+    provider_profile_ref: str | None = Field(
+        None, alias="providerProfileRef", min_length=1, max_length=255
+    )
+    agent_profile: dict[str, Any] | None = Field(None, alias="agentProfile")
 _PROTECTED_BRANCH_REFS = {"head", "main", "master", "develop", "trunk", "prod", "production"}
 _SAFE_PROMOTION_SIDE_EFFECT_STATES = {
     "none",
@@ -12008,6 +12014,22 @@ async def create_remediation_checkpoint_branch(
         "remediationWorkflowId": workflow_id,
         "remediationContextRef": link.context_artifact_ref,
         "repairActionKind": "checkpoint_branch.create_from_remediation_context",
+        "runtimeSelection": {
+            "providerProfileRef": payload.provider_profile_ref,
+            "runtimeContextPolicy": runtime_context_policy,
+            "publishMode": "none",
+            "gitWorkBranch": payload.gitWorkBranch,
+            "agentProfile": (
+                {
+                    "profileId": agent_profile_snapshot["profileId"],
+                    "version": agent_profile_snapshot["version"],
+                    "digest": agent_profile_snapshot["digest"],
+                }
+                if agent_profile_snapshot
+                else None
+            ),
+            "agentProfileSnapshot": agent_profile_snapshot,
+        },
     }
     session.add(
         WorkflowCheckpointBranchOperation(
@@ -12029,6 +12051,9 @@ async def create_remediation_checkpoint_branch(
                     "actionKind": "checkpoint_branch.create_from_remediation_context",
                     "runtimeContextPolicy": runtime_context_policy,
                 },
+                "runtimeSelection": dict(
+                    branch.diagnostics.get("runtimeSelection") or {}
+                ),
             },
         )
     )
@@ -13419,6 +13444,24 @@ async def create_checkpoint_branch(
     instruction_ref, instruction_digest = _instruction_identity(payload.instructions)
     branch_id = _new_checkpoint_branch_id()
     branch_turn_id = _new_checkpoint_branch_turn_id()
+    agent_profile_snapshot = None
+    if payload.agent_profile is not None:
+        selection = dict(payload.agent_profile)
+        if payload.provider_profile_ref:
+            selected_ref = selection.get("providerProfileRef")
+            if selected_ref and selected_ref != payload.provider_profile_ref:
+                raise HTTPException(
+                    status_code=status.HTTP_409_CONFLICT,
+                    detail="agent profile and branch Provider Profile selections conflict",
+                )
+            selection["providerProfileRef"] = payload.provider_profile_ref
+        agent_profile_snapshot = await resolve_agent_profile_snapshot(
+            session,
+            selection=selection,
+            consumer_type="checkpoint",
+            consumer_id=branch_id,
+            user=user,
+        )
     await _prepare_checkpoint_branch_launch(
         session=session,
         record=record,

--- a/api_service/api/routers/omnigent_agent_profiles.py
+++ b/api_service/api/routers/omnigent_agent_profiles.py
@@ -37,6 +37,10 @@ from api_service.services.omnigent_agent_profile_service import (
     projection_readiness,
     synchronize_upstream_inventory,
 )
+from api_service.services.omnigent_agent_bundle_service import (
+    BundleValidationError,
+    publish_validated_agent_bundle,
+)
 from api_service.api.routers.temporal_artifacts import _get_temporal_artifact_service
 from api_service.services.omnigent_agent_smoke_service import (
     DEFAULT_SMOKE_TIMEOUT_SECONDS,
@@ -197,6 +201,9 @@ class ValidateCreate(BaseModel):
 class SmokeCreate(BaseModel):
     version: int | None = Field(None, ge=1)
 
+class BundleImportCreate(BaseModel):
+    version: int | None = Field(None, ge=1)
+
 def _assert_owner(profile: OmnigentAgentProfile, user: User) -> None:
     if profile.owner_id != user.id and not user.is_superuser:
         raise HTTPException(403, "profile owner permission required")
@@ -230,7 +237,9 @@ def _response(profile: OmnigentAgentProfile, versions: list[OmnigentAgentProfile
             "defaultForRuntime": profile.default_for_runtime, "versions": [{"version": v.version, "digest": v.digest, "document": v.document,
             "parentVersion": v.parent_version, "clonedFromProfileId": v.cloned_from_profile_id,
             "clonedFromVersion": v.cloned_from_version, "upstreamSnapshot": v.upstream_snapshot,
-            "validationResult": v.validation_result, "createdAt": v.created_at} for v in versions]}
+            "validationResult": v.validation_result,
+            "rolloutMetadata": getattr(v, "rollout_metadata", None),
+            "createdAt": v.created_at} for v in versions]}
 
 async def _load(session: AsyncSession, profile_id: str) -> tuple[OmnigentAgentProfile, list[OmnigentAgentProfileVersion]]:
     profile = await session.get(OmnigentAgentProfile, profile_id)
@@ -552,6 +561,77 @@ async def smoke_validate_profile(
             },
         )
     )
+    await session.commit()
+    return result
+
+
+@router.post("/{profile_id}/import-bundle")
+async def import_profile_bundle(
+    profile_id: str,
+    body: BundleImportCreate,
+    session: AsyncSession = Depends(get_async_session),
+    current_user: User = Depends(get_current_user()),
+    artifact_service: TemporalArtifactService = Depends(_get_temporal_artifact_service),
+    bridge_config: OmnigentBridgeConfig = Depends(_require_bridge_enabled),
+    bridge_proxy: OmnigentBridgeSessionProxy | None = Depends(_get_bridge_proxy),
+) -> dict[str, Any]:
+    """Publish one validated immutable bundle through the authorized facade."""
+
+    _require_provider_profile_permission(current_user, "provider_profiles.write")
+    profile, versions = await _load(session, profile_id)
+    _assert_owner(profile, current_user)
+    target_number = body.version or profile.active_version or (
+        versions[0].version if versions else None
+    )
+    target = next((v for v in versions if v.version == target_number), None)
+    if target is None:
+        raise HTTPException(404, "profile version not found")
+    source = target.document.get("source", {})
+    artifact_ref = str(source.get("bundleArtifactRef") or "")
+    if not artifact_ref:
+        raise HTTPException(409, "profile version is not artifact-backed")
+    if target.document.get("endpointRef") != "default":
+        raise HTTPException(409, "profile endpoint is outside the configured bridge scope")
+    if (
+        bridge_config.host_protocol_mode != "proxy"
+        or target.document.get("bridgeMode") != "proxy"
+        or bridge_proxy is None
+    ):
+        raise HTTPException(409, "bundle import requires the authorized proxy bridge mode")
+    if not target.validation_result or target.validation_result.get("ready") is not True:
+        raise HTTPException(409, "profile version must pass validation before bundle import")
+
+    artifact_id = artifact_ref.removeprefix("artifact:")
+    stored_artifact, bundle_bytes = await artifact_service.read(
+        artifact_id=artifact_id, principal=str(current_user.id)
+    )
+    filename = f"{profile_id}-v{target.version}.bundle"
+    try:
+        result = await publish_validated_agent_bundle(
+            data=bundle_bytes,
+            content_type=str(stored_artifact.content_type or "application/octet-stream"),
+            expected_digest=str(source["bundleDigest"]),
+            filename=filename,
+            publish=bridge_proxy.import_agent_bundle,
+        )
+    except (BundleValidationError, OmnigentBridgeError) as exc:
+        failure = {
+            "schemaVersion": "moonmind.omnigent-agent-bundle-import.v1",
+            "status": "failed",
+            "failureClass": (
+                exc.failure_class if isinstance(exc, OmnigentBridgeError) else "validation_error"
+            ),
+        }
+        target.rollout_metadata = {**(target.rollout_metadata or {}), "bundleImport": failure}
+        session.add(_audit(profile_id, "bundle_import_failed", current_user,
+                           version=target.version, metadata=failure))
+        await session.commit()
+        raise HTTPException(409 if isinstance(exc, BundleValidationError) else 502,
+                            "bundle import failed; see profile audit evidence") from exc
+
+    target.rollout_metadata = {**(target.rollout_metadata or {}), "bundleImport": result}
+    session.add(_audit(profile_id, "bundle_imported", current_user,
+                       version=target.version, metadata=result))
     await session.commit()
     return result
 

--- a/api_service/api/routers/omnigent_agent_profiles.py
+++ b/api_service/api/routers/omnigent_agent_profiles.py
@@ -30,7 +30,6 @@ from api_service.db.models import (
     OmnigentAgentProfileVersion,
     OmnigentUpstreamAgentProjection,
     ManagedAgentProviderProfile,
-    TemporalArtifact,
     User,
 )
 from api_service.services.omnigent_agent_profile_service import (
@@ -39,9 +38,10 @@ from api_service.services.omnigent_agent_profile_service import (
     synchronize_upstream_inventory,
 )
 from api_service.api.routers.temporal_artifacts import _get_temporal_artifact_service
-from api_service.services.omnigent_agent_bundle_service import (
-    BundleValidationError,
-    validate_agent_bundle,
+from api_service.services.omnigent_agent_smoke_service import (
+    DEFAULT_SMOKE_TIMEOUT_SECONDS,
+    run_profile_readiness_checks,
+    run_smoke_validation,
 )
 from moonmind.workflows.temporal.artifacts import TemporalArtifactService
 from moonmind.omnigent.bridge_config import (
@@ -194,6 +194,9 @@ class SnapshotCreate(BaseModel):
 class ValidateCreate(BaseModel):
     version: int | None = Field(None, ge=1)
 
+class SmokeCreate(BaseModel):
+    version: int | None = Field(None, ge=1)
+
 def _assert_owner(profile: OmnigentAgentProfile, user: User) -> None:
     if profile.owner_id != user.id and not user.is_superuser:
         raise HTTPException(403, "profile owner permission required")
@@ -259,6 +262,38 @@ async def _refresh_upstream_projection(
         bridge_mode=str(config.host_protocol_mode),
         inventory=inventory,
     )
+
+
+def _bridge_refresh(
+    session: AsyncSession,
+    *,
+    config: OmnigentBridgeConfig,
+    proxy: OmnigentBridgeSessionProxy | None,
+    embedded_facade: OmnigentEmbeddedHostProtocolFacade | None,
+):
+    """Bind the upstream-projection refresh to the readiness-check core."""
+
+    async def _refresh() -> None:
+        await _refresh_upstream_projection(
+            session, config=config, proxy=proxy, embedded_facade=embedded_facade
+        )
+
+    return _refresh
+
+
+def _artifact_bundle_reader(
+    artifact_service: TemporalArtifactService, current_user: User
+):
+    """Bind artifact-boundary bundle reads to the readiness-check core."""
+
+    async def _read(artifact_id: str) -> bytes:
+        _stored_artifact, bundle_bytes = await artifact_service.read(
+            artifact_id=artifact_id, principal=str(current_user.id)
+        )
+        return bundle_bytes
+
+    return _read
+
 
 @router.get("")
 async def list_profiles(session: AsyncSession = Depends(get_async_session), current_user: User = Depends(get_current_user())) -> list[dict[str, Any]]:
@@ -406,117 +441,119 @@ async def validate_profile(
     target = next((v for v in versions if v.version == target_number), None)
     if target is None:
         raise HTTPException(404, "profile version not found")
-    document = target.document
-    checks: list[dict[str, Any]] = []
-    source = document["source"]
-    if source.get("upstreamId"):
-        await _refresh_upstream_projection(
+    outcome = await run_profile_readiness_checks(
+        session,
+        document=target.document,
+        refresh_upstream=_bridge_refresh(
             session,
             config=bridge_config,
             proxy=bridge_proxy,
             embedded_facade=embedded_facade,
-        )
-        projection = await session.get(
-            OmnigentUpstreamAgentProjection,
-            projection_identity(
-                document["endpointRef"], source["upstreamId"],
-                source.get("upstreamVersion"),
-            ),
-        )
-        upstream_readiness = projection_readiness(
-            projection,
-            bridge_mode=document["bridgeMode"],
-            harness=document["harness"],
-            required_capabilities=document.get("requiredCapabilities", []),
-        )
-        checks.append({
-            "name": "upstream_identity",
-            **upstream_readiness,
-        })
-        target.upstream_snapshot = projection.metadata_snapshot if projection else None
-    else:
-        artifact_id = source["bundleArtifactRef"].removeprefix("artifact:")
-        artifact = await session.get(TemporalArtifact, artifact_id)
-        expected = source["bundleDigest"].removeprefix("sha256:")
-        safe_types = {
-            "application/zip", "application/x-tar", "application/gzip",
-            "application/vnd.moonmind.omnigent-agent-bundle+zip",
-        }
-        bundle_ready = bool(
-            artifact and artifact.sha256 == expected
-            and artifact.content_type in safe_types
-            and artifact.size_bytes is not None
-            and 0 < artifact.size_bytes <= 50 * 1024 * 1024
-            and artifact.created_by_principal
-        )
-        checks.append({
-            "name": "bundle_provenance", "ready": bundle_ready,
-            "reason": None if bundle_ready else
-            "bundle must resolve to a creator-attributed artifact with matching digest, safe media type, and bounded size",
-        })
-        if bundle_ready:
-            try:
-                _stored_artifact, bundle_bytes = await artifact_service.read(
-                    artifact_id=artifact_id,
-                    principal=str(current_user.id),
-                )
-                bundle_metadata = validate_agent_bundle(
-                    bundle_bytes, artifact.content_type or ""
-                )
-                declared_capabilities = set(bundle_metadata["capabilities"])
-                required_capabilities = set(document["requiredCapabilities"])
-                content_ready = (
-                    bundle_metadata["harness"] == document["harness"]
-                    and required_capabilities.issubset(declared_capabilities)
-                )
-                checks.append({
-                    "name": "bundle_contents",
-                    "ready": content_ready,
-                    "reason": None if content_ready else
-                    "bundle harness or capabilities do not satisfy the profile",
-                    "metadata": bundle_metadata,
-                })
-                target.upstream_snapshot = {
-                    "source": "artifact",
-                    "artifactRef": source["bundleArtifactRef"],
-                    "digest": source["bundleDigest"],
-                    **bundle_metadata,
-                }
-            except BundleValidationError as exc:
-                checks.append({
-                    "name": "bundle_contents", "ready": False,
-                    "reason": str(exc),
-                })
-            except Exception:
-                # Artifact authorization/storage details are intentionally not exposed.
-                checks.append({
-                    "name": "bundle_contents", "ready": False,
-                    "reason": "bundle content could not be read through the artifact boundary",
-                })
-    requirements = document["providerRequirements"]
-    providers = list((await session.execute(select(ManagedAgentProviderProfile).where(
-        ManagedAgentProviderProfile.runtime_id == requirements["runtimeId"],
-        ManagedAgentProviderProfile.enabled.is_(True),
-    ))).scalars())
-    compatible_provider = any(
-        row.credential_source.value == requirements["credentialSource"]
-        and row.runtime_materialization_mode.value == requirements["materializationMode"]
-        and (not requirements.get("providerIds") or row.provider_id in requirements["providerIds"])
-        for row in providers
+        ),
+        read_bundle_bytes=_artifact_bundle_reader(artifact_service, current_user),
     )
-    checks.append({
-        "name": "provider_profile", "ready": compatible_provider,
-        "reason": None if compatible_provider else "no enabled compatible Provider Profile",
-    })
-    ready = all(check["ready"] for check in checks)
+    target.upstream_snapshot = outcome.upstream_snapshot
     target.validation_result = {
         "schemaVersion": "moonmind.omnigent-agent-profile-validation.v1",
-        "ready": ready, "checks": checks,
+        "ready": outcome.ready, "checks": outcome.checks,
     }
     session.add(_audit(profile_id, "validated", current_user, version=target.version,
-                       metadata={"ready": ready}))
+                       metadata={"ready": outcome.ready}))
     await session.commit()
     return target.validation_result
+
+@router.post("/{profile_id}/smoke")
+async def smoke_validate_profile(
+    profile_id: str,
+    body: SmokeCreate,
+    session: AsyncSession = Depends(get_async_session),
+    current_user: User = Depends(get_current_user()),
+    artifact_service: TemporalArtifactService = Depends(_get_temporal_artifact_service),
+    bridge_config: OmnigentBridgeConfig = Depends(_require_bridge_enabled),
+    bridge_proxy: OmnigentBridgeSessionProxy | None = Depends(_get_bridge_proxy),
+    embedded_facade: OmnigentEmbeddedHostProtocolFacade | None = Depends(
+        _get_create_embedded_facade
+    ),
+) -> dict[str, Any]:
+    """Run an operator-triggered bounded smoke preflight (Sec 7).
+
+    Reuses the shared readiness checks, adds the strongest *safe* session-start
+    capability probe (bridge reachability, never a real launch), bounds the
+    whole preflight by a time budget, secret-scans diagnostics, and guarantees
+    release of any validation-owned lease. A pass is readiness evidence, not a
+    workflow-success guarantee, so it never mutates the version's activation
+    validation result.
+    """
+    _require_provider_profile_permission(current_user, "provider_profiles.write")
+    profile, versions = await _load(session, profile_id)
+    _assert_owner(profile, current_user)
+    target_number = body.version or profile.active_version or (
+        versions[0].version if versions else None
+    )
+    target = next((v for v in versions if v.version == target_number), None)
+    if target is None:
+        raise HTTPException(404, "profile version not found")
+
+    facade = (
+        embedded_facade
+        if bridge_config.host_protocol_mode == HOST_PROTOCOL_MODE_EMBEDDED
+        else bridge_proxy
+    )
+    diagnostics: list[str] = []
+
+    async def _preflight():
+        return await run_profile_readiness_checks(
+            session,
+            document=target.document,
+            refresh_upstream=_bridge_refresh(
+                session,
+                config=bridge_config,
+                proxy=bridge_proxy,
+                embedded_facade=embedded_facade,
+            ),
+            read_bundle_bytes=_artifact_bundle_reader(artifact_service, current_user),
+        )
+
+    async def _session_start_probe() -> dict[str, Any]:
+        # Strongest safe session-start capability: prove the endpoint can be
+        # reached to enumerate hosts without launching a real agent session.
+        if facade is None:
+            return {"ready": False, "reason": "Omnigent bridge is unavailable"}
+        try:
+            await facade.list_hosts()
+            return {"ready": True, "reason": None}
+        except OmnigentBridgeError as exc:
+            diagnostics.append(f"session-start probe failed: {exc}")
+            return {
+                "ready": False,
+                "reason": "bridge endpoint is not reachable for a session-start check",
+            }
+
+    result = await run_smoke_validation(
+        preflight=_preflight,
+        session_start_probe=_session_start_probe,
+        cleanup=None,  # reachability probe creates no durable session or lease
+        diagnostics=diagnostics,
+        timeout_seconds=DEFAULT_SMOKE_TIMEOUT_SECONDS,
+        profile_id=profile_id,
+        version=target.version,
+    )
+    session.add(
+        _audit(
+            profile_id, "smoke_validated", current_user, version=target.version,
+            metadata={
+                "ready": result["ready"],
+                "timedOut": result["timedOut"],
+                "durationMs": result["durationMs"],
+                "checks": [
+                    {"name": check["name"], "ready": check["ready"]}
+                    for check in result["checks"]
+                ],
+            },
+        )
+    )
+    await session.commit()
+    return result
 
 @router.post("/{profile_id}/default")
 async def make_default(profile_id: str, session: AsyncSession = Depends(get_async_session), current_user: User = Depends(get_current_user())) -> dict[str, Any]:

--- a/api_service/api/routers/omnigent_agent_profiles.py
+++ b/api_service/api/routers/omnigent_agent_profiles.py
@@ -205,6 +205,11 @@ class BundleImportCreate(BaseModel):
     version: int | None = Field(None, ge=1)
 
 def _assert_owner(profile: OmnigentAgentProfile, user: User) -> None:
+    # Ownerless workspace profiles are bootstrap/operator-managed resources.
+    # Callers have already enforced provider_profiles.write before reaching
+    # lifecycle mutations.
+    if profile.owner_id is None and profile.visibility == "workspace":
+        return
     if profile.owner_id != user.id and not user.is_superuser:
         raise HTTPException(403, "profile owner permission required")
 
@@ -601,6 +606,35 @@ async def import_profile_bundle(
     if not target.validation_result or target.validation_result.get("ready") is not True:
         raise HTTPException(409, "profile version must pass validation before bundle import")
 
+    existing_import = (target.rollout_metadata or {}).get("bundleImport") or {}
+    if existing_import.get("status") == "succeeded":
+        return existing_import
+    if existing_import.get("status") == "publishing":
+        raise HTTPException(
+            409,
+            "bundle import is already reserved; reconcile its audit evidence before retrying",
+        )
+    operation_key = f"{profile_id}@{target.version}:{source['bundleDigest']}"
+    reservation = {
+        "schemaVersion": "moonmind.omnigent-agent-bundle-import.v1",
+        "status": "publishing",
+        "idempotencyKey": operation_key,
+    }
+    target.rollout_metadata = {
+        **(target.rollout_metadata or {}),
+        "bundleImport": reservation,
+    }
+    session.add(
+        _audit(
+            profile_id,
+            "bundle_import_reserved",
+            current_user,
+            version=target.version,
+            metadata=reservation,
+        )
+    )
+    await session.commit()
+
     artifact_id = artifact_ref.removeprefix("artifact:")
     stored_artifact, bundle_bytes = await artifact_service.read(
         artifact_id=artifact_id, principal=str(current_user.id)
@@ -629,6 +663,7 @@ async def import_profile_bundle(
         raise HTTPException(409 if isinstance(exc, BundleValidationError) else 502,
                             "bundle import failed; see profile audit evidence") from exc
 
+    result = {**result, "idempotencyKey": operation_key}
     target.rollout_metadata = {**(target.rollout_metadata or {}), "bundleImport": result}
     session.add(_audit(profile_id, "bundle_imported", current_user,
                        version=target.version, metadata=result))

--- a/api_service/api/routers/omnigent_bridge.py
+++ b/api_service/api/routers/omnigent_bridge.py
@@ -26,6 +26,7 @@ from fastapi import (
 )
 from fastapi.responses import Response, StreamingResponse
 from pydantic import AliasChoices, BaseModel, ConfigDict, Field, ValidationError
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from api_service.api.execution_principal import (
     execution_principal_dependency,
@@ -34,7 +35,7 @@ from api_service.api.execution_principal import (
 from api_service.api.routers.executions import _get_service as _get_execution_service
 from api_service.api.routers.retrieval_gateway import get_capability_registry
 from api_service.auth_providers import get_current_user
-from api_service.db.base import async_session_maker
+from api_service.db.base import async_session_maker, get_async_session
 from api_service.db.models import User
 from api_service.retrieval_capabilities import RetrievalCapabilityRegistry
 from api_service.services.omnigent_agent_profile_service import (
@@ -711,6 +712,29 @@ async def _resolve_bridge_binding(
     )
 
 
+async def _get_launch_default_agent_name(
+    session: AsyncSession = Depends(get_async_session),
+) -> str | None:
+    """Resolve the durable default Omnigent agent for a proxy-mode launch.
+
+    MoonLadderStudios/MoonMind#3517 §8: an active default agent profile is the
+    durable authority; ``OMNIGENT_DEFAULT_AGENT_NAME`` is only a recorded
+    bootstrap/local-development fallback. A profile marked default but not
+    launch-ready is a conflict and fails closed at this launch boundary.
+    """
+
+    from api_service.services.omnigent_agent_bootstrap_service import (
+        BootstrapDefaultConflictError,
+        resolve_default_agent_selection,
+    )
+
+    try:
+        resolution = await resolve_default_agent_selection(session)
+    except BootstrapDefaultConflictError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    return resolution.default_agent_name or None
+
+
 @router.post(
     _ROUTES.create_session,
     response_model=OmnigentSessionResponse,
@@ -727,6 +751,7 @@ async def create_omnigent_session(
     embedded_facade: OmnigentEmbeddedHostProtocolFacade | None = Depends(
         _get_create_embedded_facade
     ),
+    launch_default_agent_name: str | None = Depends(_get_launch_default_agent_name),
 ) -> dict[str, Any]:
     """Create or reuse an Omnigent-shaped session in the configured bridge mode."""
 
@@ -758,7 +783,11 @@ async def create_omnigent_session(
                 failure_class="system_error",
                 status_code=501,
             )
-        return await proxy.create_session(request=payload, binding=binding)
+        return await proxy.create_session(
+            request=payload,
+            binding=binding,
+            default_agent_name_override=launch_default_agent_name,
+        )
     except OmnigentBridgeError as exc:
         raise _http_error_from_bridge(exc) from exc
 

--- a/api_service/api/routers/recurring_workflows.py
+++ b/api_service/api/routers/recurring_workflows.py
@@ -725,6 +725,12 @@ async def create_recurring_workflow(
             owner_user_id=owner_user_id,
             target=payload.target,
             policy=payload.policy,
+            agent_profile_selection=(
+                payload.target.get("agentProfile")
+                if isinstance(payload.target.get("agentProfile"), dict)
+                else None
+            ),
+            actor=user,
         )
     except Exception as exc:  # pragma: no cover - thin mapping layer
         _log_route_exception(

--- a/api_service/main.py
+++ b/api_service/main.py
@@ -299,6 +299,38 @@ async def _sync_env_managed_secrets() -> int:
         )
         return 0
 
+
+async def _sync_omnigent_bootstrap_agent_profile() -> str | None:
+    """Materialize OMNIGENT_DEFAULT_AGENT_NAME as a durable bootstrap profile.
+
+    Section 8 of MoonLadderStudios/MoonMind#3517: when no durable Omnigent
+    agent-profile state exists yet, the environment default is materialized as
+    an explicit draft bootstrap profile version so operators can validate and
+    promote it. Durable state always wins; this is idempotent and skipped once
+    any profile exists. Kept resilient so it never blocks startup.
+    """
+
+    try:
+        from api_service.services.omnigent_agent_bootstrap_service import (
+            seed_bootstrap_agent_profile,
+        )
+
+        async with get_async_session_context() as session:
+            return await seed_bootstrap_agent_profile(session)
+    except (OperationalError, ProgrammingError, SQLAlchemyError, OSError) as exc:
+        logger.warning(
+            "Omnigent bootstrap agent profile seeding skipped until schema is ready: %s",
+            exc,
+        )
+        return None
+    except Exception as exc:  # pragma: no cover - convenience seeding, never fatal
+        logger.warning(
+            "Failed to materialize Omnigent bootstrap agent profile during startup: %s",
+            exc,
+        )
+        return None
+
+
 async def _initialize_oidc_provider(app: FastAPI):
     """Initializes the OIDC provider by fetching discovery documents if needed."""
     provider = settings.oidc.AUTH_PROVIDER
@@ -1653,6 +1685,7 @@ async def startup_event():
             await seed_bootstrap_policies(session)
     except (OperationalError, ProgrammingError, SQLAlchemyError, OSError) as exc:
         logger.warning("Omnigent policy bootstrap skipped until schema is ready: %s", exc)
+    await _sync_omnigent_bootstrap_agent_profile()
     await _sync_env_managed_secrets()
     # Embedded mode is an authority-sensitive enablement boundary. Evidence
     # refs cannot make it ready when its pinned verifier or SecretRef fails.

--- a/api_service/services/omnigent_agent_bootstrap_service.py
+++ b/api_service/services/omnigent_agent_bootstrap_service.py
@@ -188,7 +188,6 @@ async def resolve_default_agent_selection(
             )
         document = version.document or {}
         source = document.get("source", {}) if isinstance(document, dict) else {}
-        snapshot = version.upstream_snapshot or {}
         bundle_import = (version.rollout_metadata or {}).get("bundleImport") or {}
         imported_agent = bundle_import.get("upstreamAgent") or {}
         agent_id = _clean(source.get("upstreamId")) or _clean(imported_agent.get("id")) or None

--- a/api_service/services/omnigent_agent_bootstrap_service.py
+++ b/api_service/services/omnigent_agent_bootstrap_service.py
@@ -189,8 +189,15 @@ async def resolve_default_agent_selection(
         document = version.document or {}
         source = document.get("source", {}) if isinstance(document, dict) else {}
         snapshot = version.upstream_snapshot or {}
-        agent_id = _clean(source.get("upstreamId")) or None
-        agent_name = _clean(snapshot.get("name")) or agent_id
+        bundle_import = (version.rollout_metadata or {}).get("bundleImport") or {}
+        imported_agent = bundle_import.get("upstreamAgent") or {}
+        agent_id = _clean(source.get("upstreamId")) or _clean(imported_agent.get("id")) or None
+        if not agent_id:
+            raise BootstrapDefaultConflictError(
+                f"default Omnigent agent profile '{default_profile.profile_id}' "
+                "has no stable launch agent identity"
+            )
+        agent_name = agent_id
         return DefaultAgentResolution(
             source="durable_profile",
             agent_id=agent_id,

--- a/api_service/services/omnigent_agent_bootstrap_service.py
+++ b/api_service/services/omnigent_agent_bootstrap_service.py
@@ -1,0 +1,300 @@
+"""Durable bootstrap default for Omnigent agent selection (MoonLadderStudios/MoonMind#3517).
+
+Section 8 of MoonLadderStudios/MoonMind#3517 requires migrating the
+``OMNIGENT_DEFAULT_AGENT_NAME`` environment default and its single-default
+behavior into an explicit, durable, seeded bootstrap agent profile. The
+environment value is retained only as a bootstrap/local-development fallback,
+its use is recorded, durable state wins, and conflicts fail closed.
+
+This module owns two side-effect-free-by-default primitives:
+
+* :func:`resolve_default_agent_selection` — the authority that prefers the
+  durable active default profile and records env-fallback use; and
+* :func:`seed_bootstrap_agent_profile` — startup materialization of the env
+  default as an explicit draft bootstrap profile version when no durable
+  agent-profile state exists.
+
+The seeded bootstrap profile is a **draft**: activation requires bridge-backed
+validation evidence that cannot be produced offline, so an operator promotes
+the materialized version once the endpoint is reachable. Until an active
+default profile exists, the recorded environment fallback governs selection.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Mapping
+
+from sqlalchemy import func, select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from api_service.db.models import (
+    OmnigentAgentProfile,
+    OmnigentAgentProfileAuditEvent,
+    OmnigentAgentProfileVersion,
+)
+
+logger = logging.getLogger(__name__)
+
+BOOTSTRAP_PROFILE_ID = "omnigent-bootstrap-default"
+_ENV_DEFAULT_AGENT_NAME = "OMNIGENT_DEFAULT_AGENT_NAME"
+
+# Canonical Codex-via-Omnigent defaults for the materialized bootstrap version.
+# These mirror the built-in ``omnigent-codex@1`` execution path and carry no
+# runtime authority (no credentials, host paths, or launch settings).
+_BOOTSTRAP_ENDPOINT_REF = "default"
+_BOOTSTRAP_BRIDGE_MODE = "proxy"
+_BOOTSTRAP_HARNESS = "codex-native"
+_BOOTSTRAP_EXECUTION_PROFILE_REF = "omnigent-codex@1"
+_BOOTSTRAP_LAUNCH_POLICY_REF = "codex-on-demand@1"
+_BOOTSTRAP_PROVIDER_RUNTIME_ID = "codex_cli"
+_BOOTSTRAP_PROVIDER_CREDENTIAL_SOURCE = "oauth_volume"
+_BOOTSTRAP_PROVIDER_MATERIALIZATION_MODE = "oauth_home"
+_BOOTSTRAP_REQUIRED_CAPABILITIES = ["session.start"]
+
+
+class BootstrapDefaultConflictError(RuntimeError):
+    """A durable default profile exists but is not in a launch-ready state.
+
+    Sec 8 requires conflicts to fail closed rather than silently falling back
+    to the environment value.
+    """
+
+
+@dataclass(frozen=True, slots=True)
+class DefaultAgentResolution:
+    """Resolved default Omnigent agent selection and its provenance."""
+
+    source: str  # "durable_profile" | "env_fallback" | "none"
+    agent_id: str | None = None
+    agent_name: str | None = None
+    profile_id: str | None = None
+    version: int | None = None
+    used_env_fallback: bool = False
+
+    @property
+    def default_agent_name(self) -> str:
+        """Name fed into the name-based fallback resolution slot."""
+
+        return (self.agent_name or "").strip()
+
+
+def _clean(value: object | None) -> str:
+    if value is None:
+        return ""
+    return str(value).strip()
+
+
+def _env_default_agent_name(env: Mapping[str, Any] | None) -> str:
+    source = env if env is not None else os.environ
+    return _clean(source.get(_ENV_DEFAULT_AGENT_NAME))
+
+
+def _digest(document: Mapping[str, Any]) -> str:
+    encoded = json.dumps(
+        document, sort_keys=True, separators=(",", ":"), ensure_ascii=False
+    ).encode()
+    return "sha256:" + hashlib.sha256(encoded).hexdigest()
+
+
+def build_bootstrap_document(agent_name: str) -> dict[str, Any]:
+    """Build the normalized bootstrap profile document for an env agent name.
+
+    The environment provides only a stable upstream agent selector; the
+    remaining fields use the canonical Codex-via-Omnigent defaults so the
+    materialized draft is a coherent starting point an operator can validate
+    and promote. The result is the fully-normalized document form (identical
+    to what the profile API persists for an equivalent create) so digests
+    stay consistent across the system without coupling to the router models.
+    """
+
+    return {
+        "bridgeMode": _BOOTSTRAP_BRIDGE_MODE,
+        "capture": {"evidence": True, "stream": True},
+        "continuations": {"branch": True, "checkpoint": True, "remediation": True},
+        "endpointRef": _BOOTSTRAP_ENDPOINT_REF,
+        "execution": {
+            "allowedLaunchPolicyRefs": [_BOOTSTRAP_LAUNCH_POLICY_REF],
+            "defaultExecutionProfileRef": _BOOTSTRAP_EXECUTION_PROFILE_REF,
+        },
+        "harness": _BOOTSTRAP_HARNESS,
+        "model": {"settings": {}},
+        "policyRef": _BOOTSTRAP_LAUNCH_POLICY_REF,
+        "providerRequirements": {
+            "credentialSource": _BOOTSTRAP_PROVIDER_CREDENTIAL_SOURCE,
+            "materializationMode": _BOOTSTRAP_PROVIDER_MATERIALIZATION_MODE,
+            "providerIds": [],
+            "runtimeId": _BOOTSTRAP_PROVIDER_RUNTIME_ID,
+        },
+        "publish": {"mode": "none"},
+        "rag": {"followUp": {}, "initial": {}},
+        "requiredCapabilities": list(_BOOTSTRAP_REQUIRED_CAPABILITIES),
+        "schemaVersion": "moonmind.omnigent-agent-profile.v1",
+        "skills": [],
+        "source": {"upstreamId": agent_name},
+        "tools": [],
+        "workspace": {"mutation": "allowed", "requiredCapabilities": []},
+    }
+
+
+async def _load_active_version(
+    session: AsyncSession, profile: OmnigentAgentProfile
+) -> OmnigentAgentProfileVersion | None:
+    if profile.active_version is None:
+        return None
+    return await session.scalar(
+        select(OmnigentAgentProfileVersion).where(
+            OmnigentAgentProfileVersion.profile_id == profile.profile_id,
+            OmnigentAgentProfileVersion.version == profile.active_version,
+        )
+    )
+
+
+async def resolve_default_agent_selection(
+    session: AsyncSession, *, env: Mapping[str, Any] | None = None
+) -> DefaultAgentResolution:
+    """Resolve the default Omnigent agent selection, durable state first.
+
+    * A durable active profile marked ``default_for_runtime`` wins and yields
+      its stable upstream identity.
+    * A profile marked default but not active/validated is a conflict and
+      fails closed.
+    * Otherwise the ``OMNIGENT_DEFAULT_AGENT_NAME`` environment value is used
+      as a bootstrap/local-development fallback and its use is recorded.
+    """
+
+    default_profile = await session.scalar(
+        select(OmnigentAgentProfile).where(
+            OmnigentAgentProfile.default_for_runtime.is_(True)
+        )
+    )
+    if default_profile is not None:
+        if default_profile.state != "active" or default_profile.active_version is None:
+            raise BootstrapDefaultConflictError(
+                "default Omnigent agent profile "
+                f"'{default_profile.profile_id}' is marked default but is not "
+                "an active validated version"
+            )
+        version = await _load_active_version(session, default_profile)
+        if version is None:
+            raise BootstrapDefaultConflictError(
+                "default Omnigent agent profile "
+                f"'{default_profile.profile_id}' has no resolvable active version"
+            )
+        document = version.document or {}
+        source = document.get("source", {}) if isinstance(document, dict) else {}
+        snapshot = version.upstream_snapshot or {}
+        agent_id = _clean(source.get("upstreamId")) or None
+        agent_name = _clean(snapshot.get("name")) or agent_id
+        return DefaultAgentResolution(
+            source="durable_profile",
+            agent_id=agent_id,
+            agent_name=agent_name,
+            profile_id=default_profile.profile_id,
+            version=version.version,
+            used_env_fallback=False,
+        )
+
+    env_name = _env_default_agent_name(env)
+    if env_name:
+        logger.info(
+            "Omnigent default agent resolved from %s bootstrap fallback; "
+            "no durable active default profile is present",
+            _ENV_DEFAULT_AGENT_NAME,
+        )
+        return DefaultAgentResolution(
+            source="env_fallback",
+            agent_name=env_name,
+            used_env_fallback=True,
+        )
+
+    return DefaultAgentResolution(source="none")
+
+
+async def seed_bootstrap_agent_profile(
+    session: AsyncSession,
+    *,
+    env: Mapping[str, Any] | None = None,
+    now: datetime | None = None,
+) -> str | None:
+    """Materialize the env default as a draft bootstrap profile when absent.
+
+    Idempotent and fail-closed: skips when any durable agent-profile state
+    already exists (durable state wins) or when no environment default is
+    configured. Returns the seeded profile id, or ``None`` when nothing was
+    materialized.
+    """
+
+    env_name = _env_default_agent_name(env)
+    if not env_name:
+        return None
+
+    existing_count = int(
+        await session.scalar(select(func.count()).select_from(OmnigentAgentProfile))
+        or 0
+    )
+    if existing_count:
+        # Durable state already exists; never overwrite it from the env value.
+        return None
+
+    observed_at = now or datetime.now(timezone.utc)
+    document = build_bootstrap_document(env_name)
+    profile = OmnigentAgentProfile(
+        profile_id=BOOTSTRAP_PROFILE_ID,
+        display_name="Bootstrap Omnigent Default",
+        description=(
+            "Materialized from the OMNIGENT_DEFAULT_AGENT_NAME environment "
+            "default. Validate and activate this version to make it the "
+            "durable runtime default."
+        ),
+        owner_id=None,
+        visibility="workspace",
+        state="draft",
+    )
+    version = OmnigentAgentProfileVersion(
+        profile_id=BOOTSTRAP_PROFILE_ID,
+        version=1,
+        digest=_digest(document),
+        document=document,
+        created_by=None,
+        rollout_metadata={
+            "origin": "env_bootstrap",
+            "envVar": _ENV_DEFAULT_AGENT_NAME,
+            "materializedAt": observed_at.isoformat(),
+        },
+    )
+    audit = OmnigentAgentProfileAuditEvent(
+        profile_id=BOOTSTRAP_PROFILE_ID,
+        action="bootstrap_materialized",
+        version=1,
+        actor_id=None,
+        metadata_json={"origin": "env_bootstrap", "envVar": _ENV_DEFAULT_AGENT_NAME},
+    )
+    session.add_all([profile, version, audit])
+    try:
+        await session.commit()
+    except IntegrityError:
+        # A concurrent startup already seeded the bootstrap profile.
+        await session.rollback()
+        return None
+    logger.info(
+        "Materialized Omnigent bootstrap agent profile '%s' from %s",
+        BOOTSTRAP_PROFILE_ID,
+        _ENV_DEFAULT_AGENT_NAME,
+    )
+    return BOOTSTRAP_PROFILE_ID
+
+
+__all__ = [
+    "BOOTSTRAP_PROFILE_ID",
+    "BootstrapDefaultConflictError",
+    "DefaultAgentResolution",
+    "build_bootstrap_document",
+    "resolve_default_agent_selection",
+    "seed_bootstrap_agent_profile",
+]

--- a/api_service/services/omnigent_agent_bundle_service.py
+++ b/api_service/services/omnigent_agent_bundle_service.py
@@ -2,10 +2,12 @@
 from __future__ import annotations
 
 import io
+import hashlib
 import json
 import re
 import tarfile
 import zipfile
+from collections.abc import Awaitable, Callable, Mapping
 from typing import Any
 
 MAX_BUNDLE_BYTES = 50 * 1024 * 1024
@@ -121,4 +123,43 @@ def validate_agent_bundle(data: bytes, content_type: str) -> dict[str, Any]:
         "license": manifest.get("license"),
         "fileCount": len(members),
         "expandedBytes": sum(size for _, _, size in members),
+    }
+
+
+async def publish_validated_agent_bundle(
+    *,
+    data: bytes,
+    content_type: str,
+    expected_digest: str,
+    filename: str,
+    publish: Callable[..., Awaitable[Mapping[str, Any]]],
+) -> dict[str, Any]:
+    """Validate an immutable artifact, then publish it through the bridge.
+
+    The digest and archive are checked before the first upstream side effect.
+    Only stable, bounded upstream identity fields cross back into durable profile
+    evidence; arbitrary provider response content is intentionally discarded.
+    """
+
+    actual_digest = "sha256:" + hashlib.sha256(data).hexdigest()
+    if actual_digest != expected_digest:
+        raise BundleValidationError("bundle content digest does not match profile version")
+    validate_agent_bundle(data, content_type)
+    response = await publish(
+        filename=filename,
+        content=data,
+        content_type=content_type,
+    )
+    upstream_id = str(response.get("id") or response.get("agentId") or "").strip()
+    if not upstream_id:
+        raise BundleValidationError("upstream import did not return a stable agent id")
+    upstream = {"id": upstream_id[:255]}
+    for source_key, target_key in (("name", "name"), ("version", "version")):
+        value = str(response.get(source_key) or "").strip()
+        if value:
+            upstream[target_key] = value[:255]
+    return {
+        "schemaVersion": "moonmind.omnigent-agent-bundle-import.v1",
+        "status": "succeeded",
+        "upstreamAgent": upstream,
     }

--- a/api_service/services/omnigent_agent_profile_selection.py
+++ b/api_service/services/omnigent_agent_profile_selection.py
@@ -1,0 +1,132 @@
+"""Resolve immutable Omnigent agent-profile selections at authoring boundaries."""
+from __future__ import annotations
+
+import copy
+from typing import Any, Mapping
+
+from fastapi import HTTPException, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from api_service.db.models import (
+    ManagedAgentProviderProfile,
+    OmnigentAgentProfile,
+    OmnigentAgentProfileUsage,
+    OmnigentAgentProfileVersion,
+    OmnigentUpstreamAgentProjection,
+    User,
+)
+from api_service.services.omnigent_agent_profile_service import (
+    projection_identity,
+    projection_readiness,
+)
+
+_OVERRIDABLE_SECTIONS = frozenset({"model", "capture", "rag", "publish"})
+
+
+async def resolve_agent_profile_snapshot(
+    session: AsyncSession,
+    *,
+    selection: Mapping[str, Any],
+    consumer_type: str,
+    consumer_id: str,
+    user: User,
+) -> dict[str, Any]:
+    """Validate, persist, and return one launch-authoritative profile snapshot.
+
+    The caller must invoke this before committing the consumer so the usage row
+    and authored consumer are one database transaction.
+    """
+    profile_id = str(selection.get("profileId") or "").strip()
+    if not profile_id:
+        raise HTTPException(status.HTTP_422_UNPROCESSABLE_CONTENT, "agentProfile.profileId is required")
+    profile = await session.get(OmnigentAgentProfile, profile_id)
+    if profile is None or (profile.visibility == "private" and profile.owner_id != user.id):
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "agent profile not found")
+    if profile.state != "active":
+        raise HTTPException(status.HTTP_409_CONFLICT, "agent profile is not active")
+
+    requested_version = selection.get("version")
+    version_number = int(requested_version) if requested_version is not None else profile.active_version
+    version = await session.scalar(
+        select(OmnigentAgentProfileVersion).where(
+            OmnigentAgentProfileVersion.profile_id == profile_id,
+            OmnigentAgentProfileVersion.version == version_number,
+        )
+    )
+    if version is None or not version.validation_result or version.validation_result.get("ready") is not True:
+        raise HTTPException(status.HTTP_409_CONFLICT, "selected profile version is not launch ready")
+
+    document = copy.deepcopy(version.document)
+    source = document.get("source") or {}
+    upstream_snapshot = version.upstream_snapshot
+    if source.get("upstreamId"):
+        projection = await session.get(
+            OmnigentUpstreamAgentProjection,
+            projection_identity(document["endpointRef"], source["upstreamId"], source.get("upstreamVersion")),
+        )
+        readiness = projection_readiness(
+            projection,
+            bridge_mode=document["bridgeMode"],
+            harness=document["harness"],
+            required_capabilities=document.get("requiredCapabilities", []),
+        )
+        if not readiness["ready"]:
+            raise HTTPException(status.HTTP_409_CONFLICT, readiness["reason"])
+        upstream_snapshot = projection.metadata_snapshot
+
+    overrides = selection.get("overrides") or {}
+    if not isinstance(overrides, Mapping):
+        raise HTTPException(status.HTTP_422_UNPROCESSABLE_CONTENT, "agentProfile.overrides must be an object")
+    rejected = set(overrides) - _OVERRIDABLE_SECTIONS
+    if rejected:
+        raise HTTPException(
+            status.HTTP_422_UNPROCESSABLE_CONTENT,
+            f"unsupported profile overrides: {', '.join(sorted(rejected))}",
+        )
+    for key, value in overrides.items():
+        if not isinstance(value, Mapping):
+            raise HTTPException(status.HTTP_422_UNPROCESSABLE_CONTENT, f"{key} override must be an object")
+        document[key] = {**document.get(key, {}), **dict(value)}
+
+    requirements = document["providerRequirements"]
+    provider_query = select(ManagedAgentProviderProfile).where(
+            ManagedAgentProviderProfile.enabled.is_(True),
+            ManagedAgentProviderProfile.runtime_id == requirements["runtimeId"],
+            ManagedAgentProviderProfile.credential_source == requirements["credentialSource"],
+            ManagedAgentProviderProfile.runtime_materialization_mode == requirements["materializationMode"],
+        )
+    if requirements.get("providerIds"):
+        provider_query = provider_query.where(
+            ManagedAgentProviderProfile.provider_id.in_(requirements["providerIds"])
+        )
+    compatible_provider = await session.scalar(provider_query.limit(1))
+    if compatible_provider is None:
+        raise HTTPException(status.HTTP_409_CONFLICT, "no enabled compatible Provider Profile")
+
+    snapshot = {
+        "schemaVersion": "moonmind.omnigent-agent-profile-snapshot.v1",
+        "profileId": profile_id,
+        "version": version.version,
+        "digest": version.digest,
+        "document": document,
+        "providerProfileRef": compatible_provider.profile_id,
+        "executionProfileRef": document["execution"]["defaultExecutionProfileRef"],
+        "allowedLaunchPolicyRefs": document["execution"]["allowedLaunchPolicyRefs"],
+        "policyRef": document["policyRef"],
+        "upstreamSnapshot": upstream_snapshot,
+        "validationResult": version.validation_result,
+    }
+    session.add(OmnigentAgentProfileUsage(
+        consumer_type=consumer_type,
+        consumer_id=consumer_id,
+        profile_id=profile_id,
+        version=version.version,
+        digest=version.digest,
+        effective_snapshot=snapshot,
+    ))
+    await session.flush()
+    return snapshot
+
+
+__all__ = ["resolve_agent_profile_snapshot"]

--- a/api_service/services/omnigent_agent_profile_selection.py
+++ b/api_service/services/omnigent_agent_profile_selection.py
@@ -91,7 +91,18 @@ async def resolve_agent_profile_snapshot(
         raise HTTPException(status.HTTP_409_CONFLICT, "agent profile is not active")
 
     requested_version = selection.get("version")
-    version_number = int(requested_version) if requested_version is not None else profile.active_version
+    try:
+        version_number = int(requested_version) if requested_version is not None else profile.active_version
+    except (TypeError, ValueError) as exc:
+        raise HTTPException(
+            status.HTTP_422_UNPROCESSABLE_CONTENT,
+            "agentProfile.version must be a positive integer",
+        ) from exc
+    if version_number is None or version_number < 1:
+        raise HTTPException(
+            status.HTTP_422_UNPROCESSABLE_CONTENT,
+            "agentProfile.version must be a positive integer",
+        )
     version = await session.scalar(
         select(OmnigentAgentProfileVersion).where(
             OmnigentAgentProfileVersion.profile_id == profile_id,
@@ -134,6 +145,20 @@ async def resolve_agent_profile_snapshot(
             raise HTTPException(status.HTTP_422_UNPROCESSABLE_CONTENT, f"{key} override must be an object")
         document[key] = {**document.get(key, {}), **dict(value)}
 
+    # Overrides cross the same authority boundary as authored versions. Re-run
+    # the canonical document schema so unknown fields and authority-bearing
+    # values cannot enter an effective launch snapshot.
+    from api_service.api.routers.omnigent_agent_profiles import AgentProfileDocument
+    try:
+        document = AgentProfileDocument.model_validate(document).model_dump(
+            mode="json", by_alias=True, exclude_none=True
+        )
+    except Exception as exc:
+        raise HTTPException(
+            status.HTTP_422_UNPROCESSABLE_CONTENT,
+            "agentProfile overrides do not form a valid profile document",
+        ) from exc
+
     requirements = document["providerRequirements"]
     provider_query = select(ManagedAgentProviderProfile).where(
             ManagedAgentProviderProfile.enabled.is_(True),
@@ -168,6 +193,24 @@ async def resolve_agent_profile_snapshot(
             "selected Provider Profile is not launch ready or has no capacity",
         )
 
+    source = document.get("source") or {}
+    bundle_import = (version.rollout_metadata or {}).get("bundleImport") or {}
+    imported_agent = bundle_import.get("upstreamAgent") or {}
+    agent_id = str(source.get("upstreamId") or imported_agent.get("id") or "").strip()
+    if not agent_id:
+        raise HTTPException(
+            status.HTTP_409_CONFLICT,
+            "selected profile has no stable launch agent identity",
+        )
+    allowed_launch_policies = document["execution"]["allowedLaunchPolicyRefs"]
+    requested_launch_policy = str(selection.get("launchPolicyRef") or "").strip()
+    if requested_launch_policy and requested_launch_policy not in allowed_launch_policies:
+        raise HTTPException(
+            status.HTTP_422_UNPROCESSABLE_CONTENT,
+            "agentProfile.launchPolicyRef is not allowed by the selected profile",
+        )
+    launch_policy_ref = requested_launch_policy or allowed_launch_policies[0]
+
     snapshot = {
         "schemaVersion": "moonmind.omnigent-agent-profile-snapshot.v1",
         "profileId": profile_id,
@@ -177,6 +220,8 @@ async def resolve_agent_profile_snapshot(
         "providerProfileRef": compatible_provider.profile_id,
         "executionProfileRef": document["execution"]["defaultExecutionProfileRef"],
         "allowedLaunchPolicyRefs": document["execution"]["allowedLaunchPolicyRefs"],
+        "launchPolicyRef": launch_policy_ref,
+        "agentId": agent_id,
         "policyRef": document["policyRef"],
         "upstreamSnapshot": upstream_snapshot,
         "validationResult": version.validation_result,

--- a/api_service/services/omnigent_agent_profile_selection.py
+++ b/api_service/services/omnigent_agent_profile_selection.py
@@ -20,8 +20,52 @@ from api_service.services.omnigent_agent_profile_service import (
     projection_identity,
     projection_readiness,
 )
+from api_service.services.provider_profile_readiness import provider_profile_launch_ready
 
 _OVERRIDABLE_SECTIONS = frozenset({"model", "capture", "rag", "publish"})
+
+
+def _enforce_override_ceilings(
+    *, defaults: Mapping[str, Any], overrides: Mapping[str, Any]
+) -> None:
+    """Reject authored values that exceed ceilings stored in the version."""
+    rag_defaults = defaults.get("rag") or {}
+    rag_overrides = overrides.get("rag") or {}
+    for key in ("maxTokens", "maxLatencyMs"):
+        ceiling = rag_defaults.get(key)
+        requested = rag_overrides.get(key)
+        if ceiling is not None and requested is not None and requested > ceiling:
+            raise HTTPException(
+                status.HTTP_422_UNPROCESSABLE_CONTENT,
+                f"rag.{key} override exceeds the selected profile policy ceiling",
+            )
+
+    capture_defaults = defaults.get("capture") or {}
+    capture_overrides = overrides.get("capture") or {}
+    retention_ceiling = capture_defaults.get("retentionDays")
+    requested_retention = capture_overrides.get("retentionDays")
+    if (
+        retention_ceiling is not None
+        and requested_retention is not None
+        and requested_retention > retention_ceiling
+    ):
+        raise HTTPException(
+            status.HTTP_422_UNPROCESSABLE_CONTENT,
+            "capture.retentionDays override exceeds the selected profile policy ceiling",
+        )
+
+    publish_rank = {"none": 0, "draft": 1, "ready": 2, "auto": 3}
+    publish_default = (defaults.get("publish") or {}).get("mode")
+    publish_override = (overrides.get("publish") or {}).get("mode")
+    if (
+        publish_default in publish_rank
+        and publish_override in publish_rank
+        and publish_rank[publish_override] > publish_rank[publish_default]
+    ):
+        raise HTTPException(
+            status.HTTP_422_UNPROCESSABLE_CONTENT,
+            "publish.mode override exceeds the selected profile policy ceiling",
+        )
 
 
 async def resolve_agent_profile_snapshot(
@@ -84,6 +128,7 @@ async def resolve_agent_profile_snapshot(
             status.HTTP_422_UNPROCESSABLE_CONTENT,
             f"unsupported profile overrides: {', '.join(sorted(rejected))}",
         )
+    _enforce_override_ceilings(defaults=document, overrides=overrides)
     for key, value in overrides.items():
         if not isinstance(value, Mapping):
             raise HTTPException(status.HTTP_422_UNPROCESSABLE_CONTENT, f"{key} override must be an object")
@@ -100,9 +145,28 @@ async def resolve_agent_profile_snapshot(
         provider_query = provider_query.where(
             ManagedAgentProviderProfile.provider_id.in_(requirements["providerIds"])
         )
+    requested_provider_profile = str(
+        selection.get("providerProfileRef") or selection.get("providerProfileId") or ""
+    ).strip()
+    if not requested_provider_profile:
+        raise HTTPException(
+            status.HTTP_422_UNPROCESSABLE_CONTENT,
+            "agentProfile.providerProfileRef is required",
+        )
+    provider_query = provider_query.where(
+        ManagedAgentProviderProfile.profile_id == requested_provider_profile
+    )
     compatible_provider = await session.scalar(provider_query.limit(1))
     if compatible_provider is None:
-        raise HTTPException(status.HTTP_409_CONFLICT, "no enabled compatible Provider Profile")
+        raise HTTPException(
+            status.HTTP_409_CONFLICT,
+            "selected Provider Profile is not enabled or compatible",
+        )
+    if not provider_profile_launch_ready(compatible_provider):
+        raise HTTPException(
+            status.HTTP_409_CONFLICT,
+            "selected Provider Profile is not launch ready or has no capacity",
+        )
 
     snapshot = {
         "schemaVersion": "moonmind.omnigent-agent-profile-snapshot.v1",

--- a/api_service/services/omnigent_agent_smoke_service.py
+++ b/api_service/services/omnigent_agent_smoke_service.py
@@ -37,6 +37,7 @@ from api_service.services.omnigent_agent_profile_service import (
     projection_identity,
     projection_readiness,
 )
+from api_service.services.provider_profile_readiness import provider_profile_launch_ready
 from moonmind.security.outbound_scan import scan_outbound_text
 
 SMOKE_SCHEMA_VERSION = "moonmind.omnigent-agent-profile-smoke.v1"
@@ -202,7 +203,8 @@ async def run_profile_readiness_checks(
         ).scalars()
     )
     compatible_provider = any(
-        row.credential_source.value == requirements["credentialSource"]
+        provider_profile_launch_ready(row)
+        and row.credential_source.value == requirements["credentialSource"]
         and row.runtime_materialization_mode.value == requirements["materializationMode"]
         and (
             not requirements.get("providerIds")

--- a/api_service/services/omnigent_agent_smoke_service.py
+++ b/api_service/services/omnigent_agent_smoke_service.py
@@ -1,0 +1,329 @@
+"""Operator-triggered bounded smoke validation for Omnigent agent profiles.
+
+Section 7 of MoonLadderStudios/MoonMind#3517 requires a bounded preflight that
+checks endpoint reachability, the exact resolved source, capabilities, Provider
+Profile readiness, compiled policy, and the strongest *safe* session-start
+capability before an operator relies on a profile version. Diagnostics are
+bounded and secret-scanned, and cancellation/failure/timeout release only
+validation-owned leases and resources. A pass is readiness evidence, not a
+workflow-success guarantee.
+
+The readiness-check core (:func:`run_profile_readiness_checks`) is shared with
+the activation validator so both surfaces evaluate identical semantics; only
+the packaging (timeout budget, session-start probe, diagnostics scrubbing, and
+lease cleanup) is specific to smoke validation.
+"""
+from __future__ import annotations
+
+import asyncio
+import time
+from collections.abc import Awaitable, Callable, Iterable, Mapping
+from dataclasses import dataclass, field
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from api_service.db.models import (
+    ManagedAgentProviderProfile,
+    OmnigentUpstreamAgentProjection,
+    TemporalArtifact,
+)
+from api_service.services.omnigent_agent_bundle_service import (
+    BundleValidationError,
+    validate_agent_bundle,
+)
+from api_service.services.omnigent_agent_profile_service import (
+    projection_identity,
+    projection_readiness,
+)
+from moonmind.security.outbound_scan import scan_outbound_text
+
+SMOKE_SCHEMA_VERSION = "moonmind.omnigent-agent-profile-smoke.v1"
+DEFAULT_SMOKE_TIMEOUT_SECONDS = 30.0
+_MAX_DIAGNOSTIC_LINES = 32
+_MAX_DIAGNOSTIC_CHARS = 512
+_SAFE_BUNDLE_TYPES = {
+    "application/zip",
+    "application/x-tar",
+    "application/gzip",
+    "application/vnd.moonmind.omnigent-agent-bundle+zip",
+}
+_MAX_BUNDLE_ARTIFACT_BYTES = 50 * 1024 * 1024
+
+
+@dataclass(slots=True)
+class ReadinessOutcome:
+    """Result of the shared profile readiness-check core."""
+
+    checks: list[dict[str, Any]] = field(default_factory=list)
+    upstream_snapshot: dict[str, Any] | None = None
+
+    @property
+    def ready(self) -> bool:
+        return bool(self.checks) and all(check["ready"] for check in self.checks)
+
+
+@dataclass(slots=True)
+class SmokeResult:
+    """Bounded smoke-validation evidence for one profile version."""
+
+    ready: bool
+    checks: list[dict[str, Any]]
+    diagnostics: list[str]
+    duration_ms: int
+    timed_out: bool
+    upstream_snapshot: dict[str, Any] | None = None
+
+    def as_dict(self, *, profile_id: str, version: int) -> dict[str, Any]:
+        return {
+            "schemaVersion": SMOKE_SCHEMA_VERSION,
+            "profileId": profile_id,
+            "version": version,
+            "ready": self.ready,
+            "timedOut": self.timed_out,
+            "durationMs": self.duration_ms,
+            "checks": self.checks,
+            "diagnostics": self.diagnostics,
+        }
+
+
+async def run_profile_readiness_checks(
+    session: AsyncSession,
+    *,
+    document: Mapping[str, Any],
+    refresh_upstream: Callable[[], Awaitable[None]],
+    read_bundle_bytes: Callable[[str], Awaitable[bytes]],
+) -> ReadinessOutcome:
+    """Evaluate credential-free readiness for a resolved profile document.
+
+    Shared by activation validation and smoke validation so both surfaces
+    apply identical semantics. ``refresh_upstream`` synchronizes the bounded
+    upstream projection through the authenticated bridge; ``read_bundle_bytes``
+    reads an artifact-backed bundle through the artifact authorization boundary
+    (raising on unauthorized/unavailable content).
+    """
+
+    checks: list[dict[str, Any]] = []
+    upstream_snapshot: dict[str, Any] | None = None
+    source = document["source"]
+    if source.get("upstreamId"):
+        await refresh_upstream()
+        projection = await session.get(
+            OmnigentUpstreamAgentProjection,
+            projection_identity(
+                document["endpointRef"],
+                source["upstreamId"],
+                source.get("upstreamVersion"),
+            ),
+        )
+        readiness = projection_readiness(
+            projection,
+            bridge_mode=document["bridgeMode"],
+            harness=document["harness"],
+            required_capabilities=document.get("requiredCapabilities", []),
+        )
+        checks.append({"name": "upstream_identity", **readiness})
+        upstream_snapshot = projection.metadata_snapshot if projection else None
+    else:
+        artifact_id = source["bundleArtifactRef"].removeprefix("artifact:")
+        artifact = await session.get(TemporalArtifact, artifact_id)
+        expected = source["bundleDigest"].removeprefix("sha256:")
+        bundle_ready = bool(
+            artifact
+            and artifact.sha256 == expected
+            and artifact.content_type in _SAFE_BUNDLE_TYPES
+            and artifact.size_bytes is not None
+            and 0 < artifact.size_bytes <= _MAX_BUNDLE_ARTIFACT_BYTES
+            and artifact.created_by_principal
+        )
+        checks.append(
+            {
+                "name": "bundle_provenance",
+                "ready": bundle_ready,
+                "reason": None
+                if bundle_ready
+                else (
+                    "bundle must resolve to a creator-attributed artifact with "
+                    "matching digest, safe media type, and bounded size"
+                ),
+            }
+        )
+        if bundle_ready:
+            try:
+                bundle_bytes = await read_bundle_bytes(artifact_id)
+                bundle_metadata = validate_agent_bundle(
+                    bundle_bytes, artifact.content_type or ""
+                )
+                declared = set(bundle_metadata["capabilities"])
+                required = set(document.get("requiredCapabilities", []))
+                content_ready = (
+                    bundle_metadata["harness"] == document["harness"]
+                    and required.issubset(declared)
+                )
+                checks.append(
+                    {
+                        "name": "bundle_contents",
+                        "ready": content_ready,
+                        "reason": None
+                        if content_ready
+                        else "bundle harness or capabilities do not satisfy the profile",
+                        "metadata": bundle_metadata,
+                    }
+                )
+                upstream_snapshot = {
+                    "source": "artifact",
+                    "artifactRef": source["bundleArtifactRef"],
+                    "digest": source["bundleDigest"],
+                    **bundle_metadata,
+                }
+            except BundleValidationError as exc:
+                checks.append(
+                    {"name": "bundle_contents", "ready": False, "reason": str(exc)}
+                )
+            except Exception:
+                # Artifact authorization/storage details are not exposed.
+                checks.append(
+                    {
+                        "name": "bundle_contents",
+                        "ready": False,
+                        "reason": "bundle content could not be read through the artifact boundary",
+                    }
+                )
+    requirements = document["providerRequirements"]
+    providers = list(
+        (
+            await session.execute(
+                select(ManagedAgentProviderProfile).where(
+                    ManagedAgentProviderProfile.runtime_id == requirements["runtimeId"],
+                    ManagedAgentProviderProfile.enabled.is_(True),
+                )
+            )
+        ).scalars()
+    )
+    compatible_provider = any(
+        row.credential_source.value == requirements["credentialSource"]
+        and row.runtime_materialization_mode.value == requirements["materializationMode"]
+        and (
+            not requirements.get("providerIds")
+            or row.provider_id in requirements["providerIds"]
+        )
+        for row in providers
+    )
+    checks.append(
+        {
+            "name": "provider_profile",
+            "ready": compatible_provider,
+            "reason": None
+            if compatible_provider
+            else "no enabled compatible Provider Profile",
+        }
+    )
+    return ReadinessOutcome(checks=checks, upstream_snapshot=upstream_snapshot)
+
+
+def scrub_diagnostics(lines: Iterable[str]) -> list[str]:
+    """Bound and secret-scan smoke diagnostics before they are recorded.
+
+    Each line is scanned in high-security mode; any line carrying secret-like
+    material is replaced with a redacted marker so diagnostics never leak
+    credentials into audit evidence.
+    """
+
+    scrubbed: list[str] = []
+    for raw in list(lines)[:_MAX_DIAGNOSTIC_LINES]:
+        text = str(raw)[:_MAX_DIAGNOSTIC_CHARS]
+        result = scan_outbound_text(text, high_security_mode=True)
+        if result.allowed:
+            scrubbed.append(text)
+        else:
+            categories = ", ".join(sorted({f.category for f in result.findings}))
+            scrubbed.append(f"[redacted smoke diagnostic: {categories}]")
+    return scrubbed
+
+
+async def run_smoke_validation(
+    *,
+    preflight: Callable[[], Awaitable[ReadinessOutcome]],
+    session_start_probe: Callable[[], Awaitable[dict[str, Any]]],
+    cleanup: Callable[[], Awaitable[None]] | None = None,
+    diagnostics: Iterable[str] = (),
+    timeout_seconds: float = DEFAULT_SMOKE_TIMEOUT_SECONDS,
+    monotonic: Callable[[], float] | None = None,
+    profile_id: str,
+    version: int,
+) -> dict[str, Any]:
+    """Run a bounded smoke preflight, guaranteeing lease/resource cleanup.
+
+    ``preflight`` runs the shared readiness checks; ``session_start_probe`` is
+    the strongest *safe* session-start capability check (bridge reachability,
+    never a real launch). The whole preflight runs under ``timeout_seconds``;
+    on success, failure, cancellation, or timeout ``cleanup`` is always invoked
+    exactly once so only validation-owned leases and resources are released.
+    """
+
+    clock = monotonic or time.monotonic
+    started = clock()
+    extra: list[str] = []
+    checks: list[dict[str, Any]] = []
+    upstream_snapshot: dict[str, Any] | None = None
+    timed_out = False
+
+    async def _run() -> ReadinessOutcome:
+        outcome = await preflight()
+        probe = await session_start_probe()
+        outcome.checks.append({"name": "session_start", **probe})
+        return outcome
+
+    try:
+        outcome = await asyncio.wait_for(_run(), timeout=timeout_seconds)
+        checks = outcome.checks
+        upstream_snapshot = outcome.upstream_snapshot
+    except asyncio.TimeoutError:
+        timed_out = True
+        checks = [
+            {
+                "name": "smoke_timeout",
+                "ready": False,
+                "reason": "smoke validation exceeded the bounded time budget",
+            }
+        ]
+        extra.append(f"smoke validation timed out after {timeout_seconds:g}s")
+    except Exception as exc:  # noqa: BLE001 - surfaced as a failed check, not a 500
+        checks = [
+            {
+                "name": "smoke_error",
+                "ready": False,
+                "reason": "smoke validation could not complete",
+            }
+        ]
+        extra.append(f"smoke validation error: {type(exc).__name__}")
+    finally:
+        if cleanup is not None:
+            await cleanup()
+
+    # Snapshot diagnostics after the preflight so probe/preflight appends to a
+    # caller-owned mutable sink are captured before scrubbing.
+    collected = list(diagnostics) + extra
+    duration_ms = int((clock() - started) * 1000)
+    ready = (not timed_out) and bool(checks) and all(c["ready"] for c in checks)
+    result = SmokeResult(
+        ready=ready,
+        checks=checks,
+        diagnostics=scrub_diagnostics(collected),
+        duration_ms=duration_ms,
+        timed_out=timed_out,
+        upstream_snapshot=upstream_snapshot,
+    )
+    return result.as_dict(profile_id=profile_id, version=version)
+
+
+__all__ = [
+    "DEFAULT_SMOKE_TIMEOUT_SECONDS",
+    "SMOKE_SCHEMA_VERSION",
+    "ReadinessOutcome",
+    "SmokeResult",
+    "run_profile_readiness_checks",
+    "run_smoke_validation",
+    "scrub_diagnostics",
+]

--- a/api_service/services/recurring_workflows_service.py
+++ b/api_service/services/recurring_workflows_service.py
@@ -20,6 +20,10 @@ from api_service.db.models import (
     RecurringWorkflowRunTrigger,
     RecurringWorkflowScopeType,
     TemporalExecutionRecord,
+    User,
+)
+from api_service.services.omnigent_agent_profile_selection import (
+    resolve_agent_profile_snapshot,
 )
 from moonmind.workflows.recurring.cron import (
     compute_next_occurrence,
@@ -624,6 +628,8 @@ class RecurringWorkflowsService:
         owner_user_id: UUID | None,
         target: Mapping[str, Any],
         policy: Mapping[str, Any] | None,
+        agent_profile_selection: Mapping[str, Any] | None = None,
+        actor: User | None = None,
     ) -> RecurringWorkflowDefinition:
         schedule_kind = _normalize_schedule_type(schedule_type)
         cron_normalized = str(cron or "").strip()
@@ -672,6 +678,28 @@ class RecurringWorkflowsService:
         )
         self._session.add(definition)
         await self._session.flush()
+
+        if agent_profile_selection is not None:
+            if actor is None:
+                raise RecurringWorkflowValidationError(
+                    "an authenticated actor is required for agent profile selection"
+                )
+            snapshot = await resolve_agent_profile_snapshot(
+                self._session,
+                selection=agent_profile_selection,
+                consumer_type="schedule",
+                consumer_id=str(definition_id),
+                user=actor,
+            )
+            definition.target = {
+                **definition.target,
+                "agentProfile": {
+                    "profileId": snapshot["profileId"],
+                    "version": snapshot["version"],
+                    "digest": snapshot["digest"],
+                },
+                "agentProfileSnapshot": snapshot,
+            }
 
         workflow_type, workflow_input = self._workflow_bundle_for_target(
             definition_id=definition_id,

--- a/api_service/services/recurring_workflows_service.py
+++ b/api_service/services/recurring_workflows_service.py
@@ -705,7 +705,10 @@ class RecurringWorkflowsService:
             definition_id=definition_id,
             name=name_text,
             owner_user_id=owner_user_id,
-            target_payload=target_payload,
+            # Profile resolution above replaces the authored selection with the
+            # immutable launch snapshot. Build the durable schedule input from
+            # that authoritative target, not the pre-resolution request copy.
+            target_payload=definition.target,
         )
 
         try:

--- a/api_service/services/recurring_workflows_service.py
+++ b/api_service/services/recurring_workflows_service.py
@@ -691,6 +691,21 @@ class RecurringWorkflowsService:
                 consumer_id=str(definition_id),
                 user=actor,
             )
+            initial_parameters = dict(definition.target.get("initialParameters") or {})
+            initial_parameters["agentProfile"] = {
+                "profileId": snapshot["profileId"],
+                "version": snapshot["version"],
+                "digest": snapshot["digest"],
+            }
+            initial_parameters["agentProfileSnapshot"] = snapshot
+            initial_parameters["profileId"] = snapshot["providerProfileRef"]
+            initial_parameters["omnigent"] = {
+                **dict(initial_parameters.get("omnigent") or {}),
+                "agentProfileRef": f"{snapshot['profileId']}@{snapshot['version']}",
+                "executionProfileRef": snapshot["executionProfileRef"],
+                "launchPolicyRef": snapshot["launchPolicyRef"],
+                "agent": {"agentId": snapshot["agentId"]},
+            }
             definition.target = {
                 **definition.target,
                 "agentProfile": {
@@ -699,6 +714,7 @@ class RecurringWorkflowsService:
                     "digest": snapshot["digest"],
                 },
                 "agentProfileSnapshot": snapshot,
+                "initialParameters": initial_parameters,
             }
 
         workflow_type, workflow_input = self._workflow_bundle_for_target(

--- a/docs/Omnigent/AgentProfiles.md
+++ b/docs/Omnigent/AgentProfiles.md
@@ -16,10 +16,11 @@ startup and the durable active default profile is the launch-boundary authority,
 with the `OMNIGENT_DEFAULT_AGENT_NAME` fallback retained only when durable active
 state is absent (its use recorded, conflicts fail closed).
 
-Dashboard authoring selectors, transactional snapshot use by workflow and
-continuation submissions, and bundle import/publish into the upstream endpoint
-remain desired state until their corresponding production boundaries and
-controlling tests land.
+Dashboard profile management, readiness-aware workflow and schedule selectors,
+transactional immutable snapshots, bounded bundle import, smoke validation, and
+durable bootstrap authority are implemented. Checkpoint-branch and remediation
+authoring preserve the originating immutable agent-profile and Provider Profile
+selection so continuation cannot silently substitute runtime authority.
 
 ## Purpose and identities
 

--- a/docs/Omnigent/AgentProfiles.md
+++ b/docs/Omnigent/AgentProfiles.md
@@ -8,11 +8,18 @@ Issue: MoonLadderStudios/MoonMind#3517
 
 This document defines the target contract. The repository currently implements the
 persistent profile/version/audit/usage records, lifecycle API, bounded upstream
-projection, basic metadata validation, and an explicit snapshot-resolution API.
+projection, metadata and archive-content validation, an explicit snapshot-resolution
+API, an operator-triggered bounded smoke-validation endpoint with lease cleanup and
+secret-scanned diagnostics, and durable bootstrap materialization: the
+environment-derived default is seeded as an explicit draft bootstrap profile at
+startup and the durable active default profile is the launch-boundary authority,
+with the `OMNIGENT_DEFAULT_AGENT_NAME` fallback retained only when durable active
+state is absent (its use recorded, conflicts fail closed).
+
 Dashboard authoring selectors, transactional snapshot use by workflow and
-continuation submissions, archive-content inspection and import, smoke-session
-validation with lease cleanup, and durable bootstrap migration remain desired
-state until their corresponding production boundaries and controlling tests land.
+continuation submissions, and bundle import/publish into the upstream endpoint
+remain desired state until their corresponding production boundaries and
+controlling tests land.
 
 ## Purpose and identities
 

--- a/frontend/src/entrypoints/omnigent-inventory.test.tsx
+++ b/frontend/src/entrypoints/omnigent-inventory.test.tsx
@@ -88,6 +88,30 @@ describe('OmnigentInventoryPage', () => {
     expect(await screen.findByRole('button', { name: 'Activate Team Codex' })).toBeTruthy();
   });
 
+  it('creates an upstream profile through structured controls without raw JSON', async () => {
+    renderPage({
+      page: 'omnigent-inventory', apiBase: '/api', features: { omnigentAgents: true },
+      initialData: { uiEndpoints: { omnigentAgents: '/api/omnigent/api/agents' } },
+    });
+    await screen.findByText('Team Codex');
+    fireEvent.click(screen.getByRole('button', { name: 'Create from upstream or bundle' }));
+    expect(screen.queryByLabelText('Normalized profile document (JSON)')).toBeNull();
+    fireEvent.change(screen.getByLabelText('Profile id'), { target: { value: 'new-codex' } });
+    fireEvent.change(screen.getByLabelText('Display name'), { target: { value: 'New Codex' } });
+    fireEvent.change(screen.getByLabelText('Stable upstream agent id'), { target: { value: 'agent-42' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save immutable profile version' }));
+
+    await waitFor(() => expect(vi.mocked(fetch).mock.calls.some(([url, init]) =>
+      String(url) === '/api/omnigent/agent-profiles' && (init as RequestInit | undefined)?.method === 'POST')).toBe(true));
+    const call = vi.mocked(fetch).mock.calls.find(([url, init]) =>
+      String(url) === '/api/omnigent/agent-profiles' && (init as RequestInit | undefined)?.method === 'POST');
+    const body = JSON.parse(String((call?.[1] as RequestInit).body));
+    expect(body.document).toMatchObject({
+      endpointRef: 'default', source: { upstreamId: 'agent-42' }, harness: 'codex-native',
+      continuations: { checkpoint: true, branch: true, remediation: true },
+    });
+  });
+
   it('does not fetch policy actions without a capability contract', async () => {
     window.history.replaceState({}, '', '/omnigent/policies');
     renderPage({ page: 'omnigent-inventory', apiBase: '/api', features: { omnigentPolicies: false } });

--- a/frontend/src/entrypoints/omnigent-inventory.tsx
+++ b/frontend/src/entrypoints/omnigent-inventory.tsx
@@ -35,6 +35,7 @@ type AuditEvent = { eventId: string; version: number | null; type: string; actor
 type ProfileVersion = {
   version: number;
   digest: string;
+  document?: Record<string, unknown>;
   validationResult?: { ready?: boolean } | null;
 };
 type AgentProfile = {
@@ -156,6 +157,8 @@ export default function OmnigentInventoryPage({ payload }: { payload: BootPayloa
   const [selectedVersion, setSelectedVersion] = useState<PolicyVersion | null>(null);
   const [notice, setNotice] = useState('');
   const [editor, setEditor] = useState<{ mode: 'create' | 'clone' | 'version'; id: string; name: string; document: string } | null>(null);
+  const [agentEditor, setAgentEditor] = useState<{ mode: 'create' | 'clone' | 'version'; source?: AgentProfile; id: string; name: string; description: string; document: string } | null>(null);
+  const [selectedProfile, setSelectedProfile] = useState<AgentProfile | null>(null);
   const kind: InventoryKind = location.pathname === '/omnigent/policies'
     || location.pathname.startsWith('/omnigent/policies/')
     ? 'policies'
@@ -203,10 +206,10 @@ export default function OmnigentInventoryPage({ payload }: { payload: BootPayloa
       const response = await fetch(
         `/api/omnigent/agent-profiles/${encodeURIComponent(profile.profileId)}/${suffix}`,
         {
-          method: 'POST',
+          method: action === 'delete' ? 'DELETE' : 'POST',
           credentials: 'same-origin',
           headers: { 'Content-Type': 'application/json' },
-          ...(action === 'validate'
+          ...(['validate', 'smoke', 'import-bundle'].includes(action)
             ? { body: JSON.stringify({ version: profile.versions[0]?.version ?? null }) }
             : {}),
         },
@@ -214,6 +217,42 @@ export default function OmnigentInventoryPage({ payload }: { payload: BootPayloa
       if (!response.ok) throw new Error(`${action} failed (${response.status})`);
     },
     onSuccess: () => void profiles.refetch(),
+  });
+  const saveAgentProfile = useMutation({
+    mutationFn: async (draft: NonNullable<typeof agentEditor>) => {
+      const document = JSON.parse(draft.document) as Record<string, unknown>;
+      let url = '/api/omnigent/agent-profiles';
+      let body: Record<string, unknown> = { profileId: draft.id, displayName: draft.name, description: draft.description || null, visibility: 'private', document };
+      if (draft.mode === 'version') {
+        url = `/api/omnigent/agent-profiles/${encodeURIComponent(draft.source!.profileId)}/versions`;
+        body = { document };
+      } else if (draft.mode === 'clone') {
+        url = `/api/omnigent/agent-profiles/${encodeURIComponent(draft.source!.profileId)}/clone`;
+        body = { profileId: draft.id, displayName: draft.name, version: draft.source!.activeVersion || draft.source!.versions[0]?.version };
+      }
+      const response = await fetch(url, { method: 'POST', credentials: 'same-origin', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) });
+      if (!response.ok) throw new Error(`Agent profile save failed (${response.status})`);
+      return response.json();
+    },
+    onSuccess: async () => { setAgentEditor(null); await profiles.refetch(); },
+  });
+  const profileAudit = useQuery({
+    queryKey: ['omnigent-agent-profile-audit', selectedProfile?.profileId],
+    enabled: Boolean(selectedProfile),
+    queryFn: async (): Promise<Array<Record<string, unknown>>> => {
+      const response = await fetch(`/api/omnigent/agent-profiles/${encodeURIComponent(selectedProfile!.profileId)}/audit`, { credentials: 'same-origin' });
+      if (!response.ok) throw new Error(`Audit request failed (${response.status})`);
+      return response.json();
+    },
+  });
+  const profileUsage = useQuery({
+    queryKey: ['omnigent-agent-profile-usage', selectedProfile?.profileId],
+    enabled: Boolean(selectedProfile),
+    queryFn: async (): Promise<Array<Record<string, unknown>>> => {
+      const response = await fetch(`/api/omnigent/agent-profiles/${encodeURIComponent(selectedProfile!.profileId)}/usage`, { credentials: 'same-origin' });
+      if (!response.ok) throw new Error(`Usage request failed (${response.status})`);
+      return response.json();
+    },
   });
   const versions = useQuery({
     queryKey: ['omnigent-policy-versions', selected?.id],
@@ -374,12 +413,21 @@ export default function OmnigentInventoryPage({ payload }: { payload: BootPayloa
     {kind === 'agents' ? <section aria-labelledby="omnigent-profiles-heading">
       <div className="omnigent-inventory__toolbar">
         <div><p className="eyebrow">Reusable configuration</p><h2 id="omnigent-profiles-heading">Agent profiles</h2></div>
-        <button type="button" onClick={() => void profiles.refetch()} disabled={profiles.isFetching}>Refresh profiles</button>
+        <div className="actions"><button type="button" onClick={() => setAgentEditor({ mode: 'create', id: '', name: '', description: '', document: '{\n  "schemaVersion": "moonmind.omnigent-agent-profile.v1"\n}' })}>Create from upstream or bundle</button><button type="button" onClick={() => void profiles.refetch()} disabled={profiles.isFetching}>Refresh profiles</button></div>
       </div>
       <p>Immutable, validated selections used by workflows and continuations.</p>
       {profiles.isPending ? <p role="status">Loading agent profiles…</p> : null}
       {profiles.isError ? <p role="alert">{profiles.error.message}</p> : null}
       {profileAction.isError ? <p role="alert">{profileAction.error.message}</p> : null}
+      {agentEditor ? <form className="omnigent-policy-editor" onSubmit={(event) => { event.preventDefault(); saveAgentProfile.mutate(agentEditor); }}>
+        <h3>{agentEditor.mode === 'version' ? 'Edit as immutable new version' : agentEditor.mode === 'clone' ? 'Clone agent profile' : 'Create agent profile'}</h3>
+        <label><span>Profile id</span><input value={agentEditor.id} disabled={agentEditor.mode === 'version'} onChange={(event) => setAgentEditor({ ...agentEditor, id: event.target.value })} required /></label>
+        <label><span>Display name</span><input value={agentEditor.name} disabled={agentEditor.mode === 'version'} onChange={(event) => setAgentEditor({ ...agentEditor, name: event.target.value })} required /></label>
+        <label><span>Description</span><input value={agentEditor.description} disabled={agentEditor.mode !== 'create'} onChange={(event) => setAgentEditor({ ...agentEditor, description: event.target.value })} /></label>
+        {agentEditor.mode !== 'clone' ? <label><span>Normalized profile document (JSON)</span><textarea rows={18} value={agentEditor.document} onChange={(event) => setAgentEditor({ ...agentEditor, document: event.target.value })} required /></label> : null}
+        {saveAgentProfile.isError ? <p role="alert">{saveAgentProfile.error.message}</p> : null}
+        <button type="submit" disabled={saveAgentProfile.isPending}>Save immutable profile version</button><button type="button" onClick={() => setAgentEditor(null)}>Cancel</button>
+      </form> : null}
       {profiles.data?.length === 0 ? <p>No persistent agent profiles are available.</p> : null}
       {profiles.data?.length ? <div className="omnigent-inventory__table-wrap"><table>
         <thead><tr><th>Profile</th><th>Lifecycle</th><th>Version history</th><th>Readiness</th><th>Actions</th></tr></thead>
@@ -392,15 +440,29 @@ export default function OmnigentInventoryPage({ payload }: { payload: BootPayloa
             <td>{latest ? <><span>Version {latest.version}</span><small title={latest.digest}>{latest.digest.slice(0, 18)}…</small><small>{profile.versions.length} immutable version{profile.versions.length === 1 ? '' : 's'}</small></> : 'No versions'}</td>
             <td>{ready ? 'Ready' : 'Validation required'}</td>
             <td>
+              <button type="button" onClick={() => setSelectedProfile(profile)}>View details, history, diff, audit, and usage</button>
+              <button type="button" onClick={() => setAgentEditor({ mode: 'clone', source: profile, id: `${profile.profileId}-clone`, name: `${profile.displayName} clone`, description: profile.description || '', document: '{}' })}>Clone {profile.displayName}</button>
+              {latest?.document ? <button type="button" onClick={() => setAgentEditor({ mode: 'version', source: profile, id: profile.profileId, name: profile.displayName, description: profile.description || '', document: JSON.stringify(latest.document, null, 2) })}>Edit {profile.displayName} as new version</button> : null}
               <button type="button" disabled={profileAction.isPending} onClick={() => profileAction.mutate({ profile, action: 'validate' })}>Validate {profile.displayName}</button>
+              <button type="button" disabled={profileAction.isPending || !ready} onClick={() => profileAction.mutate({ profile, action: 'smoke' })}>Smoke test {profile.displayName}</button>
+              {latest?.document && (latest.document.source as { bundleArtifactRef?: unknown } | undefined)?.bundleArtifactRef ? <button type="button" disabled={profileAction.isPending} onClick={() => profileAction.mutate({ profile, action: 'import-bundle' })}>Import bundle for {profile.displayName}</button> : null}
               {ready && (profile.state !== 'active' || latest.version !== profile.activeVersion) ? <button type="button" disabled={profileAction.isPending} onClick={() => profileAction.mutate({ profile, action: 'activate' })}>Activate {profile.displayName}</button> : null}
               {profile.state === 'active' && !profile.defaultForRuntime ? <button type="button" disabled={profileAction.isPending} onClick={() => profileAction.mutate({ profile, action: 'default' })}>Make {profile.displayName} default</button> : null}
               {profile.state === 'active' ? <button type="button" disabled={profileAction.isPending} onClick={() => profileAction.mutate({ profile, action: 'disable' })}>Disable {profile.displayName}</button> : null}
               {profile.state !== 'deprecated' ? <button type="button" disabled={profileAction.isPending} onClick={() => profileAction.mutate({ profile, action: 'deprecate' })}>Deprecate {profile.displayName}</button> : null}
+              {profile.state === 'draft' ? <button type="button" className="destructive" disabled={profileAction.isPending} onClick={() => { if (window.confirm(`Delete unused draft ${profile.displayName}? This cannot be undone.`)) profileAction.mutate({ profile, action: 'delete' }); }}>Delete unused draft {profile.displayName}</button> : null}
             </td>
           </tr>;
         })}</tbody>
       </table></div> : null}
+      {selectedProfile ? <section className="card" aria-labelledby="agent-profile-detail-heading">
+        <div className="actions"><h3 id="agent-profile-detail-heading">{selectedProfile.displayName} details</h3><button type="button" onClick={() => setSelectedProfile(null)}>Close details</button></div>
+        <p><code>{selectedProfile.profileId}</code> · {selectedProfile.state} · {selectedProfile.versions.length} immutable version{selectedProfile.versions.length === 1 ? '' : 's'}</p>
+        <h4>Version history and normalized diff</h4>
+        {selectedProfile.versions.map((version, index) => <details key={version.version}><summary>Version {version.version} · {version.digest}</summary><pre>{JSON.stringify(version.document, null, 2)}</pre>{index < selectedProfile.versions.length - 1 ? <pre aria-label={`Normalized diff version ${selectedProfile.versions[index + 1]!.version} to ${version.version}`}>{JSON.stringify({ from: selectedProfile.versions[index + 1]!.document, to: version.document }, null, 2)}</pre> : null}</details>)}
+        <h4>Dependent workflows and schedules</h4>{profileUsage.isPending ? <p role="status">Loading usage…</p> : <pre>{JSON.stringify(profileUsage.data || [], null, 2)}</pre>}
+        <h4>Audit history</h4>{profileAudit.isPending ? <p role="status">Loading audit…</p> : <pre>{JSON.stringify(profileAudit.data || [], null, 2)}</pre>}
+      </section> : null}
     </section> : null}
   </div>;
 }

--- a/frontend/src/entrypoints/omnigent-inventory.tsx
+++ b/frontend/src/entrypoints/omnigent-inventory.tsx
@@ -69,7 +69,7 @@ function structuredProfileDocument(draft: AgentProfileEditor): Record<string, un
     },
     providerRequirements: {
       runtimeId: draft.providerRuntime || 'codex_cli', providerIds: [],
-      credentialSource: 'oauth', materializationMode: 'host',
+      credentialSource: 'oauth_volume', materializationMode: 'oauth_home',
     },
     workspace: { mutation: 'allowed', requiredCapabilities: [] },
     continuations: { checkpoint: true, branch: true, remediation: true },

--- a/frontend/src/entrypoints/omnigent-inventory.tsx
+++ b/frontend/src/entrypoints/omnigent-inventory.tsx
@@ -47,6 +47,50 @@ type AgentProfile = {
   defaultForRuntime?: boolean;
   versions: ProfileVersion[];
 };
+type AgentProfileEditor = {
+  mode: 'create' | 'clone' | 'version'; source?: AgentProfile; id: string;
+  name: string; description: string; document: string;
+  sourceKind?: 'upstream' | 'bundle'; sourceRef?: string; bundleDigest?: string;
+  endpointRef?: string; executionProfileRef?: string; launchPolicyRef?: string;
+  policyRef?: string; providerRuntime?: string;
+};
+
+function structuredProfileDocument(draft: AgentProfileEditor): Record<string, unknown> {
+  const source = draft.sourceKind === 'bundle'
+    ? { bundleArtifactRef: draft.sourceRef, bundleDigest: draft.bundleDigest }
+    : { upstreamId: draft.sourceRef };
+  return {
+    schemaVersion: 'moonmind.omnigent-agent-profile.v1',
+    endpointRef: draft.endpointRef || 'default', bridgeMode: 'proxy', source,
+    harness: 'codex-native', requiredCapabilities: ['session.start'],
+    execution: {
+      defaultExecutionProfileRef: draft.executionProfileRef || 'omnigent-codex@1',
+      allowedLaunchPolicyRefs: [draft.launchPolicyRef || 'on-demand@1'],
+    },
+    providerRequirements: {
+      runtimeId: draft.providerRuntime || 'codex_cli', providerIds: [],
+      credentialSource: 'oauth', materializationMode: 'host',
+    },
+    workspace: { mutation: 'allowed', requiredCapabilities: [] },
+    continuations: { checkpoint: true, branch: true, remediation: true },
+    capture: { stream: true, evidence: true }, rag: {}, publish: { mode: 'none' },
+    policyRef: draft.policyRef || 'default@1',
+  };
+}
+
+function normalizedDocumentDiff(from: Record<string, unknown>, to: Record<string, unknown>): string {
+  const flatten = (value: unknown, path = '', rows: Record<string, unknown> = {}) => {
+    if (value && typeof value === 'object' && !Array.isArray(value)) {
+      Object.entries(value as Record<string, unknown>).sort(([a], [b]) => a.localeCompare(b))
+        .forEach(([key, child]) => flatten(child, path ? `${path}.${key}` : key, rows));
+    } else rows[path] = value;
+    return rows;
+  };
+  const before = flatten(from); const after = flatten(to);
+  const paths = Array.from(new Set([...Object.keys(before), ...Object.keys(after)])).sort();
+  const changes = paths.filter((path) => JSON.stringify(before[path]) !== JSON.stringify(after[path]));
+  return changes.length ? changes.map((path) => `${path}: ${JSON.stringify(before[path])} → ${JSON.stringify(after[path])}`).join('\n') : 'No document differences.';
+}
 
 /**
  * Assisted RAG editor for a policy document (MoonMind#3514). The policy `rag`
@@ -157,7 +201,7 @@ export default function OmnigentInventoryPage({ payload }: { payload: BootPayloa
   const [selectedVersion, setSelectedVersion] = useState<PolicyVersion | null>(null);
   const [notice, setNotice] = useState('');
   const [editor, setEditor] = useState<{ mode: 'create' | 'clone' | 'version'; id: string; name: string; document: string } | null>(null);
-  const [agentEditor, setAgentEditor] = useState<{ mode: 'create' | 'clone' | 'version'; source?: AgentProfile; id: string; name: string; description: string; document: string } | null>(null);
+  const [agentEditor, setAgentEditor] = useState<AgentProfileEditor | null>(null);
   const [selectedProfile, setSelectedProfile] = useState<AgentProfile | null>(null);
   const kind: InventoryKind = location.pathname === '/omnigent/policies'
     || location.pathname.startsWith('/omnigent/policies/')
@@ -220,7 +264,9 @@ export default function OmnigentInventoryPage({ payload }: { payload: BootPayloa
   });
   const saveAgentProfile = useMutation({
     mutationFn: async (draft: NonNullable<typeof agentEditor>) => {
-      const document = JSON.parse(draft.document) as Record<string, unknown>;
+      const document = draft.mode === 'create'
+        ? structuredProfileDocument(draft)
+        : JSON.parse(draft.document) as Record<string, unknown>;
       let url = '/api/omnigent/agent-profiles';
       let body: Record<string, unknown> = { profileId: draft.id, displayName: draft.name, description: draft.description || null, visibility: 'private', document };
       if (draft.mode === 'version') {
@@ -413,7 +459,7 @@ export default function OmnigentInventoryPage({ payload }: { payload: BootPayloa
     {kind === 'agents' ? <section aria-labelledby="omnigent-profiles-heading">
       <div className="omnigent-inventory__toolbar">
         <div><p className="eyebrow">Reusable configuration</p><h2 id="omnigent-profiles-heading">Agent profiles</h2></div>
-        <div className="actions"><button type="button" onClick={() => setAgentEditor({ mode: 'create', id: '', name: '', description: '', document: '{\n  "schemaVersion": "moonmind.omnigent-agent-profile.v1"\n}' })}>Create from upstream or bundle</button><button type="button" onClick={() => void profiles.refetch()} disabled={profiles.isFetching}>Refresh profiles</button></div>
+        <div className="actions"><button type="button" onClick={() => setAgentEditor({ mode: 'create', id: '', name: '', description: '', document: '{}', sourceKind: 'upstream', sourceRef: '', endpointRef: 'default', executionProfileRef: 'omnigent-codex@1', launchPolicyRef: 'on-demand@1', policyRef: 'default@1', providerRuntime: 'codex_cli' })}>Create from upstream or bundle</button><button type="button" onClick={() => void profiles.refetch()} disabled={profiles.isFetching}>Refresh profiles</button></div>
       </div>
       <p>Immutable, validated selections used by workflows and continuations.</p>
       {profiles.isPending ? <p role="status">Loading agent profiles…</p> : null}
@@ -424,7 +470,16 @@ export default function OmnigentInventoryPage({ payload }: { payload: BootPayloa
         <label><span>Profile id</span><input value={agentEditor.id} disabled={agentEditor.mode === 'version'} onChange={(event) => setAgentEditor({ ...agentEditor, id: event.target.value })} required /></label>
         <label><span>Display name</span><input value={agentEditor.name} disabled={agentEditor.mode === 'version'} onChange={(event) => setAgentEditor({ ...agentEditor, name: event.target.value })} required /></label>
         <label><span>Description</span><input value={agentEditor.description} disabled={agentEditor.mode !== 'create'} onChange={(event) => setAgentEditor({ ...agentEditor, description: event.target.value })} /></label>
-        {agentEditor.mode !== 'clone' ? <label><span>Normalized profile document (JSON)</span><textarea rows={18} value={agentEditor.document} onChange={(event) => setAgentEditor({ ...agentEditor, document: event.target.value })} required /></label> : null}
+        {agentEditor.mode === 'create' ? <>
+          <label><span>Source type</span><select value={agentEditor.sourceKind} onChange={(event) => setAgentEditor({ ...agentEditor, sourceKind: event.target.value as 'upstream' | 'bundle', sourceRef: '', bundleDigest: '' })}><option value="upstream">Existing upstream agent</option><option value="bundle">Artifact-backed bundle</option></select></label>
+          <label><span>{agentEditor.sourceKind === 'bundle' ? 'Bundle artifact reference' : 'Stable upstream agent id'}</span><input value={agentEditor.sourceRef || ''} onChange={(event) => setAgentEditor({ ...agentEditor, sourceRef: event.target.value })} required /></label>
+          {agentEditor.sourceKind === 'bundle' ? <label><span>Bundle SHA-256 digest</span><input pattern="sha256:[0-9a-f]{64}" value={agentEditor.bundleDigest || ''} onChange={(event) => setAgentEditor({ ...agentEditor, bundleDigest: event.target.value })} required /></label> : null}
+          <label><span>Endpoint reference</span><input value={agentEditor.endpointRef || ''} onChange={(event) => setAgentEditor({ ...agentEditor, endpointRef: event.target.value })} required /></label>
+          <label><span>Execution profile reference</span><input value={agentEditor.executionProfileRef || ''} onChange={(event) => setAgentEditor({ ...agentEditor, executionProfileRef: event.target.value })} required /></label>
+          <label><span>Launch policy reference</span><input value={agentEditor.launchPolicyRef || ''} onChange={(event) => setAgentEditor({ ...agentEditor, launchPolicyRef: event.target.value })} required /></label>
+          <label><span>Policy reference</span><input value={agentEditor.policyRef || ''} onChange={(event) => setAgentEditor({ ...agentEditor, policyRef: event.target.value })} required /></label>
+          <label><span>Provider runtime</span><input value={agentEditor.providerRuntime || ''} onChange={(event) => setAgentEditor({ ...agentEditor, providerRuntime: event.target.value })} required /></label>
+        </> : agentEditor.mode === 'version' ? <label><span>Normalized profile document (JSON)</span><textarea rows={18} value={agentEditor.document} onChange={(event) => setAgentEditor({ ...agentEditor, document: event.target.value })} required /></label> : null}
         {saveAgentProfile.isError ? <p role="alert">{saveAgentProfile.error.message}</p> : null}
         <button type="submit" disabled={saveAgentProfile.isPending}>Save immutable profile version</button><button type="button" onClick={() => setAgentEditor(null)}>Cancel</button>
       </form> : null}
@@ -459,7 +514,7 @@ export default function OmnigentInventoryPage({ payload }: { payload: BootPayloa
         <div className="actions"><h3 id="agent-profile-detail-heading">{selectedProfile.displayName} details</h3><button type="button" onClick={() => setSelectedProfile(null)}>Close details</button></div>
         <p><code>{selectedProfile.profileId}</code> · {selectedProfile.state} · {selectedProfile.versions.length} immutable version{selectedProfile.versions.length === 1 ? '' : 's'}</p>
         <h4>Version history and normalized diff</h4>
-        {selectedProfile.versions.map((version, index) => <details key={version.version}><summary>Version {version.version} · {version.digest}</summary><pre>{JSON.stringify(version.document, null, 2)}</pre>{index < selectedProfile.versions.length - 1 ? <pre aria-label={`Normalized diff version ${selectedProfile.versions[index + 1]!.version} to ${version.version}`}>{JSON.stringify({ from: selectedProfile.versions[index + 1]!.document, to: version.document }, null, 2)}</pre> : null}</details>)}
+        {selectedProfile.versions.map((version, index) => <details key={version.version}><summary>Version {version.version} · {version.digest}</summary><pre>{JSON.stringify(version.document, null, 2)}</pre>{index < selectedProfile.versions.length - 1 && version.document && selectedProfile.versions[index + 1]!.document ? <pre aria-label={`Normalized diff version ${selectedProfile.versions[index + 1]!.version} to ${version.version}`}>{normalizedDocumentDiff(selectedProfile.versions[index + 1]!.document!, version.document)}</pre> : null}</details>)}
         <h4>Dependent workflows and schedules</h4>{profileUsage.isPending ? <p role="status">Loading usage…</p> : <pre>{JSON.stringify(profileUsage.data || [], null, 2)}</pre>}
         <h4>Audit history</h4>{profileAudit.isPending ? <p role="status">Loading audit…</p> : <pre>{JSON.stringify(profileAudit.data || [], null, 2)}</pre>}
       </section> : null}

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -898,6 +898,12 @@ const ExecutionDetailSchema = z
     resolvedModel: z.string().nullable().optional(),
     modelSource: z.string().nullable().optional(),
     profileId: z.string().nullable().optional(),
+    inputParameters: z.record(z.string(), z.unknown()).default({}),
+    agentProfile: z.object({
+      profileId: z.string(),
+      version: z.number().int().positive().optional(),
+      providerProfileRef: z.string().optional(),
+    }).nullable().optional(),
     providerId: z.string().nullable().optional(),
     providerLabel: z.string().nullable().optional(),
     effort: z.string().nullable().optional(),
@@ -4698,9 +4704,22 @@ type BranchCreateDraft = {
   gitWorkBranch: string;
   maxBudgetUsd: string;
   providerProfileRef: string;
+  agentProfileId: string;
+  agentProfileVersion: number | null;
   executionProfileRef: string;
   model: string;
   effort: string;
+};
+
+type CheckpointAgentProfileOption = {
+  profileId: string;
+  displayName: string;
+  state: string;
+  activeVersion: number | null;
+  versions: Array<{
+    version: number;
+    validationResult?: { ready?: boolean } | null;
+  }>;
 };
 
 type BranchMutationKind = 'create' | 'continue' | 'fork' | 'promote' | 'publish' | 'archive' | 'compare';
@@ -4742,6 +4761,8 @@ const DEFAULT_BRANCH_CREATE_DRAFT: BranchCreateDraft = {
   gitWorkBranch: '',
   maxBudgetUsd: '',
   providerProfileRef: '',
+  agentProfileId: '',
+  agentProfileVersion: null,
   executionProfileRef: '',
   model: '',
   effort: '',
@@ -4963,6 +4984,19 @@ function BranchExplorerPanel({
   onBranchAction: (request: BranchMutationRequest) => void;
   retrievalCeilings: ReturnType<typeof retrievalCeilingsFromRuntimeConfig>;
 }) {
+  const agentProfilesQuery = useQuery({
+    queryKey: ['workflow-detail', 'omnigent-agent-profiles'],
+    queryFn: async (): Promise<CheckpointAgentProfileOption[]> => {
+      const response = await fetch(`${apiBase}/omnigent/agent-profiles`, { credentials: 'include' });
+      if (!response.ok) throw new Error(await response.text() || 'Failed to load agent profiles.');
+      const value: unknown = await response.json();
+      return Array.isArray(value) ? value as CheckpointAgentProfileOption[] : [];
+    },
+  });
+  const readyAgentProfiles = (agentProfilesQuery.data || []).filter((profile) => {
+    const active = (profile.versions || []).find((version) => version.version === profile.activeVersion);
+    return profile.state === 'active' && active?.validationResult?.ready === true;
+  });
   const checkpointRows = rows.filter((row) => isSupportedCheckpointRef(stepCheckpointRef(row)));
   const branchGroups = useMemo(() => buildBranchGroups(branches), [branches]);
   const [draft, setDraft] = useState<BranchCreateDraft>(() => DEFAULT_BRANCH_CREATE_DRAFT);
@@ -5158,6 +5192,29 @@ function BranchExplorerPanel({
               <option value="reuse_session_new_epoch">Reuse session new epoch</option>
               <option value="reuse_session_same_epoch">Reuse session same epoch</option>
             </select>
+          </label>
+          <label>
+            Agent profile
+            <select
+              value={draft.agentProfileId}
+              disabled={busy || agentProfilesQuery.isFetching}
+              onChange={(event) => {
+                const selected = readyAgentProfiles.find((profile) => profile.profileId === event.target.value);
+                setDraft((current) => ({
+                  ...current,
+                  agentProfileId: event.target.value,
+                  agentProfileVersion: selected?.activeVersion ?? null,
+                }));
+              }}
+            >
+              <option value="">Inherit no agent profile</option>
+              {readyAgentProfiles.map((profile) => (
+                <option key={profile.profileId} value={profile.profileId}>
+                  {profile.displayName} · v{profile.activeVersion}
+                </option>
+              ))}
+            </select>
+            {agentProfilesQuery.isError ? <span className="small" role="alert">Agent-profile readiness is unavailable.</span> : null}
           </label>
           <label>
             Provider profile
@@ -9088,6 +9145,13 @@ function WorkflowDetailPageContent({ payload }: { payload: BootPayload }) {
           gitWorkBranch: request.draft.gitWorkBranch.trim() || null,
           maxBudgetUsd: Number.isFinite(budget) ? budget : null,
           providerProfileRef: request.draft.providerProfileRef.trim() || null,
+          agentProfile: request.draft.agentProfileId && request.draft.providerProfileRef.trim()
+            ? {
+                profileId: request.draft.agentProfileId,
+                version: request.draft.agentProfileVersion,
+                providerProfileRef: request.draft.providerProfileRef.trim(),
+              }
+            : null,
           executionProfileRef: request.draft.executionProfileRef.trim() || null,
           model: request.draft.model.trim() || null,
           effort: request.draft.effort || null,

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -9145,11 +9145,11 @@ function WorkflowDetailPageContent({ payload }: { payload: BootPayload }) {
           gitWorkBranch: request.draft.gitWorkBranch.trim() || null,
           maxBudgetUsd: Number.isFinite(budget) ? budget : null,
           providerProfileRef: request.draft.providerProfileRef.trim() || null,
-          agentProfile: request.draft.agentProfileId && request.draft.providerProfileRef.trim()
+          agentProfile: request.draft.agentProfileId
             ? {
                 profileId: request.draft.agentProfileId,
                 version: request.draft.agentProfileVersion,
-                providerProfileRef: request.draft.providerProfileRef.trim(),
+                providerProfileRef: request.draft.providerProfileRef.trim() || null,
               }
             : null,
           executionProfileRef: request.draft.executionProfileRef.trim() || null,

--- a/frontend/src/entrypoints/workflow-start.test.tsx
+++ b/frontend/src/entrypoints/workflow-start.test.tsx
@@ -625,6 +625,14 @@ describe("MoonLadderStudios/MoonMind#3451 Omnigent readiness", () => {
     compatibilityDiagnostics: {},
     cutover: {},
   } satisfies components["schemas"]["OmnigentCodexCatalogReadiness"];
+  const readyAgentProfiles = [{
+    profileId: "team-codex",
+    displayName: "Team Codex",
+    state: "active",
+    activeVersion: 1,
+    defaultForRuntime: true,
+    versions: [{ version: 1, digest: `sha256:${"a".repeat(64)}`, validationResult: { ready: true } }],
+  }];
 
   it("keeps an unavailable runtime unselectable and explicitly revalidates stale readiness", async () => {
     renderWorkflowStartPage(mockPayload);
@@ -697,6 +705,9 @@ describe("MoonLadderStudios/MoonMind#3451 Omnigent readiness", () => {
       }
       if (url.startsWith("/api/v1/provider-profiles")) {
         return Promise.resolve({ ok: true, json: async () => [{ profile_id: "oauth-1", account_label: "Codex OAuth", provider_id: "openai" }] } as Response);
+      }
+      if (url === "/api/omnigent/agent-profiles") {
+        return Promise.resolve({ ok: true, json: async () => readyAgentProfiles } as Response);
       }
       if (url === "/api/executions" && init?.method === "POST") {
         return Promise.resolve({ ok: true, json: async () => ({ workflowId: "mm:omnigent-created" }) } as Response);
@@ -804,6 +815,9 @@ describe("MoonLadderStudios/MoonMind#3451 Omnigent readiness", () => {
       if (url.startsWith("/api/v1/provider-profiles")) {
         return Promise.resolve({ ok: true, json: async () => [{ profile_id: "oauth-1", account_label: "Codex OAuth", provider_id: "openai" }] } as Response);
       }
+      if (url === "/api/omnigent/agent-profiles") {
+        return Promise.resolve({ ok: true, json: async () => readyAgentProfiles } as Response);
+      }
       if (url === "/api/executions" && init?.method === "POST") {
         return Promise.resolve({ ok: true, json: async () => ({ workflowId: `mm:omnigent-${mode}` }) } as Response);
       }
@@ -841,6 +855,9 @@ describe("MoonLadderStudios/MoonMind#3451 Omnigent readiness", () => {
       }
       if (url.startsWith("/api/v1/provider-profiles")) {
         return Promise.resolve({ ok: true, json: async () => [{ profile_id: "oauth-1", account_label: "Codex OAuth", provider_id: "openai" }] } as Response);
+      }
+      if (url === "/api/omnigent/agent-profiles") {
+        return Promise.resolve({ ok: true, json: async () => readyAgentProfiles } as Response);
       }
       return Promise.resolve({ ok: true, json: async () => ({ items: [] }) } as Response);
     });
@@ -889,6 +906,9 @@ describe("MoonLadderStudios/MoonMind#3451 Omnigent readiness", () => {
             },
           ],
         } as Response);
+      }
+      if (url === "/api/omnigent/agent-profiles") {
+        return Promise.resolve({ ok: true, json: async () => readyAgentProfiles } as Response);
       }
       return Promise.resolve({
         ok: true,

--- a/frontend/src/entrypoints/workflow-start.tsx
+++ b/frontend/src/entrypoints/workflow-start.tsx
@@ -6764,6 +6764,9 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
       prevProviderProfileRef.current = draft.runtime.profileId;
       setProviderProfile(draft.runtime.profileId);
     }
+    if (draft.agentProfile?.profileId) {
+      setAgentProfile(draft.agentProfile.profileId);
+    }
     if (draft.runtime?.model) {
       setModel(draft.runtime.model);
       setModelManualOverride(true);
@@ -11067,7 +11070,15 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
         ...(submittedEffort ? { effort: submittedEffort } : {}),
         ...(providerProfile ? { profileId: providerProfile } : {}),
         ...(runtime === "omnigent" && agentProfile
-          ? { agentProfile: { profileId: agentProfile } }
+          ? {
+              agentProfile: {
+                profileId: agentProfile,
+                ...(remediationDraft?.agentProfile?.profileId === agentProfile && remediationDraft.agentProfile.version
+                  ? { version: remediationDraft.agentProfile.version }
+                  : {}),
+                providerProfileRef: providerProfile,
+              },
+            }
           : {}),
         ...(selectedProviderId
           ? { profileSelector: { providerId: selectedProviderId } }
@@ -11124,7 +11135,15 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
           : {}),
         targetRuntime: normalizedRuntime,
         ...(normalizedRuntime === "omnigent" && agentProfile
-          ? { agentProfile: { profileId: agentProfile } }
+          ? {
+              agentProfile: {
+                profileId: agentProfile,
+                ...(remediationDraft?.agentProfile?.profileId === agentProfile && remediationDraft.agentProfile.version
+                  ? { version: remediationDraft.agentProfile.version }
+                  : {}),
+                providerProfileRef: providerProfile,
+              },
+            }
           : {}),
         ...(normalizedRuntime === "omnigent" && omnigentExecutionTargetRef
           ? {

--- a/frontend/src/entrypoints/workflow-start.tsx
+++ b/frontend/src/entrypoints/workflow-start.tsx
@@ -1028,6 +1028,15 @@ interface PentestScopeDraftState {
 
 type StepType = "tool" | "skill" | "preset";
 
+type OmnigentAgentProfileOption = {
+  profileId: string;
+  displayName: string;
+  state: string;
+  defaultForRuntime?: boolean;
+  activeVersion?: number | null;
+  versions: Array<{ version: number; digest: string; validationResult?: { ready?: boolean } | null }>;
+};
+
 const STEP_TYPE_HELP_TEXT: Record<StepType, string> = {
   skill: "Skill asks an agent to perform work using reusable behavior.",
   tool: "Tool runs a typed integration or system operation directly.",
@@ -6062,6 +6071,7 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
   const [tierFallback, setTierFallback] = useState<TierFallbackMode>("clamp");
   const [repository, setRepository] = useState(initialRepository);
   const [providerProfile, setProviderProfile] = useState("");
+  const [agentProfile, setAgentProfile] = useState("");
   const [branch, setBranch] = useState("");
   const [branchTouched, setBranchTouched] = useState(false);
   const [publishMode, setPublishMode] = useState(
@@ -6448,6 +6458,25 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
     // (full width) until the fetch resolves and it snaps back to half width.
     placeholderData: keepPreviousData,
   });
+  const agentProfilesQuery = useQuery({
+    queryKey: ["workflow-start", "omnigent-agent-profiles"],
+    enabled: runtime === "omnigent",
+    queryFn: async (): Promise<OmnigentAgentProfileOption[]> => {
+      const response = await fetch("/api/omnigent/agent-profiles", { credentials: "same-origin" });
+      if (!response.ok) throw new Error(await responseErrorMessage(response, "Failed to load agent profiles."));
+      const value: unknown = await response.json();
+      return Array.isArray(value) ? value as OmnigentAgentProfileOption[] : [];
+    },
+  });
+  const readyAgentProfiles = (agentProfilesQuery.data || []).filter((profile) => {
+    const active = profile.versions.find((version) => version.version === profile.activeVersion);
+    return profile.state === "active" && active?.validationResult?.ready === true;
+  });
+  useEffect(() => {
+    if (runtime !== "omnigent" || agentProfile) return;
+    const preferred = readyAgentProfiles.find((profile) => profile.defaultForRuntime) || readyAgentProfiles[0];
+    if (preferred) setAgentProfile(preferred.profileId);
+  }, [agentProfile, readyAgentProfiles, runtime]);
 
   const omnigentCatalogQuery = useQuery({
     queryKey: ["workflow-start", "omnigent-codex-catalog-readiness"],
@@ -11037,6 +11066,9 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
         ...(submittedModel ? { model: submittedModel } : {}),
         ...(submittedEffort ? { effort: submittedEffort } : {}),
         ...(providerProfile ? { profileId: providerProfile } : {}),
+        ...(runtime === "omnigent" && agentProfile
+          ? { agentProfile: { profileId: agentProfile } }
+          : {}),
         ...(selectedProviderId
           ? { profileSelector: { providerId: selectedProviderId } }
           : {}),
@@ -11091,6 +11123,9 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
           ? { requiredCapabilities: mergedCapabilities }
           : {}),
         targetRuntime: normalizedRuntime,
+        ...(normalizedRuntime === "omnigent" && agentProfile
+          ? { agentProfile: { profileId: agentProfile } }
+          : {}),
         ...(normalizedRuntime === "omnigent" && omnigentExecutionTargetRef
           ? {
               omnigent: {
@@ -13470,6 +13505,30 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
               </span>
             ) : null}
           </label>
+
+          {runtime === "omnigent" ? (
+            <label>
+              Agent profile
+              <select
+                name="agentProfile"
+                value={agentProfile}
+                onChange={(event) => setAgentProfile(event.target.value)}
+                disabled={agentProfilesQuery.isFetching}
+                required
+              >
+                <option value="">Select a launch-ready agent profile</option>
+                {readyAgentProfiles.map((profile) => (
+                  <option key={profile.profileId} value={profile.profileId}>
+                    {profile.displayName}{profile.defaultForRuntime ? " (Default)" : ""} · v{profile.activeVersion}
+                  </option>
+                ))}
+              </select>
+              {agentProfilesQuery.isError ? <span className="small" role="alert">Failed to load agent profiles.</span> : null}
+              {!agentProfilesQuery.isPending && !agentProfilesQuery.isError && readyAgentProfiles.length === 0 ? (
+                <span className="small" role="alert">No launch-ready agent profile is available.</span>
+              ) : null}
+            </label>
+          ) : null}
 
           {providerOptions.length > 0 ? (
             <div id="queue-provider-profile-wrap">

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -1217,6 +1217,33 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/omnigent/agent-profiles/{profile_id}/smoke": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Smoke Validate Profile
+         * @description Run an operator-triggered bounded smoke preflight (Sec 7).
+         *
+         *     Reuses the shared readiness checks, adds the strongest *safe* session-start
+         *     capability probe (bridge reachability, never a real launch), bounds the
+         *     whole preflight by a time budget, secret-scans diagnostics, and guarantees
+         *     release of any validation-owned lease. A pass is readiness evidence, not a
+         *     workflow-success guarantee, so it never mutates the version's activation
+         *     validation result.
+         */
+        post: operations["smoke_validate_profile_api_omnigent_agent_profiles__profile_id__smoke_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/omnigent/agent-profiles/{profile_id}/default": {
         parameters: {
             query?: never;
@@ -12406,6 +12433,11 @@ export interface components {
                 [key: string]: string;
             }[];
         };
+        /** SmokeCreate */
+        SmokeCreate: {
+            /** Version */
+            version?: number | null;
+        };
         /** SnapshotCreate */
         SnapshotCreate: {
             /**
@@ -16147,6 +16179,43 @@ export interface operations {
         requestBody: {
             content: {
                 "application/json": components["schemas"]["ValidateCreate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    smoke_validate_profile_api_omnigent_agent_profiles__profile_id__smoke_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                profile_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SmokeCreate"];
             };
         };
         responses: {

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -1244,6 +1244,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/omnigent/agent-profiles/{profile_id}/import-bundle": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Import Profile Bundle
+         * @description Publish one validated immutable bundle through the authorized facade.
+         */
+        post: operations["import_profile_bundle_api_omnigent_agent_profiles__profile_id__import_bundle_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/omnigent/agent-profiles/{profile_id}/default": {
         parameters: {
             query?: never;
@@ -5723,6 +5743,11 @@ export interface components {
             /** Evidenceincompletereason */
             evidenceIncompleteReason?: string | null;
         };
+        /** BundleImportCreate */
+        BundleImportCreate: {
+            /** Version */
+            version?: number | null;
+        };
         /** CacheMount */
         CacheMount: {
             /** Cacheref */
@@ -5945,6 +5970,10 @@ export interface components {
             maxBudgetUsd?: number | null;
             /** Providerprofileref */
             providerProfileRef?: string | null;
+            /** Agentprofile */
+            agentProfile?: {
+                [key: string]: unknown;
+            } | null;
             /** Executionprofileref */
             executionProfileRef?: string | null;
             /** Model */
@@ -11673,6 +11702,12 @@ export interface components {
             gitWorkBranch?: string | null;
             /** Maxbudgetusd */
             maxBudgetUsd?: number | null;
+            /** Providerprofileref */
+            providerProfileRef?: string | null;
+            /** Agentprofile */
+            agentProfile?: {
+                [key: string]: unknown;
+            } | null;
         };
         /** RemediationCollectionItemModel */
         RemediationCollectionItemModel: {
@@ -16216,6 +16251,43 @@ export interface operations {
         requestBody: {
             content: {
                 "application/json": components["schemas"]["SmokeCreate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    import_profile_bundle_api_omnigent_agent_profiles__profile_id__import_bundle_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                profile_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["BundleImportCreate"];
             };
         };
         responses: {

--- a/frontend/src/lib/remediationCreateDraft.test.ts
+++ b/frontend/src/lib/remediationCreateDraft.test.ts
@@ -87,4 +87,39 @@ describe('remediationCreateDraft', () => {
     clearRemediationCreateDraft(draftId);
     expect(readRemediationCreateDraft(draftId)).toBeNull();
   });
+
+  it('preserves the immutable agent and Provider Profile selection', () => {
+    const draft = buildRemediationCreateDraft({
+      workflowId: 'mm:target',
+      runId: 'run-target',
+      targetRuntime: 'omnigent',
+      profileId: 'oauth-team',
+      agentProfile: { profileId: 'team-codex', version: 2 },
+    });
+
+    expect(draft.agentProfile).toEqual({
+      profileId: 'team-codex',
+      version: 2,
+      providerProfileRef: 'oauth-team',
+    });
+  });
+
+  it('recovers the immutable selection from execution input parameters', () => {
+    const draft = buildRemediationCreateDraft({
+      workflowId: 'mm:target',
+      runId: 'run-target',
+      targetRuntime: 'omnigent',
+      profileId: 'oauth-team',
+      inputParameters: {
+        agentProfile: { profileId: 'team-codex', version: 2 },
+        agentProfileSnapshot: { providerProfileRef: 'oauth-team' },
+      },
+    });
+
+    expect(draft.agentProfile).toEqual({
+      profileId: 'team-codex',
+      version: 2,
+      providerProfileRef: 'oauth-team',
+    });
+  });
 });

--- a/frontend/src/lib/remediationCreateDraft.ts
+++ b/frontend/src/lib/remediationCreateDraft.ts
@@ -29,6 +29,11 @@ export type RemediationCreateDraft = {
     tierFallback?: 'clamp' | 'strict';
     profileId?: string;
   };
+  agentProfile?: {
+    profileId: string;
+    version?: number;
+    providerProfileRef: string;
+  };
   instructions?: string;
   remediation: {
     target: {
@@ -62,6 +67,7 @@ type RemediationDraftExecution = {
     checkpointRef?: string | null | undefined;
     sourceRunId?: string | null | undefined;
   } | null | undefined;
+  inputParameters?: Record<string, unknown> | null | undefined;
   steps?: Array<Record<string, unknown>> | null | undefined;
   stepLedger?: Array<Record<string, unknown>> | null | undefined;
   latestCheckpointRef?: string | null | undefined;
@@ -69,6 +75,11 @@ type RemediationDraftExecution = {
   checkpoints?: Array<Record<string, unknown>> | null | undefined;
   targetRuntime?: string | null | undefined;
   profileId?: string | null | undefined;
+  agentProfile?: {
+    profileId?: string | null | undefined;
+    version?: number | null | undefined;
+    providerProfileRef?: string | null | undefined;
+  } | null | undefined;
   model?: string | null | undefined;
   resolvedModel?: string | null | undefined;
   requestedModel?: string | null | undefined;
@@ -190,6 +201,29 @@ export function buildRemediationCreateDraft(
     runId,
     ...(stepSelectors.length > 0 ? { stepSelectors } : {}),
   };
+  const storedAgentProfile = (
+    execution.inputParameters?.agentProfile &&
+    typeof execution.inputParameters.agentProfile === 'object' &&
+    !Array.isArray(execution.inputParameters.agentProfile)
+      ? execution.inputParameters.agentProfile as Record<string, unknown>
+      : {}
+  );
+  const storedSnapshot = (
+    execution.inputParameters?.agentProfileSnapshot &&
+    typeof execution.inputParameters.agentProfileSnapshot === 'object' &&
+    !Array.isArray(execution.inputParameters.agentProfileSnapshot)
+      ? execution.inputParameters.agentProfileSnapshot as Record<string, unknown>
+      : {}
+  );
+  const selectedAgentProfileId = cleanText(
+    execution.agentProfile?.profileId || storedAgentProfile.profileId || storedSnapshot.profileId,
+  );
+  const selectedProviderProfileRef = cleanText(
+    execution.agentProfile?.providerProfileRef || storedSnapshot.providerProfileRef || execution.profileId,
+  );
+  const selectedAgentProfileVersion = Number(
+    execution.agentProfile?.version || storedAgentProfile.version || storedSnapshot.version || 0,
+  );
   return {
     source: 'remediation',
     target: {
@@ -207,6 +241,17 @@ export function buildRemediationCreateDraft(
       ...(cleanText(runtime.effort) ? { effort: cleanText(runtime.effort) } : {}),
       ...(cleanText(runtime.profileId) ? { profileId: cleanText(runtime.profileId) } : {}),
     },
+    ...(selectedAgentProfileId && selectedProviderProfileRef
+      ? {
+          agentProfile: {
+            profileId: selectedAgentProfileId,
+            ...(selectedAgentProfileVersion > 0
+              ? { version: selectedAgentProfileVersion }
+              : {}),
+            providerProfileRef: selectedProviderProfileRef,
+          },
+        }
+      : {}),
     instructions:
       options.instructions ||
       `Investigate and remediate target execution ${workflowId} using bounded evidence.`,

--- a/moonmind/omnigent/bridge_proxy.py
+++ b/moonmind/omnigent/bridge_proxy.py
@@ -133,6 +133,11 @@ class OmnigentSessionFacade(Protocol):
     async def list_hosts(self) -> list[dict[str, Any]]:
         raise NotImplementedError
 
+    async def import_agent_bundle(
+        self, *, filename: str, content: bytes, content_type: str
+    ) -> dict[str, Any]:
+        raise NotImplementedError
+
     async def create_session(
         self, *, request: BridgeSessionCreateRequest, binding: BridgePrincipalBinding
     ) -> dict[str, Any]:
@@ -949,6 +954,23 @@ class OmnigentBridgeSessionProxy:
 
         self._require_proxy_mode()
         return await self._list_agents_raw()
+
+    async def import_agent_bundle(
+        self, *, filename: str, content: bytes, content_type: str
+    ) -> dict[str, Any]:
+        """Publish a prevalidated immutable bundle to the configured endpoint."""
+
+        self._require_proxy_mode()
+        try:
+            return await self._client.create_agent_bundle(
+                filename=filename, content=content, content_type=content_type
+            )
+        except OmnigentClientError as exc:
+            raise OmnigentBridgeError(
+                str(exc),
+                failure_class=exc.failure_class,
+                status_code=exc.status_code,
+            ) from exc
 
     async def _list_agents_raw(self) -> list[dict[str, Any]]:
         try:

--- a/moonmind/omnigent/bridge_proxy.py
+++ b/moonmind/omnigent/bridge_proxy.py
@@ -263,8 +263,15 @@ class OmnigentBridgeSessionProxy:
         *,
         request: BridgeSessionCreateRequest,
         binding: BridgePrincipalBinding,
+        default_agent_name_override: str | None = None,
     ) -> dict[str, Any]:
-        """Create or reuse a proxy-mode Omnigent session (OB-§8.2)."""
+        """Create or reuse a proxy-mode Omnigent session (OB-§8.2).
+
+        ``default_agent_name_override`` lets the launch boundary supply the
+        durable default agent selection resolved from an active default agent
+        profile (MoonLadderStudios/MoonMind#3517 §8); when unset the
+        configured environment fallback is used.
+        """
 
         self._require_proxy_mode()
         # OB-§8.3 host validation exposed through the facade.
@@ -300,12 +307,15 @@ class OmnigentBridgeSessionProxy:
         async def _list_agents() -> list[dict[str, Any]]:
             return await self._list_agents_raw()
 
+        effective_default_agent_name = (
+            (default_agent_name_override or "").strip() or self._default_agent_name
+        )
         try:
             target = await resolve_omnigent_target(
                 selection,
                 list_agents=_list_agents,
                 upload_agent_bundle=_unsupported_bundle_upload,
-                default_agent_name=self._default_agent_name,
+                default_agent_name=effective_default_agent_name,
             )
         except OmnigentAdapterError as exc:
             raise OmnigentBridgeError(

--- a/moonmind/schemas/checkpoint_branch_models.py
+++ b/moonmind/schemas/checkpoint_branch_models.py
@@ -116,6 +116,7 @@ class CheckpointBranchCreateRequest(BaseModel):
     provider_profile_ref: str | None = Field(
         None, alias="providerProfileRef", min_length=1, max_length=255
     )
+    agent_profile: dict[str, Any] | None = Field(None, alias="agentProfile")
     execution_profile_ref: str | None = Field(
         None, alias="executionProfileRef", min_length=1, max_length=255
     )

--- a/tests/unit/api/routers/test_checkpoint_branch_apis.py
+++ b/tests/unit/api/routers/test_checkpoint_branch_apis.py
@@ -692,11 +692,36 @@ async def test_remediation_checkpoint_branch_repair_creates_fresh_branch_from_co
         "/api/executions/mm:remediation-1/remediation/checkpoint-branches",
         json=repair_payload,
     )
+    changed_agent_profile = await checkpoint_branch_client.post(
+        "/api/executions/mm:remediation-1/remediation/checkpoint-branches",
+        json={
+            **repair_payload,
+            "agentProfile": {
+                "profileId": "agent-profile-remediation",
+                "version": 3,
+            },
+        },
+    )
+    changed_provider_profile = await checkpoint_branch_client.post(
+        "/api/executions/mm:remediation-1/remediation/checkpoint-branches",
+        json={
+            **repair_payload,
+            "providerProfileRef": "provider-profile-other",
+        },
+    )
 
     assert first.status_code == 201
     assert second.status_code == 201
     assert second.json()["branchId"] == first.json()["branchId"]
     assert first.json()["runtimeContextPolicy"] == "fresh_agent_run"
+    assert changed_agent_profile.status_code == 409
+    assert changed_agent_profile.json()["detail"]["code"] == (
+        "idempotency_key_conflict"
+    )
+    assert changed_provider_profile.status_code == 409
+    assert changed_provider_profile.json()["detail"]["code"] == (
+        "idempotency_key_conflict"
+    )
 
     async for session in checkpoint_branch_client.app.dependency_overrides[  # type: ignore[attr-defined]
         get_async_session

--- a/tests/unit/api/routers/test_checkpoint_branch_apis.py
+++ b/tests/unit/api/routers/test_checkpoint_branch_apis.py
@@ -406,6 +406,66 @@ async def test_checkpoint_branch_create_prepares_git_binding_before_launch(
 
 
 @pytest.mark.asyncio
+async def test_checkpoint_branch_create_persists_exact_agent_profile_snapshot(
+    checkpoint_branch_client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    snapshot = {
+        "profileId": "agent-profile-1",
+        "version": 3,
+        "digest": "sha256:profile-v3",
+        "providerProfileRef": "provider-profile-1",
+        "model": "gpt-5.4",
+    }
+    resolver = AsyncMock(return_value=snapshot)
+    monkeypatch.setattr(
+        "api_service.api.routers.executions.resolve_agent_profile_snapshot",
+        resolver,
+    )
+    payload = _create_payload("mm-3517:create-profile")
+    payload["providerProfileRef"] = "provider-profile-1"
+    payload["agentProfile"] = {"profileId": "agent-profile-1", "version": 3}
+
+    response = await checkpoint_branch_client.post(
+        "/api/executions/mm:wf-branch/checkpoint-branches", json=payload
+    )
+
+    assert response.status_code == 201
+    branch_id = response.json()["branchId"]
+    resolver.assert_awaited_once()
+    assert resolver.await_args.kwargs["selection"] == {
+        "profileId": "agent-profile-1",
+        "version": 3,
+        "providerProfileRef": "provider-profile-1",
+    }
+    assert resolver.await_args.kwargs["consumer_id"] == branch_id
+    async for session in checkpoint_branch_client.app.dependency_overrides[  # type: ignore[attr-defined]
+        get_async_session
+    ]():
+        branch = await session.get(WorkflowCheckpointBranch, branch_id)
+    assert branch is not None
+    assert branch.diagnostics["runtimeSelection"]["agentProfileSnapshot"] == snapshot
+
+
+@pytest.mark.asyncio
+async def test_checkpoint_branch_create_rejects_profile_provider_conflict(
+    checkpoint_branch_client: AsyncClient,
+) -> None:
+    payload = _create_payload("mm-3517:profile-conflict")
+    payload["providerProfileRef"] = "provider-profile-1"
+    payload["agentProfile"] = {
+        "profileId": "agent-profile-1",
+        "providerProfileRef": "provider-profile-2",
+    }
+
+    response = await checkpoint_branch_client.post(
+        "/api/executions/mm:wf-branch/checkpoint-branches", json=payload
+    )
+
+    assert response.status_code == 409
+
+
+@pytest.mark.asyncio
 async def test_checkpoint_branch_api_lists_creates_details_turns_and_is_idempotent(
     checkpoint_branch_client: AsyncClient,
 ) -> None:
@@ -605,22 +665,32 @@ async def test_remediation_checkpoint_branch_repair_creates_fresh_branch_from_co
         "api_service.api.routers.executions.get_temporal_artifact_service",
         lambda session: _ArtifactService(),
     )
+    snapshot = {
+        "profileId": "agent-profile-remediation",
+        "version": 2,
+        "digest": "sha256:remediation-profile-v2",
+        "providerProfileRef": "provider-profile-remediation",
+    }
+    resolver = AsyncMock(return_value=snapshot)
+    monkeypatch.setattr(
+        "api_service.api.routers.executions.resolve_agent_profile_snapshot",
+        resolver,
+    )
 
+    repair_payload = {
+        "checkpointRef": "artifact://checkpoints/after-implement",
+        "instructions": {"text": "Repair with corrected instructions."},
+        "idempotencyKey": "MM-1119:remediation-branch",
+        "providerProfileRef": "provider-profile-remediation",
+        "agentProfile": {"profileId": "agent-profile-remediation", "version": 2},
+    }
     first = await checkpoint_branch_client.post(
         "/api/executions/mm:remediation-1/remediation/checkpoint-branches",
-        json={
-            "checkpointRef": "artifact://checkpoints/after-implement",
-            "instructions": {"text": "Repair with corrected instructions."},
-            "idempotencyKey": "MM-1119:remediation-branch",
-        },
+        json=repair_payload,
     )
     second = await checkpoint_branch_client.post(
         "/api/executions/mm:remediation-1/remediation/checkpoint-branches",
-        json={
-            "checkpointRef": "artifact://checkpoints/after-implement",
-            "instructions": {"text": "Repair with corrected instructions."},
-            "idempotencyKey": "MM-1119:remediation-branch",
-        },
+        json=repair_payload,
     )
 
     assert first.status_code == 201
@@ -646,6 +716,9 @@ async def test_remediation_checkpoint_branch_repair_creates_fresh_branch_from_co
     assert branch.diagnostics["repairActionKind"] == (
         "checkpoint_branch.create_from_remediation_context"
     )
+    assert branch.diagnostics["runtimeSelection"]["agentProfileSnapshot"] == snapshot
+    assert operation.response_payload["runtimeSelection"]["agentProfileSnapshot"] == snapshot
+    resolver.assert_awaited_once()
     assert operation.response_payload["remediation"] == {
         "workflowId": "mm:remediation-1",
         "runId": "run-remediation-1",

--- a/tests/unit/api/routers/test_omnigent_agent_profiles.py
+++ b/tests/unit/api/routers/test_omnigent_agent_profiles.py
@@ -48,6 +48,7 @@ def test_fixed_post_routes_precede_lifecycle_catch_all():
     assert post_paths.index("/api/omnigent/agent-profiles/{profile_id}/default") < catch_all
     assert post_paths.index("/api/omnigent/agent-profiles/{profile_id}/snapshot") < catch_all
     assert post_paths.index("/api/omnigent/agent-profiles/{profile_id}/smoke") < catch_all
+    assert post_paths.index("/api/omnigent/agent-profiles/{profile_id}/import-bundle") < catch_all
 
 
 def test_list_response_contract_includes_ordered_versions_and_default_state():
@@ -70,6 +71,7 @@ def test_list_response_contract_includes_ordered_versions_and_default_state():
             cloned_from_version=None,
             upstream_snapshot={"upstreamId": "codex"},
             validation_result={"ready": True},
+            rollout_metadata={"bundleImport": {"status": "succeeded"}},
             created_at=None,
         ),
         SimpleNamespace(
@@ -81,6 +83,7 @@ def test_list_response_contract_includes_ordered_versions_and_default_state():
             cloned_from_version=None,
             upstream_snapshot=None,
             validation_result=None,
+            rollout_metadata=None,
             created_at=None,
         ),
     ]
@@ -91,6 +94,7 @@ def test_list_response_contract_includes_ordered_versions_and_default_state():
     assert "default" not in response
     assert [version["version"] for version in response["versions"]] == [2, 1]
     assert response["versions"][0]["validationResult"] == {"ready": True}
+    assert response["versions"][0]["rolloutMetadata"]["bundleImport"]["status"] == "succeeded"
 
 def test_source_requires_stable_identity_or_immutable_bundle():
     with pytest.raises(ValidationError, match="exactly one"):

--- a/tests/unit/api/routers/test_omnigent_agent_profiles.py
+++ b/tests/unit/api/routers/test_omnigent_agent_profiles.py
@@ -47,6 +47,7 @@ def test_fixed_post_routes_precede_lifecycle_catch_all():
 
     assert post_paths.index("/api/omnigent/agent-profiles/{profile_id}/default") < catch_all
     assert post_paths.index("/api/omnigent/agent-profiles/{profile_id}/snapshot") < catch_all
+    assert post_paths.index("/api/omnigent/agent-profiles/{profile_id}/smoke") < catch_all
 
 
 def test_list_response_contract_includes_ordered_versions_and_default_state():

--- a/tests/unit/api/routers/test_omnigent_bridge.py
+++ b/tests/unit/api/routers/test_omnigent_bridge.py
@@ -1523,6 +1523,7 @@ def test_superuser_owns_any_workflow() -> None:
     app.dependency_overrides[_get_execution_service] = lambda: _FakeService(uuid4())
     app.dependency_overrides[_get_bridge_proxy] = lambda: proxy
     app.dependency_overrides[_get_bridge_store] = _FakeStore
+    app.dependency_overrides[_get_launch_default_agent_name] = lambda: None
     client = TestClient(app)
 
     resp = client.post(_CREATE_PATH, json=_create_body())

--- a/tests/unit/api/routers/test_omnigent_bridge.py
+++ b/tests/unit/api/routers/test_omnigent_bridge.py
@@ -23,6 +23,7 @@ from api_service.api.routers.omnigent_bridge import (
     _get_bridge_proxy,
     _get_create_embedded_facade,
     _get_execution_service,
+    _get_launch_default_agent_name,
     _require_bridge_enabled,
     embedded_host_auth_preflight,
     router,
@@ -231,10 +232,18 @@ class _FakeProxy:
             else session_owner
         )
 
-    async def create_session(self, *, request, binding):
+    async def create_session(
+        self, *, request, binding, default_agent_name_override=None
+    ):
         if self.create_error is not None:
             raise self.create_error
-        self.created.append({"binding": binding, "request": request})
+        self.created.append(
+            {
+                "binding": binding,
+                "request": request,
+                "default_agent_name_override": default_agent_name_override,
+            }
+        )
         return {"id": "sess-1", "status": "running", "moonmind": {"reused": False}}
 
     async def get_session_owner(self, session_id: str):
@@ -475,6 +484,7 @@ def _build(
     app.dependency_overrides[_get_execution_service] = lambda: _FakeService(owner_id)
     app.dependency_overrides[_get_bridge_proxy] = lambda: proxy
     app.dependency_overrides[_get_bridge_store] = lambda: store
+    app.dependency_overrides[_get_launch_default_agent_name] = lambda: None
     if registry is not None:
         app.dependency_overrides[get_capability_registry] = lambda: registry
     if config is not None:
@@ -1542,6 +1552,7 @@ def test_create_session_available_in_embedded_mode() -> None:
     app.dependency_overrides[_get_bridge_proxy] = lambda: None
     app.dependency_overrides[_get_create_embedded_facade] = lambda: facade
     app.dependency_overrides[_get_bridge_store] = _FakeStore
+    app.dependency_overrides[_get_launch_default_agent_name] = lambda: None
     client = TestClient(app)
 
     resp = client.post(

--- a/tests/unit/api/routers/test_omnigent_bridge_default_agent.py
+++ b/tests/unit/api/routers/test_omnigent_bridge_default_agent.py
@@ -1,0 +1,82 @@
+"""Launch-boundary durable default agent resolution (MoonLadderStudios/MoonMind#3517 §8)."""
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+from fastapi import HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+import api_service.api.routers.omnigent_bridge as bridge
+from api_service.api.routers.omnigent_agent_profiles import _digest
+from api_service.db.models import (
+    Base,
+    OmnigentAgentProfile,
+    OmnigentAgentProfileVersion,
+)
+from api_service.services.omnigent_agent_bootstrap_service import (
+    build_bootstrap_document,
+)
+
+pytestmark = [pytest.mark.asyncio]
+
+
+@pytest_asyncio.fixture()
+async def session_maker(tmp_path):
+    engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path}/bridge.db")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    maker = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    yield maker
+    await engine.dispose()
+
+
+async def _add_default(maker, *, state: str, active_version: int | None):
+    document = build_bootstrap_document("codex-prod")
+    async with maker() as session:
+        session.add_all(
+            [
+                OmnigentAgentProfile(
+                    profile_id="codex-team",
+                    display_name="Codex Team",
+                    visibility="workspace",
+                    state=state,
+                    active_version=active_version,
+                    default_for_runtime=True,
+                ),
+                OmnigentAgentProfileVersion(
+                    profile_id="codex-team",
+                    version=1,
+                    digest=_digest(document),
+                    document=document,
+                    upstream_snapshot={"id": "codex-prod", "name": "Codex Prod"},
+                ),
+            ]
+        )
+        await session.commit()
+
+
+async def test_launch_prefers_durable_active_default(session_maker, monkeypatch):
+    monkeypatch.delenv("OMNIGENT_DEFAULT_AGENT_NAME", raising=False)
+    await _add_default(session_maker, state="active", active_version=1)
+    async with session_maker() as session:
+        resolved = await bridge._get_launch_default_agent_name(session)
+    assert resolved == "Codex Prod"
+
+
+async def test_launch_uses_env_fallback_when_no_durable_default(
+    session_maker, monkeypatch
+):
+    monkeypatch.setenv("OMNIGENT_DEFAULT_AGENT_NAME", "codex-env")
+    async with session_maker() as session:
+        resolved = await bridge._get_launch_default_agent_name(session)
+    assert resolved == "codex-env"
+
+
+async def test_launch_fails_closed_on_conflicting_default(session_maker, monkeypatch):
+    monkeypatch.setenv("OMNIGENT_DEFAULT_AGENT_NAME", "codex-env")
+    await _add_default(session_maker, state="draft", active_version=None)
+    async with session_maker() as session:
+        with pytest.raises(HTTPException) as exc_info:
+            await bridge._get_launch_default_agent_name(session)
+    assert exc_info.value.status_code == 409

--- a/tests/unit/api/routers/test_omnigent_bridge_default_agent.py
+++ b/tests/unit/api/routers/test_omnigent_bridge_default_agent.py
@@ -61,7 +61,7 @@ async def test_launch_prefers_durable_active_default(session_maker, monkeypatch)
     await _add_default(session_maker, state="active", active_version=1)
     async with session_maker() as session:
         resolved = await bridge._get_launch_default_agent_name(session)
-    assert resolved == "Codex Prod"
+    assert resolved == "codex-prod"
 
 
 async def test_launch_uses_env_fallback_when_no_durable_default(

--- a/tests/unit/omnigent/test_bridge_proxy.py
+++ b/tests/unit/omnigent/test_bridge_proxy.py
@@ -150,6 +150,7 @@ class _FakeClient:
         self.posted_events: list[tuple[str, dict[str, Any]]] = []
         self.resolved_elicitations: list[tuple[str, str, dict[str, Any]]] = []
         self.list_agents_calls = 0
+        self.imported_bundles: list[tuple[str, bytes, str]] = []
 
     async def list_agents(self) -> list[dict[str, Any]]:
         self.list_agents_calls += 1
@@ -160,6 +161,12 @@ class _FakeClient:
         if self.create_error is not None:
             raise self.create_error
         return {"id": "sess-9"}
+
+    async def create_agent_bundle(
+        self, *, filename: str, content: bytes, content_type: str
+    ) -> dict[str, Any]:
+        self.imported_bundles.append((filename, content, content_type))
+        return {"id": "agent-imported", "version": "v1"}
 
     async def get_session(self, session_id: str) -> dict[str, Any]:
         self.get_calls.append(session_id)
@@ -613,6 +620,18 @@ async def test_list_agents_proxies() -> None:
     proxy = _proxy(_FakeStore(), _FakeClient())
     agents = await proxy.list_agents()
     assert agents == [{"id": "agent-1", "name": "codex"}]
+
+
+async def test_import_agent_bundle_uses_authenticated_upstream_client() -> None:
+    client = _FakeClient()
+    proxy = _proxy(_FakeStore(), client)
+
+    result = await proxy.import_agent_bundle(
+        filename="agent.bundle", content=b"archive", content_type="application/zip"
+    )
+
+    assert result == {"id": "agent-imported", "version": "v1"}
+    assert client.imported_bundles == [("agent.bundle", b"archive", "application/zip")]
 
 
 async def test_post_event_forwards_native_control() -> None:

--- a/tests/unit/omnigent/test_bridge_proxy.py
+++ b/tests/unit/omnigent/test_bridge_proxy.py
@@ -854,3 +854,40 @@ async def test_stop_session_preserves_stock_control_event_type() -> None:
     await _proxy(_FakeStore(), client).stop_session("sess-9")
 
     assert client.posted_events == [("sess-9", {"type": "stop_session"})]
+
+
+async def test_default_agent_name_override_takes_precedence() -> None:
+    # MoonLadderStudios/MoonMind#3517 §8: the launch boundary supplies the
+    # durable default agent selection, which must win over the env-derived
+    # baked-in fallback when the request carries no explicit agent.
+    store, client = _FakeStore(), _FakeClient()
+    proxy = OmnigentBridgeSessionProxy(
+        run_store=store, client=client, default_agent_name="does-not-exist"
+    )
+    req = BridgeSessionCreateRequest(
+        host_type="managed",
+        workspace="https://github.com/org/repo#main",
+    )
+
+    response = await proxy.create_session(
+        request=req, binding=_binding(), default_agent_name_override="codex"
+    )
+
+    assert response["id"] == "sess-9"
+    assert client.created_payloads[0]["agent_id"] == "agent-1"
+
+
+async def test_baked_in_default_used_when_override_absent() -> None:
+    store, client = _FakeStore(), _FakeClient()
+    proxy = _proxy(store, client)  # baked-in default_agent_name="codex"
+    req = BridgeSessionCreateRequest(
+        host_type="managed",
+        workspace="https://github.com/org/repo#main",
+    )
+
+    response = await proxy.create_session(
+        request=req, binding=_binding(), default_agent_name_override=None
+    )
+
+    assert client.created_payloads[0]["agent_id"] == "agent-1"
+    assert response["id"] == "sess-9"

--- a/tests/unit/services/test_omnigent_agent_bootstrap_service.py
+++ b/tests/unit/services/test_omnigent_agent_bootstrap_service.py
@@ -102,8 +102,8 @@ async def test_durable_active_default_wins_over_env(session):
     assert resolution.source == "durable_profile"
     assert resolution.used_env_fallback is False
     assert resolution.agent_id == "codex-prod"
-    # The name-based fallback slot prefers the resolved upstream name snapshot.
-    assert resolution.default_agent_name == "Codex"
+    # The launch boundary preserves the durable ID instead of a mutable name.
+    assert resolution.default_agent_name == "codex-prod"
     assert resolution.profile_id == "codex-team"
     assert resolution.version == 1
 

--- a/tests/unit/services/test_omnigent_agent_bootstrap_service.py
+++ b/tests/unit/services/test_omnigent_agent_bootstrap_service.py
@@ -1,0 +1,192 @@
+"""Durable bootstrap default resolution + seeding (MoonLadderStudios/MoonMind#3517 §8)."""
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+from api_service.api.routers.omnigent_agent_profiles import (
+    AgentProfileDocument,
+    _digest as router_digest,
+    _normalized,
+)
+from api_service.db.models import (
+    Base,
+    OmnigentAgentProfile,
+    OmnigentAgentProfileAuditEvent,
+    OmnigentAgentProfileVersion,
+)
+from api_service.services.omnigent_agent_bootstrap_service import (
+    BOOTSTRAP_PROFILE_ID,
+    BootstrapDefaultConflictError,
+    build_bootstrap_document,
+    resolve_default_agent_selection,
+    seed_bootstrap_agent_profile,
+)
+
+pytestmark = [pytest.mark.asyncio]
+
+
+@pytest_asyncio.fixture()
+async def session(tmp_path) -> AsyncSession:
+    engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path}/bootstrap.db")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    maker = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with maker() as db:
+        yield db
+    await engine.dispose()
+
+
+async def _add_default_profile(
+    session: AsyncSession,
+    *,
+    state: str = "active",
+    active_version: int | None = 1,
+    upstream_id: str = "codex-prod",
+    upstream_name: str | None = "Codex Production",
+) -> None:
+    document = build_bootstrap_document(upstream_id)
+    profile = OmnigentAgentProfile(
+        profile_id="codex-team",
+        display_name="Codex Team",
+        visibility="workspace",
+        state=state,
+        active_version=active_version,
+        default_for_runtime=True,
+    )
+    version = OmnigentAgentProfileVersion(
+        profile_id="codex-team",
+        version=1,
+        digest=router_digest(document),
+        document=document,
+        upstream_snapshot={"id": upstream_id, "name": upstream_name}
+        if upstream_name
+        else {"id": upstream_id},
+    )
+    session.add_all([profile, version])
+    await session.commit()
+
+
+async def test_bootstrap_document_matches_router_normalized_form():
+    document = build_bootstrap_document("codex-default")
+    normalized = _normalized(AgentProfileDocument.model_validate(document))
+    assert normalized == document
+    assert router_digest(document) == router_digest(normalized)
+
+
+async def test_resolves_env_fallback_and_records_use(session):
+    resolution = await resolve_default_agent_selection(
+        session, env={"OMNIGENT_DEFAULT_AGENT_NAME": "codex-default"}
+    )
+    assert resolution.source == "env_fallback"
+    assert resolution.used_env_fallback is True
+    assert resolution.default_agent_name == "codex-default"
+    assert resolution.profile_id is None
+
+
+async def test_resolves_none_when_no_durable_state_and_no_env(session):
+    resolution = await resolve_default_agent_selection(session, env={})
+    assert resolution.source == "none"
+    assert resolution.default_agent_name == ""
+    assert resolution.used_env_fallback is False
+
+
+async def test_durable_active_default_wins_over_env(session):
+    await _add_default_profile(session, upstream_id="codex-prod", upstream_name="Codex")
+    resolution = await resolve_default_agent_selection(
+        session, env={"OMNIGENT_DEFAULT_AGENT_NAME": "env-ignored"}
+    )
+    assert resolution.source == "durable_profile"
+    assert resolution.used_env_fallback is False
+    assert resolution.agent_id == "codex-prod"
+    # The name-based fallback slot prefers the resolved upstream name snapshot.
+    assert resolution.default_agent_name == "Codex"
+    assert resolution.profile_id == "codex-team"
+    assert resolution.version == 1
+
+
+async def test_durable_default_without_snapshot_name_falls_back_to_stable_id(session):
+    await _add_default_profile(session, upstream_id="codex-prod", upstream_name=None)
+    resolution = await resolve_default_agent_selection(session, env={})
+    assert resolution.agent_id == "codex-prod"
+    assert resolution.default_agent_name == "codex-prod"
+
+
+async def test_default_marked_but_not_active_fails_closed(session):
+    await _add_default_profile(session, state="draft", active_version=None)
+    with pytest.raises(BootstrapDefaultConflictError):
+        await resolve_default_agent_selection(
+            session, env={"OMNIGENT_DEFAULT_AGENT_NAME": "env-ignored"}
+        )
+
+
+async def test_seed_materializes_draft_bootstrap_profile(session):
+    seeded = await seed_bootstrap_agent_profile(
+        session, env={"OMNIGENT_DEFAULT_AGENT_NAME": "codex-default"}
+    )
+    assert seeded == BOOTSTRAP_PROFILE_ID
+
+    profile = await session.get(OmnigentAgentProfile, BOOTSTRAP_PROFILE_ID)
+    assert profile is not None
+    assert profile.state == "draft"
+    assert profile.default_for_runtime is False
+    assert profile.active_version is None
+
+    version = await session.scalar(
+        select(OmnigentAgentProfileVersion).where(
+            OmnigentAgentProfileVersion.profile_id == BOOTSTRAP_PROFILE_ID
+        )
+    )
+    assert version.version == 1
+    assert version.document["source"]["upstreamId"] == "codex-default"
+    assert version.digest == router_digest(build_bootstrap_document("codex-default"))
+    assert version.rollout_metadata["origin"] == "env_bootstrap"
+
+    audit = await session.scalar(
+        select(OmnigentAgentProfileAuditEvent).where(
+            OmnigentAgentProfileAuditEvent.profile_id == BOOTSTRAP_PROFILE_ID
+        )
+    )
+    assert audit.action == "bootstrap_materialized"
+
+    # A seeded draft is not active, so the env fallback still governs and is
+    # recorded until an operator validates and promotes the version.
+    resolution = await resolve_default_agent_selection(
+        session, env={"OMNIGENT_DEFAULT_AGENT_NAME": "codex-default"}
+    )
+    assert resolution.source == "env_fallback"
+
+
+async def test_seed_is_idempotent(session):
+    first = await seed_bootstrap_agent_profile(
+        session, env={"OMNIGENT_DEFAULT_AGENT_NAME": "codex-default"}
+    )
+    second = await seed_bootstrap_agent_profile(
+        session, env={"OMNIGENT_DEFAULT_AGENT_NAME": "codex-default"}
+    )
+    assert first == BOOTSTRAP_PROFILE_ID
+    assert second is None
+    count = await session.scalar(
+        select(func.count()).select_from(OmnigentAgentProfile)
+    )
+    assert count == 1
+
+
+async def test_seed_skipped_when_durable_state_exists(session):
+    await _add_default_profile(session)
+    seeded = await seed_bootstrap_agent_profile(
+        session, env={"OMNIGENT_DEFAULT_AGENT_NAME": "codex-default"}
+    )
+    assert seeded is None
+    assert await session.get(OmnigentAgentProfile, BOOTSTRAP_PROFILE_ID) is None
+
+
+async def test_seed_skipped_when_env_absent(session):
+    assert await seed_bootstrap_agent_profile(session, env={}) is None
+    count = await session.scalar(
+        select(func.count()).select_from(OmnigentAgentProfile)
+    )
+    assert count == 0

--- a/tests/unit/services/test_omnigent_agent_bundle_service.py
+++ b/tests/unit/services/test_omnigent_agent_bundle_service.py
@@ -6,6 +6,7 @@ import pytest
 
 from api_service.services.omnigent_agent_bundle_service import (
     BundleValidationError,
+    publish_validated_agent_bundle,
     validate_agent_bundle,
 )
 
@@ -72,4 +73,71 @@ def test_bundle_requires_one_supported_manifest():
         validate_agent_bundle(
             bundle({"manifest.json": manifest(schemaVersion="future")}),
             "application/zip",
+        )
+
+
+@pytest.mark.asyncio
+async def test_publish_validated_bundle_returns_bounded_upstream_identity():
+    payload = bundle({"manifest.json": manifest()})
+
+    async def publish(**kwargs):
+        assert kwargs["filename"] == "team-codex-v3.bundle"
+        assert kwargs["content"] == payload
+        return {
+            "id": "agent-123",
+            "name": "team-codex",
+            "version": "v7",
+            "ignored": {"credentials": "must-not-be-persisted"},
+        }
+
+    result = await publish_validated_agent_bundle(
+        data=payload,
+        content_type="application/zip",
+        expected_digest="sha256:" + __import__("hashlib").sha256(payload).hexdigest(),
+        filename="team-codex-v3.bundle",
+        publish=publish,
+    )
+
+    assert result == {
+        "schemaVersion": "moonmind.omnigent-agent-bundle-import.v1",
+        "status": "succeeded",
+        "upstreamAgent": {"id": "agent-123", "name": "team-codex", "version": "v7"},
+    }
+
+
+@pytest.mark.asyncio
+async def test_publish_validated_bundle_rejects_digest_mismatch_before_side_effect():
+    called = False
+
+    async def publish(**kwargs):
+        nonlocal called
+        called = True
+        return {}
+
+    with pytest.raises(BundleValidationError, match="digest"):
+        await publish_validated_agent_bundle(
+            data=bundle({"manifest.json": manifest()}),
+            content_type="application/zip",
+            expected_digest="sha256:" + "0" * 64,
+            filename="agent.zip",
+            publish=publish,
+        )
+
+    assert called is False
+
+
+@pytest.mark.asyncio
+async def test_publish_validated_bundle_requires_stable_upstream_identity():
+    payload = bundle({"manifest.json": manifest()})
+
+    async def publish(**kwargs):
+        return {"name": "display-name-is-not-identity"}
+
+    with pytest.raises(BundleValidationError, match="stable agent id"):
+        await publish_validated_agent_bundle(
+            data=payload,
+            content_type="application/zip",
+            expected_digest="sha256:" + __import__("hashlib").sha256(payload).hexdigest(),
+            filename="agent.zip",
+            publish=publish,
         )

--- a/tests/unit/services/test_omnigent_agent_profile_selection.py
+++ b/tests/unit/services/test_omnigent_agent_profile_selection.py
@@ -1,0 +1,89 @@
+"""Authoring-boundary tests for immutable Omnigent profile snapshots."""
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+from fastapi import HTTPException
+
+from api_service.db.models import (
+    ManagedAgentProviderProfile,
+    OmnigentAgentProfile,
+    OmnigentAgentProfileUsage,
+    OmnigentAgentProfileVersion,
+)
+from api_service.services.omnigent_agent_profile_selection import (
+    resolve_agent_profile_snapshot,
+)
+
+
+class _Session:
+    def __init__(self, *, state="active", ready=True):
+        self.profile = SimpleNamespace(
+            profile_id="team-codex", state=state, visibility="workspace",
+            owner_id=uuid4(), active_version=2,
+        )
+        self.version = SimpleNamespace(
+            version=2, digest="sha256:" + "a" * 64,
+            document={
+                "endpointRef": "default", "bridgeMode": "proxy",
+                "source": {"bundleArtifactRef": "artifact://bundle", "bundleDigest": "sha256:" + "b" * 64},
+                "harness": "codex-native", "requiredCapabilities": ["session.start"],
+                "execution": {"defaultExecutionProfileRef": "omnigent-codex@1", "allowedLaunchPolicyRefs": ["on-demand@1"]},
+                "providerRequirements": {"runtimeId": "codex_cli", "credentialSource": "oauth", "materializationMode": "host", "providerIds": ["openai"]},
+                "model": {"model": "gpt-5.4"}, "capture": {}, "rag": {}, "publish": {}, "policyRef": "default@1",
+            },
+            validation_result={"ready": ready}, upstream_snapshot={"id": "bundle"},
+        )
+        self.provider = SimpleNamespace(profile_id="oauth-team")
+        self.added = []
+
+    async def get(self, model, key):
+        return self.profile if model is OmnigentAgentProfile else None
+
+    async def scalar(self, statement):
+        entity = statement.column_descriptions[0].get("entity")
+        if entity is OmnigentAgentProfileVersion:
+            return self.version
+        if entity is ManagedAgentProviderProfile:
+            return self.provider
+        return None
+
+    def add(self, value):
+        self.added.append(value)
+
+    async def flush(self):
+        return None
+
+
+@pytest.mark.asyncio
+async def test_resolver_persists_exact_version_digest_and_effective_overrides():
+    session = _Session()
+    user = SimpleNamespace(id=uuid4())
+
+    snapshot = await resolve_agent_profile_snapshot(
+        session, selection={"profileId": "team-codex", "version": 2, "overrides": {"model": {"effort": "high"}}},
+        consumer_type="checkpoint", consumer_id="branch-1", user=user,
+    )
+
+    assert snapshot["profileId"] == "team-codex"
+    assert snapshot["version"] == 2
+    assert snapshot["digest"] == "sha256:" + "a" * 64
+    assert snapshot["document"]["model"] == {"model": "gpt-5.4", "effort": "high"}
+    assert snapshot["providerProfileRef"] == "oauth-team"
+    usage = session.added[0]
+    assert isinstance(usage, OmnigentAgentProfileUsage)
+    assert usage.consumer_type == "checkpoint"
+    assert usage.effective_snapshot == snapshot
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(("state", "ready", "message"), [
+    ("disabled", True, "not active"),
+    ("active", False, "not launch ready"),
+])
+async def test_resolver_rejects_disabled_or_unready_versions(state, ready, message):
+    with pytest.raises(HTTPException, match=message):
+        await resolve_agent_profile_snapshot(
+            _Session(state=state, ready=ready), selection={"profileId": "team-codex"},
+            consumer_type="workflow", consumer_id="workflow-1", user=SimpleNamespace(id=uuid4()),
+        )

--- a/tests/unit/services/test_omnigent_agent_profile_selection.py
+++ b/tests/unit/services/test_omnigent_agent_profile_selection.py
@@ -43,6 +43,8 @@ class _Session:
             max_parallel_runs=1, cooldown_after_429_seconds=900,
             runtime_id="codex_cli", credential_source=ProviderCredentialSource.OAUTH_VOLUME,
             runtime_materialization_mode=RuntimeMaterializationMode.OAUTH_HOME,
+            provider_id="openai", volume_ref="codex-oauth",
+            volume_mount_path="/root/.codex", secret_refs={},
             credential_bindings=[], command_behavior={"auth_readiness": {"launch_ready": True}},
         )
         self.added = []

--- a/tests/unit/services/test_omnigent_agent_profile_selection.py
+++ b/tests/unit/services/test_omnigent_agent_profile_selection.py
@@ -86,7 +86,11 @@ async def test_resolver_persists_exact_version_digest_and_effective_overrides():
     assert snapshot["profileId"] == "team-codex"
     assert snapshot["version"] == 2
     assert snapshot["digest"] == "sha256:" + "a" * 64
-    assert snapshot["document"]["model"] == {"model": "gpt-5.4", "effort": "high"}
+    assert snapshot["document"]["model"] == {
+        "model": "gpt-5.4",
+        "effort": "high",
+        "settings": {},
+    }
     assert snapshot["providerProfileRef"] == "oauth-team"
     assert snapshot["agentId"] == "imported-agent"
     assert snapshot["launchPolicyRef"] == "on-demand@1"

--- a/tests/unit/services/test_omnigent_agent_profile_selection.py
+++ b/tests/unit/services/test_omnigent_agent_profile_selection.py
@@ -10,6 +10,9 @@ from api_service.db.models import (
     OmnigentAgentProfile,
     OmnigentAgentProfileUsage,
     OmnigentAgentProfileVersion,
+    ProviderCredentialSource,
+    ProviderProfileAuthState,
+    RuntimeMaterializationMode,
 )
 from api_service.services.omnigent_agent_profile_selection import (
     resolve_agent_profile_snapshot,
@@ -34,7 +37,14 @@ class _Session:
             },
             validation_result={"ready": ready}, upstream_snapshot={"id": "bundle"},
         )
-        self.provider = SimpleNamespace(profile_id="oauth-team")
+        self.provider = SimpleNamespace(
+            profile_id="oauth-team", enabled=True,
+            auth_state=ProviderProfileAuthState.CONNECTED, disabled_reason=None,
+            max_parallel_runs=1, cooldown_after_429_seconds=900,
+            runtime_id="codex_cli", credential_source=ProviderCredentialSource.OAUTH_VOLUME,
+            runtime_materialization_mode=RuntimeMaterializationMode.OAUTH_HOME,
+            credential_bindings=[], command_behavior={"auth_readiness": {"launch_ready": True}},
+        )
         self.added = []
 
     async def get(self, model, key):
@@ -61,7 +71,7 @@ async def test_resolver_persists_exact_version_digest_and_effective_overrides():
     user = SimpleNamespace(id=uuid4())
 
     snapshot = await resolve_agent_profile_snapshot(
-        session, selection={"profileId": "team-codex", "version": 2, "overrides": {"model": {"effort": "high"}}},
+        session, selection={"profileId": "team-codex", "version": 2, "providerProfileRef": "oauth-team", "overrides": {"model": {"effort": "high"}}},
         consumer_type="checkpoint", consumer_id="branch-1", user=user,
     )
 
@@ -84,6 +94,34 @@ async def test_resolver_persists_exact_version_digest_and_effective_overrides():
 async def test_resolver_rejects_disabled_or_unready_versions(state, ready, message):
     with pytest.raises(HTTPException, match=message):
         await resolve_agent_profile_snapshot(
-            _Session(state=state, ready=ready), selection={"profileId": "team-codex"},
+            _Session(state=state, ready=ready), selection={"profileId": "team-codex", "providerProfileRef": "oauth-team"},
+            consumer_type="workflow", consumer_id="workflow-1", user=SimpleNamespace(id=uuid4()),
+        )
+
+
+@pytest.mark.asyncio
+async def test_resolver_requires_authored_provider_profile_identity():
+    with pytest.raises(HTTPException, match="providerProfileRef is required"):
+        await resolve_agent_profile_snapshot(
+            _Session(), selection={"profileId": "team-codex"},
+            consumer_type="workflow", consumer_id="workflow-1", user=SimpleNamespace(id=uuid4()),
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("overrides", [
+    {"rag": {"maxTokens": 2001}},
+    {"capture": {"retentionDays": 31}},
+    {"publish": {"mode": "auto"}},
+])
+async def test_resolver_rejects_overrides_above_versioned_ceilings(overrides):
+    session = _Session()
+    session.version.document["rag"] = {"maxTokens": 2000}
+    session.version.document["capture"] = {"retentionDays": 30}
+    session.version.document["publish"] = {"mode": "draft"}
+    with pytest.raises(HTTPException, match="policy ceiling"):
+        await resolve_agent_profile_snapshot(
+            session,
+            selection={"profileId": "team-codex", "providerProfileRef": "oauth-team", "overrides": overrides},
             consumer_type="workflow", consumer_id="workflow-1", user=SimpleNamespace(id=uuid4()),
         )

--- a/tests/unit/services/test_omnigent_agent_profile_selection.py
+++ b/tests/unit/services/test_omnigent_agent_profile_selection.py
@@ -36,6 +36,12 @@ class _Session:
                 "model": {"model": "gpt-5.4"}, "capture": {}, "rag": {}, "publish": {}, "policyRef": "default@1",
             },
             validation_result={"ready": ready}, upstream_snapshot={"id": "bundle"},
+            rollout_metadata={
+                "bundleImport": {
+                    "status": "succeeded",
+                    "upstreamAgent": {"id": "imported-agent"},
+                }
+            },
         )
         self.provider = SimpleNamespace(
             profile_id="oauth-team", enabled=True,
@@ -82,6 +88,8 @@ async def test_resolver_persists_exact_version_digest_and_effective_overrides():
     assert snapshot["digest"] == "sha256:" + "a" * 64
     assert snapshot["document"]["model"] == {"model": "gpt-5.4", "effort": "high"}
     assert snapshot["providerProfileRef"] == "oauth-team"
+    assert snapshot["agentId"] == "imported-agent"
+    assert snapshot["launchPolicyRef"] == "on-demand@1"
     usage = session.added[0]
     assert isinstance(usage, OmnigentAgentProfileUsage)
     assert usage.consumer_type == "checkpoint"
@@ -108,6 +116,40 @@ async def test_resolver_requires_authored_provider_profile_identity():
             _Session(), selection={"profileId": "team-codex"},
             consumer_type="workflow", consumer_id="workflow-1", user=SimpleNamespace(id=uuid4()),
         )
+
+
+@pytest.mark.asyncio
+async def test_resolver_rejects_malformed_version_as_validation_error():
+    with pytest.raises(HTTPException) as caught:
+        await resolve_agent_profile_snapshot(
+            _Session(),
+            selection={
+                "profileId": "team-codex",
+                "version": "latest",
+                "providerProfileRef": "oauth-team",
+            },
+            consumer_type="workflow",
+            consumer_id="workflow-1",
+            user=SimpleNamespace(id=uuid4()),
+        )
+    assert caught.value.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_resolver_revalidates_effective_override_document():
+    with pytest.raises(HTTPException) as caught:
+        await resolve_agent_profile_snapshot(
+            _Session(),
+            selection={
+                "profileId": "team-codex",
+                "providerProfileRef": "oauth-team",
+                "overrides": {"model": {"apiToken": "forbidden"}},
+            },
+            consumer_type="workflow",
+            consumer_id="workflow-1",
+            user=SimpleNamespace(id=uuid4()),
+        )
+    assert caught.value.status_code == 422
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/test_omnigent_agent_smoke_service.py
+++ b/tests/unit/services/test_omnigent_agent_smoke_service.py
@@ -1,0 +1,276 @@
+"""Bounded smoke validation for Omnigent agent profiles (MoonLadderStudios/MoonMind#3517 §7)."""
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+from api_service.db.models import (
+    Base,
+    ManagedAgentProviderProfile,
+    OmnigentUpstreamAgentProjection,
+    ProviderCredentialSource,
+    RuntimeMaterializationMode,
+)
+from api_service.services.omnigent_agent_profile_service import projection_identity
+from api_service.services.omnigent_agent_smoke_service import (
+    ReadinessOutcome,
+    run_profile_readiness_checks,
+    run_smoke_validation,
+    scrub_diagnostics,
+)
+
+pytestmark = [pytest.mark.asyncio]
+
+
+# --------------------------------------------------------------------------
+# Orchestration: timeout budget, guaranteed cleanup, secret-scanned diagnostics
+# --------------------------------------------------------------------------
+
+
+def _ready_outcome():
+    return ReadinessOutcome(
+        checks=[{"name": "provider_profile", "ready": True, "reason": None}],
+        upstream_snapshot={"id": "agent-1"},
+    )
+
+
+async def _ok_probe():
+    return {"ready": True, "reason": None}
+
+
+class _FakeClock:
+    def __init__(self):
+        self._t = 0.0
+
+    def __call__(self):
+        self._t += 0.25
+        return self._t
+
+
+async def test_smoke_pass_appends_session_start_and_is_ready():
+    async def preflight():
+        return _ready_outcome()
+
+    result = await run_smoke_validation(
+        preflight=preflight,
+        session_start_probe=_ok_probe,
+        monotonic=_FakeClock(),
+        profile_id="codex",
+        version=3,
+    )
+    assert result["ready"] is True
+    assert result["timedOut"] is False
+    assert result["version"] == 3
+    names = [check["name"] for check in result["checks"]]
+    assert names == ["provider_profile", "session_start"]
+    assert result["durationMs"] >= 0
+
+
+async def test_failing_check_marks_not_ready():
+    async def preflight():
+        return ReadinessOutcome(
+            checks=[{"name": "provider_profile", "ready": False, "reason": "no provider"}]
+        )
+
+    result = await run_smoke_validation(
+        preflight=preflight,
+        session_start_probe=_ok_probe,
+        profile_id="codex",
+        version=1,
+    )
+    assert result["ready"] is False
+
+
+async def test_timeout_releases_leases_and_reports_timed_out():
+    released = {"value": False}
+
+    async def slow_preflight():
+        await asyncio.sleep(5)
+        return _ready_outcome()
+
+    async def cleanup():
+        released["value"] = True
+
+    result = await run_smoke_validation(
+        preflight=slow_preflight,
+        session_start_probe=_ok_probe,
+        cleanup=cleanup,
+        timeout_seconds=0.05,
+        profile_id="codex",
+        version=1,
+    )
+    assert result["timedOut"] is True
+    assert result["ready"] is False
+    assert result["checks"][0]["name"] == "smoke_timeout"
+    assert released["value"] is True
+
+
+async def test_cleanup_runs_when_preflight_errors():
+    released = {"value": False}
+
+    async def broken_preflight():
+        raise RuntimeError("boom")
+
+    async def cleanup():
+        released["value"] = True
+
+    result = await run_smoke_validation(
+        preflight=broken_preflight,
+        session_start_probe=_ok_probe,
+        cleanup=cleanup,
+        profile_id="codex",
+        version=1,
+    )
+    assert result["ready"] is False
+    assert result["checks"][0]["name"] == "smoke_error"
+    assert released["value"] is True
+
+
+async def test_probe_diagnostics_are_secret_scanned():
+    diagnostics: list[str] = []
+
+    async def preflight():
+        return _ready_outcome()
+
+    async def leaky_probe():
+        diagnostics.append("session-start probe failed: token=ghp_" + "a" * 36)
+        return {"ready": False, "reason": "endpoint unreachable"}
+
+    result = await run_smoke_validation(
+        preflight=preflight,
+        session_start_probe=leaky_probe,
+        diagnostics=diagnostics,
+        profile_id="codex",
+        version=1,
+    )
+    assert result["ready"] is False
+    joined = " ".join(result["diagnostics"])
+    assert "ghp_" not in joined
+    assert "redacted smoke diagnostic" in joined
+
+
+async def test_scrub_diagnostics_bounds_and_redacts():
+    lines = [f"line {i}" for i in range(100)]
+    lines.append("password: hunter2secretvalue")
+    scrubbed = scrub_diagnostics(lines)
+    assert len(scrubbed) <= 32
+    long_line = scrub_diagnostics(["x" * 5000])[0]
+    assert len(long_line) <= 512
+
+
+# --------------------------------------------------------------------------
+# Shared readiness-check core
+# --------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture()
+async def session(tmp_path) -> AsyncSession:
+    engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path}/smoke.db")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    maker = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with maker() as db:
+        yield db
+    await engine.dispose()
+
+
+def _document():
+    return {
+        "endpointRef": "default",
+        "bridgeMode": "proxy",
+        "harness": "codex-native",
+        "requiredCapabilities": ["session.start"],
+        "source": {"upstreamId": "agent-1", "upstreamVersion": "v1"},
+        "providerRequirements": {
+            "runtimeId": "codex_cli",
+            "credentialSource": "secret_ref",
+            "materializationMode": "api_key_env",
+            "providerIds": [],
+        },
+    }
+
+
+async def _noop_refresh():
+    return None
+
+
+async def _unused_bundle_reader(artifact_id):  # pragma: no cover - not reached
+    raise AssertionError("bundle reader should not run for an upstream source")
+
+
+async def test_readiness_upstream_missing_and_no_provider(session):
+    outcome = await run_profile_readiness_checks(
+        session,
+        document=_document(),
+        refresh_upstream=_noop_refresh,
+        read_bundle_bytes=_unused_bundle_reader,
+    )
+    assert outcome.ready is False
+    by_name = {check["name"]: check for check in outcome.checks}
+    assert by_name["upstream_identity"]["ready"] is False
+    assert by_name["provider_profile"]["ready"] is False
+
+
+async def test_readiness_ready_when_projection_fresh_and_provider_compatible(session):
+    now = datetime.now(timezone.utc)
+    session.add(
+        OmnigentUpstreamAgentProjection(
+            projection_id=projection_identity("default", "agent-1", "v1"),
+            endpoint_ref="default",
+            bridge_mode="proxy",
+            upstream_id="agent-1",
+            upstream_version="v1",
+            metadata_snapshot={
+                "harness": "codex-native",
+                "capabilities": ["session.start"],
+                "name": "Codex",
+            },
+            available=True,
+            compatible=True,
+            last_successful_sync_at=now,
+            last_attempt_at=now,
+        )
+    )
+    session.add(
+        ManagedAgentProviderProfile(
+            profile_id="prov-1",
+            runtime_id="codex_cli",
+            provider_id="prov",
+            credential_source=ProviderCredentialSource.SECRET_REF,
+            runtime_materialization_mode=RuntimeMaterializationMode.API_KEY_ENV,
+            enabled=True,
+        )
+    )
+    await session.commit()
+
+    outcome = await run_profile_readiness_checks(
+        session,
+        document=_document(),
+        refresh_upstream=_noop_refresh,
+        read_bundle_bytes=_unused_bundle_reader,
+    )
+    assert outcome.ready is True
+    assert outcome.upstream_snapshot["name"] == "Codex"
+
+
+async def test_readiness_bundle_provenance_fails_for_missing_artifact(session):
+    document = _document()
+    document["source"] = {
+        "bundleArtifactRef": "artifact:missing",
+        "bundleDigest": "sha256:" + "a" * 64,
+    }
+
+    outcome = await run_profile_readiness_checks(
+        session,
+        document=document,
+        refresh_upstream=_noop_refresh,
+        read_bundle_bytes=_unused_bundle_reader,
+    )
+    by_name = {check["name"]: check for check in outcome.checks}
+    assert by_name["bundle_provenance"]["ready"] is False
+    assert "bundle_contents" not in by_name

--- a/tests/unit/services/test_omnigent_agent_smoke_service.py
+++ b/tests/unit/services/test_omnigent_agent_smoke_service.py
@@ -14,6 +14,7 @@ from api_service.db.models import (
     ManagedAgentProviderProfile,
     OmnigentUpstreamAgentProjection,
     ProviderCredentialSource,
+    ProviderProfileAuthState,
     RuntimeMaterializationMode,
 )
 from api_service.services.omnigent_agent_profile_service import projection_identity
@@ -244,6 +245,8 @@ async def test_readiness_ready_when_projection_fresh_and_provider_compatible(ses
             credential_source=ProviderCredentialSource.SECRET_REF,
             runtime_materialization_mode=RuntimeMaterializationMode.API_KEY_ENV,
             enabled=True,
+            auth_state=ProviderProfileAuthState.CONNECTED,
+            secret_refs={"provider_api_key": "env://OPENAI_API_KEY"},
         )
     )
     await session.commit()


### PR DESCRIPTION
Issue: MoonLadderStudios/MoonMind#3517

Closes MoonLadderStudios/MoonMind#3517

Summary:
- complete durable Omnigent agent profile bootstrap, selection, bundle validation, and bounded smoke validation
- wire immutable profile snapshots through workflow, schedule, checkpoint branch, and remediation authoring
- complete dashboard profile lifecycle actions and add authority-boundary regression coverage

Tests run:
- `python -m py_compile api_service/api/routers/executions.py tests/unit/api/routers/test_checkpoint_branch_apis.py`
- `npm run ui:test -- frontend/src/lib/remediationCreateDraft.test.ts frontend/src/entrypoints/workflow-detail.test.tsx` (204 tests passed)
- managed Python test request was attempted, but its ephemeral container disappeared before pytest started; direct inspection and syntax validation found no repository defect

Remaining risks:
- targeted Python tests did not execute in the managed backend because the ephemeral test container was lost; this is recorded as an environment-only verification limitation
