### PR TITLE
Demote custom Workflow Chat projection to read-only diagnostics/fallback (MoonLadderStudios/MoonMind#3640)

### DIFF
--- a/frontend/src/entrypoints/WorkflowChatNative.test.tsx
+++ b/frontend/src/entrypoints/WorkflowChatNative.test.tsx
@@ -3,7 +3,7 @@
  * (MoonLadderStudios/MoonMind#3638).
  */
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { waitFor } from '@testing-library/react';
+import { fireEvent, waitFor } from '@testing-library/react';
 
 import { renderWithClient } from '../utils/test-utils';
 import {
@@ -102,7 +102,7 @@ describe('WorkflowChatNative', () => {
     expect(queryByTestId('workflow-native-chat-frame')).toBeNull();
   });
 
-  it('shows the unavailable reason and still renders the fallback', async () => {
+  it('shows the unavailable reason, a Retry, and still renders the fallback', async () => {
     mockFetch(
       bindingResponse({ state: 'unavailable', unavailableReason: 'native_ui_upstream_unavailable', chatUrl: '' }),
     );
@@ -113,7 +113,74 @@ describe('WorkflowChatNative', () => {
     );
 
     expect(await findByTestId('workflow-native-chat-unavailable')).toBeTruthy();
+    // The unavailable state is retryable, so a stable Retry action is offered.
+    expect(await findByTestId('workflow-native-chat-retry')).toBeTruthy();
     expect(await findByText('legacy projection')).toBeTruthy();
+  });
+
+  it('surfaces a stable reason and Retry when the binding request is unreachable', async () => {
+    // A non-404 error makes fetchWorkflowChatBinding throw, so the query errors.
+    mockFetch(null, 500);
+    const { findByTestId, findByText } = renderWithClient(
+      <WorkflowChatNative apiBase={API_BASE} workflowId={WORKFLOW_ID} active>
+        <div>legacy projection</div>
+      </WorkflowChatNative>,
+    );
+
+    const unavailable = await findByTestId('workflow-native-chat-unavailable');
+    expect(unavailable.textContent).toContain('native_chat_binding_unreachable');
+    expect(await findByTestId('workflow-native-chat-retry')).toBeTruthy();
+    // Native failure still shows the read-only fallback rather than swapping in a
+    // behaviorally different interactive chat.
+    expect(await findByText('legacy projection')).toBeTruthy();
+  });
+
+  it('offers Retry while the native session is still starting', async () => {
+    mockFetch(bindingResponse({ state: 'starting', chatUrl: '' }));
+    const { findByTestId } = renderWithClient(
+      <WorkflowChatNative apiBase={API_BASE} workflowId={WORKFLOW_ID} active />,
+    );
+
+    const unavailable = await findByTestId('workflow-native-chat-unavailable');
+    expect(unavailable.textContent).toContain('native_chat_session_starting');
+    expect(await findByTestId('workflow-native-chat-retry')).toBeTruthy();
+  });
+
+  it('does not offer Retry for a runtime that never had a native binding', async () => {
+    mockFetch(null, 404);
+    const { findByText, queryByTestId } = renderWithClient(
+      <WorkflowChatNative apiBase={API_BASE} workflowId={WORKFLOW_ID} active>
+        <div>legacy projection</div>
+      </WorkflowChatNative>,
+    );
+
+    // A clean 404 is a stable historical state: no unavailable banner, no Retry,
+    // just the read-only fallback projection.
+    expect(await findByText('legacy projection')).toBeTruthy();
+    expect(queryByTestId('workflow-native-chat-unavailable')).toBeNull();
+    expect(queryByTestId('workflow-native-chat-retry')).toBeNull();
+  });
+
+  it('refetches the binding and mounts native chat when Retry succeeds', async () => {
+    const fetchMock = vi
+      .fn()
+      // First attempt: upstream not reachable yet.
+      .mockResolvedValueOnce({ ok: false, status: 500, json: async () => null } as unknown as Response)
+      // Retry: the native binding is now available.
+      .mockResolvedValue({ ok: true, status: 200, json: async () => bindingResponse() } as unknown as Response);
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { findByTestId } = renderWithClient(
+      <WorkflowChatNative apiBase={API_BASE} workflowId={WORKFLOW_ID} active>
+        <div>legacy projection</div>
+      </WorkflowChatNative>,
+    );
+
+    const retry = await findByTestId('workflow-native-chat-retry');
+    fireEvent.click(retry);
+
+    const frame = await findByTestId('workflow-native-chat-frame');
+    expect(frame.getAttribute('src')).toBe(CHAT_URL);
   });
 
   it('does not fetch while the chat tab is inactive', () => {

--- a/frontend/src/entrypoints/WorkflowChatNative.tsx
+++ b/frontend/src/entrypoints/WorkflowChatNative.tsx
@@ -126,27 +126,55 @@ export function WorkflowChatNative({
     );
   }
 
-  // Native UI is unavailable for this workflow: surface the stable reason and an
-  // authorized full-page escape hatch when one exists, then fall back to the
-  // legacy read-only compatibility projection (docs/UI/WorkflowChatPanel.md §11).
-  const unavailableReason = binding?.unavailableReason;
+  // Native UI is unavailable for this workflow: surface the stable reason, a
+  // Retry when the condition is retryable, and an authorized full-page escape
+  // hatch when one exists, then fall back to the read-only diagnostic and
+  // compatibility projection (docs/UI/WorkflowChatPanel.md §11,
+  // MoonLadderStudios/MoonMind#3640).
+  //
+  // The fallback never becomes a behaviorally different interactive chat: the
+  // `children` projection is read-only, so native failure does not silently swap
+  // in a second composer.
+  const unavailableReason = query.isError
+    ? 'native_chat_binding_unreachable'
+    : binding?.unavailableReason
+      ?? (binding?.state === 'starting' ? 'native_chat_session_starting' : undefined);
+  const retryable =
+    query.isError || binding?.state === 'starting' || binding?.state === 'unavailable';
   const escapeHatch =
     binding && binding.chatUrl ? fullPageChatUrl(binding.chatUrl) : null;
   return (
     <>
-      {unavailableReason ? (
+      {unavailableReason || retryable ? (
         <div className="td-native-chat-unavailable" data-testid="workflow-native-chat-unavailable">
-          <p className="small">Native chat is unavailable: {unavailableReason}</p>
-          {escapeHatch ? (
-            <a
-              className="button secondary"
-              href={escapeHatch}
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              Open in Omnigent
-            </a>
-          ) : null}
+          <p className="small">
+            Native chat is unavailable{unavailableReason ? `: ${unavailableReason}` : '.'}
+          </p>
+          <div className="button-group td-native-chat-actions">
+            {retryable ? (
+              <button
+                type="button"
+                className="secondary"
+                onClick={() => {
+                  void query.refetch();
+                }}
+                data-testid="workflow-native-chat-retry"
+              >
+                Retry
+              </button>
+            ) : null}
+            {escapeHatch ? (
+              <a
+                className="button secondary"
+                href={escapeHatch}
+                target="_blank"
+                rel="noopener noreferrer"
+                data-testid="workflow-native-chat-open"
+              >
+                Open in Omnigent
+              </a>
+            ) : null}
+          </div>
         </div>
       ) : null}
       {children}

--- a/frontend/src/entrypoints/workflow-detail.test.tsx
+++ b/frontend/src/entrypoints/workflow-detail.test.tsx
@@ -8539,8 +8539,8 @@ describe('Workflow Detail Entrypoint', () => {
     expect(screen.getByTestId('chat-session-blocks')).toBeTruthy();
   });
 
-  it('uses advertised bridge capabilities and exposes delivery-unknown messages', async () => {
-    window.history.pushState({}, 'Bridge Controls Test', '/workflows/test-123/chat?source=temporal');
+  it('demotes the bridge projection to a read-only diagnostic surface with no composer or session controls on the primary Chat route (MoonLadderStudios/MoonMind#3640)', async () => {
+    window.history.pushState({}, 'Bridge Read-Only Test', '/workflows/test-123/chat?source=temporal');
     const priorEventSource = window.EventSource;
     window.EventSource = MockEventSource as unknown as typeof EventSource;
     const mockExecution = {
@@ -8552,61 +8552,54 @@ describe('Workflow Detail Entrypoint', () => {
       const url = String(input);
       if (url.includes('/omnigent/bridge-sessions/resolve')) return Promise.resolve({ ok: true, json: async () => ({
         bridgeSessionId: 'brs-controls', status: 'running', providerSessionRef: 'provider-session',
-        capabilities: { sendFollowUp: true, interruptTurn: true },
+        capabilities: { sendFollowUp: true, interruptTurn: true, clearSession: true, cancelSession: true, stop: true, resolveElicitation: true, terminalCleanup: true },
       }) } as Response);
       if (url.includes('/omnigent/bridge-sessions/brs-controls/events')) return Promise.resolve({ ok: true, json: async () => ({
-        schemaVersion: 'moonmind.bridge-session-events-page.v1', bridgeSessionId: 'brs-controls', items: [],
-        after: 0, nextCursor: null, hasMore: false, terminal: false, latestSequence: 0,
+        schemaVersion: 'moonmind.bridge-session-events-page.v1', bridgeSessionId: 'brs-controls',
+        items: [
+          { sequence: 1, timestamp: '2026-07-09T00:00:01Z', stream: 'stdout', text: 'Bridge assistant output', kind: 'assistant_message', sessionId: 'brs-controls', metadata: { responseId: 'resp-1' } },
+          { sequence: 2, timestamp: '2026-07-09T00:00:02Z', stream: 'session', kind: 'approval_requested', text: 'Allow the provider action?', metadata: { elicitationId: 'el-pending' } },
+        ],
+        after: 0, nextCursor: '2', hasMore: false, terminal: false, latestSequence: 2,
       }) } as Response);
-      if (url.includes('/omnigent/v1/sessions/provider-session/events')) return Promise.resolve({ ok: true, json: async () => ({}) } as Response);
       if (url.includes('/artifacts')) return Promise.resolve({ ok: true, json: async () => ({ artifacts: [] }) } as Response);
       return Promise.resolve({ ok: true, json: async () => mockExecution } as Response);
     });
 
     try {
+      // Even with a fully advertised capability set and actions enabled, the primary
+      // Chat route mounts only the read-only diagnostic surface. The native Omnigent
+      // application owns the single interactive composer and session controls.
       renderWithClient(<WorkflowDetailPage payload={actionsPayload} />);
-      const input = await screen.findByLabelText('Follow-up message');
-      fireEvent.change(input, { target: { value: 'Continue with the fix.' } });
-      fireEvent.click(screen.getByRole('button', { name: 'Send follow-up' }));
-      await waitFor(() => expect(screen.getByText(/Delivery confirmation pending/)).toBeTruthy());
-      expect(screen.getByRole('button', { name: 'Interrupt turn' })).toBeTruthy();
-      expect(fetchSpy.mock.calls.some(([url, init]) =>
-        String(url).includes('/omnigent/v1/sessions/provider-session/events') &&
-        String((init as RequestInit | undefined)?.body).includes('clientEventKey'))).toBe(true);
-    } finally {
-      window.EventSource = priorEventSource;
-    }
-  });
 
-  it('shows failed bridge delivery and denies controls not advertised by the server', async () => {
-    window.history.pushState({}, 'Bridge Failed Controls Test', '/workflows/test-123/chat?source=temporal');
-    const priorEventSource = window.EventSource;
-    window.EventSource = MockEventSource as unknown as typeof EventSource;
-    const mockExecution = { taskId: 'test-123', workflowId: 'test-123', source: 'temporal', namespace: 'default', title: 'Bridge controls', summary: 'Running', createdAt: '2026-07-09T00:00:00Z', updatedAt: '2026-07-09T00:00:30Z', status: 'running', state: 'executing', rawState: 'running', actions: {} };
-    fetchSpy.mockImplementation((input: RequestInfo | URL) => {
-      const url = String(input);
-      if (url.includes('/bridge-sessions/resolve')) return Promise.resolve({ ok: true, json: async () => ({ bridgeSessionId: 'brs-fail', status: 'running', providerSessionRef: 'provider-session', capabilities: { sendFollowUp: true, interruptTurn: false } }) } as Response);
-      if (url.includes('/bridge-sessions/brs-fail/events')) return Promise.resolve({ ok: true, json: async () => ({ schemaVersion: 'moonmind.bridge-session-events-page.v1', bridgeSessionId: 'brs-fail', items: [], after: 0, nextCursor: null, hasMore: false, terminal: false, latestSequence: 0 }) } as Response);
-      if (url.includes('/omnigent/v1/sessions/provider-session/events')) return Promise.resolve({ ok: false, status: 403, json: async () => ({ detail: 'not authorized' }) } as Response);
-      if (url.includes('/artifacts')) return Promise.resolve({ ok: true, json: async () => ({ artifacts: [] }) } as Response);
-      return Promise.resolve({ ok: true, json: async () => mockExecution } as Response);
-    });
-    try {
-      renderWithClient(<WorkflowDetailPage payload={actionsPayload} />);
-      fireEvent.change(await screen.findByLabelText('Follow-up message'), { target: { value: 'Continue.' } });
-      fireEvent.click(screen.getByRole('button', { name: 'Send follow-up' }));
-      await waitFor(() => expect(screen.getByText(/Operator message · Failed/)).toBeTruthy());
+      // Durable evidence still renders under the clearly labeled diagnostic surface.
+      expect(await screen.findByTestId('workflow-chat-diagnostics')).toBeTruthy();
+      expect(screen.getByRole('heading', { name: 'Diagnostic event history' })).toBeTruthy();
+      expect((await screen.findAllByText('Bridge assistant output')).length).toBeGreaterThan(0);
+
+      // None of the demoted mutation affordances mount on the primary Chat route.
+      expect(screen.queryByLabelText('Follow-up message')).toBeNull();
+      expect(screen.queryByRole('button', { name: 'Send follow-up' })).toBeNull();
       expect(screen.queryByRole('button', { name: 'Interrupt turn' })).toBeNull();
-      expect(screen.getByRole('region', { name: 'Bridge session controls' })).toBeTruthy();
+      expect(screen.queryByRole('button', { name: 'Clear session' })).toBeNull();
+      expect(screen.queryByRole('button', { name: 'Cancel session' })).toBeNull();
+      expect(screen.queryByRole('button', { name: 'Stop session' })).toBeNull();
+      expect(screen.queryByRole('button', { name: 'Remove owned session' })).toBeNull();
+      expect(screen.queryByRole('button', { name: 'Approve' })).toBeNull();
+      expect(screen.queryByRole('region', { name: 'Bridge session controls' })).toBeNull();
+      expect(screen.queryByRole('region', { name: 'Pending operator request el-pending' })).toBeNull();
+
+      // The demoted custom composer never posts to the legacy bridge-control endpoint.
+      expect(fetchSpy.mock.calls.some(([url]) =>
+        String(url).includes('/omnigent/v1/sessions/provider-session/events'))).toBe(false);
     } finally {
       window.EventSource = priorEventSource;
     }
   });
 
-  it('executes advertised bridge elicitation, clear, and cancel controls and preserves durable outcomes', async () => {
+  it('preserves bridge runtime identity, compatibility diagnostics, and resolved-approval evidence read-only without exposing session controls (MoonLadderStudios/MoonMind#3640)', async () => {
     window.history.pushState({}, 'Bridge Intervention Test', '/workflows/test-123/chat?source=temporal');
     const priorEventSource = window.EventSource;
-    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
     window.EventSource = MockEventSource as unknown as typeof EventSource;
     const mockExecution = { taskId: 'test-123', workflowId: 'test-123', source: 'temporal', namespace: 'default', title: 'Bridge interventions', summary: 'Running', createdAt: '2026-07-09T00:00:00Z', updatedAt: '2026-07-09T00:00:30Z', status: 'running', state: 'executing', rawState: 'running', actions: {} };
     fetchSpy.mockImplementation((input: RequestInfo | URL) => {
@@ -8643,7 +8636,9 @@ describe('Workflow Detail Entrypoint', () => {
     });
     try {
       renderWithClient(<WorkflowDetailPage payload={actionsPayload} />);
-      expect(await screen.findByRole('region', { name: 'Pending operator request el-pending' })).toBeTruthy();
+      // Read-only runtime identity and compatibility diagnostics are preserved under
+      // the demoted diagnostic surface. Wait on durable event content before asserting.
+      expect((await screen.findAllByText('Previously approved by operator.')).length).toBeGreaterThan(0);
       const identity = screen.getByRole('region', { name: 'Omnigent runtime identity' });
       expect(identity.textContent).toContain('Codex via Omnigent');
       expect(identity.textContent).toContain('codex-profile');
@@ -8651,35 +8646,20 @@ describe('Workflow Detail Entrypoint', () => {
       const compatibility = screen.getByRole('region', { name: 'Omnigent compatibility diagnostics' });
       expect(compatibility.textContent).toContain('embedded_omnigent_compatible_server');
       expect(compatibility.textContent).toContain('artifact://embedded-mode-row');
-      expect(screen.getAllByText('Previously approved by operator.').length).toBeGreaterThan(0);
-      expect(screen.queryByRole('region', { name: 'Pending operator request el-resolved' })).toBeNull();
 
-      fireEvent.click(screen.getByRole('button', { name: 'Approve' }));
-      await waitFor(() => expect(fetchSpy.mock.calls.some(([url, init]) =>
-        String(url).endsWith('/omnigent/v1/sessions/provider-session/elicitations/el-pending/resolve') &&
-        JSON.parse(String((init as RequestInit).body)).decision === 'approved')).toBe(true));
-      fireEvent.click(screen.getByRole('button', { name: 'Clear session' }));
-      await waitFor(() => expect(fetchSpy.mock.calls.some(([url, init]) =>
-        String(url).endsWith('/omnigent/v1/sessions/provider-session/events') &&
-        JSON.parse(String((init as RequestInit).body)).type === 'clear_session')).toBe(true));
-      fireEvent.click(screen.getByRole('button', { name: 'Cancel session' }));
-      await waitFor(() => expect(fetchSpy.mock.calls.some(([url, init]) =>
-        String(url).endsWith('/omnigent/v1/sessions/provider-session/events') &&
-        JSON.parse(String((init as RequestInit).body)).type === 'session.cancel')).toBe(true));
-      fireEvent.click(screen.getByRole('button', { name: 'Stop session' }));
-      await waitFor(() => expect(fetchSpy.mock.calls.some(([url, init]) =>
-        String(url).endsWith('/omnigent/v1/sessions/provider-session/events') &&
-        JSON.parse(String((init as RequestInit).body)).type === 'stop_session' &&
-        JSON.parse(String((init as RequestInit).body)).expectedBridgeSessionId === 'brs-interventions' &&
-        JSON.parse(String((init as RequestInit).body)).expectedRunnerId === 'runner-1' &&
-        typeof JSON.parse(String((init as RequestInit).body)).idempotencyKey === 'string')).toBe(true));
-      fireEvent.click(screen.getByRole('button', { name: 'Remove owned session' }));
-      await waitFor(() => expect(fetchSpy.mock.calls.some(([url, init]) =>
-        String(url).endsWith('/omnigent/v1/sessions/provider-session/events') &&
-        JSON.parse(String((init as RequestInit).body)).type === 'cleanup_session' &&
-        JSON.parse(String((init as RequestInit).body)).expectedWorkflowId === 'test-123')).toBe(true));
+      // Even with a fully advertised capability set, no interactive session controls or
+      // pending-approval affordances mount on the primary Chat route.
+      expect(screen.queryByRole('region', { name: 'Pending operator request el-pending' })).toBeNull();
+      expect(screen.queryByRole('button', { name: 'Approve' })).toBeNull();
+      expect(screen.queryByRole('button', { name: 'Clear session' })).toBeNull();
+      expect(screen.queryByRole('button', { name: 'Cancel session' })).toBeNull();
+      expect(screen.queryByRole('button', { name: 'Stop session' })).toBeNull();
+      expect(screen.queryByRole('button', { name: 'Remove owned session' })).toBeNull();
+
+      // No control request reaches the legacy bridge-control endpoints.
+      expect(fetchSpy.mock.calls.some(([url]) =>
+        String(url).includes('/omnigent/v1/sessions/provider-session/'))).toBe(false);
     } finally {
-      confirmSpy.mockRestore();
       window.EventSource = priorEventSource;
     }
   });
@@ -10159,149 +10139,6 @@ describe('Workflow Detail Entrypoint', () => {
         }),
       );
     });
-  });
-
-  it('handles Escape as a supported stop action and exposes disabled reasons for compact chat controls', async () => {
-    window.history.pushState({}, 'Test', '/workflows/test-123?source=temporal');
-    const codexPayload: BootPayload = {
-      ...mockPayload,
-      initialData: {
-        dashboardConfig: {
-          features: {
-            temporalDashboard: { actionsEnabled: true },
-            logStreamingEnabled: true,
-            liveLogsSessionTimelineEnabled: true,
-          },
-        },
-      },
-    };
-    const mockExecution = {
-      taskId: 'test-123',
-      workflowId: 'test-123',
-      namespace: 'default',
-      temporalRunId: '01-run',
-      runId: '01-run',
-      source: 'temporal',
-      title: 'Codex session task',
-      summary: 'Session-backed work',
-      status: 'running',
-      state: 'executing',
-      rawState: 'executing',
-      targetRuntime: 'codex_cli',
-      agentRunId: 'wf-task-1',
-      createdAt: '2026-03-28T00:00:00Z',
-      updatedAt: '2026-03-28T00:00:02Z',
-      actions: {},
-    };
-    let capabilities = {
-      sendFollowUp: false,
-      clearSession: false,
-      interruptTurn: true,
-      cancelSession: true,
-    };
-
-    fetchSpy.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
-      const url = String(input);
-      if (url.includes('/observability-summary')) {
-        return Promise.resolve({
-          ok: true,
-          json: async () => ({
-            summary: {
-              status: 'running',
-              supportsLiveStreaming: false,
-              liveStreamStatus: 'unavailable',
-              sessionSnapshot: {
-                sessionId: 'sess:wf-task-1:codex_cli',
-                sessionEpoch: 1,
-                containerId: 'ctr-1',
-                threadId: 'thread-1',
-                activeTurnId: 'turn-1',
-              },
-              interventionCapabilities: capabilities,
-            },
-          }),
-        } as Response);
-      }
-      if (url.includes('/observability/events')) {
-        return Promise.resolve({ ok: true, json: async () => ({ events: [], truncated: false }) } as Response);
-      }
-      if (url.includes('/logs/merged')) {
-        return Promise.resolve({ ok: true, text: async () => '' } as unknown as Response);
-      }
-      if (url.includes('/artifact-sessions/sess%3Awf-task-1%3Acodex_cli/control')) {
-        return Promise.resolve({
-          ok: true,
-          json: async () => ({
-            action: JSON.parse(String(init?.body || '{}')).action,
-            projection: {
-              agent_run_id: 'wf-task-1',
-              session_id: 'sess:wf-task-1:codex_cli',
-              session_epoch: 1,
-              grouped_artifacts: [],
-              latest_summary_ref: null,
-              latest_checkpoint_ref: null,
-              latest_control_event_ref: { artifact_id: 'art-control' },
-              latest_reset_boundary_ref: null,
-            },
-          }),
-        } as Response);
-      }
-      if (url.includes('/artifact-sessions/sess%3Awf-task-1%3Acodex_cli')) {
-        return Promise.resolve({
-          ok: true,
-          json: async () => ({
-            agent_run_id: 'wf-task-1',
-            session_id: 'sess:wf-task-1:codex_cli',
-            session_epoch: 1,
-            grouped_artifacts: [],
-            latest_summary_ref: null,
-            latest_checkpoint_ref: null,
-            latest_control_event_ref: null,
-            latest_reset_boundary_ref: null,
-          }),
-        } as Response);
-      }
-      if (url.includes('/artifacts')) {
-        return Promise.resolve({ ok: true, json: async () => ({ artifacts: [] }) } as Response);
-      }
-      return Promise.resolve({ ok: true, json: async () => mockExecution } as Response);
-    });
-
-    renderWithClient(<WorkflowDetailPage payload={codexPayload} />);
-
-    const followUp = await screen.findByLabelText('Follow-up message');
-    expect((screen.getByRole('button', { name: 'Continue session' }) as HTMLButtonElement).disabled).toBe(true);
-    expect(screen.getAllByText('Follow-up is not supported for this session.').length).toBeGreaterThan(0);
-    expect((screen.getByRole('button', { name: 'Clear / Reset' }) as HTMLButtonElement).disabled).toBe(true);
-    expect(screen.getByText('Clear / Reset is not supported for this session.')).toBeTruthy();
-
-    fireEvent.keyDown(followUp, { key: 'Escape' });
-    await waitFor(() => {
-      expect(fetchSpy).toHaveBeenCalledWith(
-        '/api/agent-runs/wf-task-1/artifact-sessions/sess%3Awf-task-1%3Acodex_cli/control',
-        expect.objectContaining({
-          method: 'POST',
-          body: expect.stringContaining('"action":"interrupt_turn"'),
-        }),
-      );
-    });
-
-    fetchSpy.mockClear();
-    capabilities = {
-      sendFollowUp: false,
-      clearSession: false,
-      interruptTurn: false,
-      cancelSession: false,
-    };
-    cleanup();
-    renderWithClient(<WorkflowDetailPage payload={codexPayload} />);
-    fireEvent.keyDown(await screen.findByLabelText('Follow-up message'), { key: 'Escape' });
-    await new Promise((resolve) => setTimeout(resolve, 0));
-    expect(fetchSpy.mock.calls.some(([url]) => String(url).includes('/control'))).toBe(false);
-    expect((screen.getByRole('button', { name: 'Interrupt turn' }) as HTMLButtonElement).disabled).toBe(true);
-    expect(screen.getByText('Interrupt turn is not supported for this session.')).toBeTruthy();
-    expect((screen.getByRole('button', { name: 'Cancel session' }) as HTMLButtonElement).disabled).toBe(true);
-    expect(screen.getByText('Cancel session is not supported for this session.')).toBeTruthy();
   });
 
   it('keeps polling session continuity until a projection or terminal state exists', () => {

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -2999,35 +2999,6 @@ async function resolveBridgeSessionProjection({
   };
 }
 
-async function postBridgeSessionControl(
-  apiBase: string,
-  providerSessionRef: string,
-  payload: Record<string, unknown>,
-): Promise<void> {
-  const resp = await fetch(joinApiBasePath(apiBase, `/omnigent/v1/sessions/${encodeURIComponent(providerSessionRef)}/events`), {
-    method: 'POST', credentials: 'include', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(payload),
-  });
-  if (!resp.ok) throw buildObservabilityRequestError(resp.status);
-}
-
-async function resolveBridgeElicitation(
-  apiBase: string,
-  providerSessionRef: string,
-  elicitationId: string,
-  decision: 'approved' | 'rejected',
-): Promise<void> {
-  const resp = await fetch(joinApiBasePath(
-    apiBase,
-    `/omnigent/v1/sessions/${encodeURIComponent(providerSessionRef)}/elicitations/${encodeURIComponent(elicitationId)}/resolve`,
-  ), {
-    method: 'POST',
-    credentials: 'include',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ decision }),
-  });
-  if (!resp.ok) throw buildObservabilityRequestError(resp.status);
-}
-
 async function fetchBridgeSessionEvents(
   apiBase: string,
   bridgeSessionId: string,
@@ -4526,7 +4497,6 @@ function StepObservabilityGroup({
   workflowId: string;
   routes: AgentRunRouteTemplates;
 }) {
-  const [bridgeOptimisticMessages, setBridgeOptimisticMessages] = useState<OptimisticChatSessionMessage[]>([]);
   const agentRunId = row.refs.agentRunId;
   const explicitBridgeSessionId =
     row.refs.bridgeSessionId ||
@@ -4577,8 +4547,6 @@ function StepObservabilityGroup({
           bridgeSessionId={bridgeSessionId}
           isTerminal={stepTerminal(row.status)}
           projection={bridgeResolutionQuery.data ?? { bridgeSessionId, capabilities: {} }}
-          optimisticMessages={bridgeOptimisticMessages}
-          setOptimisticMessages={setBridgeOptimisticMessages}
         />
       );
     }
@@ -6248,36 +6216,38 @@ function LiveLogsPanel({
   );
 }
 
+/**
+ * Read-only bridge-event diagnostic projection (MoonLadderStudios/MoonMind#3640).
+ *
+ * The native Omnigent application is the only interactive Workflow Chat surface.
+ * This panel projects durable evidence only — the normalized chat view, the Raw
+ * Timeline escape hatch, runtime identity, compatibility/launch diagnostics,
+ * terminal evidence, and harvested resource groups. It carries no composer,
+ * approval cards, or interrupt/stop/clear/cancel/harvest/remove controls, so no
+ * legacy bridge-control endpoint remains an easier policy bypass around the
+ * scoped native path.
+ */
 function BridgeSessionLogsPanel({
   apiBase,
   bridgeSessionId,
   isTerminal,
   projection,
-  optimisticMessages,
-  setOptimisticMessages,
-  actionsEnabled = false,
 }: {
   apiBase: string;
   bridgeSessionId: string;
   isTerminal: boolean;
   projection: BridgeSessionProjection;
-  optimisticMessages: OptimisticChatSessionMessage[];
-  setOptimisticMessages: Dispatch<SetStateAction<OptimisticChatSessionMessage[]>>;
-  actionsEnabled?: boolean;
 }) {
   const [logContent, setLogContent] = useState<TimelineRow[]>([]);
   const [viewerState, setViewerState] = useState<LogViewerState>('starting');
   const [wrapLines, setWrapLines] = useState(true);
   const [liveAnnouncement, setLiveAnnouncement] = useState('');
-  const [message, setMessage] = useState('');
-  const [controlError, setControlError] = useState<string | null>(null);
-  const [controlBusy, setControlBusy] = useState(false);
   const lastSeqRef = useRef<number | null>(null);
   const esRef = useRef<EventSource | null>(null);
   const isVisible = usePageVisibility();
   const chatBlocks = useMemo(
-    () => reduceTimelineRowsToChatBlocks(logContent, bridgeSessionId, optimisticMessages),
-    [bridgeSessionId, logContent, optimisticMessages],
+    () => reduceTimelineRowsToChatBlocks(logContent, bridgeSessionId, []),
+    [bridgeSessionId, logContent],
   );
 
   const eventsQuery = useQuery({
@@ -6455,103 +6425,6 @@ function BridgeSessionLogsPanel({
     if (logContent.length === 0) return;
     copyTextToClipboard(logContent.map((line) => getCopyableRowText(line)).join('\n'));
   };
-  const canSend = Boolean(actionsEnabled && projection.providerSessionRef && projection.capabilities.sendFollowUp && !isTerminal);
-  const canInterrupt = Boolean(actionsEnabled && projection.providerSessionRef && projection.capabilities.interruptTurn && !isTerminal);
-  const canClear = Boolean(actionsEnabled && projection.providerSessionRef && projection.capabilities.clearSession && !isTerminal);
-  const canCancel = Boolean(actionsEnabled && projection.providerSessionRef && projection.capabilities.cancelSession && !isTerminal);
-  const canHarvest = Boolean(actionsEnabled && projection.providerSessionRef && projection.capabilities.harvestResources && !isTerminal);
-  const canStop = Boolean(actionsEnabled && projection.providerSessionRef && projection.capabilities.stop && !isTerminal);
-  const canRemove = Boolean(
-    actionsEnabled
-      && projection.providerSessionRef
-      && (
-        projection.capabilities.terminalCleanup
-        || (isTerminal && projection.compatibilityProfile === 'omnigent.embedded.v1')
-      ),
-  );
-  const canResolveElicitation = Boolean(
-    actionsEnabled && projection.providerSessionRef && projection.capabilities.resolveElicitation && !isTerminal,
-  );
-  const pendingElicitations = useMemo(() => {
-    if (!canResolveElicitation) return [];
-    const resolvedIds = new Set(logContent
-      .filter((row) => ['approval_resolved', 'approval_granted', 'approval_denied', 'intervention_resolved'].includes(row.kind ?? ''))
-      .map((row) => String(row.metadata?.elicitationId ?? row.metadata?.requestId ?? '').trim())
-      .filter(Boolean));
-    const pending = new Map<string, string>();
-    for (const row of logContent) {
-      if (!['approval_requested', 'intervention_requested'].includes(row.kind ?? '')) continue;
-      const id = String(row.metadata?.elicitationId ?? row.metadata?.requestId ?? '').trim();
-      if (id && !resolvedIds.has(id)) pending.set(id, row.text || 'Operator decision requested.');
-    }
-    return Array.from(pending, ([id, text]) => ({ id, text }));
-  }, [canResolveElicitation, logContent]);
-  const submitMessage = async () => {
-    const text = message.trim();
-    if (!text || !projection.providerSessionRef || !canSend) return;
-    const clientEventKey = crypto.randomUUID();
-    const optimistic: OptimisticChatSessionMessage = {
-      type: 'chat_session.message_submitted', clientEventKey, sessionId: bridgeSessionId,
-      sessionEpoch: 0, message: text, status: 'pending',
-    };
-    setOptimisticMessages((items) => [...items, optimistic]);
-    setMessage(''); setControlError(null); setControlBusy(true);
-    try {
-      await postBridgeSessionControl(apiBase, projection.providerSessionRef, {
-        type: 'message', message: text, clientEventKey,
-      });
-      setOptimisticMessages((items) => items.map((item) => item.clientEventKey === clientEventKey
-        ? { ...item, status: 'delivery_unknown' } : item));
-    } catch (error) {
-      const detail = (error as Error).message;
-      setControlError(detail);
-      setOptimisticMessages((items) => items.map((item) => item.clientEventKey === clientEventKey
-        ? { ...item, status: 'failed', error: detail } : item));
-    } finally { setControlBusy(false); }
-  };
-  const interrupt = async () => {
-    if (!projection.providerSessionRef || !canInterrupt) return;
-    setControlError(null); setControlBusy(true);
-    try { await postBridgeSessionControl(apiBase, projection.providerSessionRef, { type: 'session.interrupt' }); }
-    catch (error) { setControlError((error as Error).message); }
-    finally { setControlBusy(false); }
-  };
-  const runControl = async (payload: Record<string, unknown>) => {
-    if (!projection.providerSessionRef) return;
-    setControlError(null); setControlBusy(true);
-    try { await postBridgeSessionControl(apiBase, projection.providerSessionRef, payload); }
-    catch (error) { setControlError((error as Error).message); }
-    finally { setControlBusy(false); }
-  };
-  const durableControlPayload = (type: 'stop_session' | 'cleanup_session') => ({
-    type,
-    clientEventKey: crypto.randomUUID(),
-    idempotencyKey: crypto.randomUUID(),
-    expectedWorkflowId: projection.workflowId,
-    expectedRunId: projection.runId,
-    expectedStepExecutionId: projection.stepExecutionId,
-    expectedAgentRunId: projection.agentRunId,
-    expectedBridgeSessionId: projection.bridgeSessionId,
-    expectedSessionId: projection.providerSessionRef,
-    expectedHostId: projection.omnigentHostRef,
-    expectedRunnerId: projection.omnigentRunnerRef,
-    expectedTurnState: projection.firstMessageState,
-    expectedTerminalState: projection.status,
-  });
-  const removeSession = async () => {
-    if (!projection.providerSessionRef || !canRemove) return;
-    setControlError(null); setControlBusy(true);
-    try { await postBridgeSessionControl(apiBase, projection.providerSessionRef, durableControlPayload('cleanup_session')); }
-    catch (error) { setControlError((error as Error).message); }
-    finally { setControlBusy(false); }
-  };
-  const resolveElicitation = async (elicitationId: string, decision: 'approved' | 'rejected') => {
-    if (!projection.providerSessionRef || !canResolveElicitation) return;
-    setControlError(null); setControlBusy(true);
-    try { await resolveBridgeElicitation(apiBase, projection.providerSessionRef, elicitationId, decision); }
-    catch (error) { setControlError((error as Error).message); }
-    finally { setControlBusy(false); }
-  };
 
   return (
     <div className="stack live-logs-panel">
@@ -6702,34 +6575,6 @@ function BridgeSessionLogsPanel({
           </div>
         )}
       </div>
-      {(canSend || canInterrupt || canClear || canCancel || canHarvest || canStop || canRemove || pendingElicitations.length > 0 || optimisticMessages.length > 0) ? (
-        <section className="stack chat-session-controls" aria-label="Bridge session controls">
-          <h3>Session Controls</h3>
-          {controlError ? <div className="notice error">{controlError}</div> : null}
-          {optimisticMessages.map((item) => (
-            <div key={item.clientEventKey} role="status" className={`chat-session-message chat-session-message-${item.status}`}>
-              Operator message · {item.status === 'pending' ? 'Sending' : item.status === 'failed' ? 'Failed' : 'Delivery confirmation pending'}
-              {item.error ? `: ${item.error}` : null}
-            </div>
-          ))}
-          {canSend ? <><label htmlFor="bridge-follow-up">Follow-up message</label><textarea id="bridge-follow-up" value={message} onChange={(event) => setMessage(event.target.value)} disabled={controlBusy} rows={3} /><button type="button" onClick={() => void submitMessage()} disabled={controlBusy || !message.trim()}>Send follow-up</button></> : null}
-          {pendingElicitations.map((elicitation) => (
-            <section key={elicitation.id} className="stack" aria-label={`Pending operator request ${elicitation.id}`}>
-              <p>{elicitation.text}</p>
-              <div className="button-group">
-                <button type="button" onClick={() => void resolveElicitation(elicitation.id, 'approved')} disabled={controlBusy}>Approve</button>
-                <button type="button" className="secondary" onClick={() => void resolveElicitation(elicitation.id, 'rejected')} disabled={controlBusy}>Reject</button>
-              </div>
-            </section>
-          ))}
-          {canInterrupt ? <button type="button" className="secondary" onClick={() => void interrupt()} disabled={controlBusy}>Interrupt turn</button> : null}
-          {canHarvest ? <button type="button" className="secondary" onClick={() => void runControl({ type: 'harvest_session', clientEventKey: crypto.randomUUID() }).then(() => resourcesQuery.refetch())} disabled={controlBusy}>Harvest evidence</button> : null}
-          {canStop ? <button type="button" className="danger" onClick={() => { if (window.confirm('Stop this Omnigent session?')) void runControl(durableControlPayload('stop_session')); }} disabled={controlBusy}>Stop session</button> : null}
-          {canClear ? <button type="button" className="secondary" onClick={() => { if (window.confirm('Clear this bridge session?')) void runControl({ type: 'clear_session' }); }} disabled={controlBusy}>Clear session</button> : null}
-          {canCancel ? <button type="button" className="danger" onClick={() => { if (window.confirm('Cancel this bridge session?')) void runControl({ type: 'session.cancel' }); }} disabled={controlBusy}>Cancel session</button> : null}
-          {canRemove ? <button type="button" className="danger" onClick={() => { if (window.confirm('Remove the owned Omnigent session after evidence harvest?')) void removeSession(); }} disabled={controlBusy}>Remove owned session</button> : null}
-        </section>
-      ) : null}
     </div>
   );
 }
@@ -8442,6 +8287,101 @@ function RunComparisonPanel({
   );
 }
 
+/**
+ * Read-only bridge-event diagnostic and compatibility fallback for the primary
+ * Workflow Chat route (MoonLadderStudios/MoonMind#3640).
+ *
+ * The native Omnigent application owns the one interactive composer and session
+ * controls; this surface only projects durable evidence — bridge events, the Raw
+ * Timeline escape hatch, resource groups, compatibility/launch diagnostics,
+ * terminal evidence, and legacy managed-run/merged-log fallback. It never mounts
+ * the custom follow-up textarea, an optimistic message lane, approval cards, or
+ * interrupt/stop/clear/cancel/harvest/remove controls: `actionsEnabled` stays
+ * false and no optimistic-message setter is wired. A clearly labeled "Diagnostic
+ * event history" heading distinguishes it from the native chat above
+ * (docs/UI/WorkflowChatPanel.md §11).
+ */
+function WorkflowChatDiagnostics({
+  apiBase,
+  logStreamingEnabled,
+  resolvedAgentRunId,
+  showAgentRunAttachNotice,
+  isTerminal,
+  routes,
+  sessionTimelineEnabled,
+  structuredHistoryEnabled,
+  resolvedBridgeSessionId,
+  bridgeProjection,
+  bridgeResolutionLoading,
+  missingAgentRunState,
+}: {
+  apiBase: string;
+  logStreamingEnabled: boolean;
+  resolvedAgentRunId: string | null;
+  showAgentRunAttachNotice: boolean;
+  isTerminal: boolean;
+  routes: AgentRunRouteTemplates;
+  sessionTimelineEnabled: boolean;
+  structuredHistoryEnabled: boolean;
+  resolvedBridgeSessionId: string;
+  bridgeProjection: BridgeSessionProjection;
+  bridgeResolutionLoading: boolean;
+  missingAgentRunState: MissingAgentRunState | null;
+}) {
+  return (
+    <section
+      className="stack td-chat-diagnostics"
+      aria-label="Diagnostic event history"
+      data-testid="workflow-chat-diagnostics"
+    >
+      <div>
+        <h4>Diagnostic event history</h4>
+        <p className="small">
+          Read-only bridge events, resource evidence, terminal artifacts, and merged logs for
+          this workflow. This diagnostic and compatibility surface never sends messages or controls
+          the session; use the native Omnigent chat for live interaction.
+        </p>
+      </div>
+      {logStreamingEnabled ? (
+        resolvedAgentRunId ? (
+          <>
+            {showAgentRunAttachNotice ? (
+              <p className="small">Waiting for managed runtime launch to create live logs.</p>
+            ) : null}
+            <LiveLogsPanel
+              apiBase={apiBase}
+              agentRunId={resolvedAgentRunId}
+              isTerminal={isTerminal}
+              autoExpand
+              disclosure={false}
+              routes={routes}
+              sessionTimelineEnabled={sessionTimelineEnabled}
+              structuredHistoryEnabled={structuredHistoryEnabled}
+            />
+          </>
+        ) : resolvedBridgeSessionId ? (
+          <BridgeSessionLogsPanel
+            apiBase={apiBase}
+            bridgeSessionId={resolvedBridgeSessionId}
+            isTerminal={isTerminal}
+            projection={bridgeProjection}
+          />
+        ) : bridgeResolutionLoading ? (
+          <p className="small">Checking bridge session evidence.</p>
+        ) : (
+          <p className="small">
+            {missingAgentRunState
+              ? renderMissingAgentRunCopy(missingAgentRunState)
+              : 'Waiting for managed runtime launch to create live logs.'}
+          </p>
+        )
+      ) : (
+        <p className="small">Live log streaming is disabled for this dashboard.</p>
+      )}
+    </section>
+  );
+}
+
 function WorkflowDetailPageContent({ payload }: { payload: BootPayload }) {
   const queryClient = useQueryClient();
   const toast = useDashboardToast();
@@ -9694,7 +9634,9 @@ function WorkflowDetailPageContent({ payload }: { payload: BootPayload }) {
               <div>
                 <h3>Workflow Chat</h3>
                 <p className="small">
-                  Session transcript, live runtime events, and eligible operator controls for this workflow.
+                  Interactive chat is the native Omnigent application. When native chat is
+                  unavailable, a read-only diagnostic and compatibility fallback preserves the
+                  session evidence below.
                 </p>
               </div>
               <WorkflowChatNative
@@ -9702,55 +9644,20 @@ function WorkflowDetailPageContent({ payload }: { payload: BootPayload }) {
                 workflowId={execution.workflowId || execution.taskId || ''}
                 active={chatTabActive}
               >
-              {logStreamingEnabled ? (
-                resolvedAgentRunId ? (
-                  <>
-                    {showAgentRunAttachNotice ? (
-                      <p className="small">Waiting for managed runtime launch to create live logs.</p>
-                    ) : null}
-                    <LiveLogsPanel
-                      apiBase={payload.apiBase}
-                      agentRunId={resolvedAgentRunId}
-                      isTerminal={isTerminalExecution}
-                      autoExpand
-                      disclosure={false}
-                      routes={agentRunRoutes}
-                      sessionTimelineEnabled={sessionTimelineEnabled}
-                      structuredHistoryEnabled={structuredHistoryEnabled}
-                      optimisticMessages={chatOptimisticMessages}
-                    />
-                  </>
-                ) : resolvedBridgeSessionId ? (
-                  <BridgeSessionLogsPanel
-                    apiBase={payload.apiBase}
-                    bridgeSessionId={resolvedBridgeSessionId}
-                    isTerminal={isTerminalExecution}
-                    projection={resolvedBridgeProjection}
-                    optimisticMessages={chatOptimisticMessages}
-                    setOptimisticMessages={setChatOptimisticMessages}
-                    actionsEnabled={actionsOn}
-                  />
-                ) : bridgeResolutionQuery.isLoading ? (
-                  <p className="small">Checking bridge session evidence.</p>
-                ) : (
-                  <p className="small">{missingAgentRunState ? renderMissingAgentRunCopy(missingAgentRunState) : 'Waiting for managed runtime launch to create live logs.'}</p>
-                )
-              ) : (
-                <p className="small">Live log streaming is disabled for this dashboard.</p>
-              )}
-              {resolvedAgentRunId && actionsOn ? (
-                <SessionContinuityPanel
+                <WorkflowChatDiagnostics
                   apiBase={payload.apiBase}
-                  agentRunId={resolvedAgentRunId}
-                  targetRuntime={execution.targetRuntime}
+                  logStreamingEnabled={logStreamingEnabled}
+                  resolvedAgentRunId={resolvedAgentRunId}
+                  showAgentRunAttachNotice={showAgentRunAttachNotice}
                   isTerminal={isTerminalExecution}
-                  invalidateWorkflowDetail={invalidate}
                   routes={agentRunRoutes}
-                  optimisticMessages={chatOptimisticMessages}
-                  setOptimisticMessages={setChatOptimisticMessages}
-                  compact
+                  sessionTimelineEnabled={sessionTimelineEnabled}
+                  structuredHistoryEnabled={structuredHistoryEnabled}
+                  resolvedBridgeSessionId={resolvedBridgeSessionId}
+                  bridgeProjection={resolvedBridgeProjection}
+                  bridgeResolutionLoading={bridgeResolutionQuery.isLoading}
+                  missingAgentRunState={missingAgentRunState}
                 />
-              ) : null}
               </WorkflowChatNative>
             </section>
           ) : null}


### PR DESCRIPTION
## Issue

MoonLadderStudios/MoonMind#3640 — [Omnigent native chat 8/10] Demote the custom Workflow Chat projection to read-only diagnostics and fallback

Closes MoonLadderStudios/MoonMind#3640

## Summary

Makes the native Omnigent application the only primary interactive Workflow Chat surface and demotes the MoonMind bridge-event projection to a clearly labeled **read-only diagnostic and compatibility fallback**.

- **Extract the diagnostic projection** — the bridge-event/log projection mounted on the primary Chat route is extracted into a focused, read-only `WorkflowChatDiagnostics` component rendered under a distinct **"Diagnostic event history"** heading/aria-label, so it is visually and semantically separated from Native Chat. It preserves the durable evidence surfaces (LiveLogsPanel, BridgeSessionLogsPanel, Raw Timeline, runtime identity, compatibility/launch diagnostics, resource groups, terminal evidence, merged-log fallback) with no `actionsEnabled` flag and no optimistic-message setter.
- **Remove duplicate mutation affordances from primary Chat** — the custom follow-up composer + Send, the browser-local optimistic message lane, duplicate Approve/Reject cards, and the interrupt/stop/clear/cancel/harvest/remove controls no longer mount on the primary Chat route. The interactive `SessionContinuityPanel` is relocated off the Chat route to the Steps tab, where it uses the canonical agent-run control contracts.
- **Close the legacy policy-bypass path** — the now-dead interactive machinery is structurally stripped from `BridgeSessionLogsPanel`, and the `postBridgeSessionControl` / `resolveBridgeElicitation` helpers are deleted so no legacy `/omnigent/v1/sessions/.../events` or `.../elicitations/.../resolve` endpoint remains an easier bypass around the scoped native path.
- **Truthful fallback behavior** — `WorkflowChatNative` renders exactly one native iframe when a live binding exists (and does not mount the read-only children, so no background diagnostic SSE runs while native Chat is primary). When the binding is starting, unavailable, or unreachable it surfaces a stable unavailable reason, a **Retry** action, and an authorized **Open in Omnigent** escape hatch, and never silently switches to a behaviorally different interactive custom chat.
- Historical/direct-runtime readability and truthful provenance labels (e.g. "Codex via Omnigent") are retained.

## Tests run

- `npm run ui:test -- src/entrypoints/WorkflowChatNative.test.tsx src/entrypoints/workflow-detail.test.tsx` — **PASS** (2 files, 209 tests). New assertions cover the read-only demotion (no composer/approval/session controls, no posts to legacy bridge-control endpoints) and `WorkflowChatNative` stable-reason + Retry + refetch-to-native behavior across unavailable/starting/unreachable/404 states.
- `tsc --noEmit` (frontend typecheck) — **PASS** (exit 0), confirming the removed helpers/props/imports left no dead references or type errors.

## Remaining risks

- Full-browser behavioral acceptance beyond jsdom — no background SSE at true runtime, screen-reader announcement fidelity, virtualization at large history volume, and reduced-motion behavior — is best confirmed by manual/browser verification. These a11y/perf capabilities are pre-existing and retained unchanged; structural gating is verified in source and unit tests.
- Direct `vitest` CLI cannot be invoked with the `:` in the workspace path; the documented `npm ui:test` wrapper (colon-free temp dir) was used instead. Tooling note only, not an implementation defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
