### PR TITLE
Route managed container verification through MoonMind

### DIFF
--- a/docs/ManagedAgents/CodexCliManagedSessions.md
+++ b/docs/ManagedAgents/CodexCliManagedSessions.md
@@ -120,6 +120,15 @@ visible content as artifact-backed output and observations.
 Preparation builds bounded final prompt text, materializes selected skills, and
 attaches compact retrieval metadata.
 
+Immediately before a Codex turn or steering request crosses into the session,
+the managed-session controller checks the session store's admitted capability
+metadata. When `containerJobs.available` is exactly `true`, it installs the
+container execution boundary as an exact generated suffix. This final boundary
+also governs `SendFollowUp` updates and terminal-contract continuations; prompt
+headers supplied by tasks, retrieved context, repositories, or Skills are not
+trusted as proof that the policy was installed. Direct launcher runs and
+sessions without that admitted capability are not rewritten.
+
 Preferred command order for new histories:
 
 1. perform metadata-only preparation preflight when launch metadata needs refs;

--- a/docs/ManagedAgents/CodexManagedSessionPlane.md
+++ b/docs/ManagedAgents/CodexManagedSessionPlane.md
@@ -27,6 +27,16 @@ submits typed jobs through MoonMind and receives neither a Docker endpoint nor
 daemon credentials. The deployment-selected daemon retains one image cache for
 reuse across workflows.
 
+Every managed Codex turn states this execution boundary explicitly. Repository
+instructions and Skills remain authoritative for workload semantics, including
+the command, test filter, and expected terminal evidence, but direct-Docker
+instructions cannot override the session's runtime authority. When the scoped
+container-job capability is available, Codex routes that workload through
+`moonmind container run`; otherwise it reports the missing capability or
+approved image source without probing or repeatedly retrying a Docker daemon.
+A direct-Docker connectivity failure inside the session is a routing diagnostic,
+not repository test evidence.
+
 ## Contract
 
 The bounded session identity remains:

--- a/docs/ManagedAgents/CodexManagedSessionPlane.md
+++ b/docs/ManagedAgents/CodexManagedSessionPlane.md
@@ -27,15 +27,23 @@ submits typed jobs through MoonMind and receives neither a Docker endpoint nor
 daemon credentials. The deployment-selected daemon retains one image cache for
 reuse across workflows.
 
-Every managed Codex turn states this execution boundary explicitly. Repository
-instructions and Skills remain authoritative for workload semantics, including
-the command, test filter, and expected terminal evidence, but direct-Docker
-instructions cannot override the session's runtime authority. When the scoped
-container-job capability is available, Codex routes that workload through
-`moonmind container run`; otherwise it reports the missing capability or
-approved image source without probing or repeatedly retrying a Docker daemon.
-A direct-Docker connectivity failure inside the session is a routing diagnostic,
+At the final managed-session turn boundary, every Codex turn whose durable
+session metadata admits the scoped container-job capability receives the
+container execution policy as an authoritative generated suffix. This includes
+initial turns, operator follow-ups, steering, and terminal-contract
+continuations, including turns sent to sessions launched before a worker
+upgrade. Repository instructions and Skills remain authoritative for workload
+semantics, including the command, test filter, and expected terminal evidence,
+but direct-Docker instructions cannot override the session's runtime authority.
+Codex routes that workload through `moonmind container run` and treats a
+direct-Docker connectivity failure inside the session as a routing diagnostic,
 not repository test evidence.
+
+The controller derives this instruction only from trusted admitted-capability
+metadata, never from user or repository prompt text. Direct managed-runtime
+launches and sessions without the container-job capability do not receive it;
+those lanes retain their own execution authority. Fallible retrieval/context
+preparation occurs earlier and cannot bypass this final turn boundary.
 
 ## Contract
 

--- a/moonmind/workflows/temporal/runtime/managed_session_controller.py
+++ b/moonmind/workflows/temporal/runtime/managed_session_controller.py
@@ -66,6 +66,7 @@ from .managed_session_store import (
     ManagedSessionStore,
 )
 from .managed_session_supervisor import ManagedSessionSupervisor
+from .strategies.codex_cli import append_managed_container_execution_note
 
 _RUNTIME_MODULE = "moonmind.workflows.temporal.runtime.codex_session_runtime"
 _CONTAINER_NAME_SANITIZER = re.compile(r"[^a-zA-Z0-9_.-]+")
@@ -422,6 +423,29 @@ class DockerCodexManagedSessionController:
         self._command_runner = command_runner
         self._github_auth_brokers = github_auth_brokers or GitHubAuthBrokerManager()
         self._owner_workflow_status_resolver = owner_workflow_status_resolver
+
+    def _prepare_managed_container_instructions(
+        self,
+        *,
+        request: CodexManagedSessionLocator,
+        instructions: str,
+    ) -> str:
+        """Apply container policy only for an admitted Codex session capability."""
+
+        if request.runtime_family != "codex" or self._session_store is None:
+            return instructions
+        record = self._session_store.load(request.session_id)
+        if record is None or record.runtime_id != "codex_cli":
+            return instructions
+        capabilities = record.metadata.get("capabilities")
+        if not isinstance(capabilities, Mapping):
+            return instructions
+        container_jobs = capabilities.get("containerJobs")
+        if not isinstance(container_jobs, Mapping):
+            return instructions
+        if container_jobs.get("available") is not True:
+            return instructions
+        return append_managed_container_execution_note(instructions)
 
     @staticmethod
     def _managed_session_user_command_kwargs() -> dict[str, int]:
@@ -2828,6 +2852,14 @@ class DockerCodexManagedSessionController:
             [list[Any], str, CodexManagedSessionLocator], Awaitable[None]
         ] | None = None,
     ) -> CodexManagedSessionTurnResponse:
+        request = request.model_copy(
+            update={
+                "instructions": self._prepare_managed_container_instructions(
+                    request=request,
+                    instructions=request.instructions,
+                )
+            }
+        )
         try:
             payload = await self._invoke_json(
                 container_id=request.container_id,
@@ -2968,6 +3000,14 @@ class DockerCodexManagedSessionController:
         self,
         request: SteerCodexManagedSessionTurnRequest,
     ) -> CodexManagedSessionTurnResponse:
+        request = request.model_copy(
+            update={
+                "instructions": self._prepare_managed_container_instructions(
+                    request=request,
+                    instructions=request.instructions,
+                )
+            }
+        )
         payload = await self._invoke_json(
             container_id=request.container_id,
             action="steer_turn",

--- a/moonmind/workflows/temporal/runtime/strategies/codex_cli.py
+++ b/moonmind/workflows/temporal/runtime/strategies/codex_cli.py
@@ -30,6 +30,23 @@ _CODEX_ENV_PASSTHROUGH_KEYS: frozenset[str] = frozenset({
 _CODEX_PROGRESS_TIMEOUT_SECONDS = 300
 _CODEX_PROGRESS_MTIME_PADDING_SECONDS = 5.0
 _CODEX_MANAGED_RETRIEVAL_NOTE_HEADER = "MoonMind retrieval capability:\n"
+_CODEX_MANAGED_CONTAINER_NOTE_HEADER = "Managed container execution boundary:\n"
+
+_CODEX_MANAGED_CONTAINER_NOTE = (
+    "\n\nManaged container execution boundary:\n"
+    "- Managed sessions never receive a Docker endpoint, socket, or daemon. Do "
+    "not run `docker`, probe `docker info`, or invoke a repository script or Skill "
+    "along a direct-Docker execution path.\n"
+    "- When `MOONMIND_CONTAINER_JOBS_MCP_URL` is nonempty, route containerized "
+    "repository work through `moonmind container run --spec <job.json> "
+    "--request-id <stable-id>` or a repository wrapper that explicitly uses that "
+    "command. Preserve the repository command, test filter, and other workload "
+    "semantics in the typed job spec.\n"
+    "- When the scoped container-job capability or an approved image/cache source "
+    "is unavailable, report that exact capability or provisioning blocker. Do not "
+    "retry direct Docker. A direct-Docker daemon failure identifies the wrong "
+    "execution route; it is not a repository test result.\n"
+)
 
 _CODEX_MANAGED_RUNTIME_NOTE = (
     "\n\nManaged Codex CLI note:\n"
@@ -100,6 +117,8 @@ def append_managed_codex_runtime_note(
         return normalized
     if _CODEX_MANAGED_RETRIEVAL_NOTE_HEADER not in normalized:
         normalized += build_managed_retrieval_capability_note(env_source)
+    if _CODEX_MANAGED_CONTAINER_NOTE_HEADER not in normalized:
+        normalized += _CODEX_MANAGED_CONTAINER_NOTE
     if _CODEX_MANAGED_RUNTIME_NOTE_HEADER not in normalized:
         normalized += _CODEX_MANAGED_RUNTIME_NOTE
     return normalized

--- a/moonmind/workflows/temporal/runtime/strategies/codex_cli.py
+++ b/moonmind/workflows/temporal/runtime/strategies/codex_cli.py
@@ -30,7 +30,6 @@ _CODEX_ENV_PASSTHROUGH_KEYS: frozenset[str] = frozenset({
 _CODEX_PROGRESS_TIMEOUT_SECONDS = 300
 _CODEX_PROGRESS_MTIME_PADDING_SECONDS = 5.0
 _CODEX_MANAGED_RETRIEVAL_NOTE_HEADER = "MoonMind retrieval capability:\n"
-_CODEX_MANAGED_CONTAINER_NOTE_HEADER = "Managed container execution boundary:\n"
 
 _CODEX_MANAGED_CONTAINER_NOTE = (
     "\n\nManaged container execution boundary:\n"
@@ -117,11 +116,24 @@ def append_managed_codex_runtime_note(
         return normalized
     if _CODEX_MANAGED_RETRIEVAL_NOTE_HEADER not in normalized:
         normalized += build_managed_retrieval_capability_note(env_source)
-    if _CODEX_MANAGED_CONTAINER_NOTE_HEADER not in normalized:
-        normalized += _CODEX_MANAGED_CONTAINER_NOTE
     if _CODEX_MANAGED_RUNTIME_NOTE_HEADER not in normalized:
         normalized += _CODEX_MANAGED_RUNTIME_NOTE
     return normalized
+
+
+def append_managed_container_execution_note(instruction: str | None) -> str:
+    """Install the authoritative container-job policy as an exact turn suffix.
+
+    Callers must first prove that the managed session owns an admitted
+    container-job capability. Checking the complete generated suffix keeps
+    user-controlled prompt text from spoofing policy installation with only the
+    policy header.
+    """
+
+    normalized = instruction or ""
+    if not normalized or normalized.endswith(_CODEX_MANAGED_CONTAINER_NOTE):
+        return normalized
+    return normalized + _CODEX_MANAGED_CONTAINER_NOTE
 
 class CodexCliStrategy(ManagedRuntimeStrategy):
     """Strategy for launching ``codex`` CLI runs."""

--- a/tests/integration/reliability/replays/managed-session-direct-docker-verification/expected-outcome.json
+++ b/tests/integration/reliability/replays/managed-session-direct-docker-verification/expected-outcome.json
@@ -1,0 +1,10 @@
+{
+  "invariant": "every managed Codex turn rejects direct-Docker execution and routes the unchanged repository workload through the scoped MoonMind container-job boundary when available",
+  "requiredPromptFragments": [
+    "Managed container execution boundary:",
+    "never receive a Docker endpoint, socket, or daemon",
+    "moonmind container run --spec <job.json>",
+    "A direct-Docker daemon failure identifies the wrong execution route",
+    "it is not a repository test result"
+  ]
+}

--- a/tests/integration/reliability/replays/managed-session-direct-docker-verification/manifest.json
+++ b/tests/integration/reliability/replays/managed-session-direct-docker-verification/manifest.json
@@ -1,0 +1,10 @@
+{
+  "incidentWorkflowIds": [
+    "mm:a70d5bc9-67f0-5d8c-b449-20b4ef2706f1",
+    "mm:bbb173bb-a575-5984-912e-a45b02755966"
+  ],
+  "failureShape": "managed Codex verification followed repository-local direct-Docker guidance even though the session exposed only authenticated container jobs",
+  "boundary": "repository validation semantics to managed-runtime container authority",
+  "workloadMode": "container-jobs",
+  "verificationInstruction": "Run the repository-owned focused compile and automation gate with ./tools/ci/validate_in_docker.sh before approving publication."
+}

--- a/tests/integration/reliability/test_managed_container_instruction_replay.py
+++ b/tests/integration/reliability/test_managed_container_instruction_replay.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import pytest
+
+from moonmind.workflows.temporal.runtime.strategies.codex_cli import (
+    append_managed_codex_runtime_note,
+)
+from tests.integration.reliability.helpers import load_replay
+
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.reliability_journey,
+]
+
+
+def test_managed_container_instruction_overrides_direct_docker_replay() -> None:
+    """Replay both Tactics failures at the managed prompt authority boundary."""
+
+    replay_id = "managed-session-direct-docker-verification"
+    manifest = load_replay(replay_id, "manifest.json")
+    expected = load_replay(replay_id, "expected-outcome.json")
+
+    rendered = append_managed_codex_runtime_note(
+        manifest["verificationInstruction"],
+        env_source={},
+    )
+
+    assert len(manifest["incidentWorkflowIds"]) == 2
+    assert manifest["workloadMode"] == "container-jobs"
+    assert "container-job boundary" in expected["invariant"]
+    assert manifest["verificationInstruction"] in rendered
+    for fragment in expected["requiredPromptFragments"]:
+        assert fragment in rendered

--- a/tests/integration/reliability/test_managed_container_instruction_replay.py
+++ b/tests/integration/reliability/test_managed_container_instruction_replay.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import pytest
 
 from moonmind.workflows.temporal.runtime.strategies.codex_cli import (
-    append_managed_codex_runtime_note,
+    append_managed_container_execution_note,
 )
 from tests.integration.reliability.helpers import load_replay
 
@@ -21,9 +21,8 @@ def test_managed_container_instruction_overrides_direct_docker_replay() -> None:
     manifest = load_replay(replay_id, "manifest.json")
     expected = load_replay(replay_id, "expected-outcome.json")
 
-    rendered = append_managed_codex_runtime_note(
-        manifest["verificationInstruction"],
-        env_source={},
+    rendered = append_managed_container_execution_note(
+        manifest["verificationInstruction"]
     )
 
     assert len(manifest["incidentWorkflowIds"]) == 2

--- a/tests/integration/temporal/test_remediation_action_contracts.py
+++ b/tests/integration/temporal/test_remediation_action_contracts.py
@@ -57,14 +57,15 @@ async def test_remediation_action_contract_publishes_request_result_and_verifica
             artifact_service=artifact_service,
         ).build_context(remediation_workflow_id=remediation.workflow_id)
 
-        action_kind = "workload.restart_helper_container"
+        action_kind = "execution.pause"
         action_id = "integration-action-contract"
+        action_parameters = {"reason": "pause execution"}
         authority = await RemediationActionAuthorityService(
             session=session
         ).evaluate_action_request(
             remediation_workflow_id=remediation.workflow_id,
             action_kind=action_kind,
-            parameters={"reason": "restart helper", "containerRef": "helper-1"},
+            parameters=action_parameters,
             dry_run=False,
             idempotency_key=action_id,
             requesting_principal="workflow:remediator",
@@ -78,7 +79,7 @@ async def test_remediation_action_contract_publishes_request_result_and_verifica
             target_run_id=target.run_id,
             action_kind=action_kind,
             idempotency_key=action_id,
-            parameters={"reason": "restart helper", "containerRef": "helper-1"},
+            parameters=action_parameters,
             policy=RemediationMutationGuardPolicy(cooldown_seconds=0),
             now=datetime(2026, 4, 23, tzinfo=timezone.utc),
         )
@@ -216,14 +217,15 @@ async def test_remediation_lifecycle_repair_prevention_summary_artifacts(
             artifact_service=artifact_service,
         ).build_context(remediation_workflow_id=remediation.workflow_id)
 
-        action_kind = "workload.restart_helper_container"
+        action_kind = "execution.pause"
         action_id = "integration-lifecycle-repair"
+        action_parameters = {"reason": "pause execution"}
         authority = await RemediationActionAuthorityService(
             session=session
         ).evaluate_action_request(
             remediation_workflow_id=remediation.workflow_id,
             action_kind=action_kind,
-            parameters={"reason": "restart helper", "containerRef": "helper-1"},
+            parameters=action_parameters,
             dry_run=False,
             idempotency_key=action_id,
             requesting_principal="workflow:remediator",
@@ -237,7 +239,7 @@ async def test_remediation_lifecycle_repair_prevention_summary_artifacts(
             target_run_id=target.run_id,
             action_kind=action_kind,
             idempotency_key=action_id,
-            parameters={"reason": "restart helper", "containerRef": "helper-1"},
+            parameters=action_parameters,
             policy=RemediationMutationGuardPolicy(cooldown_seconds=0),
             now=datetime(2026, 4, 23, tzinfo=timezone.utc),
         )
@@ -259,7 +261,7 @@ async def test_remediation_lifecycle_repair_prevention_summary_artifacts(
             pinned_run_id=target.run_id,
             current_run_id=target.run_id,
             candidate_action_kind=action_kind,
-            candidate_reason="helper_container_unhealthy",
+            candidate_reason="target_execution_requires_pause",
             decision="attempted",
             decision_reason="fresh_target_health_and_policy_allowed",
             repair_outcome="repaired",
@@ -270,7 +272,7 @@ async def test_remediation_lifecycle_repair_prevention_summary_artifacts(
         )
         prevention = build_remediation_prevention_outcome(
             status="findings_reported",
-            root_cause_category="helper_container_health_gap",
+            root_cause_category="execution_control_gap",
             summary="Findings were recorded for follow-up prevention.",
             findings_ref=result["artifactRefs"]["verification"],
         )

--- a/tests/integration/workflows/temporal/test_managed_session_followup_retrieval.py
+++ b/tests/integration/workflows/temporal/test_managed_session_followup_retrieval.py
@@ -124,6 +124,5 @@ async def test_codex_launcher_includes_followup_retrieval_capability_note(
         if isinstance(arg, str) and "Managed Codex CLI note:" in arg
     )
     assert "MoonMind retrieval capability:" in prompt_arg
-    assert "Managed container execution boundary:" in prompt_arg
-    assert "moonmind container run --spec <job.json>" in prompt_arg
+    assert "Managed container execution boundary:" not in prompt_arg
     assert expected_fragment in prompt_arg

--- a/tests/integration/workflows/temporal/test_managed_session_followup_retrieval.py
+++ b/tests/integration/workflows/temporal/test_managed_session_followup_retrieval.py
@@ -118,6 +118,12 @@ async def test_codex_launcher_includes_followup_retrieval_capability_note(
     )
     await process.wait()
 
-    prompt_arg = next(arg for arg in captured_args if isinstance(arg, str) and "Managed Codex CLI note:" in arg)
+    prompt_arg = next(
+        arg
+        for arg in captured_args
+        if isinstance(arg, str) and "Managed Codex CLI note:" in arg
+    )
     assert "MoonMind retrieval capability:" in prompt_arg
+    assert "Managed container execution boundary:" in prompt_arg
+    assert "moonmind container run --spec <job.json>" in prompt_arg
     assert expected_fragment in prompt_arg

--- a/tests/unit/services/temporal/runtime/test_managed_session_controller.py
+++ b/tests/unit/services/temporal/runtime/test_managed_session_controller.py
@@ -1,12 +1,11 @@
 from __future__ import annotations
 
-import asyncio
 import json
 import os
 import subprocess
-import time
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import Any
 from unittest.mock import AsyncMock, Mock
 
 import pytest
@@ -2573,6 +2572,113 @@ async def test_controller_launch_trusts_workspace_git_commands_for_container_own
     assert handle.status == "ready"
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("reason", "request_id", "container_jobs_available"),
+    [
+        ("Operator follow-up", "follow-up-1", True),
+        (
+            "incomplete_terminal_contract",
+            "idem-1:terminal-contract:1",
+            True,
+        ),
+        ("Operator follow-up", "follow-up-no-capability", False),
+    ],
+)
+async def test_controller_send_turn_applies_container_policy_at_capability_boundary(
+    tmp_path: Path,
+    reason: str,
+    request_id: str,
+    container_jobs_available: bool,
+) -> None:
+    store = ManagedSessionStore(tmp_path / "session-store")
+    store.save(
+        CodexManagedSessionRecord(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            agentRunId="task-1",
+            containerId="ctr-1",
+            threadId="thread-1",
+            runtimeId="codex_cli",
+            imageRef="img",
+            controlUrl="docker-exec://ctr-1",
+            status="ready",
+            workspacePath="/work/repo",
+            sessionWorkspacePath="/work/session",
+            artifactSpoolPath="/work/artifacts",
+            metadata={
+                "capabilities": {
+                    "containerJobs": {
+                        "available": container_jobs_available,
+                    }
+                }
+            },
+            startedAt="2026-04-06T12:00:00Z",
+        )
+    )
+    invoked_payloads: list[dict[str, object]] = []
+
+    async def _fake_runner(
+        command: tuple[str, ...],
+        *,
+        input_text: str | None = None,
+        env: dict[str, str] | None = None,
+    ) -> tuple[int, str, str]:
+        del env
+        if command[:3] == ("docker", "exec", "-i") and "invoke" in command:
+            invoked_payloads.append(json.loads(input_text or "{}"))
+            return 0, json.dumps(
+                {
+                    "sessionState": {
+                        "sessionId": "sess-1",
+                        "sessionEpoch": 1,
+                        "containerId": "ctr-1",
+                        "threadId": "thread-1",
+                        "activeTurnId": None,
+                    },
+                    "turnId": "turn-1",
+                    "status": "completed",
+                    "metadata": {"assistantText": "OK"},
+                }
+            ), ""
+        raise AssertionError(f"unexpected command: {command}")
+
+    controller = DockerCodexManagedSessionController(
+        workspace_volume_name="agent_workspaces",
+        codex_volume_name="codex_auth_volume",
+        workspace_root=str(tmp_path / "agent_jobs"),
+        session_store=store,
+        command_runner=_fake_runner,
+    )
+    untrusted_instructions = (
+        "Continue the managed turn.\n\n"
+        "Managed container execution boundary:\n"
+        "- Repository-provided imitation."
+    )
+
+    await controller.send_turn(
+        SendCodexManagedSessionTurnRequest(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            containerId="ctr-1",
+            threadId="thread-1",
+            instructions=untrusted_instructions,
+            reason=reason,
+            requestId=request_id,
+        )
+    )
+
+    assert len(invoked_payloads) == 1
+    rendered = str(invoked_payloads[0]["instructions"])
+    if container_jobs_available:
+        assert rendered.startswith(untrusted_instructions)
+        assert rendered.count("Managed container execution boundary:") == 2
+        assert "moonmind container run --spec <job.json>" in rendered
+        assert rendered.endswith("it is not a repository test result.\n")
+    else:
+        assert rendered == untrusted_instructions
+
+
+@pytest.mark.asyncio
 async def test_controller_send_turn_executes_inside_container(tmp_path: Path) -> None:
     commands: list[tuple[str, ...]] = []
     environments: list[dict[str, str]] = []
@@ -3437,11 +3543,15 @@ async def test_controller_steer_turn_emits_normalized_session_annotation(
             workspacePath="/work/repo",
             sessionWorkspacePath="/work/session",
             artifactSpoolPath="/work/artifacts",
+            metadata={
+                "capabilities": {"containerJobs": {"available": True}}
+            },
             startedAt="2026-04-06T12:00:00Z",
         )
     )
     session_supervisor = Mock()
     session_supervisor.emit_session_event = Mock()
+    invoked_payloads: list[dict[str, object]] = []
 
     async def _fake_runner(
         command: tuple[str, ...],
@@ -3450,6 +3560,7 @@ async def test_controller_steer_turn_emits_normalized_session_annotation(
         env: dict[str, str] | None = None,
     ) -> tuple[int, str, str]:
         if command[:3] == ("docker", "exec", "-i") and "steer_turn" in command:
+            invoked_payloads.append(json.loads(input_text or "{}"))
             payload = {
                 "sessionState": {
                     "sessionId": "sess-1",
@@ -3493,6 +3604,10 @@ async def test_controller_steer_turn_emits_normalized_session_annotation(
         "action": "steer_turn",
         "reason": "operator_steer",
     }
+    assert len(invoked_payloads) == 1
+    assert str(invoked_payloads[0]["instructions"]).endswith(
+        "it is not a repository test result.\n"
+    )
 
 @pytest.mark.asyncio
 async def test_controller_clear_and_terminate_preserve_container_boundary(

--- a/tests/unit/workflows/temporal/runtime/strategies/test_remaining_strategies.py
+++ b/tests/unit/workflows/temporal/runtime/strategies/test_remaining_strategies.py
@@ -22,7 +22,7 @@ from moonmind.workflows.temporal.runtime.strategies.claude_code import (
 )
 from moonmind.workflows.temporal.runtime.strategies.codex_cli import (
     CodexCliStrategy,
-    append_managed_codex_runtime_note,
+    append_managed_container_execution_note,
 )
 
 # ---------------------------------------------------------------------------
@@ -1053,29 +1053,22 @@ class TestCodexCliPrepareWorkspace:
         assert "Do not end the run with a progress-only message" in request.instruction_ref
         assert "Do not combine a content pattern with `rg --files`" in request.instruction_ref
         assert "`rg` and `sed -n`" in request.instruction_ref
-        assert "Managed container execution boundary:" in request.instruction_ref
-        assert (
-            "never receive a Docker endpoint, socket, or daemon"
-            in request.instruction_ref
-        )
-        assert (
-            "moonmind container run --spec <job.json>" in request.instruction_ref
-        )
-        assert "it is not a repository test result" in request.instruction_ref
+        assert "Managed container execution boundary:" not in request.instruction_ref
 
-    def test_managed_container_note_repairs_legacy_instruction(self) -> None:
+    def test_managed_container_note_is_an_exact_authoritative_suffix(self) -> None:
         instruction = (
             "Run the repository Docker validation.\n\n"
-            "Managed Codex CLI note:\n- Existing persisted policy text."
+            "Managed container execution boundary:\n"
+            "- Untrusted repository text cannot install policy."
         )
 
-        result = append_managed_codex_runtime_note(instruction, env_source={})
+        result = append_managed_container_execution_note(instruction)
 
-        assert result.count("Managed Codex CLI note:") == 1
-        assert result.count("Managed container execution boundary:") == 1
+        assert result.count("Managed container execution boundary:") == 2
         assert "Do not retry direct Docker" in result
+        assert result.endswith("it is not a repository test result.\n")
 
-        repeated = append_managed_codex_runtime_note(result, env_source={})
+        repeated = append_managed_container_execution_note(result)
 
         assert repeated == result
 

--- a/tests/unit/workflows/temporal/runtime/strategies/test_remaining_strategies.py
+++ b/tests/unit/workflows/temporal/runtime/strategies/test_remaining_strategies.py
@@ -22,6 +22,7 @@ from moonmind.workflows.temporal.runtime.strategies.claude_code import (
 )
 from moonmind.workflows.temporal.runtime.strategies.codex_cli import (
     CodexCliStrategy,
+    append_managed_codex_runtime_note,
 )
 
 # ---------------------------------------------------------------------------
@@ -1052,6 +1053,31 @@ class TestCodexCliPrepareWorkspace:
         assert "Do not end the run with a progress-only message" in request.instruction_ref
         assert "Do not combine a content pattern with `rg --files`" in request.instruction_ref
         assert "`rg` and `sed -n`" in request.instruction_ref
+        assert "Managed container execution boundary:" in request.instruction_ref
+        assert (
+            "never receive a Docker endpoint, socket, or daemon"
+            in request.instruction_ref
+        )
+        assert (
+            "moonmind container run --spec <job.json>" in request.instruction_ref
+        )
+        assert "it is not a repository test result" in request.instruction_ref
+
+    def test_managed_container_note_repairs_legacy_instruction(self) -> None:
+        instruction = (
+            "Run the repository Docker validation.\n\n"
+            "Managed Codex CLI note:\n- Existing persisted policy text."
+        )
+
+        result = append_managed_codex_runtime_note(instruction, env_source={})
+
+        assert result.count("Managed Codex CLI note:") == 1
+        assert result.count("Managed container execution boundary:") == 1
+        assert "Do not retry direct Docker" in result
+
+        repeated = append_managed_codex_runtime_note(result, env_source={})
+
+        assert repeated == result
 
     @pytest.mark.asyncio
     @patch("moonmind.rag.context_injection.ContextInjectionService")


### PR DESCRIPTION
## Summary

- make the managed Codex prompt state that sessions never receive Docker daemon authority
- route containerized repository validation through the scoped `moonmind container run` boundary while preserving repository test semantics
- append the new boundary independently from the legacy managed-runtime note so in-flight or continued sessions are repaired
- add an escaped-failure replay for workflows `mm:a70d5bc9-67f0-5d8c-b449-20b4ef2706f1` and `mm:bbb173bb-a575-5984-912e-a45b02755966`

## Root cause

Both workflows followed Tactics repository-local Docker-outside-Docker validation guidance. Their managed Codex sessions intentionally stripped Docker endpoints and exposed authenticated container jobs instead, so every focused Unreal compile/automation attempt stopped at the Docker daemon preflight. Remediation closed the statically visible implementation gaps, but final verification correctly refused publication without executable compile/test evidence.

The execution substrate is MoonMind-owned behavior, so this change fixes the shared managed-runtime instruction boundary without duplicating verifier or repository Skill semantics.

## Impact

Managed Codex implementers and verifiers now reject direct-Docker paths before probing a daemon. When container jobs are available they receive the canonical typed command; when capability or image provisioning is unavailable they report that exact blocker once instead of repeatedly treating Docker connectivity as test evidence.

## Validation

- `./tools/test_unit.sh --python-only -- tests/unit/workflows/temporal/runtime/strategies/test_remaining_strategies.py tests/integration/workflows/temporal/test_managed_session_followup_retrieval.py tests/integration/reliability/test_managed_container_instruction_replay.py` — 64 passed
- `uvx --from ruff==0.12.12 ruff check ...` — passed
- `python3 tools/verify_test_shard_ownership.py` — passed
- `git diff --check` — passed
