### PR TITLE
Filter batch workflows to open GitHub issues

### DIFF
--- a/.agents/skills/batch-workflows/SKILL.md
+++ b/.agents/skills/batch-workflows/SKILL.md
@@ -48,7 +48,7 @@ Progress" with a single batch run.
 - `additional_jql` (string, optional): advanced JQL AND-clause appended to the
   project/status query.
 - `issue_range` (string, GitHub preset only): inclusive `START-END` search
-  criteria. Numeric members are not targets unless GitHub returns an Issue.
+  criteria. Numeric members are targets only when GitHub returns an open Issue.
 - `repository` (string, optional): repository override when workflow context
   cannot infer it.
 - `publish_mode` (string, optional): advanced child publish override, `none`,
@@ -83,10 +83,11 @@ Progress" with a single batch run.
    For GitHub, the inclusive number range is search criteria, not a target list.
    GitHub issues and pull requests share numbers, and numbers may be absent. Use
    the helper's `--github-issue-range` plus `--github-repository` inputs so its
-   trusted GraphQL `issue(number:)` lookup returns only real Issue objects.
-   Pull requests and absent numbers are omitted normally and never become
-   targets. The helper rejects numeric spans wider than 1,000 numbers before
-   querying GitHub and writes the resolved target artifact before queueing.
+   trusted GraphQL `issue(number:)` lookup returns only open Issue objects.
+   Closed issues, pull requests, absent numbers, and responses without an
+   explicit open state are omitted normally and never become targets. The helper
+   rejects numeric spans wider than 1,000 numbers before querying GitHub and
+   writes the resolved target artifact before queueing.
 
 2. **Queue child workflows** by running the helper:
 

--- a/.agents/skills/batch-workflows/bin/batch_workflows.py
+++ b/.agents/skills/batch-workflows/bin/batch_workflows.py
@@ -182,11 +182,12 @@ def resolve_github_issue_range(
     *,
     run_command: Any = subprocess.run,
 ) -> list[dict[str, Any]]:
-    """Return only GitHub Issue objects whose numbers fall in ``issue_range``.
+    """Return only open GitHub Issues whose numbers fall in ``issue_range``.
 
     GitHub's shared issue/PR numbering means numeric members of the range may be
     pull requests or may not exist. Querying the GraphQL ``issue(number:)`` field
     makes those entries resolve to null, so neither can become a workflow target.
+    Closed issues and responses without an explicit open state are also omitted.
     """
 
     owner, name = _github_repository_parts(repository)
@@ -270,6 +271,9 @@ def resolve_github_issue_range(
             issue = repository_data.get(f"issue{number}")
             if not isinstance(issue, dict):
                 continue
+            issue_state = (_text(issue.get("state")) or "").upper()
+            if issue_state != "OPEN":
+                continue
             labels_node = (
                 issue.get("labels") if isinstance(issue.get("labels"), dict) else {}
             )
@@ -289,7 +293,7 @@ def resolve_github_issue_range(
                         "title": str(issue.get("title") or ""),
                         "body": str(issue.get("body") or ""),
                         "url": str(issue.get("url") or ""),
-                        "state": str(issue.get("state") or "").lower(),
+                        "state": issue_state.lower(),
                         "labels": labels,
                     },
                     "repository": normalized_repository,

--- a/api_service/data/presets/batch-github-workflows.yaml
+++ b/api_service/data/presets/batch-github-workflows.yaml
@@ -1,8 +1,8 @@
 slug: batch-github-workflows
 title: Batch GitHub Workflows
 description: Resolve an inclusive GitHub issue-number range and queue one GitHub
-  Issue Implement or GitHub Issue Orchestrate workflow per existing issue in the
-  range with inherited runtime settings and a shared publish override.
+  Issue Implement or GitHub Issue Orchestrate workflow per open issue in the range
+  with inherited runtime settings and a shared publish override.
 scope: global
 tags:
 - batch
@@ -143,18 +143,19 @@ steps:
     Treat the inclusive GitHub issue-number range "{{ inputs.issue_range }}" as
     search criteria for repository "{{ inputs.repository }}", not as a list of
     targets. GitHub issues and pull requests share numbering, and some numbers may
-    not exist. Queue children only for Issue objects returned by GitHub; never queue
-    a pull request or fabricate a target for an absent number. When the repository
-    input is empty, use the repository from workflow context. Do not re-select
-    provider, model, or effort: every child inherits the parent runtime via
-    runtimeInheritance="caller".
+    not exist. Queue children only for open Issue objects returned by GitHub; never
+    queue a closed issue or pull request, or fabricate a target for an absent
+    number. When the repository input is empty, use the repository from workflow
+    context. Do not re-select provider, model, or effort: every child inherits the
+    parent runtime via runtimeInheritance="caller".
 
     Resolve the range and queue each matched issue with "{{ inputs.run_ref }}" and
     publish override "{{ inputs.publish_mode }}" using one helper invocation. The
-    portable helper performs the trusted GitHub query, excludes pull requests and
-    absent numbers, rejects numeric spans wider than 1,000 before querying, writes
+    portable helper performs the trusted GitHub query, excludes closed issues,
+    pull requests, absent numbers, and responses without an explicit open state,
+    rejects numeric spans wider than 1,000 before querying, writes
     artifacts/batch-workflows-targets.json, applies max_workflows to the resolved
-    Issue objects, and queues the children:
+    open Issue objects, and queues the children:
     python3 "$MOONMIND_ACTIVE_SKILLS_DIR/batch-workflows/bin/batch_workflows.py" \
     --github-issue-range "{{ inputs.issue_range }}" \
     --github-repository "{{ inputs.repository }}" \

--- a/tests/unit/api/test_batch_github_workflows_preset.py
+++ b/tests/unit/api/test_batch_github_workflows_preset.py
@@ -88,7 +88,7 @@ async def test_batch_github_workflows_seed_and_expansion_contract(tmp_path):
         '--github-repository "MoonLadderStudios/MoonMind"'
         in step["instructions"]
     )
-    assert "only for Issue objects returned by GitHub" in step["instructions"]
+    assert "only for open Issue objects returned by GitHub" in step["instructions"]
     assert (
         "--targets artifacts/batch-workflows-targets.json"
         not in step["instructions"]

--- a/tests/unit/test_batch_workflows.py
+++ b/tests/unit/test_batch_workflows.py
@@ -124,7 +124,7 @@ def test_parse_github_issue_range_rejects_invalid_search_criteria(value):
         module["parse_github_issue_range"](value)
 
 
-def test_resolve_github_issue_range_excludes_pull_requests_and_absent_numbers():
+def test_resolve_github_issue_range_excludes_non_open_issues_and_missing_numbers():
     module = _load_module()
     calls: list[list[str]] = []
 
@@ -155,6 +155,22 @@ def test_resolve_github_issue_range_excludes_pull_requests_and_absent_numbers():
                             # request number and a number that does not exist.
                             "issue41": None,
                             "issue42": None,
+                            "issue43": {
+                                "number": 43,
+                                "title": "Closed issue",
+                                "body": "Already completed",
+                                "url": "https://github.com/acme/widgets/issues/43",
+                                "state": "CLOSED",
+                                "labels": {"nodes": [{"name": "done"}]},
+                            },
+                            "issue44": {
+                                "number": 44,
+                                "title": "Issue with unusable state",
+                                "body": "Provider response is incomplete",
+                                "url": "https://github.com/acme/widgets/issues/44",
+                                "state": "",
+                                "labels": {"nodes": []},
+                            },
                         }
                     },
                     "errors": [
@@ -180,7 +196,7 @@ def test_resolve_github_issue_range_excludes_pull_requests_and_absent_numbers():
 
     targets = module["resolve_github_issue_range"](
         "acme/widgets",
-        "40-42",
+        "40-44",
         run_command=fake_run,
     )
 
@@ -199,6 +215,8 @@ def test_resolve_github_issue_range_excludes_pull_requests_and_absent_numbers():
     assert "issue40: issue(number: 40)" in query_arg
     assert "issue41: issue(number: 41)" in query_arg
     assert "issue42: issue(number: 42)" in query_arg
+    assert "issue43: issue(number: 43)" in query_arg
+    assert "issue44: issue(number: 44)" in query_arg
     assert "-F" not in calls[0]
     assert calls[0].count("-f") == 3
     assert "owner=acme" in calls[0]


### PR DESCRIPTION
## Summary

- admit only GitHub issues whose GraphQL state is explicitly `OPEN` during batch range resolution
- fail closed for closed, blank-state, missing, and pull-request range members before target evidence or child queueing
- align the portable skill and Batch GitHub Workflows preset with the open-only contract
- add regression coverage for closed and malformed-state issue responses

## Root cause

The prior range-discovery fix queried each number through GitHub's `issue(number:)` field, which correctly excluded pull requests and missing numbers. It also fetched each issue's state, but copied that state into the target without checking it. As a result, closed issues were still written to the resolved target artifact and queued.

## Validation

- `./tools/test_unit.sh tests/unit/test_batch_workflows.py tests/unit/api/test_batch_github_workflows_preset.py --python-only` — 44 passed
- live read-only resolution of `MoonLadderStudios/MoonMind` range `3621-3642` — 9 targets, all `open`
- `git diff --check`
