### PR TITLE
Fix Omnigent terminal retry authority

### DIFF
--- a/moonmind/omnigent/bridge_store.py
+++ b/moonmind/omnigent/bridge_store.py
@@ -42,6 +42,7 @@ FIRST_MESSAGE_PREPARED = "prepared"
 FIRST_MESSAGE_POSTING = "posting"
 FIRST_MESSAGE_POSTED = "posted"
 FIRST_MESSAGE_TERMINAL = "terminal"
+FIRST_MESSAGE_ITEM_FRONTIER_KEY = "first_message_pre_dispatch_item_ids"
 
 # MM-1155 (source: MM-1140): durable bridge event journal carried on the
 # canonical bridge session row metadata. ``session.created`` (OmnigentBridge.md
@@ -1687,6 +1688,53 @@ class OmnigentBridgeSessionStore:
                 )
             await session.commit()
             await session.refresh(row)
+            return _detached(session, row)
+
+    async def record_first_message_item_frontier(
+        self,
+        idempotency_key: str,
+        *,
+        item_ids: Sequence[str],
+    ) -> OmnigentBridgeSession:
+        """Persist the bounded pre-dispatch item frontier exactly once."""
+
+        normalized = sorted(
+            {
+                str(item_id).strip()
+                for item_id in item_ids
+                if str(item_id).strip()
+            }
+        )
+        if len(normalized) > 256:
+            raise ValueError("pre-dispatch item frontier exceeds 256 items")
+        if any(len(item_id) > 255 for item_id in normalized):
+            raise ValueError(
+                "pre-dispatch item frontier contains an oversized item id"
+            )
+        if len(json.dumps(normalized).encode("utf-8")) > 32_768:
+            raise ValueError("pre-dispatch item frontier exceeds the 32 KiB limit")
+
+        async with self._session_factory() as session:
+            row = await self._require(session, idempotency_key)
+            metadata = dict(row.metadata_ or {})
+            existing = metadata.get(FIRST_MESSAGE_ITEM_FRONTIER_KEY)
+            if existing is not None:
+                if existing != normalized:
+                    raise OmnigentIdempotencyError(
+                        "pre-dispatch item frontier changed after persistence"
+                    )
+            else:
+                if row.first_message_state not in {
+                    FIRST_MESSAGE_NOT_PREPARED,
+                    FIRST_MESSAGE_PREPARED,
+                }:
+                    raise OmnigentIdempotencyError(
+                        "pre-dispatch item frontier cannot be recorded after posting"
+                    )
+                metadata[FIRST_MESSAGE_ITEM_FRONTIER_KEY] = normalized
+                row.metadata_ = metadata
+                await session.commit()
+                await session.refresh(row)
             return _detached(session, row)
 
     async def record_initial_context(

--- a/moonmind/omnigent/execute.py
+++ b/moonmind/omnigent/execute.py
@@ -93,6 +93,8 @@ _ACTIVITY_HEARTBEAT_STATE: ContextVar[dict[str, Any] | None] = ContextVar(
 class OmnigentSessionStillRunningError(OmnigentClientError):
     """Raised when the stream ends while the provider session is still active."""
 
+    code = "OMNIGENT_CURRENT_TURN_TERMINAL_AMBIGUOUS"
+
 
 def _session_id(payload: dict[str, Any]) -> str:
     raw = payload.get("id") or payload.get("session_id") or payload.get("sessionId")
@@ -497,65 +499,62 @@ def _snapshot_contains_current_turn_progress(
     snapshot: Mapping[str, Any],
     *,
     marker: str,
+    baseline_item_ids: frozenset[str] | None = None,
 ) -> bool:
     """Prove provider work occurred after this invocation's marked message.
 
     Omnigent can replay the previous turn's terminal SSE event when a stream is
-    opened before posting the next message. The per-message marker is durable in
-    the user item, so item ordering—not a stale session status—authoritatively
-    distinguishes current-turn progress from the preceding turn.
+    opened before posting the next message. Prefer the per-message marker; when
+    the bounded stock snapshot has evicted that marker, item identities captured
+    immediately before dispatch preserve the same ordering boundary.
     """
 
+    return bool(
+        _marked_turn_item_state(
+            snapshot,
+            marker=marker,
+            baseline_item_ids=baseline_item_ids,
+        )["progress"]
+    )
+
+
+def _snapshot_item_ids(snapshot: Mapping[str, Any] | None) -> frozenset[str] | None:
+    """Capture the bounded item identity frontier before dispatching a turn."""
+
+    if not isinstance(snapshot, Mapping):
+        return None
     raw_items = snapshot.get("items")
     if not isinstance(raw_items, list):
-        return False
-    marked_message_index = -1
-    for index, raw_item in enumerate(raw_items):
-        if not isinstance(raw_item, Mapping):
-            continue
-        if str(raw_item.get("type") or "").strip() != "message":
-            continue
-        data = raw_item.get("data")
-        item_data = data if isinstance(data, Mapping) else {}
-        if str(item_data.get("role") or "").strip().lower() != "user":
-            continue
-        if _nested_value_contains_text(raw_item, needle=marker):
-            marked_message_index = index
-    if marked_message_index < 0:
-        return False
-    for raw_item in raw_items[marked_message_index + 1 :]:
-        if not isinstance(raw_item, Mapping):
-            continue
-        item_type = str(raw_item.get("type") or "").strip()
-        if item_type in {"function_call", "function_call_output"}:
-            return True
-        if item_type != "message":
-            continue
-        data = raw_item.get("data")
-        item_data = data if isinstance(data, Mapping) else {}
-        if str(item_data.get("role") or "").strip().lower() == "assistant":
-            return True
-    return False
+        return None
+    return frozenset(
+        item_id
+        for raw_item in raw_items
+        if isinstance(raw_item, Mapping)
+        if (item_id := str(raw_item.get("id") or "").strip())
+    )
 
 
 def _marked_turn_item_state(
     snapshot: Mapping[str, Any],
     *,
     marker: str,
+    baseline_item_ids: frozenset[str] | None = None,
 ) -> dict[str, Any]:
     """Summarize ordered completion evidence after one marked user item.
 
     Native Codex can accept a new message as a steer while the preceding turn
     is still producing tools. Those items share the same session response id,
-    so the completion boundary must come from item ordering: a textual
-    assistant after the last tool is terminal, while an unmatched tool call is
-    still active regardless of the stock server's stale ``idle`` projection.
+    so the completion boundary must come from item ordering: the marker when it
+    remains projected, otherwise item IDs absent from the pre-dispatch snapshot.
+    A textual assistant after the last tool is terminal, while an unmatched tool
+    call is still active regardless of the stock server's stale ``idle`` state.
     """
 
     raw_items = snapshot.get("items")
     if not isinstance(raw_items, list):
         return {
             "markerIndex": -1,
+            "boundarySource": None,
             "progress": False,
             "terminalAssistantAfterWork": False,
             "unfinishedToolCall": False,
@@ -575,9 +574,28 @@ def _marked_turn_item_state(
         if _nested_value_contains_text(raw_item, needle=marker):
             marked_message_index = index
 
-    if marked_message_index < 0:
+    progress_start_index: int | None = (
+        marked_message_index + 1 if marked_message_index >= 0 else None
+    )
+    boundary_source = "marker" if progress_start_index is not None else None
+    if progress_start_index is None and baseline_item_ids is not None:
+        progress_start_index = next(
+            (
+                index
+                for index, raw_item in enumerate(raw_items)
+                if isinstance(raw_item, Mapping)
+                and (item_id := str(raw_item.get("id") or "").strip())
+                and item_id not in baseline_item_ids
+            ),
+            None,
+        )
+        if progress_start_index is not None:
+            boundary_source = "pre_dispatch_item_ids"
+
+    if progress_start_index is None:
         return {
             "markerIndex": -1,
+            "boundarySource": None,
             "progress": False,
             "terminalAssistantAfterWork": False,
             "unfinishedToolCall": False,
@@ -590,8 +608,8 @@ def _marked_turn_item_state(
     pending_call_ids: set[str] = set()
     anonymous_pending_calls = 0
     for index, raw_item in enumerate(
-        raw_items[marked_message_index + 1 :],
-        start=marked_message_index + 1,
+        raw_items[progress_start_index:],
+        start=progress_start_index,
     ):
         if not isinstance(raw_item, Mapping):
             continue
@@ -643,9 +661,11 @@ def _marked_turn_item_state(
     )
     return {
         "markerIndex": marked_message_index,
+        "boundarySource": boundary_source,
         "progress": progress,
         "terminalAssistantAfterWork": (
-            last_text_assistant_index > max(marked_message_index, last_tool_index)
+            last_text_assistant_index
+            > max(progress_start_index - 1, last_tool_index)
         ),
         "unfinishedToolCall": bool(pending_call_ids or anonymous_pending_calls),
         "signature": signature,
@@ -675,6 +695,7 @@ def _snapshot_confirms_current_turn_terminal(
     snapshot: Mapping[str, Any],
     *,
     marker: str,
+    baseline_item_ids: frozenset[str] | None = None,
 ) -> bool:
     """Identify a structurally terminal assistant candidate for a marked turn.
 
@@ -685,7 +706,11 @@ def _snapshot_confirms_current_turn_terminal(
     assistant preamble can be followed by a tool that has not appeared yet.
     """
 
-    state = _marked_turn_item_state(snapshot, marker=marker)
+    state = _marked_turn_item_state(
+        snapshot,
+        marker=marker,
+        baseline_item_ids=baseline_item_ids,
+    )
     return bool(
         state["progress"]
         and state["terminalAssistantAfterWork"]
@@ -806,6 +831,7 @@ async def _await_marked_turn_terminal(
     client: OmnigentHttpClient,
     session_id: str,
     marker: str,
+    baseline_item_ids: frozenset[str] | None = None,
     event_count: int,
     terminal_status: str,
     timeout_seconds: float = 1800.0,
@@ -832,7 +858,11 @@ async def _await_marked_turn_terminal(
     while loop.time() < deadline:
         snapshot = await client.get_session(session_id)
         normalized = normalize_omnigent_observation(snapshot)
-        turn_state = _marked_turn_item_state(snapshot, marker=marker)
+        turn_state = _marked_turn_item_state(
+            snapshot,
+            marker=marker,
+            baseline_item_ids=baseline_item_ids,
+        )
         progress = bool(turn_state["progress"])
         if not isinstance(snapshot.get("items"), list) and normalized in {
             "completed",
@@ -850,7 +880,7 @@ async def _await_marked_turn_terminal(
             ), snapshot
         if (
             normalized in {"failed", "canceled", "timed_out"}
-            and turn_state["markerIndex"] >= 0
+            and turn_state["boundarySource"] is not None
             and progress
         ):
             # A marked provider failure is stronger than a replayed successful
@@ -901,6 +931,7 @@ async def _await_marked_turn_terminal(
                 "firstMessagePosted": True,
                 "terminalSnapshotPolling": True,
                 "currentTurnProgress": progress,
+                "currentTurnBoundarySource": turn_state["boundarySource"],
                 "terminalAssistantAfterWork": bool(
                     turn_state["terminalAssistantAfterWork"]
                 ),
@@ -1156,6 +1187,7 @@ async def run_omnigent_execution(
     first_message_posted = False
     first_message_response_identifiers: dict[str, str] = {}
     initial_snapshot: dict[str, Any] | None = None
+    pre_dispatch_item_ids: frozenset[str] | None = None
     raw_events: list[dict[str, Any]] = []
     normalized_events: list[dict[str, Any]] = []
     event_diagnostics: list[dict[str, Any]] = []
@@ -1358,6 +1390,7 @@ async def run_omnigent_execution(
                 )
             with suppress(Exception):
                 initial_snapshot = await client.get_session(session_id)
+            pre_dispatch_item_ids = _snapshot_item_ids(initial_snapshot)
 
             if first_message_text is not None:
                 first_message = {
@@ -1749,6 +1782,7 @@ async def run_omnigent_execution(
                             _snapshot_confirms_current_turn_terminal(
                                 terminal_snapshot,
                                 marker=marker,
+                                baseline_item_ids=pre_dispatch_item_ids,
                             )
                         )
                         if arrived_after_message_post and not current_turn_progress:
@@ -1767,6 +1801,7 @@ async def run_omnigent_execution(
                                         _snapshot_confirms_current_turn_terminal(
                                             terminal_snapshot,
                                             marker=marker,
+                                            baseline_item_ids=pre_dispatch_item_ids,
                                         )
                                     )
                                     if current_turn_progress:
@@ -1784,6 +1819,7 @@ async def run_omnigent_execution(
                             client=client,
                             session_id=session_id,
                             marker=marker,
+                            baseline_item_ids=pre_dispatch_item_ids,
                             event_count=event_count["value"],
                             terminal_status=normalized,
                         )
@@ -1817,6 +1853,7 @@ async def run_omnigent_execution(
                         _snapshot_contains_current_turn_progress(
                             final_snapshot,
                             marker=marker,
+                            baseline_item_ids=pre_dispatch_item_ids,
                         )
                     ):
                         raise OmnigentSessionStillRunningError(

--- a/moonmind/omnigent/execute.py
+++ b/moonmind/omnigent/execute.py
@@ -38,6 +38,7 @@ from moonmind.omnigent.bridge_security import (
     redact_raw_events,
 )
 from moonmind.omnigent.bridge_store import (
+    FIRST_MESSAGE_ITEM_FRONTIER_KEY,
     FIRST_MESSAGE_NOT_PREPARED,
     FIRST_MESSAGE_POSTED,
     FIRST_MESSAGE_POSTING,
@@ -531,6 +532,33 @@ def _snapshot_item_ids(snapshot: Mapping[str, Any] | None) -> frozenset[str] | N
         for raw_item in raw_items
         if isinstance(raw_item, Mapping)
         if (item_id := str(raw_item.get("id") or "").strip())
+    )
+
+
+def _validated_pre_dispatch_item_ids(raw_item_ids: Any) -> frozenset[str]:
+    """Validate one bounded persisted or heartbeat item frontier."""
+
+    if not isinstance(raw_item_ids, list):
+        raise OmnigentContractError("Persisted pre-dispatch item frontier is invalid")
+    item_ids = frozenset(
+        str(item_id).strip() for item_id in raw_item_ids if str(item_id).strip()
+    )
+    if len(item_ids) != len(raw_item_ids):
+        raise OmnigentContractError("Persisted pre-dispatch item frontier is invalid")
+    return item_ids
+
+
+def _persisted_pre_dispatch_item_ids(durable_row: Any) -> frozenset[str] | None:
+    """Restore the exact item frontier recorded before the message side effect."""
+
+    metadata = getattr(durable_row, "metadata_", None)
+    if (
+        not isinstance(metadata, Mapping)
+        or FIRST_MESSAGE_ITEM_FRONTIER_KEY not in metadata
+    ):
+        return None
+    return _validated_pre_dispatch_item_ids(
+        metadata[FIRST_MESSAGE_ITEM_FRONTIER_KEY]
     )
 
 
@@ -1290,6 +1318,27 @@ async def run_omnigent_execution(
                 )
 
             retry_state = _heartbeat_state()
+            heartbeat_pre_dispatch_item_ids = (
+                _validated_pre_dispatch_item_ids(retry_state["preDispatchItemIds"])
+                if "preDispatchItemIds" in retry_state
+                else None
+            )
+            durable_pre_dispatch_item_ids = _persisted_pre_dispatch_item_ids(
+                durable_row
+            )
+            if (
+                heartbeat_pre_dispatch_item_ids is not None
+                and durable_pre_dispatch_item_ids is not None
+                and heartbeat_pre_dispatch_item_ids != durable_pre_dispatch_item_ids
+            ):
+                raise OmnigentContractError(
+                    "Omnigent retry item frontier conflicts with durable state"
+                )
+            pre_dispatch_item_ids = (
+                durable_pre_dispatch_item_ids
+                if durable_pre_dispatch_item_ids is not None
+                else heartbeat_pre_dispatch_item_ids
+            )
             durable_session_id = str(
                 getattr(durable_row, "omnigent_session_id", None) or ""
             ).strip()
@@ -1390,7 +1439,34 @@ async def run_omnigent_execution(
                 )
             with suppress(Exception):
                 initial_snapshot = await client.get_session(session_id)
-            pre_dispatch_item_ids = _snapshot_item_ids(initial_snapshot)
+            if (
+                pre_dispatch_item_ids is None
+                and not first_message_posted
+                and not first_message_reconcile_required
+            ):
+                pre_dispatch_item_ids = _snapshot_item_ids(initial_snapshot)
+                if pre_dispatch_item_ids is not None and run_store is not None:
+                    record_frontier = getattr(
+                        run_store, "record_first_message_item_frontier", None
+                    )
+                    if callable(record_frontier):
+                        durable_row = await record_frontier(
+                            request.idempotency_key,
+                            item_ids=sorted(pre_dispatch_item_ids),
+                        )
+                        persisted_frontier = _persisted_pre_dispatch_item_ids(
+                            durable_row
+                        )
+                        if persisted_frontier is not None:
+                            pre_dispatch_item_ids = persisted_frontier
+            if pre_dispatch_item_ids is not None:
+                _safe_heartbeat(
+                    {
+                        "omnigentSessionId": session_id,
+                        "firstMessagePosted": first_message_posted,
+                        "preDispatchItemIds": sorted(pre_dispatch_item_ids),
+                    }
+                )
 
             if first_message_text is not None:
                 first_message = {
@@ -1849,18 +1925,29 @@ async def run_omnigent_execution(
                     "canceled",
                     "timed_out",
                 }:
-                    if isinstance(final_snapshot.get("items"), list) and not (
-                        _snapshot_contains_current_turn_progress(
+                    if isinstance(final_snapshot.get("items"), list):
+                        turn_state = _marked_turn_item_state(
                             final_snapshot,
                             marker=marker,
                             baseline_item_ids=pre_dispatch_item_ids,
                         )
-                    ):
-                        raise OmnigentSessionStillRunningError(
-                            "Omnigent stream ended before the current marked turn "
-                            "produced provider work"
+                        if not turn_state["progress"]:
+                            raise OmnigentSessionStillRunningError(
+                                "Omnigent stream ended before the current marked turn "
+                                "produced provider work"
+                            )
+                        terminal_status, final_snapshot = (
+                            await _await_marked_turn_terminal(
+                                client=client,
+                                session_id=session_id,
+                                marker=marker,
+                                baseline_item_ids=pre_dispatch_item_ids,
+                                event_count=event_count["value"],
+                                terminal_status=normalized_snapshot,
+                            )
                         )
-                    terminal_status = normalized_snapshot
+                    else:
+                        terminal_status = normalized_snapshot
                     # The stream ended without emitting a terminal event but the
                     # final snapshot is terminal. Append an indexed terminal event
                     # derived from the snapshot so the durable event index records

--- a/moonmind/omnigent/profile_bound_execution.py
+++ b/moonmind/omnigent/profile_bound_execution.py
@@ -33,6 +33,7 @@ from moonmind.omnigent.checkpoints import (
     recovery_mode,
     validate_cold_restore_target,
 )
+from moonmind.omnigent.execute import OmnigentSessionStillRunningError
 from moonmind.omnigent.oauth_host_runtime import OmnigentOAuthHostRuntime
 from moonmind.omnigent.remediation_workspace import (
     RemediationWorkspaceBinding,
@@ -742,7 +743,7 @@ class OmnigentProfileBoundExecutionCoordinator:
         remediation_resolution: Mapping[str, Any] | None = None
         workspace_locator_payload: Mapping[str, Any] | None = None
         terminal_status = "completed"
-        attempt_cancelled = False
+        attempt_cleanup_deferred_code: str | None = None
         # Bounded, credential-free evidence accumulated across the run so the
         # unified authority chain (MoonLadderStudios/MoonMind#3561) can be emitted
         # once at terminal, covering both success and every failure path.
@@ -1726,7 +1727,10 @@ class OmnigentProfileBoundExecutionCoordinator:
                 )
             return result
         except (Exception, asyncio.CancelledError) as exc:
-            attempt_cancelled = isinstance(exc, asyncio.CancelledError)
+            if isinstance(exc, asyncio.CancelledError):
+                attempt_cleanup_deferred_code = "activity_cancelled"
+            elif isinstance(exc, OmnigentSessionStillRunningError):
+                attempt_cleanup_deferred_code = "ambiguous_terminal_state"
             terminal_status = "failed"
             if bridge_ready:
                 code, failure_class, remediation = _failure_evidence(exc)
@@ -1782,16 +1786,16 @@ class OmnigentProfileBoundExecutionCoordinator:
         finally:
             safe_to_release_provider = host_lease is None
             if host_lease is not None and binding is not None:
-                if attempt_cancelled:
-                    # A Temporal timeout can schedule the retry before the
-                    # canceled coroutine finishes. Leave the deterministic host
-                    # and credential lease for that retry (or the janitor) so an
-                    # old attempt cannot stop/remove the new attempt's host.
+                if attempt_cleanup_deferred_code is not None:
+                    # A Temporal timeout or ambiguous terminal observation can
+                    # schedule a retry against the same durable bridge. Leave the
+                    # deterministic host and credential lease for that retry (or
+                    # the janitor) so the retry cannot be redirected to a new host.
                     authority_cleanup_mode = "retry_or_janitor_reconciliation"
                     authority_reasons.append(
                         {
                             "stage": "host_cleanup",
-                            "code": "activity_cancelled",
+                            "code": attempt_cleanup_deferred_code,
                             "failureClass": "system_error",
                             "remediationAction": "retry_or_reconcile_stale_host",
                         }
@@ -1799,7 +1803,7 @@ class OmnigentProfileBoundExecutionCoordinator:
                     await emit(
                         "host_cleanup",
                         "waiting",
-                        code="activity_cancelled",
+                        code=attempt_cleanup_deferred_code,
                         remediation_action="retry_or_reconcile_stale_host",
                         metadata={
                             "cleanupCompleted": False,

--- a/tests/integration/reliability/replays/omnigent-evicted-turn-marker-retry-authority/expected-outcome.json
+++ b/tests/integration/reliability/replays/omnigent-evicted-turn-marker-retry-authority/expected-outcome.json
@@ -1,0 +1,7 @@
+{
+  "acceptCurrentTurnProgress": true,
+  "acceptCurrentTurnTerminal": true,
+  "terminalBoundarySource": "pre_dispatch_item_ids",
+  "ambiguousCleanupCode": "ambiguous_terminal_state",
+  "retryAuthority": "same_host_profile_and_bridge"
+}

--- a/tests/integration/reliability/replays/omnigent-evicted-turn-marker-retry-authority/expected-outcome.json
+++ b/tests/integration/reliability/replays/omnigent-evicted-turn-marker-retry-authority/expected-outcome.json
@@ -1,6 +1,7 @@
 {
   "acceptCurrentTurnProgress": true,
   "acceptCurrentTurnTerminal": true,
+  "frontierAuthority": "durable_bridge_metadata",
   "terminalBoundarySource": "pre_dispatch_item_ids",
   "ambiguousCleanupCode": "ambiguous_terminal_state",
   "retryAuthority": "same_host_profile_and_bridge"

--- a/tests/integration/reliability/replays/omnigent-evicted-turn-marker-retry-authority/manifest.json
+++ b/tests/integration/reliability/replays/omnigent-evicted-turn-marker-retry-authority/manifest.json
@@ -6,7 +6,7 @@
   "activityType": "integration.omnigent.profile_bound_execute",
   "failureShape": "a long continuation evicted its marked user item from the stock 100-item snapshot; MoonMind ignored the completed current response, timed out terminal polling, removed the durable on-demand host, and the Temporal retry was rejected when it tried to bind the immutable bridge to a replacement host",
   "stockSnapshotItemLimit": 100,
-  "sessionId": "8aea8cc0feb544d0ab360294dae4d01f",
+  "sessionId": "synthetic-evicted-marker-session",
   "currentTurnMarker": "MoonMind-Omnigent-Run: repository-continuation:1",
   "preDispatchSnapshot": {
     "status": "idle",

--- a/tests/integration/reliability/replays/omnigent-evicted-turn-marker-retry-authority/manifest.json
+++ b/tests/integration/reliability/replays/omnigent-evicted-turn-marker-retry-authority/manifest.json
@@ -1,0 +1,32 @@
+{
+  "schemaVersion": "moonmind.reliability-replay.v1",
+  "replayId": "omnigent-evicted-turn-marker-retry-authority",
+  "incidentWorkflowId": "mm:d41f834c-c276-4fc1-ac83-9740ed3ba88e",
+  "failedChildWorkflowId": "mm:d41f834c-c276-4fc1-ac83-9740ed3ba88e:agent:tpl:github-issue-implement:02:00d88605",
+  "activityType": "integration.omnigent.profile_bound_execute",
+  "failureShape": "a long continuation evicted its marked user item from the stock 100-item snapshot; MoonMind ignored the completed current response, timed out terminal polling, removed the durable on-demand host, and the Temporal retry was rejected when it tried to bind the immutable bridge to a replacement host",
+  "stockSnapshotItemLimit": 100,
+  "sessionId": "8aea8cc0feb544d0ab360294dae4d01f",
+  "currentTurnMarker": "MoonMind-Omnigent-Run: repository-continuation:1",
+  "preDispatchSnapshot": {
+    "status": "idle",
+    "active_response_id": null,
+    "items": [
+      {"id": "prior-item-98", "type": "function_call_output", "data": {"call_id": "prior-call-98"}},
+      {"id": "prior-assistant-99", "type": "message", "data": {"role": "assistant", "content": [{"type": "output_text", "text": "Earlier turn complete"}]}}
+    ]
+  },
+  "observedProviderEvents": [
+    {"type": "response.in_progress", "response_id": "response-current"},
+    {"type": "response.completed", "response_id": "response-current"}
+  ],
+  "terminalSnapshot": {
+    "status": "idle",
+    "active_response_id": null,
+    "items": [
+      {"id": "current-call", "type": "function_call", "data": {"call_id": "current-call"}},
+      {"id": "current-output", "type": "function_call_output", "data": {"call_id": "current-call"}},
+      {"id": "current-assistant", "type": "message", "data": {"role": "assistant", "content": [{"type": "output_text", "text": "Continuation complete"}]}}
+    ]
+  }
+}

--- a/tests/integration/reliability/test_escaped_failure_journeys.py
+++ b/tests/integration/reliability/test_escaped_failure_journeys.py
@@ -24,11 +24,15 @@ from api_service.db.models import Base
 from api_service.services.omnigent_policies import bootstrap_document
 from moonmind.omnigent import oauth_host_runtime as oauth_host_runtime_module
 from moonmind.omnigent.bridge_events import build_omnigent_bridge_event
-from moonmind.omnigent.bridge_store import OmnigentBridgeSessionStore
+from moonmind.omnigent.bridge_store import (
+    FIRST_MESSAGE_ITEM_FRONTIER_KEY,
+    OmnigentBridgeSessionStore,
+)
 from moonmind.omnigent.execute import (
     OmnigentSessionStillRunningError,
     _await_marked_turn_terminal,
     _marked_turn_item_state,
+    _persisted_pre_dispatch_item_ids,
     _safe_heartbeat,
     _snapshot_confirms_current_turn_terminal,
     _snapshot_contains_current_turn_progress,
@@ -206,9 +210,18 @@ async def test_evicted_turn_marker_preserves_terminal_and_retry_authority() -> N
     replay_id = "omnigent-evicted-turn-marker-retry-authority"
     manifest = load_replay(replay_id, "manifest.json")
     expected = load_replay(replay_id, "expected-outcome.json")
-    baseline_item_ids = frozenset(
-        str(item["id"]) for item in manifest["preDispatchSnapshot"]["items"]
+    baseline_item_ids = _persisted_pre_dispatch_item_ids(
+        SimpleNamespace(
+            metadata_={
+                FIRST_MESSAGE_ITEM_FRONTIER_KEY: [
+                    str(item["id"])
+                    for item in manifest["preDispatchSnapshot"]["items"]
+                ]
+            }
+        )
     )
+    assert baseline_item_ids is not None
+    assert expected["frontierAuthority"] == "durable_bridge_metadata"
     terminal_snapshot = manifest["terminalSnapshot"]
     marker = manifest["currentTurnMarker"]
 

--- a/tests/integration/reliability/test_escaped_failure_journeys.py
+++ b/tests/integration/reliability/test_escaped_failure_journeys.py
@@ -26,7 +26,9 @@ from moonmind.omnigent import oauth_host_runtime as oauth_host_runtime_module
 from moonmind.omnigent.bridge_events import build_omnigent_bridge_event
 from moonmind.omnigent.bridge_store import OmnigentBridgeSessionStore
 from moonmind.omnigent.execute import (
+    OmnigentSessionStillRunningError,
     _await_marked_turn_terminal,
+    _marked_turn_item_state,
     _safe_heartbeat,
     _snapshot_confirms_current_turn_terminal,
     _snapshot_contains_current_turn_progress,
@@ -196,6 +198,73 @@ async def test_profile_bound_activity_heartbeats_preflight_and_fences_cancelled_
     assert "host_stop" not in owner_calls
     assert "provider_released" not in actions
     assert expected["releaseProviderLeaseOnCancellation"] is False
+
+
+async def test_evicted_turn_marker_preserves_terminal_and_retry_authority() -> None:
+    """Replay mm:d41f834c at both terminal and host-authority boundaries."""
+
+    replay_id = "omnigent-evicted-turn-marker-retry-authority"
+    manifest = load_replay(replay_id, "manifest.json")
+    expected = load_replay(replay_id, "expected-outcome.json")
+    baseline_item_ids = frozenset(
+        str(item["id"]) for item in manifest["preDispatchSnapshot"]["items"]
+    )
+    terminal_snapshot = manifest["terminalSnapshot"]
+    marker = manifest["currentTurnMarker"]
+
+    state = _marked_turn_item_state(
+        terminal_snapshot,
+        marker=marker,
+        baseline_item_ids=baseline_item_ids,
+    )
+    assert state["markerIndex"] == -1
+    assert state["boundarySource"] == expected["terminalBoundarySource"]
+    assert _snapshot_contains_current_turn_progress(
+        terminal_snapshot,
+        marker=marker,
+        baseline_item_ids=baseline_item_ids,
+    ) is expected["acceptCurrentTurnProgress"]
+    assert _snapshot_confirms_current_turn_terminal(
+        terminal_snapshot,
+        marker=marker,
+        baseline_item_ids=baseline_item_ids,
+    ) is expected["acceptCurrentTurnTerminal"]
+
+    class CappedSnapshotClient:
+        async def get_session(self, _session_id: str) -> dict[str, object]:
+            return terminal_snapshot
+
+    status, snapshot = await _await_marked_turn_terminal(
+        client=CappedSnapshotClient(),
+        session_id=manifest["sessionId"],
+        marker=marker,
+        baseline_item_ids=baseline_item_ids,
+        event_count=len(manifest["observedProviderEvents"]),
+        terminal_status="completed",
+        interval_seconds=0.001,
+        quiet_period_seconds=0.002,
+    )
+    assert status == "completed"
+    assert snapshot is terminal_snapshot
+
+    events, actions, owner_calls = await _run_coordinator_failure_case(
+        fail_at="resource_harvest",
+        code="OMNIGENT_CURRENT_TURN_TERMINAL_AMBIGUOUS",
+        injected_error=OmnigentSessionStillRunningError(
+            "current marked turn did not reach terminal state"
+        ),
+    )
+    cleanup_event = next(
+        payload
+        for event_type, payload in events
+        if event_type == "host_cleanup" and payload["status"] == "waiting"
+    )
+    assert cleanup_event["code"] == expected["ambiguousCleanupCode"]
+    assert cleanup_event["metadata"]["janitorRequired"] is True
+    assert "host_stop" not in owner_calls
+    assert "host_remove" not in owner_calls
+    assert "provider_released" not in actions
+    assert expected["retryAuthority"] == "same_host_profile_and_bridge"
 
 
 async def test_pr_resolver_child_compiles_bindable_stock_agent_identity(

--- a/tests/unit/omnigent/test_bridge_store.py
+++ b/tests/unit/omnigent/test_bridge_store.py
@@ -18,6 +18,7 @@ from sqlalchemy.orm import sessionmaker
 from api_service.db.models import Base, OmnigentBridgeSession
 from moonmind.omnigent.bridge_store import (
     BRIDGE_EVENT_JOURNAL_KEY,
+    FIRST_MESSAGE_ITEM_FRONTIER_KEY,
     FIRST_MESSAGE_TERMINAL,
     SESSION_CREATED_EVENT_TYPE,
     STATUS_ACTIVE,
@@ -421,6 +422,43 @@ async def test_attach_and_first_message_transitions(store):
     assert posted.first_message_state == "posted"
     assert posted.first_message_pending_id == "pnd-1"
     assert posted.first_message_item_id == "itm-1"
+
+
+@pytest.mark.asyncio
+async def test_first_message_item_frontier_is_durable_and_immutable(store):
+    await store.get_or_create(
+        request=_request(),
+        endpoint_ref="default",
+        agent_id=None,
+        agent_name=None,
+        target_metadata={},
+    )
+
+    recorded = await store.record_first_message_item_frontier(
+        "idem-1", item_ids=["prior-2", "prior-1", "prior-1"]
+    )
+    assert recorded.metadata_[FIRST_MESSAGE_ITEM_FRONTIER_KEY] == [
+        "prior-1",
+        "prior-2",
+    ]
+    repeated = await store.record_first_message_item_frontier(
+        "idem-1", item_ids=["prior-1", "prior-2"]
+    )
+    assert repeated.metadata_[FIRST_MESSAGE_ITEM_FRONTIER_KEY] == [
+        "prior-1",
+        "prior-2",
+    ]
+
+    await store.mark_prepared("idem-1", digest="sha256:abc", marker="marker")
+    await store.mark_posting("idem-1")
+    await store.mark_posted("idem-1")
+    with pytest.raises(
+        OmnigentIdempotencyError,
+        match="pre-dispatch item frontier changed",
+    ):
+        await store.record_first_message_item_frontier(
+            "idem-1", item_ids=["replacement-item"]
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/omnigent/test_execute.py
+++ b/tests/unit/omnigent/test_execute.py
@@ -18,6 +18,10 @@ from moonmind.omnigent.bridge_artifacts import (
     build_omnigent_result,
     build_omnigent_terminal_refs,
 )
+from moonmind.omnigent.bridge_store import (
+    FIRST_MESSAGE_ITEM_FRONTIER_KEY,
+    OmnigentDigestMismatchError,
+)
 from moonmind.omnigent.execute import (
     OmnigentContractError,
     OmnigentSessionStillRunningError,
@@ -34,7 +38,6 @@ from moonmind.omnigent.execute import (
     run_omnigent_execution,
 )
 from moonmind.rag.context_injection import PromptContextResolution
-from moonmind.omnigent.bridge_store import OmnigentDigestMismatchError
 from moonmind.schemas.agent_runtime_models import AgentExecutionRequest
 
 
@@ -1086,7 +1089,9 @@ async def test_run_omnigent_execution_waits_for_terminal_result(
         async def list_agents(self) -> dict[str, object]:
             return {"items": [{"id": "agent-1", "name": "codex-native-ui"}]}
 
-        async def create_session(self, payload: dict[str, object]) -> dict[str, object]:
+        async def create_session(
+            self, payload: dict[str, object]
+        ) -> dict[str, object]:
             assert payload["agent_id"] == "agent-1"
             assert payload["labels"]["moonmind.issue"] == "MM-1059"
             return {"id": "session-1"}
@@ -1261,7 +1266,9 @@ async def test_run_omnigent_execution_uses_nested_session_parameters(
         async def list_agents(self) -> dict[str, object]:
             raise AssertionError("agentId should avoid list_agents lookup")
 
-        async def create_session(self, payload: dict[str, object]) -> dict[str, object]:
+        async def create_session(
+            self, payload: dict[str, object]
+        ) -> dict[str, object]:
             captured_session_payloads.append(payload)
             return {"id": "session-1"}
 
@@ -1833,6 +1840,89 @@ async def test_run_omnigent_execution_raises_when_stream_ends_still_running(
 
 
 @pytest.mark.asyncio
+async def test_stream_end_polls_unfinished_current_turn_before_completion(
+    monkeypatch,
+) -> None:
+    snapshots = [
+        {
+            "status": "idle",
+            "active_response_id": None,
+            "items": [{"id": "prior-item", "type": "function_call_output"}],
+        },
+        {
+            "status": "completed",
+            "active_response_id": None,
+            "items": [
+                {
+                    "id": "current-call",
+                    "type": "function_call",
+                    "data": {"call_id": "current-call"},
+                }
+            ],
+        },
+    ]
+    awaited: dict[str, object] = {}
+
+    class FakeClient:
+        def __init__(self, **_: object) -> None:
+            self.snapshot_index = 0
+
+        async def list_agents(self) -> dict[str, object]:
+            return {"items": [{"id": "agent-1", "name": "codex-native-ui"}]}
+
+        async def create_session(self, payload: dict[str, object]) -> dict[str, object]:
+            return {"id": "session-1"}
+
+        async def post_event(
+            self,
+            session_id: str,
+            payload: dict[str, object],
+        ) -> dict[str, object]:
+            return {}
+
+        async def stream_events(self, session_id: str):
+            if False:
+                yield {}
+
+        async def get_session(self, session_id: str) -> dict[str, object]:
+            snapshot = snapshots[min(self.snapshot_index, len(snapshots) - 1)]
+            self.snapshot_index += 1
+            return snapshot
+
+    async def reject_unfinished_turn(**kwargs: object):
+        awaited.update(kwargs)
+        raise OmnigentSessionStillRunningError("unfinished current tool call")
+
+    monkeypatch.setenv("OMNIGENT_ENABLED", "true")
+    monkeypatch.setenv("OMNIGENT_SERVER_URL", "https://omnigent.test")
+    monkeypatch.setattr("moonmind.omnigent.execute.OmnigentHttpClient", FakeClient)
+    monkeypatch.setattr(
+        "moonmind.omnigent.execute._await_marked_turn_terminal",
+        reject_unfinished_turn,
+    )
+
+    with pytest.raises(OmnigentSessionStillRunningError):
+        await run_omnigent_execution(
+            AgentExecutionRequest(
+                agentKind="external",
+                agentId="omnigent",
+                correlationId="corr-1",
+                idempotencyKey="idem-unfinished-current-turn",
+                parameters={
+                    "omnigent": {
+                        "agent": {"agentName": "codex-native-ui"},
+                        "session": {"allowEmptyWorkspace": True},
+                        "prompt": {"text": "Do the task"},
+                    },
+                },
+            )
+        )
+
+    assert awaited["baseline_item_ids"] == frozenset({"prior-item"})
+    assert awaited["terminal_status"] == "completed"
+
+
+@pytest.mark.asyncio
 async def test_run_omnigent_execution_reuses_heartbeat_session_on_retry(
     monkeypatch,
     tmp_path,
@@ -2068,6 +2158,122 @@ async def test_run_omnigent_execution_reuses_persisted_session_on_retry(
         "itemId": "item-1",
     }
     assert external_state["artifactRefs"]["diagnosticsRef"] == result.diagnostics_ref
+
+
+@pytest.mark.asyncio
+async def test_run_omnigent_execution_reuses_persisted_item_frontier_on_retry(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    calls: list[str] = []
+    awaited: dict[str, object] = {}
+    terminal_snapshot = {
+        "status": "idle",
+        "active_response_id": None,
+        "summary": "durably reattached after marker eviction",
+        "items": [
+            {
+                "id": "current-call",
+                "type": "function_call",
+                "data": {"call_id": "current-call"},
+            },
+            {
+                "id": "current-output",
+                "type": "function_call_output",
+                "data": {"call_id": "current-call"},
+            },
+            {
+                "id": "current-assistant",
+                "type": "message",
+                "data": {
+                    "role": "assistant",
+                    "content": [{"type": "output_text", "text": "Done"}],
+                },
+            },
+        ],
+    }
+
+    class Row:
+        omnigent_session_id = "persisted-session"
+        first_message_state = "posted"
+        first_message_pending_id = "pending-1"
+        first_message_item_id = "marked-item"
+        metadata_ = {FIRST_MESSAGE_ITEM_FRONTIER_KEY: ["prior-item"]}
+
+    class Store:
+        async def get_or_create(self, **_: object) -> Row:
+            return Row()
+
+        async def get_binding(self, *_a: object, **_k: object) -> None:
+            return None
+
+        async def mark_prepared(self, *_: object, **__: object) -> Row:
+            return Row()
+
+        async def mark_terminal(self, *_: object, **__: object) -> Row:
+            return Row()
+
+    class FakeClient:
+        def __init__(self, **_: object) -> None:
+            pass
+
+        async def list_agents(self) -> dict[str, object]:
+            return {"items": [{"id": "agent-1", "name": "codex-native-ui"}]}
+
+        async def create_session(self, payload: dict[str, object]) -> dict[str, object]:
+            calls.append("create_session")
+            return {"id": "new-session"}
+
+        async def post_event(
+            self,
+            session_id: str,
+            payload: dict[str, object],
+        ) -> dict[str, object]:
+            calls.append("post_event")
+            return {}
+
+        async def stream_events(self, session_id: str):
+            assert session_id == "persisted-session"
+            yield {"type": "response.completed"}
+
+        async def get_session(self, session_id: str) -> dict[str, object]:
+            assert session_id == "persisted-session"
+            return terminal_snapshot
+
+    async def capture_terminal_wait(**kwargs: object):
+        awaited.update(kwargs)
+        return "completed", terminal_snapshot
+
+    monkeypatch.setenv("OMNIGENT_ENABLED", "true")
+    monkeypatch.setenv("OMNIGENT_SERVER_URL", "https://omnigent.test")
+    monkeypatch.setattr("moonmind.omnigent.execute.OmnigentHttpClient", FakeClient)
+    monkeypatch.setattr(
+        "moonmind.omnigent.execute._await_marked_turn_terminal",
+        capture_terminal_wait,
+    )
+    artifact_gateway = LocalOmnigentArtifactGateway(root=tmp_path)
+
+    result = await run_omnigent_execution(
+        AgentExecutionRequest(
+            agentKind="external",
+            agentId="omnigent",
+            correlationId="corr-1",
+            idempotencyKey="idem-persisted-frontier",
+            parameters={
+                "omnigent": {
+                    "agent": {"agentName": "codex-native-ui"},
+                    "session": {"allowEmptyWorkspace": True},
+                    "prompt": {"text": "continue"},
+                },
+            },
+        ),
+        run_store=Store(),
+        artifact_gateway=artifact_gateway,
+    )
+
+    assert result.summary == "durably reattached after marker eviction"
+    assert calls == []
+    assert awaited["baseline_item_ids"] == frozenset({"prior-item"})
 
 
 @pytest.mark.asyncio

--- a/tests/unit/omnigent/test_execute.py
+++ b/tests/unit/omnigent/test_execute.py
@@ -243,6 +243,70 @@ async def test_snapshot_polling_accepts_marked_progress_while_session_is_idle() 
 
 
 @pytest.mark.asyncio
+async def test_snapshot_polling_uses_pre_dispatch_item_ids_when_marker_is_evicted() -> None:
+    """A capped stock snapshot must not erase current-turn terminal evidence."""
+
+    marker = "MoonMind-Omnigent-Run: continuation-with-many-tools"
+    baseline_item_ids = frozenset({"prior-1", "prior-2"})
+    terminal = {
+        "status": "idle",
+        "active_response_id": None,
+        "items": [
+            {
+                "id": "call-current",
+                "type": "function_call",
+                "data": {"call_id": "call-current"},
+            },
+            {
+                "id": "output-current",
+                "type": "function_call_output",
+                "data": {"call_id": "call-current"},
+            },
+            {
+                "id": "assistant-current",
+                "type": "message",
+                "data": {
+                    "role": "assistant",
+                    "content": [{"type": "output_text", "text": "Done"}],
+                },
+            },
+        ],
+    }
+
+    class Client:
+        async def get_session(self, _session_id: str) -> dict[str, Any]:
+            return terminal
+
+    assert not _snapshot_contains_current_turn_progress(terminal, marker=marker)
+    assert _snapshot_contains_current_turn_progress(
+        terminal,
+        marker=marker,
+        baseline_item_ids=baseline_item_ids,
+    )
+    assert not _snapshot_contains_current_turn_progress(
+        {
+            "status": "idle",
+            "items": [{"id": "prior-1", "type": "function_call_output"}],
+        },
+        marker=marker,
+        baseline_item_ids=baseline_item_ids,
+    )
+    status, snapshot = await _await_marked_turn_terminal(
+        client=Client(),
+        session_id="session-1",
+        marker=marker,
+        baseline_item_ids=baseline_item_ids,
+        event_count=9,
+        terminal_status="completed",
+        interval_seconds=0.001,
+        quiet_period_seconds=0.002,
+    )
+
+    assert status == "completed"
+    assert snapshot is terminal
+
+
+@pytest.mark.asyncio
 async def test_snapshot_polling_preserves_marked_provider_failure() -> None:
     marker = "MoonMind-Omnigent-Run: failed-turn"
     failed = {

--- a/tests/unit/omnigent/test_oauth_profile_lifecycle.py
+++ b/tests/unit/omnigent/test_oauth_profile_lifecycle.py
@@ -44,6 +44,7 @@ from moonmind.omnigent.execution_profiles import (
     compile_effective_launch,
     validate_effective_launch_snapshot,
 )
+from moonmind.omnigent.execute import OmnigentSessionStillRunningError
 from moonmind.omnigent.oauth_host_runtime import OmnigentOAuthHostRuntime
 from moonmind.security.egress import OMNIGENT_EGRESS_PROFILE
 from moonmind.omnigent.mounted_tool_preflight import MountedToolPreflightError
@@ -3849,9 +3850,10 @@ async def _run_coordinator_failure_case(
     elif fail_at in {"none", "host_stop", "host_remove", "release"}:
         await coordinator.execute(request)
     else:
-        with pytest.raises(OmnigentOAuthHostError) as captured:
+        with pytest.raises(type(error)) as captured:
             await coordinator.execute(request)
-        assert captured.value.code == code
+        if isinstance(error, OmnigentOAuthHostError):
+            assert captured.value.code == code
     return events, actions, owners.calls
 
 
@@ -3870,6 +3872,54 @@ async def test_cancelled_attempt_defers_host_and_profile_cleanup_to_retry_or_jan
         event_type == "host_cleanup"
         and payload["status"] == "waiting"
         and payload["code"] == "activity_cancelled"
+        for event_type, payload in events
+    )
+    assert any(
+        event_type == "profile_lease_release"
+        and payload["status"] == "waiting"
+        for event_type, payload in events
+    )
+
+
+@pytest.mark.asyncio
+async def test_ambiguous_terminal_attempt_preserves_exact_host_for_temporal_retry() -> None:
+    request = AgentExecutionRequest(
+        agentKind="external",
+        agentId="omnigent",
+        executionProfileRef="codex",
+        correlationId="workflow-1",
+        idempotencyKey="idem-ambiguous-terminal",
+        workspaceSpec={
+            "workspaceLocator": {
+                "kind": "sandbox",
+                "workspaceId": hashlib.sha256(
+                    b"workflow-1:idem-ambiguous-terminal"
+                ).hexdigest()[:24],
+            }
+        },
+        parameters={
+            "omnigent": {
+                "launchPolicyRef": "codex-on-demand@1",
+                "session": {"workspace": "https://example.com/repo.git"},
+            }
+        },
+    )
+    events, actions, owner_calls = await _run_coordinator_failure_case(
+        fail_at="resource_harvest",
+        code="OMNIGENT_CURRENT_TURN_TERMINAL_AMBIGUOUS",
+        request=request,
+        injected_error=OmnigentSessionStillRunningError(
+            "current marked turn did not reach terminal state"
+        ),
+    )
+
+    assert "host_remove" not in owner_calls
+    assert "host_removed" not in actions
+    assert "provider_released" not in actions
+    assert any(
+        event_type == "host_cleanup"
+        and payload["status"] == "waiting"
+        and payload["code"] == "ambiguous_terminal_state"
         for event_type, payload in events
     )
     assert any(


### PR DESCRIPTION
## Summary

- recognize completed Omnigent turns when the marked user item has been evicted from the bounded session snapshot
- preserve the durable host, provider-profile lease, and bridge authority when terminal state remains ambiguous
- add unit regressions and a required-CI escaped-failure replay for workflow `mm:d41f834c-c276-4fc1-ac83-9740ed3ba88e`

## Root cause

A long repository continuation exceeded Omnigent's 100-item stock snapshot. The current-turn marker was evicted even though the response completed, so MoonMind waited for the terminal poll timeout. Ordinary failure cleanup then removed the on-demand host and released its profile lease. Temporal retried with a newly registered host, and the immutable bridge correctly rejected rebinding to that replacement host.

## Validation

- affected Omnigent unit suites: 207 passed
- escaped-failure reliability replay file: 64 passed
- full Omnigent unit directory: 701 passed; four unrelated local failures remain from modified submodules and macOS read-only directory replacement behavior
- `git diff --check`
- Python compileall for changed Python files

The pre-existing local `moonspec` and `omnigent` submodule pointer changes are excluded from this PR.