### PR TITLE
[Omnigent native chat 2/10] Binding-scoped HTTP/SSE facade with per-request authorization (MoonLadderStudios/MoonMind#3634)

### DIFF
--- a/api_service/api/routers/omnigent_bridge.py
+++ b/api_service/api/routers/omnigent_bridge.py
@@ -97,6 +97,22 @@ from moonmind.omnigent.settings import (
     resolved_proxy_forward_headers,
     resolved_server_url,
 )
+from moonmind.omnigent.workflow_chat_facade import (
+    CODE_BINDING_UNKNOWN,
+    CODE_MALFORMED_PAYLOAD,
+    CODE_OPERATION_DENIED,
+    CODE_PAYLOAD_TOO_LARGE,
+    CODE_ROUTE_NOT_ALLOWLISTED,
+    CODE_SESSION_NOT_READY,
+    CODE_SESSION_READ_ONLY,
+    CODE_UNSUPPORTED_MEDIA_TYPE,
+    WorkflowChatFacadeError,
+    assert_no_identity_substitution,
+    is_read_only,
+    match_facade_operation,
+    recompute_capabilities,
+    required_capability_for_event,
+)
 from moonmind.utils.build_info import resolve_moonmind_build_id
 from moonmind.workflows.adapters.omnigent_agent_adapter import (
     OmnigentAgentSelection,
@@ -1792,87 +1808,124 @@ async def post_omnigent_session_event(
         proxy=control_facade,
     )
     try:
-        if payload.type in {"clear_session", "reset_session"}:
-            # Embedded mode rejects clear/reset without replacing or stopping the
-            # session, so revoking first would permanently disable retrieval for
-            # a session that keeps running.  Reject before mutating authority.
-            if config.host_protocol_mode == HOST_PROTOCOL_MODE_EMBEDDED:
-                raise OmnigentBridgeError(
-                    "Embedded clear/reset requires a new session and idempotency key.",
-                    failure_class="user_error",
-                    status_code=status.HTTP_409_CONFLICT,
-                    code="omnigent_embedded_new_session_required",
-                )
-            await _revoke_session_retrieval_authority(
-                session_id=session_id,
-                registry=registry,
-                store=store,
-                reason="session_replaced",
-            )
-        if payload.type in {"stop", "session.stop", "stop_session"}:
-            await _revoke_session_retrieval_authority(
-                session_id=session_id,
-                registry=registry,
-                store=store,
-                reason="session_stopped",
-            )
-            if config.host_protocol_mode == HOST_PROTOCOL_MODE_EMBEDDED:
-                assert embedded_facade is not None
-                return await embedded_facade.stop_session(
-                    session_id,
-                    payload=payload.model_dump(by_alias=True, exclude_none=True),
-                    actor=str(user.id),
-                )
-            return await control_facade.stop_session(session_id)
-        if payload.type in {"cleanup_session", "terminal_cleanup"}:
-            if config.host_protocol_mode != HOST_PROTOCOL_MODE_EMBEDDED:
-                raise OmnigentBridgeError(
-                    "Typed owned-resource cleanup is unavailable in this mode.",
-                    failure_class="user_error", status_code=501,
-                    code="omnigent_bridge_capability_unavailable",
-                )
-            assert embedded_facade is not None
-            await _revoke_session_retrieval_authority(
-                session_id=session_id,
-                registry=registry,
-                store=store,
-                reason="session_cleanup",
-            )
-            return await embedded_facade.cleanup_session(
-                session_id,
-                payload=payload.model_dump(by_alias=True, exclude_none=True),
-                actor=str(user.id),
-            )
-        if config.host_protocol_mode == HOST_PROTOCOL_MODE_EMBEDDED:
-            assert embedded_facade is not None
-            if payload.type == "harvest_session":
-                return await embedded_facade.harvest_session(
-                    session_id,
-                    payload=payload.model_dump(by_alias=True, exclude_none=True),
-                    actor=str(user.id),
-                )
-            if payload.type == "interrupt":
-                raise OmnigentBridgeError(
-                    "Embedded interrupt is not supported by the pinned host "
-                    "protocol; use stop when terminating the runner is intended.",
-                    failure_class="user_error",
-                    status_code=status.HTTP_501_NOT_IMPLEMENTED,
-                    code="omnigent_embedded_control_unsupported",
-                )
-            if payload.type not in {"message", "user.message"}:
-                raise OmnigentBridgeError(
-                    f"Embedded control {payload.type!r} is not supported.",
-                    failure_class="user_error",
-                    status_code=status.HTTP_501_NOT_IMPLEMENTED,
-                    code="omnigent_embedded_control_unsupported",
-                )
-            return await embedded_facade.post_event(
-                session_id=session_id, event=payload, actor=str(user.id)
-            )
-        assert proxy is not None
-        return await proxy.post_event(session_id=session_id, event=payload)
+        return await _apply_owned_session_control(
+            control_facade=control_facade,
+            session_id=session_id,
+            payload=payload,
+            config=config,
+            actor=str(user.id),
+            proxy=proxy,
+            embedded_facade=embedded_facade,
+            registry=registry,
+            store=store,
+        )
     except OmnigentBridgeError as exc:
         raise _http_error_from_bridge(exc) from exc
+
+
+async def _apply_owned_session_control(
+    *,
+    control_facade: Any,
+    session_id: str,
+    payload: BridgeSessionEventRequest,
+    config: OmnigentBridgeConfig,
+    actor: str,
+    proxy: OmnigentBridgeSessionProxy | None,
+    embedded_facade: OmnigentEmbeddedHostProtocolFacade | None,
+    registry: RetrievalCapabilityRegistry,
+    store: OmnigentBridgeSessionStore,
+) -> dict[str, Any]:
+    """Apply an Omnigent control event to an already-authorized provider session.
+
+    Shared canonical control path for both the provider-session control route
+    (``post_omnigent_session_event``) and the binding-scoped Workflow Chat
+    facade. Callers authorize the session first (by provider-session owner or by
+    durable ``chatBindingId`` binding) and pass the resolved ``session_id``;
+    this helper owns the harvest/clear/stop/cleanup policy, embedded/proxy
+    branching, and retrieval-authority revocation so neither surface reimplements
+    control semantics. Raises :class:`OmnigentBridgeError`; callers map it to a
+    redacted HTTP error.
+    """
+
+    if payload.type in {"clear_session", "reset_session"}:
+        # Embedded mode rejects clear/reset without replacing or stopping the
+        # session, so revoking first would permanently disable retrieval for
+        # a session that keeps running.  Reject before mutating authority.
+        if config.host_protocol_mode == HOST_PROTOCOL_MODE_EMBEDDED:
+            raise OmnigentBridgeError(
+                "Embedded clear/reset requires a new session and idempotency key.",
+                failure_class="user_error",
+                status_code=status.HTTP_409_CONFLICT,
+                code="omnigent_embedded_new_session_required",
+            )
+        await _revoke_session_retrieval_authority(
+            session_id=session_id,
+            registry=registry,
+            store=store,
+            reason="session_replaced",
+        )
+    if payload.type in {"stop", "session.stop", "stop_session"}:
+        await _revoke_session_retrieval_authority(
+            session_id=session_id,
+            registry=registry,
+            store=store,
+            reason="session_stopped",
+        )
+        if config.host_protocol_mode == HOST_PROTOCOL_MODE_EMBEDDED:
+            assert embedded_facade is not None
+            return await embedded_facade.stop_session(
+                session_id,
+                payload=payload.model_dump(by_alias=True, exclude_none=True),
+                actor=actor,
+            )
+        return await control_facade.stop_session(session_id)
+    if payload.type in {"cleanup_session", "terminal_cleanup"}:
+        if config.host_protocol_mode != HOST_PROTOCOL_MODE_EMBEDDED:
+            raise OmnigentBridgeError(
+                "Typed owned-resource cleanup is unavailable in this mode.",
+                failure_class="user_error", status_code=501,
+                code="omnigent_bridge_capability_unavailable",
+            )
+        assert embedded_facade is not None
+        await _revoke_session_retrieval_authority(
+            session_id=session_id,
+            registry=registry,
+            store=store,
+            reason="session_cleanup",
+        )
+        return await embedded_facade.cleanup_session(
+            session_id,
+            payload=payload.model_dump(by_alias=True, exclude_none=True),
+            actor=actor,
+        )
+    if config.host_protocol_mode == HOST_PROTOCOL_MODE_EMBEDDED:
+        assert embedded_facade is not None
+        if payload.type == "harvest_session":
+            return await embedded_facade.harvest_session(
+                session_id,
+                payload=payload.model_dump(by_alias=True, exclude_none=True),
+                actor=actor,
+            )
+        if payload.type == "interrupt":
+            raise OmnigentBridgeError(
+                "Embedded interrupt is not supported by the pinned host "
+                "protocol; use stop when terminating the runner is intended.",
+                failure_class="user_error",
+                status_code=status.HTTP_501_NOT_IMPLEMENTED,
+                code="omnigent_embedded_control_unsupported",
+            )
+        if payload.type not in {"message", "user.message"}:
+            raise OmnigentBridgeError(
+                f"Embedded control {payload.type!r} is not supported.",
+                failure_class="user_error",
+                status_code=status.HTTP_501_NOT_IMPLEMENTED,
+                code="omnigent_embedded_control_unsupported",
+            )
+        return await embedded_facade.post_event(
+            session_id=session_id, event=payload, actor=actor
+        )
+    assert proxy is not None
+    return await proxy.post_event(session_id=session_id, event=payload)
 
 
 @router.post(
@@ -2591,7 +2644,671 @@ async def ingest_embedded_omnigent_host_event(
         raise _http_error_from_bridge(exc) from exc
 
 
+# ---------------------------------------------------------------------------
+# Binding-scoped Workflow Chat facade (MoonLadderStudios/MoonMind#3634)
+#
+# The native Omnigent web application drives one binding-scoped surface keyed by
+# an opaque ``chatBindingId`` (docs/Omnigent/OmnigentBridge.md §4.2, §5.2):
+#
+#   /api/workflow-chat-bindings/{chatBindingId}/omnigent/{path}
+#
+# Every request (and every SSE reconnect) independently authenticates the
+# MoonMind caller, resolves the durable binding, authorizes the caller against
+# the bound Workflow Execution and requested operation, verifies session
+# references map to the one bound provider session, recomputes capabilities from
+# trusted state, strips MoonMind credentials, injects server-side upstream
+# authority, and fails closed before any unauthorized upstream access.
+#
+# Binding resolution seam: allocation of the dedicated opaque ``chat_binding_id``
+# column (§7.1) is MoonLadderStudios/MoonMind#3633. Until it lands, the facade
+# resolves ``chatBindingId`` through the durable bridge session — the existing
+# opaque, server-owned MoonMind key. The provider session id and upstream
+# endpoint stay server-side, so the browser contract is unchanged when a
+# dedicated lookup is introduced (swap ``_resolve_chat_binding_row`` only).
+# ---------------------------------------------------------------------------
+
+WORKFLOW_CHAT_BINDINGS_MOUNT_PATH = "/api/workflow-chat-bindings"
+
+workflow_chat_router = APIRouter(tags=["Omnigent Workflow Chat"])
+
+_FACADE_MAX_BODY_BYTES = 1 * 1024 * 1024
+# Full caller reauthorization cadence while a stream is open. Each new SSE
+# connection (including every EventSource reconnect) is fully authorized by the
+# route dependencies; a long-lived open stream additionally re-verifies binding
+# authority on this cadence so it cannot silently outlive revoked authority.
+_FACADE_STREAM_REAUTH_EVERY_POLLS = 15
+
+
+async def _resolve_chat_binding_row(
+    *, chat_binding_id: str, store: OmnigentBridgeSessionStore
+) -> Any | None:
+    """Resolve the durable binding row for an opaque ``chatBindingId``.
+
+    Single resolution seam (see module note). Today the ``chatBindingId`` is the
+    durable ``bridge_session_id``; when #3633 adds a dedicated ``chat_binding_id``
+    column, only this function changes.
+    """
+
+    return await store.get_bridge_session(chat_binding_id)
+
+
+def _audit_facade(
+    *,
+    outcome: str,
+    operation: str,
+    chat_binding_id: str,
+    user: Any,
+    reason: str | None = None,
+) -> None:
+    """Record bounded, non-disclosing audit evidence for the facade boundary.
+
+    Security-relevant denials and mutations are logged server-side with the
+    binding id and caller only. The record never states whether an alternate
+    provider session exists, matching the non-enumerating browser contract.
+    """
+
+    logger.info(
+        "omnigent.workflow_chat_facade outcome=%s operation=%s binding=%s caller=%s%s",
+        outcome,
+        operation,
+        chat_binding_id,
+        getattr(user, "id", None),
+        f" reason={reason}" if reason else "",
+    )
+
+
+def _binding_unknown_error() -> WorkflowChatFacadeError:
+    """One non-enumerating error shared by unknown-binding and unauthorized-caller.
+
+    Returning the same typed 404 for a missing binding and for a caller that does
+    not own an existing binding prevents enumerating which binding ids exist and
+    never reveals whether an alternate provider session exists (OB-§4.2).
+    """
+
+    return WorkflowChatFacadeError(
+        "No Workflow Chat binding resolves the requested id.",
+        failure_class="user_error",
+        status_code=status.HTTP_404_NOT_FOUND,
+        code=CODE_BINDING_UNKNOWN,
+    )
+
+
+async def _resolve_and_authorize_chat_binding(
+    *,
+    chat_binding_id: str,
+    operation: str,
+    user: User,
+    service: Any,
+    store: OmnigentBridgeSessionStore,
+) -> Any:
+    """Resolve the durable binding and authorize the caller, failing closed.
+
+    Implements OB-§4.2 steps 1-3 for one request: authenticate (already enforced
+    by the route dependency), resolve the durable binding, and authorize the
+    caller against the bound Workflow Execution. Unknown binding and unauthorized
+    caller collapse to one non-enumerating response; the audit record carries the
+    precise reason.
+    """
+
+    row = await _resolve_chat_binding_row(chat_binding_id=chat_binding_id, store=store)
+    if row is None:
+        _audit_facade(
+            outcome="denied",
+            operation=operation,
+            chat_binding_id=chat_binding_id,
+            user=user,
+            reason="binding_unknown",
+        )
+        raise _binding_unknown_error()
+    workflow_id = str(getattr(row, "moonmind_workflow_id", "") or "").strip()
+    agent_run_id = str(getattr(row, "moonmind_agent_run_id", "") or "").strip() or None
+    principal = await resolve_execution_principal(
+        user=user,
+        service=service,
+        workflow_id_header=workflow_id,
+        agent_run_id_header=agent_run_id,
+    )
+    if not principal.workflow_id:
+        _audit_facade(
+            outcome="denied",
+            operation=operation,
+            chat_binding_id=chat_binding_id,
+            user=user,
+            reason="caller_unauthorized",
+        )
+        raise _binding_unknown_error()
+    return row
+
+
+def _virtualize_facade_payload(
+    payload: Any, *, provider_session_id: str, chat_binding_id: str
+) -> Any:
+    """Rewrite a response so no server-side identity reaches the browser.
+
+    Exact-match occurrences of the provider session id are replaced by the
+    virtual ``chatBindingId`` at any nesting depth, and top-level upstream
+    topology fields (endpoint, host, runner, and MoonMind binding metadata) are
+    dropped. Provider session id and upstream endpoint never leave the server
+    (``exposeProviderSessionId: false``).
+    """
+
+    def _rewrite(value: Any) -> Any:
+        if isinstance(value, str):
+            if provider_session_id and value == provider_session_id:
+                return chat_binding_id
+            return value
+        if isinstance(value, dict):
+            return {key: _rewrite(item) for key, item in value.items()}
+        if isinstance(value, list):
+            return [_rewrite(item) for item in value]
+        return value
+
+    rewritten = _rewrite(payload)
+    if isinstance(rewritten, dict):
+        for leaked_key in (
+            "moonmind",
+            "host_id",
+            "hostId",
+            "runner_id",
+            "runnerId",
+            "endpoint",
+            "endpoint_ref",
+            "endpointRef",
+            "base_url",
+            "baseUrl",
+            "upstream_url",
+            "upstreamUrl",
+        ):
+            rewritten.pop(leaked_key, None)
+        if "id" in rewritten or "session_id" in rewritten or "sessionId" in rewritten:
+            rewritten["id"] = chat_binding_id
+    return rewritten
+
+
+async def _read_facade_json_body(request: Request) -> dict[str, Any]:
+    """Read a bounded JSON object body for a facade mutation, or fail closed."""
+
+    content_type = str(request.headers.get("content-type") or "").split(";")[0].strip()
+    if content_type.lower() != "application/json":
+        raise WorkflowChatFacadeError(
+            "This operation requires an application/json request body.",
+            failure_class="user_error",
+            status_code=status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
+            code=CODE_UNSUPPORTED_MEDIA_TYPE,
+        )
+    raw = await request.body()
+    if len(raw) > _FACADE_MAX_BODY_BYTES:
+        raise WorkflowChatFacadeError(
+            "The request body exceeds the Workflow Chat facade limit.",
+            failure_class="user_error",
+            status_code=413,
+            code=CODE_PAYLOAD_TOO_LARGE,
+        )
+    try:
+        parsed = json.loads(raw or b"{}")
+    except (json.JSONDecodeError, ValueError) as exc:
+        raise WorkflowChatFacadeError(
+            "The request body is not valid JSON.",
+            failure_class="user_error",
+            status_code=status.HTTP_400_BAD_REQUEST,
+            code=CODE_MALFORMED_PAYLOAD,
+        ) from exc
+    if not isinstance(parsed, dict):
+        raise WorkflowChatFacadeError(
+            "The request body must be a JSON object.",
+            failure_class="user_error",
+            status_code=status.HTTP_400_BAD_REQUEST,
+            code=CODE_MALFORMED_PAYLOAD,
+        )
+    return parsed
+
+
+def _facade_liveness_state(row: Any) -> str:
+    status_value = str(getattr(row, "status", "") or "").strip().lower()
+    if is_read_only(status_value):
+        return "ended"
+    if not str(getattr(row, "omnigent_session_id", "") or "").strip():
+        return "starting"
+    return "available"
+
+
+async def _stream_workflow_chat_events(
+    *,
+    request: Request,
+    chat_binding_id: str,
+    initial_cursor: int,
+    user: User,
+    service: Any,
+    store: OmnigentBridgeSessionStore,
+):
+    """Yield durable bridge-journal events with cursor + reauthorization semantics.
+
+    Authorization already ran before this generator is returned. The generator
+    additionally re-verifies binding authority on a bounded cadence so a stream
+    cannot silently outlive revoked authority, translates ``Last-Event-ID`` /
+    cursor resume, surfaces retention gaps, and only reports terminal on durable
+    terminal evidence (stream close is never treated as terminal success).
+    """
+
+    last_sequence = initial_cursor
+    idle_polls = 0
+    polls_since_reauth = 0
+    while True:
+        if await request.is_disconnected():
+            return
+        polls_since_reauth += 1
+        if polls_since_reauth >= _FACADE_STREAM_REAUTH_EVERY_POLLS:
+            polls_since_reauth = 0
+            try:
+                await _resolve_and_authorize_chat_binding(
+                    chat_binding_id=chat_binding_id,
+                    operation="stream_events",
+                    user=user,
+                    service=service,
+                    store=store,
+                )
+            except (WorkflowChatFacadeError, OmnigentBridgeError, HTTPException):
+                payload = {
+                    "code": CODE_BINDING_UNKNOWN,
+                    "message": "Workflow Chat binding authority is no longer valid.",
+                }
+                yield (
+                    "event: error\n"
+                    f"data: {json.dumps(payload, separators=(',', ':'))}\n\n"
+                )
+                return
+        page = await store.list_event_page(
+            chat_binding_id, after=last_sequence, limit=_BRIDGE_STREAM_PAGE_SIZE
+        )
+        if (
+            page.earliest_sequence is not None
+            and last_sequence + 1 < page.earliest_sequence
+        ):
+            gap = BridgeRetentionGap(
+                requested_after=last_sequence,
+                earliest_available=page.earliest_sequence,
+            )
+            yield (
+                "event: retention_gap\n"
+                f"data: {gap.model_dump_json(by_alias=True)}\n\n"
+            )
+            return
+        for row in page.rows:
+            last_sequence = row.sequence
+            idle_polls = 0
+            event_payload = json.dumps(
+                _bridge_event_payload(row), separators=(",", ":")
+            )
+            yield f"id: {row.sequence}\nevent: bridge_event\ndata: {event_payload}\n\n"
+        session_row = await store.get_bridge_session(chat_binding_id)
+        envelope = _terminal_envelope(session_row)
+        if (
+            envelope is not None
+            and last_sequence >= page.latest_sequence
+            and not page.has_more
+        ):
+            confirmation = await store.list_event_page(
+                chat_binding_id, after=last_sequence, limit=1
+            )
+            if confirmation.rows or confirmation.latest_sequence > last_sequence:
+                continue
+            yield (
+                "event: terminal\n"
+                f"data: {envelope.model_dump_json(by_alias=True)}\n\n"
+            )
+            return
+        if page.has_more:
+            continue
+        idle_polls += 1
+        yield ": keepalive\n\n"
+        if idle_polls >= _BRIDGE_STREAM_MAX_IDLE_POLLS:
+            return
+        await asyncio.sleep(_BRIDGE_STREAM_POLL_SECONDS)
+
+
+def _initial_stream_cursor(
+    *, cursor: int | None, since: int | None, last_event_id: str | None
+) -> int:
+    header_cursor: int | None = None
+    if last_event_id:
+        try:
+            header_cursor = int(last_event_id)
+        except ValueError as exc:
+            raise WorkflowChatFacadeError(
+                "The Last-Event-ID cursor is invalid.",
+                failure_class="user_error",
+                status_code=status.HTTP_400_BAD_REQUEST,
+                code=CODE_MALFORMED_PAYLOAD,
+            ) from exc
+    return max(
+        (value for value in (cursor, header_cursor, since) if value is not None),
+        default=0,
+    )
+
+
+@workflow_chat_router.api_route(
+    "/{chat_binding_id}/omnigent/{omnigent_path:path}",
+    methods=["GET", "POST"],
+    responses=_PUBLIC_ERROR_RESPONSES,
+)
+async def workflow_chat_binding_facade(
+    chat_binding_id: str,
+    omnigent_path: str,
+    request: Request,
+    config: OmnigentBridgeConfig = Depends(_require_bridge_enabled),
+    user: User = Depends(get_current_user()),
+    service: Any = Depends(_get_execution_service),
+    store: OmnigentBridgeSessionStore = Depends(_get_bridge_store),
+    proxy: OmnigentBridgeSessionProxy | None = Depends(_get_bridge_proxy),
+    embedded_facade: OmnigentEmbeddedHostProtocolFacade | None = Depends(
+        _get_create_embedded_facade
+    ),
+    registry: RetrievalCapabilityRegistry = Depends(get_capability_registry),
+):
+    """Single binding-scoped entrypoint for the native Omnigent Workflow Chat UI.
+
+    Not a generic reverse proxy: every request is matched against an explicit
+    method + route allowlist, reauthorized against the durable binding, checked
+    for identity substitution, capability-gated from recomputed trusted state,
+    and forwarded only to the server-resolved provider session with MoonMind
+    credentials stripped and upstream credentials injected server-side.
+    """
+
+    try:
+        return await _dispatch_workflow_chat_facade(
+            chat_binding_id=chat_binding_id,
+            omnigent_path=omnigent_path,
+            request=request,
+            config=config,
+            user=user,
+            service=service,
+            store=store,
+            proxy=proxy,
+            embedded_facade=embedded_facade,
+            registry=registry,
+        )
+    except (WorkflowChatFacadeError, OmnigentBridgeError) as exc:
+        raise _http_error_from_bridge(exc) from exc
+
+
+async def _dispatch_workflow_chat_facade(
+    *,
+    chat_binding_id: str,
+    omnigent_path: str,
+    request: Request,
+    config: OmnigentBridgeConfig,
+    user: User,
+    service: Any,
+    store: OmnigentBridgeSessionStore,
+    proxy: OmnigentBridgeSessionProxy | None,
+    embedded_facade: OmnigentEmbeddedHostProtocolFacade | None,
+    registry: RetrievalCapabilityRegistry,
+):
+    # 1. Resolve + authorize the durable binding first, so an unauthorized
+    #    caller cannot even probe which routes exist (fully non-enumerating).
+    match = match_facade_operation(request.method, omnigent_path)
+    operation_name = match.operation.name if match else "unknown"
+    row = await _resolve_and_authorize_chat_binding(
+        chat_binding_id=chat_binding_id,
+        operation=operation_name,
+        user=user,
+        service=service,
+        store=store,
+    )
+
+    # 2. Enforce the explicit method + route allowlist.
+    if match is None:
+        _audit_facade(
+            outcome="denied",
+            operation="unknown",
+            chat_binding_id=chat_binding_id,
+            user=user,
+            reason="route_not_allowlisted",
+        )
+        raise WorkflowChatFacadeError(
+            "The requested route is not available on this binding.",
+            failure_class="user_error",
+            status_code=status.HTTP_404_NOT_FOUND,
+            code=CODE_ROUTE_NOT_ALLOWLISTED,
+        )
+    operation = match.operation
+    params = match.params
+    provider_session_id = str(getattr(row, "omnigent_session_id", "") or "").strip()
+    session_status = str(getattr(row, "status", "") or "")
+    capabilities = recompute_capabilities(session_status)
+
+    # 3. Read a bounded JSON body for mutations before the substitution guard.
+    body: dict[str, Any] | None = None
+    if request.method.upper() == "POST":
+        body = await _read_facade_json_body(request)
+
+    # 4. Reject any attempt to substitute a server-owned identity in the path,
+    #    query, body, or headers (session id may only echo the bound id).
+    try:
+        assert_no_identity_substitution(
+            chat_binding_id=chat_binding_id,
+            path_session_id=params.get("session_id"),
+            query=dict(request.query_params),
+            body=body,
+            headers=request.headers,
+        )
+    except WorkflowChatFacadeError:
+        _audit_facade(
+            outcome="denied",
+            operation=operation.name,
+            chat_binding_id=chat_binding_id,
+            user=user,
+            reason="identity_substitution",
+        )
+        raise
+
+    # 5. Liveness probe is served locally and never forwarded upstream.
+    if operation.name == "liveness":
+        return {
+            "chatBindingId": chat_binding_id,
+            "state": _facade_liveness_state(row),
+            "readOnly": is_read_only(session_status),
+            "capabilities": capabilities,
+        }
+
+    # 6. Recompute-driven capability + session-state gates.
+    if operation.requires_provider_session and not provider_session_id:
+        raise WorkflowChatFacadeError(
+            "The Workflow Chat binding has no active provider session yet.",
+            failure_class="user_error",
+            status_code=status.HTTP_409_CONFLICT,
+            code=CODE_SESSION_NOT_READY,
+        )
+    if operation.capability and not capabilities.get(operation.capability, False):
+        _audit_facade(
+            outcome="denied",
+            operation=operation.name,
+            chat_binding_id=chat_binding_id,
+            user=user,
+            reason="capability_denied",
+        )
+        raise WorkflowChatFacadeError(
+            "The requested operation is not permitted for this binding.",
+            failure_class="user_error",
+            status_code=status.HTTP_403_FORBIDDEN,
+            code=CODE_OPERATION_DENIED,
+        )
+
+    facade = (
+        embedded_facade
+        if config.host_protocol_mode == HOST_PROTOCOL_MODE_EMBEDDED
+        else proxy
+    )
+    if operation.name != "stream_events" and facade is None:
+        raise WorkflowChatFacadeError(
+            "The Omnigent bridge host protocol mode does not support this route.",
+            failure_class="system_error",
+            status_code=status.HTTP_501_NOT_IMPLEMENTED,
+            code="omnigent_bridge_mode_unsupported",
+        )
+
+    # 7. Live/replay stream from the durable journal (cursor + reauth semantics).
+    if operation.name == "stream_events":
+        initial_cursor = _initial_stream_cursor(
+            cursor=_int_or_none(request.query_params.get("cursor")),
+            since=_int_or_none(request.query_params.get("since")),
+            last_event_id=request.headers.get("Last-Event-ID"),
+        )
+        return StreamingResponse(
+            _stream_workflow_chat_events(
+                request=request,
+                chat_binding_id=chat_binding_id,
+                initial_cursor=initial_cursor,
+                user=user,
+                service=service,
+                store=store,
+            ),
+            media_type="text/event-stream",
+        )
+
+    # 8. Session metadata / catalog.
+    if operation.name == "list_agents":
+        agents = await facade.list_agents()
+        return _virtualize_facade_payload(
+            agents,
+            provider_session_id=provider_session_id,
+            chat_binding_id=chat_binding_id,
+        )
+
+    # 9. Session snapshot / bootstrap / history.
+    if operation.name == "get_session":
+        snapshot = await facade.get_session(provider_session_id)
+        virtualized = _virtualize_facade_payload(
+            snapshot,
+            provider_session_id=provider_session_id,
+            chat_binding_id=chat_binding_id,
+        )
+        if isinstance(virtualized, dict):
+            virtualized["capabilities"] = capabilities
+            virtualized["readOnly"] = is_read_only(session_status)
+        return virtualized
+
+    # 10. Message / control events — routed through the shared control path.
+    if operation.name == "post_event":
+        try:
+            event = BridgeSessionEventRequest.model_validate(body or {})
+        except ValidationError as exc:
+            raise WorkflowChatFacadeError(
+                "The control event body is not a supported shape.",
+                failure_class="user_error",
+                status_code=status.HTTP_400_BAD_REQUEST,
+                code=CODE_MALFORMED_PAYLOAD,
+            ) from exc
+        if is_read_only(session_status):
+            raise WorkflowChatFacadeError(
+                "This Workflow Chat session is terminal and read-only.",
+                failure_class="user_error",
+                status_code=status.HTTP_409_CONFLICT,
+                code=CODE_SESSION_READ_ONLY,
+            )
+        required = required_capability_for_event(event.type)
+        if not capabilities.get(required, False):
+            _audit_facade(
+                outcome="denied",
+                operation="post_event",
+                chat_binding_id=chat_binding_id,
+                user=user,
+                reason="capability_denied",
+            )
+            raise WorkflowChatFacadeError(
+                "The requested control is not permitted for this binding.",
+                failure_class="user_error",
+                status_code=status.HTTP_403_FORBIDDEN,
+                code=CODE_OPERATION_DENIED,
+            )
+        result = await _apply_owned_session_control(
+            control_facade=facade,
+            session_id=provider_session_id,
+            payload=event,
+            config=config,
+            actor=str(user.id),
+            proxy=proxy,
+            embedded_facade=embedded_facade,
+            registry=registry,
+            store=store,
+        )
+        _audit_facade(
+            outcome="mutation",
+            operation=f"post_event:{event.type}",
+            chat_binding_id=chat_binding_id,
+            user=user,
+        )
+        return _virtualize_facade_payload(
+            result,
+            provider_session_id=provider_session_id,
+            chat_binding_id=chat_binding_id,
+        )
+
+    # 11. Elicitation / approval resolution.
+    if operation.name == "resolve_elicitation":
+        if is_read_only(session_status):
+            raise WorkflowChatFacadeError(
+                "This Workflow Chat session is terminal and read-only.",
+                failure_class="user_error",
+                status_code=status.HTTP_409_CONFLICT,
+                code=CODE_SESSION_READ_ONLY,
+            )
+        actor_kwargs = (
+            {"actor": str(user.id)}
+            if config.host_protocol_mode == HOST_PROTOCOL_MODE_EMBEDDED
+            else {}
+        )
+        result = await facade.resolve_elicitation(
+            session_id=provider_session_id,
+            elicitation_id=params["elicitation_id"],
+            payload=body or {},
+            **actor_kwargs,
+        )
+        _audit_facade(
+            outcome="mutation",
+            operation="resolve_elicitation",
+            chat_binding_id=chat_binding_id,
+            user=user,
+        )
+        return _virtualize_facade_payload(
+            result,
+            provider_session_id=provider_session_id,
+            chat_binding_id=chat_binding_id,
+        )
+
+    # 12. Read-only resource indexes and content.
+    resource_value = params.get("res_path") or params.get("file_id")
+    result = await facade.get_resource(
+        operation.name, provider_session_id, resource_value
+    )
+    if operation.binary and isinstance(result, bytes):
+        media_type = (
+            "text/x-diff"
+            if operation.name == "workspace_diff"
+            else "application/octet-stream"
+        )
+        return Response(content=result, media_type=media_type)
+    return _virtualize_facade_payload(
+        result,
+        provider_session_id=provider_session_id,
+        chat_binding_id=chat_binding_id,
+    )
+
+
+def _int_or_none(value: Any) -> int | None:
+    text = str(value or "").strip()
+    if not text:
+        return None
+    try:
+        parsed = int(text)
+    except ValueError:
+        return None
+    return parsed if parsed >= 0 else None
+
+
 __all__ = [
     "OMNIGENT_BRIDGE_MOUNT_PATH",
+    "WORKFLOW_CHAT_BINDINGS_MOUNT_PATH",
     "router",
+    "workflow_chat_router",
 ]

--- a/api_service/api/routers/omnigent_bridge.py
+++ b/api_service/api/routers/omnigent_bridge.py
@@ -19,6 +19,7 @@ import logging
 import os
 from datetime import timedelta
 from typing import Any, Literal
+from uuid import uuid4
 
 from fastapi import (
     APIRouter, Depends, Header, HTTPException, Query, Request, WebSocket,
@@ -98,7 +99,9 @@ from moonmind.omnigent.settings import (
     resolved_server_url,
 )
 from moonmind.omnigent.workflow_chat_facade import (
+    CAP_RESOLVE_ELICITATION,
     CODE_BINDING_UNKNOWN,
+    CODE_CONTENT_BLOCKED,
     CODE_MALFORMED_PAYLOAD,
     CODE_OPERATION_DENIED,
     CODE_PAYLOAD_TOO_LARGE,
@@ -112,6 +115,11 @@ from moonmind.omnigent.workflow_chat_facade import (
     match_facade_operation,
     recompute_capabilities,
     required_capability_for_event,
+)
+from moonmind.security import (
+    OutboundBundleItem,
+    resolve_high_security_mode,
+    scan_outbound_bundle,
 )
 from moonmind.utils.build_info import resolve_moonmind_build_id
 from moonmind.workflows.adapters.omnigent_agent_adapter import (
@@ -2780,16 +2788,39 @@ async def _resolve_and_authorize_chat_binding(
     return row
 
 
+# Upstream/topology keys that must never reach the browser, at any nesting
+# depth. Dropped from every mapping in a virtualized response — not only the
+# root — so a list result (e.g. ``GET v1/agents``) or a nested snapshot/resource
+# object cannot preserve ``endpoint``, ``host_id``, ``runner_id``, or MoonMind
+# binding metadata (OB-§4.2: provider topology stays server-side).
+_FACADE_TOPOLOGY_KEYS: frozenset[str] = frozenset(
+    {
+        "moonmind",
+        "host_id",
+        "hostId",
+        "runner_id",
+        "runnerId",
+        "endpoint",
+        "endpoint_ref",
+        "endpointRef",
+        "base_url",
+        "baseUrl",
+        "upstream_url",
+        "upstreamUrl",
+    }
+)
+
+
 def _virtualize_facade_payload(
     payload: Any, *, provider_session_id: str, chat_binding_id: str
 ) -> Any:
     """Rewrite a response so no server-side identity reaches the browser.
 
     Exact-match occurrences of the provider session id are replaced by the
-    virtual ``chatBindingId`` at any nesting depth, and top-level upstream
-    topology fields (endpoint, host, runner, and MoonMind binding metadata) are
-    dropped. Provider session id and upstream endpoint never leave the server
-    (``exposeProviderSessionId: false``).
+    virtual ``chatBindingId`` at any nesting depth, and upstream topology fields
+    (endpoint, host, runner, and MoonMind binding metadata) are dropped from
+    every mapping regardless of response shape. Provider session id and upstream
+    endpoint never leave the server (``exposeProviderSessionId: false``).
     """
 
     def _rewrite(value: Any) -> Any:
@@ -2798,28 +2829,17 @@ def _virtualize_facade_payload(
                 return chat_binding_id
             return value
         if isinstance(value, dict):
-            return {key: _rewrite(item) for key, item in value.items()}
+            return {
+                key: _rewrite(item)
+                for key, item in value.items()
+                if key not in _FACADE_TOPOLOGY_KEYS
+            }
         if isinstance(value, list):
             return [_rewrite(item) for item in value]
         return value
 
     rewritten = _rewrite(payload)
     if isinstance(rewritten, dict):
-        for leaked_key in (
-            "moonmind",
-            "host_id",
-            "hostId",
-            "runner_id",
-            "runnerId",
-            "endpoint",
-            "endpoint_ref",
-            "endpointRef",
-            "base_url",
-            "baseUrl",
-            "upstream_url",
-            "upstreamUrl",
-        ):
-            rewritten.pop(leaked_key, None)
         if "id" in rewritten or "session_id" in rewritten or "sessionId" in rewritten:
             rewritten["id"] = chat_binding_id
     return rewritten
@@ -2836,14 +2856,42 @@ async def _read_facade_json_body(request: Request) -> dict[str, Any]:
             status_code=status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
             code=CODE_UNSUPPORTED_MEDIA_TYPE,
         )
-    raw = await request.body()
-    if len(raw) > _FACADE_MAX_BODY_BYTES:
-        raise WorkflowChatFacadeError(
+
+    def _too_large() -> WorkflowChatFacadeError:
+        return WorkflowChatFacadeError(
             "The request body exceeds the Workflow Chat facade limit.",
             failure_class="user_error",
             status_code=413,
             code=CODE_PAYLOAD_TOO_LARGE,
         )
+
+    # Reject an oversized *declared* length before reading a single byte so an
+    # authenticated client cannot make the API buffer a very large payload just
+    # to receive the 413 (OB-§4.2 resource boundary).
+    declared_length = request.headers.get("content-length")
+    if declared_length is not None:
+        try:
+            if int(declared_length) > _FACADE_MAX_BODY_BYTES:
+                raise _too_large()
+        except ValueError as exc:
+            raise WorkflowChatFacadeError(
+                "The request declared an invalid content length.",
+                failure_class="user_error",
+                status_code=status.HTTP_400_BAD_REQUEST,
+                code=CODE_MALFORMED_PAYLOAD,
+            ) from exc
+
+    # Consume the ASGI body incrementally with a hard byte cap so a chunked or
+    # length-underdeclared upload is aborted as soon as it crosses the limit
+    # rather than after the whole payload is resident in memory.
+    chunks: list[bytes] = []
+    received = 0
+    async for chunk in request.stream():
+        received += len(chunk)
+        if received > _FACADE_MAX_BODY_BYTES:
+            raise _too_large()
+        chunks.append(chunk)
+    raw = b"".join(chunks)
     try:
         parsed = json.loads(raw or b"{}")
     except (json.JSONDecodeError, ValueError) as exc:
@@ -2872,10 +2920,224 @@ def _facade_liveness_state(row: Any) -> str:
     return "available"
 
 
+def _durable_terminal_snapshot(
+    row: Any, *, chat_binding_id: str, capabilities: dict[str, bool]
+) -> dict[str, Any]:
+    """Build a read-only bootstrap snapshot from the durable projection.
+
+    Used when a terminal binding's provider session was deleted after harvest:
+    the durable row still carries final snapshots, event journals, and terminal
+    refs, so the native application can display its read-only transcript without
+    a live upstream session id. No server-side identity is included.
+    """
+
+    envelope = _terminal_envelope(row)
+    snapshot: dict[str, Any] = {
+        "id": chat_binding_id,
+        "sessionId": chat_binding_id,
+        "status": str(getattr(row, "status", "") or ""),
+        "readOnly": True,
+        "capabilities": capabilities,
+        "providerSessionAvailable": False,
+    }
+    if envelope is not None:
+        snapshot["terminal"] = envelope.model_dump(by_alias=True)
+    return snapshot
+
+
+def _facade_idempotency_key(request: Request) -> str | None:
+    """Return the caller-supplied ``Idempotency-Key`` for a facade mutation."""
+
+    raw = str(request.headers.get("Idempotency-Key") or "").strip()
+    return raw[:255] or None
+
+
+def _collect_text_fields(value: Any, *, prefix: str = "body") -> list[tuple[str, str]]:
+    """Recursively collect ``(location, text)`` pairs from a JSON-shaped body."""
+
+    collected: list[tuple[str, str]] = []
+    if isinstance(value, str):
+        collected.append((prefix, value))
+    elif isinstance(value, dict):
+        for key, item in value.items():
+            collected.extend(_collect_text_fields(item, prefix=f"{prefix}.{key}"))
+    elif isinstance(value, (list, tuple)):
+        for index, item in enumerate(value):
+            collected.extend(_collect_text_fields(item, prefix=f"{prefix}[{index}]"))
+    return collected
+
+
+def _scan_native_event_before_forward(*, body: dict[str, Any] | None) -> None:
+    """Fail closed on secret-bearing native content in high-security mode.
+
+    The repository's fail-closed security mode must apply on the browser
+    composer path too: a native message carrying a credential or another blocked
+    secret must not reach ``_apply_owned_session_control`` and be posted
+    upstream. Every text-bearing field at any depth is scanned; a non-mapping
+    (uninspectable) body was already rejected by :func:`_read_facade_json_body`.
+    """
+
+    if not resolve_high_security_mode():
+        return
+    items = [
+        OutboundBundleItem(location=location, content=text)
+        for location, text in _collect_text_fields(body or {})
+    ]
+    if not items:
+        return
+    result = scan_outbound_bundle(items, high_security_mode=True)
+    if not result.allowed:
+        raise WorkflowChatFacadeError(
+            "The message contains content blocked by the security policy.",
+            failure_class="user_error",
+            status_code=status.HTTP_403_FORBIDDEN,
+            code=CODE_CONTENT_BLOCKED,
+        )
+
+
+async def _revalidate_binding_before_mutation(
+    *,
+    store: OmnigentBridgeSessionStore,
+    chat_binding_id: str,
+    expected_provider_session_id: str,
+) -> tuple[Any, str, dict[str, bool]]:
+    """Re-read and compare-and-set the binding state at the mutation handoff.
+
+    The read-only decision and capabilities were computed from the row loaded at
+    the start of the request, but the provider mutation is issued later — after
+    the body is buffered and scanned. Re-resolve the durable binding immediately
+    before the side effect so a session that terminalized, was replaced, or had
+    its policy revoked mid-request cannot be mutated with stale authority. The
+    fresh provider session id and fresh capabilities are returned for the caller
+    to forward with and re-check.
+    """
+
+    fresh = await _resolve_chat_binding_row(chat_binding_id=chat_binding_id, store=store)
+    if fresh is None:
+        raise _binding_unknown_error()
+    fresh_status = str(getattr(fresh, "status", "") or "")
+    if is_read_only(fresh_status):
+        raise WorkflowChatFacadeError(
+            "This Workflow Chat session is terminal and read-only.",
+            failure_class="user_error",
+            status_code=status.HTTP_409_CONFLICT,
+            code=CODE_SESSION_READ_ONLY,
+        )
+    fresh_provider = str(getattr(fresh, "omnigent_session_id", "") or "").strip()
+    if fresh_provider != expected_provider_session_id:
+        raise WorkflowChatFacadeError(
+            "The Workflow Chat session changed before the request completed.",
+            failure_class="user_error",
+            status_code=status.HTTP_409_CONFLICT,
+            code=CODE_SESSION_NOT_READY,
+        )
+    fresh_capabilities = recompute_capabilities(
+        fresh_status, policy_capabilities=_projection_capabilities(fresh)
+    )
+    return fresh, fresh_provider, fresh_capabilities
+
+
+async def _claim_facade_message(
+    *,
+    store: OmnigentBridgeSessionStore,
+    row: Any,
+    event_type: str,
+    actor: str,
+    idempotency_key: str,
+) -> bool:
+    """Atomically claim a native message submission for exactly-once forwarding.
+
+    Persists a durable, secret-safe control record keyed by the caller's
+    idempotency key. Returns ``True`` for the one claimant that may forward the
+    provider POST and ``False`` on a replay (browser retry or double-submit), so
+    the facade never issues a duplicate provider turn or duplicate billing.
+    """
+
+    return await store.claim_lifecycle_event(
+        row.idempotency_key,
+        event_type="workflow_chat_message",
+        event_identity=f"workflow-chat-message:{idempotency_key}",
+        summary=f"native chat {event_type}",
+        metadata={
+            "actor": actor,
+            "controlType": event_type,
+            "controlOutcome": "posting",
+            "controlIdempotencyKey": idempotency_key,
+            "sourceMode": "workflow_chat_facade",
+        },
+    )
+
+
+async def _record_facade_mutation_audit(
+    *,
+    store: OmnigentBridgeSessionStore,
+    row: Any,
+    control_type: str,
+    outcome: str,
+    actor: str,
+    idempotency_key: str | None = None,
+) -> None:
+    """Persist durable, secret-safe evidence of a facade mutation (OB-§19).
+
+    A rotating process log is not durable evidence, so mutation outcomes are
+    recorded in the binding's durable control/event ledger with the actor,
+    control type, normalized outcome, and (when present) idempotency key.
+    """
+
+    metadata: dict[str, Any] = {
+        "actor": actor,
+        "controlType": control_type,
+        "controlOutcome": outcome,
+        "sourceMode": "workflow_chat_facade",
+    }
+    if idempotency_key:
+        metadata["controlIdempotencyKey"] = idempotency_key
+    identity_suffix = idempotency_key or actor
+    try:
+        await store.record_lifecycle_event(
+            row.idempotency_key,
+            event_type="workflow_chat_control",
+            event_identity=(
+                f"workflow-chat-control:{control_type}:{outcome}:{identity_suffix}"
+            ),
+            summary=f"workflow chat {control_type} {outcome}",
+            metadata=metadata,
+        )
+    except OmnigentIdempotencyError:
+        # The durable row lock lost a benign race with terminal processing; the
+        # authoritative terminal evidence remains, so the audit is best-effort.
+        logger.info(
+            "omnigent.workflow_chat_facade audit-skip control=%s outcome=%s",
+            control_type,
+            outcome,
+        )
+
+
+def _event_is_chat_visible(row: Any) -> bool:
+    """Return whether a journal row is meant for the browser transcript.
+
+    Bridge lifecycle/control rows explicitly set
+    ``metadata.moonmind.workflowChatVisible = False`` (they can carry internal
+    control idempotency keys, cleanup details, and host-lease references). Those
+    rows are excluded from the native SSE stream; anything without an explicit
+    ``False`` remains visible.
+    """
+
+    metadata = getattr(row, "metadata_", None)
+    if not isinstance(metadata, dict):
+        return True
+    moonmind = metadata.get("moonmind")
+    if isinstance(moonmind, dict) and moonmind.get("workflowChatVisible") is False:
+        return False
+    return True
+
+
 async def _stream_workflow_chat_events(
     *,
     request: Request,
     chat_binding_id: str,
+    bridge_session_id: str,
+    provider_session_id: str,
     initial_cursor: int,
     user: User,
     service: Any,
@@ -2888,6 +3150,11 @@ async def _stream_workflow_chat_events(
     cannot silently outlive revoked authority, translates ``Last-Event-ID`` /
     cursor resume, surfaces retention gaps, and only reports terminal on durable
     terminal evidence (stream close is never treated as terminal success).
+
+    Journal reads use the resolved ``bridge_session_id`` (not the browser's
+    ``chat_binding_id``); reauthorization uses the ``chat_binding_id``. Rows the
+    durable projection marks non-visible are skipped, and every emitted event is
+    virtualized so no server-side identity reaches the browser.
     """
 
     last_sequence = initial_cursor
@@ -2918,7 +3185,7 @@ async def _stream_workflow_chat_events(
                 )
                 return
         page = await store.list_event_page(
-            chat_binding_id, after=last_sequence, limit=_BRIDGE_STREAM_PAGE_SIZE
+            bridge_session_id, after=last_sequence, limit=_BRIDGE_STREAM_PAGE_SIZE
         )
         if (
             page.earliest_sequence is not None
@@ -2936,11 +3203,25 @@ async def _stream_workflow_chat_events(
         for row in page.rows:
             last_sequence = row.sequence
             idle_polls = 0
+            if not _event_is_chat_visible(row):
+                continue
+            payload = _bridge_event_payload(row)
+            # The browser only ever sees the opaque chatBindingId; map the
+            # server-owned bridge-session identifiers to it before virtualizing
+            # away any provider session id.
+            for identity_key in ("bridgeSessionId", "sessionId", "session_id"):
+                if identity_key in payload:
+                    payload[identity_key] = chat_binding_id
             event_payload = json.dumps(
-                _bridge_event_payload(row), separators=(",", ":")
+                _virtualize_facade_payload(
+                    payload,
+                    provider_session_id=provider_session_id,
+                    chat_binding_id=chat_binding_id,
+                ),
+                separators=(",", ":"),
             )
             yield f"id: {row.sequence}\nevent: bridge_event\ndata: {event_payload}\n\n"
-        session_row = await store.get_bridge_session(chat_binding_id)
+        session_row = await store.get_bridge_session(bridge_session_id)
         envelope = _terminal_envelope(session_row)
         if (
             envelope is not None
@@ -2948,7 +3229,7 @@ async def _stream_workflow_chat_events(
             and not page.has_more
         ):
             confirmation = await store.list_event_page(
-                chat_binding_id, after=last_sequence, limit=1
+                bridge_session_id, after=last_sequence, limit=1
             )
             if confirmation.rows or confirmation.latest_sequence > last_sequence:
                 continue
@@ -3073,9 +3354,18 @@ async def _dispatch_workflow_chat_facade(
         )
     operation = match.operation
     params = match.params
+    # Journal reads use the resolved durable bridge-session key; the browser only
+    # ever names the opaque ``chat_binding_id`` (they are the same value today but
+    # diverge once #3633 adds a dedicated binding column — see module note).
+    bridge_session_id = str(getattr(row, "bridge_session_id", "") or "").strip()
     provider_session_id = str(getattr(row, "omnigent_session_id", "") or "").strip()
     session_status = str(getattr(row, "status", "") or "")
-    capabilities = recompute_capabilities(session_status)
+    # Capabilities are recomputed from trusted status *and* intersected with the
+    # binding's stored policy so a disabled operation is never re-advertised or
+    # re-authorized from status alone.
+    capabilities = recompute_capabilities(
+        session_status, policy_capabilities=_projection_capabilities(row)
+    )
 
     # 3. Read a bounded JSON body for mutations before the substitution guard.
     body: dict[str, Any] | None = None
@@ -3112,7 +3402,21 @@ async def _dispatch_workflow_chat_facade(
         }
 
     # 6. Recompute-driven capability + session-state gates.
-    if operation.requires_provider_session and not provider_session_id:
+    #    A terminal binding deliberately survives provider cleanup with durable
+    #    final snapshots and event journals, so its read-only transcript bootstrap
+    #    (``get_session``) is served from the durable projection rather than
+    #    requiring a live upstream session id. Every other provider-session-backed
+    #    operation still fails closed until a session is attached.
+    serve_durable_terminal_snapshot = (
+        operation.name == "get_session"
+        and is_read_only(session_status)
+        and not provider_session_id
+    )
+    if (
+        operation.requires_provider_session
+        and not provider_session_id
+        and not serve_durable_terminal_snapshot
+    ):
         raise WorkflowChatFacadeError(
             "The Workflow Chat binding has no active provider session yet.",
             failure_class="user_error",
@@ -3150,14 +3454,16 @@ async def _dispatch_workflow_chat_facade(
     # 7. Live/replay stream from the durable journal (cursor + reauth semantics).
     if operation.name == "stream_events":
         initial_cursor = _initial_stream_cursor(
-            cursor=_int_or_none(request.query_params.get("cursor")),
-            since=_int_or_none(request.query_params.get("since")),
+            cursor=_strict_query_cursor(request.query_params.get("cursor"), "cursor"),
+            since=_strict_query_cursor(request.query_params.get("since"), "since"),
             last_event_id=request.headers.get("Last-Event-ID"),
         )
         return StreamingResponse(
             _stream_workflow_chat_events(
                 request=request,
                 chat_binding_id=chat_binding_id,
+                bridge_session_id=bridge_session_id,
+                provider_session_id=provider_session_id,
                 initial_cursor=initial_cursor,
                 user=user,
                 service=service,
@@ -3177,6 +3483,14 @@ async def _dispatch_workflow_chat_facade(
 
     # 9. Session snapshot / bootstrap / history.
     if operation.name == "get_session":
+        if serve_durable_terminal_snapshot:
+            # Provider session was deleted after harvest; bootstrap the read-only
+            # transcript from the durable projection instead of a live upstream id.
+            return _durable_terminal_snapshot(
+                row,
+                chat_binding_id=chat_binding_id,
+                capabilities=capabilities,
+            )
         snapshot = await facade.get_session(provider_session_id)
         virtualized = _virtualize_facade_payload(
             snapshot,
@@ -3221,9 +3535,73 @@ async def _dispatch_workflow_chat_facade(
                 status_code=status.HTTP_403_FORBIDDEN,
                 code=CODE_OPERATION_DENIED,
             )
+
+        # Fail-closed outbound secret scan before any provider forward.
+        try:
+            _scan_native_event_before_forward(body=body)
+        except WorkflowChatFacadeError:
+            _audit_facade(
+                outcome="denied",
+                operation="post_event",
+                chat_binding_id=chat_binding_id,
+                user=user,
+                reason="content_blocked",
+            )
+            raise
+
+        # Revalidate the binding/session state at the mutation handoff (CAS):
+        # the row was loaded before the body was buffered and scanned.
+        fresh_row, fresh_provider, fresh_capabilities = (
+            await _revalidate_binding_before_mutation(
+                store=store,
+                chat_binding_id=chat_binding_id,
+                expected_provider_session_id=provider_session_id,
+            )
+        )
+        if not fresh_capabilities.get(required, False):
+            _audit_facade(
+                outcome="denied",
+                operation="post_event",
+                chat_binding_id=chat_binding_id,
+                user=user,
+                reason="capability_revoked",
+            )
+            raise WorkflowChatFacadeError(
+                "The requested control is not permitted for this binding.",
+                failure_class="user_error",
+                status_code=status.HTTP_403_FORBIDDEN,
+                code=CODE_OPERATION_DENIED,
+            )
+
+        # Idempotent submission: a caller-supplied ``Idempotency-Key`` makes a
+        # browser retry or double-submit resolve to exactly one provider turn.
+        client_key = _facade_idempotency_key(request)
+        effective_key = client_key or f"mm-{uuid4().hex}"
+        claimed = await _claim_facade_message(
+            store=store,
+            row=fresh_row,
+            event_type=event.type,
+            actor=str(user.id),
+            idempotency_key=effective_key,
+        )
+        if not claimed:
+            # Replay of a previously accepted key: reconcile without re-posting.
+            _audit_facade(
+                outcome="deduplicated",
+                operation=f"post_event:{event.type}",
+                chat_binding_id=chat_binding_id,
+                user=user,
+            )
+            return {
+                "ok": True,
+                "deduplicated": True,
+                "type": event.type,
+                "session_id": chat_binding_id,
+            }
+
         result = await _apply_owned_session_control(
             control_facade=facade,
-            session_id=provider_session_id,
+            session_id=fresh_provider,
             payload=event,
             config=config,
             actor=str(user.id),
@@ -3231,6 +3609,14 @@ async def _dispatch_workflow_chat_facade(
             embedded_facade=embedded_facade,
             registry=registry,
             store=store,
+        )
+        await _record_facade_mutation_audit(
+            store=store,
+            row=fresh_row,
+            control_type=event.type,
+            outcome="posted",
+            actor=str(user.id),
+            idempotency_key=effective_key,
         )
         _audit_facade(
             outcome="mutation",
@@ -3240,7 +3626,7 @@ async def _dispatch_workflow_chat_facade(
         )
         return _virtualize_facade_payload(
             result,
-            provider_session_id=provider_session_id,
+            provider_session_id=fresh_provider,
             chat_binding_id=chat_binding_id,
         )
 
@@ -3253,16 +3639,67 @@ async def _dispatch_workflow_chat_facade(
                 status_code=status.HTTP_409_CONFLICT,
                 code=CODE_SESSION_READ_ONLY,
             )
+        # Approval resolution requires its own capability (intersected with the
+        # binding policy), not merely a non-terminal session. A workflow owner
+        # whose effective policy denies approval must not resolve elicitations.
+        if not capabilities.get(CAP_RESOLVE_ELICITATION, False):
+            _audit_facade(
+                outcome="denied",
+                operation="resolve_elicitation",
+                chat_binding_id=chat_binding_id,
+                user=user,
+                reason="capability_denied",
+            )
+            raise WorkflowChatFacadeError(
+                "Approval resolution is not permitted for this binding.",
+                failure_class="user_error",
+                status_code=status.HTTP_403_FORBIDDEN,
+                code=CODE_OPERATION_DENIED,
+            )
+
+        # Revalidate the binding/session state at the mutation handoff so a
+        # revoked policy or replaced session cannot be resolved with stale
+        # authority (stale/replayed resolutions are also rejected upstream by
+        # the provider's pending-elicitation check).
+        fresh_row, fresh_provider, fresh_capabilities = (
+            await _revalidate_binding_before_mutation(
+                store=store,
+                chat_binding_id=chat_binding_id,
+                expected_provider_session_id=provider_session_id,
+            )
+        )
+        if not fresh_capabilities.get(CAP_RESOLVE_ELICITATION, False):
+            _audit_facade(
+                outcome="denied",
+                operation="resolve_elicitation",
+                chat_binding_id=chat_binding_id,
+                user=user,
+                reason="capability_revoked",
+            )
+            raise WorkflowChatFacadeError(
+                "Approval resolution is not permitted for this binding.",
+                failure_class="user_error",
+                status_code=status.HTTP_403_FORBIDDEN,
+                code=CODE_OPERATION_DENIED,
+            )
         actor_kwargs = (
             {"actor": str(user.id)}
             if config.host_protocol_mode == HOST_PROTOCOL_MODE_EMBEDDED
             else {}
         )
         result = await facade.resolve_elicitation(
-            session_id=provider_session_id,
+            session_id=fresh_provider,
             elicitation_id=params["elicitation_id"],
             payload=body or {},
             **actor_kwargs,
+        )
+        await _record_facade_mutation_audit(
+            store=store,
+            row=fresh_row,
+            control_type="resolve_elicitation",
+            outcome="posted",
+            actor=str(user.id),
+            idempotency_key=_facade_idempotency_key(request),
         )
         _audit_facade(
             outcome="mutation",
@@ -3272,7 +3709,7 @@ async def _dispatch_workflow_chat_facade(
         )
         return _virtualize_facade_payload(
             result,
-            provider_session_id=provider_session_id,
+            provider_session_id=fresh_provider,
             chat_binding_id=chat_binding_id,
         )
 
@@ -3295,15 +3732,35 @@ async def _dispatch_workflow_chat_facade(
     )
 
 
-def _int_or_none(value: Any) -> int | None:
+def _strict_query_cursor(value: Any, field: str) -> int | None:
+    """Parse a stream ``cursor``/``since`` query value, or fail closed.
+
+    A missing value returns ``None``. Unlike a silently-coerced cursor, a
+    nonnumeric or negative value is rejected with the stable malformed-cursor
+    error rather than resuming the stream from zero and replaying the entire
+    retained journal, which would duplicate already-rendered transcript events.
+    """
+
     text = str(value or "").strip()
     if not text:
         return None
     try:
         parsed = int(text)
-    except ValueError:
-        return None
-    return parsed if parsed >= 0 else None
+    except ValueError as exc:
+        raise WorkflowChatFacadeError(
+            f"The {field} cursor is invalid.",
+            failure_class="user_error",
+            status_code=status.HTTP_400_BAD_REQUEST,
+            code=CODE_MALFORMED_PAYLOAD,
+        ) from exc
+    if parsed < 0:
+        raise WorkflowChatFacadeError(
+            f"The {field} cursor is invalid.",
+            failure_class="user_error",
+            status_code=status.HTTP_400_BAD_REQUEST,
+            code=CODE_MALFORMED_PAYLOAD,
+        )
+    return parsed
 
 
 __all__ = [

--- a/api_service/api/routers/omnigent_bridge.py
+++ b/api_service/api/routers/omnigent_bridge.py
@@ -2692,12 +2692,13 @@ async def _resolve_chat_binding_row(
 ) -> Any | None:
     """Resolve the durable binding row for an opaque ``chatBindingId``.
 
-    Single resolution seam (see module note). Today the ``chatBindingId`` is the
-    durable ``bridge_session_id``; when #3633 adds a dedicated ``chat_binding_id``
-    column, only this function changes.
+    Single resolution seam (see module note). MoonLadderStudios/MoonMind#3633
+    added the dedicated opaque ``chat_binding_id`` column, so the browser-facing
+    id is resolved by that column. The resolved row's server-owned
+    ``bridge_session_id`` is what journal and terminal lookups use.
     """
 
-    return await store.get_bridge_session(chat_binding_id)
+    return await store.get_session_by_chat_binding_id(chat_binding_id)
 
 
 def _audit_facade(

--- a/api_service/api/routers/omnigent_bridge.py
+++ b/api_service/api/routers/omnigent_bridge.py
@@ -3268,11 +3268,6 @@ def _initial_stream_cursor(
     )
 
 
-@workflow_chat_router.api_route(
-    "/{chat_binding_id}/omnigent/{omnigent_path:path}",
-    methods=["GET", "POST"],
-    responses=_PUBLIC_ERROR_RESPONSES,
-)
 async def workflow_chat_binding_facade(
     chat_binding_id: str,
     omnigent_path: str,
@@ -3311,6 +3306,23 @@ async def workflow_chat_binding_facade(
         )
     except (WorkflowChatFacadeError, OmnigentBridgeError) as exc:
         raise _http_error_from_bridge(exc) from exc
+
+
+# Register the single binding-scoped facade handler once per HTTP method with an
+# explicit, method-suffixed operation id. A single ``api_route(methods=[...])``
+# derives its OpenAPI operation id from ``route.methods`` (a set), so the
+# exported operation id — and the frontend types generated from it — would flip
+# between ``_get`` and ``_post`` across processes with different hash seeds,
+# making the generated-contract check non-deterministic. One route per method
+# keeps the exported contract stable (matching the proxy router idiom).
+for _facade_method in ("GET", "POST"):
+    workflow_chat_router.add_api_route(
+        "/{chat_binding_id}/omnigent/{omnigent_path:path}",
+        workflow_chat_binding_facade,
+        methods=[_facade_method],
+        operation_id=f"workflow_chat_binding_facade_{_facade_method.lower()}",
+        responses=_PUBLIC_ERROR_RESPONSES,
+    )
 
 
 async def _dispatch_workflow_chat_facade(

--- a/api_service/main.py
+++ b/api_service/main.py
@@ -65,7 +65,9 @@ from api_service.api.routers.agent_runs import sessions_router as session_resour
 from api_service.api.routers.sessions import router as sessions_router
 from api_service.api.routers.omnigent_bridge import (
     OMNIGENT_BRIDGE_MOUNT_PATH,
+    WORKFLOW_CHAT_BINDINGS_MOUNT_PATH,
     router as omnigent_bridge_router,
+    workflow_chat_router as omnigent_workflow_chat_router,
 )
 from api_service.api.routers.omnigent_catalog import router as omnigent_catalog_router
 from api_service.api.routers.omnigent_policies import router as omnigent_policies_router
@@ -603,6 +605,9 @@ app.include_router(agent_runs_router, prefix="/api")
 app.include_router(sessions_router, prefix="/api")
 app.include_router(session_resources_router, prefix="/api")
 app.include_router(omnigent_bridge_router, prefix=OMNIGENT_BRIDGE_MOUNT_PATH)
+app.include_router(
+    omnigent_workflow_chat_router, prefix=WORKFLOW_CHAT_BINDINGS_MOUNT_PATH
+)
 app.include_router(omnigent_catalog_router)
 app.include_router(omnigent_policies_router)
 app.include_router(workflow_console_router)

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -3695,6 +3695,42 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/workflow-chat-bindings/{chat_binding_id}/omnigent/{omnigent_path}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Workflow Chat Binding Facade
+         * @description Single binding-scoped entrypoint for the native Omnigent Workflow Chat UI.
+         *
+         *     Not a generic reverse proxy: every request is matched against an explicit
+         *     method + route allowlist, reauthorized against the durable binding, checked
+         *     for identity substitution, capability-gated from recomputed trusted state,
+         *     and forwarded only to the server-resolved provider session with MoonMind
+         *     credentials stripped and upstream credentials injected server-side.
+         */
+        get: operations["workflow_chat_binding_facade_get"];
+        put?: never;
+        /**
+         * Workflow Chat Binding Facade
+         * @description Single binding-scoped entrypoint for the native Omnigent Workflow Chat UI.
+         *
+         *     Not a generic reverse proxy: every request is matched against an explicit
+         *     method + route allowlist, reauthorized against the durable binding, checked
+         *     for identity substitution, capability-gated from recomputed trusted state,
+         *     and forwarded only to the server-resolved provider session with MoonMind
+         *     credentials stripped and upstream credentials injected server-side.
+         */
+        post: operations["workflow_chat_binding_facade_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/omnigent/codex-catalog-readiness": {
         parameters: {
             query?: never;
@@ -22218,6 +22254,214 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    workflow_chat_binding_facade_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                chat_binding_id: string;
+                omnigent_path: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OmnigentPublicErrorResponse"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OmnigentPublicErrorResponse"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OmnigentPublicErrorResponse"];
+                };
+            };
+            /** @description Conflict */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OmnigentPublicErrorResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OmnigentPublicErrorResponse"];
+                };
+            };
+            /** @description Not Implemented */
+            501: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OmnigentPublicErrorResponse"];
+                };
+            };
+            /** @description Bad Gateway */
+            502: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OmnigentPublicErrorResponse"];
+                };
+            };
+            /** @description Service Unavailable */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OmnigentPublicErrorResponse"];
+                };
+            };
+        };
+    };
+    workflow_chat_binding_facade_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                chat_binding_id: string;
+                omnigent_path: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OmnigentPublicErrorResponse"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OmnigentPublicErrorResponse"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OmnigentPublicErrorResponse"];
+                };
+            };
+            /** @description Conflict */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OmnigentPublicErrorResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OmnigentPublicErrorResponse"];
+                };
+            };
+            /** @description Not Implemented */
+            501: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OmnigentPublicErrorResponse"];
+                };
+            };
+            /** @description Bad Gateway */
+            502: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OmnigentPublicErrorResponse"];
+                };
+            };
+            /** @description Service Unavailable */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OmnigentPublicErrorResponse"];
                 };
             };
         };

--- a/moonmind/omnigent/bridge_store.py
+++ b/moonmind/omnigent/bridge_store.py
@@ -1615,6 +1615,31 @@ class OmnigentBridgeSessionStore:
                 return None
             return _detached(session, row)
 
+    async def get_session_by_chat_binding_id(
+        self, chat_binding_id: str
+    ) -> OmnigentBridgeSession | None:
+        """Return one bridge session by its opaque, browser-facing ``chat_binding_id``.
+
+        MoonLadderStudios/MoonMind#3633: the dedicated ``chat_binding_id`` column
+        is the only identity the browser names on the binding-scoped facade. It is
+        distinct from the server-owned ``bridge_session_id`` (used for journal and
+        terminal lookups), so the facade resolves the durable row by this column.
+        """
+
+        key = (chat_binding_id or "").strip()
+        if not key:
+            return None
+        async with self._session_factory() as session:
+            result = await session.execute(
+                select(OmnigentBridgeSession)
+                .where(OmnigentBridgeSession.chat_binding_id == key)
+                .limit(1)
+            )
+            row = result.scalars().first()
+            if row is None:
+                return None
+            return _detached(session, row)
+
     async def resolve_projection_session(
         self,
         *,

--- a/moonmind/omnigent/workflow_chat_facade.py
+++ b/moonmind/omnigent/workflow_chat_facade.py
@@ -57,6 +57,7 @@ CODE_SESSION_READ_ONLY = "omnigent_chat_session_read_only"
 CODE_UNSUPPORTED_MEDIA_TYPE = "omnigent_chat_unsupported_media_type"
 CODE_PAYLOAD_TOO_LARGE = "omnigent_chat_payload_too_large"
 CODE_MALFORMED_PAYLOAD = "omnigent_chat_malformed_payload"
+CODE_CONTENT_BLOCKED = "omnigent_chat_content_blocked"
 
 
 class WorkflowChatFacadeError(OmnigentBridgeError):
@@ -90,22 +91,46 @@ _ALWAYS_DENIED_CAPABILITIES: tuple[str, ...] = (
 )
 
 
-def recompute_capabilities(status: str | None) -> dict[str, bool]:
+def recompute_capabilities(
+    status: str | None,
+    *,
+    policy_capabilities: Mapping[str, Any] | None = None,
+) -> dict[str, bool]:
     """Recompute effective capabilities from trusted session state (OB-§4.2 step 6).
 
     Capabilities are never trusted from mutable browser state; they are derived
     from the durable binding's coarse status on every request. A terminal
     session is read-only: transcript and resource reads remain, all mutations
     are denied.
+
+    The status-derived result is *intersected* with the binding's stored policy
+    (``policy_capabilities``, e.g. the durable projection's
+    ``interventionCapabilities``). A capability is granted only when both the
+    trusted session state permits it and the stored policy does not explicitly
+    disable it, so a profile/launch policy that turns off ``sendMessage`` is
+    never re-advertised or re-authorized from status alone. Capabilities the
+    policy does not mention keep their status-derived value; the policy can
+    remove authority but never grant authority the facade withholds.
     """
 
-    read_only = str(status or "").strip().lower() in TERMINAL_SESSION_STATUSES
+    read_only = is_read_only(status)
+    policy = policy_capabilities or {}
+
+    def _grant(capability: str, status_allows: bool) -> bool:
+        if not status_allows:
+            return False
+        # A stored policy value only ever removes authority. Any non-``True``
+        # value (explicit ``False``, or a non-bool) fails closed.
+        if capability in policy and policy.get(capability) is not True:
+            return False
+        return True
+
     capabilities = {
-        CAP_VIEW_TRANSCRIPT: True,
-        CAP_READ_RESOURCES: True,
-        CAP_SEND_MESSAGE: not read_only,
-        CAP_INTERRUPT_TURN: not read_only,
-        CAP_RESOLVE_ELICITATION: not read_only,
+        CAP_VIEW_TRANSCRIPT: _grant(CAP_VIEW_TRANSCRIPT, True),
+        CAP_READ_RESOURCES: _grant(CAP_READ_RESOURCES, True),
+        CAP_SEND_MESSAGE: _grant(CAP_SEND_MESSAGE, not read_only),
+        CAP_INTERRUPT_TURN: _grant(CAP_INTERRUPT_TURN, not read_only),
+        CAP_RESOLVE_ELICITATION: _grant(CAP_RESOLVE_ELICITATION, not read_only),
     }
     for denied in _ALWAYS_DENIED_CAPABILITIES:
         capabilities[denied] = False
@@ -269,15 +294,39 @@ def match_facade_operation(method: str, path: str) -> FacadeMatch | None:
     return None
 
 
+# Sentinel capability the facade never grants. Any composer/control event that
+# is not on the supported allowlist maps here and is therefore denied: the
+# browser facade only carries message and interrupt authority, never the
+# distinct stop, reset, harvest, or cleanup authority those controls require.
+CAP_CONTROL_UNSUPPORTED = "controlUnsupported"
+
+# Composer/control events the binding-scoped facade supports, mapped to the one
+# capability each requires. ``stop_session``, ``clear_session``,
+# ``reset_session``, ``cleanup_session``, ``terminal_cleanup``,
+# ``harvest_session``, and any future control are intentionally absent: they
+# stop, reset, harvest, or destroy owned runtime resources and need their own
+# authority, which the browser facade does not carry (OB-§4.2, §16).
+_SUPPORTED_COMPOSER_EVENTS: dict[str, str] = {
+    "message": CAP_SEND_MESSAGE,
+    "user.message": CAP_SEND_MESSAGE,
+    "interrupt": CAP_INTERRUPT_TURN,
+}
+
+
 def required_capability_for_event(event_type: str | None) -> str:
-    """Map a composer/control event type to the capability it requires."""
+    """Map a supported composer event type to the capability it requires.
+
+    Only ``message``/``user.message`` (``sendMessage``) and ``interrupt``
+    (``interruptTurn``) are supported through the browser facade. Every other
+    event type — including ``stop_session``, ``clear_session``,
+    ``cleanup_session``, and ``terminal_cleanup`` — maps to
+    :data:`CAP_CONTROL_UNSUPPORTED`, a capability the facade never grants, so a
+    caller holding only ``sendMessage`` cannot reach a destructive control by
+    naming an off-allowlist event type.
+    """
 
     raw = str(event_type or "").strip().lower()
-    if raw == "interrupt":
-        return CAP_INTERRUPT_TURN
-    # message, stop, clear/reset, cleanup, and other controls the composer
-    # offers are gated by sendMessage authority.
-    return CAP_SEND_MESSAGE
+    return _SUPPORTED_COMPOSER_EVENTS.get(raw, CAP_CONTROL_UNSUPPORTED)
 
 
 # --- Identity-substitution guard (OB-§4.2 steps 4-5, brief §3) ----------------
@@ -376,23 +425,35 @@ def _reject_identity(message: str, *, code: str = CODE_IDENTITY_SUBSTITUTION) ->
     )
 
 
-def _scan_mapping_for_identity(
-    mapping: Mapping[str, Any], *, chat_binding_id: str
-) -> None:
-    for raw_key, raw_value in mapping.items():
-        normalized = _normalize_key(raw_key)
-        if normalized in _SESSION_ID_KEYS:
-            value = str(raw_value or "").strip()
-            if value and value != chat_binding_id:
+def _scan_value_for_identity(value: Any, *, chat_binding_id: str) -> None:
+    """Recursively fail closed on any server-owned identity at any depth.
+
+    ``BridgeSessionEventRequest`` permits arbitrary extra nested data and
+    forwards it unchanged, so a forbidden identity or a mismatched session id
+    could otherwise hide inside nested event ``data``/content envelopes,
+    metadata, or list items. Every mapping and list is inspected, not just the
+    body root and one ``metadata`` mapping.
+    """
+
+    if isinstance(value, Mapping):
+        for raw_key, raw_value in value.items():
+            normalized = _normalize_key(raw_key)
+            if normalized in _SESSION_ID_KEYS:
+                session_value = str(raw_value or "").strip()
+                if session_value and session_value != chat_binding_id:
+                    _reject_identity(
+                        "A session reference does not map to the bound session.",
+                        code=CODE_SESSION_SUBSTITUTION,
+                    )
+                continue
+            if normalized in _FORBIDDEN_IDENTITY_KEYS:
                 _reject_identity(
-                    "A session reference does not map to the bound session.",
-                    code=CODE_SESSION_SUBSTITUTION,
+                    "The request attempts to supply a server-owned identity."
                 )
-            continue
-        if normalized in _FORBIDDEN_IDENTITY_KEYS:
-            _reject_identity(
-                "The request attempts to supply a server-owned identity."
-            )
+            _scan_value_for_identity(raw_value, chat_binding_id=chat_binding_id)
+    elif isinstance(value, (list, tuple)):
+        for item in value:
+            _scan_value_for_identity(item, chat_binding_id=chat_binding_id)
 
 
 def assert_no_identity_substitution(
@@ -420,7 +481,7 @@ def assert_no_identity_substitution(
         )
 
     if query:
-        _scan_mapping_for_identity(query, chat_binding_id=chat_binding_id)
+        _scan_value_for_identity(query, chat_binding_id=chat_binding_id)
 
     if headers:
         for raw_name in headers.keys():
@@ -429,14 +490,12 @@ def assert_no_identity_substitution(
                     "The request attempts to supply a server-owned identity header."
                 )
 
-    if isinstance(body, Mapping):
-        _scan_mapping_for_identity(body, chat_binding_id=chat_binding_id)
-        metadata = body.get("metadata")
-        if isinstance(metadata, Mapping):
-            _scan_mapping_for_identity(metadata, chat_binding_id=chat_binding_id)
+    if body is not None:
+        _scan_value_for_identity(body, chat_binding_id=chat_binding_id)
 
 
 __all__ = [
+    "CAP_CONTROL_UNSUPPORTED",
     "CAP_INTERRUPT_TURN",
     "CAP_READ_RESOURCES",
     "CAP_RESOLVE_ELICITATION",
@@ -444,6 +503,7 @@ __all__ = [
     "CAP_VIEW_TRANSCRIPT",
     "CODE_BINDING_UNKNOWN",
     "CODE_CALLER_UNAUTHORIZED",
+    "CODE_CONTENT_BLOCKED",
     "CODE_IDENTITY_SUBSTITUTION",
     "CODE_MALFORMED_PAYLOAD",
     "CODE_OPERATION_DENIED",

--- a/moonmind/omnigent/workflow_chat_facade.py
+++ b/moonmind/omnigent/workflow_chat_facade.py
@@ -1,0 +1,466 @@
+"""Binding-scoped Workflow Chat facade primitives (MoonLadderStudios/MoonMind#3634).
+
+The native Omnigent web application never calls the provider/service session API
+with a caller-selected provider session id. It receives an opaque MoonMind
+``chatBindingId`` and drives one binding-scoped facade
+(``docs/Omnigent/OmnigentBridge.md`` §4.2, §5.2):
+
+```text
+/api/workflow-chat-bindings/{chatBindingId}/omnigent/{path}
+```
+
+This module holds the runtime-neutral primitives the FastAPI facade router
+composes: the explicit route/method allowlist for the selected compatibility
+profile (the facade is never a generic open reverse proxy), the per-request
+identity-substitution guard, the capability recompute, and the stable, redacted
+error codes. Keeping these decisions here (rather than inline in the router)
+lets them be unit-tested in isolation and keeps the browser-boundary semantics
+in one place.
+
+Binding resolution note: the opaque ``chat_binding_id`` column described in
+§7.1 and its allocation are owned by MoonLadderStudios/MoonMind#3633. Until that
+lands, the facade resolves ``chatBindingId`` through the durable bridge session
+(``bridge_session_id`` — itself an opaque, server-owned MoonMind key that maps
+to the workflow owner, provider session id, and upstream endpoint). The
+provider session id and upstream endpoint stay server-side either way, so the
+browser-facing contract in this module does not change when a dedicated
+``chat_binding_id`` lookup is introduced.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from typing import Any
+
+from moonmind.omnigent.bridge_proxy import OmnigentBridgeError
+
+# Coarse session statuses that make a binding read-only. A read-only binding
+# still serves transcript/resource reads but rejects every mutation before any
+# upstream forward (OB-§4.2, §16). Kept aligned with the terminal set the bridge
+# store coalesces from normalized provider statuses.
+TERMINAL_SESSION_STATUSES: frozenset[str] = frozenset(
+    {"completed", "failed", "canceled", "cancelled", "timed_out", "stopped"}
+)
+
+
+# --- Stable, redacted facade error codes (OB-§4.2 step list, brief §6) --------
+CODE_BINDING_UNKNOWN = "omnigent_chat_binding_unknown"
+CODE_CALLER_UNAUTHORIZED = "omnigent_chat_caller_unauthorized"
+CODE_ROUTE_NOT_ALLOWLISTED = "omnigent_chat_route_not_allowlisted"
+CODE_OPERATION_DENIED = "omnigent_chat_operation_denied"
+CODE_SESSION_SUBSTITUTION = "omnigent_chat_session_substitution"
+CODE_IDENTITY_SUBSTITUTION = "omnigent_chat_identity_substitution"
+CODE_SESSION_NOT_READY = "omnigent_chat_session_not_ready"
+CODE_SESSION_READ_ONLY = "omnigent_chat_session_read_only"
+CODE_UNSUPPORTED_MEDIA_TYPE = "omnigent_chat_unsupported_media_type"
+CODE_PAYLOAD_TOO_LARGE = "omnigent_chat_payload_too_large"
+CODE_MALFORMED_PAYLOAD = "omnigent_chat_malformed_payload"
+
+
+class WorkflowChatFacadeError(OmnigentBridgeError):
+    """Typed, redacted binding-scoped facade error.
+
+    Subclasses :class:`OmnigentBridgeError` so the router's existing
+    bridge-error-to-HTTP mapping renders one consistent, non-enumerating error
+    envelope for both facades.
+    """
+
+
+# --- Capability keys the browser projection understands (WorkflowChatPanel §5)
+CAP_VIEW_TRANSCRIPT = "viewTranscript"
+CAP_SEND_MESSAGE = "sendMessage"
+CAP_INTERRUPT_TURN = "interruptTurn"
+CAP_RESOLVE_ELICITATION = "resolveElicitation"
+CAP_READ_RESOURCES = "readResources"
+
+# Capabilities the facade intentionally never grants to the browser. These are
+# authority/immutability boundaries (terminal creation, workspace mutation,
+# per-session model/effort/goal changes) that require separate authorization the
+# facade does not carry; they are always reported false so the native UI hides
+# the affordance and the server rejects the operation if attempted.
+_ALWAYS_DENIED_CAPABILITIES: tuple[str, ...] = (
+    "createTerminal",
+    "writeTerminal",
+    "mutateWorkspace",
+    "changeModel",
+    "changeEffort",
+    "changeGoal",
+)
+
+
+def recompute_capabilities(status: str | None) -> dict[str, bool]:
+    """Recompute effective capabilities from trusted session state (OB-§4.2 step 6).
+
+    Capabilities are never trusted from mutable browser state; they are derived
+    from the durable binding's coarse status on every request. A terminal
+    session is read-only: transcript and resource reads remain, all mutations
+    are denied.
+    """
+
+    read_only = str(status or "").strip().lower() in TERMINAL_SESSION_STATUSES
+    capabilities = {
+        CAP_VIEW_TRANSCRIPT: True,
+        CAP_READ_RESOURCES: True,
+        CAP_SEND_MESSAGE: not read_only,
+        CAP_INTERRUPT_TURN: not read_only,
+        CAP_RESOLVE_ELICITATION: not read_only,
+    }
+    for denied in _ALWAYS_DENIED_CAPABILITIES:
+        capabilities[denied] = False
+    return capabilities
+
+
+def is_read_only(status: str | None) -> bool:
+    return str(status or "").strip().lower() in TERMINAL_SESSION_STATUSES
+
+
+# --- Route / method allowlist (OB-§4.1 compatibility matrix, §4.2) ------------
+# The facade exposes only the Omnigent-shaped operations the native application
+# needs. Every entry is an explicit (method, path-pattern) pair; anything not
+# matched here is rejected with a non-enumerating error. Session lifecycle
+# (create/attach/delete) is deliberately excluded: the browser receives a
+# pre-created binding and never authors session creation through the facade.
+
+_SESSION = r"(?P<session_id>[^/]+)"
+
+
+@dataclass(frozen=True, slots=True)
+class FacadeOperation:
+    """One allowlisted binding-scoped operation."""
+
+    name: str
+    method: str
+    pattern: re.Pattern[str]
+    # Capability required to invoke the operation. ``None`` means no capability
+    # gate beyond ownership (e.g. liveness). For ``post_event`` the capability
+    # depends on the event type and is resolved separately.
+    capability: str | None = CAP_VIEW_TRANSCRIPT
+    # Whether the sub-path names a provider session that must map to the bound
+    # session (i.e. the ``{session_id}`` segment must equal the chatBindingId).
+    references_session: bool = True
+    # Whether the operation requires an attached provider session id upstream.
+    requires_provider_session: bool = True
+    mutation: bool = False
+    sse: bool = False
+    binary: bool = False
+
+
+def _op(path: str, **kwargs: Any) -> FacadeOperation:
+    return FacadeOperation(pattern=re.compile("^" + path + "$"), **kwargs)
+
+
+FACADE_OPERATIONS: tuple[FacadeOperation, ...] = (
+    # Liveness/reconnect probe — served locally, never forwarded upstream.
+    _op(
+        r"health",
+        name="liveness",
+        method="GET",
+        capability=None,
+        references_session=False,
+        requires_provider_session=False,
+    ),
+    # Session catalog / metadata required to bootstrap the native UI.
+    _op(
+        r"v1/agents",
+        name="list_agents",
+        method="GET",
+        references_session=False,
+        requires_provider_session=False,
+    ),
+    # Session snapshot / bootstrap / history.
+    _op(rf"v1/sessions/{_SESSION}", name="get_session", method="GET"),
+    # Live/replay stream (SSE) — served from the durable bridge journal so
+    # Last-Event-ID cursor semantics and mid-stream reauthorization apply.
+    _op(
+        rf"v1/sessions/{_SESSION}/stream",
+        name="stream_events",
+        method="GET",
+        sse=True,
+        requires_provider_session=False,
+    ),
+    # Message and supported control events. Capability is resolved per event
+    # type (and read-only state) by the router, so no generic gate applies here.
+    _op(
+        rf"v1/sessions/{_SESSION}/events",
+        name="post_event",
+        method="POST",
+        capability=None,
+        mutation=True,
+    ),
+    # Elicitation / approval resolution — capability + read-only gate applied by
+    # the router.
+    _op(
+        rf"v1/sessions/{_SESSION}/elicitations/(?P<elicitation_id>[^/]+)/resolve",
+        name="resolve_elicitation",
+        method="POST",
+        capability=None,
+        mutation=True,
+    ),
+    # Read-only resource indexes and content.
+    _op(
+        rf"v1/sessions/{_SESSION}/resources/environments/default/changes",
+        name="changed_files",
+        method="GET",
+        capability=CAP_READ_RESOURCES,
+    ),
+    _op(
+        rf"v1/sessions/{_SESSION}/resources/environments/default/filesystem",
+        name="workspace_files",
+        method="GET",
+        capability=CAP_READ_RESOURCES,
+    ),
+    _op(
+        rf"v1/sessions/{_SESSION}/resources/environments/default/filesystem/"
+        r"(?P<res_path>.+)",
+        name="workspace_file",
+        method="GET",
+        capability=CAP_READ_RESOURCES,
+        binary=True,
+    ),
+    _op(
+        rf"v1/sessions/{_SESSION}/resources/environments/default/diff/"
+        r"(?P<res_path>.+)",
+        name="workspace_diff",
+        method="GET",
+        capability=CAP_READ_RESOURCES,
+        binary=True,
+    ),
+    _op(
+        rf"v1/sessions/{_SESSION}/resources/files",
+        name="session_files",
+        method="GET",
+        capability=CAP_READ_RESOURCES,
+    ),
+    _op(
+        rf"v1/sessions/{_SESSION}/resources/files/(?P<file_id>[^/]+)/content",
+        name="session_file",
+        method="GET",
+        capability=CAP_READ_RESOURCES,
+        binary=True,
+    ),
+)
+
+
+@dataclass(frozen=True, slots=True)
+class FacadeMatch:
+    operation: FacadeOperation
+    params: dict[str, str] = field(default_factory=dict)
+
+
+def match_facade_operation(method: str, path: str) -> FacadeMatch | None:
+    """Return the allowlisted operation for a method + sub-path, or ``None``.
+
+    ``path`` is the portion after ``/omnigent/`` (no leading slash). Any method
+    or path not explicitly allowlisted returns ``None`` so the router can answer
+    with one non-enumerating rejection (OB-§4.2: no generic open reverse proxy;
+    unknown targets do not reveal upstream session existence).
+    """
+
+    normalized = str(method or "").strip().upper()
+    candidate = str(path or "").strip().strip("/")
+    for operation in FACADE_OPERATIONS:
+        if operation.method != normalized:
+            continue
+        matched = operation.pattern.match(candidate)
+        if matched is not None:
+            return FacadeMatch(operation=operation, params=dict(matched.groupdict()))
+    return None
+
+
+def required_capability_for_event(event_type: str | None) -> str:
+    """Map a composer/control event type to the capability it requires."""
+
+    raw = str(event_type or "").strip().lower()
+    if raw == "interrupt":
+        return CAP_INTERRUPT_TURN
+    # message, stop, clear/reset, cleanup, and other controls the composer
+    # offers are gated by sendMessage authority.
+    return CAP_SEND_MESSAGE
+
+
+# --- Identity-substitution guard (OB-§4.2 steps 4-5, brief §3) ----------------
+# Structural keys that name an upstream/topology/authority identity the browser
+# must never be able to inject through path, query, body, or header. A message
+# body legitimately never carries these; their presence is an injection attempt
+# and fails closed before any upstream forward. Bare session ids are handled
+# separately (they may echo the virtual/bound id but never a different one).
+_FORBIDDEN_IDENTITY_KEYS: frozenset[str] = frozenset(
+    {
+        "provider_session_id",
+        "providersessionid",
+        "endpoint",
+        "endpoint_ref",
+        "endpointref",
+        "base_url",
+        "baseurl",
+        "upstream",
+        "upstream_url",
+        "upstreamurl",
+        "server_url",
+        "serverurl",
+        "host",
+        "host_id",
+        "hostid",
+        "runner",
+        "runner_id",
+        "runnerid",
+        "workspace",
+        "workspace_root",
+        "workspaceroot",
+        "workspace_path",
+        "workspacepath",
+        "agent_profile",
+        "agentprofile",
+        "agent_profile_ref",
+        "provider_profile",
+        "providerprofile",
+        "provider_profile_id",
+        "launch_policy",
+        "launchpolicy",
+        "launch_policy_ref",
+        "model",
+        "model_override",
+        "modeloverride",
+        "effort",
+        "reasoning_effort",
+        "reasoningeffort",
+        "goal",
+        "credential",
+        "credentials",
+        "bridge_session_id",
+        "bridgesessionid",
+        "workflow_id",
+        "workflowid",
+        "agent_run_id",
+        "agentrunid",
+        "endpointref",
+    }
+)
+# Keys that name a session id. Their value may only be the bound chatBindingId.
+_SESSION_ID_KEYS: frozenset[str] = frozenset(
+    {"session_id", "sessionid", "session"}
+)
+# Request headers that attempt to name an upstream identity. sanitize_proxy
+# already prevents credential headers from crossing the boundary; these are
+# rejected outright (and audited) rather than silently dropped, because their
+# presence is an explicit substitution attempt.
+_FORBIDDEN_IDENTITY_HEADERS: frozenset[str] = frozenset(
+    {
+        "x-omnigent-session",
+        "x-omnigent-session-id",
+        "x-provider-session-id",
+        "x-omnigent-endpoint",
+        "x-omnigent-endpoint-ref",
+        "x-upstream-url",
+        "x-omnigent-host",
+        "x-omnigent-host-id",
+        "x-omnigent-runner",
+        "x-omnigent-runner-id",
+        "x-omnigent-workspace",
+    }
+)
+
+
+def _normalize_key(value: Any) -> str:
+    return str(value or "").strip().lower().replace("-", "_").replace(".", "_")
+
+
+def _reject_identity(message: str, *, code: str = CODE_IDENTITY_SUBSTITUTION) -> None:
+    raise WorkflowChatFacadeError(
+        message,
+        failure_class="user_error",
+        status_code=403,
+        code=code,
+    )
+
+
+def _scan_mapping_for_identity(
+    mapping: Mapping[str, Any], *, chat_binding_id: str
+) -> None:
+    for raw_key, raw_value in mapping.items():
+        normalized = _normalize_key(raw_key)
+        if normalized in _SESSION_ID_KEYS:
+            value = str(raw_value or "").strip()
+            if value and value != chat_binding_id:
+                _reject_identity(
+                    "A session reference does not map to the bound session.",
+                    code=CODE_SESSION_SUBSTITUTION,
+                )
+            continue
+        if normalized in _FORBIDDEN_IDENTITY_KEYS:
+            _reject_identity(
+                "The request attempts to supply a server-owned identity."
+            )
+
+
+def assert_no_identity_substitution(
+    *,
+    chat_binding_id: str,
+    path_session_id: str | None,
+    query: Mapping[str, Any] | None = None,
+    body: Any | None = None,
+    headers: Mapping[str, Any] | None = None,
+) -> None:
+    """Fail closed on any attempt to substitute a server-owned identity.
+
+    Enforces OB-§4.2 steps 4-5 / brief §3 at the facade boundary: the only
+    session id the browser may name is the bound ``chatBindingId``; upstream
+    endpoint, host, runner, workspace, profile, launch policy, model, effort,
+    goal, and credential identities may not appear in the path, query, body, or
+    headers. The provider session id is virtualized server-side and never
+    supplied by the caller.
+    """
+
+    if path_session_id is not None and path_session_id != chat_binding_id:
+        _reject_identity(
+            "A session reference does not map to the bound session.",
+            code=CODE_SESSION_SUBSTITUTION,
+        )
+
+    if query:
+        _scan_mapping_for_identity(query, chat_binding_id=chat_binding_id)
+
+    if headers:
+        for raw_name in headers.keys():
+            if str(raw_name or "").strip().lower() in _FORBIDDEN_IDENTITY_HEADERS:
+                _reject_identity(
+                    "The request attempts to supply a server-owned identity header."
+                )
+
+    if isinstance(body, Mapping):
+        _scan_mapping_for_identity(body, chat_binding_id=chat_binding_id)
+        metadata = body.get("metadata")
+        if isinstance(metadata, Mapping):
+            _scan_mapping_for_identity(metadata, chat_binding_id=chat_binding_id)
+
+
+__all__ = [
+    "CAP_INTERRUPT_TURN",
+    "CAP_READ_RESOURCES",
+    "CAP_RESOLVE_ELICITATION",
+    "CAP_SEND_MESSAGE",
+    "CAP_VIEW_TRANSCRIPT",
+    "CODE_BINDING_UNKNOWN",
+    "CODE_CALLER_UNAUTHORIZED",
+    "CODE_IDENTITY_SUBSTITUTION",
+    "CODE_MALFORMED_PAYLOAD",
+    "CODE_OPERATION_DENIED",
+    "CODE_PAYLOAD_TOO_LARGE",
+    "CODE_ROUTE_NOT_ALLOWLISTED",
+    "CODE_SESSION_NOT_READY",
+    "CODE_SESSION_READ_ONLY",
+    "CODE_SESSION_SUBSTITUTION",
+    "CODE_UNSUPPORTED_MEDIA_TYPE",
+    "FACADE_OPERATIONS",
+    "FacadeMatch",
+    "FacadeOperation",
+    "TERMINAL_SESSION_STATUSES",
+    "WorkflowChatFacadeError",
+    "assert_no_identity_substitution",
+    "is_read_only",
+    "match_facade_operation",
+    "recompute_capabilities",
+    "required_capability_for_event",
+]

--- a/tests/unit/api/routers/test_omnigent_workflow_chat.py
+++ b/tests/unit/api/routers/test_omnigent_workflow_chat.py
@@ -38,7 +38,6 @@ from moonmind.omnigent.settings import resolved_proxy_forward_headers
 from moonmind.omnigent.workflow_chat_facade import (
     CAP_CONTROL_UNSUPPORTED,
     CAP_INTERRUPT_TURN,
-    CAP_RESOLVE_ELICITATION,
     CAP_SEND_MESSAGE,
     CAP_VIEW_TRANSCRIPT,
     WorkflowChatFacadeError,

--- a/tests/unit/api/routers/test_omnigent_workflow_chat.py
+++ b/tests/unit/api/routers/test_omnigent_workflow_chat.py
@@ -1,0 +1,685 @@
+"""Router + primitive tests for the binding-scoped Workflow Chat facade.
+
+MoonLadderStudios/MoonMind#3634: the native Omnigent web application reaches the
+provider session only through
+``/api/workflow-chat-bindings/{chatBindingId}/omnigent/{path}``. Every request
+independently authenticates, resolves the durable binding, authorizes the
+caller and operation, rejects identity substitution, strips MoonMind
+credentials, and forwards only to the server-resolved provider session.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import Mock
+from uuid import uuid4
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from api_service.api.routers.omnigent_bridge import (
+    WORKFLOW_CHAT_BINDINGS_MOUNT_PATH,
+    _get_bridge_proxy,
+    _get_bridge_store,
+    _get_create_embedded_facade,
+    _get_execution_service,
+    _require_bridge_enabled,
+    workflow_chat_router,
+)
+from api_service.api.routers.retrieval_gateway import get_capability_registry
+from api_service.auth_providers import get_current_user
+from moonmind.omnigent.bridge_config import HOST_PROTOCOL_MODE_PROXY
+from moonmind.omnigent.settings import resolved_proxy_forward_headers
+from moonmind.omnigent.workflow_chat_facade import (
+    CAP_SEND_MESSAGE,
+    CAP_VIEW_TRANSCRIPT,
+    WorkflowChatFacadeError,
+    assert_no_identity_substitution,
+    match_facade_operation,
+    recompute_capabilities,
+)
+from moonmind.workflows.adapters.omnigent_client import OmnigentHttpClient
+
+_USER_ID = uuid4()
+_UNSET = object()
+
+_PROVIDER_SESSION_ID = "prov-sess-1"
+_CHAT_BINDING_ID = "brs-1"
+
+
+def _mock_user():
+    return SimpleNamespace(id=_USER_ID, email="chat@example.com", is_superuser=False)
+
+
+class _FakeService:
+    def __init__(self, owner_id: Any, *, deny_after: int | None = None) -> None:
+        self._owner_id = owner_id
+        self._deny_after = deny_after
+        self.calls = 0
+
+    async def describe_execution(self, workflow_id: str):
+        self.calls += 1
+        if self._deny_after is not None and self.calls > self._deny_after:
+            # Simulate the workflow authority being revoked mid-stream.
+            return SimpleNamespace(owner_id=uuid4())
+        return SimpleNamespace(owner_id=self._owner_id)
+
+
+def _row(**overrides: Any) -> SimpleNamespace:
+    values = dict(
+        bridge_session_id=_CHAT_BINDING_ID,
+        moonmind_workflow_id="mm:w1",
+        moonmind_run_id="run-1",
+        moonmind_agent_run_id="ar-1",
+        step_execution_id="step-1",
+        idempotency_key="idem-1",
+        status="active",
+        omnigent_session_id=_PROVIDER_SESSION_ID,
+        omnigent_host_id="host-1",
+        compatibility_profile="omnigent.server.v1",
+        terminal_refs={},
+        metadata_={},
+        diagnostics_ref=None,
+        capture_manifest_ref=None,
+        initial_snapshot_ref=None,
+        final_snapshot_ref=None,
+        raw_events_ref=None,
+        normalized_events_ref=None,
+        external_state_ref=None,
+    )
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def _event(sequence: int) -> SimpleNamespace:
+    return SimpleNamespace(
+        event_id=f"evt-{sequence}",
+        bridge_session_id=_CHAT_BINDING_ID,
+        sequence=sequence,
+        timestamp=SimpleNamespace(isoformat=lambda: "2026-08-07T00:00:00+00:00"),
+        direction="host_to_moonmind",
+        event_type="response.delta",
+        normalized_status="running",
+        text_preview="hello",
+        artifact_ref=None,
+        metadata_={},
+    )
+
+
+class _FakeStore:
+    def __init__(self, *, row: Any = _UNSET, events: list[Any] | None = None) -> None:
+        self._row = _row() if row is _UNSET else row
+        self._events = events or []
+        self.appended: list[dict[str, Any]] = []
+
+    async def get_bridge_session(self, bridge_session_id: str):
+        return self._row
+
+    async def get_session_by_provider_session_id(self, session_id: str):
+        if self._row and getattr(self._row, "omnigent_session_id", None) == session_id:
+            return self._row
+        return None
+
+    async def list_event_page(self, bridge_session_id: str, *, after: int, limit: int):
+        rows = [event for event in self._events if event.sequence > after]
+        return SimpleNamespace(
+            rows=rows[:limit],
+            has_more=len(rows) > limit,
+            latest_sequence=max((event.sequence for event in self._events), default=0),
+            earliest_sequence=min(
+                (event.sequence for event in self._events), default=None
+            ),
+        )
+
+    async def append_events(self, bridge_session_id: str, events: list[dict[str, Any]]):
+        self.appended.extend(events)
+
+
+class _FakeProxy:
+    def __init__(self) -> None:
+        self.posted: list[dict[str, Any]] = []
+        self.resolved: list[dict[str, Any]] = []
+        self.resources: list[tuple[str, str, str | None]] = []
+
+    async def get_session(self, session_id: str):
+        return {
+            "id": session_id,
+            "status": "running",
+            "providerSessionField": session_id,
+            "host_id": "host-1",
+            "moonmind": {"workflowId": "mm:w1", "bridgeSessionId": _CHAT_BINDING_ID},
+        }
+
+    async def list_agents(self):
+        return [{"id": "agent-1", "name": "codex"}]
+
+    async def get_resource(self, operation: str, session_id: str, value=None):
+        self.resources.append((operation, session_id, value))
+        if operation in {"workspace_file", "workspace_diff", "session_file"}:
+            return b"RAW-BYTES"
+        return {"files": [{"path": "src/main.py", "session": session_id}]}
+
+    async def post_event(self, *, session_id: str, event, actor=None):
+        self.posted.append(
+            {"session_id": session_id, "type": event.type, "actor": actor}
+        )
+        return {"ok": True, "type": event.type, "session_id": session_id}
+
+    async def stop_session(self, session_id: str):
+        return {"ok": True, "status": "stopped", "session_id": session_id}
+
+    async def resolve_elicitation(
+        self, *, session_id: str, elicitation_id: str, payload, actor=None
+    ):
+        self.resolved.append(
+            {
+                "session_id": session_id,
+                "elicitation_id": elicitation_id,
+                "payload": payload,
+            }
+        )
+        return {"ok": True, "elicitationId": elicitation_id, "session_id": session_id}
+
+
+def _fake_registry() -> SimpleNamespace:
+    return SimpleNamespace(
+        has_live_session_authority=Mock(return_value=False),
+        revoke_scope=Mock(return_value=[]),
+    )
+
+
+def _build(
+    *,
+    owner_id: Any = _USER_ID,
+    proxy: _FakeProxy | None = None,
+    store: _FakeStore | None = None,
+    registry: Any | None = None,
+    service: Any | None = None,
+) -> tuple[TestClient, _FakeProxy, _FakeStore]:
+    app = FastAPI()
+    app.include_router(
+        workflow_chat_router, prefix=WORKFLOW_CHAT_BINDINGS_MOUNT_PATH
+    )
+    proxy = proxy or _FakeProxy()
+    store = store or _FakeStore()
+    registry = registry or _fake_registry()
+    config = SimpleNamespace(host_protocol_mode=HOST_PROTOCOL_MODE_PROXY)
+    app.dependency_overrides[get_current_user()] = _mock_user
+    app.dependency_overrides[_get_execution_service] = lambda: (
+        service or _FakeService(owner_id)
+    )
+    app.dependency_overrides[_get_bridge_store] = lambda: store
+    app.dependency_overrides[_get_bridge_proxy] = lambda: proxy
+    app.dependency_overrides[_get_create_embedded_facade] = lambda: None
+    app.dependency_overrides[get_capability_registry] = lambda: registry
+    app.dependency_overrides[_require_bridge_enabled] = lambda: config
+    return TestClient(app), proxy, store
+
+
+def _path(suffix: str, *, binding: str = _CHAT_BINDING_ID) -> str:
+    return f"{WORKFLOW_CHAT_BINDINGS_MOUNT_PATH}/{binding}/omnigent/{suffix}"
+
+
+# --- Snapshot / bootstrap ----------------------------------------------------
+
+
+def test_owner_snapshot_virtualizes_provider_identity() -> None:
+    client, _proxy, _store = _build()
+
+    response = client.get(_path(f"v1/sessions/{_CHAT_BINDING_ID}"))
+
+    assert response.status_code == 200
+    body = response.json()
+    # The provider session id is virtualized to the chatBindingId and never
+    # leaks; upstream topology and MoonMind binding metadata are stripped.
+    assert body["id"] == _CHAT_BINDING_ID
+    assert _PROVIDER_SESSION_ID not in response.text
+    assert body["providerSessionField"] == _CHAT_BINDING_ID
+    assert "moonmind" not in body
+    assert "host_id" not in body
+    # Capabilities are recomputed from trusted state on every request.
+    assert body["capabilities"][CAP_SEND_MESSAGE] is True
+    assert body["readOnly"] is False
+
+
+def test_non_owner_gets_non_enumerating_binding_unknown() -> None:
+    client, _proxy, _store = _build(owner_id=uuid4())
+
+    response = client.get(_path(f"v1/sessions/{_CHAT_BINDING_ID}"))
+
+    assert response.status_code == 404
+    assert response.json()["detail"]["code"] == "omnigent_chat_binding_unknown"
+
+
+def test_unknown_binding_is_non_enumerating() -> None:
+    client, _proxy, _store = _build(store=_FakeStore(row=None))
+
+    response = client.get(_path(f"v1/sessions/{_CHAT_BINDING_ID}"))
+
+    assert response.status_code == 404
+    assert response.json()["detail"]["code"] == "omnigent_chat_binding_unknown"
+
+
+# --- Allowlist ---------------------------------------------------------------
+
+
+def test_route_not_allowlisted_is_rejected() -> None:
+    client, _proxy, _store = _build()
+
+    # Session creation is never exposed through the browser facade.
+    response = client.post(_path("v1/sessions"))
+
+    assert response.status_code == 404
+    assert response.json()["detail"]["code"] == "omnigent_chat_route_not_allowlisted"
+
+
+def test_delete_method_not_allowlisted() -> None:
+    client, _proxy, _store = _build()
+
+    response = client.request("DELETE", _path(f"v1/sessions/{_CHAT_BINDING_ID}"))
+
+    assert response.status_code in (404, 405)
+
+
+# --- Identity substitution ---------------------------------------------------
+
+
+def test_session_substitution_in_path_is_rejected() -> None:
+    client, _proxy, _store = _build()
+
+    response = client.get(_path("v1/sessions/some-other-session"))
+
+    assert response.status_code == 403
+    assert response.json()["detail"]["code"] == "omnigent_chat_session_substitution"
+
+
+def test_identity_substitution_in_query_is_rejected() -> None:
+    client, _proxy, _store = _build()
+
+    response = client.get(
+        _path(f"v1/sessions/{_CHAT_BINDING_ID}"),
+        params={"endpoint": "http://evil.internal"},
+    )
+
+    assert response.status_code == 403
+    assert response.json()["detail"]["code"] == "omnigent_chat_identity_substitution"
+
+
+def test_identity_substitution_in_body_is_rejected() -> None:
+    client, _proxy, _store = _build()
+
+    response = client.post(
+        _path(f"v1/sessions/{_CHAT_BINDING_ID}/events"),
+        json={"type": "message", "host_id": "evil-host"},
+    )
+
+    assert response.status_code == 403
+    assert response.json()["detail"]["code"] == "omnigent_chat_identity_substitution"
+
+
+def test_session_id_body_mismatch_is_rejected() -> None:
+    client, _proxy, _store = _build()
+
+    response = client.post(
+        _path(f"v1/sessions/{_CHAT_BINDING_ID}/events"),
+        json={"type": "message", "session_id": "other-session"},
+    )
+
+    assert response.status_code == 403
+    assert response.json()["detail"]["code"] == "omnigent_chat_session_substitution"
+
+
+def test_identity_substitution_header_is_rejected() -> None:
+    client, _proxy, _store = _build()
+
+    response = client.get(
+        _path(f"v1/sessions/{_CHAT_BINDING_ID}"),
+        headers={"X-Omnigent-Endpoint": "http://evil.internal"},
+    )
+
+    assert response.status_code == 403
+    assert response.json()["detail"]["code"] == "omnigent_chat_identity_substitution"
+
+
+# --- Credential separation ---------------------------------------------------
+
+
+def test_moonmind_credentials_cannot_cross_to_upstream() -> None:
+    """The client the facade forwards through drops MoonMind credentials and
+    injects only the server-side upstream token (OB-§16 rule 7)."""
+
+    client = OmnigentHttpClient(
+        base_url="https://omnigent.internal",
+        api_token="upstream-secret",
+        forward_headers={
+            "authorization": "Bearer moonmind-jwt",
+            "cookie": "session=abc",
+            "x-csrf-token": "csrf",
+            "x-moonmind-user": "user-1",
+            "x-moonmind-authorization": "internal",
+            "content-type": "application/json",
+        },
+        upstream_header_allowlist=resolved_proxy_forward_headers(),
+    )
+
+    headers = client._headers()
+
+    assert headers["Authorization"] == "Bearer upstream-secret"
+    assert "moonmind-jwt" not in headers["Authorization"]
+    assert "Cookie" not in headers and "cookie" not in headers
+    assert not any(name.lower().startswith("x-moonmind") for name in headers)
+    assert not any(name.lower() == "x-csrf-token" for name in headers)
+
+
+# --- Capabilities / read-only ------------------------------------------------
+
+
+def test_terminal_session_snapshot_is_read_only() -> None:
+    client, _proxy, _store = _build(store=_FakeStore(row=_row(status="completed")))
+
+    response = client.get(_path(f"v1/sessions/{_CHAT_BINDING_ID}"))
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["readOnly"] is True
+    assert body["capabilities"][CAP_SEND_MESSAGE] is False
+    assert body["capabilities"][CAP_VIEW_TRANSCRIPT] is True
+
+
+def test_terminal_session_rejects_message() -> None:
+    client, _proxy, _store = _build(store=_FakeStore(row=_row(status="completed")))
+
+    response = client.post(
+        _path(f"v1/sessions/{_CHAT_BINDING_ID}/events"),
+        json={"type": "message"},
+    )
+
+    assert response.status_code == 409
+    assert response.json()["detail"]["code"] == "omnigent_chat_session_read_only"
+
+
+def test_session_without_provider_session_is_not_ready() -> None:
+    client, _proxy, _store = _build(
+        store=_FakeStore(row=_row(omnigent_session_id="", status="declared"))
+    )
+
+    response = client.get(_path(f"v1/sessions/{_CHAT_BINDING_ID}"))
+
+    assert response.status_code == 409
+    assert response.json()["detail"]["code"] == "omnigent_chat_session_not_ready"
+
+
+# --- Message / control forwarding -------------------------------------------
+
+
+def test_message_forwarded_to_bound_provider_session() -> None:
+    client, proxy, _store = _build()
+
+    response = client.post(
+        _path(f"v1/sessions/{_CHAT_BINDING_ID}/events"),
+        json={"type": "message", "data": {"content": [{"type": "text", "text": "hi"}]}},
+    )
+
+    assert response.status_code == 200
+    # Forwarded to the server-owned provider session, not the browser-visible id.
+    assert proxy.posted == [
+        {"session_id": _PROVIDER_SESSION_ID, "type": "message", "actor": None}
+    ]
+    # Response is virtualized back to the chatBindingId.
+    assert response.json()["session_id"] == _CHAT_BINDING_ID
+    assert _PROVIDER_SESSION_ID not in response.text
+
+
+def test_stop_revokes_and_forwards() -> None:
+    registry = _fake_registry()
+    client, proxy, _store = _build(registry=registry)
+
+    response = client.post(
+        _path(f"v1/sessions/{_CHAT_BINDING_ID}/events"),
+        json={"type": "stop"},
+    )
+
+    assert response.status_code == 200
+    registry.revoke_scope.assert_called_once()
+
+
+def test_resolve_elicitation_forwarded_to_bound_session() -> None:
+    client, proxy, _store = _build()
+
+    response = client.post(
+        _path(f"v1/sessions/{_CHAT_BINDING_ID}/elicitations/el-9/resolve"),
+        json={"decision": "approve"},
+    )
+
+    assert response.status_code == 200
+    assert proxy.resolved == [
+        {
+            "session_id": _PROVIDER_SESSION_ID,
+            "elicitation_id": "el-9",
+            "payload": {"decision": "approve"},
+        }
+    ]
+
+
+def test_message_requires_json_content_type() -> None:
+    client, _proxy, _store = _build()
+
+    response = client.post(
+        _path(f"v1/sessions/{_CHAT_BINDING_ID}/events"),
+        content="type=message",
+        headers={"content-type": "text/plain"},
+    )
+
+    assert response.status_code == 415
+    assert response.json()["detail"]["code"] == "omnigent_chat_unsupported_media_type"
+
+
+def test_malformed_json_body_is_rejected() -> None:
+    client, _proxy, _store = _build()
+
+    response = client.post(
+        _path(f"v1/sessions/{_CHAT_BINDING_ID}/events"),
+        content="{not-json",
+        headers={"content-type": "application/json"},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"]["code"] == "omnigent_chat_malformed_payload"
+
+
+def test_oversized_body_is_rejected() -> None:
+    client, _proxy, _store = _build()
+
+    response = client.post(
+        _path(f"v1/sessions/{_CHAT_BINDING_ID}/events"),
+        content=b"x" * (1 * 1024 * 1024 + 16),
+        headers={"content-type": "application/json"},
+    )
+
+    assert response.status_code == 413
+    assert response.json()["detail"]["code"] == "omnigent_chat_payload_too_large"
+
+
+# --- Resources ---------------------------------------------------------------
+
+
+def test_resource_index_delegated_to_bound_session() -> None:
+    client, proxy, _store = _build()
+
+    response = client.get(
+        _path(
+            f"v1/sessions/{_CHAT_BINDING_ID}"
+            "/resources/environments/default/changes"
+        )
+    )
+
+    assert response.status_code == 200
+    assert proxy.resources == [("changed_files", _PROVIDER_SESSION_ID, None)]
+
+
+def test_resource_file_returns_bytes() -> None:
+    client, proxy, _store = _build()
+
+    response = client.get(
+        _path(
+            f"v1/sessions/{_CHAT_BINDING_ID}"
+            "/resources/environments/default/filesystem/src/main.py"
+        )
+    )
+
+    assert response.status_code == 200
+    assert response.content == b"RAW-BYTES"
+    assert response.headers["content-type"].startswith("application/octet-stream")
+    assert proxy.resources == [
+        ("workspace_file", _PROVIDER_SESSION_ID, "src/main.py")
+    ]
+
+
+def test_workspace_diff_media_type() -> None:
+    client, proxy, _store = _build()
+
+    response = client.get(
+        _path(
+            f"v1/sessions/{_CHAT_BINDING_ID}"
+            "/resources/environments/default/diff/src/main.py"
+        )
+    )
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/x-diff")
+
+
+def test_list_agents_metadata() -> None:
+    client, _proxy, _store = _build()
+
+    response = client.get(_path("v1/agents"))
+
+    assert response.status_code == 200
+    assert response.json() == [{"id": "agent-1", "name": "codex"}]
+
+
+def test_liveness_probe_is_local() -> None:
+    client, proxy, _store = _build()
+
+    response = client.get(_path("health"))
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["chatBindingId"] == _CHAT_BINDING_ID
+    assert body["state"] == "available"
+    assert body["readOnly"] is False
+    assert proxy.resources == []  # never touched upstream
+
+
+# --- SSE replay / reconnect / revocation ------------------------------------
+
+
+def test_stream_replays_from_cursor_and_terminates() -> None:
+    store = _FakeStore(row=_row(status="completed"), events=[_event(1), _event(2)])
+    client, _proxy, _store = _build(store=store)
+
+    response = client.get(_path(f"v1/sessions/{_CHAT_BINDING_ID}/stream"))
+
+    assert response.status_code == 200
+    assert "id: 1" in response.text
+    assert "id: 2" in response.text
+    assert "event: terminal" in response.text
+
+
+def test_stream_last_event_id_resumes_after_delivered() -> None:
+    store = _FakeStore(row=_row(status="completed"), events=[_event(1), _event(2)])
+    client, _proxy, _store = _build(store=store)
+
+    response = client.get(
+        _path(f"v1/sessions/{_CHAT_BINDING_ID}/stream"),
+        headers={"Last-Event-ID": "1"},
+    )
+
+    assert response.status_code == 200
+    assert "id: 2" in response.text
+    assert "id: 1\n" not in response.text
+
+
+def test_stream_reports_retention_gap() -> None:
+    store = _FakeStore(row=_row(status="active"), events=[_event(5), _event(6)])
+    client, _proxy, _store = _build(store=store)
+
+    response = client.get(_path(f"v1/sessions/{_CHAT_BINDING_ID}/stream"))
+
+    assert response.status_code == 200
+    assert "event: retention_gap" in response.text
+
+
+def test_stream_stops_when_authority_revoked_midstream(monkeypatch) -> None:
+    import api_service.api.routers.omnigent_bridge as module
+
+    # Force reauthorization on the first poll so the revoked authority is
+    # observed immediately rather than after the default cadence.
+    monkeypatch.setattr(module, "_FACADE_STREAM_REAUTH_EVERY_POLLS", 1)
+    store = _FakeStore(row=_row(status="active"), events=[_event(1)])
+    # The binding is authorized when the stream opens, then denied on the next
+    # authorization pass (deny_after=1).
+    service = _FakeService(_USER_ID, deny_after=1)
+    client, _proxy, _store = _build(store=store, service=service)
+
+    response = client.get(_path(f"v1/sessions/{_CHAT_BINDING_ID}/stream"))
+
+    assert response.status_code == 200
+    assert "event: error" in response.text
+    assert "omnigent_chat_binding_unknown" in response.text
+
+
+# --- Primitive-level coverage ------------------------------------------------
+
+
+def test_match_facade_operation_allowlist() -> None:
+    assert match_facade_operation("GET", "v1/agents").operation.name == "list_agents"
+    assert match_facade_operation("GET", "health").operation.name == "liveness"
+    match = match_facade_operation("POST", "v1/sessions/abc/events")
+    assert match.operation.name == "post_event"
+    assert match.params["session_id"] == "abc"
+    # Not allowlisted: generic reverse-proxy targets and wrong methods.
+    assert match_facade_operation("POST", "v1/sessions") is None
+    assert match_facade_operation("GET", "v1/sessions/abc/events") is None
+    assert match_facade_operation("DELETE", "v1/sessions/abc") is None
+    assert match_facade_operation("GET", "../../etc/passwd") is None
+
+
+def test_recompute_capabilities_read_only_when_terminal() -> None:
+    active = recompute_capabilities("active")
+    terminal = recompute_capabilities("completed")
+
+    assert active[CAP_SEND_MESSAGE] is True
+    assert terminal[CAP_SEND_MESSAGE] is False
+    assert terminal[CAP_VIEW_TRANSCRIPT] is True
+    # Authority-boundary capabilities are never granted through the facade.
+    assert active["changeModel"] is False
+    assert active["mutateWorkspace"] is False
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"path_session_id": "other"},
+        {"path_session_id": None, "query": {"host_id": "x"}},
+        {"path_session_id": None, "body": {"type": "message", "endpoint": "x"}},
+        {"path_session_id": None, "body": {"metadata": {"model": "gpt"}}},
+        {"path_session_id": None, "headers": {"x-provider-session-id": "x"}},
+    ],
+)
+def test_identity_guard_fails_closed(kwargs) -> None:
+    with pytest.raises(WorkflowChatFacadeError):
+        assert_no_identity_substitution(chat_binding_id=_CHAT_BINDING_ID, **kwargs)
+
+
+def test_identity_guard_allows_bound_session_echo() -> None:
+    # The bound id may legitimately be echoed in the body/query.
+    assert_no_identity_substitution(
+        chat_binding_id=_CHAT_BINDING_ID,
+        path_session_id=_CHAT_BINDING_ID,
+        query={"since": "3"},
+        body={"type": "message", "session_id": _CHAT_BINDING_ID},
+        headers={"content-type": "application/json"},
+    )

--- a/tests/unit/api/routers/test_omnigent_workflow_chat.py
+++ b/tests/unit/api/routers/test_omnigent_workflow_chat.py
@@ -30,15 +30,22 @@ from api_service.api.routers.omnigent_bridge import (
 )
 from api_service.api.routers.retrieval_gateway import get_capability_registry
 from api_service.auth_providers import get_current_user
-from moonmind.omnigent.bridge_config import HOST_PROTOCOL_MODE_PROXY
+from moonmind.omnigent.bridge_config import (
+    HOST_PROTOCOL_MODE_EMBEDDED,
+    HOST_PROTOCOL_MODE_PROXY,
+)
 from moonmind.omnigent.settings import resolved_proxy_forward_headers
 from moonmind.omnigent.workflow_chat_facade import (
+    CAP_CONTROL_UNSUPPORTED,
+    CAP_INTERRUPT_TURN,
+    CAP_RESOLVE_ELICITATION,
     CAP_SEND_MESSAGE,
     CAP_VIEW_TRANSCRIPT,
     WorkflowChatFacadeError,
     assert_no_identity_substitution,
     match_facade_operation,
     recompute_capabilities,
+    required_capability_for_event,
 )
 from moonmind.workflows.adapters.omnigent_client import OmnigentHttpClient
 
@@ -47,6 +54,9 @@ _UNSET = object()
 
 _PROVIDER_SESSION_ID = "prov-sess-1"
 _CHAT_BINDING_ID = "brs-1"
+# The durable bridge-session key is server-owned and (once #3633 lands) distinct
+# from the browser-facing chatBindingId. Journal reads must use this key.
+_BRIDGE_SESSION_ID = "brs-internal-1"
 
 
 def _mock_user():
@@ -69,7 +79,7 @@ class _FakeService:
 
 def _row(**overrides: Any) -> SimpleNamespace:
     values = dict(
-        bridge_session_id=_CHAT_BINDING_ID,
+        bridge_session_id=_BRIDGE_SESSION_ID,
         moonmind_workflow_id="mm:w1",
         moonmind_run_id="run-1",
         moonmind_agent_run_id="ar-1",
@@ -93,10 +103,10 @@ def _row(**overrides: Any) -> SimpleNamespace:
     return SimpleNamespace(**values)
 
 
-def _event(sequence: int) -> SimpleNamespace:
+def _event(sequence: int, *, metadata: dict[str, Any] | None = None) -> SimpleNamespace:
     return SimpleNamespace(
         event_id=f"evt-{sequence}",
-        bridge_session_id=_CHAT_BINDING_ID,
+        bridge_session_id=_BRIDGE_SESSION_ID,
         sequence=sequence,
         timestamp=SimpleNamespace(isoformat=lambda: "2026-08-07T00:00:00+00:00"),
         direction="host_to_moonmind",
@@ -104,17 +114,35 @@ def _event(sequence: int) -> SimpleNamespace:
         normalized_status="running",
         text_preview="hello",
         artifact_ref=None,
-        metadata_={},
+        metadata_=metadata if metadata is not None else {},
     )
 
 
 class _FakeStore:
-    def __init__(self, *, row: Any = _UNSET, events: list[Any] | None = None) -> None:
+    def __init__(
+        self,
+        *,
+        row: Any = _UNSET,
+        events: list[Any] | None = None,
+        rows_by_call: list[Any] | None = None,
+    ) -> None:
         self._row = _row() if row is _UNSET else row
+        # When provided, successive ``get_bridge_session`` calls return each row
+        # in turn (the last is sticky), so a test can simulate the durable state
+        # changing between the initial load and the mutation-handoff re-read.
+        self._rows_by_call = list(rows_by_call) if rows_by_call else None
+        self._get_calls = 0
         self._events = events or []
         self.appended: list[dict[str, Any]] = []
+        self.lifecycle: list[dict[str, Any]] = []
+        self.claimed: set[str] = set()
+        self.event_query_keys: list[str] = []
 
     async def get_bridge_session(self, bridge_session_id: str):
+        if self._rows_by_call is not None:
+            index = min(self._get_calls, len(self._rows_by_call) - 1)
+            self._get_calls += 1
+            return self._rows_by_call[index]
         return self._row
 
     async def get_session_by_provider_session_id(self, session_id: str):
@@ -123,6 +151,7 @@ class _FakeStore:
         return None
 
     async def list_event_page(self, bridge_session_id: str, *, after: int, limit: int):
+        self.event_query_keys.append(bridge_session_id)
         rows = [event for event in self._events if event.sequence > after]
         return SimpleNamespace(
             rows=rows[:limit],
@@ -135,6 +164,47 @@ class _FakeStore:
 
     async def append_events(self, bridge_session_id: str, events: list[dict[str, Any]]):
         self.appended.extend(events)
+
+    async def claim_lifecycle_event(
+        self,
+        idempotency_key: str,
+        *,
+        event_type: str,
+        event_identity: str,
+        summary: str,
+        metadata: dict[str, Any] | None = None,
+    ) -> bool:
+        if event_identity in self.claimed:
+            return False
+        self.claimed.add(event_identity)
+        self.lifecycle.append(
+            {
+                "kind": "claim",
+                "event_type": event_type,
+                "event_identity": event_identity,
+                "metadata": metadata or {},
+            }
+        )
+        return True
+
+    async def record_lifecycle_event(
+        self,
+        idempotency_key: str,
+        *,
+        event_type: str,
+        event_identity: str,
+        summary: str,
+        metadata: dict[str, Any] | None = None,
+    ):
+        self.lifecycle.append(
+            {
+                "kind": "record",
+                "event_type": event_type,
+                "event_identity": event_identity,
+                "metadata": metadata or {},
+            }
+        )
+        return self._row
 
 
 class _FakeProxy:
@@ -183,6 +253,57 @@ class _FakeProxy:
         return {"ok": True, "elicitationId": elicitation_id, "session_id": session_id}
 
 
+class _FakeEmbeddedFacade:
+    """Embedded-host facade contract exercised by the second supported host mode.
+
+    The changed router has separate embedded branches for messages, cleanup,
+    approvals, resources, catalog reads, and actor propagation; this fake lets
+    the suite cover the embedded facade boundary rather than only proxy mode.
+    """
+
+    def __init__(self) -> None:
+        self.posted: list[dict[str, Any]] = []
+        self.resolved: list[dict[str, Any]] = []
+        self.resources: list[tuple[str, str, str | None]] = []
+
+    async def get_session(self, session_id: str):
+        return {
+            "id": session_id,
+            "status": "running",
+            "providerSessionField": session_id,
+            "host_id": "host-1",
+            "moonmind": {"workflowId": "mm:w1", "bridgeSessionId": _BRIDGE_SESSION_ID},
+        }
+
+    async def list_agents(self):
+        return [{"id": "agent-1", "name": "codex", "host_id": "host-1"}]
+
+    async def get_resource(self, operation: str, session_id: str, value=None):
+        self.resources.append((operation, session_id, value))
+        if operation in {"workspace_file", "workspace_diff", "session_file"}:
+            return b"RAW-BYTES"
+        return {"files": [{"path": "src/main.py", "session": session_id}]}
+
+    async def post_event(self, *, session_id: str, event, actor=None):
+        self.posted.append(
+            {"session_id": session_id, "type": event.type, "actor": actor}
+        )
+        return {"ok": True, "type": event.type, "session_id": session_id}
+
+    async def resolve_elicitation(
+        self, *, session_id: str, elicitation_id: str, payload, actor=None
+    ):
+        self.resolved.append(
+            {
+                "session_id": session_id,
+                "elicitation_id": elicitation_id,
+                "payload": payload,
+                "actor": actor,
+            }
+        )
+        return {"ok": True, "elicitationId": elicitation_id, "session_id": session_id}
+
+
 def _fake_registry() -> SimpleNamespace:
     return SimpleNamespace(
         has_live_session_authority=Mock(return_value=False),
@@ -216,6 +337,37 @@ def _build(
     app.dependency_overrides[get_capability_registry] = lambda: registry
     app.dependency_overrides[_require_bridge_enabled] = lambda: config
     return TestClient(app), proxy, store
+
+
+def _build_embedded(
+    *,
+    owner_id: Any = _USER_ID,
+    embedded: _FakeEmbeddedFacade | None = None,
+    store: _FakeStore | None = None,
+    registry: Any | None = None,
+    service: Any | None = None,
+) -> tuple[TestClient, _FakeEmbeddedFacade, _FakeStore]:
+    """Build a client whose bridge runs in the embedded host protocol mode."""
+
+    app = FastAPI()
+    app.include_router(
+        workflow_chat_router, prefix=WORKFLOW_CHAT_BINDINGS_MOUNT_PATH
+    )
+    embedded = embedded or _FakeEmbeddedFacade()
+    store = store or _FakeStore()
+    registry = registry or _fake_registry()
+    config = SimpleNamespace(host_protocol_mode=HOST_PROTOCOL_MODE_EMBEDDED)
+    app.dependency_overrides[get_current_user()] = _mock_user
+    app.dependency_overrides[_get_execution_service] = lambda: (
+        service or _FakeService(owner_id)
+    )
+    app.dependency_overrides[_get_bridge_store] = lambda: store
+    # In embedded mode the proxy is absent; the embedded facade services routes.
+    app.dependency_overrides[_get_bridge_proxy] = lambda: None
+    app.dependency_overrides[_get_create_embedded_facade] = lambda: embedded
+    app.dependency_overrides[get_capability_registry] = lambda: registry
+    app.dependency_overrides[_require_bridge_enabled] = lambda: config
+    return TestClient(app), embedded, store
 
 
 def _path(suffix: str, *, binding: str = _CHAT_BINDING_ID) -> str:
@@ -432,7 +584,11 @@ def test_message_forwarded_to_bound_provider_session() -> None:
     assert _PROVIDER_SESSION_ID not in response.text
 
 
-def test_stop_revokes_and_forwards() -> None:
+def test_stop_control_denied_without_distinct_authority() -> None:
+    # The browser facade carries message/interrupt authority only. Destructive
+    # session controls (stop/clear/cleanup/terminal_cleanup) need their own
+    # authority the facade does not grant, so a caller with sendMessage cannot
+    # reach them by naming an off-allowlist event type.
     registry = _fake_registry()
     client, proxy, _store = _build(registry=registry)
 
@@ -441,8 +597,28 @@ def test_stop_revokes_and_forwards() -> None:
         json={"type": "stop"},
     )
 
-    assert response.status_code == 200
-    registry.revoke_scope.assert_called_once()
+    assert response.status_code == 403
+    assert response.json()["detail"]["code"] == "omnigent_chat_operation_denied"
+    # The destructive control never reached the revocation/forward path.
+    registry.revoke_scope.assert_not_called()
+    assert proxy.posted == []
+
+
+@pytest.mark.parametrize(
+    "event_type",
+    ["stop", "stop_session", "clear_session", "cleanup_session", "terminal_cleanup"],
+)
+def test_destructive_controls_denied(event_type: str) -> None:
+    client, proxy, _store = _build()
+
+    response = client.post(
+        _path(f"v1/sessions/{_CHAT_BINDING_ID}/events"),
+        json={"type": event_type},
+    )
+
+    assert response.status_code == 403
+    assert response.json()["detail"]["code"] == "omnigent_chat_operation_denied"
+    assert proxy.posted == []
 
 
 def test_resolve_elicitation_forwarded_to_bound_session() -> None:
@@ -613,11 +789,13 @@ def test_stream_reports_retention_gap() -> None:
 
 
 def test_stream_stops_when_authority_revoked_midstream(monkeypatch) -> None:
-    import api_service.api.routers.omnigent_bridge as module
-
     # Force reauthorization on the first poll so the revoked authority is
-    # observed immediately rather than after the default cadence.
-    monkeypatch.setattr(module, "_FACADE_STREAM_REAUTH_EVERY_POLLS", 1)
+    # observed immediately rather than after the default cadence. The setattr
+    # target is addressed by dotted path so the module is not imported twice.
+    monkeypatch.setattr(
+        "api_service.api.routers.omnigent_bridge._FACADE_STREAM_REAUTH_EVERY_POLLS",
+        1,
+    )
     store = _FakeStore(row=_row(status="active"), events=[_event(1)])
     # The binding is authorized when the stream opens, then denied on the next
     # authorization pass (deny_after=1).
@@ -683,3 +861,405 @@ def test_identity_guard_allows_bound_session_echo() -> None:
         body={"type": "message", "session_id": _CHAT_BINDING_ID},
         headers={"content-type": "application/json"},
     )
+
+
+# --- Capability policy intersection (interventionCapabilities) ---------------
+
+
+def test_recompute_capabilities_intersects_binding_policy() -> None:
+    # A stored policy that disables sendMessage must remove it even on a live,
+    # non-terminal session; it can never re-grant a status-denied capability.
+    caps = recompute_capabilities(
+        "active", policy_capabilities={"sendMessage": False}
+    )
+    assert caps[CAP_SEND_MESSAGE] is False
+    assert caps[CAP_INTERRUPT_TURN] is True
+    assert caps[CAP_VIEW_TRANSCRIPT] is True
+
+    # A policy cannot grant a mutation on a terminal (read-only) session.
+    terminal = recompute_capabilities(
+        "completed", policy_capabilities={"sendMessage": True}
+    )
+    assert terminal[CAP_SEND_MESSAGE] is False
+
+
+def test_message_denied_when_policy_disables_send() -> None:
+    store = _FakeStore(
+        row=_row(metadata_={"interventionCapabilities": {"sendMessage": False}})
+    )
+    client, proxy, _store = _build(store=store)
+
+    response = client.post(
+        _path(f"v1/sessions/{_CHAT_BINDING_ID}/events"),
+        json={"type": "message", "data": {"content": [{"type": "text", "text": "hi"}]}},
+    )
+
+    assert response.status_code == 403
+    assert response.json()["detail"]["code"] == "omnigent_chat_operation_denied"
+    assert proxy.posted == []
+
+
+# --- Composer event allowlist ------------------------------------------------
+
+
+def test_required_capability_for_event_allowlist() -> None:
+    assert required_capability_for_event("message") == CAP_SEND_MESSAGE
+    assert required_capability_for_event("user.message") == CAP_SEND_MESSAGE
+    assert required_capability_for_event("interrupt") == CAP_INTERRUPT_TURN
+    # Destructive/unknown controls map to a capability the facade never grants.
+    for control in ("stop_session", "cleanup_session", "terminal_cleanup", "weird"):
+        assert required_capability_for_event(control) == CAP_CONTROL_UNSUPPORTED
+
+
+def test_interrupt_is_forwarded() -> None:
+    client, proxy, _store = _build()
+
+    response = client.post(
+        _path(f"v1/sessions/{_CHAT_BINDING_ID}/events"),
+        json={"type": "interrupt"},
+    )
+
+    assert response.status_code == 200
+    assert proxy.posted == [
+        {"session_id": _PROVIDER_SESSION_ID, "type": "interrupt", "actor": None}
+    ]
+
+
+# --- Recursive identity guard ------------------------------------------------
+
+
+def test_identity_guard_scans_nested_body_and_lists() -> None:
+    # A forbidden identity hidden inside nested event data or a list item is
+    # rejected, not only the body root and one metadata mapping.
+    with pytest.raises(WorkflowChatFacadeError):
+        assert_no_identity_substitution(
+            chat_binding_id=_CHAT_BINDING_ID,
+            path_session_id=None,
+            body={"type": "message", "data": {"endpoint": "http://evil"}},
+        )
+    with pytest.raises(WorkflowChatFacadeError):
+        assert_no_identity_substitution(
+            chat_binding_id=_CHAT_BINDING_ID,
+            path_session_id=None,
+            body={"type": "message", "items": [{"provider_session_id": "other"}]},
+        )
+    with pytest.raises(WorkflowChatFacadeError):
+        assert_no_identity_substitution(
+            chat_binding_id=_CHAT_BINDING_ID,
+            path_session_id=None,
+            body={"data": {"session_id": "other-session"}},
+        )
+
+
+def test_nested_identity_substitution_rejected_via_router() -> None:
+    client, _proxy, _store = _build()
+
+    response = client.post(
+        _path(f"v1/sessions/{_CHAT_BINDING_ID}/events"),
+        json={"type": "message", "data": {"provider_session_id": "other"}},
+    )
+
+    assert response.status_code == 403
+    # ``provider_session_id`` is a forbidden server-owned identity key, hidden a
+    # level deep inside event ``data`` — the recursive scan still rejects it.
+    assert response.json()["detail"]["code"] == "omnigent_chat_identity_substitution"
+
+
+# --- Recursive topology redaction --------------------------------------------
+
+
+def test_list_response_topology_redacted_recursively() -> None:
+    class _TopoProxy(_FakeProxy):
+        async def list_agents(self):
+            return [
+                {
+                    "id": "agent-1",
+                    "endpoint": "http://internal",
+                    "host_id": "host-1",
+                    "runner_id": "runner-1",
+                    "nested": {"moonmind": {"secret": True}, "keep": "ok"},
+                }
+            ]
+
+    client, _proxy, _store = _build(proxy=_TopoProxy())
+
+    response = client.get(_path("v1/agents"))
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body[0]["id"] == "agent-1"
+    # Topology keys are dropped at every mapping depth, not only the root.
+    assert "endpoint" not in body[0]
+    assert "host_id" not in body[0]
+    assert "runner_id" not in body[0]
+    assert body[0]["nested"] == {"keep": "ok"}
+    assert "internal" not in response.text
+
+
+# --- Outbound secret scan (fail-closed high-security mode) -------------------
+
+
+def test_high_security_blocks_secret_bearing_message(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "moonmind.security.outbound_scan.resolve_high_security_mode",
+        lambda *a, **k: True,
+    )
+    monkeypatch.setattr(
+        "api_service.api.routers.omnigent_bridge.resolve_high_security_mode",
+        lambda *a, **k: True,
+    )
+    client, proxy, _store = _build()
+
+    response = client.post(
+        _path(f"v1/sessions/{_CHAT_BINDING_ID}/events"),
+        json={
+            "type": "message",
+            "data": {
+                "content": [
+                    {"type": "text", "text": "ghp_" + "a" * 36}
+                ]
+            },
+        },
+    )
+
+    assert response.status_code == 403
+    assert response.json()["detail"]["code"] == "omnigent_chat_content_blocked"
+    # The blocked content never reached the provider.
+    assert proxy.posted == []
+
+
+# --- Approval authority ------------------------------------------------------
+
+
+def test_resolve_elicitation_denied_when_policy_disables_approval() -> None:
+    store = _FakeStore(
+        row=_row(metadata_={"interventionCapabilities": {"resolveElicitation": False}})
+    )
+    client, proxy, _store = _build(store=store)
+
+    response = client.post(
+        _path(f"v1/sessions/{_CHAT_BINDING_ID}/elicitations/el-9/resolve"),
+        json={"decision": "approve"},
+    )
+
+    assert response.status_code == 403
+    assert response.json()["detail"]["code"] == "omnigent_chat_operation_denied"
+    assert proxy.resolved == []
+
+
+# --- Idempotent message submission -------------------------------------------
+
+
+def test_message_idempotency_key_dedupes_replay() -> None:
+    client, proxy, store = _build()
+    headers = {"Idempotency-Key": "browser-retry-1"}
+    payload = {"type": "message", "data": {"content": [{"type": "text", "text": "hi"}]}}
+
+    first = client.post(
+        _path(f"v1/sessions/{_CHAT_BINDING_ID}/events"), json=payload, headers=headers
+    )
+    second = client.post(
+        _path(f"v1/sessions/{_CHAT_BINDING_ID}/events"), json=payload, headers=headers
+    )
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    # Exactly one provider turn was issued despite the retry.
+    assert len(proxy.posted) == 1
+    assert second.json()["deduplicated"] is True
+
+
+def test_message_records_durable_control_audit() -> None:
+    client, proxy, store = _build()
+
+    response = client.post(
+        _path(f"v1/sessions/{_CHAT_BINDING_ID}/events"),
+        json={"type": "message", "data": {"content": [{"type": "text", "text": "hi"}]}},
+    )
+
+    assert response.status_code == 200
+    # A durable claim (idempotency) and a durable "posted" control audit exist.
+    kinds = {entry["kind"] for entry in store.lifecycle}
+    assert "claim" in kinds
+    assert any(
+        entry["metadata"].get("controlOutcome") == "posted"
+        for entry in store.lifecycle
+    )
+
+
+# --- Mutation-handoff revalidation (compare-and-set) -------------------------
+
+
+def test_message_rejected_when_session_terminalizes_midrequest() -> None:
+    # The row is active when first loaded, then terminal on the handoff re-read.
+    store = _FakeStore(
+        rows_by_call=[_row(status="active"), _row(status="completed")]
+    )
+    client, proxy, _store = _build(store=store)
+
+    response = client.post(
+        _path(f"v1/sessions/{_CHAT_BINDING_ID}/events"),
+        json={"type": "message", "data": {"content": [{"type": "text", "text": "hi"}]}},
+    )
+
+    assert response.status_code == 409
+    assert response.json()["detail"]["code"] == "omnigent_chat_session_read_only"
+    assert proxy.posted == []
+
+
+# --- Terminal durable read after provider cleanup ----------------------------
+
+
+def test_terminal_binding_serves_durable_snapshot_without_provider_session() -> None:
+    store = _FakeStore(
+        row=_row(
+            status="completed",
+            omnigent_session_id="",
+            terminal_refs={"summary": "done"},
+            diagnostics_ref="art://diag",
+        )
+    )
+    client, proxy, _store = _build(store=store)
+
+    response = client.get(_path(f"v1/sessions/{_CHAT_BINDING_ID}"))
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["id"] == _CHAT_BINDING_ID
+    assert body["readOnly"] is True
+    assert body["providerSessionAvailable"] is False
+    # Served from the durable projection; no upstream get_session call was made.
+    assert proxy.resources == []
+
+
+# --- Strict stream cursors ---------------------------------------------------
+
+
+@pytest.mark.parametrize("param", ["cursor", "since"])
+def test_stream_rejects_malformed_cursor(param: str) -> None:
+    store = _FakeStore(row=_row(status="active"), events=[_event(1)])
+    client, _proxy, _store = _build(store=store)
+
+    response = client.get(
+        _path(f"v1/sessions/{_CHAT_BINDING_ID}/stream"), params={param: "-3"}
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"]["code"] == "omnigent_chat_malformed_payload"
+
+    non_numeric = client.get(
+        _path(f"v1/sessions/{_CHAT_BINDING_ID}/stream"), params={param: "abc"}
+    )
+    assert non_numeric.status_code == 400
+
+
+# --- SSE journal key + visibility filter -------------------------------------
+
+
+def test_stream_uses_resolved_bridge_session_key() -> None:
+    store = _FakeStore(
+        row=_row(status="completed", bridge_session_id=_BRIDGE_SESSION_ID),
+        events=[_event(1)],
+    )
+    client, _proxy, _store = _build(store=store)
+
+    response = client.get(_path(f"v1/sessions/{_CHAT_BINDING_ID}/stream"))
+
+    assert response.status_code == 200
+    # Journal reads used the durable bridge-session key, not the chatBindingId.
+    assert _store.event_query_keys
+    assert all(key == _BRIDGE_SESSION_ID for key in _store.event_query_keys)
+    # The browser transcript exposes only the opaque chatBindingId.
+    assert _BRIDGE_SESSION_ID not in response.text
+    assert _CHAT_BINDING_ID in response.text
+
+
+def test_stream_excludes_non_visible_lifecycle_rows() -> None:
+    visible = _event(1)
+    hidden = _event(
+        2, metadata={"moonmind": {"workflowChatVisible": False, "source": "lifecycle"}}
+    )
+    store = _FakeStore(row=_row(status="completed"), events=[visible, hidden])
+    client, _proxy, _store = _build(store=store)
+
+    response = client.get(_path(f"v1/sessions/{_CHAT_BINDING_ID}/stream"))
+
+    assert response.status_code == 200
+    # The visible row is streamed; the internal lifecycle row is not.
+    assert "id: 1" in response.text
+    assert "id: 2" not in response.text
+
+
+# --- Embedded host protocol mode boundary ------------------------------------
+
+
+def test_embedded_message_forwarded_with_actor() -> None:
+    client, embedded, _store = _build_embedded()
+
+    response = client.post(
+        _path(f"v1/sessions/{_CHAT_BINDING_ID}/events"),
+        json={"type": "message", "data": {"content": [{"type": "text", "text": "hi"}]}},
+    )
+
+    assert response.status_code == 200
+    assert len(embedded.posted) == 1
+    # The embedded branch propagates the caller as actor (proxy mode does not).
+    assert embedded.posted[0]["actor"] == str(_USER_ID)
+    assert embedded.posted[0]["session_id"] == _PROVIDER_SESSION_ID
+
+
+def test_embedded_snapshot_virtualizes_and_gates_capabilities() -> None:
+    client, embedded, _store = _build_embedded()
+
+    response = client.get(_path(f"v1/sessions/{_CHAT_BINDING_ID}"))
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["id"] == _CHAT_BINDING_ID
+    assert "host_id" not in body
+    assert "moonmind" not in body
+    assert body["capabilities"][CAP_SEND_MESSAGE] is True
+
+
+def test_embedded_resolve_elicitation_propagates_actor() -> None:
+    client, embedded, _store = _build_embedded()
+
+    response = client.post(
+        _path(f"v1/sessions/{_CHAT_BINDING_ID}/elicitations/el-9/resolve"),
+        json={"decision": "approve"},
+    )
+
+    assert response.status_code == 200
+    assert embedded.resolved == [
+        {
+            "session_id": _PROVIDER_SESSION_ID,
+            "elicitation_id": "el-9",
+            "payload": {"decision": "approve"},
+            "actor": str(_USER_ID),
+        }
+    ]
+
+
+def test_embedded_resource_read_delegated() -> None:
+    client, embedded, _store = _build_embedded()
+
+    response = client.get(
+        _path(
+            f"v1/sessions/{_CHAT_BINDING_ID}"
+            "/resources/environments/default/changes"
+        )
+    )
+
+    assert response.status_code == 200
+    assert embedded.resources == [("changed_files", _PROVIDER_SESSION_ID, None)]
+
+
+def test_embedded_catalog_read() -> None:
+    client, embedded, _store = _build_embedded()
+
+    response = client.get(_path("v1/agents"))
+
+    assert response.status_code == 200
+    body = response.json()
+    # Topology stripped even from the embedded catalog list response.
+    assert body == [{"id": "agent-1", "name": "codex"}]

--- a/tests/unit/api/routers/test_omnigent_workflow_chat.py
+++ b/tests/unit/api/routers/test_omnigent_workflow_chat.py
@@ -138,12 +138,19 @@ class _FakeStore:
         self.claimed: set[str] = set()
         self.event_query_keys: list[str] = []
 
-    async def get_bridge_session(self, bridge_session_id: str):
+    def _next_row(self):
         if self._rows_by_call is not None:
             index = min(self._get_calls, len(self._rows_by_call) - 1)
             self._get_calls += 1
             return self._rows_by_call[index]
         return self._row
+
+    async def get_bridge_session(self, bridge_session_id: str):
+        return self._next_row()
+
+    async def get_session_by_chat_binding_id(self, chat_binding_id: str):
+        # #3633 dedicated-column resolution seam used by the facade.
+        return self._next_row()
 
     async def get_session_by_provider_session_id(self, session_id: str):
         if self._row and getattr(self._row, "omnigent_session_id", None) == session_id:
@@ -1172,6 +1179,21 @@ def test_stream_uses_resolved_bridge_session_key() -> None:
     # The browser transcript exposes only the opaque chatBindingId.
     assert _BRIDGE_SESSION_ID not in response.text
     assert _CHAT_BINDING_ID in response.text
+
+
+def test_facade_resolves_via_chat_binding_column() -> None:
+    # #3633: the browser id is the dedicated chat_binding_id column, distinct
+    # from bridge_session_id. Resolving it as a bridge_session_id must not work.
+    class _ColumnOnlyStore(_FakeStore):
+        async def get_bridge_session(self, bridge_session_id: str):
+            return None
+
+    client, _proxy, _store = _build(store=_ColumnOnlyStore())
+
+    response = client.get(_path(f"v1/sessions/{_CHAT_BINDING_ID}"))
+
+    assert response.status_code == 200
+    assert response.json()["id"] == _CHAT_BINDING_ID
 
 
 def test_stream_excludes_non_visible_lifecycle_rows() -> None:


### PR DESCRIPTION
## Issue

Implements MoonLadderStudios/MoonMind#3634 — [Omnigent native chat 2/10] Build the binding-scoped HTTP and SSE facade with per-request authorization.

Closes MoonLadderStudios/MoonMind#3634

## Summary

Adds a binding-scoped Omnigent facade so the native web application talks to Omnigent exclusively through one MoonMind-owned surface keyed by `chatBindingId`:

```
/api/workflow-chat-bindings/{chatBindingId}/omnigent/{path}
```

- **Scoped facade router (no open reverse proxy):** New route family in `api_service/api/routers/omnigent_bridge.py`, wired in `api_service/main.py`, with an explicit method+route allowlist (`FACADE_OPERATIONS` / `match_facade_operation` in the new `moonmind/omnigent/workflow_chat_facade.py`). Covers session bootstrap/snapshot/history, message and control events, replay/live SSE, elicitation/approval resolution, session metadata, read-only resource indexes/content, and reconnect/liveness probes. Non-allowlisted routes/methods are rejected with `CODE_ROUTE_NOT_ALLOWLISTED`.
- **Per-request reauthorization:** Every request — and every SSE reconnect — authenticates the caller, resolves the durable binding, authorizes the caller against the bound Workflow Execution and the requested operation, recomputes effective capabilities from trusted state, and rejects stale/terminal mutations before any upstream forwarding. Possession of a URL or a prior bootstrap is never sufficient.
- **Identity-substitution prevention:** `assert_no_identity_substitution` rejects attempts to alter/inject provider session ID, upstream base URL/endpoint, host/runner, workspace, agent/provider profile, launch policy, model, effort, goal, credential, or alternate bridge/Workflow identity across path/query/body/header. The provider session ID is virtualized to the `chatBindingId` so it never reaches the browser. Unknown/unauthorized targets get shared non-enumerating responses.
- **Credential separation:** MoonMind cookies, JWTs, bearer/CSRF/internal-auth/identity/tracing headers are stripped; only an explicit transport/content header allowlist is forwarded; upstream Omnigent credentials are injected server-side and never returned to the browser; upstream errors/redirects are redacted.
- **Streaming semantics:** SSE authorizes before opening, reauthorizes mid-stream, translates durable cursor/`Last-Event-ID` semantics, surfaces retention gaps, stops on revoked authority, cannot be retargeted via query/body, bounds keepalive/idle, and reports terminal only on durable evidence (stream close is not treated as success).
- **Stable, redacted errors + audit posture:** Typed `CODE_*` error constants under one redacted envelope for binding unknown/stale, caller unauthorized, operation denied, session substitution, stale/terminal state, and media/payload violations. Audit records the binding and caller only, never whether an alternate provider session exists.
- **Existing bridge routes preserved:** The pre-existing provider-session bridge router remains mounted for internal/diagnostic use and is no longer the browser's primary route.

### Scope note

`chatBindingId` currently resolves through the durable `bridge_session_id` behind a single resolution seam (`_resolve_chat_binding_row`). The dedicated opaque `chat_binding_id` column is owned by the explicit dependency #3633 and is out of scope for #3634; the browser-facing contract is unchanged when that lookup lands.

## Tests run

- `python -m pytest tests/unit/api/routers/test_omnigent_workflow_chat.py -q` → **37 passed** (33 test functions incl. parametrizations); hermetic FastAPI `TestClient` with dependency overrides/fakes.
- `python -m pytest tests/unit/api/routers/ -k omnigent -q` → **168 passed, 848 deselected**; confirms no regression in the existing provider-session bridge, default-agent, catalog, or agent-profile router tests.

(Ran with `MOONMIND_FORCE_LOCAL_TESTS=1` because `MOONMIND_AGENT_RUN_ID` was not set in this runtime, so the managed `moonmind container python-tests` path was unavailable — environment note, non-blocking; the same tests were run hermetically in-process.)

## Remaining risks

- Coverage is hermetic unit-level (FastAPI `TestClient` + fakes); no live end-to-end run against a real upstream Omnigent instance was exercised in this environment.
- `chatBindingId` → `bridge_session_id` resolution depends on #3633 landing the dedicated column; until then the seam maps through the bridge session.
- The managed container test path (`moonmind container python-tests`) was not exercisable in this runtime; verification relied on in-process hermetic runs.
