### PR TITLE
Fix GitHub issue workflow repository authority

### DIFF
--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -10182,6 +10182,59 @@ def _selected_repository_skill_names(
     return names
 
 
+def _selected_github_issue_repositories(
+    task_payload: Mapping[str, Any],
+) -> set[str]:
+    input_payloads: list[Mapping[str, Any]] = []
+    task_inputs = task_payload.get("inputs")
+    if isinstance(task_inputs, Mapping):
+        input_payloads.append(task_inputs)
+
+    applied_templates = task_payload.get("appliedStepTemplates")
+    if isinstance(applied_templates, list):
+        for template in applied_templates:
+            if not isinstance(template, Mapping):
+                continue
+            template_inputs = template.get("inputs")
+            if isinstance(template_inputs, Mapping):
+                input_payloads.append(template_inputs)
+
+    repositories_by_identity: dict[str, str] = {}
+    for inputs in input_payloads:
+        issue = inputs.get("github_issue")
+        if not isinstance(issue, Mapping):
+            continue
+        repository = str(issue.get("repository") or "").strip()
+        if repository:
+            repositories_by_identity.setdefault(repository.casefold(), repository)
+    return set(repositories_by_identity.values())
+
+
+def _validate_github_issue_repository_authority(
+    *,
+    repository_payload: str | Mapping[str, Any] | None,
+    task_payload: Mapping[str, Any],
+) -> None:
+    submitted_repository = repository_name_from_value(repository_payload)
+    issue_repositories = _selected_github_issue_repositories(task_payload)
+    if not submitted_repository or not issue_repositories:
+        return
+    if len(issue_repositories) > 1:
+        raise _invalid_workflow_request(
+            "GitHub issue inputs target multiple repositories: "
+            + ", ".join(sorted(issue_repositories))
+            + ". Submit one repository authority per workflow."
+        )
+    issue_repository = next(iter(issue_repositories))
+    if issue_repository.casefold() == submitted_repository.casefold():
+        return
+    raise _invalid_workflow_request(
+        f"payload.repository '{submitted_repository}' does not match the GitHub "
+        f"issue repository '{issue_repository}'. Choose the issue repository as "
+        "the workflow repository before submission."
+    )
+
+
 def _validate_repository_submission_compatibility(
     *,
     repository_payload: str | Mapping[str, Any] | None,
@@ -10194,6 +10247,10 @@ def _validate_repository_submission_compatibility(
             "payload.workflow.repository must not contain a repository target; "
             "use payload.repository."
         )
+    _validate_github_issue_repository_authority(
+        repository_payload=repository_payload,
+        task_payload=task_payload,
+    )
     if not isinstance(repository_payload, Mapping):
         return
     if "git" in task_payload:

--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -281,6 +281,7 @@ from moonmind.workflows.executions.execution_contract import (
 from moonmind.workflows.executions.repository_contract import (
     RepositoryContractError,
     compile_repository_target,
+    github_repository_name_from_value,
     repository_branch_from_value,
     repository_name_from_value,
 )
@@ -10186,9 +10187,29 @@ def _selected_github_issue_repositories(
     task_payload: Mapping[str, Any],
 ) -> set[str]:
     input_payloads: list[Mapping[str, Any]] = []
+
+    def collect_binding_inputs(binding: object) -> None:
+        if not isinstance(binding, Mapping):
+            return
+        inputs = binding.get("inputs")
+        if not isinstance(inputs, Mapping):
+            inputs = binding.get("args")
+        if isinstance(inputs, Mapping):
+            input_payloads.append(inputs)
+
     task_inputs = task_payload.get("inputs")
     if isinstance(task_inputs, Mapping):
         input_payloads.append(task_inputs)
+    collect_binding_inputs(task_payload.get("tool"))
+    collect_binding_inputs(task_payload.get("skill"))
+
+    steps = task_payload.get("steps")
+    if isinstance(steps, list):
+        for step in steps:
+            if not isinstance(step, Mapping):
+                continue
+            collect_binding_inputs(step.get("tool"))
+            collect_binding_inputs(step.get("skill"))
 
     applied_templates = task_payload.get("appliedStepTemplates")
     if isinstance(applied_templates, list):
@@ -10217,7 +10238,7 @@ def _validate_github_issue_repository_authority(
 ) -> None:
     submitted_repository = repository_name_from_value(repository_payload)
     issue_repositories = _selected_github_issue_repositories(task_payload)
-    if not submitted_repository or not issue_repositories:
+    if not issue_repositories:
         return
     if len(issue_repositories) > 1:
         raise _invalid_workflow_request(
@@ -10226,7 +10247,19 @@ def _validate_github_issue_repository_authority(
             + ". Submit one repository authority per workflow."
         )
     issue_repository = next(iter(issue_repositories))
-    if issue_repository.casefold() == submitted_repository.casefold():
+    if not submitted_repository:
+        raise _invalid_workflow_request(
+            "payload.repository is required when GitHub issue inputs select "
+            f"repository '{issue_repository}'."
+        )
+    submitted_identity = (
+        github_repository_name_from_value(submitted_repository)
+        or submitted_repository
+    ).casefold()
+    issue_identity = (
+        github_repository_name_from_value(issue_repository) or issue_repository
+    ).casefold()
+    if issue_identity == submitted_identity:
         return
     raise _invalid_workflow_request(
         f"payload.repository '{submitted_repository}' does not match the GitHub "

--- a/frontend/src/entrypoints/workflow-start.test.tsx
+++ b/frontend/src/entrypoints/workflow-start.test.tsx
@@ -16406,12 +16406,47 @@ describe("Task Create MM-578 Preset expansion", () => {
       throw new Error("Expected submitted first step");
     }
     expect(submittedStep.instructions).toBe("Edited generated MM-578 step.");
+    expect(submittedStep.repositoryOperation).toBeUndefined();
     expect(submittedStep.source).toMatchObject({
       kind: "detached",
       presetId: "mm-578-preset",
       includePath: ["root", "fetch"],
       originalStepId: "fetch-jira-issue",
     });
+  });
+
+  it("clears generated repository authority when the step type changes", async () => {
+    renderWithClient(<WorkflowStartPage payload={mockPayload} />);
+
+    const step = (await screen.findByText("Step 1")).closest(
+      "section",
+    ) as HTMLElement;
+    selectStepType(step, "Preset");
+    const presetSelect = within(step).getByLabelText(
+      "Preset Template",
+    ) as HTMLSelectElement;
+    await waitFor(() => {
+      expect(presetSelect.options.length).toBeGreaterThan(1);
+    });
+    fireEvent.change(presetSelect, {
+      target: { value: "global::::mm-578-preset" },
+    });
+    fireEvent.click(within(step).getByRole("button", { name: "Expand" }));
+    expect(await screen.findByDisplayValue("Fetch MM-578.")).toBeTruthy();
+
+    const generatedStep = (await screen.findByText("Step 1")).closest(
+      "section",
+    ) as HTMLElement;
+    selectStepType(generatedStep, "Skill");
+    fireEvent.click(screen.getByRole("button", { name: "Start Workflow" }));
+
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledWith(
+        "/api/executions",
+        expect.objectContaining({ method: "POST" }),
+      );
+    });
+    expect(latestCreateTaskSteps()[0]?.repositoryOperation).toBeUndefined();
   });
 
   it("submits applied preset-generated Tool and Skill steps with executable binding and provenance", async () => {

--- a/frontend/src/entrypoints/workflow-start.test.tsx
+++ b/frontend/src/entrypoints/workflow-start.test.tsx
@@ -15671,6 +15671,7 @@ describe("Task Create MM-578 Preset expansion", () => {
               id: "tpl:mm-578-preset:1:01",
               title: "Fetch Jira issue",
               instructions: "Fetch MM-578.",
+              repositoryOperation: "read",
               tool: {
                 type: "tool",
                 id: "jira.get_issue",
@@ -15688,6 +15689,7 @@ describe("Task Create MM-578 Preset expansion", () => {
               id: "tpl:mm-578-preset:1:02",
               title: "Implement preset story",
               instructions: "Implement MM-578.",
+              repositoryOperation: "write",
               annotations: {
                 issueImplementRole: "moonspec-remediation-loop",
                 remediationLoop: {
@@ -16451,6 +16453,7 @@ describe("Task Create MM-578 Preset expansion", () => {
       id: "tpl:mm-578-preset:1:01",
       title: "Fetch Jira issue",
       type: "tool",
+      repositoryOperation: "read",
       instructions: "Fetch MM-578.",
       tool: {
         type: "tool",
@@ -16470,6 +16473,7 @@ describe("Task Create MM-578 Preset expansion", () => {
       id: "tpl:mm-578-preset:1:02",
       title: "Implement preset story",
       type: "skill",
+      repositoryOperation: "write",
       instructions: "Implement MM-578.",
       annotations: {
         issueImplementRole: "moonspec-remediation-loop",
@@ -16627,6 +16631,10 @@ describe("Task Create MM-578 Preset expansion", () => {
     const steps = latestCreateTaskSteps();
     expect(steps).toHaveLength(2);
     expect(steps.map((entry) => entry.type)).toEqual(["tool", "skill"]);
+    expect(steps.map((entry) => entry.repositoryOperation)).toEqual([
+      "read",
+      "write",
+    ]);
     expect(steps.some((entry) => entry.type === "preset")).toBe(false);
     expect(steps[0]?.source).toEqual({
       kind: "preset-derived",
@@ -17807,8 +17815,11 @@ describe("Task Create schema-driven capability inputs", () => {
 
     const issueInput = await within(step).findByLabelText("GitHub issue");
     fireEvent.change(issueInput, {
-      target: { value: "https://github.com/MoonLadderStudios/MoonMind/issues/123" },
+      target: { value: "https://github.com/MoonLadderStudios/Tactics/issues/123" },
     });
+    expect((screen.getByLabelText("GitHub Repo") as HTMLInputElement).value).toBe(
+      "MoonLadderStudios/Tactics",
+    );
     fireEvent.click(within(step).getByRole("button", { name: "Expand" }));
 
     await waitFor(() => {
@@ -17821,9 +17832,9 @@ describe("Task Create schema-driven capability inputs", () => {
             inputs?: { github_issue?: { repository?: string; number?: number; url?: string } };
           };
           return (
-            payload.inputs?.github_issue?.repository === "MoonLadderStudios/MoonMind" &&
+            payload.inputs?.github_issue?.repository === "MoonLadderStudios/Tactics" &&
             payload.inputs?.github_issue?.number === 123 &&
-            payload.inputs?.github_issue?.url === "https://github.com/MoonLadderStudios/MoonMind/issues/123"
+            payload.inputs?.github_issue?.url === "https://github.com/MoonLadderStudios/Tactics/issues/123"
           );
         }),
       ).toBe(true);

--- a/frontend/src/entrypoints/workflow-start.tsx
+++ b/frontend/src/entrypoints/workflow-start.tsx
@@ -8401,6 +8401,7 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
         const nextStep: StepState = {
           ...step,
           stepType: nextType,
+          repositoryOperation: "",
         };
 
         // MM-936: explicitRequiredCapabilities is a step-level field that is
@@ -10555,7 +10556,7 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
             ...(sourceStep.title.trim()
               ? { title: sourceStep.title.trim() }
               : {}),
-            ...(sourceStep.repositoryOperation
+            ...(sourceStep.repositoryOperation && !sourceInstructionsChanged
               ? { repositoryOperation: sourceStep.repositoryOperation }
               : {}),
             ...(hasSubmittedStepShape && shouldSubmitStepType

--- a/frontend/src/entrypoints/workflow-start.tsx
+++ b/frontend/src/entrypoints/workflow-start.tsx
@@ -906,6 +906,7 @@ interface ExpandedStepPayload {
   skill?: PresetStepSkill;
   tool?: PresetStepSkill;
   type?: string;
+  repositoryOperation?: "read" | "write";
   annotations?: Record<string, unknown>;
   source?: Record<string, unknown>;
   presetProvenance?: Record<string, unknown>;
@@ -987,6 +988,7 @@ interface StepAttachmentRef {
 }
 
 type StepType = "tool" | "skill" | "preset";
+type RepositoryOperation = "" | "read" | "write";
 
 type OmnigentAgentProfileVersionOption = {
   version: number;
@@ -1060,6 +1062,7 @@ interface StepState {
   title: string;
   stepType: StepType;
   instructions: string;
+  repositoryOperation: RepositoryOperation;
   toolId: string;
   toolInputs: string;
   toolInputValues: Record<string, unknown>;
@@ -1887,6 +1890,7 @@ function createStepStateEntry(
     title: "",
     stepType: "skill",
     instructions: "",
+    repositoryOperation: "",
     toolId: "",
     toolInputs: "{}",
     toolInputValues: {},
@@ -2193,6 +2197,7 @@ function createStepStateEntriesFromTemporalDraft(
       title: step.title,
       stepType: step.stepType,
       instructions: step.instructions,
+      repositoryOperation: step.repositoryOperation || "",
       skillId:
         step.stepType === "skill"
           ? shouldUsePrimarySkill
@@ -3342,6 +3347,11 @@ function mapExpandedStepToState(
     title: String(step.title || "").trim(),
     stepType: isToolStep ? "tool" : "skill",
     instructions,
+    repositoryOperation:
+      step.repositoryOperation === "read" ||
+      step.repositoryOperation === "write"
+        ? step.repositoryOperation
+        : "",
     toolId: isToolStep ? String(tool.id || tool.name || "").trim() : "",
     toolInputs: isToolStep ? JSON.stringify(inlineInputs, null, 2) : "{}",
     toolInputValues: isToolStep
@@ -4079,6 +4089,7 @@ function SchemaCapabilityFields({
   repositoryOptions,
   branchOptions,
   onChange,
+  onGitHubIssueRepositoryChange,
 }: {
   fields: Array<[string, unknown]>;
   detail: Pick<PresetDetail, "uiSchema" | "defaults">;
@@ -4088,6 +4099,7 @@ function SchemaCapabilityFields({
   repositoryOptions: RepositoryOption[];
   branchOptions: BranchOption[];
   onChange: (name: string, value: unknown) => void;
+  onGitHubIssueRepositoryChange?: (repository: string) => void;
 }): ReactElement | null {
   if (fields.length === 0) {
     return null;
@@ -4152,13 +4164,27 @@ function SchemaCapabilityFields({
                 aria-invalid={Boolean(error)}
                 onChange={(event) => {
                   if (provider === "github") {
-                    onChange(
-                      name,
-                      normalizeGitHubIssueInput(
-                        event.target.value,
-                        String(issueValue.repository || readLocalPreference(LAST_REPOSITORY_OPTION_PREFERENCE_KEY) || ""),
+                    const normalizedIssue = normalizeGitHubIssueInput(
+                      event.target.value,
+                      String(
+                        issueValue.repository ||
+                          readLocalPreference(
+                            LAST_REPOSITORY_OPTION_PREFERENCE_KEY,
+                          ) ||
+                          "",
                       ),
                     );
+                    onChange(name, normalizedIssue);
+                    const issueRepository = String(
+                      normalizedIssue.repository || "",
+                    ).trim();
+                    if (
+                      issueRepository &&
+                      Number.isInteger(normalizedIssue.number) &&
+                      Number(normalizedIssue.number) > 0
+                    ) {
+                      onGitHubIssueRepositoryChange?.(issueRepository);
+                    }
                     return;
                   }
                   onChange(name, {
@@ -5723,6 +5749,7 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
   const [modelTier, setModelTier] = useState("");
   const [tierFallback, setTierFallback] = useState<TierFallbackMode>("clamp");
   const [repository, setRepository] = useState(initialRepository);
+  const [repositoryTouched, setRepositoryTouched] = useState(false);
   const [providerProfile, setProviderProfile] = useState("");
   const [agentProfile, setAgentProfile] = useState("");
   const [branch, setBranch] = useState("");
@@ -6383,6 +6410,7 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
     }
     if (draft.repository) {
       setRepository(draft.repository);
+      setRepositoryTouched(true);
     }
     if (draft.branch) {
       setBranch(draft.branch);
@@ -6457,6 +6485,7 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
     remediationDraftIdRef.current = draftId;
     setRemediationDraft(draft);
     setRepository(draft.repository || "MoonLadderStudios/MoonMind");
+    setRepositoryTouched(true);
     if (draft.branch) {
       setBranch(draft.branch);
       setBranchTouched(false);
@@ -7997,8 +8026,17 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
   })();
   const handleRepositoryChange = (value: string) => {
     setRepository(value);
+    setRepositoryTouched(true);
     const selectedOption = repositoryOptionValue(repositoryOptions, value);
     writeLocalPreference(LAST_REPOSITORY_OPTION_PREFERENCE_KEY, selectedOption);
+  };
+  const handleGitHubIssueRepositoryChange = (issueRepository: string) => {
+    if (repositoryTouched || repository.trim() === issueRepository) {
+      return;
+    }
+    setRepository(issueRepository);
+    setBranch("");
+    setBranchTouched(false);
   };
 
   function stepPresetStatusText(step: StepState): string {
@@ -10517,6 +10555,9 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
             ...(sourceStep.title.trim()
               ? { title: sourceStep.title.trim() }
               : {}),
+            ...(sourceStep.repositoryOperation
+              ? { repositoryOperation: sourceStep.repositoryOperation }
+              : {}),
             ...(hasSubmittedStepShape && shouldSubmitStepType
               ? { type: submittedStepType }
               : {}),
@@ -12095,6 +12136,9 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
                             disabled={false}
                             repositoryOptions={repositoryOptions}
                             branchOptions={branchOptions}
+                            onGitHubIssueRepositoryChange={
+                              handleGitHubIssueRepositoryChange
+                            }
                             onChange={(name, value) =>
                               updateToolInputValue(step.localId, name, value)
                             }
@@ -12110,6 +12154,9 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
                                 disabled={false}
                                 repositoryOptions={repositoryOptions}
                                 branchOptions={branchOptions}
+                                onGitHubIssueRepositoryChange={
+                                  handleGitHubIssueRepositoryChange
+                                }
                                 onChange={(name, value) =>
                                   updateToolInputValue(step.localId, name, value)
                                 }
@@ -12299,6 +12346,9 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
                           disabled={false}
                           repositoryOptions={repositoryOptions}
                           branchOptions={branchOptions}
+                          onGitHubIssueRepositoryChange={
+                            handleGitHubIssueRepositoryChange
+                          }
                           onChange={(name, value) =>
                             updateStepPresetInputValue(
                               step.localId,
@@ -12586,6 +12636,9 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
                           disabled={isApplyingPreset}
                           repositoryOptions={repositoryOptions}
                           branchOptions={branchOptions}
+                          onGitHubIssueRepositoryChange={
+                            handleGitHubIssueRepositoryChange
+                          }
                           onChange={(name, value) =>
                             updateStepPresetInputValue(
                               step.localId,

--- a/frontend/src/lib/temporalTaskEditing.test.ts
+++ b/frontend/src/lib/temporalTaskEditing.test.ts
@@ -322,6 +322,7 @@ describe("buildTemporalSubmissionDraftFromExecution runtime command metadata", (
               id: "tpl:jira-implement:1.0.0:01",
               title: "Load Jira preset brief",
               type: "tool",
+              repositoryOperation: "read",
               instructions: "Load MM-901.",
               tool: { id: "jira.load_preset_brief", inputs: { issueKey: "MM-901" } },
             },
@@ -329,6 +330,7 @@ describe("buildTemporalSubmissionDraftFromExecution runtime command metadata", (
               id: "tpl:jira-implement:1.0.0:02",
               title: "Assess existing implementation state",
               type: "skill",
+              repositoryOperation: "write",
               instructions: "Assess MM-901.",
               annotations: {
                 issueImplementRole: "moonspec-remediation-loop",
@@ -347,6 +349,10 @@ describe("buildTemporalSubmissionDraftFromExecution runtime command metadata", (
     expect(draft.steps.map((step) => step.title)).toEqual([
       "Load Jira preset brief",
       "Assess existing implementation state",
+    ]);
+    expect(draft.steps.map((step) => step.repositoryOperation)).toEqual([
+      "read",
+      "write",
     ]);
     expect(draft.steps[1]?.annotations).toEqual({
       issueImplementRole: "moonspec-remediation-loop",

--- a/frontend/src/lib/temporalTaskEditing.ts
+++ b/frontend/src/lib/temporalTaskEditing.ts
@@ -131,6 +131,7 @@ export type TemporalSubmissionDraft = {
     id: string;
     title: string;
     instructions: string;
+    repositoryOperation?: 'read' | 'write';
     runtime?: {
       mode?: string | null;
       model?: string | null;
@@ -540,6 +541,14 @@ function draftStepFrom(value: unknown): TemporalSubmissionDraft['steps'][number]
           ? 'tool'
           : 'skill';
   const instructions = stringValue(step.instructions);
+  const rawRepositoryOperation = stringValue(
+    step.repositoryOperation,
+    step.repository_operation,
+  ).toLowerCase();
+  const repositoryOperation: 'read' | 'write' | null =
+    rawRepositoryOperation === 'read' || rawRepositoryOperation === 'write'
+      ? rawRepositoryOperation
+      : null;
   const id = stringValue(step.id);
   const templateStepId = stringValue(
     step.templateStepId,
@@ -569,6 +578,7 @@ function draftStepFrom(value: unknown): TemporalSubmissionDraft['steps'][number]
     id,
     title: stringValue(step.title),
     instructions,
+    ...(repositoryOperation ? { repositoryOperation } : {}),
     ...(Object.keys(runtime).length > 0 ? { runtime } : {}),
     stepType,
     ...(Object.keys(tool).length > 0 ? { tool } : {}),
@@ -625,6 +635,7 @@ function draftStepFrom(value: unknown): TemporalSubmissionDraft['steps'][number]
     result.id ||
     result.title ||
     result.instructions ||
+    Boolean(result.repositoryOperation) ||
     Object.keys(runtime).length > 0 ||
     result.stepType !== 'skill' ||
     result.skillId ||

--- a/moonmind/workflows/executions/repository_contract.py
+++ b/moonmind/workflows/executions/repository_contract.py
@@ -8,10 +8,12 @@ drift across authoring and runtime code.
 
 from __future__ import annotations
 
-from collections.abc import Awaitable, Callable, Mapping, Sequence
 import json
+import re
+from collections.abc import Awaitable, Callable, Mapping, Sequence
 from pathlib import Path
 from typing import Annotated, Any, Literal
+from urllib.parse import urlsplit
 
 from pydantic import BaseModel, ConfigDict, Field, TypeAdapter, model_validator
 
@@ -24,6 +26,7 @@ REPOSITORY_CONNECTION_MISMATCH = "REPOSITORY_CONNECTION_MISMATCH"
 REPOSITORY_CLIENT_MISMATCH = "REPOSITORY_CLIENT_MISMATCH"
 REPOSITORY_CREDENTIAL_UNAVAILABLE = "REPOSITORY_CREDENTIAL_UNAVAILABLE"
 REPOSITORY_REMOTE_TIP_MISMATCH = "REPOSITORY_REMOTE_TIP_MISMATCH"
+_GITHUB_REPOSITORY_NAME_PATTERN = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
 
 
 class RepositoryContractError(ValueError):
@@ -287,6 +290,41 @@ def repository_name_from_value(
         return ""
     name = repository.get("name")
     return name.strip() if isinstance(name, str) else ""
+
+
+def github_repository_name_from_value(value: object) -> str:
+    """Project supported GitHub repository forms to ``owner/repository``."""
+
+    raw = str(value or "").strip()
+    if not raw:
+        return ""
+    direct = raw.rstrip("/").removesuffix(".git")
+    if _GITHUB_REPOSITORY_NAME_PATTERN.fullmatch(direct):
+        return direct
+
+    if raw.startswith("git@github.com:"):
+        candidate = raw.removeprefix("git@github.com:").rstrip("/")
+        candidate = candidate.removesuffix(".git")
+        return candidate if _GITHUB_REPOSITORY_NAME_PATTERN.fullmatch(candidate) else ""
+
+    try:
+        parsed = urlsplit(raw)
+    except ValueError:
+        return ""
+    if (
+        parsed.scheme.lower() not in {"http", "https"}
+        or (parsed.hostname or "").lower() not in {"github.com", "www.github.com"}
+        or parsed.username
+        or parsed.password
+        or parsed.query
+        or parsed.fragment
+    ):
+        return ""
+    parts = [part for part in parsed.path.split("/") if part]
+    if len(parts) != 2:
+        return ""
+    candidate = f"{parts[0]}/{parts[1].removesuffix('.git')}"
+    return candidate if _GITHUB_REPOSITORY_NAME_PATTERN.fullmatch(candidate) else ""
 
 
 def repository_branch_from_value(value: object) -> str:
@@ -655,6 +693,7 @@ __all__ = [
     "decode_legacy_repository_history_v1",
     "derive_repository_capabilities",
     "ensure_repository_ready",
+    "github_repository_name_from_value",
     "load_repository_connection",
     "materialize_resolved_repository_target",
     "persist_repository_connection",

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -8143,6 +8143,115 @@ def test_create_task_shaped_execution_accepts_provider_repository_for_resolvers(
     assert create_kwargs["initial_parameters"]["repository"] == repository_target
 
 
+@pytest.mark.parametrize(
+    "repository_payload",
+    [
+        "MoonLadderStudios/MoonMind",
+        {
+            "provider": "git",
+            "connectionRef": "repository-connection:git-default",
+            "repository": {"name": "MoonLadderStudios/MoonMind"},
+            "branch": {"name": "main"},
+        },
+    ],
+)
+@pytest.mark.parametrize(
+    "issue_authority",
+    [
+        {
+            "inputs": {
+                "github_issue": {
+                    "repository": "MoonLadderStudios/Tactics",
+                    "number": 2490,
+                }
+            }
+        },
+        {
+            "appliedStepTemplates": [
+                {
+                    "slug": "github-issue-implement",
+                    "inputs": {
+                        "github_issue": {
+                            "repository": "MoonLadderStudios/Tactics",
+                            "number": 2490,
+                        }
+                    },
+                }
+            ]
+        },
+    ],
+)
+def test_create_execution_rejects_github_issue_repository_mismatch(
+    client: tuple[TestClient, AsyncMock, SimpleNamespace],
+    repository_payload: object,
+    issue_authority: dict[str, Any],
+) -> None:
+    test_client, service, _user = client
+
+    response = test_client.post(
+        "/api/executions",
+        json={
+            "type": "workflow",
+            "payload": {
+                "repository": repository_payload,
+                "targetRuntime": "omnigent",
+                "workflow": {
+                    "instructions": "Implement the selected GitHub issue.",
+                    **issue_authority,
+                },
+            },
+        },
+    )
+
+    assert response.status_code == 422
+    message = response.json()["detail"]["message"]
+    assert "MoonLadderStudios/MoonMind" in message
+    assert "MoonLadderStudios/Tactics" in message
+    assert "does not match the GitHub issue repository" in message
+    service.create_execution.assert_not_awaited()
+
+
+def test_create_execution_accepts_matching_github_issue_repository(
+    client: tuple[TestClient, AsyncMock, SimpleNamespace],
+) -> None:
+    test_client, service, _user = client
+    service.create_execution.return_value = _build_execution_record()
+
+    response = test_client.post(
+        "/api/executions",
+        json={
+            "type": "workflow",
+            "payload": {
+                "repository": "MoonLadderStudios/Tactics",
+                "targetRuntime": "codex",
+                "workflow": {
+                    "instructions": "Implement the selected GitHub issue.",
+                    "inputs": {
+                        "github_issue": {
+                            "repository": "MoonLadderStudios/Tactics",
+                            "number": 2490,
+                        }
+                    },
+                    "appliedStepTemplates": [
+                        {
+                            "slug": "github-issue-implement",
+                            "inputs": {
+                                "github_issue": {
+                                    "repository": "moonladderstudios/tactics",
+                                    "number": 2490,
+                                }
+                            },
+                        }
+                    ],
+                },
+            },
+        },
+    )
+
+    assert response.status_code == 201, response.json()
+    service.create_execution.assert_awaited_once()
+
+
 def test_create_task_shaped_execution_rejects_malformed_repository_target(
     client: tuple[TestClient, AsyncMock, SimpleNamespace],
 ) -> None:

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -7469,6 +7469,7 @@ def test_create_task_shaped_execution_enriches_github_issue_preset_title(
         json={
             "type": "workflow",
             "payload": {
+                "repository": "MoonLadderStudios/MoonMind",
                 "workflow": {
                     "title": "GitHub Issue Implement",
                     "instructions": "Implement the selected GitHub issue.",
@@ -8179,6 +8180,38 @@ def test_create_task_shaped_execution_accepts_provider_repository_for_resolvers(
                 }
             ]
         },
+        {
+            "steps": [
+                {
+                    "type": "tool",
+                    "tool": {
+                        "id": "github.load_issue_preset_brief",
+                        "inputs": {
+                            "github_issue": {
+                                "repository": "MoonLadderStudios/Tactics",
+                                "number": 2490,
+                            }
+                        },
+                    },
+                }
+            ]
+        },
+        {
+            "steps": [
+                {
+                    "type": "skill",
+                    "skill": {
+                        "id": "github-issue-verify",
+                        "args": {
+                            "github_issue": {
+                                "repository": "MoonLadderStudios/Tactics",
+                                "number": 2490,
+                            }
+                        },
+                    },
+                }
+            ]
+        },
     ],
 )
 def test_create_execution_rejects_github_issue_repository_mismatch(
@@ -8211,8 +8244,31 @@ def test_create_execution_rejects_github_issue_repository_mismatch(
     service.create_execution.assert_not_awaited()
 
 
+@pytest.mark.parametrize(
+    "repository_payload",
+    [
+        "MoonLadderStudios/Tactics",
+        {
+            "provider": "git",
+            "connectionRef": "repository-connection:git-default",
+            "repository": {
+                "name": "https://github.com/MoonLadderStudios/Tactics"
+            },
+            "branch": {"name": "main"},
+        },
+        {
+            "provider": "git",
+            "connectionRef": "repository-connection:git-default",
+            "repository": {
+                "name": "git@github.com:MoonLadderStudios/Tactics.git"
+            },
+            "branch": {"name": "main"},
+        },
+    ],
+)
 def test_create_execution_accepts_matching_github_issue_repository(
     client: tuple[TestClient, AsyncMock, SimpleNamespace],
+    repository_payload: object,
 ) -> None:
     test_client, service, _user = client
     service.create_execution.return_value = _build_execution_record()
@@ -8222,7 +8278,7 @@ def test_create_execution_accepts_matching_github_issue_repository(
         json={
             "type": "workflow",
             "payload": {
-                "repository": "MoonLadderStudios/Tactics",
+                "repository": repository_payload,
                 "targetRuntime": "codex",
                 "workflow": {
                     "instructions": "Implement the selected GitHub issue.",
@@ -8250,6 +8306,35 @@ def test_create_execution_accepts_matching_github_issue_repository(
 
     assert response.status_code == 201, response.json()
     service.create_execution.assert_awaited_once()
+
+
+def test_create_execution_requires_repository_for_github_issue_authority(
+    client: tuple[TestClient, AsyncMock, SimpleNamespace],
+) -> None:
+    test_client, service, _user = client
+
+    response = test_client.post(
+        "/api/executions",
+        json={
+            "type": "workflow",
+            "payload": {
+                "targetRuntime": "omnigent",
+                "workflow": {
+                    "instructions": "Implement the selected GitHub issue.",
+                    "inputs": {
+                        "github_issue": {
+                            "repository": "MoonLadderStudios/Tactics",
+                            "number": 2490,
+                        }
+                    },
+                },
+            },
+        },
+    )
+
+    assert response.status_code == 422
+    assert "payload.repository is required" in response.json()["detail"]["message"]
+    service.create_execution.assert_not_awaited()
 
 
 def test_create_task_shaped_execution_rejects_malformed_repository_target(

--- a/tests/unit/workflows/executions/test_repository_contract.py
+++ b/tests/unit/workflows/executions/test_repository_contract.py
@@ -16,6 +16,7 @@ from moonmind.workflows.executions.repository_contract import (
     decode_legacy_repository_history_v1,
     derive_repository_capabilities,
     ensure_repository_ready,
+    github_repository_name_from_value,
     load_repository_connection,
     materialize_resolved_repository_target,
     persist_repository_connection,
@@ -93,6 +94,30 @@ def test_repository_projection_helpers_support_scalar_and_structured_values() ->
     )
     assert repository_name_from_value(target, provider="lore") == ""
     assert repository_branch_from_value(target) == "feature/repository-target"
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("MoonLadderStudios/MoonMind", "MoonLadderStudios/MoonMind"),
+        (
+            "https://github.com/MoonLadderStudios/MoonMind",
+            "MoonLadderStudios/MoonMind",
+        ),
+        (
+            "https://www.github.com/MoonLadderStudios/MoonMind.git/",
+            "MoonLadderStudios/MoonMind",
+        ),
+        (
+            "git@github.com:MoonLadderStudios/MoonMind.git",
+            "MoonLadderStudios/MoonMind",
+        ),
+        ("https://gitlab.com/MoonLadderStudios/MoonMind", ""),
+        ("https://github.com/owner/repo/issues", ""),
+    ],
+)
+def test_github_repository_name_projection(value: str, expected: str) -> None:
+    assert github_repository_name_from_value(value) == expected
 
 
 @pytest.mark.parametrize("legacy", ["owner/repo", None, 123])


### PR DESCRIPTION
## Summary

- preserve preset step `repositoryOperation` metadata through expansion, saved-draft reconstruction, and workflow submission
- derive the workflow repository from a valid GitHub issue selection until the operator explicitly chooses a repository
- reject GitHub issue/repository authority mismatches at the API boundary before scheduling an agent

## Root cause

Workflow `mm:48ec5c73-4bb4-4c78-8380-9f5aa88ae367` targeted `MoonLadderStudios/MoonMind` while its selected issue was `MoonLadderStudios/Tactics#2490`. The frontend also dropped the assessment step's `repositoryOperation: read` metadata. Omnigent therefore treated the blocked read-only assessment as a repository-writing step and exhausted eight repository-output continuations before returning `OMNIGENT_REPOSITORY_OUTPUT_MISSING`.

## Verification

- `TZ=UTC ./tools/test_unit.sh --dashboard-only --ui-args frontend/src/entrypoints/workflow-start.test.tsx frontend/src/lib/temporalTaskEditing.test.ts` — 141 passed
- `./tools/test_unit.sh --python-only tests/unit/api/routers/test_executions.py` — 398 passed
- `npm run ui:typecheck`
- focused ESLint on the changed frontend files
