### PR TITLE
Fix Omnigent agent-profile reruns

### DIFF
--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -60,6 +60,7 @@ from api_service.db.models import (
 )
 from api_service.services.checkpoint_branches import prepare_checkpoint_branch_workspace
 from api_service.services.omnigent_agent_profile_selection import (
+    compile_agent_profile_snapshot_parameters,
     resolve_agent_profile_snapshot,
 )
 from api_service.services.control_stop_continuation import (
@@ -10724,31 +10725,10 @@ async def _create_execution_from_workflow_request(
             consumer_id=reserved_workflow_id,
             user=user,
         )
-        initial_parameters["agentProfileSnapshot"] = profile_snapshot
-        initial_parameters["agentProfile"] = {
-            "profileId": profile_snapshot["profileId"],
-            "version": profile_snapshot["version"],
-            "digest": profile_snapshot["digest"],
-        }
-        effective_profile = profile_snapshot["document"]
-        effective_model = effective_profile.get("model") or {}
-        initial_parameters["profileId"] = profile_snapshot["providerProfileRef"]
-        if effective_model.get("model") is not None:
-            initial_parameters["model"] = effective_model["model"]
-        if effective_model.get("effort") is not None:
-            initial_parameters["effort"] = effective_model["effort"]
-        initial_parameters["omnigent"] = {
-            **dict(initial_parameters.get("omnigent") or {}),
-            "agentProfileRef": (
-                f"{profile_snapshot['profileId']}@{profile_snapshot['version']}"
-            ),
-            "executionProfileRef": profile_snapshot["executionProfileRef"],
-            "launchPolicyRef": profile_snapshot["launchPolicyRef"],
-            "agent": {"agentId": profile_snapshot["agentId"]},
-        }
-        initial_parameters["rag"] = effective_profile.get("rag") or {}
-        initial_parameters["capture"] = effective_profile.get("capture") or {}
-        initial_parameters["workspace"] = effective_profile.get("workspace") or {}
+        initial_parameters = compile_agent_profile_snapshot_parameters(
+            initial_parameters,
+            snapshot=profile_snapshot,
+        )
 
     try:
         start_contract = resolve_user_workflow_start_contract(settings.temporal)

--- a/api_service/services/omnigent_agent_profile_selection.py
+++ b/api_service/services/omnigent_agent_profile_selection.py
@@ -68,6 +68,78 @@ def _enforce_override_ceilings(
         )
 
 
+def compile_agent_profile_snapshot_parameters(
+    parameters: Mapping[str, Any],
+    *,
+    snapshot: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Compile one trusted agent-profile snapshot into workflow parameters.
+
+    ``parameters.omnigent`` remains the authored product-intent surface.  The
+    immutable snapshot carries the selected upstream agent and profile
+    authority separately so the Temporal workflow can validate and merge it at
+    the runtime-request boundary.
+    """
+
+    document = snapshot.get("document")
+    if not isinstance(document, Mapping):
+        raise TypeError("agent profile snapshot document must be an object")
+
+    required_snapshot_fields = (
+        "profileId",
+        "version",
+        "digest",
+        "providerProfileRef",
+        "executionProfileRef",
+        "launchPolicyRef",
+        "agentId",
+    )
+    missing = [
+        field
+        for field in required_snapshot_fields
+        if snapshot.get(field) is None or str(snapshot.get(field)).strip() == ""
+    ]
+    if missing:
+        raise ValueError(
+            "agent profile snapshot is missing required fields: "
+            + ", ".join(missing)
+        )
+
+    compiled = copy.deepcopy(dict(parameters))
+    compiled["agentProfileSnapshot"] = copy.deepcopy(dict(snapshot))
+    compiled["agentProfile"] = {
+        "profileId": snapshot["profileId"],
+        "version": snapshot["version"],
+        "digest": snapshot["digest"],
+    }
+    compiled["profileId"] = snapshot["providerProfileRef"]
+
+    effective_model = document.get("model")
+    if isinstance(effective_model, Mapping):
+        if effective_model.get("model") is not None:
+            compiled["model"] = effective_model["model"]
+        if effective_model.get("effort") is not None:
+            compiled["effort"] = effective_model["effort"]
+
+    # Host realization uses the canonical authored names.  Profile identity,
+    # Provider Profile identity, and upstream agent identity stay exclusively
+    # in the trusted snapshot instead of leaking into this authored block.
+    authored_omnigent = compiled.get("omnigent")
+    omnigent = (
+        copy.deepcopy(dict(authored_omnigent))
+        if isinstance(authored_omnigent, Mapping)
+        else {}
+    )
+    omnigent["executionTargetRef"] = snapshot["executionProfileRef"]
+    omnigent["launchPolicyRef"] = snapshot["launchPolicyRef"]
+    compiled["omnigent"] = omnigent
+
+    compiled["rag"] = copy.deepcopy(document.get("rag") or {})
+    compiled["capture"] = copy.deepcopy(document.get("capture") or {})
+    compiled["workspace"] = copy.deepcopy(document.get("workspace") or {})
+    return compiled
+
+
 async def resolve_agent_profile_snapshot(
     session: AsyncSession,
     *,
@@ -238,4 +310,7 @@ async def resolve_agent_profile_snapshot(
     return snapshot
 
 
-__all__ = ["resolve_agent_profile_snapshot"]
+__all__ = [
+    "compile_agent_profile_snapshot_parameters",
+    "resolve_agent_profile_snapshot",
+]

--- a/api_service/services/recurring_workflows_service.py
+++ b/api_service/services/recurring_workflows_service.py
@@ -23,6 +23,7 @@ from api_service.db.models import (
     User,
 )
 from api_service.services.omnigent_agent_profile_selection import (
+    compile_agent_profile_snapshot_parameters,
     resolve_agent_profile_snapshot,
 )
 from moonmind.workflows.recurring.cron import (
@@ -692,20 +693,10 @@ class RecurringWorkflowsService:
                 user=actor,
             )
             initial_parameters = dict(definition.target.get("initialParameters") or {})
-            initial_parameters["agentProfile"] = {
-                "profileId": snapshot["profileId"],
-                "version": snapshot["version"],
-                "digest": snapshot["digest"],
-            }
-            initial_parameters["agentProfileSnapshot"] = snapshot
-            initial_parameters["profileId"] = snapshot["providerProfileRef"]
-            initial_parameters["omnigent"] = {
-                **dict(initial_parameters.get("omnigent") or {}),
-                "agentProfileRef": f"{snapshot['profileId']}@{snapshot['version']}",
-                "executionProfileRef": snapshot["executionProfileRef"],
-                "launchPolicyRef": snapshot["launchPolicyRef"],
-                "agent": {"agentId": snapshot["agentId"]},
-            }
+            initial_parameters = compile_agent_profile_snapshot_parameters(
+                initial_parameters,
+                snapshot=snapshot,
+            )
             definition.target = {
                 **definition.target,
                 "agentProfile": {
@@ -716,6 +707,7 @@ class RecurringWorkflowsService:
                 "agentProfileSnapshot": snapshot,
                 "initialParameters": initial_parameters,
             }
+            await self._session.flush()
 
         workflow_type, workflow_input = self._workflow_bundle_for_target(
             definition_id=definition_id,

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -673,6 +673,9 @@ RUN_OMNIGENT_CHECKPOINT_BRANCH_TURN_REQUEST_PATCH = (
 RUN_OMNIGENT_AUTHORED_SELECTION_COMPILER_PATCH = (
     "run-omnigent-authored-selection-compiler-v1"
 )
+RUN_OMNIGENT_AGENT_PROFILE_SNAPSHOT_COMPILER_PATCH = (
+    "run-omnigent-agent-profile-snapshot-compiler-v1"
+)
 RUN_ALREADY_IMPLEMENTED_JIRA_COMPLETION_PATCH = (
     "run-already-implemented-jira-completion-v1"
 )
@@ -18552,10 +18555,33 @@ class MoonMindRunWorkflow:
             if self._workflow_patch_enabled(
                 RUN_OMNIGENT_AUTHORED_SELECTION_COMPILER_PATCH
             ):
-                parameters["omnigent"] = self._compile_authored_omnigent_selection(
-                    raw_omnigent_parameters,
-                    path=f"node[{node_id}].omnigent",
+                agent_profile_snapshot = (
+                    workflow_parameters.get("agentProfileSnapshot")
+                    if isinstance(workflow_parameters, Mapping)
+                    else None
                 )
+                if (
+                    agent_id == "omnigent"
+                    and isinstance(agent_profile_snapshot, Mapping)
+                    and self._workflow_patch_enabled(
+                        RUN_OMNIGENT_AGENT_PROFILE_SNAPSHOT_COMPILER_PATCH
+                    )
+                ):
+                    parameters["omnigent"] = (
+                        self._compile_agent_profile_snapshot_omnigent_selection(
+                            raw_omnigent_parameters,
+                            snapshot=agent_profile_snapshot,
+                            execution_profile_ref=execution_profile_ref,
+                            path=f"node[{node_id}].omnigent",
+                        )
+                    )
+                else:
+                    parameters["omnigent"] = (
+                        self._compile_authored_omnigent_selection(
+                            raw_omnigent_parameters,
+                            path=f"node[{node_id}].omnigent",
+                        )
+                    )
             else:
                 # Preserve the exact historical activity input for workflows whose
                 # histories predate the product compiler boundary.
@@ -21675,6 +21701,153 @@ class MoonMindRunWorkflow:
                     f"{path}.agent.harnessOverride must be a supported native harness"
                 )
         return normalized
+
+    def _compile_agent_profile_snapshot_omnigent_selection(
+        self,
+        value: Mapping[str, Any],
+        *,
+        snapshot: Mapping[str, Any],
+        execution_profile_ref: str | None,
+        path: str,
+    ) -> dict[str, Any]:
+        """Merge trusted profile authority after validating authored intent.
+
+        Agent-profile snapshots produced by the API are immutable launch
+        authority.  Older persisted executions also copied some of that
+        authority into ``parameters.omnigent``.  Accept only exact copies of
+        those legacy fields, discard them from the authored surface, then merge
+        the snapshot through the canonical runtime names.
+        """
+
+        normalized_snapshot = self._json_mapping(
+            snapshot,
+            path="workflow.agentProfileSnapshot",
+        )
+        schema_version = self._required_string(
+            normalized_snapshot,
+            "schemaVersion",
+            error_message="agentProfileSnapshot.schemaVersion is required",
+        )
+        if schema_version != "moonmind.omnigent-agent-profile-snapshot.v1":
+            raise ValueError("agentProfileSnapshot.schemaVersion is unsupported")
+
+        profile_id = self._required_string(
+            normalized_snapshot,
+            "profileId",
+            error_message="agentProfileSnapshot.profileId is required",
+        )
+        profile_version = normalized_snapshot.get("version")
+        if (
+            isinstance(profile_version, bool)
+            or not isinstance(profile_version, int)
+            or profile_version < 1
+        ):
+            raise ValueError("agentProfileSnapshot.version must be a positive integer")
+        provider_profile_ref = self._required_string(
+            normalized_snapshot,
+            "providerProfileRef",
+            error_message="agentProfileSnapshot.providerProfileRef is required",
+        )
+        if execution_profile_ref != provider_profile_ref:
+            raise ValueError(
+                "agentProfileSnapshot.providerProfileRef conflicts with "
+                "the resolved execution profile"
+            )
+
+        target_ref = self._required_string(
+            normalized_snapshot,
+            "executionProfileRef",
+            error_message="agentProfileSnapshot.executionProfileRef is required",
+        )
+        launch_policy_ref = self._required_string(
+            normalized_snapshot,
+            "launchPolicyRef",
+            error_message="agentProfileSnapshot.launchPolicyRef is required",
+        )
+        agent_id = self._required_string(
+            normalized_snapshot,
+            "agentId",
+            error_message="agentProfileSnapshot.agentId is required",
+        )
+        document = self._mapping_value(normalized_snapshot, "document")
+        if not document:
+            raise ValueError("agentProfileSnapshot.document is required")
+        endpoint_ref = self._required_string(
+            document,
+            "endpointRef",
+            error_message="agentProfileSnapshot.document.endpointRef is required",
+        )
+        harness = self._required_string(
+            document,
+            "harness",
+            error_message="agentProfileSnapshot.document.harness is required",
+        )
+        if harness not in {"codex-native", "claude-native"}:
+            raise ValueError("agentProfileSnapshot.document.harness is unsupported")
+
+        authored = self._json_mapping(value, path=path)
+
+        def discard_legacy_field(key: str, expected: str) -> None:
+            if key not in authored:
+                return
+            observed = authored.pop(key)
+            if not isinstance(observed, str) or observed.strip() != expected:
+                raise ValueError(f"{path}.{key} conflicts with agentProfileSnapshot")
+
+        discard_legacy_field(
+            "agentProfileRef",
+            f"{profile_id}@{profile_version}",
+        )
+        discard_legacy_field("executionProfileRef", target_ref)
+
+        raw_agent = authored.get("agent")
+        if isinstance(raw_agent, Mapping):
+            authored_agent = dict(raw_agent)
+            if "agentId" in authored_agent:
+                observed_agent_id = authored_agent.pop("agentId")
+                if (
+                    not isinstance(observed_agent_id, str)
+                    or observed_agent_id.strip() != agent_id
+                ):
+                    raise ValueError(
+                        f"{path}.agent.agentId conflicts with agentProfileSnapshot"
+                    )
+            if authored_agent:
+                authored["agent"] = authored_agent
+            else:
+                authored.pop("agent", None)
+
+        compiled = self._compile_authored_omnigent_selection(
+            authored,
+            path=path,
+        )
+
+        for key, expected in (
+            ("endpointRef", endpoint_ref),
+            ("executionTargetRef", target_ref),
+            ("launchPolicyRef", launch_policy_ref),
+        ):
+            observed = compiled.get(key)
+            if observed is not None and (
+                not isinstance(observed, str) or observed.strip() != expected
+            ):
+                raise ValueError(f"{path}.{key} conflicts with agentProfileSnapshot")
+            compiled[key] = expected
+
+        compiled_agent = (
+            dict(compiled.get("agent"))
+            if isinstance(compiled.get("agent"), Mapping)
+            else {}
+        )
+        authored_harness = compiled_agent.get("harnessOverride")
+        if authored_harness is not None and authored_harness != harness:
+            raise ValueError(
+                f"{path}.agent.harnessOverride conflicts with agentProfileSnapshot"
+            )
+        compiled_agent["harnessOverride"] = harness
+        compiled_agent["agentId"] = agent_id
+        compiled["agent"] = compiled_agent
+        return compiled
 
     def _json_value(self, value: Any, *, path: str) -> Any:
         if value is None or isinstance(value, (str, int, float, bool)):

--- a/tests/integration/reliability/replays/omnigent-agent-profile-rerun-compiler/expected-outcome.json
+++ b/tests/integration/reliability/replays/omnigent-agent-profile-rerun-compiler/expected-outcome.json
@@ -1,0 +1,13 @@
+{
+  "invariant": "trusted agent-profile authority is validated against the immutable snapshot and merged only after authored Omnigent intent passes validation",
+  "executionProfileRef": "codex_openai_oauth",
+  "omnigent": {
+    "endpointRef": "default",
+    "executionTargetRef": "omnigent-codex@1",
+    "launchPolicyRef": "codex-on-demand@1",
+    "agent": {
+      "harnessOverride": "codex-native",
+      "agentId": "16a06503889b0c3034496821afd41b9e"
+    }
+  }
+}

--- a/tests/integration/reliability/replays/omnigent-agent-profile-rerun-compiler/manifest.json
+++ b/tests/integration/reliability/replays/omnigent-agent-profile-rerun-compiler/manifest.json
@@ -1,0 +1,39 @@
+{
+  "incidentWorkflowId": "mm:ec891001-114a-4a59-92a2-7fce41a5ebf6",
+  "runId": "019fd2d8-8fe3-7aa5-a440-a5dfb09e366f",
+  "sourceWorkflowId": "mm:06cb96c8-e22f-41ce-8392-476b55f83bd7",
+  "failureShape": "an exact full rerun copied trusted agent-profile resolution into the authored Omnigent selection after the compiler patch became active",
+  "boundary": "MoonMind.UserWorkflow plan node to AgentExecutionRequest",
+  "escapedFailure": "unsupported authored fields: agentProfileRef, executionProfileRef",
+  "nodeInputs": {
+    "runtime": {
+      "mode": "omnigent",
+      "executionProfileRef": "codex_openai_oauth"
+    }
+  },
+  "workflowParameters": {
+    "omnigent": {
+      "executionTargetRef": "omnigent-codex@1",
+      "launchPolicyRef": "codex-on-demand@1",
+      "agentProfileRef": "omnigent-bootstrap-default@1",
+      "executionProfileRef": "omnigent-codex@1",
+      "agent": {
+        "agentId": "16a06503889b0c3034496821afd41b9e"
+      }
+    },
+    "agentProfileSnapshot": {
+      "schemaVersion": "moonmind.omnigent-agent-profile-snapshot.v1",
+      "profileId": "omnigent-bootstrap-default",
+      "version": 1,
+      "digest": "sha256:2f95702919229bde2540932f94d2389f464d2555b212cee860692a2e22ea16c1",
+      "providerProfileRef": "codex_openai_oauth",
+      "executionProfileRef": "omnigent-codex@1",
+      "launchPolicyRef": "codex-on-demand@1",
+      "agentId": "16a06503889b0c3034496821afd41b9e",
+      "document": {
+        "endpointRef": "default",
+        "harness": "codex-native"
+      }
+    }
+  }
+}

--- a/tests/integration/reliability/test_escaped_failure_journeys.py
+++ b/tests/integration/reliability/test_escaped_failure_journeys.py
@@ -1003,6 +1003,44 @@ async def test_omnigent_checkpoint_waits_for_workspace_materialization(
     ]
 
 
+async def test_omnigent_agent_profile_rerun_compiles_trusted_snapshot(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Replay mm:ec891001 at the workflow-to-AgentRun request boundary."""
+
+    replay_id = "omnigent-agent-profile-rerun-compiler"
+    manifest = load_replay(replay_id, "manifest.json")
+    expected = load_replay(replay_id, "expected-outcome.json")
+    parent = MoonMindRunWorkflow()
+    parent_info = SimpleNamespace(
+        namespace="default",
+        workflow_id=manifest["incidentWorkflowId"],
+        run_id=manifest["runId"],
+        task_queue="mm.workflow.merge_automation",
+        search_attributes={},
+    )
+    monkeypatch.setattr(run_workflow_module.workflow, "info", lambda: parent_info)
+    monkeypatch.setattr(run_workflow_module.workflow, "patched", lambda _patch: True)
+
+    with pytest.raises(ValueError, match=manifest["escapedFailure"]):
+        parent._compile_authored_omnigent_selection(
+            manifest["workflowParameters"]["omnigent"],
+            path="node[node-1].omnigent",
+        )
+
+    request = parent._build_agent_execution_request(
+        node_inputs=manifest["nodeInputs"],
+        node_id="node-1",
+        tool_name="omnigent",
+        workflow_parameters=manifest["workflowParameters"],
+    )
+
+    assert request.agent_kind == "external"
+    assert request.agent_id == "omnigent"
+    assert request.execution_profile_ref == expected["executionProfileRef"]
+    assert request.parameters["omnigent"] == expected["omnigent"]
+
+
 async def test_codex_session_record_uses_step_workflow_checkpoint_authority(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -4355,6 +4355,70 @@ def test_create_task_shaped_execution_preserves_omnigent_selection(
     }
 
 
+def test_create_execution_keeps_resolved_agent_profile_out_of_authored_omnigent(
+    client: tuple[TestClient, AsyncMock, SimpleNamespace],
+) -> None:
+    test_client, service, _user = client
+    service.create_execution.return_value = _build_execution_record()
+    test_client.app.dependency_overrides[get_async_session] = _empty_session_override
+    snapshot = {
+        "schemaVersion": "moonmind.omnigent-agent-profile-snapshot.v1",
+        "profileId": "omnigent-bootstrap-default",
+        "version": 1,
+        "digest": "sha256:" + "a" * 64,
+        "providerProfileRef": "codex-openai-oauth",
+        "executionProfileRef": "omnigent-codex@1",
+        "launchPolicyRef": "codex-on-demand@1",
+        "agentId": "upstream-codex-agent",
+        "document": {
+            "model": {"settings": {}},
+            "rag": {},
+            "capture": {"stream": True},
+            "workspace": {"mutation": "allowed"},
+        },
+    }
+
+    with patch(
+        "api_service.api.routers.executions.resolve_agent_profile_snapshot",
+        new=AsyncMock(return_value=snapshot),
+    ):
+        response = test_client.post(
+            "/api/executions",
+            json={
+                "type": "workflow",
+                "payload": {
+                    "targetRuntime": "omnigent",
+                    "agentProfile": {
+                        "profileId": "omnigent-bootstrap-default",
+                        "providerProfileRef": "codex-openai-oauth",
+                    },
+                    "omnigent": {
+                        "executionTargetRef": "omnigent-codex@1",
+                        "launchPolicyRef": "codex-on-demand@1",
+                    },
+                    "workflow": {
+                        "instructions": "Run the selected agent profile.",
+                        "runtime": {"mode": "omnigent"},
+                    },
+                },
+            },
+        )
+
+    assert response.status_code == 201, response.text
+    initial_parameters = service.create_execution.await_args.kwargs[
+        "initial_parameters"
+    ]
+    assert initial_parameters["agentProfileSnapshot"] == snapshot
+    assert initial_parameters["profileId"] == "codex-openai-oauth"
+    assert initial_parameters["omnigent"] == {
+        "executionTargetRef": "omnigent-codex@1",
+        "launchPolicyRef": "codex-on-demand@1",
+    }
+    assert "agentProfileRef" not in initial_parameters["omnigent"]
+    assert "executionProfileRef" not in initial_parameters["omnigent"]
+    assert "agent" not in initial_parameters["omnigent"]
+
+
 def test_create_task_shaped_execution_rejects_unsupported_step_runtime(
     client: tuple[TestClient, AsyncMock, SimpleNamespace],
 ) -> None:

--- a/tests/unit/services/test_omnigent_agent_profile_selection.py
+++ b/tests/unit/services/test_omnigent_agent_profile_selection.py
@@ -15,6 +15,7 @@ from api_service.db.models import (
     RuntimeMaterializationMode,
 )
 from api_service.services.omnigent_agent_profile_selection import (
+    compile_agent_profile_snapshot_parameters,
     resolve_agent_profile_snapshot,
 )
 
@@ -71,6 +72,50 @@ class _Session:
 
     async def flush(self):
         return None
+
+
+def test_snapshot_parameter_compiler_keeps_authority_out_of_authored_omnigent() -> None:
+    snapshot = {
+        "schemaVersion": "moonmind.omnigent-agent-profile-snapshot.v1",
+        "profileId": "team-codex",
+        "version": 2,
+        "digest": "sha256:" + "a" * 64,
+        "providerProfileRef": "oauth-team",
+        "executionProfileRef": "omnigent-codex@2",
+        "launchPolicyRef": "on-demand@1",
+        "agentId": "upstream-agent-2",
+        "document": {
+            "model": {"model": "gpt-5.4", "effort": "high"},
+            "rag": {"maxTokens": 2000},
+            "capture": {"retentionDays": 14},
+            "workspace": {"mutation": "allowed"},
+        },
+    }
+
+    compiled = compile_agent_profile_snapshot_parameters(
+        {
+            "model": "stale-model",
+            "omnigent": {"launchPolicyRef": "stale-policy"},
+        },
+        snapshot=snapshot,
+    )
+
+    assert compiled["agentProfileSnapshot"] == snapshot
+    assert compiled["agentProfile"] == {
+        "profileId": "team-codex",
+        "version": 2,
+        "digest": "sha256:" + "a" * 64,
+    }
+    assert compiled["profileId"] == "oauth-team"
+    assert compiled["model"] == "gpt-5.4"
+    assert compiled["effort"] == "high"
+    assert compiled["omnigent"] == {
+        "executionTargetRef": "omnigent-codex@2",
+        "launchPolicyRef": "on-demand@1",
+    }
+    assert compiled["rag"] == {"maxTokens": 2000}
+    assert compiled["capture"] == {"retentionDays": 14}
+    assert compiled["workspace"] == {"mutation": "allowed"}
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/test_recurring_workflows_service.py
+++ b/tests/unit/services/test_recurring_workflows_service.py
@@ -123,6 +123,85 @@ async def test_create_definition_creates_temporal_schedule(
             }
 
 
+async def test_create_definition_compiles_agent_profile_snapshot_separately(
+    tmp_path: Path,
+    mock_temporal_adapter,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    snapshot = {
+        "schemaVersion": "moonmind.omnigent-agent-profile-snapshot.v1",
+        "profileId": "omnigent-bootstrap-default",
+        "version": 1,
+        "digest": "sha256:" + "a" * 64,
+        "providerProfileRef": "codex-openai-oauth",
+        "executionProfileRef": "omnigent-codex@1",
+        "launchPolicyRef": "codex-on-demand@1",
+        "agentId": "upstream-codex-agent",
+        "document": {
+            "model": {"settings": {}},
+            "rag": {},
+            "capture": {"stream": True},
+            "workspace": {"mutation": "allowed"},
+        },
+    }
+    resolver = AsyncMock(return_value=snapshot)
+    monkeypatch.setattr(
+        "api_service.services.recurring_workflows_service.resolve_agent_profile_snapshot",
+        resolver,
+    )
+
+    async with recurring_db(tmp_path) as session_maker, session_maker() as session:
+        service = RecurringWorkflowsService(
+            session,
+            temporal_client_adapter=mock_temporal_adapter,
+        )
+        definition = await service.create_definition(
+            name="Profile schedule",
+            description=None,
+            enabled=True,
+            schedule_type="cron",
+            cron="0 6 * * *",
+            timezone="UTC",
+            scope_type="personal",
+            scope_ref=None,
+            owner_user_id=uuid4(),
+            target={
+                "workflowType": "MoonMind.UserWorkflow",
+                "initialParameters": {
+                    "targetRuntime": "omnigent",
+                    "omnigent": {
+                        "executionTargetRef": "omnigent-codex@1",
+                        "launchPolicyRef": "codex-on-demand@1",
+                    },
+                    "workflow": {
+                        "instructions": "Run the selected profile.",
+                        "runtime": {"mode": "omnigent"},
+                    },
+                },
+            },
+            policy=None,
+            agent_profile_selection={
+                "profileId": "omnigent-bootstrap-default",
+                "providerProfileRef": "codex-openai-oauth",
+            },
+            actor=SimpleNamespace(id=uuid4()),
+        )
+
+    initial_parameters = definition.target["initialParameters"]
+    assert initial_parameters["agentProfileSnapshot"] == snapshot
+    assert initial_parameters["omnigent"] == {
+        "executionTargetRef": "omnigent-codex@1",
+        "launchPolicyRef": "codex-on-demand@1",
+    }
+    assert "agentProfileRef" not in initial_parameters["omnigent"]
+    assert "executionProfileRef" not in initial_parameters["omnigent"]
+    scheduled_parameters = mock_temporal_adapter.create_schedule.await_args.kwargs[
+        "workflow_input"
+    ]["initial_parameters"]
+    assert scheduled_parameters["agentProfileSnapshot"] == snapshot
+    assert scheduled_parameters["omnigent"] == initial_parameters["omnigent"]
+
+
 async def test_started_at_by_workflow_id_orders_duplicate_rows_deterministically() -> None:
     session = AsyncMock(spec=AsyncSession)
     session.execute.return_value = SimpleNamespace(all=lambda: [])

--- a/tests/unit/workflows/temporal/test_run_replayer.py
+++ b/tests/unit/workflows/temporal/test_run_replayer.py
@@ -27,6 +27,7 @@ from moonmind.workflows.temporal.workflows.run import (
     RUN_CANONICAL_NO_COMMIT_OUTCOME_PATCH,
     RUN_MANAGED_SESSION_CHECKPOINT_LOCATOR_PATCH,
     RUN_MOONSPEC_TITLE_REMEDIATION_DETECTION_PATCH,
+    RUN_OMNIGENT_AGENT_PROFILE_SNAPSHOT_COMPILER_PATCH,
     RUN_OMNIGENT_AUTHORED_SELECTION_COMPILER_PATCH,
     RUN_PLAN_ROUTED_MOONSPEC_REMEDIATION_PATCH,
     RUN_REMEDIATION_CONTINUE_MANAGED_SESSION_PATCH,
@@ -427,6 +428,57 @@ class _CurrentOmnigentCompilerReplayFixture:
             return authored
         return MoonMindRunWorkflow()._compile_authored_omnigent_selection(
             authored,
+            path="workflow.omnigent",
+        )
+
+
+def _agent_profile_snapshot_replay_inputs() -> tuple[dict[str, Any], dict[str, Any]]:
+    return (
+        {
+            "executionTargetRef": "omnigent-codex@1",
+            "launchPolicyRef": "codex-on-demand@1",
+            "agentProfileRef": "omnigent-bootstrap-default@1",
+            "executionProfileRef": "omnigent-codex@1",
+            "agent": {"agentId": "upstream-codex-agent"},
+        },
+        {
+            "schemaVersion": "moonmind.omnigent-agent-profile-snapshot.v1",
+            "profileId": "omnigent-bootstrap-default",
+            "version": 1,
+            "digest": "sha256:" + "a" * 64,
+            "providerProfileRef": "codex-openai-oauth",
+            "executionProfileRef": "omnigent-codex@1",
+            "launchPolicyRef": "codex-on-demand@1",
+            "agentId": "upstream-codex-agent",
+            "document": {
+                "endpointRef": "default",
+                "harness": "codex-native",
+            },
+        },
+    )
+
+
+@workflow.defn(name="OmnigentAgentProfileSnapshotCompilerReplayFixture")
+class _LegacyOmnigentAgentProfileSnapshotCompilerReplayFixture:
+    @workflow.run
+    async def run(self) -> dict[str, Any]:
+        authored, _snapshot = _agent_profile_snapshot_replay_inputs()
+        return authored
+
+
+@workflow.defn(name="OmnigentAgentProfileSnapshotCompilerReplayFixture")
+class _CurrentOmnigentAgentProfileSnapshotCompilerReplayFixture:
+    @workflow.run
+    async def run(self) -> dict[str, Any]:
+        authored, snapshot = _agent_profile_snapshot_replay_inputs()
+        if not workflow.patched(
+            RUN_OMNIGENT_AGENT_PROFILE_SNAPSHOT_COMPILER_PATCH
+        ):
+            return authored
+        return MoonMindRunWorkflow()._compile_agent_profile_snapshot_omnigent_selection(
+            authored,
+            snapshot=snapshot,
+            execution_profile_ref="codex-openai-oauth",
             path="workflow.omnigent",
         )
 
@@ -1066,6 +1118,55 @@ async def test_github_3453_pre_change_omnigent_history_replays() -> None:
 
     replayer = Replayer(
         workflows=[_CurrentOmnigentCompilerReplayFixture],
+        workflow_runner=UnsandboxedWorkflowRunner(),
+    )
+    await replayer.replay_workflow(legacy_history)
+    await replayer.replay_workflow(current_history)
+
+
+@pytest.mark.asyncio
+async def test_agent_profile_snapshot_compiler_histories_replay() -> None:
+    authored, _snapshot = _agent_profile_snapshot_replay_inputs()
+    compiled = {
+        "endpointRef": "default",
+        "executionTargetRef": "omnigent-codex@1",
+        "launchPolicyRef": "codex-on-demand@1",
+        "agent": {
+            "harnessOverride": "codex-native",
+            "agentId": "upstream-codex-agent",
+        },
+    }
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        async with Worker(
+            env.client,
+            task_queue="test-agent-profile-snapshot-legacy-replay",
+            workflows=[_LegacyOmnigentAgentProfileSnapshotCompilerReplayFixture],
+            workflow_runner=UnsandboxedWorkflowRunner(),
+        ):
+            legacy = await env.client.start_workflow(
+                _LegacyOmnigentAgentProfileSnapshotCompilerReplayFixture.run,
+                id="test-agent-profile-snapshot-legacy-history",
+                task_queue="test-agent-profile-snapshot-legacy-replay",
+            )
+            assert await legacy.result() == authored
+            legacy_history = await legacy.fetch_history()
+
+        async with Worker(
+            env.client,
+            task_queue="test-agent-profile-snapshot-current-replay",
+            workflows=[_CurrentOmnigentAgentProfileSnapshotCompilerReplayFixture],
+            workflow_runner=UnsandboxedWorkflowRunner(),
+        ):
+            current = await env.client.start_workflow(
+                _CurrentOmnigentAgentProfileSnapshotCompilerReplayFixture.run,
+                id="test-agent-profile-snapshot-current-history",
+                task_queue="test-agent-profile-snapshot-current-replay",
+            )
+            assert await current.result() == compiled
+            current_history = await current.fetch_history()
+
+    replayer = Replayer(
+        workflows=[_CurrentOmnigentAgentProfileSnapshotCompilerReplayFixture],
         workflow_runner=UnsandboxedWorkflowRunner(),
     )
     await replayer.replay_workflow(legacy_history)

--- a/tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py
@@ -30,6 +30,7 @@ from moonmind.workflows.temporal.workflows.run import (
     RUN_CHECKPOINT_BRANCH_TURN_CONTEXT_PATCH,
     RUN_EXISTING_SKILLSET_TERMINAL_CONTRACT_PATCH,
     RUN_JSON_ARTIFACT_WRITE_COMPLETE_PATCH,
+    RUN_OMNIGENT_AGENT_PROFILE_SNAPSHOT_COMPILER_PATCH,
     RUN_OMNIGENT_AUTHORED_SELECTION_COMPILER_PATCH,
     RUN_OMNIGENT_CHECKPOINT_BRANCH_TURN_REQUEST_PATCH,
     RUN_PR_RESOLVER_SKILL_OWNED_EXECUTION_PATCH,
@@ -1981,6 +1982,133 @@ class TestBuildAgentExecutionRequest(unittest.TestCase):
             "_moonmindProfileAuthorization",
             request.parameters["omnigent"],
         )
+
+    def test_agent_profile_snapshot_compiles_legacy_rerun_selection(self) -> None:
+        wf = MoonMindRunWorkflow()
+        wf._profile_snapshots = {
+            "codex-openai-oauth": {
+                "profile_id": "codex-openai-oauth",
+                "runtime_id": "codex_cli",
+            }
+        }
+
+        class MockInfo:
+            namespace = "default"
+            workflow_id = "mm:agent-profile-rerun"
+            run_id = "rerun-1"
+
+        snapshot = {
+            "schemaVersion": "moonmind.omnigent-agent-profile-snapshot.v1",
+            "profileId": "omnigent-bootstrap-default",
+            "version": 1,
+            "digest": "sha256:" + "a" * 64,
+            "providerProfileRef": "codex-openai-oauth",
+            "executionProfileRef": "omnigent-codex@1",
+            "launchPolicyRef": "codex-on-demand@1",
+            "agentId": "upstream-codex-agent",
+            "document": {
+                "endpointRef": "default",
+                "harness": "codex-native",
+            },
+        }
+        legacy_selection = {
+            "executionTargetRef": "omnigent-codex@1",
+            "launchPolicyRef": "codex-on-demand@1",
+            "agentProfileRef": "omnigent-bootstrap-default@1",
+            "executionProfileRef": "omnigent-codex@1",
+            "agent": {"agentId": "upstream-codex-agent"},
+        }
+
+        with patch(
+            "moonmind.workflows.temporal.workflows.run.workflow.info",
+            return_value=MockInfo(),
+        ), patch(
+            "moonmind.workflows.temporal.workflows.run.workflow.patched",
+            side_effect=lambda patch_id: patch_id
+            in {
+                RUN_OMNIGENT_AUTHORED_SELECTION_COMPILER_PATCH,
+                RUN_OMNIGENT_AGENT_PROFILE_SNAPSHOT_COMPILER_PATCH,
+            },
+        ):
+            request = wf._build_agent_execution_request(
+                node_inputs={
+                    "runtime": {
+                        "mode": "omnigent",
+                        "executionProfileRef": "codex-openai-oauth",
+                    },
+                },
+                workflow_parameters={
+                    "omnigent": legacy_selection,
+                    "agentProfileSnapshot": snapshot,
+                },
+                node_id="node-1",
+                tool_name="omnigent",
+            )
+
+        self.assertEqual(
+            request.parameters["omnigent"],
+            {
+                "endpointRef": "default",
+                "executionTargetRef": "omnigent-codex@1",
+                "launchPolicyRef": "codex-on-demand@1",
+                "agent": {
+                    "harnessOverride": "codex-native",
+                    "agentId": "upstream-codex-agent",
+                    "agentName": "codex",
+                },
+            },
+        )
+        self.assertEqual(request.execution_profile_ref, "codex-openai-oauth")
+
+    def test_agent_profile_snapshot_rejects_conflicting_legacy_authority(self) -> None:
+        wf = MoonMindRunWorkflow()
+
+        class MockInfo:
+            namespace = "default"
+            workflow_id = "mm:agent-profile-rerun"
+            run_id = "rerun-1"
+
+        snapshot = {
+            "schemaVersion": "moonmind.omnigent-agent-profile-snapshot.v1",
+            "profileId": "omnigent-bootstrap-default",
+            "version": 1,
+            "digest": "sha256:" + "a" * 64,
+            "providerProfileRef": "codex-openai-oauth",
+            "executionProfileRef": "omnigent-codex@1",
+            "launchPolicyRef": "codex-on-demand@1",
+            "agentId": "upstream-codex-agent",
+            "document": {
+                "endpointRef": "default",
+                "harness": "codex-native",
+            },
+        }
+
+        with patch(
+            "moonmind.workflows.temporal.workflows.run.workflow.info",
+            return_value=MockInfo(),
+        ), patch(
+            "moonmind.workflows.temporal.workflows.run.workflow.patched",
+            return_value=True,
+        ), pytest.raises(
+            ValueError,
+            match="agentProfileRef conflicts with agentProfileSnapshot",
+        ):
+            wf._build_agent_execution_request(
+                node_inputs={
+                    "runtime": {
+                        "mode": "omnigent",
+                        "executionProfileRef": "codex-openai-oauth",
+                    },
+                },
+                workflow_parameters={
+                    "omnigent": {
+                        "agentProfileRef": "forged-profile@9",
+                    },
+                    "agentProfileSnapshot": snapshot,
+                },
+                node_id="node-1",
+                tool_name="omnigent",
+            )
 
     def test_github_3453_compiler_rejects_authored_authority_without_fallback(
         self,


### PR DESCRIPTION
## Summary

- keep immutable Omnigent agent-profile snapshots separate from authored `parameters.omnigent` intent
- compile and validate trusted profile, launch, harness, and upstream-agent identity at the workflow-to-AgentRun boundary behind a replay-safe Temporal patch
- accept only exact legacy copies from persisted rerun payloads, while rejecting conflicts
- flush recurring workflow snapshot updates before refresh so schedule definitions retain the resolved authority
- add the minimized replay fixture for workflow `mm:ec891001-114a-4a59-92a2-7fce41a5ebf6`

## Root cause

The agent-profile authoring change copied resolved fields (`agentProfileRef`, `executionProfileRef`, and `agent.agentId`) into the authored Omnigent selection. Updated workers correctly reject those fields as runtime authority. The source execution ran on a stale worker without that compiler patch; its exact full rerun then failed immediately after the worker rollout activated the validation.

## Impact

Fresh agent-profile workflows, exact reruns of affected executions, and recurring definitions now preserve one canonical authority path: authored intent is validated first, then the immutable snapshot supplies resolved identity. Conflicting copied authority fails closed.

## Validation

- `./tools/test_unit.sh` targeted API, profile compiler, recurring schedule, workflow dispatch, and Temporal replay coverage: 15 passed
- full `tests/unit/services/test_recurring_workflows_service.py`: 18 passed
- escaped-failure reliability journey for the incident payload: 1 passed
- removed-capability semantics and status-domain audits passed