### PR TITLE
Fix Omnigent rerun authority chain

### DIFF
--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -61,6 +61,7 @@ from api_service.db.models import (
 from api_service.services.checkpoint_branches import prepare_checkpoint_branch_workspace
 from api_service.services.omnigent_agent_profile_selection import (
     compile_agent_profile_snapshot_parameters,
+    refresh_managed_bootstrap_snapshot_for_rerun,
     resolve_agent_profile_snapshot,
 )
 from api_service.services.control_stop_continuation import (
@@ -15238,6 +15239,13 @@ async def rerun_execution(
     # Use canonical parameters with rerun-specific sanitization to avoid carrying
     # task dependency edges and recovery metadata from a prior execution.
     initial_params = service._full_rerun_parameters(canonical.parameters or {})
+    reserved_workflow_id = f"mm:{_uuid4()}"
+    initial_params = await refresh_managed_bootstrap_snapshot_for_rerun(
+        session,
+        parameters=initial_params,
+        consumer_id=reserved_workflow_id,
+        user=user,
+    )
 
     # Generate a new idempotency key based on the original workflow ID
     new_idempotency_key = f"rerun:{workflow_id}:{_uuid4()}"
@@ -15256,6 +15264,7 @@ async def rerun_execution(
             idempotency_key=new_idempotency_key,
             repository=None,
             integration=None,
+            _workflow_id=reserved_workflow_id,
         )
     except TemporalExecutionValidationError as exc:
         raise HTTPException(

--- a/api_service/services/omnigent_agent_bootstrap_service.py
+++ b/api_service/services/omnigent_agent_bootstrap_service.py
@@ -20,6 +20,7 @@ and enforced network before it advertises the runtime as available.
 """
 from __future__ import annotations
 
+import copy
 import hashlib
 import json
 import logging
@@ -36,6 +37,8 @@ from api_service.db.models import (
     OmnigentAgentProfile,
     OmnigentAgentProfileAuditEvent,
     OmnigentAgentProfileVersion,
+    OmnigentPolicy,
+    OmnigentPolicyVersion,
     OmnigentUpstreamAgentProjection,
 )
 from api_service.services.omnigent_agent_profile_service import (
@@ -116,7 +119,10 @@ def _digest(document: Mapping[str, Any]) -> str:
 
 
 def build_bootstrap_document(
-    agent_name: str, *, upstream_version: str | None = None
+    agent_name: str,
+    *,
+    upstream_version: str | None = None,
+    launch_policy_ref: str = _BOOTSTRAP_LAUNCH_POLICY_REF,
 ) -> dict[str, Any]:
     """Build the normalized bootstrap profile document for a stable agent ID.
 
@@ -134,12 +140,12 @@ def build_bootstrap_document(
         "continuations": {"branch": True, "checkpoint": True, "remediation": True},
         "endpointRef": _BOOTSTRAP_ENDPOINT_REF,
         "execution": {
-            "allowedLaunchPolicyRefs": [_BOOTSTRAP_LAUNCH_POLICY_REF],
+            "allowedLaunchPolicyRefs": [launch_policy_ref],
             "defaultExecutionProfileRef": _BOOTSTRAP_EXECUTION_PROFILE_REF,
         },
         "harness": _BOOTSTRAP_HARNESS,
         "model": {"settings": {}},
-        "policyRef": _BOOTSTRAP_LAUNCH_POLICY_REF,
+        "policyRef": launch_policy_ref,
         "providerRequirements": {
             "credentialSource": _BOOTSTRAP_PROVIDER_CREDENTIAL_SOURCE,
             "materializationMode": _BOOTSTRAP_PROVIDER_MATERIALIZATION_MODE,
@@ -247,6 +253,7 @@ async def seed_bootstrap_agent_profile(
     now: datetime | None = None,
     upstream_id: str | None = None,
     upstream_version: str | None = None,
+    launch_policy_ref: str = _BOOTSTRAP_LAUNCH_POLICY_REF,
 ) -> str | None:
     """Materialize an active profile only for a synchronized upstream identity.
 
@@ -288,6 +295,7 @@ async def seed_bootstrap_agent_profile(
     document = build_bootstrap_document(
         stable_upstream_id,
         upstream_version=upstream_version,
+        launch_policy_ref=launch_policy_ref,
     )
     profile = OmnigentAgentProfile(
         profile_id=BOOTSTRAP_PROFILE_ID,
@@ -417,6 +425,130 @@ async def default_agent_profile_ready(
     )
 
 
+async def _active_bootstrap_launch_policy_ref(session: AsyncSession) -> str:
+    """Resolve the active built-in policy without embedding its version."""
+
+    policy = await session.get(OmnigentPolicy, "codex-on-demand")
+    if policy is None or policy.default_version is None:
+        return _BOOTSTRAP_LAUNCH_POLICY_REF
+    version = await session.scalar(
+        select(OmnigentPolicyVersion).where(
+            OmnigentPolicyVersion.policy_id == policy.policy_id,
+            OmnigentPolicyVersion.version == policy.default_version,
+        )
+    )
+    if (
+        version is None
+        or version.state != "active"
+        or not version.validation_json
+        or version.validation_json.get("valid") is not True
+    ):
+        return _BOOTSTRAP_LAUNCH_POLICY_REF
+    return f"{policy.policy_id}@{version.version}"
+
+
+async def _reconcile_bootstrap_profile_launch_policy(
+    session: AsyncSession,
+    *,
+    launch_policy_ref: str,
+    now: datetime,
+) -> bool:
+    """Advance the managed profile when its immutable policy authority moves."""
+
+    profile = await session.get(OmnigentAgentProfile, BOOTSTRAP_PROFILE_ID)
+    if (
+        profile is None
+        or profile.state != "active"
+        or profile.active_version is None
+    ):
+        return False
+    active = await _load_active_version(session, profile)
+    if active is None or not isinstance(active.document, Mapping):
+        return False
+    rollout = active.rollout_metadata or {}
+    if rollout.get("origin") not in {
+        "builtin_default",
+        "env_bootstrap",
+        "bootstrap_policy_cutover",
+    }:
+        return False
+    execution = active.document.get("execution")
+    if not isinstance(execution, Mapping):
+        return False
+    if (
+        execution.get("allowedLaunchPolicyRefs") == [launch_policy_ref]
+        and active.document.get("policyRef") == launch_policy_ref
+    ):
+        return True
+
+    document = copy.deepcopy(active.document)
+    document["execution"]["allowedLaunchPolicyRefs"] = [launch_policy_ref]
+    document["policyRef"] = launch_policy_ref
+    digest = _digest(document)
+    candidate = await session.scalar(
+        select(OmnigentAgentProfileVersion).where(
+            OmnigentAgentProfileVersion.profile_id == BOOTSTRAP_PROFILE_ID,
+            OmnigentAgentProfileVersion.digest == digest,
+        )
+    )
+    if candidate is None:
+        latest = int(
+            await session.scalar(
+                select(func.max(OmnigentAgentProfileVersion.version)).where(
+                    OmnigentAgentProfileVersion.profile_id == BOOTSTRAP_PROFILE_ID
+                )
+            )
+            or 0
+        )
+        candidate = OmnigentAgentProfileVersion(
+            profile_id=BOOTSTRAP_PROFILE_ID,
+            version=latest + 1,
+            digest=digest,
+            document=document,
+            parent_version=active.version,
+            upstream_snapshot=copy.deepcopy(active.upstream_snapshot),
+            validation_result=copy.deepcopy(active.validation_result),
+            rollout_metadata={
+                "origin": "bootstrap_policy_cutover",
+                "previousOrigin": rollout.get("origin"),
+                "previousLaunchPolicyRef": active.document.get("policyRef"),
+                "launchPolicyRef": launch_policy_ref,
+                "materializedAt": now.isoformat(),
+            },
+            created_by=None,
+        )
+        session.add(candidate)
+    profile.active_version = candidate.version
+    session.add(
+        OmnigentAgentProfileAuditEvent(
+            profile_id=BOOTSTRAP_PROFILE_ID,
+            action="bootstrap_launch_policy_cutover",
+            version=candidate.version,
+            actor_id=None,
+            metadata_json={
+                "previousVersion": active.version,
+                "launchPolicyRef": launch_policy_ref,
+                "state": "active",
+            },
+        )
+    )
+    try:
+        await session.commit()
+    except IntegrityError:
+        await session.rollback()
+        # A concurrent startup may have completed the same immutable cutover.
+        profile = await session.get(OmnigentAgentProfile, BOOTSTRAP_PROFILE_ID)
+        if profile is None:
+            return False
+        current = await _load_active_version(session, profile)
+        return bool(
+            current is not None
+            and current.digest == digest
+            and current.document.get("policyRef") == launch_policy_ref
+        )
+    return True
+
+
 async def reconcile_bootstrap_agent_profile(
     session: AsyncSession,
     *,
@@ -460,12 +592,19 @@ async def reconcile_bootstrap_agent_profile(
         _inventory_text(candidate, "version", "agentVersion", "agent_version")
         or None
     )
+    launch_policy_ref = await _active_bootstrap_launch_policy_ref(session)
     await seed_bootstrap_agent_profile(
         session,
         env=env,
         now=observed_at,
         upstream_id=upstream_id,
         upstream_version=upstream_version,
+        launch_policy_ref=launch_policy_ref,
+    )
+    await _reconcile_bootstrap_profile_launch_policy(
+        session,
+        launch_policy_ref=launch_policy_ref,
+        now=observed_at,
     )
     return await default_agent_profile_ready(session, now=observed_at)
 

--- a/api_service/services/omnigent_agent_profile_selection.py
+++ b/api_service/services/omnigent_agent_profile_selection.py
@@ -130,6 +130,20 @@ def compile_agent_profile_snapshot_parameters(
         if isinstance(authored_omnigent, Mapping)
         else {}
     )
+    # Older executions duplicated trusted snapshot identity into the authored
+    # block. A newly resolved snapshot must remove those stale copies before it
+    # writes the canonical target/policy fields, otherwise immutable profile
+    # version advancement creates two contradictory authorities in one request.
+    omnigent.pop("agentProfileRef", None)
+    omnigent.pop("executionProfileRef", None)
+    raw_agent = omnigent.get("agent")
+    if isinstance(raw_agent, Mapping):
+        agent = copy.deepcopy(dict(raw_agent))
+        agent.pop("agentId", None)
+        if agent:
+            omnigent["agent"] = agent
+        else:
+            omnigent.pop("agent", None)
     omnigent["executionTargetRef"] = snapshot["executionProfileRef"]
     omnigent["launchPolicyRef"] = snapshot["launchPolicyRef"]
     compiled["omnigent"] = omnigent
@@ -310,7 +324,100 @@ async def resolve_agent_profile_snapshot(
     return snapshot
 
 
+async def refresh_managed_bootstrap_snapshot_for_rerun(
+    session: AsyncSession,
+    *,
+    parameters: Mapping[str, Any],
+    consumer_id: str,
+    user: User,
+) -> dict[str, Any]:
+    """Refresh product-managed launch authority while preserving run intent.
+
+    Exact reruns retain authored task inputs and operator-owned immutable profile
+    selections. The deployment-managed bootstrap profile is different: its
+    active version advances when MoonMind moves a built-in launch policy, so a
+    rerun must re-resolve that trusted snapshot rather than replaying an
+    authority version that the durable host binding no longer selects.
+    """
+
+    from api_service.services.omnigent_agent_bootstrap_service import (
+        BOOTSTRAP_PROFILE_ID,
+    )
+
+    compiled = copy.deepcopy(dict(parameters))
+    previous = compiled.get("agentProfileSnapshot")
+    if (
+        not isinstance(previous, Mapping)
+        or previous.get("profileId") != BOOTSTRAP_PROFILE_ID
+    ):
+        return compiled
+    previous_version_number = previous.get("version")
+    previous_digest = str(previous.get("digest") or "").strip()
+    if (
+        isinstance(previous_version_number, bool)
+        or not isinstance(previous_version_number, int)
+        or previous_version_number < 1
+        or not previous_digest
+    ):
+        raise HTTPException(
+            status.HTTP_409_CONFLICT,
+            "managed bootstrap snapshot lineage is incomplete",
+        )
+    previous_version = await session.scalar(
+        select(OmnigentAgentProfileVersion).where(
+            OmnigentAgentProfileVersion.profile_id == BOOTSTRAP_PROFILE_ID,
+            OmnigentAgentProfileVersion.version == previous_version_number,
+        )
+    )
+    if previous_version is None or previous_version.digest != previous_digest:
+        raise HTTPException(
+            status.HTTP_409_CONFLICT,
+            "managed bootstrap snapshot lineage does not match durable state",
+        )
+
+    selection: dict[str, Any] = {
+        "profileId": BOOTSTRAP_PROFILE_ID,
+        "providerProfileRef": previous.get("providerProfileRef"),
+    }
+    previous_document = previous.get("document")
+    if not isinstance(previous_document, Mapping):
+        raise HTTPException(
+            status.HTTP_409_CONFLICT,
+            "managed bootstrap snapshot document is unavailable",
+        )
+    overrides: dict[str, dict[str, Any]] = {}
+    for section in _OVERRIDABLE_SECTIONS:
+        baseline_section = previous_version.document.get(section) or {}
+        effective_section = previous_document.get(section) or {}
+        if not isinstance(baseline_section, Mapping) or not isinstance(
+            effective_section, Mapping
+        ):
+            continue
+        changed = {
+            key: copy.deepcopy(value)
+            for key, value in effective_section.items()
+            if baseline_section.get(key) != value
+        }
+        if changed:
+            overrides[section] = changed
+    if overrides:
+        selection["overrides"] = overrides
+
+    refreshed = await resolve_agent_profile_snapshot(
+        session,
+        selection=selection,
+        consumer_type="workflow",
+        consumer_id=consumer_id,
+        user=user,
+    )
+    return compile_agent_profile_snapshot_parameters(
+        compiled,
+        snapshot=refreshed,
+    )
+
+
 __all__ = [
     "compile_agent_profile_snapshot_parameters",
+    "refresh_managed_bootstrap_snapshot_for_rerun",
     "resolve_agent_profile_snapshot",
 ]

--- a/api_service/services/omnigent_agent_profile_selection.py
+++ b/api_service/services/omnigent_agent_profile_selection.py
@@ -393,11 +393,16 @@ async def refresh_managed_bootstrap_snapshot_for_rerun(
             effective_section, Mapping
         ):
             continue
-        changed = {
-            key: copy.deepcopy(value)
-            for key, value in effective_section.items()
-            if baseline_section.get(key) != value
-        }
+        missing = object()
+        changed: dict[str, Any] = {}
+        for key in sorted(set(baseline_section) | set(effective_section)):
+            baseline_value = baseline_section.get(key, missing)
+            effective_value = effective_section.get(key, missing)
+            if effective_value is missing:
+                if baseline_value is not missing:
+                    changed[key] = None
+            elif baseline_value is missing or baseline_value != effective_value:
+                changed[key] = copy.deepcopy(effective_value)
         if changed:
             overrides[section] = changed
     if overrides:

--- a/api_service/services/omnigent_policies.py
+++ b/api_service/services/omnigent_policies.py
@@ -2,12 +2,13 @@
 
 from __future__ import annotations
 
+import copy
 import logging
-from datetime import UTC, datetime
 import os
 import platform
 import re
 from collections.abc import Awaitable, Callable, Mapping
+from datetime import UTC, datetime
 from typing import Any
 from uuid import uuid4
 
@@ -33,6 +34,7 @@ from moonmind.omnigent.policies import (
     document_digest,
     normalize_document,
 )
+from moonmind.omnigent.stock_agents import CODEX_STOCK_AGENT_NAME
 from moonmind.security.egress import OMNIGENT_EGRESS_PROFILE
 from moonmind.workflows.temporal.container_image_acquisition import (
     normalize_image_reference,
@@ -753,7 +755,11 @@ def bootstrap_document(
     return PolicyDocument.model_validate({
         "schemaVersion": 1,
         "endpoint": {"ref": "default", "bridgeModes": ["embedded", "proxy"]},
-        "execution": {"profileRef": execution_profile_ref, "harness": "codex-native", "agentIdentities": ["codex"]},
+        "execution": {
+            "profileRef": execution_profile_ref,
+            "harness": "codex-native",
+            "agentIdentities": [CODEX_STOCK_AGENT_NAME],
+        },
         "host": {"mode": host_mode, "backendRef": "compose" if host_mode == "static_compose" else "container-backend",
                  "architectures": [architecture],
                  "serverImageRef": server_image_ref if _DIGEST_IMAGE.fullmatch(server_image_ref or "") else "image-ref:omnigent-server",
@@ -782,6 +788,34 @@ def bootstrap_document(
     })
 
 
+def _legacy_bootstrap_agent_identity(row: OmnigentPolicyVersion) -> bool:
+    """Match only MoonMind's pre-release built-in ``codex`` identity."""
+
+    if row.policy_id not in {
+        definition[0] for definition in _BOOTSTRAP_POLICY_DEFINITIONS
+    } or row.version != 1:
+        return False
+    document = row.document_json
+    execution = document.get("execution") if isinstance(document, Mapping) else None
+    return bool(
+        isinstance(execution, Mapping)
+        and execution.get("profileRef") == "omnigent-codex@1"
+        and execution.get("harness") == "codex-native"
+        and execution.get("agentIdentities") == ["codex"]
+    )
+
+
+def _canonical_bootstrap_agent_identity(row: OmnigentPolicyVersion) -> bool:
+    document = row.document_json
+    execution = document.get("execution") if isinstance(document, Mapping) else None
+    return bool(
+        isinstance(execution, Mapping)
+        and execution.get("profileRef") == "omnigent-codex@1"
+        and execution.get("harness") == "codex-native"
+        and execution.get("agentIdentities") == [CODEX_STOCK_AGENT_NAME]
+    )
+
+
 async def seed_bootstrap_policies(
     session: AsyncSession,
     *,
@@ -807,10 +841,30 @@ async def seed_bootstrap_policies(
                 default_row = None
             if (
                 default_row is not None
+                and _legacy_bootstrap_agent_identity(default_row)
+            ):
+                reconciliation_required = True
+                break
+            if (
+                default_row is not None
                 and default_row.state == PolicyState.ACTIVE.value
                 and default_row.validation_json.get("valid")
+                and not _legacy_bootstrap_agent_identity(default_row)
             ):
-                continue
+                legacy_binding = (
+                    await session.execute(
+                        select(OmnigentOAuthHostBindingRecord.binding_ref)
+                        .where(
+                            OmnigentOAuthHostBindingRecord.launch_policy_ref
+                            == f"{policy_id}@1"
+                        )
+                        .limit(1)
+                    )
+                ).scalar_one_or_none()
+                if legacy_binding is None:
+                    continue
+                reconciliation_required = True
+                break
         try:
             row = await service.get_version(policy_id, 1)
         except PolicyNotFound:
@@ -842,6 +896,82 @@ async def seed_bootstrap_policies(
                                        document=document, actor="bootstrap")
         else:
             row = await service.get_version(policy_id, 1)
+            if _legacy_bootstrap_agent_identity(row):
+                versions = await service.versions(policy_id)
+                candidate = versions[0]
+                legacy_ref = f"{policy_id}@{row.version}"
+                if candidate.version == row.version:
+                    migrated_payload = copy.deepcopy(row.document_json)
+                    migrated_payload["execution"]["agentIdentities"] = [
+                        CODEX_STOCK_AGENT_NAME
+                    ]
+                    migrated_document = PolicyDocument.model_validate(
+                        migrated_payload
+                    )
+                    candidate = await service.new_version(
+                        policy_id=policy_id,
+                        document=migrated_document,
+                        actor="bootstrap",
+                        expected_parent_ref=legacy_ref,
+                    )
+                elif not (
+                    candidate.created_by == "bootstrap"
+                    and candidate.parent_ref == legacy_ref
+                    and _canonical_bootstrap_agent_identity(candidate)
+                ):
+                    # A later operator-authored version owns policy evolution.
+                    # Do not rewrite or route around that authority.
+                    continue
+                if not candidate.validation_json.get("valid"):
+                    continue
+                if candidate.state not in {
+                    PolicyState.DRAFT.value,
+                    PolicyState.ACTIVE.value,
+                }:
+                    continue
+                bindings = list(
+                    (
+                        await session.execute(
+                            select(OmnigentOAuthHostBindingRecord).where(
+                                OmnigentOAuthHostBindingRecord.launch_policy_ref
+                                == legacy_ref
+                            )
+                        )
+                    )
+                    .scalars()
+                    .all()
+                )
+                if (
+                    candidate.state == PolicyState.ACTIVE.value
+                    and policy.default_version == candidate.version
+                    and not bindings
+                ):
+                    continue
+                candidate = await service.transition(
+                    policy_id=policy_id,
+                    version=candidate.version,
+                    state=PolicyState.ACTIVE,
+                    actor="bootstrap",
+                    make_default=True,
+                )
+                for binding in bindings:
+                    binding.launch_policy_ref = f"{policy_id}@{candidate.version}"
+                    binding.effective_launch_snapshot_json = None
+                service._event(
+                    policy_id,
+                    candidate.version,
+                    "bootstrap_agent_identity_cutover",
+                    "bootstrap",
+                    {
+                        "agentIdentity": CODEX_STOCK_AGENT_NAME,
+                        "previousRef": legacy_ref,
+                        "policyRef": f"{policy_id}@{candidate.version}",
+                        "updatedBindingCount": len(bindings),
+                    },
+                )
+                await session.commit()
+                seeded.append(policy_id)
+                continue
             if row.state != PolicyState.DRAFT.value or row.validation_json.get("valid"):
                 continue
             normalized = normalize_document(document)

--- a/api_service/services/omnigent_policies.py
+++ b/api_service/services/omnigent_policies.py
@@ -19,6 +19,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from api_service.db.models import (
     OmnigentBridgeSession,
     OmnigentOAuthHostBindingRecord,
+    OmnigentOAuthHostLeaseRecord,
     OmnigentPolicy,
     OmnigentPolicyEvent,
     OmnigentPolicyVersion,
@@ -27,6 +28,7 @@ from moonmind.config.container_backend_settings import (
     ContainerBackendConfigError,
     resolve_container_backend_settings,
 )
+from moonmind.omnigent.oauth_hosts import ACTIVE_HOST_STATES
 from moonmind.omnigent.policies import (
     PolicyDocument,
     PolicyState,
@@ -947,14 +949,43 @@ async def seed_bootstrap_policies(
                     and not bindings
                 ):
                     continue
-                candidate = await service.transition(
-                    policy_id=policy_id,
-                    version=candidate.version,
-                    state=PolicyState.ACTIVE,
-                    actor="bootstrap",
-                    make_default=True,
-                )
-                for binding in bindings:
+                if not (
+                    candidate.state == PolicyState.ACTIVE.value
+                    and policy.default_version == candidate.version
+                ):
+                    candidate = await service.transition(
+                        policy_id=policy_id,
+                        version=candidate.version,
+                        state=PolicyState.ACTIVE,
+                        actor="bootstrap",
+                        make_default=True,
+                    )
+                active_binding_refs: set[str] = set()
+                if bindings:
+                    active_binding_refs = set(
+                        (
+                            await session.execute(
+                                select(
+                                    OmnigentOAuthHostLeaseRecord.binding_ref
+                                ).where(
+                                    OmnigentOAuthHostLeaseRecord.binding_ref.in_(
+                                        [binding.binding_ref for binding in bindings]
+                                    ),
+                                    OmnigentOAuthHostLeaseRecord.status.in_(
+                                        ACTIVE_HOST_STATES
+                                    ),
+                                )
+                            )
+                        )
+                        .scalars()
+                        .all()
+                    )
+                cutover_bindings = [
+                    binding
+                    for binding in bindings
+                    if binding.binding_ref not in active_binding_refs
+                ]
+                for binding in cutover_bindings:
                     binding.launch_policy_ref = f"{policy_id}@{candidate.version}"
                     binding.effective_launch_snapshot_json = None
                 service._event(
@@ -966,7 +997,8 @@ async def seed_bootstrap_policies(
                         "agentIdentity": CODEX_STOCK_AGENT_NAME,
                         "previousRef": legacy_ref,
                         "policyRef": f"{policy_id}@{candidate.version}",
-                        "updatedBindingCount": len(bindings),
+                        "updatedBindingCount": len(cutover_bindings),
+                        "deferredBindingCount": len(active_binding_refs),
                     },
                 )
                 await session.commit()

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -494,6 +494,7 @@ services:
       - TEMPORAL_WORKER_FLEET=sandbox
       - TEMPORAL_ACTIVITY_SANDBOX_TASK_QUEUE=${TEMPORAL_ACTIVITY_SANDBOX_TASK_QUEUE:-mm.activity.sandbox}
       - TEMPORAL_SANDBOX_WORKER_CONCURRENCY=${TEMPORAL_SANDBOX_WORKER_CONCURRENCY:-2}
+      - WORKFLOW_WORKSPACE_ROOT=/work/agent_jobs
       - CODEX_VOLUME_PATH=${CODEX_VOLUME_PATH:-/home/app/.codex}
       - CODEX_HOME=${CODEX_VOLUME_PATH:-/home/app/.codex}
       - CODEX_CONFIG_HOME=${CODEX_VOLUME_PATH:-/home/app/.codex}
@@ -622,7 +623,7 @@ services:
       - MOONMIND_AGENT_RUNTIME_STORE=${MOONMIND_AGENT_RUNTIME_STORE:-/work/agent_jobs}
       - WORKFLOW_WORKSPACE_ROOT=/work/agent_jobs
       - WORKFLOW_DOCKER_DAEMON_MODE=remote
-      - WORKFLOW_WORKSPACE_DAEMON_ROOT=${WORKFLOW_WORKSPACE_DAEMON_ROOT:-/var/lib/docker/volumes/${COMPOSE_PROJECT_NAME:-moonmind}_agent_workspaces/_data}
+      - WORKFLOW_WORKSPACE_DAEMON_ROOT=${WORKFLOW_WORKSPACE_DAEMON_ROOT:-/var/lib/docker/volumes/${MOONMIND_AGENT_WORKSPACES_VOLUME_NAME:-agent_workspaces}/_data}
       - MOONMIND_AGENT_RUNTIME_ARTIFACTS=${MOONMIND_AGENT_RUNTIME_ARTIFACTS:-/work/agent_jobs/artifacts}
       - MOONMIND_MANAGED_RUNTIME_JANITOR_ENABLED=${MOONMIND_MANAGED_RUNTIME_JANITOR_ENABLED:-true}
       - MOONMIND_MANAGED_RUNTIME_JANITOR_DRY_RUN=${MOONMIND_MANAGED_RUNTIME_JANITOR_DRY_RUN:-false}
@@ -688,6 +689,8 @@ services:
       codex-auth-init:
         condition: service_completed_successfully
       claude-auth-init:
+        condition: service_completed_successfully
+      omnigent-tools-init:
         condition: service_completed_successfully
       docker-proxy:
         condition: service_started
@@ -836,7 +839,6 @@ services:
       - local-network
 
   omnigent-tools-init:
-    profiles: ["omnigent-host", "omnigent-host-claude", "omnigent-host-codex"]
     image: ${OMNIGENT_GH_IMAGE:-serversideup/github-cli:alpine-2.76.2}
     user: "0:0"
     entrypoint: ["/opt/moonmind/init-mounted-tools.sh"]
@@ -905,8 +907,9 @@ services:
       HTTPS_PROXY: http://omnigent-egress-proxy:3129
       http_proxy: http://omnigent-egress-proxy:3129
       https_proxy: http://omnigent-egress-proxy:3129
-      NO_PROXY: ""
-      no_proxy: ""
+      NO_PROXY: localhost,127.0.0.1
+      no_proxy: localhost,127.0.0.1
+      OMNIGENT_RUNNER_ENV_PASSTHROUGH: HTTP_PROXY,HTTPS_PROXY,http_proxy,https_proxy,NO_PROXY,no_proxy
       PATH: /opt/moonmind-tools/bin:${OMNIGENT_HOST_BASE_PATH:-/opt/venv/bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin}
       MOONMIND_ACTIVE_SKILLS_DIR: /opt/moonmind-skills
       OMNIGENT_SERVER_URL: http://omnigent:8000
@@ -1021,8 +1024,9 @@ services:
       HTTPS_PROXY: http://omnigent-egress-proxy:3129
       http_proxy: http://omnigent-egress-proxy:3129
       https_proxy: http://omnigent-egress-proxy:3129
-      NO_PROXY: ""
-      no_proxy: ""
+      NO_PROXY: localhost,127.0.0.1
+      no_proxy: localhost,127.0.0.1
+      OMNIGENT_RUNNER_ENV_PASSTHROUGH: HTTP_PROXY,HTTPS_PROXY,http_proxy,https_proxy,NO_PROXY,no_proxy
       PATH: /opt/moonmind-tools/bin:${OMNIGENT_HOST_BASE_PATH:-/opt/venv/bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin}
       MOONMIND_ACTIVE_SKILLS_DIR: /opt/moonmind-skills
       HOME: /home/app
@@ -1184,6 +1188,7 @@ services:
         condition: service_completed_successfully
     networks:
       - local-network
+      - omnigent-egress-network
     restart: unless-stopped
 
   agent-workspaces-init:

--- a/docs/Omnigent/OmnigentHostMountedTools.md
+++ b/docs/Omnigent/OmnigentHostMountedTools.md
@@ -76,7 +76,7 @@ The target design is governed by these decisions:
 3. **The bundle is read-only to hosts and runners.** A trusted initializer prepares it before the host starts. Agent processes never update the bundle.
 4. **Tool versions are explicit.** The initializer uses pinned versions and verifies the expected bytes before publishing a bundle as ready. `latest` is not a durable tool identity.
 5. **Both ordinary and login-shell paths are supported.** The host receives a `PATH` value at launch and a small `/etc/profile.d` snippet so `bash -lc` sessions retain `/opt/moonmind-tools/bin`.
-6. **Required capabilities determine readiness.** A mounted executable may be present on every compatible host, but a run receives readiness guarantees and any required credentials only when its normalized `requiredCapabilities` demand them.
+6. **Required capabilities determine readiness.** A mounted executable may be present on every compatible host, but a run receives readiness guarantees and any required credentials only when its normalized `requiredCapabilities` demand them. The Run workflow carries that authored list into the canonical `AgentExecutionRequest`; host preflight and the provider adapter consume the same list rather than re-deriving it.
 7. **Tool availability does not grant authorization.** Credentials are resolved separately through MoonMind's existing settings and secret-reference boundaries.
 8. **Portable Skills receive the real CLI they declare.** MoonMind does not replace `gh` with an incomplete host-native emulator when the resolved Skill implementation calls `gh` directly.
 9. **Missing required tools fail before session creation or mutation.** MoonMind must not start an Omnigent runner and let the Skill discover the missing executable after reasoning has begun.
@@ -137,7 +137,7 @@ The manifest is readiness evidence and diagnostics metadata. It contains no cred
 
 ### 4.3 Storage
 
-For the local Compose path, the preferred storage is one versioned Docker named volume populated by an initializer service.
+For the local Compose path, the preferred storage is one versioned Docker named volume populated by an initializer service. The initializer is a default one-shot dependency of the agent-runtime worker, so on-demand hosts are operational without enabling a static-host Compose profile and no tool container remains running at steady state.
 
 For on-demand host launches, MoonMind mounts the same named volume into each compatible host. A daemon-visible read-only bind source is also valid when a deployment already manages immutable tool directories outside Docker volumes.
 
@@ -161,6 +161,13 @@ For each declared tool, the initializer must:
 The initializer is idempotent. A completed bundle whose manifest does not match the expected manifest fails rather than being modified in place. Incomplete staging state without a completed manifest is not a bundle: the initializer may safely remove that private staging state and retry. Staging paths are unique to an initializer attempt, so a failed attempt cannot poison the versioned published volume or expose partial files to hosts.
 
 Tool downloads do not occur inside an ordinary Omnigent workflow session. An agent cannot add arbitrary executables to the shared bundle.
+
+Before an on-demand host is created, the trusted runtime adapter probes the
+completed named volume through the system Docker boundary and verifies the
+pinned tool version. It never invokes deployment Compose from the worker: the
+worker's project path is not Docker-daemon path authority. A missing or stale
+bundle fails with `tool_bundle_unavailable` and deployment-initialization
+evidence before session creation.
 
 ---
 
@@ -250,31 +257,51 @@ The current `pr-resolver` Skill declares both `git` and `gh` because it must mod
 
 ### 7.2 Baseline credential mapping
 
-The simple baseline uses the stock host's Git credential convention and GitHub CLI's standard environment authentication on an on-demand host or a host dedicated to exactly one run:
+The simple baseline uses GitHub CLI's standard configuration on an on-demand host or a host dedicated to exactly one run:
 
 ```text
-GIT_TOKEN=<MoonMind-resolved GitHub credential>
-GIT_USERNAME=x-access-token
-GH_TOKEN=<MoonMind-resolved GitHub credential>
-GH_CONFIG_DIR=<run-private-workspace>/.config/gh
+XDG_CONFIG_HOME=<lease-owned-cache>/moonmind-xdg
 GH_PROMPT_DISABLED=1
 GH_NO_UPDATE_NOTIFIER=1
 GH_NO_EXTENSION_UPDATE_NOTIFIER=1
 ```
 
-The same narrowly scoped credential may back `GIT_TOKEN` and `GH_TOKEN` for that run. `GH_CONFIG_DIR` is created with owner-only permissions inside the run-private workspace and is never shared between sessions. A reusable static host is not eligible for credential-bearing GitHub runs because its host-wide runner environment would expose `GIT_TOKEN` and passthrough values to unrelated runners. Such a deployment must route the run to an on-demand or run-dedicated host; per-run environment injection may make reusable hosts eligible only when that isolation boundary is implemented and verified.
+The trusted host entrypoint receives the narrowly scoped credential only long enough to write `gh/hosts.yml` with owner-only permissions under the lease-owned cache volume. It removes the raw credential before Omnigent starts, while the non-secret `XDG_CONFIG_HOME` selector reaches the runner and native Codex app-server. The cache volume is outside the repository workspace and is removed with the host lease, so it is neither shared between sessions nor eligible for workspace capture. A reusable static host is not eligible for credential-bearing GitHub runs because its host-wide configuration could expose credentials to unrelated runners. Such a deployment must route the run to an on-demand or run-dedicated host.
 
 The tool bundle never contains token values. MoonMind resolves the credential at the trusted launch boundary and must keep it out of workflow payloads, Temporal history, logs, artifacts, and durable host metadata.
 
 ### 7.3 Runner environment
 
-On an on-demand or run-dedicated host, the stock Omnigent host intentionally forwards `GIT_TOKEN` and `GIT_USERNAME` for Git transport. GitHub CLI settings that are not part of the stock credential allowlist must be explicitly forwarded to that run's spawned runner:
+On an on-demand or run-dedicated host, GitHub CLI settings that are not part of the stock runner allowlist must be explicitly forwarded to that run's spawned runner:
 
 ```text
-OMNIGENT_RUNNER_ENV_PASSTHROUGH=GH_TOKEN,GH_CONFIG_DIR,GH_PROMPT_DISABLED,GH_NO_UPDATE_NOTIFIER,GH_NO_EXTENSION_UPDATE_NOTIFIER
+OMNIGENT_RUNNER_ENV_PASSTHROUGH=MOONMIND_STEP_EXECUTION_ID,XDG_CONFIG_HOME,GH_PROMPT_DISABLED,GH_NO_UPDATE_NOTIFIER,GH_NO_EXTENSION_UPDATE_NOTIFIER
 ```
 
 A deployment may append other non-secret runtime selectors to the same comma-separated setting when another canonical MoonMind contract requires them.
+
+For the stock Codex native wrapper, no token-bearing environment variable or
+terminal argument is required. Native Codex preserves `XDG_CONFIG_HOME`, and
+model-authored `gh` commands therefore use the same lease-private standard
+configuration that both preflight boundaries prove before session creation.
+
+Terminal-evidence Skills also receive the exact, non-secret
+`MOONMIND_STEP_EXECUTION_ID` for the current attempt. The on-demand host forwards
+that identity to its runner and mounts a run-private
+`/etc/profile.d/moonmind-execution.sh` so a native Codex login shell restores it
+after Codex applies its own subprocess environment filter. The generated profile
+is outside the repository workspace, is bound to the same execution-specific
+runtime-script snapshot as the host lease, and is removed with that run-owned
+materialization. This lets the portable Skill stamp its normal `executionRef`;
+MoonMind does not synthesize or rewrite the Skill's terminal evidence.
+
+For a terminal `merged` or `already_merged` resolver disposition, AgentRun
+validates both the Skill's execution-bound `var/pr_resolver/result.json` and its
+canonical `artifacts/publish_result.json` companion. It publishes each exact
+file as a durable artifact and passes the publish-evidence ref to the parent
+workflow. Auto-publication finalization reads and validates that artifact; it
+does not require a second publisher, infer success from the disposition alone,
+or copy merge semantics into the Omnigent integration.
 
 ### 7.4 Private workspace preparation
 

--- a/docs/Omnigent/OmnigentHostOAuth.md
+++ b/docs/Omnigent/OmnigentHostOAuth.md
@@ -344,7 +344,22 @@ GEMINI_API_KEY
 GOOGLE_API_KEY
 ```
 
-Required mounted tools and resolved Skill snapshots are validated before the corresponding execution capability is claimed. GitHub credentials, when required, are resolved independently at a trusted boundary and injected only into an isolated on-demand run-dedicated host and its authoritative runner environment. A reusable static OAuth host does not receive per-run GitHub mutation credentials.
+Required mounted tools and resolved Skill snapshots are validated before the corresponding execution capability is claimed. GitHub credentials, when required, are resolved independently at a trusted boundary and materialized as owner-only standard `gh` configuration in the isolated on-demand host's lease-owned cache. The raw credential is removed before Omnigent starts; only the non-secret config selector reaches its authoritative runner. A reusable static OAuth host does not receive per-run GitHub mutation credentials.
+
+An on-demand host also receives the exact non-secret step execution identity for
+its current lease. MoonMind forwards `MOONMIND_STEP_EXECUTION_ID` to the runner
+and mounts a generated, execution-owned login profile at
+`/etc/profile.d/moonmind-execution.sh`. Native Codex deliberately filters
+unknown variables from the app-server process, so the login profile restores
+the identity for model-authored shell commands without embedding it in terminal
+arguments or mutable repository files. The profile is validated against the
+run-owned runtime-script snapshot and must fail closed on a missing, unsafe, or
+mismatched identity. Terminal-evidence Skills remain responsible for writing
+their own evidence with this execution ref. When a resolver reaches a terminal
+merge disposition, AgentRun durably publishes both the validated resolver result
+and the Skill-authored `artifacts/publish_result.json` companion. The parent
+consumes that companion by artifact ref as auto-publication evidence, preserving
+the Skill as semantic authority while keeping the authority handoff durable.
 
 ---
 
@@ -448,6 +463,13 @@ Terminal cleanup occurs after available session evidence is harvested:
 9. release the Provider Profile lease last.
 
 If host cleanup fails, the Provider Profile lease remains held or explicitly marked for janitor reconciliation. MoonMind does not report successful release while a credential consumer may still be active.
+
+Cancellation can close the owning workflow before janitor reconciliation has made
+the old host lease terminal. An immediate rerun that reaches host admission during
+that interval waits behind the active lease with
+`OMNIGENT_OAUTH_HOST_PROFILE_BUSY` evidence and retries the same selected profile.
+It does not expose the database uniqueness constraint, reuse the canceled run's
+authority, or select a different profile.
 
 The janitor reconciles expired leases, missing containers, orphan labeled containers, stale credential generations, and force-drain requests. It uses durable bindings and labels and never removes unrelated containers, unrelated state volumes, the canonical OAuth volume, or application data.
 

--- a/moonmind/omnigent/authority_chain.py
+++ b/moonmind/omnigent/authority_chain.py
@@ -125,10 +125,10 @@ def _publication_state(
 ) -> str:
     """Classify the publication disposition MoonMind owns for this run.
 
-    The coordinator does not itself push; the actual commit/push/PR side effects
-    are performed by the shared publication path after the run result returns.
-    Until that owner produces terminal evidence, the projection records the
-    disposition the Omnigent execution boundary *authorized*
+    The coordinator invokes the shared runtime publication boundary before host
+    cleanup so publication failures remain retryable lifecycle evidence. Until
+    that owner produces terminal evidence, the projection records the disposition
+    the Omnigent execution boundary *authorized*
     (``authorized_pending_publication``). Once realized commit/push/PR evidence is
     present in the result metadata, the state is reconciled to ``published`` so the
     chain reflects the publication owner's terminal outcome rather than a stale

--- a/moonmind/omnigent/bridge_events.py
+++ b/moonmind/omnigent/bridge_events.py
@@ -18,6 +18,7 @@ from moonmind.omnigent.bridge_security import redact_raw_events
 from moonmind.schemas.agent_runtime_models import AgentExecutionRequest
 
 BRIDGE_EVENT_SCHEMA_VERSION = "moonmind.omnigent_bridge.event.v1"
+BRIDGE_EVENT_DEDUPLICATION_KEY_MAX_LENGTH = 128
 
 _TERMINAL_STATUSES = {
     "completed",
@@ -37,22 +38,66 @@ _NON_TERMINAL_STATUSES = {
 }
 _RECOGNIZED_EXACT_EVENT_TYPES = {
     "",
+    "browser.action_request",
     "completed",
     "failed",
     "host.capabilities",
     "host.heartbeat",
+    "injection.consumed",
     "resource.changed_file",
     "resource.session_file",
+    "response.cancelled",
+    "response.client_task.cancel",
+    "response.compaction.completed",
+    "response.compaction.failed",
+    "response.compaction.in_progress",
     "response.completed",
+    "response.created",
     "response.delta",
     "response.elicitation_request",
+    "response.elicitation_resolved",
+    "response.error",
     "response.failed",
+    "response.function_call_output.delta",
+    "response.heartbeat",
+    "response.in_progress",
+    "response.incomplete",
     "response.output",
+    "response.policy_denied",
+    "response.queued",
+    "response.reasoning.started",
+    "response.reasoning_summary_text.delta",
+    "response.reasoning_text.delta",
+    "response.retry",
+    "session.agent_changed",
+    "session.changed_files.invalidated",
+    "session.collaboration_mode",
     "session.created",
     "session.final_snapshot",
+    "session.heartbeat",
+    "session.interrupted",
+    "session.mcp_startup",
+    "session.model",
+    "session.model_options",
+    "session.presence",
+    "session.reasoning_effort",
+    "session.resource.created",
+    "session.resource.deleted",
+    "session.sandbox_status",
+    "session.skills",
     "session.started",
+    "session.status",
+    "session.superseded",
+    "session.terminal.activity",
+    "session.terminal_pending",
+    "session.todos",
+    "session.usage",
     "stream.done",
     "stream.resume_gap",
+    "turn.cancelled",
+    "turn.completed",
+    "turn.failed",
+    "turn.started",
 }
 _RECOGNIZED_EVENT_PREFIXES = (
     "response.output",
@@ -68,6 +113,18 @@ class BridgeEventNormalization:
 
     event: dict[str, Any]
     diagnostic: dict[str, Any] | None = None
+
+
+def bounded_deduplication_key(key: str) -> str:
+    """Fit a durable event identity without discarding distinguishing suffixes."""
+
+    if len(key) <= BRIDGE_EVENT_DEDUPLICATION_KEY_MAX_LENGTH:
+        return key
+    digest = hashlib.sha256(key.encode()).hexdigest()
+    prefix_length = (
+        BRIDGE_EVENT_DEDUPLICATION_KEY_MAX_LENGTH - len(digest) - 1
+    )
+    return f"{key[:prefix_length]}:{digest}"
 
 
 def normalize_omnigent_observation(payload: dict[str, Any]) -> str | None:
@@ -152,7 +209,7 @@ def build_omnigent_bridge_event(
         ).hexdigest()
         deduplication_key = f"cursor:{sequence}:{digest}"
     event["metadata"]["reconciliation"] = reconciliation
-    event["deduplicationKey"] = deduplication_key[:128]
+    event["deduplicationKey"] = bounded_deduplication_key(deduplication_key)
     if diagnostic is not None:
         event["metadata"]["moonmind"]["contractDrift"] = diagnostic
     text_preview = _text_preview(payload)
@@ -188,15 +245,40 @@ def _normalize_status(
     event_type = _event_type(payload)
     if event_type == "stream.done":
         return None
-    if event_type in {"response.completed", "completed"}:
+    if event_type in {"response.completed", "turn.completed", "completed"}:
         return "completed"
-    if event_type in {"response.failed", "failed"}:
+    if event_type in {
+        "response.error",
+        "response.failed",
+        "response.incomplete",
+        "response.policy_denied",
+        "turn.failed",
+        "failed",
+    }:
         return "failed"
+    if event_type in {
+        "response.cancelled",
+        "session.interrupted",
+        "session.superseded",
+        "turn.cancelled",
+    }:
+        return "canceled"
     if event_type in {"response.elicitation_request", "elicitation_request"}:
         return "awaiting_approval"
+    if event_type == "browser.action_request":
+        return "intervention_requested"
     if event_type == "session.created":
         return "created"
-    if event_type == "session.started":
+    if event_type in {
+        "response.created",
+        "response.heartbeat",
+        "response.in_progress",
+        "response.queued",
+        "response.retry",
+        "session.heartbeat",
+        "session.started",
+        "turn.started",
+    }:
         return "running"
     if not _is_recognized_event_type(event_type):
         message = f"Unsupported Omnigent event type: {event_type}"

--- a/moonmind/omnigent/bridge_store.py
+++ b/moonmind/omnigent/bridge_store.py
@@ -17,6 +17,7 @@ stream is preserved per event on ``omnigent_bridge_session_events``.
 
 from __future__ import annotations
 
+import hashlib
 import json
 from collections.abc import Callable, Iterable, Sequence
 from datetime import UTC, datetime
@@ -27,6 +28,7 @@ from sqlalchemy import delete, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from api_service.db.models import OmnigentBridgeSession, OmnigentBridgeSessionEvent
+from moonmind.omnigent.bridge_events import bounded_deduplication_key
 from moonmind.omnigent.bridge_security import BridgeSessionBinding, redact_raw_events
 from moonmind.schemas.agent_runtime_models import AgentExecutionRequest
 from moonmind.utils.logging import redact_sensitive_payload
@@ -609,6 +611,70 @@ class OmnigentBridgeSessionStore:
                 await session.commit()
             else:
                 changed = False
+                if (
+                    row.status in _TERMINAL_STATUSES
+                    and row.first_message_posted_at is None
+                ):
+                    # A profile-bound Activity can fail during host preflight,
+                    # before Omnigent receives the first message, and then be
+                    # retried by Temporal with the same idempotency key.  The
+                    # failed coordinator attempt still terminalizes its bridge
+                    # row.  Treating that terminal marker as proof that the
+                    # prompt was posted makes the retry create a fresh session
+                    # and then skip its only message forever.
+                    #
+                    # No provider-side message exists in this state, so it is
+                    # safe to reopen the same idempotent journal.  Preserve the
+                    # failed generation's compact refs in metadata, then clear
+                    # only generation-scoped routing/capture fields.  Existing
+                    # lifecycle events remain immutable evidence and the next
+                    # attempt appends its own attempt-qualified transitions.
+                    prior_attempts = list(
+                        (row.metadata_ or {}).get("unpostedAttemptHistory") or []
+                    )
+                    prior_attempts.append(
+                        {
+                            "status": row.status,
+                            "terminalRefs": dict(row.terminal_refs or {}),
+                            "rawEventsRef": row.raw_events_ref,
+                            "normalizedEventsRef": row.normalized_events_ref,
+                            "initialSnapshotRef": row.initial_snapshot_ref,
+                            "finalSnapshotRef": row.final_snapshot_ref,
+                            "captureManifestRef": row.capture_manifest_ref,
+                            "diagnosticsRef": row.diagnostics_ref,
+                            "externalStateRef": row.external_state_ref,
+                            "recordedAt": datetime.now(tz=UTC).isoformat(),
+                        }
+                    )
+                    reset_metadata = dict(row.metadata_ or {})
+                    reset_metadata["unpostedAttemptHistory"] = prior_attempts[-10:]
+                    reset_metadata.pop("initialRetrieval", None)
+                    row.metadata_ = reset_metadata
+                    row.status = STATUS_DECLARED
+                    row.first_message_state = FIRST_MESSAGE_NOT_PREPARED
+                    row.first_message_digest = None
+                    row.first_message_marker = None
+                    row.first_message_post_attempted_at = None
+                    row.first_message_pending_id = None
+                    row.first_message_item_id = None
+                    row.omnigent_session_id = None
+                    row.omnigent_host_id = None
+                    row.omnigent_runner_id = None
+                    row.provider_profile_id = None
+                    row.provider_lease_id = None
+                    row.credential_generation = None
+                    row.host_binding_ref = None
+                    row.host_lease_ref = None
+                    row.effective_launch_snapshot_json = None
+                    row.raw_events_ref = None
+                    row.normalized_events_ref = None
+                    row.initial_snapshot_ref = None
+                    row.final_snapshot_ref = None
+                    row.capture_manifest_ref = None
+                    row.diagnostics_ref = None
+                    row.external_state_ref = None
+                    row.terminal_refs = {}
+                    changed = True
                 if row.omnigent_agent_id is None and agent_id is not None:
                     row.omnigent_agent_id = agent_id
                     changed = True
@@ -1265,7 +1331,9 @@ class OmnigentBridgeSessionStore:
                     event_id=stable_event_id,
                     bridge_session_id=row.bridge_session_id,
                     sequence=sequence,
-                    deduplication_key=f"lifecycle:{event_identity}"[:128],
+                    deduplication_key=bounded_deduplication_key(
+                        f"lifecycle:{event_identity}"
+                    ),
                     timestamp=datetime.now(tz=UTC),
                     direction="moonmind_system",
                     event_type=(
@@ -2072,21 +2140,20 @@ def _build_event_rows(
 
 def _event_deduplication_key(event: dict[str, Any]) -> str:
     """Prefer explicit/provider identity, otherwise bind content to its cursor."""
-    import hashlib
     import json
 
     explicit = _string_or_none(event.get("deduplicationKey"))
     if explicit:
-        return explicit[:128]
+        return bounded_deduplication_key(explicit)
     metadata = event.get("metadata") or {}
     reconciliation = metadata.get("reconciliation") or {}
     provider_id = _string_or_none(reconciliation.get("providerEventId"))
     if provider_id:
-        return f"provider:{provider_id}"[:128]
+        return bounded_deduplication_key(f"provider:{provider_id}")
     cursor = reconciliation.get("streamCursor") or event.get("sequence") or 0
     canonical = json.dumps(event, sort_keys=True, separators=(",", ":"), default=str)
     digest = hashlib.sha256(canonical.encode()).hexdigest()
-    return f"cursor:{cursor}:{digest}"[:128]
+    return bounded_deduplication_key(f"cursor:{cursor}:{digest}")
 
 
 def _workflow_id(request: AgentExecutionRequest) -> str:

--- a/moonmind/omnigent/execute.py
+++ b/moonmind/omnigent/execute.py
@@ -7,8 +7,9 @@ import hashlib
 import inspect
 import json
 import logging
-from collections.abc import AsyncIterator
-from contextlib import suppress
+from collections.abc import AsyncIterator, Mapping
+from contextlib import asynccontextmanager, suppress
+from contextvars import ContextVar
 from pathlib import Path
 from typing import Any
 
@@ -79,6 +80,14 @@ _NON_TERMINAL_STATUSES = {
     "idle",
 }
 _logger = logging.getLogger(__name__)
+
+_ACTIVITY_HEARTBEAT_INTERVAL_SECONDS = 30.0
+_MARKED_TURN_QUIET_PERIOD_SECONDS = 60.0
+_MARKED_TOOL_ONLY_QUIET_PERIOD_SECONDS = 300.0
+_ACTIVITY_HEARTBEAT_STATE: ContextVar[dict[str, Any] | None] = ContextVar(
+    "omnigent_activity_heartbeat_state",
+    default=None,
+)
 
 
 class OmnigentSessionStillRunningError(OmnigentClientError):
@@ -471,6 +480,220 @@ def _snapshot_contains_first_message_marker(
     return False
 
 
+def _nested_value_contains_text(value: Any, *, needle: str) -> bool:
+    stack: list[Any] = [value]
+    while stack:
+        current = stack.pop()
+        if isinstance(current, Mapping):
+            stack.extend(current.values())
+        elif isinstance(current, list):
+            stack.extend(current)
+        elif isinstance(current, str) and needle in current:
+            return True
+    return False
+
+
+def _snapshot_contains_current_turn_progress(
+    snapshot: Mapping[str, Any],
+    *,
+    marker: str,
+) -> bool:
+    """Prove provider work occurred after this invocation's marked message.
+
+    Omnigent can replay the previous turn's terminal SSE event when a stream is
+    opened before posting the next message. The per-message marker is durable in
+    the user item, so item ordering—not a stale session status—authoritatively
+    distinguishes current-turn progress from the preceding turn.
+    """
+
+    raw_items = snapshot.get("items")
+    if not isinstance(raw_items, list):
+        return False
+    marked_message_index = -1
+    for index, raw_item in enumerate(raw_items):
+        if not isinstance(raw_item, Mapping):
+            continue
+        if str(raw_item.get("type") or "").strip() != "message":
+            continue
+        data = raw_item.get("data")
+        item_data = data if isinstance(data, Mapping) else {}
+        if str(item_data.get("role") or "").strip().lower() != "user":
+            continue
+        if _nested_value_contains_text(raw_item, needle=marker):
+            marked_message_index = index
+    if marked_message_index < 0:
+        return False
+    for raw_item in raw_items[marked_message_index + 1 :]:
+        if not isinstance(raw_item, Mapping):
+            continue
+        item_type = str(raw_item.get("type") or "").strip()
+        if item_type in {"function_call", "function_call_output"}:
+            return True
+        if item_type != "message":
+            continue
+        data = raw_item.get("data")
+        item_data = data if isinstance(data, Mapping) else {}
+        if str(item_data.get("role") or "").strip().lower() == "assistant":
+            return True
+    return False
+
+
+def _marked_turn_item_state(
+    snapshot: Mapping[str, Any],
+    *,
+    marker: str,
+) -> dict[str, Any]:
+    """Summarize ordered completion evidence after one marked user item.
+
+    Native Codex can accept a new message as a steer while the preceding turn
+    is still producing tools. Those items share the same session response id,
+    so the completion boundary must come from item ordering: a textual
+    assistant after the last tool is terminal, while an unmatched tool call is
+    still active regardless of the stock server's stale ``idle`` projection.
+    """
+
+    raw_items = snapshot.get("items")
+    if not isinstance(raw_items, list):
+        return {
+            "markerIndex": -1,
+            "progress": False,
+            "terminalAssistantAfterWork": False,
+            "unfinishedToolCall": False,
+            "signature": None,
+        }
+
+    marked_message_index = -1
+    for index, raw_item in enumerate(raw_items):
+        if not isinstance(raw_item, Mapping):
+            continue
+        if str(raw_item.get("type") or "").strip() != "message":
+            continue
+        data = raw_item.get("data")
+        item_data = data if isinstance(data, Mapping) else {}
+        if str(item_data.get("role") or "").strip().lower() != "user":
+            continue
+        if _nested_value_contains_text(raw_item, needle=marker):
+            marked_message_index = index
+
+    if marked_message_index < 0:
+        return {
+            "markerIndex": -1,
+            "progress": False,
+            "terminalAssistantAfterWork": False,
+            "unfinishedToolCall": False,
+            "signature": None,
+        }
+
+    last_tool_index = -1
+    last_text_assistant_index = -1
+    progress = False
+    pending_call_ids: set[str] = set()
+    anonymous_pending_calls = 0
+    for index, raw_item in enumerate(
+        raw_items[marked_message_index + 1 :],
+        start=marked_message_index + 1,
+    ):
+        if not isinstance(raw_item, Mapping):
+            continue
+        item_type = str(raw_item.get("type") or "").strip()
+        data = raw_item.get("data")
+        item_data = data if isinstance(data, Mapping) else {}
+        if item_type == "function_call":
+            progress = True
+            last_tool_index = index
+            call_id = str(item_data.get("call_id") or "").strip()
+            if call_id:
+                pending_call_ids.add(call_id)
+            else:
+                anonymous_pending_calls += 1
+        elif item_type == "function_call_output":
+            progress = True
+            last_tool_index = index
+            call_id = str(item_data.get("call_id") or "").strip()
+            if call_id:
+                pending_call_ids.discard(call_id)
+            elif anonymous_pending_calls:
+                anonymous_pending_calls -= 1
+        elif item_type == "message":
+            role = str(item_data.get("role") or "").strip().lower()
+            if role != "assistant":
+                continue
+            progress = True
+            content = item_data.get("content")
+            if isinstance(content, list) and any(
+                isinstance(block, Mapping)
+                and str(block.get("text") or "").strip()
+                for block in content
+            ):
+                last_text_assistant_index = index
+
+    last_item = next(
+        (item for item in reversed(raw_items) if isinstance(item, Mapping)),
+        {},
+    )
+    last_data = last_item.get("data")
+    last_item_data = last_data if isinstance(last_data, Mapping) else {}
+    signature = (
+        len(raw_items),
+        str(last_item.get("id") or ""),
+        str(last_item.get("type") or ""),
+        str(last_item.get("status") or ""),
+        str(last_item_data.get("role") or ""),
+        str(last_item_data.get("call_id") or ""),
+    )
+    return {
+        "markerIndex": marked_message_index,
+        "progress": progress,
+        "terminalAssistantAfterWork": (
+            last_text_assistant_index > max(marked_message_index, last_tool_index)
+        ),
+        "unfinishedToolCall": bool(pending_call_ids or anonymous_pending_calls),
+        "signature": signature,
+    }
+
+
+def _snapshot_projects_inactive_turn(snapshot: Mapping[str, Any]) -> bool:
+    normalized = normalize_omnigent_observation(dict(snapshot))
+    if normalized in {"completed", "failed", "canceled", "timed_out", "idle"}:
+        return True
+    active_response_is_projected = (
+        "active_response_id" in snapshot or "activeResponseId" in snapshot
+    )
+    active_response_id = str(
+        snapshot.get("active_response_id")
+        or snapshot.get("activeResponseId")
+        or ""
+    ).strip()
+    return (
+        normalized in _NON_TERMINAL_STATUSES
+        and active_response_is_projected
+        and not active_response_id
+    )
+
+
+def _snapshot_confirms_current_turn_terminal(
+    snapshot: Mapping[str, Any],
+    *,
+    marker: str,
+) -> bool:
+    """Identify a structurally terminal assistant candidate for a marked turn.
+
+    Stock Omnigent can emit ``response.completed`` for an intermediate response
+    while the Codex turn remains active. A stale inactive projection is therefore
+    corroborative only. Even this structural candidate must pass the bounded
+    transcript-quiescence gate before it owns a terminal decision because an
+    assistant preamble can be followed by a tool that has not appeared yet.
+    """
+
+    state = _marked_turn_item_state(snapshot, marker=marker)
+    return bool(
+        state["progress"]
+        and state["terminalAssistantAfterWork"]
+        and not state["unfinishedToolCall"]
+        and _snapshot_projects_inactive_turn(snapshot)
+    )
+
+
 async def _unsupported_bundle_upload(bundle_ref: str) -> dict[str, Any]:
     raise OmnigentContractError(
         f"Omnigent bundleRef cannot be resolved by this activity: {bundle_ref}"
@@ -484,10 +707,49 @@ async def _maybe_await(value: Any) -> Any:
 
 
 def _safe_heartbeat(details: dict[str, Any]) -> None:
+    state = _ACTIVITY_HEARTBEAT_STATE.get()
+    payload = dict(details)
+    if state is not None:
+        # All lifecycle and streaming tasks spawned by one Activity share this
+        # mutable accumulator. A substrate-level liveness heartbeat therefore
+        # preserves the latest session/cursor evidence instead of replacing it.
+        state.update(details)
+        payload = dict(state)
     try:
-        activity.heartbeat(details)
+        activity.heartbeat(payload)
     except RuntimeError as exc:
         _logger.debug("Skipping Omnigent heartbeat outside activity context: %s", exc)
+
+
+@asynccontextmanager
+async def omnigent_activity_heartbeat(
+    *, interval_seconds: float | None = None
+) -> AsyncIterator[None]:
+    """Heartbeat the complete Activity, including host/workspace preparation."""
+
+    state: dict[str, Any] = {}
+    token = _ACTIVITY_HEARTBEAT_STATE.set(state)
+    interval = max(
+        0.01,
+        float(
+            _ACTIVITY_HEARTBEAT_INTERVAL_SECONDS
+            if interval_seconds is None
+            else interval_seconds
+        ),
+    )
+
+    async def heartbeat() -> None:
+        while True:
+            _safe_heartbeat({"activityAlive": True})
+            await asyncio.sleep(interval)
+
+    heartbeat_task = asyncio.create_task(heartbeat())
+    try:
+        yield
+    finally:
+        heartbeat_task.cancel()
+        await asyncio.gather(heartbeat_task, return_exceptions=True)
+        _ACTIVITY_HEARTBEAT_STATE.reset(token)
 
 
 def _heartbeat_details() -> tuple[Any, ...]:
@@ -539,15 +801,145 @@ async def _periodic_stream_heartbeat(
         )
 
 
+async def _await_marked_turn_terminal(
+    *,
+    client: OmnigentHttpClient,
+    session_id: str,
+    marker: str,
+    event_count: int,
+    terminal_status: str,
+    timeout_seconds: float = 1800.0,
+    interval_seconds: float = 2.0,
+    quiet_period_seconds: float = _MARKED_TURN_QUIET_PERIOD_SECONDS,
+    tool_only_quiet_period_seconds: float = (
+        _MARKED_TOOL_ONLY_QUIET_PERIOD_SECONDS
+    ),
+) -> tuple[str, dict[str, Any]]:
+    """Wait until a terminal event is stably projected into the marked turn.
+
+    Omnigent sessions are interactive and return to ``idle`` after a Codex
+    turn, so the session snapshot itself does not become terminal. Stock native
+    sessions can replay the prior SSE terminal frame and can briefly project an
+    assistant preamble as their last item before its next tool appears. Marked
+    item ordering plus a bounded stable period therefore owns the terminal
+    decision; neither a terminal frame nor a transient last assistant does.
+    """
+
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + max(1.0, timeout_seconds)
+    quiet_signature: tuple[Any, ...] | None = None
+    quiet_since: float | None = None
+    while loop.time() < deadline:
+        snapshot = await client.get_session(session_id)
+        normalized = normalize_omnigent_observation(snapshot)
+        turn_state = _marked_turn_item_state(snapshot, marker=marker)
+        progress = bool(turn_state["progress"])
+        if not isinstance(snapshot.get("items"), list) and normalized in {
+            "completed",
+            "failed",
+            "canceled",
+            "timed_out",
+        }:
+            # Older/alternate Omnigent adapters do not project ordered items.
+            # For those adapters, a terminal snapshot corroborates the live
+            # post-dispatch terminal event without inventing item evidence.
+            return (
+                normalized
+                if normalized in {"failed", "canceled", "timed_out"}
+                else terminal_status
+            ), snapshot
+        if (
+            normalized in {"failed", "canceled", "timed_out"}
+            and turn_state["markerIndex"] >= 0
+            and progress
+        ):
+            # A marked provider failure is stronger than a replayed successful
+            # SSE frame. Preserve the provider's current terminal authority so
+            # cleanup or downstream terminal-contract checks cannot be the
+            # first place that discovers the failed turn.
+            return normalized, snapshot
+        inactive = _snapshot_projects_inactive_turn(snapshot)
+        stable_candidate = bool(
+            progress and inactive and not turn_state["unfinishedToolCall"]
+        )
+        signature = turn_state["signature"]
+        if stable_candidate and isinstance(signature, tuple):
+            if quiet_signature != signature:
+                quiet_signature = signature
+                quiet_since = loop.time()
+            required_quiet_seconds = max(
+                0.0,
+                (
+                    quiet_period_seconds
+                    if turn_state["terminalAssistantAfterWork"]
+                    else tool_only_quiet_period_seconds
+                ),
+            )
+            if quiet_since is not None and (
+                loop.time() - quiet_since >= required_quiet_seconds
+            ):
+                # A preamble assistant can launch another tool after the stale
+                # idle/completed projection, and some turns end immediately
+                # after a tool result without a final assistant. Accept either
+                # shape only after the ordered transcript is inactive and
+                # unchanged for a bounded quiet period.
+                return (
+                    normalized
+                    if normalized in {"failed", "canceled", "timed_out"}
+                    else terminal_status
+                ), snapshot
+        else:
+            quiet_signature = None
+            quiet_since = None
+        _safe_heartbeat(
+            {
+                "omnigentSessionId": session_id,
+                "normalizedStatus": (
+                    normalized if normalized in _NON_TERMINAL_STATUSES else "running"
+                ),
+                "eventsCaptured": event_count,
+                "firstMessagePosted": True,
+                "terminalSnapshotPolling": True,
+                "currentTurnProgress": progress,
+                "terminalAssistantAfterWork": bool(
+                    turn_state["terminalAssistantAfterWork"]
+                ),
+                "unfinishedToolCall": bool(turn_state["unfinishedToolCall"]),
+                "turnQuietSeconds": (
+                    round(loop.time() - quiet_since, 3)
+                    if quiet_since is not None
+                    else 0.0
+                ),
+                "turnQuietTargetSeconds": (
+                    max(
+                        0.0,
+                        (
+                            quiet_period_seconds
+                            if turn_state["terminalAssistantAfterWork"]
+                            else tool_only_quiet_period_seconds
+                        ),
+                    )
+                    if stable_candidate
+                    else None
+                ),
+            }
+        )
+        await asyncio.sleep(max(0.1, interval_seconds))
+    raise OmnigentSessionStillRunningError(
+        "Omnigent current marked turn did not reach terminal state before timeout"
+    )
+
+
 async def _enqueue_stream_events(
     *,
     client: OmnigentHttpClient,
     session_id: str,
-    queue: asyncio.Queue[dict[str, Any] | BaseException | None],
+    queue: asyncio.Queue[tuple[dict[str, Any], bool] | BaseException | None],
+    message_posted: asyncio.Event,
 ) -> None:
     try:
         async for event in client.stream_events(session_id):
-            await queue.put(event)
+            await queue.put((event, message_posted.is_set()))
     except asyncio.CancelledError:
         raise
     except Exception as exc:
@@ -558,9 +950,9 @@ async def _enqueue_stream_events(
 
 async def _queued_stream_events(
     *,
-    queue: asyncio.Queue[dict[str, Any] | BaseException | None],
+    queue: asyncio.Queue[tuple[dict[str, Any], bool] | BaseException | None],
     stream_task: asyncio.Task[None],
-) -> AsyncIterator[dict[str, Any]]:
+) -> AsyncIterator[tuple[dict[str, Any], bool]]:
     while True:
         event = await queue.get()
         if event is None:
@@ -742,6 +1134,9 @@ async def run_omnigent_execution(
     *,
     artifact_gateway: OmnigentArtifactGateway | None = None,
     run_store: OmnigentBridgeSessionStore | None = None,
+    resume_session_id: str | None = None,
+    first_message_text: str | None = None,
+    defer_bridge_terminal: bool = False,
 ) -> AgentRunResult:
     """Execute one Omnigent session and return only terminal AgentRunResult."""
 
@@ -867,7 +1262,25 @@ async def run_omnigent_execution(
                 getattr(durable_row, "omnigent_session_id", None) or ""
             ).strip()
             heartbeat_session_id = _heartbeat_session_id(retry_state)
-            session_id = durable_session_id or heartbeat_session_id
+            requested_resume_session_id = str(resume_session_id or "").strip()
+            resolved_existing_session_ids = {
+                value
+                for value in (
+                    durable_session_id,
+                    heartbeat_session_id,
+                    requested_resume_session_id,
+                )
+                if value
+            }
+            if len(resolved_existing_session_ids) > 1:
+                raise OmnigentContractError(
+                    "Omnigent continuation session conflicts with durable retry state"
+                )
+            session_id = (
+                durable_session_id
+                or heartbeat_session_id
+                or requested_resume_session_id
+            )
             first_message_posted = bool(retry_state.get("firstMessagePosted"))
             first_message_reconcile_required = False
             if durable_row is not None:
@@ -875,8 +1288,14 @@ async def run_omnigent_execution(
                     durable_row.first_message_state == FIRST_MESSAGE_POSTING
                 )
                 first_message_posted = (
-                    durable_row.first_message_state
-                    in {FIRST_MESSAGE_POSTED, FIRST_MESSAGE_TERMINAL}
+                    durable_row.first_message_state == FIRST_MESSAGE_POSTED
+                    or (
+                        durable_row.first_message_state == FIRST_MESSAGE_TERMINAL
+                        and getattr(
+                            durable_row, "first_message_posted_at", None
+                        )
+                        is not None
+                    )
                 )
                 first_message_response_identifiers = _first_message_response_identifiers(
                     pending_id=getattr(durable_row, "first_message_pending_id", None),
@@ -897,7 +1316,11 @@ async def run_omnigent_execution(
                         "attachSource": (
                             "bridge_session_store"
                             if durable_session_id
-                            else "activity_heartbeat"
+                            else (
+                                "coordinator_continuation"
+                                if requested_resume_session_id
+                                else "activity_heartbeat"
+                            )
                         ),
                     }
                 )
@@ -924,25 +1347,72 @@ async def run_omnigent_execution(
                         "firstMessagePosted": False,
                     }
                 )
+            elif (
+                run_store is not None
+                and requested_resume_session_id
+                and not durable_session_id
+            ):
+                await run_store.attach_session(
+                    request.idempotency_key,
+                    requested_resume_session_id,
+                )
             with suppress(Exception):
                 initial_snapshot = await client.get_session(session_id)
 
-            first_message = await _build_omnigent_first_message(
-                request=request,
-                prompt=selection.prompt,
-                artifact_gateway=artifact_gateway,
-            )
-            first_message, retrieval_evidence = await _resolve_initial_context_message(
-                request=request,
-                first_message=first_message,
-                artifact_gateway=artifact_gateway,
-                run_store=run_store,
-                durable_row=durable_row,
-                workspace=selection.session.workspace,
-                include_idempotency_marker=selection.prompt.get(
-                    "includeIdempotencyMarker", True
-                ),
-            )
+            if first_message_text is not None:
+                first_message = {
+                    "type": "message",
+                    "data": {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "input_text",
+                                "text": str(first_message_text).strip(),
+                            }
+                        ],
+                    },
+                }
+                first_message["data"]["content"][0]["text"] = (
+                    f"{_first_message_text(first_message)}\n\n"
+                    f"{_first_message_marker(request=request)}"
+                ).strip()
+                prepared_digest = hashlib.sha256(
+                    json.dumps(
+                        first_message,
+                        sort_keys=True,
+                        separators=(",", ":"),
+                    ).encode()
+                ).hexdigest()
+                retrieval_evidence = {
+                    "state": "disabled",
+                    "mode": "session_continuation",
+                    "reason": "repository_publication_terminal_contract",
+                    "preparedMessageDigest": prepared_digest,
+                    "preparedMessageRef": await artifact_gateway.write_json(
+                        request=request,
+                        name="input.omnigent.first_message.prepared.json",
+                        payload=first_message,
+                        link_type="input.omnigent.first_message.prepared",
+                    ),
+                    "firstMessageConsumedContextRef": False,
+                }
+            else:
+                first_message = await _build_omnigent_first_message(
+                    request=request,
+                    prompt=selection.prompt,
+                    artifact_gateway=artifact_gateway,
+                )
+                first_message, retrieval_evidence = await _resolve_initial_context_message(
+                    request=request,
+                    first_message=first_message,
+                    artifact_gateway=artifact_gateway,
+                    run_store=run_store,
+                    durable_row=durable_row,
+                    workspace=selection.session.workspace,
+                    include_idempotency_marker=selection.prompt.get(
+                        "includeIdempotencyMarker", True
+                    ),
+                )
             digest = str(retrieval_evidence["preparedMessageDigest"])
             marker = _first_message_marker(request=request)
             external_state["firstMessage"].update(
@@ -1023,7 +1493,10 @@ async def run_omnigent_execution(
                             OmnigentFailureReason.FIRST_MESSAGE_DIGEST_MISMATCH
                         ),
                     )
-            stream_queue: asyncio.Queue[dict[str, Any] | BaseException | None] | None = None
+            stream_queue: asyncio.Queue[
+                tuple[dict[str, Any], bool] | BaseException | None
+            ] | None = None
+            message_posted_gate = asyncio.Event()
             if first_message_reconcile_required:
                 reconciliation_snapshot = await client.get_session(session_id)
                 if not _snapshot_contains_first_message_marker(
@@ -1098,11 +1571,17 @@ async def run_omnigent_execution(
                         client=client,
                         session_id=session_id,
                         queue=stream_queue,
+                        message_posted=message_posted_gate,
                     )
                 )
                 await asyncio.sleep(0)
                 if run_store is not None:
                     await run_store.mark_posting(request.idempotency_key)
+                # The server may emit current-turn SSE events before the POST
+                # response is returned. Open the current-turn gate immediately
+                # before dispatch; anything already queued remains pre-post
+                # replay, while events emitted during request handling are live.
+                message_posted_gate.set()
                 first_message_response = await client.post_event(session_id, first_message)
                 first_message_posted = True
                 first_message_response_identifiers = _first_message_response_identifiers(
@@ -1194,6 +1673,7 @@ async def run_omnigent_execution(
                 )
             )
             terminal_status: str | None = None
+            terminal_snapshot_override: dict[str, Any] | None = None
             try:
                 stream_events = (
                     _queued_stream_events(
@@ -1203,7 +1683,12 @@ async def run_omnigent_execution(
                     if stream_queue is not None and stream_task is not None
                     else client.stream_events(session_id)
                 )
-                async for event in stream_events:
+                async for stream_item in stream_events:
+                    if isinstance(stream_item, tuple):
+                        event, arrived_after_message_post = stream_item
+                    else:
+                        event = stream_item
+                        arrived_after_message_post = True
                     event_count["value"] += 1
                     raw_events.append(dict(event))
                     normalized_bridge_event = build_omnigent_bridge_event(
@@ -1259,8 +1744,50 @@ async def run_omnigent_execution(
                         )
                         continue
                     if normalized in {"completed", "failed", "canceled", "timed_out"}:
-                        terminal_status = normalized
-                        heartbeat_status["value"] = normalized
+                        terminal_snapshot = await client.get_session(session_id)
+                        current_turn_progress = (
+                            _snapshot_confirms_current_turn_terminal(
+                                terminal_snapshot,
+                                marker=marker,
+                            )
+                        )
+                        if arrived_after_message_post and not current_turn_progress:
+                            marker_visible = _snapshot_contains_first_message_marker(
+                                terminal_snapshot,
+                                digest=digest,
+                                marker=marker,
+                            )
+                            if marker_visible:
+                                for _ in range(20):
+                                    await asyncio.sleep(0.25)
+                                    terminal_snapshot = await client.get_session(
+                                        session_id
+                                    )
+                                    current_turn_progress = (
+                                        _snapshot_confirms_current_turn_terminal(
+                                            terminal_snapshot,
+                                            marker=marker,
+                                        )
+                                    )
+                                    if current_turn_progress:
+                                        break
+                        if not current_turn_progress and not arrived_after_message_post:
+                            # A terminal frame queued before the message was
+                            # posted belongs to the preceding turn. Keep the
+                            # stream open for the current turn's terminal event
+                            # instead of accepting stale completion.
+                            continue
+                        (
+                            terminal_status,
+                            terminal_snapshot_override,
+                        ) = await _await_marked_turn_terminal(
+                            client=client,
+                            session_id=session_id,
+                            marker=marker,
+                            event_count=event_count["value"],
+                            terminal_status=normalized,
+                        )
+                        heartbeat_status["value"] = terminal_status
                         break
                     if event_count["value"] % 8 == 0:
                         _safe_heartbeat(
@@ -1275,7 +1802,9 @@ async def run_omnigent_execution(
                 await _cancel_task(heartbeat_task)
                 await _cancel_task(stream_task)
 
-            final_snapshot = await client.get_session(session_id)
+            final_snapshot = terminal_snapshot_override or await client.get_session(
+                session_id
+            )
             if terminal_status is None:
                 normalized_snapshot = normalize_omnigent_observation(final_snapshot)
                 if normalized_snapshot in {
@@ -1284,6 +1813,16 @@ async def run_omnigent_execution(
                     "canceled",
                     "timed_out",
                 }:
+                    if isinstance(final_snapshot.get("items"), list) and not (
+                        _snapshot_contains_current_turn_progress(
+                            final_snapshot,
+                            marker=marker,
+                        )
+                    ):
+                        raise OmnigentSessionStillRunningError(
+                            "Omnigent stream ended before the current marked turn "
+                            "produced provider work"
+                        )
                     terminal_status = normalized_snapshot
                     # The stream ended without emitting a terminal event but the
                     # final snapshot is terminal. Append an indexed terminal event
@@ -1349,15 +1888,16 @@ async def run_omnigent_execution(
                 external_state=external_state,
                 capture_policy=capture_policy,
             )
-            if run_store is not None:
+            terminal_refs = build_omnigent_terminal_refs(
+                bundle,
+                terminal_status=terminal_status,
+                final_snapshot=final_snapshot,
+            )
+            if run_store is not None and not defer_bridge_terminal:
                 await run_store.mark_terminal(
                     request.idempotency_key,
                     status=terminal_status,
-                    terminal_refs=build_omnigent_terminal_refs(
-                        bundle,
-                        terminal_status=terminal_status,
-                        final_snapshot=final_snapshot,
-                    ),
+                    terminal_refs=terminal_refs,
                     # Persist the full, non-lossy normalized status stream into
                     # the durable event index (OmnigentBridge §7.2).
                     events=normalized_events,
@@ -1373,7 +1913,7 @@ async def run_omnigent_execution(
                 harvest_failure_reason = (
                     OmnigentFailureReason.OPTIONAL_RESOURCE_HARVEST_FAILED
                 )
-            return build_omnigent_result(
+            result = build_omnigent_result(
                 request=request,
                 terminal_status=terminal_status,
                 session_id=session_id,
@@ -1395,6 +1935,15 @@ async def run_omnigent_execution(
                     else None
                 ),
             )
+            if defer_bridge_terminal:
+                result_metadata = dict(result.metadata or {})
+                result_metadata["deferredBridgeTerminal"] = {
+                    "idempotencyKey": request.idempotency_key,
+                    "status": terminal_status,
+                    "terminalRefs": terminal_refs,
+                }
+                result = result.model_copy(update={"metadata": result_metadata})
+            return result
     except asyncio.CancelledError:
         await _cancel_task(heartbeat_task)
         await _cancel_task(stream_task)

--- a/moonmind/omnigent/execution_profiles.py
+++ b/moonmind/omnigent/execution_profiles.py
@@ -15,6 +15,10 @@ from typing import Any, Literal, Mapping
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from moonmind.omnigent.oauth_hosts import OmnigentOAuthHostError
+from moonmind.omnigent.stock_agents import (
+    CLAUDE_STOCK_AGENT_NAME,
+    CODEX_STOCK_AGENT_NAME,
+)
 from moonmind.security.egress import OMNIGENT_EGRESS_PROFILE
 
 _DIGEST_IMAGE = re.compile(r"^[^\s@]+@sha256:[0-9a-f]{64}$")
@@ -191,7 +195,7 @@ PROFILES = {
             version=1,
             displayName="Omnigent Codex",
             endpointRef="default",
-            agentName="codex",
+            agentName=CODEX_STOCK_AGENT_NAME,
             harness="codex-native",
             defaultPolicyRef="codex-on-demand@1",
             providerRuntime="codex_cli",
@@ -203,7 +207,7 @@ PROFILES = {
             version=1,
             displayName="Omnigent Claude",
             endpointRef="default",
-            agentName="claude",
+            agentName=CLAUDE_STOCK_AGENT_NAME,
             harness="claude-native",
             defaultPolicyRef="claude-static@1",
             providerRuntime="claude_code",

--- a/moonmind/omnigent/oauth_host_janitor.py
+++ b/moonmind/omnigent/oauth_host_janitor.py
@@ -7,6 +7,11 @@ from typing import Any
 
 from moonmind.omnigent.oauth_host_runtime import OmnigentOAuthHostRuntime
 from moonmind.omnigent.oauth_hosts import OmnigentOAuthHostRepository
+from moonmind.provider_profiles.lease_client import (
+    CredentialLease,
+    CredentialLeasePurpose,
+    ProviderProfileLeaseClient,
+)
 from moonmind.workflows.adapters.omnigent_client import OmnigentHttpClient
 
 
@@ -18,15 +23,47 @@ class OmnigentOAuthHostJanitor:
         runtime: OmnigentOAuthHostRuntime,
         client: OmnigentHttpClient,
         run_store: Any | None = None,
+        lease_client: ProviderProfileLeaseClient | None = None,
         heartbeat_timeout_seconds: int = 90,
     ) -> None:
         self._repository = repository
         self._runtime = runtime
         self._client = client
         self._run_store = run_store
+        self._lease_client = lease_client
         self._heartbeat_timeout = timedelta(
             seconds=max(30, heartbeat_timeout_seconds)
         )
+
+    async def _release_provider_lease(self, *, binding: Any, lease: Any) -> bool:
+        """Release capacity only after the credential-bearing host is stopped.
+
+        Omnigent host leases are created exclusively for ``execution_omnigent``
+        capacity. The ProviderProfileManager deliberately uses the deterministic
+        owner token as its lease ID, so the durable ``provider_lease_id`` is also
+        the release authority needed after an activity process disappears.
+        """
+
+        if self._lease_client is None:
+            return False
+        provider_lease_id = str(lease.provider_lease_id or "").strip()
+        runtime_id = str(
+            binding.credential_mount_ref.auth_volume_ref.runtime_id or ""
+        ).strip()
+        if not provider_lease_id or not runtime_id:
+            raise ValueError(
+                "host lease is missing Provider Profile release authority"
+            )
+        await self._lease_client.release_lease(
+            CredentialLease(
+                profile_id=lease.provider_profile_id,
+                runtime_id=runtime_id,
+                lease_id=provider_lease_id,
+                owner_id=provider_lease_id,
+                purpose=CredentialLeasePurpose.EXECUTION_OMNIGENT,
+            )
+        )
+        return True
 
     async def run_action(
         self,
@@ -80,18 +117,21 @@ class OmnigentOAuthHostJanitor:
         elif action_kind == "host.stop":
             if before_state not in {"stopped", "failed"}:
                 await self._runtime.stop_host(binding=binding, host_lease=lease)
+                await self._release_provider_lease(binding=binding, lease=lease)
                 lease = await self._repository.mark_host_lease_stopped(lease.lease_id)
         elif action_kind == "host.remove":
             removed = bool(lease.container_name)
             if lease.container_name:
                 await self._runtime.remove_container(lease.container_name)
             if before_state != "stopped":
+                await self._release_provider_lease(binding=binding, lease=lease)
                 lease = await self._repository.mark_host_lease_stopped(lease.lease_id)
         elif action_kind == "provider_profile.evict_stale_lease":
             if not stale:
                 raise ValueError("Provider Profile host lease is not stale")
             if before_state not in {"stopped", "failed"}:
                 await self._runtime.stop_host(binding=binding, host_lease=lease)
+                await self._release_provider_lease(binding=binding, lease=lease)
                 lease = await self._repository.mark_host_lease_stopped(lease.lease_id)
         elif action_kind == "host_lease.reconcile_stale":
             if not stale:
@@ -103,9 +143,11 @@ class OmnigentOAuthHostJanitor:
                 and not await self._runtime.container_exists(lease.container_name)
             )
             if missing:
+                await self._release_provider_lease(binding=binding, lease=lease)
                 lease = await self._repository.mark_host_lease_stopped(lease.lease_id)
             elif before_state not in {"stopped", "failed"}:
                 await self._runtime.stop_host(binding=binding, host_lease=lease)
+                await self._release_provider_lease(binding=binding, lease=lease)
                 lease = await self._repository.mark_host_lease_stopped(lease.lease_id)
 
         result = self._action_result(
@@ -157,6 +199,20 @@ class OmnigentOAuthHostJanitor:
                     }
                 )
         leases = await self._repository.list_active_host_leases()
+        terminal_provider_leases = (
+            await self._repository.list_terminal_host_leases_with_active_provider_capacity()
+            if hasattr(
+                self._repository,
+                "list_terminal_host_leases_with_active_provider_capacity",
+            )
+            else []
+        )
+        terminal_provider_lease_refs = {
+            lease.lease_id for lease in terminal_provider_leases
+        }
+        leases = list(
+            {lease.lease_id: lease for lease in [*leases, *terminal_provider_leases]}.values()
+        )
         cleanup_required = (
             await self._run_store.cleanup_required_host_lease_refs()
             if self._run_store is not None
@@ -180,12 +236,23 @@ class OmnigentOAuthHostJanitor:
             expired = lease.expires_at <= now
             stale = lease.last_heartbeat_at <= now - self._heartbeat_timeout
             terminal_cleanup = lease.lease_id in cleanup_required
+            terminal_provider_cleanup = (
+                lease.lease_id in terminal_provider_lease_refs
+            )
             reconciliation_action = reconciliation_required.get(lease.lease_id)
             missing = bool(
                 lease.container_name
                 and not await self._runtime.container_exists(lease.container_name)
             )
-            if not force and not expired and not missing and not stale and not terminal_cleanup and not reconciliation_action:
+            if (
+                not force
+                and not expired
+                and not missing
+                and not stale
+                and not terminal_cleanup
+                and not terminal_provider_cleanup
+                and not reconciliation_action
+            ):
                 continue
             binding = await self._repository.validate_binding(lease.binding_ref)
             if lease.omnigent_session_id:
@@ -203,8 +270,16 @@ class OmnigentOAuthHostJanitor:
                         }
                     )
             try:
-                if not missing:
+                # Host leases persisted before lifecycle status projection was
+                # introduced remain valid janitor inputs. Treat an absent status
+                # as active so their owned container is still stopped before the
+                # Provider Profile lease is released.
+                lease_status = str(getattr(lease, "status", "assigned") or "")
+                if not missing and lease_status not in {"stopped", "failed"}:
                     await self._runtime.stop_host(binding=binding, host_lease=lease)
+                provider_released = await self._release_provider_lease(
+                    binding=binding, lease=lease
+                )
                 await self._repository.mark_host_lease_stopped(lease.lease_id)
             except Exception as exc:
                 if (
@@ -238,10 +313,16 @@ class OmnigentOAuthHostJanitor:
                         if stale
                         else (
                             "runner_exit_cleanup" if terminal_cleanup else (
-                                reconciliation_action or "missing_container_repair"
+                                "provider_lease_reconciliation"
+                                if terminal_provider_cleanup
+                                else (
+                                    reconciliation_action
+                                    or "missing_container_repair"
+                                )
                             )
                         )
                     ),
+                    "providerLeaseReleased": provider_released,
                 }
             )
         for container_name in await self._runtime.list_managed_containers():

--- a/moonmind/omnigent/oauth_host_runtime.py
+++ b/moonmind/omnigent/oauth_host_runtime.py
@@ -9,11 +9,15 @@ import os
 import re
 import shutil
 import tarfile
+import tempfile
 from collections.abc import Mapping
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 from urllib.parse import urlsplit
+from uuid import NAMESPACE_URL, uuid5
 
+from moonmind.config.settings import settings
 from moonmind.omnigent.oauth_hosts import (
     HostPreflightFailure,
     OmnigentOAuthHostError,
@@ -25,6 +29,7 @@ from moonmind.repositories.lore_adapter import (
     LoreRepositoryProviderAdapter,
     LoreWorkspaceError,
 )
+from moonmind.publish.service import PublishService
 from moonmind.omnigent.execution_profiles import validate_effective_launch_snapshot
 from moonmind.security.egress import (
     OMNIGENT_EGRESS_PROFILE,
@@ -65,6 +70,7 @@ from moonmind.workflows.skills.run_projection import (
     materialize_run_skill_snapshot,
     verify_skill_projection,
 )
+from moonmind.utils.logging import redact_sensitive_text
 
 _FORBIDDEN_ENV = (
     "OPENAI_API_KEY",
@@ -83,9 +89,19 @@ _TOOLS_PATH = "/opt/moonmind-tools/bin"
 _DEFAULT_HOST_PATH = (
     "/opt/venv/bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin"
 )
+_RUNNER_PROXY_ENV_NAMES = tuple(
+    proxy_env.partition("=")[0] for proxy_env in omnigent_proxy_env()
+)
+_RUNNER_GITHUB_ENV_NAMES = (
+    "XDG_CONFIG_HOME",
+    "GH_PROMPT_DISABLED",
+    "GH_NO_UPDATE_NOTIFIER",
+    "GH_NO_EXTENSION_UPDATE_NOTIFIER",
+)
 _DIGEST_IMAGE = re.compile(r"^[^\s@]+@sha256:[0-9a-f]{64}$")
 _PLACEHOLDER_DIGEST = "0" * 64
 _SAFE_NETWORK = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_.-]{0,127}$")
+_SAFE_STEP_EXECUTION_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:-]{0,510}[A-Za-z0-9]$")
 _GITHUB_SLUG = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
 # Bound restore-input materialization so a hostile or oversized artifact ref
 # cannot exhaust the authorized workspace before the host launches. The limit is
@@ -95,6 +111,14 @@ _GITHUB_SLUG = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
 _MAX_RESTORE_INPUT_REFS = 64
 _MAX_RESTORE_INPUT_BYTES = 64 * 1024 * 1024
 _MAX_RESTORE_TOTAL_BYTES = 256 * 1024 * 1024
+# Stock Omnigent first publishes an offline catalog row, then replaces it with
+# the live host identity after the runner tunnel is ready. Cold image and
+# catalog startup has exceeded one minute on the supported local Compose path;
+# keep the wait bounded but large enough for that authoritative online edge.
+_HOST_REGISTRATION_ATTEMPTS = 91
+_HOST_REGISTRATION_INTERVAL_SECONDS = 2
+_DEFAULT_PUBLISH_GIT_USER_NAME = "MoonMind Worker"
+_DEFAULT_PUBLISH_GIT_USER_EMAIL = "moonmind-worker@users.noreply.github.com"
 # Restore payloads are read through the durable artifact contract as raw bytes,
 # under a dedicated service principal (mirrors the checkpoint/remediation
 # restorers, which never read restore material as an end user).
@@ -276,10 +300,20 @@ class OmnigentOAuthHostRuntime:
                 and "workspace" in set(launch.get("mountClasses") or ())
             ),
         )
+        await asyncio.to_thread(
+            self._align_workspace_ownership,
+            workspace_source,
+            runtime_uid=int(launch["runtimeUid"]),
+            runtime_gid=int(launch["runtimeGid"]),
+        )
         daemon_workspace_source = daemon_visible_workspace_path(workspace_source)
         daemon_skill_projection = daemon_visible_workspace_path(skill_projection)
         launched_container_name: str | None = None
         if binding.host_launch_profile_ref:
+            daemon_runtime_scripts = self._prepare_daemon_runtime_scripts(
+                workspace_key,
+                current_step_execution_id=current_step_execution_id,
+            )
             if "gh" in {item.strip().lower() for item in required_capabilities}:
                 await self._initialize_required_tools()
             container_name = (
@@ -293,6 +327,8 @@ class OmnigentOAuthHostRuntime:
                 container_name=container_name,
                 workspace_source=daemon_workspace_source,
                 skill_projection=daemon_skill_projection,
+                runtime_scripts=daemon_runtime_scripts,
+                current_step_execution_id=current_step_execution_id,
                 github_token=github_token,
                 effective_launch=launch,
             )
@@ -307,10 +343,7 @@ class OmnigentOAuthHostRuntime:
 
         host = await self._resolve_exact_host(binding=binding, host_lease=host_lease)
         host_id = str(host.get("id") or host.get("host_id") or host.get("hostId") or "")
-        capabilities = host.get("harnesses") or host.get("capabilities") or []
-        if isinstance(capabilities, Mapping):
-            capabilities = list(capabilities)
-        if adapter["harness"] not in {str(value) for value in capabilities}:
+        if adapter["harness"] not in self._ready_host_harnesses(host):
             raise OmnigentOAuthHostError(
                 f"registered host does not advertise {adapter['harness']}",
                 code=HostPreflightFailure.HARNESS_UNAVAILABLE.value,
@@ -367,6 +400,227 @@ class OmnigentOAuthHostRuntime:
         validated["workspaceResolution"] = dict(self._last_workspace_evidence)
         return validated
 
+    async def publish_workspace(
+        self,
+        *,
+        workspace_locator: Mapping[str, Any],
+        current_workflow_id: str,
+        current_step_execution_id: str,
+        publication_identity: str,
+        publish_mode: str,
+        base_branch: str | None,
+        repository: str,
+        github_token: str | None,
+    ) -> dict[str, Any]:
+        """Publish the exact authorized sandbox workspace through one service.
+
+        Profile-bound Omnigent execution does not use the managed-run store, so
+        its successful result cannot borrow ``agent_runtime.fetch_result``'s
+        publication side effect.  This owning runtime already holds the typed
+        workspace authority and resolved credential; it therefore resolves that
+        same workspace again, then delegates commit/scan/push semantics to the
+        canonical :class:`PublishService` before host cleanup removes access.
+        """
+
+        normalized_mode = str(publish_mode or "none").strip().lower()
+        if normalized_mode not in {"branch", "pr"}:
+            return {"push_status": "skipped"}
+        locator = WORKSPACE_LOCATOR_ADAPTER.validate_python(workspace_locator)
+        if not isinstance(locator, SandboxWorkspaceLocator):
+            raise OmnigentOAuthHostError(
+                "Omnigent repository publication requires sandbox workspace authority",
+                code=WORKSPACE_LOCATOR_UNSUPPORTED,
+            )
+        expected_id = hashlib.sha256(
+            f"{current_workflow_id}:{current_step_execution_id}".encode("utf-8")
+        ).hexdigest()[:24]
+        owner_record = SandboxWorkspaceRecordStore(self._workspace_root).load(
+            locator.workspace_id
+        )
+        workspace = resolve_sandbox_workspace_locator(
+            locator,
+            workspace_root=self._workspace_root,
+            expected_workspace_id=expected_id,
+            owner_record=owner_record,
+            expected_workflow_id=current_workflow_id,
+            expected_step_execution_id=current_step_execution_id,
+            must_exist=True,
+        )
+        safe_workspace = workspace.resolve(strict=True)
+        token = str(github_token or "").strip()
+        command_env = build_github_token_git_environment(
+            token,
+            base_env=os.environ,
+        )
+        git_user_name = (
+            str(settings.workflow.git_user_name or "").strip()
+            or _DEFAULT_PUBLISH_GIT_USER_NAME
+        )
+        git_user_email = (
+            str(settings.workflow.git_user_email or "").strip()
+            or _DEFAULT_PUBLISH_GIT_USER_EMAIL
+        )
+        command_env.update(
+            {
+                "GIT_AUTHOR_NAME": git_user_name,
+                "GIT_COMMITTER_NAME": git_user_name,
+                "GIT_AUTHOR_EMAIL": git_user_email,
+                "GIT_COMMITTER_EMAIL": git_user_email,
+            }
+        )
+
+        async def run_command(
+            command: list[str],
+            *,
+            cwd: Path | None = None,
+            check: bool = True,
+            env: Mapping[str, str] | None = None,
+            **_kwargs: Any,
+        ) -> SimpleNamespace:
+            del cwd
+            authored = [str(part) for part in command]
+            if authored and authored[0] == "git":
+                authored[1:1] = [
+                    "-c",
+                    f"safe.directory={safe_workspace}",
+                    "-C",
+                    str(safe_workspace),
+                ]
+            selected_env = build_github_token_git_environment(
+                token,
+                base_env=(dict(env) if env is not None else command_env),
+            )
+            code, stdout, stderr = await self._run(
+                *authored,
+                env=selected_env,
+                check=False,
+            )
+            if check and code != 0:
+                detail = redact_sensitive_text(stderr or stdout or "git failed")
+                raise OmnigentOAuthHostError(
+                    f"repository publication command failed: {detail[:512]}",
+                    code="OMNIGENT_REPOSITORY_PUBLICATION_FAILED",
+                )
+            return SimpleNamespace(
+                stdout=stdout,
+                stderr=stderr,
+                returncode=code,
+            )
+
+        publisher = PublishService()
+        published = await publisher.publish(
+            job_id=uuid5(NAMESPACE_URL, publication_identity),
+            instruction="Publish completed Omnigent repository work",
+            # Pull-request creation remains owned by the parent workflow. This
+            # boundary publishes and verifies the head branch it will consume.
+            publish_mode="branch",
+            publish_base_branch=str(base_branch or "main").strip() or "main",
+            runtime_mode="omnigent",
+            repo_dir=safe_workspace,
+            run_command=run_command,
+            repo=str(repository or "").strip() or None,
+            github_token=token or None,
+            publish_existing_commits=True,
+            verify_remote=True,
+        )
+        if published is None:
+            return {"push_status": "skipped"}
+        if published.status == "skipped":
+            return {
+                "push_status": "no_commits",
+                "push_branch": published.branch_name,
+                "push_base_branch": published.base_branch,
+                "push_commit_count": published.commits_ahead_of_base or 0,
+                "remote_verified": False,
+            }
+        if (
+            published.status != "published"
+            or not published.branch_pushed
+            or not published.remote_verified
+            or not published.head_sha
+            or not published.branch_name
+            or not published.base_branch
+            or not published.commits_ahead_of_base
+        ):
+            raise OmnigentOAuthHostError(
+                "repository publication did not produce authoritative remote evidence",
+                code="OMNIGENT_REPOSITORY_PUBLICATION_UNVERIFIED",
+            )
+        return {
+            "push_status": "pushed",
+            "push_branch": published.branch_name,
+            "push_base_branch": published.base_branch,
+            "push_head_sha": published.head_sha,
+            "push_commit_count": published.commits_ahead_of_base,
+            "remote_verified": True,
+            "pushRef": (
+                f"git://{str(repository or 'repository').strip()}"
+                f"/refs/heads/{published.branch_name}@{published.head_sha}"
+            ),
+        }
+
+    async def inspect_session_completion(self, session_id: str) -> dict[str, Any]:
+        """Return bounded terminal-answer evidence for one Omnigent session.
+
+        A native Codex turn can report an idle/completed status after a tool
+        result without producing the assistant's final answer. Provider status
+        alone is therefore not authoritative task-completion evidence. This
+        check reads only item ordering and roles; prompt text, assistant text,
+        tool arguments, and tool output never cross this boundary.
+        """
+
+        normalized_session_id = str(session_id or "").strip()
+        if not normalized_session_id:
+            raise OmnigentOAuthHostError(
+                "Omnigent session completion inspection requires a session id",
+                code="OMNIGENT_SESSION_COMPLETION_EVIDENCE_MISSING",
+            )
+        snapshot = await self._client.get_session(normalized_session_id)
+        raw_items = snapshot.get("items") if isinstance(snapshot, Mapping) else None
+        items = raw_items if isinstance(raw_items, list) else []
+        last_user_index = -1
+        last_tool_index = -1
+        terminal_assistant_index = -1
+        assistant_message_count = 0
+        tool_result_count = 0
+        for index, raw_item in enumerate(items):
+            if not isinstance(raw_item, Mapping):
+                continue
+            item_type = str(raw_item.get("type") or "").strip()
+            data = raw_item.get("data")
+            item_data = data if isinstance(data, Mapping) else {}
+            if item_type == "message":
+                role = str(item_data.get("role") or "").strip().lower()
+                if role == "user":
+                    last_user_index = index
+                elif role == "assistant":
+                    content = item_data.get("content")
+                    has_text = bool(
+                        isinstance(content, list)
+                        and any(
+                            isinstance(block, Mapping)
+                            and str(block.get("text") or "").strip()
+                            for block in content
+                        )
+                    )
+                    if has_text:
+                        assistant_message_count += 1
+                        terminal_assistant_index = index
+            elif item_type in {"function_call", "function_call_output"}:
+                last_tool_index = index
+                if item_type == "function_call_output":
+                    tool_result_count += 1
+
+        completion_boundary = max(last_user_index, last_tool_index)
+        return {
+            "sessionStatus": str(snapshot.get("status") or "").strip(),
+            "itemCount": len(items),
+            "assistantMessageCount": assistant_message_count,
+            "toolResultCount": tool_result_count,
+            "terminalAssistantAfterWork": terminal_assistant_index
+            > completion_boundary,
+        }
+
     async def _attest_egress(self, launch: Mapping[str, Any]):
         if launch.get("networkRef") != OMNIGENT_EGRESS_PROFILE.network_ref:
             raise OmnigentOAuthHostError(
@@ -375,7 +629,7 @@ class OmnigentOAuthHostRuntime:
             )
 
         async def runner(args):
-            code, stdout, stderr = await self._run(*args, check=False)
+            code, stdout, stderr = await self._run("docker", *args, check=False)
             return code, stdout.encode(), stderr.encode()
 
         try:
@@ -638,6 +892,121 @@ class OmnigentOAuthHostRuntime:
         )
         return Path(str(metadata["visiblePath"])).resolve()
 
+    def _prepare_runtime_scripts(
+        self,
+        workspace_key: str,
+        *,
+        current_step_execution_id: str,
+    ) -> Path:
+        """Snapshot MoonMind host scripts under the daemon-mapped run root."""
+
+        source = self._scripts_dir.resolve()
+        required_scripts = (
+            "init-oauth-host.sh",
+            "moonmind-tools.sh",
+            "start-codex-oauth-host.sh",
+            "start-claude-oauth-host.sh",
+        )
+        if not source.is_dir():
+            raise OmnigentOAuthHostError(
+                "Omnigent runtime script source is unavailable",
+                code="OMNIGENT_RUNTIME_SCRIPTS_UNAVAILABLE",
+            )
+        if any(path.is_symlink() for path in source.rglob("*")):
+            raise OmnigentOAuthHostError(
+                "Omnigent runtime script source contains unsupported symlinks",
+                code="OMNIGENT_RUNTIME_SCRIPTS_UNAVAILABLE",
+            )
+        if any(not (source / name).is_file() for name in required_scripts):
+            raise OmnigentOAuthHostError(
+                "Omnigent runtime script source is incomplete",
+                code="OMNIGENT_RUNTIME_SCRIPTS_UNAVAILABLE",
+            )
+
+        execution_id = str(current_step_execution_id or "").strip()
+        if not _SAFE_STEP_EXECUTION_ID.fullmatch(execution_id):
+            raise OmnigentOAuthHostError(
+                "Omnigent step execution identity is missing or unsafe",
+                code="OMNIGENT_STEP_EXECUTION_ID_INVALID",
+            )
+        execution_profile_payload = (
+            "# Generated for one MoonMind-owned Omnigent host lease.\n"
+            f"export MOONMIND_STEP_EXECUTION_ID='{execution_id}'\n"
+        )
+
+        digest = hashlib.sha256(workspace_key.encode("utf-8")).hexdigest()[:24]
+        target_parent = (self._workspace_root / ".omnigent-runtime-scripts").resolve()
+        target = (target_parent / digest).resolve()
+        if not target.is_relative_to(target_parent):
+            raise OmnigentOAuthHostError(
+                "Omnigent runtime script target escaped its owned root",
+                code="OMNIGENT_RUNTIME_SCRIPTS_UNAVAILABLE",
+            )
+        if target.is_dir():
+            if any(not (target / name).is_file() for name in required_scripts):
+                raise OmnigentOAuthHostError(
+                    "Omnigent runtime script snapshot is incomplete",
+                    code="OMNIGENT_RUNTIME_SCRIPTS_UNAVAILABLE",
+                )
+            try:
+                existing_execution_profile = (
+                    target / "moonmind-execution.sh"
+                ).read_text(encoding="utf-8")
+            except OSError as exc:
+                raise OmnigentOAuthHostError(
+                    "Omnigent runtime execution profile is unavailable",
+                    code="OMNIGENT_RUNTIME_SCRIPTS_UNAVAILABLE",
+                ) from exc
+            if existing_execution_profile != execution_profile_payload:
+                raise OmnigentOAuthHostError(
+                    "Omnigent runtime execution profile does not match its owner",
+                    code="OMNIGENT_RUNTIME_SCRIPTS_UNAVAILABLE",
+                )
+            return target
+
+        target_parent.mkdir(parents=True, exist_ok=True)
+        staging = Path(
+            tempfile.mkdtemp(prefix=f".{digest}-", dir=target_parent)
+        ).resolve()
+        try:
+            shutil.copytree(source, staging, dirs_exist_ok=True)
+            execution_profile = staging / "moonmind-execution.sh"
+            execution_profile.write_text(
+                execution_profile_payload,
+                encoding="utf-8",
+            )
+            execution_profile.chmod(0o444)
+            try:
+                os.replace(staging, target)
+            except FileExistsError:
+                if not target.is_dir():
+                    raise
+        finally:
+            if staging.is_dir():
+                shutil.rmtree(staging)
+
+        if any(not (target / name).is_file() for name in required_scripts) or not (
+            target / "moonmind-execution.sh"
+        ).is_file():
+            raise OmnigentOAuthHostError(
+                "Omnigent runtime script snapshot is incomplete",
+                code="OMNIGENT_RUNTIME_SCRIPTS_UNAVAILABLE",
+            )
+        return target
+
+    def _prepare_daemon_runtime_scripts(
+        self,
+        workspace_key: str,
+        *,
+        current_step_execution_id: str,
+    ) -> Path:
+        return daemon_visible_workspace_path(
+            self._prepare_runtime_scripts(
+                workspace_key,
+                current_step_execution_id=current_step_execution_id,
+            )
+        )
+
     async def stop_host(
         self, *, binding: OmnigentOAuthHostBinding, host_lease: OmnigentHostLease
     ) -> None:
@@ -741,6 +1110,8 @@ class OmnigentOAuthHostRuntime:
         container_name: str,
         workspace_source: Path,
         skill_projection: Path,
+        runtime_scripts: Path,
+        current_step_execution_id: str,
         github_token: str | None = None,
         effective_launch: Mapping[str, Any],
     ) -> None:
@@ -789,7 +1160,7 @@ class OmnigentOAuthHostRuntime:
             "--mount",
             f"type=volume,src={cache_volume},dst=/home/app/.cache",
             "--mount",
-            f"type=bind,src={self._scripts_dir},dst=/opt/moonmind,readonly",
+            f"type=bind,src={runtime_scripts},dst=/opt/moonmind,readonly",
             "--env",
             f"OAUTH_HOME={adapter['home']}",
             "--entrypoint",
@@ -816,6 +1187,8 @@ class OmnigentOAuthHostRuntime:
             "run",
             "-d",
             "--name",
+            container_name,
+            "--hostname",
             container_name,
             "--user",
             f"{effective_launch['runtimeUid']}:{effective_launch['runtimeGid']}",
@@ -844,7 +1217,15 @@ class OmnigentOAuthHostRuntime:
             "--mount",
             f"type=volume,src={cache_volume},dst=/home/app/.cache",
             "--mount",
-            f"type=bind,src={self._scripts_dir},dst=/opt/moonmind,readonly",
+            f"type=bind,src={runtime_scripts},dst=/opt/moonmind,readonly",
+            "--mount",
+            "type=bind,"
+            f"src={runtime_scripts / 'moonmind-tools.sh'},"
+            "dst=/etc/profile.d/moonmind-tools.sh,readonly",
+            "--mount",
+            "type=bind,"
+            f"src={runtime_scripts / 'moonmind-execution.sh'},"
+            "dst=/etc/profile.d/moonmind-execution.sh,readonly",
             "--mount",
             f"type=volume,src={self._tool_bundle_volume},dst=/opt/moonmind-tools,readonly",
             "--mount",
@@ -862,6 +1243,8 @@ class OmnigentOAuthHostRuntime:
             "--env",
             "MOONMIND_ACTIVE_SKILLS_DIR=/opt/moonmind-skills",
             "--env",
+            f"MOONMIND_STEP_EXECUTION_ID={current_step_execution_id}",
+            "--env",
             f"OMNIGENT_EXECUTION_TIMEOUT_SECONDS={effective_launch['limits']['timeoutSeconds']}",
             "--env",
             "OMNIGENT_EXECUTION_TIMEOUT_OWNER=temporal_workflow",
@@ -876,6 +1259,10 @@ class OmnigentOAuthHostRuntime:
             args.extend(["--env", runtime_env])
         for proxy_env in omnigent_proxy_env():
             args.extend(["--env", proxy_env])
+        runner_env_passthrough = [
+            *_RUNNER_PROXY_ENV_NAMES,
+            "MOONMIND_STEP_EXECUTION_ID",
+        ]
         token = os.getenv("OMNIGENT_HOST_TOKEN", "")
         child_env = dict(os.environ)
         if token:
@@ -883,35 +1270,36 @@ class OmnigentOAuthHostRuntime:
             args.extend(["--env", "OMNIGENT_API_TOKEN"])
         if github_token:
             child_env["GH_TOKEN"] = github_token
-            child_env["GIT_TOKEN"] = github_token
+            runner_env_passthrough.extend(_RUNNER_GITHUB_ENV_NAMES)
             args.extend(
                 [
                     "--env",
                     "GH_TOKEN",
                     "--env",
-                    "GIT_TOKEN",
-                    "--env",
-                    "GIT_USERNAME=x-access-token",
-                    "--env",
-                    "GH_CONFIG_DIR=/workspaces/run/.config/gh",
+                    "XDG_CONFIG_HOME=/home/app/.cache/moonmind-xdg",
                     "--env",
                     "GH_PROMPT_DISABLED=1",
                     "--env",
                     "GH_NO_UPDATE_NOTIFIER=1",
                     "--env",
                     "GH_NO_EXTENSION_UPDATE_NOTIFIER=1",
-                    "--env",
-                    "OMNIGENT_RUNNER_ENV_PASSTHROUGH=GH_TOKEN,GH_CONFIG_DIR,"
-                    + "GH_PROMPT_DISABLED,GH_NO_UPDATE_NOTIFIER,"
-                    + "GH_NO_EXTENSION_UPDATE_NOTIFIER",
                 ]
             )
+        args.extend(
+            [
+                "--env",
+                "OMNIGENT_RUNNER_ENV_PASSTHROUGH=" + ",".join(runner_env_passthrough),
+            ]
+        )
         for key, value in labels.items():
             args.extend(["--label", f"{key}={value}"])
-        args.extend(["--entrypoint", "/usr/bin/env"])
+        # Docker stops parsing run options at the image reference. Keep env's
+        # ``-u`` flags after that boundary; before it, Docker interprets each
+        # one as a container ``--user`` override.
+        args.extend(["--entrypoint", "/usr/bin/env", host_image_ref])
         for key in _FORBIDDEN_ENV:
             args.extend(["-u", key])
-        args.extend([host_image_ref, str(adapter["start_script"])])
+        args.append(str(adapter["start_script"]))
         await self._run(*args, env=child_env)
 
     async def _assert_container_owned(self, container_name: str, lease_id: str) -> None:
@@ -1272,6 +1660,46 @@ class OmnigentOAuthHostRuntime:
             materialization=materialization,
         )
         return workspace
+
+    def _align_workspace_ownership(
+        self,
+        workspace: Path,
+        *,
+        runtime_uid: int,
+        runtime_gid: int,
+    ) -> None:
+        """Make the isolated host UID the owner of its exact run workspace."""
+
+        resolved_workspace = workspace.resolve(strict=True)
+        if not resolved_workspace.is_relative_to(self._workspace_root):
+            raise OmnigentOAuthHostError(
+                "workspace ownership target escapes the configured workspace root",
+                code="OMNIGENT_WORKSPACE_OWNERSHIP_FAILED",
+            )
+        try:
+            os.chown(
+                resolved_workspace,
+                runtime_uid,
+                runtime_gid,
+                follow_symlinks=False,
+            )
+            for current_root, directory_names, file_names in os.walk(
+                resolved_workspace,
+                followlinks=False,
+            ):
+                current = Path(current_root)
+                for name in (*directory_names, *file_names):
+                    os.chown(
+                        current / name,
+                        runtime_uid,
+                        runtime_gid,
+                        follow_symlinks=False,
+                    )
+        except OSError as exc:
+            raise OmnigentOAuthHostError(
+                "unable to align the run workspace with the isolated host identity",
+                code="OMNIGENT_WORKSPACE_OWNERSHIP_FAILED",
+            ) from exc
 
     async def _materialize_repository(
         self,
@@ -1852,17 +2280,31 @@ class OmnigentOAuthHostRuntime:
         }
 
     async def _initialize_required_tools(self) -> None:
-        await self._run(
+        expected_version = os.getenv("OMNIGENT_GH_VERSION", "2.76.2")
+        return_code, stdout, _stderr = await self._run(
             "docker",
-            "compose",
-            "-f",
-            "docker-compose.yaml",
-            "--profile",
-            "omnigent-host-codex",
             "run",
             "--rm",
-            "omnigent-tools-init",
+            "--volume",
+            f"{self._tool_bundle_volume}:/opt/moonmind-tools:ro",
+            "--entrypoint",
+            "/opt/moonmind-tools/bin/gh",
+            self._image,
+            "--version",
+            check=False,
         )
+        first_line = stdout.splitlines()[0] if stdout.splitlines() else ""
+        if return_code != 0 or f" {expected_version} " not in f" {first_line} ":
+            raise MountedToolPreflightError(
+                "The deployment-owned Omnigent tool bundle is not ready",
+                code="tool_bundle_unavailable",
+                evidence={
+                    "tool": "gh",
+                    "phase": "deployment_initialization",
+                    "bundleVolume": self._tool_bundle_volume,
+                    "expectedVersion": expected_version,
+                },
+            )
 
     async def _compose_static_check(
         self,
@@ -1952,6 +2394,16 @@ class OmnigentOAuthHostRuntime:
         await self._run(
             "docker", "exec", container_name, "/opt/moonmind/check-runner-projections.sh"
         )
+        await self._run(
+            "docker",
+            "exec",
+            container_name,
+            "git",
+            "-C",
+            "/workspaces/run",
+            "status",
+            "--porcelain",
+        )
 
     async def _resolve_exact_host(
         self,
@@ -1959,33 +2411,62 @@ class OmnigentOAuthHostRuntime:
         binding: OmnigentOAuthHostBinding,
         host_lease: OmnigentHostLease,
     ) -> dict[str, Any]:
-        hosts = await self._client.list_hosts()
         expected_id = binding.static_host_id or host_lease.omnigent_host_id
-        if expected_id:
-            matches = [
+        expected_name = host_lease.container_name or deterministic_host_container_name(
+            host_lease.lease_id
+        )
+        adapter = self._runtime_adapter(binding)
+        for attempt in range(_HOST_REGISTRATION_ATTEMPTS):
+            hosts = await self._client.list_hosts()
+            if expected_id:
+                matches = [
+                    host
+                    for host in hosts
+                    if str(
+                        host.get("id") or host.get("hostId") or host.get("host_id")
+                    )
+                    == expected_id
+                ]
+            else:
+                matches = [
+                    host
+                    for host in hosts
+                    if str(host.get("name") or host.get("hostname") or "")
+                    in {expected_name, str(adapter["compose_service"])}
+                ]
+            online = [
                 host
-                for host in hosts
-                if str(host.get("id") or host.get("hostId") or host.get("host_id"))
-                == expected_id
+                for host in matches
+                if str(host.get("status", "online")) == "online"
             ]
-        else:
-            expected_name = deterministic_host_container_name(host_lease.lease_id)
-            adapter = self._runtime_adapter(binding)
-            matches = [
-                host
-                for host in hosts
-                if str(host.get("name") or host.get("hostname") or "")
-                in {expected_name, str(adapter["compose_service"])}
-            ]
-        online = [
-            host for host in matches if str(host.get("status", "online")) == "online"
-        ]
-        if len(online) != 1:
-            raise OmnigentOAuthHostError(
-                "expected exactly one compatible online host",
-                code=HostPreflightFailure.HOST_NOT_REGISTERED.value,
-            )
-        return dict(online[0])
+            if len(online) == 1:
+                return dict(online[0])
+            if len(online) > 1:
+                break
+            if attempt + 1 < _HOST_REGISTRATION_ATTEMPTS:
+                await asyncio.sleep(_HOST_REGISTRATION_INTERVAL_SECONDS)
+        raise OmnigentOAuthHostError(
+            "expected exactly one compatible online host after bounded registration wait",
+            code=HostPreflightFailure.HOST_NOT_REGISTERED.value,
+        )
+
+    @staticmethod
+    def _ready_host_harnesses(host: Mapping[str, Any]) -> set[str]:
+        capabilities = (
+            host.get("harnesses")
+            or host.get("capabilities")
+            or host.get("configured_harnesses")
+            or []
+        )
+        if not isinstance(capabilities, Mapping):
+            return {str(value) for value in capabilities}
+        ready_values = {"true", "ready", "available", "authenticated"}
+        return {
+            str(name)
+            for name, readiness in capabilities.items()
+            if readiness is True
+            or str(readiness).strip().lower() in ready_values
+        }
 
     @staticmethod
     async def _run(

--- a/moonmind/omnigent/oauth_hosts.py
+++ b/moonmind/omnigent/oauth_hosts.py
@@ -21,6 +21,7 @@ from api_service.db.models import (
     ManagedAgentProviderProfile,
     OmnigentOAuthHostBindingRecord,
     OmnigentOAuthHostLeaseRecord,
+    ProviderProfileSlotLease,
 )
 from moonmind.provider_profiles.oauth_policy import (
     is_claude_oauth_profile,
@@ -39,6 +40,7 @@ ACTIVE_HOST_STATES = frozenset(
     {"allocating", "starting", "ready", "assigned", "draining"}
 )
 TERMINAL_HOST_STATES = frozenset({"stopped", "failed"})
+HOST_PROFILE_BUSY_ERROR_CODE = "OMNIGENT_OAUTH_HOST_PROFILE_BUSY"
 
 
 class OmnigentOAuthHostError(RuntimeError):
@@ -368,7 +370,24 @@ class OmnigentOAuthHostRepository:
                     )
                 ).scalar_one_or_none()
                 if winner is None:
-                    raise
+                    active_profile_lease = (
+                        await session.execute(
+                            select(OmnigentOAuthHostLeaseRecord).where(
+                                OmnigentOAuthHostLeaseRecord.provider_profile_id
+                                == binding.provider_profile_id,
+                                OmnigentOAuthHostLeaseRecord.status.in_(
+                                    ACTIVE_HOST_STATES
+                                ),
+                            )
+                        )
+                    ).scalar_one_or_none()
+                    if active_profile_lease is None:
+                        raise
+                    raise OmnigentOAuthHostError(
+                        "another OAuth host lease is still active for the "
+                        "selected Provider Profile",
+                        code=HOST_PROFILE_BUSY_ERROR_CODE,
+                    ) from None
                 record = winner
             await session.refresh(record)
             return self._lease_model(record)
@@ -555,6 +574,29 @@ class OmnigentOAuthHostRepository:
             ).scalars()
             return [self._lease_model(row) for row in rows]
 
+    async def list_terminal_host_leases_with_active_provider_capacity(
+        self,
+    ) -> list[OmnigentHostLease]:
+        """Find hosts already stopped while their manager slot is still leased."""
+
+        async with self._session_factory() as session:
+            rows = (
+                await session.execute(
+                    select(OmnigentOAuthHostLeaseRecord)
+                    .join(
+                        ProviderProfileSlotLease,
+                        ProviderProfileSlotLease.lease_id
+                        == OmnigentOAuthHostLeaseRecord.provider_lease_id,
+                    )
+                    .where(
+                        OmnigentOAuthHostLeaseRecord.status.in_(
+                            TERMINAL_HOST_STATES
+                        )
+                    )
+                )
+            ).scalars()
+            return [self._lease_model(row) for row in rows]
+
     async def mark_generation_stale(
         self, *, profile_id: str, credential_generation: int
     ) -> list[str]:
@@ -634,6 +676,7 @@ def validate_preflight_result(
 
 __all__ = [
     "ACTIVE_HOST_STATES",
+    "HOST_PROFILE_BUSY_ERROR_CODE",
     "HostPreflightFailure",
     "OmnigentOAuthHostError",
     "OmnigentOAuthHostRepository",

--- a/moonmind/omnigent/profile_bound_execution.py
+++ b/moonmind/omnigent/profile_bound_execution.py
@@ -749,6 +749,7 @@ class OmnigentProfileBoundExecutionCoordinator:
         authority_workspace_resolution: Mapping[str, Any] | None = None
         authority_result: AgentRunResult | None = None
         authority_bridge_session_id: str | None = None
+        authority_idempotency_key = request.idempotency_key
         authority_cleanup_mode: str | None = None
         preflight: Mapping[str, Any] = {}
         authority_reasons: list[dict[str, Any]] = []
@@ -1564,6 +1565,7 @@ class OmnigentProfileBoundExecutionCoordinator:
                     authority_bridge_session_id = str(
                         continuation_bridge.bridge_session_id
                     )
+                    authority_idempotency_key = continuation_request.idempotency_key
                     continuation_result = await self._execute_with_host_lease_heartbeat(
                         self._execute(
                             _bind_exact_host(
@@ -1632,7 +1634,9 @@ class OmnigentProfileBoundExecutionCoordinator:
                 "hostLeaseRef": host_lease.lease_id,
                 "endpointRef": binding.endpoint_ref,
                 "omnigentHostId": host_id,
-                "bridgeSessionId": bridge.bridge_session_id,
+                "bridgeSessionId": (
+                    authority_bridge_session_id or bridge.bridge_session_id
+                ),
                 "effectiveLaunchRef": effective_launch["snapshotRef"],
                 "executionProfileRef": effective_launch["executionProfileRef"],
                 "launchPolicyRef": effective_launch["launchPolicyRef"],
@@ -1653,7 +1657,7 @@ class OmnigentProfileBoundExecutionCoordinator:
                 "terminalRef": next(iter(result.output_refs), None),
                 "diagnosticsRef": result.diagnostics_ref,
                 "omnigentSessionId": result_metadata.get("omnigentSessionId"),
-                "idempotencyKey": request.idempotency_key,
+                "idempotencyKey": authority_idempotency_key,
                 "sourceBranch": self._starting_branch(request) or "detached",
                 "outputBranch": self._target_branch(request),
                 "publicationState": str(

--- a/moonmind/omnigent/profile_bound_execution.py
+++ b/moonmind/omnigent/profile_bound_execution.py
@@ -39,11 +39,19 @@ from moonmind.omnigent.remediation_workspace import (
     RemediationWorkspaceOwner,
     SandboxRemediationWorkspaceOwner,
 )
-from moonmind.omnigent.execution_profiles import PROFILES, selection_from_request
+from moonmind.omnigent.execution_profiles import (
+    PROFILES,
+    selection_from_request,
+)
 from moonmind.omnigent.mounted_tool_preflight import MountedToolPreflightError
 from moonmind.omnigent.oauth_hosts import (
+    HOST_PROFILE_BUSY_ERROR_CODE,
     OmnigentOAuthHostError,
     OmnigentOAuthHostRepository,
+)
+from moonmind.omnigent.stock_agents import (
+    CLAUDE_STOCK_AGENT_NAME,
+    CODEX_STOCK_AGENT_NAME,
 )
 from moonmind.omnigent.workspace_intent import (
     WorkspaceIntentCompilationError,
@@ -64,7 +72,12 @@ from moonmind.provider_profiles.lease_client import (
     deterministic_lease_owner_id,
 )
 from moonmind.provider_profiles.oauth_policy import is_omnigent_oauth_profile
-from moonmind.schemas.agent_runtime_models import AgentExecutionRequest, AgentRunResult
+from moonmind.schemas.agent_runtime_models import (
+    AgentExecutionRequest,
+    AgentRunResult,
+    OmnigentHostLease,
+)
+from moonmind.schemas.temporal_activity_models import AcceptedRepositoryEvidence
 from moonmind.workflows.executions.runtime_capabilities import (
     RuntimeCapabilityError,
     resolve_runtime_execution_capabilities,
@@ -72,6 +85,22 @@ from moonmind.workflows.executions.runtime_capabilities import (
 
 
 ExecutionRunner = Callable[..., Awaitable[AgentRunResult]]
+HOST_LEASE_HEARTBEAT_INTERVAL_SECONDS = 30.0
+# The deployment janitor reconciles abandoned OAuth hosts on a five-minute
+# cadence.  Cover one complete cadence plus scheduling slack so an exact rerun
+# submitted immediately after cancellation can wait for the same profile
+# instead of surfacing a transient uniqueness failure to the operator.
+HOST_PROFILE_BUSY_WAIT_SECONDS = 360.0
+HOST_PROFILE_BUSY_POLL_SECONDS = 5.0
+REPOSITORY_PUBLICATION_CONTINUATION_LIMIT = 8
+
+_REPOSITORY_PUBLICATION_CONTINUATION_PROMPT = """\
+Continue the current task from this same session. The previous turn ended before
+authoritative completion evidence was produced. Do not restart analysis that is
+already complete. Finish the implementation, run the relevant tests, and leave
+the repository changes ready for MoonMind's publisher. Only finish when the
+original task is complete.
+"""
 
 
 def _activity_attempt() -> int:
@@ -541,6 +570,92 @@ class OmnigentProfileBoundExecutionCoordinator:
             os.getenv("WORKFLOW_WORKSPACE_ROOT", "/work/agent_jobs")
         )
 
+    async def _execute_with_host_lease_heartbeat(
+        self,
+        execution: Awaitable[AgentRunResult],
+        *,
+        host_lease_ref: str,
+        ttl_seconds: int,
+    ) -> AgentRunResult:
+        """Keep the durable host lease live for the full provider execution."""
+
+        async def heartbeat() -> None:
+            while True:
+                await self._hosts.heartbeat_host_lease(
+                    host_lease_ref,
+                    ttl_seconds=ttl_seconds,
+                )
+                await asyncio.sleep(HOST_LEASE_HEARTBEAT_INTERVAL_SECONDS)
+
+        execution_task = asyncio.create_task(execution)
+        heartbeat_task = asyncio.create_task(heartbeat())
+        try:
+            done, _pending = await asyncio.wait(
+                {execution_task, heartbeat_task},
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+            if execution_task in done:
+                return await execution_task
+            # A lease heartbeat must run until provider execution completes.
+            # Propagate its failure so the execution is canceled instead of
+            # being silently interrupted later by the stale-lease janitor.
+            await heartbeat_task
+            raise RuntimeError("host lease heartbeat stopped unexpectedly")
+        finally:
+            for task in (execution_task, heartbeat_task):
+                if not task.done():
+                    task.cancel()
+            await asyncio.gather(
+                execution_task,
+                heartbeat_task,
+                return_exceptions=True,
+            )
+
+    async def _create_host_lease_after_profile_idle(
+        self,
+        *,
+        binding: Any,
+        provider_lease: CredentialLease,
+        workflow_id: str,
+        step_execution_id: str | None,
+        idempotency_key: str,
+        emit: Callable[..., Awaitable[None]],
+    ) -> OmnigentHostLease:
+        """Wait for canceled-run host reconciliation before claiming the profile."""
+
+        deadline = asyncio.get_running_loop().time() + HOST_PROFILE_BUSY_WAIT_SECONDS
+        wait_attempt = 0
+        while True:
+            try:
+                return await self._hosts.create_or_get_host_lease(
+                    binding=binding,
+                    provider_lease_id=provider_lease.lease_id,
+                    holder_workflow_id=workflow_id,
+                    agent_run_id=step_execution_id,
+                    idempotency_key=idempotency_key,
+                )
+            except OmnigentOAuthHostError as exc:
+                if exc.code != HOST_PROFILE_BUSY_ERROR_CODE:
+                    raise
+                remaining = deadline - asyncio.get_running_loop().time()
+                if remaining <= 0:
+                    raise
+                wait_attempt += 1
+                retry_after = min(HOST_PROFILE_BUSY_POLL_SECONDS, remaining)
+                await emit(
+                    "host_lease_created",
+                    "waiting",
+                    code=HOST_PROFILE_BUSY_ERROR_CODE,
+                    remediation_action="wait_for_host_cleanup",
+                    metadata={
+                        "providerProfileId": binding.provider_profile_id,
+                        "retryAfterSeconds": retry_after,
+                        "waitAttempt": wait_attempt,
+                    },
+                    ignore_errors=True,
+                )
+                await asyncio.sleep(retry_after)
+
     async def execute(self, request: AgentExecutionRequest) -> AgentRunResult:
         profile_id = str(request.execution_profile_ref or "").strip()
         workflow_id, step_execution_id = _request_identity(request)
@@ -560,6 +675,7 @@ class OmnigentProfileBoundExecutionCoordinator:
         current_stage = "request_validated"
         active_stages: set[str] = set()
         attempt_identity = f"{request.idempotency_key}:attempt:{_activity_attempt()}"
+        deferred_bridge_terminals: list[dict[str, Any]] = []
 
         async def emit(
             stage: str,
@@ -598,12 +714,35 @@ class OmnigentProfileBoundExecutionCoordinator:
             elif status in {"completed", "ready", "failed"}:
                 active_stages.discard(stage)
 
+        def collect_deferred_bridge_terminal(
+            provider_result: AgentRunResult,
+        ) -> AgentRunResult:
+            metadata = dict(provider_result.metadata or {})
+            deferred = metadata.pop("deferredBridgeTerminal", None)
+            if isinstance(deferred, Mapping):
+                idempotency_key = str(
+                    deferred.get("idempotencyKey") or ""
+                ).strip()
+                status = str(deferred.get("status") or "").strip()
+                terminal_refs = deferred.get("terminalRefs")
+                if idempotency_key and status and isinstance(terminal_refs, Mapping):
+                    deferred_bridge_terminals.append(
+                        {
+                            "idempotencyKey": idempotency_key,
+                            "status": status,
+                            "terminalRefs": dict(terminal_refs),
+                        }
+                    )
+            return provider_result.model_copy(update={"metadata": metadata})
+
         provider_lease: CredentialLease | None = None
         host_lease = None
         binding = None
         effective_launch: dict[str, Any] | None = None
         remediation_resolution: Mapping[str, Any] | None = None
+        workspace_locator_payload: Mapping[str, Any] | None = None
         terminal_status = "completed"
+        attempt_cancelled = False
         # Bounded, credential-free evidence accumulated across the run so the
         # unified authority chain (MoonLadderStudios/MoonMind#3561) can be emitted
         # once at terminal, covering both success and every failure path.
@@ -960,12 +1099,13 @@ class OmnigentProfileBoundExecutionCoordinator:
             )
             current_stage = "host_lease_created"
             await emit(current_stage, "started")
-            host_lease = await self._hosts.create_or_get_host_lease(
+            host_lease = await self._create_host_lease_after_profile_idle(
                 binding=binding,
-                provider_lease_id=provider_lease.lease_id,
-                holder_workflow_id=workflow_id,
-                agent_run_id=step_execution_id,
+                provider_lease=provider_lease,
+                workflow_id=workflow_id,
+                step_execution_id=step_execution_id,
                 idempotency_key=request.idempotency_key,
+                emit=emit,
             )
             if host_lease.status in {"stopped", "failed"}:
                 host_lease = await self._hosts.restart_host_lease(host_lease.lease_id)
@@ -997,17 +1137,18 @@ class OmnigentProfileBoundExecutionCoordinator:
             github_token = await self._github_token(request)
             current_stage = "container_start"
             await emit(current_stage, "started")
+            workspace_locator_payload = (
+                remediation_resolution.get("workspaceLocator")
+                if remediation_resolution is not None
+                else workspace_intent.workspace_locator_payload()
+            )
             preflight = await self._runtime.prepare_host(
                 binding=binding,
                 host_lease=host_lease,
                 workspace_key=(
                     f"{workflow_id}:{step_execution_id or request.idempotency_key}"
                 ),
-                workspace_locator=(
-                    remediation_resolution.get("workspaceLocator")
-                    if remediation_resolution is not None
-                    else workspace_intent.workspace_locator_payload()
-                ),
+                workspace_locator=workspace_locator_payload,
                 current_workflow_id=workflow_id,
                 current_step_execution_id=(
                     step_execution_id or request.idempotency_key
@@ -1170,28 +1311,310 @@ class OmnigentProfileBoundExecutionCoordinator:
             await emit("first_message_post", "started")
             await emit("session_running", "started")
             await emit("resource_harvest", "started")
-            result = await self._execute(
-                _bind_exact_host(
-                    request,
-                    host_id=host_id,
-                    workspace_path=str(preflight["workspacePath"]),
-                    profile_authorization={
-                        "providerProfileId": profile_id,
-                        "credentialGeneration": host_lease.credential_generation,
-                        "providerLeaseRef": provider_lease.lease_id,
-                        "hostBindingRef": binding.binding_ref,
-                        "hostLeaseRef": host_lease.lease_id,
-                        "endpointRef": binding.endpoint_ref,
-                        "omnigentHostId": host_id,
-                        "bridgeSessionId": bridge.bridge_session_id,
-                        "effectiveLaunchRef": effective_launch["snapshotRef"],
-                    },
-                    harness=str(effective_launch["harness"]),
-                    agent_name=str(effective_launch["agentName"]),
+            result = await self._execute_with_host_lease_heartbeat(
+                self._execute(
+                    _bind_exact_host(
+                        request,
+                        host_id=host_id,
+                        workspace_path=str(preflight["workspacePath"]),
+                        profile_authorization={
+                            "providerProfileId": profile_id,
+                            "credentialGeneration": host_lease.credential_generation,
+                            "providerLeaseRef": provider_lease.lease_id,
+                            "hostBindingRef": binding.binding_ref,
+                            "hostLeaseRef": host_lease.lease_id,
+                            "endpointRef": binding.endpoint_ref,
+                            "omnigentHostId": host_id,
+                            "bridgeSessionId": bridge.bridge_session_id,
+                            "effectiveLaunchRef": effective_launch["snapshotRef"],
+                        },
+                        harness=str(effective_launch["harness"]),
+                        agent_name=str(effective_launch["agentName"]),
+                    ),
+                    artifact_gateway=self._artifact_gateway,
+                    run_store=self._run_store,
+                    defer_bridge_terminal=True,
                 ),
-                artifact_gateway=self._artifact_gateway,
-                run_store=self._run_store,
+                host_lease_ref=host_lease.lease_id,
+                ttl_seconds=int(effective_launch["limits"]["timeoutSeconds"]),
             )
+            result = collect_deferred_bridge_terminal(result)
+            publish_mode = str(
+                (request.parameters or {}).get("publishMode") or "none"
+            ).strip().lower()
+            if result.failure_class is None and publish_mode in {"branch", "pr"}:
+                publication_stage = "repository_publication"
+                for continuation_index in range(
+                    REPOSITORY_PUBLICATION_CONTINUATION_LIMIT + 1
+                ):
+                    session_id = str(
+                        (result.metadata or {}).get("omnigentSessionId") or ""
+                    ).strip()
+                    try:
+                        completion = await self._runtime.inspect_session_completion(
+                            session_id
+                        )
+                    except Exception as exc:
+                        code = str(
+                            getattr(exc, "code", None)
+                            or "OMNIGENT_SESSION_COMPLETION_EVIDENCE_MISSING"
+                        )[:96]
+                        await emit(
+                            publication_stage,
+                            "failed",
+                            code=code,
+                            summary=(
+                                "Repository publication was blocked because "
+                                "terminal session evidence could not be verified."
+                            ),
+                            failure_class="integration_error",
+                            remediation_action="retry_agent_execution",
+                            ignore_errors=True,
+                        )
+                        result = result.model_copy(
+                            update={
+                                "failure_class": "integration_error",
+                                "provider_error_code": code,
+                                "retry_recommendation": "retry",
+                                "summary": (
+                                    "Omnigent terminal session evidence was "
+                                    "unavailable before repository publication."
+                                ),
+                            }
+                        )
+                        break
+
+                    publication: Mapping[str, Any] = {"push_status": "not_attempted"}
+                    if completion.get("terminalAssistantAfterWork") is True:
+                        await emit(
+                            publication_stage,
+                            "started",
+                            metadata={
+                                "continuationCount": continuation_index,
+                                "terminalAssistantAfterWork": True,
+                            },
+                        )
+                        try:
+                            publication = await self._runtime.publish_workspace(
+                                workspace_locator=workspace_locator_payload or {},
+                                current_workflow_id=workflow_id,
+                                current_step_execution_id=(
+                                    step_execution_id or request.idempotency_key
+                                ),
+                                publication_identity=request.idempotency_key,
+                                publish_mode=publish_mode,
+                                base_branch=self._starting_branch(request),
+                                repository=str(
+                                    (request.parameters or {}).get("repository") or ""
+                                ).strip(),
+                                github_token=github_token,
+                            )
+                        except Exception as exc:
+                            code = str(
+                                getattr(exc, "code", None)
+                                or "OMNIGENT_REPOSITORY_PUBLICATION_FAILED"
+                            )[:96]
+                            await emit(
+                                publication_stage,
+                                "failed",
+                                code=code,
+                                summary=(
+                                    "Repository publication failed before host cleanup."
+                                ),
+                                failure_class="integration_error",
+                                remediation_action="retry_repository_publication",
+                                ignore_errors=True,
+                            )
+                            result = result.model_copy(
+                                update={
+                                    "failure_class": "integration_error",
+                                    "provider_error_code": code,
+                                    "retry_recommendation": "retry",
+                                    "summary": (
+                                        "Omnigent repository publication failed "
+                                        "before the remote branch was verified."
+                                    ),
+                                    "metadata": {
+                                        **dict(result.metadata or {}),
+                                        "push_status": "failed",
+                                    },
+                                }
+                            )
+                            break
+
+                    publication_metadata = dict(publication)
+                    if publication.get("push_status") == "pushed":
+                        evidence = AcceptedRepositoryEvidence(
+                            pushStatus="pushed",
+                            branch=publication.get("push_branch"),
+                            baseBranch=publication.get("push_base_branch"),
+                            headSha=publication.get("push_head_sha"),
+                            commitsAheadOfBase=publication.get("push_commit_count"),
+                            repositoryChanged=True,
+                            remoteVerified=True,
+                            authority="omnigent.profile_bound_execution",
+                        )
+                        publication_metadata["acceptedRepositoryEvidence"] = (
+                            evidence.model_dump(
+                                mode="json", by_alias=True, exclude_none=True
+                            )
+                        )
+                        result = result.model_copy(
+                            update={
+                                "metadata": {
+                                    **dict(result.metadata or {}),
+                                    **publication_metadata,
+                                    "repositoryContinuationCount": continuation_index,
+                                }
+                            }
+                        )
+                        await emit(
+                            publication_stage,
+                            "completed",
+                            metadata={
+                                "pushStatus": "pushed",
+                                "branch": publication.get("push_branch"),
+                                "baseBranch": publication.get("push_base_branch"),
+                                "headSha": publication.get("push_head_sha"),
+                                "commitsAheadOfBase": publication.get(
+                                    "push_commit_count"
+                                ),
+                                "remoteVerified": True,
+                                "continuationCount": continuation_index,
+                            },
+                        )
+                        break
+
+                    if continuation_index >= REPOSITORY_PUBLICATION_CONTINUATION_LIMIT:
+                        await emit(
+                            publication_stage,
+                            "failed",
+                            code="OMNIGENT_REPOSITORY_OUTPUT_MISSING",
+                            summary=(
+                                "Bounded same-session continuation completed "
+                                "without publishable repository output."
+                            ),
+                            failure_class="execution_error",
+                            remediation_action="retry_agent_execution",
+                        )
+                        result = result.model_copy(
+                            update={
+                                "failure_class": "execution_error",
+                                "provider_error_code": (
+                                    "OMNIGENT_REPOSITORY_OUTPUT_MISSING"
+                                ),
+                                "retry_recommendation": "retry",
+                                "summary": (
+                                    "Agent execution completed without repository "
+                                    "changes required by publishMode."
+                                ),
+                                "metadata": {
+                                    **dict(result.metadata or {}),
+                                    **publication_metadata,
+                                    "repositoryContinuationCount": continuation_index,
+                                    "terminalAssistantAfterWork": bool(
+                                        completion.get(
+                                            "terminalAssistantAfterWork", False
+                                        )
+                                    ),
+                                },
+                            }
+                        )
+                        break
+
+                    continuation_number = continuation_index + 1
+                    continuation_stage = (
+                        f"repository_continuation_{continuation_number}"
+                    )
+                    await emit(
+                        continuation_stage,
+                        "started",
+                        metadata={
+                            "priorItemCount": int(completion.get("itemCount") or 0),
+                            "priorToolResultCount": int(
+                                completion.get("toolResultCount") or 0
+                            ),
+                            "terminalAssistantAfterWork": bool(
+                                completion.get("terminalAssistantAfterWork", False)
+                            ),
+                        },
+                    )
+                    continuation_request = request.model_copy(
+                        deep=True,
+                        update={
+                            "idempotency_key": (
+                                f"{request.idempotency_key}:repository-continuation:"
+                                f"{continuation_number}"
+                            )
+                        },
+                    )
+                    continuation_bridge = (
+                        await self._run_store.bind_profile_authorization(
+                            request=continuation_request,
+                            endpoint_ref=binding.endpoint_ref,
+                            provider_profile_id=profile_id,
+                            provider_lease_id=provider_lease.lease_id,
+                            credential_generation=host_lease.credential_generation,
+                            host_binding_ref=binding.binding_ref,
+                            host_lease_ref=host_lease.lease_id,
+                            omnigent_host_id=host_id,
+                            effective_launch_snapshot=effective_launch,
+                        )
+                    )
+                    authority_bridge_session_id = str(
+                        continuation_bridge.bridge_session_id
+                    )
+                    continuation_result = await self._execute_with_host_lease_heartbeat(
+                        self._execute(
+                            _bind_exact_host(
+                                continuation_request,
+                                host_id=host_id,
+                                workspace_path=str(preflight["workspacePath"]),
+                                profile_authorization={
+                                    "providerProfileId": profile_id,
+                                    "credentialGeneration": (
+                                        host_lease.credential_generation
+                                    ),
+                                    "providerLeaseRef": provider_lease.lease_id,
+                                    "hostBindingRef": binding.binding_ref,
+                                    "hostLeaseRef": host_lease.lease_id,
+                                    "endpointRef": binding.endpoint_ref,
+                                    "omnigentHostId": host_id,
+                                    "bridgeSessionId": (
+                                        continuation_bridge.bridge_session_id
+                                    ),
+                                    "effectiveLaunchRef": effective_launch["snapshotRef"],
+                                },
+                                harness=str(effective_launch["harness"]),
+                                agent_name=str(effective_launch["agentName"]),
+                            ),
+                            artifact_gateway=self._artifact_gateway,
+                            run_store=self._run_store,
+                            resume_session_id=session_id,
+                            first_message_text=(
+                                _REPOSITORY_PUBLICATION_CONTINUATION_PROMPT
+                            ),
+                            defer_bridge_terminal=True,
+                        ),
+                        host_lease_ref=host_lease.lease_id,
+                        ttl_seconds=int(
+                            effective_launch["limits"]["timeoutSeconds"]
+                        ),
+                    )
+                    result = collect_deferred_bridge_terminal(continuation_result)
+                    await emit(
+                        continuation_stage,
+                        "failed" if result.failure_class else "completed",
+                        code=result.provider_error_code,
+                        failure_class=(
+                            str(result.failure_class)
+                            if result.failure_class
+                            else None
+                        ),
+                        metadata={"continuationNumber": continuation_number},
+                    )
+                    if result.failure_class is not None:
+                        break
             # Publish the compact, reference-only session/host plane needed by
             # the canonical Step Execution checkpoint writer.  Workspace
             # evidence is deliberately added later by the workspace capture
@@ -1299,6 +1722,7 @@ class OmnigentProfileBoundExecutionCoordinator:
                 )
             return result
         except (Exception, asyncio.CancelledError) as exc:
+            attempt_cancelled = isinstance(exc, asyncio.CancelledError)
             terminal_status = "failed"
             if bridge_ready:
                 code, failure_class, remediation = _failure_evidence(exc)
@@ -1354,72 +1778,114 @@ class OmnigentProfileBoundExecutionCoordinator:
         finally:
             safe_to_release_provider = host_lease is None
             if host_lease is not None and binding is not None:
-                try:
-                    cleanup_mode = (
-                        "on_demand_remove"
-                        if binding.host_launch_profile_ref
-                        else "static_drain"
-                    )
-                    authority_cleanup_mode = cleanup_mode
-                    await emit(
-                        "host_cleanup",
-                        "started",
-                        metadata={
-                            "sessionInterrupted": host_lease.status == "assigned",
-                            "hostCleanupMode": cleanup_mode,
-                        },
-                        ignore_errors=True,
-                    )
-                    if host_lease.status == "assigned":
-                        host_lease = await self._hosts.transition_host_lease(
-                            host_lease.lease_id,
-                            expected_status="assigned",
-                            new_status="draining",
-                        )
-                    await self._runtime.stop_host(
-                        binding=binding, host_lease=host_lease
-                    )
-                    await self._hosts.mark_host_lease_stopped(host_lease.lease_id)
-                    safe_to_release_provider = True
-                    await emit(
-                        "host_cleanup",
-                        "completed",
-                        metadata={
-                            "cleanupCompleted": True,
-                            "sessionInterrupted": True,
-                            "hostCleanupMode": cleanup_mode,
-                            "stateResourcesCleaned": True,
-                            "hostLeaseReleased": True,
-                        },
-                        ignore_errors=True,
-                    )
-                except Exception as cleanup_exc:
-                    try:
-                        await self._hosts.mark_host_lease_failed(
-                            host_lease.lease_id,
-                            code=type(cleanup_exc).__name__,
-                            summary=str(cleanup_exc),
-                        )
-                    except Exception:
-                        # Preserve the primary cleanup failure when best-effort
-                        # persistence of that failure also becomes unavailable.
-                        pass
+                if attempt_cancelled:
+                    # A Temporal timeout can schedule the retry before the
+                    # canceled coroutine finishes. Leave the deterministic host
+                    # and credential lease for that retry (or the janitor) so an
+                    # old attempt cannot stop/remove the new attempt's host.
+                    authority_cleanup_mode = "retry_or_janitor_reconciliation"
                     authority_reasons.append(
                         {
                             "stage": "host_cleanup",
-                            "code": type(cleanup_exc).__name__,
+                            "code": "activity_cancelled",
                             "failureClass": "system_error",
-                            "remediationAction": "inspect_cleanup_diagnostics",
+                            "remediationAction": "retry_or_reconcile_stale_host",
                         }
                     )
                     await emit(
                         "host_cleanup",
-                        "failed",
-                        code=type(cleanup_exc).__name__,
-                        summary=str(cleanup_exc),
-                        failure_class="system_error",
-                        remediation_action="inspect_cleanup_diagnostics",
-                        metadata={"cleanupCompleted": False, "janitorRequired": True},
+                        "waiting",
+                        code="activity_cancelled",
+                        remediation_action="retry_or_reconcile_stale_host",
+                        metadata={
+                            "cleanupCompleted": False,
+                            "janitorRequired": True,
+                        },
+                        ignore_errors=True,
+                    )
+                else:
+                    try:
+                        cleanup_mode = (
+                            "on_demand_remove"
+                            if binding.host_launch_profile_ref
+                            else "static_drain"
+                        )
+                        authority_cleanup_mode = cleanup_mode
+                        await emit(
+                            "host_cleanup",
+                            "started",
+                            metadata={
+                                "sessionInterrupted": host_lease.status == "assigned",
+                                "hostCleanupMode": cleanup_mode,
+                            },
+                            ignore_errors=True,
+                        )
+                        if host_lease.status == "assigned":
+                            host_lease = await self._hosts.transition_host_lease(
+                                host_lease.lease_id,
+                                expected_status="assigned",
+                                new_status="draining",
+                            )
+                        await self._runtime.stop_host(
+                            binding=binding, host_lease=host_lease
+                        )
+                        await self._hosts.mark_host_lease_stopped(host_lease.lease_id)
+                        safe_to_release_provider = True
+                        await emit(
+                            "host_cleanup",
+                            "completed",
+                            metadata={
+                                "cleanupCompleted": True,
+                                "sessionInterrupted": True,
+                                "hostCleanupMode": cleanup_mode,
+                                "stateResourcesCleaned": True,
+                                "hostLeaseReleased": True,
+                            },
+                            ignore_errors=True,
+                        )
+                    except Exception as cleanup_exc:
+                        try:
+                            await self._hosts.mark_host_lease_failed(
+                                host_lease.lease_id,
+                                code=type(cleanup_exc).__name__,
+                                summary=str(cleanup_exc),
+                            )
+                        except Exception:
+                            # Preserve the primary cleanup failure when best-effort
+                            # persistence of that failure also becomes unavailable.
+                            pass
+                        authority_reasons.append(
+                            {
+                                "stage": "host_cleanup",
+                                "code": type(cleanup_exc).__name__,
+                                "failureClass": "system_error",
+                                "remediationAction": "inspect_cleanup_diagnostics",
+                            }
+                        )
+                        await emit(
+                            "host_cleanup",
+                            "failed",
+                            code=type(cleanup_exc).__name__,
+                            summary=str(cleanup_exc),
+                            failure_class="system_error",
+                            remediation_action="inspect_cleanup_diagnostics",
+                            metadata={"cleanupCompleted": False, "janitorRequired": True},
+                        )
+            for deferred_terminal in deferred_bridge_terminals:
+                try:
+                    await self._run_store.mark_terminal(
+                        deferred_terminal["idempotencyKey"],
+                        status=deferred_terminal["status"],
+                        terminal_refs=deferred_terminal["terminalRefs"],
+                    )
+                except Exception as terminal_exc:
+                    authority_reasons.append(
+                        {
+                            "stage": "terminal_evidence_commit",
+                            "code": type(terminal_exc).__name__,
+                            "failureClass": "system_error",
+                            "remediationAction": "inspect_cleanup_diagnostics",
+                        }
                     )
             lease_released = provider_lease is None
             if provider_lease is not None:
@@ -1632,7 +2098,11 @@ class OmnigentProfileBoundExecutionCoordinator:
                         by_alias=True, mode="json", exclude_none=True
                     ),
                     harness=harness,
-                    agent_name=("claude" if runtime_id == "claude_code" else "codex"),
+                    agent_name=(
+                        CLAUDE_STOCK_AGENT_NAME
+                        if runtime_id == "claude_code"
+                        else CODEX_STOCK_AGENT_NAME
+                    ),
                 ),
                 artifact_gateway=self._artifact_gateway,
                 run_store=self._run_store,

--- a/moonmind/omnigent/profile_bound_execution.py
+++ b/moonmind/omnigent/profile_bound_execution.py
@@ -599,7 +599,7 @@ class OmnigentProfileBoundExecutionCoordinator:
             # A lease heartbeat must run until provider execution completes.
             # Propagate its failure so the execution is canceled instead of
             # being silently interrupted later by the stale-lease janitor.
-            await heartbeat_task
+            heartbeat_task.result()
             raise RuntimeError("host lease heartbeat stopped unexpectedly")
         finally:
             for task in (execution_task, heartbeat_task):

--- a/moonmind/omnigent/stock_agents.py
+++ b/moonmind/omnigent/stock_agents.py
@@ -1,0 +1,7 @@
+"""Canonical stock Omnigent agent identities used across runtime boundaries."""
+
+from __future__ import annotations
+
+
+CODEX_STOCK_AGENT_NAME = "codex-native-ui"
+CLAUDE_STOCK_AGENT_NAME = "claude-native-ui"

--- a/moonmind/provider_profiles/lease_client.py
+++ b/moonmind/provider_profiles/lease_client.py
@@ -117,19 +117,18 @@ class ProviderProfileLeaseClient:
         metadata: Mapping[str, Any] | None,
         owner_is_workflow: bool,
     ) -> CredentialLease:
-        workflow_id = await self._ensure_manager(runtime_id)
         safe_metadata = dict(metadata or {})
         # Most callers use an activity idempotency identity. A workflow may
         # delegate an acknowledged Update through an Activity when the
         # workflow-context ExternalWorkflowHandle cannot execute Updates; in
         # that case the stable owner really is the delegating workflow ID.
         safe_metadata["ownerIsWorkflow"] = owner_is_workflow
-        result = await self._adapter.update_workflow(
-            workflow_id,
+        result = await self._update_manager(
+            runtime_id,
             (
                 "AcquireCredentialMaintenanceLease"
                 if purpose.is_maintenance
-                else "AcquireSlot"
+                else "AcquireSlotV2"
             ),
             {
                 "requester_workflow_id": owner_id,
@@ -148,6 +147,43 @@ class ProviderProfileLeaseClient:
             purpose=purpose,
             already_held=bool(result.get("already_held")),
         )
+
+    async def _update_manager(
+        self,
+        runtime_id: str,
+        update_name: str,
+        payload: Mapping[str, Any],
+    ) -> Mapping[str, Any]:
+        """Retry an Update that races the manager's clean completion.
+
+        Ensuring and updating are two distinct Temporal RPCs. The manager can
+        complete after ``start_workflow`` reports it running but before the
+        accepted Update resolves. Re-ensuring the canonical workflow ID and
+        resubmitting the same idempotent owner request closes that race without
+        consuming the caller Activity retry.
+        """
+
+        from temporalio.client import WorkflowUpdateFailedError
+        from temporalio.exceptions import ApplicationError
+
+        for attempt in range(2):
+            workflow_id = await self._ensure_manager(runtime_id)
+            try:
+                return await self._adapter.update_workflow(
+                    workflow_id,
+                    update_name,
+                    dict(payload),
+                )
+            except WorkflowUpdateFailedError as exc:
+                cause = exc.cause
+                completed_race = bool(
+                    isinstance(cause, ApplicationError)
+                    and cause.type == "AcceptedUpdateCompletedWorkflow"
+                )
+                if attempt == 0 and completed_race:
+                    continue
+                raise
+        raise AssertionError("bounded manager update retry did not terminate")
 
     async def acquire_execution_lease(
         self,
@@ -226,10 +262,12 @@ class ProviderProfileLeaseClient:
         )
 
     async def inspect_lease(self, lease: CredentialLease) -> dict[str, Any]:
-        return await self._adapter.update_workflow(
-            await self._ensure_manager(lease.runtime_id),
-            "InspectCredentialLease",
-            {"lease_id": lease.lease_id, "owner_id": lease.owner_id},
+        return dict(
+            await self._update_manager(
+                lease.runtime_id,
+                "InspectCredentialLease",
+                {"lease_id": lease.lease_id, "owner_id": lease.owner_id},
+            )
         )
 
 

--- a/moonmind/publish/service.py
+++ b/moonmind/publish/service.py
@@ -46,6 +46,10 @@ class PublishResult:
     branch_pushed: bool = False
     pr_url: str | None = None
     branch_name: str | None = None
+    base_branch: str | None = None
+    head_sha: str | None = None
+    commits_ahead_of_base: int | None = None
+    remote_verified: bool = False
 
     def summary_text(self) -> str | None:
         if self.status == "skipped":
@@ -155,6 +159,10 @@ class PublishService:
         repo_dir: Path,
         run_command: CommandRunner,
         repo: str | None = None,
+        github_token: str | None = None,
+        publish_existing_commits: bool = False,
+        publication_branch_name: str | None = None,
+        verify_remote: bool = False,
     ) -> PublishResult | None:
         """Publish the changes to a branch or a pull request.
 
@@ -175,7 +183,8 @@ class PublishService:
             cwd=repo_dir,
             check=False,
         )
-        if not status.stdout.strip():
+        worktree_changed = bool(status.stdout.strip())
+        if not worktree_changed and not publish_existing_commits:
             return PublishResult(
                 mode=publish_mode,
                 status="skipped",
@@ -183,54 +192,150 @@ class PublishService:
                 reason="No repository changes were available to commit or publish.",
             )
 
-        branch_name = f"moonmind-job-{str(job_id)[:8]}"
+        branch_name = str(publication_branch_name or "").strip() or (
+            f"moonmind-job-{str(job_id)[:8]}"
+        )
         await run_command(
             [self._git_binary, "checkout", "-B", branch_name],
             cwd=repo_dir,
         )
-        await run_command(
-            [self._git_binary, "add", "-A"],
-            cwd=repo_dir,
-        )
-        commit_message = self._derive_default_publish_subject(
-            instruction=instruction,
-            max_chars=72,
-        )
-        await run_command(
-            [
-                self._git_binary,
-                "commit",
-                "-m",
-                commit_message,
-            ],
-            cwd=repo_dir,
-            redaction_values=(commit_message,),
-        )
-        commit_created = True
+        commit_created = False
+        if worktree_changed:
+            await run_command(
+                [self._git_binary, "add", "-A"],
+                cwd=repo_dir,
+            )
+            commit_message = self._derive_default_publish_subject(
+                instruction=instruction,
+                max_chars=72,
+            )
+            await run_command(
+                [
+                    self._git_binary,
+                    "commit",
+                    "-m",
+                    commit_message,
+                ],
+                cwd=repo_dir,
+                redaction_values=(commit_message,),
+            )
+            commit_created = True
+        base_branch = publish_base_branch or "main"
+        base_ref = f"origin/{base_branch}"
+        commit_count: int | None = None
+        if publish_existing_commits or verify_remote:
+            count_result = await run_command(
+                [
+                    self._git_binary,
+                    "rev-list",
+                    "--count",
+                    f"{base_ref}..{branch_name}",
+                ],
+                cwd=repo_dir,
+                check=False,
+            )
+            try:
+                commit_count = int(str(count_result.stdout or "").strip())
+            except (TypeError, ValueError):
+                commit_count = None
+            if publish_existing_commits and not worktree_changed and commit_count == 0:
+                return PublishResult(
+                    mode=publish_mode,
+                    status="skipped",
+                    reason_code="no_commit",
+                    reason=(
+                        "No repository commits were available over the authored "
+                        "publish base."
+                    ),
+                    branch_name=branch_name,
+                    base_branch=base_branch,
+                    commits_ahead_of_base=0,
+                )
+            if publish_existing_commits and commit_count is None:
+                raise RuntimeError(
+                    "could not measure repository commits over the authored "
+                    "publish base"
+                )
         await self._scan_git_push_before_publish(
             repo_dir=repo_dir,
             branch_name=branch_name,
-            base_ref=f"origin/{publish_base_branch or 'main'}",
+            base_ref=base_ref,
             env={**os.environ, "GIT_TERMINAL_PROMPT": "0"},
         )
-        token = ""
+        token = str(github_token or "").strip()
         push_env = {**os.environ, "GIT_TERMINAL_PROMPT": "0"}
         resolved_github_credential = None
-        if repo:
+        if repo and not token:
             from moonmind.auth.github_credentials import resolve_github_credential
 
             resolved_github_credential = await resolve_github_credential(repo=repo)
             token = resolved_github_credential.token or ""
-            if token:
-                push_env["GITHUB_TOKEN"] = token
-                push_env["GH_TOKEN"] = token
+        if token:
+            push_env["GITHUB_TOKEN"] = token
+            push_env["GH_TOKEN"] = token
+        remote_sha = ""
+        if verify_remote:
+            remote_result = await run_command(
+                [
+                    self._git_binary,
+                    "ls-remote",
+                    "--heads",
+                    "origin",
+                    f"refs/heads/{branch_name}",
+                ],
+                cwd=repo_dir,
+                check=False,
+                env=push_env,
+                redaction_values=(token,) if token else (),
+            )
+            remote_line = str(remote_result.stdout or "").strip().splitlines()
+            if remote_line:
+                remote_sha = remote_line[0].split(maxsplit=1)[0].strip()
+        push_command = [self._git_binary, "push", "-u"]
+        if verify_remote:
+            push_command.append(
+                f"--force-with-lease=refs/heads/{branch_name}:{remote_sha}"
+            )
+        push_command.extend(("origin", branch_name))
         await run_command(
-            [self._git_binary, "push", "-u", "origin", branch_name],
+            push_command,
             cwd=repo_dir,
             env=push_env,
             redaction_values=(token,) if token else (),
         )
         branch_pushed = True
+        head_sha: str | None = None
+        remote_verified = False
+        if verify_remote:
+            head_result = await run_command(
+                [self._git_binary, "rev-parse", "HEAD"],
+                cwd=repo_dir,
+            )
+            head_sha = str(head_result.stdout or "").strip() or None
+            verify_result = await run_command(
+                [
+                    self._git_binary,
+                    "ls-remote",
+                    "--heads",
+                    "origin",
+                    f"refs/heads/{branch_name}",
+                ],
+                cwd=repo_dir,
+                check=False,
+                env=push_env,
+                redaction_values=(token,) if token else (),
+            )
+            remote_lines = str(verify_result.stdout or "").strip().splitlines()
+            verified_sha = (
+                remote_lines[0].split(maxsplit=1)[0].strip()
+                if remote_lines
+                else ""
+            )
+            remote_verified = bool(head_sha and verified_sha == head_sha)
+            if not remote_verified:
+                raise RuntimeError(
+                    "published branch failed exact remote-head verification"
+                )
 
         if publish_mode == "branch":
             return PublishResult(
@@ -240,9 +345,12 @@ class PublishService:
                 commit_created=commit_created,
                 branch_pushed=branch_pushed,
                 branch_name=branch_name,
+                base_branch=base_branch,
+                head_sha=head_sha,
+                commits_ahead_of_base=commit_count,
+                remote_verified=remote_verified,
             )
 
-        base_branch = publish_base_branch or "main"
         pr_title = self._derive_default_publish_subject(
             instruction=instruction,
             max_chars=90,
@@ -282,6 +390,10 @@ class PublishService:
                 branch_pushed=branch_pushed,
                 pr_url=str(url) if url else None,
                 branch_name=branch_name,
+                base_branch=base_branch,
+                head_sha=head_sha,
+                commits_ahead_of_base=commit_count,
+                remote_verified=remote_verified,
             )
 
         if resolved_github_credential is None:
@@ -329,6 +441,10 @@ class PublishService:
             commit_created=commit_created,
             branch_pushed=branch_pushed,
             branch_name=branch_name,
+            base_branch=base_branch,
+            head_sha=head_sha,
+            commits_ahead_of_base=commit_count,
+            remote_verified=remote_verified,
         )
 
     async def _scan_git_push_before_publish(
@@ -433,6 +549,8 @@ class PublishService:
     ) -> str:
         proc = await asyncio.create_subprocess_exec(
             self._git_binary,
+            "-c",
+            f"safe.directory={repo_dir.resolve()}",
             "-C",
             str(repo_dir),
             *args,

--- a/moonmind/schemas/temporal_activity_models.py
+++ b/moonmind/schemas/temporal_activity_models.py
@@ -387,7 +387,10 @@ class AcceptedRepositoryEvidence(BaseModel):
         False, alias="candidateContaminated"
     )
     remote_verified: Literal[True] = Field(..., alias="remoteVerified")
-    authority: Literal["agent_runtime.fetch_result"] = "agent_runtime.fetch_result"
+    authority: Literal[
+        "agent_runtime.fetch_result",
+        "omnigent.profile_bound_execution",
+    ] = "agent_runtime.fetch_result"
 
     @model_validator(mode="after")
     def _validate_push_evidence(self) -> "AcceptedRepositoryEvidence":

--- a/moonmind/security/egress.py
+++ b/moonmind/security/egress.py
@@ -499,13 +499,18 @@ def restricted_proxy_env() -> tuple[str, ...]:
 
 
 def omnigent_proxy_env() -> tuple[str, ...]:
-    """Proxy environment for the isolated Omnigent control-plane ingress."""
+    """Proxy environment for isolated Omnigent hosts and their runners.
+
+    Codex's native bridge connects the TUI to its app server over a same-host
+    loopback WebSocket.  Loopback cannot reach an external destination from the
+    container, so exempt it while continuing to proxy every non-local address.
+    """
 
     return (
         f"HTTP_PROXY={OMNIGENT_PROXY_URL}",
         f"HTTPS_PROXY={OMNIGENT_PROXY_URL}",
         f"http_proxy={OMNIGENT_PROXY_URL}",
         f"https_proxy={OMNIGENT_PROXY_URL}",
-        "NO_PROXY=",
-        "no_proxy=",
+        "NO_PROXY=localhost,127.0.0.1",
+        "no_proxy=localhost,127.0.0.1",
     )

--- a/moonmind/workflows/adapters/omnigent_agent_adapter.py
+++ b/moonmind/workflows/adapters/omnigent_agent_adapter.py
@@ -21,7 +21,6 @@ from moonmind.omnigent.failure_classification import (
     OmnigentFailureReason,
     classify_omnigent_failure,
 )
-from moonmind.omnigent.stock_agents import CODEX_STOCK_AGENT_NAME
 from moonmind.schemas.agent_runtime_models import (
     AgentExecutionRequest,
     AgentRunHandle,

--- a/moonmind/workflows/adapters/omnigent_agent_adapter.py
+++ b/moonmind/workflows/adapters/omnigent_agent_adapter.py
@@ -21,6 +21,7 @@ from moonmind.omnigent.failure_classification import (
     OmnigentFailureReason,
     classify_omnigent_failure,
 )
+from moonmind.omnigent.stock_agents import CODEX_STOCK_AGENT_NAME
 from moonmind.schemas.agent_runtime_models import (
     AgentExecutionRequest,
     AgentRunHandle,
@@ -67,7 +68,6 @@ _ROOT_SELECTION_KEYS = {
     "reasoningEffort",
     "terminalLaunchArgs",
 }
-
 
 class OmnigentAdapterError(ValueError):
     """Adapter validation error carrying the canonical MoonMind failure class."""
@@ -246,6 +246,7 @@ def build_omnigent_session_create_payload(
     """Build the JSON session-create payload sent to Omnigent."""
 
     session = selection.session
+    terminal_launch_args = list(session.terminal_launch_args)
     title = (
         session.title
         or _clean((request.parameters or {}).get("title"))
@@ -267,7 +268,7 @@ def build_omnigent_session_create_payload(
         "workspace": session.workspace,
         "model_override": session.model_override,
         "reasoning_effort": session.reasoning_effort,
-        "terminal_launch_args": session.terminal_launch_args,
+        "terminal_launch_args": terminal_launch_args,
     }
     if session.host_type == "external":
         payload["host_id"] = session.host_id

--- a/moonmind/workflows/adapters/omnigent_client.py
+++ b/moonmind/workflows/adapters/omnigent_client.py
@@ -150,7 +150,7 @@ class OmnigentHttpClient:
         return await self._request("GET", f"/api/agents/{quote(agent_id, safe='')}")
 
     async def list_hosts(self) -> list[dict[str, Any]]:
-        data = await self._request("GET", "/api/hosts")
+        data = await self._request("GET", "/v1/hosts")
         if isinstance(data, list):
             return [dict(item) for item in data if isinstance(item, Mapping)]
         if isinstance(data, Mapping) and isinstance(data.get("hosts"), list):
@@ -196,6 +196,7 @@ class OmnigentHttpClient:
                     "GET",
                     f"{self._base}{path}",
                     headers=self._headers(accept="text/event-stream"),
+                    timeout=self._stream_timeout,
                 ) as response:
                     async for event in self._iter_stream_response(response):
                         yield event
@@ -321,6 +322,7 @@ class OmnigentHttpClient:
                     method,
                     f"{self._base}{path}",
                     headers=self._headers(),
+                    timeout=self._timeout,
                     **kwargs,
                 )
             except httpx.HTTPError as exc:
@@ -368,6 +370,7 @@ class OmnigentHttpClient:
                     method,
                     f"{self._base}{path}",
                     headers=self._headers(),
+                    timeout=self._timeout,
                 )
             except httpx.HTTPError as exc:
                 raise OmnigentClientError(

--- a/moonmind/workflows/temporal/activities/omnigent_activities.py
+++ b/moonmind/workflows/temporal/activities/omnigent_activities.py
@@ -287,6 +287,15 @@ async def _resolve_live_recovery_authority(
 async def omnigent_execute_activity(
     request: AgentExecutionRequest,
 ) -> AgentRunResult:
+    from moonmind.omnigent.execute import omnigent_activity_heartbeat
+
+    async with omnigent_activity_heartbeat():
+        return await _omnigent_execute_activity(request)
+
+
+async def _omnigent_execute_activity(
+    request: AgentExecutionRequest,
+) -> AgentRunResult:
     """Run one Omnigent streaming execution."""
 
     from api_service.db.base import async_session_maker
@@ -305,10 +314,10 @@ async def omnigent_execute_activity(
         resolved_proxy_forward_headers,
         resolved_server_url,
     )
-    from moonmind.provider_profiles.lease_client import ProviderProfileLeaseClient
     from moonmind.repositories.lore_runtime import (
         build_lore_repository_adapter_from_environment,
     )
+    from moonmind.provider_profiles.lease_client import ProviderProfileLeaseClient
     from moonmind.workflows.adapters.omnigent_client import OmnigentHttpClient
     from moonmind.workflows.temporal.client import TemporalClientAdapter
     from moonmind.workflows.temporal.artifacts import (
@@ -510,7 +519,9 @@ async def omnigent_oauth_host_janitor_activity(
         resolved_proxy_forward_headers,
         resolved_server_url,
     )
+    from moonmind.provider_profiles.lease_client import ProviderProfileLeaseClient
     from moonmind.workflows.adapters.omnigent_client import OmnigentHttpClient
+    from moonmind.workflows.temporal.client import TemporalClientAdapter
 
     async with httpx.AsyncClient() as http_client:
         client = OmnigentHttpClient(
@@ -524,6 +535,7 @@ async def omnigent_oauth_host_janitor_activity(
             runtime=OmnigentOAuthHostRuntime(client=client),
             client=client,
             run_store=OmnigentBridgeSessionStore(async_session_maker),
+            lease_client=ProviderProfileLeaseClient(TemporalClientAdapter()),
         )
         payload = dict(request or {})
         action_kind = str(payload.get("actionKind") or "").strip()

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -67,7 +67,9 @@ from moonmind.integrations.pentest.models import (
 )
 from moonmind.jules.status import JulesStatusSnapshot, normalize_jules_status
 from moonmind.workflows.temporal.runtime.workspace_locators import (
+    SandboxWorkspaceRecordStore,
     resolve_managed_workspace_locator,
+    resolve_sandbox_workspace_locator,
 )
 from moonmind.schemas.manifest_ingest_models import CompiledManifestPlanModel
 from moonmind.schemas.managed_checkpoint_models import (
@@ -298,6 +300,20 @@ async def _run_command(cmd, **kwargs):
     if check and proc.returncode != 0:
         raise RuntimeError(f"Command failed: {cmd} {stderr.decode('utf-8', errors='replace')}")
     return CmdRes(stdout)
+
+
+def _sandbox_workspace_git_command(workspace: Path, *args: str) -> list[str]:
+    """Build a Git command that trusts one resolved sandbox workspace only."""
+
+    resolved_workspace = str(workspace.resolve())
+    return [
+        "git",
+        "-c",
+        f"safe.directory={resolved_workspace}",
+        "-C",
+        resolved_workspace,
+        *args,
+    ]
 
 logger = getLogger(__name__)
 
@@ -3590,8 +3606,9 @@ class TemporalSandboxActivities:
                     "git_patch checkpoint kind does not support including untracked or ignored files"
                 )
             diff_result = await _run_command(
-                ["git", "diff", "--binary", model.base_commit, "--"],
-                cwd=str(workspace),
+                _sandbox_workspace_git_command(
+                    workspace, "diff", "--binary", model.base_commit, "--"
+                ),
             )
             patch_payload = diff_result.stdout.encode("utf-8")
             patch_ref = await self._put_checkpoint_bytes(
@@ -3623,7 +3640,9 @@ class TemporalSandboxActivities:
             )
         if model.kind == "git_commit":
             head = (
-                await _run_command(["git", "rev-parse", "HEAD"], cwd=str(workspace))
+                await _run_command(
+                    _sandbox_workspace_git_command(workspace, "rev-parse", "HEAD")
+                )
             ).stdout.strip()
             return WorkspaceCheckpointEvidenceModel(
                 kind="git_commit",
@@ -3655,7 +3674,11 @@ class TemporalSandboxActivities:
             head = model.base_commit
             if (workspace / ".git").exists():
                 head = (
-                    await _run_command(["git", "rev-parse", "HEAD"], cwd=str(workspace))
+                    await _run_command(
+                        _sandbox_workspace_git_command(
+                            workspace, "rev-parse", "HEAD"
+                        )
+                    )
                 ).stdout.strip()
             archive_payload, entries = self._build_worktree_archive(workspace)
             workspace_digest = _workspace_content_digest(entries)
@@ -3680,8 +3703,13 @@ class TemporalSandboxActivities:
             # the optional digest (restore already treats it as optional).
             if (workspace / ".git").exists():
                 status = await _run_command(
-                    ["git", "status", "--porcelain=v1", "-z", "--untracked-files=all"],
-                    cwd=str(workspace),
+                    _sandbox_workspace_git_command(
+                        workspace,
+                        "status",
+                        "--porcelain=v1",
+                        "-z",
+                        "--untracked-files=all",
+                    ),
                 )
                 manifest_body["gitStatusDigest"] = (
                     "sha256:"
@@ -7233,6 +7261,7 @@ class TemporalAgentRuntimeActivities:
         raw_docker_cli_enabled: bool = False,
         client_adapter: Any = None,
         pentest_provider_lease_manager: PentestProviderLeaseManager | None = None,
+        workspace_root: str | Path | None = None,
     ) -> None:
         self._artifact_service = artifact_service
         self._run_store = run_store
@@ -7245,6 +7274,9 @@ class TemporalAgentRuntimeActivities:
         self._container_job_backend = container_job_backend
         self._workflow_docker_mode = normalize_workflow_docker_mode(workflow_docker_mode)
         self._raw_docker_cli_enabled = bool(raw_docker_cli_enabled)
+        self._workspace_root = Path(
+            workspace_root or settings.workflow.workspace_root
+        ).resolve()
         if client_adapter is None:
             from moonmind.workflows.temporal import client as temporal_client_module
 
@@ -12821,6 +12853,46 @@ class TemporalAgentRuntimeActivities:
         workspace_path = str(request.get("workspacePath") or "").strip()
         if not workspace_path:
             workspace_path = str((result.metadata or {}).get("workspacePath") or "").strip()
+        raw_workspace_locator = request.get("workspaceLocator")
+        if isinstance(raw_workspace_locator, Mapping):
+            locator = WORKSPACE_LOCATOR_ADAPTER.validate_python(raw_workspace_locator)
+            if not isinstance(locator, SandboxWorkspaceLocator):
+                raise WorkspaceLocatorResolutionError(
+                    WORKSPACE_LOCATOR_UNSUPPORTED,
+                    "terminal evidence requires a sandbox workspace locator",
+                )
+            owner_workflow_id = str(
+                request.get("workspaceOwnerWorkflowId") or ""
+            ).strip()
+            owner_step_execution_id = str(
+                request.get("workspaceOwnerStepExecutionId") or ""
+            ).strip()
+            if not owner_workflow_id or not owner_step_execution_id:
+                raise WorkspaceLocatorResolutionError(
+                    WORKSPACE_IDENTITY_MISMATCH,
+                    "terminal evidence sandbox authority is incomplete",
+                )
+            expected_workspace_id = hashlib.sha256(
+                f"{owner_workflow_id}:{owner_step_execution_id}".encode("utf-8")
+            ).hexdigest()[:24]
+            owner_record = SandboxWorkspaceRecordStore(self._workspace_root).load(
+                expected_workspace_id
+            )
+            if owner_record is None:
+                raise WorkspaceLocatorResolutionError(
+                    WORKSPACE_IDENTITY_MISMATCH,
+                    "terminal evidence sandbox owner record was not found",
+                )
+            workspace_path = str(
+                resolve_sandbox_workspace_locator(
+                    locator,
+                    workspace_root=self._workspace_root,
+                    expected_workspace_id=expected_workspace_id,
+                    owner_record=owner_record,
+                    expected_workflow_id=owner_workflow_id,
+                    expected_step_execution_id=owner_step_execution_id,
+                )
+            )
         run_id = str(request.get("runId") or "").strip()
         if not workspace_path and run_id and self._run_store is not None:
             record = self._run_store.load(run_id)
@@ -12840,6 +12912,57 @@ class TemporalAgentRuntimeActivities:
         if evaluation.failure_code:
             metadata["failureCode"] = evaluation.failure_code
 
+        async def _persist_terminal_evidence_source(
+            source: Any,
+            *,
+            link_type: str,
+            labels: list[str],
+        ) -> str | None:
+            if source.path is None:
+                return None
+            if self._artifact_service is None:
+                logger.warning(
+                    "Terminal evidence artifact service is unavailable; evidence "
+                    "remains run-scoped at %s",
+                    source.relative_path,
+                )
+                return None
+            payload = source.path.read_bytes()
+            try:
+                info = temporal_activity.info()
+            except RuntimeError:
+                info = None
+            execution_ref = (
+                ExecutionRef(
+                    namespace=info.namespace,
+                    workflow_id=info.workflow_id,
+                    run_id=info.workflow_run_id,
+                    link_type=link_type,
+                )
+                if info is not None
+                else None
+            )
+            artifact, _upload = await self._artifact_service.create(
+                principal="system:agent_runtime",
+                content_type="application/json",
+                size_bytes=len(payload),
+                link=execution_ref,
+                metadata_json={
+                    "name": source.path.name,
+                    "path": source.relative_path,
+                    "producer": "activity:agent_runtime.evaluate_terminal_evidence",
+                    "labels": labels,
+                    "terminalContractId": metadata["terminalContractId"],
+                },
+            )
+            completed = await self._artifact_service.write_complete(
+                artifact_id=artifact.artifact_id,
+                principal="system:agent_runtime",
+                payload=payload,
+                content_type="application/json",
+            )
+            return completed.artifact_id
+
         # Terminal evidence is the authoritative full result for fan-out and
         # merge automation. Publish the validated run-scoped file here, before
         # the workflow projects large child records out of its result metadata.
@@ -12849,50 +12972,36 @@ class TemporalAgentRuntimeActivities:
                 workspace_path=workspace_path,
                 artifact_spool_path=artifact_spool_path,
             )
-            if source.path is not None and self._artifact_service is not None:
-                payload = source.path.read_bytes()
-                try:
-                    info = temporal_activity.info()
-                except RuntimeError:
-                    info = None
-                execution_ref = (
-                    ExecutionRef(
-                        namespace=info.namespace,
-                        workflow_id=info.workflow_id,
-                        run_id=info.workflow_run_id,
-                        link_type="output.terminal_evidence",
-                    )
-                    if info is not None
-                    else None
-                )
-                artifact, _upload = await self._artifact_service.create(
-                    principal="system:agent_runtime",
-                    content_type="application/json",
-                    size_bytes=len(payload),
-                    link=execution_ref,
-                    metadata_json={
-                        "name": source.path.name,
-                        "path": source.relative_path,
-                        "producer": (
-                            "activity:agent_runtime.evaluate_terminal_evidence"
-                        ),
-                        "labels": ["agent_runtime", "output.terminal_evidence"],
-                        "terminalContractId": metadata["terminalContractId"],
-                    },
-                )
-                completed = await self._artifact_service.write_complete(
-                    artifact_id=artifact.artifact_id,
-                    principal="system:agent_runtime",
-                    payload=payload,
-                    content_type="application/json",
-                )
-                metadata["terminalContractEvidenceRef"] = completed.artifact_id
-            elif source.path is not None:
-                logger.warning(
-                    "Terminal evidence artifact service is unavailable; evidence "
-                    "remains run-scoped at %s",
-                    source.relative_path,
-                )
+            terminal_evidence_ref = await _persist_terminal_evidence_source(
+                source,
+                link_type="output.terminal_evidence",
+                labels=["agent_runtime", "output.terminal_evidence"],
+            )
+            if terminal_evidence_ref:
+                metadata["terminalContractEvidenceRef"] = terminal_evidence_ref
+
+        # A successful pr-resolver contract already requires the portable Skill
+        # to write its canonical publish_result.json companion. Preserve that
+        # exact file as the parent workflow's auto-publish evidence instead of
+        # forcing a second publisher to infer the merge from assistant prose.
+        if (
+            evaluation.satisfied
+            and metadata["terminalContractId"] == "pr_resolver_terminal.v1"
+            and metadata.get("mergeAutomationDisposition")
+            in {"merged", "already_merged"}
+        ):
+            publish_source = resolve_terminal_evidence_source(
+                {"relativePath": "artifacts/publish_result.json"},
+                workspace_path=workspace_path,
+                artifact_spool_path=artifact_spool_path,
+            )
+            publish_evidence_ref = await _persist_terminal_evidence_source(
+                publish_source,
+                link_type="output.publish_evidence",
+                labels=["agent_runtime", "output.publish_evidence"],
+            )
+            if publish_evidence_ref:
+                metadata["publishEvidence"] = publish_evidence_ref
 
         def _validated_result(update: Mapping[str, Any]) -> AgentRunResult:
             updated = result.model_copy(update=dict(update))

--- a/moonmind/workflows/temporal/remediation_tools.py
+++ b/moonmind/workflows/temporal/remediation_tools.py
@@ -18,7 +18,6 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select
 
 from api_service.db import models as db_models
-from api_service.services.omnigent_policies import OmnigentPolicyService, PolicyConflict
 from moonmind.omnigent.policies import (
     policy_authority_evidence,
     validate_policy_authority_evidence,
@@ -714,6 +713,14 @@ class RemediationEvidenceToolService:
             raise RemediationEvidenceToolError(
                 "Target run policy authority has no policyRef."
             )
+        # Keep the API service dependency at this side-effecting service
+        # boundary. Importing it while db.models registers workflow model
+        # dependencies creates a db.models -> workflow -> policy-service cycle.
+        from api_service.services.omnigent_policies import (
+            OmnigentPolicyService,
+            PolicyConflict,
+        )
+
         try:
             snapshot = await OmnigentPolicyService(
                 self._session

--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -2010,6 +2010,17 @@ class MoonMindAgentRun:
             or (request.workspace_spec or {}).get("workspacePath")
             or ""
         ).strip()
+        workspace_locator = (request.workspace_spec or {}).get("workspaceLocator")
+        workspace_owner_workflow_id = (
+            request.step_execution.workflow_id
+            if request.step_execution is not None
+            else request.correlation_id
+        )
+        workspace_owner_step_execution_id = (
+            request.step_execution.step_execution_id
+            if request.step_execution is not None
+            else request.idempotency_key
+        )
         async def _evaluate(candidate: AgentRunResult) -> AgentRunResult:
             payload = await self._execute_routed_activity(
                 "agent_runtime.evaluate_terminal_evidence",
@@ -2020,6 +2031,15 @@ class MoonMindAgentRun:
                         else str(self.run_id or "")
                     ),
                     "workspacePath": workspace_path,
+                    "workspaceLocator": (
+                        dict(workspace_locator)
+                        if isinstance(workspace_locator, Mapping)
+                        else None
+                    ),
+                    "workspaceOwnerWorkflowId": workspace_owner_workflow_id,
+                    "workspaceOwnerStepExecutionId": (
+                        workspace_owner_step_execution_id
+                    ),
                     "artifactSpoolPath": (
                         os.path.join(
                             _MANAGED_RUNTIME_STORE_ROOT,

--- a/moonmind/workflows/temporal/workflows/provider_profile_manager.py
+++ b/moonmind/workflows/temporal/workflows/provider_profile_manager.py
@@ -79,6 +79,9 @@ FRESH_START_DB_LEASE_RESTORE_PATCH = (
     "provider-profile-manager-fresh-start-db-lease-restore-v1"
 )
 DURABLE_LEASE_GRANT_PATCH = "provider-profile-manager-durable-lease-grant-v1"
+ACTIVITY_OWNED_LEASE_VERIFICATION_PATCH = (
+    "provider-profile-manager-activity-owned-lease-verification-v1"
+)
 
 # Deterministic sort sentinel for pending requests whose scheduled queue order
 # cannot be resolved (missing scheduled_for / created_at). ISO-8601 strings sort
@@ -657,6 +660,22 @@ class MoonMindProviderProfileManagerWorkflow:
 
     @workflow.update(name="AcquireSlot")
     async def acquire_slot(self, payload: SlotAcquirePayload) -> dict[str, Any]:
+        """Compatibility handler for Updates already present in workflow history."""
+
+        return await self._acquire_slot(payload, verify_activity_owner=False)
+
+    @workflow.update(name="AcquireSlotV2")
+    async def acquire_slot_v2(self, payload: SlotAcquirePayload) -> dict[str, Any]:
+        """Reserve capacity only while the Activity's parent workflow is live."""
+
+        return await self._acquire_slot(payload, verify_activity_owner=True)
+
+    async def _acquire_slot(
+        self,
+        payload: SlotAcquirePayload,
+        *,
+        verify_activity_owner: bool,
+    ) -> dict[str, Any]:
         """Reserve and return a slot without requiring a callback signal.
 
         Activity-owned workloads cannot receive ``slot_assigned``. This update
@@ -686,6 +705,8 @@ class MoonMindProviderProfileManagerWorkflow:
         lease_metadata = self._safe_lease_metadata(payload)
 
         while not self._shutdown_requested:
+            if verify_activity_owner:
+                await self._assert_activity_lease_owner_running(lease_metadata)
             existing_profile_id = self._profile_id_for_lease(requester_id)
             if existing_profile_id is not None:
                 return {
@@ -746,6 +767,36 @@ class MoonMindProviderProfileManagerWorkflow:
         raise exceptions.ApplicationError(
             "provider profile manager is shutting down", non_retryable=True
         )
+
+    async def _assert_activity_lease_owner_running(
+        self, lease_metadata: dict[str, Any]
+    ) -> None:
+        """Reject a late Activity-owned grant once its parent is terminal."""
+
+        if lease_metadata.get("ownerIsWorkflow") is not False:
+            return
+        owner_workflow_id = self._normalize_optional_string(
+            lease_metadata.get("workflowId")
+        )
+        if owner_workflow_id is None:
+            raise exceptions.ApplicationError(
+                "Activity-owned provider lease requires workflowId authority",
+                type="ProviderProfileLeaseOwnerMissing",
+                non_retryable=True,
+            )
+        statuses = await self._verify_workflow_statuses([owner_workflow_id])
+        if statuses is None:
+            raise exceptions.ApplicationError(
+                "Unable to verify provider lease owner workflow",
+                type="ProviderProfileLeaseOwnerVerificationFailed",
+            )
+        status = statuses.get(owner_workflow_id)
+        if status is not None and not status.get("running", True):
+            raise exceptions.ApplicationError(
+                "Provider lease owner workflow is terminal",
+                type="ProviderProfileLeaseOwnerTerminal",
+                non_retryable=True,
+            )
 
     @workflow.update(name="AcquireCredentialMaintenanceLease")
     async def acquire_credential_maintenance_lease(
@@ -983,10 +1034,14 @@ class MoonMindProviderProfileManagerWorkflow:
                 await self._sync_leases_to_db()
 
             verify_lease_holders = workflow.patched(VERIFY_LEASE_HOLDERS_PATCH)
+            verify_activity_owned_leases = workflow.patched(
+                ACTIVITY_OWNED_LEASE_VERIFICATION_PATCH
+            )
             verify_pending_requesters = workflow.patched(VERIFY_PENDING_REQUESTS_PATCH)
             if verify_lease_holders or verify_pending_requesters:
                 await self._verify_active_workflows(
                     verify_lease_holders=verify_lease_holders,
+                    verify_activity_owned_leases=verify_activity_owned_leases,
                     verify_pending_requesters=verify_pending_requesters,
                 )
 
@@ -1768,15 +1823,21 @@ class MoonMindProviderProfileManagerWorkflow:
                 )
         return total_evicted
 
-    def _lease_holder_workflow_ids(self) -> list[str]:
+    def _lease_holder_workflow_ids(
+        self, *, include_activity_owned: bool = False
+    ) -> list[str]:
         """Return unique workflow IDs that currently hold profile leases."""
         all_wf_ids: list[str] = []
         for profile in self._profiles.values():
             for lease_id in profile.current_leases:
                 metadata = profile.lease_metadata.get(lease_id) or {}
-                if metadata.get("ownerIsWorkflow") is False:
+                owner_is_workflow = metadata.get("ownerIsWorkflow") is not False
+                owner_workflow_id = str(metadata.get("workflowId") or "").strip()
+                if not owner_is_workflow and not include_activity_owned:
                     continue
-                all_wf_ids.append(str(metadata.get("workflowId") or lease_id))
+                if not owner_is_workflow and not owner_workflow_id:
+                    continue
+                all_wf_ids.append(owner_workflow_id or lease_id)
         return list(dict.fromkeys(all_wf_ids))
 
     def _pending_requester_workflow_ids(self) -> list[str]:
@@ -1824,7 +1885,10 @@ class MoonMindProviderProfileManagerWorkflow:
         return statuses
 
     def _reclaim_terminal_leases(
-        self, workflow_statuses: dict[str, dict[str, Any]]
+        self,
+        workflow_statuses: dict[str, dict[str, Any]],
+        *,
+        include_activity_owned: bool = False,
     ) -> bool:
         """Remove leases held by workflows that are in a terminal state."""
         reclaimed = False
@@ -1832,9 +1896,13 @@ class MoonMindProviderProfileManagerWorkflow:
         for profile in list(self._profiles.values()):
             for wf_id in list(profile.current_leases):
                 metadata = profile.lease_metadata.get(wf_id) or {}
-                if metadata.get("ownerIsWorkflow") is False:
+                owner_is_workflow = metadata.get("ownerIsWorkflow") is not False
+                owner_workflow_id = str(metadata.get("workflowId") or "").strip()
+                if not owner_is_workflow and not include_activity_owned:
                     continue
-                owner_workflow_id = str(metadata.get("workflowId") or wf_id)
+                if not owner_is_workflow and not owner_workflow_id:
+                    continue
+                owner_workflow_id = owner_workflow_id or wf_id
                 status_info = workflow_statuses.get(owner_workflow_id, {})
                 if not status_info.get("running", True):
                     profile.release(wf_id)
@@ -1874,12 +1942,17 @@ class MoonMindProviderProfileManagerWorkflow:
         self,
         *,
         verify_lease_holders: bool,
+        verify_activity_owned_leases: bool = False,
         verify_pending_requesters: bool,
     ) -> None:
         """Verify lease holders and pending requesters with one status pass."""
         workflow_ids: list[str] = []
         if verify_lease_holders:
-            workflow_ids.extend(self._lease_holder_workflow_ids())
+            workflow_ids.extend(
+                self._lease_holder_workflow_ids(
+                    include_activity_owned=verify_activity_owned_leases
+                )
+            )
         if verify_pending_requesters:
             workflow_ids.extend(self._pending_requester_workflow_ids())
 
@@ -1889,7 +1962,10 @@ class MoonMindProviderProfileManagerWorkflow:
 
         reclaimed = False
         if verify_lease_holders:
-            reclaimed = self._reclaim_terminal_leases(workflow_statuses)
+            reclaimed = self._reclaim_terminal_leases(
+                workflow_statuses,
+                include_activity_owned=verify_activity_owned_leases,
+            )
         if verify_pending_requesters:
             self._prune_terminal_pending_requesters(workflow_statuses)
 

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -18643,6 +18643,25 @@ class MoonMindRunWorkflow:
                 param_val = workflow_parameters.get(param_key)
             if param_val is not None:
                 parameters[param_key] = param_val
+        if self._workflow_patch_enabled(
+            RUN_AGENT_REQUIRED_CAPABILITIES_PROPAGATION_PATCH
+        ):
+            required_capabilities = parameters.get("requiredCapabilities")
+            nested_repository = workspace_spec.get("repository")
+            if (
+                isinstance(required_capabilities, list)
+                and any(
+                    str(capability).strip() == "gh"
+                    for capability in required_capabilities
+                )
+                and "repository" not in parameters
+                and nested_repository is not None
+            ):
+                # Mounted-tool authorization and workspace materialization must
+                # consume the same compiled repository identity. The Omnigent
+                # coordinator's gh preflight reads the compact parameters plane,
+                # while cloning remains owned by the workspace specification.
+                parameters["repository"] = nested_repository
         checkpoint_recovery = None
         if (
             self._recovery_failed_step_id == node_id

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -21,6 +21,10 @@ with workflow.unsafe.imports_passed_through():
         AUTO_RUNTIME_SENTINEL,
         AgentExecutionRequest,
     )
+    from moonmind.omnigent.stock_agents import (
+        CLAUDE_STOCK_AGENT_NAME,
+        CODEX_STOCK_AGENT_NAME,
+    )
     from api_service.services.provider_profile_readiness import (
         provider_profile_launch_ready_from_payload,
     )
@@ -654,6 +658,9 @@ RUN_MANAGED_CHECKPOINT_LOCATOR_GUARD_PATCH = (
 RUN_OMNIGENT_PREMATERIALIZATION_CHECKPOINT_GUARD_PATCH = (
     "run-omnigent-prematerialization-checkpoint-guard-v1"
 )
+RUN_OMNIGENT_SPLIT_SESSION_WORKSPACE_CHECKPOINT_PATCH = (
+    "run-omnigent-split-session-workspace-checkpoint-v1"
+)
 RUN_RUNTIME_EXECUTION_CAPABILITIES_PATCH = "run-runtime-execution-capabilities-v1"
 RUN_DURABLE_FINALIZATION_OUTCOME_PATCH = "run-durable-finalization-outcome-v1"
 RUN_SKIP_NO_PUBLISH_PREPUBLICATION_CHECKPOINT_PATCH = (
@@ -675,6 +682,12 @@ RUN_OMNIGENT_AUTHORED_SELECTION_COMPILER_PATCH = (
 )
 RUN_OMNIGENT_AGENT_PROFILE_SNAPSHOT_COMPILER_PATCH = (
     "run-omnigent-agent-profile-snapshot-compiler-v1"
+)
+RUN_OMNIGENT_STOCK_AGENT_IDENTITY_PATCH = (
+    "run-omnigent-stock-agent-identity-v1"
+)
+RUN_AGENT_REQUIRED_CAPABILITIES_PROPAGATION_PATCH = (
+    "run-agent-required-capabilities-propagation-v1"
 )
 RUN_ALREADY_IMPLEMENTED_JIRA_COMPLETION_PATCH = (
     "run-already-implemented-jira-completion-v1"
@@ -891,6 +904,9 @@ RUN_RESOLVED_SKILL_TERMINAL_CONTRACT_PATCH = (
 )
 RUN_EXISTING_SKILLSET_TERMINAL_CONTRACT_PATCH = (
     "run-existing-skillset-terminal-contract-v1"
+)
+RUN_EMPTY_AGENT_SKILLSET_SNAPSHOT_PATCH = (
+    "run-empty-agent-skillset-snapshot-v1"
 )
 RUN_PR_RESOLVER_SELECTOR_RESOLUTION_PATCH = (
     "run-pr-resolver-selector-resolution-v1"
@@ -5833,6 +5849,16 @@ class MoonMindRunWorkflow:
         capability_snapshot = outputs.get("runtimeCapabilities") or outputs.get(
             "runtime_capabilities"
         )
+        if not isinstance(capability_snapshot, Mapping):
+            # Provider result projections intentionally omit routing inputs such
+            # as agentId. Preserve the workflow-owned capability decision made
+            # before launch so a session checkpoint kind cannot be mistaken for
+            # the independently materialized workspace checkpoint kind.
+            previous_capability_snapshot = previous_capture.get(
+                "runtimeCapabilities"
+            ) or previous_capture.get("runtime_capabilities")
+            if isinstance(previous_capability_snapshot, Mapping):
+                capability_snapshot = previous_capability_snapshot
         try:
             capability_policy_enabled = workflow.patched(
                 RUN_RUNTIME_EXECUTION_CAPABILITIES_PATCH
@@ -5951,15 +5977,18 @@ class MoonMindRunWorkflow:
                 "externalStateRef",
                 "external_state_ref",
             )
+            if external_state_ref:
+                # Omnigent's external-state artifact belongs to the session
+                # plane. Keep it alongside the sandbox locator so the v2
+                # checkpoint can attest both independent authorities.
+                capture_input["externalStateRef"] = external_state_ref
             if isinstance(workspace_locator, Mapping):
                 capture_input["workspaceLocator"] = dict(workspace_locator)
             elif workspace_path:
                 capture_input["workspacePath"] = workspace_path
             elif workspace_root_ref:
                 capture_input["workspaceRootRef"] = workspace_root_ref
-            elif external_state_ref:
-                capture_input["externalStateRef"] = external_state_ref
-            else:
+            elif not external_state_ref:
                 continue
 
             base_commit = self._checkpoint_capture_text(
@@ -5970,15 +5999,38 @@ class MoonMindRunWorkflow:
             if base_commit:
                 capture_input["baseCommit"] = base_commit
 
-            checkpoint_kind = self._checkpoint_capture_text(
+            workspace_checkpoint_kind = self._checkpoint_capture_text(
                 candidate,
-                "checkpointKind",
-                "checkpoint_kind",
                 "workspaceCheckpointKind",
                 "workspace_checkpoint_kind",
             )
+            checkpoint_kind = workspace_checkpoint_kind or self._checkpoint_capture_text(
+                candidate,
+                "checkpointKind",
+                "checkpoint_kind",
+            )
             if checkpoint_kind:
-                capture_input["kind"] = checkpoint_kind
+                session_kinds = (
+                    set(capabilities.session_state.checkpoint_kinds)
+                    if capabilities is not None
+                    and capabilities.session_state is not None
+                    else set()
+                )
+                is_omnigent_session_kind = (
+                    capabilities is not None
+                    and capabilities.runtime_id == "omnigent"
+                    and workspace_checkpoint_kind is None
+                    and checkpoint_kind in session_kinds
+                    and checkpoint_kind
+                    not in capabilities.checkpoint_capture_kinds
+                )
+                if not (
+                    is_omnigent_session_kind
+                    and workflow.patched(
+                        RUN_OMNIGENT_SPLIT_SESSION_WORKSPACE_CHECKPOINT_PATCH
+                    )
+                ):
+                    capture_input["kind"] = checkpoint_kind
             elif capabilities is None and (
                 capability_policy_enabled
                 or self._step_external_agent_ids.get(logical_step_id) != "omnigent"
@@ -6227,11 +6279,39 @@ class MoonMindRunWorkflow:
             **self._execute_kwargs_for_route(route),
         )
         if not isinstance(result, Mapping):
+            self._step_checkpoint_capture_outcomes[logical_step_id] = {
+                "status": "failed",
+                "failureCode": "CHECKPOINT_RESULT_INVALID",
+                "boundary": str(boundary),
+                "captureAuthority": resolved_policy.capture_authority,
+                "captureActivity": resolved_policy.capture_activity,
+                "capabilityCriticality": resolved_policy.criticality,
+            }
             return None
         if result.get("status") != "captured":
+            self._step_checkpoint_capture_outcomes[logical_step_id] = {
+                "status": str(result.get("status") or "failed"),
+                "failureCode": self._coerce_text(
+                    result.get("failureCode"), max_chars=100
+                )
+                or "CHECKPOINT_CAPTURE_FAILED",
+                "boundary": str(boundary),
+                "captureAuthority": resolved_policy.capture_authority,
+                "captureActivity": resolved_policy.capture_activity,
+                "capabilityCriticality": resolved_policy.criticality,
+                "summary": self._coerce_text(result.get("summary"), max_chars=500),
+            }
             return None
         workspace_evidence = result.get("workspace")
         if not isinstance(workspace_evidence, Mapping):
+            self._step_checkpoint_capture_outcomes[logical_step_id] = {
+                "status": "failed",
+                "failureCode": "CHECKPOINT_WORKSPACE_EVIDENCE_MISSING",
+                "boundary": str(boundary),
+                "captureAuthority": resolved_policy.capture_authority,
+                "captureActivity": resolved_policy.capture_activity,
+                "capabilityCriticality": resolved_policy.criticality,
+            }
             return None
         if workspace_evidence.get("kind") == "ephemeral_workspace_ref":
             return None
@@ -6477,6 +6557,9 @@ class MoonMindRunWorkflow:
                 "after-execution checkpoint."
             )
             self._attention_required = criticality == "required"
+            if criticality == "required":
+                self._publish_status = "failed"
+                self._publish_reason = self._summary
             self._update_memo()
             return
         capture_outcome = self._step_checkpoint_capture_outcomes.get(logical_step_id)
@@ -6493,17 +6576,43 @@ class MoonMindRunWorkflow:
             failure_code = self._coerce_text(
                 capture_outcome.get("failureCode"), max_chars=100
             )
+            capture_status = str(capture_outcome.get("status") or "").strip()
+            finalization_status = "unsupported"
+            if capture_status not in {"unsupported", "deferred"}:
+                finalization_status = (
+                    "degraded" if criticality == "recoverability_only" else "failed"
+                )
             row["finalizationOutcome"] = {
-                "status": "unsupported",
+                "status": finalization_status,
                 "phase": "after_execution_checkpoint",
                 "criticality": criticality,
                 "failureCode": failure_code,
-                "terminalFailureCode": None,
+                "terminalFailureCode": (
+                    FINALIZATION_RETRY_EXHAUSTED
+                    if finalization_status == "failed"
+                    else None
+                ),
                 "retryCount": 0,
                 "checkpointRef": None,
-                "message": "Checkpoint capture is unsupported by this runtime.",
+                "message": (
+                    self._coerce_text(capture_outcome.get("summary"), max_chars=500)
+                    or (
+                        "Required checkpoint capture failed."
+                        if finalization_status == "failed"
+                        else "Checkpoint capture is unsupported by this runtime."
+                    )
+                ),
                 "updatedAt": updated_at.isoformat(),
             }
+            if finalization_status == "failed":
+                self._publish_status = "failed"
+                self._publish_reason = (
+                    "Execution succeeded, but its required after-execution "
+                    "workspace checkpoint failed."
+                )
+                self._summary = self._publish_reason
+                self._attention_required = True
+                self._update_memo()
             return
         row["finalizationOutcome"] = {
             "status": "succeeded" if checkpoint_ref else "unsupported",
@@ -18030,9 +18139,6 @@ class MoonMindRunWorkflow:
             task_skills,
             node_skills if node_skills is not None else node_inputs.get("skills"),
         )
-        if effective is None and not selected_skill:
-            return None
-
         effective_payload = (
             effective.model_dump(mode="json", exclude_none=True)
             if effective is not None
@@ -18061,7 +18167,14 @@ class MoonMindRunWorkflow:
                 effective_payload["include"] = include
 
         selector = SkillSelector.model_validate(effective_payload)
-        if not selector.sets and not selector.include and not selector.exclude:
+        if (
+            not selector.sets
+            and not selector.include
+            and not selector.exclude
+            and not self._workflow_patch_enabled(
+                RUN_EMPTY_AGENT_SKILLSET_SNAPSHOT_PATCH
+            )
+        ):
             return None
 
         route = DEFAULT_ACTIVITY_CATALOG.resolve_activity("agent_skill.resolve")
@@ -18484,7 +18597,7 @@ class MoonMindRunWorkflow:
                 workspace_spec[ws_key] = ws_val
 
         parameters: dict[str, Any] = {}
-        for param_key in (
+        parameter_keys = (
             "model",
             "requestedModel",
             "modelTier",
@@ -18513,7 +18626,16 @@ class MoonMindRunWorkflow:
             "repository",
             "tenant",
             "tenantId",
+        )
+        if self._workflow_patch_enabled(
+            RUN_AGENT_REQUIRED_CAPABILITIES_PROPAGATION_PATCH
         ):
+            # Capability requirements are authored workflow/step authority. They
+            # must reach the runtime request so mounted-tool preflight and the
+            # provider adapter enforce the same contract that admission accepted.
+            # Gate the new Activity payload field for replaying histories.
+            parameter_keys = (*parameter_keys, "requiredCapabilities")
+        for param_key in parameter_keys:
             param_val = runtime_block.get(param_key)
             if param_val is None:
                 param_val = node_inputs.get(param_key)
@@ -18601,8 +18723,23 @@ class MoonMindRunWorkflow:
                     snapshot.get("agentName") or snapshot.get("agent_name"),
                     max_chars=255,
                 )
-                if not profile_agent_name and snapshot.get("runtime_id") == "codex_cli":
-                    profile_agent_name = "codex"
+                runtime_id = snapshot.get("runtime_id")
+                if not profile_agent_name and runtime_id == "codex_cli":
+                    profile_agent_name = (
+                        CODEX_STOCK_AGENT_NAME
+                        if self._workflow_patch_enabled(
+                            RUN_OMNIGENT_STOCK_AGENT_IDENTITY_PATCH
+                        )
+                        else "codex"
+                    )
+                elif (
+                    not profile_agent_name
+                    and runtime_id == "claude_code"
+                    and self._workflow_patch_enabled(
+                        RUN_OMNIGENT_STOCK_AGENT_IDENTITY_PATCH
+                    )
+                ):
+                    profile_agent_name = CLAUDE_STOCK_AGENT_NAME
                 if profile_agent_name:
                     omnigent_parameters = (
                         dict(parameters.get("omnigent"))

--- a/services/omnigent/scripts/start-codex-oauth-host.sh
+++ b/services/omnigent/scripts/start-codex-oauth-host.sh
@@ -8,6 +8,34 @@ server=${OMNIGENT_SERVER_URL:-http://omnigent:8000}
 [ -n "$expected_generation" ] || { echo "credential generation is required" >&2; exit 64; }
 printf '%s\n' "$expected_generation" > "$state_root/credential-generation"
 
+# The native Codex app-server intentionally filters token-shaped environment
+# variables before it starts.  Materialize gh's standard config in the
+# lease-owned cache volume instead, then remove the raw token before Omnigent
+# can spawn a runner.  XDG_CONFIG_HOME is a non-secret path selector that the
+# stock host and Codex both preserve; the cache volume is destroyed with this
+# on-demand host and is outside the captured repository workspace.
+github_token=${GH_TOKEN:-}
+if [ -n "$github_token" ]; then
+  case "$github_token" in
+    *[!A-Za-z0-9_]*)
+      echo "GitHub credential contains unsupported characters" >&2
+      exit 64
+      ;;
+  esac
+  github_config_home=${XDG_CONFIG_HOME:-/home/app/.cache/moonmind-xdg}
+  github_config_dir=$github_config_home/gh
+  github_config_tmp=$github_config_dir/hosts.yml.tmp.$$
+  umask 077
+  mkdir -p "$github_config_dir"
+  {
+    printf 'github.com:\n'
+    printf '    oauth_token: %s\n' "$github_token"
+    printf '    git_protocol: https\n'
+  } > "$github_config_tmp"
+  mv "$github_config_tmp" "$github_config_dir/hosts.yml"
+fi
+unset github_token GH_TOKEN GIT_TOKEN GITHUB_TOKEN
+
 until /opt/moonmind/check-codex-oauth-host.sh; do
   echo "Codex OAuth host waiting for authenticated credentials" >&2
   sleep 5

--- a/tests/helpers/omnigent_conformance.py
+++ b/tests/helpers/omnigent_conformance.py
@@ -129,7 +129,7 @@ class FakeOmnigentServer:
     def app(self) -> web.Application:
         app = web.Application()
         app.router.add_get("/v1/agents", self.list_agents)
-        app.router.add_get("/api/hosts", self.list_hosts)
+        app.router.add_get("/v1/hosts", self.list_hosts)
         app.router.add_post("/v1/sessions", self.create_session)
         app.router.add_get("/v1/sessions/{session_id}", self.get_session)
         app.router.add_post("/v1/sessions/{session_id}/events", self.post_event)

--- a/tests/integration/reliability/replays/agent-workspaces-daemon-root/expected-outcome.json
+++ b/tests/integration/reliability/replays/agent-workspaces-daemon-root/expected-outcome.json
@@ -1,0 +1,5 @@
+{
+  "invariant": "the worker remote-daemon root and the Compose named volume derive from the same operator-configurable volume identity",
+  "volumeNameTemplate": "${MOONMIND_AGENT_WORKSPACES_VOLUME_NAME:-agent_workspaces}",
+  "daemonRootTemplate": "${WORKFLOW_WORKSPACE_DAEMON_ROOT:-/var/lib/docker/volumes/${MOONMIND_AGENT_WORKSPACES_VOLUME_NAME:-agent_workspaces}/_data}"
+}

--- a/tests/integration/reliability/replays/agent-workspaces-daemon-root/manifest.json
+++ b/tests/integration/reliability/replays/agent-workspaces-daemon-root/manifest.json
@@ -1,0 +1,8 @@
+{
+  "incidentWorkflowId": "mm:cdf36806-9cab-4a7c-8d86-de568fd02c07",
+  "incidentRunId": "019fd33f-6be5-77e0-9728-8ecfcb535c3c",
+  "failedChildWorkflowId": "mm:cdf36806-9cab-4a7c-8d86-de568fd02c07:agent:node-1",
+  "failedChildRunId": "019fd33f-90ac-7537-89f7-65a56f6504ce",
+  "failureShape": "the agent-runtime worker mapped bind paths through a Compose-generated volume name even though Compose creates the explicitly named agent_workspaces volume",
+  "boundary": "Compose named-volume identity to remote Docker daemon bind source"
+}

--- a/tests/integration/reliability/replays/omnigent-abandoned-provider-lease/expected-outcome.json
+++ b/tests/integration/reliability/replays/omnigent-abandoned-provider-lease/expected-outcome.json
@@ -1,0 +1,7 @@
+{
+  "releaseOrder": [
+    "provider_released",
+    "host_lease_stopped"
+  ],
+  "providerLeaseReleased": true
+}

--- a/tests/integration/reliability/replays/omnigent-abandoned-provider-lease/manifest.json
+++ b/tests/integration/reliability/replays/omnigent-abandoned-provider-lease/manifest.json
@@ -1,0 +1,7 @@
+{
+  "incidentWorkflowId": "mm:651a14f6-ff53-43e9-a91b-b37ad276f9ef",
+  "failureShape": "a canceled or worker-terminated profile-bound Activity left its host and ProviderProfileManager slot leased, so an exact rerun waited until the 90-minute safety expiry",
+  "hostLeaseRef": "ohl_replay_abandoned",
+  "providerProfileId": "codex_openai_oauth",
+  "providerLeaseRef": "profile-lease:execution_omnigent:replay"
+}

--- a/tests/integration/reliability/replays/omnigent-active-host-lease-heartbeat/expected-outcome.json
+++ b/tests/integration/reliability/replays/omnigent-active-host-lease-heartbeat/expected-outcome.json
@@ -1,0 +1,5 @@
+{
+  "invariant": "the execution owner renews its host lease until provider execution reaches terminal state",
+  "leaseTtlSeconds": 5400,
+  "terminalSummary": "completed"
+}

--- a/tests/integration/reliability/replays/omnigent-active-host-lease-heartbeat/manifest.json
+++ b/tests/integration/reliability/replays/omnigent-active-host-lease-heartbeat/manifest.json
@@ -1,0 +1,9 @@
+{
+  "incidentWorkflowId": "mm:f2400165-4a1d-4277-a702-fe17d2045a4e",
+  "incidentRunId": "019fd3b6-67a9-7da3-b221-1bbca8e23948",
+  "failedChildWorkflowId": "mm:f2400165-4a1d-4277-a702-fe17d2045a4e:agent:node-1",
+  "failedChildRunId": "019fd3b6-827a-7da7-a40d-97016a06e0fd",
+  "hostLeaseRef": "ohl_7629c49b09bc2737dbf208a6c5a8a03b",
+  "failureShape": "a healthy long-running native Codex turn outlived the host lease's 90-second heartbeat window, so the scheduled janitor interrupted the session and removed its runner",
+  "boundary": "profile-bound provider execution to durable OAuth host lease janitor"
+}

--- a/tests/integration/reliability/replays/omnigent-auto-skill-projection/expected-outcome.json
+++ b/tests/integration/reliability/replays/omnigent-auto-skill-projection/expected-outcome.json
@@ -1,0 +1,4 @@
+{
+  "invariant": "every agent step carries an immutable resolved skill snapshot, including an empty snapshot when selectedSkill is the auto sentinel",
+  "resolvedSkillsetRef": "artifact://skillsets/mm-717ea339-node-1-empty"
+}

--- a/tests/integration/reliability/replays/omnigent-auto-skill-projection/manifest.json
+++ b/tests/integration/reliability/replays/omnigent-auto-skill-projection/manifest.json
@@ -1,0 +1,28 @@
+{
+  "incidentWorkflowId": "mm:717ea339-77ab-4e72-bd46-969b009b5508",
+  "incidentRunId": "019fd32f-cbfd-7846-bee9-79c87ebae5f8",
+  "failedChildWorkflowId": "mm:717ea339-77ab-4e72-bd46-969b009b5508:agent:node-1",
+  "failedChildRunId": "019fd32f-cf81-7df9-952b-8bd89d8de08a",
+  "failureShape": "an auto-selected agent step launched Omnigent without a resolvedSkillsetRef and failed host preparation before mutation",
+  "boundary": "MoonMind.UserWorkflow parent request compilation to MoonMind.AgentRun",
+  "ownerId": "owner-replay",
+  "logicalStepId": "node-1",
+  "nodeInputs": {
+    "runtime": {
+      "mode": "omnigent",
+      "executionProfileRef": "codex_openai_oauth"
+    },
+    "selectedSkill": "auto"
+  },
+  "resolvedSkillSet": {
+    "snapshotId": "skillset_mm-717ea339_node-1",
+    "resolvedAt": "2026-08-05T12:00:00Z",
+    "manifestRef": "artifact://skillsets/mm-717ea339-node-1-empty",
+    "skills": [],
+    "resolutionInputs": {
+      "sets": [],
+      "include": [],
+      "exclude": []
+    }
+  }
+}

--- a/tests/integration/reliability/replays/omnigent-canceled-host-rerun-admission/expected-outcome.json
+++ b/tests/integration/reliability/replays/omnigent-canceled-host-rerun-admission/expected-outcome.json
@@ -1,0 +1,7 @@
+{
+  "invariant": "a rerun waits at the host admission gate until cancellation cleanup releases the selected Provider Profile's active host lease",
+  "busyCode": "OMNIGENT_OAUTH_HOST_PROFILE_BUSY",
+  "remediationAction": "wait_for_host_cleanup",
+  "rawDatabaseErrorEscapes": false,
+  "rerunAdmittedAfterCleanup": true
+}

--- a/tests/integration/reliability/replays/omnigent-canceled-host-rerun-admission/manifest.json
+++ b/tests/integration/reliability/replays/omnigent-canceled-host-rerun-admission/manifest.json
@@ -1,0 +1,8 @@
+{
+  "incidentWorkflowId": "mm:c702174c-8d5c-4ef0-98c1-cfeb39f5be6b",
+  "incidentRunId": "019fd51e-318d-7b61-8608-ec37cb27366e",
+  "priorCanceledWorkflowId": "mm:c87a87d4-e23f-4aa0-b854-5aba03c9e56e",
+  "providerProfileId": "codex_openai_oauth",
+  "failureConstraint": "ux_omnigent_oauth_host_lease_active_profile",
+  "failureShape": "an immediate rerun acquired Provider Profile capacity while the canceled run's host lease still awaited janitor cleanup, then surfaced the database uniqueness violation"
+}

--- a/tests/integration/reliability/replays/omnigent-capability-authority-handoff/expected-outcome.json
+++ b/tests/integration/reliability/replays/omnigent-capability-authority-handoff/expected-outcome.json
@@ -1,0 +1,5 @@
+{
+  "invariant": "required capability authority reaches runtime preflight and the provider adapter without being re-derived",
+  "terminalLaunchArgs": [],
+  "replayGate": "run-agent-required-capabilities-propagation-v1"
+}

--- a/tests/integration/reliability/replays/omnigent-capability-authority-handoff/manifest.json
+++ b/tests/integration/reliability/replays/omnigent-capability-authority-handoff/manifest.json
@@ -1,0 +1,8 @@
+{
+  "incidentWorkflowId": "mm:8a8955a6-df41-423d-be91-efdf41346707",
+  "incidentRunId": "019fd527-00fd-7b73-847b-3e1fc7eb28a1",
+  "providerProfileId": "codex_openai_oauth",
+  "agentName": "codex-native-ui",
+  "requiredCapabilities": ["git", "gh"],
+  "failureShape": "workflow-level requiredCapabilities were admitted but omitted from the AgentExecutionRequest parameters, so the Codex adapter could not preserve GitHub authentication in model-authored shell commands"
+}

--- a/tests/integration/reliability/replays/omnigent-codex-remote-loopback/expected-outcome.json
+++ b/tests/integration/reliability/replays/omnigent-codex-remote-loopback/expected-outcome.json
@@ -1,0 +1,8 @@
+{
+  "invariant": "the native Codex loopback WebSocket bypasses the proxy while every non-loopback destination remains proxy-enforced",
+  "noProxy": "localhost,127.0.0.1",
+  "loopbackHosts": [
+    "localhost",
+    "127.0.0.1"
+  ]
+}

--- a/tests/integration/reliability/replays/omnigent-codex-remote-loopback/manifest.json
+++ b/tests/integration/reliability/replays/omnigent-codex-remote-loopback/manifest.json
@@ -1,0 +1,10 @@
+{
+  "incidentWorkflowId": "mm:b99b4a69-18fa-4c6a-abdf-96cf987466a2",
+  "incidentRunId": "019fd39e-193b-71db-a61a-5d11b904ca74",
+  "failedChildWorkflowId": "mm:b99b4a69-18fa-4c6a-abdf-96cf987466a2:agent:node-1",
+  "omnigentSessionId": "db98700ed632447092d9216e12ece95f",
+  "failureShape": "the stock Codex app server was listening on loopback, but the native TUI sent its local WebSocket through the restricted-egress proxy and exited before creating bridge state",
+  "boundary": "isolated Omnigent runner Codex TUI to same-container app server",
+  "codexRemoteUrl": "ws://127.0.0.1:39001",
+  "omnigentServerHost": "omnigent"
+}

--- a/tests/integration/reliability/replays/omnigent-egress-attestation-command/expected-outcome.json
+++ b/tests/integration/reliability/replays/omnigent-egress-attestation-command/expected-outcome.json
@@ -1,0 +1,11 @@
+{
+  "invariant": "the OAuth host adapter translates attestation subcommands into complete Docker CLI invocations before crossing the process boundary",
+  "runtimeCommand": [
+    "docker",
+    "network",
+    "inspect",
+    "--format",
+    "{{json .}}",
+    "moonmind_omnigent-egress-network"
+  ]
+}

--- a/tests/integration/reliability/replays/omnigent-egress-attestation-command/manifest.json
+++ b/tests/integration/reliability/replays/omnigent-egress-attestation-command/manifest.json
@@ -1,0 +1,17 @@
+{
+  "incidentWorkflowId": "mm:706d05e2-3fec-4462-82c0-b0cbc5e0e687",
+  "incidentRunId": "019fd336-dc81-79c4-a3d0-0c7ef12daca2",
+  "failedChildWorkflowId": "mm:706d05e2-3fec-4462-82c0-b0cbc5e0e687:agent:node-1",
+  "failedChildRunId": "019fd336-e4b3-7f16-8c20-b83ad7e2423f",
+  "failureShape": "OAuth host egress attestation passed a Docker subcommand directly to the process runner, which attempted to execute a nonexistent binary named network",
+  "boundary": "OmnigentOAuthHostRuntime to trusted Docker command runner",
+  "networkRef": "moonmind_omnigent-egress-network",
+  "backendRef": "omnigent-host-runtime",
+  "attestationSubcommand": [
+    "network",
+    "inspect",
+    "--format",
+    "{{json .}}",
+    "moonmind_omnigent-egress-network"
+  ]
+}

--- a/tests/integration/reliability/replays/omnigent-host-entrypoint-env-order/expected-outcome.json
+++ b/tests/integration/reliability/replays/omnigent-host-entrypoint-env-order/expected-outcome.json
@@ -1,0 +1,6 @@
+{
+  "invariant": "the immutable host image terminates Docker option parsing before /usr/bin/env receives any -u arguments",
+  "entrypoint": "/usr/bin/env",
+  "firstUnsetVariable": "OPENAI_API_KEY",
+  "startScript": "/opt/moonmind/start-codex-oauth-host.sh"
+}

--- a/tests/integration/reliability/replays/omnigent-host-entrypoint-env-order/manifest.json
+++ b/tests/integration/reliability/replays/omnigent-host-entrypoint-env-order/manifest.json
@@ -1,0 +1,9 @@
+{
+  "incidentWorkflowId": "mm:e96347f3-a5ea-427a-ba09-c6d5c17535a1",
+  "incidentRunId": "019fd344-bf68-77eb-9ddb-960280cee696",
+  "failedChildWorkflowId": "mm:e96347f3-a5ea-427a-ba09-c6d5c17535a1:agent:node-1",
+  "failedChildRunId": "019fd344-c6ae-751b-95f4-2330d7dfc699",
+  "failureShape": "the on-demand host command placed /usr/bin/env -u arguments before the image, so Docker parsed OPENAI_API_KEY as the container user",
+  "boundary": "Docker run options to container entrypoint arguments",
+  "hostImageRef": "registry.example/omnigent-host@sha256:2222222222222222222222222222222222222222222222222222222222222222"
+}

--- a/tests/integration/reliability/replays/omnigent-host-login-tools-path/expected-outcome.json
+++ b/tests/integration/reliability/replays/omnigent-host-login-tools-path/expected-outcome.json
@@ -1,0 +1,5 @@
+{
+  "invariant": "on-demand and static OAuth hosts mount the same portable profile.d script so login shells retain the mounted tool path",
+  "sourceName": "moonmind-tools.sh",
+  "containerPath": "/etc/profile.d/moonmind-tools.sh"
+}

--- a/tests/integration/reliability/replays/omnigent-host-login-tools-path/manifest.json
+++ b/tests/integration/reliability/replays/omnigent-host-login-tools-path/manifest.json
@@ -1,0 +1,9 @@
+{
+  "incidentWorkflowId": "mm:38c72f91-360d-4f59-aae2-84318768eb15",
+  "incidentRunId": "019fd349-1ad7-797a-89b8-3feedf2afc3b",
+  "failedChildWorkflowId": "mm:38c72f91-360d-4f59-aae2-84318768eb15:agent:node-1",
+  "failedChildRunId": "019fd349-2aa8-7993-9d06-c11f5497e0b4",
+  "failureShape": "the on-demand host mounted gh under /opt but omitted the profile.d script, so login shells reset PATH and returned 127 for gh",
+  "boundary": "mounted tool bundle to login-shell PATH",
+  "hostImageRef": "registry.example/omnigent-host@sha256:2222222222222222222222222222222222222222222222222222222222222222"
+}

--- a/tests/integration/reliability/replays/omnigent-host-registration-long-publication/expected-outcome.json
+++ b/tests/integration/reliability/replays/omnigent-host-registration-long-publication/expected-outcome.json
@@ -1,0 +1,7 @@
+{
+  "invariant": "exact host resolution covers the observed catalog propagation tail while retaining deterministic name and online-status checks",
+  "hostId": "host-long-publication-replay",
+  "catalogReadCount": 41,
+  "sleepCount": 40,
+  "sleepSeconds": 2
+}

--- a/tests/integration/reliability/replays/omnigent-host-registration-long-publication/manifest.json
+++ b/tests/integration/reliability/replays/omnigent-host-registration-long-publication/manifest.json
@@ -1,0 +1,9 @@
+{
+  "incidentWorkflowId": "mm:e8ca7030-2c79-4cf3-923d-dd40994606c1",
+  "incidentRunId": "019fd3e1-16e2-70d4-9b27-1b6f49d7ac1f",
+  "failedChildWorkflowId": "mm:e8ca7030-2c79-4cf3-923d-dd40994606c1:agent:node-1:execution3:retry2",
+  "failureShape": "the on-demand container became healthy but stock host-catalog publication remained offline beyond one minute on a later activity attempt",
+  "boundary": "healthy on-demand host to stock host-catalog publication",
+  "emptyCatalogReads": 40,
+  "containerName": "mm-omnigent-host-ohld921e095d61a95f0b3801b46b06d5284"
+}

--- a/tests/integration/reliability/replays/omnigent-host-registration-publication/expected-outcome.json
+++ b/tests/integration/reliability/replays/omnigent-host-registration-publication/expected-outcome.json
@@ -1,0 +1,7 @@
+{
+  "invariant": "exact host resolution tolerates bounded catalog publication latency without weakening deterministic lease identity",
+  "hostId": "host-stock-replay",
+  "catalogReadCount": 3,
+  "sleepCount": 2,
+  "sleepSeconds": 2
+}

--- a/tests/integration/reliability/replays/omnigent-host-registration-publication/manifest.json
+++ b/tests/integration/reliability/replays/omnigent-host-registration-publication/manifest.json
@@ -1,0 +1,10 @@
+{
+  "incidentWorkflowId": "mm:963a26ba-ea91-4c82-b6b3-59ff423e9d6d",
+  "incidentRunId": "019fd35b-7abd-7a01-aef0-c10f5faa8c65",
+  "failedChildWorkflowId": "mm:963a26ba-ea91-4c82-b6b3-59ff423e9d6d:agent:node-1",
+  "failedChildRunId": "019fd35b-8783-7bb5-a15c-cf8aca358a33",
+  "failureShape": "the host process had started connecting under its deterministic hostname, but MoonMind read the catalog once before registration publication and tore the host down",
+  "boundary": "on-demand host process connection to stock host-catalog publication",
+  "catalogSequence": [[], [], ["host-stock-replay"]],
+  "containerName": "mm-omnigent-host-ohlb873403abd6789da8b8b5e5d92fdc087"
+}

--- a/tests/integration/reliability/replays/omnigent-host-server-network-reachability/expected-outcome.json
+++ b/tests/integration/reliability/replays/omnigent-host-server-network-reachability/expected-outcome.json
@@ -1,0 +1,5 @@
+{
+  "invariant": "the trusted Omnigent server is reachable from isolated hosts without giving hosts general local-network access",
+  "serverNetworks": ["local-network", "omnigent-egress-network"],
+  "hostNetworks": ["omnigent-egress-network"]
+}

--- a/tests/integration/reliability/replays/omnigent-host-server-network-reachability/manifest.json
+++ b/tests/integration/reliability/replays/omnigent-host-server-network-reachability/manifest.json
@@ -1,0 +1,8 @@
+{
+  "incidentWorkflowId": "mm:89e60946-953c-440a-bae7-cf6694e7f4cd",
+  "incidentRunId": "019fd35f-e1ed-73f2-afbd-8a4c497b942e",
+  "failedChildWorkflowId": "mm:89e60946-953c-440a-bae7-cf6694e7f4cd:agent:node-1",
+  "failedChildRunId": "019fd35f-f4f7-747e-b815-00c6f0dfd50e",
+  "failureShape": "the on-demand host was isolated on omnigent-egress-network while the Omnigent server was attached only to local-network, so the host tunnel could not resolve omnigent",
+  "boundary": "isolated on-demand host network to trusted Omnigent server tunnel"
+}

--- a/tests/integration/reliability/replays/omnigent-hybrid-checkpoint-planes/expected-outcome.json
+++ b/tests/integration/reliability/replays/omnigent-hybrid-checkpoint-planes/expected-outcome.json
@@ -1,0 +1,8 @@
+{
+  "invariant": "Omnigent external-state evidence and sandbox workspace evidence remain independent planes in the same v2 checkpoint",
+  "sessionCheckpointKind": "external_state_ref",
+  "workspaceCheckpointKind": "worktree_archive",
+  "workspaceAuthority": "moonmind_sandbox",
+  "captureActivity": "workspace.capture_checkpoint",
+  "checkpointCreateActivity": "step_checkpoint.create_v2"
+}

--- a/tests/integration/reliability/replays/omnigent-hybrid-checkpoint-planes/manifest.json
+++ b/tests/integration/reliability/replays/omnigent-hybrid-checkpoint-planes/manifest.json
@@ -1,0 +1,27 @@
+{
+  "incidentWorkflowId": "mm:595b687c-c611-4e85-8276-d71c5c6fd369",
+  "incidentRunId": "019fd38b-45bd-7b8d-865c-b3bca65c19da",
+  "failedChildWorkflowId": "mm:595b687c-c611-4e85-8276-d71c5c6fd369:agent:node-1",
+  "failedChildRunId": "019fd38b-5b22-7460-ac37-c6ea392c004a",
+  "reproductionWorkflowId": "mm:b72aad73-63bd-47ed-9412-e0a50c894227",
+  "reproductionRunId": "019fd3a9-79cf-72be-bde3-76032efb4b92",
+  "omnigentSessionId": "df52056b61994593a75874cbebbbc040",
+  "externalStateRef": "artifact://omnigent/replay/checkpoint.omnigent.external_state.json",
+  "initialInputs": {
+    "targetRuntime": "omnigent"
+  },
+  "resultOutputs": {
+    "workspaceLocator": {
+      "kind": "sandbox",
+      "workspaceId": "workspace-replay",
+      "relativePath": "repo"
+    },
+    "externalStateRef": "artifact://omnigent/replay/checkpoint.omnigent.external_state.json",
+    "checkpointKind": "external_state_ref",
+    "omnigentCheckpointCapture": {
+      "externalStateRef": "artifact://omnigent/replay/checkpoint.omnigent.external_state.json"
+    }
+  },
+  "failureShape": "the Omnigent result's session-plane external_state_ref overwrote the workspace checkpoint kind, so sandbox capture rejected it instead of archiving the materialized worktree",
+  "boundary": "Omnigent terminal evidence to canonical Step Execution checkpoint capture"
+}

--- a/tests/integration/reliability/replays/omnigent-injected-client-timeout-contract/expected-outcome.json
+++ b/tests/integration/reliability/replays/omnigent-injected-client-timeout-contract/expected-outcome.json
@@ -1,0 +1,15 @@
+{
+  "invariant": "injected HTTP clients use MoonMind's bounded request timeout and unbounded SSE read timeout",
+  "requestTimeout": {
+    "connect": 60.0,
+    "read": 60.0,
+    "write": 60.0,
+    "pool": 60.0
+  },
+  "streamTimeout": {
+    "connect": 60.0,
+    "read": null,
+    "write": 60.0,
+    "pool": 60.0
+  }
+}

--- a/tests/integration/reliability/replays/omnigent-injected-client-timeout-contract/manifest.json
+++ b/tests/integration/reliability/replays/omnigent-injected-client-timeout-contract/manifest.json
@@ -1,0 +1,11 @@
+{
+  "incidentWorkflowId": "mm:64c19951-29b7-4bf9-8962-ccaf5a8494df",
+  "incidentRunId": "019fd364-107a-7bde-a929-30f5d20c87db",
+  "failedChildWorkflowId": "mm:64c19951-29b7-4bf9-8962-ccaf5a8494df:agent:node-1",
+  "failedChildRunId": "019fd364-1978-785e-9d05-e09750b22630",
+  "omnigentSessionId": "6bbdd1e661c649ebbd59c20582283581",
+  "sessionId": "session-replay",
+  "requestTimeoutSeconds": 60.0,
+  "failureShape": "an injected default httpx client replaced MoonMind's request and SSE timeout contract, timed out during native terminal bootstrap, and cleanup disconnected the live host and runner",
+  "boundary": "MoonMind Omnigent adapter to injected HTTP transport"
+}

--- a/tests/integration/reliability/replays/omnigent-lifecycle-dedup-retry/expected-outcome.json
+++ b/tests/integration/reliability/replays/omnigent-lifecycle-dedup-retry/expected-outcome.json
@@ -1,0 +1,6 @@
+{
+  "invariant": "lifecycle persistence keeps one event per full logical identity, deduplicates exact retries, and never aliases identities that differ after the database key limit",
+  "eventCount": 2,
+  "distinctDeduplicationKeyCount": 2,
+  "maximumDeduplicationKeyLength": 128
+}

--- a/tests/integration/reliability/replays/omnigent-lifecycle-dedup-retry/manifest.json
+++ b/tests/integration/reliability/replays/omnigent-lifecycle-dedup-retry/manifest.json
@@ -1,0 +1,17 @@
+{
+  "incidentWorkflowId": "mm:96eb128d-ff2e-4d22-9fe5-cde712d2c678",
+  "runId": "019fd325-7bba-79b5-a0b7-ed9c17c708f9",
+  "failureShape": "activity retries emitted distinct lifecycle identities whose distinguishing attempt and transition suffixes were discarded by 128-character prefix truncation",
+  "boundary": "integration.omnigent.profile_bound_execute lifecycle journal persistence",
+  "request": {
+    "agentKind": "external",
+    "agentId": "omnigent",
+    "executionProfileRef": "codex_openai_oauth",
+    "correlationId": "mm:96eb128d-ff2e-4d22-9fe5-cde712d2c678",
+    "idempotencyKey": "mm:96eb128d-ff2e-4d22-9fe5-cde712d2c678:019fd325-7bba-79b5-a0b7-ed9c17c708f9:node-1:execution:1:agent_execute"
+  },
+  "lifecycleEventIdentities": [
+    "mm:96eb128d-ff2e-4d22-9fe5-cde712d2c678:019fd325-7bba-79b5-a0b7-ed9c17c708f9:node-1:execution:1:agent_execute:attempt:1:request_validated:started",
+    "mm:96eb128d-ff2e-4d22-9fe5-cde712d2c678:019fd325-7bba-79b5-a0b7-ed9c17c708f9:node-1:execution:1:agent_execute:attempt:2:request_validated:started"
+  ]
+}

--- a/tests/integration/reliability/replays/omnigent-pr-resolver-publish-evidence-handoff/expected-outcome.json
+++ b/tests/integration/reliability/replays/omnigent-pr-resolver-publish-evidence-handoff/expected-outcome.json
@@ -1,0 +1,7 @@
+{
+  "invariant": "a validated merged or already-merged pr-resolver terminal contract publishes the Skill-authored publish_result.json companion by artifact ref before the parent evaluates auto publication",
+  "terminalContractSatisfied": true,
+  "publishEvidenceRef": "art_pr_publish_evidence",
+  "publishStatus": "published",
+  "publishReason": "auto publish verified merge"
+}

--- a/tests/integration/reliability/replays/omnigent-pr-resolver-publish-evidence-handoff/manifest.json
+++ b/tests/integration/reliability/replays/omnigent-pr-resolver-publish-evidence-handoff/manifest.json
@@ -1,0 +1,9 @@
+{
+  "incidentWorkflowId": "mm:a5460547-b43c-4b1d-9052-ac6612e9975b",
+  "incidentRunId": "019fd552-d243-71b4-9df3-908d6c9dd2dc",
+  "stepExecutionId": "mm:a5460547-b43c-4b1d-9052-ac6612e9975b:019fd552-d243-71b4-9df3-908d6c9dd2dc:node-1:execution:1",
+  "terminalEvidencePath": "var/pr_resolver/result.json",
+  "publishEvidencePath": "artifacts/publish_result.json",
+  "mergeAutomationDisposition": "already_merged",
+  "failureReason": "auto_publish_evidence_missing"
+}

--- a/tests/integration/reliability/replays/omnigent-pr-resolver-runtime-authority/expected-outcome.json
+++ b/tests/integration/reliability/replays/omnigent-pr-resolver-runtime-authority/expected-outcome.json
@@ -1,0 +1,7 @@
+{
+  "invariant": "a gh-capable Codex resolver receives run-private standard gh authentication without token-bearing terminal arguments, its login shell restores the exact step execution identity, and AgentRun validates matching terminal evidence through the authoritative sandbox locator",
+  "terminalLaunchArgs": [],
+  "stepExecutionIdentitySource": "/etc/profile.d/moonmind-execution.sh",
+  "terminalContractOutcome": "terminal_success",
+  "terminalContractEvidencePath": "var/pr_resolver/result.json"
+}

--- a/tests/integration/reliability/replays/omnigent-pr-resolver-runtime-authority/manifest.json
+++ b/tests/integration/reliability/replays/omnigent-pr-resolver-runtime-authority/manifest.json
@@ -1,0 +1,23 @@
+{
+  "incidentWorkflowId": "mm:e09594b0-e1a0-4205-a54e-89e5b8734e6c",
+  "incidentRunId": "019fd504-5cb2-7927-9e03-f3c34efce2c5",
+  "failedChildWorkflowId": "mm:e09594b0-e1a0-4205-a54e-89e5b8734e6c:agent:node-1:execution2:retry1",
+  "idempotencyKey": "mm:e09594b0-e1a0-4205-a54e-89e5b8734e6c:019fd504-5cb2-7927-9e03-f3c34efce2c5:node-1:execution:2:agent_execute",
+  "stepExecutionId": "mm:e09594b0-e1a0-4205-a54e-89e5b8734e6c:019fd504-5cb2-7927-9e03-f3c34efce2c5:node-1:execution:2",
+  "omnigentSessionId": "16409b93c6144319a7080f44a9eb6921",
+  "hostWorkspaceAlias": "/workspaces/run",
+  "workspaceLocator": {
+    "kind": "sandbox",
+    "workspaceId": "7d6582c2f4e2363631715dc3",
+    "relativePath": "repo"
+  },
+  "terminalContract": {
+    "contractId": "pr_resolver_terminal.v1",
+    "owner": "agent",
+    "evidenceKind": "workspace_json",
+    "relativePath": "var/pr_resolver/result.json",
+    "expectedSchemaVersion": "pr-resolver-result.v1",
+    "executionRef": "mm:e09594b0-e1a0-4205-a54e-89e5b8734e6c:019fd504-5cb2-7927-9e03-f3c34efce2c5:node-1:execution:2"
+  },
+  "failureShape": "the resolver host proved GitHub authentication before launch, but Codex filtered GH_TOKEN and MoonMind's step execution identity from shell commands, so valid merge evidence had a blank executionRef and AgentRun rejected it as stale"
+}

--- a/tests/integration/reliability/replays/omnigent-profile-bound-heartbeat-timeout/expected-outcome.json
+++ b/tests/integration/reliability/replays/omnigent-profile-bound-heartbeat-timeout/expected-outcome.json
@@ -1,0 +1,6 @@
+{
+  "periodicLifecycleHeartbeat": true,
+  "preservesStreamingHeartbeatState": true,
+  "cancelledAttemptCleanup": "retry_or_janitor_reconciliation",
+  "releaseProviderLeaseOnCancellation": false
+}

--- a/tests/integration/reliability/replays/omnigent-profile-bound-heartbeat-timeout/manifest.json
+++ b/tests/integration/reliability/replays/omnigent-profile-bound-heartbeat-timeout/manifest.json
@@ -1,0 +1,10 @@
+{
+  "schemaVersion": "moonmind.reliability-replay.v1",
+  "replayId": "omnigent-profile-bound-heartbeat-timeout",
+  "incidentWorkflowId": "mm:95bc330e-12da-4a7d-8319-98d81b76a877",
+  "failedChildWorkflowId": "resolver:pr:3614:head:8424bf1a3d78:h:0dfd6753e5df2f8b:1:agent:node-1",
+  "activityType": "integration.omnigent.profile_bound_execute",
+  "heartbeatTimeoutSeconds": 120,
+  "failureBoundary": "on-demand OAuth host preparation",
+  "retryRace": "the timed-out attempt stopped the deterministic host while attempt 2 was validating it"
+}

--- a/tests/integration/reliability/replays/omnigent-profile-bound-publication/expected-outcome.json
+++ b/tests/integration/reliability/replays/omnigent-profile-bound-publication/expected-outcome.json
@@ -1,0 +1,6 @@
+{
+  "invariant": "committed agent work is scanned, pushed, and exact-remote-head verified before profile-bound execution reports repository success",
+  "pushStatus": "pushed",
+  "commitsAheadOfBase": 1,
+  "remoteVerified": true
+}

--- a/tests/integration/reliability/replays/omnigent-profile-bound-publication/manifest.json
+++ b/tests/integration/reliability/replays/omnigent-profile-bound-publication/manifest.json
@@ -1,0 +1,7 @@
+{
+  "incidentWorkflowId": "mm:ea264977-a19a-4ec7-bfb7-f8305ef451f3",
+  "incidentRunId": "019fd3bf-202c-7382-b281-7ec29436e788",
+  "failedChildWorkflowId": "mm:ea264977-a19a-4ec7-bfb7-f8305ef451f3:agent:node-1",
+  "failureShape": "profile-bound Omnigent returned provider completion without publishing the authoritative sandbox branch, so the parent attempted PR creation against a branch with no remote commits",
+  "boundary": "profile-bound provider result to repository publication"
+}

--- a/tests/integration/reliability/replays/omnigent-publication-missing-git-identity/expected-outcome.json
+++ b/tests/integration/reliability/replays/omnigent-publication-missing-git-identity/expected-outcome.json
@@ -1,0 +1,5 @@
+{
+  "pushStatus": "pushed",
+  "commitsAheadOfBase": 1,
+  "remoteVerified": true
+}

--- a/tests/integration/reliability/replays/omnigent-publication-missing-git-identity/manifest.json
+++ b/tests/integration/reliability/replays/omnigent-publication-missing-git-identity/manifest.json
@@ -1,0 +1,8 @@
+{
+  "incidentWorkflowId": "mm:bfc017e9-57ef-4eb3-a652-8e0386f464bc",
+  "stepExecutionId": "mm:bfc017e9-57ef-4eb3-a652-8e0386f464bc:agent:node-1",
+  "failureCode": "OMNIGENT_REPOSITORY_PUBLICATION_FAILED",
+  "workspaceState": "staged_changes_without_local_git_identity",
+  "gitUserName": "MoonMind Replay",
+  "gitUserEmail": "moonmind-replay@users.noreply.github.com"
+}

--- a/tests/integration/reliability/replays/omnigent-required-checkpoint-finalization/expected-outcome.json
+++ b/tests/integration/reliability/replays/omnigent-required-checkpoint-finalization/expected-outcome.json
@@ -1,0 +1,6 @@
+{
+  "invariant": "an invalid required after-execution checkpoint fails finalization and blocks publication",
+  "finalizationStatus": "failed",
+  "publishStatus": "failed",
+  "failureCode": "invalid_checkpoint"
+}

--- a/tests/integration/reliability/replays/omnigent-required-checkpoint-finalization/manifest.json
+++ b/tests/integration/reliability/replays/omnigent-required-checkpoint-finalization/manifest.json
@@ -1,0 +1,6 @@
+{
+  "incidentWorkflowId": "mm:ea264977-a19a-4ec7-bfb7-f8305ef451f3",
+  "incidentRunId": "019fd3bf-202c-7382-b281-7ec29436e788",
+  "failureShape": "the required after-execution checkpoint returned invalid, but finalization classified it as unsupported and allowed native pull-request creation to continue",
+  "boundary": "required workspace checkpoint result to publication finalization gate"
+}

--- a/tests/integration/reliability/replays/omnigent-runner-proxy-passthrough/expected-outcome.json
+++ b/tests/integration/reliability/replays/omnigent-runner-proxy-passthrough/expected-outcome.json
@@ -1,0 +1,16 @@
+{
+  "invariant": "every isolated Omnigent runner receives the host's enforced proxy and loopback-only bypass configuration while retaining only non-secret execution identity and GitHub config selectors",
+  "passthroughNames": [
+    "HTTP_PROXY",
+    "HTTPS_PROXY",
+    "http_proxy",
+    "https_proxy",
+    "NO_PROXY",
+    "no_proxy",
+    "MOONMIND_STEP_EXECUTION_ID",
+    "XDG_CONFIG_HOME",
+    "GH_PROMPT_DISABLED",
+    "GH_NO_UPDATE_NOTIFIER",
+    "GH_NO_EXTENSION_UPDATE_NOTIFIER"
+  ]
+}

--- a/tests/integration/reliability/replays/omnigent-runner-proxy-passthrough/manifest.json
+++ b/tests/integration/reliability/replays/omnigent-runner-proxy-passthrough/manifest.json
@@ -1,0 +1,11 @@
+{
+  "incidentWorkflowId": "mm:933a5f44-acdf-4432-84bf-6361de74daee",
+  "incidentRunId": "019fd372-7abe-795d-9d9a-cad14181db77",
+  "failedChildWorkflowId": "mm:933a5f44-acdf-4432-84bf-6361de74daee:agent:node-1",
+  "failedChildRunId": "019fd372-8d8e-789a-93fc-96d461d5efeb",
+  "omnigentSessionId": "1509e4275cdd4e1eae69cb3148576e06",
+  "containerName": "mm-omnigent-host-replay",
+  "hostImageRef": "registry.example/omnigent-host@sha256:4444444444444444444444444444444444444444444444444444444444444444",
+  "failureShape": "the isolated host had proxy variables, but Omnigent filtered them out of the spawned runner; Codex could not refresh ChatGPT authentication and timed out before starting a thread",
+  "boundary": "MoonMind on-demand host launch to Omnigent runner environment"
+}

--- a/tests/integration/reliability/replays/omnigent-runtime-scripts-daemon-path/expected-outcome.json
+++ b/tests/integration/reliability/replays/omnigent-runtime-scripts-daemon-path/expected-outcome.json
@@ -1,0 +1,5 @@
+{
+  "invariant": "MoonMind runtime scripts are copied into the run-owned workspace root and rebased to the configured remote-daemon root before host creation",
+  "daemonRoot": "/var/lib/docker/volumes/agent_workspaces/_data",
+  "daemonScriptsPath": "/var/lib/docker/volumes/agent_workspaces/_data/.omnigent-runtime-scripts/5de9e0013df382bfecb790b5"
+}

--- a/tests/integration/reliability/replays/omnigent-runtime-scripts-daemon-path/manifest.json
+++ b/tests/integration/reliability/replays/omnigent-runtime-scripts-daemon-path/manifest.json
@@ -1,0 +1,15 @@
+{
+  "incidentWorkflowId": "mm:b2f61d86-cd1e-4668-bd33-3f0b335033b7",
+  "incidentRunId": "019fd339-b2d4-793a-9d7c-7256e5762e08",
+  "failedChildWorkflowId": "mm:b2f61d86-cd1e-4668-bd33-3f0b335033b7:agent:node-1",
+  "failedChildRunId": "019fd339-c341-7efc-87d3-cf2bf4c9bb6c",
+  "failureShape": "on-demand OAuth host launch passed the worker-only /app/services/omnigent/scripts path to a remote Docker daemon bind mount",
+  "boundary": "agent-runtime worker filesystem to remote Docker daemon filesystem",
+  "workspaceKey": "mm:b2f61d86-cd1e-4668-bd33-3f0b335033b7:019fd339-b2d4-793a-9d7c-7256e5762e08:node-1:execution:1:agent_execute",
+  "requiredScripts": [
+    "init-oauth-host.sh",
+    "moonmind-tools.sh",
+    "start-codex-oauth-host.sh",
+    "start-claude-oauth-host.sh"
+  ]
+}

--- a/tests/integration/reliability/replays/omnigent-sandbox-checkpoint-git-ownership/expected-outcome.json
+++ b/tests/integration/reliability/replays/omnigent-sandbox-checkpoint-git-ownership/expected-outcome.json
@@ -1,0 +1,5 @@
+{
+  "invariant": "every checkpoint Git command explicitly trusts only the already-resolved sandbox workspace",
+  "checkpointStatus": "captured",
+  "gitCommandCount": 2
+}

--- a/tests/integration/reliability/replays/omnigent-sandbox-checkpoint-git-ownership/manifest.json
+++ b/tests/integration/reliability/replays/omnigent-sandbox-checkpoint-git-ownership/manifest.json
@@ -1,0 +1,16 @@
+{
+  "incidentWorkflowId": "mm:ea264977-a19a-4ec7-bfb7-f8305ef451f3",
+  "incidentRunId": "019fd3bf-202c-7382-b281-7ec29436e788",
+  "failedActivityType": "workspace.capture_checkpoint",
+  "failedActivityEventIds": [
+    171,
+    195
+  ],
+  "workspaceLocator": {
+    "kind": "sandbox",
+    "workspaceId": "81548066e560f4b50ee5df97",
+    "relativePath": "repo"
+  },
+  "failureShape": "the root sandbox worker invoked bare Git against the app-owned Omnigent repository and Git rejected the workspace as dubious ownership",
+  "boundary": "sandbox workspace checkpoint Git invocation"
+}

--- a/tests/integration/reliability/replays/omnigent-sandbox-checkpoint-workspace-root/expected-outcome.json
+++ b/tests/integration/reliability/replays/omnigent-sandbox-checkpoint-workspace-root/expected-outcome.json
@@ -1,0 +1,5 @@
+{
+  "invariant": "the sandbox activity worker resolves typed workspace locators from the same shared volume root used by the agent-runtime materializer",
+  "workspaceRoot": "/work/agent_jobs",
+  "workspaceVolumeMount": "agent_workspaces:/work/agent_jobs"
+}

--- a/tests/integration/reliability/replays/omnigent-sandbox-checkpoint-workspace-root/manifest.json
+++ b/tests/integration/reliability/replays/omnigent-sandbox-checkpoint-workspace-root/manifest.json
@@ -1,0 +1,16 @@
+{
+  "incidentWorkflowId": "mm:fbbf6deb-4149-4146-a7ff-5dd29eb749db",
+  "incidentRunId": "019fd3ad-dea5-7377-9785-a02441110cf1",
+  "failedActivityType": "workspace.capture_checkpoint",
+  "failedActivityEventIds": [
+    171,
+    196
+  ],
+  "workspaceLocator": {
+    "kind": "sandbox",
+    "workspaceId": "ceba96934c56005ab8f161b9",
+    "relativePath": "repo"
+  },
+  "failureShape": "the agent-runtime worker materialized the sandbox under the shared agent_workspaces volume, but the sandbox worker resolved the same locator beneath its default /work root",
+  "boundary": "agent-runtime workspace materialization to sandbox checkpoint capture"
+}

--- a/tests/integration/reliability/replays/omnigent-stale-terminal-before-continuation/expected-outcome.json
+++ b/tests/integration/reliability/replays/omnigent-stale-terminal-before-continuation/expected-outcome.json
@@ -1,0 +1,10 @@
+{
+  "acceptStaleTerminal": false,
+  "acceptProgressedTerminal": false,
+  "acceptTerminalSnapshot": true,
+  "minimumBusySnapshotsObserved": 5,
+  "requiresStableQuietPeriod": true,
+  "assistantPreambleRequiresStableQuietPeriod": true,
+  "unfinishedToolCallBlocksCompletion": true,
+  "toolOnlyQuietPeriodSeconds": 300
+}

--- a/tests/integration/reliability/replays/omnigent-stale-terminal-before-continuation/manifest.json
+++ b/tests/integration/reliability/replays/omnigent-stale-terminal-before-continuation/manifest.json
@@ -1,0 +1,83 @@
+{
+  "incidentWorkflowId": "mm:63c53791-c6d7-4110-9f5a-d431241f73a6",
+  "latestIncidentWorkflowId": "mm:e2be58ae-676a-4fa0-86df-76a756560949",
+  "latestResolverWorkflowId": "resolver:pr:3616:head:90984f8268ba:h:ada0c82637af0ad2:1",
+  "sourceWorkflowId": "mm:96eb128d-ff2e-4d22-9fe5-cde712d2c678",
+  "failureShape": "the continuation stream replayed the previous turn terminal event before Codex processed the newly posted marked message, so MoonMind posted eight continuations into one still-running session",
+  "latestFailureShape": "seven marked continuation messages and all subsequent tools shared one native Codex response while stale idle/completed projections advanced the continuation loop; a later resolver also lost its required result artifact when a 60-second tool-output gap was treated as terminal",
+  "sharedNativeResponseId": "codex_replay_one_still_running_turn",
+  "currentTurnMarker": "MoonMind-Omnigent-Run:\n  correlationId: mm:63c53791-c6d7-4110-9f5a-d431241f73a6\n  idempotencyKey: repository-continuation:2",
+  "staleTerminalSnapshot": {
+    "status": "completed",
+    "items": [
+      {"type": "message", "data": {"role": "assistant", "content": [{"type": "output_text", "text": "working"}]}},
+      {"type": "function_call_output", "data": {}},
+      {"type": "message", "data": {"role": "user", "content": [{"type": "input_text", "text": "MoonMind-Omnigent-Run:\n  correlationId: mm:63c53791-c6d7-4110-9f5a-d431241f73a6\n  idempotencyKey: repository-continuation:2"}]}}
+    ]
+  },
+  "progressedSnapshot": {
+    "status": "running",
+    "active_response_id": "response-still-active",
+    "items": [
+      {"type": "message", "data": {"role": "assistant", "content": [{"type": "output_text", "text": "working"}]}},
+      {"type": "function_call_output", "data": {}},
+      {"type": "message", "data": {"role": "user", "content": [{"type": "input_text", "text": "MoonMind-Omnigent-Run:\n  correlationId: mm:63c53791-c6d7-4110-9f5a-d431241f73a6\n  idempotencyKey: repository-continuation:2"}]}},
+      {"type": "function_call", "data": {}}
+    ]
+  },
+  "terminalSnapshot": {
+    "status": "running",
+    "active_response_id": null,
+    "items": [
+      {"type": "message", "data": {"role": "assistant", "content": [{"type": "output_text", "text": "working"}]}},
+      {"type": "function_call_output", "data": {}},
+      {"type": "message", "data": {"role": "user", "content": [{"type": "input_text", "text": "MoonMind-Omnigent-Run:\n  correlationId: mm:63c53791-c6d7-4110-9f5a-d431241f73a6\n  idempotencyKey: repository-continuation:2"}]}},
+      {"type": "function_call", "data": {}},
+      {"type": "function_call_output", "data": {}},
+      {"type": "message", "data": {"role": "assistant", "content": [{"type": "output_text", "text": "done"}]}}
+    ]
+  },
+  "assistantPreambleSnapshot": {
+    "status": "idle",
+    "items": [
+      {"id": "marked-user", "response_id": "codex_replay_one_still_running_turn", "type": "message", "status": "completed", "data": {"role": "user", "content": [{"type": "input_text", "text": "MoonMind-Omnigent-Run:\n  correlationId: mm:63c53791-c6d7-4110-9f5a-d431241f73a6\n  idempotencyKey: repository-continuation:2"}]}},
+      {"id": "assistant-preamble", "response_id": "codex_replay_one_still_running_turn", "type": "message", "status": "completed", "data": {"role": "assistant", "content": [{"type": "output_text", "text": "I will inspect the repository."}]}}
+    ]
+  },
+  "busyIdleSnapshots": [
+    {
+      "status": "idle",
+      "items": [
+        {"id": "marked-user", "response_id": "codex_replay_one_still_running_turn", "type": "message", "status": "completed", "data": {"role": "user", "content": [{"type": "input_text", "text": "MoonMind-Omnigent-Run:\n  correlationId: mm:63c53791-c6d7-4110-9f5a-d431241f73a6\n  idempotencyKey: repository-continuation:2"}]}},
+        {"id": "call-1", "response_id": "codex_replay_one_still_running_turn", "type": "function_call", "status": "completed", "data": {"call_id": "call-1"}}
+      ]
+    },
+    {
+      "status": "idle",
+      "items": [
+        {"id": "marked-user", "response_id": "codex_replay_one_still_running_turn", "type": "message", "status": "completed", "data": {"role": "user", "content": [{"type": "input_text", "text": "MoonMind-Omnigent-Run:\n  correlationId: mm:63c53791-c6d7-4110-9f5a-d431241f73a6\n  idempotencyKey: repository-continuation:2"}]}},
+        {"id": "call-1", "response_id": "codex_replay_one_still_running_turn", "type": "function_call", "status": "completed", "data": {"call_id": "call-1"}},
+        {"id": "output-1", "response_id": "codex_replay_one_still_running_turn", "type": "function_call_output", "status": "completed", "data": {"call_id": "call-1"}}
+      ]
+    },
+    {
+      "status": "idle",
+      "items": [
+        {"id": "marked-user", "response_id": "codex_replay_one_still_running_turn", "type": "message", "status": "completed", "data": {"role": "user", "content": [{"type": "input_text", "text": "MoonMind-Omnigent-Run:\n  correlationId: mm:63c53791-c6d7-4110-9f5a-d431241f73a6\n  idempotencyKey: repository-continuation:2"}]}},
+        {"id": "call-1", "response_id": "codex_replay_one_still_running_turn", "type": "function_call", "status": "completed", "data": {"call_id": "call-1"}},
+        {"id": "output-1", "response_id": "codex_replay_one_still_running_turn", "type": "function_call_output", "status": "completed", "data": {"call_id": "call-1"}},
+        {"id": "call-2", "response_id": "codex_replay_one_still_running_turn", "type": "function_call", "status": "completed", "data": {"call_id": "call-2"}}
+      ]
+    },
+    {
+      "status": "idle",
+      "items": [
+        {"id": "marked-user", "response_id": "codex_replay_one_still_running_turn", "type": "message", "status": "completed", "data": {"role": "user", "content": [{"type": "input_text", "text": "MoonMind-Omnigent-Run:\n  correlationId: mm:63c53791-c6d7-4110-9f5a-d431241f73a6\n  idempotencyKey: repository-continuation:2"}]}},
+        {"id": "call-1", "response_id": "codex_replay_one_still_running_turn", "type": "function_call", "status": "completed", "data": {"call_id": "call-1"}},
+        {"id": "output-1", "response_id": "codex_replay_one_still_running_turn", "type": "function_call_output", "status": "completed", "data": {"call_id": "call-1"}},
+        {"id": "call-2", "response_id": "codex_replay_one_still_running_turn", "type": "function_call", "status": "completed", "data": {"call_id": "call-2"}},
+        {"id": "output-2", "response_id": "codex_replay_one_still_running_turn", "type": "function_call_output", "status": "completed", "data": {"call_id": "call-2"}}
+      ]
+    }
+  ]
+}

--- a/tests/integration/reliability/replays/omnigent-stock-agent-catalog-identity/expected-outcome.json
+++ b/tests/integration/reliability/replays/omnigent-stock-agent-catalog-identity/expected-outcome.json
@@ -1,0 +1,16 @@
+{
+  "invariant": "a profile-bound Codex child without an explicit agent id compiles the exact bindable stock catalog identity before Omnigent session creation",
+  "resolvedAgentId": "16a06503889b0c3034496821afd41b9e",
+  "resolvedAgentName": "codex-native-ui",
+  "bootstrapPolicyAgentIdentity": "codex-native-ui",
+  "managedProfileLaunchPolicyRef": "codex-on-demand@2",
+  "exactRerunLaunchPolicyRef": "codex-on-demand@2",
+  "legacyTrustedIdentityRemovedFromAuthoredParameters": true,
+  "catalogAgent": {
+    "id": "16a06503889b0c3034496821afd41b9e",
+    "name": "codex-native-ui",
+    "capabilities": [
+      "session.start"
+    ]
+  }
+}

--- a/tests/integration/reliability/replays/omnigent-stock-agent-catalog-identity/manifest.json
+++ b/tests/integration/reliability/replays/omnigent-stock-agent-catalog-identity/manifest.json
@@ -1,0 +1,49 @@
+{
+  "incidentWorkflowId": "mm:e444e9c1-0d72-40d1-b9d9-64e1565b70f1",
+  "incidentRunId": "019fd454-8223-7831-a629-331ab9eb0cf8",
+  "failedChildWorkflowId": "resolver:pr:3613:head:53c348bb1677:h:cd6e0ef8d8da2188:1",
+  "failedChildRunId": "019fd45d-8f28-719e-9827-e82fa2f54e9c",
+  "secondIncidentWorkflowId": "mm:d71f6681-31c1-47de-9e77-33c49a160814",
+  "secondFailedChildWorkflowId": "resolver:pr:3615:head:7dc357851f0e:h:e089811d67092eb1:1",
+  "thirdIncidentWorkflowId": "mm:e164bffa-eefa-4870-8a74-0345463bfb7a",
+  "thirdFailedChildWorkflowId": "mm:e164bffa-eefa-4870-8a74-0345463bfb7a:agent:node-1",
+  "fourthIncidentWorkflowId": "mm:bf2675e6-14d8-40c2-be6b-fbe298350705",
+  "failureShape": "the PR resolver first compiled the removed codex alias from a missing profile identity, then a persisted bootstrap policy overwrote the corrected request with the same removed identity, the immutable policy cutover left the managed agent profile and exact-rerun snapshot bound to policy version 1 while the durable host binding selected version 2, and refreshing the snapshot initially retained a duplicate legacy agentProfileRef that contradicted the new immutable version",
+  "persistedPolicyExecution": {
+    "profileRef": "omnigent-codex@1",
+    "harness": "codex-native",
+    "agentIdentities": ["codex"]
+  },
+  "profileSnapshots": {
+    "codex_openai_oauth": {
+      "profile_id": "codex_openai_oauth",
+      "runtime_id": "codex_cli"
+    }
+  },
+  "nodeInputs": {
+    "runtime": {
+      "mode": "omnigent",
+      "executionProfileRef": "codex_openai_oauth"
+    },
+    "workspaceSpec": {
+      "repository": "MoonLadderStudios/MoonMind",
+      "startingBranch": "main",
+      "targetBranch": "moonmind-job-393ade54"
+    }
+  },
+  "workflowParameters": {
+    "omnigent": {
+      "executionTargetRef": "omnigent-codex@1",
+      "launchPolicyRef": "codex-on-demand@1",
+      "agent": {
+        "harnessOverride": "codex-native"
+      }
+    }
+  },
+  "cutoverAuthority": {
+    "durableHostLaunchPolicyRef": "codex-on-demand@2",
+    "staleManagedProfileLaunchPolicyRef": "codex-on-demand@1",
+    "staleExactRerunLaunchPolicyRef": "codex-on-demand@1",
+    "staleExactRerunAgentProfileRef": "omnigent-bootstrap-default@1"
+  }
+}

--- a/tests/integration/reliability/replays/omnigent-stock-host-catalog-contract/expected-outcome.json
+++ b/tests/integration/reliability/replays/omnigent-stock-host-catalog-contract/expected-outcome.json
@@ -1,0 +1,6 @@
+{
+  "invariant": "host discovery uses the confirmed stock endpoint and resolves the deterministic container hostname plus ready configured harness",
+  "path": "/v1/hosts",
+  "hostId": "host-stock-replay",
+  "harness": "codex-native"
+}

--- a/tests/integration/reliability/replays/omnigent-stock-host-catalog-contract/manifest.json
+++ b/tests/integration/reliability/replays/omnigent-stock-host-catalog-contract/manifest.json
@@ -1,0 +1,9 @@
+{
+  "incidentWorkflowId": "mm:99f6a4a0-06b8-4b65-901f-e3f1ac0b0f5b",
+  "incidentRunId": "019fd354-a380-7178-aab6-162674384a52",
+  "failedChildWorkflowId": "mm:99f6a4a0-06b8-4b65-901f-e3f1ac0b0f5b:agent:node-1",
+  "failedChildRunId": "019fd354-b35c-7b0c-862d-8e4314e316ae",
+  "failureShape": "MoonMind requested the removed /api/hosts route after the on-demand host registered; stock Omnigent exposes /v1/hosts with host_id and configured_harnesses",
+  "boundary": "stock Omnigent host catalog to exact lease-owned host resolution",
+  "containerName": "mm-omnigent-host-ohl19763d3ada2ce975263416b6e671707e"
+}

--- a/tests/integration/reliability/replays/omnigent-stock-sse-event-contract/expected-outcome.json
+++ b/tests/integration/reliability/replays/omnigent-stock-sse-event-contract/expected-outcome.json
@@ -1,0 +1,79 @@
+{
+  "invariant": "every stock Omnigent ServerStreamEvent type has an explicit MoonMind status mapping while unknown execution-critical types still fail closed",
+  "stockEventTypeCountWithoutSessionStatus": 52,
+  "eventTypesByStatus": {
+    "running": [
+      "session.usage",
+      "session.model",
+      "session.reasoning_effort",
+      "session.collaboration_mode",
+      "session.agent_changed",
+      "session.todos",
+      "session.terminal_pending",
+      "session.sandbox_status",
+      "session.mcp_startup",
+      "session.skills",
+      "session.model_options",
+      "session.input.consumed",
+      "response.output_text.delta",
+      "response.function_call_output.delta",
+      "response.reasoning.started",
+      "response.reasoning_text.delta",
+      "response.reasoning_summary_text.delta",
+      "response.output_item.done",
+      "injection.consumed",
+      "response.output_file.done",
+      "response.heartbeat",
+      "session.heartbeat",
+      "session.presence",
+      "response.elicitation_resolved",
+      "response.created",
+      "response.queued",
+      "response.in_progress",
+      "response.retry",
+      "response.compaction.in_progress",
+      "response.compaction.completed",
+      "response.compaction.failed",
+      "response.client_task.cancel",
+      "session.resource.created",
+      "session.resource.deleted",
+      "session.child_session.updated",
+      "session.changed_files.invalidated",
+      "session.terminal.activity",
+      "turn.started"
+    ],
+    "created": [
+      "session.created"
+    ],
+    "awaiting_approval": [
+      "response.elicitation_request"
+    ],
+    "intervention_requested": [
+      "browser.action_request"
+    ],
+    "completed": [
+      "response.completed",
+      "turn.completed"
+    ],
+    "failed": [
+      "response.failed",
+      "response.incomplete",
+      "response.error",
+      "response.policy_denied",
+      "turn.failed"
+    ],
+    "canceled": [
+      "response.cancelled",
+      "session.interrupted",
+      "session.superseded",
+      "turn.cancelled"
+    ]
+  },
+  "sessionStatusCases": [
+    {"input": "idle", "normalizedStatus": "idle"},
+    {"input": "launching", "normalizedStatus": "launching"},
+    {"input": "running", "normalizedStatus": "running"},
+    {"input": "waiting", "normalizedStatus": "intervention_requested"},
+    {"input": "failed", "normalizedStatus": "failed"}
+  ]
+}

--- a/tests/integration/reliability/replays/omnigent-stock-sse-event-contract/manifest.json
+++ b/tests/integration/reliability/replays/omnigent-stock-sse-event-contract/manifest.json
@@ -1,0 +1,9 @@
+{
+  "incidentWorkflowId": "mm:60a4ed2c-6834-42d2-99cf-ae294cd9b6aa",
+  "incidentRunId": "019fd36c-75de-70fc-bc8b-807e760aef88",
+  "failedChildWorkflowId": "mm:60a4ed2c-6834-42d2-99cf-ae294cd9b6aa:agent:node-1",
+  "failedChildRunId": "019fd36c-7e0f-76f8-af06-adf10b9afb4b",
+  "omnigentSessionId": "6506acd560ef4c77a4a03b25debeef97",
+  "failureShape": "MoonMind rejected the stock session.heartbeat SSE frame as unsupported and cleaned up a running Codex turn",
+  "boundary": "stock Omnigent ServerStreamEvent union to MoonMind bridge normalization"
+}

--- a/tests/integration/reliability/replays/omnigent-tool-bundle-deployment-boundary/expected-outcome.json
+++ b/tests/integration/reliability/replays/omnigent-tool-bundle-deployment-boundary/expected-outcome.json
@@ -1,0 +1,7 @@
+{
+  "invariant": "deployment initializes the versioned named volume once and on-demand runtime probes that volume without invoking Compose",
+  "toolVolume": "moonmind-omnigent-tools-gh-2.76.2",
+  "probeImage": "omnigent-host:test",
+  "failureCode": "tool_bundle_unavailable",
+  "composeInvokedByRuntime": false
+}

--- a/tests/integration/reliability/replays/omnigent-tool-bundle-deployment-boundary/manifest.json
+++ b/tests/integration/reliability/replays/omnigent-tool-bundle-deployment-boundary/manifest.json
@@ -1,0 +1,9 @@
+{
+  "incidentWorkflowId": "mm:d4a7b625-c9d9-4cff-8512-141ce343362e",
+  "incidentRunId": "019fd52d-3a2e-7df0-a4f2-836055eb6ba8",
+  "activityType": "integration.omnigent.profile_bound_execute",
+  "failureStage": "credential_preflight",
+  "failureCode": "CODEX_OAUTH_LOGIN_STATUS_FAILED",
+  "actualFailureStage": "deployment_tool_initialization",
+  "failureShape": "the agent-runtime worker invoked deployment Docker Compose from /app even though its authoritative project mount is not a Docker-daemon-visible bind path"
+}

--- a/tests/integration/reliability/replays/omnigent-tool-output-terminal-continuation/expected-outcome.json
+++ b/tests/integration/reliability/replays/omnigent-tool-output-terminal-continuation/expected-outcome.json
@@ -1,0 +1,7 @@
+{
+  "terminalAssistantAfterWork": false,
+  "toolResultCount": 1,
+  "continuationCount": 1,
+  "pushStatus": "pushed",
+  "resumeSessionId": "replay-session-1"
+}

--- a/tests/integration/reliability/replays/omnigent-tool-output-terminal-continuation/manifest.json
+++ b/tests/integration/reliability/replays/omnigent-tool-output-terminal-continuation/manifest.json
@@ -1,0 +1,12 @@
+{
+  "incidentWorkflowId": "mm:651a14f6-ff53-43e9-a91b-b37ad276f9ef",
+  "sourceWorkflowId": "mm:96eb128d-ff2e-4d22-9fe5-cde712d2c678",
+  "failureShape": "stock Codex reported a completed turn whose last durable item was function_call_output, after an assistant preamble but before a final assistant answer or repository change",
+  "sessionStatus": "completed",
+  "items": [
+    {"type": "message", "data": {"role": "user", "content": [{"type": "input_text", "text": "task"}]}},
+    {"type": "message", "data": {"role": "assistant", "content": [{"type": "output_text", "text": "I will inspect the repository."}]}},
+    {"type": "function_call", "data": {"name": "exec"}},
+    {"type": "function_call_output", "data": {"output": "bounded replay output"}}
+  ]
+}

--- a/tests/integration/reliability/replays/omnigent-unposted-activity-retry/expected-outcome.json
+++ b/tests/integration/reliability/replays/omnigent-unposted-activity-retry/expected-outcome.json
@@ -1,0 +1,6 @@
+{
+  "status": "declared",
+  "firstMessageState": "not_prepared",
+  "omnigentSessionId": null,
+  "archivedAttemptStatus": "failed"
+}

--- a/tests/integration/reliability/replays/omnigent-unposted-activity-retry/manifest.json
+++ b/tests/integration/reliability/replays/omnigent-unposted-activity-retry/manifest.json
@@ -1,0 +1,8 @@
+{
+  "incidentWorkflowId": "mm:651a14f6-ff53-43e9-a91b-b37ad276f9ef",
+  "failureShape": "a failed host-preflight Activity terminalized the bridge row before first-message delivery; the Temporal retry reused that row, inferred firstMessagePosted from terminal state, and created an idle session with no user message",
+  "idempotencyKey": "replay-unposted-activity-retry",
+  "terminalRefs": {
+    "summary": "host preflight failed before first-message delivery"
+  }
+}

--- a/tests/integration/reliability/replays/omnigent-workspace-runtime-ownership/expected-outcome.json
+++ b/tests/integration/reliability/replays/omnigent-workspace-runtime-ownership/expected-outcome.json
@@ -1,0 +1,15 @@
+{
+  "invariant": "the complete contained run workspace is owned by the effective launch UID and GID without following repository symlinks, and host preflight checks Git before a session starts",
+  "runtimeUid": 1000,
+  "runtimeGid": 1000,
+  "gitPreflight": [
+    "docker",
+    "exec",
+    "mm-omnigent-host-replay",
+    "git",
+    "-C",
+    "/workspaces/run",
+    "status",
+    "--porcelain"
+  ]
+}

--- a/tests/integration/reliability/replays/omnigent-workspace-runtime-ownership/manifest.json
+++ b/tests/integration/reliability/replays/omnigent-workspace-runtime-ownership/manifest.json
@@ -1,0 +1,9 @@
+{
+  "incidentWorkflowId": "mm:cbb14c76-4f9c-4dd5-8c38-d9b3d613f684",
+  "incidentRunId": "019fd394-6762-77d9-8385-8c0befe10f91",
+  "failedChildWorkflowId": "mm:cbb14c76-4f9c-4dd5-8c38-d9b3d613f684:agent:node-1",
+  "failedChildRunId": "019fd394-6dd7-76d9-a86f-da8d47ee689f",
+  "omnigentSessionId": "33bc7c8f3e824356b5cb1a65e211bdbc",
+  "failureShape": "the trusted worker materialized the repository as root, then mounted it into a UID 1000 host; Git rejected the repository as dubious and the native Codex TUI exited before creating a thread",
+  "boundary": "MoonMind sandbox materialization to isolated Omnigent host identity"
+}

--- a/tests/integration/reliability/replays/provider-profile-activity-grant-after-timeout/expected-outcome.json
+++ b/tests/integration/reliability/replays/provider-profile-activity-grant-after-timeout/expected-outcome.json
@@ -1,0 +1,4 @@
+{
+  "reclaimed": true,
+  "remainingLeases": []
+}

--- a/tests/integration/reliability/replays/provider-profile-activity-grant-after-timeout/manifest.json
+++ b/tests/integration/reliability/replays/provider-profile-activity-grant-after-timeout/manifest.json
@@ -1,0 +1,8 @@
+{
+  "incidentWorkflowId": "mm:9c24f15d-dc04-49b0-8d25-48c47ed1f49c",
+  "failureShape": "AcquireSlot remained pending after its caller Activity heartbeat-timed out, then claimed capacity after an older lease was released even though the owning workflow was already terminal",
+  "providerProfileId": "codex_openai_oauth",
+  "providerLeaseRef": "profile-lease:execution_omnigent:late-grant",
+  "terminalWorkflowId": "mm:terminal-exact-rerun",
+  "terminalStatus": "FAILED"
+}

--- a/tests/integration/reliability/replays/provider-profile-manager-completed-update/expected-outcome.json
+++ b/tests/integration/reliability/replays/provider-profile-manager-completed-update/expected-outcome.json
@@ -1,0 +1,7 @@
+{
+  "managerEnsureCount": 2,
+  "managerUpdateCount": 2,
+  "activityAttemptConsumed": false,
+  "ownerIdentityPreserved": true,
+  "leaseGranted": true
+}

--- a/tests/integration/reliability/replays/provider-profile-manager-completed-update/manifest.json
+++ b/tests/integration/reliability/replays/provider-profile-manager-completed-update/manifest.json
@@ -1,0 +1,10 @@
+{
+  "incidentWorkflowId": "mm:e2be58ae-676a-4fa0-86df-76a756560949",
+  "incidentChildWorkflowId": "mm:e2be58ae-676a-4fa0-86df-76a756560949:agent:node-1",
+  "runtimeId": "codex_cli",
+  "providerProfileId": "codex_openai_oauth",
+  "ownerId": "profile-lease:execution_omnigent:replay",
+  "updateName": "AcquireSlotV2",
+  "failureType": "AcceptedUpdateCompletedWorkflow",
+  "failureShape": "the canonical ProviderProfileManager completed after ensure-manager observed it running but before the accepted lease Update completed"
+}

--- a/tests/integration/reliability/test_escaped_failure_journeys.py
+++ b/tests/integration/reliability/test_escaped_failure_journeys.py
@@ -13,8 +13,39 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
+import httpx
 import pytest
+import yaml
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from temporalio import activity
+from temporalio.testing import ActivityEnvironment
 
+from api_service.db.models import Base
+from api_service.services.omnigent_policies import bootstrap_document
+from moonmind.omnigent import oauth_host_runtime as oauth_host_runtime_module
+from moonmind.omnigent.bridge_events import build_omnigent_bridge_event
+from moonmind.omnigent.bridge_store import OmnigentBridgeSessionStore
+from moonmind.omnigent.execute import (
+    _await_marked_turn_terminal,
+    _safe_heartbeat,
+    _snapshot_confirms_current_turn_terminal,
+    _snapshot_contains_current_turn_progress,
+    omnigent_activity_heartbeat,
+)
+from moonmind.omnigent.execution_profiles import compile_effective_launch
+from moonmind.omnigent.oauth_host_janitor import OmnigentOAuthHostJanitor
+from moonmind.omnigent.oauth_host_runtime import OmnigentOAuthHostRuntime
+from moonmind.omnigent.oauth_hosts import (
+    HOST_PROFILE_BUSY_ERROR_CODE,
+    OmnigentOAuthHostError,
+)
+from moonmind.omnigent.profile_bound_execution import (
+    OmnigentProfileBoundExecutionCoordinator,
+    _bind_exact_host,
+)
+from moonmind.omnigent.stock_agents import CODEX_STOCK_AGENT_NAME
+from moonmind.security.egress import OMNIGENT_EGRESS_PROFILE
+from moonmind.security.egress import omnigent_proxy_env
 from moonmind.schemas.managed_session_models import SendCodexManagedSessionTurnRequest
 from moonmind.schemas.agent_runtime_models import (
     AgentExecutionRequest,
@@ -32,9 +63,16 @@ from moonmind.workflows.adapters.codex_session_adapter import (
     CodexSessionAdapter,
     _pr_resolver_terminal_contract,
 )
+from moonmind.workflows.adapters.omnigent_agent_adapter import (
+    OmnigentResolvedTarget,
+    build_omnigent_session_create_payload,
+    build_omnigent_selection,
+    resolve_omnigent_target,
+)
 from moonmind.workflows.executions.runtime_capabilities import (
     resolve_runtime_execution_capabilities,
 )
+from moonmind.workflows.skills.artifact_store import InMemoryArtifactStore
 from moonmind.workflows.provider_failures import classify_provider_failure
 from moonmind.workflows.temporal.activity_runtime import (
     TemporalAgentRuntimeActivities,
@@ -46,13 +84,23 @@ from moonmind.workflows.temporal.runtime.codex_session_runtime import (
     CodexManagedSessionRuntime,
 )
 from moonmind.workflows.temporal.runtime.store import ManagedRunStore
+from moonmind.workflows.temporal.runtime.workspace_locators import (
+    SandboxWorkspaceRecord,
+    SandboxWorkspaceRecordStore,
+)
 from moonmind.workflows.temporal.workflows import agent_run as agent_run_module
 from moonmind.workflows.temporal.workflows import run as run_workflow_module
 from moonmind.workflows.temporal.workflows.agent_run import MoonMindAgentRun
+from moonmind.workflows.temporal.workflows.provider_profile_manager import (
+    MoonMindProviderProfileManagerWorkflow,
+    ProfileSlotState,
+)
 from moonmind.workflows.temporal.workflows.run import (
+    RUN_AGENT_REQUIRED_CAPABILITIES_PROPAGATION_PATCH,
     RUN_HEADLESS_REMEDIATION_VERIFIED_WORKSPACE_PATCH,
     RUN_WORKFLOW_HEADLESS_REMEDIATION_PATCH,
     RUN_WORKFLOW_OWNED_REMEDIATION_HEAD_PATCH,
+    RUN_OMNIGENT_STOCK_AGENT_IDENTITY_PATCH,
     MoonMindRunWorkflow,
 )
 from moonmind.workflows.terminal_evidence import evaluate_terminal_evidence
@@ -71,6 +119,12 @@ from tests.unit.workflows.adapters.test_codex_session_adapter import (
 from tests.unit.workflows.temporal.workflows.test_run_integration import (
     _finalize_and_capture_summary,
 )
+from tests.unit.omnigent.test_oauth_profile_lifecycle import (
+    _drive_authority_chain_coordinator,
+    _run_coordinator_failure_case,
+    _binding as _oauth_binding,
+    _host_lease as _oauth_host_lease,
+)
 
 
 pytestmark = [
@@ -78,6 +132,149 @@ pytestmark = [
     pytest.mark.integration,
     pytest.mark.reliability_journey,
 ]
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+@activity.defn(name="reliability.omnigent_activity_heartbeat_probe")
+async def _omnigent_activity_heartbeat_probe() -> None:
+    async with omnigent_activity_heartbeat(interval_seconds=0.01):
+        _safe_heartbeat(
+            {"omnigentSessionId": "session-replay", "eventsCaptured": 1}
+        )
+        await asyncio.sleep(0.035)
+
+
+async def test_profile_bound_activity_heartbeats_preflight_and_fences_cancelled_cleanup() -> None:
+    """Replay the resolver timeout/retry race at the Activity-host boundary."""
+
+    manifest = load_replay(
+        "omnigent-profile-bound-heartbeat-timeout", "manifest.json"
+    )
+    expected = load_replay(
+        "omnigent-profile-bound-heartbeat-timeout", "expected-outcome.json"
+    )
+    catalog = build_default_activity_catalog()
+    route = catalog.resolve_activity(manifest["activityType"])
+
+    assert route.timeouts.heartbeat_timeout_seconds == manifest[
+        "heartbeatTimeoutSeconds"
+    ]
+    assert expected["periodicLifecycleHeartbeat"] is True
+    assert expected["preservesStreamingHeartbeatState"] is True
+
+    heartbeats: list[tuple[object, ...]] = []
+    environment = ActivityEnvironment()
+    environment.on_heartbeat = lambda *details: heartbeats.append(details)
+    await environment.run(_omnigent_activity_heartbeat_probe)
+    heartbeat_payloads = [
+        detail
+        for callback_args in heartbeats
+        for detail in callback_args
+        if isinstance(detail, dict)
+    ]
+    assert len(heartbeat_payloads) >= 2
+    assert any(payload.get("activityAlive") is True for payload in heartbeat_payloads)
+    assert all(
+        payload.get("omnigentSessionId") == "session-replay"
+        for payload in heartbeat_payloads
+        if payload.get("activityAlive") is True
+    )
+
+    events, actions, owner_calls = await _run_coordinator_failure_case(
+        fail_at="session_create",
+        code="activity_cancelled",
+        injected_error=asyncio.CancelledError(),
+    )
+    cleanup_event = next(
+        payload
+        for event_type, payload in events
+        if event_type == "host_cleanup" and payload["status"] == "waiting"
+    )
+    assert cleanup_event["metadata"]["janitorRequired"] is True
+    assert expected["cancelledAttemptCleanup"] == "retry_or_janitor_reconciliation"
+    assert "host_stop" not in owner_calls
+    assert "provider_released" not in actions
+    assert expected["releaseProviderLeaseOnCancellation"] is False
+
+
+async def test_pr_resolver_child_compiles_bindable_stock_agent_identity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Replay the resolver child that selected the removed ``codex`` name."""
+
+    replay_id = "omnigent-stock-agent-catalog-identity"
+    manifest = load_replay(replay_id, "manifest.json")
+    expected = load_replay(replay_id, "expected-outcome.json")
+    workflow_info = SimpleNamespace(
+        namespace="default",
+        workflow_id=manifest["failedChildWorkflowId"],
+        run_id=manifest["failedChildRunId"],
+        parent=None,
+        search_attributes={},
+    )
+    monkeypatch.setattr(run_workflow_module.workflow, "info", lambda: workflow_info)
+    monkeypatch.setattr(run_workflow_module.workflow, "patched", lambda _patch: True)
+
+    workflow = MoonMindRunWorkflow()
+    workflow._profile_snapshots = manifest["profileSnapshots"]
+    request = workflow._build_agent_execution_request(
+        node_inputs=manifest["nodeInputs"],
+        workflow_parameters=manifest["workflowParameters"],
+        node_id="node-1",
+        tool_name="omnigent",
+    )
+
+    assert (
+        RUN_OMNIGENT_STOCK_AGENT_IDENTITY_PATCH
+        == "run-omnigent-stock-agent-identity-v1"
+    )
+    assert request.parameters["omnigent"]["agent"]["agentName"] == (
+        CODEX_STOCK_AGENT_NAME
+    )
+    bootstrap = bootstrap_document(
+        host_mode="on_demand_docker",
+        execution_profile_ref="omnigent-codex@1",
+    ).model_dump(by_alias=True, mode="json")
+    assert bootstrap["execution"]["agentIdentities"] == [
+        expected["bootstrapPolicyAgentIdentity"]
+    ]
+    assert manifest["cutoverAuthority"]["durableHostLaunchPolicyRef"] == (
+        expected["managedProfileLaunchPolicyRef"]
+    )
+    assert manifest["cutoverAuthority"]["staleManagedProfileLaunchPolicyRef"] != (
+        expected["managedProfileLaunchPolicyRef"]
+    )
+    assert expected["exactRerunLaunchPolicyRef"] == (
+        expected["managedProfileLaunchPolicyRef"]
+    )
+    assert expected["legacyTrustedIdentityRemovedFromAuthoredParameters"] is True
+    assert manifest["cutoverAuthority"]["staleExactRerunAgentProfileRef"].endswith(
+        "@1"
+    )
+
+    async def list_agents():
+        return [expected["catalogAgent"]]
+
+    async def reject_upload(_bundle_ref: str):
+        raise AssertionError("stock identity resolution must not upload a bundle")
+
+    bound_request = _bind_exact_host(
+        request,
+        host_id="host-stock-replay",
+        workspace_path="/workspaces/run",
+        profile_authorization={"providerProfileId": "codex_openai_oauth"},
+        harness="codex-native",
+        agent_name=CODEX_STOCK_AGENT_NAME,
+    )
+    target = await resolve_omnigent_target(
+        build_omnigent_selection(bound_request),
+        list_agents=list_agents,
+        upload_agent_bundle=reject_upload,
+        default_agent=None,
+    )
+    assert target.agent_id == expected["resolvedAgentId"]
+    assert target.agent_name == expected["resolvedAgentName"]
 
 
 async def test_runtime_switch_rebinds_managed_session_authority_before_activity() -> (
@@ -1041,6 +1238,1224 @@ async def test_omnigent_agent_profile_rerun_compiles_trusted_snapshot(
     assert request.parameters["omnigent"] == expected["omnigent"]
 
 
+async def test_omnigent_lifecycle_retry_preserves_long_event_identities(
+    tmp_path: Path,
+) -> None:
+    """Replay mm:96eb128d at the lifecycle journal persistence boundary."""
+
+    replay_id = "omnigent-lifecycle-dedup-retry"
+    manifest = load_replay(replay_id, "manifest.json")
+    expected = load_replay(replay_id, "expected-outcome.json")
+    engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path}/bridge.db")
+    try:
+        async with engine.begin() as connection:
+            await connection.run_sync(Base.metadata.create_all)
+        store = OmnigentBridgeSessionStore(
+            async_sessionmaker(engine, expire_on_commit=False)
+        )
+        request = AgentExecutionRequest.model_validate(manifest["request"])
+        row = await store.get_or_create(
+            request=request,
+            endpoint_ref="pending",
+            agent_id=None,
+            agent_name=None,
+            target_metadata={},
+        )
+
+        for identity in manifest["lifecycleEventIdentities"]:
+            await store.record_lifecycle_event(
+                request.idempotency_key,
+                event_type="request_validated",
+                event_identity=identity,
+            )
+            await store.record_lifecycle_event(
+                request.idempotency_key,
+                event_type="request_validated",
+                event_identity=identity,
+            )
+
+        events = await store.list_events(row.bridge_session_id)
+        keys = [event.deduplication_key for event in events]
+        assert len(events) == expected["eventCount"]
+        assert len(set(keys)) == expected["distinctDeduplicationKeyCount"]
+        assert max(map(len, keys)) <= expected["maximumDeduplicationKeyLength"]
+        assert [event.metadata_["eventIdentity"] for event in events] == manifest[
+            "lifecycleEventIdentities"
+        ]
+    finally:
+        await engine.dispose()
+
+
+async def test_omnigent_auto_run_resolves_empty_skill_projection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Replay mm:717ea339 at the parent-to-AgentRun skill handoff."""
+
+    replay_id = "omnigent-auto-skill-projection"
+    manifest = load_replay(replay_id, "manifest.json")
+    expected = load_replay(replay_id, "expected-outcome.json")
+    workflow_info = SimpleNamespace(
+        namespace="default",
+        workflow_id=manifest["incidentWorkflowId"],
+        run_id=manifest["incidentRunId"],
+        parent=None,
+        search_attributes={},
+    )
+
+    async def resolve_skillset(*_args: object, **_kwargs: object) -> object:
+        return manifest["resolvedSkillSet"]
+
+    monkeypatch.setattr(run_workflow_module.workflow, "info", lambda: workflow_info)
+    monkeypatch.setattr(run_workflow_module.workflow, "patched", lambda _patch: True)
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "execute_activity",
+        resolve_skillset,
+    )
+    parent = MoonMindRunWorkflow()
+    parent._owner_id = manifest["ownerId"]
+    parent._step_ledger_rows = [
+        {"logicalStepId": manifest["logicalStepId"], "attempt": 1}
+    ]
+
+    resolved_ref = await parent._resolve_agent_node_skillset_ref(
+        task_skills=None,
+        node_inputs=manifest["nodeInputs"],
+        node_id=manifest["logicalStepId"],
+        existing_skillset_ref=None,
+    )
+    request = parent._build_agent_execution_request(
+        node_inputs=manifest["nodeInputs"],
+        node_id=manifest["logicalStepId"],
+        tool_name="omnigent",
+        resolved_skillset_ref=resolved_ref,
+    )
+
+    assert resolved_ref == expected["resolvedSkillsetRef"]
+    assert request.resolved_skillset_ref == expected["resolvedSkillsetRef"]
+    assert request.step_execution is not None
+    assert (
+        request.step_execution.resolved_skillset_ref
+        == expected["resolvedSkillsetRef"]
+    )
+
+
+async def test_omnigent_egress_attestation_uses_docker_command_boundary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Replay mm:706d05e2 at the trusted Docker command boundary."""
+
+    replay_id = "omnigent-egress-attestation-command"
+    manifest = load_replay(replay_id, "manifest.json")
+    expected = load_replay(replay_id, "expected-outcome.json")
+    runtime = OmnigentOAuthHostRuntime(client=SimpleNamespace())
+    runtime._run = AsyncMock(return_value=(0, "{}", ""))
+
+    async def attest(*, runner, profile, backend_ref):
+        assert profile == OMNIGENT_EGRESS_PROFILE
+        assert backend_ref == manifest["backendRef"]
+        await runner(tuple(manifest["attestationSubcommand"]))
+        return {"status": "passed"}
+
+    monkeypatch.setattr(
+        oauth_host_runtime_module,
+        "attest_docker_egress",
+        attest,
+    )
+
+    result = await runtime._attest_egress(
+        {"networkRef": manifest["networkRef"]}
+    )
+
+    assert result == {"status": "passed"}
+    runtime._run.assert_awaited_once_with(
+        *expected["runtimeCommand"],
+        check=False,
+    )
+
+
+async def test_omnigent_runtime_scripts_cross_remote_daemon_path_boundary(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Replay mm:b2f61d86 at the worker-to-Docker bind boundary."""
+
+    replay_id = "omnigent-runtime-scripts-daemon-path"
+    manifest = load_replay(replay_id, "manifest.json")
+    expected = load_replay(replay_id, "expected-outcome.json")
+    source = tmp_path / "source-scripts"
+    source.mkdir()
+    for name in manifest["requiredScripts"]:
+        script = source / name
+        script.write_text("#!/bin/sh\n", encoding="utf-8")
+        script.chmod(0o755)
+    worker_root = tmp_path / "worker-root"
+    daemon_root = Path(expected["daemonRoot"]).resolve()
+    monkeypatch.setenv("WORKFLOW_DOCKER_DAEMON_MODE", "remote")
+    monkeypatch.setenv("WORKFLOW_WORKSPACE_ROOT", str(worker_root))
+    monkeypatch.setenv("WORKFLOW_WORKSPACE_DAEMON_ROOT", str(daemon_root))
+    runtime = OmnigentOAuthHostRuntime(
+        client=SimpleNamespace(),
+        scripts_dir=source,
+        workspace_root=worker_root,
+    )
+
+    daemon_scripts = runtime._prepare_daemon_runtime_scripts(
+        manifest["workspaceKey"],
+        current_step_execution_id="workflow:run:step:execution:1",
+    )
+
+    assert daemon_scripts == Path(expected["daemonScriptsPath"]).resolve()
+    relative = daemon_scripts.relative_to(daemon_root)
+    worker_scripts = worker_root / relative
+    assert worker_scripts != source
+    assert all((worker_scripts / name).is_file() for name in manifest["requiredScripts"])
+    assert (worker_scripts / "moonmind-execution.sh").is_file()
+
+
+async def test_agent_workspace_daemon_root_uses_compose_volume_identity() -> None:
+    """Replay mm:cdf36806 at the Compose-to-Docker volume boundary."""
+
+    replay_id = "agent-workspaces-daemon-root"
+    load_replay(replay_id, "manifest.json")
+    expected = load_replay(replay_id, "expected-outcome.json")
+    compose = yaml.safe_load(
+        (REPO_ROOT / "docker-compose.yaml").read_text(encoding="utf-8")
+    )
+    worker_environment = {
+        key: value
+        for key, value in (
+            entry.split("=", 1)
+            for entry in compose["services"]["temporal-worker-agent-runtime"][
+                "environment"
+            ]
+            if "=" in entry
+        )
+    }
+
+    assert (
+        compose["volumes"]["agent_workspaces"]["name"]
+        == expected["volumeNameTemplate"]
+    )
+    assert (
+        worker_environment["MOONMIND_AGENT_WORKSPACES_VOLUME_NAME"]
+        == expected["volumeNameTemplate"]
+    )
+    assert (
+        worker_environment["WORKFLOW_WORKSPACE_DAEMON_ROOT"]
+        == expected["daemonRootTemplate"]
+    )
+
+
+async def test_omnigent_host_entrypoint_arguments_follow_image_boundary(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Replay mm:e96347f3 at the Docker options-to-entrypoint boundary."""
+
+    replay_id = "omnigent-host-entrypoint-env-order"
+    manifest = load_replay(replay_id, "manifest.json")
+    expected = load_replay(replay_id, "expected-outcome.json")
+    login_manifest = load_replay("omnigent-host-login-tools-path", "manifest.json")
+    login_expected = load_replay(
+        "omnigent-host-login-tools-path", "expected-outcome.json"
+    )
+    monkeypatch.setenv("OMNIGENT_IMAGE_REF", manifest["hostImageRef"])
+    monkeypatch.setenv("OMNIGENT_HOST_IMAGE_REF", manifest["hostImageRef"])
+    runtime = OmnigentOAuthHostRuntime(
+        client=SimpleNamespace(),
+        scripts_dir=tmp_path,
+        workspace_root=tmp_path / "workspaces",
+    )
+    runtime.container_exists = AsyncMock(return_value=False)
+    runtime._discover_upstream_path = AsyncMock(return_value="/usr/bin:/bin")
+    runtime._run = AsyncMock(
+        side_effect=[
+            (1, "", "no such container"),
+            (0, "", ""),
+            (0, "container-id", ""),
+        ]
+    )
+    binding = _oauth_binding().model_copy(
+        update={"static_host_id": None, "host_launch_profile_ref": "codex-oauth-v1"}
+    )
+    host_lease = _oauth_host_lease().model_copy(
+        update={"container_name": "mm-host-replay"}
+    )
+    effective_launch = compile_effective_launch(
+        profile_ref="omnigent-codex@1",
+        policy_ref="codex-on-demand@1",
+        provider_profile_id="codex",
+    )
+    effective_launch["hostImageRef"] = manifest["hostImageRef"]
+
+    await runtime._launch_on_demand(
+        binding=binding,
+        host_lease=host_lease,
+        container_name="mm-host-replay",
+        workspace_source=tmp_path,
+        skill_projection=tmp_path / "skills",
+        runtime_scripts=tmp_path,
+        current_step_execution_id="workflow:run:node-1:execution:1",
+        effective_launch=effective_launch,
+    )
+
+    command = runtime._run.await_args_list[-1].args
+    image_index = command.index(manifest["hostImageRef"])
+    assert command[image_index - 1] == expected["entrypoint"]
+    assert command[image_index + 1 : image_index + 3] == (
+        "-u",
+        expected["firstUnsetVariable"],
+    )
+    assert command[-1] == expected["startScript"]
+    assert login_manifest["hostImageRef"] == manifest["hostImageRef"]
+    assert (
+        "type=bind,"
+        f"src={tmp_path / login_expected['sourceName']},"
+        f"dst={login_expected['containerPath']},readonly"
+    ) in command
+
+
+async def test_omnigent_stock_host_catalog_resolves_lease_owned_host() -> None:
+    """Replay mm:99f6a4a0 at the stock host-catalog boundary."""
+
+    replay_id = "omnigent-stock-host-catalog-contract"
+    manifest = load_replay(replay_id, "manifest.json")
+    expected = load_replay(replay_id, "expected-outcome.json")
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == expected["path"]
+        return httpx.Response(
+            200,
+            json={
+                "hosts": [
+                    {
+                        "host_id": expected["hostId"],
+                        "name": manifest["containerName"],
+                        "status": "online",
+                        "configured_harnesses": {expected["harness"]: True},
+                    }
+                ]
+            },
+        )
+
+    client = oauth_host_runtime_module.OmnigentHttpClient(
+        base_url="https://omnigent.test",
+        transport=httpx.MockTransport(handler),
+    )
+    runtime = OmnigentOAuthHostRuntime(client=client)
+    binding = _oauth_binding().model_copy(
+        update={"static_host_id": None, "host_launch_profile_ref": "codex-oauth-v1"}
+    )
+    host_lease = _oauth_host_lease().model_copy(
+        update={
+            "container_name": manifest["containerName"],
+            "omnigent_host_id": None,
+        }
+    )
+
+    host = await runtime._resolve_exact_host(
+        binding=binding,
+        host_lease=host_lease,
+    )
+
+    assert host["host_id"] == expected["hostId"]
+    assert runtime._ready_host_harnesses(host) == {expected["harness"]}
+
+
+async def test_omnigent_host_registration_waits_for_catalog_publication(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Replay mm:963a26ba at the host-registration publication boundary."""
+
+    replay_id = "omnigent-host-registration-publication"
+    manifest = load_replay(replay_id, "manifest.json")
+    expected = load_replay(replay_id, "expected-outcome.json")
+    client = SimpleNamespace()
+    client.list_hosts = AsyncMock(
+        side_effect=[
+            [
+                {
+                    "host_id": host_id,
+                    "name": manifest["containerName"],
+                    "status": "online",
+                }
+                for host_id in catalog
+            ]
+            for catalog in manifest["catalogSequence"]
+        ]
+    )
+    runtime = OmnigentOAuthHostRuntime(client=client)
+    binding = _oauth_binding().model_copy(
+        update={"static_host_id": None, "host_launch_profile_ref": "codex-oauth-v1"}
+    )
+    host_lease = _oauth_host_lease().model_copy(
+        update={
+            "container_name": manifest["containerName"],
+            "omnigent_host_id": None,
+        }
+    )
+    sleep = AsyncMock()
+    monkeypatch.setattr(oauth_host_runtime_module.asyncio, "sleep", sleep)
+
+    host = await runtime._resolve_exact_host(
+        binding=binding,
+        host_lease=host_lease,
+    )
+
+    assert host["host_id"] == expected["hostId"]
+    assert client.list_hosts.await_count == expected["catalogReadCount"]
+    assert sleep.await_count == expected["sleepCount"]
+    sleep.assert_awaited_with(expected["sleepSeconds"])
+
+
+async def test_omnigent_host_registration_covers_observed_long_tail(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Replay mm:e8ca7030 after two premature host teardowns."""
+
+    replay_id = "omnigent-host-registration-long-publication"
+    manifest = load_replay(replay_id, "manifest.json")
+    expected = load_replay(replay_id, "expected-outcome.json")
+    ready_host = {
+        "host_id": expected["hostId"],
+        "name": manifest["containerName"],
+        "status": "online",
+        "configured_harnesses": {"codex-native": True},
+    }
+    client = SimpleNamespace(
+        list_hosts=AsyncMock(
+            side_effect=[
+                *([[]] * manifest["emptyCatalogReads"]),
+                [ready_host],
+            ]
+        )
+    )
+    runtime = OmnigentOAuthHostRuntime(client=client)
+    binding = _oauth_binding().model_copy(
+        update={"static_host_id": None, "host_launch_profile_ref": "codex-oauth-v1"}
+    )
+    host_lease = _oauth_host_lease().model_copy(
+        update={
+            "container_name": manifest["containerName"],
+            "omnigent_host_id": None,
+        }
+    )
+    sleep = AsyncMock()
+    monkeypatch.setattr(oauth_host_runtime_module.asyncio, "sleep", sleep)
+
+    host = await runtime._resolve_exact_host(
+        binding=binding,
+        host_lease=host_lease,
+    )
+
+    assert host["host_id"] == expected["hostId"]
+    assert client.list_hosts.await_count == expected["catalogReadCount"]
+    assert sleep.await_count == expected["sleepCount"]
+    sleep.assert_awaited_with(expected["sleepSeconds"])
+
+
+async def test_tool_output_only_omnigent_turn_continues_before_publication(
+    tmp_path: Path,
+) -> None:
+    """Replay mm:651a14f6 at the session-terminal/publication handoff."""
+
+    replay_id = "omnigent-tool-output-terminal-continuation"
+    manifest = load_replay(replay_id, "manifest.json")
+    expected = load_replay(replay_id, "expected-outcome.json")
+    inspector = OmnigentOAuthHostRuntime(
+        client=SimpleNamespace(
+            get_session=AsyncMock(
+                return_value={
+                    "status": manifest["sessionStatus"],
+                    "items": manifest["items"],
+                }
+            )
+        ),
+        scripts_dir=tmp_path,
+        workspace_root=tmp_path / "workspaces",
+    )
+    incomplete = await inspector.inspect_session_completion(
+        expected["resumeSessionId"]
+    )
+    assert incomplete["terminalAssistantAfterWork"] is expected[
+        "terminalAssistantAfterWork"
+    ]
+    assert incomplete["toolResultCount"] == expected["toolResultCount"]
+
+    runner_calls: list[dict[str, object]] = []
+
+    async def execute(_request, **kwargs):
+        runner_calls.append(dict(kwargs))
+        return AgentRunResult(
+            summary="turn complete",
+            metadata={"omnigentSessionId": expected["resumeSessionId"]},
+        )
+
+    completed = {
+        **incomplete,
+        "itemCount": incomplete["itemCount"] + 2,
+        "assistantMessageCount": incomplete["assistantMessageCount"] + 1,
+        "terminalAssistantAfterWork": True,
+    }
+    _ordered, _authority, metadata, result = (
+        await _drive_authority_chain_coordinator(
+            execute,
+            completion_evidence=[incomplete, completed],
+        )
+    )
+
+    assert result.failure_class is None
+    assert metadata["push_status"] == expected["pushStatus"]
+    assert metadata["repositoryContinuationCount"] == expected[
+        "continuationCount"
+    ]
+    assert runner_calls[1]["resume_session_id"] == expected["resumeSessionId"]
+
+
+async def test_unposted_terminal_bridge_reopens_for_temporal_activity_retry(
+    tmp_path: Path,
+) -> None:
+    """Replay mm:651a14f6 at the failed-preflight Activity retry boundary."""
+
+    replay_id = "omnigent-unposted-activity-retry"
+    manifest = load_replay(replay_id, "manifest.json")
+    expected = load_replay(replay_id, "expected-outcome.json")
+    engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path}/bridge.db")
+    async with engine.begin() as connection:
+        await connection.run_sync(Base.metadata.create_all)
+    sessions = async_sessionmaker(engine, expire_on_commit=False)
+    store = OmnigentBridgeSessionStore(sessions)
+    request = AgentExecutionRequest(
+        agentKind="external",
+        agentId="omnigent",
+        correlationId=manifest["incidentWorkflowId"],
+        idempotencyKey=manifest["idempotencyKey"],
+    )
+    try:
+        await store.get_or_create(
+            request=request,
+            endpoint_ref="pending",
+            agent_id=None,
+            agent_name=None,
+            target_metadata={},
+        )
+        await store.mark_terminal(
+            request.idempotency_key,
+            status="failed",
+            terminal_refs=manifest["terminalRefs"],
+        )
+
+        reopened = await store.get_or_create(
+            request=request,
+            endpoint_ref="pending",
+            agent_id=None,
+            agent_name=None,
+            target_metadata={},
+        )
+    finally:
+        await engine.dispose()
+
+    assert reopened.status == expected["status"]
+    assert reopened.first_message_state == expected["firstMessageState"]
+    assert reopened.omnigent_session_id is expected["omnigentSessionId"]
+    assert reopened.metadata_["unpostedAttemptHistory"][-1]["status"] == expected[
+        "archivedAttemptStatus"
+    ]
+
+
+async def test_abandoned_omnigent_host_cleanup_releases_provider_capacity() -> None:
+    """Replay mm:651a14f6 after cancellation killed its coordinator Activity."""
+
+    replay_id = "omnigent-abandoned-provider-lease"
+    manifest = load_replay(replay_id, "manifest.json")
+    expected = load_replay(replay_id, "expected-outcome.json")
+    now = datetime.now(timezone.utc)
+    order: list[str] = []
+    lease = SimpleNamespace(
+        lease_id=manifest["hostLeaseRef"],
+        provider_profile_id=manifest["providerProfileId"],
+        provider_lease_id=manifest["providerLeaseRef"],
+        binding_ref="binding-1",
+        container_name="host-1",
+        omnigent_session_id=None,
+        last_heartbeat_at=now,
+        expires_at=now.replace(year=now.year + 1),
+        status="stopped",
+    )
+
+    async def stop_host(**_kwargs):
+        order.append("host_stopped")
+
+    async def release_provider(released):
+        order.append("provider_released")
+        assert released.lease_id == manifest["providerLeaseRef"]
+        assert released.owner_id == manifest["providerLeaseRef"]
+
+    async def mark_stopped(_lease_id):
+        order.append("host_lease_stopped")
+        lease.status = "stopped"
+        return lease
+
+    repository = SimpleNamespace(
+        list_active_host_leases=AsyncMock(return_value=[]),
+        list_terminal_host_leases_with_active_provider_capacity=AsyncMock(
+            return_value=[lease]
+        ),
+        validate_binding=AsyncMock(
+            return_value=SimpleNamespace(
+                credential_mount_ref=SimpleNamespace(
+                    auth_volume_ref=SimpleNamespace(runtime_id="codex_cli")
+                )
+            )
+        ),
+        mark_host_lease_stopped=AsyncMock(side_effect=mark_stopped),
+    )
+    runtime = SimpleNamespace(
+        container_exists=AsyncMock(return_value=True),
+        stop_host=AsyncMock(side_effect=stop_host),
+        list_managed_containers=AsyncMock(return_value=[]),
+    )
+    run_store = SimpleNamespace(
+        cleanup_required_host_lease_refs=AsyncMock(
+            return_value={manifest["hostLeaseRef"]}
+        )
+    )
+
+    result = await OmnigentOAuthHostJanitor(
+        repository=repository,
+        runtime=runtime,
+        client=SimpleNamespace(),
+        run_store=run_store,
+        lease_client=SimpleNamespace(
+            release_lease=AsyncMock(side_effect=release_provider)
+        ),
+    ).run()
+
+    assert order == expected["releaseOrder"]
+    assert result["actions"][-1]["providerLeaseReleased"] is True
+
+
+async def test_terminal_activity_owner_is_reclaimed_after_late_slot_grant() -> None:
+    """Replay the AcquireSlot update completing after its Activity timed out."""
+
+    replay_id = "provider-profile-activity-grant-after-timeout"
+    manifest = load_replay(replay_id, "manifest.json")
+    expected = load_replay(replay_id, "expected-outcome.json")
+    manager = MoonMindProviderProfileManagerWorkflow()
+    manager._profiles[manifest["providerProfileId"]] = ProfileSlotState(
+        profile_id=manifest["providerProfileId"],
+        max_parallel_runs=1,
+        cooldown_after_429_seconds=300,
+        rate_limit_policy="backoff",
+        enabled=True,
+        is_default=True,
+        current_leases=[manifest["providerLeaseRef"]],
+        lease_metadata={
+            manifest["providerLeaseRef"]: {
+                "ownerIsWorkflow": False,
+                "workflowId": manifest["terminalWorkflowId"],
+            }
+        },
+    )
+
+    holder_ids = manager._lease_holder_workflow_ids(include_activity_owned=True)
+    reclaimed = manager._reclaim_terminal_leases(
+        {
+            manifest["terminalWorkflowId"]: {
+                "running": False,
+                "status": manifest["terminalStatus"],
+            }
+        },
+        include_activity_owned=True,
+    )
+
+    assert holder_ids == [manifest["terminalWorkflowId"]]
+    assert reclaimed is expected["reclaimed"]
+    assert manager._profiles[manifest["providerProfileId"]].current_leases == []
+
+
+async def test_completed_profile_manager_update_reopens_within_activity() -> None:
+    """Replay the manager completing between ensure and accepted Update."""
+
+    from temporalio.client import WorkflowUpdateFailedError
+    from temporalio.exceptions import ApplicationError
+
+    replay_id = "provider-profile-manager-completed-update"
+    manifest = load_replay(replay_id, "manifest.json")
+    expected = load_replay(replay_id, "expected-outcome.json")
+
+    class Adapter:
+        def __init__(self) -> None:
+            self.ensure_count = 0
+            self.update_count = 0
+
+        async def get_client(self):
+            return self
+
+        async def start_workflow(self, *_args, **_kwargs):
+            self.ensure_count += 1
+
+        async def update_workflow(self, _workflow_id, update_name, payload):
+            self.update_count += 1
+            assert update_name == manifest["updateName"]
+            assert payload["requester_workflow_id"] == manifest["ownerId"]
+            if self.update_count == 1:
+                raise WorkflowUpdateFailedError(
+                    ApplicationError(
+                        "manager completed before accepted Update completed",
+                        type=manifest["failureType"],
+                        non_retryable=True,
+                    )
+                )
+            return {
+                "profile_id": manifest["providerProfileId"],
+                "lease_id": manifest["ownerId"],
+            }
+
+    adapter = Adapter()
+    lease = await ProviderProfileLeaseClient(adapter).acquire_execution_lease(
+        runtime_id=manifest["runtimeId"],
+        profile_id=manifest["providerProfileId"],
+        owner_id=manifest["ownerId"],
+        purpose=CredentialLeasePurpose.EXECUTION_OMNIGENT,
+    )
+
+    assert adapter.ensure_count == expected["managerEnsureCount"]
+    assert adapter.update_count == expected["managerUpdateCount"]
+    assert (lease.owner_id == manifest["ownerId"]) is expected[
+        "ownerIdentityPreserved"
+    ]
+    assert bool(lease.lease_id) is expected["leaseGranted"]
+    assert expected["activityAttemptConsumed"] is False
+
+
+async def test_replayed_terminal_event_waits_for_current_marked_turn() -> None:
+    """Replay mm:63c53791 continuation messages racing stale SSE terminal state."""
+
+    replay_id = "omnigent-stale-terminal-before-continuation"
+    manifest = load_replay(replay_id, "manifest.json")
+    expected = load_replay(replay_id, "expected-outcome.json")
+
+    assert _snapshot_contains_current_turn_progress(
+        manifest["staleTerminalSnapshot"], marker=manifest["currentTurnMarker"]
+    ) is expected["acceptStaleTerminal"]
+    assert _snapshot_contains_current_turn_progress(
+        manifest["progressedSnapshot"], marker=manifest["currentTurnMarker"]
+    ) is True
+    assert _snapshot_confirms_current_turn_terminal(
+        manifest["progressedSnapshot"], marker=manifest["currentTurnMarker"]
+    ) is expected["acceptProgressedTerminal"]
+    assert _snapshot_confirms_current_turn_terminal(
+        manifest["terminalSnapshot"], marker=manifest["currentTurnMarker"]
+    ) is expected["acceptTerminalSnapshot"]
+
+    class BusyNativeClient:
+        def __init__(self) -> None:
+            self.calls = 0
+            self.snapshots = [
+                manifest["assistantPreambleSnapshot"],
+                *manifest["busyIdleSnapshots"],
+            ]
+
+        async def get_session(self, _session_id: str) -> dict[str, object]:
+            index = min(self.calls, len(self.snapshots) - 1)
+            self.calls += 1
+            return self.snapshots[index]
+
+    client = BusyNativeClient()
+    response_ids = {
+        item["response_id"]
+        for snapshot in client.snapshots
+        for item in snapshot["items"]
+    }
+    assert response_ids == {manifest["sharedNativeResponseId"]}
+    status, snapshot = await _await_marked_turn_terminal(
+        client=client,
+        session_id="session-replay",
+        marker=manifest["currentTurnMarker"],
+        event_count=8,
+        terminal_status="completed",
+        interval_seconds=0.001,
+        quiet_period_seconds=0.02,
+        tool_only_quiet_period_seconds=0.02,
+    )
+
+    assert status == "completed"
+    assert snapshot["items"][-1]["id"] == "output-2"
+    assert client.calls >= expected["minimumBusySnapshotsObserved"]
+    assert expected["requiresStableQuietPeriod"] is True
+    assert expected["assistantPreambleRequiresStableQuietPeriod"] is True
+    assert expected["unfinishedToolCallBlocksCompletion"] is True
+    assert expected["toolOnlyQuietPeriodSeconds"] == 300
+
+
+async def test_omnigent_server_is_reachable_from_isolated_host_network() -> None:
+    """Replay mm:89e60946 at the host-to-server network boundary."""
+
+    replay_id = "omnigent-host-server-network-reachability"
+    load_replay(replay_id, "manifest.json")
+    expected = load_replay(replay_id, "expected-outcome.json")
+    compose = yaml.safe_load(
+        (REPO_ROOT / "docker-compose.yaml").read_text(encoding="utf-8")
+    )
+
+    assert set(compose["services"]["omnigent"]["networks"]) == set(
+        expected["serverNetworks"]
+    )
+    assert set(
+        compose["services"]["omnigent-host-codex"]["networks"]
+    ) == set(expected["hostNetworks"])
+    assert compose["networks"]["omnigent-egress-network"]["internal"] is True
+
+
+async def test_omnigent_injected_client_preserves_execution_timeouts() -> None:
+    """Replay mm:64c19951 at the Omnigent client transport boundary."""
+
+    replay_id = "omnigent-injected-client-timeout-contract"
+    manifest = load_replay(replay_id, "manifest.json")
+    expected = load_replay(replay_id, "expected-outcome.json")
+    observed: dict[str, dict[str, float | None]] = {}
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        observed[request.url.path] = dict(request.extensions["timeout"])
+        if request.url.path.endswith("/stream"):
+            return httpx.Response(
+                200,
+                headers={"content-type": "text/event-stream"},
+                content=b"data: [DONE]\n\n",
+            )
+        return httpx.Response(202, json={"queued": True})
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handler)
+    ) as injected_client:
+        client = oauth_host_runtime_module.OmnigentHttpClient(
+            base_url="https://omnigent.test",
+            timeout_seconds=manifest["requestTimeoutSeconds"],
+            stream_timeout_seconds=None,
+            client=injected_client,
+        )
+        await client.post_event(manifest["sessionId"], {"type": "message"})
+        assert [event async for event in client.stream_events(manifest["sessionId"])] == []
+
+    assert observed[f"/v1/sessions/{manifest['sessionId']}/events"] == expected[
+        "requestTimeout"
+    ]
+    assert observed[f"/v1/sessions/{manifest['sessionId']}/stream"] == expected[
+        "streamTimeout"
+    ]
+
+
+async def test_omnigent_stock_sse_event_catalog_is_normalized() -> None:
+    """Replay mm:60a4ed2c against the complete stock SSE event catalog."""
+
+    replay_id = "omnigent-stock-sse-event-contract"
+    manifest = load_replay(replay_id, "manifest.json")
+    expected = load_replay(replay_id, "expected-outcome.json")
+    request = AgentExecutionRequest(
+        agentKind="external",
+        agentId="omnigent",
+        executionProfileRef="profile:test",
+        correlationId=manifest["incidentWorkflowId"],
+        idempotencyKey="stock-sse-replay",
+    )
+
+    observed: dict[str, str] = {}
+    sequence = 0
+    for normalized_status, event_types in expected["eventTypesByStatus"].items():
+        for event_type in event_types:
+            sequence += 1
+            result = build_omnigent_bridge_event(
+                payload={"type": event_type},
+                sequence=sequence,
+                request=request,
+                omnigent_session_id=manifest["omnigentSessionId"],
+            )
+            observed[event_type] = result.event["normalizedStatus"]
+            assert result.diagnostic is None
+
+    for case in expected["sessionStatusCases"]:
+        sequence += 1
+        result = build_omnigent_bridge_event(
+            payload={"type": "session.status", "status": case["input"]},
+            sequence=sequence,
+            request=request,
+            omnigent_session_id=manifest["omnigentSessionId"],
+        )
+        assert result.event["normalizedStatus"] == case["normalizedStatus"]
+
+    assert len(observed) == expected["stockEventTypeCountWithoutSessionStatus"]
+
+
+async def test_omnigent_on_demand_runner_inherits_enforced_proxy_environment(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Replay mm:933a5f44 at the host-to-runner environment boundary."""
+
+    replay_id = "omnigent-runner-proxy-passthrough"
+    manifest = load_replay(replay_id, "manifest.json")
+    expected = load_replay(replay_id, "expected-outcome.json")
+    monkeypatch.setenv("OMNIGENT_IMAGE_REF", manifest["hostImageRef"])
+    monkeypatch.setenv("OMNIGENT_HOST_IMAGE_REF", manifest["hostImageRef"])
+    runtime = OmnigentOAuthHostRuntime(
+        client=SimpleNamespace(),
+        scripts_dir=tmp_path,
+        workspace_root=tmp_path / "workspaces",
+    )
+    runtime.container_exists = AsyncMock(return_value=False)
+    runtime._discover_upstream_path = AsyncMock(return_value="/usr/bin:/bin")
+    runtime._run = AsyncMock(
+        side_effect=[(1, "", "no such container"), (0, "", ""), (0, "", "")]
+    )
+    binding = _oauth_binding().model_copy(
+        update={"static_host_id": None, "host_launch_profile_ref": "codex-oauth-v1"}
+    )
+    host_lease = _oauth_host_lease().model_copy(
+        update={
+            "container_name": manifest["containerName"],
+            "omnigent_host_id": None,
+        }
+    )
+
+    await runtime._launch_on_demand(
+        binding=binding,
+        host_lease=host_lease,
+        container_name=manifest["containerName"],
+        workspace_source=tmp_path,
+        skill_projection=tmp_path / "skills",
+        runtime_scripts=tmp_path,
+        current_step_execution_id="workflow:run:node-1:execution:1",
+        github_token="fixture-token",
+        effective_launch=compile_effective_launch(
+            profile_ref="omnigent-codex@1",
+            policy_ref="codex-on-demand@1",
+            provider_profile_id="codex",
+        ),
+    )
+
+    launch_command = runtime._run.await_args_list[-1].args
+    passthrough = next(
+        value.partition("=")[2]
+        for value in launch_command
+        if value.startswith("OMNIGENT_RUNNER_ENV_PASSTHROUGH=")
+    )
+    assert passthrough.split(",") == expected["passthroughNames"]
+
+
+async def test_omnigent_codex_remote_bridge_has_loopback_only_proxy_bypass() -> None:
+    """Replay mm:b99b4a69 at the Codex TUI-to-app-server boundary."""
+
+    replay_id = "omnigent-codex-remote-loopback"
+    manifest = load_replay(replay_id, "manifest.json")
+    expected = load_replay(replay_id, "expected-outcome.json")
+    proxy_environment = dict(
+        value.split("=", 1) for value in omnigent_proxy_env()
+    )
+
+    assert manifest["codexRemoteUrl"].startswith("ws://127.0.0.1:")
+    assert proxy_environment["NO_PROXY"] == expected["noProxy"]
+    assert proxy_environment["no_proxy"] == expected["noProxy"]
+    assert set(proxy_environment["NO_PROXY"].split(",")) == set(
+        expected["loopbackHosts"]
+    )
+    assert manifest["omnigentServerHost"] not in proxy_environment["NO_PROXY"]
+
+
+async def test_omnigent_workspace_owner_matches_isolated_host_identity(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Replay mm:cbb14c76 at workspace-to-host identity handoff."""
+
+    replay_id = "omnigent-workspace-runtime-ownership"
+    load_replay(replay_id, "manifest.json")
+    expected = load_replay(replay_id, "expected-outcome.json")
+    workspace_root = tmp_path / "workspaces"
+    workspace = workspace_root / "run" / "repo"
+    workspace.mkdir(parents=True)
+    tracked = workspace / "tracked.txt"
+    tracked.write_text("tracked", encoding="utf-8")
+    outside = tmp_path / "outside.txt"
+    outside.write_text("outside", encoding="utf-8")
+    link = workspace / "outside-link"
+    link.symlink_to(outside)
+    observed: list[tuple[Path, int, int, bool]] = []
+
+    def record_chown(path, uid, gid, *, follow_symlinks=True):
+        observed.append((Path(path), uid, gid, follow_symlinks))
+
+    monkeypatch.setattr(oauth_host_runtime_module.os, "chown", record_chown)
+    runtime = OmnigentOAuthHostRuntime(
+        client=SimpleNamespace(),
+        workspace_root=workspace_root,
+    )
+    runtime._align_workspace_ownership(
+        workspace,
+        runtime_uid=expected["runtimeUid"],
+        runtime_gid=expected["runtimeGid"],
+    )
+    runtime._run = AsyncMock(return_value=(0, "", ""))
+    await runtime._exec_check("mm-omnigent-host-replay")
+
+    observed_paths = {path for path, _uid, _gid, _follow in observed}
+    assert {workspace.resolve(), tracked, link} <= observed_paths
+    assert outside not in observed_paths
+    assert all(
+        (uid, gid, follow)
+        == (expected["runtimeUid"], expected["runtimeGid"], False)
+        for _path, uid, gid, follow in observed
+    )
+    assert list(runtime._run.await_args_list[-1].args) == expected["gitPreflight"]
+
+
+async def test_omnigent_hybrid_checkpoint_keeps_session_and_workspace_planes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Replay mm:595b687c at post-execution checkpoint capture."""
+
+    replay_id = "omnigent-hybrid-checkpoint-planes"
+    manifest = load_replay(replay_id, "manifest.json")
+    expected = load_replay(replay_id, "expected-outcome.json")
+    workflow_info = SimpleNamespace(
+        namespace="default",
+        workflow_id=manifest["incidentWorkflowId"],
+        run_id=manifest["incidentRunId"],
+        task_queue="mm.workflow.merge_automation",
+        search_attributes={},
+    )
+    monkeypatch.setattr(run_workflow_module.workflow, "info", lambda: workflow_info)
+    monkeypatch.setattr(run_workflow_module.workflow, "patched", lambda _patch: True)
+    parent = MoonMindRunWorkflow()
+    now = datetime(2026, 8, 5, 20, 11, tzinfo=timezone.utc)
+    parent._initialize_step_ledger(
+        ordered_nodes=[{"id": "node-1", "inputs": {"title": "Implement"}}],
+        dependency_map={"node-1": []},
+        updated_at=now,
+    )
+    parent._mark_step_running("node-1", updated_at=now, summary="Implementing")
+    parent._record_step_workspace_capture_input(
+        "node-1",
+        manifest["initialInputs"],
+        initialize_omnigent_capture=True,
+    )
+    parent._record_step_workspace_capture_input("node-1", manifest["resultOutputs"])
+    captured: list[dict[str, object]] = []
+
+    async def fake_execute_activity(activity, payload, **_kwargs):
+        captured.append({"activity": activity, "payload": payload})
+        if activity == expected["captureActivity"]:
+            return {
+                "status": "captured",
+                "workspace": {
+                    "kind": payload["kind"],
+                    "archiveRef": "artifact://workspace/archive",
+                    "manifestRef": "artifact://workspace/manifest",
+                    "archiveDigest": "sha256:" + ("d" * 64),
+                    "workspaceIdentityDigest": "sha256:" + ("c" * 64),
+                },
+                "diagnosticRefs": [],
+            }
+        return {"checkpointRef": "artifact://checkpoint/after_execution"}
+
+    monkeypatch.setattr(run_workflow_module.workflow, "execute_activity", fake_execute_activity)
+
+    checkpoint_ref = await parent._record_canonical_step_checkpoint(
+        "node-1",
+        boundary="after_execution",
+        updated_at=now,
+    )
+
+    assert checkpoint_ref == "artifact://checkpoint/after_execution"
+    assert captured[0]["activity"] == expected["captureActivity"]
+    assert captured[0]["payload"]["kind"] == expected["workspaceCheckpointKind"]
+    assert captured[0]["payload"]["externalStateRef"] == manifest["externalStateRef"]
+    assert captured[1]["activity"] == expected["checkpointCreateActivity"]
+
+
+async def test_sandbox_checkpoint_worker_resolves_omnigent_workspace_volume() -> None:
+    """Replay mm:fbbf6deb at the agent-runtime-to-sandbox handoff."""
+
+    replay_id = "omnigent-sandbox-checkpoint-workspace-root"
+    load_replay(replay_id, "manifest.json")
+    expected = load_replay(replay_id, "expected-outcome.json")
+    compose = yaml.safe_load(
+        (REPO_ROOT / "docker-compose.yaml").read_text(encoding="utf-8")
+    )
+    sandbox_worker = compose["services"]["temporal-worker-sandbox"]
+    environment = dict(
+        entry.split("=", 1)
+        for entry in sandbox_worker["environment"]
+        if "=" in entry
+    )
+
+    assert environment["WORKFLOW_WORKSPACE_ROOT"] == expected["workspaceRoot"]
+    assert expected["workspaceVolumeMount"] in sandbox_worker["volumes"]
+
+
+async def test_sandbox_checkpoint_git_trusts_resolved_omnigent_workspace(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Replay mm:ea264977 at the sandbox-to-Git ownership boundary."""
+
+    replay_id = "omnigent-sandbox-checkpoint-git-ownership"
+    load_replay(replay_id, "manifest.json")
+    expected = load_replay(replay_id, "expected-outcome.json")
+    workspace = tmp_path / "temporal_sandbox" / "workspace" / "repo"
+    workspace.mkdir(parents=True)
+    (workspace / ".git").mkdir()
+    resolved_workspace = str(workspace.resolve())
+    safe_prefix = [
+        "git",
+        "-c",
+        f"safe.directory={resolved_workspace}",
+        "-C",
+        resolved_workspace,
+    ]
+    commands: list[list[str]] = []
+
+    async def enforce_safe_directory(command, **_kwargs):
+        normalized = [str(part) for part in command]
+        commands.append(normalized)
+        if normalized[: len(safe_prefix)] != safe_prefix:
+            raise RuntimeError("fatal: detected dubious ownership")
+        operation = normalized[len(safe_prefix) :]
+        if operation[:2] == ["rev-parse", "HEAD"]:
+            return activity_runtime_module.CmdRes(b"abc123\n")
+        if operation[0] == "status":
+            return activity_runtime_module.CmdRes(b"")
+        raise AssertionError(f"unexpected git command: {operation}")
+
+    monkeypatch.setattr(
+        activity_runtime_module, "_run_command", enforce_safe_directory
+    )
+    activities = TemporalSandboxActivities(
+        workspace_root=tmp_path,
+        artifact_store=InMemoryArtifactStore(),
+    )
+    result = await activities.workspace_capture_checkpoint(
+        {
+            "identity": {
+                "workflowId": "source",
+                "runId": "source-run",
+                "logicalStepId": "implement",
+                "executionOrdinal": 1,
+            },
+            "boundary": "after_execution",
+            "kind": "worktree_archive",
+            "workspacePath": resolved_workspace,
+            "artifactNamespace": "checkpoint",
+            "idempotencyKey": "omnigent-sandbox-checkpoint-git-ownership",
+            "baseCommit": "abc123",
+        }
+    )
+
+    assert result["status"] == expected["checkpointStatus"]
+    assert len(commands) == expected["gitCommandCount"]
+    assert all(command[: len(safe_prefix)] == safe_prefix for command in commands)
+
+
+async def test_invalid_required_omnigent_checkpoint_blocks_publication(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Replay mm:ea264977 at the checkpoint-to-publication gate."""
+
+    replay_id = "omnigent-required-checkpoint-finalization"
+    load_replay(replay_id, "manifest.json")
+    expected = load_replay(replay_id, "expected-outcome.json")
+    parent = MoonMindRunWorkflow()
+    now = datetime(2026, 8, 5, 21, 8, tzinfo=timezone.utc)
+    monkeypatch.setattr(run_workflow_module.workflow, "patched", lambda _id: True)
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "info",
+        lambda: SimpleNamespace(workflow_id="workflow-1", run_id="run-1"),
+    )
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "upsert_search_attributes",
+        lambda _attributes: None,
+    )
+    monkeypatch.setattr(run_workflow_module.workflow, "now", lambda: now)
+    parent._initialize_step_ledger(
+        ordered_nodes=[{"id": "implement", "inputs": {"title": "Implement"}}],
+        dependency_map={"implement": []},
+        updated_at=now,
+    )
+    parent._mark_step_running("implement", updated_at=now, summary="Implementing")
+    parent._step_workspace_capture_inputs["implement"] = {
+        "workspaceLocator": {
+            "kind": "sandbox",
+            "workspaceId": "workspace-1",
+            "relativePath": "repo",
+        },
+        "criticality": "required",
+    }
+    parent._step_checkpoint_capture_outcomes["implement"] = {
+        "status": "invalid",
+        "failureCode": expected["failureCode"],
+        "summary": "Git rejected the repository ownership boundary.",
+        "capabilityCriticality": "required",
+    }
+    parent._update_memo = lambda: None  # type: ignore[method-assign]
+
+    async def missing_checkpoint(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr(
+        parent, "_record_canonical_step_checkpoint", missing_checkpoint
+    )
+    await parent._finalize_after_execution_checkpoint("implement", updated_at=now)
+
+    outcome = parent.get_step_ledger()["steps"][0]["finalizationOutcome"]
+    assert outcome["status"] == expected["finalizationStatus"]
+    assert outcome["failureCode"] == expected["failureCode"]
+    assert parent._publish_status == expected["publishStatus"]
+
+
+async def test_active_omnigent_execution_renews_host_lease_until_terminal() -> None:
+    """Replay mm:f2400165 at the execution-to-janitor authority boundary."""
+
+    replay_id = "omnigent-active-host-lease-heartbeat"
+    manifest = load_replay(replay_id, "manifest.json")
+    expected = load_replay(replay_id, "expected-outcome.json")
+    heartbeat_observed = asyncio.Event()
+
+    async def heartbeat_host_lease(lease_id: str, *, ttl_seconds: int):
+        assert lease_id == manifest["hostLeaseRef"]
+        assert ttl_seconds == expected["leaseTtlSeconds"]
+        heartbeat_observed.set()
+        return SimpleNamespace(lease_id=lease_id)
+
+    async def execution() -> AgentRunResult:
+        await heartbeat_observed.wait()
+        return AgentRunResult(summary="completed")
+
+    hosts = SimpleNamespace(
+        heartbeat_host_lease=AsyncMock(side_effect=heartbeat_host_lease)
+    )
+    coordinator = OmnigentProfileBoundExecutionCoordinator(
+        session_factory=AsyncMock(),
+        lease_client=SimpleNamespace(),
+        host_repository=hosts,
+        host_runtime=SimpleNamespace(),
+        run_store=SimpleNamespace(),
+        execution_runner=AsyncMock(),
+        artifact_gateway=SimpleNamespace(),
+    )
+
+    result = await coordinator._execute_with_host_lease_heartbeat(
+        execution(),
+        host_lease_ref=manifest["hostLeaseRef"],
+        ttl_seconds=expected["leaseTtlSeconds"],
+    )
+
+    assert result.summary == expected["terminalSummary"]
+    hosts.heartbeat_host_lease.assert_awaited_once()
+
+
 async def test_codex_session_record_uses_step_workflow_checkpoint_authority(
     tmp_path: Path,
 ) -> None:
@@ -1938,3 +3353,401 @@ async def test_instructionless_inflight_remediation_loop_remains_replayable(
 
     assert parent._remediation_loop_spec is not None
     assert parent._remediation_loop_spec.loop_id == "issue-implementation-remediation"
+
+
+async def test_omnigent_pr_resolver_runtime_authority_replay(
+    tmp_path: Path,
+) -> None:
+    """Replay mm:e09594b0 across Codex auth and terminal evidence handoffs."""
+
+    replay_id = "omnigent-pr-resolver-runtime-authority"
+    manifest = load_replay(replay_id, "manifest.json")
+    expected = load_replay(replay_id, "expected-outcome.json")
+    workspace_id = manifest["workspaceLocator"]["workspaceId"]
+    workspace = tmp_path / "temporal_sandbox" / workspace_id / "repo"
+    result_path = workspace / manifest["terminalContract"]["relativePath"]
+    result_path.parent.mkdir(parents=True)
+    result_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "pr-resolver-result.v1",
+                "executionRef": manifest["stepExecutionId"],
+                "mergeAutomationDisposition": "already_merged",
+                "status": "completed",
+            }
+        ),
+        encoding="utf-8",
+    )
+    publish_path = workspace / "artifacts" / "publish_result.json"
+    publish_path.parent.mkdir(parents=True)
+    publish_path.write_text('{"status":"already_merged"}', encoding="utf-8")
+    SandboxWorkspaceRecordStore(tmp_path).ensure(
+        SandboxWorkspaceRecord(
+            workspace_id=workspace_id,
+            workflow_id=manifest["incidentWorkflowId"],
+            step_execution_id=manifest["stepExecutionId"],
+            relative_path="repo",
+        )
+    )
+
+    request = AgentExecutionRequest(
+        agentKind="external",
+        agentId="omnigent",
+        executionProfileRef="codex_openai_oauth",
+        correlationId=manifest["incidentWorkflowId"],
+        idempotencyKey=manifest["idempotencyKey"],
+        stepExecution={
+            "workflowId": manifest["incidentWorkflowId"],
+            "runId": manifest["incidentRunId"],
+            "logicalStepId": "node-1",
+            "executionOrdinal": 2,
+            "stepExecutionId": manifest["stepExecutionId"],
+            "runtimeContextPolicy": "fresh_agent_run",
+        },
+        workspaceSpec={"workspaceLocator": manifest["workspaceLocator"]},
+        terminalContract=manifest["terminalContract"],
+        parameters={
+            "requiredCapabilities": ["git", "gh"],
+            "omnigent": {
+                "agent": {"agentName": CODEX_STOCK_AGENT_NAME},
+                "session": {
+                    "hostType": "external",
+                    "hostId": "host-replay",
+                    "workspace": manifest["hostWorkspaceAlias"],
+                },
+            },
+        },
+    )
+    selection = build_omnigent_selection(request)
+    create_payload = build_omnigent_session_create_payload(
+        request=request,
+        selection=selection,
+        target=OmnigentResolvedTarget(
+            agent_id="ag-codex-replay",
+            source="agent_id",
+        ),
+    )
+    assert create_payload["terminal_launch_args"] == expected[
+        "terminalLaunchArgs"
+    ]
+    assert all(
+        "token=" not in value.lower()
+        for value in create_payload["terminal_launch_args"]
+    )
+    runtime = OmnigentOAuthHostRuntime(
+        client=SimpleNamespace(),
+        scripts_dir=REPO_ROOT / "services" / "omnigent" / "scripts",
+        workspace_root=tmp_path,
+    )
+    runtime_scripts = runtime._prepare_runtime_scripts(
+        manifest["idempotencyKey"],
+        current_step_execution_id=manifest["stepExecutionId"],
+    )
+    assert expected["stepExecutionIdentitySource"] == (
+        "/etc/profile.d/moonmind-execution.sh"
+    )
+    assert manifest["stepExecutionId"] in (
+        runtime_scripts / "moonmind-execution.sh"
+    ).read_text(encoding="utf-8")
+
+    activities = TemporalAgentRuntimeActivities(
+        workspace_root=tmp_path,
+        client_adapter=object(),
+    )
+    agent_run = MoonMindAgentRun()
+
+    async def execute_activity(
+        name: str, payload: dict[str, object], **_kwargs: object
+    ) -> dict[str, object]:
+        assert name == "agent_runtime.evaluate_terminal_evidence"
+        evaluated = await activities.agent_runtime_evaluate_terminal_evidence(
+            payload
+        )
+        return evaluated.model_dump(mode="json", by_alias=True)
+
+    agent_run._execute_routed_activity = execute_activity  # type: ignore[method-assign]
+    evaluated = await agent_run._evaluate_terminal_contract(
+        request=request,
+        result=AgentRunResult(
+            summary="PR is already merged.",
+            metadata={"workspacePath": manifest["hostWorkspaceAlias"]},
+        ),
+    )
+
+    assert evaluated.failure_class is None
+    assert evaluated.metadata["terminalContractSatisfied"] is True
+    assert evaluated.metadata["terminalContractOutcome"] == expected[
+        "terminalContractOutcome"
+    ]
+    assert evaluated.metadata["terminalContractEvidencePath"] == expected[
+        "terminalContractEvidencePath"
+    ]
+
+
+async def test_omnigent_pr_resolver_publish_evidence_handoff_replay(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Replay mm:a5460547 across AgentRun-to-parent publication authority."""
+
+    replay_id = "omnigent-pr-resolver-publish-evidence-handoff"
+    manifest = load_replay(replay_id, "manifest.json")
+    expected = load_replay(replay_id, "expected-outcome.json")
+    workspace = tmp_path / "repo"
+    result_path = workspace / manifest["terminalEvidencePath"]
+    result_path.parent.mkdir(parents=True)
+    result_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 2,
+                "executionRef": manifest["stepExecutionId"],
+                "mergeAutomationDisposition": manifest[
+                    "mergeAutomationDisposition"
+                ],
+                "status": "merged",
+            }
+        ),
+        encoding="utf-8",
+    )
+    publish_payload = {
+        "schemaVersion": "moonmind.publish.auto.v1",
+        "mode": "auto",
+        "owner": "agent",
+        "skillId": "pr-resolver",
+        "status": "verified",
+        "action": "merge",
+        "repository": "MoonLadderStudios/MoonMind",
+        "branch": "feature",
+        "localHead": "abc1234",
+        "remoteBranchHead": None,
+        "remoteVerified": True,
+        "pushed": False,
+        "merged": True,
+        "prUrl": "https://github.com/MoonLadderStudios/MoonMind/pull/3616",
+        "blockedReason": None,
+        "verificationCommands": ["gh pr view 3616"],
+    }
+    publish_path = workspace / manifest["publishEvidencePath"]
+    publish_path.parent.mkdir(parents=True)
+    publish_path.write_text(json.dumps(publish_payload), encoding="utf-8")
+
+    artifact_service = SimpleNamespace(
+        create=AsyncMock(
+            side_effect=[
+                (SimpleNamespace(artifact_id="art-pr-terminal-evidence"), None),
+                (
+                    SimpleNamespace(artifact_id=expected["publishEvidenceRef"]),
+                    None,
+                ),
+            ]
+        ),
+        write_complete=AsyncMock(
+            side_effect=[
+                SimpleNamespace(artifact_id="art-pr-terminal-evidence"),
+                SimpleNamespace(artifact_id=expected["publishEvidenceRef"]),
+            ]
+        ),
+    )
+    activities = TemporalAgentRuntimeActivities(artifact_service=artifact_service)
+    agent_result = await activities.agent_runtime_evaluate_terminal_evidence(
+        {
+            "workspacePath": str(workspace),
+            "terminalContract": {
+                "contractId": "pr_resolver_terminal.v1",
+                "relativePath": manifest["terminalEvidencePath"],
+                "expectedSchemaVersion": "pr-resolver-result.v1",
+                "executionRef": manifest["stepExecutionId"],
+            },
+            "result": {"summary": "PR was already merged."},
+        }
+    )
+    assert agent_result.metadata["terminalContractSatisfied"] is expected[
+        "terminalContractSatisfied"
+    ]
+    assert agent_result.metadata["publishEvidence"] == expected[
+        "publishEvidenceRef"
+    ]
+
+    parent = MoonMindRunWorkflow()
+    parent._owner_type = "user"
+    parent._owner_id = "pr-resolver-publish-replay"
+    mapped_result = parent._map_agent_run_result(agent_result)
+    assert mapped_result["outputs"]["publishEvidence"] == expected[
+        "publishEvidenceRef"
+    ]
+
+    async def read_publish_evidence(
+        activity_type: str,
+        payload: object,
+        **_kwargs: object,
+    ) -> bytes:
+        assert activity_type == "artifact.read"
+        assert getattr(payload, "artifact_ref", None) == expected[
+            "publishEvidenceRef"
+        ]
+        return json.dumps(publish_payload).encode("utf-8")
+
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "patched",
+        lambda _patch_id: True,
+    )
+    monkeypatch.setattr(
+        run_workflow_module,
+        "execute_typed_activity",
+        read_publish_evidence,
+    )
+    await parent._record_publish_result_from_execution(
+        parameters={"publishMode": "auto"},
+        execution_result=mapped_result,
+    )
+
+    assert (parent._publish_status, parent._publish_reason) == (
+        expected["publishStatus"],
+        expected["publishReason"],
+    )
+    assert parent._publish_context["evidenceRef"] == expected[
+        "publishEvidenceRef"
+    ]
+
+
+async def test_omnigent_canceled_host_rerun_waits_for_admission(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Replay mm:c702174c after the immediately preceding run was canceled."""
+
+    replay_id = "omnigent-canceled-host-rerun-admission"
+    manifest = load_replay(replay_id, "manifest.json")
+    expected = load_replay(replay_id, "expected-outcome.json")
+    binding = _oauth_binding().model_copy(
+        update={"provider_profile_id": manifest["providerProfileId"]}
+    )
+    resolved_lease = _oauth_host_lease().model_copy(update={"status": "allocating"})
+    hosts = SimpleNamespace(
+        create_or_get_host_lease=AsyncMock(
+            side_effect=[
+                OmnigentOAuthHostError(
+                    "prior canceled host is still active",
+                    code=HOST_PROFILE_BUSY_ERROR_CODE,
+                ),
+                resolved_lease,
+            ]
+        )
+    )
+    emit = AsyncMock()
+    coordinator = OmnigentProfileBoundExecutionCoordinator(
+        session_factory=lambda: None,
+        lease_client=SimpleNamespace(),
+        host_repository=hosts,
+        host_runtime=SimpleNamespace(),
+        run_store=SimpleNamespace(),
+        execution_runner=AsyncMock(),
+        artifact_gateway=object(),
+    )
+    monkeypatch.setattr(
+        "moonmind.omnigent.profile_bound_execution.HOST_PROFILE_BUSY_POLL_SECONDS",
+        0.0,
+    )
+
+    admitted = await coordinator._create_host_lease_after_profile_idle(
+        binding=binding,
+        provider_lease=SimpleNamespace(lease_id="provider-lease-rerun"),
+        workflow_id=manifest["incidentWorkflowId"],
+        step_execution_id="step-rerun",
+        idempotency_key="rerun-admission",
+        emit=emit,
+    )
+
+    assert admitted == resolved_lease
+    assert hosts.create_or_get_host_lease.await_count == 2
+    assert emit.await_args.kwargs["code"] == expected["busyCode"]
+    assert (
+        emit.await_args.kwargs["remediation_action"]
+        == expected["remediationAction"]
+    )
+
+
+async def test_omnigent_required_capability_authority_reaches_adapter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Replay mm:8a8955a6 at the Run-to-provider capability handoff."""
+
+    replay_id = "omnigent-capability-authority-handoff"
+    manifest = load_replay(replay_id, "manifest.json")
+    expected = load_replay(replay_id, "expected-outcome.json")
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "info",
+        lambda: SimpleNamespace(
+            namespace="default",
+            workflow_id=manifest["incidentWorkflowId"],
+            run_id=manifest["incidentRunId"],
+            parent=None,
+        ),
+    )
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "patched",
+        lambda patch_id: (
+            patch_id == RUN_AGENT_REQUIRED_CAPABILITIES_PROPAGATION_PATCH
+        ),
+    )
+    request = MoonMindRunWorkflow()._build_agent_execution_request(
+        node_inputs={
+            "runtime": {"mode": "omnigent"},
+            "omnigent": {
+                "agent": {"agentName": manifest["agentName"]},
+                "session": {
+                    "hostType": "external",
+                    "hostId": "host-replay",
+                    "workspace": "/workspaces/run",
+                },
+            },
+        },
+        node_id="node-1",
+        tool_name="omnigent",
+        workflow_parameters={
+            "requiredCapabilities": manifest["requiredCapabilities"]
+        },
+    )
+
+    assert request.parameters["requiredCapabilities"] == manifest[
+        "requiredCapabilities"
+    ]
+    selection = build_omnigent_selection(request)
+    payload = build_omnigent_session_create_payload(
+        request=request,
+        selection=selection,
+        target=OmnigentResolvedTarget(
+            agent_id="ag-codex-replay",
+            source="agent_id",
+        ),
+    )
+    assert payload["terminal_launch_args"] == expected["terminalLaunchArgs"]
+
+
+async def test_omnigent_tool_bundle_uses_deployment_owned_named_volume(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Replay mm:d4a7b625 at the worker-to-system-Docker boundary."""
+
+    replay_id = "omnigent-tool-bundle-deployment-boundary"
+    manifest = load_replay(replay_id, "manifest.json")
+    expected = load_replay(replay_id, "expected-outcome.json")
+    monkeypatch.setenv("OMNIGENT_GH_VERSION", "2.76.2")
+    runtime = OmnigentOAuthHostRuntime(
+        client=SimpleNamespace(),
+        image=expected["probeImage"],
+    )
+    runtime._run = AsyncMock(return_value=(0, "gh version 2.76.2 (replay)\n", ""))
+
+    await runtime._initialize_required_tools()
+
+    command = runtime._run.await_args.args
+    assert manifest["failureCode"] == "CODEX_OAUTH_LOGIN_STATUS_FAILED"
+    assert command[:2] == ("docker", "run")
+    assert "compose" not in command
+    assert (
+        f"{expected['toolVolume']}:/opt/moonmind-tools:ro"
+        in command
+    )

--- a/tests/integration/reliability_journey/test_omnigent_publication_semantics_journey.py
+++ b/tests/integration/reliability_journey/test_omnigent_publication_semantics_journey.py
@@ -26,6 +26,7 @@ from uuid import UUID
 
 import pytest
 
+from moonmind.config.settings import settings
 from moonmind.omnigent.checkpoints import OmnigentCheckpointIdentity
 from moonmind.omnigent.oauth_host_runtime import OmnigentOAuthHostRuntime
 from moonmind.omnigent.policies import compile_policy_snapshot
@@ -48,6 +49,7 @@ from api_service.db.models import (
     RuntimeMaterializationMode,
 )
 from tests.unit.omnigent.test_policy_authority import policy_document
+from tests.integration.reliability.helpers import load_replay
 
 
 pytestmark = [pytest.mark.integration, pytest.mark.integration_ci]
@@ -136,6 +138,7 @@ async def _materialize_workspace(
     source: Path,
     starting_branch: str,
     target_branch: str,
+    configure_identity: bool = True,
 ) -> tuple[OmnigentOAuthHostRuntime, Path]:
     workspace_root = tmp_path / "workspaces"
     runtime = OmnigentOAuthHostRuntime(
@@ -155,7 +158,8 @@ async def _materialize_workspace(
         starting_branch=starting_branch,
         target_branch=target_branch,
     )
-    _configure_identity(workspace)
+    if configure_identity:
+        _configure_identity(workspace)
     return runtime, workspace
 
 
@@ -235,6 +239,177 @@ async def test_materialized_workspace_publishes_branch_and_recovery_is_idempoten
     assert recovery.status == "skipped"
     assert recovery.reason_code == "no_commit"
     assert _git_out(remote, "rev-parse", publication_branch) == remote_head
+
+
+@pytest.mark.asyncio
+async def test_clean_omnigent_workspace_publishes_existing_agent_commit(
+    tmp_path, monkeypatch
+) -> None:
+    """Replay the false-success shape from workflow mm:ea264977.
+
+    The native agent may honor its own commit instruction, leaving a clean
+    worktree with commits over the authored base. Publication must qualify and
+    push those commits instead of treating clean status as "no work".
+    """
+
+    replay = load_replay("omnigent-profile-bound-publication", "manifest.json")
+    expected = load_replay(
+        "omnigent-profile-bound-publication", "expected-outcome.json"
+    )
+    monkeypatch.setattr(
+        "moonmind.publish.service.resolve_high_security_mode", lambda *a, **k: False
+    )
+    remote = _init_bare_remote_with_seed(tmp_path)
+    workflow_id = replay["incidentWorkflowId"]
+    step_execution_id = replay["failedChildWorkflowId"]
+    runtime, workspace = await _materialize_workspace(
+        tmp_path,
+        workflow_id=workflow_id,
+        step_execution_id=step_execution_id,
+        source=remote,
+        starting_branch="main",
+        target_branch="agent/live-replay",
+    )
+    (workspace / "feature.py").write_text("print('fixed')\n", encoding="utf-8")
+    _git(workspace, "add", "feature.py")
+    _git(workspace, "commit", "-m", "Fix escaped workflow failure")
+    assert _git_out(workspace, "status", "--porcelain") == ""
+
+    workspace_id = hashlib.sha256(
+        f"{workflow_id}:{step_execution_id}".encode("utf-8")
+    ).hexdigest()[:24]
+    result = await runtime.publish_workspace(
+        workspace_locator={
+            "kind": "sandbox",
+            "workspaceId": workspace_id,
+            "relativePath": "repo",
+        },
+        current_workflow_id=workflow_id,
+        current_step_execution_id=step_execution_id,
+        publication_identity="replay:omnigent-profile-bound-publication",
+        publish_mode="pr",
+        base_branch="main",
+        repository="",
+        github_token=None,
+    )
+
+    assert result["push_status"] == expected["pushStatus"]
+    assert result["push_commit_count"] == expected["commitsAheadOfBase"]
+    assert result["remote_verified"] is expected["remoteVerified"]
+    assert result["push_head_sha"] == _git_out(
+        remote, "rev-parse", result["push_branch"]
+    )
+
+
+@pytest.mark.asyncio
+async def test_profile_bound_publication_reports_no_commits_over_base(
+    tmp_path, monkeypatch
+) -> None:
+    """Provider completion with an untouched workspace is not publish success."""
+
+    monkeypatch.setattr(
+        "moonmind.publish.service.resolve_high_security_mode", lambda *a, **k: False
+    )
+    remote = _init_bare_remote_with_seed(tmp_path)
+    workflow_id = "mm:no-commits-replay"
+    step_execution_id = "mm:no-commits-replay:agent:node-1"
+    runtime, _workspace = await _materialize_workspace(
+        tmp_path,
+        workflow_id=workflow_id,
+        step_execution_id=step_execution_id,
+        source=remote,
+        starting_branch="main",
+        target_branch="agent/no-commits",
+    )
+    workspace_id = hashlib.sha256(
+        f"{workflow_id}:{step_execution_id}".encode("utf-8")
+    ).hexdigest()[:24]
+
+    result = await runtime.publish_workspace(
+        workspace_locator={
+            "kind": "sandbox",
+            "workspaceId": workspace_id,
+            "relativePath": "repo",
+        },
+        current_workflow_id=workflow_id,
+        current_step_execution_id=step_execution_id,
+        publication_identity="replay:omnigent-profile-bound-no-commits",
+        publish_mode="pr",
+        base_branch="main",
+        repository="",
+        github_token=None,
+    )
+
+    assert result["push_status"] == "no_commits"
+    assert result["push_commit_count"] == 0
+    assert result["remote_verified"] is False
+
+
+@pytest.mark.asyncio
+async def test_profile_bound_publication_supplies_missing_git_identity(
+    tmp_path, monkeypatch
+) -> None:
+    """Replay mm:bfc017e9 staged output with no repository-local author."""
+
+    replay = load_replay(
+        "omnigent-publication-missing-git-identity", "manifest.json"
+    )
+    expected = load_replay(
+        "omnigent-publication-missing-git-identity", "expected-outcome.json"
+    )
+    monkeypatch.setattr(
+        "moonmind.publish.service.resolve_high_security_mode", lambda *a, **k: False
+    )
+    monkeypatch.setattr(settings.workflow, "git_user_name", replay["gitUserName"])
+    monkeypatch.setattr(settings.workflow, "git_user_email", replay["gitUserEmail"])
+    remote = _init_bare_remote_with_seed(tmp_path)
+    runtime, workspace = await _materialize_workspace(
+        tmp_path,
+        workflow_id=replay["incidentWorkflowId"],
+        step_execution_id=replay["stepExecutionId"],
+        source=remote,
+        starting_branch="main",
+        target_branch="agent/missing-identity",
+        configure_identity=False,
+    )
+    (workspace / "feature.py").write_text("print('fixed')\n", encoding="utf-8")
+    _git(workspace, "add", "feature.py")
+    subprocess.run(
+        ["git", "config", "--unset-all", "user.name"],
+        cwd=workspace,
+        check=False,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "--unset-all", "user.email"],
+        cwd=workspace,
+        check=False,
+        capture_output=True,
+    )
+
+    workspace_id = hashlib.sha256(
+        f"{replay['incidentWorkflowId']}:{replay['stepExecutionId']}".encode()
+    ).hexdigest()[:24]
+    result = await runtime.publish_workspace(
+        workspace_locator={
+            "kind": "sandbox",
+            "workspaceId": workspace_id,
+            "relativePath": "repo",
+        },
+        current_workflow_id=replay["incidentWorkflowId"],
+        current_step_execution_id=replay["stepExecutionId"],
+        publication_identity="replay:omnigent-publication-missing-git-identity",
+        publish_mode="pr",
+        base_branch="main",
+        repository="",
+        github_token=None,
+    )
+
+    assert result["push_status"] == expected["pushStatus"]
+    assert result["push_commit_count"] == expected["commitsAheadOfBase"]
+    assert result["remote_verified"] is expected["remoteVerified"]
+    assert _git_out(workspace, "log", "-1", "--format=%an") == replay["gitUserName"]
+    assert _git_out(workspace, "log", "-1", "--format=%ae") == replay["gitUserEmail"]
 
 
 # --- Journey 2: pull-request publication through canonical contract ---------
@@ -572,6 +747,27 @@ async def _drive_coordinator_materialization_to_cleanup(
         async def stop_host(self, **_kwargs):
             ordered.append({"type": "host_cleanup", "status": "completed"})
 
+        async def inspect_session_completion(self, session_id):
+            assert session_id == "session-1"
+            return {
+                "sessionStatus": "completed",
+                "itemCount": 4,
+                "assistantMessageCount": 1,
+                "toolResultCount": 1,
+                "terminalAssistantAfterWork": True,
+            }
+
+        async def publish_workspace(self, **_kwargs):
+            return {
+                "push_status": "pushed",
+                "push_branch": "agent/implement",
+                "push_base_branch": "main",
+                "push_head_sha": "a" * 40,
+                "push_commit_count": 1,
+                "remote_verified": True,
+                "pushRef": "artifact://push-1",
+            }
+
     class Store:
         async def get_or_create(self, **_kwargs):
             return SimpleNamespace(bridge_session_id="bridge-1")
@@ -588,8 +784,15 @@ async def _drive_coordinator_materialization_to_cleanup(
                 }
             )
 
+        async def mark_terminal(self, *_args, **_kwargs):
+            return None
+
     async def execute(request, **_kwargs):
-        return AgentRunResult(summary="done", outputRefs=["artifact://out-1"])
+        return AgentRunResult(
+            summary="done",
+            outputRefs=["artifact://out-1"],
+            metadata={"omnigentSessionId": "session-1"},
+        )
 
     coordinator = OmnigentProfileBoundExecutionCoordinator(
         session_factory=lambda: None,
@@ -669,9 +872,7 @@ async def test_coordinator_materialization_to_cleanup_on_demand_mutation(
     assert second["workspace"]["materializationAction"] == "reused_pre_materialized"
     assert first["runtime"]["hostMode"] == "on_demand_docker"
     assert first["publication"]["publishMode"] == "branch"
-    assert (
-        first["publication"]["publicationState"] == "authorized_pending_publication"
-    )
+    assert first["publication"]["publicationState"] == "published"
     assert first["workspace"]["candidateHead"] == "agent/implement"
     assert first["terminal"]["releaseOrdering"][-1] == "terminal"
     # Bounded + credential-free: the internal daemon/sandbox workspace paths

--- a/tests/integration/temporal/test_compose_foundation.py
+++ b/tests/integration/temporal/test_compose_foundation.py
@@ -202,6 +202,7 @@ def test_omnigent_hosts_use_versioned_read_only_tool_bundle():
     )
     assert initializer["user"] == "0:0"
     assert initializer["restart"] == "no"
+    assert "profiles" not in initializer
     assert initializer["environment"] == {
         "MOONMIND_GH_SOURCE": "/usr/local/bin/gh",
         "MOONMIND_GH_VERSION": "${OMNIGENT_GH_VERSION:-2.76.2}",
@@ -213,6 +214,9 @@ def test_omnigent_hosts_use_versioned_read_only_tool_bundle():
     assert compose["volumes"]["omnigent-tools"]["name"] == (
         "moonmind-omnigent-tools-gh-${OMNIGENT_GH_VERSION:-2.76.2}"
     )
+    assert services["temporal-worker-agent-runtime"]["depends_on"][
+        "omnigent-tools-init"
+    ] == {"condition": "service_completed_successfully"}
 
     for service_name in ("omnigent-host", "omnigent-host-claude", "omnigent-host-codex"):
         host = services[service_name]
@@ -460,6 +464,10 @@ def test_sandbox_worker_compose_egress_is_restricted_for_mm_785():
     assert "squid -k parse" in proxy_service["healthcheck"]["test"][1]
 
     sandbox_env = _env_map(services["temporal-worker-sandbox"]["environment"])
+    assert sandbox_env["WORKFLOW_WORKSPACE_ROOT"] == "/work/agent_jobs"
+    assert "agent_workspaces:/work/agent_jobs" in services[
+        "temporal-worker-sandbox"
+    ]["volumes"]
     assert sandbox_env["HTTPS_PROXY"] == (
         "${MOONMIND_SANDBOX_HTTPS_PROXY:-http://sandbox-egress-proxy:3128}"
     )
@@ -548,7 +556,10 @@ def test_omnigent_host_profile_service_is_wired_for_mm_971():
         server_service["depends_on"]["omnigent-db-init"]["condition"]
         == "service_completed_successfully"
     )
-    assert _network_names(server_service) == {"local-network"}
+    assert _network_names(server_service) == {
+        "local-network",
+        "omnigent-egress-network",
+    }
 
     host_service = services["omnigent-host"]
     assert host_service["profiles"] == ["omnigent-host"]
@@ -604,8 +615,11 @@ def test_omnigent_claude_host_profile_uses_only_canonical_oauth_credentials():
         "HTTPS_PROXY": "http://omnigent-egress-proxy:3129",
         "http_proxy": "http://omnigent-egress-proxy:3129",
         "https_proxy": "http://omnigent-egress-proxy:3129",
-        "NO_PROXY": "",
-        "no_proxy": "",
+        "NO_PROXY": "localhost,127.0.0.1",
+        "no_proxy": "localhost,127.0.0.1",
+        "OMNIGENT_RUNNER_ENV_PASSTHROUGH": (
+            "HTTP_PROXY,HTTPS_PROXY,http_proxy,https_proxy,NO_PROXY,no_proxy"
+        ),
         "MOONMIND_ACTIVE_SKILLS_DIR": "/opt/moonmind-skills",
         "OMNIGENT_SERVER_URL": "http://omnigent:8000",
         "HOME": "/home/app",
@@ -681,13 +695,17 @@ def test_omnigent_codex_host_profile_uses_only_canonical_oauth_credentials():
     assert _env_map(host_service["environment"]) == {
         # Restricted-egress enforcement (MoonLadderStudios/MoonMind#3516): the
         # static Codex host is routed through the trusted proxy on the internal
-        # network. NO_PROXY is pinned empty so no destination bypasses it.
+        # network. Only same-container loopback bypasses the proxy so Codex's
+        # native TUI can connect to its local app-server WebSocket.
         "HTTP_PROXY": "http://omnigent-egress-proxy:3129",
         "HTTPS_PROXY": "http://omnigent-egress-proxy:3129",
         "http_proxy": "http://omnigent-egress-proxy:3129",
         "https_proxy": "http://omnigent-egress-proxy:3129",
-        "NO_PROXY": "",
-        "no_proxy": "",
+        "NO_PROXY": "localhost,127.0.0.1",
+        "no_proxy": "localhost,127.0.0.1",
+        "OMNIGENT_RUNNER_ENV_PASSTHROUGH": (
+            "HTTP_PROXY,HTTPS_PROXY,http_proxy,https_proxy,NO_PROXY,no_proxy"
+        ),
         "MOONMIND_ACTIVE_SKILLS_DIR": "/opt/moonmind-skills",
         "HOME": "/home/app",
         "PATH": MOUNTED_TOOL_PATH,
@@ -849,6 +867,10 @@ def test_python_test_runtime_is_provisioned_on_demand_outside_compose_startup():
     assert worker_env["MOONMIND_AGENT_WORKSPACES_VOLUME_NAME"] == (
         "${MOONMIND_AGENT_WORKSPACES_VOLUME_NAME:-agent_workspaces}"
     )
+    assert worker_env["WORKFLOW_WORKSPACE_DAEMON_ROOT"] == (
+        "${WORKFLOW_WORKSPACE_DAEMON_ROOT:-/var/lib/docker/volumes/"
+        "${MOONMIND_AGENT_WORKSPACES_VOLUME_NAME:-agent_workspaces}/_data}"
+    )
     assert worker_env["MOONMIND_PYTHON_TEST_IMAGE"] == (
         "${MOONMIND_PYTHON_TEST_IMAGE:-}"
     )
@@ -937,7 +959,10 @@ def test_omnigent_shared_postgres_compose_topology_for_mm_970():
         == "service_completed_successfully"
     )
     assert omnigent_service["ports"] == ["${OMNIGENT_PORT:-8000}:8000"]
-    assert _network_names(omnigent_service) == {"local-network"}
+    assert _network_names(omnigent_service) == {
+        "local-network",
+        "omnigent-egress-network",
+    }
     assert "omnigent-data:/data" in omnigent_service["volumes"]
     assert "omnigent-data" in compose["volumes"]
 

--- a/tests/test_local_dev.py
+++ b/tests/test_local_dev.py
@@ -294,7 +294,7 @@ def test_sandbox_worker_uses_internal_egress_network_for_mm_785():
     assert codex_host["security_opt"] == ["no-new-privileges:true"]
     codex_env = _env_map(codex_host["environment"])
     assert codex_env["HTTPS_PROXY"] == "http://omnigent-egress-proxy:3129"
-    assert codex_env["NO_PROXY"] == ""
+    assert codex_env["NO_PROXY"] == "localhost,127.0.0.1"
 
 
 def test_api_service_runs_with_container_init():

--- a/tests/unit/api/test_omnigent_policy_service.py
+++ b/tests/unit/api/test_omnigent_policy_service.py
@@ -2,6 +2,7 @@
 
 from contextlib import asynccontextmanager
 from copy import deepcopy
+from datetime import UTC, datetime, timedelta
 
 import pytest
 from sqlalchemy import select
@@ -12,6 +13,7 @@ from api_service.db.models import (
     Base,
     OmnigentBridgeSession,
     OmnigentOAuthHostBindingRecord,
+    OmnigentOAuthHostLeaseRecord,
     OmnigentPolicy,
     OmnigentPolicyEvent,
     OmnigentPolicyVersion,
@@ -53,6 +55,7 @@ async def policy_db(tmp_path):
                     OmnigentPolicyVersion.__table__,
                     OmnigentPolicyEvent.__table__,
                     OmnigentOAuthHostBindingRecord.__table__,
+                    OmnigentOAuthHostLeaseRecord.__table__,
                     OmnigentBridgeSession.__table__,
                 ],
             )
@@ -636,15 +639,55 @@ async def test_bootstrap_seed_cuts_over_legacy_stock_agent_identity(tmp_path, mo
                 effective_launch_snapshot_json={"snapshotRef": "stale"},
             )
         )
+        now = datetime.now(UTC)
+        await session.execute(
+            OmnigentOAuthHostLeaseRecord.__table__.insert().values(
+                lease_id="active-bootstrap-lease",
+                provider_profile_id="profile",
+                provider_lease_id="provider-lease",
+                binding_ref="bootstrap-binding",
+                credential_generation=1,
+                holder_workflow_id="workflow-active",
+                idempotency_key="workflow-active:step-1",
+                lease_purpose="execution",
+                status="assigned",
+                acquired_at=now,
+                last_heartbeat_at=now,
+                host_capabilities_json={},
+                expires_at=now + timedelta(hours=1),
+            )
+        )
         await session.commit()
 
         seeded = await seed_bootstrap_policies(session, image_resolver=resolver)
+
+        binding = await session.get(
+            OmnigentOAuthHostBindingRecord,
+            "bootstrap-binding",
+        )
+        assert binding.launch_policy_ref == "codex-on-demand@1"
+        assert binding.effective_launch_snapshot_json == {"snapshotRef": "stale"}
+        await session.execute(
+            OmnigentOAuthHostLeaseRecord.__table__
+            .update()
+            .where(
+                OmnigentOAuthHostLeaseRecord.lease_id
+                == "active-bootstrap-lease"
+            )
+            .values(status="stopped", stopped_at=datetime.now(UTC))
+        )
+        await session.commit()
+        seeded_after_drain = await seed_bootstrap_policies(
+            session,
+            image_resolver=resolver,
+        )
 
         assert set(seeded) == {
             "omnigent-codex",
             "codex-static",
             "codex-on-demand",
         }
+        assert seeded_after_drain == ["codex-on-demand"]
         policies = list((await session.execute(select(OmnigentPolicy))).scalars())
         assert all(policy.default_version == 2 for policy in policies)
         migrated_versions = list(

--- a/tests/unit/api/test_omnigent_policy_service.py
+++ b/tests/unit/api/test_omnigent_policy_service.py
@@ -25,7 +25,7 @@ from api_service.services.omnigent_policies import (
     resolve_bootstrap_image_ref,
     seed_bootstrap_policies,
 )
-from moonmind.omnigent.policies import PolicyDocument, PolicyState
+from moonmind.omnigent.policies import PolicyDocument, PolicyState, document_digest
 from moonmind.security.egress import OMNIGENT_EGRESS_PROFILE
 from tests.unit.omnigent.test_policy_authority import policy_document
 
@@ -579,8 +579,104 @@ async def test_bootstrap_policies_activate_with_resolved_latest_images(
             version.document_json["host"]["serverImageRef"] == server_digest
             for version in versions
         )
+        assert all(
+            version.document_json["execution"]["agentIdentities"]
+            == ["codex-native-ui"]
+            for version in versions
+        )
         assert await bootstrap_policies_ready(session) is True
         assert await seed_bootstrap_policies(
             session, env={}, image_resolver=resolver
         ) == []
         assert len(resolution_calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_bootstrap_seed_cuts_over_legacy_stock_agent_identity(tmp_path, monkeypatch):
+    """Legacy bootstrap identity advances through an immutable version cutover."""
+
+    monkeypatch.setenv("MOONMIND_CONTAINER_JOBS_ENABLED", "true")
+    server_digest = "ghcr.io/omnigent-ai/omnigent-server@sha256:" + "1" * 64
+    host_digest = "ghcr.io/omnigent-ai/omnigent-host@sha256:" + "2" * 64
+
+    async def resolver(image_ref: str) -> str:
+        return host_digest if "host" in image_ref else server_digest
+
+    async with policy_db(tmp_path) as sessions, sessions() as session:
+        await seed_bootstrap_policies(session, image_resolver=resolver)
+        versions = list(
+            (await session.execute(select(OmnigentPolicyVersion))).scalars().all()
+        )
+        for version in versions:
+            legacy = deepcopy(version.document_json)
+            legacy["execution"]["agentIdentities"] = ["codex"]
+            version.document_json = legacy
+            version.digest = document_digest(legacy)
+        session.add(
+            OmnigentOAuthHostBindingRecord(
+                binding_ref="bootstrap-binding",
+                provider_profile_id="profile",
+                endpoint_ref="default",
+                harness="codex-native",
+                credential_mount_template_json={
+                    "authVolumeRef": {
+                        "providerProfileId": "profile",
+                        "runtimeId": "codex_cli",
+                        "providerId": "openai",
+                        "volumeRef": "codex_auth_volume",
+                        "credentialGeneration": 1,
+                        "ownerUserId": "user-1",
+                    },
+                    "targetPath": "/home/app/.codex",
+                    "accessMode": "read_write",
+                    "runtimeUid": 1000,
+                    "runtimeGid": 1000,
+                },
+                launch_policy_ref="codex-on-demand@1",
+                effective_launch_snapshot_json={"snapshotRef": "stale"},
+            )
+        )
+        await session.commit()
+
+        seeded = await seed_bootstrap_policies(session, image_resolver=resolver)
+
+        assert set(seeded) == {
+            "omnigent-codex",
+            "codex-static",
+            "codex-on-demand",
+        }
+        policies = list((await session.execute(select(OmnigentPolicy))).scalars())
+        assert all(policy.default_version == 2 for policy in policies)
+        migrated_versions = list(
+            (
+                await session.execute(
+                    select(OmnigentPolicyVersion).order_by(
+                        OmnigentPolicyVersion.policy_id,
+                        OmnigentPolicyVersion.version,
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert len(migrated_versions) == 6
+        for version in migrated_versions:
+            expected_identity = (
+                ["codex"] if version.version == 1 else ["codex-native-ui"]
+            )
+            assert version.state == PolicyState.ACTIVE.value
+            assert version.document_json["execution"]["agentIdentities"] == (
+                expected_identity
+            )
+            if version.version == 2:
+                assert version.parent_ref == f"{version.policy_id}@1"
+        event_types = set(
+            (await session.execute(select(OmnigentPolicyEvent.event_type))).scalars()
+        )
+        assert "bootstrap_agent_identity_cutover" in event_types
+        binding = await session.get(
+            OmnigentOAuthHostBindingRecord,
+            "bootstrap-binding",
+        )
+        assert binding.launch_policy_ref == "codex-on-demand@2"
+        assert binding.effective_launch_snapshot_json is None

--- a/tests/unit/omnigent/test_bridge_events.py
+++ b/tests/unit/omnigent/test_bridge_events.py
@@ -7,6 +7,7 @@ import pytest
 from moonmind.omnigent.bridge_artifacts import OmnigentContractError
 from moonmind.omnigent.bridge_events import (
     BRIDGE_EVENT_SCHEMA_VERSION,
+    bounded_deduplication_key,
     build_omnigent_bridge_event,
     normalize_omnigent_observation,
 )
@@ -21,6 +22,17 @@ def _request() -> AgentExecutionRequest:
         correlationId="corr-1",
         idempotencyKey="idem-1",
     )
+
+
+def test_bounded_deduplication_key_hashes_the_full_identity() -> None:
+    shared_prefix = "provider:" + "event-segment:" * 20
+    first = bounded_deduplication_key(f"{shared_prefix}attempt:1")
+    second = bounded_deduplication_key(f"{shared_prefix}attempt:2")
+
+    assert len(first) == 128
+    assert len(second) == 128
+    assert first != second
+    assert bounded_deduplication_key("provider:short") == "provider:short"
 
 
 def test_build_omnigent_bridge_event_emits_v1_shape() -> None:
@@ -68,6 +80,22 @@ def test_execution_critical_drift_fails_closed() -> None:
 
 def test_session_created_normalizes_without_explicit_status() -> None:
     assert normalize_omnigent_observation({"type": "session.created"}) == "created"
+
+
+def test_stock_session_heartbeat_normalizes_as_running_liveness() -> None:
+    result = build_omnigent_bridge_event(
+        payload={
+            "type": "session.heartbeat",
+            "server_time": "2026-08-05T19:37:00Z",
+        },
+        sequence=1,
+        request=_request(),
+        omnigent_session_id="sess-1",
+    )
+
+    assert result.event["eventType"] == "session.heartbeat"
+    assert result.event["normalizedStatus"] == "running"
+    assert result.diagnostic is None
 
 
 def test_resume_gap_is_a_durable_non_terminal_diagnostic() -> None:

--- a/tests/unit/omnigent/test_bridge_store.py
+++ b/tests/unit/omnigent/test_bridge_store.py
@@ -190,6 +190,45 @@ async def test_get_or_create_is_idempotent_and_declared(store):
 
 
 @pytest.mark.asyncio
+async def test_get_or_create_reopens_terminal_attempt_that_never_posted(store):
+    """Temporal retries must not inherit a false first-message terminal edge."""
+
+    request = _request("unposted-retry")
+    created = await store.get_or_create(
+        request=request,
+        endpoint_ref="endpoint",
+        agent_id="agent-1",
+        agent_name="Agent One",
+        target_metadata={},
+    )
+    await store.mark_terminal(
+        request.idempotency_key,
+        status="failed",
+        terminal_refs={"summary": "host registration failed before session start"},
+    )
+
+    reopened = await store.get_or_create(
+        request=request,
+        endpoint_ref="endpoint",
+        agent_id="agent-1",
+        agent_name="Agent One",
+        target_metadata={},
+    )
+
+    assert reopened.bridge_session_id == created.bridge_session_id
+    assert reopened.status == STATUS_DECLARED
+    assert reopened.first_message_state == "not_prepared"
+    assert reopened.terminal_refs == {}
+    assert reopened.metadata_["unpostedAttemptHistory"][-1]["status"] == "failed"
+    assert (
+        reopened.metadata_["unpostedAttemptHistory"][-1]["terminalRefs"][
+            "summary"
+        ]
+        == "host registration failed before session start"
+    )
+
+
+@pytest.mark.asyncio
 async def test_get_or_create_persists_binding_identity_override(store):
     # The Session API Facade holds a verified workflow id out-of-band and
     # synthesizes a request with no step_execution (correlation id != workflow
@@ -631,6 +670,38 @@ async def test_conflicting_intent_digest_records_a_distinct_event(store):
         if event.event_type == "lifecycle.workspace_intent_compiled"
     )
     assert digests == ["sha256:first", "sha256:second"]
+
+
+@pytest.mark.asyncio
+async def test_long_lifecycle_retry_identities_preserve_distinct_attempts(store):
+    row = await store.get_or_create(
+        request=_request(), endpoint_ref="default", agent_id=None,
+        agent_name=None, target_metadata={},
+    )
+    attempt_prefix = (
+        "mm:96eb128d-ff2e-4d22-9fe5-cde712d2c678:"
+        "019fd325-7bba-79b5-a0b7-ed9c17c708f9:"
+        "node-1:execution:1:agent_execute"
+    )
+
+    for attempt in (1, 2):
+        identity = f"{attempt_prefix}:attempt:{attempt}:request_validated:started"
+        await store.record_lifecycle_event(
+            "idem-1",
+            event_type="request_validated",
+            event_identity=identity,
+        )
+        # Replaying one activity attempt still resolves to the same event.
+        await store.record_lifecycle_event(
+            "idem-1",
+            event_type="request_validated",
+            event_identity=identity,
+        )
+
+    events = await store.list_events(row.bridge_session_id)
+    assert len(events) == 2
+    assert len({event.deduplication_key for event in events}) == 2
+    assert all(len(event.deduplication_key) <= 128 for event in events)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/omnigent/test_execute.py
+++ b/tests/unit/omnigent/test_execute.py
@@ -145,7 +145,7 @@ async def test_stream_queue_marks_pre_post_terminal_as_stale() -> None:
     message_posted.set()
     release_current_event.set()
     current_event, current_after_post = await queue.get()
-    await task
+    assert await task is None
 
     assert stale_event["type"] == "session.terminal"
     assert stale_after_post is False

--- a/tests/unit/omnigent/test_execute.py
+++ b/tests/unit/omnigent/test_execute.py
@@ -22,10 +22,14 @@ from moonmind.omnigent.execute import (
     OmnigentContractError,
     OmnigentSessionStillRunningError,
     _agent_items,
+    _await_marked_turn_terminal,
     _first_message_text,
+    _enqueue_stream_events,
     _resolve_agent_id,
     _resolve_initial_context_message,
     _restore_active_journals,
+    _snapshot_confirms_current_turn_terminal,
+    _snapshot_contains_current_turn_progress,
     normalize_omnigent_observation,
     run_omnigent_execution,
 )
@@ -42,6 +46,420 @@ def _request() -> AgentExecutionRequest:
         correlationId="corr-1",
         idempotencyKey="idem-1",
     )
+
+
+def test_current_turn_progress_ignores_prior_terminal_work() -> None:
+    marker = """MoonMind-Omnigent-Run:
+  correlationId: workflow-1
+  idempotencyKey: continuation-2"""
+    prior_only = {
+        "items": [
+            {"type": "message", "data": {"role": "assistant", "content": []}},
+            {"type": "function_call_output", "data": {}},
+            {
+                "type": "message",
+                "data": {
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": marker}],
+                },
+            },
+        ]
+    }
+    current_progress = {
+        "items": [*prior_only["items"], {"type": "function_call", "data": {}}]
+    }
+
+    assert not _snapshot_contains_current_turn_progress(prior_only, marker=marker)
+    assert _snapshot_contains_current_turn_progress(current_progress, marker=marker)
+
+
+def test_marked_tool_progress_requires_terminal_assistant_evidence() -> None:
+    marker = """MoonMind-Omnigent-Run:
+  correlationId: workflow-1
+  idempotencyKey: continuation-2"""
+    items = [
+        {
+            "type": "message",
+            "data": {
+                "role": "user",
+                "content": [{"type": "input_text", "text": marker}],
+            },
+        },
+        {"type": "function_call_output", "data": {}},
+    ]
+
+    assert not _snapshot_confirms_current_turn_terminal(
+        {
+            "status": "running",
+            "active_response_id": "response-1",
+            "items": items,
+        },
+        marker=marker,
+    )
+    assert not _snapshot_confirms_current_turn_terminal(
+        {"status": "idle", "active_response_id": None, "items": items},
+        marker=marker,
+    )
+    completed_items = [
+        *items,
+        {
+            "type": "message",
+            "data": {
+                "role": "assistant",
+                "content": [{"type": "output_text", "text": "Done"}],
+            },
+        },
+    ]
+    assert _snapshot_confirms_current_turn_terminal(
+        {"status": "running", "active_response_id": None, "items": completed_items},
+        marker=marker,
+    )
+    assert not _snapshot_confirms_current_turn_terminal(
+        {"status": "running", "items": items},
+        marker=marker,
+    )
+
+
+@pytest.mark.asyncio
+async def test_stream_queue_marks_pre_post_terminal_as_stale() -> None:
+    release_current_event = asyncio.Event()
+
+    class Client:
+        async def stream_events(self, _session_id):
+            yield {"type": "session.terminal", "status": "completed"}
+            await release_current_event.wait()
+            yield {"type": "session.terminal", "status": "completed"}
+
+    queue = asyncio.Queue()
+    message_posted = asyncio.Event()
+    task = asyncio.create_task(
+        _enqueue_stream_events(
+            client=Client(),
+            session_id="session-1",
+            queue=queue,
+            message_posted=message_posted,
+        )
+    )
+
+    stale_event, stale_after_post = await queue.get()
+    message_posted.set()
+    release_current_event.set()
+    current_event, current_after_post = await queue.get()
+    await task
+
+    assert stale_event["type"] == "session.terminal"
+    assert stale_after_post is False
+    assert current_event["type"] == "session.terminal"
+    assert current_after_post is True
+
+
+@pytest.mark.asyncio
+async def test_snapshot_polling_waits_for_marked_turn_running_transition() -> None:
+    marker = "MoonMind-Omnigent-Run: continuation-2"
+    prior_terminal = {"status": "completed", "items": []}
+    current_items = [
+        {
+            "type": "message",
+            "data": {
+                "role": "user",
+                "content": [{"type": "input_text", "text": marker}],
+            },
+        },
+        {"type": "function_call_output", "data": {}},
+    ]
+
+    class Client:
+        def __init__(self) -> None:
+            self.snapshots = [
+                prior_terminal,
+                {"status": "running", "items": current_items},
+                {
+                    "status": "running",
+                    "active_response_id": None,
+                    "items": current_items,
+                },
+            ]
+            self.calls = 0
+
+        async def get_session(self, _session_id: str) -> dict[str, Any]:
+            index = min(self.calls, len(self.snapshots) - 1)
+            self.calls += 1
+            return self.snapshots[index]
+
+    status, snapshot = await _await_marked_turn_terminal(
+        client=Client(),
+        session_id="session-1",
+        marker=marker,
+        event_count=4,
+        terminal_status="completed",
+        interval_seconds=0.001,
+        quiet_period_seconds=0.002,
+        tool_only_quiet_period_seconds=0.002,
+    )
+
+    assert status == "completed"
+    assert snapshot["items"] == current_items
+
+
+@pytest.mark.asyncio
+async def test_snapshot_polling_accepts_marked_progress_while_session_is_idle() -> None:
+    marker = "MoonMind-Omnigent-Run: continuation-2"
+    terminal = {
+        "status": "idle",
+        "items": [
+            {
+                "type": "message",
+                "data": {
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": marker}],
+                },
+            },
+            {
+                "type": "message",
+                "data": {
+                    "role": "assistant",
+                    "content": [{"type": "output_text", "text": "Done"}],
+                },
+            },
+        ],
+    }
+
+    class Client:
+        async def get_session(self, _session_id: str) -> dict[str, Any]:
+            return terminal
+
+    status, snapshot = await _await_marked_turn_terminal(
+        client=Client(),
+        session_id="session-1",
+        marker=marker,
+        event_count=4,
+        terminal_status="completed",
+        interval_seconds=0.001,
+        quiet_period_seconds=0.002,
+    )
+
+    assert status == "completed"
+    assert snapshot is terminal
+
+
+@pytest.mark.asyncio
+async def test_snapshot_polling_preserves_marked_provider_failure() -> None:
+    marker = "MoonMind-Omnigent-Run: failed-turn"
+    failed = {
+        "status": "failed",
+        "items": [
+            {
+                "type": "message",
+                "data": {
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": marker}],
+                },
+            },
+            {"type": "function_call_output", "data": {}},
+        ],
+    }
+
+    class Client:
+        async def get_session(self, _session_id: str) -> dict[str, Any]:
+            return failed
+
+    status, snapshot = await _await_marked_turn_terminal(
+        client=Client(),
+        session_id="session-1",
+        marker=marker,
+        event_count=2,
+        terminal_status="completed",
+        interval_seconds=0.001,
+    )
+
+    assert status == "failed"
+    assert snapshot is failed
+
+
+@pytest.mark.asyncio
+async def test_snapshot_polling_waits_for_quiet_after_stale_idle_tool_output() -> None:
+    marker = "MoonMind-Omnigent-Run: continuation-2"
+    marked_user = {
+        "id": "item-user",
+        "type": "message",
+        "status": "completed",
+        "data": {
+            "role": "user",
+            "content": [{"type": "input_text", "text": marker}],
+        },
+    }
+    snapshots = [
+        {
+            "status": "idle",
+            "items": [
+                marked_user,
+                {
+                    "id": "assistant-preamble",
+                    "type": "message",
+                    "status": "completed",
+                    "data": {
+                        "role": "assistant",
+                        "content": [
+                            {"type": "output_text", "text": "I will inspect it."}
+                        ],
+                    },
+                },
+            ],
+        },
+        {
+            "status": "idle",
+            "items": [
+                marked_user,
+                {
+                    "id": "assistant-preamble",
+                    "type": "message",
+                    "status": "completed",
+                    "data": {
+                        "role": "assistant",
+                        "content": [
+                            {"type": "output_text", "text": "I will inspect it."}
+                        ],
+                    },
+                },
+                {
+                    "id": "call-1",
+                    "type": "function_call",
+                    "status": "completed",
+                    "data": {"call_id": "call-1"},
+                },
+            ],
+        },
+        {
+            "status": "idle",
+            "items": [
+                marked_user,
+                {
+                    "id": "assistant-preamble",
+                    "type": "message",
+                    "status": "completed",
+                    "data": {
+                        "role": "assistant",
+                        "content": [
+                            {"type": "output_text", "text": "I will inspect it."}
+                        ],
+                    },
+                },
+                {
+                    "id": "call-1",
+                    "type": "function_call",
+                    "status": "completed",
+                    "data": {"call_id": "call-1"},
+                },
+                {
+                    "id": "output-1",
+                    "type": "function_call_output",
+                    "status": "completed",
+                    "data": {"call_id": "call-1"},
+                },
+            ],
+        },
+        {
+            "status": "idle",
+            "items": [
+                marked_user,
+                {
+                    "id": "assistant-preamble",
+                    "type": "message",
+                    "status": "completed",
+                    "data": {
+                        "role": "assistant",
+                        "content": [
+                            {"type": "output_text", "text": "I will inspect it."}
+                        ],
+                    },
+                },
+                {
+                    "id": "call-1",
+                    "type": "function_call",
+                    "status": "completed",
+                    "data": {"call_id": "call-1"},
+                },
+                {
+                    "id": "output-1",
+                    "type": "function_call_output",
+                    "status": "completed",
+                    "data": {"call_id": "call-1"},
+                },
+                {
+                    "id": "call-2",
+                    "type": "function_call",
+                    "status": "completed",
+                    "data": {"call_id": "call-2"},
+                },
+            ],
+        },
+        {
+            "status": "idle",
+            "items": [
+                marked_user,
+                {
+                    "id": "assistant-preamble",
+                    "type": "message",
+                    "status": "completed",
+                    "data": {
+                        "role": "assistant",
+                        "content": [
+                            {"type": "output_text", "text": "I will inspect it."}
+                        ],
+                    },
+                },
+                {
+                    "id": "call-1",
+                    "type": "function_call",
+                    "status": "completed",
+                    "data": {"call_id": "call-1"},
+                },
+                {
+                    "id": "output-1",
+                    "type": "function_call_output",
+                    "status": "completed",
+                    "data": {"call_id": "call-1"},
+                },
+                {
+                    "id": "call-2",
+                    "type": "function_call",
+                    "status": "completed",
+                    "data": {"call_id": "call-2"},
+                },
+                {
+                    "id": "output-2",
+                    "type": "function_call_output",
+                    "status": "completed",
+                    "data": {"call_id": "call-2"},
+                },
+            ],
+        },
+    ]
+
+    class Client:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        async def get_session(self, _session_id: str) -> dict[str, Any]:
+            index = min(self.calls, len(snapshots) - 1)
+            self.calls += 1
+            return snapshots[index]
+
+    client = Client()
+    status, snapshot = await _await_marked_turn_terminal(
+        client=client,
+        session_id="session-1",
+        marker=marker,
+        event_count=4,
+        terminal_status="completed",
+        interval_seconds=0.001,
+        quiet_period_seconds=0.02,
+        tool_only_quiet_period_seconds=0.02,
+    )
+
+    assert status == "completed"
+    assert snapshot["items"][-1]["id"] == "output-2"
+    assert client.calls >= 6
 
 
 @pytest.mark.asyncio
@@ -1422,6 +1840,76 @@ async def test_run_omnigent_execution_reuses_heartbeat_session_on_retry(
 
 
 @pytest.mark.asyncio
+async def test_run_omnigent_execution_continues_existing_session_with_new_message(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    calls: list[tuple[str, str]] = []
+
+    class FakeClient:
+        def __init__(self, **_: object) -> None:
+            self.stream_started = False
+
+        async def list_agents(self) -> dict[str, object]:
+            return {"items": [{"id": "agent-1", "name": "codex-native-ui"}]}
+
+        async def create_session(self, payload: dict[str, object]) -> dict[str, object]:
+            raise AssertionError("same-session continuation must not create a session")
+
+        async def post_event(
+            self,
+            session_id: str,
+            payload: dict[str, object],
+        ) -> dict[str, object]:
+            assert self.stream_started is True
+            text = str(payload["data"]["content"][0]["text"])
+            calls.append((session_id, text))
+            return {"pending_id": "pending-continuation-1"}
+
+        async def stream_events(self, session_id: str):
+            assert session_id == "existing-session"
+            self.stream_started = True
+            yield {"type": "turn.started"}
+            yield {"type": "turn.completed"}
+
+        async def get_session(self, session_id: str) -> dict[str, object]:
+            assert session_id == "existing-session"
+            return {"status": "completed", "summary": "continuation complete"}
+
+    monkeypatch.setenv("OMNIGENT_ENABLED", "true")
+    monkeypatch.setenv("OMNIGENT_SERVER_URL", "https://omnigent.test")
+    monkeypatch.setattr("moonmind.omnigent.execute.OmnigentHttpClient", FakeClient)
+
+    result = await run_omnigent_execution(
+        AgentExecutionRequest(
+            agentKind="external",
+            agentId="omnigent",
+            correlationId="corr-1",
+            idempotencyKey="idem-continuation-1",
+            parameters={
+                "omnigent": {
+                    "agent": {"agentName": "codex-native-ui"},
+                    "session": {"allowEmptyWorkspace": True},
+                }
+            },
+        ),
+        artifact_gateway=LocalOmnigentArtifactGateway(root=tmp_path),
+        resume_session_id="existing-session",
+        first_message_text="Continue the current task.",
+        defer_bridge_terminal=True,
+    )
+
+    assert calls and calls[0][0] == "existing-session"
+    assert calls[0][1].startswith("Continue the current task.")
+    assert "idem-continuation-1" in calls[0][1]
+    assert result.summary == "continuation complete"
+    assert result.metadata["deferredBridgeTerminal"]["status"] == "completed"
+    assert result.metadata["deferredBridgeTerminal"]["idempotencyKey"] == (
+        "idem-continuation-1"
+    )
+
+
+@pytest.mark.asyncio
 async def test_run_omnigent_execution_reuses_persisted_session_on_retry(
     monkeypatch,
     tmp_path,
@@ -2660,7 +3148,15 @@ async def test_run_omnigent_execution_redacts_raw_events_before_persistence(
         "workflowChatVisible": False,
         "source": "omnigent_stream",
     }
-    assert normalized_events[-1]["type"] == "response.completed"
+    assert any(
+        event["type"] == "response.completed"
+        and event["normalizedStatus"] == "completed"
+        for event in normalized_events
+    )
+    # This fake emits completion before post_event returns, so the queue marks
+    # it as pre-post replay. The corroborating terminal snapshot is therefore
+    # appended as the authoritative terminal index entry.
+    assert normalized_events[-1]["type"] == "session.final_snapshot"
     assert normalized_events[-1]["normalizedStatus"] == "completed"
 
     # Scan the actual durable artifact bodies emitted by the execution, rather

--- a/tests/unit/omnigent/test_execution_profiles.py
+++ b/tests/unit/omnigent/test_execution_profiles.py
@@ -13,6 +13,10 @@ from moonmind.omnigent.execution_profiles import (
 )
 from moonmind.omnigent.oauth_hosts import OmnigentOAuthHostError
 from moonmind.omnigent.oauth_host_runtime import OmnigentOAuthHostRuntime
+from moonmind.omnigent.stock_agents import (
+    CLAUDE_STOCK_AGENT_NAME,
+    CODEX_STOCK_AGENT_NAME,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -36,6 +40,7 @@ def test_versioned_profile_and_policy_compile_to_stable_safe_snapshot() -> None:
     assert first == second
     assert first["hostMode"] == "on_demand_docker"
     assert first["harness"] == "codex-native"
+    assert first["agentName"] == CODEX_STOCK_AGENT_NAME
     assert first["snapshotRef"].startswith("omnigent-launch:sha256:")
     assert "credential" not in str(first).lower()
     assert "docker.sock" not in str(first)
@@ -161,6 +166,7 @@ def test_claude_profile_compiles_exact_provider_native_snapshot() -> None:
     )
     assert launch["providerRuntime"] == "claude_code"
     assert launch["harness"] == "claude-native"
+    assert launch["agentName"] == CLAUDE_STOCK_AGENT_NAME
     assert launch["hostMode"] == "on_demand_docker"
     validate_effective_launch_snapshot(launch)
 

--- a/tests/unit/omnigent/test_follow_up_retrieval_policy.py
+++ b/tests/unit/omnigent/test_follow_up_retrieval_policy.py
@@ -251,7 +251,7 @@ def test_effective_launch_snapshot_carries_and_validates_block() -> None:
             },
             "execution": {
                 "profileRef": "omnigent-codex@1",
-                "agentIdentities": ["codex"],
+                "agentIdentities": ["codex-native-ui"],
                 "harness": "codex",
             },
             "endpoint": {"ref": "endpoint:1"},
@@ -298,7 +298,7 @@ def test_effective_launch_snapshot_defaults_to_disabled() -> None:
             },
             "execution": {
                 "profileRef": "omnigent-codex@1",
-                "agentIdentities": ["codex"],
+                "agentIdentities": ["codex-native-ui"],
                 "harness": "codex",
             },
             "endpoint": {"ref": "endpoint:1"},

--- a/tests/unit/omnigent/test_host_tool_projection.py
+++ b/tests/unit/omnigent/test_host_tool_projection.py
@@ -30,6 +30,10 @@ def test_static_hosts_project_versioned_tools_without_covering_usr_local_bin() -
     assert compose["volumes"]["omnigent-tools"]["name"] == (
         "moonmind-omnigent-tools-gh-${OMNIGENT_GH_VERSION:-2.76.2}"
     )
+    assert "profiles" not in compose["services"]["omnigent-tools-init"]
+    assert compose["services"]["temporal-worker-agent-runtime"]["depends_on"][
+        "omnigent-tools-init"
+    ] == {"condition": "service_completed_successfully"}
 
 
 def test_login_profile_prepends_tools_path_idempotently() -> None:
@@ -37,3 +41,18 @@ def test_login_profile_prepends_tools_path_idempotently() -> None:
 
     assert "*:/opt/moonmind-tools/bin:*)" in profile
     assert 'export PATH="/opt/moonmind-tools/bin${PATH:+:$PATH}"' in profile
+
+
+def test_codex_host_materializes_gh_auth_outside_workspace_and_drops_token() -> None:
+    script = Path(
+        "services/omnigent/scripts/start-codex-oauth-host.sh"
+    ).read_text()
+
+    materialize_index = script.index("github_config_home=")
+    unset_index = script.index("unset github_token GH_TOKEN")
+    host_start_index = script.index("exec omnigent host")
+
+    assert "/home/app/.cache/moonmind-xdg" in script
+    assert "/workspaces/run" not in script
+    assert 'printf \'    oauth_token: %s\\n\' "$github_token"' in script
+    assert materialize_index < unset_index < host_start_index

--- a/tests/unit/omnigent/test_oauth_host_janitor.py
+++ b/tests/unit/omnigent/test_oauth_host_janitor.py
@@ -15,8 +15,15 @@ class _Repository:
     async def list_active_host_leases(self):
         return [self.lease]
 
+    async def list_terminal_host_leases_with_active_provider_capacity(self):
+        return []
+
     async def validate_binding(self, _binding_ref):
-        return SimpleNamespace()
+        return SimpleNamespace(
+            credential_mount_ref=SimpleNamespace(
+                auth_volume_ref=SimpleNamespace(runtime_id="codex_cli")
+            )
+        )
 
     async def get_host_lease(self, lease_id):
         return self.lease if lease_id == self.lease.lease_id else None
@@ -72,11 +79,22 @@ class _Client:
         return {}
 
 
+class _LeaseClient:
+    def __init__(self, order=None):
+        self.released = []
+        self.order = order if order is not None else []
+
+    async def release_lease(self, lease):
+        self.order.append("provider_released")
+        self.released.append(lease)
+
+
 def _lease(*, heartbeat_age: int = 0):
     now = datetime.now(UTC)
     return SimpleNamespace(
         lease_id="lease-1",
         provider_profile_id="profile-1",
+        provider_lease_id="provider-lease-1",
         binding_ref="binding-1",
         container_name="host-1",
         omnigent_session_id="session-1",
@@ -183,7 +201,8 @@ async def test_janitor_reconciles_stale_heartbeat_after_restart() -> None:
 @pytest.mark.asyncio
 async def test_janitor_consumes_durable_runner_exit_cleanup_handoff() -> None:
     repository = _Repository(_lease())
-    runtime = _Runtime()
+    runtime = _Runtime(repository.order)
+    lease_client = _LeaseClient(repository.order)
     run_store = SimpleNamespace(
         cleanup_required_host_lease_refs=lambda: None,
     )
@@ -197,10 +216,51 @@ async def test_janitor_consumes_durable_runner_exit_cleanup_handoff() -> None:
         runtime=runtime,
         client=_Client(),
         run_store=run_store,
+        lease_client=lease_client,
     ).run()
 
     assert result["actions"][-1]["action"] == "runner_exit_cleanup"
     assert repository.stopped == ["lease-1"]
+    assert lease_client.released[0].lease_id == "provider-lease-1"
+    assert lease_client.released[0].owner_id == "provider-lease-1"
+    assert lease_client.released[0].runtime_id == "codex_cli"
+    assert repository.order == [
+        "host_stopped",
+        "provider_released",
+        "lease_released",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_janitor_releases_capacity_left_on_already_stopped_host() -> None:
+    lease = _lease()
+    lease.status = "stopped"
+    repository = _Repository(lease)
+    repository.list_active_host_leases = lambda: None
+
+    async def no_active_leases():
+        return []
+
+    async def terminal_provider_leases():
+        return [lease]
+
+    repository.list_active_host_leases = no_active_leases
+    repository.list_terminal_host_leases_with_active_provider_capacity = (
+        terminal_provider_leases
+    )
+    runtime = _Runtime(repository.order)
+    lease_client = _LeaseClient(repository.order)
+
+    result = await OmnigentOAuthHostJanitor(
+        repository=repository,
+        runtime=runtime,
+        client=_Client(),
+        lease_client=lease_client,
+    ).run()
+
+    assert result["actions"][-1]["action"] == "provider_lease_reconciliation"
+    assert repository.order == ["provider_released", "lease_released"]
+    assert runtime.stopped == 0
 
 
 @pytest.mark.asyncio

--- a/tests/unit/omnigent/test_oauth_profile_lifecycle.py
+++ b/tests/unit/omnigent/test_oauth_profile_lifecycle.py
@@ -1,3 +1,4 @@
+import asyncio
 from datetime import UTC, datetime, timedelta
 import hashlib
 import json
@@ -34,6 +35,7 @@ from moonmind.omnigent.checkpoints import (
     validate_restore_material,
 )
 from moonmind.omnigent.oauth_hosts import (
+    HOST_PROFILE_BUSY_ERROR_CODE,
     OmnigentOAuthHostError,
     OmnigentOAuthHostRepository,
     validate_preflight_result,
@@ -129,6 +131,120 @@ def test_persisted_policy_snapshot_is_complete_launch_authority():
     assert realized["policyAuthority"]["policyDigest"] == snapshot["policyDigest"]
     assert realized["snapshotRef"].startswith("omnigent-launch:sha256:")
     validate_effective_launch_snapshot(realized)
+
+
+@pytest.mark.asyncio
+async def test_oauth_host_egress_attestation_invokes_docker_cli(monkeypatch):
+    runtime = OmnigentOAuthHostRuntime(client=SimpleNamespace())
+    runtime._run = AsyncMock(return_value=(0, "{}", ""))
+
+    async def attest(*, runner, profile, backend_ref):
+        assert profile == OMNIGENT_EGRESS_PROFILE
+        assert backend_ref == "omnigent-host-runtime"
+        await runner(("network", "inspect", "network-1"))
+        return MagicMock()
+
+    monkeypatch.setattr(
+        "moonmind.omnigent.oauth_host_runtime.attest_docker_egress",
+        attest,
+    )
+
+    await runtime._attest_egress(
+        {"networkRef": OMNIGENT_EGRESS_PROFILE.network_ref}
+    )
+
+    runtime._run.assert_awaited_once_with(
+        "docker",
+        "network",
+        "inspect",
+        "network-1",
+        check=False,
+    )
+
+
+@pytest.mark.asyncio
+async def test_required_tool_bundle_probe_uses_remote_daemon_named_volume(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("OMNIGENT_GH_VERSION", "2.76.2")
+    runtime = OmnigentOAuthHostRuntime(
+        client=SimpleNamespace(),
+        image="omnigent-host:test",
+    )
+    runtime._run = AsyncMock(return_value=(0, "gh version 2.76.2 (test)\n", ""))
+
+    await runtime._initialize_required_tools()
+
+    runtime._run.assert_awaited_once_with(
+        "docker",
+        "run",
+        "--rm",
+        "--volume",
+        "moonmind-omnigent-tools-gh-2.76.2:/opt/moonmind-tools:ro",
+        "--entrypoint",
+        "/opt/moonmind-tools/bin/gh",
+        "omnigent-host:test",
+        "--version",
+        check=False,
+    )
+
+
+@pytest.mark.asyncio
+async def test_required_tool_bundle_probe_fails_with_stable_readiness_evidence() -> None:
+    runtime = OmnigentOAuthHostRuntime(
+        client=SimpleNamespace(),
+        image="omnigent-host:test",
+    )
+    runtime._run = AsyncMock(return_value=(127, "", "tool missing"))
+
+    with pytest.raises(MountedToolPreflightError) as failure:
+        await runtime._initialize_required_tools()
+
+    assert failure.value.code == "tool_bundle_unavailable"
+    assert failure.value.evidence == {
+        "tool": "gh",
+        "phase": "deployment_initialization",
+        "bundleVolume": "moonmind-omnigent-tools-gh-2.76.2",
+        "expectedVersion": "2.76.2",
+    }
+
+
+def test_runtime_scripts_are_snapshotted_under_daemon_mapping(
+    tmp_path, monkeypatch
+):
+    scripts = tmp_path / "source-scripts"
+    scripts.mkdir()
+    for name in (
+        "init-oauth-host.sh",
+        "moonmind-tools.sh",
+        "start-codex-oauth-host.sh",
+        "start-claude-oauth-host.sh",
+    ):
+        script = scripts / name
+        script.write_text("#!/bin/sh\n", encoding="utf-8")
+        script.chmod(0o755)
+    worker_root = tmp_path / "worker-root"
+    daemon_root = tmp_path / "daemon-root"
+    runtime = OmnigentOAuthHostRuntime(
+        client=SimpleNamespace(),
+        scripts_dir=scripts,
+        workspace_root=worker_root,
+    )
+    monkeypatch.setenv("WORKFLOW_DOCKER_DAEMON_MODE", "remote")
+    monkeypatch.setenv("WORKFLOW_WORKSPACE_ROOT", str(worker_root))
+    monkeypatch.setenv("WORKFLOW_WORKSPACE_DAEMON_ROOT", str(daemon_root))
+
+    daemon_scripts = runtime._prepare_daemon_runtime_scripts(
+        "workflow:run:step",
+        current_step_execution_id="workflow:run:step:execution:1",
+    )
+
+    relative = daemon_scripts.relative_to(daemon_root)
+    worker_scripts = worker_root / relative
+    assert daemon_scripts != scripts
+    assert worker_scripts.is_dir()
+    assert (worker_scripts / "init-oauth-host.sh").stat().st_mode & 0o111
+    assert (worker_scripts / "moonmind-execution.sh").is_file()
 
 
 @pytest.mark.parametrize(
@@ -518,7 +634,7 @@ def test_restore_rejects_checkpoint_bound_to_a_different_policy_snapshot() -> No
         document={
             "schemaVersion": 1,
             "endpoint": {"ref": "default", "bridgeModes": ["embedded"]},
-            "execution": {"profileRef": "omnigent-codex@1", "harness": "codex-native", "agentIdentities": ["codex"]},
+            "execution": {"profileRef": "omnigent-codex@1", "harness": "codex-native", "agentIdentities": ["codex-native-ui"]},
             "host": {"mode": "static_compose", "backendRef": "compose", "architectures": ["amd64"], "serverImageRef": "image@sha256:" + "1" * 64, "hostImageRef": "host@sha256:" + "2" * 64},
             "resources": {"cpuMillis": 1000, "memoryMiB": 1024, "processes": 64, "timeoutSeconds": 60, "temporaryStorageMiB": 64, "concurrency": 1},
             "network": {"attachmentRef": "network", "egressProfileRef": "egress"},
@@ -746,6 +862,7 @@ async def test_activity_lease_client_marks_deterministic_owner_as_non_workflow()
     class Adapter:
         def __init__(self) -> None:
             self.payload = None
+            self.update_name = None
 
         async def get_client(self):
             return self
@@ -753,7 +870,8 @@ async def test_activity_lease_client_marks_deterministic_owner_as_non_workflow()
         async def start_workflow(self, *_args, **_kwargs):
             return None
 
-        async def update_workflow(self, _workflow_id, _update_name, payload):
+        async def update_workflow(self, _workflow_id, update_name, payload):
+            self.update_name = update_name
             self.payload = payload
             return {
                 "profile_id": "codex",
@@ -769,8 +887,53 @@ async def test_activity_lease_client_marks_deterministic_owner_as_non_workflow()
         metadata={"ownerIsWorkflow": True, "workflowId": "workflow-1"},
     )
     assert lease.profile_id == "codex"
+    assert adapter.update_name == "AcquireSlotV2"
     assert adapter.payload["metadata"]["ownerIsWorkflow"] is False
     assert adapter.payload["metadata"]["workflowId"] == "workflow-1"
+
+
+@pytest.mark.asyncio
+async def test_activity_lease_client_reopens_manager_after_completed_update() -> None:
+    from temporalio.client import WorkflowUpdateFailedError
+    from temporalio.exceptions import ApplicationError
+
+    class Adapter:
+        def __init__(self) -> None:
+            self.start_count = 0
+            self.update_count = 0
+
+        async def get_client(self):
+            return self
+
+        async def start_workflow(self, *_args, **_kwargs):
+            self.start_count += 1
+
+        async def update_workflow(self, _workflow_id, _update_name, payload):
+            self.update_count += 1
+            if self.update_count == 1:
+                raise WorkflowUpdateFailedError(
+                    ApplicationError(
+                        "Workflow completed before the Update completed.",
+                        type="AcceptedUpdateCompletedWorkflow",
+                        non_retryable=True,
+                    )
+                )
+            return {
+                "profile_id": "codex",
+                "lease_id": payload["requester_workflow_id"],
+            }
+
+    adapter = Adapter()
+    lease = await ProviderProfileLeaseClient(adapter).acquire_execution_lease(
+        runtime_id="codex_cli",
+        profile_id="codex",
+        owner_id="profile-lease:execution_omnigent:manager-race",
+        purpose=CredentialLeasePurpose.EXECUTION_OMNIGENT,
+    )
+
+    assert lease.lease_id == "profile-lease:execution_omnigent:manager-race"
+    assert adapter.start_count == 2
+    assert adapter.update_count == 2
 
 
 @pytest.mark.asyncio
@@ -808,6 +971,49 @@ async def test_activity_lease_client_preserves_delegating_workflow_owner() -> No
     }
 
 
+def test_runtime_script_snapshot_materializes_owned_step_identity(tmp_path) -> None:
+    runtime = OmnigentOAuthHostRuntime(
+        client=SimpleNamespace(),
+        scripts_dir=Path("services/omnigent/scripts"),
+        workspace_root=tmp_path / "workspaces",
+    )
+    execution_id = "workflow:run:node-1:execution:1"
+
+    target = runtime._prepare_runtime_scripts(
+        "workspace-key",
+        current_step_execution_id=execution_id,
+    )
+
+    profile = target / "moonmind-execution.sh"
+    assert profile.read_text(encoding="utf-8") == (
+        "# Generated for one MoonMind-owned Omnigent host lease.\n"
+        f"export MOONMIND_STEP_EXECUTION_ID='{execution_id}'\n"
+    )
+    assert profile.stat().st_mode & 0o777 == 0o444
+    with pytest.raises(OmnigentOAuthHostError) as mismatch:
+        runtime._prepare_runtime_scripts(
+            "workspace-key",
+            current_step_execution_id="workflow:run:node-1:execution:2",
+        )
+    assert mismatch.value.code == "OMNIGENT_RUNTIME_SCRIPTS_UNAVAILABLE"
+
+
+def test_runtime_script_snapshot_rejects_unsafe_step_identity(tmp_path) -> None:
+    runtime = OmnigentOAuthHostRuntime(
+        client=SimpleNamespace(),
+        scripts_dir=Path("services/omnigent/scripts"),
+        workspace_root=tmp_path / "workspaces",
+    )
+
+    with pytest.raises(OmnigentOAuthHostError) as raised:
+        runtime._prepare_runtime_scripts(
+            "workspace-key",
+            current_step_execution_id="workflow:run:'unsafe'",
+        )
+
+    assert raised.value.code == "OMNIGENT_STEP_EXECUTION_ID_INVALID"
+
+
 @pytest.mark.asyncio
 async def test_on_demand_host_initializes_state_before_unprivileged_launch(
     tmp_path, monkeypatch
@@ -834,7 +1040,12 @@ async def test_on_demand_host_initializes_state_before_unprivileged_launch(
     binding = _binding().model_copy(
         update={"static_host_id": None, "host_launch_profile_ref": "codex-oauth-v1"}
     )
-    lease = _host_lease().model_copy(update={"container_name": "mm-host-lease-1"})
+    lease = _host_lease().model_copy(
+        update={
+            "container_name": "mm-host-lease-1",
+            "omnigent_host_id": None,
+        }
+    )
 
     effective_launch = compile_effective_launch(
         profile_ref="omnigent-codex@1",
@@ -849,6 +1060,8 @@ async def test_on_demand_host_initializes_state_before_unprivileged_launch(
         container_name="mm-host-lease-1",
         workspace_source=tmp_path,
         skill_projection=tmp_path / "skills",
+        runtime_scripts=tmp_path,
+        current_step_execution_id="workflow:run:node-1:execution:1",
         effective_launch=effective_launch,
     )
 
@@ -856,9 +1069,19 @@ async def test_on_demand_host_initializes_state_before_unprivileged_launch(
     assert commands[0][:3] == ("docker", "inspect", "--format")
     assert "/opt/moonmind/init-oauth-host.sh" in commands[1]
     assert commands[2][:3] == ("docker", "run", "-d")
+    assert commands[2][commands[2].index("--hostname") + 1] == "mm-host-lease-1"
     runtime._discover_upstream_path.assert_awaited_once_with(snapshot_image)
     assert commands[1][-1] == snapshot_image
-    assert commands[2][-2] == snapshot_image
+    image_index = commands[2].index(snapshot_image)
+    assert commands[2][image_index - 2 : image_index] == (
+        "--entrypoint",
+        "/usr/bin/env",
+    )
+    assert commands[2][image_index + 1 : image_index + 3] == (
+        "-u",
+        "OPENAI_API_KEY",
+    )
+    assert commands[2][-1] == "/opt/moonmind/start-codex-oauth-host.sh"
     assert environment_image not in commands[1]
     assert environment_image not in commands[2]
     assert commands[1][commands[1].index("--user") + 1] == "0:0"
@@ -867,11 +1090,30 @@ async def test_on_demand_host_initializes_state_before_unprivileged_launch(
         "type=volume,src=moonmind-omnigent-tools-gh-2.76.2,"
         "dst=/opt/moonmind-tools,readonly"
     ) in commands[2]
+    assert (
+        f"type=bind,src={tmp_path / 'moonmind-tools.sh'},"
+        "dst=/etc/profile.d/moonmind-tools.sh,readonly"
+    ) in commands[2]
+    assert (
+        f"type=bind,src={tmp_path / 'moonmind-execution.sh'},"
+        "dst=/etc/profile.d/moonmind-execution.sh,readonly"
+    ) in commands[2]
     assert "MOONMIND_ACTIVE_SKILLS_DIR=/opt/moonmind-skills" in commands[2]
+    assert (
+        "MOONMIND_STEP_EXECUTION_ID=workflow:run:node-1:execution:1"
+        in commands[2]
+    )
     assert "OMNIGENT_EXECUTION_TIMEOUT_SECONDS=5400" in commands[2]
     assert "OMNIGENT_EXECUTION_TIMEOUT_OWNER=temporal_workflow" in commands[2]
     assert "OMNIGENT_CAPTURE_OWNER=moonmind_bridge" in commands[2]
     assert "OMNIGENT_CAPTURE_RETENTION_DAYS=30" in commands[2]
+    assert (
+        "OMNIGENT_RUNNER_ENV_PASSTHROUGH="
+        "HTTP_PROXY,HTTPS_PROXY,http_proxy,https_proxy,NO_PROXY,no_proxy,"
+        "MOONMIND_STEP_EXECUTION_ID"
+    ) in commands[2]
+    assert "NO_PROXY=localhost,127.0.0.1" in commands[2]
+    assert "no_proxy=localhost,127.0.0.1" in commands[2]
     assert commands[2][commands[2].index("--stop-timeout") + 1] == "20"
     assert (
         f"type=bind,src={tmp_path / 'skills'},dst=/opt/moonmind-skills,readonly"
@@ -939,6 +1181,8 @@ async def test_on_demand_claude_host_uses_claude_runtime_adapter(tmp_path) -> No
         container_name="mm-host-lease-claude",
         workspace_source=tmp_path,
         skill_projection=tmp_path / "skills",
+        runtime_scripts=tmp_path,
+        current_step_execution_id="workflow:run:node-1:execution:1",
         effective_launch=effective_launch,
     )
 
@@ -958,6 +1202,13 @@ async def test_on_demand_claude_host_uses_claude_runtime_adapter(tmp_path) -> No
     assert "CLAUDE_CONFIG_DIR=/home/app/.claude" in launch_command
     assert "CLAUDE_HOME=/home/app/.claude" in launch_command
     assert "CLAUDE_CREDENTIAL_GENERATION=4" in launch_command
+    assert (
+        "OMNIGENT_RUNNER_ENV_PASSTHROUGH="
+        "HTTP_PROXY,HTTPS_PROXY,http_proxy,https_proxy,NO_PROXY,no_proxy,"
+        "MOONMIND_STEP_EXECUTION_ID"
+    ) in launch_command
+    assert "NO_PROXY=localhost,127.0.0.1" in launch_command
+    assert "no_proxy=localhost,127.0.0.1" in launch_command
     assert launch_command[-1] == "/opt/moonmind/start-claude-oauth-host.sh"
     configured_env = [
         launch_command[index + 1]
@@ -965,6 +1216,120 @@ async def test_on_demand_claude_host_uses_claude_runtime_adapter(tmp_path) -> No
         if value == "--env"
     ]
     assert not any(value.startswith("CODEX_") for value in configured_env)
+
+
+@pytest.mark.asyncio
+async def test_profile_bound_execution_heartbeats_host_lease_until_runner_finishes(
+) -> None:
+    heartbeat_observed = asyncio.Event()
+
+    async def heartbeat_host_lease(lease_id: str, *, ttl_seconds: int):
+        assert lease_id == "ohl-live"
+        assert ttl_seconds == 5400
+        heartbeat_observed.set()
+        return SimpleNamespace(lease_id=lease_id)
+
+    async def execution() -> AgentRunResult:
+        await heartbeat_observed.wait()
+        return AgentRunResult(summary="completed")
+
+    hosts = SimpleNamespace(
+        heartbeat_host_lease=AsyncMock(side_effect=heartbeat_host_lease)
+    )
+    coordinator = OmnigentProfileBoundExecutionCoordinator(
+        session_factory=AsyncMock(),
+        lease_client=SimpleNamespace(),
+        host_repository=hosts,
+        host_runtime=SimpleNamespace(),
+        run_store=SimpleNamespace(),
+        execution_runner=AsyncMock(),
+        artifact_gateway=SimpleNamespace(),
+    )
+
+    result = await coordinator._execute_with_host_lease_heartbeat(
+        execution(),
+        host_lease_ref="ohl-live",
+        ttl_seconds=5400,
+    )
+
+    assert result.summary == "completed"
+    hosts.heartbeat_host_lease.assert_awaited_once_with(
+        "ohl-live",
+        ttl_seconds=5400,
+    )
+
+
+@pytest.mark.asyncio
+async def test_exact_host_resolution_uses_lease_hostname_and_stock_harness_shape(
+) -> None:
+    client = SimpleNamespace()
+    client.list_hosts = AsyncMock(
+        return_value=[
+            {
+                "host_id": "host-stock-1",
+                "name": "mm-host-lease-1",
+                "status": "online",
+                "configured_harnesses": {
+                    "codex-native": True,
+                    "claude-native": False,
+                },
+            }
+        ]
+    )
+    runtime = OmnigentOAuthHostRuntime(client=client)
+    binding = _binding().model_copy(
+        update={"static_host_id": None, "host_launch_profile_ref": "codex-oauth-v1"}
+    )
+    lease = _host_lease().model_copy(
+        update={
+            "container_name": "mm-host-lease-1",
+            "omnigent_host_id": None,
+        }
+    )
+
+    host = await runtime._resolve_exact_host(binding=binding, host_lease=lease)
+
+    assert host["host_id"] == "host-stock-1"
+    assert runtime._ready_host_harnesses(host) == {"codex-native"}
+
+
+@pytest.mark.asyncio
+async def test_exact_host_resolution_waits_for_registration_publication(
+    monkeypatch,
+) -> None:
+    client = SimpleNamespace()
+    client.list_hosts = AsyncMock(
+        side_effect=[
+            [],
+            [],
+            [
+                {
+                    "host_id": "host-stock-1",
+                    "name": "mm-host-lease-1",
+                    "status": "online",
+                }
+            ],
+        ]
+    )
+    runtime = OmnigentOAuthHostRuntime(client=client)
+    binding = _binding().model_copy(
+        update={"static_host_id": None, "host_launch_profile_ref": "codex-oauth-v1"}
+    )
+    lease = _host_lease().model_copy(
+        update={
+            "container_name": "mm-host-lease-1",
+            "omnigent_host_id": None,
+        }
+    )
+    sleep = AsyncMock()
+    monkeypatch.setattr("moonmind.omnigent.oauth_host_runtime.asyncio.sleep", sleep)
+
+    host = await runtime._resolve_exact_host(binding=binding, host_lease=lease)
+
+    assert host["host_id"] == "host-stock-1"
+    assert client.list_hosts.await_count == 3
+    assert sleep.await_count == 2
+    sleep.assert_awaited_with(2)
 
 
 @pytest.mark.asyncio
@@ -1000,6 +1365,8 @@ async def test_on_demand_retry_rejects_stopped_container_from_another_lease(
             container_name="mm-host-lease-1",
             workspace_source=tmp_path,
             skill_projection=tmp_path / "skills",
+            runtime_scripts=tmp_path,
+            current_step_execution_id="workflow:run:node-1:execution:1",
             effective_launch=effective_launch,
         )
 
@@ -1139,6 +1506,73 @@ def test_tools_path_prepend_is_idempotent_and_preserves_upstream_path() -> None:
 
     assert OmnigentOAuthHostRuntime._prepend_tools_path(upstream) == expected
     assert OmnigentOAuthHostRuntime._prepend_tools_path(expected) == expected
+
+
+def test_workspace_ownership_alignment_does_not_follow_repository_symlinks(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    workspace_root = tmp_path / "workspaces"
+    workspace = workspace_root / "run" / "repo"
+    workspace.mkdir(parents=True)
+    tracked = workspace / "tracked.txt"
+    tracked.write_text("tracked", encoding="utf-8")
+    outside = tmp_path / "outside.txt"
+    outside.write_text("outside", encoding="utf-8")
+    link = workspace / "outside-link"
+    link.symlink_to(outside)
+    observed: list[tuple[Path, int, int, bool]] = []
+
+    def record_chown(path, uid, gid, *, follow_symlinks=True):
+        observed.append((Path(path), uid, gid, follow_symlinks))
+
+    monkeypatch.setattr(os, "chown", record_chown)
+    runtime = OmnigentOAuthHostRuntime(
+        client=SimpleNamespace(),
+        workspace_root=workspace_root,
+    )
+
+    runtime._align_workspace_ownership(
+        workspace,
+        runtime_uid=1000,
+        runtime_gid=1000,
+    )
+
+    observed_paths = {path for path, _uid, _gid, _follow in observed}
+    assert {workspace.resolve(), tracked, link} <= observed_paths
+    assert outside not in observed_paths
+    assert all((uid, gid, follow) == (1000, 1000, False) for _, uid, gid, follow in observed)
+
+
+@pytest.mark.asyncio
+async def test_host_preflight_rejects_git_workspace_ownership_mismatch(tmp_path) -> None:
+    runtime = OmnigentOAuthHostRuntime(
+        client=SimpleNamespace(),
+        scripts_dir=tmp_path,
+        workspace_root=tmp_path / "workspaces",
+    )
+    runtime._run = AsyncMock(return_value=(0, "", ""))
+
+    await runtime._exec_check("mm-host-lease-1")
+
+    assert [call.args for call in runtime._run.await_args_list] == [
+        (
+            "docker",
+            "exec",
+            "mm-host-lease-1",
+            "/opt/moonmind/check-runner-projections.sh",
+        ),
+        (
+            "docker",
+            "exec",
+            "mm-host-lease-1",
+            "git",
+            "-C",
+            "/workspaces/run",
+            "status",
+            "--porcelain",
+        ),
+    ]
 
 
 def test_github_write_probe_uses_publish_or_skill_side_effect() -> None:
@@ -1960,6 +2394,15 @@ async def test_host_repository_creates_idempotent_binding_and_lease(tmp_path) ->
             idempotency_key="idem-1",
         )
         assert first.lease_id == second.lease_id
+        with pytest.raises(OmnigentOAuthHostError) as busy:
+            await repository.create_or_get_host_lease(
+                binding=binding,
+                provider_lease_id="provider-lease-rerun",
+                holder_workflow_id="workflow-rerun",
+                agent_run_id="step-rerun",
+                idempotency_key="idem-rerun",
+            )
+        assert busy.value.code == HOST_PROFILE_BUSY_ERROR_CODE
         starting = await repository.transition_host_lease(
             first.lease_id,
             expected_status="allocating",
@@ -1968,6 +2411,64 @@ async def test_host_repository_creates_idempotent_binding_and_lease(tmp_path) ->
         assert starting.status == "starting"
     finally:
         await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_coordinator_waits_for_canceled_host_cleanup_before_rerun(
+    monkeypatch,
+) -> None:
+    binding = _binding()
+    provider_lease = SimpleNamespace(lease_id="provider-lease-rerun")
+    lease = _host_lease().model_copy(update={"status": "allocating"})
+    hosts = SimpleNamespace(
+        create_or_get_host_lease=AsyncMock(
+            side_effect=[
+                OmnigentOAuthHostError(
+                    "prior canceled host is still draining",
+                    code=HOST_PROFILE_BUSY_ERROR_CODE,
+                ),
+                lease,
+            ]
+        )
+    )
+    emit = AsyncMock()
+    coordinator = OmnigentProfileBoundExecutionCoordinator(
+        session_factory=lambda: None,
+        lease_client=SimpleNamespace(),
+        host_repository=hosts,
+        host_runtime=SimpleNamespace(),
+        run_store=SimpleNamespace(),
+        execution_runner=AsyncMock(),
+        artifact_gateway=object(),
+    )
+    monkeypatch.setattr(
+        "moonmind.omnigent.profile_bound_execution.HOST_PROFILE_BUSY_POLL_SECONDS",
+        0.0,
+    )
+
+    resolved = await coordinator._create_host_lease_after_profile_idle(
+        binding=binding,
+        provider_lease=provider_lease,
+        workflow_id="workflow-rerun",
+        step_execution_id="step-rerun",
+        idempotency_key="idem-rerun",
+        emit=emit,
+    )
+
+    assert resolved == lease
+    assert hosts.create_or_get_host_lease.await_count == 2
+    emit.assert_awaited_once_with(
+        "host_lease_created",
+        "waiting",
+        code=HOST_PROFILE_BUSY_ERROR_CODE,
+        remediation_action="wait_for_host_cleanup",
+        metadata={
+            "providerProfileId": binding.provider_profile_id,
+            "retryAfterSeconds": 0.0,
+            "waitAttempt": 1,
+        },
+        ignore_errors=True,
+    )
 
 
 @pytest.mark.asyncio
@@ -2141,7 +2642,10 @@ async def test_coordinator_releases_provider_lease_after_host_cleanup() -> None:
 
 async def _drive_authority_chain_coordinator(
     execute,
-) -> tuple[list[str], list[dict], dict]:
+    *,
+    publication: dict | None = None,
+    completion_evidence: list[dict] | None = None,
+) -> tuple[list[str], list[dict], dict, AgentRunResult]:
     """Drive a fully-stubbed on-demand coordinator run with the given runner.
 
     Returns the ordered lifecycle event-type stream and every emitted
@@ -2151,6 +2655,7 @@ async def _drive_authority_chain_coordinator(
 
     ordered: list[str] = []
     authority_metadata: list[dict] = []
+    completion_sequence = list(completion_evidence or [])
 
     provider_lease = SimpleNamespace(
         profile_id="codex",
@@ -2257,6 +2762,28 @@ async def _drive_authority_chain_coordinator(
         async def stop_host(self, **_kwargs):
             ordered.append("host_cleanup")
 
+        async def publish_workspace(self, **_kwargs):
+            return publication or {
+                "push_status": "pushed",
+                "push_branch": "moonmind-job-00000000",
+                "push_base_branch": "main",
+                "push_head_sha": "a" * 40,
+                "push_commit_count": 1,
+                "remote_verified": True,
+                "pushRef": "artifact://push-1",
+            }
+
+        async def inspect_session_completion(self, _session_id):
+            if completion_sequence:
+                return completion_sequence.pop(0)
+            return {
+                "sessionStatus": "completed",
+                "itemCount": 4,
+                "assistantMessageCount": 1,
+                "toolResultCount": 1,
+                "terminalAssistantAfterWork": True,
+            }
+
     class Store:
         async def get_or_create(self, **_kwargs):
             return SimpleNamespace(bridge_session_id="bridge-1")
@@ -2270,6 +2797,9 @@ async def _drive_authority_chain_coordinator(
             if "authorityChain" in metadata:
                 authority_metadata.append(metadata["authorityChain"])
 
+        async def mark_terminal(self, *_args, **_kwargs):
+            return None
+
     coordinator = OmnigentProfileBoundExecutionCoordinator(
         session_factory=lambda: None,
         lease_client=LeaseClient(),
@@ -2278,6 +2808,22 @@ async def _drive_authority_chain_coordinator(
         run_store=Store(),
         execution_runner=execute,
         artifact_gateway=object(),
+    )
+
+    async def _resolve_policy_snapshot(_policy_ref: str) -> dict:
+        document = policy_document()
+        document["host"]["mode"] = "on_demand_docker"
+        document["host"]["backendRef"] = "container-backend"
+        document["session"]["cleanup"] = "remove"
+        return compile_policy_snapshot(
+            policy_id="codex-on-demand",
+            version=1,
+            document=document,
+            validation={"valid": True, "diagnostics": []},
+        )
+
+    coordinator._resolve_policy_snapshot = AsyncMock(  # type: ignore[method-assign]
+        side_effect=_resolve_policy_snapshot
     )
     coordinator._resolve_profile = AsyncMock(  # type: ignore[method-assign]
         return_value=SimpleNamespace(
@@ -2320,7 +2866,12 @@ async def _drive_authority_chain_coordinator(
             },
         )
     )
-    return ordered, authority_metadata, dict(coordinator_result.metadata or {})
+    return (
+        ordered,
+        authority_metadata,
+        dict(coordinator_result.metadata or {}),
+        coordinator_result,
+    )
 
 
 @pytest.mark.asyncio
@@ -2339,7 +2890,7 @@ async def test_coordinator_emits_bounded_authority_chain_before_terminal() -> No
             metadata={"pushRef": "artifact://push-1"},
         )
 
-    ordered, authority_metadata, result_metadata = (
+    ordered, authority_metadata, result_metadata, _result = (
         await _drive_authority_chain_coordinator(execute)
     )
 
@@ -2376,6 +2927,133 @@ async def test_coordinator_emits_bounded_authority_chain_before_terminal() -> No
 
 
 @pytest.mark.asyncio
+async def test_coordinator_rejects_false_success_without_publishable_commits() -> None:
+    """A completed provider turn is not repository terminal evidence by itself."""
+
+    async def execute(request, **_kwargs):
+        return AgentRunResult(summary="provider reported completed")
+
+    ordered, authority_metadata, metadata, result = (
+        await _drive_authority_chain_coordinator(
+            execute,
+            publication={
+                "push_status": "no_commits",
+                "push_branch": "moonmind-job-00000000",
+                "push_base_branch": "main",
+                "push_commit_count": 0,
+                "remote_verified": False,
+            },
+        )
+    )
+
+    assert result.failure_class == "execution_error"
+    assert result.provider_error_code == "OMNIGENT_REPOSITORY_OUTPUT_MISSING"
+    assert result.retry_recommendation == "retry"
+    assert metadata["push_status"] == "no_commits"
+    assert metadata["repositoryContinuationCount"] == 8
+    assert "repository_publication" in ordered
+    assert authority_metadata[0]["terminal"]["harvestState"] == "failed"
+
+
+@pytest.mark.asyncio
+async def test_coordinator_continues_same_session_until_terminal_answer() -> None:
+    """A tool-output-only turn is continued before any branch is published."""
+
+    runner_calls: list[tuple[str, dict]] = []
+
+    async def execute(request, **kwargs):
+        runner_calls.append((request.idempotency_key, dict(kwargs)))
+        return AgentRunResult(
+            summary="provider turn ended",
+            metadata={"omnigentSessionId": "session-1"},
+        )
+
+    incomplete = {
+        "sessionStatus": "completed",
+        "itemCount": 5,
+        "assistantMessageCount": 1,
+        "toolResultCount": 1,
+        "terminalAssistantAfterWork": False,
+    }
+    complete = {
+        "sessionStatus": "completed",
+        "itemCount": 8,
+        "assistantMessageCount": 2,
+        "toolResultCount": 1,
+        "terminalAssistantAfterWork": True,
+    }
+
+    ordered, _authority, metadata, result = (
+        await _drive_authority_chain_coordinator(
+            execute,
+            completion_evidence=[incomplete, complete],
+        )
+    )
+
+    assert result.failure_class is None
+    assert metadata["push_status"] == "pushed"
+    assert metadata["repositoryContinuationCount"] == 1
+    assert len(runner_calls) == 2
+    assert runner_calls[1][0].endswith(":repository-continuation:1")
+    assert runner_calls[1][1]["resume_session_id"] == "session-1"
+    assert "Continue the current task" in runner_calls[1][1]["first_message_text"]
+    assert runner_calls[1][1]["defer_bridge_terminal"] is True
+    assert "repository_continuation_1" in ordered
+
+
+@pytest.mark.asyncio
+async def test_runtime_completion_requires_assistant_after_latest_tool(tmp_path) -> None:
+    client = SimpleNamespace(
+        get_session=AsyncMock(
+            side_effect=[
+                {
+                    "status": "completed",
+                    "items": [
+                        {"type": "message", "data": {"role": "user", "content": []}},
+                        {
+                            "type": "message",
+                            "data": {
+                                "role": "assistant",
+                                "content": [{"type": "output_text", "text": "Working"}],
+                            },
+                        },
+                        {"type": "function_call", "data": {}},
+                        {"type": "function_call_output", "data": {}},
+                    ],
+                },
+                {
+                    "status": "completed",
+                    "items": [
+                        {"type": "message", "data": {"role": "user", "content": []}},
+                        {"type": "function_call", "data": {}},
+                        {"type": "function_call_output", "data": {}},
+                        {
+                            "type": "message",
+                            "data": {
+                                "role": "assistant",
+                                "content": [{"type": "output_text", "text": "Done"}],
+                            },
+                        },
+                    ],
+                },
+            ]
+        )
+    )
+    runtime = OmnigentOAuthHostRuntime(
+        client=client,
+        scripts_dir=tmp_path,
+        workspace_root=tmp_path / "workspaces",
+    )
+
+    incomplete = await runtime.inspect_session_completion("session-1")
+    complete = await runtime.inspect_session_completion("session-1")
+
+    assert incomplete["terminalAssistantAfterWork"] is False
+    assert incomplete["toolResultCount"] == 1
+    assert complete["terminalAssistantAfterWork"] is True
+
+
+@pytest.mark.asyncio
 async def test_coordinator_records_returned_runner_failure_in_authority_chain() -> None:
     """A runner that returns a failed result (not raising) still records evidence.
 
@@ -2393,7 +3071,7 @@ async def test_coordinator_records_returned_runner_failure_in_authority_chain() 
             retryRecommendation="retry_after_provider_cooldown",
         )
 
-    ordered, authority_metadata, _result_metadata = (
+    ordered, authority_metadata, _result_metadata, _result = (
         await _drive_authority_chain_coordinator(execute)
     )
 
@@ -2878,6 +3556,7 @@ async def _run_coordinator_failure_case(
     code: str,
     release_failures: int = 0,
     request: AgentExecutionRequest | None = None,
+    injected_error: BaseException | None = None,
 ):
     events: list[tuple[str, dict]] = []
     actions: list[str] = []
@@ -2888,7 +3567,7 @@ async def _run_coordinator_failure_case(
         owner_id="owner-1",
         purpose=CredentialLeasePurpose.EXECUTION_OMNIGENT,
     )
-    error = _injected_launch_error(code)
+    error = injected_error or _injected_launch_error(code)
     request_uses_on_demand_policy = bool(
         request is not None
         and isinstance(request.parameters.get("omnigent"), dict)
@@ -2997,6 +3676,14 @@ async def _run_coordinator_failure_case(
     runtime._prepare_workspace = AsyncMock(  # type: ignore[method-assign]
         return_value=Path("/tmp/workspace")
     )
+    # Workspace ownership is covered by its dedicated runtime-boundary tests.
+    # This failure matrix stubs a synthetic path so each intended downstream
+    # launch/cleanup owner can surface without being preempted by that guard.
+    runtime._align_workspace_ownership = MagicMock()  # type: ignore[method-assign]
+    runtime._prepare_daemon_runtime_scripts = MagicMock(  # type: ignore[method-assign]
+        return_value=Path("/tmp/runtime-scripts")
+    )
+    runtime._initialize_required_tools = AsyncMock()  # type: ignore[method-assign]
     runtime._launch_on_demand = AsyncMock()  # type: ignore[method-assign]
     # Egress attestation is an orthogonal trusted-backend gate; this matrix
     # exercises coordinator failure/cleanup evidence, so treat enforcement as
@@ -3084,6 +3771,23 @@ async def _run_coordinator_failure_case(
         execution_runner=execute,
         artifact_gateway=object(),
     )
+
+    async def resolve_policy_snapshot(policy_ref: str) -> dict:
+        document = policy_document()
+        if policy_ref.startswith("codex-on-demand@"):
+            document["host"]["mode"] = "on_demand_docker"
+            document["host"]["backendRef"] = "container-backend"
+            document["session"]["cleanup"] = "remove"
+        return compile_policy_snapshot(
+            policy_id=policy_ref.rsplit("@", 1)[0],
+            version=int(policy_ref.rsplit("@", 1)[1]),
+            document=document,
+            validation={"valid": True, "diagnostics": []},
+        )
+
+    coordinator._resolve_policy_snapshot = AsyncMock(  # type: ignore[method-assign]
+        side_effect=resolve_policy_snapshot
+    )
     if fail_at in {"profile_missing", "profile_validation"}:
         coordinator._resolve_profile = AsyncMock(side_effect=error)  # type: ignore[method-assign]
     elif fail_at == "profile_readiness":
@@ -3126,13 +3830,40 @@ async def _run_coordinator_failure_case(
             )
         )
 
-    if fail_at in {"none", "host_stop", "host_remove", "release"}:
+    if isinstance(error, asyncio.CancelledError):
+        with pytest.raises(asyncio.CancelledError):
+            await coordinator.execute(request)
+    elif fail_at in {"none", "host_stop", "host_remove", "release"}:
         await coordinator.execute(request)
     else:
         with pytest.raises(OmnigentOAuthHostError) as captured:
             await coordinator.execute(request)
         assert captured.value.code == code
     return events, actions, owners.calls
+
+
+@pytest.mark.asyncio
+async def test_cancelled_attempt_defers_host_and_profile_cleanup_to_retry_or_janitor() -> None:
+    events, actions, owner_calls = await _run_coordinator_failure_case(
+        fail_at="container_start",
+        code="activity_cancelled",
+        injected_error=asyncio.CancelledError(),
+    )
+
+    assert "host_remove" not in owner_calls
+    assert "host_stopped" not in actions
+    assert "provider_released" not in actions
+    assert any(
+        event_type == "host_cleanup"
+        and payload["status"] == "waiting"
+        and payload["code"] == "activity_cancelled"
+        for event_type, payload in events
+    )
+    assert any(
+        event_type == "profile_lease_release"
+        and payload["status"] == "waiting"
+        for event_type, payload in events
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/omnigent/test_oauth_profile_lifecycle.py
+++ b/tests/unit/omnigent/test_oauth_profile_lifecycle.py
@@ -2785,11 +2785,19 @@ async def _drive_authority_chain_coordinator(
             }
 
     class Store:
+        def __init__(self):
+            self.bindings: dict[str, str] = {}
+
         async def get_or_create(self, **_kwargs):
             return SimpleNamespace(bridge_session_id="bridge-1")
 
-        async def bind_profile_authorization(self, **_kwargs):
-            return SimpleNamespace(bridge_session_id="bridge-1")
+        async def bind_profile_authorization(self, **kwargs):
+            idempotency_key = kwargs["request"].idempotency_key
+            bridge_session_id = self.bindings.setdefault(
+                idempotency_key,
+                f"bridge-{len(self.bindings) + 1}",
+            )
+            return SimpleNamespace(bridge_session_id=bridge_session_id)
 
         async def record_lifecycle_event(self, _key, *, event_type, **kwargs):
             ordered.append(event_type)
@@ -2999,6 +3007,11 @@ async def test_coordinator_continues_same_session_until_terminal_answer() -> Non
     assert "Continue the current task" in runner_calls[1][1]["first_message_text"]
     assert runner_calls[1][1]["defer_bridge_terminal"] is True
     assert "repository_continuation_1" in ordered
+    checkpoint = metadata["omnigentCheckpointCapture"]
+    assert checkpoint["bridgeSessionId"] == "bridge-2"
+    assert checkpoint["idempotencyKey"].endswith(
+        ":repository-continuation:1"
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/omnigent/test_policy_authority.py
+++ b/tests/unit/omnigent/test_policy_authority.py
@@ -20,7 +20,7 @@ def policy_document() -> dict:
     return {
         "schemaVersion": 1,
         "endpoint": {"ref": "default", "bridgeModes": ["embedded"]},
-        "execution": {"profileRef": "omnigent-codex@1", "harness": "codex-native", "agentIdentities": ["codex"]},
+        "execution": {"profileRef": "omnigent-codex@1", "harness": "codex-native", "agentIdentities": ["codex-native-ui"]},
         "host": {"mode": "static_compose", "backendRef": "compose", "architectures": ["amd64"],
                  "serverImageRef": "images/omnigent@sha256:" + "1" * 64,
                  "hostImageRef": "images/host@sha256:" + "2" * 64},

--- a/tests/unit/security/test_egress.py
+++ b/tests/unit/security/test_egress.py
@@ -341,7 +341,7 @@ async def test_attestation_rejects_unobserved_rules_or_unhealthy_gateway(
         )
 
 
-def test_proxy_environment_clears_bypass_variables():
+def test_proxy_environment_limits_bypass_variables_to_safe_boundaries():
     values = restricted_proxy_env()
     assert "NO_PROXY=" in values
     assert "no_proxy=" in values
@@ -349,7 +349,8 @@ def test_proxy_environment_clears_bypass_variables():
 
     omnigent_values = omnigent_proxy_env()
     assert "HTTP_PROXY=http://omnigent-egress-proxy:3129" in omnigent_values
-    assert "NO_PROXY=" in omnigent_values
+    assert "NO_PROXY=localhost,127.0.0.1" in omnigent_values
+    assert "no_proxy=localhost,127.0.0.1" in omnigent_values
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/test_omnigent_agent_bootstrap_service.py
+++ b/tests/unit/services/test_omnigent_agent_bootstrap_service.py
@@ -17,6 +17,8 @@ from api_service.db.models import (
     OmnigentAgentProfile,
     OmnigentAgentProfileAuditEvent,
     OmnigentAgentProfileVersion,
+    OmnigentPolicy,
+    OmnigentPolicyVersion,
 )
 from api_service.services.omnigent_agent_bootstrap_service import (
     BOOTSTRAP_PROFILE_ID,
@@ -265,3 +267,71 @@ async def test_reconcile_preserves_numeric_stock_agent_version(session):
         "upstreamId": "agent-1",
         "upstreamVersion": "2",
     }
+
+
+async def test_reconcile_versions_managed_profile_after_policy_cutover(session):
+    assert await reconcile_bootstrap_agent_profile(
+        session,
+        env={},
+        inventory=_inventory("codex-native-ui"),
+    ) is True
+
+    session.add_all(
+        [
+            OmnigentPolicy(
+                policy_id="codex-on-demand",
+                name="Codex on-demand host",
+                visibility="deployment",
+                default_version=2,
+            ),
+            OmnigentPolicyVersion(
+                policy_id="codex-on-demand",
+                version=2,
+                state="active",
+                document_json={},
+                digest="sha256:" + "2" * 64,
+                created_by="bootstrap",
+                validation_json={"valid": True},
+                compatibility_json={},
+                rollout_json={},
+            ),
+        ]
+    )
+    await session.commit()
+
+    assert await reconcile_bootstrap_agent_profile(
+        session,
+        env={},
+        inventory=_inventory("codex-native-ui"),
+    ) is True
+
+    profile = await session.get(OmnigentAgentProfile, BOOTSTRAP_PROFILE_ID)
+    assert profile is not None
+    assert profile.active_version == 2
+    versions = list(
+        (
+            await session.execute(
+                select(OmnigentAgentProfileVersion)
+                .where(
+                    OmnigentAgentProfileVersion.profile_id
+                    == BOOTSTRAP_PROFILE_ID
+                )
+                .order_by(OmnigentAgentProfileVersion.version)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert [version.document["policyRef"] for version in versions] == [
+        "codex-on-demand@1",
+        "codex-on-demand@2",
+    ]
+    assert versions[1].parent_version == 1
+    cutover = await session.scalar(
+        select(OmnigentAgentProfileAuditEvent).where(
+            OmnigentAgentProfileAuditEvent.action
+            == "bootstrap_launch_policy_cutover"
+        )
+    )
+    assert cutover is not None
+    assert cutover.version == 2

--- a/tests/unit/services/test_omnigent_agent_profile_selection.py
+++ b/tests/unit/services/test_omnigent_agent_profile_selection.py
@@ -16,6 +16,7 @@ from api_service.db.models import (
 )
 from api_service.services.omnigent_agent_profile_selection import (
     compile_agent_profile_snapshot_parameters,
+    refresh_managed_bootstrap_snapshot_for_rerun,
     resolve_agent_profile_snapshot,
 )
 
@@ -95,7 +96,15 @@ def test_snapshot_parameter_compiler_keeps_authority_out_of_authored_omnigent() 
     compiled = compile_agent_profile_snapshot_parameters(
         {
             "model": "stale-model",
-            "omnigent": {"launchPolicyRef": "stale-policy"},
+            "omnigent": {
+                "agentProfileRef": "team-codex@1",
+                "executionProfileRef": "omnigent-codex@1",
+                "launchPolicyRef": "stale-policy",
+                "agent": {
+                    "agentId": "stale-agent-id",
+                    "agentName": "portable-agent-name",
+                },
+            },
         },
         snapshot=snapshot,
     )
@@ -110,6 +119,7 @@ def test_snapshot_parameter_compiler_keeps_authority_out_of_authored_omnigent() 
     assert compiled["model"] == "gpt-5.4"
     assert compiled["effort"] == "high"
     assert compiled["omnigent"] == {
+        "agent": {"agentName": "portable-agent-name"},
         "executionTargetRef": "omnigent-codex@2",
         "launchPolicyRef": "on-demand@1",
     }
@@ -218,3 +228,109 @@ async def test_resolver_rejects_overrides_above_versioned_ceilings(overrides):
             selection={"profileId": "team-codex", "providerProfileRef": "oauth-team", "overrides": overrides},
             consumer_type="workflow", consumer_id="workflow-1", user=SimpleNamespace(id=uuid4()),
         )
+
+
+@pytest.mark.asyncio
+async def test_exact_rerun_refreshes_managed_bootstrap_authority(monkeypatch):
+    old_digest = "sha256:" + "1" * 64
+    previous_version = SimpleNamespace(
+        digest=old_digest,
+        document={
+            "model": {"model": "gpt-5.6-sol"},
+            "capture": {},
+            "rag": {},
+            "publish": {},
+        },
+    )
+
+    class _RerunSession:
+        async def scalar(self, statement):
+            return previous_version
+
+    captured = {}
+
+    async def _resolve(session, *, selection, consumer_type, consumer_id, user):
+        captured.update(
+            selection=selection,
+            consumer_type=consumer_type,
+            consumer_id=consumer_id,
+        )
+        return {
+            "schemaVersion": "moonmind.omnigent-agent-profile-snapshot.v1",
+            "profileId": "omnigent-bootstrap-default",
+            "version": 2,
+            "digest": "sha256:" + "2" * 64,
+            "providerProfileRef": "codex_openai_oauth",
+            "executionProfileRef": "omnigent-codex@1",
+            "launchPolicyRef": "codex-on-demand@2",
+            "agentId": "codex-native-ui",
+            "document": {
+                "model": {"model": "gpt-5.6-sol", "effort": "xhigh"},
+                "capture": {},
+                "rag": {},
+                "publish": {},
+                "workspace": {},
+            },
+        }
+
+    monkeypatch.setattr(
+        "api_service.services.omnigent_agent_profile_selection."
+        "resolve_agent_profile_snapshot",
+        _resolve,
+    )
+    refreshed = await refresh_managed_bootstrap_snapshot_for_rerun(
+        _RerunSession(),
+        parameters={
+            "instructions": "keep the same task",
+            "agentProfileSnapshot": {
+                "profileId": "omnigent-bootstrap-default",
+                "version": 1,
+                "digest": old_digest,
+                "providerProfileRef": "codex_openai_oauth",
+                "document": {
+                    "model": {"model": "gpt-5.6-sol", "effort": "xhigh"},
+                    "capture": {},
+                    "rag": {},
+                    "publish": {},
+                },
+            },
+            "omnigent": {
+                "agentProfileRef": "omnigent-bootstrap-default@1",
+                "executionProfileRef": "omnigent-codex@1",
+                "launchPolicyRef": "codex-on-demand@1",
+                "agent": {"agentId": "stale-agent-id"},
+            },
+        },
+        consumer_id="mm:rerun",
+        user=SimpleNamespace(id=uuid4()),
+    )
+
+    assert refreshed["instructions"] == "keep the same task"
+    assert refreshed["agentProfile"]["version"] == 2
+    assert refreshed["omnigent"] == {
+        "executionTargetRef": "omnigent-codex@1",
+        "launchPolicyRef": "codex-on-demand@2",
+    }
+    assert captured == {
+        "selection": {
+            "profileId": "omnigent-bootstrap-default",
+            "providerProfileRef": "codex_openai_oauth",
+            "overrides": {"model": {"effort": "xhigh"}},
+        },
+        "consumer_type": "workflow",
+        "consumer_id": "mm:rerun",
+    }
+
+
+@pytest.mark.asyncio
+async def test_exact_rerun_preserves_operator_owned_profile_snapshot():
+    parameters = {
+        "agentProfileSnapshot": {"profileId": "operator-profile"},
+        "omnigent": {"launchPolicyRef": "operator-policy@7"},
+    }
+    assert await refresh_managed_bootstrap_snapshot_for_rerun(
+        SimpleNamespace(),
+        parameters=parameters,
+        consumer_id="mm:rerun",
+        user=SimpleNamespace(id=uuid4()),
+    ) == parameters

--- a/tests/unit/services/test_omnigent_agent_profile_selection.py
+++ b/tests/unit/services/test_omnigent_agent_profile_selection.py
@@ -323,6 +323,79 @@ async def test_exact_rerun_refreshes_managed_bootstrap_authority(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_exact_rerun_reconstructs_explicit_null_overrides(monkeypatch):
+    old_digest = "sha256:" + "3" * 64
+    previous_version = SimpleNamespace(
+        digest=old_digest,
+        document={
+            "model": {"model": "gpt-5.6-sol", "effort": "xhigh"},
+            "capture": {"retentionDays": 30},
+            "rag": {},
+            "publish": {},
+        },
+    )
+
+    class _RerunSession:
+        async def scalar(self, statement):
+            return previous_version
+
+    captured = {}
+
+    async def _resolve(session, *, selection, consumer_type, consumer_id, user):
+        captured["selection"] = selection
+        return {
+            "schemaVersion": "moonmind.omnigent-agent-profile-snapshot.v1",
+            "profileId": "omnigent-bootstrap-default",
+            "version": 2,
+            "digest": "sha256:" + "4" * 64,
+            "providerProfileRef": "codex_openai_oauth",
+            "executionProfileRef": "omnigent-codex@1",
+            "launchPolicyRef": "codex-on-demand@2",
+            "agentId": "codex-native-ui",
+            "document": {
+                "model": {},
+                "capture": {},
+                "rag": {},
+                "publish": {},
+                "workspace": {},
+            },
+        }
+
+    monkeypatch.setattr(
+        "api_service.services.omnigent_agent_profile_selection."
+        "resolve_agent_profile_snapshot",
+        _resolve,
+    )
+
+    await refresh_managed_bootstrap_snapshot_for_rerun(
+        _RerunSession(),
+        parameters={
+            "agentProfileSnapshot": {
+                "profileId": "omnigent-bootstrap-default",
+                "version": 1,
+                "digest": old_digest,
+                "providerProfileRef": "codex_openai_oauth",
+                # The effective snapshot was serialized with exclude_none=True,
+                # so these omitted baseline keys are authored null overrides.
+                "document": {
+                    "model": {},
+                    "capture": {},
+                    "rag": {},
+                    "publish": {},
+                },
+            }
+        },
+        consumer_id="mm:rerun-null-overrides",
+        user=SimpleNamespace(id=uuid4()),
+    )
+
+    assert captured["selection"]["overrides"] == {
+        "model": {"effort": None, "model": None},
+        "capture": {"retentionDays": None},
+    }
+
+
+@pytest.mark.asyncio
 async def test_exact_rerun_preserves_operator_owned_profile_snapshot():
     parameters = {
         "agentProfileSnapshot": {"profileId": "operator-profile"},

--- a/tests/unit/workflows/adapters/test_omnigent_agent_adapter.py
+++ b/tests/unit/workflows/adapters/test_omnigent_agent_adapter.py
@@ -324,6 +324,64 @@ def test_session_create_payload_host_id_rules() -> None:
     assert payload["host_id"] == "host_1"
 
 
+def test_codex_gh_session_keeps_authored_terminal_arguments() -> None:
+    req = _request(
+        parameters={
+            "requiredCapabilities": ["git", "gh"],
+            "omnigent": {
+                "agent": {"agentName": "codex-native-ui"},
+                "session": {
+                    "hostType": "external",
+                    "hostId": "host_1",
+                    "workspace": "/workspaces/run",
+                    "terminalLaunchArgs": ["--no-alt-screen"],
+                },
+            },
+        }
+    )
+    selection = build_omnigent_selection(req)
+
+    payload = build_omnigent_session_create_payload(
+        request=req,
+        selection=selection,
+        target=OmnigentResolvedTarget(
+            agent_id="ag_codex",
+            source="agent_id",
+        ),
+    )
+
+    assert payload["terminal_launch_args"] == ["--no-alt-screen"]
+
+
+def test_codex_session_without_gh_keeps_authored_shell_policy() -> None:
+    req = _request(
+        parameters={
+            "requiredCapabilities": ["git"],
+            "omnigent": {
+                "session": {
+                    "hostType": "external",
+                    "hostId": "host_1",
+                    "workspace": "/workspaces/run",
+                    "terminalLaunchArgs": ["--no-alt-screen"],
+                }
+            },
+        }
+    )
+    selection = build_omnigent_selection(req)
+
+    payload = build_omnigent_session_create_payload(
+        request=req,
+        selection=selection,
+        target=OmnigentResolvedTarget(
+            agent_id="ag_codex",
+            source="agent_name",
+            agent_name="codex-native-ui",
+        ),
+    )
+
+    assert payload["terminal_launch_args"] == ["--no-alt-screen"]
+
+
 def test_session_create_payload_keeps_id_only_labels() -> None:
     req = _request(
         parameters={

--- a/tests/unit/workflows/adapters/test_omnigent_client.py
+++ b/tests/unit/workflows/adapters/test_omnigent_client.py
@@ -14,7 +14,10 @@ from moonmind.workflows.adapters.omnigent_client import (
 
 @pytest.mark.asyncio
 async def test_omnigent_client_exposes_confirmed_operations() -> None:
+    requested_paths: list[str] = []
+
     async def handler(request: httpx.Request) -> httpx.Response:
+        requested_paths.append(request.url.path)
         if request.method == "GET" and request.url.path == "/v1/agents":
             assert request.url.params["limit"] == "1000"
             return httpx.Response(
@@ -30,6 +33,20 @@ async def test_omnigent_client_exposes_confirmed_operations() -> None:
                         }
                     ],
                     "has_more": False,
+                },
+            )
+        if request.method == "GET" and request.url.path == "/v1/hosts":
+            return httpx.Response(
+                200,
+                json={
+                    "hosts": [
+                        {
+                            "host_id": "host-1",
+                            "name": "mm-host-1",
+                            "status": "online",
+                            "configured_harnesses": {"codex-native": True},
+                        }
+                    ]
                 },
             )
         if request.method == "GET" and request.url.path.endswith("/diff/src/app.py"):
@@ -58,6 +75,15 @@ async def test_omnigent_client_exposes_confirmed_operations() -> None:
             "capabilities": ["session.start"],
         }
     ]
+    assert await client.list_hosts() == [
+        {
+            "host_id": "host-1",
+            "name": "mm-host-1",
+            "status": "online",
+            "configured_harnesses": {"codex-native": True},
+        }
+    ]
+    assert "/v1/hosts" in requested_paths
     assert await client.get_agent("ag_1") == {"ok": True}
     assert await client.create_agent_bundle(
         filename="bundle.tgz",
@@ -82,6 +108,53 @@ async def test_omnigent_client_exposes_confirmed_operations() -> None:
     assert await client.interrupt("sess_1") == {"ok": True}
     assert await client.stop_session("sess_1") == {"ok": True}
     assert await client.delete_session("sess_1") == {"ok": True}
+
+
+@pytest.mark.asyncio
+async def test_injected_http_client_preserves_omnigent_timeout_contract() -> None:
+    """An injected client must not replace Omnigent's transport timeouts."""
+
+    observed_timeouts: dict[str, dict[str, float | None]] = {}
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        observed_timeouts[request.url.path] = dict(request.extensions["timeout"])
+        if request.url.path.endswith("/stream"):
+            return httpx.Response(
+                200,
+                headers={"content-type": "text/event-stream"},
+                content=b"data: [DONE]\n\n",
+            )
+        return httpx.Response(200, json={"ok": True})
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handler)
+    ) as injected_client:
+        client = OmnigentHttpClient(
+            base_url="https://omnigent.test",
+            timeout_seconds=47.0,
+            stream_timeout_seconds=None,
+            client=injected_client,
+        )
+
+        assert await client.post_event("sess_1", {"type": "message"}) == {
+            "ok": True
+        }
+        assert [event async for event in client.stream_events("sess_1")] == []
+
+    request_timeout = observed_timeouts["/v1/sessions/sess_1/events"]
+    assert request_timeout == {
+        "connect": 47.0,
+        "read": 47.0,
+        "write": 47.0,
+        "pool": 47.0,
+    }
+    stream_timeout = observed_timeouts["/v1/sessions/sess_1/stream"]
+    assert stream_timeout == {
+        "connect": 47.0,
+        "read": None,
+        "write": 47.0,
+        "pool": 47.0,
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/unit/workflows/temporal/test_agent_runtime_activities.py
+++ b/tests/unit/workflows/temporal/test_agent_runtime_activities.py
@@ -56,6 +56,10 @@ from moonmind.workflows.temporal.activity_runtime import (
     TemporalAgentRuntimeActivities,
     TemporalIntegrationActivities,
 )
+from moonmind.workflows.temporal.runtime.workspace_locators import (
+    SandboxWorkspaceRecord,
+    SandboxWorkspaceRecordStore,
+)
 from moonmind.workflows.temporal.runtime.managed_session_controller import (
     ManagedSessionReapResult,
 )
@@ -6322,6 +6326,163 @@ async def test_terminal_evidence_activity_fails_completed_prose_without_artifact
     assert result.failure_class == "execution_error"
     assert result.metadata["terminalContractAuthority"] == "MoonMind.AgentRun"
     assert result.metadata["failureCode"] == "INCOMPLETE_TERMINAL_CONTRACT"
+
+
+@pytest.mark.asyncio
+async def test_terminal_evidence_activity_resolves_authoritative_sandbox_locator(
+    tmp_path: Path,
+) -> None:
+    workflow_id = "mm:e09594b0-e1a0-4205-a54e-89e5b8734e6c"
+    step_execution_id = (
+        f"{workflow_id}:019fd504-5cb2-7927-9e03-f3c34efce2c5:"
+        "node-1:execution:2"
+    )
+    workspace_id = hashlib.sha256(
+        f"{workflow_id}:{step_execution_id}".encode("utf-8")
+    ).hexdigest()[:24]
+    workspace = tmp_path / "temporal_sandbox" / workspace_id / "repo"
+    result_path = workspace / "var" / "pr_resolver" / "result.json"
+    result_path.parent.mkdir(parents=True)
+    result_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "pr-resolver-result.v1",
+                "executionRef": step_execution_id,
+                "mergeAutomationDisposition": "already_merged",
+                "status": "completed",
+            }
+        ),
+        encoding="utf-8",
+    )
+    publish_path = workspace / "artifacts" / "publish_result.json"
+    publish_path.parent.mkdir(parents=True)
+    publish_path.write_text('{"status":"already_merged"}', encoding="utf-8")
+    SandboxWorkspaceRecordStore(tmp_path).ensure(
+        SandboxWorkspaceRecord(
+            workspace_id=workspace_id,
+            workflow_id=workflow_id,
+            step_execution_id=step_execution_id,
+            relative_path="repo",
+        )
+    )
+
+    activities = TemporalAgentRuntimeActivities(workspace_root=tmp_path)
+    result = await activities.agent_runtime_evaluate_terminal_evidence(
+        {
+            # Reproduce the escaped boundary: this alias exists only in the
+            # on-demand host and must not win over the canonical locator.
+            "workspacePath": "/workspaces/run",
+            "workspaceLocator": {
+                "kind": "sandbox",
+                "workspaceId": workspace_id,
+                "relativePath": "repo",
+            },
+            "workspaceOwnerWorkflowId": workflow_id,
+            "workspaceOwnerStepExecutionId": step_execution_id,
+            "terminalContract": {
+                "contractId": "pr_resolver_terminal.v1",
+                "relativePath": "var/pr_resolver/result.json",
+                "expectedSchemaVersion": "pr-resolver-result.v1",
+                "executionRef": step_execution_id,
+            },
+            "result": {"summary": "PR was already merged."},
+        }
+    )
+
+    assert result.failure_class is None
+    assert result.metadata["terminalContractSatisfied"] is True
+    assert result.metadata["terminalContractOutcome"] == "terminal_success"
+    assert result.metadata["terminalContractEvidencePath"] == (
+        "var/pr_resolver/result.json"
+    )
+
+
+@pytest.mark.asyncio
+async def test_terminal_evidence_activity_publishes_pr_resolver_companion(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "repo"
+    execution_ref = "workflow:run:node-1:execution:1"
+    result_path = workspace / "var" / "pr_resolver" / "result.json"
+    result_path.parent.mkdir(parents=True)
+    result_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 2,
+                "executionRef": execution_ref,
+                "mergeAutomationDisposition": "already_merged",
+                "status": "merged",
+            }
+        ),
+        encoding="utf-8",
+    )
+    publish_payload = {
+        "schemaVersion": "moonmind.publish.auto.v1",
+        "mode": "auto",
+        "owner": "agent",
+        "skillId": "pr-resolver",
+        "status": "verified",
+        "action": "merge",
+        "repository": "MoonLadderStudios/MoonMind",
+        "branch": "feature",
+        "localHead": "abc1234",
+        "remoteBranchHead": None,
+        "remoteVerified": True,
+        "pushed": False,
+        "merged": True,
+        "prUrl": "https://github.com/MoonLadderStudios/MoonMind/pull/1",
+        "blockedReason": None,
+        "verificationCommands": ["gh pr view 1"],
+    }
+    publish_path = workspace / "artifacts" / "publish_result.json"
+    publish_path.parent.mkdir(parents=True)
+    publish_path.write_text(json.dumps(publish_payload), encoding="utf-8")
+    artifact_service = MagicMock()
+    artifact_service.create = AsyncMock(
+        side_effect=[
+            (SimpleNamespace(artifact_id="art-terminal-evidence"), None),
+            (SimpleNamespace(artifact_id="art-publish-evidence"), None),
+        ]
+    )
+    artifact_service.write_complete = AsyncMock(
+        side_effect=[
+            SimpleNamespace(artifact_id="art-terminal-evidence"),
+            SimpleNamespace(artifact_id="art-publish-evidence"),
+        ]
+    )
+    activities = TemporalAgentRuntimeActivities(artifact_service=artifact_service)
+
+    result = await activities.agent_runtime_evaluate_terminal_evidence(
+        {
+            "workspacePath": str(workspace),
+            "terminalContract": {
+                "contractId": "pr_resolver_terminal.v1",
+                "relativePath": "var/pr_resolver/result.json",
+                "expectedSchemaVersion": "pr-resolver-result.v1",
+                "executionRef": execution_ref,
+            },
+            "result": {"summary": "PR was already merged."},
+        }
+    )
+
+    assert result.failure_class is None
+    assert result.metadata["terminalContractEvidenceRef"] == (
+        "art-terminal-evidence"
+    )
+    assert result.metadata["publishEvidence"] == "art-publish-evidence"
+    create_calls = artifact_service.create.await_args_list
+    assert create_calls[0].kwargs["metadata_json"]["path"] == (
+        "var/pr_resolver/result.json"
+    )
+    assert create_calls[1].kwargs["metadata_json"]["path"] == (
+        "artifacts/publish_result.json"
+    )
+    published = json.loads(
+        artifact_service.write_complete.await_args_list[1]
+        .kwargs["payload"]
+        .decode("utf-8")
+    )
+    assert published == publish_payload
 
 
 @pytest.mark.asyncio

--- a/tests/unit/workflows/temporal/test_checkpoint_restore.py
+++ b/tests/unit/workflows/temporal/test_checkpoint_restore.py
@@ -16,6 +16,7 @@ from moonmind.schemas.checkpoint_restore_models import (
     ManagedWorkspaceRestoreRequest,
 )
 from moonmind.workflows.skills.artifact_store import InMemoryArtifactStore
+from moonmind.workflows.temporal import activity_runtime as activity_runtime_module
 from moonmind.workflows.temporal.activity_runtime import TemporalSandboxActivities
 from moonmind.workflows.temporal.runtime.checkpoint_restore import (
     ManagedCheckpointRestoreService,
@@ -90,6 +91,64 @@ def _request(
         "capabilityDigest": "sha256:capability",
         "idempotencyKey": key,
     }
+
+
+@pytest.mark.asyncio
+async def test_sandbox_capture_trusts_only_the_resolved_workspace_for_git(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source, base = _repo(tmp_path / "temporal_sandbox" / "source")
+    resolved_source = str(source.resolve())
+    expected_prefix = [
+        "git",
+        "-c",
+        f"safe.directory={resolved_source}",
+        "-C",
+        resolved_source,
+    ]
+    commands: list[list[str]] = []
+
+    async def enforce_safe_directory(command, **_kwargs):
+        normalized = [str(part) for part in command]
+        commands.append(normalized)
+        if normalized[: len(expected_prefix)] != expected_prefix:
+            raise RuntimeError(
+                f"fatal: detected dubious ownership in repository at '{resolved_source}'"
+            )
+        operation = normalized[len(expected_prefix) :]
+        if operation[:2] == ["rev-parse", "HEAD"]:
+            return activity_runtime_module.CmdRes(f"{base}\n".encode())
+        if operation[0] == "status":
+            return activity_runtime_module.CmdRes(b"")
+        raise AssertionError(f"unexpected git command: {operation}")
+
+    monkeypatch.setattr(activity_runtime_module, "_run_command", enforce_safe_directory)
+    sandbox = TemporalSandboxActivities(
+        workspace_root=tmp_path,
+        artifact_store=InMemoryArtifactStore(),
+    )
+
+    capture = await sandbox.workspace_capture_checkpoint(
+        {
+            "identity": {
+                "workflowId": "source",
+                "runId": "source-run",
+                "logicalStepId": "implement",
+                "executionOrdinal": 1,
+            },
+            "boundary": "after_execution",
+            "kind": "worktree_archive",
+            "workspacePath": resolved_source,
+            "artifactNamespace": "checkpoint",
+            "idempotencyKey": "capture-safe-directory",
+            "baseCommit": base,
+        }
+    )
+
+    assert capture["status"] == "captured"
+    assert len(commands) == 2
+    assert all(command[: len(expected_prefix)] == expected_prefix for command in commands)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/workflows/temporal/test_omnigent_activities.py
+++ b/tests/unit/workflows/temporal/test_omnigent_activities.py
@@ -1,3 +1,4 @@
+import asyncio
 import inspect
 from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
@@ -155,9 +156,25 @@ def test_checkpoint_recovery_decision_ignores_caller_availability_assertions() -
 
 @pytest.mark.asyncio
 @patch("moonmind.omnigent.execute.run_omnigent_execution")
-async def test_omnigent_execute_activity_delegates(mock_run):
+async def test_omnigent_execute_activity_delegates(
+    mock_run, monkeypatch: pytest.MonkeyPatch
+):
     expected_result = AgentRunResult(summary="done", output_refs=[])
-    mock_run.return_value = expected_result
+    heartbeats: list[tuple[object, ...]] = []
+
+    async def delayed_run(*_args, **_kwargs):
+        omnigent_execute_module._safe_heartbeat(  # type: ignore[attr-defined]
+            {"omnigentSessionId": "session-1", "eventsCaptured": 1}
+        )
+        await asyncio.sleep(0.035)
+        return expected_result
+
+    mock_run.side_effect = delayed_run
+    monkeypatch.setattr(
+        omnigent_execute_module,
+        "_ACTIVITY_HEARTBEAT_INTERVAL_SECONDS",
+        0.01,
+    )
 
     req = AgentExecutionRequest(
         agentKind="external",
@@ -167,6 +184,7 @@ async def test_omnigent_execute_activity_delegates(mock_run):
     )
 
     env = ActivityEnvironment()
+    env.on_heartbeat = lambda *details: heartbeats.append(details)
     result = await env.run(omnigent_execute_activity, req)
 
     assert result == expected_result
@@ -175,6 +193,20 @@ async def test_omnigent_execute_activity_delegates(mock_run):
     assert called_req == req
     assert isinstance(mock_run.call_args.kwargs["artifact_gateway"], LocalOmnigentArtifactGateway)
     assert isinstance(mock_run.call_args.kwargs["run_store"], OmnigentBridgeSessionStore)
+    assert len(heartbeats) >= 2
+    heartbeat_payloads = [
+        detail
+        for callback_args in heartbeats
+        for detail in callback_args
+        if isinstance(detail, dict)
+    ]
+    assert any(payload.get("activityAlive") is True for payload in heartbeat_payloads)
+    assert all(
+        payload.get("omnigentSessionId") == "session-1"
+        for payload in heartbeat_payloads
+        if payload.get("activityAlive") is True
+        and payload.get("eventsCaptured") == 1
+    )
 
 
 def test_omnigent_execution_path_does_not_use_managed_github_broker() -> None:

--- a/tests/unit/workflows/temporal/test_provider_profile_manager.py
+++ b/tests/unit/workflows/temporal/test_provider_profile_manager.py
@@ -10,6 +10,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from moonmind.workflows.temporal.workflows.provider_profile_manager import (
+    ACTIVITY_OWNED_LEASE_VERIFICATION_PATCH,
     BILLING_AWARE_PROFILE_SELECTION_PATCH,
     CLAUDE_OAUTH_EXCLUSIVE_CAPACITY_PATCH,
     CODEX_OAUTH_LEGACY_RESTORE_PATCH,
@@ -2174,6 +2175,81 @@ class TestProviderProfileManagerHelpers:
         assert [req.requester_workflow_id for req in wf._pending_requests] == [
             "wf-shared"
         ]
+
+    @pytest.mark.asyncio
+    async def test_verify_activity_owned_lease_reclaims_terminal_parent(self):
+        wf = self._make_workflow()
+        lease_id = "profile-lease:execution_omnigent:abandoned"
+        wf._profiles["p1"] = ProfileSlotState(
+            profile_id="p1",
+            max_parallel_runs=1,
+            cooldown_after_429_seconds=300,
+            rate_limit_policy="backoff",
+            enabled=True,
+            is_default=True,
+            current_leases=[lease_id],
+            lease_metadata={
+                lease_id: {
+                    "ownerIsWorkflow": False,
+                    "workflowId": "mm:terminal-parent",
+                }
+            },
+        )
+
+        async def fake_execute_activity(_name: str, payload: dict, **_kwargs):
+            assert payload == {"workflow_ids": ["mm:terminal-parent"]}
+            return {
+                "mm:terminal-parent": {"running": False, "status": "FAILED"}
+            }
+
+        wf._sync_leases_to_db = AsyncMock(return_value=True)  # type: ignore[method-assign]
+        with patch(
+            "moonmind.workflows.temporal.workflows.provider_profile_manager.workflow"
+        ) as mock_wf:
+            mock_wf.execute_activity.side_effect = fake_execute_activity
+            mock_wf.patched.return_value = True
+            await wf._verify_active_workflows(
+                verify_lease_holders=True,
+                verify_activity_owned_leases=True,
+                verify_pending_requesters=False,
+            )
+
+        assert wf._profiles["p1"].current_leases == []
+        wf._sync_leases_to_db.assert_awaited_once()
+        assert ACTIVITY_OWNED_LEASE_VERIFICATION_PATCH.endswith("-v1")
+
+    @pytest.mark.asyncio
+    async def test_acquire_slot_v2_rejects_late_grant_for_terminal_parent(self):
+        wf = self._make_workflow()
+        wf._profiles["p1"] = ProfileSlotState(
+            profile_id="p1",
+            max_parallel_runs=1,
+            cooldown_after_429_seconds=300,
+            rate_limit_policy="backoff",
+            enabled=True,
+            is_default=True,
+        )
+        wf._verify_workflow_statuses = AsyncMock(  # type: ignore[method-assign]
+            return_value={
+                "mm:terminal-parent": {"running": False, "status": "FAILED"}
+            }
+        )
+
+        with pytest.raises(Exception, match="owner workflow is terminal"):
+            await wf.acquire_slot_v2(
+                {
+                    "requester_workflow_id": "profile-lease:late-grant",
+                    "runtime_id": "codex_cli",
+                    "execution_profile_ref": "p1",
+                    "purpose": "execution_omnigent",
+                    "metadata": {
+                        "ownerIsWorkflow": False,
+                        "workflowId": "mm:terminal-parent",
+                    },
+                }
+            )
+
+        assert wf._profiles["p1"].current_leases == []
 
     def test_run_drains_queue_before_best_effort_pending_verification(self):
         import inspect

--- a/tests/unit/workflows/temporal/test_remediation_issue_3511.py
+++ b/tests/unit/workflows/temporal/test_remediation_issue_3511.py
@@ -241,7 +241,7 @@ async def test_real_handoff_resolves_persisted_target_run_policy() -> None:
     policy_service = AsyncMock()
     policy_service.resolve_runtime_snapshot.return_value = snapshot
     with patch(
-        "moonmind.workflows.temporal.remediation_tools.OmnigentPolicyService",
+        "api_service.services.omnigent_policies.OmnigentPolicyService",
         return_value=policy_service,
     ):
         resolved = await service._resolve_target_policy_snapshot(
@@ -266,7 +266,7 @@ async def test_real_handoff_rejects_stale_persisted_policy_before_dispatch() -> 
     policy_service = AsyncMock()
     policy_service.resolve_runtime_snapshot.return_value = current_snapshot
     with patch(
-        "moonmind.workflows.temporal.remediation_tools.OmnigentPolicyService",
+        "api_service.services.omnigent_policies.OmnigentPolicyService",
         return_value=policy_service,
     ), pytest.raises(RemediationEvidenceToolError, match="stale or unavailable"):
         await service._resolve_target_policy_snapshot(

--- a/tests/unit/workflows/temporal/test_run_artifacts.py
+++ b/tests/unit/workflows/temporal/test_run_artifacts.py
@@ -16,7 +16,16 @@ from moonmind.workflows.temporal.activity_catalog import (
 from moonmind.workflows.temporal.activity_runtime import (
     TemporalAgentRuntimeActivities,
 )
-from moonmind.workflows.temporal.workflows.run import MoonMindRunWorkflow
+from moonmind.workflows.temporal.workflows.run import (
+    RUN_EMPTY_AGENT_SKILLSET_SNAPSHOT_PATCH,
+    MoonMindRunWorkflow,
+)
+
+
+def _all_patches_except_empty_skillset(patch_id: str) -> bool:
+    """Keep generic execution fixtures focused on their asserted boundary."""
+
+    return patch_id != RUN_EMPTY_AGENT_SKILLSET_SNAPSHOT_PATCH
 
 
 @pytest.fixture(autouse=True)
@@ -257,7 +266,7 @@ def test_initialize_from_payload_tracks_declared_dependencies(
         "upsert_memo",
         lambda memo: captured_memo.append(dict(memo)),
     )
-    monkeypatch.setattr(run_workflow_module.workflow, "patched", lambda _patch_id: True)
+    monkeypatch.setattr(run_workflow_module.workflow, "patched", _all_patches_except_empty_skillset)
 
     workflow._update_memo()
 
@@ -411,7 +420,7 @@ async def test_run_execution_stage_reads_plan_and_dispatches_steps(
         {"namespace": "default", "workflow_id": "wf-1", "run_id": "run-1"},
     )
     monkeypatch.setattr(run_workflow_module.workflow, "info", workflow_info)
-    monkeypatch.setattr(run_workflow_module.workflow, "patched", lambda patch_id: True)
+    monkeypatch.setattr(run_workflow_module.workflow, "patched", _all_patches_except_empty_skillset)
 
     await workflow._run_execution_stage(
         parameters={"repo": "MoonLadderStudios/MoonMind"},
@@ -507,7 +516,7 @@ async def test_run_finalizing_stage_writes_dependency_summary_metadata(
     )
     monkeypatch.setattr(run_workflow_module.workflow, "info", workflow_info)
     monkeypatch.setattr(run_workflow_module.workflow, "now", lambda: finish_time)
-    monkeypatch.setattr(run_workflow_module.workflow, "patched", lambda patch_id: True)
+    monkeypatch.setattr(run_workflow_module.workflow, "patched", _all_patches_except_empty_skillset)
 
     await workflow._run_finalizing_stage(
         parameters={"runtime": {"mode": "codex"}, "publishMode": "none"},
@@ -612,7 +621,7 @@ async def test_run_finalizing_stage_writes_structured_moonspec_failure_summary(
     )
     monkeypatch.setattr(run_workflow_module.workflow, "info", workflow_info)
     monkeypatch.setattr(run_workflow_module.workflow, "now", lambda: finish_time)
-    monkeypatch.setattr(run_workflow_module.workflow, "patched", lambda _patch_id: True)
+    monkeypatch.setattr(run_workflow_module.workflow, "patched", _all_patches_except_empty_skillset)
     monkeypatch.setattr(
         run_workflow_module.workflow,
         "upsert_memo",
@@ -743,7 +752,7 @@ async def test_run_finalizing_stage_writes_transient_codex_failure_summary(
     )
     monkeypatch.setattr(run_workflow_module.workflow, "info", workflow_info)
     monkeypatch.setattr(run_workflow_module.workflow, "now", lambda: finish_time)
-    monkeypatch.setattr(run_workflow_module.workflow, "patched", lambda _patch_id: True)
+    monkeypatch.setattr(run_workflow_module.workflow, "patched", _all_patches_except_empty_skillset)
     monkeypatch.setattr(run_workflow_module.workflow, "upsert_memo", lambda _memo: None)
     monkeypatch.setattr(
         run_workflow_module.workflow,
@@ -874,7 +883,7 @@ async def test_run_execution_stage_rejects_legacy_skill_registry_dispatch(
         {"namespace": "default", "workflow_id": "wf-1", "run_id": "run-1"},
     )
     monkeypatch.setattr(run_workflow_module.workflow, "info", workflow_info)
-    monkeypatch.setattr(run_workflow_module.workflow, "patched", lambda patch_id: True)
+    monkeypatch.setattr(run_workflow_module.workflow, "patched", _all_patches_except_empty_skillset)
 
     await workflow._run_execution_stage(
         parameters={"repo": "MoonLadderStudios/MoonMind"},
@@ -979,7 +988,7 @@ async def test_run_execution_stage_skips_empty_registry_for_agent_runtime_only_p
         {"namespace": "default", "workflow_id": "wf-1", "run_id": "run-1"},
     )
     monkeypatch.setattr(run_workflow_module.workflow, "info", workflow_info)
-    monkeypatch.setattr(run_workflow_module.workflow, "patched", lambda patch_id: True)
+    monkeypatch.setattr(run_workflow_module.workflow, "patched", _all_patches_except_empty_skillset)
 
     await workflow._run_execution_stage(
         parameters={"repo": "MoonLadderStudios/MoonMind"},
@@ -2586,7 +2595,7 @@ async def test_run_execution_stage_fail_fast_raises_when_tool_returns_failed_sta
         {"namespace": "default", "workflow_id": "wf-1", "run_id": "run-1"},
     )
     monkeypatch.setattr(run_workflow_module.workflow, "info", workflow_info)
-    monkeypatch.setattr(run_workflow_module.workflow, "patched", lambda patch_id: True)
+    monkeypatch.setattr(run_workflow_module.workflow, "patched", _all_patches_except_empty_skillset)
 
     with pytest.raises(ValueError) as exc_info:
         await workflow._run_execution_stage(
@@ -2675,7 +2684,7 @@ async def test_run_execution_stage_continue_mode_keeps_running_after_failed_stat
         {"namespace": "default", "workflow_id": "wf-1", "run_id": "run-1"},
     )
     monkeypatch.setattr(run_workflow_module.workflow, "info", workflow_info)
-    monkeypatch.setattr(run_workflow_module.workflow, "patched", lambda patch_id: True)
+    monkeypatch.setattr(run_workflow_module.workflow, "patched", _all_patches_except_empty_skillset)
 
     await workflow._run_execution_stage(
         parameters={"repo": "MoonLadderStudios/MoonMind"},
@@ -2945,7 +2954,7 @@ async def test_run_execution_stage_publish_pr_blocks_after_failed_continue_step(
         {"namespace": "default", "workflow_id": "wf-1", "run_id": "run-1"},
     )
     monkeypatch.setattr(run_workflow_module.workflow, "info", workflow_info)
-    monkeypatch.setattr(run_workflow_module.workflow, "patched", lambda _patch_id: True)
+    monkeypatch.setattr(run_workflow_module.workflow, "patched", _all_patches_except_empty_skillset)
 
     await workflow._run_execution_stage(
         parameters={
@@ -3026,7 +3035,7 @@ async def test_run_execution_stage_publish_mode_pr_requires_pull_request_url(
         {"namespace": "default", "workflow_id": "wf-1", "run_id": "run-1"},
     )
     monkeypatch.setattr(run_workflow_module.workflow, "info", workflow_info)
-    monkeypatch.setattr(run_workflow_module.workflow, "patched", lambda patch_id: True)
+    monkeypatch.setattr(run_workflow_module.workflow, "patched", _all_patches_except_empty_skillset)
 
     with pytest.raises(
         ValueError,
@@ -3096,7 +3105,7 @@ async def test_run_execution_stage_publish_mode_pr_accepts_github_pull_request_u
         {"namespace": "default", "workflow_id": "wf-1", "run_id": "run-1"},
     )
     monkeypatch.setattr(run_workflow_module.workflow, "info", workflow_info)
-    monkeypatch.setattr(run_workflow_module.workflow, "patched", lambda patch_id: True)
+    monkeypatch.setattr(run_workflow_module.workflow, "patched", _all_patches_except_empty_skillset)
 
     await workflow._run_execution_stage(
         parameters={"repo": "MoonLadderStudios/MoonMind", "publishMode": "pr"},
@@ -3216,7 +3225,7 @@ async def test_run_execution_stage_publish_mode_pr_uses_publish_overrides(
         {"namespace": "default", "workflow_id": "wf-1", "run_id": "run-1"},
     )
     monkeypatch.setattr(run_workflow_module.workflow, "info", workflow_info)
-    monkeypatch.setattr(run_workflow_module.workflow, "patched", lambda patch_id: True)
+    monkeypatch.setattr(run_workflow_module.workflow, "patched", _all_patches_except_empty_skillset)
 
     await workflow._run_execution_stage(
         parameters={
@@ -3343,7 +3352,7 @@ async def test_run_execution_stage_publish_mode_pr_defaults_title_from_task_inte
         {"namespace": "default", "workflow_id": "wf-1", "run_id": "run-1"},
     )
     monkeypatch.setattr(run_workflow_module.workflow, "info", workflow_info)
-    monkeypatch.setattr(run_workflow_module.workflow, "patched", lambda patch_id: True)
+    monkeypatch.setattr(run_workflow_module.workflow, "patched", _all_patches_except_empty_skillset)
 
     await workflow._run_execution_stage(
         parameters={
@@ -3486,7 +3495,7 @@ async def test_run_execution_stage_publish_mode_pr_prefers_pushed_branch_for_nat
         {"namespace": "default", "workflow_id": "wf-1", "run_id": "run-1"},
     )
     monkeypatch.setattr(run_workflow_module.workflow, "info", workflow_info)
-    monkeypatch.setattr(run_workflow_module.workflow, "patched", lambda patch_id: True)
+    monkeypatch.setattr(run_workflow_module.workflow, "patched", _all_patches_except_empty_skillset)
 
     await workflow._run_execution_stage(
         parameters={
@@ -3691,7 +3700,7 @@ async def test_skipped_jira_blocker_wait_restores_executing_state(
         "wait_condition",
         fake_wait_condition,
     )
-    monkeypatch.setattr(run_workflow_module.workflow, "patched", lambda _patch_id: True)
+    monkeypatch.setattr(run_workflow_module.workflow, "patched", _all_patches_except_empty_skillset)
     monkeypatch.setattr(
         run_workflow_module.workflow,
         "logger",
@@ -3846,7 +3855,7 @@ async def test_run_execution_stage_fail_fast_raises_provider_failure_summary(
         {"namespace": "default", "workflow_id": "wf-1", "run_id": "run-1"},
     )
     monkeypatch.setattr(run_workflow_module.workflow, "info", workflow_info)
-    monkeypatch.setattr(run_workflow_module.workflow, "patched", lambda _patch_id: True)
+    monkeypatch.setattr(run_workflow_module.workflow, "patched", _all_patches_except_empty_skillset)
     monkeypatch.setattr(
         MoonMindRunWorkflow,
         "_resolve_agent_node_skillset_ref",
@@ -4049,7 +4058,7 @@ async def test_run_execution_stage_fail_fast_raises_agent_runtime_failure_summar
         {"namespace": "default", "workflow_id": "wf-1", "run_id": "run-1"},
     )
     monkeypatch.setattr(run_workflow_module.workflow, "info", workflow_info)
-    monkeypatch.setattr(run_workflow_module.workflow, "patched", lambda _patch_id: True)
+    monkeypatch.setattr(run_workflow_module.workflow, "patched", _all_patches_except_empty_skillset)
     monkeypatch.setattr(
         MoonMindRunWorkflow,
         "_resolve_agent_node_skillset_ref",
@@ -4210,7 +4219,7 @@ async def test_run_execution_stage_does_not_retry_permanent_agent_runtime_failur
         {"namespace": "default", "workflow_id": "wf-1", "run_id": "run-1"},
     )
     monkeypatch.setattr(run_workflow_module.workflow, "info", workflow_info)
-    monkeypatch.setattr(run_workflow_module.workflow, "patched", lambda _patch_id: True)
+    monkeypatch.setattr(run_workflow_module.workflow, "patched", _all_patches_except_empty_skillset)
     monkeypatch.setattr(
         MoonMindRunWorkflow,
         "_resolve_agent_node_skillset_ref",
@@ -4400,7 +4409,7 @@ async def test_run_marks_blocked_outcome_as_failed_terminal_state(
     monkeypatch.setattr(
         run_workflow_module.workflow,
         "patched",
-        lambda _patch_id: True,
+        _all_patches_except_empty_skillset,
     )
     monkeypatch.setattr(
         run_workflow_module.workflow,
@@ -4558,7 +4567,7 @@ async def test_run_observes_cancel_after_late_stages_before_completion(
         "now",
         lambda: datetime.now(timezone.utc),
     )
-    monkeypatch.setattr(run_workflow_module.workflow, "patched", lambda _patch_id: True)
+    monkeypatch.setattr(run_workflow_module.workflow, "patched", _all_patches_except_empty_skillset)
     monkeypatch.setattr(run_workflow_module.workflow, "upsert_memo", lambda _memo: None)
     monkeypatch.setattr(
         run_workflow_module.workflow,
@@ -4687,7 +4696,7 @@ async def test_run_records_no_commit_terminal_state_for_skipped_publish(
         "now",
         lambda: datetime.now(timezone.utc),
     )
-    monkeypatch.setattr(run_workflow_module.workflow, "patched", lambda _patch_id: True)
+    monkeypatch.setattr(run_workflow_module.workflow, "patched", _all_patches_except_empty_skillset)
     monkeypatch.setattr(run_workflow_module.workflow, "upsert_memo", lambda _memo: None)
     monkeypatch.setattr(
         run_workflow_module.workflow,
@@ -6111,7 +6120,7 @@ async def test_run_execution_stage_publish_mode_pr_jules_skips_native_pr(
         {"namespace": "default", "workflow_id": "wf-1", "run_id": "run-1"},
     )
     monkeypatch.setattr(run_workflow_module.workflow, "info", workflow_info)
-    monkeypatch.setattr(run_workflow_module.workflow, "patched", lambda patch_id: True)
+    monkeypatch.setattr(run_workflow_module.workflow, "patched", _all_patches_except_empty_skillset)
 
     await workflow._run_execution_stage(
         parameters={"repo": "MoonLadderStudios/MoonMind", "publishMode": "pr"},
@@ -6242,7 +6251,7 @@ async def test_run_execution_stage_jules_pr_extracts_url_from_diagnostics_ref(
         {"namespace": "default", "workflow_id": "wf-1", "run_id": "run-1"},
     )
     monkeypatch.setattr(run_workflow_module.workflow, "info", workflow_info)
-    monkeypatch.setattr(run_workflow_module.workflow, "patched", lambda patch_id: True)
+    monkeypatch.setattr(run_workflow_module.workflow, "patched", _all_patches_except_empty_skillset)
 
     await workflow._run_execution_stage(
         parameters={"repo": "MoonLadderStudios/MoonMind", "publishMode": "pr"},
@@ -6375,7 +6384,7 @@ async def test_run_execution_stage_non_jules_agent_with_session_id_creates_nativ
         {"namespace": "default", "workflow_id": "wf-1", "run_id": "run-1"},
     )
     monkeypatch.setattr(run_workflow_module.workflow, "info", workflow_info)
-    monkeypatch.setattr(run_workflow_module.workflow, "patched", lambda patch_id: True)
+    monkeypatch.setattr(run_workflow_module.workflow, "patched", _all_patches_except_empty_skillset)
 
     await wf._run_execution_stage(
         parameters={"repo": "MoonLadderStudios/MoonMind", "publishMode": "pr"},
@@ -6623,7 +6632,7 @@ async def test_run_execution_stage_skips_native_pr_after_push_failure(
         {"namespace": "default", "workflow_id": "wf-1", "run_id": "run-1"},
     )
     monkeypatch.setattr(run_workflow_module.workflow, "info", workflow_info)
-    monkeypatch.setattr(run_workflow_module.workflow, "patched", lambda patch_id: True)
+    monkeypatch.setattr(run_workflow_module.workflow, "patched", _all_patches_except_empty_skillset)
 
     await wf._run_execution_stage(
         parameters={"repo": "MoonLadderStudios/MoonMind", "publishMode": "pr"},
@@ -6741,7 +6750,7 @@ async def test_run_execution_stage_stops_after_publish_lease_conflict(
         {"namespace": "default", "workflow_id": "wf-1", "run_id": "run-1"},
     )
     monkeypatch.setattr(run_workflow_module.workflow, "info", workflow_info)
-    monkeypatch.setattr(run_workflow_module.workflow, "patched", lambda patch_id: True)
+    monkeypatch.setattr(run_workflow_module.workflow, "patched", _all_patches_except_empty_skillset)
 
     await wf._run_execution_stage(
         parameters={"repo": "MoonLadderStudios/MoonMind", "publishMode": "pr"},
@@ -6765,7 +6774,7 @@ async def test_run_proposals_stage_global_disable_halts_execution(
     from moonmind.config.settings import settings
     workflow = MoonMindRunWorkflow()
     monkeypatch.setattr(settings.workflow, "enable_proposals", False)
-    monkeypatch.setattr(run_workflow_module.workflow, "patched", lambda x: True)
+    monkeypatch.setattr(run_workflow_module.workflow, "patched", _all_patches_except_empty_skillset)
     
     # Enable proposing tasks in params, but global switch should stop it
     await workflow._run_proposals_stage(parameters={"proposeTasks": True})
@@ -6784,7 +6793,7 @@ async def test_run_proposals_stage_ignores_legacy_fallback_policy(
     workflow._owner_type = "user"
     workflow_info = type("WorkflowInfo", (), {"workflow_id": "wf-1", "run_id": "run-1", "namespace": "default"})()
     monkeypatch.setattr(run_workflow_module.workflow, "info", lambda: workflow_info)
-    monkeypatch.setattr(run_workflow_module.workflow, "patched", lambda x: True)
+    monkeypatch.setattr(run_workflow_module.workflow, "patched", _all_patches_except_empty_skillset)
     monkeypatch.setattr(run_workflow_module.workflow, "now", lambda: datetime.now(timezone.utc))
     
     captured_policy = None
@@ -6823,7 +6832,7 @@ async def test_run_proposals_stage_uses_workflow_proposal_policy(
     workflow._owner_type = "user"
     workflow_info = type("WorkflowInfo", (), {"workflow_id": "wf-1", "run_id": "run-1", "namespace": "default"})()
     monkeypatch.setattr(run_workflow_module.workflow, "info", lambda: workflow_info)
-    monkeypatch.setattr(run_workflow_module.workflow, "patched", lambda x: True)
+    monkeypatch.setattr(run_workflow_module.workflow, "patched", _all_patches_except_empty_skillset)
     monkeypatch.setattr(run_workflow_module.workflow, "now", lambda: datetime.now(timezone.utc))
     
     captured_policy = None
@@ -6883,7 +6892,7 @@ def test_update_memo_persists_pull_request_url_under_canonical_key(
         "upsert_memo",
         lambda memo: captured_memo.append(dict(memo)),
     )
-    monkeypatch.setattr(run_workflow_module.workflow, "patched", lambda _patch_id: True)
+    monkeypatch.setattr(run_workflow_module.workflow, "patched", _all_patches_except_empty_skillset)
 
     workflow._update_memo()
 

--- a/tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py
@@ -135,6 +135,11 @@ async def test_terminal_contract_continuation_is_agent_run_owned_and_bounded(
         stepExecutionId="wf-task-1:run-1:batch-workflows:execution:2",
         runtimeContextPolicy="reuse_session_same_epoch",
     )
+    request.workspace_spec["workspaceLocator"] = {
+        "kind": "sandbox",
+        "workspaceId": "sandbox-workspace-1",
+        "relativePath": "repo",
+    }
     calls: list[tuple[str, Any]] = []
     evaluations = 0
 
@@ -173,6 +178,15 @@ async def test_terminal_contract_continuation_is_agent_run_owned_and_bounded(
     assert result.metadata["terminalContractRecoveryOutcome"] == "recovered"
     assert result.metadata["terminalContractContinuationCount"] == 1
     assert calls[0][1]["runId"] == "wf-task-1"
+    assert calls[0][1]["workspaceLocator"] == {
+        "kind": "sandbox",
+        "workspaceId": "sandbox-workspace-1",
+        "relativePath": "repo",
+    }
+    assert calls[0][1]["workspaceOwnerWorkflowId"] == "wf-task-1"
+    assert calls[0][1]["workspaceOwnerStepExecutionId"] == (
+        "wf-task-1:run-1:batch-workflows:execution:2"
+    )
     assert [name for name, _ in calls] == [
         "agent_runtime.evaluate_terminal_evidence",
         "agent_runtime.load_session_snapshot",

--- a/tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py
@@ -25,14 +25,17 @@ from moonmind.schemas.agent_skill_models import (
     SkillTerminalContract,
 )
 from moonmind.workflows.temporal.workflows.run import (
+    RUN_AGENT_REQUIRED_CAPABILITIES_PROPAGATION_PATCH,
     RUN_ASSESSMENT_PARAMETER_INJECTION_PATCH,
     RUN_CHECKPOINT_RECOVERY_STATE_MACHINE_PATCH,
     RUN_CHECKPOINT_BRANCH_TURN_CONTEXT_PATCH,
+    RUN_EMPTY_AGENT_SKILLSET_SNAPSHOT_PATCH,
     RUN_EXISTING_SKILLSET_TERMINAL_CONTRACT_PATCH,
     RUN_JSON_ARTIFACT_WRITE_COMPLETE_PATCH,
     RUN_OMNIGENT_AGENT_PROFILE_SNAPSHOT_COMPILER_PATCH,
     RUN_OMNIGENT_AUTHORED_SELECTION_COMPILER_PATCH,
     RUN_OMNIGENT_CHECKPOINT_BRANCH_TURN_REQUEST_PATCH,
+    RUN_OMNIGENT_STOCK_AGENT_IDENTITY_PATCH,
     RUN_PR_RESOLVER_SKILL_OWNED_EXECUTION_PATCH,
     RUN_RESOLVED_SKILL_TERMINAL_CONTRACT_PATCH,
     RUN_SLOT_CONTINUITY_PATCH,
@@ -40,6 +43,55 @@ from moonmind.workflows.temporal.workflows.run import (
     RUN_TRUSTED_PR_RESOLVER_NATIVE_BINDING_PATCH,
     MoonMindRunWorkflow,
 )
+
+
+def test_agent_request_propagates_required_capabilities_with_replay_gate() -> None:
+    info = SimpleNamespace(
+        namespace="default",
+        workflow_id="mm:required-capabilities",
+        run_id="run-required-capabilities",
+        parent=None,
+    )
+    workflow_parameters = {"requiredCapabilities": ["git", "gh"]}
+
+    with (
+        patch(
+            "moonmind.workflows.temporal.workflows.run.workflow.info",
+            return_value=info,
+        ),
+        patch(
+            "moonmind.workflows.temporal.workflows.run.workflow.patched",
+            side_effect=lambda patch_id: (
+                patch_id == RUN_AGENT_REQUIRED_CAPABILITIES_PROPAGATION_PATCH
+            ),
+        ),
+    ):
+        current = MoonMindRunWorkflow()._build_agent_execution_request(
+            node_inputs={"runtime": {"mode": "omnigent"}},
+            node_id="node-1",
+            tool_name="omnigent",
+            workflow_parameters=workflow_parameters,
+        )
+
+    with (
+        patch(
+            "moonmind.workflows.temporal.workflows.run.workflow.info",
+            return_value=info,
+        ),
+        patch(
+            "moonmind.workflows.temporal.workflows.run.workflow.patched",
+            return_value=False,
+        ),
+    ):
+        replaying = MoonMindRunWorkflow()._build_agent_execution_request(
+            node_inputs={"runtime": {"mode": "omnigent"}},
+            node_id="node-1",
+            tool_name="omnigent",
+            workflow_parameters=workflow_parameters,
+        )
+
+    assert current.parameters["requiredCapabilities"] == ["git", "gh"]
+    assert "requiredCapabilities" not in replaying.parameters
 
 
 def _resolved_skill(skill_name: str) -> ResolvedSkillEntry:
@@ -246,6 +298,95 @@ class TestSlotContinuityMetadata(unittest.TestCase):
         self.assertEqual(request.parameters, {})
 
 class TestAgentSkillSnapshotResolution(unittest.IsolatedAsyncioTestCase):
+    async def test_auto_agent_node_resolves_empty_snapshot_before_launch(
+        self,
+    ) -> None:
+        wf = MoonMindRunWorkflow()
+        wf._owner_id = "owner-1"
+        wf._step_ledger_rows = [{"logicalStepId": "node-1", "attempt": 1}]
+        resolved = ResolvedSkillSet(
+            snapshot_id="skillset-wf-node-1",
+            resolved_at=datetime.now(UTC),
+            manifest_ref="artifact://skillsets/empty-node-1",
+            skills=[],
+        )
+        info = SimpleNamespace(
+            namespace="default",
+            workflow_id="mm:717ea339-77ab-4e72-bd46-969b009b5508",
+            run_id="019fd32f-cbfd-7846-bee9-79c87ebae5f8",
+            parent=None,
+        )
+
+        with (
+            patch(
+                "moonmind.workflows.temporal.workflows.run.workflow.execute_activity",
+                new=AsyncMock(return_value=resolved),
+            ) as execute_activity,
+            patch(
+                "moonmind.workflows.temporal.workflows.run.workflow.patched",
+                side_effect=lambda patch_id: (
+                    patch_id == RUN_EMPTY_AGENT_SKILLSET_SNAPSHOT_PATCH
+                ),
+            ),
+            patch(
+                "moonmind.workflows.temporal.workflows.run.workflow.info",
+                return_value=info,
+            ),
+        ):
+            resolved_ref = await wf._resolve_agent_node_skillset_ref(
+                task_skills=None,
+                node_inputs={
+                    "runtime": {"mode": "omnigent"},
+                    "selectedSkill": "auto",
+                },
+                node_id="node-1",
+                existing_skillset_ref=None,
+            )
+            request = wf._build_agent_execution_request(
+                node_inputs={
+                    "runtime": {"mode": "omnigent"},
+                    "selectedSkill": "auto",
+                },
+                node_id="node-1",
+                tool_name="omnigent",
+                resolved_skillset_ref=resolved_ref,
+            )
+
+        self.assertEqual(resolved_ref, "artifact://skillsets/empty-node-1")
+        selector = execute_activity.call_args.kwargs["args"][0]
+        self.assertEqual(
+            selector.model_dump(mode="json", exclude_none=True),
+            {"sets": [], "include": [], "exclude": []},
+        )
+        self.assertEqual(request.resolved_skillset_ref, resolved_ref)
+        self.assertIsNotNone(request.step_execution)
+        self.assertEqual(request.step_execution.resolved_skillset_ref, resolved_ref)
+
+    async def test_auto_agent_node_preserves_pre_patch_history(self) -> None:
+        wf = MoonMindRunWorkflow()
+
+        with (
+            patch(
+                "moonmind.workflows.temporal.workflows.run.workflow.execute_activity",
+                new=AsyncMock(),
+            ) as execute_activity,
+            patch(
+                "moonmind.workflows.temporal.workflows.run.workflow.patched",
+                side_effect=lambda patch_id: (
+                    patch_id != RUN_EMPTY_AGENT_SKILLSET_SNAPSHOT_PATCH
+                ),
+            ),
+        ):
+            resolved_ref = await wf._resolve_agent_node_skillset_ref(
+                task_skills=None,
+                node_inputs={"selectedSkill": "auto"},
+                node_id="node-1",
+                existing_skillset_ref=None,
+            )
+
+        self.assertIsNone(resolved_ref)
+        execute_activity.assert_not_awaited()
+
     async def test_existing_resolved_skillset_supplies_owned_terminal_contract(
         self,
     ) -> None:
@@ -1945,9 +2086,11 @@ class TestBuildAgentExecutionRequest(unittest.TestCase):
             return_value=MockInfo(),
         ), patch(
             "moonmind.workflows.temporal.workflows.run.workflow.patched",
-            side_effect=lambda patch_id: (
-                patch_id == RUN_OMNIGENT_AUTHORED_SELECTION_COMPILER_PATCH
-            ),
+            side_effect=lambda patch_id: patch_id
+            in {
+                RUN_OMNIGENT_AUTHORED_SELECTION_COMPILER_PATCH,
+                RUN_OMNIGENT_STOCK_AGENT_IDENTITY_PATCH,
+            },
         ):
             request = wf._build_agent_execution_request(
                 node_inputs={
@@ -1972,7 +2115,7 @@ class TestBuildAgentExecutionRequest(unittest.TestCase):
         expected_selection = dict(authored_selection)
         expected_selection["agent"] = {
             "harnessOverride": "codex-native",
-            "agentName": "codex",
+            "agentName": "codex-native-ui",
         }
         self.assertEqual(request.parameters["omnigent"], expected_selection)
         self.assertNotIn("hostId", request.parameters["omnigent"])

--- a/tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py
@@ -52,7 +52,10 @@ def test_agent_request_propagates_required_capabilities_with_replay_gate() -> No
         run_id="run-required-capabilities",
         parent=None,
     )
-    workflow_parameters = {"requiredCapabilities": ["git", "gh"]}
+    workflow_parameters = {
+        "requiredCapabilities": ["git", "gh"],
+        "workspaceSpec": {"repository": "MoonLadderStudios/MoonMind"},
+    }
 
     with (
         patch(
@@ -91,7 +94,10 @@ def test_agent_request_propagates_required_capabilities_with_replay_gate() -> No
         )
 
     assert current.parameters["requiredCapabilities"] == ["git", "gh"]
+    assert current.workspace_spec["repository"] == "MoonLadderStudios/MoonMind"
+    assert current.parameters["repository"] == "MoonLadderStudios/MoonMind"
     assert "requiredCapabilities" not in replaying.parameters
+    assert "repository" not in replaying.parameters
 
 
 def _resolved_skill(skill_name: str) -> ResolvedSkillEntry:

--- a/tests/unit/workflows/temporal/workflows/test_run_integration.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_integration.py
@@ -17,6 +17,7 @@ from moonmind.workflows.temporal.workflows.run import (
     RUN_CONDITIONAL_REGISTRY_READ_PATCH,
     RUN_DIRECT_TOOL_REPORT_OUTPUTS_PATCH,
     RUN_DURABLE_PUBLISH_CONTEXT_MERGE_HANDOFF_PATCH,
+    RUN_EMPTY_AGENT_SKILLSET_SNAPSHOT_PATCH,
     RUN_FAILED_RUN_RECOVERY_MANIFEST_PATCH,
     RUN_HANDOFF_ACCEPTED_DISPOSITION_GATE_PATCH,
     RUN_HEADLESS_REMEDIATION_VERIFIED_WORKSPACE_PATCH,
@@ -70,6 +71,12 @@ _LOOP_RUNTIME = {
     "effort": "high",
     "executionProfileRef": "codex_openai_oauth",
 }
+
+
+def _all_patches_except_empty_skillset(patch_id: str) -> bool:
+    """Keep generic execution fixtures focused on their asserted boundary."""
+
+    return patch_id != RUN_EMPTY_AGENT_SKILLSET_SNAPSHOT_PATCH
 
 
 def _loop_controller_node(loop: dict[str, Any]) -> dict[str, Any]:
@@ -241,7 +248,7 @@ async def _finalize_and_capture_summary(
         noop_terminate_sessions,
     )
     monkeypatch.setattr(run_workflow_module.workflow, "info", workflow_info)
-    monkeypatch.setattr(run_workflow_module.workflow, "patched", lambda _patch_id: True)
+    monkeypatch.setattr(run_workflow_module.workflow, "patched", _all_patches_except_empty_skillset)
     monkeypatch.setattr(
         run_workflow_module.workflow,
         "execute_activity",
@@ -1054,7 +1061,7 @@ async def test_run_execution_stage_bundles_consecutive_jules_nodes(
         {"namespace": "default", "workflow_id": "wf-1", "run_id": "run-1", "search_attributes": {}},
     )
     monkeypatch.setattr(run_workflow_module.workflow, "info", workflow_info)
-    monkeypatch.setattr(run_workflow_module.workflow, "patched", lambda _patch_id: True)
+    monkeypatch.setattr(run_workflow_module.workflow, "patched", _all_patches_except_empty_skillset)
 
     await workflow._run_execution_stage(
         parameters={"repo": "org/repo", "publishMode": "none"},
@@ -6937,7 +6944,7 @@ def test_native_pr_branch_resolution_prefers_publish_context_branch(
     mock_run_workflow: MoonMindRunWorkflow,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(run_workflow_module.workflow, "patched", lambda _patch_id: True)
+    monkeypatch.setattr(run_workflow_module.workflow, "patched", _all_patches_except_empty_skillset)
     mock_run_workflow._publish_context["branch"] = "804-workflow-detail-tabs"
     mock_run_workflow._publish_context["baseRef"] = "origin/main"
 
@@ -6962,7 +6969,7 @@ def test_native_pr_branch_resolution_normalizes_base_ref_candidates(
     mock_run_workflow: MoonMindRunWorkflow,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(run_workflow_module.workflow, "patched", lambda _patch_id: True)
+    monkeypatch.setattr(run_workflow_module.workflow, "patched", _all_patches_except_empty_skillset)
 
     _, base_branch = mock_run_workflow._resolve_native_pr_branches(
         parameters={},

--- a/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
@@ -141,6 +141,10 @@ def _managed_checkpoint_capture_result(payload: Any) -> dict[str, Any]:
     }
 
 
+def _empty_skill_resolution() -> dict[str, str]:
+    return {"manifestRef": "art_empty_skill_snapshot"}
+
+
 @pytest.mark.asyncio
 async def test_omnigent_result_is_joined_into_canonical_checkpoint_at_workflow_boundary(
     monkeypatch: pytest.MonkeyPatch,
@@ -4112,6 +4116,53 @@ async def test_after_execution_finalization_failure_preserves_primary_outcome(
 
 
 @pytest.mark.asyncio
+async def test_required_invalid_checkpoint_blocks_publication(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _configure_workflow_runtime(monkeypatch)
+    workflow = MoonMindRunWorkflow()
+    now = datetime(2026, 8, 5, 21, 8, tzinfo=UTC)
+    workflow._initialize_step_ledger(
+        ordered_nodes=[{"id": "implement", "inputs": {"title": "Implement"}}],
+        dependency_map={"implement": []},
+        updated_at=now,
+    )
+    workflow._mark_step_running("implement", updated_at=now, summary="Implementing")
+    workflow._step_workspace_capture_inputs["implement"] = {
+        "workspaceLocator": {
+            "kind": "sandbox",
+            "workspaceId": "workspace-1",
+            "relativePath": "repo",
+        },
+        "criticality": "required",
+    }
+    workflow._step_checkpoint_capture_outcomes["implement"] = {
+        "status": "invalid",
+        "failureCode": "invalid_checkpoint",
+        "summary": "Git rejected the repository ownership boundary.",
+        "capabilityCriticality": "required",
+    }
+
+    async def missing_checkpoint(*_args: Any, **_kwargs: Any) -> None:
+        return None
+
+    monkeypatch.setattr(
+        workflow, "_record_canonical_step_checkpoint", missing_checkpoint
+    )
+    await workflow._finalize_after_execution_checkpoint("implement", updated_at=now)
+
+    outcome = workflow.get_step_ledger()["steps"][0]["finalizationOutcome"]
+    assert outcome["status"] == "failed"
+    assert outcome["failureCode"] == "invalid_checkpoint"
+    assert outcome["message"] == "Git rejected the repository ownership boundary."
+    assert workflow._publish_status == "failed"
+    assert workflow._publish_reason == (
+        "Execution succeeded, but its required after-execution workspace "
+        "checkpoint failed."
+    )
+
+
+@pytest.mark.asyncio
 async def test_after_execution_finalization_is_idempotent_and_does_not_execute_agent(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -4425,6 +4476,79 @@ async def test_run_uses_external_omnigent_identity_for_checkpoint_capture(
             }
         }
     }
+
+
+@pytest.mark.asyncio
+async def test_omnigent_result_keeps_session_ref_separate_from_workspace_capture(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _configure_workflow_runtime(monkeypatch)
+    monkeypatch.setattr(run_module.workflow, "patched", lambda _patch_id: True)
+    workflow = MoonMindRunWorkflow()
+    now = datetime(2026, 8, 5, 20, 11, tzinfo=UTC)
+    workflow._initialize_step_ledger(
+        ordered_nodes=[{"id": "implement", "inputs": {"title": "Implement"}}],
+        dependency_map={"implement": []},
+        updated_at=now,
+    )
+    workflow._mark_step_running("implement", updated_at=now, summary="Implementing")
+    workflow._record_step_workspace_capture_input(
+        "implement",
+        {
+            "targetRuntime": "omnigent",
+        },
+        initialize_omnigent_capture=True,
+    )
+    workflow._record_step_workspace_capture_input(
+        "implement",
+        {
+            "workspaceLocator": {
+                "kind": "sandbox",
+                "workspaceId": "workspace-replay",
+                "relativePath": "repo",
+            },
+            "externalStateRef": "artifact://omnigent/replay/external-state.json",
+            "checkpointKind": "external_state_ref",
+            "omnigentCheckpointCapture": {
+                "externalStateRef": "artifact://omnigent/replay/external-state.json"
+            },
+        },
+    )
+    capture_input = workflow._step_workspace_capture_inputs["implement"]
+
+    assert capture_input["externalStateRef"] == (
+        "artifact://omnigent/replay/external-state.json"
+    )
+    assert capture_input["workspaceLocator"]["kind"] == "sandbox"
+    assert "kind" not in capture_input
+
+    captured: list[dict[str, Any]] = []
+
+    async def fake_execute_activity(
+        activity: str,
+        payload: dict[str, Any],
+        **_kwargs: Any,
+    ) -> dict[str, Any]:
+        captured.append({"activity": activity, "payload": payload})
+        if activity == "workspace.capture_checkpoint":
+            return _managed_checkpoint_capture_result(payload)
+        return _checkpoint_create_result(payload)
+
+    monkeypatch.setattr(run_module.workflow, "execute_activity", fake_execute_activity)
+
+    checkpoint_ref = await workflow._record_canonical_step_checkpoint(
+        "implement",
+        boundary="after_execution",
+        updated_at=now,
+    )
+
+    assert checkpoint_ref == "artifact://checkpoint/after_execution"
+    assert captured[0]["payload"]["kind"] == "worktree_archive"
+    assert captured[0]["payload"]["externalStateRef"] == (
+        "artifact://omnigent/replay/external-state.json"
+    )
+    assert captured[1]["activity"] == "step_checkpoint.create_v2"
+    assert captured[1]["payload"]["workspace"]["kind"] == "worktree_archive"
 
 
 def test_run_derives_external_omnigent_identity_from_runtime_selection() -> None:
@@ -5015,9 +5139,11 @@ async def test_run_execution_stage_propagates_agent_child_cancellation_under_con
 
     async def fake_execute_activity(
         activity_type: str,
-        payload: Any,
+        payload: Any = None,
         **_kwargs: Any,
     ) -> Any:
+        if activity_type == "agent_skill.resolve":
+            return _empty_skill_resolution()
         if activity_type == "resilience.compile_policy":
             return _resilience_policy_compile_result(payload)
         if activity_type == "provider_profile.list":
@@ -5121,9 +5247,11 @@ async def test_run_execution_stage_marks_step_reviewing_and_records_passed_check
 
     async def fake_execute_activity(
         activity_type: str,
-        payload: Any,
+        payload: Any = None,
         **_kwargs: Any,
     ) -> Any:
+        if activity_type == "agent_skill.resolve":
+            return _empty_skill_resolution()
         if activity_type == "resilience.compile_policy":
             return _resilience_policy_compile_result(payload)
         if activity_type == "provider_profile.list":
@@ -5318,9 +5446,11 @@ async def test_run_execution_stage_retries_failed_reviews_with_feedback_and_retr
 
     async def fake_execute_activity(
         activity_type: str,
-        payload: Any,
+        payload: Any = None,
         **_kwargs: Any,
     ) -> Any:
+        if activity_type == "agent_skill.resolve":
+            return _empty_skill_resolution()
         if activity_type == "resilience.compile_policy":
             return _resilience_policy_compile_result(payload)
         if activity_type == "provider_profile.list":
@@ -5499,9 +5629,11 @@ async def test_run_execution_stage_stops_downstream_handoff_when_gate_budget_exh
 
     async def fake_execute_activity(
         activity_type: str,
-        payload: Any,
+        payload: Any = None,
         **_kwargs: Any,
     ) -> Any:
+        if activity_type == "agent_skill.resolve":
+            return _empty_skill_resolution()
         if activity_type == "resilience.compile_policy":
             return _resilience_policy_compile_result(payload)
         if activity_type == "provider_profile.list":
@@ -5677,9 +5809,11 @@ async def test_run_execution_stage_stops_downstream_handoff_when_no_progress_bud
 
     async def fake_execute_activity(
         activity_type: str,
-        payload: Any,
+        payload: Any = None,
         **_kwargs: Any,
     ) -> Any:
+        if activity_type == "agent_skill.resolve":
+            return _empty_skill_resolution()
         if activity_type == "resilience.compile_policy":
             return _resilience_policy_compile_result(payload)
         if activity_type == "provider_profile.list":
@@ -5830,9 +5964,11 @@ async def test_run_execution_stage_continues_independent_nodes_after_gate_stop(
 
     async def fake_execute_activity(
         activity_type: str,
-        payload: Any,
+        payload: Any = None,
         **_kwargs: Any,
     ) -> Any:
+        if activity_type == "agent_skill.resolve":
+            return _empty_skill_resolution()
         if activity_type == "resilience.compile_policy":
             return _resilience_policy_compile_result(payload)
         if activity_type == "provider_profile.list":
@@ -5982,9 +6118,11 @@ async def test_run_execution_stage_retries_agent_runtime_reviews_with_feedback_i
 
     async def fake_execute_activity(
         activity_type: str,
-        payload: Any,
+        payload: Any = None,
         **_kwargs: Any,
     ) -> Any:
+        if activity_type == "agent_skill.resolve":
+            return _empty_skill_resolution()
         if activity_type == "resilience.compile_policy":
             return _resilience_policy_compile_result(payload)
         if activity_type == "provider_profile.list":


### PR DESCRIPTION
## Summary

- make Omnigent lifecycle events retry-safe and reopenable without duplicating durable state
- preserve runtime authority across skill snapshots, provider leases, managed hosts, workspaces, tools, checkpoints, and publication
- use run-private standard GitHub CLI configuration and restore the exact step execution identity inside native Codex login shells
- accept only Skill-authored terminal and publish evidence, including the PR resolver merge disposition
- add minimized replay fixtures for every escaped failure found while repeatedly exercising the live workflow

## Live verification

- exact rerun of `mm:96eb128d-ff2e-4d22-9fe5-cde712d2c678`: `mm:fa0a0b85-48b5-47e2-a09d-276e72dd47f2`
- authoritative result: `WORKFLOW_EXECUTION_STATUS_COMPLETED`
- API projection: `status=completed`, “Workflow completed successfully”
- the rerun created PR #3617; merge automation launched `pr-resolver`, the resolver corrected its failing frontend assertion, all checks passed, and PR #3617 merged
- the resolver agent, merge-automation workflow, and exact rerun parent all completed successfully

## Tests

- full hermetic integration selector: 531 passed, 1 skipped, 224 deselected
- focused host lifecycle/tool projection: 146 passed
- focused host/adapter/terminal/run dispatch: 287 passed plus 9 subtests
- focused activity/run integration: 352 passed
- focused remediation coverage after import-cycle repair: 26 passed
- focused review-finding regression suite: 223 passed
- full Python unit run: 10,790 passed, 10 skipped, 1 xfailed, 23 subtests; 12 failures were observed, 2 relevant failures were fixed and rerun, and the remaining 10 are pre-existing local worktree/macOS environment mismatches (dirty submodule projections, local publish-policy configuration, immutable-directory rename behavior, and /tmp path normalization)
