### PR TITLE
Preserve PR base across workflow steps

### DIFF
--- a/docs/Workflows/WorkflowPublishing.md
+++ b/docs/Workflows/WorkflowPublishing.md
@@ -123,6 +123,14 @@ Example:
 
 For PR publication, the authored `branch` is the selected repository branch and PR base. MoonMind creates or obtains a runtime-generated work branch for the PR head, pushes changes there, and creates a pull request back to the authored base branch.
 
+An agent-runtime Step with `publishMode = branch` or `publishMode = pr` has
+repository write authority by default. The runtime records that effective
+`repositoryOperation = write` in the durable plan. When an earlier Step has
+already published the cumulative candidate, a downstream publishing Step starts
+from that verified candidate head but continues to compare and publish against
+the original authored base branch; the candidate branch must never become its
+own publication base.
+
 When merge automation is explicitly enabled for a PR-publishing Workflow Execution, successful PR publication starts a parent-owned `MoonMind.MergeAutomation` child workflow. The original `MoonMind.UserWorkflow` remains in `awaiting_external` while merge automation waits for configured external readiness signals and runs `pr-resolver` with publish mode `auto`; downstream dependencies on the original Workflow Execution are satisfied only after merge automation succeeds.
 
 Operator-facing detail payloads present PR publishing with merge automation as the single publish mode value `pr_with_merge_automation`. Worker-bound execution input remains normalized as `publishMode = "pr"` plus merge automation configuration, because merge automation is an orchestration extension of PR publishing rather than a separate repository publish primitive. Details must not expose a second selection flag such as `mergeAutomationSelected`; active or terminal merge automation state belongs under the `mergeAutomation` status object.

--- a/moonmind/workflows/temporal/worker_runtime.py
+++ b/moonmind/workflows/temporal/worker_runtime.py
@@ -895,6 +895,31 @@ def _normalize_runtime_mode(raw_mode: Any) -> str:
         return str(settings.workflow.default_runtime or "codex_cli").strip().lower()
     return normalized
 
+
+def _compile_repository_operation(
+    inputs: dict[str, Any],
+    *,
+    is_agent_runtime: bool,
+) -> None:
+    """Make repository authority explicit in one durable plan node."""
+
+    repository_operation = str(
+        inputs.get("repositoryOperation") or ""
+    ).strip().lower()
+    if repository_operation == "read":
+        # A read-only repository step may still write its declared handoff
+        # artifacts, but it cannot own repository mutation or publication.
+        inputs["publishMode"] = "none"
+    elif (
+        is_agent_runtime
+        and str(inputs.get("publishMode") or "").strip().lower()
+        in {"branch", "pr"}
+    ):
+        # Managed publication is repository mutation authority. Make the
+        # default explicit so downstream steps retain the authored base.
+        inputs["repositoryOperation"] = "write"
+
+
 _JIRA_AGENT_SKILLS = JIRA_AGENT_SKILLS
 _STORY_OUTPUT_TASK_TOOLS = frozenset(
     {
@@ -2138,14 +2163,10 @@ def _build_runtime_planner():
                     step_node_inputs.pop("selectedSkill", None)
                 if is_story_output_tool:
                     step_node_inputs["publishMode"] = "none"
-                repository_operation = str(
-                    step_node_inputs.get("repositoryOperation") or ""
-                ).strip().lower()
-                if repository_operation == "read":
-                    # A read-only repository step may still write its declared
-                    # handoff artifacts, but it cannot own repository mutation
-                    # or publication. Compile that authority away before launch.
-                    step_node_inputs["publishMode"] = "none"
+                _compile_repository_operation(
+                    step_node_inputs,
+                    is_agent_runtime=is_agent_runtime_step,
+                )
 
                 nodes.append({
                     "id": step_id,
@@ -2191,6 +2212,10 @@ def _build_runtime_planner():
                 )
                 if _jira_agent_skill_selected(selected_skill_name):
                     expanded_inputs["publishMode"] = "none"
+                _compile_repository_operation(
+                    expanded_inputs,
+                    is_agent_runtime=True,
+                )
                 expanded_publish_mode = str(
                     expanded_inputs.get("publishMode") or ""
                 ).strip().lower()
@@ -2245,6 +2270,10 @@ def _build_runtime_planner():
             if is_story_output_tool:
                 node_inputs.pop("selectedSkill", None)
                 node_inputs["publishMode"] = "none"
+            _compile_repository_operation(
+                node_inputs,
+                is_agent_runtime=not is_story_output_tool,
+            )
             node_publish_mode = str(node_inputs.get("publishMode") or "").strip().lower()
             if node_publish_mode in {"auto", "none"} and not is_story_output_tool:
                 node_inputs["instructions"] = (

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -605,6 +605,13 @@ RUN_REPOSITORY_BOUND_NO_COMMIT_OUTCOME_PATCH = (
     "run-repository-bound-no-commit-outcome-v1"
 )
 RUN_PUBLISHED_BRANCH_HANDOFF_PATCH = "run-published-branch-handoff-v1"
+# Preserve the authored PR/branch base when a downstream publishing step omits
+# repositoryOperation. Publishing itself is mutation authority, so current
+# executions compile that omission to ``write`` while older histories replay
+# their recorded candidate-as-base behavior.
+RUN_PUBLISH_MODE_REPOSITORY_OPERATION_PATCH = (
+    "run-publish-mode-repository-operation-v1"
+)
 # Assert the producing Step Execution reached the `accepted` terminal
 # disposition before an external handoff runs, in addition to the existing
 # MoonSpec gate verdict block. Guarded for replay safety so in-flight runs keep
@@ -19053,6 +19060,24 @@ class MoonMindRunWorkflow:
         repository_operation = str(
             node_inputs.get("repositoryOperation") or ""
         ).strip().lower()
+        if (
+            not repository_operation
+            and self._patched_or_false_outside_workflow(
+                RUN_PUBLISH_MODE_REPOSITORY_OPERATION_PATCH
+            )
+        ):
+            effective_publish_mode = runtime_block.get("publishMode")
+            if effective_publish_mode is None:
+                effective_publish_mode = node_inputs.get("publishMode")
+            if effective_publish_mode is None and isinstance(
+                workflow_parameters, Mapping
+            ):
+                effective_publish_mode = workflow_parameters.get("publishMode")
+            if str(effective_publish_mode or "").strip().lower() in {
+                "branch",
+                "pr",
+            }:
+                repository_operation = "write"
         if self._patched_or_false_outside_workflow(
             RUN_PUBLISHED_BRANCH_HANDOFF_PATCH
         ):

--- a/tests/integration/reliability/replays/omnigent-pr-step-candidate-base/expected-outcome.json
+++ b/tests/integration/reliability/replays/omnigent-pr-step-candidate-base/expected-outcome.json
@@ -1,0 +1,6 @@
+{
+  "repositoryOperation": "write",
+  "publishBaseBranch": "main",
+  "candidateBranch": "moonmind-job-24a73665",
+  "candidateHeadSha": "b651c9e47fe6e7696ef575b6969ed7d682c78338"
+}

--- a/tests/integration/reliability/replays/omnigent-pr-step-candidate-base/manifest.json
+++ b/tests/integration/reliability/replays/omnigent-pr-step-candidate-base/manifest.json
@@ -1,0 +1,36 @@
+{
+  "failureShapeId": "omnigent-pr-step-candidate-base",
+  "incidentWorkflowId": "mm:6103dddf-2e68-4185-9481-5668d5916642",
+  "incidentRunId": "019fe3a7-4522-78a5-af30-9ea9a5a03311",
+  "runtime": "omnigent",
+  "boundary": "published branch handoff to downstream PR-publishing AgentExecutionRequest",
+  "logicalStepId": "tpl:github-issue-implement:05:a328c02c",
+  "workflowInfo": {
+    "namespace": "default",
+    "workflow_id": "mm:6103dddf-2e68-4185-9481-5668d5916642",
+    "run_id": "019fe3a7-4522-78a5-af30-9ea9a5a03311",
+    "parent": null
+  },
+  "publishContext": {
+    "pushStatus": "pushed",
+    "branch": "moonmind-job-24a73665",
+    "headSha": "b651c9e47fe6e7696ef575b6969ed7d682c78338",
+    "baseRef": "main"
+  },
+  "nodeInputs": {
+    "targetRuntime": "omnigent",
+    "repository": "MoonLadderStudios/MoonMind",
+    "startingBranch": "main",
+    "targetBranch": "fetch-github-issue-moonladderstudios-moo-7af037d8",
+    "publishMode": "pr"
+  },
+  "observedFailure": {
+    "providerErrorCode": "OMNIGENT_REPOSITORY_OUTPUT_MISSING",
+    "pushStatus": "no_commits",
+    "pushBranch": "moonmind-job-24a73665",
+    "pushBaseBranch": "moonmind-job-24a73665",
+    "repositoryContinuationCount": 8,
+    "genericExecutionAttempts": 4
+  },
+  "invariant": "A PR-publishing downstream step continues from the verified candidate head while comparing repository output to the original PR base, even when repositoryOperation was omitted by an older plan."
+}

--- a/tests/integration/reliability/test_escaped_failure_journeys.py
+++ b/tests/integration/reliability/test_escaped_failure_journeys.py
@@ -107,6 +107,8 @@ from moonmind.workflows.temporal.workflows.run import (
     RUN_WORKFLOW_HEADLESS_REMEDIATION_PATCH,
     RUN_WORKFLOW_OWNED_REMEDIATION_HEAD_PATCH,
     RUN_OMNIGENT_STOCK_AGENT_IDENTITY_PATCH,
+    RUN_PUBLISH_MODE_REPOSITORY_OPERATION_PATCH,
+    RUN_PUBLISHED_BRANCH_HANDOFF_PATCH,
     MoonMindRunWorkflow,
 )
 from moonmind.workflows.terminal_evidence import evaluate_terminal_evidence
@@ -140,6 +142,46 @@ pytestmark = [
 ]
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+async def test_omnigent_pr_step_reuses_candidate_against_original_base(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Replay mm:6103dddf at the published-branch request boundary."""
+
+    replay_id = "omnigent-pr-step-candidate-base"
+    manifest = load_replay(replay_id, "manifest.json")
+    expected = load_replay(replay_id, "expected-outcome.json")
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.workflows.run.workflow.info",
+        lambda: SimpleNamespace(**manifest["workflowInfo"]),
+    )
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.workflows.run.workflow.patched",
+        lambda patch_id: patch_id
+        in {
+            RUN_PUBLISHED_BRANCH_HANDOFF_PATCH,
+            RUN_PUBLISH_MODE_REPOSITORY_OPERATION_PATCH,
+        },
+    )
+
+    parent = MoonMindRunWorkflow()
+    parent._publish_context.update(manifest["publishContext"])
+    request = parent._build_agent_execution_request(
+        node_inputs=manifest["nodeInputs"],
+        node_id=manifest["logicalStepId"],
+        tool_name="omnigent",
+    )
+
+    assert request.parameters["repositoryOperation"] == expected[
+        "repositoryOperation"
+    ]
+    assert request.workspace_spec is not None
+    assert request.workspace_spec["startingBranch"] == expected["publishBaseBranch"]
+    assert request.workspace_spec["targetBranch"] == expected["candidateBranch"]
+    assert request.workspace_spec["repositoryTarget"]["revision"]["commitSha"] == (
+        expected["candidateHeadSha"]
+    )
 
 
 @activity.defn(name="reliability.omnigent_activity_heartbeat_probe")

--- a/tests/unit/api/test_presets_service.py
+++ b/tests/unit/api/test_presets_service.py
@@ -3440,6 +3440,7 @@ async def test_seed_catalog_github_issue_implement_expands_shared_includes(tmp_p
         "artifacts/github-issue-implement-brief.json"
         in expanded["steps"][1]["instructions"]
     )
+    assert expanded["steps"][1]["repositoryOperation"] == "read"
     assert expanded["steps"][1]["skill"]["args"] == {
         "brief_artifact_path": "artifacts/github-issue-implement-brief.json",
         "assessment_artifact_path": (
@@ -3449,6 +3450,7 @@ async def test_seed_catalog_github_issue_implement_expands_shared_includes(tmp_p
     assert expanded["steps"][2]["tool"]["id"] == "github.check_issue_blockers"
     assert expanded["steps"][3]["tool"]["id"] == "github.update_issue_status"
     assert expanded["steps"][5]["skill"]["id"] == "moonspec-verify"
+    assert expanded["steps"][5]["repositoryOperation"] == "read"
     assert expanded["steps"][5]["skill"]["args"] == {
         "verification_target": "issue_brief",
         "issue_provider": "github",

--- a/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
+++ b/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
@@ -3538,6 +3538,32 @@ def test_runtime_planner_read_repository_step_removes_publish_authority():
     assert plan["nodes"][1]["inputs"]["repositoryOperation"] == "read"
     assert plan["nodes"][1]["inputs"]["publishMode"] == "none"
 
+
+def test_runtime_planner_pr_step_defaults_repository_write_authority():
+    planner = _build_runtime_planner()
+    snapshot = _make_snapshot()
+
+    plan = planner(
+        inputs={
+            "task": {
+                "instructions": "Implement the change",
+                "runtime": {"mode": "omnigent"},
+                "publish": {"mode": "pr"},
+                "steps": [
+                    {
+                        "id": "implement",
+                        "instructions": "Implement the change.",
+                    }
+                ],
+            }
+        },
+        parameters={},
+        snapshot=snapshot,
+    )
+
+    assert plan["nodes"][0]["inputs"]["repositoryOperation"] == "write"
+
+
 def test_runtime_planner_multi_step_auto_generated_ids():
     """When steps lack explicit IDs, sequential IDs are generated."""
     planner = _build_runtime_planner()

--- a/tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py
@@ -43,6 +43,7 @@ from moonmind.workflows.temporal.workflows.run import (
     RUN_OMNIGENT_CHECKPOINT_BRANCH_TURN_REQUEST_PATCH,
     RUN_OMNIGENT_STOCK_AGENT_IDENTITY_PATCH,
     RUN_PR_RESOLVER_SKILL_OWNED_EXECUTION_PATCH,
+    RUN_PUBLISH_MODE_REPOSITORY_OPERATION_PATCH,
     RUN_PUBLISHED_BRANCH_HANDOFF_PATCH,
     RUN_REPOSITORY_BOUND_NO_COMMIT_OUTCOME_PATCH,
     RUN_RESOLVED_SKILL_TERMINAL_CONTRACT_PATCH,
@@ -4143,6 +4144,56 @@ class TestEnsureAssessmentParameters(unittest.TestCase):
         self.assertEqual(
             request.workspace_spec["targetBranch"],
             "moonmind-job-2602f4e9",
+        )
+        self.assertEqual(request.parameters["repositoryOperation"], "write")
+
+    def test_pr_publish_request_defaults_to_write_on_published_branch(self) -> None:
+        wf = MoonMindRunWorkflow()
+        wf._publish_context.update(
+            {
+                "pushStatus": "pushed",
+                "branch": "moonmind-job-24a73665",
+                "headSha": "b651c9e47fe6e7696ef575b6969ed7d682c78338",
+                "baseRef": "main",
+            }
+        )
+        info = SimpleNamespace(
+            namespace="default",
+            workflow_id="mm:6103dddf-2e68-4185-9481-5668d5916642",
+            run_id="019fe3a7-4522-78a5-af30-9ea9a5a03311",
+            parent=None,
+        )
+        with (
+            patch(
+                "moonmind.workflows.temporal.workflows.run.workflow.info",
+                return_value=info,
+            ),
+            patch(
+                "moonmind.workflows.temporal.workflows.run.workflow.patched",
+                side_effect=lambda patch_id: patch_id
+                in {
+                    RUN_PUBLISHED_BRANCH_HANDOFF_PATCH,
+                    RUN_PUBLISH_MODE_REPOSITORY_OPERATION_PATCH,
+                },
+            ),
+        ):
+            request = wf._build_agent_execution_request(
+                node_inputs={
+                    "targetRuntime": "omnigent",
+                    "repository": "MoonLadderStudios/MoonMind",
+                    "startingBranch": "main",
+                    "targetBranch": "generated-plan-branch",
+                    "publishMode": "pr",
+                },
+                node_id="implement",
+                tool_name="omnigent",
+            )
+
+        assert request.workspace_spec is not None
+        self.assertEqual(request.workspace_spec["startingBranch"], "main")
+        self.assertEqual(
+            request.workspace_spec["targetBranch"],
+            "moonmind-job-24a73665",
         )
         self.assertEqual(request.parameters["repositoryOperation"], "write")
 


### PR DESCRIPTION
## Summary

- compile omitted `repositoryOperation` as `write` for agent-runtime steps using managed branch or PR publication
- preserve the authored PR base while downstream steps continue from the verified cumulative candidate head
- document the publication contract and add regression coverage for read-only preset expansion
- add a minimized production replay for workflow `mm:6103dddf-2e68-4185-9481-5668d5916642`

## Root cause

The failed workflow's assessment step published the implementation commit to `moonmind-job-24a73665`. The downstream implementation step correctly started from that verified candidate, but its older plan omitted `repositoryOperation`. Published-branch handoff therefore treated the candidate as both the source and publication base. Omnigent compared the branch to itself, reported zero commits, and exhausted eight same-session continuations across four execution attempts with `OMNIGENT_REPOSITORY_OUTPUT_MISSING`.

Current preset expansion already marks assessment and verification steps read-only. This change also makes the complementary write default explicit in new durable plans and repairs older omitted-operation plans behind a replay-safe Temporal patch.

## Impact

Multi-step PR and branch workflows can reuse work produced by an earlier accepted step without being forced to create a redundant commit. The candidate remains pinned to its remotely verified SHA and is compared against the original authored base branch.

## Validation

- `./tools/test_unit.sh --python-only tests/unit/workflows/temporal/test_temporal_worker_runtime.py tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py` (246 passed, 9 subtests passed)
- `./tools/test_unit.sh --python-only tests/unit/workflows/temporal/workflows/test_run_integration.py` (204 passed)
- `./tools/test_unit.sh --python-only tests/integration/reliability/test_escaped_failure_journeys.py::test_omnigent_pr_step_reuses_candidate_against_original_base` (1 passed)
- `./tools/test_unit.sh --python-only tests/unit/api/test_presets_service.py::test_seed_catalog_github_issue_implement_expands_shared_includes` (1 passed)
- `git diff --check`
