### PR TITLE
Recover completed Codex managed turns

### DIFF
--- a/moonmind/workflows/temporal/runtime/codex_session_runtime.py
+++ b/moonmind/workflows/temporal/runtime/codex_session_runtime.py
@@ -1119,6 +1119,29 @@ class CodexManagedSessionRuntime:
         return False
 
     @staticmethod
+    def _payload_has_turn_reference(payload: Any) -> bool:
+        if isinstance(payload, Mapping):
+            if str(payload.get("turnId") or payload.get("turn_id") or "").strip():
+                return True
+            turn_payload = payload.get("turn")
+            if isinstance(turn_payload, Mapping) and str(
+                turn_payload.get("id") or ""
+            ).strip():
+                return True
+            return any(
+                CodexManagedSessionRuntime._payload_has_turn_reference(
+                    payload.get(nested_key)
+                )
+                for nested_key in ("payload", "data", "delta", "item", "event")
+            )
+        if isinstance(payload, list):
+            return any(
+                CodexManagedSessionRuntime._payload_has_turn_reference(item)
+                for item in payload
+            )
+        return False
+
+    @staticmethod
     def _rollout_entry_timestamp(payload: Mapping[str, Any]) -> float | None:
         timestamp_text = str(payload.get("timestamp") or "").strip()
         if not timestamp_text:
@@ -1174,7 +1197,6 @@ class CodexManagedSessionRuntime:
             return _RolloutTurnScan()
         last_text = ""
         terminal_text = ""
-        terminal_cutoff = None
         references_active_turn = False
         entries_scanned = 0
         entries_referencing_turn = 0
@@ -1183,10 +1205,6 @@ class CodexManagedSessionRuntime:
         error_text: str | None = None
         provider_failure_reason: str | None = None
         inside_active_turn = False
-        if turn_started_at is not None:
-            terminal_cutoff = (
-                float(turn_started_at) - _ROLLOUT_RECOVERY_TIMESTAMP_SKEW_SECONDS
-            )
         try:
             rollout_file = Path(rollout_path)
             for stripped in self._iter_rollout_lines(rollout_file):
@@ -1200,40 +1218,37 @@ class CodexManagedSessionRuntime:
                     continue
                 entries_scanned += 1
                 references_turn = self._payload_references_turn(payload, vendor_turn_id)
+                has_turn_reference = self._payload_has_turn_reference(payload)
                 if references_turn:
                     references_active_turn = True
                     entries_referencing_turn += 1
                     text = self._assistant_text_from_rollout_entry(payload)
                     if text:
                         last_text = text
-                text = self._terminal_assistant_text_from_rollout_entry(payload)
-                if text:
-                    if references_turn:
-                        terminal_text = text
-                    elif terminal_cutoff is not None:
-                        entry_timestamp = self._rollout_entry_timestamp(payload)
-                        if entry_timestamp is not None and entry_timestamp >= terminal_cutoff:
-                            terminal_text = text
                 entry_type = str(payload.get("type") or "").strip().lower()
-                if entry_type != "event_msg":
-                    continue
                 event_payload = payload.get("payload")
-                if not isinstance(event_payload, Mapping):
+                event_type = ""
+                if entry_type == "event_msg" and isinstance(event_payload, Mapping):
+                    event_type = str(event_payload.get("type") or "").strip().lower()
+                if event_type == "task_started":
+                    inside_active_turn = references_turn
+                event_belongs_to_turn = references_turn or (
+                    inside_active_turn and not has_turn_reference
+                )
+                text = self._terminal_assistant_text_from_rollout_entry(payload)
+                if text and event_belongs_to_turn:
+                    terminal_text = text
+                if entry_type != "event_msg" or not isinstance(
+                    event_payload, Mapping
+                ):
                     continue
-                event_type = str(event_payload.get("type") or "").strip().lower()
-                event_belongs_to_turn = references_turn or inside_active_turn
-                if event_type == "task_started" and references_turn:
-                    inside_active_turn = True
-                    event_belongs_to_turn = True
                 if event_belongs_to_turn and event_type and event_type not in event_types:
                     event_types.append(event_type)
                 if event_belongs_to_turn and provider_failure_reason is None:
                     provider_failure_reason = (
                         self._provider_failure_reason_from_rollout_event(event_payload)
                     )
-                if not references_turn:
-                    continue
-                if event_type != "task_complete":
+                if event_type != "task_complete" or not event_belongs_to_turn:
                     continue
                 saw_task_complete = True
                 inside_active_turn = False
@@ -1487,6 +1502,7 @@ class CodexManagedSessionRuntime:
                         payload,
                         vendor_turn_id,
                     )
+                    has_turn_reference = self._payload_has_turn_reference(payload)
                     entry_type = str(payload.get("type") or "").strip().lower()
                     event_payload = payload.get("payload")
                     event_type = ""
@@ -1496,10 +1512,11 @@ class CodexManagedSessionRuntime:
                         event_type = str(
                             event_payload.get("type") or ""
                         ).strip().lower()
-                    if event_type == "task_started" and references_turn:
-                        mirror.inside_active_turn = True
+                    if event_type == "task_started":
+                        mirror.inside_active_turn = references_turn
                     belongs_to_active_turn = (
-                        references_turn or mirror.inside_active_turn
+                        references_turn
+                        or (mirror.inside_active_turn and not has_turn_reference)
                     )
                     if (
                         mirror.turn_started_at is not None
@@ -1519,9 +1536,7 @@ class CodexManagedSessionRuntime:
                     terminal_text = self._terminal_assistant_text_from_rollout_entry(
                         payload
                     )
-                    if terminal_text and (
-                        belongs_to_active_turn or entry_timestamp is not None
-                    ):
+                    if terminal_text and belongs_to_active_turn:
                         mirror.terminal_assistant_text = terminal_text
                     if event_type == "task_complete" and belongs_to_active_turn:
                         mirror.saw_task_complete = True
@@ -2403,20 +2418,6 @@ class CodexManagedSessionRuntime:
         client: CodexAppServerRpcClient | None = None,
         vendor_thread_id: str | None = None,
     ) -> _CompletedTurnInspection:
-        assistant_text = self._extract_assistant_text(
-            thread_payload,
-            vendor_turn_id=vendor_turn_id,
-        )
-        if assistant_text:
-            return _CompletedTurnInspection(assistant_text=assistant_text)
-        if client is not None and vendor_thread_id:
-            assistant_text = self._assistant_text_from_turn_items_list(
-                client=client,
-                vendor_thread_id=vendor_thread_id,
-                vendor_turn_id=vendor_turn_id,
-            )
-            if assistant_text:
-                return _CompletedTurnInspection(assistant_text=assistant_text)
         vendor_thread_path = self._resolved_rollout_path(
             state=state,
             thread_payload=thread_payload,
@@ -2426,6 +2427,31 @@ class CodexManagedSessionRuntime:
             vendor_turn_id=vendor_turn_id,
             turn_started_at=state.last_control_at,
         )
+        if rollout_scan.terminal_assistant_text:
+            return _CompletedTurnInspection(
+                assistant_text=rollout_scan.terminal_assistant_text,
+                rollout_scan=rollout_scan,
+            )
+        assistant_text = self._extract_assistant_text(
+            thread_payload,
+            vendor_turn_id=vendor_turn_id,
+        )
+        if assistant_text:
+            return _CompletedTurnInspection(
+                assistant_text=assistant_text,
+                rollout_scan=rollout_scan,
+            )
+        if client is not None and vendor_thread_id:
+            assistant_text = self._assistant_text_from_turn_items_list(
+                client=client,
+                vendor_thread_id=vendor_thread_id,
+                vendor_turn_id=vendor_turn_id,
+            )
+            if assistant_text:
+                return _CompletedTurnInspection(
+                    assistant_text=assistant_text,
+                    rollout_scan=rollout_scan,
+                )
         return _CompletedTurnInspection(
             assistant_text=rollout_scan.assistant_text,
             rollout_scan=rollout_scan,
@@ -2687,7 +2713,7 @@ class CodexManagedSessionRuntime:
                     remaining = deadline - now
                     if grace_remaining > 0 and remaining > 0:
                         try:
-                            client.wait_for_notification(
+                            notification = client.wait_for_notification(
                                 None,
                                 timeout_seconds=min(
                                     _MISSING_TURN_VISIBILITY_RETRY_SECONDS,
@@ -2695,6 +2721,20 @@ class CodexManagedSessionRuntime:
                                     remaining,
                                 ),
                             )
+                            terminal_notification = self._terminal_notification_turn(
+                                notification,
+                                vendor_turn_id=vendor_turn_id,
+                            )
+                            if terminal_notification is not None:
+                                terminal_turn, outcome = terminal_notification
+                                return (
+                                    self._thread_payload_with_terminal_turn(
+                                        thread_payload,
+                                        turn_payload=terminal_turn,
+                                        vendor_turn_id=vendor_turn_id,
+                                    ),
+                                    outcome,
+                                )
                             continue
                         except TimeoutError:
                             # Expected during grace-period polling; retry until the deadline.

--- a/moonmind/workflows/temporal/runtime/codex_session_runtime.py
+++ b/moonmind/workflows/temporal/runtime/codex_session_runtime.py
@@ -144,6 +144,7 @@ def _redact_text(value: Any, *, max_chars: int) -> str:
 class _RolloutTurnScan:
     references_turn: bool = False
     assistant_text: str = ""
+    terminal_assistant_text: str = ""
     saw_task_complete: bool = False
     error_text: str | None = None
     provider_failure_reason: str | None = None
@@ -192,6 +193,9 @@ class _RolloutLiveMirror:
     turn_started_at: float | None = None
     last_assistant_text: str = ""
     last_assistant_text_matches_active_turn: bool = False
+    terminal_assistant_text: str = ""
+    saw_task_complete: bool = False
+    terminal_error_text: str | None = None
     inside_active_turn: bool = False
     emitted_assistant_texts: set[str] = field(default_factory=set)
     emitted_live_keys: set[str] = field(default_factory=set)
@@ -1245,6 +1249,7 @@ class CodexManagedSessionRuntime:
         return _RolloutTurnScan(
             references_turn=references_active_turn,
             assistant_text=last_text or terminal_text,
+            terminal_assistant_text=terminal_text,
             saw_task_complete=saw_task_complete,
             error_text=error_text,
             provider_failure_reason=provider_failure_reason,
@@ -1511,6 +1516,22 @@ class CodexManagedSessionRuntime:
                         mirror.offset = handle.tell()
                         continue
                     live_output = self._rollout_entry_live_output(payload)
+                    terminal_text = self._terminal_assistant_text_from_rollout_entry(
+                        payload
+                    )
+                    if terminal_text and (
+                        belongs_to_active_turn or entry_timestamp is not None
+                    ):
+                        mirror.terminal_assistant_text = terminal_text
+                    if event_type == "task_complete" and belongs_to_active_turn:
+                        mirror.saw_task_complete = True
+                        for field_name in ("error", "reason", "message"):
+                            extracted_error = self._error_text_from_value(
+                                event_payload.get(field_name)
+                            )
+                            if extracted_error:
+                                mirror.terminal_error_text = extracted_error
+                                break
                     if live_output is None:
                         mirror.offset = handle.tell()
                         continue
@@ -1965,6 +1986,7 @@ class CodexManagedSessionRuntime:
             "entriesScanned": scan.entries_scanned,
             "entriesReferencingTurn": scan.entries_referencing_turn,
             "referencesTurn": scan.references_turn,
+            "hasTerminalAssistantText": bool(scan.terminal_assistant_text),
             "sawTaskComplete": scan.saw_task_complete,
             "eventTypes": list(scan.event_types),
             "errorText": cls._diagnostic_value(scan.error_text),
@@ -2211,6 +2233,99 @@ class CodexManagedSessionRuntime:
                     disposition="no_op",
                 )
         return None
+
+    def _stale_turn_rollout_terminal_outcome(
+        self,
+        scan: _RolloutTurnScan,
+        *,
+        vendor_turn_id: str,
+        turn_started_at: float | None,
+    ) -> _TurnTerminalOutcome | None:
+        """Accept only provider-owned terminal transcript evidence.
+
+        A normal assistant message may be commentary emitted while tools are
+        still running, so it cannot override an app-server ``inProgress``
+        projection. A fresh final-phase assistant message or task-complete event
+        is terminal evidence and may reconcile that stale projection.
+        """
+
+        if not (
+            scan.terminal_assistant_text
+            or scan.saw_task_complete
+            or scan.error_text
+        ):
+            return None
+        outcome = self._rollout_terminal_outcome_from_scan(
+            scan,
+            vendor_turn_id=vendor_turn_id,
+            turn_started_at=turn_started_at,
+        )
+        if outcome is not None:
+            return outcome
+        if scan.saw_task_complete:
+            return _TurnTerminalOutcome(status="completed")
+        return None
+
+    @staticmethod
+    def _live_rollout_terminal_outcome(
+        mirror: _RolloutLiveMirror,
+    ) -> _TurnTerminalOutcome | None:
+        if mirror.terminal_error_text:
+            return _TurnTerminalOutcome(
+                status="failed",
+                error_text=mirror.terminal_error_text,
+                failure_class="permanent",
+            )
+        if mirror.terminal_assistant_text or mirror.saw_task_complete:
+            return _TurnTerminalOutcome(status="completed")
+        return None
+
+    @classmethod
+    def _terminal_notification_turn(
+        cls,
+        notification: Mapping[str, Any],
+        *,
+        vendor_turn_id: str,
+    ) -> tuple[Mapping[str, Any], _TurnTerminalOutcome] | None:
+        params = notification.get("params")
+        if not isinstance(params, Mapping):
+            return None
+        turn_payload = params.get("turn")
+        if not isinstance(turn_payload, Mapping):
+            return None
+        if str(turn_payload.get("id") or "").strip() != vendor_turn_id:
+            return None
+        outcome = cls._terminal_turn_outcome(turn_payload)
+        if outcome is None:
+            return None
+        return turn_payload, outcome
+
+    @staticmethod
+    def _thread_payload_with_terminal_turn(
+        thread_payload: Mapping[str, Any],
+        *,
+        turn_payload: Mapping[str, Any],
+        vendor_turn_id: str,
+    ) -> Mapping[str, Any]:
+        merged_payload = dict(thread_payload)
+        raw_thread = thread_payload.get("thread")
+        merged_thread = dict(raw_thread) if isinstance(raw_thread, Mapping) else {}
+        raw_turns = merged_thread.get("turns")
+        turns = list(raw_turns) if isinstance(raw_turns, list) else []
+        replaced = False
+        for index, existing_turn in enumerate(turns):
+            if not isinstance(existing_turn, Mapping):
+                continue
+            if str(existing_turn.get("id") or "").strip() != vendor_turn_id:
+                continue
+            turns[index] = dict(turn_payload)
+            replaced = True
+            break
+        if not replaced:
+            turns.append(dict(turn_payload))
+        merged_thread["turns"] = turns
+        merged_payload["thread"] = merged_thread
+        return merged_payload
 
     def _completed_turn_without_assistant_outcome(
         self,
@@ -2532,6 +2647,9 @@ class CodexManagedSessionRuntime:
                 outcome = self._terminal_turn_outcome(turn_payload)
                 if outcome is not None:
                     return thread_payload, outcome
+                outcome = self._live_rollout_terminal_outcome(rollout_mirror)
+                if outcome is not None:
+                    return thread_payload, outcome
                 outcome = self._failed_thread_terminal_outcome(
                     state=state,
                     thread_payload=thread_payload,
@@ -2599,12 +2717,26 @@ class CodexManagedSessionRuntime:
                 )
 
             try:
-                client.wait_for_notification(
+                notification = client.wait_for_notification(
                     None,
                     timeout_seconds=min(1.0, remaining),
                 )
             except TimeoutError:
                 continue
+            terminal_notification = self._terminal_notification_turn(
+                notification,
+                vendor_turn_id=vendor_turn_id,
+            )
+            if terminal_notification is not None:
+                terminal_turn, outcome = terminal_notification
+                return (
+                    self._thread_payload_with_terminal_turn(
+                        thread_payload,
+                        turn_payload=terminal_turn,
+                        vendor_turn_id=vendor_turn_id,
+                    ),
+                    outcome,
+                )
 
     def _find_vendor_thread_path(self, vendor_thread_id: str) -> str | None:
         sessions_root = self._codex_home_path / "sessions"
@@ -2857,7 +2989,21 @@ class CodexManagedSessionRuntime:
         if isinstance(turn_payload, Mapping):
             outcome = self._terminal_turn_outcome(turn_payload)
             if outcome is None:
-                return state
+                rollout_scan = self._scan_rollout_for_turn(
+                    self._resolved_rollout_path(
+                        state=state,
+                        thread_payload=thread_payload,
+                    ),
+                    vendor_turn_id=active_turn_id,
+                    turn_started_at=state.last_control_at,
+                )
+                outcome = self._stale_turn_rollout_terminal_outcome(
+                    rollout_scan,
+                    vendor_turn_id=active_turn_id,
+                    turn_started_at=state.last_control_at,
+                )
+                if outcome is None:
+                    return state
         else:
             outcome = self._missing_turn_terminal_outcome(
                 state=state,

--- a/tests/helpers/codex_session_runtime.py
+++ b/tests/helpers/codex_session_runtime.py
@@ -16,6 +16,7 @@ def write_fake_app_server(
     omit_turns_on_initial_reads: int = 0,
     omit_turns_when_incomplete: bool = False,
     assistant_text: str = "OK",
+    in_progress_assistant_text: str | None = None,
     thread_status_type: str = "idle",
     thread_status_reason: str | None = None,
     fail_thread_resume: bool = False,
@@ -82,6 +83,7 @@ OMIT_TURNS_ON_READ = __OMIT_TURNS_ON_READ__
 OMIT_TURNS_ON_INITIAL_READS = __OMIT_TURNS_ON_INITIAL_READS__
 OMIT_TURNS_WHEN_INCOMPLETE = __OMIT_TURNS_WHEN_INCOMPLETE__
 ASSISTANT_TEXT = __ASSISTANT_TEXT__
+IN_PROGRESS_ASSISTANT_TEXT = __IN_PROGRESS_ASSISTANT_TEXT__
 THREAD_STATUS_TYPE = __THREAD_STATUS_TYPE__
 THREAD_STATUS_REASON = __THREAD_STATUS_REASON__
 ROLLOUT_ENTRIES_ON_READ = __ROLLOUT_ENTRIES_ON_READ__
@@ -311,6 +313,10 @@ __COMPLETION_BLOCK__
             turn_items = [
                 {"type": "agentMessage", "id": "msg-1", "text": ASSISTANT_TEXT, "phase": "final_answer", "memoryCitation": None}
             ]
+        elif IN_PROGRESS_ASSISTANT_TEXT is not None:
+            turn_items = [
+                {"type": "agentMessage", "id": "msg-progress-1", "text": IN_PROGRESS_ASSISTANT_TEXT, "phase": "commentary", "memoryCitation": None}
+            ]
         should_omit_turns = (
             (OMIT_TURNS_ON_READ or thread_read_attempts <= OMIT_TURNS_ON_INITIAL_READS)
             and (turn_completed or OMIT_TURNS_WHEN_INCOMPLETE)
@@ -409,6 +415,7 @@ __COMPLETION_BLOCK__
         .replace("__START_THREAD_ID__", repr(start_thread_id))
         .replace("__START_THREAD_PATH__", repr(start_thread_path))
         .replace("__ASSISTANT_TEXT__", repr(assistant_text))
+        .replace("__IN_PROGRESS_ASSISTANT_TEXT__", repr(in_progress_assistant_text))
         .replace("__THREAD_STATUS_TYPE__", repr(thread_status_type))
         .replace("__THREAD_STATUS_REASON__", repr(thread_status_reason))
         .replace("__ROLLOUT_ENTRIES_ON_READ__", repr(rollout_entries_on_read or []))

--- a/tests/helpers/codex_session_runtime.py
+++ b/tests/helpers/codex_session_runtime.py
@@ -9,6 +9,8 @@ def write_fake_app_server(
     tmp_path: Path,
     *,
     completion_notification_method: str | None = "turn/completed",
+    completion_notification_assistant_text: str | None = None,
+    completion_visible_on_thread_read: bool = True,
     complete_turn_on_read: bool = True,
     omit_turns_on_read: bool = False,
     omit_turns_on_initial_reads: int = 0,
@@ -35,12 +37,21 @@ def write_fake_app_server(
 ) -> Path:
     script = tmp_path / "fake_app_server.py"
     completion_block = """
-        turn_completed = True
+        turn_completed = COMPLETION_VISIBLE_ON_THREAD_READ
+        completion_items = []
+        if COMPLETION_NOTIFICATION_ASSISTANT_TEXT is not None:
+            completion_items = [{
+                "type": "agentMessage",
+                "id": "completion-msg-1",
+                "text": COMPLETION_NOTIFICATION_ASSISTANT_TEXT,
+                "phase": "final_answer",
+                "memoryCitation": None,
+            }]
         sys.stdout.write(json.dumps({
             "method": COMPLETION_NOTIFICATION_METHOD,
             "params": {
                 "threadId": thread_id,
-                "turn": {"id": "vendor-turn-1", "items": [], "status": "completed", "error": None},
+                "turn": {"id": "vendor-turn-1", "items": completion_items, "status": "completed", "error": None},
             },
         }) + "\\n")
 """.rstrip()
@@ -64,6 +75,8 @@ RESUME_REQUIRES_EXISTING_ROLLOUT_PATH = __RESUME_REQUIRES_EXISTING_ROLLOUT_PATH_
 START_THREAD_ID = __START_THREAD_ID__
 START_THREAD_PATH = __START_THREAD_PATH__
 COMPLETION_NOTIFICATION_METHOD = __COMPLETION_NOTIFICATION_METHOD__
+COMPLETION_NOTIFICATION_ASSISTANT_TEXT = __COMPLETION_NOTIFICATION_ASSISTANT_TEXT__
+COMPLETION_VISIBLE_ON_THREAD_READ = __COMPLETION_VISIBLE_ON_THREAD_READ__
 COMPLETE_TURN_ON_READ = __COMPLETE_TURN_ON_READ__
 OMIT_TURNS_ON_READ = __OMIT_TURNS_ON_READ__
 OMIT_TURNS_ON_INITIAL_READS = __OMIT_TURNS_ON_INITIAL_READS__
@@ -374,6 +387,14 @@ __COMPLETION_BLOCK__
         .replace(
             "__COMPLETION_NOTIFICATION_METHOD__",
             repr(completion_notification_method),
+        )
+        .replace(
+            "__COMPLETION_NOTIFICATION_ASSISTANT_TEXT__",
+            repr(completion_notification_assistant_text),
+        )
+        .replace(
+            "__COMPLETION_VISIBLE_ON_THREAD_READ__",
+            "True" if completion_visible_on_thread_read else "False",
         )
         .replace(
             "__COMPLETE_TURN_ON_READ__",

--- a/tests/integration/services/temporal/test_codex_session_runtime.py
+++ b/tests/integration/services/temporal/test_codex_session_runtime.py
@@ -19,6 +19,57 @@ from tests.helpers.codex_session_runtime import (
 
 pytestmark = [pytest.mark.integration, pytest.mark.integration_ci]
 
+
+def test_runtime_send_turn_accepts_terminal_notification_when_thread_read_lags(
+    tmp_path: Path,
+) -> None:
+    request = launch_request(tmp_path)
+    transcript_path = (
+        Path(request.codex_home_path)
+        / "sessions"
+        / "2026"
+        / "08"
+        / "10"
+        / "rollout-2026-08-10T15-09-23-vendor-thread-1.jsonl"
+    )
+    transcript_path.parent.mkdir(parents=True, exist_ok=True)
+    transcript_path.write_text("", encoding="utf-8")
+    final_text = "Completed while thread/read still reported inProgress"
+    script = write_fake_app_server(
+        tmp_path,
+        completion_notification_assistant_text=final_text,
+        completion_visible_on_thread_read=False,
+        complete_turn_on_read=False,
+        start_thread_path=str(transcript_path),
+    )
+    runtime = CodexManagedSessionRuntime(
+        workspace_path=request.workspace_path,
+        session_workspace_path=request.session_workspace_path,
+        artifact_spool_path=request.artifact_spool_path,
+        codex_home_path=request.codex_home_path,
+        image_ref=request.image_ref,
+        control_url="docker-exec://mm-codex-session-sess-1",
+        container_id="ctr-1",
+        app_server_command=("python3", str(script)),
+        turn_completion_timeout_seconds=0.1,
+    )
+    runtime.launch_session(request)
+
+    response = runtime.send_turn(
+        SendCodexManagedSessionTurnRequest(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            containerId="ctr-1",
+            threadId="logical-thread-1",
+            instructions="Reply with exactly the word OK",
+        )
+    )
+
+    assert response.status == "completed"
+    assert response.metadata["assistantText"] == final_text
+    assert response.session_state.active_turn_id is None
+
+
 def test_runtime_send_turn_recovers_task_complete_message_from_rollout_transcript(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
+++ b/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
@@ -2537,6 +2537,7 @@ def test_runtime_session_status_recovers_fresh_final_rollout_for_stale_turn(
                     "type": "event_msg",
                     "payload": {
                         "type": "agent_message",
+                        "turn_id": "vendor-turn-1",
                         "message": final_text,
                         "phase": "final",
                     },
@@ -2558,6 +2559,206 @@ def test_runtime_session_status_recovers_fresh_final_rollout_for_stale_turn(
     assert status.session_state.active_turn_id is None
     assert status.metadata["lastTurnStatus"] == "completed"
     assert status.metadata["lastAssistantText"] == final_text
+
+
+def test_runtime_session_status_prefers_terminal_rollout_over_interim_thread_item(
+    tmp_path: Path,
+) -> None:
+    request = launch_request(tmp_path)
+    transcript_path = (
+        Path(request.codex_home_path)
+        / "sessions"
+        / "2026"
+        / "08"
+        / "10"
+        / "rollout-2026-08-10T15-09-23-vendor-thread-1.jsonl"
+    )
+    transcript_path.parent.mkdir(parents=True, exist_ok=True)
+    transcript_path.write_text("", encoding="utf-8")
+    script = write_fake_app_server(
+        tmp_path,
+        completion_notification_method=None,
+        complete_turn_on_read=False,
+        in_progress_assistant_text="Interim commentary from thread/read",
+        start_thread_path=str(transcript_path),
+    )
+    runtime = CodexManagedSessionRuntime(
+        workspace_path=request.workspace_path,
+        session_workspace_path=request.session_workspace_path,
+        artifact_spool_path=request.artifact_spool_path,
+        codex_home_path=request.codex_home_path,
+        image_ref=request.image_ref,
+        control_url="docker-exec://mm-codex-session-sess-1",
+        container_id="ctr-1",
+        app_server_command=("python3", str(script)),
+        turn_completion_timeout_seconds=0.01,
+    )
+    runtime.launch_session(request)
+
+    response = runtime.send_turn(
+        SendCodexManagedSessionTurnRequest(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            containerId="ctr-1",
+            threadId="logical-thread-1",
+            instructions="Reply with exactly the word OK",
+        )
+    )
+    assert response.status == "running"
+
+    final_text = "Authoritative final answer from rollout"
+    timestamp = _iso_timestamp(minutes_offset=0)
+    with transcript_path.open("a", encoding="utf-8") as handle:
+        handle.write(
+            "\n".join(
+                (
+                    json.dumps(
+                        {
+                            "timestamp": timestamp,
+                            "type": "event_msg",
+                            "payload": {
+                                "type": "task_started",
+                                "turn_id": "vendor-turn-1",
+                            },
+                        }
+                    ),
+                    json.dumps(
+                        {
+                            "timestamp": timestamp,
+                            "type": "event_msg",
+                            "payload": {
+                                "type": "agent_message",
+                                "message": final_text,
+                                "phase": "final",
+                            },
+                        }
+                    ),
+                    json.dumps(
+                        {
+                            "timestamp": timestamp,
+                            "type": "event_msg",
+                            "payload": {
+                                "type": "task_complete",
+                                "turn_id": "vendor-turn-1",
+                                "last_agent_message": final_text,
+                            },
+                        }
+                    ),
+                )
+            )
+            + "\n"
+        )
+
+    status = runtime.session_status(
+        CodexManagedSessionLocator(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            containerId="ctr-1",
+            threadId="logical-thread-1",
+        )
+    )
+
+    assert status.status == "ready"
+    assert status.metadata["lastTurnStatus"] == "completed"
+    assert status.metadata["lastAssistantText"] == final_text
+
+
+def test_runtime_session_status_ignores_recent_final_from_previous_turn(
+    tmp_path: Path,
+) -> None:
+    request = launch_request(tmp_path)
+    timestamp = _iso_timestamp(minutes_offset=0)
+    transcript_path = (
+        Path(request.codex_home_path)
+        / "sessions"
+        / "2026"
+        / "08"
+        / "10"
+        / "rollout-2026-08-10T15-09-23-vendor-thread-1.jsonl"
+    )
+    transcript_path.parent.mkdir(parents=True, exist_ok=True)
+    transcript_path.write_text(
+        "\n".join(
+            (
+                json.dumps(
+                    {
+                        "timestamp": timestamp,
+                        "type": "event_msg",
+                        "payload": {
+                            "type": "task_started",
+                            "turn_id": "vendor-turn-0",
+                        },
+                    }
+                ),
+                json.dumps(
+                    {
+                        "timestamp": timestamp,
+                        "type": "event_msg",
+                        "payload": {
+                            "type": "agent_message",
+                            "message": "Final answer from the previous turn",
+                            "phase": "final",
+                        },
+                    }
+                ),
+                json.dumps(
+                    {
+                        "timestamp": timestamp,
+                        "type": "event_msg",
+                        "payload": {
+                            "type": "task_complete",
+                            "turn_id": "vendor-turn-0",
+                            "last_agent_message": "Final answer from the previous turn",
+                        },
+                    }
+                ),
+            )
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    script = write_fake_app_server(
+        tmp_path,
+        completion_notification_method=None,
+        complete_turn_on_read=False,
+        start_thread_path=str(transcript_path),
+    )
+    runtime = CodexManagedSessionRuntime(
+        workspace_path=request.workspace_path,
+        session_workspace_path=request.session_workspace_path,
+        artifact_spool_path=request.artifact_spool_path,
+        codex_home_path=request.codex_home_path,
+        image_ref=request.image_ref,
+        control_url="docker-exec://mm-codex-session-sess-1",
+        container_id="ctr-1",
+        app_server_command=("python3", str(script)),
+        turn_completion_timeout_seconds=0.01,
+    )
+    runtime.launch_session(request)
+
+    response = runtime.send_turn(
+        SendCodexManagedSessionTurnRequest(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            containerId="ctr-1",
+            threadId="logical-thread-1",
+            instructions="Reply with exactly the word OK",
+        )
+    )
+    assert response.status == "running"
+
+    status = runtime.session_status(
+        CodexManagedSessionLocator(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            containerId="ctr-1",
+            threadId="logical-thread-1",
+        )
+    )
+
+    assert status.status == "busy"
+    assert status.session_state.active_turn_id == "vendor-turn-1"
+    assert status.metadata["lastTurnStatus"] == "running"
 
 
 def test_runtime_send_turn_ignores_nonterminal_rollout_assistant_for_stale_turn(
@@ -2749,6 +2950,7 @@ def test_runtime_send_turn_stays_running_when_large_rollout_tail_has_active_turn
     )
     script = write_fake_app_server(
         tmp_path,
+        completion_notification_method=None,
         omit_turns_on_read=True,
         start_thread_path=str(transcript_path),
     )
@@ -2884,7 +3086,7 @@ def test_runtime_send_turn_recovers_terminal_rollout_without_turn_reference(
                         "type": "event_msg",
                         "payload": {
                             "type": "task_started",
-                            "turn_id": "codex-turn-1",
+                            "turn_id": "vendor-turn-1",
                         },
                     }
                 ),
@@ -3958,6 +4160,58 @@ def test_runtime_send_turn_waits_for_fallback_started_turn_visibility(
     )
 
 
+def test_runtime_send_turn_preserves_completion_during_fallback_visibility_grace(
+    tmp_path: Path,
+) -> None:
+    request = launch_request(tmp_path)
+    transcript_path = (
+        Path(request.codex_home_path)
+        / "sessions"
+        / "2026"
+        / "06"
+        / "28"
+        / "rollout-2026-06-28T13-46-25-vendor-thread-2.jsonl"
+    )
+    transcript_path.parent.mkdir(parents=True)
+    transcript_path.write_text("", encoding="utf-8")
+    script = write_fake_app_server(
+        tmp_path,
+        fail_thread_resume=True,
+        start_thread_id="vendor-thread-2",
+        start_thread_path=str(transcript_path),
+        completion_notification_assistant_text="OK from terminal notification",
+        completion_visible_on_thread_read=False,
+        omit_turns_on_read=True,
+        omit_turns_when_incomplete=True,
+    )
+    runtime = CodexManagedSessionRuntime(
+        workspace_path=request.workspace_path,
+        session_workspace_path=request.session_workspace_path,
+        artifact_spool_path=request.artifact_spool_path,
+        codex_home_path=request.codex_home_path,
+        image_ref=request.image_ref,
+        control_url="docker-exec://mm-codex-session-sess-1",
+        container_id="ctr-1",
+        app_server_command=("python3", str(script)),
+        missing_turn_visibility_grace_seconds=0.01,
+    )
+    runtime.launch_session(request)
+
+    response = runtime.send_turn(
+        SendCodexManagedSessionTurnRequest(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            containerId="ctr-1",
+            threadId="logical-thread-1",
+            instructions="Reply with exactly the word OK",
+        )
+    )
+
+    assert response.status == "completed"
+    assert response.metadata["assistantText"] == "OK from terminal notification"
+    assert response.session_state.active_turn_id is None
+
+
 def test_runtime_send_turn_marks_missing_fallback_turn_subtype_after_grace(
     tmp_path: Path,
 ) -> None:
@@ -3974,6 +4228,7 @@ def test_runtime_send_turn_marks_missing_fallback_turn_subtype_after_grace(
     transcript_path.write_text("", encoding="utf-8")
     script = write_fake_app_server(
         tmp_path,
+        completion_notification_method=None,
         fail_thread_resume=True,
         start_thread_id="vendor-thread-2",
         start_thread_path=str(transcript_path),

--- a/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
+++ b/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
@@ -2440,6 +2440,7 @@ def test_runtime_send_turn_stays_running_when_rollout_turn_has_not_completed(
     )
     script = write_fake_app_server(
         tmp_path,
+        completion_notification_method=None,
         omit_turns_on_read=True,
         start_thread_path=str(transcript_path),
     )
@@ -2481,6 +2482,151 @@ def test_runtime_send_turn_stays_running_when_rollout_turn_has_not_completed(
     assert handle.status == "busy"
     assert handle.metadata["lastTurnStatus"] == "running"
 
+
+def test_runtime_session_status_recovers_fresh_final_rollout_for_stale_turn(
+    tmp_path: Path,
+) -> None:
+    request = launch_request(tmp_path)
+    transcript_path = (
+        Path(request.codex_home_path)
+        / "sessions"
+        / "2026"
+        / "08"
+        / "10"
+        / "rollout-2026-08-10T15-09-23-vendor-thread-1.jsonl"
+    )
+    transcript_path.parent.mkdir(parents=True, exist_ok=True)
+    transcript_path.write_text("", encoding="utf-8")
+    script = write_fake_app_server(
+        tmp_path,
+        completion_notification_method=None,
+        complete_turn_on_read=False,
+        start_thread_path=str(transcript_path),
+    )
+    runtime = CodexManagedSessionRuntime(
+        workspace_path=request.workspace_path,
+        session_workspace_path=request.session_workspace_path,
+        artifact_spool_path=request.artifact_spool_path,
+        codex_home_path=request.codex_home_path,
+        image_ref=request.image_ref,
+        control_url="docker-exec://mm-codex-session-sess-1",
+        container_id="ctr-1",
+        app_server_command=("python3", str(script)),
+        turn_completion_timeout_seconds=0.01,
+    )
+    runtime.launch_session(request)
+
+    response = runtime.send_turn(
+        SendCodexManagedSessionTurnRequest(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            containerId="ctr-1",
+            threadId="logical-thread-1",
+            instructions="Reply with exactly the word OK",
+        )
+    )
+    assert response.status == "running"
+
+    final_text = "Recovered from durable final rollout evidence"
+    timestamp = _iso_timestamp(minutes_offset=5)
+    with transcript_path.open("a", encoding="utf-8") as handle:
+        handle.write(
+            json.dumps(
+                {
+                    "timestamp": timestamp,
+                    "type": "event_msg",
+                    "payload": {
+                        "type": "agent_message",
+                        "message": final_text,
+                        "phase": "final",
+                    },
+                }
+            )
+            + "\n"
+        )
+
+    status = runtime.session_status(
+        CodexManagedSessionLocator(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            containerId="ctr-1",
+            threadId="logical-thread-1",
+        )
+    )
+
+    assert status.status == "ready"
+    assert status.session_state.active_turn_id is None
+    assert status.metadata["lastTurnStatus"] == "completed"
+    assert status.metadata["lastAssistantText"] == final_text
+
+
+def test_runtime_send_turn_ignores_nonterminal_rollout_assistant_for_stale_turn(
+    tmp_path: Path,
+) -> None:
+    request = launch_request(tmp_path)
+    transcript_path = (
+        Path(request.codex_home_path)
+        / "sessions"
+        / "2026"
+        / "08"
+        / "10"
+        / "rollout-2026-08-10T15-09-23-vendor-thread-1.jsonl"
+    )
+    transcript_path.parent.mkdir(parents=True, exist_ok=True)
+    transcript_path.write_text("", encoding="utf-8")
+    timestamp = _iso_timestamp(minutes_offset=5)
+    script = write_fake_app_server(
+        tmp_path,
+        completion_notification_method=None,
+        complete_turn_on_read=False,
+        start_thread_path=str(transcript_path),
+        rollout_entries_on_read=[
+            {
+                "timestamp": timestamp,
+                "type": "event_msg",
+                "payload": {
+                    "type": "task_started",
+                    "turn_id": "vendor-turn-1",
+                },
+            },
+            {
+                "timestamp": timestamp,
+                "type": "event_msg",
+                "payload": {
+                    "type": "agent_message",
+                    "message": "Still working",
+                    "phase": "commentary",
+                },
+            },
+        ],
+    )
+    runtime = CodexManagedSessionRuntime(
+        workspace_path=request.workspace_path,
+        session_workspace_path=request.session_workspace_path,
+        artifact_spool_path=request.artifact_spool_path,
+        codex_home_path=request.codex_home_path,
+        image_ref=request.image_ref,
+        control_url="docker-exec://mm-codex-session-sess-1",
+        container_id="ctr-1",
+        app_server_command=("python3", str(script)),
+        turn_completion_timeout_seconds=0.01,
+    )
+    runtime.launch_session(request)
+
+    response = runtime.send_turn(
+        SendCodexManagedSessionTurnRequest(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            containerId="ctr-1",
+            threadId="logical-thread-1",
+            instructions="Reply with exactly the word OK",
+        )
+    )
+
+    assert response.status == "running"
+    assert response.session_state.active_turn_id == "vendor-turn-1"
+
+
 def test_runtime_session_status_fails_empty_task_complete_after_running_turn(
     tmp_path: Path,
 ) -> None:
@@ -2510,6 +2656,7 @@ def test_runtime_session_status_fails_empty_task_complete_after_running_turn(
     )
     script = write_fake_app_server(
         tmp_path,
+        completion_notification_method=None,
         omit_turns_on_read=True,
         start_thread_path=str(transcript_path),
     )


### PR DESCRIPTION
## Summary

- accept a matching terminal app-server turn notification as authoritative completion even when `thread/read` still projects `inProgress`
- recover stranded active turns from fresh provider-owned final rollout evidence
- keep commentary and other nonterminal assistant output from ending a live turn
- add a minimized subprocess-boundary replay of workflow `mm:1cf3dab9-c3f9-4bda-bc56-7a9394c3f2fd`

## Root cause

The Codex agent completed its work and emitted a final response within minutes, but MoonMind discarded the terminal turn payload delivered as an app-server notification. When the in-process wait expired, the runtime returned `running` and closed the app-server process. The controller then polled persisted state that could only remain `running`, so each one-hour execution budget expired and the workflow retried the completed work four times before failing after eight hours.

The recovery path also ignored fresh `phase=final` rollout evidence whenever the stale `thread/read` response still contained an in-progress turn. This change reconciles those provider-owned terminal signals at the managed-session authority boundary.

## Validation

- managed-session runtime/controller/supervisor unit slice: 224 passed
- Codex runtime and subprocess-boundary slice: 104 passed
- hermetic integration CI: 531 passed, 1 skipped
- Ruff checks, Python compilation, and `git diff --check`: passed

A generic local unit wrapper also launched the unrelated frontend suite and encountered one timezone-sensitive Workflow Create assertion (`12:00Z` vs `20:00Z`); no frontend files are changed by this PR.