### PR TITLE
Fix Codex final-answer turn completion

### DIFF
--- a/moonmind/workflows/temporal/runtime/codex_session_runtime.py
+++ b/moonmind/workflows/temporal/runtime/codex_session_runtime.py
@@ -1172,6 +1172,7 @@ class CodexManagedSessionRuntime:
             return _RolloutTurnScan()
         last_text = ""
         terminal_text = ""
+        terminal_text_bound_to_active_turn = False
         terminal_cutoff = None
         references_active_turn = False
         entries_scanned = 0
@@ -1199,6 +1200,12 @@ class CodexManagedSessionRuntime:
                 entries_scanned += 1
                 references_turn = self._payload_references_turn(payload, vendor_turn_id)
                 if references_turn:
+                    if (
+                        not references_active_turn
+                        and terminal_text
+                        and not terminal_text_bound_to_active_turn
+                    ):
+                        terminal_text = ""
                     references_active_turn = True
                     entries_referencing_turn += 1
                     text = self._assistant_text_from_rollout_entry(payload)
@@ -1206,12 +1213,14 @@ class CodexManagedSessionRuntime:
                         last_text = text
                 text = self._terminal_assistant_text_from_rollout_entry(payload)
                 if text:
-                    if references_turn or inside_active_turn:
+                    if references_turn or inside_active_turn or references_active_turn:
                         terminal_text = text
+                        terminal_text_bound_to_active_turn = True
                     elif terminal_cutoff is not None:
                         entry_timestamp = self._rollout_entry_timestamp(payload)
                         if entry_timestamp is not None and entry_timestamp >= terminal_cutoff:
                             terminal_text = text
+                            terminal_text_bound_to_active_turn = False
                 entry_type = str(payload.get("type") or "").strip().lower()
                 if entry_type != "event_msg":
                     continue
@@ -2296,6 +2305,20 @@ class CodexManagedSessionRuntime:
         client: CodexAppServerRpcClient | None = None,
         vendor_thread_id: str | None = None,
     ) -> _CompletedTurnInspection:
+        vendor_thread_path = self._resolved_rollout_path(
+            state=state,
+            thread_payload=thread_payload,
+        )
+        rollout_scan = self._scan_rollout_for_turn(
+            vendor_thread_path,
+            vendor_turn_id=vendor_turn_id,
+            turn_started_at=state.last_control_at,
+        )
+        if rollout_scan.terminal_assistant_text:
+            return _CompletedTurnInspection(
+                assistant_text=rollout_scan.terminal_assistant_text,
+                rollout_scan=rollout_scan,
+            )
         assistant_text = self._extract_assistant_text(
             thread_payload,
             vendor_turn_id=vendor_turn_id,
@@ -2310,15 +2333,6 @@ class CodexManagedSessionRuntime:
             )
             if assistant_text:
                 return _CompletedTurnInspection(assistant_text=assistant_text)
-        vendor_thread_path = self._resolved_rollout_path(
-            state=state,
-            thread_payload=thread_payload,
-        )
-        rollout_scan = self._scan_rollout_for_turn(
-            vendor_thread_path,
-            vendor_turn_id=vendor_turn_id,
-            turn_started_at=state.last_control_at,
-        )
         return _CompletedTurnInspection(
             assistant_text=rollout_scan.assistant_text,
             rollout_scan=rollout_scan,
@@ -2531,24 +2545,6 @@ class CodexManagedSessionRuntime:
                 thread_payload=thread_payload,
                 mirror=rollout_mirror,
             )
-            if rollout_mirror.last_terminal_assistant_text:
-                state = self._load_state()
-                rollout_scan = self._scan_rollout_for_turn(
-                    self._resolved_rollout_path(
-                        state=state,
-                        thread_payload=thread_payload,
-                    ),
-                    vendor_turn_id=vendor_turn_id,
-                    turn_started_at=state.last_control_at,
-                )
-                if rollout_scan.terminal_assistant_text:
-                    outcome = self._rollout_terminal_outcome_from_scan(
-                        rollout_scan,
-                        vendor_turn_id=vendor_turn_id,
-                        turn_started_at=state.last_control_at,
-                    )
-                    if outcome is not None:
-                        return thread_payload, outcome
             turn_payload = self._find_turn_payload(
                 thread_payload,
                 vendor_turn_id=vendor_turn_id,
@@ -2565,6 +2561,24 @@ class CodexManagedSessionRuntime:
                 )
                 if outcome is not None:
                     return thread_payload, outcome
+                if rollout_mirror.last_terminal_assistant_text:
+                    state = self._load_state()
+                    rollout_scan = self._scan_rollout_for_turn(
+                        self._resolved_rollout_path(
+                            state=state,
+                            thread_payload=thread_payload,
+                        ),
+                        vendor_turn_id=vendor_turn_id,
+                        turn_started_at=state.last_control_at,
+                    )
+                    if rollout_scan.terminal_assistant_text:
+                        outcome = self._rollout_terminal_outcome_from_scan(
+                            rollout_scan,
+                            vendor_turn_id=vendor_turn_id,
+                            turn_started_at=state.last_control_at,
+                        )
+                        if outcome is not None:
+                            return thread_payload, outcome
             else:
                 state = self._load_state()
                 vendor_thread_path = self._resolved_rollout_path(
@@ -2844,6 +2858,26 @@ class CodexManagedSessionRuntime:
         if status in {"failed", "interrupted"} and error_text and previous_status != status:
             self._append_spool("stderr", f"turn {status}: {error_text}\n")
 
+    @staticmethod
+    def _assistant_text_was_published(
+        state: CodexSessionRuntimeState,
+        *,
+        turn_id: str,
+        assistant_text: str,
+    ) -> bool:
+        expected = assistant_text.strip()
+        if not expected:
+            return False
+        for event in state.observability_events:
+            if event.get("kind") != "assistant_message_completed":
+                continue
+            if str(event.get("turnId") or "").strip() != turn_id:
+                continue
+            observed = str(event.get("text") or "").strip()
+            if observed.removeprefix("assistant: ").strip() == expected:
+                return True
+        return False
+
     def _refresh_turn_state(
         self,
         state: CodexSessionRuntimeState,
@@ -2882,6 +2916,12 @@ class CodexManagedSessionRuntime:
         outcome = None
         if isinstance(turn_payload, Mapping):
             outcome = self._terminal_turn_outcome(turn_payload)
+            if outcome is None:
+                outcome = self._failed_thread_terminal_outcome(
+                    state=state,
+                    thread_payload=thread_payload,
+                    vendor_turn_id=active_turn_id,
+                )
             if outcome is None:
                 vendor_thread_path = self._resolved_rollout_path(
                     state=state,
@@ -2947,6 +2987,11 @@ class CodexManagedSessionRuntime:
             status=status,
             assistant_text=assistant_text,
             error_text=error_text,
+            append_assistant_to_spool=not self._assistant_text_was_published(
+                state,
+                turn_id=active_turn_id,
+                assistant_text=assistant_text,
+            ),
             failure_class=failure_class,
             disposition=disposition,
         )

--- a/moonmind/workflows/temporal/runtime/codex_session_runtime.py
+++ b/moonmind/workflows/temporal/runtime/codex_session_runtime.py
@@ -144,6 +144,7 @@ def _redact_text(value: Any, *, max_chars: int) -> str:
 class _RolloutTurnScan:
     references_turn: bool = False
     assistant_text: str = ""
+    terminal_assistant_text: str = ""
     saw_task_complete: bool = False
     error_text: str | None = None
     provider_failure_reason: str | None = None
@@ -191,6 +192,7 @@ class _RolloutLiveMirror:
     offset: int = 0
     turn_started_at: float | None = None
     last_assistant_text: str = ""
+    last_terminal_assistant_text: str = ""
     last_assistant_text_matches_active_turn: bool = False
     inside_active_turn: bool = False
     emitted_assistant_texts: set[str] = field(default_factory=set)
@@ -1204,7 +1206,7 @@ class CodexManagedSessionRuntime:
                         last_text = text
                 text = self._terminal_assistant_text_from_rollout_entry(payload)
                 if text:
-                    if references_turn:
+                    if references_turn or inside_active_turn:
                         terminal_text = text
                     elif terminal_cutoff is not None:
                         entry_timestamp = self._rollout_entry_timestamp(payload)
@@ -1244,7 +1246,8 @@ class CodexManagedSessionRuntime:
             return _RolloutTurnScan()
         return _RolloutTurnScan(
             references_turn=references_active_turn,
-            assistant_text=last_text or terminal_text,
+            assistant_text=terminal_text or last_text,
+            terminal_assistant_text=terminal_text,
             saw_task_complete=saw_task_complete,
             error_text=error_text,
             provider_failure_reason=provider_failure_reason,
@@ -1531,6 +1534,10 @@ class CodexManagedSessionRuntime:
                         if normalized_text and belongs_to_active_turn:
                             mirror.last_assistant_text = normalized_text
                             mirror.last_assistant_text_matches_active_turn = True
+                            if self._terminal_assistant_text_from_rollout_entry(
+                                payload
+                            ):
+                                mirror.last_terminal_assistant_text = normalized_text
                         if normalized_text in mirror.emitted_assistant_texts:
                             mirror.offset = handle.tell()
                             continue
@@ -1965,6 +1972,7 @@ class CodexManagedSessionRuntime:
             "entriesScanned": scan.entries_scanned,
             "entriesReferencingTurn": scan.entries_referencing_turn,
             "referencesTurn": scan.references_turn,
+            "sawTerminalAssistant": bool(scan.terminal_assistant_text),
             "sawTaskComplete": scan.saw_task_complete,
             "eventTypes": list(scan.event_types),
             "errorText": cls._diagnostic_value(scan.error_text),
@@ -2523,6 +2531,24 @@ class CodexManagedSessionRuntime:
                 thread_payload=thread_payload,
                 mirror=rollout_mirror,
             )
+            if rollout_mirror.last_terminal_assistant_text:
+                state = self._load_state()
+                rollout_scan = self._scan_rollout_for_turn(
+                    self._resolved_rollout_path(
+                        state=state,
+                        thread_payload=thread_payload,
+                    ),
+                    vendor_turn_id=vendor_turn_id,
+                    turn_started_at=state.last_control_at,
+                )
+                if rollout_scan.terminal_assistant_text:
+                    outcome = self._rollout_terminal_outcome_from_scan(
+                        rollout_scan,
+                        vendor_turn_id=vendor_turn_id,
+                        turn_started_at=state.last_control_at,
+                    )
+                    if outcome is not None:
+                        return thread_payload, outcome
             turn_payload = self._find_turn_payload(
                 thread_payload,
                 vendor_turn_id=vendor_turn_id,
@@ -2857,7 +2883,24 @@ class CodexManagedSessionRuntime:
         if isinstance(turn_payload, Mapping):
             outcome = self._terminal_turn_outcome(turn_payload)
             if outcome is None:
-                return state
+                vendor_thread_path = self._resolved_rollout_path(
+                    state=state,
+                    thread_payload=thread_payload,
+                )
+                rollout_scan = self._scan_rollout_for_turn(
+                    vendor_thread_path,
+                    vendor_turn_id=active_turn_id,
+                    turn_started_at=state.last_control_at,
+                )
+                if not rollout_scan.terminal_assistant_text:
+                    return state
+                outcome = self._rollout_terminal_outcome_from_scan(
+                    rollout_scan,
+                    vendor_turn_id=active_turn_id,
+                    turn_started_at=state.last_control_at,
+                )
+                if outcome is None:
+                    return state
         else:
             outcome = self._missing_turn_terminal_outcome(
                 state=state,

--- a/tests/helpers/codex_session_runtime.py
+++ b/tests/helpers/codex_session_runtime.py
@@ -14,6 +14,7 @@ def write_fake_app_server(
     omit_turns_on_initial_reads: int = 0,
     omit_turns_when_incomplete: bool = False,
     assistant_text: str = "OK",
+    incomplete_assistant_text: str | None = None,
     thread_status_type: str = "idle",
     thread_status_reason: str | None = None,
     fail_thread_resume: bool = False,
@@ -69,6 +70,7 @@ OMIT_TURNS_ON_READ = __OMIT_TURNS_ON_READ__
 OMIT_TURNS_ON_INITIAL_READS = __OMIT_TURNS_ON_INITIAL_READS__
 OMIT_TURNS_WHEN_INCOMPLETE = __OMIT_TURNS_WHEN_INCOMPLETE__
 ASSISTANT_TEXT = __ASSISTANT_TEXT__
+INCOMPLETE_ASSISTANT_TEXT = __INCOMPLETE_ASSISTANT_TEXT__
 THREAD_STATUS_TYPE = __THREAD_STATUS_TYPE__
 THREAD_STATUS_REASON = __THREAD_STATUS_REASON__
 ROLLOUT_ENTRIES_ON_READ = __ROLLOUT_ENTRIES_ON_READ__
@@ -298,6 +300,10 @@ __COMPLETION_BLOCK__
             turn_items = [
                 {"type": "agentMessage", "id": "msg-1", "text": ASSISTANT_TEXT, "phase": "final_answer", "memoryCitation": None}
             ]
+        elif INCOMPLETE_ASSISTANT_TEXT is not None:
+            turn_items = [
+                {"type": "agentMessage", "id": "msg-1", "text": INCOMPLETE_ASSISTANT_TEXT, "phase": "commentary", "memoryCitation": None}
+            ]
         should_omit_turns = (
             (OMIT_TURNS_ON_READ or thread_read_attempts <= OMIT_TURNS_ON_INITIAL_READS)
             and (turn_completed or OMIT_TURNS_WHEN_INCOMPLETE)
@@ -388,6 +394,7 @@ __COMPLETION_BLOCK__
         .replace("__START_THREAD_ID__", repr(start_thread_id))
         .replace("__START_THREAD_PATH__", repr(start_thread_path))
         .replace("__ASSISTANT_TEXT__", repr(assistant_text))
+        .replace("__INCOMPLETE_ASSISTANT_TEXT__", repr(incomplete_assistant_text))
         .replace("__THREAD_STATUS_TYPE__", repr(thread_status_type))
         .replace("__THREAD_STATUS_REASON__", repr(thread_status_reason))
         .replace("__ROLLOUT_ENTRIES_ON_READ__", repr(rollout_entries_on_read or []))

--- a/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
+++ b/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
@@ -2481,6 +2481,195 @@ def test_runtime_send_turn_stays_running_when_rollout_turn_has_not_completed(
     assert handle.status == "busy"
     assert handle.metadata["lastTurnStatus"] == "running"
 
+
+def test_runtime_send_turn_completes_from_final_answer_when_turn_status_is_stale(
+    tmp_path: Path,
+) -> None:
+    request = launch_request(tmp_path)
+    transcript_path = (
+        Path(request.codex_home_path)
+        / "sessions"
+        / "2026"
+        / "08"
+        / "10"
+        / "rollout-2026-08-10T15-09-29-vendor-thread-1.jsonl"
+    )
+    transcript_path.parent.mkdir(parents=True, exist_ok=True)
+    transcript_path.write_text("", encoding="utf-8")
+    script = write_fake_app_server(
+        tmp_path,
+        completion_notification_method=None,
+        complete_turn_on_read=False,
+        start_thread_path=str(transcript_path),
+        thread_status_type="active",
+        rollout_entries_on_read=[
+            {
+                "timestamp": _iso_timestamp(minutes_offset=0),
+                "type": "event_msg",
+                "payload": {
+                    "type": "task_started",
+                    "turn_id": "vendor-turn-1",
+                },
+            },
+            {
+                "timestamp": _iso_timestamp(minutes_offset=0),
+                "type": "response_item",
+                "payload": {
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [
+                        {"type": "output_text", "text": "Still working"}
+                    ],
+                    "phase": "commentary",
+                },
+            },
+            {
+                "timestamp": _iso_timestamp(minutes_offset=0),
+                "type": "response_item",
+                "payload": {
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [
+                        {"type": "output_text", "text": "Authoritative result"}
+                    ],
+                    "phase": "final_answer",
+                },
+            },
+        ],
+    )
+    runtime = CodexManagedSessionRuntime(
+        workspace_path=request.workspace_path,
+        session_workspace_path=request.session_workspace_path,
+        artifact_spool_path=request.artifact_spool_path,
+        codex_home_path=request.codex_home_path,
+        image_ref=request.image_ref,
+        control_url="docker-exec://mm-codex-session-sess-1",
+        container_id="ctr-1",
+        app_server_command=("python3", str(script)),
+        turn_completion_timeout_seconds=0.1,
+    )
+    runtime.launch_session(request)
+
+    response = runtime.send_turn(
+        SendCodexManagedSessionTurnRequest(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            containerId="ctr-1",
+            threadId="logical-thread-1",
+            instructions="Reply with exactly the word OK",
+        )
+    )
+
+    assert response.status == "completed"
+    assert response.session_state.active_turn_id is None
+    assert response.metadata["assistantText"] == "Authoritative result"
+
+
+def test_runtime_send_turn_does_not_complete_from_commentary_when_status_is_stale(
+    tmp_path: Path,
+) -> None:
+    request = launch_request(tmp_path)
+    transcript_path = (
+        Path(request.codex_home_path)
+        / "sessions"
+        / "2026"
+        / "08"
+        / "10"
+        / "rollout-2026-08-10T15-09-29-vendor-thread-1.jsonl"
+    )
+    transcript_path.parent.mkdir(parents=True, exist_ok=True)
+    transcript_path.write_text("", encoding="utf-8")
+    script = write_fake_app_server(
+        tmp_path,
+        completion_notification_method=None,
+        complete_turn_on_read=False,
+        start_thread_path=str(transcript_path),
+        thread_status_type="active",
+        rollout_entries_on_read=[
+            {
+                "timestamp": _iso_timestamp(minutes_offset=0),
+                "type": "event_msg",
+                "payload": {
+                    "type": "task_started",
+                    "turn_id": "vendor-turn-1",
+                },
+            },
+            {
+                "timestamp": _iso_timestamp(minutes_offset=0),
+                "type": "response_item",
+                "payload": {
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [
+                        {"type": "output_text", "text": "Still working"}
+                    ],
+                    "phase": "commentary",
+                },
+            },
+        ],
+    )
+    runtime = CodexManagedSessionRuntime(
+        workspace_path=request.workspace_path,
+        session_workspace_path=request.session_workspace_path,
+        artifact_spool_path=request.artifact_spool_path,
+        codex_home_path=request.codex_home_path,
+        image_ref=request.image_ref,
+        control_url="docker-exec://mm-codex-session-sess-1",
+        container_id="ctr-1",
+        app_server_command=("python3", str(script)),
+        turn_completion_timeout_seconds=0.01,
+    )
+    runtime.launch_session(request)
+
+    response = runtime.send_turn(
+        SendCodexManagedSessionTurnRequest(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            containerId="ctr-1",
+            threadId="logical-thread-1",
+            instructions="Reply with exactly the word OK",
+        )
+    )
+
+    assert response.status == "running"
+    assert response.session_state.active_turn_id == "vendor-turn-1"
+
+    with transcript_path.open("a", encoding="utf-8") as handle:
+        handle.write(
+            json.dumps(
+                {
+                    "timestamp": _iso_timestamp(minutes_offset=0),
+                    "type": "response_item",
+                    "payload": {
+                        "type": "message",
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "type": "output_text",
+                                "text": "Recovered final result",
+                            }
+                        ],
+                        "phase": "final_answer",
+                    },
+                }
+            )
+            + "\n"
+        )
+
+    handle = runtime.session_status(
+        CodexManagedSessionLocator(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            containerId="ctr-1",
+            threadId="logical-thread-1",
+        )
+    )
+
+    assert handle.status == "ready"
+    assert handle.session_state.active_turn_id is None
+    assert handle.metadata["lastAssistantText"] == "Recovered final result"
+
+
 def test_runtime_session_status_fails_empty_task_complete_after_running_turn(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
+++ b/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
@@ -2500,6 +2500,7 @@ def test_runtime_send_turn_completes_from_final_answer_when_turn_status_is_stale
         tmp_path,
         completion_notification_method=None,
         complete_turn_on_read=False,
+        incomplete_assistant_text="Stale thread commentary",
         start_thread_path=str(transcript_path),
         thread_status_type="active",
         rollout_entries_on_read=[
@@ -2563,6 +2564,161 @@ def test_runtime_send_turn_completes_from_final_answer_when_turn_status_is_stale
     assert response.status == "completed"
     assert response.session_state.active_turn_id is None
     assert response.metadata["assistantText"] == "Authoritative result"
+
+
+def test_runtime_session_status_rejects_prior_turn_final_before_active_boundary(
+    tmp_path: Path,
+) -> None:
+    request = launch_request(tmp_path)
+    transcript_path = (
+        Path(request.codex_home_path)
+        / "sessions"
+        / "2026"
+        / "08"
+        / "10"
+        / "rollout-2026-08-10T15-09-29-vendor-thread-1.jsonl"
+    )
+    transcript_path.parent.mkdir(parents=True, exist_ok=True)
+    transcript_path.write_text(
+        json.dumps(
+            {
+                "timestamp": _iso_timestamp(minutes_offset=0),
+                "type": "response_item",
+                "payload": {
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [
+                        {"type": "output_text", "text": "Previous turn result"}
+                    ],
+                    "phase": "final_answer",
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    script = write_fake_app_server(
+        tmp_path,
+        completion_notification_method=None,
+        complete_turn_on_read=False,
+        start_thread_path=str(transcript_path),
+        thread_status_type="active",
+        rollout_entries_on_read=[
+            {
+                "timestamp": _iso_timestamp(minutes_offset=0),
+                "type": "event_msg",
+                "payload": {
+                    "type": "task_started",
+                    "turn_id": "vendor-turn-1",
+                },
+            }
+        ],
+    )
+    runtime = CodexManagedSessionRuntime(
+        workspace_path=request.workspace_path,
+        session_workspace_path=request.session_workspace_path,
+        artifact_spool_path=request.artifact_spool_path,
+        codex_home_path=request.codex_home_path,
+        image_ref=request.image_ref,
+        control_url="docker-exec://mm-codex-session-sess-1",
+        container_id="ctr-1",
+        app_server_command=("python3", str(script)),
+        turn_completion_timeout_seconds=0.01,
+    )
+    runtime.launch_session(request)
+
+    response = runtime.send_turn(
+        SendCodexManagedSessionTurnRequest(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            containerId="ctr-1",
+            threadId="logical-thread-1",
+            instructions="Reply with exactly the word OK",
+        )
+    )
+    handle = runtime.session_status(
+        CodexManagedSessionLocator(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            containerId="ctr-1",
+            threadId="logical-thread-1",
+        )
+    )
+
+    assert response.status == "running"
+    assert handle.status == "busy"
+    assert handle.session_state.active_turn_id == "vendor-turn-1"
+
+
+def test_runtime_send_turn_prefers_failed_thread_over_rollout_final_answer(
+    tmp_path: Path,
+) -> None:
+    request = launch_request(tmp_path)
+    transcript_path = (
+        Path(request.codex_home_path)
+        / "sessions"
+        / "2026"
+        / "08"
+        / "10"
+        / "rollout-2026-08-10T15-09-29-vendor-thread-1.jsonl"
+    )
+    transcript_path.parent.mkdir(parents=True, exist_ok=True)
+    transcript_path.write_text("", encoding="utf-8")
+    script = write_fake_app_server(
+        tmp_path,
+        completion_notification_method=None,
+        complete_turn_on_read=False,
+        start_thread_path=str(transcript_path),
+        thread_status_type="failed",
+        thread_status_reason="provider failed the thread",
+        rollout_entries_on_read=[
+            {
+                "timestamp": _iso_timestamp(minutes_offset=0),
+                "type": "event_msg",
+                "payload": {
+                    "type": "task_started",
+                    "turn_id": "vendor-turn-1",
+                },
+            },
+            {
+                "timestamp": _iso_timestamp(minutes_offset=0),
+                "type": "response_item",
+                "payload": {
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [
+                        {"type": "output_text", "text": "Do not hide failure"}
+                    ],
+                    "phase": "final_answer",
+                },
+            },
+        ],
+    )
+    runtime = CodexManagedSessionRuntime(
+        workspace_path=request.workspace_path,
+        session_workspace_path=request.session_workspace_path,
+        artifact_spool_path=request.artifact_spool_path,
+        codex_home_path=request.codex_home_path,
+        image_ref=request.image_ref,
+        control_url="docker-exec://mm-codex-session-sess-1",
+        container_id="ctr-1",
+        app_server_command=("python3", str(script)),
+        turn_completion_timeout_seconds=0.1,
+    )
+    runtime.launch_session(request)
+
+    response = runtime.send_turn(
+        SendCodexManagedSessionTurnRequest(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            containerId="ctr-1",
+            threadId="logical-thread-1",
+            instructions="Reply with exactly the word OK",
+        )
+    )
+
+    assert response.status == "failed"
+    assert response.metadata["reason"] == "provider failed the thread"
 
 
 def test_runtime_send_turn_does_not_complete_from_commentary_when_status_is_stale(
@@ -2668,6 +2824,99 @@ def test_runtime_send_turn_does_not_complete_from_commentary_when_status_is_stal
     assert handle.status == "ready"
     assert handle.session_state.active_turn_id is None
     assert handle.metadata["lastAssistantText"] == "Recovered final result"
+
+
+def test_runtime_session_status_does_not_duplicate_published_rollout_final_answer(
+    tmp_path: Path,
+) -> None:
+    request = launch_request(tmp_path)
+    transcript_path = (
+        Path(request.codex_home_path)
+        / "sessions"
+        / "2026"
+        / "08"
+        / "10"
+        / "rollout-2026-08-10T15-09-29-vendor-thread-1.jsonl"
+    )
+    transcript_path.parent.mkdir(parents=True, exist_ok=True)
+    transcript_path.write_text("", encoding="utf-8")
+    script = write_fake_app_server(
+        tmp_path,
+        completion_notification_method=None,
+        complete_turn_on_read=False,
+        start_thread_path=str(transcript_path),
+        thread_status_type="active",
+    )
+    runtime = CodexManagedSessionRuntime(
+        workspace_path=request.workspace_path,
+        session_workspace_path=request.session_workspace_path,
+        artifact_spool_path=request.artifact_spool_path,
+        codex_home_path=request.codex_home_path,
+        image_ref=request.image_ref,
+        control_url="docker-exec://mm-codex-session-sess-1",
+        container_id="ctr-1",
+        app_server_command=("python3", str(script)),
+    )
+    runtime.launch_session(request)
+    state = runtime._load_state()
+    state.active_turn_id = "vendor-turn-1"
+    state.last_turn_id = "vendor-turn-1"
+    state.last_turn_status = "running"
+    state.last_control_at = time.time()
+    state.observability_events = [
+        {
+            "kind": "assistant_message_completed",
+            "turnId": "vendor-turn-1",
+            "text": "assistant: Authoritative result",
+        }
+    ]
+    runtime._save_state(state)
+    transcript_path.write_text(
+        "\n".join(
+            json.dumps(entry)
+            for entry in (
+                {
+                    "timestamp": _iso_timestamp(minutes_offset=0),
+                    "type": "event_msg",
+                    "payload": {
+                        "type": "task_started",
+                        "turn_id": "vendor-turn-1",
+                    },
+                },
+                {
+                    "timestamp": _iso_timestamp(minutes_offset=0),
+                    "type": "response_item",
+                    "payload": {
+                        "type": "message",
+                        "role": "assistant",
+                        "content": [
+                            {"type": "output_text", "text": "Authoritative result"}
+                        ],
+                        "phase": "final_answer",
+                    },
+                },
+            )
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    runtime._append_spool("stdout", "assistant: Authoritative result\n")
+
+    handle = runtime.session_status(
+        CodexManagedSessionLocator(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            containerId="ctr-1",
+            threadId="logical-thread-1",
+        )
+    )
+
+    stdout_text = (Path(request.artifact_spool_path) / "stdout.log").read_text(
+        encoding="utf-8"
+    )
+    assert handle.status == "ready"
+    assert handle.metadata["lastAssistantText"] == "Authoritative result"
+    assert stdout_text.count("assistant: Authoritative result\n") == 1
 
 
 def test_runtime_session_status_fails_empty_task_complete_after_running_turn(


### PR DESCRIPTION
## Summary

- recognize a turn-bound Codex rollout `final` / `final_answer` event as terminal when app-server `thread/read` remains stale
- keep commentary-only output non-terminal
- reconcile an already-running turn from final-answer evidence during a later session-status poll
- expose whether terminal assistant evidence was observed in bounded rollout diagnostics

## Root cause

Workflow `mm:14bd521d-aa2d-4355-9468-86e884302166` produced valid batch fan-out evidence and Codex emitted its final answer, but Codex 0.146 emitted no `turn/completed` or `task_complete` event and continued reporting the turn as `inProgress`. MoonMind streamed the final answer but trusted the stale status until the 3,600-second execution deadline, causing repeated already-completed fan-out attempts.

## Impact

Managed Codex workflows can advance when the authoritative rollout reaches `final_answer` even if app-server status fails to transition. Terminal-contract validation still runs above this boundary before the workflow accepts skill completion, and progress commentary alone cannot complete a turn.

## Validation

- `./tools/test_unit.sh --python-only tests/unit/services/temporal/runtime/test_codex_session_runtime.py` — 101 passed
- `git diff --check` — passed
