### PR TITLE
Fix standalone Omnigent PR resolver continuation handling

### DIFF
--- a/moonmind/omnigent/execute.py
+++ b/moonmind/omnigent/execute.py
@@ -167,6 +167,20 @@ async def _build_omnigent_first_message(
             parts.append("Input refs: " + ", ".join(request.input_refs))
         text = "\n\n".join(parts)
 
+    parameters = request.parameters if isinstance(request.parameters, dict) else {}
+    metadata = parameters.get("metadata")
+    moonmind = metadata.get("moonmind") if isinstance(metadata, dict) else {}
+    if not isinstance(moonmind, dict):
+        moonmind = {}
+    continuation_authority_instruction = str(
+        moonmind.get("terminalContinuationAuthorityInstruction") or ""
+    ).strip()
+    if (
+        continuation_authority_instruction
+        and continuation_authority_instruction not in text
+    ):
+        text = f"{text}\n\n{continuation_authority_instruction}"
+
     return {
         "type": "message",
         "data": {

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -618,6 +618,12 @@ RUN_UNGATED_CONTINUATION_DISPOSITION_PATCH = (
     "run-ungated-continuation-disposition-v1"
 )
 RUN_GATED_STEP_CONTINUATION_PATCH = "run-gated-step-continuation-v1"
+# Expose the workflow-owned continuation capability to the portable Skill at
+# launch.  The absence of an authority is meaningful: a one-shot runtime must
+# keep supported waits in the foreground because no later workflow owns them.
+RUN_TERMINAL_CONTINUATION_AUTHORITY_INSTRUCTIONS_PATCH = (
+    "run-terminal-continuation-authority-instructions-v1"
+)
 # Merge-automation dispositions that are *continuations*: they only have meaning
 # when a MoonMind.MergeAutomation gate re-enters and finalizes the merge. A
 # standalone (ungated) resolver run that ends in one of these states has not
@@ -11905,6 +11911,15 @@ class MoonMindRunWorkflow:
                                         "terminal evidence. MoonMind must not substitute "
                                         "native PR snapshot, comment, gate, or merge logic."
                                     )
+                                    if workflow.patched(
+                                        RUN_TERMINAL_CONTINUATION_AUTHORITY_INSTRUCTIONS_PATCH
+                                    ):
+                                        portable_note = (
+                                            f"{portable_note}\n\n"
+                                            + self._terminal_continuation_authority_instruction(
+                                                request
+                                            )
+                                        )
                                     request = request.model_copy(
                                         update={
                                             "instruction_ref": (
@@ -13939,6 +13954,30 @@ class MoonMindRunWorkflow:
         outputs = self._get_from_result(result, "outputs")
         if not isinstance(outputs, Mapping):
             return True
+
+        metadata = outputs.get("metadata")
+        if not isinstance(metadata, Mapping):
+            metadata = {}
+
+        # A validated terminal-contract decision belongs to the selected Skill,
+        # not to generic provider recovery.  Retrying terminal failure evidence
+        # can repeat mutations or override a deliberate manual-review result.
+        # Likewise, a rejected continuation cannot become owned merely by
+        # relaunching the same top-level workflow.  Missing/malformed evidence
+        # remains retryable through the existing bounded repair path.
+        terminal_contract_outcome = str(
+            metadata.get("terminalContractOutcome") or ""
+        ).strip().lower()
+        terminal_contract_recovery = str(
+            metadata.get("terminalContractRecoveryOutcome") or ""
+        ).strip().lower()
+        if terminal_contract_outcome == "terminal_failure":
+            return False
+        if (
+            terminal_contract_outcome == "continuation_requested"
+            and terminal_contract_recovery.startswith("continuation_rejected_")
+        ):
+            return False
 
         provider_failure = outputs.get("providerFailure")
         if not isinstance(provider_failure, Mapping):
@@ -17130,6 +17169,31 @@ class MoonMindRunWorkflow:
         if not parent:
             return False
         return parent == self._actual_parent_workflow_id()
+
+    @staticmethod
+    def _terminal_continuation_authority_instruction(
+        request: AgentExecutionRequest,
+    ) -> str:
+        """Describe continuation ownership without duplicating Skill semantics."""
+
+        authority = request.terminal_continuation_authority
+        if authority is None:
+            return (
+                "Execution continuation authority: none. No durable parent "
+                "workflow owns a later gate cycle after this agent process "
+                "exits. Treat this execution as standalone: if the resolved "
+                "Skill describes a parent-owned typed continuation, do not emit "
+                "it; keep supported bounded waits in the foreground and follow "
+                "the Skill to a terminal outcome."
+            )
+        allowed_actions = ", ".join(authority.allowed_actions)
+        return (
+            "Execution continuation authority: validated. Durable parent "
+            f"{authority.owner_workflow_type} owns gate "
+            f"'{authority.gate_type}' and permits only these typed actions: "
+            f"{allowed_actions}. Return a continuation only when the resolved "
+            "Skill authorizes that exact action."
+        )
 
     @staticmethod
     def _normalize_gate_type(value: str | None) -> str:

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -624,6 +624,12 @@ RUN_GATED_STEP_CONTINUATION_PATCH = "run-gated-step-continuation-v1"
 RUN_TERMINAL_CONTINUATION_AUTHORITY_INSTRUCTIONS_PATCH = (
     "run-terminal-continuation-authority-instructions-v1"
 )
+# Keep retry classification replay-stable for histories that already recorded
+# the prior provider-only decision. New executions use validated terminal
+# contract provenance to avoid repeating completed resolver mutations.
+RUN_TERMINAL_CONTRACT_RETRY_DECISION_PATCH = (
+    "run-terminal-contract-retry-decision-v1"
+)
 # Merge-automation dispositions that are *continuations*: they only have meaning
 # when a MoonMind.MergeAutomation gate re-enters and finalizes the merge. A
 # standalone (ungated) resolver run that ends in one of these states has not
@@ -11914,18 +11920,32 @@ class MoonMindRunWorkflow:
                                     if workflow.patched(
                                         RUN_TERMINAL_CONTINUATION_AUTHORITY_INSTRUCTIONS_PATCH
                                     ):
-                                        portable_note = (
-                                            f"{portable_note}\n\n"
-                                            + self._terminal_continuation_authority_instruction(
+                                        authority_instruction = (
+                                            self._terminal_continuation_authority_instruction(
                                                 request
                                             )
                                         )
+                                        portable_note = (
+                                            f"{portable_note}\n\n"
+                                            + authority_instruction
+                                        )
+                                        request_parameters = (
+                                            self._parameters_with_terminal_continuation_authority_instruction(
+                                                request,
+                                                authority_instruction=(
+                                                    authority_instruction
+                                                ),
+                                            )
+                                        )
+                                    else:
+                                        request_parameters = request.parameters
                                     request = request.model_copy(
                                         update={
                                             "instruction_ref": (
                                                 str(request.instruction_ref or "")
                                                 + portable_note
-                                            )
+                                            ),
+                                            "parameters": request_parameters,
                                         }
                                     )
                             if temporal_pr_resolver:
@@ -13955,30 +13975,6 @@ class MoonMindRunWorkflow:
         if not isinstance(outputs, Mapping):
             return True
 
-        metadata = outputs.get("metadata")
-        if not isinstance(metadata, Mapping):
-            metadata = {}
-
-        # A validated terminal-contract decision belongs to the selected Skill,
-        # not to generic provider recovery.  Retrying terminal failure evidence
-        # can repeat mutations or override a deliberate manual-review result.
-        # Likewise, a rejected continuation cannot become owned merely by
-        # relaunching the same top-level workflow.  Missing/malformed evidence
-        # remains retryable through the existing bounded repair path.
-        terminal_contract_outcome = str(
-            metadata.get("terminalContractOutcome") or ""
-        ).strip().lower()
-        terminal_contract_recovery = str(
-            metadata.get("terminalContractRecoveryOutcome") or ""
-        ).strip().lower()
-        if terminal_contract_outcome == "terminal_failure":
-            return False
-        if (
-            terminal_contract_outcome == "continuation_requested"
-            and terminal_contract_recovery.startswith("continuation_rejected_")
-        ):
-            return False
-
         provider_failure = outputs.get("providerFailure")
         if not isinstance(provider_failure, Mapping):
             provider_failure = {}
@@ -14018,6 +14014,37 @@ class MoonMindRunWorkflow:
             turn_metadata.get("failureClass"),
             turn_metadata.get("failure_class"),
         )
+
+        metadata = outputs.get("metadata")
+        if not isinstance(metadata, Mapping):
+            metadata = {}
+
+        # A validated resolver terminal disposition belongs to the selected
+        # Skill, not generic provider recovery. Retrying manual-review or failed
+        # terminal evidence can repeat mutations. A rejected typed continuation
+        # is non-retryable only when the synthetic resolver continuation error is
+        # the authoritative failure; real provider failures keep their existing
+        # bounded retry classification. Missing or malformed terminal evidence
+        # also stays retryable so the repair path can recover it.
+        if self._workflow_patch_enabled(
+            RUN_TERMINAL_CONTRACT_RETRY_DECISION_PATCH
+        ):
+            terminal_contract_outcome = str(
+                metadata.get("terminalContractOutcome") or ""
+            ).strip().lower()
+            merge_automation_disposition = str(
+                metadata.get("mergeAutomationDisposition") or ""
+            ).strip().lower()
+            if (
+                terminal_contract_outcome == "terminal_failure"
+                and merge_automation_disposition in {"manual_review", "failed"}
+            ):
+                return False
+            if (
+                terminal_contract_outcome == "continuation_requested"
+                and provider_error_code == "pr_resolver_reenter_gate"
+            ):
+                return False
 
         if provider_error_code in {"401", "403"}:
             return False
@@ -17194,6 +17221,24 @@ class MoonMindRunWorkflow:
             f"{allowed_actions}. Return a continuation only when the resolved "
             "Skill authorizes that exact action."
         )
+
+    @staticmethod
+    def _parameters_with_terminal_continuation_authority_instruction(
+        request: AgentExecutionRequest,
+        *,
+        authority_instruction: str,
+    ) -> dict[str, Any]:
+        """Expose continuation authority at the Omnigent adapter boundary."""
+
+        parameters = dict(request.parameters or {})
+        raw_metadata = parameters.get("metadata")
+        metadata = dict(raw_metadata) if isinstance(raw_metadata, Mapping) else {}
+        raw_moonmind = metadata.get("moonmind")
+        moonmind = dict(raw_moonmind) if isinstance(raw_moonmind, Mapping) else {}
+        moonmind["terminalContinuationAuthorityInstruction"] = authority_instruction
+        metadata["moonmind"] = moonmind
+        parameters["metadata"] = metadata
+        return parameters
 
     @staticmethod
     def _normalize_gate_type(value: str | None) -> str:

--- a/tests/integration/reliability/replays/omnigent-pr-resolver-unowned-continuation/expected-outcome.json
+++ b/tests/integration/reliability/replays/omnigent-pr-resolver-unowned-continuation/expected-outcome.json
@@ -1,0 +1,7 @@
+{
+  "continuationAuthority": "none",
+  "standaloneInstruction": true,
+  "retryable": false,
+  "genericRetryCount": 0,
+  "parentState": "failed"
+}

--- a/tests/integration/reliability/replays/omnigent-pr-resolver-unowned-continuation/manifest.json
+++ b/tests/integration/reliability/replays/omnigent-pr-resolver-unowned-continuation/manifest.json
@@ -1,0 +1,45 @@
+{
+  "failureShapeId": "omnigent-pr-resolver-unowned-continuation",
+  "incidentWorkflowId": "mm:7f52b94b-ad08-4e9d-a02a-772c72ae7964",
+  "incidentRunId": "019fe3a3-1f33-7e02-b6b2-a954c3ca3111",
+  "runtime": "omnigent",
+  "boundary": "standalone UserWorkflow AgentRun result to parent retry classification",
+  "request": {
+    "agentKind": "external",
+    "agentId": "omnigent",
+    "correlationId": "mm:7f52b94b-ad08-4e9d-a02a-772c72ae7964",
+    "idempotencyKey": "mm:7f52b94b-ad08-4e9d-a02a-772c72ae7964:node-1:execution:4",
+    "instructionRef": "Execute the resolved pr-resolver Skill.",
+    "terminalContract": {
+      "contractId": "pr_resolver_terminal.v1",
+      "owner": "agent",
+      "evidenceKind": "workspace_json",
+      "relativePath": "var/pr_resolver/result.json",
+      "expectedSchemaVersion": "moonmind.pr-resolver-result.v1",
+      "executionRef": "mm:7f52b94b-ad08-4e9d-a02a-772c72ae7964:019fe3a3-1f33-7e02-b6b2-a954c3ca3111:node-1:execution:4"
+    }
+  },
+  "childResult": {
+    "status": "FAILED",
+    "outputs": {
+      "error": "execution_error",
+      "summary": "Agent completed an authoritative durable continuation handoff.",
+      "failureClass": "execution_error",
+      "providerErrorCode": "PR_RESOLVER_REENTER_GATE",
+      "metadata": {
+        "terminalContractOutcome": "continuation_requested",
+        "terminalContractRecoveryOutcome": "continuation_rejected_unowned",
+        "mergeAutomationDisposition": "reenter_gate",
+        "gatedContinuation": {
+          "schemaVersion": "gated-continuation/v1",
+          "gateType": "merge_automation",
+          "action": "reenter_gate",
+          "reason": "ci_running",
+          "headSha": "99cf91833869bbbf2617d90479fc6f35c9dfeb9f",
+          "retryAfterSeconds": 60
+        }
+      }
+    }
+  },
+  "invariant": "A standalone one-shot runtime is told it has no durable continuation owner, and a rejected parent-owned handoff is terminal instead of retried as a provider failure"
+}

--- a/tests/integration/reliability/test_escaped_failure_journeys.py
+++ b/tests/integration/reliability/test_escaped_failure_journeys.py
@@ -935,6 +935,34 @@ async def test_invalid_batch_range_records_terminal_failure_without_retry(
     assert expected["parentState"] == "failed"
 
 
+async def test_standalone_omnigent_resolver_rejects_unowned_continuation_without_retry(
+) -> None:
+    """Replay mm:7f52b94b at the runtime-instruction and retry boundaries."""
+
+    replay_id = "omnigent-pr-resolver-unowned-continuation"
+    manifest = load_replay(replay_id, "manifest.json")
+    expected = load_replay(replay_id, "expected-outcome.json")
+    request = AgentExecutionRequest.model_validate(manifest["request"])
+    assert request.terminal_continuation_authority is None
+
+    parent = MoonMindRunWorkflow()
+    instruction = parent._terminal_continuation_authority_instruction(request)
+    assert f"continuation authority: {expected['continuationAuthority']}" in instruction
+    assert ("Treat this execution as standalone" in instruction) is expected[
+        "standaloneInstruction"
+    ]
+
+    retryable = parent._activity_result_retryable(
+        manifest["childResult"],
+        failure_message="execution_error",
+        tool_type="agent_runtime",
+    )
+
+    assert retryable is expected["retryable"]
+    assert expected["genericRetryCount"] == 0
+    assert expected["parentState"] == "failed"
+
+
 async def test_completed_batch_no_op_replays_through_production_activity_route(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/integration/reliability/test_escaped_failure_journeys.py
+++ b/tests/integration/reliability/test_escaped_failure_journeys.py
@@ -936,6 +936,7 @@ async def test_invalid_batch_range_records_terminal_failure_without_retry(
 
 
 async def test_standalone_omnigent_resolver_rejects_unowned_continuation_without_retry(
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Replay mm:7f52b94b at the runtime-instruction and retry boundaries."""
 
@@ -944,6 +945,10 @@ async def test_standalone_omnigent_resolver_rejects_unowned_continuation_without
     expected = load_replay(replay_id, "expected-outcome.json")
     request = AgentExecutionRequest.model_validate(manifest["request"])
     assert request.terminal_continuation_authority is None
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.workflows.run.workflow.patched",
+        lambda _patch: True,
+    )
 
     parent = MoonMindRunWorkflow()
     instruction = parent._terminal_continuation_authority_instruction(request)

--- a/tests/unit/omnigent/test_execute.py
+++ b/tests/unit/omnigent/test_execute.py
@@ -27,6 +27,7 @@ from moonmind.omnigent.execute import (
     OmnigentSessionStillRunningError,
     _agent_items,
     _await_marked_turn_terminal,
+    _build_omnigent_first_message,
     _first_message_text,
     _enqueue_stream_events,
     _resolve_agent_id,
@@ -49,6 +50,54 @@ def _request() -> AgentExecutionRequest:
         correlationId="corr-1",
         idempotencyKey="idem-1",
     )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("prompt", "inline_instruction", "artifact_text", "expected_base"),
+    [
+        ({"text": "Explicit prompt"}, "Inline prompt", None, "Explicit prompt"),
+        (
+            {"instructionRef": "artifact://prompt"},
+            "Inline prompt",
+            "Artifact prompt",
+            "Artifact prompt",
+        ),
+        ({}, "Inline prompt", None, "Inline prompt"),
+    ],
+)
+async def test_first_message_includes_terminal_continuation_authority(
+    prompt: dict[str, Any],
+    inline_instruction: str,
+    artifact_text: str | None,
+    expected_base: str,
+) -> None:
+    authority_instruction = "Execution continuation authority: none."
+    request = _request()
+    request.instruction_ref = inline_instruction
+    request.parameters = {
+        "metadata": {
+            "moonmind": {
+                "terminalContinuationAuthorityInstruction": authority_instruction
+            }
+        }
+    }
+
+    class Gateway:
+        async def read_text(self, ref: str) -> str:
+            assert ref == "artifact://prompt"
+            assert artifact_text is not None
+            return artifact_text
+
+    message = await _build_omnigent_first_message(
+        request=request,
+        prompt=prompt,
+        artifact_gateway=Gateway(),
+    )
+    text = _first_message_text(message)
+
+    assert expected_base in text
+    assert text.count(authority_instruction) == 1
 
 
 def test_current_turn_progress_ignores_prior_terminal_work() -> None:

--- a/tests/unit/workflows/temporal/test_run_ungated_continuation_disposition.py
+++ b/tests/unit/workflows/temporal/test_run_ungated_continuation_disposition.py
@@ -131,31 +131,80 @@ def test_gated_runtime_instruction_names_validated_authority() -> None:
     assert "reenter_gate" in instruction
 
 
+def test_continuation_authority_is_exposed_to_runtime_adapter_metadata() -> None:
+    request = _agent_request(
+        parameters={
+            "metadata": {"moonmind": {"latestContextPackRef": "artifact://context"}},
+            "title": "Resolve PR",
+        }
+    )
+    authority_instruction = (
+        MoonMindRunWorkflow._terminal_continuation_authority_instruction(request)
+    )
+
+    parameters = (
+        MoonMindRunWorkflow._parameters_with_terminal_continuation_authority_instruction(
+            request,
+            authority_instruction=authority_instruction,
+        )
+    )
+
+    assert parameters["title"] == "Resolve PR"
+    assert (
+        parameters["metadata"]["moonmind"]["latestContextPackRef"]
+        == "artifact://context"
+    )
+    assert (
+        parameters["metadata"]["moonmind"][
+            "terminalContinuationAuthorityInstruction"
+        ]
+        == authority_instruction
+    )
+
+
 @pytest.mark.parametrize(
-    ("terminal_outcome", "recovery_outcome"),
+    ("metadata", "provider_error_code"),
     [
-        ("terminal_failure", "unsupported_or_exhausted"),
-        ("continuation_requested", "continuation_rejected_unowned"),
         (
-            "continuation_requested",
-            "continuation_rejected_failure_provenance",
+            {
+                "terminalContractOutcome": "terminal_failure",
+                "terminalContractRecoveryOutcome": "unsupported_or_exhausted",
+                "mergeAutomationDisposition": "manual_review",
+            },
+            None,
+        ),
+        (
+            {
+                "terminalContractOutcome": "terminal_failure",
+                "terminalContractRecoveryOutcome": "unsupported_or_exhausted",
+                "mergeAutomationDisposition": "failed",
+            },
+            None,
+        ),
+        (
+            {
+                "terminalContractOutcome": "continuation_requested",
+                "terminalContractRecoveryOutcome": "continuation_rejected_unowned",
+                "mergeAutomationDisposition": "reenter_gate",
+            },
+            "PR_RESOLVER_REENTER_GATE",
         ),
     ],
 )
 def test_terminal_contract_decisions_do_not_trigger_generic_runtime_retry(
-    terminal_outcome: str,
-    recovery_outcome: str,
+    monkeypatch: pytest.MonkeyPatch,
+    metadata: dict[str, str],
+    provider_error_code: str | None,
 ) -> None:
+    monkeypatch.setattr(run_workflow_module.workflow, "patched", lambda _patch: True)
     workflow = MoonMindRunWorkflow()
     result = {
         "status": "FAILED",
         "outputs": {
             "error": "execution_error",
             "failureClass": "execution_error",
-            "metadata": {
-                "terminalContractOutcome": terminal_outcome,
-                "terminalContractRecoveryOutcome": recovery_outcome,
-            },
+            "providerErrorCode": provider_error_code,
+            "metadata": metadata,
         },
     }
 
@@ -169,7 +218,10 @@ def test_terminal_contract_decisions_do_not_trigger_generic_runtime_retry(
     )
 
 
-def test_missing_terminal_evidence_remains_retryable() -> None:
+def test_missing_terminal_evidence_remains_retryable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(run_workflow_module.workflow, "patched", lambda _patch: True)
     workflow = MoonMindRunWorkflow()
     result = {
         "status": "FAILED",
@@ -177,8 +229,62 @@ def test_missing_terminal_evidence_remains_retryable() -> None:
             "error": "execution_error",
             "failureClass": "execution_error",
             "metadata": {
+                "terminalContractOutcome": "terminal_failure",
                 "terminalContractRecoveryOutcome": "continuation_boundary_unavailable",
                 "terminalContractMissingEvidence": ["var/pr_resolver/result.json"],
+            },
+        },
+    }
+
+    assert workflow._activity_result_retryable(
+        result,
+        failure_message="execution_error",
+        tool_type="agent_runtime",
+    )
+
+
+def test_real_provider_failure_with_rejected_continuation_remains_retryable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(run_workflow_module.workflow, "patched", lambda _patch: True)
+    workflow = MoonMindRunWorkflow()
+    result = {
+        "status": "FAILED",
+        "outputs": {
+            "error": "execution_error",
+            "failureClass": "execution_error",
+            "providerErrorCode": "RATE_LIMITED",
+            "retryRecommendation": "retry",
+            "metadata": {
+                "terminalContractOutcome": "continuation_requested",
+                "terminalContractRecoveryOutcome": (
+                    "continuation_rejected_failure_provenance"
+                ),
+                "mergeAutomationDisposition": "reenter_gate",
+            },
+        },
+    }
+
+    assert workflow._activity_result_retryable(
+        result,
+        failure_message="execution_error",
+        tool_type="agent_runtime",
+    )
+
+
+def test_existing_history_preserves_provider_retry_decision(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(run_workflow_module.workflow, "patched", lambda _patch: False)
+    workflow = MoonMindRunWorkflow()
+    result = {
+        "status": "FAILED",
+        "outputs": {
+            "error": "execution_error",
+            "failureClass": "execution_error",
+            "metadata": {
+                "terminalContractOutcome": "terminal_failure",
+                "mergeAutomationDisposition": "manual_review",
             },
         },
     }

--- a/tests/unit/workflows/temporal/test_run_ungated_continuation_disposition.py
+++ b/tests/unit/workflows/temporal/test_run_ungated_continuation_disposition.py
@@ -18,6 +18,7 @@ from temporalio import client, exceptions
 from temporalio.testing import WorkflowEnvironment
 from temporalio.worker import UnsandboxedWorkflowRunner, Worker
 
+from moonmind.schemas.agent_runtime_models import AgentExecutionRequest
 from moonmind.workflows.temporal.workflows.merge_gate import (
     build_resolver_run_request,
 )
@@ -87,6 +88,106 @@ def test_gated_parameters_are_recognized_as_merge_automation_owned(
 def test_standalone_resolver_parameters_are_not_gated() -> None:
     workflow = MoonMindRunWorkflow()
     assert workflow._is_merge_automation_gated(_ungated_resolver_parameters()) is False
+
+
+def _agent_request(**updates: Any) -> AgentExecutionRequest:
+    payload: dict[str, Any] = {
+        "agentKind": "external",
+        "agentId": "omnigent",
+        "correlationId": "mm:standalone-resolver",
+        "idempotencyKey": "mm:standalone-resolver:node-1:execution:1",
+    }
+    payload.update(updates)
+    return AgentExecutionRequest.model_validate(payload)
+
+
+def test_standalone_runtime_instruction_denies_parent_owned_continuation() -> None:
+    instruction = MoonMindRunWorkflow._terminal_continuation_authority_instruction(
+        _agent_request()
+    )
+
+    assert "continuation authority: none" in instruction
+    assert "Treat this execution as standalone" in instruction
+    assert "keep supported bounded waits in the foreground" in instruction
+
+
+def test_gated_runtime_instruction_names_validated_authority() -> None:
+    instruction = MoonMindRunWorkflow._terminal_continuation_authority_instruction(
+        _agent_request(
+            terminalContinuationAuthority={
+                "schemaVersion": "terminal-continuation-authority/v1",
+                "gateType": "merge_automation",
+                "ownerWorkflowId": "merge-automation:1",
+                "ownerRunId": "merge-run-1",
+                "ownerWorkflowType": "MoonMind.MergeAutomation",
+                "allowedActions": ["reenter_gate"],
+                "source": "validated_temporal_parent",
+            }
+        )
+    )
+
+    assert "continuation authority: validated" in instruction
+    assert "MoonMind.MergeAutomation" in instruction
+    assert "reenter_gate" in instruction
+
+
+@pytest.mark.parametrize(
+    ("terminal_outcome", "recovery_outcome"),
+    [
+        ("terminal_failure", "unsupported_or_exhausted"),
+        ("continuation_requested", "continuation_rejected_unowned"),
+        (
+            "continuation_requested",
+            "continuation_rejected_failure_provenance",
+        ),
+    ],
+)
+def test_terminal_contract_decisions_do_not_trigger_generic_runtime_retry(
+    terminal_outcome: str,
+    recovery_outcome: str,
+) -> None:
+    workflow = MoonMindRunWorkflow()
+    result = {
+        "status": "FAILED",
+        "outputs": {
+            "error": "execution_error",
+            "failureClass": "execution_error",
+            "metadata": {
+                "terminalContractOutcome": terminal_outcome,
+                "terminalContractRecoveryOutcome": recovery_outcome,
+            },
+        },
+    }
+
+    assert (
+        workflow._activity_result_retryable(
+            result,
+            failure_message="execution_error",
+            tool_type="agent_runtime",
+        )
+        is False
+    )
+
+
+def test_missing_terminal_evidence_remains_retryable() -> None:
+    workflow = MoonMindRunWorkflow()
+    result = {
+        "status": "FAILED",
+        "outputs": {
+            "error": "execution_error",
+            "failureClass": "execution_error",
+            "metadata": {
+                "terminalContractRecoveryOutcome": "continuation_boundary_unavailable",
+                "terminalContractMissingEvidence": ["var/pr_resolver/result.json"],
+            },
+        },
+    }
+
+    assert workflow._activity_result_retryable(
+        result,
+        failure_message="execution_error",
+        tool_type="agent_runtime",
+    )
 
 
 def test_empty_merge_gate_without_parent_is_not_gated() -> None:


### PR DESCRIPTION
## Summary

- expose validated or absent durable continuation authority in the portable `pr-resolver` launch instructions
- keep terminal Skill outcomes and rejected unowned continuations out of generic provider retries
- add a minimized replay fixture for failed workflow `mm:7f52b94b-ad08-4e9d-a02a-772c72ae7964`

## Root cause

The standalone Omnigent resolver was not told that its `AgentExecutionRequest` had no `terminalContinuationAuthority`. After pushing a merge-conflict fix, it exited on `ci_running` with a `reenter_gate` handoff. `MoonMind.AgentRun` correctly rejected that parent-owned continuation, but the parent classified the resulting `execution_error` as a generic retryable provider failure and relaunched the resolver until its retry budget was exhausted. Earlier `manual_review` terminal evidence was retried for the same reason.

The fix exposes continuation ownership without moving any resolver semantics out of the portable Skill. It also uses the existing terminal-contract outcome metadata to stop generic retries after authoritative terminal decisions while preserving bounded repair for missing evidence.

## Validation

- `29 passed` — `test_run_ungated_continuation_disposition.py`
- `1 passed` — escaped-failure replay for the incident workflow
- `124 passed, 9 subtests passed` — `test_run_agent_dispatch.py`
