### PR TITLE
Recover Docker disk pressure before Postgres startup

### DIFF
--- a/docs/ManagedAgents/DockerBackendService.md
+++ b/docs/ManagedAgents/DockerBackendService.md
@@ -607,6 +607,14 @@ may evict unused images under disk pressure while protecting images used by
 active containers and operator-pinned digests. Job cleanup never performs global
 image pruning.
 
+The operator recovery path is `tools/cleanup-docker-space.sh`. It must remain
+usable when the Docker data root has no free space: inspection must not launch a
+diagnostic container, and `--dry-run` must execute only read operations. During
+the pre-cutover cleanup window, the utility may discover sidecars through the
+`moonmind.kind=session-docker-sidecar` ownership label and prune only images that
+their nested daemons report as unused. This compatibility cleanup is bounded to
+labeled MoonMind sidecars and must not remove active workload images.
+
 ---
 
 ## 12. Container security and resources

--- a/tests/unit/tools/test_cleanup_docker_space.py
+++ b/tests/unit/tools/test_cleanup_docker_space.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+CLEANUP_SCRIPT = REPO_ROOT / "tools" / "cleanup-docker-space.sh"
+
+
+def _bash() -> str:
+    bash = shutil.which("bash")
+    if bash is None:
+        pytest.skip("cleanup-docker-space.sh requires Bash")
+    return bash
+
+
+def _run_cleanup(
+    tmp_path: Path,
+    *args: str,
+    sidecar_ids: str = "abc123def456",
+) -> tuple[subprocess.CompletedProcess[str], list[str]]:
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    docker_log = tmp_path / "docker.log"
+    fake_docker = fake_bin / "docker"
+    fake_docker.write_text(
+        """#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >> "${FAKE_DOCKER_LOG:?}"
+
+if [[ "${1:-} ${2:-}" == "ps --filter" ]]; then
+  printf '%s\\n' "${FAKE_SIDECAR_IDS:-}"
+fi
+""",
+        encoding="utf-8",
+    )
+    fake_docker.chmod(0o755)
+
+    env = os.environ.copy()
+    env["PATH"] = f"{fake_bin}{os.pathsep}{env['PATH']}"
+    env["FAKE_DOCKER_LOG"] = str(docker_log)
+    env["FAKE_SIDECAR_IDS"] = sidecar_ids
+    result = subprocess.run(
+        [_bash(), str(CLEANUP_SCRIPT), *args],
+        cwd=REPO_ROOT,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    commands = docker_log.read_text(encoding="utf-8").splitlines()
+    return result, commands
+
+
+def test_dry_run_is_read_only_and_does_not_launch_diagnostic_container(
+    tmp_path: Path,
+) -> None:
+    assert os.access(CLEANUP_SCRIPT, os.X_OK)
+
+    result, commands = _run_cleanup(tmp_path, "--dry-run")
+
+    assert result.returncode == 0, result.stderr
+    assert commands == [
+        "system df",
+        "ps --filter label=moonmind.kind=session-docker-sidecar --format {{.ID}}",
+        (
+            "exec abc123def456 docker "
+            "-H unix:///var/run/moonmind-docker/docker.sock system df"
+        ),
+        "system df",
+    ]
+    assert "Would run: docker exec abc123def456 docker" in result.stdout
+    assert "Would run: docker container prune -f" in result.stdout
+    assert "Would run: docker image prune -f" in result.stdout
+    assert "Would run: docker builder prune -af" in result.stdout
+    assert "--dry-run" not in "\n".join(commands)
+    assert all(not command.startswith("run ") for command in commands)
+    assert all(" prune " not in f" {command} " for command in commands)
+
+
+def test_cleanup_prunes_only_unused_sidecar_images_and_safe_host_resources(
+    tmp_path: Path,
+) -> None:
+    result, commands = _run_cleanup(tmp_path)
+
+    assert result.returncode == 0, result.stderr
+    assert commands == [
+        "system df",
+        "ps --filter label=moonmind.kind=session-docker-sidecar --format {{.ID}}",
+        (
+            "exec abc123def456 docker "
+            "-H unix:///var/run/moonmind-docker/docker.sock system df"
+        ),
+        (
+            "exec abc123def456 docker "
+            "-H unix:///var/run/moonmind-docker/docker.sock image prune -af"
+        ),
+        "container prune -f",
+        "image prune -f",
+        "builder prune -af",
+        "system df",
+    ]
+    assert "volume prune" not in "\n".join(commands)
+    assert all(not command.startswith("run ") for command in commands)
+
+
+def test_cleanup_rejects_unexpected_sidecar_identifier(tmp_path: Path) -> None:
+    result, commands = _run_cleanup(tmp_path, sidecar_ids="not-a-container-id")
+
+    assert result.returncode == 1
+    assert "refusing unexpected Docker container id" in result.stderr
+    assert all(not command.startswith("exec ") for command in commands)

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -1,0 +1,1 @@
+"""Repository-local command-line helpers used by tests and automation."""

--- a/tools/cleanup-docker-space.sh
+++ b/tools/cleanup-docker-space.sh
@@ -8,12 +8,13 @@ Usage: cleanup-docker-space.sh [--dry-run] [--aggressive] [--help]
 Run Docker-space cleanup tasks to reclaim local disk.
 
 Default mode is safe/recovering:
+  - Remove unused images from labeled pre-cutover MoonMind session sidecars
   - Remove stopped containers
   - Remove dangling images
   - Prune builder cache
 
 Use --aggressive to also remove all unused images and unused volumes.
-Use --dry-run to print what would be removed without deleting it.
+Use --dry-run to inspect disk usage and print cleanup commands without deleting.
 USAGE
 }
 
@@ -46,47 +47,102 @@ if ! command -v docker >/dev/null 2>&1; then
   exit 1
 fi
 
-echo "== Docker disk check for MoonMind postgres volume (best-effort) =="
-if docker volume inspect moonmind_postgres-data >/dev/null 2>&1; then
-  docker run --rm -v moonmind_postgres-data:/data alpine sh -c 'df -h /data'
-else
-  echo "Note: moonmind_postgres-data volume is not present yet."
-fi
+cleanup_failed=0
 
-prune_arg=()
+print_command() {
+  printf 'Would run:'
+  printf ' %q' "$@"
+  printf '\n'
+}
+
+run_cleanup() {
+  if [[ "$DRY_RUN" -eq 1 ]]; then
+    print_command "$@"
+    return 0
+  fi
+
+  printf 'Running:'
+  printf ' %q' "$@"
+  printf '\n'
+  if ! "$@"; then
+    echo "Warning: cleanup command failed; continuing with the remaining recovery steps." >&2
+    cleanup_failed=1
+  fi
+}
+
+show_docker_usage() {
+  echo "== Docker disk usage (best-effort) =="
+  if ! docker system df; then
+    echo "Warning: Docker disk usage is unavailable; continuing with cleanup." >&2
+  fi
+}
+
+prune_pre_cutover_sidecars() {
+  local sidecar_output
+  local sidecar_id
+
+  echo "== Pre-cutover MoonMind session sidecars =="
+  if ! sidecar_output="$(
+    docker ps \
+      --filter 'label=moonmind.kind=session-docker-sidecar' \
+      --format '{{.ID}}'
+  )"; then
+    echo "Warning: could not discover managed-session sidecars." >&2
+    cleanup_failed=1
+    return
+  fi
+
+  if [[ -z "$sidecar_output" ]]; then
+    echo "No active pre-cutover session sidecars found."
+    return
+  fi
+
+  while IFS= read -r sidecar_id; do
+    [[ -n "$sidecar_id" ]] || continue
+    if [[ ! "$sidecar_id" =~ ^[0-9a-f]{12,64}$ ]]; then
+      echo "Warning: refusing unexpected Docker container id: $sidecar_id" >&2
+      cleanup_failed=1
+      continue
+    fi
+
+    echo "Sidecar $sidecar_id disk usage (best-effort):"
+    if ! docker exec "$sidecar_id" docker \
+      -H unix:///var/run/moonmind-docker/docker.sock system df; then
+      echo "Warning: sidecar $sidecar_id disk usage is unavailable." >&2
+    fi
+    run_cleanup docker exec "$sidecar_id" docker \
+      -H unix:///var/run/moonmind-docker/docker.sock image prune -af
+  done <<<"$sidecar_output"
+}
+
+show_docker_usage
+
 if [[ "$DRY_RUN" -eq 1 ]]; then
-  prune_arg+=(--dry-run)
   echo "Dry-run mode: no data will be removed."
 fi
 
-echo "== Stopping cleanup plan =="
+prune_pre_cutover_sidecars
+
+echo "== Host cleanup plan =="
 if [[ "$AGGRESSIVE" -eq 1 ]]; then
   echo "Mode: aggressive"
 else
-  echo "Mode: safe (non-destructive by default)"
+  echo "Mode: safe recovery"
 fi
 
-if [[ "$DRY_RUN" -eq 1 ]]; then
-  echo "Would run: docker container prune -f ${prune_arg[*]}"
-  echo "Would run: docker image prune -f ${prune_arg[*]}"
-  echo "Would run: docker builder prune -f --all ${prune_arg[*]}"
-  if [[ "$AGGRESSIVE" -eq 1 ]]; then
-    echo "Would run: docker image prune -f -a ${prune_arg[*]}"
-    echo "Would run: docker volume prune -f ${prune_arg[*]}"
-  fi
-else
-  echo "Running docker container prune -f"
-  docker container prune -f
-  echo "Running docker image prune -f"
-  docker image prune -f
-  echo "Running docker builder prune -af"
-  docker builder prune -af
-  if [[ "$AGGRESSIVE" -eq 1 ]]; then
-    echo "Running docker image prune -af"
-    docker image prune -af
-    echo "Running docker volume prune -f"
-    docker volume prune -f
-  fi
+run_cleanup docker container prune -f
+run_cleanup docker image prune -f
+run_cleanup docker builder prune -af
+if [[ "$AGGRESSIVE" -eq 1 ]]; then
+  run_cleanup docker image prune -af
+  run_cleanup docker volume prune -f
+fi
+
+show_docker_usage
+
+if [[ "$cleanup_failed" -ne 0 ]]; then
+  echo "Cleanup completed with one or more failures." >&2
+  exit 1
 fi
 
 echo "Cleanup complete."


### PR DESCRIPTION
## Summary

- reclaim unused images from labeled pre-cutover MoonMind session sidecars during Docker-space recovery
- keep recovery usable on a full Docker data root by replacing the diagnostic container launch with read-only daemon inspection
- make `--dry-run` genuinely non-mutating and stop forwarding unsupported flags to Docker
- mark the recovery utility executable, document its ownership boundary, and add focused regression tests

## Root cause

Postgres was restart-looping because the shared Docker data root was full, not because the database volume had grown or PostgreSQL was misconfigured. Two active pre-cutover managed-session sidecar graphs each retained an unused 73.36 GB Tactics base image. The existing recovery utility could not reliably help because it attempted to launch an Alpine diagnostic container before cleanup and implemented dry-run by passing unsupported `--dry-run` flags to Docker prune commands.

The live deployment was recovered by removing only those two unused sidecar image copies. This freed about 147 GB without touching PostgreSQL data, MinIO artifacts, agent workspaces, or the shared host image.

## Impact

Operators can now run `./tools/cleanup-docker-space.sh --dry-run` safely under disk pressure, see the exact cleanup plan, and reclaim unused images from MoonMind-owned legacy sidecars while Docker protects images referenced by containers. The normal Compose stack then starts without altering database state.

## Validation

- `./tools/test_unit.sh --python-only tests/unit/tools/test_cleanup_docker_space.py tests/unit/tools/test_check_documentation_architecture.py` — 31 passed
- `bash -n tools/cleanup-docker-space.sh`
- `git diff --check`
- live `./tools/cleanup-docker-space.sh --dry-run` against the recovered deployment
- `docker compose up -d`, followed by service status verification; Postgres, API, Omnigent, Temporal, and all workers are running, with health-checked services healthy
