### PR TITLE
Defer Omnigent checkpoints until workspace materializes

### DIFF
--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -651,6 +651,9 @@ RUN_MANAGED_CHECKPOINT_CAPTURE_PATCH = "run-managed-checkpoint-capture-v1"
 RUN_MANAGED_CHECKPOINT_LOCATOR_GUARD_PATCH = (
     "run-managed-checkpoint-locator-guard-v1"
 )
+RUN_OMNIGENT_PREMATERIALIZATION_CHECKPOINT_GUARD_PATCH = (
+    "run-omnigent-prematerialization-checkpoint-guard-v1"
+)
 RUN_RUNTIME_EXECUTION_CAPABILITIES_PATCH = "run-runtime-execution-capabilities-v1"
 RUN_DURABLE_FINALIZATION_OUTCOME_PATCH = "run-durable-finalization-outcome-v1"
 RUN_SKIP_NO_PUBLISH_PREPUBLICATION_CHECKPOINT_PATCH = (
@@ -6095,6 +6098,38 @@ class MoonMindRunWorkflow:
             self._step_checkpoint_capture_outcomes[logical_step_id] = {
                 "status": "deferred",
                 "failureCode": "CHECKPOINT_WORKSPACE_LOCATOR_UNAVAILABLE",
+                "boundary": str(boundary),
+                "captureAuthority": resolved_policy.capture_authority,
+                "captureActivity": resolved_policy.capture_activity,
+                "capabilityCriticality": resolved_policy.criticality,
+            }
+            return None
+
+        omnigent_checkpoint_capture = capture_input.get(
+            "omnigentCheckpointCapture"
+        )
+        omnigent_capture_boundary_state = (
+            str(
+                omnigent_checkpoint_capture.get("captureBoundaryState") or ""
+            ).strip()
+            if isinstance(omnigent_checkpoint_capture, Mapping)
+            else ""
+        )
+        if (
+            resolved_policy.capture_activity == "workspace.capture_checkpoint"
+            and workflow.patched(
+                RUN_OMNIGENT_PREMATERIALIZATION_CHECKPOINT_GUARD_PATCH
+            )
+            and omnigent_capture_boundary_state == "session_not_started"
+        ):
+            # The deterministic sandbox locator is known before AgentRun starts,
+            # but profile-bound Omnigent owns repository materialization inside
+            # its coordinator activity.  Defer the initial after-prepare and
+            # before-execution captures instead of asking the sandbox worker to
+            # archive a workspace that cannot exist yet.
+            self._step_checkpoint_capture_outcomes[logical_step_id] = {
+                "status": "deferred",
+                "failureCode": "CHECKPOINT_WORKSPACE_MATERIALIZATION_PENDING",
                 "boundary": str(boundary),
                 "captureAuthority": resolved_policy.capture_authority,
                 "captureActivity": resolved_policy.capture_activity,

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -5778,6 +5778,8 @@ class MoonMindRunWorkflow:
         self,
         logical_step_id: str,
         outputs: Mapping[str, Any],
+        *,
+        initialize_omnigent_capture: bool = False,
     ) -> None:
         raw_agent_kind = outputs.get("agentKind") or outputs.get("agent_kind")
         raw_agent_id = outputs.get("agentId") or outputs.get("agent_id")
@@ -5870,9 +5872,15 @@ class MoonMindRunWorkflow:
                         "relativePath": ".",
                     }
                 elif capabilities.runtime_id == "omnigent":
-                    capture_input["omnigentCheckpointCapture"] = {
-                        "captureBoundaryState": "session_not_started"
-                    }
+                    if initialize_omnigent_capture:
+                        # This marker and its authority bit are authored only by
+                        # the workflow call site that resolved the effective
+                        # agent runtime. Candidate plan/result mappings cannot
+                        # opt another sandbox step out of checkpoint capture.
+                        capture_input["omnigentCheckpointCapture"] = {
+                            "captureBoundaryState": "session_not_started"
+                        }
+                        capture_input["omnigentPrematerializationOwned"] = True
                     try:
                         wf_info = workflow.info()
                         identity = StepExecutionIdentityModel(
@@ -5907,7 +5915,14 @@ class MoonMindRunWorkflow:
                 "omnigent_checkpoint_capture"
             )
             if isinstance(omnigent_capture, Mapping):
-                capture_input["omnigentCheckpointCapture"] = dict(omnigent_capture)
+                candidate_capture = dict(omnigent_capture)
+                if (
+                    candidate_capture.get("captureBoundaryState")
+                    == "session_not_started"
+                ):
+                    candidate_capture.pop("captureBoundaryState")
+                if candidate_capture:
+                    capture_input["omnigentCheckpointCapture"] = candidate_capture
             omnigent_checkpoint = candidate.get("omnigentCheckpoint") or candidate.get(
                 "omnigent_checkpoint"
             )
@@ -6120,6 +6135,8 @@ class MoonMindRunWorkflow:
             and workflow.patched(
                 RUN_OMNIGENT_PREMATERIALIZATION_CHECKPOINT_GUARD_PATCH
             )
+            and boundary in {"after_prepare", "before_execution"}
+            and capture_input.get("omnigentPrematerializationOwned") is True
             and omnigent_capture_boundary_state == "session_not_started"
         ):
             # The deterministic sandbox locator is known before AgentRun starts,
@@ -11170,6 +11187,16 @@ class MoonMindRunWorkflow:
                 self._record_step_workspace_capture_input(
                     node_id,
                     capture_input_source,
+                    initialize_omnigent_capture=(
+                        tool_type == "agent_runtime"
+                        and _normalize_agent_runtime_id(
+                            self._agent_id_from_runtime_inputs(
+                                node_inputs=node_inputs,
+                                fallback_name=tool_name,
+                            )
+                        )
+                        == "omnigent"
+                    ),
                 )
                 current_step_execution = self._step_execution_for(node_id) or 1
                 attempt_reason = (

--- a/tests/integration/reliability/replays/omnigent-checkpoint-before-workspace/expected-outcome.json
+++ b/tests/integration/reliability/replays/omnigent-checkpoint-before-workspace/expected-outcome.json
@@ -1,0 +1,11 @@
+{
+  "activityCalls": [],
+  "captureOutcome": {
+    "status": "deferred",
+    "failureCode": "CHECKPOINT_WORKSPACE_MATERIALIZATION_PENDING",
+    "boundary": "after_prepare",
+    "captureAuthority": "moonmind_sandbox",
+    "captureActivity": "workspace.capture_checkpoint",
+    "capabilityCriticality": "required"
+  }
+}

--- a/tests/integration/reliability/replays/omnigent-checkpoint-before-workspace/manifest.json
+++ b/tests/integration/reliability/replays/omnigent-checkpoint-before-workspace/manifest.json
@@ -1,0 +1,21 @@
+{
+  "incidentWorkflowId": "mm:06cb96c8-e22f-41ce-8392-476b55f83bd7",
+  "runId": "019fd09d-b880-7e41-add8-d9f8536536cb",
+  "failureShape": "sandbox checkpoint capture was scheduled before the Omnigent coordinator materialized its repository workspace",
+  "boundary": "after_prepare",
+  "stepInputs": {
+    "agentKind": "external",
+    "agentId": "omnigent",
+    "runtime": {
+      "mode": "omnigent"
+    }
+  },
+  "escapedActivityPayload": {
+    "kind": "worktree_archive",
+    "workspaceLocator": {
+      "kind": "sandbox",
+      "workspaceId": "14a2cb0f5fc11332ae612db5",
+      "relativePath": "repo"
+    }
+  }
+}

--- a/tests/integration/reliability/test_escaped_failure_journeys.py
+++ b/tests/integration/reliability/test_escaped_failure_journeys.py
@@ -940,6 +940,65 @@ async def test_managed_checkpoint_waits_for_authoritative_locator(
     ]
 
 
+async def test_omnigent_checkpoint_waits_for_workspace_materialization(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Replay mm:06cb96c8 before the Omnigent coordinator materializes its repo."""
+    replay_id = "omnigent-checkpoint-before-workspace"
+    manifest = load_replay(replay_id, "manifest.json")
+    expected = load_replay(replay_id, "expected-outcome.json")
+    parent = MoonMindRunWorkflow()
+    parent_info = SimpleNamespace(
+        namespace="default",
+        workflow_id=manifest["incidentWorkflowId"],
+        run_id=manifest["runId"],
+        task_queue="mm.workflow.merge_automation",
+        search_attributes={},
+    )
+    monkeypatch.setattr(run_workflow_module.workflow, "info", lambda: parent_info)
+    monkeypatch.setattr(run_workflow_module.workflow, "patched", lambda _patch: True)
+
+    activity_calls: list[str] = []
+
+    async def capture_activity(
+        activity_type: str,
+        _payload: dict[str, object],
+        **_kwargs: object,
+    ) -> object:
+        activity_calls.append(activity_type)
+        raise AssertionError("sandbox capture ran before Omnigent materialized the repo")
+
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "execute_activity",
+        capture_activity,
+    )
+    now = datetime(2026, 8, 5, 6, 30, tzinfo=timezone.utc)
+    parent._initialize_step_ledger(
+        ordered_nodes=[{"id": "node-1", "inputs": {"title": "Implement"}}],
+        dependency_map={"node-1": []},
+        updated_at=now,
+    )
+    parent._mark_step_running("node-1", updated_at=now, summary="Implementing")
+    parent._record_step_workspace_capture_input("node-1", manifest["stepInputs"])
+
+    capture_input = parent._step_workspace_capture_inputs["node-1"]
+    assert capture_input["workspaceLocator"] == manifest["escapedActivityPayload"][
+        "workspaceLocator"
+    ]
+    checkpoint_ref = await parent._record_canonical_step_checkpoint(
+        "node-1",
+        boundary=manifest["boundary"],
+        updated_at=now,
+    )
+
+    assert checkpoint_ref is None
+    assert activity_calls == expected["activityCalls"]
+    assert parent._step_checkpoint_capture_outcomes["node-1"] == expected[
+        "captureOutcome"
+    ]
+
+
 async def test_codex_session_record_uses_step_workflow_checkpoint_authority(
     tmp_path: Path,
 ) -> None:

--- a/tests/integration/reliability/test_escaped_failure_journeys.py
+++ b/tests/integration/reliability/test_escaped_failure_journeys.py
@@ -980,7 +980,11 @@ async def test_omnigent_checkpoint_waits_for_workspace_materialization(
         updated_at=now,
     )
     parent._mark_step_running("node-1", updated_at=now, summary="Implementing")
-    parent._record_step_workspace_capture_input("node-1", manifest["stepInputs"])
+    parent._record_step_workspace_capture_input(
+        "node-1",
+        manifest["stepInputs"],
+        initialize_omnigent_capture=True,
+    )
 
     capture_input = parent._step_workspace_capture_inputs["node-1"]
     assert capture_input["workspaceLocator"] == manifest["escapedActivityPayload"][

--- a/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
@@ -3749,6 +3749,7 @@ async def test_omnigent_checkpoint_defers_until_sandbox_workspace_is_materialize
             "agentId": "omnigent",
             "runtime": {"mode": "omnigent"},
         },
+        initialize_omnigent_capture=True,
     )
 
     async def unexpected_activity(*_args: Any, **_kwargs: Any) -> Any:
@@ -3792,6 +3793,7 @@ async def test_omnigent_checkpoint_guard_replays_previous_activity_shape(
             "agentId": "omnigent",
             "runtime": {"mode": "omnigent"},
         },
+        initialize_omnigent_capture=True,
     )
     captured: list[dict[str, Any]] = []
 
@@ -3827,6 +3829,98 @@ async def test_omnigent_checkpoint_guard_replays_previous_activity_shape(
         "workspace.capture_checkpoint"
     ]
     assert captured[0]["payload"]["workspaceLocator"]["kind"] == "sandbox"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("boundary", ["after_execution", "before_publication"])
+async def test_omnigent_checkpoint_guard_does_not_defer_terminal_boundaries(
+    monkeypatch: pytest.MonkeyPatch,
+    boundary: str,
+) -> None:
+    _configure_workflow_runtime(monkeypatch)
+    monkeypatch.setattr(run_module.workflow, "patched", lambda _patch_id: True)
+    workflow = MoonMindRunWorkflow()
+    workflow._record_step_workspace_capture_input(
+        "node-1",
+        {
+            "agentKind": "external",
+            "agentId": "omnigent",
+            "runtime": {"mode": "omnigent"},
+        },
+        initialize_omnigent_capture=True,
+    )
+    captured: list[str] = []
+
+    async def capture_activity(
+        activity_type: str,
+        payload: dict[str, Any],
+        **_kwargs: Any,
+    ) -> dict[str, Any]:
+        captured.append(activity_type)
+        return _managed_checkpoint_capture_result(payload)
+
+    monkeypatch.setattr(run_module.workflow, "execute_activity", capture_activity)
+    identity = StepExecutionIdentityModel(
+        workflowId="workflow-1",
+        runId="run-1",
+        logicalStepId="node-1",
+        executionOrdinal=1,
+    )
+
+    await workflow._capture_canonical_step_checkpoint_workspace(
+        "node-1", identity=identity, boundary=boundary
+    )
+
+    assert captured == ["workspace.capture_checkpoint"]
+
+
+@pytest.mark.asyncio
+async def test_non_omnigent_input_cannot_inject_prematerialization_defer_marker(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _configure_workflow_runtime(monkeypatch)
+    monkeypatch.setattr(run_module.workflow, "patched", lambda _patch_id: True)
+    workflow = MoonMindRunWorkflow()
+    workflow._record_step_workspace_capture_input(
+        "node-1",
+        {
+            "omnigentCheckpointCapture": {
+                "captureBoundaryState": "session_not_started"
+            },
+            "workspaceLocator": {
+                "kind": "sandbox",
+                "workspaceId": "sandbox-workspace",
+                "relativePath": "repo",
+            },
+            "checkpointKind": "worktree_archive",
+        },
+    )
+    capture_input = workflow._step_workspace_capture_inputs["node-1"]
+    assert "omnigentCheckpointCapture" not in capture_input
+    assert "omnigentPrematerializationOwned" not in capture_input
+    captured: list[str] = []
+
+    async def capture_activity(
+        activity_type: str,
+        payload: dict[str, Any],
+        **_kwargs: Any,
+    ) -> dict[str, Any]:
+        captured.append(activity_type)
+        return _managed_checkpoint_capture_result(payload)
+
+    monkeypatch.setattr(run_module.workflow, "execute_activity", capture_activity)
+    identity = StepExecutionIdentityModel(
+        workflowId="workflow-1",
+        runId="run-1",
+        logicalStepId="node-1",
+        executionOrdinal=1,
+    )
+
+    await workflow._capture_canonical_step_checkpoint_workspace(
+        "node-1", identity=identity, boundary="after_prepare"
+    )
+
+    assert captured == ["workspace.capture_checkpoint"]
 
 
 def test_run_derives_managed_authority_from_agent_id() -> None:
@@ -4276,7 +4370,11 @@ async def test_run_uses_external_omnigent_identity_for_checkpoint_capture(
         tool_name="external",
         step_execution=1,
     )
-    workflow._record_step_workspace_capture_input("implement", node_inputs)
+    workflow._record_step_workspace_capture_input(
+        "implement",
+        node_inputs,
+        initialize_omnigent_capture=True,
+    )
 
     async def fake_execute_activity(
         activity: str,

--- a/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
@@ -3726,6 +3726,109 @@ async def test_managed_checkpoint_locator_guard_replays_previous_activity_shape(
     assert "workspaceLocator" not in captured[0]["payload"]
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize("boundary", ["after_prepare", "before_execution"])
+async def test_omnigent_checkpoint_defers_until_sandbox_workspace_is_materialized(
+    monkeypatch: pytest.MonkeyPatch,
+    boundary: str,
+) -> None:
+    _configure_workflow_runtime(monkeypatch)
+    monkeypatch.setattr(run_module.workflow, "patched", lambda _patch_id: True)
+    workflow = MoonMindRunWorkflow()
+    now = datetime(2026, 8, 5, 6, 30, tzinfo=UTC)
+    workflow._initialize_step_ledger(
+        ordered_nodes=[{"id": "node-1", "inputs": {"title": "Implement"}}],
+        dependency_map={"node-1": []},
+        updated_at=now,
+    )
+    workflow._mark_step_running("node-1", updated_at=now, summary="Implementing")
+    workflow._record_step_workspace_capture_input(
+        "node-1",
+        {
+            "agentKind": "external",
+            "agentId": "omnigent",
+            "runtime": {"mode": "omnigent"},
+        },
+    )
+
+    async def unexpected_activity(*_args: Any, **_kwargs: Any) -> Any:
+        raise AssertionError("capture must wait for Omnigent workspace materialization")
+
+    monkeypatch.setattr(run_module.workflow, "execute_activity", unexpected_activity)
+
+    checkpoint_ref = await workflow._record_canonical_step_checkpoint(
+        "node-1",
+        boundary=boundary,
+        updated_at=now,
+    )
+
+    assert checkpoint_ref is None
+    assert workflow._step_checkpoint_capture_outcomes["node-1"] == {
+        "status": "deferred",
+        "failureCode": "CHECKPOINT_WORKSPACE_MATERIALIZATION_PENDING",
+        "boundary": boundary,
+        "captureAuthority": "moonmind_sandbox",
+        "captureActivity": "workspace.capture_checkpoint",
+        "capabilityCriticality": "required",
+    }
+
+
+@pytest.mark.asyncio
+async def test_omnigent_checkpoint_guard_replays_previous_activity_shape(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _configure_workflow_runtime(monkeypatch)
+    monkeypatch.setattr(
+        run_module.workflow,
+        "patched",
+        lambda patch_id: patch_id
+        != run_module.RUN_OMNIGENT_PREMATERIALIZATION_CHECKPOINT_GUARD_PATCH,
+    )
+    workflow = MoonMindRunWorkflow()
+    workflow._record_step_workspace_capture_input(
+        "node-1",
+        {
+            "agentKind": "external",
+            "agentId": "omnigent",
+            "runtime": {"mode": "omnigent"},
+        },
+    )
+    captured: list[dict[str, Any]] = []
+
+    async def previous_capture_activity(
+        activity_type: str,
+        payload: dict[str, Any],
+        **_kwargs: Any,
+    ) -> dict[str, Any]:
+        captured.append({"activity": activity_type, "payload": payload})
+        return {
+            "status": "captured",
+            "workspace": {"kind": "worktree_archive"},
+            "diagnosticRefs": [],
+        }
+
+    monkeypatch.setattr(
+        run_module.workflow,
+        "execute_activity",
+        previous_capture_activity,
+    )
+    identity = StepExecutionIdentityModel(
+        workflowId="workflow-1",
+        runId="run-1",
+        logicalStepId="node-1",
+        executionOrdinal=1,
+    )
+
+    await workflow._capture_canonical_step_checkpoint_workspace(
+        "node-1", identity=identity, boundary="after_prepare"
+    )
+
+    assert [call["activity"] for call in captured] == [
+        "workspace.capture_checkpoint"
+    ]
+    assert captured[0]["payload"]["workspaceLocator"]["kind"] == "sandbox"
+
+
 def test_run_derives_managed_authority_from_agent_id() -> None:
     workflow = MoonMindRunWorkflow()
 


### PR DESCRIPTION
## Summary

- defer initial Omnigent sandbox checkpoints while the coordinator has not materialized the repository workspace
- preserve existing Temporal history behavior with a replay-safe patch marker
- add focused boundary coverage and a minimized escaped-failure replay for workflow `mm:06cb96c8-e22f-41ce-8392-476b55f83bd7`

## Root cause

The parent workflow derived the deterministic sandbox locator before starting `MoonMind.AgentRun`, while profile-bound Omnigent owns repository checkout inside its coordinator activity. The parent immediately scheduled `workspace.capture_checkpoint` at `after_prepare`, so the sandbox worker correctly rejected a workspace that could not exist yet and the Omnigent child never started.

The workflow now records pre-materialization checkpoint boundaries as deferred with `CHECKPOINT_WORKSPACE_MATERIALIZATION_PENDING`. Once Omnigent returns its materialized workspace evidence, normal checkpoint capture continues unchanged.

## Impact

Codex-via-Omnigent workflows can reach the agent runtime instead of failing during the parent workflow's initial checkpoint. Existing in-flight histories retain their previously recorded activity shape.

## Validation

- `./tools/test_unit.sh --python-only tests/unit/workflows/temporal/workflows/test_run_step_ledger.py` — 97 passed
- `MOONMIND_FORCE_LOCAL_TESTS=1 .venv/bin/python -m pytest tests/integration/reliability/test_escaped_failure_journeys.py -m reliability_journey -q --tb=short --durations=25` — 29 passed
- `git diff --check`
- Python compilation of the changed workflow and test modules
