### PR TITLE
Persist opaque Workflow Chat bindings and expose chat-binding API (MoonLadderStudios/MoonMind#3633)

### DIFF
--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -40,7 +40,7 @@ from temporalio.service import RPCError
 from api_service.api.dependencies import resolve_template_scope_for_user
 from api_service.auth_providers import get_current_user
 from api_service.core import sync as execution_sync
-from api_service.db.base import get_async_session
+from api_service.db.base import async_session_maker, get_async_session
 from api_service.db.models import (
     AgentSkillDefinition,
     ManagedAgentProviderProfile,
@@ -205,6 +205,10 @@ from moonmind.workflows.executions.preset_goal_scheduler import (
 )
 from moonmind.workflows.executions.runtime_defaults import normalize_runtime_id
 from moonmind.omnigent.cutover import effective_phase, select_runtime
+from moonmind.omnigent.bridge_store import (
+    BridgeChatBindingAmbiguousError,
+    OmnigentBridgeSessionStore,
+)
 from moonmind.workflows.executions.runtime_capabilities import (
     resolve_runtime_execution_capabilities,
 )
@@ -14655,6 +14659,114 @@ async def describe_execution(
         if agent_run_id:
             execution = execution.model_copy(update={"agent_run_id": agent_run_id})
     return execution
+
+
+def _chat_binding_alias(value: str) -> str:
+    parts = value.split("_")
+    return parts[0] + "".join(part.title() for part in parts[1:])
+
+
+class WorkflowChatBinding(BaseModel):
+    """Browser-safe native Workflow Chat binding (MoonLadderStudios/MoonMind#3633).
+
+    Maps one visible Workflow Execution to one server-owned Omnigent session
+    through the opaque ``chatBindingId``. Provider session, bridge session,
+    endpoint, host, runner, credential, profile, policy, and workspace
+    identities are deliberately absent: they stay server-side and are only
+    exposed through separately authorized diagnostic routes
+    (docs/UI/WorkflowChatPanel.md §5, OmnigentBridge.md §15).
+    """
+
+    model_config = ConfigDict(
+        alias_generator=_chat_binding_alias, populate_by_name=True
+    )
+
+    chat_binding_id: str = ""
+    workflow_id: str
+    run_id: str | None = None
+    logical_step_id: str | None = None
+    step_execution_id: str | None = None
+    chat_url: str = ""
+    api_base: str = ""
+    state: Literal["starting", "available", "ended", "unavailable"]
+    read_only: bool
+    capabilities: dict[str, bool] = Field(default_factory=dict)
+    unavailable_reason: str | None = None
+
+
+@router.get("/{workflow_id}/chat-binding", response_model=WorkflowChatBinding)
+async def resolve_workflow_chat_binding(
+    workflow_id: str,
+    response: Response,
+    service: TemporalExecutionService = Depends(_get_service),
+    user: User = Depends(get_current_user()),
+) -> WorkflowChatBinding:
+    """Resolve the authorized, browser-safe native Workflow Chat binding.
+
+    MoonLadderStudios/MoonMind#3633. The caller is authorized against the
+    Workflow *before* any binding information is returned; possession of a
+    binding id is never treated as authorization. The server generates the
+    binding-scoped ``chatUrl`` and ``apiBase`` — the browser must not author an
+    upstream route, provider session id, or endpoint.
+    """
+
+    canonical_workflow_id, alias_used = _canonicalize_execution_identifier(workflow_id)
+    # Authorize against the Workflow first (OmnigentBridge.md §16 rule 1); an
+    # unknown/deleted/unauthorized Workflow fails here without revealing whether
+    # any provider session exists.
+    await _get_owned_execution(
+        service=service,
+        workflow_id=canonical_workflow_id,
+        user=user,
+    )
+    if alias_used:
+        _mark_execution_alias_usage(
+            response,
+            raw_identifier=workflow_id,
+            canonical_identifier=canonical_workflow_id,
+        )
+
+    store = OmnigentBridgeSessionStore(async_session_maker)
+    try:
+        resolution = await store.resolve_chat_binding(
+            workflow_id=canonical_workflow_id
+        )
+    except BridgeChatBindingAmbiguousError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "code": "omnigent_chat_binding_ambiguous",
+                "message": (
+                    "The Workflow has multiple active chat-capable sessions."
+                ),
+            },
+        ) from exc
+
+    chat_url = ""
+    api_base = ""
+    if resolution.chat_binding_id:
+        # Server-owned, binding-scoped navigation targets. The browser never
+        # substitutes the upstream route (docs/UI/WorkflowChatPanel.md §4).
+        chat_url = (
+            f"/omnigent-ui/workflow-chat/{resolution.chat_binding_id}?embedded=1"
+        )
+        api_base = (
+            f"/api/workflow-chat-bindings/{resolution.chat_binding_id}/omnigent"
+        )
+
+    return WorkflowChatBinding(
+        chat_binding_id=resolution.chat_binding_id or "",
+        workflow_id=canonical_workflow_id,
+        run_id=resolution.run_id,
+        logical_step_id=resolution.logical_step_id,
+        step_execution_id=resolution.step_execution_id,
+        chat_url=chat_url,
+        api_base=api_base,
+        state=resolution.state,
+        read_only=resolution.read_only,
+        capabilities=resolution.capabilities,
+        unavailable_reason=resolution.unavailable_reason,
+    )
 
 
 class ContinueRemediationBudgetProposal(BaseModel):

--- a/api_service/db/models.py
+++ b/api_service/db/models.py
@@ -397,9 +397,20 @@ class OmnigentBridgeSession(Base):
         Index("ix_omnigent_bridge_sessions_session", "omnigent_session_id"),
         Index("ix_omnigent_bridge_sessions_workflow", "moonmind_workflow_id"),
         Index("ix_omnigent_bridge_sessions_status", "status"),
+        # MoonLadderStudios/MoonMind#3633: opaque, unguessable browser-safe
+        # Workflow Chat binding handle. Unique so one logical binding maps to one
+        # id; nullable so historical rows and not-yet-bound sessions carry NULL
+        # until allocation (NULLs are distinct under both SQLite and Postgres
+        # unique indexes, so they never collide).
+        Index(
+            "uq_omnigent_bridge_sessions_chat_binding",
+            "chat_binding_id",
+            unique=True,
+        ),
     )
 
     bridge_session_id: Mapped[str] = mapped_column(String(255), primary_key=True)
+    chat_binding_id: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
     provider: Mapped[str] = mapped_column(String(64), nullable=False)
     compatibility_profile: Mapped[str] = mapped_column(String(128), nullable=False)
     moonmind_workflow_id: Mapped[str] = mapped_column(String(255), nullable=False)

--- a/api_service/migrations/versions/353_omnigent_chat_binding.py
+++ b/api_service/migrations/versions/353_omnigent_chat_binding.py
@@ -1,0 +1,53 @@
+"""Add opaque Workflow Chat binding identity to bridge sessions.
+
+Issue MoonLadderStudios/MoonMind#3633: persist an opaque, unguessable
+``chat_binding_id`` on the canonical ``omnigent_bridge_sessions`` store so one
+visible Workflow Execution maps to exactly one server-owned Omnigent session
+through a browser-safe handle. The id is kept distinct from
+``bridge_session_id``, ``idempotency_key``, ``moonmind_workflow_id``,
+``moonmind_run_id``, ``moonmind_agent_run_id``, and the provider session id.
+
+Backfill policy (OmnigentBridge.md §7.1/§8.2 step 7): the column is nullable and
+no row is rewritten by this migration. Historical rows keep ``NULL`` and are
+backfilled deterministically on the next authoritative touch — ``session.created``
+persistence or the first chat-binding resolution allocates the id idempotently
+only once the durable Workflow-to-provider session binding exists. This keeps
+Temporal replay compatibility (no persisted-payload shape changes, no workflow
+identity change) and does not break historical projections; the unique index
+treats ``NULL`` as distinct so un-backfilled rows never collide.
+
+Revision ID: 353_omnigent_chat_binding
+Revises: 352_remediation_verification
+Create Date: 2026-08-07
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "353_omnigent_chat_binding"
+down_revision = "352_remediation_verification"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "omnigent_bridge_sessions",
+        sa.Column("chat_binding_id", sa.String(length=255), nullable=True),
+    )
+    op.create_index(
+        "uq_omnigent_bridge_sessions_chat_binding",
+        "omnigent_bridge_sessions",
+        ["chat_binding_id"],
+        unique=True,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "uq_omnigent_bridge_sessions_chat_binding",
+        table_name="omnigent_bridge_sessions",
+    )
+    op.drop_column("omnigent_bridge_sessions", "chat_binding_id")

--- a/docs/Omnigent/OmnigentBridge.md
+++ b/docs/Omnigent/OmnigentBridge.md
@@ -853,6 +853,7 @@ type WorkflowChatBinding = {
   logicalStepId?: string;
   stepExecutionId?: string;
   chatUrl: string;
+  apiBase: string;
   state: 'starting' | 'available' | 'ended' | 'unavailable';
   readOnly: boolean;
   capabilities: Record<string, boolean>;

--- a/docs/UI/WorkflowChatPanel.md
+++ b/docs/UI/WorkflowChatPanel.md
@@ -126,6 +126,7 @@ type WorkflowChatBinding = {
   logicalStepId?: string;
   stepExecutionId?: string;
   chatUrl: string;
+  apiBase: string;
   state: 'starting' | 'available' | 'ended' | 'unavailable';
   readOnly: boolean;
   capabilities: {

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -2296,6 +2296,32 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/executions/{workflow_id}/chat-binding": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Resolve Workflow Chat Binding
+         * @description Resolve the authorized, browser-safe native Workflow Chat binding.
+         *
+         *     MoonLadderStudios/MoonMind#3633. The caller is authorized against the
+         *     Workflow *before* any binding information is returned; possession of a
+         *     binding id is never treated as authorization. The server generates the
+         *     binding-scoped ``chatUrl`` and ``apiBase`` — the browser must not author an
+         *     upstream route, provider session id, or endpoint.
+         */
+        get: operations["resolve_workflow_chat_binding_api_executions__workflow_id__chat_binding_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/executions/{workflow_id}/actions/continue-remediation": {
         parameters: {
             query?: never;
@@ -13536,6 +13562,55 @@ export interface components {
             signalStatus?: string | null;
         };
         /**
+         * WorkflowChatBinding
+         * @description Browser-safe native Workflow Chat binding (MoonLadderStudios/MoonMind#3633).
+         *
+         *     Maps one visible Workflow Execution to one server-owned Omnigent session
+         *     through the opaque ``chatBindingId``. Provider session, bridge session,
+         *     endpoint, host, runner, credential, profile, policy, and workspace
+         *     identities are deliberately absent: they stay server-side and are only
+         *     exposed through separately authorized diagnostic routes
+         *     (docs/UI/WorkflowChatPanel.md §5, OmnigentBridge.md §15).
+         */
+        WorkflowChatBinding: {
+            /**
+             * Chatbindingid
+             * @default
+             */
+            chatBindingId: string;
+            /** Workflowid */
+            workflowId: string;
+            /** Runid */
+            runId?: string | null;
+            /** Logicalstepid */
+            logicalStepId?: string | null;
+            /** Stepexecutionid */
+            stepExecutionId?: string | null;
+            /**
+             * Chaturl
+             * @default
+             */
+            chatUrl: string;
+            /**
+             * Apibase
+             * @default
+             */
+            apiBase: string;
+            /**
+             * State
+             * @enum {string}
+             */
+            state: "starting" | "available" | "ended" | "unavailable";
+            /** Readonly */
+            readOnly: boolean;
+            /** Capabilities */
+            capabilities?: {
+                [key: string]: boolean;
+            };
+            /** Unavailablereason */
+            unavailableReason?: string | null;
+        };
+        /**
          * WorkflowInputSnapshotDescriptorModel
          * @description Compact pointer to the authoritative original task input snapshot.
          */
@@ -18669,6 +18744,37 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["ExecutionModel"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    resolve_workflow_chat_binding_api_executions__workflow_id__chat_binding_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                workflow_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["WorkflowChatBinding"];
                 };
             };
             /** @description Validation Error */

--- a/moonmind/omnigent/bridge_store.py
+++ b/moonmind/omnigent/bridge_store.py
@@ -115,6 +115,14 @@ CHAT_BINDING_ID_PREFIX = "chatb_"
 # unavailable reason rather than falling through to an arbitrary session.
 SUPPORTED_CHAT_BINDING_PROVIDERS = frozenset({BRIDGE_PROVIDER})
 
+# Compatibility profiles whose bridge sessions the Omnigent facade can actually
+# serve. ``provider`` alone is insufficient: cross-runtime compatibility paths
+# (for example the direct-Codex migration path) reuse the shared
+# ``provider="omnigent"`` row yet carry a distinct compatibility profile the
+# native chat surface cannot serve. Those rows resolve to ``unsupported_runtime``
+# instead of advertising an Omnigent-native binding (MoonLadderStudios/MoonMind#3633).
+SUPPORTED_CHAT_BINDING_PROFILES = frozenset({BRIDGE_COMPATIBILITY_PROFILE})
+
 # Browser-safe Workflow Chat binding states (OmnigentBridge.md §15,
 # docs/UI/WorkflowChatPanel.md §5).
 CHAT_BINDING_STATE_STARTING = "starting"
@@ -142,6 +150,40 @@ def _is_provider_session_deleted(row: OmnigentBridgeSession) -> bool:
     if not isinstance(metadata, dict):
         return False
     return bool(metadata.get(PROVIDER_SESSION_DELETED_KEY))
+
+
+def _chat_binding_compatibility_profile(row: OmnigentBridgeSession) -> str:
+    """Return the row's effective compatibility profile.
+
+    The persisted ``compatibility_profile`` column is coalesced to the Omnigent
+    server profile for every row, so a cross-runtime compatibility session
+    records its real profile in metadata instead. Prefer that metadata value and
+    fall back to the column so the discriminator reflects what the session can
+    actually serve.
+    """
+
+    metadata = getattr(row, "metadata_", None)
+    if isinstance(metadata, dict):
+        profile = str(metadata.get("compatibilityProfile") or "").strip()
+        if profile:
+            return profile
+    return str(getattr(row, "compatibility_profile", "") or "").strip()
+
+
+def _serves_native_chat(row: OmnigentBridgeSession) -> bool:
+    """Return whether the Omnigent chat facade can serve this bridge session.
+
+    A native chat binding requires both a supported provider and a supported
+    compatibility profile; a compatibility/migration session that reuses the
+    Omnigent provider row is rejected so it resolves to ``unsupported_runtime``
+    rather than advertising a binding the facade cannot serve
+    (MoonLadderStudios/MoonMind#3633).
+    """
+
+    return (
+        row.provider in SUPPORTED_CHAT_BINDING_PROVIDERS
+        and _chat_binding_compatibility_profile(row) in SUPPORTED_CHAT_BINDING_PROFILES
+    )
 
 
 def _chat_binding_capabilities(row: OmnigentBridgeSession) -> dict[str, bool]:
@@ -681,6 +723,13 @@ class OmnigentBridgeSessionStore:
         """
 
         metadata = dict(target_metadata or {})
+        # Persist the request's logical step so the chat-binding projection can
+        # label and validate the Chat context. The row only carries the physical
+        # ``step_execution_id`` column; the logical id lives in metadata
+        # (MoonLadderStudios/MoonMind#3633).
+        logical_step_id = _logical_step_id(request)
+        if logical_step_id and "logicalStepId" not in metadata:
+            metadata["logicalStepId"] = logical_step_id
         resolved_workflow_id = (workflow_id or "").strip() or _workflow_id(request)
         resolved_agent_run_id = (agent_run_id or "").strip() or _agent_run_id(request)
         async with self._session_factory() as session:
@@ -1677,10 +1726,14 @@ class OmnigentBridgeSessionStore:
                 .values(chat_binding_id=candidate)
             )
             await session.commit()
-            refreshed = await session.get(OmnigentBridgeSession, key)
-            if refreshed is not None and refreshed.chat_binding_id:
-                return refreshed.chat_binding_id
-            return candidate
+            # ``async_session_maker`` uses ``expire_on_commit=False`` and the
+            # guarded UPDATE ran through Core, so the identity-mapped ``row`` (and
+            # a plain ``session.get``) still carries the pre-update ``None``.
+            # Force a reload so the losing side of a concurrent first-time
+            # allocation returns the *persisted* winning id instead of its own
+            # unpersisted candidate, which would generate URLs that never resolve.
+            await session.refresh(row)
+            return row.chat_binding_id
 
     async def resolve_chat_binding(
         self,
@@ -1725,9 +1778,7 @@ class OmnigentBridgeSessionStore:
 
         if not rows:
             return self._unavailable_binding(workflow, run, "no_session")
-        supported = [
-            row for row in rows if row.provider in SUPPORTED_CHAT_BINDING_PROVIDERS
-        ]
+        supported = [row for row in rows if _serves_native_chat(row)]
         if not supported:
             return self._unavailable_binding(workflow, run, "unsupported_runtime")
 
@@ -1746,20 +1797,34 @@ class OmnigentBridgeSessionStore:
             # starting; there is no durable binding to allocate yet.
             return self._starting_binding(active[0], workflow, run)
 
-        terminal_capable = [
-            row
-            for row in supported
-            if _is_terminal_bridge_status(row.status)
-            and _is_provider_bound(row)
-            and not _is_provider_session_deleted(row)
-        ]
-        if terminal_capable:
-            return await self._live_binding(
-                terminal_capable[0], workflow, run, terminal=True
-            )
-        # Terminal work whose provider session was cleaned up leaves no native
-        # transcript to replay; never fall through to an arbitrary session.
-        return self._unavailable_binding(workflow, run, "session_cleaned_up")
+        # Identify the *authoritative* latest terminal session before selecting a
+        # transcript. ``rows`` is ordered newest-first, and a cleaned-up session
+        # keeps its deleted marker even though the delete cleared its provider
+        # binding, so a terminal row that ever had a provider session is a
+        # candidate. Decide against that newest candidate: if its provider
+        # transcript was cleaned up, fail closed with ``session_cleaned_up``
+        # rather than silently replaying an older run's or step's stale transcript
+        # (MoonLadderStudios/MoonMind#3633).
+        latest_terminal = next(
+            (
+                row
+                for row in supported
+                if _is_terminal_bridge_status(row.status)
+                and (_is_provider_bound(row) or _is_provider_session_deleted(row))
+            ),
+            None,
+        )
+        if latest_terminal is None:
+            # No terminal session ever bound a provider session, so there is no
+            # native transcript to replay.
+            return self._unavailable_binding(workflow, run, "session_cleaned_up")
+        if _is_provider_session_deleted(latest_terminal) or not _is_provider_bound(
+            latest_terminal
+        ):
+            return self._unavailable_binding(workflow, run, "session_cleaned_up")
+        return await self._live_binding(
+            latest_terminal, workflow, run, terminal=True
+        )
 
     async def _live_binding(
         self,
@@ -1774,8 +1839,11 @@ class OmnigentBridgeSessionStore:
         # Read-only posture is driven by the bound session and its effective
         # capabilities, never by Workflow terminality alone: a terminal session
         # is always read-only, and a live session is writable only when its
-        # capability projection does not withhold ``sendMessage``.
-        read_only = terminal or capabilities.get("sendMessage") is False
+        # capability projection affirmatively grants ``sendMessage``. Fail closed
+        # when the capability is missing (historical rows and compatibility paths
+        # persist no snapshot) so the browser is never told sending is allowed
+        # without affirmative evidence (MoonLadderStudios/MoonMind#3633).
+        read_only = terminal or capabilities.get("sendMessage") is not True
         return ChatBindingResolution(
             state=(
                 CHAT_BINDING_STATE_ENDED
@@ -2514,6 +2582,12 @@ def _agent_run_id(request: AgentExecutionRequest) -> str:
 def _step_execution_id(request: AgentExecutionRequest) -> str | None:
     if request.step_execution is not None:
         return _string_or_none(request.step_execution.step_execution_id)
+    return None
+
+
+def _logical_step_id(request: AgentExecutionRequest) -> str | None:
+    if request.step_execution is not None:
+        return _string_or_none(request.step_execution.logical_step_id)
     return None
 
 

--- a/moonmind/omnigent/bridge_store.py
+++ b/moonmind/omnigent/bridge_store.py
@@ -19,12 +19,13 @@ from __future__ import annotations
 
 import hashlib
 import json
+import secrets
 from collections.abc import Callable, Iterable, Sequence
 from datetime import UTC, datetime
 from typing import Any, NamedTuple
 from uuid import NAMESPACE_URL, uuid4, uuid5
 
-from sqlalchemy import delete, func, select
+from sqlalchemy import delete, func, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from api_service.db.models import OmnigentBridgeSession, OmnigentBridgeSessionEvent
@@ -101,6 +102,73 @@ EMBEDDED_RUNNER_TRANSITIONS: dict[str | None, frozenset[str]] = {
 
 BRIDGE_PROVIDER = "omnigent"
 BRIDGE_COMPATIBILITY_PROFILE = "omnigent.server.v1"
+
+# MoonLadderStudios/MoonMind#3633: opaque, unguessable browser-safe Workflow
+# Chat binding handle (OmnigentBridge.md §7.1/§8.2 step 7). It is an
+# authorization *lookup key*, never a bearer capability, and is kept distinct
+# from the bridge session id, idempotency key, workflow/run/agent-run ids, and
+# the provider session id.
+CHAT_BINDING_ID_PREFIX = "chatb_"
+
+# Providers whose bridge sessions can back a native Workflow Chat surface. A row
+# bound to any other provider resolves to an explicit ``unsupported_runtime``
+# unavailable reason rather than falling through to an arbitrary session.
+SUPPORTED_CHAT_BINDING_PROVIDERS = frozenset({BRIDGE_PROVIDER})
+
+# Browser-safe Workflow Chat binding states (OmnigentBridge.md §15,
+# docs/UI/WorkflowChatPanel.md §5).
+CHAT_BINDING_STATE_STARTING = "starting"
+CHAT_BINDING_STATE_AVAILABLE = "available"
+CHAT_BINDING_STATE_ENDED = "ended"
+CHAT_BINDING_STATE_UNAVAILABLE = "unavailable"
+
+
+def _generate_chat_binding_id() -> str:
+    """Return a fresh opaque, unguessable chat-binding id."""
+
+    return f"{CHAT_BINDING_ID_PREFIX}{secrets.token_urlsafe(24)}"
+
+
+def _is_terminal_bridge_status(status: str | None) -> bool:
+    return str(status or "").strip().lower() in _TERMINAL_STATUSES
+
+
+def _is_provider_bound(row: OmnigentBridgeSession) -> bool:
+    return bool(str(getattr(row, "omnigent_session_id", None) or "").strip())
+
+
+def _is_provider_session_deleted(row: OmnigentBridgeSession) -> bool:
+    metadata = getattr(row, "metadata_", None)
+    if not isinstance(metadata, dict):
+        return False
+    return bool(metadata.get(PROVIDER_SESSION_DELETED_KEY))
+
+
+def _chat_binding_capabilities(row: OmnigentBridgeSession) -> dict[str, bool]:
+    """Project the stored effective capabilities as a browser-safe bool map."""
+
+    metadata = getattr(row, "metadata_", None)
+    if not isinstance(metadata, dict):
+        return {}
+    raw = metadata.get("interventionCapabilities")
+    if not isinstance(raw, dict):
+        raw = metadata.get("capabilities")
+    if not isinstance(raw, dict):
+        return {}
+    return {
+        str(key): value
+        for key, value in raw.items()
+        if isinstance(key, str) and isinstance(value, bool)
+    }
+
+
+def _chat_binding_logical_step_id(row: OmnigentBridgeSession) -> str | None:
+    metadata = getattr(row, "metadata_", None)
+    if not isinstance(metadata, dict):
+        return None
+    value = metadata.get("logicalStepId")
+    text = str(value or "").strip()
+    return text or None
 
 # Bridge lifecycle states owned by the bridge before the provider reports a
 # normalized status (§7.1). ``active`` is the coalesced non-terminal value.
@@ -201,6 +269,35 @@ def _advance_embedded_lifecycle(
 
 class BridgeProjectionAmbiguousError(RuntimeError):
     """Raised when an explicitly scoped projection resolves to multiple sessions."""
+
+
+class BridgeChatBindingAmbiguousError(RuntimeError):
+    """Raised when a Workflow has multiple active chat-capable sessions.
+
+    MoonLadderStudios/MoonMind#3633: an active Workflow must resolve the *exact*
+    active chat-capable session. Two or more concurrent active bindings are
+    rejected rather than silently selecting the newest arbitrary provider
+    session (OmnigentBridge.md §15/§17).
+    """
+
+
+class ChatBindingResolution(NamedTuple):
+    """Trusted, browser-safe resolution of one Workflow Chat binding.
+
+    MoonLadderStudios/MoonMind#3633. Carries only server-owned, browser-safe
+    values; the provider session id, bridge session id, endpoint, host, runner,
+    credential, profile, policy, and workspace identities stay server-side.
+    """
+
+    state: str
+    read_only: bool
+    chat_binding_id: str | None
+    workflow_id: str
+    run_id: str | None
+    step_execution_id: str | None
+    logical_step_id: str | None
+    capabilities: dict[str, bool]
+    unavailable_reason: str | None
 
 
 class BridgeEventPage(NamedTuple):
@@ -1548,6 +1645,189 @@ class OmnigentBridgeSessionStore:
                 return None
             return _detached(session, row)
 
+    async def ensure_chat_binding_id(self, bridge_session_id: str) -> str | None:
+        """Return the opaque chat-binding id for a row, allocating it if missing.
+
+        MoonLadderStudios/MoonMind#3633. Idempotent and retry-safe: allocation
+        only happens once the durable Workflow-to-provider session binding
+        exists (an ``omnigent_session_id`` is attached), and a guarded
+        ``UPDATE ... WHERE chat_binding_id IS NULL`` makes concurrent callers
+        converge on the single winning id. Historical rows created before this
+        column are backfilled deterministically on their first resolution.
+        """
+
+        key = (bridge_session_id or "").strip()
+        if not key:
+            return None
+        async with self._session_factory() as session:
+            row = await session.get(OmnigentBridgeSession, key)
+            if row is None:
+                return None
+            if row.chat_binding_id:
+                return row.chat_binding_id
+            if not str(row.omnigent_session_id or "").strip():
+                return None
+            candidate = _generate_chat_binding_id()
+            await session.execute(
+                update(OmnigentBridgeSession)
+                .where(
+                    OmnigentBridgeSession.bridge_session_id == key,
+                    OmnigentBridgeSession.chat_binding_id.is_(None),
+                )
+                .values(chat_binding_id=candidate)
+            )
+            await session.commit()
+            refreshed = await session.get(OmnigentBridgeSession, key)
+            if refreshed is not None and refreshed.chat_binding_id:
+                return refreshed.chat_binding_id
+            return candidate
+
+    async def resolve_chat_binding(
+        self,
+        *,
+        workflow_id: str,
+        run_id: str | None = None,
+    ) -> ChatBindingResolution:
+        """Resolve the authoritative browser-safe Workflow Chat binding (§15).
+
+        MoonLadderStudios/MoonMind#3633. Resolution order:
+
+        1. the exact active chat-capable session for the Workflow/run;
+        2. an active session still starting (no durable binding yet);
+        3. the last authoritative chat-capable session for a terminal Workflow,
+           returned read-only;
+        4. an explicit unavailable state with a stable reason.
+
+        Ambiguous active candidates are rejected rather than selecting the
+        newest arbitrary provider session; unsupported runtimes and cleaned-up
+        sessions return stable unavailable reasons instead of falling through.
+        """
+
+        workflow = (workflow_id or "").strip()
+        if not workflow:
+            return self._unavailable_binding(workflow, None, "no_session")
+        run = (run_id or "").strip() or None
+        async with self._session_factory() as session:
+            statement = select(OmnigentBridgeSession).where(
+                OmnigentBridgeSession.moonmind_workflow_id == workflow
+            )
+            if run:
+                statement = statement.where(
+                    OmnigentBridgeSession.moonmind_run_id == run
+                )
+            statement = statement.order_by(
+                OmnigentBridgeSession.updated_at.desc(),
+                OmnigentBridgeSession.created_at.desc(),
+                OmnigentBridgeSession.bridge_session_id.desc(),
+            )
+            result = await session.execute(statement)
+            rows = [_detached(session, row) for row in result.scalars().all()]
+
+        if not rows:
+            return self._unavailable_binding(workflow, run, "no_session")
+        supported = [
+            row for row in rows if row.provider in SUPPORTED_CHAT_BINDING_PROVIDERS
+        ]
+        if not supported:
+            return self._unavailable_binding(workflow, run, "unsupported_runtime")
+
+        active = [row for row in supported if not _is_terminal_bridge_status(row.status)]
+        active_capable = [row for row in active if _is_provider_bound(row)]
+        if len(active_capable) > 1:
+            raise BridgeChatBindingAmbiguousError(
+                "Workflow has multiple active chat-capable Omnigent sessions"
+            )
+        if active_capable:
+            return await self._live_binding(
+                active_capable[0], workflow, run, terminal=False
+            )
+        if active:
+            # A launch that has not yet attached a provider session is still
+            # starting; there is no durable binding to allocate yet.
+            return self._starting_binding(active[0], workflow, run)
+
+        terminal_capable = [
+            row
+            for row in supported
+            if _is_terminal_bridge_status(row.status)
+            and _is_provider_bound(row)
+            and not _is_provider_session_deleted(row)
+        ]
+        if terminal_capable:
+            return await self._live_binding(
+                terminal_capable[0], workflow, run, terminal=True
+            )
+        # Terminal work whose provider session was cleaned up leaves no native
+        # transcript to replay; never fall through to an arbitrary session.
+        return self._unavailable_binding(workflow, run, "session_cleaned_up")
+
+    async def _live_binding(
+        self,
+        row: OmnigentBridgeSession,
+        workflow: str,
+        run: str | None,
+        *,
+        terminal: bool,
+    ) -> ChatBindingResolution:
+        chat_binding_id = await self.ensure_chat_binding_id(row.bridge_session_id)
+        capabilities = _chat_binding_capabilities(row)
+        # Read-only posture is driven by the bound session and its effective
+        # capabilities, never by Workflow terminality alone: a terminal session
+        # is always read-only, and a live session is writable only when its
+        # capability projection does not withhold ``sendMessage``.
+        read_only = terminal or capabilities.get("sendMessage") is False
+        return ChatBindingResolution(
+            state=(
+                CHAT_BINDING_STATE_ENDED
+                if terminal
+                else CHAT_BINDING_STATE_AVAILABLE
+            ),
+            read_only=read_only,
+            chat_binding_id=chat_binding_id,
+            workflow_id=workflow,
+            run_id=(row.moonmind_run_id or run),
+            step_execution_id=row.step_execution_id,
+            logical_step_id=_chat_binding_logical_step_id(row),
+            capabilities=capabilities,
+            unavailable_reason=None,
+        )
+
+    def _starting_binding(
+        self,
+        row: OmnigentBridgeSession,
+        workflow: str,
+        run: str | None,
+    ) -> ChatBindingResolution:
+        return ChatBindingResolution(
+            state=CHAT_BINDING_STATE_STARTING,
+            read_only=True,
+            chat_binding_id=None,
+            workflow_id=workflow,
+            run_id=(row.moonmind_run_id or run),
+            step_execution_id=row.step_execution_id,
+            logical_step_id=_chat_binding_logical_step_id(row),
+            capabilities={},
+            unavailable_reason=None,
+        )
+
+    def _unavailable_binding(
+        self,
+        workflow: str,
+        run: str | None,
+        reason: str,
+    ) -> ChatBindingResolution:
+        return ChatBindingResolution(
+            state=CHAT_BINDING_STATE_UNAVAILABLE,
+            read_only=True,
+            chat_binding_id=None,
+            workflow_id=workflow,
+            run_id=run,
+            step_execution_id=None,
+            logical_step_id=None,
+            capabilities={},
+            unavailable_reason=reason,
+        )
+
     async def attach_session(
         self, idempotency_key: str, session_id: str
     ) -> OmnigentBridgeSession:
@@ -1605,6 +1885,15 @@ class OmnigentBridgeSessionStore:
                 entry.get("type") == SESSION_CREATED_EVENT_TYPE for entry in journal
             )
             changed = False
+            # MoonLadderStudios/MoonMind#3633: allocate the opaque chat-binding
+            # id only after the durable Workflow-to-provider session binding
+            # exists (§8.2 step 7). ``session.created`` runs on both the create
+            # and reuse paths after the provider session id is attached, so this
+            # is the retry-safe, idempotent allocation point: it fires once and a
+            # replayed create/attach under the same key reuses the existing id.
+            if session_id and not row.chat_binding_id:
+                row.chat_binding_id = _generate_chat_binding_id()
+                changed = True
             if capabilities is not None:
                 metadata["interventionCapabilities"] = capabilities
                 changed = True

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -56,8 +56,13 @@ from api_service.api.routers.executions import (
     router,
     update_execution as update_execution_route,
 )
+from api_service.api.routers import executions as executions_module
 from api_service.auth_providers import get_current_user
 from api_service.db.base import get_async_session
+from moonmind.omnigent.bridge_store import (
+    BridgeChatBindingAmbiguousError,
+    ChatBindingResolution,
+)
 from api_service.db.models import (
     Base,
     MoonMindWorkflowState,
@@ -15847,3 +15852,207 @@ def test_serialize_execution_canceled_state_uses_correct_spelling() -> None:
     assert payload.status == "canceled"
     assert payload.dashboard_status == "canceled"
     assert payload.temporal_status == "canceled"
+
+
+# --- native Workflow Chat binding API (MoonLadderStudios/MoonMind#3633) -------
+
+
+_CHAT_BINDING_ALLOWED_KEYS = {
+    "chatBindingId",
+    "workflowId",
+    "runId",
+    "logicalStepId",
+    "stepExecutionId",
+    "chatUrl",
+    "apiBase",
+    "state",
+    "readOnly",
+    "capabilities",
+    "unavailableReason",
+}
+
+# Identities that must never appear in the ordinary browser-safe response.
+_CHAT_BINDING_FORBIDDEN_KEYS = {
+    "providerSessionId",
+    "bridgeSessionId",
+    "agentRunId",
+    "omnigentSessionId",
+    "endpoint",
+    "endpointRef",
+    "omnigentEndpointRef",
+    "hostId",
+    "hostBindingRef",
+    "runnerId",
+    "omnigentRunnerRef",
+    "credentialGeneration",
+    "providerProfileId",
+    "agentProfileSnapshotRef",
+    "launchPolicyRef",
+    "policyId",
+    "workspace",
+}
+
+
+def _chat_binding_app(resolution=None, *, error=None, owner_id="user-123"):
+    app = FastAPI()
+    app.include_router(router)
+    service = AsyncMock()
+    service.describe_execution.return_value = _build_execution_record(owner_id=owner_id)
+    app.dependency_overrides[_get_service] = lambda: service
+    return app, service
+
+
+class _FakeChatBindingStore:
+    def __init__(self, resolution=None, error=None):
+        self._resolution = resolution
+        self._error = error
+
+    async def resolve_chat_binding(self, *, workflow_id, run_id=None):
+        if self._error is not None:
+            raise self._error
+        return self._resolution
+
+
+def _install_fake_store(monkeypatch, resolution=None, error=None):
+    monkeypatch.setattr(
+        executions_module,
+        "OmnigentBridgeSessionStore",
+        lambda *_a, **_k: _FakeChatBindingStore(resolution=resolution, error=error),
+    )
+
+
+def test_chat_binding_available_is_browser_safe(monkeypatch) -> None:
+    resolution = ChatBindingResolution(
+        state="available",
+        read_only=False,
+        chat_binding_id="chatb_opaque123",
+        workflow_id="mm:wf-1",
+        run_id="run-2",
+        step_execution_id="mm:wf-1:run-2:implement:execution:1",
+        logical_step_id="implement",
+        capabilities={"viewTranscript": True, "sendMessage": True},
+        unavailable_reason=None,
+    )
+    app, _service = _chat_binding_app()
+    _override_user_dependencies(app, is_superuser=True)
+    _install_fake_store(monkeypatch, resolution=resolution)
+
+    with TestClient(app) as client:
+        response = client.get("/api/executions/mm:wf-1/chat-binding")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert set(body.keys()) <= _CHAT_BINDING_ALLOWED_KEYS
+    assert not (_CHAT_BINDING_FORBIDDEN_KEYS & set(body.keys()))
+    assert body["chatBindingId"] == "chatb_opaque123"
+    assert body["state"] == "available"
+    assert body["readOnly"] is False
+    # Server-generated, binding-scoped navigation targets.
+    assert body["chatUrl"] == "/omnigent-ui/workflow-chat/chatb_opaque123?embedded=1"
+    assert body["apiBase"] == "/api/workflow-chat-bindings/chatb_opaque123/omnigent"
+    assert body["capabilities"] == {"viewTranscript": True, "sendMessage": True}
+
+
+def test_chat_binding_terminal_is_read_only(monkeypatch) -> None:
+    resolution = ChatBindingResolution(
+        state="ended",
+        read_only=True,
+        chat_binding_id="chatb_terminal",
+        workflow_id="mm:wf-1",
+        run_id="run-2",
+        step_execution_id=None,
+        logical_step_id=None,
+        capabilities={"viewTranscript": True},
+        unavailable_reason=None,
+    )
+    app, _service = _chat_binding_app()
+    _override_user_dependencies(app, is_superuser=True)
+    _install_fake_store(monkeypatch, resolution=resolution)
+
+    with TestClient(app) as client:
+        response = client.get("/api/executions/mm:wf-1/chat-binding")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["state"] == "ended"
+    assert body["readOnly"] is True
+    assert body["chatUrl"].startswith("/omnigent-ui/workflow-chat/chatb_terminal")
+
+
+def test_chat_binding_unavailable_has_no_scoped_urls(monkeypatch) -> None:
+    resolution = ChatBindingResolution(
+        state="unavailable",
+        read_only=True,
+        chat_binding_id=None,
+        workflow_id="mm:wf-1",
+        run_id=None,
+        step_execution_id=None,
+        logical_step_id=None,
+        capabilities={},
+        unavailable_reason="no_session",
+    )
+    app, _service = _chat_binding_app()
+    _override_user_dependencies(app, is_superuser=True)
+    _install_fake_store(monkeypatch, resolution=resolution)
+
+    with TestClient(app) as client:
+        response = client.get("/api/executions/mm:wf-1/chat-binding")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["state"] == "unavailable"
+    assert body["unavailableReason"] == "no_session"
+    assert body["chatBindingId"] == ""
+    assert body["chatUrl"] == ""
+    assert body["apiBase"] == ""
+
+
+def test_chat_binding_ambiguous_returns_409(monkeypatch) -> None:
+    app, _service = _chat_binding_app()
+    _override_user_dependencies(app, is_superuser=True)
+    _install_fake_store(monkeypatch, error=BridgeChatBindingAmbiguousError("ambiguous"))
+
+    with TestClient(app) as client:
+        response = client.get("/api/executions/mm:wf-1/chat-binding")
+
+    assert response.status_code == 409
+    assert response.json()["detail"]["code"] == "omnigent_chat_binding_ambiguous"
+
+
+def test_chat_binding_unauthorized_workflow_returns_404(monkeypatch) -> None:
+    # A non-admin caller who does not own the workflow is rejected before any
+    # binding information is resolved.
+    app, _service = _chat_binding_app(owner_id="another-user")
+    _override_user_dependencies(app, is_superuser=False)
+    resolved = {"called": False}
+
+    class _GuardStore:
+        def __init__(self, *_a, **_k):
+            pass
+
+        async def resolve_chat_binding(self, *, workflow_id, run_id=None):
+            resolved["called"] = True
+            raise AssertionError("resolution must not run for an unauthorized caller")
+
+    monkeypatch.setattr(executions_module, "OmnigentBridgeSessionStore", _GuardStore)
+
+    with TestClient(app) as client:
+        response = client.get("/api/executions/mm:wf-1/chat-binding")
+
+    assert response.status_code == 404
+    assert resolved["called"] is False
+
+
+def test_chat_binding_unknown_workflow_returns_404(monkeypatch) -> None:
+    app = FastAPI()
+    app.include_router(router)
+    service = AsyncMock()
+    service.describe_execution.side_effect = TemporalExecutionNotFoundError("missing")
+    app.dependency_overrides[_get_service] = lambda: service
+    _override_user_dependencies(app, is_superuser=True)
+    _install_fake_store(monkeypatch, resolution=None)
+
+    with TestClient(app) as client:
+        response = client.get("/api/executions/mm:wf-unknown/chat-binding")
+
+    assert response.status_code == 404

--- a/tests/unit/omnigent/test_bridge_store.py
+++ b/tests/unit/omnigent/test_bridge_store.py
@@ -10,6 +10,9 @@ Source design traceability: OmnigentBridge.md (MM-1152, source issue MM-1140).
 
 from __future__ import annotations
 
+import sqlite3
+from datetime import UTC, datetime, timedelta
+
 import pytest
 import pytest_asyncio
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
@@ -1399,3 +1402,213 @@ async def test_resolve_chat_binding_prefers_active_over_terminal(store):
     resolution = await store.resolve_chat_binding(workflow_id="mm:wf-1")
     assert resolution.state == CHAT_BINDING_STATE_AVAILABLE
     assert resolution.chat_binding_id == active_binding
+
+
+@pytest.mark.asyncio
+async def test_resolve_chat_binding_read_only_without_capability_snapshot(store):
+    """Fail closed when no capability snapshot exists (MoonLadderStudios/MoonMind#3633)."""
+
+    # Historical rows and compatibility paths persist no ``interventionCapabilities``
+    # snapshot; the binding must be read-only rather than advertising send.
+    await _seed_chat_session(
+        store, key="idem-1", workflow_id="mm:wf-1", agent_run_id="ar-1",
+        session_id="sess-1", capabilities=None,
+    )
+    resolution = await store.resolve_chat_binding(workflow_id="mm:wf-1")
+    assert resolution.state == CHAT_BINDING_STATE_AVAILABLE
+    assert resolution.read_only is True
+    assert resolution.capabilities == {}
+
+
+@pytest.mark.asyncio
+async def test_resolve_chat_binding_read_only_when_send_capability_absent(store):
+    """A partial snapshot without ``sendMessage`` still fails closed."""
+
+    await _seed_chat_session(
+        store, key="idem-1", workflow_id="mm:wf-1", agent_run_id="ar-1",
+        session_id="sess-1", capabilities={"viewTranscript": True},
+    )
+    resolution = await store.resolve_chat_binding(workflow_id="mm:wf-1")
+    assert resolution.read_only is True
+
+
+@pytest.mark.asyncio
+async def test_resolve_chat_binding_rejects_cross_runtime_compat_session(store):
+    """A direct-Codex compatibility row reuses ``provider="omnigent"`` but the
+    Omnigent facade cannot serve it (MoonLadderStudios/MoonMind#3633)."""
+
+    await store.get_or_create(
+        request=_request("idem-1"),
+        endpoint_ref="direct-codex-compat",
+        agent_id="agent-1",
+        agent_name="Codex CLI",
+        target_metadata={
+            "hostType": "managed",
+            "compatibilityProfile": "moonmind.codex_direct_compat.v1",
+            "producer": "direct_codex_managed_session",
+        },
+        workflow_id="mm:wf-1",
+        agent_run_id="ar-1",
+    )
+    await store.attach_session("idem-1", "sess-1")
+    await store.record_session_created("idem-1", session_id="sess-1")
+
+    row = await store.get_existing("idem-1")
+    # The provider column is still the shared Omnigent provider...
+    assert row.provider == "omnigent"
+
+    resolution = await store.resolve_chat_binding(workflow_id="mm:wf-1")
+    # ...but the compatibility profile is not one the facade can serve.
+    assert resolution.state == CHAT_BINDING_STATE_UNAVAILABLE
+    assert resolution.unavailable_reason == "unsupported_runtime"
+
+
+async def _set_updated_at(store, bridge_session_id: str, when: datetime) -> None:
+    async with store._session_factory() as session:
+        row = await session.get(OmnigentBridgeSession, bridge_session_id)
+        row.updated_at = when
+        await session.commit()
+
+
+@pytest.mark.asyncio
+async def test_resolve_chat_binding_fails_closed_when_latest_terminal_cleaned_up(store):
+    """Never replay an older run's transcript when the newest terminal session
+    was cleaned up (MoonLadderStudios/MoonMind#3633)."""
+
+    base = datetime(2026, 1, 1, tzinfo=UTC)
+    # Older terminal session whose transcript is still present.
+    await _seed_chat_session(
+        store, key="idem-old", workflow_id="mm:wf-1", agent_run_id="ar-old",
+        session_id="sess-old", terminal_status="completed",
+    )
+    old_row = await store.get_existing("idem-old")
+    # Newest terminal session, whose provider transcript was cleaned up.
+    await _seed_chat_session(
+        store, key="idem-new", workflow_id="mm:wf-1", agent_run_id="ar-new",
+        session_id="sess-new", terminal_status="completed", delete_session=True,
+    )
+    new_row = await store.get_existing("idem-new")
+    await _set_updated_at(store, old_row.bridge_session_id, base)
+    await _set_updated_at(store, new_row.bridge_session_id, base + timedelta(minutes=5))
+
+    resolution = await store.resolve_chat_binding(workflow_id="mm:wf-1")
+    assert resolution.state == CHAT_BINDING_STATE_UNAVAILABLE
+    assert resolution.unavailable_reason == "session_cleaned_up"
+
+
+@pytest.mark.asyncio
+async def test_resolve_chat_binding_uses_latest_terminal_when_older_cleaned_up(store):
+    """The authoritative latest terminal session is returned even if an older
+    session was cleaned up."""
+
+    base = datetime(2026, 1, 1, tzinfo=UTC)
+    await _seed_chat_session(
+        store, key="idem-old", workflow_id="mm:wf-1", agent_run_id="ar-old",
+        session_id="sess-old", terminal_status="completed", delete_session=True,
+    )
+    old_row = await store.get_existing("idem-old")
+    await _seed_chat_session(
+        store, key="idem-new", workflow_id="mm:wf-1", agent_run_id="ar-new",
+        session_id="sess-new", terminal_status="completed",
+    )
+    new_row = await store.get_existing("idem-new")
+    await _set_updated_at(store, old_row.bridge_session_id, base)
+    await _set_updated_at(store, new_row.bridge_session_id, base + timedelta(minutes=5))
+
+    resolution = await store.resolve_chat_binding(workflow_id="mm:wf-1")
+    assert resolution.state == CHAT_BINDING_STATE_ENDED
+    assert resolution.read_only is True
+    assert resolution.chat_binding_id == new_row.chat_binding_id
+
+
+@pytest.mark.asyncio
+async def test_get_or_create_persists_logical_step_id_in_metadata(store):
+    """The logical step id is projected onto the chat binding
+    (MoonLadderStudios/MoonMind#3633)."""
+
+    await store.get_or_create(
+        request=_request("idem-1", with_step=True),
+        endpoint_ref="default",
+        agent_id="agent-1",
+        agent_name="codex",
+        target_metadata={"hostType": "managed"},
+    )
+    row = await store.get_existing("idem-1")
+    assert row.metadata_.get("logicalStepId") == "implement"
+
+    await store.attach_session("idem-1", "sess-1")
+    await store.record_session_created("idem-1", session_id="sess-1")
+    resolution = await store.resolve_chat_binding(workflow_id="mm:wf-1")
+    assert resolution.logical_step_id == "implement"
+
+
+@pytest.mark.asyncio
+async def test_ensure_chat_binding_returns_persisted_winner_on_concurrent_allocation(
+    tmp_path, monkeypatch
+):
+    """The losing side of a concurrent first-time allocation must return the
+    *persisted* winning id, never its own unpersisted candidate
+    (MoonLadderStudios/MoonMind#3633)."""
+
+    from moonmind.omnigent import bridge_store as bridge_store_module
+
+    db_path = f"{tmp_path}/bridge_race.db"
+    # WAL lets the simulated concurrent winner commit through a second connection
+    # while the resolver holds its read transaction open.
+    seed = sqlite3.connect(db_path)
+    try:
+        seed.execute("PRAGMA journal_mode=WAL")
+    finally:
+        seed.close()
+
+    engine = create_async_engine(
+        f"sqlite+aiosqlite:///{db_path}", connect_args={"timeout": 30}
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    session_maker = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    race_store = OmnigentBridgeSessionStore(session_maker)
+    try:
+        await race_store.get_or_create(
+            request=_request("idem-race"),
+            endpoint_ref="default",
+            agent_id="agent-1",
+            agent_name="codex",
+            target_metadata={"hostType": "managed"},
+            workflow_id="mm:wf-race",
+            agent_run_id="ar-race",
+        )
+        # A bound provider session with no chat-binding id yet (historical row).
+        await race_store.attach_session("idem-race", "sess-race")
+        row = await race_store.get_existing("idem-race")
+        assert row.chat_binding_id is None
+
+        winner = f"{CHAT_BINDING_ID_PREFIX}winner"
+        loser = f"{CHAT_BINDING_ID_PREFIX}loser"
+
+        def _winning_allocation() -> str:
+            # Commit the winning id in the gap between this caller's SELECT and
+            # its guarded UPDATE, so the guarded UPDATE affects zero rows.
+            writer = sqlite3.connect(db_path, timeout=30)
+            try:
+                writer.execute(
+                    "UPDATE omnigent_bridge_sessions SET chat_binding_id = ? "
+                    "WHERE bridge_session_id = ? AND chat_binding_id IS NULL",
+                    (winner, row.bridge_session_id),
+                )
+                writer.commit()
+            finally:
+                writer.close()
+            return loser
+
+        monkeypatch.setattr(
+            bridge_store_module, "_generate_chat_binding_id", _winning_allocation
+        )
+
+        resolved = await race_store.ensure_chat_binding_id(row.bridge_session_id)
+        assert resolved == winner
+
+        persisted = await race_store.get_existing("idem-race")
+        assert persisted.chat_binding_id == winner
+    finally:
+        await engine.dispose()

--- a/tests/unit/omnigent/test_bridge_store.py
+++ b/tests/unit/omnigent/test_bridge_store.py
@@ -18,12 +18,18 @@ from sqlalchemy.orm import sessionmaker
 from api_service.db.models import Base, OmnigentBridgeSession
 from moonmind.omnigent.bridge_store import (
     BRIDGE_EVENT_JOURNAL_KEY,
+    CHAT_BINDING_ID_PREFIX,
+    CHAT_BINDING_STATE_AVAILABLE,
+    CHAT_BINDING_STATE_ENDED,
+    CHAT_BINDING_STATE_STARTING,
+    CHAT_BINDING_STATE_UNAVAILABLE,
     FIRST_MESSAGE_ITEM_FRONTIER_KEY,
     FIRST_MESSAGE_TERMINAL,
     SESSION_CREATED_EVENT_TYPE,
     STATUS_ACTIVE,
     STATUS_CREATING,
     STATUS_DECLARED,
+    BridgeChatBindingAmbiguousError,
     BridgeProjectionAmbiguousError,
     OmnigentBridgeSessionStore,
     OmnigentDigestMismatchError,
@@ -1175,3 +1181,221 @@ async def test_record_session_created_persists_across_get_or_create(store):
     )
     assert BRIDGE_EVENT_JOURNAL_KEY in row.metadata_
     assert len(row.metadata_[BRIDGE_EVENT_JOURNAL_KEY]) == 1
+
+
+# --- opaque chat-binding identity + resolution (MoonLadderStudios/MoonMind#3633)
+
+
+async def _seed_chat_session(
+    store,
+    *,
+    key: str,
+    workflow_id: str,
+    agent_run_id: str,
+    session_id: str | None,
+    capabilities: dict | None = None,
+    terminal_status: str | None = None,
+    delete_session: bool = False,
+):
+    """Create a bridge row and drive it to the requested lifecycle state."""
+
+    await store.get_or_create(
+        request=_request(key),
+        endpoint_ref="default",
+        agent_id="agent-1",
+        agent_name="codex",
+        target_metadata={"hostType": "managed"},
+        workflow_id=workflow_id,
+        agent_run_id=agent_run_id,
+    )
+    if session_id is not None:
+        await store.attach_session(key, session_id)
+        await store.record_session_created(
+            key, session_id=session_id, capabilities=capabilities
+        )
+    if terminal_status is not None:
+        await store.mark_terminal(key, status=terminal_status)
+    if delete_session and session_id is not None:
+        await store.record_provider_session_deleted(session_id)
+
+
+@pytest.mark.asyncio
+async def test_chat_binding_allocated_only_after_provider_binding(store):
+    await store.get_or_create(
+        request=_request("idem-1"),
+        endpoint_ref="default",
+        agent_id="agent-1",
+        agent_name="codex",
+        target_metadata={"hostType": "managed"},
+        workflow_id="mm:wf-1",
+        agent_run_id="ar-1",
+    )
+    # No provider session yet -> no durable binding to allocate.
+    assert await store.ensure_chat_binding_id(
+        (await store.get_existing("idem-1")).bridge_session_id
+    ) is None
+
+    await store.attach_session("idem-1", "sess-1")
+    created = await store.record_session_created("idem-1", session_id="sess-1")
+    assert created.chat_binding_id
+    assert created.chat_binding_id.startswith(CHAT_BINDING_ID_PREFIX)
+
+
+@pytest.mark.asyncio
+async def test_chat_binding_allocation_is_idempotent_across_retries(store):
+    await _seed_chat_session(
+        store, key="idem-1", workflow_id="mm:wf-1", agent_run_id="ar-1",
+        session_id="sess-1",
+    )
+    row = await store.get_existing("idem-1")
+    first = row.chat_binding_id
+    assert first
+
+    # A replayed session.created must reuse the same id.
+    again = await store.record_session_created("idem-1", session_id="sess-1")
+    assert again.chat_binding_id == first
+    # ensure_chat_binding_id is also idempotent.
+    assert await store.ensure_chat_binding_id(row.bridge_session_id) == first
+
+
+@pytest.mark.asyncio
+async def test_ensure_chat_binding_backfills_historical_row(store):
+    """A row created before the column existed is backfilled on first touch."""
+
+    await _seed_chat_session(
+        store, key="idem-1", workflow_id="mm:wf-1", agent_run_id="ar-1",
+        session_id="sess-1",
+    )
+    row = await store.get_existing("idem-1")
+    # Simulate a historical row with a bound provider session but no binding id.
+    async with store._session_factory() as session:
+        db_row = await session.get(OmnigentBridgeSession, row.bridge_session_id)
+        db_row.chat_binding_id = None
+        await session.commit()
+
+    backfilled = await store.ensure_chat_binding_id(row.bridge_session_id)
+    assert backfilled and backfilled.startswith(CHAT_BINDING_ID_PREFIX)
+    # Stable on repeat.
+    assert await store.ensure_chat_binding_id(row.bridge_session_id) == backfilled
+
+
+@pytest.mark.asyncio
+async def test_resolve_chat_binding_active_available(store):
+    await _seed_chat_session(
+        store, key="idem-1", workflow_id="mm:wf-1", agent_run_id="ar-1",
+        session_id="sess-1", capabilities={"viewTranscript": True, "sendMessage": True},
+    )
+    resolution = await store.resolve_chat_binding(workflow_id="mm:wf-1")
+    assert resolution.state == CHAT_BINDING_STATE_AVAILABLE
+    assert resolution.read_only is False
+    assert resolution.chat_binding_id
+    assert resolution.capabilities == {"viewTranscript": True, "sendMessage": True}
+
+
+@pytest.mark.asyncio
+async def test_resolve_chat_binding_read_only_from_capabilities(store):
+    await _seed_chat_session(
+        store, key="idem-1", workflow_id="mm:wf-1", agent_run_id="ar-1",
+        session_id="sess-1", capabilities={"viewTranscript": True, "sendMessage": False},
+    )
+    resolution = await store.resolve_chat_binding(workflow_id="mm:wf-1")
+    # Active workflow, but the capability projection withholds sendMessage.
+    assert resolution.state == CHAT_BINDING_STATE_AVAILABLE
+    assert resolution.read_only is True
+
+
+@pytest.mark.asyncio
+async def test_resolve_chat_binding_starting_has_no_binding(store):
+    await store.get_or_create(
+        request=_request("idem-1"),
+        endpoint_ref="default",
+        agent_id="agent-1",
+        agent_name="codex",
+        target_metadata={"hostType": "managed"},
+        workflow_id="mm:wf-1",
+        agent_run_id="ar-1",
+    )
+    resolution = await store.resolve_chat_binding(workflow_id="mm:wf-1")
+    assert resolution.state == CHAT_BINDING_STATE_STARTING
+    assert resolution.chat_binding_id is None
+    assert resolution.read_only is True
+
+
+@pytest.mark.asyncio
+async def test_resolve_chat_binding_terminal_read_only(store):
+    await _seed_chat_session(
+        store, key="idem-1", workflow_id="mm:wf-1", agent_run_id="ar-1",
+        session_id="sess-1", terminal_status="completed",
+    )
+    resolution = await store.resolve_chat_binding(workflow_id="mm:wf-1")
+    assert resolution.state == CHAT_BINDING_STATE_ENDED
+    assert resolution.read_only is True
+    assert resolution.chat_binding_id
+
+
+@pytest.mark.asyncio
+async def test_resolve_chat_binding_unavailable_when_no_session(store):
+    resolution = await store.resolve_chat_binding(workflow_id="mm:wf-unknown")
+    assert resolution.state == CHAT_BINDING_STATE_UNAVAILABLE
+    assert resolution.unavailable_reason == "no_session"
+    assert resolution.chat_binding_id is None
+
+
+@pytest.mark.asyncio
+async def test_resolve_chat_binding_cleaned_up_session(store):
+    await _seed_chat_session(
+        store, key="idem-1", workflow_id="mm:wf-1", agent_run_id="ar-1",
+        session_id="sess-1", terminal_status="completed", delete_session=True,
+    )
+    resolution = await store.resolve_chat_binding(workflow_id="mm:wf-1")
+    assert resolution.state == CHAT_BINDING_STATE_UNAVAILABLE
+    assert resolution.unavailable_reason == "session_cleaned_up"
+
+
+@pytest.mark.asyncio
+async def test_resolve_chat_binding_unsupported_runtime(store):
+    await _seed_chat_session(
+        store, key="idem-1", workflow_id="mm:wf-1", agent_run_id="ar-1",
+        session_id="sess-1",
+    )
+    row = await store.get_existing("idem-1")
+    async with store._session_factory() as session:
+        db_row = await session.get(OmnigentBridgeSession, row.bridge_session_id)
+        db_row.provider = "some-other-runtime"
+        await session.commit()
+
+    resolution = await store.resolve_chat_binding(workflow_id="mm:wf-1")
+    assert resolution.state == CHAT_BINDING_STATE_UNAVAILABLE
+    assert resolution.unavailable_reason == "unsupported_runtime"
+
+
+@pytest.mark.asyncio
+async def test_resolve_chat_binding_rejects_ambiguous_active_sessions(store):
+    await _seed_chat_session(
+        store, key="idem-1", workflow_id="mm:wf-1", agent_run_id="ar-1",
+        session_id="sess-1",
+    )
+    await _seed_chat_session(
+        store, key="idem-2", workflow_id="mm:wf-1", agent_run_id="ar-2",
+        session_id="sess-2",
+    )
+    with pytest.raises(BridgeChatBindingAmbiguousError):
+        await store.resolve_chat_binding(workflow_id="mm:wf-1")
+
+
+@pytest.mark.asyncio
+async def test_resolve_chat_binding_prefers_active_over_terminal(store):
+    # A terminal session plus one active session -> the active one wins and is
+    # not treated as ambiguous.
+    await _seed_chat_session(
+        store, key="idem-old", workflow_id="mm:wf-1", agent_run_id="ar-old",
+        session_id="sess-old", terminal_status="completed",
+    )
+    await _seed_chat_session(
+        store, key="idem-new", workflow_id="mm:wf-1", agent_run_id="ar-new",
+        session_id="sess-new",
+    )
+    active_binding = (await store.get_existing("idem-new")).chat_binding_id
+    resolution = await store.resolve_chat_binding(workflow_id="mm:wf-1")
+    assert resolution.state == CHAT_BINDING_STATE_AVAILABLE
+    assert resolution.chat_binding_id == active_binding


### PR DESCRIPTION
## Issue

Implements MoonLadderStudios/MoonMind#3633 — [Omnigent native chat 1/10] Persist opaque Workflow Chat bindings and expose the chat-binding API.

Closes MoonLadderStudios/MoonMind#3633

## Summary

Adds the authoritative browser-safe `WorkflowChatBinding` that maps one visible Workflow Execution to exactly one server-owned Omnigent session, without exposing provider session, bridge session, endpoint, host, runner, credential, profile, policy, or workspace identity to the ordinary browser path.

- **Durable opaque binding identity** — adds an unguessable `chat_binding_id` (`chatb_` + `secrets.token_urlsafe(24)`) to the existing `omnigent_bridge_sessions` model (migration `353_omnigent_chat_binding.py`, nullable column + unique index). No parallel binding table. Kept distinct from `workflowId`, `runId`, `agentRunId`, `bridgeSessionId`, and provider session ID. Allocation happens only after the durable Workflow-to-provider session binding exists and is retry-safe/idempotent (guarded `ensure_chat_binding_id` UPDATE). Historical rows backfill deterministically on first authoritative touch; NULLs stay distinct under the unique index, so no rows are rewritten and Temporal replay/persisted payloads are unaffected.
- **Authoritative resolver** — `resolve_chat_binding` resolves from trusted state in precedence order (active Step Execution/AgentRun binding → active chat-capable bridge session → last authoritative chat-capable session for a terminal Workflow, read-only → explicit unavailable). Ambiguous active candidates are rejected (`BridgeChatBindingAmbiguousError`) rather than picking the newest arbitrary provider session.
- **Browser-safe route** — `GET /api/executions/{workflowId}/chat-binding` authorizes the caller against the Workflow (`_get_owned_execution`) before touching the store or returning any binding, and returns only the browser-safe `WorkflowChatBinding` allowlist. Server-generated, binding-scoped `chatUrl=/omnigent-ui/workflow-chat/{id}?embedded=1` and `apiBase=/api/workflow-chat-bindings/{id}/omnigent`; the browser never constructs the upstream route.
- **Truthful state + read-only posture** — `starting` / `available` / `ended` (read-only replay) / `unavailable` with stable reasons (`unsupported_runtime`, `no_session`, `session_cleaned_up`). Read-only is driven by the bound session, immutable policy, and effective capabilities — not merely by nonterminal Workflow status.
- **Diagnostics preserved** — `/bridge-sessions/resolve` and bridge event/resource routes are untouched; the native binding uses a separate authorized route and is not made the primary/authorization route.

## Files changed

- `api_service/api/routers/executions.py` — chat-binding route + `WorkflowChatBinding` response model, authorization, 409-on-ambiguity mapping.
- `api_service/db/models.py` — `chat_binding_id` column + unique index.
- `api_service/db/migrations/versions/353_omnigent_chat_binding.py` — migration/backfill.
- `moonmind/omnigent/bridge_store.py` — allocation, `ensure_chat_binding_id`, `resolve_chat_binding`, resolution precedence.
- `tests/unit/omnigent/test_bridge_store.py`, `tests/unit/api/routers/test_executions.py` — coverage.
- `docs/Omnigent/OmnigentBridge.md`, `docs/UI/WorkflowChatPanel.md` — doc references.

## Tests run

Hermetic unit tests (run via `python -m pytest`; the managed container runner was unavailable in the verification runtime because `MOONMIND_AGENT_RUN_ID` was unset — non-blocking per the test taxonomy):

- `tests/unit/omnigent/test_bridge_store.py` — full suite **65 passed**; chat-binding subset **12 passed** (allocation-only-after-binding, idempotent retries, historical backfill, active/available, read-only-from-capabilities, starting, terminal read-only, `no_session`, `session_cleaned_up`, `unsupported_runtime`, ambiguity rejection, active-over-terminal preference).
- `tests/unit/api/routers/test_executions.py -k chat_binding` — **6 passed** (browser-safe allowlist + forbidden-identity assertions, server-generated scoped URLs, terminal read-only, unavailable has no scoped URLs, 409 ambiguity, unauthorized 404, unknown-workflow 404).
- OpenAPI contract export — route `/api/executions/{workflow_id}/chat-binding` and `WorkflowChatBinding` schema present with exactly the 11 browser-safe properties (no provider/bridge/endpoint/host/runner/credential/profile/policy/workspace leaks).

## Remaining risks

- Full multi-viewer runtime authorization (owner / shared authorized viewer / unauthorized viewer) and live runtime state transitions require a deployed environment; the owner/unauthorized/unknown-workflow paths are covered hermetically here, and authorization delegates to the pre-existing codebase-wide `_get_owned_execution` helper.
- Downstream binding-scoped routes (`/api/workflow-chat-bindings/{id}/omnigent`), native UI serving/proxying, and `SubmitChatInstruction`/workflow-plan steering are explicit non-goals of this issue (1/10 in the native-chat series) and are tracked separately.
- No frontend generated OpenAPI/TypeScript fixtures reference the binding yet; UI consumption is a non-goal for this issue. The server contract is verified via the OpenAPI export.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
