### PR TITLE
Add Workflow Detail native Omnigent Chat route and thin context shell (MoonLadderStudios/MoonMind#3639)

### DIFF
--- a/frontend/src/entrypoints/workflow-detail.test.tsx
+++ b/frontend/src/entrypoints/workflow-detail.test.tsx
@@ -499,6 +499,21 @@ describe('Workflow Detail Entrypoint', () => {
           json: async () => stepsSnapshot,
         } as Response);
       }
+      if (url.includes('/chat-binding')) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: async () => ({
+            chatBindingId: 'cb-test',
+            workflowId: 'test-123',
+            chatUrl: '/omnigent-ui/workflow-chat/cb-test?embedded=1',
+            apiBase: '/api/workflow-chat-bindings/cb-test/omnigent',
+            state: 'available',
+            readOnly: false,
+            capabilities: { sendMessage: true },
+          }),
+        } as Response);
+      }
       if (url.includes('/artifacts?link_type=report.primary&latest_only=true')) {
         return Promise.resolve({
           ok: true,
@@ -8169,7 +8184,8 @@ describe('Workflow Detail Entrypoint', () => {
     renderWithClient(<WorkflowDetailPage payload={mockPayload} />);
 
     await waitFor(() => {
-      expect(screen.getByText('Encoded task')).toBeTruthy();
+      // The title renders in both the detail header and the native chat context bar.
+      expect(screen.getAllByText('Encoded task').length).toBeGreaterThan(0);
       expect(screen.getByText('Workflow mm:test-123')).toBeTruthy();
     });
 
@@ -8210,7 +8226,7 @@ describe('Workflow Detail Entrypoint', () => {
   });
 
   it('renders bridge session events before managed-runtime missing copy', async () => {
-    window.history.pushState({}, 'Bridge Chat Test', '/workflows/test-123/chat?source=temporal');
+    window.history.pushState({}, 'Bridge Chat Test', '/workflows/test-123/debug?source=temporal');
     const mockExecution = {
       taskId: 'test-123',
       workflowId: 'test-123',
@@ -8314,7 +8330,7 @@ describe('Workflow Detail Entrypoint', () => {
     ['direct Codex compatibility', 'codex_direct_compat'],
     ['Omnigent', 'omnigent_bridge'],
   ])('projects an active %s journey through shared history, SSE, chat, and resources', async (_label, source) => {
-    window.history.pushState({}, 'Bridge parity journey', '/workflows/test-123/chat?source=temporal');
+    window.history.pushState({}, 'Bridge parity journey', '/workflows/test-123/debug?source=temporal');
     const priorEventSource = window.EventSource;
     window.EventSource = MockEventSource as unknown as typeof EventSource;
     const bridgeSessionId = `brs-parity-${source}`;
@@ -8374,7 +8390,7 @@ describe('Workflow Detail Entrypoint', () => {
   });
 
   it('renders an understandable failed-before-stream lifecycle with zero provider events', async () => {
-    window.history.pushState({}, 'Failed Launch Chat', '/workflows/test-123/chat?source=temporal');
+    window.history.pushState({}, 'Failed Launch Chat', '/workflows/test-123/debug?source=temporal');
     const mockExecution = {
       taskId: 'test-123', workflowId: 'test-123', namespace: 'default',
       temporalRunId: 'failed-launch-run', runId: 'failed-launch-run', source: 'temporal',
@@ -8457,7 +8473,7 @@ describe('Workflow Detail Entrypoint', () => {
   });
 
   it('shows an authorization error instead of resource preview or download actions', async () => {
-    window.history.pushState({}, 'Bridge Authorization Test', '/workflows/test-123/chat?source=temporal');
+    window.history.pushState({}, 'Bridge Authorization Test', '/workflows/test-123/debug?source=temporal');
     const execution = {
       taskId: 'test-123', workflowId: 'test-123', namespace: 'default',
       temporalRunId: 'auth-run', runId: 'auth-run', source: 'temporal',
@@ -8495,7 +8511,7 @@ describe('Workflow Detail Entrypoint', () => {
   });
 
   it('renders bridge terminal failure evidence even without provider deltas', async () => {
-    window.history.pushState({}, 'Bridge Failure Test', '/workflows/test-123/chat?source=temporal');
+    window.history.pushState({}, 'Bridge Failure Test', '/workflows/test-123/debug?source=temporal');
     const mockExecution = {
       taskId: 'test-123', workflowId: 'test-123', source: 'temporal', namespace: 'default',
       title: 'Bridge failure', summary: 'Failed before streaming',
@@ -8540,7 +8556,7 @@ describe('Workflow Detail Entrypoint', () => {
   });
 
   it('uses advertised bridge capabilities and exposes delivery-unknown messages', async () => {
-    window.history.pushState({}, 'Bridge Controls Test', '/workflows/test-123/chat?source=temporal');
+    window.history.pushState({}, 'Bridge Controls Test', '/workflows/test-123/debug?source=temporal');
     const priorEventSource = window.EventSource;
     window.EventSource = MockEventSource as unknown as typeof EventSource;
     const mockExecution = {
@@ -8579,7 +8595,7 @@ describe('Workflow Detail Entrypoint', () => {
   });
 
   it('shows failed bridge delivery and denies controls not advertised by the server', async () => {
-    window.history.pushState({}, 'Bridge Failed Controls Test', '/workflows/test-123/chat?source=temporal');
+    window.history.pushState({}, 'Bridge Failed Controls Test', '/workflows/test-123/debug?source=temporal');
     const priorEventSource = window.EventSource;
     window.EventSource = MockEventSource as unknown as typeof EventSource;
     const mockExecution = { taskId: 'test-123', workflowId: 'test-123', source: 'temporal', namespace: 'default', title: 'Bridge controls', summary: 'Running', createdAt: '2026-07-09T00:00:00Z', updatedAt: '2026-07-09T00:00:30Z', status: 'running', state: 'executing', rawState: 'running', actions: {} };
@@ -8604,7 +8620,7 @@ describe('Workflow Detail Entrypoint', () => {
   });
 
   it('executes advertised bridge elicitation, clear, and cancel controls and preserves durable outcomes', async () => {
-    window.history.pushState({}, 'Bridge Intervention Test', '/workflows/test-123/chat?source=temporal');
+    window.history.pushState({}, 'Bridge Intervention Test', '/workflows/test-123/debug?source=temporal');
     const priorEventSource = window.EventSource;
     const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
     window.EventSource = MockEventSource as unknown as typeof EventSource;
@@ -8685,7 +8701,7 @@ describe('Workflow Detail Entrypoint', () => {
   });
 
   it('does not expose bridge elicitation, clear, or cancel actions unless advertised', async () => {
-    window.history.pushState({}, 'Bridge Denied Intervention Test', '/workflows/test-123/chat?source=temporal');
+    window.history.pushState({}, 'Bridge Denied Intervention Test', '/workflows/test-123/debug?source=temporal');
     const priorEventSource = window.EventSource;
     window.EventSource = MockEventSource as unknown as typeof EventSource;
     const mockExecution = { taskId: 'test-123', workflowId: 'test-123', source: 'temporal', namespace: 'default', title: 'Bridge interventions', summary: 'Running', createdAt: '2026-07-09T00:00:00Z', updatedAt: '2026-07-09T00:00:30Z', status: 'running', state: 'executing', rawState: 'running', actions: {} };
@@ -10162,7 +10178,7 @@ describe('Workflow Detail Entrypoint', () => {
   });
 
   it('handles Escape as a supported stop action and exposes disabled reasons for compact chat controls', async () => {
-    window.history.pushState({}, 'Test', '/workflows/test-123?source=temporal');
+    window.history.pushState({}, 'Test', '/workflows/test-123/debug?source=temporal');
     const codexPayload: BootPayload = {
       ...mockPayload,
       initialData: {

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -91,6 +91,7 @@ import {
   workflowDetailSubrouteFromPath,
   workflowDetailSubrouteHref,
 } from '../lib/workflowDetailRoutes';
+import { WorkflowNativeChatRoute } from '../features/workflow-native-chat';
 
 export {
   WORKFLOW_SIDEBAR_ANIMATED_RESTART_MS,
@@ -8536,7 +8537,7 @@ function WorkflowDetailPageContent({ payload }: { payload: BootPayload }) {
   const executionIdempotencyKey = execution?.idempotencyKey || execution?.idempotency_key || '';
   const shouldResolveBridgeSession = Boolean(
     execution &&
-      detailSubroute === 'chat' &&
+      detailSubroute === 'debug' &&
       !resolvedAgentRunId &&
       !explicitBridgeSessionId &&
       workflowId,
@@ -9689,11 +9690,45 @@ function WorkflowDetailPageContent({ payload }: { payload: BootPayload }) {
           </div>
 
           {chatTabActive ? (
-            <section className="stack td-chat-region td-evidence-region" aria-label="Workflow chat">
+            execution ? (
+              <WorkflowNativeChatRoute
+                apiBase={payload.apiBase}
+                workflowId={workflowId}
+                routeWorkflowId={taskId ?? workflowId}
+                search={search}
+                workflowTitle={workflowSubject}
+                statusPill={
+                  <WorkflowLifecycleStatusPill
+                    status={resolveWorkflowDisplayStatus(
+                      execution.rawState,
+                      execution.state,
+                      execution.status,
+                    )}
+                  />
+                }
+                runtimeLabel={
+                  execution.targetRuntime ? formatRuntimeLabel(execution.targetRuntime) : null
+                }
+                pollIntervalMs={detailPoll}
+                onNavigate={setDetailSubroute}
+              />
+            ) : (
+              <p className="small" role="status">
+                Loading workflow chat…
+              </p>
+            )
+          ) : null}
+
+          {debugTabActive ? (
+            <section
+              className="stack td-chat-region td-evidence-region"
+              aria-label="Session diagnostics"
+            >
               <div>
-                <h3>Workflow Chat</h3>
+                <h3>Session diagnostics</h3>
                 <p className="small">
-                  Session transcript, live runtime events, and eligible operator controls for this workflow.
+                  Read-only bridge session transcript, live runtime events, and eligible operator
+                  controls. Diagnostics only — the native chat experience is on the Chat tab.
                 </p>
               </div>
               {logStreamingEnabled ? (

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -9710,6 +9710,7 @@ function WorkflowDetailPageContent({ payload }: { payload: BootPayload }) {
                 runtimeLabel={
                   execution.targetRuntime ? formatRuntimeLabel(execution.targetRuntime) : null
                 }
+                workflowTerminal={isTerminalExecution}
                 pollIntervalMs={detailPoll}
                 onNavigate={setDetailSubroute}
               />

--- a/frontend/src/features/workflow-native-chat/NativeChatFrame.tsx
+++ b/frontend/src/features/workflow-native-chat/NativeChatFrame.tsx
@@ -1,0 +1,113 @@
+// Mounts the native Omnigent application through the server-generated,
+// same-origin scoped chat URL (MoonLadderStudios/MoonMind#3639).
+//
+// MoonMind supplies only the frame: it never recreates the transcript, composer,
+// queue, approvals, tools, or session lifecycle. The frame fills the primary
+// pane, exposes an accessible name, shows a neutral loading placeholder (never
+// the legacy composer), and reports native-application load/liveness failures up
+// so the route can offer an explicit, actionable fallback.
+import { useEffect, useRef, useState } from 'react';
+
+export type NativeChatFrameSignal = 'ready' | 'disconnected' | 'incompatible';
+
+/** Message shape the embedded native application posts to the host frame. */
+const NATIVE_CHAT_MESSAGE_TYPE = 'moonmind:workflow-chat';
+
+interface NativeChatFrameProps {
+  /** Same-origin, MoonMind-scoped embedded chat URL from the binding. */
+  src: string;
+  /** Accessible name for the iframe (screen-reader and focus target). */
+  title: string;
+  readOnly?: boolean;
+  /** Time to wait for the frame to load before treating it as incompatible. */
+  loadTimeoutMs?: number;
+  onSignal?: (signal: NativeChatFrameSignal) => void;
+}
+
+function isNativeChatSignal(value: unknown): value is NativeChatFrameSignal {
+  return value === 'ready' || value === 'disconnected' || value === 'incompatible';
+}
+
+export function NativeChatFrame({
+  src,
+  title,
+  readOnly = false,
+  loadTimeoutMs = 20000,
+  onSignal,
+}: NativeChatFrameProps) {
+  const iframeRef = useRef<HTMLIFrameElement | null>(null);
+  const loadedRef = useRef(false);
+  const [loaded, setLoaded] = useState(false);
+
+  const markLoaded = () => {
+    loadedRef.current = true;
+    setLoaded(true);
+  };
+
+  // A load timeout is treated as a native UI compatibility/version failure so
+  // the route surfaces the full-page escape hatch instead of hanging on the
+  // placeholder forever. A frame that has already loaded is left alone.
+  useEffect(() => {
+    loadedRef.current = false;
+    setLoaded(false);
+    const timer = window.setTimeout(() => {
+      if (loadedRef.current) {
+        return;
+      }
+      onSignal?.('incompatible');
+    }, loadTimeoutMs);
+    return () => window.clearTimeout(timer);
+    // Reset whenever the mounted session changes.
+  }, [src, loadTimeoutMs, onSignal]);
+
+  // Liveness and compatibility signals from the same-origin native application.
+  useEffect(() => {
+    function handleMessage(event: MessageEvent) {
+      if (event.origin !== window.location.origin) {
+        return;
+      }
+      const frameWindow = iframeRef.current?.contentWindow;
+      if (frameWindow && event.source !== frameWindow) {
+        return;
+      }
+      const data = event.data as { type?: unknown; status?: unknown } | null;
+      if (!data || data.type !== NATIVE_CHAT_MESSAGE_TYPE) {
+        return;
+      }
+      if (isNativeChatSignal(data.status)) {
+        if (data.status === 'ready') {
+          loadedRef.current = true;
+          setLoaded(true);
+        }
+        onSignal?.(data.status);
+      }
+    }
+    window.addEventListener('message', handleMessage);
+    return () => window.removeEventListener('message', handleMessage);
+  }, [onSignal]);
+
+  return (
+    <div className="wf-native-chat__frame" data-loaded={loaded ? 'true' : 'false'}>
+      {loaded ? null : (
+        <div className="wf-native-chat__loading" role="status" aria-live="polite">
+          <span className="wf-native-chat__spinner" aria-hidden="true" />
+          <span>Loading conversation…</span>
+        </div>
+      )}
+      <iframe
+        ref={iframeRef}
+        className="wf-native-chat__iframe"
+        src={src}
+        title={title}
+        data-readonly={readOnly ? 'true' : 'false'}
+        referrerPolicy="same-origin"
+        allow="clipboard-read; clipboard-write"
+        onLoad={() => {
+          markLoaded();
+          onSignal?.('ready');
+        }}
+        onError={() => onSignal?.('incompatible')}
+      />
+    </div>
+  );
+}

--- a/frontend/src/features/workflow-native-chat/NativeChatUnavailableState.tsx
+++ b/frontend/src/features/workflow-native-chat/NativeChatUnavailableState.tsx
@@ -1,0 +1,100 @@
+// Explicit, actionable state panel for every non-mounted native chat status
+// (MoonLadderStudios/MoonMind#3639). It never renders a composer or falls back
+// to the legacy custom chat implementation — it states the stable reason and
+// offers bounded next steps: retry, the authorized full-page native surface, and
+// links to captured evidence / diagnostics.
+import type { MouseEvent } from 'react';
+
+import {
+  nativeChatStateCopy,
+  type NativeChatStatus,
+} from './chatBindingModel';
+
+interface NativeChatUnavailableStateProps {
+  status: NativeChatStatus;
+  unavailableReason?: string | null;
+  onRetry?: (() => void) | null;
+  /** Full-page MoonMind-scoped native surface (never an upstream URL). */
+  fullPageHref?: string | null;
+  /** MoonMind-scoped evidence subroute href. */
+  evidenceHref?: string | null;
+  /** MoonMind-scoped diagnostics (Debug) subroute href. */
+  diagnosticsHref?: string | null;
+  /** SPA navigation for internal (evidence/diagnostics) links. */
+  onNavigate?: ((href: string) => void) | null;
+}
+
+function isPlainClick(event: MouseEvent<HTMLAnchorElement>): boolean {
+  return (
+    event.button === 0 &&
+    !event.metaKey &&
+    !event.ctrlKey &&
+    !event.shiftKey &&
+    !event.altKey
+  );
+}
+
+export function NativeChatUnavailableState({
+  status,
+  unavailableReason = null,
+  onRetry = null,
+  fullPageHref = null,
+  evidenceHref = null,
+  diagnosticsHref = null,
+  onNavigate = null,
+}: NativeChatUnavailableStateProps) {
+  const copy = nativeChatStateCopy(status, unavailableReason);
+
+  const handleInternal = (href: string) => (event: MouseEvent<HTMLAnchorElement>) => {
+    if (!onNavigate || !isPlainClick(event)) {
+      return;
+    }
+    event.preventDefault();
+    onNavigate(href);
+  };
+
+  return (
+    <div
+      className="wf-native-chat__state"
+      data-status={status}
+      role={copy.role}
+      aria-live={copy.role === 'status' ? 'polite' : 'assertive'}
+    >
+      {copy.role === 'status' ? (
+        <span className="wf-native-chat__spinner" aria-hidden="true" />
+      ) : null}
+      <h3 className="wf-native-chat__state-title">{copy.title}</h3>
+      <p className="small wf-native-chat__state-desc">{copy.description}</p>
+      <div className="wf-native-chat__state-actions">
+        {copy.canRetry && onRetry ? (
+          <button type="button" className="button secondary small" onClick={onRetry}>
+            Retry
+          </button>
+        ) : null}
+        {fullPageHref ? (
+          <a className="button secondary small" href={fullPageHref}>
+            Open in Omnigent
+          </a>
+        ) : null}
+        {evidenceHref ? (
+          <a
+            className="button secondary small"
+            href={evidenceHref}
+            onClick={handleInternal(evidenceHref)}
+          >
+            View captured evidence
+          </a>
+        ) : null}
+        {diagnosticsHref ? (
+          <a
+            className="button secondary small"
+            href={diagnosticsHref}
+            onClick={handleInternal(diagnosticsHref)}
+          >
+            Open diagnostics
+          </a>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/workflow-native-chat/WorkflowChatContextBar.tsx
+++ b/frontend/src/features/workflow-native-chat/WorkflowChatContextBar.tsx
@@ -1,0 +1,106 @@
+// Thin MoonMind workflow context bar rendered above the native Omnigent chat
+// application (MoonLadderStudios/MoonMind#3639). It owns workflow context and
+// bounded navigation only — it must stay visually subordinate to the native
+// application and must not duplicate the native session header or control
+// cluster (composer, queue, approvals, tools, file rail, terminals).
+import type { MouseEvent, ReactNode } from 'react';
+
+interface WorkflowChatContextBarProps {
+  workflowTitle: string;
+  statusPill?: ReactNode;
+  stepLabel?: string | null;
+  runtimeLabel?: string | null;
+  /** Bounded read-only/unavailable status label, or null when writable. */
+  statusLabel?: string | null;
+  overviewHref: string;
+  evidenceHref: string;
+  /** Full-page MoonMind-scoped native surface; null hides the action. */
+  fullPageHref?: string | null;
+  /** Terminal-only "Continue in a new workflow" href; null hides the action. */
+  continueHref?: string | null;
+  /** SPA navigation for internal (overview/evidence/continue) links. */
+  onNavigate: (href: string) => void;
+}
+
+function isPlainClick(event: MouseEvent<HTMLAnchorElement>): boolean {
+  return (
+    event.button === 0 &&
+    !event.metaKey &&
+    !event.ctrlKey &&
+    !event.shiftKey &&
+    !event.altKey
+  );
+}
+
+export function WorkflowChatContextBar({
+  workflowTitle,
+  statusPill = null,
+  stepLabel = null,
+  runtimeLabel = null,
+  statusLabel = null,
+  overviewHref,
+  evidenceHref,
+  fullPageHref = null,
+  continueHref = null,
+  onNavigate,
+}: WorkflowChatContextBarProps) {
+  const handleInternal = (href: string) => (event: MouseEvent<HTMLAnchorElement>) => {
+    if (!isPlainClick(event)) {
+      return;
+    }
+    event.preventDefault();
+    onNavigate(href);
+  };
+
+  return (
+    <header className="wf-native-chat__context-bar" aria-label="Workflow chat context">
+      <div className="wf-native-chat__identity">
+        <span className="wf-native-chat__title" title={workflowTitle}>
+          {workflowTitle}
+        </span>
+        <span className="wf-native-chat__meta">
+          {statusPill}
+          {statusLabel ? (
+            <span className="wf-native-chat__status-label">{statusLabel}</span>
+          ) : null}
+          {stepLabel ? (
+            <span className="wf-native-chat__step">{stepLabel}</span>
+          ) : null}
+          {runtimeLabel ? (
+            <span className="wf-native-chat__runtime">{runtimeLabel}</span>
+          ) : null}
+        </span>
+      </div>
+      <nav className="wf-native-chat__actions" aria-label="Workflow chat actions">
+        <a
+          className="button secondary small"
+          href={overviewHref}
+          onClick={handleInternal(overviewHref)}
+        >
+          Back to Overview
+        </a>
+        <a
+          className="button secondary small"
+          href={evidenceHref}
+          onClick={handleInternal(evidenceHref)}
+        >
+          View captured evidence
+        </a>
+        {fullPageHref ? (
+          <a className="button secondary small" href={fullPageHref}>
+            Open in Omnigent
+          </a>
+        ) : null}
+        {continueHref ? (
+          <a
+            className="button secondary small"
+            href={continueHref}
+            onClick={handleInternal(continueHref)}
+          >
+            Continue in a new workflow
+          </a>
+        ) : null}
+      </nav>
+    </header>
+  );
+}

--- a/frontend/src/features/workflow-native-chat/WorkflowNativeChatRoute.test.tsx
+++ b/frontend/src/features/workflow-native-chat/WorkflowNativeChatRoute.test.tsx
@@ -104,16 +104,19 @@ describe('WorkflowNativeChatRoute', () => {
     expect(onNavigate).toHaveBeenCalledWith('overview', '/workflows/wf-1/overview?source=temporal');
   });
 
-  it('shows a terminal read-only session with Continue in a new workflow', async () => {
+  it('shows a terminal read-only session and withholds Continue until the handoff exists', async () => {
     mockBinding(() => ({
       body: { ...AVAILABLE, state: 'ended', readOnly: true, capabilities: {} },
     }));
     renderRoute();
     await screen.findByTitle('Ship the thing — Omnigent chat');
     expect(screen.getByText(/session ended/i)).toBeTruthy();
+    // The continuation handoff (linked execution + authorized source identity)
+    // does not exist yet, so the misleading "Continue" affordance is withheld
+    // rather than pointed at the source workflow's Overview.
     expect(
-      screen.getByRole('link', { name: 'Continue in a new workflow' }),
-    ).toBeTruthy();
+      screen.queryByRole('link', { name: 'Continue in a new workflow' }),
+    ).toBeNull();
   });
 
   it('renders an explicit unsupported-runtime state with no iframe', async () => {

--- a/frontend/src/features/workflow-native-chat/WorkflowNativeChatRoute.test.tsx
+++ b/frontend/src/features/workflow-native-chat/WorkflowNativeChatRoute.test.tsx
@@ -1,0 +1,227 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { MockInstance } from 'vitest';
+
+import { cleanup, fireEvent, renderWithClient, screen, waitFor } from '../../utils/test-utils';
+import { WorkflowNativeChatRoute } from './WorkflowNativeChatRoute';
+import type { WorkflowChatBinding } from './chatBindingModel';
+
+const AVAILABLE: WorkflowChatBinding = {
+  chatBindingId: 'cb-1',
+  workflowId: 'wf-1',
+  runId: 'run-1',
+  logicalStepId: 'step-a',
+  chatUrl: '/omnigent-ui/workflow-chat/cb-1?embedded=1',
+  apiBase: '/api/workflow-chat-bindings/cb-1/omnigent',
+  state: 'available',
+  readOnly: false,
+  capabilities: { sendMessage: true },
+};
+
+let fetchSpy: MockInstance;
+
+function mockBinding(
+  responder: () => { status?: number; body: unknown },
+) {
+  fetchSpy.mockImplementation((input: RequestInfo | URL) => {
+    const url = String(input);
+    if (url.includes('/chat-binding')) {
+      const { status = 200, body } = responder();
+      return Promise.resolve({
+        ok: status >= 200 && status < 300,
+        status,
+        clone() {
+          return { json: async () => body } as Response;
+        },
+        json: async () => body,
+      } as unknown as Response);
+    }
+    return Promise.resolve({ ok: true, status: 200, json: async () => ({}) } as Response);
+  });
+}
+
+function renderRoute(onNavigate = vi.fn()) {
+  renderWithClient(
+    <WorkflowNativeChatRoute
+      apiBase="/api"
+      workflowId="wf-1"
+      routeWorkflowId="wf-1"
+      search={new URLSearchParams('source=temporal')}
+      workflowTitle="Ship the thing"
+      runtimeLabel="Codex via Omnigent"
+      pollIntervalMs={5000}
+      onNavigate={onNavigate}
+    />,
+  );
+  return onNavigate;
+}
+
+describe('WorkflowNativeChatRoute', () => {
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(window, 'fetch');
+    fetchSpy.mockClear();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it('mounts the native application through the server scoped url without the legacy composer', async () => {
+    mockBinding(() => ({ body: AVAILABLE }));
+    renderRoute();
+
+    const frame = await screen.findByTitle('Ship the thing — Omnigent chat');
+    expect(frame.tagName).toBe('IFRAME');
+    expect(frame.getAttribute('src')).toBe('/omnigent-ui/workflow-chat/cb-1?embedded=1');
+    // No legacy custom composer/transcript is rendered on the native path.
+    expect(document.querySelector('textarea')).toBeNull();
+    expect(screen.queryByTestId('chat-session-blocks')).toBeNull();
+    // Context bar exposes bounded workflow context + actions.
+    expect(screen.getByText('Ship the thing')).toBeTruthy();
+    expect(screen.getByText('Codex via Omnigent')).toBeTruthy();
+    expect(screen.getByRole('link', { name: 'Back to Overview' })).toBeTruthy();
+    expect(screen.getByRole('link', { name: 'View captured evidence' })).toBeTruthy();
+  });
+
+  it('never displays an upstream Omnigent url or provider session id', async () => {
+    mockBinding(() => ({ body: AVAILABLE }));
+    renderRoute();
+    await screen.findByTitle('Ship the thing — Omnigent chat');
+    const html = document.body.innerHTML;
+    expect(html).not.toContain('run-1');
+    expect(html).not.toContain('http://');
+    expect(html).not.toContain('https://');
+    // Open in Omnigent stays within the MoonMind-scoped full-page surface.
+    const openLink = screen.getByRole('link', { name: 'Open in Omnigent' });
+    expect(openLink.getAttribute('href')).toBe('/omnigent-ui/workflow-chat/cb-1');
+  });
+
+  it('routes Back to Overview through SPA navigation instead of a reload', async () => {
+    mockBinding(() => ({ body: AVAILABLE }));
+    const onNavigate = renderRoute();
+    const backLink = await screen.findByRole('link', { name: 'Back to Overview' });
+    fireEvent.click(backLink);
+    expect(onNavigate).toHaveBeenCalledWith('overview', '/workflows/wf-1/overview?source=temporal');
+  });
+
+  it('shows a terminal read-only session with Continue in a new workflow', async () => {
+    mockBinding(() => ({
+      body: { ...AVAILABLE, state: 'ended', readOnly: true, capabilities: {} },
+    }));
+    renderRoute();
+    await screen.findByTitle('Ship the thing — Omnigent chat');
+    expect(screen.getByText(/session ended/i)).toBeTruthy();
+    expect(
+      screen.getByRole('link', { name: 'Continue in a new workflow' }),
+    ).toBeTruthy();
+  });
+
+  it('renders an explicit unsupported-runtime state with no iframe', async () => {
+    mockBinding(() => ({
+      body: {
+        ...AVAILABLE,
+        chatBindingId: '',
+        chatUrl: '',
+        apiBase: '',
+        state: 'unavailable',
+        readOnly: true,
+        unavailableReason: 'unsupported_runtime',
+      },
+    }));
+    renderRoute();
+    expect(
+      await screen.findByText('Chat unavailable for this runtime'),
+    ).toBeTruthy();
+    expect(document.querySelector('iframe')).toBeNull();
+    expect(screen.queryByRole('link', { name: 'Continue in a new workflow' })).toBeNull();
+  });
+
+  it('surfaces an unauthorized state and no session details', async () => {
+    mockBinding(() => ({ status: 403, body: { detail: 'forbidden' } }));
+    renderRoute();
+    const alert = await screen.findByRole('alert');
+    expect(alert.textContent).toMatch(/Not authorized/i);
+    expect(document.querySelector('iframe')).toBeNull();
+  });
+
+  it('surfaces the ambiguous-binding conflict', async () => {
+    mockBinding(() => ({
+      status: 409,
+      body: { detail: { code: 'omnigent_chat_binding_ambiguous' } },
+    }));
+    renderRoute();
+    expect(await screen.findByText('Multiple active sessions')).toBeTruthy();
+  });
+
+  it('falls back to an actionable state when the native app reports disconnected', async () => {
+    mockBinding(() => ({ body: AVAILABLE }));
+    renderRoute();
+    const frame = (await screen.findByTitle(
+      'Ship the thing — Omnigent chat',
+    )) as HTMLIFrameElement;
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        origin: window.location.origin,
+        source: frame.contentWindow,
+        data: { type: 'moonmind:workflow-chat', status: 'disconnected' },
+      }),
+    );
+    expect(await screen.findByText('Chat disconnected')).toBeTruthy();
+    // The full-page native escape hatch stays available as a durable fallback
+    // (offered both in the context bar and the fallback panel).
+    expect(
+      screen.getAllByRole('link', { name: 'Open in Omnigent' }).length,
+    ).toBeGreaterThan(0);
+  });
+
+  it('falls back when the native app reports an incompatible version', async () => {
+    mockBinding(() => ({ body: AVAILABLE }));
+    renderRoute();
+    const frame = (await screen.findByTitle(
+      'Ship the thing — Omnigent chat',
+    )) as HTMLIFrameElement;
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        origin: window.location.origin,
+        source: frame.contentWindow,
+        data: { type: 'moonmind:workflow-chat', status: 'incompatible' },
+      }),
+    );
+    expect(await screen.findByText('Native chat could not load')).toBeTruthy();
+  });
+
+  it('ignores native-app messages from a foreign origin', async () => {
+    mockBinding(() => ({ body: AVAILABLE }));
+    renderRoute();
+    const frame = (await screen.findByTitle(
+      'Ship the thing — Omnigent chat',
+    )) as HTMLIFrameElement;
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        origin: 'https://evil.example',
+        source: frame.contentWindow,
+        data: { type: 'moonmind:workflow-chat', status: 'disconnected' },
+      }),
+    );
+    // The frame stays mounted; a cross-origin message cannot force a fallback.
+    expect(screen.getByTitle('Ship the thing — Omnigent chat')).toBeTruthy();
+    expect(screen.queryByText('Chat disconnected')).toBeNull();
+  });
+
+  it('shows a polite starting placeholder without mounting the frame', async () => {
+    mockBinding(() => ({
+      body: {
+        ...AVAILABLE,
+        chatBindingId: '',
+        chatUrl: '',
+        apiBase: '',
+        state: 'starting',
+        readOnly: true,
+      },
+    }));
+    renderRoute();
+    await waitFor(() => expect(screen.getByText('Starting session')).toBeTruthy());
+    expect(document.querySelector('iframe')).toBeNull();
+    expect(screen.getByRole('status')).toBeTruthy();
+  });
+});

--- a/frontend/src/features/workflow-native-chat/WorkflowNativeChatRoute.tsx
+++ b/frontend/src/features/workflow-native-chat/WorkflowNativeChatRoute.tsx
@@ -1,0 +1,153 @@
+// Canonical Workflow Detail native Chat route (MoonLadderStudios/MoonMind#3639).
+//
+// Renders a thin MoonMind context bar over the native Omnigent application for
+// the authoritative WorkflowChatBinding. MoonMind owns navigation, workflow
+// context, and loading/error/unsupported states; the native application owns the
+// transcript, composer, queue, approvals, tools, file rail, terminals, and
+// session lifecycle. Ordinary native messages never invoke Workflow actions and
+// this route never calls /chat-instructions.
+import { useEffect, useMemo, useState } from 'react';
+import type { ReactNode } from 'react';
+
+import {
+  workflowDetailSubrouteFromPath,
+  workflowDetailSubrouteHref,
+  type WorkflowDetailSubroute,
+} from '../../lib/workflowDetailRoutes';
+import {
+  deriveNativeChatStatus,
+  fullPageChatHref,
+  isMountableNativeChatStatus,
+  nativeChatContextStatusLabel,
+  resolveSameOriginChatUrl,
+} from './chatBindingModel';
+import { NativeChatFrame, type NativeChatFrameSignal } from './NativeChatFrame';
+import { NativeChatUnavailableState } from './NativeChatUnavailableState';
+import { WorkflowChatContextBar } from './WorkflowChatContextBar';
+import { useWorkflowChatBinding } from './useWorkflowChatBinding';
+
+interface WorkflowNativeChatRouteProps {
+  apiBase: string;
+  /** Canonical workflow id used to resolve the binding. */
+  workflowId: string;
+  /** Workflow id used to build MoonMind navigation hrefs. */
+  routeWorkflowId: string;
+  search: URLSearchParams;
+  workflowTitle: string;
+  statusPill?: ReactNode;
+  runtimeLabel?: string | null;
+  enabled?: boolean;
+  pollIntervalMs?: number;
+  onNavigate: (subroute: WorkflowDetailSubroute, href: string) => void;
+}
+
+export function WorkflowNativeChatRoute({
+  apiBase,
+  workflowId,
+  routeWorkflowId,
+  search,
+  workflowTitle,
+  statusPill = null,
+  runtimeLabel = null,
+  enabled = true,
+  pollIntervalMs,
+  onNavigate,
+}: WorkflowNativeChatRouteProps) {
+  const query = useWorkflowChatBinding({
+    apiBase,
+    workflowId,
+    enabled,
+    ...(pollIntervalMs != null ? { pollIntervalMs } : {}),
+  });
+  const binding = query.data ?? null;
+  const errorStatus = query.error ? query.error.status : null;
+
+  const serverStatus = deriveNativeChatStatus({
+    isLoading: query.isLoading,
+    binding,
+    errorStatus,
+  });
+
+  // Client-detected native-application failures (compatibility / disconnect)
+  // override an otherwise-mountable server status so the fallback is explicit.
+  const [frameSignal, setFrameSignal] = useState<NativeChatFrameSignal | null>(null);
+  const chatUrl = binding?.chatUrl ?? null;
+  useEffect(() => {
+    setFrameSignal(null);
+  }, [chatUrl]);
+
+  const status = useMemo(() => {
+    if (
+      isMountableNativeChatStatus(serverStatus) &&
+      frameSignal &&
+      frameSignal !== 'ready'
+    ) {
+      return frameSignal === 'disconnected' ? 'disconnected' : 'incompatible';
+    }
+    return serverStatus;
+  }, [serverStatus, frameSignal]);
+
+  const origin = window.location.origin;
+  const iframeSrc = resolveSameOriginChatUrl(binding?.chatUrl, origin);
+  const fullHref = fullPageChatHref(binding?.chatUrl, origin);
+
+  const overviewHref = workflowDetailSubrouteHref(routeWorkflowId, 'overview', search);
+  const evidenceHref = workflowDetailSubrouteHref(routeWorkflowId, 'evidence', search);
+  const debugHref = workflowDetailSubrouteHref(routeWorkflowId, 'debug', search);
+  const continueHref = serverStatus === 'terminal' ? overviewHref : null;
+
+  const navigate = (href: string) => {
+    let pathname: string;
+    try {
+      pathname = new URL(href, origin).pathname;
+    } catch {
+      pathname = href;
+    }
+    onNavigate(workflowDetailSubrouteFromPath(pathname), href);
+  };
+
+  const mountFrame = isMountableNativeChatStatus(status) && Boolean(iframeSrc);
+  const readOnly =
+    Boolean(binding?.readOnly) || status === 'readOnly' || status === 'terminal';
+  const stepLabel = binding?.logicalStepId ? `Step ${binding.logicalStepId}` : null;
+
+  return (
+    <section className="stack wf-native-chat" aria-label="Workflow chat">
+      <WorkflowChatContextBar
+        workflowTitle={workflowTitle}
+        statusPill={statusPill}
+        stepLabel={stepLabel}
+        runtimeLabel={runtimeLabel}
+        statusLabel={nativeChatContextStatusLabel(status)}
+        overviewHref={overviewHref}
+        evidenceHref={evidenceHref}
+        fullPageHref={fullHref}
+        continueHref={continueHref}
+        onNavigate={navigate}
+      />
+      <div className="wf-native-chat__surface">
+        {mountFrame && iframeSrc ? (
+          <NativeChatFrame
+            src={iframeSrc}
+            title={`${workflowTitle} — Omnigent chat`}
+            readOnly={readOnly}
+            onSignal={setFrameSignal}
+          />
+        ) : (
+          <NativeChatUnavailableState
+            status={status}
+            unavailableReason={binding?.unavailableReason ?? null}
+            onRetry={() => {
+              setFrameSignal(null);
+              void query.refetch();
+            }}
+            fullPageHref={fullHref}
+            evidenceHref={evidenceHref}
+            diagnosticsHref={debugHref}
+            onNavigate={navigate}
+          />
+        )}
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/features/workflow-native-chat/WorkflowNativeChatRoute.tsx
+++ b/frontend/src/features/workflow-native-chat/WorkflowNativeChatRoute.tsx
@@ -37,6 +37,8 @@ interface WorkflowNativeChatRouteProps {
   statusPill?: ReactNode;
   runtimeLabel?: string | null;
   enabled?: boolean;
+  /** Whether the parent workflow has reached a terminal state. */
+  workflowTerminal?: boolean;
   pollIntervalMs?: number;
   onNavigate: (subroute: WorkflowDetailSubroute, href: string) => void;
 }
@@ -50,6 +52,7 @@ export function WorkflowNativeChatRoute({
   statusPill = null,
   runtimeLabel = null,
   enabled = true,
+  workflowTerminal = false,
   pollIntervalMs,
   onNavigate,
 }: WorkflowNativeChatRouteProps) {
@@ -57,6 +60,7 @@ export function WorkflowNativeChatRoute({
     apiBase,
     workflowId,
     enabled,
+    workflowTerminal,
     ...(pollIntervalMs != null ? { pollIntervalMs } : {}),
   });
   const binding = query.data ?? null;
@@ -94,7 +98,12 @@ export function WorkflowNativeChatRoute({
   const overviewHref = workflowDetailSubrouteHref(routeWorkflowId, 'overview', search);
   const evidenceHref = workflowDetailSubrouteHref(routeWorkflowId, 'evidence', search);
   const debugHref = workflowDetailSubrouteHref(routeWorkflowId, 'debug', search);
-  const continueHref = serverStatus === 'terminal' ? overviewHref : null;
+  // "Continue in a new workflow" is intentionally omitted until the
+  // workflow-creation/continuation handoff (which must carry the authorized
+  // source identity and evidence and create a linked execution) exists. Pointing
+  // it at the source workflow's Overview would create no linked continuation and
+  // only mislead the operator, so the affordance is withheld rather than faked.
+  const continueHref = null;
 
   const navigate = (href: string) => {
     let pathname: string;

--- a/frontend/src/features/workflow-native-chat/chatBindingModel.test.ts
+++ b/frontend/src/features/workflow-native-chat/chatBindingModel.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  deriveNativeChatStatus,
+  fullPageChatHref,
+  isMountableNativeChatStatus,
+  nativeChatContextStatusLabel,
+  nativeChatStateCopy,
+  resolveSameOriginChatUrl,
+  type WorkflowChatBinding,
+} from './chatBindingModel';
+
+const ORIGIN = 'https://moonmind.example';
+
+function binding(overrides: Partial<WorkflowChatBinding>): WorkflowChatBinding {
+  return {
+    chatBindingId: 'cb-1',
+    workflowId: 'wf-1',
+    chatUrl: '/omnigent-ui/workflow-chat/cb-1?embedded=1',
+    apiBase: '/api/workflow-chat-bindings/cb-1/omnigent',
+    state: 'available',
+    readOnly: false,
+    capabilities: {},
+    ...overrides,
+  };
+}
+
+describe('deriveNativeChatStatus', () => {
+  it('reports loading while the request is in flight with no data', () => {
+    expect(
+      deriveNativeChatStatus({ isLoading: true, binding: null, errorStatus: null }),
+    ).toBe('loading');
+  });
+
+  it('maps writable and read-only available bindings', () => {
+    expect(
+      deriveNativeChatStatus({
+        isLoading: false,
+        binding: binding({ state: 'available', readOnly: false }),
+        errorStatus: null,
+      }),
+    ).toBe('available');
+    expect(
+      deriveNativeChatStatus({
+        isLoading: false,
+        binding: binding({ state: 'available', readOnly: true }),
+        errorStatus: null,
+      }),
+    ).toBe('readOnly');
+  });
+
+  it('maps starting and terminal states', () => {
+    expect(
+      deriveNativeChatStatus({
+        isLoading: false,
+        binding: binding({ state: 'starting', readOnly: true }),
+        errorStatus: null,
+      }),
+    ).toBe('starting');
+    expect(
+      deriveNativeChatStatus({
+        isLoading: false,
+        binding: binding({ state: 'ended', readOnly: true }),
+        errorStatus: null,
+      }),
+    ).toBe('terminal');
+  });
+
+  it('discriminates unavailable reasons', () => {
+    expect(
+      deriveNativeChatStatus({
+        isLoading: false,
+        binding: binding({ state: 'unavailable', unavailableReason: 'unsupported_runtime' }),
+        errorStatus: null,
+      }),
+    ).toBe('unsupported');
+    expect(
+      deriveNativeChatStatus({
+        isLoading: false,
+        binding: binding({ state: 'unavailable', unavailableReason: 'no_session' }),
+        errorStatus: null,
+      }),
+    ).toBe('missing');
+    expect(
+      deriveNativeChatStatus({
+        isLoading: false,
+        binding: binding({ state: 'unavailable', unavailableReason: 'session_cleaned_up' }),
+        errorStatus: null,
+      }),
+    ).toBe('missing');
+  });
+
+  it('maps request errors to explicit statuses and fails closed on unknown states', () => {
+    expect(
+      deriveNativeChatStatus({ isLoading: false, binding: null, errorStatus: 401 }),
+    ).toBe('unauthorized');
+    expect(
+      deriveNativeChatStatus({ isLoading: false, binding: null, errorStatus: 403 }),
+    ).toBe('unauthorized');
+    expect(
+      deriveNativeChatStatus({ isLoading: false, binding: null, errorStatus: 404 }),
+    ).toBe('notFound');
+    expect(
+      deriveNativeChatStatus({ isLoading: false, binding: null, errorStatus: 409 }),
+    ).toBe('ambiguous');
+    expect(
+      deriveNativeChatStatus({ isLoading: false, binding: null, errorStatus: 503 }),
+    ).toBe('unavailable');
+    // Degraded provider input (unknown state) must not mount the native app.
+    expect(
+      deriveNativeChatStatus({
+        isLoading: false,
+        binding: binding({ state: 'weird' as WorkflowChatBinding['state'] }),
+        errorStatus: null,
+      }),
+    ).toBe('unavailable');
+  });
+});
+
+describe('isMountableNativeChatStatus', () => {
+  it('mounts only available, read-only, and terminal', () => {
+    expect(isMountableNativeChatStatus('available')).toBe(true);
+    expect(isMountableNativeChatStatus('readOnly')).toBe(true);
+    expect(isMountableNativeChatStatus('terminal')).toBe(true);
+    for (const status of [
+      'loading',
+      'starting',
+      'unsupported',
+      'missing',
+      'unauthorized',
+      'notFound',
+      'ambiguous',
+      'incompatible',
+      'disconnected',
+      'unavailable',
+    ] as const) {
+      expect(isMountableNativeChatStatus(status)).toBe(false);
+    }
+  });
+});
+
+describe('resolveSameOriginChatUrl', () => {
+  it('returns the same-origin relative path for a scoped url', () => {
+    expect(
+      resolveSameOriginChatUrl('/omnigent-ui/workflow-chat/cb-1?embedded=1', ORIGIN),
+    ).toBe('/omnigent-ui/workflow-chat/cb-1?embedded=1');
+  });
+
+  it('rejects blank and cross-origin urls (never mounts upstream)', () => {
+    expect(resolveSameOriginChatUrl('', ORIGIN)).toBeNull();
+    expect(resolveSameOriginChatUrl(null, ORIGIN)).toBeNull();
+    expect(
+      resolveSameOriginChatUrl('https://upstream.omnigent.invalid/chat/xyz', ORIGIN),
+    ).toBeNull();
+  });
+});
+
+describe('fullPageChatHref', () => {
+  it('drops the embedded flag but stays on the MoonMind origin', () => {
+    expect(
+      fullPageChatHref('/omnigent-ui/workflow-chat/cb-1?embedded=1', ORIGIN),
+    ).toBe('/omnigent-ui/workflow-chat/cb-1');
+  });
+
+  it('refuses to construct an upstream url', () => {
+    expect(
+      fullPageChatHref('https://upstream.omnigent.invalid/chat/xyz?embedded=1', ORIGIN),
+    ).toBeNull();
+    expect(fullPageChatHref('', ORIGIN)).toBeNull();
+  });
+});
+
+describe('nativeChatStateCopy', () => {
+  it('announces transient states politely and failures assertively', () => {
+    expect(nativeChatStateCopy('starting').role).toBe('status');
+    expect(nativeChatStateCopy('loading').role).toBe('status');
+    expect(nativeChatStateCopy('unauthorized').role).toBe('alert');
+    expect(nativeChatStateCopy('incompatible').canRetry).toBe(true);
+    expect(nativeChatStateCopy('unsupported').canRetry).toBe(false);
+  });
+
+  it('distinguishes cleaned-up terminal transcripts from missing sessions', () => {
+    expect(nativeChatStateCopy('missing', 'session_cleaned_up').description).toMatch(
+      /durable evidence/i,
+    );
+    expect(nativeChatStateCopy('missing', 'no_session').description).toMatch(
+      /No native chat session/i,
+    );
+  });
+});
+
+describe('nativeChatContextStatusLabel', () => {
+  it('labels read-only and terminal posture and hides for writable', () => {
+    expect(nativeChatContextStatusLabel('available')).toBeNull();
+    expect(nativeChatContextStatusLabel('readOnly')).toBe('Read-only');
+    expect(nativeChatContextStatusLabel('terminal')).toMatch(/read-only/i);
+    expect(nativeChatContextStatusLabel('disconnected')).toBe('Disconnected');
+  });
+});

--- a/frontend/src/features/workflow-native-chat/chatBindingModel.ts
+++ b/frontend/src/features/workflow-native-chat/chatBindingModel.ts
@@ -1,0 +1,269 @@
+// Browser-safe model + pure presentation helpers for the Workflow Detail native
+// Omnigent Chat route (MoonLadderStudios/MoonMind#3639).
+//
+// This module holds no React and no I/O so the binding-state derivation and the
+// URL guards can be unit tested directly. The route renders exclusively from the
+// authoritative binding returned by GET /api/executions/{workflowId}/chat-binding;
+// it never infers, repairs, or authors an upstream Omnigent URL in the browser.
+import type { components } from '../../generated/openapi';
+
+/** Authoritative browser-safe binding (MoonLadderStudios/MoonMind#3633). */
+export type WorkflowChatBinding = components['schemas']['WorkflowChatBinding'];
+
+/** Server-owned lifecycle state carried in the binding body. */
+export type WorkflowChatBindingServerState = WorkflowChatBinding['state'];
+
+/**
+ * Resolved presentation status for the native chat route. This is a superset of
+ * the server `state`: it folds in read-only posture, the `unavailableReason`
+ * discriminant, transport/auth failures, and client-detected native-application
+ * failures so each surface is explicit and independently actionable.
+ */
+export type NativeChatStatus =
+  | 'loading' // binding request in flight
+  | 'starting' // binding exists but the provider session is not attached yet
+  | 'available' // native session available and writable
+  | 'readOnly' // native session available but read-only
+  | 'terminal' // terminal session, read-only transcript
+  | 'unsupported' // runtime does not serve a native chat session
+  | 'missing' // no session bound, or a terminal session was cleaned up / stale
+  | 'unauthorized' // caller is not authorized against the workflow
+  | 'notFound' // workflow unknown to the caller
+  | 'ambiguous' // multiple active chat-capable sessions
+  | 'incompatible' // native UI compatibility/version failure (client-detected)
+  | 'disconnected' // scoped transport disconnected with durable fallback available
+  | 'unavailable'; // upstream/server unavailable
+
+/** Statuses where the native Omnigent application should be mounted. */
+export const NATIVE_CHAT_MOUNTED_STATUSES: readonly NativeChatStatus[] = [
+  'available',
+  'readOnly',
+  'terminal',
+];
+
+export function isMountableNativeChatStatus(status: NativeChatStatus): boolean {
+  return NATIVE_CHAT_MOUNTED_STATUSES.includes(status);
+}
+
+/**
+ * Map the authoritative binding (or a transport/auth error) to a resolved
+ * presentation status. The browser renders from server truth only: a stale,
+ * missing, or unauthorized binding fails closed and never falls back to an
+ * arbitrary provider session.
+ */
+export function deriveNativeChatStatus(input: {
+  isLoading: boolean;
+  binding: WorkflowChatBinding | null | undefined;
+  errorStatus: number | null;
+}): NativeChatStatus {
+  const { isLoading, binding, errorStatus } = input;
+  if (errorStatus != null) {
+    if (errorStatus === 401 || errorStatus === 403) {
+      return 'unauthorized';
+    }
+    if (errorStatus === 404) {
+      return 'notFound';
+    }
+    if (errorStatus === 409) {
+      return 'ambiguous';
+    }
+    // 5xx, network failures, and unexpected statuses are upstream unavailability.
+    return 'unavailable';
+  }
+  if (!binding) {
+    return isLoading ? 'loading' : 'unavailable';
+  }
+  switch (binding.state) {
+    case 'starting':
+      return 'starting';
+    case 'available':
+      return binding.readOnly ? 'readOnly' : 'available';
+    case 'ended':
+      return 'terminal';
+    case 'unavailable':
+      return binding.unavailableReason === 'unsupported_runtime'
+        ? 'unsupported'
+        : 'missing';
+    default:
+      // Degraded / unknown provider input fails closed rather than mounting.
+      return 'unavailable';
+  }
+}
+
+/**
+ * Resolve the server-generated embedded chat URL to a same-origin path safe to
+ * use as an iframe `src`. Returns `null` for a blank URL or any URL that does
+ * not resolve to the MoonMind origin, so the route can never mount an upstream
+ * Omnigent surface even if the server contract regresses.
+ */
+export function resolveSameOriginChatUrl(
+  chatUrl: string | null | undefined,
+  origin: string,
+): string | null {
+  if (!chatUrl) {
+    return null;
+  }
+  let url: URL;
+  try {
+    url = new URL(chatUrl, origin);
+  } catch {
+    return null;
+  }
+  if (url.origin !== origin) {
+    return null;
+  }
+  return `${url.pathname}${url.search}${url.hash}`;
+}
+
+/**
+ * Derive the MoonMind-scoped full-page "Open in Omnigent" href from the
+ * server-generated embedded chat URL. The `embedded` presentational flag is
+ * dropped so the full-page surface renders native chrome, but the path stays
+ * within the same MoonMind origin — the browser never navigates directly to the
+ * upstream server.
+ */
+export function fullPageChatHref(
+  chatUrl: string | null | undefined,
+  origin: string,
+): string | null {
+  if (!chatUrl) {
+    return null;
+  }
+  let url: URL;
+  try {
+    url = new URL(chatUrl, origin);
+  } catch {
+    return null;
+  }
+  if (url.origin !== origin) {
+    return null;
+  }
+  url.searchParams.delete('embedded');
+  return `${url.pathname}${url.search}${url.hash}`;
+}
+
+export interface NativeChatStateCopy {
+  title: string;
+  description: string;
+  /** `status` for polite/transient states, `alert` for actionable failures. */
+  role: 'status' | 'alert';
+  canRetry: boolean;
+}
+
+/**
+ * User-facing copy for every non-mounted status. Kept pure so the wording and
+ * the retry/announcement affordance for each state are covered by unit tests.
+ */
+export function nativeChatStateCopy(
+  status: NativeChatStatus,
+  unavailableReason?: string | null,
+): NativeChatStateCopy {
+  switch (status) {
+    case 'loading':
+      return {
+        title: 'Loading conversation',
+        description: 'Resolving the workflow chat binding.',
+        role: 'status',
+        canRetry: false,
+      };
+    case 'starting':
+      return {
+        title: 'Starting session',
+        description:
+          'The native session is starting. This view will open automatically once it is ready.',
+        role: 'status',
+        canRetry: true,
+      };
+    case 'unsupported':
+      return {
+        title: 'Chat unavailable for this runtime',
+        description:
+          'This workflow runs on a runtime that does not provide a native chat session.',
+        role: 'alert',
+        canRetry: false,
+      };
+    case 'missing':
+      return {
+        title: 'No chat session available',
+        description:
+          unavailableReason === 'session_cleaned_up'
+            ? 'The terminal session transcript has been captured to durable evidence and is no longer live.'
+            : 'No native chat session is bound to this workflow yet.',
+        role: 'alert',
+        canRetry: true,
+      };
+    case 'unauthorized':
+      return {
+        title: 'Not authorized',
+        description: 'You do not have permission to open chat for this workflow.',
+        role: 'alert',
+        canRetry: false,
+      };
+    case 'notFound':
+      return {
+        title: 'Workflow not found',
+        description: 'This workflow could not be found for your account.',
+        role: 'alert',
+        canRetry: false,
+      };
+    case 'ambiguous':
+      return {
+        title: 'Multiple active sessions',
+        description:
+          'More than one active chat session is bound to this workflow. Resolve the conflict before opening chat.',
+        role: 'alert',
+        canRetry: true,
+      };
+    case 'incompatible':
+      return {
+        title: 'Native chat could not load',
+        description:
+          'The native chat application failed to load in this browser. Open it in a full page or review captured evidence instead.',
+        role: 'alert',
+        canRetry: true,
+      };
+    case 'disconnected':
+      return {
+        title: 'Chat disconnected',
+        description:
+          'The live chat connection dropped. Retry the live session or review captured evidence.',
+        role: 'alert',
+        canRetry: true,
+      };
+    case 'unavailable':
+    default:
+      return {
+        title: 'Chat is temporarily unavailable',
+        description: 'The chat service could not be reached. Try again in a moment.',
+        role: 'alert',
+        canRetry: true,
+      };
+  }
+}
+
+/** Bounded read-only/unavailable label for the context bar, or null when writable. */
+export function nativeChatContextStatusLabel(
+  status: NativeChatStatus,
+): string | null {
+  switch (status) {
+    case 'readOnly':
+      return 'Read-only';
+    case 'terminal':
+      return 'Session ended · read-only';
+    case 'starting':
+      return 'Starting';
+    case 'disconnected':
+      return 'Disconnected';
+    case 'incompatible':
+      return 'Unavailable';
+    case 'unsupported':
+    case 'missing':
+    case 'unavailable':
+    case 'unauthorized':
+    case 'notFound':
+    case 'ambiguous':
+      return 'Chat unavailable';
+    default:
+      return null;
+  }
+}

--- a/frontend/src/features/workflow-native-chat/index.ts
+++ b/frontend/src/features/workflow-native-chat/index.ts
@@ -1,0 +1,28 @@
+// Workflow Detail native Omnigent Chat feature (MoonLadderStudios/MoonMind#3639).
+export { WorkflowNativeChatRoute } from './WorkflowNativeChatRoute';
+export { WorkflowChatContextBar } from './WorkflowChatContextBar';
+export { NativeChatFrame } from './NativeChatFrame';
+export { NativeChatUnavailableState } from './NativeChatUnavailableState';
+export {
+  useWorkflowChatBinding,
+  ChatBindingRequestError,
+  fetchWorkflowChatBinding,
+  workflowChatBindingQueryKey,
+  chatBindingEndpoint,
+} from './useWorkflowChatBinding';
+export {
+  deriveNativeChatStatus,
+  fullPageChatHref,
+  resolveSameOriginChatUrl,
+  isMountableNativeChatStatus,
+  nativeChatStateCopy,
+  nativeChatContextStatusLabel,
+  NATIVE_CHAT_MOUNTED_STATUSES,
+} from './chatBindingModel';
+export type {
+  WorkflowChatBinding,
+  WorkflowChatBindingServerState,
+  NativeChatStatus,
+  NativeChatStateCopy,
+} from './chatBindingModel';
+export type { NativeChatFrameSignal } from './NativeChatFrame';

--- a/frontend/src/features/workflow-native-chat/useWorkflowChatBinding.test.tsx
+++ b/frontend/src/features/workflow-native-chat/useWorkflowChatBinding.test.tsx
@@ -1,0 +1,136 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { MockInstance } from 'vitest';
+
+import { cleanup, renderHook, waitFor } from '../../utils/test-utils';
+import {
+  ChatBindingRequestError,
+  fetchWorkflowChatBinding,
+  useWorkflowChatBinding,
+} from './useWorkflowChatBinding';
+import type { WorkflowChatBinding } from './chatBindingModel';
+
+const AVAILABLE: WorkflowChatBinding = {
+  chatBindingId: 'cb-1',
+  workflowId: 'wf-1',
+  runId: 'run-1',
+  logicalStepId: 'step-a',
+  chatUrl: '/omnigent-ui/workflow-chat/cb-1?embedded=1',
+  apiBase: '/api/workflow-chat-bindings/cb-1/omnigent',
+  state: 'available',
+  readOnly: false,
+  capabilities: { sendMessage: true },
+};
+
+function wrapper() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+}
+
+describe('fetchWorkflowChatBinding', () => {
+  let fetchSpy: MockInstance;
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(window, 'fetch');
+    fetchSpy.mockClear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('bounds the request with an abort deadline and surfaces a retryable timeout error', async () => {
+    vi.useFakeTimers();
+    // The proxy never resolves; only the abort deadline ends the request.
+    fetchSpy.mockImplementation(
+      (_input: RequestInfo | URL, init?: RequestInit) =>
+        new Promise((_resolve, reject) => {
+          init?.signal?.addEventListener('abort', () => {
+            reject(new DOMException('Aborted', 'AbortError'));
+          });
+        }),
+    );
+
+    const pending = fetchWorkflowChatBinding('/api', 'wf-1', 15000);
+    const assertion = expect(pending).rejects.toMatchObject({
+      status: 408,
+      code: 'chat_binding_request_timeout',
+    });
+    await vi.advanceTimersByTimeAsync(15000);
+    await assertion;
+    await expect(pending).rejects.toBeInstanceOf(ChatBindingRequestError);
+  });
+});
+
+describe('useWorkflowChatBinding polling posture', () => {
+  let fetchSpy: MockInstance;
+
+  function mockBinding(body: WorkflowChatBinding) {
+    fetchSpy.mockImplementation(() =>
+      Promise.resolve({
+        ok: true,
+        status: 200,
+        clone() {
+          return { json: async () => body } as Response;
+        },
+        json: async () => body,
+      } as unknown as Response),
+    );
+  }
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(window, 'fetch');
+    fetchSpy.mockClear();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it('keeps resolving the authoritative binding while the workflow is nonterminal', async () => {
+    mockBinding(AVAILABLE);
+    renderHook(
+      () =>
+        useWorkflowChatBinding({
+          apiBase: '/api',
+          workflowId: 'wf-1',
+          enabled: true,
+          workflowTerminal: false,
+          pollIntervalMs: 50,
+        }),
+      { wrapper: wrapper() },
+    );
+
+    // Even though the binding already resolved to `available`, the resolver keeps
+    // polling so a later Step's replacement session is discovered.
+    await waitFor(() => expect(fetchSpy.mock.calls.length).toBeGreaterThanOrEqual(2), {
+      timeout: 2000,
+    });
+  });
+
+  it('stops resolving once the workflow is terminal', async () => {
+    mockBinding({ ...AVAILABLE, state: 'ended', readOnly: true });
+    renderHook(
+      () =>
+        useWorkflowChatBinding({
+          apiBase: '/api',
+          workflowId: 'wf-1',
+          enabled: true,
+          workflowTerminal: true,
+          pollIntervalMs: 50,
+        }),
+      { wrapper: wrapper() },
+    );
+
+    await waitFor(() => expect(fetchSpy).toHaveBeenCalledTimes(1));
+    // A terminal workflow cannot spawn a new chat-capable session, so no further
+    // polling occurs even after several would-be intervals elapse.
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/features/workflow-native-chat/useWorkflowChatBinding.ts
+++ b/frontend/src/features/workflow-native-chat/useWorkflowChatBinding.ts
@@ -30,14 +30,42 @@ export function chatBindingEndpoint(apiBase: string, workflowId: string): string
   return `${base}/executions/${encodeURIComponent(workflowId)}/chat-binding`;
 }
 
+/** Default abort deadline for a single chat-binding request. */
+export const DEFAULT_CHAT_BINDING_TIMEOUT_MS = 15000;
+
 export async function fetchWorkflowChatBinding(
   apiBase: string,
   workflowId: string,
+  requestTimeoutMs: number = DEFAULT_CHAT_BINDING_TIMEOUT_MS,
 ): Promise<WorkflowChatBinding> {
-  const response = await fetch(chatBindingEndpoint(apiBase, workflowId), {
-    credentials: 'include',
-    headers: { Accept: 'application/json' },
-  });
+  // A stalled proxy or hung upstream must not leave the request pending forever:
+  // bound it with an abort deadline so React Query resolves to an actionable,
+  // retryable error state instead of an indefinite loading spinner.
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), requestTimeoutMs);
+  let response: Response;
+  try {
+    response = await fetch(chatBindingEndpoint(apiBase, workflowId), {
+      credentials: 'include',
+      headers: { Accept: 'application/json' },
+      signal: controller.signal,
+    });
+  } catch (error) {
+    if (controller.signal.aborted) {
+      throw new ChatBindingRequestError(
+        408,
+        'Timed out resolving chat binding',
+        'chat_binding_request_timeout',
+      );
+    }
+    throw new ChatBindingRequestError(
+      0,
+      `Failed to reach chat binding service: ${(error as Error).message}`,
+      'chat_binding_request_failed',
+    );
+  } finally {
+    clearTimeout(timer);
+  }
   if (!response.ok) {
     let code: string | null = null;
     try {
@@ -68,18 +96,34 @@ export function useWorkflowChatBinding(args: {
   apiBase: string;
   workflowId: string;
   enabled: boolean;
+  /**
+   * Whether the parent workflow has reached a terminal state. While the workflow
+   * is nonterminal a later Step can create a different active chat-capable
+   * session (and therefore a new authoritative `chatBindingId`), so the resolver
+   * must keep polling to discover the replacement rather than staying attached to
+   * a superseded session.
+   */
+  workflowTerminal?: boolean;
   pollIntervalMs?: number;
+  requestTimeoutMs?: number;
 }): UseQueryResult<WorkflowChatBinding, ChatBindingRequestError> {
-  const { apiBase, workflowId, enabled, pollIntervalMs = 5000 } = args;
+  const {
+    apiBase,
+    workflowId,
+    enabled,
+    workflowTerminal = false,
+    pollIntervalMs = 5000,
+    requestTimeoutMs,
+  } = args;
   return useQuery<WorkflowChatBinding, ChatBindingRequestError>({
     queryKey: workflowChatBindingQueryKey(workflowId),
-    queryFn: () => fetchWorkflowChatBinding(apiBase, workflowId),
+    queryFn: () => fetchWorkflowChatBinding(apiBase, workflowId, requestTimeoutMs),
     enabled: enabled && Boolean(workflowId),
     retry: false,
-    // Only poll while the session is still coming up; a resolved binding is
-    // stable and the native application owns its own liveness afterwards.
-    refetchInterval: (query) =>
-      query.state.data?.state === 'starting' ? pollIntervalMs : false,
+    // Keep resolving the authoritative binding while the workflow is nonterminal
+    // so a new active Step's session is discovered; stop only once the workflow
+    // is terminal, when no further chat-capable session can appear.
+    refetchInterval: () => (workflowTerminal ? false : pollIntervalMs),
     staleTime: pollIntervalMs,
   });
 }

--- a/frontend/src/features/workflow-native-chat/useWorkflowChatBinding.ts
+++ b/frontend/src/features/workflow-native-chat/useWorkflowChatBinding.ts
@@ -1,0 +1,85 @@
+// Data hook for the authoritative Workflow Chat binding
+// (MoonLadderStudios/MoonMind#3639). Fetches GET
+// /api/executions/{workflowId}/chat-binding and exposes the raw binding plus the
+// request error. Status derivation lives in `chatBindingModel` so it can be unit
+// tested without a query client. The browser never repairs the binding here.
+import { useQuery } from '@tanstack/react-query';
+import type { UseQueryResult } from '@tanstack/react-query';
+
+import type { WorkflowChatBinding } from './chatBindingModel';
+
+/** Error carrying the HTTP status of a failed chat-binding request. */
+export class ChatBindingRequestError extends Error {
+  readonly status: number;
+  readonly code: string | null;
+
+  constructor(status: number, message: string, code: string | null = null) {
+    super(message);
+    this.name = 'ChatBindingRequestError';
+    this.status = status;
+    this.code = code;
+  }
+}
+
+export function workflowChatBindingQueryKey(workflowId: string) {
+  return ['workflow-chat-binding', workflowId] as const;
+}
+
+export function chatBindingEndpoint(apiBase: string, workflowId: string): string {
+  const base = apiBase.replace(/\/+$/, '');
+  return `${base}/executions/${encodeURIComponent(workflowId)}/chat-binding`;
+}
+
+export async function fetchWorkflowChatBinding(
+  apiBase: string,
+  workflowId: string,
+): Promise<WorkflowChatBinding> {
+  const response = await fetch(chatBindingEndpoint(apiBase, workflowId), {
+    credentials: 'include',
+    headers: { Accept: 'application/json' },
+  });
+  if (!response.ok) {
+    let code: string | null = null;
+    try {
+      const body = (await response.clone().json()) as { detail?: unknown };
+      const detail = body?.detail;
+      if (typeof detail === 'string') {
+        code = detail;
+      } else if (
+        detail &&
+        typeof detail === 'object' &&
+        typeof (detail as { code?: unknown }).code === 'string'
+      ) {
+        code = (detail as { code: string }).code;
+      }
+    } catch {
+      // Non-JSON error body; the status alone drives the presentation status.
+    }
+    throw new ChatBindingRequestError(
+      response.status,
+      `Failed to resolve chat binding (${response.status})`,
+      code,
+    );
+  }
+  return (await response.json()) as WorkflowChatBinding;
+}
+
+export function useWorkflowChatBinding(args: {
+  apiBase: string;
+  workflowId: string;
+  enabled: boolean;
+  pollIntervalMs?: number;
+}): UseQueryResult<WorkflowChatBinding, ChatBindingRequestError> {
+  const { apiBase, workflowId, enabled, pollIntervalMs = 5000 } = args;
+  return useQuery<WorkflowChatBinding, ChatBindingRequestError>({
+    queryKey: workflowChatBindingQueryKey(workflowId),
+    queryFn: () => fetchWorkflowChatBinding(apiBase, workflowId),
+    enabled: enabled && Boolean(workflowId),
+    retry: false,
+    // Only poll while the session is still coming up; a resolved binding is
+    // stable and the native application owns its own liveness afterwards.
+    refetchInterval: (query) =>
+      query.state.data?.state === 'starting' ? pollIntervalMs : false,
+    staleTime: pollIntervalMs,
+  });
+}

--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -9875,3 +9875,154 @@ button.workflow-workspace-sidebar-row:active {
   border-radius: 0.5rem;
   padding: 0.6rem 0.8rem;
 }
+
+/* Workflow Detail native Omnigent Chat route (MoonLadderStudios/MoonMind#3639).
+   MoonMind owns a thin context bar; the native application fills the primary
+   pane. Keep the context bar visually subordinate to the native surface. */
+.wf-native-chat {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  min-width: 0;
+}
+.wf-native-chat__context-bar {
+  align-items: center;
+  border-bottom: 1px solid rgb(var(--mm-border));
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 1rem;
+  justify-content: space-between;
+  padding-bottom: 0.5rem;
+}
+.wf-native-chat__identity {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem 0.75rem;
+  min-width: 0;
+}
+.wf-native-chat__title {
+  color: rgb(var(--mm-ink));
+  font-weight: 600;
+  max-width: 40ch;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.wf-native-chat__meta {
+  align-items: center;
+  color: rgb(var(--mm-muted));
+  display: flex;
+  flex-wrap: wrap;
+  font-size: 0.85rem;
+  gap: 0.35rem 0.6rem;
+}
+.wf-native-chat__status-label,
+.wf-native-chat__step,
+.wf-native-chat__runtime {
+  color: rgb(var(--mm-muted));
+}
+.wf-native-chat__status-label {
+  border: 1px solid rgb(var(--mm-border));
+  border-radius: 999px;
+  padding: 0.05rem 0.5rem;
+}
+.wf-native-chat__actions {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+.wf-native-chat__surface {
+  display: flex;
+  min-height: min(70vh, 760px);
+  position: relative;
+}
+.wf-native-chat__frame {
+  display: flex;
+  flex: 1 1 auto;
+  min-height: inherit;
+  position: relative;
+  width: 100%;
+}
+.wf-native-chat__iframe {
+  border: 0;
+  flex: 1 1 auto;
+  height: 100%;
+  min-height: inherit;
+  width: 100%;
+}
+.wf-native-chat__loading {
+  align-items: center;
+  background: rgb(var(--mm-bg));
+  color: rgb(var(--mm-muted));
+  display: flex;
+  gap: 0.6rem;
+  inset: 0;
+  justify-content: center;
+  position: absolute;
+  z-index: 1;
+}
+.wf-native-chat__state {
+  align-items: center;
+  border: 1px dashed rgb(var(--mm-border));
+  border-radius: 0.75rem;
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+  gap: 0.5rem;
+  justify-content: center;
+  padding: 2rem 1.25rem;
+  text-align: center;
+}
+.wf-native-chat__state-title {
+  margin: 0;
+}
+.wf-native-chat__state-desc {
+  color: rgb(var(--mm-muted));
+  margin: 0;
+  max-width: 52ch;
+}
+.wf-native-chat__state-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  justify-content: center;
+}
+.wf-native-chat__spinner {
+  animation: wf-native-chat-spin 0.9s linear infinite;
+  border: 2px solid rgb(var(--mm-border));
+  border-radius: 50%;
+  border-top-color: rgb(var(--mm-accent));
+  height: 1.1rem;
+  width: 1.1rem;
+}
+@keyframes wf-native-chat-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+@media (max-width: 720px) {
+  .wf-native-chat__context-bar {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+  .wf-native-chat__surface {
+    min-height: min(80vh, 620px);
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .wf-native-chat__spinner {
+    animation: none;
+  }
+}
+@media (forced-colors: active) {
+  .wf-native-chat__iframe,
+  .wf-native-chat__state {
+    border: 1px solid CanvasText;
+  }
+  .wf-native-chat__spinner {
+    border-color: CanvasText;
+    border-top-color: Highlight;
+  }
+}


### PR DESCRIPTION
## Issue

Implements MoonLadderStudios/MoonMind#3639 — [Omnigent native chat 7/10] Add the Workflow Detail native Chat route and thin workflow context shell.

Closes MoonLadderStudios/MoonMind#3639

## Summary

Adds the canonical Workflow Detail native Omnigent Chat experience at `/workflows/{workflowId}/chat`, replacing the legacy custom bridge-event chat projection on the primary path with the native application driven by the authoritative `WorkflowChatBinding`.

- New focused module `frontend/src/features/workflow-native-chat/`:
  - `WorkflowNativeChatRoute` — route surface that wires binding state, context bar, native frame, and fallback selection.
  - `WorkflowChatContextBar` — thin, visually subordinate workflow context bar (title, status, current/source Step, runtime label, bounded read-only/unavailable status, Back to Overview, View captured evidence, Open in Omnigent scoped full-page route, terminal-only Continue in a new workflow).
  - `NativeChatFrame` — mounts the native application through the server-generated same-origin scoped `chatUrl` in an iframe with an accessible title and a neutral loading placeholder (never flashes the legacy composer); reacts only to typed liveness signals (`ready`/`disconnected`/`incompatible`).
  - `NativeChatUnavailableState` — explicit, actionable copy and affordances (retry, full-page, evidence, diagnostics) for every non-writable state.
  - `useWorkflowChatBinding` — fetches `GET /api/executions/{workflowId}/chat-binding` and renders exclusively from server truth (fails closed on stale/missing/unauthorized; no browser-side inference or repair).
  - `chatBindingModel` — browser-safe binding derivation, same-origin URL resolution (`resolveSameOriginChatUrl` / `fullPageChatHref` reject cross-origin so no upstream Omnigent URL or provider session id is ever constructed/displayed), state mapping, and copy.
- Wires the new route into the existing `/workflows/{workflowId}/chat` subroute in `workflow-detail.tsx` and relocates the legacy bridge-event chat projection to the `/debug` ("Session diagnostics") subroute, keeping bridge diagnostics reusable for #3640.
- Adds `.wf-native-chat` styles in `frontend/src/styles/dashboard.css` (responsive, reduced-motion, and forced-colors/high-contrast rules; ellipsized title; flex surface that fills the pane).
- Workflow actions (Edit/Rerun/Resume/Remediate/Cancel/Continue) stay outside the native composer; no heuristic message classification and no `/chat-instructions` call from this route.

## Tests run

- `./tools/test_unit.sh --dashboard-only --ui-args workflow-native-chat` — PASS (2 files, 24 tests: `chatBindingModel.test.ts` + `WorkflowNativeChatRoute.test.tsx`).
- `./tools/test_unit.sh --dashboard-only --ui-args workflow-detail.test` — PASS (200 tests; native chat wiring + legacy projection now on `/debug`).
- `./tools/test_unit.sh --dashboard-only --ui-args dashboardBrand` — PASS (9 tests; new `.wf-native-chat` CSS respects brand pins).
- `tsc --noEmit -p frontend/tsconfig.json` — PASS.
- `eslint -c frontend/eslint.config.mjs frontend/src/features/workflow-native-chat` — PASS.

## Remaining risks

- Frontend-only change; `integration_ci` not run because no Docker/compose/db/migration/runtime integration boundary is touched.
- Assistive-technology (screen reader) announcement behavior, keyboard focus restoration against a real AT stack, and real-browser high-contrast/reduced-motion/large-native-session rendering are confirmable only by rendering the built dashboard. The DOM/ARIA contract (roles, `aria-live`, iframe title) and CSS rules are covered by unit/brand-pin tests, but live-browser/AT rendering is out of this runtime and recorded as advisory, non-blocking scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
