### PR TITLE
MoonLadderStudios/MoonMind#3624: make remediation capabilities truthful

### DIFF
--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -11807,77 +11807,6 @@ def _serialize_remediation_link_summary(link: Any) -> RemediationLinkSummaryMode
         status_value=status_value,
     )
 
-async def _attach_remediation_capability_projection(
-    link: Any, *, session: AsyncSession
-) -> None:
-    """Resolve exact-target inputs that are intentionally absent from the link row."""
-
-    target = await session.get(
-        db_models.TemporalExecutionCanonicalRecord,
-        str(getattr(link, "target_workflow_id", "")),
-    )
-    remediation = await session.get(
-        db_models.TemporalExecutionCanonicalRecord,
-        str(getattr(link, "remediation_workflow_id", "")),
-    )
-    if target is None or remediation is None:
-        link.current_target_state = "missing"
-        link.allowed_actions = ()
-        link.evidence_degraded = True
-        link.unavailable_evidence_classes = ("target_identity",)
-        return
-
-    link.current_target_state = _enum_value(getattr(target, "state", None))
-    target_parameters = dict(getattr(target, "parameters", None) or {})
-    target_workflow = target_parameters.get("workflow") or target_parameters.get("task")
-    target_workflow = target_workflow if isinstance(target_workflow, Mapping) else {}
-    runtime = target_workflow.get("runtime")
-    runtime = runtime if isinstance(runtime, Mapping) else {}
-    search_attributes = dict(getattr(target, "search_attributes", None) or {})
-    link.target_runtime = (
-        str(
-            runtime.get("mode")
-            or target_parameters.get("targetRuntime")
-            or search_attributes.get("mm_target_runtime")
-            or ""
-        ).strip()
-        or None
-    )
-
-    remediation_parameters = dict(getattr(remediation, "parameters", None) or {})
-    remediation_workflow = remediation_parameters.get("workflow") or remediation_parameters.get("task")
-    remediation_workflow = (
-        remediation_workflow if isinstance(remediation_workflow, Mapping) else {}
-    )
-    policy = remediation_workflow.get("remediation")
-    policy = policy if isinstance(policy, Mapping) else {}
-    link.allowed_actions = (
-        remediation_action_kinds()
-        if policy.get("actionPolicyRef") == "admin_healer_default"
-        else ()
-    )
-
-    bridge = (
-        await session.execute(
-            select(db_models.OmnigentBridgeSession)
-            .where(
-                db_models.OmnigentBridgeSession.moonmind_workflow_id
-                == link.target_workflow_id,
-                db_models.OmnigentBridgeSession.moonmind_run_id == link.target_run_id,
-            )
-            .order_by(db_models.OmnigentBridgeSession.updated_at.desc())
-            .limit(1)
-        )
-    ).scalar_one_or_none()
-    launch = (
-        bridge.effective_launch_snapshot_json
-        if bridge is not None
-        and isinstance(bridge.effective_launch_snapshot_json, Mapping)
-        else {}
-    )
-    link.host_mode = str(launch.get("hostMode") or "").strip() or None
-    link.evidence_degraded = False
-    link.unavailable_evidence_classes = ()
     policy_actions = _bounded_string_list(getattr(link, "allowed_actions", None))
     target_state = str(getattr(link, "current_target_state", "") or "").strip()
     unavailable_evidence = set(
@@ -11951,6 +11880,84 @@ async def _attach_remediation_capability_projection(
         createdAt=getattr(link, "created_at", None),
         updatedAt=getattr(link, "updated_at", None),
     )
+
+
+async def _attach_remediation_capability_projection(
+    link: Any, *, session: AsyncSession
+) -> None:
+    """Resolve exact-target inputs that are intentionally absent from the link row."""
+
+    target = await session.get(
+        db_models.TemporalExecutionCanonicalRecord,
+        str(getattr(link, "target_workflow_id", "")),
+    )
+    remediation = await session.get(
+        db_models.TemporalExecutionCanonicalRecord,
+        str(getattr(link, "remediation_workflow_id", "")),
+    )
+    if target is None or remediation is None:
+        link.current_target_state = "missing"
+        link.allowed_actions = ()
+        link.evidence_degraded = True
+        link.unavailable_evidence_classes = ("target_identity",)
+        return
+
+    link.current_target_state = _enum_value(getattr(target, "state", None))
+    target_parameters = dict(getattr(target, "parameters", None) or {})
+    target_workflow = target_parameters.get("workflow") or target_parameters.get(
+        "task"
+    )
+    target_workflow = target_workflow if isinstance(target_workflow, Mapping) else {}
+    runtime = target_workflow.get("runtime")
+    runtime = runtime if isinstance(runtime, Mapping) else {}
+    search_attributes = dict(getattr(target, "search_attributes", None) or {})
+    link.target_runtime = (
+        str(
+            runtime.get("mode")
+            or target_parameters.get("targetRuntime")
+            or search_attributes.get("mm_target_runtime")
+            or ""
+        ).strip()
+        or None
+    )
+
+    remediation_parameters = dict(getattr(remediation, "parameters", None) or {})
+    remediation_workflow = remediation_parameters.get(
+        "workflow"
+    ) or remediation_parameters.get("task")
+    remediation_workflow = (
+        remediation_workflow if isinstance(remediation_workflow, Mapping) else {}
+    )
+    policy = remediation_workflow.get("remediation")
+    policy = policy if isinstance(policy, Mapping) else {}
+    link.allowed_actions = (
+        remediation_action_kinds()
+        if policy.get("actionPolicyRef") == "admin_healer_default"
+        else ()
+    )
+
+    bridge = (
+        await session.execute(
+            select(db_models.OmnigentBridgeSession)
+            .where(
+                db_models.OmnigentBridgeSession.moonmind_workflow_id
+                == link.target_workflow_id,
+                db_models.OmnigentBridgeSession.moonmind_run_id == link.target_run_id,
+            )
+            .order_by(db_models.OmnigentBridgeSession.updated_at.desc())
+            .limit(1)
+        )
+    ).scalar_one_or_none()
+    launch = (
+        bridge.effective_launch_snapshot_json
+        if bridge is not None
+        and isinstance(bridge.effective_launch_snapshot_json, Mapping)
+        else {}
+    )
+    link.host_mode = str(launch.get("hostMode") or "").strip() or None
+    link.evidence_degraded = False
+    link.unavailable_evidence_classes = ()
+
 
 def _remediation_approval_request_id(remediation_workflow_id: str) -> str:
     return f"{remediation_workflow_id}:approval"

--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -89,6 +89,11 @@ from moonmind.workflows.executions.title_derivation import (
     is_generic_title,
     synthesize_workflow_title,
 )
+from moonmind.workflows.temporal.remediation_actions import (
+    RemediationCapabilityContext,
+    remediation_action_capability_matrix,
+)
+from api_service.services.remediation_actions import build_remediation_action_executor
 from moonmind.runtime_intent import (
     RuntimeIntentValidationError,
     validate_runtime_tier_intent,
@@ -659,6 +664,19 @@ class RemediationCheckpointBranchLinkModel(BaseModel):
             raise ValueError("next action baseline must match the persisted head")
         return self
 
+class RemediationActionCapabilityModel(BaseModel):
+    actionKind: str
+    requestable: bool
+    dryRunSupported: bool
+    executionBackendReady: bool
+    approvalBackendReady: bool
+    verificationBackendReady: bool
+    supportedTargetRuntimes: list[str]
+    supportedHostModes: list[str]
+    requiredEvidenceClasses: list[str]
+    blockedReasons: list[str]
+
+
 class RemediationLinkSummaryModel(BaseModel):
     remediationWorkflowId: str
     remediationRunId: str
@@ -679,6 +697,9 @@ class RemediationLinkSummaryModel(BaseModel):
     selectedSteps: list[str] | None = None
     currentTargetState: str | None = None
     allowedActions: list[str] | None = None
+    actionCapabilities: list[RemediationActionCapabilityModel] = Field(
+        default_factory=list
+    )
     evidenceDegraded: bool | None = None
     unavailableEvidenceClasses: list[str] | None = None
     liveObservation: RemediationLiveObservationModel | None = None
@@ -11784,6 +11805,44 @@ def _serialize_remediation_link_summary(link: Any) -> RemediationLinkSummaryMode
         authority_mode=authority_mode,
         status_value=status_value,
     )
+    policy_actions = _bounded_string_list(getattr(link, "allowed_actions", None))
+    target_state = str(getattr(link, "current_target_state", "") or "").strip()
+    unavailable_evidence = set(
+        _bounded_string_list(getattr(link, "unavailable_evidence_classes", None)) or []
+    )
+    known_evidence = {
+        "execution_state",
+        "workflow_history",
+        "target_identity",
+        "action_result",
+        "continuity_boundary",
+    } - unavailable_evidence
+    approval_backend_ready = authority_mode == "admin_auto" or (
+        authority_mode == "approval_gated"
+        and isinstance(getattr(link, "approval_state", None), dict)
+    )
+    executor = build_remediation_action_executor()
+    backend_readiness = {
+        action_kind: action_kind in executor._adapters
+        for action_kind in (row["actionKind"] for row in remediation_action_capability_matrix())
+    }
+    capability_context = RemediationCapabilityContext(
+        target_runtime=(str(getattr(link, "target_runtime", "") or "").strip() or None),
+        host_mode=(str(getattr(link, "host_mode", "") or "").strip() or None),
+        target_state_eligible=target_state.lower() not in {"unknown", "missing"},
+        current_evidence_classes=tuple(sorted(known_evidence)),
+        require_current_evidence=bool(getattr(link, "evidence_degraded", False)),
+        # Missing persisted policy projection is not permission to advertise
+        # every catalog action. Fail closed until the owning projection supplies
+        # the immutable target-policy intersection.
+        policy_allowed_action_kinds=tuple(policy_actions or ()),
+        caller_allowed_action_kinds=tuple(policy_actions or ()),
+        execution_backend_readiness=backend_readiness,
+        approval_backend_ready=approval_backend_ready,
+    )
+    capability_matrix = [
+        dict(row) for row in remediation_action_capability_matrix(context=capability_context)
+    ]
 
     return RemediationLinkSummaryModel(
         remediationWorkflowId=str(getattr(link, "remediation_workflow_id", "")),
@@ -11801,7 +11860,12 @@ def _serialize_remediation_link_summary(link: Any) -> RemediationLinkSummaryMode
         contextArtifactRef=getattr(link, "context_artifact_ref", None),
         selectedSteps=_bounded_string_list(getattr(link, "selected_steps", None)),
         currentTargetState=getattr(link, "current_target_state", None),
-        allowedActions=_bounded_string_list(getattr(link, "allowed_actions", None)),
+        allowedActions=[
+            str(row["actionKind"])
+            for row in capability_matrix
+            if row["requestable"] is True
+        ],
+        actionCapabilities=capability_matrix,
         evidenceDegraded=getattr(link, "evidence_degraded", None),
         unavailableEvidenceClasses=_bounded_string_list(
             getattr(link, "unavailable_evidence_classes", None)

--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -41,6 +41,7 @@ from temporalio.service import RPCError
 from api_service.api.dependencies import resolve_template_scope_for_user
 from api_service.auth_providers import get_current_user
 from api_service.core import sync as execution_sync
+from api_service.db import models as db_models
 from api_service.db.base import async_session_maker, get_async_session
 from api_service.db.models import (
     AgentSkillDefinition,

--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -92,6 +92,7 @@ from moonmind.workflows.executions.title_derivation import (
 from moonmind.workflows.temporal.remediation_actions import (
     RemediationCapabilityContext,
     remediation_action_capability_matrix,
+    remediation_action_kinds,
 )
 from api_service.services.remediation_actions import build_remediation_action_executor
 from moonmind.runtime_intent import (
@@ -11805,6 +11806,78 @@ def _serialize_remediation_link_summary(link: Any) -> RemediationLinkSummaryMode
         authority_mode=authority_mode,
         status_value=status_value,
     )
+
+async def _attach_remediation_capability_projection(
+    link: Any, *, session: AsyncSession
+) -> None:
+    """Resolve exact-target inputs that are intentionally absent from the link row."""
+
+    target = await session.get(
+        db_models.TemporalExecutionCanonicalRecord,
+        str(getattr(link, "target_workflow_id", "")),
+    )
+    remediation = await session.get(
+        db_models.TemporalExecutionCanonicalRecord,
+        str(getattr(link, "remediation_workflow_id", "")),
+    )
+    if target is None or remediation is None:
+        link.current_target_state = "missing"
+        link.allowed_actions = ()
+        link.evidence_degraded = True
+        link.unavailable_evidence_classes = ("target_identity",)
+        return
+
+    link.current_target_state = _enum_value(getattr(target, "state", None))
+    target_parameters = dict(getattr(target, "parameters", None) or {})
+    target_workflow = target_parameters.get("workflow") or target_parameters.get("task")
+    target_workflow = target_workflow if isinstance(target_workflow, Mapping) else {}
+    runtime = target_workflow.get("runtime")
+    runtime = runtime if isinstance(runtime, Mapping) else {}
+    search_attributes = dict(getattr(target, "search_attributes", None) or {})
+    link.target_runtime = (
+        str(
+            runtime.get("mode")
+            or target_parameters.get("targetRuntime")
+            or search_attributes.get("mm_target_runtime")
+            or ""
+        ).strip()
+        or None
+    )
+
+    remediation_parameters = dict(getattr(remediation, "parameters", None) or {})
+    remediation_workflow = remediation_parameters.get("workflow") or remediation_parameters.get("task")
+    remediation_workflow = (
+        remediation_workflow if isinstance(remediation_workflow, Mapping) else {}
+    )
+    policy = remediation_workflow.get("remediation")
+    policy = policy if isinstance(policy, Mapping) else {}
+    link.allowed_actions = (
+        remediation_action_kinds()
+        if policy.get("actionPolicyRef") == "admin_healer_default"
+        else ()
+    )
+
+    bridge = (
+        await session.execute(
+            select(db_models.OmnigentBridgeSession)
+            .where(
+                db_models.OmnigentBridgeSession.moonmind_workflow_id
+                == link.target_workflow_id,
+                db_models.OmnigentBridgeSession.moonmind_run_id == link.target_run_id,
+            )
+            .order_by(db_models.OmnigentBridgeSession.updated_at.desc())
+            .limit(1)
+        )
+    ).scalar_one_or_none()
+    launch = (
+        bridge.effective_launch_snapshot_json
+        if bridge is not None
+        and isinstance(bridge.effective_launch_snapshot_json, Mapping)
+        else {}
+    )
+    link.host_mode = str(launch.get("hostMode") or "").strip() or None
+    link.evidence_degraded = False
+    link.unavailable_evidence_classes = ()
     policy_actions = _bounded_string_list(getattr(link, "allowed_actions", None))
     target_state = str(getattr(link, "current_target_state", "") or "").strip()
     unavailable_evidence = set(
@@ -11817,10 +11890,7 @@ def _serialize_remediation_link_summary(link: Any) -> RemediationLinkSummaryMode
         "action_result",
         "continuity_boundary",
     } - unavailable_evidence
-    approval_backend_ready = authority_mode == "admin_auto" or (
-        authority_mode == "approval_gated"
-        and isinstance(getattr(link, "approval_state", None), dict)
-    )
+    approval_backend_ready = authority_mode in {"admin_auto", "approval_gated"}
     executor = build_remediation_action_executor()
     backend_readiness = {
         action_kind: action_kind in executor._adapters
@@ -12044,6 +12114,7 @@ async def list_execution_remediations(
     workflow_id: str,
     direction: str = Query("inbound"),
     service: TemporalExecutionService = Depends(_get_service),
+    session: AsyncSession = Depends(get_async_session),
     user: User = Depends(get_current_user()),
 ) -> RemediationLinksResponseModel:
     if direction not in {"inbound", "outbound"}:
@@ -12061,6 +12132,12 @@ async def list_execution_remediations(
     else:
         links = await service.list_remediation_targets(workflow_id)
 
+    await asyncio.gather(
+        *(
+            _attach_remediation_capability_projection(link, session=session)
+            for link in links
+        )
+    )
     return RemediationLinksResponseModel(
         direction=direction,
         items=[_serialize_remediation_link_summary(link) for link in links],

--- a/api_service/services/omnigent_policies.py
+++ b/api_service/services/omnigent_policies.py
@@ -686,11 +686,7 @@ async def resolve_bootstrap_image_refs(
 # listed explicitly (not imported) to keep the seed reviewable and to avoid a
 # circular import with the temporal remediation package; a unit test guards
 # against catalog drift.
-_BOOTSTRAP_ALLOWED_REMEDIATION_ACTIONS: tuple[str, ...] = (
-    "cleanup.verify",
-    "target.annotate",
-    "target.verify",
-)
+_BOOTSTRAP_ALLOWED_REMEDIATION_ACTIONS: tuple[str, ...] = ()
 _BOOTSTRAP_APPROVAL_REMEDIATION_ACTIONS: tuple[str, ...] = (
     "execution.pause",
     "execution.resume",
@@ -699,20 +695,6 @@ _BOOTSTRAP_APPROVAL_REMEDIATION_ACTIONS: tuple[str, ...] = (
     "execution.cancel",
     "execution.force_terminate",
     "checkpoint_branch.create_from_remediation_context",
-    "session.interrupt_turn",
-    "session.clear",
-    "session.cancel",
-    "session.terminate",
-    "session.restart_container",
-    "provider_profile.evict_stale_lease",
-    "workload.restart_helper_container",
-    "workload.reap_orphan_container",
-    "host.drain",
-    "host.stop",
-    "host.restart",
-    "host.remove",
-    "host_lease.reconcile_stale",
-    "cleanup.request_janitor",
 )
 
 

--- a/api_service/services/remediation_actions.py
+++ b/api_service/services/remediation_actions.py
@@ -16,9 +16,13 @@ from moonmind.omnigent.policies import (
     validate_approval_binding,
 )
 from moonmind.workflows.temporal.client import TemporalClientAdapter
+from moonmind.workflows.temporal.remediation_actions import remediation_action_kinds
 from moonmind.workflows.temporal.remediation_tools import (
     MoonMindControlPlaneRemediationActionExecutor,
     RemediationTargetHealthSnapshot,
+)
+from moonmind.workflows.temporal.remediation_verification import (
+    verification_contract_for,
 )
 from moonmind.workflows.temporal.service import TemporalExecutionService
 
@@ -213,7 +217,7 @@ class TemporalRemediationControlPlane:
         # evidence and classifies the actual repair outcome (issue #3622); this
         # adapter no longer claims "verified" immediately after persistence.
         return {
-            "status": "applied",
+            "status": "accepted",
             "message": "Checkpoint Branch was persisted by its durable owner.",
             "beforeEvidenceRefs": before,
             "afterEvidenceRefs": [
@@ -226,6 +230,9 @@ class TemporalRemediationControlPlane:
                 "Re-verify the target objective from fresh evidence; a persisted "
                 "branch is a remediation candidate, not a confirmed repair."
             ),
+            "deliveryStage": "branch_graph_created",
+            "branchTurnLaunched": False,
+            "terminalBranchResultAvailable": False,
         }
 
     async def session_control(
@@ -349,24 +356,30 @@ class TemporalRemediationControlPlane:
             target: RemediationTargetHealthSnapshot,
         ) -> Mapping[str, Any]:
             before = [f"execution:{target.workflow_id}:run:{target.current_run_id}"]
+            action_id = str(action_request.get("actionId") or "").strip()
+            action_kind = str(action_request.get("actionKind") or "").strip()
+            target_identity = {
+                "workflowId": target.workflow_id,
+                "runId": target.current_run_id,
+            }
             try:
-                return await handler(action_request, guard_result, target)
+                result = dict(await handler(action_request, guard_result, target))
             except ValueError as exc:
-                return {
+                result = {
                     "status": "precondition_failed",
                     "reason": str(exc),
                     "beforeEvidenceRefs": before,
                     "afterEvidenceRefs": [],
                 }
             except asyncio.TimeoutError:
-                return {
+                result = {
                     "status": "timed_out",
                     "reason": "owning control plane timed out",
                     "beforeEvidenceRefs": before,
                     "afterEvidenceRefs": [],
                 }
             except Exception as exc:
-                return {
+                result = {
                     "status": "delivery_unknown",
                     "reason": (
                         "owning control plane did not return authoritative "
@@ -375,6 +388,19 @@ class TemporalRemediationControlPlane:
                     "beforeEvidenceRefs": before,
                     "afterEvidenceRefs": [],
                 }
+            result.setdefault("beforeEvidenceRefs", [])
+            result.setdefault("afterEvidenceRefs", [])
+            result["idempotencyIdentity"] = action_id
+            result["targetIdentity"] = target_identity
+            result["resultIdentity"] = {
+                "actionId": action_id,
+                "actionKind": action_kind,
+                "targetWorkflowId": target.workflow_id,
+            }
+            result["verificationContract"] = verification_contract_for(
+                action_kind
+            ).to_payload()
+            return result
 
         return execute
 
@@ -544,8 +570,13 @@ def build_remediation_action_executor(
             CheckpointBranchService(session) if session is not None else None
         ),
     )
+    ready = set(remediation_action_kinds())
     return MoonMindControlPlaneRemediationActionExecutor(
-        plane.handlers(enforce_policy=True)
+        {
+            action_kind: handler
+            for action_kind, handler in plane.handlers(enforce_policy=True).items()
+            if action_kind in ready
+        }
     )
 
 

--- a/docs/Workflows/WorkflowRemediation.md
+++ b/docs/Workflows/WorkflowRemediation.md
@@ -606,6 +606,19 @@ The remediation runtime should not scrape dashboard pages. It should receive a M
   Live follow when supported.
 
 - `remediation.list_allowed_actions()`
+
+Action discovery is capability-truthful. Each catalog identity has an
+independently evaluated capability row containing `requestable`,
+`dryRunSupported`, `executionBackendReady`, `approvalBackendReady`,
+`verificationBackendReady`, `supportedTargetRuntimes`, `supportedHostModes`,
+`requiredEvidenceClasses`, and bounded `blockedReasons`. The executable list is
+the intersection of catalog enablement, caller/profile permission, an owning
+execution adapter, durable approval support, and an authoritative verifier.
+Actions without both an execution owner and verifier remain visible only in the
+capability matrix and are rejected before mutation. In particular, managed
+session terminate/restart, targeted janitor cleanup, cleanup verification,
+target annotation/verification, helper-container, and Omnigent host/lease
+actions are not executable until their missing owners are wired.
   Return action kinds allowed by `actionPolicyRef`.
 
 - `remediation.execute_action(actionKind, params, dryRun?)`

--- a/docs/Workflows/WorkflowRemediation.md
+++ b/docs/Workflows/WorkflowRemediation.md
@@ -612,13 +612,22 @@ independently evaluated capability row containing `requestable`,
 `dryRunSupported`, `executionBackendReady`, `approvalBackendReady`,
 `verificationBackendReady`, `supportedTargetRuntimes`, `supportedHostModes`,
 `requiredEvidenceClasses`, and bounded `blockedReasons`. The executable list is
-the intersection of catalog enablement, caller/profile permission, an owning
-execution adapter, durable approval support, and an authoritative verifier.
+the intersection of catalog enablement, immutable target policy,
+caller/profile permission, current target state and evidence, action-specific
+runtime and host support, live owning execution-adapter readiness, durable
+approval support, and authoritative verifier readiness. The owning service
+evaluates those inputs for the exact remediation link; static catalog
+enablement is not backend readiness.
 Actions without both an execution owner and verifier remain visible only in the
 capability matrix and are rejected before mutation. In particular, managed
 session terminate/restart, targeted janitor cleanup, cleanup verification,
 target annotation/verification, helper-container, and Omnigent host/lease
 actions are not executable until their missing owners are wired.
+Workflow Detail publishes the full evaluated matrix as `actionCapabilities`;
+`allowedActions` is derived only from rows whose `requestable` value is true.
+Disabled rows retain bounded reasons so operators can distinguish policy,
+target/evidence, runtime/host, execution, approval, and verification blockers
+before requesting an action.
   Return action kinds allowed by `actionPolicyRef`.
 
 - `remediation.execute_action(actionKind, params, dryRun?)`

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -1065,6 +1065,21 @@ const RemediationLockOutcomeSchema = z
   })
   .passthrough();
 
+const RemediationActionCapabilitySchema = z
+  .object({
+    actionKind: z.string(),
+    requestable: z.boolean(),
+    dryRunSupported: z.boolean(),
+    executionBackendReady: z.boolean(),
+    approvalBackendReady: z.boolean(),
+    verificationBackendReady: z.boolean(),
+    supportedTargetRuntimes: z.array(z.string()),
+    supportedHostModes: z.array(z.string()),
+    requiredEvidenceClasses: z.array(z.string()),
+    blockedReasons: z.array(z.string()),
+  })
+  .passthrough();
+
 const RemediationLinkSchema = z
   .object({
     remediationWorkflowId: z.string(),
@@ -1083,6 +1098,7 @@ const RemediationLinkSchema = z
     selectedSteps: z.array(z.string()).nullable().optional(),
     currentTargetState: z.string().nullable().optional(),
     allowedActions: z.array(z.string()).nullable().optional(),
+    actionCapabilities: z.array(RemediationActionCapabilitySchema).optional().default([]),
     evidenceDegraded: z.boolean().nullable().optional(),
     unavailableEvidenceClasses: z.array(z.string()).nullable().optional(),
     liveObservation: RemediationLiveObservationSchema.nullable().optional(),
@@ -7565,6 +7581,31 @@ function remediationListValue(items: string[] | null | undefined): string {
   return items && items.length > 0 ? items.join(', ') : '—';
 }
 
+function RemediationCapabilityMatrix({
+  rows,
+}: {
+  rows: z.infer<typeof RemediationActionCapabilitySchema>[];
+}) {
+  if (rows.length === 0) return null;
+  return (
+    <details>
+      <summary>
+        Action capability matrix ({rows.filter((row) => row.requestable).length} executable / {rows.length} catalog)
+      </summary>
+      <ul className="td-remediation-list">
+        {rows.map((row) => (
+          <li key={row.actionKind}>
+            <code>{row.actionKind}</code>:{' '}
+            {row.requestable
+              ? 'requestable'
+              : `disabled — ${remediationListValue(row.blockedReasons)}`}
+          </li>
+        ))}
+      </ul>
+    </details>
+  );
+}
+
 // Post-action verification (issue #3622) publishes a compact classification into
 // the verification artifact metadata so the dashboard can render the trusted
 // repair-verification outcome separately from action delivery without fetching
@@ -7767,6 +7808,7 @@ function RemediationRelationshipsPanel({
                   <Card label="Lock Holder">{item.activeLockHolder || item.lockOutcome?.holder || '—'}</Card>
                   <Card label="Lock Outcome">{item.lockOutcome?.state || '—'}</Card>
                 </div>
+                <RemediationCapabilityMatrix rows={item.actionCapabilities} />
                 {item.evidenceDegraded ? (
                   <p className="notice subtle">
                     Evidence is degraded. Unavailable: {remediationListValue(item.unavailableEvidenceClasses)}.

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -11573,6 +11573,29 @@ export interface components {
             /** Message */
             message?: string | null;
         };
+        /** RemediationActionCapabilityModel */
+        RemediationActionCapabilityModel: {
+            /** Actionkind */
+            actionKind: string;
+            /** Requestable */
+            requestable: boolean;
+            /** Dryrunsupported */
+            dryRunSupported: boolean;
+            /** Executionbackendready */
+            executionBackendReady: boolean;
+            /** Approvalbackendready */
+            approvalBackendReady: boolean;
+            /** Verificationbackendready */
+            verificationBackendReady: boolean;
+            /** Supportedtargetruntimes */
+            supportedTargetRuntimes: string[];
+            /** Supportedhostmodes */
+            supportedHostModes: string[];
+            /** Requiredevidenceclasses */
+            requiredEvidenceClasses: string[];
+            /** Blockedreasons */
+            blockedReasons: string[];
+        };
         /** RemediationApprovalDecisionRequest */
         RemediationApprovalDecisionRequest: {
             /** Decision */
@@ -11824,6 +11847,8 @@ export interface components {
             currentTargetState?: string | null;
             /** Allowedactions */
             allowedActions?: string[] | null;
+            /** Actioncapabilities */
+            actionCapabilities?: components["schemas"]["RemediationActionCapabilityModel"][];
             /** Evidencedegraded */
             evidenceDegraded?: boolean | null;
             /** Unavailableevidenceclasses */

--- a/moonmind/workflows/temporal/remediation_actions.py
+++ b/moonmind/workflows/temporal/remediation_actions.py
@@ -21,6 +21,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from api_service.db import models as db_models
 from moonmind.utils.logging import redact_sensitive_payload, redact_sensitive_text
+from moonmind.workflows.temporal.remediation_verification import (
+    verification_contract_for,
+)
 
 if TYPE_CHECKING:
     from moonmind.workflows.temporal.remediation_context import (
@@ -381,14 +384,92 @@ _SUPPORTED_AUTHORITY_MODES = frozenset(
     {"observe_only", "approval_gated", "admin_auto"}
 )
 
+# Execution readiness is deliberately explicit and conservative. An action is
+# requestable only when both its owning mutation adapter and its authoritative
+# verifier are wired. Keeping unavailable identities in ``_ACTION_CATALOG``
+# lets policy and documentation expose a stable, bounded disabled reason without
+# advertising the action as executable (MoonLadderStudios/MoonMind#3624).
+_EXECUTION_BACKEND_READY = frozenset(
+    {
+        "execution.pause",
+        "execution.resume",
+        "execution.request_rerun_same_workflow",
+        "execution.start_fresh_rerun",
+        "checkpoint_branch.create_from_remediation_context",
+        "execution.cancel",
+        "execution.force_terminate",
+        "session.interrupt_turn",
+        "session.clear",
+        "session.cancel",
+        "provider_profile.evict_stale_lease",
+        "workload.restart_helper_container",
+        "workload.reap_orphan_container",
+        "host.drain",
+        "host.stop",
+        "host.restart",
+        "host.remove",
+        "host_lease.reconcile_stale",
+    }
+)
+
+
+def remediation_action_capability(action_kind: str) -> Mapping[str, Any]:
+    """Return the canonical, independently evaluated readiness projection."""
+
+    normalized = str(action_kind or "").strip()
+    metadata = _ACTION_CATALOG.get(normalized)
+    contract = verification_contract_for(normalized)
+    catalog_enabled = bool(metadata and metadata.get("enabled"))
+    execution_ready = normalized in _EXECUTION_BACKEND_READY
+    verification_ready = contract.automatically_verifiable
+    approval_ready = catalog_enabled
+    blocked: list[str] = []
+    if not catalog_enabled:
+        blocked.append("action_not_in_enabled_catalog")
+    if not execution_ready:
+        blocked.append("execution_backend_unavailable")
+    if not approval_ready:
+        blocked.append("approval_backend_unavailable")
+    if not verification_ready:
+        blocked.append("authoritative_verifier_unavailable")
+    requestable = not blocked
+    return {
+        "requestable": requestable,
+        "dryRunSupported": catalog_enabled,
+        "executionBackendReady": execution_ready,
+        "approvalBackendReady": approval_ready,
+        "verificationBackendReady": verification_ready,
+        "supportedTargetRuntimes": ["temporal", "omnigent"],
+        "supportedHostModes": ["managed", "external"],
+        "requiredEvidenceClasses": list(
+            dict.fromkeys(
+                contract.before_evidence_classes + contract.after_evidence_classes
+            )
+        ),
+        "blockedReasons": blocked,
+    }
+
+
+def remediation_action_capability_matrix() -> tuple[Mapping[str, Any], ...]:
+    """Return every catalog identity, including truthfully disabled actions."""
+
+    return tuple(
+        {
+            "actionKind": action_kind,
+            **remediation_action_capability(action_kind),
+        }
+        for action_kind in _ACTION_CATALOG
+    )
+
 
 def remediation_action_kinds() -> tuple[str, ...]:
-    """Return the canonical enabled action identities for adapter construction."""
+    """Return canonical identities with ready execution and verification owners."""
 
     return tuple(
         action_kind
         for action_kind, metadata in _ACTION_CATALOG.items()
         if metadata.get("enabled") is True
+        and remediation_action_capability(action_kind)["requestable"] is True
     )
 _ABSOLUTE_PATH_PATTERN = re.compile(
     r"/(?:[A-Za-z0-9._:@+-]+/)*[A-Za-z0-9._:@+-]+"
@@ -686,6 +767,9 @@ class RemediationActionAuthorityService:
                 continue
             if action_kind not in allowed_by_profile:
                 continue
+            capability = remediation_action_capability(action_kind)
+            if not capability["requestable"]:
+                continue
             actions.append(
                 {
                     "actionKind": action_kind,
@@ -697,6 +781,7 @@ class RemediationActionAuthorityService:
                     "verificationRequired": True,
                     "verificationHint": action_info["verification_hint"],
                     "auditPayloadShape": deepcopy(_COMMON_AUDIT_PAYLOAD_SHAPE),
+                    **capability,
                 }
             )
         return tuple(actions)
@@ -2541,5 +2626,8 @@ __all__ = [
     "RemediationPermissionSet",
     "RemediationSecurityProfile",
     "RemediationTargetFreshnessDecision",
+    "remediation_action_capability",
+    "remediation_action_capability_matrix",
+    "remediation_action_kinds",
     "remediation_changes_require_checkpoint_branch",
 ]

--- a/moonmind/workflows/temporal/remediation_actions.py
+++ b/moonmind/workflows/temporal/remediation_actions.py
@@ -413,7 +413,13 @@ _EXECUTION_BACKEND_READY = frozenset(
 )
 
 _OMNIGENT_ONLY_TARGETS = frozenset(
-    {"session", "provider_profile", "workload", "host", "host_lease"}
+    {
+        "managed_session",
+        "provider_profile_lease",
+        "workload_container",
+        "omnigent_host",
+        "host_lease",
+    }
 )
 
 

--- a/moonmind/workflows/temporal/remediation_actions.py
+++ b/moonmind/workflows/temporal/remediation_actions.py
@@ -12,7 +12,7 @@ import re
 from collections import defaultdict
 from collections.abc import Mapping, Sequence
 from copy import deepcopy
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Any, Literal
 
@@ -412,17 +412,62 @@ _EXECUTION_BACKEND_READY = frozenset(
     }
 )
 
+_OMNIGENT_ONLY_TARGETS = frozenset(
+    {"session", "provider_profile", "workload", "host", "host_lease"}
+)
 
-def remediation_action_capability(action_kind: str) -> Mapping[str, Any]:
-    """Return the canonical, independently evaluated readiness projection."""
+
+@dataclass(frozen=True, slots=True)
+class RemediationCapabilityContext:
+    """Live, exact-target inputs resolved by the owning service boundary."""
+
+    target_runtime: str | None = None
+    host_mode: str | None = None
+    target_state_eligible: bool = True
+    current_evidence_classes: Sequence[str] = field(default_factory=tuple)
+    require_current_evidence: bool = False
+    policy_allowed_action_kinds: Sequence[str] | None = None
+    caller_allowed_action_kinds: Sequence[str] | None = None
+    execution_backend_readiness: Mapping[str, bool] | None = None
+    approval_backend_ready: bool = True
+    verification_backend_readiness: Mapping[str, bool] | None = None
+
+
+def _action_support(action_kind: str) -> tuple[list[str], list[str]]:
+    target_type = str((_ACTION_CATALOG.get(action_kind) or {}).get("target_type") or "")
+    if target_type in _OMNIGENT_ONLY_TARGETS:
+        return ["omnigent"], ["managed"]
+    return ["temporal", "codex_cli", "claude_code", "gemini_cli", "omnigent"], [
+        "managed",
+        "external",
+    ]
+
+
+def remediation_action_capability(
+    action_kind: str,
+    *,
+    context: RemediationCapabilityContext | None = None,
+) -> Mapping[str, Any]:
+    """Evaluate one action against catalog and live exact-target readiness."""
 
     normalized = str(action_kind or "").strip()
     metadata = _ACTION_CATALOG.get(normalized)
     contract = verification_contract_for(normalized)
     catalog_enabled = bool(metadata and metadata.get("enabled"))
+    supported_runtimes, supported_host_modes = _action_support(normalized)
     execution_ready = normalized in _EXECUTION_BACKEND_READY
     verification_ready = contract.automatically_verifiable
     approval_ready = catalog_enabled
+    if context is not None:
+        if context.execution_backend_readiness is not None:
+            execution_ready = execution_ready and bool(
+                context.execution_backend_readiness.get(normalized, False)
+            )
+        if context.verification_backend_readiness is not None:
+            verification_ready = verification_ready and bool(
+                context.verification_backend_readiness.get(normalized, False)
+            )
+        approval_ready = catalog_enabled and context.approval_backend_ready
     blocked: list[str] = []
     if not catalog_enabled:
         blocked.append("action_not_in_enabled_catalog")
@@ -432,6 +477,23 @@ def remediation_action_capability(action_kind: str) -> Mapping[str, Any]:
         blocked.append("approval_backend_unavailable")
     if not verification_ready:
         blocked.append("authoritative_verifier_unavailable")
+    if context is not None:
+        policy = context.policy_allowed_action_kinds
+        if policy is not None and normalized not in set(policy):
+            blocked.append("target_policy_denied")
+        caller = context.caller_allowed_action_kinds
+        if caller is not None and normalized not in set(caller):
+            blocked.append("caller_permission_denied")
+        if not context.target_state_eligible:
+            blocked.append("target_state_ineligible")
+        if context.target_runtime and context.target_runtime not in supported_runtimes:
+            blocked.append("target_runtime_unsupported")
+        if context.host_mode and context.host_mode not in supported_host_modes:
+            blocked.append("host_mode_unsupported")
+        required = set(contract.before_evidence_classes)
+        available = set(context.current_evidence_classes)
+        if context.require_current_evidence and not required.issubset(available):
+            blocked.append("required_evidence_unavailable")
     requestable = not blocked
     return {
         "requestable": requestable,
@@ -439,8 +501,8 @@ def remediation_action_capability(action_kind: str) -> Mapping[str, Any]:
         "executionBackendReady": execution_ready,
         "approvalBackendReady": approval_ready,
         "verificationBackendReady": verification_ready,
-        "supportedTargetRuntimes": ["temporal", "omnigent"],
-        "supportedHostModes": ["managed", "external"],
+        "supportedTargetRuntimes": supported_runtimes,
+        "supportedHostModes": supported_host_modes,
         "requiredEvidenceClasses": list(
             dict.fromkeys(
                 contract.before_evidence_classes + contract.after_evidence_classes
@@ -450,13 +512,15 @@ def remediation_action_capability(action_kind: str) -> Mapping[str, Any]:
     }
 
 
-def remediation_action_capability_matrix() -> tuple[Mapping[str, Any], ...]:
+def remediation_action_capability_matrix(
+    *, context: RemediationCapabilityContext | None = None
+) -> tuple[Mapping[str, Any], ...]:
     """Return every catalog identity, including truthfully disabled actions."""
 
     return tuple(
         {
             "actionKind": action_kind,
-            **remediation_action_capability(action_kind),
+            **remediation_action_capability(action_kind, context=context),
         }
         for action_kind in _ACTION_CATALOG
     )
@@ -749,6 +813,7 @@ class RemediationActionAuthorityService:
         *,
         permissions: RemediationPermissionSet,
         security_profile: RemediationSecurityProfile | None,
+        capability_context: RemediationCapabilityContext | None = None,
     ) -> tuple[Mapping[str, Any], ...]:
         """Return enabled action metadata allowed by caller permissions and profile."""
 
@@ -767,7 +832,14 @@ class RemediationActionAuthorityService:
                 continue
             if action_kind not in allowed_by_profile:
                 continue
-            capability = remediation_action_capability(action_kind)
+            live_context = capability_context or RemediationCapabilityContext()
+            live_context = replace(
+                live_context,
+                caller_allowed_action_kinds=tuple(allowed_by_profile),
+            )
+            capability = remediation_action_capability(
+                action_kind, context=live_context
+            )
             if not capability["requestable"]:
                 continue
             actions.append(
@@ -2610,6 +2682,7 @@ def remediation_changes_require_checkpoint_branch(
 
 
 __all__ = [
+    "RemediationCapabilityContext",
     "REMEDIATION_BRANCH_SENSITIVE_FIELDS",
     "RemediationActionAuthorityResult",
     "RemediationActionAuthorityService",

--- a/moonmind/workflows/temporal/remediation_actions.py
+++ b/moonmind/workflows/temporal/remediation_actions.py
@@ -399,7 +399,6 @@ _EXECUTION_BACKEND_READY = frozenset(
         "execution.cancel",
         "execution.force_terminate",
         "session.interrupt_turn",
-        "session.clear",
         "session.cancel",
         "provider_profile.evict_stale_lease",
         "workload.restart_helper_container",
@@ -440,13 +439,12 @@ class RemediationCapabilityContext:
 
 
 def _action_support(action_kind: str) -> tuple[list[str], list[str]]:
+    from moonmind.workflows.executions.execution_contract import SUPPORTED_RUNTIME_MODES
+
     target_type = str((_ACTION_CATALOG.get(action_kind) or {}).get("target_type") or "")
     if target_type in _OMNIGENT_ONLY_TARGETS:
-        return ["omnigent"], ["managed"]
-    return ["temporal", "codex_cli", "claude_code", "gemini_cli", "omnigent"], [
-        "managed",
-        "external",
-    ]
+        return ["omnigent"], ["static_compose", "on_demand_docker"]
+    return sorted(SUPPORTED_RUNTIME_MODES | {"temporal"}), []
 
 
 def remediation_action_capability(
@@ -494,7 +492,11 @@ def remediation_action_capability(
             blocked.append("target_state_ineligible")
         if context.target_runtime and context.target_runtime not in supported_runtimes:
             blocked.append("target_runtime_unsupported")
-        if context.host_mode and context.host_mode not in supported_host_modes:
+        if (
+            context.host_mode
+            and supported_host_modes
+            and context.host_mode not in supported_host_modes
+        ):
             blocked.append("host_mode_unsupported")
         required = set(contract.before_evidence_classes)
         available = set(context.current_evidence_classes)
@@ -503,7 +505,7 @@ def remediation_action_capability(
     requestable = not blocked
     return {
         "requestable": requestable,
-        "dryRunSupported": catalog_enabled,
+        "dryRunSupported": False,
         "executionBackendReady": execution_ready,
         "approvalBackendReady": approval_ready,
         "verificationBackendReady": verification_ready,
@@ -614,7 +616,7 @@ class RemediationActionAuthorityResult:
                     "resourceKind": _target_type(self.action_kind),
                 },
                 "riskTier": self.risk,
-                "dryRun": self.reason == "dry_run",
+                "dryRun": self.reason.startswith("dry_run"),
                 "idempotencyKey": self.idempotency_key,
                 "params": dict(self.redacted_parameters),
             },
@@ -1231,6 +1233,33 @@ class RemediationActionAuthorityService:
                 approval_ref=approval_ref,
                 parameters=parameters,
             )
+        if dry_run:
+            return self._linked_result(
+                link=link,
+                action_kind=action_kind,
+                risk=risk,
+                decision="denied",
+                reason="dry_run_unsupported",
+                idempotency_key=idempotency_key,
+                requesting_principal=requesting_principal,
+                security_profile=security_profile,
+                approval_ref=approval_ref,
+                parameters=parameters,
+            )
+        capability = remediation_action_capability(action_kind)
+        if not capability["requestable"]:
+            return self._linked_result(
+                link=link,
+                action_kind=action_kind,
+                risk=risk,
+                decision="denied",
+                reason=str(capability["blockedReasons"][0]),
+                idempotency_key=idempotency_key,
+                requesting_principal=requesting_principal,
+                security_profile=security_profile,
+                approval_ref=approval_ref,
+                parameters=parameters,
+            )
         if not permissions.can_view_target:
             return self._linked_result(
                 link=link,
@@ -1251,22 +1280,6 @@ class RemediationActionAuthorityService:
                 risk=risk,
                 decision="denied",
                 reason="unsupported_authority_mode",
-                idempotency_key=idempotency_key,
-                requesting_principal=requesting_principal,
-                security_profile=security_profile,
-                approval_ref=approval_ref,
-                parameters=parameters,
-            )
-        if dry_run:
-            decision: RemediationActionDecision = (
-                "dry_run_only" if authority_mode == "observe_only" else "allowed"
-            )
-            return self._linked_result(
-                link=link,
-                action_kind=action_kind,
-                risk=risk,
-                decision=decision,
-                reason="dry_run",
                 idempotency_key=idempotency_key,
                 requesting_principal=requesting_principal,
                 security_profile=security_profile,

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -5436,10 +5436,17 @@ def test_list_remediations_for_target_returns_compact_inbound_links(
         )
     ]
 
-    with patch.object(
-        executions_module,
-        "_attach_remediation_capability_projection",
-        new=AsyncMock(),
+    with (
+        patch.object(
+            executions_module,
+            "_attach_remediation_capability_projection",
+            new=AsyncMock(),
+        ),
+        patch.object(
+            executions_module,
+            "remediation_action_capability_matrix",
+            return_value=(),
+        ),
     ):
         response = test_client.get(
             "/api/executions/mm:target-workflow/remediations",
@@ -5466,7 +5473,8 @@ def test_list_remediations_for_target_returns_compact_inbound_links(
                 "contextArtifactRef": "art_context",
                 "selectedSteps": None,
                 "currentTargetState": None,
-                "allowedActions": None,
+                "allowedActions": [],
+                "actionCapabilities": [],
                 "evidenceDegraded": None,
                 "unavailableEvidenceClasses": None,
                 "liveObservation": None,
@@ -5520,10 +5528,17 @@ def test_list_remediations_for_remediation_returns_compact_outbound_links(
         )
     ]
 
-    with patch.object(
-        executions_module,
-        "_attach_remediation_capability_projection",
-        new=AsyncMock(),
+    with (
+        patch.object(
+            executions_module,
+            "_attach_remediation_capability_projection",
+            new=AsyncMock(),
+        ),
+        patch.object(
+            executions_module,
+            "remediation_action_capability_matrix",
+            return_value=(),
+        ),
     ):
         response = test_client.get(
             "/api/executions/mm:remediation-1/remediations",
@@ -5548,7 +5563,8 @@ def test_list_remediations_for_remediation_returns_compact_outbound_links(
         "contextArtifactRef": None,
         "selectedSteps": None,
         "currentTargetState": None,
-        "allowedActions": None,
+        "allowedActions": [],
+        "actionCapabilities": [],
         "evidenceDegraded": None,
         "unavailableEvidenceClasses": None,
         "liveObservation": None,
@@ -5643,10 +5659,17 @@ def test_list_remediations_for_remediation_returns_rich_operator_metadata(
         )
     ]
 
-    with patch.object(
-        executions_module,
-        "_attach_remediation_capability_projection",
-        new=AsyncMock(),
+    with (
+        patch.object(
+            executions_module,
+            "_attach_remediation_capability_projection",
+            new=AsyncMock(),
+        ),
+        patch.object(
+            executions_module,
+            "remediation_action_capability_matrix",
+            return_value=(),
+        ),
     ):
         response = test_client.get(
             "/api/executions/mm:remediation-rich/remediations",
@@ -5657,7 +5680,8 @@ def test_list_remediations_for_remediation_returns_rich_operator_metadata(
     item = response.json()["items"][0]
     assert item["selectedSteps"] == ["collect-context", "repair-runtime"]
     assert item["currentTargetState"] == "awaiting_external"
-    assert item["allowedActions"] == ["inspect_context", "request_approval"]
+    assert item["allowedActions"] == []
+    assert item["actionCapabilities"] == []
     assert item["evidenceDegraded"] is True
     assert item["unavailableEvidenceClasses"] == [
         "runtime_stderr",

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -5436,10 +5436,15 @@ def test_list_remediations_for_target_returns_compact_inbound_links(
         )
     ]
 
-    response = test_client.get(
-        "/api/executions/mm:target-workflow/remediations",
-        params={"direction": "inbound"},
-    )
+    with patch.object(
+        executions_module,
+        "_attach_remediation_capability_projection",
+        new=AsyncMock(),
+    ):
+        response = test_client.get(
+            "/api/executions/mm:target-workflow/remediations",
+            params={"direction": "inbound"},
+        )
 
     assert response.status_code == 200
     assert response.json() == {
@@ -5515,10 +5520,15 @@ def test_list_remediations_for_remediation_returns_compact_outbound_links(
         )
     ]
 
-    response = test_client.get(
-        "/api/executions/mm:remediation-1/remediations",
-        params={"direction": "outbound"},
-    )
+    with patch.object(
+        executions_module,
+        "_attach_remediation_capability_projection",
+        new=AsyncMock(),
+    ):
+        response = test_client.get(
+            "/api/executions/mm:remediation-1/remediations",
+            params={"direction": "outbound"},
+        )
 
     assert response.status_code == 200
     assert response.json()["direction"] == "outbound"
@@ -5633,10 +5643,15 @@ def test_list_remediations_for_remediation_returns_rich_operator_metadata(
         )
     ]
 
-    response = test_client.get(
-        "/api/executions/mm:remediation-rich/remediations",
-        params={"direction": "outbound"},
-    )
+    with patch.object(
+        executions_module,
+        "_attach_remediation_capability_projection",
+        new=AsyncMock(),
+    ):
+        response = test_client.get(
+            "/api/executions/mm:remediation-rich/remediations",
+            params={"direction": "outbound"},
+        )
 
     assert response.status_code == 200
     item = response.json()["items"][0]

--- a/tests/unit/api/routers/test_remediation_capability_projection.py
+++ b/tests/unit/api/routers/test_remediation_capability_projection.py
@@ -1,0 +1,65 @@
+"""Workflow Detail boundary coverage for remediation capability discovery."""
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+
+from api_service.api.routers.executions import _serialize_remediation_link_summary
+
+
+def test_remediation_link_publishes_complete_evaluated_capability_matrix() -> None:
+    now = datetime(2026, 8, 9, tzinfo=UTC)
+    link = SimpleNamespace(
+        remediation_workflow_id="remediation-1",
+        remediation_run_id="remediation-run-1",
+        target_workflow_id="target-1",
+        target_run_id="target-run-1",
+        mode="repair",
+        authority_mode="admin_auto",
+        status="acting",
+        allowed_actions=["execution.pause"],
+        current_target_state="running",
+        target_runtime="temporal",
+        host_mode="managed",
+        evidence_degraded=False,
+        unavailable_evidence_classes=[],
+        checkpoint_branch_links=[],
+        created_at=now,
+        updated_at=now,
+    )
+
+    result = _serialize_remediation_link_summary(link)
+
+    rows = {row.actionKind: row for row in result.actionCapabilities}
+    assert result.allowedActions == ["execution.pause"]
+    assert rows["execution.pause"].requestable is True
+    assert rows["execution.resume"].requestable is False
+    assert "target_policy_denied" in rows["execution.resume"].blockedReasons
+    assert rows["session.terminate"].requestable is False
+    assert "execution_backend_unavailable" in rows["session.terminate"].blockedReasons
+
+
+def test_remediation_link_reports_approval_backend_unavailable_before_request() -> None:
+    now = datetime(2026, 8, 9, tzinfo=UTC)
+    link = SimpleNamespace(
+        remediation_workflow_id="remediation-1",
+        remediation_run_id="remediation-run-1",
+        target_workflow_id="target-1",
+        target_run_id="target-run-1",
+        mode="repair",
+        authority_mode="approval_gated",
+        status="created",
+        approval_state=None,
+        allowed_actions=["execution.pause"],
+        current_target_state="running",
+        evidence_degraded=False,
+        checkpoint_branch_links=[],
+        created_at=now,
+        updated_at=now,
+    )
+
+    result = _serialize_remediation_link_summary(link)
+    pause = next(
+        row for row in result.actionCapabilities if row.actionKind == "execution.pause"
+    )
+    assert pause.requestable is False
+    assert "approval_backend_unavailable" in pause.blockedReasons

--- a/tests/unit/api/routers/test_remediation_capability_projection.py
+++ b/tests/unit/api/routers/test_remediation_capability_projection.py
@@ -38,7 +38,7 @@ def test_remediation_link_publishes_complete_evaluated_capability_matrix() -> No
     assert "execution_backend_unavailable" in rows["session.terminate"].blockedReasons
 
 
-def test_remediation_link_reports_approval_backend_unavailable_before_request() -> None:
+def test_remediation_link_reports_approval_backend_ready_before_request() -> None:
     now = datetime(2026, 8, 9, tzinfo=UTC)
     link = SimpleNamespace(
         remediation_workflow_id="remediation-1",
@@ -61,5 +61,6 @@ def test_remediation_link_reports_approval_backend_unavailable_before_request() 
     pause = next(
         row for row in result.actionCapabilities if row.actionKind == "execution.pause"
     )
-    assert pause.requestable is False
-    assert "approval_backend_unavailable" in pause.blockedReasons
+    assert pause.requestable is True
+    assert pause.approvalBackendReady is True
+    assert "approval_backend_unavailable" not in pause.blockedReasons

--- a/tests/unit/omnigent/test_policy_authority.py
+++ b/tests/unit/omnigent/test_policy_authority.py
@@ -192,13 +192,9 @@ def test_bootstrap_keeps_mutating_remediation_actions_approval_gated():
             assert decision["approvalClass"] and decision["reviewerRule"]
 
 
-def test_bootstrap_approval_rule_is_bindable():
+def test_bootstrap_does_not_authorize_unready_action():
     snapshot = _bootstrap_snapshot()
-    binding = bind_approval_request(
-        snapshot, "host.restart", target_expected_state="run-1"
-    )
-    assert binding["approvalClass"] == "remediation"
-    assert binding["reviewerRule"] == "workflow-owner"
+    assert resolve_action(snapshot, "host.restart")["decision"] == "deny"
 
 
 def test_policy_authority_evidence_rejects_unvalidated_snapshot():

--- a/tests/unit/workflows/temporal/test_remediation_context.py
+++ b/tests/unit/workflows/temporal/test_remediation_context.py
@@ -247,6 +247,16 @@ CANONICAL_REMEDIATION_ACTIONS = {
     "workload.reap_orphan_container",
 }
 
+REQUESTABLE_REMEDIATION_ACTIONS = {
+    "checkpoint_branch.create_from_remediation_context",
+    "execution.pause",
+    "execution.resume",
+    "execution.request_rerun_same_workflow",
+    "execution.start_fresh_rerun",
+    "execution.cancel",
+    "execution.force_terminate",
+}
+
 def test_remediation_action_authority_lists_canonical_mm483_action_registry():
     service = RemediationActionAuthorityService(session=object())
 
@@ -257,7 +267,7 @@ def test_remediation_action_authority_lists_canonical_mm483_action_registry():
         ),
     )
 
-    assert {item["actionKind"] for item in allowed} == CANONICAL_REMEDIATION_ACTIONS
+    assert {item["actionKind"] for item in allowed} == REQUESTABLE_REMEDIATION_ACTIONS
     for item in allowed:
         assert item["riskTier"] in {"low", "medium", "high"}
         assert item["targetType"]
@@ -267,6 +277,11 @@ def test_remediation_action_authority_lists_canonical_mm483_action_registry():
         assert item["verificationRequired"] is True
         assert item["verificationHint"]
         assert item["auditPayloadShape"]
+        assert item["requestable"] is True
+        assert item["executionBackendReady"] is True
+        assert item["approvalBackendReady"] is True
+        assert item["verificationBackendReady"] is True
+        assert item["blockedReasons"] == []
 
 def test_remediation_action_authority_rejects_legacy_action_aliases():
     service = RemediationActionAuthorityService(session=object())
@@ -283,10 +298,7 @@ def test_remediation_action_authority_rejects_legacy_action_aliases():
         ),
     )
 
-    assert {item["actionKind"] for item in allowed} == {
-        "workload.restart_helper_container",
-        "session.terminate",
-    }
+    assert allowed == ()
 
 def test_remediation_action_authority_lists_policy_compatible_actions():
     service = RemediationActionAuthorityService(session=object())
@@ -300,20 +312,20 @@ def test_remediation_action_authority_lists_policy_compatible_actions():
     allowed = service.list_allowed_actions(
         permissions=_admin_permissions(),
         security_profile=_admin_profile(
-            allowed_action_kinds=("workload.restart_helper_container",)
+            allowed_action_kinds=("execution.pause",)
         ),
     )
 
-    assert [item["actionKind"] for item in allowed] == ["workload.restart_helper_container"]
+    assert [item["actionKind"] for item in allowed] == ["execution.pause"]
     assert allowed[0]["riskTier"] == "medium"
-    assert allowed[0]["targetType"] == "workload_container"
+    assert allowed[0]["targetType"] == "execution"
     assert allowed[0]["inputMetadata"]["reason"]["required"] is False
 
     allowed[0]["inputMetadata"]["reason"]["required"] = True
     listed_again = service.list_allowed_actions(
         permissions=_admin_permissions(),
         security_profile=_admin_profile(
-            allowed_action_kinds=("workload.restart_helper_container",)
+            allowed_action_kinds=("execution.pause",)
         ),
     )
     assert listed_again[0]["inputMetadata"]["reason"]["required"] is False
@@ -338,7 +350,7 @@ def test_remediation_action_authority_does_not_advertise_raw_admin_actions():
     )
 
     action_kinds = {item["actionKind"] for item in allowed}
-    assert action_kinds == {"workload.restart_helper_container", "session.terminate"}
+    assert action_kinds == set()
     assert not action_kinds.intersection(
         {
             "raw_host_shell",

--- a/tests/unit/workflows/temporal/test_remediation_context.py
+++ b/tests/unit/workflows/temporal/test_remediation_context.py
@@ -223,7 +223,12 @@ def _admin_profile(**overrides):
     data = {
         "profile_ref": "admin_healer",
         "execution_principal": "service:admin-healer",
-        "allowed_action_kinds": ("workload.restart_helper_container", "session.terminate"),
+        "allowed_action_kinds": (
+            "execution.pause",
+            "execution.force_terminate",
+            "workload.restart_helper_container",
+            "session.terminate",
+        ),
         "enabled": True,
     }
     data.update(overrides)
@@ -2326,13 +2331,13 @@ async def test_remediation_execute_action_delegates_and_publishes_lifecycle_arti
         )
         await builder.build_context(remediation_workflow_id=remediation.workflow_id)
 
-        action_kind = "workload.restart_helper_container"
+        action_kind = "execution.pause"
         authority = await RemediationActionAuthorityService(
             session=session
         ).evaluate_action_request(
             remediation_workflow_id=remediation.workflow_id,
             action_kind=action_kind,
-            parameters={"reason": "restart helper", "containerRef": "container-1"},
+            parameters={"reason": "pause execution"},
             dry_run=False,
             idempotency_key="execute-action-1",
             requesting_principal="workflow:remediator",
@@ -2348,7 +2353,7 @@ async def test_remediation_execute_action_delegates_and_publishes_lifecycle_arti
             target_run_id=target.run_id,
             action_kind=action_kind,
             idempotency_key="execute-action-1",
-            parameters={"reason": "restart helper", "containerRef": "container-1"},
+            parameters={"reason": "pause execution"},
             policy=RemediationMutationGuardPolicy(cooldown_seconds=0),
             now=datetime(2026, 4, 23, tzinfo=timezone.utc),
         )
@@ -2423,8 +2428,8 @@ async def test_execute_action_preserves_approval_lifecycle_artifact_refs(
             artifact_service=artifact_service,
         ).build_context(remediation_workflow_id=remediation.workflow_id)
 
-        action_kind = "workload.restart_helper_container"
-        parameters = {"reason": "restart helper", "containerRef": "container-1"}
+        action_kind = "execution.pause"
+        parameters = {"reason": "pause execution"}
         authority = await RemediationActionAuthorityService(
             session=session
         ).evaluate_action_request(
@@ -2669,7 +2674,6 @@ async def test_remediation_execute_action_publishes_v1_request_and_result_artifa
             action_kind=action_kind,
             parameters={
                 "reason": "Authorization: Bearer raw-secret-token",
-                "containerRef": "container-1",
             },
             dry_run=False,
             idempotency_key=action_id,
@@ -2684,7 +2688,7 @@ async def test_remediation_execute_action_publishes_v1_request_and_result_artifa
             target_run_id=target.run_id,
             action_kind=action_kind,
             idempotency_key=action_id,
-            parameters={"reason": "restart helper", "containerRef": "container-1"},
+            parameters={"reason": "pause execution"},
             policy=RemediationMutationGuardPolicy(cooldown_seconds=0),
             now=datetime(2026, 4, 23, tzinfo=timezone.utc),
         )
@@ -2714,7 +2718,7 @@ async def test_remediation_execute_action_publishes_v1_request_and_result_artifa
         assert request_payload["requester"] == "workflow:remediator"
         assert request_payload["target"] == {
             "workflowId": target.workflow_id,
-            "resourceKind": "workload_container",
+            "resourceKind": "execution",
         }
         assert request_payload["riskTier"] == "medium"
         assert request_payload["dryRun"] is False
@@ -2756,13 +2760,13 @@ async def test_remediation_execute_action_rejects_unsupported_result_status(
             artifact_service=artifact_service,
         ).build_context(remediation_workflow_id=remediation.workflow_id)
 
-        action_kind = "workload.restart_helper_container"
+        action_kind = "execution.pause"
         authority = await RemediationActionAuthorityService(
             session=session
         ).evaluate_action_request(
             remediation_workflow_id=remediation.workflow_id,
             action_kind=action_kind,
-            parameters={"reason": "restart helper", "containerRef": "container-1"},
+            parameters={"reason": "pause execution"},
             dry_run=False,
             idempotency_key="unsupported-status",
             requesting_principal="workflow:remediator",
@@ -2776,7 +2780,7 @@ async def test_remediation_execute_action_rejects_unsupported_result_status(
             target_run_id=target.run_id,
             action_kind=action_kind,
             idempotency_key="unsupported-status",
-            parameters={"reason": "restart helper", "containerRef": "container-1"},
+            parameters={"reason": "pause execution"},
             policy=RemediationMutationGuardPolicy(cooldown_seconds=0),
             now=datetime(2026, 4, 23, tzinfo=timezone.utc),
         )
@@ -2814,13 +2818,13 @@ async def test_remediation_execute_action_rejects_mismatched_authority_or_guard_
         )
         await builder.build_context(remediation_workflow_id=remediation.workflow_id)
 
-        action_kind = "workload.restart_helper_container"
+        action_kind = "execution.pause"
         authority = await RemediationActionAuthorityService(
             session=session
         ).evaluate_action_request(
             remediation_workflow_id=remediation.workflow_id,
             action_kind=action_kind,
-            parameters={"reason": "restart helper", "containerRef": "container-1"},
+            parameters={"reason": "pause execution"},
             dry_run=False,
             idempotency_key="execute-action-context",
             requesting_principal="workflow:remediator",
@@ -2836,7 +2840,7 @@ async def test_remediation_execute_action_rejects_mismatched_authority_or_guard_
             target_run_id=target.run_id,
             action_kind=action_kind,
             idempotency_key="execute-action-context",
-            parameters={"reason": "restart helper", "containerRef": "container-1"},
+            parameters={"reason": "pause execution"},
             policy=RemediationMutationGuardPolicy(cooldown_seconds=0),
             now=datetime(2026, 4, 23, tzinfo=timezone.utc),
         )
@@ -2942,7 +2946,7 @@ async def test_remediation_action_authority_enforces_authority_modes(
 
         dry_run = await service.evaluate_action_request(
             remediation_workflow_id=remediation.workflow_id,
-            action_kind="workload.restart_helper_container",
+            action_kind="execution.pause",
             parameters={"reason": "diagnose only"},
             dry_run=True,
             idempotency_key="observe-dry-run",
@@ -2961,7 +2965,7 @@ async def test_remediation_action_authority_enforces_authority_modes(
 
         denied = await service.evaluate_action_request(
             remediation_workflow_id=remediation.workflow_id,
-            action_kind="workload.restart_helper_container",
+            action_kind="execution.pause",
             parameters={"reason": "side effect"},
             dry_run=False,
             idempotency_key="observe-execute",
@@ -2987,8 +2991,8 @@ async def test_remediation_action_authority_requires_approval_for_gated_mode(
 
         pending = await service.evaluate_action_request(
             remediation_workflow_id=remediation.workflow_id,
-            action_kind="workload.restart_helper_container",
-            parameters={"containerRef": "container-1"},
+            action_kind="execution.pause",
+            parameters={},
             dry_run=False,
             idempotency_key="gated-pending",
             requesting_principal="user:operator",
@@ -3009,8 +3013,8 @@ async def test_remediation_action_authority_requires_approval_for_gated_mode(
 
         forged = await service.evaluate_action_request(
             remediation_workflow_id=remediation.workflow_id,
-            action_kind="workload.restart_helper_container",
-            parameters={"containerRef": "container-1"},
+            action_kind="execution.pause",
+            parameters={},
             dry_run=False,
             idempotency_key="gated-approved",
             requesting_principal="user:operator",
@@ -3036,7 +3040,7 @@ async def test_remediation_action_authority_enforces_profile_permissions_and_ris
 
         view_only = await service.evaluate_action_request(
             remediation_workflow_id=remediation.workflow_id,
-            action_kind="workload.restart_helper_container",
+            action_kind="execution.pause",
             parameters={},
             dry_run=False,
             idempotency_key="view-only",
@@ -3049,7 +3053,7 @@ async def test_remediation_action_authority_enforces_profile_permissions_and_ris
 
         disabled_profile = await service.evaluate_action_request(
             remediation_workflow_id=remediation.workflow_id,
-            action_kind="workload.restart_helper_container",
+            action_kind="execution.pause",
             parameters={},
             dry_run=False,
             idempotency_key="disabled-profile",
@@ -3062,8 +3066,8 @@ async def test_remediation_action_authority_enforces_profile_permissions_and_ris
 
         allowed = await service.evaluate_action_request(
             remediation_workflow_id=remediation.workflow_id,
-            action_kind="workload.restart_helper_container",
-            parameters={"containerRef": "container-1"},
+            action_kind="execution.pause",
+            parameters={},
             dry_run=False,
             idempotency_key="medium-allowed",
             requesting_principal="user:operator",
@@ -3075,7 +3079,7 @@ async def test_remediation_action_authority_enforces_profile_permissions_and_ris
         assert allowed.executable is True
         payload = allowed.to_dict()
         assert payload["schemaVersion"] == "v1"
-        assert payload["request"]["actionKind"] == "workload.restart_helper_container"
+        assert payload["request"]["actionKind"] == "execution.pause"
         assert payload["request"]["riskTier"] == "medium"
         assert payload["request"]["dryRun"] is False
         assert payload["result"]["status"] == "applied"
@@ -3086,7 +3090,7 @@ async def test_remediation_action_authority_enforces_profile_permissions_and_ris
 
         high_risk = await service.evaluate_action_request(
             remediation_workflow_id=remediation.workflow_id,
-            action_kind="session.terminate",
+            action_kind="execution.force_terminate",
             parameters={},
             dry_run=False,
             idempotency_key="high-risk",
@@ -3119,7 +3123,7 @@ async def test_remediation_action_authority_rejects_unsupported_authority_mode(
         service = RemediationActionAuthorityService(session=session)
         result = await service.evaluate_action_request(
             remediation_workflow_id=remediation.workflow_id,
-            action_kind="workload.restart_helper_container",
+            action_kind="execution.pause",
             parameters={},
             dry_run=False,
             idempotency_key="unsupported-authority",
@@ -3146,8 +3150,8 @@ async def test_remediation_action_authority_cache_keys_include_request_shape(
 
         allowed = await service.evaluate_action_request(
             remediation_workflow_id=remediation.workflow_id,
-            action_kind="workload.restart_helper_container",
-            parameters={"containerRef": "container-1"},
+            action_kind="execution.pause",
+            parameters={},
             dry_run=False,
             idempotency_key="same-idempotency-key",
             requesting_principal="user:operator",
@@ -3156,7 +3160,7 @@ async def test_remediation_action_authority_cache_keys_include_request_shape(
         )
         high_risk = await service.evaluate_action_request(
             remediation_workflow_id=remediation.workflow_id,
-            action_kind="session.terminate",
+            action_kind="execution.force_terminate",
             parameters={},
             dry_run=False,
             idempotency_key="same-idempotency-key",
@@ -3166,7 +3170,7 @@ async def test_remediation_action_authority_cache_keys_include_request_shape(
         )
         dry_run = await service.evaluate_action_request(
             remediation_workflow_id=remediation.workflow_id,
-            action_kind="workload.restart_helper_container",
+            action_kind="execution.pause",
             parameters={},
             dry_run=True,
             idempotency_key="same-idempotency-key",
@@ -3342,7 +3346,7 @@ async def test_remediation_action_authority_uses_prepared_action_context(
         )
         preparation = await tools.prepare_action_request(
             remediation_workflow_id=remediation.workflow_id,
-            action_kind="workload.restart_helper_container",
+            action_kind="execution.pause",
         )
 
         service = RemediationActionAuthorityService(session=session)
@@ -3351,7 +3355,6 @@ async def test_remediation_action_authority_uses_prepared_action_context(
             action_kind=preparation.action_kind,
             parameters={
                 "reason": f"target state was {preparation.target.state}",
-                "containerRef": "container-1",
             },
             dry_run=False,
             idempotency_key="prepared-action",
@@ -3378,7 +3381,7 @@ async def test_remediation_action_authority_validates_action_inputs(
 
         invalid = await service.evaluate_action_request(
             remediation_workflow_id=remediation.workflow_id,
-            action_kind="workload.restart_helper_container",
+            action_kind="execution.pause",
             parameters={"unknown": "value"},
             dry_run=False,
             idempotency_key="invalid-inputs",
@@ -3393,7 +3396,7 @@ async def test_remediation_action_authority_validates_action_inputs(
 
         wrong_type = await service.evaluate_action_request(
             remediation_workflow_id=remediation.workflow_id,
-            action_kind="workload.restart_helper_container",
+            action_kind="execution.pause",
             parameters={"reason": False},
             dry_run=False,
             idempotency_key="invalid-input-type",

--- a/tests/unit/workflows/temporal/test_remediation_context.py
+++ b/tests/unit/workflows/temporal/test_remediation_context.py
@@ -2950,11 +2950,12 @@ async def test_remediation_action_authority_enforces_authority_modes(
             permissions=_admin_permissions(),
             security_profile=_admin_profile(),
         )
-        assert dry_run.decision == "dry_run_only"
+        assert dry_run.decision == "denied"
+        assert dry_run.reason == "dry_run_unsupported"
         assert dry_run.executable is False
         dry_run_payload = dry_run.to_dict()
         assert dry_run_payload["request"]["dryRun"] is True
-        assert dry_run_payload["result"]["status"] == "no_op"
+        assert dry_run_payload["result"]["status"] == "rejected"
         assert dry_run_payload["result"]["verificationRequired"] is False
         assert dry_run_payload["result"]["verificationHint"] is None
 

--- a/tests/unit/workflows/temporal/test_remediation_context.py
+++ b/tests/unit/workflows/temporal/test_remediation_context.py
@@ -2572,14 +2572,14 @@ async def test_remediation_execute_action_reuses_retry_artifacts(
             artifact_service=artifact_service,
         ).build_context(remediation_workflow_id=remediation.workflow_id)
 
-        action_kind = "workload.restart_helper_container"
+        action_kind = "execution.pause"
         action_id = "execute-action-retry"
         authority = await RemediationActionAuthorityService(
             session=session
         ).evaluate_action_request(
             remediation_workflow_id=remediation.workflow_id,
             action_kind=action_kind,
-            parameters={"reason": "restart helper", "containerRef": "container-1"},
+            parameters={"reason": "pause execution"},
             dry_run=False,
             idempotency_key=action_id,
             requesting_principal="workflow:remediator",
@@ -2593,7 +2593,7 @@ async def test_remediation_execute_action_reuses_retry_artifacts(
             target_run_id=target.run_id,
             action_kind=action_kind,
             idempotency_key=action_id,
-            parameters={"reason": "restart helper", "containerRef": "container-1"},
+            parameters={"reason": "pause execution"},
             policy=RemediationMutationGuardPolicy(cooldown_seconds=0),
             now=datetime(2026, 4, 23, tzinfo=timezone.utc),
         )
@@ -2665,7 +2665,7 @@ async def test_remediation_execute_action_publishes_v1_request_and_result_artifa
             artifact_service=artifact_service,
         ).build_context(remediation_workflow_id=remediation.workflow_id)
 
-        action_kind = "workload.restart_helper_container"
+        action_kind = "execution.pause"
         action_id = "execute-action-v1"
         authority = await RemediationActionAuthorityService(
             session=session

--- a/tests/unit/workflows/temporal/test_remediation_issue_3511.py
+++ b/tests/unit/workflows/temporal/test_remediation_issue_3511.py
@@ -51,7 +51,7 @@ def test_corrected_execution_choices_require_checkpoint_branch() -> None:
     ) == ("model", "publishMode")
 
 
-def test_requested_control_plane_actions_are_in_typed_catalog() -> None:
+def test_unready_control_plane_actions_are_not_advertised() -> None:
     expected = {
         "host.drain",
         "host.stop",
@@ -76,7 +76,7 @@ def test_requested_control_plane_actions_are_in_typed_catalog() -> None:
         ),
     )
 
-    assert expected == {item["actionKind"] for item in catalog}
+    assert catalog == ()
 
 
 async def test_issue_3620_authority_persists_and_resolves_exact_expiring_approval() -> None:
@@ -782,7 +782,12 @@ async def test_checkpoint_branch_adapter_persists_graph_through_service() -> Non
         _production_target_health(),
     )
 
-    assert result["status"] == "applied"
+    assert result["status"] == "accepted"
+    assert result["deliveryStage"] == "branch_graph_created"
+    assert result["branchTurnLaunched"] is False
+    assert result["terminalBranchResultAvailable"] is False
+    assert result["idempotencyIdentity"] == "action-branch"
+    assert result["verificationContract"]["automaticallyVerifiable"] is True
     payload = checkpoint_service.create_branch_graph.await_args.args[0]
     assert payload["source"]["workflowId"] == "target"
     assert payload["source"]["runId"] == "target-run"

--- a/tests/unit/workflows/temporal/test_remediation_issue_3511.py
+++ b/tests/unit/workflows/temporal/test_remediation_issue_3511.py
@@ -106,12 +106,8 @@ async def test_issue_3620_authority_persists_and_resolves_exact_expiring_approva
     )
     kwargs = dict(
         remediation_workflow_id="remediation-1",
-        action_kind="host.restart",
-        parameters={
-            "providerProfileId": "profile-1",
-            "hostLeaseRef": "lease-1",
-            "expectedHostState": "running",
-        },
+        action_kind="execution.force_terminate",
+        parameters={"reason": "terminal recovery"},
         dry_run=False,
         idempotency_key="action-1",
         requesting_principal="operator:requester",
@@ -121,7 +117,7 @@ async def test_issue_3620_authority_persists_and_resolves_exact_expiring_approva
         security_profile=RemediationSecurityProfile(
             profile_ref="admin",
             execution_principal="operator:requester",
-            allowed_action_kinds=("host.restart",),
+            allowed_action_kinds=("execution.force_terminate",),
         ),
     )
 

--- a/tests/unit/workflows/temporal/test_remediation_issue_3624.py
+++ b/tests/unit/workflows/temporal/test_remediation_issue_3624.py
@@ -42,6 +42,7 @@ def test_every_requestable_action_has_execution_and_verification_owners() -> Non
         assert capability["executionBackendReady"] is True
         assert capability["approvalBackendReady"] is True
         assert capability["verificationBackendReady"] is True
+        assert capability["dryRunSupported"] is False
 
 
 def test_incomplete_owners_are_disabled_with_bounded_reasons() -> None:
@@ -54,6 +55,7 @@ def test_incomplete_owners_are_disabled_with_bounded_reasons() -> None:
             "execution_backend_unavailable",
             "authoritative_verifier_unavailable",
         },
+        "session.clear": {"execution_backend_unavailable"},
         "cleanup.request_janitor": {
             "execution_backend_unavailable",
             "authoritative_verifier_unavailable",
@@ -117,10 +119,6 @@ def test_production_executor_registers_only_requestable_actions() -> None:
             "target_runtime_unsupported",
         ),
         (
-            RemediationCapabilityContext(host_mode="unknown-host-mode"),
-            "host_mode_unsupported",
-        ),
-        (
             RemediationCapabilityContext(policy_allowed_action_kinds=()),
             "target_policy_denied",
         ),
@@ -154,7 +152,10 @@ def test_action_specific_runtime_and_host_filtering(action_kind: str) -> None:
         ),
     )
     assert capability["supportedTargetRuntimes"] == ["omnigent"]
-    assert capability["supportedHostModes"] == ["managed"]
+    assert capability["supportedHostModes"] == [
+        "static_compose",
+        "on_demand_docker",
+    ]
     assert set(capability["blockedReasons"]) >= {
         "target_runtime_unsupported",
         "host_mode_unsupported",

--- a/tests/unit/workflows/temporal/test_remediation_issue_3624.py
+++ b/tests/unit/workflows/temporal/test_remediation_issue_3624.py
@@ -136,9 +136,19 @@ def test_live_readiness_transitions_are_bounded(context, reason) -> None:
     assert reason in capability["blockedReasons"]
 
 
-def test_action_specific_runtime_and_host_filtering() -> None:
-    capability = remediation_action_capability(
+@pytest.mark.parametrize(
+    "action_kind",
+    [
         "session.interrupt_turn",
+        "provider_profile.evict_stale_lease",
+        "workload.restart_helper_container",
+        "host.drain",
+        "host_lease.reconcile_stale",
+    ],
+)
+def test_action_specific_runtime_and_host_filtering(action_kind: str) -> None:
+    capability = remediation_action_capability(
+        action_kind,
         context=RemediationCapabilityContext(
             target_runtime="codex_cli", host_mode="external"
         ),

--- a/tests/unit/workflows/temporal/test_remediation_issue_3624.py
+++ b/tests/unit/workflows/temporal/test_remediation_issue_3624.py
@@ -55,7 +55,10 @@ def test_incomplete_owners_are_disabled_with_bounded_reasons() -> None:
             "execution_backend_unavailable",
             "authoritative_verifier_unavailable",
         },
-        "session.clear": {"execution_backend_unavailable"},
+        "session.clear": {
+            "execution_backend_unavailable",
+            "authoritative_verifier_unavailable",
+        },
         "cleanup.request_janitor": {
             "execution_backend_unavailable",
             "authoritative_verifier_unavailable",

--- a/tests/unit/workflows/temporal/test_remediation_issue_3624.py
+++ b/tests/unit/workflows/temporal/test_remediation_issue_3624.py
@@ -1,12 +1,18 @@
 """Capability-truthful remediation catalog coverage for GitHub issue #3624."""
 
+import pytest
+
+from api_service.services.remediation_actions import (
+    build_remediation_action_executor,
+)
 from moonmind.workflows.temporal.remediation_actions import (
+    RemediationActionAuthorityService,
+    RemediationCapabilityContext,
+    RemediationPermissionSet,
+    RemediationSecurityProfile,
     remediation_action_capability,
     remediation_action_capability_matrix,
     remediation_action_kinds,
-)
-from api_service.services.remediation_actions import (
-    build_remediation_action_executor,
 )
 
 
@@ -81,3 +87,88 @@ def test_production_executor_registers_only_requestable_actions() -> None:
     assert "session.terminate" not in executor._adapters
     assert "cleanup.request_janitor" not in executor._adapters
     assert "host.restart" not in executor._adapters
+
+
+@pytest.mark.parametrize(
+    ("context", "reason"),
+    [
+        (
+            RemediationCapabilityContext(target_state_eligible=False),
+            "target_state_ineligible",
+        ),
+        (
+            RemediationCapabilityContext(approval_backend_ready=False),
+            "approval_backend_unavailable",
+        ),
+        (
+            RemediationCapabilityContext(
+                execution_backend_readiness={"execution.pause": False}
+            ),
+            "execution_backend_unavailable",
+        ),
+        (
+            RemediationCapabilityContext(
+                verification_backend_readiness={"execution.pause": False}
+            ),
+            "authoritative_verifier_unavailable",
+        ),
+        (
+            RemediationCapabilityContext(target_runtime="unknown-runtime"),
+            "target_runtime_unsupported",
+        ),
+        (
+            RemediationCapabilityContext(host_mode="unknown-host-mode"),
+            "host_mode_unsupported",
+        ),
+        (
+            RemediationCapabilityContext(policy_allowed_action_kinds=()),
+            "target_policy_denied",
+        ),
+        (
+            RemediationCapabilityContext(caller_allowed_action_kinds=()),
+            "caller_permission_denied",
+        ),
+    ],
+)
+def test_live_readiness_transitions_are_bounded(context, reason) -> None:
+    capability = remediation_action_capability("execution.pause", context=context)
+    assert capability["requestable"] is False
+    assert reason in capability["blockedReasons"]
+
+
+def test_action_specific_runtime_and_host_filtering() -> None:
+    capability = remediation_action_capability(
+        "session.interrupt_turn",
+        context=RemediationCapabilityContext(
+            target_runtime="codex_cli", host_mode="external"
+        ),
+    )
+    assert capability["supportedTargetRuntimes"] == ["omnigent"]
+    assert capability["supportedHostModes"] == ["managed"]
+    assert set(capability["blockedReasons"]) >= {
+        "target_runtime_unsupported",
+        "host_mode_unsupported",
+    }
+
+
+def test_allowed_actions_are_derived_from_live_evaluated_rows() -> None:
+    service = RemediationActionAuthorityService(session=None)  # type: ignore[arg-type]
+    permissions = RemediationPermissionSet(
+        can_view_target=True,
+        can_request_admin_profile=True,
+    )
+    profile = RemediationSecurityProfile(
+        profile_ref="profile-1",
+        execution_principal="service:remediation",
+        allowed_action_kinds=("execution.pause", "execution.resume"),
+    )
+    rows = service.list_allowed_actions(
+        permissions=permissions,
+        security_profile=profile,
+        capability_context=RemediationCapabilityContext(
+            policy_allowed_action_kinds=("execution.pause",),
+            target_runtime="temporal",
+            host_mode="managed",
+        ),
+    )
+    assert [row["actionKind"] for row in rows] == ["execution.pause"]

--- a/tests/unit/workflows/temporal/test_remediation_issue_3624.py
+++ b/tests/unit/workflows/temporal/test_remediation_issue_3624.py
@@ -1,0 +1,83 @@
+"""Capability-truthful remediation catalog coverage for GitHub issue #3624."""
+
+from moonmind.workflows.temporal.remediation_actions import (
+    remediation_action_capability,
+    remediation_action_capability_matrix,
+    remediation_action_kinds,
+)
+from api_service.services.remediation_actions import (
+    build_remediation_action_executor,
+)
+
+
+def test_capability_matrix_has_one_complete_row_per_catalog_action() -> None:
+    matrix = remediation_action_capability_matrix()
+    assert len(matrix) == len({row["actionKind"] for row in matrix})
+    for row in matrix:
+        assert set(
+            (
+                "requestable",
+                "dryRunSupported",
+                "executionBackendReady",
+                "approvalBackendReady",
+                "verificationBackendReady",
+                "supportedTargetRuntimes",
+                "supportedHostModes",
+                "requiredEvidenceClasses",
+                "blockedReasons",
+            )
+        ).issubset(row)
+        assert row["requestable"] is (not row["blockedReasons"])
+
+
+def test_every_requestable_action_has_execution_and_verification_owners() -> None:
+    for action_kind in remediation_action_kinds():
+        capability = remediation_action_capability(action_kind)
+        assert capability["executionBackendReady"] is True
+        assert capability["approvalBackendReady"] is True
+        assert capability["verificationBackendReady"] is True
+
+
+def test_incomplete_owners_are_disabled_with_bounded_reasons() -> None:
+    expected = {
+        "session.terminate": {
+            "execution_backend_unavailable",
+            "authoritative_verifier_unavailable",
+        },
+        "session.restart_container": {
+            "execution_backend_unavailable",
+            "authoritative_verifier_unavailable",
+        },
+        "cleanup.request_janitor": {
+            "execution_backend_unavailable",
+            "authoritative_verifier_unavailable",
+        },
+        "cleanup.verify": {
+            "execution_backend_unavailable",
+            "authoritative_verifier_unavailable",
+        },
+        "target.annotate": {
+            "execution_backend_unavailable",
+            "authoritative_verifier_unavailable",
+        },
+        "target.verify": {
+            "execution_backend_unavailable",
+            "authoritative_verifier_unavailable",
+        },
+        "host.restart": {"authoritative_verifier_unavailable"},
+        "workload.restart_helper_container": {
+            "authoritative_verifier_unavailable"
+        },
+    }
+    for action_kind, reasons in expected.items():
+        capability = remediation_action_capability(action_kind)
+        assert capability["requestable"] is False
+        assert set(capability["blockedReasons"]) == reasons
+
+
+def test_production_executor_registers_only_requestable_actions() -> None:
+    executor = build_remediation_action_executor()
+    assert set(executor._adapters) == set(remediation_action_kinds())
+    assert "session.terminate" not in executor._adapters
+    assert "cleanup.request_janitor" not in executor._adapters
+    assert "host.restart" not in executor._adapters


### PR DESCRIPTION
Issue: MoonLadderStudios/MoonMind#3624

Closes MoonLadderStudios/MoonMind#3624

## Summary

- add a capability/readiness model that intersects policy, permissions, target state and evidence, execution, approval, verification, runtime, and host support
- publish evaluated remediation capabilities in Workflow Detail and register only requestable actions
- disable incomplete action owners before mutation with bounded reasons, while preserving typed outcomes and verification contracts
- align Omnigent target classification across managed sessions, provider-profile leases, workload containers, hosts, and host leases
- update remediation documentation and regression coverage

## Tests run

- `moonmind container python-tests tests/unit/workflows/temporal/test_remediation_issue_3624.py tests/unit/api/routers/test_remediation_capability_projection.py tests/unit/workflows/temporal/test_remediation_context.py tests/unit/workflows/temporal/test_remediation_verification.py` — 108 passed
- workspace skill-projection preflight — passed
- `git diff --check origin/main...HEAD` — passed

## Remaining risks

Incomplete adapters remain intentionally unavailable until their owning execution and authoritative verification backends are ready. The focused unit suite passed; no broader integration suite was run for this bounded change.