### PR TITLE
Fix Omnigent default host policy selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ If you already have a subscription with a model provider:
 3. Follow the instructions on the new tab
 4. Go back to Settings and click Finalize
 
-To expose a Settings-authenticated OAuth profile to Omnigent, enable the matching dedicated host profile in `.env`, for example `COMPOSE_PROFILES="omnigent-host-codex"`, and rerun `docker compose up -d`. The dedicated hosts live in the canonical Compose file, so no platform-specific `COMPOSE_FILE` list is required. See [Combined Stack Validation and Rollback](docs/Omnigent/CombinedStackValidationAndRollback.md#dedicated-oauth-hosts).
+After Finalize, a launch-ready OAuth profile is available to the normal on-demand Omnigent path without additional Compose configuration. Dedicated static hosts are an optional advanced deployment choice; to use one, enable the matching host profile in `.env`, for example `COMPOSE_PROFILES="omnigent-host-codex"`, rerun `docker compose up -d`, and explicitly select its static host policy. The dedicated hosts live in the canonical Compose file, so no platform-specific `COMPOSE_FILE` list is required. See [Combined Stack Validation and Rollback](docs/Omnigent/CombinedStackValidationAndRollback.md#dedicated-oauth-hosts).
 
 ## Why MoonMind?
 

--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -10719,6 +10719,28 @@ async def _create_execution_from_workflow_request(
             )
         if not isinstance(agent_profile_selection, Mapping):
             raise _invalid_workflow_request("agentProfile must be an object.")
+        agent_profile_selection = dict(agent_profile_selection)
+        authored_omnigent = payload.get("omnigent")
+        authored_launch_policy_ref = (
+            str(authored_omnigent.get("launchPolicyRef") or "").strip()
+            if isinstance(authored_omnigent, Mapping)
+            else ""
+        )
+        selected_launch_policy_ref = str(
+            agent_profile_selection.get("launchPolicyRef") or ""
+        ).strip()
+        if (
+            authored_launch_policy_ref
+            and selected_launch_policy_ref
+            and authored_launch_policy_ref != selected_launch_policy_ref
+        ):
+            raise _invalid_workflow_request(
+                "agentProfile.launchPolicyRef must match omnigent.launchPolicyRef."
+            )
+        if authored_launch_policy_ref:
+            agent_profile_selection["launchPolicyRef"] = (
+                authored_launch_policy_ref
+            )
         profile_snapshot = await resolve_agent_profile_snapshot(
             session,
             selection=agent_profile_selection,

--- a/api_service/api/routers/omnigent_catalog.py
+++ b/api_service/api/routers/omnigent_catalog.py
@@ -506,8 +506,7 @@ async def get_omnigent_codex_catalog_readiness(
         select(OmnigentPolicy, OmnigentPolicyVersion)
         .join(
             OmnigentPolicyVersion,
-            (OmnigentPolicyVersion.policy_id == OmnigentPolicy.policy_id)
-            & (OmnigentPolicyVersion.version == OmnigentPolicy.default_version),
+            OmnigentPolicyVersion.policy_id == OmnigentPolicy.policy_id,
         )
         .where(OmnigentPolicyVersion.state == "active")
     )).all())
@@ -521,7 +520,8 @@ async def get_omnigent_codex_catalog_readiness(
         )
         default_policy = POLICIES.get(profile.default_policy_ref)
         default_policy_id = default_policy.policy_id if default_policy else None
-        launch_policies_by_id: dict[str, LaunchPolicyReadiness] = {}
+        launch_policies_by_ref: dict[str, LaunchPolicyReadiness] = {}
+        persisted_default_ref: str | None = None
         unavailable_policy_reasons: list[GateReason] = []
         for policy in POLICIES.values():
             if not policy.policy_id.startswith(provider_slug + "-"):
@@ -552,7 +552,7 @@ async def get_omnigent_codex_catalog_readiness(
                 if mode_readiness["conformanceState"] != "ready":
                     policy_reasons.append(_reason("bridge_conformance_gated"))
             if not policy_reasons:
-                launch_policies_by_id[policy.policy_id] = LaunchPolicyReadiness(
+                launch_policies_by_ref[policy.ref] = LaunchPolicyReadiness(
                     ref=policy.ref,
                     displayName=(
                         "On-demand Docker"
@@ -560,11 +560,16 @@ async def get_omnigent_codex_catalog_readiness(
                         else "Static Compose"
                     ),
                     hostMode=policy.host_mode,
-                    isDefault=policy.policy_id == default_policy_id,
+                    isDefault=False,
                 )
                 available_modes.append(policy.host_mode)
             unavailable_policy_reasons.extend(policy_reasons)
         for identity, version in persisted_policies:
+            if not (
+                identity.visibility == "deployment"
+                or identity.owner_user_id == getattr(current_user, "id", None)
+            ):
+                continue
             document = version.document_json
             if document.get("execution", {}).get("profileRef") != profile.ref:
                 continue
@@ -592,7 +597,7 @@ async def get_omnigent_codex_catalog_readiness(
                 policy_reasons.append(_reason("static_host_not_ready"))
             if not policy_reasons:
                 persisted_ref = f"{identity.policy_id}@{version.version}"
-                launch_policies_by_id[identity.policy_id] = LaunchPolicyReadiness(
+                launch_policies_by_ref[persisted_ref] = LaunchPolicyReadiness(
                     ref=persisted_ref,
                     displayName=(
                         str(getattr(identity, "name", "") or "").strip()
@@ -603,12 +608,27 @@ async def get_omnigent_codex_catalog_readiness(
                         )
                     ),
                     hostMode=host_mode,
-                    isDefault=identity.policy_id == default_policy_id,
+                    isDefault=False,
                 )
+                if (
+                    identity.policy_id == default_policy_id
+                    and version.version == identity.default_version
+                ):
+                    persisted_default_ref = persisted_ref
                 available_modes.append(host_mode)
             unavailable_policy_reasons.extend(policy_reasons)
+        preferred_default_ref = (
+            persisted_default_ref
+            if persisted_default_ref in launch_policies_by_ref
+            else profile.default_policy_ref
+        )
         launch_policies = sorted(
-            launch_policies_by_id.values(),
+            (
+                policy.model_copy(
+                    update={"is_default": policy.ref == preferred_default_ref}
+                )
+                for policy in launch_policies_by_ref.values()
+            ),
             key=lambda item: (not item.is_default, item.display_name, item.ref),
         )
         if not launch_policies:

--- a/api_service/api/routers/omnigent_catalog.py
+++ b/api_service/api/routers/omnigent_catalog.py
@@ -65,7 +65,7 @@ from .omnigent_bridge import (
 
 router = APIRouter(prefix="/api/omnigent", tags=["Omnigent Catalog"])
 
-_SCHEMA_VERSION = "moonmind.omnigent-codex-readiness.v1"
+_SCHEMA_VERSION = "moonmind.omnigent-codex-readiness.v2"
 _DIGEST_IMAGE = re.compile(r"^[^\s@]+@sha256:[0-9a-f]{64}$")
 _ACCEPTANCE_ROWS = (
     "static_profile_bound",
@@ -105,18 +105,28 @@ class IneligibleProviderProfile(BaseModel):
     gate_reasons: list[GateReason] = Field(alias="gateReasons")
 
 
+class LaunchPolicyReadiness(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+    ref: str
+    display_name: str = Field(alias="displayName")
+    host_mode: Literal["static_compose", "on_demand_docker"] = Field(
+        alias="hostMode"
+    )
+    is_default: bool = Field(False, alias="isDefault")
+
+
 class ExecutionProfileReadiness(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
     ref: str
     display_name: str = Field(alias="displayName")
     available: bool
-    policy_refs: list[str] = Field(alias="policyRefs")
+    launch_policies: list[LaunchPolicyReadiness] = Field(alias="launchPolicies")
     gate_reasons: list[GateReason] = Field(alias="gateReasons")
 
 
 class OmnigentCodexCatalogReadiness(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
-    schema_version: Literal["moonmind.omnigent-codex-readiness.v1"] = Field(
+    schema_version: Literal["moonmind.omnigent-codex-readiness.v2"] = Field(
         _SCHEMA_VERSION, alias="schemaVersion"
     )
     runtime_id: Literal["omnigent"] = Field("omnigent", alias="runtimeId")
@@ -509,7 +519,9 @@ async def get_omnigent_codex_catalog_readiness(
         provider_slug = (
             "claude" if profile.provider_runtime == "claude_code" else "codex"
         )
-        policy_refs: list[str] = []
+        default_policy = POLICIES.get(profile.default_policy_ref)
+        default_policy_id = default_policy.policy_id if default_policy else None
+        launch_policies_by_id: dict[str, LaunchPolicyReadiness] = {}
         unavailable_policy_reasons: list[GateReason] = []
         for policy in POLICIES.values():
             if not policy.policy_id.startswith(provider_slug + "-"):
@@ -540,7 +552,16 @@ async def get_omnigent_codex_catalog_readiness(
                 if mode_readiness["conformanceState"] != "ready":
                     policy_reasons.append(_reason("bridge_conformance_gated"))
             if not policy_reasons:
-                policy_refs.append(policy.ref)
+                launch_policies_by_id[policy.policy_id] = LaunchPolicyReadiness(
+                    ref=policy.ref,
+                    displayName=(
+                        "On-demand Docker"
+                        if policy.host_mode == "on_demand_docker"
+                        else "Static Compose"
+                    ),
+                    hostMode=policy.host_mode,
+                    isDefault=policy.policy_id == default_policy_id,
+                )
                 available_modes.append(policy.host_mode)
             unavailable_policy_reasons.extend(policy_reasons)
         for identity, version in persisted_policies:
@@ -571,11 +592,26 @@ async def get_omnigent_codex_catalog_readiness(
                 policy_reasons.append(_reason("static_host_not_ready"))
             if not policy_reasons:
                 persisted_ref = f"{identity.policy_id}@{version.version}"
-                if persisted_ref not in policy_refs:
-                    policy_refs.append(persisted_ref)
+                launch_policies_by_id[identity.policy_id] = LaunchPolicyReadiness(
+                    ref=persisted_ref,
+                    displayName=(
+                        str(getattr(identity, "name", "") or "").strip()
+                        or (
+                            "On-demand Docker"
+                            if host_mode == "on_demand_docker"
+                            else "Static Compose"
+                        )
+                    ),
+                    hostMode=host_mode,
+                    isDefault=identity.policy_id == default_policy_id,
+                )
                 available_modes.append(host_mode)
             unavailable_policy_reasons.extend(policy_reasons)
-        if not policy_refs:
+        launch_policies = sorted(
+            launch_policies_by_id.values(),
+            key=lambda item: (not item.is_default, item.display_name, item.ref),
+        )
+        if not launch_policies:
             for reason in unavailable_policy_reasons:
                 if reason.code not in {existing.code for existing in profile_reasons}:
                     profile_reasons.append(reason)
@@ -586,11 +622,11 @@ async def get_omnigent_codex_catalog_readiness(
             displayName=profile.display_name,
             available=(
                 profile.enabled
-                and bool(policy_refs)
+                and bool(launch_policies)
                 and bool(eligible_by_runtime.get(profile.provider_runtime))
                 and not deployment_reasons
             ),
-            policyRefs=policy_refs,
+            launchPolicies=launch_policies,
             gateReasons=profile_reasons,
         ))
 

--- a/frontend/src/entrypoints/workflow-start.test.tsx
+++ b/frontend/src/entrypoints/workflow-start.test.tsx
@@ -757,8 +757,23 @@ describe("MoonLadderStudios/MoonMind#3451 Omnigent readiness", () => {
     const request = JSON.parse(String((createCall?.[1] as RequestInit | undefined)?.body));
     expect(request.payload).toMatchObject({
       targetRuntime: "omnigent",
+      agentProfile: {
+        profileId: "team-codex",
+        providerProfileRef: "oauth-1",
+        launchPolicyRef: "on-demand-v1",
+      },
       omnigent: { executionTargetRef: "omnigent-codex-default", launchPolicyRef: "on-demand-v1" },
-      task: { runtime: { mode: "omnigent", profileId: "oauth-1" } },
+      task: {
+        runtime: {
+          mode: "omnigent",
+          profileId: "oauth-1",
+          agentProfile: {
+            profileId: "team-codex",
+            providerProfileRef: "oauth-1",
+            launchPolicyRef: "on-demand-v1",
+          },
+        },
+      },
     });
     expect(JSON.stringify(request)).not.toMatch(/hostId|volume|credential|registrationToken|image|network|mount/i);
   });
@@ -833,6 +848,174 @@ describe("MoonLadderStudios/MoonMind#3451 Omnigent readiness", () => {
     expect(request.payload.omnigent).toEqual({
       executionTargetRef: "omnigent-codex-default",
       launchPolicyRef: "on-demand-v2",
+    });
+    expect(request.payload.agentProfile.launchPolicyRef).toBe("on-demand-v2");
+    expect(request.payload.task.runtime.agentProfile.launchPolicyRef).toBe(
+      "on-demand-v2",
+    );
+  });
+
+  it("keeps a historical profile version compatible for an Omnigent rerun", async () => {
+    window.history.pushState(
+      {},
+      "Task Rerun",
+      "/workflows/new?rerunExecutionId=mm%3Aomnigent-history",
+    );
+    const versionedCatalog = {
+      ...readyOmnigentCatalog,
+      executionProfiles: [{
+        ref: "omnigent-codex-default",
+        displayName: "Codex default",
+        available: true,
+        launchPolicies: [
+          {
+            ref: "on-demand-v2",
+            displayName: "On-demand Docker v2",
+            hostMode: "on_demand_docker",
+            isDefault: true,
+          },
+          {
+            ref: "on-demand-v1",
+            displayName: "On-demand Docker v1",
+            hostMode: "on_demand_docker",
+            isDefault: false,
+          },
+        ],
+        gateReasons: [],
+      }],
+    } satisfies components["schemas"]["OmnigentCodexCatalogReadiness"];
+    const versionedAgentProfiles = [{
+      profileId: "team-codex",
+      displayName: "Team Codex",
+      state: "active",
+      activeVersion: 2,
+      defaultForRuntime: true,
+      versions: [
+        {
+          version: 1,
+          digest: `sha256:${"a".repeat(64)}`,
+          document: {
+            execution: {
+              defaultExecutionProfileRef: "omnigent-codex-default",
+              allowedLaunchPolicyRefs: ["on-demand-v1"],
+            },
+            policyRef: "on-demand-v1",
+          },
+          validationResult: { ready: true },
+        },
+        {
+          version: 2,
+          digest: `sha256:${"b".repeat(64)}`,
+          document: {
+            execution: {
+              defaultExecutionProfileRef: "omnigent-codex-default",
+              allowedLaunchPolicyRefs: ["on-demand-v2"],
+            },
+            policyRef: "on-demand-v2",
+          },
+          validationResult: { ready: true },
+        },
+      ],
+    }];
+    fetchSpy.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url === "/api/omnigent/codex-catalog-readiness") {
+        return Promise.resolve({ ok: true, json: async () => versionedCatalog } as Response);
+      }
+      if (url === "/api/omnigent/agent-profiles") {
+        return Promise.resolve({ ok: true, json: async () => versionedAgentProfiles } as Response);
+      }
+      if (url.startsWith("/api/v1/provider-profiles")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => [{
+            profile_id: "oauth-1",
+            account_label: "Codex OAuth",
+            provider_id: "openai",
+          }],
+        } as Response);
+      }
+      if (url === "/api/executions/mm%3Aomnigent-history?source=temporal") {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            workflowId: "mm:omnigent-history",
+            workflowType: "MoonMind.UserWorkflow",
+            state: "completed",
+            targetRuntime: "omnigent",
+            profileId: "oauth-1",
+            repository: "MoonLadderStudios/MoonMind",
+            publishMode: "pr",
+            inputParameters: {
+              targetRuntime: "omnigent",
+              repository: "MoonLadderStudios/MoonMind",
+              profileId: "oauth-1",
+              publishMode: "pr",
+              reportOutput: { enabled: false },
+              agentProfile: { profileId: "team-codex", version: 1 },
+              omnigent: {
+                executionTargetRef: "omnigent-codex-default",
+                launchPolicyRef: "on-demand-v1",
+              },
+              workflow: {
+                instructions: "Rerun the historical Omnigent policy.",
+                runtime: { mode: "omnigent", profileId: "oauth-1" },
+                publish: { mode: "pr" },
+                reportOutput: { enabled: false },
+              },
+            },
+            actions: { canUpdateInputs: false, canRerun: true },
+          }),
+        } as Response);
+      }
+      if (
+        url === "/api/executions/mm%3Aomnigent-history/update" &&
+        init?.method === "POST"
+      ) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            accepted: true,
+            applied: "continue_as_new",
+            execution: { workflowId: "mm:omnigent-history-rerun" },
+          }),
+        } as Response);
+      }
+      return Promise.resolve({ ok: true, json: async () => ({ items: [] }) } as Response);
+    });
+
+    renderWorkflowStartPage(omnigentPayload());
+
+    const hostPolicy = await screen.findByLabelText("Host policy");
+    await waitFor(() => {
+      expect((hostPolicy as HTMLSelectElement).value).toBe("on-demand-v1");
+    });
+    expect(screen.queryByText(/Choose a compatible Omnigent host policy/)).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Start New Run" }));
+
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledWith(
+        "/api/executions/mm%3Aomnigent-history/update",
+        expect.objectContaining({ method: "POST" }),
+      );
+    });
+    const updateCall = fetchSpy.mock.calls.find(
+      ([url]) => String(url) === "/api/executions/mm%3Aomnigent-history/update",
+    );
+    expect(JSON.parse(String(updateCall?.[1]?.body))).toMatchObject({
+      updateName: "RequestRerun",
+      parametersPatch: {
+        agentProfile: {
+          profileId: "team-codex",
+          version: 1,
+          providerProfileRef: "oauth-1",
+          launchPolicyRef: "on-demand-v1",
+        },
+        omnigent: {
+          executionTargetRef: "omnigent-codex-default",
+          launchPolicyRef: "on-demand-v1",
+        },
+      },
     });
   });
 

--- a/frontend/src/entrypoints/workflow-start.test.tsx
+++ b/frontend/src/entrypoints/workflow-start.test.tsx
@@ -567,7 +567,7 @@ describe("MoonLadderStudios/MoonMind#3451 Omnigent readiness", () => {
         return Promise.resolve({
           ok: true,
           json: async () => ({
-            schemaVersion: "moonmind.omnigent-codex-readiness.v1",
+            schemaVersion: "moonmind.omnigent-codex-readiness.v2",
             runtimeId: "omnigent",
             displayName: "Codex via Omnigent",
             available: false,
@@ -609,7 +609,7 @@ describe("MoonLadderStudios/MoonMind#3451 Omnigent readiness", () => {
   }
 
   const readyOmnigentCatalog = {
-    schemaVersion: "moonmind.omnigent-codex-readiness.v1",
+    schemaVersion: "moonmind.omnigent-codex-readiness.v2",
     runtimeId: "omnigent",
     displayName: "Codex via Omnigent",
     agentKind: "external",
@@ -617,7 +617,13 @@ describe("MoonLadderStudios/MoonMind#3451 Omnigent readiness", () => {
     harness: "codex-native",
     available: true,
     defaultExecutionProfileRef: "omnigent-codex-default",
-    executionProfiles: [{ ref: "omnigent-codex-default", displayName: "Codex default", available: true, policyRefs: ["on-demand-v1"], gateReasons: [] }],
+    executionProfiles: [{
+      ref: "omnigent-codex-default",
+      displayName: "Codex default",
+      available: true,
+      launchPolicies: [{ ref: "on-demand-v1", displayName: "On-demand Docker", hostMode: "on_demand_docker", isDefault: true }],
+      gateReasons: [],
+    }],
     eligibleProviderProfiles: [{ profileId: "oauth-1", label: "Codex OAuth", providerId: "openai", runtimeId: "codex_cli", busy: false, queueWhenBusy: true }],
     ineligibleProviderProfiles: [],
     hostModes: ["on_demand_docker"],
@@ -673,12 +679,18 @@ describe("MoonLadderStudios/MoonMind#3451 Omnigent readiness", () => {
         return Promise.resolve({
           ok: true,
           json: async () => ({
-            schemaVersion: "moonmind.omnigent-codex-readiness.v1",
+            schemaVersion: "moonmind.omnigent-codex-readiness.v2",
             runtimeId: "omnigent",
             displayName: "Codex via Omnigent",
             available: true,
             defaultExecutionProfileRef: "omnigent-codex-default",
-            executionProfiles: [{ ref: "omnigent-codex-default", displayName: "Codex default", available: true, policyRefs: ["on-demand-v1"], gateReasons: [] }],
+            executionProfiles: [{
+              ref: "omnigent-codex-default",
+              displayName: "Codex default",
+              available: true,
+              launchPolicies: [{ ref: "on-demand-v1", displayName: "On-demand Docker", hostMode: "on_demand_docker", isDefault: true }],
+              gateReasons: [],
+            }],
             eligibleProviderProfiles: [{ profileId: "oauth-1", label: "Codex OAuth", providerId: "openai", runtimeId: "codex_cli", busy: true, queueWhenBusy: false }],
             ineligibleProviderProfiles: [],
             gateReasons: [],
@@ -751,6 +763,79 @@ describe("MoonLadderStudios/MoonMind#3451 Omnigent readiness", () => {
     expect(JSON.stringify(request)).not.toMatch(/hostId|volume|credential|registrationToken|image|network|mount/i);
   });
 
+  it("adopts the active default policy version without requiring a host-policy choice", async () => {
+    const activePolicyCatalog = {
+      ...readyOmnigentCatalog,
+      executionProfiles: [{
+        ref: "omnigent-codex-default",
+        displayName: "Codex default",
+        available: true,
+        launchPolicies: [{
+          ref: "on-demand-v2",
+          displayName: "On-demand Docker",
+          hostMode: "on_demand_docker",
+          isDefault: true,
+        }],
+        gateReasons: [],
+      }],
+    } satisfies components["schemas"]["OmnigentCodexCatalogReadiness"];
+    const activePolicyAgentProfiles = [{
+      ...readyAgentProfiles[0],
+      versions: [{
+        version: 1,
+        digest: `sha256:${"a".repeat(64)}`,
+        document: {
+          execution: {
+            defaultExecutionProfileRef: "omnigent-codex-default",
+            allowedLaunchPolicyRefs: ["on-demand-v2"],
+          },
+          policyRef: "on-demand-v2",
+        },
+        validationResult: { ready: true },
+      }],
+    }];
+    fetchSpy.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url === "/api/omnigent/codex-catalog-readiness") {
+        return Promise.resolve({ ok: true, json: async () => activePolicyCatalog } as Response);
+      }
+      if (url.startsWith("/api/v1/provider-profiles")) {
+        return Promise.resolve({ ok: true, json: async () => [{ profile_id: "oauth-1", account_label: "Codex OAuth", provider_id: "openai" }] } as Response);
+      }
+      if (url === "/api/omnigent/agent-profiles") {
+        return Promise.resolve({ ok: true, json: async () => activePolicyAgentProfiles } as Response);
+      }
+      if (url === "/api/executions" && init?.method === "POST") {
+        return Promise.resolve({ ok: true, json: async () => ({ workflowId: "mm:omnigent-active-policy" }) } as Response);
+      }
+      return Promise.resolve({ ok: true, json: async () => ({ items: [] }) } as Response);
+    });
+
+    renderWorkflowStartPage(omnigentPayload());
+    fireEvent.change(await screen.findByLabelText("Runtime"), { target: { value: "omnigent" } });
+    fireEvent.change(await screen.findByLabelText("Provider profile"), { target: { value: "oauth-1" } });
+
+    const hostPolicy = await screen.findByLabelText("Host policy");
+    await waitFor(() => expect((hostPolicy as HTMLSelectElement).value).toBe("on-demand-v2"));
+    expect(within(hostPolicy).getByRole("option", { name: "On-demand Docker (Default)" })).toBeTruthy();
+    expect(screen.queryByText(/Choose a compatible Omnigent host policy/)).toBeNull();
+
+    fireEvent.change(screen.getByLabelText("Instructions"), {
+      target: { value: "Use the active default policy." },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Start Workflow" }));
+
+    await waitFor(() => expect(navigateTo).toHaveBeenCalledWith("/workflows/mm%3Aomnigent-active-policy?source=temporal"));
+    const createCall = fetchSpy.mock.calls.find(([url, options]) =>
+      String(url) === "/api/executions" && (options as RequestInit | undefined)?.method === "POST",
+    );
+    const request = JSON.parse(String((createCall?.[1] as RequestInit | undefined)?.body));
+    expect(request.payload.omnigent).toEqual({
+      executionTargetRef: "omnigent-codex-default",
+      launchPolicyRef: "on-demand-v2",
+    });
+  });
+
   it("filters mixed Provider Profiles by execution target and resets an incompatible selection", async () => {
     const payload = omnigentPayload();
     const initialData = payload.initialData as {
@@ -770,8 +855,8 @@ describe("MoonLadderStudios/MoonMind#3451 Omnigent readiness", () => {
       ...readyOmnigentCatalog,
       defaultExecutionProfileRef: "omnigent-codex@1",
       executionProfiles: [
-        { ref: "omnigent-codex@1", displayName: "Omnigent Codex", available: true, policyRefs: ["codex-static@1"], gateReasons: [] },
-        { ref: "omnigent-claude@1", displayName: "Omnigent Claude", available: true, policyRefs: ["claude-static@1"], gateReasons: [] },
+        { ref: "omnigent-codex@1", displayName: "Omnigent Codex", available: true, launchPolicies: [{ ref: "codex-static@1", displayName: "Codex static", hostMode: "static_compose", isDefault: true }], gateReasons: [] },
+        { ref: "omnigent-claude@1", displayName: "Omnigent Claude", available: true, launchPolicies: [{ ref: "claude-static@1", displayName: "Claude static", hostMode: "static_compose", isDefault: true }], gateReasons: [] },
       ],
       eligibleProviderProfiles: [
         { profileId: "codex-oauth", label: "OpenAI subscription", providerId: "openai", runtimeId: "codex_cli", busy: false, queueWhenBusy: true },

--- a/frontend/src/entrypoints/workflow-start.tsx
+++ b/frontend/src/entrypoints/workflow-start.tsx
@@ -606,8 +606,15 @@ interface OmnigentCatalogGateReason {
   remediationHref: string;
 }
 
+interface OmnigentLaunchPolicyOption {
+  ref: string;
+  displayName: string;
+  hostMode: "static_compose" | "on_demand_docker";
+  isDefault: boolean;
+}
+
 interface OmnigentCodexCatalogReadiness {
-  schemaVersion: "moonmind.omnigent-codex-readiness.v1";
+  schemaVersion: "moonmind.omnigent-codex-readiness.v2";
   runtimeId: "omnigent";
   displayName: string;
   available: boolean;
@@ -616,7 +623,7 @@ interface OmnigentCodexCatalogReadiness {
     ref: string;
     displayName: string;
     available: boolean;
-    policyRefs: string[];
+    launchPolicies: OmnigentLaunchPolicyOption[];
     gateReasons: OmnigentCatalogGateReason[];
   }>;
   eligibleProviderProfiles: Array<{
@@ -1029,14 +1036,51 @@ interface PentestScopeDraftState {
 
 type StepType = "tool" | "skill" | "preset";
 
+type OmnigentAgentProfileVersionOption = {
+  version: number;
+  digest: string;
+  document?: {
+    execution?: {
+      defaultExecutionProfileRef?: string;
+      allowedLaunchPolicyRefs?: string[];
+    };
+    policyRef?: string;
+  };
+  validationResult?: { ready?: boolean } | null;
+};
+
 type OmnigentAgentProfileOption = {
   profileId: string;
   displayName: string;
   state: string;
   defaultForRuntime?: boolean;
   activeVersion?: number | null;
-  versions: Array<{ version: number; digest: string; validationResult?: { ready?: boolean } | null }>;
+  versions: OmnigentAgentProfileVersionOption[];
 };
+
+function resolveOmnigentLaunchPolicyOptions(
+  launchPolicies: OmnigentLaunchPolicyOption[],
+  agentProfileVersion: OmnigentAgentProfileVersionOption | undefined,
+): {
+  selectable: OmnigentLaunchPolicyOption[];
+  preferred: OmnigentLaunchPolicyOption | undefined;
+} {
+  const allowedPolicyRefs =
+    agentProfileVersion?.document?.execution?.allowedLaunchPolicyRefs || [];
+  const selectable = launchPolicies.filter(
+    (policy) =>
+      allowedPolicyRefs.length === 0 || allowedPolicyRefs.includes(policy.ref),
+  );
+  const preferredPolicyRefs = [
+    agentProfileVersion?.document?.policyRef,
+    ...allowedPolicyRefs,
+    launchPolicies.find((policy) => policy.isDefault)?.ref,
+  ].filter((ref): ref is string => Boolean(ref));
+  const preferred = preferredPolicyRefs
+    .map((ref) => selectable.find((policy) => policy.ref === ref))
+    .find(Boolean);
+  return { selectable, preferred };
+}
 
 const STEP_TYPE_HELP_TEXT: Record<StepType, string> = {
   skill: "Skill asks an agent to perform work using reusable behavior.",
@@ -6042,6 +6086,8 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
   const [omnigentLaunchPolicyRef, setOmnigentLaunchPolicyRef] = useState(
     String(omnigentProfiles[0]?.defaultPolicyRef || omnigentPolicies[0]?.ref || ""),
   );
+  const [omnigentLaunchPolicyAuthored, setOmnigentLaunchPolicyAuthored] =
+    useState(false);
   const [model, setModel] = useState(
     String(
       defaultTaskModelByRuntime[defaultRuntime] ||
@@ -6465,6 +6511,13 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
     const active = profile.versions.find((version) => version.version === profile.activeVersion);
     return profile.state === "active" && active?.validationResult?.ready === true;
   });
+  const selectedOmnigentAgentProfile = readyAgentProfiles.find(
+    (profile) => profile.profileId === agentProfile,
+  );
+  const selectedOmnigentAgentProfileVersion =
+    selectedOmnigentAgentProfile?.versions.find(
+      (version) => version.version === selectedOmnigentAgentProfile.activeVersion,
+    );
   useEffect(() => {
     if (runtime !== "omnigent" || agentProfile) return;
     const preferred = readyAgentProfiles.find((profile) => profile.defaultForRuntime) || readyAgentProfiles[0];
@@ -6511,6 +6564,41 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
       setOmnigentExecutionTargetRef(omnigentCatalogQuery.data.defaultExecutionProfileRef);
     }
   }, [runtime, omnigentCatalogQuery.data, omnigentExecutionTargetRef]);
+
+  useEffect(() => {
+    if (
+      runtime !== "omnigent" ||
+      pageMode.mode !== "create" ||
+      omnigentLaunchPolicyAuthored ||
+      !omnigentCatalogQuery.data
+    ) {
+      return;
+    }
+    const executionProfile = (
+      omnigentCatalogQuery.data.executionProfiles || []
+    ).find(
+      (profile) =>
+        profile.ref ===
+        (omnigentExecutionTargetRef ||
+          omnigentCatalogQuery.data.defaultExecutionProfileRef),
+    );
+    if (!executionProfile) return;
+    const { preferred: preferredPolicy } = resolveOmnigentLaunchPolicyOptions(
+      executionProfile.launchPolicies,
+      selectedOmnigentAgentProfileVersion,
+    );
+    if (preferredPolicy && preferredPolicy.ref !== omnigentLaunchPolicyRef) {
+      setOmnigentLaunchPolicyRef(preferredPolicy.ref);
+    }
+  }, [
+    omnigentCatalogQuery.data,
+    omnigentExecutionTargetRef,
+    omnigentLaunchPolicyAuthored,
+    omnigentLaunchPolicyRef,
+    pageMode.mode,
+    runtime,
+    selectedOmnigentAgentProfileVersion,
+  ]);
 
   useEffect(() => {
     const profiles = activeProviderProfiles;
@@ -6650,6 +6738,7 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
     }
     if (draft.omnigentLaunchPolicyRef) {
       setOmnigentLaunchPolicyRef(draft.omnigentLaunchPolicyRef);
+      setOmnigentLaunchPolicyAuthored(true);
     }
     if (draft.model) {
       setModel(draft.model);
@@ -8065,9 +8154,11 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
       (readiness) => readiness.ref === profile.ref && readiness.available,
     ),
   );
-  const selectableOmnigentPolicies = omnigentPolicies.filter((policy) =>
-    selectedOmnigentReadiness?.policyRefs.includes(String(policy.ref || "")),
-  );
+  const { selectable: selectableOmnigentPolicies } =
+    resolveOmnigentLaunchPolicyOptions(
+      selectedOmnigentReadiness?.launchPolicies || [],
+      selectedOmnigentAgentProfileVersion,
+    );
   const selectedEligibleOmnigentProfile = (omnigentCatalogQuery.data?.eligibleProviderProfiles || []).find(
     (profile) =>
       profile.profileId === providerProfile &&
@@ -8079,6 +8170,9 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
       profile.runtimeId === selectedOmnigentProviderRuntime,
   );
   const selectedOmnigentPolicyAvailable = selectableOmnigentPolicies.some(
+    (policy) => policy.ref === omnigentLaunchPolicyRef,
+  );
+  const selectedOmnigentLaunchPolicy = selectableOmnigentPolicies.find(
     (policy) => policy.ref === omnigentLaunchPolicyRef,
   );
   const omnigentSelectionGateReason =
@@ -9991,6 +10085,7 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
     setAttachmentTargetErrors({});
 
     const normalizedRuntime = runtime.trim().toLowerCase();
+    let submittedOmnigentLaunchPolicyRef = omnigentLaunchPolicyRef;
     const supportedAgentRuntimeIds = runtimeOptions.map((item) =>
       item.trim().toLowerCase(),
     );
@@ -10033,7 +10128,29 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
         clearSubmitBusy();
         return;
       }
-      if (!executionProfile.policyRefs.includes(omnigentLaunchPolicyRef)) {
+      const {
+        selectable: refreshedCompatiblePolicies,
+        preferred: refreshedPreferredPolicy,
+      } = resolveOmnigentLaunchPolicyOptions(
+        executionProfile.launchPolicies,
+        selectedOmnigentAgentProfileVersion,
+      );
+      if (
+        !refreshedCompatiblePolicies.some(
+          (policy) => policy.ref === submittedOmnigentLaunchPolicyRef,
+        ) &&
+        !omnigentLaunchPolicyAuthored
+      ) {
+        if (refreshedPreferredPolicy) {
+          submittedOmnigentLaunchPolicyRef = refreshedPreferredPolicy.ref;
+          setOmnigentLaunchPolicyRef(refreshedPreferredPolicy.ref);
+        }
+      }
+      if (
+        !refreshedCompatiblePolicies.some(
+          (policy) => policy.ref === submittedOmnigentLaunchPolicyRef,
+        )
+      ) {
         setSubmitMessage(
           "The selected Omnigent host policy is no longer compatible. Choose an available policy explicitly.",
         );
@@ -11142,8 +11259,8 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
           ? {
               omnigent: {
                 executionTargetRef: omnigentExecutionTargetRef,
-                ...(omnigentLaunchPolicyRef
-                  ? { launchPolicyRef: omnigentLaunchPolicyRef }
+                ...(submittedOmnigentLaunchPolicyRef
+                  ? { launchPolicyRef: submittedOmnigentLaunchPolicyRef }
                   : {}),
               },
             }
@@ -13592,6 +13709,7 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
                 onChange={(event) => {
                   const ref = event.target.value;
                   setOmnigentExecutionTargetRef(ref);
+                  setOmnigentLaunchPolicyAuthored(false);
                   const profile = omnigentProfiles.find((item) => item.ref === ref);
                   if (profile?.defaultPolicyRef) {
                     setOmnigentLaunchPolicyRef(profile.defaultPolicyRef);
@@ -13615,7 +13733,10 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
               <select
                 name="omnigentLaunchPolicyRef"
                 value={omnigentLaunchPolicyRef}
-                onChange={(event) => setOmnigentLaunchPolicyRef(event.target.value)}
+                onChange={(event) => {
+                  setOmnigentLaunchPolicyRef(event.target.value);
+                  setOmnigentLaunchPolicyAuthored(true);
+                }}
               >
                 {!selectableOmnigentPolicies.some((policy) => policy.ref === omnigentLaunchPolicyRef) && omnigentLaunchPolicyRef ? (
                   <option value={omnigentLaunchPolicyRef} disabled>
@@ -13624,7 +13745,8 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
                 ) : null}
                 {selectableOmnigentPolicies.map((policy) => (
                   <option key={policy.ref} value={policy.ref}>
-                    {policy.hostMode === "on_demand_docker" ? "On-demand Docker" : "Static Compose"}
+                    {policy.displayName}
+                    {policy.isDefault ? " (Default)" : ""}
                   </option>
                 ))}
               </select>
@@ -13642,7 +13764,7 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
             <div className="notice small" aria-label="Effective Omnigent selection">
               <div>Runtime: Codex via Omnigent</div>
               <div>Provider Profile: {providerOptions.find((option) => option.id === providerProfile)?.label || historicalOmnigentProviderProfile?.label || providerProfile || "Not selected"}</div>
-              <div>Host mode: {omnigentPolicies.find((policy) => policy.ref === omnigentLaunchPolicyRef)?.hostMode === "on_demand_docker" ? "On-demand Docker" : "Static Compose"}</div>
+              <div>Host mode: {selectedOmnigentLaunchPolicy?.hostMode === "on_demand_docker" ? "On-demand Docker" : selectedOmnigentLaunchPolicy?.hostMode === "static_compose" ? "Static Compose" : "Not selected"}</div>
               <div>Policy: {omnigentLaunchPolicyRef || "Not selected"}</div>
               <div>Repository: {repository.trim() || "Not selected"}</div>
             </div>

--- a/frontend/src/entrypoints/workflow-start.tsx
+++ b/frontend/src/entrypoints/workflow-start.tsx
@@ -6514,9 +6514,19 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
   const selectedOmnigentAgentProfile = readyAgentProfiles.find(
     (profile) => profile.profileId === agentProfile,
   );
+  const authoredOmnigentAgentProfileVersion =
+    remediationDraft?.agentProfile?.profileId === agentProfile
+      ? remediationDraft.agentProfile.version
+      : pageMode.mode !== "create" &&
+          temporalDraftQuery.data?.draft.agentProfile?.profileId === agentProfile
+        ? temporalDraftQuery.data.draft.agentProfile.version || undefined
+        : undefined;
   const selectedOmnigentAgentProfileVersion =
     selectedOmnigentAgentProfile?.versions.find(
-      (version) => version.version === selectedOmnigentAgentProfile.activeVersion,
+      (version) =>
+        version.version ===
+        (authoredOmnigentAgentProfileVersion ||
+          selectedOmnigentAgentProfile.activeVersion),
     );
   useEffect(() => {
     if (runtime !== "omnigent" || agentProfile) return;
@@ -6732,6 +6742,9 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
     if (draft.providerProfile) {
       prevProviderProfileRef.current = draft.providerProfile;
       setProviderProfile(draft.providerProfile);
+    }
+    if (draft.agentProfile?.profileId) {
+      setAgentProfile(draft.agentProfile.profileId);
     }
     if (draft.omnigentExecutionTargetRef) {
       setOmnigentExecutionTargetRef(draft.omnigentExecutionTargetRef);
@@ -11183,10 +11196,13 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
           ? {
               agentProfile: {
                 profileId: agentProfile,
-                ...(remediationDraft?.agentProfile?.profileId === agentProfile && remediationDraft.agentProfile.version
-                  ? { version: remediationDraft.agentProfile.version }
+                ...(authoredOmnigentAgentProfileVersion
+                  ? { version: authoredOmnigentAgentProfileVersion }
                   : {}),
                 providerProfileRef: providerProfile,
+                ...(submittedOmnigentLaunchPolicyRef
+                  ? { launchPolicyRef: submittedOmnigentLaunchPolicyRef }
+                  : {}),
               },
             }
           : {}),
@@ -11248,10 +11264,13 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
           ? {
               agentProfile: {
                 profileId: agentProfile,
-                ...(remediationDraft?.agentProfile?.profileId === agentProfile && remediationDraft.agentProfile.version
-                  ? { version: remediationDraft.agentProfile.version }
+                ...(authoredOmnigentAgentProfileVersion
+                  ? { version: authoredOmnigentAgentProfileVersion }
                   : {}),
                 providerProfileRef: providerProfile,
+                ...(submittedOmnigentLaunchPolicyRef
+                  ? { launchPolicyRef: submittedOmnigentLaunchPolicyRef }
+                  : {}),
               },
             }
           : {}),

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -8534,8 +8534,8 @@ export interface components {
             displayName: string;
             /** Available */
             available: boolean;
-            /** Policyrefs */
-            policyRefs: string[];
+            /** Launchpolicies */
+            launchPolicies: components["schemas"]["LaunchPolicyReadiness"][];
             /** Gatereasons */
             gateReasons: components["schemas"]["GateReason"][];
         };
@@ -9401,6 +9401,23 @@ export interface components {
             /** Id */
             id?: string | null;
         };
+        /** LaunchPolicyReadiness */
+        LaunchPolicyReadiness: {
+            /** Ref */
+            ref: string;
+            /** Displayname */
+            displayName: string;
+            /**
+             * Hostmode
+             * @enum {string}
+             */
+            hostMode: "static_compose" | "on_demand_docker";
+            /**
+             * Isdefault
+             * @default false
+             */
+            isDefault: boolean;
+        };
         /**
          * LinkArtifactRequest
          * @description Link an existing artifact to one execution reference.
@@ -9885,10 +9902,10 @@ export interface components {
         OmnigentCodexCatalogReadiness: {
             /**
              * Schemaversion
-             * @default moonmind.omnigent-codex-readiness.v1
+             * @default moonmind.omnigent-codex-readiness.v2
              * @constant
              */
-            schemaVersion: "moonmind.omnigent-codex-readiness.v1";
+            schemaVersion: "moonmind.omnigent-codex-readiness.v2";
             /**
              * Runtimeid
              * @default omnigent

--- a/frontend/src/lib/temporalTaskEditing.test.ts
+++ b/frontend/src/lib/temporalTaskEditing.test.ts
@@ -11,6 +11,10 @@ describe("MoonLadderStudios/MoonMind#3452 Omnigent draft round-trip", () => {
       inputParameters: {
         targetRuntime: "omnigent",
         profileId: "codex-oauth-team",
+        agentProfile: {
+          profileId: "team-codex",
+          version: 3,
+        },
         omnigent: {
           executionTargetRef: "omnigent-codex-default",
           launchPolicyRef: "omnigent-codex-on-demand-v1",
@@ -25,8 +29,39 @@ describe("MoonLadderStudios/MoonMind#3452 Omnigent draft round-trip", () => {
     expect(draft).toMatchObject({
       runtime: "omnigent",
       providerProfile: "codex-oauth-team",
+      agentProfile: {
+        profileId: "team-codex",
+        version: 3,
+      },
       omnigentExecutionTargetRef: "omnigent-codex-default",
       omnigentLaunchPolicyRef: "omnigent-codex-on-demand-v1",
+    });
+  });
+
+  it("reconstructs immutable agent-profile identity from the trusted snapshot", () => {
+    const draft = buildTemporalSubmissionDraftFromExecution({
+      workflowId: "mm:omnigent-rerun",
+      workflowType: "MoonMind.UserWorkflow",
+      targetRuntime: "omnigent",
+      inputParameters: {
+        agentProfileSnapshot: {
+          profileId: "managed-bootstrap",
+          version: 4,
+        },
+        omnigent: {
+          executionTargetRef: "omnigent-codex-default",
+          launchPolicyRef: "on-demand-v4",
+        },
+        workflow: {
+          instructions: "Rerun the historical selection.",
+          runtime: { mode: "omnigent" },
+        },
+      },
+    });
+
+    expect(draft.agentProfile).toEqual({
+      profileId: "managed-bootstrap",
+      version: 4,
     });
   });
 

--- a/frontend/src/lib/temporalTaskEditing.ts
+++ b/frontend/src/lib/temporalTaskEditing.ts
@@ -107,6 +107,10 @@ export type TemporalSubmissionDraftPresetPayload = {
 export type TemporalSubmissionDraft = {
   runtime: string | null;
   providerProfile: string | null;
+  agentProfile: {
+    profileId: string;
+    version: number | null;
+  } | null;
   omnigentExecutionTargetRef: string | null;
   omnigentLaunchPolicyRef: string | null;
   model: string | null;
@@ -898,6 +902,8 @@ export function buildTemporalSubmissionDraftFromExecution(
     : workflowRecord(artifactParams);
   const runtime = objectValue(task.runtime);
   const artifactRuntime = objectValue(artifactTask.runtime);
+  const agentProfile = objectValue(params.agentProfile);
+  const agentProfileSnapshot = objectValue(params.agentProfileSnapshot);
   const omnigent = objectValue(params.omnigent);
   const artifactOmnigent = objectValue(artifactParams.omnigent);
   const git = objectValue(task.git);
@@ -990,6 +996,21 @@ export function buildTemporalSubmissionDraftFromExecution(
       runtime.profileId,
       artifactRuntime.profileId,
     ),
+    agentProfile: (() => {
+      const profileId = nullableStringValue(
+        agentProfile.profileId,
+        agentProfileSnapshot.profileId,
+      );
+      return profileId
+        ? {
+            profileId,
+            version: positiveIntegerValue(
+              agentProfile.version,
+              agentProfileSnapshot.version,
+            ),
+          }
+        : null;
+    })(),
     omnigentExecutionTargetRef: nullableStringValue(
       snapshotDraft.omnigentExecutionTargetRef,
       omnigent.executionTargetRef,

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -4378,9 +4378,10 @@ def test_create_execution_keeps_resolved_agent_profile_out_of_authored_omnigent(
         },
     }
 
+    profile_resolver = AsyncMock(return_value=snapshot)
     with patch(
         "api_service.api.routers.executions.resolve_agent_profile_snapshot",
-        new=AsyncMock(return_value=snapshot),
+        new=profile_resolver,
     ):
         response = test_client.post(
             "/api/executions",
@@ -4405,6 +4406,11 @@ def test_create_execution_keeps_resolved_agent_profile_out_of_authored_omnigent(
         )
 
     assert response.status_code == 201, response.text
+    assert profile_resolver.await_args.kwargs["selection"] == {
+        "profileId": "omnigent-bootstrap-default",
+        "providerProfileRef": "codex-openai-oauth",
+        "launchPolicyRef": "codex-on-demand@1",
+    }
     initial_parameters = service.create_execution.await_args.kwargs[
         "initial_parameters"
     ]

--- a/tests/unit/api/routers/test_omnigent_catalog.py
+++ b/tests/unit/api/routers/test_omnigent_catalog.py
@@ -182,7 +182,7 @@ def test_first_run_canary_rejects_an_untrusted_header(monkeypatch):
     assert "acceptance_evidence_unavailable" in {
         reason["code"] for reason in body["supportGateReasons"]
     }
-    assert body["schemaVersion"] == "moonmind.omnigent-codex-readiness.v1"
+    assert body["schemaVersion"] == "moonmind.omnigent-codex-readiness.v2"
     assert body["available"] is True
     assert body["cutover"] == {
         "policyVersion": "moonmind.codex-omnigent-cutover/v1",
@@ -427,9 +427,11 @@ def test_catalog_rejects_placeholder_image_digests(monkeypatch):
 def test_resolved_persisted_policy_keeps_latest_from_being_a_launch_blocker(
     monkeypatch,
 ):
-    identity = SimpleNamespace(policy_id="codex-on-demand")
+    identity = SimpleNamespace(
+        policy_id="codex-on-demand", name="On-demand Docker"
+    )
     version = SimpleNamespace(
-        version=1,
+        version=2,
         state="active",
         validation_json={"valid": True},
         document_json={
@@ -463,7 +465,14 @@ def test_resolved_persisted_policy_keeps_latest_from_being_a_launch_blocker(
         for profile in body["executionProfiles"]
         if profile["ref"] == "omnigent-codex@1"
     )
-    assert "codex-on-demand@1" in codex_profile["policyRefs"]
+    assert codex_profile["launchPolicies"] == [
+        {
+            "ref": "codex-on-demand@2",
+            "displayName": "On-demand Docker",
+            "hostMode": "on_demand_docker",
+            "isDefault": True,
+        }
+    ]
     assert "immutable_image_unavailable" not in {
         reason["code"] for reason in body["gateReasons"]
     }

--- a/tests/unit/api/routers/test_omnigent_catalog.py
+++ b/tests/unit/api/routers/test_omnigent_catalog.py
@@ -428,7 +428,11 @@ def test_resolved_persisted_policy_keeps_latest_from_being_a_launch_blocker(
     monkeypatch,
 ):
     identity = SimpleNamespace(
-        policy_id="codex-on-demand", name="On-demand Docker"
+        policy_id="codex-on-demand",
+        name="On-demand Docker",
+        default_version=2,
+        visibility="deployment",
+        owner_user_id=None,
     )
     version = SimpleNamespace(
         version=2,
@@ -476,6 +480,100 @@ def test_resolved_persisted_policy_keeps_latest_from_being_a_launch_blocker(
     assert "immutable_image_unavailable" not in {
         reason["code"] for reason in body["gateReasons"]
     }
+
+
+def test_catalog_retains_all_ready_active_policy_versions(monkeypatch):
+    identity = SimpleNamespace(
+        policy_id="codex-on-demand",
+        name="On-demand Docker",
+        default_version=2,
+        visibility="deployment",
+        owner_user_id=None,
+    )
+
+    def version(number):
+        return SimpleNamespace(
+            version=number,
+            state="active",
+            validation_json={"valid": True},
+            document_json={
+                "execution": {"profileRef": "omnigent-codex@1"},
+                "host": {
+                    "mode": "on_demand_docker",
+                    "serverImageRef": "registry.test/server@sha256:" + "1" * 64,
+                    "hostImageRef": "registry.test/host@sha256:" + "2" * 64,
+                },
+                "network": {
+                    "attachmentRef": OMNIGENT_EGRESS_NETWORK_REF,
+                    "egressProfileRef": OMNIGENT_EGRESS_PROFILE.ref,
+                },
+            },
+        )
+
+    body = TestClient(_app(
+        monkeypatch,
+        session=_Session(
+            [_profile()],
+            policies=[(identity, version(1)), (identity, version(2))],
+        ),
+    )).get("/api/omnigent/codex-catalog-readiness").json()
+
+    codex_profile = next(
+        profile
+        for profile in body["executionProfiles"]
+        if profile["ref"] == "omnigent-codex@1"
+    )
+    assert [
+        (policy["ref"], policy["isDefault"])
+        for policy in codex_profile["launchPolicies"]
+    ] == [
+        ("codex-on-demand@2", True),
+        ("codex-on-demand@1", False),
+    ]
+
+
+def test_catalog_filters_persisted_policies_not_visible_to_caller(monkeypatch):
+    hidden_name = "Private policy name must not escape"
+    identity = SimpleNamespace(
+        policy_id="codex-private",
+        name=hidden_name,
+        default_version=1,
+        visibility="private",
+        owner_user_id="other-user",
+    )
+    version = SimpleNamespace(
+        version=1,
+        state="active",
+        validation_json={"valid": True},
+        document_json={
+            "execution": {"profileRef": "omnigent-codex@1"},
+            "host": {
+                "mode": "on_demand_docker",
+                "serverImageRef": "registry.test/server@sha256:" + "1" * 64,
+                "hostImageRef": "registry.test/host@sha256:" + "2" * 64,
+            },
+            "network": {
+                "attachmentRef": OMNIGENT_EGRESS_NETWORK_REF,
+                "egressProfileRef": OMNIGENT_EGRESS_PROFILE.ref,
+            },
+        },
+    )
+    app = _app(
+        monkeypatch,
+        session=_Session([_profile()], policies=[(identity, version)]),
+    )
+    app.dependency_overrides[get_current_user()] = lambda: SimpleNamespace(
+        id="current-user", is_superuser=False
+    )
+    monkeypatch.setattr(
+        catalog, "_require_provider_profile_permission", lambda *_: None
+    )
+
+    response = TestClient(app).get("/api/omnigent/codex-catalog-readiness")
+
+    assert response.status_code == 200
+    assert "codex-private@1" not in response.text
+    assert hidden_name not in response.text
 
 
 def test_catalog_filters_profiles_not_visible_to_caller(monkeypatch):


### PR DESCRIPTION
## Summary

- expose active versioned Omnigent launch policies and their default metadata through readiness
- automatically reconcile unauthored Workflow Create defaults to the active compatible policy
- preserve explicit host-policy choices and rerun authority
- document on-demand hosting as the zero-configuration default after OAuth finalization

## Root cause

Workflow Create initialized `codex-on-demand@1` from the bootstrap catalog while the live readiness and active agent profile advertised `codex-on-demand@2`. Readiness exposed only bare refs, so the UI could neither render nor adopt the active version and blocked submission with “Choose a compatible Omnigent host policy.”

## Validation

- `./tools/test_unit.sh --python-only tests/unit/api/routers/test_omnigent_catalog.py` — 24 passed
- `TZ=UTC npm run ui:test -- frontend/src/entrypoints/workflow-start.test.tsx` — 121 passed
- `npm run ui:typecheck`
- targeted ESLint for Workflow Create source and tests
- deterministic OpenAPI type regeneration