### PR TITLE
Harden Codex managed turn runtime selection

### DIFF
--- a/docs/ManagedAgents/CodexCliManagedSessions.md
+++ b/docs/ManagedAgents/CodexCliManagedSessions.md
@@ -2,7 +2,7 @@
 
 Status: Desired state  
 Owners: MoonMind Platform  
-Last updated: 2026-07-13
+Last updated: 2026-08-10
 Related:
 
 - [`docs/Temporal/ManagedAndExternalAgentExecutionModel.md`](../Temporal/ManagedAndExternalAgentExecutionModel.md)
@@ -151,6 +151,21 @@ sticky thread setting applies.
 The override is applied to the first turn even when MoonMind reuses an existing
 workflow-scoped session, and terminal-contract continuation turns retain the
 same resolved selection.
+
+A reusable session advertises the exact turn runtime-selection contract in its
+status metadata. When an explicit selection targets an idle session that does
+not advertise that contract, MoonMind replaces the pre-contract container
+before sending the turn. An active pre-contract session is rejected instead of
+being replaced while it owns an in-flight turn. Requests without an explicit
+selection omit the new fields and remain valid for already-running containers.
+Temporal continuation histories preserve their recorded payload shape through
+a workflow patch marker; new histories carry the exact selected strings on
+every continuation, including a continuation after a clear/reset boundary.
+
+The controller records the accepted model and effort and emits model-status
+evidence as soon as the runtime accepts the turn. Terminal polling may enrich
+that evidence, but it is not the authority boundary for whether the requested
+selection launched.
 
 ---
 

--- a/docs/ManagedAgents/CodexCliManagedSessions.md
+++ b/docs/ManagedAgents/CodexCliManagedSessions.md
@@ -139,6 +139,19 @@ Preferred command order for new histories:
 Changes to this order are replay-visible and require Temporal patch/version
 markers or Worker Versioning so in-flight histories replay their recorded path.
 
+### 3.3 Turn runtime selection
+
+The resolved Codex `model` and `effort` values travel on the managed-session
+turn request and map directly to the App Server `turn/start` fields of the same
+names. MoonMind does not translate or clamp explicit values at this boundary;
+Codex remains the validation authority and returns its normal protocol error for
+an unsupported value. Omitted values remain omitted so the provider profile or
+sticky thread setting applies.
+
+The override is applied to the first turn even when MoonMind reuses an existing
+workflow-scoped session, and terminal-contract continuation turns retain the
+same resolved selection.
+
 ---
 
 ## 4. Session identity

--- a/moonmind/schemas/managed_session_models.py
+++ b/moonmind/schemas/managed_session_models.py
@@ -1242,6 +1242,8 @@ class SendCodexManagedSessionTurnRequest(CodexManagedSessionLocator):
     instructions: NonBlankStr = Field(..., alias="instructions")
     reason: NonBlankStr | None = Field(None, alias="reason")
     request_id: NonBlankStr | None = Field(None, alias="requestId")
+    model: NonBlankStr | None = Field(None, alias="model")
+    effort: NonBlankStr | None = Field(None, alias="effort")
     bridge_publication: dict[str, Any] | None = Field(
         None, alias="bridgePublication"
     )

--- a/moonmind/schemas/managed_session_models.py
+++ b/moonmind/schemas/managed_session_models.py
@@ -41,6 +41,7 @@ def _validate_absolute_posix_path(value: str, *, field_name: str) -> str:
     return normalized
 
 _RESERVED_SESSION_ENV_PREFIX = "MOONMIND_SESSION_"
+CODEX_TURN_RUNTIME_SELECTION_CONTRACT = "codex.turn_runtime_selection.v1"
 _PER_TURN_SESSION_ENV_KEYS = frozenset(
     {
         "MOONMIND_ACTIVE_SKILLS_DIR",
@@ -1242,12 +1243,19 @@ class SendCodexManagedSessionTurnRequest(CodexManagedSessionLocator):
     instructions: NonBlankStr = Field(..., alias="instructions")
     reason: NonBlankStr | None = Field(None, alias="reason")
     request_id: NonBlankStr | None = Field(None, alias="requestId")
-    model: NonBlankStr | None = Field(None, alias="model")
-    effort: NonBlankStr | None = Field(None, alias="effort")
+    model: str | None = Field(None, alias="model")
+    effort: str | None = Field(None, alias="effort")
     bridge_publication: dict[str, Any] | None = Field(
         None, alias="bridgePublication"
     )
     environment: dict[str, str] = Field(default_factory=dict, alias="environment")
+
+    @field_validator("model", "effort")
+    @classmethod
+    def _validate_runtime_selection(cls, value: str | None) -> str | None:
+        if value is not None and not value.strip():
+            raise ValueError("runtime selection value must not be blank")
+        return value
 
     @field_validator("environment")
     @classmethod

--- a/moonmind/workflows/adapters/codex_session_adapter.py
+++ b/moonmind/workflows/adapters/codex_session_adapter.py
@@ -33,6 +33,7 @@ from moonmind.schemas.agent_runtime_models import (
 )
 from moonmind.schemas.container_job_models import OwnerIdentity
 from moonmind.schemas.managed_session_models import (
+    CODEX_TURN_RUNTIME_SELECTION_CONTRACT,
     CodexManagedSessionArtifactsPublication,
     CodexManagedSessionBinding,
     CodexManagedSessionClearRequest,
@@ -1841,23 +1842,36 @@ class CodexSessionAdapter(ManagedAgentAdapter):
                         snapshot = refreshed_snapshot
                         replace_existing = self._replace_existing_on_resume_mismatch
                     else:
-                        await self._signal_control_action(
-                            action="resume_session",
-                            reason=None,
-                            container_id=handle.session_state.container_id,
-                            thread_id=handle.session_state.thread_id,
-                            active_turn_id=handle.session_state.active_turn_id,
-                        )
-                        return handle
+                        if self._requires_runtime_selection_cutover(
+                            request=request,
+                            handle=handle,
+                        ):
+                            snapshot = refreshed_snapshot
+                            replace_existing = True
+                        else:
+                            await self._signal_control_action(
+                                action="resume_session",
+                                reason=None,
+                                container_id=handle.session_state.container_id,
+                                thread_id=handle.session_state.thread_id,
+                                active_turn_id=handle.session_state.active_turn_id,
+                            )
+                            return handle
             else:
-                await self._signal_control_action(
-                    action="resume_session",
-                    reason=None,
-                    container_id=handle.session_state.container_id,
-                    thread_id=handle.session_state.thread_id,
-                    active_turn_id=handle.session_state.active_turn_id,
-                )
-                return handle
+                if self._requires_runtime_selection_cutover(
+                    request=request,
+                    handle=handle,
+                ):
+                    replace_existing = True
+                else:
+                    await self._signal_control_action(
+                        action="resume_session",
+                        reason=None,
+                        container_id=handle.session_state.container_id,
+                        thread_id=handle.session_state.thread_id,
+                        active_turn_id=handle.session_state.active_turn_id,
+                    )
+                    return handle
 
         active_binding = snapshot.binding
         if active_binding.session_epoch < binding.session_epoch:
@@ -1927,6 +1941,35 @@ class CodexSessionAdapter(ManagedAgentAdapter):
             active_turn_id=handle.session_state.active_turn_id,
         )
         return handle
+
+    @staticmethod
+    def _requires_runtime_selection_cutover(
+        *,
+        request: AgentExecutionRequest,
+        handle: CodexManagedSessionHandle,
+    ) -> bool:
+        has_explicit_selection = any(
+            request.parameters.get(key) is not None for key in ("model", "effort")
+        )
+        if not has_explicit_selection:
+            return False
+        if (
+            handle.metadata.get("turnRuntimeSelectionContract")
+            == CODEX_TURN_RUNTIME_SELECTION_CONTRACT
+        ):
+            return False
+        if handle.session_state.active_turn_id is not None:
+            raise RuntimeError(
+                "cannot replace an active managed Codex session that predates "
+                "the turn runtime-selection contract"
+            )
+        logger.warning(
+            "Replacing managed Codex session %s before applying explicit model or "
+            "effort because its runtime predates %s.",
+            handle.session_state.session_id,
+            CODEX_TURN_RUNTIME_SELECTION_CONTRACT,
+        )
+        return True
 
     async def _prepare_launch_metadata_for_request(
         self,

--- a/moonmind/workflows/adapters/codex_session_adapter.py
+++ b/moonmind/workflows/adapters/codex_session_adapter.py
@@ -160,6 +160,8 @@ _SESSION_ARTIFACT_METADATA_FIELDS = (
     "canaryEvidence",
 )
 _TURN_METADATA_SCALAR_FIELDS = (
+    "model",
+    "effort",
     "reason",
     "continuationFailureType",
     "failureCause",
@@ -806,6 +808,8 @@ class CodexSessionAdapter(ManagedAgentAdapter):
                             threadId=current_locator.thread_id,
                             instructions=instructions,
                             requestId=f"{request.idempotency_key}:initial",
+                            model=request.parameters.get("model"),
+                            effort=request.parameters.get("effort"),
                             bridgePublication=bridge_publication,
                             environment=turn_environment,
                         )

--- a/moonmind/workflows/temporal/runtime/codex_session_runtime.py
+++ b/moonmind/workflows/temporal/runtime/codex_session_runtime.py
@@ -3240,18 +3240,20 @@ class CodexManagedSessionRuntime:
             authoritative_state.vendor_thread_path = recovered_vendor_thread_path
             state = authoritative_state
 
-            started = client.request(
-                "turn/start",
-                {
-                    "threadId": vendor_thread_id,
-                    "input": [
-                        {
-                            "type": "text",
-                            "text": request.instructions,
-                        }
-                    ],
-                },
-            )
+            turn_start_params: dict[str, Any] = {
+                "threadId": vendor_thread_id,
+                "input": [
+                    {
+                        "type": "text",
+                        "text": request.instructions,
+                    }
+                ],
+            }
+            if request.model is not None:
+                turn_start_params["model"] = request.model
+            if request.effort is not None:
+                turn_start_params["effort"] = request.effort
+            started = client.request("turn/start", turn_start_params)
             turn_payload = started.get("turn")
             if not isinstance(turn_payload, Mapping):
                 raise RuntimeError("codex app-server turn/start did not return a turn")

--- a/moonmind/workflows/temporal/runtime/codex_session_runtime.py
+++ b/moonmind/workflows/temporal/runtime/codex_session_runtime.py
@@ -26,6 +26,7 @@ from typing import Any, Callable, Iterator, Mapping, Sequence
 from pydantic import BaseModel, ConfigDict, Field
 
 from moonmind.schemas.managed_session_models import (
+    CODEX_TURN_RUNTIME_SELECTION_CONTRACT,
     CodexManagedSessionArtifactsPublication,
     CodexManagedSessionClearRequest,
     CodexManagedSessionHandle,
@@ -922,6 +923,9 @@ class CodexManagedSessionRuntime:
             "vendorThreadId": state.vendor_thread_id,
             **dict(metadata or {}),
         }
+        merged["turnRuntimeSelectionContract"] = (
+            CODEX_TURN_RUNTIME_SELECTION_CONTRACT
+        )
         if state.last_assistant_text:
             merged.setdefault("lastAssistantText", state.last_assistant_text)
         if state.last_turn_id:

--- a/moonmind/workflows/temporal/runtime/managed_session_controller.py
+++ b/moonmind/workflows/temporal/runtime/managed_session_controller.py
@@ -2875,6 +2875,7 @@ class DockerCodexManagedSessionController:
                 action="send_turn",
                 payload=request.model_dump(
                     by_alias=True,
+                    exclude_none=True,
                     exclude={"bridge_publication", "environment"},
                 ),
                 extra_env=request.environment or None,
@@ -2888,6 +2889,40 @@ class DockerCodexManagedSessionController:
             if recovered is None:
                 raise
             response = self._with_runtime_family(recovered, request)
+
+        runtime_selection: dict[str, str] = {}
+        if request.model is not None:
+            runtime_selection["model"] = request.model
+        if request.effort is not None:
+            runtime_selection["effort"] = request.effort
+        if runtime_selection and self._session_store is not None:
+            admitted_record = self._session_store.load(request.session_id)
+            if admitted_record is not None:
+                admitted_metadata = dict(admitted_record.metadata)
+                admitted_metadata.update(runtime_selection)
+                admitted_record = await self._session_store.update(
+                    request.session_id,
+                    session_epoch=response.session_state.session_epoch,
+                    container_id=response.session_state.container_id,
+                    thread_id=response.session_state.thread_id,
+                    active_turn_id=response.session_state.active_turn_id,
+                    status=self._record_status_from_turn_status(response.status),
+                    updated_at=datetime.now(tz=UTC),
+                    metadata=admitted_metadata,
+                )
+                if (
+                    request.model is not None
+                    and self._observability_bridge is not None
+                ):
+                    model_metadata: dict[str, object] = {"action": "send_turn"}
+                    if request.effort is not None:
+                        model_metadata["effort"] = request.effort
+                    self._observability_bridge.emit_model_status(
+                        record=admitted_record,
+                        model=request.model,
+                        metadata=model_metadata,
+                        active_turn_id=response.turn_id,
+                    )
 
         initial_observations = response.metadata.get("observabilityEvents")
         if observation_sink is not None and isinstance(initial_observations, list):
@@ -2906,11 +2941,6 @@ class DockerCodexManagedSessionController:
             )
             terminal_response = self._with_runtime_family(terminal_response, request)
 
-        runtime_selection: dict[str, str] = {}
-        if request.model is not None:
-            runtime_selection["model"] = request.model
-        if request.effort is not None:
-            runtime_selection["effort"] = request.effort
         if runtime_selection:
             terminal_response = terminal_response.model_copy(
                 update={
@@ -2964,18 +2994,6 @@ class DockerCodexManagedSessionController:
                             turn_id=response.turn_id,
                             reason=request.reason,
                         )
-                        if request.model is not None:
-                            model_metadata: dict[str, object] = {
-                                "action": "send_turn"
-                            }
-                            if request.effort is not None:
-                                model_metadata["effort"] = request.effort
-                            self._observability_bridge.emit_model_status(
-                                record=updated_record,
-                                model=request.model,
-                                metadata=model_metadata,
-                                active_turn_id=response.turn_id,
-                            )
                         self._observability_bridge.emit_native_observations(
                             record=updated_record,
                             observations=terminal_response.metadata.get(

--- a/moonmind/workflows/temporal/runtime/managed_session_controller.py
+++ b/moonmind/workflows/temporal/runtime/managed_session_controller.py
@@ -2906,10 +2906,26 @@ class DockerCodexManagedSessionController:
             )
             terminal_response = self._with_runtime_family(terminal_response, request)
 
+        runtime_selection: dict[str, str] = {}
+        if request.model is not None:
+            runtime_selection["model"] = request.model
+        if request.effort is not None:
+            runtime_selection["effort"] = request.effort
+        if runtime_selection:
+            terminal_response = terminal_response.model_copy(
+                update={
+                    "metadata": {
+                        **terminal_response.metadata,
+                        **runtime_selection,
+                    }
+                }
+            )
+
         if self._session_store is not None:
             record = self._session_store.load(request.session_id)
             if record is not None:
                 record_metadata = dict(record.metadata)
+                record_metadata.update(runtime_selection)
                 assistant_text = terminal_response.metadata.get("assistantText")
                 if isinstance(assistant_text, str) and assistant_text.strip():
                     record_metadata.update(_last_assistant_text_metadata(assistant_text))
@@ -2948,6 +2964,18 @@ class DockerCodexManagedSessionController:
                             turn_id=response.turn_id,
                             reason=request.reason,
                         )
+                        if request.model is not None:
+                            model_metadata: dict[str, object] = {
+                                "action": "send_turn"
+                            }
+                            if request.effort is not None:
+                                model_metadata["effort"] = request.effort
+                            self._observability_bridge.emit_model_status(
+                                record=updated_record,
+                                model=request.model,
+                                metadata=model_metadata,
+                                active_turn_id=response.turn_id,
+                            )
                         self._observability_bridge.emit_native_observations(
                             record=updated_record,
                             observations=terminal_response.metadata.get(

--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -89,6 +89,9 @@ TERMINAL_CONTRACT_CHECKPOINT_ON_FAILURE_PATCH_ID = (
 TERMINAL_CONTRACT_RUNTIME_FAILURE_AUTHORITY_PATCH_ID = (
     "agent-run-terminal-contract-runtime-failure-authority-v1"
 )
+CODEX_TURN_RUNTIME_SELECTION_PATCH_ID = (
+    "agent-run-codex-turn-runtime-selection-v1"
+)
 PR_RESOLVER_OWNED_CONTINUATION_PATCH_ID = "agent-run-pr-resolver-owned-continuation-v1"
 PR_RESOLVER_CONTINUATION_OBSERVABILITY_PATCH_ID = (
     "agent-run-pr-resolver-continuation-observability-v1"
@@ -2320,6 +2323,15 @@ class MoonMindAgentRun:
                 )
                 container_id = snapshot.get("containerId")
                 thread_id = snapshot.get("threadId")
+            runtime_selection_patch_enabled = workflow.patched(
+                CODEX_TURN_RUNTIME_SELECTION_PATCH_ID
+            )
+            runtime_selection: dict[str, Any] = {}
+            if runtime_selection_patch_enabled:
+                runtime_selection = {
+                    "model": request.parameters.get("model"),
+                    "effort": request.parameters.get("effort"),
+                }
             turn_request = SendCodexManagedSessionTurnRequest(
                 sessionId=session_id,
                 sessionEpoch=session_epoch,
@@ -2340,14 +2352,25 @@ class MoonMindAgentRun:
                         else None
                     ),
                 ),
+                **runtime_selection,
             )
+            turn_activity_payload: object = turn_request
+            if not runtime_selection_patch_enabled:
+                # Preserve the byte-level payload shape already recorded by
+                # pre-selection histories. The Pydantic converter includes
+                # optional defaults unless they are explicitly excluded.
+                turn_activity_payload = turn_request.model_dump(
+                    mode="json",
+                    by_alias=True,
+                    exclude={"model", "effort"},
+                )
             history.append(
                 {"continuation": continuation, "reason": "missing_terminal_evidence", "outcome": "requested"}
             )
             try:
                 await self._execute_routed_activity(
                     "agent_runtime.send_turn",
-                    turn_request,
+                    turn_activity_payload,
                     cancellation_type=ActivityCancellationType.TRY_CANCEL,
                 )
             except Exception:

--- a/tests/helpers/codex_session_runtime.py
+++ b/tests/helpers/codex_session_runtime.py
@@ -32,6 +32,7 @@ def write_fake_app_server(
     skill_outcome_payload: dict | str | None = None,
     steer_record_path: Path | None = None,
     interrupt_record_path: Path | None = None,
+    turn_start_record_path: Path | None = None,
     codex_home_record_path: Path | None = None,
     thread_recovery_error_message: str | None = None,
     thread_read_error_message: str | None = None,
@@ -64,6 +65,7 @@ import os
 import sys
 
 INTERRUPT_RECORD_PATH = __INTERRUPT_RECORD_PATH__
+TURN_START_RECORD_PATH = __TURN_START_RECORD_PATH__
 STEER_RECORD_PATH = __STEER_RECORD_PATH__
 CODEX_HOME_RECORD_PATH = __CODEX_HOME_RECORD_PATH__
 FAIL_THREAD_RESUME = __FAIL_THREAD_RESUME__
@@ -223,6 +225,9 @@ for line in sys.stdin:
         assert isinstance(input_items, list)
         assert input_items[0]["type"] == "text"
         assert input_items[0]["text"] == "Reply with exactly the word OK"
+        if TURN_START_RECORD_PATH:
+            with open(TURN_START_RECORD_PATH, "w", encoding="utf-8") as handle:
+                json.dump(message["params"], handle)
         turn_completed = COMPLETE_TURN_ON_READ and not COMPLETION_NOTIFICATION_METHOD
         sys.stdout.write(json.dumps({
             "id": msg_id,
@@ -368,6 +373,10 @@ __COMPLETION_BLOCK__
         script_template.replace(
             "__INTERRUPT_RECORD_PATH__",
             repr(str(interrupt_record_path) if interrupt_record_path is not None else ""),
+        )
+        .replace(
+            "__TURN_START_RECORD_PATH__",
+            repr(str(turn_start_record_path) if turn_start_record_path is not None else ""),
         )
         .replace(
             "__STEER_RECORD_PATH__",

--- a/tests/integration/reliability/replays/codex-stale-final-runtime-selection/expected-outcome.json
+++ b/tests/integration/reliability/replays/codex-stale-final-runtime-selection/expected-outcome.json
@@ -1,0 +1,9 @@
+{
+  "status": "completed",
+  "activeTurnId": null,
+  "assistantText": "Queued the requested Dependabot workflows.",
+  "turnStart": {
+    "model": "gpt-5.3-codex-spark",
+    "effort": "xhigh"
+  }
+}

--- a/tests/integration/reliability/replays/codex-stale-final-runtime-selection/manifest.json
+++ b/tests/integration/reliability/replays/codex-stale-final-runtime-selection/manifest.json
@@ -1,0 +1,10 @@
+{
+  "incidentWorkflowId": "mm:bc689115-e389-4cdf-b221-89df19bcca08-2026-08-10T13:00:00Z",
+  "incidentRunId": "019febc2-3155-74d4-8474-f1425dcf8b3c",
+  "failureShape": "Codex emitted a final_answer rollout event without task_complete while thread/read remained active, so the managed turn retained activeTurnId and held the only OAuth profile slot; the requested model and effort were also absent from turn/start",
+  "boundary": "managed AgentRun request through Codex app-server turn/start and durable rollout terminal recovery",
+  "threadStatusType": "active",
+  "requestedModel": "gpt-5.3-codex-spark",
+  "requestedEffort": "xhigh",
+  "rolloutRelativePath": "sessions/2026/08/10/rollout-2026-08-10T18-10-35-vendor-thread-1.jsonl"
+}

--- a/tests/integration/reliability/replays/codex-stale-final-runtime-selection/provider-transcript.jsonl
+++ b/tests/integration/reliability/replays/codex-stale-final-runtime-selection/provider-transcript.jsonl
@@ -1,0 +1,4 @@
+{"timestamp":"2026-08-10T18:10:35.000Z","type":"event_msg","payload":{"type":"task_started","turn_id":"vendor-turn-1"}}
+{"timestamp":"2026-08-10T18:11:10.000Z","type":"event_msg","payload":{"type":"agent_message","message":"Queued the requested Dependabot workflows.","phase":"final_answer"}}
+{"timestamp":"2026-08-10T18:11:10.001Z","type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"Queued the requested Dependabot workflows."}],"phase":"final_answer"}}
+{"timestamp":"2026-08-10T18:11:10.002Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":100,"output_tokens":20}}}}

--- a/tests/integration/services/temporal/test_codex_session_runtime.py
+++ b/tests/integration/services/temporal/test_codex_session_runtime.py
@@ -6,13 +6,23 @@ from pathlib import Path
 
 import pytest
 
+from moonmind.schemas.agent_runtime_models import AgentExecutionRequest
 from moonmind.schemas.managed_session_models import (
+    CodexManagedSessionBinding,
     CodexManagedSessionLocator,
+    CodexManagedSessionSnapshot,
+    FetchCodexManagedSessionSummaryRequest,
+    PublishCodexManagedSessionArtifactsRequest,
     SendCodexManagedSessionTurnRequest,
 )
+from moonmind.workflows.adapters.codex_session_adapter import CodexSessionAdapter
 from moonmind.workflows.temporal.runtime.codex_session_runtime import (
     CodexManagedSessionRuntime,
 )
+from moonmind.workflows.temporal.runtime.managed_session_controller import (
+    DockerCodexManagedSessionController,
+)
+from moonmind.workflows.temporal.runtime.store import ManagedRunStore
 from tests.helpers.codex_session_runtime import (
     launch_request,
     write_fake_app_server,
@@ -22,7 +32,8 @@ from tests.integration.reliability.helpers import load_replay
 pytestmark = [pytest.mark.integration, pytest.mark.integration_ci]
 
 
-def test_runtime_replays_stale_final_answer_with_exact_model_and_effort(
+@pytest.mark.asyncio
+async def test_runtime_replays_stale_final_answer_with_exact_model_and_effort(
     tmp_path: Path,
 ) -> None:
     replay_id = "codex-stale-final-runtime-selection"
@@ -75,21 +86,137 @@ def test_runtime_replays_stale_final_answer_with_exact_model_and_effort(
     )
     runtime.launch_session(request)
 
-    response = runtime.send_turn(
-        SendCodexManagedSessionTurnRequest(
+    async def command_runner(
+        command: tuple[str, ...],
+        *,
+        input_text: str | None = None,
+        env: dict[str, str] | None = None,
+    ) -> tuple[int, str, str]:
+        del env
+        payload = json.loads(input_text or "{}")
+        action = command[-1]
+        if action == "session_status":
+            response = runtime.session_status(
+                CodexManagedSessionLocator.model_validate(payload)
+            )
+        elif action == "send_turn":
+            response = runtime.send_turn(
+                SendCodexManagedSessionTurnRequest.model_validate(payload)
+            )
+        else:
+            raise AssertionError(f"unexpected runtime action: {action}")
+        return 0, response.model_dump_json(by_alias=True), ""
+
+    controller = DockerCodexManagedSessionController(
+        workspace_volume_name="agent_workspaces",
+        codex_volume_name="codex_auth_volume",
+        workspace_root=str(tmp_path),
+        command_runner=command_runner,
+        turn_poll_interval_seconds=0,
+    )
+    binding = CodexManagedSessionBinding(
+        workflowId="wf-task-1:session:codex_cli",
+        agentRunId="wf-task-1",
+        sessionId="sess-1",
+        sessionEpoch=1,
+        runtimeId="codex_cli",
+        executionProfileRef="codex-default",
+    )
+
+    async def load_snapshot(_workflow_id: str) -> CodexManagedSessionSnapshot:
+        return CodexManagedSessionSnapshot(
+            binding=binding,
+            status="active",
+            containerId="ctr-1",
+            threadId="logical-thread-1",
+            activeTurnId=None,
+            terminationRequested=False,
+        )
+
+    async def unexpected_launch(_payload: object) -> object:
+        raise AssertionError("compatible managed session should be reused")
+
+    async def prepare_turn_instructions(_payload: dict[str, object]) -> str:
+        return "Reply with exactly the word OK"
+
+    async def fetch_summary(
+        summary_request: FetchCodexManagedSessionSummaryRequest,
+    ):
+        return runtime.fetch_session_summary(summary_request)
+
+    async def publish_artifacts(
+        publication_request: PublishCodexManagedSessionArtifactsRequest,
+    ):
+        return runtime.publish_session_artifacts(publication_request)
+
+    async def noop(*_args: object, **_kwargs: object) -> None:
+        return None
+
+    async def profile_fetcher(*, runtime_id: str) -> dict[str, object]:
+        assert runtime_id == "codex_cli"
+        return {
+            "profiles": [
+                {
+                    "profile_id": "codex-default",
+                    "credential_source": "oauth_volume",
+                }
+            ]
+        }
+
+    adapter = CodexSessionAdapter(
+        profile_fetcher=profile_fetcher,
+        slot_requester=noop,
+        slot_releaser=noop,
+        cooldown_reporter=noop,
+        workflow_id="wf-agent-run-1",
+        runtime_id="codex_cli",
+        run_store=ManagedRunStore(tmp_path / "managed-runs"),
+        load_session_snapshot=load_snapshot,
+        launch_session=unexpected_launch,
+        session_status=controller.session_status,
+        prepare_turn_instructions=prepare_turn_instructions,
+        send_turn=controller.send_turn,
+        interrupt_turn=noop,
+        clear_remote_session=noop,
+        terminate_remote_session=noop,
+        fetch_remote_summary=fetch_summary,
+        publish_remote_artifacts=publish_artifacts,
+        attach_runtime_handles=noop,
+        apply_session_control_action=noop,
+        workspace_root=str(tmp_path),
+        session_image_ref=request.image_ref,
+    )
+    execution = AgentExecutionRequest(
+        agentKind="managed",
+        agentId="codex",
+        executionProfileRef="codex-default",
+        correlationId="corr-replay-1",
+        idempotencyKey="idem-replay-1",
+        instructionRef="artifact:instructions",
+        managedSession=binding,
+        workspaceSpec={"workspacePath": request.workspace_path},
+        parameters={
+            "publishMode": "none",
+            "model": manifest["requestedModel"],
+            "effort": manifest["requestedEffort"],
+        },
+        timeoutPolicy={},
+    )
+
+    handle = await adapter.start(execution)
+    result = await adapter.fetch_result(handle.run_id)
+
+    assert handle.status == expected["status"]
+    assert result.summary == expected["assistantText"]
+    runtime_handle = runtime.session_status(
+        CodexManagedSessionLocator(
             sessionId="sess-1",
             sessionEpoch=1,
             containerId="ctr-1",
             threadId="logical-thread-1",
-            instructions="Reply with exactly the word OK",
-            model=manifest["requestedModel"],
-            effort=manifest["requestedEffort"],
         )
     )
-
-    assert response.status == expected["status"]
-    assert response.session_state.active_turn_id == expected["activeTurnId"]
-    assert response.metadata["assistantText"] == expected["assistantText"]
+    assert runtime_handle.session_state.active_turn_id == expected["activeTurnId"]
     turn_start = json.loads(turn_start_record_path.read_text(encoding="utf-8"))
     assert turn_start["model"] == expected["turnStart"]["model"]
     assert turn_start["effort"] == expected["turnStart"]["effort"]

--- a/tests/integration/services/temporal/test_codex_session_runtime.py
+++ b/tests/integration/services/temporal/test_codex_session_runtime.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 import pytest
@@ -16,8 +17,82 @@ from tests.helpers.codex_session_runtime import (
     launch_request,
     write_fake_app_server,
 )
+from tests.integration.reliability.helpers import load_replay
 
 pytestmark = [pytest.mark.integration, pytest.mark.integration_ci]
+
+
+def test_runtime_replays_stale_final_answer_with_exact_model_and_effort(
+    tmp_path: Path,
+) -> None:
+    replay_id = "codex-stale-final-runtime-selection"
+    manifest = load_replay(replay_id, "manifest.json")
+    expected = load_replay(replay_id, "expected-outcome.json")
+    transcript_source = (
+        Path(__file__).resolve().parents[2]
+        / "reliability"
+        / "replays"
+        / replay_id
+        / "provider-transcript.jsonl"
+    )
+    rollout_entries = [
+        json.loads(line)
+        for line in transcript_source.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    # Preserve the incident event order and payloads while moving its historical
+    # timestamps inside this test turn's rollout-freshness boundary.
+    replay_start = datetime.now(UTC) + timedelta(seconds=1)
+    for index, entry in enumerate(rollout_entries):
+        entry["timestamp"] = (
+            replay_start + timedelta(milliseconds=index)
+        ).isoformat().replace("+00:00", "Z")
+    request = launch_request(tmp_path)
+    transcript_path = Path(request.codex_home_path) / manifest["rolloutRelativePath"]
+    transcript_path.parent.mkdir(parents=True, exist_ok=True)
+    transcript_path.write_text("", encoding="utf-8")
+    turn_start_record_path = tmp_path / "turn-start.json"
+    script = write_fake_app_server(
+        tmp_path,
+        completion_notification_method=None,
+        complete_turn_on_read=False,
+        incomplete_assistant_text="Runtime still reports this turn as active",
+        start_thread_path=str(transcript_path),
+        thread_status_type=manifest["threadStatusType"],
+        rollout_entries_on_read=rollout_entries,
+        turn_start_record_path=turn_start_record_path,
+    )
+    runtime = CodexManagedSessionRuntime(
+        workspace_path=request.workspace_path,
+        session_workspace_path=request.session_workspace_path,
+        artifact_spool_path=request.artifact_spool_path,
+        codex_home_path=request.codex_home_path,
+        image_ref=request.image_ref,
+        control_url="docker-exec://mm-codex-session-sess-1",
+        container_id="ctr-1",
+        app_server_command=("python3", str(script)),
+        turn_completion_timeout_seconds=0.1,
+    )
+    runtime.launch_session(request)
+
+    response = runtime.send_turn(
+        SendCodexManagedSessionTurnRequest(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            containerId="ctr-1",
+            threadId="logical-thread-1",
+            instructions="Reply with exactly the word OK",
+            model=manifest["requestedModel"],
+            effort=manifest["requestedEffort"],
+        )
+    )
+
+    assert response.status == expected["status"]
+    assert response.session_state.active_turn_id == expected["activeTurnId"]
+    assert response.metadata["assistantText"] == expected["assistantText"]
+    turn_start = json.loads(turn_start_record_path.read_text(encoding="utf-8"))
+    assert turn_start["model"] == expected["turnStart"]["model"]
+    assert turn_start["effort"] == expected["turnStart"]["effort"]
 
 
 def test_runtime_send_turn_accepts_terminal_notification_when_thread_read_lags(

--- a/tests/unit/schemas/test_managed_session_models.py
+++ b/tests/unit/schemas/test_managed_session_models.py
@@ -487,8 +487,18 @@ def test_send_codex_managed_session_turn_request_trims_instruction_and_reason() 
 
     assert request.instructions == "Investigate the failing test"
     assert request.reason == "Operator follow-up"
-    assert request.model == "gpt-5.3-codex-spark"
-    assert request.effort == "xhigh"
+    assert request.model == "  gpt-5.3-codex-spark  "
+    assert request.effort == "  xhigh  "
+
+    with pytest.raises(ValidationError, match="must not be blank"):
+        SendCodexManagedSessionTurnRequest(
+            sessionId="sess-123",
+            sessionEpoch=1,
+            containerId="ctr-123",
+            threadId="thread-1",
+            instructions="Continue",
+            model="   ",
+        )
 
 def test_send_codex_managed_session_turn_request_defaults_environment_for_old_payloads() -> None:
     request = SendCodexManagedSessionTurnRequest.model_validate(

--- a/tests/unit/schemas/test_managed_session_models.py
+++ b/tests/unit/schemas/test_managed_session_models.py
@@ -481,10 +481,14 @@ def test_send_codex_managed_session_turn_request_trims_instruction_and_reason() 
         threadId="thread-1",
         instructions="  Investigate the failing test  ",
         reason="  Operator follow-up  ",
+        model="  gpt-5.3-codex-spark  ",
+        effort="  xhigh  ",
     )
 
     assert request.instructions == "Investigate the failing test"
     assert request.reason == "Operator follow-up"
+    assert request.model == "gpt-5.3-codex-spark"
+    assert request.effort == "xhigh"
 
 def test_send_codex_managed_session_turn_request_defaults_environment_for_old_payloads() -> None:
     request = SendCodexManagedSessionTurnRequest.model_validate(
@@ -498,6 +502,8 @@ def test_send_codex_managed_session_turn_request_defaults_environment_for_old_pa
     )
 
     assert request.environment == {}
+    assert request.model is None
+    assert request.effort is None
 
 def test_send_codex_managed_session_turn_request_limits_per_turn_environment() -> None:
     request = SendCodexManagedSessionTurnRequest(

--- a/tests/unit/services/temporal/runtime/test_managed_session_controller.py
+++ b/tests/unit/services/temporal/runtime/test_managed_session_controller.py
@@ -2759,11 +2759,110 @@ async def test_controller_send_turn_executes_inside_container(tmp_path: Path) ->
         "workflow:step:execution:2"
     )
 
+
 @pytest.mark.asyncio
-async def test_controller_send_turn_polls_session_status_until_completed() -> None:
+@pytest.mark.parametrize(
+    ("model", "effort", "expected_selection"),
+    [
+        (None, None, {}),
+        (
+            "  gpt-5.3-codex-spark  ",
+            "  xhigh  ",
+            {
+                "model": "  gpt-5.3-codex-spark  ",
+                "effort": "  xhigh  ",
+            },
+        ),
+    ],
+)
+async def test_controller_serializes_runtime_selection_without_transforming_it(
+    model: str | None,
+    effort: str | None,
+    expected_selection: dict[str, str],
+) -> None:
+    invoked_payloads: list[dict[str, object]] = []
+
+    async def _fake_runner(
+        command: tuple[str, ...],
+        *,
+        input_text: str | None = None,
+        env: dict[str, str] | None = None,
+    ) -> tuple[int, str, str]:
+        del env
+        if command[:3] == ("docker", "exec", "-i") and "invoke" in command:
+            invoked_payloads.append(json.loads(input_text or "{}"))
+            return 0, json.dumps(
+                {
+                    "sessionState": {
+                        "sessionId": "sess-1",
+                        "sessionEpoch": 1,
+                        "containerId": "ctr-1",
+                        "threadId": "logical-thread-1",
+                        "activeTurnId": None,
+                    },
+                    "turnId": "vendor-turn-1",
+                    "status": "completed",
+                    "metadata": {"assistantText": "OK"},
+                }
+            ), ""
+        raise AssertionError(f"unexpected command: {command}")
+
+    controller = DockerCodexManagedSessionController(
+        workspace_volume_name="agent_workspaces",
+        codex_volume_name="codex_auth_volume",
+        workspace_root="/tmp/agent_jobs",
+        command_runner=_fake_runner,
+    )
+
+    await controller.send_turn(
+        SendCodexManagedSessionTurnRequest(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            containerId="ctr-1",
+            threadId="logical-thread-1",
+            instructions="Reply with exactly the word OK",
+            model=model,
+            effort=effort,
+        )
+    )
+
+    assert len(invoked_payloads) == 1
+    assert {key: invoked_payloads[0][key] for key in expected_selection} == (
+        expected_selection
+    )
+    if model is None:
+        assert "model" not in invoked_payloads[0]
+    if effort is None:
+        assert "effort" not in invoked_payloads[0]
+
+
+@pytest.mark.asyncio
+async def test_controller_send_turn_polls_session_status_until_completed(
+    tmp_path: Path,
+) -> None:
     commands: list[tuple[str, ...]] = []
     session_status_calls = 0
     session_status_payloads: list[dict[str, object]] = []
+    store = ManagedSessionStore(tmp_path / "session-store")
+    store.save(
+        CodexManagedSessionRecord(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            agentRunId="task-1",
+            containerId="ctr-1",
+            threadId="logical-thread-1",
+            runtimeId="codex_cli",
+            imageRef="img",
+            controlUrl="docker-exec://ctr-1",
+            status="ready",
+            workspacePath="/work/repo",
+            sessionWorkspacePath="/work/session",
+            artifactSpoolPath="/work/artifacts",
+            startedAt="2026-04-06T12:00:00Z",
+        )
+    )
+    session_supervisor = Mock()
+    session_supervisor.emit_session_event = Mock()
 
     async def _fake_runner(
         command: tuple[str, ...],
@@ -2788,6 +2887,12 @@ async def test_controller_send_turn_polls_session_status_until_completed() -> No
             }
             return 0, json.dumps(payload), ""
         if command[:3] == ("docker", "exec", "-i") and "session_status" in command:
+            emitted = session_supervisor.emit_session_event.call_args_list
+            assert [call.kwargs["kind"] for call in emitted] == ["model_status"]
+            admitted = store.load("sess-1")
+            assert admitted is not None
+            assert admitted.metadata["model"] == "gpt-5.3-codex-spark"
+            assert admitted.metadata["effort"] == "xhigh"
             session_status_payloads.append(json.loads(input_text or "{}"))
             session_status_calls += 1
             if session_status_calls == 1:
@@ -2828,6 +2933,8 @@ async def test_controller_send_turn_polls_session_status_until_completed() -> No
         workspace_volume_name="agent_workspaces",
         codex_volume_name="codex_auth_volume",
         workspace_root="/tmp/agent_jobs",
+        session_store=store,
+        session_supervisor=session_supervisor,
         command_runner=_fake_runner,
         turn_poll_interval_seconds=0,
     )
@@ -2839,12 +2946,16 @@ async def test_controller_send_turn_polls_session_status_until_completed() -> No
             containerId="ctr-1",
             threadId="logical-thread-1",
             instructions="Reply with exactly the word OK",
+            model="gpt-5.3-codex-spark",
+            effort="xhigh",
         )
     )
 
     assert response.status == "completed"
     assert response.turn_id == "vendor-turn-1"
     assert response.metadata["assistantText"] == "OK"
+    assert response.metadata["model"] == "gpt-5.3-codex-spark"
+    assert response.metadata["effort"] == "xhigh"
     assert len(session_status_payloads) == 2
     for payload in session_status_payloads:
         assert payload["sessionId"] == "sess-1"
@@ -3312,9 +3423,9 @@ async def test_controller_send_turn_emits_follow_up_reason_in_session_events(
     assert stored.metadata["model"] == "gpt-5.3-codex-spark"
     assert stored.metadata["effort"] == "xhigh"
     assert emitted_kinds == [
+        "model_status",
         "user_message_submitted",
         "turn_started",
-        "model_status",
         "assistant_message",
         "assistant_message_completed",
         "turn_completed",
@@ -3322,15 +3433,15 @@ async def test_controller_send_turn_emits_follow_up_reason_in_session_events(
     assert emitted_metadata == [
         {
             "action": "send_turn",
+            "model": "gpt-5.3-codex-spark",
+            "effort": "xhigh",
+        },
+        {
+            "action": "send_turn",
             "messageLength": len("Reply with exactly the word OK"),
             "reason": "Operator follow-up",
         },
         {"action": "send_turn", "reason": "Operator follow-up"},
-        {
-            "action": "send_turn",
-            "model": "gpt-5.3-codex-spark",
-            "effort": "xhigh",
-        },
         {
             "action": "send_turn",
             "contentLength": len("OK"),

--- a/tests/unit/services/temporal/runtime/test_managed_session_controller.py
+++ b/tests/unit/services/temporal/runtime/test_managed_session_controller.py
@@ -2692,6 +2692,9 @@ async def test_controller_send_turn_executes_inside_container(tmp_path: Path) ->
         commands.append(command)
         environments.append(dict(env or {}))
         if command[:3] == ("docker", "exec", "-i") and "invoke" in command:
+            invoked = json.loads(input_text or "{}")
+            assert invoked["model"] == "gpt-5.3-codex-spark"
+            assert invoked["effort"] == "xhigh"
             payload = {
                 "sessionState": {
                     "sessionId": "sess-1",
@@ -2721,6 +2724,8 @@ async def test_controller_send_turn_executes_inside_container(tmp_path: Path) ->
             containerId="ctr-1",
             threadId="logical-thread-1",
             instructions="Reply with exactly the word OK",
+            model="gpt-5.3-codex-spark",
+            effort="xhigh",
             environment={
                 "MOONMIND_ACTIVE_SKILLS_DIR": (
                     "/work/runtime/skills_active/snapshot-retry"
@@ -2732,6 +2737,8 @@ async def test_controller_send_turn_executes_inside_container(tmp_path: Path) ->
 
     assert response.status == "completed"
     assert response.metadata["assistantText"] == "OK"
+    assert response.metadata["model"] == "gpt-5.3-codex-spark"
+    assert response.metadata["effort"] == "xhigh"
     assert len(commands) == 1
     exec_command = commands[0]
     assert exec_command[:3] == ("docker", "exec", "-i")
@@ -3287,6 +3294,8 @@ async def test_controller_send_turn_emits_follow_up_reason_in_session_events(
             threadId="thread-1",
             instructions="Reply with exactly the word OK",
             reason="Operator follow-up",
+            model="gpt-5.3-codex-spark",
+            effort="xhigh",
         )
     )
 
@@ -3298,9 +3307,14 @@ async def test_controller_send_turn_emits_follow_up_reason_in_session_events(
         call.kwargs.get("kind")
         for call in session_supervisor.emit_session_event.call_args_list
     ]
+    stored = store.load("sess-1")
+    assert stored is not None
+    assert stored.metadata["model"] == "gpt-5.3-codex-spark"
+    assert stored.metadata["effort"] == "xhigh"
     assert emitted_kinds == [
         "user_message_submitted",
         "turn_started",
+        "model_status",
         "assistant_message",
         "assistant_message_completed",
         "turn_completed",
@@ -3312,6 +3326,11 @@ async def test_controller_send_turn_emits_follow_up_reason_in_session_events(
             "reason": "Operator follow-up",
         },
         {"action": "send_turn", "reason": "Operator follow-up"},
+        {
+            "action": "send_turn",
+            "model": "gpt-5.3-codex-spark",
+            "effort": "xhigh",
+        },
         {
             "action": "send_turn",
             "contentLength": len("OK"),

--- a/tests/unit/workflows/adapters/test_codex_session_adapter.py
+++ b/tests/unit/workflows/adapters/test_codex_session_adapter.py
@@ -21,6 +21,7 @@ from moonmind.schemas.agent_runtime_models import (
     ManagedRunRecord,
 )
 from moonmind.schemas.managed_session_models import (
+    CODEX_TURN_RUNTIME_SELECTION_CONTRACT,
     CodexManagedSessionArtifactsPublication,
     CodexManagedSessionBinding,
     CodexManagedSessionHandle,
@@ -298,6 +299,8 @@ def _session_handle(
     container_id: str,
     thread_id: str,
     status: str = "ready",
+    supports_turn_runtime_selection: bool = True,
+    active_turn_id: str | None = None,
 ) -> CodexManagedSessionHandle:
     return CodexManagedSessionHandle(
         sessionState={
@@ -305,11 +308,20 @@ def _session_handle(
             "sessionEpoch": session_epoch,
             "containerId": container_id,
             "threadId": thread_id,
-            "activeTurnId": None,
+            "activeTurnId": active_turn_id,
         },
         status=status,
         imageRef="ghcr.io/moonladderstudios/moonmind:latest",
         controlUrl=f"docker-exec://{container_id}",
+        metadata=(
+            {
+                "turnRuntimeSelectionContract": (
+                    CODEX_TURN_RUNTIME_SELECTION_CONTRACT
+                )
+            }
+            if supports_turn_runtime_selection
+            else {}
+        ),
     )
 
 def _turn_response(
@@ -3923,6 +3935,136 @@ async def test_start_reuses_existing_workflow_scoped_session_without_launching(
         "containerId": "container-existing",
         "threadId": "thread-existing",
     }
+
+
+async def test_start_replaces_reused_session_without_runtime_selection_contract(
+    tmp_path: Path,
+) -> None:
+    binding = _binding()
+    launch_calls: list[dict[str, Any]] = []
+    send_turn_calls: list[SendCodexManagedSessionTurnRequest] = []
+
+    async def _load_snapshot(_workflow_id: str) -> CodexManagedSessionSnapshot:
+        return _snapshot(
+            binding=binding,
+            container_id="container-pre-contract",
+            thread_id="thread-pre-contract",
+        )
+
+    async def _session_status(_request: Any) -> CodexManagedSessionHandle:
+        return _session_handle(
+            session_id=binding.session_id,
+            session_epoch=binding.session_epoch,
+            container_id="container-pre-contract",
+            thread_id="thread-pre-contract",
+            supports_turn_runtime_selection=False,
+        )
+
+    async def _launch_session(request: dict[str, Any]) -> CodexManagedSessionHandle:
+        launch_calls.append(request)
+        return _session_handle(
+            session_id=binding.session_id,
+            session_epoch=binding.session_epoch,
+            container_id="container-current",
+            thread_id=f"thread:{binding.session_id}:1",
+        )
+
+    async def _send_turn(
+        request: SendCodexManagedSessionTurnRequest,
+    ) -> CodexManagedSessionTurnResponse:
+        send_turn_calls.append(request)
+        return _turn_response(
+            session_id=request.session_id,
+            session_epoch=request.session_epoch,
+            container_id=request.container_id,
+            thread_id=request.thread_id,
+        )
+
+    async def _fetch_summary(
+        request: FetchCodexManagedSessionSummaryRequest,
+    ) -> CodexManagedSessionSummary:
+        return _summary(
+            session_id=request.session_id,
+            session_epoch=request.session_epoch,
+            container_id=request.container_id,
+            thread_id=request.thread_id,
+        )
+
+    async def _publish_artifacts(
+        request: PublishCodexManagedSessionArtifactsRequest,
+    ) -> CodexManagedSessionArtifactsPublication:
+        return _publication(
+            session_id=request.session_id,
+            session_epoch=request.session_epoch,
+            container_id=request.container_id,
+            thread_id=request.thread_id,
+        )
+
+    adapter = CodexSessionAdapter(
+        profile_fetcher=_fake_profiles(
+            [{"profile_id": "codex-default", "credential_source": "secret_ref"}]
+        ),
+        slot_requester=_async_noop,
+        slot_releaser=_async_noop,
+        cooldown_reporter=_async_noop,
+        workflow_id="wf-agent-run-1",
+        runtime_id="codex_cli",
+        run_store=ManagedRunStore(tmp_path / "managed_runs"),
+        load_session_snapshot=_load_snapshot,
+        launch_session=_launch_session,
+        session_status=_session_status,
+        prepare_turn_instructions=_prepare_turn_instructions,
+        send_turn=_send_turn,
+        interrupt_turn=_async_noop,
+        clear_remote_session=_async_noop,
+        terminate_remote_session=_async_noop,
+        fetch_remote_summary=_fetch_summary,
+        publish_remote_artifacts=_publish_artifacts,
+        attach_runtime_handles=_async_noop,
+        apply_session_control_action=_async_noop,
+        workspace_root=str(tmp_path / "agent_jobs"),
+        session_image_ref="ghcr.io/moonladderstudios/moonmind:latest",
+    )
+    request = _request(binding)
+    request.parameters.update(
+        {"model": "gpt-5.3-codex-spark", "effort": "xhigh"}
+    )
+
+    handle = await adapter.start(request)
+
+    assert handle.status == "completed"
+    assert len(launch_calls) == 1
+    assert launch_calls[0]["request"]["replaceExisting"] is True
+    assert send_turn_calls[0].container_id == "container-current"
+    assert send_turn_calls[0].model == "gpt-5.3-codex-spark"
+    assert send_turn_calls[0].effort == "xhigh"
+
+
+async def test_start_rejects_active_session_without_runtime_selection_contract(
+) -> None:
+    binding = _binding()
+    request = _request(binding)
+    request.parameters.update(
+        {"model": "gpt-5.3-codex-spark", "effort": "xhigh"}
+    )
+    handle = _session_handle(
+        session_id=binding.session_id,
+        session_epoch=binding.session_epoch,
+        container_id="container-pre-contract",
+        thread_id="thread-pre-contract",
+        status="busy",
+        supports_turn_runtime_selection=False,
+        active_turn_id="turn-active",
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match="cannot replace an active managed Codex session",
+    ):
+        CodexSessionAdapter._requires_runtime_selection_cutover(
+            request=request,
+            handle=handle,
+        )
 
 
 async def test_start_retries_existing_session_status_after_locator_mismatch(

--- a/tests/unit/workflows/adapters/test_codex_session_adapter.py
+++ b/tests/unit/workflows/adapters/test_codex_session_adapter.py
@@ -3898,6 +3898,8 @@ async def test_start_reuses_existing_workflow_scoped_session_without_launching(
     request.parameters["_moonmindActiveSkillsDir"] = (
         "/work/runtime/skills_active/snapshot-retry"
     )
+    request.parameters["model"] = "gpt-5.3-codex-spark"
+    request.parameters["effort"] = "xhigh"
 
     handle = await adapter.start(request)
 
@@ -3911,6 +3913,8 @@ async def test_start_reuses_existing_workflow_scoped_session_without_launching(
             "wf-user-1:run-user-1:queue-github-issues:execution:2"
         ),
     }
+    assert send_turn_calls[0].model == "gpt-5.3-codex-spark"
+    assert send_turn_calls[0].effort == "xhigh"
     assert request.parameters["_moonmindActiveSkillsDir"] == (
         "/work/runtime/skills_active/snapshot-retry"
     )

--- a/tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py
@@ -16,10 +16,16 @@ from moonmind.schemas.agent_runtime_models import (
     AgentRunStatus,
     _MAX_SUMMARY_CHARS,
 )
+from moonmind.schemas.managed_session_models import (
+    SendCodexManagedSessionTurnRequest,
+)
 from moonmind.schemas.temporal_activity_models import AgentRuntimeFetchResultInput
 from moonmind.workflows.provider_failures import ProviderFailureEvent
 from moonmind.workflows.temporal.workflows import agent_run as agent_run_module
-from moonmind.workflows.temporal.workflows.agent_run import MoonMindAgentRun
+from moonmind.workflows.temporal.workflows.agent_run import (
+    CODEX_TURN_RUNTIME_SELECTION_PATCH_ID,
+    MoonMindAgentRun,
+)
 from moonmind.workflows.temporal.workflows.merge_gate import build_resolver_run_request
 
 pytestmark = [pytest.mark.asyncio]
@@ -116,10 +122,21 @@ def _terminal_contract_snapshot(
     }
 
 
+@pytest.mark.parametrize("runtime_selection_patch_enabled", [False, True])
 async def test_terminal_contract_continuation_is_agent_run_owned_and_bounded(
     monkeypatch: pytest.MonkeyPatch,
+    runtime_selection_patch_enabled: bool,
 ) -> None:
     _configure_workflow_runtime(monkeypatch)
+    monkeypatch.setattr(
+        agent_run_module.workflow,
+        "patched",
+        lambda patch_id: (
+            runtime_selection_patch_enabled
+            if patch_id == CODEX_TURN_RUNTIME_SELECTION_PATCH_ID
+            else True
+        ),
+    )
     run = MoonMindAgentRun()
     request = AgentExecutionRequest.model_validate(
         _request_with_terminal_contract().model_dump(by_alias=True)
@@ -127,6 +144,8 @@ async def test_terminal_contract_continuation_is_agent_run_owned_and_bounded(
     request.parameters["_moonmindActiveSkillsDir"] = (
         "/work/runtime/skills_active/snapshot-retry"
     )
+    request.parameters["model"] = "gpt-5.3-codex-spark"
+    request.parameters["effort"] = "xhigh"
     request.step_execution = AgentRuntimeStepExecutionLaunch(
         workflowId="wf-task-1",
         runId="run-1",
@@ -194,11 +213,22 @@ async def test_terminal_contract_continuation_is_agent_run_owned_and_bounded(
         "agent_runtime.fetch_result",
         "agent_runtime.evaluate_terminal_evidence",
     ]
-    turn = calls[2][1]
+    raw_turn = calls[2][1]
+    if runtime_selection_patch_enabled:
+        assert isinstance(raw_turn, SendCodexManagedSessionTurnRequest)
+    else:
+        assert isinstance(raw_turn, dict)
+        assert "model" not in raw_turn
+        assert "effort" not in raw_turn
+    turn = SendCodexManagedSessionTurnRequest.model_validate(raw_turn)
     assert turn.request_id == "idem-managed-1:terminal-contract:1"
     assert turn.session_epoch == 3
     assert turn.container_id == "ctr-reset"
     assert turn.thread_id == "thr-reset"
+    assert turn.model == (
+        "gpt-5.3-codex-spark" if runtime_selection_patch_enabled else None
+    )
+    assert turn.effort == ("xhigh" if runtime_selection_patch_enabled else None)
     assert turn.environment == {
         "MOONMIND_ACTIVE_SKILLS_DIR": "/work/runtime/skills_active/snapshot-retry",
         "MOONMIND_STEP_EXECUTION_ID": (


### PR DESCRIPTION
## What changed

- carry optional resolved `model` and `effort` values across the managed-session turn contract and pass them unchanged to Codex App Server `turn/start`
- preserve the accepted per-turn selection in result/session metadata and emit a per-turn model-status event
- add a minimized replay fixture for `mm:bc689115-e389-4cdf-b221-89df19bcca08-2026-08-10T13:00:00Z`, where Codex emitted `final_answer` without `task_complete` while `thread/read` stayed active
- document the managed-session runtime-selection contract

## Why

The incident combined two authority-boundary gaps. The deployed session image predated the current `main` terminal-rollout recovery, so a completed provider turn retained `activeTurnId` and held the only OAuth profile slot. Separately, the workflow request contained `gpt-5.3-codex-spark` and `xhigh`, but the managed-session adapter dropped both before `turn/start`, leaving the profile default visible and effective.

The replay makes the escaped completion shape required integration evidence: the runtime must treat the durable final answer as terminal and clear `activeTurnId` even when provider status remains stale. The new turn fields are optional for in-flight payload compatibility. Explicit values are not translated or clamped; unsupported values fail through normal Codex validation, while omitted values retain the provider or sticky-thread default.

## Impact

Requested Codex model/effort overrides now reach the actual billable turn, including reused workflow-scoped sessions, and operators can see which selection was applied. The incident replay prevents a regression that would strand the managed turn and monopolize provider capacity.

## Verification

- `./tools/test_unit.sh tests/unit/schemas/test_managed_session_models.py tests/unit/workflows/adapters/test_codex_session_adapter.py tests/unit/services/temporal/runtime/test_managed_session_controller.py tests/unit/services/temporal/runtime/test_codex_session_runtime.py --python-only` — 313 passed
- `./tools/test_integration.sh` — 532 passed, 1 skipped
- targeted replay boundary — 4 passed
- Ruff checks and `git diff --check` passed